### PR TITLE
[jvm-packages] Leverage the Spark ml API to read DataFrame from files in LibSVM format.

### DIFF
--- a/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/spark/SparkWithDataFrame.scala
+++ b/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/spark/SparkWithDataFrame.scala
@@ -17,11 +17,9 @@
 package ml.dmlc.xgboost4j.scala.example.spark
 
 import ml.dmlc.xgboost4j.scala.Booster
-import ml.dmlc.xgboost4j.scala.spark.{XGBoost, DataUtils}
-import org.apache.spark.mllib.util.MLUtils
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.{SparkSession, SQLContext, Row}
-import org.apache.spark.{SparkContext, SparkConf}
+import ml.dmlc.xgboost4j.scala.spark.XGBoost
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.SparkConf
 
 object SparkWithDataFrame {
   def main(args: Array[String]): Unit = {
@@ -41,16 +39,8 @@ object SparkWithDataFrame {
     val inputTrainPath = args(2)
     val inputTestPath = args(3)
     // build dataset
-    val trainRDDOfRows = MLUtils.loadLibSVMFile(sparkSession.sparkContext, inputTrainPath).
-      map{ labeledPoint => Row(labeledPoint.features, labeledPoint.label)}
-    val trainDF = sparkSession.createDataFrame(trainRDDOfRows, StructType(
-      Array(StructField("features", ArrayType(FloatType)), StructField("label", IntegerType))))
-    val testRDDOfRows = MLUtils.loadLibSVMFile(sparkSession.sparkContext, inputTestPath).
-      zipWithIndex().map{ case (labeledPoint, id) =>
-      Row(id, labeledPoint.features, labeledPoint.label)}
-    val testDF = sparkSession.createDataFrame(testRDDOfRows, StructType(
-      Array(StructField("id", LongType),
-        StructField("features", ArrayType(FloatType)), StructField("label", IntegerType))))
+    val trainDF = sparkSession.sqlContext.read.format("libsvm").load(inputTrainPath)
+    val testDF = sparkSession.sqlContext.read.format("libsvm").load(inputTestPath)
     // start training
     val paramMap = List(
       "eta" -> 0.1f,


### PR DESCRIPTION
Currently the way ```SparkWithDataFrame.scala``` reads data in LibSBM format is still calling the old API ```MLUtils.loadLibSVMFile``` from mllib pakcage, which is causing the following errors with Spark 2.0:

``` 
User class threw exception: java.lang.IllegalArgumentException: requirement failed: Column features must be of type org.apache.spark.ml.linalg.VectorUDT@3bfc3ba7 but was actually ArrayType(FloatType,true). 
```

A cleaner way of reading ```DataFrame``` from files in LibSVM format is to leverage the Spark ml API, as proposed in this PR, which is also more intuitive for folks who are interested to learn XGBoost with Spark 2.0.

The change proposed in this PR has been successfully tested on Spark 2.0.0 hosted on a cluster managed by Hadoop 2.6 (Yarn).