### PR TITLE
Update dmlc-core submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ endif()
 
 # dmlc-core
 add_subdirectory(dmlc-core)
-set(LINK_LIBRARIES dmlccore rabit)
+set(LINK_LIBRARIES dmlc rabit)
 
 
 if(USE_CUDA)

--- a/amalgamation/dmlc-minimum0.cc
+++ b/amalgamation/dmlc-minimum0.cc
@@ -7,6 +7,8 @@
 #include "../dmlc-core/src/io/recordio_split.cc"
 #include "../dmlc-core/src/io/input_split_base.cc"
 #include "../dmlc-core/src/io/local_filesys.cc"
+#include "../dmlc-core/src/io/filesys.cc"
+#include "../dmlc-core/src/io/indexed_recordio_split.cc"
 #include "../dmlc-core/src/data.cc"
 #include "../dmlc-core/src/io.cc"
 #include "../dmlc-core/src/recordio.cc"

--- a/plugin/dense_parser/dense_libsvm.cc
+++ b/plugin/dense_parser/dense_libsvm.cc
@@ -69,7 +69,7 @@ class DensifyParser : public dmlc::Parser<IndexType> {
   std::vector<xgboost::bst_float> dense_value_;
 };
 
-template<typename IndexType>
+template<typename IndexType, typename DType = real_t>
 Parser<IndexType> *
 CreateDenseLibSVMParser(const std::string& path,
                         const std::map<std::string, std::string>& args,
@@ -82,5 +82,6 @@ CreateDenseLibSVMParser(const std::string& path,
 }
 }  // namespace data
 
-DMLC_REGISTER_DATA_PARSER(uint32_t, dense_libsvm, data::CreateDenseLibSVMParser<uint32_t>);
+DMLC_REGISTER_DATA_PARSER(uint32_t, real_t, dense_libsvm,
+  data::CreateDenseLibSVMParser<uint32_t __DMLC_COMMA real_t>);
 }  // namespace dmlc

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -118,7 +118,7 @@ if [ ${TASK} == "cmake_test" ]; then
 
     # Build/test without AVX
     mkdir build && cd build
-    cmake .. -DGOOGLE_TEST=ON
+    cmake .. -DGOOGLE_TEST=ON -DGTEST_ROOT=../gtest/
     make
     cd ..
     ./testxgboost
@@ -126,7 +126,7 @@ if [ ${TASK} == "cmake_test" ]; then
     
     # Build/test with AVX
     mkdir build && cd build
-    cmake .. -DGOOGLE_TEST=ON -DUSE_AVX=ON
+    cmake .. -DGOOGLE_TEST=ON -DUSE_AVX=ON -DGTEST_ROOT=../gtest/
     make
     cd ..
     ./testxgboost


### PR DESCRIPTION
This is a follow-up of #3215. Updating the dmlc-core submodule lets XGBoost take advantage of fixes applied to the CSV parser.

Ideally, I'd like to see https://github.com/dmlc/dmlc-core/pull/385 to be merged before this PR gets approved.