### PR TITLE
change type of xgbclassifier.classes_ from list to numpy array

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -363,7 +363,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             metric measured on the validation set to stderr.
         """
         evals_result = {}
-        self.classes_ = list(np.unique(y))
+        self.classes_ = np.unique(y)
         self.n_classes_ = len(self.classes_)
 
 


### PR DESCRIPTION
Field classes_ in xgbclassifier has to have numpy array type for some sklearn procedures. For example I got error while using sklearn.ensemble.AdaBoostClassifier because classes_ had list type rather then numpy array.