### PR TITLE
[CI] Add external Docker build cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,8 @@ import groovy.transform.Field
 /* Unrestricted tasks: tasks that do NOT generate artifacts */
 
 // Command to run command inside a docker container
-def dockerRun = 'tests/ci_build/ci_build.sh'
+def dockerCacheRepo = '812345574397.dkr.ecr.us-west-2.amazonaws.com'
+def dockerRun = "DOCKER_CACHE_REPO=${dockerCacheRepo} tests/ci_build/ci_build.sh"
 // Utility functions
 @Field
 def utils

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     agent none
 
     environment {
-        DOCKER_CACHE_REPO = '812345574397.dkr.ecr.us-west-2.amazonaws.com'
+        DOCKER_CACHE_REPO = '492475357299.dkr.ecr.us-west-2.amazonaws.com'
     }
 
     // Setup common job properties

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,7 @@ import groovy.transform.Field
 /* Unrestricted tasks: tasks that do NOT generate artifacts */
 
 // Command to run command inside a docker container
-def dockerCacheRepo = '812345574397.dkr.ecr.us-west-2.amazonaws.com'
-def dockerRun = "DOCKER_CACHE_REPO=${dockerCacheRepo} tests/ci_build/ci_build.sh"
+def dockerRun = 'tests/ci_build/ci_build.sh'
 // Utility functions
 @Field
 def utils
@@ -24,6 +23,10 @@ def buildMatrix = [
 pipeline {
     // Each stage specify its own agent
     agent none
+
+    environment {
+        DOCKER_CACHE_REPO = '812345574397.dkr.ecr.us-west-2.amazonaws.com'
+    }
 
     // Setup common job properties
     options {

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -15,8 +15,8 @@ RUN \
     wget https://repo.continuum.io/miniconda/Miniconda2-4.3.27-Linux-x86_64.sh && \
     bash Miniconda2-4.3.27-Linux-x86_64.sh -b -p /opt/python && \
     # CMake
-    wget -nv -nc https://cmake.org/files/v3.6/cmake-3.6.0-Linux-x86_64.sh --no-check-certificate && \
-    bash cmake-3.6.0-Linux-x86_64.sh --skip-license --prefix=/usr
+    wget -nv -nc https://cmake.org/files/v3.8/cmake-3.8.0-Linux-x86_64.sh --no-check-certificate && \
+    bash cmake-3.8.0-Linux-x86_64.sh --skip-license --prefix=/usr
 
 # NCCL2 (License: https://docs.nvidia.com/deeplearning/sdk/nccl-sla/index.html)
 RUN \

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -15,8 +15,8 @@ RUN \
     wget https://repo.continuum.io/miniconda/Miniconda2-4.3.27-Linux-x86_64.sh && \
     bash Miniconda2-4.3.27-Linux-x86_64.sh -b -p /opt/python && \
     # CMake
-    wget -nv -nc https://cmake.org/files/v3.8/cmake-3.8.0-Linux-x86_64.sh --no-check-certificate && \
-    bash cmake-3.8.0-Linux-x86_64.sh --skip-license --prefix=/usr
+    wget -nv -nc https://cmake.org/files/v3.6/cmake-3.6.0-Linux-x86_64.sh --no-check-certificate && \
+    bash cmake-3.6.0-Linux-x86_64.sh --skip-license --prefix=/usr
 
 # NCCL2 (License: https://docs.nvidia.com/deeplearning/sdk/nccl-sla/index.html)
 RUN \

--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -131,12 +131,12 @@ fi
 
 echo "docker build \
     ${CI_DOCKER_BUILD_ARG} \
-    -t ${DOCKER_IMG_NAME} \
+    -t ${DOCKER_IMG_NAME}:${BRANCH_NAME} \
     -f ${DOCKERFILE_PATH} ${DOCKER_CONTEXT_PATH} \
     ${CACHE_FROM_CMD}"
 docker build \
     ${CI_DOCKER_BUILD_ARG} \
-    -t "${DOCKER_IMG_NAME}" \
+    -t "${DOCKER_IMG_NAME}:${BRANCH_NAME}" \
     -f "${DOCKERFILE_PATH}" "${DOCKER_CONTEXT_PATH}" \
     ${CACHE_FROM_CMD}
 

--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -122,6 +122,9 @@ echo "Building container (${DOCKER_IMG_NAME})..."
 # If enviornment variable DOCKER_CACHE_REPO is set, use an external Docker repo for build caching
 if [[ -n "${DOCKER_CACHE_REPO}" ]]
 then
+    # Login for Docker registiry
+    echo '$(python3 -m awscli ecr get-login --no-include-email --region us-west-2)'
+    $(python3 -m awscli ecr get-login --no-include-email --region us-west-2)
     echo "docker pull ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME} || true"
     docker pull "${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}" || true
     CACHE_FROM_CMD="--cache-from ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"

--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -113,11 +113,20 @@ cat <<EOF
    NODE_NAME: ${NODE_NAME}
    DOCKER CONTAINER NAME: ${DOCKER_IMG_NAME}
    USER_IDS: ${USER_IDS}
+   CHANGE_ID: ${CHANGE_ID}
+   BRANCH_NAME: ${BRANCH_NAME}
 EOF
 
 
 # Build the docker container.
 echo "Building container (${DOCKER_IMG_NAME})..."
+
+# If enviornment variable DOCKER_CACHE_REPO is set, try to use an external Docker repo for build caching
+if [[ -n "${DOCKER_CACHE_REPO}" ]]
+then
+  true
+fi
+
 # --pull should be default
 echo "docker build \
     ${CI_DOCKER_BUILD_ARG} \

--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -131,12 +131,12 @@ fi
 
 echo "docker build \
     ${CI_DOCKER_BUILD_ARG} \
-    -t ${DOCKER_IMG_NAME}:${BRANCH_NAME} \
+    -t ${DOCKER_IMG_NAME} \
     -f ${DOCKERFILE_PATH} ${DOCKER_CONTEXT_PATH} \
     ${CACHE_FROM_CMD}"
 docker build \
     ${CI_DOCKER_BUILD_ARG} \
-    -t "${DOCKER_IMG_NAME}:${BRANCH_NAME}" \
+    -t "${DOCKER_IMG_NAME}" \
     -f "${DOCKERFILE_PATH}" "${DOCKER_CONTEXT_PATH}" \
     ${CACHE_FROM_CMD}
 
@@ -149,6 +149,8 @@ fi
 # If enviornment variable DOCKER_CACHE_REPO is set, use an external Docker repo for build caching
 if [[ -n "${DOCKER_CACHE_REPO}" ]]
 then
+    echo "docker tag ${DOCKER_IMG_NAME} ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
+    docker tag "${DOCKER_IMG_NAME}" "${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
     echo "docker push ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
     docker push "${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
     if [[ $? != "0" ]]; then

--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -113,34 +113,48 @@ cat <<EOF
    NODE_NAME: ${NODE_NAME}
    DOCKER CONTAINER NAME: ${DOCKER_IMG_NAME}
    USER_IDS: ${USER_IDS}
-   CHANGE_ID: ${CHANGE_ID}
-   BRANCH_NAME: ${BRANCH_NAME}
 EOF
 
 
 # Build the docker container.
 echo "Building container (${DOCKER_IMG_NAME})..."
 
-# If enviornment variable DOCKER_CACHE_REPO is set, try to use an external Docker repo for build caching
+# If enviornment variable DOCKER_CACHE_REPO is set, use an external Docker repo for build caching
 if [[ -n "${DOCKER_CACHE_REPO}" ]]
 then
-  true
+    echo "docker pull ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME} || true"
+    docker pull "${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}" || true
+    CACHE_FROM_CMD="--cache-from ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
+else
+    CACHE_FROM_CMD=''
 fi
 
-# --pull should be default
 echo "docker build \
     ${CI_DOCKER_BUILD_ARG} \
     -t ${DOCKER_IMG_NAME} \
-    -f ${DOCKERFILE_PATH} ${DOCKER_CONTEXT_PATH}"
+    -f ${DOCKERFILE_PATH} ${DOCKER_CONTEXT_PATH} \
+    ${CACHE_FROM_CMD}"
 docker build \
     ${CI_DOCKER_BUILD_ARG} \
     -t "${DOCKER_IMG_NAME}" \
-    -f "${DOCKERFILE_PATH}" "${DOCKER_CONTEXT_PATH}"
+    -f "${DOCKERFILE_PATH}" "${DOCKER_CONTEXT_PATH}" \
+    ${CACHE_FROM_CMD}
 
 # Check docker build status
 if [[ $? != "0" ]]; then
     echo "ERROR: docker build failed."
     exit 1
+fi
+
+# If enviornment variable DOCKER_CACHE_REPO is set, use an external Docker repo for build caching
+if [[ -n "${DOCKER_CACHE_REPO}" ]]
+then
+    echo "docker push ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
+    docker push "${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
+    if [[ $? != "0" ]]; then
+        echo "ERROR: could not update Docker cache ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
+        exit 1
+    fi
 fi
 
 


### PR DESCRIPTION
* ~Upgrade CMake to 3.8, as needed by #4323~ CMake upgrade has been postponed.
* Add external Docker build cache, so that we can automatically cache builds from the latest Dockerfile. Docker caches are super important for speeding up CI builds. (Right now, I have to manually update the cache every time Dockerfile is updated.)