### PR TITLE
[jvm-packages] Fix JVM doc build

### DIFF
--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -319,6 +319,7 @@
                 <version>2.19.1</version>
                 <configuration>
                     <skipTests>false</skipTests>
+                    <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
To get around of the bug https://issues.apache.org/jira/browse/SUREFIRE-1588, set `useSystemClassLoader=false`.