### PR TITLE
[jvm-packages] Exposed baseMargin

### DIFF
--- a/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/spark/SparkWithRDD.scala
+++ b/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/spark/SparkWithRDD.scala
@@ -49,7 +49,7 @@ object SparkWithRDD {
       "eta" -> 0.1f,
       "max_depth" -> 2,
       "objective" -> "binary:logistic").toMap
-    val xgboostModel = XGBoost.train(trainRDD, paramMap, numRound, nWorkers = args(1).toInt,
+    val xgboostModel = XGBoost.trainWithRDD(trainRDD, paramMap, numRound, nWorkers = args(1).toInt,
       useExternalMemory = true)
     xgboostModel.booster.predict(new DMatrix(testSet))
     // save model to HDFS path

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -53,15 +53,6 @@ case class TrackerConf(workerConnectionTimeout: Long, trackerImpl: String)
 object XGBoost extends Serializable {
   private val logger = LogFactory.getLog("XGBoostSpark")
 
-  private def convertBoosterToXGBoostModel(booster: Booster, isClassification: Boolean):
-      XGBoostModel = {
-    if (!isClassification) {
-      new XGBoostRegressionModel(booster)
-    } else {
-      new XGBoostClassificationModel(booster)
-    }
-  }
-
   private def fromDenseToSparseLabeledPoints(
       denseLabeledPoints: Iterator[MLLabeledPoint],
       missing: Float): Iterator[MLLabeledPoint] = {
@@ -310,8 +301,7 @@ object XGBoost extends Serializable {
       configMap: Map[String, Any], sparkJobThread: Thread, isClassificationTask: Boolean):
     XGBoostModel = {
     if (trackerReturnVal == 0) {
-      val xgboostModel = convertBoosterToXGBoostModel(distributedBoosters.first(),
-        isClassificationTask)
+      val xgboostModel = XGBoostModel(distributedBoosters.first(), isClassificationTask)
       distributedBoosters.unpersist(false)
       xgboostModel
     } else {

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -65,7 +65,6 @@ object XGBoost extends Serializable {
             values += dFeatures.values(i)
           }
         }
-
         val sFeatures = new SparseVector(dFeatures.values.length, indices.result(),
           values.result())
         MLLabeledPoint(label, sFeatures)
@@ -94,9 +93,7 @@ object XGBoost extends Serializable {
     } else {
       trainingSet
     }
-
     val partitionedBaseMargin = baseMargin.repartition(partitionedTrainingSet.getNumPartitions)
-
     val appName = partitionedTrainingSet.context.appName
     // to workaround the empty partitions in training dataset,
     // this might not be the best efficient implementation, see
@@ -107,17 +104,14 @@ object XGBoost extends Serializable {
           s"detected an empty partition in the training data, partition ID:" +
               s" ${TaskContext.getPartitionId()}")
       }
-
       val cacheFileName = if (useExternalMemory) {
         s"$appName-${TaskContext.get().stageId()}-" +
             s"dtrain_cache-${TaskContext.getPartitionId()}"
       } else {
         null
       }
-
       rabitEnv.put("DMLC_TASK_ID", TaskContext.getPartitionId().toString)
       Rabit.init(rabitEnv)
-
       val partitionItr = fromDenseToSparseLabeledPoints(trainingSamples, missing)
       val trainingMatrix = new DMatrix(new JDMatrix(partitionItr, cacheFileName))
       try {

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -209,6 +209,7 @@ object XGBoost extends Serializable {
    * @throws ml.dmlc.xgboost4j.java.XGBoostError when the model training is failed
    * @return XGBoostModel when successful training
    */
+  @deprecated("Use XGBoost.trainWithRDD instead.")
   def train(
       trainingData: RDD[MLLabeledPoint],
       params: Map[String, Any],

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
@@ -331,6 +331,13 @@ abstract class XGBoostModel(protected var _booster: Booster)
 }
 
 object XGBoostModel extends MLReadable[XGBoostModel] {
+  private[spark] def apply(booster: Booster, isClassification: Boolean): XGBoostModel = {
+    if (!isClassification) {
+      new XGBoostRegressionModel(booster)
+    } else {
+      new XGBoostClassificationModel(booster)
+    }
+  }
 
   override def read: MLReader[XGBoostModel] = new XGBoostModelModelReader
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
@@ -125,16 +125,15 @@ abstract class XGBoostModel(protected var _booster: Booster)
               case (null, _) => {
                 val predStr = broadcastBooster.value.evalSet(Array(dMatrix), Array(evalName), iter)
                 val Array(evName, predNumeric) = predStr.split(":")
-                Rabit.shutdown()
                 Iterator(Some(evName, predNumeric.toFloat))
               }
               case _ => {
                 val predictions = broadcastBooster.value.predict(dMatrix)
-                Rabit.shutdown()
                 Iterator(Some((evalName, evalFunc.eval(predictions, dMatrix))))
               }
             }
           } finally {
+            Rabit.shutdown()
             dMatrix.delete()
           }
         } else {
@@ -152,7 +151,7 @@ abstract class XGBoostModel(protected var _booster: Booster)
    * @param testSet test set represented as RDD
    * @param missingValue the specified value to represent the missing value
    */
-  def predict(testSet: RDD[MLDenseVector], missingValue: Float): RDD[Array[Array[Float]]] = {
+  def predict(testSet: RDD[MLDenseVector], missingValue: Float): RDD[Array[Float]] = {
     val broadcastBooster = testSet.sparkContext.broadcast(_booster)
     testSet.mapPartitions { testSamples =>
       val sampleArray = testSamples.toList
@@ -170,10 +169,9 @@ abstract class XGBoostModel(protected var _booster: Booster)
         }
         val dMatrix = new DMatrix(flatSampleArray, numRows, numColumns, missingValue)
         try {
-          val res = broadcastBooster.value.predict(dMatrix)
-          Rabit.shutdown()
-          Iterator(res)
+          broadcastBooster.value.predict(dMatrix).iterator
         } finally {
+          Rabit.shutdown()
           dMatrix.delete()
         }
       }
@@ -187,7 +185,7 @@ abstract class XGBoostModel(protected var _booster: Booster)
    * @param useExternalCache whether to use external cache for the test set
    */
   def predict(testSet: RDD[MLVector], useExternalCache: Boolean = false):
-      RDD[Array[Array[Float]]] = {
+      RDD[Array[Float]] = {
     val broadcastBooster = testSet.sparkContext.broadcast(_booster)
     val appName = testSet.context.appName
     testSet.mapPartitions { testSamples =>
@@ -204,10 +202,9 @@ abstract class XGBoostModel(protected var _booster: Booster)
         }
         val dMatrix = new DMatrix(new JDMatrix(testSamples, cacheFileName))
         try {
-          val res = broadcastBooster.value.predict(dMatrix)
-          Rabit.shutdown()
-          Iterator(res)
+          broadcastBooster.value.predict(dMatrix).iterator
         } finally {
+          Rabit.shutdown()
           dMatrix.delete()
         }
       } else {

--- a/jvm-packages/xgboost4j-spark/src/test/resources/log4j.properties
+++ b/jvm-packages/xgboost4j-spark/src/test/resources/log4j.properties
@@ -1,0 +1,1 @@
+log4j.logger.org.apache.spark=ERROR

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/SharedSparkContext.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/SharedSparkContext.scala
@@ -22,19 +22,22 @@ import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite}
 trait SharedSparkContext extends FunSuite with BeforeAndAfter with BeforeAndAfterAll
   with Serializable {
 
-  @transient protected implicit var sc: SparkContext = null
+  @transient protected implicit var sc: SparkContext = _
 
   override def beforeAll() {
-    // build SparkContext
-    val sparkConf = new SparkConf().setMaster("local[*]").setAppName("XGBoostSuite").
-      set("spark.driver.memory", "512m")
+    val sparkConf = new SparkConf()
+      .setMaster("local[*]")
+      .setAppName("XGBoostSuite")
+      .set("spark.driver.memory", "512m")
+      .set("spark.ui.enabled", "false")
+
     sc = new SparkContext(sparkConf)
-    sc.setLogLevel("ERROR")
   }
 
   override def afterAll() {
     if (sc != null) {
       sc.stop()
+      sc = null
     }
   }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
@@ -253,7 +253,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
       "objective" -> "binary:logistic")
     val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, 5, numWorkers)
     val predRDD = xgBoostModel.predict(testRDD)
-    val predResult1 = predRDD.collect()(0)
+    val predResult1 = predRDD.collect()
     assert(testRDD.count() === predResult1.length)
     import DataUtils._
     val predResult2 = xgBoostModel.booster.predict(new DMatrix(testSet.iterator))
@@ -359,7 +359,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
     val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, 5, nWorkers = 1)
     val predRDD = xgBoostModel.predict(testRDD)
-    val predResult1: Array[Array[Float]] = predRDD.collect()(0)
+    val predResult1: Array[Array[Float]] = predRDD.collect()
     assert(testRDD.count() === predResult1.length)
 
     val avgMetric = xgBoostModel.eval(trainingRDD, "test", iter = 0, groupData = trainGroupData)
@@ -387,7 +387,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
     val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, 5, nWorkers = 2)
     val predRDD = xgBoostModel.predict(testRDD)
-    val predResult1: Array[Array[Float]] = predRDD.collect()(0)
+    val predResult1: Array[Array[Float]] = predRDD.collect()
     assert(testRDD.count() === predResult1.length)
   }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
@@ -252,7 +252,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
       "objective" -> "binary:logistic")
     val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, 5, numWorkers)
     val predRDD = xgBoostModel.predict(testRDD)
-    val predResult1 = predRDD.collect()
+    val predResult1 = predRDD.collect()(0)
     assert(testRDD.count() === predResult1.length)
     import DataUtils._
     val predResult2 = xgBoostModel.booster.predict(new DMatrix(testSet.iterator))
@@ -358,7 +358,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
     val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, 5, nWorkers = 1)
     val predRDD = xgBoostModel.predict(testRDD)
-    val predResult1: Array[Array[Float]] = predRDD.collect()
+    val predResult1: Array[Array[Float]] = predRDD.collect()(0)
     assert(testRDD.count() === predResult1.length)
 
     val avgMetric = xgBoostModel.eval(trainingRDD, "test", iter = 0, groupData = trainGroupData)
@@ -386,7 +386,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
     val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, 5, nWorkers = 2)
     val predRDD = xgBoostModel.predict(testRDD)
-    val predResult1: Array[Array[Float]] = predRDD.collect()
+    val predResult1: Array[Array[Float]] = predRDD.collect()(0)
     assert(testRDD.count() === predResult1.length)
   }
 
@@ -403,7 +403,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
       val trainMargin = {
         XGBoost.trainWithRDD(trainRDD, paramMap, round = 1, nWorkers = 2)
             .predict(trainRDD.map(_.features), outputMargin = true)
-            .map { case Array(m) => m }
+            .flatMap { _.flatten.iterator }
       }
 
       val xgBoostModel = XGBoost.trainWithRDD(
@@ -413,6 +413,6 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
         nWorkers = 2,
         baseMargin = trainMargin)
 
-      assert(testRDD.count() === xgBoostModel.predict(testRDD).count())
+      assert(testRDD.count() === xgBoostModel.predict(testRDD).first().length)
     }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
@@ -17,17 +17,15 @@
 package ml.dmlc.xgboost4j.scala.spark
 
 import java.nio.file.Files
-import java.util.concurrent.{BlockingQueue, LinkedBlockingDeque}
+import java.util.concurrent.LinkedBlockingDeque
 
 import scala.collection.mutable.ListBuffer
 import scala.io.Source
 import scala.util.Random
-import scala.concurrent.duration._
 
-import ml.dmlc.xgboost4j.java.{Rabit, DMatrix => JDMatrix, RabitTracker => PyRabitTracker}
+import ml.dmlc.xgboost4j.java.{Rabit, DMatrix => JDMatrix}
 import ml.dmlc.xgboost4j.scala.DMatrix
 import ml.dmlc.xgboost4j.scala.rabit.RabitTracker
-import org.scalatest.Ignore
 
 import org.apache.spark.SparkContext
 import org.apache.spark.ml.feature.LabeledPoint
@@ -83,7 +81,8 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
       List("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
         "objective" -> "binary:logistic").toMap,
       new java.util.HashMap[String, String](),
-      numWorkers = 2, round = 5, eval = null, obj = null, useExternalMemory = true)
+      numWorkers = 2, round = 5, eval = null, obj = null, useExternalMemory = true,
+      missing = Float.NaN, baseMargin = null)
     val boosterCount = boosterRDD.count()
     assert(boosterCount === 2)
     cleanExternalCache("XGBoostSuite")
@@ -390,4 +389,30 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
     val predResult1: Array[Array[Float]] = predRDD.collect()
     assert(testRDD.count() === predResult1.length)
   }
+
+    test("test use base margin") {
+      val trainSet = loadLabelPoints(getClass.getResource("/rank-demo-0.txt.train").getFile)
+      val trainRDD = sc.parallelize(trainSet, numSlices = 1)
+
+      val testSet = loadLabelPoints(getClass.getResource("/rank-demo.txt.test").getFile)
+      val testRDD = sc.parallelize(testSet, numSlices = 1).map(_.features)
+
+      val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
+        "objective" -> "rank:pairwise")
+
+      val trainMargin = {
+        XGBoost.trainWithRDD(trainRDD, paramMap, round = 1, nWorkers = 2)
+            .predict(trainRDD.map(_.features), outputMargin = true)
+            .map { case Array(m) => m }
+      }
+
+      val xgBoostModel = XGBoost.trainWithRDD(
+        trainRDD,
+        paramMap,
+        round = 1,
+        nWorkers = 2,
+        baseMargin = trainMargin)
+
+      assert(testRDD.count() === xgBoostModel.predict(testRDD).count())
+    }
 }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -171,26 +171,19 @@ public class DMatrix {
   }
 
   /**
-   * if specified, xgboost will start from this init margin
-   * can be used to specify initial prediction to boost from
+   * Set base margin (initial prediction).
    *
-   * @param baseMargin base margin
-   * @throws XGBoostError native error
+   * The margin must have the same number of elements as the number of
+   * rows in this matrix.
    */
   public void setBaseMargin(float[] baseMargin) throws XGBoostError {
-    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixSetFloatInfo(handle, "base_margin", baseMargin));
-  }
+    if (baseMargin.length != rowNum()) {
+      throw new IllegalArgumentException(String.format(
+              "base margin must have exactly %s elements, got %s",
+              rowNum(), baseMargin.length));
+    }
 
-  /**
-   * if specified, xgboost will start from this init margin
-   * can be used to specify initial prediction to boost from
-   *
-   * @param baseMargin base margin
-   * @throws XGBoostError native error
-   */
-  public void setBaseMargin(float[][] baseMargin) throws XGBoostError {
-    float[] flattenMargin = flatten(baseMargin);
-    setBaseMargin(flattenMargin);
+    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixSetFloatInfo(handle, "base_margin", baseMargin));
   }
 
   /**
@@ -236,10 +229,7 @@ public class DMatrix {
   }
 
   /**
-   * get base margin of the DMatrix
-   *
-   * @return base margin
-   * @throws XGBoostError native error
+   * Get base margin of the DMatrix.
    */
   public float[] getBaseMargin() throws XGBoostError {
     return getFloatInfo("base_margin");
@@ -284,22 +274,6 @@ public class DMatrix {
    */
   public long getHandle() {
     return handle;
-  }
-
-  /**
-   * flatten a mat to array
-   */
-  private static float[] flatten(float[][] mat) {
-    int size = 0;
-    for (float[] array : mat) size += array.length;
-    float[] result = new float[size];
-    int pos = 0;
-    for (float[] ar : mat) {
-      System.arraycopy(ar, 0, result, pos, ar.length);
-      pos += ar.length;
-    }
-
-    return result;
   }
 
   @Override

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -187,6 +187,13 @@ public class DMatrix {
   }
 
   /**
+   * Set base margin (initial prediction).
+   */
+  public void setBaseMargin(float[][] baseMargin) throws XGBoostError {
+    setBaseMargin(flatten(baseMargin));
+  }
+
+  /**
    * Set group sizes of DMatrix (used for ranking)
    *
    * @param group group size as array
@@ -274,6 +281,22 @@ public class DMatrix {
    */
   public long getHandle() {
     return handle;
+  }
+
+  /**
+   * flatten a mat to array
+   */
+  private static float[] flatten(float[][] mat) {
+    int size = 0;
+    for (float[] array : mat) size += array.length;
+    float[] result = new float[size];
+    int pos = 0;
+    for (float[] ar : mat) {
+      System.arraycopy(ar, 0, result, pos, ar.length);
+      pos += ar.length;
+    }
+
+    return result;
   }
 
   @Override

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DataBatch.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DataBatch.java
@@ -70,9 +70,7 @@ class DataBatch {
         rowOffset[i] = offset;
         label[i] = labeledPoint.label;
         if (labeledPoint.indices != null) {
-          System.arraycopy(
-                  labeledPoint.indices, 0,
-                  featureIndex, offset,
+          System.arraycopy(labeledPoint.indices, 0, featureIndex, offset,
                   labeledPoint.indices.length);
         } else {
           for (int j = 0; j < labeledPoint.values.length; j++) {

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DataBatch.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DataBatch.java
@@ -1,7 +1,8 @@
 package ml.dmlc.xgboost4j.java;
 
-import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 import ml.dmlc.xgboost4j.LabeledPoint;
 
@@ -13,20 +14,18 @@ import ml.dmlc.xgboost4j.LabeledPoint;
  */
 class DataBatch {
   /** The offset of each rows in the sparse matrix */
-  long[] rowOffset = null;
+  final long[] rowOffset;
   /** weight of each data point, can be null */
-  float[] weight = null;
+  final float[] weight;
   /** label of each data point, can be null */
-  float[] label = null;
+  final float[] label;
   /** index of each feature(column) in the sparse matrix */
-  int[] featureIndex = null;
+  final int[] featureIndex;
   /** value of each non-missing entry in the sparse matrix */
-  float[] featureValue = null;
+  final float[] featureValue ;
 
-  public DataBatch() {}
-
-  public DataBatch(long[] rowOffset, float[] weight, float[] label, int[] featureIndex,
-                   float[] featureValue) {
+  DataBatch(long[] rowOffset, float[] weight, float[] label, int[] featureIndex,
+            float[] featureValue) {
     this.rowOffset = rowOffset;
     this.weight = weight;
     this.label = label;
@@ -34,80 +33,64 @@ class DataBatch {
     this.featureValue = featureValue;
   }
 
-
-  /**
-   * Get number of rows in the data batch.
-   * @return Number of rows in the data batch.
-   */
-  public int numRows() {
-    return rowOffset.length - 1;
-  }
-
-  /**
-   * Shallow copy a DataBatch
-   * @return a copy of the batch
-   */
-  public DataBatch shallowCopy() {
-    DataBatch b = new DataBatch();
-    b.rowOffset = this.rowOffset;
-    b.weight = this.weight;
-    b.label = this.label;
-    b.featureIndex = this.featureIndex;
-    b.featureValue = this.featureValue;
-    return b;
-  }
-
   static class BatchIterator implements Iterator<DataBatch> {
-    private Iterator<LabeledPoint> base;
-    private int batchSize;
+    private final Iterator<LabeledPoint> base;
+    private final int batchSize;
 
-    BatchIterator(java.util.Iterator<LabeledPoint> base, int batchSize) {
+    BatchIterator(Iterator<LabeledPoint> base, int batchSize) {
       this.base = base;
       this.batchSize = batchSize;
     }
+
     @Override
     public boolean hasNext() {
       return base.hasNext();
     }
+
     @Override
     public DataBatch next() {
-      int num_rows = 0, num_elem = 0;
-      java.util.List<LabeledPoint> batch = new java.util.ArrayList<LabeledPoint>();
-      for (int i = 0; i < this.batchSize; ++i) {
-        if (!base.hasNext()) break;
-        LabeledPoint inst = base.next();
-        batch.add(inst);
-        num_elem += inst.values.length;
-        ++num_rows;
+      int numRows = 0;
+      int numElem = 0;
+      List<LabeledPoint> batch = new ArrayList<>(batchSize);
+      while (base.hasNext() && batch.size() < batchSize) {
+        LabeledPoint labeledPoint = base.next();
+        batch.add(labeledPoint);
+        numElem += labeledPoint.values.length;
+        numRows++;
       }
-      DataBatch ret = new DataBatch();
-      // label
-      ret.rowOffset = new long[num_rows + 1];
-      ret.label = new float[num_rows];
-      ret.featureIndex = new int[num_elem];
-      ret.featureValue = new float[num_elem];
-      // current offset
+
+      long[] rowOffset = new long[numRows + 1];
+      float[] label = new float[numRows];
+      int[] featureIndex = new int[numElem];
+      float[] featureValue = new float[numElem];
+
       int offset = 0;
-      for (int i = 0; i < batch.size(); ++i) {
-        LabeledPoint inst = batch.get(i);
-        ret.rowOffset[i] = offset;
-        ret.label[i] = inst.label;
-        if (inst.indices != null) {
-          System.arraycopy(inst.indices, 0, ret.featureIndex, offset, inst.indices.length);
-        } else{
-          for (int j = 0; j < inst.values.length; ++j) {
-            ret.featureIndex[offset + j] = j;
+      for (int i = 0; i < batch.size(); i++) {
+        LabeledPoint labeledPoint = batch.get(i);
+        rowOffset[i] = offset;
+        label[i] = labeledPoint.label;
+        if (labeledPoint.indices != null) {
+          System.arraycopy(
+                  labeledPoint.indices, 0,
+                  featureIndex, offset,
+                  labeledPoint.indices.length);
+        } else {
+          for (int j = 0; j < labeledPoint.values.length; j++) {
+            featureIndex[offset + j] = j;
           }
         }
-        System.arraycopy(inst.values, 0, ret.featureValue, offset, inst.values.length);
-        offset += inst.values.length;
+
+        System.arraycopy(labeledPoint.values, 0, featureValue, offset, labeledPoint.values.length);
+        offset += labeledPoint.values.length;
       }
-      ret.rowOffset[batch.size()] = offset;
-      return ret;
+
+      rowOffset[batch.size()] = offset;
+      return new DataBatch(rowOffset, null, label, featureIndex, featureValue);
     }
+
     @Override
     public void remove() {
-      throw new Error("not implemented");
+      throw new UnsupportedOperationException("DataBatch.BatchIterator.remove");
     }
   }
 }

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
@@ -129,11 +129,11 @@ class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
   }
 
   /**
-    * if specified, xgboost will start from this init margin
-    * can be used to specify initial prediction to boost from
-    *
-    * @param baseMargin base margin
-    */
+   * if specified, xgboost will start from this init margin
+   * can be used to specify initial prediction to boost from
+   *
+   * @param baseMargin base margin
+   */
   @throws(classOf[XGBoostError])
   def setBaseMargin(baseMargin: Array[Array[Float]]): Unit = {
     jDMatrix.setBaseMargin(baseMargin)

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
@@ -127,18 +127,7 @@ class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
   def setBaseMargin(baseMargin: Array[Float]): Unit = {
     jDMatrix.setBaseMargin(baseMargin)
   }
-
-  /**
-   * if specified, xgboost will start from this init margin
-   * can be used to specify initial prediction to boost from
-   *
-   * @param baseMargin base margin
-   */
-  @throws(classOf[XGBoostError])
-  def setBaseMargin(baseMargin: Array[Array[Float]]): Unit = {
-    jDMatrix.setBaseMargin(baseMargin)
-  }
-
+  
   /**
    * Set group sizes of DMatrix (used for ranking)
    *

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
@@ -127,7 +127,7 @@ class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
   def setBaseMargin(baseMargin: Array[Float]): Unit = {
     jDMatrix.setBaseMargin(baseMargin)
   }
-  
+
   /**
    * Set group sizes of DMatrix (used for ranking)
    *

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
@@ -129,6 +129,17 @@ class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
   }
 
   /**
+    * if specified, xgboost will start from this init margin
+    * can be used to specify initial prediction to boost from
+    *
+    * @param baseMargin base margin
+    */
+  @throws(classOf[XGBoostError])
+  def setBaseMargin(baseMargin: Array[Array[Float]]): Unit = {
+    jDMatrix.setBaseMargin(baseMargin)
+  }
+
+  /**
    * Set group sizes of DMatrix (used for ranking)
    *
    * @param group group size as array


### PR DESCRIPTION
The users can now initialize boosting with predictions from an external model. This feature is implemented via RDD API and therefore does not require the user to know the partitioning of the training set.