### PR TITLE
Specify a value for num_class even if n_classes_ <= 2

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -465,6 +465,8 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         if self.n_classes_ > 2:
             # Switch to using a multiclass objective in the underlying XGB instance
             xgb_options["objective"] = "multi:softprob"
+
+        if self.n_classes_ >= 2:
             xgb_options['num_class'] = self.n_classes_
 
         feval = eval_metric if callable(eval_metric) else None


### PR DESCRIPTION
The error message produced was:
`xgboost.core.XGBoostError: value 0for Parameter num_class should be greater equal to 1`
This was due to not specifying a value for num_class.

The fix moves the setting of num_class out of the if statement.