### PR TITLE
Enable callbacks from sklearn interface.

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -218,7 +218,7 @@ class XGBModel(XGBModelBase):
         return xgb_params
 
     def fit(self, X, y, sample_weight=None, eval_set=None, eval_metric=None,
-            early_stopping_rounds=None, verbose=True):
+            early_stopping_rounds=None, verbose=True, callbacks=None):
         # pylint: disable=missing-docstring,invalid-name,attribute-defined-outside-init
         """
         Fit the gradient boosting model
@@ -255,6 +255,10 @@ class XGBModel(XGBModelBase):
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation
             metric measured on the validation set to stderr.
+        callbacks : list of callables, optional.
+            List of callbacks to run after each boosting round. Each function is
+            called with a `core.CallbackEnv` object representing the current
+            training state.
         """
         if sample_weight is not None:
             trainDmatrix = DMatrix(X, label=y, weight=sample_weight, missing=self.missing)
@@ -288,7 +292,8 @@ class XGBModel(XGBModelBase):
                               self.n_estimators, evals=evals,
                               early_stopping_rounds=early_stopping_rounds,
                               evals_result=evals_result, obj=obj, feval=feval,
-                              verbose_eval=verbose)
+                              verbose_eval=verbose,
+                              callbacks=callbacks)
 
         if evals_result:
             for val in evals_result.items():
@@ -406,7 +411,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
                                             random_state, seed, missing, **kwargs)
 
     def fit(self, X, y, sample_weight=None, eval_set=None, eval_metric=None,
-            early_stopping_rounds=None, verbose=True):
+            early_stopping_rounds=None, verbose=True, callbacks=None):
         # pylint: disable = attribute-defined-outside-init,arguments-differ
         """
         Fit gradient boosting classifier
@@ -443,6 +448,10 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation
             metric measured on the validation set to stderr.
+        callbacks : list of callables, optional.
+            List of callbacks to run after each boosting round. Each function is
+            called with a `core.CallbackEnv` object representing the current
+            training state.
         """
         evals_result = {}
         self.classes_ = np.unique(y)
@@ -497,7 +506,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
                               evals=evals,
                               early_stopping_rounds=early_stopping_rounds,
                               evals_result=evals_result, obj=obj, feval=feval,
-                              verbose_eval=verbose)
+                              verbose_eval=verbose, callbacks=callbacks)
 
         self.objective = xgb_options["objective"]
         if evals_result:

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -407,7 +407,7 @@ def test_callbacks_regressor():
     regressor.fit(X=X, y=y, callbacks=[callback])
 
     # Ensure the callback has been executed the correct number of times.
-    self.assertEqual(callback_log, list(range(n_estimators)))
+    assert callback_log == list(range(n_estimators))
 
 def test_callbacks_classifier():
     tm._skip_if_no_sklearn()
@@ -424,5 +424,5 @@ def test_callbacks_classifier():
     classifier.fit(X=X, y=y, callbacks=[callback])
 
     # Ensure the callback has been executed the correct number of times.
-    self.assertEqual(callback_log, list(range(n_estimators)))
+    assert callback_log == list(range(n_estimators))
 

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -393,14 +393,16 @@ def test_sklearn_clone():
     clf.n_jobs = -1
     clone(clf)
 
+
 def test_callbacks_regressor():
     tm._skip_if_no_sklearn()
     n_estimators = 10
     regressor = xgb.XGBRegressor(n_estimators=n_estimators, max_depth=2)
 
     callback_log = []
+
     def callback(callback_env):
-      callback_log.append(callback_env.iteration)
+        callback_log.append(callback_env.iteration)
 
     X = np.random.randn(100, 40)
     y = np.random.randn(100)
@@ -409,14 +411,16 @@ def test_callbacks_regressor():
     # Ensure the callback has been executed the correct number of times.
     assert callback_log == list(range(n_estimators))
 
+
 def test_callbacks_classifier():
     tm._skip_if_no_sklearn()
     n_estimators = 10
     classifier = xgb.XGBClassifier(n_estimators=n_estimators, max_depth=2)
 
     callback_log = []
+
     def callback(callback_env):
-      callback_log.append(callback_env.iteration)
+        callback_log.append(callback_env.iteration)
 
     X = np.random.randn(100, 40)
     # this is inclusive of low and exclusive of high, so binary labels.
@@ -425,4 +429,3 @@ def test_callbacks_classifier():
 
     # Ensure the callback has been executed the correct number of times.
     assert callback_log == list(range(n_estimators))
-

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -392,3 +392,35 @@ def test_sklearn_clone():
     clf = xgb.XGBClassifier(n_jobs=2, nthread=3)
     clf.n_jobs = -1
     clone(clf)
+
+def test_callbacks_regressor():
+    n_estimators = 10
+    regressor = xgb.XGBRegressor(n_estimators=n_estimators, max_depth=2)
+
+    callback_log = []
+    def callback(callback_env):
+      callback_log.append(callback_env.iteration)
+
+    X = np.random.randn(100, 40)
+    y = np.random.randn(100)
+    regressor.fit(X=X, y=y, callbacks=[callback])
+
+    # Ensure the callback has been executed the correct number of times.
+    self.assertEqual(callback_log, list(range(n_estimators)))
+
+def test_callbacks_classifier():
+    n_estimators = 10
+    classifier = xgb.XGBClassifier(n_estimators=n_estimators, max_depth=2)
+
+    callback_log = []
+    def callback(callback_env):
+      callback_log.append(callback_env.iteration)
+
+    X = np.random.randn(100, 40)
+    # this is inclusive of low and exclusive of high, so binary labels.
+    y = np.random.randint(low=0, high=2, size=[100])
+    classifier.fit(X=X, y=y, callbacks=[callback])
+
+    # Ensure the callback has been executed the correct number of times.
+    self.assertEqual(callback_log, list(range(n_estimators)))
+

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -394,6 +394,7 @@ def test_sklearn_clone():
     clone(clf)
 
 def test_callbacks_regressor():
+    tm._skip_if_no_sklearn()
     n_estimators = 10
     regressor = xgb.XGBRegressor(n_estimators=n_estimators, max_depth=2)
 
@@ -409,6 +410,7 @@ def test_callbacks_regressor():
     self.assertEqual(callback_log, list(range(n_estimators)))
 
 def test_callbacks_classifier():
+    tm._skip_if_no_sklearn()
     n_estimators = 10
     classifier = xgb.XGBClassifier(n_estimators=n_estimators, max_depth=2)
 


### PR DESCRIPTION
Simple patch to enable mid-train callbacks to be used in XGBRegressor and XGBClassifier.