### PR TITLE
Evaluate the expected number of trees in EvalOneIter

### DIFF
--- a/src/learner.cc
+++ b/src/learner.cc
@@ -361,7 +361,8 @@ class LearnerImpl : public Learner {
       metrics_.emplace_back(Metric::Create(obj_->DefaultEvalMetric()));
     }
     for (size_t i = 0; i < data_sets.size(); ++i) {
-      this->PredictRaw(data_sets[i], &preds_);
+      // iter starts at 0, ntree_limit starts at 1
+      this->PredictRaw(data_sets[i], &preds_, iter + 1);
       obj_->EvalTransform(&preds_);
       for (auto& ev : metrics_) {
         os << '\t' << data_names[i] << '-' << ev->Name() << ':'


### PR DESCRIPTION
EvalOneIter takes an argument iter which, per the related header
file, indicates the iteration number to evaluate. Prior to this patch
the only effect this argument had was to change the number printed
in the output. Update the function to evaluate the requested boosting
iteration.

This has no effect on existing training as the desired iteration to
evaluate is always passed so the output looks correct to the user.