### PR TITLE
add default max_delta_step to for count:poisson

### DIFF
--- a/src/objective/regression_obj.cc
+++ b/src/objective/regression_obj.cc
@@ -150,7 +150,7 @@ XGBOOST_REGISTER_OBJECTIVE(LogisticRaw, "binary:logitraw")
 struct PoissonRegressionParam : public dmlc::Parameter<PoissonRegressionParam> {
   float max_delta_step;
   DMLC_DECLARE_PARAMETER(PoissonRegressionParam) {
-    DMLC_DECLARE_FIELD(max_delta_step).set_lower_bound(0.0f)
+    DMLC_DECLARE_FIELD(max_delta_step).set_lower_bound(0.0f).set_default(0.7f)
         .describe("Maximum delta step we allow each weight estimation to be." \
                   " This parameter is required for possion regression.");
   }


### PR DESCRIPTION
unable to load, save, or dump model that was created in a different R session unless setting a default for max_delta_step.  this is related to issues #1236 and #1253.