### PR TITLE
 update online prediction function in learner.h

### DIFF
--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -188,9 +188,9 @@ inline void Learner::Predict(const SparseBatch::Inst& inst,
                              std::vector<bst_float>* out_preds,
                              unsigned ntree_limit) const {
   gbm_->Predict(inst, out_preds, ntree_limit);
-  if (out_preds->size() == 1) {
-    (*out_preds)[0] += base_score_;
-  }
+  //if (out_preds->size() == 1) {
+  //  (*out_preds)[0] += base_score_;
+  //}
   if (!output_margin) {
     obj_->PredTransform(out_preds);
   }


### PR DESCRIPTION
在线预测Predict(const SparseBatch::Inst& inst, ...)与批量预测Predict(DMatrix * p_fmat, ...) 针对同一批数据预测结果不同，定位后发现问题出在每次加载模型（learner->Load()）之后，参数base_score_ 值都不相同。而批量预测代码中没有用到base_score_参数，而在线预测实现中会用到base_score_参数（第191-193行），如果注释掉这个if条件，那么单样本预测和批量预测结果才一致。两个问题请教：
1. 为什么批量预测没用到base_score_参数，而单样本预测要用？（都是二分类问题）
2. base_score_的作用是什么？有什么物理意义？