### PR TITLE
Handle an edge case for monotonic 'hist'

### DIFF
--- a/doc/tutorials/monotonic.md
+++ b/doc/tutorials/monotonic.md
@@ -77,7 +77,7 @@ Some other examples:
 - ```(1,0)```: An increasing constraint on the first predictor and no constraint on the second.
 - ```(0,-1)```: No constraint on the first predictor and a decreasing constraint on the second.
 
-**Choise of tree construction algorithm**. To use monotonic constraints, be
+**Choice of tree construction algorithm**. To use monotonic constraints, be
 sure to set the `tree_method` parameter to one of `'exact'`, `'hist'`, and
 `'gpu_hist'`.
 


### PR DESCRIPTION
This is a follow-up of PR #3085.

When monotonic constraints are applied in conjunction with the 'hist' algorithm, it is often the case that all valid split candidates (those satisfying the monotonic constraints) result in negative loss change. This commit handles this edge case correctly, by refusing to split when any valid split results in negative loss change.

See discussion at https://github.com/dmlc/xgboost/pull/3085#pullrequestreview-100365400 for more details.

TODO: create a test case demonstrating the edge case.