### PR TITLE
[jvm-packages] Fix early stop with xgboost4j-spark

### DIFF
--- a/doc/jvm/xgboost4j_spark_tutorial.rst
+++ b/doc/jvm/xgboost4j_spark_tutorial.rst
@@ -194,11 +194,11 @@ After we set XGBoostClassifier parameters and feature/label column, we can build
 Early Stopping
 ----------------
 
-Early stopping is a feature to prevent the unnecessary training iterations. By specifying ``num_early_stopping_rounds`` or directly call ``setNumEarlyStoppingRounds`` over a XGBoostClassifier or XGBoostRegressor, we can define number of rounds for the evaluation metric going to the unexpected direction to tolerate before stopping the training.
+Early stopping is a feature to prevent the unnecessary training iterations. By specifying ``num_early_stopping_rounds`` or directly call ``setNumEarlyStoppingRounds`` over a XGBoostClassifier or XGBoostRegressor, we can define number of rounds if the evaluation metric going away from the best iteration and early stop training iterations.
 
 In additional to ``num_early_stopping_rounds``, you also need to define ``maximize_evaluation_metrics`` or call ``setMaximizeEvaluationMetrics`` to specify whether you want to maximize or minimize the metrics in training.
 
-After specifying these two parameters, the training would stop when the metrics goes to the other direction against the one specified by ``maximize_evaluation_metrics`` for ``num_early_stopping_rounds`` iterations.
+For example, we need to maximize the evaluation metrics (set ``maximize_evaluation_metrics`` with true), and set ``num_early_stopping_rounds`` with 5. The evaluation metric of 10th iteration is the maximum one until now. In the following iterations, if there is no evaluation metric greater than the 10th iteration's (best one), the traning would be early stopped at 15th iteration.  
 
 Training with Evaluation Sets
 ----------------

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -209,12 +209,13 @@ public class XGBoost {
         // to determinate early stop.
         float score = metricsOut[metricsOut.length - 1];
         if (isMaximizeEvaluation(params)) {
-          if (score >= bestScore) {
+          // Update best score if the current score is better (no update when equal)
+          if (score > bestScore) {
             bestScore = score;
             bestIteration = iter;
           }
         } else {
-          if (score <= bestScore) {
+          if (score < bestScore) {
             bestScore = score;
             bestIteration = iter;
           }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -222,7 +222,7 @@ public class XGBoost {
         if (earlyStoppingRounds > 0) {
           if (shouldEarlyStop(earlyStoppingRounds, iter, bestIteration)) {
             Rabit.trackerPrint(String.format(
-              "early stopping after %d rounds away from the best iteration", earlyStoppingRounds));
+                    "early stopping after %d rounds away from the best iteration", earlyStoppingRounds));
             break;
           }
         }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -153,7 +153,7 @@ public class XGBoost {
     evalNames = names.toArray(new String[names.size()]);
     evalMats = mats.toArray(new DMatrix[mats.size()]);
     if (isMaximizeEvaluation(params)) {
-      bestScore = Float.MIN_VALUE;
+      bestScore = -Float.MAX_VALUE;
     } else {
       bestScore = Float.MAX_VALUE;
     }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -222,7 +222,8 @@ public class XGBoost {
         if (earlyStoppingRounds > 0) {
           if (shouldEarlyStop(earlyStoppingRounds, iter, bestIteration)) {
             Rabit.trackerPrint(String.format(
-                    "early stopping after %d rounds away from the best iteration", earlyStoppingRounds));
+                    "early stopping after %d rounds away from the best iteration",
+                        earlyStoppingRounds));
             break;
           }
         }


### PR DESCRIPTION
Two major take aways:
* Fix the early stop condition: training stops if the current iteration is ```earlyStoppingSteps``` away from the _best iteration_. 
* If there are multiple ```watches```, only the last one is used to determinate early stop.