### PR TITLE
Enforce exclusion between pred_interactions=True and pred_interactions=True

### DIFF
--- a/src/learner.cc
+++ b/src/learner.cc
@@ -549,9 +549,9 @@ class LearnerImpl : public Learner {
                HostDeviceVector<bst_float>* out_preds, unsigned ntree_limit,
                bool pred_leaf, bool pred_contribs, bool approx_contribs,
                bool pred_interactions) override {
-    bool multiple_predictions = static_cast<int>(pred_leaf) +
-                                static_cast<int>(pred_interactions) +
-                                static_cast<int>(pred_contribs);
+    int multiple_predictions = static_cast<int>(pred_leaf) +
+                               static_cast<int>(pred_interactions) +
+                               static_cast<int>(pred_contribs);
     CHECK_LE(multiple_predictions, 1) << "Perform one kind of prediction at a time.";
     if (pred_contribs) {
       gbm_->PredictContribution(data, &out_preds->HostVector(), ntree_limit, approx_contribs);


### PR DESCRIPTION
This piece of code is subtly broken:
https://github.com/dmlc/xgboost/blob/fbbae3386a9b6ff3ed31fe4ef5106a3c4665c6e5/src/learner.cc#L548-L569
The problem here is that `multiple_predictions` has an incorrect type (`bool`), so the sum
```cpp
bool multiple_predictions = static_cast<int>(pred_leaf) + 
                            static_cast<int>(pred_interactions) + 
                            static_cast<int>(pred_contribs); 
```
gets truncated down to 1. So it is not able to detect whether the user enabled both `pred_interactions` and `pred_contribs`.

Enabling both `pred_interactions` and `pred_contribs` causes an undefined behavior. Specifically, the snippet
```python
preds = model.predict(dtest, pred_contribs=True, pred_interactions=True)
```
will cause an error similar to #4276. Here's why:
1. In the C++ layer, we run `PredictContribution()`, computing feature contribution SHAP: https://github.com/dmlc/xgboost/blob/b48f895027fcb159961857f1e24ab7a67eda14dd/src/learner.cc#L556-L557

2. Meanwhile, in the Python layer, we set `ngroup = int(chunk_size / ((data.num_col() + 1) * (data.num_col() + 1)))`. This is way too many groups compared to the output produced by the C++ layer in the previous step. 
https://github.com/dmlc/xgboost/blob/b48f895027fcb159961857f1e24ab7a67eda14dd/python-package/xgboost/core.py#L1303-L1314

**Fix** Simply allow only one kind of prediction at a time.

Fixes #4276