### PR TITLE
[jvm-packages] Fixed the sanity check for parameter 'nthread' against 'spark.task.cpus'.

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -188,9 +188,9 @@ object XGBoost extends Serializable {
     implicit val sc = trainingData.sparkContext
     var overridedConfMap = configMap
     if (overridedConfMap.contains("nthread")) {
-      val nThread = overridedConfMap("nthread")
-      val coresPerTask = sc.getConf.get("spark.task.cpus", "1")
-      require(nThread.toString <= coresPerTask,
+      val nThread = overridedConfMap("nthread").toString.toInt
+      val coresPerTask = sc.getConf.get("spark.task.cpus", "1").toInt
+      require(nThread <= coresPerTask,
         s"the nthread configuration ($nThread) must be no larger than " +
           s"spark.task.cpus ($coresPerTask)")
     } else {


### PR DESCRIPTION
The original comparison `nThread.toString <= coresPerTask` compares two strings lexically, which leads to failures of assertion, *e.g.*

```
the nthread configuration (4) must be no larger than spark.task.cpus (12)
```

An detailed exception with stack trace:

```
Exception in thread "main" java.lang.IllegalArgumentException: requirement failed: the nthread configuration (4) must be no larger than spark.task.cpus (12)
       	at scala.Predef$.require(Predef.scala:219)
       	at ml.dmlc.xgboost4j.scala.spark.XGBoost$.train(XGBoost.scala:142)
       	at ml.dmlc.xgboost4j.scala.example.spark.PlAlgoModelTrainSpark$.main(PlAlgoModelTrainSpark.scala:96)
       	at ml.dmlc.xgboost4j.scala.example.spark.PlAlgoModelTrainSpark.main(PlAlgoModelTrainSpark.scala)
       	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
       	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
       	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
       	at java.lang.reflect.Method.invoke(Method.java:497)
       	at org.apache.spark.deploy.SparkSubmit$.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:731)
       	at org.apache.spark.deploy.SparkSubmit$.doRunMain$1(SparkSubmit.scala:181)
       	at org.apache.spark.deploy.SparkSubmit$.submit(SparkSubmit.scala:206)
       	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:121)
       	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```

Converting both strings to integers fixes this issue. Confirmed in my own testing.