### PR TITLE
add exclude features function

### DIFF
--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -14,7 +14,8 @@ DataMatrix* LoadDataMatrix(const char *fname,
                            bool silent,
                            bool savebuffer,
                            bool loadsplit,
-                           const char *cache_file) {
+                           const char *cache_file, 
+                           utils::FeatMap *fmap) {
   using namespace std;
   std::string fname_ = fname;
   
@@ -35,7 +36,7 @@ DataMatrix* LoadDataMatrix(const char *fname,
         !std::strncmp(fname, "hdfs://", 7) ||
         loadsplit) {
       DMatrixSimple *dmat = new DMatrixSimple();
-      dmat->LoadText(fname, silent, loadsplit);
+      dmat->LoadText(fname, silent, loadsplit, fmap);
       return dmat;
     }
     int magic;
@@ -50,7 +51,7 @@ DataMatrix* LoadDataMatrix(const char *fname,
     }
     fs.Close();
     DMatrixSimple *dmat = new DMatrixSimple();
-    dmat->CacheLoad(fname, silent, savebuffer);
+    dmat->CacheLoad(fname, silent, savebuffer, fmap);
     return dmat;
   } else {
     std::string cache_fname = cache_file;
@@ -74,7 +75,7 @@ DataMatrix* LoadDataMatrix(const char *fname,
         return dmat;
       } else {
         DMatrixPage *dmat = new DMatrixPage();
-        dmat->LoadText(fname, cache_file, false, loadsplit);
+        dmat->LoadText(fname, cache_file, false, loadsplit, fmap);
         return dmat;
       }
     }

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -8,6 +8,7 @@
  */
 #include "../data.h"
 #include "../learner/dmatrix.h"
+ #include "../utils/fmap.h"
 
 namespace xgboost {
 /*! \brief namespace related to data format */
@@ -30,7 +31,7 @@ DataMatrix* LoadDataMatrix(const char *fname,
                            bool silent,
                            bool savebuffer,
                            bool loadsplit,
-                           const char *cache_file = NULL);
+                           const char *cache_file = NULL, utils::FeatMap *fmap = NULL);
 /*!
  * \brief save DataMatrix into stream, 
  *  note: the saved dmatrix format may not be in exactly same as input

--- a/src/io/page_dmatrix-inl.hpp
+++ b/src/io/page_dmatrix-inl.hpp
@@ -133,7 +133,8 @@ class DMatrixPageBase : public DataMatrix {
   inline void LoadText(const char *uri,
                        const char* cache_file,
                        bool silent,
-                       bool loadsplit) {
+                       bool loadsplit,
+                       utils::FeatMap *fmap = NULL) {
     if (!silent) {
       utils::Printf("start generate text file from %s\n", uri);
     }
@@ -149,7 +150,7 @@ class DMatrixPageBase : public DataMatrix {
     size_t bytes_write = 0;
     double tstart = rabit::utils::GetTime();
     LibSVMParser parser(
-        dmlc::InputSplit::Create(uri, rank, npart, "text"), 16);
+        dmlc::InputSplit::Create(uri, rank, npart, "text"), 16, fmap);
     info.Clear();
     while (parser.Next()) {
       const LibSVMPage &batch = parser.Value();

--- a/src/io/simple_dmatrix-inl.hpp
+++ b/src/io/simple_dmatrix-inl.hpp
@@ -86,14 +86,15 @@ class DMatrixSimple : public DataMatrix {
    * \param loadsplit whether loadsplit of data or all the data
    * \param silent whether print information or not
    */
-  inline void LoadText(const char *uri, bool silent = false, bool loadsplit = false) {
+  inline void LoadText(const char *uri, bool silent = false, bool loadsplit = false, utils::FeatMap *fmap = NULL) {
     int rank = 0, npart = 1;
     if (loadsplit) {
       rank = rabit::GetRank();
       npart = rabit::GetWorldSize();
     }
+
     LibSVMParser parser(
-        dmlc::InputSplit::Create(uri, rank, npart, "text"), 16);
+        dmlc::InputSplit::Create(uri, rank, npart, "text"), 16, fmap);
     this->Clear();
     while (parser.Next()) {
       const LibSVMPage &batch = parser.Value();
@@ -224,7 +225,7 @@ class DMatrixSimple : public DataMatrix {
    * \param silent whether print information or not
    * \param savebuffer whether do save binary buffer if it is text
    */
-  inline void CacheLoad(const char *fname, bool silent = false, bool savebuffer = true) {
+  inline void CacheLoad(const char *fname, bool silent = false, bool savebuffer = true, utils::FeatMap *fmap = NULL) {
     using namespace std;
     size_t len = strlen(fname);
     if (len > 8 && !strcmp(fname + len - 7, ".buffer")) {
@@ -236,7 +237,7 @@ class DMatrixSimple : public DataMatrix {
     char bname[1024];
     utils::SPrintf(bname, sizeof(bname), "%s.buffer", fname);
     if (!this->LoadBinary(bname, silent)) {
-      this->LoadText(fname, silent);
+      this->LoadText(fname, silent, false, fmap);
       if (savebuffer) this->SaveBinary(bname, silent);
     }
   }

--- a/src/utils/thread_buffer.h
+++ b/src/utils/thread_buffer.h
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include "./utils.h"
 #include "./thread.h"
+#include "./fmap.h"
 namespace xgboost {
 namespace utils {
 /*!
@@ -40,7 +41,18 @@ class ThreadBuffer {
    * \param param a initialize parameter that will pass to factory, ignore it if not necessary
    * \return false if the initlization can't be done, e.g. buffer file hasn't been created 
    */
-  inline bool Init(void) {
+  inline bool Init(utils::FeatMap *fmap) {
+    if (!factory.Init(fmap)) return false;
+    for (int i = 0; i < buf_size; ++i) {
+      bufA.push_back(factory.Create());
+      bufB.push_back(factory.Create());
+    }
+    this->init_end = true;
+    this->StartLoader();
+    return true;
+  }  
+
+  inline bool Init() {
     if (!factory.Init()) return false;
     for (int i = 0; i < buf_size; ++i) {
       bufA.push_back(factory.Create());

--- a/src/xgboost_main.cpp
+++ b/src/xgboost_main.cpp
@@ -137,18 +137,18 @@ class BoostLearnTask {
     if (name_fmap != "NULL") fmap.LoadText(name_fmap.c_str());
     if (task == "dump") return;
     if (task == "pred") {
-      data = io::LoadDataMatrix(test_path.c_str(), silent != 0, use_buffer != 0, loadsplit);
+      data = io::LoadDataMatrix(test_path.c_str(), silent != 0, use_buffer != 0, loadsplit, NULL,&fmap);
     } else {
       // training
       data = io::LoadDataMatrix(train_path.c_str(),
                                 silent != 0 && load_part == 0,
-                                use_buffer != 0, loadsplit);
+                                use_buffer != 0, loadsplit, NULL, &fmap);
       utils::Assert(eval_data_names.size() == eval_data_paths.size(), "BUG");
       for (size_t i = 0; i < eval_data_names.size(); ++i) {
         deval.push_back(io::LoadDataMatrix(eval_data_paths[i].c_str(),
                                            silent != 0,
                                            use_buffer != 0,
-                                           loadsplit));
+                                           loadsplit, NULL, &fmap));
         devalall.push_back(deval.back());
       }
             


### PR DESCRIPTION
Hi,
I have implemented a method to exclude features in libsvm without regenerating train data.

The only thing you need to do is to add '#' at the beginning of line in feature map file(feature map file contains feature_index, feature_name, feature_type), and provide 'fmap' param with the right feature map file. If you do not provide fmap param, all features will be loaded into memory.
