### PR TITLE
Fix VisibleDeprecationWarning

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -904,7 +904,8 @@ class Booster(object):
             preds = preds.astype(np.int32)
         nrow = data.num_row()
         if preds.size != nrow and preds.size % nrow == 0:
-            preds = preds.reshape(nrow, preds.size / nrow)
+            ncol = int(preds.size / nrow)
+            preds = preds.reshape(nrow, ncol)
         return preds
 
     def save_model(self, fname):

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -269,7 +269,7 @@ def mknfold(dall, nfold, param, seed, evals=(), fpreproc=None, stratified=False,
 
     if stratified is False and folds is None:
         randidx = np.random.permutation(dall.num_row())
-        kstep = len(randidx) / nfold
+        kstep = int(len(randidx) / nfold)
         idset = [randidx[(i * kstep): min(len(randidx), (i + 1) * kstep)] for i in range(nfold)]
     elif folds is not None:
         idset = [x[1] for x in folds]


### PR DESCRIPTION
XGBoost raises VisibleDeprecationWarning when the numpy version is over 0.9.

```
(xgboost-3.5.1) SUNGHEEui-MacBook:xgboost shaynekang$ nosetests tests/python/

...

/Users/shaynekang/.pyenv/versions/3.5.1/envs/xgboost-3.5.1/lib/python3.5/site-packages/xgboost-0.4-py3.5.egg/xgboost/training.py:273: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  idset = [randidx[(i * kstep): min(len(randidx), (i + 1) * kstep)] for i in range(nfold)]

...

/Users/shaynekang/.pyenv/versions/3.5.1/envs/xgboost-3.5.1/lib/python3.5/site-packages/xgboost-0.4-py3.5.egg/xgboost/core.py:907: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  preds = preds.reshape(nrow, preds.size / nrow)

...

----------------------------------------------------------------------
Ran 31 tests in 1.260s
```

All of these problems cause misuse of datatype. I try to convert non-integer variables to integer than problems are solved.