### PR TITLE
[jvm-packages] change the API name 

### DIFF
--- a/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/flink/DistTrainWithFlink.scala
+++ b/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/flink/DistTrainWithFlink.scala
@@ -25,6 +25,7 @@ object DistTrainWithFlink {
     // read trainining data
     val trainData =
       MLUtils.readLibSVM(env, "/path/to/data/agaricus.txt.train")
+    val testData = MLUtils.readLibSVM(env, "/path/to/data/agaricus.txt.test")
     // define parameters
     val paramMap = List(
       "eta" -> 0.1,
@@ -34,7 +35,7 @@ object DistTrainWithFlink {
     val round = 2
     // train the model
     val model = XGBoost.train(paramMap, trainData, round)
-    val predTrain = model.predict(trainData.map{x => x.vector})
-    model.saveModelToHadoop("file:///path/to/xgboost.model")
+    val predTest = model.predict(testData.map{x => x.vector})
+    model.saveModelAsHadoopFile("file:///path/to/xgboost.model")
   }
 }

--- a/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/spark/DistTrainWithSpark.scala
+++ b/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/spark/DistTrainWithSpark.scala
@@ -40,6 +40,6 @@ object DistTrainWithSpark {
       "objective" -> "binary:logistic").toMap
     val xgboostModel = XGBoost.train(trainRDD, paramMap, numRound)
     // save model to HDFS path
-    xgboostModel.saveModelToHadoop(outputModelPath)
+    xgboostModel.saveModelAsHadoopFile(outputModelPath)
   }
 }

--- a/jvm-packages/xgboost4j-flink/src/main/scala/ml/dmlc/xgboost4j/scala/flink/XGBoost.scala
+++ b/jvm-packages/xgboost4j-flink/src/main/scala/ml/dmlc/xgboost4j/scala/flink/XGBoost.scala
@@ -70,7 +70,7 @@ object XGBoost {
     * @param modelPath The path that is accessible by hadoop filesystem API.
     * @return The loaded model
     */
-  def loadModelFromHadoop(modelPath: String) : XGBoostModel = {
+  def loadModelFromHadoopFile(modelPath: String) : XGBoostModel = {
     new XGBoostModel(
       XGBoostScala.loadModel(
         FileSystem

--- a/jvm-packages/xgboost4j-flink/src/main/scala/ml/dmlc/xgboost4j/scala/flink/XGBoostModel.scala
+++ b/jvm-packages/xgboost4j-flink/src/main/scala/ml/dmlc/xgboost4j/scala/flink/XGBoostModel.scala
@@ -31,7 +31,7 @@ class XGBoostModel (booster: Booster) extends Serializable {
     *
     * @param modelPath The model path as in Hadoop path.
     */
-  def saveModelToHadoop(modelPath: String): Unit = {
+  def saveModelAsHadoopFile(modelPath: String): Unit = {
     booster.saveModel(FileSystem
       .get(new Configuration)
       .create(new Path(modelPath)))

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -128,7 +128,8 @@ object XGBoost extends Serializable {
    * @param modelPath The path of the file representing the model
    * @return The loaded model
    */
-  def loadModelFromHadoop(modelPath: String)(implicit sparkContext: SparkContext): XGBoostModel = {
+  def loadModelFromHadoopFile(modelPath: String)(implicit sparkContext: SparkContext):
+      XGBoostModel = {
     val path = new Path(modelPath)
     val dataInStream = path.getFileSystem(sparkContext.hadoopConfiguration).open(path)
     val xgBoostModel = new XGBoostModel(SXGBoost.loadModel(dataInStream))

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
@@ -49,7 +49,7 @@ class XGBoostModel(booster: Booster)(implicit val sc: SparkContext) extends Seri
    *
    * @param modelPath The model path as in Hadoop path.
    */
-  def saveModelToHadoop(modelPath: String): Unit = {
+  def saveModelToHadoopFile(modelPath: String): Unit = {
     val path = new Path(modelPath)
     val outputStream = path.getFileSystem(sc.hadoopConfiguration).create(path)
     booster.saveModel(outputStream)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
@@ -49,7 +49,7 @@ class XGBoostModel(booster: Booster)(implicit val sc: SparkContext) extends Seri
    *
    * @param modelPath The model path as in Hadoop path.
    */
-  def saveModelToHadoopFile(modelPath: String): Unit = {
+  def saveModelAsHadoopFile(modelPath: String): Unit = {
     val path = new Path(modelPath)
     val outputStream = path.getFileSystem(sc.hadoopConfiguration).create(path)
     booster.saveModel(outputStream)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostSuite.scala
@@ -150,8 +150,8 @@ class XGBoostSuite extends FunSuite with BeforeAndAfter {
       "objective" -> "binary:logistic").toMap
     val xgBoostModel = XGBoost.train(trainingRDD, paramMap, 5)
     assert(eval.eval(xgBoostModel.predict(testSetDMatrix), testSetDMatrix) < 0.1)
-    xgBoostModel.saveModelToHadoop(tempFile.toFile.getAbsolutePath)
-    val loadedXGBooostModel = XGBoost.loadModelFromHadoop(tempFile.toFile.getAbsolutePath)
+    xgBoostModel.saveModelAsHadoopFile(tempFile.toFile.getAbsolutePath)
+    val loadedXGBooostModel = XGBoost.loadModelFromHadoopFile(tempFile.toFile.getAbsolutePath)
     val predicts = loadedXGBooostModel.predict(testSetDMatrix)
     assert(eval.eval(predicts, testSetDMatrix) < 0.1)
   }


### PR DESCRIPTION
Due to the changes in https://github.com/dmlc/xgboost/pull/965

I feel that we need to change the API name to reflect that we are supporting hadoop-compatible files instead of just HDFS/local file system, 

I prefer to keep consistent with spark's api http://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.rdd.PairRDDFunctions

i.e. saveAs.... 