### PR TITLE
Fix #4163: always copy sliced data

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2015-2019 by Contributors
+ * Copyright (c) 2015 by Contributors
  * \file c_api.h
  * \author Tianqi Chen
  * \brief C API of XGBoost, used for interfacing to other languages.
@@ -284,23 +284,6 @@ XGB_DLL int XGDMatrixSetFloatInfo(DMatrixHandle handle,
                                   const float *array,
                                   bst_ulong len);
 /*!
- * \brief `XGDMatrixSetFloatInfo' with strided array as input.
- *
- * \param handle a instance of data matrix
- * \param field field name, can be label, weight
- * \param array pointer to float vector
- * \param stride stride of input vector
- * \param len length of array
- *
- * \return 0 when success, -1 when failure happens
- */
-XGB_DLL int XGDMatrixSetFloatInfoStrided(DMatrixHandle handle,
-                                         const char *field,
-                                         const float *array,
-                                         const bst_ulong stride,
-                                         bst_ulong len);
-
-/*!
  * \brief set uint32 vector to a content in info
  * \param handle a instance of data matrix
  * \param field field name
@@ -312,23 +295,6 @@ XGB_DLL int XGDMatrixSetUIntInfo(DMatrixHandle handle,
                                  const char *field,
                                  const unsigned *array,
                                  bst_ulong len);
-
-/*!
- * \brief `XGDMatrixSetUIntInfo' with strided array as input.
- *
- * \param handle a instance of data matrix
- * \param field field name
- * \param array pointer to unsigned int vector
- * \param stride stride of input vector
- * \param len length of array
- *
- * \return 0 when success, -1 when failure happens
- */
-XGB_DLL int XGDMatrixSetUIntInfoStrided(DMatrixHandle handle,
-                                        const char *field,
-                                        const unsigned *array,
-                                        const bst_ulong stride,
-                                        bst_ulong len);
 /*!
  * \brief set label of the training matrix
  * \param handle a instance of data matrix

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -122,7 +122,6 @@ class MetaInfo {
    * \param num Number of elements in the source array.
    */
   void SetInfo(const char* key, const void* dptr, DataType dtype, size_t num);
-  void SetInfo(const char* key, const void* dptr, DataType dtype, size_t stride, size_t num);
 
  private:
   /*! \brief argsort of labels */

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -587,7 +587,8 @@ class DMatrix(object):
         if getattr(data, 'base', None) is not None and \
            data.base is not None and isinstance(data, np.ndarray) \
            and isinstance(data.base, np.ndarray) and (not data.flags.c_contiguous):
-            raise ValueError('Should use set_float_info_npy2d() to use sliced data')
+            self.set_float_info_npy2d(field, data)
+            return
         c_data = c_array(ctypes.c_float, data)
         _check_call(_LIB.XGDMatrixSetFloatInfo(self.handle,
                                                c_str(field),
@@ -634,7 +635,11 @@ class DMatrix(object):
         if getattr(data, 'base', None) is not None and \
            data.base is not None and isinstance(data, np.ndarray) \
            and isinstance(data.base, np.ndarray) and (not data.flags.c_contiguous):
-            raise ValueError('Sliced data is not allowed for uint property')
+            warnings.warn("Use subset (sliced data) of np.ndarray is not recommended " + \
+                          "because it will generate extra copies and increase memory consumption")
+            data = np.array(data, copy=True, dtype=ctypes.c_uint)
+        else:
+            data = np.array(data, copy=False, dtype=ctypes.c_uint)
         _check_call(_LIB.XGDMatrixSetUIntInfo(self.handle,
                                               c_str(field),
                                               c_array(ctypes.c_uint, data),

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -584,6 +584,9 @@ class DMatrix(object):
         data: numpy array
             The array of data to be set
         """
+        if data.base is not None and isinstance(data, np.ndarray) \
+           and isinstance(data.base, np.ndarray) and (not data.flags.c_contiguous):
+            raise ValueError('Should use set_float_info_npy2d() to use sliced data')
         c_data = c_array(ctypes.c_float, data)
         _check_call(_LIB.XGDMatrixSetFloatInfo(self.handle,
                                                c_str(field),
@@ -602,7 +605,13 @@ class DMatrix(object):
         data: numpy array
             The array of data to be set
         """
-        data = np.array(data, copy=False, dtype=np.float32)
+        if data.base is not None and isinstance(data, np.ndarray) \
+           and isinstance(data.base, np.ndarray) and (not data.flags.c_contiguous):
+            warnings.warn("Use subset (sliced data) of np.ndarray is not recommended " + \
+                          "because it will generate extra copies and increase memory consumption")
+            data = np.array(data, copy=True, dtype=np.float32)
+        else:
+            data = np.array(data, copy=False, dtype=np.float32)
         c_data = data.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
         _check_call(_LIB.XGDMatrixSetFloatInfo(self.handle,
                                                c_str(field),
@@ -620,6 +629,9 @@ class DMatrix(object):
         data: numpy array
             The array of data to be set
         """
+        if data.base is not None and isinstance(data, np.ndarray) \
+           and isinstance(data.base, np.ndarray) and (not data.flags.c_contiguous):
+            raise ValueError('Sliced data is not allowed for uint property')
         _check_call(_LIB.XGDMatrixSetUIntInfo(self.handle,
                                               c_str(field),
                                               c_array(ctypes.c_uint, data),

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -635,7 +635,7 @@ class DMatrix(object):
         if getattr(data, 'base', None) is not None and \
            data.base is not None and isinstance(data, np.ndarray) \
            and isinstance(data.base, np.ndarray) and (not data.flags.c_contiguous):
-            warnings.warn("Use subset (sliced data) of np.ndarray is not recommended " + \
+            warnings.warn("Use subset (sliced data) of np.ndarray is not recommended " +
                           "because it will generate extra copies and increase memory consumption")
             data = np.array(data, copy=True, dtype=ctypes.c_uint)
         else:

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -609,7 +609,7 @@ class DMatrix(object):
         if getattr(data, 'base', None) is not None and \
            data.base is not None and isinstance(data, np.ndarray) \
            and isinstance(data.base, np.ndarray) and (not data.flags.c_contiguous):
-            warnings.warn("Use subset (sliced data) of np.ndarray is not recommended " + \
+            warnings.warn("Use subset (sliced data) of np.ndarray is not recommended " +
                           "because it will generate extra copies and increase memory consumption")
             data = np.array(data, copy=True, dtype=np.float32)
         else:

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -584,7 +584,8 @@ class DMatrix(object):
         data: numpy array
             The array of data to be set
         """
-        if data.base is not None and isinstance(data, np.ndarray) \
+        if getattr(data, 'base', None) is not None and \
+           data.base is not None and isinstance(data, np.ndarray) \
            and isinstance(data.base, np.ndarray) and (not data.flags.c_contiguous):
             raise ValueError('Should use set_float_info_npy2d() to use sliced data')
         c_data = c_array(ctypes.c_float, data)
@@ -605,7 +606,8 @@ class DMatrix(object):
         data: numpy array
             The array of data to be set
         """
-        if data.base is not None and isinstance(data, np.ndarray) \
+        if getattr(data, 'base', None) is not None and \
+           data.base is not None and isinstance(data, np.ndarray) \
            and isinstance(data.base, np.ndarray) and (not data.flags.c_contiguous):
             warnings.warn("Use subset (sliced data) of np.ndarray is not recommended " + \
                           "because it will generate extra copies and increase memory consumption")
@@ -629,7 +631,8 @@ class DMatrix(object):
         data: numpy array
             The array of data to be set
         """
-        if data.base is not None and isinstance(data, np.ndarray) \
+        if getattr(data, 'base', None) is not None and \
+           data.base is not None and isinstance(data, np.ndarray) \
            and isinstance(data.base, np.ndarray) and (not data.flags.c_contiguous):
             raise ValueError('Sliced data is not allowed for uint property')
         _check_call(_LIB.XGDMatrixSetUIntInfo(self.handle,

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2019 by Contributors
+// Copyright (c) 2014 by Contributors
 
 #include <xgboost/data.h>
 #include <xgboost/learner.h>
@@ -768,9 +768,9 @@ XGB_DLL int XGDMatrixSaveBinary(DMatrixHandle handle,
 }
 
 XGB_DLL int XGDMatrixSetFloatInfo(DMatrixHandle handle,
-                                  const char* field,
-                                  const xgboost::bst_float* info,
-                                  xgboost::bst_ulong len) {
+                          const char* field,
+                          const bst_float* info,
+                          xgboost::bst_ulong len) {
   API_BEGIN();
   CHECK_HANDLE();
   static_cast<std::shared_ptr<DMatrix>*>(handle)
@@ -778,38 +778,14 @@ XGB_DLL int XGDMatrixSetFloatInfo(DMatrixHandle handle,
   API_END();
 }
 
-XGB_DLL int XGDMatrixSetFloatInfoStrided(DMatrixHandle handle,
-                                         const char* field,
-                                         const xgboost::bst_float* info,
-                                         const xgboost::bst_ulong stride,
-                                         xgboost::bst_ulong len) {
-  API_BEGIN();
-  CHECK_HANDLE();
-  static_cast<std::shared_ptr<DMatrix>*>(handle)
-      ->get()->Info().SetInfo(field, info, kFloat32, stride, len);
-  API_END();
-}
-
 XGB_DLL int XGDMatrixSetUIntInfo(DMatrixHandle handle,
-                                 const char* field,
-                                 const unsigned* array,
-                                 xgboost::bst_ulong len) {
+                         const char* field,
+                         const unsigned* info,
+                         xgboost::bst_ulong len) {
   API_BEGIN();
   CHECK_HANDLE();
   static_cast<std::shared_ptr<DMatrix>*>(handle)
-      ->get()->Info().SetInfo(field, array, kUInt32, len);
-  API_END();
-}
-
-XGB_DLL int XGDMatrixSetUIntInfoStrided(DMatrixHandle handle,
-                                        const char* field,
-                                        const unsigned* array,
-                                        const xgboost::bst_ulong stride,
-                                        xgboost::bst_ulong len) {
-  API_BEGIN();
-  CHECK_HANDLE();
-  static_cast<std::shared_ptr<DMatrix>*>(handle)
-      ->get()->Info().SetInfo(field, array, kUInt32, stride, len);
+      ->get()->Info().SetInfo(field, info, kUInt32, len);
   API_END();
 }
 
@@ -888,8 +864,8 @@ XGB_DLL int XGDMatrixNumCol(const DMatrixHandle handle,
 
 // xgboost implementation
 XGB_DLL int XGBoosterCreate(const DMatrixHandle dmats[],
-                            xgboost::bst_ulong len,
-                            BoosterHandle *out) {
+                    xgboost::bst_ulong len,
+                    BoosterHandle *out) {
   API_BEGIN();
   std::vector<std::shared_ptr<DMatrix> > mats;
   for (xgboost::bst_ulong i = 0; i < len; ++i) {

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2015-2019 by Contributors
+ * Copyright 2015 by Contributors
  * \file data.cc
  */
 #include <xgboost/data.h>
@@ -100,76 +100,52 @@ inline bool MetaTryLoadFloatInfo(const std::string& fname,
 #define DISPATCH_CONST_PTR(dtype, old_ptr, cast_ptr, proc)              \
   switch (dtype) {                                                      \
     case kFloat32: {                                                    \
-      auto cast_ptr = reinterpret_cast<const float*>(old_ptr); proc;    \
-      break;                                                            \
+      auto cast_ptr = reinterpret_cast<const float*>(old_ptr); proc; break; \
     }                                                                   \
     case kDouble: {                                                     \
-      auto cast_ptr = reinterpret_cast<const double*>(old_ptr); proc;   \
-      break;                                                            \
+      auto cast_ptr = reinterpret_cast<const double*>(old_ptr); proc; break; \
     }                                                                   \
     case kUInt32: {                                                     \
-      auto cast_ptr = reinterpret_cast<const uint32_t*>(old_ptr); proc; \
-      break;                                                            \
+      auto cast_ptr = reinterpret_cast<const uint32_t*>(old_ptr); proc; break; \
     }                                                                   \
     case kUInt64: {                                                     \
-      auto cast_ptr = reinterpret_cast<const uint64_t*>(old_ptr); proc; \
-      break;                                                            \
+      auto cast_ptr = reinterpret_cast<const uint64_t*>(old_ptr); proc; break; \
     }                                                                   \
     default: LOG(FATAL) << "Unknown data type" << dtype;                \
   }                                                                     \
 
 
 void MetaInfo::SetInfo(const char* key, const void* dptr, DataType dtype, size_t num) {
-  this->SetInfo(key, dptr, dtype, 1, num);
-}
-
-template <typename IterIn, typename IterOut>
-void StridedCopy(IterIn in_beg, IterIn in_end, IterOut out_beg, size_t stride) {
-  if (stride != 1) {
-    IterOut out_iter = out_beg;
-    for (IterIn in_iter = in_beg; in_iter < in_end; in_iter += stride) {
-      *out_iter = *in_iter;
-      out_iter++;
-    }
-  } else {
-    // There can be builtin optimization in std::copy
-    std::copy(in_beg, in_end, out_beg);
-  }
-}
-
-void MetaInfo::SetInfo(
-    const char* key, const void* dptr, DataType dtype, size_t stride, size_t num) {
-  size_t view_length =
-      static_cast<size_t>(std::ceil(static_cast<bst_float>(num) / stride));
   if (!std::strcmp(key, "root_index")) {
-    root_index_.resize(view_length);
+    root_index_.resize(num);
     DISPATCH_CONST_PTR(dtype, dptr, cast_dptr,
-                       StridedCopy(cast_dptr, cast_dptr + num, root_index_.begin(), stride));
+                       std::copy(cast_dptr, cast_dptr + num, root_index_.begin()));
   } else if (!std::strcmp(key, "label")) {
     auto& labels = labels_.HostVector();
-    labels.resize(view_length);
+    labels.resize(num);
     DISPATCH_CONST_PTR(dtype, dptr, cast_dptr,
-                       StridedCopy(cast_dptr, cast_dptr + num, labels.begin(), stride));
+                       std::copy(cast_dptr, cast_dptr + num, labels.begin()));
   } else if (!std::strcmp(key, "weight")) {
     auto& weights = weights_.HostVector();
-    weights.resize(view_length);
+    weights.resize(num);
     DISPATCH_CONST_PTR(dtype, dptr, cast_dptr,
-                       StridedCopy(cast_dptr, cast_dptr + num, weights.begin(), stride));
+                       std::copy(cast_dptr, cast_dptr + num, weights.begin()));
   } else if (!std::strcmp(key, "base_margin")) {
     auto& base_margin = base_margin_.HostVector();
-    base_margin.resize(view_length);
+    base_margin.resize(num);
     DISPATCH_CONST_PTR(dtype, dptr, cast_dptr,
-                       StridedCopy(cast_dptr, cast_dptr + num, base_margin.begin(), stride));
+                       std::copy(cast_dptr, cast_dptr + num, base_margin.begin()));
   } else if (!std::strcmp(key, "group")) {
-    group_ptr_.resize(view_length+1);
+    group_ptr_.resize(num + 1);
     DISPATCH_CONST_PTR(dtype, dptr, cast_dptr,
-                       StridedCopy(cast_dptr, cast_dptr + num, group_ptr_.begin() + 1, stride));
+                       std::copy(cast_dptr, cast_dptr + num, group_ptr_.begin() + 1));
     group_ptr_[0] = 0;
     for (size_t i = 1; i < group_ptr_.size(); ++i) {
       group_ptr_[i] = group_ptr_[i - 1] + group_ptr_[i];
     }
   }
 }
+
 
 DMatrix* DMatrix::Load(const std::string& uri,
                        bool silent,

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -63,6 +63,14 @@ class TestBasic(unittest.TestCase):
         # assert they are the same
         assert np.sum(np.abs(preds2 - preds)) == 0
 
+    def test_np_view(self):
+        y = np.array([12, 34, 56], np.float32)[::2]
+        from_view = xgb.DMatrix([], label=y).get_label()
+        from_array = xgb.DMatrix([], label=y + 0).get_label()
+        print(from_view)
+        print(from_array)
+        assert (from_view == from_array).all()
+
     def test_record_results(self):
         dtrain = xgb.DMatrix(dpath + 'agaricus.txt.train')
         dtest = xgb.DMatrix(dpath + 'agaricus.txt.test')

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -63,12 +63,6 @@ class TestBasic(unittest.TestCase):
         # assert they are the same
         assert np.sum(np.abs(preds2 - preds)) == 0
 
-    def test_np_view(self):
-        y = np.array([12, 34, 56], np.float32)[::2]
-        from_view = xgb.DMatrix([], label=y).get_label()
-        from_array = xgb.DMatrix([], label=y + 0).get_label()
-        assert (from_view == from_array).all()
-
     def test_record_results(self):
         dtrain = xgb.DMatrix(dpath + 'agaricus.txt.train')
         dtest = xgb.DMatrix(dpath + 'agaricus.txt.test')

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -67,8 +67,7 @@ class TestBasic(unittest.TestCase):
         y = np.array([12, 34, 56], np.float32)[::2]
         from_view = xgb.DMatrix([], label=y).get_label()
         from_array = xgb.DMatrix([], label=y + 0).get_label()
-        print(from_view)
-        print(from_array)
+        assert (from_view.shape == from_array.shape)
         assert (from_view == from_array).all()
 
     def test_record_results(self):

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -64,9 +64,21 @@ class TestBasic(unittest.TestCase):
         assert np.sum(np.abs(preds2 - preds)) == 0
 
     def test_np_view(self):
+        # Sliced Float32 array
         y = np.array([12, 34, 56], np.float32)[::2]
         from_view = xgb.DMatrix([], label=y).get_label()
         from_array = xgb.DMatrix([], label=y + 0).get_label()
+        assert (from_view.shape == from_array.shape)
+        assert (from_view == from_array).all()
+
+        # Sliced UInt array
+        z = np.array([12, 34, 56], np.uint32)[::2]
+        dmat = xgb.DMatrix([])
+        dmat.set_uint_info('root_index', z)
+        from_view = dmat.get_uint_info('root_index')
+        dmat = xgb.DMatrix([])
+        dmat.set_uint_info('root_index', z + 0)
+        from_array = dmat.get_uint_info('root_index')
         assert (from_view.shape == from_array.shape)
         assert (from_view == from_array).all()
 


### PR DESCRIPTION
#4147 attempted to read sliced NumPy array directly into the C++ backend, but it relied on a NumPy internal variable (`data.base`) whose meaning we are not able to determine precisely. In particular, `len(data.base)` can sometimes mean the number of bytes in the NumPy array and other times mean the number of elements in the array.

Rather than dealing with undocumented NumPy internals, we'll take the approach of Microsoft/LightGBM#1210, i.e. always copy sliced data. This approach increases memory consumption slightly but the effect is not too bad. After all, the data matrix gets always copied when the input is a slice:
https://github.com/dmlc/xgboost/blob/c8c472f39aa08d5b8f180076a429f09317451cc7/python-package/xgboost/core.py#L487-L490

Closes #4163