### PR TITLE
Update PyPI maintainer; use VERSION for binary wheels

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -22,15 +22,14 @@ print("Install libxgboost from: %s" % LIB_PATH)
 # detailed instruction in setup_pip.py
 setup(name='xgboost',
       version=open(os.path.join(CURRENT_DIR, 'xgboost/VERSION')).read().strip(),
-      # version='0.4a23',
       description="XGBoost Python Package",
       long_description=open(os.path.join(CURRENT_DIR, 'README.rst')).read(),
       install_requires=[
           'numpy',
           'scipy',
       ],
-      maintainer='Hongliang Liu',
-      maintainer_email='phunter.lau@gmail.com',
+      maintainer='Hyunsu Cho',
+      maintainer_email='chohyu01@cs.washington.edu',
       zip_safe=False,
       packages=find_packages(),
       # this will use MANIFEST.in during install where we specify additional files,

--- a/python-package/setup_pip.py
+++ b/python-package/setup_pip.py
@@ -41,15 +41,14 @@ LIB_PATH = libpath['find_lib_path']()
 # python setup.py register sdist upload
 # and be sure to test it firstly using "python setup.py register sdist upload -r pypitest"
 setup(name='xgboost',
-      # version=open(os.path.join(CURRENT_DIR, 'xgboost/VERSION')).read().strip(),
-      version='0.6a2',
+      version=open(os.path.join(CURRENT_DIR, 'xgboost/VERSION')).read().strip(),
       description='XGBoost Python Package',
       install_requires=[
           'numpy',
           'scipy',
       ],
-      maintainer='Hongliang Liu',
-      maintainer_email='phunter.lau@gmail.com',
+      maintainer='Hyunsu Cho',
+      maintainer_email='chohyu01@cs.washington.edu',
       zip_safe=False,
       packages=find_packages(),
       # don't need this and don't use this, give everything to MANIFEST.in


### PR DESCRIPTION
This patch is essential so that the Python wheels get correct version number.