### PR TITLE
[jvm-packages] Fixed checkstyle excludes on Windows

### DIFF
--- a/jvm-packages/checkstyle-suppressions.xml
+++ b/jvm-packages/checkstyle-suppressions.xml
@@ -28,6 +28,5 @@
 -->
 
 <suppressions>
-<suppress checks=".*"
-files="xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java"/>
+  <suppress checks=".*" files="XGBoostJNI.java"/>
 </suppressions>


### PR DESCRIPTION
XGBoostJNI.java was not excluded on Windows, probably because the path
specified in 'checkstyle-suppressions.xml' used UNIX file separators.

Closes #2347, #2017.