### PR TITLE
Better error message for failed library loading

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -132,11 +132,12 @@ def _load_lib():
     if not lib_success:
         libname = os.path.basename(lib_paths[0])
         raise XGBoostError(
-            'XGBoost Library ({}) could not be loaded.\n'.format(libname) + \
-            'Likely causes:\n' + \
-            '  * OpenMP runtime is not installed ' + \
-            '(vcomp140.dll for Windows, libgomp.so for UNIX-like OSes)\n' + \
-            '  * You are running 32-bit Python on a 64-bit OS\n' + \
+            'XGBoost Library ({}) could not be loaded.\n'.format(libname) +
+            'Likely causes:\n' +
+            '  * OpenMP runtime is not installed ' +
+            '(vcomp140.dll or libgomp-1.dll for Windows, ' +
+            'libgomp.so for UNIX-like OSes)\n' +
+            '  * You are running 32-bit Python on a 64-bit OS\n' +
             'Error message(s): {}\n'.format(os_error_list))
     lib.XGBGetLastError.restype = ctypes.c_char_p
     lib.callback = _get_log_callback_func()


### PR DESCRIPTION
Addresses #3616.

On some systems, the XGBoost library (`libxgboost.so`, `xgboost.dll`, or `libxgboost.dylib`) may fail to load because of missing dependencies. Previously, it would result in a uninformative error
```
UnboundLocalError: local variable 'lib' referenced before assignment
```

This pull request is aimed at producing a better error message for this scenario.