### PR TITLE
XGBoosterCreate api unified to use const DMatrixHandle[] argument

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -266,7 +266,7 @@ XGB_DLL int XGDMatrixNumCol(DMatrixHandle handle,
  * \param out handle to the result booster
  * \return 0 when success, -1 when failure happens
  */
-XGB_DLL int XGBoosterCreate(void* dmats[],
+XGB_DLL int XGBoosterCreate(const DMatrixHandle dmats[],
                             bst_ulong len,
                             BoosterHandle *out);
 /*!

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -463,7 +463,7 @@ int XGDMatrixNumCol(const DMatrixHandle handle,
 }
 
 // xgboost implementation
-int XGBoosterCreate(DMatrixHandle dmats[],
+int XGBoosterCreate(const DMatrixHandle dmats[],
                     bst_ulong len,
                     BoosterHandle *out) {
   API_BEGIN();


### PR DESCRIPTION
first, there's a mismatch between declaration and definition (`void *` in the header), secondly, `DMatrixHandle` array can be `const`.