### PR TITLE
For CRAN submission, remove all #pragma's that suppress compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,7 @@ Rpack: clean_all
 	cat R-package/src/Makevars.in|sed '2s/.*/PKGROOT=./' | sed '3s/.*/ENABLE_STD_THREAD=0/' > xgboost/src/Makevars.in
 	cp xgboost/src/Makevars.in xgboost/src/Makevars.win
 	sed -i -e 's/@OPENMP_CXXFLAGS@/$$\(SHLIB_OPENMP_CFLAGS\)/g' xgboost/src/Makevars.win
+	bash R-package/remove_warning_suppression_pragma.sh
 
 Rbuild: Rpack
 	R CMD build --no-build-vignettes xgboost

--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,7 @@ Rpack: clean_all
 	cp xgboost/src/Makevars.in xgboost/src/Makevars.win
 	sed -i -e 's/@OPENMP_CXXFLAGS@/$$\(SHLIB_OPENMP_CFLAGS\)/g' xgboost/src/Makevars.win
 	bash R-package/remove_warning_suppression_pragma.sh
+	rm xgboost/remove_warning_suppression_pragma.sh
 
 Rbuild: Rpack
 	R CMD build --no-build-vignettes xgboost

--- a/R-package/remove_warning_suppression_pragma.sh
+++ b/R-package/remove_warning_suppression_pragma.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# remove all #pragma's that suppress compiler warnings
+set -e
+set -x
+for file in xgboost/src/dmlc-core/include/dmlc/*.h
+do
+  sed -i '' -e 's/^.*#pragma GCC diagnostic.*$//' -e 's/^.*#pragma clang diagnostic.*$//' -e 's/^.*#pragma warning.*$//' "${file}"
+done
+set +x
+set +e

--- a/R-package/remove_warning_suppression_pragma.sh
+++ b/R-package/remove_warning_suppression_pragma.sh
@@ -4,7 +4,11 @@ set -e
 set -x
 for file in xgboost/src/dmlc-core/include/dmlc/*.h
 do
-  sed -i '' -e 's/^.*#pragma GCC diagnostic.*$//' -e 's/^.*#pragma clang diagnostic.*$//' -e 's/^.*#pragma warning.*$//' "${file}"
+  sed -i.bak -e 's/^.*#pragma GCC diagnostic.*$//' -e 's/^.*#pragma clang diagnostic.*$//' -e 's/^.*#pragma warning.*$//' "${file}"
+done
+for file in xgboost/src/dmlc-core/include/dmlc/*.h.bak
+do
+  rm "${file}"
 done
 set +x
 set +e


### PR DESCRIPTION
A few headers in dmlc-core contain #pragma's that disable compiler warnings, which is against the CRAN submission policy. Fix the problem by removing the offending #pragma's as part of the command `make Rbuild`.

This addresses issue #3322.