### PR TITLE
c_api.cc variable declared inapproiate

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -406,6 +406,7 @@ void prefixsum_inplace(size_t *x, size_t N) {
       suma[0] = 0;
     }
     size_t sum = 0;
+    size_t offset = 0;
 #pragma omp for schedule(static)
     for (omp_ulong i = 0; i < N; i++) {
       sum += x[i];
@@ -413,7 +414,6 @@ void prefixsum_inplace(size_t *x, size_t N) {
     }
     suma[ithread+1] = sum;
 #pragma omp barrier
-    size_t offset = 0;
     for (omp_ulong i = 0; i < static_cast<omp_ulong>(ithread+1); i++) {
       offset += suma[i];
     }


### PR DESCRIPTION
In line 461, the "size_t offset = 0;" should be declared before any calculation, otherwise will cause compilation error. 

When using CMake for mvn package under jvm-package, will cause error below:
```
I:\Libraries\xgboost\src\c_api\c_api.cc(416): error C2146: Missing ";" before "offset" [I:\Libraries\xgboost\build\objxgboost.vcxproj]
```

and with the modification in the PR the problem solved.
Not sure with higher CMaker will fix the problem, but in C standard, the variable maybe better to be declared on the top in the function. 