### PR TITLE
fixed MinGW missed dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ else()
   # Performance
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops")
 endif()
+if(WIN32 AND MINGW)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++")
+endif()
 
 # AVX
 if(USE_AVX)


### PR DESCRIPTION
Fixed #977. Very old issue, but is still presented while xgboost installation via MinGW.