### PR TITLE
Configure n_gpus.

### DIFF
--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -45,4 +45,18 @@ TEST(learner, SelectTreeMethod) {
   delete mat_ptr;
 }
 
+TEST(learner, DetectGpuUsage) {
+  using Arg = std::pair<std::string, std::string>;
+  auto mat_ptr = CreateDMatrix(10, 10, 0);
+  std::vector<std::shared_ptr<xgboost::DMatrix>> mat = {*mat_ptr};
+  auto learner = std::unique_ptr<Learner>(Learner::Create(mat));
+
+  learner->Configure({Arg("tree_method", "hist")});
+  ASSERT_EQ(learner->GetConfigurationArguments().at("n_gpus"), "0");
+
+  learner->Configure({Arg("predictor", "gpu_predictor")});
+  ASSERT_EQ(learner->GetConfigurationArguments().find("n_gpus"),
+            learner->GetConfigurationArguments().cend());
+}
+
 }  // namespace xgboost


### PR DESCRIPTION
This is supposed to be a quick fix for users that don't want to use GPU, but have a GPU in their machine.
The current method of disabling GPU is by specifying `n_gpus=0` explicitly.  This PR tries to disable GPU automatically when it's appropriate.

After having a more sound structure of parameters management, we should remove the logic created in here.