### PR TITLE
Add warning when save_model() is called from scikit-learn interface

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -278,6 +278,11 @@ class XGBModel(XGBModelBase):
         fname : string
             Output file name
         """
+        warnings.warn("save_model: Useful attributes in the Python " +
+                      "object {} will be lost. ".format(type(self).__name__) +
+                      "If you did not mean to export the model to " +
+                      "a non-Python binding of XGBoost, consider " +
+                      "using `pickle` or `joblib` to save your model.", Warning)
         self.get_booster().save_model(fname)
 
     def load_model(self, fname):


### PR DESCRIPTION
Many methods of `XGBClassifier` relies on the existence of certain fields, such as `self.objective`, `self.missing`, and `self.n_classes_` (these fields exist to ensure interoperability with scikit-learn) and these fields are **not** preserved by the call to `XGBClassifier.save_model()`, as the binary serialization format is not aware of these fields. See #4517, where `XGBClassifier.save_model()` breaks `predict_proba()` for multi-class classifiers.

Fix: Display prominent warning whenever `save_model()` is called from `XGBClassifier`. The recommendation is not to use it, unless the purpose is to export the model to a non-Python environment (e.g. Java).

EDIT. Maybe we should just deprecate `save_model()`, as its name is quite misleading, and call it `export_model_for_external_use()` or something like that.