### PR TITLE
fix issue #3140: fix early stopping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@ XGBoost Change Log
 ==================
 
 This file records the changes in xgboost library in reverse chronological order.
-
+ 
 *  BREAKING CHANGES: Updated linear modelling algorithms. In particular L1/L2 regularisation penalties are now normalised to number of training examples. This makes the implementation consistent with sklearn/glmnet. L2 regularisation has also been removed from the intercept. To produce linear models with the old regularisation behaviour, the alpha/lambda regularisation parameters can be manually scaled by dividing them by the number of training examples.
 
 ## v0.7 (2017.12.30)

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -197,13 +197,13 @@ public class XGBoost {
           metrics[i][iter] = metricsOut[i];
         }
 
-        boolean decreasing = true;
+        boolean decreasing = false;
         float[] criterion = metrics[metrics.length - 1];
         for (int shift = 0; shift < Math.min(iter, earlyStoppingRound) - 1; shift++) {
-          decreasing &= criterion[iter - shift] <= criterion[iter - shift - 1];
+          decreasing |= criterion[iter - shift] <= criterion[iter - shift - 1];
         }
 
-        if (!decreasing) {
+        if (!decreasing && earlyStoppingRound > 0) {
           Rabit.trackerPrint(String.format(
                   "early stopping after %d decreasing rounds", earlyStoppingRound));
           break;

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
@@ -176,8 +176,14 @@ public class BoosterImplTest {
 
     // Make sure we've stopped early.
     for (int w = 0; w < watches.size(); w++) {
-      for (int r = earlyStoppingRound + 1; r < round; r++) {
+      for (int r = earlyStoppingRound; r < round; r++) {
         TestCase.assertEquals(0.0f, metrics[w][r]);
+      }
+    }
+    // Make sure we've not stopped too early
+    for (int w = 0; w < watches.size(); w++) {
+      for (int r = 0; r < earlyStoppingRound; r++) {
+        TestCase.assertNotSame(0.0f, metrics[w][r]);
       }
     }
   }


### PR DESCRIPTION
Fixing the unit test for early stopping, and then fixed the actual early stopping code to make the new unit test pass. This is to fix: https://github.com/dmlc/xgboost/issues/3140