### PR TITLE
Missing parentheses in call to 'print' 

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -10,7 +10,7 @@ sys.path.insert(0, '.')
 build_sh = subprocess.Popen(['sh', 'xgboost/build-python.sh'])
 build_sh.wait()
 output = build_sh.communicate()
-print output
+print (output)
 
 import xgboost
 


### PR DESCRIPTION
Hello,
I try to install xgboost on Anaconda 3 with the command pip install xgboost.
I have the following error: SyntaxError: Missing parentheses in call to 'print'
It occurs on line 13 in setup.py, when 'print output' is called.
Thanks!