### PR TITLE
Updated obsolete installation instructions

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -28,13 +28,40 @@ install.packages("xgboost", repos="http://dmlc.ml/drat/", type="source")
 
 ***Important*** Due to the usage of submodule, `install_github` is no longer support to install the
 latest version of R package. 
-For up-to-date version, please install from github. Windows user will need to install [RTools](http://cran.r-project.org/bin/windows/Rtools/) first.
+For up-to-date version, please install from github.
+
+Windows users will need to install [RTools](http://cran.r-project.org/bin/windows/Rtools/) first. They also need to download [MinGW-W64](http://iweb.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/installer/mingw-w64-install.exe) using x86_64 architecture during installation.
+
+Run the following command to add MinGW to PATH in Windows if not already added.
+
+```cmd
+PATH %PATH%;C:\Program Files\mingw-w64\x86_64-5.3.0-posix-seh-rt_v4-rev0\mingw64\bin
+```
+
+To compile xgboost at the root of your storage, run the following bash script.
 
 ```bash
 git clone --recursive https://github.com/dmlc/xgboost
 cd xgboost
-make Rbuild
-R CMD INSTALL xgboost_0.4-3.tar.gz
+git submodule init
+git submodule update
+alias make='mingw32-make'
+cd dmlc-core
+make -j4
+cd ../rabit
+make lib/librabit_empty.a -j4
+cd ..
+cp make/mingw64.mk config.mk
+make -j4
+```
+
+Run the following R script to install xgboost package from the root directory.
+
+```r
+install.package('devtools') # if not installed
+setwd('C:/xgboost/')
+library(devtools)
+install('R-package')
 ```
 
 For more detailed installation instructions, please see [here](http://xgboost.readthedocs.org/en/latest/build.html#r-package-installation).

--- a/doc/build.md
+++ b/doc/build.md
@@ -154,6 +154,13 @@ There are several ways to install the package:
     cd python-package; python setup.py develop --user
     ```
 
+4. If you are installing the latest xgboost version which require compilation, add MinGW to the system PATH:
+
+    ```python
+    import os
+    os.environ['PATH'] = os.environ['PATH'] + ';C:\\Program Files\\mingw-w64\\x86_64-5.3.0-posix-seh-rt_v4-rev0\\mingw64\\bin'
+    ```
+
 ## R Package Installation
 
 You can install R package from cran just like other packages, or you can install from our weekly updated drat repo:
@@ -162,8 +169,9 @@ You can install R package from cran just like other packages, or you can install
 install.packages("drat", repos="https://cran.rstudio.com")
 drat:::addRepo("dmlc")
 install.packages("xgboost", repos="http://dmlc.ml/drat/", type = "source")
-
 ```
+
+If you would like to use the latest xgboost version and already compiled xgboost, use `library(devtools); install('xgboost/R-package')` to install manually xgboost package (change the path accordingly to where you compiled xgboost).
 
 For OSX users, single threaded version will be installed, to install multi-threaded version.
 First follow [Building on OSX](#building-on-osx) to get the OpenMP enabled compiler, then:
@@ -181,13 +189,21 @@ First follow [Building on OSX](#building-on-osx) to get the OpenMP enabled compi
   ```
 
 Due to the usage of submodule, `install_github` is no longer support to install the
-latest version of R package. To install the latest version,
+latest version of R package. To install the latest version run the following bash script,
 
 ```bash
 git clone --recursive https://github.com/dmlc/xgboost
 cd xgboost
-make Rbuild
-R CMD INSTALL xgboost_0.4-3.tar.gz
+git submodule init
+git submodule update
+alias make='mingw32-make'
+cd dmlc-core
+make -j4
+cd ../rabit
+make lib/librabit_empty.a -j4
+cd ..
+cp make/mingw64.mk config.mk
+make -j4
 ```
 
 ## Trouble Shooting

--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -26,6 +26,12 @@ For up-to-date version, please install from github.
    `windows folder <../windows/>`__. See also the `installation
    tutorial <https://www.kaggle.com/c/otto-group-product-classification-challenge/forums/t/13043/run-xgboost-from-windows-and-python>`__
    from Kaggle Otto Forum.
+-  Add MinGW to the system PATH in Windows if you are using the latest version of xgboost which requires compilation:
+
+    ```python
+    import os
+    os.environ['PATH'] = os.environ['PATH'] + ';C:\\Program Files\\mingw-w64\\x86_64-5.3.0-posix-seh-rt_v4-rev0\\mingw64\\bin'
+    ```
 
 Examples
 --------


### PR DESCRIPTION
Fixed local compilation, and installation for R package and Python package. Modified the according documents.

Used JeanFrancoisPuget's instructions (https://www.ibm.com/developerworks/community/blogs/jfp/entry/Installing_XGBoost_For_Anaconda_on_Windows?lang=en) and my own local try at compiling xgboost and installing the R package using devtools.