### PR TITLE
[jvm-packages][bug-fix] Predict in XGBoostModel to handle mapPartitions correctly.

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
@@ -71,7 +71,7 @@ class XGBoostModel(_booster: Booster) extends Serializable {
    * @param testSet test set represented as RDD
    * @param useExternalCache whether to use external cache for the test set
    */
-  def predict(testSet: RDD[Vector], useExternalCache: Boolean = false): RDD[Array[Array[Float]]] = {
+  def predict(testSet: RDD[Vector], useExternalCache: Boolean = false): RDD[Array[Float]] = {
     import DataUtils._
     val broadcastBooster = testSet.sparkContext.broadcast(_booster)
     val appName = testSet.context.appName
@@ -89,7 +89,7 @@ class XGBoostModel(_booster: Booster) extends Serializable {
         val dMatrix = new DMatrix(new JDMatrix(testSamples, cacheFileName))
         val res = broadcastBooster.value.predict(dMatrix)
         Rabit.shutdown()
-        Iterator(res)
+        res.iterator
       } else {
         Iterator()
       }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostSuite.scala
@@ -201,7 +201,7 @@ class XGBoostSuite extends FunSuite with BeforeAndAfter {
   test("test consistency of prediction functions with RDD") {
     val trainingRDD = buildTrainingRDD()
     val testSet = readFile(getClass.getResource("/agaricus.txt.test").getFile)
-    val testRDD = sc.parallelize(testSet, numSlices = 1).map(_.features)
+    val testRDD = sc.parallelize(testSet, numSlices = 2).map(_.features)
     val testCollection = testRDD.collect()
     for (i <- testSet.indices) {
       assert(testCollection(i).toDense.values.sameElements(testSet(i).features.toDense.values))
@@ -210,7 +210,8 @@ class XGBoostSuite extends FunSuite with BeforeAndAfter {
       "objective" -> "binary:logistic").toMap
     val xgBoostModel = XGBoost.train(trainingRDD, paramMap, 5, numWorkers)
     val predRDD = xgBoostModel.predict(testRDD)
-    val predResult1 = predRDD.collect()(0)
+    val predResult1 = predRDD.collect()
+    assert(testRDD.count() === predResult1.size)
     import DataUtils._
     val predResult2 = xgBoostModel.booster.predict(new DMatrix(testSet.iterator))
     for (i <- predResult1.indices; j <- predResult1(i).indices) {


### PR DESCRIPTION
Currently, the predict returns RDD[Array[Array[Float]]] where in the elements in RDD equates to the number of partitions rather than the original number of elements in testRDD - RDD[Vector].

This patch would fix the bug and return RDD[Array[Float]], where the number of elements in the testRDD and the return RDD would match. Test cases have been updated appropriately. 