### PR TITLE
Use yaml.safe_load.

### DIFF
--- a/tests/ci_build/tidy.py
+++ b/tests/ci_build/tidy.py
@@ -164,7 +164,7 @@ class ClangTidy(object):
             self.compile_commands = json.load(fd)
         tidy_file = os.path.join(self.root_path, '.clang-tidy')
         with open(tidy_file) as fd:
-            self.clang_tidy = yaml.load(fd)
+            self.clang_tidy = yaml.safe_load(fd)
             self.clang_tidy = str(self.clang_tidy)
         all_files = []
         for entry in self.compile_commands:


### PR DESCRIPTION
`load` without `Loader` is deprecated.