### PR TITLE
Update doc for feature constraints.  Fix some warnings.

### DIFF
--- a/doc/gpu/index.rst
+++ b/doc/gpu/index.rst
@@ -50,13 +50,15 @@ Supported parameters
 +--------------------------------+----------------------------+--------------+
 | ``gpu_id``                     | |tick|                     | |tick|       |
 +--------------------------------+----------------------------+--------------+
-| ``n_gpus``                     | |cross|                    | |tick|       |
+| ``n_gpus`` (deprecated)        | |cross|                    | |tick|       |
 +--------------------------------+----------------------------+--------------+
 | ``predictor``                  | |tick|                     | |tick|       |
 +--------------------------------+----------------------------+--------------+
 | ``grow_policy``                | |cross|                    | |tick|       |
 +--------------------------------+----------------------------+--------------+
 | ``monotone_constraints``       | |cross|                    | |tick|       |
++--------------------------------+----------------------------+--------------+
+| ``interaction_constraints``    | |cross|                    | |tick|       |
 +--------------------------------+----------------------------+--------------+
 | ``single_precision_histogram`` | |cross|                    | |tick|       |
 +--------------------------------+----------------------------+--------------+
@@ -65,7 +67,8 @@ GPU accelerated prediction is enabled by default for the above mentioned ``tree_
 
 The experimental parameter ``single_precision_histogram`` can be set to True to enable building histograms using single precision. This may improve speed, in particular on older architectures.
 
-The device ordinal can be selected using the ``gpu_id`` parameter, which defaults to 0.
+The device ordinal (which GPU to use if you have many of them) can be selected using the
+``gpu_id`` parameter, which defaults to 0 (the first device reported by CUDA runtime).
 
 
 The GPU algorithms currently work with CLI, Python and R packages. See :doc:`/build` for details.
@@ -80,14 +83,7 @@ The GPU algorithms currently work with CLI, Python and R packages. See :doc:`/bu
 
 Single Node Multi-GPU
 =====================
-.. note:: Single node multi-GPU training is deprecated. Please use distributed GPU training with one process per GPU.
-
-Multiple GPUs can be used with the ``gpu_hist`` tree method using the ``n_gpus`` parameter. which defaults to 1. If this is set to -1 all available GPUs will be used.  If ``gpu_id`` is specified as non-zero, the selected gpu devices will be from ``gpu_id`` to ``gpu_id+n_gpus``, please note that ``gpu_id+n_gpus`` must be less than or equal to the number of available GPUs on your system.  As with GPU vs. CPU, multi-GPU will not always be faster than a single GPU due to PCI bus bandwidth that can limit performance.
-
-.. note:: Enabling multi-GPU training
-
-  Default installation may not enable multi-GPU training. To use multiple GPUs, make sure to read :ref:`build_gpu_support`.  XGBoost supports multi-GPU training on a single machine via specifying the `n_gpus' parameter.
-
+.. note:: Single node multi-GPU training with `n_gpus` parameter is deprecated after 0.90.  Please use distributed GPU training with one process per GPU.
 
 Multi-node Multi-GPU Training
 =============================
@@ -100,41 +96,43 @@ Objective functions
 ===================
 Most of the objective functions implemented in XGBoost can be run on GPU.  Following table shows current support status.
 
-+-----------------+-------------+
-| Objectives      | GPU support |
-+-----------------+-------------+
-| reg:squarederror| |tick|      |
-+-----------------+-------------+
-| reg:logistic    | |tick|      |
-+-----------------+-------------+
-| binary:logistic | |tick|      |
-+-----------------+-------------+
-| binary:logitraw | |tick|      |
-+-----------------+-------------+
-| binary:hinge    | |tick|      |
-+-----------------+-------------+
-| count:poisson   | |tick|      |
-+-----------------+-------------+
-| reg:gamma       | |tick|      |
-+-----------------+-------------+
-| reg:tweedie     | |tick|      |
-+-----------------+-------------+
-| multi:softmax   | |tick|      |
-+-----------------+-------------+
-| multi:softprob  | |tick|      |
-+-----------------+-------------+
-| survival:cox    | |cross|     |
-+-----------------+-------------+
-| rank:pairwise   | |cross|     |
-+-----------------+-------------+
-| rank:ndcg       | |cross|     |
-+-----------------+-------------+
-| rank:map        | |cross|     |
-+-----------------+-------------+
++--------------------+-------------+
+| Objectives         | GPU support |
++--------------------+-------------+
+| reg:squarederror   | |tick|      |
++--------------------+-------------+
+| reg:squaredlogerror| |tick|      |
++--------------------+-------------+
+| reg:logistic       | |tick|      |
++--------------------+-------------+
+| binary:logistic    | |tick|      |
++--------------------+-------------+
+| binary:logitraw    | |tick|      |
++--------------------+-------------+
+| binary:hinge       | |tick|      |
++--------------------+-------------+
+| count:poisson      | |tick|      |
++--------------------+-------------+
+| reg:gamma          | |tick|      |
++--------------------+-------------+
+| reg:tweedie        | |tick|      |
++--------------------+-------------+
+| multi:softmax      | |tick|      |
++--------------------+-------------+
+| multi:softprob     | |tick|      |
++--------------------+-------------+
+| survival:cox       | |cross|     |
++--------------------+-------------+
+| rank:pairwise      | |cross|     |
++--------------------+-------------+
+| rank:ndcg          | |cross|     |
++--------------------+-------------+
+| rank:map           | |cross|     |
++--------------------+-------------+
 
-For multi-gpu support, objective functions also honor the ``n_gpus`` parameter,
-which, by default is set to 1.  To disable running objectives on GPU, just set
-``n_gpus`` to 0.
+Objective will run on GPU if GPU updater (``gpu_hist``), otherwise they will run on CPU by
+default.  For unsupported objectives XGBoost will fall back to using CPU implementation by
+default.
 
 Metric functions
 ===================
@@ -145,15 +143,17 @@ Following table shows current support status for evaluation metrics on the GPU.
 +=================+=============+
 | rmse            | |tick|      |
 +-----------------+-------------+
+| rmsle           | |tick|      |
++-----------------+-------------+
 | mae             | |tick|      |
 +-----------------+-------------+
 | logloss         | |tick|      |
 +-----------------+-------------+
 | error           | |tick|      |
 +-----------------+-------------+
-| merror          | |cross|     |
+| merror          | |tick|      |
 +-----------------+-------------+
-| mlogloss        | |cross|     |
+| mlogloss        | |tick|      |
 +-----------------+-------------+
 | auc             | |cross|     |
 +-----------------+-------------+
@@ -174,10 +174,8 @@ Following table shows current support status for evaluation metrics on the GPU.
 | tweedie-nloglik | |tick|      |
 +-----------------+-------------+
 
-As for objective functions, metrics honor the ``n_gpus`` parameter,
-which, by default is set to 1.  To disable running metrics on GPU, just set
-``n_gpus`` to 0.
-
+Similar to objective functions, default device for metrics is selected based on tree
+updater and predictor (which is selected based on tree updater).
 
 Benchmarks
 ==========

--- a/doc/gpu/index.rst
+++ b/doc/gpu/index.rst
@@ -86,8 +86,7 @@ Multiple GPUs can be used with the ``gpu_hist`` tree method using the ``n_gpus``
 
 .. note:: Enabling multi-GPU training
 
-  Default installation may not enable multi-GPU training. To use multiple GPUs, make sure to read :ref:`build_gpu_support`.
-XGBoost supports multi-GPU training on a single machine via specifying the `n_gpus' parameter.
+  Default installation may not enable multi-GPU training. To use multiple GPUs, make sure to read :ref:`build_gpu_support`.  XGBoost supports multi-GPU training on a single machine via specifying the `n_gpus' parameter.
 
 
 Multi-node Multi-GPU Training
@@ -100,9 +99,6 @@ XGBoost supports fully distributed GPU training using `Dask
 Objective functions
 ===================
 Most of the objective functions implemented in XGBoost can be run on GPU.  Following table shows current support status.
-
-.. |tick| unicode:: U+2714
-.. |cross| unicode:: U+2718
 
 +-----------------+-------------+
 | Objectives      | GPU support |
@@ -143,9 +139,6 @@ which, by default is set to 1.  To disable running objectives on GPU, just set
 Metric functions
 ===================
 Following table shows current support status for evaluation metrics on the GPU.
-
-.. |tick| unicode:: U+2714
-.. |cross| unicode:: U+2718
 
 +-----------------+-------------+
 | Metric          | GPU Support |

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -101,24 +101,25 @@ def _run_with_rabit(rabit_args, func, *args):
 
 
 def run(client, func, *args):
-    """
-    Launch arbitrary function on dask workers. Workers are connected by rabit, allowing
-    distributed training. The environment variable OMP_NUM_THREADS is defined on each worker
-    according to dask - this means that calls to xgb.train() will use the threads allocated by
-    dask by default, unless the user overrides the nthread parameter.
+    """Launch arbitrary function on dask workers. Workers are connected by rabit,
+    allowing distributed training. The environment variable OMP_NUM_THREADS is
+    defined on each worker according to dask - this means that calls to
+    xgb.train() will use the threads allocated by dask by default, unless the
+    user overrides the nthread parameter.
 
-    Note: Windows platforms are not officially supported. Contributions are welcome here.
+    Note: Windows platforms are not officially
+      supported. Contributions are welcome here.
 
     :param client: Dask client representing the cluster
-    :param func: Python function to be executed by each worker. Typically contains xgboost
-    training code.
+    :param func: Python function to be executed by each worker. Typically
+       contains xgboost training code.
     :param args: Arguments to be forwarded to func
     :return: Dict containing the function return value for each worker
+
     """
     if platform.system() == 'Windows':
-        logging.warning(
-            'Windows is not officially supported for dask/xgboost integration. Contributions '
-            'welcome.')
+        logging.warning('Windows is not officially supported for dask/xgboost'
+                        'integration. Contributions welcome.')
     workers = list(client.scheduler_info()['workers'].keys())
     env = client.run(_start_tracker, len(workers), workers=[workers[0]])
     rabit_args = [('%s=%s' % item).encode() for item in env[workers[0]].items()]

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -184,18 +184,16 @@ def to_graphviz(booster, fmap='', num_trees=0, rankdir='UT',
     no_color : str, default '#FF0000'
         Edge color when doesn't meet the node condition.
     condition_node_params : dict (optional)
-        condition node configuration,
-        {'shape':'box',
-               'style':'filled,rounded',
-               'fillcolor':'#78bceb'
-        }
+      condition node configuration,
+      {'shape':'box',
+       'style':'filled,rounded',
+       'fillcolor':'#78bceb'}
 
     leaf_node_params : dict (optional)
         leaf node configuration
         {'shape':'box',
-               'style':'filled',
-               'fillcolor':'#e48038'
-        }
+         'style':'filled',
+         'fillcolor':'#e48038'}
 
     kwargs :
         Other keywords passed to graphviz graph_attr

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -105,8 +105,8 @@ class XGBModel(XGBModelBase):
         Value in the data which needs to be present as a missing value. If
         None, defaults to np.nan.
     importance_type: string, default "gain"
-        The feature importance type for the feature_importances_ property: either "gain",
-        "weight", "cover", "total_gain" or "total_cover".
+        The feature importance type for the feature_importances\\_ property:
+        either "gain", "weight", "cover", "total_gain" or "total_cover".
     \\*\\*kwargs : dict, optional
         Keyword arguments for XGBoost Booster object.  Full documentation of parameters can
         be found here: https://github.com/dmlc/xgboost/blob/master/doc/parameter.rst.


### PR DESCRIPTION
I'm not confident about my writing, please help verifying.  Otherwise it might be very embarrassing ...

I am not sure about how to fix the following warnings yet:
```
/home/fis/Workspace/xgb/xgboost/doc/gpu/index.rst:89: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/home/fis/Workspace/xgb/xgboost/doc/jvm/index.rst:3: WARNING: Duplicate explicit target name: "here".
/home/fis/Workspace/xgb/xgboost/doc/jvm/xgboost4j_spark_tutorial.rst:3: WARNING: Duplicate explicit target name: "here".
/home/fis/Workspace/xgb/xgboost/doc/jvm/xgboost4j_spark_tutorial.rst:3: WARNING: Duplicate explicit target name: "here".
/home/fis/Workspace/xgb/xgboost/python-package/xgboost/plotting.py:docstring of xgboost.to_graphviz:19: WARNING: Unexpected indentation.
/home/fis/Workspace/xgb/xgboost/python-package/xgboost/plotting.py:docstring of xgboost.to_graphviz:24: WARNING: Unexpected indentation.

```