### PR TITLE
 Combine thread launches into single launch per tree for gpu_hist

### DIFF
--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -62,6 +62,13 @@ struct TreeParam : public dmlc::Parameter<TreeParam> {
     DMLC_DECLARE_FIELD(size_leaf_vector).set_lower_bound(0).set_default(0)
         .describe("Size of leaf vector, reserved for vector tree");
   }
+
+  bool operator==(const TreeParam& b) const {
+    return num_roots == b.num_roots && num_nodes == b.num_nodes &&
+           num_deleted == b.num_deleted && max_depth == b.max_depth &&
+           num_feature == b.num_feature &&
+           size_leaf_vector == b.size_leaf_vector;
+  }
 };
 
 /*! \brief node statistics used in regression tree */
@@ -193,6 +200,7 @@ class RegTree {
              cright_ == b.cright_ && sindex_ == b.sindex_ &&
              info_.leaf_value == b.info_.leaf_value;
     }
+
    private:
     /*!
      * \brief in leaf node, we have weights, in non-leaf nodes,
@@ -310,14 +318,9 @@ class RegTree {
 
   bool operator==(const RegTree& b) const {
     return nodes_ == b.nodes_ && stats_ == b.stats_ &&
-           deleted_nodes_ == b.deleted_nodes_ &&
-           param.num_roots == b.param.num_roots &&
-           param.num_nodes == b.param.num_nodes &&
-           param.num_deleted == b.param.num_deleted &&
-           param.max_depth == b.param.max_depth &&
-           param.num_feature == b.param.num_feature;
+           deleted_nodes_ == b.deleted_nodes_ && param == b.param;
   }
-  
+
   /**
    * \brief Expands a leaf node into two additional leaf nodes.
    *

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -74,6 +74,10 @@ struct RTreeNodeStat {
   bst_float base_weight;
   /*! \brief number of child that is leaf node known up to now */
   int leaf_child_cnt;
+  bool operator==(const RTreeNodeStat& b) const {
+    return loss_chg == b.loss_chg && sum_hess == b.sum_hess &&
+           base_weight == b.base_weight && leaf_child_cnt == b.leaf_child_cnt;
+  }
 };
 
 /*!
@@ -184,7 +188,11 @@ class RegTree {
       if (is_left_child) pidx |= (1U << 31);
       this->parent_ = pidx;
     }
-
+    bool operator==(const Node& b) const {
+      return parent_ == b.parent_ && cleft_ == b.cleft_ &&
+             cright_ == b.cright_ && sindex_ == b.sindex_ &&
+             info_.leaf_value == b.info_.leaf_value;
+    }
    private:
     /*!
      * \brief in leaf node, we have weights, in non-leaf nodes,
@@ -300,6 +308,16 @@ class RegTree {
     fo->Write(dmlc::BeginPtr(stats_), sizeof(RTreeNodeStat) * nodes_.size());
   }
 
+  bool operator==(const RegTree& b) const {
+    return nodes_ == b.nodes_ && stats_ == b.stats_ &&
+           deleted_nodes_ == b.deleted_nodes_ &&
+           param.num_roots == b.param.num_roots &&
+           param.num_nodes == b.param.num_nodes &&
+           param.num_deleted == b.param.num_deleted &&
+           param.max_depth == b.param.max_depth &&
+           param.num_feature == b.param.num_feature;
+  }
+  
   /**
    * \brief Expands a leaf node into two additional leaf nodes.
    *

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,7 +99,9 @@ endif (XGBOOST_BUILTIN_PREFETCH_PRESENT)
 if (USE_OPENMP)
   find_package(OpenMP REQUIRED)
   if (OpenMP_CXX_FOUND OR OPENMP_FOUND)
-    target_compile_options(objxgboost PRIVATE  $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
+    target_compile_options(objxgboost PRIVATE  $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>
+      $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
+    )
     list(APPEND SRC_LIBS ${OpenMP_CXX_LIBRARIES})
     set(LINKED_LIBRARIES_PRIVATE "${LINKED_LIBRARIES_PRIVATE};${SRC_LIBS}" PARENT_SCOPE)
   endif (OpenMP_CXX_FOUND OR OPENMP_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,12 @@ if (USE_CUDA)
     target_compile_definitions(objxgboost PRIVATE -DXGBOOST_USE_NVTX=1)
   endif (USE_NVTX)
 
+  # OpenMP is mandatory for cuda version
+  find_package(OpenMP REQUIRED)
+  target_compile_options(objxgboost PRIVATE  
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
+  )
+
   set_target_properties(objxgboost PROPERTIES
     CUDA_SEPARABLE_COMPILATION OFF)
 else (USE_CUDA)
@@ -99,9 +105,7 @@ endif (XGBOOST_BUILTIN_PREFETCH_PRESENT)
 if (USE_OPENMP)
   find_package(OpenMP REQUIRED)
   if (OpenMP_CXX_FOUND OR OPENMP_FOUND)
-    target_compile_options(objxgboost PRIVATE  $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>
-      $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
-    )
+    target_compile_options(objxgboost PRIVATE  $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
     list(APPEND SRC_LIBS ${OpenMP_CXX_LIBRARIES})
     set(LINKED_LIBRARIES_PRIVATE "${LINKED_LIBRARIES_PRIVATE};${SRC_LIBS}" PARENT_SCOPE)
   endif (OpenMP_CXX_FOUND OR OPENMP_FOUND)

--- a/src/common/random.h
+++ b/src/common/random.h
@@ -115,8 +115,16 @@ class ColumnSampler {
  public:
   /** 
    * \brief Column sampler constructor.
-   * \note This constructor synchronizes the RNG seed across processes.
+   * \note This constructor manually sets the rng seed
    */
+  explicit ColumnSampler(uint32_t seed) {
+    rng_.seed(seed);
+  }
+
+  /**
+  * \brief Column sampler constructor.
+  * \note This constructor synchronizes the RNG seed across processes.
+  */
   ColumnSampler() {
     uint32_t seed = common::GlobalRandom()();
     rabit::Broadcast(&seed, sizeof(seed), 0);

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -342,7 +342,8 @@ class GPUPredictor : public xgboost::Predictor {
   }
 
  public:
-  GPUPredictor() : cpu_predictor_(Predictor::Create("cpu_predictor")) {}
+  GPUPredictor()                                               // NOLINT
+      : cpu_predictor_(Predictor::Create("cpu_predictor")) {}  // NOLINT
 
   void PredictBatch(DMatrix* dmat, HostDeviceVector<bst_float>* out_preds,
                     const gbm::GBTreeModel& model, int tree_begin,

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -598,7 +598,8 @@ inline void SortPosition(dh::CubMemory* temp_memory, common::Span<int> position,
 }
 
 /*! \brief Count how many rows are assigned to left node. */
-__device__ void CountLeft(int64_t* d_count, int val, int left_nidx) {
+__forceinline__ __device__ void CountLeft(int64_t* d_count, int val,
+                                          int left_nidx) {
 #if __CUDACC_VER_MAJOR__ > 8
   int mask = __activemask();
   unsigned ballot = __ballot_sync(mask, val == left_nidx);
@@ -1495,6 +1496,11 @@ class GPUHistMakerSpecialised{
           shard->UpdateTree(gpair, p_fmat, tree,
                           &reducer_);
         });
+
+    // Check the shards produced identical trees
+    for (auto i = 1ull; i < dummy_trees.size(); i++) {
+      CHECK(*p_tree == dummy_trees.at(i));
+    }
   }
 
   bool UpdatePredictionCache(

--- a/tests/cpp/common/test_random.cc
+++ b/tests/cpp/common/test_random.cc
@@ -51,7 +51,7 @@ TEST(ColumnSampler, Test) {
 
 // Test if different threads using the same seed produce the same result
 TEST(ColumnSampler, ThreadSynchronisation) {
-  const int64_t num_threads = 10;
+  const int64_t num_threads = 100;
   int n = 128;
   int iterations = 10;
   int levels = 5;
@@ -70,6 +70,7 @@ TEST(ColumnSampler, ThreadSynchronisation) {
         if (result != reference_result) {
           success = false;
         }
+#pragma omp barrier
       }
     }
   }

--- a/tests/distributed/distributed_gpu.py
+++ b/tests/distributed/distributed_gpu.py
@@ -54,7 +54,8 @@ base_params = {
     'max_depth': 2,
     'eta': 1,
     'verbosity': 0,
-    'objective': 'binary:logistic'
+    'objective': 'binary:logistic',
+    'debug_synchronize': True
 }
 
 

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -51,7 +51,7 @@ class TestGPU(unittest.TestCase):
         variable_param = {'n_gpus': [-1], 'max_depth': [2, 10],
                           'max_leaves': [255, 4],
                           'max_bin': [2, 256],
-                          'grow_policy': ['lossguide']}
+                          'grow_policy': ['lossguide'], 'debug_synchronize': [True]}
         for param in parameter_combinations(variable_param):
             param['tree_method'] = 'gpu_hist'
             gpu_results = run_suite(param, select_datasets=datasets)


### PR DESCRIPTION
This PR contains major changes in the design of the gpu_hist algorithm. Previously we repeatedly launched groups of omp threads with one thread per GPU to execute some unit of work on the GPU. During a single tree construction there would be hundreds of thread launches. This can cause stalls as shown here:
![multi-gpu-stall](https://user-images.githubusercontent.com/7307640/55758034-b25e2d00-5aa9-11e9-9cc2-31853e60b6c1.png)
This PR now launches one thread per GPU and this thread is used to construct the entire tree, only exiting when tree construction is finished. Each device shard still needs to communicate with other shards, but this is achieved via NCCL.

So we now no longer need to create and destroy many threads per iteration (or rely on the omp implementation to manage the thread pool efficiently) and we now avoid any unnecessary CPU thread synchronisation.

This PR also fixes #4332

Potential issues to look out for:
- Each device shard redundantly builds its own tree. If these trees were to somehow get out of sync, the algorithm would fail. Given that the histograms have been synced, I expect these to be identical. This potential issue also applies to the distributed GPU version even before this PR.
- Correct use of NCCL. I believe we have had some issues with deadlocks when using NCCL from multiple threads before. I have never experienced this myself. 

@canonizer @trivialfis can you please review.