### PR TITLE
Fix test_param.cc header path

### DIFF
--- a/tests/cpp/tree/test_param.cc
+++ b/tests/cpp/tree/test_param.cc
@@ -1,5 +1,5 @@
 // Copyright by Contributors
-#include "../../src/tree/param.h"
+#include "../../../src/tree/param.h"
 
 #include "../helpers.h"
 


### PR DESCRIPTION
Fix include path of tests/cpp/test_param.cc

Currently the build process can pass is because cmake adds -I<path-to>/dmlc-core/include compiler flag, which let "../../" accidentally becomes the root path of xgboost.