### PR TITLE
[DATA] fix instance weights loading

### DIFF
--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -223,6 +223,10 @@ DMatrix* DMatrix::Load(const std::string& uri,
       LOG(CONSOLE) << info.base_margin.size()
                    << " base_margin are loaded from " << fname << ".base_margin";
     }
+    if (MetaTryLoadFloatInfo(fname + ".weight", &info.weights) && !silent) {
+      LOG(CONSOLE) << info.weights.size()
+                   << " weights are loaded from " << fname << ".weight";
+    }
   }
   return dmat;
 }


### PR DESCRIPTION
Hi Maintainers,
I recently updated xgboost, I found ".weight" file support is broken. It seems the check-condition was removed for some reason, I don't know whether there is a official guide describe the reason although I was trying to find it.

I am not alone.
#1023 