### PR TITLE
Use __CUDA__ macro with __NVCC__.

### DIFF
--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -69,7 +69,7 @@
 /*!
  * \brief Tag function as usable by device
  */
-#ifdef __NVCC__
+#if defined (__CUDA__) || defined(__NVCC__)
 #define XGBOOST_DEVICE __host__ __device__
 #else
 #define XGBOOST_DEVICE


### PR DESCRIPTION
* \_\_CUDA\_\_ is defined in clang. Making the change won't make clang
compile xgboost, but syntax checking for *.cu from clang is at least partially
working.