### PR TITLE
Deprecation warning for lists passed into DMatrix

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -381,7 +381,9 @@ class DMatrix(object):
         label = _maybe_dt_array(label)
         weight = _maybe_dt_array(weight)
 
-        if isinstance(data, STRING_TYPES):
+        if isinstance(data, list):
+            raise TypeError('can not initialize DMatrix from list)
+        elif isinstance(data, STRING_TYPES):
             self.handle = ctypes.c_void_p()
             _check_call(_LIB.XGDMatrixCreateFromFile(c_str(data),
                                                      ctypes.c_int(silent),

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -14,6 +14,7 @@ import ctypes
 import os
 import re
 import sys
+import warnings
 
 import numpy as np
 import scipy.sparse
@@ -382,7 +383,8 @@ class DMatrix(object):
         weight = _maybe_dt_array(weight)
 
         if isinstance(data, list):
-            raise TypeError('can not initialize DMatrix from list')
+            warnings.warn('Initializing DMatrix from List is deprecated.',
+                          DeprecationWarning)
         elif isinstance(data, STRING_TYPES):
             self.handle = ctypes.c_void_p()
             _check_call(_LIB.XGDMatrixCreateFromFile(c_str(data),

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -385,7 +385,7 @@ class DMatrix(object):
         if isinstance(data, list):
             warnings.warn('Initializing DMatrix from List is deprecated.',
                           DeprecationWarning)
-            
+
         if isinstance(data, STRING_TYPES):
             self.handle = ctypes.c_void_p()
             _check_call(_LIB.XGDMatrixCreateFromFile(c_str(data),

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -382,7 +382,7 @@ class DMatrix(object):
         weight = _maybe_dt_array(weight)
 
         if isinstance(data, list):
-            raise TypeError('can not initialize DMatrix from list)
+            raise TypeError('can not initialize DMatrix from list')
         elif isinstance(data, STRING_TYPES):
             self.handle = ctypes.c_void_p()
             _check_call(_LIB.XGDMatrixCreateFromFile(c_str(data),

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -385,7 +385,8 @@ class DMatrix(object):
         if isinstance(data, list):
             warnings.warn('Initializing DMatrix from List is deprecated.',
                           DeprecationWarning)
-        elif isinstance(data, STRING_TYPES):
+            
+        if isinstance(data, STRING_TYPES):
             self.handle = ctypes.c_void_p()
             _check_call(_LIB.XGDMatrixCreateFromFile(c_str(data),
                                                      ctypes.c_int(silent),


### PR DESCRIPTION
The documentation does not include lists as an allowed type for the data inputted into DMatrix. Despite this, a list can be passed in without an error. This change would prevent a list form being passed in directly.

I experienced an issue where passing in a list vs a np.array resulted in different predictions (sometimes over 10% relative difference) for the same data. Though these differences were infrequent (~1.5% of cases tested), in certain applications this could cause serious issues.