### PR TITLE
add `gpu_hist` support to Spark

### DIFF
--- a/jvm-packages/create_jni.py
+++ b/jvm-packages/create_jni.py
@@ -19,7 +19,8 @@ CONFIG = {
     "USE_AZURE": "OFF",
     "USE_S3": "OFF",
 
-    "USE_CUDA": "OFF",
+    "USE_CUDA": "ON",
+    "USE_NCCL": "ON",
     "JVM_BINDINGS": "ON"
 }
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -264,9 +264,10 @@ object XGBoost extends Serializable {
 
     if (params.contains("tree_method")) {
       require(params("tree_method") == "hist" ||
+        params("tree_method") == "gpu_hist" ||
         params("tree_method") == "approx" ||
         params("tree_method") == "auto", "xgboost4j-spark only supports tree_method as 'hist'," +
-        " 'approx' and 'auto'")
+        " 'gpu_hist', 'approx' and 'auto'")
     }
     if (params.contains("train_test_ratio")) {
       logger.warn("train_test_ratio is deprecated since XGBoost 0.82, we recommend to explicitly" +

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/BoosterParams.scala
@@ -145,11 +145,13 @@ private[spark] trait BoosterParams extends Params {
   final def getAlpha: Double = $(alpha)
 
   /**
-   * The tree construction algorithm used in XGBoost. options: {'auto', 'exact', 'approx'}
+   * The tree construction algorithm used in XGBoost. options: {'auto', 'exact', 'approx', 'hist',
+   * 'gpu_hist', 'gpu_exact'}
    *  [default='auto']
    */
   final val treeMethod = new Param[String](this, "treeMethod",
-    "The tree construction algorithm used in XGBoost, options: {'auto', 'exact', 'approx', 'hist'}",
+    "The tree construction algorithm used in XGBoost, options: {'auto', 'exact', 'approx', " +
+    "'hist', 'gpu_hist', 'gpu_exact'}",
     (value: String) => BoosterParams.supportedTreeMethods.contains(value))
 
   final def getTreeMethod: String = $(treeMethod)
@@ -284,7 +286,7 @@ private[spark] object BoosterParams {
 
   val supportedBoosters = HashSet("gbtree", "gblinear", "dart")
 
-  val supportedTreeMethods = HashSet("auto", "exact", "approx", "hist")
+  val supportedTreeMethods = HashSet("auto", "exact", "approx", "hist", "gpu_hist", "gpu_exact")
 
   val supportedGrowthPolicies = HashSet("depthwise", "lossguide")
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -57,6 +57,14 @@ private[spark] trait GeneralParams extends Params {
   final def getNthread: Int = $(nthread)
 
   /**
+   * number of GPUs to use per worker: -1=use all GPUs. default 1
+   */
+  final val nGpus = new IntParam(this, "nGpus", "number of GPUs to use per worker",
+    ParamValidators.gtEq(-1))
+
+  final def getNGpus: Int = $(nGpus)
+
+  /**
    * whether to use external memory as cache. default: false
    */
   final val useExternalMemory = new BooleanParam(this, "useExternalMemory",
@@ -171,7 +179,7 @@ private[spark] trait GeneralParams extends Params {
 
   final def getSeed: Long = $(seed)
 
-  setDefault(numRound -> 1, numWorkers -> 1, nthread -> 1,
+  setDefault(numRound -> 1, numWorkers -> 1, nthread -> 1, nGpus -> 1,
     useExternalMemory -> false, silent -> 0, verbosity -> 1,
     customObj -> null, customEval -> null, missing -> Float.NaN,
     trackerConf -> TrackerConf(), seed -> 0, timeoutRequestWorkers -> 30 * 60 * 1000L,


### PR DESCRIPTION
Two parts to the PR:
* On the Spark/Scala side, it's mostly plumbing.
* On the C++/CUDA side, create the NCCL communicator for distributed mode, with support for different GPUs per node (e.g. a mixture of DGX-1s and DGX-2s). Partially based on #4095.

I've tested this on GCP with a 20-node Spark Standalone cluster, 1 T4 GPU per node.

@RAMitchell @canonizer @CodingCat @mt-jones