### PR TITLE
More Pandas dtypes and more flexible variable naming

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -139,7 +139,7 @@ def c_array(ctype, values):
 
 
 def _maybe_from_pandas(data, feature_names, feature_types):
--    """ Extract internal data from pd.DataFrame """
+    """ Extract internal data from pd.DataFrame """
     try:
         import pandas as pd
     except ImportError:

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -215,7 +215,7 @@ class DMatrix(object):
         silent : boolean, optional
             Whether print messages during construction
         feature_names : list, optional
-            Set names for features. 
+            Set names for features.
             When data is a Pandas DataFrame, feature_names will be ignored.
         feature_types : list, optional
             Set types for features.

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -138,12 +138,8 @@ def c_array(ctype, values):
     return (ctype * len(values))(*values)
 
 
-def _maybe_from_pandas(data, label, feature_names, feature_types):
-    """ Extract internal data from pd.DataFrame
-
-    If data is Pandas DataFrame, feature_names passed through will be ignored and
-    overwritten by the column names of the Pandas DataFrame.
-    """
+def _maybe_from_pandas(data, feature_names, feature_types):
+-    """ Extract internal data from pd.DataFrame """
     try:
         import pandas as pd
     except ImportError:

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -138,27 +138,50 @@ def c_array(ctype, values):
     return (ctype * len(values))(*values)
 
 
-def _maybe_from_pandas(data, feature_names, feature_types):
-    """ Extract internal data from pd.DataFrame """
+def _maybe_from_pandas(data, label, feature_names, feature_types):
+    """ Extract internal data from pd.DataFrame
+
+    If data is Pandas DataFrame, feature_names passed through will be ignored and
+    overwritten by the column names of the Pandas DataFrame.
+    """
     try:
         import pandas as pd
     except ImportError:
-        return data, feature_names, feature_types
+        return data, label, feature_names, feature_types
 
     if not isinstance(data, pd.DataFrame):
-        return data, feature_names, feature_types
+        return data, label, feature_names, feature_types
 
-    dtypes = data.dtypes
-    if not all(dtype.name in ('int64', 'float64', 'bool') for dtype in dtypes):
-        raise ValueError('DataFrame.dtypes must be int, float or bool')
+    data_dtypes = data.dtypes
+    if not all(dtype.name in ('int8', 'int16', 'int32', 'int64',
+                              'uint8', 'uint16', 'uint32', 'uint64',
+                              'float16', 'float32', 'float64',
+                              'bool') for dtype in data_dtypes):
+        raise ValueError('DataFrame.dtypes for data must be int, float or bool')
 
-    if feature_names is None:
-        feature_names = data.columns.format()
+    if label is not None:
+        if isinstance(label, pd.DataFrame):
+            label_dtypes = label.dtypes
+            if not all(dtype.name in ('int8', 'int16', 'int32', 'int64',
+                                      'uint8', 'uint16', 'uint32', 'uint64',
+                                      'float16', 'float32', 'float64',
+                                      'bool') for dtype in label_dtypes):
+                raise ValueError('DataFrame.dtypes for label must be int, float or bool')
+            else:
+                label = label.values.astype('float')
+
+    feature_names = data.columns.format()
+
     if feature_types is None:
-        mapper = {'int64': 'int', 'float64': 'q', 'bool': 'i'}
-        feature_types = [mapper[dtype.name] for dtype in dtypes]
+        mapper = {'int8': 'int', 'int16': 'int', 'int32': 'int', 'int64': 'int',
+                  'uint8': 'int', 'uint16': 'int', 'uint32': 'int', 'uint64': 'int',
+                  'float16': 'float', 'float32': 'float', 'float64': 'float',
+                  'bool': 'int'}
+        feature_types = [mapper[dtype.name] for dtype in data_dtypes]
+
     data = data.values.astype('float')
-    return data, feature_names, feature_types
+
+    return data, label, feature_names, feature_types
 
 class DMatrix(object):
     """Data Matrix used in XGBoost.
@@ -192,9 +215,10 @@ class DMatrix(object):
         silent : boolean, optional
             Whether print messages during construction
         feature_names : list, optional
-            Labels for features.
+            Set names for features. 
+            When data is a Pandas DataFrame, feature_names will be ignored.
         feature_types : list, optional
-            Labels for features.
+            Set types for features.
         """
         # force into void_p, mac need to pass things in as void_p
         if data is None:
@@ -204,8 +228,10 @@ class DMatrix(object):
         klass = getattr(getattr(data, '__class__', None), '__name__', None)
         if klass == 'DataFrame':
             # once check class name to avoid unnecessary pandas import
-            data, feature_names, feature_types = _maybe_from_pandas(data, feature_names,
-                                                                    feature_types)
+            data, label, feature_names, feature_types = _maybe_from_pandas(data,
+                                                                           label,
+                                                                           feature_names,
+                                                                           feature_types)
 
         if isinstance(data, STRING_TYPES):
             self.handle = ctypes.c_void_p()
@@ -520,10 +546,10 @@ class DMatrix(object):
             if len(feature_names) != self.num_col():
                 msg = 'feature_names must have the same length as data'
                 raise ValueError(msg)
-            # prohibit to use symbols may affect to parse. e.g. ``[]=.``
-            if not all(isinstance(f, STRING_TYPES) and f.isalnum()
+            # prohibit to use symbols may affect to parse. e.g. []<
+            if not all(isinstance(f, STRING_TYPES) and not any(x in f for x in {'[', ']', '<'})
                        for f in feature_names):
-                raise ValueError('all feature_names must be alphanumerics')
+                raise ValueError('feature_names may not contain [, ] or <')
         else:
             # reset feature_types also
             self.feature_types = None
@@ -556,12 +582,11 @@ class DMatrix(object):
             if len(feature_types) != self.num_col():
                 msg = 'feature_types must have the same length as data'
                 raise ValueError(msg)
-            # prohibit to use symbols may affect to parse. e.g. ``[]=.``
 
-            valid = ('q', 'i', 'int', 'float')
+            valid = ('int', 'float')
             if not all(isinstance(f, STRING_TYPES) and f in valid
                        for f in feature_types):
-                raise ValueError('all feature_names must be {i, q, int, float}')
+                raise ValueError('All feature_names must be {int, float}')
         self._feature_types = feature_types
 
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -213,7 +213,6 @@ class DMatrix(object):
             Whether print messages during construction
         feature_names : list, optional
             Set names for features.
-            When data is a Pandas DataFrame, feature_names will be ignored.
         feature_types : list, optional
             Set types for features.
         """

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -170,7 +170,8 @@ def _maybe_from_pandas(data, label, feature_names, feature_types):
             else:
                 label = label.values.astype('float')
 
-    feature_names = data.columns.format()
+    if feature_names is None:
+        feature_names = data.columns.format()
 
     if feature_types is None:
         mapper = {'int8': 'int', 'int16': 'int', 'int32': 'int', 'int64': 'int',

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -138,7 +138,7 @@ def c_array(ctype, values):
     return (ctype * len(values))(*values)
 
 
-def _maybe_from_pandas(data, feature_names, feature_types):
+def _maybe_from_pandas(data, label, feature_names, feature_types):
     """ Extract internal data from pd.DataFrame """
     try:
         import pandas as pd

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -176,7 +176,7 @@ def _maybe_from_pandas(data, label, feature_names, feature_types):
         mapper = {'int8': 'int', 'int16': 'int', 'int32': 'int', 'int64': 'int',
                   'uint8': 'int', 'uint16': 'int', 'uint32': 'int', 'uint64': 'int',
                   'float16': 'float', 'float32': 'float', 'float64': 'float',
-                  'bool': 'int'}
+                  'bool': 'i'}
         feature_types = [mapper[dtype.name] for dtype in data_dtypes]
 
     data = data.values.astype('float')
@@ -583,10 +583,10 @@ class DMatrix(object):
                 msg = 'feature_types must have the same length as data'
                 raise ValueError(msg)
 
-            valid = ('int', 'float')
+            valid = ('int', 'float', 'i', 'q')
             if not all(isinstance(f, STRING_TYPES) and f in valid
                        for f in feature_types):
-                raise ValueError('All feature_names must be {int, float}')
+                raise ValueError('All feature_names must be {int, float, i, q}')
         self._feature_types = feature_types
 
 

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -73,12 +73,12 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
                 if evals_result is not None:
                     res = re.findall("([0-9a-zA-Z@]+[-]*):-?([0-9.]+).", msg)
                     for key in evals_name:
-                        evals_idx =  evals_name.index(key)
+                        evals_idx = evals_name.index(key)
                         res_per_eval = len(res) / len(evals_name)
                         for r in range(res_per_eval):
                             res_item = res[(evals_idx*res_per_eval) + r]
                             res_key = res_item[0]
-                            res_val = res_item[1]                           
+                            res_val = res_item[1]
                             if res_key in evals_result[key]:
                                 evals_result[key][res_key].append(res_val)
                             else:
@@ -130,12 +130,12 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
             if evals_result is not None:
                 res = re.findall("([0-9a-zA-Z@]+[-]*):-?([0-9.]+).", msg)
                 for key in evals_name:
-                    evals_idx =  evals_name.index(key)
+                    evals_idx = evals_name.index(key)
                     res_per_eval = len(res) / len(evals_name)
                     for r in range(res_per_eval):
                         res_item = res[(evals_idx*res_per_eval) + r]
                         res_key = res_item[0]
-                        res_val = res_item[1]                           
+                        res_val = res_item[1]
                         if res_key in evals_result[key]:
                             evals_result[key][res_key].append(res_val)
                         else:

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -45,7 +45,7 @@ class TestBasic(unittest.TestCase):
                           feature_names=['a', 'b', 'c', 'd', 'd'])
         # contains symbol
         self.assertRaises(ValueError, xgb.DMatrix, data,
-                          feature_names=['a', 'b', 'c', 'd', 'e=1'])
+                          feature_names=['a', 'b', 'c', 'd', 'e<1'])
 
         dm = xgb.DMatrix(data)
         dm.feature_names = list('abcde')
@@ -102,7 +102,7 @@ class TestBasic(unittest.TestCase):
         df = pd.DataFrame([[1, 2., True], [2, 3., False]], columns=['a', 'b', 'c'])
         dm = xgb.DMatrix(df, label=pd.Series([1, 2]))
         assert dm.feature_names == ['a', 'b', 'c']
-        assert dm.feature_types == ['int', 'q', 'i']
+        assert dm.feature_types == ['int', 'float', 'i']
         assert dm.num_row() == 2
         assert dm.num_col() == 3
 
@@ -122,14 +122,14 @@ class TestBasic(unittest.TestCase):
         df = pd.DataFrame([[1, 2., True], [2, 3., False]])
         dm = xgb.DMatrix(df, label=pd.Series([1, 2]))
         assert dm.feature_names == ['0', '1', '2']
-        assert dm.feature_types == ['int', 'q', 'i']
+        assert dm.feature_types == ['int', 'float', 'i']
         assert dm.num_row() == 2
         assert dm.num_col() == 3
 
         df = pd.DataFrame([[1, 2., 1], [2, 3., 1]], columns=[4, 5, 6])
         dm = xgb.DMatrix(df, label=pd.Series([1, 2]))
         assert dm.feature_names == ['4', '5', '6']
-        assert dm.feature_types == ['int', 'q', 'int']
+        assert dm.feature_types == ['int', 'float', 'int']
         assert dm.num_row() == 2
         assert dm.num_col() == 3
 
@@ -237,3 +237,6 @@ class TestBasic(unittest.TestCase):
         assert isinstance(g, Digraph)
         ax = xgb.plot_tree(bst2, num_trees=0)
         assert isinstance(ax, Axes)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Pandas DataFrame supports more dtypes than 'int64', 'float64' and 'bool', therefor added a bunch of extra dtypes for the data variable.
- From now on the label variable can be a Pandas DataFrame with the same dtypes as the data variable or it can be a numpy.ndarray
- If the label is a Pandas DataFrame, it will be converted to float.
- If no feature_types is set, the data dtypes will be converted to 'int', 'float' or 'i' (bool).
- ~~If data is Pandas DataFrame, feature_names passed through will be ignored and overwritten by the column names of the Pandas DataFrame.~~
- The feature_names may contain every character except [, ] or <
- List of possible dtypes: 
 - 'int8', 'int16', 'int32', 'int64'
 - 'uint8', 'uint16', 'uint32', 'uint64'
 - 'float16', 'float32', 'float64'
 - 'bool'

An example to test various changes:
```python
import xgboost as xgb
import pandas as pd

col_1 = [76.1, 44, 20.4, 42, 74, 73, 6, 57, 59.224, 26, 64, 28, 99, 90.8, 40, 77, 14, 2, 97, 33]
col_2 = [62, 31, 51, 19, 1.4, 80, 74, 15.22, 42, 26, 29.7, 95, 2, 99, 12.87, 58, 30, 68, 92, 45]
col_3 = [1, 1, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0]
target = [1, 1, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0]

# X and y both DataFrames.
# X uses column names with an underscore
X = pd.DataFrame({'COL_1':col_1,
                  'COL_2':col_2,
                  'COL_3':col_3})
y = pd.DataFrame({'TARGET':target})

# Testing different types
# All three can be 'int8', 'float16', 'uint32' etc.
X['COL_1'] = X['COL_1'].astype('uint8')
X['COL_2'] = X['COL_2'].astype('float32')
X['COL_3'] = X['COL_3'].astype('bool')

# Testing a vary strange column name
strange_column_name = 'v3Ry_$t@ng3 N@m3'
X.rename(columns={'COL_1':strange_column_name}, inplace=True)

X_train = X[0:15]
X_test = X[15:20]

# Can be a numpy.ndarray when using y_train = y[0:15].values
y_train = y[0:15]

param_dist = {'objective':'binary:logistic', 'n_estimators':2}

clf = xgb.XGBModel(**param_dist)
clf.fit(X_train, y_train)
y_pred = clf.predict(X_test)

print(y_pred)
```