### PR TITLE
[jvm-packages] Add rank:ndcg and rank:map to Spark supported objectives

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -82,7 +82,7 @@ private[spark] trait LearningTaskParams extends Params {
 private[spark] object LearningTaskParams {
   val supportedObjective = HashSet("reg:linear", "reg:logistic", "binary:logistic",
     "binary:logitraw", "count:poisson", "multi:softmax", "multi:softprob", "rank:pairwise",
-    "reg:gamma", "reg:tweedie")
+    "rank:ndcg", "rank:map", "reg:gamma", "reg:tweedie")
 
   val supportedEvalMetrics = HashSet("rmse", "mae", "logloss", "error", "merror", "mlogloss",
     "auc", "aucpr", "ndcg", "map", "gamma-deviance")


### PR DESCRIPTION
According to the [Learning Task Parameters documentation](https://xgboost.readthedocs.io/en/latest/parameter.html#learning-task-parameters), `rank:ndcg` and `rank:map` learning objectives should be available.

There is a little discussion about if there was any specific reason why these objectives were previously omitted [here](https://github.com/dmlc/xgboost/issues/901) and [here](https://discuss.xgboost.ai/t/jvm-packge-does-xgboost-spark-support-rank-ndcg/229).