### PR TITLE
added files from local R build to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,7 @@ metastore_db
 
 plugin/updater_gpu/test/cpp/data
 /include/xgboost/build_config.h
+
+# files from R-package source install
+**/config.status
+R-package/src/Makevars


### PR DESCRIPTION
When running the [instructions for installing the development version of the R-package](https://xgboost.readthedocs.io/en/latest/build.html#installing-the-development-version), I found that two new files were cerated which are not currently ignored by this project's `.gitignore`:

![image](https://user-images.githubusercontent.com/7608904/55767553-f700ae80-5a3e-11e9-8027-699084d2ae71.png)

I hope you'll consider this PR to ignore these files in `.gitignore` to make it clear to future contributors that those files should not be committed and to prevent people from inadvertently committing them if they use `git add .`.