### PR TITLE
Fix tweedie handling of base_score

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -75,3 +75,4 @@ List of Contributors
 * [Andrew Hannigan](https://github.com/andrewhannigan)
 * [Andy Adinets](https://github.com/canonizer)
 * [Henry Gouk](https://github.com/henrygouk)
+* [Pierre de Sahb](https://github.com/pdesahb)

--- a/src/objective/regression_obj.cc
+++ b/src/objective/regression_obj.cc
@@ -394,6 +394,11 @@ class TweedieRegression : public ObjFunction {
       preds[j] = std::exp(preds[j]);
     }
   }
+
+  bst_float ProbToMargin(bst_float base_score) const override {
+    return std::log(base_score);
+  }
+
   const char* DefaultEvalMetric() const override {
     std::ostringstream os;
     os << "tweedie-nloglik@" << param_.tweedie_variance_power;

--- a/tests/cpp/objective/test_regression_obj.cc
+++ b/tests/cpp/objective/test_regression_obj.cc
@@ -163,9 +163,9 @@ TEST(Objective, TweedieRegressionBasic) {
     << "Expected error when label < 0 for TweedieRegression";
 
   // test ProbToMargin
-  EXPECT_NEAR(obj->ProbToMargin(0.1f), 0.10f, 0.01f);
-  EXPECT_NEAR(obj->ProbToMargin(0.5f), 0.5f, 0.01f);
-  EXPECT_NEAR(obj->ProbToMargin(0.9f), 0.89f, 0.01f);
+  EXPECT_NEAR(obj->ProbToMargin(0.1f), -2.30f, 0.01f);
+  EXPECT_NEAR(obj->ProbToMargin(0.5f), -0.69f, 0.01f);
+  EXPECT_NEAR(obj->ProbToMargin(0.9f), -0.10f, 0.01f);
 
   // test PredTransform
   xgboost::HostDeviceVector<xgboost::bst_float> io_preds = {0, 0.1f, 0.5f, 0.9f, 1};


### PR DESCRIPTION
Unlike `reg:poisson`, the `ProbToMargin` function for `TweedieRegression` was not defined so the `base_score` was not passed through a `std::log`.
