### PR TITLE
Fix compatibility issue for model files on 32-bit abd 64-bit architec…

### DIFF
--- a/src/gbm/gblinear-inl.hpp
+++ b/src/gbm/gblinear-inl.hpp
@@ -267,6 +267,7 @@ class GBLinear : public IGradBooster {
     }
     // load model from file
     inline void LoadModel(utils::IStream &fi) { // NOLINT(*)
+      XGBOOST_STATIC_ASSERT(sizeof(Param) % sizeof(uint64_t) == 0)
       utils::Assert(fi.Read(&param, sizeof(Param)) != 0, "Load LinearBooster");
       fi.Read(&weight);
     }

--- a/src/gbm/gbtree-inl.hpp
+++ b/src/gbm/gbtree-inl.hpp
@@ -44,6 +44,7 @@ class GBTree : public IGradBooster {
   }
   virtual void LoadModel(utils::IStream &fi, bool with_pbuffer) { // NOLINT(*)
     this->Clear();
+    XGBOOST_STATIC_ASSERT(sizeof(ModelParam) % sizeof(uint64_t) == 0)
     utils::Check(fi.Read(&mparam, sizeof(ModelParam)) != 0,
                  "GBTree: invalid model file");
     trees.resize(mparam.num_trees);
@@ -440,10 +441,10 @@ class GBTree : public IGradBooster {
     int num_trees;
     /*! \brief number of root: default 0, means single tree */
     int num_roots;
-    /*! \brief number of features to be used by trees */
-    int num_feature;
     /*! \brief size of predicton buffer allocated used for buffering */
     int64_t num_pbuffer;
+    /*! \brief number of features to be used by trees */
+    int num_feature;
     /*!
      * \brief how many output group a single instance can produce
      *  this affects the behavior of number of output we have:

--- a/src/learner/learner-inl.hpp
+++ b/src/learner/learner-inl.hpp
@@ -165,6 +165,7 @@ class BoostLearner : public rabit::Serializable {
    */
   inline void LoadModel(utils::IStream &fi,  // NOLINT(*)
                         bool calc_num_feature = true) {
+    XGBOOST_STATIC_ASSERT(sizeof(ModelParam) % sizeof(uint64_t) == 0)
     utils::Check(fi.Read(&mparam, sizeof(ModelParam)) != 0,
                  "BoostLearner: wrong model format");
     {

--- a/src/tree/model.h
+++ b/src/tree/model.h
@@ -50,7 +50,7 @@ class TreeModel {
      */
     int size_leaf_vector;
     /*! \brief reserved part */
-    int reserved[31];
+    int reserved[32];
     /*! \brief constructor */
     Param(void) {
       max_depth = 0;
@@ -175,6 +175,8 @@ class TreeModel {
     unsigned sindex_;
     // extra info
     Info info_;
+    // reserved field
+    int reserved;
     // set parent
     inline void set_parent(int pidx, bool is_left_child = true) {
       if (is_left_child) pidx |= (1U << 31);
@@ -295,12 +297,15 @@ class TreeModel {
    * \param fi input stream
    */
   inline void LoadModel(utils::IStream &fi) { // NOLINT(*)
+    XGBOOST_STATIC_ASSERT(sizeof(Param) % sizeof(uint64_t) == 0)
     utils::Check(fi.Read(&param, sizeof(Param)) > 0,
                  "TreeModel: wrong format");
     nodes.resize(param.num_nodes); stats.resize(param.num_nodes);
     utils::Assert(param.num_nodes != 0, "invalid model");
+    XGBOOST_STATIC_ASSERT(sizeof(Node) % sizeof(uint64_t) == 0)
     utils::Check(fi.Read(BeginPtr(nodes), sizeof(Node) * nodes.size()) > 0,
                  "TreeModel: wrong format");
+    XGBOOST_STATIC_ASSERT(sizeof(NodeStat) % sizeof(uint64_t) == 0)
     utils::Check(fi.Read(BeginPtr(stats), sizeof(NodeStat) * stats.size()) > 0,
                  "TreeModel: wrong format");
     if (param.size_leaf_vector != 0) {

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -53,6 +53,13 @@ typedef __int64 int64_t;
 #include <inttypes.h>
 #endif
 
+#define XGBOOST_JOIN(x_, y_) _XGBOOST_JOIN_IMPL(x_, y_)
+#define _XGBOOST_JOIN_IMPL(x_, y_) _XGBOOST_JOIN_IMPL2(x_, y_)
+#define _XGBOOST_JOIN_IMPL2(x_, y_) x_##y_
+
+#define XGBOOST_STATIC_ASSERT(expr_) \
+    typedef char XGBOOST_JOIN(xgboost_static_assert_, __LINE__)[(expr_) ? 1 : -1];
+
 namespace xgboost {
 /*! \brief namespace for helper utils of the project */
 namespace utils {


### PR DESCRIPTION
There was an issue that model files created on x86_64 (Mac OS X 64-bit) couldn't be used on armv7 (iOS 32-bit). The problem was caused by the serialized/deserialized structures padding. So I made the structures size multiple to 64 bit. There could be another solution — to use compiler attributes — but that attributes differ from compiler to compiler, so it would be harder to keep the code crossplatform.