### PR TITLE
[jvm-packages] Fixed Exception handling for fragmented Rabit 'print' tracker command.

### DIFF
--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/rabit/handler/RabitWorkerHandler.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/rabit/handler/RabitWorkerHandler.scala
@@ -129,8 +129,8 @@ private[scala] class RabitWorkerHandler(host: String, worldSize: Int, tracker: A
         Try(decodeCommand(readBuffer)) match {
           case scala.util.Success(decodedCommand) =>
             tracker ! decodedCommand
-          case scala.util.Failure(th: java.nio.BufferOverflowException) =>
-            // BufferOverflowException would occur if the message to print has not arrived yet.
+          case scala.util.Failure(th: java.nio.BufferUnderflowException) =>
+            // BufferUnderflowException would occur if the message to print has not arrived yet.
             // Do nothing, wait for next Tcp.Received event
           case scala.util.Failure(th: Throwable) => throw th
         }


### PR DESCRIPTION
This is a PR attempting to fix the issue reported in #2069. The same issue was originally reported in #1925. 

Previously, a PR (#1993) was submitted to address the buffer underflow exception. However, the pattern matching at https://github.com/dmlc/xgboost/blob/master/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/rabit/handler/RabitWorkerHandler.scala#L132 was incorrect. It was supposed to catch `BufferUnderflowException`; instead, I wrote `BufferOverflowException`. 

The unit test which was supposed to test the exception handling was also incorrectly constructed due to an ill-formed ByteBuffer. The unit test was updated to fix the error, with more checks added to make sure that the tracker command was constructed properly. 

@CodingCat Please verify that this PR resolves the flaky test issues.