### PR TITLE
Save outputs in high precision in CLI prediction

### DIFF
--- a/src/cli_main.cc
+++ b/src/cli_main.cc
@@ -333,7 +333,8 @@ void CLIPredict(const CLIParam& param) {
       dmlc::Stream::Create(param.name_pred.c_str(), "w"));
   dmlc::ostream os(fo.get());
   for (bst_float p : preds.HostVector()) {
-    os << p << '\n';
+    os << std::setprecision(std::numeric_limits<bst_float>::max_digits10 + 2)
+       << p << '\n';
   }
   // force flush before fo destruct.
   os.set_stream(nullptr);


### PR DESCRIPTION
Currently, `CLIPredict()` saves prediction results in default 6-digit precision which causes precision loss. This PR sets precision to a level so that the conversion back to `bst_float` is lossless.

Related: #3298.