### PR TITLE
Use old parallel algorithm for histogram construction by default

### DIFF
--- a/src/tree/fast_hist_param.h
+++ b/src/tree/fast_hist_param.h
@@ -42,7 +42,7 @@ struct FastHistParam : public dmlc::Parameter<FastHistParam> {
                   "advanced use");
     DMLC_DECLARE_FIELD(sparse_threshold).set_range(0, 1.0).set_default(0.2)
         .describe("percentage threshold for treating a feature as sparse");
-    DMLC_DECLARE_FIELD(enable_feature_grouping).set_lower_bound(0).set_default(1)
+    DMLC_DECLARE_FIELD(enable_feature_grouping).set_lower_bound(0).set_default(0)
         .describe("if >0, enable feature grouping to ameliorate work imbalance "
                   "among worker threads");
     DMLC_DECLARE_FIELD(max_conflict_rate).set_range(0, 1.0).set_default(0)


### PR DESCRIPTION
It has been reported that new parallel algorithm (#2493) results in excessive
message usage and random crashes. Until issues are resolved, XGBoost should use
the old parallel algorithm by default. The user would have to specify
`enable_feature_grouping=1` manually to enable the new algorithm.