### PR TITLE
fix typo on documentation page

### DIFF
--- a/doc/_static/xgboost-theme/index.html
+++ b/doc/_static/xgboost-theme/index.html
@@ -32,7 +32,7 @@
         <p>Runs on Windows, Linux and OS X, as well as various cloud Platforms</p>
       </div>
       <div class="col-lg-4 col-sm-6">
-        <h3><i class="fa fa-wrench"></i>Multiple Lanuages</h3>
+        <h3><i class="fa fa-wrench"></i>Multiple Languages</h3>
         <p>Supports multiple languages including C++, Python, R, Java, Scala, Julia.</p>
       </div>
       <div class="col-lg-4 col-sm-6">


### PR DESCRIPTION
This pull request replaces "Lanuages" -> "Languages" in the documentation landing page.