### PR TITLE
Fix print.xgb.Booster for R

### DIFF
--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -37,11 +37,14 @@ xgb.handleToBooster <- function(handle, raw = NULL) {
 # Check whether xgb.Booster.handle is null
 # internal utility function
 is.null.handle <- function(handle) {
+  if (is.null(handle)) return(TRUE)
+
   if (!identical(class(handle), "xgb.Booster.handle"))
     stop("argument type must be xgb.Booster.handle")
 
-  if (is.null(handle) || .Call(XGCheckNullPtr_R, handle))
+  if (.Call(XGCheckNullPtr_R, handle))
     return(TRUE)
+
   return(FALSE)
 }
 

--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -537,7 +537,7 @@ xgb.ntree <- function(bst) {
 print.xgb.Booster <- function(x, verbose = FALSE, ...) {
   cat('##### xgb.Booster\n')
 
-  valid_handle <- is.null.handle(x$handle)
+  valid_handle <- !is.null.handle(x$handle)
   if (!valid_handle)
     cat("Handle is invalid! Suggest using xgb.Booster.complete\n")
 


### PR DESCRIPTION
I always get "Handle is invalid!" message with the R package xgboost 0.71.1. I found that `valid_handle` is `TRUE` when `x$handle` is (a kind of ) `NULL`, but it seems to be the opposite.