### PR TITLE
Removes extraneous log

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -261,7 +261,6 @@ XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,
     mat.info.num_col = num_col;
   }
   mat.info.num_row = nindptr - 1;
-  LOG(INFO) << "num_row=" << mat.info.num_row;
   mat.info.num_nonzero = mat.row_data_.size();
   *out = new std::shared_ptr<DMatrix>(DMatrix::Create(std::move(source)));
   API_END();


### PR DESCRIPTION
This log appears to fire every time I ask the python package to make a prediction. It's the only log that fires from XGBoost. When we're getting predictions on millions of items a day in production, this log seems out of place.