### PR TITLE
Update datatable usage

### DIFF
--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -49,7 +49,11 @@ except ImportError:
 
 # dt
 try:
-    from datatable import DataTable
+    import datatable
+    if hasattr(datatable, "Frame"):
+        DataTable = datatable.Frame
+    else:
+        DataTable = datatable.DataTable
     DT_INSTALLED = True
 except ImportError:
 


### PR DESCRIPTION
This PR ensures that xgboost continues to work correctly with the upcoming changes to the `datatable` package.
- Prefer name `dt.Frame` instead of `dt.DataTable` (which was deprecated a year ago);
- `dt.Frame.internal` namespace will be removed; instead the underlying data pointers can be accessed using `datatable.internal.frame_column_data_r()` (which returns a `ctypes.c_void_p` object).
