### PR TITLE
merge latest rabit module

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,3 +85,4 @@ List of Contributors
 * [Andrew Thia](https://github.com/BlueTea88)
   - Andrew Thia implemented feature interaction constraints
 * [Wei Tian](https://github.com/weitian)
+* [Chen Qin] (https://github.com/chenqin)


### PR DESCRIPTION
cleanup and apply fix to address OSX test failure on
https://github.com/dmlc/xgboost/pull/3818
