### PR TITLE
[py]Preserve the actual objective used on the booster

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -441,6 +441,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
                               evals_result=evals_result, obj=obj, feval=feval,
                               verbose_eval=verbose)
 
+        self.objective = xgb_options["objective"]
         if evals_result:
             for val in evals_result.items():
                 evals_result_key = list(val[1].keys())[0]


### PR DESCRIPTION
Save the actual objective used on xgboost.train.

Not saving it was giving problem in predict_proba, as issue  #1215