### PR TITLE
modifying cv show_progress to allow print-every-n behavior

### DIFF
--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -283,8 +283,7 @@ def mknfold(dall, nfold, param, seed, evals=(), fpreproc=None):
         ret.append(CVPack(dtrain, dtest, plst))
     return ret
 
-
-def aggcv(rlist, show_stdv=True, show_progress=None, as_pandas=True):
+def aggcv(rlist, show_stdv=True, show_progress=None, as_pandas=True, trial=None):
     # pylint: disable=invalid-name
     """
     Aggregate cross-validation results.
@@ -336,8 +335,9 @@ def aggcv(rlist, show_stdv=True, show_progress=None, as_pandas=True):
         if show_progress is None:
             show_progress = True
 
-    if show_progress:
+    if (isinstance(show_progress, int) and trial % show_progress == 0) or (isinstance(show_progress, bool) and show_progress):
         sys.stderr.write(msg + '\n')
+        sys.stderr.flush()
 
     return results
 
@@ -418,7 +418,7 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, metrics=(),
             fold.update(i, obj)
         res = aggcv([f.eval(i, feval) for f in cvfolds],
                     show_stdv=show_stdv, show_progress=show_progress,
-                    as_pandas=as_pandas)
+                    as_pandas=as_pandas, trial=i)
         results.append(res)
 
         if early_stopping_rounds is not None:

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -283,10 +283,14 @@ def mknfold(dall, nfold, param, seed, evals=(), fpreproc=None):
         ret.append(CVPack(dtrain, dtest, plst))
     return ret
 
-def aggcv(rlist, show_stdv=True, show_progress=None, as_pandas=True, trial=None):
+def aggcv(rlist, show_stdv=True, show_progress=None, as_pandas=True, trial=0):
     # pylint: disable=invalid-name
     """
     Aggregate cross-validation results.
+    
+    If show_progress is true, progress is displayed in every call. If
+    show_progress is an integer, progress will only be displayed every
+    `show_progress` trees, tracked via trial.
     """
     cvmap = {}
     idx = rlist[0].split()[0]
@@ -319,8 +323,6 @@ def aggcv(rlist, show_stdv=True, show_progress=None, as_pandas=True, trial=None)
 
         index.extend([k + '-mean', k + '-std'])
         results.extend([mean, std])
-
-
 
     if as_pandas:
         try:
@@ -376,9 +378,11 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, metrics=(),
     as_pandas : bool, default True
         Return pd.DataFrame when pandas is installed.
         If False or pandas is not installed, return np.ndarray
-    show_progress : bool or None, default None
+    show_progress : bool, int, or None, default None
         Whether to display the progress. If None, progress will be displayed
-        when np.ndarray is returned.
+        when np.ndarray is returned. If True, progress will be displayed at 
+        boosting stage. If an integer is given, progress will be displayed 
+        is printed at every given `show_progress` boosting stage. 
     show_stdv : bool, default True
         Whether to display the standard deviation in progress.
         Results are not affected, and always contains std.

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -382,7 +382,7 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, metrics=(),
         Whether to display the progress. If None, progress will be displayed
         when np.ndarray is returned. If True, progress will be displayed at 
         boosting stage. If an integer is given, progress will be displayed 
-        is printed at every given `show_progress` boosting stage. 
+        at every given `show_progress` boosting stage. 
     show_stdv : bool, default True
         Whether to display the standard deviation in progress.
         Results are not affected, and always contains std.


### PR DESCRIPTION
This change allows you to set `cv()`'s `show_progress` to an integer n to print progress every n trees instead of for each tree, similar to the behavior of `train()`'s `verbose_eval` behavior.