### PR TITLE
[Blocking][jvm-packages] For training data with group, empty RDD partition threw exception (#3749)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -80,3 +80,4 @@ List of Contributors
   - liuliang01 added support for the qid column for LibSVM input format. This makes ranking task easier in distributed setting.
 * [Andrew Thia](https://github.com/BlueTea88)
   - Andrew Thia implemented feature interaction constraints
+* [Wei Tian](https://github.com/weitian)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -494,7 +494,7 @@ private[spark] class LabeledPointGroupIterator(base: Iterator[XGBLabeledPoint])
   extends AbstractIterator[XGBLabeledPointGroup] {
 
   private var firstPointOfNextGroup: XGBLabeledPoint = null
-  private var isNewGroup = true
+  private var isNewGroup = false
 
   override def hasNext: Boolean = {
     return base.hasNext || isNewGroup


### PR DESCRIPTION
private var isNewGroup = true

  override def hasNext: Boolean = {
    return base.hasNext || isNewGroup
 }

The initial value for isNewGroup should be false otherwise the hasNext is wrong with empty partition.

