### PR TITLE
In AUC and AUCPR metrics, detect whether weights are per-instance or per-group

### DIFF
--- a/src/metric/rank_metric.cc
+++ b/src/metric/rank_metric.cc
@@ -143,9 +143,9 @@ struct EvalAMS : public Metric {
 struct EvalAuc : public Metric {
  private:
   template <typename WeightPolicy>
-  bst_float _Eval(const HostDeviceVector<bst_float> &preds,
-                  const MetaInfo &info,
-                  bool distributed) {
+  bst_float Eval(const HostDeviceVector<bst_float> &preds,
+                 const MetaInfo &info,
+                 bool distributed) {
     CHECK_NE(info.labels_.Size(), 0U) << "label set cannot be empty";
     CHECK_EQ(preds.Size(), info.labels_.Size())
         << "label size predict size not match";
@@ -220,9 +220,9 @@ struct EvalAuc : public Metric {
     const bool is_ranking_task =
       !info.group_ptr_.empty() && info.weights_.Size() != info.num_row_;
     if (is_ranking_task) {
-      return _Eval<PerGroupWeightPolicy>(preds, info, distributed);
+      return Eval<PerGroupWeightPolicy>(preds, info, distributed);
     } else {
-      return _Eval<PerInstanceWeightPolicy>(preds, info, distributed);
+      return Eval<PerInstanceWeightPolicy>(preds, info, distributed);
     }
   }
   const char* Name() const override {
@@ -443,9 +443,9 @@ struct EvalAucPR : public Metric {
   // see https://doi.org/10.1371/journal.pone.0092209
  private:
   template <typename WeightPolicy>
-  bst_float _Eval(const HostDeviceVector<bst_float> &preds,
-                  const MetaInfo &info,
-                  bool distributed) {
+  bst_float Eval(const HostDeviceVector<bst_float> &preds,
+                 const MetaInfo &info,
+                 bool distributed) {
     CHECK_NE(info.labels_.Size(), 0U) << "label set cannot be empty";
     CHECK_EQ(preds.Size(), info.labels_.Size())
         << "label size predict size not match";
@@ -538,9 +538,9 @@ struct EvalAucPR : public Metric {
     const bool is_ranking_task =
       !info.group_ptr_.empty() && info.weights_.Size() != info.num_row_;
     if (is_ranking_task) {
-      return _Eval<PerGroupWeightPolicy>(preds, info, distributed);
+      return Eval<PerGroupWeightPolicy>(preds, info, distributed);
     } else {
-      return _Eval<PerInstanceWeightPolicy>(preds, info, distributed);
+      return Eval<PerInstanceWeightPolicy>(preds, info, distributed);
     }
   }
   const char *Name() const override { return "aucpr"; }

--- a/tests/python/test_ranking.py
+++ b/tests/python/test_ranking.py
@@ -1,0 +1,39 @@
+import numpy as np
+from scipy.sparse import csr_matrix
+import xgboost
+
+def test_ranking_with_weighted_data():
+    Xrow = np.array([1, 2, 6, 8, 11, 14, 16, 17])
+    Xcol = np.array([0, 0, 1, 1,  2,  2,  3,  3])
+    X = csr_matrix((np.ones(shape=8), (Xrow, Xcol)), shape=(20, 4))
+    y = np.array([0.0, 1.0, 1.0, 0.0, 0.0,
+                  0.0, 1.0, 0.0, 1.0, 0.0,
+                  0.0, 1.0, 0.0, 0.0, 1.0,
+                  0.0, 1.0, 1.0, 0.0, 0.0])
+    weights = np.array([1.0, 2.0, 3.0, 4.0])
+
+    group = np.array([5, 5, 5, 5], dtype=np.uint)
+    dtrain = xgboost.DMatrix(X, label=y, weight=weights)
+    dtrain.set_group(group)
+
+    params = {'eta': 1, 'tree_method': 'exact',
+              'objective': 'rank:pairwise', 'eval_metric': 'auc',
+              'max_depth': 1}
+    evals_result = {}
+    bst = xgboost.train(params, dtrain, 10, evals=[(dtrain, 'train')],
+                        evals_result=evals_result)
+    auc_rec = evals_result['train']['auc']
+    assert all(p <= q for p, q in zip(auc_rec, auc_rec[1:]))
+
+    for i in range(1, 11):
+        pred = bst.predict(dtrain, ntree_limit=i)
+        # is_sorted[i]: is i-th group correctly sorted by the ranking predictor?
+        is_sorted = []
+        for k in range(0, 20, 5):
+            ind = np.argsort(-pred[k:k+5])
+            z = y[ind+k]
+            is_sorted.append(all(i >= j for i, j in zip(z, z[1:])))
+        # Since we give weights 1, 2, 3, 4 to the four query groups,
+        # the ranking predictor will first try to correctly sort the last query group
+        # before correctly sorting other groups.
+        assert all(p <= q for p, q in zip(is_sorted, is_sorted[1:]))


### PR DESCRIPTION
# Overview
This is a proposed bugfix based on PR https://github.com/dmlc/xgboost/pull/3379 originally submitted by @ngoyal2707, which intends to change how the instance weight vector is defined.

For a training dataset of K groups and N total training examples/instances, @ngoyal2707's original PR requires a weight vector of length K. That is, each group has its own weight, and the same weight is shared by all instances in the same group. While this scheme of specifying group weights works without issues in isolation, it however does conflicts with the computation of certain ranking metrics (e.g. `auc` and `aucpr`) in https://github.com/dmlc/xgboost/blob/master/src/metric/rank_metric.cc, which expects the weights to be populated for **every training example**. 

## Example
To demonstrate the bug, we can use the following example Python code:
```python
import numpy as np
import xgboost as xgb

# some mock training data with 20 training examples and 10 features, divided into 4 groups
# each group has 5 training examples.
X = np.random.rand(20, 10)
y = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0])
weights = np.array([1.0, 2.0, 3.0, 4.0])

# construct DMatrix
group = np.array([5, 5, 5, 5], dtype=np.uint)
dmatrix = xgb.DMatrix(X, label=y, weight=weights)
dmatrix.set_group(group)

train_params = {
    "learning_rate": 0.1,
    "min_child_weight": 1,
    "tree_method": "exact",
    "objective": "rank:ndcg",
    "nthread": -1
}

xgb.train(train_params, dmatrix, 10, evals=[(dmatrix, 'train')])
```
The above code will run without issues. But if we add a ranking metric that also uses weights to the `eval_metric` parameter, like:
```python
train_params = {
    "learning_rate": 0.1,
    "min_child_weight": 1,
    "tree_method": "exact",
    "objective": "rank:ndcg",
    "nthread": -1,
    "eval_metric": "auc"
}

xgb.train(train_params, dmatrix, 10, evals=[(dmatrix, 'train')])
```
The `xgb.train` function call will fail with the following exception (most likely due to the underlying C++ code accessing memory that is out-of-bound):


> XGBoostError: b'[12:31:37] src/metric/rank_metric.cc:137: Check failed: !auc_error AUC: the dataset only contains pos or neg samples\n\nStack trace returned 7 entries:\n[bt] (0) 0   libxgboost.dylib                    0x0000001a12bff100 dmlc::StackTrace(unsigned long) + 464\n[bt] (1) 1   libxgboost.dylib                    0x0000001a12bfede4 dmlc::LogMessageFatal::~LogMessageFatal() + 52\n[bt] (2) 2   libxgboost.dylib                    0x0000001a12c6fea6 xgboost::metric::EvalAuc::Eval(std::__1::vector<float, std::__1::allocator<float> > const&, xgboost::MetaInfo const&, bool) const + 1846\n[bt] (3) 3   libxgboost.dylib                    0x0000001a12bfbe1b xgboost::LearnerImpl::EvalOneIter(int, std::__1::vector<xgboost::DMatrix*, std::__1::allocator<xgboost::DMatrix*> > const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) + 1275\n[bt] (4) 4   libxgboost.dylib                    0x0000001a12c1773d XGBoosterEvalOneIter + 717\n[bt] (5) 5   libffi.6.dylib                      0x000000010cdfb884 ffi_call_unix64 + 76\n[bt] (6) 6   ???                                 0x00007ffee4554950 0x0 + 140732729215312\n\n'

## Proposed fix
To resolve the issue demonstrated above, this PR proposes to change the calculation of ranking objective in `rank_obj.cc` such that the utilization of weights is aligned with the implementation in `rank_metric.cc`. 

Note that the alternative is to change how the weights are accessed in `rank_metric.cc`, such that when training a ranking model, the calculation of AUC and AUC-PR metrics assumes that the weights are provided on a per-group basis. However, using a per-group weighting scheme does reduce the overall flexibility of specifying weights. 

# ToDo
Update the documentation in https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.DMatrix.set_weight so that it reflects the changes.