### PR TITLE
n_first_tree = 1 should select only the first tree

### DIFF
--- a/R-package/R/xgb.model.dt.tree.R
+++ b/R-package/R/xgb.model.dt.tree.R
@@ -85,7 +85,7 @@ xgb.model.dt.tree <- function(feature_names = NULL, model = NULL, text = NULL,
   td[, Tree := cumsum(ifelse(is.na(Tree), 0L, Tree)) - 1L]
   
   n_first_tree <- min(max(td$Tree), n_first_tree)
-  td <- td[Tree <= n_first_tree & !grepl('^booster', t)]
+  td <- td[Tree < n_first_tree & !grepl('^booster', t)]
   
   td[, Node := stri_match_first_regex(t, "(\\d+):")[,2] %>% as.numeric ]
   td[, ID := add.tree.id(Node, Tree)]


### PR DESCRIPTION
Currently, calling xgb.plot.tree with n_first_tree = 1 plots the first two trees. This is an attempt to correct this bug.
Here is a snippet to see the bug:
```
library(xgboost)
data(agaricus.train, package='xgboost')
data(agaricus.test, package='xgboost')
train <- agaricus.train
test <- agaricus.test
bstSparse <- xgboost(data = train$data, label = train$label, max.depth = 2, eta = 1, nthread = 2, nround = 2, objective = "binary:logistic")
xgb.plot.tree(model = bstSparse, n_first_tree = 1)
```