### PR TITLE
 Require leaf statistics when expanding tree

### DIFF
--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -303,14 +303,22 @@ class RegTree {
   }
 
   /**
-   * \brief Expands a leaf node into two additional leaf nodes
+   * \brief Expands a leaf node into two additional leaf nodes.
    *
-   * \param nid           The node index to expand.
-   * \param split_index   Feature index of the split.
-   * \param split_value   The split condition.
-   * \param default_left  True to default left.
+   * \param nid               The node index to expand.
+   * \param split_index       Feature index of the split.
+   * \param split_value       The split condition.
+   * \param default_left      True to default left.
+   * \param base_weight       The base weight, before learning rate.
+   * \param left_leaf_weight  The left leaf weight for prediction, modified by learning rate.
+   * \param right_leaf_weight The right leaf weight for prediction, modified by learning rate.
+   * \param loss_change       The loss change.
+   * \param sum_hess          The sum hess.
    */
-  void ExpandNode(int nid, unsigned split_index, bst_float split_value, bool default_left) {
+  void ExpandNode(int nid, unsigned split_index, bst_float split_value,
+                  bool default_left, bst_float base_weight,
+                  bst_float left_leaf_weight, bst_float right_leaf_weight,
+                  bst_float loss_change, float sum_hess) {
     int pleft = this->AllocNode();
     int pright = this->AllocNode();
     auto &node = nodes_[nid];
@@ -322,8 +330,12 @@ class RegTree {
     node.SetSplit(split_index, split_value,
                          default_left);
     // mark right child as 0, to indicate fresh leaf
-    nodes_[pleft].SetLeaf(0.0f, 0);
-    nodes_[pright].SetLeaf(0.0f, 0);
+    nodes_[pleft].SetLeaf(left_leaf_weight, 0);
+    nodes_[pright].SetLeaf(right_leaf_weight, 0);
+
+    this->Stat(nid).loss_chg = loss_change;
+    this->Stat(nid).base_weight = base_weight;
+    this->Stat(nid).sum_hess = sum_hess;
   }
 
   /*!

--- a/src/tree/updater_gpu_common.cuh
+++ b/src/tree/updater_gpu_common.cuh
@@ -296,7 +296,8 @@ inline void Dense2SparseTree(RegTree* p_tree,
   for (int gpu_nid = 0; gpu_nid < h_nodes.size(); gpu_nid++) {
     const DeviceNodeStats& n = h_nodes[gpu_nid];
     if (!n.IsUnused() && !n.IsLeaf()) {
-      tree.ExpandNode(nid, n.fidx, n.fvalue, n.dir == kLeftDir);
+      tree.ExpandNode(nid, n.fidx, n.fvalue, n.dir == kLeftDir, n.weight, 0.0f,
+                      0.0f, n.root_gain, n.sum_gradients.GetHess());
       tree.Stat(nid).loss_chg = n.root_gain;
       tree.Stat(nid).base_weight = n.weight;
       tree.Stat(nid).sum_hess = n.sum_gradients.GetHess();

--- a/src/tree/updater_histmaker.cc
+++ b/src/tree/updater_histmaker.cc
@@ -192,7 +192,8 @@ class HistMaker: public BaseMaker {
         c.SetSubstract(node_sum, s);
         if (c.sum_hess >= param_.min_child_weight) {
           double loss_chg = s.CalcGain(param_) + c.CalcGain(param_) - root_gain;
-          if (best->Update(static_cast<bst_float>(loss_chg), fid, hist.cut[i], false)) {
+          if (best->Update(static_cast<bst_float>(loss_chg), fid, hist.cut[i],
+                           false, s, c)) {
             *left_sum = s;
           }
         }
@@ -205,7 +206,7 @@ class HistMaker: public BaseMaker {
         c.SetSubstract(node_sum, s);
         if (c.sum_hess >= param_.min_child_weight) {
           double loss_chg = s.CalcGain(param_) + c.CalcGain(param_) - root_gain;
-          if (best->Update(static_cast<bst_float>(loss_chg), fid, hist.cut[i-1], true)) {
+          if (best->Update(static_cast<bst_float>(loss_chg), fid, hist.cut[i-1], true, s, c)) {
             *left_sum = c;
           }
         }

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -429,8 +429,13 @@ void QuantileHistMaker::Builder::ApplySplit(int nid,
 
   /* 1. Create child nodes */
   NodeEntry& e = snode_[nid];
+  bst_float left_leaf_weight =
+      spliteval_->ComputeWeight(nid, e.best.left_sum) * param_.learning_rate;
+  bst_float right_leaf_weight =
+      spliteval_->ComputeWeight(nid, e.best.right_sum) * param_.learning_rate;
   p_tree->ExpandNode(nid, e.best.SplitIndex(), e.best.split_value,
-                    e.best.DefaultLeft());
+                     e.best.DefaultLeft(), e.weight, left_leaf_weight,
+                     right_leaf_weight, e.best.loss_chg, e.stats.sum_hess);
 
   /* 2. Categorize member rows */
   const auto nthread = static_cast<bst_omp_uint>(this->nthread_);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -698,6 +698,7 @@ void QuantileHistMaker::Builder::EnumerateSplit(int d_step,
               spliteval_->ComputeSplitScore(nodeID, fid, e, c) -
               snode.root_gain);
           split_pt = cut_val[i];
+          best.Update(loss_chg, fid, split_pt, d_step == -1, e, c);
         } else {
           // backward enumeration: split at left bound of each bin
           loss_chg = static_cast<bst_float>(
@@ -709,8 +710,8 @@ void QuantileHistMaker::Builder::EnumerateSplit(int d_step,
           } else {
             split_pt = cut_val[i - 1];
           }
+          best.Update(loss_chg, fid, split_pt, d_step == -1, c, e);
         }
-        best.Update(loss_chg, fid, split_pt, d_step == -1);
       }
     }
   }

--- a/src/tree/updater_skmaker.cc
+++ b/src/tree/updater_skmaker.cc
@@ -281,12 +281,21 @@ class SketchMaker: public BaseMaker {
       const int nid = qexpand_[wid];
       const SplitEntry &best = sol[wid];
       // set up the values
-      p_tree->Stat(nid).loss_chg = best.loss_chg;
       this->SetStats(nid, node_stats_[nid], p_tree);
       // now we know the solution in snode[nid], set split
       if (best.loss_chg > kRtEps) {
+        bst_float base_weight = node_stats_[nid].CalcWeight(param_);
+        bst_float left_leaf_weight =
+            CalcWeight(param_, best.left_sum.sum_grad, best.left_sum.sum_hess) *
+            param_.learning_rate;
+        bst_float right_leaf_weight =
+            CalcWeight(param_, best.right_sum.sum_grad,
+                       best.right_sum.sum_hess) *
+            param_.learning_rate;
         p_tree->ExpandNode(nid, best.SplitIndex(), best.split_value,
-                          best.DefaultLeft());
+                           best.DefaultLeft(), base_weight, left_leaf_weight,
+                           right_leaf_weight, best.loss_chg,
+                           node_stats_[nid].sum_hess);
       } else {
         (*p_tree)[nid].SetLeaf(p_tree->Stat(nid).base_weight * param_.learning_rate);
       }

--- a/src/tree/updater_skmaker.cc
+++ b/src/tree/updater_skmaker.cc
@@ -336,7 +336,9 @@ class SketchMaker: public BaseMaker {
       if (s.sum_hess >= param_.min_child_weight &&
           c.sum_hess >= param_.min_child_weight) {
         double loss_chg = s.CalcGain(param_) + c.CalcGain(param_) - root_gain;
-        best->Update(static_cast<bst_float>(loss_chg), fid, fsplits[i], false);
+        best->Update(static_cast<bst_float>(loss_chg), fid, fsplits[i], false,
+                     GradStats(s.pos_grad - s.neg_grad , s.sum_hess),
+                     GradStats(c.pos_grad - c.neg_grad, c.sum_hess));
       }
       // backward
       c.SetSubstract(feat_sum, s);
@@ -344,7 +346,9 @@ class SketchMaker: public BaseMaker {
       if (s.sum_hess >= param_.min_child_weight &&
           c.sum_hess >= param_.min_child_weight) {
         double loss_chg = s.CalcGain(param_) + c.CalcGain(param_) - root_gain;
-        best->Update(static_cast<bst_float>(loss_chg), fid, fsplits[i], true);
+        best->Update(static_cast<bst_float>(loss_chg), fid, fsplits[i], true,
+                     GradStats(s.pos_grad - s.neg_grad, s.sum_hess),
+                     GradStats(c.pos_grad - c.neg_grad, c.sum_hess));
       }
     }
     {
@@ -355,8 +359,10 @@ class SketchMaker: public BaseMaker {
           c.sum_hess >= param_.min_child_weight) {
         bst_float cpt = fsplits.back();
         double loss_chg = s.CalcGain(param_) + c.CalcGain(param_) - root_gain;
-        best->Update(static_cast<bst_float>(loss_chg),
-                     fid, cpt + std::abs(cpt) + 1.0f, false);
+        best->Update(static_cast<bst_float>(loss_chg), fid,
+                     cpt + std::abs(cpt) + 1.0f, false,
+                     GradStats(s.pos_grad - s.neg_grad, s.sum_hess),
+                     GradStats(c.pos_grad - c.neg_grad, c.sum_hess));
       }
     }
   }

--- a/tests/cpp/tree/test_param.cc
+++ b/tests/cpp/tree/test_param.cc
@@ -82,12 +82,15 @@ TEST(Param, SplitEntry) {
 
   xgboost::tree::SplitEntry se2;
   EXPECT_FALSE(se1.Update(se2));
-  EXPECT_FALSE(se2.Update(-1, 100, 0, true));
-  ASSERT_TRUE(se2.Update(1, 100, 0, true));
+  EXPECT_FALSE(se2.Update(-1, 100, 0, true, xgboost::tree::GradStats(),
+                          xgboost::tree::GradStats()));
+  ASSERT_TRUE(se2.Update(1, 100, 0, true, xgboost::tree::GradStats(),
+                         xgboost::tree::GradStats()));
   ASSERT_TRUE(se1.Update(se2));
 
   xgboost::tree::SplitEntry se3;
-  se3.Update(2, 101, 0, false);
+  se3.Update(2, 101, 0, false, xgboost::tree::GradStats(),
+             xgboost::tree::GradStats());
   xgboost::tree::SplitEntry::Reduce(se2, se3);
   EXPECT_EQ(se2.SplitIndex(), 101);
   EXPECT_FALSE(se2.DefaultLeft());

--- a/tests/cpp/tree/test_prune.cc
+++ b/tests/cpp/tree/test_prune.cc
@@ -38,22 +38,13 @@ TEST(Updater, Prune) {
   pruner->Init(cfg);
 
   // loss_chg < min_split_loss;
-  tree.ExpandNode(0, 0, 0, true);
-  int cleft = tree[0].LeftChild();
-  int cright = tree[0].RightChild();
-  tree[cleft].SetLeaf(0.3f, 0);
-  tree[cright].SetLeaf(0.4f, 0);
+  tree.ExpandNode(0, 0, 0, true, 0.0f, 0.3f, 0.4f, 0.0f, 0.0f);
   pruner->Update(&gpair, dmat->get(), trees);
 
   ASSERT_EQ(tree.NumExtraNodes(), 0);
 
   // loss_chg > min_split_loss;
-  tree.ExpandNode(0, 0, 0, true);
-  cleft = tree[0].LeftChild();
-  cright = tree[0].RightChild();
-  tree[cleft].SetLeaf(0.3f, 0);
-  tree[cright].SetLeaf(0.4f, 0);
-  tree.Stat(0).loss_chg = 11;
+  tree.ExpandNode(0, 0, 0, true, 0.0f, 0.3f, 0.4f, 11.0f, 0.0f);
   pruner->Update(&gpair, dmat->get(), trees);
 
   ASSERT_EQ(tree.NumExtraNodes(), 2);

--- a/tests/cpp/tree/test_refresh.cc
+++ b/tests/cpp/tree/test_refresh.cc
@@ -29,12 +29,9 @@ TEST(Updater, Refresh) {
   std::vector<RegTree*> trees {&tree};
   std::unique_ptr<TreeUpdater> refresher(TreeUpdater::Create("refresh"));
 
-  tree.ExpandNode(0, 0, 0, true);
+  tree.ExpandNode(0, 2, 0.2f, false, 0.0, 0.2f, 0.8f, 0.0f, 0.0f);
   int cleft = tree[0].LeftChild();
   int cright = tree[0].RightChild();
-  tree[cleft].SetLeaf(0.2f, 0);
-  tree[cright].SetLeaf(0.8f, 0);
-  tree[0].SetSplit(2, 0.2f);
 
   tree.Stat(cleft).base_weight = 1.2;
   tree.Stat(cright).base_weight = 1.3;


### PR DESCRIPTION
This PR extends the RegTree::ExpandNode() function to require summary statistics for the node being expanded as well as leaf weights for the left and right child. Calculating the leaf weights in advance for the child nodes required cacheing the left and right gradient sums from split calculation, so I have extended the SplitEntry class with this information.

There are several impacts to this change:
- Expanding a tree node is now a safe operation. After you call ExpandNode() the tree is complete and may be used immediately with all the required statistics and leaf nodes configured.
- As a consequence of the above, all code in tree updater algorithms that manually accesses RegTree internals such as tree nodes, statistics or leaf nodes becomes unnecessary (e.g. [this](https://github.com/dmlc/xgboost/blob/f75a21af25d1752648d78d8efae33b6cb1a7fac9/src/tree/updater_colmaker.cc#L124)). I have not remove these in this PR as it would make it too complicated, but I have verified that it is possible to remove them safely.
- Because the gradient sums in the newly created node children are cached, we no longer need to recalculate this. This means we can remove loops such as [this](https://github.com/dmlc/xgboost/blob/f75a21af25d1752648d78d8efae33b6cb1a7fac9/src/tree/updater_colmaker.cc#L214) and [this](https://github.com/dmlc/xgboost/blob/f75a21af25d1752648d78d8efae33b6cb1a7fac9/src/tree/updater_quantile_hist.cc#L631) for free. Again I will leave this for a future PR.

So in summary this will collapse a lot of the complexity around configuring a decision tree and will also improve performance. This is the way I have been doing things already in the GPU algorithms so it also helps me unify the code base.
