### PR TITLE
open README with utf-8 and add gcc-8

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name, exec-used
 """Setup xgboost package."""
 from __future__ import absolute_import
+import io
 import sys
 import os
 from setuptools import setup, find_packages
@@ -31,7 +32,7 @@ print("Install libxgboost from: %s" % LIB_PATH)
 setup(name='xgboost',
       version=open(os.path.join(CURRENT_DIR, 'xgboost/VERSION')).read().strip(),
       description="XGBoost Python Package",
-      long_description=open(os.path.join(CURRENT_DIR, 'README.rst')).read(),
+      long_description=io.open(os.path.join(CURRENT_DIR, 'README.rst'), encoding='utf-8').read(),
       install_requires=[
           'numpy',
           'scipy',

--- a/python-package/xgboost/build-python.sh
+++ b/python-package/xgboost/build-python.sh
@@ -25,6 +25,9 @@ if echo "${OSTYPE}" | grep -q "darwin"; then
   elif which g++-7; then
     export CC=gcc-7
     export CXX=g++-7
+  elif which g++-8; then
+    export CC=gcc-8
+    export CXX=g++-8
   elif which clang++; then
     export CC=clang
     export CXX=clang++


### PR DESCRIPTION
Use `io.open` with `utf-8` to prevent the following error on machines with non-standard locale:
https://github.com/RGF-team/rgf/issues/65
https://github.com/henry0312/pytest-codestyle/pull/34