### PR TITLE
allow underscores in feature names (v2)

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -521,7 +521,7 @@ class DMatrix(object):
                 msg = 'feature_names must have the same length as data'
                 raise ValueError(msg)
             # prohibit to use symbols may affect to parse. e.g. ``[]=.``
-            if not all(isinstance(f, STRING_TYPES) and f.isalnum()
+            if not all(isinstance(f, STRING_TYPES) and f.replace('_', '').isalnum()
                        for f in feature_names):
                 raise ValueError('all feature_names must be alphanumerics')
         else:


### PR DESCRIPTION
Since https://github.com/dmlc/xgboost/commit/db490d1c7593e0c679194310d271fca745657b8f feature names with underscores like "VAR_01" are
prohibited. This patch allows underscores as special character in
feature names.