### PR TITLE
Avoid generating NaNs in UnwoundPathSum

### DIFF
--- a/R-package/tests/testthat/test_interactions.R
+++ b/R-package/tests/testthat/test_interactions.R
@@ -81,6 +81,39 @@ test_that("predict feature interactions works", {
   expect_lt(max(abs(intr - gt_intr)), 0.1)
 })
 
+test_that("SHAP contribution values are not NAN", {
+  d <- data.frame(
+    x1 = c(-2.3, 1.4, 5.9, 2, 2.5, 0.3, -3.6, -0.2, 0.5, -2.8, -4.6, 3.3, -1.2,
+           -1.1, -2.3, 0.4, -1.5, -0.2, -1, 3.7),
+    x2 = c(291.179171, 269.198331, 289.942097, 283.191669, 269.673332,
+           294.158346, 287.255835, 291.530838, 285.899586, 269.290833,
+           268.649586, 291.530841, 280.074593, 269.484168, 293.94042,
+           294.327506, 296.20709, 295.441669, 283.16792, 270.227085),
+    y = c(9, 15, 5.7, 9.2, 22.4, 5, 9, 3.2, 7.2, 13.1, 7.8, 16.9, 6.5, 22.1,
+          5.3, 10.4, 11.1, 13.9, 11, 20.5),
+    fold = c(2, 2, 2, 1, 2, 2, 1, 2, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2))
+
+  ivs <- c("x1", "x2")
+
+  fit <- xgboost(
+    verbose = 0,
+    params = list(
+      objective = "reg:linear",
+      eval_metric = "rmse"),
+    data = as.matrix(subset(d, fold == 2)[, ivs]),
+    label = subset(d, fold == 2)$y,
+    nthread = 1,
+    nrounds = 3)
+
+  shaps <- as.data.frame(predict(fit,
+    newdata = as.matrix(subset(d, fold == 1)[, ivs]),
+    predcontrib = T))
+  result <- cbind(shaps, sum = rowSums(shaps), pred = predict(fit,
+      newdata = as.matrix(subset(d, fold == 1)[, ivs])))
+
+  expect_true(identical(TRUE, all.equal(result$sum, result$pred, tol = 1e-6)))
+})
+
 
 test_that("multiclass feature interactions work", {
   dm <- xgb.DMatrix(as.matrix(iris[,-5]), label=as.numeric(iris$Species)-1)

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -293,9 +293,12 @@ bst_float UnwoundPathSum(const PathElement *unique_path, unsigned unique_depth,
       total += tmp;
       next_one_portion = unique_path[i].pweight - tmp * zero_fraction * ((unique_depth - i)
                          / static_cast<bst_float>(unique_depth + 1));
-    } else {
+    } else if (zero_fraction != 0) {
       total += (unique_path[i].pweight / zero_fraction) / ((unique_depth - i)
                / static_cast<bst_float>(unique_depth + 1));
+    } else {
+      CHECK_EQ(unique_path[i].pweight, 0)
+        << "Unique path " << i << " must have zero weight";
     }
   }
   return total;


### PR DESCRIPTION
This is my attempt to fix the bug creating NaN SHAP values (#3333). I have an example R script (below) which produces NaN SHAPs without this patch and doesn't produce any with it, but I don't know whether my change is statistically correct.

The script is:

```R
library(xgboost)

d = data.frame(
    x1 = c(-2.3, 1.4, 5.9, 2, 2.5, 0.3, -3.6, -0.2, 0.5, -2.8, -4.6, 3.3, -1.2, -1.1, -2.3, 0.4, -1.5, -0.2, -1, 3.7),
    x2 = c(291.179171, 269.198331, 289.942097, 283.191669, 269.673332, 294.158346, 287.255835, 291.530838, 285.899586, 269.290833, 268.649586, 291.530841, 280.074593, 269.484168, 293.94042, 294.327506, 296.20709, 295.441669, 283.16792, 270.227085),
    y = c(9, 15, 5.7, 9.2, 22.4, 5, 9, 3.2, 7.2, 13.1, 7.8, 16.9, 6.5, 22.1, 5.3, 10.4, 11.1, 13.9, 11, 20.5),
    fold = c(2, 2, 2, 1, 2, 2, 1, 2, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2))

ivs = c("x1", "x2")

set.seed(50)

fit = xgboost(
    verbose = 0,
    params = list(
        objective = "reg:linear",
        eval_metric = "rmse"),
    data = as.matrix(subset(d, fold == 2)[, ivs]),
    label = subset(d, fold == 2)$y,
    nthread = 1,
    nrounds = 3)

shaps = as.data.frame(predict(fit,
    newdata = as.matrix(subset(d, fold == 1)[, ivs]),
    predcontrib = T))
result = cbind(shaps, sum = rowSums(shaps), pred = predict(fit,
    newdata = as.matrix(subset(d, fold == 1)[, ivs])))
print(result)

message(if (identical(TRUE, all.equal(result$sum, result$pred, tol = 1e-6)))
       "Looks good"
   else
       "Oh no")
```

Its output without the change is:

```R
          x1  x2     BIAS sum      pred
1  0.2951230 NaN 6.967499 NaN  5.478699
2 -0.6753536 NaN 6.967499 NaN  5.478699
3  0.2951230 NaN 6.967499 NaN  5.478699
4  0.8563597 NaN 6.967499 NaN 11.253153
Oh no
```

Its output with the change is:

```R
          x1         x2     BIAS       sum      pred
1  0.2951230 -1.7839233 6.967499  5.478699  5.478699
2 -0.6753536 -0.8134466 6.967499  5.478699  5.478699
3  0.2951230 -1.7839233 6.967499  5.478699  5.478699
4  0.8563597  3.4292932 6.967499 11.253152 11.253153
Looks good
```

CC @slundberg, @allanjust, @liuyanguu

Fixes #3333.