### PR TITLE
Plugging in gp_xgboost_gridsearch

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -116,6 +116,7 @@ Send a PR to add a one sentence description:)
 ## Tools using XGBoost
 
 - [BayesBoost](https://github.com/mpearmain/BayesBoost) - Bayesian Optimization using xgboost and sklearn API
+- [gp_xgboost_gridsearch](https://github.com/vatsan/gp_xgboost_gridsearch) - In-database parallel grid-search for XGBoost on [Greenplum](https://github.com/greenplum-db/gpdb) using PL/Python 
 
 ## Awards
 - [John Chambers Award](http://stat-computing.org/awards/jmc/winners.html) - 2016 Winner: XGBoost R Package, by Tong He (Simon Fraser University) and Tianqi Chen (University of Washington)


### PR DESCRIPTION
In-database parallel gridsearch for XGBoost on Greenplum (open-source MPP database based on Postgres) using PL/Python.