### PR TITLE
fix pushd problem of pip building, convert README to rst for PyPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,8 +180,10 @@ pythonpack:
 	#make clean
 	cd subtree/rabit;make clean;cd ..
 	rm -rf xgboost-deploy xgboost*.tar.gz
+	#pip install pypandoc and also brew/apt-get install pandoc
+	python python-package/conv_rst.py
 	cp -r python-package xgboost-deploy
-	cp *.md xgboost-deploy/
+	#cp *.md xgboost-deploy/
 	cp LICENSE xgboost-deploy/
 	cp Makefile xgboost-deploy/xgboost
 	cp -r wrapper xgboost-deploy/xgboost
@@ -189,6 +191,7 @@ pythonpack:
 	cp -r multi-node xgboost-deploy/xgboost
 	cp -r windows xgboost-deploy/xgboost
 	cp -r src xgboost-deploy/xgboost
+	cp python-package/setup_pip.py xgboost-deploy/setup.py
 	#make python
 
 pythonbuild:

--- a/python-package/MANIFEST.in
+++ b/python-package/MANIFEST.in
@@ -1,4 +1,4 @@
-include *.sh *.md
+include *.sh *.md *.rst
 recursive-include xgboost *
 recursive-include xgboost/wrapper *
 recursive-include xgboost/windows *

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -1,0 +1,56 @@
+XGBoost Python Package
+======================
+
+|PyPI version| |PyPI downloads|
+
+Installation
+------------
+
+We are on `PyPI <https://pypi.python.org/pypi/xgboost>`__ now. For
+stable version, please install using pip:
+
+-  ``pip install xgboost``
+-  Note for windows users: this pip installation may not work on some
+   windows environment, and it may cause unexpected errors. pip
+   installation on windows is currently disabled for further
+   invesigation, please install from github.
+
+For up-to-date version, please install from github.
+
+-  To make the python module, type ``./build.sh`` in the root directory
+   of project
+-  Make sure you have
+   `setuptools <https://pypi.python.org/pypi/setuptools>`__
+-  Install with ``python setup.py install`` from this directory.
+-  For windows users, please use the Visual Studio project file under
+   `windows folder <../windows/>`__. See also the `installation
+   tutorial <https://www.kaggle.com/c/otto-group-product-classification-challenge/forums/t/13043/run-xgboost-from-windows-and-python>`__
+   from Kaggle Otto Forum.
+
+Examples
+--------
+
+-  Refer also to the walk through example in `demo
+   folder <../demo/guide-python>`__
+-  See also the `example scripts <../demo/kaggle-higgs>`__ for Kaggle
+   Higgs Challenge, including `speedtest
+   script <../demo/kaggle-higgs/speedtest.py>`__ on this dataset.
+
+Note
+----
+
+-  If you want to build xgboost on Mac OS X with multiprocessing support
+   where clang in XCode by default doesn't support, please install gcc
+   4.9 or higher using `homebrew <http://brew.sh/>`__
+   ``brew tap homebrew/versions; brew install gcc49``
+-  If you want to run XGBoost process in parallel using the fork backend
+   for joblib/multiprocessing, you must build XGBoost without support
+   for OpenMP by ``make no_omp=1``. Otherwise, use the forkserver (in
+   Python 3.4) or spawn backend. See the
+   `sklearn\_parallel.py <../demo/guide-python/sklearn_parallel.py>`__
+   demo.
+
+.. |PyPI version| image:: https://badge.fury.io/py/xgboost.svg
+   :target: http://badge.fury.io/py/xgboost
+.. |PyPI downloads| image:: https://img.shields.io/pypi/dm/xgboost.svg
+   :target: https://pypi.python.org/pypi/xgboost/

--- a/python-package/build_trouble_shooting.md
+++ b/python-package/build_trouble_shooting.md
@@ -20,6 +20,7 @@ Linux platform (also Mac OS X in general)
 
 * installed C++ compilers, for example `g++` and `gcc` (Linux) or `clang LLVM` (Mac OS X). Recommended compilers are `g++-5` or newer (Linux and Mac), or `clang` comes with Xcode in Mac OS X. For installting compilers, please refer to your system package management commands, e.g. `apt-get` `yum` or `brew`(Mac).
 * compilers in your `$PATH`. Try typing `gcc` and see if your have it in your path.
+* Do you use other shells than `bash` and install from `pip`? In some old version of pip installation, the shell script used `pushd` for changing directory and triggering the build process, which may failed some shells without `pushd` command. Please update to the latest version by removing the old installation and redo `pip install xgboost`
 
 **Trouble 1**: I see the same error message in **Trouble 0** when install from `pip install xgboost`.
 

--- a/python-package/conv_rst.py
+++ b/python-package/conv_rst.py
@@ -1,0 +1,6 @@
+# pylint: disable=invalid-name, exec-used
+"""Convert README.md to README.rst for PyPI"""
+from pypandoc import convert
+read_md = convert('python-package/README.md', 'rst')
+with open('python-package/README.rst', 'w') as rst_file:
+    rst_file.write(read_md)

--- a/python-package/setup.cfg
+++ b/python-package/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description-file = README.rst

--- a/python-package/setup_pip.py
+++ b/python-package/setup_pip.py
@@ -34,8 +34,8 @@ LIB_PATH = libpath['find_lib_path']()
 #and be sure to test it firstly using "python setup.py register sdist upload -r pypitest"
 setup(name='xgboost',
       #version=open(os.path.join(CURRENT_DIR, 'xgboost/VERSION')).read().strip(),
-      version='0.4a24',
-      description=open(os.path.join(CURRENT_DIR, 'README.md')).read(),
+      version='0.4a28',
+      description=open(os.path.join(CURRENT_DIR, 'README.rst')).read(),
       install_requires=[
           'numpy',
           'scipy',

--- a/python-package/xgboost/build-python.sh
+++ b/python-package/xgboost/build-python.sh
@@ -10,7 +10,9 @@
 #       conflict with build.sh which is for everything. 
 
 
-pushd xgboost
+#pushd xgboost
+oldpath=`pwd`
+cd ./xgboost/
 #remove the pre-compiled .so and trigger the system's on-the-fly compiling
 make clean
 if make python; then
@@ -25,4 +27,4 @@ else
     echo "If you want multi-threaded version"
     echo "See additional instructions in doc/build.md"
 fi
-popd
+cd $oldpath


### PR DESCRIPTION
Fixed `pushd` problem in `build_python.sh`: on some machines not using bash or compatible shells, the old build script may fail secretly on `pushd` command which causes some pip installation issue.
Added `conv_rst.py` for converting README.md to README.rst: PyPI doesn't accept markdown so the PyPI `xgboost` page was so messed up. The pip maintainer should use makefile for triggering `conv_rst.py` in `pythonpack` section for generating `README.rst` on the fly. It needs pypandoc on pip maintainer's machine (`pip install pypandoc`, also commented in Makefile)