### PR TITLE
Update URL for "Multiclass logloss".

### DIFF
--- a/doc/parameter.md
+++ b/doc/parameter.md
@@ -179,7 +179,7 @@ Specify the learning task and the corresponding learning objective. The objectiv
     - "error": Binary classification error rate. It is calculated as #(wrong cases)/#(all cases). For the predictions, the evaluation will regard the instances with prediction value larger than 0.5 as positive instances, and the others as negative instances.
     - "error@t": a different than 0.5 binary classification threshold value could be specified by providing a numerical value through 't'.
     - "merror": Multiclass classification error rate. It is calculated as #(wrong cases)/#(all cases).
-    - "mlogloss": [Multiclass logloss](https://www.kaggle.com/wiki/MultiClassLogLoss)
+    - "mlogloss": [Multiclass logloss](https://www.kaggle.com/wiki/LogLoss)
     - "auc": [Area under the curve](http://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_curve) for ranking evaluation.
     - "ndcg":[Normalized Discounted Cumulative Gain](http://en.wikipedia.org/wiki/NDCG)
     - "map":[Mean average precision](http://en.wikipedia.org/wiki/Mean_average_precision#Mean_average_precision)


### PR DESCRIPTION
The original URL (https://www.kaggle.com/wiki/MultiClassLogLoss) shows 404 Error. Changes it to https://www.kaggle.com/wiki/LogLoss