### PR TITLE
Fix performance degradation of BuildHist on Windows

### DIFF
--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -188,7 +188,7 @@ void GHistBuilder::BuildHist(const std::vector<bst_gpair>& gpair,
     stat_buf_[i] = stat;
   }
 
-  #pragma omp parallel for num_threads(nthread) schedule(dynamic)
+  #pragma omp parallel for num_threads(nthread) schedule(guided)
   for (bst_omp_uint i = 0; i < nrows - rest; i += K) {
     const bst_omp_uint tid = omp_get_thread_num();
     const size_t off = tid * nbins_;


### PR DESCRIPTION
Reported in issue #2165. Dynamic scheduling of OpenMP loops involve
implicit synchronization. To implement synchronization, libgomp uses futex
(fast userspace mutex), whereas MinGW uses kernel-space mutex, which is more
costly. With chunk size of 1, synchronization overhead may become prohibitive
on Windows machines.

Solution: use 'guided' schedule to minimize the number of syncs