### PR TITLE
Fix broken R test: Install Homebrew GCC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ addons:
       - g++-7
   homebrew:
     packages:
+      - gcc@7
       - graphviz
     update: true
 

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -90,6 +90,8 @@ if [ ${TASK} == "r_test" ]; then
     if [ ${TRAVIS_OS_NAME} == "osx" ]; then
         # Work-around to fix "gfortran command not found" error
         sudo ln -s $(which gfortran-7) /usr/local/bin/gfortran
+        sudo mkdir -p /usr/local/gfortran/lib/gcc/x86_64-apple-darwin15
+        sudo ln -s /usr/local/lib/gcc/7/libgfortran /usr/local/gfortran/lib/gcc/x86_64-apple-darwin15/6.1.0
     fi
 
     curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -91,7 +91,7 @@ if [ ${TASK} == "r_test" ]; then
         # Work-around to fix "gfortran command not found" error
         sudo ln -s $(which gfortran-7) /usr/local/bin/gfortran
         sudo mkdir -p /usr/local/gfortran/lib/gcc/x86_64-apple-darwin15
-        sudo ln -s /usr/local/lib/gcc/7/libgfortran /usr/local/gfortran/lib/gcc/x86_64-apple-darwin15/6.1.0
+        sudo ln -s /usr/local/lib/gcc/7 /usr/local/gfortran/lib/gcc/x86_64-apple-darwin15/6.1.0
     fi
 
     curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -89,7 +89,7 @@ if [ ${TASK} == "r_test" ]; then
     export R_CHECK_ARGS="--no-vignettes --no-manual"
     if [ ${TRAVIS_OS_NAME} == "osx" ]; then
         # Work-around to fix "gfortran command not found" error
-        sudo ln -s $(which gfortran-7) /usr/bin/gfortran
+        sudo ln -s $(which gfortran-7) /usr/local/bin/gfortran
     fi
 
     curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -87,6 +87,11 @@ if [ ${TASK} == "r_test" ]; then
     export _R_CHECK_TIMINGS_=0
     export R_BUILD_ARGS="--no-build-vignettes --no-manual"
     export R_CHECK_ARGS="--no-vignettes --no-manual"
+    if [ ${TRAVIS_OS_NAME} == "osx" ]; then
+        export CC='gcc-7'
+        export CXX='g++-7'
+        export FC='gfortran-7'
+    fi
 
     curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
     chmod 755 ./travis-tool.sh

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -88,9 +88,8 @@ if [ ${TASK} == "r_test" ]; then
     export R_BUILD_ARGS="--no-build-vignettes --no-manual"
     export R_CHECK_ARGS="--no-vignettes --no-manual"
     if [ ${TRAVIS_OS_NAME} == "osx" ]; then
-        export CC='gcc-7'
-        export CXX='g++-7'
-        export FC='gfortran-7'
+        # Work-around to fix "gfortran command not found" error
+        sudo ln -s $(which gfortran-7) /usr/bin/gfortran
     fi
 
     curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-if [ ${TRAVIS_OS_NAME} == "osx" ]; then	
-    brew link gcc@7 --force
+if [ ${TRAVIS_OS_NAME} == "osx" ]; then
+    export CC='gcc-7'
+    export CXX='g++-7'
+    export FC='gfortran-7'
 fi
 
 if [ ${TASK} == "lint" ]; then

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-if [ ${TRAVIS_OS_NAME} == "osx" ]; then
-    export CC='gcc-7'
-    export CXX='g++-7'
-    export FC='gfortran-7'
-fi
-
 if [ ${TASK} == "lint" ]; then
     pip install --user  cpplint 'pylint==1.4.4' 'astroid==1.3.6' 
 fi

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ ${TRAVIS_OS_NAME} == "osx" ]; then	
+    brew link gcc --force
+fi
+
 if [ ${TASK} == "lint" ]; then
     pip install --user  cpplint 'pylint==1.4.4' 'astroid==1.3.6' 
 fi

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ ${TRAVIS_OS_NAME} == "osx" ]; then	
-    brew link gcc --force
+    brew link gcc@7 --force
 fi
 
 if [ ${TASK} == "lint" ]; then


### PR DESCRIPTION
Missing GCC Fortran causes installation failure of a dependency package (igraph).

@trivialfis @CodingCat @RAMitchell This should fix the R test.