### PR TITLE
Amend xgb.createFolds to handle classes of a single element.

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -262,7 +262,8 @@ xgb.createFolds <- function(y, k = 10)
       ## add enough random integers to get  length(seqVector) == numInClass[i]
       if (numInClass[i] %% k > 0) seqVector <- c(seqVector, sample.int(k, numInClass[i] %% k))
       ## shuffle the integers for fold assignment and assign to this classes's data
-      foldVector[y == dimnames(numInClass)$y[i]] <- sample(seqVector)
+      ## x[sample.int(length(x))] is used to handle the case of length(x) == 1
+      foldVector[y == dimnames(numInClass)$y[i]] <- x[sample.int(length(x))]
     }
   } else {
     foldVector <- seq(along = y)


### PR DESCRIPTION
When a label contains a level with only one case I get the warning,
`Warning message:
In foldVector[y == dimnames(numInClass)$y[i]] <- sample(seqVector) :
  number of items to replace is not a multiple of replacement length`
This is caused by the "undesired behaviour" as per [sample documentation](https://stat.ethz.ch/R-manual/R-devel/library/base/html/sample.html), so I have implemented the solution in the same documentation.