### PR TITLE
Improve .gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,6 @@ Debug
 *.cpage.col
 *.cpage
 *.Rproj
-./xgboost
 ./xgboost.mpi
 ./xgboost.mock
 #.Rbuildignore
@@ -68,7 +67,7 @@ nb-configuration*
 .settings/
 build
 config.mk
-xgboost
+/xgboost
 *.data
 build_plugin
 dmlc-core

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 *.Rcheck
 *.rds
 *.tar.gz
-#*txt*
 *conf
 *buffer
 *model
@@ -52,7 +51,7 @@ Debug
 #.Rbuildignore
 R-package.Rproj
 *.cache*
-#java
+# java
 java/xgboost4j/target
 java/xgboost4j/tmp
 java/xgboost4j-demo/target

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,6 @@ config.mk
 /xgboost
 *.data
 build_plugin
-dmlc-core
 .idea
 recommonmark/
 tags


### PR DESCRIPTION
In particular, the patterns involving 'xgboost' seemed overly broad. We shouldn't ignore /include/xgboost, I think.