### PR TITLE
- training with external memory - part 2 of 2

### DIFF
--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -627,10 +627,10 @@ struct DeviceShard;
 // entire dataset across multiple sparse page batches. This keeps track of the number
 // of rows to process from a batch and the position from which to process on each device.
 struct RowStateOnDevice {
-  const size_t n_rows; // Number of rows assigned to this device
-  size_t n_rows_processed; // Number of rows processed thus far
-  size_t batch_n_rows; // Number of rows to process from the current sparse page batch
-  size_t row_offset; // Offset from the current sparse page batch to begin processing
+  const size_t n_rows;  // Number of rows assigned to this device
+  size_t n_rows_processed;  // Number of rows processed thus far
+  size_t batch_n_rows;  // Number of rows to process from the current sparse page batch
+  size_t row_offset;  // Offset from the current sparse page batch to begin processing
 
   explicit RowStateOnDevice(size_t nrows)
     : n_rows(nrows), n_rows_processed(0), batch_n_rows(0), row_offset(0) {

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -165,6 +165,27 @@ std::shared_ptr<xgboost::DMatrix> *CreateDMatrix(int rows, int columns,
 
 std::unique_ptr<DMatrix> CreateSparsePageDMatrix(size_t n_entries, size_t page_size);
 
+/**
+ * \fn std::unique_ptr<DMatrix> CreateSparsePageDMatrixWithRC(size_t n_rows, size_t n_cols,
+ *                                                            size_t page_size);
+ *
+ * \brief Creates dmatrix with some records, each record containing random number of
+ *        features in [1, n_cols]
+ *
+ * \param n_rows      Number of records to create.
+ * \param n_cols      Max number of features within that record.
+ * \param page_size   Sparse page size for the pages within the dmatrix. If page size is 0
+ *                    then the entire dmatrix is resident in memory; else, multiple sparse pages
+ *                    of page size are created and backed to disk, which would have to be
+ *                    streamed in at point of use.
+ * \param deterministic The content inside the dmatrix is constant for this configuration, if true;
+ *                      else, the content changes every time this method is invoked
+ *
+ * \return The new dmatrix.
+ */
+std::unique_ptr<DMatrix> CreateSparsePageDMatrixWithRC(size_t n_rows, size_t n_cols,
+                                                       size_t page_size, bool deterministic);
+
 gbm::GBTreeModel CreateTestModel();
 
 inline LearnerTrainParam CreateEmptyGenericParam(int gpu_id, int n_gpus) {

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -84,7 +84,7 @@ void BuildGidx(DeviceShard<GradientSumT>* shard, int n_rows, int n_cols,
   }
   shard->InitCompressedData(cmat, row_stride, is_dense);
   shard->CreateHistIndices(
-    batch, cmat, RowStateOnDevice::CreateRowStateOnDevice(batch.Size(), batch.Size()), -1);
+    batch, cmat, RowStateOnDevice(batch.Size(), batch.Size()), -1);
 
   delete dmat;
 }

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -77,7 +77,14 @@ void BuildGidx(DeviceShard<GradientSumT>* shard, int n_rows, int n_cols,
 
   auto is_dense = (*dmat)->Info().num_nonzero_ ==
                   (*dmat)->Info().num_row_ * (*dmat)->Info().num_col_;
-  shard->InitCompressedData(cmat, batch, is_dense);
+  size_t row_stride = 0;
+  const auto &offset_vec = batch.offset.ConstHostVector();
+  for (size_t i = 1; i < offset_vec.size(); ++i) {
+    row_stride = std::max(row_stride, offset_vec[i] - offset_vec[i-1]);
+  }
+  shard->InitCompressedData(cmat, row_stride, is_dense);
+  shard->CreateHistIndices(
+    batch, cmat, RowStateOnDevice::CreateRowStateOnDevice(batch.Size(), batch.Size()), -1);
 
   delete dmat;
 }
@@ -481,5 +488,46 @@ TEST(GpuHist, SortPosition) {
   TestSortPosition({2, 2, 2, 2}, 1, 2);
   TestSortPosition({1, 2, 1, 2, 3}, 1, 2);
 }
+
+TEST(GpuHist, TestHistogramIndex) {
+  // Test if the compressed histogram index matches when using a sparse
+  // dmatrix with and without using external memory
+
+  int constexpr kNRows = 1000, kNCols = 10;
+
+  // Build 2 matrices and build a histogram maker with that
+  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker, hist_maker_ext;
+  std::unique_ptr<DMatrix> hist_maker_dmat(
+    CreateSparsePageDMatrixWithRC(kNRows, kNCols, 0, true));
+  std::unique_ptr<DMatrix> hist_maker_ext_dmat(
+    CreateSparsePageDMatrixWithRC(kNRows, kNCols, 128UL, true));
+
+  std::vector<std::pair<std::string, std::string>> training_params = {
+    {"max_depth", "1"},
+    {"max_leaves", "0"}
+  };
+
+  LearnerTrainParam learner_param(CreateEmptyGenericParam(0, 1));
+  hist_maker.Init(training_params, &learner_param);
+  hist_maker.InitDataOnce(hist_maker_dmat.get());
+  hist_maker_ext.Init(training_params, &learner_param);
+  hist_maker_ext.InitDataOnce(hist_maker_ext_dmat.get());
+
+  // Extract the device shards from the histogram makers and from that its compressed
+  // histogram index
+  const auto &dev_shard = hist_maker.shards_[0];
+  std::vector<common::CompressedByteT> h_gidx_buffer(dev_shard->gidx_buffer.size());
+  dh::CopyDeviceSpanToVector(&h_gidx_buffer, dev_shard->gidx_buffer);
+
+  const auto &dev_shard_ext = hist_maker_ext.shards_[0];
+  std::vector<common::CompressedByteT> h_gidx_buffer_ext(dev_shard_ext->gidx_buffer.size());
+  dh::CopyDeviceSpanToVector(&h_gidx_buffer_ext, dev_shard_ext->gidx_buffer);
+
+  ASSERT_EQ(dev_shard->n_bins, dev_shard_ext->n_bins);
+  ASSERT_EQ(dev_shard->gidx_buffer.size(), dev_shard_ext->gidx_buffer.size());
+
+  ASSERT_EQ(h_gidx_buffer, h_gidx_buffer_ext);
+}
+
 }  // namespace tree
 }  // namespace xgboost


### PR DESCRIPTION
   - when external memory support is enabled, building of histogram indices are
     done incrementally for every sparse page
   - the entire set of input data is divided across multiple gpu's and the relative
     row positions within each device is tracked when building the compressed histogram buffer
   - the external memory is used for building the compressed buffer *only*. it is required for the compressed buffer to fit entirely into the gpu memory
   - this was tested using a mortgage dataset containing ~ 670m rows before 4xt4's could be
     saturated

@RAMitchell @canonizer @rongou - please review