### PR TITLE
Sync number of features after loaded matrix in different workers.

### DIFF
--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -210,6 +210,10 @@ DMatrix* DMatrix::Load(const std::string& uri,
     LOG(CONSOLE) << dmat->info().num_row << 'x' << dmat->info().num_col << " matrix with "
                  << dmat->info().num_nonzero << " entries loaded from " << uri;
   }
+  /* sync up number of features after matrix loaded.
+   * partitioned data will fail the train/val validation check 
+   * since partitioned data not knowing the real number of features. */
+  rabit::Allreduce<rabit::op::Max>(&dmat->info().num_col, 1);
   // backward compatiblity code.
   if (!load_row_split) {
     MetaInfo& info = dmat->info();


### PR DESCRIPTION
When xgboost ran in distributed mode, different workers load different part of train file and val file.
It might happen that the partition of the val file didn't get the real number of the features. (Say, the maximum index in this partition is 99, while the truth is 100) In this case, the train partition and the val partition will fail the validation check. 

I add an allreduce call to sync up the number of features after workers loaded different partitions, so that each partition knows the real number of features and the validation check will note fail.