### PR TITLE
fix (trivial) leak in xgboost_regrank

### DIFF
--- a/regrank/xgboost_regrank.h
+++ b/regrank/xgboost_regrank.h
@@ -27,6 +27,10 @@ namespace xgboost{
                 obj_ = NULL;
                 name_obj_ = "reg:linear";
             }
+            /*! \brief destructor */
+            ~RegRankBoostLearner(void){
+                delete obj_;
+            }
             /*!
              * \brief a regression booter associated with training and evaluating data
              * \param mats  array of pointers to matrix whose prediction result need to be cached


### PR DESCRIPTION
Hello.

I fixed trivial leak in RegRankBoostLearner.
This PR may help users who uses xgboost as a library, but for many this is not important.
After running valgrind, I got these leaks:

```
$ valgrind --leak-check=full ../../xgboost mq2008.conf

(snip)

build GBRT with 9630 instances
tree train end, 1 roots, 118 extra nodes, 0 pruned nodes ,max_depth=6
[3]     test-map:0.493151

updating end, 6 sec in all
==68506==
==68506== HEAP SUMMARY:
==68506==     in use at exit: 29,803 bytes in 380 blocks
==68506==   total heap usage: 965 allocs, 585 frees, 5,534,747 bytes allocated
==68506==
==68506== 24 bytes in 1 blocks are definitely lost in loss record 19 of 79
==68506==    at 0x6DFB: malloc (in /usr/local/Cellar/valgrind/3.9.0/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==68506==    by 0x6E28D: operator new(unsigned long) (in /usr/lib/libc++.1.dylib)
==68506==    by 0x10001650D: xgboost::regrank::CreateObjFunction(char const*) (in ../../xgboost)
==68506==    by 0x1000162BA: xgboost::regrank::RegRankBoostLearner::InitTrainer() (in ../../xgboost)
==68506==    by 0x100002750: xgboost::regrank::RegBoostTask::InitLearner() (in ../../xgboost)
==68506==    by 0x10000095C: xgboost::regrank::RegBoostTask::Run(int, char**) (in ../../xgboost)
==68506==    by 0x100000777: main (in ../../xgboost)
==68506==
==68506== LEAK SUMMARY:
==68506==    definitely lost: 24 bytes in 1 blocks
==68506==    indirectly lost: 0 bytes in 0 blocks
==68506==      possibly lost: 0 bytes in 0 blocks
==68506==    still reachable: 4,244 bytes in 4 blocks
==68506==         suppressed: 25,535 bytes in 375 blocks
==68506== Reachable blocks (those to which a pointer was found) are not shown.
==68506== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==68506==
==68506== For counts of detected and suppressed errors, rerun with: -v
==68506== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 237 from 80)
```

Thanks.
