### PR TITLE
[jvm-packages] #2843 Add "round" and "objective" as model parameters

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
@@ -35,8 +35,8 @@ import org.json4s.DefaultFormats
  */
 class XGBoostEstimator private[spark](
   override val uid: String, xgboostParams: Map[String, Any])
-  extends Predictor[Vector, XGBoostEstimator, XGBoostModel]
-  with LearningTaskParams with GeneralParams with BoosterParams with MLWritable {
+  extends Predictor[Vector, XGBoostEstimator, XGBoostModel] with BoostingAlgorithmParams
+    with LearningTaskParams with GeneralParams with BoosterParams with MLWritable {
 
   def this(xgboostParams: Map[String, Any]) =
     this(Identifiable.randomUID("XGBoostEstimator"), xgboostParams: Map[String, Any])

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
@@ -35,7 +35,7 @@ import org.json4s.DefaultFormats
  */
 class XGBoostEstimator private[spark](
   override val uid: String, xgboostParams: Map[String, Any])
-  extends Predictor[Vector, XGBoostEstimator, XGBoostModel] with BoostingAlgorithmParams
+  extends Predictor[Vector, XGBoostEstimator, XGBoostModel] with BoostingParams
     with LearningTaskParams with GeneralParams with BoosterParams with MLWritable {
 
   def this(xgboostParams: Map[String, Any]) =

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
@@ -18,7 +18,7 @@ package ml.dmlc.xgboost4j.scala.spark
 
 import scala.collection.JavaConverters._
 import ml.dmlc.xgboost4j.java.Rabit
-import ml.dmlc.xgboost4j.scala.spark.params.{BoosterParams, BoostingAlgorithmParams, DefaultXGBoostParamsWriter}
+import ml.dmlc.xgboost4j.scala.spark.params.{BoosterParams, BoostingParams, DefaultXGBoostParamsWriter}
 import ml.dmlc.xgboost4j.scala.{Booster, DMatrix, EvalTrait}
 import org.apache.hadoop.fs.{FSDataOutputStream, Path}
 import org.apache.spark.ml.PredictionModel
@@ -37,7 +37,7 @@ import org.json4s.DefaultFormats
  */
 abstract class XGBoostModel(protected var _booster: Booster)
   extends PredictionModel[MLVector, XGBoostModel] with BoosterParams
-    with BoostingAlgorithmParams with Serializable with MLWritable {
+    with BoostingParams with Serializable with MLWritable {
 
   def setLabelCol(name: String): XGBoostModel = set(labelCol, name)
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostModel.scala
@@ -17,13 +17,10 @@
 package ml.dmlc.xgboost4j.scala.spark
 
 import scala.collection.JavaConverters._
-
 import ml.dmlc.xgboost4j.java.Rabit
-import ml.dmlc.xgboost4j.scala.spark.params.{BoosterParams, DefaultXGBoostParamsWriter}
+import ml.dmlc.xgboost4j.scala.spark.params.{BoosterParams, BoostingAlgorithmParams, DefaultXGBoostParamsWriter}
 import ml.dmlc.xgboost4j.scala.{Booster, DMatrix, EvalTrait}
-
 import org.apache.hadoop.fs.{FSDataOutputStream, Path}
-
 import org.apache.spark.ml.PredictionModel
 import org.apache.spark.ml.feature.{LabeledPoint => MLLabeledPoint}
 import org.apache.spark.ml.linalg.{DenseVector => MLDenseVector, Vector => MLVector}
@@ -39,8 +36,8 @@ import org.json4s.DefaultFormats
  * the base class of [[XGBoostClassificationModel]] and [[XGBoostRegressionModel]]
  */
 abstract class XGBoostModel(protected var _booster: Booster)
-  extends PredictionModel[MLVector, XGBoostModel] with BoosterParams with Serializable
-    with Params with MLWritable {
+  extends PredictionModel[MLVector, XGBoostModel] with BoosterParams
+    with BoostingAlgorithmParams with Serializable with MLWritable {
 
   def setLabelCol(name: String): XGBoostModel = set(labelCol, name)
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoostingAlgorithmParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoostingAlgorithmParams.scala
@@ -1,0 +1,48 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package ml.dmlc.xgboost4j.scala.spark.params
+
+import scala.collection.immutable.HashSet
+
+import org.apache.spark.ml.param._
+
+trait BoostingAlgorithmParams extends Params {
+
+  /**
+   * The number of rounds for boosting
+   */
+  val round = new IntParam(this, "num_round", "The number of rounds for boosting",
+    ParamValidators.gtEq(1))
+
+  /**
+   * Specify the learning task and the corresponding learning objective.
+   * options: reg:linear, reg:logistic, binary:logistic, binary:logitraw, count:poisson,
+   * multi:softmax, multi:softprob, rank:pairwise, reg:gamma. default: reg:linear
+   */
+  val objective = new Param[String](this, "objective", "objective function used for training," +
+    s" options: {${BoostingAlgorithmParams.supportedObjective.mkString(",")}",
+    (value: String) => BoostingAlgorithmParams.supportedObjective.contains(value))
+
+  setDefault(objective -> "reg:linear", round -> 1)
+
+}
+
+private[spark] object BoostingAlgorithmParams {
+  val supportedObjective = HashSet("reg:linear", "reg:logistic", "binary:logistic",
+    "binary:logitraw", "count:poisson", "multi:softmax", "multi:softprob", "rank:pairwise",
+    "reg:gamma")
+}

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoostingParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoostingParams.scala
@@ -20,7 +20,7 @@ import scala.collection.immutable.HashSet
 
 import org.apache.spark.ml.param._
 
-trait BoostingAlgorithmParams extends Params {
+trait BoostingParams extends Params {
 
   /**
    * The number of rounds for boosting
@@ -34,15 +34,15 @@ trait BoostingAlgorithmParams extends Params {
    * multi:softmax, multi:softprob, rank:pairwise, reg:gamma. default: reg:linear
    */
   val objective = new Param[String](this, "objective", "objective function used for training," +
-    s" options: {${BoostingAlgorithmParams.supportedObjective.mkString(",")}",
-    (value: String) => BoostingAlgorithmParams.supportedObjective.contains(value))
+    s" options: {${BoostingParams.supportedObjectives.mkString(",")}",
+    (value: String) => BoostingParams.supportedObjectives.contains(value))
 
   setDefault(objective -> "reg:linear", round -> 1)
 
 }
 
-private[spark] object BoostingAlgorithmParams {
-  val supportedObjective = HashSet("reg:linear", "reg:logistic", "binary:logistic",
+private[spark] object BoostingParams {
+  val supportedObjectives = Set("reg:linear", "reg:logistic", "binary:logistic",
     "binary:logitraw", "count:poisson", "multi:softmax", "multi:softprob", "rank:pairwise",
     "reg:gamma")
 }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -23,12 +23,6 @@ import org.apache.spark.ml.param._
 trait GeneralParams extends Params {
 
   /**
-   * The number of rounds for boosting
-   */
-  val round = new IntParam(this, "num_round", "The number of rounds for boosting",
-    ParamValidators.gtEq(1))
-
-  /**
    * number of workers used to train xgboost model. default: 1
    */
   val nWorkers = new IntParam(this, "nworkers", "number of workers used to run xgboost",
@@ -109,7 +103,7 @@ trait GeneralParams extends Params {
   /** Random seed for the C++ part of XGBoost and train/test splitting. */
   val seed = new LongParam(this, "seed", "random seed")
 
-  setDefault(round -> 1, nWorkers -> 1, numThreadPerTask -> 1,
+  setDefault(nWorkers -> 1, numThreadPerTask -> 1,
     useExternalMemory -> false, silent -> 0,
     customObj -> null, customEval -> null, missing -> Float.NaN,
     trackerConf -> TrackerConf(), seed -> 0, timeoutRequestWorkers -> 30 * 60 * 1000L

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -28,15 +28,6 @@ trait LearningTaskParams extends Params {
   val numClasses = new IntParam(this, "num_class", "number of classes")
 
   /**
-   * Specify the learning task and the corresponding learning objective.
-   * options: reg:linear, reg:logistic, binary:logistic, binary:logitraw, count:poisson,
-   * multi:softmax, multi:softprob, rank:pairwise, reg:gamma. default: reg:linear
-   */
-  val objective = new Param[String](this, "objective", "objective function used for training," +
-    s" options: {${LearningTaskParams.supportedObjective.mkString(",")}",
-    (value: String) => LearningTaskParams.supportedObjective.contains(value))
-
-  /**
    * the initial prediction score of all instances, global bias. default=0.5
    */
   val baseScore = new DoubleParam(this, "base_score", "the initial prediction score of all" +
@@ -86,16 +77,12 @@ trait LearningTaskParams extends Params {
     "stopping the training",
     (value: Int) => value == 0 || value > 1)
 
-  setDefault(objective -> "reg:linear", baseScore -> 0.5, numClasses -> 2, groupData -> null,
+  setDefault(baseScore -> 0.5, numClasses -> 2, groupData -> null,
     baseMarginCol -> "baseMargin", weightCol -> "weight", trainTestRatio -> 1.0,
     numEarlyStoppingRounds -> 0)
 }
 
 private[spark] object LearningTaskParams {
-  val supportedObjective = HashSet("reg:linear", "reg:logistic", "binary:logistic",
-    "binary:logitraw", "count:poisson", "multi:softmax", "multi:softprob", "rank:pairwise",
-    "reg:gamma")
-
   val supportedEvalMetrics = HashSet("rmse", "mae", "logloss", "error", "merror", "mlogloss",
     "auc", "ndcg", "map", "gamma-deviance")
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
@@ -194,6 +194,8 @@ class XGBoostDFSuite extends FunSuite with PerTest {
     assert(model.get[Double](model.eta).get == 0.1)
     assert(model.get[Int](model.maxDepth).get == 6)
     assert(model.asInstanceOf[XGBoostClassificationModel].numOfClasses == 6)
+    assert(model.get[Int](model.round).get == 5)
+    assert(model.get[String](model.objective).get == "multi:softmax")
   }
 
   test("test use base margin") {


### PR DESCRIPTION
This is a simple patch that would address the problem in https://github.com/dmlc/xgboost/issues/2843. A new trait `BoostingAlgorithmParams` is created and holds other boosting-level (or ensemble-level) params (different from "booster" params) that should also be available in the model. `XGBoostEstimator` and `XGBoostModel` then mix in this trait so that the parameters are owned by both.

Obviously, there may be other parameters that should be transferred to the model, so we can discuss that here as well. If there is some design history that I've missed about why these parameters weren't copied originally, please let me know. 