### PR TITLE
Disable flaky tests in R-package/tests/testthat/test_update.R

### DIFF
--- a/R-package/tests/testthat/test_update.R
+++ b/R-package/tests/testthat/test_update.R
@@ -7,6 +7,10 @@ data(agaricus.test, package = 'xgboost')
 dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 
+# Disable flaky tests for 32-bit Windows.
+# See https://github.com/dmlc/xgboost/issues/3720
+win32_flag = .Platform$OS.type == "windows" && .Machine$sizeof.pointer != 8
+
 test_that("updating the model works", {
   watchlist = list(train = dtrain, test = dtest)
 
@@ -29,7 +33,9 @@ test_that("updating the model works", {
   tr1r <- xgb.model.dt.tree(model = bst1r)
   # all should be the same when no subsampling
   expect_equal(bst1$evaluation_log, bst1r$evaluation_log)
-  expect_equal(tr1, tr1r, tolerance = 0.00001, check.attributes = FALSE)
+  if (!win32_flag) {
+    expect_equal(tr1, tr1r, tolerance = 0.00001, check.attributes = FALSE)
+  }
 
   # the same boosting with subsampling with an extra 'refresh' updater:
   p2r <- modifyList(p2, list(updater = 'grow_colmaker,prune,refresh', refresh_leaf = FALSE))
@@ -38,7 +44,9 @@ test_that("updating the model works", {
   tr2r <- xgb.model.dt.tree(model = bst2r)
   # should be the same evaluation but different gains and larger cover
   expect_equal(bst2$evaluation_log, bst2r$evaluation_log)
-  expect_equal(tr2[Feature == 'Leaf']$Quality, tr2r[Feature == 'Leaf']$Quality)
+  if (!win32_flag) {
+    expect_equal(tr2[Feature == 'Leaf']$Quality, tr2r[Feature == 'Leaf']$Quality)
+  }
   expect_gt(sum(abs(tr2[Feature != 'Leaf']$Quality - tr2r[Feature != 'Leaf']$Quality)), 100)
   expect_gt(sum(tr2r$Cover) / sum(tr2$Cover), 1.5)
 
@@ -61,7 +69,9 @@ test_that("updating the model works", {
   expect_gt(sum(tr2u$Cover) / sum(tr2$Cover), 1.5)
   # the results should be the same as for the model with an extra 'refresh' updater
   expect_equal(bst2r$evaluation_log, bst2u$evaluation_log)
-  expect_equal(tr2r, tr2u, tolerance = 0.00001, check.attributes = FALSE)
+  if (!win32_flag) {
+    expect_equal(tr2r, tr2u, tolerance = 0.00001, check.attributes = FALSE)
+  }
   
   # process type 'update' for no-subsampling model, refreshing only the tree stats from TEST data:
   p1ut <- modifyList(p1, list(process_type = 'update', updater = 'refresh', refresh_leaf = FALSE))


### PR DESCRIPTION
Disable flaky tests in R-package/tests/testthat/test_update.R.
Lines 32, 41 and 64 randomly fail for 32-bit Windows + MinGW target.

Build log (AppVeyor): https://ci.appveyor.com/project/tqchen/xgboost/build/1.0.2949/job/7i0d2lim73hhy44f#L2960, https://ci.appveyor.com/project/tqchen/xgboost/build/1.0.2954/job/l2icjm6yq4kc2k3s#L3093