### PR TITLE
Cleanup pandas support

### DIFF
--- a/python-package/conv_rst.py
+++ b/python-package/conv_rst.py
@@ -1,6 +1,8 @@
 # pylint: disable=invalid-name, exec-used
 """Convert README.md to README.rst for PyPI"""
+
 from pypandoc import convert
+
 read_md = convert('python-package/README.md', 'rst')
 with open('python-package/README.rst', 'w') as rst_file:
     rst_file.write(read_md)

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+# pylint: disable=unused-import, invalid-name
+"""For compatibility"""
+
+from __future__ import absolute_import
+
+import sys
+
+
+PY3 = (sys.version_info[0] == 3)
+
+if PY3:
+    # pylint: disable=invalid-name, redefined-builtin
+    STRING_TYPES = str,
+else:
+    # pylint: disable=invalid-name
+    STRING_TYPES = basestring,
+
+# pandas
+try:
+    from pandas import DataFrame
+    PANDAS_INSTALLED = True
+except ImportError:
+
+    class DataFrame(object):
+        """ dummy for pandas.DataFrame """
+        pass
+
+    PANDAS_INSTALLED = False
+
+# sklearn
+try:
+    from sklearn.base import BaseEstimator
+    from sklearn.base import RegressorMixin, ClassifierMixin
+    from sklearn.preprocessing import LabelEncoder
+    SKLEARN_INSTALLED = True
+
+    XGBModelBase = BaseEstimator
+    XGBRegressorBase = RegressorMixin
+    XGBClassifierBase = ClassifierMixin
+except ImportError:
+    SKLEARN_INSTALLED = False
+
+    # used for compatiblity without sklearn
+    XGBModelBase = object
+    XGBClassifierBase = object
+    XGBRegressorBase = object

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -7,23 +7,9 @@ import numpy as np
 from .core import Booster, DMatrix, XGBoostError
 from .training import train
 
-try:
-    from sklearn.base import BaseEstimator
-    from sklearn.base import RegressorMixin, ClassifierMixin
-    from sklearn.preprocessing import LabelEncoder
-    SKLEARN_INSTALLED = True
-except ImportError:
-    SKLEARN_INSTALLED = False
+from .compat import (SKLEARN_INSTALLED, XGBModelBase,
+                     XGBClassifierBase, XGBRegressorBase, LabelEncoder)
 
-# used for compatiblity without sklearn
-XGBModelBase = object
-XGBClassifierBase = object
-XGBRegressorBase = object
-
-if SKLEARN_INSTALLED:
-    XGBModelBase = BaseEstimator
-    XGBRegressorBase = RegressorMixin
-    XGBClassifierBase = ClassifierMixin
 
 class XGBModel(XGBModelBase):
     # pylint: disable=too-many-arguments, too-many-instance-attributes, invalid-name


### PR DESCRIPTION
Follow-up for #597. We should handle ``data`` and ``label`` separately, because ``data`` can be other than ``DataFrame`` but ``label`` is.