### PR TITLE
Improve update position function

### DIFF
--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -766,7 +766,8 @@ typename std::iterator_traits<T>::value_type SumReduction(
     dh::CubMemory &tmp_mem, T in, int nVals) {
   using ValueT = typename std::iterator_traits<T>::value_type;
   size_t tmpSize;
-  dh::safe_cuda(cub::DeviceReduce::Sum(nullptr, tmpSize, in, in, nVals));
+  ValueT *dummy_out = nullptr;
+  dh::safe_cuda(cub::DeviceReduce::Sum(nullptr, tmpSize, in, dummy_out, nVals));
   // Allocate small extra memory for the return value
   tmp_mem.LazyAllocate(tmpSize + sizeof(ValueT));
   auto ptr = reinterpret_cast<ValueT *>(tmp_mem.d_temp_storage) + 1;
@@ -1074,4 +1075,71 @@ xgboost::common::Span<T> ToSpan(thrust::device_vector<T>& vec,
   using IndexT = typename xgboost::common::Span<T>::index_type;
   return ToSpan(vec, static_cast<IndexT>(offset), static_cast<IndexT>(size));
 }
+
+template <typename FunctionT>
+class LauncherItr {
+public:
+  int idx;
+  FunctionT f;
+  XGBOOST_DEVICE LauncherItr() : idx(0) {}
+  XGBOOST_DEVICE LauncherItr(int idx, FunctionT f) : idx(idx), f(f) {}
+  XGBOOST_DEVICE LauncherItr &operator=(int output) {
+    f(idx, output);
+    return *this;
+  }
+};
+
+/**
+ * \brief Thrust compatible iterator type - discards algorithm output and launches device lambda
+ *        with the index of the output and the algorithm output as arguments.
+ *
+ * \author  Rory
+ * \date  7/9/2017
+ *
+ * \tparam  FunctionT Type of the function t.
+ */
+template <typename FunctionT>
+class DiscardLambdaItr {
+public:
+ // Required iterator traits
+ using self_type = DiscardLambdaItr;  // NOLINT
+ using difference_type = ptrdiff_t;   // NOLINT
+ using value_type = void;       // NOLINT
+ using pointer = value_type *;  // NOLINT
+ using reference = LauncherItr<FunctionT>;  // NOLINT
+ using iterator_category = typename thrust::detail::iterator_facade_category<
+     thrust::any_system_tag, thrust::random_access_traversal_tag, value_type,
+     reference>::type;  // NOLINT
+private:
+  difference_type offset_;
+  FunctionT f_;
+public:
+ XGBOOST_DEVICE explicit DiscardLambdaItr(FunctionT f) : offset_(0), f_(f) {}
+ XGBOOST_DEVICE DiscardLambdaItr(difference_type offset, FunctionT f)
+     : offset_(offset), f_(f) {}
+ XGBOOST_DEVICE self_type operator+(const int &b) const {
+   return DiscardLambdaItr(offset_ + b, f_);
+  }
+  XGBOOST_DEVICE self_type operator++() {
+    offset_++;
+    return *this;
+  }
+  XGBOOST_DEVICE self_type operator++(int) {
+    self_type retval = *this;
+    offset_++;
+    return retval;
+  }
+  XGBOOST_DEVICE self_type &operator+=(const int &b) {
+    offset_ += b;
+    return *this;
+  }
+  XGBOOST_DEVICE reference operator*() const {
+    return LauncherItr<FunctionT>(offset_, f_);
+  }
+  XGBOOST_DEVICE reference operator[](int idx) {
+    self_type offset = (*this) + idx;
+    return *offset;
+  }
+};
+
 }  // namespace dh

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -327,8 +327,6 @@ TEST(GpuHist, ApplySplit) {
   shard->row_stride = n_cols;
   thrust::sequence(shard->ridx.CurrentDVec().tbegin(),
                    shard->ridx.CurrentDVec().tend());
-  // Free inside DeviceShard
-  dh::safe_cuda(cudaMallocHost(&(shard->tmp_pinned), sizeof(int64_t)));
   // Initialize GPUHistMaker
   hist_maker.param_ = param;
   RegTree tree;
@@ -389,5 +387,44 @@ TEST(GpuHist, ApplySplit) {
   ASSERT_EQ(shard->ridx_segments[right_nidx].end, 16);
 }
 
+void TestSortPosition(const std::vector<int>& position_in, int left_idx,
+                      int right_idx) {
+  int left_count = std::count(position_in.begin(), position_in.end(), left_idx);
+  thrust::device_vector<int> position = position_in;
+  thrust::device_vector<int> position_out(position.size());
+
+  thrust::device_vector<bst_uint> ridx(position.size());
+  thrust::sequence(ridx.begin(), ridx.end());
+  thrust::device_vector<bst_uint> ridx_out(ridx.size());
+  dh::CubMemory tmp;
+  SortPosition(
+      &tmp, common::Span<int>(position.data().get(), position.size()),
+      common::Span<int>(position_out.data().get(), position_out.size()),
+      common::Span<bst_uint>(ridx.data().get(), ridx.size()),
+      common::Span<bst_uint>(ridx_out.data().get(), ridx_out.size()), left_idx,
+      right_idx, left_count);
+  thrust::host_vector<int> position_result = position_out;
+  thrust::host_vector<int> ridx_result = ridx_out;
+
+  // Check position is sorted
+  EXPECT_TRUE(std::is_sorted(position_result.begin(), position_result.end()));
+  // Check row indices are sorted inside left and right segment
+  EXPECT_TRUE(
+      std::is_sorted(ridx_result.begin(), ridx_result.begin() + left_count));
+  EXPECT_TRUE(
+      std::is_sorted(ridx_result.begin() + left_count, ridx_result.end()));
+
+  // Check key value pairs are the same
+  for (auto i = 0ull; i < ridx_result.size(); i++) {
+    EXPECT_EQ(position_result[i], position_in[ridx_result[i]]);
+  }
+}
+
+TEST(GpuHist, SortPosition) {
+  TestSortPosition({1, 2, 1, 2, 1}, 1, 2);
+  TestSortPosition({1, 1, 1, 1}, 1, 2);
+  TestSortPosition({2, 2, 2, 2}, 1, 2);
+  TestSortPosition({1, 2, 1, 2, 3}, 1, 2);
+}
 }  // namespace tree
 }  // namespace xgboost


### PR DESCRIPTION
I rewrote the radix sort function to optimise for the case of 1 bit keys (instances either go to the left node or right node). This is much faster, although impact on total program run-time is not very high. It also saves about 8 bytes per row of memory.