### PR TITLE
fix R check warning

### DIFF
--- a/R-package/demo/00Index
+++ b/R-package/demo/00Index
@@ -11,4 +11,5 @@ early_stopping                  Early Stop in training
 poisson_regression              Poisson Regression on count data
 tweedie_regression              Tweddie Regression
 gpu_accelerated                 GPU-accelerated tree building algorithms
+interaction_constraints         Interaction constraints among features
 


### PR DESCRIPTION
Add the new demo on interaction constraints to `00Index`.