### PR TITLE
Make lib path relatrive to fix setup error #1932

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -16,7 +16,7 @@ libpath_py = os.path.join(CURRENT_DIR, 'xgboost/libpath.py')
 libpath = {'__file__': libpath_py}
 exec(compile(open(libpath_py, "rb").read(), libpath_py, 'exec'), libpath, libpath)
 
-LIB_PATH = libpath['find_lib_path']()
+LIB_PATH = [os.path.relpath(libfile, CURRENT_DIR) for libfile in libpath['find_lib_path']()]
 print("Install libxgboost from: %s" % LIB_PATH)
 # Please use setup_pip.py for generating and deploying pip installation
 # detailed instruction in setup_pip.py


### PR DESCRIPTION
fixing error on `python setup.py install`:
```
setup() arguments must *always* be /-separated paths relative to the
setup.py directory, *never* absolute paths.
```

see #1932