### PR TITLE
Python: Add feature_types to DMatrix

### DIFF
--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -47,6 +47,23 @@ class TestBasic(unittest.TestCase):
         self.assertRaises(ValueError, xgb.DMatrix, data,
                           feature_names=['a', 'b', 'c', 'd', 'e=1'])
 
+        dm = xgb.DMatrix(data)
+        dm.set_feature_names(list('abcde'))
+        assert dm.get_feature_names() == list('abcde')
+
+        dm.set_feature_types('q')
+        assert dm.get_feature_types() == list('qqqqq')
+
+        dm.set_feature_types(list('qiqiq'))
+        assert dm.get_feature_types() == list('qiqiq')
+
+        self.assertRaises(ValueError, dm.set_feature_types, list('abcde'))
+
+        # reset
+        dm.set_feature_names(None)
+        assert dm.get_feature_names() is None
+        assert dm.get_feature_types() is None
+
     def test_feature_names(self):
         data = np.random.randn(100, 5)
         target = np.array([0, 1] * 50)

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -48,21 +48,23 @@ class TestBasic(unittest.TestCase):
                           feature_names=['a', 'b', 'c', 'd', 'e=1'])
 
         dm = xgb.DMatrix(data)
-        dm.set_feature_names(list('abcde'))
-        assert dm.get_feature_names() == list('abcde')
+        dm.feature_names = list('abcde')
+        assert dm.feature_names == list('abcde')
 
-        dm.set_feature_types('q')
-        assert dm.get_feature_types() == list('qqqqq')
+        dm.feature_types = 'q'
+        assert dm.feature_types == list('qqqqq')
 
-        dm.set_feature_types(list('qiqiq'))
-        assert dm.get_feature_types() == list('qiqiq')
+        dm.feature_types = list('qiqiq')
+        assert dm.feature_types == list('qiqiq')
 
-        self.assertRaises(ValueError, dm.set_feature_types, list('abcde'))
+        def incorrect_type_set():
+            dm.feature_types = list('abcde')
+        self.assertRaises(ValueError, incorrect_type_set)
 
         # reset
-        dm.set_feature_names(None)
-        assert dm.get_feature_names() is None
-        assert dm.get_feature_types() is None
+        dm.feature_names = None
+        assert dm.feature_names is None
+        assert dm.feature_types is None
 
     def test_feature_names(self):
         data = np.random.randn(100, 5)


### PR DESCRIPTION
Follow-up for #488. This PR makes control output without using ``featmap.txt``. Also, made following changes.

- [x] Fixed ``plotting.to_graphiz`` function to support indicator variables.
- [x] Added getter and setter for features / types to be compat with other properties. 

~~I'm going to make ``feature_types`` works as below.~~

  - ~~If user passes ``feature_types``, validate then use it as it is.~~
      - ~~Check ``i`` columns only have 0/1 values.~~
      - ~~Check ``int`` columns only have int-like values (``dtype`` may be float though)~~
      - ~~Not check ``q``, ``float`` columns~~
  - ~~If user doesn't pass ``feature_types``, use ``i`` for columns only has 0/1 values. Use ``q`` for other columns.~~