### PR TITLE
Fix a bug to handle Executable and Library with same name (xgboost) correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,9 @@ add_subdirectory(dmlc-core)
 
 add_library(rabit STATIC ${RABIT_SOURCES})
 
-add_executable(xgboost ${SOURCES})
-add_library(libxgboost SHARED ${SOURCES})
+add_executable(xgboost-bin ${SOURCES})
+SET_TARGET_PROPERTIES(xgboost-bin PROPERTIES OUTPUT_NAME xgboost)
+add_library(xgboost SHARED ${SOURCES})
 
+target_link_libraries(xgboost-bin dmlccore rabit)
 target_link_libraries(xgboost dmlccore rabit)
-target_link_libraries(libxgboost dmlccore rabit)


### PR DESCRIPTION
add_library(libxgboost SHARED ${SOURCES}) builds a library named
liblibxgboost.so; However, simply changing it to add_library(xgboost ...)
won't work, as add_executable(xgboost ...) and add_library(xgbboost ...)
will then have the same target name. This patch correctly handles the
same-name situation through SET_TARGET_PROPERTIES.