### PR TITLE
Add grouping to Python sklearn interface

### DIFF
--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -52,6 +52,7 @@ try:
     from sklearn.base import BaseEstimator
     from sklearn.base import RegressorMixin, ClassifierMixin
     from sklearn.preprocessing import LabelEncoder
+    from sklearn.utils import safe_indexing
     try:
         from sklearn.model_selection import KFold, StratifiedKFold
     except ImportError:
@@ -66,6 +67,8 @@ try:
     XGBKFold = KFold
     XGBStratifiedKFold = StratifiedKFold
     XGBLabelEncoder = LabelEncoder
+
+    xgb_safe_indexing = safe_indexing
 except ImportError:
     SKLEARN_INSTALLED = False
 
@@ -77,3 +80,5 @@ except ImportError:
     XGBKFold = None
     XGBStratifiedKFold = None
     XGBLabelEncoder = None
+
+    xgb_safe_indexing = None

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -602,6 +602,39 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
 
 def _prepare_dmatrix(X, y=None, sample_weight=None, groups=None,
                      group_sizes=None, missing=None, n_jobs=None):
+    """Decorate an objective function
+
+    Converts an objective function using the typical sklearn metrics
+    signature so that it is usable with ``xgboost.training.train``
+
+    Parameters
+    ----------
+    X : array_like
+        Feature matrix
+    y : array_like
+        Labels
+    sample_weight : array_like
+        instance weights
+    groups: array_like
+        Group identifiers for pairwise ranking
+    group_sizes: array_like
+        Group sizes of X data for pairwise ranking
+    missing : float, optional
+        Value in the data which needs to be present as a missing value. If
+        None, defaults to np.nan.
+    n_jobs : int
+        Number of parallel threads used to run xgboost.  (replaces nthread)
+
+    Returns
+    -------
+    (prepared_data, original_sorting) : (DMatrix, Optional[np.array])
+        Returns a DMatrix created from python data structures.
+
+        If grouping was passed, the returned DMatrix contains the (X, y) data
+        sorted so groups are next to each other, the returned original_sorting
+        list contains a list of the new indicies that will resort the data
+        back into the original sort.
+    """
     if groups is not None and group_sizes is not None:
         raise AssertionError('Please supply either groups, or group_sizes, not both.')
 


### PR DESCRIPTION
Adds support to pass through `groups` & `group_sizes` to XGBoost's `sklearn` interface.

~~This is more of a proof of concept, I want to rework the interface so that `groups` is used the way the `sklearn` does things.  With `sklearn` groups should be a group identifier, while for `xgboost` it expects the data to be sorted by group, and then given group sizes.  I was thinking about making a `group_sizes` parameter, and then having a `groups` parameter that works the `sklearn` way.  Let me know if that sounds good!~~

This adds ability to build ranking models through the `sklearn` API, by setting `.fit(X, y, groups=groups)`, which will now:
1) resort the data so groups are next to each other (based on `groups`)
2) on the created dmatrix, it will call `DMatrix.set_group(...)` with the calculated group sizes
3) goes through existing `Booster.predict(...)` code path
4) resorts the results back to what they original were
5) returns back to what called the `sklearn` API

I also passed through `group_sizes` if the programmer would rather use the XGBoost style of handing grouping, instead of how sklearn handles it (which is to assign a group number for every row).

#815 seems related, but it looks like they just jumped down to using `DMatrix` & `train` directly... but I have a bunch of parameter tuning setup so I don't want to rework that code. 😄 