### PR TITLE
Implement enforcing monotonicity within GBLinear

### DIFF
--- a/src/common/vector_serializer.h
+++ b/src/common/vector_serializer.h
@@ -1,0 +1,76 @@
+#include <iostream>
+#include <cstddef>
+#include <vector>
+
+// define string serializer for vector, to get the arguments
+namespace std {
+inline std::ostream &operator<<(std::ostream &os, const std::vector<int> &t) {
+  os << '(';
+  for (std::vector<int>::const_iterator it = t.begin(); it != t.end(); ++it) {
+    if (it != t.begin())
+      os << ',';
+    os << *it;
+  }
+  // python style tuple
+  if (t.size() == 1)
+    os << ',';
+  os << ')';
+  return os;
+}
+
+inline std::istream &operator>>(std::istream &is, std::vector<int> &t) {
+  // get (
+  while (true) {
+    char ch = is.peek();
+    if (isdigit(ch)) {
+      int idx;
+      if (is >> idx) {
+        t.assign(&idx, &idx + 1);
+      }
+      return is;
+    }
+    is.get();
+    if (ch == '(')
+      break;
+    if (!isspace(ch)) {
+      is.setstate(std::ios::failbit);
+      return is;
+    }
+  }
+  int idx;
+  std::vector<int> tmp;
+  while (is >> idx) {
+    tmp.push_back(idx);
+    char ch;
+    do {
+      ch = is.get();
+    } while (isspace(ch));
+    if (ch == 'L') {
+      ch = is.get();
+    }
+    if (ch == ',') {
+      while (true) {
+        ch = is.peek();
+        if (isspace(ch)) {
+          is.get();
+          continue;
+        }
+        if (ch == ')') {
+          is.get();
+          break;
+        }
+        break;
+      }
+      if (ch == ')')
+        break;
+    } else if (ch == ')') {
+      break;
+    } else {
+      is.setstate(std::ios::failbit);
+      return is;
+    }
+  }
+  t.assign(tmp.begin(), tmp.end());
+  return is;
+}
+}  // namespace std

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -14,6 +14,7 @@
 #include <sstream>
 #include <cstring>
 #include <algorithm>
+#include "../common/vector_serializer.h"
 
 namespace xgboost {
 namespace gbm {
@@ -50,6 +51,8 @@ struct GBLinearTrainParam : public dmlc::Parameter<GBLinearTrainParam> {
   float reg_alpha;
   /*! \brief regularization weight for L2 norm in bias */
   float reg_lambda_bias;
+  /*! \brief array that specify the direction of each feature's beta */
+  std::vector<int> monotone_constraints;
   // declare parameters
   DMLC_DECLARE_PARAMETER(GBLinearTrainParam) {
     DMLC_DECLARE_FIELD(learning_rate).set_lower_bound(0.0f).set_default(1.0f)
@@ -65,6 +68,9 @@ struct GBLinearTrainParam : public dmlc::Parameter<GBLinearTrainParam> {
     DMLC_DECLARE_ALIAS(reg_lambda, lambda);
     DMLC_DECLARE_ALIAS(reg_alpha, alpha);
     DMLC_DECLARE_ALIAS(reg_lambda_bias, lambda_bias);
+    DMLC_DECLARE_FIELD(monotone_constraints)
+        .set_default(std::vector<int>())
+        .describe("Constraint of variable monotonicity");
   }
   // given original weight calculate delta
   inline double CalcDelta(double sum_grad, double sum_hess, double w) const {

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -13,7 +13,7 @@
 #include <cstring>
 #include <limits>
 #include <vector>
-
+#include "../common/vector_serializer.h"
 
 namespace xgboost {
 namespace tree {
@@ -520,78 +520,5 @@ struct SplitEntry {
 
 }  // namespace tree
 }  // namespace xgboost
-
-// define string serializer for vector, to get the arguments
-namespace std {
-inline std::ostream &operator<<(std::ostream &os, const std::vector<int> &t) {
-  os << '(';
-  for (std::vector<int>::const_iterator it = t.begin(); it != t.end(); ++it) {
-    if (it != t.begin())
-      os << ',';
-    os << *it;
-  }
-  // python style tuple
-  if (t.size() == 1)
-    os << ',';
-  os << ')';
-  return os;
-}
-
-inline std::istream &operator>>(std::istream &is, std::vector<int> &t) {
-  // get (
-  while (true) {
-    char ch = is.peek();
-    if (isdigit(ch)) {
-      int idx;
-      if (is >> idx) {
-        t.assign(&idx, &idx + 1);
-      }
-      return is;
-    }
-    is.get();
-    if (ch == '(')
-      break;
-    if (!isspace(ch)) {
-      is.setstate(std::ios::failbit);
-      return is;
-    }
-  }
-  int idx;
-  std::vector<int> tmp;
-  while (is >> idx) {
-    tmp.push_back(idx);
-    char ch;
-    do {
-      ch = is.get();
-    } while (isspace(ch));
-    if (ch == 'L') {
-      ch = is.get();
-    }
-    if (ch == ',') {
-      while (true) {
-        ch = is.peek();
-        if (isspace(ch)) {
-          is.get();
-          continue;
-        }
-        if (ch == ')') {
-          is.get();
-          break;
-        }
-        break;
-      }
-      if (ch == ')')
-        break;
-    } else if (ch == ')') {
-      break;
-    } else {
-      is.setstate(std::ios::failbit);
-      return is;
-    }
-  }
-  t.assign(tmp.begin(), tmp.end());
-  return is;
-}
-}  // namespace std
 
 #endif  // XGBOOST_TREE_PARAM_H_


### PR DESCRIPTION
In reference to ticket: #2515 
Use will need to provide monotonic factors indexes in `monotone_constraints` using the following format:
{Factor Index},{Direction(1|-1)};...
and as for factors that does not have rules they can be skipped, 
Example:
`monotone_constraints = "13,1;332,-1;2334,1"`
the model will force a positive weight for factors marked with `1` and negative weight for factors marked with `-1`
