### PR TITLE
call to DMatrix was missing 'missing=self.missing' 

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -222,7 +222,7 @@ class XGBModel(XGBModelBase):
 
         evals_result = {}
         if eval_set is not None:
-            evals = list(DMatrix(x[0], label=x[1],missing=self.missing) for x in eval_set)
+            evals = list(DMatrix(x[0], label=x[1], missing=self.missing) for x in eval_set)
             evals = list(zip(evals, ["validation_{}".format(i) for i in
                                      range(len(evals))]))
         else:

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -222,7 +222,7 @@ class XGBModel(XGBModelBase):
 
         evals_result = {}
         if eval_set is not None:
-            evals = list(DMatrix(x[0], label=x[1]) for x in eval_set)
+            evals = list(DMatrix(x[0], label=x[1],missing=self.missing) for x in eval_set)
             evals = list(zip(evals, ["validation_{}".format(i) for i in
                                      range(len(evals))]))
         else:


### PR DESCRIPTION
In the fit function for XGBModel, if eval_set is specified with missing data there is an error related to 'missing' not being given. This is because the call to DMatrix is missing 'missing=self.missing'. I have fixed that.