### PR TITLE
Use nccl group calls to prevent from dead lock.

### DIFF
--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -852,7 +852,7 @@ class AllReducer {
 #ifdef XGBOOST_USE_NCCL
   std::vector<ncclComm_t> comms;
   std::vector<cudaStream_t> streams;
-  std::vector<int> device_ordinals;
+  std::vector<int> device_ordinals;  // device id from CUDA
 #endif
 
  public:

--- a/src/common/host_device_vector.cu
+++ b/src/common/host_device_vector.cu
@@ -459,9 +459,8 @@ HostDeviceVector<T>& HostDeviceVector<T>::operator=
 
 template <typename T>
 HostDeviceVector<T>::~HostDeviceVector() {
-  HostDeviceVectorImpl<T>* tmp = impl_;
+  delete impl_;
   impl_ = nullptr;
-  delete tmp;
 }
 
 template <typename T>

--- a/tests/cpp/tree/test_gpu_exact.cu
+++ b/tests/cpp/tree/test_gpu_exact.cu
@@ -42,6 +42,9 @@ TEST(GPUExact, Update) {
   ASSERT_NEAR(tree.Stat(2).sum_hess, 2, kRtEps);
 
   ASSERT_NEAR(tree.Stat(0).loss_chg, 0.8f, kRtEps);
+
+  delete dmat;
+  delete p_gpuexact_maker;
 }
 
 }  // namespace tree


### PR DESCRIPTION
* launch all reduce sequentially.
* Fix gpu_exact test memory leak.

close #4107