### PR TITLE
Fixed shared library loading in the Python package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,15 @@ ifndef LINT_LANG
 	LINT_LANG= "all"
 endif
 
-ifneq ($(UNAME), Windows)
-	CFLAGS += -fPIC
-	XGBOOST_DYLIB = lib/libxgboost.so
-else
+ifeq ($(UNAME), Windows)
 	XGBOOST_DYLIB = lib/libxgboost.dll
 	JAVAINCFLAGS += -I${JAVA_HOME}/include/win32
+else ifeq ($(UNAME), Darwin)
+	XGBOOST_DYLIB = lib/libxgboost.dylib
+	CFLAGS += -fPIC
+else
+	XGBOOST_DYLIB = lib/libxgboost.so
+	CFLAGS += -fPIC
 endif
 
 ifeq ($(UNAME), Linux)
@@ -162,7 +165,7 @@ lib/libxgboost.a: $(ALL_DEP)
 	@mkdir -p $(@D)
 	ar crv $@ $(filter %.o, $?)
 
-lib/libxgboost.dll lib/libxgboost.so: $(ALL_DEP)
+lib/libxgboost.dll lib/libxgboost.so lib/libxgboost.dylib: $(ALL_DEP)
 	@mkdir -p $(@D)
 	$(CXX) $(CFLAGS) -shared -o $@ $(filter %.o %a,  $^) $(LDFLAGS)
 

--- a/python-package/xgboost/libpath.py
+++ b/python-package/xgboost/libpath.py
@@ -34,7 +34,11 @@ def find_lib_path():
             # hack for pip installation when copy all parent source directory here
             dll_path.append(os.path.join(curr_path, './windows/Release/'))
         dll_path = [os.path.join(p, 'xgboost.dll') for p in dll_path]
+    elif sys.platform.startswith('linux'):
         dll_path = [os.path.join(p, 'libxgboost.so') for p in dll_path]
+    elif sys.platform == 'darwin':
+        dll_path = [os.path.join(p, 'libxgboost.dylib') for p in dll_path]
+
     lib_path = [p for p in dll_path if os.path.exists(p) and os.path.isfile(p)]
 
     # From github issues, most of installation errors come from machines w/o compilers

--- a/python-package/xgboost/libpath.py
+++ b/python-package/xgboost/libpath.py
@@ -24,7 +24,7 @@ def find_lib_path():
     dll_path = [curr_path, os.path.join(curr_path, '../../lib/'),
                 os.path.join(curr_path, './lib/'),
                 os.path.join(sys.prefix, 'xgboost')]
-    if os.name == 'nt':
+    if sys.platform == 'win32':
         if platform.architecture()[0] == '64bit':
             dll_path.append(os.path.join(curr_path, '../../windows/x64/Release/'))
             # hack for pip installation when copy all parent source directory here
@@ -33,8 +33,7 @@ def find_lib_path():
             dll_path.append(os.path.join(curr_path, '../../windows/Release/'))
             # hack for pip installation when copy all parent source directory here
             dll_path.append(os.path.join(curr_path, './windows/Release/'))
-        dll_path = [os.path.join(p, 'libxgboost.dll') for p in dll_path]
-    else:
+        dll_path = [os.path.join(p, 'xgboost.dll') for p in dll_path]
         dll_path = [os.path.join(p, 'libxgboost.so') for p in dll_path]
     lib_path = [p for p in dll_path if os.path.exists(p) and os.path.isfile(p)]
 


### PR DESCRIPTION
As discussed in 2cb51f7097df44f7f2993d47865b0090194e2dc4.

I haven't implemented the symlink, because 
* it was previously broken for OS X as well (the shared library had an .so extension) and 
* I'd rather prefer pushing the users to do the right thing. 

If you think I should do otherwise, please comment.