### PR TITLE
Update multiclass_obj.cc due to an error in hessian calculation

### DIFF
--- a/src/objective/multiclass_obj.cc
+++ b/src/objective/multiclass_obj.cc
@@ -63,7 +63,7 @@ class SoftmaxMultiClassObj : public ObjFunction {
         const bst_float wt = info.GetWeight(i);
         for (int k = 0; k < nclass; ++k) {
           bst_float p = rec[k];
-          const bst_float h = 2.0f * p * (1.0f - p) * wt;
+          const bst_float h = 1.0f * p * (1.0f - p) * wt;
           if (label == k) {
             out_gpair->at(i * nclass + k) = bst_gpair((p - 1.0f) * wt, h);
           } else {


### PR DESCRIPTION
In line 66, the calculation of hessian (2nd derivatives) is h = 2.0f * p * (1.0f - p) * wt;
However, if you take the derivative from the gradient (line 68 and 70), the correct hessian, I believe is, h = 1.0f * p * (1.0f - p) * wt;
Therefore I proposed this change. I also did some testing. After re-compile codes with h = 1.0f * p * (1.0f - p) * wt, the algorithm found better optimized solution.

Let me know your thoughts.
Xiaowei