### PR TITLE
[WIP] Expose group info to C API + other wrappers

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -295,15 +295,29 @@ XGB_DLL int XGDMatrixSetUIntInfo(DMatrixHandle handle,
                                  const unsigned *array,
                                  bst_ulong len);
 /*!
- * \brief set label of the training matrix
+ * \brief set group info of a data matrix
  * \param handle a instance of data matrix
- * \param group pointer to group size
- * \param len length of array
+ * \param group array of group sizes, where group[i] represents the number of
+ *              instances in i-th group
+ * \param len length of array, should be equal to number of groups
  * \return 0 when success, -1 when failure happens
  */
 XGB_DLL int XGDMatrixSetGroup(DMatrixHandle handle,
-                              const unsigned *group,
+                              const unsigned* group,
                               bst_ulong len);
+
+/*!
+ * \brief get group info of a data matrix
+ * \param handle a instance of data matrix
+ * \param out_group used to store array of group sizes, where group[i] would
+ *                  represent the number of instances in i-th group
+ * \param out_len used to set length of out_group, i.e. number of groups
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixGetGroup(const DMatrixHandle handle,
+                              const unsigned** out_group,
+                              bst_ulong* out_len);
+
 /*!
  * \brief get float info vector from matrix
  * \param handle a instance of data matrix

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -193,7 +193,9 @@ struct XGBAPIThreadLocalEntry {
   std::vector<std::string> ret_vec_str;
   /*! \brief result holder for returning string pointers */
   std::vector<const char *> ret_vec_charp;
-  /*! \brief returning float vector. */
+  /*! \brief result holder for returning unsigned int vector. */
+  std::vector<unsigned> ret_vec_uint;
+  /*! \brief result holder for returning float vector. */
   std::vector<bst_float> ret_vec_float;
   /*! \brief temp variable of gradient pairs. */
   std::vector<GradientPair> tmp_gpair;
@@ -752,6 +754,26 @@ XGB_DLL int XGDMatrixSetGroup(DMatrixHandle handle,
   for (uint64_t i = 0; i < len; ++i) {
     info.group_ptr_[i + 1] = info.group_ptr_[i] + group[i];
   }
+  API_END();
+}
+
+XGB_DLL int XGDMatrixGetGroup(const DMatrixHandle handle,
+                              const unsigned** out_group,
+                              bst_ulong* out_len) {
+  std::vector<unsigned>& group = XGBAPIThreadLocalStore::Get()->ret_vec_uint;
+  group.resize(0);
+
+  API_BEGIN();
+  CHECK_HANDLE();
+  auto* pmat = static_cast<std::shared_ptr<DMatrix>*>(handle);
+  const MetaInfo& info = pmat->get()->Info();
+
+  const size_t len = info.group_ptr_.size();
+  for (size_t i = 0; i < len; ++i) {
+    group.push_back(info.group_ptr_[i + 1] - info.group_ptr_[i]);
+  }
+  *out_group = dmlc::BeginPtr(group);
+  *out_len = static_cast<bst_ulong>(group.size());
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -759,7 +759,7 @@ XGB_DLL int XGDMatrixSetGroup(DMatrixHandle handle,
 
 XGB_DLL int XGDMatrixGetGroup(const DMatrixHandle handle,
                               const unsigned** out_group,
-                              bst_ulong* out_len) {
+                              xgboost::bst_ulong* out_len) {
   std::vector<unsigned>& group = XGBAPIThreadLocalStore::Get()->ret_vec_uint;
   group.resize(0);
 
@@ -773,7 +773,7 @@ XGB_DLL int XGDMatrixGetGroup(const DMatrixHandle handle,
     group.push_back(info.group_ptr_[i + 1] - info.group_ptr_[i]);
   }
   *out_group = dmlc::BeginPtr(group);
-  *out_len = static_cast<bst_ulong>(group.size());
+  *out_len = static_cast<xgboost::bst_ulong>(group.size());
   API_END();
 }
 


### PR DESCRIPTION
As pointed out in https://discuss.xgboost.ai/t/jvm-packages-getting-group-for-custom-rank-objective-and-eval/89, it is currently not possible to extract group info from DMatrix outside of the core lib. This is because the C API does not have a function for getting group info. (Weirdly, there is a C API function for setting group info.)

TODOs:
- [ ] Add C++ test
- [ ] Expose the function to Python wrapper
- [ ] Expose the function to Java/Scala wrapper
- [ ] Expose the function to R wrapper