### PR TITLE
[CI] Optimize external Docker build cache

### DIFF
--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -122,14 +122,18 @@ echo "Building container (${DOCKER_IMG_NAME})..."
 # If enviornment variable DOCKER_CACHE_REPO is set, use an external Docker repo for build caching
 if [[ -n "${DOCKER_CACHE_REPO}" ]]
 then
-    # Login for Docker registiry
+    # Login for Docker registry
     echo '$(python3 -m awscli ecr get-login --no-include-email --region us-west-2)'
     $(python3 -m awscli ecr get-login --no-include-email --region us-west-2)
+    # Pull pre-build container from Docker build cache,
+    # if one exists for the particular branch or pull request
     echo "docker pull ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
     if docker pull "${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
     then
       CACHE_FROM_CMD="--cache-from ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
     else
+      # If the build cache is empty of the particular branch or pull request,
+      # use the build cache associated with the master branch
       echo "docker pull ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:master"
       docker pull "${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:master" || true
       CACHE_FROM_CMD="--cache-from ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:master"
@@ -158,6 +162,8 @@ fi
 # If enviornment variable DOCKER_CACHE_REPO is set, use an external Docker repo for build caching
 if [[ -n "${DOCKER_CACHE_REPO}" ]]
 then
+    # Push the container we just built to the Docker build cache
+    # that is associated with the particular branch or pull request
     echo "docker tag ${DOCKER_IMG_NAME} ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
     docker tag "${DOCKER_IMG_NAME}" "${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
     echo "docker push ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"

--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -125,9 +125,15 @@ then
     # Login for Docker registiry
     echo '$(python3 -m awscli ecr get-login --no-include-email --region us-west-2)'
     $(python3 -m awscli ecr get-login --no-include-email --region us-west-2)
-    echo "docker pull ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME} || true"
-    docker pull "${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}" || true
-    CACHE_FROM_CMD="--cache-from ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
+    echo "docker pull ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
+    if docker pull "${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
+    then
+      CACHE_FROM_CMD="--cache-from ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"
+    else
+      echo "docker pull ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:master"
+      docker pull "${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:master" || true
+      CACHE_FROM_CMD="--cache-from ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:master"
+    fi
 else
     CACHE_FROM_CMD=''
 fi


### PR DESCRIPTION
This is a follow-up to #4331.

Docker build caches are per-branch, so new pull requests will initially have no build cache, causing the Docker containers to be built from scratch. New pull requests should use the cache associated with the
master branch. This makes sense, since most pull requests do not modify the Dockerfile.