### PR TITLE
build uber jar with dependency by default, this is the behavior of ol…

### DIFF
--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -123,6 +123,9 @@
         </profile>
         <profile>
             <id>assembly</id>
+            <activation>
+              <activeByDefault>true</activeByDefault>
+            </activation>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
…d release

building fat jar is the old behavior and its good to be consistent.  