### PR TITLE
fix training.py and sklearn.py for evals_result in python3

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -190,7 +190,7 @@ class XGBModel(XGBModelBase):
 
         if evals_result:
             for val in evals_result.items():
-                evals_result_key = val[1].keys()[0]
+                evals_result_key = list(val[1].keys())[0]
                 evals_result[val[0]][evals_result_key] = val[1][evals_result_key]
             self.evals_result_ = evals_result
 
@@ -341,7 +341,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
 
         if evals_result:
             for val in evals_result.items():
-                evals_result_key = val[1].keys()[0]
+                evals_result_key = list(val[1].keys())[0]
                 evals_result[val[0]][evals_result_key] = val[1][evals_result_key]
             self.evals_result_ = evals_result
 

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -78,7 +78,7 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
                     res = re.findall("([0-9a-zA-Z@]+[-]*):-?([0-9.]+).", msg)
                     for key in evals_name:
                         evals_idx = evals_name.index(key)
-                        res_per_eval = len(res) / len(evals_name)
+                        res_per_eval = len(res) // len(evals_name)
                         for r in range(res_per_eval):
                             res_item = res[(evals_idx*res_per_eval) + r]
                             res_key = res_item[0]
@@ -135,7 +135,7 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
                 res = re.findall("([0-9a-zA-Z@]+[-]*):-?([0-9.]+).", msg)
                 for key in evals_name:
                     evals_idx = evals_name.index(key)
-                    res_per_eval = len(res) / len(evals_name)
+                    res_per_eval = len(res) // len(evals_name)
                     for r in range(res_per_eval):
                         res_item = res[(evals_idx*res_per_eval) + r]
                         res_key = res_item[0]


### PR DESCRIPTION
I've fixed a few lines to run evals_result in Python Version 3.

- training.py

TypeError: 'float' object cannot be interpreted as an integer

In Python3, / operator has been changed as follows:

```
# Python2:
>>> 100/3
33
>>> 100//3
33
>>>

# Python3:
>>> 100/3
33.333333333333336
>>> 100//3
33
>>>
```


- sklearn.py

TypeError: 'dict_keys' object does not support indexing

In Python3, keys() function return 'dict_keys' object.

```
# Python2:
>>> x = {"key": "value"}
>>> x.keys()
['key']

# Python3:
>>> x = {"key": "value"}
>>> x.keys()
dict_keys(['key'])
```
