### PR TITLE
[jvm-packages] Updates to Java Booster to support other feature importance measures

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -405,7 +405,7 @@ public class Booster implements Serializable, KryoSerializable {
    * TOTAL_COVER = Total cover over all splits of a feature
    */
 
-  class FeatureImportanceType {
+  public static class FeatureImportanceType {
     public static final String GAIN = "gain";
     public static final String COVER = "cover";
     public static final String TOTAL_GAIN = "total_gain";
@@ -518,19 +518,19 @@ public class Booster implements Serializable, KryoSerializable {
             fidWithImportance[1].split(splitter)[1].split(",")[0]
         );
         String fid = fidWithImportance[0].split("<")[0];
-        if (importanceMap.contains(fid)) {
+        if (importanceMap.containsKey(fid)) {
           importanceMap.put(fid, importance + importanceMap.get(fid));
-          weightMap.put(fid, 1 + weightMap.get(fid))
+          weightMap.put(fid, 1d + weightMap.get(fid));
         } else {
           importanceMap.put(fid, importance);
-          weightMap.put(fid, 1);
+          weightMap.put(fid, 1d);
         }
       }
     }
     if (importanceType == FeatureImportanceType.COVER
         || importanceType == FeatureImportanceType.GAIN) {
       for (String fid: importanceMap.keySet()) {
-        importanceMap.put(fid, importanceMap.get(fid)/weightMap.get(fid))
+        importanceMap.put(fid, importanceMap.get(fid)/weightMap.get(fid));
       }
     }
     return importanceMap;

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -466,7 +466,7 @@ public class Booster implements Serializable, KryoSerializable {
    * @throws XGBoostError native error
    */
   public Map<String, Double> getScore(
-    String[] featureNames, FeatureImportanceType importanceType
+      String[] featureNames, FeatureImportanceType importanceType
   ) throws XGBoostError {
     String[] modelInfos = getModelDump(featureNames, true);
     return getFeatureImportanceFromModel(modelInfos, importanceType);
@@ -480,7 +480,7 @@ public class Booster implements Serializable, KryoSerializable {
    * @throws XGBoostError native error
    */
   public Map<String, Double> getScore(
-    String featureMap, FeatureImportanceType importanceType
+      String featureMap, FeatureImportanceType importanceType
   ) throws XGBoostError {
     String[] modelInfos = getModelDump(featureMap, true);
     return getFeatureImportanceFromModel(modelInfos, importanceType);
@@ -494,13 +494,13 @@ public class Booster implements Serializable, KryoSerializable {
    * @throws XGBoostError native error
    */
   private Map<String, Double> getFeatureImportanceFromModel(
-    String[] modelInfos, FeatureImportanceType importanceType
+      String[] modelInfos, FeatureImportanceType importanceType
   ) throws XGBoostError {
     Map<String, Double> importanceMap = new HashMap<>();
     Map<String, Double> weightMap = new HashMap<>();
     String splitter = "gain=";
     if (importanceType == FeatureImportanceType.COVER
-      || importanceType == FeatureImportanceType.TOTAL_COVER) {
+        || importanceType == FeatureImportanceType.TOTAL_COVER) {
       splitter = "cover=";
     }
     for (String tree: modelInfos) {
@@ -512,7 +512,7 @@ public class Booster implements Serializable, KryoSerializable {
         String[] fidWithImportance = array[1].split("\\]");
         // Extract gain or cover from string after closing bracket
         Double importance = Double.parseDouble(
-          fidWithImportance[1].split(splitter)[1].split(",")[0]
+            fidWithImportance[1].split(splitter)[1].split(",")[0]
         );
         String fid = fidWithImportance[0].split("<")[0];
         if (importanceMap.contains(fid)) {
@@ -525,7 +525,7 @@ public class Booster implements Serializable, KryoSerializable {
       }
     }
     if (importanceType == FeatureImportanceType.COVER
-      || importanceType == FeatureImportanceType.GAIN) {
+        || importanceType == FeatureImportanceType.GAIN) {
       for (String fid: importanceMap.keySet()) {
         importanceMap.put(fid, importanceMap.get(fid)/weightMap.get(fid))
       }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -405,8 +405,11 @@ public class Booster implements Serializable, KryoSerializable {
    * TOTAL_COVER = Total cover over all splits of a feature
    */
 
-  enum FeatureImportanceType {
-    GAIN, COVER, TOTAL_GAIN, TOTAL_COVER;
+  class FeatureImportanceType {
+    public static final String GAIN = "gain";
+    public static final String COVER = "cover";
+    public static final String TOTAL_GAIN = "total_gain";
+    public static final String TOTAL_COVER = "total_cover";
   }
 
   /**
@@ -466,7 +469,7 @@ public class Booster implements Serializable, KryoSerializable {
    * @throws XGBoostError native error
    */
   public Map<String, Double> getScore(
-      String[] featureNames, FeatureImportanceType importanceType
+      String[] featureNames, String importanceType
   ) throws XGBoostError {
     String[] modelInfos = getModelDump(featureNames, true);
     return getFeatureImportanceFromModel(modelInfos, importanceType);
@@ -480,7 +483,7 @@ public class Booster implements Serializable, KryoSerializable {
    * @throws XGBoostError native error
    */
   public Map<String, Double> getScore(
-      String featureMap, FeatureImportanceType importanceType
+      String featureMap, String importanceType
   ) throws XGBoostError {
     String[] modelInfos = getModelDump(featureMap, true);
     return getFeatureImportanceFromModel(modelInfos, importanceType);
@@ -494,7 +497,7 @@ public class Booster implements Serializable, KryoSerializable {
    * @throws XGBoostError native error
    */
   private Map<String, Double> getFeatureImportanceFromModel(
-      String[] modelInfos, FeatureImportanceType importanceType
+      String[] modelInfos, String importanceType
   ) throws XGBoostError {
     Map<String, Double> importanceMap = new HashMap<>();
     Map<String, Double> weightMap = new HashMap<>();

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -434,7 +434,8 @@ public class Booster implements Serializable, KryoSerializable {
   /**
    * Get the importance of each feature based purely on weights (number of splits)
    *
-   * @return featureScoreMap key: feature index, value: feature importance score based on weight, can be null
+   * @return featureScoreMap key: feature index,
+   * value: feature importance score based on weight, can be null
    * @throws XGBoostError native error
    */
   private Map<String, Integer> getFeatureWeightsFromModel(String[] modelInfos) throws XGBoostError {
@@ -460,10 +461,13 @@ public class Booster implements Serializable, KryoSerializable {
   /**
    * Get the feature importances for gain or cover (average or total)
    *
-   * @return featureImportanceMap key: feature index, values: feature importance score based on gain or cover, can be null
+   * @return featureImportanceMap key: feature index,
+   * values: feature importance score based on gain or cover, can be null
    * @throws XGBoostError native error
    */
-  public Map<String, Double> getScore(String[] featureNames, FeatureImportanceType importanceType) throws XGBoostError {
+  public Map<String, Double> getScore(
+    String[] featureNames, FeatureImportanceType importanceType
+  ) throws XGBoostError {
     String[] modelInfos = getModelDump(featureNames, true);
     return getFeatureImportanceFromModel(modelInfos, importanceType);
   }
@@ -471,10 +475,13 @@ public class Booster implements Serializable, KryoSerializable {
   /**
    * Get the feature importances for gain or cover (average or total), with feature names
    *
-   * @return featureImportanceMap key: feature name, values: feature importance score based on gain or cover, can be null
+   * @return featureImportanceMap key: feature name,
+   * values: feature importance score based on gain or cover, can be null
    * @throws XGBoostError native error
    */
-  public Map<String, Double> getScore(String featureMap, FeatureImportanceType importanceType) throws XGBoostError {
+  public Map<String, Double> getScore(
+    String featureMap, FeatureImportanceType importanceType
+  ) throws XGBoostError {
     String[] modelInfos = getModelDump(featureMap, true);
     return getFeatureImportanceFromModel(modelInfos, importanceType);
   }
@@ -482,14 +489,18 @@ public class Booster implements Serializable, KryoSerializable {
   /**
    * Get the importance of each feature based on information gain or cover
    *
-   * @return featureImportanceMap key: feature index, value: feature importance score based on information gain or cover, can be null
+   * @return featureImportanceMap key: feature index, value: feature importance score
+   * based on information gain or cover, can be null
    * @throws XGBoostError native error
    */
-  private Map<String, Double> getFeatureImportanceFromModel(String[] modelInfos, FeatureImportanceType importanceType) throws XGBoostError {
+  private Map<String, Double> getFeatureImportanceFromModel(
+    String[] modelInfos, FeatureImportanceType importanceType
+  ) throws XGBoostError {
     Map<String, Double> importanceMap = new HashMap<>();
     Map<String, Double> weightMap = new HashMap<>();
     String splitter = "gain=";
-    if (importanceType == FeatureImportanceType.COVER || importanceType == FeatureImportanceType.TOTAL_COVER) {
+    if (importanceType == FeatureImportanceType.COVER
+      || importanceType == FeatureImportanceType.TOTAL_COVER) {
       splitter = "cover=";
     }
     for (String tree: modelInfos) {
@@ -500,7 +511,9 @@ public class Booster implements Serializable, KryoSerializable {
         }
         String[] fidWithImportance = array[1].split("\\]");
         // Extract gain or cover from string after closing bracket
-        Double importance = Double.parseDouble(fidWithImportance[1].split(splitter)[1].split(",")[0]);
+        Double importance = Double.parseDouble(
+          fidWithImportance[1].split(splitter)[1].split(",")[0]
+        );
         String fid = fidWithImportance[0].split("<")[0];
         if (importanceMap.contains(fid)) {
           importanceMap.put(fid, importance + importanceMap.get(fid));
@@ -511,7 +524,8 @@ public class Booster implements Serializable, KryoSerializable {
         }
       }
     }
-    if (importanceType == FeatureImportanceType.COVER || importanceType == FeatureImportanceType.GAIN) {
+    if (importanceType == FeatureImportanceType.COVER
+      || importanceType == FeatureImportanceType.GAIN) {
       for (String fid: importanceMap.keySet()) {
         importanceMap.put(fid, importanceMap.get(fid)/weightMap.get(fid))
       }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -417,7 +417,7 @@ public class Booster implements Serializable, KryoSerializable {
    */
   public Map<String, Integer> getFeatureScore(String[] featureNames) throws XGBoostError {
     String[] modelInfos = getModelDump(featureNames, false);
-    getFeatureWeightsFromModel(modelInfos);
+    return getFeatureWeightsFromModel(modelInfos);
   }
 
   /**
@@ -428,7 +428,7 @@ public class Booster implements Serializable, KryoSerializable {
    */
   public Map<String, Integer> getFeatureScore(String featureMap) throws XGBoostError {
     String[] modelInfos = getModelDump(featureMap, false);
-    getFeatureWeightsFromModel(modelInfos);
+    return getFeatureWeightsFromModel(modelInfos);
   }
 
   /**
@@ -465,7 +465,7 @@ public class Booster implements Serializable, KryoSerializable {
    */
   public Map<String, Double> getScore(String[] featureNames, FeatureImportanceType importanceType) throws XGBoostError {
     String[] modelInfos = getModelDump(featureNames, true);
-    getFeatureImportanceFromModel(modelInfos, importanceType);
+    return getFeatureImportanceFromModel(modelInfos, importanceType);
   }
 
   /**
@@ -476,7 +476,7 @@ public class Booster implements Serializable, KryoSerializable {
    */
   public Map<String, Double> getScore(String featureMap, FeatureImportanceType importanceType) throws XGBoostError {
     String[] modelInfos = getModelDump(featureMap, true);
-    getFeatureImportanceFromModel(modelInfos, importanceType);
+    return getFeatureImportanceFromModel(modelInfos, importanceType);
   }
 
   /**

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -16,9 +16,12 @@
 package ml.dmlc.xgboost4j.java;
 
 import java.io.*;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
@@ -410,6 +413,8 @@ public class Booster implements Serializable, KryoSerializable {
     public static final String COVER = "cover";
     public static final String TOTAL_GAIN = "total_gain";
     public static final String TOTAL_COVER = "total_cover";
+    public static final Set<String> ACCEPTED_TYPES = new HashSet<>(
+            Arrays.asList(WEIGHT, GAIN, COVER, TOTAL_GAIN, TOTAL_COVER));
   }
 
   /**
@@ -496,11 +501,7 @@ public class Booster implements Serializable, KryoSerializable {
    */
   private Map<String, Double> getFeatureImportanceFromModel(
           String[] modelInfos, String importanceType) throws XGBoostError {
-    if (importanceType != FeatureImportanceType.WEIGHT &&
-            importanceType != FeatureImportanceType.COVER &&
-            importanceType != FeatureImportanceType.TOTAL_COVER &&
-            importanceType != FeatureImportanceType.GAIN &&
-            importanceType != FeatureImportanceType.TOTAL_GAIN) {
+    if (!FeatureImportanceType.ACCEPTED_TYPES.contains(importanceType)) {
       throw new AssertionError(String.format("Importance type %s is not supported",
               importanceType));
     }
@@ -513,6 +514,9 @@ public class Booster implements Serializable, KryoSerializable {
       }
       return importanceMap;
     }
+    /* Each split in the tree has this text form:
+    "0:[f28<-9.53674316e-07] yes=1,no=2,missing=1,gain=4000.53101,cover=1628.25"
+    So the line has to be split according to whether cover or gain is desired */
     String splitter = "gain=";
     if (importanceType == FeatureImportanceType.COVER
         || importanceType == FeatureImportanceType.TOTAL_COVER) {
@@ -539,6 +543,8 @@ public class Booster implements Serializable, KryoSerializable {
         }
       }
     }
+    /* By default we calculate total gain and total cover.
+    Divide by the number of nodes per feature to get gain / cover */
     if (importanceType == FeatureImportanceType.COVER
         || importanceType == FeatureImportanceType.GAIN) {
       for (String fid: importanceMap.keySet()) {

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
@@ -233,7 +233,7 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
   @throws(classOf[XGBoostError])
   def getScore(featureMap: String = null,
                importanceType: String = FeatureImportanceType.GAIN
-              ): mutable.Map[String, Integer] = {
+              ): mutable.Map[String, Double] = {
     booster.getScore(featureMap, importanceType).asScala
   }
 
@@ -246,7 +246,7 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
   @throws(classOf[XGBoostError])
   def getScore(featureNames: Array[String],
                importanceType: String = FeatureImportanceType.GAIN
-              ): mutable.Map[String, Integer] = {
+              ): mutable.Map[String, Double] = {
     booster.getScore(featureNames, importanceType).asScala
   }
 

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
@@ -231,9 +231,7 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
     * @return featureScoreMap  key: feature index, value: feature importance score
     */
   @throws(classOf[XGBoostError])
-  def getScore(featureMap: String,
-               importanceType: String
-              ): Map[String, Double] = {
+  def getScore(featureMap: String, importanceType: String): Map[String, Double] = {
     Map(booster.getScore(featureMap, importanceType)
         .asScala.mapValues(_.doubleValue).toSeq: _*)
   }
@@ -246,9 +244,7 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
     * @return featureScoreMap  key: feature name, value: feature importance score
     */
   @throws(classOf[XGBoostError])
-  def getScore(featureNames: Array[String],
-               importanceType: String
-              ): Map[String, Double] = {
+  def getScore(featureNames: Array[String], importanceType: String): Map[String, Double] = {
     Map(booster.getScore(featureNames, importanceType)
         .asScala.mapValues(_.doubleValue).toSeq: _*)
   }

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
@@ -19,7 +19,6 @@ package ml.dmlc.xgboost4j.scala
 import com.esotericsoftware.kryo.io.{Output, Input}
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 import ml.dmlc.xgboost4j.java.{Booster => JBooster}
-import ml.dmlc.xgboost4j.java.Booster.FeatureImportanceType
 import ml.dmlc.xgboost4j.java.XGBoostError
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -227,27 +226,33 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
 
   /**
     * Get importance of each feature based on information gain or cover
+    * Supported: ["gain, "cover", "total_gain", "total_cover"]
     *
     * @return featureScoreMap  key: feature index, value: feature importance score
     */
   @throws(classOf[XGBoostError])
-  def getScore(featureMap: String = null,
-               importanceType: String = FeatureImportanceType.GAIN
+  def getScore(featureMap: String,
+               importanceType: String
               ): mutable.Map[String, Double] = {
-    booster.getScore(featureMap, importanceType).asScala
+    mutable.Map(
+      booster.getScore(featureMap, importanceType)
+        .asScala.mapValues(_.doubleValue).toSeq: _*)
   }
 
   /**
     * Get importance of each feature based on information gain or cover
     * , with specified feature names.
+    * Supported: ["gain, "cover", "total_gain", "total_cover"]
     *
     * @return featureScoreMap  key: feature name, value: feature importance score
     */
   @throws(classOf[XGBoostError])
   def getScore(featureNames: Array[String],
-               importanceType: String = FeatureImportanceType.GAIN
+               importanceType: String
               ): mutable.Map[String, Double] = {
-    booster.getScore(featureNames, importanceType).asScala
+    mutable.Map(
+      booster.getScore(featureNames, importanceType)
+        .asScala.mapValues(_.doubleValue).toSeq: _*)
   }
 
   def getVersion: Int = booster.getVersion

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
@@ -19,6 +19,7 @@ package ml.dmlc.xgboost4j.scala
 import com.esotericsoftware.kryo.io.{Output, Input}
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 import ml.dmlc.xgboost4j.java.{Booster => JBooster}
+import ml.dmlc.xgboost4j.java.Booster.FeatureImportanceType
 import ml.dmlc.xgboost4j.java.XGBoostError
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -204,7 +205,7 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
 
 
   /**
-   * Get importance of each feature
+   * Get importance of each feature based on weight only (number of splits)
    *
    * @return featureScoreMap  key: feature index, value: feature importance score
    */
@@ -214,13 +215,33 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
   }
 
   /**
-    * Get importance of each feature with specified feature names.
+    * Get importance of each feature based on weight only (number of splits), with specified feature names.
     *
     * @return featureScoreMap  key: feature name, value: feature importance score
     */
   @throws(classOf[XGBoostError])
   def getFeatureScore(featureNames: Array[String]): mutable.Map[String, Integer] = {
     booster.getFeatureScore(featureNames).asScala
+  }
+
+  /**
+    * Get importance of each feature based on information gain or cover
+    *
+    * @return featureScoreMap  key: feature index, value: feature importance score
+    */
+  @throws(classOf[XGBoostError])
+  def getScore(featureMap: String = null, importanceType: FeatureImportanceType = FeatureImportanceType.GAIN): mutable.Map[String, Integer] = {
+    booster.getScore(featureMap, importanceType).asScala
+  }
+
+  /**
+    * Get importance of each feature based on information gain or cover, with specified feature names.
+    *
+    * @return featureScoreMap  key: feature name, value: feature importance score
+    */
+  @throws(classOf[XGBoostError])
+  def getScore(featureNames: Array[String], importanceType: FeatureImportanceType = FeatureImportanceType.GAIN): mutable.Map[String, Integer] = {
+    booster.getScore(featureNames, importanceType).asScala
   }
 
   def getVersion: Int = booster.getVersion

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
@@ -233,9 +233,8 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
   @throws(classOf[XGBoostError])
   def getScore(featureMap: String,
                importanceType: String
-              ): mutable.Map[String, Double] = {
-    mutable.Map(
-      booster.getScore(featureMap, importanceType)
+              ): Map[String, Double] = {
+    Map(booster.getScore(featureMap, importanceType)
         .asScala.mapValues(_.doubleValue).toSeq: _*)
   }
 
@@ -249,9 +248,8 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
   @throws(classOf[XGBoostError])
   def getScore(featureNames: Array[String],
                importanceType: String
-              ): mutable.Map[String, Double] = {
-    mutable.Map(
-      booster.getScore(featureNames, importanceType)
+              ): Map[String, Double] = {
+    Map(booster.getScore(featureNames, importanceType)
         .asScala.mapValues(_.doubleValue).toSeq: _*)
   }
 

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
@@ -215,7 +215,8 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
   }
 
   /**
-    * Get importance of each feature based on weight only (number of splits), with specified feature names.
+    * Get importance of each feature based on weight only
+    * (number of splits), with specified feature names.
     *
     * @return featureScoreMap  key: feature name, value: feature importance score
     */
@@ -230,17 +231,22 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
     * @return featureScoreMap  key: feature index, value: feature importance score
     */
   @throws(classOf[XGBoostError])
-  def getScore(featureMap: String = null, importanceType: FeatureImportanceType = FeatureImportanceType.GAIN): mutable.Map[String, Integer] = {
+  def getScore(featureMap: String = null,
+               importanceType: FeatureImportanceType = FeatureImportanceType.GAIN
+              ): mutable.Map[String, Integer] = {
     booster.getScore(featureMap, importanceType).asScala
   }
 
   /**
-    * Get importance of each feature based on information gain or cover, with specified feature names.
+    * Get importance of each feature based on information gain or cover
+    * , with specified feature names.
     *
     * @return featureScoreMap  key: feature name, value: feature importance score
     */
   @throws(classOf[XGBoostError])
-  def getScore(featureNames: Array[String], importanceType: FeatureImportanceType = FeatureImportanceType.GAIN): mutable.Map[String, Integer] = {
+  def getScore(featureNames: Array[String],
+               importanceType: FeatureImportanceType = FeatureImportanceType.GAIN
+              ): mutable.Map[String, Integer] = {
     booster.getScore(featureNames, importanceType).asScala
   }
 

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/Booster.scala
@@ -232,7 +232,7 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
     */
   @throws(classOf[XGBoostError])
   def getScore(featureMap: String = null,
-               importanceType: FeatureImportanceType = FeatureImportanceType.GAIN
+               importanceType: String = FeatureImportanceType.GAIN
               ): mutable.Map[String, Integer] = {
     booster.getScore(featureMap, importanceType).asScala
   }
@@ -245,7 +245,7 @@ class Booster private[xgboost4j](private[xgboost4j] var booster: JBooster)
     */
   @throws(classOf[XGBoostError])
   def getScore(featureNames: Array[String],
-               importanceType: FeatureImportanceType = FeatureImportanceType.GAIN
+               importanceType: String = FeatureImportanceType.GAIN
               ): mutable.Map[String, Integer] = {
     booster.getScore(featureNames, importanceType).asScala
   }

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
@@ -292,7 +292,7 @@ public class BoosterImplTest {
   }
 
   @Test
-  public void testGetFeatureImportance() throws XGBoostError {
+  public void testGetFeatureImportanceGain() throws XGBoostError {
     DMatrix trainMat = new DMatrix("../../demo/data/agaricus.txt.train");
     DMatrix testMat = new DMatrix("../../demo/data/agaricus.txt.test");
 
@@ -300,6 +300,42 @@ public class BoosterImplTest {
     String[] featureNames = new String[126];
     for(int i = 0; i < 126; i++) featureNames[i] = "test_feature_name_" + i;
     Map<String, Double> scoreMap = booster.getScore(featureNames, "gain");
+    for (String fName: scoreMap.keySet()) TestCase.assertTrue(fName.startsWith("test_feature_name_"));
+  }
+
+  @Test
+  public void testGetFeatureImportanceTotalGain() throws XGBoostError {
+    DMatrix trainMat = new DMatrix("../../demo/data/agaricus.txt.train");
+    DMatrix testMat = new DMatrix("../../demo/data/agaricus.txt.test");
+
+    Booster booster = trainBooster(trainMat, testMat);
+    String[] featureNames = new String[126];
+    for(int i = 0; i < 126; i++) featureNames[i] = "test_feature_name_" + i;
+    Map<String, Double> scoreMap = booster.getScore(featureNames, "total_gain");
+    for (String fName: scoreMap.keySet()) TestCase.assertTrue(fName.startsWith("test_feature_name_"));
+  }
+
+  @Test
+  public void testGetFeatureImportanceCover() throws XGBoostError {
+    DMatrix trainMat = new DMatrix("../../demo/data/agaricus.txt.train");
+    DMatrix testMat = new DMatrix("../../demo/data/agaricus.txt.test");
+
+    Booster booster = trainBooster(trainMat, testMat);
+    String[] featureNames = new String[126];
+    for(int i = 0; i < 126; i++) featureNames[i] = "test_feature_name_" + i;
+    Map<String, Double> scoreMap = booster.getScore(featureNames, "cover");
+    for (String fName: scoreMap.keySet()) TestCase.assertTrue(fName.startsWith("test_feature_name_"));
+  }
+
+  @Test
+  public void testGetFeatureImportanceTotalCover() throws XGBoostError {
+    DMatrix trainMat = new DMatrix("../../demo/data/agaricus.txt.train");
+    DMatrix testMat = new DMatrix("../../demo/data/agaricus.txt.test");
+
+    Booster booster = trainBooster(trainMat, testMat);
+    String[] featureNames = new String[126];
+    for(int i = 0; i < 126; i++) featureNames[i] = "test_feature_name_" + i;
+    Map<String, Double> scoreMap = booster.getScore(featureNames, "total_cover");
     for (String fName: scoreMap.keySet()) TestCase.assertTrue(fName.startsWith("test_feature_name_"));
   }
 

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
@@ -280,7 +280,7 @@ public class BoosterImplTest {
   }
 
   @Test
-  public void testGetFeatureImportance() throws XGBoostError {
+  public void testGetFeatureScore() throws XGBoostError {
     DMatrix trainMat = new DMatrix("../../demo/data/agaricus.txt.train");
     DMatrix testMat = new DMatrix("../../demo/data/agaricus.txt.test");
 
@@ -288,6 +288,18 @@ public class BoosterImplTest {
     String[] featureNames = new String[126];
     for(int i = 0; i < 126; i++) featureNames[i] = "test_feature_name_" + i;
     Map<String, Integer> scoreMap = booster.getFeatureScore(featureNames);
+    for (String fName: scoreMap.keySet()) TestCase.assertTrue(fName.startsWith("test_feature_name_"));
+  }
+
+  @Test
+  public void testGetFeatureImportance() throws XGBoostError {
+    DMatrix trainMat = new DMatrix("../../demo/data/agaricus.txt.train");
+    DMatrix testMat = new DMatrix("../../demo/data/agaricus.txt.test");
+
+    Booster booster = trainBooster(trainMat, testMat);
+    String[] featureNames = new String[126];
+    for(int i = 0; i < 126; i++) featureNames[i] = "test_feature_name_" + i;
+    Map<String, Double> scoreMap = booster.getScore(featureNames, "gain");
     for (String fName: scoreMap.keySet()) TestCase.assertTrue(fName.startsWith("test_feature_name_"));
   }
 


### PR DESCRIPTION
The [Python API](https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.Booster.get_score) currently supports obtaining feature importances for the following types:
- Weights
- Cover (Total and Average)
- Gain (Total and Average)
The Java Booster API only supports the first (weights-based), which finds the feature importances based on the number of nodes that the feature was used to split on.
This PR adds in the other two feature importance measures (gain and cover) mimicking the Python API and making it consistent across the board
