### PR TITLE
Use cmake in sdist python package if available, up version to a3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,8 @@ pippack: clean_all
 	cp -r python-package xgboost-python
 	cp -r Makefile xgboost-python/xgboost/
 	cp -r make xgboost-python/xgboost/
+	cp -r cmake xgboost-python/xgboost/
+	cp -r CMakeLists.txt xgboost-python/xgboost/
 	cp -r src xgboost-python/xgboost/
 	cp -r include xgboost-python/xgboost/
 	cp -r dmlc-core xgboost-python/xgboost/

--- a/python-package/MANIFEST.in
+++ b/python-package/MANIFEST.in
@@ -1,7 +1,8 @@
-include *.md *.rst
+include *.md *.rst CMakeLists.txt
 recursive-include xgboost *
 recursive-include xgboost/include *
 recursive-include xgboost/src *
+recursive-include xgboost/cmake *
 recursive-include xgboost/make *
 recursive-include xgboost/rabit *
 recursive-include xgboost/lib *

--- a/python-package/setup_pip.py
+++ b/python-package/setup_pip.py
@@ -42,7 +42,7 @@ LIB_PATH = libpath['find_lib_path']()
 # and be sure to test it firstly using "python setup.py register sdist upload -r pypitest"
 setup(name='xgboost',
       # version=open(os.path.join(CURRENT_DIR, 'xgboost/VERSION')).read().strip(),
-      version='0.6a2',
+      version='0.6a3',
       description='XGBoost Python Package',
       install_requires=[
           'numpy',

--- a/python-package/xgboost/build-python.sh
+++ b/python-package/xgboost/build-python.sh
@@ -7,24 +7,31 @@
 # See additional instruction in doc/build.md
 
 # note: this script is build for python package only, and it might have some filename
-#       conflict with build.sh which is for everything. 
+#       conflict with build.sh which is for everything.
 
 
 #pushd xgboost
 oldpath=`pwd`
 cd ./xgboost/
-#remove the pre-compiled .so and trigger the system's on-the-fly compiling
-make clean
-if make lib/libxgboost.so -j4; then
-    echo "Successfully build multi-thread xgboost"
+#If cmake is installed, prefer that build
+if which cmake >> /dev/null; then
+    cmake .
+    make || make USE_OPENMP=0
 else
-    echo "-----------------------------"
-    echo "Building multi-thread xgboost failed"
-    echo "Start to build single-thread xgboost"
+    #Use distributed makefile
+    #remove the pre-compiled .so and trigger the system's on-the-fly compiling
     make clean
-    make lib/libxgboost.so -j4 USE_OPENMP=0
-    echo "Successfully build single-thread xgboost"
-    echo "If you want multi-threaded version"
-    echo "See additional instructions in doc/build.md"
+    if make lib/libxgboost.so -j4; then
+        echo "Successfully build multi-thread xgboost"
+    else
+        echo "-----------------------------"
+        echo "Building multi-thread xgboost failed"
+        echo "Start to build single-thread xgboost"
+        make clean
+        make lib/libxgboost.so -j4 USE_OPENMP=0
+        echo "Successfully build single-thread xgboost"
+        echo "If you want multi-threaded version"
+        echo "See additional instructions in doc/build.md"
+    fi
 fi
 cd $oldpath


### PR DESCRIPTION
If cmake is available on the system building the pip
package, use it.

To use:
 - make pippack
 - cd xgboost-python
 - bash prep_pip.sh
 - cd dist
 - pip install xgboost-0.6a3.tar.gz

see #2206 