### PR TITLE
Python CV returns pd.DataFrame or np.ndarray

### DIFF
--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -64,7 +64,7 @@ if [ ${TASK} == "python-package" -o ${TASK} == "python-package3" ]; then
         conda create -n myenv python=2.7
     fi
     source activate myenv
-    conda install numpy scipy matplotlib nose
+    conda install numpy scipy pandas matplotlib nose
     python -m pip install graphviz
 
     make all CXX=${CXX} || exit -1

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -127,6 +127,36 @@ class TestBasic(unittest.TestCase):
         data = np.array([['a', 'b'], ['c', 'd']])
         self.assertRaises(ValueError, xgb.DMatrix, data)
 
+    def test_cv(self):
+        dm = xgb.DMatrix(dpath + 'agaricus.txt.train')
+        params = {'max_depth':2, 'eta':1, 'silent':1, 'objective':'binary:logistic' }
+
+        import pandas as pd
+        cv = xgb.cv(params, dm, num_boost_round=10, nfold=10)
+        assert isinstance(cv, pd.DataFrame)
+        exp = pd.Index([u'test-error-mean', u'test-error-std',
+                        u'train-error-mean', u'train-error-std'])
+        assert cv.columns.equals(exp)
+
+        # show progress log (result is the same as above)
+        cv = xgb.cv(params, dm, num_boost_round=10, nfold=10,
+                    show_progress=True)
+        assert isinstance(cv, pd.DataFrame)
+        exp = pd.Index([u'test-error-mean', u'test-error-std',
+                        u'train-error-mean', u'train-error-std'])
+        assert cv.columns.equals(exp)
+        cv = xgb.cv(params, dm, num_boost_round=10, nfold=10,
+                    show_progress=True, show_stdv=False)
+        assert isinstance(cv, pd.DataFrame)
+        exp = pd.Index([u'test-error-mean', u'test-error-std',
+                        u'train-error-mean', u'train-error-std'])
+        assert cv.columns.equals(exp)
+
+        # return np.ndarray
+        cv = xgb.cv(params, dm, num_boost_round=10, nfold=10, as_pandas=False)
+        assert isinstance(cv, np.ndarray)
+        assert cv.shape == (10, 4)
+
     def test_plotting(self):
         bst2 = xgb.Booster(model_file='xgb.model')
         # plotting


### PR DESCRIPTION
Closes #294.

``xgb.cv`` behaves as below.

- If ``pandas`` is installed, return ``pd.DataFrame`` by default. No progress messages are output in this case, because ``pd.DataFrame`` should contain all information.
  - Progress message can be enabled by specifying ``show_progres=True``.
- If ``pandas`` is not installed, or explicitly specified ``as_pandas=False``, return ``np.ndarray``. Progress messages are output because ``np.ndarray`` can't contain metadata.
  - Progress message can be disabled by specifying ``show_progres=False``.

Pls see my gist for full example: https://gist.github.com/sinhrks/cc9a88f74074fc296e12#file-pandas-cv-ipynb

CC: @fyears 