### PR TITLE
add tests symbol link for pycharm users

### DIFF
--- a/python-package/xgboost/tests
+++ b/python-package/xgboost/tests
@@ -1,0 +1,1 @@
+../../tests/python/


### PR DESCRIPTION
this links to tests folder and allow pycharm users open python-package as the root folder