### PR TITLE
[GPU-Plugin] Multi-GPU gpu_id bug fixes and additional documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 *.Rcheck
 *.rds
 *.tar.gz
-*txt*
+#*txt*
 *conf
 *buffer
 *model

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,8 @@ project (xgboost)
 find_package(OpenMP)
 
 option(PLUGIN_UPDATER_GPU "Build GPU accelerated tree construction plugin")
-set(GPU_COMPUTE_VER 35;50;52;60;61 CACHE STRING
-    "Space separated list of compute versions to be built against")
 if(PLUGIN_UPDATER_GPU)
   cmake_minimum_required (VERSION 3.5)
-  find_package(CUDA REQUIRED)
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
@@ -83,6 +80,14 @@ set(RABIT_SOURCES
     rabit/src/c_api.cc
 )
 
+set(NCCL_SOURCES
+    nccl/src/*.cu
+)
+set(UPDATER_GPU_SOURCES
+    plugin/updater_gpu/src/*.cu
+    plugin/updater_gpu/src/exact/*.cu
+)
+
 add_subdirectory(dmlc-core)
 
 add_library(rabit STATIC ${RABIT_SOURCES})
@@ -102,35 +107,44 @@ endif()
 set(LINK_LIBRARIES dmlccore rabit)
 
 if(PLUGIN_UPDATER_GPU)
-    # nccl
-    set(LINK_LIBRARIES ${LINK_LIBRARIES} nccl)
-    add_subdirectory(nccl)
-    set(NCCL_DIRECTORY ${PROJECT_SOURCE_DIR}/nccl)
-    include_directories(${NCCL_DIRECTORY}/src)
-    set(LINK_LIBRARIES ${LINK_LIBRARIES} ${CUDA_LIBRARIES})
-    #Find cub
-    set(CUB_DIRECTORY ${PROJECT_SOURCE_DIR}/cub/)
-    include_directories(${CUB_DIRECTORY})
-    #Find googletest
-    set(GTEST_DIRECTORY "${CACHE_PREFIX}" CACHE PATH "Googletest directory")
-    include_directories(${GTEST_DIRECTORY}/include)
-    #gencode flags
-    set(GENCODE_FLAGS "")
-    foreach(ver ${GPU_COMPUTE_VER})
-      set(GENCODE_FLAGS "${GENCODE_FLAGS}-gencode arch=compute_${ver},code=sm_${ver};")
-    endforeach()
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};--expt-extended-lambda;${GENCODE_FLAGS};-lineinfo;")
-    if(NOT MSVC)
-      set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xcompiler -fPIC")
-    endif()
-    set(CUDA_SOURCES
-      plugin/updater_gpu/src/updater_gpu.cu
-      plugin/updater_gpu/src/gpu_hist_builder.cu
-      )
-    # use below for forcing specific arch
-    cuda_compile(CUDA_OBJS ${CUDA_SOURCES} ${CUDA_NVCC_FLAGS})
+  find_package(CUDA REQUIRED)
+  
+  # nccl
+  set(LINK_LIBRARIES ${LINK_LIBRARIES} nccl)
+  add_subdirectory(nccl)
+  set(NCCL_DIRECTORY ${PROJECT_SOURCE_DIR}/nccl)
+  include_directories(${NCCL_DIRECTORY}/src)
+
+  #Find cub
+  set(CUB_DIRECTORY ${PROJECT_SOURCE_DIR}/cub/)
+  include_directories(${CUB_DIRECTORY})
+
+  #Find googletest
+  set(GTEST_DIRECTORY "${CACHE_PREFIX}" CACHE PATH "Googletest directory")
+  include_directories(${GTEST_DIRECTORY}/include)
+
+  #gencode flags
+  set(GPU_COMPUTE_VER 35;50;52;60;61 CACHE STRING
+    "Space separated list of compute versions to be built against")
+  
+  set(GENCODE_FLAGS "")
+  foreach(ver ${GPU_COMPUTE_VER})
+    set(GENCODE_FLAGS "${GENCODE_FLAGS}-gencode arch=compute_${ver},code=sm_${ver};")
+  endforeach()
+  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};--expt-extended-lambda;${GENCODE_FLAGS};-lineinfo;")
+  if(NOT MSVC)
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xcompiler -fPIC")
+  endif()
+  set(CUDA_SOURCES
+    plugin/updater_gpu/src/updater_gpu.cu
+    plugin/updater_gpu/src/gpu_hist_builder.cu
+    )
+  # use below for forcing specific arch
+  cuda_compile(CUDA_OBJS ${CUDA_SOURCES} ${CUDA_NVCC_FLAGS})
+  
+
 else()
-    set(CUDA_OBJS "")
+  set(CUDA_OBJS "")
 endif()
 
 add_library(objxgboost OBJECT ${SOURCES})

--- a/plugin/updater_gpu/README.md
+++ b/plugin/updater_gpu/README.md
@@ -63,6 +63,22 @@ submodule: The plugin also depends on CUB 1.6.4 - https://nvlabs.github.io/cub/ 
 
 submodule: NVIDIA NCCL from https://github.com/NVIDIA/nccl with windows port allowed by git@github.com:h2oai/nccl.git
 
+## Download full repo + full submodules for your choice (or empty) path <mypath>
+
+git clone --recursive https://github.com/dmlc/xgboost.git <mypath>
+
+## Download with shallow submodules for much quicker download:
+
+git 2.9.0+ (assumes only HEAD used for all submodules, but not true currently for dmlc-core and rabbit)
+
+git clone --recursive --shallow-submodules https://github.com/dmlc/xgboost.git <mypath>
+
+git 2.9.0-: (only cub is shallow, as largest repo)
+
+git clone https://github.com/dmlc/xgboost.git <mypath>
+cd <mypath>
+bash plugin/updater/gpu/gitshallow_submodules.sh
+
 ## Build
 
 From the command line on Linux starting from the xgboost directory:
@@ -84,11 +100,17 @@ $ mkdir build
 $ cd build
 $ cmake .. -G"Visual Studio 14 2015 Win64" -DPLUGIN_UPDATER_GPU=ON
 ```
-Cmake will generate an xgboost.sln solution file in the build directory. Build this solution in release mode as a x64 build.
+Cmake will create an xgboost.sln solution file in the build directory. Build this solution in release mode as a x64 build.
 
 Visual studio community 2015, supported by cuda toolkit (http://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/#axzz4isREr2nS), can be downloaded from: https://my.visualstudio.com/Downloads?q=Visual%20Studio%20Community%202015 .  You may also be able to use a later version of visual studio depending on whether the CUDA toolkit supports it.  Note that Mingw cannot be used with cuda.
 
+### For other nccl libraries
+
+On some systems, nccl libraries are specific to a particular system (IBM Power or nvidia-docker) and can enable use of nvlink (between GPUs or even between GPUs and system memory).  In that case, one wants to avoid the static nccl library by changing "STATIC" to "SHARED" in nccl/CMakeLists.txt and deleting the shared nccl library created (so that the system one is used).
+
 ### For Developers!
+
+
 
 In case you want to build only for a specific GPU(s), for eg. GP100 and GP102,
 whose compute capability are 60 and 61 respectively:
@@ -101,12 +123,12 @@ By default, the versions will include support for all GPUs in Maxwell and Pascal
 Now, it also supports the usual 'make' flow to build gpu-enabled tree construction plugins. It's currently only tested on Linux. From the xgboost directory
 ```bash
 # make sure CUDA SDK bin directory is in the 'PATH' env variable
-$ make PLUGIN_UPDATER_GPU=ON
+$ make -j PLUGIN_UPDATER_GPU=ON
 ```
 
 Similar to cmake, if you want to build only for a specific GPU(s):
 ```bash
-$ make PLUGIN_UPDATER_GPU=ON GPU_COMPUTE_VER="60 61"
+$ make -j PLUGIN_UPDATER_GPU=ON GPU_COMPUTE_VER="60 61"
 ```
 
 ### For Developers!

--- a/plugin/updater_gpu/benchmark/benchmark.py
+++ b/plugin/updater_gpu/benchmark/benchmark.py
@@ -16,6 +16,8 @@ def run_benchmark(args, gpu_algorithm, cpu_algorithm):
     param = {'objective': 'binary:logistic',
              'max_depth': 6,
              'silent': 1,
+             'n_gpus': 1,
+             'gpu_id': 0,
              'eval_metric': 'auc'}
 
     param['tree_method'] = gpu_algorithm
@@ -41,9 +43,9 @@ args = parser.parse_args()
 
 if 'gpu_hist' in args.algorithm:
     run_benchmark(args, args.algorithm, 'hist')
-if 'gpu_exact' in args.algorithm:
+elif 'gpu_exact' in args.algorithm:
     run_benchmark(args, args.algorithm, 'exact')
-if 'all' in args.algorithm:
+elif 'all' in args.algorithm:
     run_benchmark(args, 'gpu_exact', 'exact')
     run_benchmark(args, 'gpu_hist', 'hist')
 

--- a/plugin/updater_gpu/gitshallow_submodules.sh
+++ b/plugin/updater_gpu/gitshallow_submodules.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+git submodule init
+for i in $(git submodule | awk '{print $2}'); do
+    spath=$(git config -f .gitmodules --get submodule.$i.path)
+    surl=$(git config -f .gitmodules --get submodule.$i.url)
+    if [ $spath == "cub" ]
+    then
+        git submodule update --depth 3 $spath
+    else
+        git submodule update $spath
+    fi
+done

--- a/plugin/updater_gpu/src/device_helpers.cuh
+++ b/plugin/updater_gpu/src/device_helpers.cuh
@@ -9,11 +9,11 @@
 #include <algorithm>
 #include <chrono>
 #include <ctime>
+#include <cub/cub.cuh>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <numeric>
-#include <cub/cub.cuh>
 
 #ifndef NCCL
 #define NCCL 1
@@ -29,8 +29,8 @@
 
 namespace dh {
 
-#define HOST_DEV_INLINE  __host__ __device__ __forceinline__
-#define DEV_INLINE       __device__ __forceinline__
+#define HOST_DEV_INLINE __host__ __device__ __forceinline__
+#define DEV_INLINE __device__ __forceinline__
 
 /*
  * Error handling  functions
@@ -126,6 +126,11 @@ inline std::string device_name(int device_idx) {
   return std::string(prop.name);
 }
 
+// ensure gpu_id is correct, so not dependent upon user knowing details
+inline int get_device_idx(int gpu_id) {
+  // protect against overrun for gpu_id
+  return (std::abs(gpu_id) + 0) % dh::n_visible_devices();
+}
 
 /*
  *  Timers
@@ -309,11 +314,13 @@ enum memory_type { DEVICE, DEVICE_MANAGED };
 
 template <memory_type MemoryT>
 class bulk_allocator;
-template <typename T> class dvec2;
+template <typename T>
+class dvec2;
 
 template <typename T>
 class dvec {
- friend class dvec2<T>;
+  friend class dvec2<T>;
+
  private:
   T *_ptr;
   size_t _size;
@@ -327,9 +334,10 @@ class dvec {
     _ptr = static_cast<T *>(ptr);
     _size = size;
     _device_idx = device_idx;
+    safe_cuda(cudaSetDevice(_device_idx));
   }
 
-  dvec() : _ptr(NULL), _size(0), _device_idx(0) {}
+  dvec() : _ptr(NULL), _size(0), _device_idx(-1) {}
   size_t size() const { return _size; }
   int device_idx() const { return _device_idx; }
   bool empty() const { return _ptr == NULL || _size == 0; }
@@ -378,6 +386,10 @@ class dvec {
     if (other.device_idx() == this->device_idx()) {
       thrust::copy(other.tbegin(), other.tend(), this->tbegin());
     } else {
+      std::cout << "deviceother: " << other.device_idx()
+                << " devicethis: " << this->device_idx() << std::endl;
+      std::cout << "size deviceother: " << other.size()
+                << " devicethis: " << this->device_idx() << std::endl;
       throw std::runtime_error("Cannot copy to/from different devices");
     }
 
@@ -401,26 +413,24 @@ class dvec {
  */
 template <typename T>
 class dvec2 {
-
  private:
   dvec<T> _d1, _d2;
   cub::DoubleBuffer<T> _buff;
   int _device_idx;
-
 
  public:
   void external_allocate(int device_idx, void *ptr1, void *ptr2, size_t size) {
     if (!empty()) {
       throw std::runtime_error("Tried to allocate dvec2 but already allocated");
     }
+    _device_idx = device_idx;
     _d1.external_allocate(_device_idx, ptr1, size);
     _d2.external_allocate(_device_idx, ptr2, size);
     _buff.d_buffers[0] = static_cast<T *>(ptr1);
     _buff.d_buffers[1] = static_cast<T *>(ptr2);
     _buff.selector = 0;
-    _device_idx = device_idx;
   }
-  dvec2() : _d1(), _d2(), _buff(), _device_idx(0) {}
+  dvec2() : _d1(), _d2(), _buff(), _device_idx(-1) {}
 
   size_t size() const { return _d1.size(); }
   int device_idx() const { return _device_idx; }
@@ -433,7 +443,7 @@ class dvec2 {
 
   T *current() { return _buff.Current(); }
 
-  dvec<T> &current_dvec() { return _buff.selector == 0? d1() : d2(); }
+  dvec<T> &current_dvec() { return _buff.selector == 0 ? d1() : d2(); }
 
   T *other() { return _buff.Alternate(); }
 };
@@ -459,7 +469,8 @@ class bulk_allocator {
 
   template <typename T, typename SizeT, typename... Args>
   size_t get_size_bytes(dvec<T> *first_vec, SizeT first_size, Args... args) {
-    return get_size_bytes<T,SizeT>(first_vec, first_size) + get_size_bytes(args...);
+    return get_size_bytes<T, SizeT>(first_vec, first_size) +
+           get_size_bytes(args...);
   }
 
   template <typename T, typename SizeT>
@@ -496,20 +507,23 @@ class bulk_allocator {
 
   template <typename T, typename SizeT, typename... Args>
   size_t get_size_bytes(dvec2<T> *first_vec, SizeT first_size, Args... args) {
-      return get_size_bytes<T,SizeT>(first_vec, first_size) + get_size_bytes(args...);
+    return get_size_bytes<T, SizeT>(first_vec, first_size) +
+           get_size_bytes(args...);
   }
 
   template <typename T, typename SizeT>
-  void allocate_dvec(int device_idx, char *ptr, dvec2<T> *first_vec, SizeT first_size) {
-    first_vec->external_allocate(device_idx, static_cast<void *>(ptr),
-         static_cast<void *>(ptr+align_round_up(first_size * sizeof(T))),
-         first_size);
+  void allocate_dvec(int device_idx, char *ptr, dvec2<T> *first_vec,
+                     SizeT first_size) {
+    first_vec->external_allocate(
+        device_idx, static_cast<void *>(ptr),
+        static_cast<void *>(ptr + align_round_up(first_size * sizeof(T))),
+        first_size);
   }
 
   template <typename T, typename SizeT, typename... Args>
-  void allocate_dvec(int device_idx, char *ptr, dvec2<T> *first_vec, SizeT first_size,
-                     Args... args) {
-    allocate_dvec<T,SizeT>(device_idx, ptr, first_vec, first_size);
+  void allocate_dvec(int device_idx, char *ptr, dvec2<T> *first_vec,
+                     SizeT first_size, Args... args) {
+    allocate_dvec<T, SizeT>(device_idx, ptr, first_vec, first_size);
     ptr += (align_round_up(first_size * sizeof(T)) * 2);
     allocate_dvec(device_idx, ptr, args...);
   }
@@ -706,11 +720,11 @@ struct BernoulliRng {
  * @param name name used to track later
  * @param stream cuda stream where to measure time
  */
-#define TIMEIT(call, name)                  \
-  do {                                      \
-    dh::Timer t1234;                        \
-    call;                                   \
-    t1234.printElapsed(name);               \
-  } while(0)
+#define TIMEIT(call, name)    \
+  do {                        \
+    dh::Timer t1234;          \
+    call;                     \
+    t1234.printElapsed(name); \
+  } while (0)
 
 }  // namespace dh

--- a/plugin/updater_gpu/src/exact/gradients.cuh
+++ b/plugin/updater_gpu/src/exact/gradients.cuh
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION, Xgboost contributors.  All rights reserved.
+ * Copyright (c) 2017, NVIDIA CORPORATION, Xgboost contributors.  All rights
+ * reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +18,6 @@
 
 #include "../common.cuh"
 
-
 namespace xgboost {
 namespace tree {
 namespace exact {
@@ -32,9 +32,9 @@ struct gpu_gpair {
   /** the 'h_i' as it appears in the xgboost paper */
   float h;
 
-  HOST_DEV_INLINE gpu_gpair(): g(0.f), h(0.f) {}
-  HOST_DEV_INLINE gpu_gpair(const float& _g, const float& _h): g(_g), h(_h) {}
-  HOST_DEV_INLINE gpu_gpair(const gpu_gpair& a): g(a.g), h(a.h) {}
+  HOST_DEV_INLINE gpu_gpair() : g(0.f), h(0.f) {}
+  HOST_DEV_INLINE gpu_gpair(const float& _g, const float& _h) : g(_g), h(_h) {}
+  HOST_DEV_INLINE gpu_gpair(const gpu_gpair& a) : g(a.g), h(a.h) {}
 
   /**
    * @brief Checks whether the hessian is more than the defined weight
@@ -60,19 +60,18 @@ struct gpu_gpair {
 
   HOST_DEV_INLINE friend gpu_gpair operator+(const gpu_gpair& a,
                                              const gpu_gpair& b) {
-    return gpu_gpair(a.g+b.g, a.h+b.h);
+    return gpu_gpair(a.g + b.g, a.h + b.h);
   }
 
   HOST_DEV_INLINE friend gpu_gpair operator-(const gpu_gpair& a,
                                              const gpu_gpair& b) {
-    return gpu_gpair(a.g-b.g, a.h-b.h);
+    return gpu_gpair(a.g - b.g, a.h - b.h);
   }
 
   HOST_DEV_INLINE gpu_gpair(int value) {
     *this = gpu_gpair((float)value, (float)value);
   }
 };
-
 
 /**
  * @brief Gradient value getter function
@@ -81,7 +80,8 @@ struct gpu_gpair {
  * @param instIds instance index buffer
  * @return the expected gradient value
  */
-HOST_DEV_INLINE gpu_gpair get(int id, const gpu_gpair* vals, const int* instIds) {
+HOST_DEV_INLINE gpu_gpair get(int id, const gpu_gpair* vals,
+                              const int* instIds) {
   id = instIds[id];
   return vals[id];
 }

--- a/plugin/updater_gpu/src/exact/loss_functions.cuh
+++ b/plugin/updater_gpu/src/exact/loss_functions.cuh
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION, Xgboost contributors.  All rights reserved.
+ * Copyright (c) 2017, NVIDIA CORPORATION, Xgboost contributors.  All rights
+ * reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +19,13 @@
 #include "../common.cuh"
 #include "gradients.cuh"
 
-
 namespace xgboost {
 namespace tree {
 namespace exact {
 
-HOST_DEV_INLINE float device_calc_loss_chg(const TrainParam &param,
-                                           const gpu_gpair &scan,
-                                           const gpu_gpair &missing,
-                                           const gpu_gpair &parent_sum,
-                                           const float &parent_gain,
-                                           bool missing_left) {
+HOST_DEV_INLINE float device_calc_loss_chg(
+    const TrainParam &param, const gpu_gpair &scan, const gpu_gpair &missing,
+    const gpu_gpair &parent_sum, const float &parent_gain, bool missing_left) {
   gpu_gpair left = scan;
   if (missing_left) {
     left += missing;

--- a/plugin/updater_gpu/src/exact/node.cuh
+++ b/plugin/updater_gpu/src/exact/node.cuh
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, NVIDIA CORPORATION, Xgboost contributors.  All rights reserved.
+ * Copyright (c) 2017, NVIDIA CORPORATION, Xgboost contributors.  All rights
+ * reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +16,8 @@
  */
 #pragma once
 
-#include "gradients.cuh"
 #include "../common.cuh"
-
+#include "gradients.cuh"
 
 namespace xgboost {
 namespace tree {
@@ -34,10 +34,8 @@ enum DefaultDirection {
   RightDir
 };
 
-
 /** used to assign default id to a Node */
 static const int UNUSED_NODE = -1;
-
 
 /**
  * @struct Split node.cuh
@@ -49,7 +47,7 @@ struct Split {
   /** index where to split in the DMatrix */
   int index;
 
-  HOST_DEV_INLINE Split(): score(-FLT_MAX), index(INT_MAX) {}
+  HOST_DEV_INLINE Split() : score(-FLT_MAX), index(INT_MAX) {}
 
   /**
    * @brief Whether the split info is valid to be used to create a new child
@@ -60,7 +58,6 @@ struct Split {
     return ((score >= minSplitLoss) && (index != INT_MAX));
   }
 };
-
 
 /**
  * @struct Node node.cuh
@@ -84,9 +81,14 @@ class Node {
   /** node id (used as key for reduce/scan) */
   node_id_t id;
 
-  HOST_DEV_INLINE Node(): gradSum(), score(-FLT_MAX), weight(-FLT_MAX),
-                          dir(LeftDir), threshold(0.f), colIdx(UNUSED_NODE),
-                          id(UNUSED_NODE) {}
+  HOST_DEV_INLINE Node()
+      : gradSum(),
+        score(-FLT_MAX),
+        weight(-FLT_MAX),
+        dir(LeftDir),
+        threshold(0.f),
+        colIdx(UNUSED_NODE),
+        id(UNUSED_NODE) {}
 
   /** Tells whether this node is part of the decision tree */
   HOST_DEV_INLINE bool isUnused() const { return (id == UNUSED_NODE); }
@@ -100,7 +102,6 @@ class Node {
   HOST_DEV_INLINE bool isDefaultLeft() const { return (dir == LeftDir); }
 };
 
-
 /**
  * @struct Segment node.cuh
  * @brief Space inefficient, but super easy to implement structure to define
@@ -112,14 +113,13 @@ struct Segment {
   /** end index of the segment */
   int end;
 
-  HOST_DEV_INLINE Segment(): start(-1), end(-1) {}
+  HOST_DEV_INLINE Segment() : start(-1), end(-1) {}
 
   /** Checks whether the current structure defines a valid segment */
   HOST_DEV_INLINE bool isValid() const {
     return !((start == -1) || (end == -1));
   }
 };
-
 
 /**
  * @enum NodeType node.cuh
@@ -133,7 +133,6 @@ enum NodeType {
   /** unused node */
   UNUSED
 };
-
 
 /**
  * @brief Absolute BFS order IDs to col-wise unique IDs based on user input

--- a/plugin/updater_gpu/src/exact/split2node.cuh
+++ b/plugin/updater_gpu/src/exact/split2node.cuh
@@ -17,9 +17,8 @@
 
 #include "../../../../src/tree/param.h"
 #include "gradients.cuh"
-#include "node.cuh"
 #include "loss_functions.cuh"
-
+#include "node.cuh"
 
 namespace xgboost {
 namespace tree {
@@ -39,7 +38,7 @@ namespace exact {
 template <typename node_id_t>
 DEV_INLINE void updateOneChildNode(Node<node_id_t>* nodes, int nid,
                                    const gpu_gpair& grad,
-                                   const TrainParam &param) {
+                                   const TrainParam& param) {
   nodes[nid].gradSum = grad;
   nodes[nid].score = CalcGain(param, grad.g, grad.h);
   nodes[nid].weight = CalcWeight(param, grad.g, grad.h);
@@ -58,18 +57,18 @@ DEV_INLINE void updateOneChildNode(Node<node_id_t>* nodes, int nid,
 template <typename node_id_t>
 DEV_INLINE void updateChildNodes(Node<node_id_t>* nodes, int pid,
                                  const gpu_gpair& gradL, const gpu_gpair& gradR,
-                                 const TrainParam &param) {
+                                 const TrainParam& param) {
   int childId = (pid * 2) + 1;
   updateOneChildNode(nodes, childId, gradL, param);
-  updateOneChildNode(nodes, childId+1, gradR, param);
+  updateOneChildNode(nodes, childId + 1, gradR, param);
 }
 
 template <typename node_id_t>
 DEV_INLINE void updateNodeAndChildren(Node<node_id_t>* nodes, const Split& s,
-                                      const Node<node_id_t>& n, int absNodeId, int colId,
-                                      const gpu_gpair& gradScan,
+                                      const Node<node_id_t>& n, int absNodeId,
+                                      int colId, const gpu_gpair& gradScan,
                                       const gpu_gpair& colSum, float thresh,
-                                      const TrainParam &param) {
+                                      const TrainParam& param) {
   bool missingLeft = true;
   // get the default direction for the current node
   gpu_gpair missing = n.gradSum - colSum;
@@ -84,19 +83,17 @@ DEV_INLINE void updateNodeAndChildren(Node<node_id_t>* nodes, const Split& s,
   rGradSum = n.gradSum - lGradSum;
   updateChildNodes(nodes, absNodeId, lGradSum, rGradSum, param);
   // update default-dir, threshold and feature id for current node
-  nodes[absNodeId].dir = missingLeft? LeftDir : RightDir;
+  nodes[absNodeId].dir = missingLeft ? LeftDir : RightDir;
   nodes[absNodeId].colIdx = colId;
   nodes[absNodeId].threshold = thresh;
 }
 
-template <typename node_id_t, int BLKDIM=256>
-__global__ void split2nodeKernel(Node<node_id_t>* nodes, const Split* nodeSplits,
-                                 const gpu_gpair* gradScans,
-                                 const gpu_gpair* gradSums, const float* vals,
-                                 const int* colIds, const int* colOffsets,
-                                 const node_id_t* nodeAssigns, int nUniqKeys,
-                                 node_id_t nodeStart, int nCols,
-                                 const TrainParam param) {
+template <typename node_id_t, int BLKDIM = 256>
+__global__ void split2nodeKernel(
+    Node<node_id_t>* nodes, const Split* nodeSplits, const gpu_gpair* gradScans,
+    const gpu_gpair* gradSums, const float* vals, const int* colIds,
+    const int* colOffsets, const node_id_t* nodeAssigns, int nUniqKeys,
+    node_id_t nodeStart, int nCols, const TrainParam param) {
   int uid = (blockIdx.x * blockDim.x) + threadIdx.x;
   if (uid >= nUniqKeys) {
     return;
@@ -105,11 +102,11 @@ __global__ void split2nodeKernel(Node<node_id_t>* nodes, const Split* nodeSplits
   Split s = nodeSplits[uid];
   if (s.isSplittable(param.min_split_loss)) {
     int idx = s.index;
-    int nodeInstId = abs2uniqKey(idx, nodeAssigns, colIds, nodeStart,
-                                 nUniqKeys);
-    updateNodeAndChildren(nodes, s, nodes[absNodeId], absNodeId,
-                          colIds[idx], gradScans[idx],
-                          gradSums[nodeInstId], vals[idx], param);
+    int nodeInstId =
+        abs2uniqKey(idx, nodeAssigns, colIds, nodeStart, nUniqKeys);
+    updateNodeAndChildren(nodes, s, nodes[absNodeId], absNodeId, colIds[idx],
+                          gradScans[idx], gradSums[nodeInstId], vals[idx],
+                          param);
   } else {
     // cannot be split further, so this node is a leaf!
     nodes[absNodeId].score = -FLT_MAX;
@@ -129,20 +126,20 @@ __global__ void split2nodeKernel(Node<node_id_t>* nodes, const Split* nodeSplits
  * @param nUniqKeys number of nodes that we are currently working on
  * @param nodeStart start offset of the nodes in the overall BFS tree
  * @param nCols number of columns
- * @param preUniquifiedKeys whether to uniquify the keys from inside kernel or not
+ * @param preUniquifiedKeys whether to uniquify the keys from inside kernel or
+ * not
  * @param param the training parameter struct
  */
-template <typename node_id_t, int BLKDIM=256>
-void split2node(Node<node_id_t>* nodes, const Split* nodeSplits, const gpu_gpair* gradScans,
-                const gpu_gpair* gradSums, const float* vals, const int* colIds,
-                const int* colOffsets, const node_id_t* nodeAssigns,
-                int nUniqKeys, node_id_t nodeStart, int nCols,
-                const TrainParam param) {
+template <typename node_id_t, int BLKDIM = 256>
+void split2node(Node<node_id_t>* nodes, const Split* nodeSplits,
+                const gpu_gpair* gradScans, const gpu_gpair* gradSums,
+                const float* vals, const int* colIds, const int* colOffsets,
+                const node_id_t* nodeAssigns, int nUniqKeys,
+                node_id_t nodeStart, int nCols, const TrainParam param) {
   int nBlks = dh::div_round_up(nUniqKeys, BLKDIM);
-  split2nodeKernel<<<nBlks,BLKDIM>>>(nodes, nodeSplits, gradScans, gradSums,
-                                     vals, colIds, colOffsets, nodeAssigns,
-                                     nUniqKeys, nodeStart, nCols,
-                                     param);
+  split2nodeKernel<<<nBlks, BLKDIM>>>(nodes, nodeSplits, gradScans, gradSums,
+                                      vals, colIds, colOffsets, nodeAssigns,
+                                      nUniqKeys, nodeStart, nCols, param);
 }
 
 }  // namespace exact

--- a/plugin/updater_gpu/src/gpu_data.cuh
+++ b/plugin/updater_gpu/src/gpu_data.cuh
@@ -73,11 +73,12 @@ struct GPUData {
         n_features, foffsets.data(), foffsets.data() + 1);
 
     // Allocate memory
-    size_t free_memory = dh::available_memory(param_in.gpu_id);
-    ba.allocate(param_in.gpu_id,
-                &fvalues, in_fvalues.size(), &fvalues_temp,
-        in_fvalues.size(), &fvalues_cached, in_fvalues.size(), &foffsets,
-        in_foffsets.size(), &instance_id, in_instance_id.size(),
+    size_t free_memory =
+        dh::available_memory(dh::get_device_idx(param_in.gpu_id));
+    ba.allocate(
+        dh::get_device_idx(param_in.gpu_id), &fvalues, in_fvalues.size(),
+        &fvalues_temp, in_fvalues.size(), &fvalues_cached, in_fvalues.size(),
+        &foffsets, in_foffsets.size(), &instance_id, in_instance_id.size(),
         &instance_id_temp, in_instance_id.size(), &instance_id_cached,
         in_instance_id.size(), &feature_id, in_feature_id.size(), &node_id,
         in_fvalues.size(), &node_id_temp, in_fvalues.size(), &node_id_instance,
@@ -91,7 +92,7 @@ struct GPUData {
       const int mb_size = 1048576;
       LOG(CONSOLE) << "Allocated " << ba.size() / mb_size << "/"
                    << free_memory / mb_size << " MB on "
-                   << dh::device_name(param_in.gpu_id);
+                   << dh::device_name(dh::get_device_idx(param_in.gpu_id));
     }
 
     fvalues_cached = in_fvalues;

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -157,11 +157,11 @@ class ColMaker: public TreeUpdater {
             feat_index.push_back(i);
           }
         }
-        unsigned n = static_cast<unsigned>(param.colsample_bytree * feat_index.size());
+        unsigned n = std::max(static_cast<unsigned>(1),
+                              static_cast<unsigned>(param.colsample_bytree * feat_index.size()));
         std::shuffle(feat_index.begin(), feat_index.end(), common::GlobalRandom());
-        CHECK_GT(n, 0U)
-            << "colsample_bytree=" << param.colsample_bytree
-            << " is too small that no feature can be included";
+        CHECK_GT(param.colsample_bytree, 0U)
+            << "colsample_bytree cannot be zero.";
         feat_index.resize(n);
       }
       {
@@ -627,9 +627,10 @@ class ColMaker: public TreeUpdater {
       std::vector<bst_uint> feat_set = feat_index;
       if (param.colsample_bylevel != 1.0f) {
         std::shuffle(feat_set.begin(), feat_set.end(), common::GlobalRandom());
-        unsigned n = static_cast<unsigned>(param.colsample_bylevel * feat_index.size());
-        CHECK_GT(n, 0U)
-            << "colsample_bylevel is too small that no feature can be included";
+        unsigned n = std::max(static_cast<unsigned>(1),
+                              static_cast<unsigned>(param.colsample_bylevel * feat_index.size()));
+        CHECK_GT(param.colsample_bylevel, 0U)
+            << "colsample_bylevel cannot be zero.";
         feat_set.resize(n);
       }
       dmlc::DataIter<ColBatch>* iter = p_fmat->ColIterator(feat_set);

--- a/src/tree/updater_fast_hist.cc
+++ b/src/tree/updater_fast_hist.cc
@@ -409,11 +409,11 @@ class FastHistMaker: public TreeUpdater {
             feat_index.push_back(i);
           }
         }
-        unsigned n = static_cast<unsigned>(param.colsample_bytree * feat_index.size());
+        unsigned n = std::max(static_cast<unsigned>(1),
+                              static_cast<unsigned>(param.colsample_bytree * feat_index.size()));
         std::shuffle(feat_index.begin(), feat_index.end(), common::GlobalRandom());
-        CHECK_GT(n, 0U)
-            << "colsample_bytree=" << param.colsample_bytree
-            << " is too small that no feature can be included";
+        CHECK_GT(param.colsample_bytree, 0U)
+            << "colsample_bytree cannot be zero.";
         feat_index.resize(n);
       }
       if (data_layout_ == kDenseDataZeroBased || data_layout_ == kDenseDataOneBased) {


### PR DESCRIPTION
* Fixed ability to use gpu_id to access other GPUs for both grow_gpu and grow_gpu_hist methods.
* Default to no sharding of nodes as on typical systems and depths this is expensive due to communication overhead.  Added new param.h option findsplit_shardongpus that defaults to 0.
* Additional documentation for the gpu plugin.
* Updated cub submodule to latest 1.7.0 version that has various bug fixes.
* Allow user to avoid cloning recursive and call plugin/updater_gpu/gitshallow_submodules.sh because cub has very large history that is not needed.  Leads to much faster clone of xgboost.
* Bug fix to use of colsample so doesn't lead to 0 columns selected (both cpu and gpu code)