### PR TITLE
[Python] AppVeyor CI for Python wheel package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,16 +6,25 @@ environment:
           ver: 2013
           generator: "Visual Studio 12 2013 Win64"
           configuration: Release
+          platform: x64
         - target: msvc
           ver: 2015
           generator: "Visual Studio 14 2015 Win64"
           configuration: Debug
+          platform: x64
         - target: msvc
           ver: 2015
           generator: "Visual Studio 14 2015 Win64"
           configuration: Release
+          platform: x64
+        - target: msvc
+          ver: 2015
+          generator: "Visual Studio 14 2015"
+          configuration: Release
+          platform: Win32
         - target: mingw
           generator: "Unix Makefiles"
+          platform: x64
         - target: jvm
         - target: rmsvc
           ver: 2015
@@ -26,9 +35,6 @@ environment:
 
 #matrix:
 #    fast_finish: true
-
-platform:
-    - x64
 
 install:
     - git submodule update --init --recursive
@@ -73,7 +79,9 @@ build_script:
     # Python package
     - if /i "%DO_PYTHON%" == "on" (
         cd %APPVEYOR_BUILD_FOLDER%\python-package &&
-        python setup.py install
+        python setup.py install &&
+        mkdir wheel &&
+        python setup.py bdist_wheel --universal --plat-name win-amd64 -d wheel
       )
     # R package: make + mingw standard CRAN packaging (only x64 for now)
     - if /i "%target%" == "rmingw" (
@@ -121,4 +129,7 @@ artifacts:
       name: Bits
     # binary R-package
     - path: '**\xgboost_*.zip'
+      name: Bits
+    # binary Python wheel package
+    - path: '**\*.whl'
       name: Bits

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,25 +6,16 @@ environment:
           ver: 2013
           generator: "Visual Studio 12 2013 Win64"
           configuration: Release
-          platform: x64
         - target: msvc
           ver: 2015
           generator: "Visual Studio 14 2015 Win64"
           configuration: Debug
-          platform: x64
         - target: msvc
           ver: 2015
           generator: "Visual Studio 14 2015 Win64"
           configuration: Release
-          platform: x64
-        - target: msvc
-          ver: 2015
-          generator: "Visual Studio 14 2015"
-          configuration: Release
-          platform: Win32
         - target: mingw
           generator: "Unix Makefiles"
-          platform: x64
         - target: jvm
         - target: rmsvc
           ver: 2015
@@ -35,6 +26,9 @@ environment:
 
 #matrix:
 #    fast_finish: true
+
+platform:
+    - x64
 
 install:
     - git submodule update --init --recursive


### PR DESCRIPTION
This patch changes appveyor config.
Added new msvc target for win32 platform.
Wheel artifacts are created after build stage for msvc release targets.
```
python-package\wheel\xgboost-0.6-py2.py3-none-win32.whl
python-package\wheel\xgboost-0.6-py2.py3-none-win_amd64.whl
```

Slightly related to [#1551](https://github.com/dmlc/xgboost/issues/1551)