### PR TITLE
Prevents approx error when using custom eval

### DIFF
--- a/R-package/R/callbacks.R
+++ b/R-package/R/callbacks.R
@@ -350,7 +350,7 @@ cb.early.stop <- function(stopping_rounds, maximize=FALSE,
   finalizer <- function(env) {
     if (!is.null(env$bst)) {
       attr_best_score = as.numeric(xgb.attr(env$bst$handle, 'best_score'))
-      if (best_score != attr_best_score)
+      if (!((best_score < (attr_best_score + 1e-12)) & (best_score > (attr_best_score - 1e-12))))
         stop("Inconsistent 'best_score' values between the closure state: ", best_score,
              " and the xgb.attr: ", attr_best_score)
       env$bst$best_iteration = best_iteration


### PR DESCRIPTION
Prevents xgboost in R from erroring when the following conditions are met:

* You are using a custom evaluation function
* The score is not reproducible, most of the times at 1e-13 precision
* You are using the default early_stopping_rounds callback (thus, early_stopping_rounds parameter is setup)

Allowing leniency in the best score comparison (by 1e-12) allows to prevent xgboost from stopping and cancelling the model right when training the model is over, even if R reports the difference between best_score and attr_best_score is virtually 0 when printed (but will ever say they are not equal). Hence, the user do not lose his/her model at the end (especially useful if the model takes hours/days to train or if it is run in a batch).