### PR TITLE
[core] fix slow predict-caching with many classes

### DIFF
--- a/cmake/modules/FindLibR.cmake
+++ b/cmake/modules/FindLibR.cmake
@@ -117,7 +117,7 @@ else()
     # ask R for R_HOME 
     if(LIBR_EXECUTABLE)
       execute_process(
-        COMMAND ${LIBR_EXECUTABLE} "--slave" "--no-save" "-e" "cat(normalizePath(R.home(), winslash='/'))"
+        COMMAND ${LIBR_EXECUTABLE} "--slave" "--no-save" "-e" "cat(normalizePath(R.home(),winslash='/'))"
         OUTPUT_VARIABLE LIBR_HOME)
     endif()
     # if R executable not available, query R_HOME path from registry

--- a/src/objective/regression_obj.cc
+++ b/src/objective/regression_obj.cc
@@ -56,7 +56,7 @@ class RegLossObj : public ObjFunction {
     int nthread = omp_get_max_threads();
     // Use a maximum of 8 threads
 #pragma omp parallel for schedule(static) num_threads(std::min(8, nthread))
-    for (int i = 0; i < n - remainder; i += 8) {
+    for (omp_ulong i = 0; i < n - remainder; i += 8) {
       avx::Float8 y(&info.labels[i]);
       avx::Float8 p = Loss::PredTransform(avx::Float8(&preds[i]));
       avx::Float8 w = info.weights.empty() ? avx::Float8(1.0f)

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -100,12 +100,8 @@ class CPUPredictor : public Predictor {
                         const gbm::GBTreeModel& model, int tree_begin,
                         unsigned ntree_limit) {
     // TODO(Rory): Check if this specialisation actually improves performance
-    if (model.param.num_output_group == 1) {
-      PredLoopSpecalize(dmat, out_preds, model, 1, tree_begin, ntree_limit);
-    } else {
-      PredLoopSpecalize(dmat, out_preds, model, model.param.num_output_group,
-                        tree_begin, ntree_limit);
-    }
+    PredLoopSpecalize(dmat, out_preds, model, model.param.num_output_group,
+                      tree_begin, ntree_limit);
   }
 
  public:
@@ -132,10 +128,9 @@ class CPUPredictor : public Predictor {
     this->PredLoopInternal(dmat, out_preds, model, tree_begin, ntree_limit);
   }
 
-  void UpdatePredictionCache(
-      const gbm::GBTreeModel& model,
-      std::vector<std::unique_ptr<TreeUpdater>>* updaters,
-      int num_new_trees) override {
+  void UpdatePredictionCache(const gbm::GBTreeModel& model,
+                             std::vector<std::unique_ptr<TreeUpdater>>* updaters,
+                             int num_new_trees) override {
     int old_ntree = model.trees.size() - num_new_trees;
     // update cache entry
     for (auto& kv : cache_) {


### PR DESCRIPTION
Addresses the issue of the O(num_class^2) prediction cache behavior #1689, #2926 where cache updates within CommitModel may start dominating with many classes. The reason was that the cache was updated for each single class group commit in a boosting round. E.g., with
```R
set.seed(1)
n <- 1e4
num_feat <- 200
num_class <- 150
y <- apply(rmultinom(n, 1, rep(1, num_class)), 2, function(yy) which(yy != 0)) - 1
dtr <- xgb.DMatrix(matrix(rnorm(n*num_feat), n, num_feat), label = y)
param <- list(objective='multi:softprob', num_class=num_class, debug_verbose=1,
              tree_method='hist', subsample=0.6)
bst <- xgb.train(param, data=dtr, nrounds=1)
rm(bst)
gc()
```
the timing result before (note that no watchlist was used, and using it would make caching even slower):
```
[16:21:50] ======== Monitor: GBTree ========
[16:21:50] BoostNewTrees:	 6.436368s
[16:21:50] CommitModel:	 10.707612s
```
and after the fix:
```
[16:22:51] ======== Monitor: GBTree ========
[16:22:51] BoostNewTrees:	 6.497372s
[16:22:51] CommitModel:	 0.109006s
```

Some minor changes:
- remove redundant 'if' in cpu_predictor
- get rid of compiler warnings
- make R on windows not to complain about configure script by providing an empty configure.win
- workaround for R v3.4.3 bug #3081