### PR TITLE
delete duplicated code in python-package

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -141,7 +141,6 @@ class XGBModel(XGBModelBase):
         self.silent = silent
         self.objective = objective
         self.booster = booster
-        self.nthread = nthread
         self.gamma = gamma
         self.min_child_weight = min_child_weight
         self.max_delta_step = max_delta_step


### PR DESCRIPTION
delete duplicated code in python-package.
The line 142 and line 158 in the python-package/xgboost/sklearn.py are the same code, delete line 142.