### PR TITLE
[r-package] cut CI-time dependency on craigcitro/r-travis (fixes #4348)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ addons:
       - g++-4.8
       - gcc-7
       - g++-7
+      - r-base-dev
+      - r-recommended
   homebrew:
     packages:
       - gcc@7

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ addons:
       - graphviz
       - openssl
       - libgit2
+      - r
     update: true
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,6 @@ addons:
       - g++-4.8
       - gcc-7
       - g++-7
-      - r-base-dev
-      - r-recommended
   homebrew:
     packages:
       - gcc@7

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -84,7 +84,10 @@ if [ ${TASK} == "r_test" ]; then
     cd ./xgboost
 
     # Install package deps
-    Rscript -e "install.packages('devtools', repos = 'http://cloud.r-project.org')"
+    Rscript -e "install.packages( \
+        c('devtools', 'knitr', 'rmarkdown', 'testthat', 'lintr') \
+        , repos = 'http://cloud.r-project.org' \
+    )"
     Rscript -e \
         "devtools::install_deps( \
             repos = 'http://cloud.r-project.org',\

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -85,14 +85,15 @@ if [ ${TASK} == "r_test" ]; then
 
     # Install package deps
     Rscript -e "install.packages( \
-        c('devtools', 'knitr', 'rmarkdown', 'testthat', 'lintr') \
+        c('devtools', 'testthat', 'lintr') \
         , repos = 'http://cloud.r-project.org' \
+        ,  dependencies = c('Depends', 'Imports', 'LinkingTo') \
     )"
     Rscript -e \
         "devtools::install_deps( \
             repos = 'http://cloud.r-project.org',\
             upgrade = 'never', \
-            dependencies = c('Depends', 'Imports') \
+            dependencies = c('Depends', 'Imports', 'LinkingTo') \
         )"
 
     # install suggested packages separately to avoid huge build times
@@ -109,6 +110,7 @@ if [ ${TASK} == "r_test" ]; then
     R_PACKAGE_TARBALL=$(ls -1t *.tar.gz | head -n 1)
 
     export _R_CHECK_TIMINGS_=0
+    export R_CHECK_FORCE_SUGGESTS=false
     R CMD check \
         ${R_PACKAGE_TARBALL} \
         --no-vignettes \

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -79,12 +79,6 @@ fi
 
 if [ ${TASK} == "r_test" ]; then
     set -e
-    if [ ${TRAVIS_OS_NAME} == "osx" ]; then
-        # Work-around to fix "gfortran command not found" error
-        sudo ln -s $(which gfortran-7) /usr/local/bin/gfortran
-        sudo mkdir -p /usr/local/gfortran/lib/gcc/x86_64-apple-darwin15
-        sudo ln -s /usr/local/lib/gcc/7 /usr/local/gfortran/lib/gcc/x86_64-apple-darwin15/6.1.0
-    fi
 
     make Rpack
     cd ./xgboost

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -88,7 +88,6 @@ if [ ${TASK} == "r_test" ]; then
         c('devtools', 'testthat', 'lintr') \
         , repos = 'http://cloud.r-project.org' \
         , dependencies = c('Depends', 'Imports', 'LinkingTo') \
-        , type = 'both' \
     )"
 
     Rscript -e \
@@ -103,7 +102,6 @@ if [ ${TASK} == "r_test" ]; then
         c('DiagrammeR', 'Ckmeans.1d.dp', 'vcd') \
         , repos = 'https://cloud.r-project.org' \
         , dependencies = c('Depends', 'Imports', 'LinkingTo') \
-        , type = 'both' \
     )"
 
     # Run tests

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -79,9 +79,6 @@ fi
 
 if [ ${TASK} == "r_test" ]; then
     set -e
-    export _R_CHECK_TIMINGS_=0
-    export R_BUILD_ARGS="--no-build-vignettes --no-manual"
-    export R_CHECK_ARGS="--no-vignettes --no-manual"
     if [ ${TRAVIS_OS_NAME} == "osx" ]; then
         # Work-around to fix "gfortran command not found" error
         sudo ln -s $(which gfortran-7) /usr/local/bin/gfortran
@@ -89,13 +86,39 @@ if [ ${TASK} == "r_test" ]; then
         sudo ln -s /usr/local/lib/gcc/7 /usr/local/gfortran/lib/gcc/x86_64-apple-darwin15/6.1.0
     fi
 
-    curl -OL https://raw.githubusercontent.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-    chmod 755 ./travis-tool.sh
-    ./travis-tool.sh bootstrap
     make Rpack
     cd ./xgboost
-    ../travis-tool.sh install_deps
-    ../travis-tool.sh run_tests
+
+    # Install package deps
+    Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
+    Rscript -e \
+        "devtools::install_deps( \
+            repos = 'http://cran.rstudio.com',\
+            upgrade = 'never', \
+            dependencies = c('Depends', 'Imports') \
+        )"
+
+    # install suggested packages separately to avoid huge build times
+    Rscript -e "install.packages(c('DiagrammeR', 'Ckmeans.1d.dp', 'vcd'))"
+
+    # Run tests
+    echo "Building with R CMD build"
+    R CMD build \
+        --no-build-vignettes \
+        --no-manual \
+        .
+
+    echo "Running R tests"
+    R_PACKAGE_TARBALL=$(ls -1t *.tar.gz | head -n 1)
+
+    export _R_CHECK_TIMINGS_=0
+    R CMD check \
+        ${R_PACKAGE_TARBALL} \
+        --no-vignettes \
+        --no-manual \
+        --as-cran \
+        --install-args=--build
+
     exit 0
 fi
 

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -87,17 +87,24 @@ if [ ${TASK} == "r_test" ]; then
     Rscript -e "install.packages( \
         c('devtools', 'testthat', 'lintr') \
         , repos = 'http://cloud.r-project.org' \
-        ,  dependencies = c('Depends', 'Imports', 'LinkingTo') \
+        , dependencies = c('Depends', 'Imports', 'LinkingTo') \
+        , type = 'both' \
     )"
+
     Rscript -e \
         "devtools::install_deps( \
-            repos = 'http://cloud.r-project.org',\
-            upgrade = 'never', \
-            dependencies = c('Depends', 'Imports', 'LinkingTo') \
+            repos = 'http://cloud.r-project.org' \
+            , upgrade = 'never' \
+            , dependencies = c('Depends', 'Imports', 'LinkingTo') \
         )"
 
     # install suggested packages separately to avoid huge build times
-    Rscript -e "install.packages(c('DiagrammeR', 'Ckmeans.1d.dp', 'vcd'), repos = 'https://cloud.r-project.org')"
+    Rscript -e "install.packages( \
+        c('DiagrammeR', 'Ckmeans.1d.dp', 'vcd') \
+        , repos = 'https://cloud.r-project.org' \
+        , dependencies = c('Depends', 'Imports', 'LinkingTo') \
+        , type = 'both' \
+    )"
 
     # Run tests
     echo "Building with R CMD build"
@@ -110,7 +117,7 @@ if [ ${TASK} == "r_test" ]; then
     R_PACKAGE_TARBALL=$(ls -1t *.tar.gz | head -n 1)
 
     export _R_CHECK_TIMINGS_=0
-    export R_CHECK_FORCE_SUGGESTS=false
+    export _R_CHECK_FORCE_SUGGESTS_=false
     R CMD check \
         ${R_PACKAGE_TARBALL} \
         --no-vignettes \

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -84,16 +84,16 @@ if [ ${TASK} == "r_test" ]; then
     cd ./xgboost
 
     # Install package deps
-    Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.com')"
+    Rscript -e "install.packages('devtools', repos = 'http://cloud.r-project.org')"
     Rscript -e \
         "devtools::install_deps( \
-            repos = 'http://cran.rstudio.com',\
+            repos = 'http://cloud.r-project.org',\
             upgrade = 'never', \
             dependencies = c('Depends', 'Imports') \
         )"
 
     # install suggested packages separately to avoid huge build times
-    Rscript -e "install.packages(c('DiagrammeR', 'Ckmeans.1d.dp', 'vcd'))"
+    Rscript -e "install.packages(c('DiagrammeR', 'Ckmeans.1d.dp', 'vcd'), repos = 'https://cloud.r-project.org')"
 
     # Run tests
     echo "Building with R CMD build"


### PR DESCRIPTION
Currently, this project's R stage on Travis depends on `craigcitro/r-travis`, a project that was officially [deprecated in July 2016](https://github.com/craigcitro/r-travis/commit/dd538f85b2d3ca42e6587beb363f2ea54de5bb55). In this PR, I propose a way to factor it out.

See #4348 and other linked issues there for more details.

Thanks for considering it!