### PR TITLE
Disable retries in Jenkins CI, since we're now using On-Demand instances instead of Spot

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ def buildPlatformCmake(buildName, conf, nodeReq, dockerTarget) {
     }
     def test_suite = conf["withGpu"] ? (conf["multiGpu"] ? "mgpu" : "gpu") : "cpu"
     // Build node - this is returned result
-    retry(3) {
+    retry(1) {
         node(nodeReq) {
             unstash name: 'srcs'
             echo """

--- a/Jenkinsfile-restricted
+++ b/Jenkinsfile-restricted
@@ -56,7 +56,7 @@ pipeline {
         stage('Jenkins: Build doc') {
             steps {
                 script {
-                    retry(3) {
+                    retry(1) {
                         node('linux && cpu && restricted') {
                             unstash name: 'srcs'
                             echo 'Building doc...'
@@ -99,7 +99,7 @@ def buildPlatformCmake(buildName, conf, nodeReq, dockerTarget) {
         dockerArgs = "--build-arg CUDA_VERSION=" + conf["cudaVersion"]
     }
     // Build node - this is returned result
-    retry(3) {
+    retry(1) {
         node(nodeReq) {
             unstash name: 'srcs'
             echo """


### PR DESCRIPTION
Spot instances are just too unreliable. They are interrupted too often, and thus tests have to be re-started, holding up pull requests. In addition, sometimes Spot requests are denied, leading to 2 hour timeouts for pull requests. We will be exclusively using on-demand instances from now on.