### PR TITLE
[jvm-packages] Require vanilla Apache Spark

### DIFF
--- a/doc/jvm/index.rst
+++ b/doc/jvm/index.rst
@@ -58,9 +58,11 @@ For sbt, please add the repository and dependency in build.sbt as following:
 
 If you want to use XGBoost4J-Spark, replace ``xgboost4j`` with ``xgboost4j-spark``.
 
-.. note:: XGBoost4J-Spark requires Spark 2.3+
+.. note:: XGBoost4J-Spark requires Apache Spark 2.3+
 
-  XGBoost4J-Spark now requires Spark 2.3+. Latest versions of XGBoost4J-Spark uses facilities of `org.apache.spark.ml.param.shared` extensively to provide for a tight integration with Spark MLLIB framework, and these facilities are not fully available on earlier versions of Spark.
+  XGBoost4J-Spark now requires **Apache Spark 2.3+**. Latest versions of XGBoost4J-Spark uses facilities of `org.apache.spark.ml.param.shared` extensively to provide for a tight integration with Spark MLLIB framework, and these facilities are not fully available on earlier versions of Spark.
+
+  Also, make sure to install Spark directly from `Apache website <https://spark.apache.org/>`_. **Upstream XGBoost is not guaranteed to work with third-party distributions of Spark, such as Cloudera Spark.** Consult appropriate third parties to obtain their distribution of XGBoost.
 
 Installation from maven repo
 ============================

--- a/doc/jvm/xgboost4j_spark_tutorial.rst
+++ b/doc/jvm/xgboost4j_spark_tutorial.rst
@@ -61,9 +61,13 @@ and then refer to the snapshot dependency by adding:
       <version>next_version_num-SNAPSHOT</version>
   </dependency>
 
-.. note:: XGBoost4J-Spark requires Spark 2.3+
+.. note:: XGBoost4J-Spark requires Apache Spark 2.3+
 
-  XGBoost4J-Spark now requires Spark 2.3+. Latest versions of XGBoost4J-Spark uses facilities of `org.apache.spark.ml.param.shared` extensively to provide for a tight integration with Spark MLLIB framework, and these facilities are not fully available on earlier versions of Spark.
+  XGBoost4J-Spark now requires **Apache Spark 2.3+**. Latest versions of XGBoost4J-Spark uses facilities of `org.apache.spark.ml.param.shared` extensively to provide for a tight integration with Spark MLLIB framework, and these facilities are not fully available on earlier versions of Spark.
+
+  Also, make sure to install Spark directly from `Apache website <https://spark.apache.org/>`_. **Upstream XGBoost is not guaranteed to work with third-party distributions of Spark, such as Cloudera Spark.** Consult appropriate third parties to obtain their distribution of XGBoost.
+
+Installation from maven repo
 
 .. note:: Use of Python in XGBoost4J-Spark
 


### PR DESCRIPTION
See discussion at https://discuss.xgboost.ai/t/xgboost0-72-when-tried-to-compile-with-spark2-3cloudera3-errors-out. We are not able to support third-party distributions of Spark, since they potentially contain breaking changes over the vanilla Apache Spark.