### PR TITLE
Fix docstring for XGBModel.predict() [skip ci]

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -431,8 +431,8 @@ class XGBModel(XGBModelBase):
 
         Parameters
         ----------
-        data : DMatrix
-            The dmatrix storing the input.
+        data : numpy.array/scipy.sparse
+            Data to predict with
         output_margin : bool
             Whether to output the raw untransformed margin value.
         ntree_limit : int


### PR DESCRIPTION
Input to `XGBClassifier.predict()` / `XGBRegressor.predict()` / `XGBRanker.predict()` should be either NumPy or SciPy array, NOT DMatrix.

Closes #4582, #4549