### PR TITLE
Fix multi-GPU test failures

### DIFF
--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -201,10 +201,11 @@ class GPUCoordinateUpdater : public LinearUpdater {
     monitor_.Stop("LazyInitShards");
 
     monitor_.Start("UpdateGpair");
+    auto &in_gpair_host = in_gpair->ConstHostVector();
     // Update gpair
     dh::ExecuteIndexShards(&shards_, [&](int idx, std::unique_ptr<DeviceShard>& shard) {
       if (!shard->IsEmpty()) {
-        shard->UpdateGpair(in_gpair->ConstHostVector(), model->param);
+        shard->UpdateGpair(in_gpair_host, model->param);
       }
     });
     monitor_.Stop("UpdateGpair");


### PR DESCRIPTION
I believe the issue was that calls to ->ConstHostVector() can modify the underlying vector, allocating or de allocating memory. Multiple threads were calling this in parallel resulting in strange memory errors.

@trivialfis I used ordinary gdb to find this as cuda-gdb seems to just crash.