### PR TITLE
Use Sphinx 2.1+ to compile documentation

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>=2.1
 mock
 guzzle_sphinx_theme
 breathe


### PR DESCRIPTION
ReadTheDocs service (it hosts https://xgboost.readthedocs.io/en/latest/) has been previously using Sphinx 1.8.1, which is quite an old version. Upgrade Sphinx to 2.1+.

cc @trivialfis 