### PR TITLE
- set the appropriate device before freeing device memory...

### DIFF
--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -552,6 +552,8 @@ struct CubMemory {
       XGBDeviceAllocator<uint8_t> allocator;
       allocator.deallocate(thrust::device_ptr<uint8_t>(static_cast<uint8_t *>(d_temp_storage)),
         temp_storage_bytes);
+      d_temp_storage = nullptr;
+      temp_storage_bytes = 0;
     }
   }
 

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -237,11 +237,19 @@ class MemoryLogger {
       peak_allocated_bytes =
         std::max(peak_allocated_bytes, currently_allocated_bytes);
       num_allocations++;
+      CHECK_GT(num_allocations, num_deallocations);
     }
-    void RegisterDeallocation(void *ptr) {
+    void RegisterDeallocation(void *ptr, size_t n, int current_device) {
+      auto itr = device_allocations.find(ptr);
+      if (itr == device_allocations.end()) {
+        LOG(FATAL) << "Attempting to deallocate " << n << " bytes on device "
+                   << current_device << " that was never allocated ";
+      }
       num_deallocations++;
-      currently_allocated_bytes -= device_allocations[ptr];
-      device_allocations.erase(ptr);
+      CHECK_LE(num_deallocations, num_allocations);
+      CHECK_EQ(itr->second, n);
+      currently_allocated_bytes -= itr->second;
+      device_allocations.erase(itr);
     }
   };
   std::map<int, DeviceStats>
@@ -256,14 +264,15 @@ public:
     int current_device;
     safe_cuda(cudaGetDevice(&current_device));
     stats_[current_device].RegisterAllocation(ptr, n);
+    CHECK_LE(stats_[current_device].peak_allocated_bytes, dh::TotalMemory(current_device));
   }
-  void RegisterDeallocation(void *ptr) {
+  void RegisterDeallocation(void *ptr, size_t n) {
     if (!xgboost::ConsoleLogger::ShouldLog(xgboost::ConsoleLogger::LV::kDebug))
       return;
     std::lock_guard<std::mutex> guard(mutex_);
     int current_device;
     safe_cuda(cudaGetDevice(&current_device));
-    stats_[current_device].RegisterDeallocation(ptr);
+    stats_[current_device].RegisterDeallocation(ptr, n, current_device);
   }
   void Log() {
     if (!xgboost::ConsoleLogger::ShouldLog(xgboost::ConsoleLogger::LV::kDebug))
@@ -299,7 +308,7 @@ struct XGBDefaultDeviceAllocator : thrust::device_malloc_allocator<T> {
     return ptr;
   }
   void deallocate(pointer ptr, size_t n) {
-    GlobalMemoryLogger().RegisterDeallocation(ptr.get());
+    GlobalMemoryLogger().RegisterDeallocation(ptr.get(), n);
     return super_t::deallocate(ptr, n);
   }
 };

--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -150,6 +150,10 @@ struct GPUSketcher {
       n_rows_(row_end - row_begin), param_(std::move(param)), sketch_container_(sketch_container) {
     }
 
+    ~DeviceShard() {
+      dh::safe_cuda(cudaSetDevice(device_));
+    }
+
     inline size_t GetRowStride() const {
        return row_stride_;
     }

--- a/src/common/host_device_vector.cu
+++ b/src/common/host_device_vector.cu
@@ -49,6 +49,10 @@ struct HostDeviceVectorImpl {
       : proper_size_{0}, device_{-1}, start_{0}, perm_d_{false},
         cached_size_{static_cast<size_t>(~0)}, vec_{nullptr} {}
 
+    ~DeviceShard() {
+       SetDevice();
+    }
+
     void Init(HostDeviceVectorImpl<T>* vec, int device) {
       if (vec_ == nullptr) { vec_ = vec; }
       CHECK_EQ(vec, vec_);

--- a/src/common/host_device_vector.cu
+++ b/src/common/host_device_vector.cu
@@ -50,7 +50,7 @@ struct HostDeviceVectorImpl {
         cached_size_{static_cast<size_t>(~0)}, vec_{nullptr} {}
 
     ~DeviceShard() {
-       SetDevice();
+      SetDevice();
     }
 
     void Init(HostDeviceVectorImpl<T>* vec, int device) {

--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -81,6 +81,10 @@ class DeviceShard {
     RescaleIndices(device_id_, ridx_begin_, data_);
   }
 
+  ~DeviceShard() {
+    dh::safe_cuda(cudaSetDevice(device_id_));
+  }
+
   bool IsEmpty() {
     return (ridx_end_ - ridx_begin_) == 0;
   }

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -60,7 +60,7 @@ class ElementWiseMetricsReduction {
 
   PackedReduceResult DeviceReduceMetrics(
       GPUSet::GpuIdType device_id,
-      dh::CubMemory &allocator,
+      dh::CubMemory *allocator,
       const HostDeviceVector<bst_float>& weights,
       const HostDeviceVector<bst_float>& labels,
       const HostDeviceVector<bst_float>& preds) {
@@ -78,7 +78,7 @@ class ElementWiseMetricsReduction {
     auto d_policy = policy_;
 
     PackedReduceResult result = thrust::transform_reduce(
-        thrust::cuda::par(allocator),
+        thrust::cuda::par(*allocator),
         begin, end,
         [=] XGBOOST_DEVICE(size_t idx) {
           bst_float weight = is_null_weight ? 1.0f : s_weights[idx];
@@ -118,7 +118,7 @@ class ElementWiseMetricsReduction {
         size_t index = devices.Index(id);
         dh::CubMemory allocator;
         res_per_device.at(index) =
-            DeviceReduceMetrics(id, allocator, weights, labels, preds);
+            DeviceReduceMetrics(id, &allocator, weights, labels, preds);
       }
 
       for (auto const& res : res_per_device) {

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -60,7 +60,7 @@ class ElementWiseMetricsReduction {
 
   PackedReduceResult DeviceReduceMetrics(
       GPUSet::GpuIdType device_id,
-      size_t device_index,
+      dh::CubMemory &allocator,
       const HostDeviceVector<bst_float>& weights,
       const HostDeviceVector<bst_float>& labels,
       const HostDeviceVector<bst_float>& preds) {
@@ -78,7 +78,7 @@ class ElementWiseMetricsReduction {
     auto d_policy = policy_;
 
     PackedReduceResult result = thrust::transform_reduce(
-        thrust::cuda::par(allocators_.at(device_index)),
+        thrust::cuda::par(allocator),
         begin, end,
         [=] XGBOOST_DEVICE(size_t idx) {
           bst_float weight = is_null_weight ? 1.0f : s_weights[idx];
@@ -107,10 +107,6 @@ class ElementWiseMetricsReduction {
     }
 #if defined(XGBOOST_USE_CUDA)
     else {  // NOLINT
-      if (allocators_.size() != devices.Size()) {
-        allocators_.clear();
-        allocators_.resize(devices.Size());
-      }
       preds.Shard(devices);
       labels.Shard(devices);
       weights.Shard(devices);
@@ -120,8 +116,9 @@ class ElementWiseMetricsReduction {
       for (GPUSet::GpuIdType id = *devices.begin(); id < *devices.end(); ++id) {
         dh::safe_cuda(cudaSetDevice(id));
         size_t index = devices.Index(id);
+        dh::CubMemory allocator;
         res_per_device.at(index) =
-            DeviceReduceMetrics(id, index, weights, labels, preds);
+            DeviceReduceMetrics(id, allocator, weights, labels, preds);
       }
 
       for (auto const& res : res_per_device) {
@@ -134,9 +131,6 @@ class ElementWiseMetricsReduction {
 
  private:
   EvalRow policy_;
-#if defined(XGBOOST_USE_CUDA)
-  std::vector<dh::CubMemory> allocators_;
-#endif  // defined(XGBOOST_USE_CUDA)
 };
 
 struct EvalRowRMSE {

--- a/tests/cpp/common/test_host_device_vector.cu
+++ b/tests/cpp/common/test_host_device_vector.cu
@@ -21,7 +21,7 @@ void SetDevice(int device) {
 
 struct HostDeviceVectorSetDeviceHandler {
   template <typename Functor>
-  HostDeviceVectorSetDeviceHandler(Functor f) {
+  explicit HostDeviceVectorSetDeviceHandler(Functor f) {
     SetCudaSetDeviceHandler(f);
   }
 

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "../helpers.h"
 
+#if defined(XGBOOST_USE_NCCL)
 namespace {
 
 inline void CheckCAPICall(int ret) {
@@ -17,6 +18,7 @@ inline void CheckCAPICall(int ret) {
 }
 
 }  // namespace anonymous
+#endif
 
 extern const std::map<std::string, std::string>&
 QueryBoosterConfigurationArguments(BoosterHandle handle);


### PR DESCRIPTION
   - pr #4532 added a global memory tracker/logger to keep track of number of (de)allocations
     and peak memory usage on a per device basis. this has exposed issues with how device memory
     has been deallocated
   - in a few code paths, the destructor that takes care of releasing device memory does not set
     the appropriate device id (as we rely on the one synthesized by the compiler to release it).
     as a consequence, the memory was attempted to be released on devices
     that never allocated it in the first place. as to why this worked (without crashing) is beyond me
   - this pr adds the appropriate check to make sure that the (de)allocation counts and memory usages
     makes sense for the device. since verbosity is typically increased on debug/non-retail builds, adding
     these extra checks shouldn't cause performance degradation; rather, it can be useful to
     expose (de)allocation issues

@RAMitchell @rongou @trivialfis - please review