### PR TITLE
install xgboost so it can be imported

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -56,5 +56,5 @@ setup(name='xgboost',
       include_package_data=True,
       #!!! don't use data_files, otherwise install_data process will copy it to
       #root directory for some machines, and cause confusions on building
-      #data_files=[('xgboost', LIB_PATH)],
+      data_files=[('xgboost', LIB_PATH)],
       url='https://github.com/dmlc/xgboost')


### PR DESCRIPTION
**After installing xgboost on a docker container (Dockerfile below) importing xgboost into python does not work.**

To reproduce:
python
Python 2.7.6 (default, Jun 22 2015, 17:58:13) 
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import xgboost
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/xgboost-0.4-py2.7.egg/xgboost/__init__.py", line 11, in <module>
    from .core import DMatrix, Booster
  File "/usr/local/lib/python2.7/dist-packages/xgboost-0.4-py2.7.egg/xgboost/core.py", line 92, in <module>
    _LIB = _load_lib()
  File "/usr/local/lib/python2.7/dist-packages/xgboost-0.4-py2.7.egg/xgboost/core.py", line 83, in _load_lib
    lib_path = find_lib_path()
  File "/usr/local/lib/python2.7/dist-packages/xgboost-0.4-py2.7.egg/xgboost/libpath.py", line 43, in find_lib_path
    'List of candidates:\n' + ('\n'.join(dll_path)))
xgboost.libpath.XGBoostLibraryNotFound: Cannot find XGBoost Libarary in the candicate path, did you run build.sh in root path?
List of candidates:
/usr/local/lib/python2.7/dist-packages/xgboost-0.4-py2.7.egg/xgboost/libxgboostwrapper.so
/usr/local/lib/python2.7/dist-packages/xgboost-0.4-py2.7.egg/xgboost/../../wrapper/libxgboostwrapper.so
/usr/local/lib/python2.7/dist-packages/xgboost-0.4-py2.7.egg/xgboost/./wrapper/libxgboostwrapper.so

**This pull requests fixes this.**

The machine was installed like so:
FROM registry.spotify.net/spotify/trusty:0.19

RUN apt-get update && \
    apt-get install -y build-essential python-dev python-setuptools python-pip \
                       python-numpy python-scipy python-openssl \
                       python-sklearn wget git

RUN pip install simplejson httplib2 google-api-python-client pandas

RUN mkdir /xgboost && cd /xgboost && \
    git clone https://github.com/dmlc/xgboost.git && \
    cd xgboost && \
    ./build.sh && \
    cd python-package && python setup.py install

WORKDIR /app
COPY bin/retaining-features /usr/bin/retaining-features
COPY src src
COPY auth/bigquery_credentials.dat bigquery_credentials.dat

ENV PYTHONPATH /app/src/main/python
