### PR TITLE
Use int instead of char in CLI config parser

### DIFF
--- a/src/common/config.h
+++ b/src/common/config.h
@@ -58,12 +58,12 @@ class ConfigReaderBase {
    * \brief to be implemented by subclass,
    * get next token, return EOF if end of file
    */
-  virtual char GetChar() = 0;
+  virtual int GetChar() = 0;
   /*! \brief to be implemented by child, check if end of stream */
   virtual bool IsEnd() = 0;
 
  private:
-  char ch_buf_;
+  int ch_buf_;
   std::string s_name_, s_val_, s_buf_;
 
   inline void SkipLine() {
@@ -79,7 +79,7 @@ class ConfigReaderBase {
         case '\"': return;
         case '\r':
         case '\n': LOG(FATAL)<< "ConfigReader: unterminated string";
-        default: *tok += ch_buf_;
+        default: *tok += static_cast<char>(ch_buf_);
       }
     }
     LOG(FATAL) << "ConfigReader: unterminated string";
@@ -89,7 +89,7 @@ class ConfigReaderBase {
       switch (ch_buf_) {
         case '\\': *tok += this->GetChar(); break;
         case '\'': return;
-        default: *tok += ch_buf_;
+        default: *tok += static_cast<char>(ch_buf_);
       }
     }
     LOG(FATAL) << "unterminated string";
@@ -128,7 +128,7 @@ class ConfigReaderBase {
           if (tok->length() != 0) return new_line;
           break;
         default:
-          *tok += ch_buf_;
+          *tok += static_cast<char>(ch_buf_);
           ch_buf_ = this->GetChar();
           break;
       }
@@ -152,7 +152,7 @@ class ConfigStreamReader: public ConfigReaderBase {
   explicit ConfigStreamReader(std::istream &fin) : fin_(fin) {}
 
  protected:
-  char GetChar() override {
+  int GetChar() override {
     return fin_.get();
   }
   /*! \brief to be implemented by child, check if end of stream */


### PR DESCRIPTION
I was playing around with AWS's latest offering of ARM instances, and running the binary classification CLI example resulted into an infinite loop.

**Diagnosis.** `std::istream.get()` and `getchar()` have return type `int`, not `char`, because both may return EOF, which is commonly -1. Storing EOF in a `char` results in undefined behavior. The `char` type is usually signed on x86 systems but unsigned on ARM systems (see http://blog.cdleary.com/2012/11/arm-chars-are-unsigned-by-default/), so the undefined behavior will only be apparent when compiled on ARM.

EDIT. The [DMLC config parser](https://github.com/dmlc/dmlc-core/blob/649be18a8c55c48517861d67158a45dec54992ee/src/config.cc) suffers from the same issue. Fortunately, DMLC JSON parser and parameter packs are unaffected.