### PR TITLE
Patch to improve multithreaded performance scaling

### DIFF
--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -68,7 +68,9 @@ class ColumnMatrix {
   }
 
   // construct column matrix from GHistIndexMatrix
-  inline void Init(const GHistIndexMatrix& gmat, DataType dtype) {
+  inline void Init(const GHistIndexMatrix& gmat,
+                   DataType dtype,
+                   double sparse_threshold) {
     this->dtype = dtype;
     /* if dtype is smaller than uint32_t, multiple bin_id's will be stored in each
        slot of internal buffer. */
@@ -93,7 +95,7 @@ class ColumnMatrix {
     gmat.GetFeatureCounts(&feature_counts_[0]);
     // classify features
     for (uint32_t fid = 0; fid < nfeature; ++fid) {
-      if (static_cast<double>(feature_counts_[fid]) < 0.5*nrow) {
+      if (static_cast<double>(feature_counts_[fid]) < sparse_threshold * nrow) {
         type_[fid] = kSparseColumn;
       } else {
         type_[fid] = kDenseColumn;

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -29,6 +29,9 @@ switch (dtype) {                \
 #include <limits>
 #include <vector>
 #include "hist_util.h"
+#include "../tree/fast_hist_param.h"
+
+using xgboost::tree::FastHistParam;
 
 namespace xgboost {
 namespace common {
@@ -69,9 +72,8 @@ class ColumnMatrix {
 
   // construct column matrix from GHistIndexMatrix
   inline void Init(const GHistIndexMatrix& gmat,
-                   DataType dtype,
-                   double sparse_threshold) {
-    this->dtype = dtype;
+                   const FastHistParam& param) {
+    this->dtype = static_cast<DataType>(param.colmat_dtype);
     /* if dtype is smaller than uint32_t, multiple bin_id's will be stored in each
        slot of internal buffer. */
     packing_factor_ = sizeof(uint32_t) / static_cast<size_t>(this->dtype);
@@ -95,7 +97,8 @@ class ColumnMatrix {
     gmat.GetFeatureCounts(&feature_counts_[0]);
     // classify features
     for (uint32_t fid = 0; fid < nfeature; ++fid) {
-      if (static_cast<double>(feature_counts_[fid]) < sparse_threshold * nrow) {
+      if (static_cast<double>(feature_counts_[fid])
+                 < param.sparse_threshold * nrow) {
         type_[fid] = kSparseColumn;
       } else {
         type_[fid] = kDenseColumn;

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -7,8 +7,9 @@
 #include <dmlc/omp.h>
 #include <vector>
 #include "./sync.h"
-#include "./hist_util.h"
+#include "./random.h"
 #include "./column_matrix.h"
+#include "./hist_util.h"
 #include "./quantile.h"
 
 namespace xgboost {
@@ -154,6 +155,251 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat) {
   }
 }
 
+template <typename T>
+static unsigned GetConflictCount(const std::vector<bool>& mark,
+                                 const Column<T>& column,
+                                 unsigned max_cnt) {
+  unsigned ret = 0;
+  if (column.type == xgboost::common::kDenseColumn) {
+    for (size_t i = 0; i < column.len; ++i) {
+      if (column.index[i] != std::numeric_limits<T>::max() && mark[i]) {
+        ++ret;
+        if (ret > max_cnt) {
+          return max_cnt + 1;
+        }
+      }
+    }
+  } else {
+    for (size_t i = 0; i < column.len; ++i) {
+      if (mark[column.row_ind[i]]) {
+        ++ret;
+        if (ret > max_cnt) {
+          return max_cnt + 1;
+        }
+      }
+    }
+  }
+  return ret;
+}
+
+template <typename T>
+static inline void
+MarkUsed(std::vector<bool>* p_mark, const Column<T>& column) {
+  std::vector<bool>& mark = *p_mark;
+  if (column.type == xgboost::common::kDenseColumn) {
+    for (size_t i = 0; i < column.len; ++i) {
+      if (column.index[i] != std::numeric_limits<T>::max()) {
+        mark[i] = true;
+      }
+    }
+  } else {
+    for (size_t i = 0; i < column.len; ++i) {
+      mark[column.row_ind[i]] = true;
+    }
+  }
+}
+
+template <typename T>
+static inline std::vector<std::vector<unsigned>>
+FindGroups_(const std::vector<unsigned>& feature_list,
+            const std::vector<bst_uint>& feature_nnz,
+            const ColumnMatrix& colmat,
+            unsigned nrow,
+            unsigned max_conflict_cnt) {
+  const unsigned max_search_group = 100;
+
+  /* Goal: Bundle features together that has little or no "overlap", i.e.
+           only a few data points should have nonzero values for
+           member features.
+           Note that one-hot encoded features will be grouped together. */
+
+  std::vector<std::vector<unsigned>> groups;
+  std::vector<std::vector<bool>> conflict_marks;
+  std::vector<unsigned> group_nnz;
+  std::vector<unsigned> group_conflict_cnt;
+
+  for (auto fid : feature_list) {
+    const Column<T>& column = colmat.GetColumn<T>(fid);
+
+    const size_t cur_fid_nnz = feature_nnz[fid];
+    bool need_new_group = true;
+
+    // randomly choose some of existing groups as candidates
+    std::vector<unsigned> search_groups;
+    for (size_t gid = 0; gid < groups.size(); ++gid) {
+      if (group_nnz[gid] + cur_fid_nnz <= nrow + max_conflict_cnt) {
+        search_groups.push_back(gid);
+      }
+    }
+    std::shuffle(search_groups.begin(), search_groups.end(), common::GlobalRandom());
+    if (search_groups.size() > max_search_group) {
+      search_groups.resize(max_search_group);
+    }
+
+    // examine each candidate group: is it okay to insert fid?
+    for (auto gid : search_groups) {
+      const unsigned rest_max_cnt = max_conflict_cnt - group_conflict_cnt[gid];
+      const unsigned cnt = GetConflictCount(conflict_marks[gid], column, rest_max_cnt);
+      if (cnt <= rest_max_cnt) {
+        need_new_group = false;
+        groups[gid].push_back(fid);
+        group_conflict_cnt[gid] += cnt;
+        group_nnz[gid] += cur_fid_nnz - cnt;
+        MarkUsed(&conflict_marks[gid], column);
+        break;
+      }
+    }
+
+    // create new group if necessary
+    if (need_new_group) {
+      groups.emplace_back();
+      groups.back().push_back(fid);
+      group_conflict_cnt.push_back(0);
+      conflict_marks.emplace_back(nrow, false);
+      MarkUsed(&conflict_marks.back(), column);
+      group_nnz.emplace_back(cur_fid_nnz);
+    }
+  }
+
+  return groups;
+}
+
+static inline std::vector<std::vector<unsigned>>
+FindGroups(const std::vector<unsigned>& feature_list,
+           const std::vector<bst_uint>& feature_nnz,
+           const ColumnMatrix& colmat,
+           unsigned nrow,
+           unsigned max_conflict_cnt) {
+  XGBOOST_TYPE_SWITCH(colmat.dtype, {
+    return FindGroups_<DType>(feature_list, feature_nnz, colmat, nrow, max_conflict_cnt);
+  });
+  return std::vector<std::vector<unsigned>>();  // to avoid warning message
+}
+
+static inline std::vector<std::vector<unsigned>>
+FastFeatureGrouping(const GHistIndexMatrix& gmat,
+                    const ColumnMatrix& colmat,
+                    double max_conflict_rate,
+                    double sparse_threshold) {
+  const size_t nrow = gmat.row_ptr.size() - 1;
+  const size_t nfeature = gmat.cut->row_ptr.size() - 1;
+  const unsigned max_conflict_cnt
+    = static_cast<unsigned>(max_conflict_rate * nrow);
+
+  std::vector<unsigned> feature_list(nfeature);
+  std::iota(feature_list.begin(), feature_list.end(), 0);
+
+  // sort features by nonzero counts, descending order
+  std::vector<bst_uint> feature_nnz(nfeature);
+  std::vector<unsigned> features_by_nnz(feature_list);
+  gmat.GetFeatureCounts(&feature_nnz[0]);
+  std::sort(features_by_nnz.begin(), features_by_nnz.end(),
+            [&feature_nnz](int a, int b) {
+    return feature_nnz[a] > feature_nnz[b];
+  });
+
+  auto groups_alt1 = FindGroups(feature_list, feature_nnz, colmat, nrow, max_conflict_cnt);
+  auto groups_alt2 = FindGroups(features_by_nnz, feature_nnz, colmat, nrow, max_conflict_cnt);
+  auto& groups = (groups_alt1.size() > groups_alt2.size()) ? groups_alt2 : groups_alt1;
+
+  // take apart small, sparse groups, as it won't help speed
+  {
+    std::vector<std::vector<unsigned>> ret;
+    for (const auto& group : groups) {
+      if (group.size() <= 1 || group.size() >= 5) {
+        ret.push_back(group);  // keep singleton groups and large (5+) groups
+      } else {
+        unsigned nnz = 0;
+        for (auto fid : group) {
+          nnz += feature_nnz[fid];
+        }
+        double nnz_rate = static_cast<double>(nnz) / nrow;
+        // take apart small sparse group, due it will not gain on speed
+        if (nnz_rate <= sparse_threshold) {
+          for (auto fid : group) {
+            ret.emplace_back();
+            ret.back().push_back(fid);
+          }
+        } else {
+          ret.push_back(group);
+        }
+      }
+    }
+    groups = std::move(ret);
+  }
+
+  // shuffle groups
+  std::shuffle(groups.begin(), groups.end(), common::GlobalRandom());
+
+  return groups;
+}
+
+void GHistIndexBlockMatrix::Init(const GHistIndexMatrix& gmat,
+                                 const ColumnMatrix& colmat,
+                                 double max_conflict_rate,
+                                 double sparse_threshold) {
+  cut = gmat.cut;
+
+  const size_t nrow = gmat.row_ptr.size() - 1;
+  const size_t nbins = gmat.cut->row_ptr.back();
+
+  /* step 1: form feature groups */
+  auto groups = FastFeatureGrouping(gmat, colmat, max_conflict_rate,
+                                    sparse_threshold);
+  const size_t nblock = groups.size();
+
+  /* step 2: build a new CSR matrix for each feature group */
+  std::vector<unsigned> bin2block(nbins);  // lookup table [bin id] => [block id]
+  for (size_t group_id = 0; group_id < nblock; ++group_id) {
+    for (auto& fid : groups[group_id]) {
+      const unsigned bin_begin = gmat.cut->row_ptr[fid];
+      const unsigned bin_end = gmat.cut->row_ptr[fid + 1];
+      for (unsigned bin_id = bin_begin; bin_id < bin_end; ++bin_id) {
+        bin2block[bin_id] = group_id;
+      }
+    }
+  }
+  std::vector<std::vector<unsigned>> index_temp(nblock);
+  std::vector<std::vector<unsigned>> row_ptr_temp(nblock);
+  for (size_t block_id = 0; block_id < nblock; ++block_id) {
+    row_ptr_temp[block_id].push_back(0);
+  }
+  for (size_t rid = 0; rid < nrow; ++rid) {
+    const size_t ibegin = static_cast<size_t>(gmat.row_ptr[rid]);
+    const size_t iend = static_cast<size_t>(gmat.row_ptr[rid + 1]);
+    for (size_t j = ibegin; j < iend; ++j) {
+      const size_t bin_id = gmat.index[j];
+      const size_t block_id = bin2block[bin_id];
+      index_temp[block_id].push_back(bin_id);
+    }
+    for (size_t block_id = 0; block_id < nblock; ++block_id) {
+      row_ptr_temp[block_id].push_back(index_temp[block_id].size());
+    }
+  }
+
+  /* step 3: concatenate CSR matrices into one (index, row_ptr) pair */
+  std::vector<size_t> index_blk_ptr;
+  std::vector<size_t> row_ptr_blk_ptr;
+  index_blk_ptr.push_back(0);
+  row_ptr_blk_ptr.push_back(0);
+  for (size_t block_id = 0; block_id < nblock; ++block_id) {
+    index.insert(index.end(), index_temp[block_id].begin(), index_temp[block_id].end());
+    row_ptr.insert(row_ptr.end(), row_ptr_temp[block_id].begin(), row_ptr_temp[block_id].end());
+    index_blk_ptr.push_back(index.size());
+    row_ptr_blk_ptr.push_back(row_ptr.size());
+  }
+
+  // save shortcut for each block
+  for (size_t block_id = 0; block_id < nblock; ++block_id) {
+    Block blk;
+    blk.index_begin = &index[index_blk_ptr[block_id]];
+    blk.row_ptr_begin = &row_ptr[row_ptr_blk_ptr[block_id]];
+    blk.index_end = &index[index_blk_ptr[block_id + 1]];
+    blk.row_ptr_end = &row_ptr[row_ptr_blk_ptr[block_id + 1]];
+    blocks.push_back(blk);
+  }
+}
+
 void GHistBuilder::BuildHist(const std::vector<bst_gpair>& gpair,
                              const RowSetCollection::Elem row_indices,
                              const GHistIndexMatrix& gmat,
@@ -161,32 +407,11 @@ void GHistBuilder::BuildHist(const std::vector<bst_gpair>& gpair,
                              GHistRow hist) {
   data_.resize(nbins_ * nthread_, GHistEntry());
   std::fill(data_.begin(), data_.end(), GHistEntry());
-  stat_buf_.resize(row_indices.size());
 
   const int K = 8;  // loop unrolling factor
   const bst_omp_uint nthread = static_cast<bst_omp_uint>(this->nthread_);
   const bst_omp_uint nrows = row_indices.end - row_indices.begin;
   const bst_omp_uint rest = nrows % K;
-
-  #pragma omp parallel for num_threads(nthread) schedule(static)
-  for (bst_omp_uint i = 0; i < nrows - rest; i += K) {
-    bst_uint rid[K];
-    bst_gpair stat[K];
-    for (int k = 0; k < K; ++k) {
-      rid[k] = row_indices.begin[i + k];
-    }
-    for (int k = 0; k < K; ++k) {
-      stat[k] = gpair[rid[k]];
-    }
-    for (int k = 0; k < K; ++k) {
-      stat_buf_[i + k] = stat[k];
-    }
-  }
-  for (bst_omp_uint i = nrows - rest; i < nrows; ++i) {
-    const bst_uint rid = row_indices.begin[i];
-    const bst_gpair stat = gpair[rid];
-    stat_buf_[i] = stat;
-  }
 
   #pragma omp parallel for num_threads(nthread) schedule(guided)
   for (bst_omp_uint i = 0; i < nrows - rest; i += K) {
@@ -204,7 +429,7 @@ void GHistBuilder::BuildHist(const std::vector<bst_gpair>& gpair,
       iend[k] = static_cast<size_t>(gmat.row_ptr[rid[k] + 1]);
     }
     for (int k = 0; k < K; ++k) {
-      stat[k] = stat_buf_[i + k];
+      stat[k] = gpair[rid[k]];
     }
     for (int k = 0; k < K; ++k) {
       for (size_t j = ibegin[k]; j < iend[k]; ++j) {
@@ -217,7 +442,7 @@ void GHistBuilder::BuildHist(const std::vector<bst_gpair>& gpair,
     const bst_uint rid = row_indices.begin[i];
     const size_t ibegin = static_cast<size_t>(gmat.row_ptr[rid]);
     const size_t iend = static_cast<size_t>(gmat.row_ptr[rid + 1]);
-    const bst_gpair stat = stat_buf_[i];
+    const bst_gpair stat = gpair[rid];
     for (size_t j = ibegin; j < iend; ++j) {
       const size_t bin = gmat.index[j];
       data_[bin].Add(stat);
@@ -234,10 +459,60 @@ void GHistBuilder::BuildHist(const std::vector<bst_gpair>& gpair,
   }
 }
 
+void GHistBuilder::BuildBlockHist(const std::vector<bst_gpair>& gpair,
+                                  const RowSetCollection::Elem row_indices,
+                                  const GHistIndexBlockMatrix& gmatb,
+                                  const std::vector<bst_uint>& feat_set,
+                                  GHistRow hist) {
+  const int K = 8;  // loop unrolling factor
+  const bst_omp_uint nthread = static_cast<bst_omp_uint>(this->nthread_);
+  const bst_omp_uint nblock = gmatb.GetNumBlock();
+  const bst_omp_uint nrows = row_indices.end - row_indices.begin;
+  const bst_omp_uint rest = nrows % K;
+
+  #pragma omp parallel for num_threads(nthread) schedule(guided)
+  for (bst_omp_uint bid = 0; bid < nblock; ++bid) {
+    auto gmat = gmatb[bid];
+
+    for (bst_omp_uint i = 0; i < nrows - rest; i += K) {
+      bst_uint rid[K];
+      size_t ibegin[K];
+      size_t iend[K];
+      bst_gpair stat[K];
+      for (int k = 0; k < K; ++k) {
+        rid[k] = row_indices.begin[i + k];
+      }
+      for (int k = 0; k < K; ++k) {
+        ibegin[k] = static_cast<size_t>(gmat.row_ptr[rid[k]]);
+        iend[k] = static_cast<size_t>(gmat.row_ptr[rid[k] + 1]);
+      }
+      for (int k = 0; k < K; ++k) {
+        stat[k] = gpair[rid[k]];
+      }
+      for (int k = 0; k < K; ++k) {
+        for (size_t j = ibegin[k]; j < iend[k]; ++j) {
+          const size_t bin = gmat.index[j];
+          hist.begin[bin].Add(stat[k]);
+        }
+      }
+    }
+    for (bst_omp_uint i = nrows - rest; i < nrows; ++i) {
+      const bst_uint rid = row_indices.begin[i];
+      const size_t ibegin = static_cast<size_t>(gmat.row_ptr[rid]);
+      const size_t iend = static_cast<size_t>(gmat.row_ptr[rid + 1]);
+      const bst_gpair stat = gpair[rid];
+      for (size_t j = ibegin; j < iend; ++j) {
+        const size_t bin = gmat.index[j];
+        hist.begin[bin].Add(stat);
+      }
+    }
+  }
+}
+
 void GHistBuilder::SubtractionTrick(GHistRow self, GHistRow sibling, GHistRow parent) {
   const bst_omp_uint nthread = static_cast<bst_omp_uint>(this->nthread_);
   const bst_omp_uint nbins = static_cast<bst_omp_uint>(nbins_);
-  const int K = 8;
+  const int K = 8;  // loop unrolling factor
   const bst_omp_uint rest = nbins % K;
   #pragma omp parallel for num_threads(nthread) schedule(static)
   for (bst_omp_uint bin_id = 0; bin_id < nbins - rest; bin_id += K) {

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -5,6 +5,7 @@
  * \author Philip Cho, Tianqi Chen
  */
 #include <dmlc/omp.h>
+#include <numeric>
 #include <vector>
 #include "./sync.h"
 #include "./random.h"

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -184,7 +184,7 @@ static unsigned GetConflictCount(const std::vector<bool>& mark,
 }
 
 template <typename T>
-static inline void
+inline void
 MarkUsed(std::vector<bool>* p_mark, const Column<T>& column) {
   std::vector<bool>& mark = *p_mark;
   if (column.type == xgboost::common::kDenseColumn) {
@@ -201,7 +201,7 @@ MarkUsed(std::vector<bool>* p_mark, const Column<T>& column) {
 }
 
 template <typename T>
-static inline std::vector<std::vector<unsigned>>
+inline std::vector<std::vector<unsigned>>
 FindGroups_(const std::vector<unsigned>& feature_list,
             const std::vector<bst_uint>& feature_nnz,
             const ColumnMatrix& colmat,
@@ -265,7 +265,7 @@ FindGroups_(const std::vector<unsigned>& feature_list,
   return groups;
 }
 
-static inline std::vector<std::vector<unsigned>>
+inline std::vector<std::vector<unsigned>>
 FindGroups(const std::vector<unsigned>& feature_list,
            const std::vector<bst_uint>& feature_nnz,
            const ColumnMatrix& colmat,
@@ -277,7 +277,7 @@ FindGroups(const std::vector<unsigned>& feature_list,
   return std::vector<std::vector<unsigned>>();  // to avoid warning message
 }
 
-static inline std::vector<std::vector<unsigned>>
+inline std::vector<std::vector<unsigned>>
 FastFeatureGrouping(const GHistIndexMatrix& gmat,
                     const ColumnMatrix& colmat,
                     double max_conflict_rate,

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -11,6 +11,9 @@
 #include <limits>
 #include <vector>
 #include "row_set.h"
+#include "../tree/fast_hist_param.h"
+
+using xgboost::tree::FastHistParam;
 
 namespace xgboost {
 namespace common {
@@ -148,8 +151,7 @@ class GHistIndexBlockMatrix {
  public:
   void Init(const GHistIndexMatrix& gmat,
             const ColumnMatrix& colmat,
-            double max_conflict_rate,
-            double sparse_threshold);
+            const FastHistParam& param);
 
   inline GHistIndexBlock operator[](bst_uint i) const {
     return GHistIndexBlock(blocks[i].row_ptr_begin, blocks[i].index_begin);

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -24,6 +24,10 @@ struct GHistEntry {
 
   GHistEntry() : sum_grad(0), sum_hess(0) {}
 
+  inline void Clear() {
+    sum_grad = sum_hess = 0;
+  }
+
   /*! \brief add a bst_gpair to the sum */
   inline void Add(const bst_gpair& e) {
     sum_grad += e.grad;
@@ -125,6 +129,49 @@ struct GHistIndexMatrix {
   std::vector<unsigned> hit_count_tloc_;
 };
 
+struct GHistIndexBlock {
+  const unsigned* row_ptr;
+  const unsigned* index;
+
+  inline GHistIndexBlock(const unsigned* row_ptr, const unsigned* index)
+    : row_ptr(row_ptr), index(index) {}
+
+  // get i-th row
+  inline GHistIndexRow operator[](bst_uint i) const {
+    return GHistIndexRow(&index[0] + row_ptr[i], row_ptr[i + 1] - row_ptr[i]);
+  }
+};
+
+class ColumnMatrix;
+
+class GHistIndexBlockMatrix {
+ public:
+  void Init(const GHistIndexMatrix& gmat,
+            const ColumnMatrix& colmat,
+            double max_conflict_rate,
+            double sparse_threshold);
+
+  inline GHistIndexBlock operator[](bst_uint i) const {
+    return GHistIndexBlock(blocks[i].row_ptr_begin, blocks[i].index_begin);
+  }
+
+  inline unsigned GetNumBlock() const {
+    return blocks.size();
+  }
+
+ private:
+  std::vector<unsigned> row_ptr;
+  std::vector<unsigned> index;
+  const HistCutMatrix* cut;
+  struct Block {
+    const unsigned* row_ptr_begin;
+    const unsigned* row_ptr_end;
+    const unsigned* index_begin;
+    const unsigned* index_end;
+  };
+  std::vector<Block> blocks;
+};
+
 /*!
  * \brief histogram of graident statistics for a single node.
  *  Consists of multiple GHistEntry's, each entry showing total graident statistics 
@@ -206,6 +253,12 @@ class GHistBuilder {
                  const GHistIndexMatrix& gmat,
                  const std::vector<bst_uint>& feat_set,
                  GHistRow hist);
+  // same, with feature grouping
+  void BuildBlockHist(const std::vector<bst_gpair>& gpair,
+                      const RowSetCollection::Elem row_indices,
+                      const GHistIndexBlockMatrix& gmatb,
+                      const std::vector<bst_uint>& feat_set,
+                      GHistRow hist);
   // construct a histogram via subtraction trick
   void SubtractionTrick(GHistRow self, GHistRow sibling, GHistRow parent);
 
@@ -215,7 +268,6 @@ class GHistBuilder {
   /*! \brief number of all bins over all features */
   size_t nbins_;
   std::vector<GHistEntry> data_;
-  std::vector<bst_gpair> stat_buf_;
 };
 
 

--- a/src/tree/fast_hist_param.h
+++ b/src/tree/fast_hist_param.h
@@ -1,0 +1,64 @@
+/*!
+ * Copyright 2017 by Contributors
+ * \file updater_fast_hist.h
+ * \brief parameters for histogram-based training
+ * \author Philip Cho, Tianqi Chen
+ */
+#ifndef XGBOOST_TREE_FAST_HIST_PARAM_H_
+#define XGBOOST_TREE_FAST_HIST_PARAM_H_
+
+namespace xgboost {
+namespace tree {
+
+/*! \brief training parameters for histogram-based training */
+struct FastHistParam : public dmlc::Parameter<FastHistParam> {
+  // integral data type to be used with columnar data storage
+  enum class DataType { uint8 = 1, uint16 = 2, uint32 = 4 };
+  int colmat_dtype;
+  // percentage threshold for treating a feature as sparse
+  // e.g. 0.2 indicates a feature with fewer than 20% nonzeros is considered sparse
+  double sparse_threshold;
+  // use feature grouping? (default yes)
+  int enable_feature_grouping;
+  // when grouping features, how many "conflicts" to allow.
+  // conflict is when an instance has nonzero values for two or more features
+  // default is 0, meaning features should be strictly complementary
+  double max_conflict_rate;
+  // when grouping features, how much effort to expend to prevent singleton groups
+  // we'll try to insert each feature into existing groups before creating a new group
+  // for that feature; to save time, only up to (max_search_group) of existing groups
+  // will be considered. If set to zero, ALL existing groups will be examined
+  unsigned max_search_group;
+
+  // declare the parameters
+  DMLC_DECLARE_PARAMETER(FastHistParam) {
+    DMLC_DECLARE_FIELD(colmat_dtype)
+        .set_default(static_cast<int>(DataType::uint32))
+        .add_enum("uint8", static_cast<int>(DataType::uint8))
+        .add_enum("uint16", static_cast<int>(DataType::uint16))
+        .add_enum("uint32", static_cast<int>(DataType::uint32))
+        .describe("Integral data type to be used with columnar data storage."
+                  "May carry marginal performance implications. Reserved for "
+                  "advanced use");
+    DMLC_DECLARE_FIELD(sparse_threshold).set_range(0, 1.0).set_default(0.2)
+        .describe("percentage threshold for treating a feature as sparse");
+    DMLC_DECLARE_FIELD(enable_feature_grouping).set_lower_bound(0).set_default(1)
+        .describe("if >0, enable feature grouping to ameliorate work imbalance "
+                  "among worker threads");
+    DMLC_DECLARE_FIELD(max_conflict_rate).set_range(0, 1.0).set_default(0)
+        .describe("when grouping features, how many \"conflicts\" to allow."
+       "conflict is when an instance has nonzero values for two or more features."
+       "default is 0, meaning features should be strictly complementary.");
+    DMLC_DECLARE_FIELD(max_search_group).set_lower_bound(0).set_default(100)
+        .describe("when grouping features, how much effort to expend to prevent "
+                  "singleton groups. We'll try to insert each feature into existing "
+                  "groups before creating a new group for that feature; to save time, "
+                  "only up to (max_search_group) of existing groups will be "
+                  "considered. If set to zero, ALL existing groups will be examined.");
+  }
+};
+
+}  // namespace tree
+}  // namespace xgboost
+
+#endif  // XGBOOST_TREE_FAST_HIST_PARAM_H_

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -26,6 +26,13 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
   float min_split_loss;
   // maximum depth of a tree
   int max_depth;
+  // maximum number of leaves
+  int max_leaves;
+  // if using histogram based algorithm, maximum number of bins per feature
+  int max_bin;
+  // growing policy
+  enum TreeGrowPolicy { kDepthWise = 0, kLossGuide = 1 };
+  int grow_policy;
   // flag to print out detailed breakdown of runtime
   int debug_verbose;
   //----- the rest parameters are less important ----
@@ -90,6 +97,18 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
         .describe(
             "Maximum depth of the tree; 0 indicates no limit; a limit is required "
             "for depthwise policy");
+    DMLC_DECLARE_FIELD(max_leaves).set_lower_bound(0).set_default(0).describe(
+        "Maximum number of leaves; 0 indicates no limit.");
+    DMLC_DECLARE_FIELD(max_bin).set_lower_bound(2).set_default(256).describe(
+        "if using histogram-based algorithm, maximum number of bins per feature");
+    DMLC_DECLARE_FIELD(grow_policy)
+        .set_default(kDepthWise)
+        .add_enum("depthwise", kDepthWise)
+        .add_enum("lossguide", kLossGuide)
+        .describe(
+            "Tree growing policy. 0: favor splitting at nodes closest to the node, "
+            "i.e. grow depth-wise. 1: favor splitting at nodes with highest loss "
+            "change. (cf. LightGBM)");
     DMLC_DECLARE_FIELD(min_child_weight)
         .set_lower_bound(0.0f)
         .set_default(1.0f)

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -26,15 +26,6 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
   float min_split_loss;
   // maximum depth of a tree
   int max_depth;
-  // maximum number of leaves
-  int max_leaves;
-  // if using histogram based algorithm, maximum number of bins per feature
-  int max_bin;
-  enum class DataType { uint8 = 1, uint16 = 2, uint32 = 4 };
-  int colmat_dtype;
-  // growing policy
-  enum TreeGrowPolicy { kDepthWise = 0, kLossGuide = 1 };
-  int grow_policy;
   // flag to print out detailed breakdown of runtime
   int debug_verbose;
   //----- the rest parameters are less important ----
@@ -99,26 +90,6 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
         .describe(
             "Maximum depth of the tree; 0 indicates no limit; a limit is required "
             "for depthwise policy");
-    DMLC_DECLARE_FIELD(max_leaves).set_lower_bound(0).set_default(0).describe(
-        "Maximum number of leaves; 0 indicates no limit.");
-    DMLC_DECLARE_FIELD(max_bin).set_lower_bound(2).set_default(256).describe(
-        "if using histogram-based algorithm, maximum number of bins per feature");
-    DMLC_DECLARE_FIELD(grow_policy)
-        .set_default(kDepthWise)
-        .add_enum("depthwise", kDepthWise)
-        .add_enum("lossguide", kLossGuide)
-        .describe(
-            "Tree growing policy. 0: favor splitting at nodes closest to the node, "
-            "i.e. grow depth-wise. 1: favor splitting at nodes with highest loss "
-            "change. (cf. LightGBM)");
-    DMLC_DECLARE_FIELD(colmat_dtype)
-        .set_default(static_cast<int>(DataType::uint32))
-        .add_enum("uint8", static_cast<int>(DataType::uint8))
-        .add_enum("uint16", static_cast<int>(DataType::uint16))
-        .add_enum("uint32", static_cast<int>(DataType::uint32))
-        .describe("Integral data type to be used with columnar data storage."
-                  "May carry marginal performance implications. Reserved for "
-                  "advanced use");
     DMLC_DECLARE_FIELD(min_child_weight)
         .set_lower_bound(0.0f)
         .set_default(1.0f)

--- a/src/tree/updater_fast_hist.cc
+++ b/src/tree/updater_fast_hist.cc
@@ -43,7 +43,7 @@ struct FastHistParam : public dmlc::Parameter<FastHistParam> {
   enum class DataType { uint8 = 1, uint16 = 2, uint32 = 4 };
   int colmat_dtype;
   // percentage threshold for treating a feature as sparse
-  // e.g. 0.2 indicates a feature with fewer than 20% nonzeros is considered sparse 
+  // e.g. 0.2 indicates a feature with fewer than 20% nonzeros is considered sparse
   double sparse_threshold;
   // use feature grouping? (default yes)
   int enable_feature_grouping;


### PR DESCRIPTION
Change parallel strategy for histogram construction.
Instead of partitioning data rows among multiple threads, partition feature columns instead. Useful heuristics for assigning partitions have been adopted from [LightGBM project](https://github.com/Microsoft/LightGBM/blob/master/src/io/dataset.cpp). In particular, features that do not have overlapping nonzeros are grouped together.

How to use: by default, the new parallel strategy will be used. To revert to old behavior, simply set `enable_feature_grouping=0`.

Background: poor performance scaling with respect to number of worker threads has been reported by [a user benchmark](https://github.com/Laurae2/gbt_benchmarks). OpenMP inserts an implicit synchronization barrier at end of each parallel loop; with high work imbalance, most threads were doing no useful work but waiting. Partitioning data column-wise reduces work imbalance and thus improve performance.