### PR TITLE
Fix confilict between <parallel/algorithm> and nvcc

### DIFF
--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -48,7 +48,7 @@
 #define XGBOOST_ALIGNAS(X)
 #endif
 
-#if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ >= 8
+#if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ >= 8 && !defined(__NVCC__)
 #include <parallel/algorithm>
 #define XGBOOST_PARALLEL_SORT(X, Y, Z) __gnu_parallel::sort((X), (Y), (Z))
 #define XGBOOST_PARALLEL_STABLE_SORT(X, Y, Z) __gnu_parallel::stable_sort((X), (Y), (Z))


### PR DESCRIPTION
Should fix #2218.
It seems there is a conflict between gcc's <parallel/algorithm> and nvcc, at least in gcc 4.9.x