### PR TITLE
Monotone constraints for gpu_hist

### DIFF
--- a/doc/gpu/index.md
+++ b/doc/gpu/index.md
@@ -46,6 +46,8 @@ Specify the 'tree_method' parameter as one of the following algorithms.
 +--------------------+------------+-----------+
 | grow_policy        | |cross|    | |tick|    |
 +--------------------+------------+-----------+
+| monotone_constraints  | |cross|    | |tick|    |
++--------------------+------------+-----------+
 
 ```
 

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -319,7 +319,9 @@ class ColMaker: public TreeUpdater {
             if (c.sum_hess >= param.min_child_weight &&
                 e.stats.sum_hess >= param.min_child_weight) {
               bst_float loss_chg = static_cast<bst_float>(
-                  constraints_[nid].CalcSplitGain(param, fid, e.stats, c) - snode[nid].root_gain);
+                  constraints_[nid].CalcSplitGain(
+                      param, param.monotone_constraints[fid], e.stats, c) -
+                  snode[nid].root_gain);
               e.best.Update(loss_chg, fid, fsplit, false);
             }
           }
@@ -329,7 +331,9 @@ class ColMaker: public TreeUpdater {
             if (c.sum_hess >= param.min_child_weight &&
                 tmp.sum_hess >= param.min_child_weight) {
               bst_float loss_chg = static_cast<bst_float>(
-                  constraints_[nid].CalcSplitGain(param, fid, tmp, c) - snode[nid].root_gain);
+                  constraints_[nid].CalcSplitGain(
+                      param, param.monotone_constraints[fid], tmp, c) -
+                  snode[nid].root_gain);
               e.best.Update(loss_chg, fid, fsplit, true);
             }
           }
@@ -341,7 +345,9 @@ class ColMaker: public TreeUpdater {
           if (c.sum_hess >= param.min_child_weight &&
               tmp.sum_hess >= param.min_child_weight) {
             bst_float loss_chg = static_cast<bst_float>(
-                constraints_[nid].CalcSplitGain(param, fid, tmp, c) - snode[nid].root_gain);
+                constraints_[nid].CalcSplitGain(
+                    param, param.monotone_constraints[fid], tmp, c) -
+                snode[nid].root_gain);
             e.best.Update(loss_chg, fid, e.last_fvalue + rt_eps, true);
           }
         }
@@ -372,9 +378,11 @@ class ColMaker: public TreeUpdater {
                 if (c.sum_hess >= param.min_child_weight &&
                     e.stats.sum_hess >= param.min_child_weight) {
                   bst_float loss_chg = static_cast<bst_float>(
-                      constraints_[nid].CalcSplitGain(param, fid, e.stats, c) -
+                      constraints_[nid].CalcSplitGain(
+                          param, param.monotone_constraints[fid], e.stats, c) -
                       snode[nid].root_gain);
-                  e.best.Update(loss_chg, fid, (fvalue + e.first_fvalue) * 0.5f, false);
+                  e.best.Update(loss_chg, fid, (fvalue + e.first_fvalue) * 0.5f,
+                                false);
                 }
               }
               if (need_backward) {
@@ -383,7 +391,8 @@ class ColMaker: public TreeUpdater {
                 if (c.sum_hess >= param.min_child_weight &&
                     cright.sum_hess >= param.min_child_weight) {
                   bst_float loss_chg = static_cast<bst_float>(
-                      constraints_[nid].CalcSplitGain(param, fid, c, cright) -
+                      constraints_[nid].CalcSplitGain(
+                          param, param.monotone_constraints[fid], c, cright) -
                       snode[nid].root_gain);
                   e.best.Update(loss_chg, fid, (fvalue + e.first_fvalue) * 0.5f, true);
                 }
@@ -414,12 +423,17 @@ class ColMaker: public TreeUpdater {
             bst_float loss_chg;
             if (d_step == -1) {
               loss_chg = static_cast<bst_float>(
-                  constraints_[nid].CalcSplitGain(param, fid, c, e.stats) - snode[nid].root_gain);
+                  constraints_[nid].CalcSplitGain(
+                      param, param.monotone_constraints[fid], c, e.stats) -
+                  snode[nid].root_gain);
             } else {
               loss_chg = static_cast<bst_float>(
-                  constraints_[nid].CalcSplitGain(param, fid, e.stats, c) - snode[nid].root_gain);
+                  constraints_[nid].CalcSplitGain(
+                      param, param.monotone_constraints[fid], e.stats, c) -
+                  snode[nid].root_gain);
             }
-            e.best.Update(loss_chg, fid, (fvalue + e.last_fvalue) * 0.5f, d_step == -1);
+            e.best.Update(loss_chg, fid, (fvalue + e.last_fvalue) * 0.5f,
+                          d_step == -1);
           }
         }
         // update the statistics
@@ -492,10 +506,14 @@ class ColMaker: public TreeUpdater {
           bst_float loss_chg;
           if (d_step == -1) {
             loss_chg = static_cast<bst_float>(
-                constraints_[nid].CalcSplitGain(param, fid, c, e.stats) - snode[nid].root_gain);
+                constraints_[nid].CalcSplitGain(
+                    param, param.monotone_constraints[fid], c, e.stats) -
+                snode[nid].root_gain);
           } else {
             loss_chg = static_cast<bst_float>(
-                constraints_[nid].CalcSplitGain(param, fid, e.stats, c) - snode[nid].root_gain);
+                constraints_[nid].CalcSplitGain(
+                    param, param.monotone_constraints[fid], e.stats, c) -
+                snode[nid].root_gain);
           }
           const bst_float gap = std::abs(e.last_fvalue) + rt_eps;
           const bst_float delta = d_step == +1 ? gap: -gap;
@@ -545,11 +563,13 @@ class ColMaker: public TreeUpdater {
               bst_float loss_chg;
               if (d_step == -1) {
                 loss_chg = static_cast<bst_float>(
-                    constraints_[nid].CalcSplitGain(param, fid, c, e.stats) -
+                    constraints_[nid].CalcSplitGain(
+                        param, param.monotone_constraints[fid], c, e.stats) -
                     snode[nid].root_gain);
               } else {
                 loss_chg = static_cast<bst_float>(
-                    constraints_[nid].CalcSplitGain(param, fid, e.stats, c) -
+                    constraints_[nid].CalcSplitGain(
+                        param, param.monotone_constraints[fid], e.stats, c) -
                     snode[nid].root_gain);
               }
               e.best.Update(loss_chg, fid, (fvalue + e.last_fvalue) * 0.5f, d_step == -1);
@@ -565,14 +585,19 @@ class ColMaker: public TreeUpdater {
         const int nid = qexpand[i];
         ThreadEntry &e = temp[nid];
         c.SetSubstract(snode[nid].stats, e.stats);
-        if (e.stats.sum_hess >= param.min_child_weight && c.sum_hess >= param.min_child_weight) {
+        if (e.stats.sum_hess >= param.min_child_weight &&
+            c.sum_hess >= param.min_child_weight) {
           bst_float loss_chg;
           if (d_step == -1) {
             loss_chg = static_cast<bst_float>(
-                constraints_[nid].CalcSplitGain(param, fid, c, e.stats) - snode[nid].root_gain);
+                constraints_[nid].CalcSplitGain(
+                    param, param.monotone_constraints[fid], c, e.stats) -
+                snode[nid].root_gain);
           } else {
             loss_chg = static_cast<bst_float>(
-                constraints_[nid].CalcSplitGain(param, fid, e.stats, c) - snode[nid].root_gain);
+                constraints_[nid].CalcSplitGain(
+                    param, param.monotone_constraints[fid], e.stats, c) -
+                snode[nid].root_gain);
           }
           const bst_float gap = std::abs(e.last_fvalue) + rt_eps;
           const bst_float delta = d_step == +1 ? gap: -gap;

--- a/src/tree/updater_gpu.cu
+++ b/src/tree/updater_gpu.cu
@@ -302,7 +302,7 @@ DEV_INLINE void argMaxWithAtomics(
       ExactSplitCandidate s;
       bst_gpair missing = parentSum - colSum;
       s.score = loss_chg_missing(gradScans[id], missing, parentSum, parentGain,
-                                 param, tmp);
+                                 param, 0, ValueConstraint(), tmp);
       s.index = id;
       atomicArgMax(nodeSplits + uid, s);
     }  // end if nodeId != UNUSED_NODE
@@ -580,7 +580,7 @@ class GPUMaker : public TreeUpdater {
         // get the default direction for the current node
         bst_gpair missing = n.sum_gradients - gradSum;
         loss_chg_missing(gradScan, missing, n.sum_gradients, n.root_gain,
-                         gpu_param, missingLeft);
+                         gpu_param, 0, ValueConstraint(), missingLeft);
         // get the score/weight/id/gradSum for left and right child nodes
         bst_gpair lGradSum = missingLeft ? gradScan + missing : gradScan;
         bst_gpair rGradSum = n.sum_gradients - lGradSum;

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -97,7 +97,7 @@ def train_sparse(param_in, comparison_tree_method):
 
 # Enumerates all permutations of variable parameters
 def assert_updater_accuracy(tree_method, comparison_tree_method, variable_param, tolerance):
-    param = {'tree_method': tree_method }
+    param = {'tree_method': tree_method}
     names = sorted(variable_param)
     combinations = it.product(*(variable_param[Name] for Name in names))
 
@@ -109,10 +109,14 @@ def assert_updater_accuracy(tree_method, comparison_tree_method, variable_param,
             param_tmp[name] = set[i]
 
         print(param_tmp, file=sys.stderr)
-        assert_accuracy(train_boston(param_tmp, comparison_tree_method), tree_method, comparison_tree_method, tolerance, param_tmp)
-        assert_accuracy(train_digits(param_tmp, comparison_tree_method), tree_method, comparison_tree_method, tolerance, param_tmp)
-        assert_accuracy(train_cancer(param_tmp, comparison_tree_method), tree_method, comparison_tree_method, tolerance, param_tmp)
-        assert_accuracy(train_sparse(param_tmp, comparison_tree_method), tree_method, comparison_tree_method, tolerance, param_tmp)
+        assert_accuracy(train_boston(param_tmp, comparison_tree_method), tree_method, comparison_tree_method, tolerance,
+                        param_tmp)
+        assert_accuracy(train_digits(param_tmp, comparison_tree_method), tree_method, comparison_tree_method, tolerance,
+                        param_tmp)
+        assert_accuracy(train_cancer(param_tmp, comparison_tree_method), tree_method, comparison_tree_method, tolerance,
+                        param_tmp)
+        assert_accuracy(train_sparse(param_tmp, comparison_tree_method), tree_method, comparison_tree_method, tolerance,
+                        param_tmp)
 
 
 @attr('gpu')
@@ -122,5 +126,6 @@ class TestGPU(unittest.TestCase):
         assert_updater_accuracy('gpu_exact', 'exact', variable_param, 0.02)
 
     def test_gpu_hist(self):
-        variable_param = {'n_gpus': [1, -1], 'max_depth': [2, 6], 'max_leaves': [255, 4], 'max_bin': [2, 16, 1024]}
+        variable_param = {'n_gpus': [1, -1], 'max_depth': [2, 6], 'max_leaves': [255, 4], 'max_bin': [2, 16, 1024],
+                          'grow_policy': ['depthwise', 'lossguide']}
         assert_updater_accuracy('gpu_hist', 'hist', variable_param, 0.01)

--- a/tests/python-gpu/test_monotonic_constraints.py
+++ b/tests/python-gpu/test_monotonic_constraints.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+
+import numpy as np
+import unittest
+import xgboost as xgb
+from nose.plugins.attrib import attr
+from sklearn.datasets import make_regression
+
+rng = np.random.RandomState(1994)
+
+
+def non_decreasing(L):
+    return all((x - y) < 0.001 for x, y in zip(L, L[1:]))
+
+
+def non_increasing(L):
+    return all((y - x) < 0.001 for x, y in zip(L, L[1:]))
+
+
+def assert_constraint(constraint, tree_method):
+    n = 1000
+    X, y = make_regression(n, random_state=rng, n_features=1, n_informative=1)
+    dtrain = xgb.DMatrix(X, y)
+    param = {}
+    param['tree_method'] = tree_method
+    param['monotone_constraints'] = "(" + str(constraint) + ")"
+    bst = xgb.train(param, dtrain)
+    dpredict = xgb.DMatrix(X[X[:, 0].argsort()])
+    pred = bst.predict(dpredict)
+    if constraint > 0:
+        assert non_decreasing(pred)
+    elif constraint < 0:
+        assert non_increasing(pred)
+
+
+@attr('gpu')
+class TestMonotonicConstraints(unittest.TestCase):
+    def test_exact(self):
+        assert_constraint(1, 'exact')
+        assert_constraint(-1, 'exact')
+
+    def test_gpu_hist(self):
+        assert_constraint(1, 'gpu_hist')
+        assert_constraint(-1, 'gpu_hist')


### PR DESCRIPTION
Implements monotone constraints for the GPU histogram algorithm.

Contains unit tests for the univariate case.

Also passes visual tests here for multivariate case: https://github.com/XiaoxiaoWang87/xgboost_mono_test

Implementing this feature required some small changes to the existing constraints code. In particular it was not possible to access the vector containing the constraints information (param.monotone_constraints) in device code. For this reason the CalcSplitGain function now directly accepts an integer constraint instead of requiring params as an argument.