### PR TITLE
Enable convergence tester for early stopping.

### DIFF
--- a/python-package/xgboost/automl_core.py
+++ b/python-package/xgboost/automl_core.py
@@ -209,6 +209,14 @@ NUM_TREE_LOWER_BOUND = 0
 DEFAULT_METRIC = {'binary': 'auc', 'multi': 'merror', 'reg': 'rmse', 'rank': 'ndcg',\
                   'survival': 'cox-nloglik'}
 
+def get_optimization_direction(params):
+    maximize_score = False
+    metric = params['eval_metric']
+    if any(metric.startswith(x) for x in MAXIMIZE_METRICS):
+        maximize_score = True
+
+    return maximize_score
+
 def xgb_parameter_checker(params, num_round, num_class=None, skip_list=[]):
     """
     XGBoost hyper-parameter checker.
@@ -324,11 +332,7 @@ def xgb_parameter_checker(params, num_round, num_class=None, skip_list=[]):
             warnings.warn(param_invalid_value_info('eval_metric', DEFAULT_METRIC[objective_type]))
             params['eval_metric'] = DEFAULT_METRIC[objective_type]
 
-    maximize_score = False
-    metric = params['eval_metric']
-    if any(metric.startswith(x) for x in MAXIMIZE_METRICS):
-        maximize_score = True
-
+    maximize_score = get_optimization_direction(params)
     params['maximize_eval_metric'] = str(maximize_score)
 
     return params

--- a/python-package/xgboost/automl_core.py
+++ b/python-package/xgboost/automl_core.py
@@ -1,0 +1,340 @@
+# coding: utf-8
+# pylint: disable=too-many-locals, too-many-arguments, invalid-name
+# pylint: disable=too-many-branches, too-many-statements
+"""AutoML Library containing useful routines."""
+from __future__ import absolute_import
+
+import warnings
+
+
+class ParamError(Exception):
+    """
+    Excetion raised for errors in hyper-parameter configuration.
+    """
+
+class ConvergenceTester():
+    """Convergence tester.
+
+        The rule for convergence is idx + n < size * c, where idx is the
+        index best metric value so far and size is the current number of
+        points in the series, n and c are parameters for the test.
+    """
+
+    def __init__(self, min_num_points=-1, n=0, c=1.0, maximize=False):
+        """
+        Parameters
+        ----------
+        min_num_points : int
+            The minimum number of points to be considered convergence.
+        n : int
+            The n.
+        c : float
+            A constant factor in [0, 1]
+        """
+        self.min_num_points = min_num_points
+        self.n = n
+        self.c = c
+        self.maximize = maximize
+        self.measure_list = []
+        self.best_idx = -1
+        if maximize:
+            self.best_so_far = float('-inf')
+        else:
+            self.best_so_far = float('inf')
+
+    @staticmethod
+    def parse(cc):
+        """
+        ConvergenceTester configuration parser.
+
+        Returns
+        -------
+        result : A configured ConvergenceTester.
+        """
+        maximize = False
+        min_num_points = -1
+        n = 0
+        c = 1.0
+        if cc and cc.strip():
+            strs = cc.split(":")
+            if strs:
+                maximize = strs[0].lower() == 'true'
+            if len(strs) > 1:
+                min_num_points = int(strs[1])
+            if len(strs) > 2:
+                n = int(strs[2])
+            if len(strs) > 3:
+                c = float(strs[3])
+        return ConvergenceTester(min_num_points, n, c, maximize=maximize)
+
+    def size(self):
+        """
+        Returns the size of the series.
+
+        Returns
+        -------
+        result : the size of the series.
+        """
+        return len(self.measure_list)
+
+    def set_maximize(self, maximize):
+        """Sets whether to maximize the metric.
+
+        Parameters
+        ----------
+        maximize : bool
+            Whether to maximize the metric.
+        """
+        self.maximize = maximize
+
+    def is_first_better(self, a, b):
+        """Returns whether to the 1st metric value is better than the 2nd one.
+
+        Parameters
+        ----------
+        a : float
+            the 1st metric value.
+        b : float
+            the 2nd metric value.
+
+        Returns
+        -------
+        result : whether to the 1st metric value is better than the 2nd one.
+        """
+        if self.maximize:
+            return a > b
+        else:
+            return a < b
+
+    def add(self, v):
+        """Adds a metric value.
+
+        Parameters
+        ----------
+        v : float
+            The metric value to add.
+        """
+        self.measure_list.append(v)
+
+        if self.is_first_better(v, self.best_so_far):
+            self.best_so_far = v
+            self.best_idx = self.size() - 1
+
+    def get_best_idx(self):
+        """
+        Returns the index for best metric value so far.
+
+        Returns
+        -------
+        result : the index for best metric value so far.
+        """
+        return self.best_idx
+
+    def get_best_so_far(self):
+        """
+        Returns the best metric value so far.
+
+        Returns
+        -------
+        result : the best metric value so far.
+        """
+        return self.best_so_far
+
+    def is_maximize(self):
+        """
+        Returns whether to maximize the metric.
+
+        Returns
+        -------
+        result : whether to maximize the metric.
+        """
+        return self.maximize
+
+    def is_converged(self):
+        """
+        Returns true if the series is converged.
+
+        Returns
+        -------
+        result : true if the series is converged.
+        """
+        return self.min_num_points >= 0 and \
+               self.size() > self.min_num_points and \
+               self.best_idx >= 0 and \
+               self.best_idx + 1 + self.n < self.size() * self.c
+
+    def print_params(self):
+        """
+        Returns the string representation of this convergence tester.
+
+        Returns
+        -------
+        result : the string representation of this convergence tester.
+        """
+        return "maximize = {0}, min_num_points = {1}, n = {2}, c = {3}".format( \
+            self.maximize, self.min_num_points, self.n, self.c)
+
+def param_undefined_info(param_name, default_value):
+    """
+    Returns info warning an undefined parameter.
+    """
+    return "Parameter warning: the hyper-parameter " + \
+           "'{}' is not specified, will use default value '{}'" \
+           .format(param_name, default_value)
+
+def param_invalid_value_info(param_name, default_value):
+    """
+    Returns info warning an invalid parameter configuration.
+    """
+    return "Parameter warning: the configuration of hyper-parameter "+ \
+           "'{}' is not valid, will use default value '{}'" \
+           .format(param_name, default_value)
+
+# Available values and bounds of hyper-parameters
+OBJECTIVE_LIST = ['reg:linear', 'reg:logistic', 'binary:logistic', 'binary:logitraw', \
+     'binary:hinge', 'count:poisson', 'multi:softmax', 'multi:softprob',\
+     'reg:gamma', 'reg:tweedie', 'rank:ndcg', 'rank:pairwise', \
+     'rank:map', 'survival:cox']
+METRIC_LIST = ['rmse', 'mae', 'logloss', 'error', 'merror', 'mlogloss', 'auc', \
+  'poisson-nloglik', 'gamma-nloglik', 'gamma-deviance', 'tweedie-nloglik', \
+  'ndcg', 'map', 'aucpr', 'ndcg-', 'map-', 'cox-nloglik']
+METRIC_CHECKLIST = ['error@', 'ndcg@', 'map@']
+MAXIMIZE_METRICS = ('auc', 'map', 'ndcg')
+MAX_DEPTH_DEFAULT_VALUE = 6
+MAX_DEPTH_LOWER_BOUND = 0
+ETA_DEFAULT_VALUE = 0.3
+ETA_LOWER_BOUND = 0.0
+ETA_UPPER_BOUND = 1.0
+NUM_TREE_DEFAULT_VALUE = 100
+NUM_TREE_LOWER_BOUND = 0
+DEFAULT_METRIC = {'binary': 'auc', 'multi': 'merror', 'reg': 'rmse', 'rank': 'ndcg',\
+                  'survival': 'cox-nloglik'}
+
+def xgb_parameter_checker(params, num_round, num_class=None, skip_list=[]):
+    """
+    XGBoost hyper-parameter checker.
+
+    This function checks if the input hyper-parameters setting
+    satisfies specific requirements and use default values for
+    parameters not satisfying requirements.
+
+    Parameters
+    ----------
+    params : dict
+        XGBoost hyper-parameter configuration.
+    num_round: int
+        number of boosting rounds.
+    num_class: int
+        number of classes in the target feature.
+    skip_list: list
+        list of parameters that can be skipped checking.
+
+    Returns
+    -------
+    result:
+        A checked and corrected XGBoost hyper-parameter
+        configuration.
+    """
+    # check objective function
+    if 'objective' in params:
+        objective = params['objective']
+        if objective not in OBJECTIVE_LIST:
+            raise ParamError("The objective function '{}' is not supported.".format(objective))
+    else:
+        raise ParamError("The objective function is not specified.")
+
+    objective_type = objective.split(':')[0]
+    # check number of classes in label
+    if not num_class and 'num_class' in params:
+        try:
+            num_class = int(params['num_class'])
+        except Exception:
+            raise ParamError("Parameter num_class is ill-formed: " + params['num_class'])
+    if num_class:
+        num_class = int(num_class)
+        if objective_type == 'binary' and num_class != 2:
+            raise ParamError("Binary objective function can not handle more than " +\
+                              "2 classes label. Recommend using 'multi:softmax'")
+        if objective_type != 'binary' and num_class == 2:
+            warnings.warn("Only 2 classes in label. Will use 'binary:logistic' as " +\
+                              "the objective function")
+            params['objective'] = 'binary:logistic'
+        params['num_class'] = num_class
+    if objective_type == 'binary':
+        params.pop('num_class', None)
+
+    if 'max_depth' not in skip_list:
+        try:
+            max_depth = params['max_depth']
+            max_depth = int(max_depth)
+            if  max_depth <= MAX_DEPTH_LOWER_BOUND:
+                warnings.warn(param_invalid_value_info('max_depth', MAX_DEPTH_DEFAULT_VALUE))
+                params['max_depth'] = MAX_DEPTH_DEFAULT_VALUE
+        except KeyError:
+            warnings.warn(param_undefined_info('max_depth', MAX_DEPTH_DEFAULT_VALUE))
+            params['max_depth'] = MAX_DEPTH_DEFAULT_VALUE
+        except ValueError:
+            warnings.warn(param_invalid_value_info('max_depth', MAX_DEPTH_DEFAULT_VALUE))
+            params['max_depth'] = MAX_DEPTH_DEFAULT_VALUE
+
+    if 'eta' not in skip_list:
+        try:
+            learning_rate_key = 'eta'
+            if learning_rate_key not in params:
+                learning_rate_key = 'learning_rate'
+            eta = params[learning_rate_key]
+            eta = float(eta)
+            if eta <= ETA_LOWER_BOUND or eta > ETA_UPPER_BOUND:
+                warnings.warn(param_invalid_value_info('eta (alias: learning_rate)', ETA_DEFAULT_VALUE))
+                params['eta'] = ETA_DEFAULT_VALUE
+        except KeyError:
+            warnings.warn(param_undefined_info('eta (alias: learning_rate)', ETA_DEFAULT_VALUE))
+            params['eta'] = ETA_DEFAULT_VALUE
+        except ValueError:
+            warnings.warn(param_invalid_value_info('eta (alias: learning_rate)', ETA_DEFAULT_VALUE))
+            params['eta'] = ETA_DEFAULT_VALUE
+
+    try:
+        num_tree = int(num_round)
+        if num_tree <= NUM_TREE_LOWER_BOUND:
+            warnings.warn(param_invalid_value_info('num_round', NUM_TREE_DEFAULT_VALUE))
+            params['num_round'] = NUM_TREE_DEFAULT_VALUE
+    except KeyError:
+        warnings.warn(param_undefined_info('num_round', NUM_TREE_DEFAULT_VALUE))
+        params['num_round'] = NUM_TREE_DEFAULT_VALUE
+    except ValueError:
+        warnings.warn(param_invalid_value_info('num_round', NUM_TREE_DEFAULT_VALUE))
+        params['num_round'] = NUM_TREE_DEFAULT_VALUE
+
+    if 'eval_metric' not in params:
+        objective_type = objective.split(':')[0]
+        warnings.warn(param_undefined_info('eval_metric', DEFAULT_METRIC[objective_type]))
+        params['eval_metric'] = DEFAULT_METRIC[objective_type]
+    if params['eval_metric'] not in METRIC_LIST:
+        checked = False
+        for metric_to_check in METRIC_CHECKLIST:
+            if metric_to_check in params['eval_metric']:
+                mid_num = params['eval_metric'].strip(metric_to_check).rstrip('-')
+                try:
+                    mid_num = float(mid_num)
+                except ValueError:
+                    raise ParamError("A number required after '{}'".format(metric_to_check))
+                checked = True
+        if not checked:
+            objective_type = objective.split(':')[0]
+            warnings.warn(param_invalid_value_info('eval_metric', DEFAULT_METRIC[objective_type]))
+            params['eval_metric'] = DEFAULT_METRIC[objective_type]
+
+    maximize_score = False
+    metric = params['eval_metric']
+    if any(metric.startswith(x) for x in MAXIMIZE_METRICS):
+        maximize_score = True
+
+    if 'maximize_eval_metric' in params:
+        maximize_eval_metric = params['maximize_eval_metric'].lower() == 'true'
+        if maximize_eval_metric != maximize_score:
+            warnings.warn(param_invalid_value_info('maximize_eval_metric', str(maximize_score)))
+    else:
+        params['maximize_eval_metric'] = str(maximize_score)
+
+    return params

--- a/python-package/xgboost/automl_core_tests.py
+++ b/python-package/xgboost/automl_core_tests.py
@@ -1,0 +1,63 @@
+"""Unit tests for AutoML Library functions."""
+import unittest
+import automl_core
+import xgboost as xgb
+
+class TestAutomlCore(unittest.TestCase):
+    """
+    A class providing tests for automl_core main functions
+    """
+
+    '''
+    def test_default_values(self):
+        """
+        A test checking the setting up of default values for hyper-parameters
+        """
+        params = {'objective': 'binary:logistic'}
+        expected_params = {'objective': 'binary:logistic', 'max_depth': 6, \
+                           'learning_rate': 0.3, 'n_estimators': 100, \
+                           'eval_metric': 'auc'}
+        with self.assertWarns(Warning):
+            params = automl_core.xgb_parameter_checker(params, 2)
+        self.assertEqual(params, expected_params)
+    '''
+
+    def test_objective(self):
+        """
+        A test for the objective
+        """
+        params = {}
+        with self.assertRaises(automl_core.ParamError):
+            automl_core.xgb_parameter_checker(params, 2)
+
+    def test_num_class(self):
+        """
+        A test for number of classes
+        """
+        params = {'objective': 'binary:logistic'}
+        with self.assertRaises(automl_core.ParamError):
+            automl_core.xgb_parameter_checker(params, 4)
+
+    def test_metric(self):
+        """
+        A test for evaluation metric
+        """
+        params = {'objective': 'binary:logistic', 'max_depth': 6, \
+                  'learning_rate': 0.3, 'n_estimators': 100, \
+                  'eval_metric': 'ndcg@ab'}
+        with self.assertRaises(automl_core.ParamError):
+            params = automl_core.xgb_parameter_checker(params, 2)
+
+    def test_metric_optimization_direction(self):
+        """
+        A test for metric optimization direction
+        """
+        params = {'objective': 'binary:logistic', 'max_depth': 6, \
+                  'learning_rate': 0.3, 'n_estimators': 100, \
+                  'eval_metric': 'auc'}
+        automl_core.xgb_parameter_checker(params)
+        maximize_eval_metric = params['maximize_eval_metric'].lower() == 'true'
+        self.assertTrue(maximize_eval_metric)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 from .core import Booster, STRING_TYPES, XGBoostError, CallbackEnv, EarlyStopException
 from .compat import (SKLEARN_INSTALLED, XGBStratifiedKFold)
-from .automl_core import ConvergenceTester, xgb_parameter_checker
+from .automl_core import ConvergenceTester, xgb_parameter_checker, get_optimization_direction
 from . import rabit
 from . import callback
 
@@ -211,7 +211,7 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
 
     if check_params:
         params = xgb_parameter_checker(params, num_boost_round)
-    maximize=params['maximize_eval_metric'].lower() == 'true'
+    maximize = get_optimization_direction(params)
 
     # Most of legacy advanced options becomes callbacks
     if isinstance(verbose_eval, bool) and verbose_eval:


### PR DESCRIPTION
1.   Enable convergence tester for early stopping.
2.  Get rid of the need to specify optimization direction in convergence tester.
