### PR TITLE
Downgrade Jenkins agent to CUDA 9.2, to fix broken NCCL2 installation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ def dockerRun = 'tests/ci_build/ci_build.sh'
 def utils
 
 def buildMatrix = [
-    [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": true,  "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "10.1", "multiGpu": true],
+    [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": true,  "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "9.2", "multiGpu": true],
     [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": true,  "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "9.2" ],
     [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": true,  "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "8.0" ],
     [ "enabled": true,  "os" : "linux", "withGpu": true, "withNccl": false, "withOmp": true, "pythonVersion": "2.7", "cudaVersion": "8.0" ],


### PR DESCRIPTION
See https://xgboost-ci.net/blue/organizations/jenkins/xgboost/detail/PR-4231/2/pipeline/51.

The current scripts downloads NCCL2 from URL `https://developer.download.nvidia.com/compute/redist/nccl/v2.2/nccl_2.2.13-1%2Bcuda${CUDA_VERSION}_x86_64.txz`. This URL works fine when `CUDA_VERSION` is 8.x or 9.x but fails for 10.1.

~~TODO. Either find a link that's not behind a login wall, OR upload installers to a private S3 bucket.~~
EDIT. I think it would be best if we place NCCL2 installers inside the worker image. This way, we don't generate unnecessary HTTP traffic.