### PR TITLE
Minor improvements to xgboost/jvm-packages build 

### DIFF
--- a/jvm-packages/create_jni.sh
+++ b/jvm-packages/create_jni.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -e -x
+
 echo "build java wrapper"
 
 # cd to script's directory

--- a/jvm-packages/xgboost4j/pom.xml
+++ b/jvm-packages/xgboost4j/pom.xml
@@ -40,6 +40,7 @@
                     <plugin>
                         <artifactId>exec-maven-plugin</artifactId>
                         <groupId>org.codehaus.mojo</groupId>
+                        <version>1.6.0</version>
                         <executions>
                             <execution><!-- Run our version calculation script -->
                                 <id>native</id>


### PR DESCRIPTION
- Fixed one of the Maven warnings, complaining about missing version for `exec-maven-plugin`.
- Changed `create_jni.sh` to be easier to debug.