### PR TITLE
[WIP] Add lower and upper bounds on the label for survival analysis

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -47,6 +47,12 @@ class MetaInfo {
   uint64_t num_nonzero_{0};
   /*! \brief label of each instance */
   HostDeviceVector<bst_float> labels_;
+  /*! \brief lower bound label of each instance; used for survival analysis,
+   *         where labels are left-, right- or interval-censored. */
+  HostDeviceVector<bst_float> labels_lower_bound_;
+  /*! \brief upper bound label of each instance; used for survival analysis,
+   *         where labels are left-, right- or interval-censored. */
+  HostDeviceVector<bst_float> labels_upper_bound_;
   /*!
    * \brief specified root index of each instance,
    *  can be used for multi task setting
@@ -68,9 +74,11 @@ class MetaInfo {
    */
   HostDeviceVector<bst_float> base_margin_;
   /*! \brief version flag, used to check version of this info */
-  static const int kVersion = 2;
-  /*! \brief version that introduced qid field */
+  static const int kVersion = 3;
+  /*! \brief version that introduced field qids_ */
   static const int kVersionQidAdded = 2;
+  /*! \brief version that introduced fields labels_lower_bound_, labels_upper_bound_ */
+  static const int kVersionBounedLabelAdded = 3;
   /*! \brief default constructor */
   MetaInfo()  = default;
   /*!

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -42,6 +42,8 @@ void MetaInfo::SaveBinary(dmlc::Stream *fo) const {
   fo->Write(labels_.HostVector());
   fo->Write(group_ptr_);
   fo->Write(qids_);
+  fo->Write(labels_lower_bound_.HostVector());
+  fo->Write(labels_upper_bound_.HostVector());
   fo->Write(weights_.HostVector());
   fo->Write(root_index_);
   fo->Write(base_margin_.HostVector());
@@ -59,8 +61,16 @@ void MetaInfo::LoadBinary(dmlc::Stream *fi) {
   CHECK(fi->Read(&group_ptr_)) << "MetaInfo: invalid format";
   if (version >= kVersionQidAdded) {
     CHECK(fi->Read(&qids_)) << "MetaInfo: invalid format";
-  } else {  // old format doesn't contain qid field
+  } else {  // old format doesn't contain field qids_
     qids_.clear();
+  }
+  if (version >= kVersionBounedLabelAdded) {
+    CHECK(fi->Read(&labels_lower_bound_.HostVector())) << "MetaInfo: invalid format";
+    CHECK(fi->Read(&labels_upper_bound_.HostVector())) << "MetaInfo: invalid format";
+  } else {  // old format doesn't contain fields labels_lower_bound_, labels_upper_bound_
+    qids_.clear();
+    labels_lower_bound_.HostVector().clear();
+    labels_upper_bound_.HostVector().clear();
   }
   CHECK(fi->Read(&weights_.HostVector())) << "MetaInfo: invalid format";
   CHECK(fi->Read(&root_index_)) << "MetaInfo: invalid format";

--- a/tests/cpp/data/test_metainfo.cc
+++ b/tests/cpp/data/test_metainfo.cc
@@ -55,7 +55,7 @@ TEST(MetaInfo, SaveLoadBinary) {
   info.SaveBinary(fs);
   delete fs;
 
-  ASSERT_EQ(GetFileSize(tmp_file), 84)
+  ASSERT_EQ(GetFileSize(tmp_file), 100)
     << "Expected saved binary file size to be same as object size";
 
   fs = dmlc::Stream::Create(tmp_file.c_str(), "r");


### PR DESCRIPTION
As part of #4491, we need to add lower and upper bounds for the label, where the label is [censored](https://en.wikipedia.org/wiki/Censoring_(statistics)). 

[More information coming]

cc @avinashbarnwal