### PR TITLE
Allow XGBRanker sklearn interface to use other xgboost ranking objectives

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -921,7 +921,7 @@ class XGBRanker(XGBModel):
                                         base_score, random_state, seed, missing)
         if callable(self.objective):
             raise ValueError("custom objective function not supported by XGBRanker")
-        elif self.objective != "rank:pairwise":
+        elif "rank:" not in self.objective:
             raise ValueError("please use XGBRanker for ranking task")
 
     def fit(self, X, y, group, sample_weight=None, eval_set=None, sample_weight_eval_set=None,


### PR DESCRIPTION
```
clf = xgb.XGBRanker(objective="rank:map")
```
The above code returns "please use XGBRanker for ranking task", despite passing a valid ranking objective.

This PR allows any objective function with the substring "rank:" instead of just "rank:pairwise".