### PR TITLE
fix cran, update R-package version to 0.4-3

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: xgboost
 Type: Package
 Title: Extreme Gradient Boosting
-Version: 0.4-2
+Version: 0.4-3
 Date: 2015-08-01
 Author: Tianqi Chen <tianqi.tchen@gmail.com>, Tong He <hetong007@gmail.com>,
     Michael Benesty <michael@benesty.fr>

--- a/R-package/src/xgboost_R.h
+++ b/R-package/src/xgboost_R.h
@@ -7,11 +7,11 @@
 #ifndef XGBOOST_R_H_ // NOLINT(*)
 #define XGBOOST_R_H_ // NOLINT(*)
 
-extern "C" {
+
 #include <Rinternals.h>
 #include <R_ext/Random.h>
 #include <Rmath.h>
-}
+
 #include <xgboost/c_api.h>
 
 /*!


### PR DESCRIPTION
The package on CRAN is just updated to 0.4-3 due to a minor bug. This PR brings the fix to the github version. 