### PR TITLE
Fix #1464

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -36,8 +36,8 @@ even better to send pull request if you can fix the problem.
 ## Build the Shared Library
 
 Our goal is to build the shared library:
-- On Linux/OSX the target library is ```libxgboost.so```
-- On Windows the target library is ```libxgboost.dll```
+- On Linux/OSX the target library is `libxgboost.so`
+- On Windows the target library is `libxgboost.dll`
 
 The minimal building requirement is
 
@@ -99,7 +99,7 @@ export CXX = g++-5
 
 Now, build using the following commands
 
-````bash
+```bash
 cd ..; cp make/config.mk ./config.mk; make -j4
 ```
 


### PR DESCRIPTION
1. Remove the extra ` to fix https://xgboost.readthedocs.io/en/latest/build.html
2. Use ` for inline code