### PR TITLE
[jvm-packages] fix MLlib CrossValidator issues #1941

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
@@ -196,7 +196,7 @@ trait BoosterParams extends Params {
     minChildWeight -> 1, maxDeltaStep -> 0,
     subSample -> 1, colSampleByTree -> 1, colSampleByLevel -> 1,
     lambda -> 1, alpha -> 0, treeMethod -> "auto", sketchEps -> 0.03,
-    scalePosWeight -> 0, sampleType -> "uniform", normalizeType -> "tree",
+    scalePosWeight -> 1, sampleType -> "uniform", normalizeType -> "tree",
     rateDrop -> 0.0, skipDrop -> 0.0, lambdaBias -> 0)
 
   /**


### PR DESCRIPTION
Actually, one friend of mine find out the default scalePosWeight is set to 0, which triggered issue #1941 