### PR TITLE
Add Coverage Report for Java and Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ addons:
 before_install:
   - source dmlc-core/scripts/travis/travis_setup_env.sh
   - export PYTHONPATH=${PYTHONPATH}:${PWD}/python-package
-  - echo "MAVEN_OPTS='-Xmx2048m -XX:MaxPermSize=1024m -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=error'" > ~/.mavenrc
+  - echo "MAVEN_OPTS='-Xmx4g -XX:MaxPermSize=1024m -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=error'" > ~/.mavenrc
 
 install:
   - source tests/travis/setup.sh

--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -215,6 +215,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.9</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -199,6 +199,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
                 <configuration>
+                    <argLine>-Xmx2048m</argLine>
                     <skipTests>false</skipTests>
                 </configuration>
             </plugin>

--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -199,7 +199,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
                 <configuration>
-                    <argLine>-Xmx2048m</argLine>
                     <skipTests>false</skipTests>
                 </configuration>
             </plugin>

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -32,8 +32,10 @@ if [ ${TASK} == "python_test" ]; then
     source activate python3
     python --version
     conda install numpy scipy pandas matplotlib nose scikit-learn
-    python -m pip install graphviz
+    python -m pip install graphviz pytest pytest-cov codecov
     python -m nose tests/python || exit -1
+    py.test tests/python --cov=python-package/xgboost
+    codecov
     source activate python2
     echo "-------------------------------"
     python --version
@@ -49,8 +51,10 @@ if [ ${TASK} == "python_lightweight_test" ]; then
     source activate python3
     python --version
     conda install numpy scipy nose
-    python -m pip install graphviz
+    python -m pip install graphviz pytest pytest-cov codecov
     python -m nose tests/python || exit -1
+    py.test tests/python --cov=python-package/xgboost
+    codecov
     source activate python2
     echo "-------------------------------"
     python --version


### PR DESCRIPTION
The current codecov only reports the coverage of cpp code. To better integrate with codecov plugin, we should enable coverage report for Java and Python as well.