### PR TITLE
Added other feature importances in python package

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1024,7 +1024,7 @@ class Booster(object):
            The name of feature map file
         """
 
-        return get_score(fmap, importance_type='weight')
+        return self.get_score(fmap, importance_type='weight')
 
     def get_score(self, fmap='', importance_type='weight'):
         """Get feature importance of each feature.

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -153,6 +153,7 @@ def _maybe_pandas_data(data, feature_names, feature_types):
         msg = """DataFrame.dtypes for data must be int, float or bool.
 Did not expect the data types in fields """
         raise ValueError(msg + ', '.join(bad_fields))
+        
     if feature_names is None:
         feature_names = data.columns.format()
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -153,7 +153,7 @@ def _maybe_pandas_data(data, feature_names, feature_types):
         msg = """DataFrame.dtypes for data must be int, float or bool.
 Did not expect the data types in fields """
         raise ValueError(msg + ', '.join(bad_fields))
-        
+
     if feature_names is None:
         feature_names = data.columns.format()
 
@@ -1040,14 +1040,14 @@ class Booster(object):
            The name of feature map file
         """
 
-        if importance_type not in ['weight','gain','cover']:
+        if importance_type not in ['weight', 'gain', 'cover']:
             msg = "importance_type mismatch, got '{}', expected 'weight', 'gain', or 'cover'"
             raise ValueError(msg.format(importance_type))
 
         # if it's weight, then omap stores the number of missing values
         if importance_type == 'weight':
             # do a simpler tree dump to save time
-            trees = self.get_dump(fmap,with_stats=False)
+            trees = self.get_dump(fmap, with_stats=False)
 
             fmap = {}
             for tree in trees:
@@ -1061,7 +1061,8 @@ class Booster(object):
                     # extract feature name from string between []
                     fid = arr[1].split(']')[0].split('<')[0]
 
-                    if fid not in fmap: # if the feature hasn't been seen yet
+                    if fid not in fmap:
+                        # if the feature hasn't been seen yet
                         fmap[fid] = 1
                     else:
                         fmap[fid] += 1
@@ -1069,7 +1070,7 @@ class Booster(object):
             return fmap
 
         else:
-            trees = self.get_dump(fmap,with_stats=True)
+            trees = self.get_dump(fmap, with_stats=True)
 
             importance_type += '='
             fmap = {}
@@ -1091,7 +1092,8 @@ class Booster(object):
                     # extract feature name from string before closing bracket
                     fid = fid[0].split('<')[0]
 
-                    if fid not in fmap: # if the feature hasn't been seen yet
+                    if fid not in fmap:
+                        # if the feature hasn't been seen yet
                         fmap[fid] = 1
                         gmap[fid] = g
                     else:

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -14,7 +14,7 @@ from .sklearn import XGBModel
 def plot_importance(booster, ax=None, height=0.2,
                     xlim=None, ylim=None, title='Feature importance',
                     xlabel='F score', ylabel='Features',
-                    importance_type='gain',
+                    importance_type='weight',
                     grid=True, **kwargs):
 
     """Plot importance based on fitted trees.

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -66,7 +66,7 @@ def plot_importance(booster, ax=None, height=0.2,
         raise ValueError('tree must be Booster, XGBModel or dict instance')
 
     if len(importance) == 0:
-        raise ValueError('Booster.get_fscore() results in empty')
+        raise ValueError('Booster.get_score() results in empty')
 
     tuples = [(k, importance[k]) for k in importance]
     tuples = sorted(tuples, key=lambda x: x[1])

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -25,6 +25,12 @@ def plot_importance(booster, ax=None, height=0.2,
         Booster or XGBModel instance, or dict taken by Booster.get_fscore()
     ax : matplotlib Axes, default None
         Target axes instance. If None, new figure and axes will be created.
+    importance_type : str, default "weight"
+        How the importance is calculated: either "weight", "gain", or "cover"
+        "weight" is the number of times a feature appears in a tree
+        "gain" is the average gain of splits which use the feature
+        "cover" is the average coverage of splits which use the feature
+            where coverage is defined as the number of samples affected by the split
     height : float, default 0.2
         Bar height, passed to ax.barh()
     xlim : tuple, default None

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -14,6 +14,7 @@ from .sklearn import XGBModel
 def plot_importance(booster, ax=None, height=0.2,
                     xlim=None, ylim=None, title='Feature importance',
                     xlabel='F score', ylabel='Features',
+                    importance_type='gain',
                     grid=True, **kwargs):
 
     """Plot importance based on fitted trees.
@@ -50,9 +51,9 @@ def plot_importance(booster, ax=None, height=0.2,
         raise ImportError('You must install matplotlib to plot importance')
 
     if isinstance(booster, XGBModel):
-        importance = booster.booster().get_fscore()
+        importance = booster.booster().get_score(importance_type=importance_type)
     elif isinstance(booster, Booster):
-        importance = booster.get_fscore()
+        importance = booster.get_score(importance_type=importance_type)
     elif isinstance(booster, dict):
         importance = booster
     else:

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -109,6 +109,7 @@ class XGBModel(XGBModelBase):
     hess: array_like of shape [n_samples]
         The value of the second derivative for each sample point
     """
+
     def __init__(self, max_depth=3, learning_rate=0.1, n_estimators=100,
                  silent=True, objective="reg:linear",
                  nthread=-1, gamma=0, min_child_weight=1, max_delta_step=0,

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -150,7 +150,6 @@ class TestBasic(unittest.TestCase):
         assert len(scores3) == len(features)
         assert len(scores4) == len(features)
 
-
         # check backwards compatibility of get_fscore
         fscores = bst.get_fscore()
         assert scores1 == fscores


### PR DESCRIPTION
From what I could tell the python package only implemented feature importances using `get_fscore()` which returned the number of times a feature was used to split data (I called this "weight", it was called "weight" in the R package). I added a function to calculate the average gain/coverage called `get_score()` with input importance_type. I also added it to plotting.py so the user can plot gain/coverage with `plot_importance` and a unit test to make sure I didn't botch anything.