### PR TITLE
[jvm-packages] Allowed subsampling test from the training data frame/RDD

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -157,6 +157,7 @@ object XGBoost extends Serializable {
       } finally {
         Rabit.shutdown()
         trainMatrix.delete()
+        testMatrix.delete()
       }
     }.cache()
   }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -130,9 +130,11 @@ object XGBoost extends Serializable {
       rabitEnv.put("DMLC_TASK_ID", TaskContext.getPartitionId().toString)
       Rabit.init(rabitEnv)
       val trainTestRatio = params.get("trainTestRatio").map(_.toString.toDouble).getOrElse(1.0)
-      val r = new Random()  // TODO: can support XGBoost seed parameter.
       // In the worst-case this would store [[trainTestRatio]] of points
       // buffered in memory.
+      val r = params.get("seed")
+          .map(v => new Random(v.toString.toLong))
+          .getOrElse(new Random())
       val (trainPoints, testPoints) = fromDenseToSparseLabeledPoints(labeledPoints, missing)
           .partition(_ => r.nextDouble() <= trainTestRatio)
       val trainMatrix = new DMatrix(trainPoints, cacheFileName)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -17,7 +17,7 @@
 package ml.dmlc.xgboost4j.scala.spark.params
 
 import ml.dmlc.xgboost4j.scala.spark.TrackerConf
-import ml.dmlc.xgboost4j.scala.{EvalTrait, ObjectiveTrait}
+
 import org.apache.spark.ml.param._
 
 trait GeneralParams extends Params {
@@ -99,9 +99,12 @@ trait GeneralParams extends Params {
     */
   val trackerConf = new TrackerConfParam(this, "tracker_conf", "Rabit tracker configurations")
 
+  /** Random seed for the C++ part of XGBoost and train/test splitting. */
+  val seed = new LongParam(this, "seed", "random seed")
+
   setDefault(round -> 1, nWorkers -> 1, numThreadPerTask -> 1,
     useExternalMemory -> false, silent -> 0,
     customObj -> null, customEval -> null, missing -> Float.NaN,
-    trackerConf -> TrackerConf()
+    trackerConf -> TrackerConf(), seed -> 0
   )
 }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -18,7 +18,7 @@ package ml.dmlc.xgboost4j.scala.spark.params
 
 import scala.collection.immutable.HashSet
 
-import org.apache.spark.ml.param.{DoubleParam, IntParam, Param, Params}
+import org.apache.spark.ml.param._
 
 trait LearningTaskParams extends Params {
 
@@ -70,8 +70,15 @@ trait LearningTaskParams extends Params {
    */
   val weightCol = new Param[String](this, "weightCol", "weight column name")
 
+  /**
+   * Fraction of training points to use for testing.
+   */
+  val trainTestRatio = new Param[Double](this, "trainTestRatio",
+    "fraction of training points to use for testing",
+    ParamValidators.inRange(0, 1))
+
   setDefault(objective -> "reg:linear", baseScore -> 0.5, numClasses -> 2, groupData -> null,
-    baseMarginCol -> "baseMargin", weightCol -> "weight")
+    baseMarginCol -> "baseMargin", weightCol -> "weight", trainTestRatio -> 1.0)
 }
 
 private[spark] object LearningTaskParams {

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -73,7 +73,7 @@ trait LearningTaskParams extends Params {
   /**
    * Fraction of training points to use for testing.
    */
-  val trainTestRatio = new Param[Double](this, "trainTestRatio",
+  val trainTestRatio = new DoubleParam(this, "trainTestRatio",
     "fraction of training points to use for testing",
     ParamValidators.inRange(0, 1))
 

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
@@ -18,6 +18,7 @@ package ml.dmlc.xgboost4j.scala.spark
 
 import ml.dmlc.xgboost4j.scala.{DMatrix, XGBoost => ScalaXGBoost}
 import ml.dmlc.xgboost4j.{LabeledPoint => XGBLabeledPoint}
+
 import org.apache.spark.ml.linalg.DenseVector
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.sql._
@@ -232,5 +233,16 @@ class XGBoostDFSuite extends FunSuite with PerTest {
 
     // The predictions heavily relies on the first training instance, and thus are very close.
     predictions.foreach(pred => assert(math.abs(pred - predictions.head) <= 0.01f))
+  }
+
+  test("test train/test split") {
+    val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
+      "objective" -> "binary:logistic", "trainTestRatio" -> "0.5")
+
+    val trainingDf = buildDataFrame(Classification.train)
+    XGBoost.trainWithDataFrame(trainingDf, paramMap, round = 1, nWorkers = numWorkers)
+
+    // Cannot assert anything until the training metrics are exposed.
+    // See dmlc/xgboost#2710
   }
 }


### PR DESCRIPTION
The implementation requires storing `1 - trainTestRatio` points in memory
to make the sampling work.

An alternative approach would be to construct the full DMatrix and then
slice it deterministically into train/test. The peak memory consumption
of such scenario, however, is twice the dataset size.

Implementing a test for this feature requires #2710.