### PR TITLE
Enable auto-locking of issues closed long ago

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,34 @@
+# Configuration for lock-threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 90
+
+# Issues and pull requests with these labels will not be locked. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+
+# Repository to extend settings from
+# _extends: repo


### PR DESCRIPTION
Issues that were closed more than 90 days ago will be locked automatically so that no additional comments would be allowed. We will use a bot to do this: https://probot.github.io/apps/lock/

Background: As a maintainer, I often see people leaving comments to old issue posts that were closed long ago. Those comments are hard to discover and assist with, since they get buried under list of other active issues.

With the change, users who want to follow up with an old issue would be asked to file a new issue.

Visit https://github.com/dmlc/xgboost/issues?utf8=%E2%9C%93&q=is%3Aclosed+updated%3A%3C2018-07-25 to see the list of issues that would be locked under the proposed setting.