### PR TITLE
Fix typo in ElasticNet threshold function

### DIFF
--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -142,11 +142,12 @@ class ElasticNet final : public SplitEvaluator {
 
   inline double ThresholdL1(double g) const {
     if (g > params_.reg_alpha) {
-      g = g - params_.reg_alpha;
+      return g - params_.reg_alpha;
     } else if (g < -params_.reg_alpha) {
-      g = g + params_.reg_alpha;
+      return g + params_.reg_alpha;
+    } else {
+      return 0.0;
     }
-    return g;
   }
 };
 


### PR DESCRIPTION
I think the `ThresholdL1` function in `split_evaluator.cc` has a typo: for small values of `g`, it makes more sense to return `0` rather than `g`.  This is what the version of `ThresholdL1` in `param.h` does.  (In fact, maybe it would be simplest to just call that one directly?)

But I could be missing something -- @henrygouk is the original author so maybe he can correct me.