### PR TITLE
Produce xgboost.so for XGBoost-R on Mac OSX, so that `make install` works

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,9 @@ if(R_LIB)
   target_link_libraries(xgboost ${LINK_LIBRARIES})
   # R uses no lib prefix in shared library names of its packages
   set_target_properties(xgboost PROPERTIES PREFIX "")
+  if(APPLE)
+    set_target_properties(xgboost PROPERTIES SUFFIX ".so")
+  endif()
 
   setup_rpackage_install_target(xgboost ${CMAKE_CURRENT_BINARY_DIR})
   # use a dummy location for any other remaining installs

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -306,7 +306,7 @@ You can install xgboost from CRAN just like any other R package:
 
   install.packages("xgboost")
 
-For OSX users, single-threaded version will be installed. So only one thread will be used for training. To enable use of multiple threads (and utilize capacity of multi-core CPUs), see the section osx_multithread_ to install XGBoost from source.
+For OSX users, single-threaded version will be installed. So only one thread will be used for training. To enable use of multiple threads (and utilize capacity of multi-core CPUs), see the section :ref:`osx_multithread` to install XGBoost from source.
 
 Installing the development version
 ----------------------------------


### PR DESCRIPTION
Now installing R package with multi-threading on OSX is much easier: invoke CMake with `R_LIB=ON` option and run `make` and `make install`.