### PR TITLE
[jvm-packages] fix the scalability issue of prediction

### DIFF
--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -335,25 +335,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
as we fixed in training part, iterator.duplicate() keeps the gap of two iterators in memory and it leads to the memory pressure to the system 

this part eliminate this duplicate() and convert it to a RDD zipPartitions