### PR TITLE
- make test fails to find testxgboost, if a build directory is created

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ if(GOOGLE_TEST)
       $<TARGET_OBJECTS:objxgboost>)
   endif ()
 
-  set_output_directory(testxgboost ${PROJECT_SOURCE_DIR})
+  set_output_directory(testxgboost ${CMAKE_BINARY_DIR})
   target_include_directories(testxgboost
     PRIVATE ${GTEST_INCLUDE_DIRS})
   target_link_libraries(testxgboost ${GTEST_LIBRARIES} ${LINK_LIBRARIES})

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -166,7 +166,7 @@ environment variable:
 
   .. code-block:: bash
 
-    ASAN_OPTIONS=protect_shadow_gap=0 ../testxgboost
+    ASAN_OPTIONS=protect_shadow_gap=0 ${BUILD_DIR}/testxgboost
 
 For details, please consult `official documentation <https://github.com/google/sanitizers/wiki>`_ for sanitizers.
 

--- a/src/common/host_device_vector.cc
+++ b/src/common/host_device_vector.cc
@@ -19,8 +19,8 @@ struct HostDeviceVectorImpl {
   HostDeviceVectorImpl(std::initializer_list<T> init) : data_h_(init) {}
   explicit HostDeviceVectorImpl(std::vector<T>  init) : data_h_(std::move(init)){}
 
-  void swap(HostDeviceVectorImpl &other) {
-          data_h_.swap(other.data_h_);
+  void Swap(HostDeviceVectorImpl &other) {
+     data_h_.swap(other.data_h_);
   }
 
   std::vector<T>& Vec() { return data_h_; }
@@ -66,7 +66,7 @@ HostDeviceVector<T>& HostDeviceVector<T>::operator=(const HostDeviceVector<T>& o
   }
 
   HostDeviceVectorImpl<T> newInstance(*other.impl_);
-  newInstance.swap(*impl_);
+  newInstance.Swap(*impl_);
 
   return *this;
 }
@@ -79,7 +79,8 @@ GPUSet HostDeviceVector<T>::Devices() const { return GPUSet::Empty(); }
 
 template <typename T>
 const GPUDistribution& HostDeviceVector<T>::Distribution() const {
-  return GPUDistribution();
+  static GPUDistribution dummyInstance;
+  return dummyInstance;
 }
 
 template <typename T>

--- a/src/common/host_device_vector.cc
+++ b/src/common/host_device_vector.cc
@@ -17,7 +17,7 @@ template <typename T>
 struct HostDeviceVectorImpl {
   explicit HostDeviceVectorImpl(size_t size, T v) : data_h_(size, v) {}
   HostDeviceVectorImpl(std::initializer_list<T> init) : data_h_(init) {}
-  explicit HostDeviceVectorImpl(std::vector<T>  init) : data_h_(std::move(init)){}
+  explicit HostDeviceVectorImpl(std::vector<T>  init) : data_h_(std::move(init)) {}
 
   void Swap(HostDeviceVectorImpl &other) {
      data_h_.swap(other.data_h_);

--- a/src/common/host_device_vector.cu
+++ b/src/common/host_device_vector.cu
@@ -171,7 +171,7 @@ struct HostDeviceVectorImpl {
     HostDeviceVectorImpl<T>* vec_;
   };
 
-  HostDeviceVectorImpl(size_t size, T v, GPUDistribution distribution)
+  HostDeviceVectorImpl(size_t size, T v, const GPUDistribution &distribution)
     : distribution_(distribution), perm_h_(distribution.IsEmpty()), size_d_(0) {
     if (!distribution_.IsEmpty()) {
       size_d_ = size;
@@ -194,7 +194,7 @@ struct HostDeviceVectorImpl {
 
   // Initializer can be std::vector<T> or std::initializer_list<T>
   template <class Initializer>
-  HostDeviceVectorImpl(const Initializer& init, GPUDistribution distribution)
+  HostDeviceVectorImpl(const Initializer& init, const GPUDistribution &distribution)
     : distribution_(distribution), perm_h_(distribution.IsEmpty()), size_d_(0) {
     if (!distribution_.IsEmpty()) {
       size_d_ = init.size();
@@ -435,19 +435,19 @@ struct HostDeviceVectorImpl {
 
 template <typename T>
 HostDeviceVector<T>::HostDeviceVector
-(size_t size, T v, GPUDistribution distribution) : impl_(nullptr) {
+(size_t size, T v, const GPUDistribution &distribution) : impl_(nullptr) {
   impl_ = new HostDeviceVectorImpl<T>(size, v, distribution);
 }
 
 template <typename T>
 HostDeviceVector<T>::HostDeviceVector
-(std::initializer_list<T> init, GPUDistribution distribution) : impl_(nullptr) {
+(std::initializer_list<T> init, const GPUDistribution &distribution) : impl_(nullptr) {
   impl_ = new HostDeviceVectorImpl<T>(init, distribution);
 }
 
 template <typename T>
 HostDeviceVector<T>::HostDeviceVector
-(const std::vector<T>& init, GPUDistribution distribution) : impl_(nullptr) {
+(const std::vector<T>& init, const GPUDistribution &distribution) : impl_(nullptr) {
   impl_ = new HostDeviceVectorImpl<T>(init, distribution);
 }
 
@@ -461,8 +461,10 @@ template <typename T>
 HostDeviceVector<T>& HostDeviceVector<T>::operator=
 (const HostDeviceVector<T>& other) {
   if (this == &other) { return *this; }
+
+  std::unique_ptr<HostDeviceVectorImpl<T>> newImpl(new HostDeviceVectorImpl<T>(*other.impl_));
   delete impl_;
-  impl_ = new HostDeviceVectorImpl<T>(*other.impl_);
+  impl_ = newImpl.release();
   return *this;
 }
 

--- a/src/common/host_device_vector.h
+++ b/src/common/host_device_vector.h
@@ -93,7 +93,7 @@ class GPUDistribution {
 
  private:
   GPUDistribution(GPUSet devices, int granularity, int overlap,
-                  std::vector<size_t> offsets)
+                  std::vector<size_t> &&offsets)
     : devices_(devices), granularity_(granularity), overlap_(overlap),
     offsets_(std::move(offsets)) {}
 
@@ -109,7 +109,7 @@ class GPUDistribution {
   }
 
   static GPUDistribution Explicit(GPUSet devices, std::vector<size_t> offsets) {
-    return GPUDistribution(devices, 1, 0, offsets);
+    return GPUDistribution(devices, 1, 0, std::move(offsets));
   }
 
   friend bool operator==(const GPUDistribution& a, const GPUDistribution& b) {
@@ -195,11 +195,11 @@ template <typename T>
 class HostDeviceVector {
  public:
   explicit HostDeviceVector(size_t size = 0, T v = T(),
-                            GPUDistribution distribution = GPUDistribution());
+                            const GPUDistribution &distribution = GPUDistribution());
   HostDeviceVector(std::initializer_list<T> init,
-                   GPUDistribution distribution = GPUDistribution());
+                   const GPUDistribution &distribution = GPUDistribution());
   explicit HostDeviceVector(const std::vector<T>& init,
-                            GPUDistribution distribution = GPUDistribution());
+                            const GPUDistribution &distribution = GPUDistribution());
   ~HostDeviceVector();
   HostDeviceVector(const HostDeviceVector<T>&);
   HostDeviceVector<T>& operator=(const HostDeviceVector<T>&);

--- a/tests/ci_build/test_gpu.sh
+++ b/tests/ci_build/test_gpu.sh
@@ -5,4 +5,4 @@ cd python-package
 python setup.py install --user
 cd ..
 pytest -v -s --fulltrace -m "(not mgpu) and (not slow)" tests/python-gpu
-./testxgboost --gtest_filter=-*.MGPU_*
+./build/testxgboost --gtest_filter=-*.MGPU_*

--- a/tests/ci_build/test_mgpu.sh
+++ b/tests/ci_build/test_mgpu.sh
@@ -5,7 +5,7 @@ cd python-package
 python setup.py install --user
 cd ..
 pytest -v -s --fulltrace -m "(not slow) and mgpu" tests/python-gpu
-./testxgboost --gtest_filter=*.MGPU_*
+./build/testxgboost --gtest_filter=*.MGPU_*
 
 cd tests/distributed
 ./runtests-gpu.sh

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -128,8 +128,8 @@ if [ ${TASK} == "cmake_test" ]; then
     PLUGINS="-DPLUGIN_LZ4=ON -DPLUGIN_DENSE_PARSER=ON"
     cmake .. -DGOOGLE_TEST=ON -DGTEST_ROOT=$PWD/../gtest/ ${PLUGINS}
     make
-    cd ..
     ./testxgboost
+    cd ..
     rm -rf build
 fi
 
@@ -175,10 +175,10 @@ if [ ${TASK} == "sanitizer_test" ]; then
       -DCMAKE_CXX_FLAGS="-fuse-ld=gold" \
       -DCMAKE_C_FLAGS="-fuse-ld=gold"
     make
-    cd ..
 
     export ASAN_SYMBOLIZER_PATH=$(which llvm-symbolizer)
     ASAN_OPTIONS=symbolize=1 ./testxgboost
+    cd ..
     rm -rf build
     exit 0
 fi


### PR DESCRIPTION
  on which cmake is run. this appends the build directory to the test binary
- make the assignments of HostDeviceVector exception safe
- rm storing a dummy GPUDistribution instance for CPU based code