### PR TITLE
Added GPU versions of multiple objective functions.

### DIFF
--- a/doc/parameter.md
+++ b/doc/parameter.md
@@ -165,6 +165,9 @@ Specify the learning task and the corresponding learning objective. The objectiv
   - "reg:logistic" --logistic regression
   - "binary:logistic" --logistic regression for binary classification, output probability
   - "binary:logitraw" --logistic regression for binary classification, output score before logistic transformation
+  - "gpu:reg:linear", "gpu:reg:logistic", "gpu:binary:logistic", gpu:binary:logitraw" --versions
+    of the corresponding objective functions evaluated on the GPU; note that like the GPU histogram algorithm,
+    they can only be used when the entire training session uses the same dataset
   - "count:poisson" --poisson regression for count data, output mean of poisson distribution
     - max_delta_step is set to 0.7 by default in poisson regression (used to safeguard optimization)
   - "multi:softmax" --set XGBoost to do multiclass classification using the softmax objective, you also need to set num_class(number of classes)

--- a/src/common/math.h
+++ b/src/common/math.h
@@ -19,8 +19,8 @@ namespace common {
  * \param x input parameter
  * \return the transformed value.
  */
-inline float Sigmoid(float x) {
-  return 1.0f / (1.0f + std::exp(-x));
+XGBOOST_DEVICE inline float Sigmoid(float x) {
+  return 1.0f / (1.0f + expf(-x));
 }
 
 /*!

--- a/src/objective/objective.cc
+++ b/src/objective/objective.cc
@@ -28,6 +28,9 @@ namespace xgboost {
 namespace obj {
 // List of files that will be force linked in static links.
 DMLC_REGISTRY_LINK_TAG(regression_obj);
+#ifdef XGBOOST_USE_CUDA
+  DMLC_REGISTRY_LINK_TAG(regression_obj_gpu);
+#endif
 DMLC_REGISTRY_LINK_TAG(multiclass_obj);
 DMLC_REGISTRY_LINK_TAG(rank_obj);
 }  // namespace obj

--- a/src/objective/regression_loss.h
+++ b/src/objective/regression_loss.h
@@ -1,0 +1,72 @@
+#ifndef XGBOOST_OBJECTIVE_LOSS_H_
+#define XGBOOST_OBJECTIVE_LOSS_H_
+
+#include <dmlc/omp.h>
+#include <xgboost/logging.h>
+#include "../common/math.h"
+
+namespace xgboost {
+namespace obj {
+
+// common regressions
+// linear regression
+struct LinearSquareLoss {
+  XGBOOST_DEVICE static bst_float PredTransform(bst_float x) { return x; }
+  XGBOOST_DEVICE static bool CheckLabel(bst_float x) { return true; }
+  XGBOOST_DEVICE static bst_float FirstOrderGradient(bst_float predt, bst_float label) {
+    return predt - label;
+  }
+  XGBOOST_DEVICE static bst_float SecondOrderGradient(bst_float predt, bst_float label) {
+    return 1.0f;
+  }
+  static bst_float ProbToMargin(bst_float base_score) { return base_score; }
+  static const char* LabelErrorMsg() { return ""; }
+  static const char* DefaultEvalMetric() { return "rmse"; }
+};
+ 
+// logistic loss for probability regression task
+struct LogisticRegression {
+  XGBOOST_DEVICE static bst_float PredTransform(bst_float x) { return common::Sigmoid(x); }
+  XGBOOST_DEVICE static bool CheckLabel(bst_float x) { return x >= 0.0f && x <= 1.0f; }
+  XGBOOST_DEVICE static bst_float FirstOrderGradient(bst_float predt, bst_float label) {
+    return predt - label;
+  }
+  XGBOOST_DEVICE static bst_float SecondOrderGradient(bst_float predt, bst_float label) {
+    const float eps = 1e-16f;
+    return fmaxf(predt * (1.0f - predt), eps);
+  }
+  static bst_float ProbToMargin(bst_float base_score) {
+    CHECK(base_score > 0.0f && base_score < 1.0f)
+      << "base_score must be in (0,1) for logistic loss";
+    return -logf(1.0f / base_score - 1.0f);
+  }
+  static const char* LabelErrorMsg() {
+    return "label must be in [0,1] for logistic regression";
+  }
+  static const char* DefaultEvalMetric() { return "rmse"; }
+};
+ 
+// logistic loss for binary classification task
+struct LogisticClassification : public LogisticRegression {
+  static const char* DefaultEvalMetric() { return "error"; }
+};
+ 
+// logistic loss, but predict un-transformed margin
+struct LogisticRaw : public LogisticRegression {
+  XGBOOST_DEVICE static bst_float PredTransform(bst_float x) { return x; }
+  XGBOOST_DEVICE static bst_float FirstOrderGradient(bst_float predt, bst_float label) {
+    predt = common::Sigmoid(predt);
+    return predt - label;
+  }
+  XGBOOST_DEVICE static bst_float SecondOrderGradient(bst_float predt, bst_float label) {
+    const float eps = 1e-16f;
+    predt = common::Sigmoid(predt);
+    return fmaxf(predt * (1.0f - predt), eps);
+  }
+  static const char* DefaultEvalMetric() { return "auc"; }
+};
+
+}
+}
+
+#endif

--- a/src/objective/regression_obj.cc
+++ b/src/objective/regression_obj.cc
@@ -11,60 +11,12 @@
 #include <algorithm>
 #include <utility>
 #include "../common/math.h"
+#include "./regression_loss.h"
 
 namespace xgboost {
 namespace obj {
 
 DMLC_REGISTRY_FILE_TAG(regression_obj);
-
-// common regressions
-// linear regression
-struct LinearSquareLoss {
-  static bst_float PredTransform(bst_float x) { return x; }
-  static bool CheckLabel(bst_float x) { return true; }
-  static bst_float FirstOrderGradient(bst_float predt, bst_float label) { return predt - label; }
-  static bst_float SecondOrderGradient(bst_float predt, bst_float label) { return 1.0f; }
-  static bst_float ProbToMargin(bst_float base_score) { return base_score; }
-  static const char* LabelErrorMsg() { return ""; }
-  static const char* DefaultEvalMetric() { return "rmse"; }
-};
-// logistic loss for probability regression task
-struct LogisticRegression {
-  static bst_float PredTransform(bst_float x) { return common::Sigmoid(x); }
-  static bool CheckLabel(bst_float x) { return x >= 0.0f && x <= 1.0f; }
-  static bst_float FirstOrderGradient(bst_float predt, bst_float label) { return predt - label; }
-  static bst_float SecondOrderGradient(bst_float predt, bst_float label) {
-    const float eps = 1e-16f;
-    return std::max(predt * (1.0f - predt), eps);
-  }
-  static bst_float ProbToMargin(bst_float base_score) {
-    CHECK(base_score > 0.0f && base_score < 1.0f)
-        << "base_score must be in (0,1) for logistic loss";
-    return -std::log(1.0f / base_score - 1.0f);
-  }
-  static const char* LabelErrorMsg() {
-    return "label must be in [0,1] for logistic regression";
-  }
-  static const char* DefaultEvalMetric() { return "rmse"; }
-};
-// logistic loss for binary classification task.
-struct LogisticClassification : public LogisticRegression {
-  static const char* DefaultEvalMetric() { return "error"; }
-};
-// logistic loss, but predict un-transformed margin
-struct LogisticRaw : public LogisticRegression {
-  static bst_float PredTransform(bst_float x) { return x; }
-  static bst_float FirstOrderGradient(bst_float predt, bst_float label) {
-    predt = common::Sigmoid(predt);
-    return predt - label;
-  }
-  static bst_float SecondOrderGradient(bst_float predt, bst_float label) {
-    const float eps = 1e-16f;
-    predt = common::Sigmoid(predt);
-    return std::max(predt * (1.0f - predt), eps);
-  }
-  static const char* DefaultEvalMetric() { return "auc"; }
-};
 
 struct RegLossParam : public dmlc::Parameter<RegLossParam> {
   float scale_pos_weight;

--- a/src/objective/regression_obj_gpu.cu
+++ b/src/objective/regression_obj_gpu.cu
@@ -1,0 +1,211 @@
+// GPU implementation of objective function.  Necessary as evaluating the objective
+// function takes significant time when training on the GPU.
+
+#include <dmlc/omp.h>
+#include <thrust/device_vector.h>
+#include <thrust/copy.h>
+#include <xgboost/logging.h>
+#include <xgboost/objective.h>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include "../common/device_helpers.cuh"
+#include "./regression_loss.h"
+
+using namespace dh;
+
+namespace xgboost {
+namespace obj {
+
+
+DMLC_REGISTRY_FILE_TAG(regression_obj_gpu);
+
+struct GPURegLossParam : public dmlc::Parameter<GPURegLossParam> {
+  float scale_pos_weight;
+  // declare parameters
+  DMLC_DECLARE_PARAMETER(GPURegLossParam) {
+    DMLC_DECLARE_FIELD(scale_pos_weight).set_default(1.0f).set_lower_bound(0.0f)
+        .describe("Scale the weight of positive examples by this factor");
+  }
+};
+
+// GPU kernel for gradient computation
+template<typename Loss>
+__global__ void get_gradient_k
+(bst_gpair *__restrict__ out_gpair,  uint *__restrict__ label_correct,
+ const float * __restrict__ preds, const float * __restrict__ labels,
+ const float * __restrict__ weights, int n, float scale_pos_weight) {
+  int i = threadIdx.x + blockIdx.x * blockDim.x;
+  if (i >= n)
+    return;
+  float p = Loss::PredTransform(preds[i]);
+  float w = weights == nullptr ? 1.0f : weights[i];
+  float label = labels[i];
+  if (label == 1.0f)
+    w *= scale_pos_weight;
+  if (!Loss::CheckLabel(label))
+    atomicAnd(label_correct, 0);
+  out_gpair[i] = bst_gpair
+    (Loss::FirstOrderGradient(p, label) * w, Loss::SecondOrderGradient(p, label) * w);
+}
+
+// GPU kernel for predicate transformation
+template<typename Loss>
+__global__ void pred_transform_k(float * __restrict__ preds, int n) {
+  int i = threadIdx.x + blockIdx.x * blockDim.x;
+  if (i >= n)
+    return;
+  preds[i] = Loss::PredTransform(preds[i]);
+}
+
+// regression loss function for evaluation on GPU (eventually)
+template<typename Loss>
+class GPURegLossObj : public ObjFunction {
+  protected:
+
+  // manages device data
+  struct DeviceData {
+    dvec<float> preds, labels, weights;
+    dvec<uint> label_correct;
+    dvec<bst_gpair> out_gpair;
+    bulk_allocator<memory_type::DEVICE> ba;
+
+    // allocate everything on device
+    DeviceData(size_t n) {
+      ba.allocate(0, true,
+                  &preds, n,
+                  &labels, n,
+                  &weights, n,
+                  &label_correct, 1,
+                  &out_gpair, n);
+    }
+    size_t size() const { return preds.size(); }
+  };
+
+  
+  bool copied_;
+  std::unique_ptr<DeviceData> data_;
+
+  // allocate device data for n elements, do nothing if enough memory is allocated already
+  void LazyResize(int n) {
+    if (data_ != NULL && data_->size() >= n)
+      return;
+    copied_ = false;
+    // free the old data and allocate the new data
+    data_.reset(nullptr_t());
+    std::unique_ptr<DeviceData> new_data(new DeviceData(n));
+    data_.swap(new_data);
+  }
+  
+ public:
+  GPURegLossObj() : copied_(false) {}
+  
+  void Configure(const std::vector<std::pair<std::string, std::string> >& args) override {
+    param_.InitAllowUnknown(args);
+  }
+  void GetGradient(const std::vector<float> &preds,
+                   const MetaInfo &info,
+                   int iter,
+                   std::vector<bst_gpair> *out_gpair) override {
+    CHECK_NE(info.labels.size(), 0U) << "label set cannot be empty";
+    CHECK_EQ(preds.size(), info.labels.size())
+        << "labels are not correctly provided"
+        << "preds.size=" << preds.size() << ", label.size=" << info.labels.size();
+    out_gpair->resize(preds.size());
+
+    // start calculating gradient
+    const omp_ulong ndata = static_cast<omp_ulong>(preds.size());
+
+    // always use GPU 0
+    safe_cuda(cudaSetDevice(0));
+    LazyResize(ndata);
+
+    DeviceData& d = *data_;
+
+    d.label_correct.fill(1);
+
+    // only copy the labels and weights once, similar to how the data is copied
+    if (!copied_) {
+      thrust::copy(info.labels.begin(), info.labels.end(), d.labels.tbegin());
+      if (info.weights.size() > 0)
+        thrust::copy(info.weights.begin(), info.weights.end(), d.weights.tbegin());
+      copied_ = true;
+    }
+    
+    // copy input data to the GPU
+    thrust::copy(preds.begin(), preds.end(), d.preds.tbegin());
+    
+    // run the kernel
+    const int block = 256;
+    get_gradient_k<Loss><<<div_round_up(ndata, block), block>>>
+      (d.out_gpair.data(), d.label_correct.data(), d.preds.data(),
+       d.labels.data(), info.weights.size() > 0 ? d.weights.data() : nullptr,
+       ndata, param_.scale_pos_weight);
+    safe_cuda(cudaGetLastError());
+    safe_cuda(cudaDeviceSynchronize());
+
+    // copy output data from the GPU
+    thrust::copy_n(d.out_gpair.tbegin(), out_gpair->size(), out_gpair->begin());
+    uint label_correct_uint = 0;
+    thrust::copy_n(d.label_correct.tbegin(), 1, &label_correct_uint);
+    bool label_correct = label_correct_uint != 0;
+    
+    if (!label_correct) {
+      LOG(FATAL) << Loss::LabelErrorMsg();
+    }
+  }
+  
+  const char* DefaultEvalMetric() const override {
+    return Loss::DefaultEvalMetric();
+  }
+  
+  void PredTransform(std::vector<float> *io_preds) override {
+    std::vector<float> &preds = *io_preds;
+    const bst_omp_uint ndata = static_cast<bst_omp_uint>(preds.size());
+    
+    // always use GPU 0
+    safe_cuda(cudaSetDevice(0));
+    LazyResize(ndata);
+
+    DeviceData& d = *data_;
+
+    thrust::copy(preds.begin(), preds.end(), d.preds.tbegin());
+
+    const int block = 256;
+    pred_transform_k<Loss><<<div_round_up(ndata, block), block>>>(d.preds.data(), ndata);
+    safe_cuda(cudaGetLastError());
+    safe_cuda(cudaDeviceSynchronize());
+    thrust::copy_n(d.preds.tbegin(), preds.size(), preds.begin());
+  }
+  
+  float ProbToMargin(float base_score) const override {
+    return Loss::ProbToMargin(base_score);
+  }
+
+ protected:
+  GPURegLossParam param_;
+};
+
+// register the objective functions
+DMLC_REGISTER_PARAMETER(GPURegLossParam);
+
+XGBOOST_REGISTER_OBJECTIVE(GPULinearRegression, "gpu:reg:linear")
+.describe("Linear regression (computed on GPU).")
+.set_body([]() { return new GPURegLossObj<LinearSquareLoss>(); });
+
+XGBOOST_REGISTER_OBJECTIVE(GPULogisticRegression, "gpu:reg:logistic")
+.describe("Logistic regression for probability regression task (computed on GPU).")
+.set_body([]() { return new GPURegLossObj<LogisticRegression>(); });
+
+XGBOOST_REGISTER_OBJECTIVE(GPULogisticClassification, "gpu:binary:logistic")
+.describe("Logistic regression for binary classification task (computed on GPU).")
+.set_body([]() { return new GPURegLossObj<LogisticClassification>(); });
+
+XGBOOST_REGISTER_OBJECTIVE(GPULogisticRaw, "gpu:binary:logitraw")
+.describe("Logistic regression for classification, output score "
+          "before logistic transformation (computed on GPU)")
+.set_body([]() { return new GPURegLossObj<LogisticRaw>(); });
+
+}
+}

--- a/tests/cpp/objective/test_regression_obj_gpu.cu
+++ b/tests/cpp/objective/test_regression_obj_gpu.cu
@@ -1,0 +1,66 @@
+#include <xgboost/objective.h>
+
+#include "../helpers.h"
+
+TEST(Objective, GPULinearRegressionGPair) {
+  xgboost::ObjFunction * obj = xgboost::ObjFunction::Create("gpu:reg:linear");
+  std::vector<std::pair<std::string, std::string> > args;
+  obj->Configure(args);
+  CheckObjFunction(obj,
+                   {0, 0.1f, 0.9f,   1,    0,  0.1f, 0.9f,  1},
+                   {0,   0,   0,   0,    1,    1,    1, 1},
+                   {1,   1,   1,   1,    1,    1,    1, 1},
+                   {0, 0.1f, 0.9f, 1.0f, -1.0f, -0.9f, -0.1f, 0},
+                   {1,   1,   1,   1,    1,    1,    1, 1});
+
+  ASSERT_NO_THROW(obj->DefaultEvalMetric());
+}
+
+TEST(Objective, GPULogisticRegressionGPair) {
+  xgboost::ObjFunction * obj = xgboost::ObjFunction::Create("gpu:reg:logistic");
+  std::vector<std::pair<std::string, std::string> > args;
+  obj->Configure(args);
+  CheckObjFunction(obj,
+                   {   0,  0.1f,  0.9f,    1,    0,   0.1f,  0.9f,      1},
+                   {   0,    0,    0,    0,    1,     1,     1,     1},
+                   {   1,    1,    1,    1,    1,     1,     1,     1},
+                   { 0.5f, 0.52f, 0.71f, 0.73f, -0.5f, -0.47f, -0.28f, -0.26f},
+                   {0.25f, 0.24f, 0.20f, 0.19f, 0.25f,  0.24f,  0.20f,  0.19f});
+}
+
+TEST(Objective, GPULogisticRegressionBasic) {
+  xgboost::ObjFunction * obj = xgboost::ObjFunction::Create("gpu:reg:logistic");
+  std::vector<std::pair<std::string, std::string> > args;
+  obj->Configure(args);
+
+  // test label validation
+  EXPECT_ANY_THROW(CheckObjFunction(obj, {0}, {10}, {1}, {0}, {0}))
+    << "Expected error when label not in range [0,1f] for LogisticRegression";
+
+  // test ProbToMargin
+  EXPECT_NEAR(obj->ProbToMargin(0.1f), -2.197f, 0.01f);
+  EXPECT_NEAR(obj->ProbToMargin(0.5f), 0, 0.01f);
+  EXPECT_NEAR(obj->ProbToMargin(0.9f), 2.197f, 0.01f);
+  EXPECT_ANY_THROW(obj->ProbToMargin(10))
+    << "Expected error when base_score not in range [0,1f] for LogisticRegression";
+
+  // test PredTransform
+  std::vector<xgboost::bst_float> preds = {0, 0.1f, 0.5f, 0.9f, 1};
+  std::vector<xgboost::bst_float> out_preds = {0.5f, 0.524f, 0.622f, 0.710f, 0.731f};
+  obj->PredTransform(&preds);
+  for (int i = 0; i < static_cast<int>(preds.size()); ++i) {
+    EXPECT_NEAR(preds[i], out_preds[i], 0.01f);
+  }
+}
+
+TEST(Objective, GPULogisticRawGPair) {
+  xgboost::ObjFunction * obj = xgboost::ObjFunction::Create("gpu:binary:logitraw");
+  std::vector<std::pair<std::string, std::string> > args;
+  obj->Configure(args);
+  CheckObjFunction(obj,
+                   {   0,  0.1f,  0.9f,    1,    0,   0.1f,   0.9f,     1},
+                   {   0,    0,    0,    0,    1,     1,     1,     1},
+                   {   1,    1,    1,    1,    1,     1,     1,     1},
+                   { 0.5f, 0.52f, 0.71f, 0.73f, -0.5f, -0.47f, -0.28f, -0.26f},
+                   {0.25f, 0.24f, 0.20f, 0.19f, 0.25f,  0.24f,  0.20f,  0.19f});
+}


### PR DESCRIPTION
Hi,
1. reg:linear, reg:logistic, binary:logistic and binary:logitraw have GPU versions now
2. All comments from the previously closed PR #2791 have been addressed here.
3. Our testing shows ~9-10% end-to-end training time improvement using the benchmark.py (on a Quadro GP100 workstation)

Some observations:
Most of the time in the objective function evaluation is actually spent in copying data between host and GPU. We need to update the interface of objective function evaluation to help eliminate these copies. This should further reduce training time.

Let us know in case you need any more inputs from us.

Regards,
Thejaswi