### PR TITLE
[jvm-packages] Automatically set maximize_evaluation_metrics if not explicitly given in XGBoost4J-Spark

### DIFF
--- a/doc/jvm/xgboost4j_spark_tutorial.rst
+++ b/doc/jvm/xgboost4j_spark_tutorial.rst
@@ -239,7 +239,7 @@ Early Stopping
 
 Early stopping is a feature to prevent the unnecessary training iterations. By specifying ``num_early_stopping_rounds`` or directly call ``setNumEarlyStoppingRounds`` over a XGBoostClassifier or XGBoostRegressor, we can define number of rounds if the evaluation metric going away from the best iteration and early stop training iterations.
 
-In additional to ``num_early_stopping_rounds``, you also need to define ``maximize_evaluation_metrics`` or call ``setMaximizeEvaluationMetrics`` to specify whether you want to maximize or minimize the metrics in training.
+When it comes to custom eval metrics, in additional to ``num_early_stopping_rounds``, you also need to define ``maximize_evaluation_metrics`` or call ``setMaximizeEvaluationMetrics`` to specify whether you want to maximize or minimize the metrics in training. For built-in eval metrics, XGBoost4J-Spark will automatically select the direction.
 
 For example, we need to maximize the evaluation metrics (set ``maximize_evaluation_metrics`` with true), and set ``num_early_stopping_rounds`` with 5. The evaluation metric of 10th iteration is the maximum one until now. In the following iterations, if there is no evaluation metric greater than the 10th iteration's (best one), the traning would be early stopped at 15th iteration.  
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -160,6 +160,10 @@ object XGBoost extends Serializable {
         .map(_.toString.toInt).getOrElse(0)
       val overridedParams = if (numEarlyStoppingRounds > 0 &&
           !params.contains("maximize_evaluation_metrics")) {
+        if params.contains("custom_eval") {
+            throw new IllegalArgumentException("maximize_evaluation_metrics has to be "
+                + "specified when custom_eval is set")
+        }
         val eval_metric = params("eval_metric").toString
         val maximize = LearningTaskParams.evalMetricsToMaximize contains eval_metric
         logger.info("parameter \"maximize_evaluation_metrics\" is set to " + maximize)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -160,7 +160,7 @@ object XGBoost extends Serializable {
         .map(_.toString.toInt).getOrElse(0)
       val overridedParams = if (numEarlyStoppingRounds > 0 &&
           !params.contains("maximize_evaluation_metrics")) {
-        if params.contains("custom_eval") {
+        if (params.contains("custom_eval")) {
             throw new IllegalArgumentException("maximize_evaluation_metrics has to be "
                 + "specified when custom_eval is set")
         }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -111,6 +111,10 @@ private[spark] object LearningTaskParams {
 
   val supportedObjectiveType = HashSet("regression", "classification")
 
-  val supportedEvalMetrics = HashSet("rmse", "mae", "logloss", "error", "merror", "mlogloss",
-    "auc", "aucpr", "ndcg", "map", "gamma-deviance")
+  val evalMetricsToMaximize = HashSet("auc", "aucpr", "ndcg", "map")
+
+  val evalMetricsToMinimize = HashSet("rmse", "mae", "logloss", "error", "merror",
+    "mlogloss", "gamma-deviance")
+
+  val supportedEvalMetrics = evalMetricsToMaximize union evalMetricsToMinimize
 }


### PR DESCRIPTION
This pull request is aimed at resolving "[jvm-packages] false should be the default value of maximize_evaluation_metrics"(#4422).
The metric names to maximize are aligned with [xgboost.callback.early_stop](https://github.com/dmlc/xgboost/blob/master/python-package/xgboost/callback.py#L189) in the Python package.
To avoid duplicating codes in both `XGBoostClassifier` and `XGBoostRegressor`, parameter `maximize_evaluation_metrics` is set in [XGBoost.scala](https://github.com/dmlc/xgboost/blob/master/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala) when not provided by user.


closes https://github.com/dmlc/xgboost/issues/4422