### PR TITLE
Retry Jenkins CI tests up to 3 times to improve reliability (redux)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,8 +73,8 @@ def buildPlatformCmake(buildName, conf, nodeReq, dockerTarget) {
     }
     def test_suite = conf["withGpu"] ? (conf["multiGpu"] ? "mgpu" : "gpu") : "cpu"
     // Build node - this is returned result
-    node(nodeReq) {
-        retry(3) {
+    retry(3) {
+        node(nodeReq) {
             unstash name: 'srcs'
             echo """
             |===== XGBoost CMake build =====

--- a/Jenkinsfile-restricted
+++ b/Jenkinsfile-restricted
@@ -48,11 +48,11 @@ pipeline {
             }
         }
         stage('Jenkins: Build doc') {
-            agent {
-                label 'linux && cpu && restricted'
-            }
-            steps {
-                retry(3) {
+            retry(3) {
+                agent {
+                    label 'linux && cpu && restricted'
+                }
+                steps {
                     unstash name: 'srcs'
                     script {
                         def commit_id = "${GIT_COMMIT}"
@@ -96,8 +96,8 @@ def buildPlatformCmake(buildName, conf, nodeReq, dockerTarget) {
         dockerArgs = "--build-arg CUDA_VERSION=" + conf["cudaVersion"]
     }
     // Build node - this is returned result
-    node(nodeReq) {
-        retry(3) {
+    retry(3) {
+        node(nodeReq) {
             unstash name: 'srcs'
             echo """
             |===== XGBoost CMake build =====


### PR DESCRIPTION
#3769 does not really work, since failed tests are restarted on workers that already went down. Rearrange `retry` blocks to choose a new worker to re-run failed tests.