### PR TITLE
[jvm-packages] add configuration flag to control whether to cache transformed training set

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -77,6 +77,12 @@ private[spark] trait LearningTaskParams extends Params {
   final def getTrainTestRatio: Double = $(trainTestRatio)
 
   /**
+   * whether caching training data
+   */
+  final val cacheTrainingSet = new BooleanParam(this, "cacheTrainingSet",
+    "whether caching training data")
+
+  /**
    * If non-zero, the training will be stopped after a specified number
    * of consecutive increases in any evaluation metric.
    */
@@ -95,7 +101,7 @@ private[spark] trait LearningTaskParams extends Params {
   final def getMaximizeEvaluationMetrics: Boolean = $(maximizeEvaluationMetrics)
 
   setDefault(objective -> "reg:squarederror", baseScore -> 0.5,
-    trainTestRatio -> 1.0, numEarlyStoppingRounds -> 0)
+    trainTestRatio -> 1.0, numEarlyStoppingRounds -> 0, cacheTrainingSet -> false)
 }
 
 private[spark] object LearningTaskParams {


### PR DESCRIPTION
the current behavior of xgboost-spark is to avoid caching training data for the user. However, with the checkpoint feature, user has to repartition data for every checkpoint construction which potentially prolongs the overall execution time (depends on the cost of repartition and memory usage)

this PR adds a flag to grant the user with the permission to control whether to cache repartitioned data