### PR TITLE
[jvm-packages] allowing chaining prediction

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
@@ -404,7 +404,7 @@ class XGBoostGeneralSuite extends FunSuite with PerTest {
     val modelPath = getClass.getResource("/model/0.82/model").getPath
     val model = XGBoostClassificationModel.read.load(modelPath)
     val r = new Random(0)
-    val df = ss.createDataFrame(Seq.fill(1000000)(1).map(i => (i, i))).
+    val df = ss.createDataFrame(Seq.fill(100000)(1).map(i => (i, i))).
       toDF("feature", "label").repartition(5)
     val assembler = new VectorAssembler()
       .setInputCols(df.columns.filter(!_.contains("label")))


### PR DESCRIPTION
this PR is to include  https://github.com/dmlc/rabit/pull/99

the use case is like following 

```
val df1 = xgbmodel.transform(training)
val df2 = xgbmodel2.transform(df1)
```

because we shutdown rabit in both of df1 and df2 (the task will processing df1's partition first and then df2's ), the original code explicitly prohibit such usage pattern, 

I added a test to guard this usage pattern 

@sperlingxx would you mind helping to review ?