### PR TITLE
fix signature of __deepcopy__ method

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -643,7 +643,7 @@ class Booster(object):
     def __copy__(self):
         return self.__deepcopy__()
 
-    def __deepcopy__(self):
+    def __deepcopy__(self, memo):
         return Booster(model_file=self.save_raw())
 
     def copy(self):

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -641,7 +641,7 @@ class Booster(object):
         self.set_param({'seed': 0})
 
     def __copy__(self):
-        return self.__deepcopy__()
+        return self.__deepcopy__(None)
 
     def __deepcopy__(self, memo):
         return Booster(model_file=self.save_raw())


### PR DESCRIPTION
fix issue#751 https://github.com/dmlc/xgboost/issues/751.
the memo argument seems not to be used in the following code, i suggest it renamed to a single '_'