### PR TITLE
Appveyor fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ install:
           Import-Module "$Env:TEMP\appveyor-tool.ps1"
           Bootstrap
           $DEPS = "c('data.table','magrittr','stringi','ggplot2','DiagrammeR','Ckmeans.1d.dp','vcd','testthat','igraph','knitr','rmarkdown')"
-          cmd /c "R.exe -q -e ""install.packages($DEPS, repos='$CRAN', type='win.binary')"" 2>&1"
+          cmd.exe /c "R.exe -q -e ""install.packages($DEPS, repos='$CRAN', type='win.binary')"" 2>&1"
         }
 
 build_script:


### PR DESCRIPTION
MSYS has suddenly started to litter the PATH with some C:\MinGW\msys\1.0\bin\cmd executable in Appveyor. Changing cmd to cmd.exe allows picking the proper windows system CMD.