### PR TITLE
Fix dimension mismatch crash

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -274,7 +274,8 @@ class DMatrix(object):
                 raise TypeError('can not initialize DMatrix from {}'.format(type(data).__name__))
         if label is not None:
             if data.shape[0] != label.shape[0]:
-                raise ValueError('length mismatch: {} for data vs {} for label'.format(len(data),len(label)))
+                raise ValueError('length mismatch: {} for data vs {} for label'.format(
+                    data.shape[0], label.shape[0]))
             self.set_label(label)
         if weight is not None:
             self.set_weight(weight)

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -273,9 +273,9 @@ class DMatrix(object):
             except:
                 raise TypeError('can not initialize DMatrix from {}'.format(type(data).__name__))
         if label is not None:
-            if data.shape[0] != label.shape[0]:
+            if data.shape[0] != np.array(label).shape[0]:
                 raise ValueError('length mismatch: {} for data vs {} for label'.format(
-                    data.shape[0], label.shape[0]))
+                    data.shape[0], np.array(label).shape[0]))
             self.set_label(label)
         if weight is not None:
             self.set_weight(weight)

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -273,6 +273,8 @@ class DMatrix(object):
             except:
                 raise TypeError('can not initialize DMatrix from {}'.format(type(data).__name__))
         if label is not None:
+            if len(data) != len(label):
+                raise ValueError('length mismatch: {} for data vs {} for label'.format(len(data),len(label)))
             self.set_label(label)
         if weight is not None:
             self.set_weight(weight)

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -273,7 +273,7 @@ class DMatrix(object):
             except:
                 raise TypeError('can not initialize DMatrix from {}'.format(type(data).__name__))
         if label is not None:
-            if len(data) != len(label):
+            if data.shape[0] != label.shape[0]:
                 raise ValueError('length mismatch: {} for data vs {} for label'.format(len(data),len(label)))
             self.set_label(label)
         if weight is not None:

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -87,7 +87,7 @@ class TestBasic(unittest.TestCase):
                           feature_names=list('abcdef'))
         # different length labels
         with self.assertRaises(ValueError):
-            xgb.DMatrix(np.random.randn(5,5),[1,2])
+            xgb.DMatrix(np.random.randn(5,5), [1,2])
         # contains duplicates
         self.assertRaises(ValueError, xgb.DMatrix, data,
                           feature_names=['a', 'b', 'c', 'd', 'd'])

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -85,6 +85,8 @@ class TestBasic(unittest.TestCase):
         # different length
         self.assertRaises(ValueError, xgb.DMatrix, data,
                           feature_names=list('abcdef'))
+        # different length labels
+        self.assertRaises(ValueError, xgb.DMatrix(data,label=[1,2]))
         # contains duplicates
         self.assertRaises(ValueError, xgb.DMatrix, data,
                           feature_names=['a', 'b', 'c', 'd', 'd'])

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -87,7 +87,7 @@ class TestBasic(unittest.TestCase):
                           feature_names=list('abcdef'))
         # different length labels
         with self.assertRaises(ValueError):
-            xgb.DMatrix(np.random.randn(5,5), [1,2])
+            xgb.DMatrix(np.random.randn(5, 5), [1, 2])
         # contains duplicates
         self.assertRaises(ValueError, xgb.DMatrix, data,
                           feature_names=['a', 'b', 'c', 'd', 'd'])

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -86,7 +86,8 @@ class TestBasic(unittest.TestCase):
         self.assertRaises(ValueError, xgb.DMatrix, data,
                           feature_names=list('abcdef'))
         # different length labels
-        self.assertRaises(ValueError, xgb.DMatrix(data,label=[1,2]))
+        with self.assertRaises(ValueError):
+            xgb.DMatrix(np.random.randn(5,5),[1,2])
         # contains duplicates
         self.assertRaises(ValueError, xgb.DMatrix, data,
                           feature_names=['a', 'b', 'c', 'd', 'd'])


### PR DESCRIPTION
Currently, if one's data and labels are not the same length, Python will crash, requiring a restart of the console:
 
![ipython crash](https://cloud.githubusercontent.com/assets/20972961/26355712/b608e2b2-3f97-11e7-85d8-ded13a327935.png)

When using a large dataset that requires several minutes to load, this is very frustrating - one simple error necessitates reloading the files, losing precious time.  This PR fixes the issue by adding a simple check for the length of the labels and data in the DMatrix constructor.  

The issue affects both the Sklearn and Training APIs and is fixed for both APIs here.