### PR TITLE
[jvm-packages] Expose setMissing method in trained Model

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -247,6 +247,8 @@ class XGBoostClassificationModel private[ml](
 
   def setTreeLimit(value: Int): this.type = set(treeLimit, value)
 
+  def setMissing(value: Float): this.type = set(missing, value)
+
   def setInferBatchSize(value: Int): this.type = set(inferBatchSize, value)
 
   /**

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -242,6 +242,8 @@ class XGBoostRegressionModel private[ml] (
 
   def setTreeLimit(value: Int): this.type = set(treeLimit, value)
 
+  def setMissing(value: Float): this.type = set(missing, value)
+
   def setInferBatchSize(value: Int): this.type = set(inferBatchSize, value)
 
   /**


### PR DESCRIPTION
As discussed in https://discuss.xgboost.ai/t/jvm-packages-v0-90-sparse-vector-prediction-issue-on-missing-values/903/5, we should expose `setMissing()` method in XGBoostClassificationModel / XGBoostRegressionModel, so that `transform()` will behave correctly.