### PR TITLE
Fixing duplicate params in demo

### DIFF
--- a/R-package/demo/custom_objective.R
+++ b/R-package/demo/custom_objective.R
@@ -33,7 +33,7 @@ evalerror <- function(preds, dtrain) {
   return(list(metric = "error", value = err))
 }
 
-param <- list(max.depth=2,eta=1,nthread = 2, silent=1, 
+param <- list(max.depth=2, eta=1, nthread = 2, silent=1, 
               objective=logregobj, eval_metric=evalerror)
 print ('start training with user customized objective')
 # training with customized objective, we can also do step by step training
@@ -57,9 +57,9 @@ logregobjattr <- function(preds, dtrain) {
   hess <- preds * (1 - preds)
   return(list(grad = grad, hess = hess))
 }
-
+param <- list(max.depth=2, eta=1, nthread = 2, silent=1, 
+              objective=logregobjattr, eval_metric=evalerror)
 print ('start training with user customized objective, with additional attributes in DMatrix')
 # training with customized objective, we can also do step by step training
 # simply look at xgboost.py's implementation of train
-bst <- xgb.train(param, dtrain, num_round, watchlist, 
-                 objective=logregobj, eval_metric=evalerror)
+bst <- xgb.train(param, dtrain, num_round, watchlist)


### PR DESCRIPTION
Issue in "demo(package="xgboost", custom_objective)"

> bst <- xgb.train(param, dtrain, num_round, watchlist, 
+                  objective=logregobj, eval_metric=evalerror)
Error in xgb.train(param, dtrain, num_round, watchlist, objective = logregobj,  : 
  Duplicated term in parameters. Please check your list of params.