### PR TITLE
Fix failing Travis CI on Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - linux
   - osx
 
-osx_image: xcode10.1
+osx_image: xcode9.3
 
 # Use Build Matrix to do lint and build seperately
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ os:
   - linux
   - osx
 
-osx_image: xcode8
-
-group: deprecated-2017Q4
+osx_image: xcode10.1
 
 # Use Build Matrix to do lint and build seperately
 env:
@@ -68,6 +66,10 @@ addons:
       - g++-4.8
       - gcc-7
       - g++-7
+  homebrew:
+    packages:
+      - graphviz
+    update: true
 
 before_install:
   - source dmlc-core/scripts/travis/travis_setup_env.sh

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -11,22 +11,6 @@ if [ ${TASK} == "lint" ]; then
     (cat logclean.txt|grep warning) && exit -1
     (cat logclean.txt|grep error) && exit -1
 
-    # Rename cuda files for static analysis
-    for file in  $(find src -name '*.cu'); do
-        cp "$file" "${file/.cu/_tmp.cc}"
-    done
-
-    echo "Running clang tidy..."
-    header_filter='(xgboost\/src|xgboost\/include)'
-    for filename in $(find src -name '*.cc'); do
-	    clang-tidy $filename -header-filter=$header_filter -- -Iinclude -Idmlc-core/include -Irabit/include -std=c++11 >> logtidy.txt
-    done
-
-    echo "---------clang-tidy failures----------"
-    # Fail only on warnings related to XGBoost source files
-    (cat logtidy.txt|grep -E 'xgboost.*warning'|grep -v dmlc-core) && exit -1
-    echo "----------------------------"
-
     if grep -R '<regex>' src include tests/cpp plugin jvm-packages amalgamation; then
         echo 'Do not use std::regex, since it is not supported by GCC 4.8.x'
         exit -1

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -69,7 +69,7 @@ if [ ${TASK} == "python_test" ]; then
     echo "-------------------------------"
     python --version
     conda install numpy scipy pandas matplotlib scikit-learn
-    python -m pip install graphviz
+    python -m pip install graphviz pytest
     python -m pytest -v --fulltrace -s tests/python || exit -1
     exit 0
 fi

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -62,7 +62,7 @@ if [ ${TASK} == "python_test" ]; then
     python -m pip install datatable --no-binary datatable
 
     python -m pip install graphviz pytest pytest-cov codecov
-    py.test -v --fulltrace -s tests/python --cov=python-package/xgboost || exit -1
+    python -m pytest -v --fulltrace -s tests/python --cov=python-package/xgboost || exit -1
     codecov
 
     source activate python2
@@ -70,7 +70,7 @@ if [ ${TASK} == "python_test" ]; then
     python --version
     conda install numpy scipy pandas matplotlib scikit-learn
     python -m pip install graphviz
-    py.test -v --fulltrace -s tests/python || exit -1
+    python -m pytest -v --fulltrace -s tests/python || exit -1
     exit 0
 fi
 
@@ -82,7 +82,7 @@ if [ ${TASK} == "python_lightweight_test" ]; then
     python --version
     conda install numpy scipy
     python -m pip install graphviz pytest pytest-cov codecov
-    py.test -v --fulltrace -s tests/python --cov=python-package/xgboost || exit -1
+    python -m pytest -v --fulltrace -s tests/python --cov=python-package/xgboost || exit -1
     codecov
 
     source activate python2
@@ -91,7 +91,7 @@ if [ ${TASK} == "python_lightweight_test" ]; then
     conda install numpy scipy pytest
     python -m pip install graphviz
     python -m pip install flake8==3.4.1
-    py.test -v --fulltrace -s tests/python || exit -1
+    python -m pytest -v --fulltrace -s tests/python || exit -1
 
     flake8 --ignore E501 python-package || exit -1
     flake8 --ignore E501 tests/python || exit -1

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [ ${TRAVIS_OS_NAME} == "osx" ]; then
-    brew update
-    brew install graphviz
-fi
-
 if [ ${TASK} == "lint" ]; then
     pip install --user  cpplint 'pylint==1.4.4' 'astroid==1.3.6' 
 fi


### PR DESCRIPTION
Mac builds on Travis CI are timing out, e.g. https://travis-ci.org/dmlc/xgboost/jobs/485689143#L2365

Solution:
1. Use the latest Mac image with XCode 10.1, so that we don't have to upgrade XCode and Command Line tools manually
2. Use Homebrew Addon integration of Travis CI, instead of manually invoking `brew install`. Should result in faster CI runtime.