### PR TITLE
[jvm-packages] use ML's para system to build the passed-in params to XGBoost

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -246,7 +246,7 @@ object XGBoost extends Serializable {
     require(tracker.start(connectionTimeout), "FAULT: Failed to start tracker")
     tracker
   }
-
+  
   /**
    * various of train()
    * @param trainingData the trainingset represented as RDD

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -246,7 +246,7 @@ object XGBoost extends Serializable {
     require(tracker.start(connectionTimeout), "FAULT: Failed to start tracker")
     tracker
   }
-  
+
   /**
    * various of train()
    * @param trainingData the trainingset represented as RDD

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
@@ -128,13 +128,6 @@ class XGBoostEstimator private[spark](
   }
 
   override def copy(extra: ParamMap): XGBoostEstimator = {
-    val est = defaultCopy(extra).asInstanceOf[XGBoostEstimator]
-    /*
-    // we need to synchronize the params here instead of in the constructor
-    // because we cannot guarantee that params (default implementation) is initialized fully
-    // before the other member variables
-    est.fromParamsToXGBParamMap()
-    */
-    est
+    defaultCopy(extra).asInstanceOf[XGBoostEstimator]
   }
 }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.{Dataset, Row}
  * XGBoost Estimator to produce a XGBoost model
  */
 class XGBoostEstimator private[spark](
-  override val uid: String, private[spark] var xgboostParams: Map[String, Any])
+  override val uid: String, xgboostParams: Map[String, Any])
   extends Predictor[MLVector, XGBoostEstimator, XGBoostModel]
   with LearningTaskParams with GeneralParams with BoosterParams {
 
@@ -40,7 +40,6 @@ class XGBoostEstimator private[spark](
     this(Identifiable.randomUID("XGBoostEstimator"), xgboostParams: Map[String, Any])
 
   def this(uid: String) = this(uid, Map[String, Any]())
-
 
   // called in fromXGBParamMapToParams only when eval_metric is not defined
   private def setupDefaultEvalMetric(): String = {
@@ -93,16 +92,11 @@ class XGBoostEstimator private[spark](
 
   fromXGBParamMapToParams()
 
-  // only called when XGBParamMap is empty, i.e. in the constructor this(String)
-  // TODO: refactor to be functional
-  private def fromParamsToXGBParamMap(): Map[String, Any] = {
-    require(xgboostParams.isEmpty, "fromParamsToXGBParamMap can only be called when" +
-      " XGBParamMap is empty, i.e. in the constructor this(String)")
+  private[spark] def fromParamsToXGBParamMap: Map[String, Any] = {
     val xgbParamMap = new mutable.HashMap[String, Any]()
     for (param <- params) {
       xgbParamMap += param.name -> $(param)
     }
-    xgboostParams = xgbParamMap.toMap
     xgbParamMap.toMap
   }
 
@@ -116,8 +110,9 @@ class XGBoostEstimator private[spark](
         LabeledPoint(label, feature)
     }
     transformSchema(trainingSet.schema, logging = true)
-    val trainedModel = XGBoost.trainWithRDD(instances, xgboostParams, $(round), $(nWorkers),
-      $(customObj), $(customEval), $(useExternalMemory), $(missing)).setParent(this)
+    val trainedModel = XGBoost.trainWithRDD(instances, fromParamsToXGBParamMap,
+      $(round), $(nWorkers), $(customObj), $(customEval), $(useExternalMemory),
+      $(missing)).setParent(this)
     val returnedModel = copyValues(trainedModel)
     if (XGBoost.isClassificationTask(xgboostParams)) {
       val numClass = {
@@ -134,10 +129,12 @@ class XGBoostEstimator private[spark](
 
   override def copy(extra: ParamMap): XGBoostEstimator = {
     val est = defaultCopy(extra).asInstanceOf[XGBoostEstimator]
+    /*
     // we need to synchronize the params here instead of in the constructor
     // because we cannot guarantee that params (default implementation) is initialized fully
-    // before the other params
+    // before the other member variables
     est.fromParamsToXGBParamMap()
+    */
     est
   }
 }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
@@ -196,7 +196,7 @@ trait BoosterParams extends Params {
     minChildWeight -> 1, maxDeltaStep -> 0,
     subSample -> 1, colSampleByTree -> 1, colSampleByLevel -> 1,
     lambda -> 1, alpha -> 0, treeMethod -> "auto", sketchEps -> 0.03,
-    scalePosWeight -> 1, sampleType -> "uniform", normalizeType -> "tree",
+    scalePosWeight -> 1.0, sampleType -> "uniform", normalizeType -> "tree",
     rateDrop -> 0.0, skipDrop -> 0.0, lambdaBias -> 0)
 
   /**


### PR DESCRIPTION
this is a further fix of https://github.com/dmlc/xgboost/issues/1941 based on https://github.com/dmlc/xgboost/pull/2042

the cross validation issue is caused by a misconfiguration of default value of scale_pos_weight, and this misconfiguration only takes effect when we create an estimator with copy() 

the reason is that when doing copy, we use the ML's parameters to build a Map and pass this Map to trainingWithRDD(), however, when creating estimator from the user's code, we directly use the user-defined Map to pass to trainingWithRDD()

in this patch, I unify these two paths and always uses ML's parameters to build a Map right before we call trainingWithRDD()