### PR TITLE
bugfix evals_result regex

### DIFF
--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -118,7 +118,7 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
                 sys.stderr.write(msg + '\n')
 
             if evals_result is not None:
-                res = re.findall(":-([0-9.]+).", msg)
+                res = re.findall(":-?([0-9.]+).", msg)
                 for key, val in zip(evals_name, res):
                     evals_result[key].append(val)
 


### PR DESCRIPTION
The evals_results currently remains empty if early stopping is used and if the eval metric provides positive values.