### PR TITLE
update macOS gcc@5 installation guide

### DIFF
--- a/python-package/README.rst
+++ b/python-package/README.rst
@@ -26,6 +26,11 @@ Please install ``gcc@5`` from `Homebrew <https://brew.sh/>`_::
 
     brew install gcc@5
 
+After installing ``gcc@5``, set it as your compiler::
+
+    export CC = gcc-5
+    export CXX = g++-5
+
 Linux
 -----
 


### PR DESCRIPTION
After installing gcc@5, CMAKE_C_COMPILER will not be set to gcc-5 automatically in some macOS environment  and the installation of xgboost will still fail. Manually setting the compiler will solve the problem.