### PR TITLE
fixes typo in error message

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -223,7 +223,7 @@ class DMatrix(object):
                 csr = scipy.sparse.csr_matrix(data)
                 self._init_from_csr(csr)
             except:
-                raise TypeError('can not intialize DMatrix from {}'.format(type(data).__name__))
+                raise TypeError('can not initialize DMatrix from {}'.format(type(data).__name__))
         if label is not None:
             self.set_label(label)
         if weight is not None:


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/7017045/10781321/626d4934-7d03-11e5-96d5-e501d19b3801.png)
![image](https://cloud.githubusercontent.com/assets/7017045/10781322/6c7e30dc-7d03-11e5-94cd-fb5a5a8cab16.png)

Changes "intialize" to "initialize" with an "i" between "in" and "t"