### PR TITLE
Fix bug with name of sleep function

### DIFF
--- a/subtree/rabit/src/allreduce_base.cc
+++ b/subtree/rabit/src/allreduce_base.cc
@@ -200,7 +200,7 @@ utils::TCPSocket AllreduceBase::ConnectTracker(void) const {
         utils::Socket::Error("Connect");
       } else {
         fprintf(stderr, "retry connect to ip(retry time %d): [%s]\n", retry, tracker_uri.c_str());
-        sleep(1);
+        Sleep(1);
         continue;
       }
     }


### PR DESCRIPTION
In Windows the name of "sleep" function should start with uppercase letter