### PR TITLE
[jvm-packages] disable booster setup for xgboost4j-spark

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -173,7 +173,7 @@ object XGBoost extends Serializable {
     require(tracker.start(trackerConf.workerConnectionTimeout), "FAULT: Failed to start tracker")
     tracker
   }
-  
+
   /**
    * @return A tuple of the booster and the metrics used to build training summary
    */

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -173,7 +173,7 @@ object XGBoost extends Serializable {
     require(tracker.start(trackerConf.workerConnectionTimeout), "FAULT: Failed to start tracker")
     tracker
   }
-
+  
   /**
    * @return A tuple of the booster and the metrics used to build training summary
    */

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -82,9 +82,6 @@ class XGBoostClassifier (
 
   def setSeed(value: Long): this.type = set(seed, value)
 
-  // setters for booster params
-  def setBooster(value: String): this.type = set(booster, value)
-
   def setEta(value: Double): this.type = set(eta, value)
 
   def setGamma(value: Double): this.type = set(gamma, value)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -84,9 +84,6 @@ class XGBoostRegressor (
 
   def setSeed(value: Long): this.type = set(seed, value)
 
-  // setters for booster params
-  def setBooster(value: String): this.type = set(booster, value)
-
   def setEta(value: Double): this.type = set(eta, value)
 
   def setGamma(value: Double): this.type = set(gamma, value)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
@@ -23,15 +23,6 @@ import org.apache.spark.ml.param.{DoubleParam, IntParam, Param, Params}
 private[spark] trait BoosterParams extends Params {
 
   /**
-   * Booster to use, options: {'gbtree', 'gblinear', 'dart'}
-   */
-  final val booster = new Param[String](this, "booster",
-    s"Booster to use, options: {'gbtree', 'gblinear', 'dart'}",
-    (value: String) => BoosterParams.supportedBoosters.contains(value.toLowerCase))
-
-  final def getBooster: String = $(booster)
-
-  /**
    * step size shrinkage used in update to prevents overfitting. After each boosting step, we
    * can directly get the weights of new features and eta actually shrinks the feature weights
    * to make the boosting process more conservative. [default=0.3] range: [0,1]
@@ -246,7 +237,7 @@ private[spark] trait BoosterParams extends Params {
 
   final def getLambdaBias: Double = $(lambdaBias)
 
-  setDefault(booster -> "gbtree", eta -> 0.3, gamma -> 0, maxDepth -> 6,
+  setDefault(eta -> 0.3, gamma -> 0, maxDepth -> 6,
     minChildWeight -> 1, maxDeltaStep -> 0,
     growPolicy -> "depthwise", maxBins -> 16,
     subsample -> 1, colsampleBytree -> 1, colsampleBylevel -> 1,

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -16,8 +16,11 @@
 
 package ml.dmlc.xgboost4j.scala.spark.params
 
+import java.security.InvalidParameterException
+
 import com.google.common.base.CaseFormat
 import ml.dmlc.xgboost4j.scala.spark.TrackerConf
+
 import org.apache.spark.ml.param._
 import scala.collection.mutable
 
@@ -198,6 +201,12 @@ private[spark] trait ParamMapFuncs extends Params {
 
   def XGBoostToMLlibParams(xgboostParams: Map[String, Any]): Unit = {
     for ((paramName, paramValue) <- xgboostParams) {
+      if ((paramName == "booster" && paramValue != "gbtree") ||
+        (paramName == "updater" && paramValue != "grow_colmaker,prune")) {
+        throw new InvalidParameterException(s"you specified $paramName as $paramValue," +
+          s" XGBoost-Spark only supports gbtree as booster type" +
+          " and grow_colmaker,prune as the updater type")
+      }
       val name = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, paramName)
       params.find(_.name == name) match {
         case None =>

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -16,8 +16,6 @@
 
 package ml.dmlc.xgboost4j.scala.spark.params
 
-import java.security.InvalidParameterException
-
 import com.google.common.base.CaseFormat
 import ml.dmlc.xgboost4j.scala.spark.TrackerConf
 
@@ -203,7 +201,7 @@ private[spark] trait ParamMapFuncs extends Params {
     for ((paramName, paramValue) <- xgboostParams) {
       if ((paramName == "booster" && paramValue != "gbtree") ||
         (paramName == "updater" && paramValue != "grow_colmaker,prune")) {
-        throw new InvalidParameterException(s"you specified $paramName as $paramValue," +
+        throw new IllegalArgumentException(s"you specified $paramName as $paramValue," +
           s" XGBoost-Spark only supports gbtree as booster type" +
           " and grow_colmaker,prune as the updater type")
       }


### PR DESCRIPTION
as gbtree is the only booster type having distributed updater (hist_maker,prune) we should disable the configuration of these two parameters to avoid confusing users