### PR TITLE
Make comparison of feature names in `_validate_features` order agnostic

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1253,7 +1253,7 @@ class Booster(object):
             self.feature_types = data.feature_types
         else:
             # Booster can't accept data with different feature names
-            if self.feature_names != data.feature_names:
+            if collections.Counter(self.feature_names) != collections.Counter(data.feature_names):
                 dat_missing = set(self.feature_names) - set(data.feature_names)
                 my_missing = set(data.feature_names) - set(self.feature_names)
 


### PR DESCRIPTION
Encountered this problem when I tried to wrap a model into an service. I serialised my model into a pickle file. My service extracts the same set of features from the input, de-serialises the model and calls the `predict` method on it with extracted features. I ran into `feature_names mismatch` error, even though the feature names in the training and input data match. This is because of the following line: 
```python
if self.feature_names != data.feature_names:
    ...
```

Both `self.feature_names` and `data.feature_names` are both lists, and Python compares both order and values of items when two lists are compared. Modified the code to make the comparison order agnostic.

Disclaimer: I'm not a data scientist, but engineer trying to production-ise an ML model. If the order-specific comparison is intentional, please close the PR.
