### PR TITLE
Fixed off by 1 bug in early.stop.rounds in xgb.cv

### DIFF
--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -191,7 +191,7 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
 
         # early_Stopping
         if (!is.null(early.stop.round)){
-            score <- strsplit(ret,'\\s+')[[1]][1 + length(metrics) + 2]
+            score <- strsplit(ret,'\\s+')[[1]][2 + length(metrics)]
             score <- strsplit(score,'\\+|:')[[1]][[2]]
             score <- as.numeric(score)
             if ( (maximize && score > bestScore) || (!maximize && score < bestScore)) {


### PR DESCRIPTION
early.stop.rounds had an off by 1 bug in xgb.cv. This was causing one of two undesirable behaviors:

1) If only one metric is specified, the test metric is not accessible and runs off the end of the vector
2) If multiple metrics are specified, the wrong metric is used for stopping early