### PR TITLE
colsample non-deterministic behavior on a different machines fix

### DIFF
--- a/src/tree/updater.cpp
+++ b/src/tree/updater.cpp
@@ -15,6 +15,9 @@
 #endif
 
 namespace xgboost {
+std::mt19937 rng(0);
+std::uniform_int_distribution<> rdist(0,RAND_MAX);
+
 namespace tree {
 IUpdater* CreateUpdater(const char *name) {
   using namespace std;

--- a/src/utils/random.h
+++ b/src/utils/random.h
@@ -14,22 +14,30 @@
 #include <vector>
 #include <algorithm>
 #include "./utils.h"
+#include <random>
 
 /*! namespace of PRNG */
 namespace xgboost {
+extern std::mt19937 rng;
+extern std::uniform_int_distribution<> rdist;
+
 namespace random {
+
 #ifndef XGBOOST_CUSTOMIZE_PRNG_
 /*! \brief seed the PRNG */
 inline void Seed(unsigned seed) {
   srand(seed);
+  rng.seed(seed);
+  rdist.reset();
 }
+
 /*! \brief basic function, uniform */
 inline double Uniform(void) {
-  return static_cast<double>(rand()) / (static_cast<double>(RAND_MAX)+1.0); // NOLINT(*)
+  return static_cast<double>(rdist(rng)) / (static_cast<double>(RAND_MAX)+1.0); // NOLINT(*)
 }
 /*! \brief return a real numer uniform in (0,1) */
 inline double NextDouble2(void) {
-  return (static_cast<double>(rand()) + 1.0) / (static_cast<double>(RAND_MAX)+2.0); // NOLINT(*)
+  return (static_cast<double>(rdist(rng)) + 1.0) / (static_cast<double>(RAND_MAX)+2.0); // NOLINT(*)
 }
 /*! \brief return  x~N(0,1) */
 inline double Normal(void) {


### PR DESCRIPTION
C++ standard rand() was changed to mt19937 fixing this [problem](http://stackoverflow.com/questions/7115459/c-rand-and-srand-gets-different-output-on-different-machines) and this [issue](https://github.com/dmlc/xgboost/issues/310).

Problems: 
*  Only for C++11.
*  I'm not sure about calling functions and variables in the updater.cpp. 