### PR TITLE
Add parameter to make node type configurable in plot tree

### DIFF
--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -28,11 +28,10 @@ def plot_importance(booster, ax=None, height=0.2,
     grid : bool, Turn the axes grids on or off.  Default is True (On).
     importance_type : str, default "weight"
         How the importance is calculated: either "weight", "gain", or "cover"
-
-        * "weight" is the number of times a feature appears in a tree
-        * "gain" is the average gain of splits which use the feature
-        * "cover" is the average coverage of splits which use the feature
-          where coverage is defined as the number of samples affected by the split
+        "weight" is the number of times a feature appears in a tree
+        "gain" is the average gain of splits which use the feature
+        "cover" is the average coverage of splits which use the feature
+            where coverage is defined as the number of samples affected by the split
     max_num_features : int, default None
         Maximum number of top features displayed on plot. If None, all features will be displayed.
     height : float, default 0.2
@@ -124,17 +123,17 @@ _EDGEPAT = re.compile(r'yes=(\d+),no=(\d+),missing=(\d+)')
 _EDGEPAT2 = re.compile(r'yes=(\d+),no=(\d+)')
 
 
-def _parse_node(graph, text):
+def _parse_node(graph, text,conditionNodeParams,leafNodeParams):
     """parse dumped node"""
     match = _NODEPAT.match(text)
     if match is not None:
         node = match.group(1)
-        graph.node(node, label=match.group(2), shape='circle')
+        graph.node(node, label=match.group(2), **conditionNodeParams)
         return node
     match = _LEAFPAT.match(text)
     if match is not None:
         node = match.group(1)
-        graph.node(node, label=match.group(2), shape='box')
+        graph.node(node, label=match.group(2),**leafNodeParams)
         return node
     raise ValueError('Unable to parse node: {0}'.format(text))
 
@@ -164,7 +163,7 @@ def _parse_edge(graph, node, text, yes_color='#0000FF', no_color='#FF0000'):
 
 
 def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
-                yes_color='#0000FF', no_color='#FF0000', **kwargs):
+                yes_color='#0000FF', no_color='#FF0000',conditionNodeParams={},leafNodeParams={}, **kwargs):
 
     """Convert specified tree to graphviz instance. IPython can automatically plot the
     returned graphiz instance. Otherwise, you should call .render() method
@@ -184,6 +183,18 @@ def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
         Edge color when meets the node condition.
     no_color : str, default '#FF0000'
         Edge color when doesn't meet the node condition.
+    conditionNodeParams : dict, default {}
+        condition node configuration,
+        {'shape':'box',
+               'style':'filled,rounded',
+               'fillcolor':'#78bceb'
+        }
+    leafNodeParams : dict, default {}
+        leaf node configuration
+        {'shape':'box',
+               'style':'filled',
+               'fillcolor':'#e48038'
+        }
     kwargs :
         Other keywords passed to graphviz graph_attr
 
@@ -212,7 +223,7 @@ def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
 
     for i, text in enumerate(tree):
         if text[0].isdigit():
-            node = _parse_node(graph, text)
+            node = _parse_node(graph, text,conditionNodeParams=conditionNodeParams,leafNodeParams= leafNodeParams)
         else:
             if i == 0:
                 # 1st string must be node
@@ -266,3 +277,4 @@ def plot_tree(booster, fmap='', num_trees=0, rankdir='UT', ax=None, **kwargs):
     ax.imshow(img)
     ax.axis('off')
     return ax
+    

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -163,7 +163,8 @@ def _parse_edge(graph, node, text, yes_color='#0000FF', no_color='#FF0000'):
 
 
 def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
-                yes_color='#0000FF', no_color='#FF0000', conditionNodeParams={}, leafNodeParams={}, **kwargs):
+                yes_color='#0000FF', no_color='#FF0000',
+                conditionNodeParams=None, leafNodeParams=None, **kwargs):
     """Convert specified tree to graphviz instance. IPython can automatically plot the
     returned graphiz instance. Otherwise, you should call .render() method
     of the returned graphiz instance.
@@ -182,13 +183,13 @@ def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
         Edge color when meets the node condition.
     no_color : str, default '#FF0000'
         Edge color when doesn't meet the node condition.
-    conditionNodeParams : dict, default {}
+    conditionNodeParams : dict (optional)
         condition node configuration,
         {'shape':'box',
                'style':'filled,rounded',
                'fillcolor':'#78bceb'
         }
-    leafNodeParams : dict, default {}
+    leafNodeParams : dict (optional)
         leaf node configuration
         {'shape':'box',
                'style':'filled',
@@ -201,6 +202,11 @@ def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
     -------
     ax : matplotlib Axes
     """
+
+    if conditionNodeParams is None:
+        conditionNodeParams = {}
+    if leafNodeParams is None:
+        leafNodeParams = {}
 
     try:
         from graphviz import Digraph
@@ -223,7 +229,8 @@ def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
     for i, text in enumerate(tree):
         if text[0].isdigit():
             node = _parse_node(
-                graph, text, conditionNodeParams=conditionNodeParams, leafNodeParams=leafNodeParams)
+                graph, text, conditionNodeParams=conditionNodeParams,
+                leafNodeParams=leafNodeParams)
         else:
             if i == 0:
                 # 1st string must be node

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -28,10 +28,11 @@ def plot_importance(booster, ax=None, height=0.2,
     grid : bool, Turn the axes grids on or off.  Default is True (On).
     importance_type : str, default "weight"
         How the importance is calculated: either "weight", "gain", or "cover"
-        "weight" is the number of times a feature appears in a tree
-        "gain" is the average gain of splits which use the feature
-        "cover" is the average coverage of splits which use the feature
-            where coverage is defined as the number of samples affected by the split
+
+        * "weight" is the number of times a feature appears in a tree
+        * "gain" is the average gain of splits which use the feature
+        * "cover" is the average coverage of splits which use the feature
+          where coverage is defined as the number of samples affected by the split
     max_num_features : int, default None
         Maximum number of top features displayed on plot. If None, all features will be displayed.
     height : float, default 0.2

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -16,7 +16,6 @@ def plot_importance(booster, ax=None, height=0.2,
                     xlabel='F score', ylabel='Features',
                     importance_type='weight', max_num_features=None,
                     grid=True, show_values=True, **kwargs):
-
     """Plot importance based on fitted trees.
 
     Parameters
@@ -124,7 +123,7 @@ _EDGEPAT = re.compile(r'yes=(\d+),no=(\d+),missing=(\d+)')
 _EDGEPAT2 = re.compile(r'yes=(\d+),no=(\d+)')
 
 
-def _parse_node(graph, text,conditionNodeParams,leafNodeParams):
+def _parse_node(graph, text, conditionNodeParams, leafNodeParams):
     """parse dumped node"""
     match = _NODEPAT.match(text)
     if match is not None:
@@ -134,7 +133,7 @@ def _parse_node(graph, text,conditionNodeParams,leafNodeParams):
     match = _LEAFPAT.match(text)
     if match is not None:
         node = match.group(1)
-        graph.node(node, label=match.group(2),**leafNodeParams)
+        graph.node(node, label=match.group(2), **leafNodeParams)
         return node
     raise ValueError('Unable to parse node: {0}'.format(text))
 
@@ -164,8 +163,7 @@ def _parse_edge(graph, node, text, yes_color='#0000FF', no_color='#FF0000'):
 
 
 def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
-                yes_color='#0000FF', no_color='#FF0000',conditionNodeParams={},leafNodeParams={}, **kwargs):
-
+                yes_color='#0000FF', no_color='#FF0000', conditionNodeParams={}, leafNodeParams={}, **kwargs):
     """Convert specified tree to graphviz instance. IPython can automatically plot the
     returned graphiz instance. Otherwise, you should call .render() method
     of the returned graphiz instance.
@@ -224,7 +222,8 @@ def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
 
     for i, text in enumerate(tree):
         if text[0].isdigit():
-            node = _parse_node(graph, text,conditionNodeParams=conditionNodeParams,leafNodeParams= leafNodeParams)
+            node = _parse_node(
+                graph, text, conditionNodeParams=conditionNodeParams, leafNodeParams=leafNodeParams)
         else:
             if i == 0:
                 # 1st string must be node
@@ -268,7 +267,8 @@ def plot_tree(booster, fmap='', num_trees=0, rankdir='UT', ax=None, **kwargs):
     if ax is None:
         _, ax = plt.subplots(1, 1)
 
-    g = to_graphviz(booster, fmap=fmap, num_trees=num_trees, rankdir=rankdir, **kwargs)
+    g = to_graphviz(booster, fmap=fmap, num_trees=num_trees,
+                    rankdir=rankdir, **kwargs)
 
     s = BytesIO()
     s.write(g.pipe(format='png'))
@@ -278,4 +278,3 @@ def plot_tree(booster, fmap='', num_trees=0, rankdir='UT', ax=None, **kwargs):
     ax.imshow(img)
     ax.axis('off')
     return ax
-    

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -123,17 +123,17 @@ _EDGEPAT = re.compile(r'yes=(\d+),no=(\d+),missing=(\d+)')
 _EDGEPAT2 = re.compile(r'yes=(\d+),no=(\d+)')
 
 
-def _parse_node(graph, text, conditionNodeParams, leafNodeParams):
+def _parse_node(graph, text, condition_node_params, leaf_node_params):
     """parse dumped node"""
     match = _NODEPAT.match(text)
     if match is not None:
         node = match.group(1)
-        graph.node(node, label=match.group(2), **conditionNodeParams)
+        graph.node(node, label=match.group(2), **condition_node_params)
         return node
     match = _LEAFPAT.match(text)
     if match is not None:
         node = match.group(1)
-        graph.node(node, label=match.group(2), **leafNodeParams)
+        graph.node(node, label=match.group(2), **leaf_node_params)
         return node
     raise ValueError('Unable to parse node: {0}'.format(text))
 
@@ -164,7 +164,7 @@ def _parse_edge(graph, node, text, yes_color='#0000FF', no_color='#FF0000'):
 
 def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
                 yes_color='#0000FF', no_color='#FF0000',
-                conditionNodeParams=None, leafNodeParams=None, **kwargs):
+                condition_node_params=None, leaf_node_params=None, **kwargs):
     """Convert specified tree to graphviz instance. IPython can automatically plot the
     returned graphiz instance. Otherwise, you should call .render() method
     of the returned graphiz instance.
@@ -183,13 +183,13 @@ def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
         Edge color when meets the node condition.
     no_color : str, default '#FF0000'
         Edge color when doesn't meet the node condition.
-    conditionNodeParams : dict (optional)
+    condition_node_params : dict (optional)
         condition node configuration,
         {'shape':'box',
                'style':'filled,rounded',
                'fillcolor':'#78bceb'
         }
-    leafNodeParams : dict (optional)
+    leaf_node_params : dict (optional)
         leaf node configuration
         {'shape':'box',
                'style':'filled',
@@ -203,10 +203,10 @@ def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
     ax : matplotlib Axes
     """
 
-    if conditionNodeParams is None:
-        conditionNodeParams = {}
-    if leafNodeParams is None:
-        leafNodeParams = {}
+    if condition_node_params is None:
+        condition_node_params = {}
+    if leaf_node_params is None:
+        leaf_node_params = {}
 
     try:
         from graphviz import Digraph
@@ -229,8 +229,8 @@ def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
     for i, text in enumerate(tree):
         if text[0].isdigit():
             node = _parse_node(
-                graph, text, conditionNodeParams=conditionNodeParams,
-                leafNodeParams=leafNodeParams)
+                graph, text, condition_node_params=condition_node_params,
+                leaf_node_params=leaf_node_params)
         else:
             if i == 0:
                 # 1st string must be node


### PR DESCRIPTION
add parameters `'conditionNodeParams'` and `'leafNodeParams'` to function  `to_graphviz` enable to configure node type
as mentioned in issue https://github.com/dmlc/xgboost/issues/3858