### PR TITLE
Add total_gain and total_cover importance measures

### DIFF
--- a/tests/python/test_shap.py
+++ b/tests/python/test_shap.py
@@ -33,10 +33,14 @@ class TestSHAP(unittest.TestCase):
         scores2 = bst.get_score(importance_type='weight')
         scores3 = bst.get_score(importance_type='cover')
         scores4 = bst.get_score(importance_type='gain')
+        scores5 = bst.get_score(importance_type='total_cover')
+        scores6 = bst.get_score(importance_type='total_gain')
         assert len(scores1) == len(features)
         assert len(scores2) == len(features)
         assert len(scores3) == len(features)
         assert len(scores4) == len(features)
+        assert len(scores5) == len(features)
+        assert len(scores6) == len(features)
 
         # check backwards compatibility of get_fscore
         fscores = bst.get_fscore()


### PR DESCRIPTION
Add `'total_gain'` and `'total_cover'` as possible `importance_type`
arguments to `Booster.get_score` in the Python package.

`get_score` already accepts a `'gain'` argument, which returns each
feature's average gain over all of its splits.  `'total_gain'` does the
same, but returns a total rather than an average.  This seems more
intuitively meaningful, and also matches the behavior of the R package's
`xgb.importance` function.

I also added an analogous `'total_cover'` command for consistency.

This resolves #3484.