### PR TITLE
[jvm-package] Expose nativeBooster for XGBoostClassificationModel and XGBoostRegressionModel

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -211,6 +211,12 @@ class XGBoostClassificationModel private[ml](
   // only called in copy()
   def this(uid: String) = this(uid, 2, null)
 
+  /**
+   * Get the native booster instance of this model.
+   * This is used to call low-level APIs on native booster, such as "getFeatureScore".
+   */
+  def nativeBooster: Booster = _booster
+
   private var trainingSummary: Option[XGBoostTrainingSummary] = None
 
   /**

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -207,6 +207,12 @@ class XGBoostRegressionModel private[ml] (
   // only called in copy()
   def this(uid: String) = this(uid, null)
 
+  /**
+   * Get the native booster instance of this model.
+   * This is used to call low-level APIs on native booster, such as "getFeatureScore".
+   */
+  def nativeBooster: Booster = _booster
+
   private var trainingSummary: Option[XGBoostTrainingSummary] = None
 
   /**


### PR DESCRIPTION
This is used to call low-level APIs on native booster, such as "getFeatureScore".