### PR TITLE
Fix bug with gpu_predictor caching behaviour

### DIFF
--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -1,5 +1,4 @@
 import numpy as np
-import random
 import xgboost as xgb
 import testing as tm
 from nose.tools import raises

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -91,10 +91,6 @@ def test_feature_importances():
     xgb_model = xgb.XGBClassifier(seed=0).fit(X, y)
     np.testing.assert_almost_equal(xgb_model.feature_importances_, exp)
 
-    # string columns, the feature order must be kept
-    chars = list('abcdefghijklmnopqrstuvwxyz')
-    X.columns = ["".join(random.sample(chars, 5)) for x in range(64)]
-
     xgb_model = xgb.XGBClassifier(seed=0).fit(X, y)
     np.testing.assert_almost_equal(xgb_model.feature_importances_, exp)
 


### PR DESCRIPTION
Restrict the gpu_predictor to only caching matrices also stored in the host DMatrix cache. This guarantees a matrix cached on the device will always have a valid pointer to a DMatrix on the host.

This fixes #3162, which was caused by the DMatrix being deleted on the host but the gpu_predictor was still dereferencing its pointer.