### PR TITLE
Fixed Setting verbose_eval to False causes DivisionByZero 

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -38,7 +38,7 @@ def print_evaluation(period=1, show_stdv=True):
     """
     def callback(env):
         """internal function"""
-        if env.rank != 0 or len(env.evaluation_result_list) == 0:
+        if env.rank != 0 or len(env.evaluation_result_list) == 0 or period is False:
             return
         i = env.iteration
         if (i % period == 0 or i + 1 == env.begin_iteration):


### PR DESCRIPTION
related to 
https://github.com/dmlc/xgboost/issues/1251