### PR TITLE
c_api.cc: Bring back silent argument

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -207,7 +207,7 @@ int XGDMatrixCreateFromFile(const char *fname,
     LOG(CONSOLE) << "XGBoost distributed mode detected, "
                  << "will split data among workers";
   }
-  *out = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, false, true));
+  *out = new std::shared_ptr<DMatrix>(DMatrix::Load(fname, silent != 0, true));
   API_END();
 }
 


### PR DESCRIPTION
In ecb3a271bed151252fb048528ce5a90ad75bb68f the silent argument
in XGDMatrixCreateFromFile of c_api.cc was always overridden to
be false. This disabled the functionality to hide log messages.

This commit reverts that part to enable the hiding of log messages.

Fixes https://github.com/dmlc/xgboost/issues/1216
Fixes https://github.com/dmlc/xgboost/issues/1742
