### PR TITLE
make sure that xgboost has gcc 5.x at the very least to build on gcc tool chain...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ if (MSVC)
   cmake_minimum_required(VERSION 3.11)
 endif (MSVC)
 
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+  message(FATAL_ERROR "GCC version must be at least 5.0!")
+endif()
+
 set_default_configuration_release()
 
 #-- Options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,6 @@ if (MSVC)
   cmake_minimum_required(VERSION 3.11)
 endif (MSVC)
 
-if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
-  message(FATAL_ERROR "GCC version must be at least 5.0!")
-endif()
-
 set_default_configuration_release()
 
 #-- Options


### PR DESCRIPTION
- pr #4521 started using regex's whose support is iffy at best on gcc 4.8.x which comes standard
   with core stock centos7
- prevent someone from building with this gcc toolchain and require at least 5.x

@hcho3 @trivialfis please review