### PR TITLE
Fix early stopping in python wrapper

### DIFF
--- a/wrapper/xgboost.py
+++ b/wrapper/xgboost.py
@@ -657,7 +657,7 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
         maximize_score = False
         if 'eval_metric' in params:
             maximize_metrics = ('auc', 'map', 'ndcg')
-            if filter(lambda x: params['eval_metric'].startswith(x), maximize_metrics):
+            if list(filter(lambda x: params['eval_metric'].startswith(x), maximize_metrics)):
                 maximize_score = True
 
         if maximize_score:


### PR DESCRIPTION
As for now, python early stopping counts every metric as being miximized.

The problem is filter object is always `True` so we have to convert it to list before `if`'ing:

    In [1]: list(filter(lambda x: True, [1, 2, 3]))
    Out[1]: [1, 2, 3]
    In [2]: list(filter(lambda x: False, [1, 2, 3]))
    Out[2]: []
    In [3]: if filter(lambda x: True, [1, 2, 3]):
      ....:     print("yes")
      ....:     
    yes
    In [4]: if filter(lambda x: False, [1, 2, 3]):
      ....:     print("yes")
      ....:     
    yes