### PR TITLE
[jvm-packages] support specified feature names when getModelDump and getFeatureScore

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -370,14 +370,67 @@ public class Booster implements Serializable, KryoSerializable {
   }
 
   /**
+   * Get the dump of the model as a string array with specified feature names.
+   *
+   * @param featureNames Names of the features.
+   * @return dumped model information
+   * @throws XGBoostError
+   */
+  public String[] getModelDump(String[] featureNames, boolean withStats) throws XGBoostError {
+    return getModelDump(featureNames, withStats, "text");
+  }
+
+  public String[] getModelDump(String[] featureNames, boolean withStats, String format)
+    throws XGBoostError {
+    int statsFlag = 0;
+    if (withStats) {
+      statsFlag = 1;
+    }
+    if (format == null) {
+      format = "text";
+    }
+    String[][] modelInfos = new String[1][];
+    XGBoostJNI.checkCall(XGBoostJNI.XGBoosterDumpModelExWithFeatures(
+        handle, featureNames, statsFlag, format, modelInfos));
+    return modelInfos[0];
+  }
+
+  /**
+   * Get importance of each feature with specified feature names.
+   *
+   * @return featureScoreMap  key: feature index, value: feature importance score, can be nill.
+   * @throws XGBoostError native error
+   */
+  public Map<String, Integer> getFeatureScore(String[] featureNames) throws XGBoostError {
+    String[] modelInfos = getModelDump(featureNames, false);
+    Map<String, Integer> featureScore = new HashMap<>();
+    for (String tree : modelInfos) {
+      for (String node : tree.split("\n")) {
+        String[] array = node.split("\\[");
+        if (array.length == 1) {
+          continue;
+        }
+        String fid = array[1].split("\\]")[0];
+        fid = fid.split("<")[0];
+        if (featureScore.containsKey(fid)) {
+          featureScore.put(fid, 1 + featureScore.get(fid));
+        } else {
+          featureScore.put(fid, 1);
+        }
+      }
+    }
+    return featureScore;
+  }
+
+  /**
    * Get importance of each feature
    *
-   * @return featureMap  key: feature index, value: feature importance score, can be nill
+   * @return featureScoreMap  key: feature index, value: feature importance score, can be nill
    * @throws XGBoostError native error
    */
   public Map<String, Integer> getFeatureScore(String featureMap) throws XGBoostError {
     String[] modelInfos = getModelDump(featureMap, false);
-    Map<String, Integer> featureScore = new HashMap<String, Integer>();
+    Map<String, Integer> featureScore = new HashMap<>();
     for (String tree : modelInfos) {
       for (String node : tree.split("\n")) {
         String[] array = node.split("\\[");

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -398,7 +398,7 @@ public class Booster implements Serializable, KryoSerializable {
   /**
    * Get importance of each feature with specified feature names.
    *
-   * @return featureScoreMap  key: feature index, value: feature importance score, can be nill.
+   * @return featureScoreMap  key: feature name, value: feature importance score, can be nill.
    * @throws XGBoostError native error
    */
   public Map<String, Integer> getFeatureScore(String[] featureNames) throws XGBoostError {

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -111,6 +111,9 @@ class XGBoostJNI {
   public final static native int XGBoosterDumpModelEx(long handle, String fmap, int with_stats,
                                                       String format, String[][] out_strings);
 
+  public final static native int XGBoosterDumpModelExWithFeatures(
+    long handle, String[] feature_names, int with_stats, String format, String[][] out_strings);
+
   public final static native int XGBoosterGetAttr(long handle, String key, String[] out_string);
   public final static native int XGBoosterSetAttr(long handle, String key, String value);
   public final static native int XGBoosterLoadRabitCheckpoint(long handle, int[] out_version);

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
@@ -193,13 +193,12 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
     * @param featureNames Names of features.
     */
   @throws(classOf[XGBoostError])
-  def getModelDump(featureNames: Array[String])
-  : Array[String] = {
+  def getModelDump(featureNames: Array[String]): Array[String] = {
     booster.getModelDump(featureNames, false, "text")
   }
 
   def getModelDump(featureNames: Array[String], withStats: Boolean, format: String)
-  : Array[String] = {
+    : Array[String] = {
     booster.getModelDump(featureNames, withStats, format)
   }
 
@@ -217,7 +216,7 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
   /**
     * Get importance of each feature with specified feature names.
     *
-    * @return featureScoreMap  key: feature index, value: feature importance score
+    * @return featureScoreMap  key: feature name, value: feature importance score
     */
   @throws(classOf[XGBoostError])
   def getFeatureScore(featureNames: Array[String]): mutable.Map[String, Integer] = {

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
@@ -188,13 +188,40 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
   }
 
   /**
+    * Dump model as Array of string with specified feature names.
+    *
+    * @param featureNames Names of features.
+    */
+  @throws(classOf[XGBoostError])
+  def getModelDump(featureNames: Array[String])
+  : Array[String] = {
+    booster.getModelDump(featureNames, false, "text")
+  }
+
+  def getModelDump(featureNames: Array[String], withStats: Boolean, format: String)
+  : Array[String] = {
+    booster.getModelDump(featureNames, withStats, format)
+  }
+
+
+  /**
    * Get importance of each feature
    *
-   * @return featureMap  key: feature index, value: feature importance score
+   * @return featureScoreMap  key: feature index, value: feature importance score
    */
   @throws(classOf[XGBoostError])
   def getFeatureScore(featureMap: String = null): mutable.Map[String, Integer] = {
     booster.getFeatureScore(featureMap).asScala
+  }
+
+  /**
+    * Get importance of each feature with specified feature names.
+    *
+    * @return featureScoreMap  key: feature index, value: feature importance score
+    */
+  @throws(classOf[XGBoostError])
+  def getFeatureScore(featureNames: Array[String]): mutable.Map[String, Integer] = {
+    booster.getFeatureScore(featureNames).asScala
   }
 
   def getVersion: Int = booster.getVersion

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.h
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.h
@@ -225,6 +225,14 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModel
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGBoosterDumpModelExWithFeatures
+ * Signature: (JLjava/lang/String;I[[Ljava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModelExWithFeatures
+  (JNIEnv *, jclass, jlong, jobjectArray, jint, jstring, jobjectArray);
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGBoosterGetAttr
  * Signature: (JLjava/lang/String;[Ljava/lang/String;)I
  */

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
@@ -271,6 +271,24 @@ public class BoosterImplTest {
     Booster booster = trainBooster(trainMat, testMat);
     String[] dump = booster.getModelDump("", false, "json");
     TestCase.assertEquals("  { \"nodeid\":", dump[0].substring(0, 13));
+
+    // test with specified feature names
+    String[] featureNames = new String[126];
+    for(int i = 0; i < 126; i++) featureNames[i] = "test_feature_name_" + i;
+    dump = booster.getModelDump(featureNames, false, "json");
+    TestCase.assertTrue(dump[0].contains("test_feature_name_"));
+  }
+
+  @Test
+  public void testGetFeatureImportance() throws XGBoostError {
+    DMatrix trainMat = new DMatrix("../../demo/data/agaricus.txt.train");
+    DMatrix testMat = new DMatrix("../../demo/data/agaricus.txt.test");
+
+    Booster booster = trainBooster(trainMat, testMat);
+    String[] featureNames = new String[126];
+    for(int i = 0; i < 126; i++) featureNames[i] = "test_feature_name_" + i;
+    Map<String, Integer> scoreMap = booster.getFeatureScore(featureNames);
+    for (String fName: scoreMap.keySet()) TestCase.assertTrue(fName.startsWith("test_feature_name_"));
   }
 
   @Test


### PR DESCRIPTION
I've add a jni stub `XGBoosterDumpModelExWithFeatures` to support setting feature names when getting model dump and feature scores. And some new tests are added.

Could you help to take a look? @CodingCat 

close #3725 