### PR TITLE
Use feature interaction constraints to narrow search space for split candidates

### DIFF
--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -61,7 +61,7 @@ bst_float SplitEvaluator::ComputeSplitScore(bst_uint nodeid,
   return ComputeSplitScore(nodeid, featureid, left_stats, right_stats, left_weight, right_weight);
 }
 
-bool SplitEvaluator::CheckValidation(bst_uint nodeid, bst_uint featureid) {
+bool SplitEvaluator::CheckValidation(bst_uint nodeid, bst_uint featureid) const {
   return true;
 }
 
@@ -301,6 +301,10 @@ class MonotonicConstraint final : public SplitEvaluator {
     }
   }
 
+  bool CheckValidation(bst_uint nodeid, bst_uint featureid) const override {
+    return true;
+  }
+
  private:
   MonotonicConstraintParams params_;
   std::unique_ptr<SplitEvaluator> inner_;
@@ -485,7 +489,7 @@ class InteractionConstraint final : public SplitEvaluator {
     }
   }
 
-  bool CheckValidation(bst_uint nodeid, bst_uint featureid) override {
+  bool CheckValidation(bst_uint nodeid, bst_uint featureid) const override {
     return CheckInteractionConstraint(featureid, nodeid);
   }
 

--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -61,7 +61,7 @@ bst_float SplitEvaluator::ComputeSplitScore(bst_uint nodeid,
   return ComputeSplitScore(nodeid, featureid, left_stats, right_stats, left_weight, right_weight);
 }
 
-bool SplitEvaluator::CheckValidation(bst_uint nodeid, bst_uint featureid) const {
+bool SplitEvaluator::CheckFeatureConstraint(bst_uint nodeid, bst_uint featureid) const {
   return true;
 }
 
@@ -157,7 +157,7 @@ class ElasticNet final : public SplitEvaluator {
     return w;
   }
 
-  bool CheckValidation(bst_uint nodeid, bst_uint featureid) const override {
+  bool CheckFeatureConstraint(bst_uint nodeid, bst_uint featureid) const override {
     return true;
   }
 
@@ -305,7 +305,7 @@ class MonotonicConstraint final : public SplitEvaluator {
     }
   }
 
-  bool CheckValidation(bst_uint nodeid, bst_uint featureid) const override {
+  bool CheckFeatureConstraint(bst_uint nodeid, bst_uint featureid) const override {
     return true;
   }
 
@@ -493,7 +493,7 @@ class InteractionConstraint final : public SplitEvaluator {
     }
   }
 
-  bool CheckValidation(bst_uint nodeid, bst_uint featureid) const override {
+  bool CheckFeatureConstraint(bst_uint nodeid, bst_uint featureid) const override {
     return CheckInteractionConstraint(featureid, nodeid);
   }
 

--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -157,6 +157,10 @@ class ElasticNet final : public SplitEvaluator {
     return w;
   }
 
+  bool CheckValidation(bst_uint nodeid, bst_uint featureid) const override {
+    return true;
+  }
+
  private:
   ElasticNetParams params_;
 

--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -61,6 +61,10 @@ bst_float SplitEvaluator::ComputeSplitScore(bst_uint nodeid,
   return ComputeSplitScore(nodeid, featureid, left_stats, right_stats, left_weight, right_weight);
 }
 
+bool SplitEvaluator::CheckValidation(bst_uint nodeid, bst_uint featureid) {
+  return true;
+}
+
 //! \brief Encapsulates the parameters for ElasticNet
 struct ElasticNetParams : public dmlc::Parameter<ElasticNetParams> {
   bst_float reg_lambda;
@@ -479,6 +483,10 @@ class InteractionConstraint final : public SplitEvaluator {
         }
       }
     }
+  }
+
+  bool CheckValidation(bst_uint nodeid, bst_uint featureid) override {
+    return CheckInteractionConstraint(featureid, nodeid);
   }
 
  private:

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -70,9 +70,10 @@ class SplitEvaluator {
                         bst_float leftweight,
                         bst_float rightweight);
 
-  // Check validation before evaluating splits to narrow search space
-  virtual bool CheckValidation(bst_uint nodeid,
-                               bst_uint featureid) const = 0;
+  // Check whether a given feature is feasible for a given node.
+  // Use this function to narrow the search space for split candidates
+  virtual bool CheckFeatureConstraint(bst_uint nodeid,
+                                      bst_uint featureid) const = 0;
 };
 
 struct SplitEvaluatorReg

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -69,6 +69,9 @@ class SplitEvaluator {
                         bst_uint featureid,
                         bst_float leftweight,
                         bst_float rightweight);
+
+  // Check validation before evaluating splits to narrow search space
+  virtual bool CheckValidation(bst_uint nodeid, bst_uint featureid);
 };
 
 struct SplitEvaluatorReg

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -72,7 +72,7 @@ class SplitEvaluator {
 
   // Check validation before evaluating splits to narrow search space
   virtual bool CheckValidation(bst_uint nodeid,
-                               bst_uint featureid) const;
+                               bst_uint featureid) const = 0;
 };
 
 struct SplitEvaluatorReg

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -71,7 +71,8 @@ class SplitEvaluator {
                         bst_float rightweight);
 
   // Check validation before evaluating splits to narrow search space
-  virtual bool CheckValidation(bst_uint nodeid, bst_uint featureid);
+  virtual bool CheckValidation(bst_uint nodeid,
+                               bst_uint featureid) const;
 };
 
 struct SplitEvaluatorReg

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -581,7 +581,8 @@ void QuantileHistMaker::Builder::EvaluateSplit(const int nid,
   }
 
 #pragma omp parallel for schedule(dynamic) num_threads(nthread)
-  for (const bst_omp_uint& fid : validFeatures) {
+  for (bst_omp_uint i = 0; i < validFeatures.size(); ++i) {  // NOLINT(*)
+    const bst_uint fid = validFeatures[i];
     const unsigned tid = omp_get_thread_num();
     this->EnumerateSplit(-1, gmat, node_hist, snode_[nid], info,
                          &best_split_tloc_[tid], fid, nid);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -574,8 +574,8 @@ void QuantileHistMaker::Builder::EvaluateSplit(const int nid,
   // filter unvalidated candidates to narrow search space
   std::vector<bst_uint> validFeatures;
   for (bst_uint i = 0; i < nfeature; ++i) {
-    const bst_uint fid = feature_set[i];
-    if (spliteval_->CheckValidation(fid, nid)) {
+    const bst_uint fid = static_cast<const bst_uint>(feature_set[i]);
+    if (spliteval_->CheckValidation(fid, static_cast<const bst_uint>(nid))) {
       validFeatures.push_back(fid);
     }
   }

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -581,8 +581,7 @@ void QuantileHistMaker::Builder::EvaluateSplit(const int nid,
   }
 
 #pragma omp parallel for schedule(dynamic) num_threads(nthread)
-  for (bst_omp_uint i = 0; i < validFeatures.size(); ++i) {
-    const bst_uint fid = validFeatures[i];
+  for (bst_omp_uint fid : validFeatures) {
     const unsigned tid = omp_get_thread_num();
     this->EnumerateSplit(-1, gmat, node_hist, snode_[nid], info,
                          &best_split_tloc_[tid], fid, nid);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -579,9 +579,10 @@ void QuantileHistMaker::Builder::EvaluateSplit(const int nid,
       validFeatures.push_back(fid);
     }
   }
+  const auto n_valid_feature = static_cast<bst_omp_uint>(validFeatures.size());
 
 #pragma omp parallel for schedule(dynamic) num_threads(nthread)
-  for (bst_omp_uint i = 0; i < validFeatures.size(); ++i) {  // NOLINT(*)
+  for (bst_omp_uint i = 0; i < n_valid_feature; ++i) {  // NOLINT(*)
     const bst_uint fid = validFeatures[i];
     const unsigned tid = omp_get_thread_num();
     this->EnumerateSplit(-1, gmat, node_hist, snode_[nid], info,

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -575,7 +575,7 @@ void QuantileHistMaker::Builder::EvaluateSplit(const int nid,
   std::vector<bst_uint> validFeatures;
   for (bst_uint i = 0; i < nfeature; ++i) {
     const bst_uint fid = static_cast<const bst_uint>(feature_set[i]);
-    if (spliteval_->CheckValidation(fid, static_cast<const bst_uint>(nid))) {
+    if (spliteval_->CheckValidation(nid, fid)) {
       validFeatures.push_back(fid);
     }
   }

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -581,7 +581,7 @@ void QuantileHistMaker::Builder::EvaluateSplit(const int nid,
   }
 
 #pragma omp parallel for schedule(dynamic) num_threads(nthread)
-  for (bst_omp_uint fid : validFeatures) {
+  for (const bst_omp_uint& fid : validFeatures) {
     const unsigned tid = omp_get_thread_num();
     this->EnumerateSplit(-1, gmat, node_hist, snode_[nid], info,
                          &best_split_tloc_[tid], fid, nid);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -575,7 +575,7 @@ void QuantileHistMaker::Builder::EvaluateSplit(const int nid,
   std::vector<bst_uint> validFeatures;
   for (bst_uint i = 0; i < nfeature; ++i) {
     const bst_uint fid = static_cast<const bst_uint>(feature_set[i]);
-    if (spliteval_->CheckValidation(nid, fid)) {
+    if (spliteval_->CheckFeatureConstraint(nid, fid)) {
       validFeatures.push_back(fid);
     }
   }


### PR DESCRIPTION
Fixes #4217 

Use feature interaction constraints to narrow search space for split candidates.

