### PR TITLE
[R] fix #1903

### DIFF
--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -185,6 +185,8 @@ predict.xgb.Booster <- function(object, newdata, missing = NA,
     newdata <- xgb.DMatrix(newdata, missing = missing)
   if (is.null(ntreelimit))
     ntreelimit <- NVL(object$best_ntreelimit, 0)
+  if (NVL(object$params[['booster']], '') == 'gblinear')
+    ntreelimit <- 0
   if (ntreelimit < 0)
     stop("ntreelimit cannot be negative")
   


### PR DESCRIPTION
Enforce ntreelimit=0 in predict for gblinear.