### PR TITLE
mgpu predictor using explicit offsets

### DIFF
--- a/src/common/host_device_vector.h
+++ b/src/common/host_device_vector.h
@@ -110,6 +110,9 @@ class GPUDistribution {
     return GPUDistribution(devices, granularity, 0, std::vector<size_t>());
   }
 
+  // NOTE(rongou): Explicit offsets don't necessarily cover the whole vector. Sections before the
+  // first shard or after the last shard may be on host only. This windowing is done in the GPU
+  // predictor for external memory support.
   static GPUDistribution Explicit(GPUSet devices, std::vector<size_t> offsets) {
     return GPUDistribution(devices, 1, 0, std::move(offsets));
   }

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -291,7 +291,6 @@ class GPUPredictor : public xgboost::Predictor {
 
       const int BLOCK_THREADS = 128;
       size_t num_rows = batch.offset.DeviceSize(device_) - 1;
-      if (num_rows < 1) { return; }
       const int GRID_SIZE = static_cast<int>(dh::DivRoundUp(num_rows, BLOCK_THREADS));
 
       int shared_memory_bytes = static_cast<int>

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -361,6 +361,7 @@ class GPUPredictor : public xgboost::Predictor {
       DeviceOffsets(batch.offset, &device_offsets);
       batch.data.Reshard(GPUDistribution::Explicit(devices_, device_offsets));
 
+      // TODO(rongou): only copy the model once for all the batches.
       dh::ExecuteIndexShards(&shards_, [&](int idx, DeviceShard& shard) {
         shard.PredictInternal(batch, dmat->Info(), out_preds, model,
                               h_tree_segments, h_nodes, tree_begin, tree_end);

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -242,7 +242,7 @@ class GPUPredictor : public xgboost::Predictor {
     auto& offsets = *out_offsets;
     size_t n_shards = devices_.Size();
     offsets.resize(n_shards + 2);
-    size_t rows_per_shard = (batch_size + n_shards - 1) / n_shards; 
+    size_t rows_per_shard = (batch_size + n_shards - 1) / n_shards;
     for (int shard = 0; shard < devices_.Size(); ++shard) {
       offsets[shard] = batch_offset + shard * rows_per_shard * n_classes;
     }

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -268,6 +268,9 @@ class GPUPredictor : public xgboost::Predictor {
      const thrust::host_vector<size_t>& h_tree_segments,
      const thrust::host_vector<DevicePredictionNode>& h_nodes,
      size_t tree_begin, size_t tree_end) {
+      if (predictions->DeviceSize(device_) == 0) {
+        return;
+      }
       dh::safe_cuda(cudaSetDevice(device_));
       nodes_.resize(h_nodes.size());
       dh::safe_cuda(cudaMemcpyAsync(dh::Raw(nodes_), h_nodes.data(),

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -338,7 +338,10 @@ class GPUPredictor : public xgboost::Predictor {
 
     size_t batch_offset = 0;
     for (auto &batch : dmat->GetRowBatches()) {
-      batch.offset.Shard(GPUDistribution::Overlap(devices_, 1));
+      GPUSet devices = GPUSet::All(param_.gpu_id, param_.n_gpus, batch.Size());
+      ConfigureShards(devices);
+
+      batch.offset.Reshard(GPUDistribution::Overlap(devices_, 1));
 
       std::vector<size_t> device_offsets;
       DeviceOffsets(batch.offset, &device_offsets);

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -242,7 +242,6 @@ TEST(gpu_predictor, MGPU_ExternalMemoryTest) {
   std::vector<std::unique_ptr<DMatrix>> dmats;
   dmats.push_back(CreateSparsePageDMatrix(9, 64UL));
   dmats.push_back(CreateSparsePageDMatrix(128, 128UL));
-  dmats.push_back(CreateSparsePageDMatrix(1024, 1024UL));
 
   for (const auto& dmat: dmats) {
     // Test predict batch

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -244,6 +244,7 @@ TEST(gpu_predictor, MGPU_ExternalMemoryTest) {
   std::vector<std::unique_ptr<DMatrix>> dmats;
   dmats.push_back(CreateSparsePageDMatrix(9, 64UL));
   dmats.push_back(CreateSparsePageDMatrix(128, 128UL));
+  dmats.push_back(CreateSparsePageDMatrix(1024, 1024UL));
 
   for (const auto& dmat: dmats) {
     // Test predict batch


### PR DESCRIPTION
Alternative approach to #4437. Uses explicit offsets of slide over the out prediction vector. I feel this is slightly cleaner, but I'm ok with either approach.

@canonizer @RAMitchell @sriramch 