### PR TITLE
R: fix "bestInd" and add "best_ntreelimit" to xgb.Booster

### DIFF
--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -196,9 +196,9 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
             score <- as.numeric(score)
             if ( (maximize && score > bestScore) || (!maximize && score < bestScore)) {
                 bestScore <- score
-                bestInd <- i
+                bestInd <- i - 1
             } else {
-                if (i - bestInd >= early.stop.round) {
+                if (i - bestInd > early.stop.round) {
                     earlyStopflag <- TRUE
                     cat('Stopping. Best iteration:', bestInd, '\n')
                     break
@@ -211,7 +211,7 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
         for (k in 1:nfold) {
             fd <- xgb_folds[[k]]
             if (!is.null(early.stop.round) && earlyStopflag) {
-              res <- xgb.iter.eval(fd$booster, fd$watchlist, bestInd - 1, feval, prediction)
+              res <- xgb.iter.eval(fd$booster, fd$watchlist, bestInd, feval, prediction)
             } else {
               res <- xgb.iter.eval(fd$booster, fd$watchlist, nrounds - 1, feval, prediction)
             }

--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -208,10 +208,10 @@ xgb.train <- function(params=list(), data, nrounds, watchlist = list(),
         score <- as.numeric(score)
         if ( (maximize && score > bestScore) || (!maximize && score < bestScore)) {
           bestScore <- score
-          bestInd <- i
+          bestInd <- i - 1
         } else {
           earlyStopflag = TRUE
-          if (i - bestInd >= early.stop.round) {
+          if (i - bestInd > early.stop.round) {
             cat('Stopping. Best iteration:', bestInd, '\n')
             break
           }
@@ -229,6 +229,11 @@ xgb.train <- function(params=list(), data, nrounds, watchlist = list(),
   if (!is.null(early.stop.round)) {
     bst$bestScore <- bestScore
     bst$bestInd <- bestInd
+    if (!is.null(params$num_parallel_tree)) {
+      bst$best_ntreelimit <- (bst$bestInd + 1) * params$num_parallel_tree
+    } else {
+      bst$best_ntreelimit <- bst$bestInd + 1    
+    }
   }
 
   attr(bst, "call") <- fit.call


### PR DESCRIPTION
Added *best_ntreelimit* attribute to *xgb.Booster* if early stopped.

Currently, *xgb.Booster$bestInd* returns the next value of the index of the best iteration specified in the eval message created by booster. This is inconsistent with the implementation in python package.
