### PR TITLE
[jvm-packages] xgboost4j: publishing sources along with bins

### DIFF
--- a/doc/jvm/index.md
+++ b/doc/jvm/index.md
@@ -13,6 +13,25 @@ Before you install XGBoost4J, you need to define environment variable `JAVA_HOME
 
 After your `JAVA_HOME` is defined correctly, it is as simple as run `mvn package` under jvm-packages directory to install XGBoost4J. You can also skip the tests by running `mvn -DskipTests=true package`, if you are sure about the correctness of your local setup.
 
+To publish the artifacts to your local maven repository, run
+
+    mvn install
+
+Or, if you would like to skip tests, run 
+
+    mvn -DskipTests install
+
+This command will publish the xgboost binaries, the compiled java classes as well as the java sources to your local repository. Then you can use XGBoost4J in your Java projects by including the following dependency in `pom.xml`:
+
+    <dependency>
+      <groupId>ml.dmlc</groupId>
+      <artifactId>xgboost4j</artifactId>
+      <version>0.7</version>
+    </dependency>
+
+
+
+
 After integrating with Dataframe/Dataset APIs of Spark 2.0, XGBoost4J-Spark only supports compile with Spark 2.x. You can build XGBoost4J-Spark as a component of XGBoost4J by running `mvn package`, and you can specify the version of spark with `mvn -Dspark.version=2.0.0 package`.   (To continue working with Spark 1.x, the users are supposed to update pom.xml by modifying the properties like `spark.version`, `scala.version`, and `scala.binary.version`. Users also need to change the implemention by replacing SparkSession with SQLContext and the type of API parameters from Dataset[_] to Dataframe)
 
 Contents

--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -159,6 +159,14 @@
                             <goal>compile</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>add-source</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
 

--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -78,6 +78,20 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.0</version>


### PR DESCRIPTION
This code snippet publishes the sources to the maven local repo along with the binaries. 

With this change it is possible to use Java IDEs functions like "jump to function" and see the actual source code - as they automatically get the sources from the maven repo. 