### PR TITLE
Support Dask 2.0

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -91,7 +91,11 @@ def create_worker_dmatrix(*args, **kwargs):
 
 
 def _run_with_rabit(rabit_args, func, *args):
-    os.environ["OMP_NUM_THREADS"] = str(distributed_get_worker().ncores)
+    worker = distributed_get_worker()
+    try:
+        os.environ["OMP_NUM_THREADS"] = str(worker.ncores)
+    except AttributeError:
+        os.environ["OMP_NUM_THREADS"] = str(worker.nthreads)
     try:
         rabit.init(rabit_args)
         result = func(*args)

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -24,7 +24,7 @@ RUN \
     pip install pyyaml cpplint pylint astroid sphinx numpy scipy pandas matplotlib sh recommonmark guzzle_sphinx_theme mock \
                 breathe matplotlib graphviz pytest scikit-learn wheel kubernetes urllib3 && \
     pip install https://h2o-release.s3.amazonaws.com/datatable/stable/datatable-0.7.0/datatable-0.7.0-cp37-cp37m-linux_x86_64.whl && \
-    conda install dask
+    conda install dask=2.0.0
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -17,7 +17,7 @@ ENV PATH=/opt/python/bin:$PATH
 # Install Python packages
 RUN \
     pip install numpy pytest scipy scikit-learn pandas matplotlib wheel kubernetes urllib3 graphviz && \
-    conda install dask
+    conda install dask=2.0.0
 
 ENV GOSU_VERSION 1.10
 


### PR DESCRIPTION
The current Dask integration in XGBoost (`xgboost/dask.py`) does not work with Dask 2.0.0 (released Jun 25, 2019) because dask/distributed#2758 replaced all occurrences of `ncores` with `nthreads`.

This pull request will access `ncores` and `nthreads`, whichever is available, so that XGBoost can work with both 1.2.x and 2.0.0 versions of Dask.

Also, we specify the exact version of Dask in the Dockerfile, so that we know which version of Dask XGBoost is tested with.

@RAMitchell @mrocklin @mt-jones