### PR TITLE
Update Jenkins CI to accommodate CUDA 10.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,11 @@ def buildPlatformCmake(buildName, conf, nodeReq, dockerTarget) {
                 # Test the wheel for compatibility on a barebones CPU container
                 ${dockerRun} release ${dockerArgs} bash -c " \
                     pip install --user python-package/dist/xgboost-*-none-any.whl && \
-                    python -m nose tests/python"
+                    python -m nose -v tests/python"
+                # Test the wheel for compatibility on CUDA 10.0 container
+                ${dockerRun} gpu --build-arg CUDA_VERSION=10.0 bash -c " \
+                    pip install --user python-package/dist/xgboost-*-none-any.whl && \
+                    python -m nose -v --eval-attr='(not slow) and (not mgpu)' tests/python-gpu"
                 """
             }
         }

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -21,13 +21,14 @@ RUN \
 
 # NCCL2 (License: https://docs.nvidia.com/deeplearning/sdk/nccl-sla/index.html)
 RUN \
-    export CUDA_SHORT=`echo $CUDA_VERSION | egrep -o '[0-9]\.[0-9]'` && \
+    export CUDA_SHORT=`echo $CUDA_VERSION | egrep -o '[0-9]+\.[0-9]'` && \
+    if [ "${CUDA_SHORT}" != "10.0" ]; then \
     wget https://developer.download.nvidia.com/compute/redist/nccl/v2.2/nccl_2.2.13-1%2Bcuda${CUDA_SHORT}_x86_64.txz && \
     tar xf "nccl_2.2.13-1+cuda${CUDA_SHORT}_x86_64.txz" && \
     cp nccl_2.2.13-1+cuda${CUDA_SHORT}_x86_64/include/nccl.h /usr/include && \
     cp nccl_2.2.13-1+cuda${CUDA_SHORT}_x86_64/lib/* /usr/lib && \
     rm -f nccl_2.2.13-1+cuda${CUDA_SHORT}_x86_64.txz && \
-    rm -r nccl_2.2.13-1+cuda${CUDA_SHORT}_x86_64
+    rm -r nccl_2.2.13-1+cuda${CUDA_SHORT}_x86_64; fi
 
 ENV PATH=/opt/python/bin:$PATH
 ENV CC=/opt/rh/devtoolset-2/root/usr/bin/gcc


### PR DESCRIPTION
CUDA 10.0 was released on September 19, 2018. To ensure that XGBoost works with the latest CUDA, add CUDA 10.0 to the Jenkins CI server (https://xgboost-ci.net).