### PR TITLE
Update OSX build instructions

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -57,9 +57,9 @@ git clone --recursive https://github.com/dmlc/xgboost
 cd xgboost; make -j4
 ```
 
-### Building on OSX
+### Building on Mac OS X
 
-First, obtain gcc-7.x.x with brew (https://brew.sh/) if you want multi-threaded version. Note: installation of `gcc` can take a while (~ 30 minutes)
+First, obtain gcc-7.x.x with brew (https://brew.sh/) if you want multi-threaded version, otherwise, Clang is ok if OpenMP / multi-threaded is not required. Note: installation of `gcc` can take a while (~ 30 minutes)
 
 ```bash
 brew install gcc

--- a/doc/build.md
+++ b/doc/build.md
@@ -59,7 +59,7 @@ cd xgboost; make -j4
 
 ### Building on Mac OS X
 
-**Building with pip - simple method**
+**Install with pip - simple method**
 
 First, make sure you obtained *gcc-5* (newer version does not work with this method yet). Note: installation of `gcc` can take a while (~ 30 minutes)
 
@@ -73,7 +73,7 @@ You might need to run the following command with `sudo` if you run into some per
 pip install xgboost
 ```
 
-**Building from the source code - advanced method**
+**Build from the source code - advanced method**
 
 First, obtain gcc-7.x.x with brew (https://brew.sh/) if you want multi-threaded version, otherwise, Clang is ok if OpenMP / multi-threaded is not required. Note: installation of `gcc` can take a while (~ 30 minutes)
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -59,7 +59,7 @@ cd xgboost; make -j4
 
 ### Building on OSX
 
-First, obtain gcc-7.x.x with brew if you want multi-threaded version
+First, obtain gcc-7.x.x with brew (https://brew.sh/) if you want multi-threaded version. Note: installation of `gcc` can take a while (~ 30 minutes)
 
 ```bash
 brew install gcc

--- a/doc/build.md
+++ b/doc/build.md
@@ -59,19 +59,11 @@ cd xgboost; make -j4
 
 ### Building on OSX
 
-On OSX, one builds xgboost by
+First, obtain gcc-7.x.x with brew if you want multi-threaded version
 
 ```bash
-git clone --recursive https://github.com/dmlc/xgboost
-cd xgboost; cp make/minimum.mk ./config.mk; make -j4
+brew install gcc
 ```
-
-This builds xgboost without multi-threading, because by default clang in OSX does not come with open-mp.
-See the following paragraph for OpenMP enabled xgboost.
-
-
-Here is the complete solution to use OpenMP-enabled compilers to install XGBoost.
-Obtain gcc-6.x.x with openmp support by `brew install gcc --without-multilib`. (`brew` is the de facto standard of `apt-get` on OS X. So installing [HPC](http://hpc.sourceforge.net/) separately is not recommended, but it should work.). Installation of `gcc` can take a while (~ 30 minutes)
 
 Now, clone the repository
 
@@ -80,13 +72,6 @@ git clone --recursive https://github.com/dmlc/xgboost
 ```
 
 and build using the following commands
-
-```bash
-cd xgboost; cp make/config.mk ./config.mk; make -j4
-```
-
-NOTE:
-If you use OSX El Capitan, brew installs gcc the latest version gcc-6. So you may need to modify Makefile#L46 and change gcc-5 to gcc-6. After that change gcc-5/g++-5 to gcc-6/g++-6 in make/config.mk then build using the following commands
 
 ```bash
 cd xgboost; cp make/config.mk ./config.mk; make -j4

--- a/doc/build.md
+++ b/doc/build.md
@@ -59,6 +59,22 @@ cd xgboost; make -j4
 
 ### Building on Mac OS X
 
+**Building with pip - simple method**
+
+First, make sure you obtained *gcc-5* (newer version does not work with this method yet). Note: installation of `gcc` can take a while (~ 30 minutes)
+
+```bash
+brew install gcc5
+```
+
+You might need to run the following command with `sudo` if you run into some permission errors:
+
+```bash
+pip install xgboost
+```
+
+**Building from the source code - advanced method**
+
 First, obtain gcc-7.x.x with brew (https://brew.sh/) if you want multi-threaded version, otherwise, Clang is ok if OpenMP / multi-threaded is not required. Note: installation of `gcc` can take a while (~ 30 minutes)
 
 ```bash
@@ -76,6 +92,7 @@ and build using the following commands
 ```bash
 cd xgboost; cp make/config.mk ./config.mk; make -j4
 ```
+head over to `Python Package Installation` for the next steps
 
 ### Building on Windows
 You need to first clone the xgboost repo with recursive option clone the submodules.


### PR DESCRIPTION
Keeping things simpler for OS X users:

- tested on macOS Sierra 10.12.6
- `brew install gcc` is now at v 0.7.2,
- `--without-multilib` isn't an option anymore:

```
$ brew info gcc
gcc: stable 7.2.0 (bottled), HEAD
GNU compiler collection
https://gcc.gnu.org/
/usr/local/Cellar/gcc/7.2.0 (1,487 files, 284MB) *
  Poured from bottle on 2017-10-11 at 23:04:26
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/gcc.rb
==> Dependencies
Required: gmp ✔, libmpc ✔, mpfr ✔, isl ✔
==> Options
--with-jit
	Build just-in-time compiler
--with-nls
	Build with native language support (localization)
--HEAD
	Install HEAD version
```
(it's actually not needed in our case as `there is no incompatibility between OpenMP and multilib support` https://github.com/Homebrew/homebrew-core/pull/16751)