### PR TITLE
[python-package] Remove output_margin from XGBClassifier.predict_proba argument list.

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -564,7 +564,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             column_indexes[class_probs > 0.5] = 1
         return self._le.inverse_transform(column_indexes)
 
-    def predict_proba(self, data, output_margin=False, ntree_limit=0):
+    def predict_proba(self, data, ntree_limit=0):
         """
         Predict the probability of each `data` example being of a given class.
         NOTE: This function is not thread safe.
@@ -575,8 +575,6 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         ----------
         data : DMatrix
             The dmatrix storing the input.
-        output_margin : bool
-            Whether to output the raw untransformed margin value.
         ntree_limit : int
             Limit number of trees in the prediction; defaults to 0 (use all trees).
         Returns
@@ -586,7 +584,6 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         """
         test_dmatrix = DMatrix(data, missing=self.missing, nthread=self.n_jobs)
         class_probs = self.get_booster().predict(test_dmatrix,
-                                                 output_margin=output_margin,
                                                  ntree_limit=ntree_limit)
         if self.objective == "multi:softprob":
             return class_probs


### PR DESCRIPTION
```XGBClassifier.predict_proba``` is to predict class probabilities, so it doesn't make sense to support ```output_margin```. If users want to output margin, they can just use ```predict(data, output_margin=True)```.

Some users report misuse of this argument when calling ```XGBClassifier.predict_proba``` at #3308. If users set ```output_margin=True``` when calling ```predict_proba``` by mistake, it will produce confused and meaningless result.

For example, this is the correct result:
(This is binary classification, each column is the probability of the sample being of a given class)
```
>>> model.predict_proba(X_test, output_margin=False)[0:10]
array([[0.9545844 , 0.04541559],
       [0.05245447, 0.9475455 ],
       [0.41897488, 0.5810251 ],
       [0.9831998 , 0.0168002 ],
       [0.4119159 , 0.5880841 ],
       [0.31113452, 0.6888655 ],
       [0.9705527 , 0.02944732],
       [0.93274003, 0.06725994],
       [0.11494881, 0.8850512 ],
       [0.6501156 , 0.34988442]], dtype=float32)
``` 
And this is wrong result:
```
>>> model.predict_proba(X_test, output_margin=True)[0:10]
array([[ 4.0454206 , -3.0454206 ],
       [-1.8939297 ,  2.8939297 ],
       [ 0.67301685,  0.32698315],
       [ 5.069422  , -4.069422  ],
       [ 0.64394915,  0.35605082],
       [ 0.20517927,  0.7948207 ],
       [ 4.4952626 , -3.4952626 ],
       [ 3.6295617 , -2.6295617 ],
       [-1.0411582 ,  2.0411582 ],
       [ 1.6195472 , -0.61954725]], dtype=float32)
```
