### PR TITLE
add C_API about incremental DMatrix building

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -35,6 +35,8 @@ typedef void *BoosterHandle;  // NOLINT(*)
 typedef void *DataIterHandle;  // NOLINT(*)
 /*! \brief handle to a internal data holder. */
 typedef void *DataHolderHandle;  // NOLINT(*)
+/*! \brief handle to a data source. */
+typedef void *DataSourceHandle;  // NOLINT(*)
 
 /*! \brief Mini batch used in XGBoost Data Iteration */
 typedef struct {  // NOLINT(*)
@@ -127,6 +129,41 @@ XGB_DLL int XGDMatrixCreateFromDataIter(
     XGBCallbackDataIterNext* callback,
     const char* cache_info,
     DMatrixHandle *out);
+
+/*!
+ * \brief create a XGBoost DataSource(SimpleCSRSource)
+ * \param num_row row number, which is used to pre-allocate memory
+ * \param num_nonzero number of elements, which is used to pre-allocate memory
+ * \param out created XGBoost DataSource
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDataSourceCreate(const size_t num_row,
+                               const size_t num_nonzero,
+                               DataSourceHandle *out);
+
+/*!
+ * \brief append CSR format data into XGBoost DataSource
+ * \param indptr pointer to row headers
+ * \param indices findex
+ * \param data fvalue
+ * \param nindptr number of rows in the matrix + 1
+ * \param handle instance of XGBoost DataSource
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDataSourceAppendData(const size_t *indptr,
+                                   const unsigned *indices,
+                                   const float *data,
+                                   size_t nindptr,
+                                   DataSourceHandle handle);
+
+/*!
+ * \brief create a matrix content from XGBoost DataSource(SimpleCSRSource)
+ * \param handle instance of XGBoost DataSource
+ * \param out created dmatrix
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixCreateFromDataSource(DataSourceHandle handle,
+                                          DMatrixHandle *out);
 
 /*!
  * \brief create a matrix content from CSR format

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -83,6 +83,8 @@ TEST(c_api, XGDMatrixCreateFromDataSource) {
 
   DMatrixHandle mat_handle;
   XGDMatrixCreateFromDataSource(handle, &mat_handle);
+  delete handle;
+
   std::shared_ptr<xgboost::DMatrix> *dmat =
       static_cast<std::shared_ptr<xgboost::DMatrix> *>(mat_handle);
   xgboost::MetaInfo &info = (*dmat)->Info();

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -63,3 +63,56 @@ TEST(c_api, XGDMatrixCreateFromMat_omp) {
     delete dmat;
   }
 }
+
+TEST(c_api, XGDMatrixCreateFromDataSource) {
+  DataSourceHandle handle;
+  XGDataSourceCreate(0, 0, &handle);
+  // test multiple data appending
+  const std::vector<size_t>& indptr = {0, 2, 3, 6};
+  const std::vector<unsigned>& indices = {1, 3, 0, 2, 4, 3};
+  const std::vector<float>& data = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+  XGDataSourceAppendData(indptr.data(), indices.data(), data.data(),
+                         indptr.size(),
+                         handle);
+  const std::vector<size_t>& indptr1 = {0, 3, 4};
+  const std::vector<unsigned>& indices1 = {0, 2, 9, 0};
+  const std::vector<float>& data1 = {-1.0f, -2.0f, -3.0f, -4.0f};
+  XGDataSourceAppendData(indptr1.data(), indices1.data(), data1.data(),
+                         indptr1.size(),
+                         handle);
+
+  DMatrixHandle mat_handle;
+  XGDMatrixCreateFromDataSource(handle, &mat_handle);
+  std::shared_ptr<xgboost::DMatrix> *dmat =
+      static_cast<std::shared_ptr<xgboost::DMatrix> *>(mat_handle);
+  xgboost::MetaInfo &info = (*dmat)->Info();
+  ASSERT_EQ(info.num_col_, 10);
+  ASSERT_EQ(info.num_row_, 5);
+  ASSERT_EQ(info.num_nonzero_, 10);
+
+  for (const auto &batch : (*dmat)->GetRowBatches()) {
+    ASSERT_EQ(batch[0][0].index, 1);
+    ASSERT_EQ(batch[0][1].index, 3);
+    ASSERT_EQ(batch[1][0].index, 0);
+    ASSERT_EQ(batch[2][0].index, 2);
+    ASSERT_EQ(batch[2][1].index, 4);
+    ASSERT_EQ(batch[2][2].index, 3);
+    ASSERT_EQ(batch[3][0].index, 0);
+    ASSERT_EQ(batch[3][1].index, 2);
+    ASSERT_EQ(batch[3][2].index, 9);
+    ASSERT_EQ(batch[4][0].index, 0);
+    ASSERT_EQ(batch[0][0].fvalue, 0.0f);
+    ASSERT_EQ(batch[0][1].fvalue, 1.0f);
+    ASSERT_EQ(batch[1][0].fvalue, 2.0f);
+    ASSERT_EQ(batch[2][0].fvalue, 3.0f);
+    ASSERT_EQ(batch[2][1].fvalue, 4.0f);
+    ASSERT_EQ(batch[2][2].fvalue, 5.0f);
+    ASSERT_EQ(batch[3][0].fvalue, -1.0f);
+    ASSERT_EQ(batch[3][1].fvalue, -2.0f);
+    ASSERT_EQ(batch[3][2].fvalue, -3.0f);
+    ASSERT_EQ(batch[4][0].fvalue, -4.0f);
+  }
+
+  delete dmat;
+}
+


### PR DESCRIPTION
Add C_API for data::DataSource, by which,  data can be fetched gradually by appending to the tail of DataSource. And Then,  DMatrix can be created by data::DataSource.

I think, these APIs is helpful to build _DMatrix Builder_ for other languages (like python). Since now, when we build a DMatrix in python, we need cache all data in format like pandas.DataFrame. With _DMatrix Builder_ , additional cache can be avoided. 

 I'm willing to write _DMatrix Builder_  for python later.
