### PR TITLE
Several fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,4 @@
 [submodule "cub"]
 	path = cub
 	url = https://github.com/NVlabs/cub
+	shallow = true

--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,19 @@ endif
 
 ROOTDIR = $(CURDIR)
 
-# workarounds for some crazy old make versions seen in windows
+# workarounds for some buggy old make & msys2 versions seen in windows
 ifeq (NA, $(shell test ! -d "$(ROOTDIR)" && echo NA ))
-$(warning attempting to fix non-existing ROOTDIR [$(ROOTDIR)])
-ROOTDIR := $(shell pwd)
-$(warning new ROOTDIR [$(ROOTDIR)] $(shell test -d "$(ROOTDIR)" && echo " is OK" ))
+        $(warning Attempting to fix non-existing ROOTDIR [$(ROOTDIR)])
+        ROOTDIR := $(shell pwd)
+        $(warning New ROOTDIR [$(ROOTDIR)] $(shell test -d "$(ROOTDIR)" && echo " is OK" ))
 endif
-ifeq (NA, $(shell test ! -f "$(MAKE)" && echo NA ))
-$(warning attempting to fix non-existing MAKE $(MAKE))
-MAKE := $(shell which make)
-$(warning new MAKE [$(MAKE)] $(shell test -f "$(MAKE)" && echo " is OK" ))
+MAKE_OK := $(shell "$(MAKE)" -v 2> /dev/null)
+ifndef MAKE_OK
+        $(warning Attempting to recover non-functional MAKE [$(MAKE)])
+        MAKE := $(shell which make 2> /dev/null)
+        MAKE_OK := $(shell "$(MAKE)" -v 2> /dev/null)
 endif
+$(warning MAKE [$(MAKE)] - $(if $(MAKE_OK),checked OK,PROBLEM))
 
 ifeq ($(OS), Windows_NT)
 	UNAME="Windows"

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -235,8 +235,7 @@ def mknfold(dall, nfold, param, seed, evals=(), fpreproc=None, stratified=False,
             idx = np.random.permutation(dall.num_row())
         else:
             idx = np.arange(dall.num_row())
-        kstep = int(len(idx) / nfold)
-        idset = [idx[(i * kstep): min(len(idx), (i + 1) * kstep)] for i in range(nfold)]
+        idset = np.array_split(idx, nfold)
     elif folds is not None and isinstance(folds, list):
         idset = [x[1] for x in folds]
         nfold = len(idset)

--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -75,6 +75,7 @@ struct GBTreeModel {
       }
       trees.clear();
       param.num_trees = 0;
+      tree_info.clear();
     }
   }
 


### PR DESCRIPTION
- Fixed the serialization bug after the update process #2545
- The CV folds splitting process in python could omit some data instances. E.g.
```python
nrow = 9
nfold = 5
idx = np.arange(nrow)
kstep = int(len(idx) / nfold)
[idx[(i * kstep): min(len(idx), (i + 1) * kstep)] for i in range(nfold)]
```
produces `[array([0]), array([1]), array([2]), array([3]), array([4])]` which omits indices from 5 to 8

- Some make versions in windows (coming with Rtools or some MSYS2 distributions) get wrong locations for $CURDIR and $MAKE. I've added some attempts to auto-fix them. That should, hopefully, cure many make-in-windows related issues.
- `make clean` should clean up the R-package as well
- The recently added `cub` git submodule adds 146M to a cloned xgboost repository, making it 168M total. Most of it is in cub's git pack file. It makes sense to clone `cub` as a shallow submodule, without dragging along its huge history. The `shallow = true` setting that I've added to .gitmodules should work for git from v2.10, but we might want to think about how to handle it for older git as well.