### PR TITLE
Move feature_importances_ to base XGBModel for XGBRegressor access

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -328,6 +328,20 @@ class XGBModel(XGBModelBase):
 
         return evals_result
 
+    @property
+    def feature_importances_(self):
+        """
+        Returns
+        -------
+        feature_importances_ : array of shape = [n_features]
+
+        """
+        b = self.booster()
+        fs = b.get_fscore()
+        all_features = [fs.get(f, 0.) for f in b.feature_names]
+        all_features = np.array(all_features, dtype=np.float32)
+        return all_features / all_features.sum()
+
 
 class XGBClassifier(XGBModel, XGBClassifierBase):
     # pylint: disable=missing-docstring,too-many-arguments,invalid-name
@@ -517,20 +531,6 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             raise XGBoostError('No results.')
 
         return evals_result
-
-    @property
-    def feature_importances_(self):
-        """
-        Returns
-        -------
-        feature_importances_ : array of shape = [n_features]
-
-        """
-        b = self.booster()
-        fs = b.get_fscore()
-        all_features = [fs.get(f, 0.) for f in b.feature_names]
-        all_features = np.array(all_features, dtype=np.float32)
-        return all_features / all_features.sum()
 
 
 class XGBRegressor(XGBModel, XGBRegressorBase):


### PR DESCRIPTION
I noticed the `XGBRegressor` is missing `feature_importances_` that `XGBClassifier` has. I think it's very useful for visualizations or potentially feature selection for downstream models.

It's easy to move this method into the base `XGBModel` to provide access to `XGBRegressor` as well. 

See below:

``` python
from xgboost.sklearn import XGBRegressor, XGBClassifier
import numpy as np

# Current method in XGBClassifier
def feature_importances_(self):
    """
    Returns
    -------
    feature_importances_ : array of shape = [n_features]

    """
    b = self.booster()
    fs = b.get_fscore()
    all_features = [fs.get(f, 0.) for f in b.feature_names]
    all_features = np.array(all_features, dtype=np.float32)
    return all_features / all_features.sum()

# Build test data
random_state = np.random.RandomState(1)
X = random_state.uniform(0, 1, (100, 3))
y = X[:, 0]

# Fit regressor, classifier
reg = XGBRegressor().fit(X, y)
clf = XGBClassifier().fit(X, y > 0.5)

# Output importances
print 'Classifier importances:\n%s' % clf.feature_importances_


# Show solution
print 'Regressor importances using the method in XGBClassifier:\n%s' % feature_importances_(reg)
```

Output:

```
Classifier importances:
[ 1.  0.  0.]
Regressor importances using the method in XGBClassifier:
[ 0.95961541  0.01923077  0.02115385]
```

What are your thoughts on adding this?

Related: #11, #1543 
