### PR TITLE
base_margin was not copied by XGDMatrixSliceDMatrix

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -400,6 +400,9 @@ XGB_DLL int XGDMatrixSliceDMatrix(DMatrixHandle handle,
     if (src.info.weights.size() != 0) {
       ret.info.weights.push_back(src.info.weights[ridx]);
     }
+    if (src.info.base_margin.size() != 0) {
+      ret.info.base_margin.push_back(src.info.base_margin[ridx]);
+    }
     if (src.info.root_index.size() != 0) {
       ret.info.root_index.push_back(src.info.root_index[ridx]);
     }


### PR DESCRIPTION
This resolves #2006. I have locally recompiled the new version and can verify that this fix indeed fixes the issue (base_margin is now copied and sliced accordingly during CV). 
Thanks.