### PR TITLE
Initial commit for bart.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ address, leak and thread.")
 ## Plugins
 option(PLUGIN_LZ4 "Build lz4 plugin" OFF)
 option(PLUGIN_DENSE_PARSER "Build dense parser plugin" OFF)
+option(PLUGIN_BART "Build bart plugin" ON)
 
 ## Deprecation warning
 if (USE_AVX)
@@ -54,6 +55,10 @@ if (USE_CUDA)
   format_gencode_flags("${GPU_COMPUTE_VER}" GEN_CODE)
   message(STATUS "CUDA GEN_CODE: ${GEN_CODE}")
 endif (USE_CUDA)
+
+if (PLUGIN_BART)
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/plugin/bart)
+endif (PLUGIN_BART)
 
 # dmlc-core
 add_subdirectory(${PROJECT_SOURCE_DIR}/dmlc-core)

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -495,7 +495,7 @@ class RegTree {
    */
   void FillNodeMeanValues();
 
- private:
+ protected:
   // vector of nodes
   std::vector<Node> nodes_;
   // free node space, used during training process

--- a/plugin/bart/CMakeLists.txt
+++ b/plugin/bart/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(BART_SOURCES
+  ${CMAKE_CURRENT_LIST_DIR}/src/bart.cc
+  ${CMAKE_CURRENT_LIST_DIR}/src/gibbs_updater.cc
+  PARENT_SCOPE)
+
+if (GOOGLE_TEST)
+  set(BART_TESTS_SOURCE
+    ${CMAKE_CURRENT_LIST_DIR}/tests/test_gibbs_updater.cc
+    ${CMAKE_CURRENT_LIST_DIR}/tests/test_rv.cc
+    PARENT_SCOPE)
+endif (GOOGLE_TEST)

--- a/plugin/bart/src/bart.cc
+++ b/plugin/bart/src/bart.cc
@@ -68,7 +68,7 @@ class Bart : public GradientBooster {
 };
 
 XGBOOST_REGISTER_GBM(Bart, "bart")
-    .describe("Linear booster, implement generalized linear model.")
+    .describe("Bayesian Additive Tree.")
     .set_body([](const std::vector<std::shared_ptr<DMatrix> > &cache,
                  bst_float base_margin) {
       return new Bart(cache, base_margin);

--- a/plugin/bart/src/bart.cc
+++ b/plugin/bart/src/bart.cc
@@ -1,0 +1,78 @@
+#include <xgboost/data.h>
+#include <xgboost/gbm.h>
+#include <vector>
+
+#include "gibbs_updater.h"
+
+namespace xgboost {
+namespace bart {
+
+struct BartTrainParam : public dmlc::Parameter<BartTrainParam> {
+  bst_uint num_trees;
+  DMLC_DECLARE_PARAMETER(BartTrainParam) {
+    DMLC_DECLARE_FIELD(num_trees)
+        .set_default(100);
+  }
+};
+
+DMLC_REGISTER_PARAMETER(BartTrainParam);
+
+class Bart : public GradientBooster {
+  GibbsUpdater _updater;
+  std::vector<std::shared_ptr<RegTree>> _p_trees;
+  BartTrainParam _param;
+
+ public:
+  explicit Bart(const std::vector<std::shared_ptr<DMatrix> > &cache,
+                bst_float base_margin) {}
+  void Configure(const std::vector<std::pair<std::string, std::string> >& cfg) override {
+    _param.InitAllowUnknown(cfg);
+    _p_trees.resize(_param.num_trees);
+    for (size_t i = 0; i < _param.num_trees; ++i)  {
+      _p_trees[i].reset(new RegTree);
+    }
+    _updater.configure(cfg);
+  }
+
+  void Load(dmlc::Stream* fi) override {}
+  void Save(dmlc::Stream* fo) const override {}
+  void DoBoost(DMatrix *p_fmat,
+               HostDeviceVector<GradientPair> *in_gpair,
+               ObjFunction* obj) override {
+    _updater.update(p_fmat, _p_trees);
+  }
+  void PredictBatch(DMatrix *p_fmat,
+                    HostDeviceVector<bst_float> *out_preds,
+                    unsigned ntree_limit) override {
+    // _updater.predict(p_fmat, _p_trees, out_preds);
+  }
+  void PredictLeaf(DMatrix *p_fmat,
+                   std::vector<bst_float> *out_preds,
+                   unsigned ntree_limit) override {}
+  void PredictInstance(const SparsePage::Inst &inst,
+                       std::vector<bst_float> *out_preds,
+                       unsigned ntree_limit,
+                       unsigned root_index) override {}
+  void PredictContribution(DMatrix* p_fmat,
+                           std::vector<bst_float>* out_contribs,
+                           unsigned ntree_limit, bool approximate, int condition = 0,
+                           unsigned condition_feature = 0) override {}
+  void PredictInteractionContributions(DMatrix* p_fmat,
+                                       std::vector<bst_float>* out_contribs,
+                                       unsigned ntree_limit, bool approximate) override {}
+  std::vector<std::string> DumpModel(const FeatureMap& fmap,
+                                     bool with_stats,
+                                     std::string format) const override {
+    return {};
+  }
+};
+
+XGBOOST_REGISTER_GBM(Bart, "bart")
+    .describe("Linear booster, implement generalized linear model.")
+    .set_body([](const std::vector<std::shared_ptr<DMatrix> > &cache,
+                 bst_float base_margin) {
+      return new Bart(cache, base_margin);
+    });
+}
+
+}  // namespace xgboost

--- a/plugin/bart/src/gibbs_updater.cc
+++ b/plugin/bart/src/gibbs_updater.cc
@@ -119,9 +119,9 @@ int32_t TreeMutation::grow(float sigma, GibbsParam param, DMatrix* p_fmat) {
   for (auto& batch : p_fmat->GetColumnBatches()) {
     auto column = batch[split_feature];
     CHECK_NE(column.size(), 0);
-    auto max = column[column.size() - 1].fvalue;
-    auto min = column[0].fvalue;
-    CHECK_GE(min, max);
+    auto min = column[column.size() - 1].fvalue;
+    auto max = column[0].fvalue;
+    CHECK_LE(min, max);
     split_cond = Uniform(min, max).sample();
   }
 

--- a/plugin/bart/src/gibbs_updater.cc
+++ b/plugin/bart/src/gibbs_updater.cc
@@ -1,0 +1,340 @@
+#include <dmlc/parameter.h>
+#include <xgboost/base.h>
+#include <xgboost/data.h>
+#include <xgboost/logging.h>
+#include <xgboost/tree_model.h>
+
+#include <cinttypes>
+
+#include "gibbs_updater.h"
+#include "rv.h"
+#include "../../src/common/timer.h"
+
+namespace xgboost {
+
+DMLC_REGISTER_PARAMETER(GibbsParam);
+
+bst_float TreeMutation::growTransitionRatio(int32_t nid) {
+  CHECK_NE(this, _chain->at(_tree_id).back().get())
+      << "Tree being sampled should not be put into the chain.";
+  auto const& last_tree = _chain->lastTree(_tree_id);
+  float const n_splitable_nodes = last_tree->_splitable_nodes.size();
+  float const n_splitable_features = _splitable_features.size();
+  // find number of internal nodes which have only two childern
+  // terminal nodes.  Since every split has exact two children, that
+  // would be all parents of leaf nodes.
+  float const n_prunable_nodes = _prunable_nodes.size();
+
+  // FIXME(trivialfis): For now we just assume the values are unique
+  float const n_rows_in_node = _indices.at(nid).size() + kRtEps;
+  float result = std::log(n_rows_in_node) + std::log(n_splitable_features)
+                 + std::log(n_splitable_nodes) - std::log(n_prunable_nodes);
+  return result;
+}
+
+bst_float TreeMutation::growLikelihoodRatio(float sigma, float sigma_mu,
+                                            int32_t parent, int32_t left, int32_t right) {
+  float const n_left_rows = _indices.at(left).size();
+  float const n_right_rows = _indices.at(right).size();
+
+  float parent_to_children = 0;
+  {
+    float parent = sigma * (sigma + n_left_rows * sigma_mu);
+    float left = sigma + n_left_rows * sigma_mu;
+    float right = sigma + n_right_rows * sigma_mu;
+
+    parent_to_children = parent / (left * right);
+    parent_to_children = std::sqrt(parent_to_children);
+    parent_to_children = std::log(parent_to_children);
+  }
+
+  float exp_term = 0;
+  {
+    float left_response = 0;
+    for (size_t i = 0; i < n_left_rows; ++i) {
+      left_response += _responses[_indices[left][i]];
+    }
+    left_response *= left_response;
+    float denominator = sigma + n_left_rows * sigma_mu + kRtEps;
+    exp_term += left_response / denominator;
+  }
+  {
+    float right_response = 0;
+    for (size_t i  = 0; i < n_right_rows; ++i) {
+      right_response += _responses[_indices[right][i]];
+    }
+    right_response *= right_response;
+    float denominator = sigma + n_right_rows * sigma_mu + kRtEps;
+    exp_term += right_response / denominator;
+  }
+  {
+    float parent_response = 0.0f;
+    for (size_t i = 0; i < _indices.at(parent).size(); ++i) {
+      parent_response += _responses[_indices[parent][i]];
+    }
+    parent_response *= parent_response;
+    float denominator = sigma + _indices.at(parent).size() * sigma_mu + kRtEps;
+    exp_term -= parent_response / denominator;
+  }
+  float const multiplier = sigma_mu / (2 * sigma + kRtEps);
+  exp_term *= multiplier;
+
+  float result = parent_to_children + exp_term;
+  return result;
+}
+
+bst_float TreeMutation::growTreeStructureRatio(int32_t parent,
+                                               bst_float const alpha, bst_float const beta) {
+  bst_float const depth = RegTree::GetDepth(parent);
+  bst_float const n_splitable_nodes = _splitable_nodes.size() + kRtEps;
+  bst_float const n_rows_in_node = _indices.at(parent).size() + kRtEps;
+
+  bst_float result = std::log(alpha);
+  result += 2.0f * std::log(1 - (alpha / std::pow(2+depth, beta)));
+  result -= std::log(std::pow(1+depth, beta) - alpha);
+  result -= std::log(n_splitable_nodes);
+  result -= std::log(n_rows_in_node);
+
+  return result;
+}
+
+int32_t TreeMutation::grow(float sigma, GibbsParam param, DMatrix* p_fmat) {
+  if (_splitable_nodes.size() == 0) {
+    LOG(DEBUG) << "No splitable node.";
+    return kRejected;
+  }
+  // sample a node for split
+  size_t const splitnode_pos = Uniform(0, _splitable_nodes.size()).sample();
+  int32_t const split_nid = _splitable_nodes[splitnode_pos];
+  CHECK((*this)[split_nid].IsLeaf())     << "split.nid: " << split_nid;
+  CHECK(!(*this)[split_nid].IsDeleted()) << "split.nid: " << split_nid;
+
+  // sample a column for split
+  auto feature_id = static_cast<int32_t>(
+      Uniform(0, _splitable_features.size()).sample());
+  auto split_feature = _splitable_features[feature_id];
+
+  // sample a value for split
+  bst_float split_cond = 0;
+  for (auto& batch : p_fmat->GetColumnBatches()) {
+    auto column = batch[split_feature];
+    CHECK_NE(column.size(), 0);
+    auto max = column[column.size() - 1].fvalue;
+    auto min = column[0].fvalue;
+    CHECK_GE(min, max);
+    split_cond = Uniform(min, max).sample();
+  }
+
+  this->applySplit(split_nid, split_feature, split_cond, p_fmat);
+  return split_nid;
+}
+
+int32_t TreeMutation::prune(float sigma, GibbsParam param, DMatrix *p_fmat) {
+  if (_prunable_nodes.size() == 0) {
+    LOG(DEBUG) << "No prunable node found.";
+    return kRejected;
+  }
+  // sample a node to prune
+  size_t prune_pos = static_cast<size_t>(Uniform(0, _prunable_nodes.size()).sample());
+  int32_t parent_id = _prunable_nodes[prune_pos];
+
+  CHECK(!(*this)[parent_id].IsLeaf()) << "prune.id: " << parent_id;
+
+  int32_t left_id = (*this)[parent_id].LeftChild();
+  auto left_node = (*this)[left_id];
+
+  int32_t right_id = (*this)[parent_id].RightChild();
+  auto right_node = (*this)[right_id];
+
+  applyPrune(parent_id, (*this)[parent_id].SplitIndex());
+  return parent_id;
+}
+
+void GibbsUpdater::updateTrees(DMatrix* p_fmat) {
+  auto& labels = p_fmat->Info().labels_.HostVector();
+  for (int32_t tree_id = 0; tree_id < _chain.size(); ++tree_id) {
+    computeResponse(tree_id, labels);
+    auto& tree = _chain.lastTree(tree_id);  // the last tree
+    TreeMutation candidate{ &_chain, tree_id, p_fmat };
+    candidate = *tree;
+    candidate.updateResponse(_responses_cache);
+
+    // choose action
+    auto action_id = _move_chooser.sample();
+    auto action = static_cast<MoveKind>(action_id);
+    if (tree->NumExtraNodes() == 0) {
+      // force grow
+      action = MoveKind::kGrow;
+    }
+    int32_t changed_nid = TreeMutation::kRejected;
+    switch(action) {
+      case MoveKind::kGrow: {
+        int32_t split_nid = candidate.grow(_sigma, _param, p_fmat);
+        if (split_nid == TreeMutation::kRejected) {
+          break;
+        }
+        int32_t left_id = candidate[split_nid].LeftChild();
+        int32_t right_id = candidate[split_nid].RightChild();
+
+        float const ratio =
+            candidate.growAcceptanceRatio(split_nid, left_id, right_id, _sigma, _param);
+        bool accept = std::log(Uniform(0.0f, 1.0f).sample()) < ratio;
+
+        if (accept) {
+          changed_nid = split_nid;
+        } else {
+          LOG(DEBUG) << "Grow proposal rejected.";
+          changed_nid = TreeMutation::kRejected;
+        }
+      }
+        break;
+      case MoveKind::kPrune: {
+        int32_t prune_nid = candidate.prune(_sigma, _param, p_fmat);
+        if (prune_nid == TreeMutation::kRejected) {
+          break;
+        }
+        int32_t left_id = candidate[prune_nid].LeftChild();
+        int32_t right_id = candidate[prune_nid].RightChild();
+        float const ratio = -candidate.growAcceptanceRatio(
+            prune_nid, left_id, right_id, _sigma, _param);
+        bool accept = std::log(Uniform(0.0f, 1.0f).sample()) < ratio;
+        if (accept) {
+          changed_nid = prune_nid;
+        } else {
+          LOG(DEBUG) << "prune proposal rejected.";
+          changed_nid = TreeMutation::kRejected;
+        }
+      }
+        break;
+      case MoveKind::kChange:
+        LOG(FATAL) << "Not implemented.";
+        break;
+      case MoveKind::kSwap:
+        LOG(FATAL) << "Not implemented.";
+        break;
+    }
+
+    if (changed_nid != TreeMutation::kRejected) {
+      auto& old_predictions = tree->getPredictionCache();
+      CHECK_EQ(old_predictions.size(), _running_sum.size());
+      for (size_t i = 0; i < _running_sum.size(); ++i) {
+        _running_sum[i] -= old_predictions[i];
+      }
+
+      candidate.sampleLeaf(changed_nid, _sigma, _param);
+      _chain.at(tree_id).emplace_back(
+          std::unique_ptr<TreeMutation>{new TreeMutation{&_chain, tree_id, p_fmat}});
+      *_chain.lastTree(tree_id) = candidate;
+
+      auto& predictions = candidate.getPredictionCache();
+      for (size_t i = 0; i < _running_sum.size(); ++i) {
+        _running_sum[i] += predictions[i];
+      }
+    } else {
+      std::unique_ptr<TreeMutation> copied_tree { new TreeMutation{&_chain, tree_id, p_fmat} };
+      // Copy the tree first, `emplace_back` might destroy the pointer during resize.
+      *copied_tree = *tree;
+      CHECK_GT(_chain.size(), tree_id);
+      // push the old tree
+      _chain.add(tree_id, std::move(copied_tree));
+    }
+  }
+}
+
+void GibbsUpdater::computeResponse(size_t tree_id, std::vector<float> const& labels) {
+  _responses_cache.resize(labels.size());
+  auto& trees = _chain.back();
+  auto predictions = trees.at(tree_id)->getPredictionCache();
+  for (size_t i = 0; i < _responses_cache.size(); ++i) {
+    _responses_cache[i] = labels [i] - _running_sum[i] + predictions[i];
+  }
+}
+
+std::pair<float, float> normaliseLabels(HostDeviceVector<bst_float>* y) {
+  auto& h_y = y->HostVector();
+  auto min_iter = std::min_element(h_y.cbegin(), h_y.cend());
+  auto max_iter = std::max_element(h_y.cbegin(), h_y.cend());
+
+  bst_float min = *min_iter;
+  bst_float max = *max_iter;
+
+  bst_float diff = *max_iter - *min_iter;
+  std::transform(h_y.begin(), h_y.end(), h_y.begin(),
+                 [&](bst_float value) {
+                   return (*min_iter + *max_iter) / 2;
+                 });
+  return std::make_pair(min, max);
+}
+
+void GibbsUpdater::initData(DMatrix* p_fmat) {
+  auto& info = p_fmat->Info();
+  // FIXME: Change to out of place.
+  std::tie(_y_min, _y_max) = normaliseLabels(&info.labels_);
+  _running_sum.resize(info.num_row_);
+
+  // compute prior for sigma
+  float shape = (_param.nu + info.num_row_) * 0.5;
+  float rate = _param.nu * _param.lambda * 0.5;
+  _sigma_sampler = InverseGamma(shape, rate);
+}
+
+void GibbsUpdater::initTrees() {
+  _chain.resize(1);
+  _chain.at(0).resize(_param.num_trees);
+  auto& trees = _chain.at(0);
+
+  int32_t tree_id = 0;
+  for (auto& tree : trees) {
+    // since we normalise labels, mean is just 0
+    tree.reset(new TreeMutation{&_chain, tree_id, _p_fmat});
+    (*tree)[0].SetLeaf(0);
+    CHECK((*tree)[0].IsLeaf());
+    tree_id++;
+  }
+}
+
+void GibbsUpdater::init(DMatrix *p_fmat, std::vector<std::shared_ptr<RegTree>> &trees) {
+  _p_fmat = p_fmat;
+  if (!this->_initialized) {
+    this->initTrees();
+    this->initData(p_fmat);
+    this->_initialized = true;
+  }
+}
+
+void GibbsUpdater::drawSigma(DMatrix* p_fmat, TreeMutation& tree) {
+  auto& info = p_fmat->Info();
+  auto& prediction_cache = tree.getPredictionCache();
+  auto& responses = tree.getResponses();
+  CHECK_EQ(prediction_cache.size(), responses.size());
+  auto sum_residue = 1.0f;
+
+  for (int32_t i = 0; i < prediction_cache.size(); ++i) {
+    responses[i] -= prediction_cache[i];
+    sum_residue += responses[i] * responses[i];
+  }
+
+  float shape = _param.nu * info.num_row_ * 0.5;
+  float rate = (_param.nu * _param.lambda + sum_residue) * 0.5;
+  _sigma_sampler = InverseGamma(shape, rate);
+  _sigma = _sigma_sampler.sample();
+  _sigma_chain.push_back(_sigma);
+}
+
+void GibbsUpdater::update(DMatrix* dmat, std::vector<std::shared_ptr<RegTree>>& trees) {
+  init(dmat, trees);
+  updateTrees(dmat);
+}
+
+// FIXME(trivialfis): Implement complete proposal
+GibbsUpdater::GibbsUpdater() :
+    _move_chooser{0, 2}, _initialized{false} {
+  _monitor.Init("Gibbs");
+}
+
+void GibbsUpdater::configure(
+    const std::vector<std::pair<std::string, std::string> > &args) {
+  _param.InitAllowUnknown(args);
+}
+
+}  // namespace xgboost

--- a/plugin/bart/src/gibbs_updater.h
+++ b/plugin/bart/src/gibbs_updater.h
@@ -1,0 +1,385 @@
+#ifndef GIBBS_UPDATER_H_
+#define GIBBS_UPDATER_H_
+
+#include <cmath>
+#include <memory>
+#include <vector>
+#include <map>
+#include <queue>
+
+#include <dmlc/parameter.h>
+#include <xgboost/base.h>
+#include <xgboost/data.h>
+#include <xgboost/tree_model.h>
+#include <xgboost/predictor.h>
+
+#include "rv.h"
+#include "pool.h"
+#include "../../src/common/timer.h"
+
+namespace xgboost {
+
+struct GibbsParam : public dmlc::Parameter<GibbsParam> {
+  // control splits
+  bst_float alpha;
+  bst_float beta;
+
+  bst_float mu;
+  bst_float sigma;
+
+  bst_uint num_trees;
+
+  bst_float nu;
+  bst_float lambda;
+  bst_uint burn_in;
+
+  DMLC_DECLARE_PARAMETER(GibbsParam) {
+    DMLC_DECLARE_FIELD(alpha)
+        .set_range(0, 1)
+        .set_default(0.95)
+        .describe("Controls tree structure");
+    DMLC_DECLARE_FIELD(beta)
+        .set_default(2.0f)
+        .describe("Controls tree structure");
+
+    DMLC_DECLARE_FIELD(mu)
+        .set_default(0.0f);
+    DMLC_DECLARE_FIELD(sigma)
+        .set_default(0.2);
+
+    DMLC_DECLARE_FIELD(num_trees)
+        .set_default(100)
+        .describe("Number of trees.");
+
+    DMLC_DECLARE_FIELD(nu)
+        .set_default(3.0f);  // FIXME: Set prior
+    DMLC_DECLARE_FIELD(lambda)
+        .set_default(1.0f);  // FIXME: Set prior
+    DMLC_DECLARE_FIELD(burn_in)
+        .set_lower_bound(0)
+        .set_default(100)
+        .describe("Number of iterations for burn in.");
+  }
+};
+
+class TreeMutation;
+
+class GibbsUpdater {
+  enum class MoveKind {
+    kGrow,
+    kPrune,
+    kSwap,
+    kChange
+  };
+
+ public:
+  /* \brief One sample in the chain. */
+  using SigleTreeChain = std::vector<std::unique_ptr<TreeMutation>>;
+  /* \brief Sampling chain for all trees. */
+  struct TreesChain : public std::vector<SigleTreeChain> {
+    std::unique_ptr<TreeMutation>& lastTree(int32_t tree_idx) {
+      return this->at(tree_idx).back();
+    }
+    void add(int32_t tree_idx, std::unique_ptr<TreeMutation>&& p_tree) {
+      this->at(tree_idx).emplace_back(p_tree);
+    }
+  };
+
+  /*
+   * \brief Implement the diffing trick from bart-machine
+   *
+   * See `bartMachine: Machine Learning with Bayesian Additive Regression Trees'
+   * Section 3.1 and corresponding source code.
+   */
+  std::vector<bst_float> _running_sum;
+
+  void update(DMatrix* dmat, std::vector<std::shared_ptr<RegTree>>& trees);
+
+  GibbsUpdater();
+  void configure(const std::vector<std::pair<std::string, std::string>>& args);
+
+ protected:
+  void init(DMatrix* p_fmat, std::vector<std::shared_ptr<RegTree>>& trees);
+  void initData(DMatrix* p_fmat);
+  void initTrees();
+
+  /*
+   * \brief Compute posterior for sigma.
+   */
+  void drawSigma(DMatrix* dmat, TreeMutation& tree);
+
+  void computeResponse(size_t tree_id, std::vector<float> const& labels);
+  void updateTrees(DMatrix* p_fmat);
+
+ protected:
+  Uniform _move_chooser;
+
+  InverseGamma _sigma_sampler;
+  float _sigma;
+  std::vector<InverseGamma> _sigma_chain;
+
+  bst_float _y_min;
+  bst_float _y_max;
+
+  GibbsParam _param;
+  common::Monitor _monitor;
+
+  TreesChain _chain;
+  std::vector<bst_float> _responses_cache;
+  DMatrix* _p_fmat;
+
+  bool _initialized;
+};
+
+class TreeMutation : public RegTree {
+ public:
+  static constexpr int32_t kRejected {-1};
+
+ protected:
+  std::vector<std::vector<size_t>> _indices;
+  // FIXME(trivialfis): Move out to updater
+  std::vector<float> _responses;
+  // FIXME(trivialfis): Move out to updater
+  std::vector<float> _predictions;
+
+  PersistentPool<int32_t> _splitable_nodes;
+  PersistentPool<int32_t> _splitable_features;
+
+  PersistentPool<int32_t> _prunable_nodes;
+
+  int32_t _tree_id;
+  GibbsUpdater::TreesChain* _chain;
+
+ protected:
+  bst_float growTransitionRatio(int32_t nid);
+  bst_float growLikelihoodRatio(float sigma, float sigma_mu,
+                                int32_t parent, int32_t left, int32_t right);
+  bst_float growTreeStructureRatio(int32_t parent,
+                                   float const alpha, float const beta);
+
+ public:
+  TreeMutation(GibbsUpdater::TreesChain* chain, int32_t tree_id,
+               DMatrix const* p_fmat) :
+      _chain{chain}, _tree_id{tree_id}
+  {
+    _splitable_nodes.push(0);  // root
+
+    auto const& info = p_fmat->Info();
+    _splitable_features = PersistentPool<int32_t>(info.num_col_);
+
+    _predictions.resize(info.num_row_, 0);
+    _responses.resize(info.num_row_, 0);
+
+    _indices.resize(1);
+    _indices[0].resize(info.num_row_);
+    for (size_t i = 0; i < info.num_row_; ++i) {
+      _indices[0][i] = i;
+    }
+  }
+
+  TreeMutation& operator=(TreeMutation const& other) {
+    // from regtree
+    this->nodes_ = other.nodes_;
+    this->deleted_nodes_ = other.deleted_nodes_;
+    this->node_mean_values_ = other.node_mean_values_;
+    this->stats_ = other.stats_;
+
+    // extended data field
+    this->_indices = other._indices;
+    this->_responses = other._responses;
+    this->_predictions = other._responses;
+    this->_splitable_nodes = other._splitable_nodes;
+    this->_splitable_features = other._splitable_features;
+    this->_prunable_nodes = other._prunable_nodes;
+
+    this->_chain = other._chain;
+    return *this;
+  }
+
+  TreeMutation& operator=(TreeMutation&& other) {
+    // from regtree
+    this->nodes_ = std::move(other.nodes_);
+    this->deleted_nodes_ = std::move(other.deleted_nodes_);
+    this->node_mean_values_ = std::move(other.node_mean_values_);
+    this->stats_ = std::move(other.stats_);
+
+    // extended data field
+    this->_indices = std::move(other._indices);
+    this->_responses = std::move(other._responses);
+    this->_predictions = std::move(other._responses);
+    this->_splitable_nodes = std::move(other._splitable_nodes);
+    this->_splitable_features = std::move(other._splitable_features);
+    this->_prunable_nodes = std::move(other._prunable_nodes);
+
+    this->_chain = other._chain;
+    return *this;
+  }
+
+  bst_float growAcceptanceRatio(
+      int32_t parent, int32_t left, int32_t right,
+      float sigma,
+      GibbsParam const& param) {
+
+    auto transition = growTransitionRatio(parent);
+    auto likelihood = growLikelihoodRatio(sigma, param.sigma, parent, left, right);
+    auto structure = growTreeStructureRatio(parent, param.alpha, param.beta);
+
+    float ratio = std::min(0.0f,
+                           transition + likelihood + structure);
+    return ratio;
+  }
+
+  int32_t grow(float sigma, GibbsParam param, DMatrix* p_fmat);
+  int32_t prune(float sigma, GibbsParam param, DMatrix* p_fmat);
+
+  bst_float sumResponsesByNode(int32_t nid) {
+    auto& node_indiecs = _indices.at(nid);
+    float sum = 0;
+    for (size_t i = 0; i < node_indiecs.size(); ++i) {
+      float value = _responses.at(node_indiecs.at(i));
+      sum += value;
+    }
+    return sum;
+  }
+  /*
+   * \brief sample from leafs' posterior distribution
+   */
+  Normal leafValueDistribution(bst_float sigma,
+                               int32_t nid,
+                               GibbsParam const& param) {
+    float sum = sumResponsesByNode(nid);
+    auto const loc = (sum / (_indices.at(nid).size() * param.sigma + sigma));
+    auto const scale = (sigma * param.sigma /
+                        (_indices.at(nid).size() * param.sigma + sigma));
+    auto const leaf = Normal(loc, scale);
+    return leaf;
+  }
+
+  void applySplit(int32_t node_id, int32_t split_index, float split_cond,
+                  DMatrix* p_fmat) {
+    CHECK_GE(node_id, 0);
+    _splitable_features.erase(split_index);
+    _splitable_nodes.erase(node_id);
+
+    // assign split
+    int const pleft = this->AllocNode();
+    int const pright = this->AllocNode();
+    CHECK(!(*this)[pleft].IsDeleted()) << pleft;
+    CHECK(!(*this)[pright].IsDeleted()) << pright;
+    (*this)[pleft].SetParent(node_id);
+    (*this)[node_id].SetLeftChild(pleft);
+    (*this)[pright].SetParent(node_id);
+    (*this)[node_id].SetRightChild(pright);
+
+    (*this)[pleft].SetLeaf(std::numeric_limits<bst_float>::infinity());
+    (*this)[pright].SetLeaf(std::numeric_limits<bst_float>::infinity());
+
+    auto& node = (*this)[node_id];
+
+    _prunable_nodes.push(node_id);
+    if (!node.IsRoot() && _indices.at(node.Parent()).size() >= 2) {
+      // the original parent is prunable.
+      _prunable_nodes.erase(node.Parent());
+    }
+
+    std::vector<size_t> left_indices;
+    std::vector<size_t> right_indices;
+    auto& info = p_fmat->Info();
+    for (auto batch : p_fmat->GetRowBatches()) {
+      for (size_t row_id = 0; row_id < info.num_row_; ++row_id) {
+        auto row_inst = batch[row_id];
+        for (auto& entry : row_inst) {
+          // with unknow column indices store in an Entry instead of
+          // standard CSR format, we have to walk through all values
+          // to get the wanted entry
+          if (entry.index == split_index) {
+            if (entry.fvalue < split_cond) {
+              left_indices.emplace_back(row_id);
+            } else {
+              right_indices.emplace_back(row_id);
+            }
+          }
+        }
+      }
+    }
+
+    int32_t left_id = (*this)[node_id].LeftChild();
+    CHECK_GE(left_id, 0);
+    int32_t right_id = (*this)[node_id].RightChild();
+    CHECK_GE(right_id, 0);
+    size_t max_id = std::max(std::max(left_id, right_id), node_id);
+    if (_indices.size() < max_id) {
+      _indices.resize(max_id + 1);
+    }
+    _indices.at(left_id) = std::move(left_indices);
+    _indices.at(right_id) = std::move(right_indices);
+  }
+
+  void applyPrune(int32_t node_id, int32_t split_index) {
+    _splitable_features.push(split_index);
+    _splitable_nodes.push(node_id);
+
+    _prunable_nodes.erase(node_id);
+    auto & node = (*this)[node_id];
+    if (!node.IsRoot() && _indices.at(node.Parent()).size() >= 2) {
+      _prunable_nodes.push(node.Parent());
+    }
+
+    _indices.erase(_indices.begin() + node.LeftChild());
+    _indices.erase(_indices.begin() + node.RightChild());
+
+    // assign value in leaf sampling
+    CHECK_GT(nodes_.size(), node_id);
+    this->CollapseToLeaf(node_id, std::numeric_limits<float>::infinity());
+  }
+
+  void sampleLeaf(int32_t last_node_id,
+                  float sigma,
+                  GibbsParam const& param) {
+    auto& node = (*this)[last_node_id];
+
+    if (node.IsLeaf()) {
+      auto value = leafValueDistribution(sigma, last_node_id,  param).sample();
+      (*this)[last_node_id].SetLeaf(value);
+      for (auto ind : _indices.at(last_node_id)) {
+        _predictions.at(ind) = value;
+      }
+    } else {
+      int32_t left_id = node.LeftChild();
+      int32_t right_id = node.RightChild();
+
+      auto left_value = leafValueDistribution(sigma, left_id,  param).sample();
+      auto right_value = leafValueDistribution(sigma, right_id, param).sample();
+
+      (*this)[left_id].SetLeaf(left_value);
+      (*this)[right_id].SetLeaf(right_value);
+
+      auto& left_node = RegTree::nodes_.at(left_id);
+      auto& right_node = RegTree::nodes_.at(right_id);
+
+      for (auto ind : _indices[left_id]) {
+        _predictions.at(ind) = left_node.LeafValue();
+      }
+      for (auto ind : _indices[right_id]) {
+        _predictions.at(ind) = right_node.LeafValue();
+      }
+    }
+  }
+
+  void updateResponse(std::vector<bst_float> const& new_responses) {
+    for (size_t i = 0; i < _responses.size(); ++i) {
+      _responses.at(i) = new_responses.at(i);
+    }
+  }
+
+  decltype(_responses)& getResponses() {
+    return _responses;
+  }
+  decltype(_predictions)& getPredictionCache() {
+    return _predictions;
+  }
+};
+
+}  // xgboost
+
+#endif  // GIBBS_UPDATER_H_

--- a/plugin/bart/src/gibbs_updater.h
+++ b/plugin/bart/src/gibbs_updater.h
@@ -81,7 +81,7 @@ class GibbsUpdater {
       return this->at(tree_idx).back();
     }
     void add(int32_t tree_idx, std::unique_ptr<TreeMutation>&& p_tree) {
-      this->at(tree_idx).emplace_back(p_tree);
+      this->at(tree_idx).emplace_back(std::move(p_tree));
     }
   };
 

--- a/plugin/bart/src/pool.h
+++ b/plugin/bart/src/pool.h
@@ -1,0 +1,60 @@
+#ifndef BART_POOL_H_
+#define BART_POOL_H_
+
+#include <cstddef>
+#include <vector>
+
+namespace xgboost {
+/*
+ * \brief A pool of un-ordered memory that never got deallocated.
+ */
+template <typename Type>
+class PersistentPool {
+  std::vector<Type> _values;
+  size_t _n_values;
+
+ public:
+  PersistentPool() : _n_values{0} {}
+  PersistentPool(size_t n_values)
+      : _values(n_values),
+        _n_values{n_values} {}
+  PersistentPool(size_t n_values, Type value) :
+      _values(n_values), _n_values(n_values) {
+    for (size_t i = 0; i < n_values; ++i) {
+      _values[i] = std::move(value);
+    }
+  }
+
+  void push(Type value) {
+    if (_n_values == _values.size()) {
+      _values.push_back(value);
+    } else {
+      _values[_n_values] = value;
+    }
+    _n_values ++;
+  }
+  void erase(size_t position) {
+    CHECK_LT(position, _values.size());
+    // no need for memory management
+    std::swap(_values[position],
+              _values[_n_values-1]);
+    _n_values--;
+    CHECK_GE(_n_values, 0);
+  }
+
+  size_t size() const { return _n_values; }
+  std::vector<Type> const& data() const { return _values; }
+  std::vector<Type>&       data()       { return _values; }
+
+  Type& operator[](size_t position) {
+    CHECK_GT(_n_values, position);
+    return _values[position];
+  }
+  Type const& operator[](size_t position) const {
+    CHECK_GT(_n_values, position);
+    return _values[position];
+  }
+};
+
+}      // namespace xgboost
+#endif  // BART_POOL_H_

--- a/plugin/bart/src/rv.h
+++ b/plugin/bart/src/rv.h
@@ -1,0 +1,108 @@
+/*!
+ * Copyright 2019 by Contributors
+ * \file rv.h
+ * \author Jiaming Yuan
+ */
+
+#ifndef BART_RV_H_
+#define BART_RV_H_
+
+#include <random>
+#include <xgboost/base.h>
+#include "../../src/common/random.h"
+
+namespace xgboost {
+
+class RandomVariable {
+ public:
+  virtual bst_float sample() const = 0;
+  virtual bst_float mean() const = 0;
+  virtual bst_float variance() const = 0;
+};
+
+class Gamma : public RandomVariable {
+ protected:
+  bst_float _shape;
+  bst_float _rate;
+
+ public:
+  Gamma(bst_float shape=0, bst_float rate=0) :
+      _shape{shape}, _rate{rate} {
+    CHECK_GT(shape, 0.0f);
+    CHECK_GT(rate, 0.0f);
+  }
+
+  bst_float sample() const override {
+    // c++ parameterize as shape and scale, while in Bayes it's more
+    // usual to parameterize as shape and rate
+    // rate = 1 / scale
+    std::gamma_distribution<bst_float> distribution(_shape, 1.0f / (_rate + kRtEps));
+    return distribution(common::GlobalRandom());
+  }
+
+  bst_float mean() const override {
+    return _shape / _rate;
+  }
+  bst_float variance() const override {
+    return _shape / (_rate * _rate);
+  }
+};
+
+class InverseGamma final : public Gamma {
+ public:
+  InverseGamma(bst_float shape=1.0, bst_float rate=1.0) : Gamma(shape, rate) {}
+  bst_float sample() const override {
+    bst_float inv_gamma = 1.0f / Gamma::sample();
+    return inv_gamma;
+  }
+  bst_float mean() const override {
+    bst_float scale = 1 / Gamma::_rate;
+    return scale / (Gamma::_shape - 1);
+  }
+  bst_float variance() const override {
+    bst_float scale = 1 / Gamma::_rate;
+    bst_float var = (scale * scale) / ((_shape - 1) * (_shape - 1) * (_shape - 2));
+    return var;
+  }
+};
+
+class Normal final : public RandomVariable {
+  bst_float _loc;
+  bst_float _scale;
+
+ public:
+  Normal(bst_float loc=0, bst_float scale=1) : _loc{loc}, _scale{scale} {}
+
+  bst_float mean()     const override { return _loc;   }
+  bst_float variance() const override { return _scale; }
+
+  bst_float sample() const override {
+    std::normal_distribution<bst_float> distribution(_loc, _scale);
+    return distribution(common::GlobalRandom());
+  }
+};
+
+class Uniform final : public RandomVariable {
+  bst_float _lower;
+  bst_float _upper;
+
+ public:
+  Uniform(bst_float lower=0, bst_float upper=1) :
+      _lower{lower}, _upper{upper} {}
+
+  bst_float sample() const override {
+    std::uniform_real_distribution<bst_float> distribution(_lower, _upper);
+    return distribution(common::GlobalRandom());
+  }
+
+  bst_float mean() const override {
+    return 0.5 * (_lower + _upper);
+  }
+  bst_float variance() const override {
+    bst_float var = (1.0f / 12.0f) * (_upper - _lower) * (_upper - _lower);
+    return var;
+  }
+};
+
+}      // namespace xgboost
+#endif  // BART_RV_H_

--- a/plugin/bart/tests/test_gibbs_updater.cc
+++ b/plugin/bart/tests/test_gibbs_updater.cc
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+#include "../../../tests/cpp/helpers.h"
+
+#include "../../../src/common/random.h"
+#include "../src/rv.h"
+#include "../src/gibbs_updater.h"
+
+namespace xgboost {
+
+TEST(GibbsUpdater, PersistentPool) {
+  constexpr size_t kValues = 16;
+  PersistentPool<int32_t> pool(kValues);
+  ASSERT_EQ(pool.size(), kValues);
+
+  auto& data = pool.data();
+  ASSERT_EQ(data.size(), kValues);
+  for (size_t i = 0; i < data.size(); ++i) {
+    data[i] = i;
+  }
+
+  pool.erase(1);
+  ASSERT_EQ(pool[1], 15);
+  ASSERT_EQ(pool.size(), 15);
+
+  pool.push(17);
+  ASSERT_EQ(pool.size(), kValues);
+  ASSERT_EQ(pool[kValues-1], 17);
+
+  pool.push(57);
+  ASSERT_EQ(pool.size(), kValues + 1);
+  ASSERT_EQ(pool[pool.size() - 1], 57);
+}
+
+TEST(GibbsUpdater, Grow) {
+  // RegTree tree;
+  GibbsParam param;
+  std::vector<std::pair<std::string, std::string>> args {};
+  param.InitAllowUnknown(args);
+
+  constexpr size_t kRows = 16;
+  constexpr size_t kCols = 7;
+  constexpr float kSparsity = 0.3;
+
+  HostDeviceVector<float> labels;
+  labels.Resize(kRows);
+  std::vector<float>& h_labels = labels.HostVector();
+  for (size_t i = 0; i < kRows; ++i) {
+    h_labels[i] = i;
+  }
+
+  GibbsUpdater::TreesChain chain;
+  chain.resize(1);     // one generation
+  chain[0].resize(1);  // one tree
+
+  auto dmat = CreateDMatrix(kRows, kCols, kSparsity, 3);
+
+  TreeMutation mutate(&chain, 0, dmat->get());
+  mutate.grow(0, param, dmat->get());
+
+  ASSERT_EQ(mutate.NumExtraNodes(), 2);
+  delete dmat;
+}
+
+TEST(GibbsUpdater, Prune) {
+  GibbsParam param;
+  std::vector<std::pair<std::string, std::string>> args {};
+  param.InitAllowUnknown(args);
+  constexpr size_t kRows = 16;
+  constexpr size_t kCols = 7;
+  constexpr float kSparsity = 0.3;
+  auto dmat = CreateDMatrix(kRows, kCols, kSparsity, 3);
+
+  GibbsUpdater::TreesChain chain;
+  chain.resize(1);     // one generation
+  chain[0].resize(1);  // one tree
+  TreeMutation mutate(&chain, 0, dmat->get());
+  mutate.grow(0, param, dmat->get());
+  ASSERT_EQ(mutate.NumExtraNodes(), 2);
+
+  mutate.prune(0, param, dmat->get());
+  ASSERT_EQ(mutate.NumExtraNodes(), 0);
+  delete dmat;
+}
+
+TEST(GibbsUpdater, Update) {
+  std::vector<std::pair<std::string, std::string>> args {};
+
+  constexpr size_t kRows = 16;
+  constexpr size_t kCols = 7;
+  constexpr float kSparsity = 0.3;
+  auto dmat = CreateDMatrix(kRows, kCols, kSparsity, 3);
+  auto& info = (*dmat)->Info();
+  info.labels_.Resize(kRows);
+  auto h_labels = info.labels_.HostVector();
+  for (size_t i = 0; i < h_labels.size(); ++i) {
+    h_labels[i] = i;
+  }
+
+  std::vector<std::shared_ptr<RegTree>> trees {std::make_shared<RegTree>()};
+  GibbsUpdater updater;
+  updater.configure(args);
+  updater.update((*(dmat)).get(), trees);
+
+  delete dmat;
+}
+
+}  // namespace xgboost

--- a/plugin/bart/tests/test_rv.cc
+++ b/plugin/bart/tests/test_rv.cc
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include "../src/rv.h"
+#include "../../../tests/cpp/helpers.h"
+#include "../../../src/common/random.h"
+
+namespace xgboost {
+
+TEST(RV, Uniform) {
+  constexpr float kEps = 1e-4;
+  std::vector<float> uniform(10, 0.5f);
+  for (size_t i = 0; i < 10; ++i) {
+    uniform[i] = Uniform(0, 1).sample();
+  }
+  for (size_t i = 0; i < 10; ++i) {
+    ASSERT_LE(uniform[i], 1.0f);
+    ASSERT_GE(uniform[i], 0.0f);
+  }
+
+  auto dist = Uniform(0, 1);
+  ASSERT_NEAR(dist.mean(), 0.5, kEps);
+  ASSERT_NEAR(dist.variance(), 0.08329, kEps);
+}
+
+TEST(RV, Normal) {
+  constexpr float kEps = 1e-4;
+  auto dist = Normal(2.0, 3.0);
+  ASSERT_NEAR(dist.mean(), 2.0f, kEps);
+  ASSERT_NEAR(dist.variance(), 3.0f, kEps);
+}
+
+TEST(RV, Gamma) {
+  constexpr float kEps = 1e-4;
+  auto dist = Gamma(1.0, 2.0);
+  ASSERT_NEAR(dist.mean(), 0.5, kEps);
+  ASSERT_NEAR(dist.variance(), 0.25, kEps);
+}
+}  // namespace xgboost

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,9 +25,14 @@ if (PLUGIN_LZ4)
   list(APPEND PLUGINS_SOURCES ${PROJECT_SOURCE_DIR}/plugin/lz4/sparse_page_lz4_format.cc)
   list(APPEND SRC_LIBS lz4)
 endif (PLUGIN_LZ4)
+
 if (PLUGIN_DENSE_PARSER)
   list(APPEND PLUGINS_SOURCES ${PROJECT_SOURCE_DIR}/plugin/dense_parser/dense_libsvm.cc)
 endif (PLUGIN_DENSE_PARSER)
+
+if (PLUGIN_BART)
+  list(APPEND PLUGINS_SOURCES ${BART_SOURCES})
+endif(PLUGIN_BART)
 
 #-- Object library
 # Object library is necessary for jvm-package, which creates its own shared

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -1,6 +1,10 @@
 find_package(GTest REQUIRED)
 file(GLOB_RECURSE TEST_SOURCES "*.cc")
 
+if (PLUGIN_BART)
+  list(APPEND TEST_SOURCES ${BART_TESTS_SOURCE})
+endif(PLUGIN_BART)
+
 if (USE_CUDA)
   file(GLOB_RECURSE CUDA_TEST_SOURCES "*.cu")
   list(APPEND TEST_SOURCES ${CUDA_TEST_SOURCES})
@@ -49,7 +53,8 @@ target_link_libraries(testxgboost
   ${GTEST_LIBRARIES}
   ${LINKED_LIBRARIES_PRIVATE}
   ${OpenMP_CXX_LIBRARIES})
-target_compile_definitions(testxgboost PRIVATE ${XGBOOST_DEFINITIONS})
+target_compile_definitions(testxgboost
+  PRIVATE ${XGBOOST_DEFINITIONS})
 if (USE_OPENMP)
   target_compile_options(testxgboost PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
 endif (USE_OPENMP)

--- a/tests/cpp/test_main.cc
+++ b/tests/cpp/test_main.cc
@@ -1,7 +1,11 @@
 // Copyright by Contributors
 #include <gtest/gtest.h>
+#include <xgboost/logging.h>
 
 int main(int argc, char ** argv) {
+  std::vector<std::pair<std::string, std::string>> verbosity{{"verbosity", "3"}};
+  xgboost::ConsoleLogger::Configure(verbosity.begin(), verbosity.end());
+
   testing::InitGoogleTest(&argc, argv);
   testing::FLAGS_gtest_death_test_style = "threadsafe";
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Introduced in #4398, this is a draft implementation of  **[Bayesian Additive Regression Tree](https://arxiv.org/pdf/0806.3286.pdf)**.  It's a tree ensemble model with MCMC(CGM98 gibbs) as structure learning algorithm.  Although  XGBoost is a gradient boosting library, which is quite different than sampling methods.  There are Bayesian methods that use gradient, but to my knowledge non has apply it on tree model yet.  I'm interested in this subject and want to work on it in the future if possible.  I hope that implementing bart can open up the possibility of Bayesian view in XGBoost.

Currently it's far from usable, notably missing a predictor, classification support, burn in support and optimization is non-exist.  Also, please ignore the styling.

Other than these, there are a few design issues to be addressed:
- gibbs sampling doesn't use gradient at all so there will be conflict with current internal structure.
- sampling based method is kind of hard to test.
- missing data handling is difficult since we can't just accumulate some statistic.

In this PR a `GibbsUpdater` is created to coordinate the sampling iteration, while `TreeMutation` class is an enhanced version of `RegTree` with specific sampling features.  New model lives in plugin for now.  I would like to know the opinion from community about this added feature. The development will continue if it's accepted as an useful model and suitable to live in XGBoost.

@tqchen @hcho3 @RAMitchell @CodingCat and anyone who's interested. ;-)