### PR TITLE
Fix data file shipping confusions on pip install for #463

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,6 @@ pythonpack:
 	cp -r multi-node xgboost-deploy/xgboost
 	cp -r windows xgboost-deploy/xgboost
 	cp -r src xgboost-deploy/xgboost
-
 	#make python
 
 pythonbuild:

--- a/python-package/MANIFEST.in
+++ b/python-package/MANIFEST.in
@@ -5,3 +5,10 @@ recursive-include xgboost/windows *
 recursive-include xgboost/subtree *
 recursive-include xgboost/src *
 recursive-include xgboost/multi-node *
+#exclude pre-compiled .o file for less confusions
+#include the pre-compiled .so is needed as a placeholder
+#since it will be copy after compiling on the fly
+global-exclude xgboost/wrapper/*.so.gz
+global-exclude xgboost/*.o
+global-exclude *.pyo
+global-exclude *.pyc

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -16,7 +16,7 @@ if False:
     if not os.name == 'nt': #if not windows
         os.system('sh ./xgboost/build-python.sh')
     else:
-        print 'Windows users please use github installation.'
+        print('Windows users please use github installation.')
         sys.exit()
 
 

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -2,6 +2,7 @@
 """Setup xgboost package."""
 from __future__ import absolute_import
 import sys
+import os
 from setuptools import setup, find_packages
 import subprocess
 sys.path.insert(0, '.')
@@ -10,12 +11,14 @@ import os
 #build on the fly if install in pip
 #otherwise, use build.sh in the parent directory
 
-if 'pip' in __file__:
+#ugly solution since pip version transition and the old pip detection method not
+#working. Manually turn on when packing up for pip installation
+if False:
     if not os.name == 'nt': #if not windows
-        build_sh = subprocess.Popen(['sh', 'xgboost/build-python.sh'])
-        build_sh.wait()
-        output = build_sh.communicate()
-        print(output)
+        os.system('sh ./xgboost/build-python.sh')
+    else:
+        print 'Windows users please use github installation.'
+        sys.exit()
 
 
 CURRENT_DIR = os.path.dirname(__file__)
@@ -28,7 +31,6 @@ libpath = {'__file__': libpath_py}
 exec(compile(open(libpath_py, "rb").read(), libpath_py, 'exec'), libpath, libpath)
 
 LIB_PATH = libpath['find_lib_path']()
-#print LIB_PATH
 
 #to deploy to pip, please use
 #make pythonpack
@@ -36,7 +38,7 @@ LIB_PATH = libpath['find_lib_path']()
 #and be sure to test it firstly using "python setup.py register sdist upload -r pypitest"
 setup(name='xgboost',
       version=open(os.path.join(CURRENT_DIR, 'xgboost/VERSION')).read().strip(),
-      #version='0.4a13',
+      #version='0.4a23',
       description=open(os.path.join(CURRENT_DIR, 'README.md')).read(),
       install_requires=[
           'numpy',
@@ -53,5 +55,7 @@ setup(name='xgboost',
       #this will use MANIFEST.in during install where we specify additional files,
       #this is the golden line
       include_package_data=True,
-      data_files=[('xgboost', LIB_PATH)],
+      #!!! don't use data_files, otherwise install_data process will copy it to 
+      #root directory for some machines, and cause confusions on building
+      #data_files=[('xgboost', LIB_PATH)],
       url='https://github.com/dmlc/xgboost')

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -4,10 +4,9 @@ from __future__ import absolute_import
 import sys
 import os
 from setuptools import setup, find_packages
-import subprocess
+#import subprocess
 sys.path.insert(0, '.')
 
-import os
 #build on the fly if install in pip
 #otherwise, use build.sh in the parent directory
 
@@ -55,7 +54,7 @@ setup(name='xgboost',
       #this will use MANIFEST.in during install where we specify additional files,
       #this is the golden line
       include_package_data=True,
-      #!!! don't use data_files, otherwise install_data process will copy it to 
+      #!!! don't use data_files, otherwise install_data process will copy it to
       #root directory for some machines, and cause confusions on building
       #data_files=[('xgboost', LIB_PATH)],
       url='https://github.com/dmlc/xgboost')

--- a/python-package/xgboost/build-python.sh
+++ b/python-package/xgboost/build-python.sh
@@ -11,6 +11,8 @@
 
 
 pushd xgboost
+#remove the pre-compiled .so and trigger the system's on-the-fly compiling
+make clean
 if make python; then
     echo "Successfully build multi-thread xgboost"
 else


### PR DESCRIPTION
Fix data file shipping confusions on pip install for #463 by:
1. removing data_files in setup.py and giving MANIFEST.in the full control of file shipping
2. leaving a pre-compiled .so file in the `xgboost/wrapper/` and deleting it during pip installation, so it can force system compiling

Add error message for windows users for less confusion.

Current pip installation should give errors when there is no gcc installed on the system, which is the right thing.