### PR TITLE
Empty evaluation list in early stopping should produce meaningful error message

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -222,7 +222,11 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
 
     def callback(env):
         """internal function"""
-        score = env.evaluation_result_list[-1][1]
+        if not env.evaluation_result_list:
+            score = float('-inf') if maximize_score else float('inf')
+            # if evaluation list is empty, best_score shouldn't be updated
+        else:
+            score = env.evaluation_result_list[-1][1]
         if not state:
             init(env)
         best_score = state['best_score']

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -224,11 +224,7 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
         """internal function"""
         if not state:
             init(env)
-        if not env.evaluation_result_list[-1]:
-            score = float('-inf') if state['maximize_score'] else float('inf')
-            # if evaluation list is empty, best_score shouldn't be updated
-        else:
-            score = env.evaluation_result_list[-1][1]
+        score = env.evaluation_result_list[-1][1]
         best_score = state['best_score']
         best_iteration = state['best_iteration']
         maximize_score = state['maximize_score']

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -222,13 +222,13 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
 
     def callback(env):
         """internal function"""
-        if not env.evaluation_result_list:
-            score = float('-inf') if maximize_score else float('inf')
+        if not state:
+            init(env)
+        if not env.evaluation_result_list[-1]:
+            score = float('-inf') if state['maximize_score'] else float('inf')
             # if evaluation list is empty, best_score shouldn't be updated
         else:
             score = env.evaluation_result_list[-1][1]
-        if not state:
-            init(env)
         best_score = state['best_score']
         best_iteration = state['best_iteration']
         maximize_score = state['maximize_score']


### PR DESCRIPTION
Closes #4443, by ignoring iterations with empty evaluation result.