### PR TITLE
Improve initial setup time and memory consumption in fast histogram

### DIFF
--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -79,7 +79,7 @@ struct HistCutMatrix {
   }
   // create histogram cut matrix given statistics from data
   // using approximate quantile sketch approach
-  void Init(DMatrix* p_fmat, uint32_t max_num_bins);
+  void Init(DMatrix* p_fmat, uint32_t max_num_bins, bool verbose = false);
 };
 
 

--- a/src/common/memory.h
+++ b/src/common/memory.h
@@ -1,0 +1,37 @@
+/*!
+ * Copyright 2017 by Contributors
+ * \file memory.h
+ * \brief Utility for memory
+ * \author Philip Cho
+ */
+#ifndef XGBOOST_COMMON_MEMORY_H_
+#define XGBOOST_COMMON_MEMORY_H_
+
+#ifndef _WIN32
+#include <unistd.h>
+#else
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+namespace xgboost {
+namespace common {
+
+#ifndef _WIN32
+inline size_t GetSystemMemory() {
+  size_t pages = sysconf(_SC_PHYS_PAGES);
+  size_t page_size = sysconf(_SC_PAGE_SIZE);
+  return pages * page_size;
+}
+#else
+inline size_t GetSystemMemory() {
+  MEMORYSTATUSEX status;
+  status.dwLength = sizeof(status);
+  GlobalMemoryStatusEx(&status);
+  return status.ullTotalPhys;
+}
+#endif
+
+}  // namespace common
+}  // namespace xgboost
+#endif  // XGBOOST_COMMON_MEMORY_H_

--- a/src/tree/fast_hist_param.h
+++ b/src/tree/fast_hist_param.h
@@ -18,8 +18,10 @@ struct FastHistParam : public dmlc::Parameter<FastHistParam> {
   // percentage threshold for treating a feature as sparse
   // e.g. 0.2 indicates a feature with fewer than 20% nonzeros is considered sparse
   double sparse_threshold;
-  // use feature grouping? (default yes)
+  // use feature grouping? (default no)
   int enable_feature_grouping;
+  // use columnar access structure? (default yes)
+  int use_columnar_access;
   // when grouping features, how many "conflicts" to allow.
   // conflict is when an instance has nonzero values for two or more features
   // default is 0, meaning features should be strictly complementary
@@ -45,7 +47,9 @@ struct FastHistParam : public dmlc::Parameter<FastHistParam> {
     DMLC_DECLARE_FIELD(enable_feature_grouping).set_lower_bound(0).set_default(0)
         .describe("if >0, enable feature grouping to ameliorate work imbalance "
                   "among worker threads");
-    DMLC_DECLARE_FIELD(max_conflict_rate).set_range(0, 1.0).set_default(0)
+    DMLC_DECLARE_FIELD(use_columnar_access).set_lower_bound(0).set_default(1)
+        .describe("if >0, store a transposed copy of input matrix for fast columnar access");
+    DMLC_DECLARE_FIELD(max_conflict_rate).set_range(1, 1.0).set_default(0)
         .describe("when grouping features, how many \"conflicts\" to allow."
        "conflict is when an instance has nonzero values for two or more features."
        "default is 0, meaning features should be strictly complementary.");


### PR DESCRIPTION
This is a response to issue #2326.
* Modified implementation for approximate quantile sketch for reduced memory consumption
* Parallel construction of columnar access structure -- this is a transposed version of input matrix to speed up column-wise access.
* Option (`use_columnar_access=0`) to disable columnar access structure entirely, to further reduce initial setup time and memory usage. Column access may slow down with this option.
* Slightly improved feature grouping algorithm