### PR TITLE
correct CalcDCG in rank_metric.cc and rank_obj.cc

### DIFF
--- a/src/metric/rank_metric.cc
+++ b/src/metric/rank_metric.cc
@@ -257,7 +257,7 @@ struct EvalNDCG : public EvalRankList{
     for (size_t i = 0; i < rec.size() && i < this->topn_; ++i) {
       const unsigned rel = rec[i].second;
       if (rel != 0) {
-        sumdcg += ((1 << rel) - 1) / std::log(i + 2.0) * std::log(2.0);
+        sumdcg += ((1 << rel) - 1) / std::log2(i + 2.0);
       }
     }
     return static_cast<float>(sumdcg);

--- a/src/metric/rank_metric.cc
+++ b/src/metric/rank_metric.cc
@@ -257,7 +257,7 @@ struct EvalNDCG : public EvalRankList{
     for (size_t i = 0; i < rec.size() && i < this->topn_; ++i) {
       const unsigned rel = rec[i].second;
       if (rel != 0) {
-        sumdcg += ((1 << rel) - 1) / std::log(i + 2.0);
+        sumdcg += ((1 << rel) - 1) / std::log(i + 2.0) * std::log(2.0);
       }
     }
     return static_cast<float>(sumdcg);

--- a/src/objective/rank_obj.cc
+++ b/src/objective/rank_obj.cc
@@ -215,7 +215,7 @@ class LambdaRankObjNDCG : public LambdaRankObj {
     for (size_t i = 0; i < labels.size(); ++i) {
       const unsigned rel = static_cast<unsigned>(labels[i]);
       if (rel != 0) {
-        sumdcg += ((1 << rel) - 1) / std::log(static_cast<float>(i + 2));
+        sumdcg += ((1 << rel) - 1) / std::log(static_cast<float>(i + 2)) * std::log(2.0);
       }
     }
     return static_cast<float>(sumdcg);

--- a/src/objective/rank_obj.cc
+++ b/src/objective/rank_obj.cc
@@ -215,7 +215,7 @@ class LambdaRankObjNDCG : public LambdaRankObj {
     for (size_t i = 0; i < labels.size(); ++i) {
       const unsigned rel = static_cast<unsigned>(labels[i]);
       if (rel != 0) {
-        sumdcg += ((1 << rel) - 1) / std::log(static_cast<float>(i + 2)) * std::log(2.0);
+        sumdcg += ((1 << rel) - 1) / std::log2(static_cast<float>(i + 2));
       }
     }
     return static_cast<float>(sumdcg);


### PR DESCRIPTION
DCG use log base-2, however `std::log` returns log base-e.