### PR TITLE
[jvm-packages] Fix "Rabit returns with exit code 3" problem

### DIFF
--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/rabit/handler/RabitTrackerHandler.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/rabit/handler/RabitTrackerHandler.scala
@@ -175,7 +175,6 @@ private[scala] class RabitTrackerHandler(numWorkers: Int)
 
       if (shutdownWorkers.size == numWorkers) {
         promisedShutdownWorkers.success(shutdownWorkers.size)
-        context.stop(self)
       }
 
     case WorkerRecover(prevRank, worldSize, jobId) =>


### PR DESCRIPTION
This PR addresses the following issues:

- https://github.com/dmlc/xgboost/issues/4054
- https://github.com/salesforce/TransmogrifAI/issues/181
- https://github.com/dmlc/xgboost/issues/3418

closes #4054 #3418

It looks like there is a race condition between actors and sometimes the Tracker actor might get shut down before its supervisor is notified about completing the job.
There is no need to kill the actor explicitly after all workers are done as RabitTracker will shutdown the system anyways after hearing back from the actor: https://github.com/dmlc/xgboost/blob/master/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/rabit/RabitTracker.scala#L159