### PR TITLE
Fix doc for customized objective/metric

### DIFF
--- a/doc/tutorials/custom_metric_obj.rst
+++ b/doc/tutorials/custom_metric_obj.rst
@@ -122,7 +122,7 @@ parameter:
 
 We will be able to see XGBoost printing something like:
 
-.. code-block::
+.. code-block:: none
 
     [0]	dtrain-PyRMSLE:1.37153	dtest-PyRMSLE:1.31487
     [1]	dtrain-PyRMSLE:1.26619	dtest-PyRMSLE:1.20899


### PR DESCRIPTION
Follow-up to #4598. The example training log was not being displayed because of a syntax issue.