### PR TITLE
[CI] Remove CUDA 8.0 from CI pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,6 @@ pipeline {
         script {
           parallel ([
             'build-cpu': { BuildCPU() },
-            'build-gpu-cuda8.0': { BuildCUDA(cuda_version: '8.0') },
             'build-gpu-cuda9.0': { BuildCUDA(cuda_version: '9.0') },
             'build-gpu-cuda10.0': { BuildCUDA(cuda_version: '10.0') },
             'build-gpu-cuda10.1': { BuildCUDA(cuda_version: '10.1') },
@@ -72,7 +71,6 @@ pipeline {
         script {
           parallel ([
             'test-python-cpu': { TestPythonCPU() },
-            'test-python-gpu-cuda8.0': { TestPythonGPU(cuda_version: '8.0') },
             'test-python-gpu-cuda9.0': { TestPythonGPU(cuda_version: '9.0') },
             'test-python-gpu-cuda10.0': { TestPythonGPU(cuda_version: '10.0') },
             'test-python-gpu-cuda10.1': { TestPythonGPU(cuda_version: '10.1') },
@@ -197,11 +195,8 @@ def BuildCUDA(args) {
     ${dockerRun} ${container_type} ${docker_binary} ${docker_args} tests/ci_build/build_via_cmake.sh -DUSE_CUDA=ON -DUSE_NCCL=ON -DOPEN_MP:BOOL=ON
     ${dockerRun} ${container_type} ${docker_binary} ${docker_args} bash -c "cd python-package && rm -rf dist/* && python setup.py bdist_wheel --universal"
     """
-    // Stash wheel for CUDA 8.0 / 9.0 target
-    if (args.cuda_version == '8.0') {
-      echo 'Stashing Python wheel...'
-      stash name: 'xgboost_whl_cuda8', includes: 'python-package/dist/*.whl'
-    } else if (args.cuda_version == '9.0') {
+    // Stash wheel for CUDA 9.0 target
+    if (args.cuda_version == '9.0') {
       echo 'Stashing Python wheel...'
       stash name: 'xgboost_whl_cuda9', includes: 'python-package/dist/*.whl'
       archiveArtifacts artifacts: "python-package/dist/*.whl", allowEmptyArchive: true
@@ -262,11 +257,7 @@ def TestPythonCPU() {
 def TestPythonGPU(args) {
   nodeReq = (args.multi_gpu) ? 'linux && mgpu' : 'linux && gpu'
   node(nodeReq) {
-    if (args.cuda_version == '8.0') {
-      unstash name: 'xgboost_whl_cuda8'
-    } else {
-      unstash name: 'xgboost_whl_cuda9'
-    }
+    unstash name: 'xgboost_whl_cuda9'
     unstash name: 'srcs'
     echo "Test Python GPU: CUDA ${args.cuda_version}"
     def container_type = "gpu"


### PR DESCRIPTION
See https://github.com/dmlc/xgboost/pull/4554#discussion_r295070473. Now that we are distributing XGBoost compiled with CUDA 9.0, we will cease testing XGBoost against CUDA 8.0 target. This should reduce the cost of the Jenkins CI pipeline.