### PR TITLE
MS Visual Studio 2015 fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,10 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -fPIC")
 
 # Make sure we are using C++11
 # Visual Studio 12.0 and newer supports enough c++11 to make this work
-if(MSVC AND MSVC_VERSION LESS 1800)
+if(MSVC)
+  if(MSVC_VERSION LESS 1800)
     message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+  endif()
 else()
   # GCC 4.6 with c++0x supports enough to make this work
   include(CheckCXXCompilerFlag)


### PR DESCRIPTION
Fixed to work with future versions of visual studio i.e., 2015

MSVC has it's own section for setting compile parameters, it shouldn't need to fall into section below i.e., checking for c++11 as this is definitely already supported, though this isn't an issue for Visual Studio 2012, it breaks for later versions
of visual studio i.e., 2015 when the default c++ is version 14.  Though still backward compatible with c++11