### PR TITLE
[BLOCKING] Make CMakeLists.txt compatible with CMake 3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,14 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.3)
 project(xgboost LANGUAGES CXX C VERSION 0.82)
 include(cmake/Utils.cmake)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
 cmake_policy(SET CMP0022 NEW)
+
+if (MSVC)
+  if (${CMAKE_VERSION} VERSION_LESS "3.11.0")
+    message(FATAL_ERROR "To compile with Visual Studio, please use CMake 3.11 or newer")
+  endif (${CMAKE_VERSION} VERSION_LESS "3.11.0")
+endif (MSVC)
 
 set_default_configuration_release()
 msvc_use_static_runtime()
@@ -42,6 +48,11 @@ if (USE_SANITIZER)
   include(cmake/Sanitizer.cmake)
   enable_sanitizers("${ENABLED_SANITIZERS}")
 endif (USE_SANITIZER)
+
+# Create OpenMP target if enabled
+if (USE_OPENMP)
+  use_openmp()
+endif (USE_OPENMP)
 
 if (USE_CUDA)
   cmake_minimum_required(VERSION 3.12)
@@ -103,6 +114,7 @@ target_include_directories(xgboost
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
 target_link_libraries(xgboost PRIVATE ${LINKED_LIBRARIES_PRIVATE})
+target_link_libraries(xgboost PUBLIC ${LINKED_LIBRARIES_PUBLIC})
 
 # This creates its own shared library `xgboost4j'.
 if (JVM_BINDINGS)
@@ -119,6 +131,7 @@ target_include_directories(runxgboost
   ${PROJECT_SOURCE_DIR}/dmlc-core/include
   ${PROJECT_SOURCE_DIR}/rabit/include)
 target_link_libraries(runxgboost PRIVATE ${LINKED_LIBRARIES_PRIVATE})
+target_link_libraries(runxgboost PUBLIC ${LINKED_LIBRARIES_PUBLIC})
 set_target_properties(
   runxgboost PROPERTIES
   OUTPUT_NAME xgboost

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -1,3 +1,18 @@
+# Adopted from https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html
+function(use_openmp)
+  # For CMake < 3.9, we need to make the target ourselves
+  find_package(OpenMP REQUIRED)
+  if(NOT TARGET OpenMP::OpenMP_CXX)
+    find_package(Threads REQUIRED)
+    add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
+    set_property(TARGET OpenMP::OpenMP_CXX
+                 PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
+    # Only works if the same flag is passed to the linker; use CMake 3.9+ otherwise (Intel, AppleClang)
+    set_property(TARGET OpenMP::OpenMP_CXX
+                 PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
+  endif()
+endfunction(use_openmp)
+
 # Automatically set source group based on folder
 function(auto_source_group SOURCES)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ int main() {
 # Add plugins to source files
 if (PLUGIN_LZ4)
   list(APPEND PLUGINS_SOURCES ${PROJECT_SOURCE_DIR}/plugin/lz4/sparse_page_lz4_format.cc)
-  list(APPEND SRC_LIBS lz4)
+  list(APPEND SRC_PRIVATE_LIBS lz4)
 endif (PLUGIN_LZ4)
 if (PLUGIN_DENSE_PARSER)
   list(APPEND PLUGINS_SOURCES ${PROJECT_SOURCE_DIR}/plugin/dense_parser/dense_libsvm.cc)
@@ -49,7 +49,7 @@ if (USE_CUDA)
     find_package(Nccl REQUIRED)
     target_include_directories(objxgboost PRIVATE ${NCCL_INCLUDE_DIR})
     target_compile_definitions(objxgboost PRIVATE -DXGBOOST_USE_NCCL=1)
-    list(APPEND SRC_LIBS ${NCCL_LIBRARY})
+    list(APPEND SRC_PRIVATE_LIBS ${NCCL_LIBRARY})
   endif (USE_NCCL)
 
   if (USE_NVTX)
@@ -58,7 +58,6 @@ if (USE_CUDA)
   endif (USE_NVTX)
 
   # OpenMP is mandatory for cuda version
-  find_package(OpenMP REQUIRED)
   target_compile_options(objxgboost PRIVATE  
     $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
   )
@@ -77,7 +76,7 @@ target_include_directories(objxgboost
 target_compile_options(objxgboost
   PRIVATE
   $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/MP>
-  $<$<COMPILE_LANGUAGE:CXX>:-funroll-loops>)
+  $<$<AND:$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<COMPILE_LANGUAGE:CXX>>:-funroll-loops>)
 if (WIN32 AND MINGW)
   target_compile_options(objxgboost PUBLIC -static-libstdc++)
 endif (WIN32 AND MINGW)
@@ -103,11 +102,9 @@ if (XGBOOST_BUILTIN_PREFETCH_PRESENT)
 endif (XGBOOST_BUILTIN_PREFETCH_PRESENT)
 
 if (USE_OPENMP)
-  find_package(OpenMP REQUIRED)
-  if (OpenMP_CXX_FOUND OR OPENMP_FOUND)
-    target_compile_options(objxgboost PRIVATE  $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
-    list(APPEND SRC_LIBS ${OpenMP_CXX_LIBRARIES})
-    set(LINKED_LIBRARIES_PRIVATE "${LINKED_LIBRARIES_PRIVATE};${SRC_LIBS}" PARENT_SCOPE)
-  endif (OpenMP_CXX_FOUND OR OPENMP_FOUND)
+  list(APPEND SRC_PUBLIC_LIBS OpenMP::OpenMP_CXX)
+  target_compile_options(objxgboost PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
 endif (USE_OPENMP)
+set(LINKED_LIBRARIES_PUBLIC "${LINKED_LIBRARIES_PUBLIC};${SRC_PUBLIC_LIBS}" PARENT_SCOPE)
+set(LINKED_LIBRARIES_PRIVATE "${LINKED_LIBRARIES_PRIVATE};${SRC_PRIVATE_LIBS}" PARENT_SCOPE)
 #-- End object library

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -6,10 +6,10 @@ ENV DEBIAN_FRONTEND noninteractive
 # Install all basic requirements
 RUN \
     apt-get update && \
-    apt-get install -y tar unzip wget git build-essential doxygen graphviz llvm libasan2 && \
+    apt-get install -y tar unzip wget git build-essential doxygen graphviz llvm libasan2 libidn11 && \
     # CMake
-    wget -nv -nc https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh --no-check-certificate && \
-    bash cmake-3.12.0-Linux-x86_64.sh --skip-license --prefix=/usr && \
+    wget -nv -nc https://cmake.org/files/v3.3/cmake-3.3.0-Linux-x86_64.sh --no-check-certificate && \
+    bash cmake-3.3.0-Linux-x86_64.sh --skip-license --prefix=/usr && \
     # Python
     wget https://repo.continuum.io/miniconda/Miniconda3-4.5.12-Linux-x86_64.sh && \
     bash Miniconda3-4.5.12-Linux-x86_64.sh -b -p /opt/python

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -47,10 +47,9 @@ set_target_properties(
 target_link_libraries(testxgboost
   PRIVATE
   ${GTEST_LIBRARIES}
-  ${LINKED_LIBRARIES_PRIVATE}
-  ${OpenMP_CXX_LIBRARIES})
+  ${LINKED_LIBRARIES_PRIVATE})
 target_compile_definitions(testxgboost PRIVATE ${XGBOOST_DEFINITIONS})
 if (USE_OPENMP)
-  target_compile_options(testxgboost PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
+  target_link_libraries(testxgboost PUBLIC OpenMP::OpenMP_CXX)
 endif (USE_OPENMP)
 set_output_directory(testxgboost ${PROJECT_BINARY_DIR})


### PR DESCRIPTION
* Export OpenMP as a PUBLIC target
* Upgrade CMake to 3.3, to use the generator expression `COMPILE_LANGUAGE:CXX`. For the same reason, require CMake 3.11 for Visual Studio
* Use CMake 3.3 in the `build-cpu` task of Jenkins
* Remove `-funroll-loops` flag when compiled with MSVC

Closes #4415