### PR TITLE
[trivial] Fix typo in Poisson metric name.

### DIFF
--- a/src/metric/elementwise_metric.cc
+++ b/src/metric/elementwise_metric.cc
@@ -124,7 +124,7 @@ struct EvalError : public EvalEWiseBase<EvalError> {
   std::string name_;
 };
 
-struct EvalPoissionNegLogLik : public EvalEWiseBase<EvalPoissionNegLogLik> {
+struct EvalPoissonNegLogLik : public EvalEWiseBase<EvalPoissonNegLogLik> {
   const char *Name() const override {
     return "poisson-nloglik";
   }
@@ -205,7 +205,7 @@ XGBOOST_REGISTER_METRIC(Error, "error")
 
 XGBOOST_REGISTER_METRIC(PossionNegLoglik, "poisson-nloglik")
 .describe("Negative loglikelihood for poisson regression.")
-.set_body([](const char* param) { return new EvalPoissionNegLogLik(); });
+.set_body([](const char* param) { return new EvalPoissonNegLogLik(); });
 
 XGBOOST_REGISTER_METRIC(GammaDeviance, "gamma-deviance")
 .describe("Residual deviance for gamma regression.")


### PR DESCRIPTION
Fixes a small typo in the Poisson metric.

BTW I couldn't find an easy way to run the tests for the package.

Looking at `dmlc-core/scripts/packages.mk` it includes a call to `wget http://googletest.googlecode.com/files/gtest-1.7.0.zip` which currently leads to a 404. Let me know if I should open an issue for that, and if there's an easy way to run tests locally, I'm a newbie with C++ testing.