### PR TITLE
Fix `demo/rank` data processing order

### DIFF
--- a/demo/rank/runexp.sh
+++ b/demo/rank/runexp.sh
@@ -1,11 +1,5 @@
-python trans_data.py train.txt mq2008.train mq2008.train.group
-
-python trans_data.py test.txt mq2008.test mq2008.test.group
-
-python trans_data.py vali.txt mq2008.vali mq2008.vali.group
+#!/bin/bash
 
 ../../xgboost mq2008.conf
 
 ../../xgboost mq2008.conf task=pred model_in=0004.model
-
-

--- a/demo/rank/wgetdata.sh
+++ b/demo/rank/wgetdata.sh
@@ -2,3 +2,9 @@
 wget https://s3-us-west-2.amazonaws.com/xgboost-examples/MQ2008.rar
 unrar x MQ2008.rar
 mv -f MQ2008/Fold1/*.txt .
+
+python trans_data.py train.txt mq2008.train mq2008.train.group
+
+python trans_data.py test.txt mq2008.test mq2008.test.group
+
+python trans_data.py vali.txt mq2008.vali mq2008.vali.group


### PR DESCRIPTION
This is a very trivial issue. I noticed that with the original script, data processing is bundled with `run_exp.sh`, which now serves as a demo on how to use CLI. If one wants to play with python interface, he needs to execute `run_exp.sh` first. I figured that it might be better to process the data right after it is downloaded so one can run the python demos independently from CLI demo. 