### PR TITLE
[jvm-packages] Refactor XGBoost-Spark params to make it compatible with both XGBoost and Spark MLLib

### DIFF
--- a/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/spark/SparkModelTuningTool.scala
+++ b/jvm-packages/xgboost4j-example/src/main/scala/ml/dmlc/xgboost4j/scala/example/spark/SparkModelTuningTool.scala
@@ -163,7 +163,7 @@ object SparkModelTuningTool {
     val xgbEstimator = new XGBoostRegressor(xgboostParam).setFeaturesCol("features").
       setLabelCol("logSales")
     val paramGrid = new ParamGridBuilder()
-      .addGrid(xgbEstimator.round, Array(20, 50))
+      .addGrid(xgbEstimator.numRound, Array(20, 50))
       .addGrid(xgbEstimator.eta, Array(0.1, 0.4))
       .build()
     val tv = new TrainValidationSplit()

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -133,7 +133,7 @@ object XGBoost extends Serializable {
         fromBaseMarginsToArray(baseMargins), cacheDirName)
 
       try {
-        val numEarlyStoppingRounds = params.get("numEarlyStoppingRounds")
+        val numEarlyStoppingRounds = params.get("num_early_stopping_rounds")
             .map(_.toString.toInt).getOrElse(0)
         val metrics = Array.tabulate(watches.size)(_ => Array.ofDim[Float](round))
         val booster = SXGBoost.train(watches.train, params, round,
@@ -313,7 +313,7 @@ private object Watches {
       labeledPoints: Iterator[XGBLabeledPoint],
       baseMarginsOpt: Option[Array[Float]],
       cacheDirName: Option[String]): Watches = {
-    val trainTestRatio = params.get("trainTestRatio").map(_.toString.toDouble).getOrElse(1.0)
+    val trainTestRatio = params.get("train_test_ratio").map(_.toString.toDouble).getOrElse(1.0)
     val seed = params.get("seed").map(_.toString.toLong).getOrElse(System.nanoTime())
     val r = new Random(seed)
     val testPoints = mutable.ArrayBuffer.empty[XGBLabeledPoint]
@@ -335,8 +335,8 @@ private object Watches {
     }
 
     // TODO: use group attribute from the points.
-    if (params.contains("groupData") && params("groupData") != null) {
-      trainMatrix.setGroup(params("groupData").asInstanceOf[Seq[Seq[Int]]](
+    if (params.contains("group_data") && params("group_data") != null) {
+      trainMatrix.setGroup(params("group_data").asInstanceOf[Seq[Seq[Int]]](
         TaskContext.getPartitionId()).toArray)
     }
     new Watches(trainMatrix, testMatrix, cacheDirName)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -39,7 +39,7 @@ import org.json4s.DefaultFormats
 import scala.collection.mutable
 
 private[spark] trait XGBoostRegressorParams extends GeneralParams with BoosterParams
-  with LearningTaskParams with HasBaseMarginCol with  HasWeightCol with ParamMapFuncs
+  with LearningTaskParams with HasBaseMarginCol with HasWeightCol with ParamMapFuncs
 
 class XGBoostRegressor (
     override val uid: String,

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -20,7 +20,7 @@ import scala.collection.JavaConverters._
 
 import ml.dmlc.xgboost4j.java.Rabit
 import ml.dmlc.xgboost4j.{LabeledPoint => XGBLabeledPoint}
-import ml.dmlc.xgboost4j.scala.spark.params.{DefaultXGBoostParamsReader, Utils, _}
+import ml.dmlc.xgboost4j.scala.spark.params.{DefaultXGBoostParamsReader, _}
 import ml.dmlc.xgboost4j.scala.{Booster, DMatrix, XGBoost => SXGBoost}
 
 import org.apache.hadoop.fs.Path
@@ -38,14 +38,14 @@ import org.json4s.DefaultFormats
 
 import scala.collection.mutable
 
-private[spark] trait XGBoostRegressorParams extends LearningTaskParams
-  with GeneralParams with BoosterParams with HasWeightCol
+private[spark] trait XGBoostRegressorParams extends GeneralParams with BoosterParams
+  with LearningTaskParams with HasBaseMarginCol with  HasWeightCol with ParamMapFuncs
 
 class XGBoostRegressor (
     override val uid: String,
     private val xgboostParams: Map[String, Any])
   extends Predictor[Vector, XGBoostRegressor, XGBoostRegressionModel]
-    with XGBoostRegressorParams with HasBaseMarginCol with MLWritable {
+    with XGBoostRegressorParams with DefaultParamsWritable {
 
   def this() = this(Identifiable.randomUID("xgbr"), Map[String, Any]())
 
@@ -54,46 +54,91 @@ class XGBoostRegressor (
   def this(xgboostParams: Map[String, Any]) = this(
     Identifiable.randomUID("xgbr"), xgboostParams)
 
+  XGBoostToMLlibParams(xgboostParams)
+
   def setWeightCol(value: String): this.type = set(weightCol, value)
 
   def setBaseMarginCol(value: String): this.type = set(baseMarginCol, value)
 
-  private def fromXGBParamMapToParams(): Unit = {
-    for ((paramName, paramValue) <- xgboostParams) {
-      params.find(_.name == paramName) match {
-        case None =>
-        case Some(_: DoubleParam) =>
-          set(paramName, paramValue.toString.toDouble)
-        case Some(_: BooleanParam) =>
-          set(paramName, paramValue.toString.toBoolean)
-        case Some(_: IntParam) =>
-          set(paramName, paramValue.toString.toInt)
-        case Some(_: FloatParam) =>
-          set(paramName, paramValue.toString.toFloat)
-        case Some(_: Param[_]) =>
-          set(paramName, paramValue)
-      }
-    }
-  }
+  // setters for general params
+  def setNumRound(value: Int): this.type = set(numRound, value)
 
-  fromXGBParamMapToParams()
+  def setNumWorkers(value: Int): this.type = set(numWorkers, value)
 
-  private[spark] def fromParamsToXGBParamMap: Map[String, Any] = {
-    val xgbParamMap = new mutable.HashMap[String, Any]()
-    for (param <- params) {
-      if (isDefined(param)) {
-        xgbParamMap += param.name -> $(param)
-      }
-    }
-    val r = xgbParamMap.toMap
-    r
-  }
+  def setNthread(value: Int): this.type = set(nthread, value)
+
+  def setUseExternalMemory(value: Boolean): this.type = set(useExternalMemory, value)
+
+  def setSilent(value: Int): this.type = set(silent, value)
+
+  def setMissing(value: Float): this.type = set(missing, value)
+
+  def setTimeoutRequestWorkers(value: Long): this.type = set(timeoutRequestWorkers, value)
+
+  def setCheckpointPath(value: String): this.type = set(checkpointPath, value)
+
+  def setCheckpointInterval(value: Int): this.type = set(checkpointInterval, value)
+
+  def setSeed(value: Long): this.type = set(seed, value)
+
+  // setters for booster params
+  def setBooster(value: String): this.type = set(booster, value)
+
+  def setEta(value: Double): this.type = set(eta, value)
+
+  def setGamma(value: Double): this.type = set(gamma, value)
+
+  def setMaxDepth(value: Int): this.type = set(maxDepth, value)
+
+  def setMinChildWeight(value: Double): this.type = set(minChildWeight, value)
+
+  def setMaxDeltaStep(value: Double): this.type = set(maxDeltaStep, value)
+
+  def setSubsample(value: Double): this.type = set(subsample, value)
+
+  def setColsampleBytree(value: Double): this.type = set(colsampleBytree, value)
+
+  def setColsampleBylevel(value: Double): this.type = set(colsampleBylevel, value)
+
+  def setLambda(value: Double): this.type = set(lambda, value)
+
+  def setAlpha(value: Double): this.type = set(alpha, value)
+
+  def setTreeMethod(value: String): this.type = set(treeMethod, value)
+
+  def setGrowPolicy(value: String): this.type = set(growPolicy, value)
+
+  def setMaxBins(value: Int): this.type = set(maxBins, value)
+
+  def setSketchEps(value: Double): this.type = set(sketchEps, value)
+
+  def setScalePosWeight(value: Double): this.type = set(scalePosWeight, value)
+
+  def setSampleType(value: String): this.type = set(sampleType, value)
+
+  def setNormalizeType(value: String): this.type = set(normalizeType, value)
+
+  def setRateDrop(value: Double): this.type = set(rateDrop, value)
+
+  def setSkipDrop(value: Double): this.type = set(skipDrop, value)
+
+  def setLambdaBias(value: Double): this.type = set(lambdaBias, value)
+
+  // setters for learning params
+  def setObjective(value: String): this.type = set(objective, value)
+
+  def setBaseScore(value: Double): this.type = set(baseScore, value)
+
+  def setEvalMetric(value: String): this.type = set(evalMetric, value)
+
+  def setTrainTestRatio(value: Double): this.type = set(trainTestRatio, value)
+
+  def setNumEarlyStoppingRounds(value: Int): this.type = set(numEarlyStoppingRounds, value)
 
   // called at the start of fit/train when 'eval_metric' is not defined
   private def setupDefaultEvalMetric(): String = {
-    val objFunc = xgboostParams("objective")
-    require(objFunc != null, "Users must set \'objective\' via xgboostParams.")
-    if (objFunc.toString.startsWith("rank")) {
+    require(isDefined(objective), "Users must set \'objective\' via xgboostParams.")
+    if ($(objective).startsWith("rank")) {
       "map"
     } else {
       "rmse"
@@ -102,8 +147,8 @@ class XGBoostRegressor (
 
   override protected def train(dataset: Dataset[_]): XGBoostRegressionModel = {
 
-    if (xgboostParams.get("eval_metric").isEmpty) {
-      set("eval_metric", setupDefaultEvalMetric())
+    if (!isDefined(evalMetric) || $(evalMetric).isEmpty) {
+      set(evalMetric, setupDefaultEvalMetric())
     }
 
     val weight = if (!isDefined(weightCol) || $(weightCol).isEmpty) lit(1.0) else col($(weightCol))
@@ -126,53 +171,23 @@ class XGBoostRegressor (
       XGBLabeledPoint(label, indices, values, baseMargin = baseMargin, weight = weight)
     }
     transformSchema(dataset.schema, logging = true)
-    val derivedXGBParamMap = fromParamsToXGBParamMap
+    val derivedXGBParamMap = MLlib2XGBoostParams
     // All non-null param maps in XGBoostRegressor are in derivedXGBParamMap.
-    val (booster, metrics) = XGBoost.trainDistributed(instances, derivedXGBParamMap,
-      $(round), $(nWorkers), $(customObj), $(customEval), $(useExternalMemory),
+    val (_booster, _metrics) = XGBoost.trainDistributed(instances, derivedXGBParamMap,
+      $(numRound), $(numWorkers), $(customObj), $(customEval), $(useExternalMemory),
       $(missing))
-    val model = new XGBoostRegressionModel(uid, booster)
-    val summary = XGBoostTrainingSummary(metrics)
+    val model = new XGBoostRegressionModel(uid, _booster)
+    val summary = XGBoostTrainingSummary(_metrics)
     model.setSummary(summary)
     model
   }
 
   override def copy(extra: ParamMap): XGBoostRegressor = defaultCopy(extra)
-
-  override def write: MLWriter = new XGBoostRegressor.XGBoostRegressorWriter(this)
 }
 
-object XGBoostRegressor extends MLReadable[XGBoostRegressor] {
-
-  override def read: MLReader[XGBoostRegressor] = new XGBoostRegressorReader
+object XGBoostRegressor extends DefaultParamsReadable[XGBoostRegressor] {
 
   override def load(path: String): XGBoostRegressor = super.load(path)
-
-  private[XGBoostRegressor]
-  class XGBoostRegressorWriter(instance: XGBoostRegressor) extends MLWriter {
-
-    override protected def saveImpl(path: String): Unit = {
-      require(instance.fromParamsToXGBParamMap("custom_eval") == null &&
-        instance.fromParamsToXGBParamMap("custom_obj") == null,
-        "we do not support persist XGBoostEstimator with customized evaluator and objective" +
-          " function for now")
-      implicit val format = DefaultFormats
-      implicit val sc = super.sparkSession.sparkContext
-      DefaultXGBoostParamsWriter.saveMetadata(instance, path, sc)
-    }
-  }
-
-  private class XGBoostRegressorReader extends MLReader[XGBoostRegressor] {
-
-    override def load(path: String): XGBoostRegressor = {
-      val metadata = DefaultXGBoostParamsReader.loadMetadata(path, sc)
-      val cls = Utils.classForName(metadata.className)
-      val instance =
-        cls.getConstructor(classOf[String]).newInstance(metadata.uid).asInstanceOf[Params]
-      DefaultXGBoostParamsReader.getAndSetParams(instance, metadata)
-      instance.asInstanceOf[XGBoostRegressor]
-    }
-  }
 }
 
 class XGBoostRegressionModel private[ml] (

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
@@ -20,40 +20,48 @@ import scala.collection.immutable.HashSet
 
 import org.apache.spark.ml.param.{DoubleParam, IntParam, Param, Params}
 
-trait BoosterParams extends Params {
+private[spark] trait BoosterParams extends Params {
 
   /**
    * Booster to use, options: {'gbtree', 'gblinear', 'dart'}
    */
-  val boosterType = new Param[String](this, "booster",
+  final val booster = new Param[String](this, "booster",
     s"Booster to use, options: {'gbtree', 'gblinear', 'dart'}",
     (value: String) => BoosterParams.supportedBoosters.contains(value.toLowerCase))
+
+  final def getBooster: String = $(booster)
 
   /**
    * step size shrinkage used in update to prevents overfitting. After each boosting step, we
    * can directly get the weights of new features and eta actually shrinks the feature weights
    * to make the boosting process more conservative. [default=0.3] range: [0,1]
    */
-  val eta = new DoubleParam(this, "eta", "step size shrinkage used in update to prevents" +
+  final val eta = new DoubleParam(this, "eta", "step size shrinkage used in update to prevents" +
     " overfitting. After each boosting step, we can directly get the weights of new features." +
     " and eta actually shrinks the feature weights to make the boosting process more conservative.",
     (value: Double) => value >= 0 && value <= 1)
+
+  final def getEta: Double = $(eta)
 
   /**
    * minimum loss reduction required to make a further partition on a leaf node of the tree.
    * the larger, the more conservative the algorithm will be. [default=0] range: [0,
    * Double.MaxValue]
    */
-  val gamma = new DoubleParam(this, "gamma", "minimum loss reduction required to make a further" +
-      " partition on a leaf node of the tree. the larger, the more conservative the algorithm" +
-    " will be.", (value: Double) => value >= 0)
+  final val gamma = new DoubleParam(this, "gamma", "minimum loss reduction required to make a " +
+    "further partition on a leaf node of the tree. the larger, the more conservative the " +
+    "algorithm will be.", (value: Double) => value >= 0)
+
+  final def getGamma: Double = $(gamma)
 
   /**
    * maximum depth of a tree, increase this value will make model more complex / likely to be
    * overfitting. [default=6] range: [1, Int.MaxValue]
    */
-  val maxDepth = new IntParam(this, "max_depth", "maximum depth of a tree, increase this value" +
-    " will make model more complex/likely to be overfitting.", (value: Int) => value >= 1)
+  final val maxDepth = new IntParam(this, "maxDepth", "maximum depth of a tree, increase this " +
+    "value will make model more complex/likely to be overfitting.", (value: Int) => value >= 1)
+
+  final def getMaxDepth: Int = $(maxDepth)
 
   /**
    * minimum sum of instance weight(hessian) needed in a child. If the tree partition step results
@@ -62,12 +70,14 @@ trait BoosterParams extends Params {
    * to minimum number of instances needed to be in each node. The larger, the more conservative
    * the algorithm will be. [default=1] range: [0, Double.MaxValue]
    */
-  val minChildWeight = new DoubleParam(this, "min_child_weight", "minimum sum of instance" +
+  final val minChildWeight = new DoubleParam(this, "minChildWeight", "minimum sum of instance" +
     " weight(hessian) needed in a child. If the tree partition step results in a leaf node with" +
     " the sum of instance weight less than min_child_weight, then the building process will" +
     " give up further partitioning. In linear regression mode, this simply corresponds to minimum" +
     " number of instances needed to be in each node. The larger, the more conservative" +
     " the algorithm will be.", (value: Double) => value >= 0)
+
+  final def getMinChildWeight: Double = $(minChildWeight)
 
   /**
    * Maximum delta step we allow each tree's weight estimation to be. If the value is set to 0, it
@@ -76,69 +86,88 @@ trait BoosterParams extends Params {
    * regression when class is extremely imbalanced. Set it to value of 1-10 might help control the
    * update. [default=0] range: [0, Double.MaxValue]
    */
-  val maxDeltaStep = new DoubleParam(this, "max_delta_step", "Maximum delta step we allow each" +
-    " tree's weight" +
+  final val maxDeltaStep = new DoubleParam(this, "maxDeltaStep", "Maximum delta step we allow " +
+    "each tree's weight" +
     " estimation to be. If the value is set to 0, it means there is no constraint. If it is set" +
     " to a positive value, it can help making the update step more conservative. Usually this" +
     " parameter is not needed, but it might help in logistic regression when class is extremely" +
     " imbalanced. Set it to value of 1-10 might help control the update",
     (value: Double) => value >= 0)
 
+  final def getMaxDeltaStep: Double = $(maxDeltaStep)
+
   /**
    * subsample ratio of the training instance. Setting it to 0.5 means that XGBoost randomly
    * collected half of the data instances to grow trees and this will prevent overfitting.
    * [default=1] range:(0,1]
    */
-  val subSample = new DoubleParam(this, "subsample", "subsample ratio of the training instance." +
-    " Setting it to 0.5 means that XGBoost randomly collected half of the data instances to" +
-    " grow trees and this will prevent overfitting.", (value: Double) => value <= 1 && value > 0)
+  final val subsample = new DoubleParam(this, "subsample", "subsample ratio of the training " +
+    "instance. Setting it to 0.5 means that XGBoost randomly collected half of the data " +
+    "instances to grow trees and this will prevent overfitting.",
+    (value: Double) => value <= 1 && value > 0)
+
+  final def getSubsample: Double = $(subsample)
 
   /**
    * subsample ratio of columns when constructing each tree. [default=1] range: (0,1]
    */
-  val colSampleByTree = new DoubleParam(this, "colsample_bytree", "subsample ratio of columns" +
-    " when constructing each tree.", (value: Double) => value <= 1 && value > 0)
+  final val colsampleBytree = new DoubleParam(this, "colsampleBytree", "subsample ratio of " +
+    "columns when constructing each tree.", (value: Double) => value <= 1 && value > 0)
+
+  final def getColsampleBytree: Double = $(colsampleBytree)
 
   /**
    * subsample ratio of columns for each split, in each level. [default=1] range: (0,1]
    */
-  val colSampleByLevel = new DoubleParam(this, "colsample_bylevel", "subsample ratio of columns" +
-    " for each split, in each level.", (value: Double) => value <= 1 && value > 0)
+  final val colsampleBylevel = new DoubleParam(this, "colsampleBylevel", "subsample ratio of " +
+    "columns for each split, in each level.", (value: Double) => value <= 1 && value > 0)
+
+  final def getColsampleBylevel: Double = $(colsampleBylevel)
 
   /**
    * L2 regularization term on weights, increase this value will make model more conservative.
    * [default=1]
    */
-  val lambda = new DoubleParam(this, "lambda", "L2 regularization term on weights, increase this" +
-    " value will make model more conservative.", (value: Double) => value >= 0)
+  final val lambda = new DoubleParam(this, "lambda", "L2 regularization term on weights, " +
+    "increase this value will make model more conservative.", (value: Double) => value >= 0)
+
+  final def getLambda: Double = $(lambda)
 
   /**
    * L1 regularization term on weights, increase this value will make model more conservative.
    * [default=0]
    */
-  val alpha = new DoubleParam(this, "alpha", "L1 regularization term on weights, increase this" +
-    " value will make model more conservative.", (value: Double) => value >= 0)
+  final val alpha = new DoubleParam(this, "alpha", "L1 regularization term on weights, increase " +
+    "this value will make model more conservative.", (value: Double) => value >= 0)
+
+  final def getAlpha: Double = $(alpha)
 
   /**
    * The tree construction algorithm used in XGBoost. options: {'auto', 'exact', 'approx'}
    *  [default='auto']
    */
-  val treeMethod = new Param[String](this, "tree_method",
+  final val treeMethod = new Param[String](this, "treeMethod",
     "The tree construction algorithm used in XGBoost, options: {'auto', 'exact', 'approx', 'hist'}",
     (value: String) => BoosterParams.supportedTreeMethods.contains(value))
+
+  final def getTreeMethod: String = $(treeMethod)
 
   /**
    * growth policy for fast histogram algorithm
    */
-  val growthPolicty = new Param[String](this, "grow_policy",
+  final val growPolicy = new Param[String](this, "growPolicy",
     "growth policy for fast histogram algorithm",
     (value: String) => BoosterParams.supportedGrowthPolicies.contains(value))
+
+  final def getGrowPolicy: String = $(growPolicy)
 
   /**
    * maximum number of bins in histogram
    */
-  val maxBins = new IntParam(this, "max_bin", "maximum number of bins in histogram",
+  final val maxBins = new IntParam(this, "maxBin", "maximum number of bins in histogram",
     (value: Int) => value > 0)
+
+  final def getMaxBins: Int = $(maxBins)
 
   /**
    * This is only used for approximate greedy algorithm.
@@ -146,19 +175,23 @@ trait BoosterParams extends Params {
    * number of bins, this comes with theoretical guarantee with sketch accuracy.
    * [default=0.03] range: (0, 1)
    */
-  val sketchEps = new DoubleParam(this, "sketch_eps",
+  final val sketchEps = new DoubleParam(this, "sketchEps",
     "This is only used for approximate greedy algorithm. This roughly translated into" +
       " O(1 / sketch_eps) number of bins. Compared to directly select number of bins, this comes" +
       " with theoretical guarantee with sketch accuracy.",
     (value: Double) => value < 1 && value > 0)
 
+  final def getSketchEps: Double = $(sketchEps)
+
   /**
    * Control the balance of positive and negative weights, useful for unbalanced classes. A typical
    * value to consider: sum(negative cases) / sum(positive cases).   [default=0]
    */
-  val scalePosWeight = new DoubleParam(this, "scale_pos_weight", "Control the balance of positive" +
-    " and negative weights, useful for unbalanced classes. A typical value to consider:" +
+  final val scalePosWeight = new DoubleParam(this, "scalePosWeight", "Control the balance of " +
+    "positive and negative weights, useful for unbalanced classes. A typical value to consider:" +
     " sum(negative cases) / sum(positive cases)")
+
+  final def getScalePosWeight: Double = $(scalePosWeight)
 
   // Dart boosters
 
@@ -167,72 +200,59 @@ trait BoosterParams extends Params {
    * Type of sampling algorithm. "uniform": dropped trees are selected uniformly.
    * "weighted": dropped trees are selected in proportion to weight. [default="uniform"]
    */
-  val sampleType = new Param[String](this, "sample_type", "type of sampling algorithm, options:" +
-    " {'uniform', 'weighted'}",
+  final val sampleType = new Param[String](this, "sampleType", "type of sampling algorithm, " +
+    "options: {'uniform', 'weighted'}",
     (value: String) => BoosterParams.supportedSampleType.contains(value))
+
+  final def getSampleType: String = $(sampleType)
 
   /**
    * Parameter of Dart booster.
    * type of normalization algorithm, options: {'tree', 'forest'}. [default="tree"]
    */
-  val normalizeType = new Param[String](this, "normalize_type", "type of normalization" +
+  final val normalizeType = new Param[String](this, "normalizeType", "type of normalization" +
     " algorithm, options: {'tree', 'forest'}",
     (value: String) => BoosterParams.supportedNormalizeType.contains(value))
+
+  final def getNormalizeType: String = $(normalizeType)
 
   /**
    * Parameter of Dart booster.
    * dropout rate. [default=0.0] range: [0.0, 1.0]
    */
-  val rateDrop = new DoubleParam(this, "rate_drop", "dropout rate", (value: Double) =>
+  final val rateDrop = new DoubleParam(this, "rateDrop", "dropout rate", (value: Double) =>
     value >= 0 && value <= 1)
+
+  final def getRateDrop: Double = $(rateDrop)
 
   /**
    * Parameter of Dart booster.
    * probability of skip dropout. If a dropout is skipped, new trees are added in the same manner
    * as gbtree. [default=0.0] range: [0.0, 1.0]
    */
-  val skipDrop = new DoubleParam(this, "skip_drop", "probability of skip dropout. If" +
+  final val skipDrop = new DoubleParam(this, "skipDrop", "probability of skip dropout. If" +
     " a dropout is skipped, new trees are added in the same manner as gbtree.",
     (value: Double) => value >= 0 && value <= 1)
+
+  final def getSkipDrop: Double = $(skipDrop)
 
   // linear booster
   /**
    * Parameter of linear booster
    * L2 regularization term on bias, default 0(no L1 reg on bias because it is not important)
    */
-  val lambdaBias = new DoubleParam(this, "lambda_bias", "L2 regularization term on bias, default" +
-    " 0 (no L1 reg on bias because it is not important)", (value: Double) => value >= 0)
+  final val lambdaBias = new DoubleParam(this, "lambdaBias", "L2 regularization term on bias, " +
+    "default 0 (no L1 reg on bias because it is not important)", (value: Double) => value >= 0)
 
-  setDefault(boosterType -> "gbtree", eta -> 0.3, gamma -> 0, maxDepth -> 6,
+  final def getLambdaBias: Double = $(lambdaBias)
+
+  setDefault(booster -> "gbtree", eta -> 0.3, gamma -> 0, maxDepth -> 6,
     minChildWeight -> 1, maxDeltaStep -> 0,
-    growthPolicty -> "depthwise", maxBins -> 16,
-    subSample -> 1, colSampleByTree -> 1, colSampleByLevel -> 1,
+    growPolicy -> "depthwise", maxBins -> 16,
+    subsample -> 1, colsampleBytree -> 1, colsampleBylevel -> 1,
     lambda -> 1, alpha -> 0, treeMethod -> "auto", sketchEps -> 0.03,
     scalePosWeight -> 1.0, sampleType -> "uniform", normalizeType -> "tree",
     rateDrop -> 0.0, skipDrop -> 0.0, lambdaBias -> 0)
-
-  /**
-   * Explains all params of this instance. See `explainParam()`.
-   */
-  override def explainParams(): String = {
-    // TODO: filter some parameters according to the booster type
-    val boosterTypeStr = $(boosterType)
-    val validParamList = {
-      if (boosterTypeStr == "gblinear") {
-        // gblinear
-        params.filter(param => param.name == "lambda" ||
-          param.name == "alpha" || param.name == "lambda_bias")
-      } else if (boosterTypeStr != "dart") {
-        // gbtree
-        params.filter(param => param.name != "sample_type" &&
-          param.name != "normalize_type" && param.name != "rate_drop" && param.name != "skip_drop")
-      } else {
-        // dart
-        params.filter(_.name != "lambda_bias")
-      }
-    }
-    explainParam(boosterType) + "\n" ++ validParamList.map(explainParam).mkString("\n")
-  }
 }
 
 private[spark] object BoosterParams {

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -16,84 +16,104 @@
 
 package ml.dmlc.xgboost4j.scala.spark.params
 
+import com.google.common.base.CaseFormat
 import ml.dmlc.xgboost4j.scala.spark.TrackerConf
-
 import org.apache.spark.ml.param._
+import scala.collection.mutable
 
-trait GeneralParams extends Params {
+private[spark] trait GeneralParams extends Params {
 
   /**
    * The number of rounds for boosting
    */
-  val round = new IntParam(this, "num_round", "The number of rounds for boosting",
+  final val numRound = new IntParam(this, "numRound", "The number of rounds for boosting",
     ParamValidators.gtEq(1))
+
+  final def getNumRound: Int = $(numRound)
 
   /**
    * number of workers used to train xgboost model. default: 1
    */
-  val nWorkers = new IntParam(this, "nworkers", "number of workers used to run xgboost",
+  final val numWorkers = new IntParam(this, "numWorkers", "number of workers used to run xgboost",
     ParamValidators.gtEq(1))
+
+  final def getNumWorkers: Int = $(numWorkers)
 
   /**
    * number of threads used by per worker. default 1
    */
-  val numThreadPerTask = new IntParam(this, "nthread", "number of threads used by per worker",
+  final val nthread = new IntParam(this, "nthread", "number of threads used by per worker",
     ParamValidators.gtEq(1))
+
+  final def getNthread: Int = $(nthread)
 
   /**
    * whether to use external memory as cache. default: false
    */
-  val useExternalMemory = new BooleanParam(this, "use_external_memory", "whether to use external" +
-    "memory as cache")
+  final val useExternalMemory = new BooleanParam(this, "useExternalMemory",
+    "whether to use external memory as cache")
+
+  final def getUseExternalMemory: Boolean = $(useExternalMemory)
 
   /**
    * 0 means printing running messages, 1 means silent mode. default: 0
    */
-  val silent = new IntParam(this, "silent",
+  final val silent = new IntParam(this, "silent",
     "0 means printing running messages, 1 means silent mode.",
     (value: Int) => value >= 0 && value <= 1)
+
+  final def getSilent: Int = $(silent)
 
   /**
    * customized objective function provided by user. default: null
    */
-  val customObj = new CustomObjParam(this, "custom_obj", "customized objective function " +
+  final val customObj = new CustomObjParam(this, "customObj", "customized objective function " +
     "provided by user")
 
   /**
    * customized evaluation function provided by user. default: null
    */
-  val customEval = new CustomEvalParam(this, "custom_eval", "customized evaluation function " +
-    "provided by user")
+  final val customEval = new CustomEvalParam(this, "customEval",
+    "customized evaluation function provided by user")
 
   /**
    * the value treated as missing. default: Float.NaN
    */
-  val missing = new FloatParam(this, "missing", "the value treated as missing")
+  final val missing = new FloatParam(this, "missing", "the value treated as missing")
+
+  final def getMissing: Float = $(missing)
 
   /**
     * the maximum time to wait for the job requesting new workers. default: 30 minutes
     */
-  val timeoutRequestWorkers = new LongParam(this, "timeout_request_workers", "the maximum time to" +
-    " request new Workers if numCores are insufficient. The timeout will be disabled if this" +
-    " value is set smaller than or equal to 0.")
+  final val timeoutRequestWorkers = new LongParam(this, "timeoutRequestWorkers", "the maximum " +
+    "time to request new Workers if numCores are insufficient. The timeout will be disabled " +
+    "if this value is set smaller than or equal to 0.")
+
+  final def getTimeoutRequestWorkers: Long = $(timeoutRequestWorkers)
 
   /**
     * The hdfs folder to load and save checkpoint boosters. default: `empty_string`
     */
-  val checkpointPath = new Param[String](this, "checkpoint_path", "the hdfs folder to load and " +
-    "save checkpoints. If there are existing checkpoints in checkpoint_path. The job will load " +
-    "the checkpoint with highest version as the starting point for training. If " +
+  final val checkpointPath = new Param[String](this, "checkpointPath", "the hdfs folder to load " +
+    "and save checkpoints. If there are existing checkpoints in checkpoint_path. The job will " +
+    "load the checkpoint with highest version as the starting point for training. If " +
     "checkpoint_interval is also set, the job will save a checkpoint every a few rounds.")
+
+  final def getCheckpointPath: String = $(checkpointPath)
 
   /**
     * Param for set checkpoint interval (&gt;= 1) or disable checkpoint (-1). E.g. 10 means that
     * the trained model will get checkpointed every 10 iterations. Note: `checkpoint_path` must
     * also be set if the checkpoint interval is greater than 0.
     */
-  val checkpointInterval: IntParam = new IntParam(this, "checkpoint_interval", "set checkpoint " +
-    "interval (>= 1) or disable checkpoint (-1). E.g. 10 means that the trained model will get " +
-    "checkpointed every 10 iterations. Note: `checkpoint_path` must also be set if the checkpoint" +
-    " interval is greater than 0.", (interval: Int) => interval == -1 || interval >= 1)
+  final val checkpointInterval: IntParam = new IntParam(this, "checkpointInterval",
+    "set checkpoint interval (>= 1) or disable checkpoint (-1). E.g. 10 means that the trained " +
+      "model will get checkpointed every 10 iterations. Note: `checkpoint_path` must also be " +
+      "set if the checkpoint interval is greater than 0.",
+    (interval: Int) => interval == -1 || interval >= 1)
+
+  final def getCheckpointInterval: Int = $(checkpointInterval)
 
   /**
     * Rabit tracker configurations. The parameter must be provided as an instance of the
@@ -122,12 +142,14 @@ trait GeneralParams extends Params {
     *        Note that zero timeout value means to wait indefinitely (equivalent to Duration.Inf).
     *        Ignored if the tracker implementation is "python".
     */
-  val trackerConf = new TrackerConfParam(this, "tracker_conf", "Rabit tracker configurations")
+  final val trackerConf = new TrackerConfParam(this, "trackerConf", "Rabit tracker configurations")
 
   /** Random seed for the C++ part of XGBoost and train/test splitting. */
-  val seed = new LongParam(this, "seed", "random seed")
+  final val seed = new LongParam(this, "seed", "random seed")
 
-  setDefault(round -> 1, nWorkers -> 1, numThreadPerTask -> 1,
+  final def getSeed: Long = $(seed)
+
+  setDefault(numRound -> 1, numWorkers -> 1, nthread -> 1,
     useExternalMemory -> false, silent -> 0,
     customObj -> null, customEval -> null, missing -> Float.NaN,
     trackerConf -> TrackerConf(), seed -> 0, timeoutRequestWorkers -> 30 * 60 * 1000L,
@@ -146,4 +168,48 @@ trait HasBaseMarginCol extends Params {
 
   /** @group getParam */
   final def getBaseMarginCol: String = $(baseMarginCol)
+}
+
+trait HasNumClass extends Params {
+
+  /**
+   * number of classes
+   */
+  final val numClass = new IntParam(this, "numClass", "number of classes")
+
+  /** @group getParam */
+  final def getNumClass: Int = $(numClass)
+}
+
+private[spark] trait ParamMapFuncs extends Params {
+
+  def XGBoostToMLlibParams(xgboostParams: Map[String, Any]): Unit = {
+    for ((paramName, paramValue) <- xgboostParams) {
+      val name = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, paramName)
+      params.find(_.name == name) match {
+        case None =>
+        case Some(_: DoubleParam) =>
+          set(name, paramValue.toString.toDouble)
+        case Some(_: BooleanParam) =>
+          set(name, paramValue.toString.toBoolean)
+        case Some(_: IntParam) =>
+          set(name, paramValue.toString.toInt)
+        case Some(_: FloatParam) =>
+          set(name, paramValue.toString.toFloat)
+        case Some(_: Param[_]) =>
+          set(name, paramValue)
+      }
+    }
+  }
+
+  def MLlib2XGBoostParams: Map[String, Any] = {
+    val xgboostParams = new mutable.HashMap[String, Any]()
+    for (param <- params) {
+      if (isDefined(param)) {
+        val name = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, param.name)
+        xgboostParams += name -> $(param)
+      }
+    }
+    xgboostParams.toMap
+  }
 }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -20,22 +20,26 @@ import scala.collection.immutable.HashSet
 
 import org.apache.spark.ml.param._
 
-trait LearningTaskParams extends Params {
+private[spark] trait LearningTaskParams extends Params {
 
   /**
    * Specify the learning task and the corresponding learning objective.
    * options: reg:linear, reg:logistic, binary:logistic, binary:logitraw, count:poisson,
    * multi:softmax, multi:softprob, rank:pairwise, reg:gamma. default: reg:linear
    */
-  val objective = new Param[String](this, "objective", "objective function used for training," +
-    s" options: {${LearningTaskParams.supportedObjective.mkString(",")}",
+  final val objective = new Param[String](this, "objective", "objective function used for " +
+    s"training, options: {${LearningTaskParams.supportedObjective.mkString(",")}",
     (value: String) => LearningTaskParams.supportedObjective.contains(value))
+
+  final def getObjective: String = $(objective)
 
   /**
    * the initial prediction score of all instances, global bias. default=0.5
    */
-  val baseScore = new DoubleParam(this, "base_score", "the initial prediction score of all" +
+  final val baseScore = new DoubleParam(this, "baseScore", "the initial prediction score of all" +
     " instances, global bias")
+
+  final def getBaseScore: Double = $(baseScore)
 
   /**
    * evaluation metrics for validation data, a default metric will be assigned according to
@@ -43,34 +47,40 @@ trait LearningTaskParams extends Params {
    * ranking). options: rmse, mae, logloss, error, merror, mlogloss, auc, aucpr, ndcg, map,
    * gamma-deviance
    */
-  val evalMetric = new Param[String](this, "eval_metric", "evaluation metrics for validation" +
-    " data, a default metric will be assigned according to objective (rmse for regression, and" +
-    " error for classification, mean average precision for ranking), options: " +
-    s" {${LearningTaskParams.supportedEvalMetrics.mkString(",")}}",
+  final val evalMetric = new Param[String](this, "evalMetric", "evaluation metrics for " +
+    "validation data, a default metric will be assigned according to objective " +
+    "(rmse for regression, and error for classification, mean average precision for ranking), " +
+    s"options: {${LearningTaskParams.supportedEvalMetrics.mkString(",")}}",
     (value: String) => LearningTaskParams.supportedEvalMetrics.contains(value))
+
+  final def getEvalMetric: String = $(evalMetric)
 
   /**
     * group data specify each group sizes for ranking task. To correspond to partition of
     * training data, it is nested.
     */
-  val groupData = new GroupDataParam(this, "groupData", "group data specify each group size" +
-    " for ranking task. To correspond to partition of training data, it is nested.")
+  final val groupData = new GroupDataParam(this, "groupData", "group data specify each group " +
+    "size for ranking task. To correspond to partition of training data, it is nested.")
 
   /**
    * Fraction of training points to use for testing.
    */
-  val trainTestRatio = new DoubleParam(this, "trainTestRatio",
+  final val trainTestRatio = new DoubleParam(this, "trainTestRatio",
     "fraction of training points to use for testing",
     ParamValidators.inRange(0, 1))
+
+  final def getTrainTestRatio: Double = $(trainTestRatio)
 
   /**
    * If non-zero, the training will be stopped after a specified number
    * of consecutive increases in any evaluation metric.
    */
-  val numEarlyStoppingRounds = new IntParam(this, "numEarlyStoppingRounds",
+  final val numEarlyStoppingRounds = new IntParam(this, "numEarlyStoppingRounds",
     "number of rounds of decreasing eval metric to tolerate before " +
     "stopping the training",
     (value: Int) => value == 0 || value > 1)
+
+  final def getNumEarlyStoppingRounds: Int = $(numEarlyStoppingRounds)
 
   setDefault(objective -> "reg:linear", baseScore -> 0.5, groupData -> null,
     trainTestRatio -> 1.0, numEarlyStoppingRounds -> 0)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/CheckpointManagerSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/CheckpointManagerSuite.scala
@@ -27,7 +27,7 @@ class CheckpointManagerSuite extends FunSuite with PerTest with BeforeAndAfterAl
   private lazy val (model4, model8) = {
     val training = buildDataFrame(Classification.train)
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
-      "objective" -> "binary:logistic", "nWorkers" -> sc.defaultParallelism)
+      "objective" -> "binary:logistic", "num_workers" -> sc.defaultParallelism)
     val _model4 = new XGBoostClassifier(paramMap ++ Seq("num_round" -> 2)).fit(training)
     val _model8 = new XGBoostClassifier(paramMap ++ Seq("num_round" -> 4)).fit(training)
     (_model4, _model8)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostConfigureSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostConfigureSuite.scala
@@ -29,7 +29,7 @@ class XGBoostConfigureSuite extends FunSuite with PerTest {
   test("nthread configuration must be no larger than spark.task.cpus") {
     val training = buildDataFrame(Classification.train)
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
-      "objective" -> "binary:logistic",
+      "objective" -> "binary:logistic", "num_workers" -> numWorkers,
       "nthread" -> (sc.getConf.getInt("spark.task.cpus", 1) + 1))
     intercept[IllegalArgumentException] {
       new XGBoostClassifier(paramMap ++ Seq("num_round" -> 2)).fit(training)
@@ -41,7 +41,7 @@ class XGBoostConfigureSuite extends FunSuite with PerTest {
     val training = buildDataFrame(Classification.train)
     val testDM = new DMatrix(Classification.test.iterator, null)
     val paramMap = Map("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
-      "objective" -> "binary:logistic", "num_round" -> 5, "nWorkers" -> numWorkers)
+      "objective" -> "binary:logistic", "num_round" -> 5, "num_workers" -> numWorkers)
 
     val model = new XGBoostClassifier(paramMap).fit(training)
     val eval = new EvalError()

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
@@ -90,11 +90,10 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
     val training = buildDataFrame(Classification.train)
     val testDM = new DMatrix(Classification.test.iterator)
     val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
-      "objective" -> "binary:logistic", "num_round" -> 5, "nWorkers" -> numWorkers,
-      "useExternalMemory" -> true)
+      "objective" -> "binary:logistic", "num_round" -> 5, "num_workers" -> numWorkers,
+      "use_external_memory" -> true)
     val model = new XGBoostClassifier(paramMap).fit(training)
-    assert(eval.eval(model._booster.predict(testDM, outPutMargin = true),
-      testDM) < 0.1)
+    assert(eval.eval(model._booster.predict(testDM, outPutMargin = true), testDM) < 0.1)
   }
 
 
@@ -102,12 +101,11 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
     val eval = new EvalError()
     val training = buildDataFrame(Classification.train)
     val testDM = new DMatrix(Classification.test.iterator)
-    val paramMap = List("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
-      "objective" -> "binary:logistic", "num_round" -> 5, "nWorkers" -> numWorkers,
-      "tracker_conf" -> TrackerConf(60 * 60 * 1000, "scala")).toMap
+    val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
+      "objective" -> "binary:logistic", "num_round" -> 5, "num_workers" -> numWorkers,
+      "tracker_conf" -> TrackerConf(60 * 60 * 1000, "scala"))
     val model = new XGBoostClassifier(paramMap).fit(training)
-    assert(eval.eval(model._booster.predict(testDM, outPutMargin = true),
-      testDM) < 0.1)
+    assert(eval.eval(model._booster.predict(testDM, outPutMargin = true), testDM) < 0.1)
   }
 
 
@@ -117,11 +115,10 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
     val testDM = new DMatrix(Classification.test.iterator)
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "binary:logistic", "tree_method" -> "hist", "grow_policy" -> "depthwise",
-      "eval_metric" -> "error", "num_round" -> 5, "nWorkers" -> math.min(numWorkers, 2))
+      "eval_metric" -> "error", "num_round" -> 5, "num_workers" -> math.min(numWorkers, 2))
     // TODO: histogram algorithm seems to be very very sensitive to worker number
     val model = new XGBoostClassifier(paramMap).fit(training)
-    assert(eval.eval(model._booster.predict(testDM, outPutMargin = true),
-      testDM) < 0.1)
+    assert(eval.eval(model._booster.predict(testDM, outPutMargin = true), testDM) < 0.1)
   }
 
   ignore("test with fast histo lossguide") {
@@ -131,7 +128,7 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "1",
       "objective" -> "binary:logistic", "tree_method" -> "hist", "grow_policy" -> "lossguide",
       "max_leaves" -> "8", "eval_metric" -> "error", "num_round" -> 5,
-      "nWorkers" -> math.min(numWorkers, 2))
+      "num_workers" -> math.min(numWorkers, 2))
     val model = new XGBoostClassifier(paramMap).fit(training)
     val x = eval.eval(model._booster.predict(testDM, outPutMargin = true), testDM)
     assert(x < 0.1)
@@ -144,7 +141,7 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "0",
       "objective" -> "binary:logistic", "tree_method" -> "hist",
       "grow_policy" -> "lossguide", "max_leaves" -> "8", "max_bin" -> "16",
-      "eval_metric" -> "error", "num_round" -> 5, "nWorkers" -> math.min(numWorkers, 2))
+      "eval_metric" -> "error", "num_round" -> 5, "num_workers" -> math.min(numWorkers, 2))
     val model = new XGBoostClassifier(paramMap).fit(training)
     val x = eval.eval(model._booster.predict(testDM, outPutMargin = true), testDM)
     assert(x < 0.1)
@@ -157,7 +154,7 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "0",
       "objective" -> "binary:logistic", "tree_method" -> "hist",
       "grow_policy" -> "depthwise", "max_leaves" -> "8", "max_depth" -> "2",
-      "eval_metric" -> "error", "num_round" -> 10, "nWorkers" -> math.min(numWorkers, 2))
+      "eval_metric" -> "error", "num_round" -> 10, "num_workers" -> math.min(numWorkers, 2))
     val model = new XGBoostClassifier(paramMap).fit(training)
     val x = eval.eval(model._booster.predict(testDM, outPutMargin = true), testDM)
     assert(x < 0.1)
@@ -170,7 +167,7 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
     val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0", "silent" -> "0",
       "objective" -> "binary:logistic", "tree_method" -> "hist",
       "grow_policy" -> "depthwise", "max_depth" -> "2", "max_bin" -> "2",
-      "eval_metric" -> "error", "num_round" -> 10, "nWorkers" -> math.min(numWorkers, 2))
+      "eval_metric" -> "error", "num_round" -> 10, "num_workers" -> math.min(numWorkers, 2))
     val model = new XGBoostClassifier(paramMap).fit(training)
     val x = eval.eval(model._booster.predict(testDM, outPutMargin = true), testDM)
     assert(x < 0.1)
@@ -182,7 +179,7 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
       val numCols = 5
 
       val data = (0 until numRows).map { x =>
-        val label = Random.nextDouble
+        val label = Random.nextInt(2)
         val values = Array.tabulate[Double](numCols) { c =>
           if (c == numCols - 1) -0.1 else Random.nextDouble
         }
@@ -195,7 +192,7 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
 
     val denseDF = buildDenseDataFrame().repartition(4)
     val paramMap = List("eta" -> "1", "max_depth" -> "2", "silent" -> "1",
-      "objective" -> "binary:logistic", "missing" -> -0.1f).toMap
+      "objective" -> "binary:logistic", "missing" -> -0.1f, "num_workers" -> numWorkers).toMap
     val model = new XGBoostClassifier(paramMap).fit(denseDF)
     model.transform(denseDF).collect()
   }
@@ -206,7 +203,7 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
     val testDM = new DMatrix(Classification.test.iterator)
     val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "binary:logistic", "timeout_request_workers" -> 0L,
-      "num_round" -> 5, "nWorkers" -> numWorkers)
+      "num_round" -> 5, "num_workers" -> numWorkers)
     val model = new XGBoostClassifier(paramMap).fit(training)
     val x = eval.eval(model._booster.predict(testDM, outPutMargin = true), testDM)
     assert(x < 0.1)
@@ -220,7 +217,7 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
     val tmpPath = Files.createTempDirectory("model1").toAbsolutePath.toString
     val paramMap = Map("eta" -> "1", "max_depth" -> 2, "silent" -> "1",
       "objective" -> "binary:logistic", "checkpoint_path" -> tmpPath,
-      "checkpoint_interval" -> 2, "nWorkers" -> numWorkers)
+      "checkpoint_interval" -> 2, "num_workers" -> numWorkers)
 
     val prevModel = new XGBoostClassifier(paramMap ++ Seq("num_round" -> 5)).fit(training)
     def error(model: Booster): Float = eval.eval(


### PR DESCRIPTION
Refactor and reorganize XGBoost-Spark params, now it follows both XGBoost(snake_case for param names) and Spark MLlib(camelCase) convention. For example, if you would like to train a ```XGBoostClassificationModel```, you can use either of the following ways:
* Set params with XGBoost way
```
val paramMap = Map(
      "eta" -> "1",
      "max_depth" -> "6",
      "silent" -> "1",
      "objective" -> "binary:logistic",
      "num_round" -> 5,
      "num_workers" -> 4)
val model1 = new XGBoostClassifier(paramMap).fit(trainingDF)
```

* Set params with Spark MLlib way
```
val model2 = new XGBoostClassifier()
      .setEta(1)
      .setMaxDepth(6)
      .setSilent(1)
      .setObjective("binary:logistic")
      .setNumRound(5)
      .setNumWorkers(4)
      .fit(trainingDF)
```