### PR TITLE
[Blocking] [jvm-packages] Upgrade Scala to 2.11.12 to address CVE-2017-15288

### DIFF
--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <flink.version>1.5.0</flink.version>
         <spark.version>2.3.1</spark.version>
-        <scala.version>2.11.8</scala.version>
+        <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
     </properties>
     <repositories>


### PR DESCRIPTION
A privilege escalation vulnerability (CVE-2017-15288) has been identified in the Scala compilation daemon. See https://nvd.nist.gov/vuln/detail/CVE-2017-15288.

Fix: Upgrade Scala to 2.11.12.