### PR TITLE
Add travis logo to README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src=https://raw.githubusercontent.com/dmlc/dmlc.github.io/master/img/logo-m/xgboost.png width=135/>  eXtreme Gradient Boosting
 ===========
 [![Build Status](https://xgboost-ci.net/job/xgboost/job/master/badge/icon?style=plastic)](https://xgboost-ci.net/blue/organizations/jenkins/xgboost/activity)
-[![Build Status](https://travis-ci.org/dmlc/xgboost.svg?branch=master)](https://travis-ci.org/dmlc/xgboost)
+[![Build Status](https://img.shields.io/travis/dmlc/xgboost.svg?label=build&logo=travis&branch=master)](https://travis-ci.org/dmlc/xgboost)
 [![Build Status](https://ci.appveyor.com/api/projects/status/5ypa8vaed6kpmli8?svg=true)](https://ci.appveyor.com/project/tqchen/xgboost)
 [![Documentation Status](https://readthedocs.org/projects/xgboost/badge/?version=latest)](https://xgboost.readthedocs.org)
 [![GitHub license](http://dmlc.github.io/img/apache2.svg)](./LICENSE)


### PR DESCRIPTION
While reading through your docs tonight, I noticed that the first two badges in the main README are indistinguishable visually:

![image](https://user-images.githubusercontent.com/7608904/55766620-1269ba80-5a3b-11e9-9344-cb2956137a57.png)

Would you consider this small PR to add the Travis logo to the Travis badge?

![image](https://user-images.githubusercontent.com/7608904/55766648-30371f80-5a3b-11e9-9276-3900d02a7e56.png)