### PR TITLE
Add classes_ attribute to scikit-learn wrapper

### DIFF
--- a/wrapper/xgboost.py
+++ b/wrapper/xgboost.py
@@ -935,8 +935,8 @@ class XGBClassifier(XGBModel, XGBClassifier):
                                             base_score, seed)
 
     def fit(self, X, y, sample_weight=None):
-        y_values = list(np.unique(y))
-        self.n_classes_ = len(y_values)
+        self.classes_ = list(np.unique(y))
+        self.n_classes_ = len(self.classes_)
         if self.n_classes_ > 2:
             # Switch to using a multiclass objective in the underlying XGB instance
             self.objective = "multi:softprob"


### PR DESCRIPTION
Scikit-learn's ensemble methods (bagging in particular) require that the base estimators implement a classes_ attribute in addition to n_classes_.  This information is already being captured in the "fit" method of xgboost's scikit-learn wrapper class as a local variable.  I simply modified it to save the list of classes in an instance attribute.  This change allows xgboost models to be used in a bagging ensemble.