### PR TITLE
[CI] Add Windows GPU to Jenkins CI pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,8 @@ set_target_properties(
 
 set_output_directory(runxgboost ${PROJECT_SOURCE_DIR})
 set_output_directory(xgboost ${PROJECT_SOURCE_DIR}/lib)
+# Ensure these two targets do not build simultaneously, as they produce outputs with conflicting names
+add_dependencies(xgboost runxgboost)
 
 #-- Installing XGBoost
 if (R_LIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ if (MSVC)
 endif (MSVC)
 
 set_default_configuration_release()
-msvc_use_static_runtime()
 
 #-- Options
 option(BUILD_C_DOC "Build documentation for C APIs using Doxygen." OFF)
@@ -67,6 +66,7 @@ if (USE_CUDA)
 endif (USE_CUDA)
 
 # dmlc-core
+msvc_use_static_runtime()
 add_subdirectory(${PROJECT_SOURCE_DIR}/dmlc-core)
 set_target_properties(dmlc PROPERTIES
   CXX_STANDARD 11
@@ -214,3 +214,8 @@ if (GOOGLE_TEST)
     PROPERTIES
     PASS_REGULAR_EXPRESSION ".*test-rmse:0.087.*")
 endif (GOOGLE_TEST)
+
+# For MSVC: Call msvc_use_static_runtime() once again to completely
+# replace /MD with /MT. See https://github.com/dmlc/xgboost/issues/4462
+# for issues caused by mixing of /MD and /MT flags
+msvc_use_static_runtime()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
 
   // Build stages
   stages {
-    stage('Get sources') {
+    stage('Jenkins Linux: Get sources') {
       agent { label 'linux && cpu' }
       steps {
         script {
@@ -35,7 +35,7 @@ pipeline {
         milestone ordinal: 1
       }
     }
-    stage('Formatting Check') {
+    stage('Jenkins Linux: Formatting Check') {
       agent none
       steps {
         script {
@@ -49,7 +49,7 @@ pipeline {
         milestone ordinal: 2
       }
     }
-    stage('Build') {
+    stage('Jenkins Linux: Build') {
       agent none
       steps {
         script {
@@ -65,7 +65,7 @@ pipeline {
         milestone ordinal: 3
       }
     }
-    stage('Test') {
+    stage('Jenkins Linux: Test') {
       agent none
       steps {
         script {

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -7,7 +7,7 @@ pipeline {
   agent none
   // Build stages
   stages {
-    stage('Get sources') {
+    stage('Jenkins Win64: Get sources') {
       agent { label 'win64' }
       steps {
         script {
@@ -17,7 +17,7 @@ pipeline {
         milestone ordinal: 1
       }
     }
-    stage('Build') {
+    stage('Jenkins Win64: Build') {
       agent none
       steps {
         script {

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -51,7 +51,9 @@ def BuildWin64() {
     unstash name: 'srcs'
     echo "Building XGBoost for Windows AMD64 target..."
     sh """
-    ECHO "Good Morning"
+    mkdir build
+    cd build
+    cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON
     """
     deleteDir()
   }

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -57,7 +57,7 @@ def BuildWin64() {
     """
     bat """
     cd build
-    "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release -fl -flp:logfile=MSBuild.log;verbosity=diagnostic
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release || "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release || "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release
     """
     bat """
     cd python-package
@@ -65,7 +65,6 @@ def BuildWin64() {
     """
     stash name: 'xgboost_win_whl', includes: 'python-package/dist/*.whl'
     archiveArtifacts artifacts: "python-package/dist/*.whl", allowEmptyArchive: true
-    archiveArtifacts artifacts: "build/MSBuild.log", allowEmptyArchive: true
     deleteDir()
   }
 }

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -54,7 +54,15 @@ def BuildWin64() {
     mkdir build
     cd build
     cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" amd64
+    msbuild xgboost.sln /m /p:Configuration=Release -fl -flp:logfile=MSBuild.log;verbosity=diagnostic
+    cd ..\\python-package
+    conda activate
+    python setup.py bdist_wheel --universal
     """
+    stash name: 'xgboost_win_whl', includes: 'python-package/dist/*.whl'
+    archiveArtifacts artifacts: "python-package/dist/*.whl", allowEmptyArchive: true
+    archiveArtifacts artifacts: "build/MSBuild.log", allowEmptyArchive: true
     deleteDir()
   }
 }

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -1,0 +1,58 @@
+#!/usr/bin/groovy
+// -*- mode: groovy -*-
+
+/* Jenkins pipeline for Windows AMD64 target */
+
+pipeline {
+  agent none
+  // Build stages
+  stages {
+    stage('Get sources') {
+      agent { label 'win64' }
+      steps {
+        script {
+          checkoutSrcs()
+        }
+        stash name: 'srcs'
+        milestone ordinal: 1
+      }
+    }
+    stage('Build') {
+      agent none
+      steps {
+        script {
+          parallel ([
+            'build-win64': { BuildWin64() }
+          ])
+        }
+        milestone ordinal: 2
+      }
+    }
+  }
+}
+
+// check out source code from git
+def checkoutSrcs() {
+  retry(5) {
+    try {
+      timeout(time: 2, unit: 'MINUTES') {
+        checkout scm
+        sh 'git submodule update --init'
+      }
+    } catch (exc) {
+      deleteDir()
+      error "Failed to fetch source codes"
+    }
+  }
+}
+
+def BuildWin64() {
+  node('win64') {
+    unstash name: 'srcs'
+    echo "Building XGBoost for Windows AMD64 target..."
+    sh """
+    ECHO "Good Morning"
+    """
+    deleteDir()
+  }
+}

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -57,7 +57,7 @@ def BuildWin64() {
     """
     bat """
     cd build
-    "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release || "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release || "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release
     """
     bat """
     cd python-package

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -50,11 +50,12 @@ def BuildWin64() {
   node('win64') {
     unstash name: 'srcs'
     echo "Building XGBoost for Windows AMD64 target..."
-    sh """
+    bat """
     mkdir build
     cd build
     cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON
-    "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release -fl -flp:logfile=MSBuild.log;verbosity=diagnostic
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" amd64
+    msbuild xgboost.sln /m /p:Configuration=Release -fl -flp:logfile=MSBuild.log;verbosity=diagnostic
     cd ..\\python-package
     conda activate
     python setup.py bdist_wheel --universal

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -54,8 +54,7 @@ def BuildWin64() {
     mkdir build
     cd build
     cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON
-    "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" amd64
-    msbuild xgboost.sln /m /p:Configuration=Release -fl -flp:logfile=MSBuild.log;verbosity=diagnostic
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release -fl -flp:logfile=MSBuild.log;verbosity=diagnostic
     cd ..\\python-package
     conda activate
     python setup.py bdist_wheel --universal

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -56,8 +56,7 @@ def BuildWin64() {
     cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON
     "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release -fl -flp:logfile=MSBuild.log;verbosity=diagnostic
     cd ..\\python-package
-    conda activate
-    python setup.py bdist_wheel --universal
+    conda activate && python setup.py bdist_wheel --universal
     """
     stash name: 'xgboost_win_whl', includes: 'python-package/dist/*.whl'
     archiveArtifacts artifacts: "python-package/dist/*.whl", allowEmptyArchive: true

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -54,8 +54,13 @@ def BuildWin64() {
     mkdir build
     cd build
     cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON
+    """
+    bat """
+    cd build
     "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe" xgboost.sln /m /p:Configuration=Release -fl -flp:logfile=MSBuild.log;verbosity=diagnostic
-    cd ..\\python-package
+    """
+    bat """
+    cd python-package
     conda activate && python setup.py bdist_wheel --universal
     """
     stash name: 'xgboost_win_whl', includes: 'python-package/dist/*.whl'

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -17,6 +17,10 @@ endfunction(auto_source_group)
 function(msvc_use_static_runtime)
   if(MSVC)
       set(variables
+          CMAKE_C_FLAGS_DEBUG
+          CMAKE_C_FLAGS_MINSIZEREL
+          CMAKE_C_FLAGS_RELEASE
+          CMAKE_C_FLAGS_RELWITHDEBINFO
           CMAKE_CXX_FLAGS_DEBUG
           CMAKE_CXX_FLAGS_MINSIZEREL
           CMAKE_CXX_FLAGS_RELEASE
@@ -29,6 +33,7 @@ function(msvc_use_static_runtime)
           endif()
       endforeach()
       set(variables
+          CMAKE_CUDA_FLAGS
           CMAKE_CUDA_FLAGS_DEBUG
           CMAKE_CUDA_FLAGS_MINSIZEREL
           CMAKE_CUDA_FLAGS_RELEASE
@@ -37,6 +42,10 @@ function(msvc_use_static_runtime)
       foreach(variable ${variables})
           if(${variable} MATCHES "-MD")
               string(REGEX REPLACE "-MD" "-MT" ${variable} "${${variable}}")
+              set(${variable} "${${variable}}"  PARENT_SCOPE)
+          endif()
+          if(${variable} MATCHES "/MD")
+              string(REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
               set(${variable} "${${variable}}"  PARENT_SCOPE)
           endif()
       endforeach()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ if (USE_CUDA)
     $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda>
     $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>
     $<$<COMPILE_LANGUAGE:CUDA>:-lineinfo>
-    $<$<COMPILE_LANGUAGE:CUDA>:--std=c++11>
+    $<$<AND:$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<COMPILE_LANGUAGE:CUDA>>:--std=c++11>
     $<$<COMPILE_LANGUAGE:CUDA>:${GEN_CODE}>)
 
   if (USE_NCCL)
@@ -113,4 +113,10 @@ if (USE_OPENMP)
     set(LINKED_LIBRARIES_PRIVATE "${LINKED_LIBRARIES_PRIVATE};${SRC_LIBS}" PARENT_SCOPE)
   endif (OpenMP_CXX_FOUND OR OPENMP_FOUND)
 endif (USE_OPENMP)
+
+# For MSVC: Call msvc_use_static_runtime() once again to completely
+# replace /MD with /MT. See https://github.com/dmlc/xgboost/issues/4462
+# for issues caused by mixing of /MD and /MT flags
+msvc_use_static_runtime()
+
 #-- End object library


### PR DESCRIPTION
1\. Add Windows GPU to Jenkins CI pipeline (see #4234). All pull requests will now be tested to ensure compatibility with Windows platform.

2\. Fix #4462: Use `/MT` flag consistently so that MSVC builds don't fail

Background: Microsoft Visual C++ (MSVC) offers [multiple options for the C++ runtime](https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=vs-2019): `/MT` (static runtime) and `/MD` (shared DLL runtime).  XGBoost has traditionally used `/MT` to compile all sources. The utility function `msvc_use_static_runtime()` is defined in `cmake/Utils.cmake` to replace all occurrences of `/MD` with `/MT`.

Diagnosis of #4462: Recently, #4323 revised CMakeLists.txt extensively so as to incorporate [CUDA as a first-class language](https://cliutils.gitlab.io/modern-cmake/chapters/packages/CUDA.html#method-1-cuda-as-a-first-class-language). The same pull request also split off `objxgboost` target as a separate CMake module. For some unknown reasons, `objxgboost` was using `/MD`, whereas the rest of XGBoost was using `/MT`.

Fix (more of a hack actually): Call `msvc_use_static_runtime()` multiple times to completely remove `/MD`.

Fixes #4462.