### PR TITLE
Use consistent type for sharding GPU data in GPU coordinate updater

### DIFF
--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -220,17 +220,18 @@ class GPUCoordinateUpdater : public LinearUpdater {
                                                p_fmat->Info().num_row_));
     auto devices = dist_.Devices();
 
-    int n_devices = devices.Size();
+    size_t n_devices = static_cast<size_t>(devices.Size());
     size_t row_begin = 0;
-    size_t shard_size =
-        static_cast<size_t>(std::ceil(static_cast<double>(p_fmat->Info().num_row_) / n_devices));
+    size_t num_row = static_cast<size_t>(p_fmat->Info().num_row_);
+    // Use fast integer ceiling
+    // See https://stackoverflow.com/a/2745086
+    size_t shard_size = (num_row + n_devices - 1) / n_devices;
 
     // Partition input matrix into row segments
     std::vector<size_t> row_segments;
     row_segments.push_back(0);
     for (int d_idx = 0; d_idx < n_devices; ++d_idx) {
-      size_t row_end = std::min(row_begin + shard_size,
-                                static_cast<size_t>(p_fmat->Info().num_row_));
+      size_t row_end = std::min(row_begin + shard_size, num_row);
       row_segments.push_back(row_end);
       row_begin = row_end;
     }

--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -221,16 +221,16 @@ class GPUCoordinateUpdater : public LinearUpdater {
     auto devices = dist_.Devices();
 
     int n_devices = devices.Size();
-    bst_uint row_begin = 0;
-    bst_uint shard_size =
-        std::ceil(static_cast<double>(p_fmat->Info().num_row_) / n_devices);
+    size_t row_begin = 0;
+    size_t shard_size =
+        static_cast<size_t>(std::ceil(static_cast<double>(p_fmat->Info().num_row_) / n_devices));
 
     // Partition input matrix into row segments
     std::vector<size_t> row_segments;
     row_segments.push_back(0);
     for (int d_idx = 0; d_idx < n_devices; ++d_idx) {
-      bst_uint row_end = std::min(static_cast<size_t>(row_begin + shard_size),
-                                  p_fmat->Info().num_row_);
+      size_t row_end = std::min(row_begin + shard_size,
+                                static_cast<size_t>(p_fmat->Info().num_row_));
       row_segments.push_back(row_end);
       row_begin = row_end;
     }


### PR DESCRIPTION
See discussion at https://discuss.xgboost.ai/t/xgboost-with-gpu-support-on-macos/446/7. When a user tried compiling XGBoost on Mac OSX with CUDA enabled, the following compiler error occurred:
```cpp
src/linear/updater_gpu_coordinate.cu(232):
   error: no instance of overloaded function "std::min" matches the argument list
            argument types are: (size_t, uint64_t)
```

To prevent this error, use consistent types in `src/linear/updater_gpu_coordinate.cu`.