### PR TITLE
Have ConsoleLogger log to stderr instead of stdout

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -12,7 +12,7 @@ namespace xgboost {
 
 #if XGBOOST_CUSTOMIZE_LOGGER == 0
 ConsoleLogger::~ConsoleLogger() {
-  std::cout << log_stream_.str() << std::endl;
+  std::cerr << log_stream_.str() << std::endl;
 }
 
 TrackerLogger::~TrackerLogger() {


### PR DESCRIPTION
On Unix systems, it's common for programs to read their input from stdin, and
write their output to stdout.  Messages should be written to stderr, where they
won't corrupt a program's output, and where they can be seen by the user even
if the output is being redirected.

This is mostly a problem when XGBoost is being used from Python or from another
program.
