### PR TITLE
Update cmake with native cuda support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.2)
-project(xgboost)
+project(xgboost LANGUAGES CXX)
 include(cmake/Utils.cmake)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
 find_package(OpenMP)
@@ -165,21 +165,20 @@ if (GENERATE_COMPILATION_DATABASE)
 endif (GENERATE_COMPILATION_DATABASE)
 
 if(USE_CUDA AND (NOT GENERATE_COMPILATION_DATABASE))
-  find_package(CUDA 8.0 REQUIRED)
-  cmake_minimum_required(VERSION 3.5)
-
+  cmake_minimum_required(VERSION 3.9)
+  enable_language(CUDA)
   add_definitions(-DXGBOOST_USE_CUDA)
 
   include_directories(cub)
 
   if(USE_NCCL)
     find_package(Nccl REQUIRED)
-    cuda_include_directories(${NCCL_INCLUDE_DIR})
+    include_directories(${NCCL_INCLUDE_DIR})
     add_definitions(-DXGBOOST_USE_NCCL)
   endif()
 
   if(USE_NVTX)
-    cuda_include_directories("${NVTX_HEADER_DIR}")
+    include_directories("${NVTX_HEADER_DIR}")
     add_definitions(-DXGBOOST_USE_NVTX)
   endif()
 
@@ -187,12 +186,14 @@ if(USE_CUDA AND (NOT GENERATE_COMPILATION_DATABASE))
   format_gencode_flags("${GPU_COMPUTE_VER}" GENCODE_FLAGS)
   message("cuda architecture flags: ${GENCODE_FLAGS}")
 
-  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};--expt-extended-lambda;--expt-relaxed-constexpr;${GENCODE_FLAGS};-lineinfo;")
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${GENCODE_FLAGS} --expt-relaxed-constexpr --expt-extended-lambda")
+  
   if(NOT MSVC)
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xcompiler -fPIC; -Xcompiler -Werror; -std=c++11")
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -fPIC -Xcompiler -Werror -std=c++11")
   endif()
 
-  cuda_add_library(gpuxgboost ${CUDA_SOURCES} STATIC)
+  add_library(gpuxgboost STATIC ${CUDA_SOURCES})
+  target_compile_features(gpuxgboost PUBLIC cxx_std_11)
 
   if(USE_NCCL)
     link_directories(${NCCL_LIBRARY})

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -29,6 +29,18 @@ function(msvc_use_static_runtime)
               set(${variable} "${${variable}}"  PARENT_SCOPE)
           endif()
       endforeach()
+      set(variables
+          CMAKE_CUDA_FLAGS_DEBUG
+          CMAKE_CUDA_FLAGS_MINSIZEREL
+          CMAKE_CUDA_FLAGS_RELEASE
+          CMAKE_CUDA_FLAGS_RELWITHDEBINFO
+      )
+      foreach(variable ${variables})
+          if(${variable} MATCHES "-MD")
+              string(REGEX REPLACE "-MD" "-MT" ${variable} "${${variable}}")
+              set(${variable} "${${variable}}"  PARENT_SCOPE)
+          endif()
+      endforeach()
   endif()
 endfunction(msvc_use_static_runtime)
 
@@ -69,11 +81,11 @@ function(format_gencode_flags flags out)
   endif()
   # Generate SASS
   foreach(ver ${flags})
-    set(${out} "${${out}}-gencode arch=compute_${ver},code=sm_${ver};")
+    set(${out} "${${out}}-gencode arch=compute_${ver},code=sm_${ver} ")
   endforeach()
   # Generate PTX for last architecture
   list(GET flags -1 ver)
-  set(${out} "${${out}}-gencode arch=compute_${ver},code=compute_${ver};")
+  set(${out} "${${out}}-gencode arch=compute_${ver},code=compute_${ver} ")
   
   set(${out} "${${out}}" PARENT_SCOPE)
 endfunction(format_gencode_flags flags)

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -15,8 +15,8 @@ RUN \
     wget https://repo.continuum.io/miniconda/Miniconda2-4.3.27-Linux-x86_64.sh && \
     bash Miniconda2-4.3.27-Linux-x86_64.sh -b -p /opt/python && \
     # CMake
-    wget -nv -nc https://cmake.org/files/v3.6/cmake-3.6.0-Linux-x86_64.sh --no-check-certificate && \
-    bash cmake-3.6.0-Linux-x86_64.sh --skip-license --prefix=/usr
+    wget -nv -nc https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.sh --no-check-certificate && \
+    bash cmake-3.9.0-Linux-x86_64.sh --skip-license --prefix=/usr
 
 # NCCL2 (License: https://docs.nvidia.com/deeplearning/sdk/nccl-sla/index.html)
 RUN \


### PR DESCRIPTION
FindCuda.cmake is deprecated, making it a good time to switch.

Native cuda support in cmake allows me to enable compilation dynamic parallelism in future (which I couldn't do with old cuda cmake) as well as enables multithreaded compilation on Windows, saving me a lot of development time.

@trivialfis I think we discussed this in the past and I was hesitant to switch because of problems, but this time when I tried it everything went smoothly so I guess I just did something wrong last time.