### PR TITLE
Fix #3638: Binary classification demo should produce LIBSVM with 0-based indexing

### DIFF
--- a/demo/binary_classification/mapfeat.py
+++ b/demo/binary_classification/mapfeat.py
@@ -18,7 +18,7 @@ def loadfmap( fname ):
             if it.strip() == '':
                 continue
             k , v = it.split('=')
-            fmap[ idx ][ v ] = len(nmap) + 1
+            fmap[ idx ][ v ] = len(nmap)
             nmap[ len(nmap) ] = ftype+'='+k
     return fmap, nmap
 


### PR DESCRIPTION
Fixes #3638 by ensuring that feature indices start with 0, not 1.