### PR TITLE
Add native support for Dask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ plugin/updater_gpu/test/cpp/data
 # files from R-package source install
 **/config.status
 R-package/src/Makevars
+
+# Python install
+python-package/xgboost/tracker.py

--- a/demo/dask/README.md
+++ b/demo/dask/README.md
@@ -2,12 +2,19 @@
 
 [Dask](https://dask.org/) is a parallel computing library built on Python. Dask allows easy management of distributed workers and excels handling large distributed data science workflows.
 
-This demo shows how to train and make predictions for an xgboost model on a distributed dask environment. We make use of first-class support in xgboost for launching dask workers. Workers launched in this manner are automatically connected via xgboosts underlying communication framework, Rabit. The calls to `xgb.train()` and `xgb.predict()` occur in parallel on each worker and are synchronized.
+The simple demo shows how to train and make predictions for an xgboost model on a distributed dask environment. We make use of first-class support in xgboost for launching dask workers. Workers launched in this manner are automatically connected via xgboosts underlying communication framework, Rabit. The calls to `xgb.train()` and `xgb.predict()` occur in parallel on each worker and are synchronized.
+
+The GPU demo shows how to configure and use GPUs on the local machine for training on a large dataset.
 
 ## Requirements
 Dask is trivial to install using either pip or conda. [See here for official install documentation](https://docs.dask.org/en/latest/install.html).
 
-## Running the script
+The GPU demo requires [GPUtil](https://github.com/anderskm/gputil) for detecting system GPUs.
+
+Install via `pip install gputil` 
+
+## Running the scripts
 ```bash
-python dask_demo.py
+python dask_simple_demo.py
+python dask_gpu_demo.py
 ```

--- a/demo/dask/README.md
+++ b/demo/dask/README.md
@@ -5,7 +5,7 @@
 This demo shows how to train and make predictions for an xgboost model on a distributed dask environment. We make use of first-class support in xgboost for launching dask workers. Workers launched in this manner are automatically connected via xgboosts underlying communication framework, Rabit. The calls to `xgb.train()` and `xgb.predict()` occur in parallel on each worker and are synchronized.
 
 ## Requirements
-Dask is trivial to install from a conda environment. [See here for official install documentation](https://docs.dask.org/en/latest/install.html).
+Dask is trivial to install using either pip or conda. [See here for official install documentation](https://docs.dask.org/en/latest/install.html).
 
 ## Running the script
 ```bash

--- a/demo/dask/README.md
+++ b/demo/dask/README.md
@@ -1,0 +1,13 @@
+# Dask Integration
+
+[Dask](https://dask.org/) is a parallel computing library built on Python. Dask allows easy management of distributed workers and excels handling large distributed data science workflows.
+
+This demo shows how to train and make predictions for an xgboost model on a distributed dask environment. We make use of first-class support in xgboost for launching dask workers. Workers launched in this manner are automatically connected via xgboosts underlying communication framework, Rabit. The calls to `xgb.train()` and `xgb.predict()` occur in parallel on each worker and are synchronized.
+
+## Requirements
+Dask is trivial to install from a conda environment. [See here for official install documentation](https://docs.dask.org/en/latest/install.html).
+
+## Running the script
+```bash
+python dask_demo.py
+```

--- a/demo/dask/dask_demo.py
+++ b/demo/dask/dask_demo.py
@@ -8,10 +8,10 @@ import xgboost as xgb
 # Define the function to be executed on each worker
 def train(X, y):
     print("Start training with worker #{}".format(xgb.rabit.get_rank()))
-    # X,y are dask data frame objects distributed across the cluster.
+    # X,y are dask objects distributed across the cluster.
     # We must obtain the data local to this worker and convert it to DMatrix for training.
     # xgb.dask.create_worker_dmatrix follows the API exactly of the standard DMatrix constructor
-    # (xgb.DMatrix()), except that it 'unpacks' dask dataframe objects to obtain data local to
+    # (xgb.DMatrix()), except that it 'unpacks' dask distributed objects to obtain data local to
     # this worker
     dtrain = xgb.dask.create_worker_dmatrix(X, y)
 
@@ -30,15 +30,15 @@ def main():
     cluster = LocalCluster(n_workers=2, threads_per_worker=2)
     client = Client(cluster)
 
-    # Generate some small test data and convert to a distributed dask dataframe
+    # Generate some small test data as a dask array
     # These data frames are internally split into partitions of 20 rows each and then distributed
     #  among workers, so we will have 5 partitions distributed among 2 workers
-    # Note that the partition size MUST be consistent across different dask dataframes
+    # Note that the partition size MUST be consistent across different dask dataframes/arrays
     n = 10
     m = 100
     partition_size = 20
-    X = dd.from_array(da.random.random((m, n), partition_size))
-    y = dd.from_array(da.random.random(m, partition_size))
+    X = da.random.random((m, n), partition_size)
+    y = da.random.random(m, partition_size)
 
     # xgb.dask.run launches an arbitrary function and its arguments on the cluster
     # Here train(X, y) will be called on each worker

--- a/demo/dask/dask_demo.py
+++ b/demo/dask/dask_demo.py
@@ -1,0 +1,54 @@
+from distributed import Client, LocalCluster
+import dask.dataframe as dd
+import numpy as np
+import xgboost as xgb
+
+
+# Define the function to be executed on each worker
+def train(X, y):
+    print("Start training with worker #{}".format(xgb.rabit.get_rank()))
+    # X,y are dask data frame objects distributed across the cluster.
+    # We must obtain the data local to this worker and convert it to DMatrix for training.
+    # xgb.dask.create_worker_dmatrix follows the API exactly of the standard DMatrix constructor
+    # (xgb.DMatrix()), except that it 'unpacks' dask dataframe objects to obtain data local to
+    # this worker
+    dtrain = xgb.dask.create_worker_dmatrix(X, y)
+
+    # Train on the data. Each worker will communicate and synchronise during training. The output
+    #  model is expected to be identical on each worker.
+    bst = xgb.train({}, dtrain)
+    # Make predictions on local data
+    pred = bst.predict(dtrain)
+    print("Finished training with worker #{}".format(xgb.rabit.get_rank()))
+    # Get text representation of the model
+    return bst.get_dump()
+
+
+def main():
+    # Launch a very simple local cluster using two distributed workers with two CPU threads each
+    cluster = LocalCluster(n_workers=2, threads_per_worker=2)
+    client = Client(cluster)
+
+    # Generate some small test data and convert to a distributed dask dataframe
+    # These data frames are internally split into partitions of 20 rows each and then distributed
+    #  among workers, so we will have 5 partitions distributed among 2 workers
+    # Note that the partition size MUST be consistent across different dask dataframes
+    n = 10
+    m = 100
+    partition_size = 20
+    X = dd.from_array(np.random.random((m, n)), partition_size)
+    y = dd.from_array(np.random.random(m), partition_size)
+
+    # xgb.dask.run launches an arbitrary function and its arguments on the cluster
+    # Here train(X, y) will be called on each worker
+    # This function blocks until all work is complete
+    models = xgb.dask.run(client, train, X, y)
+
+    # models contains a dictionary mapping workers to results
+    # We expect that the models are the same over all workers
+    first_model = next(iter(models.values()))
+    assert all(model == first_model for worker, model in models.items())
+
+
+if __name__ == '__main__':
+    main()

--- a/demo/dask/dask_demo.py
+++ b/demo/dask/dask_demo.py
@@ -1,5 +1,6 @@
 from distributed import Client, LocalCluster
 import dask.dataframe as dd
+import dask.array as da
 import numpy as np
 import xgboost as xgb
 
@@ -36,8 +37,8 @@ def main():
     n = 10
     m = 100
     partition_size = 20
-    X = dd.from_array(np.random.random((m, n)), partition_size)
-    y = dd.from_array(np.random.random(m), partition_size)
+    X = dd.from_array(da.random.random((m, n), partition_size))
+    y = dd.from_array(da.random.random(m, partition_size))
 
     # xgb.dask.run launches an arbitrary function and its arguments on the cluster
     # Here train(X, y) will be called on each worker

--- a/demo/dask/dask_gpu_demo.py
+++ b/demo/dask/dask_gpu_demo.py
@@ -1,0 +1,42 @@
+from dask.distributed import Client, LocalCluster
+import dask.dataframe as dd
+import dask.array as da
+import numpy as np
+import xgboost as xgb
+import GPUtil
+import time
+
+
+# Define the function to be executed on each worker
+def train(X, y, available_devices):
+    dtrain = xgb.dask.create_worker_dmatrix(X, y)
+    local_device = available_devices[xgb.rabit.get_rank()]
+    # Specify the GPU algorithm and device for this worker
+    params = {"tree_method": "gpu_hist", "gpu_id": local_device}
+    print("Worker {} starting training on {} rows".format(xgb.rabit.get_rank(), dtrain.num_row()))
+    start = time.time()
+    xgb.train(params, dtrain, num_boost_round=500)
+    end = time.time()
+    print("Worker {} finished training in {:0.2f}s".format(xgb.rabit.get_rank(), end - start))
+
+
+def main():
+    max_devices = 16
+    # Check which devices we have locally
+    available_devices = GPUtil.getAvailable(limit=max_devices)
+    # Use one worker per device
+    cluster = LocalCluster(n_workers=len(available_devices), threads_per_worker=4)
+    client = Client(cluster)
+
+    # Set up a relatively large regression problem
+    n = 100
+    m = 10000000
+    partition_size = 100000
+    X = da.random.random((m, n), partition_size)
+    y = da.random.random(m, partition_size)
+
+    xgb.dask.run(client, train, X, y, available_devices)
+
+
+if __name__ == '__main__':
+    main()

--- a/demo/dask/dask_simple_demo.py
+++ b/demo/dask/dask_simple_demo.py
@@ -1,4 +1,4 @@
-from distributed import Client, LocalCluster
+from dask.distributed import Client, LocalCluster
 import dask.dataframe as dd
 import dask.array as da
 import numpy as np

--- a/doc/python/python_api.rst
+++ b/doc/python/python_api.rst
@@ -65,3 +65,13 @@ Callback API
 .. autofunction:: xgboost.callback.reset_learning_rate
 
 .. autofunction:: xgboost.callback.early_stop
+
+Dask API
+--------
+.. automodule:: xgboost.dask
+
+.. autofunction:: xgboost.dask.run
+
+.. autofunction:: xgboost.dask.create_worker_dmatrix
+
+.. autofunction:: xgboost.dask.get_local_data

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -5,6 +5,7 @@ import io
 import sys
 import os
 from setuptools import setup, find_packages
+
 # import subprocess
 sys.path.insert(0, '.')
 
@@ -40,7 +41,8 @@ setup(name='xgboost',
       maintainer='Hyunsu Cho',
       maintainer_email='chohyu01@cs.washington.edu',
       zip_safe=False,
-      packages=find_packages(),
+      packages=['dmlc_tracker'] + find_packages(),
+      package_dir={'dmlc_tracker': '../dmlc-core/tracker/dmlc_tracker'},
       # this will use MANIFEST.in during install where we specify additional files,
       # this is the golden line
       include_package_data=True,

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 import io
 import sys
+import shutil
 import os
 from setuptools import setup, find_packages
 
@@ -28,6 +29,10 @@ for libfile in libpath['find_lib_path']():
         continue
 
 print("Install libxgboost from: %s" % LIB_PATH)
+
+# Get dmlc tracker script
+shutil.copy('../dmlc-core/tracker/dmlc_tracker/tracker.py', 'xgboost/')
+
 # Please use setup_pip.py for generating and deploying pip installation
 # detailed instruction in setup_pip.py
 setup(name='xgboost',
@@ -41,8 +46,7 @@ setup(name='xgboost',
       maintainer='Hyunsu Cho',
       maintainer_email='chohyu01@cs.washington.edu',
       zip_safe=False,
-      packages=['dmlc_tracker'] + find_packages(),
-      package_dir={'dmlc_tracker': '../dmlc-core/tracker/dmlc_tracker'},
+      packages=find_packages(),
       # this will use MANIFEST.in during install where we specify additional files,
       # this is the golden line
       include_package_data=True,

--- a/python-package/xgboost/__init__.py
+++ b/python-package/xgboost/__init__.py
@@ -11,6 +11,7 @@ import os
 from .core import DMatrix, Booster
 from .training import train, cv
 from . import rabit                   # noqa
+from . import dask  # noqa
 try:
     from .sklearn import XGBModel, XGBClassifier, XGBRegressor, XGBRanker
     from .sklearn import XGBRFClassifier, XGBRFRegressor

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -31,15 +31,12 @@ except ImportError:
 
 # pandas
 try:
-    import pandas
     from pandas import DataFrame
-    from pandas import concat
     from pandas import MultiIndex
 
     PANDAS_INSTALLED = True
 except ImportError:
 
-    pandas = object
     MultiIndex = object
     DataFrame = object
     PANDAS_INSTALLED = False
@@ -97,12 +94,16 @@ except ImportError:
 
 # dask
 try:
-    import dask
-    import distributed
+    from dask.dataframe import DataFrame as DaskDataFrame
+    from dask.dataframe import Series as DaskSeries
+    from distributed import get_client as distributed_get_client
+    from distributed import get_worker as distributed_get_worker
 
     DASK_INSTALLED = True
 except ImportError:
-    dask = object
-    distributed = object
+    DaskDataFrame = object
+    DaskSeries = object
+    distributed_get_client = None
+    distributed_get_worker = None
 
     DASK_INSTALLED = False

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -43,6 +43,9 @@ except ImportError:
 
 # dt
 try:
+    # Workaround for #4473, compatibility with dask
+    if sys.__stdin__.closed:
+        sys.__stdin__ = None
     import datatable
 
     if hasattr(datatable, "Frame"):

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -97,7 +97,6 @@ except ImportError:
 
 # dask
 try:
-    # from dask import DataFrame as DaskDataFrame
     import dask
     import distributed
 

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -96,6 +96,7 @@ except ImportError:
 try:
     from dask.dataframe import DataFrame as DaskDataFrame
     from dask.dataframe import Series as DaskSeries
+    from dask.array import Array as DaskArray
     from distributed import get_client as distributed_get_client
     from distributed import get_worker as distributed_get_worker
 
@@ -103,6 +104,7 @@ try:
 except ImportError:
     DaskDataFrame = object
     DaskSeries = object
+    DaskArray = object
     distributed_get_client = None
     distributed_get_worker = None
 

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -6,12 +6,12 @@ from __future__ import absolute_import
 
 import sys
 
-
 PY3 = (sys.version_info[0] == 3)
 
 if PY3:
     # pylint: disable=invalid-name, redefined-builtin
     STRING_TYPES = (str,)
+
 
     def py_str(x):
         """convert c string back to python string"""
@@ -19,36 +19,35 @@ if PY3:
 else:
     STRING_TYPES = (basestring,)  # pylint: disable=undefined-variable
 
+
     def py_str(x):
         """convert c string back to python string"""
         return x
 
 try:
-    import cPickle as pickle   # noqa
+    import cPickle as pickle  # noqa
 except ImportError:
-    import pickle              # noqa
-
+    import pickle  # noqa
 
 # pandas
 try:
+    import pandas
     from pandas import DataFrame
+    from pandas import concat
     from pandas import MultiIndex
+
     PANDAS_INSTALLED = True
 except ImportError:
 
-    # pylint: disable=too-few-public-methods
-    class MultiIndex(object):
-        """ dummy for pandas.MultiIndex """
-
-    # pylint: disable=too-few-public-methods
-    class DataFrame(object):
-        """ dummy for pandas.DataFrame """
-
+    pandas = object
+    MultiIndex = object
+    DataFrame = object
     PANDAS_INSTALLED = False
 
 # dt
 try:
     import datatable
+
     if hasattr(datatable, "Frame"):
         DataTable = datatable.Frame
     else:
@@ -60,6 +59,7 @@ except ImportError:
     class DataTable(object):
         """ dummy for datatable.DataTable """
 
+
     DT_INSTALLED = False
 
 # sklearn
@@ -67,6 +67,7 @@ try:
     from sklearn.base import BaseEstimator
     from sklearn.base import RegressorMixin, ClassifierMixin
     from sklearn.preprocessing import LabelEncoder
+
     try:
         from sklearn.model_selection import KFold, StratifiedKFold
     except ImportError:
@@ -92,3 +93,17 @@ except ImportError:
     XGBKFold = None
     XGBStratifiedKFold = None
     XGBLabelEncoder = None
+
+
+# dask
+try:
+    # from dask import DataFrame as DaskDataFrame
+    import dask
+    import distributed
+
+    DASK_INSTALLED = True
+except ImportError:
+    dask = object
+    distributed = object
+
+    DASK_INSTALLED = False

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -97,7 +97,6 @@ try:
     from dask.dataframe import DataFrame as DaskDataFrame
     from dask.dataframe import Series as DaskSeries
     from dask.array import Array as DaskArray
-    from distributed import get_client as distributed_get_client
     from distributed import get_worker as distributed_get_worker
 
     DASK_INSTALLED = True
@@ -105,7 +104,6 @@ except ImportError:
     DaskDataFrame = object
     DaskSeries = object
     DaskArray = object
-    distributed_get_client = None
     distributed_get_worker = None
 
     DASK_INSTALLED = False

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -4,12 +4,10 @@ import os
 import sys
 import math
 from threading import Thread
-import distributed
-import dask
 import numpy as np
-import pandas as pd
 from . import rabit
 from .core import DMatrix
+from .compat import (DataFrame, pandas, dask, distributed)
 
 # Try to find the dmlc tracker script
 
@@ -42,8 +40,8 @@ def __start_tracker():
 def __concat(data):
     if isinstance(data[0], np.ndarray):
         return np.concatenate(data, axis=0)
-    if isinstance(data[0], (pd.DataFrame, pd.Series)):
-        return pd.concat(data, axis=0)
+    if isinstance(data[0], (DataFrame, pandas.Series)):
+        return pandas.concat(data, axis=0)
 
     raise TypeError("Data must be either numpy arrays or pandas dataframes"
                     ". Got %s" % type(data[0]))

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -4,10 +4,9 @@ import os
 import sys
 import math
 from threading import Thread
-import numpy as np
 from . import rabit
 from .core import DMatrix
-from .compat import (DaskDataFrame, DaskSeries, DaskArray, distributed_get_client,
+from .compat import (DaskDataFrame, DaskSeries, DaskArray,
                      distributed_get_worker)
 
 # Try to find the dmlc tracker script

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1,5 +1,5 @@
 # pylint: disable=wrong-import-position,wrong-import-order,import-error
-"""Dask extensions for xgboost"""
+"""Dask extensions for distributed training. See xgboost/demo/dask for examples."""
 import os
 import sys
 import math
@@ -20,6 +20,7 @@ try:
 except ImportError:
     # If packaged it will be local
     from .tracker import RabitTracker  # noqa
+
 
 def _start_tracker(n_workers):
     """ Start Rabit tracker """

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -47,11 +47,11 @@ def __concat(data):
                     ". Got %s" % type(data[0]))
 
 
-def __merge_partitions(dd, begin_partition, end_partition, total_partitions):
-    if dd.npartitions != total_partitions:
+def __merge_partitions(data, begin_partition, end_partition, total_partitions):
+    if data.npartitions != total_partitions:
         raise ValueError("Dask data must have the same partitions")
     # Get local partitions
-    partitions = [dd.partitions[i].compute() for i in
+    partitions = [data.partitions[i].compute() for i in
                   range(begin_partition, end_partition)]
     if not partitions:
         raise ValueError("Worker " + str(

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -12,7 +12,7 @@ from .compat import (DaskDataFrame, DaskSeries, DaskArray,
 # Try to find the dmlc tracker script
 
 TRACKER_PATH = os.path.dirname(__file__) + "/../../dmlc-core/tracker/dmlc_tracker"
-ALTERNATE_TRACKER_PATH = os.path.dirname(__file__) + "/dmlc-core/tracker/dmlc_tracker"
+ALTERNATE_TRACKER_PATH = os.path.dirname(__file__) + "/../dmlc_tracker"
 sys.path.append(TRACKER_PATH)
 sys.path.append(ALTERNATE_TRACKER_PATH)
 from tracker import RabitTracker  # noqa

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1,0 +1,106 @@
+# pylint: disable=wrong-import-position,wrong-import-order,import-error
+"""Dask extensions for xgboost"""
+import os
+import sys
+import math
+from threading import Thread
+import distributed
+import dask
+import numpy as np
+import pandas as pd
+from . import rabit
+from .core import DMatrix
+
+# Try to find the dmlc tracker script
+
+TRACKER_PATH = os.path.dirname(__file__) + "/../../dmlc-core/tracker/dmlc_tracker"
+ALTERNATE_TRACKER_PATH = os.path.dirname(__file__) + "/../dmlc-core/tracker/dmlc_tracker"
+sys.path.append(TRACKER_PATH)
+sys.path.append(ALTERNATE_TRACKER_PATH)
+from tracker import RabitTracker  # noqa
+
+
+def __start_tracker():
+    """ Start Rabit tracker """
+    client = distributed.get_client()
+    host = client.scheduler.address
+    if '://' in host:
+        host = host.rsplit('://', 1)[1]
+    host = host.split(':')[0]
+    n_workers = len(client.scheduler_info()['workers'])
+    env = {'DMLC_NUM_WORKER': n_workers}
+    rabit_context = RabitTracker(hostIP=host, nslave=n_workers)
+    env.update(rabit_context.slave_envs())
+
+    rabit_context.start(n_workers)
+    thread = Thread(target=rabit_context.join)
+    thread.daemon = True
+    thread.start()
+    return env
+
+
+def __concat(data):
+    if isinstance(data[0], np.ndarray):
+        return np.concatenate(data, axis=0)
+    if isinstance(data[0], (pd.DataFrame, pd.Series)):
+        return pd.concat(data, axis=0)
+
+    raise TypeError("Data must be either numpy arrays or pandas dataframes"
+                    ". Got %s" % type(data[0]))
+
+
+def create_worker_dmatrix(*args):
+    """
+    Creates a DMatrix object local to a given worker. Simply forwards arguments onto the standard
+    DMatrix constructor, if one of the arguments is a dask dataframe, unpack the data frame to
+    get the local components.
+
+    All dask dataframe arguments must use the same partitioning.
+
+    :param args: DMatrix constructor args.
+    :return: DMatrix object containing data local to current dask worker
+    """
+    total_partitions = args[0].npartitions
+    partition_size = int(math.ceil(total_partitions / rabit.get_world_size()))
+    begin_partition = partition_size * rabit.get_rank()
+    end_partition = min(begin_partition + partition_size, total_partitions)
+    dmatrix_args = []
+    for arg in args:
+        if isinstance(arg, (dask.dataframe.core.DataFrame, dask.dataframe.core.Series)):
+            if arg.npartitions != total_partitions:
+                raise ValueError("Dask data must have the same partitions")
+            # Get local partitions
+            partitions = [arg.partitions[i].compute() for i in
+                          range(begin_partition, end_partition)]
+            if not partitions:
+                raise ValueError("Worker " + str(
+                    rabit.get_rank()) + " has no data. Try using smaller partitions")
+            dmatrix_args.append(__concat(partitions))
+    return DMatrix(dmatrix_args[0], *dmatrix_args[1:])
+
+
+def __run_with_rabit(rabit_args, func, *args):
+    os.environ["OMP_NUM_THREADS"] = str(distributed.get_worker().ncores)
+    try:
+        rabit.init(rabit_args)
+        result = func(*args)
+    finally:
+        rabit.finalize()
+    return result
+
+
+def run(client, func, *args):
+    """
+    Launch arbitrary function on dask workers. Workers are connected by rabit, allowing
+    distributed training. The environment variable OMP_NUM_THREADS is defined on each worker
+    according to dask - this means that calls to xgb.train() will use the threads allocated by
+    dask by default, unless the user overrides the nthread parameter.
+    :param client: Dask client representing the cluster
+    :param func: Python function to be executed by each worker. Typically contains xgboost
+    training code.
+    :param args: Arguments to be forwarded to func
+    :return: Dict containing the function return value for each worker
+    """
+    env = client.run_on_scheduler(__start_tracker)
+    rabit_args = [('%s=%s' % item).encode() for item in env.items()]
+    return client.run(__run_with_rabit, rabit_args, func, *args)

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -12,7 +12,7 @@ from .compat import (DaskDataFrame, DaskSeries, DaskArray,
 # Try to find the dmlc tracker script
 
 TRACKER_PATH = os.path.dirname(__file__) + "/../../dmlc-core/tracker/dmlc_tracker"
-ALTERNATE_TRACKER_PATH = os.path.dirname(__file__) + "/../dmlc-core/tracker/dmlc_tracker"
+ALTERNATE_TRACKER_PATH = os.path.dirname(__file__) + "/dmlc-core/tracker/dmlc_tracker"
 sys.path.append(TRACKER_PATH)
 sys.path.append(ALTERNATE_TRACKER_PATH)
 from tracker import RabitTracker  # noqa

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -18,8 +18,13 @@ sys.path.append(ALTERNATE_TRACKER_PATH)
 from tracker import RabitTracker  # noqa
 
 
-def _start_tracker(host, n_workers):
+def _start_tracker(n_workers):
     """ Start Rabit tracker """
+    host = distributed_get_worker().address
+    if '://' in host:
+        host = host.rsplit('://', 1)[1]
+    host, port = host.split(':')
+    port = int(port)
     env = {'DMLC_NUM_WORKER': n_workers}
     rabit_context = RabitTracker(hostIP=host, nslave=n_workers)
     env.update(rabit_context.slave_envs())
@@ -99,11 +104,7 @@ def run(client, func, *args):
     :param args: Arguments to be forwarded to func
     :return: Dict containing the function return value for each worker
     """
-    host = client.scheduler.address
-    if '://' in host:
-        host = host.rsplit('://', 1)[1]
-    host = host.split(':')[0]
-    n_workers = len(client.scheduler_info()['workers'])
-    env = client.run_on_scheduler(_start_tracker, host, n_workers)
-    rabit_args = [('%s=%s' % item).encode() for item in env.items()]
+    workers = list(client.scheduler_info()['workers'].keys())
+    env = client.run(_start_tracker, len(workers), workers=[workers[0]])
+    rabit_args = [('%s=%s' % item).encode() for item in env[workers[0]].items()]
     return client.run(_run_with_rabit, rabit_args, func, *args)

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -24,7 +24,7 @@ RUN \
     pip install pyyaml cpplint pylint astroid sphinx numpy scipy pandas matplotlib sh recommonmark guzzle_sphinx_theme mock \
                 breathe matplotlib graphviz pytest scikit-learn wheel kubernetes urllib3 && \
     pip install https://h2o-release.s3.amazonaws.com/datatable/stable/datatable-0.7.0/datatable-0.7.0-cp37-cp37m-linux_x86_64.whl && \
-    conda install dask distributed -c conda-forge
+    conda install dask
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -23,7 +23,8 @@ ENV GOSU_VERSION 1.10
 RUN \
     pip install pyyaml cpplint pylint astroid sphinx numpy scipy pandas matplotlib sh recommonmark guzzle_sphinx_theme mock \
                 breathe matplotlib graphviz pytest scikit-learn wheel kubernetes urllib3 && \
-    pip install https://h2o-release.s3.amazonaws.com/datatable/stable/datatable-0.7.0/datatable-0.7.0-cp37-cp37m-linux_x86_64.whl
+    pip install https://h2o-release.s3.amazonaws.com/datatable/stable/datatable-0.7.0/datatable-0.7.0-cp37-cp37m-linux_x86_64.whl && \
+    conda install dask distributed -c conda-forge
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -17,7 +17,7 @@ ENV PATH=/opt/python/bin:$PATH
 # Install Python packages
 RUN \
     pip install numpy pytest scipy scikit-learn pandas matplotlib wheel kubernetes urllib3 graphviz && \
-    conda install dask distributed -c conda-forge
+    conda install dask
 
 ENV GOSU_VERSION 1.10
 

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -16,7 +16,8 @@ ENV PATH=/opt/python/bin:$PATH
 
 # Install Python packages
 RUN \
-    pip install numpy pytest scipy scikit-learn pandas matplotlib wheel kubernetes urllib3 graphviz
+    pip install numpy pytest scipy scikit-learn pandas matplotlib wheel kubernetes urllib3 graphviz && \
+    conda install dask distributed -c conda-forge
 
 ENV GOSU_VERSION 1.10
 

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -4,7 +4,7 @@ import xgboost as xgb
 import numpy as np
 
 try:
-    from dask.distributed.utils_test import client, loop, cluster_fixture
+    from distributed.utils_test import client, loop, cluster_fixture
     import dask.dataframe as dd
     import dask.array as da
 except ImportError:

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -1,10 +1,14 @@
 import testing as tm
-from distributed.utils_test import client, loop, cluster_fixture
-import dask.dataframe as dd
-import dask.array as da
+import pytest
 import xgboost as xgb
 import numpy as np
-import pytest
+
+try:
+    from dask.distributed.utils_test import client, loop, cluster_fixture
+    import dask.dataframe as dd
+    import dask.array as da
+except ImportError:
+    pass
 
 pytestmark = pytest.mark.skipif(**tm.no_sklearn())
 

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -2,6 +2,10 @@ import testing as tm
 import pytest
 import xgboost as xgb
 import numpy as np
+import sys
+
+if sys.platform.startswith("win"):
+    pytest.skip("Skipping dask tests on Windows", allow_module_level=True)
 
 try:
     from distributed.utils_test import client, loop, cluster_fixture
@@ -10,7 +14,7 @@ try:
 except ImportError:
     pass
 
-pytestmark = pytest.mark.skipif(**tm.no_sklearn())
+pytestmark = pytest.mark.skipif(**tm.no_dask())
 
 
 def run_train():
@@ -27,7 +31,7 @@ def test_train(client):
     # If they build the model together the output should be 0.5
     xgb.dask.run(client, run_train)
     # Run again to check we can have multiple sessions
-    # xgb.dask.run(client, run_train)
+    xgb.dask.run(client, run_train)
 
 
 def run_create_dmatrix(X, y, weights):

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -1,0 +1,73 @@
+import testing as tm
+from distributed import Client, LocalCluster
+import dask.dataframe as dd
+import xgboost as xgb
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.skipif(**tm.no_sklearn())
+
+
+def run_train():
+    # Contains one label equal to rank
+    dmat = xgb.DMatrix([[0]], label=[xgb.rabit.get_rank()])
+    bst = xgb.train({"eta": 1.0}, dmat, 1)
+    return bst.predict(dmat)
+
+
+def test_train():
+    # Train two workers, the first has label 0, the second has label 1
+    # If they build the model together the output should be 0.5
+    cluster = LocalCluster(n_workers=2, threads_per_worker=2)
+    client = Client(cluster)
+    preds = xgb.dask.run(client, run_train)
+    assert all(v[0] == 0.5 for v in preds.values())
+
+
+def run_dask_dataframe(X, y, weights):
+    dmat = xgb.dask.create_worker_dmatrix(X, y, weight=weights)
+    # Expect this worker to get two partitions and concatenate them
+    assert dmat.num_row() == 50
+
+
+def test_dask_dataframe():
+    cluster = LocalCluster(n_workers=2, threads_per_worker=2)
+    client = Client(cluster)
+    n = 10
+    m = 100
+    partition_size = 25
+    X = dd.from_array(np.random.random((m, n)), partition_size)
+    y = dd.from_array(np.random.random(m), partition_size)
+    weights = dd.from_array(np.random.random(m), partition_size)
+    xgb.dask.run(client, run_dask_dataframe, X, y, weights)
+
+
+def run_inconsistent_partitions(X, y):
+    with pytest.raises(ValueError) as e_info:
+        xgb.dask.create_worker_dmatrix(X, y)
+
+
+def test_inconsistent_partitions():
+    cluster = LocalCluster(n_workers=2, threads_per_worker=2)
+    client = Client(cluster)
+    n = 10
+    m = 100
+    X = dd.from_array(np.random.random((m, n)), 10)
+    y = dd.from_array(np.random.random(m), 20)
+    xgb.dask.run(client, run_inconsistent_partitions, X, y)
+
+
+def run_sklearn():
+    # Contains one label equal to rank
+    X = [[0]]
+    y = [xgb.rabit.get_rank()]
+    model = xgb.XGBRegressor(learning_rate=1.0)
+    model.fit(X, y)
+    return model.predict(X)
+
+
+def test_sklearn():
+    cluster = LocalCluster(n_workers=2, threads_per_worker=2)
+    client = Client(cluster)
+    preds = xgb.dask.run(client, run_sklearn)
+    assert all(v[0] == 0.5 for v in preds.values())

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -1,10 +1,15 @@
 # coding: utf-8
-from xgboost.compat import SKLEARN_INSTALLED, PANDAS_INSTALLED, DT_INSTALLED
+from xgboost.compat import SKLEARN_INSTALLED, PANDAS_INSTALLED, DT_INSTALLED, DASK_INSTALLED
 
 
 def no_sklearn():
     return {'condition': not SKLEARN_INSTALLED,
             'reason': 'Scikit-Learn is not installed'}
+
+
+def no_dask():
+    return {'condition': not DASK_INSTALLED,
+            'reason': 'Dask is not installed'}
 
 
 def no_pandas():
@@ -20,7 +25,7 @@ def no_dt():
 def no_matplotlib():
     reason = 'Matplotlib is not installed.'
     try:
-        import matplotlib.pyplot as _     # noqa
+        import matplotlib.pyplot as _  # noqa
         return {'condition': False,
                 'reason': reason}
     except ImportError:


### PR DESCRIPTION
There has been some discussion about integrating dask-xgboost into the main xgboost repository (dask/dask-xgboost#39). This will make maintenance/packaging easier and ensure the documentation lives in the same place.

I have taken a different approach to the integration than the original dask-xgboost, which completely wraps everything into a new API. I have instead provided helper functions for launching dask workers. Workers launched in this way are automatically connected via rabit and may perform distributed training.

I believe this approach is very flexible as we do not need to modify the existing xgboost python API in any way, we just call these functions using the dask launcher. This approach was also extremely lightweight in terms of code.

See the demo for a worked example.

TODO:
- [x] Add python tests
- [x] Provide multi-GPU demo
- [x] Possibly support sklearn APIs

@mrocklin @mt-jones @TomAugspurger