### PR TITLE
python DMatrix now accepts pandas DataFrame

### DIFF
--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -64,7 +64,7 @@ if [ ${TASK} == "python-package" -o ${TASK} == "python-package3" ]; then
         conda create -n myenv python=2.7
     fi
     source activate myenv
-    conda install numpy scipy matplotlib nose
+    conda install numpy scipy pandas matplotlib nose
     python -m pip install graphviz
 
     make all CXX=${CXX} || exit -1

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -97,6 +97,27 @@ class TestBasic(unittest.TestCase):
             dm = xgb.DMatrix(dummy, feature_names=list('abcde'))
             self.assertRaises(ValueError, bst.predict, dm)
 
+    def test_pandas(self):
+        import pandas as pd
+        df = pd.DataFrame([[1, 2., True], [2, 3., False]], columns=['a', 'b', 'c'])
+        dm = xgb.DMatrix(df, label=pd.Series([1, 2]))
+        assert dm.feature_names == ['a', 'b', 'c']
+        assert dm.feature_types == ['int', 'q', 'i']
+        assert dm.num_row() == 2
+        assert dm.num_col() == 3
+
+        # overwrite feature_names and feature_types
+        dm = xgb.DMatrix(df, label=pd.Series([1, 2]),
+                         feature_names=['x', 'y', 'z'], feature_types=['q', 'q', 'q'])
+        assert dm.feature_names == ['x', 'y', 'z']
+        assert dm.feature_types == ['q', 'q', 'q']
+        assert dm.num_row() == 2
+        assert dm.num_col() == 3
+
+        # incorrect dtypes
+        df = pd.DataFrame([[1, 2., 'x'], [2, 3., 'y']], columns=['a', 'b', 'c'])
+        self.assertRaises(ValueError, xgb.DMatrix, df)
+
     def test_load_file_invalid(self):
 
         self.assertRaises(ValueError, xgb.Booster,


### PR DESCRIPTION
Related to #294. It is nice if we can create ``DMatrix`` from ``pandas.DataFrame``. Feature names and types are automatically retrieved by ``DataFrame`` definitions otherwise specified.

Non-supported data types (other than ``int``, ``float``, ``bool`` ) result in ``ValueError``. 