### PR TITLE
Add option on OSX to use macports (Issue #1667)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ endif
 # it is useful for pip install compiling-on-the-fly
 OS := $(shell uname)
 ifeq ($(OS), Darwin)
-export CC = $(if $(shell which gcc-6),gcc-6,clang)
-export CXX = $(if $(shell which g++-6),g++-6,clang++)
+export CC = $(if $(shell which gcc-6),gcc-6,$(if $(shell which gcc-mp-6), gcc-mp-6, clang))
+export CXX = $(if $(shell which g++-6),g++-6,$(if $(shell which g++-mp-6),g++-mp-6, clang++))
 endif
 
 export LDFLAGS= -pthread -lm $(ADD_LDFLAGS) $(DMLC_LDFLAGS) $(PLUGIN_LDFLAGS)


### PR DESCRIPTION
Problem and fix of this PR were described in Issue #1667.
Basically it adds the following to the Makefile in order to allow macports users on OS X to use gcc-6 for installation.
```
export CC = $(if $(shell which gcc-6),gcc-6,$(if $(shell which gcc-mp-6), gcc-mp-6, clang))
export CXX = $(if $(shell which g++-6),g++-6,$(if $(shell which g++-mp-6),g++-mp-6, clang++))
```
Please note that the documentation should be updated accordingly (let me know if I can help).