### PR TITLE
Support feature names in Python package 

### DIFF
--- a/scripts/travis_osx_install.sh
+++ b/scripts/travis_osx_install.sh
@@ -5,15 +5,3 @@ if [ ${TRAVIS_OS_NAME} != "osx" ]; then
 fi
 
 brew update
-
-if [ ${TASK} == "python-package" ]; then
-    brew install python git graphviz
-    easy_install pip
-    pip install numpy scipy matplotlib nose
-fi
-
-if [ ${TASK} == "python-package3" ]; then
-    brew install python3 git graphviz
-    sudo pip3 install --upgrade setuptools
-    pip3 install numpy scipy matplotlib nose graphviz
-fi

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -33,30 +33,44 @@ if [ ${TASK} == "R-package" ]; then
     scripts/travis_R_script.sh || exit -1
 fi
 
-if [ ${TASK} == "python-package" ]; then
-    sudo apt-get install graphviz
-    sudo apt-get install python-numpy python-scipy python-matplotlib python-nose
-    sudo python -m pip install graphviz
-    make all CXX=${CXX} || exit -1
-    nosetests tests/python || exit -1
-fi
+if [ ${TASK} == "python-package" -o ${TASK} == "python-package3" ]; then
 
-if [ ${TASK} == "python-package3" ]; then
-    sudo apt-get install graphviz
-    # python3-matplotlib is unavailale on Ubuntu 12.04
-    sudo apt-get install python3-dev
-    sudo apt-get install python3-numpy python3-scipy python3-nose python3-setuptools
-
-    make all CXX=${CXX} || exit -1
-
-    if [ ${TRAVIS_OS_NAME} != "osx" ]; then
-        sudo easy_install3 pip
-        sudo easy_install3 -U distribute
-        sudo pip install graphviz matplotlib
-        nosetests3 tests/python || exit -1
+    if [ ${TRAVIS_OS_NAME} == "osx" ]; then
+        brew install graphviz
+        if [ ${TASK} == "python-package3" ]; then
+            wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+        else
+            wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh
+        fi
     else
-        nosetests tests/python || exit -1
+        sudo apt-get install graphviz
+        if [ ${TASK} == "python-package3" ]; then
+            wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+        else
+            wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
+        fi
     fi
+    bash conda.sh -b -p $HOME/miniconda
+    export PATH="$HOME/miniconda/bin:$PATH"
+    hash -r
+    conda config --set always_yes yes --set changeps1 no
+    conda update -q conda
+    # Useful for debugging any issues with conda
+    conda info -a
+
+    if [ ${TASK} == "python-package3" ]; then
+        conda create -n myenv python=3.4
+    else
+        conda create -n myenv python=2.7
+    fi
+    source activate myenv
+    conda install numpy scipy matplotlib nose
+    python -m pip install graphviz
+
+    make all CXX=${CXX} || exit -1
+
+    python -m nose tests/python || exit -1
+    python --version
 fi
 
 # only test java under linux for now

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import numpy as np
 import xgboost as xgb
 
@@ -33,21 +34,25 @@ def test_feature_names():
     data = np.random.randn(100, 5)
     target = np.array([0, 1] * 50)
 
-    features = ['Feature1', 'Feature2', 'Feature3', 'Feature4', 'Feature5']
-    dm = xgb.DMatrix(data, label=target,
-                     feature_names=features)
-    assert dm.feature_names == features
-    assert dm.num_row() == 100
-    assert dm.num_col() == 5
+    cases = [['Feature1', 'Feature2', 'Feature3', 'Feature4', 'Feature5'],
+             [u'要因1', u'要因2', u'要因3', u'要因4', u'要因5']]
 
-    params={'objective': 'multi:softprob',
-            'eval_metric': 'mlogloss',
-            'eta': 0.3,
-            'num_class': 3}
+    for features in cases:
+        dm = xgb.DMatrix(data, label=target,
+                         feature_names=features)
+        assert dm.feature_names == features
+        assert dm.num_row() == 100
+        assert dm.num_col() == 5
 
-    bst = xgb.train(params, dm, num_boost_round=10)
-    scores = bst.get_fscore()
-    assert list(sorted(k for k in scores)) == features
+        params={'objective': 'multi:softprob',
+                'eval_metric': 'mlogloss',
+                'eta': 0.3,
+                'num_class': 3}
+
+        bst = xgb.train(params, dm, num_boost_round=10)
+        scores = bst.get_fscore()
+        assert list(sorted(k for k in scores)) == features
+
 
 def test_plotting():
     bst2 = xgb.Booster(model_file='xgb.model')

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -29,6 +29,26 @@ def test_basic():
     # assert they are the same
     assert np.sum(np.abs(preds2-preds)) == 0
 
+def test_feature_names():
+    data = np.random.randn(100, 5)
+    target = np.array([0, 1] * 50)
+
+    features = ['Feature1', 'Feature2', 'Feature3', 'Feature4', 'Feature5']
+    dm = xgb.DMatrix(data, label=target,
+                     feature_names=features)
+    assert dm.feature_names == features
+    assert dm.num_row() == 100
+    assert dm.num_col() == 5
+
+    params={'objective': 'multi:softprob',
+            'eval_metric': 'mlogloss',
+            'eta': 0.3,
+            'num_class': 3}
+
+    bst = xgb.train(params, dm, num_boost_round=10)
+    scores = bst.get_fscore()
+    assert list(sorted(k for k in scores)) == features
+
 def test_plotting():
     bst2 = xgb.Booster(model_file='xgb.model')
     # plotting

--- a/wrapper/xgboost_wrapper.cpp
+++ b/wrapper/xgboost_wrapper.cpp
@@ -445,9 +445,9 @@ int XGDMatrixNumRow(const DMatrixHandle handle,
 
 int XGDMatrixNumCol(const DMatrixHandle handle,
                     bst_ulong *out) {
-    API_BEGIN();
-    *out = static_cast<size_t>(static_cast<const DataMatrix*>(handle)->info.num_col());
-    API_END();
+  API_BEGIN();
+  *out = static_cast<size_t>(static_cast<const DataMatrix*>(handle)->info.num_col());
+  API_END();
 }
 
 // xgboost implementation
@@ -575,6 +575,23 @@ int XGBoosterDumpModel(BoosterHandle handle,
   utils::FeatMap featmap;
   if (strlen(fmap) != 0) {
     featmap.LoadText(fmap);
+  }
+  *out_models = static_cast<Booster*>(handle)->GetModelDump(
+      featmap, with_stats != 0, len);
+  API_END();
+}
+
+int XGBoosterDumpModelWithFeatures(BoosterHandle handle,
+                                   int fnum,
+                                   const char **fname,
+                                   const char **ftype,
+                                   int with_stats,
+                                   bst_ulong *len,
+                                   const char ***out_models) {
+  API_BEGIN();
+  utils::FeatMap featmap;
+  for (int i = 0; i < fnum; ++i) {
+      featmap.PushBack(i, fname[i], ftype[i]);
   }
   *out_models = static_cast<Booster*>(handle)->GetModelDump(
       featmap, with_stats != 0, len);

--- a/wrapper/xgboost_wrapper.cpp
+++ b/wrapper/xgboost_wrapper.cpp
@@ -435,11 +435,19 @@ int XGDMatrixGetUIntInfo(const DMatrixHandle handle,
   *out_dptr = BeginPtr(vec);
   API_END();
 }
+
 int XGDMatrixNumRow(const DMatrixHandle handle,
                     bst_ulong *out) {
   API_BEGIN();
   *out = static_cast<bst_ulong>(static_cast<const DataMatrix*>(handle)->info.num_row());
   API_END();
+}
+
+int XGDMatrixNumCol(const DMatrixHandle handle,
+                    bst_ulong *out) {
+    API_BEGIN();
+    *out = static_cast<size_t>(static_cast<const DataMatrix*>(handle)->info.num_col());
+    API_END();
 }
 
 // xgboost implementation

--- a/wrapper/xgboost_wrapper.h
+++ b/wrapper/xgboost_wrapper.h
@@ -184,6 +184,13 @@ XGB_DLL int XGDMatrixGetUIntInfo(const DMatrixHandle handle,
  */
 XGB_DLL int XGDMatrixNumRow(DMatrixHandle handle,
                             bst_ulong *out);
+/*!
+ * \brief get number of columns
+ * \param handle the handle to the DMatrix
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixNumCol(DMatrixHandle handle,
+                            bst_ulong *out);
 // --- start XGBoost class
 /*!
  * \brief create xgboost learner

--- a/wrapper/xgboost_wrapper.h
+++ b/wrapper/xgboost_wrapper.h
@@ -331,4 +331,24 @@ XGB_DLL int XGBoosterDumpModel(BoosterHandle handle,
                                int with_stats,
                                bst_ulong *out_len,
                                const char ***out_dump_array);
+
+/*!
+ * \brief dump model, return array of strings representing model dump
+ * \param handle handle
+ * \param fnum number of features
+ * \param fnum names of features
+ * \param fnum types of features
+ * \param with_stats whether to dump with statistics
+ * \param out_len length of output array
+ * \param out_dump_array pointer to hold representing dump of each model
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterDumpModelWithFeatures(BoosterHandle handle,
+                                           int fnum,
+                                           const char **fname,
+                                           const char **ftype,
+                                           int with_stats,
+                                           bst_ulong *len,
+                                           const char ***out_models);
+
 #endif  // XGBOOST_WRAPPER_H_


### PR DESCRIPTION
Python package can now handle feature names.

- Feature names can be set to ``DMatrix`` via ``feature_names`` kw as below(optional).
  - ``feature_names`` must be a list only consistes form alphanumerics. Because symbols may corrupt ``get_dump`` function.
```
dm = xgb.DMatrix(iris.data, label=iris.target,
                 feature_names=['SepalLength', 'SepalWidth', 'PetalLength', 'PetalWidth'])
```
- When ``DMatrix`` with ``feature_names`` is passed to ``Booster``, ``Booster`` stores it. Once ``Booster`` has ``feature_names``, it will not accept ``DMatrix`` with different ``feature_names``. Because these are regarded as different data.
- ``get_fscore`` and ``get_dump`` will attach ``Booster``'s feature names if exists.
  - Thus, plotting functions can use it as below.

```
xgb.plot_importance(bst)
```
![index](https://cloud.githubusercontent.com/assets/1696302/9830974/59b37e32-597f-11e5-8964-6f59caf29ba8.png)


See my gist example for more detail.

https://gist.github.com/sinhrks/cc9a88f74074fc296e12#file-add_featurenames-ipynb