### PR TITLE
'hist': improved subsampling

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -292,6 +292,15 @@ class DMatrix {
   virtual float GetColDensity(size_t cidx) const = 0;
   /*! \return reference of buffered rowset, in column access */
   virtual const RowSet& buffered_rowset() const = 0;
+  // get subsampled indices.
+  virtual std::vector<uint64_t> get_subsampled_indices(
+      const float subsample,
+      const std::vector<xgboost::bst_gpair>& gpair
+  ) {
+      std::vector<uint64_t> subsampled_indices;
+      return subsampled_indices;
+  };
+
   /*! \brief virtual destructor */
   virtual ~DMatrix() {}
   /*!

--- a/src/tree/updater_fast_hist.cc
+++ b/src/tree/updater_fast_hist.cc
@@ -339,7 +339,7 @@ class FastHistMaker: public TreeUpdater {
     // initialize temp data structure
     inline void InitData(const GHistIndexMatrix& gmat,
                          const std::vector<bst_gpair>& gpair,
-                         const DMatrix& fmat,
+                         DMatrix& fmat,
                          const RegTree& tree) {
       CHECK_EQ(tree.param.num_nodes, tree.param.num_roots)
           << "ColMakerHist: can only grow new tree";
@@ -372,13 +372,9 @@ class FastHistMaker: public TreeUpdater {
         std::vector<size_t>& row_indices = row_set_collection_.row_indices_;
         // mark subsample and build list of member rows
         if (param.subsample < 1.0f) {
-          std::bernoulli_distribution coin_flip(param.subsample);
-          auto& rnd = common::GlobalRandom();
-          for (size_t i = 0; i < info.num_row; ++i) {
-            if (gpair[i].GetHess() >= 0.0f && coin_flip(rnd)) {
-              row_indices.push_back(i);
-            }
-          }
+            row_indices = fmat.get_subsampled_indices(
+                param.subsample, gpair
+            );
         } else {
           for (size_t i = 0; i < info.num_row; ++i) {
             if (gpair[i].GetHess() >= 0.0f) {


### PR DESCRIPTION
The current subsampling approach used in xgboost is;

1. computationally inefficient.
2. highly dependent on the seed; specifically, certain seeds could lead to massive oversampling/undersampling.
3. unaligned with the documentation; specifically in the parameters section of the docs it (incorrectly) states;

"subsample [default=1]
subsample ratio of the training instance. Setting it to 0.5 means that XGBoost randomly collected half of the data instances to grow trees".

I would like to replace the approach with an approach that doesn't suffer these drawbacks; in particular I think it should be possible to apply the following idea;

1. do one step of a Fisher-Yates shuffle.
2. calculate the statistics of the first subsampled point.
3. if the hessian is positive then include this point as a datapoint.
4. repeat.

This will avoid the need to calculate and query the statistics for each datapoint; thereby reducing a, per tree, O(number of datapoints) operation to a, per tree, O(subsample size) operation.

I've already added some code in this pull request which implements the Fisher-Yates shuffle. However, elsewhere, the code still needs to be changed so that the statistics (the hessian and gradient) aren't calculated for each datapoint and only calculated on the fly to get the indices that are part of the subsample. 

I need help- from someone who knows the codebase in depth- for this last part because I'm not 100% sure on where/how best to do this (@khotilov @hcho3).