### PR TITLE
Check existance of seed/nthread keys before checking their value.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -67,3 +67,4 @@ List of Contributors
   - Rory is the author of the GPU plugin and also contributed the cmake build system and windows continuous integration
 * [Gideon Whitehead](https://github.com/gaw89)
 * [Yi-Lin Juang](https://github.com/frankyjuang)
+* [Andrew Hannigan](https://github.com/andrewhannigan)

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -197,14 +197,14 @@ class XGBModel(XGBModelBase):
         """Get xgboost type parameters."""
         xgb_params = self.get_params()
         random_state = xgb_params.pop('random_state')
-        if xgb_params['seed'] is not None:
+        if 'seed' in xgb_params and xgb_params['seed'] is not None:
             warnings.warn('The seed parameter is deprecated as of version .6.'
                           'Please use random_state instead.'
                           'seed is deprecated.', DeprecationWarning)
         else:
             xgb_params['seed'] = random_state
         n_jobs = xgb_params.pop('n_jobs')
-        if xgb_params['nthread'] is not None:
+        if 'nthread' in xgb_params and xgb_params['nthread'] is not None:
             warnings.warn('The nthread parameter is deprecated as of version .6.'
                           'Please use n_jobs instead.'
                           'nthread is deprecated.', DeprecationWarning)


### PR DESCRIPTION
Currently, `XGBClassifier.get_xgb_params()` throws an error if `seed` or `nthread` are missing from the `__init__` method of a child class of `XGBClassifier`.  Since `nthread` and `seed` are deprecated, we should not force child classes of `XGBClassifier` to include `nthread` and `seed` in the `__init__` method.  This PR fixes the issue in `XGBClassifier.get_xgb_params()` by checking for the existence of the `nthread` and `seed` keys in the `xgb_params` dict before checking the values associated with the keys.