### PR TITLE
[Build] Fix the dmlc-core static library name in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 
 # dmlc-core
 add_subdirectory(dmlc-core)
-set(LINK_LIBRARIES dmlccore rabit)
+set(LINK_LIBRARIES dmlc rabit)
 
 
 if(USE_CUDA)


### PR DESCRIPTION
The static library built by the dmlc-core submodule is named libdmlc.a.
However, CMakeLists.txt searches for a library named libdmlccore.a during
the link time, resulting in the "-ldmlccore not found" error. This issue
is fixed in this commmit.