### PR TITLE
Fix C API header compatibility with C compilers

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -7,16 +7,16 @@
 #ifndef XGBOOST_C_API_H_
 #define XGBOOST_C_API_H_
 
-#include <cstdint>
-
 #ifdef __cplusplus
 #define XGB_EXTERN_C extern "C"
+#include <cstdio>
+#else
+#define XGB_EXTERN_C
+#include <stdio.h>
+#include <stdint.h>
 #endif
 
 // XGBoost C API will include APIs in Rabit C API
-XGB_EXTERN_C {
-#include <stdio.h>
-}
 #include <rabit/c_api.h>
 
 #if defined(_MSC_VER) || defined(_WIN32)


### PR DESCRIPTION
Makes `c_api.h` compatible with C compilers - fixes `c_api.h:10:10: fatal error: 'cstdint' file not found`and `error: unknown type name 'uint64_t` errors. This fix was tested on MacOS + Clang and Linux + GCC.

See also https://github.com/dmlc/rabit/pull/44.