### PR TITLE
Update training.py and sklearn.py for evals_result

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,3 +50,4 @@ List of Contributors
 * [Hongliang Liu](https://github.com/phunterlau)
   - Hongliang is the maintainer of xgboost python PyPI package for pip installation.
 * [Huayi Zhang](https://github.com/irachex)
+* [Johan Manders](https://github.com/johanmanders)

--- a/demo/guide-python/README.md
+++ b/demo/guide-python/README.md
@@ -9,4 +9,6 @@ XGBoost Python Feature Walkthrough
 * [Predicting leaf indices](predict_leaf_indices.py)
 * [Sklearn Wrapper](sklearn_examples.py)
 * [Sklearn Parallel](sklearn_parallel.py)
+* [Sklearn access evals result](sklearn_evals_result.py)
+* [Access evals result](evals_result.py)
 * [External Memory](external_memory.py)

--- a/demo/guide-python/evals_result.py
+++ b/demo/guide-python/evals_result.py
@@ -1,0 +1,29 @@
+import xgboost as xgb
+##
+#  This script demonstrate how to access the eval metrics in xgboost
+##
+dtrain = xgb.DMatrix('../data/agaricus.txt.train', silent=True)
+dtest = xgb.DMatrix('../data/agaricus.txt.test', silent=True)
+
+param = [('max_depth', 2), ('objective', 'binary:logistic'), ('eval_metric', 'logloss'), ('eval_metric', 'error')]
+ 
+num_round = 2
+watchlist = [(dtest,'eval'), (dtrain,'train')]
+
+evals_result = {}
+bst = xgb.train(param, dtrain, num_round, watchlist, evals_result=evals_result)
+
+print('Access logloss metric directly from evals_result:')
+print(evals_result['eval']['logloss'])
+
+print('')
+print('Access metrics through a loop:')
+for e_name, e_mtrs in evals_result.items():
+    print('- {}'.format(e_name))
+    for e_mtr_name, e_mtr_vals in e_mtrs.items():
+        print('   - {}'.format(e_mtr_name))
+        print('      - {}'.format(e_mtr_vals))
+
+print('')
+print('Access complete dictionary:')
+print(evals_result)

--- a/demo/guide-python/evals_result.py
+++ b/demo/guide-python/evals_result.py
@@ -1,7 +1,8 @@
-import xgboost as xgb
 ##
 #  This script demonstrate how to access the eval metrics in xgboost
 ##
+
+import xgboost as xgb
 dtrain = xgb.DMatrix('../data/agaricus.txt.train', silent=True)
 dtest = xgb.DMatrix('../data/agaricus.txt.test', silent=True)
 

--- a/demo/guide-python/sklearn_evals_result.py
+++ b/demo/guide-python/sklearn_evals_result.py
@@ -1,0 +1,43 @@
+##
+#  This script demonstrate how to access the xgboost eval metrics by using sklearn
+##
+
+import xgboost as xgb
+import numpy as np
+from sklearn.datasets import make_hastie_10_2
+
+X, y = make_hastie_10_2(n_samples=2000, random_state=42)
+
+# Map labels from {-1, 1} to {0, 1}
+labels, y = np.unique(y, return_inverse=True)
+
+X_train, X_test = X[:1600], X[1600:]
+y_train, y_test = y[:1600], y[1600:]
+
+param_dist = {'objective':'binary:logistic', 'n_estimators':2}
+
+clf = xgb.XGBModel(**param_dist)
+# Or you can use: clf = xgb.XGBClassifier(**param_dist)
+
+clf.fit(X_train, y_train,
+        eval_set=[(X_train, y_train), (X_test, y_test)], 
+        eval_metric='logloss',
+        verbose=True)
+
+# Load evals result by calling the evals_result() function
+evals_result = clf.evals_result()
+
+print('Access logloss metric directly from validation_0:')
+print(evals_result['validation_0']['logloss'])
+
+print('')
+print('Access metrics through a loop:')
+for e_name, e_mtrs in evals_result.items():
+    print('- {}'.format(e_name))
+    for e_mtr_name, e_mtr_vals in e_mtrs.items():
+        print('   - {}'.format(e_mtr_name))
+        print('      - {}'.format(e_mtr_vals))
+ 
+print('')
+print('Access complete dict:')
+print(evals_result)

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -203,11 +203,11 @@ class XGBModel(XGBModelBase):
         # pylint: disable=missing-docstring,invalid-name
         test_dmatrix = DMatrix(data, missing=self.missing)
         return self.booster().predict(test_dmatrix)
-    
+
     def evals_result(self):
         """Return the evaluation results.
 
-        If eval_set is passed to the `fit` function, you can call evals_result() to 
+        If eval_set is passed to the `fit` function, you can call evals_result() to
         get evaluation results for all passed eval_sets. When eval_metric is also
         passed to the `fit` function, the evals_result will contain the eval_metrics
         passed to the `fit` function
@@ -215,27 +215,28 @@ class XGBModel(XGBModelBase):
         Returns
         -------
         evals_result : dictionary
-        
+
         Example
         -------
         param_dist = {'objective':'binary:logistic', 'n_estimators':2}
-        
+
         clf = xgb.XGBModel(**param_dist)
 
         clf.fit(X_train, y_train,
-                eval_set=[(X_train, y_train), (X_test, y_test)], 
+                eval_set=[(X_train, y_train), (X_test, y_test)],
                 eval_metric='logloss',
                 verbose=True)
-        
+
         evals_result = clf.evals_result()
-        
-        The variable evals_result will contain: 
-        {'validation_0': {'logloss': ['0.604835', '0.531479']}, 'validation_1': {'logloss': ['0.41965', '0.17686']}}
+
+        The variable evals_result will contain:
+        {'validation_0': {'logloss': ['0.604835', '0.531479']},
+         'validation_1': {'logloss': ['0.41965', '0.17686']}}
         """
         if self.evals_result_:
             evals_result = self.evals_result_
         else:
-            raise Error('No results.')
+            raise XGBoostError('No results.')
         
         return evals_result
 
@@ -373,7 +374,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
     def evals_result(self):
         """Return the evaluation results.
 
-        If eval_set is passed to the `fit` function, you can call evals_result() to 
+        If eval_set is passed to the `fit` function, you can call evals_result() to
         get evaluation results for all passed eval_sets. When eval_metric is also
         passed to the `fit` function, the evals_result will contain the eval_metrics
         passed to the `fit` function
@@ -381,27 +382,28 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         Returns
         -------
         evals_result : dictionary
-        
+
         Example
         -------
         param_dist = {'objective':'binary:logistic', 'n_estimators':2}
-        
+
         clf = xgb.XGBClassifier(**param_dist)
 
         clf.fit(X_train, y_train,
-                eval_set=[(X_train, y_train), (X_test, y_test)], 
+                eval_set=[(X_train, y_train), (X_test, y_test)],
                 eval_metric='logloss',
                 verbose=True)
-        
+
         evals_result = clf.evals_result()
-        
-        The variable evals_result will contain: 
-        {'validation_0': {'logloss': ['0.604835', '0.531479']}, 'validation_1': {'logloss': ['0.41965', '0.17686']}}
+
+        The variable evals_result will contain:
+        {'validation_0': {'logloss': ['0.604835', '0.531479']},
+         'validation_1': {'logloss': ['0.41965', '0.17686']}}
         """
         if self.evals_result_:
             evals_result = self.evals_result_
         else:
-            raise Error('No results.')
+            raise XGBoostError('No results.')
         
         return evals_result
 

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -237,7 +237,7 @@ class XGBModel(XGBModelBase):
             evals_result = self.evals_result_
         else:
             raise XGBoostError('No results.')
-        
+
         return evals_result
 
 
@@ -370,7 +370,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             classone_probs = class_probs
             classzero_probs = 1.0 - classone_probs
             return np.vstack((classzero_probs, classone_probs)).transpose()
-    
+
     def evals_result(self):
         """Return the evaluation results.
 
@@ -404,7 +404,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             evals_result = self.evals_result_
         else:
             raise XGBoostError('No results.')
-        
+
         return evals_result
 
 class XGBRegressor(XGBModel, XGBRegressorBase):

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -190,8 +190,7 @@ class XGBModel(XGBModelBase):
 
         if eval_results:
             for val in eval_results.items():
-                for k, v in val[1].items():
-                    eval_results[val[0]] = np.array(v, dtype=float)
+                eval_results[val[0]] = [np.array(v[1], dtype=float) for v in val[1].items()]
             self.eval_results = eval_results
 
         if early_stopping_rounds is not None:
@@ -305,8 +304,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
 
         if eval_results:
             for val in eval_results.items():
-                for k, v in val[1].items():
-                    eval_results[val[0]] = np.array(v, dtype=float)
+                eval_results[val[0]] = [np.array(v[1], dtype=float) for v in val[1].items()]
             self.eval_results = eval_results
 
         if early_stopping_rounds is not None:

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -187,10 +187,11 @@ class XGBModel(XGBModelBase):
                               early_stopping_rounds=early_stopping_rounds,
                               evals_result=eval_results, feval=feval,
                               verbose_eval=verbose)
+
         if eval_results:
-            eval_results = {k: np.array(v, dtype=float)
-                            for k, v in eval_results.items()}
-            eval_results = {k: np.array(v) for k, v in eval_results.items()}
+            for val in eval_results.items():
+                for k, v in val[1].items():
+                    eval_results[val[0]] = np.array(v, dtype=float)
             self.eval_results = eval_results
 
         if early_stopping_rounds is not None:
@@ -303,8 +304,9 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
                               verbose_eval=verbose)
 
         if eval_results:
-            eval_results = {k: np.array(v, dtype=float)
-                            for k, v in eval_results.items()}
+            for val in eval_results.items():
+                for k, v in val[1].items():
+                    eval_results[val[0]] = np.array(v, dtype=float)
             self.eval_results = eval_results
 
         if early_stopping_rounds is not None:

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -73,12 +73,12 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
                 if evals_result is not None:
                     res = re.findall("([0-9a-zA-Z@]+[-]*):-?([0-9.]+).", msg)
                     for key in evals_name:
-                        evals_idx =  evals_name.index(key)
+                        evals_idx = evals_name.index(key)
                         res_per_eval = len(res) / len(evals_name)
                         for r in range(res_per_eval):
                             res_item = res[(evals_idx*res_per_eval) + r]
                             res_key = res_item[0]
-                            res_val = res_item[1]                           
+                            res_val = res_item[1]
                             if res_key in evals_result[key]:
                                 evals_result[key][res_key].append(res_val)
                             else:
@@ -130,12 +130,12 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
             if evals_result is not None:
                 res = re.findall("([0-9a-zA-Z@]+[-]*):-?([0-9.]+).", msg)
                 for key in evals_name:
-                    evals_idx =  evals_name.index(key)
+                    evals_idx = evals_name.index(key)
                     res_per_eval = len(res) / len(evals_name)
                     for r in range(res_per_eval):
                         res_item = res[(evals_idx*res_per_eval) + r]
                         res_key = res_item[0]
-                        res_val = res_item[1]                           
+                        res_val = res_item[1]
                         if res_key in evals_result[key]:
                             evals_result[key][res_key].append(res_val)
                         else:

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -41,7 +41,8 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
         This dictionary stores the evaluation results of all the items in watchlist.
         Example: with a watchlist containing [(dtest,'eval'), (dtrain,'train')] and
         and a paramater containing ('eval_metric', 'logloss')
-        Returns: {'train': {'logloss': ['0.48253', '0.35953']}, 'eval': {'logloss': ['0.480385', '0.357756']}}
+        Returns: {'train': {'logloss': ['0.48253', '0.35953']},
+                  'eval': {'logloss': ['0.480385', '0.357756']}}
     verbose_eval : bool
         If `verbose_eval` then the evaluation metric on the validation set, if
         given, is printed at each boosting stage.
@@ -320,4 +321,3 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, metrics=(),
         results = np.array(results)
 
     return results
-

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -56,7 +56,7 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
         else:
             evals_name = [d[1] for d in evals]
             evals_result.clear()
-            evals_result.update({key: [] for key in evals_name})
+            evals_result.update({key: {} for key in evals_name})
 
     if not early_stopping_rounds:
         for i in range(num_boost_round):
@@ -71,9 +71,18 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
                 if verbose_eval:
                     sys.stderr.write(msg + '\n')
                 if evals_result is not None:
-                    res = re.findall(":-?([0-9.]+).", msg)
-                    for key, val in zip(evals_name, res):
-                        evals_result[key].append(val)
+                    res = re.findall("([0-9a-zA-Z@]+[-]*):-?([0-9.]+).", msg)
+                    for key in evals_name:
+                        evals_idx =  evals_name.index(key)
+                        res_per_eval = len(res) / len(evals_name)
+                        for r in range(res_per_eval):
+                            res_item = res[(evals_idx*res_per_eval) + r]
+                            res_key = res_item[0]
+                            res_val = res_item[1]                           
+                            if res_key in evals_result[key]:
+                                evals_result[key][res_key].append(res_val)
+                            else:
+                                evals_result[key][res_key] = [res_val]
         return bst
 
     else:
@@ -119,9 +128,18 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
                 sys.stderr.write(msg + '\n')
 
             if evals_result is not None:
-                res = re.findall(":-?([0-9.]+).", msg)
-                for key, val in zip(evals_name, res):
-                    evals_result[key].append(val)
+                res = re.findall("([0-9a-zA-Z@]+[-]*):-?([0-9.]+).", msg)
+                for key in evals_name:
+                    evals_idx =  evals_name.index(key)
+                    res_per_eval = len(res) / len(evals_name)
+                    for r in range(res_per_eval):
+                        res_item = res[(evals_idx*res_per_eval) + r]
+                        res_key = res_item[0]
+                        res_val = res_item[1]                           
+                        if res_key in evals_result[key]:
+                            evals_result[key][res_key].append(res_val)
+                        else:
+                            evals_result[key][res_key] = [res_val]
 
             score = float(msg.rsplit(':', 1)[1])
             if (maximize_score and score > best_score) or \

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -38,7 +38,10 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
         If early stopping occurs, the model will have two additional fields:
         bst.best_score and bst.best_iteration.
     evals_result: dict
-        This dictionary stores the evaluation results of all the items in watchlist
+        This dictionary stores the evaluation results of all the items in watchlist.
+        Example: with a watchlist containing [(dtest,'eval'), (dtrain,'train')] and
+        and a paramater containing ('eval_metric', 'logloss')
+        Returns: {'train': {'logloss': ['0.48253', '0.35953']}, 'eval': {'logloss': ['0.480385', '0.357756']}}
     verbose_eval : bool
         If `verbose_eval` then the evaluation metric on the validation set, if
         given, is printed at each boosting stage.


### PR DESCRIPTION
Made changes to training.py to make sure all eval_metric information get passed to evals_result. Previous version lost and mislabeled data in evals_result when using more than one eval_metric.

Structure of eval_metric is now:
```
eval_metric[evals][eval_metric] = list of metrics
```
Example for XGBoost train:
```python
import xgboost as xgb

dtrain = xgb.DMatrix('../data/agaricus.txt.train', silent=True)
dtest = xgb.DMatrix('../data/agaricus.txt.test', silent=True)

param = [('max_depth', 2), ('objective', 'binary:logistic'), ('bst:eta', 0.01), ('eval_metric', 'logloss'), ('eval_metric', 'error')]

watchlist  = [(dtest,'eval'), (dtrain,'train')]
num_round = 2
evals_result = {}
bst = xgb.train(param, dtrain, num_round, watchlist, evals_result=evals_result)

print('Access logloss metric directly from eval:')
print(evals_result['eval']['logloss'])

print('')

print('Access metrics through a loop:')
for e_name, e_mtrs in evals_result.items():
    print('- {}'.format(e_name))
    for e_mtr_name, e_mtr_vals in e_mtrs.items():
        print('   - {}'.format(e_mtr_name))
        print('      - {}'.format(e_mtr_vals))

print('')

print('Access complete dict:')
print(evals_result)
```
Prints:
```
Access logloss metric directly from eval:
['0.480385', '0.357756']

Access metrics through a loop:
- train
   - logloss
      - ['0.48253', '0.35953']
- eval
   - logloss
      - ['0.480385', '0.357756']

Access complete dict:
{'train': {'logloss': ['0.48253', '0.35953']}, 'eval': {'logloss': ['0.480385', '0.357756']}}
```

Also made changes to sklearn.py to make sure the structure of evals_result is the same as training.py.

Example for Sklearn implementation:
```python
import xgboost as xgb
import numpy as np
from sklearn.datasets import make_hastie_10_2

X, y = make_hastie_10_2(n_samples=2000, random_state=42)

# map labels from {-1, 1} to {0, 1}
labels, y = np.unique(y, return_inverse=True)

X_train, X_test = X[:1600], X[1600:]
y_train, y_test = y[:1600], y[1600:]

param_dist = {'objective':'binary:logistic', 'n_estimators':2}

clf = xgb.XGBModel(**param_dist)

# You can also use: 
# clf = xgb.XGBClassifier(**param_dist)
 
clf.fit(X_train, y_train,
        eval_set=[(X_train, y_train), (X_test, y_test)], 
        eval_metric='logloss',
        verbose=True)
 
evals_result = clf.evals_result()
 
print('Access logloss metric directly from validation_0:')
print(evals_result['validation_0']['logloss'])
 
print('')
 
print('Access metrics through a loop:')
for e_name, e_mtrs in evals_result.items():
    print('- {}'.format(e_name))
    for e_mtr_name, e_mtr_vals in e_mtrs.items():
        print('   - {}'.format(e_mtr_name))
        print('      - {}'.format(e_mtr_vals))
 
print('')
 
print('Access complete dict:')
print(evals_result)
```
Prints:
```
Access logloss metric directly from validation_0:
['0.682260', '0.672904']

Access metrics through a loop:
- validation_0
   - logloss
      - ['0.682260', '0.672904']
- validation_1
   - logloss
      - ['0.68558', '0.67917']

Access complete dict:
{'validation_0': {'logloss': ['0.682260', '0.672904']}, 'validation_1': {'logloss': ['0.68558', '0.67917']}}
```
