### PR TITLE
Increase precision of bst_float values in tree dumps

### DIFF
--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -5,6 +5,8 @@
  */
 #include <xgboost/tree_model.h>
 #include <sstream>
+#include <limits>
+#include <iomanip>
 #include "./param.h"
 
 namespace xgboost {
@@ -20,6 +22,7 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
                  const FeatureMap& fmap,
                  int nid, int depth, int add_comma,
                  bool with_stats, std::string format) {
+  int floatMaxPrecision = std::numeric_limits<bst_float>::max_digits10;
   if (format == "json") {
     if (add_comma) {
       fo << ",";
@@ -38,15 +41,15 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
   if (tree[nid].IsLeaf()) {
     if (format == "json") {
       fo << "{ \"nodeid\": " << nid
-         << ", \"leaf\": " << tree[nid].LeafValue();
+         << ", \"leaf\": " << std::setprecision(floatMaxPrecision) << tree[nid].LeafValue();
       if (with_stats) {
-        fo << ", \"cover\": " << tree.Stat(nid).sum_hess;
+        fo << ", \"cover\": " << std::setprecision(floatMaxPrecision) << tree.Stat(nid).sum_hess;
       }
       fo << " }";
     } else {
-      fo << nid << ":leaf=" << tree[nid].LeafValue();
+      fo << nid << ":leaf=" << std::setprecision(floatMaxPrecision) << tree[nid].LeafValue();
       if (with_stats) {
-        fo << ",cover=" << tree.Stat(nid).sum_hess;
+        fo << ",cover=" << std::setprecision(floatMaxPrecision) << tree.Stat(nid).sum_hess;
       }
       fo << '\n';
     }
@@ -95,12 +98,12 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
             fo << "{ \"nodeid\": " << nid
                << ", \"depth\": " << depth
                << ", \"split\": \"" << fmap.Name(split_index) << "\""
-               << ", \"split_condition\": " << cond
+               << ", \"split_condition\": " << std::setprecision(floatMaxPrecision) << cond
                << ", \"yes\": " << tree[nid].LeftChild()
                << ", \"no\": " << tree[nid].RightChild()
                << ", \"missing\": " << tree[nid].DefaultChild();
           } else {
-            fo << nid << ":[" << fmap.Name(split_index) << "<" << cond
+            fo << nid << ":[" << std::setprecision(floatMaxPrecision) << fmap.Name(split_index) << "<" << cond
                << "] yes=" << tree[nid].LeftChild()
                << ",no=" << tree[nid].RightChild()
                << ",missing=" << tree[nid].DefaultChild();
@@ -114,12 +117,12 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
         fo << "{ \"nodeid\": " << nid
            << ", \"depth\": " << depth
            << ", \"split\": " << split_index
-           << ", \"split_condition\": " << cond
+           << ", \"split_condition\": " << std::setprecision(floatMaxPrecision) << cond
            << ", \"yes\": " << tree[nid].LeftChild()
            << ", \"no\": " << tree[nid].RightChild()
            << ", \"missing\": " << tree[nid].DefaultChild();
       } else {
-        fo << nid << ":[f" << split_index << "<"<< cond
+        fo << nid << ":[f" << split_index << "<"<< std::setprecision(floatMaxPrecision) << cond
            << "] yes=" << tree[nid].LeftChild()
            << ",no=" << tree[nid].RightChild()
            << ",missing=" << tree[nid].DefaultChild();
@@ -127,10 +130,11 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
     }
     if (with_stats) {
       if (format == "json") {
-        fo << ", \"gain\": " << tree.Stat(nid).loss_chg
-           << ", \"cover\": " << tree.Stat(nid).sum_hess;
+        fo << ", \"gain\": " << std::setprecision(floatMaxPrecision) << tree.Stat(nid).loss_chg
+           << ", \"cover\": " << std::setprecision(floatMaxPrecision) << tree.Stat(nid).sum_hess;
       } else {
-        fo << ",gain=" << tree.Stat(nid).loss_chg << ",cover=" << tree.Stat(nid).sum_hess;
+        fo << ",gain=" << std::setprecision(floatMaxPrecision) << tree.Stat(nid).loss_chg
+           << ",cover=" << std::setprecision(floatMaxPrecision) << tree.Stat(nid).sum_hess;
       }
     }
     if (format == "json") {

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -103,7 +103,8 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
                << ", \"no\": " << tree[nid].RightChild()
                << ", \"missing\": " << tree[nid].DefaultChild();
           } else {
-            fo << nid << ":[" << std::setprecision(floatMaxPrecision) << fmap.Name(split_index) << "<" << cond
+            fo << nid << ":[" << fmap.Name(split_index)
+               << "<" << std::setprecision(floatMaxPrecision) << cond
                << "] yes=" << tree[nid].LeftChild()
                << ",no=" << tree[nid].RightChild()
                << ",missing=" << tree[nid].DefaultChild();

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -22,7 +22,7 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
                  const FeatureMap& fmap,
                  int nid, int depth, int add_comma,
                  bool with_stats, std::string format) {
-  int floatMaxPrecision = std::numeric_limits<bst_float>::max_digits10;
+  int float_max_precision = std::numeric_limits<bst_float>::max_digits10;
   if (format == "json") {
     if (add_comma) {
       fo << ",";
@@ -41,15 +41,15 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
   if (tree[nid].IsLeaf()) {
     if (format == "json") {
       fo << "{ \"nodeid\": " << nid
-         << ", \"leaf\": " << std::setprecision(floatMaxPrecision) << tree[nid].LeafValue();
+         << ", \"leaf\": " << std::setprecision(float_max_precision) << tree[nid].LeafValue();
       if (with_stats) {
-        fo << ", \"cover\": " << std::setprecision(floatMaxPrecision) << tree.Stat(nid).sum_hess;
+        fo << ", \"cover\": " << std::setprecision(float_max_precision) << tree.Stat(nid).sum_hess;
       }
       fo << " }";
     } else {
-      fo << nid << ":leaf=" << std::setprecision(floatMaxPrecision) << tree[nid].LeafValue();
+      fo << nid << ":leaf=" << std::setprecision(float_max_precision) << tree[nid].LeafValue();
       if (with_stats) {
-        fo << ",cover=" << std::setprecision(floatMaxPrecision) << tree.Stat(nid).sum_hess;
+        fo << ",cover=" << std::setprecision(float_max_precision) << tree.Stat(nid).sum_hess;
       }
       fo << '\n';
     }
@@ -98,13 +98,13 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
             fo << "{ \"nodeid\": " << nid
                << ", \"depth\": " << depth
                << ", \"split\": \"" << fmap.Name(split_index) << "\""
-               << ", \"split_condition\": " << std::setprecision(floatMaxPrecision) << cond
+               << ", \"split_condition\": " << std::setprecision(float_max_precision) << cond
                << ", \"yes\": " << tree[nid].LeftChild()
                << ", \"no\": " << tree[nid].RightChild()
                << ", \"missing\": " << tree[nid].DefaultChild();
           } else {
             fo << nid << ":[" << fmap.Name(split_index)
-               << "<" << std::setprecision(floatMaxPrecision) << cond
+               << "<" << std::setprecision(float_max_precision) << cond
                << "] yes=" << tree[nid].LeftChild()
                << ",no=" << tree[nid].RightChild()
                << ",missing=" << tree[nid].DefaultChild();
@@ -118,12 +118,12 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
         fo << "{ \"nodeid\": " << nid
            << ", \"depth\": " << depth
            << ", \"split\": " << split_index
-           << ", \"split_condition\": " << std::setprecision(floatMaxPrecision) << cond
+           << ", \"split_condition\": " << std::setprecision(float_max_precision) << cond
            << ", \"yes\": " << tree[nid].LeftChild()
            << ", \"no\": " << tree[nid].RightChild()
            << ", \"missing\": " << tree[nid].DefaultChild();
       } else {
-        fo << nid << ":[f" << split_index << "<"<< std::setprecision(floatMaxPrecision) << cond
+        fo << nid << ":[f" << split_index << "<"<< std::setprecision(float_max_precision) << cond
            << "] yes=" << tree[nid].LeftChild()
            << ",no=" << tree[nid].RightChild()
            << ",missing=" << tree[nid].DefaultChild();
@@ -131,11 +131,11 @@ void DumpRegTree(std::stringstream& fo,  // NOLINT(*)
     }
     if (with_stats) {
       if (format == "json") {
-        fo << ", \"gain\": " << std::setprecision(floatMaxPrecision) << tree.Stat(nid).loss_chg
-           << ", \"cover\": " << std::setprecision(floatMaxPrecision) << tree.Stat(nid).sum_hess;
+        fo << ", \"gain\": " << std::setprecision(float_max_precision) << tree.Stat(nid).loss_chg
+           << ", \"cover\": " << std::setprecision(float_max_precision) << tree.Stat(nid).sum_hess;
       } else {
-        fo << ",gain=" << std::setprecision(floatMaxPrecision) << tree.Stat(nid).loss_chg
-           << ",cover=" << std::setprecision(floatMaxPrecision) << tree.Stat(nid).sum_hess;
+        fo << ",gain=" << std::setprecision(float_max_precision) << tree.Stat(nid).loss_chg
+           << ",cover=" << std::setprecision(float_max_precision) << tree.Stat(nid).sum_hess;
       }
     }
     if (format == "json") {


### PR DESCRIPTION
`DumpRegTree` writes floats with default 6-digits precision which causes precision loss. 
This PR aims at setting the precision to a level where the conversion back to float is lossless.