### PR TITLE
Bugfix: xgboost</lib/native/libhdfs.a: could not read symbols: Bad value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ ifeq ($(cxx11),1)
 else 
 endif
 
+ifndef HADOOP_HDFS_HOME
+	HADOOP_HDFS_HOME=$(HADOOP_HOME)
+endif
+
 # handling dmlc
 ifdef dmlc
 	ifndef config
@@ -29,6 +33,9 @@ ifdef dmlc
 	include $(dmlc)/make/dmlc.mk
 	LDFLAGS+= $(DMLC_LDFLAGS)
 	LIBDMLC=$(dmlc)/libdmlc.a
+	ifeq ($(HADOOP_CDH_BINARY), 1)
+		STATIC_LIB=$(HADOOP_HDFS_HOME)/lib/native/libhdfs.a
+	endif
 else
 	LIBDMLC=dmlc_simple.o
 endif
@@ -66,7 +73,7 @@ subtree/rabit/lib/librabit_mpi.a: subtree/rabit/src/engine_mpi.cc
 	+	cd subtree/rabit;make lib/librabit_mpi.a; cd ../..
 
 $(BIN) : 
-	$(CXX) $(CFLAGS) -o $@ $(filter %.cpp %.o %.c %.cc %.a, $^) $(LDFLAGS) 
+	$(CXX) $(CFLAGS) -o $@ $(filter %.cpp %.o %.c %.cc %.a, $^) $(LDFLAGS) $(STATIC_LIB)
 
 $(MOCKBIN) : 
 	$(CXX) $(CFLAGS) -o $@ $(filter %.cpp %.o %.c %.cc %.a, $^) $(LDFLAGS) 


### PR DESCRIPTION
For Hadoop_CDH distribution (yum installed), there exists no libhdfs.so(dynamic lib) just libhdfs.a(static lib). 
A switch "HADOOP_CDH_BINARY" is added for this situation, it enables static compiling, so xgboost
wil not search for libhdfs.so anymore while running.