### PR TITLE
Update build doc: PyPI wheel now support multi-GPU

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -13,7 +13,7 @@ Installation Guide
     #   * xgboost-{version}-py2.py3-none-win_amd64.whl
     pip3 install xgboost
 
-  * The binary wheel will support GPU algorithms (`gpu_exact`, `gpu_hist`) on machines with NVIDIA GPUs. **However, it will not support multi-GPU training; only single GPU will be used.** To enable multi-GPU training, download and install the binary wheel from `this page <https://s3-us-west-2.amazonaws.com/xgboost-wheels/list.html>`_.
+  * The binary wheel will support GPU algorithms (`gpu_exact`, `gpu_hist`) on machines with NVIDIA GPUs. Please note that **training with multiple GPUs is only supported for Linux platform**. See :doc:`gpu/index`.
   * Currently, we provide binary wheels for 64-bit Linux and Windows.
 
 ****************************
@@ -70,19 +70,21 @@ Our goal is to build the shared library:
 The minimal building requirement is
 
 - A recent C++ compiler supporting C++11 (g++-4.8 or higher)
-
-We can edit ``make/config.mk`` to change the compile options, and then build by
-``make``. If everything goes well, we can go to the specific language installation section.
+- CMake 3.2 or higher
 
 Building on Ubuntu/Debian
 =========================
 
-On Ubuntu, one builds XGBoost by running
+On Ubuntu, one builds XGBoost by running CMake:
 
 .. code-block:: bash
 
   git clone --recursive https://github.com/dmlc/xgboost
-  cd xgboost; make -j4
+  cd xgboost
+  mkdir build
+  cd build
+  cmake ..
+  make -j4
 
 Building on OSX
 ===============
@@ -90,11 +92,11 @@ Building on OSX
 Install with pip: simple method
 --------------------------------
 
-First, obtain ``gcc-7`` with Homebrew (https://brew.sh/) to enable multi-threading (i.e. using multiple CPU threads for training). The default Apple Clang compiler does not support OpenMP, so using the default compiler would have disabled multi-threading.
+First, obtain ``gcc-8`` with Homebrew (https://brew.sh/) to enable multi-threading (i.e. using multiple CPU threads for training). The default Apple Clang compiler does not support OpenMP, so using the default compiler would have disabled multi-threading.
 
 .. code-block:: bash
 
-  brew install gcc@7
+  brew install gcc@8
 
 Then install XGBoost with ``pip``:
 
@@ -107,11 +109,11 @@ You might need to run the command with ``--user`` flag if you run into permissio
 Build from the source code - advanced method
 --------------------------------------------
 
-Obtain ``gcc-7`` from Homebrew:
+Obtain ``gcc-8`` from Homebrew:
 
 .. code-block:: bash
 
-  brew install gcc@7
+  brew install gcc@8
 
 Now clone the repository:
 
@@ -119,13 +121,13 @@ Now clone the repository:
 
   git clone --recursive https://github.com/dmlc/xgboost
 
-Create the ``build/`` directory and invoke CMake. Make sure to add ``CC=gcc-7 CXX=g++-7`` so that Homebrew GCC is selected. After invoking CMake, you can build XGBoost with ``make``:
+Create the ``build/`` directory and invoke CMake. Make sure to add ``CC=gcc-8 CXX=g++-8`` so that Homebrew GCC is selected. After invoking CMake, you can build XGBoost with ``make``:
 
 .. code-block:: bash
 
   mkdir build
   cd build
-  CC=gcc-7 CXX=g++-7 cmake ..
+  CC=gcc-8 CXX=g++-8 cmake ..
   make -j4
 
 You may now continue to `Python Package Installation`_.
@@ -141,6 +143,20 @@ We recommend you use `Git for Windows <https://git-for-windows.github.io/>`_, as
   git submodule update
 
 XGBoost support compilation with Microsoft Visual Studio and MinGW.
+
+Compile XGBoost with Microsoft Visual Studio
+--------------------------------------------
+To build with Visual Studio, we will need CMake. Make sure to install a recent version of CMake. Then run the following from the root of the XGBoost directory:
+
+.. code-block:: bash
+
+  mkdir build
+  cd build
+  cmake .. -G"Visual Studio 14 2015 Win64"
+
+This specifies an out of source build using the Visual Studio 64 bit generator. (Change the ``-G`` option appropriately if you have a different version of Visual Studio installed.) Open the ``.sln`` file in the build directory and build with Visual Studio.
+
+After the build process successfully ends, you will find a ``xgboost.dll`` library file inside ``./lib/`` folder.
 
 Compile XGBoost using MinGW
 ---------------------------
@@ -162,22 +178,6 @@ To build with MinGW, type:
   cp make/mingw64.mk config.mk; make -j4
 
 See :ref:`mingw_python` for buildilng XGBoost for Python.
-
-Compile XGBoost with Microsoft Visual Studio
---------------------------------------------
-To build with Visual Studio, we will need CMake. Make sure to install a recent version of CMake. Then run the following from the root of the XGBoost directory:
-
-.. code-block:: bash
-
-  mkdir build
-  cd build
-  cmake .. -G"Visual Studio 12 2013 Win64"
-
-This specifies an out of source build using the MSVC 12 64 bit generator. Open the ``.sln`` file in the build directory and build with Visual Studio. To use the Python module you can copy ``xgboost.dll`` into ``python-package/xgboost``.
-
-After the build process successfully ends, you will find a ``xgboost.dll`` library file inside ``./lib/`` folder, copy this file to the the API package folder like ``python-package/xgboost`` if you are using Python API.
-
-Unofficial windows binaries and instructions on how to use them are hosted on `Guido Tapia's blog <http://www.picnet.com.au/blogs/guido/post/2016/09/22/xgboost-windows-x64-binaries-for-download/>`_.
 
 .. _build_gpu_support:
 
@@ -207,13 +207,7 @@ From the command line on Linux starting from the XGBoost directory:
     cmake .. -DUSE_CUDA=ON -DUSE_NCCL=ON -DNCCL_ROOT=/path/to/nccl2
     make -j4
 
-On Windows, see what options for generators you have for CMake, and choose one with ``[arch]`` replaced with Win64:
-
-.. code-block:: bash
-
-  cmake -help
-
-Then run CMake as follows:
+On Windows, run CMake as follows:
 
 .. code-block:: bash
 
@@ -221,13 +215,15 @@ Then run CMake as follows:
   cd build
   cmake .. -G"Visual Studio 14 2015 Win64" -DUSE_CUDA=ON
 
+(Change the ``-G`` option appropriately if you have a different version of Visual Studio installed.)
+
 .. note:: Visual Studio 2017 Win64 Generator may not work
 
   Choosing the Visual Studio 2017 generator may cause compilation failure. When it happens, specify the 2015 compiler by adding the ``-T`` option:
 
   .. code-block:: bash
 
-    make .. -G"Visual Studio 15 2017 Win64" -T v140,cuda=8.0 -DR_LIB=ON -DUSE_CUDA=ON
+    make .. -G"Visual Studio 15 2017 Win64" -T v140,cuda=8.0 -DUSE_CUDA=ON
 
 To speed up compilation, the compute version specific to your GPU could be passed to cmake as, e.g., ``-DGPU_COMPUTE_VER=50``.
 The above cmake configuration run will create an ``xgboost.sln`` solution file in the build directory. Build this solution in release mode as a x64 build, either from Visual studio or from command line:
@@ -241,14 +237,14 @@ To speed up compilation, run multiple jobs in parallel by appending option ``-- 
 Customized Building
 ===================
 
-The configuration file ``config.mk`` modifies several compilation flags:
+We recommend the use of CMake for most use cases. See the full range of building options in CMakeLists.txt.
+
+Alternatively, you may use Makefile. The Makefile uses a configuration file ``config.mk``, which lets you modify several compilation flags:
 - Whether to enable support for various distributed filesystems such as HDFS and Amazon S3
 - Which compiler to use
 - And some more
 
 To customize, first copy ``make/config.mk`` to the project root and then modify the copy.
-
-Alternatively, use CMake.
 
 Python Package Installation
 ===========================
@@ -275,9 +271,9 @@ package manager, e.g. in Debian use
   If you recompiled XGBoost, then you need to reinstall it again to make the new library take effect.
 
 2. Only set the environment variable ``PYTHONPATH`` to tell Python where to find
-   the library. For example, assume we cloned `xgboost` on the home directory
-   `~`. then we can added the following line in `~/.bashrc`.
-   This option is **recommended for developers** who change the code frequently. The changes will be immediately reflected once you pulled the code and rebuild the project (no need to call ``setup`` again)
+   the library. For example, assume we cloned ``xgboost`` on the home directory
+   ``~``. then we can added the following line in ``~/.bashrc``.
+   This option is **recommended for developers** who change the code frequently. The changes will be immediately reflected once you pulled the code and rebuild the project (no need to call ``setup`` again).
 
 .. code-block:: bash
 
@@ -289,30 +285,22 @@ package manager, e.g. in Debian use
 
   cd python-package; python setup.py develop --user
 
-4. If you are installing the latest XGBoost version which requires compilation, add MinGW to the system PATH:
-
-.. code-block:: bash
-
-    import os
-    os.environ['PATH'] = os.environ['PATH'] + ';C:\\Program Files\\mingw-w64\\x86_64-5.3.0-posix-seh-rt_v4-rev0\\mingw64\\bin'
-
 .. _mingw_python:
 
-Building XGBoost library for Python for Windows with MinGW-w64
---------------------------------------------------------------
+Building XGBoost library for Python for Windows with MinGW-w64 (Advanced)
+-------------------------------------------------------------------------
 
-Windows versions of Python are built with Microsoft Visual Studio. Usually Python binary modules are built with the same compiler the interpreter is built with, raising several potential concerns.
+Windows versions of Python are built with Microsoft Visual Studio. Usually Python binary modules are built with the same compiler the interpreter is built with. However, you may not be able to use Visual Studio, for following reasons:
 
-1. VS is proprietary and commercial software. Microsoft provides a freeware "Community" edition, but its licensing terms are unsuitable for many organizations.
-2. Visual Studio contains telemetry, as documented in `Microsoft Visual Studio Licensing Terms <https://visualstudio.microsoft.com/license-terms/mt736442/>`_. It `has been inserting telemetry <https://old.reddit.com/r/cpp/comments/4ibauu/visual_studio_adding_telemetry_function_calls_to/>`_ into apps for some time. In order to download VS distribution from MS servers one has to run the application containing telemetry. These facts have raised privacy and security concerns among some users and system administrators. Running software with telemetry may be against the policy of your organization.
-3. g++ usually generates faster code on ``-O3``.
+1. VS is proprietary and commercial software. Microsoft provides a freeware "Community" edition, but its licensing terms impose restrictions as to where and how it can be used.
+2. Visual Studio contains telemetry, as documented in `Microsoft Visual Studio Licensing Terms <https://visualstudio.microsoft.com/license-terms/mt736442/>`_. Running software with telemetry may be against the policy of your organization.
 
-So you may want to build XGBoost with g++ own your own risk. This opens a can of worms, because MSVC uses Microsoft runtime and MinGW-w64 uses own runtime, and the runtimes have different incompatible memory allocators. But in fact this setup is usable if you know how to deal with it. Here is some experience.
+So you may want to build XGBoost with GCC own your own risk. This presents some difficulties because MSVC uses Microsoft runtime and MinGW-w64 uses own runtime, and the runtimes have different incompatible memory allocators. But in fact this setup is usable if you know how to deal with it. Here is some experience.
 
 1. The Python interpreter will crash on exit if XGBoost was used. This is usually not a big issue.
 2. ``-O3`` is OK.
 3. ``-mtune=native`` is also OK.
-4. Don't use ``-march=native`` gcc flag. Using it causes the Python interpreter to crash if the dll was actually used.
+4. Don't use ``-march=native`` gcc flag. Using it causes the Python interpreter to crash if the DLL was actually used.
 5. You may need to provide the lib with the runtime libs. If ``mingw32/bin`` is not in ``PATH``, build a wheel (``python setup.py bdist_wheel``), open it with an archiver and put the needed dlls to the directory where ``xgboost.dll`` is situated. Then you can install the wheel with ``pip``.
 
 R Package Installation
@@ -355,7 +343,7 @@ In this case, just start R as you would normally do and run the following:
   setwd('wherever/you/cloned/it/xgboost/R-package/')
   install.packages('.', repos = NULL, type="source")
 
-The package could also be built and installed with cmake (and Visual C++ 2015 on Windows) using instructions from the next section, but without GPU support (omit the ``-DUSE_CUDA=ON`` cmake parameter).
+The package could also be built and installed with CMake (and Visual C++ 2015 on Windows) using instructions from :ref:`r_gpu_support`, but without GPU support (omit the ``-DUSE_CUDA=ON`` cmake parameter).
 
 If all fails, try `Building the shared library`_ to see whether a problem is specific to R package or not.
 
@@ -364,11 +352,11 @@ If all fails, try `Building the shared library`_ to see whether a problem is spe
 Installing R package on Mac OSX with multi-threading
 ----------------------------------------------------
 
-First, obtain ``gcc-7`` with Homebrew (https://brew.sh/) to enable multi-threading (i.e. using multiple CPU threads for training). The default Apple Clang compiler does not support OpenMP, so using the default compiler would have disabled multi-threading.
+First, obtain ``gcc-8`` with Homebrew (https://brew.sh/) to enable multi-threading (i.e. using multiple CPU threads for training). The default Apple Clang compiler does not support OpenMP, so using the default compiler would have disabled multi-threading.
 
 .. code-block:: bash
 
-  brew install gcc@7
+  brew install gcc@8
 
 Now, clone the repository:
 
@@ -376,7 +364,7 @@ Now, clone the repository:
 
   git clone --recursive https://github.com/dmlc/xgboost
 
-Create the ``build/`` directory and invoke CMake with option ``R_LIB=ON``. Make sure to add ``CC=gcc-7 CXX=g++-7`` so that Homebrew GCC is selected. After invoking CMake, you can install the R package by running ``make`` and ``make install``:
+Create the ``build/`` directory and invoke CMake with option ``R_LIB=ON``. Make sure to add ``CC=gcc-8 CXX=g++-8`` so that Homebrew GCC is selected. After invoking CMake, you can install the R package by running ``make`` and ``make install``:
 
 .. code-block:: bash
 
@@ -385,6 +373,8 @@ Create the ``build/`` directory and invoke CMake with option ``R_LIB=ON``. Make 
   CC=gcc-7 CXX=g++-7 cmake .. -DR_LIB=ON
   make -j4
   make install
+
+.. _r_gpu_support:
 
 Installing R package with GPU support
 -------------------------------------
@@ -401,7 +391,7 @@ On Linux, starting from the XGBoost directory type:
   make install -j
 
 When default target is used, an R package shared library would be built in the ``build`` area.
-The ``install`` target, in addition, assembles the package files with this shared library under ``build/R-package``, and runs ``R CMD INSTALL``.
+The ``install`` target, in addition, assembles the package files with this shared library under ``build/R-package`` and runs ``R CMD INSTALL``.
 
 On Windows, CMake with Visual C++ Build Tools (or Visual Studio) has to be used to build an R package with GPU support. Rtools must also be installed (perhaps, some other MinGW distributions with ``gendef.exe`` and ``dlltool.exe`` would work, but that was not tested).
 
@@ -412,8 +402,8 @@ On Windows, CMake with Visual C++ Build Tools (or Visual Studio) has to be used 
   cmake .. -G"Visual Studio 14 2015 Win64" -DUSE_CUDA=ON -DR_LIB=ON
   cmake --build . --target install --config Release
 
-When ``--target xgboost`` is used, an R package dll would be built under ``build/Release``.
-The ``--target install``, in addition, assembles the package files with this dll under ``build/R-package``, and runs ``R CMD INSTALL``.
+When ``--target xgboost`` is used, an R package DLL would be built under ``build/Release``.
+The ``--target install``, in addition, assembles the package files with this dll under ``build/R-package`` and runs ``R CMD INSTALL``.
 
 If cmake can't find your R during the configuration step, you might provide the location of its executable to cmake like this: ``-DLIBR_EXECUTABLE="C:/Program Files/R/R-3.4.1/bin/x64/R.exe"``.
 


### PR DESCRIPTION
* Multi-GPU training will work right away after running `pip install xgboost`.
* Use GCC 8 in Homebrew.
* Recommend use of CMake over Makefile.