### PR TITLE
BUG: incorrect model_file results in segfault

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -743,7 +743,10 @@ class Booster(object):
             Input file name or memory buffer(see also save_raw)
         """
         if isinstance(fname, str):  # assume file name
-            _LIB.XGBoosterLoadModel(self.handle, c_str(fname))
+            if os.path.exists(fname):
+                _LIB.XGBoosterLoadModel(self.handle, c_str(fname))
+            else:
+                raise ValueError("No such file: {0}")
         else:
             buf = fname
             length = ctypes.c_ulong(len(buf))

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -1,8 +1,19 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 import xgboost as xgb
+import unittest
+
 
 dpath = 'demo/data/'
+
+
+class TestBasic(unittest.TestCase):
+
+    def test_load_file_invalid(self):
+
+        self.assertRaises(ValueError, xgb.Booster,
+                          model_file='incorrect_path')
+
 
 def test_basic():
     dtrain = xgb.DMatrix(dpath + 'agaricus.txt.train')


### PR DESCRIPTION
Closes #487.

I found #487 description is based on misunderstanding.  Current logic always regard input ``str`` as filename.

This should be after #496.