### PR TITLE
COMPAT: Decode bytes object for Python 3.

### DIFF
--- a/wrapper/xgboost.py
+++ b/wrapper/xgboost.py
@@ -517,7 +517,7 @@ class Booster(object):
                                         int(with_stats), ctypes.byref(length))
         res = []
         for i in range(length.value):
-            res.append(str(sarr[i]))
+            res.append(str(sarr[i].decode('ascii')))
         return res
 
     def get_fscore(self, fmap=''):


### PR DESCRIPTION
I'm not quite sure how you'd handle non-ascii encoded strings in the models, so I punted on this in favor of ascii only. Right now on Python 3 though, the byte objects coerce to strings like so if you don't explicitly decode them. I.e., the b"" gets written to the model object.

```
In [3]: b"asdasa"
Out[3]: b'asdasa'

In [4]: str(b"asdasa")
Out[4]: "b'asdasa'"
```