### PR TITLE
Fix matrix attributes not sliced

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -301,12 +301,17 @@ slice.xgb.DMatrix <- function(object, idxset, ...) {
 
   attr_list <- attributes(object)
   nr <- nrow(object)
-  len <- sapply(attr_list, length)
+  len <- sapply(attr_list, NROW)
   ind <- which(len == nr)
   if (length(ind) > 0) {
     nms <- names(attr_list)[ind]
     for (i in seq_along(ind)) {
-      attr(ret, nms[i]) <- attr(object, nms[i])[idxset]
+      obj_attr <- attr(object, nms[i])
+      if (NCOL(obj_attr) > 1) {
+        attr(ret, nms[i]) <- obj_attr[idxset,]
+      } else {
+        attr(ret, nms[i]) <- obj_attr[idxset]
+      }
     }
   }
   return(structure(ret, class = "xgb.DMatrix"))


### PR DESCRIPTION
In the R package, the user can provide additional information for the custom objective function by adding attributes to the `DMatrix` . `xgb.cv` relies on `slice.xgb.DMatrix` for slicing the folds. 

However, those attributes are sliced only if they are vectors of same length as the `DMatrix`. In a multiclass problem, it makes sense to use a matrix instead of a vector for additional information about the classes. 

MWE:
```r
library(xgboost)

data(agaricus.train, package = "xgboost")

dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
attr(dtrain, "vec") <- getinfo(dtrain, "label")
nrow(dtrain)
#> [1] 6513
train_len <- length(attr(dtrain, "vec"))
attr(dtrain, "mat") <- matrix(runif(train_len * 2), nrow = train_len, ncol = 2)
length(attr(dtrain, "mat")) # != nrow(dtrain), will not be sliced
#> [1] 13026
dim(attr(dtrain, "mat"))
#> [1] 6513    2

dtrain <- slice(dtrain, 1:20)
length(attr(dtrain, "vec"))
#> [1] 20
attr(dtrain, "mat")
#> NULL
```

<sup>Created on 2019-03-29 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

This PR fixes the issue by testing `NROW` instead of `length` and slices tabular attributes by row, similarly to what is done for the `DMatrix` itself.