### PR TITLE
Add parallel sort for MSVC

### DIFF
--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -55,6 +55,10 @@
 #define XGBOOST_PARALLEL_SORT(X, Y, Z) __gnu_parallel::sort((X), (Y), (Z))
 #define XGBOOST_PARALLEL_STABLE_SORT(X, Y, Z) \
   __gnu_parallel::stable_sort((X), (Y), (Z))
+#elif defined(_MSC_VER) && (!__INTEL_COMPILER)
+#include <ppl.h>
+#define XGBOOST_PARALLEL_SORT(X, Y, Z) concurrency::parallel_sort((X), (Y), (Z))
+#define XGBOOST_PARALLEL_STABLE_SORT(X, Y, Z) std::stable_sort((X), (Y), (Z))
 #else
 #define XGBOOST_PARALLEL_SORT(X, Y, Z) std::sort((X), (Y), (Z))
 #define XGBOOST_PARALLEL_STABLE_SORT(X, Y, Z) std::stable_sort((X), (Y), (Z))


### PR DESCRIPTION
Improves sorting performance by around 5x on 8 core fx8350 vs std::sort().

In particular this speeds up the AUC metric calculation.