### PR TITLE
[jvm-packages] add DMatrix batchSize as parameter

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -36,18 +36,17 @@ public class DMatrix {
   }
 
   /**
-   * Create DMatrix from iterator.
-   *
-   * @param iter The data iterator of mini batch to provide the data.
-   * @param cacheInfo Cache path information, used for external memory setting, can be null.
-   * @throws XGBoostError
-   */
-  public DMatrix(Iterator<LabeledPoint> iter, String cacheInfo) throws XGBoostError {
+     * Create DMatrix from iterator.
+     *
+     * @param iter The data iterator of mini batch to provide the data.
+     * @param cacheInfo Cache path information, used for external memory setting, can be null.
+     * @param batchSize Size of batch, recommended 32 << 10
+     * @throws XGBoostError
+     */
+  public DMatrix(Iterator<LabeledPoint> iter, String cacheInfo, int batchSize) throws XGBoostError {
     if (iter == null) {
       throw new NullPointerException("iter: null");
     }
-    // 32k as batch size
-    int batchSize = 32 << 10;
     Iterator<DataBatch> batchIter = new DataBatch.BatchIterator(iter, batchSize);
     long[] out = new long[1];
     XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCreateFromDataIter(batchIter, cacheInfo, out));

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
@@ -36,10 +36,11 @@ class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
     *
     * @param dataIter An iterator of LabeledPoint
     * @param cacheInfo  Cache path information, used for external memory setting, null by default.
+    * @param batchSize size of batch
     * @throws XGBoostError native error
     */
-  def this(dataIter: Iterator[LabeledPoint], cacheInfo: String = null) {
-    this(new JDMatrix(dataIter.asJava, cacheInfo))
+  def this(dataIter: Iterator[LabeledPoint], cacheInfo: String = null, batchSize: Int = 32 << 10) {
+    this(new JDMatrix(dataIter.asJava, cacheInfo, batchSize))
   }
 
   /**

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/DMatrixTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/DMatrixTest.java
@@ -42,9 +42,17 @@ public class DMatrixTest {
       blist.add(p);
       labelall.add(p.label());
     }
-    DMatrix dmat = new DMatrix(blist.iterator(), null);
+
+    DMatrix dmat = new DMatrix(blist.iterator(), null, 32<<10);
     // get label
     float[] labels = dmat.getLabel();
+    for (int i = 0; i < labels.length; ++i) {
+      TestCase.assertTrue(labelall.get(i) == labels[i]);
+    }
+    // test bach iterator
+    dmat = new DMatrix(blist.iterator(), null, 300);
+    // get label
+    labels = dmat.getLabel();
     for (int i = 0; i < labels.length; ++i) {
       TestCase.assertTrue(labelall.get(i) == labels[i]);
     }


### PR DESCRIPTION
32k seems a magic number in XGBoost DMatrix constructor implementation. Same magic number also shows in rabbit ring replication minimal batch threshold. The goal of this PR is to allow end user tune batch size on their specific cluster environment and training sample size.
