### PR TITLE
Add scikit-learn tests

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -4,7 +4,6 @@
 """Core XGBoost Library."""
 from __future__ import absolute_import
 
-import warnings
 import collections
 import ctypes
 import os

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -4,12 +4,12 @@
 """Core XGBoost Library."""
 from __future__ import absolute_import
 
+import warnings
 import collections
 import ctypes
 import os
 import re
 import sys
-
 import numpy as np
 import scipy.sparse
 
@@ -374,11 +374,15 @@ class DMatrix(object):
         if label is not None:
             if isinstance(label, np.ndarray):
                 self.set_label_npy2d(label)
+            elif getattr(label, '__array__', None) is not None:
+                self.set_label_npy2d(label.__array__())
             else:
                 self.set_label(label)
         if weight is not None:
             if isinstance(weight, np.ndarray):
                 self.set_weight_npy2d(weight)
+            elif getattr(weight, '__array__', None) is not None:
+                self.set_weight_npy2d(weight.__array__())
             else:
                 self.set_weight(weight)
 
@@ -428,7 +432,7 @@ class DMatrix(object):
         and type if memory use is a concern.
         """
         if len(mat.shape) != 2:
-            raise ValueError('Input numpy.ndarray must be 2 dimensional')
+            raise ValueError('Input numpy.ndarray must be 2 dimensional. Reshape your data.')
         # flatten the array by rows and ensure it is float32.
         # we try to avoid data copies if possible (reshape returns a view when possible
         # and we explicitly tell np.array to try and avoid copying)

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme, E0012, R0912
+# pylint: disable=too-many-arguments, too-many-locals, invalid-name, fixme, E0012, R0912, C0302
 """Scikit-Learn Wrapper interface for XGBoost."""
 from __future__ import absolute_import
 
@@ -17,6 +17,7 @@ from .compat import (SKLEARN_INSTALLED, XGBModelBase,
 
 
 def _check_label_1d(label):
+    """Produce warning if label is not 1D array"""
     label = np.array(label, copy=False, dtype=np.float32)
     if len(label.shape) == 2 and label.shape[1] == 1:
         warnings.warn('A column-vector y was passed when a 1d array was'

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -25,6 +25,7 @@ def _check_label_1d(label):
                       '(n_samples, ), for example using ravel().',
                       DataConversionWarning, stacklevel=2)
 
+
 def _objective_decorator(func):
     """Decorate an objective function
 

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 
 import numpy as np
 import warnings
+from sklearn.exceptions import NotFittedError
+from sklearn.exceptions import DataConversionWarning
 from .core import Booster, DMatrix, XGBoostError
 from .training import train
 
@@ -13,6 +15,14 @@ from .training import train
 from .compat import (SKLEARN_INSTALLED, XGBModelBase,
                      XGBClassifierBase, XGBRegressorBase, XGBLabelEncoder)
 
+
+def _check_label_1d(label):
+    label = np.array(label, copy=False, dtype=np.float32)
+    if len(label.shape) == 2 and label.shape[1] == 1:
+        warnings.warn('A column-vector y was passed when a 1d array was'
+                      ' expected. Please change the shape of y to '
+                      '(n_samples, ), for example using ravel().',
+                      DataConversionWarning, stacklevel=2)
 
 def _objective_decorator(func):
     """Decorate an objective function
@@ -178,7 +188,7 @@ class XGBModel(XGBModelBase):
         booster : a xgboost booster of underlying model
         """
         if self._Booster is None:
-            raise XGBoostError('need to call fit or load_model beforehand')
+            raise NotFittedError('need to call fit or load_model beforehand')
         return self._Booster
 
     def get_params(self, deep=False):
@@ -286,6 +296,7 @@ class XGBModel(XGBModelBase):
             file name of stored xgb model or 'Booster' instance Xgb model to be
             loaded before training (allows training continuation).
         """
+        _check_label_1d(label=y)
         if sample_weight is not None:
             trainDmatrix = DMatrix(X, label=y, weight=sample_weight,
                                    missing=self.missing, nthread=self.n_jobs)
@@ -536,6 +547,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             file name of stored xgb model or 'Booster' instance Xgb model to be
             loaded before training (allows training continuation).
         """
+        _check_label_1d(label=y)
         evals_result = {}
         self.classes_ = np.unique(y)
         self.n_classes_ = len(self.classes_)
@@ -912,6 +924,7 @@ class XGBRanker(XGBModel):
             file name of stored xgb model or 'Booster' instance Xgb model to be
             loaded before training (allows training continuation).
         """
+        _check_label_1d(label=y)
         # check if group information is provided
         if group is None:
             raise ValueError("group is required for ranking task")

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -206,9 +206,11 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
     nrow = dtrain.num_row()
     ncol = dtrain.num_col()
     if nrow <= 0:
-        raise ValueError('{} row(s) (shape=({}, {})) while a minimum of 1 is required.'.format(nrow, nrow, ncol))
+        raise ValueError('{} row(s) (shape=({}, {})) while a minimum of 1 is required.'\
+                         .format(nrow, nrow, ncol))
     if ncol <= 0:
-        raise ValueError('{} feature(s) (shape=({}, {})) while a minimum of 1 is required.'.format(ncol, nrow, ncol))
+        raise ValueError('{} feature(s) (shape=({}, {})) while a minimum of 1 is required.'\
+                         .format(ncol, nrow, ncol))
     label = dtrain.get_label()
     if nrow != len(label):
         raise ValueError('Label must have same length as the number of data rows')

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -203,6 +203,16 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
                       DeprecationWarning)
         callbacks.append(callback.reset_learning_rate(learning_rates))
 
+    nrow = dtrain.num_row()
+    ncol = dtrain.num_col()
+    if nrow <= 0:
+        raise ValueError('{} row(s) (shape=({}, {})) while a minimum of 1 is required.'.format(nrow, nrow, ncol))
+    if ncol <= 0:
+        raise ValueError('{} feature(s) (shape=({}, {})) while a minimum of 1 is required.'.format(ncol, nrow, ncol))
+    label = dtrain.get_label()
+    if nrow != len(label):
+        raise ValueError('Label must have same length as the number of data rows')
+
     return _train_internal(params, dtrain,
                            num_boost_round=num_boost_round,
                            evals=evals,

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -206,10 +206,10 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
     nrow = dtrain.num_row()
     ncol = dtrain.num_col()
     if nrow <= 0:
-        raise ValueError('{} row(s) (shape=({}, {})) while a minimum of 1 is required.'\
+        raise ValueError('{} row(s) (shape=({}, {})) while a minimum of 1 is required.'
                          .format(nrow, nrow, ncol))
     if ncol <= 0:
-        raise ValueError('{} feature(s) (shape=({}, {})) while a minimum of 1 is required.'\
+        raise ValueError('{} feature(s) (shape=({}, {})) while a minimum of 1 is required.'
                          .format(ncol, nrow, ncol))
     label = dtrain.get_label()
     if nrow != len(label):


### PR DESCRIPTION
Goal is to pass scikit-learn's check_estimator() for XGBClassifier, XGBRegressor, and XGBRanker.
It is actually not possible to do so entirely, since check_estimator() assumes that NaN is disallowed, but XGBoost allows for NaN as missing values. However, it is always good idea to add some checks inspired by check_estimator().

Related: #3580