### PR TITLE
Make python package wheelable

### DIFF
--- a/python-package/xgboost/libpath.py
+++ b/python-package/xgboost/libpath.py
@@ -3,6 +3,7 @@
 
 import os
 import platform
+import sys
 
 
 class XGBoostLibraryNotFound(Exception):
@@ -21,7 +22,8 @@ def find_lib_path():
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
     # make pythonpack hack: copy this directory one level upper for setup.py
     dll_path = [curr_path, os.path.join(curr_path, '../../lib/'),
-                os.path.join(curr_path, './lib/')]
+                os.path.join(curr_path, './lib/'),
+                os.path.join(sys.prefix, 'xgboost')]
     if os.name == 'nt':
         if platform.architecture()[0] == '64bit':
             dll_path.append(os.path.join(curr_path, '../../windows/x64/Release/'))


### PR DESCRIPTION
Currently xgboost can only be installed by running:

    python setup.py install

Now it can be packaged (in binary form) as a wheel and installed like:

    pip install xgboost-0.6-py2-none-any.whl

distutils and wheel install `data_files` differently than setuptools.
setuptools will install the `data_files` in the package directory whereas the
others install it in `sys.prefix`. By adding `sys.prefix` to the list of
directories to check for the shared library, xgboost can now be distributed as
a wheel.