### PR TITLE
[xgboost4j-spark] Allow set the parameter "maxLeaves".

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -113,6 +113,8 @@ class XGBoostClassifier (
 
   def setMaxBins(value: Int): this.type = set(maxBins, value)
 
+  def setMaxLeaves(value: Int): this.type = set(maxLeaves, value)
+
   def setSketchEps(value: Double): this.type = set(sketchEps, value)
 
   def setScalePosWeight(value: Double): this.type = set(scalePosWeight, value)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -113,6 +113,8 @@ class XGBoostRegressor (
 
   def setMaxBins(value: Int): this.type = set(maxBins, value)
 
+  def setMaxLeaves(value: Int): this.type = set(maxLeaves, value)
+
   def setSketchEps(value: Double): this.type = set(sketchEps, value)
 
   def setScalePosWeight(value: Double): this.type = set(scalePosWeight, value)


### PR DESCRIPTION
When tree_method="hist" and grow_policy="lossguide", max_leaves is needed.