### PR TITLE
Use Sudo-enabled VM which has 7.5GB memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # disable sudo for container build.
-sudo: false
+sudo: required
 
 # Enabling test on Linux and OS X
 os:
@@ -58,7 +58,7 @@ addons:
 before_install:
   - source dmlc-core/scripts/travis/travis_setup_env.sh
   - export PYTHONPATH=${PYTHONPATH}:${PWD}/python-package
-  - echo "MAVEN_OPTS='-Xmx4g -XX:MaxPermSize=1024m -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=error'" > ~/.mavenrc
+  - echo "MAVEN_OPTS='-Xmx2g -XX:MaxPermSize=1024m -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=error'" > ~/.mavenrc
 
 install:
   - source tests/travis/setup.sh


### PR DESCRIPTION
So the travis jobs are killed by linux OOM killer rather than maven. Because the travis container only has 4GB memory, the OOM killer seems very aggressive. If we switch to Sudo-enabled VM, we will be much safer.

https://docs.travis-ci.com/user/reference/overview/