### PR TITLE
[jvm-packages] Avoid use of Seq.apply in buildGroups

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -311,15 +311,15 @@ private object Watches {
   def buildGroups(groups: Seq[Int]): Seq[Int] = {
     val output = mutable.ArrayBuffer.empty[Int]
     var count = 1
-    var i = 1
-    while (i < groups.length) {
-      if (groups(i) != groups(i - 1)) {
+    var lastGroup = groups.head
+    for (group <- groups.tail) {
+      if (group != lastGroup) {
+        lastGroup = group
         output += count
         count = 1
       } else {
         count += 1
       }
-      i += 1
     }
     output += count
     output


### PR DESCRIPTION
Fixes https://github.com/dmlc/xgboost/issues/3412

Regarding the concern with memory usage in https://github.com/dmlc/xgboost/pull/3387, since Seq is lazy I don't think there's much overhead (and it definitely isn't loading the whole thing in memory, otherwise the indexing wouldn't be an issue) compared to using the iterator directly.

Manually ran and checked that it 1) had the same output and 2) completed for a large input