### PR TITLE
[jvm-packages] Allow supression of Rabit output in Booster::train in xgboost4j

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -239,7 +239,7 @@ public class XGBoost {
     return booster;
   }
 
-  static Integer tryGetIntFromObject(Object o) {
+  private static Integer tryGetIntFromObject(Object o) {
     if (o instanceof Integer) {
       return (int)o;
     } else if (o instanceof String) {
@@ -253,7 +253,7 @@ public class XGBoost {
     }
   }
 
-  static boolean shouldPrint(Map<String, Object> params, int iter) {
+  private static boolean shouldPrint(Map<String, Object> params, int iter) {
     Object silent = params.get("silent");
     Integer silentInt = tryGetIntFromObject(silent);
     if (silent != null) {

--- a/jvm-packages/xgboost4j/src/test/scala/ml/dmlc/xgboost4j/scala/ScalaBoosterImplSuite.scala
+++ b/jvm-packages/xgboost4j/src/test/scala/ml/dmlc/xgboost4j/scala/ScalaBoosterImplSuite.scala
@@ -139,7 +139,7 @@ class ScalaBoosterImplSuite extends FunSuite {
 
   test("cross validation") {
     val trainMat = new DMatrix("../../demo/data/agaricus.txt.train")
-    val params = List("eta" -> "1.0", "max_depth" -> "3", "slient" -> "1", "nthread" -> "6",
+    val params = List("eta" -> "1.0", "max_depth" -> "3", "silent" -> "1", "nthread" -> "6",
       "objective" -> "binary:logistic", "gamma" -> "1.0", "eval_metric" -> "error").toMap
     val round = 2
     val nfold = 5


### PR DESCRIPTION
There is currently no option to suppress the output from Rabit in xgboost4j. Redirecting `System.out` temporarilly does not help either (since the print happens in native code). This can result in a large amount of printing to the screen, resulting in other important messages being lost.

This PR changes the behavior to the following:
* Setting "silent" in this map to "true", "True", a non-zero integer, or a string that can be parsed to such an int will prevent printing.
* Setting "verbose_eval" to "False" or "false" will prevent printing.
* Setting "verbose_eval" to an int (or a String parseable to an int) `n` will result in printing every n steps, or no printing is `n` is zero.
    
This is to match the python behaviour described here: https://www.kaggle.com/c/rossmann-store-sales/discussion/17499
