### PR TITLE
Add JSON model dump functionality documentation

### DIFF
--- a/demo/binary_classification/README.md
+++ b/demo/binary_classification/README.md
@@ -102,7 +102,7 @@ After training, we can use the output model to get the prediction of the test da
 For binary classification, the output predictions are probability confidence scores in [0,1], corresponds to the probability of the label to be positive.
 
 #### Dump Model
-This is a preliminary feature, so far only tree model support text dump. XGBoost can display the tree models in text files and we can scan the model in an easy way:
+This is a preliminary feature, so only tree models support text dump. XGBoost can display the tree models in text or JSON files, and we can scan the model in an easy way:
 ```
 ../../xgboost mushroom.conf task=dump model_in=0002.model name_dump=dump.raw.txt
 ../../xgboost mushroom.conf task=dump model_in=0002.model fmap=featmap.txt name_dump=dump.nice.txt

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -361,6 +361,10 @@ The following parameters are only used in the console version of XGBoost
 
   - Feature map, used for dumping model
 
+* ``dump_format`` [default= ``text``] options: ``text``, ``json``
+
+  - Format of model dump file
+
 * ``name_dump`` [default= ``dump.txt``]
 
   - Name of model dump file


### PR DESCRIPTION
I wrote a native XGBoost to Vespa converter that uses XGBoost's JSON model dump as input (https://github.com/vespa-engine/vespa/pull/6577), so I added some missing documentation for the existing `dump_format` parameter in the CLI version.