### PR TITLE
Ensure pandas DataFrame column names are treated as strings in type error message

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -231,7 +231,7 @@ def _maybe_pandas_data(data, feature_names, feature_types):
 
     data_dtypes = data.dtypes
     if not all(dtype.name in PANDAS_DTYPE_MAPPER for dtype in data_dtypes):
-        bad_fields = [data.columns[i] for i, dtype in
+        bad_fields = [str(data.columns[i]) for i, dtype in
                       enumerate(data_dtypes) if dtype.name not in PANDAS_DTYPE_MAPPER]
 
         msg = """DataFrame.dtypes for data must be int, float or bool.


### PR DESCRIPTION
Closes https://github.com/dmlc/xgboost/issues/4480

If the DataFrame column names aren't strings, constructing the error message here will yield an error:
```
File "/databricks/python/lib/python3.6/site-packages/shap/explainers/tree.py", line 172, in shap_values
    X = xgboost.DMatrix(X)
  File "/databricks/python/lib/python3.6/site-packages/xgboost/core.py", line 384, in __init__
    feature_types)
  File "/databricks/python/lib/python3.6/site-packages/xgboost/core.py", line 241, in _maybe_pandas_data
    raise ValueError(msg + ', '.join(bad_fields))
TypeError: sequence item 0: expected str instance, int found
```

This simply ensures it's a string.