### PR TITLE
More robust DMatrix creation from a sparse matrix

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -27,7 +27,7 @@ xgb.DMatrix <- function(data, info = list(), missing = NA, ...) {
                     PACKAGE = "xgboost")
     cnames <- colnames(data)
   } else if (class(data) == "dgCMatrix") {
-    handle <- .Call("XGDMatrixCreateFromCSC_R", data@p, data@i, data@x,
+    handle <- .Call("XGDMatrixCreateFromCSC_R", data@p, data@i, data@x, nrow(data),
                     PACKAGE = "xgboost")
     cnames <- colnames(data)
   } else {

--- a/R-package/src/xgboost_R.h
+++ b/R-package/src/xgboost_R.h
@@ -43,11 +43,13 @@ XGB_DLL SEXP XGDMatrixCreateFromMat_R(SEXP mat,
  * \param indptr pointer to column headers
  * \param indices row indices
  * \param data content of the data
+ * \param num_row numer of rows (when it's set to 0, then guess from data)
  * \return created dmatrix
  */
 XGB_DLL SEXP XGDMatrixCreateFromCSC_R(SEXP indptr,
                                       SEXP indices,
-                                      SEXP data);
+                                      SEXP data,
+                                      SEXP num_row);
 
 /*!
  * \brief create a new dmatrix from sliced content of existing matrix

--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -1,4 +1,5 @@
 require(xgboost)
+require(Matrix)
 
 context("testing xgb.DMatrix functionality")
 
@@ -64,4 +65,14 @@ test_that("xgb.DMatrix: colnames", {
   expect_equal(colnames(dtest), new_names)
   expect_silent(colnames(dtest) <- NULL)
   expect_null(colnames(dtest))
+})
+
+test_that("xgb.DMatrix: nrow is correct for a very sparse matrix", {
+  set.seed(123)
+  nr <- 1000
+  x <- rsparsematrix(nr, 100, density=0.0005)
+  # we want it very sparse, so that last rows are empty
+  expect_lt(max(x@i), nr)
+  dtest <- xgb.DMatrix(x)
+  expect_equal(dim(dtest), dim(x))
 })

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -114,7 +114,7 @@ XGB_DLL int XGDMatrixCreateFromDataIter(
     DMatrixHandle *out);
 
 /*!
- * \brief create a matrix content from csr format
+ * \brief create a matrix content from CSR format
  * \param indptr pointer to row headers
  * \param indices findex
  * \param data fvalue
@@ -125,16 +125,15 @@ XGB_DLL int XGDMatrixCreateFromDataIter(
  * \return 0 when success, -1 when failure happens
  */
 XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,
-                                   const unsigned* indices,
-                                   const float* data,
-                                   size_t nindptr,
-                                   size_t nelem,
-                                   size_t num_col,
-                                   DMatrixHandle* out);
-
+                                     const unsigned* indices,
+                                     const float* data,
+                                     size_t nindptr,
+                                     size_t nelem,
+                                     size_t num_col,
+                                     DMatrixHandle* out);
 /*!
  * \deprecated
- * \brief create a matrix content from csr format
+ * \brief create a matrix content from CSR format
  * \param indptr pointer to row headers
  * \param indices findex
  * \param data fvalue
@@ -149,7 +148,6 @@ XGB_DLL int XGDMatrixCreateFromCSR(const bst_ulong *indptr,
                                    bst_ulong nindptr,
                                    bst_ulong nelem,
                                    DMatrixHandle *out);
-
 /*!
  * \brief create a matrix content from CSC format
  * \param col_ptr pointer to col headers
@@ -168,7 +166,6 @@ XGB_DLL int XGDMatrixCreateFromCSCEx(const size_t* col_ptr,
                                      size_t nelem,
                                      size_t num_row,
                                      DMatrixHandle* out);
-
 /*!
  * \deprecated
  * \brief create a matrix content from CSC format

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -120,6 +120,26 @@ XGB_DLL int XGDMatrixCreateFromDataIter(
  * \param data fvalue
  * \param nindptr number of rows in the matix + 1
  * \param nelem number of nonzero elements in the matrix
+ * \param num_col number of columns; when it's set to 0, then guess from data
+ * \param out created dmatrix
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,
+                                   const unsigned* indices,
+                                   const float* data,
+                                   size_t nindptr,
+                                   size_t nelem,
+                                   size_t num_col,
+                                   DMatrixHandle* out);
+
+/*!
+ * \deprecated
+ * \brief create a matrix content from csr format
+ * \param indptr pointer to row headers
+ * \param indices findex
+ * \param data fvalue
+ * \param nindptr number of rows in the matix + 1
+ * \param nelem number of nonzero elements in the matrix
  * \param out created dmatrix
  * \return 0 when success, -1 when failure happens
  */
@@ -129,7 +149,28 @@ XGB_DLL int XGDMatrixCreateFromCSR(const bst_ulong *indptr,
                                    bst_ulong nindptr,
                                    bst_ulong nelem,
                                    DMatrixHandle *out);
+
 /*!
+ * \brief create a matrix content from CSC format
+ * \param col_ptr pointer to col headers
+ * \param indices findex
+ * \param data fvalue
+ * \param nindptr number of rows in the matix + 1
+ * \param nelem number of nonzero elements in the matrix
+ * \param num_row number of rows; when it's set to 0, then guess from data
+ * \param out created dmatrix
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixCreateFromCSCEx(const size_t* col_ptr,
+                                     const unsigned* indices,
+                                     const float* data,
+                                     size_t nindptr,
+                                     size_t nelem,
+                                     size_t num_row,
+                                     DMatrixHandle* out);
+
+/*!
+ * \deprecated
  * \brief create a matrix content from CSC format
  * \param col_ptr pointer to col headers
  * \param indices findex

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -287,10 +287,11 @@ class DMatrix(object):
         if len(csr.indices) != len(csr.data):
             raise ValueError('length mismatch: {} vs {}'.format(len(csr.indices), len(csr.data)))
         self.handle = ctypes.c_void_p()
-        _check_call(_LIB.XGDMatrixCreateFromCSR(c_array(ctypes.c_ulong, csr.indptr),
+        _check_call(_LIB.XGDMatrixCreateFromCSREx(c_array(ctypes.c_size_t, csr.indptr),
                                                 c_array(ctypes.c_uint, csr.indices),
                                                 c_array(ctypes.c_float, csr.data),
                                                 len(csr.indptr), len(csr.data),
+                                                csr.shape[1],
                                                 ctypes.byref(self.handle)))
 
     def _init_from_csc(self, csc):
@@ -300,10 +301,11 @@ class DMatrix(object):
         if len(csc.indices) != len(csc.data):
             raise ValueError('length mismatch: {} vs {}'.format(len(csc.indices), len(csc.data)))
         self.handle = ctypes.c_void_p()
-        _check_call(_LIB.XGDMatrixCreateFromCSC(c_array(ctypes.c_ulong, csc.indptr),
+        _check_call(_LIB.XGDMatrixCreateFromCSCEx(c_array(ctypes.c_size_t, csc.indptr),
                                                 c_array(ctypes.c_uint, csc.indices),
                                                 c_array(ctypes.c_float, csc.data),
                                                 len(csc.indptr), len(csc.data),
+                                                csc.shape[0],
                                                 ctypes.byref(self.handle)))
 
     def _init_from_npy2d(self, mat, missing):

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -288,11 +288,11 @@ class DMatrix(object):
             raise ValueError('length mismatch: {} vs {}'.format(len(csr.indices), len(csr.data)))
         self.handle = ctypes.c_void_p()
         _check_call(_LIB.XGDMatrixCreateFromCSREx(c_array(ctypes.c_size_t, csr.indptr),
-                                                c_array(ctypes.c_uint, csr.indices),
-                                                c_array(ctypes.c_float, csr.data),
-                                                len(csr.indptr), len(csr.data),
-                                                csr.shape[1],
-                                                ctypes.byref(self.handle)))
+                                                  c_array(ctypes.c_uint, csr.indices),
+                                                  c_array(ctypes.c_float, csr.data),
+                                                  len(csr.indptr), len(csr.data),
+                                                  csr.shape[1],
+                                                  ctypes.byref(self.handle)))
 
     def _init_from_csc(self, csc):
         """
@@ -302,11 +302,11 @@ class DMatrix(object):
             raise ValueError('length mismatch: {} vs {}'.format(len(csc.indices), len(csc.data)))
         self.handle = ctypes.c_void_p()
         _check_call(_LIB.XGDMatrixCreateFromCSCEx(c_array(ctypes.c_size_t, csc.indptr),
-                                                c_array(ctypes.c_uint, csc.indices),
-                                                c_array(ctypes.c_float, csc.data),
-                                                len(csc.indptr), len(csc.data),
-                                                csc.shape[0],
-                                                ctypes.byref(self.handle)))
+                                                  c_array(ctypes.c_uint, csc.indices),
+                                                  c_array(ctypes.c_float, csc.data),
+                                                  len(csc.indptr), len(csc.data),
+                                                  csc.shape[0],
+                                                  ctypes.byref(self.handle)))
 
     def _init_from_npy2d(self, mat, missing):
         """

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -232,7 +232,7 @@ XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,
                            const float* data,
                            size_t nindptr,
                            size_t nelem,
-						   size_t num_col,
+                           size_t num_col,
                            DMatrixHandle* out) {
   std::unique_ptr<data::SimpleCSRSource> source(new data::SimpleCSRSource());
 
@@ -250,7 +250,7 @@ XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,
   }
   if (num_col > 0) {
     CHECK_LE(mat.info.num_col, num_col);
-	mat.info.num_col = num_col;
+    mat.info.num_col = num_col;
   }
   mat.info.num_row = nindptr - 1;
   mat.info.num_nonzero = nelem;
@@ -323,7 +323,7 @@ XGB_DLL int XGDMatrixCreateFromCSCEx(const size_t* col_ptr,
   mat.info.num_row = mat.row_ptr_.size() - 1;
   if (num_row > 0) {
     CHECK_LE(mat.info.num_row, num_row);
-	mat.info.num_row = num_row ;
+    mat.info.num_row = num_row;
   }
   mat.info.num_col = ncol;
   mat.info.num_nonzero = nelem;

--- a/tests/python/test_sparse_dmatrix.py
+++ b/tests/python/test_sparse_dmatrix.py
@@ -1,0 +1,35 @@
+import numpy as np
+import scipy.sparse
+import xgboost as xgb
+from scipy.sparse import rand
+
+rng = np.random.RandomState(1)
+
+param = {'max_depth': 3, 'objective': 'binary:logistic', 'silent': False}
+
+
+def test_sparse_dmatrix_csr():
+    nrow = 100
+    ncol = 1000
+    x = rand(nrow, ncol, density=0.0005, format='csr', random_state=rng)
+    assert x.indices.max() < ncol - 1
+    x.data[:] = 1
+    dtrain = xgb.DMatrix(x, label = np.random.binomial(1, 0.3, nrow))
+    assert (dtrain.num_row(), dtrain.num_col()) == (nrow, ncol)
+    watchlist = [(dtrain, 'train')]
+    bst = xgb.train(param, dtrain, 5, watchlist)
+    preds = bst.predict(dtrain)
+
+
+def test_sparse_dmatrix_csc():
+    nrow = 1000
+    ncol = 100
+    x = rand(nrow, ncol, density=0.0005, format='csc', random_state=rng)
+    assert x.indices.max() < nrow - 1
+    x.data[:] = 1
+    dtrain = xgb.DMatrix(x, label = np.random.binomial(1, 0.3, nrow))
+    assert (dtrain.num_row(), dtrain.num_col()) == (nrow, ncol)
+    watchlist = [(dtrain, 'train')]
+    bst = xgb.train(param, dtrain, 5, watchlist)
+    preds = bst.predict(dtrain)
+

--- a/tests/python/test_sparse_dmatrix.py
+++ b/tests/python/test_sparse_dmatrix.py
@@ -1,11 +1,10 @@
 import numpy as np
-import scipy.sparse
 import xgboost as xgb
 from scipy.sparse import rand
 
 rng = np.random.RandomState(1)
 
-param = {'max_depth': 3, 'objective': 'binary:logistic', 'silent': False}
+param = {'max_depth': 3, 'objective': 'binary:logistic', 'silent': 1}
 
 
 def test_sparse_dmatrix_csr():
@@ -14,11 +13,11 @@ def test_sparse_dmatrix_csr():
     x = rand(nrow, ncol, density=0.0005, format='csr', random_state=rng)
     assert x.indices.max() < ncol - 1
     x.data[:] = 1
-    dtrain = xgb.DMatrix(x, label = np.random.binomial(1, 0.3, nrow))
+    dtrain = xgb.DMatrix(x, label=np.random.binomial(1, 0.3, nrow))
     assert (dtrain.num_row(), dtrain.num_col()) == (nrow, ncol)
     watchlist = [(dtrain, 'train')]
     bst = xgb.train(param, dtrain, 5, watchlist)
-    preds = bst.predict(dtrain)
+    bst.predict(dtrain)
 
 
 def test_sparse_dmatrix_csc():
@@ -27,9 +26,8 @@ def test_sparse_dmatrix_csc():
     x = rand(nrow, ncol, density=0.0005, format='csc', random_state=rng)
     assert x.indices.max() < nrow - 1
     x.data[:] = 1
-    dtrain = xgb.DMatrix(x, label = np.random.binomial(1, 0.3, nrow))
+    dtrain = xgb.DMatrix(x, label=np.random.binomial(1, 0.3, nrow))
     assert (dtrain.num_row(), dtrain.num_col()) == (nrow, ncol)
     watchlist = [(dtrain, 'train')]
     bst = xgb.train(param, dtrain, 5, watchlist)
-    preds = bst.predict(dtrain)
-
+    bst.predict(dtrain)


### PR DESCRIPTION
Addresses #1583 

The new "explicit" XGDMatrixCreateFromCS*Ex functions are pretty much duplicates of the old ones with an extra argument, slight code change, and slightly safer types. The old ones are marked as `\deprecated` in their doc. 

I've updated the Python interface, but need to think a bit more about R (would like to make it handle the 64 bit indexing properly). And I didn't touch jvm.
