### PR TITLE
fix DeprecationWarning on sklearn.cross_validation

### DIFF
--- a/demo/guide-python/sklearn_examples.py
+++ b/demo/guide-python/sklearn_examples.py
@@ -8,7 +8,10 @@ import pickle
 import xgboost as xgb
 
 import numpy as np
-from sklearn.cross_validation import KFold, train_test_split
+try:
+    from sklearn.model_selection import KFold, train_test_split
+except:
+    from sklearn.cross_validation import KFold, train_test_split
 from sklearn.metrics import confusion_matrix, mean_squared_error
 from sklearn.grid_search import GridSearchCV
 from sklearn.datasets import load_iris, load_digits, load_boston

--- a/tests/python/test_early_stopping.py
+++ b/tests/python/test_early_stopping.py
@@ -11,7 +11,10 @@ class TestEarlyStopping(unittest.TestCase):
     def test_early_stopping_nonparallel(self):
         tm._skip_if_no_sklearn()
         from sklearn.datasets import load_digits
-        from sklearn.cross_validation import train_test_split
+        try:
+            from from sklearn.model_selection import train_test_split
+        except:
+            from sklearn.cross_validation import train_test_split
 
         digits = load_digits(2)
         X = digits['data']

--- a/tests/python/test_early_stopping.py
+++ b/tests/python/test_early_stopping.py
@@ -12,7 +12,7 @@ class TestEarlyStopping(unittest.TestCase):
         tm._skip_if_no_sklearn()
         from sklearn.datasets import load_digits
         try:
-            from from sklearn.model_selection import train_test_split
+            from sklearn.model_selection import train_test_split
         except:
             from sklearn.cross_validation import train_test_split
 

--- a/tests/python/test_eval_metrics.py
+++ b/tests/python/test_eval_metrics.py
@@ -57,7 +57,10 @@ class TestEvalMetrics(unittest.TestCase):
 
     def test_eval_metrics(self):
         tm._skip_if_no_sklearn()
-        from sklearn.cross_validation import train_test_split
+        try:
+            from sklearn.model_selection import train_test_split
+        except:
+            from sklearn.cross_validation import train_test_split
         from sklearn.datasets import load_digits
 
         digits = load_digits(2)

--- a/tests/python/test_fast_hist.py
+++ b/tests/python/test_fast_hist.py
@@ -10,7 +10,10 @@ class TestFastHist(unittest.TestCase):
     def test_fast_hist(self):
         tm._skip_if_no_sklearn()
         from sklearn.datasets import load_digits
-        from sklearn.cross_validation import train_test_split
+        try:
+            from sklearn.model_selection import train_test_split
+        except:
+            from sklearn.cross_validation import train_test_split
 
         digits = load_digits(2)
         X = digits['data']

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -20,7 +20,9 @@ def test_binary_classification():
     try:
         kf = KFold(y.shape[0], n_folds=2, shuffle=True, random_state=rng)
     except TypeError:  # sklearn.model_selection.KFold uses n_split
-        kf = KFold(y.shape[0], n_splits=2, shuffle=True, random_state=rng)
+        kf = KFold(
+            n_splits=2, shuffle=True, random_state=rng
+        ).split(y.shape[0])
     for train_index, test_index in kf:
         xgb_model = xgb.XGBClassifier().fit(X[train_index], y[train_index])
         preds = xgb_model.predict(X[test_index])

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -17,7 +17,10 @@ def test_binary_classification():
     digits = load_digits(2)
     y = digits['target']
     X = digits['data']
-    kf = KFold(y.shape[0], n_folds=2, shuffle=True, random_state=rng)
+    try:
+        kf = KFold(y.shape[0], n_folds=2, shuffle=True, random_state=rng)
+    except TypeError:  # sklearn.model_selection.KFold uses n_split
+        kf = KFold(y.shape[0], n_split=2, shuffle=True, random_state=rng)
     for train_index, test_index in kf:
         xgb_model = xgb.XGBClassifier().fit(X[train_index], y[train_index])
         preds = xgb_model.predict(X[test_index])

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -9,7 +9,10 @@ rng = np.random.RandomState(1994)
 def test_binary_classification():
     tm._skip_if_no_sklearn()
     from sklearn.datasets import load_digits
-    from sklearn.cross_validation import KFold
+    try:
+        from sklearn.model_selection import KFold
+    except:
+        from sklearn.cross_validation import KFold
 
     digits = load_digits(2)
     y = digits['target']
@@ -27,7 +30,10 @@ def test_binary_classification():
 def test_multiclass_classification():
     tm._skip_if_no_sklearn()
     from sklearn.datasets import load_iris
-    from sklearn.cross_validation import KFold
+    try:
+        from sklearn.cross_validation import KFold
+    except:
+        from sklearn.model_selection import KFold
 
     def check_pred(preds, labels):
         err = sum(1 for i in range(len(preds))

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -22,7 +22,7 @@ def test_binary_classification():
     except TypeError:  # sklearn.model_selection.KFold uses n_split
         kf = KFold(
             n_splits=2, shuffle=True, random_state=rng
-        ).split(y.shape[0])
+        ).split(xrange(y.shape[0]))
     for train_index, test_index in kf:
         xgb_model = xgb.XGBClassifier().fit(X[train_index], y[train_index])
         preds = xgb_model.predict(X[test_index])

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -22,7 +22,7 @@ def test_binary_classification():
     except TypeError:  # sklearn.model_selection.KFold uses n_split
         kf = KFold(
             n_splits=2, shuffle=True, random_state=rng
-        ).split(xrange(y.shape[0]))
+        ).split(np.arange(y.shape[0]))
     for train_index, test_index in kf:
         xgb_model = xgb.XGBClassifier().fit(X[train_index], y[train_index])
         preds = xgb_model.predict(X[test_index])

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -20,7 +20,7 @@ def test_binary_classification():
     try:
         kf = KFold(y.shape[0], n_folds=2, shuffle=True, random_state=rng)
     except TypeError:  # sklearn.model_selection.KFold uses n_split
-        kf = KFold(y.shape[0], n_split=2, shuffle=True, random_state=rng)
+        kf = KFold(y.shape[0], n_splits=2, shuffle=True, random_state=rng)
     for train_index, test_index in kf:
         xgb_model = xgb.XGBClassifier().fit(X[train_index], y[train_index])
         preds = xgb_model.predict(X[test_index])


### PR DESCRIPTION
`sklearn.cross_validation` module is [deprecated](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/cross_validation.py#L40) in scikit-learn 0.18, this PR will resolve this problem.