### PR TITLE
Fix compilation on OS X with GCC 7

### DIFF
--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -9,16 +9,13 @@
 #define XGBOOST_TREE_UPDATER_H_
 
 #include <dmlc/registry.h>
+#include <functional>
 #include <vector>
 #include <utility>
 #include <string>
 #include "./base.h"
 #include "./data.h"
 #include "./tree_model.h"
-
-#ifdef _MSC_VER
-#include <functional>
-#endif
 
 namespace xgboost {
 /*!

--- a/src/data/sparse_batch_page.h
+++ b/src/data/sparse_batch_page.h
@@ -17,14 +17,11 @@
 #include <string>
 #include <utility>
 #include <memory>
+#include <functional>
 
 #if DMLC_ENABLE_STD_THREAD
 #include <dmlc/concurrency.h>
 #include <thread>
-#endif
-
-#ifdef _MSC_VER
-#include <functional>
 #endif
 
 namespace xgboost {


### PR DESCRIPTION
Compilation failed with

```
In file included from src/tree/tree_updater.cc:6:0:
include/xgboost/tree_updater.h:75:46: error: 'function' is not a member of 'std'
                                         std::function<TreeUpdater* ()> > {
```

caused by a missing `<functional>` include.