### PR TITLE
Update version of a compiler for Mac OS

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -69,7 +69,7 @@ See the following paragraph for OpenMP enabled xgboost.
 
 
 Here is the complete solution to use OpenMP-enabled compilers to install XGBoost.
-Obtain gcc-5.x.x with openmp support by `brew install gcc --without-multilib`. (`brew` is the de facto standard of `apt-get` on OS X. So installing [HPC](http://hpc.sourceforge.net/) separately is not recommended, but it should work.). Installation of `gcc` can take a while (~ 30 minutes)
+Obtain gcc-6.x.x with openmp support by `brew install gcc --without-multilib`. (`brew` is the de facto standard of `apt-get` on OS X. So installing [HPC](http://hpc.sourceforge.net/) separately is not recommended, but it should work.). Installation of `gcc` can take a while (~ 30 minutes)
 
 Now, clone the repository
 
@@ -93,8 +93,8 @@ export CXX = g++
 with
 
 ```bash
-export CC = gcc-5
-export CXX = g++-5
+export CC = gcc-6
+export CXX = g++-6
 ```
 
 Now, build using the following commands


### PR DESCRIPTION
When you brew a gcc with OpenMP support (), it installs a new version 6.1.0
For smoother installation and for consistency with current brew formulae the doc was modified 5->6.
