### PR TITLE
Deprecate gpu_exact, bump required cuda version in docs

### DIFF
--- a/doc/gpu/index.rst
+++ b/doc/gpu/index.rst
@@ -5,10 +5,10 @@ XGBoost GPU Support
 This page contains information about GPU algorithms supported in XGBoost.
 To install GPU support, checkout the :doc:`/build`.
 
-.. note:: CUDA 8.0, Compute Capability 3.5 required
+.. note:: CUDA 9.0, Compute Capability 3.5 required
 
   The GPU algorithms in XGBoost require a graphics card with compute capability 3.5 or higher, with
-  CUDA toolkits 8.0 or later.
+  CUDA toolkits 9.0 or later.
   (See `this list <https://en.wikipedia.org/wiki/CUDA#GPUs_supported>`_ to look up compute capability of your GPU card.)
 
 *********************************************
@@ -23,13 +23,13 @@ Specify the ``tree_method`` parameter as one of the following algorithms.
 Algorithms
 ----------
 
-+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| tree_method  | Description                                                                                                                                                           |
-+==============+=======================================================================================================================================================================+
-| gpu_exact    | The standard XGBoost tree construction algorithm. Performs exact search for splits. Slower and uses considerably more memory than ``gpu_hist``.                       |
-+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| gpu_hist     | Equivalent to the XGBoost fast histogram algorithm. Much faster and uses considerably less memory. NOTE: Will run very slowly on GPUs older than Pascal architecture. |
-+--------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| tree_method           | Description                                                                                                                                                           |
++=======================+=======================================================================================================================================================================+
+| gpu_exact (deprecated)| The standard XGBoost tree construction algorithm. Performs exact search for splits. Slower and uses considerably more memory than ``gpu_hist``.                       |
++-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| gpu_hist              | Equivalent to the XGBoost fast histogram algorithm. Much faster and uses considerably less memory. NOTE: Will run very slowly on GPUs older than Pascal architecture. |
++-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Supported parameters
 --------------------
@@ -37,29 +37,29 @@ Supported parameters
 .. |tick| unicode:: U+2714
 .. |cross| unicode:: U+2718
 
-+--------------------------------+---------------+--------------+
-| parameter                      | ``gpu_exact`` | ``gpu_hist`` |
-+================================+===============+==============+
-| ``subsample``                  | |cross|       | |tick|       |
-+--------------------------------+---------------+--------------+
-| ``colsample_bytree``           | |cross|       | |tick|       |
-+--------------------------------+---------------+--------------+
-| ``colsample_bylevel``          | |cross|       | |tick|       |
-+--------------------------------+---------------+--------------+
-| ``max_bin``                    | |cross|       | |tick|       |
-+--------------------------------+---------------+--------------+
-| ``gpu_id``                     | |tick|        | |tick|       |
-+--------------------------------+---------------+--------------+
-| ``n_gpus``                     | |cross|       | |tick|       |
-+--------------------------------+---------------+--------------+
-| ``predictor``                  | |tick|        | |tick|       |
-+--------------------------------+---------------+--------------+
-| ``grow_policy``                | |cross|       | |tick|       |
-+--------------------------------+---------------+--------------+
-| ``monotone_constraints``       | |cross|       | |tick|       |
-+--------------------------------+---------------+--------------+
-| ``single_precision_histogram`` | |cross|       | |tick|       |
-+--------------------------------+---------------+--------------+
++--------------------------------+----------------------------+--------------+
+| parameter                      | ``gpu_exact`` (deprecated) | ``gpu_hist`` |
++================================+============================+==============+
+| ``subsample``                  | |cross|                    | |tick|       |
++--------------------------------+----------------------------+--------------+
+| ``colsample_bytree``           | |cross|                    | |tick|       |
++--------------------------------+----------------------------+--------------+
+| ``colsample_bylevel``          | |cross|                    | |tick|       |
++--------------------------------+----------------------------+--------------+
+| ``max_bin``                    | |cross|                    | |tick|       |
++--------------------------------+----------------------------+--------------+
+| ``gpu_id``                     | |tick|                     | |tick|       |
++--------------------------------+----------------------------+--------------+
+| ``n_gpus``                     | |cross|                    | |tick|       |
++--------------------------------+----------------------------+--------------+
+| ``predictor``                  | |tick|                     | |tick|       |
++--------------------------------+----------------------------+--------------+
+| ``grow_policy``                | |cross|                    | |tick|       |
++--------------------------------+----------------------------+--------------+
+| ``monotone_constraints``       | |cross|                    | |tick|       |
++--------------------------------+----------------------------+--------------+
+| ``single_precision_histogram`` | |cross|                    | |tick|       |
++--------------------------------+----------------------------+--------------+
 
 GPU accelerated prediction is enabled by default for the above mentioned ``tree_method`` parameters but can be switched to CPU prediction by setting ``predictor`` to ``cpu_predictor``. This could be useful if you want to conserve GPU memory. Likewise when using CPU algorithms, GPU accelerated prediction can be enabled by setting ``predictor`` to ``gpu_predictor``.
 

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -111,7 +111,7 @@ Parameters for Tree Booster
 
   - The tree construction algorithm used in XGBoost. See description in the `reference paper <http://arxiv.org/abs/1603.02754>`_.
   - XGBoost supports ``hist`` and ``approx`` for distributed training and only support ``approx`` for external memory version.
-  - Choices: ``auto``, ``exact``, ``approx``, ``hist``, ``gpu_exact``, ``gpu_hist``
+  - Choices: ``auto``, ``exact``, ``approx``, ``hist``, ``gpu_hist``
 
     - ``auto``: Use heuristic to choose the fastest method.
 
@@ -123,7 +123,6 @@ Parameters for Tree Booster
     - ``exact``: Exact greedy algorithm.
     - ``approx``: Approximate greedy algorithm using quantile sketch and gradient histogram.
     - ``hist``: Fast histogram optimized approximate greedy algorithm. It uses some performance improvements such as bins caching.
-    - ``gpu_exact``: GPU implementation of ``exact`` algorithm.
     - ``gpu_hist``: GPU implementation of ``hist`` algorithm.
 
 * ``sketch_eps`` [default=0.03]

--- a/src/tree/updater_gpu.cu
+++ b/src/tree/updater_gpu.cu
@@ -830,7 +830,11 @@ class GPUMaker : public TreeUpdater {
 
 XGBOOST_REGISTER_TREE_UPDATER(GPUMaker, "grow_gpu")
     .describe("Grow tree with GPU.")
-    .set_body([]() { return new GPUMaker(); });
+    .set_body([]() {
+      LOG(WARNING) << "The gpu_exact tree method is deprecated and may be "
+                      "removed in a future version.";
+      return new GPUMaker();
+    });
 
 }  // namespace tree
 }  // namespace xgboost


### PR DESCRIPTION
Document deprecation of the exact GPU algorithm. I am no longer willing to support this algorithm, users should be encouraged to use 'gpu_hist' in all cases.

Reduction in old code will help reduce maintenance burden and refactoring overhead for those of us currently working on GPU algorithms.