### PR TITLE
remove/optional python _validate_features

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -820,6 +820,7 @@ class Booster(object):
         """
         if not isinstance(dtrain, DMatrix):
             raise TypeError('invalid training matrix: {}'.format(type(dtrain).__name__))
+        self._validate_features(dtrain)
 
         if fobj is None:
             _check_call(_LIB.XGBoosterUpdateOneIter(self.handle, ctypes.c_int(iteration),
@@ -846,6 +847,7 @@ class Booster(object):
             raise ValueError('grad / hess length mismatch: {} / {}'.format(len(grad), len(hess)))
         if not isinstance(dtrain, DMatrix):
             raise TypeError('invalid training matrix: {}'.format(type(dtrain).__name__))
+        self._validate_features(dtrain)
 
         _check_call(_LIB.XGBoosterBoostOneIter(self.handle, dtrain.handle,
                                                c_array(ctypes.c_float, grad),

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -820,7 +820,6 @@ class Booster(object):
         """
         if not isinstance(dtrain, DMatrix):
             raise TypeError('invalid training matrix: {}'.format(type(dtrain).__name__))
-        self._validate_features(dtrain)
 
         if fobj is None:
             _check_call(_LIB.XGBoosterUpdateOneIter(self.handle, ctypes.c_int(iteration),
@@ -847,7 +846,6 @@ class Booster(object):
             raise ValueError('grad / hess length mismatch: {} / {}'.format(len(grad), len(hess)))
         if not isinstance(dtrain, DMatrix):
             raise TypeError('invalid training matrix: {}'.format(type(dtrain).__name__))
-        self._validate_features(dtrain)
 
         _check_call(_LIB.XGBoosterBoostOneIter(self.handle, dtrain.handle,
                                                c_array(ctypes.c_float, grad),
@@ -921,7 +919,7 @@ class Booster(object):
         return self.eval_set([(data, name)], iteration)
 
     def predict(self, data, output_margin=False, ntree_limit=0, pred_leaf=False,
-                pred_contribs=False):
+                pred_contribs=False, valid_feat=False):
         """
         Predict with data.
 
@@ -953,6 +951,9 @@ class Booster(object):
             all feature contributions is equal to the prediction. Note that the bias is added
             as the final column, on top of the regular features.
 
+        valid_feat : bool
+            If columns should be validated prior to prediction.
+
         Returns
         -------
         prediction : numpy array
@@ -965,7 +966,8 @@ class Booster(object):
         if pred_contribs:
             option_mask |= 0x04
 
-        self._validate_features(data)
+        if valid_feat:
+            self._validate_features(data)
 
         length = c_bst_ulong()
         preds = ctypes.POINTER(ctypes.c_float)()

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -141,7 +141,8 @@ class TestBasic(unittest.TestCase):
 
             # different feature name must raises error
             dm = xgb.DMatrix(dummy, feature_names=list('abcde'))
-            self.assertRaises(ValueError, bst.predict, dm)
+            with self.assertRaises(ValueError):
+                bst.predict(dm, valid_feat=True)
 
     def test_feature_importances(self):
         data = np.random.randn(100, 5)

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -197,5 +197,5 @@ class TestModels(unittest.TestCase):
         bst = xgb.train([], dm2)
         bst.predict(dm2)  # success
         with self.assertRaises(ValueError):
-            bst.predict(dm1 valid_feat=True)
+            bst.predict(dm1, valid_feat=True)
         bst.predict(dm2)  # success

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -190,10 +190,12 @@ class TestModels(unittest.TestCase):
 
         bst = xgb.train([], dm1)
         bst.predict(dm1)  # success
-        self.assertRaises(ValueError, bst.predict, dm2)
+        with self.assertRaises(ValueError):
+            bst.predict(dm2, valid_feat=True)
         bst.predict(dm1)  # success
 
         bst = xgb.train([], dm2)
         bst.predict(dm2)  # success
-        self.assertRaises(ValueError, bst.predict, dm1)
+        with self.assertRaises(ValueError):
+            bst.predict(dm1 valid_feat=True)
         bst.predict(dm2)  # success


### PR DESCRIPTION
Removing `_validate_features` from `update` and `boost` & making it optional for `predict` as mentioned in https://github.com/dmlc/xgboost/issues/1605.