### PR TITLE
fixes #2055

### DIFF
--- a/R-package/demo/caret_wrapper.R
+++ b/R-package/demo/caret_wrapper.R
@@ -24,7 +24,7 @@ df[,ID:=NULL]
 #-------------Basic Training using XGBoost in caret Library-----------------
 # Set up control parameters for caret::train
 # Here we use 10-fold cross-validation, repeating twice, and using random search for tuning hyper-parameters.
-fitControl <- trainControl(method = "cv", number = 10, repeats = 2, search = "random")
+fitControl <- trainControl(method = "repeatedcv", number = 10, repeats = 2, search = "random")
 # train a xgbTree model using caret::train
 model <- train(factor(Improved)~., data = df, method = "xgbTree", trControl = fitControl)
 


### PR DESCRIPTION
in `caret` settings, if you want do 10*10 cross validation, you need to set repeats=10, number=10 and method=repeatedcv, if you set method=cv, actually just one 10-fold cross validation will be run; fixes #2055