### PR TITLE
Class function returns more than one value

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -54,7 +54,7 @@ xgb.DMatrix <- function(data, info = list(), missing = NA, ...) {
 # internal helper method
 xgb.get.DMatrix <- function(data, label = NULL, missing = NA, weight = NULL) {
   inClass <- class(data)
-  if (inClass == "dgCMatrix" || inClass == "matrix") {
+  if ("dgCMatrix" %in% inClass || "matrix" %in% inClass ) {
     if (is.null(label)) {
       stop("xgboost: need label when data is a matrix")
     }


### PR DESCRIPTION
Fix to a bug when the class function returns more than one value. In that case, the code will fail.
The fixed code simply checks if the "matrix" value is in the set of classes the object can have.