### PR TITLE
[CI] Specify account ID when logging into ECR Docker registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,8 @@ pipeline {
   agent none
 
   environment {
-    DOCKER_CACHE_REPO = '492475357299.dkr.ecr.us-west-2.amazonaws.com'
+    DOCKER_CACHE_ECR_ID = '492475357299'
+    DOCKER_CACHE_ECR_REGION = 'us-west-2'
   }
 
   // Setup common job properties

--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -144,7 +144,7 @@ then
     DOCKER_CACHE_REPO="${DOCKER_CACHE_ECR_ID}.dkr.ecr.${DOCKER_CACHE_ECR_REGION}.amazonaws.com"
     echo "Using AWS ECR; repo URL = ${DOCKER_CACHE_REPO}"
     # Login for Docker registry
-    echo "$(python3 -m awscli ecr get-login --no-include-email --region ${DOCKER_CACHE_ECR_REGION} --registry-ids ${DOCKER_CACHE_ECR_ID})"
+    echo "\$(python3 -m awscli ecr get-login --no-include-email --region ${DOCKER_CACHE_ECR_REGION} --registry-ids ${DOCKER_CACHE_ECR_ID})"
     $(python3 -m awscli ecr get-login --no-include-email --region ${DOCKER_CACHE_ECR_REGION} --registry-ids ${DOCKER_CACHE_ECR_ID})
     # Pull pre-build container from Docker build cache,
     # if one exists for the particular branch or pull request

--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -137,12 +137,15 @@ EOF
 # Build the docker container.
 echo "Building container (${DOCKER_IMG_NAME})..."
 
-# If enviornment variable DOCKER_CACHE_REPO is set, use an external Docker repo for build caching
-if [[ -n "${DOCKER_CACHE_REPO}" ]]
+# If enviornment variables DOCKER_CACHE_ECR_ID and DOCKER_CACHE_ECR_REGION are set, use AWS ECR for build caching
+if [[ -n "${DOCKER_CACHE_ECR_ID}" && -n "${DOCKER_CACHE_ECR_REGION}" ]]
 then
+    # Format Docker repo URL
+    DOCKER_CACHE_REPO="${DOCKER_CACHE_ECR_ID}.dkr.ecr.${DOCKER_CACHE_ECR_REGION}.amazonaws.com"
+    echo "Using AWS ECR; repo URL = ${DOCKER_CACHE_REPO}"
     # Login for Docker registry
-    echo '$(python3 -m awscli ecr get-login --no-include-email --region us-west-2)'
-    $(python3 -m awscli ecr get-login --no-include-email --region us-west-2)
+    echo "$(python3 -m awscli ecr get-login --no-include-email --region ${DOCKER_CACHE_ECR_REGION} --registry-ids ${DOCKER_CACHE_ECR_ID})"
+    $(python3 -m awscli ecr get-login --no-include-email --region ${DOCKER_CACHE_ECR_REGION} --registry-ids ${DOCKER_CACHE_ECR_ID})
     # Pull pre-build container from Docker build cache,
     # if one exists for the particular branch or pull request
     echo "docker pull ${DOCKER_CACHE_REPO}/${DOCKER_IMG_NAME}:${BRANCH_NAME}"


### PR DESCRIPTION
Background: The Jenkins CI pipeline (https://xgboost-ci.net) uses AWS ECR (Elastic Container Registry) to cache Docker images, in order to speed up builds.

This pull request will explicitly specify the AWS account ID (492475357299) when connecting to ECR. This change is intended to allow worker instances from another AWS account to connect to the same ECR registry. Having multiple AWS accounts is necessary to divide the expenses between multiple billing accounts.