### PR TITLE
[jvm-packages] Fixed test/train persistence

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -151,6 +151,12 @@ object XGBoost extends Serializable {
       } finally {
         Rabit.shutdown()
         watches.delete()
+        cacheDirName.foreach { name =>
+          val cacheDir = new File(name)
+          if (!cacheDir.listFiles().forall(_.delete()) || !cacheDir.delete()) {
+            throw new IllegalStateException(s"failed to delete $cacheDir")
+          }
+        }
       }
     }.cache()
   }


### PR DESCRIPTION
Prior to this PR both data sets were persisted in the same directory, i.e. the test data replaced the training one which led to

* training on less data (since usually test < train) and
* test loss being exactly equal to the training loss.

Closes #2945.