### PR TITLE
Use int32_t explicitly when serializing version

### DIFF
--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -33,7 +33,7 @@ void MetaInfo::Clear() {
 }
 
 void MetaInfo::SaveBinary(dmlc::Stream *fo) const {
-  int version = kVersion;
+  int32_t version = kVersion;
   fo->Write(&version, sizeof(version));
   fo->Write(&num_row, sizeof(num_row));
   fo->Write(&num_col, sizeof(num_col));


### PR DESCRIPTION
Use int32_t explicitly when serializing version field of dmatrix meta in binary format. On ILP64 architectures, although very little, size of int is 64 bits.