### PR TITLE
Address #3933: document limitation of DMLC CSV parser + recommend Pandas

### DIFF
--- a/doc/python/python_intro.rst
+++ b/doc/python/python_intro.rst
@@ -48,9 +48,15 @@ The data is stored in a :py:class:`DMatrix <xgboost.DMatrix>` object.
     dtrain = xgb.DMatrix('train.csv?format=csv&label_column=0')
     dtest = xgb.DMatrix('test.csv?format=csv&label_column=0')
 
-  (Note that XGBoost does not support categorical features; if your data contains
-  categorical features, load it as a NumPy array first and then perform
-  `one-hot encoding <http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html>`_.)
+  .. note:: Categorical features not supported
+
+    Note that XGBoost does not support categorical features; if your data contains
+    categorical features, load it as a NumPy array first and then perform
+    `one-hot encoding <http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.OneHotEncoder.html>`_.
+
+  .. note:: Use Pandas to load CSV files with headers
+
+    Currently, the DMLC data parser cannot parse CSV files with headers. Use Pandas (see below) to read CSV files with headers.
 
 * To load a NumPy array into :py:class:`DMatrix <xgboost.DMatrix>`:
 


### PR DESCRIPTION
Currently, the DMLC parser for CSV is limited and does not recognize the header. This limitation should be documented.

Closes #3933.