### PR TITLE
[python-package] Fix the issue #1439

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -163,11 +163,11 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
         maximize_score = maximize
         metric = env.evaluation_result_list[-1][0]
 
-        if any(env.evaluation_result_list[-1][0].split('-')[1].startswith(x)
+        if any(env.evaluation_result_list[-1][0].split('-')[-1].startswith(x)
                for x in maximize_at_n_metrics):
             maximize_score = True
 
-        if any(env.evaluation_result_list[-1][0].split('-')[1].split(":")[0] == x
+        if any(env.evaluation_result_list[-1][0].split('-')[-1].split(":")[0] == x
                for x in maximize_metrics):
             maximize_score = True
 


### PR DESCRIPTION
        *Fix 1439
        *Fix python_wrapper when eval set name contain '-' will cause early_stop maximize variable con't set to True propely

Change-Id: Ib0595afd4ae7b445a84c00a3a8faeccc506c6d13