### PR TITLE
Fix issue #1236: cli_main crashes when dumping count:poisson model

### DIFF
--- a/src/cli_main.cc
+++ b/src/cli_main.cc
@@ -271,6 +271,7 @@ void CLIDump2Text(const CLIParam& param) {
   std::unique_ptr<Learner> learner(Learner::Create({}));
   std::unique_ptr<dmlc::Stream> fi(
       dmlc::Stream::Create(param.model_in.c_str(), "r"));
+  learner->Configure(param.cfg);
   learner->Load(fi.get());
   // dump data
   std::vector<std::string> dump = learner->Dump2Text(fmap, param.dump_stats);


### PR DESCRIPTION
Fix a bug which crashes the program when dumping a count:poisson model