### PR TITLE
[jvm-packages] Deduplicated train/test data access in tests

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/TrainTestData.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/TrainTestData.scala
@@ -1,0 +1,74 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package ml.dmlc.xgboost4j.scala.spark
+
+import scala.io.Source
+
+import org.apache.spark.ml.feature.{LabeledPoint => MLLabeledPoint}
+import org.apache.spark.ml.linalg.{Vectors => MLVectors}
+
+trait TrainTestData {
+  private def getResourceLines(resource: String): Iterator[String] = {
+    require(resource.startsWith("/"), "resource must start with /")
+    val is = getClass.getResourceAsStream(resource)
+    if (is == null) {
+      sys.error(s"failed to resolve resource $resource")
+    }
+
+    Source.fromInputStream(is).getLines()
+  }
+
+  protected def getGroups(resource: String): Seq[Int] = {
+    getResourceLines(resource).map(_.toInt).toSeq
+  }
+
+  protected def getLabeledPoints(resource: String, zeroBased: Boolean): Seq[MLLabeledPoint] = {
+    getResourceLines(resource).map { line =>
+      val labelAndFeatures = line.split(" ")
+      val label = labelAndFeatures.head.toDouble
+      val values = new Array[Double](126)
+      for (feature <- labelAndFeatures.tail) {
+        val idAndValue = feature.split(":")
+        if (!zeroBased) {
+          values(idAndValue(0).toInt - 1) = idAndValue(1).toDouble
+        } else {
+          values(idAndValue(0).toInt) = idAndValue(1).toDouble
+        }
+      }
+
+      MLLabeledPoint(label, MLVectors.dense(values))
+    }.toSeq
+  }
+}
+
+object Agaricus extends TrainTestData {
+  val train: Seq[MLLabeledPoint] = getLabeledPoints("/agaricus.txt.train", zeroBased = false)
+  val test: Seq[MLLabeledPoint] = getLabeledPoints("/agaricus.txt.test", zeroBased = false)
+}
+
+object Machine extends TrainTestData {
+  val train: Seq[MLLabeledPoint] = getLabeledPoints("/machine.txt.train", zeroBased = true)
+  val test: Seq[MLLabeledPoint] = getLabeledPoints("/machine.txt.test", zeroBased = true)
+}
+
+object RankDemo extends TrainTestData {
+  val train0: Seq[MLLabeledPoint] = getLabeledPoints("/rank-demo-0.txt.train", zeroBased = false)
+  val train1: Seq[MLLabeledPoint] = getLabeledPoints("/rank-demo-1.txt.train", zeroBased = false)
+  val trainGroup0: Seq[Int] = getGroups("/rank-demo-0.txt.train.group")
+  val trainGroup1: Seq[Int] = getGroups("/rank-demo-1.txt.train.group")
+  val test: Seq[MLLabeledPoint] = getLabeledPoints("/rank-demo.txt.test", zeroBased = false)
+}

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/TrainTestData.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/TrainTestData.scala
@@ -22,7 +22,7 @@ import org.apache.spark.ml.feature.{LabeledPoint => MLLabeledPoint}
 import org.apache.spark.ml.linalg.{Vectors => MLVectors}
 
 trait TrainTestData {
-  private def getResourceLines(resource: String): Iterator[String] = {
+  protected def getResourceLines(resource: String): Iterator[String] = {
     require(resource.startsWith("/"), "resource must start with /")
     val is = getClass.getResourceAsStream(resource)
     if (is == null) {
@@ -30,10 +30,6 @@ trait TrainTestData {
     }
 
     Source.fromInputStream(is).getLines()
-  }
-
-  protected def getGroups(resource: String): Seq[Int] = {
-    getResourceLines(resource).map(_.toInt).toSeq
   }
 
   protected def getLabeledPoints(resource: String, zeroBased: Boolean): Seq[MLLabeledPoint] = {
@@ -51,24 +47,28 @@ trait TrainTestData {
       }
 
       MLLabeledPoint(label, MLVectors.dense(values))
-    }.toSeq
+    }.toList
   }
 }
 
-object Agaricus extends TrainTestData {
+object Classification extends TrainTestData {
   val train: Seq[MLLabeledPoint] = getLabeledPoints("/agaricus.txt.train", zeroBased = false)
   val test: Seq[MLLabeledPoint] = getLabeledPoints("/agaricus.txt.test", zeroBased = false)
 }
 
-object Machine extends TrainTestData {
+object Regression extends TrainTestData {
   val train: Seq[MLLabeledPoint] = getLabeledPoints("/machine.txt.train", zeroBased = true)
   val test: Seq[MLLabeledPoint] = getLabeledPoints("/machine.txt.test", zeroBased = true)
 }
 
-object RankDemo extends TrainTestData {
+object Ranking extends TrainTestData {
   val train0: Seq[MLLabeledPoint] = getLabeledPoints("/rank-demo-0.txt.train", zeroBased = false)
   val train1: Seq[MLLabeledPoint] = getLabeledPoints("/rank-demo-1.txt.train", zeroBased = false)
   val trainGroup0: Seq[Int] = getGroups("/rank-demo-0.txt.train.group")
   val trainGroup1: Seq[Int] = getGroups("/rank-demo-1.txt.train.group")
   val test: Seq[MLLabeledPoint] = getLabeledPoints("/rank-demo.txt.test", zeroBased = false)
+
+  private def getGroups(resource: String): Seq[Int] = {
+    getResourceLines(resource).map(_.toInt).toList
+  }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/Utils.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/Utils.scala
@@ -35,8 +35,4 @@ trait Utils extends Serializable {
       file.delete()
     }
   }
-
-  protected def buildTrainingRDD(sparkContext: SparkContext): RDD[LabeledPoint] = {
-    sparkContext.parallelize(Agaricus.train, numWorkers)
-  }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/Utils.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/Utils.scala
@@ -18,14 +18,6 @@ package ml.dmlc.xgboost4j.scala.spark
 
 import java.io.File
 
-import scala.collection.mutable.ListBuffer
-import scala.io.Source
-
-import org.apache.spark.SparkContext
-import org.apache.spark.ml.feature.LabeledPoint
-import org.apache.spark.ml.linalg.{DenseVector, Vector => SparkVector}
-import org.apache.spark.rdd.RDD
-
 trait Utils extends Serializable {
   protected val numWorkers: Int = Runtime.getRuntime.availableProcessors()
 

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/Utils.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/Utils.scala
@@ -27,9 +27,7 @@ import org.apache.spark.ml.linalg.{DenseVector, Vector => SparkVector}
 import org.apache.spark.rdd.RDD
 
 trait Utils extends Serializable {
-  protected val numWorkers = Runtime.getRuntime().availableProcessors()
-
-  protected var labeledPointsRDD: RDD[LabeledPoint] = null
+  protected val numWorkers: Int = Runtime.getRuntime.availableProcessors()
 
   protected def cleanExternalCache(prefix: String): Unit = {
     val dir = new File(".")
@@ -38,53 +36,7 @@ trait Utils extends Serializable {
     }
   }
 
-  protected def loadLabelPoints(filePath: String, zeroBased: Boolean = false):
-      List[LabeledPoint] = {
-    val file = Source.fromFile(new File(filePath))
-    val sampleList = new ListBuffer[LabeledPoint]
-    for (sample <- file.getLines()) {
-      sampleList += fromColValueStringToLabeledPoint(sample, zeroBased)
-    }
-    sampleList.toList
-  }
-
-  protected def loadLabelAndVector(filePath: String, zeroBased: Boolean = false):
-      List[(Double, SparkVector)] = {
-    val file = Source.fromFile(new File(filePath))
-    val sampleList = new ListBuffer[(Double, SparkVector)]
-    for (sample <- file.getLines()) {
-      sampleList += fromColValueStringToLabelAndVector(sample, zeroBased)
-    }
-    sampleList.toList
-  }
-
-  protected def fromColValueStringToLabelAndVector(line: String, zeroBased: Boolean):
-      (Double, SparkVector) = {
-    val labelAndFeatures = line.split(" ")
-    val label = labelAndFeatures(0).toDouble
-    val features = labelAndFeatures.tail
-    val denseFeature = new Array[Double](126)
-    for (feature <- features) {
-      val idAndValue = feature.split(":")
-      if (!zeroBased) {
-        denseFeature(idAndValue(0).toInt - 1) = idAndValue(1).toDouble
-      } else {
-        denseFeature(idAndValue(0).toInt) = idAndValue(1).toDouble
-      }
-    }
-    (label, new DenseVector(denseFeature))
-  }
-
-  protected def fromColValueStringToLabeledPoint(line: String, zeroBased: Boolean): LabeledPoint = {
-    val (label, sv) = fromColValueStringToLabelAndVector(line, zeroBased)
-    LabeledPoint(label, sv)
-  }
-
   protected def buildTrainingRDD(sparkContext: SparkContext): RDD[LabeledPoint] = {
-    if (labeledPointsRDD == null) {
-      val sampleList = loadLabelPoints(getClass.getResource("/agaricus.txt.train").getFile)
-      labeledPointsRDD = sparkContext.parallelize(sampleList, numWorkers)
-    }
-    labeledPointsRDD
+    sparkContext.parallelize(Agaricus.train, numWorkers)
   }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostConfigureSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostConfigureSuite.scala
@@ -29,7 +29,7 @@ class XGBoostConfigureSuite extends FunSuite with Utils {
     val customSparkContext = new SparkContext(sparkConf)
     customSparkContext.setLogLevel("ERROR")
     // start another app
-    val trainingRDD = customSparkContext.parallelize(Agaricus.train)
+    val trainingRDD = customSparkContext.parallelize(Classification.train)
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
       "objective" -> "binary:logistic", "nthread" -> 6)
     intercept[IllegalArgumentException] {
@@ -45,9 +45,9 @@ class XGBoostConfigureSuite extends FunSuite with Utils {
     sparkConf.registerKryoClasses(Array(classOf[Booster]))
     val customSparkContext = new SparkContext(sparkConf)
     customSparkContext.setLogLevel("ERROR")
-    val trainingRDD = customSparkContext.parallelize(Agaricus.train)
+    val trainingRDD = customSparkContext.parallelize(Classification.train)
     import DataUtils._
-    val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
+    val testSetDMatrix = new DMatrix(new JDMatrix(Classification.test.iterator, null))
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
       "objective" -> "binary:logistic")
     val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, 5, numWorkers)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostConfigureSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostConfigureSuite.scala
@@ -39,7 +39,6 @@ class XGBoostConfigureSuite extends FunSuite with Utils {
   }
 
   test("kryoSerializer test") {
-    labeledPointsRDD = null
     val eval = new EvalError()
     val sparkConf = new SparkConf().setMaster("local[*]").setAppName("XGBoostSuite")
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
@@ -47,9 +46,8 @@ class XGBoostConfigureSuite extends FunSuite with Utils {
     val customSparkContext = new SparkContext(sparkConf)
     customSparkContext.setLogLevel("ERROR")
     val trainingRDD = buildTrainingRDD(customSparkContext)
-    val testSet = loadLabelPoints(getClass.getResource("/agaricus.txt.test").getFile).iterator
     import DataUtils._
-    val testSetDMatrix = new DMatrix(new JDMatrix(testSet, null))
+    val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
       "objective" -> "binary:logistic")
     val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, 5, numWorkers)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostConfigureSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostConfigureSuite.scala
@@ -29,7 +29,7 @@ class XGBoostConfigureSuite extends FunSuite with Utils {
     val customSparkContext = new SparkContext(sparkConf)
     customSparkContext.setLogLevel("ERROR")
     // start another app
-    val trainingRDD = buildTrainingRDD(customSparkContext)
+    val trainingRDD = customSparkContext.parallelize(Agaricus.train)
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
       "objective" -> "binary:logistic", "nthread" -> 6)
     intercept[IllegalArgumentException] {
@@ -45,7 +45,7 @@ class XGBoostConfigureSuite extends FunSuite with Utils {
     sparkConf.registerKryoClasses(Array(classOf[Booster]))
     val customSparkContext = new SparkContext(sparkConf)
     customSparkContext.setLogLevel("ERROR")
-    val trainingRDD = buildTrainingRDD(customSparkContext)
+    val trainingRDD = customSparkContext.parallelize(Agaricus.train)
     import DataUtils._
     val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
@@ -74,7 +74,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
   }
 
   test("build RDD containing boosters with the specified worker number") {
-    val trainingRDD = sc.parallelize(Agaricus.train)
+    val trainingRDD = sc.parallelize(Classification.train)
     val boosterRDD = XGBoost.buildDistributedBoosters(
       trainingRDD,
       List("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
@@ -89,9 +89,9 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   test("training with external memory cache") {
     val eval = new EvalError()
-    val trainingRDD = sc.parallelize(Agaricus.train)
+    val trainingRDD = sc.parallelize(Classification.train)
     import DataUtils._
-    val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
+    val testSetDMatrix = new DMatrix(new JDMatrix(Classification.test.iterator, null))
     val paramMap = List("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "binary:logistic").toMap
     val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, round = 5,
@@ -104,9 +104,9 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   test("training with Scala-implemented Rabit tracker") {
     val eval = new EvalError()
-    val trainingRDD = sc.parallelize(Agaricus.train)
+    val trainingRDD = sc.parallelize(Classification.train)
     import DataUtils._
-    val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
+    val testSetDMatrix = new DMatrix(new JDMatrix(Classification.test.iterator, null))
     val paramMap = List("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "binary:logistic",
       "tracker_conf" -> TrackerConf(60 * 60 * 1000, "scala")).toMap
@@ -118,9 +118,9 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   ignore("test with fast histo depthwise") {
     val eval = new EvalError()
-    val trainingRDD = sc.parallelize(Agaricus.train)
+    val trainingRDD = sc.parallelize(Classification.train)
     import DataUtils._
-    val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
+    val testSetDMatrix = new DMatrix(new JDMatrix(Classification.test.iterator, null))
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "binary:logistic", "tree_method" -> "hist",
       "grow_policy" -> "depthwise", "eval_metric" -> "error")
@@ -133,9 +133,9 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   ignore("test with fast histo lossguide") {
     val eval = new EvalError()
-    val trainingRDD = sc.parallelize(Agaricus.train)
+    val trainingRDD = sc.parallelize(Classification.train)
     import DataUtils._
-    val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
+    val testSetDMatrix = new DMatrix(new JDMatrix(Classification.test.iterator, null))
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "1",
             "objective" -> "binary:logistic", "tree_method" -> "hist",
             "grow_policy" -> "lossguide", "max_leaves" -> "8", "eval_metric" -> "error")
@@ -148,9 +148,9 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   ignore("test with fast histo lossguide with max bin") {
     val eval = new EvalError()
-    val trainingRDD = sc.parallelize(Agaricus.train)
+    val trainingRDD = sc.parallelize(Classification.train)
     import DataUtils._
-    val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
+    val testSetDMatrix = new DMatrix(new JDMatrix(Classification.test.iterator, null))
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "0",
             "objective" -> "binary:logistic", "tree_method" -> "hist",
             "grow_policy" -> "lossguide", "max_leaves" -> "8", "max_bin" -> "16",
@@ -164,9 +164,9 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   ignore("test with fast histo depthwidth with max depth") {
     val eval = new EvalError()
-    val trainingRDD = sc.parallelize(Agaricus.train)
+    val trainingRDD = sc.parallelize(Classification.train)
     import DataUtils._
-    val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
+    val testSetDMatrix = new DMatrix(new JDMatrix(Classification.test.iterator, null))
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "0",
       "objective" -> "binary:logistic", "tree_method" -> "hist",
       "grow_policy" -> "depthwise", "max_leaves" -> "8", "max_depth" -> "2",
@@ -180,9 +180,9 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   ignore("test with fast histo depthwidth with max depth and max bin") {
     val eval = new EvalError()
-    val trainingRDD = sc.parallelize(Agaricus.train)
+    val trainingRDD = sc.parallelize(Classification.train)
     import DataUtils._
-    val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
+    val testSetDMatrix = new DMatrix(new JDMatrix(Classification.test.iterator, null))
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "0",
             "objective" -> "binary:logistic", "tree_method" -> "hist",
             "grow_policy" -> "depthwise", "max_depth" -> "2", "max_bin" -> "2",
@@ -233,8 +233,8 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
   }
 
   test("test consistency of prediction functions with RDD") {
-    val trainingRDD = sc.parallelize(Agaricus.train)
-    val testSet = Agaricus.test
+    val trainingRDD = sc.parallelize(Classification.train)
+    val testSet = Classification.test
     val testRDD = sc.parallelize(testSet, numSlices = 1).map(_.features)
     val testCollection = testRDD.collect()
     for (i <- testSet.indices) {
@@ -254,7 +254,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
   }
 
   test("test eval functions with RDD") {
-    val trainingRDD = sc.parallelize(Agaricus.train).cache()
+    val trainingRDD = sc.parallelize(Classification.train).cache()
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
       "objective" -> "binary:logistic")
     val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, round = 5, nWorkers = numWorkers)
@@ -268,7 +268,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
       sparkContext.getOrElse(sc).parallelize(List[SparkVector](), numWorkers)
     }
 
-    val trainingRDD = sc.parallelize(Agaricus.train)
+    val trainingRDD = sc.parallelize(Classification.train)
     val testRDD = buildEmptyRDD()
     val paramMap = List("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
       "objective" -> "binary:logistic").toMap
@@ -278,9 +278,9 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   test("test model consistency after save and load") {
     val eval = new EvalError()
-    val trainingRDD = sc.parallelize(Agaricus.train)
+    val trainingRDD = sc.parallelize(Classification.train)
     import DataUtils._
-    val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
+    val testSetDMatrix = new DMatrix(new JDMatrix(Classification.test.iterator, null))
     val tempDir = Files.createTempDirectory("xgboosttest-")
     val tempFile = Files.createTempFile(tempDir, "", "")
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
@@ -299,7 +299,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
   test("test save and load of different types of models") {
     val tempDir = Files.createTempDirectory("xgboosttest-")
     val tempFile = Files.createTempFile(tempDir, "", "")
-    val trainingRDD = sc.parallelize(Agaricus.train)
+    val trainingRDD = sc.parallelize(Classification.train)
     var paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "reg:linear")
     // validate regression model
@@ -334,9 +334,9 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
   }
 
   test("test use groupData") {
-    val trainingRDD = sc.parallelize(RankDemo.train0, numSlices = 1)
-    val trainGroupData: Seq[Seq[Int]] = Seq(RankDemo.trainGroup0)
-    val testRDD = sc.parallelize(RankDemo.test, numSlices = 1).map(_.features)
+    val trainingRDD = sc.parallelize(Ranking.train0, numSlices = 1)
+    val trainGroupData: Seq[Seq[Int]] = Seq(Ranking.trainGroup0)
+    val testRDD = sc.parallelize(Ranking.test, numSlices = 1).map(_.features)
 
     val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "rank:pairwise", "eval_metric" -> "ndcg", "groupData" -> trainGroupData)
@@ -351,13 +351,13 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
   }
 
   test("test use nested groupData") {
-    val trainingRDD0 = sc.parallelize(RankDemo.train0, numSlices = 1)
-    val trainingRDD1 = sc.parallelize(RankDemo.train1, numSlices = 1)
+    val trainingRDD0 = sc.parallelize(Ranking.train0, numSlices = 1)
+    val trainingRDD1 = sc.parallelize(Ranking.train1, numSlices = 1)
     val trainingRDD = trainingRDD0.union(trainingRDD1)
 
-    val trainGroupData: Seq[Seq[Int]] = Seq(RankDemo.trainGroup0, RankDemo.trainGroup1)
+    val trainGroupData: Seq[Seq[Int]] = Seq(Ranking.trainGroup0, Ranking.trainGroup1)
 
-    val testRDD = sc.parallelize(RankDemo.test, numSlices = 1).map(_.features)
+    val testRDD = sc.parallelize(Ranking.test, numSlices = 1).map(_.features)
 
     val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "rank:pairwise", "groupData" -> trainGroupData)
@@ -369,8 +369,8 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
   }
 
     test("test use base margin") {
-      val trainRDD = sc.parallelize(RankDemo.train0, numSlices = 1)
-      val testRDD = sc.parallelize(RankDemo.test, numSlices = 1).map(_.features)
+      val trainRDD = sc.parallelize(Ranking.train0, numSlices = 1)
+      val testRDD = sc.parallelize(Ranking.test, numSlices = 1).map(_.features)
 
       val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
         "objective" -> "rank:pairwise")

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
@@ -74,7 +74,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
   }
 
   test("build RDD containing boosters with the specified worker number") {
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     val boosterRDD = XGBoost.buildDistributedBoosters(
       trainingRDD,
       List("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
@@ -89,7 +89,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   test("training with external memory cache") {
     val eval = new EvalError()
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     import DataUtils._
     val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
     val paramMap = List("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
@@ -104,7 +104,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   test("training with Scala-implemented Rabit tracker") {
     val eval = new EvalError()
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     import DataUtils._
     val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
     val paramMap = List("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
@@ -118,7 +118,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   ignore("test with fast histo depthwise") {
     val eval = new EvalError()
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     import DataUtils._
     val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "6", "silent" -> "1",
@@ -133,7 +133,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   ignore("test with fast histo lossguide") {
     val eval = new EvalError()
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     import DataUtils._
     val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "1",
@@ -148,7 +148,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   ignore("test with fast histo lossguide with max bin") {
     val eval = new EvalError()
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     import DataUtils._
     val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "0",
@@ -164,7 +164,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   ignore("test with fast histo depthwidth with max depth") {
     val eval = new EvalError()
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     import DataUtils._
     val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "0",
@@ -180,7 +180,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   ignore("test with fast histo depthwidth with max depth and max bin") {
     val eval = new EvalError()
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     import DataUtils._
     val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "0",
@@ -233,7 +233,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
   }
 
   test("test consistency of prediction functions with RDD") {
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     val testSet = Agaricus.test
     val testRDD = sc.parallelize(testSet, numSlices = 1).map(_.features)
     val testCollection = testRDD.collect()
@@ -254,7 +254,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
   }
 
   test("test eval functions with RDD") {
-    val trainingRDD = buildTrainingRDD(sc).cache()
+    val trainingRDD = sc.parallelize(Agaricus.train).cache()
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
       "objective" -> "binary:logistic")
     val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, round = 5, nWorkers = numWorkers)
@@ -268,7 +268,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
       sparkContext.getOrElse(sc).parallelize(List[SparkVector](), numWorkers)
     }
 
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     val testRDD = buildEmptyRDD()
     val paramMap = List("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
       "objective" -> "binary:logistic").toMap
@@ -278,7 +278,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
 
   test("test model consistency after save and load") {
     val eval = new EvalError()
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     import DataUtils._
     val testSetDMatrix = new DMatrix(new JDMatrix(Agaricus.test.iterator, null))
     val tempDir = Files.createTempDirectory("xgboosttest-")
@@ -299,7 +299,7 @@ class XGBoostGeneralSuite extends SharedSparkContext with Utils {
   test("test save and load of different types of models") {
     val tempDir = Files.createTempDirectory("xgboosttest-")
     val tempFile = Files.createTempFile(tempDir, "", "")
-    val trainingRDD = buildTrainingRDD(sc)
+    val trainingRDD = sc.parallelize(Agaricus.train)
     var paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "reg:linear")
     // validate regression model


### PR DESCRIPTION
This is preparatory PR for a proper implementation of baseMargin, which sadly doesn't work for RDDs with >1 partition.