### PR TITLE
Fix XGDMatrixFree argument type

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -238,7 +238,7 @@ XGB_DLL int XGDMatrixSliceDMatrix(DMatrixHandle handle,
  * \brief free space in data matrix
  * \return 0 when success, -1 when failure happens
  */
-XGB_DLL int XGDMatrixFree(void *handle);
+XGB_DLL int XGDMatrixFree(DMatrixHandle handle);
 /*!
  * \brief load a data matrix into binary file
  * \param handle a instance of data matrix


### PR DESCRIPTION
`XGDMatrixFree()` argument type was different between `include/xgboost/c_api.h` and `src/c_api/c_api.cc`. This fix adjusts argument type to `src/c_api/c_api.cc`.