### PR TITLE
 Fix wget for google tests in CI (follow-up)

### DIFF
--- a/tests/ci_build/build_via_cmake.sh
+++ b/tests/ci_build/build_via_cmake.sh
@@ -4,7 +4,7 @@ set -e
 # Build gtest via cmake
 rm -rf gtest
 wget -nc https://github.com/google/googletest/archive/release-1.7.0.zip
-unzip release-1.7.0.zip
+unzip -n release-1.7.0.zip
 mv googletest-release-1.7.0 gtest && cd gtest
 cmake . && make 
 mkdir lib && mv libgtest.a lib

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -117,7 +117,7 @@ if [ ${TASK} == "cmake_test" ]; then
     set -e
     # Build gtest via cmake
     wget -nc https://github.com/google/googletest/archive/release-1.7.0.zip
-    unzip release-1.7.0.zip
+    unzip -n release-1.7.0.zip
     mv googletest-release-1.7.0 gtest && cd gtest
     cmake . && make
     mkdir lib && mv libgtest.a lib


### PR DESCRIPTION
This is a follow-up of #3414. The google test archive should not be un-zipped when the extracted directory already exists.