### PR TITLE
[jvm-packages] XGBoost4j Windows fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ ifneq ($(UNAME), Windows)
 	XGBOOST_DYLIB = lib/libxgboost.so
 else
 	XGBOOST_DYLIB = lib/libxgboost.dll
+	JAVAINCFLAGS += -I${JAVA_HOME}/include/win32
 endif
 
 ifeq ($(UNAME), Linux)

--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -47,7 +47,7 @@ namespace xgboost {
  */
 typedef uint32_t bst_uint;
 /*! \brief long integers */
-typedef unsigned long bst_ulong;  // NOLINT(*)
+typedef uint64_t bst_ulong;  // NOLINT(*)
 /*! \brief float type, used for storing statistics */
 typedef float bst_float;
 

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -24,7 +24,7 @@ XGB_EXTERN_C {
 #endif
 
 // manually define unsign long
-typedef unsigned long bst_ulong;  // NOLINT(*)
+typedef uint64_t bst_ulong;  // NOLINT(*)
 
 /*! \brief handle to DMatrix */
 typedef void *DMatrixHandle;
@@ -40,7 +40,7 @@ typedef struct {
   /*! \brief number of rows in the minibatch */
   size_t size;
   /*! \brief row pointer to the rows in the data */
-  long* offset;  // NOLINT(*)
+  int64_t* offset;  // NOLINT(*)
   /*! \brief labels of each instance */
   float* label;
   /*! \brief weight of each instance, can be NULL */

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -40,7 +40,12 @@ typedef struct {
   /*! \brief number of rows in the minibatch */
   size_t size;
   /*! \brief row pointer to the rows in the data */
+#ifdef __APPLE__
+  /* Necessary as Java on MacOS defines jlong as long int, and gcc defines int64_t as long long int. */
+  long* offset; // NOLINT(*)
+#else
   int64_t* offset;  // NOLINT(*)
+#endif
   /*! \brief labels of each instance */
   float* label;
   /*! \brief weight of each instance, can be NULL */

--- a/jvm-packages/create_jni.bat
+++ b/jvm-packages/create_jni.bat
@@ -1,20 +1,19 @@
-echo "move native library"
-set libsource=..\windows\x64\Release\xgboost4j.dll
+echo "copy native library"
+set libsource=..\lib\libxgboost4j.so
 
 if not exist %libsource% (
 goto end
 )
 
-set libfolder=xgboost4j\src\main\resources\lib
+set libfolder=src\main\resources\lib
 set libpath=%libfolder%\xgboost4j.dll
 if not exist %libfolder% (mkdir %libfolder%)
 if exist %libpath% (del %libpath%)
-move %libsource% %libfolder%
+copy %libsource% %libpath%
 echo complete
-pause
 exit
 
 :end
-  echo "source library not found, please build it first from ..\windows\xgboost.sln"
+  echo "source library not found, please build it first by runing mingw32-make jvm"
   pause
   exit

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -24,7 +24,11 @@
 // helper functions
 // set handle
 void setHandle(JNIEnv *jenv, jlongArray jhandle, void* handle) {
+#ifdef __APPLE__
+  long out = (long) handle;
+#else
   int64_t out = (int64_t) handle;
+#endif
   jenv->SetLongArrayRegion(jhandle, 0, 1, &out);
 }
 

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -12,6 +12,7 @@
   limitations under the License.
 */
 
+#include <cstdint>
 #include <xgboost/c_api.h>
 #include <xgboost/base.h>
 #include <xgboost/logging.h>
@@ -23,7 +24,7 @@
 // helper functions
 // set handle
 void setHandle(JNIEnv *jenv, jlongArray jhandle, void* handle) {
-  long out = (long) handle;
+  int64_t out = (int64_t) handle;
   jenv->SetLongArrayRegion(jhandle, 0, 1, &out);
 }
 
@@ -87,7 +88,7 @@ XGB_EXTERN_C int XGBoost4jCallbackDataIterNext(
         cbatch.weight = nullptr;
       }
       long max_elem = cbatch.offset[cbatch.size];
-      cbatch.index = jenv->GetIntArrayElements(jindex, 0);
+      cbatch.index = (int*) jenv->GetIntArrayElements(jindex, 0);
       cbatch.value = jenv->GetFloatArrayElements(jvalue, 0);
       CHECK_EQ(jenv->GetArrayLength(jindex), max_elem)
           << "batch.index.length must equal batch.offset.back()";
@@ -107,7 +108,7 @@ XGB_EXTERN_C int XGBoost4jCallbackDataIterNext(
         jenv->ReleaseFloatArrayElements(jweight, cbatch.weight, 0);
         jenv->DeleteLocalRef(jweight);
       }
-      jenv->ReleaseIntArrayElements(jindex, cbatch.index, 0);
+      jenv->ReleaseIntArrayElements(jindex, (jint*) cbatch.index, 0);
       jenv->DeleteLocalRef(jindex);
       jenv->ReleaseFloatArrayElements(jvalue, cbatch.value, 0);
       jenv->DeleteLocalRef(jvalue);
@@ -199,7 +200,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   jfloat* data = jenv->GetFloatArrayElements(jdata, 0);
   bst_ulong nindptr = (bst_ulong)jenv->GetArrayLength(jindptr);
   bst_ulong nelem = (bst_ulong)jenv->GetArrayLength(jdata);
-  int ret = (jint) XGDMatrixCreateFromCSR((unsigned long const *)indptr, (unsigned int const *)indices, (float const *)data, nindptr, nelem, &result);
+  jint ret = (jint) XGDMatrixCreateFromCSR((bst_ulong const *)indptr, (unsigned int const *)indices, (float const *)data, nindptr, nelem, &result);
   setHandle(jenv, jout, result);
   //Release
   jenv->ReleaseLongArrayElements(jindptr, indptr, 0);
@@ -222,7 +223,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   bst_ulong nindptr = (bst_ulong)jenv->GetArrayLength(jindptr);
   bst_ulong nelem = (bst_ulong)jenv->GetArrayLength(jdata);
 
-  int ret = (jint) XGDMatrixCreateFromCSC((unsigned long const *)indptr, (unsigned int const *)indices, (float const *)data, nindptr, nelem, &result);
+  jint ret = (jint) XGDMatrixCreateFromCSC((bst_ulong const *)indptr, (unsigned int const *)indices, (float const *)data, nindptr, nelem, &result);
   setHandle(jenv, jout, result);
   //release
   jenv->ReleaseLongArrayElements(jindptr, indptr, 0);
@@ -243,7 +244,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   jfloat* data = jenv->GetFloatArrayElements(jdata, 0);
   bst_ulong nrow = (bst_ulong)jnrow;
   bst_ulong ncol = (bst_ulong)jncol;
-  int ret = (jint) XGDMatrixCreateFromMat((float const *)data, nrow, ncol, jmiss, &result);
+  jint ret = (jint) XGDMatrixCreateFromMat((float const *)data, nrow, ncol, jmiss, &result);
   setHandle(jenv, jout, result);
   //release
   jenv->ReleaseFloatArrayElements(jdata, data, 0);
@@ -263,7 +264,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSliceDMat
   jint* indexset = jenv->GetIntArrayElements(jindexset, 0);
   bst_ulong len = (bst_ulong)jenv->GetArrayLength(jindexset);
 
-  int ret = XGDMatrixSliceDMatrix(handle, (int const *)indexset, len, &result);
+  jint ret = (jint) XGDMatrixSliceDMatrix(handle, (int const *)indexset, len, &result);
   setHandle(jenv, jout, result);
   //release
   jenv->ReleaseIntArrayElements(jindexset, indexset, 0);
@@ -649,7 +650,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterLoadRabit
   BoosterHandle handle = (BoosterHandle) jhandle;
   int version;
   int ret = XGBoosterLoadRabitCheckpoint(handle, &version);
-  jenv->SetIntArrayRegion(jout, 0, 1, &version);
+  jint jversion = version;
+  jenv->SetIntArrayRegion(jout, 0, 1, &jversion);
   return ret;
 }
 
@@ -721,7 +723,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_RabitTrackerPrint
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_RabitGetRank
   (JNIEnv *jenv, jclass jcls, jintArray jout) {
-  int rank = RabitGetRank();
+  jint rank = RabitGetRank();
   jenv->SetIntArrayRegion(jout, 0, 1, &rank);
   return 0;
 }
@@ -733,7 +735,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_RabitGetRank
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_RabitGetWorldSize
   (JNIEnv *jenv, jclass jcls, jintArray jout) {
-  int out = RabitGetWorldSize();
+  jint out = RabitGetWorldSize();
   jenv->SetIntArrayRegion(jout, 0, 1, &out);
   return 0;
 }
@@ -745,7 +747,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_RabitGetWorldSize
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_RabitVersionNumber
   (JNIEnv *jenv, jclass jcls, jintArray jout) {
-  int out = RabitVersionNumber();
+  jint out = RabitVersionNumber();
   jenv->SetIntArrayRegion(jout, 0, 1, &out);
   return 0;
 }


### PR DESCRIPTION
This pull request fixes issue #1491. It switches `bst_ulong` over to `uint64_t`
from `unsigned long` which is a consistent size on all supported 64-bit
platforms. There are small changes to the Makefile and create_jni.bat files to
cope with the different file locations. The JNI wrapper itself has several types
changed over to `jint` from `int`, and a few casts. It also adds an ifdef for
MacOS as there Java defines `jlong` to be `long int`, and gcc defines `int64_t`
to be `long long int`, which despite both of them being 64-bit integers are
different types. I tested this against the Java & Scala unit tests, and also
that the Python & R libraries built and imported successfully on Windows (7 and
10, MingW64 gcc 5.3), Linux (Ubuntu 16.04 and RHEL7) and MacOS (10.11 with
Macports GCC 5.3).

The correct build procedure on Windows for the JVM packages is now to run
"mingw32-make jvm" before running the maven build inside jvm-packages. This
still has issues if the JAVA_HOME path has spaces in it, so make sure these are
escaped or the path doesn't have spaces.

This pull request doesn't currently update any documentation, but I'm happy to
do that as necessary.