### PR TITLE
build.sh hints for errors related to: Cannot find XGBoost Library in the candidate path, did you install compilers and run build.sh in root path?

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,35 @@
 if make; then
     echo "Successfully build multi-thread xgboost"
 else
+
+    not_ready=0
+
+    if [[ ! -e ./rabit/Makefile ]]; then
+        echo ""
+        echo "Please clone the rabit repository into this directory."
+        echo "Here are the commands:"
+        echo "rm -rf rabit"
+        echo "git clone https://github.com/dmlc/rabit.git rabit"
+        not_ready=1
+    fi
+    
+    if [[ ! -e ./dmlc-core/Makefile ]]; then
+        echo ""
+        echo "Please clone the dmlc-core repository into this directory."
+        echo "Here are the commands:"
+        echo "rm -rf dmlc-core"
+        echo "git clone https://github.com/dmlc/dmlc-core.git dmlc-core"
+        not_ready=1
+    fi
+
+    if [[ "${not_ready}" == "1" ]]; then
+        echo ""
+        echo "Please fix the errors above and retry the build"
+        echo ""
+        exit 1
+    fi
+
+
     echo "-----------------------------"
     echo "Building multi-thread xgboost failed"
     echo "Start to build single-thread xgboost"

--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,8 @@ else
 
     if [[ "${not_ready}" == "1" ]]; then
         echo ""
-        echo "Please fix the errors above and retry the build"
+        echo "Please fix the errors above and retry the build or reclone the repository with:"
+        echo "git clone --recursive https://github.com/dmlc/xgboost.git"
         echo ""
         exit 1
     fi


### PR DESCRIPTION
Provide hints on how to build if a new user just clones the repository without --recursive and is looking for help with this error

```
xgboost/python-package$ python setup.py develop
Traceback (most recent call last):
  File "setup.py", line 19, in <module>
    LIB_PATH = [os.path.relpath(libfile, CURRENT_DIR) for libfile in libpath['find_lib_path']()]
  File "xgboost/libpath.py", line 46, in find_lib_path
    'List of candidates:\n' + ('\n'.join(dll_path)))
__builtin__.XGBoostLibraryNotFound: Cannot find XGBoost Library in the candidate path, did you install compilers and run build.sh in root path?
```