### PR TITLE
Inconsistency in libsvm formats

### DIFF
--- a/jvm-packages/README.md
+++ b/jvm-packages/README.md
@@ -16,7 +16,10 @@ and power xgboost into JVM ecosystem.
 You can find more about XGBoost on [Documentation](https://xgboost.readthedocs.org/en/latest/jvm/index.html) and [Resource Page](../demo/README.md).
 
 ## Hello World
-*NOTE*: Use **one-based** ascending indexes for libsvm format in distributed training mode, WHEREAS - use **zero-based** ascending indexes format when predicting (using the model saved by distributed training) in normal mode.
+*NOTE*: Use **1-based** ascending indexes for libsvm format in distributed training mode:
+- Spark does the internal conversion, and do not accept formats that are 0-based
+- WHEREAS - use **0-based** indexes format when predicting (for instance using the saved model in the Python package) in normal mode
+
 ### XGBoost Scala
 ```scala
 import ml.dmlc.xgboost4j.scala.DMatrix

--- a/jvm-packages/README.md
+++ b/jvm-packages/README.md
@@ -16,6 +16,7 @@ and power xgboost into JVM ecosystem.
 You can find more about XGBoost on [Documentation](https://xgboost.readthedocs.org/en/latest/jvm/index.html) and [Resource Page](../demo/README.md).
 
 ## Hello World
+*NOTE*: Use **one-based** ascending indexes for libsvm format in distributed training mode, WHEREAS - use **zero-based** ascending indexes format when predicting (using the model saved by distributed training) in normal mode.
 ### XGBoost Scala
 ```scala
 import ml.dmlc.xgboost4j.scala.DMatrix


### PR DESCRIPTION
I found out that when I trained a model using the distributed version of the JVM package - the libsvm format for the indexes has to be **one-based** ascending order. Whereas, when I used the saved model in the Python package it expected the libsvm format to be **zero-based** - which resulted in different predictions in the Python package. To work around this you have to modify your libsvm format accordingly.