### PR TITLE
updating Mac installation instructions

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -69,12 +69,40 @@ See the following paragraph for OpenMP enabled xgboost.
 
 
 Here is the complete solution to use OpenMP-enabled compilers to install XGBoost.
-Obtain gcc-5.x.x with openmp support by `brew install gcc --without-multilib`. (`brew` is the de facto standard of `apt-get` on OS X. So installing [HPC](http://hpc.sourceforge.net/) separately is not recommended, but it should work.)
+Obtain gcc-5.x.x with openmp support by `brew install gcc --without-multilib`. (`brew` is the de facto standard of `apt-get` on OS X. So installing [HPC](http://hpc.sourceforge.net/) separately is not recommended, but it should work.). Installation of `gcc` can take a while (~ 30 minutes)
+
+Now, clone the repository
 
 ```bash
 git clone --recursive https://github.com/dmlc/xgboost
-cd xgboost; cp make/config.mk ./config.mk; make -j4
 ```
+
+The next step is to update the compliers in xgboost's configuration file
+
+```bash
+cd xgboost
+```
+
+Open make/config.mk file and replace the following two lines
+
+```bash
+export CC = gcc
+export CXX = g++
+```
+
+with
+
+```bash
+export CC = gcc-5
+export CXX = g++-5
+```
+
+Now, build using the following commands
+
+````bash
+cd ..; cp make/config.mk ./config.mk; make -j4
+```
+
 
 ### Building on Windows
 You need to first clone the xgboost repo with recursive option clone the submodules.


### PR DESCRIPTION
In Mac, even after gcc is installed from homebrew, gcc and g++ still point to clang's version. 

Need to update the make/config.mk file to point the gcc and g++ compliers to the version installed by homebrew. 

More details can be found in this blog: https://www.ibm.com/developerworks/community/blogs/jfp/entry/Installing_XGBoost_on_Mac_OSX?lang=en