### PR TITLE
Have to `unname` before comparison

### DIFF
--- a/R-package/R/callbacks.R
+++ b/R-package/R/callbacks.R
@@ -350,7 +350,7 @@ cb.early.stop <- function(stopping_rounds, maximize=FALSE,
   finalizer <- function(env) {
     if (!is.null(env$bst)) {
       attr_best_score = as.numeric(xgb.attr(env$bst$handle, 'best_score'))
-      if (best_score != attr_best_score)
+      if (!isTRUE(all.equal(unname(best_score), attr_best_score)))
         stop("Inconsistent 'best_score' values between the closure state: ", best_score,
              " and the xgb.attr: ", attr_best_score)
       env$bst$best_iteration = best_iteration


### PR DESCRIPTION
I've put a browser there and inspected

```r
Called from: finalizer(env)
Browse[1]> best_score
 eval-auc
0.9381443
Browse[1]> attr_best_score
[1] 0.9381443
Browse[1]> all.equal(best_score, attr_best_score)
[1] "names for target but not for current"
Browse[1]> all.equal(unname(best_score), attr_best_score)
[1] TRUE
Browse[1]> unname(best_score)
[1] 0.9381443
Browse[1]> attr_best_score
[1] 0.9381443
Browse[1]> attr_best_score %>% str
 num 0.938
Browse[1]> unname(best_score) %>% str
 num 0.938
```