### PR TITLE
statically compile cli_main.cc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ jvm-packages/lib/libxgboost4j.so: jvm-packages/xgboost4j/src/native/xgboost4j.cp
 	$(CXX) $(CFLAGS) $(JAVAINCFLAGS) -shared -o $@ $(filter %.cpp %.o %.a, $^) $(LDFLAGS)
 
 xgboost: $(CLI_OBJ) $(ALL_DEP)
-	$(CXX) $(CFLAGS) -o $@  $(filter %.o %.a, $^)  $(LDFLAGS)
+	$(CXX) $(CFLAGS) -static -o $@  $(filter %.o %.a, $^)  $(LDFLAGS)
 
 rcpplint:
 	python2 dmlc-core/scripts/lint.py xgboost ${LINT_LANG} R-package/src


### PR DESCRIPTION
Statically compile cli_main.cc, will be very convenient to use binary 'xgboost' everywhere.
The shortcoming is the xgboost's storage increase from 2 MB to 8 MB. I think it can be ignored.

Background:
I trained a classification by xgboost in my machine, and run it on hadoop every map to do prediction.
When running on hadoop, the soft links' absolute path not equals with my machine.
I tried to copy *.so to hadoop, but the prefix of absolute path still not equals.
Statically compile cli_main.cc solved the problem.