### PR TITLE
Add prediction of feature contributions

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -382,6 +382,7 @@ XGB_DLL int XGBoosterEvalOneIter(BoosterHandle handle,
  *          0:normal prediction
  *          1:output margin instead of transformed value
  *          2:output leaf index of trees instead of leaf value, note leaf index is unique per tree
+ *          4:output feature contributions of all trees instead of predictions
  * \param ntree_limit limit number of trees used for prediction, this is only valid for boosted trees
  *    when the parameter is set to 0, we will use all the trees
  * \param out_len used to store length of returning result

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -107,6 +107,19 @@ class GradientBooster {
   virtual void PredictLeaf(DMatrix* dmat,
                            std::vector<bst_float>* out_preds,
                            unsigned ntree_limit = 0) = 0;
+
+  /*!
+   * \brief predict the feature contributions of each tree, the output will be nsample * (nfeats + 1) vector
+   *        this is only valid in gbtree predictor
+   * \param dmat feature matrix
+   * \param out_contribs output vector to hold the contributions
+   * \param ntree_limit limit the number of trees used in prediction, when it equals 0, this means
+   *    we do not limit number of trees
+   */
+  virtual void PredictContribution(DMatrix* dmat,
+                           std::vector<bst_float>* out_contribs,
+                           unsigned ntree_limit = 0) = 0;
+
   /*!
    * \brief dump the model in the requested format
    * \param fmap feature map that may help give interpretations of feature

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -103,12 +103,14 @@ class Learner : public rabit::Serializable {
    * \param ntree_limit limit number of trees used for boosted tree
    *   predictor, when it equals 0, this means we are using all the trees
    * \param pred_leaf whether to only predict the leaf index of each tree in a boosted tree predictor
+   * \param pred_contribs whether to only predict the feature contributions of all trees
    */
   virtual void Predict(DMatrix* data,
                        bool output_margin,
                        std::vector<bst_float> *out_preds,
                        unsigned ntree_limit = 0,
-                       bool pred_leaf = false) const = 0;
+                       bool pred_leaf = false,
+                       bool pred_contribs = false) const = 0;
   /*!
    * \brief Set additional attribute to the Booster.
    *  The property will be saved along the booster.

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -562,10 +562,11 @@ inline bst_float RegTree::Predict(const RegTree::FVec& feat, unsigned root_id) c
 }
 
 inline void RegTree::FillNodeMeanValues() {
-  if (this->node_mean_values.size() > 0) {
+  size_t num_nodes = this->param.num_nodes;
+  if (this->node_mean_values.size() == num_nodes) {
     return;
   }
-  this->node_mean_values.resize(this->param.num_nodes);
+  this->node_mean_values.resize(num_nodes);
   int root_id = 0;
   this->FillNodeMeanValue(root_id);
 }

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -567,8 +567,9 @@ inline void RegTree::FillNodeMeanValues() {
     return;
   }
   this->node_mean_values.resize(num_nodes);
-  int root_id = 0;
-  this->FillNodeMeanValue(root_id);
+  for (int root_id = 0; root_id < param.num_roots; ++root_id) {
+    this->FillNodeMeanValue(root_id);
+  }
 }
 
 inline bst_float RegTree::FillNodeMeanValue(int nid) {

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -911,7 +911,8 @@ class Booster(object):
         self._validate_features(data)
         return self.eval_set([(data, name)], iteration)
 
-    def predict(self, data, output_margin=False, ntree_limit=0, pred_leaf=False):
+    def predict(self, data, output_margin=False, ntree_limit=0, pred_leaf=False,
+                pred_contribs=False):
         """
         Predict with data.
 
@@ -937,6 +938,12 @@ class Booster(object):
             Note that the leaf index of a tree is unique per tree, so you may find leaf 1
             in both tree 1 and tree 0.
 
+        pred_contribs : bool
+            When this option is on, the output will be a matrix of (nsample, nfeats+1)
+            with each record indicating the feature contributions of all trees. The sum of
+            all feature contributions is equal to the prediction. Note that the bias is added
+            as the final column, on top of the regular features.
+
         Returns
         -------
         prediction : numpy array
@@ -946,6 +953,8 @@ class Booster(object):
             option_mask |= 0x01
         if pred_leaf:
             option_mask |= 0x02
+        if pred_contribs:
+            option_mask |= 0x04
 
         self._validate_features(data)
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -622,7 +622,8 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
       static_cast<std::shared_ptr<DMatrix>*>(dmat)->get(),
       (option_mask & 1) != 0,
       &preds, ntree_limit,
-      (option_mask & 2) != 0);
+      (option_mask & 2) != 0,
+      (option_mask & 4) != 0);
   *out_result = dmlc::BeginPtr(preds);
   *len = static_cast<xgboost::bst_ulong>(preds.size());
   API_END();

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -223,6 +223,11 @@ class GBLinear : public GradientBooster {
                    unsigned ntree_limit) override {
     LOG(FATAL) << "gblinear does not support predict leaf index";
   }
+  void PredictContribution(DMatrix* p_fmat,
+                           std::vector<bst_float>* out_contribs,
+                           unsigned ntree_limit) override {
+    LOG(FATAL) << "gblinear does not support predict contributions";
+  }
 
   std::vector<std::string> DumpModel(const FeatureMap& fmap,
                                      bool with_stats,

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -590,11 +590,6 @@ class GBTree : public GradientBooster {
         size_t row_idx = static_cast<size_t>(batch.base_rowid + i);
         unsigned root_id = info.GetRoot(row_idx);
         RegTree::FVec &feats = thread_temp[omp_get_thread_num()];
-        // determine learning_rate
-        // NOTE: there should be a better way of doing this
-        int leaf_id = trees[0]->GetLeafIndex(feats, root_id);
-        float learning_rate =
-          (*trees[0])[leaf_id].leaf_value() / trees[0]->stat(leaf_id).base_weight;
         // loop over all classes
         for (int gid = 0; gid < mparam.num_output_group; ++gid) {
           bst_float *p_contribs = &contribs[(row_idx * mparam.num_output_group + gid) * ncolumns];
@@ -604,6 +599,11 @@ class GBTree : public GradientBooster {
             if (tree_info[j] != gid) {
               continue;
             }
+            // determine learning_rate
+            // NOTE: there should be a better way of doing this
+            int leaf_id = trees[j]->GetLeafIndex(feats, root_id);
+            float learning_rate =
+              (*trees[j])[leaf_id].leaf_value() / trees[j]->stat(leaf_id).base_weight;
             trees[j]->CalculateContributions(feats, root_id, learning_rate, p_contribs);
           }
           feats.Drop(batch[i]);

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -400,8 +400,11 @@ class LearnerImpl : public Learner {
                bool output_margin,
                std::vector<bst_float> *out_preds,
                unsigned ntree_limit,
-               bool pred_leaf) const override {
-    if (pred_leaf) {
+               bool pred_leaf,
+               bool pred_contribs) const override {
+    if (pred_contribs) {
+      gbm_->PredictContribution(data, out_preds, ntree_limit);
+    } else if (pred_leaf) {
       gbm_->PredictLeaf(data, out_preds, ntree_limit);
     } else {
       this->PredictRaw(data, out_preds, ntree_limit);


### PR DESCRIPTION
This implements the idea described at http://blog.datadive.net/interpreting-random-forests/
which tries to give insight in how a prediction is composed of its feature contributions
and a bias.

The calculation of the node values is based on the findings of @SauceCat at https://github.com/dmlc/xgboost/issues/1986.

Open issues:
 1. I added this functionality to `XGBoosterPredict()` as another value to `option_mask`. However it is mutually exclusive with the `PredictLeaf()` and `PredictRaw()` options, so it feels wrong to being able to pass `0x07` to this function (which is no different from `0x04`)
 1. to calculate the values at each node, I multiply the learning rate with the `base_weight` property. However, the `learning_rate` value seems to be unavailable in `GBTree` (or `RegTree` for that matter). So the code calculates it by dividing the leaf value with the base weight, which is pretty hacky.
 1. only the Python bindings have been updated to expose this new functionality