### PR TITLE
Fix errors on R-devel

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: xgboost
 Type: Package
 Title: Extreme Gradient Boosting
-Version: 0.81.0.1
-Date: 2018-08-13
+Version: 0.82.0.1
+Date: 2019-03-11
 Authors@R: c(
   person("Tianqi", "Chen", role = c("aut"),
          email = "tianqi.tchen@gmail.com"),

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -182,7 +182,7 @@ test_that("xgb.cv works", {
   expect_is(cv, 'xgb.cv.synchronous')
   expect_false(is.null(cv$evaluation_log))
   expect_lt(cv$evaluation_log[, min(test_error_mean)], 0.03)
-  expect_lt(cv$evaluation_log[, min(test_error_std)], 0.004)
+  expect_lt(cv$evaluation_log[, min(test_error_std)], 0.008)
   expect_equal(cv$niter, 2)
   expect_false(is.null(cv$folds) && is.list(cv$folds))
   expect_length(cv$folds, 5)

--- a/R-package/tests/testthat/test_callbacks.R
+++ b/R-package/tests/testthat/test_callbacks.R
@@ -282,7 +282,7 @@ test_that("prediction in xgb.cv works for gblinear too", {
 })
 
 test_that("prediction in early-stopping xgb.cv works", {
-  set.seed(1)
+  set.seed(11)
   expect_output(
     cv <- xgb.cv(param, dtrain, nfold = 5, eta = 0.1, nrounds = 20,
                  early_stopping_rounds = 5, maximize = FALSE, prediction = TRUE)

--- a/src/common/transform.h
+++ b/src/common/transform.h
@@ -171,8 +171,8 @@ class Transform {
     /*! \brief Range object specifying parallel threads index range. */
     Range range_;
     /*! \brief Whether resharding for vectors is required. */
-    GPUDistribution distribution_;
     bool reshard_;
+    GPUDistribution distribution_;
   };
 
  public:


### PR DESCRIPTION
R-devel recently changed the RNG behavior, and that breaks R unittests. 

This PR

- Bumps up the version number of the R-package
- Fix the unittest for both the latest R release and R-devel
- Fix a `-Wreorder` warning.

I have already submitted the R-package 0.82 to CRAN with these fixes.