### PR TITLE
Fixes for repeated Configure calls

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -32,7 +32,16 @@ class Booster {
   }
 
   inline void SetParam(const std::string& name, const std::string& val) {
-    cfg_.push_back(std::make_pair(name, val));
+    auto it = std::find_if(cfg_.begin(), cfg_.end(),
+      [&name](decltype(*cfg_.begin()) &x) {
+        return x.first == name;
+      }
+    );
+    if (it == cfg_.end()) {
+      cfg_.push_back(std::make_pair(name, val));
+    } else {
+      (*it).second = val;
+    }
     if (configured_) {
       learner_->Configure(cfg_);
     }
@@ -277,7 +286,7 @@ int XGDMatrixCreateFromCSC(const bst_ulong* col_ptr,
                    RowBatch::Entry(static_cast<bst_uint>(i), data[j]),
                    tid);
     }
-}
+  }
   mat.info.num_row = mat.row_ptr_.size() - 1;
   mat.info.num_col = static_cast<uint64_t>(ncol);
   mat.info.num_nonzero = nelem;

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -35,8 +35,7 @@ class Booster {
     auto it = std::find_if(cfg_.begin(), cfg_.end(),
       [&name](decltype(*cfg_.begin()) &x) {
         return x.first == name;
-      }
-    );
+      });
     if (it == cfg_.end()) {
       cfg_.push_back(std::make_pair(name, val));
     } else {

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -189,9 +189,9 @@ class LearnerImpl : public Learner {
       mparam.InitAllowUnknown(args);
       name_obj_ = cfg_["objective"];
       name_gbm_ = cfg_["booster"];
+      // set seed only before the model is initialized
+      common::GlobalRandom().seed(tparam.seed);
     }
-
-    common::GlobalRandom().seed(tparam.seed);
 
     // set number of features correctly.
     cfg_["num_feature"] = common::ToString(mparam.num_feature);


### PR DESCRIPTION
- Make random seed resetting in Configure happen only before a model is initialized. That should help with #1054.
- Prevent accumulation of parameter "history" within `Booster::cfg_` during repeated Configure calls, by resetting the value if a name already exists. It shouldn't really change any results, except it would make the propagation of parameters more efficient while doing parameter resets at each iteration for models with thousands of rounds.