### PR TITLE
MinGW: shared library prefix and appveyor CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ file(GLOB_RECURSE SOURCES
 # Only add main function for executable target
 list(REMOVE_ITEM SOURCES ${PROJECT_SOURCE_DIR}/src/cli_main.cc)
 
+
+# rabit
 # TODO: Create rabit cmakelists.txt
 set(RABIT_SOURCES
     rabit/src/allreduce_base.cc
@@ -49,16 +51,28 @@ set(RABIT_SOURCES
     rabit/src/engine.cc
     rabit/src/c_api.cc
 )
+set(RABIT_EMPTY_SOURCES
+    rabit/src/engine_empty.cc
+    rabit/src/c_api.cc
+)
+if(MINGW)
+  # build a dummy rabit library
+  add_library(rabit STATIC ${RABIT_EMPTY_SOURCES})
+else()
+  add_library(rabit STATIC ${RABIT_SOURCES})
+endif()
 
+
+# dmlc-core
+add_subdirectory(dmlc-core)
+set(LINK_LIBRARIES dmlccore rabit)
+
+
+# GPU Plugin
 file(GLOB_RECURSE CUDA_SOURCES
     plugin/updater_gpu/src/*.cu
     plugin/updater_gpu/src/*.cuh
 )
-
-add_subdirectory(dmlc-core)
-set(LINK_LIBRARIES dmlccore rabit)
-
-# GPU Plugin
 if(PLUGIN_UPDATER_GPU)
   find_package(CUDA 7.5 REQUIRED)
   cmake_minimum_required(VERSION 3.5)
@@ -82,8 +96,6 @@ if(PLUGIN_UPDATER_GPU)
   list(APPEND SOURCES plugin/updater_gpu/src/register_updater_gpu.cc) 
 endif()
 
-add_library(rabit STATIC ${RABIT_SOURCES})
-
 add_library(objxgboost OBJECT ${SOURCES})
 
 # Executable
@@ -98,6 +110,10 @@ target_link_libraries(runxgboost ${LINK_LIBRARIES})
 add_library(xgboost SHARED $<TARGET_OBJECTS:objxgboost>)
 target_link_libraries(xgboost ${LINK_LIBRARIES})
 set_output_directory(xgboost ${PROJECT_SOURCE_DIR}/lib)
+if(MINGW)
+  # remove the 'lib' prefix to conform to windows convention for shared library names
+  set_target_properties(xgboost PROPERTIES PREFIX "")
+endif()
 
 #Ensure these two targets do not build simultaneously, as they produce outputs with conflicting names
 add_dependencies(xgboost runxgboost)

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ ifndef LINT_LANG
 endif
 
 ifeq ($(UNAME), Windows)
-	XGBOOST_DYLIB = lib/libxgboost.dll
+	XGBOOST_DYLIB = lib/xgboost.dll
 	JAVAINCFLAGS += -I${JAVA_HOME}/include/win32
 else
 ifeq ($(UNAME), Darwin)
@@ -176,7 +176,7 @@ lib/libxgboost.a: $(ALL_DEP)
 	@mkdir -p $(@D)
 	ar crv $@ $(filter %.o, $?)
 
-lib/libxgboost.dll lib/libxgboost.so lib/libxgboost.dylib: $(ALL_DEP)
+lib/xgboost.dll lib/libxgboost.so lib/libxgboost.dylib: $(ALL_DEP)
 	@mkdir -p $(@D)
 	$(CXX) $(CFLAGS) -shared -o $@ $(filter %.o %a,  $^) $(LDFLAGS)
 
@@ -213,7 +213,7 @@ cover: check
 endif
 
 clean:
-	$(RM) -rf build build_plugin lib bin *~ */*~ */*/*~ */*/*/*~ */*.o */*/*.o */*/*/*.o xgboost
+	$(RM) -rf build build_plugin lib bin *~ */*~ */*/*~ */*/*/*~ */*.o */*/*.o */*/*/*.o #xgboost
 	$(RM) -rf build_tests *.gcov tests/cpp/xgboost_test
 
 clean_all: clean

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,15 +22,18 @@ platform:
 install:
     - git submodule update --init --recursive
     # MinGW
-    - set PATH=C:\msys64\mingw64\bin\;C:\msys64\usr\bin\;%PATH%
+    - set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%
     - gcc -v
     - ls -l C:\
     # Miniconda2
     - set PATH=;C:\Miniconda-x64;C:\Miniconda-x64\Scripts;%PATH%
     - where python
     - python --version
-    # do python build only for mingw
-    - if /i "%target%" == "mingw" conda install -y numpy scipy pandas matplotlib nose scikit-learn graphviz python-graphviz
+    # do python build for mingw and one of the msvc jobs
+    - set DO_PYTHON=off
+    - if /i "%target%" == "mingw" set DO_PYTHON=on
+    - if /i "%target%_%ver%_%configuration%" == "msvc_2015_Release" set DO_PYTHON=on
+    - if /i "%DO_PYTHON%" == "on" conda install -y numpy scipy pandas matplotlib nose scikit-learn graphviz python-graphviz
 
 build_script:
     - cd %APPVEYOR_BUILD_FOLDER%
@@ -44,12 +47,14 @@ build_script:
         mkdir build_mingw &&
         cd build_mingw &&
         cmake .. -G"%generator%" &&
-        make -j2 &&
-        cd ../python-package &&
+        make -j2
+      )
+    - if /i "%DO_PYTHON%" == "on" (
+        cd %APPVEYOR_BUILD_FOLDER%\python-package &&
         python setup.py install
       )
     - if /i "%target%" == "jvm" cd jvm-packages && mvn test -pl :xgboost4j
 
 test_script:
     - cd %APPVEYOR_BUILD_FOLDER%
-    - if /i "%target%" == "mingw" python -m nose tests/python
+    - if /i "%DO_PYTHON%" == "on" python -m nose tests/python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,30 +1,55 @@
 environment:
-        matrix:
-                - target: native
-                  solution_name: C:/projects/xgboost/build2013/xgboost.sln
-                - target: native
-                  solution_name: C:/projects/xgboost/build2015/xgboost.sln
-                - target: jvm
-platform:
-        - x64
+    matrix:
+        - target: msvc
+          ver: 2013
+          generator: "Visual Studio 12 2013 Win64"
+          configuration: Release
+        - target: msvc
+          ver: 2015
+          generator: "Visual Studio 14 2015 Win64"
+          configuration: Debug
+        - target: msvc
+          ver: 2015
+          generator: "Visual Studio 14 2015 Win64"
+          configuration: Release
+        - target: mingw
+          generator: "Unix Makefiles"
+        - target: jvm
 
-configuration:
-        - Debug
-        - Release
+platform:
+    - x64
 
 install:
-        - SET PATH=;%PATH%
-        - git submodule update --init --recursive
-
-before_build:
-        - mkdir build2013
-        - mkdir build2015
-        - cd build2013
-        - cmake .. -G"Visual Studio 12 2013 Win64" -DCMAKE_CONFIGURATION_TYPES="Release;Debug;" 
-        - cd ../build2015
-        - cmake .. -G"Visual Studio 14 2015 Win64" -DCMAKE_CONFIGURATION_TYPES="Release;Debug;" 
+    - git submodule update --init --recursive
+    # MinGW
+    - set PATH=C:\msys64\mingw64\bin\;C:\msys64\usr\bin\;%PATH%
+    - gcc -v
+    - ls -l C:\
+    # Miniconda2
+    - set PATH=;C:\Miniconda-x64;C:\Miniconda-x64\Scripts;%PATH%
+    - where python
+    - python --version
+    # do python build only for mingw
+    - if /i "%target%" == "mingw" conda install -y numpy scipy pandas matplotlib nose scikit-learn graphviz python-graphviz
 
 build_script:
-        - cd %APPVEYOR_BUILD_FOLDER%
-        - if "%target%" == "native" msbuild %solution_name%
-        - if "%target%" == "jvm" cd jvm-packages && mvn test -pl :xgboost4j
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - if /i "%target%" == "msvc" (
+        mkdir build_msvc%ver% &&
+        cd build_msvc%ver% &&
+        cmake .. -G"%generator%" -DCMAKE_CONFIGURATION_TYPES="Release;Debug;" &&
+        msbuild xgboost.sln
+      )
+    - if /i "%target%" == "mingw" (
+        mkdir build_mingw &&
+        cd build_mingw &&
+        cmake .. -G"%generator%" &&
+        make -j2 &&
+        cd ../python-package &&
+        python setup.py install
+      )
+    - if /i "%target%" == "jvm" cd jvm-packages && mvn test -pl :xgboost4j
+
+test_script:
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - if /i "%target%" == "mingw" python -m nose tests/python

--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -43,13 +43,13 @@
 /*!
  * \brief Check if alignas(*) keyword is supported. (g++ 4.8 or higher)
  */
-#if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ >= 8
+#if defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 8) || __GNUC__ > 4)
 #define XGBOOST_ALIGNAS(X) alignas(X)
 #else
 #define XGBOOST_ALIGNAS(X)
 #endif
 
-#if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ >= 8 && \
+#if defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 8) || __GNUC__ > 4) && \
     !defined(__CUDACC__)
 #include <parallel/algorithm>
 #define XGBOOST_PARALLEL_SORT(X, Y, Z) __gnu_parallel::sort((X), (Y), (Z))

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -414,7 +414,7 @@ void prefixsum_inplace(size_t *x, size_t N) {
     suma[ithread+1] = sum;
 #pragma omp barrier
     size_t offset = 0;
-    for (omp_ulong i = 0; i < (ithread+1); i++) {
+    for (omp_ulong i = 0; i < static_cast<omp_ulong>(ithread+1); i++) {
       offset += suma[i];
     }
 #pragma omp for schedule(static)
@@ -442,7 +442,6 @@ XGB_DLL int XGDMatrixCreateFromMat_omp(const bst_float* data,
   //  const int nthreadmax = omp_get_max_threads();
   if (nthread <= 0) nthread=nthreadmax;
   omp_set_num_threads(nthread);
-  xgboost::bst_ulong nrow_reserve_per_thread = std::ceil(nrow/static_cast<double>(nthread));
 
   std::unique_ptr<data::SimpleCSRSource> source(new data::SimpleCSRSource());
   data::SimpleCSRSource& mat = *source;


### PR DESCRIPTION
- As discussed in #2461 , dropped the 'lib' prefix from shared library name in MinGW as well. Python package works with mingw again.
- Added Apveyor CI for MinGW and python
- I don't think it is necessary to run two appveyor jobs for jvm; and, perhaps, can live without a Debug job for MSVC2013
- some 'g++ 4.8 or higher' defines seemed to (unintentionally?) miss versions above 4