### PR TITLE
Add the missing max_delta_step

### DIFF
--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -223,3 +223,17 @@ test_that("train and predict with non-strict classes", {
   expect_error(pr <- predict(bst, train_dense), regexp = NA)
   expect_equal(pr0, pr)
 })
+
+test_that("max_delta_step works", {
+  dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
+  watchlist <- list(train = dtrain)
+  param <- list(objective = "binary:logistic", eval_metric="logloss", max_depth = 2, nthread = 2, eta = 0.5)
+  nrounds = 5
+  # model with no restriction on max_delta_step
+  bst1 <- xgb.train(param, dtrain, nrounds, watchlist, verbose = 1)
+  # model with restricted max_delta_step
+  bst2 <- xgb.train(param, dtrain, nrounds, watchlist, verbose = 1, max_delta_step = 1)
+  # the no-restriction model is expected to have consistently lower loss during the initial interations
+  expect_true(all(bst1$evaluation_log$train_logloss < bst2$evaluation_log$train_logloss))
+  expect_lt(mean(bst1$evaluation_log$train_logloss)/mean(bst2$evaluation_log$train_logloss), 0.8)
+})

--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -63,7 +63,6 @@ bst_float SplitEvaluator::ComputeSplitScore(bst_uint nodeid,
 struct ElasticNetParams : public dmlc::Parameter<ElasticNetParams> {
   bst_float reg_lambda;
   bst_float reg_alpha;
-  bst_float reg_gamma;
   // maximum delta update we can add in weight estimation
   // this parameter can be used to stabilize update
   // default=0 means no constraint on weight delta
@@ -78,10 +77,6 @@ struct ElasticNetParams : public dmlc::Parameter<ElasticNetParams> {
       .set_lower_bound(0.0)
       .set_default(0.0)
       .describe("L1 regularization on leaf weight");
-    DMLC_DECLARE_FIELD(reg_gamma)
-      .set_lower_bound(0.0)
-      .set_default(0.0)
-      .describe("Cost incurred by adding a new leaf node to the tree");
     DMLC_DECLARE_FIELD(max_delta_step)
       .set_lower_bound(0.0f)
       .set_default(0.0f)
@@ -89,7 +84,6 @@ struct ElasticNetParams : public dmlc::Parameter<ElasticNetParams> {
                 "If the value is set to 0, it means there is no constraint");
     DMLC_DECLARE_ALIAS(reg_lambda, lambda);
     DMLC_DECLARE_ALIAS(reg_alpha, alpha);
-    DMLC_DECLARE_ALIAS(reg_gamma, gamma);
   }
 };
 
@@ -172,7 +166,7 @@ class ElasticNet final : public SplitEvaluator {
 };
 
 XGBOOST_REGISTER_SPLIT_EVALUATOR(ElasticNet, "elastic_net")
-.describe("Use an elastic net regulariser and a cost per leaf node")
+.describe("Use an elastic net regulariser")
 .set_body([](std::unique_ptr<SplitEvaluator> inner) {
     return new ElasticNet(std::move(inner));
   });

--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -136,7 +136,7 @@ class ElasticNet final : public SplitEvaluator {
       const override {
     auto loss = weight * (2.0 * stats.sum_grad + stats.sum_hess * weight
         + params_.reg_lambda * weight)
-        + params_.reg_alpha * std::abs(weight);
+        + 2.0 * params_.reg_alpha * std::abs(weight);
     return -loss;
   }
 
@@ -144,8 +144,7 @@ class ElasticNet final : public SplitEvaluator {
     if (params_.max_delta_step == 0.0f) {
       return Sqr(ThresholdL1(stats.sum_grad)) / (stats.sum_hess + params_.reg_lambda);
     } else {
-      bst_float w = ComputeWeight(parentID, stats);
-      return ComputeScore(parentID, stats, w);
+      return ComputeScore(parentID, stats, ComputeWeight(parentID, stats));
     }
   }
 


### PR DESCRIPTION
The `max_delta_step` parameter fell through the cracks during the recent change to `SplitEvaluator` for the `grow_colmaker` and `grow_fast_histmaker` updaters. It can be very useful for noisy datasets. I didn't see any noticeable timing performance change for the default `max_delta_step=0` case.

Also I've removed the unused reg_gamma parameter from ElasticNet, since it's only to be used during pruning.