### PR TITLE
[Blocking] Fix #3840: Clean up logic for parsing tree_method parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,8 @@ Rpack: clean_all
 	cp -r src xgboost/src/src
 	cp -r include xgboost/src/include
 	cp -r amalgamation xgboost/src/amalgamation
+	mkdir -p xgboost/src/tests/cpp
+	cp tests/cpp/test_learner.h xgboost/src/tests/cpp
 	mkdir -p xgboost/src/rabit
 	cp -r rabit/include xgboost/src/rabit/include
 	cp -r rabit/src xgboost/src/rabit/src

--- a/src/common/enum_class_param.h
+++ b/src/common/enum_class_param.h
@@ -71,12 +71,11 @@ class FieldEntry<EnumClass> : public FieldEntry<int> {  \
     has_default_ = true;  \
     return *this;  \
   }  \
-  /* NOLINTNEXTLINE */  \
   inline void Init(const std::string &key, void *head, EnumClass& ref) {  \
     Super::Init(key, head, *reinterpret_cast<int*>(&ref));  \
   }  \
 };  \
 }  /* namespace parameter */  \
-}  /* namespace dmlc */
+}  /* namespace dmlc */  // NOLINT
 
 #endif  // XGBOOST_COMMON_ENUM_CLASS_PARAM_H_

--- a/src/common/enum_class_param.h
+++ b/src/common/enum_class_param.h
@@ -19,7 +19,7 @@
  *
  * Usage:
  *
- * \code
+ * \code{.cpp}
  *
  *   // enum class must inherit from int type
  *   enum class Foo : int {
@@ -44,7 +44,7 @@
  *   };
  *
  *   DMLC_REGISTER_PARAMETER(MyParam);
- *
+ * \endcode
  */
 #define DECLARE_FIELD_ENUM_CLASS(EnumClass) \
 namespace dmlc {  \

--- a/src/common/enum_class_param.h
+++ b/src/common/enum_class_param.h
@@ -1,0 +1,45 @@
+/*!
+ * Copyright 2015-2018 by Contributors
+ * \file enum_class_param.h
+ * \brief macro for using C++11 enum class as DMLC parameter
+ * \author Hyunsu Philip Cho
+ */
+
+#ifndef XGBOOST_COMMON_ENUM_CLASS_PARAM_H_
+#define XGBOOST_COMMON_ENUM_CLASS_PARAM_H_
+
+#include <dmlc/parameter.h>
+#include <string>
+#include <type_traits>
+
+// specialization of FieldEntry for enum class (backed by int)
+#define DECLARE_FIELD_ENUM_CLASS(EnumClass) \
+template <>  \
+class dmlc::parameter::FieldEntry< EnumClass >  \
+  : public dmlc::parameter::FieldEntry<int> {  \
+ public:  \
+  FieldEntry<EnumClass>() {  \
+    static_assert(  \
+      std::is_same<int, typename std::underlying_type<EnumClass>::type>::value,  \
+      "enum class must be backed by int");  \
+    is_enum_ = true;  \
+  }  \
+  typedef FieldEntry<int> Super;  \
+  void Set(void *head, const std::string &value) const override {  \
+    Super::Set(head, value);  \
+  }  \
+  inline FieldEntry<EnumClass>& add_enum(const std::string &key, EnumClass value) {  \
+    Super::add_enum(key, static_cast<int>(value));  \
+    return *this;  \
+  }  \
+  inline FieldEntry<EnumClass>& set_default(const EnumClass& default_value) {  \
+    default_value_ = static_cast<int>(default_value);  \
+    has_default_ = true;  \
+    return *this;  \
+  }  \
+  inline void Init(const std::string &key, void *head, EnumClass& ref) {  \
+    Super::Init(key, head, *reinterpret_cast<int*>(&ref));  \
+  }  \
+};
+
+#endif  // XGBOOST_COMMON_ENUM_CLASS_PARAM_H_

--- a/src/common/enum_class_param.h
+++ b/src/common/enum_class_param.h
@@ -71,11 +71,11 @@ class FieldEntry<EnumClass> : public FieldEntry<int> {  \
     has_default_ = true;  \
     return *this;  \
   }  \
-  inline void Init(const std::string &key, void *head, EnumClass& ref) {  \
+  inline void Init(const std::string &key, void *head, EnumClass& ref) {  /* NOLINT */  \
     Super::Init(key, head, *reinterpret_cast<int*>(&ref));  \
   }  \
 };  \
 }  /* namespace parameter */  \
-}  /* namespace dmlc */  // NOLINT
+}  /* namespace dmlc */
 
 #endif  // XGBOOST_COMMON_ENUM_CLASS_PARAM_H_

--- a/src/common/enum_class_param.h
+++ b/src/common/enum_class_param.h
@@ -14,9 +14,10 @@
 
 // specialization of FieldEntry for enum class (backed by int)
 #define DECLARE_FIELD_ENUM_CLASS(EnumClass) \
+namespace dmlc {  \
+namespace parameter {  \
 template <>  \
-class dmlc::parameter::FieldEntry< EnumClass >  \
-  : public dmlc::parameter::FieldEntry<int> {  \
+class FieldEntry<EnumClass> : public FieldEntry<int> {  \
  public:  \
   FieldEntry<EnumClass>() {  \
     static_assert(  \
@@ -24,7 +25,7 @@ class dmlc::parameter::FieldEntry< EnumClass >  \
       "enum class must be backed by int");  \
     is_enum_ = true;  \
   }  \
-  typedef FieldEntry<int> Super;  \
+  using Super = FieldEntry<int>;  \
   void Set(void *head, const std::string &value) const override {  \
     Super::Set(head, value);  \
   }  \
@@ -37,9 +38,12 @@ class dmlc::parameter::FieldEntry< EnumClass >  \
     has_default_ = true;  \
     return *this;  \
   }  \
+  /* NOLINTNEXTLINE */  \
   inline void Init(const std::string &key, void *head, EnumClass& ref) {  \
     Super::Init(key, head, *reinterpret_cast<int*>(&ref));  \
   }  \
-};
+};  \
+}  /* namespace parameter */  \
+}  /* namespace dmlc */
 
 #endif  // XGBOOST_COMMON_ENUM_CLASS_PARAM_H_

--- a/src/common/enum_class_param.h
+++ b/src/common/enum_class_param.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2015-2018 by Contributors
+ * Copyright 2018 by Contributors
  * \file enum_class_param.h
  * \brief macro for using C++11 enum class as DMLC parameter
  * \author Hyunsu Philip Cho
@@ -12,7 +12,40 @@
 #include <string>
 #include <type_traits>
 
-// specialization of FieldEntry for enum class (backed by int)
+/*!
+ * \brief Specialization of FieldEntry for enum class (backed by int)
+ *
+ * Use this macro to use C++11 enum class as DMLC parameters
+ *
+ * Usage:
+ *
+ * \code
+ *
+ *   // enum class must inherit from int type
+ *   enum class Foo : int {
+ *     kBar = 0, kFrog = 1, kCat = 2, kDog = 3
+ *   };
+ *
+ *   // This line is needed to prevent compilation error
+ *   DECLARE_FIELD_ENUM_CLASS(Foo);
+ *
+ *   // Now define DMLC parameter as usual;
+ *   //   enum classes can now be members.
+ *   struct MyParam : dmlc::Parameter<MyParam> {
+ *     Foo foo;
+ *     DMLC_DECLARE_PARAMETER(MyParam) {
+ *       DMLC_DECLARE_FIELD(foo)
+ *         .set_default(Foo::kBar)
+ *         .add_enum("bar", Foo::kBar)
+ *         .add_enum("frog", Foo::kFrog)
+ *         .add_enum("cat", Foo::kCat)
+ *         .add_enum("dog", Foo::kDog);
+ *     }
+ *   };
+ *
+ *   DMLC_REGISTER_PARAMETER(MyParam);
+ *
+ */
 #define DECLARE_FIELD_ENUM_CLASS(EnumClass) \
 namespace dmlc {  \
 namespace parameter {  \

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -666,7 +666,7 @@ class LearnerImpl : public Learner, public LearnerTestHook {
   common::Monitor monitor_;
 
   // diagnostic method reserved for C++ test learner.SelectTreeMethod
-  std::string GetUpdaterSequence(void) const override {
+  std::string GetUpdaterSequence() const override {
     return cfg_.at("updater");
   }
 };

--- a/tests/cpp/common/test_enum_class_param.cc
+++ b/tests/cpp/common/test_enum_class_param.cc
@@ -1,0 +1,55 @@
+#include "../../../src/common/enum_class_param.h"
+#include <dmlc/parameter.h>
+#include <gtest/gtest.h>
+
+enum class Foo : int {
+  kBar = 0, kFrog = 1, kCat = 2, kDog = 3
+};
+
+DECLARE_FIELD_ENUM_CLASS(Foo);
+
+struct MyParam : dmlc::Parameter<MyParam> {
+  Foo foo;
+  int bar;
+  DMLC_DECLARE_PARAMETER(MyParam) {
+    DMLC_DECLARE_FIELD(foo)
+      .set_default(Foo::kBar)
+      .add_enum("bar", Foo::kBar)
+      .add_enum("frog", Foo::kFrog)
+      .add_enum("cat", Foo::kCat)
+      .add_enum("dog", Foo::kDog);
+    DMLC_DECLARE_FIELD(bar)
+      .set_default(-1);
+  }
+};
+
+DMLC_REGISTER_PARAMETER(MyParam);
+
+TEST(EnumClassParam, Basic) {
+  MyParam param;
+  std::map<std::string, std::string> kwargs{
+    {"foo", "frog"}, {"bar", "10"}
+  };
+  // try initializing
+  param.Init(kwargs);
+  ASSERT_EQ(param.foo, Foo::kFrog);
+  ASSERT_EQ(param.bar, 10);
+
+  // try all possible enum values
+  kwargs["foo"] = "bar";
+  param.Init(kwargs);
+  ASSERT_EQ(param.foo, Foo::kBar);
+  kwargs["foo"] = "frog";
+  param.Init(kwargs);
+  ASSERT_EQ(param.foo, Foo::kFrog);
+  kwargs["foo"] = "cat";
+  param.Init(kwargs);
+  ASSERT_EQ(param.foo, Foo::kCat);
+  kwargs["foo"] = "dog";
+  param.Init(kwargs);
+  ASSERT_EQ(param.foo, Foo::kDog);
+
+  // try setting non-existent enum value
+  kwargs["foo"] = "human";
+  ASSERT_THROW(param.Init(kwargs), dmlc::ParamError);
+}

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -2,9 +2,20 @@
 #include <gtest/gtest.h>
 #include <vector>
 #include "helpers.h"
+#include "./test_learner.h"
 #include "xgboost/learner.h"
 
 namespace xgboost {
+
+class LearnerTestHookAdapter {
+ public:
+  static inline std::string GetUpdaterSequence(const Learner* learner) {
+    const LearnerTestHook* hook = dynamic_cast<const LearnerTestHook*>(learner);
+    CHECK(hook) << "LearnerImpl did not inherit from LearnerTestHook";
+    return hook->GetUpdaterSequence();
+  }
+};
+
 TEST(learner, Test) {
   typedef std::pair<std::string, std::string> arg;
   auto args = {arg("tree_method", "exact")};
@@ -15,4 +26,33 @@ TEST(learner, Test) {
 
   delete mat_ptr;
 }
+
+TEST(learner, SelectTreeMethod) {
+  using arg = std::pair<std::string, std::string>;
+  auto mat_ptr = CreateDMatrix(10, 10, 0);
+  std::vector<std::shared_ptr<xgboost::DMatrix>> mat = {*mat_ptr};
+  auto learner = std::unique_ptr<Learner>(Learner::Create(mat));
+
+  // Test if `tree_method` can be set
+  learner->Configure({arg("tree_method", "approx")});
+  ASSERT_EQ(LearnerTestHookAdapter::GetUpdaterSequence(learner.get()),
+            "grow_histmaker,prune");
+  learner->Configure({arg("tree_method", "exact")});
+  ASSERT_EQ(LearnerTestHookAdapter::GetUpdaterSequence(learner.get()),
+            "grow_colmaker,prune");
+  learner->Configure({arg("tree_method", "hist")});
+  ASSERT_EQ(LearnerTestHookAdapter::GetUpdaterSequence(learner.get()),
+            "grow_fast_histmaker");
+#ifdef XGBOOST_USE_CUDA
+  learner->Configure({arg("tree_method", "gpu_exact")});
+  ASSERT_EQ(LearnerTestHookAdapter::GetUpdaterSequence(learner.get()),
+            "grow_gpu,prune");
+  learner->Configure({arg("tree_method", "gpu_hist")});
+  ASSERT_EQ(LearnerTestHookAdapter::GetUpdaterSequence(learner.get()),
+            "grow_gpu_hist");
+#endif
+
+  delete mat_ptr;
+}
+
 }  // namespace xgboost

--- a/tests/cpp/test_learner.h
+++ b/tests/cpp/test_learner.h
@@ -1,7 +1,7 @@
 /*!
  * Copyright 2018 by Contributors
  * \file test_learner.h
- * \brief Interface
+ * \brief Hook to access implementation class of Learner
  * \author Hyunsu Philip Cho
  */
 
@@ -14,7 +14,7 @@ namespace xgboost {
 class LearnerTestHook {
  private:
   virtual std::string GetUpdaterSequence(void) const = 0;
-  // allow friend access to C++ test learner.SelectTreeMethod
+  // allow friend access to C++ tests for Learner
   friend class LearnerTestHookAdapter;
 };
 }  // namespace xgboost

--- a/tests/cpp/test_learner.h
+++ b/tests/cpp/test_learner.h
@@ -1,0 +1,22 @@
+/*!
+ * Copyright 2018 by Contributors
+ * \file test_learner.h
+ * \brief Interface
+ * \author Hyunsu Philip Cho
+ */
+
+#ifndef XGBOOST_TESTS_CPP_TEST_LEARNER_H_
+#define XGBOOST_TESTS_CPP_TEST_LEARNER_H_
+
+#include <string>
+
+namespace xgboost {
+class LearnerTestHook {
+ private:
+  virtual std::string GetUpdaterSequence(void) const = 0;
+  // allow friend access to C++ test learner.SelectTreeMethod
+  friend class LearnerTestHookAdapter;
+};
+}  // namespace xgboost
+
+#endif  // XGBOOST_TESTS_CPP_TEST_LEARNER_H_

--- a/tests/cpp/test_learner.h
+++ b/tests/cpp/test_learner.h
@@ -13,7 +13,7 @@
 namespace xgboost {
 class LearnerTestHook {
  private:
-  virtual std::string GetUpdaterSequence(void) const = 0;
+  virtual std::string GetUpdaterSequence() const = 0;
   // allow friend access to C++ tests for Learner
   friend class LearnerTestHookAdapter;
 };


### PR DESCRIPTION
Try to consolidate logic concerning `tree_method` and `updater` into one place. Also use C++11 enum class for `tree_method` for extra safety. (For instance, compilers will generate warning if a `switch` statement doesn't handle all possible values of an enum class. This makes our code future-proof, in case someone decides to add another tree method.)

Closes #3840.