### PR TITLE
[Jenkins CI] Do not build artifacts for pull requests

### DIFF
--- a/Jenkinsfile-restricted
+++ b/Jenkinsfile-restricted
@@ -5,7 +5,8 @@
 
 import groovy.transform.Field
 
-/* Unrestricted tasks: tasks that do NOT generate artifacts */
+/* Restricted tasks: tasks generating artifacts, such as binary wheels and
+                     documentation */
 
 // Command to run command inside a docker container
 def dockerRun = 'tests/ci_build/ci_build.sh'
@@ -35,7 +36,7 @@ pipeline {
     stages {
         stage('Jenkins: Get sources') {
             agent {
-                label 'unrestricted'
+                label 'restricted'
             }
             steps {
                 script {
@@ -46,12 +47,34 @@ pipeline {
                 milestone label: 'Sources ready', ordinal: 1
             }
         }
-        stage('Jenkins: Build & Test') {
+        stage('Jenkins: Build doc') {
+            agent {
+                label 'linux && cpu && restricted'
+            }
+            steps {
+                unstash name: 'srcs'
+                script {
+                    def commit_id = "${GIT_COMMIT}"
+                    def branch_name = "${GIT_LOCAL_BRANCH}"
+                    echo 'Building doc...'
+                    dir ('jvm-packages') {
+                        sh "bash ./build_doc.sh ${commit_id}"
+                        archiveArtifacts artifacts: "${commit_id}.tar.bz2", allowEmptyArchive: true
+                        echo 'Deploying doc...'
+                        withAWS(credentials:'xgboost-doc-bucket') {
+                            s3Upload file: "${commit_id}.tar.bz2", bucket: 'xgboost-docs', acl: 'PublicRead', path: "${branch_name}.tar.bz2"
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Jenkins: Build artifacts') {
             steps {
                 script {
                     parallel (buildMatrix.findAll{it['enabled']}.collectEntries{ c ->
                         def buildName = utils.getBuildName(c)
-                        utils.buildFactory(buildName, c, false, this.&buildPlatformCmake)
+                        utils.buildFactory(buildName, c, true, this.&buildPlatformCmake)
                     })
                 }
             }
@@ -82,7 +105,17 @@ def buildPlatformCmake(buildName, conf, nodeReq, dockerTarget) {
         // Invoke command inside docker
         sh """
         ${dockerRun} ${dockerTarget} ${dockerArgs} tests/ci_build/build_via_cmake.sh ${opts}
-        ${dockerRun} ${dockerTarget} ${dockerArgs} tests/ci_build/test_${dockerTarget}.sh
+        ${dockerRun} ${dockerTarget} ${dockerArgs} bash -c "cd python-package; rm -f dist/*; python setup.py bdist_wheel --universal"
+        rm -rf "${distDir}"; mkdir -p "${distDir}/py"
+        cp xgboost "${distDir}"
+        cp -r lib "${distDir}"
+        cp -r python-package/dist "${distDir}/py"
+        # Test the wheel for compatibility on a barebones CPU container
+        ${dockerRun} release ${dockerArgs} bash -c " \
+            auditwheel show xgboost-*-py2-none-any.whl
+            pip install --user python-package/dist/xgboost-*-none-any.whl && \
+            python -m nose tests/python"
         """
+        archiveArtifacts artifacts: "${distDir}/**/*.*", allowEmptyArchive: true
     }
 }

--- a/tests/ci_build/jenkins_tools.Groovy
+++ b/tests/ci_build/jenkins_tools.Groovy
@@ -1,0 +1,52 @@
+#!/usr/bin/groovy
+// -*- mode: groovy -*-
+
+/* Utility functions for Jenkins */
+
+// Command to run command inside a docker container
+dockerRun = 'tests/ci_build/ci_build.sh'
+
+// initialize source codes
+def checkoutSrcs() {
+  retry(5) {
+    try {
+      timeout(time: 2, unit: 'MINUTES') {
+        checkout scm
+        sh 'git submodule update --init'
+      }
+    } catch (exc) {
+      deleteDir()
+      error "Failed to fetch source codes"
+    }
+  }
+}
+
+/**
+ * Creates cmake and make builds
+ */
+def buildFactory(buildName, conf, restricted, build_func) {
+    def os = conf["os"]
+    def device = conf["withGpu"] ? "gpu" : "cpu"
+    def restricted_flag = restricted ? "restricted" : "unrestricted"
+    def nodeReq = "${os} && ${device} && ${restricted_flag}"
+    def dockerTarget = conf["withGpu"] ? "gpu" : "cpu"
+    [ ("${buildName}") : { build_func("${buildName}", conf, nodeReq, dockerTarget) }
+    ]
+}
+
+def cmakeOptions(conf) {
+    return ([
+        conf["withGpu"] ? '-DUSE_CUDA=ON' : '-DUSE_CUDA=OFF',
+        conf["withNccl"] ? '-DUSE_NCCL=ON' : '-DUSE_NCCL=OFF',
+        conf["withOmp"] ? '-DOPEN_MP:BOOL=ON' : '']
+        ).join(" ")
+}
+
+def getBuildName(conf) {
+    def gpuLabel = conf['withGpu'] ? ("_cuda" + conf['cudaVersion'] + (conf['withNccl'] ? "_nccl" : "_nonccl")) : "_cpu"
+    def ompLabel = conf['withOmp'] ? "_omp" : ""
+    def pyLabel = "_py${conf['pythonVersion']}"
+    return "${conf['os']}${gpuLabel}${ompLabel}${pyLabel}"
+}
+
+return this


### PR DESCRIPTION
Right now, the Jenkins CI server (https://xgboost-ci.net) creates artifacts (binary Python wheels and documentation) for every branch and pull request. This is a security risk, since an adversary is able to create a pull request and inject malicious code.

Fix: Build artifacts only for branches `master`, `release_0.72`, and `release_0.80`. The danger of malicious code is lessened because every pull request is vetted before getting merged to a branch.