### PR TITLE
Test wheel compatibility on CPU containers, for all pull requests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,14 +85,18 @@ def buildPlatformCmake(buildName, conf, nodeReq, dockerTarget) {
         sh """
         ${dockerRun} ${dockerTarget} ${dockerArgs} tests/ci_build/build_via_cmake.sh ${opts}
         ${dockerRun} ${dockerTarget} ${dockerArgs} tests/ci_build/test_${test_suite}.sh
-        ${dockerRun} ${dockerTarget} ${dockerArgs} bash -c "cd python-package; rm -f dist/*; python setup.py bdist_wheel --universal"
-        rm -rf "${distDir}"; mkdir -p "${distDir}/py"
-        cp xgboost "${distDir}"
-        cp -r python-package/dist "${distDir}/py"
-        # Test the wheel for compatibility on a barebones CPU container
-        ${dockerRun} release ${dockerArgs} bash -c " \
-            pip install --user python-package/dist/xgboost-*-none-any.whl && \
-            python -m nose tests/python"
         """
+        if (!conf["multiGpu"]) {
+            sh """
+            ${dockerRun} ${dockerTarget} ${dockerArgs} bash -c "cd python-package; rm -f dist/*; python setup.py bdist_wheel --universal"
+            rm -rf "${distDir}"; mkdir -p "${distDir}/py"
+            cp xgboost "${distDir}"
+            cp -r python-package/dist "${distDir}/py"
+            # Test the wheel for compatibility on a barebones CPU container
+            ${dockerRun} release ${dockerArgs} bash -c " \
+                pip install --user python-package/dist/xgboost-*-none-any.whl && \
+                python -m nose tests/python"
+            """
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,14 @@ def buildPlatformCmake(buildName, conf, nodeReq, dockerTarget) {
         sh """
         ${dockerRun} ${dockerTarget} ${dockerArgs} tests/ci_build/build_via_cmake.sh ${opts}
         ${dockerRun} ${dockerTarget} ${dockerArgs} tests/ci_build/test_${test_suite}.sh
+        ${dockerRun} ${dockerTarget} ${dockerArgs} bash -c "cd python-package; rm -f dist/*; python setup.py bdist_wheel --universal"
+        rm -rf "${distDir}"; mkdir -p "${distDir}/py"
+        cp xgboost "${distDir}"
+        cp -r python-package/dist "${distDir}/py"
+        # Test the wheel for compatibility on a barebones CPU container
+        ${dockerRun} release ${dockerArgs} bash -c " \
+            pip install --user python-package/dist/xgboost-*-none-any.whl && \
+            python -m nose tests/python"
         """
     }
 }

--- a/Jenkinsfile-restricted
+++ b/Jenkinsfile-restricted
@@ -110,11 +110,6 @@ def buildPlatformCmake(buildName, conf, nodeReq, dockerTarget) {
         cp xgboost "${distDir}"
         cp -r lib "${distDir}"
         cp -r python-package/dist "${distDir}/py"
-        # Test the wheel for compatibility on a barebones CPU container
-        ${dockerRun} release ${dockerArgs} bash -c " \
-            auditwheel show xgboost-*-py2-none-any.whl
-            pip install --user python-package/dist/xgboost-*-none-any.whl && \
-            python -m nose tests/python"
         """
         archiveArtifacts artifacts: "${distDir}/**/*.*", allowEmptyArchive: true
     }


### PR DESCRIPTION
Related: #3746

It is important that the binary wheel (`xgboost-*-none-any.whl`) can run on machines without GPUs, so the CI server should test its compatibility for every incoming pull request.