### PR TITLE
Fix for the issue #3264.

### DIFF
--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -37,9 +37,9 @@ __device__ GradientPairSumT ReduceFeature(const GradientPairSumT* begin,
     bool thread_active = itr + threadIdx.x < end;
     // Scan histogram
     GradientPairSumT bin = thread_active ? *(itr + threadIdx.x) : GradientPairSumT();
-
-    local_sum += ReduceT(temp_storage->sum_reduce).Reduce(bin, cub::Sum());
+    local_sum += bin;
   }
+  local_sum = ReduceT(temp_storage->sum_reduce).Reduce(local_sum, cub::Sum());
 
   if (threadIdx.x == 0) {
     shared_sum = local_sum;


### PR DESCRIPTION
Performing cub reduction inside a loop, using temporary shared memory location, without a barrier between successive calls was causing race conditions on K80/K40 cards. Not sure why this hasn't been a problem on Maxwell/Pascal/Volta! See the Issue #3264 for the root-cause and the final output after this fix.