### PR TITLE
fix gpu predictor when dmatrix is mismatched with model

### DIFF
--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -278,7 +278,7 @@ class GPUPredictor : public xgboost::Predictor {
     }
 
     void PredictInternal
-    (const SparsePage& batch, const MetaInfo& info,
+    (const SparsePage& batch, size_t num_features,
      HostDeviceVector<bst_float>* predictions) {
       if (predictions->DeviceSize(device_) == 0) { return; }
       dh::safe_cuda(cudaSetDevice(device_));
@@ -287,7 +287,7 @@ class GPUPredictor : public xgboost::Predictor {
       const int GRID_SIZE = static_cast<int>(dh::DivRoundUp(num_rows, BLOCK_THREADS));
 
       int shared_memory_bytes = static_cast<int>
-        (sizeof(float) * info.num_col_ * BLOCK_THREADS);
+        (sizeof(float) * num_features * BLOCK_THREADS);
       bool use_shared = true;
       if (shared_memory_bytes > max_shared_memory_bytes_) {
         shared_memory_bytes = 0;
@@ -300,7 +300,7 @@ class GPUPredictor : public xgboost::Predictor {
       PredictKernel<BLOCK_THREADS><<<GRID_SIZE, BLOCK_THREADS, shared_memory_bytes>>>
         (dh::ToSpan(nodes_), predictions->DeviceSpan(device_), dh::ToSpan(tree_segments_),
          dh::ToSpan(tree_group_), batch.offset.DeviceSpan(device_),
-         batch.data.DeviceSpan(device_), this->tree_begin_, this->tree_end_, info.num_col_,
+         batch.data.DeviceSpan(device_), this->tree_begin_, this->tree_end_, num_features,
          num_rows, entry_start, use_shared, this->num_group_);
     }
 
@@ -363,7 +363,7 @@ class GPUPredictor : public xgboost::Predictor {
       batch.data.Reshard(GPUDistribution::Explicit(devices_, device_offsets));
 
       dh::ExecuteIndexShards(&shards_, [&](int idx, DeviceShard& shard) {
-        shard.PredictInternal(batch, dmat->Info(), out_preds);
+        shard.PredictInternal(batch, model.param.num_feature, out_preds);
       });
       batch_offset += batch.Size() * model.param.num_output_group;
     }


### PR DESCRIPTION
This should fix the problem #4594 is trying to enforce.

@RAMitchell @CodingCat 