### PR TITLE
support auc evaluation when the dataset only contains pos or neg samples

### DIFF
--- a/src/learner/evaluation-inl.hpp
+++ b/src/learner/evaluation-inl.hpp
@@ -391,7 +391,7 @@ struct EvalAuc : public IEvaluator {
       #pragma omp for schedule(static)
       for (bst_omp_uint k = 0; k < ngroup; ++k) {
         rec.clear();
-        // add a dummy positive record and a dummy negative record, 
+        // add a dummy positive record and a dummy negative record,
         // in case that the dataset only contains pos or neg samples
         rec.push_back(std::make_pair(0.0, UINT_MAX));
         rec.push_back(std::make_pair(1.0, UINT_MAX));
@@ -408,7 +408,7 @@ struct EvalAuc : public IEvaluator {
             // for dummy samples
             wt = 1.0;
             ctr = rec[j].first;
-          } else { 
+          } else {
             // for real samples
             wt = info.GetWeight(rec[j].second);
             ctr = info.labels[rec[j].second];


### PR DESCRIPTION
If running xgboost on yarn, sometimes  an execption with the message "dataset only contains pos or neg samples" will be threw during auc evaluating. That is because, when running xgboost on yarn, sample data will be split into multipile small splits for workers, some small splits may only contains pos or neg samples actually. 
For example, if the sample data is as follows:
```
0.0  1:0 2:1
0.0  0:0 2:1
1.0  1:0 2:0
1.0  1:0 2:0
```
if running xgboost on yarn with 2 workers, the data will be split into two splits like this:
```
0.0  1:0 2:1
0.0  0:0 2:1
```
```
1.0  1:0 2:0
1.0  1:0 2:0
```

to avoid throwing an error, add a pos sample and a neg sample respectively, and it will have little impact on the auc evaluation