### PR TITLE
[R] Make early.stop.round message respect verbose flag in xgb.cv()

### DIFF
--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -200,7 +200,9 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
             } else {
                 if (i - bestInd >= early.stop.round) {
                     earlyStopflag <- TRUE
-                    cat('Stopping. Best iteration:', bestInd, '\n')
+                    if (verbose) {
+                        cat('Stopping. Best iteration:', bestInd, '\n')
+                    }
                     break
                 }
             }


### PR DESCRIPTION
Currently if the early.stop.round parameter is set, there is no way to turn off the message that indicates which round was stopped on. For automated operation, I currently have to wrap sink() around the call to xgb.cv() to avoid unwanted output. This request makes printing the message depend on the verbose flag, so if verbose is FALSE no output about the early.stop.round is printed.
