### PR TITLE
bugfix: when metric's name contains `-`

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -79,7 +79,9 @@ def record_evaluation(eval_result):
     def init(env):
         """internal function"""
         for k, _ in env.evaluation_result_list:
-            key, metric = k.split('-')
+            pos = k.index('-')
+            key = k[:pos]
+            metric = k[pos + 1:]
             if key not in eval_result:
                 eval_result[key] = {}
             if metric not in eval_result[key]:
@@ -90,7 +92,9 @@ def record_evaluation(eval_result):
         if len(eval_result) == 0:
             init(env)
         for k, v in env.evaluation_result_list:
-            key, metric = k.split('-')
+            pos = k.index('-')
+            key = k[:pos]
+            metric = k[pos + 1:]
             eval_result[key][metric].append(v)
     return callback
 


### PR DESCRIPTION
When metric's name contains `-`, Python will complain about insufficient arguments to unpack.