### PR TITLE
Fix auc error in distributed mode caused by imbalanced dataset

### DIFF
--- a/src/metric/rank_metric.cc
+++ b/src/metric/rank_metric.cc
@@ -197,18 +197,21 @@ struct EvalAuc : public Metric {
       // this is the AUC
       sum_auc += sum_pospair / (sum_npos * sum_nneg);
     }
-    CHECK(!auc_error)
-      << "AUC: the dataset only contains pos or neg samples";
-    /* Report average AUC across all groups */
-    if (distributed) {
-      bst_float dat[2];
+
+    // Report average AUC across all groups
+    // In distributed mode, workers which only contains pos or neg samples
+    // will be ignored when aggregate AUC.
+    bst_float dat[2] = {0.0f, 0.0f};
+    if (!auc_error) {
       dat[0] = static_cast<bst_float>(sum_auc);
       dat[1] = static_cast<bst_float>(ngroup);
-      rabit::Allreduce<rabit::op::Sum>(dat, 2);
-      return dat[0] / dat[1];
-    } else {
-      return static_cast<bst_float>(sum_auc) / ngroup;
     }
+    if (distributed) {
+      rabit::Allreduce<rabit::op::Sum>(dat, 2);
+    }
+    CHECK_GT(dat[1], 0.0f)
+      << "AUC: the dataset only contains pos or neg samples";
+    return dat[0] / dat[1];
   }
 
  public:
@@ -515,19 +518,22 @@ struct EvalAucPR : public Metric {
         CHECK(!auc_error) << "AUC-PR: error in calculation";
       }
     }
-    CHECK(!auc_error) << "AUC-PR: the dataset only contains pos or neg samples";
-    /* Report average AUC across all groups */
-    if (distributed) {
-      bst_float dat[2];
+
+    // Report average AUC-PR across all groups
+    // In distributed mode, workers which only contains pos or neg samples
+    // will be ignored when aggregate AUC-PR.
+    bst_float dat[2] = {0.0f, 0.0f};
+    if (!auc_error) {
       dat[0] = static_cast<bst_float>(sum_auc);
       dat[1] = static_cast<bst_float>(ngroup);
-      rabit::Allreduce<rabit::op::Sum>(dat, 2);
-      CHECK_LE(dat[0], dat[1]) << "AUC-PR: AUC > 1.0";
-      return dat[0] / dat[1];
-    } else {
-      CHECK_LE(sum_auc, static_cast<double>(ngroup)) << "AUC-PR: AUC > 1.0";
-      return static_cast<bst_float>(sum_auc) / ngroup;
     }
+    if (distributed) {
+      rabit::Allreduce<rabit::op::Sum>(dat, 2);
+    }
+    CHECK_GT(dat[1], 0.0f)
+      << "AUC-PR: the dataset only contains pos or neg samples";
+    CHECK_LE(dat[0], dat[1]) << "AUC-PR: AUC > 1.0";
+    return dat[0] / dat[1];
   }
 
  public:


### PR DESCRIPTION
Running xgboost distributedly with imbalanced datasets may trigger the exception: `AUC: the dataset only contains pos or neg samples` ,  especially when world_size is large.  Because sub datasets held by some workers only contains no pos or neg samples,  which will cause local exceptions.

This PR modified the response of `auc_error`.  In distribute mode, workers whose `auc_error > 0` will be ignored in AUC average rather than raising an error.
