### PR TITLE
GLM test unit: make run deterministic

### DIFF
--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -12,7 +12,7 @@ rng = np.random.RandomState(1994)
 class TestModels(unittest.TestCase):
     def test_glm(self):
         param = {'silent': 1, 'objective': 'binary:logistic',
-                 'booster': 'gblinear', 'alpha': 0.0001, 'lambda': 1}
+                 'booster': 'gblinear', 'alpha': 0.0001, 'lambda': 1, 'nthread': 1}
         watchlist = [(dtest, 'eval'), (dtrain, 'train')]
         num_round = 4
         bst = xgb.train(param, dtrain, num_round, watchlist)


### PR DESCRIPTION
Fixes PR #2121 error which is due to bad luck (non deterministic outcome of multithreaded gblinear).

I managed to get >0.20 error after trying 100,000 random xgboost gblinear, which means a false positive issue is possible.

You can compare on the following which are based on #2121 commit e32d759:

* Not failing (and will not fail oddly): https://travis-ci.org/Laurae2/xgboost/jobs/214635300
* Reported weird failure (pure luck): https://travis-ci.org/dmlc/xgboost/jobs/213328891