### PR TITLE
Minor refactor of split evaluation in gpu_hist

### DIFF
--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -257,6 +257,14 @@ class DVec {
 
   const T *Data() const { return ptr_; }
 
+  xgboost::common::Span<const T> GetSpan() const {
+    return xgboost::common::Span<const T>(ptr_, this->Size());
+  }
+
+  xgboost::common::Span<T> GetSpan() {
+    return xgboost::common::Span<T>(ptr_, this->Size());
+  }
+
   std::vector<T> AsVector() const {
     std::vector<T> h_vector(Size());
     safe_cuda(cudaSetDevice(device_idx_));
@@ -497,8 +505,9 @@ struct CubMemory {
   ~CubMemory() { Free(); }
 
   template <typename T>
-  T *Pointer() {
-    return static_cast<T *>(d_temp_storage);
+  xgboost::common::Span<T> GetSpan(size_t size) {
+    this->LazyAllocate(size * sizeof(T));
+    return xgboost::common::Span<T>(static_cast<T*>(d_temp_storage), size);
   }
 
   void Free() {

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -1024,7 +1024,7 @@ class GPUHistMaker : public TreeUpdater {
         node_value_constraints_[nidx]);
   }
 
-  void InitRoot(DMatrix* p_fmat, RegTree* p_tree) {
+  void InitRoot(RegTree* p_tree) {
     constexpr int root_nidx = 0;
     // Sum gradients
     std::vector<GradientPair> tmp_sums(shards_.size());
@@ -1142,7 +1142,7 @@ class GPUHistMaker : public TreeUpdater {
     this->InitData(gpair, p_fmat);
     monitor_.Stop("InitData", dist_.Devices());
     monitor_.Start("InitRoot", dist_.Devices());
-    this->InitRoot(p_fmat, p_tree);
+    this->InitRoot(p_tree);
     monitor_.Stop("InitRoot", dist_.Devices());
 
     auto timestamp = qexpand_->size();


### PR DESCRIPTION
Move split evaluation logic into each device instead of having this logic "globally".  This is in preparation for a future PR where each device will propose splits based on its subset of the data, each device will vote and then the algorithm will globally calculate the optimal split for the selected feature.

Use span class in split evaluation for improved memory safety.