### PR TITLE
[Bug Found] IndexOutOfBoundsException

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -48,7 +48,7 @@ object XGBoost extends Serializable {
         val indices = new ListBuffer[Int]
         val values = new ListBuffer[Double]
         for (i <- dVector.values.indices) {
-          if (values(i) != missing) {
+          if (dVector.values(i) != missing) {
             indices += i
             values += dVector.values(i)
           }


### PR DESCRIPTION
ml.dmlc.xgboost4j.scala.spark.XGBoost.scala:51

values is empty when we meet it at first time, so values(0) throw an IndexOutOfBoundsException.
It should be  dVector.values(i) instead of values(i).