### PR TITLE
[jvm-packages] Implemented early stopping

### DIFF
--- a/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/BasicWalkThrough.scala
+++ b/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/BasicWalkThrough.scala
@@ -85,7 +85,7 @@ object BasicWalkThrough {
     val watches2 = new mutable.HashMap[String, DMatrix]
     watches2 += "train" -> trainMax2
     watches2 += "test" -> testMax2
-    val booster3 = XGBoost.train(trainMax2, params.toMap, round, watches2.toMap, null, null)
+    val booster3 = XGBoost.train(trainMax2, params.toMap, round, watches2.toMap)
     val predicts3 = booster3.predict(testMax2)
     println(checkPredicts(predicts, predicts3))
   }

--- a/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/CrossValidation.scala
+++ b/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/CrossValidation.scala
@@ -41,6 +41,6 @@ object CrossValidation {
     val metrics: Array[String] = null
 
     val evalHist: Array[String] =
-      XGBoost.crossValidation(trainMat, params.toMap, round, nfold, metrics, null, null)
+      XGBoost.crossValidation(trainMat, params.toMap, round, nfold, metrics)
   }
 }

--- a/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/CustomObjective.scala
+++ b/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/CustomObjective.scala
@@ -151,7 +151,8 @@ object CustomObjective {
     val round = 2
     // train a model
     val booster = XGBoost.train(trainMat, params.toMap, round, watches.toMap)
-    XGBoost.train(trainMat, params.toMap, round, watches.toMap, new LogRegObj, new EvalError)
+    XGBoost.train(trainMat, params.toMap, round, watches.toMap,
+      obj = new LogRegObj, eval = new EvalError)
   }
 
 }

--- a/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/ExternalMemory.scala
+++ b/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/ExternalMemory.scala
@@ -54,6 +54,6 @@ object ExternalMemory {
     testMat.setBaseMargin(testPred)
 
     System.out.println("result of running from initial prediction")
-    val booster2 = XGBoost.train(trainMat, params.toMap, 1, watches.toMap, null, null)
+    val booster2 = XGBoost.train(trainMat, params.toMap, 1, watches.toMap)
   }
 }

--- a/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/GeneralizedLinearModel.scala
+++ b/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/GeneralizedLinearModel.scala
@@ -52,7 +52,7 @@ object GeneralizedLinearModel {
     watches += "test" -> testMat
 
     val round = 4
-    val booster = XGBoost.train(trainMat, params.toMap, 1, watches.toMap, null, null)
+    val booster = XGBoost.train(trainMat, params.toMap, 1, watches.toMap)
     val predicts = booster.predict(testMat)
     val eval = new CustomEval
     println(s"error=${eval.eval(predicts, testMat)}")

--- a/jvm-packages/xgboost4j-flink/src/main/scala/ml/dmlc/xgboost4j/scala/flink/XGBoost.scala
+++ b/jvm-packages/xgboost4j-flink/src/main/scala/ml/dmlc/xgboost4j/scala/flink/XGBoost.scala
@@ -55,7 +55,7 @@ object XGBoost {
       val trainMat = new DMatrix(dataIter, null)
       val watches = List("train" -> trainMat).toMap
       val round = 2
-      val booster = XGBoostScala.train(trainMat, paramMap, round, watches, null, null)
+      val booster = XGBoostScala.train(trainMat, paramMap, round, watches)
       Rabit.shutdown()
       collector.collect(new XGBoostModel(booster))
     }

--- a/jvm-packages/xgboost4j-flink/src/main/scala/ml/dmlc/xgboost4j/scala/flink/XGBoost.scala
+++ b/jvm-packages/xgboost4j-flink/src/main/scala/ml/dmlc/xgboost4j/scala/flink/XGBoost.scala
@@ -55,7 +55,10 @@ object XGBoost {
       val trainMat = new DMatrix(dataIter, null)
       val watches = List("train" -> trainMat).toMap
       val round = 2
-      val booster = XGBoostScala.train(trainMat, paramMap, round, watches)
+      val numEarlyStoppingRounds = paramMap.get("numEarlyStoppingRounds")
+          .map(_.toString.toInt).getOrElse(0)
+      val booster = XGBoostScala.train(trainMat, paramMap, round, watches,
+        earlyStoppingRound = numEarlyStoppingRounds)
       Rabit.shutdown()
       collector.collect(new XGBoostModel(booster))
     }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -129,7 +129,7 @@ object XGBoost extends Serializable {
       }
       rabitEnv.put("DMLC_TASK_ID", TaskContext.getPartitionId().toString)
       Rabit.init(rabitEnv)
-      val watches = Watches.build(params,
+      val watches = Watches(params,
         fromDenseToSparseLabeledPoints(labeledPoints, missing),
         fromBaseMarginsToArray(baseMargins), cacheFileName)
 
@@ -432,7 +432,7 @@ private class Watches private(val train: DMatrix, val test: DMatrix) {
 }
 
 private object Watches {
-  def build(
+  def apply(
       params: Map[String, Any],
       labeledPoints: Iterator[XGBLabeledPoint],
       baseMarginsOpt: Option[Array[Float]],

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -137,8 +137,11 @@ object XGBoost extends Serializable {
             TaskContext.getPartitionId()).toArray)
         }
         fromBaseMarginsToArray(baseMargins).foreach(trainingMatrix.setBaseMargin)
+        val numEarlyStoppingRounds = params.get("numEarlyStoppingRounds")
+            .map(_.toString.toInt).getOrElse(0)
         val booster = SXGBoost.train(trainingMatrix, params, round,
-          watches = Map("train" -> trainingMatrix), obj = obj, eval = eval)
+          watches = Map("train" -> trainingMatrix), obj = obj, eval = eval,
+          earlyStoppingRound = numEarlyStoppingRounds)
         Iterator(booster)
       } finally {
         Rabit.shutdown()

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -138,7 +138,7 @@ object XGBoost extends Serializable {
         }
         fromBaseMarginsToArray(baseMargins).foreach(trainingMatrix.setBaseMargin)
         val booster = SXGBoost.train(trainingMatrix, params, round,
-          watches = Map("train" -> trainingMatrix), obj, eval)
+          watches = Map("train" -> trainingMatrix), obj = obj, eval = eval)
         Iterator(booster)
       } finally {
         Rabit.shutdown()

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -130,9 +130,11 @@ object XGBoost extends Serializable {
       rabitEnv.put("DMLC_TASK_ID", TaskContext.getPartitionId().toString)
       Rabit.init(rabitEnv)
       val trainTestRatio = params.get("trainTestRatio").map(_.toString.toDouble).getOrElse(1.0)
-      val r = new Random()  // TODO: can support XGBoost seed parameter.
       // In the worst-case this would store [[trainTestRatio]] of points
       // buffered in memory.
+      val r = params.get("seed")
+          .map(v => new Random(v.toString.toLong))
+          .getOrElse(new Random())
       val (trainPoints, testPoints) = fromDenseToSparseLabeledPoints(labeledPoints, missing)
           .partition(_ => r.nextDouble() <= trainTestRatio)
       val trainMatrix = new DMatrix(trainPoints, cacheFileName)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -17,6 +17,7 @@
 package ml.dmlc.xgboost4j.scala.spark
 
 import scala.collection.mutable
+import scala.util.Random
 
 import ml.dmlc.xgboost4j.java.{IRabitTracker, Rabit, XGBoostError, RabitTracker => PyRabitTracker}
 import ml.dmlc.xgboost4j.scala.rabit.RabitTracker
@@ -94,7 +95,7 @@ object XGBoost extends Serializable {
   }
 
   private[spark] def buildDistributedBoosters(
-      trainingSet: RDD[XGBLabeledPoint],
+      data: RDD[XGBLabeledPoint],
       params: Map[String, Any],
       rabitEnv: java.util.Map[String, String],
       numWorkers: Int,
@@ -103,19 +104,19 @@ object XGBoost extends Serializable {
       eval: EvalTrait,
       useExternalMemory: Boolean,
       missing: Float): RDD[Booster] = {
-    val partitionedTrainingSet = if (trainingSet.getNumPartitions != numWorkers) {
+    val partitionedData = if (data.getNumPartitions != numWorkers) {
       logger.info(s"repartitioning training set to $numWorkers partitions")
-      trainingSet.repartition(numWorkers)
+      data.repartition(numWorkers)
     } else {
-      trainingSet
+      data
     }
-    val partitionedBaseMargin = partitionedTrainingSet.map(_.baseMargin)
-    val appName = partitionedTrainingSet.context.appName
+    val partitionedBaseMargin = partitionedData.map(_.baseMargin)
+    val appName = partitionedData.context.appName
     // to workaround the empty partitions in training dataset,
     // this might not be the best efficient implementation, see
     // (https://github.com/dmlc/xgboost/issues/1277)
-    partitionedTrainingSet.zipPartitions(partitionedBaseMargin) { (trainingPoints, baseMargins) =>
-      if (trainingPoints.isEmpty) {
+    partitionedData.zipPartitions(partitionedBaseMargin) { (labeledPoints, baseMargins) =>
+      if (labeledPoints.isEmpty) {
         throw new XGBoostError(
           s"detected an empty partition in the training data, partition ID:" +
               s" ${TaskContext.getPartitionId()}")
@@ -128,24 +129,36 @@ object XGBoost extends Serializable {
       }
       rabitEnv.put("DMLC_TASK_ID", TaskContext.getPartitionId().toString)
       Rabit.init(rabitEnv)
-      val trainingMatrix = new DMatrix(
-        fromDenseToSparseLabeledPoints(trainingPoints, missing), cacheFileName)
+      val trainTestRatio = params.get("trainTestRatio").map(_.toString.toDouble).getOrElse(1.0)
+      val r = new Random()  // TODO: can support XGBoost seed parameter.
+      // In the worst-case this would store [[trainTestRatio]] of points
+      // buffered in memory.
+      val (trainPoints, testPoints) = fromDenseToSparseLabeledPoints(labeledPoints, missing)
+          .partition(_ => r.nextDouble() <= trainTestRatio)
+      val trainMatrix = new DMatrix(trainPoints, cacheFileName)
+      val testMatrix = new DMatrix(testPoints, cacheFileName)
+      val watches = mutable.Map("train" -> trainMatrix)
+      if (testMatrix.rowNum > 0) {
+        watches += "test" -> testMatrix
+      }
+
       try {
         // TODO: use group attribute from the points.
         if (params.contains("groupData") && params("groupData") != null) {
-          trainingMatrix.setGroup(params("groupData").asInstanceOf[Seq[Seq[Int]]](
+          trainMatrix.setGroup(params("groupData").asInstanceOf[Seq[Seq[Int]]](
             TaskContext.getPartitionId()).toArray)
         }
-        fromBaseMarginsToArray(baseMargins).foreach(trainingMatrix.setBaseMargin)
+        fromBaseMarginsToArray(baseMargins).foreach(trainMatrix.setBaseMargin)
         val numEarlyStoppingRounds = params.get("numEarlyStoppingRounds")
             .map(_.toString.toInt).getOrElse(0)
-        val booster = SXGBoost.train(trainingMatrix, params, round,
-          watches = Map("train" -> trainingMatrix), obj = obj, eval = eval,
+        val booster = SXGBoost.train(trainMatrix, params, round,
+          watches = watches.toMap, obj = obj, eval = eval,
           earlyStoppingRound = numEarlyStoppingRounds)
         Iterator(booster)
       } finally {
         Rabit.shutdown()
-        trainingMatrix.delete()
+        trainMatrix.delete()
+        testMatrix.delete()
       }
     }.cache()
   }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -17,7 +17,7 @@
 package ml.dmlc.xgboost4j.scala.spark.params
 
 import ml.dmlc.xgboost4j.scala.spark.TrackerConf
-import ml.dmlc.xgboost4j.scala.{EvalTrait, ObjectiveTrait}
+
 import org.apache.spark.ml.param._
 
 trait GeneralParams extends Params {
@@ -99,9 +99,12 @@ trait GeneralParams extends Params {
     */
   val trackerConf = new TrackerConfParam(this, "tracker_conf", "Rabit tracker configurations")
 
+  /** Random seed for the C++ part of XGBoost and train/test splitting. */
+  val seed = new LongParam(this, "seed", "random seed")
+
   setDefault(round -> 1, nWorkers -> 1, numThreadPerTask -> 1,
     useExternalMemory -> false, silent -> 0,
     customObj -> null, customEval -> null, missing -> Float.NaN,
-    trackerConf -> TrackerConf()
+    trackerConf -> TrackerConf(), seed -> 0
   )
 }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -18,7 +18,7 @@ package ml.dmlc.xgboost4j.scala.spark.params
 
 import scala.collection.immutable.HashSet
 
-import org.apache.spark.ml.param.{DoubleParam, IntParam, Param, Params}
+import org.apache.spark.ml.param._
 
 trait LearningTaskParams extends Params {
 
@@ -70,8 +70,17 @@ trait LearningTaskParams extends Params {
    */
   val weightCol = new Param[String](this, "weightCol", "weight column name")
 
+  /**
+   * If non-zero, the training will be stopped after a specified number
+   * of consecutive increases in any evaluation metric.
+   */
+  val numEarlyStoppingRounds = new IntParam(this, "numEarlyStoppingRounds",
+    "number of rounds of decreasing eval metric to tolerate before " +
+    "stopping the training",
+    (value: Int) => value == 0 || value > 1)
+
   setDefault(objective -> "reg:linear", baseScore -> 0.5, numClasses -> 2, groupData -> null,
-    baseMarginCol -> "baseMargin", weightCol -> "weight")
+    baseMarginCol -> "baseMargin", weightCol -> "weight", numEarlyStoppingRounds -> 0)
 }
 
 private[spark] object LearningTaskParams {

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -71,6 +71,13 @@ trait LearningTaskParams extends Params {
   val weightCol = new Param[String](this, "weightCol", "weight column name")
 
   /**
+   * Fraction of training points to use for testing.
+   */
+  val trainTestRatio = new DoubleParam(this, "trainTestRatio",
+    "fraction of training points to use for testing",
+    ParamValidators.inRange(0, 1))
+
+  /**
    * If non-zero, the training will be stopped after a specified number
    * of consecutive increases in any evaluation metric.
    */
@@ -80,7 +87,8 @@ trait LearningTaskParams extends Params {
     (value: Int) => value == 0 || value > 1)
 
   setDefault(objective -> "reg:linear", baseScore -> 0.5, numClasses -> 2, groupData -> null,
-    baseMarginCol -> "baseMargin", weightCol -> "weight", numEarlyStoppingRounds -> 0)
+    baseMarginCol -> "baseMargin", weightCol -> "weight", trainTestRatio -> 1.0,
+    numEarlyStoppingRounds -> 0)
 }
 
 private[spark] object LearningTaskParams {

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
@@ -18,6 +18,7 @@ package ml.dmlc.xgboost4j.scala.spark
 
 import ml.dmlc.xgboost4j.scala.{DMatrix, XGBoost => ScalaXGBoost}
 import ml.dmlc.xgboost4j.{LabeledPoint => XGBLabeledPoint}
+
 import org.apache.spark.ml.linalg.DenseVector
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.sql._
@@ -233,5 +234,16 @@ class XGBoostDFSuite extends FunSuite with PerTest {
 
     // The predictions heavily relies on the first training instance, and thus are very close.
     predictions.foreach(pred => assert(math.abs(pred - predictions.head) <= 0.01f))
+  }
+
+  test("test early stopping") {
+    val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
+      "objective" -> "reg:linear", "numEarlyStoppingRounds" -> 2)
+
+    val trainingDF = buildDataFrame(Regression.train)
+    XGBoost.trainWithDataFrame(trainingDF, paramMap, round = 5,
+      nWorkers = numWorkers)
+
+    // No asserts because evaluation metrics are not yet exposed in the API.
   }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
@@ -236,6 +236,16 @@ class XGBoostDFSuite extends FunSuite with PerTest {
     predictions.foreach(pred => assert(math.abs(pred - predictions.head) <= 0.01f))
   }
 
+  test("test train/test split") {
+    val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
+      "objective" -> "binary:logistic", "trainTestRatio" -> "0.5")
+
+    val trainingDf = buildDataFrame(Classification.train)
+    XGBoost.trainWithDataFrame(trainingDf, paramMap, round = 1, nWorkers = numWorkers)
+
+    // No asserts because evaluation metrics are not yet exposed in the API.
+  }
+
   test("test early stopping") {
     val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "reg:linear", "numEarlyStoppingRounds" -> 2)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
@@ -236,25 +236,4 @@ class XGBoostDFSuite extends FunSuite with PerTest {
     // The predictions heavily relies on the first training instance, and thus are very close.
     predictions.foreach(pred => assert(math.abs(pred - predictions.head) <= 0.01f))
   }
-
-  test("test train/test split") {
-    val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
-      "objective" -> "binary:logistic", "trainTestRatio" -> "0.5")
-
-    val trainingDf = buildDataFrame(Classification.train)
-    XGBoost.trainWithDataFrame(trainingDf, paramMap, round = 1, nWorkers = numWorkers)
-
-    // No asserts because evaluation metrics are not yet exposed in the API.
-  }
-
-  test("test early stopping") {
-    val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
-      "objective" -> "reg:linear", "numEarlyStoppingRounds" -> 2)
-
-    val trainingDF = buildDataFrame(Regression.train)
-    XGBoost.trainWithDataFrame(trainingDF, paramMap, round = 5,
-      nWorkers = numWorkers)
-
-    // No asserts because evaluation metrics are not yet exposed in the API.
-  }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
@@ -202,7 +202,8 @@ class XGBoostDFSuite extends FunSuite with PerTest {
     val trainingDfWithMargin = trainingDf.withColumn("margin", functions.rand())
     val testRDD = sc.parallelize(Classification.test.map(_.features))
     val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
-      "objective" -> "binary:logistic", "baseMarginCol" -> "margin")
+      "objective" -> "binary:logistic", "baseMarginCol" -> "margin",
+      "testTrainSplit" -> 0.5)
 
     def trainPredict(df: Dataset[_]): Array[Float] = {
       XGBoost.trainWithDataFrame(df, paramMap, round = 1, nWorkers = numWorkers)

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -201,6 +201,12 @@ public class Booster implements Serializable, KryoSerializable {
    */
   public String evalSet(DMatrix[] evalMatrixs, String[] evalNames, IEvaluation eval)
           throws XGBoostError {
+    // Hopefully, a tiny redundant allocation wouldn't hurt.
+    return evalSet(evalMatrixs, evalNames, eval, new float[evalNames.length]);
+  }
+
+  public String evalSet(DMatrix[] evalMatrixs, String[] evalNames, IEvaluation eval,
+                        float[] metricsOut) throws XGBoostError {
     String evalInfo = "";
     for (int i = 0; i < evalNames.length; i++) {
       String evalName = evalNames[i];
@@ -208,6 +214,7 @@ public class Booster implements Serializable, KryoSerializable {
       float evalResult = eval.eval(predict(evalMat), evalMat);
       String evalMetric = eval.getMetric();
       evalInfo += String.format("\t%s-%s:%f", evalName, evalMetric, evalResult);
+      metricsOut[i] = evalResult;
     }
     return evalInfo;
   }

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/XGBoost.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/XGBoost.scala
@@ -45,42 +45,17 @@ object XGBoost {
       dtrain: DMatrix,
       params: Map[String, Any],
       round: Int,
-      watches: Map[String, DMatrix],
-      metrics: Array[Array[Float]],
-      obj: ObjectiveTrait,
-      eval: EvalTrait): Booster = {
-    val jWatches = watches.map{case (name, matrix) => (name, matrix.jDMatrix)}
+      watches: Map[String, DMatrix] = Map(),
+      metrics: Array[Array[Float]] = null,
+      obj: ObjectiveTrait = null,
+      eval: EvalTrait = null): Booster = {
+    val jWatches = watches.mapValues(_.jDMatrix).asJava
     val xgboostInJava = JXGBoost.train(
       dtrain.jDMatrix,
       // we have to filter null value for customized obj and eval
-      params.filter(_._2 != null).map{
-        case (key: String, value) => (key, value.toString)
-      }.toMap[String, AnyRef].asJava,
-      round, jWatches.asJava, metrics, obj, eval)
+      params.filter(_._2 != null).mapValues(_.toString.asInstanceOf[AnyRef]).asJava,
+      round, jWatches, metrics, obj, eval)
     new Booster(xgboostInJava)
-  }
-
-  /**
-    * Train a booster given parameters.
-    *
-    * @param dtrain  Data to be trained.
-    * @param params  Parameters.
-    * @param round   Number of boosting iterations.
-    * @param watches a group of items to be evaluated during training, this allows user to watch
-    *                performance on the validation set.
-    * @param obj     customized objective
-    * @param eval    customized evaluation
-    * @return The trained booster.
-    */
-  @throws(classOf[XGBoostError])
-  def train(
-      dtrain: DMatrix,
-      params: Map[String, Any],
-      round: Int,
-      watches: Map[String, DMatrix] = Map[String, DMatrix](),
-      obj: ObjectiveTrait = null,
-      eval: EvalTrait = null): Booster = {
-    train(dtrain, params, round, watches, null, obj, eval)
   }
 
   /**

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/XGBoost.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/XGBoost.scala
@@ -36,6 +36,9 @@ object XGBoost {
     *                performance on the validation set.
     * @param metrics array containing the evaluation metrics for each matrix in watches for each
     *                iteration
+    * @param earlyStoppingRound if non-zero, training would be stopped
+    *                           after a specified number of consecutive
+    *                           increases in any evaluation metric.
     * @param obj     customized objective
     * @param eval    customized evaluation
     * @return The trained booster.

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/XGBoost.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/XGBoost.scala
@@ -48,13 +48,14 @@ object XGBoost {
       watches: Map[String, DMatrix] = Map(),
       metrics: Array[Array[Float]] = null,
       obj: ObjectiveTrait = null,
-      eval: EvalTrait = null): Booster = {
+      eval: EvalTrait = null,
+      earlyStoppingRound: Int = 0): Booster = {
     val jWatches = watches.mapValues(_.jDMatrix).asJava
     val xgboostInJava = JXGBoost.train(
       dtrain.jDMatrix,
       // we have to filter null value for customized obj and eval
       params.filter(_._2 != null).mapValues(_.toString.asInstanceOf[AnyRef]).asJava,
-      round, jWatches, metrics, obj, eval)
+      round, jWatches, metrics, obj, eval, earlyStoppingRound)
     new Booster(xgboostInJava)
   }
 

--- a/jvm-packages/xgboost4j/src/test/scala/ml/dmlc/xgboost4j/scala/ScalaBoosterImplSuite.scala
+++ b/jvm-packages/xgboost4j/src/test/scala/ml/dmlc/xgboost4j/scala/ScalaBoosterImplSuite.scala
@@ -74,7 +74,7 @@ class ScalaBoosterImplSuite extends FunSuite {
     val watches = List("train" -> trainMat, "test" -> testMat).toMap
 
     val round = 2
-    XGBoost.train(trainMat, paramMap, round, watches, null, null)
+    XGBoost.train(trainMat, paramMap, round, watches)
   }
 
   private def trainBoosterWithFastHisto(
@@ -84,7 +84,7 @@ class ScalaBoosterImplSuite extends FunSuite {
       paramMap: Map[String, String],
       threshold: Float): Booster = {
     val metrics = Array.fill(watches.size, round)(0.0f)
-    val booster = XGBoost.train(trainMat, paramMap, round, watches, metrics, null, null)
+    val booster = XGBoost.train(trainMat, paramMap, round, watches, metrics)
     for (i <- 0 until watches.size; j <- 1 until metrics(i).length) {
       assert(metrics(i)(j) >= metrics(i)(j - 1))
     }
@@ -143,7 +143,7 @@ class ScalaBoosterImplSuite extends FunSuite {
       "objective" -> "binary:logistic", "gamma" -> "1.0", "eval_metric" -> "error").toMap
     val round = 2
     val nfold = 5
-    XGBoost.crossValidation(trainMat, params, round, nfold, null, null, null)
+    XGBoost.crossValidation(trainMat, params, round, nfold)
   }
 
   test("test with fast histo depthwise") {


### PR DESCRIPTION
This PR allows configuring the number of consecutive increases in the eval metrics which lead to early stopping. The parameter is exposed both in standalone versions in Java/Scala and in the distributed ones.