### PR TITLE
[Makefile] change makefile to support clang-omp++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,10 @@ endif
 # it is useful for pip install compiling-on-the-fly
 OS := $(shell uname)
 ifeq ($(OS), Darwin)
-export CC = $(if $(shell which gcc-5),gcc-5,clang)
-export CXX = $(if $(shell which g++-5),g++-5,clang++)
+	ifneq ($(CXX), clang-omp++) 
+		export CC = $(if $(shell which gcc-5),gcc-5,clang-omp)
+		export CXX = $(if $(shell which g++-5),g++-5,clang-omp++)
+	endif	
 endif
 
 export LDFLAGS= -pthread -lm $(ADD_LDFLAGS) $(DMLC_LDFLAGS) $(PLUGIN_LDFLAGS)


### PR DESCRIPTION
the current Makefile  for MacOS  does not allow the users to use clang-omp++ when their systems contain g++-5....

the modifications here are:

1. change clang++/clang to clang-omp++/clang-omp for OpenMP support

2. allow the user to set CXX=clang-omp++ before run `make`

