### PR TITLE
Improve multi-threaded performance

### DIFF
--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -49,9 +49,12 @@
 #endif
 
 #if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ >= 8
-#define XGBOOST_PARALLEL_SORT_SUPPORTED 1
+#include <parallel/algorithm>
+#define XGBOOST_PARALLEL_SORT(X, Y, Z) __gnu_parallel::sort((X), (Y), (Z))
+#define XGBOOST_PARALLEL_STABLE_SORT(X, Y, Z) __gnu_parallel::stable_sort((X), (Y), (Z))
 #else
-#define XGBOOST_PARALLEL_SORT_SUPPORTED 0
+#define XGBOOST_PARALLEL_SORT(X, Y, Z) std::sort((X), (Y), (Z))
+#define XGBOOST_PARALLEL_STABLE_SORT(X, Y, Z) std::stable_sort((X), (Y), (Z))
 #endif
 
 /*! \brief namespace of xgboo st*/

--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -48,6 +48,12 @@
 #define XGBOOST_ALIGNAS(X)
 #endif
 
+#if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ >= 8
+#define XGBOOST_PARALLEL_SORT_SUPPORTED 1
+#else
+#define XGBOOST_PARALLEL_SORT_SUPPORTED 0
+#endif
+
 /*! \brief namespace of xgboo st*/
 namespace xgboost {
 /*!

--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -45,14 +45,11 @@ class TreeUpdater {
   virtual void Update(const std::vector<bst_gpair>& gpair,
                       DMatrix* data,
                       const std::vector<RegTree*>& trees) = 0;
-  /*!
-   * \brief this is simply a function for optimizing performance
-   * this function asks the updater to return the leaf position of each instance in the previous performed update.
-   * if it is cached in the updater, if it is not available, return nullptr
-   * \return array of leaf position of each instance in the last updated tree
-   */
-  virtual const int* GetLeafPosition() const {
-    return nullptr;
+
+  virtual bool UpdatePredictionCache(const DMatrix* data,
+                                     std::vector<bst_float>* out_preds,
+                                     bst_float base_margin) const {
+    return false;
   }
   /*!
    * \brief Create a tree updater given name

--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -46,9 +46,18 @@ class TreeUpdater {
                       DMatrix* data,
                       const std::vector<RegTree*>& trees) = 0;
 
+  /*!
+   * \brief determines whether updater has enough knowledge about a given dataset
+   *        to quickly update prediction cache its training data and performs the
+   *        update if possible.
+   * \param data: data matrix
+   * \param out_preds: prediction cache to be updated
+   * \return boolean indicating whether updater has capability to update
+   *         the prediction cache. If true, the prediction cache will have been
+   *         updated by the time this function returns.
+   */
   virtual bool UpdatePredictionCache(const DMatrix* data,
-                                     std::vector<bst_float>* out_preds,
-                                     bst_float base_margin) const {
+                                     std::vector<bst_float>* out_preds) const {
     return false;
   }
   /*!

--- a/src/cli_main.cc
+++ b/src/cli_main.cc
@@ -194,7 +194,9 @@ void CLITrain(const CLIParam& param) {
       learner->InitModel();
     }
   }
-  LOG(INFO) << "Loading data: " << dmlc::GetTime() - tstart_data_load << " sec";
+  if (param.silent == 0) {
+    LOG(INFO) << "Loading data: " << dmlc::GetTime() - tstart_data_load << " sec";
+  }
   // start training.
   const double start = dmlc::GetTime();
   for (int i = version / 2; i < param.num_round; ++i) {

--- a/src/cli_main.cc
+++ b/src/cli_main.cc
@@ -155,6 +155,7 @@ struct CLIParam : public dmlc::Parameter<CLIParam> {
 DMLC_REGISTER_PARAMETER(CLIParam);
 
 void CLITrain(const CLIParam& param) {
+  const double tstart_data_load = dmlc::GetTime();
   if (rabit::IsDistributed()) {
     std::string pname = rabit::GetProcessorName();
     LOG(CONSOLE) << "start " << pname << ":" << rabit::GetRank();
@@ -193,6 +194,7 @@ void CLITrain(const CLIParam& param) {
       learner->InitModel();
     }
   }
+  LOG(INFO) << "Loading data: " << dmlc::GetTime() - tstart_data_load << " sec";
   // start training.
   const double start = dmlc::GetTime();
   for (int i = version / 2; i < param.num_round; ++i) {

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -1,0 +1,214 @@
+/*!
+ * Copyright 2017 by Contributors
+ * \file column_matrix.h
+ * \brief Utility for fast column-wise access
+ * \author Philip Cho
+ */
+
+#define XGBOOST_TYPE_SWITCH(dtype, OP)					\
+switch (dtype) {						\
+  case xgboost::common::kUInt32 : {						\
+    using DType = uint32_t;					\
+    OP; break;							\
+  }								\
+  case xgboost::common::kUInt16 : {						\
+    using DType = uint16_t;					\
+    OP; break;							\
+  }								\
+  case xgboost::common::kUInt8 : {						\
+    using DType = uint8_t;					\
+    OP; break;							\
+    default: LOG(FATAL) << "don't recognize type flag" << dtype;	\
+  } \
+}
+
+#ifndef XGBOOST_COLUMN_MATRIX_H_
+#define XGBOOST_COLUMN_MATRIX_H_
+
+#include "hist_util.h"
+
+namespace xgboost {
+namespace common {
+
+enum DataType {
+  kUInt8 = 1,
+  kUInt16 = 2,
+  kUInt32 = 4
+};
+
+enum ColumnType {
+  kDenseColumn,
+  kSparseColumn
+};
+
+template<typename T>
+class Column {
+ public:
+  ColumnType type_;
+  const T* index_;
+  uint32_t index_base_;
+  const uint32_t* row_ind_;
+  size_t len_;
+};
+
+class ColumnMatrix {
+ public:
+  inline uint32_t GetNumFeature() const {
+    return type_.size();
+  }
+
+  inline void Init(const GHistIndexMatrix& gmat, DataType dtype) {
+    this->dtype = dtype;
+    packing_factor_ = sizeof(uint32_t) / static_cast<size_t>(this->dtype);
+
+    const uint32_t nfeature = gmat.cut->row_ptr.size() - 1;
+    const omp_ulong nrow = static_cast<omp_ulong>(gmat.row_ptr.size() - 1);
+    int nthread;
+    #pragma omp parallel
+    {
+      nthread = omp_get_num_threads();
+    }
+    nthread = std::max(nthread / 2, 1);
+
+    // identify type of each column
+    feature_counts_.resize(nfeature);
+    type_.resize(nfeature);
+    std::fill(feature_counts_.begin(), feature_counts_.end(), 0);
+
+    uint32_t max_val = 0;
+    XGBOOST_TYPE_SWITCH(this->dtype, {
+      max_val = std::numeric_limits<DType>::max();
+    });
+    for (uint32_t fid = 0; fid < nfeature; ++fid) {
+      CHECK_LE(gmat.cut->row_ptr[fid + 1] - gmat.cut->row_ptr[fid], max_val);
+    }
+
+    gmat.GetFeatureCounts(&feature_counts_[0]);
+    // classify features
+    for (uint32_t fid = 0; fid < nfeature; ++fid) {
+      if (static_cast<double>(feature_counts_[fid]) < 0.5*nrow) {
+        type_[fid] = kSparseColumn;
+      } else {
+        type_[fid] = kDenseColumn;
+      }
+    }
+
+    // want to compute storage boundary for each feature
+    // using variants of prefix sum scan
+    boundary_.resize(nfeature);
+    bst_uint accum_index_ = 0;
+    bst_uint accum_row_ind_ = 0;
+    for (uint32_t fid = 0; fid < nfeature; ++fid) {
+      boundary_[fid].index_begin = accum_index_;
+      boundary_[fid].row_ind_begin = accum_row_ind_;
+      if (type_[fid] == kDenseColumn) {
+        accum_index_ += nrow;
+      } else {
+        accum_index_ += feature_counts_[fid];
+        accum_row_ind_ += feature_counts_[fid];
+      }
+      boundary_[fid].index_end = accum_index_;
+      boundary_[fid].row_ind_end = accum_row_ind_;
+    }
+
+    index_.resize((boundary_[nfeature - 1].index_end
+                   + (packing_factor_ - 1)) / packing_factor_);
+    row_ind_.resize(boundary_[nfeature - 1].row_ind_end);
+
+    // store least bin id for each feature
+    index_base_.resize(nfeature);
+    for (uint32_t fid = 0; fid < nfeature; ++fid) {
+      index_base_[fid] = gmat.cut->row_ptr[fid];
+    }
+
+    // fill index_ for dense columns
+    for (uint32_t fid = 0; fid < nfeature; ++fid) {
+      if (type_[fid] == kDenseColumn) {
+        const uint32_t ibegin = boundary_[fid].index_begin;
+        XGBOOST_TYPE_SWITCH(this->dtype, {
+          const size_t block_offset = ibegin / packing_factor_;
+          const size_t elem_offset = ibegin % packing_factor_;
+          DType* begin = reinterpret_cast<DType*>(&index_[block_offset]) + elem_offset;
+          DType* end = begin + nrow;
+          std::fill(begin, end, std::numeric_limits<DType>::max());
+            // max() indicates missing values
+        });
+      }
+    }
+
+    // loop over all rows and fill column entries
+    // top_ind[fid] = how many nonzeros have this feature accumulated so far?
+    std::vector<uint32_t> top_ind;
+    top_ind.resize(nfeature);
+    std::fill(top_ind.begin(), top_ind.end(), 0);
+    for (uint32_t rid = 0; rid < nrow; ++rid) {
+      const size_t ibegin = static_cast<size_t>(gmat.row_ptr[rid]);
+      const size_t iend = static_cast<size_t>(gmat.row_ptr[rid + 1]);
+      size_t fid = 0;
+      for (size_t i = ibegin; i < iend; ++i) {
+        const size_t bin_id = gmat.index[i];
+        while (bin_id >= gmat.cut->row_ptr[fid + 1]) {
+          ++fid;
+        }
+        if (type_[fid] == kDenseColumn) {
+          XGBOOST_TYPE_SWITCH(this->dtype, {
+            const size_t block_offset = boundary_[fid].index_begin / packing_factor_;
+            const size_t elem_offset = boundary_[fid].index_begin % packing_factor_;
+            DType* begin = reinterpret_cast<DType*>(&index_[block_offset]) + elem_offset;
+            begin[rid] = bin_id - index_base_[fid];
+          });
+        } else {
+          XGBOOST_TYPE_SWITCH(this->dtype, {
+            const size_t block_offset = boundary_[fid].index_begin / packing_factor_;
+            const size_t elem_offset = boundary_[fid].index_begin % packing_factor_;
+            DType* begin = reinterpret_cast<DType*>(&index_[block_offset]) + elem_offset;
+            begin[top_ind[fid]] = bin_id - index_base_[fid];
+          });
+          row_ind_[boundary_[fid].row_ind_begin + top_ind[fid]] = rid;
+          ++top_ind[fid];
+        }
+      }
+    }
+  }
+
+  template<typename T>
+  inline Column<T> GetColumn(unsigned fid) const {
+    Column<T> c;
+
+    c.type_ = type_[fid];
+    const size_t block_offset = boundary_[fid].index_begin / packing_factor_;
+    const size_t elem_offset = boundary_[fid].index_begin % packing_factor_;
+    c.index_ = reinterpret_cast<const T*>(&index_[block_offset]) + elem_offset;
+    c.index_base_ = index_base_[fid];
+    c.row_ind_ = &row_ind_[boundary_[fid].row_ind_begin];
+    c.len_ = boundary_[fid].index_end - boundary_[fid].index_begin;
+
+    return c;
+  }
+
+ public:
+  DataType dtype;
+
+ private:
+  struct ColumnBoundary {
+    unsigned index_begin;
+    unsigned index_end;
+    unsigned row_ind_begin;
+    unsigned row_ind_end;
+  };
+
+  std::vector<bst_uint> feature_counts_;
+  std::vector<ColumnType> type_;
+  std::vector<uint32_t> index_;  // index_: may store smaller integers; needs padding
+  std::vector<uint32_t> row_ind_;
+  std::vector<ColumnBoundary> boundary_;
+
+  size_t packing_factor_;
+
+  // index_base_[fid]: least bin id for feature fid
+  std::vector<uint32_t> index_base_;
+};
+
+}  // namespace common
+}  // namespace xgboost
+#endif  // XGBOOST_COLUMN_MATRIX_H_

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -5,28 +5,30 @@
  * \author Philip Cho
  */
 
-#ifndef XGBOOST_COLUMN_MATRIX_H_
-#define XGBOOST_COLUMN_MATRIX_H_
+#ifndef XGBOOST_COMMON_COLUMN_MATRIX_H_
+#define XGBOOST_COMMON_COLUMN_MATRIX_H_
 
-#define XGBOOST_TYPE_SWITCH(dtype, OP)					\
-switch (dtype) {						\
-  case xgboost::common::kUInt32 : {						\
+#define XGBOOST_TYPE_SWITCH(dtype, OP)        \
+switch (dtype) {                \
+  case xgboost::common::kUInt32 : {           \
     typedef uint32_t DType;         \
-    OP; break;							\
-  }								\
-  case xgboost::common::kUInt16 : {						\
+    OP; break;              \
+  }               \
+  case xgboost::common::kUInt16 : {           \
     typedef uint16_t DType;         \
-    OP; break;							\
-  }								\
-  case xgboost::common::kUInt8 : {						\
-    typedef uint8_t DType;         \
-    OP; break;							\
-    default: LOG(FATAL) << "don't recognize type flag" << dtype;	\
-  } \
+    OP; break;              \
+  }               \
+  case xgboost::common::kUInt8 : {            \
+    typedef uint8_t DType;          \
+    OP; break;              \
+    default: LOG(FATAL) << "don't recognize type flag" << dtype;  \
+  }               \
 }
 
-#include "hist_util.h"
 #include <type_traits>
+#include <limits>
+#include <vector>
+#include "hist_util.h"
 
 namespace xgboost {
 namespace common {
@@ -180,9 +182,10 @@ class ColumnMatrix {
      to determine type of bin id's */
   template<typename T>
   inline Column<T> GetColumn(unsigned fid) const {
-    CHECK( (std::is_same<T,uint32_t>::value
-       || std::is_same<T,uint16_t>::value
-       || std::is_same<T,uint8_t>::value) );
+    const bool valid_type = std::is_same<T, uint32_t>::value
+                          || std::is_same<T, uint16_t>::value
+                          || std::is_same<T, uint8_t>::value;
+    CHECK(valid_type);
 
     Column<T> c;
 
@@ -225,4 +228,4 @@ class ColumnMatrix {
 
 }  // namespace common
 }  // namespace xgboost
-#endif  // XGBOOST_COLUMN_MATRIX_H_
+#endif  // XGBOOST_COMMON_COLUMN_MATRIX_H_

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -10,15 +10,15 @@
 
 #define XGBOOST_TYPE_SWITCH(dtype, OP)        \
 switch (dtype) {                \
-  case xgboost::common::kUInt32 : {           \
+  case xgboost::common::uint32 : {           \
     typedef uint32_t DType;         \
     OP; break;              \
   }               \
-  case xgboost::common::kUInt16 : {           \
+  case xgboost::common::uint16 : {           \
     typedef uint16_t DType;         \
     OP; break;              \
   }               \
-  case xgboost::common::kUInt8 : {            \
+  case xgboost::common::uint8 : {            \
     typedef uint8_t DType;          \
     OP; break;              \
     default: LOG(FATAL) << "don't recognize type flag" << dtype;  \
@@ -35,9 +35,9 @@ namespace common {
 
 /*! \brief indicator of data type used for storing bin id's in a column. */
 enum DataType {
-  kUInt8 = 1,
-  kUInt16 = 2,
-  kUInt32 = 4
+  uint8 = 1,
+  uint16 = 2,
+  uint32 = 4
 };
 
 /*! \brief column type */
@@ -220,7 +220,7 @@ class ColumnMatrix {
   std::vector<uint32_t> row_ind_;
   std::vector<ColumnBoundary> boundary_;
 
-  size_t packing_factor_;
+  size_t packing_factor_;  // how many integers are stored in each slot of index_
 
   // index_base_[fid]: least bin id for feature fid
   std::vector<uint32_t> index_base_;

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -11,15 +11,15 @@
 #define XGBOOST_TYPE_SWITCH(dtype, OP)					\
 switch (dtype) {						\
   case xgboost::common::kUInt32 : {						\
-    using DType = uint32_t;					\
+    typedef uint32_t DType;         \
     OP; break;							\
   }								\
   case xgboost::common::kUInt16 : {						\
-    using DType = uint16_t;					\
+    typedef uint16_t DType;         \
     OP; break;							\
   }								\
   case xgboost::common::kUInt8 : {						\
-    using DType = uint8_t;					\
+    typedef uint8_t DType;         \
     OP; break;							\
     default: LOG(FATAL) << "don't recognize type flag" << dtype;	\
   } \

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -163,7 +163,7 @@ void GHistBuilder::BuildHist(const std::vector<bst_gpair>& gpair,
   std::fill(data_.begin(), data_.end(), GHistEntry());
   stat_buf_.resize(row_indices.size());
 
-  const int K = 8; // loop unrolling factor
+  const int K = 8;  // loop unrolling factor
   const bst_omp_uint nthread = static_cast<bst_omp_uint>(this->nthread_);
   const bst_omp_uint nrows = row_indices.end - row_indices.begin;
   const bst_omp_uint rest = nrows % K;

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -140,7 +140,7 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat) {
         if (it == cend) it = cend - 1;
         unsigned idx = static_cast<unsigned>(it - cut->cut.begin());
         index[ibegin + j] = idx;
-        hit_count_tloc_[tid * nbins + idx]++;
+        ++hit_count_tloc_[tid * nbins + idx];
       }
       std::sort(index.begin() + ibegin, index.begin() + iend);
     }

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -8,6 +8,7 @@
 #include <vector>
 #include "./sync.h"
 #include "./hist_util.h"
+#include "./column_matrix.h"
 #include "./quantile.h"
 
 namespace xgboost {
@@ -105,18 +106,19 @@ void HistCutMatrix::Init(DMatrix* p_fmat, size_t max_num_bins) {
   }
 }
 
-
 void GHistIndexMatrix::Init(DMatrix* p_fmat) {
   CHECK(cut != nullptr);
   dmlc::DataIter<RowBatch>* iter = p_fmat->RowIterator();
-  hit_count.resize(cut->row_ptr.back(), 0);
 
   int nthread;
+  const unsigned nbins = cut->row_ptr.back();
   #pragma omp parallel
   {
     nthread = omp_get_num_threads();
   }
   nthread = std::max(nthread / 2, 1);
+  hit_count.resize(nbins, 0);
+  hit_count_tloc_.resize(nthread * nbins, 0);
 
   iter->BeforeFirst();
   row_ptr.push_back(0);
@@ -134,6 +136,7 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat) {
     omp_ulong bsize = static_cast<omp_ulong>(batch.size);
     #pragma omp parallel for num_threads(nthread) schedule(static)
     for (omp_ulong i = 0; i < bsize; ++i) { // NOLINT(*)
+      const int tid = omp_get_thread_num();
       size_t ibegin = row_ptr[rbegin + i];
       size_t iend = row_ptr[rbegin + i + 1];
       RowBatch::Inst inst = batch[i];
@@ -147,79 +150,17 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat) {
         if (it == cend) it = cend - 1;
         unsigned idx = static_cast<unsigned>(it - cut->cut.begin());
         index[ibegin + j] = idx;
+        hit_count_tloc_[tid * nbins + idx]++;
       }
       std::sort(index.begin() + ibegin, index.begin() + iend);
     }
-  }
-}
 
-void GHistBuilder::BuildHist(const std::vector<bst_gpair>& gpair,
-                             const RowSetCollection::Elem row_indices,
-                             const GHistIndexMatrix& gmat,
-                             GHistRow hist) {
-  CHECK(!data_.empty()) << "GHistBuilder must be initialized";
-  CHECK_EQ(data_.size(), nbins_ * nthread_) << "invalid dimensions for temp buffer";
-
-  std::fill(data_.begin(), data_.end(), GHistEntry());
-
-  const int K = 8;  // loop unrolling factor
-  const bst_omp_uint nthread = static_cast<bst_omp_uint>(this->nthread_);
-  const bst_omp_uint nrows = row_indices.end - row_indices.begin;
-  const bst_omp_uint rest = nrows % K;
-
-  #pragma omp parallel for num_threads(nthread) schedule(static)
-  for (bst_omp_uint i = 0; i < nrows - rest; i += K) {
-    const bst_omp_uint tid = omp_get_thread_num();
-    const size_t off = tid * nbins_;
-    bst_uint rid[K];
-    bst_gpair stat[K];
-    size_t ibegin[K], iend[K];
-    for (int k = 0; k < K; ++k) {
-      rid[k] = row_indices.begin[i + k];
-    }
-    for (int k = 0; k < K; ++k) {
-      stat[k] = gpair[rid[k]];
-    }
-    for (int k = 0; k < K; ++k) {
-      ibegin[k] = static_cast<size_t>(gmat.row_ptr[rid[k]]);
-      iend[k] = static_cast<size_t>(gmat.row_ptr[rid[k] + 1]);
-    }
-    for (int k = 0; k < K; ++k) {
-      for (size_t j = ibegin[k]; j < iend[k]; ++j) {
-        const size_t bin = gmat.index[j];
-        data_[off + bin].Add(stat[k]);
+    #pragma omp parallel for num_threads(nthread) schedule(static)
+    for (omp_ulong idx = 0; idx < nbins; ++idx) {
+      for (int tid = 0; tid < nthread; ++tid) {
+        hit_count[idx] += hit_count_tloc_[tid * nbins + idx];
       }
     }
-  }
-  for (bst_omp_uint i = nrows - rest; i < nrows; ++i) {
-    const bst_uint rid = row_indices.begin[i];
-    const bst_gpair stat = gpair[rid];
-    const size_t ibegin = static_cast<size_t>(gmat.row_ptr[rid]);
-    const size_t iend = static_cast<size_t>(gmat.row_ptr[rid + 1]);
-    for (size_t j = ibegin; j < iend; ++j) {
-      const size_t bin = gmat.index[j];
-      data_[bin].Add(stat);
-    }
-  }
-
-  /* reduction */
-  const bst_omp_uint nbins = static_cast<bst_omp_uint>(nbins_);
-  #pragma omp parallel for num_threads(nthread) schedule(static)
-  for (bst_omp_uint bin_id = 0; bin_id < nbins; ++bin_id) {
-    for (bst_omp_uint tid = 0; tid < nthread; ++tid) {
-      hist.begin[bin_id].Add(data_[tid * nbins_ + bin_id]);
-    }
-  }
-}
-
-void GHistBuilder::SubtractionTrick(GHistRow self,
-                                    GHistRow sibling,
-                                    GHistRow parent) {
-  const bst_omp_uint nthread = static_cast<bst_omp_uint>(this->nthread_);
-  const bst_omp_uint nbins = static_cast<bst_omp_uint>(nbins_);
-  #pragma omp parallel for num_threads(nthread) schedule(static)
-  for (bst_omp_uint bin_id = 0; bin_id < nbins; ++bin_id) {
-    self.begin[bin_id].SetSubtract(parent.begin[bin_id], sibling.begin[bin_id]);
   }
 }
 

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -102,18 +102,27 @@ struct GHistIndexMatrix {
   std::vector<unsigned> index;
   /*! \brief hit count of each index */
   std::vector<unsigned> hit_count;
-  /*! \brief optional remap index from outter row_id -> internal row_id*/
-  std::vector<unsigned> remap_index;
   /*! \brief The corresponding cuts */
   const HistCutMatrix* cut;
   // Create a global histogram matrix, given cut
   void Init(DMatrix* p_fmat);
-  // build remap
-  void Remap();
   // get i-th row
   inline GHistIndexRow operator[](bst_uint i) const {
     return GHistIndexRow(&index[0] + row_ptr[i], row_ptr[i + 1] - row_ptr[i]);
   }
+  inline void GetFeatureCounts(bst_uint* counts) const {
+    const unsigned nfeature = cut->row_ptr.size() - 1;
+    for (unsigned fid = 0; fid < nfeature; ++fid) {
+      const unsigned ibegin = cut->row_ptr[fid];
+      const unsigned iend = cut->row_ptr[fid + 1];
+      for (unsigned i = ibegin; i < iend; ++i) {
+        counts[fid] += hit_count[i];
+      }
+    }
+  }
+
+ private:
+  std::vector<unsigned> hit_count_tloc_;
 };
 
 /*!
@@ -189,16 +198,112 @@ class GHistBuilder {
   inline void Init(size_t nthread, size_t nbins) {
     nthread_ = nthread;
     nbins_ = nbins;
-    data_.resize(nthread * nbins, GHistEntry());
   }
 
   // construct a histogram via histogram aggregation
-  void BuildHist(const std::vector<bst_gpair>& gpair,
-                 const RowSetCollection::Elem row_indices,
-                 const GHistIndexMatrix& gmat,
-                 GHistRow hist);
+  inline void BuildHist(const std::vector<bst_gpair>& gpair,
+                        const RowSetCollection::Elem row_indices,
+                        const GHistIndexMatrix& gmat,
+                        const std::vector<bst_uint>& feat_set,
+                        GHistRow hist) {
+    data_.resize(nbins_ * nthread_, GHistEntry());
+    std::fill(data_.begin(), data_.end(), GHistEntry());
+    stat_buf_.resize(row_indices.size());
+
+    const int K = 8; // loop unrolling factor
+    const bst_omp_uint nthread = static_cast<bst_omp_uint>(this->nthread_);
+    const bst_omp_uint nrows = row_indices.end - row_indices.begin;
+    const bst_omp_uint rest = nrows % K;
+
+    #pragma omp parallel for num_threads(nthread) schedule(static)
+    for (bst_omp_uint i = 0; i < nrows - rest; i += K) {
+      bst_uint rid[K];
+      bst_gpair stat[K];
+      for (int k = 0; k < K; ++k) {
+        rid[k] = row_indices.begin[i + k];
+      }
+      for (int k = 0; k < K; ++k) {
+        stat[k] = gpair[rid[k]];
+      }
+      for (int k = 0; k < K; ++k) {
+        stat_buf_[i + k] = stat[k];
+      }
+    }
+    for (bst_omp_uint i = nrows - rest; i < nrows; ++i) {
+      const bst_uint rid = row_indices.begin[i];
+      const bst_gpair stat = gpair[rid];
+      stat_buf_[i] = stat;
+    }
+
+    #pragma omp parallel for num_threads(nthread) schedule(dynamic)
+    for (bst_omp_uint i = 0; i < nrows - rest; i += K) {
+      const bst_omp_uint tid = omp_get_thread_num();
+      const size_t off = tid * nbins_;
+      bst_uint rid[K];
+      size_t ibegin[K];
+      size_t iend[K];
+      bst_gpair stat[K];
+      for (int k = 0; k < K; ++k) {
+        rid[k] = row_indices.begin[i + k];
+      }
+      for (int k = 0; k < K; ++k) {
+        ibegin[k] = static_cast<size_t>(gmat.row_ptr[rid[k]]);
+        iend[k] = static_cast<size_t>(gmat.row_ptr[rid[k] + 1]);
+      }
+      for (int k = 0; k < K; ++k) {
+        stat[k] = stat_buf_[i + k];
+      }
+      for (int k = 0; k < K; ++k) {
+        for (size_t j = ibegin[k]; j < iend[k]; ++j) {
+          const size_t bin = gmat.index[j];
+          data_[off + bin].Add(stat[k]);
+        }
+      }
+    }
+    for (bst_omp_uint i = nrows - rest; i < nrows; ++i) {
+      const bst_uint rid = row_indices.begin[i];
+      const size_t ibegin = static_cast<size_t>(gmat.row_ptr[rid]);
+      const size_t iend = static_cast<size_t>(gmat.row_ptr[rid + 1]);
+      const bst_gpair stat = stat_buf_[i];
+      for (size_t j = ibegin; j < iend; ++j) {
+        const size_t bin = gmat.index[j];
+        data_[bin].Add(stat);
+      }
+    }
+
+    /* reduction */
+    const bst_omp_uint nbins = static_cast<bst_omp_uint>(nbins_);
+    #pragma omp parallel for num_threads(nthread) schedule(static)
+    for (bst_omp_uint bin_id = 0; bin_id < nbins; ++bin_id) {
+      for (bst_omp_uint tid = 0; tid < nthread; ++tid) {
+        hist.begin[bin_id].Add(data_[tid * nbins_ + bin_id]);
+      }
+    }
+  }
   // construct a histogram via subtraction trick
-  void SubtractionTrick(GHistRow self, GHistRow sibling, GHistRow parent);
+  inline void SubtractionTrick(GHistRow self, GHistRow sibling, GHistRow parent) {
+    const bst_omp_uint nthread = static_cast<bst_omp_uint>(this->nthread_);
+    const bst_omp_uint nbins = static_cast<bst_omp_uint>(nbins_);
+    const int K = 8;
+    const bst_omp_uint rest = nbins % K;
+    #pragma omp parallel for num_threads(nthread) schedule(static)
+    for (bst_omp_uint bin_id = 0; bin_id < nbins - rest; bin_id += K) {
+      GHistEntry pb[K];
+      GHistEntry sb[K];
+      for (int k = 0; k < K; ++k) {
+        pb[k] = parent.begin[bin_id + k];
+      }
+      for (int k = 0; k < K; ++k) {
+        sb[k] = sibling.begin[bin_id + k];
+      }
+      for (int k = 0; k < K; ++k) {
+        self.begin[bin_id + k].SetSubtract(pb[k], sb[k]);
+      }
+    }
+    for (bst_omp_uint bin_id = nbins - rest; bin_id < nbins; ++bin_id) {
+      self.begin[bin_id].SetSubtract(parent.begin[bin_id], sibling.begin[bin_id]);
+    }
+  }
 
  private:
   /*! \brief number of threads for parallel computation */
@@ -206,6 +311,7 @@ class GHistBuilder {
   /*! \brief number of all bins over all features */
   size_t nbins_;
   std::vector<GHistEntry> data_;
+  std::vector<bst_gpair> stat_buf_;
 };
 
 

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -201,109 +201,13 @@ class GHistBuilder {
   }
 
   // construct a histogram via histogram aggregation
-  inline void BuildHist(const std::vector<bst_gpair>& gpair,
-                        const RowSetCollection::Elem row_indices,
-                        const GHistIndexMatrix& gmat,
-                        const std::vector<bst_uint>& feat_set,
-                        GHistRow hist) {
-    data_.resize(nbins_ * nthread_, GHistEntry());
-    std::fill(data_.begin(), data_.end(), GHistEntry());
-    stat_buf_.resize(row_indices.size());
-
-    const int K = 8; // loop unrolling factor
-    const bst_omp_uint nthread = static_cast<bst_omp_uint>(this->nthread_);
-    const bst_omp_uint nrows = row_indices.end - row_indices.begin;
-    const bst_omp_uint rest = nrows % K;
-
-    #pragma omp parallel for num_threads(nthread) schedule(static)
-    for (bst_omp_uint i = 0; i < nrows - rest; i += K) {
-      bst_uint rid[K];
-      bst_gpair stat[K];
-      for (int k = 0; k < K; ++k) {
-        rid[k] = row_indices.begin[i + k];
-      }
-      for (int k = 0; k < K; ++k) {
-        stat[k] = gpair[rid[k]];
-      }
-      for (int k = 0; k < K; ++k) {
-        stat_buf_[i + k] = stat[k];
-      }
-    }
-    for (bst_omp_uint i = nrows - rest; i < nrows; ++i) {
-      const bst_uint rid = row_indices.begin[i];
-      const bst_gpair stat = gpair[rid];
-      stat_buf_[i] = stat;
-    }
-
-    #pragma omp parallel for num_threads(nthread) schedule(dynamic)
-    for (bst_omp_uint i = 0; i < nrows - rest; i += K) {
-      const bst_omp_uint tid = omp_get_thread_num();
-      const size_t off = tid * nbins_;
-      bst_uint rid[K];
-      size_t ibegin[K];
-      size_t iend[K];
-      bst_gpair stat[K];
-      for (int k = 0; k < K; ++k) {
-        rid[k] = row_indices.begin[i + k];
-      }
-      for (int k = 0; k < K; ++k) {
-        ibegin[k] = static_cast<size_t>(gmat.row_ptr[rid[k]]);
-        iend[k] = static_cast<size_t>(gmat.row_ptr[rid[k] + 1]);
-      }
-      for (int k = 0; k < K; ++k) {
-        stat[k] = stat_buf_[i + k];
-      }
-      for (int k = 0; k < K; ++k) {
-        for (size_t j = ibegin[k]; j < iend[k]; ++j) {
-          const size_t bin = gmat.index[j];
-          data_[off + bin].Add(stat[k]);
-        }
-      }
-    }
-    for (bst_omp_uint i = nrows - rest; i < nrows; ++i) {
-      const bst_uint rid = row_indices.begin[i];
-      const size_t ibegin = static_cast<size_t>(gmat.row_ptr[rid]);
-      const size_t iend = static_cast<size_t>(gmat.row_ptr[rid + 1]);
-      const bst_gpair stat = stat_buf_[i];
-      for (size_t j = ibegin; j < iend; ++j) {
-        const size_t bin = gmat.index[j];
-        data_[bin].Add(stat);
-      }
-    }
-
-    /* reduction */
-    const bst_omp_uint nbins = static_cast<bst_omp_uint>(nbins_);
-    #pragma omp parallel for num_threads(nthread) schedule(static)
-    for (bst_omp_uint bin_id = 0; bin_id < nbins; ++bin_id) {
-      for (bst_omp_uint tid = 0; tid < nthread; ++tid) {
-        hist.begin[bin_id].Add(data_[tid * nbins_ + bin_id]);
-      }
-    }
-  }
+  void BuildHist(const std::vector<bst_gpair>& gpair,
+                 const RowSetCollection::Elem row_indices,
+                 const GHistIndexMatrix& gmat,
+                 const std::vector<bst_uint>& feat_set,
+                 GHistRow hist);
   // construct a histogram via subtraction trick
-  inline void SubtractionTrick(GHistRow self, GHistRow sibling, GHistRow parent) {
-    const bst_omp_uint nthread = static_cast<bst_omp_uint>(this->nthread_);
-    const bst_omp_uint nbins = static_cast<bst_omp_uint>(nbins_);
-    const int K = 8;
-    const bst_omp_uint rest = nbins % K;
-    #pragma omp parallel for num_threads(nthread) schedule(static)
-    for (bst_omp_uint bin_id = 0; bin_id < nbins - rest; bin_id += K) {
-      GHistEntry pb[K];
-      GHistEntry sb[K];
-      for (int k = 0; k < K; ++k) {
-        pb[k] = parent.begin[bin_id + k];
-      }
-      for (int k = 0; k < K; ++k) {
-        sb[k] = sibling.begin[bin_id + k];
-      }
-      for (int k = 0; k < K; ++k) {
-        self.begin[bin_id + k].SetSubtract(pb[k], sb[k]);
-      }
-    }
-    for (bst_omp_uint bin_id = nbins - rest; bin_id < nbins; ++bin_id) {
-      self.begin[bin_id].SetSubtract(parent.begin[bin_id], sibling.begin[bin_id]);
-    }
-  }
+  void SubtractionTrick(GHistRow self, GHistRow sibling, GHistRow parent);
 
  private:
   /*! \brief number of threads for parallel computation */

--- a/src/common/row_set.h
+++ b/src/common/row_set.h
@@ -21,11 +21,13 @@ class RowSetCollection {
   struct Elem {
     const bst_uint* begin;
     const bst_uint* end;
+    int nid;
     Elem(void)
-        : begin(nullptr), end(nullptr) {}
+        : begin(nullptr), end(nullptr), nid(-1) {}
     Elem(const bst_uint* begin,
-         const bst_uint* end)
-        : begin(begin), end(end) {}
+         const bst_uint* end,
+         int nid)
+        : begin(begin), end(end), nid(nid) {}
 
     inline size_t size() const {
       return end - begin;
@@ -36,6 +38,15 @@ class RowSetCollection {
     std::vector<bst_uint> left;
     std::vector<bst_uint> right;
   };
+
+  inline std::vector<Elem>::const_iterator begin() const {
+    return elem_of_each_node_.begin();
+  }
+
+  inline std::vector<Elem>::const_iterator end() const {
+    return elem_of_each_node_.end();
+  }
+
   /*! \brief return corresponding element set given the node_id */
   inline const Elem& operator[](unsigned node_id) const {
     const Elem& e = elem_of_each_node_[node_id];
@@ -53,7 +64,7 @@ class RowSetCollection {
     CHECK_EQ(elem_of_each_node_.size(), 0U);
     const bst_uint* begin = dmlc::BeginPtr(row_indices_);
     const bst_uint* end = dmlc::BeginPtr(row_indices_) + row_indices_.size();
-    elem_of_each_node_.emplace_back(Elem(begin, end));
+    elem_of_each_node_.emplace_back(Elem(begin, end, 0));
   }
   // split rowset into two
   inline void AddSplit(unsigned node_id,
@@ -79,15 +90,15 @@ class RowSetCollection {
     }
 
     if (left_node_id >= elem_of_each_node_.size()) {
-      elem_of_each_node_.resize(left_node_id + 1, Elem(nullptr, nullptr));
+      elem_of_each_node_.resize(left_node_id + 1, Elem(nullptr, nullptr, -1));
     }
     if (right_node_id >= elem_of_each_node_.size()) {
-      elem_of_each_node_.resize(right_node_id + 1, Elem(nullptr, nullptr));
+      elem_of_each_node_.resize(right_node_id + 1, Elem(nullptr, nullptr, -1));
     }
 
-    elem_of_each_node_[left_node_id] = Elem(begin, split_pt);
-    elem_of_each_node_[right_node_id] = Elem(split_pt, e.end);
-    elem_of_each_node_[node_id] = Elem(nullptr, nullptr);
+    elem_of_each_node_[left_node_id] = Elem(begin, split_pt, left_node_id);
+    elem_of_each_node_[right_node_id] = Elem(split_pt, e.end, right_node_id);
+    elem_of_each_node_[node_id] = Elem(nullptr, nullptr, -1);
   }
 
   // stores the row indices in the set

--- a/src/common/row_set.h
+++ b/src/common/row_set.h
@@ -21,13 +21,13 @@ class RowSetCollection {
   struct Elem {
     const bst_uint* begin;
     const bst_uint* end;
-    int nid;
+    int node_id;
     Elem(void)
-        : begin(nullptr), end(nullptr), nid(-1) {}
+        : begin(nullptr), end(nullptr), node_id(-1) {}
     Elem(const bst_uint* begin,
          const bst_uint* end,
-         int nid)
-        : begin(begin), end(end), nid(nid) {}
+         int node_id)
+        : begin(begin), end(end), node_id(node_id) {}
 
     inline size_t size() const {
       return end - begin;

--- a/src/common/row_set.h
+++ b/src/common/row_set.h
@@ -17,11 +17,14 @@ namespace common {
 /*! \brief collection of rowset */
 class RowSetCollection {
  public:
-  /*! \brief subset of rows */
+  /*! \brief data structure to store an instance set, a subset of
+   *  rows (instances) associated with a particular node in a decision
+   *  tree. */
   struct Elem {
     const bst_uint* begin;
     const bst_uint* end;
     int node_id;
+      // id of node associated with this instance set; -1 means uninitialized
     Elem(void)
         : begin(nullptr), end(nullptr), node_id(-1) {}
     Elem(const bst_uint* begin,

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -500,7 +500,7 @@ class GBTree : public GradientBooster {
 
       if (mparam.num_output_group == 1 && updaters.size() > 0 && new_trees.size() == 1
         && updaters.back()->UpdatePredictionCache(e.data.get(), &(e.predictions)) ) {
-        ; // do nothing
+        {}  // do nothing
       } else {
         PredLoopInternal<GBTree>(
             e.data.get(), &(e.predictions),

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -498,7 +498,7 @@ class GBTree : public GradientBooster {
         }
       }
 
-      if (mparam.num_output_group == 1 && updaters.size() > 0
+      if (mparam.num_output_group == 1 && updaters.size() > 0 && new_trees.size() == 1
         && updaters.back()->UpdatePredictionCache(e.data.get(), &(e.predictions)) ) {
         ; // do nothing
       } else {

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -486,25 +486,18 @@ class GBTree : public GradientBooster {
       CacheEntry& e = kv.second;
 
       if (e.predictions.size() == 0) {
-        const int num_group = mparam.num_output_group;
-        const size_t n = num_group * e.data->info().num_row;
-        const std::vector<bst_float>& base_margin = e.data->info().base_margin;
-        e.predictions.resize(n);
-        if (base_margin.size() != 0) {
-          CHECK_EQ(e.predictions.size(), n);
-          std::copy(base_margin.begin(), base_margin.end(), e.predictions.begin());
-        } else {
-          std::fill(e.predictions.begin(), e.predictions.end(), base_margin_);
-        }
-      }
-
-      if (mparam.num_output_group == 1 && updaters.size() > 0 && new_trees.size() == 1
-        && updaters.back()->UpdatePredictionCache(e.data.get(), &(e.predictions)) ) {
-        {}  // do nothing
-      } else {
         PredLoopInternal<GBTree>(
             e.data.get(), &(e.predictions),
-            old_ntree, trees.size(), false);
+            0, trees.size(), true);
+      } else {
+        if (mparam.num_output_group == 1 && updaters.size() > 0 && new_trees.size() == 1
+          && updaters.back()->UpdatePredictionCache(e.data.get(), &(e.predictions)) ) {
+          {}  // do nothing
+        } else {
+          PredLoopInternal<GBTree>(
+              e.data.get(), &(e.predictions),
+              old_ntree, trees.size(), false);
+        }
       }
     }
   }

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -84,6 +84,8 @@ struct LearnerTrainParam
   // number of threads to use if OpenMP is enabled
   // if equals 0, use system default
   int nthread;
+  // flag to print out detailed breakdown of runtime
+  int debug_verbose;
   // declare parameters
   DMLC_DECLARE_PARAMETER(LearnerTrainParam) {
     DMLC_DECLARE_FIELD(seed).set_default(0)
@@ -110,6 +112,10 @@ struct LearnerTrainParam
         .describe("maximum row per batch.");
     DMLC_DECLARE_FIELD(nthread).set_default(0)
         .describe("Number of threads to use.");
+    DMLC_DECLARE_FIELD(debug_verbose)
+        .set_lower_bound(0)
+        .set_default(0)
+        .describe("flag to print out detailed breakdown of runtime");
   }
 };
 
@@ -331,7 +337,9 @@ class LearnerImpl : public Learner {
       }
     }
 
-    LOG(INFO) << "EvalOneIter(): " << dmlc::GetTime() - tstart << " sec";
+    if (tparam.debug_verbose > 0) {
+      LOG(INFO) << "EvalOneIter(): " << dmlc::GetTime() - tstart << " sec";
+    }
     return os.str();
   }
 

--- a/src/metric/rank_metric.cc
+++ b/src/metric/rank_metric.cc
@@ -101,6 +101,7 @@ struct EvalAuc : public Metric {
     // sum statistics
     bst_float sum_auc = 0.0f;
     int auc_error = 0;
+#if XGBOOST_PARALLEL_SORT_SUPPORTED == 1
     // each thread takes a local rec
     std::vector< std::pair<bst_float, unsigned> > rec;
     for (bst_omp_uint k = 0; k < ngroup; ++k) {

--- a/src/metric/rank_metric.cc
+++ b/src/metric/rank_metric.cc
@@ -258,7 +258,6 @@ struct EvalNDCG : public EvalRankList{
     return sumdcg;
   }
   virtual bst_float EvalMetric(std::vector<std::pair<bst_float, unsigned> > &rec) const { // NOLINT(*)
-
     XGBOOST_PARALLEL_STABLE_SORT(rec.begin(), rec.end(), common::CmpFirst);
     bst_float dcg = this->CalcDCG(rec);
     XGBOOST_PARALLEL_STABLE_SORT(rec.begin(), rec.end(), common::CmpSecond);

--- a/src/metric/rank_metric.cc
+++ b/src/metric/rank_metric.cc
@@ -10,10 +10,6 @@
 #include "../common/sync.h"
 #include "../common/math.h"
 
-#if XGBOOST_PARALLEL_SORT_SUPPORTED == 1
-#include <parallel/algorithm>
-#endif
-
 namespace xgboost {
 namespace metric {
 // tag the this file, used by force static link later.
@@ -101,7 +97,6 @@ struct EvalAuc : public Metric {
     // sum statistics
     bst_float sum_auc = 0.0f;
     int auc_error = 0;
-#if XGBOOST_PARALLEL_SORT_SUPPORTED == 1
     // each thread takes a local rec
     std::vector< std::pair<bst_float, unsigned> > rec;
     for (bst_omp_uint k = 0; k < ngroup; ++k) {
@@ -109,7 +104,7 @@ struct EvalAuc : public Metric {
       for (unsigned j = gptr[k]; j < gptr[k + 1]; ++j) {
         rec.push_back(std::make_pair(preds[j], j));
       }
-      __gnu_parallel::sort(rec.begin(), rec.end(), common::CmpFirst);
+      XGBOOST_PARALLEL_SORT(rec.begin(), rec.end(), common::CmpFirst);
       // calculate AUC
       double sum_pospair = 0.0;
       double sum_npos = 0.0, sum_nneg = 0.0, buf_pos = 0.0, buf_neg = 0.0;
@@ -137,47 +132,6 @@ struct EvalAuc : public Metric {
       // this is the AUC
       sum_auc += sum_pospair / (sum_npos*sum_nneg);
     }
-#else
-    #pragma omp parallel reduction(+:sum_auc)
-    {
-      // each thread takes a local rec
-      std::vector< std::pair<bst_float, unsigned> > rec;
-      #pragma omp for schedule(static)
-      for (bst_omp_uint k = 0; k < ngroup; ++k) {
-        rec.clear();
-        for (unsigned j = gptr[k]; j < gptr[k + 1]; ++j) {
-          rec.push_back(std::make_pair(preds[j], j));
-        }
-        std::sort(rec.begin(), rec.end(), common::CmpFirst);
-        // calculate AUC
-        double sum_pospair = 0.0;
-        double sum_npos = 0.0, sum_nneg = 0.0, buf_pos = 0.0, buf_neg = 0.0;
-        for (size_t j = 0; j < rec.size(); ++j) {
-          const bst_float wt = info.GetWeight(rec[j].second);
-          const bst_float ctr = info.labels[rec[j].second];
-          // keep bucketing predictions in same bucket
-          if (j != 0 && rec[j].first != rec[j - 1].first) {
-            sum_pospair += buf_neg * (sum_npos + buf_pos *0.5);
-            sum_npos += buf_pos;
-            sum_nneg += buf_neg;
-            buf_neg = buf_pos = 0.0f;
-          }
-          buf_pos += ctr * wt;
-          buf_neg += (1.0f - ctr) * wt;
-        }
-        sum_pospair += buf_neg * (sum_npos + buf_pos *0.5);
-        sum_npos += buf_pos;
-        sum_nneg += buf_neg;
-        // check weird conditions
-        if (sum_npos <= 0.0 || sum_nneg <= 0.0) {
-          auc_error = 1;
-          continue;
-        }
-        // this is the AUC
-        sum_auc += sum_pospair / (sum_npos*sum_nneg);
-      }
-    }
-#endif
     CHECK(!auc_error)
       << "AUC: the dataset only contains pos or neg samples";
     if (distributed) {
@@ -305,17 +259,10 @@ struct EvalNDCG : public EvalRankList{
   }
   virtual bst_float EvalMetric(std::vector<std::pair<bst_float, unsigned> > &rec) const { // NOLINT(*)
 
-#if XGBOOST_PARALLEL_SORT_SUPPORTED == 1
-    __gnu_parallel::stable_sort(rec.begin(), rec.end(), common::CmpFirst);
+    XGBOOST_PARALLEL_STABLE_SORT(rec.begin(), rec.end(), common::CmpFirst);
     bst_float dcg = this->CalcDCG(rec);
-    __gnu_parallel::stable_sort(rec.begin(), rec.end(), common::CmpSecond);
+    XGBOOST_PARALLEL_STABLE_SORT(rec.begin(), rec.end(), common::CmpSecond);
     bst_float idcg = this->CalcDCG(rec);
-#else
-    std::stable_sort(rec.begin(), rec.end(), common::CmpFirst);
-    bst_float dcg = this->CalcDCG(rec);
-    std::stable_sort(rec.begin(), rec.end(), common::CmpSecond);
-    bst_float idcg = this->CalcDCG(rec);
-#endif
     if (idcg == 0.0f) {
       if (minus_) {
         return 0.0f;

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -35,6 +35,8 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
   int max_leaves;
   // if using histogram based algorithm, maximum number of bins per feature
   int max_bin;
+  enum class DataType { kUInt8 = 1, kUInt16 = 2, kUInt32 = 4 };
+  int colmat_dtype;
   // growing policy
   enum TreeGrowPolicy { kDepthWise = 0, kLossGuide = 1 };
   int grow_policy;
@@ -110,6 +112,12 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
             "Tree growing policy. 0: favor splitting at nodes closest to the node, "
             "i.e. grow depth-wise. 1: favor splitting at nodes with highest loss "
             "change. (cf. LightGBM)");
+    DMLC_DECLARE_FIELD(colmat_dtype)
+        .set_default(static_cast<int>(DataType::kUInt32))
+        .add_enum("kUInt8", static_cast<int>(DataType::kUInt8))
+        .add_enum("kUInt16", static_cast<int>(DataType::kUInt16))
+        .add_enum("kUInt32", static_cast<int>(DataType::kUInt32))
+        .describe("");
     DMLC_DECLARE_FIELD(min_child_weight)
         .set_lower_bound(0.0f)
         .set_default(1.0f)

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -35,7 +35,7 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
   int max_leaves;
   // if using histogram based algorithm, maximum number of bins per feature
   int max_bin;
-  enum class DataType { kUInt8 = 1, kUInt16 = 2, kUInt32 = 4 };
+  enum class DataType { uint8 = 1, uint16 = 2, uint32 = 4 };
   int colmat_dtype;
   // growing policy
   enum TreeGrowPolicy { kDepthWise = 0, kLossGuide = 1 };
@@ -113,11 +113,13 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
             "i.e. grow depth-wise. 1: favor splitting at nodes with highest loss "
             "change. (cf. LightGBM)");
     DMLC_DECLARE_FIELD(colmat_dtype)
-        .set_default(static_cast<int>(DataType::kUInt32))
-        .add_enum("kUInt8", static_cast<int>(DataType::kUInt8))
-        .add_enum("kUInt16", static_cast<int>(DataType::kUInt16))
-        .add_enum("kUInt32", static_cast<int>(DataType::kUInt32))
-        .describe("");
+        .set_default(static_cast<int>(DataType::uint32))
+        .add_enum("uint8", static_cast<int>(DataType::uint8))
+        .add_enum("uint16", static_cast<int>(DataType::uint16))
+        .add_enum("uint32", static_cast<int>(DataType::uint32))
+        .describe("Integral data type to be used with columnar data storage."
+                  "May carry marginal performance implications. Reserved for "
+                  "advanced use");
     DMLC_DECLARE_FIELD(min_child_weight)
         .set_lower_bound(0.0f)
         .set_default(1.0f)

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -38,6 +38,7 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
   // growing policy
   enum TreeGrowPolicy { kDepthWise = 0, kLossGuide = 1 };
   int grow_policy;
+  // flag to print out detailed breakdown of runtime
   int debug_verbose;
   //----- the rest parameters are less important ----
   // minimum amount of hessian(weight) allowed in a child
@@ -90,9 +91,7 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
     DMLC_DECLARE_FIELD(debug_verbose)
         .set_lower_bound(0)
         .set_default(0)
-        .describe(
-            "Setting verbose flag with a positive value causes the updater "
-            "to print out *detailed* list of tasks and their runtime");
+        .describe("flag to print out detailed breakdown of runtime");
     DMLC_DECLARE_FIELD(max_depth)
         .set_lower_bound(0)
         .set_default(6)

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -792,9 +792,6 @@ class DistColMaker : public ColMaker<TStats, TConstraint> {
     // update position after the tree is pruned
     builder.UpdatePosition(dmat, *trees[0]);
   }
-  const int* GetLeafPosition() const override {
-    return builder.GetLeafPosition();
-  }
 
  private:
   struct Builder : public ColMaker<TStats, TConstraint>::Builder {
@@ -949,11 +946,6 @@ class TreeUpdaterSwitch : public TreeUpdater {
               const std::vector<RegTree*>& trees) override {
     CHECK(inner_ != nullptr);
     inner_->Update(gpair, data, trees);
-  }
-
-  const int* GetLeafPosition() const override {
-    CHECK(inner_ != nullptr);
-    return inner_->GetLeafPosition();
   }
 
  private:

--- a/src/tree/updater_fast_hist.cc
+++ b/src/tree/updater_fast_hist.cc
@@ -291,7 +291,8 @@ class FastHistMaker: public TreeUpdater {
       }
 
       if (leaf_value_cache_.empty()) {
-        leaf_value_cache_.resize(p_last_tree_->param.num_nodes, std::numeric_limits<float>::infinity());
+        leaf_value_cache_.resize(p_last_tree_->param.num_nodes,
+          std::numeric_limits<float>::infinity());
       }
 
       CHECK_GT(out_preds.size(), 0);
@@ -531,10 +532,10 @@ class FastHistMaker: public TreeUpdater {
       Column<T> column = column_matrix.GetColumn<T>(fid);
       if (column.type == xgboost::common::kDenseColumn) {
         ApplySplitDenseData(rowset, gmat, &row_split_tloc_, column, split_cond,
-          default_left); 
+          default_left);
       } else {
         ApplySplitSparseData(rowset, gmat, &row_split_tloc_, column, lower_bound,
-          upper_bound, split_cond, default_left); 
+          upper_bound, split_cond, default_left);
       }
 
       row_set_collection_.AddSplit(
@@ -567,7 +568,7 @@ class FastHistMaker: public TreeUpdater {
           rbin[k] = column.index[rid[k]];
         }
         for (int k = 0; k < K; ++k) {
-          if (rbin[k] == std::numeric_limits<T>::max()) { // missing value
+          if (rbin[k] == std::numeric_limits<T>::max()) {  // missing value
             if (default_left) {
               left.push_back(rid[k]);
             } else {
@@ -587,7 +588,7 @@ class FastHistMaker: public TreeUpdater {
         auto& right = row_split_tloc[nthread-1].right;
         const bst_uint rid = rowset.begin[i];
         const T rbin = column.index[rid];
-        if (rbin == std::numeric_limits<T>::max()) { // missing value
+        if (rbin == std::numeric_limits<T>::max()) {  // missing value
           if (default_left) {
             left.push_back(rid);
           } else {

--- a/src/tree/updater_fast_hist.cc
+++ b/src/tree/updater_fast_hist.cc
@@ -137,7 +137,8 @@ class FastHistMaker: public TreeUpdater {
     // constructor
     explicit Builder(const TrainParam& param,
                      std::unique_ptr<TreeUpdater> pruner)
-      : param(param), pruner_(std::move(pruner)) {}
+      : param(param), pruner_(std::move(pruner)),
+        p_last_tree_(nullptr), p_last_fmat_(nullptr) {}
     // update one tree, growing
     virtual void Update(const GHistIndexMatrix& gmat,
                         const ColumnMatrix& column_matrix,
@@ -458,11 +459,11 @@ class FastHistMaker: public TreeUpdater {
       const bst_omp_uint nthread = static_cast<bst_omp_uint>(this->nthread);
       best_split_tloc_.resize(nthread);
       #pragma omp parallel for schedule(static) num_threads(nthread)
-      for (unsigned tid = 0; tid < nthread; ++tid) {
+      for (bst_omp_uint tid = 0; tid < nthread; ++tid) {
         best_split_tloc_[tid] = snode[nid].best;
       }
       #pragma omp parallel for schedule(dynamic) num_threads(nthread)
-      for (unsigned i = 0; i < nfeature; ++i) {
+      for (bst_omp_uint i = 0; i < nfeature; ++i) {
         const bst_uint fid = feat_set[i];
         const unsigned tid = omp_get_thread_num();
         this->EnumerateSplit(-1, gmat, hist[nid], snode[nid], constraints_[nid], info,
@@ -826,8 +827,8 @@ class FastHistMaker: public TreeUpdater {
     std::unique_ptr<TreeUpdater> pruner_;
 
     // back pointers to tree and data matrix
-    const RegTree* p_last_tree_ = nullptr;
-    const DMatrix* p_last_fmat_ = nullptr;
+    const RegTree* p_last_tree_;
+    const DMatrix* p_last_fmat_;
 
     // constraint value
     std::vector<TConstraint> constraints_;

--- a/tests/python/test_fast_hist.py
+++ b/tests/python/test_fast_hist.py
@@ -15,6 +15,32 @@ class TestFastHist(unittest.TestCase):
         except:
             from sklearn.cross_validation import train_test_split
 
+        # regression test --- hist must be same as exact on all-categorial data
+        dpath = 'demo/data/'
+        ag_dtrain = xgb.DMatrix(dpath + 'agaricus.txt.train')
+        ag_dtest = xgb.DMatrix(dpath + 'agaricus.txt.test')
+        ag_param = {'max_depth': 2,
+                    'tree_method': 'exact',
+                    'eta': 1,
+                    'silent': 1,
+                    'objective': 'binary:logistic',
+                    'eval_metric': 'auc'}
+        ag_param2 = {'max_depth': 2,
+                     'tree_method': 'hist',
+                     'eta': 1,
+                     'silent': 1,
+                     'objective': 'binary:logistic',
+                     'eval_metric': 'auc'}
+        ag_res = {}
+        ag_res2 = {}
+
+        xgb.train(ag_param, ag_dtrain, 10, [(ag_dtrain, 'train'), (ag_dtest, 'test')],
+                  evals_result=ag_res)
+        xgb.train(ag_param2, ag_dtrain, 10, [(ag_dtrain, 'train'), (ag_dtest, 'test')],
+                  evals_result=ag_res2)
+        assert ag_res['train']['auc'] == ag_res2['train']['auc']
+        assert ag_res['test']['auc'] == ag_res2['test']['auc']
+
         digits = load_digits(2)
         X = digits['data']
         y = digits['target']


### PR DESCRIPTION
* Use columnwise accessor to accelerate `ApplySplit()` step, with support for a compressed representation
* Parallel sort for evaluation step
* Cache gradient pairs when building histograms in `BuildHist()`

TODO: write a blog post