### PR TITLE
Optimizations of pre-processing for 'hist' tree method

### DIFF
--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -71,7 +71,7 @@ class ColumnMatrix {
   // construct column matrix from GHistIndexMatrix
   inline void Init(const GHistIndexMatrix& gmat,
                    double  sparse_threshold) {
-    const auto nfeature = static_cast<bst_uint>(gmat.cut.row_ptr.size() - 1);
+    const int32_t nfeature = static_cast<int32_t>(gmat.cut.row_ptr.size() - 1);
     const size_t nrow = gmat.row_ptr.size() - 1;
 
     // identify type of each column
@@ -86,7 +86,7 @@ class ColumnMatrix {
 
     gmat.GetFeatureCounts(&feature_counts_[0]);
     // classify features
-    for (bst_uint fid = 0; fid < nfeature; ++fid) {
+    for (int32_t fid = 0; fid < nfeature; ++fid) {
       if (static_cast<double>(feature_counts_[fid])
                  < sparse_threshold * nrow) {
         type_[fid] = kSparseColumn;
@@ -100,7 +100,7 @@ class ColumnMatrix {
     boundary_.resize(nfeature);
     size_t accum_index_ = 0;
     size_t accum_row_ind_ = 0;
-    for (bst_uint fid = 0; fid < nfeature; ++fid) {
+    for (int32_t fid = 0; fid < nfeature; ++fid) {
       boundary_[fid].index_begin = accum_index_;
       boundary_[fid].row_ind_begin = accum_row_ind_;
       if (type_[fid] == kDenseColumn) {
@@ -126,7 +126,7 @@ class ColumnMatrix {
     // pre-fill index_ for dense columns
 
     #pragma omp parallel for
-    for (bst_uint fid = 0; fid < nfeature; ++fid) {
+    for (int32_t fid = 0; fid < nfeature; ++fid) {
       if (type_[fid] == kDenseColumn) {
         const size_t ibegin = boundary_[fid].index_begin;
         uint32_t* begin = &index_[ibegin];

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -124,6 +124,8 @@ class ColumnMatrix {
     }
 
     // pre-fill index_ for dense columns
+
+    #pragma omp parallel for
     for (bst_uint fid = 0; fid < nfeature; ++fid) {
       if (type_[fid] == kDenseColumn) {
         const size_t ibegin = boundary_[fid].index_begin;
@@ -184,8 +186,8 @@ class ColumnMatrix {
 
   std::vector<size_t> feature_counts_;
   std::vector<ColumnType> type_;
-  std::vector<uint32_t> index_;  // index_: may store smaller integers; needs padding
-  std::vector<size_t> row_ind_;
+  SimpleArray<uint32_t> index_;  // index_: may store smaller integers; needs padding
+  SimpleArray<size_t> row_ind_;
   std::vector<ColumnBoundary> boundary_;
 
   // index_base_[fid]: least bin id for feature fid

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -137,7 +137,7 @@ void HistCutMatrix::Init(DMatrix* p_fmat, uint32_t max_num_bins) {
           }
           #pragma omp barrier
           #pragma omp for schedule(static)
-          for (size_t icol = 0; icol < ncol; ++icol) {
+          for (int32_t icol = 0; icol < static_cast<int32_t>(ncol); ++icol) {
             for (size_t tid = 0; tid < nthread; ++tid) {
               auto* p_sizes = sizes.data() + ncol * tid;
               auto* p_buff = buff[tid].data() + icol * block_size;

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -68,8 +68,7 @@ void HistCutMatrix::Init(DMatrix* p_fmat, uint32_t max_num_bins) {
   // Use group index for weights?
   bool const use_group_ind = num_groups != 0 && weights.size() != info.num_row_;
 
-  if (use_group_ind)
-  {
+  if (use_group_ind) {
     for (const auto &batch : p_fmat->GetRowBatches()) {
       size_t group_ind = this->SearchGroupIndFromBaseRow(group_ptr, batch.base_rowid);
       #pragma omp parallel num_threads(nthread) firstprivate(group_ind, use_group_ind)
@@ -108,7 +107,7 @@ void HistCutMatrix::Init(DMatrix* p_fmat, uint32_t max_num_bins) {
       const size_t n_blocks = size / block_size_iter + !!(size % block_size_iter);
 
       std::vector<std::vector<std::pair<float, float>>> buff(nthread);
-      for(size_t tid = 0; tid < nthread; ++tid) {
+      for (size_t tid = 0; tid < nthread; ++tid) {
         buff[tid].resize(block_size * ncol);
       }
 
@@ -125,7 +124,7 @@ void HistCutMatrix::Init(DMatrix* p_fmat, uint32_t max_num_bins) {
           auto* p_sizes = sizes.data() + ncol * tid;
           auto* p_buff = buff[tid].data();
 
-          for(size_t i = ibegin; i < iend; ++i) {
+          for (size_t i = ibegin; i < iend; ++i) {
             size_t const ridx = batch.base_rowid + i;
             bst_float w = info.GetWeight(ridx);
             SparsePage::Inst const inst = batch[i];
@@ -138,12 +137,12 @@ void HistCutMatrix::Init(DMatrix* p_fmat, uint32_t max_num_bins) {
           }
           #pragma omp barrier
           #pragma omp for schedule(static)
-          for(size_t icol = 0; icol < ncol; ++icol) {
-            for(size_t tid = 0; tid < nthread; ++tid) {
+          for (size_t icol = 0; icol < ncol; ++icol) {
+            for (size_t tid = 0; tid < nthread; ++tid) {
               auto* p_sizes = sizes.data() + ncol * tid;
               auto* p_buff = buff[tid].data() + icol * block_size;
 
-              for(size_t i = 0; i < p_sizes[icol]; ++i) {
+              for (size_t i = 0; i < p_sizes[icol]; ++i) {
                 sketchs[icol].Push(p_buff[i].first,  p_buff[i].second);
               }
 
@@ -230,7 +229,7 @@ uint32_t HistCutMatrix::GetBinIdx(const Entry& e) {
 
 void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
   cut.Init(p_fmat, max_num_bins);
-  const size_t nthread = omp_get_max_threads();
+  const int32_t nthread = omp_get_max_threads();
   // const int nthread = 1;
   const uint32_t nbins = cut.row_ptr.back();
   hit_count.resize(nbins, 0);
@@ -257,8 +256,7 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
     #pragma omp parallel num_threads(nthread)
     {
       #pragma omp for
-      for(size_t tid = 0; tid < nthread; ++tid)
-      {
+      for (int32_t tid = 0; tid < nthread; ++tid) {
         size_t ibegin = block_size * tid;
         size_t iend = (tid == (nthread-1) ? batch.Size() : (block_size * (tid+1)));
 
@@ -272,17 +270,19 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
       #pragma omp single
       {
         p_part[0] = prev_sum;
-        for (size_t i = 1; i < nthread; ++i)
+        for (int32_t i = 1; i < nthread; ++i) {
           p_part[i] = p_part[i - 1] + row_ptr[rbegin + i*block_size];
+        }
       }
 
       #pragma omp for
-      for(size_t tid = 0; tid < nthread; ++tid) {
+      for (int32_t tid = 0; tid < nthread; ++tid) {
         size_t ibegin = block_size * tid;
         size_t iend = (tid == (nthread-1) ? batch.Size() : (block_size * (tid+1)));
 
-        for (size_t i = ibegin; i < iend; ++i)
+        for (size_t i = ibegin; i < iend; ++i) {
           row_ptr[rbegin + 1 + i] += p_part[tid];
+        }
       }
     }
 

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -21,7 +21,6 @@ namespace common {
 
 template<typename T>
 struct SimpleArray {
-
   ~SimpleArray() {
     free(ptr_);
     ptr_ = nullptr;
@@ -76,7 +75,7 @@ struct SimpleArray {
     return ptr_ + n_;
   }
 
-private:
+ private:
   T* ptr_ = nullptr;
   size_t n_ = 0;
 };

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -19,6 +19,71 @@
 namespace xgboost {
 namespace common {
 
+template<typename T>
+struct SimpleArray {
+
+  ~SimpleArray() {
+    free(ptr_);
+    ptr_ = nullptr;
+  }
+
+  void resize(size_t n) {
+    T* ptr = static_cast<T*>(malloc(n*sizeof(T)));
+    memcpy(ptr, ptr_, n_ * sizeof(T));
+    free(ptr_);
+    ptr_ = ptr;
+    n_ = n;
+  }
+
+  T& operator[](size_t idx) {
+    return ptr_[idx];
+  }
+
+  T& operator[](size_t idx) const {
+    return ptr_[idx];
+  }
+
+  size_t size() const {
+    return n_;
+  }
+
+  T back() const {
+    return ptr_[n_-1];
+  }
+
+  T* data() {
+    return ptr_;
+  }
+
+  const T* data() const {
+    return ptr_;
+  }
+
+
+  T* begin() {
+    return ptr_;
+  }
+
+  const T* begin() const {
+    return ptr_;
+  }
+
+  T* end() {
+    return ptr_ + n_;
+  }
+
+  const T* end() const {
+    return ptr_ + n_;
+  }
+
+private:
+  T* ptr_ = nullptr;
+  size_t n_ = 0;
+};
+
+
+
+
 /*! \brief Cut configuration for all the features. */
 struct HistCutMatrix {
   /*! \brief Unit pointer to rows by element position */

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -19,6 +19,10 @@
 namespace xgboost {
 namespace common {
 
+/*
+ * \brief A thin wrapper around dynamically allocated C-style array.
+ * Make sure to call resize() before use.
+ */
 template<typename T>
 struct SimpleArray {
   ~SimpleArray() {

--- a/src/common/row_set.h
+++ b/src/common/row_set.h
@@ -59,7 +59,6 @@ class RowSetCollection {
   }
   // clear up things
   inline void Clear() {
-    row_indices_.clear();
     elem_of_each_node_.clear();
   }
   // initialize node id 0->everything

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -435,7 +435,6 @@ void QuantileHistMaker::Builder::InitData(const GHistIndexMatrix& gmat,
       }
       row_indices.resize(j);
     } else {
-
       MemStackAllocator<int, 128> buff(this->nthread_);
       int* p_buff = buff.Get();
       std::fill(p_buff, p_buff + this->nthread_, false);
@@ -446,10 +445,11 @@ void QuantileHistMaker::Builder::InitData(const GHistIndexMatrix& gmat,
       {
         const size_t tid = omp_get_thread_num();
         const size_t ibegin = tid * block_size;
-        const size_t iend = std::min(ibegin + block_size, info.num_row_);
+        const size_t iend = std::min(static_cast<size_t>(ibegin + block_size),
+            static_cast<size_t>(info.num_row_));
 
         for (size_t i = ibegin; i < iend; ++i) {
-          if(gpair[i].GetHess() < 0.0f) {
+          if (gpair[i].GetHess() < 0.0f) {
             buff.Get()[tid] = true;
             break;
           }
@@ -457,11 +457,13 @@ void QuantileHistMaker::Builder::InitData(const GHistIndexMatrix& gmat,
       }
 
       bool has_heg_hess = false;
-      for (size_t tid = 0; tid < this->nthread_; ++tid)
-        if (p_buff[tid] == true)
+      for (size_t tid = 0; tid < this->nthread_; ++tid) {
+        if (p_buff[tid] == true) {
           has_heg_hess = true;
+        }
+      }
 
-      if(has_heg_hess) {
+      if (has_heg_hess) {
         size_t j = 0;
         for (size_t i = 0; i < info.num_row_; ++i) {
           if (gpair[i].GetHess() >= 0.0f) {
@@ -474,7 +476,8 @@ void QuantileHistMaker::Builder::InitData(const GHistIndexMatrix& gmat,
         {
           const size_t tid = omp_get_thread_num();
           const size_t ibegin = tid * block_size;
-          const size_t iend = std::min(ibegin + block_size, info.num_row_);
+          const size_t iend = std::min(static_cast<size_t>(ibegin + block_size),
+              static_cast<size_t>(info.num_row_));
           for (size_t i = ibegin; i < iend; ++i) {
            p_row_indices[i] = i;
           }

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -435,8 +435,8 @@ void QuantileHistMaker::Builder::InitData(const GHistIndexMatrix& gmat,
       }
       row_indices.resize(j);
     } else {
-      MemStackAllocator<int, 128> buff(this->nthread_);
-      int* p_buff = buff.Get();
+      MemStackAllocator<bool, 128> buff(this->nthread_);
+      bool* p_buff = buff.Get();
       std::fill(p_buff, p_buff + this->nthread_, false);
 
       const size_t block_size = info.num_row_ / this->nthread_ + !!(info.num_row_ % this->nthread_);
@@ -450,20 +450,20 @@ void QuantileHistMaker::Builder::InitData(const GHistIndexMatrix& gmat,
 
         for (size_t i = ibegin; i < iend; ++i) {
           if (gpair[i].GetHess() < 0.0f) {
-            buff.Get()[tid] = true;
+            p_buff[tid] = true;
             break;
           }
         }
       }
 
-      bool has_heg_hess = false;
+      bool has_neg_hess = false;
       for (size_t tid = 0; tid < this->nthread_; ++tid) {
-        if (p_buff[tid] == true) {
-          has_heg_hess = true;
+        if (p_buff[tid]) {
+          has_neg_hess = true;
         }
       }
 
-      if (has_heg_hess) {
+      if (has_neg_hess) {
         size_t j = 0;
         for (size_t i = 0; i < info.num_row_; ++i) {
           if (gpair[i].GetHess() >= 0.0f) {

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -30,20 +30,17 @@
 namespace xgboost {
 
 template<typename T, size_t MaxStackSize>
-class MemStackAllocator
-{
-public:
-  MemStackAllocator(size_t required_size): required_size_(required_size) {
+class MemStackAllocator {
+ public:
+  explicit MemStackAllocator(size_t required_size): required_size_(required_size) {
   }
 
   T* Get() {
-    if(!ptr_)
-    {
-      if (MaxStackSize>=required_size_) {
+    if (!ptr_) {
+      if (MaxStackSize >= required_size_) {
         ptr_ = stack_mem_;
-      }
-      else {
-        ptr_ = (T*)malloc(required_size_ * sizeof(T));
+      } else {
+        ptr_ =  reinterpret_cast<T*>(malloc(required_size_ * sizeof(T)));
         do_free_ = true;
       }
     }
@@ -55,7 +52,8 @@ public:
     if (do_free_) free(ptr_);
   }
 
-private:
+
+ private:
   T* ptr_ = nullptr;
   bool do_free_ = false;
   size_t required_size_;

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -28,6 +28,40 @@
 #include "../common/column_matrix.h"
 
 namespace xgboost {
+
+template<typename T, size_t MaxStackSize>
+class MemStackAllocator
+{
+public:
+  MemStackAllocator(size_t required_size): required_size_(required_size) {
+  }
+
+  T* Get() {
+    if(!ptr_)
+    {
+      if (MaxStackSize>=required_size_) {
+        ptr_ = stack_mem_;
+      }
+      else {
+        ptr_ = (T*)malloc(required_size_ * sizeof(T));
+        do_free_ = true;
+      }
+    }
+
+    return ptr_;
+  }
+
+  ~MemStackAllocator() {
+    if (do_free_) free(ptr_);
+  }
+
+private:
+  T* ptr_ = nullptr;
+  bool do_free_ = false;
+  size_t required_size_;
+  T stack_mem_[MaxStackSize];
+};
+
 namespace tree {
 
 using xgboost::common::HistCutMatrix;

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -29,6 +29,9 @@
 
 namespace xgboost {
 
+/*!
+ * \brief A C-style array with in-stack allocation. As long as the array is smaller than MaxStackSize, it will be allocated inside the stack. Otherwise, it will be heap-allocated.
+ */
 template<typename T, size_t MaxStackSize>
 class MemStackAllocator {
  public:


### PR DESCRIPTION
This commit is a part of this [pull-request](https://github.com/dmlc/xgboost/pull/4278).
Performance before this commit:

Data Set | First iteration | 50 iterations
-- | -- | --
Higgs1m, ms | 900 | 3889
Higgs10m, ms | 8923 | 33638
9m x 45, ms | 6093 | 19389

Performance results for these changes:

Data Set | First iteration | 50 iterations
-- | -- | --
Higgs1m, ms | 672 | 3502
Higgs10m, ms | 7834 | 30121
9m x 45, ms | 4369 | 15960

HW: Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz, 2 sockets, 14 cores per socket.