### PR TITLE
Python supports pd.DataFrame with non-str columns

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -153,7 +153,7 @@ def _maybe_from_pandas(data, feature_names, feature_types):
         raise ValueError('DataFrame.dtypes must be int, float or bool')
 
     if feature_names is None:
-        feature_names = data.columns.tolist()
+        feature_names = data.columns.format()
     if feature_types is None:
         mapper = {'int64': 'int', 'float64': 'q', 'bool': 'i'}
         feature_types = [mapper[dtype.name] for dtype in dtypes]

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -118,6 +118,21 @@ class TestBasic(unittest.TestCase):
         df = pd.DataFrame([[1, 2., 'x'], [2, 3., 'y']], columns=['a', 'b', 'c'])
         self.assertRaises(ValueError, xgb.DMatrix, df)
 
+        # numeric columns
+        df = pd.DataFrame([[1, 2., True], [2, 3., False]])
+        dm = xgb.DMatrix(df, label=pd.Series([1, 2]))
+        assert dm.feature_names == ['0', '1', '2']
+        assert dm.feature_types == ['int', 'q', 'i']
+        assert dm.num_row() == 2
+        assert dm.num_col() == 3
+
+        df = pd.DataFrame([[1, 2., 1], [2, 3., 1]], columns=[4, 5, 6])
+        dm = xgb.DMatrix(df, label=pd.Series([1, 2]))
+        assert dm.feature_names == ['4', '5', '6']
+        assert dm.feature_types == ['int', 'q', 'int']
+        assert dm.num_row() == 2
+        assert dm.num_col() == 3
+
     def test_load_file_invalid(self):
 
         self.assertRaises(ValueError, xgb.Booster,


### PR DESCRIPTION
Follow-up for #522. When DataFrame columns are non-numeric, convert it to str.