### PR TITLE
- do not create device vectors for the entire sparse page while compu…

### DIFF
--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -1326,14 +1326,17 @@ inline void DeviceShard<GradientSumT>::CreateHistIndices(
     }
     size_t batch_nrows = batch_row_end - batch_row_begin;
 
-    const auto ent_cnt_begin = offset_vec[device_row_state.row_offset_in_current_batch + batch_row_begin];
-    const auto ent_cnt_end = offset_vec[device_row_state.row_offset_in_current_batch + batch_row_end];
+    const auto ent_cnt_begin = 
+      offset_vec[device_row_state.row_offset_in_current_batch + batch_row_begin];
+    const auto ent_cnt_end = 
+      offset_vec[device_row_state.row_offset_in_current_batch + batch_row_end];
 
     /*! \brief row offset in SparsePage (the input data). */
     dh::device_vector<size_t> row_ptrs(batch_nrows+1);
-    thrust::copy(offset_vec.data() + device_row_state.row_offset_in_current_batch + batch_row_begin,
-                 offset_vec.data() + device_row_state.row_offset_in_current_batch + batch_row_end + 1,
-                 row_ptrs.begin());
+    thrust::copy(
+      offset_vec.data() + device_row_state.row_offset_in_current_batch + batch_row_begin,
+      offset_vec.data() + device_row_state.row_offset_in_current_batch + batch_row_end + 1,
+      row_ptrs.begin());
 
     // number of entries in this batch.
     size_t n_entries = ent_cnt_end - ent_cnt_begin;

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -1326,9 +1326,9 @@ inline void DeviceShard<GradientSumT>::CreateHistIndices(
     }
     size_t batch_nrows = batch_row_end - batch_row_begin;
 
-    const auto ent_cnt_begin = 
+    const auto ent_cnt_begin =
       offset_vec[device_row_state.row_offset_in_current_batch + batch_row_begin];
-    const auto ent_cnt_end = 
+    const auto ent_cnt_end =
       offset_vec[device_row_state.row_offset_in_current_batch + batch_row_end];
 
     /*! \brief row offset in SparsePage (the input data). */


### PR DESCRIPTION
…ting histograms...

   - while creating the compressed histogram indices, the row vector is created for the entire
     sparse page batch. this is needless as we only process chunks at a time based on a slice
     of the total gpu memory
   - this pr will allocate only as much as required to store the appropriate row indices and the entries

@RAMitchell please review.