### PR TITLE
WIP: [JVM] use num of Executors as nWorkers in trainWithDataFrame if possible

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -176,18 +176,19 @@ object XGBoost extends Serializable {
       missing: Float = Float.NaN,
       featureCol: String = "features",
       labelCol: String = "label"): XGBoostModel = {
-    val nWorkers_ = if (nWorkers == 0) {
+    val nWorkersInferred = if (nWorkers == 0) {
       val nExecutors = currentActiveExecutorsNum(trainingData.sparkSession.sparkContext)
       val nPartitions = trainingData.rdd.getNumPartitions
       nExecutors min nPartitions
     } else nWorkers
-    require(nWorkers_ > 0, s"you must specify more than 0 workers, while get $nWorkers_ workers.")
+    require(nWorkersInferred > 0,
+            s"you must specify more than 0 workers, while get $nWorkersInferred workers.")
     val estimator = new XGBoostEstimator(params)
     // assigning general parameters
     estimator.
       set(estimator.useExternalMemory, useExternalMemory).
       set(estimator.round, round).
-      set(estimator.nWorkers, nWorkers_).
+      set(estimator.nWorkers, nWorkersInferred).
       set(estimator.customObj, obj).
       set(estimator.customEval, eval).
       set(estimator.missing, missing).

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -198,8 +198,9 @@ object XGBoost extends Serializable {
 
   private[this] def currentActiveExecutorsNum(sc: SparkContext): Int = {
     val driverHost: String = sc.getConf.get("spark.driver.host")
-    sc.getExecutorMemoryStatus.keys
-    .count(e => !e.contains(driverHost))
+    sc.getExecutorMemoryStatus
+      .keys
+      .count(e => !e.contains(driverHost))
   }
 
   private[spark] def isClassificationTask(params: Map[String, Any]): Boolean = {

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -169,26 +169,37 @@ object XGBoost extends Serializable {
       trainingData: Dataset[_],
       params: Map[String, Any],
       round: Int,
-      nWorkers: Int,
+      nWorkers: Int = 0,
       obj: ObjectiveTrait = null,
       eval: EvalTrait = null,
       useExternalMemory: Boolean = false,
       missing: Float = Float.NaN,
       featureCol: String = "features",
       labelCol: String = "label"): XGBoostModel = {
-    require(nWorkers > 0, "you must specify more than 0 workers")
+    val nWorkers_ = if (nWorkers == 0) {
+      val nExecutors = currentActiveExecutorsNum(trainingData.sparkSession.sparkContext)
+      val nPartitions = trainingData.rdd.getNumPartitions
+      nExecutors min nPartitions
+    } else nWorkers
+    require(nWorkers_ > 0, s"you must specify more than 0 workers, while get $nWorkers_ workers.")
     val estimator = new XGBoostEstimator(params)
     // assigning general parameters
     estimator.
       set(estimator.useExternalMemory, useExternalMemory).
       set(estimator.round, round).
-      set(estimator.nWorkers, nWorkers).
+      set(estimator.nWorkers, nWorkers_).
       set(estimator.customObj, obj).
       set(estimator.customEval, eval).
       set(estimator.missing, missing).
       setFeaturesCol(featureCol).
       setLabelCol(labelCol).
       fit(trainingData)
+  }
+
+  private[this] def currentActiveExecutorsNum(sc: SparkContext): Int = {
+    val driverHost: String = sc.getConf.get("spark.driver.host")
+    sc.getExecutorMemoryStatus.keys
+    .count(e => !e.contains(driverHost))
   }
 
   private[spark] def isClassificationTask(params: Map[String, Any]): Boolean = {


### PR DESCRIPTION
The PR is opened for #2684 . Because it is my first contribute to XGBoost, more feedback and guide  is necessary for me.

### What changes were proposed in this pull request?

By default `nWorkers` is given as the smaller value between the number of executors and the number of partitions .


### How was this patch tested?

+ [ ] maybe an unit test is needed.
+ [ ] pass all tests.