### PR TITLE
Use homebrew gcc if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-export CC  = gcc
-#build on the fly
-export CXX = g++
+export CC  = $(if $(shell which gcc-5),gcc-5,gcc)
+export CXX = $(if $(shell which g++-5),g++-5,gcc)
+
 export MPICXX = mpicxx
 export LDFLAGS= -pthread -lm
 export CFLAGS = -Wall -O3 -msse2  -Wno-unknown-pragmas -funroll-loops


### PR DESCRIPTION
OS X Homebrew currently installs a bin called `gcc-5` rather than `gcc`. This should help with issues https://github.com/dmlc/xgboost/issues/465 and https://github.com/dmlc/xgboost/issues/276.