### PR TITLE
[jvm-packages]fix bug doing rabit call after finalize

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
@@ -149,7 +149,7 @@ abstract class XGBoostModel(protected var _booster: Booster)
           flatSampleArray(i) = sampleArray(i / numColumns).values(i % numColumns).toFloat
         }
         val dMatrix = new DMatrix(flatSampleArray, numRows, numColumns, missingValue)
-        val res = broadcastBooster.value.predictLeaf(dMatrix)
+        val res = broadcastBooster.value.predict(dMatrix)
         Rabit.shutdown()
         Iterator(res)
       }


### PR DESCRIPTION
fix bug: doing rabit call after finalize in spark prediction phase #1420 

The above has fixed the fucntion of predict(testSet: RDD[MLVector], useExternalCache: Boolean = false),but predictLeaves() and predict(testSet: RDD[MLDenseVector], missingValue: Float)
have the same problem.so I fixed them.