### PR TITLE
(Minor) Fix in SparkParallelTracker to work with Spark2.3

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/SparkParallelismTracker.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/SparkParallelismTracker.scala
@@ -76,11 +76,12 @@ class SparkParallelismTracker(
   }
 
   private[this] def safeExecute[T](body: => T): T = {
-    sc.listenerBus.listeners.add(0, new TaskFailedListener)
+    val listener = new TaskFailedListener;
+    sc.addSparkListener(listener)
     try {
       body
     } finally {
-      sc.listenerBus.listeners.remove(0)
+      sc.listenerBus.removeListener(listener)
     }
   }
 


### PR DESCRIPTION
This PR changes how xgboost registers and removes Listeners to SparkContext so that it works on Spark2.3 while it continues to work on versions of Spark >= 2.0.

Spark 2.3 includes changes in LiveListenerBus which are incompatible with xgboost's SparkParallelTracker - the SparkContext::listenerBus member variable changed type and it is no longer possible to register or deregister listeners by directly accessing list of listeners in it. I've changed  it so that listener is registered via public method on SparkContext. The public method for removing listener has been added only in Spark2.3 and in order to run on older versions of Spark I still call the method on the listenerBus instance.

This change means xgboost will not compile against/ run on spark version < 2.0. 