### PR TITLE
Fix Python environment for distributed unit tests

### DIFF
--- a/tests/distributed/runtests.sh
+++ b/tests/distributed/runtests.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 echo "====== 1. Basic distributed test with Python ======"
-PYTHONPATH=../../python-package/ ../../dmlc-core/tracker/dmlc-submit  --cluster=local --num-workers=3\
+PYTHONPATH=../../python-package/ python ../../dmlc-core/tracker/dmlc-submit  --cluster=local --num-workers=3\
   python test_basic.py
 
 echo "====== 2. Regression test for issue #3402 ======"
-PYTHONPATH=../../python-package/ ../../dmlc-core/tracker/dmlc-submit  --cluster=local --num-workers=2 --worker-cores=1\
+PYTHONPATH=../../python-package/ python ../../dmlc-core/tracker/dmlc-submit  --cluster=local --num-workers=2 --worker-cores=1\
   python test_issue3402.py

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -147,6 +147,11 @@ fi
 if [ ${TASK} == "distributed_test" ]; then
     set -e
     make all || exit -1
+    echo "-------------------------------"
+    source activate python3
+    python --version
+    conda install numpy scipy
+    python -m pip install kubernetes
     cd tests/distributed
     ./runtests.sh
 fi

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -10,8 +10,7 @@ if [ ${TASK} == "lint" ]; then
 fi
 
 
-if [ ${TASK} == "python_test" ] || [ ${TASK} == "python_lightweight_test" ]; then
-    # python2
+if [ ${TASK} == "python_test" ] || [ ${TASK} == "python_lightweight_test" ] || [ ${TASK} ==  "distributed_test" ]; then
     if [ ${TRAVIS_OS_NAME} == "osx" ]; then
         wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
     else
@@ -26,8 +25,4 @@ if [ ${TASK} == "python_test" ] || [ ${TASK} == "python_lightweight_test" ]; the
     conda info -a
     conda create -n python3 python=3.5
     conda create -n python2 python=2.7
-fi
-
-if [ ${TASK} == "distributed_test" ]; then
-    pip install --user kubernetes numpy scipy
 fi


### PR DESCRIPTION
Currently, dmlc tracker is failing for `distributed_test` unit tests, due to Python 2.x incompatibility. As a workaround, use Miniconda + Python 3.