### PR TITLE
keep builtin evaluations while using customized evaluation function

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -866,7 +866,7 @@ class Booster(object):
         _check_call(_LIB.XGBoosterEvalOneIter(self.handle, iteration,
                                               dmats, evnames, len(evals),
                                               ctypes.byref(msg)))
-        res = msg.value
+        res = msg.value.decode()
         if feval is not None:
             for dmat, evname in evals:
                 feval_ret = feval(self.predict(dmat), dmat)

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -853,23 +853,21 @@ class Booster(object):
         result: str
             Evaluation result string.
         """
-        if feval is None:
-            for d in evals:
-                if not isinstance(d[0], DMatrix):
-                    raise TypeError('expected DMatrix, got {}'.format(type(d[0]).__name__))
-                if not isinstance(d[1], STRING_TYPES):
-                    raise TypeError('expected string, got {}'.format(type(d[1]).__name__))
-                self._validate_features(d[0])
+        for d in evals:
+            if not isinstance(d[0], DMatrix):
+                raise TypeError('expected DMatrix, got {}'.format(type(d[0]).__name__))
+            if not isinstance(d[1], STRING_TYPES):
+                raise TypeError('expected string, got {}'.format(type(d[1]).__name__))
+            self._validate_features(d[0])
 
-            dmats = c_array(ctypes.c_void_p, [d[0].handle for d in evals])
-            evnames = c_array(ctypes.c_char_p, [c_str(d[1]) for d in evals])
-            msg = ctypes.c_char_p()
-            _check_call(_LIB.XGBoosterEvalOneIter(self.handle, iteration,
-                                                  dmats, evnames, len(evals),
-                                                  ctypes.byref(msg)))
-            return msg.value
-        else:
-            res = '[%d]' % iteration
+        dmats = c_array(ctypes.c_void_p, [d[0].handle for d in evals])
+        evnames = c_array(ctypes.c_char_p, [c_str(d[1]) for d in evals])
+        msg = ctypes.c_char_p()
+        _check_call(_LIB.XGBoosterEvalOneIter(self.handle, iteration,
+                                              dmats, evnames, len(evals),
+                                              ctypes.byref(msg)))
+        res = msg.value
+        if feval is not None:
             for dmat, evname in evals:
                 feval_ret = feval(self.predict(dmat), dmat)
                 if isinstance(feval_ret, list):
@@ -878,7 +876,7 @@ class Booster(object):
                 else:
                     name, val = feval_ret
                     res += '\t%s-%s:%f' % (evname, name, val)
-            return res
+        return res
 
     def eval(self, data, name='eval', iteration=0):
         """Evaluate the model on mat.


### PR DESCRIPTION
For python packages, some times I just want to add one or few customized evaluation functions besides the builtin evaluation functions. We can support both.
