### PR TITLE
simplify installation of R pkg devel version

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -21,9 +21,7 @@ install.packages('xgboost')
 
 You can also install from our weekly updated drat repo:
 ```r
-install.packages("drat", repos="https://cran.rstudio.com")
-drat:::addRepo("dmlc")
-install.packages("xgboost", repos="http://dmlc.ml/drat/", type="source")
+install.packages("xgboost", repos=c("http://dmlc.ml/drat/", getOption("repos")), type="source")
 ```
 
 ***Important*** Due to the usage of submodule, `install_github` is no longer support to install the


### PR DESCRIPTION
While I'm big fan of drat, it isn't really needed here. Below code to reproduce installation from base R. `xgboost` is taken from your drat, while all `xgboost` dependencies are taken from repo defined in `repos` option (default user cran mirror(s)).
```
docker pull r-base
docker run -it r-base
install.packages("xgboost", repos=c("http://dmlc.ml/drat/", getOption("repos")), type="source")
packageVersion("xgboost")
#[1] ‘0.6.0’
```