### PR TITLE
[jvm-packages] Build the JNI bindings on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,10 @@
 environment:
         matrix:
-                - solution_name: C:/projects/xgboost/build2013/xgboost.sln
-                - solution_name: C:/projects/xgboost/build2015/xgboost.sln
+                - target: native
+                  solution_name: C:/projects/xgboost/build2013/xgboost.sln
+                - target: native
+                  solution_name: C:/projects/xgboost/build2015/xgboost.sln
+                - target: jvm
 platform:
         - x64
 
@@ -19,5 +22,7 @@ before_build:
         - cmake .. -G"Visual Studio 12 2013 Win64"
         - cd ../build2015
         - cmake .. -G"Visual Studio 14 2015 Win64"
+
 build_script:
-        - msbuild %solution_name% 
+        - if "%target%" == "native" msbuild %solution_name%
+        - if "%target%" == "jvm" cd jvm-packages && C:\Python36-x64\python create_jni.py


### PR DESCRIPTION
This makes Appveyor compile the JNI bindings on Appveyor. No tests are executed.