### PR TITLE
Fix OSX compile error: ambiguous call to function abs which both exists in c and c++.

### DIFF
--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include <cstring>
+#include <cmath>
 
 namespace xgboost {
 namespace tree {


### PR DESCRIPTION
```
In file included from src/tree/tree_model.cc:8:0:
src/tree/./param.h: In member function 'double xgboost::tree::TrainParam::CalcGain(double, double) const':
src/tree/./param.h:127:61: error: call of overloaded 'abs(double&)' is ambiguous
         return - 2.0 * (ret + (double)reg_alpha * std::abs(w));
```