### PR TITLE
fix online prediction function in learner.h

### DIFF
--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -188,9 +188,6 @@ inline void Learner::Predict(const SparseBatch::Inst& inst,
                              std::vector<bst_float>* out_preds,
                              unsigned ntree_limit) const {
   gbm_->Predict(inst, out_preds, ntree_limit);
-  if (out_preds->size() == 1) {
-    (*out_preds)[0] += base_score_;
-  }
   if (!output_margin) {
     obj_->PredTransform(out_preds);
   }


### PR DESCRIPTION
I use the online prediction function(`inline void Predict(const SparseBatch::Inst &inst, ... ) const;`), the results obtained are different from the results of the batch prediction function(`  virtual void Predict(DMatrix* data, ...) const = 0`). After the investigation found that the online prediction function using the `base_score_` parameters, and the batch prediction function is not used in this parameter. It is found that the `base_score_` values are different when the same model file is loaded many times.

```
1st times：base_score_: 6.69023e-21
2nd times：base_score_: -3.7668e+19
3rd times：base_score_: 5.40507e+07
```
 Online prediction results are affected by `base_score_` parameters. After deleting the if condition(`if (out_preds->size() == 1)`) , the online prediction is consistent with the batch prediction results, and the xgboost prediction results are consistent with python version.  Therefore, it is likely that the online prediction function is bug