### PR TITLE
Early stopping for Python wrapper

### DIFF
--- a/wrapper/xgboost.py
+++ b/wrapper/xgboost.py
@@ -578,7 +578,7 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None):
         maximize_score = False
         if 'eval_metric' in params:
             maximize_metrics = ('auc', 'map', 'ndcg')
-            if filter( lambda x: params['eval_metric'].startswith(x), maximize_metrics ):
+            if filter(lambda x: params['eval_metric'].startswith(x), maximize_metrics):
                 maximize_score = True
         
         if maximize_score:
@@ -601,7 +601,7 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None):
                 
             sys.stderr.write(msg + '\n')
             
-            score = float(msg.rsplit( ':', 1 )[1])
+            score = float(msg.rsplit(':', 1)[1])
             if (maximize_score and score > best_score) or \
                 (not maximize_score and score < best_score):
                 best_score = score

--- a/wrapper/xgboost.py
+++ b/wrapper/xgboost.py
@@ -577,8 +577,8 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None):
         # either minimize loss or maximize AUC/MAP/NDCG
         maximize_score = False
         if 'eval_metric' in params:
-			maximize_metrics = ('auc', 'map', 'ndcg')
-			if filter( lambda x: params['eval_metric'].startswith(x), maximize_metrics ):
+            maximize_metrics = ('auc', 'map', 'ndcg')
+            if filter( lambda x: params['eval_metric'].startswith(x), maximize_metrics ):
                 maximize_score = True
         
         if maximize_score:


### PR DESCRIPTION
Hey guys,

I have implemented early stopping in Python interface. To activate it, you set the number of boosting rounds to a negative number, for example -1 means that validation score must improve every round, -2: at least every second round, and so on. Obviously to compute validation score you need at least one set in _evals_; if there's more than one, early stopping will look at the last. It works with both losses (minimizing) and AUC/MAP/NDCG (maximizing).

Feel free to edit or let me know what to change.