### PR TITLE
add threshold to early stopping in training

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -146,7 +146,7 @@ def reset_learning_rate(learning_rates):
     return callback
 
 
-def early_stop(stopping_rounds, maximize=False, verbose=True):
+def early_stop(stopping_rounds, threshold=None, maximize=False, verbose=True):
     """Create a callback that activates early stoppping.
 
     Validation error needs to decrease at least
@@ -164,6 +164,8 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
     stopp_rounds : int
        The stopping rounds before the trend occur.
 
+	threshold : float
+	   An optional threshold to smooth the early stopping.
     maximize : bool
         Whether to maximize evaluation metric.
 
@@ -230,8 +232,8 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
         best_score = state['best_score']
         best_iteration = state['best_iteration']
         maximize_score = state['maximize_score']
-        if (maximize_score and score > best_score) or \
-                (not maximize_score and score < best_score):
+        if (maximize_score and score > (best_score+env.threshold)) or \
+                (not maximize_score and score < (best_score+env.threshold)):
             msg = '[%d]\t%s' % (
                 env.iteration,
                 '\t'.join([_fmt_metric(x) for x in env.evaluation_result_list]))

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -218,7 +218,7 @@ class XGBModel(XGBModelBase):
         return xgb_params
 
     def fit(self, X, y, sample_weight=None, eval_set=None, eval_metric=None,
-            early_stopping_rounds=None, verbose=True):
+            early_stopping_rounds=None, early_stopping_threshold=None, verbose=True):
         # pylint: disable=missing-docstring,invalid-name,attribute-defined-outside-init
         """
         Fit the gradient boosting model
@@ -252,6 +252,10 @@ class XGBModel(XGBModelBase):
             and bst.best_ntree_limit.
             (Use bst.best_ntree_limit to get the correct value if num_parallel_tree
             and/or num_class appears in the parameters)
+		early_stopping_threshold : float
+			Sets an potional threshold to smoothen the early stopping policy.
+			If after early_stopping_rounds iterations, the model hasn't improved 
+			more than the threshold, the learning stops.
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation
             metric measured on the validation set to stderr.
@@ -287,6 +291,7 @@ class XGBModel(XGBModelBase):
         self._Booster = train(params, trainDmatrix,
                               self.n_estimators, evals=evals,
                               early_stopping_rounds=early_stopping_rounds,
+							  early_stopping_threshold=early_stopping_threshold,
                               evals_result=evals_result, obj=obj, feval=feval,
                               verbose_eval=verbose)
 
@@ -406,7 +411,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
                                             random_state, seed, missing, **kwargs)
 
     def fit(self, X, y, sample_weight=None, eval_set=None, eval_metric=None,
-            early_stopping_rounds=None, verbose=True):
+            early_stopping_rounds=None, early_stopping_threshold=None, verbose=True):
         # pylint: disable = attribute-defined-outside-init,arguments-differ
         """
         Fit gradient boosting classifier
@@ -440,6 +445,11 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             and bst.best_ntree_limit.
             (Use bst.best_ntree_limit to get the correct value if num_parallel_tree
             and/or num_class appears in the parameters)
+		early_stopping_threshold : float, optional
+			Sets an potional threshold to smoothen the early stopping policy.
+			If after <early_stopping_rounds> round(s), the validation error hasn't 
+			decreased more than the threshold, the learning stops. To be used only with
+			early_stopping_rounds activated.
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation
             metric measured on the validation set to stderr.
@@ -496,6 +506,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         self._Booster = train(xgb_options, train_dmatrix, self.n_estimators,
                               evals=evals,
                               early_stopping_rounds=early_stopping_rounds,
+							  early_stopping_threshold=early_stopping_threshold,
                               evals_result=evals_result, obj=obj, feval=feval,
                               verbose_eval=verbose)
 


### PR DESCRIPTION
- Added in callback.py an optional threshold so that when the validation
doesn't improve more than the threshold after <early_stopping_rounds>,
the learning stops. This prevents from long inefficient training after
 a small amount of very useful rounds.

- Added in sklearn.py the corresponding options, so that the training can
be called with the threshold as an option.