### PR TITLE
minor latex typo fix in "Introduction to Boosted Tree's" documentation

### DIFF
--- a/doc/model.md
+++ b/doc/model.md
@@ -188,7 +188,7 @@ By defining it formally, we can get a better idea of what we are learning, and y
 Here is the magical part of the derivation. After reformalizing the tree model, we can write the objective value with the ``$ t$``-th tree as:
 
 ```math
-Obj^{(t)} &\approx \sum_{i=1}^n [g_i w_q(x_i) + \frac{1}{2} h_i w_{q(x_i)}^2] + \gamma T + \frac{1}{2}\lambda \sum_{j=1}^T w_j^2\\
+Obj^{(t)} &\approx \sum_{i=1}^n [g_i w_{q(x_i)} + \frac{1}{2} h_i w_{q(x_i)}^2] + \gamma T + \frac{1}{2}\lambda \sum_{j=1}^T w_j^2\\
 &= \sum^T_{j=1} [(\sum_{i\in I_j} g_i) w_j + \frac{1}{2} (\sum_{i\in I_j} h_i + \lambda) w_j^2 ] + \gamma T
 ```
 


### PR DESCRIPTION
Fixes a latex typo in the derivation of the objective function