### PR TITLE
Speed up Jenkins CI by not compiling CMake

### DIFF
--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -14,10 +14,8 @@ RUN \
     wget https://repo.continuum.io/miniconda/Miniconda2-4.3.27-Linux-x86_64.sh && \
     bash Miniconda2-4.3.27-Linux-x86_64.sh -b -p /opt/python && \
     # CMake
-    wget http://www.cmake.org/files/v3.5/cmake-3.5.2.tar.gz && \
-    tar -xvzf cmake-3.5.2.tar.gz && \
-    cd cmake-3.5.2/ && ./configure && make && make install && cd ../ && \
-    rm -rf cmake-3.5.2/ && rm -rf cmake-3.5.2.tar.gz
+    wget -nv -nc https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.sh --no-check-certificate && \
+    bash cmake-3.5.2-Linux-x86_64.sh --skip-license --prefix=/usr
 
 # NCCL2 (License: https://docs.nvidia.com/deeplearning/sdk/nccl-sla/index.html)
 RUN \


### PR DESCRIPTION
Conserve CI resources by downloading pre-compiled CMake binaries, instead of compiling it from scratch every time. This also speeds up CI turn-around time.