### PR TITLE
Fix up `make pippack` command for building source package for PyPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,11 @@ endif
 clean:
 	$(RM) -rf build build_plugin lib bin *~ */*~ */*/*~ */*/*/*~ */*.o */*/*.o */*/*/*.o #xgboost
 	$(RM) -rf build_tests *.gcov tests/cpp/xgboost_test
-	cd R-package/src; $(RM) -rf rabit src include dmlc-core amalgamation *.so *.dll; cd $(ROOTDIR)
+	if [ -d "R-package/src" ]; then \
+		cd R-package/src; \
+		$(RM) -rf rabit src include dmlc-core amalgamation *.so *.dll; \
+		cd $(ROOTDIR); \
+	fi
 
 clean_all: clean
 	cd $(DMLC_CORE); "$(MAKE)" clean; cd $(ROOTDIR)
@@ -212,16 +216,28 @@ pypack: ${XGBOOST_DYLIB}
 	cp ${XGBOOST_DYLIB} python-package/xgboost
 	cd python-package; tar cf xgboost.tar xgboost; cd ..
 
-# create pip installation pack for PyPI
+# create pip source dist (sdist) pack for PyPI
 pippack: clean_all
 	rm -rf xgboost-python
+# remove symlinked directories in python-package/xgboost
+	rm -rf python-package/xgboost/lib
+	rm -rf python-package/xgboost/dmlc-core
+	rm -rf python-package/xgboost/include
+	rm -rf python-package/xgboost/make
+	rm -rf python-package/xgboost/rabit
+	rm -rf python-package/xgboost/src
 	cp -r python-package xgboost-python
 	cp -r Makefile xgboost-python/xgboost/
 	cp -r make xgboost-python/xgboost/
 	cp -r src xgboost-python/xgboost/
+	cp -r tests xgboost-python/xgboost/
 	cp -r include xgboost-python/xgboost/
 	cp -r dmlc-core xgboost-python/xgboost/
 	cp -r rabit xgboost-python/xgboost/
+# Use setup_pip.py instead of setup.py
+	mv xgboost-python/setup_pip.py xgboost-python/setup.py
+# Build sdist tarball
+	cd xgboost-python; python setup.py sdist; mv dist/*.tar.gz ..; cd ..
 
 # Script to make a clean installable R package.
 Rpack: clean_all

--- a/python-package/setup_pip.py
+++ b/python-package/setup_pip.py
@@ -12,7 +12,10 @@ sys.path.insert(0, '.')
 # please don't use this file for installing from github
 
 if os.name != 'nt':     # if not windows, compile and install
-    os.system('sh ./xgboost/build-python.sh')
+    # if not windows, compile and install
+    if len(sys.argv) < 2 or sys.argv[1] != 'sdist':
+        # do not build for sdist
+        os.system('sh ./xgboost/build-python.sh')
 else:
     print('Windows users please use github installation.')
     sys.exit()
@@ -30,16 +33,14 @@ class BinaryDistribution(Distribution):
 # We can not import `xgboost.libpath` in setup.py directly since xgboost/__init__.py
 # import `xgboost.core` and finally will import `numpy` and `scipy` which are setup
 # `install_requires`. That's why we're using `exec` here.
-libpath_py = os.path.join(CURRENT_DIR, 'xgboost/libpath.py')
-libpath = {'__file__': libpath_py}
-exec(compile(open(libpath_py, "rb").read(), libpath_py, 'exec'), libpath, libpath)
+# do not import libpath for sdist
+if len(sys.argv) < 2 or sys.argv[1] != 'sdist':
+    libpath_py = os.path.join(CURRENT_DIR, 'xgboost/libpath.py')
+    libpath = {'__file__': libpath_py}
+    exec(compile(open(libpath_py, "rb").read(), libpath_py, 'exec'), libpath, libpath)
 
-LIB_PATH = libpath['find_lib_path']()
+    LIB_PATH = libpath['find_lib_path']()
 
-# to deploy to pip, please use
-# make pythonpack
-# python setup.py register sdist upload
-# and be sure to test it firstly using "python setup.py register sdist upload -r pypitest"
 setup(name='xgboost',
       version=open(os.path.join(CURRENT_DIR, 'xgboost/VERSION')).read().strip(),
       description='XGBoost Python Package',

--- a/python-package/xgboost/build-python.sh
+++ b/python-package/xgboost/build-python.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This is a simple script to make xgboost in MAC and Linux for python wrapper only
 # Basically, it first try to make with OpenMP, if fails, disable OpenMP and make it again.
 # This will automatically make xgboost for MAC users who don't have OpenMP support.
@@ -9,22 +9,44 @@
 # note: this script is build for python package only, and it might have some filename
 #       conflict with build.sh which is for everything. 
 
+set -e
+set -x
 
 #pushd xgboost
 oldpath=`pwd`
 cd ./xgboost/
+
+if echo "${OSTYPE}" | grep -q "darwin"; then
+  LIB_XGBOOST=libxgboost.dylib
+  # Use OpenMP-capable compiler if possible
+  if which g++-5; then
+    export CC=gcc-5
+    export CXX=g++-5
+  elif which g++-7; then
+    export CC=gcc-7
+    export CXX=g++-7
+  elif which clang++; then
+    export CC=clang
+    export CXX=clang++
+  fi
+else
+  LIB_XGBOOST=libxgboost.so
+fi
+
 #remove the pre-compiled .so and trigger the system's on-the-fly compiling
 make clean
-if make lib/libxgboost.so -j4; then
+if make lib/${LIB_XGBOOST} -j4; then
     echo "Successfully build multi-thread xgboost"
 else
     echo "-----------------------------"
     echo "Building multi-thread xgboost failed"
     echo "Start to build single-thread xgboost"
     make clean
-    make lib/libxgboost.so -j4 USE_OPENMP=0
+    make lib/${LIB_XGBOOST} -j4 USE_OPENMP=0
     echo "Successfully build single-thread xgboost"
     echo "If you want multi-threaded version"
     echo "See additional instructions in doc/build.md"
 fi
 cd $oldpath
+
+set +x


### PR DESCRIPTION
* Now `make pippack` works without any manual action: it will produce `xgboost-[version].tar.gz`, which one can use by typing `pip3 install xgboost-[version].tar.gz`. I tested it on MacOS and Linux.
* Detect OpenMP-capable compilers (clang, gcc-5, gcc-7) on MacOS

This PR will fix recent reports of failed installation on MacOS, such as #3118, #3194, #2426, provided that a new release is issued using `make pippack`. I plan to make release 0.71 once this is merged.