### PR TITLE
Improve setup.py by adding extra dependencies

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -43,6 +43,13 @@ setup(name='xgboost',
           'numpy',
           'scipy',
       ],
+      extras_require={
+          'pandas': ['pandas'],
+          'sklearn': ['sklearn'],
+          'dask': ['dask', 'pandas', 'distributed'],
+          'datatable': ['datatable'],
+          'plotting': ['graphviz', 'matplotlib']
+      },
       maintainer='Hyunsu Cho',
       maintainer_email='chohyu01@cs.washington.edu',
       zip_safe=False,

--- a/python-package/setup_pip.py
+++ b/python-package/setup_pip.py
@@ -48,6 +48,13 @@ setup(name='xgboost',
           'numpy',
           'scipy',
       ],
+      extras_require={
+          'pandas': ['pandas'],
+          'sklearn': ['sklearn'],
+          'dask': ['dask', 'pandas', 'distributed'],
+          'datatable': ['datatable'],
+          'plotting': ['graphviz', 'matplotlib']
+      },
       maintainer='Hyunsu Cho',
       maintainer_email='chohyu01@cs.washington.edu',
       zip_safe=False,


### PR DESCRIPTION
I did some python code reading and I noticed that we have a lot of optional dependencies which are not fully exposed though setup.py.

So I added extra dependencies.
Now one can use

  pip install -e .[dask]

to install all xgboost supporting dask