### PR TITLE
Fix broken doc build due to Matplotlib 3.0 release

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,7 +62,6 @@ release = xgboost.__version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones
 extensions = [
-    'matplotlib.sphinxext.only_directives',
     'matplotlib.sphinxext.plot_directive',
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',


### PR DESCRIPTION
`matplotlib.sphinxext.only_directives` extension has been removed from Matplotlib 3.0.