### PR TITLE
CV: silent error on folds using generators

### DIFF
--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import
 
 import warnings
+import collections
 import numpy as np
 from .core import Booster, STRING_TYPES, XGBoostError, CallbackEnv, EarlyStopException
 from .compat import (SKLEARN_INSTALLED, XGBStratifiedKFold)
@@ -237,7 +238,7 @@ def mknfold(dall, nfold, param, seed, evals=(), fpreproc=None, stratified=False,
             idx = np.arange(dall.num_row())
         kstep = int(len(idx) / nfold)
         idset = [idx[(i * kstep): min(len(idx), (i + 1) * kstep)] for i in range(nfold)]
-    elif folds is not None and isinstance(folds, list):
+    elif folds is not None and isinstance(folds, (list, collections.Iterable)):
         idset = [x[1] for x in folds]
         nfold = len(idset)
     else:

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -238,7 +238,7 @@ def mknfold(dall, nfold, param, seed, evals=(), fpreproc=None, stratified=False,
             idx = np.arange(dall.num_row())
         kstep = int(len(idx) / nfold)
         idset = [idx[(i * kstep): min(len(idx), (i + 1) * kstep)] for i in range(nfold)]
-    elif folds is not None and isinstance(folds, (list, collections.Iterable)):
+    elif folds is not None and isinstance(folds, collections.Iterable):
         idset = [x[1] for x in folds]
         nfold = len(idset)
     else:


### PR DESCRIPTION
When passing custom generator folds to an `xgboost.cv` instance, e.g.:
```
((shuffle(train, random_state=42), shuffle(test, random_state=42))
for train, test in group_kfold.split(X, y, r))
```
XGBoost silently re-creates its own folds, as the iterable type is not caught at line 241 in `mknfold`:
```
    elif folds is not None and isinstance(folds, list):
        idset = [x[1] for x in folds]
        nfold = len(idset)
```