### PR TITLE
config.mk: Set TEST_COVER to 0 by default

### DIFF
--- a/make/config.mk
+++ b/make/config.mk
@@ -50,7 +50,7 @@ LIBJVM=$(JAVA_HOME)/jre/lib/amd64/server
 # whether to test with coverage measurement or not. (only used for `make cover`)
 # measured with gcov and html report generated with lcov if it is installed.
 # this disables optimization to ensure coverage information is correct
-TEST_COVER = 1
+TEST_COVER = 0
 
 # path to gtest library (only used when $BUILD_TEST=1)
 # there should be an include path in $GTEST_PATH/include and library in $GTEST_PATH/lib


### PR DESCRIPTION
Set the TEST_COVER to 0 by default so it uses optimization
-O3 when compiling.