### PR TITLE
GBTree::Predict performance fix: removed excess thread_temp initializ…

### DIFF
--- a/src/gbm/gbtree-inl.hpp
+++ b/src/gbm/gbtree-inl.hpp
@@ -138,13 +138,7 @@ class GBTree : public IGradBooster {
     {
       nthread = omp_get_num_threads();
     }
-    int prev_thread_temp_size = thread_temp.size();
-    if(prev_thread_temp_size < nthread) {
-      thread_temp.resize(nthread, tree::RegTree::FVec());
-      for (int i = prev_thread_temp_size; i < nthread; ++i) {
-        thread_temp[i].Init(mparam.num_feature);
-      }
-    }
+    InitThreadTemp(nthread);
     std::vector<float> &preds = *out_preds;
     const size_t stride = info.num_row * mparam.num_output_group;
     preds.resize(stride * (mparam.size_leaf_vector+1));
@@ -197,13 +191,7 @@ class GBTree : public IGradBooster {
     {
       nthread = omp_get_num_threads();
     }
-    int prev_thread_temp_size = thread_temp.size();
-    if(prev_thread_temp_size < nthread) {
-      thread_temp.resize(nthread, tree::RegTree::FVec());
-      for (int i = prev_thread_temp_size; i < nthread; ++i) {
-        thread_temp[i].Init(mparam.num_feature);
-      }
-    }
+    InitThreadTemp(nthread);
     this->PredPath(p_fmat, info, out_preds, ntree_limit);
   }
   virtual std::vector<std::string> DumpModel(const utils::FeatMap& fmap, int option) {
@@ -394,6 +382,16 @@ class GBTree : public IGradBooster {
           preds[ridx * ntree_limit + j] = static_cast<float>(tid);
         }
         feats.Drop(batch[i]);
+      }
+    }
+  }
+  // init thread buffers
+  inline void InitThreadTemp(int nthread) {
+    int prev_thread_temp_size = thread_temp.size();
+    if(prev_thread_temp_size < nthread) {
+      thread_temp.resize(nthread, tree::RegTree::FVec());
+      for (int i = prev_thread_temp_size; i < nthread; ++i) {
+        thread_temp[i].Init(mparam.num_feature);
       }
     }
   }

--- a/src/gbm/gbtree-inl.hpp
+++ b/src/gbm/gbtree-inl.hpp
@@ -138,9 +138,12 @@ class GBTree : public IGradBooster {
     {
       nthread = omp_get_num_threads();
     }
-    thread_temp.resize(nthread, tree::RegTree::FVec());
-    for (int i = 0; i < nthread; ++i) {
-      thread_temp[i].Init(mparam.num_feature);
+    int prev_thread_temp_size = thread_temp.size();
+    if(prev_thread_temp_size < nthread) {
+      thread_temp.resize(nthread, tree::RegTree::FVec());
+      for (int i = prev_thread_temp_size; i < nthread; ++i) {
+        thread_temp[i].Init(mparam.num_feature);
+      }
     }
     std::vector<float> &preds = *out_preds;
     const size_t stride = info.num_row * mparam.num_output_group;
@@ -194,9 +197,12 @@ class GBTree : public IGradBooster {
     {
       nthread = omp_get_num_threads();
     }
-    thread_temp.resize(nthread, tree::RegTree::FVec());
-    for (int i = 0; i < nthread; ++i) {
-      thread_temp[i].Init(mparam.num_feature);
+    int prev_thread_temp_size = thread_temp.size();
+    if(prev_thread_temp_size < nthread) {
+      thread_temp.resize(nthread, tree::RegTree::FVec());
+      for (int i = prev_thread_temp_size; i < nthread; ++i) {
+        thread_temp[i].Init(mparam.num_feature);
+      }
     }
     this->PredPath(p_fmat, info, out_preds, ntree_limit);
   }

--- a/src/gbm/gbtree-inl.hpp
+++ b/src/gbm/gbtree-inl.hpp
@@ -388,7 +388,7 @@ class GBTree : public IGradBooster {
   // init thread buffers
   inline void InitThreadTemp(int nthread) {
     int prev_thread_temp_size = thread_temp.size();
-    if(prev_thread_temp_size < nthread) {
+    if (prev_thread_temp_size < nthread) {
       thread_temp.resize(nthread, tree::RegTree::FVec());
       for (int i = prev_thread_temp_size; i < nthread; ++i) {
         thread_temp[i].Init(mparam.num_feature);


### PR DESCRIPTION
I use BoostLearner::Predict in c++ code on gbtree model with big number of features (16M)
BoostLearner::Predict give bad performance in case when I call BoostLearner::Predict for small data portion
My research show that bottleneck in GBTree::Predict function:
```
 thread_temp.resize(nthread, tree::RegTree::FVec());
    for (int i = 0; i < nthread; ++i) {
      thread_temp[i].Init(mparam.num_feature);
    }
```
FVec::Init call std::fill (16 Mb of float's in my case).
It seems possible to remove excess initialization of thread_temp on each call, because GBTree::Pred revert changed FVec values:
```
    if (itop != trees.size()) {
      p_feats->Fill(inst);
      ….
      p_feats->Drop(inst);
    }
```
Applied next changes: BoostLearner::Predict and BoostLearner::PredictLeaf initialize thread_temp only on first call or on OMP thread pool extending.
It helped to me, now on one CPU core (Intel(R) Xeon® CPU X5650  @ 2.67GHz, OMP disabled) BoostLearner::Predict give 625000 calls/sec (without patch it give: 120 calls/sec)

M.b it will help someone