### PR TITLE
Fixed loop bound in create.new.tree.features

### DIFF
--- a/R-package/demo/predict_leaf_indices.R
+++ b/R-package/demo/predict_leaf_indices.R
@@ -27,7 +27,7 @@ head(pred_with_leaf)
 create.new.tree.features <- function(model, original.features){
   pred_with_leaf <- predict(model, original.features, predleaf = TRUE)
   cols <- list()
-  for(i in 1:length(trees)){
+  for(i in 1:model$niter){
     # max is not the real max but it s not important for the purpose of adding features
     leaf.id <- sort(unique(pred_with_leaf[,i]))
     cols[[i]] <- factor(x = pred_with_leaf[,i], level = leaf.id)


### PR DESCRIPTION
for loop in create.new.tree.features was referencing length(trees) as the upper bound of the loop. trees is a base R dataset and not the model that the code is generating. Changed loop boundary to model$niter which should be the number of trees.