### PR TITLE
Simplify bound checking in feature interaction constraints

### DIFF
--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -515,12 +515,8 @@ class InteractionConstraint final : public SplitEvaluator {
   //   permissible in a given node; returns false otherwise
   inline bool CheckInteractionConstraint(bst_uint featureid, bst_uint nodeid) const {
     // short-circuit if no constraint is specified
-    if (params_.interaction_constraints.empty()) {
-      return true;
-    }
-    CHECK_LT(nodeid, int_cont_.size()) << "Invariant violated: nodeid = "
-      << nodeid << ", int_cont_.size() = " << int_cont_.size();
-    return (int_cont_[nodeid].count(featureid) > 0);
+    return (params_.interaction_constraints.empty()
+            || int_cont_.at(nodeid).count(featureid) > 0);
   }
 };
 


### PR DESCRIPTION
A follow-up of #4426 and #4341. Simplify the bound checking in `CheckInteractionConstraint()` by using the bound checking interface [`std::vector::at()`](https://en.cppreference.com/w/cpp/container/vector/at).