### PR TITLE
python: multiple eval_metrics changes

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -745,8 +745,13 @@ class Booster(object):
         else:
             res = '[%d]' % iteration
             for dmat, evname in evals:
-                name, val = feval(self.predict(dmat), dmat)
-                res += '\t%s-%s:%f' % (evname, name, val)
+                feval_ret = feval(self.predict(dmat), dmat)
+                if isinstance(feval_ret, list):
+                    for name, val in feval_ret:
+                        res += '\t%s-%s:%f' % (evname, name, val)
+                else:
+                    name, val = feval_ret
+                    res += '\t%s-%s:%f' % (evname, name, val)
             return res
 
     def eval(self, data, name='eval', iteration=0):

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -105,8 +105,9 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
         # is params a list of tuples? are we using multiple eval metrics?
         if isinstance(params, list):
             if len(params) != len(dict(params).items()):
-                raise ValueError('Check your params.'\
-                                     'Early stopping works with single eval metric only.')
+                pass
+                # raise ValueError('Check your params.'\
+                #                     'Early stopping works with single eval metric only.')
             params = dict(params)
 
         # either minimize loss or maximize AUC/MAP/NDCG


### PR DESCRIPTION
- Allows feval to return a list of tuples (name, error/score value)
- Changed behavior for multiple eval_metrics in conjunction with
early_stopping: Instead of raising an error, the last passed evel_metric
(or last entry in return value of feval) is used for early stopping