### PR TITLE
[TREE] Interaction Constraints again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ if(USE_AVX)
   add_definitions(-DXGBOOST_USE_AVX)
 endif()
 
+# enable custom logging
+add_definitions(-DDMLC_LOG_CUSTOMIZE=1)
 
 # compiled code customizations for R package
 if(R_LIB)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
 dockerRun = 'tests/ci_build/ci_build.sh'
 
 def buildMatrix = [
-    [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": true,  "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "9.1" ],
+    [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": true,  "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "9.2" ],
     [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": true,  "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "8.0" ],
     [ "enabled": false,  "os" : "linux", "withGpu": false, "withNccl": false, "withOmp": true, "pythonVersion": "2.7", "cudaVersion": ""  ],
 ]

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
 endif
 
 export LDFLAGS= -pthread -lm $(ADD_LDFLAGS) $(DMLC_LDFLAGS) $(PLUGIN_LDFLAGS)
-export CFLAGS=  -std=c++11 -Wall -Wno-unknown-pragmas -Iinclude $(ADD_CFLAGS) $(PLUGIN_CFLAGS)
+export CFLAGS= -DDMLC_LOG_CUSTOMIZE=1 -std=c++11 -Wall -Wno-unknown-pragmas -Iinclude $(ADD_CFLAGS) $(PLUGIN_CFLAGS)
 CFLAGS += -I$(DMLC_CORE)/include -I$(RABIT)/include -I$(GTEST_PATH)/include
 #java include path
 export JAVAINCFLAGS = -I${JAVA_HOME}/include -I./java

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ XGBoost Change Log
 
 This file records the changes in xgboost library in reverse chronological order.
 
+## v0.72.1 (2018.07.08)
+This version is only applicable for the Python package. The content is identical to that of v0.72.
+
 ## v0.72 (2018.06.01)
 * Starting with this release, we plan to make a new release every two months. See #3252 for more details.
 * Fix a pathological behavior (near-zero second-order gradients) in multiclass objective (#3304)

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -27,13 +27,13 @@ NVL <- function(x, val) {
 
 # Merges booster params with whatever is provided in ...
 # plus runs some checks
-check.booster.params <- function(params, ...) {
-  if (typeof(params) != "list") 
+check.booster.params <- function(params, column_names, ...) {
+  if (typeof(params) != "list")
     stop("params must be a list")
-  
+
   # in R interface, allow for '.' instead of '_' in parameter names
   names(params) <- gsub("\\.", "_", names(params))
-  
+
   # merge parameters from the params and the dots-expansion
   dot_params <- list(...)
   names(dot_params) <- gsub("\\.", "_", names(dot_params))
@@ -41,15 +41,15 @@ check.booster.params <- function(params, ...) {
                        names(dot_params))) > 0)
     stop("Same parameters in 'params' and in the call are not allowed. Please check your 'params' list.")
   params <- c(params, dot_params)
-  
+
   # providing a parameter multiple times makes sense only for 'eval_metric'
   name_freqs <- table(names(params))
   multi_names <- setdiff(names(name_freqs[name_freqs > 1]), 'eval_metric')
   if (length(multi_names) > 0) {
     warning("The following parameters were provided multiple times:\n\t",
             paste(multi_names, collapse = ', '), "\n  Only the last value for each of them will be used.\n")
-    # While xgboost internals would choose the last value for a multiple-times parameter, 
-    # enforce it here in R as well (b/c multi-parameters might be used further in R code, 
+    # While xgboost internals would choose the last value for a multiple-times parameter,
+    # enforce it here in R as well (b/c multi-parameters might be used further in R code,
     # and R takes the 1st value when multiple elements with the same name are present in a list).
     for (n in multi_names) {
       del_idx <- which(n == names(params))
@@ -57,23 +57,49 @@ check.booster.params <- function(params, ...) {
       params[[del_idx]] <- NULL
     }
   }
-  
+
   # for multiclass, expect num_class to be set
   if (typeof(params[['objective']]) == "character" &&
       substr(NVL(params[['objective']], 'x'), 1, 6) == 'multi:' &&
       as.numeric(NVL(params[['num_class']], 0)) < 2) {
         stop("'num_class' > 1 parameter must be set for multiclass classification")
   }
-  
+
   # monotone_constraints parser
-  
   if (!is.null(params[['monotone_constraints']]) &&
       typeof(params[['monotone_constraints']]) != "character") {
         vec2str = paste(params[['monotone_constraints']], collapse = ',')
         vec2str = paste0('(', vec2str, ')')
         params[['monotone_constraints']] = vec2str
   }
-  
+
+  # interaction constraints parser
+  if (!is.null(params[['int_constraints']])){
+    # check input class
+    temp.in_class <- unique(sapply(params[['int_constraints']], class))
+    if (length(temp.in_class) > 1) stop('invalid class specification for int_constraints')
+    if (is.null(column_names)) stop('require column names to set interaction constraints')
+
+    # initialise list
+    int.cont <- list()
+    length(int.cont) <- length(params[['int_constraints']])
+
+    # convert input to list of 1/0 vectors
+    for (i in 1:length(params[['int_constraints']])){
+      int.cont[[i]] <- as.integer(column_names %in% params[['int_constraints']][[i]])
+      if (all(params[['int_constraints']][[i]] %in% column_names) == F)
+        stop('unknown variable names in int_constraints')
+    }
+
+    # recast parameter as string
+    params[['int_constraints']] <- as.vector(data.matrix(data.frame(int.cont)))
+    vec2str <- paste(params[['int_constraints']], collapse=',')
+    vec2str <- paste0('(', vec2str, ')')
+    params[['int_constraints']] <- vec2str
+
+    # number of specified interactions in interaction constraints
+    params[['nint_constraints']] <- length(params[['int_constraints']])
+  }
   return(params)
 }
 
@@ -83,10 +109,10 @@ check.booster.params <- function(params, ...) {
 check.custom.obj <- function(env = parent.frame()) {
   if (!is.null(env$params[['objective']]) && !is.null(env$obj))
     stop("Setting objectives in 'params' and 'obj' at the same time is not allowed")
-  
+
   if (!is.null(env$obj) && typeof(env$obj) != 'closure')
     stop("'obj' must be a function")
-  
+
   # handle the case when custom objective function was provided through params
   if (!is.null(env$params[['objective']]) &&
       typeof(env$params$objective) == 'closure') {
@@ -100,21 +126,21 @@ check.custom.obj <- function(env = parent.frame()) {
 check.custom.eval <- function(env = parent.frame()) {
   if (!is.null(env$params[['eval_metric']]) && !is.null(env$feval))
     stop("Setting evaluation metrics in 'params' and 'feval' at the same time is not allowed")
-  
+
   if (!is.null(env$feval) && typeof(env$feval) != 'closure')
     stop("'feval' must be a function")
-  
+
   # handle a situation when custom eval function was provided through params
   if (!is.null(env$params[['eval_metric']]) &&
       typeof(env$params$eval_metric) == 'closure') {
     env$feval <- env$params$eval_metric
     env$params$eval_metric <- NULL
   }
-  
+
   # require maximize to be set when custom feval and early stopping are used together
   if (!is.null(env$feval) &&
       is.null(env$maximize) && (
-        !is.null(env$early_stopping_rounds) || 
+        !is.null(env$early_stopping_rounds) ||
         has.callbacks(env$callbacks, 'cb.early.stop')))
     stop("Please set 'maximize' to indicate whether the evaluation metric needs to be maximized or not")
 }
@@ -141,15 +167,15 @@ xgb.iter.update <- function(booster_handle, dtrain, iter, obj = NULL) {
 
 
 # Evaluate one iteration.
-# Returns a named vector of evaluation metrics 
+# Returns a named vector of evaluation metrics
 # with the names in a 'datasetname-metricname' format.
 xgb.iter.eval <- function(booster_handle, watchlist, iter, feval = NULL) {
   if (!identical(class(booster_handle), "xgb.Booster.handle"))
     stop("class of booster_handle must be xgb.Booster.handle")
 
-  if (length(watchlist) == 0) 
+  if (length(watchlist) == 0)
     return(NULL)
-  
+
   evnames <- names(watchlist)
   if (is.null(feval)) {
     msg <- .Call(XGBoosterEvalOneIter_R, booster_handle, as.integer(iter), watchlist, as.list(evnames))
@@ -176,7 +202,7 @@ xgb.iter.eval <- function(booster_handle, watchlist, iter, feval = NULL) {
 
 # Generates random (stratified if needed) CV folds
 generate.cv.folds <- function(nfold, nrows, stratified, label, params) {
-  
+
   # cannot do it for rank
   if (exists('objective', where = params) &&
       is.character(params$objective) &&
@@ -279,22 +305,22 @@ xgb.createFolds <- function(y, k = 10)
 #
 
 #' Deprecation notices.
-#' 
+#'
 #' At this time, some of the parameter names were changed in order to make the code style more uniform.
 #' The deprecated parameters would be removed in the next release.
-#' 
+#'
 #' To see all the current deprecated and new parameters, check the \code{xgboost:::depr_par_lut} table.
-#' 
-#' A deprecation warning is shown when any of the deprecated parameters is used in a call. 
-#' An additional warning is shown when there was a partial match to a deprecated parameter 
+#'
+#' A deprecation warning is shown when any of the deprecated parameters is used in a call.
+#' An additional warning is shown when there was a partial match to a deprecated parameter
 #' (as R is able to partially match parameter names).
-#' 
+#'
 #' @name xgboost-deprecated
 NULL
 
 # Lookup table for the deprecated parameters bookkeeping
 depr_par_lut <- matrix(c(
-  'print.every.n', 'print_every_n', 
+  'print.every.n', 'print_every_n',
   'early.stop.round', 'early_stopping_rounds',
   'training.data', 'data',
   'with.stats', 'with_stats',

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -80,6 +80,9 @@ check.booster.params <- function(params, column_names, ...) {
     if (length(temp.in_class) > 1) stop('invalid class specification for int_constraints')
     if (is.null(column_names)) stop('require column names to set interaction constraints')
 
+    # number of specified interactions in interaction constraints
+    params[['nint_constraints']] <- length(params[['int_constraints']])
+
     # initialise list
     int.cont <- list()
     length(int.cont) <- length(params[['int_constraints']])
@@ -96,9 +99,6 @@ check.booster.params <- function(params, column_names, ...) {
     vec2str <- paste(params[['int_constraints']], collapse=',')
     vec2str <- paste0('(', vec2str, ')')
     params[['int_constraints']] <- vec2str
-
-    # number of specified interactions in interaction constraints
-    params[['nint_constraints']] <- length(params[['int_constraints']])
   }
   return(params)
 }

--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -1,7 +1,7 @@
 #' Cross Validation
-#' 
+#'
 #' The cross validation function of xgboost
-#' 
+#'
 #' @param params the list of parameters. Commonly used ones are:
 #' \itemize{
 #'   \item \code{objective} objective function, common ones are
@@ -18,12 +18,12 @@
 #'   See also demo/ for walkthrough example in R.
 #' @param data takes an \code{xgb.DMatrix}, \code{matrix}, or \code{dgCMatrix} as the input.
 #' @param nrounds the max number of iterations
-#' @param nfold the original dataset is randomly partitioned into \code{nfold} equal size subsamples. 
+#' @param nfold the original dataset is randomly partitioned into \code{nfold} equal size subsamples.
 #' @param label vector of response values. Should be provided only when data is an R-matrix.
-#' @param missing is only used when input is a dense matrix. By default is set to NA, which means 
-#'        that NA values should be considered as 'missing' by the algorithm. 
+#' @param missing is only used when input is a dense matrix. By default is set to NA, which means
+#'        that NA values should be considered as 'missing' by the algorithm.
 #'        Sometimes, 0 or other extreme value might be used to represent missing values.
-#' @param prediction A logical value indicating whether to return the test fold predictions 
+#' @param prediction A logical value indicating whether to return the test fold predictions
 #'        from each CV model. This parameter engages the \code{\link{cb.cv.predict}} callback.
 #' @param showsd \code{boolean}, whether to show standard deviation of cross validation
 #' @param metrics, list of evaluation metrics to be used in cross validation,
@@ -37,22 +37,22 @@
 #'   \item \code{aucpr} Area under PR curve
 #'   \item \code{merror} Exact matching error, used to evaluate multi-class classification
 #' }
-#' @param obj customized objective function. Returns gradient and second order 
+#' @param obj customized objective function. Returns gradient and second order
 #'        gradient with given prediction and dtrain.
-#' @param feval custimized evaluation function. Returns 
-#'        \code{list(metric='metric-name', value='metric-value')} with given 
+#' @param feval custimized evaluation function. Returns
+#'        \code{list(metric='metric-name', value='metric-value')} with given
 #'        prediction and dtrain.
-#' @param stratified a \code{boolean} indicating whether sampling of folds should be stratified 
+#' @param stratified a \code{boolean} indicating whether sampling of folds should be stratified
 #'        by the values of outcome labels.
 #' @param folds \code{list} provides a possibility to use a list of pre-defined CV folds
-#'        (each element must be a vector of test fold's indices). When folds are supplied, 
+#'        (each element must be a vector of test fold's indices). When folds are supplied,
 #'        the \code{nfold} and \code{stratified} parameters are ignored.
 #' @param verbose \code{boolean}, print the statistics during the process
 #' @param print_every_n Print each n-th iteration evaluation messages when \code{verbose>0}.
-#'        Default is 1 which means all messages are printed. This parameter is passed to the 
+#'        Default is 1 which means all messages are printed. This parameter is passed to the
 #'        \code{\link{cb.print.evaluation}} callback.
-#' @param early_stopping_rounds If \code{NULL}, the early stopping function is not triggered. 
-#'        If set to an integer \code{k}, training with a validation set will stop if the performance 
+#' @param early_stopping_rounds If \code{NULL}, the early stopping function is not triggered.
+#'        If set to an integer \code{k}, training with a validation set will stop if the performance
 #'        doesn't improve for \code{k} rounds.
 #'        Setting this parameter engages the \code{\link{cb.early.stop}} callback.
 #' @param maximize If \code{feval} and \code{early_stopping_rounds} are set,
@@ -60,46 +60,46 @@
 #'        When it is \code{TRUE}, it means the larger the evaluation score the better.
 #'        This parameter is passed to the \code{\link{cb.early.stop}} callback.
 #' @param callbacks a list of callback functions to perform various task during boosting.
-#'        See \code{\link{callbacks}}. Some of the callbacks are automatically created depending on the 
-#'        parameters' values. User can provide either existing or their own callback methods in order 
+#'        See \code{\link{callbacks}}. Some of the callbacks are automatically created depending on the
+#'        parameters' values. User can provide either existing or their own callback methods in order
 #'        to customize the training process.
 #' @param ... other parameters to pass to \code{params}.
-#' 
-#' @details 
-#' The original sample is randomly partitioned into \code{nfold} equal size subsamples. 
-#' 
-#' Of the \code{nfold} subsamples, a single subsample is retained as the validation data for testing the model, and the remaining \code{nfold - 1} subsamples are used as training data. 
-#' 
+#'
+#' @details
+#' The original sample is randomly partitioned into \code{nfold} equal size subsamples.
+#'
+#' Of the \code{nfold} subsamples, a single subsample is retained as the validation data for testing the model, and the remaining \code{nfold - 1} subsamples are used as training data.
+#'
 #' The cross-validation process is then repeated \code{nrounds} times, with each of the \code{nfold} subsamples used exactly once as the validation data.
-#' 
+#'
 #' All observations are used for both training and validation.
-#' 
+#'
 #' Adapted from \url{http://en.wikipedia.org/wiki/Cross-validation_\%28statistics\%29#k-fold_cross-validation}
 #'
-#' @return 
+#' @return
 #' An object of class \code{xgb.cv.synchronous} with the following elements:
 #' \itemize{
 #'   \item \code{call} a function call.
-#'   \item \code{params} parameters that were passed to the xgboost library. Note that it does not 
+#'   \item \code{params} parameters that were passed to the xgboost library. Note that it does not
 #'         capture parameters changed by the \code{\link{cb.reset.parameters}} callback.
-#'   \item \code{callbacks} callback functions that were either automatically assigned or 
+#'   \item \code{callbacks} callback functions that were either automatically assigned or
 #'         explicitly passed.
 #'   \item \code{evaluation_log} evaluation history storead as a \code{data.table} with the
-#'         first column corresponding to iteration number and the rest corresponding to the 
+#'         first column corresponding to iteration number and the rest corresponding to the
 #'         CV-based evaluation means and standard deviations for the training and test CV-sets.
 #'         It is created by the \code{\link{cb.evaluation.log}} callback.
 #'   \item \code{niter} number of boosting iterations.
 #'   \item \code{nfeatures} number of features in training data.
-#'   \item \code{folds} the list of CV folds' indices - either those passed through the \code{folds} 
+#'   \item \code{folds} the list of CV folds' indices - either those passed through the \code{folds}
 #'         parameter or randomly generated.
 #'   \item \code{best_iteration} iteration number with the best evaluation metric value
 #'         (only available with early stopping).
-#'   \item \code{best_ntreelimit} the \code{ntreelimit} value corresponding to the best iteration, 
+#'   \item \code{best_ntreelimit} the \code{ntreelimit} value corresponding to the best iteration,
 #'         which could further be used in \code{predict} method
 #'         (only available with early stopping).
-#'   \item \code{pred} CV prediction values available when \code{prediction} is set. 
+#'   \item \code{pred} CV prediction values available when \code{prediction} is set.
 #'         It is either vector or matrix (see \code{\link{cb.cv.predict}}).
-#'   \item \code{models} a liost of the CV folds' models. It is only available with the explicit 
+#'   \item \code{models} a liost of the CV folds' models. It is only available with the explicit
 #'         setting of the \code{cb.cv.predict(save_models = TRUE)} callback.
 #' }
 #'
@@ -110,32 +110,32 @@
 #'                   max_depth = 3, eta = 1, objective = "binary:logistic")
 #' print(cv)
 #' print(cv, verbose=TRUE)
-#' 
+#'
 #' @export
 xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = NA,
                    prediction = FALSE, showsd = TRUE, metrics=list(),
-                   obj = NULL, feval = NULL, stratified = TRUE, folds = NULL, 
+                   obj = NULL, feval = NULL, stratified = TRUE, folds = NULL,
                    verbose = TRUE, print_every_n=1L,
                    early_stopping_rounds = NULL, maximize = NULL, callbacks = list(), ...) {
 
   check.deprecation(...)
-  
-  params <- check.booster.params(params, ...)
+
+  params <- check.booster.params(params, column_names = colnames(data), ...)
   # TODO: should we deprecate the redundant 'metrics' parameter?
   for (m in metrics)
     params <- c(params, list("eval_metric" = m))
-  
+
   check.custom.obj()
   check.custom.eval()
 
   #if (is.null(params[['eval_metric']]) && is.null(feval))
   #  stop("Either 'eval_metric' or 'feval' must be provided for CV")
-  
+
   # Check the labels
   if ( (inherits(data, 'xgb.DMatrix') && is.null(getinfo(data, 'label'))) ||
        (!inherits(data, 'xgb.DMatrix') && is.null(label)))
     stop("Labels must be provided for CV either through xgb.DMatrix, or through 'label=' when 'data' is matrix")
-  
+
   # CV folds
   if(!is.null(folds)) {
     if(!is.list(folds) || length(folds) < 2)
@@ -146,7 +146,7 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
       stop("'nfold' must be > 1")
     folds <- generate.cv.folds(nfold, nrow(data), stratified, label, params)
   }
-  
+
   # Potential TODO: sequential CV
   #if (strategy == 'sequential')
   #  stop('Sequential CV strategy is not yet implemented')
@@ -166,7 +166,7 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
   stop_condition <- FALSE
   if (!is.null(early_stopping_rounds) &&
       !has.callbacks(callbacks, 'cb.early.stop')) {
-    callbacks <- add.cb(callbacks, cb.early.stop(early_stopping_rounds, 
+    callbacks <- add.cb(callbacks, cb.early.stop(early_stopping_rounds,
                                                  maximize = maximize, verbose = verbose))
   }
   # CV-predictions callback
@@ -177,7 +177,7 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
   # Sort the callbacks into categories
   cb <- categorize.callbacks(callbacks)
 
-  
+
   # create the booster-folds
   dall <- xgb.get.DMatrix(data, label, missing)
   bst_folds <- lapply(seq_along(folds), function(k) {
@@ -197,12 +197,12 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
   # those are fixed for CV (no training continuation)
   begin_iteration <- 1
   end_iteration <- nrounds
-  
+
   # synchronous CV boosting: run CV folds' models within each iteration
   for (iteration in begin_iteration:end_iteration) {
-    
+
     for (f in cb$pre_iter) f()
-    
+
     msg <- lapply(bst_folds, function(fd) {
       xgb.iter.update(fd$bst, fd$dtrain, iteration - 1, obj)
       xgb.iter.eval(fd$bst, fd$watchlist, iteration - 1, feval)
@@ -210,9 +210,9 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
     msg <- simplify2array(msg)
     bst_evaluation <- rowMeans(msg)
     bst_evaluation_err <- sqrt(rowMeans(msg^2) - bst_evaluation^2)
-    
+
     for (f in cb$post_iter) f()
-    
+
     if (stop_condition) break
   }
   for (f in cb$finalize) f(finalize = TRUE)
@@ -236,17 +236,17 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
 
 
 #' Print xgb.cv result
-#' 
+#'
 #' Prints formatted results of \code{xgb.cv}.
-#' 
+#'
 #' @param x an \code{xgb.cv.synchronous} object
 #' @param verbose whether to print detailed data
 #' @param ... passed to \code{data.table.print}
-#' 
+#'
 #' @details
-#' When not verbose, it would only print the evaluation results, 
+#' When not verbose, it would only print the evaluation results,
 #' including the best iteration (when available).
-#' 
+#'
 #' @examples
 #' data(agaricus.train, package='xgboost')
 #' train <- agaricus.train
@@ -254,13 +254,13 @@ xgb.cv <- function(params=list(), data, nrounds, nfold, label = NULL, missing = 
 #'                eta = 1, nthread = 2, nrounds = 2, objective = "binary:logistic")
 #' print(cv)
 #' print(cv, verbose=TRUE)
-#' 
+#'
 #' @rdname print.xgb.cv
 #' @method print xgb.cv.synchronous
 #' @export
 print.xgb.cv.synchronous <- function(x, verbose = FALSE, ...) {
   cat('##### xgb.cv ', length(x$folds), '-folds\n', sep = '')
-  
+
   if (verbose) {
     if (!is.null(x$call)) {
       cat('call:\n  ')
@@ -268,8 +268,8 @@ print.xgb.cv.synchronous <- function(x, verbose = FALSE, ...) {
     }
     if (!is.null(x$params)) {
       cat('params (as set within xgb.cv):\n')
-      cat( '  ', 
-           paste(names(x$params), 
+      cat( '  ',
+           paste(names(x$params),
                  paste0('"', unlist(x$params), '"'),
                  sep = ' = ', collapse = ', '), '\n', sep = '')
     }
@@ -280,9 +280,9 @@ print.xgb.cv.synchronous <- function(x, verbose = FALSE, ...) {
         print(x)
       })
     }
-    
+
     for (n in c('niter', 'best_iteration', 'best_ntreelimit')) {
-      if (is.null(x[[n]])) 
+      if (is.null(x[[n]]))
         next
       cat(n, ': ', x[[n]], '\n', sep = '')
     }
@@ -293,10 +293,10 @@ print.xgb.cv.synchronous <- function(x, verbose = FALSE, ...) {
     }
   }
 
-  if (verbose) 
+  if (verbose)
     cat('evaluation_log:\n')
   print(x$evaluation_log, row.names = FALSE, ...)
-  
+
   if (!is.null(x$best_iteration)) {
     cat('Best iteration:\n')
     print(x$evaluation_log[x$best_iteration], row.names = FALSE, ...)

--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -1,43 +1,44 @@
 #' eXtreme Gradient Boosting Training
-#' 
+#'
 #' \code{xgb.train} is an advanced interface for training an xgboost model.
 #' The \code{xgboost} function is a simpler wrapper for \code{xgb.train}.
 #'
-#' @param params the list of parameters. 
+#' @param params the list of parameters.
 #'        The complete list of parameters is available at \url{http://xgboost.readthedocs.io/en/latest/parameter.html}.
 #'        Below is a shorter summary:
-#' 
+#'
 #' 1. General Parameters
-#' 
+#'
 #' \itemize{
 #'   \item \code{booster} which booster to use, can be \code{gbtree} or \code{gblinear}. Default: \code{gbtree}.
 #' }
-#'  
+#'
 #' 2. Booster Parameters
-#' 
+#'
 #' 2.1. Parameter for Tree Booster
-#' 
+#'
 #' \itemize{
 #'   \item \code{eta} control the learning rate: scale the contribution of each tree by a factor of \code{0 < eta < 1} when it is added to the current approximation. Used to prevent overfitting by making the boosting process more conservative. Lower value for \code{eta} implies larger value for \code{nrounds}: low \code{eta} value means model more robust to overfitting but slower to compute. Default: 0.3
-#'   \item \code{gamma} minimum loss reduction required to make a further partition on a leaf node of the tree. the larger, the more conservative the algorithm will be. 
+#'   \item \code{gamma} minimum loss reduction required to make a further partition on a leaf node of the tree. the larger, the more conservative the algorithm will be.
 #'   \item \code{max_depth} maximum depth of a tree. Default: 6
 #'   \item \code{min_child_weight} minimum sum of instance weight (hessian) needed in a child. If the tree partition step results in a leaf node with the sum of instance weight less than min_child_weight, then the building process will give up further partitioning. In linear regression mode, this simply corresponds to minimum number of instances needed to be in each node. The larger, the more conservative the algorithm will be. Default: 1
-#'   \item \code{subsample} subsample ratio of the training instance. Setting it to 0.5 means that xgboost randomly collected half of the data instances to grow trees and this will prevent overfitting. It makes computation shorter (because less data to analyse). It is advised to use this parameter with \code{eta} and increase \code{nround}. Default: 1 
+#'   \item \code{subsample} subsample ratio of the training instance. Setting it to 0.5 means that xgboost randomly collected half of the data instances to grow trees and this will prevent overfitting. It makes computation shorter (because less data to analyse). It is advised to use this parameter with \code{eta} and increase \code{nround}. Default: 1
 #'   \item \code{colsample_bytree} subsample ratio of columns when constructing each tree. Default: 1
 #'   \item \code{num_parallel_tree} Experimental parameter. number of trees to grow per round. Useful to test Random Forest through Xgboost (set \code{colsample_bytree < 1}, \code{subsample  < 1}  and \code{round = 1}) accordingly. Default: 1
 #'   \item \code{monotone_constraints} A numerical vector consists of \code{1}, \code{0} and \code{-1} with its length equals to the number of features in the training data. \code{1} is increasing, \code{-1} is decreasing and \code{0} is no constraint.
+#'   \item \code{int_constraints} A list of character vectors specifying column names for interaction constraints - each item of the list represents the columns of one permissible interaction.  Leave unspecified for no interaction constraints.
 #' }
-#' 
+#'
 #' 2.2. Parameter for Linear Booster
-#'  
+#'
 #' \itemize{
 #'   \item \code{lambda} L2 regularization term on weights. Default: 0
 #'   \item \code{lambda_bias} L2 regularization term on bias. Default: 0
 #'   \item \code{alpha} L1 regularization term on weights. (there is no L1 reg on bias because it is not important). Default: 0
 #' }
-#' 
-#' 3. Task Parameters 
-#' 
+#'
+#' 3. Task Parameters
+#'
 #' \itemize{
 #' \item \code{objective} specify the learning task and the corresponding learning objective, users can pass a self-defined function to it. The default objective options are below:
 #'   \itemize{
@@ -53,32 +54,32 @@
 #'   \item \code{base_score} the initial prediction score of all instances, global bias. Default: 0.5
 #'   \item \code{eval_metric} evaluation metrics for validation data. Users can pass a self-defined function to it. Default: metric will be assigned according to objective(rmse for regression, and error for classification, mean average precision for ranking). List is provided in detail section.
 #' }
-#' 
+#'
 #' @param data training dataset. \code{xgb.train} accepts only an \code{xgb.DMatrix} as the input.
 #'        \code{xgboost}, in addition, also accepts \code{matrix}, \code{dgCMatrix}, or name of a local data file.
 #' @param nrounds max number of boosting iterations.
 #' @param watchlist named list of xgb.DMatrix datasets to use for evaluating model performance.
 #'        Metrics specified in either \code{eval_metric} or \code{feval} will be computed for each
-#'        of these datasets during each boosting iteration, and stored in the end as a field named 
-#'        \code{evaluation_log} in the resulting object. When either \code{verbose>=1} or 
+#'        of these datasets during each boosting iteration, and stored in the end as a field named
+#'        \code{evaluation_log} in the resulting object. When either \code{verbose>=1} or
 #'        \code{\link{cb.print.evaluation}} callback is engaged, the performance results are continuously
-#'        printed out during the training. 
+#'        printed out during the training.
 #'        E.g., specifying \code{watchlist=list(validation1=mat1, validation2=mat2)} allows to track
 #'        the performance of each round's model on mat1 and mat2.
-#' @param obj customized objective function. Returns gradient and second order 
+#' @param obj customized objective function. Returns gradient and second order
 #'        gradient with given prediction and dtrain.
-#' @param feval custimized evaluation function. Returns 
-#'        \code{list(metric='metric-name', value='metric-value')} with given 
+#' @param feval custimized evaluation function. Returns
+#'        \code{list(metric='metric-name', value='metric-value')} with given
 #'        prediction and dtrain.
 #' @param verbose If 0, xgboost will stay silent. If 1, it will print information about performance.
 #'        If 2, some additional information will be printed out.
-#'        Note that setting \code{verbose > 0} automatically engages the 
+#'        Note that setting \code{verbose > 0} automatically engages the
 #'        \code{cb.print.evaluation(period=1)} callback function.
 #' @param print_every_n Print each n-th iteration evaluation messages when \code{verbose>0}.
-#'        Default is 1 which means all messages are printed. This parameter is passed to the 
+#'        Default is 1 which means all messages are printed. This parameter is passed to the
 #'        \code{\link{cb.print.evaluation}} callback.
-#' @param early_stopping_rounds If \code{NULL}, the early stopping function is not triggered. 
-#'        If set to an integer \code{k}, training with a validation set will stop if the performance 
+#' @param early_stopping_rounds If \code{NULL}, the early stopping function is not triggered.
+#'        If set to an integer \code{k}, training with a validation set will stop if the performance
 #'        doesn't improve for \code{k} rounds.
 #'        Setting this parameter engages the \code{\link{cb.early.stop}} callback.
 #' @param maximize If \code{feval} and \code{early_stopping_rounds} are set,
@@ -89,33 +90,33 @@
 #'        0 means save at the end. The saving is handled by the \code{\link{cb.save.model}} callback.
 #' @param save_name the name or path for periodically saved model file.
 #' @param xgb_model a previously built model to continue the training from.
-#'        Could be either an object of class \code{xgb.Booster}, or its raw data, or the name of a 
+#'        Could be either an object of class \code{xgb.Booster}, or its raw data, or the name of a
 #'        file with a previously saved model.
 #' @param callbacks a list of callback functions to perform various task during boosting.
-#'        See \code{\link{callbacks}}. Some of the callbacks are automatically created depending on the 
-#'        parameters' values. User can provide either existing or their own callback methods in order 
+#'        See \code{\link{callbacks}}. Some of the callbacks are automatically created depending on the
+#'        parameters' values. User can provide either existing or their own callback methods in order
 #'        to customize the training process.
 #' @param ... other parameters to pass to \code{params}.
-#' @param label vector of response values. Should not be provided when data is 
+#' @param label vector of response values. Should not be provided when data is
 #'        a local data file name or an \code{xgb.DMatrix}.
 #' @param missing by default is set to NA, which means that NA values should be considered as 'missing'
 #'        by the algorithm. Sometimes, 0 or other extreme value might be used to represent missing values.
 #'        This parameter is only used when input is a dense matrix.
 #' @param weight a vector indicating the weight for each row of the input.
-#' 
-#' @details 
-#' These are the training functions for \code{xgboost}. 
-#' 
-#' The \code{xgb.train} interface supports advanced features such as \code{watchlist}, 
-#' customized objective and evaluation metric functions, therefore it is more flexible 
+#'
+#' @details
+#' These are the training functions for \code{xgboost}.
+#'
+#' The \code{xgb.train} interface supports advanced features such as \code{watchlist},
+#' customized objective and evaluation metric functions, therefore it is more flexible
 #' than the \code{xgboost} interface.
 #'
-#' Parallelization is automatically enabled if \code{OpenMP} is present. 
+#' Parallelization is automatically enabled if \code{OpenMP} is present.
 #' Number of threads can also be manually specified via \code{nthread} parameter.
-#' 
+#'
 #' The evaluation metric is chosen automatically by Xgboost (according to the objective)
 #' when the \code{eval_metric} parameter is not provided.
-#' User may set one or several \code{eval_metric} parameters. 
+#' User may set one or several \code{eval_metric} parameters.
 #' Note that when using a customized metric, only this single metric can be used.
 #' The folloiwing is the list of built-in metrics for which Xgboost provides optimized implementation:
 #'   \itemize{
@@ -130,7 +131,7 @@
 #'      \item \code{aucpr} Area under the PR curve. \url{https://en.wikipedia.org/wiki/Precision_and_recall} for ranking evaluation.
 #'      \item \code{ndcg} Normalized Discounted Cumulative Gain (for ranking task). \url{http://en.wikipedia.org/wiki/NDCG}
 #'   }
-#' 
+#'
 #' The following callbacks are automatically created when certain parameters are set:
 #' \itemize{
 #'   \item \code{cb.print.evaluation} is turned on when \code{verbose > 0};
@@ -139,8 +140,8 @@
 #'   \item \code{cb.early.stop}: when \code{early_stopping_rounds} is set.
 #'   \item \code{cb.save.model}: when \code{save_period > 0} is set.
 #' }
-#' 
-#' @return 
+#'
+#' @return
 #' An object of class \code{xgb.Booster} with the following elements:
 #' \itemize{
 #'   \item \code{handle} a handle (pointer) to the xgboost model in memory.
@@ -150,13 +151,13 @@
 #'         first column corresponding to iteration number and the rest corresponding to evaluation
 #'         metrics' values. It is created by the \code{\link{cb.evaluation.log}} callback.
 #'   \item \code{call} a function call.
-#'   \item \code{params} parameters that were passed to the xgboost library. Note that it does not 
+#'   \item \code{params} parameters that were passed to the xgboost library. Note that it does not
 #'         capture parameters changed by the \code{\link{cb.reset.parameters}} callback.
-#'   \item \code{callbacks} callback functions that were either automatically assigned or 
+#'   \item \code{callbacks} callback functions that were either automatically assigned or
 #'         explicitely passed.
 #'   \item \code{best_iteration} iteration number with the best evaluation metric value
 #'         (only available with early stopping).
-#'   \item \code{best_ntreelimit} the \code{ntreelimit} value corresponding to the best iteration, 
+#'   \item \code{best_ntreelimit} the \code{ntreelimit} value corresponding to the best iteration,
 #'         which could further be used in \code{predict} method
 #'         (only available with early stopping).
 #'   \item \code{best_score} the best evaluation metric value during early stopping.
@@ -165,12 +166,12 @@
 #'         (only when comun names were defined in training data).
 #'   \item \code{nfeatures} number of features in training data.
 #' }
-#' 
+#'
 #' @seealso
 #' \code{\link{callbacks}},
 #' \code{\link{predict.xgb.Booster}},
 #' \code{\link{xgb.cv}}
-#' 
+#'
 #' @references
 #'
 #' Tianqi Chen and Carlos Guestrin, "XGBoost: A Scalable Tree Boosting System",
@@ -179,17 +180,17 @@
 #' @examples
 #' data(agaricus.train, package='xgboost')
 #' data(agaricus.test, package='xgboost')
-#' 
+#'
 #' dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 #' dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 #' watchlist <- list(train = dtrain, eval = dtest)
-#' 
+#'
 #' ## A simple xgb.train example:
-#' param <- list(max_depth = 2, eta = 1, silent = 1, nthread = 2, 
+#' param <- list(max_depth = 2, eta = 1, silent = 1, nthread = 2,
 #'               objective = "binary:logistic", eval_metric = "auc")
 #' bst <- xgb.train(param, dtrain, nrounds = 2, watchlist)
-#' 
-#' 
+#'
+#'
 #' ## An xgb.train example where custom objective and evaluation metric are used:
 #' logregobj <- function(preds, dtrain) {
 #'    labels <- getinfo(dtrain, "label")
@@ -203,58 +204,58 @@
 #'   err <- as.numeric(sum(labels != (preds > 0)))/length(labels)
 #'   return(list(metric = "error", value = err))
 #' }
-#' 
+#'
 #' # These functions could be used by passing them either:
 #' #  as 'objective' and 'eval_metric' parameters in the params list:
-#' param <- list(max_depth = 2, eta = 1, silent = 1, nthread = 2, 
+#' param <- list(max_depth = 2, eta = 1, silent = 1, nthread = 2,
 #'               objective = logregobj, eval_metric = evalerror)
 #' bst <- xgb.train(param, dtrain, nrounds = 2, watchlist)
-#' 
+#'
 #' #  or through the ... arguments:
 #' param <- list(max_depth = 2, eta = 1, silent = 1, nthread = 2)
 #' bst <- xgb.train(param, dtrain, nrounds = 2, watchlist,
 #'                  objective = logregobj, eval_metric = evalerror)
-#' 
+#'
 #' #  or as dedicated 'obj' and 'feval' parameters of xgb.train:
 #' bst <- xgb.train(param, dtrain, nrounds = 2, watchlist,
 #'                  obj = logregobj, feval = evalerror)
-#' 
-#' 
+#'
+#'
 #' ## An xgb.train example of using variable learning rates at each iteration:
 #' param <- list(max_depth = 2, eta = 1, silent = 1, nthread = 2,
 #'               objective = "binary:logistic", eval_metric = "auc")
 #' my_etas <- list(eta = c(0.5, 0.1))
 #' bst <- xgb.train(param, dtrain, nrounds = 2, watchlist,
 #'                  callbacks = list(cb.reset.parameters(my_etas)))
-#' 
+#'
 #' ## Early stopping:
 #' bst <- xgb.train(param, dtrain, nrounds = 25, watchlist,
 #'                  early_stopping_rounds = 3)
-#' 
+#'
 #' ## An 'xgboost' interface example:
-#' bst <- xgboost(data = agaricus.train$data, label = agaricus.train$label, 
-#'                max_depth = 2, eta = 1, nthread = 2, nrounds = 2, 
+#' bst <- xgboost(data = agaricus.train$data, label = agaricus.train$label,
+#'                max_depth = 2, eta = 1, nthread = 2, nrounds = 2,
 #'                objective = "binary:logistic")
 #' pred <- predict(bst, agaricus.test$data)
-#' 
+#'
 #' @rdname xgb.train
 #' @export
 xgb.train <- function(params = list(), data, nrounds, watchlist = list(),
                       obj = NULL, feval = NULL, verbose = 1, print_every_n = 1L,
                       early_stopping_rounds = NULL, maximize = NULL,
-                      save_period = NULL, save_name = "xgboost.model", 
+                      save_period = NULL, save_name = "xgboost.model",
                       xgb_model = NULL, callbacks = list(), ...) {
-  
+
   check.deprecation(...)
-  
-  params <- check.booster.params(params, ...)
+
+  params <- check.booster.params(params, column_names = colnames(data), ...)
 
   check.custom.obj()
   check.custom.eval()
-  
+
   # data & watchlist checks
   dtrain <- data
-  if (!inherits(dtrain, "xgb.DMatrix")) 
+  if (!inherits(dtrain, "xgb.DMatrix"))
     stop("second argument dtrain must be xgb.DMatrix")
   if (length(watchlist) > 0) {
     if (typeof(watchlist) != "list" ||
@@ -287,7 +288,7 @@ xgb.train <- function(params = list(), data, nrounds, watchlist = list(),
   stop_condition <- FALSE
   if (!is.null(early_stopping_rounds) &&
       !has.callbacks(callbacks, 'cb.early.stop')) {
-    callbacks <- add.cb(callbacks, cb.early.stop(early_stopping_rounds, 
+    callbacks <- add.cb(callbacks, cb.early.stop(early_stopping_rounds,
                                                  maximize = maximize, verbose = verbose))
   }
   # Sort the callbacks into categories
@@ -317,22 +318,22 @@ xgb.train <- function(params = list(), data, nrounds, watchlist = list(),
 
   # TODO: distributed code
   rank <- 0
-  
+
   niter_skip <- ifelse(is_update, 0, niter_init)
   begin_iteration <- niter_skip + 1
   end_iteration <- niter_skip + nrounds
-  
+
   # the main loop for boosting iterations
   for (iteration in begin_iteration:end_iteration) {
-    
+
     for (f in cb$pre_iter) f()
-    
+
     xgb.iter.update(bst$handle, dtrain, iteration - 1, obj)
-    
+
     bst_evaluation <- numeric(0)
     if (length(watchlist) > 0)
       bst_evaluation <- xgb.iter.eval(bst$handle, watchlist, iteration - 1, feval)
-    
+
     xgb.attr(bst$handle, 'niter') <- iteration - 1
 
     for (f in cb$post_iter) f()
@@ -340,9 +341,9 @@ xgb.train <- function(params = list(), data, nrounds, watchlist = list(),
     if (stop_condition) break
   }
   for (f in cb$finalize) f(finalize = TRUE)
-  
+
   bst <- xgb.Booster.complete(bst, saveraw = TRUE)
-  
+
   # store the total number of boosting iterations
   bst$niter = end_iteration
 

--- a/R-package/demo/interaction_constraints.R
+++ b/R-package/demo/interaction_constraints.R
@@ -1,0 +1,74 @@
+library(xgboost)
+library(data.table)
+
+set.seed(1024)
+
+# Function to obtain a list of interactions fitted in trees
+treeInteractions <- function(in.tree, in.depth){
+  temp.tree <- copy(in.tree)
+  if (in.depth < 2) return(list())
+  if (nrow(in.tree) == 1) return(list())
+
+  # Attach parent nodes
+  for (i in 2:in.depth){
+    if (i == 2) temp.tree[, ID_merge:=ID] else temp.tree[, ID_merge:=get(paste0('parent_',i-2))]
+    temp.parents_left <- temp.tree[!is.na(Split), list(i.id=ID, i.feature=Feature, ID_merge=Yes)]
+    temp.parents_right <- temp.tree[!is.na(Split), list(i.id=ID, i.feature=Feature, ID_merge=No)]
+
+    setorderv(temp.tree, 'ID_merge')
+    setorderv(temp.parents_left, 'ID_merge')
+    setorderv(temp.parents_right, 'ID_merge')
+
+    temp.tree <- merge(temp.tree, temp.parents_left, by='ID_merge', all.x=T)
+    temp.tree[!is.na(i.id), c(paste0('parent_',i-1), paste0('parent_feat_',i-1)):=list(i.id,i.feature)]
+    temp.tree[, c('i.id','i.feature'):=NULL]
+
+    temp.tree <- merge(temp.tree, temp.parents_right, by='ID_merge', all.x=T)
+    temp.tree[!is.na(i.id), c(paste0('parent_',i-1), paste0('parent_feat_',i-1)):=list(i.id,i.feature)]
+    temp.tree[, c('i.id','i.feature'):=NULL]
+  }
+
+  # Extract nodes with interactions
+  temp <- temp.tree[!is.na(Split) & !is.na(parent_1)]
+  temp <- temp[, c('Feature',paste0('parent_feat_',1:(in.depth-1))), with=F]
+  temp <- split(temp, 1:nrow(temp))
+  temp.int <- lapply(temp, as.character)
+
+  # Remove NAs (no parent interaction)
+  temp.int <- lapply(temp.int, function(x) x[!is.na(x)])
+
+  # Remove non-interactions (same variable)
+  temp.int <- lapply(temp.int, unique)
+  temp <- sapply(temp.int, length)
+  temp.int <- temp.int[temp > 1]
+  temp.int <- unique(lapply(temp.int, sort))
+
+  return(temp.int)
+}
+
+# Generate sample data
+x <- list()
+for (i in 1:10){
+  x[[i]] = i*rnorm(1000, 10)
+}
+x <- as.data.table(x)
+
+y = -1*x[, rowSums(.SD)] + x[['V1']]*x[['V2']] + x[['V3']]*x[['V4']]*x[['V5']] + rnorm(1000, 0.001) + 3*sin(x[['V7']])
+
+train = as.matrix(x)
+
+# Fit model with interaction constraints
+bst = xgboost(data = train, label = y, max_depth = 4,
+              eta = 0.1, nthread = 2, nrounds = 1000,
+              int_constraints_list = list(c('V1','V2'),c('V3','V4','V5')),
+              split_evaluator = 'interaction')
+
+temp <- xgb.model.dt.tree(colnames(train), bst)
+temp.int <- treeInteractions(temp, 4)  # limited interactions
+
+# Fit model without interaction constraints
+bst2 = xgboost(data = train, label = y, max_depth = 4,
+               eta = 0.1, nthread = 2, nrounds = 1000)
+
+temp <- xgb.model.dt.tree(colnames(train), bst2)
+temp.int2 <- treeInteractions(temp, 4)  # much more interactions

--- a/R-package/demo/interaction_constraints.R
+++ b/R-package/demo/interaction_constraints.R
@@ -60,7 +60,7 @@ train = as.matrix(x)
 # Fit model with interaction constraints
 bst = xgboost(data = train, label = y, max_depth = 4,
               eta = 0.1, nthread = 2, nrounds = 1000,
-              int_constraints_list = list(c('V1','V2'),c('V3','V4','V5')),
+              int_constraints = list(c('V1','V2'),c('V3','V4','V5')),
               split_evaluator = 'interaction')
 
 temp <- xgb.model.dt.tree(colnames(train), bst)

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -97,6 +97,15 @@ XGB_EXTERN_C typedef int XGBCallbackDataIterNext(  // NOLINT(*)
 XGB_DLL const char *XGBGetLastError(void);
 
 /*!
+ * \brief register callback function for LOG(INFO) messages -- helpful messages
+ *        that are not errors.
+ * Note: this function can be called by multiple threads. The callback function
+ *       will run on the thread that registered it
+ * \return 0 for success, -1 for failure
+ */
+XGB_DLL int XGBRegisterLogCallback(void (*callback)(const char*));
+
+/*!
  * \brief load a data matrix
  * \param fname the name of the file
  * \param silent whether print messages during loading

--- a/include/xgboost/logging.h
+++ b/include/xgboost/logging.h
@@ -9,6 +9,7 @@
 #define XGBOOST_LOGGING_H_
 
 #include <dmlc/logging.h>
+#include <dmlc/thread_local.h>
 #include <sstream>
 #include "./base.h"
 
@@ -36,6 +37,23 @@ class TrackerLogger : public BaseLogger {
  public:
   ~TrackerLogger();
 };
+
+class LogCallbackRegistry {
+ public:
+  using Callback = void (*)(const char*);
+  LogCallbackRegistry()
+    : log_callback_([] (const char* msg) { std::cerr << msg << std::endl; }) {}
+  inline void Register(Callback log_callback) {
+    this->log_callback_ = log_callback;
+  }
+  inline Callback Get() const {
+    return log_callback_;
+  }
+ private:
+  Callback log_callback_;
+};
+
+using LogCallbackRegistryStore = dmlc::ThreadLocalStore<LogCallbackRegistry>;
 
 // redefines the logging macro if not existed
 #ifndef LOG

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -398,6 +398,15 @@ class TreeModel {
   inline int NumExtraNodes() const {
     return param.num_nodes - param.num_roots - param.num_deleted;
   }
+  /*! \brief return all parent features used in splits */
+  inline std::vector<unsigned> ParentSplits(int nid) const {
+    std::vector<unsigned> csplits;
+    while (!nodes_[nid].is_root()) {
+      nid = nodes_[nid].parent();
+      csplits.push_back(nodes_[nid].split_index());
+    }
+    return csplits;
+  }
 };
 
 /*! \brief node statistics used in regression tree */

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -82,9 +82,6 @@ class XGBoostClassifier (
 
   def setSeed(value: Long): this.type = set(seed, value)
 
-  // setters for booster params
-  def setBooster(value: String): this.type = set(booster, value)
-
   def setEta(value: Double): this.type = set(eta, value)
 
   def setGamma(value: Double): this.type = set(gamma, value)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -84,9 +84,6 @@ class XGBoostRegressor (
 
   def setSeed(value: Long): this.type = set(seed, value)
 
-  // setters for booster params
-  def setBooster(value: String): this.type = set(booster, value)
-
   def setEta(value: Double): this.type = set(eta, value)
 
   def setGamma(value: Double): this.type = set(gamma, value)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
@@ -23,15 +23,6 @@ import org.apache.spark.ml.param.{DoubleParam, IntParam, Param, Params}
 private[spark] trait BoosterParams extends Params {
 
   /**
-   * Booster to use, options: {'gbtree', 'gblinear', 'dart'}
-   */
-  final val booster = new Param[String](this, "booster",
-    s"Booster to use, options: {'gbtree', 'gblinear', 'dart'}",
-    (value: String) => BoosterParams.supportedBoosters.contains(value.toLowerCase))
-
-  final def getBooster: String = $(booster)
-
-  /**
    * step size shrinkage used in update to prevents overfitting. After each boosting step, we
    * can directly get the weights of new features and eta actually shrinks the feature weights
    * to make the boosting process more conservative. [default=0.3] range: [0,1]
@@ -246,7 +237,7 @@ private[spark] trait BoosterParams extends Params {
 
   final def getLambdaBias: Double = $(lambdaBias)
 
-  setDefault(booster -> "gbtree", eta -> 0.3, gamma -> 0, maxDepth -> 6,
+  setDefault(eta -> 0.3, gamma -> 0, maxDepth -> 6,
     minChildWeight -> 1, maxDeltaStep -> 0,
     growPolicy -> "depthwise", maxBins -> 16,
     subsample -> 1, colsampleBytree -> 1, colsampleBylevel -> 1,

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -18,6 +18,7 @@ package ml.dmlc.xgboost4j.scala.spark.params
 
 import com.google.common.base.CaseFormat
 import ml.dmlc.xgboost4j.scala.spark.TrackerConf
+
 import org.apache.spark.ml.param._
 import scala.collection.mutable
 
@@ -198,6 +199,12 @@ private[spark] trait ParamMapFuncs extends Params {
 
   def XGBoostToMLlibParams(xgboostParams: Map[String, Any]): Unit = {
     for ((paramName, paramValue) <- xgboostParams) {
+      if ((paramName == "booster" && paramValue != "gbtree") ||
+        (paramName == "updater" && paramValue != "grow_colmaker,prune")) {
+        throw new IllegalArgumentException(s"you specified $paramName as $paramValue," +
+          s" XGBoost-Spark only supports gbtree as booster type" +
+          " and grow_colmaker,prune as the updater type")
+      }
       val name = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, paramName)
       params.find(_.name == name) match {
         case None =>

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -56,13 +56,6 @@ private[spark] trait LearningTaskParams extends Params {
   final def getEvalMetric: String = $(evalMetric)
 
   /**
-    * group data specify each group sizes for ranking task. To correspond to partition of
-    * training data, it is nested.
-    */
-  final val groupData = new GroupDataParam(this, "groupData", "group data specify each group " +
-    "size for ranking task. To correspond to partition of training data, it is nested.")
-
-  /**
    * Fraction of training points to use for testing.
    */
   final val trainTestRatio = new DoubleParam(this, "trainTestRatio",
@@ -82,7 +75,7 @@ private[spark] trait LearningTaskParams extends Params {
 
   final def getNumEarlyStoppingRounds: Int = $(numEarlyStoppingRounds)
 
-  setDefault(objective -> "reg:linear", baseScore -> 0.5, groupData -> null,
+  setDefault(objective -> "reg:linear", baseScore -> 0.5,
     trainTestRatio -> 1.0, numEarlyStoppingRounds -> 0)
 }
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -147,8 +147,15 @@ def _check_call(ret):
 def ctypes2numpy(cptr, length, dtype):
     """Convert a ctypes pointer array to a numpy array.
     """
-    if not isinstance(cptr, ctypes.POINTER(ctypes.c_float)):
-        raise RuntimeError('expected float pointer')
+    NUMPY_TO_CTYPES_MAPPING = {
+        np.float32: ctypes.c_float,
+        np.uint32: ctypes.c_uint,
+    }
+    if dtype not in NUMPY_TO_CTYPES_MAPPING:
+        raise RuntimeError('Supported types: {}'.format(NUMPY_TO_CTYPES_MAPPING.keys()))
+    ctype = NUMPY_TO_CTYPES_MAPPING[dtype]
+    if not isinstance(cptr, ctypes.POINTER(ctype)):
+        raise RuntimeError('expected {} pointer'.format(ctype))
     res = np.zeros(length, dtype=dtype)
     if not ctypes.memmove(res.ctypes.data, cptr, length * res.strides[0]):
         raise RuntimeError('memmove failed')
@@ -501,7 +508,7 @@ class DMatrix(object):
         Returns
         -------
         info : array
-            a numpy array of float information of the data
+            a numpy array of unsigned integer information of the data
         """
         length = c_bst_ulong()
         ret = ctypes.POINTER(ctypes.c_uint)()

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -335,9 +335,13 @@ class XGBModel(XGBModelBase):
             self.best_ntree_limit = self._Booster.best_ntree_limit
         return self
 
-    def predict(self, data, output_margin=False, ntree_limit=0):
+    def predict(self, data, output_margin=False, ntree_limit=None):
         # pylint: disable=missing-docstring,invalid-name
         test_dmatrix = DMatrix(data, missing=self.missing, nthread=self.n_jobs)
+        # get ntree_limit to use - if none specified, default to
+        # best_ntree_limit if defined, otherwise 0.
+        if ntree_limit is None:
+            ntree_limit = getattr(self, "best_ntree_limit", 0)
         return self.get_booster().predict(test_dmatrix,
                                           output_margin=output_margin,
                                           ntree_limit=ntree_limit)
@@ -556,7 +560,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
 
         return self
 
-    def predict(self, data, output_margin=False, ntree_limit=0):
+    def predict(self, data, output_margin=False, ntree_limit=None):
         """
         Predict with `data`.
         NOTE: This function is not thread safe.
@@ -570,12 +574,15 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         output_margin : bool
             Whether to output the raw untransformed margin value.
         ntree_limit : int
-            Limit number of trees in the prediction; defaults to 0 (use all trees).
+            Limit number of trees in the prediction; defaults to best_ntree_limit if defined
+            (i.e. it has been trained with early stopping), otherwise 0 (use all trees).
         Returns
         -------
         prediction : numpy array
         """
         test_dmatrix = DMatrix(data, missing=self.missing, nthread=self.n_jobs)
+        if ntree_limit is None:
+            ntree_limit = getattr(self, "best_ntree_limit", 0)
         class_probs = self.get_booster().predict(test_dmatrix,
                                                  output_margin=output_margin,
                                                  ntree_limit=ntree_limit)
@@ -586,7 +593,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             column_indexes[class_probs > 0.5] = 1
         return self._le.inverse_transform(column_indexes)
 
-    def predict_proba(self, data, ntree_limit=0):
+    def predict_proba(self, data, ntree_limit=None):
         """
         Predict the probability of each `data` example being of a given class.
         NOTE: This function is not thread safe.
@@ -598,13 +605,16 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         data : DMatrix
             The dmatrix storing the input.
         ntree_limit : int
-            Limit number of trees in the prediction; defaults to 0 (use all trees).
+            Limit number of trees in the prediction; defaults to best_ntree_limit if defined
+            (i.e. it has been trained with early stopping), otherwise 0 (use all trees).
         Returns
         -------
         prediction : numpy array
             a numpy array with the probability of each data example being of a given class.
         """
         test_dmatrix = DMatrix(data, missing=self.missing, nthread=self.n_jobs)
+        if ntree_limit is None:
+            ntree_limit = getattr(self, "best_ntree_limit", 0)
         class_probs = self.get_booster().predict(test_dmatrix,
                                                  ntree_limit=ntree_limit)
         if self.objective == "multi:softprob":

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -202,6 +202,13 @@ struct XGBAPIThreadLocalEntry {
 // define the threadlocal store.
 using XGBAPIThreadLocalStore = dmlc::ThreadLocalStore<XGBAPIThreadLocalEntry>;
 
+int XGBRegisterLogCallback(void (*callback)(const char*)) {
+  API_BEGIN();
+  LogCallbackRegistry* registry = LogCallbackRegistryStore::Get();
+  registry->Register(callback);
+  API_END();
+}
+
 int XGDMatrixCreateFromFile(const char *fname,
                             int silent,
                             DMatrixHandle *out) {

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -8,16 +8,24 @@
 #include <iostream>
 #include "./common/sync.h"
 
-namespace xgboost {
+#if !defined(XGBOOST_STRICT_R_MODE) || XGBOOST_STRICT_R_MODE == 0
+// Override logging mechanism for non-R interfaces
+void dmlc::CustomLogMessage::Log(const std::string& msg) {
+  const xgboost::LogCallbackRegistry* registry
+    = xgboost::LogCallbackRegistryStore::Get();
+  auto callback = registry->Get();
+  callback(msg.c_str());
+}
 
-#if XGBOOST_CUSTOMIZE_LOGGER == 0
+namespace xgboost {
 ConsoleLogger::~ConsoleLogger() {
-  std::cerr << log_stream_.str() << std::endl;
+  dmlc::CustomLogMessage::Log(log_stream_.str());
 }
 
 TrackerLogger::~TrackerLogger() {
   log_stream_ << '\n';
   rabit::TrackerPrint(log_stream_.str());
 }
-#endif
+
 }  // namespace xgboost
+#endif

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -73,6 +73,10 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
   bool refresh_leaf;
   // auxiliary data structure
   std::vector<int> monotone_constraints;
+  // structure to record interaction constraints
+  std::vector<int> int_constraints;
+  // number of specified interactions in interaction constraints
+  int nint_constraints;
   // gpu to use for single gpu algorithms
   int gpu_id;
   // number of GPUs to use
@@ -178,6 +182,12 @@ struct TrainParam : public dmlc::Parameter<TrainParam> {
     DMLC_DECLARE_FIELD(monotone_constraints)
         .set_default(std::vector<int>())
         .describe("Constraint of variable monotonicity");
+    DMLC_DECLARE_FIELD(int_constraints)
+        .set_default(std::vector<int>())
+        .describe("Constraints for interaction representing permitted interactions");
+    DMLC_DECLARE_FIELD(nint_constraints)
+        .set_default(0)
+        .describe("Number of specified interactions in int_constraints vector");
     DMLC_DECLARE_FIELD(gpu_id)
         .set_lower_bound(0)
         .set_default(0)

--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -269,5 +269,174 @@ XGBOOST_REGISTER_SPLIT_EVALUATOR(MonotonicConstraint, "monotonic")
     return new MonotonicConstraint();
   });
 
+/*! \brief Encapsulates the parameters required by the InteractionConstraint
+        split evaluator
+*/
+struct InteractionConstraintParams
+    : public dmlc::Parameter<InteractionConstraintParams> {
+  std::vector<bst_int> int_constraints;
+  bst_int nint_constraints;
+  float reg_lambda;
+  float reg_gamma;
+
+  DMLC_DECLARE_PARAMETER(InteractionConstraintParams) {
+    DMLC_DECLARE_FIELD(reg_lambda)
+      .set_lower_bound(0.0)
+      .set_default(1.0)
+      .describe("L2 regularization on leaf weight");
+    DMLC_DECLARE_FIELD(reg_gamma)
+      .set_lower_bound(0.0f)
+      .set_default(0.0f)
+      .describe("Cost incurred by adding a new leaf node to the tree");
+    DMLC_DECLARE_FIELD(int_constraints)
+      .set_default(std::vector<bst_int>())
+      .describe("Constraints for interactions representing permitted interactions");
+    DMLC_DECLARE_FIELD(nint_constraints)
+      .set_default(0)
+      .describe("Number of specified interactions in int_constraints vector");
+    DMLC_DECLARE_ALIAS(reg_lambda, lambda);
+    DMLC_DECLARE_ALIAS(reg_gamma, gamma);
+  }
+};
+
+DMLC_REGISTER_PARAMETER(InteractionConstraintParams);
+
+/*! \brief Enforces interaction constraints on tree features.*/
+class InteractionConstraint final : public SplitEvaluator {
+ public:
+  void Init(const std::vector<std::pair<std::string, std::string> >& args)
+      override {
+    params_.InitAllowUnknown(args);
+    Reset();
+  }
+
+  void Reset() override {
+    // Number of features on the data, implied by the relative size of int_constraints vector and nint_constraints
+    bst_uint nfeatures = params_.int_constraints.size() / params_.nint_constraints;
+
+    // Initialise interaction constraints record with all variables permitted for the first node
+    int_cont_.clear();
+    int_cont_.resize(nfeatures, std::vector<bst_uint>(1, 1));
+
+    // Initialise splits record
+    splits_.clear();
+    splits_.resize(1, std::vector<bst_uint>());
+  }
+
+  SplitEvaluator* GetHostClone() const override {
+    if (params_.int_constraints.size() == 0) {
+      // No interaction constraints specified, make a RidgePenalty evaluator
+      using std::pair;
+      using std::string;
+      using std::to_string;
+      using std::vector;
+      auto c = new RidgePenalty();
+      vector<pair<string, string> > args;
+      args.emplace_back(
+        pair<string, string>("reg_lambda", to_string(params_.reg_lambda)));
+      args.emplace_back(
+        pair<string, string>("reg_gamma", to_string(params_.reg_gamma)));
+      c->Init(args);
+      c->Reset();
+      return c;
+    } else {
+      auto c = new InteractionConstraint();
+      c->params_ = this->params_;
+      c->Reset();
+      return c;
+    }
+  }
+
+  bst_float ComputeSplitScore(bst_uint nodeid,
+                              bst_uint featureid,
+                              const GradStats& left,
+                              const GradStats& right) const override {
+    // Return negative infinity score if feature is not permitted by interaction constraints
+    bst_float infinity = std::numeric_limits<bst_float>::infinity();
+    bst_uint constraint_int = GetIntConstraint(featureid, nodeid);
+    if (constraint_int == 0) return -infinity;
+
+    // parentID is not needed for this split evaluator. Just use 0.
+    return ComputeScore(0, left) + ComputeScore(0, right);
+  }
+
+  bst_float ComputeScore(bst_uint parentID, const GradStats& stats)
+      const override {
+    return (stats.sum_grad * stats.sum_grad)
+        / (stats.sum_hess + params_.reg_lambda) - params_.reg_gamma;
+  }
+
+  bst_float ComputeWeight(bst_uint parentID, const GradStats& stats)
+      const override {
+    return -stats.sum_grad / (stats.sum_hess + params_.reg_lambda);
+  }
+
+  void AddSplit(bst_uint nodeid,
+                bst_uint leftid,
+                bst_uint rightid,
+                bst_uint featureid,
+                bst_float leftweight,
+                bst_float rightweight) override {
+    bst_uint nfeatures = params_.int_constraints.size() / params_.nint_constraints;
+    bst_uint newsize = std::max(leftid, rightid) + 1;
+
+    // Record previous splits for child nodes
+    std::vector<bst_uint> feature_splits = splits_[nodeid];  // previous features of current node
+    feature_splits.resize(feature_splits.size() + 1, featureid);  // add feature of current node
+    splits_.resize(newsize);
+    splits_[leftid] = feature_splits;
+    splits_[rightid] = feature_splits;
+
+    // Resize constraints record, initialise all features to be not permitted for new nodes
+    for (bst_uint i = 0; i < nfeatures; ++i) int_cont_[i].resize(newsize, 0);
+
+    // Permit features used in previous splits
+    for (bst_uint i = 0; i < feature_splits.size(); ++i){
+      int_cont_[feature_splits[i]][leftid] = 1;
+      int_cont_[feature_splits[i]][rightid] = 1;
+    }
+
+    // Loop across specified interactions in constraints
+    for (bst_int i = 0; i < params_.nint_constraints; i++){
+      bst_uint flag = 1;  // flags whether the specified interaction is still relevant
+
+      // Test relevance of specified interaction by checking all previous features are included
+      for (bst_uint j = 0; j < feature_splits.size(); j++){
+        bst_uint checkvar = feature_splits[j];
+        if (params_.int_constraints[nfeatures*i + checkvar] == 0) flag = 0;
+      }
+
+      // If interaction is still relevant, permit all other features in the interaction
+      if (flag == 1) for (bst_uint k = 0; k < nfeatures; k ++){
+        if (params_.int_constraints[nfeatures*i + k] != 0){
+          int_cont_[k][leftid] = 1;
+          int_cont_[k][rightid] = 1;
+        }
+      }
+    }
+  }
+
+ private:
+  InteractionConstraintParams params_;
+  // Record of interaction constraints: (Per Feature) x (Per Node)
+  std::vector< std::vector<bst_uint> > int_cont_;
+  // Record of feature ids in previous splits: (Per Node) x (Number of Previous Splits)
+  std::vector< std::vector<bst_uint> > splits_;
+
+  inline bst_uint GetIntConstraint(bst_uint featureid, bst_uint nodeid) const {
+    if (featureid < int_cont_.size()) {
+      return int_cont_[featureid][nodeid];
+    } else {
+      return 1;
+    }
+  }
+};
+
+XGBOOST_REGISTER_SPLIT_EVALUATOR(InteractionConstraint, "interaction")
+.describe("Enforces interaction constraints on tree features")
+.set_body([]() {
+    return new InteractionConstraint();
+  });
+
 }  // namespace tree
 }  // namespace xgboost

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -299,3 +299,10 @@ class TestBasic(unittest.TestCase):
             )
             output = out.getvalue().strip()
         assert output == '[array([5., 8.], dtype=float32), array([23., 43., 11.], dtype=float32)]'
+
+    def test_get_info(self):
+        dtrain = xgb.DMatrix(dpath + 'agaricus.txt.train')
+        dtrain.get_float_info('label')
+        dtrain.get_float_info('weight')
+        dtrain.get_float_info('base_margin')
+        dtrain.get_uint_info('root_index')


### PR DESCRIPTION
Trying to incorporate interaction constraints again as mentioned in #3135 and using the SplitEvaluator structure created from #3335.

Currently doesn't support both monotonic and interaction constraints at the same time.  Not sure if there is a more elegant way to do this than creating another SplitEvaluator for both monotonic and interaction constraints at the same time.  @hcho3 and @henrygouk, any thoughts on this?

There are also other parts that are not that elegant: 
- infers the number of features from int_constraints and nint_constraints rather than getting it from the data properties
- creates a vector to store features from previous splits rather than obtaining them from the tree directly

Haven't yet done testing that it actually works in R.