### PR TITLE
remove caching allocator/vector and fix issues relating to inability to train large datasets

### DIFF
--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -310,11 +310,11 @@ struct XGBDefaultDeviceAllocatorImpl : thrust::device_malloc_allocator<T> {
   };
   pointer allocate(size_t n) {
     pointer ptr = super_t::allocate(n);
-    GlobalMemoryLogger().RegisterAllocation(ptr.get(), n * sizeof(T));
+    GlobalMemoryLogger().RegisterAllocation(ptr.get(), n);
     return ptr;
   }
   void deallocate(pointer ptr, size_t n) {
-    GlobalMemoryLogger().RegisterDeallocation(ptr.get(), n *sizeof(T));
+    GlobalMemoryLogger().RegisterDeallocation(ptr.get(), n);
     return super_t::deallocate(ptr, n);
   }
 };
@@ -334,19 +334,19 @@ struct XGBCachingDeviceAllocatorImpl : thrust::device_malloc_allocator<T> {
    {
     // Configure allocator with maximum cached bin size of ~1GB and no limit on
     // maximum cached bytes
-     static cub::CachingDeviceAllocator *allocator = new cub::CachingDeviceAllocator(8, 3, 10);
-     return *allocator;
+     static cub::CachingDeviceAllocator allocator(8,3,10);
+     return allocator;
    }
    pointer allocate(size_t n) {
      T *ptr;
      GetGlobalCachingAllocator().DeviceAllocate(reinterpret_cast<void **>(&ptr),
                                                 n * sizeof(T));
-     pointer thrust_ptr(ptr);
-     GlobalMemoryLogger().RegisterAllocation(thrust_ptr.get(), n * sizeof(T));
+     pointer thrust_ptr = thrust::device_ptr<T>(ptr);
+     GlobalMemoryLogger().RegisterAllocation(thrust_ptr.get(), n);
      return thrust_ptr;
    }
    void deallocate(pointer ptr, size_t n) {
-     GlobalMemoryLogger().RegisterDeallocation(ptr.get(), n *sizeof(T));
+     GlobalMemoryLogger().RegisterDeallocation(ptr.get(), n);
      GetGlobalCachingAllocator().DeviceFree(ptr.get());
    }
   __host__ __device__
@@ -366,7 +366,8 @@ using XGBCachingDeviceAllocator = detail::XGBCachingDeviceAllocatorImpl<T>;
 /** \brief Specialisation of thrust device vector using custom allocator. */
 template <typename T>
 using device_vector = thrust::device_vector<T,  XGBDeviceAllocator<T>>;
-
+template <typename T>
+using caching_device_vector = thrust::device_vector<T,  XGBCachingDeviceAllocator<T>>;
 /**
  * \brief A double buffer, useful for algorithms like sort.
  */
@@ -380,7 +381,9 @@ class DoubleBuffer {
   DoubleBuffer(VectorT *v1, VectorT *v2) {
     a = xgboost::common::Span<T>(v1->data().get(), v1->size());
     b = xgboost::common::Span<T>(v2->data().get(), v2->size());
-    buff = cub::DoubleBuffer<T>(a.data(), b.data());
+    buff.d_buffers[0] = v1->data().get();
+    buff.d_buffers[1] = v2->data().get();
+    buff.selector = 0;
   }
 
   size_t Size() const {

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -250,6 +250,10 @@ class GPUPredictor : public xgboost::Predictor {
   struct DeviceShard {
     DeviceShard() : device_{-1} {}
 
+    ~DeviceShard() {
+      dh::safe_cuda(cudaSetDevice(device_));
+    }
+
     void Init(int device) {
       this->device_ = device;
       max_shared_memory_bytes_ = dh::MaxSharedMemory(this->device_);

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -250,10 +250,6 @@ class GPUPredictor : public xgboost::Predictor {
   struct DeviceShard {
     DeviceShard() : device_{-1} {}
 
-    ~DeviceShard() {
-      dh::safe_cuda(cudaSetDevice(device_));
-    }
-
     void Init(int device) {
       this->device_ = device;
       max_shared_memory_bytes_ = dh::MaxSharedMemory(this->device_);

--- a/src/tree/gpu_hist/row_partitioner.cu
+++ b/src/tree/gpu_hist/row_partitioner.cu
@@ -50,7 +50,7 @@ void RowPartitioner::SortPosition(common::Span<TreePositionT> position,
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes, in_itr, out_itr,
                                 position.size(), stream);
-  dh::device_vector<uint8_t> temp_storage(temp_storage_bytes);
+  dh::caching_device_vector<uint8_t> temp_storage(temp_storage_bytes);
   cub::DeviceScan::ExclusiveSum(temp_storage.data().get(), temp_storage_bytes,
                                 in_itr, out_itr, position.size(), stream);
 }

--- a/src/tree/gpu_hist/row_partitioner.cu
+++ b/src/tree/gpu_hist/row_partitioner.cu
@@ -50,7 +50,7 @@ void RowPartitioner::SortPosition(common::Span<TreePositionT> position,
   size_t temp_storage_bytes = 0;
   cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes, in_itr, out_itr,
                                 position.size(), stream);
-  dh::caching_device_vector<uint8_t> temp_storage(temp_storage_bytes);
+  dh::device_vector<uint8_t> temp_storage(temp_storage_bytes);
   cub::DeviceScan::ExclusiveSum(temp_storage.data().get(), temp_storage_bytes,
                                 in_itr, out_itr, position.size(), stream);
 }

--- a/src/tree/gpu_hist/row_partitioner.cuh
+++ b/src/tree/gpu_hist/row_partitioner.cuh
@@ -38,13 +38,13 @@ class RowPartitioner {
   int device_idx;
   /*! \brief Range of rows for each node. */
   std::vector<Segment> ridx_segments;
-  dh::caching_device_vector<RowIndexT> ridx_a;
-  dh::caching_device_vector<RowIndexT> ridx_b;
-  dh::caching_device_vector<TreePositionT> position_a;
-  dh::caching_device_vector<TreePositionT> position_b;
+  dh::device_vector<RowIndexT> ridx_a;
+  dh::device_vector<RowIndexT> ridx_b;
+  dh::device_vector<TreePositionT> position_a;
+  dh::device_vector<TreePositionT> position_b;
   dh::DoubleBuffer<RowIndexT> ridx;
   dh::DoubleBuffer<TreePositionT> position;
-  dh::caching_device_vector<int64_t>
+  dh::device_vector<int64_t>
       left_counts;  // Useful to keep a bunch of zeroed memory for sort position
   std::vector<cudaStream_t> streams;
 
@@ -133,6 +133,31 @@ class RowPartitioner {
   }
 
   /**
+   * \brief Clear the device memory that is no longer needed. This can be
+   * invoked after the tree construction is complete, but before the instance
+   * is destroyed to free up device memory that are used in double buffers which
+   * are no longer required. This can be useful if steps further down the training
+   * and prediction flow requires memory which are being held up needlessly here.
+   */
+  void ClearAuxillaryData() {
+    if (position.Current() == position_a.data().get()) {
+      position_b.clear();
+      position_b.shrink_to_fit();
+    } else {
+      position_a.clear();
+      position_a.shrink_to_fit();
+    }
+
+    if (ridx.Current() == ridx_a.data().get()) {
+      ridx_b.clear();
+      ridx_b.shrink_to_fit();
+    } else {
+      ridx_a.clear();
+      ridx_a.shrink_to_fit();
+    }
+  }
+
+  /**
    * \brief Finalise the position of all training instances after tree
    * construction is complete. Does not update any other meta information in
    * this data structure, so should only be used at the end of training.
@@ -150,6 +175,7 @@ class RowPartitioner {
       RowIndexT ridx = d_ridx[idx];
       d_position[idx] = op(ridx, position);
     });
+    this->ClearAuxillaryData();
   }
 
   /**

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -611,8 +611,6 @@ struct DeviceShard {
   /*! \brief Sum gradient for each node. */
   std::vector<GradientPair> node_sum_gradients;
   common::Span<GradientPair> node_sum_gradients_d;
-  /*! \brief On-device feature set, only actually used on one of the devices */
-  dh::device_vector<int> feature_set_d;
   /*! The row offset for this shard. */
   bst_uint row_begin_idx;
   bst_uint row_end_idx;
@@ -700,6 +698,7 @@ struct DeviceShard {
     this->interaction_constraints.Reset();
     std::fill(node_sum_gradients.begin(), node_sum_gradients.end(),
               GradientPair());
+    row_partitioner.reset();  // Release the device memory first before reallocating
     row_partitioner.reset(new RowPartitioner(device_id, n_rows));
 
     dh::safe_cuda(cudaMemcpyAsync(

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -611,8 +611,6 @@ struct DeviceShard {
   /*! \brief Sum gradient for each node. */
   std::vector<GradientPair> node_sum_gradients;
   common::Span<GradientPair> node_sum_gradients_d;
-  /*! \brief On-device feature set, only actually used on one of the devices */
-  dh::device_vector<int> feature_set_d;
   /*! The row offset for this shard. */
   bst_uint row_begin_idx;
   bst_uint row_end_idx;
@@ -700,6 +698,7 @@ struct DeviceShard {
     this->interaction_constraints.Reset();
     std::fill(node_sum_gradients.begin(), node_sum_gradients.end(),
               GradientPair());
+    row_partitioner.reset(); // Release the device memory first before reallocating
     row_partitioner.reset(new RowPartitioner(device_id, n_rows));
 
     dh::safe_cuda(cudaMemcpyAsync(

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -611,6 +611,8 @@ struct DeviceShard {
   /*! \brief Sum gradient for each node. */
   std::vector<GradientPair> node_sum_gradients;
   common::Span<GradientPair> node_sum_gradients_d;
+  /*! \brief On-device feature set, only actually used on one of the devices */
+  dh::device_vector<int> feature_set_d;
   /*! The row offset for this shard. */
   bst_uint row_begin_idx;
   bst_uint row_end_idx;
@@ -698,7 +700,6 @@ struct DeviceShard {
     this->interaction_constraints.Reset();
     std::fill(node_sum_gradients.begin(), node_sum_gradients.end(),
               GradientPair());
-    row_partitioner.reset(); // Release the device memory first before reallocating
     row_partitioner.reset(new RowPartitioner(device_id, n_rows));
 
     dh::safe_cuda(cudaMemcpyAsync(

--- a/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
+++ b/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
@@ -11,7 +11,6 @@ namespace tree {
 
 void TestSortPosition(const std::vector<int>& position_in, int left_idx,
                       int right_idx) {
-  dh::safe_cuda(cudaSetDevice(0));
   std::vector<int64_t> left_count = {
       std::count(position_in.begin(), position_in.end(), left_idx)};
   thrust::device_vector<int64_t> d_left_count = left_count;

--- a/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
+++ b/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
@@ -11,6 +11,7 @@ namespace tree {
 
 void TestSortPosition(const std::vector<int>& position_in, int left_idx,
                       int right_idx) {
+  dh::safe_cuda(cudaSetDevice(0));
   std::vector<int64_t> left_count = {
       std::count(position_in.begin(), position_in.end(), left_idx)};
   thrust::device_vector<int64_t> d_left_count = left_count;


### PR DESCRIPTION
- the caching device allocator caches device allocations in bins of different sizes, which can be reused for future allocations. however, this has regressed on xgboost's capability to train on large datasets
- device memory cached by this allocator cannot be seen by other non caching allocators
- as a consequence, types that use regular allocators (device_malloc_allocator and such) will attempt to carve out more device memory when needed, eventhough plenty may be available for use inside the caching allocators
- bottom line: this kind of allocator choice can't be made in a piecemeal fashion

i have thus resorted to using a consistent allocator type across for now and fixed issues arising out of additional allocations introduced by #4554. in the process, the unit test failures have been fixed as well (it was hanging on tesla t4's earlier).

ideally, the core stock xgboost should use the regular device allocators, and use-cases that need sophisticated (de)allocation techniques should dynamically load device allocators via `LD_PRELOAD` or some dll injection mechanism on windows, quite similar to how one can replace the glibc allocator with jemalloc/tcmalloc/vespamalloc and its likes.

it is also possible to use a caching device allocator across entire xgboost; but first, its implications have to be well understood, including, but not limited to how the different allocation bins can be configured from within xgboost for different use-cases. from what i can see from the code, it uses (whose impact on performance is unknown at present):

- a global mutex across *all* devices to retrieve and to cache allocations
- it sweeps through pertinent bin to release all free blocks and retrying, when a request for device allocation can't be satisfied, which can be fairly expensive
- it pads every device allocation request to a bin that geometrically progresses by the growth factor, thus entailing significant wastage (more for bigger device memory chunks)
 
my naive attempt to alias all `device_vector` types to a `caching_device_vector` failed as well (not investigated on this yet).

@RAMitchell @rongou - please review...
