### PR TITLE
[jvm-packages] Fix "obj_type" error to enable custom objectives and evaluations

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -193,9 +193,9 @@ object XGBoost extends Serializable {
     }
     require(nWorkers > 0, "you must specify more than 0 workers")
     if (obj != null) {
-      require(params.get("objective_type").isDefined, "parameter \"objective_type\" is not defined," +
-        " you have to specify the objective type as classification or regression with a" +
-        " customized objective function")
+      require(params.get("objective_type").isDefined, "parameter \"objective_type\" is not" +
+        " defined, you have to specify the objective type as classification or regression" +
+        " with a customized objective function")
     }
     val trackerConf = params.get("tracker_conf") match {
       case None => TrackerConf()

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -193,7 +193,7 @@ object XGBoost extends Serializable {
     }
     require(nWorkers > 0, "you must specify more than 0 workers")
     if (obj != null) {
-      require(params.get("obj_type").isDefined, "parameter \"obj_type\" is not defined," +
+      require(params.get("objective_type").isDefined, "parameter \"objective_type\" is not defined," +
         " you have to specify the objective type as classification or regression with a" +
         " customized objective function")
     }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -162,7 +162,7 @@ class XGBoostClassifier (
       set(evalMetric, setupDefaultEvalMetric())
     }
 
-    if (isDefined(customObj) && $(customObj).nonEmpty) {
+    if (isDefined(customObj) && $(customObj) != null) {
       set(obj_type, "classification")
     }
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -163,7 +163,7 @@ class XGBoostClassifier (
     }
 
     if (isDefined(customObj) && $(customObj) != null) {
-      set(obj_type, "classification")
+      set(objectiveType, "classification")
     }
 
     val _numClasses = getNumClasses(dataset)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -130,7 +130,7 @@ class XGBoostClassifier (
   // setters for learning params
   def setObjective(value: String): this.type = set(objective, value)
 
-  def setObjectiveType(value: String): this.type = set(obj_type, value)
+  def setObjectiveType(value: String): this.type = set(objectiveType, value)
 
   def setBaseScore(value: Double): this.type = set(baseScore, value)
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -130,6 +130,8 @@ class XGBoostClassifier (
   // setters for learning params
   def setObjective(value: String): this.type = set(objective, value)
 
+  def setObjectiveType(value: String): this.type = set(obj_type, value)
+
   def setBaseScore(value: Double): this.type = set(baseScore, value)
 
   def setEvalMetric(value: String): this.type = set(evalMetric, value)
@@ -158,6 +160,10 @@ class XGBoostClassifier (
 
     if (!isDefined(evalMetric) || $(evalMetric).isEmpty) {
       set(evalMetric, setupDefaultEvalMetric())
+    }
+
+    if (isDefined(customObj) && $(customObj).nonEmpty) {
+      set(obj_type, "classification")
     }
 
     val _numClasses = getNumClasses(dataset)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -160,7 +160,7 @@ class XGBoostRegressor (
       set(evalMetric, setupDefaultEvalMetric())
     }
 
-    if (isDefined(customObj) && $(customObj).nonEmpty) {
+    if (isDefined(customObj) && $(customObj) != null) {
       set(obj_type, "regression")
     }
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -130,7 +130,7 @@ class XGBoostRegressor (
   // setters for learning params
   def setObjective(value: String): this.type = set(objective, value)
 
-  def setObjectiveType(value: String): this.type = set(obj_type, value)
+  def setObjectiveType(value: String): this.type = set(objectiveType, value)
 
   def setBaseScore(value: Double): this.type = set(baseScore, value)
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -130,6 +130,8 @@ class XGBoostRegressor (
   // setters for learning params
   def setObjective(value: String): this.type = set(objective, value)
 
+  def setObjectiveType(value: String): this.type = set(obj_type, value)
+
   def setBaseScore(value: Double): this.type = set(baseScore, value)
 
   def setEvalMetric(value: String): this.type = set(evalMetric, value)
@@ -156,6 +158,10 @@ class XGBoostRegressor (
 
     if (!isDefined(evalMetric) || $(evalMetric).isEmpty) {
       set(evalMetric, setupDefaultEvalMetric())
+    }
+
+    if (isDefined(customObj) && $(customObj).nonEmpty) {
+      set(obj_type, "regression")
     }
 
     val weight = if (!isDefined(weightCol) || $(weightCol).isEmpty) lit(1.0) else col($(weightCol))

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -161,7 +161,7 @@ class XGBoostRegressor (
     }
 
     if (isDefined(customObj) && $(customObj) != null) {
-      set(obj_type, "regression")
+      set(objectiveType, "regression")
     }
 
     val weight = if (!isDefined(weightCol) || $(weightCol).isEmpty) lit(1.0) else col($(weightCol))

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -42,7 +42,7 @@ private[spark] trait LearningTaskParams extends Params {
     s"training, options: {${LearningTaskParams.supportedObjectiveType.mkString(",")}",
     (value: String) => LearningTaskParams.supportedObjectiveType.contains(value))
 
-  final def getObjectiveType: String = $(obj_type)
+  final def getObjectiveType: String = $(objectiveType)
 
 
   /**

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -38,8 +38,8 @@ private[spark] trait LearningTaskParams extends Params {
    * Corresponding type will be assigned if custom objective is defined
    * options: regression, classification. default: null
    */
-  final val obj_type = new Param[String](this, "obj_type", "objective type for training," +
-    s" options: {${LearningTaskParams.supportedObjectiveType.mkString(",")}",
+  final val obj_type = new Param[String](this, "obj_type", "objective type used for " +
+    s"training, options: {${LearningTaskParams.supportedObjectiveType.mkString(",")}",
     (value: String) => LearningTaskParams.supportedObjectiveType.contains(value))
 
   final def getObjectiveType: String = $(obj_type)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -34,6 +34,17 @@ private[spark] trait LearningTaskParams extends Params {
   final def getObjective: String = $(objective)
 
   /**
+   * Specify the learning objective type required for custom objective and eval.
+   * options: regression, classification. default: regression
+   */
+  final val obj_type = new Param[String](this, "obj_type", "objective type for training," +
+    s" options: {${LearningTaskParams.supportedObjectiveType.mkString(",")}",
+    (value: String) => LearningTaskParams.supportedObjectiveType.contains(value))
+
+  final def getObjectiveType: String = $(obj_type)
+
+
+  /**
    * the initial prediction score of all instances, global bias. default=0.5
    */
   final val baseScore = new DoubleParam(this, "baseScore", "the initial prediction score of all" +
@@ -83,6 +94,8 @@ private[spark] object LearningTaskParams {
   val supportedObjective = HashSet("reg:linear", "reg:logistic", "binary:logistic",
     "binary:logitraw", "count:poisson", "multi:softmax", "multi:softprob", "rank:pairwise",
     "reg:gamma", "reg:tweedie")
+
+  val supportedObjectiveType = HashSet("regression", "classification")
 
   val supportedEvalMetrics = HashSet("rmse", "mae", "logloss", "error", "merror", "mlogloss",
     "auc", "aucpr", "ndcg", "map", "gamma-deviance")

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -38,7 +38,7 @@ private[spark] trait LearningTaskParams extends Params {
    * Corresponding type will be assigned if custom objective is defined
    * options: regression, classification. default: null
    */
-  final val objectiveType = new Param[String](this, "objective_type", "objective type used for " +
+  final val objectiveType = new Param[String](this, "objectiveType", "objective type used for " +
     s"training, options: {${LearningTaskParams.supportedObjectiveType.mkString(",")}",
     (value: String) => LearningTaskParams.supportedObjectiveType.contains(value))
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -38,7 +38,7 @@ private[spark] trait LearningTaskParams extends Params {
    * Corresponding type will be assigned if custom objective is defined
    * options: regression, classification. default: null
    */
-  final val obj_type = new Param[String](this, "obj_type", "objective type used for " +
+  final val objectiveType = new Param[String](this, "objective_type", "objective type used for " +
     s"training, options: {${LearningTaskParams.supportedObjectiveType.mkString(",")}",
     (value: String) => LearningTaskParams.supportedObjectiveType.contains(value))
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -34,8 +34,9 @@ private[spark] trait LearningTaskParams extends Params {
   final def getObjective: String = $(objective)
 
   /**
-   * Specify the learning objective type required for custom objective and eval.
-   * options: regression, classification. default: regression
+   * The learning objective type of the specified custom objective and eval.
+   * Corresponding type will be assigned if custom objective is defined
+   * options: regression, classification. default: null
    */
   final val obj_type = new Param[String](this, "obj_type", "objective type for training," +
     s" options: {${LearningTaskParams.supportedObjectiveType.mkString(",")}",

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
@@ -145,7 +145,7 @@ class XGBoostClassifierSuite extends FunSuite with PerTest {
     val xgb = new XGBoostClassifier(xgbParamMap)
     assert(xgb.getEta === 1.0)
     assert(xgb.getObjective === "binary:logistic")
-    assert(xgb.getObjectiveType === "classification"
+    assert(xgb.getObjectiveType === "classification")
     // from spark to xgboost params
     val xgbCopy = xgb.copy(ParamMap.empty)
     assert(xgbCopy.MLlib2XGBoostParams("eta").toString.toDouble === 1.0)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
@@ -141,7 +141,7 @@ class XGBoostClassifierSuite extends FunSuite with PerTest {
 
   test("XGBoost and Spark parameters synchronize correctly") {
     val xgbParamMap = Map("eta" -> "1", "objective" -> "binary:logistic",
-      "obj_type" -> "classification")
+      "objective_type" -> "classification")
     // from xgboost params to spark params
     val xgb = new XGBoostClassifier(xgbParamMap)
     assert(xgb.getEta === 1.0)
@@ -151,7 +151,7 @@ class XGBoostClassifierSuite extends FunSuite with PerTest {
     val xgbCopy = xgb.copy(ParamMap.empty)
     assert(xgbCopy.MLlib2XGBoostParams("eta").toString.toDouble === 1.0)
     assert(xgbCopy.MLlib2XGBoostParams("objective").toString === "binary:logistic")
-    assert(xgbCopy.MLlib2XGBoostParams("obj_type").toString === "classification")
+    assert(xgbCopy.MLlib2XGBoostParams("objective_type").toString === "classification")
     val xgbCopy2 = xgb.copy(ParamMap.empty.put(xgb.evalMetric, "logloss"))
     assert(xgbCopy2.MLlib2XGBoostParams("eval_metric").toString === "logloss")
   }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
@@ -140,7 +140,8 @@ class XGBoostClassifierSuite extends FunSuite with PerTest {
   }
 
   test("XGBoost and Spark parameters synchronize correctly") {
-    val xgbParamMap = Map("eta" -> "1", "objective" -> "binary:logistic", "obj_type" -> "classification")
+    val xgbParamMap = Map("eta" -> "1", "objective" -> "binary:logistic",
+      "obj_type" -> "classification")
     // from xgboost params to spark params
     val xgb = new XGBoostClassifier(xgbParamMap)
     assert(xgb.getEta === 1.0)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
@@ -140,15 +140,17 @@ class XGBoostClassifierSuite extends FunSuite with PerTest {
   }
 
   test("XGBoost and Spark parameters synchronize correctly") {
-    val xgbParamMap = Map("eta" -> "1", "objective" -> "binary:logistic")
+    val xgbParamMap = Map("eta" -> "1", "objective" -> "binary:logistic", "obj_type" -> "classification")
     // from xgboost params to spark params
     val xgb = new XGBoostClassifier(xgbParamMap)
     assert(xgb.getEta === 1.0)
     assert(xgb.getObjective === "binary:logistic")
+    assert(xgb.getObjectiveType === "classification"
     // from spark to xgboost params
     val xgbCopy = xgb.copy(ParamMap.empty)
     assert(xgbCopy.MLlib2XGBoostParams("eta").toString.toDouble === 1.0)
     assert(xgbCopy.MLlib2XGBoostParams("objective").toString === "binary:logistic")
+    assert(xgbCopy.MLlib2XGBoostParams("obj_type").toString === "classification")
     val xgbCopy2 = xgb.copy(ParamMap.empty.put(xgb.evalMetric, "logloss"))
     assert(xgbCopy2.MLlib2XGBoostParams("eval_metric").toString === "logloss")
   }


### PR DESCRIPTION
This is to address xgboost4j-spark 0.8: customized objective function "obj_type" error when one tries to use custom objectives. If a custom objective is specified without defining obj_type, one will hit a "requirement failed: parameter "obj_type" is not defined" error when XGBoost.trainDistributed checks that it is defined in LearningTaskParams. obj_type is currently missing in LearningTaskParams.

closes https://github.com/dmlc/xgboost/issues/3620