### PR TITLE
max_digits10 guarantees float decimal roundtrip

### DIFF
--- a/src/cli_main.cc
+++ b/src/cli_main.cc
@@ -327,7 +327,7 @@ void CLIPredict(const CLIParam& param) {
       dmlc::Stream::Create(param.name_pred.c_str(), "w"));
   dmlc::ostream os(fo.get());
   for (bst_float p : preds.ConstHostVector()) {
-    os << std::setprecision(std::numeric_limits<bst_float>::max_digits10 + 2)
+    os << std::setprecision(std::numeric_limits<bst_float>::max_digits10)
        << p << '\n';
   }
   // force flush before fo destruct.


### PR DESCRIPTION
2 additional digits are not needed to guarantee that casting the decimal representation will result in the same float, see https://github.com/dmlc/xgboost/issues/3980#issuecomment-458702440