### PR TITLE
Add c_api callbacks for direct DMatrix construction

### DIFF
--- a/demo/c-api/README.md
+++ b/demo/c-api/README.md
@@ -5,6 +5,22 @@ C-APIs
 bindings.  For detailed reference, please check xgboost/c_api.h.  Here is a
 demonstration of using the API.
 
+# Train
+This example shows how to load data into a DMatrix, train and make predictions.
+
+To run the training example from this directory:
+```bash
+cd train
+make
+# Make sure the system can find the xgboost shared library
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH=}:${PWD}/../../../lib
+./c-api-demo
+```
+This demo assumes a Linux system with make and that the xgboost library is compiled.
+
+# Custom DMatrix creation
+This example shows how an external library can create a DMatrix object using function callbacks.
+
 # CMake
 If you use **CMake** for your project, you can either install **XGBoost**
 somewhere in your system and tell CMake to find it by calling

--- a/demo/c-api/dmatrix/Makefile
+++ b/demo/c-api/dmatrix/Makefile
@@ -1,0 +1,19 @@
+SRC=dmatrix-demo.c
+TGT=dmatrix-api-demo
+
+cc=cc
+CFLAGS ?=-O3
+XGBOOST_ROOT ?=../../..
+INCLUDE_DIR=-I$(XGBOOST_ROOT)/include -I$(XGBOOST_ROOT)/dmlc-core/include -I$(XGBOOST_ROOT)/rabit/include
+LIB_DIR=-L$(XGBOOST_ROOT)/lib
+
+build: $(TGT)
+
+$(TGT): $(SRC) Makefile
+	$(cc) $(CFLAGS) $(INCLUDE_DIR) $(LIB_DIR) -o $(TGT) $(SRC) -lxgboost
+
+run: $(TGT)
+	LD_LIBRARY_PATH=$(XGBOOST_ROOT)/lib ./$(TGT)
+
+clean:
+	rm -f $(TGT)

--- a/demo/c-api/dmatrix/dmatrix-demo.c
+++ b/demo/c-api/dmatrix/dmatrix-demo.c
@@ -1,0 +1,67 @@
+/*!
+ * Copyright 2019 XGBoost contributors
+ *
+ * \file dmatrix-api-demo.c
+ * \brief An example of using xgboost C API to create a DMatrix using callbacks.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <xgboost/c_api.h>
+
+#define safe_xgboost(call)                                                   \
+  {                                                                          \
+    int err = (call);                                                        \
+    if (err != 0) {                                                          \
+      fprintf(stderr, "%s:%d: error in %s: %s\n", __FILE__, __LINE__, #call, \
+              XGBGetLastError());                                            \
+      exit(1);                                                               \
+    }                                                                        \
+  }
+
+#define kNumElements 4
+#define kNumRows 2
+#define kNumColumns 2
+
+struct MyDataContainer {
+  float* data;
+  int* index;
+  size_t* offset;
+};
+
+int MyDMatrixCallback(DataIterHandle data_handle, size_t* offset,
+                      DataElement* elements) {
+  struct MyDataContainer* data = (struct MyDataContainer*)data_handle;
+  for (int i = 0; i < kNumRows + 1; i++) {
+    offset[i] = data->offset[i];
+  }
+
+  for (int i = 0; i < kNumElements; i++) {
+    DataElement e;
+    e.index = data->index[i];
+    e.fvalue = data->data[i];
+    elements[i] = e;
+  }
+  return 0;
+}
+
+int main(int argc, char** argv) {
+  float data[kNumElements] = {0.1f, 0.2f, 0.3f, 0.4f};
+  int index[kNumElements] = {0, 1, 0, 1};
+  int64_t offset[kNumRows + 1] = {0, 2, 4};
+  struct MyDataContainer container;
+  container.data = data;
+  container.index = index;
+  container.offset = offset;
+  DMatrixHandle dtrain;
+  safe_xgboost(XGDMatrixCreateFromCallBackDirect(&container, MyDMatrixCallback,
+                                                 &dtrain, kNumRows,
+                                                 kNumElements, kNumColumns));
+  long num_rows;
+  long num_columns;
+  safe_xgboost(XGDMatrixNumRow(dtrain, &num_rows));
+  safe_xgboost(XGDMatrixNumCol(dtrain, &num_columns));
+  printf("DMatrix created with %lu rows, %lu columns.\n", num_rows,
+         num_columns);
+  return 0;
+}

--- a/demo/c-api/train/Makefile
+++ b/demo/c-api/train/Makefile
@@ -3,7 +3,7 @@ TGT=c-api-demo
 
 cc=cc
 CFLAGS ?=-O3
-XGBOOST_ROOT ?=../..
+XGBOOST_ROOT ?=../../..
 INCLUDE_DIR=-I$(XGBOOST_ROOT)/include -I$(XGBOOST_ROOT)/dmlc-core/include -I$(XGBOOST_ROOT)/rabit/include
 LIB_DIR=-L$(XGBOOST_ROOT)/lib
 

--- a/demo/c-api/train/c-api-demo.c
+++ b/demo/c-api/train/c-api-demo.c
@@ -23,8 +23,8 @@ int main(int argc, char** argv) {
   
   // load the data
   DMatrixHandle dtrain, dtest;
-  safe_xgboost(XGDMatrixCreateFromFile("../data/agaricus.txt.train", silent, &dtrain));
-  safe_xgboost(XGDMatrixCreateFromFile("../data/agaricus.txt.test", silent, &dtest));
+  safe_xgboost(XGDMatrixCreateFromFile("../../data/agaricus.txt.train", silent, &dtrain));
+  safe_xgboost(XGDMatrixCreateFromFile("../../data/agaricus.txt.test", silent, &dtest));
   
   // create the booster
   BoosterHandle booster;

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -128,6 +128,39 @@ XGB_DLL int XGDMatrixCreateFromDataIter(
     const char* cache_info,
     DMatrixHandle *out);
 
+
+/** \brief Data structure representing an internal DMatrix element in CSR format. */
+typedef struct {
+  uint32_t index;
+  float fvalue;
+} DataElement;
+
+/** \brief User-defined callback function for creating DMatrix. The externally
+ * defined function should set the offsets and elements in CSR format. **/
+XGB_EXTERN_C typedef int XGBCallbackSetDataDirect(  // NOLINT(*)
+    DataIterHandle data_handle, size_t *offset, DataElement *elements);
+
+/**
+ * \brief Allows external libraries to initialise a simple in memory DMatrix by
+ * providing a callback function that copies the data. Unlike
+ * XGDMatrixCreateFromDataIter, this function is designed to use no extra memory
+ * for staging. See demo/c_api/ for an example
+ *
+ * \param data_handle This should be a pointer to your external data
+ * structure, it will be provided as an argument to the callback function
+ * \param callback Function pointer to externally defined callback.
+ * \param out The output DMatrix
+ * \param num_rows Number of rows.
+ * \param num_elements Number of elements.
+ * \param num_columns Number of columns.
+ *
+ * \return 0 when success, -1 when failure happens.
+ */
+XGB_DLL int XGDMatrixCreateFromCallBackDirect(
+    DataIterHandle data_handle, XGBCallbackSetDataDirect *callback,
+    DMatrixHandle *out, size_t num_rows, size_t num_elements,
+    size_t num_columns);
+
 /*!
  * \brief create a matrix content from CSR format
  * \param indptr pointer to row headers


### PR DESCRIPTION
This PR proposes allowing direct construction of a DMatrix object via an external callback function. This is in the same spirit as [this existing API function](https://github.com/dmlc/xgboost/blob/59ae42a1792697165507a04f4ef4879487aba2ca/include/xgboost/c_api.h#L125), but where this function copies the data entirely three times (!!), my function does it once. It cannot be used to create an external memory DMatrix, only a simple in memory DMatrix.

The idea here is to give libraries such as cudf and python datatable a pathway to efficiently create a DMatrix without explicitly creating API functions for each new library. I can trivially add a device memory version of this function.

One possible downside is that this relies on us keeping the in memory format constant. If we change the internal data layout or types for SimpleCSRSource this would break.
