### PR TITLE
[RFC] Disscussion for how to refactor DMatrix.

### DIFF
--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -114,7 +114,7 @@ struct HistCutMatrix {
 };
 
 /*! \brief Builds the cut matrix on the GPU.
- *  
+ *
  *  \return The row stride across the entire dataset.
  */
 size_t DeviceSketch

--- a/src/data/histogram.cc
+++ b/src/data/histogram.cc
@@ -1,0 +1,73 @@
+#include <xgboost/logging.h>
+#include "histogram.h"
+
+namespace xgboost {
+
+CutMatrix::CutMatrix() : column_ptrs_{0} {}
+
+void CutMatrix::Build(DMatrix* dmat, uint32_t const max_num_bins) {
+  using WXQSketch = common::WXQuantileSketch<bst_float, bst_float>;
+  auto& info = dmat->Info();
+  constexpr float kFactor = 8;
+
+  for (auto const& batch : dmat->GetColumnBatches()) {
+    for (uint32_t col_id = 0; col_id < batch.Size(); ++col_id) {
+      WXQSketch sketch;
+      common::Span<xgboost::Entry const> column = batch[col_id];
+      uint32_t n_bins = std::min(static_cast<uint32_t>(column.size()), max_num_bins);
+      sketch.Init(info.num_row_, 1.0 / (n_bins * kFactor));
+      for (auto const& entry : column) {
+        auto row_idx = entry.index;
+        sketch.Push(entry.fvalue, info.GetWeight(entry.index));
+      }
+
+      WXQSketch::SummaryContainer out_summary;
+      sketch.GetSummary(&out_summary);
+      WXQSketch::SummaryContainer summary;
+      summary.Reserve(n_bins * kFactor);
+      summary.SetPrune(out_summary, n_bins * kFactor);
+      for (size_t i = 2; i < summary.size; ++i) {
+        bst_float cut_point = summary.data[i-1].value;
+        if (i == 2 || cut_point > cut_values_.back() ) {
+          cut_values_.emplace_back(cut_point);
+        }
+      }
+
+      bst_float cpt = summary.data[summary.size - 1].value;
+      cpt += fabs(cpt) + 1e-5;
+      cut_values_.emplace_back(cpt);
+
+      auto cut_size = cut_values_.size();
+      column_ptrs_.emplace_back(cut_size);
+    }
+  }
+}
+
+BinIdx CutMatrix::SearchBin(float value, uint32_t column_id) const {
+  auto beg = column_ptrs_.at(column_id);
+  auto end = column_ptrs_.at(column_id + 1);
+  auto it = std::upper_bound(cut_values_.cbegin() + beg, cut_values_.cend() + end, value);
+  if (it == cut_values_.cend()) {
+    it = cut_values_.cend() - 1;
+  }
+  BinIdx idx = it - cut_values_.cbegin();
+  return idx;
+}
+
+HistogramIndices::HistogramIndices() : column_ptrs_{0} {}
+
+void HistogramIndices::Build(
+    DMatrix* p_fmat, CutMatrix const& cut, uint32_t const max_num_bins) {
+  for (auto const& batch : p_fmat->GetColumnBatches()) {
+    for (auto col_id = 0; col_id < batch.Size(); ++col_id) {
+      common::Span<xgboost::Entry const> column = batch[col_id];
+      for (auto entry : column) {
+        auto idx = cut.SearchBin(entry.fvalue, col_id);
+        indices_.emplace_back(idx);
+      }
+      column_ptrs_.emplace_back(indices_.size());
+    }
+  }
+}
+
+}  // namespace xgboost

--- a/src/data/histogram.h
+++ b/src/data/histogram.h
@@ -1,0 +1,38 @@
+#ifndef HISTOGRAM_H_
+#define HISTOGRAM_H_
+
+#include <xgboost/data.h>
+#include "../common/quantile.h"
+#include "../common/timer.h"
+
+namespace xgboost {
+
+using BinIdx = uint32_t;
+
+// A CSC matrix representing quantile cuts
+class CutMatrix {
+ // private:
+ public:
+  std::vector<bst_float> cut_values_;
+  std::vector<uint32_t> column_ptrs_;
+  common::Monitor monitor_;
+
+ public:
+  CutMatrix();
+  void Build(DMatrix* dmat, uint32_t const max_num_bins);
+  BinIdx SearchBin(float value, uint32_t column_id) const;
+};
+
+// records index of each data entry. CSC
+class HistogramIndices {
+ public:
+  std::vector<uint32_t> column_ptrs_;
+  std::vector<uint32_t> indices_;
+
+ public:
+  HistogramIndices();
+  void Build(DMatrix* dmat, CutMatrix const& cut, uint32_t const max_num_bins);
+};
+
+}      // namespace xgboost
+#endif  // HISTOGRAM_H_

--- a/tests/cpp/data/test_histogram.cc
+++ b/tests/cpp/data/test_histogram.cc
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+#include "../../../src/data/histogram.h"
+#include "../../../src/common/hist_util.h"
+#include "../helpers.h"
+#include "../../../src/common/timer.h"
+
+namespace xgboost {
+
+void printCsr(std::vector<uint32_t> ptrs, std::vector<float> values) {
+  for (auto p : ptrs) {
+    std::cout << p << ", ";
+  }
+  std::cout << std::endl;
+  for (size_t i = 1; i < ptrs.size(); ++i) {
+    auto beg = ptrs[i-1];
+    auto end = ptrs[i];
+    for (size_t j = beg; j < end; ++j) {
+      std::cout << values.at(j) << ", ";
+    }
+    std::cout << std::endl;
+  }
+}
+
+TEST(CutMatrix, Build) {
+  CutMatrix cuts;
+  size_t constexpr kRows = 17;
+  size_t constexpr kCols = 15;
+
+  auto pp_mat = CreateDMatrix(kRows, kCols, 0);
+  auto& p_mat = *pp_mat;
+  common::Monitor m;
+  m.Init("Test-Cut");
+
+  common::HistCutMatrix hmat;
+  m.Start("Old");
+  hmat.Init(p_mat.get(), 256);
+  m.Stop("Old");
+  printCsr(hmat.row_ptr, hmat.cut);
+
+  std::cout << std::endl;
+
+  m.Start("New");
+  cuts.Build(p_mat.get(), 256);
+  m.Stop("New");
+  printCsr(cuts.column_ptrs_, cuts.cut_values_);
+
+  delete pp_mat;
+}
+
+}  // namespace xgboost

--- a/tests/cpp/test_main.cc
+++ b/tests/cpp/test_main.cc
@@ -5,7 +5,7 @@
 #include <vector>
 
 int main(int argc, char ** argv) {
-  std::vector<std::pair<std::string, std::string>> args {{"verbosity", "2"}};
+  std::vector<std::pair<std::string, std::string>> args {{"verbosity", "3"}};
   xgboost::ConsoleLogger::Configure(args.begin(), args.end());
   testing::InitGoogleTest(&argc, argv);
   testing::FLAGS_gtest_death_test_style = "threadsafe";


### PR DESCRIPTION
Hi, @RAMitchell , since we are all working on DMatrix related code, I want to be on the same page how should we proceed to avoid conflicting work.

## Background
This PR is only a demo for how a histogram indices matrix is built.  Previously `hist_utils.cc` iterates on rows by calling `GetRowBatches`, which is complicated and memory demanding.  Here I created `data/histogram.cc` which contains 73 lines of code but is already capable of building a histogram indices (no consideration for weight groups).  And it consumes **much less** memory for sparse dataset since it understands number of rows for each column.  Also, I can further optimize it based on number of non-empty columns.  The key is by using `GetColumnBatches` (CSC instead of CSR) instead.

## The problem
DMatrix converts everything into CSR, so calling `GetColumnBatches` is quite slow, also waste in memory.  I'm positive that once the barrier is removed, our initialization stage will be much more efficient in both memory and speed.  Can we discuss a plan for bridging between backend formats including `libsvm`, `csv`, `csr`, `csc`, `dense` and `__cuda_array_interface__` to frontend outputs including `histogram indices`, `csc`, `csr`, `sorted csc`?