### PR TITLE
[jvm-packages] Fixed a subtle bug in train/test split

### DIFF
--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -63,6 +63,12 @@ XGB_EXTERN_C int XGBoost4jCallbackDataIterNext(
     if (jenv->CallBooleanMethod(jiter, hasNext)) {
       ret_value = 1;
       jobject batch = jenv->CallObjectMethod(jiter, next);
+      if (batch == nullptr) {
+        CHECK(jenv->ExceptionOccurred());
+        jenv->ExceptionDescribe();
+        return -1;
+      }
+
       jclass batchClass = jenv->GetObjectClass(batch);
       jlongArray joffset = (jlongArray)jenv->GetObjectField(
           batch, jenv->GetFieldID(batchClass, "rowOffset", "[J"));


### PR DESCRIPTION
Iterator.partition (naturally) assumes that the predicate is deterministic
but this is not the case for

    r.nextDouble() <= trainTestRatio

therefore sometimes the DMatrix(...) call got a NoSuchElementException
and crashed the JVM due to lack of exception handling in
XGBoost4jCallbackDataIterNext.