### PR TITLE
fix the problem that there is no libxgboost.dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,17 @@ add_subdirectory(dmlc-core)
 
 add_library(rabit STATIC ${RABIT_SOURCES})
 
-add_executable(xgboost-bin ${SOURCES})
-SET_TARGET_PROPERTIES(xgboost-bin PROPERTIES OUTPUT_NAME xgboost)
-add_library(xgboost SHARED ${SOURCES})
+if(MSVC)
+    add_executable(xgboost ${SOURCES})
+    add_library(libxgboost SHARED ${SOURCES})
 
-target_link_libraries(xgboost-bin dmlccore rabit)
-target_link_libraries(xgboost dmlccore rabit)
+    target_link_libraries(xgboost dmlccore rabit)
+    target_link_libraries(libxgboost dmlccore rabit)
+else()
+    add_executable(xgboost-bin ${SOURCES})
+    SET_TARGET_PROPERTIES(xgboost-bin PROPERTIES OUTPUT_NAME xgboost)
+    add_library(xgboost SHARED ${SOURCES})
+
+    target_link_libraries(xgboost-bin dmlccore rabit)
+    target_link_libraries(xgboost dmlccore rabit)
+endif()


### PR DESCRIPTION
fix the problem that there is no libxgboost.dll built with Visual Studio.