### PR TITLE
[jvm-packages] Fixed compilation on Scala 2.10

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
@@ -203,7 +203,7 @@ class XGBoostDFSuite extends FunSuite with PerTest {
       "objective" -> "binary:logistic", "baseMarginCol" -> "margin")
 
     def trainPredict(df: Dataset[_]): Array[Float] = {
-      XGBoost.trainWithDataFrame(df, paramMap, round = 1, numWorkers)
+      XGBoost.trainWithDataFrame(df, paramMap, round = 1, nWorkers = numWorkers)
           .predict(testRDD)
           .map { case Array(p) => p }
           .collect()

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
@@ -243,7 +243,7 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
     val trainingRDD = sc.parallelize(Classification.train).map(_.asML).cache()
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
       "objective" -> "binary:logistic")
-    val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, round = 5, numWorkers)
+    val xgBoostModel = XGBoost.trainWithRDD(trainingRDD, paramMap, round = 5, nWorkers = numWorkers)
     // Nan Zhu: deprecate it for now
     // xgBoostModel.eval(trainingRDD, "eval1", iter = 5, useExternalCache = false)
     xgBoostModel.eval(trainingRDD, "eval2", evalFunc = new EvalError, useExternalCache = false)


### PR DESCRIPTION
Apparently, there is a bug in 2.10 which allows passing positional arguments after a named one.