### PR TITLE
[jvm-packages] Repair spark model eval

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
@@ -116,7 +116,7 @@ abstract class XGBoostModel(protected var _booster: Booster)
               null
             }
           }
-          val dMatrix = new DMatrix(labeledPointsPartition.map(_.features.asXGB), cacheFileName)
+          val dMatrix = new DMatrix(labeledPointsPartition.map(_.asXGB), cacheFileName)
           try {
             if (groupData != null) {
               dMatrix.setGroup(groupData(TaskContext.getPartitionId()).toArray)


### PR DESCRIPTION
In the refactor to add base margins, #2532, all of the labels were lost
when creating the dmatrix. This became obvious as metrics like ndcg
always returned 1.0 regardless of the results.