### PR TITLE
new parameter in xgboost() and xgb.train() to print every N-th progress message

### DIFF
--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -66,6 +66,7 @@
 #'   prediction and dtrain,
 #' @param verbose If 0, xgboost will stay silent. If 1, xgboost will print 
 #'   information of performance. If 2, xgboost will print information of both
+#' @param printEveryN Print every N progress messages when \code{verbose>0}. Default is 1 which means all messages are printed.
 #' @param early_stop_round If \code{NULL}, the early stopping function is not triggered. 
 #'     If set to an integer \code{k}, training with a validation set will stop if the performance 
 #'     keeps getting worse consecutively for \code{k} rounds.
@@ -119,7 +120,7 @@
 #' @export
 #' 
 xgb.train <- function(params=list(), data, nrounds, watchlist = list(), 
-                      obj = NULL, feval = NULL, verbose = 1, 
+                      obj = NULL, feval = NULL, verbose = 1, printEveryN=1L,
                       early_stop_round = NULL, early.stop.round = NULL,
                       maximize = NULL, ...) {
   dtrain <- data
@@ -174,11 +175,13 @@ xgb.train <- function(params=list(), data, nrounds, watchlist = list(),
   
   handle <- xgb.Booster(params, append(watchlist, dtrain))
   bst <- xgb.handleToBooster(handle)
+  printEveryN=max( as.integer(printEveryN), 1L)
   for (i in 1:nrounds) {
     succ <- xgb.iter.update(bst$handle, dtrain, i - 1, obj)
     if (length(watchlist) != 0) {
       msg <- xgb.iter.eval(bst$handle, watchlist, i - 1, feval)
-      cat(paste(msg, "\n", sep=""))
+      if (0== ( (i-1) %% printEveryN))
+	    cat(paste(msg, "\n", sep=""))
       if (!is.null(early_stop_round))
       {
         score = strsplit(msg,':|\\s+')[[1]][3]

--- a/R-package/R/xgboost.R
+++ b/R-package/R/xgboost.R
@@ -28,6 +28,7 @@
 #' @param verbose If 0, xgboost will stay silent. If 1, xgboost will print 
 #'   information of performance. If 2, xgboost will print information of both
 #'   performance and construction progress information
+#' @param printEveryN Print every N progress messages when \code{verbose>0}. Default is 1 which means all messages are printed.
 #' @param missing Missing is only used when input is dense matrix, pick a float 
 #'     value that represents missing value. Sometimes a data use 0 or other extreme value to represents missing values.
 #' @param early_stop_round If \code{NULL}, the early stopping function is not triggered. 
@@ -57,7 +58,7 @@
 #' @export
 #' 
 xgboost <- function(data = NULL, label = NULL, missing = NULL, params = list(), nrounds, 
-                    verbose = 1, early_stop_round = NULL, early.stop.round = NULL, 
+                    verbose = 1, printEveryN=1L, early_stop_round = NULL, early.stop.round = NULL,
                     maximize = NULL, ...) {
   if (is.null(missing)) {
     dtrain <- xgb.get.DMatrix(data, label)
@@ -73,7 +74,7 @@ xgboost <- function(data = NULL, label = NULL, missing = NULL, params = list(), 
     watchlist <- list()
   }
   
-  bst <- xgb.train(params, dtrain, nrounds, watchlist, verbose = verbose,
+  bst <- xgb.train(params, dtrain, nrounds, watchlist, verbose = verbose, printEveryN=printEveryN,
                    early_stop_round = early_stop_round,
                    early.stop.round = early.stop.round)
   

--- a/R-package/man/xgb.train.Rd
+++ b/R-package/man/xgb.train.Rd
@@ -5,7 +5,7 @@
 \title{eXtreme Gradient Boosting Training}
 \usage{
 xgb.train(params = list(), data, nrounds, watchlist = list(), obj = NULL,
-  feval = NULL, verbose = 1, early_stop_round = NULL,
+  feval = NULL, verbose = 1, printEveryN=1L, early_stop_round = NULL,
   early.stop.round = NULL, maximize = NULL, ...)
 }
 \arguments{
@@ -77,6 +77,8 @@ prediction and dtrain,}
 
 \item{verbose}{If 0, xgboost will stay silent. If 1, xgboost will print
 information of performance. If 2, xgboost will print information of both}
+
+\item{printEveryN}{Print every N progress messages when \code{verbose>0}. Default is 1 which means all messages are printed.}
 
 \item{early_stop_round}{If \code{NULL}, the early stopping function is not triggered.
 If set to an integer \code{k}, training with a validation set will stop if the performance

--- a/R-package/man/xgboost.Rd
+++ b/R-package/man/xgboost.Rd
@@ -5,7 +5,7 @@
 \title{eXtreme Gradient Boosting (Tree) library}
 \usage{
 xgboost(data = NULL, label = NULL, missing = NULL, params = list(),
-  nrounds, verbose = 1, early_stop_round = NULL, early.stop.round = NULL,
+  nrounds, verbose = 1, printEveryN=1L, early_stop_round = NULL, early.stop.round = NULL,
   maximize = NULL, ...)
 }
 \arguments{
@@ -41,6 +41,8 @@ Commonly used ones are:
 \item{verbose}{If 0, xgboost will stay silent. If 1, xgboost will print
 information of performance. If 2, xgboost will print information of both
 performance and construction progress information}
+
+\item{printEveryN}{Print every N progress messages when \code{verbose>0}. Default is 1 which means all messages are printed.}
 
 \item{early_stop_round}{If \code{NULL}, the early stopping function is not triggered.
 If set to an integer \code{k}, training with a validation set will stop if the performance


### PR DESCRIPTION
For example: xgboost(... , printEveryN=100) will print only 0th, 100th, 200th, 300th ... information/progress messages.