### PR TITLE
[jvm-packages] Fix checkpoint_interval parameter name

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -90,7 +90,7 @@ trait GeneralParams extends Params {
     * the trained model will get checkpointed every 10 iterations. Note: `checkpoint_path` must
     * also be set if the checkpoint interval is greater than 0.
     */
-  val checkpointInterval: IntParam = new IntParam(this, "checkpointInterval", "set checkpoint " +
+  val checkpointInterval: IntParam = new IntParam(this, "checkpoint_interval", "set checkpoint " +
     "interval (>= 1) or disable checkpoint (-1). E.g. 10 means that the trained model will get " +
     "checkpointed every 10 iterations. Note: `checkpoint_path` must also be set if the checkpoint" +
     " interval is greater than 0.", (interval: Int) => interval == -1 || interval >= 1)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
@@ -145,8 +145,10 @@ class XGBoostDFSuite extends FunSuite with PerTest with TableDrivenPropertyCheck
     assert(xgbEstimator.get(xgbEstimator.checkpointPath).get === "checkpointPath1" )
 
     val xgbEstimatorCopy = xgbEstimator.copy(ParamMap.empty)
-    assert(xgbEstimatorCopy.fromParamsToXGBParamMap("checkpoint_path").toString === "checkpointPath1")
-    assert(xgbEstimatorCopy.fromParamsToXGBParamMap("checkpoint_interval").toString.toDouble === 13.0)
+    assert(xgbEstimatorCopy
+      .fromParamsToXGBParamMap("checkpoint_path").toString === "checkpointPath1")
+    assert(xgbEstimatorCopy
+      .fromParamsToXGBParamMap("checkpoint_interval").toString.toDouble === 13.0)
   }
 
   test("eval_metric is configured correctly") {

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
@@ -138,6 +138,17 @@ class XGBoostDFSuite extends FunSuite with PerTest with TableDrivenPropertyCheck
     assert(xgbEstimatorCopy.fromParamsToXGBParamMap("objective").toString === "binary:logistic")
   }
 
+  test("checkpoint parameters configured correctly") {
+    val xgbParamMap = Map("checkpoint_path" -> "checkpointPath1", "checkpoint_interval" -> "13")
+    val xgbEstimator = new XGBoostEstimator(xgbParamMap)
+    assert(xgbEstimator.get(xgbEstimator.checkpointInterval).get === 13.0)
+    assert(xgbEstimator.get(xgbEstimator.checkpointPath).get === "checkpointPath1" )
+
+    val xgbEstimatorCopy = xgbEstimator.copy(ParamMap.empty)
+    assert(xgbEstimatorCopy.fromParamsToXGBParamMap("checkpoint_path").toString === "checkpointPath1")
+    assert(xgbEstimatorCopy.fromParamsToXGBParamMap("checkpoint_interval").toString.toDouble === 13.0)
+  }
+
   test("eval_metric is configured correctly") {
     val xgbParamMap = Map("eta" -> "1", "objective" -> "binary:logistic")
     val xgbEstimator = new XGBoostEstimator(xgbParamMap)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostDFSuite.scala
@@ -146,18 +146,12 @@ class XGBoostDFSuite extends FunSuite with PerTest with TableDrivenPropertyCheck
     val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "binary:logistic", "checkpoint_path" -> tmpPath,
       "checkpoint_interval" -> "1")
-    val trainingItr = Classification.train.iterator
-    val testItr = Classification.test.iterator
     val round = 5
-    val trainDMatrix = new DMatrix(trainingItr)
-    val testDMatrix = new DMatrix(testItr)
-    val xgboostModel = ScalaXGBoost.train(trainDMatrix, paramMap, round)
-    val predResultFromSeq = xgboostModel.predict(testDMatrix)
     val trainingDF = buildDataFrame(Classification.train)
-    val xgBoostModelWithDF = XGBoost.trainWithDataFrame(trainingDF, paramMap,
+    XGBoost.trainWithDataFrame(trainingDF, paramMap,
       round = round, nWorkers = numWorkers)
 
-    var files = FileSystem.get(sc.hadoopConfiguration).listStatus(new Path(tmpPath))
+    val files = FileSystem.get(sc.hadoopConfiguration).listStatus(new Path(tmpPath))
     assert(files.length == 1)
     assert(files.head.getPath.getName.endsWith(".model"))
   }


### PR DESCRIPTION
The parameter in the param map should be checkpoint_interval instead of checkpointInterval to work correctly.