### PR TITLE
Add google test for a column sampling, restore metainfo tests

### DIFF
--- a/src/common/host_device_vector.cu
+++ b/src/common/host_device_vector.cu
@@ -77,9 +77,9 @@ struct HostDeviceVectorImpl {
 
     void LazySyncHost() {
       dh::safe_cuda(cudaSetDevice(device_));
-      dh::safe_cuda(
-          cudaMemcpy(vec_->data_h_.data(), data_.data().get() + start_,
-                     data_.size() * sizeof(T), cudaMemcpyDeviceToHost));
+      dh::safe_cuda(cudaMemcpy(vec_->data_h_.data() + start_,
+                               data_.data().get(), data_.size() * sizeof(T),
+                               cudaMemcpyDeviceToHost));
       on_d_ = false;
     }
 

--- a/tests/cpp/common/test_random.cc
+++ b/tests/cpp/common/test_random.cc
@@ -1,0 +1,37 @@
+#include "../../../src/common/random.h"
+#include "../helpers.h"
+#include "gtest/gtest.h"
+
+namespace xgboost {
+namespace common {
+TEST(ColumnSampler, Test) {
+  int n = 100;
+  ColumnSampler cs;
+  cs.Init(n, 0.5f, 0.5f);
+  auto &set0 = cs.GetFeatureSet(0).HostVector();
+  ASSERT_EQ(set0.size(), 25);
+
+  auto &set1 = cs.GetFeatureSet(0).HostVector();
+  ASSERT_EQ(set0, set1);
+
+  auto &set2 = cs.GetFeatureSet(1).HostVector();
+  ASSERT_NE(set1, set2);
+  ASSERT_EQ(set2.size(), 25);
+
+  // No level sampling, should be the same at different depth
+  cs.Init(n, 1.0f, 0.5f);
+  ASSERT_EQ(cs.GetFeatureSet(0).HostVector(), cs.GetFeatureSet(1).HostVector());
+
+  cs.Init(n, 1.0f, 1.0f);
+  auto &set3 = cs.GetFeatureSet(0).HostVector();
+  ASSERT_EQ(set3.size(), n);
+  cs.Init(n, 1.0f, 1.0f);
+  auto &set4 = cs.GetFeatureSet(0).HostVector();
+  ASSERT_EQ(set3, set4);
+
+  // Should always be a minimum of one feature
+  cs.Init(n, 1e-16f, 1e-16f);
+  ASSERT_EQ(cs.GetFeatureSet(0).HostVector().size(), 1);
+}
+}  // namespace common
+}  // namespace xgboost

--- a/tests/cpp/data/test_metainfo.cc
+++ b/tests/cpp/data/test_metainfo.cc
@@ -103,22 +103,32 @@ TEST(MetaInfo, LoadQid) {
     0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60
   };
   const std::vector<xgboost::Entry> expected_data{
-    {1, 1}, {2, 1}, {3, 0}, {4, 0.2}, {5, 0},
-    {1, 0}, {2, 0}, {3, 1}, {4, 0.1}, {5, 1},
-    {1, 0}, {2, 1}, {3, 0}, {4, 0.4}, {5, 0},
-    {1, 0}, {2, 0}, {3, 1}, {4, 0.3}, {5, 0},
-    {1, 0}, {2, 0}, {3, 1}, {4, 0.2}, {5, 0},
-    {1, 1}, {2, 0}, {3, 1}, {4, 0.4}, {5, 0},
-    {1, 0}, {2, 0}, {3, 1}, {4, 0.1}, {5, 0},
-    {1, 0}, {2, 0}, {3, 1}, {4, 0.2}, {5, 0},
-    {1, 0}, {2, 0}, {3, 1}, {4, 0.1}, {5, 1},
-    {1, 1}, {2, 1}, {3, 0}, {4, 0.3}, {5, 0},
-    {1, 1}, {2, 0}, {3, 0}, {4, 0.4}, {5, 1},
-    {1, 0}, {2, 1}, {3, 1}, {4, 0.5}, {5, 0}
-  };
-  for (const auto &batch : dmat->GetRowBatches()) {
-    CHECK_EQ(batch.base_rowid, 0);
-    CHECK(batch.offset == expected_offset);
-    CHECK(batch.data == expected_data);
-  }
+      xgboost::Entry(1, 1),   xgboost::Entry(2, 1),   xgboost::Entry(3, 0),
+      xgboost::Entry(4, 0.2), xgboost::Entry(5, 0),   xgboost::Entry(1, 0),
+      xgboost::Entry(2, 0),   xgboost::Entry(3, 1),   xgboost::Entry(4, 0.1),
+      xgboost::Entry(5, 1),   xgboost::Entry(1, 0),   xgboost::Entry(2, 1),
+      xgboost::Entry(3, 0),   xgboost::Entry(4, 0.4), xgboost::Entry(5, 0),
+      xgboost::Entry(1, 0),   xgboost::Entry(2, 0),   xgboost::Entry(3, 1),
+      xgboost::Entry(4, 0.3), xgboost::Entry(5, 0),   xgboost::Entry(1, 0),
+      xgboost::Entry(2, 0),   xgboost::Entry(3, 1),   xgboost::Entry(4, 0.2),
+      xgboost::Entry(5, 0),   xgboost::Entry(1, 1),   xgboost::Entry(2, 0),
+      xgboost::Entry(3, 1),   xgboost::Entry(4, 0.4), xgboost::Entry(5, 0),
+      xgboost::Entry(1, 0),   xgboost::Entry(2, 0),   xgboost::Entry(3, 1),
+      xgboost::Entry(4, 0.1), xgboost::Entry(5, 0),   xgboost::Entry(1, 0),
+      xgboost::Entry(2, 0),   xgboost::Entry(3, 1),   xgboost::Entry(4, 0.2),
+      xgboost::Entry(5, 0),   xgboost::Entry(1, 0),   xgboost::Entry(2, 0),
+      xgboost::Entry(3, 1),   xgboost::Entry(4, 0.1), xgboost::Entry(5, 1),
+      xgboost::Entry(1, 1),   xgboost::Entry(2, 1),   xgboost::Entry(3, 0),
+      xgboost::Entry(4, 0.3), xgboost::Entry(5, 0),   xgboost::Entry(1, 1),
+      xgboost::Entry(2, 0),   xgboost::Entry(3, 0),   xgboost::Entry(4, 0.4),
+      xgboost::Entry(5, 1),   xgboost::Entry(1, 0),   xgboost::Entry(2, 1),
+      xgboost::Entry(3, 1),   xgboost::Entry(4, 0.5), {5, 0}};
+  dmlc::DataIter<xgboost::SparsePage>* iter = dmat->RowIterator();
+  iter->BeforeFirst();
+  CHECK(iter->Next());
+  const xgboost::SparsePage& batch = iter->Value();
+  CHECK_EQ(batch.base_rowid, 0);
+  CHECK(batch.offset == expected_offset);
+  CHECK(batch.data == expected_data);
+  CHECK(!iter->Next());
 }

--- a/tests/cpp/data/test_metainfo.cc
+++ b/tests/cpp/data/test_metainfo.cc
@@ -69,4 +69,56 @@ TEST(MetaInfo, SaveLoadBinary) {
 }
 
 TEST(MetaInfo, LoadQid) {
+  std::string tmp_file = TempFileName();
+  {
+    std::unique_ptr<dmlc::Stream> fs(
+      dmlc::Stream::Create(tmp_file.c_str(), "w"));
+    dmlc::ostream os(fs.get());
+    os << R"qid(3 qid:1 1:1 2:1 3:0 4:0.2 5:0
+                2 qid:1 1:0 2:0 3:1 4:0.1 5:1
+                1 qid:1 1:0 2:1 3:0 4:0.4 5:0
+                1 qid:1 1:0 2:0 3:1 4:0.3 5:0
+                1 qid:2 1:0 2:0 3:1 4:0.2 5:0
+                2 qid:2 1:1 2:0 3:1 4:0.4 5:0
+                1 qid:2 1:0 2:0 3:1 4:0.1 5:0
+                1 qid:2 1:0 2:0 3:1 4:0.2 5:0
+                2 qid:3 1:0 2:0 3:1 4:0.1 5:1
+                3 qid:3 1:1 2:1 3:0 4:0.3 5:0
+                4 qid:3 1:1 2:0 3:0 4:0.4 5:1
+                1 qid:3 1:0 2:1 3:1 4:0.5 5:0)qid";
+    os.set_stream(nullptr);
+  }
+  std::unique_ptr<xgboost::DMatrix> dmat(
+    xgboost::DMatrix::Load(tmp_file, true, false, "libsvm"));
+  std::remove(tmp_file.c_str());
+
+  const xgboost::MetaInfo& info = dmat->Info();
+  const std::vector<uint64_t> expected_qids{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3};
+  const std::vector<xgboost::bst_uint> expected_group_ptr{0, 4, 8, 12};
+  CHECK(info.qids_ == expected_qids);
+  CHECK(info.group_ptr_ == expected_group_ptr);
+  CHECK_GE(info.kVersion, info.kVersionQidAdded);
+
+  const std::vector<size_t> expected_offset{
+    0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60
+  };
+  const std::vector<xgboost::Entry> expected_data{
+    {1, 1}, {2, 1}, {3, 0}, {4, 0.2}, {5, 0},
+    {1, 0}, {2, 0}, {3, 1}, {4, 0.1}, {5, 1},
+    {1, 0}, {2, 1}, {3, 0}, {4, 0.4}, {5, 0},
+    {1, 0}, {2, 0}, {3, 1}, {4, 0.3}, {5, 0},
+    {1, 0}, {2, 0}, {3, 1}, {4, 0.2}, {5, 0},
+    {1, 1}, {2, 0}, {3, 1}, {4, 0.4}, {5, 0},
+    {1, 0}, {2, 0}, {3, 1}, {4, 0.1}, {5, 0},
+    {1, 0}, {2, 0}, {3, 1}, {4, 0.2}, {5, 0},
+    {1, 0}, {2, 0}, {3, 1}, {4, 0.1}, {5, 1},
+    {1, 1}, {2, 1}, {3, 0}, {4, 0.3}, {5, 0},
+    {1, 1}, {2, 0}, {3, 0}, {4, 0.4}, {5, 1},
+    {1, 0}, {2, 1}, {3, 1}, {4, 0.5}, {5, 0}
+  };
+  for (const auto &batch : dmat->GetRowBatches()) {
+    CHECK_EQ(batch.base_rowid, 0);
+    CHECK(batch.offset == expected_offset);
+    CHECK(batch.data == expected_data);
+  }
 }


### PR DESCRIPTION
Some meta infotests were accidentally removed in a previous commit due to failures with some Windows compilers.