### PR TITLE
add path exists check when loading DMatrix to avoid crash in C++

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -262,7 +262,7 @@ class DMatrix(object):
                                                          int(silent),
                                                          ctypes.byref(self.handle)))
             else:
-                raise IOError('The \'' +data + '\' path does not exist!')
+                raise IOError('The \'' + data + '\' path does not exist!')
         elif isinstance(data, scipy.sparse.csr_matrix):
             self._init_from_csr(data)
         elif isinstance(data, scipy.sparse.csc_matrix):

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -256,10 +256,13 @@ class DMatrix(object):
         label = _maybe_pandas_label(label)
 
         if isinstance(data, STRING_TYPES):
-            self.handle = ctypes.c_void_p()
-            _check_call(_LIB.XGDMatrixCreateFromFile(c_str(data),
-                                                     int(silent),
-                                                     ctypes.byref(self.handle)))
+            if os.path.exists(data):
+                self.handle = ctypes.c_void_p()
+                _check_call(_LIB.XGDMatrixCreateFromFile(c_str(data),
+                                                         int(silent),
+                                                         ctypes.byref(self.handle)))
+            else:
+                raise FileExistsError('The \'' +data + '\' path does not exist!')
         elif isinstance(data, scipy.sparse.csr_matrix):
             self._init_from_csr(data)
         elif isinstance(data, scipy.sparse.csc_matrix):

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -262,7 +262,7 @@ class DMatrix(object):
                                                          int(silent),
                                                          ctypes.byref(self.handle)))
             else:
-                raise FileExistsError('The \'' +data + '\' path does not exist!')
+                raise IOError('The \'' +data + '\' path does not exist!')
         elif isinstance(data, scipy.sparse.csr_matrix):
             self._init_from_csr(data)
         elif isinstance(data, scipy.sparse.csc_matrix):


### PR DESCRIPTION
Currently when running `dtrain = xgb.DMatrix("train.buffer")`, if the file doesn't exist, the program would crash in C++. When running in jupyter notebooks the kernel would crash and have to be restarted, which is annoying. This commit adds a check before calling C routines.