### PR TITLE
Adding data to the return list for use in other functions

### DIFF
--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -177,10 +177,13 @@ xgb.Booster.check <- function(bst, saveraw = TRUE) {
 #'
 #' @rdname predict.xgb.Booster
 #' @export
-predict.xgb.Booster <- function(object, newdata, missing = NA,
+predict.xgb.Booster <- function(object, newdata = NULL, missing = NA,
     outputmargin = FALSE, ntreelimit = NULL, predleaf = FALSE, reshape = FALSE, ...) {
 
   object <- xgb.Booster.check(object, saveraw = FALSE)
+  if(is.null(newdata)){
+    newdata = object$data
+  }
   if (class(newdata) != "xgb.DMatrix")
     newdata <- xgb.DMatrix(newdata, missing = missing)
   if (is.null(ntreelimit))

--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -222,7 +222,8 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
     callbacks = callbacks,
     evaluation_log = evaluation_log,
     niter = end_iteration,
-    folds = folds
+    folds = folds,
+    data = data
   )
   ret <- c(ret, basket)
 

--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -348,6 +348,7 @@ xgb.train <- function(params = list(), data, nrounds, watchlist = list(),
   bst$call <- match.call()
   bst$params <- params
   bst$callbacks <- callbacks
+  bst$data <- data
   
   return(bst)
 }


### PR DESCRIPTION
It would be convenient if the xgboost objects retained the original data frame so other functions can use the object to do their work.  In R normally the predict function utilizes this object by default so newData does not have to be provided to generate predictions.  Also, I would like to have it available so I can extend the functionality of my R package to generate model metrics for xgboost models automatically

https://github.com/JackStat/ModelMetrics/issues/13