### PR TITLE
[jvm-packages] fix compatibility problem of spark version

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/MissingValueHandlingSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/MissingValueHandlingSuite.scala
@@ -16,12 +16,13 @@
 
 package ml.dmlc.xgboost4j.scala.spark
 
-import scala.util.Random
 import ml.dmlc.xgboost4j.java.XGBoostError
-import org.scalatest.FunSuite
 import org.apache.spark.ml.feature.VectorAssembler
-import org.apache.spark.ml.linalg.{DenseVector, Vectors}
+import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.sql.DataFrame
+import org.scalatest.FunSuite
+
+import scala.util.Random
 
 class MissingValueHandlingSuite extends FunSuite with PerTest {
   test("dense vectors containing missing value") {
@@ -47,16 +48,26 @@ class MissingValueHandlingSuite extends FunSuite with PerTest {
   test("handle Float.NaN as missing value correctly") {
     val spark = ss
     import spark.implicits._
-    val inputDF = Seq(
-      new DenseVector(Array[Double](1.0, 0.0, Double.NaN)) -> 1.0,
-      new DenseVector(Array[Double](1.0, 0.0, 1.0)) -> 1.0,
-      new DenseVector(Array[Double](0.0, 1.0, 0.0)) -> 0.0,
-      new DenseVector(Array[Double](1.0, 0.0, 1.0)) -> 1.0,
-      new DenseVector(Array[Double](1.0, Double.NaN, 0.0)) -> 0.0,
-      new DenseVector(Array[Double](0.0, 0.0, 0.0)) -> 0.0,
-      new DenseVector(Array[Double](0.0, 1.0, 0.0)) -> 1.0,
-      new DenseVector(Array[Double](Double.NaN, 0.0, 0.0)) -> 1.0
-    ).toDF("features", "label")
+    val testDF = Seq(
+      (1.0f, 0.0f, Float.NaN, 1.0),
+      (1.0f, 0.0f, 1.0f, 1.0),
+      (0.0f, 1.0f, 0.0f, 0.0),
+      (1.0f, 0.0f, 1.0f, 1.0),
+      (1.0f, Float.NaN, 0.0f, 0.0),
+      (0.0f, 1.0f, 0.0f, 1.0),
+      (Float.NaN, 0.0f, 0.0f, 1.0)
+    ).toDF("col1", "col2", "col3", "label")
+    val vectorAssembler = new VectorAssembler()
+      .setInputCols(Array("col1", "col2", "col3"))
+      .setOutputCol("features")
+    org.apache.spark.SPARK_VERSION match {
+      case version if version.startsWith("2.4") =>
+        val m = vectorAssembler.getClass.getDeclaredMethods
+          .filter(_.getName.contains("setHandleInvalid")).head
+        m.invoke(vectorAssembler, "keep")
+      case _ =>
+    }
+    val inputDF = vectorAssembler.transform(testDF).select("features", "label")
     val paramMap = List("eta" -> "1", "max_depth" -> "2",
       "objective" -> "binary:logistic", "missing" -> Float.NaN, "num_workers" -> 1).toMap
     val model = new XGBoostClassifier(paramMap).fit(inputDF)


### PR DESCRIPTION
I found that `VectorAssembler. setHandleInvalid`,  which used in `MissingValueHandlingSuite.scala`, 
is newly added in spark_2.4.
So, I tried to replace`VectorAssembler` by creating `DenseVector` directly.