### PR TITLE
[jvm-packages] do not filter shared library files

### DIFF
--- a/jvm-packages/xgboost4j/pom.xml
+++ b/jvm-packages/xgboost4j/pom.xml
@@ -71,6 +71,18 @@
                   </execution>
               </executions>
           </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-resources-plugin</artifactId>
+              <version>3.1.0</version>
+              <configuration>
+                  <nonFilteredFileExtensions>
+                      <nonFilteredFileExtension>dll</nonFilteredFileExtension>
+                      <nonFilteredFileExtension>dylib</nonFilteredFileExtension>
+                      <nonFilteredFileExtension>so</nonFilteredFileExtension>
+                  </nonFilteredFileExtensions>
+              </configuration>
+          </plugin>
       </plugins>
     </build>
 </project>


### PR DESCRIPTION
The recent change #4271 causes resources to be filtered, including shared library files that are copied there (see https://github.com/dmlc/xgboost/blob/master/jvm-packages/create_jni.py#L102), corrupting them in the process:
```sh
OpenJDK 64-Bit Server VM warning: You have loaded library /tmp/libxgboost4j7996472599554222538.so which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
```

@CodingCat 