### PR TITLE
In lint check, disallow std::regex since it's not supported by GCC 4.8.x

### DIFF
--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -26,6 +26,12 @@ if [ ${TASK} == "lint" ]; then
     # Fail only on warnings related to XGBoost source files
     (cat logtidy.txt|grep -E 'xgboost.*warning'|grep -v dmlc-core) && exit -1
     echo "----------------------------"
+
+    if grep -R '<regex>' src include tests/cpp plugin jvm-packages amalgamation; then
+        echo 'Do not use std::regex, since it is not supported by GCC 4.8.x'
+        exit -1
+    fi
+
     exit 0
 fi
 


### PR DESCRIPTION
Make sure that any new pull request does not use `std::regex`. Although `std::regex` is part of C++11, GCC 4.8.x does not support it. (GCC 4.8.x is used to build Python wheels for the sake for maximum portability.)