### PR TITLE
Fix wget for google tests in CI

### DIFF
--- a/tests/ci_build/build_via_cmake.sh
+++ b/tests/ci_build/build_via_cmake.sh
@@ -3,7 +3,7 @@ set -e
 
 # Build gtest via cmake
 rm -rf gtest
-wget https://github.com/google/googletest/archive/release-1.7.0.zip
+wget -nc https://github.com/google/googletest/archive/release-1.7.0.zip
 unzip release-1.7.0.zip
 mv googletest-release-1.7.0 gtest && cd gtest
 cmake . && make 

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -116,7 +116,7 @@ fi
 if [ ${TASK} == "cmake_test" ]; then
     set -e
     # Build gtest via cmake
-    wget https://github.com/google/googletest/archive/release-1.7.0.zip
+    wget -nc https://github.com/google/googletest/archive/release-1.7.0.zip
     unzip release-1.7.0.zip
     mv googletest-release-1.7.0 gtest && cd gtest
     cmake . && make


### PR DESCRIPTION
CI tests were failing because wget prompts "the user" for a response whenever the google test archive is already on the disk.

Fix: Use `-nc` option to skip download when the archive already exists