### PR TITLE
fix ylim with max_num_features in python plot_importance

### DIFF
--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -73,7 +73,6 @@ def plot_importance(booster, ax=None, height=0.2,
     tuples = [(k, importance[k]) for k in importance]
     if max_num_features is not None:
         tuples = sorted(tuples, key=lambda x: x[1])[-max_num_features:]
-        ylim = (-1, max_num_features)
     else:
         tuples = sorted(tuples, key=lambda x: x[1])
     labels, values = zip(*tuples)
@@ -101,7 +100,7 @@ def plot_importance(booster, ax=None, height=0.2,
         if not isinstance(ylim, tuple) or len(ylim) != 2:
             raise ValueError('ylim must be a tuple of 2 elements')
     else:
-        ylim = (-1, len(importance))
+        ylim = (-1, len(values))
     ax.set_ylim(ylim)
 
     if title is not None:


### PR DESCRIPTION
follow #1963 

1. not overwrite ylim if ylim is not None
2. use num_of_features as ylim instead of max_num_features if max_num_features > num_of_features