### PR TITLE
[python-package] remove extra "of" in class docstring

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -844,7 +844,7 @@ class DMatrix(object):
 
 
 class Booster(object):
-    """A Booster of of XGBoost.
+    """A Booster of XGBoost.
 
     Booster is the model of xgboost, that contains low level routines for
     training, prediction and evaluation.


### PR DESCRIPTION
I deleted a word that seems to be extra.