### PR TITLE
Fix broken make on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,9 @@ endif
 include $(DMLC_CORE)/make/dmlc.mk
 
 # include the plugins
+ifdef XGB_PLUGINS
 include $(XGB_PLUGINS)
+endif
 
 # set compiler defaults for OSX versus *nix
 # let people override either

--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,14 @@ endif
 ifeq ($(UNAME), Windows)
 	XGBOOST_DYLIB = lib/libxgboost.dll
 	JAVAINCFLAGS += -I${JAVA_HOME}/include/win32
-else ifeq ($(UNAME), Darwin)
+else
+ifeq ($(UNAME), Darwin)
 	XGBOOST_DYLIB = lib/libxgboost.dylib
 	CFLAGS += -fPIC
 else
 	XGBOOST_DYLIB = lib/libxgboost.so
 	CFLAGS += -fPIC
+endif
 endif
 
 ifeq ($(UNAME), Linux)

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -588,7 +588,7 @@ inline bst_float RegTree::FillNodeMeanValue(int nid) {
 
 inline void RegTree::CalculateContributions(const RegTree::FVec& feat, unsigned root_id,
                                             bst_float *out_contribs) const {
-  CHECK_GT(this->node_mean_values.size(), 0);
+  CHECK_GT(this->node_mean_values.size(), 0U);
   // this follows the idea of http://blog.datadive.net/interpreting-random-forests/
   bst_float node_value;
   unsigned split_index;

--- a/src/tree/updater_fast_hist.cc
+++ b/src/tree/updater_fast_hist.cc
@@ -324,7 +324,7 @@ class FastHistMaker: public TreeUpdater {
           std::numeric_limits<float>::infinity());
       }
 
-      CHECK_GT(out_preds.size(), 0);
+      CHECK_GT(out_preds.size(), 0U);
 
       for (const RowSetCollection::Elem rowset : row_set_collection_) {
         if (rowset.begin != nullptr && rowset.end != nullptr) {


### PR DESCRIPTION
fixes the following error
```
Makefile:73: Extraneous text after `else' directive
Makefile:76: *** only one `else' per conditional.  Stop.
```
