### PR TITLE
- fix issues with training with external memory on cpu

### DIFF
--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -229,7 +229,7 @@ uint32_t HistCutMatrix::GetBinIdx(const Entry& e) {
 
 void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
   cut.Init(p_fmat, max_num_bins);
-  size_t nthread = omp_get_max_threads();
+  const size_t nthread = omp_get_max_threads();
   const uint32_t nbins = cut.row_ptr.back();
   hit_count.resize(nbins, 0);
   hit_count_tloc_.resize(nthread * nbins, 0);
@@ -247,20 +247,19 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
   size_t prev_sum = 0;
 
   for (const auto &batch : p_fmat->GetRowBatches()) {
-    auto bsize = static_cast<omp_ulong>(batch.Size());
-    nthread = std::min(bsize, nthread);
+    auto batch_size = static_cast<omp_ulong>(batch.Size());
 
     MemStackAllocator<size_t, 128> partial_sums(nthread);
     size_t* p_part = partial_sums.Get();
 
-    size_t block_size =  bsize / nthread;
+    size_t block_size =  batch_size / nthread;
 
     #pragma omp parallel num_threads(nthread)
     {
       #pragma omp for
       for (int32_t tid = 0; tid < nthread; ++tid) {
         size_t ibegin = block_size * tid;
-        size_t iend = (tid == (nthread-1) ? bsize : (block_size * (tid+1)));
+        size_t iend = (tid == (nthread-1) ? batch_size : (block_size * (tid+1)));
 
         size_t sum = 0;
         for (size_t i = ibegin; i < iend; ++i) {
@@ -272,15 +271,21 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
       #pragma omp single
       {
         p_part[0] = prev_sum;
-        for (int32_t i = 1; i < nthread; ++i) {
-          p_part[i] = p_part[i - 1] + row_ptr[rbegin + i*block_size];
+        if (batch_size < nthread) {
+          // Only the last thread handles it. Hence, the offset to the
+          // row_ptr shall be the number of entries accumulated thus far
+          p_part[nthread-1] = prev_sum;
+        } else {
+          for (int32_t i = 1; i < nthread; ++i) {
+            p_part[i] = p_part[i - 1] + row_ptr[rbegin + i*block_size];
+          }
         }
       }
 
       #pragma omp for
       for (int32_t tid = 0; tid < nthread; ++tid) {
         size_t ibegin = block_size * tid;
-        size_t iend = (tid == (nthread-1) ? bsize : (block_size * (tid+1)));
+        size_t iend = (tid == (nthread-1) ? batch_size : (block_size * (tid+1)));
 
         for (size_t i = ibegin; i < iend; ++i) {
           row_ptr[rbegin + 1 + i] += p_part[tid];
@@ -288,12 +293,12 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
       }
     }
 
-    index.resize(row_ptr[rbegin + bsize]);
+    index.resize(row_ptr[rbegin + batch_size]);
 
     CHECK_GT(cut.cut.size(), 0U);
 
     #pragma omp parallel for num_threads(nthread) schedule(static)
-    for (omp_ulong i = 0; i < bsize; ++i) { // NOLINT(*)
+    for (omp_ulong i = 0; i < batch_size; ++i) { // NOLINT(*)
       const int tid = omp_get_thread_num();
       size_t ibegin = row_ptr[rbegin + i];
       size_t iend = row_ptr[rbegin + i + 1];
@@ -316,8 +321,8 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
       }
     }
 
-    prev_sum = row_ptr[rbegin + bsize];
-    rbegin += bsize;
+    prev_sum = row_ptr[rbegin + batch_size];
+    rbegin += batch_size;
   }
 }
 

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -229,7 +229,7 @@ uint32_t HistCutMatrix::GetBinIdx(const Entry& e) {
 
 void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
   cut.Init(p_fmat, max_num_bins);
-  size_t nthread = omp_get_max_threads();
+  const size_t nthread = omp_get_max_threads();
   const uint32_t nbins = cut.row_ptr.back();
   hit_count.resize(nbins, 0);
   hit_count_tloc_.resize(nthread * nbins, 0);
@@ -250,18 +250,18 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
     // The number of threads is pegged to the batch size. If the OMP
     // block is parallelized on anything other than the batch/block size,
     // it should be reassigned
-    nthread = std::min(batch.Size(), static_cast<size_t>(omp_get_max_threads()));
-    MemStackAllocator<size_t, 128> partial_sums(nthread);
+    const size_t batch_threads = std::min(batch.Size(), static_cast<size_t>(omp_get_max_threads()));
+    MemStackAllocator<size_t, 128> partial_sums(batch_threads);
     size_t* p_part = partial_sums.Get();
 
-    size_t block_size =  batch.Size() / nthread;
+    size_t block_size =  batch.Size() / batch_threads;
 
-    #pragma omp parallel num_threads(nthread)
+    #pragma omp parallel num_threads(batch_threads)
     {
       #pragma omp for
-      for (int32_t tid = 0; tid < nthread; ++tid) {
+      for (int32_t tid = 0; tid < batch_threads; ++tid) {
         size_t ibegin = block_size * tid;
-        size_t iend = (tid == (nthread-1) ? batch.Size() : (block_size * (tid+1)));
+        size_t iend = (tid == (batch_threads-1) ? batch.Size() : (block_size * (tid+1)));
 
         size_t sum = 0;
         for (size_t i = ibegin; i < iend; ++i) {
@@ -273,15 +273,15 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
       #pragma omp single
       {
         p_part[0] = prev_sum;
-        for (int32_t i = 1; i < nthread; ++i) {
+        for (int32_t i = 1; i < batch_threads; ++i) {
           p_part[i] = p_part[i - 1] + row_ptr[rbegin + i*block_size];
         }
       }
 
       #pragma omp for
-      for (int32_t tid = 0; tid < nthread; ++tid) {
+      for (int32_t tid = 0; tid < batch_threads; ++tid) {
         size_t ibegin = block_size * tid;
-        size_t iend = (tid == (nthread-1) ? batch.Size() : (block_size * (tid+1)));
+        size_t iend = (tid == (batch_threads-1) ? batch.Size() : (block_size * (tid+1)));
 
         for (size_t i = ibegin; i < iend; ++i) {
           row_ptr[rbegin + 1 + i] += p_part[tid];
@@ -293,7 +293,7 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
 
     CHECK_GT(cut.cut.size(), 0U);
 
-    #pragma omp parallel for num_threads(nthread) schedule(static)
+    #pragma omp parallel for num_threads(batch_threads) schedule(static)
     for (omp_ulong i = 0; i < batch.Size(); ++i) { // NOLINT(*)
       const int tid = omp_get_thread_num();
       size_t ibegin = row_ptr[rbegin + i];
@@ -310,7 +310,6 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
       std::sort(index.begin() + ibegin, index.begin() + iend);
     }
 
-    nthread = omp_get_max_threads();
     #pragma omp parallel for num_threads(nthread) schedule(static)
     for (bst_omp_uint idx = 0; idx < bst_omp_uint(nbins); ++idx) {
       for (size_t tid = 0; tid < nthread; ++tid) {

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -229,7 +229,7 @@ uint32_t HistCutMatrix::GetBinIdx(const Entry& e) {
 
 void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
   cut.Init(p_fmat, max_num_bins);
-  const size_t nthread = omp_get_max_threads();
+  size_t nthread = omp_get_max_threads();
   const uint32_t nbins = cut.row_ptr.back();
   hit_count.resize(nbins, 0);
   hit_count_tloc_.resize(nthread * nbins, 0);
@@ -247,19 +247,21 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
   size_t prev_sum = 0;
 
   for (const auto &batch : p_fmat->GetRowBatches()) {
-    auto batch_size = static_cast<omp_ulong>(batch.Size());
-
+    // The number of threads is pegged to the batch size. If the OMP
+    // block is parallelized on anything other than the batch/block size,
+    // it should be reassigned
+    nthread = std::min(batch.Size(), static_cast<size_t>(omp_get_max_threads()));
     MemStackAllocator<size_t, 128> partial_sums(nthread);
     size_t* p_part = partial_sums.Get();
 
-    size_t block_size =  batch_size / nthread;
+    size_t block_size =  batch.Size() / nthread;
 
     #pragma omp parallel num_threads(nthread)
     {
       #pragma omp for
       for (int32_t tid = 0; tid < nthread; ++tid) {
         size_t ibegin = block_size * tid;
-        size_t iend = (tid == (nthread-1) ? batch_size : (block_size * (tid+1)));
+        size_t iend = (tid == (nthread-1) ? batch.Size() : (block_size * (tid+1)));
 
         size_t sum = 0;
         for (size_t i = ibegin; i < iend; ++i) {
@@ -271,21 +273,15 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
       #pragma omp single
       {
         p_part[0] = prev_sum;
-        if (batch_size < nthread) {
-          // Only the last thread handles it. Hence, the offset to the
-          // row_ptr shall be the number of entries accumulated thus far
-          p_part[nthread-1] = prev_sum;
-        } else {
-          for (int32_t i = 1; i < nthread; ++i) {
-            p_part[i] = p_part[i - 1] + row_ptr[rbegin + i*block_size];
-          }
+        for (int32_t i = 1; i < nthread; ++i) {
+          p_part[i] = p_part[i - 1] + row_ptr[rbegin + i*block_size];
         }
       }
 
       #pragma omp for
       for (int32_t tid = 0; tid < nthread; ++tid) {
         size_t ibegin = block_size * tid;
-        size_t iend = (tid == (nthread-1) ? batch_size : (block_size * (tid+1)));
+        size_t iend = (tid == (nthread-1) ? batch.Size() : (block_size * (tid+1)));
 
         for (size_t i = ibegin; i < iend; ++i) {
           row_ptr[rbegin + 1 + i] += p_part[tid];
@@ -293,12 +289,12 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
       }
     }
 
-    index.resize(row_ptr[rbegin + batch_size]);
+    index.resize(row_ptr[rbegin + batch.Size()]);
 
     CHECK_GT(cut.cut.size(), 0U);
 
     #pragma omp parallel for num_threads(nthread) schedule(static)
-    for (omp_ulong i = 0; i < batch_size; ++i) { // NOLINT(*)
+    for (omp_ulong i = 0; i < batch.Size(); ++i) { // NOLINT(*)
       const int tid = omp_get_thread_num();
       size_t ibegin = row_ptr[rbegin + i];
       size_t iend = row_ptr[rbegin + i + 1];
@@ -314,6 +310,7 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
       std::sort(index.begin() + ibegin, index.begin() + iend);
     }
 
+    nthread = omp_get_max_threads();
     #pragma omp parallel for num_threads(nthread) schedule(static)
     for (bst_omp_uint idx = 0; idx < bst_omp_uint(nbins); ++idx) {
       for (size_t tid = 0; tid < nthread; ++tid) {
@@ -321,8 +318,8 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
       }
     }
 
-    prev_sum = row_ptr[rbegin + batch_size];
-    rbegin += batch_size;
+    prev_sum = row_ptr[rbegin + batch.Size()];
+    rbegin += batch.Size();
   }
 }
 

--- a/tests/cpp/common/test_column_matrix.cc
+++ b/tests/cpp/common/test_column_matrix.cc
@@ -51,22 +51,22 @@ TEST(DenseColumnWithMissing, Test) {
   delete dmat;
 }
 
-TEST(HistIndexCreationWithExternalMemory, Test) {
-#define TEST_HIST_IDX_MATRIX(NTHREADS) \
-  { \
-    /* This should create multiple sparse pages */ \
-    std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix(1024, 1024); \
-    omp_set_num_threads(NTHREADS); \
-    GHistIndexMatrix gmat; \
-    gmat.Init(dmat.get(), 256); \
-  }
+void
+TestGHistIndexMatrixCreation(size_t nthreads) {
+  /* This should create multiple sparse pages */
+  std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix(1024, 1024);
+  omp_set_num_threads(nthreads);
+  GHistIndexMatrix gmat;
+  gmat.Init(dmat.get(), 256);
+}
 
+TEST(HistIndexCreationWithExternalMemory, Test) {
   // Vary the number of threads to make sure that the last batch
   // is distributed properly to the available number of threads
   // in the thread pool
-  TEST_HIST_IDX_MATRIX(20)
-  TEST_HIST_IDX_MATRIX(30)
-  TEST_HIST_IDX_MATRIX(40)
+  TestGHistIndexMatrixCreation(20);
+  TestGHistIndexMatrixCreation(30);
+  TestGHistIndexMatrixCreation(40);
 }
 }  // namespace common
 }  // namespace xgboost

--- a/tests/cpp/common/test_column_matrix.cc
+++ b/tests/cpp/common/test_column_matrix.cc
@@ -50,5 +50,12 @@ TEST(DenseColumnWithMissing, Test) {
   }
   delete dmat;
 }
+
+TEST(HistIndexCreationWithExternalMemory, Test) {
+  // This should create multiple sparse pages
+  std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix(10000, 16UL);
+  GHistIndexMatrix gmat;
+  gmat.Init(dmat.get(), 256);
+}
 }  // namespace common
 }  // namespace xgboost

--- a/tests/cpp/common/test_column_matrix.cc
+++ b/tests/cpp/common/test_column_matrix.cc
@@ -52,10 +52,16 @@ TEST(DenseColumnWithMissing, Test) {
 }
 
 TEST(HistIndexCreationWithExternalMemory, Test) {
-  // This should create multiple sparse pages
-  std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix(10000, 16UL);
-  GHistIndexMatrix gmat;
-  gmat.Init(dmat.get(), 256);
+  for (int i = 1; i <= 32; ++i) {
+    // Vary the number of threads to make sure that the last batch
+    // is distributed properly to the available number of threads
+    // in the thread pool
+    omp_set_num_threads(i);
+    // This should create multiple sparse pages
+    std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix((33-i)*100, 16UL);
+    GHistIndexMatrix gmat;
+    gmat.Init(dmat.get(), 256);
+  }
 }
 }  // namespace common
 }  // namespace xgboost

--- a/tests/cpp/common/test_column_matrix.cc
+++ b/tests/cpp/common/test_column_matrix.cc
@@ -53,12 +53,12 @@ TEST(DenseColumnWithMissing, Test) {
 
 TEST(HistIndexCreationWithExternalMemory, Test) {
   for (int i = 1; i <= 32; ++i) {
+    // This should create multiple sparse pages
+    std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix((33-i)*100, 16UL);
     // Vary the number of threads to make sure that the last batch
     // is distributed properly to the available number of threads
     // in the thread pool
     omp_set_num_threads(i);
-    // This should create multiple sparse pages
-    std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix((33-i)*160, 16UL);
     GHistIndexMatrix gmat;
     gmat.Init(dmat.get(), 256);
   }

--- a/tests/cpp/common/test_column_matrix.cc
+++ b/tests/cpp/common/test_column_matrix.cc
@@ -58,7 +58,7 @@ TEST(HistIndexCreationWithExternalMemory, Test) {
     // in the thread pool
     omp_set_num_threads(i);
     // This should create multiple sparse pages
-    std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix((33-i)*100, 16UL);
+    std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix((33-i)*160, 16UL);
     GHistIndexMatrix gmat;
     gmat.Init(dmat.get(), 256);
   }

--- a/tests/cpp/common/test_column_matrix.cc
+++ b/tests/cpp/common/test_column_matrix.cc
@@ -52,16 +52,21 @@ TEST(DenseColumnWithMissing, Test) {
 }
 
 TEST(HistIndexCreationWithExternalMemory, Test) {
-  for (int i = 1; i <= 32; ++i) {
-    // This should create multiple sparse pages
-    std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix((33-i)*100, 16UL);
-    // Vary the number of threads to make sure that the last batch
-    // is distributed properly to the available number of threads
-    // in the thread pool
-    omp_set_num_threads(i);
-    GHistIndexMatrix gmat;
-    gmat.Init(dmat.get(), 256);
+#define TEST_HIST_IDX_MATRIX(NTHREADS) \
+  { \
+    /* This should create multiple sparse pages */ \
+    std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix(1024, 1024); \
+    omp_set_num_threads(NTHREADS); \
+    GHistIndexMatrix gmat; \
+    gmat.Init(dmat.get(), 256); \
   }
+
+  // Vary the number of threads to make sure that the last batch
+  // is distributed properly to the available number of threads
+  // in the thread pool
+  TEST_HIST_IDX_MATRIX(20)
+  TEST_HIST_IDX_MATRIX(30)
+  TEST_HIST_IDX_MATRIX(40)
 }
 }  // namespace common
 }  // namespace xgboost

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -159,6 +159,8 @@ std::unique_ptr<DMatrix> CreateSparsePageDMatrix(size_t n_entries, size_t page_s
     batch_count++;
     row_count += batch.Size();
   }
+  std::cout << "*** DEBUG: n_entries " << n_entries << ", page_size " << page_size 
+            << ", batch_count " << batch_count << ", row_count " << row_count << std::endl;
   EXPECT_GE(batch_count, 2);
   EXPECT_EQ(row_count, dmat->Info().num_row_);
 

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -159,8 +159,6 @@ std::unique_ptr<DMatrix> CreateSparsePageDMatrix(size_t n_entries, size_t page_s
     batch_count++;
     row_count += batch.Size();
   }
-  std::cout << "*** DEBUG: n_entries " << n_entries << ", page_size " << page_size 
-            << ", batch_count " << batch_count << ", row_count " << row_count << std::endl;
   EXPECT_GE(batch_count, 2);
   EXPECT_EQ(row_count, dmat->Info().num_row_);
 


### PR DESCRIPTION
   - use the batch size to determine the correct number of rows in a batch
   - use the right number of threads in omp parallalization if the batch size
     is less than the default omp max threads (applicable for the last batch)

@canonizer @RAMitchell @rongou please review.