### PR TITLE
Overload device memory allocation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB_RECURSE CPU_SOURCES *.cc)
+file(GLOB_RECURSE CPU_SOURCES *.cc *.h)
 list(REMOVE_ITEM CPU_SOURCES ${PROJECT_SOURCE_DIR}/src/cli_main.cc)
 
 include(CheckCXXSourceCompiles)
@@ -33,7 +33,7 @@ endif (PLUGIN_DENSE_PARSER)
 # Object library is necessary for jvm-package, which creates its own shared
 # library.
 if (USE_CUDA)
-  file(GLOB_RECURSE CUDA_SOURCES *.cu)
+  file(GLOB_RECURSE CUDA_SOURCES *.cu *.cuh)
   add_library(objxgboost OBJECT ${CPU_SOURCES} ${CUDA_SOURCES} ${PLUGINS_SOURCES})
   target_compile_definitions(objxgboost
     PRIVATE -DXGBOOST_USE_CUDA=1)
@@ -118,5 +118,9 @@ endif (USE_OPENMP)
 # replace /MD with /MT. See https://github.com/dmlc/xgboost/issues/4462
 # for issues caused by mixing of /MD and /MT flags
 msvc_use_static_runtime()
+
+# This grouping organises source files nicely in visual studio
+auto_source_group("${CUDA_SOURCES}")
+auto_source_group("${CPU_SOURCES}")
 
 #-- End object library

--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -130,18 +130,18 @@ struct GPUSketcher {
 
     tree::TrainParam param_;
     SketchContainer *sketch_container_;
-    thrust::device_vector<size_t> row_ptrs_;
-    thrust::device_vector<Entry> entries_;
-    thrust::device_vector<bst_float> fvalues_;
-    thrust::device_vector<bst_float> feature_weights_;
-    thrust::device_vector<bst_float> fvalues_cur_;
-    thrust::device_vector<WXQSketch::Entry> cuts_d_;
+    dh::device_vector<size_t> row_ptrs_;
+    dh::device_vector<Entry> entries_;
+    dh::device_vector<bst_float> fvalues_;
+    dh::device_vector<bst_float> feature_weights_;
+    dh::device_vector<bst_float> fvalues_cur_;
+    dh::device_vector<WXQSketch::Entry> cuts_d_;
     thrust::host_vector<WXQSketch::Entry> cuts_h_;
-    thrust::device_vector<bst_float> weights_;
-    thrust::device_vector<bst_float> weights2_;
+    dh::device_vector<bst_float> weights_;
+    dh::device_vector<bst_float> weights2_;
     std::vector<size_t> n_cuts_cur_;
-    thrust::device_vector<size_t> num_elements_;
-    thrust::device_vector<char> tmp_storage_;
+    dh::device_vector<size_t> num_elements_;
+    dh::device_vector<char> tmp_storage_;
 
    public:
     DeviceShard(int device, bst_uint row_begin, bst_uint row_end,

--- a/src/common/host_device_vector.cu
+++ b/src/common/host_device_vector.cu
@@ -161,7 +161,7 @@ struct HostDeviceVectorImpl {
 
    private:
     int device_;
-    thrust::device_vector<T> data_;
+    dh::device_vector<T> data_;
     // cached vector size
     size_t cached_size_;
     size_t start_;

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -373,7 +373,7 @@ class GPUPredictor : public xgboost::Predictor {
   }
 
  public:
-  GPUPredictor()
+  GPUPredictor()  // NOLINT
       : cpu_predictor_(Predictor::Create("cpu_predictor", learner_param_)) {}
 
   void PredictBatch(DMatrix* dmat, HostDeviceVector<bst_float>* out_preds,

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -261,15 +261,15 @@ class GPUPredictor : public xgboost::Predictor {
      size_t tree_begin, size_t tree_end) {
       dh::safe_cuda(cudaSetDevice(device_));
       nodes_.resize(h_nodes.size());
-      dh::safe_cuda(cudaMemcpyAsync(dh::Raw(nodes_), h_nodes.data(),
+      dh::safe_cuda(cudaMemcpyAsync(nodes_.data().get(), h_nodes.data(),
                                     sizeof(DevicePredictionNode) * h_nodes.size(),
                                     cudaMemcpyHostToDevice));
       tree_segments_.resize(h_tree_segments.size());
-      dh::safe_cuda(cudaMemcpyAsync(dh::Raw(tree_segments_), h_tree_segments.data(),
+      dh::safe_cuda(cudaMemcpyAsync(tree_segments_.data().get(), h_tree_segments.data(),
                                     sizeof(size_t) * h_tree_segments.size(),
                                     cudaMemcpyHostToDevice));
       tree_group_.resize(model.tree_info.size());
-      dh::safe_cuda(cudaMemcpyAsync(dh::Raw(tree_group_), model.tree_info.data(),
+      dh::safe_cuda(cudaMemcpyAsync(tree_group_.data().get(), model.tree_info.data(),
                                     sizeof(int) * model.tree_info.size(),
                                     cudaMemcpyHostToDevice));
       this->tree_begin_ = tree_begin;
@@ -306,9 +306,9 @@ class GPUPredictor : public xgboost::Predictor {
 
    private:
     int device_;
-    thrust::device_vector<DevicePredictionNode> nodes_;
-    thrust::device_vector<size_t> tree_segments_;
-    thrust::device_vector<int> tree_group_;
+    dh::device_vector<DevicePredictionNode> nodes_;
+    dh::device_vector<size_t> tree_segments_;
+    dh::device_vector<int> tree_group_;
     size_t max_shared_memory_bytes_;
     size_t tree_begin_;
     size_t tree_end_;

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -383,7 +383,7 @@ class DeviceHistogram {
  private:
   /*! \brief Map nidx to starting index of its histogram. */
   std::map<int, size_t> nidx_map_;
-  thrust::device_vector<typename GradientSumT::ValueT> data_;
+  dh::device_vector<typename GradientSumT::ValueT> data_;
   int n_bins_;
   int device_id_;
   static constexpr size_t kNumItemsInGradientSum =
@@ -410,7 +410,7 @@ class DeviceHistogram {
     return n_bins_ * kNumItemsInGradientSum;
   }
 
-  thrust::device_vector<typename GradientSumT::ValueT>& Data() {
+  dh::device_vector<typename GradientSumT::ValueT>& Data() {
     return data_;
   }
 
@@ -667,10 +667,10 @@ struct DeviceShard {
   std::vector<GradientPair> node_sum_gradients;
   common::Span<GradientPair> node_sum_gradients_d;
   /*! \brief row offset in SparsePage (the input data). */
-  thrust::device_vector<size_t> row_ptrs;
+  dh::device_vector<size_t> row_ptrs;
   /*! \brief On-device feature set, only actually used on one of the devices */
-  thrust::device_vector<int> feature_set_d;
-  thrust::device_vector<int64_t>
+  dh::device_vector<int> feature_set_d;
+  dh::device_vector<int64_t>
       left_counts;  // Useful to keep a bunch of zeroed memory for sort position
   /*! The row offset for this shard. */
   bst_uint row_begin_idx;
@@ -1304,7 +1304,7 @@ inline void DeviceShard<GradientSumT>::CreateHistIndices(
        static_cast<size_t>(n_rows));
   const std::vector<Entry>& data_vec = row_batch.data.HostVector();
 
-  thrust::device_vector<Entry> entries_d(gpu_batch_nrows * row_stride);
+  dh::device_vector<Entry> entries_d(gpu_batch_nrows * row_stride);
   size_t gpu_nbatches = dh::DivRoundUp(n_rows, gpu_batch_nrows);
 
   for (size_t gpu_batch = 0; gpu_batch < gpu_nbatches; ++gpu_batch) {
@@ -1361,6 +1361,8 @@ class GPUHistMakerSpecialised {
 
     monitor_.Init("updater_gpu_hist");
   }
+
+  ~GPUHistMakerSpecialised() { dh::GlobalMemoryLogger().Log(); }
 
   void Update(HostDeviceVector<GradientPair>* gpair, DMatrix* dmat,
               const std::vector<RegTree*>& trees) {

--- a/tests/benchmark/benchmark_tree.py
+++ b/tests/benchmark/benchmark_tree.py
@@ -22,7 +22,7 @@ def run_benchmark(args):
         if not (dtest.num_row() == args.rows * args.test_size
                 and dtrain.num_row() == args.rows * (1 - args.test_size)):
             raise ValueError("Wrong rows")
-    except xgb.core.XGBoostError:
+    except ValueError:
         print("Generating dataset: {} rows * {} columns".format(args.rows, args.columns))
         print("{}/{} test/train split".format(args.test_size, 1.0 - args.test_size))
         tmp = time.time()

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -67,3 +67,6 @@ if (USE_OPENMP)
   target_compile_options(testxgboost PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
 endif (USE_OPENMP)
 set_output_directory(testxgboost ${PROJECT_BINARY_DIR})
+
+# This grouping organises source files nicely in visual studio
+auto_source_group("${TEST_SOURCES}")

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -338,8 +338,6 @@ TEST(GpuHist, EvaluateSplits) {
 }
 
 TEST(GpuHist, ApplySplit) {
-  GPUHistMakerSpecialised<GradientPairPrecise> hist_maker =
-      GPUHistMakerSpecialised<GradientPairPrecise>();
   int constexpr kNId = 0;
   int constexpr kNRows = 16;
   int constexpr kNCols = 8;
@@ -353,11 +351,9 @@ TEST(GpuHist, ApplySplit) {
     param.monotone_constraints.emplace_back(0);
   }
 
-  hist_maker.shards_.resize(1);
-  hist_maker.shards_[0].reset(
-      new DeviceShard<GradientPairPrecise>(0, 0, 0, kNRows, param, kNCols));
+  std::unique_ptr<DeviceShard<GradientPairPrecise>> shard{
+      new DeviceShard<GradientPairPrecise>(0, 0, 0, kNRows, param, kNCols)};
 
-  auto& shard = hist_maker.shards_.at(0);
   shard->ridx_segments.resize(3);  // 3 nodes.
   shard->node_sum_gradients.resize(3);
 
@@ -368,8 +364,6 @@ TEST(GpuHist, ApplySplit) {
   thrust::sequence(
       thrust::device_pointer_cast(shard->ridx.Current()),
       thrust::device_pointer_cast(shard->ridx.Current() + shard->ridx.Size()));
-  // Initialize GPUHistMaker
-  hist_maker.param_ = param;
   RegTree tree;
 
   DeviceSplitCandidate candidate;
@@ -382,7 +376,6 @@ TEST(GpuHist, ApplySplit) {
 
   // Used to get bin_id in update position.
   common::HistCutMatrix cmat = GetHostCutMatrix();
-  hist_maker.hmat_ = cmat;
 
   MetaInfo info;
   info.num_row_ = kNRows;
@@ -421,7 +414,6 @@ TEST(GpuHist, ApplySplit) {
   shard->ellpack_matrix.gidx_iter = common::CompressedIterator<uint32_t>(
       shard->gidx_buffer.data(), num_symbols);
 
-  hist_maker.info_ = &info;
   shard->ApplySplit(candidate_entry, &tree);
   shard->UpdatePosition(candidate_entry.nid, tree[candidate_entry.nid]);
 


### PR DESCRIPTION
This PR creates a custom thrust device memory allocator. It serves as an entry point to use custom allocators in the future (such as cacheing pool allocators) and provides logging for memory usage statistics.

There should be no change in behaviour here.

The logging output looks like this:
```
[16:39:52] ======== Global Device Memory Allocations:  ========
[16:39:52] Peak memory usage: 1114mb
[16:39:52] Number of allocations: 198
```
TODO:
- [x] Thread safety

- [x] Test with multiple GPUs
