### PR TITLE
Replacing cout with LOG

### DIFF
--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -281,10 +281,10 @@ struct WQSummary {
   // helper function to print the current content of sketch
   inline void Print() const {
     for (size_t i = 0; i < this->size; ++i) {
-      LOG(INFO) << "[" << i << "] rmin=" << data[i].rmin
-                << ", rmax=" << data[i].rmax
-                << ", wmin=" << data[i].wmin
-                << ", v=" << data[i].value;
+      LOG(CONSOLE) << "[" << i << "] rmin=" << data[i].rmin
+                   << ", rmax=" << data[i].rmax
+                   << ", wmin=" << data[i].wmin
+                   << ", v=" << data[i].value;
     }
   }
   // try to fix rounding error
@@ -321,7 +321,7 @@ struct WQSummary {
     for (size_t i = 0; i < this->size; ++i) {
       if (data[i].rmin + data[i].wmin > data[i].rmax + tol ||
           data[i].rmin < -1e-6f || data[i].rmax < -1e-6f) {
-        LOG(INFO) << "----------check not pass----------";
+        LOG(INFO) << "---------- WQSummary::Check did not pass ----------";
         this->Print();
         return false;
       }
@@ -503,9 +503,8 @@ struct GKSummary {
   /*! \brief used for debug purpose, print the summary */
   inline void Print() const {
     for (size_t i = 0; i < size; ++i) {
-      std::cout << "x=" << data[i].value << "\t"
-                << "[" << data[i].rmin << "," << data[i].rmax << "]"
-                << std::endl;
+      LOG(CONSOLE) << "x=" << data[i].value << "\t"
+                   << "[" << data[i].rmin << "," << data[i].rmax << "]";
     }
   }
   /*!

--- a/src/common/timer.h
+++ b/src/common/timer.h
@@ -27,7 +27,9 @@ struct Timer {
   void Stop() { elapsed += ClockT::now() - start; }
   double ElapsedSeconds() const { return SecondsT(elapsed).count(); }
   void PrintElapsed(std::string label) {
-    printf("%s:\t %fs\n", label.c_str(), SecondsT(elapsed).count());
+    char buffer[255];
+    snprintf(buffer, 255, "%s:\t %fs", label.c_str(), SecondsT(elapsed).count());
+    LOG(CONSOLE) << buffer;
     Reset();
   }
 };
@@ -50,9 +52,7 @@ struct Monitor {
   ~Monitor() {
     if (!debug_verbose) return;
 
-    std::cout << "========\n";
-    std::cout << "Monitor: " << label << "\n";
-    std::cout << "========\n";
+    LOG(CONSOLE) << "======== Monitor: " << label << " ========";
     for (auto &kv : timer_map) {
       kv.second.PrintElapsed(kv.first);
     }

--- a/src/common/timer.h
+++ b/src/common/timer.h
@@ -28,7 +28,7 @@ struct Timer {
   double ElapsedSeconds() const { return SecondsT(elapsed).count(); }
   void PrintElapsed(std::string label) {
     char buffer[255];
-    snprintf(buffer, 255, "%s:\t %fs", label.c_str(), SecondsT(elapsed).count());
+    snprintf(buffer, sizeof(buffer), "%s:\t %fs", label.c_str(), SecondsT(elapsed).count());
     LOG(CONSOLE) << buffer;
     Reset();
   }


### PR DESCRIPTION
Submission of the R package to CRAN forbids the use of std::cout #2960, #3061. All the console output needs to go through the LOG facilities which are then captured in https://github.com/dmlc/xgboost/blob/master/R-package/src/xgboost_custom.cc

I did the change in a couple of files that are currently included in the R package submission to CRAN. @RAMitchell There's still some cout use in device_helpers.cuh and updater_gpu_hist.cu that should be preferably also changed to LOG. If there is interest, I can define, e.g., LOG_VERBATIM in https://github.com/dmlc/xgboost/blob/master/include/xgboost/logging.h that would allow using LOG(VERBATIM) very much as cout (it would not prefix its output with timestamp even when XGBOOST_LOG_WITH_TIME is defined, and would not have automatic newline).