### PR TITLE
the fix of missing value assignment for name_ variable in EvalRankLis…

### DIFF
--- a/src/metric/rank_metric.cc
+++ b/src/metric/rank_metric.cc
@@ -216,6 +216,7 @@ struct EvalRankList : public Metric {
         minus_ = true;
       }
     } else {
+      name_ = name;
       topn_ = std::numeric_limits<unsigned>::max();
     }
   }


### PR DESCRIPTION
This is a fix of  #1478 .
I test it locally, it is working fine now!