### PR TITLE
make XGBClassifier.score compatible with arrays

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -319,7 +319,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         if len(class_probs.shape) > 1:
             column_indexes = np.argmax(class_probs, axis=1)
         else:
-            column_indexes = np.repeat(0, data.shape[0])
+            column_indexes = np.repeat(0, class_probs.shape[0])
             column_indexes[class_probs > 0.5] = 1
         return self._le.inverse_transform(column_indexes)
 


### PR DESCRIPTION
Now it fails:
Traceback (most recent call last):
  File "./biologicalResponse.py", line 76, in <module>
    main()
  File "./biologicalResponse.py", line 22, in main
    score = rf.score(testFeatures, testTarget)
  File "/home/denplusplus/.local/lib/python3.4/site-packages/sklearn/base.py", line 295, in score
    return accuracy_score(y, self.predict(X), sample_weight=sample_weight)
  File "/usr/local/lib/python3.4/dist-packages/xgboost-0.4-py3.4.egg/xgboost/sklearn.py", line 322, in predict
    column_indexes = np.repeat(0, data.shape[0])
AttributeError: 'list' object has no attribute 'shape'

It seems to be just a typo fix.