### PR TITLE
Update faq.rst

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -7,7 +7,7 @@ This document contains frequently asked questions about XGBoost.
 **********************
 How to tune parameters
 **********************
-See :doc:`Parameter Tunning Guide </tutorials/param_tuning>`.
+See :doc:`Parameter Tuning Guide </tutorials/param_tuning>`.
 
 ************************
 Description on the model


### PR DESCRIPTION
The documentation needed a minor typo fix.

The anchor text was "Parameter Tunning Guide" earlier. I just fixed it to "Parameter Tuning Guide"