### PR TITLE
print_evaluation callback output on last iteration

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -32,6 +32,9 @@ def _fmt_metric(value, show_stdv=True):
 def print_evaluation(period=1, show_stdv=True):
     """Create a callback that print evaluation result.
 
+    We print the evaluation results every ``period`` iterations
+    and on the first and the last iterations.
+
     Parameters
     ----------
     period : int
@@ -50,7 +53,7 @@ def print_evaluation(period=1, show_stdv=True):
         if env.rank != 0 or len(env.evaluation_result_list) == 0 or period is False:
             return
         i = env.iteration
-        if (i % period == 0 or i + 1 == env.begin_iteration):
+        if (i % period == 0 or i + 1 == env.begin_iteration or i + 1 == env.end_iteration):
             msg = '\t'.join([_fmt_metric(x, show_stdv) for x in env.evaluation_result_list])
             rabit.tracker_print('[%d]\t%s\n' % (i, msg))
     return callback


### PR DESCRIPTION
verbose_eval docs claim it will log the last iteration (http://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train). this is also consistent w/the behavior from 0.4. not a huge deal but I found it handy to see the last iter's result b/c my period is usually large.

this doesn't address logging the last stage found by early_stopping (as noted in docs) as I'm not sure how to do that.