### PR TITLE
A couple of openmp fixes

### DIFF
--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -53,9 +53,6 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
   int parallel_option;
   // option to open cacheline optimization
   bool cache_opt;
-  // number of threads to be used for tree construction,
-  // if OpenMP is enabled, if equals 0, use system default
-  int nthread;
   // whether to not print info during training.
   bool silent;
   // declare the parameters
@@ -98,10 +95,8 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
         .describe("Different types of parallelization algorithm.");
     DMLC_DECLARE_FIELD(cache_opt).set_default(true)
         .describe("EXP Param: Cache aware optimization.");
-    DMLC_DECLARE_FIELD(nthread).set_default(0)
-        .describe("Number of threads used for training.");
     DMLC_DECLARE_FIELD(silent).set_default(false)
-        .describe("Not print information during trainig.");
+        .describe("Do not print information during trainig.");
     // add alias of parameters
     DMLC_DECLARE_ALIAS(reg_lambda, lambda);
     DMLC_DECLARE_ALIAS(reg_alpha, alpha);


### PR DESCRIPTION
* Removed exception-throwing macros out of some `omp parallel` regions, so that those exceptions could be caught. That should address #1386 
* Since setting the number of OpenMP threads is a global operation, moved the setting of `omp_set_num_threads` with the `nthread` parameter from gbtree into Learner. This way, setting the `nthread` would have effect not only when or after a gbtree model is created. That should fix #1345