### PR TITLE
Recommend pickling as the way to save XGBClassifier / XGBRegressor / XGBRanker

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -241,6 +241,13 @@ class XGBModel(XGBModelBase):
         """
         Save the model to a file.
 
+        The model is saved in an XGBoost internal binary format which is
+        universal among the various XGBoost interfaces. Auxiliary attributes of
+        the Python Booster object (such as feature names) will not be loaded.
+        Label encodings (text labels to numeric labels) will be also lost.
+        **If you are using only the Python interface, we recommend pickling the
+        model object for best results.**
+
         Parameters
         ----------
         fname : string
@@ -251,6 +258,13 @@ class XGBModel(XGBModelBase):
     def load_model(self, fname):
         """
         Load the model from a file.
+
+        The model is loaded from an XGBoost internal binary format which is
+        universal among the various XGBoost interfaces. Auxiliary attributes of
+        the Python Booster object (such as feature names) will not be loaded.
+        Label encodings (text labels to numeric labels) will be also lost.
+        **If you are using only the Python interface, we recommend pickling the
+        model object for best results.**
 
         Parameters
         ----------


### PR DESCRIPTION
The `save_model()` and `load_model()` method only saves the part of the model that's common to all language interfaces and do not preserve Python-specific attributes, such as `feature_names`. More crucially, label encoder is not preserved either; this is needed for the scikit-learn wrapper, since you may have string labels.

Fix: Explicitly recommend pickling as the way to save scikit-learn model objects.

Related issue: #3828