### PR TITLE
Removed 'flink.suffix' and added 'flink.version'

### DIFF
--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <maven.version>3.3.9</maven.version>
+        <flink.version>0.10.2</flink.version>
         <spark.version>2.1.0</spark.version>
-        <flink.suffix>_2.11</flink.suffix>
         <scala.version>2.11.8</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
     </properties>
@@ -39,8 +39,8 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <!--<properties>-->
+            <!--<flink.version>0.10.2</flink.version> -->
             <!--<spark.version>2.0.1</spark.version>-->
-            <!--<flink.suffix>_2.11</flink.suffix>-->
             <!--<scala.version>2.11.8</scala.version>-->
             <!--<scala.binary.version>2.11</scala.binary.version>-->
             <!--</properties>-->

--- a/jvm-packages/xgboost4j-flink/pom.xml
+++ b/jvm-packages/xgboost4j-flink/pom.xml
@@ -35,18 +35,18 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-scala${flink.suffix}</artifactId>
-            <version>0.10.2</version>
+            <artifactId>flink-scala_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients${flink.suffix}</artifactId>
-            <version>0.10.2</version>
+            <artifactId>flink-clients_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-ml${flink.suffix}</artifactId>
-            <version>0.10.2</version>
+            <artifactId>flink-ml_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The former was just Scala binary tag, and the latter was hardcoded in the 'xgboost4j-flink' POM.