### PR TITLE
Add multi-GPU unit test environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ def dockerRun = 'tests/ci_build/ci_build.sh'
 def utils
 
 def buildMatrix = [
+    [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": true,  "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "9.2", "multiGpu": true],
     [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": true,  "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "9.2" ],
     [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": true,  "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "8.0" ],
     [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": false, "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "8.0" ],
@@ -67,9 +68,10 @@ def buildPlatformCmake(buildName, conf, nodeReq, dockerTarget) {
     // Destination dir for artifacts
     def distDir = "dist/${buildName}"
     def dockerArgs = ""
-    if(conf["withGpu"]){
+    if (conf["withGpu"]) {
         dockerArgs = "--build-arg CUDA_VERSION=" + conf["cudaVersion"]
     }
+    def test_suite = conf["withGpu"] ? (conf["multiGpu"] ? "mgpu" : "gpu") : "cpu"
     // Build node - this is returned result
     node(nodeReq) {
         unstash name: 'srcs'
@@ -82,7 +84,7 @@ def buildPlatformCmake(buildName, conf, nodeReq, dockerTarget) {
         // Invoke command inside docker
         sh """
         ${dockerRun} ${dockerTarget} ${dockerArgs} tests/ci_build/build_via_cmake.sh ${opts}
-        ${dockerRun} ${dockerTarget} ${dockerArgs} tests/ci_build/test_${dockerTarget}.sh
+        ${dockerRun} ${dockerTarget} ${dockerArgs} tests/ci_build/test_${test_suite}.sh
         """
     }
 }

--- a/tests/ci_build/jenkins_tools.Groovy
+++ b/tests/ci_build/jenkins_tools.Groovy
@@ -26,7 +26,7 @@ def checkoutSrcs() {
  */
 def buildFactory(buildName, conf, restricted, build_func) {
     def os = conf["os"]
-    def device = conf["withGpu"] ? "gpu" : "cpu"
+    def device = conf["withGpu"] ? (conf["multiGpu"] ? "mgpu" : "gpu") : "cpu"
     def restricted_flag = restricted ? "restricted" : "unrestricted"
     def nodeReq = "${os} && ${device} && ${restricted_flag}"
     def dockerTarget = conf["withGpu"] ? "gpu" : "cpu"
@@ -43,7 +43,7 @@ def cmakeOptions(conf) {
 }
 
 def getBuildName(conf) {
-    def gpuLabel = conf['withGpu'] ? ("_cuda" + conf['cudaVersion'] + (conf['withNccl'] ? "_nccl" : "_nonccl")) : "_cpu"
+    def gpuLabel = conf['withGpu'] ? ( (conf['multiGpu'] ? "_mgpu" : "") + "_cuda" + conf['cudaVersion'] + (conf['withNccl'] ? "_nccl" : "_nonccl")) : "_cpu"
     def ompLabel = conf['withOmp'] ? "_omp" : ""
     def pyLabel = "_py${conf['pythonVersion']}"
     return "${conf['os']}${gpuLabel}${ompLabel}${pyLabel}"

--- a/tests/ci_build/test_mgpu.sh
+++ b/tests/ci_build/test_mgpu.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+cd python-package
+python setup.py install --user
+cd ..
+python -m nose -v --attr='!slow' tests/python-mgpu/
+

--- a/tests/python-mgpu/test_gpu_updaters.py
+++ b/tests/python-mgpu/test_gpu_updaters.py
@@ -1,0 +1,29 @@
+import numpy as np
+import sys
+import unittest
+
+sys.path.append("tests/python")
+import xgboost as xgb
+from regression_test_utilities import run_suite, parameter_combinations, \
+    assert_results_non_increasing
+
+def assert_gpu_results(cpu_results, gpu_results):
+    for cpu_res, gpu_res in zip(cpu_results, gpu_results):
+        # Check final eval result roughly equivalent
+        assert np.allclose(cpu_res["eval"][-1], gpu_res["eval"][-1], 1e-2, 1e-2)
+
+datasets = ["Boston", "Cancer", "Digits", "Sparse regression",
+            "Sparse regression with weights", "Small weights regression"]
+
+class TestGPU(unittest.TestCase):
+    def test_gpu_hist(self):
+        variable_param = {'n_gpus': [-1], 'max_depth': [2, 10], 'max_leaves': [255, 4],
+                          'max_bin': [2, 256],
+                          'grow_policy': ['lossguide']}
+        for param in parameter_combinations(variable_param):
+            param['tree_method'] = 'gpu_hist'
+            gpu_results = run_suite(param, select_datasets=datasets)
+            assert_results_non_increasing(gpu_results, 1e-2)
+            param['tree_method'] = 'hist'
+            cpu_results = run_suite(param, select_datasets=datasets)
+            assert_gpu_results(cpu_results, gpu_results)


### PR DESCRIPTION
* Add a new group of agents to Jenkins CI to run multi-GPU workload. The agents will use a p2.8xlarge instance.
* Add a simple test for `gpu_hist`.