### PR TITLE
Fix #3523: Fix CustomGlobalRandomEngine for R

### DIFF
--- a/src/common/random.h
+++ b/src/common/random.h
@@ -33,14 +33,14 @@ using RandomEngine = std::mt19937;
 class CustomGlobalRandomEngine {
  public:
   /*! \brief The result type */
-  typedef size_t result_type;
+  using result_type = uint32_t;
   /*! \brief The minimum of random numbers generated */
   inline static constexpr result_type min() {
     return 0;
   }
   /*! \brief The maximum random numbers generated */
   inline static constexpr result_type max() {
-    return std::numeric_limits<size_t>::max();
+    return std::numeric_limits<result_type>::max();
   }
   /*!
    * \brief seed function, to be implemented


### PR DESCRIPTION
**Diagnosis** Apple Clang's implementation of `std::shuffle` doesn't work correctly when it is run with the random bit generator for R package:
```cpp
CustomGlobalRandomEngine::result_type
CustomGlobalRandomEngine::operator()() {
  return static_cast<result_type>(
      std::floor(unif_rand() * CustomGlobalRandomEngine::max()));
}
```

Minimial reproduction of failure (compile using Apple Clang 10.0):
```cpp
std::vector<int> feature_set(100);
std::iota(feature_set.begin(), feature_set.end(), 0);
    // initialize with 0, 1, 2, 3, ..., 99
std::shuffle(feature_set.begin(), feature_set.end(), common::GlobalRandom());
    // This returns 0, 1, 2, ..., 99, so content didn't get shuffled at all!!!
```

Note that this bug is platform-dependent; it does not appear when GCC or upstream LLVM Clang is used.

**Fix** Use a platform-independent implementation of `std::shuffle`. A header-only library called PCG (Apache license) is included for this purpose.

Closes #3523.

TODO: add a regression test, replace other occurrences of `std::shuffle` in XGBoost codebase