### PR TITLE
Fix documentation for a misspelled parameter

### DIFF
--- a/doc/parameter.md
+++ b/doc/parameter.md
@@ -103,7 +103,7 @@ Parameters for Tree Booster
     - 'lossguide': split at nodes with highest loss change.
 * max_leaves, [default=0]
   - Maximum number of nodes to be added. Only relevant for the 'lossguide' grow policy.
-* max_bins, [default=256]
+* max_bin, [default=256]
   - This is only used if 'hist' is specified as `tree_method`.
   - Maximum number of discrete bins to bucket continuous features.
   - Increasing this number improves the optimality of splits at the cost of higher computation time.

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
@@ -222,7 +222,7 @@ public class BoosterImplTest {
         put("tree_method", "hist");
         put("grow_policy", "lossguide");
         put("max_leaves", 8);
-        put("max_bins", 16);
+        put("max_bin", 16);
         put("eval_metric", "auc");
       }
     };


### PR DESCRIPTION
The parameter `max_bin` was misspelled as `max_bins`. Reported in issue #2567.