### PR TITLE
refactor DMatrix to be a concrete class

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -29,11 +29,8 @@ class LearnerImpl;
 namespace data {
 // forward declare simple dmatrix.
 class SimpleDMatrix;
-
-#if DMLC_ENABLE_STD_THREAD
 // forward declare sparse page dmatrix.
 class SparsePageDMatrix;
-#endif  // DMLC_ENABLE_STD_THREAD
 }  // namespace data
 
 /*! \brief data type accepted by xgboost interface */
@@ -403,7 +400,7 @@ class RowSet {
  *  - Provide a DataSource, that can be passed to DMatrix::Create
  *      This can be used to re-use inmemory data structure into DMatrix.
  */
-class DMatrix {
+class DMatrix final {
  public:
   /*! \brief default constructor */
   DMatrix() = delete;
@@ -426,8 +423,8 @@ class DMatrix {
   bool SingleColBlock() const;
   /*! \brief get column density */
   float GetColDensity(size_t cidx);
-  /*! \brief virtual destructor */
-  virtual ~DMatrix() = default;
+  /*! \brief destructor */
+  ~DMatrix();
   /*!
    * \brief Save DMatrix to local file.
    *  The saved file only works for non-sharded dataset(single machine training).
@@ -483,15 +480,11 @@ class DMatrix {
 
  private:
   explicit DMatrix(data::SimpleDMatrix* simple_dmat);
-#if DMLC_ENABLE_STD_THREAD
   explicit DMatrix(data::SparsePageDMatrix* sparse_page_dmat);
-#endif  // DMLC_ENABLE_STD_THREAD
 
   union {
     data::SimpleDMatrix* simple_dmat_;
-#if DMLC_ENABLE_STD_THREAD
     data::SparsePageDMatrix* sparse_page_dmat_;
-#endif  // DMLC_ENABLE_STD_THREAD
   };
   bool in_memory_;
 };

--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -21,24 +21,24 @@
 namespace xgboost {
 namespace data {
 // Used for single batch data.
-class SimpleDMatrix : public DMatrix {
+class SimpleDMatrix {
  public:
   explicit SimpleDMatrix(std::unique_ptr<DataSource>&& source)
       : source_(std::move(source)) {}
 
-  MetaInfo& Info() override;
+  MetaInfo& Info();
 
-  const MetaInfo& Info() const override;
+  const MetaInfo& Info() const;
 
-  float GetColDensity(size_t cidx) override;
+  float GetColDensity(size_t cidx);
 
-  bool SingleColBlock() const override;
+  bool SingleColBlock() const;
 
-  BatchSet GetRowBatches() override;
+  BatchSet GetRowBatches();
 
-  BatchSet GetColumnBatches() override;
+  BatchSet GetColumnBatches();
 
-  BatchSet GetSortedColumnBatches() override;
+  BatchSet GetSortedColumnBatches();
 
  private:
   // source data pointer.

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -50,10 +50,10 @@ BatchSet SparsePageDMatrix::GetRowBatches() {
   return BatchSet(begin_iter);
 }
 
-BatchSet SparsePageDMatrix::GetSortedColumnBatches() {
+BatchSet SparsePageDMatrix::GetSortedColumnBatches(DMatrix* dmat) {
   // Lazily instantiate
   if (!sorted_column_source_) {
-    SparsePageSource::CreateColumnPage(this, cache_info_, true);
+    SparsePageSource::CreateColumnPage(dmat, cache_info_, true);
     sorted_column_source_.reset(
         new SparsePageSource(cache_info_, ".sorted.col.page"));
   }
@@ -64,10 +64,10 @@ BatchSet SparsePageDMatrix::GetSortedColumnBatches() {
   return BatchSet(begin_iter);
 }
 
-BatchSet SparsePageDMatrix::GetColumnBatches() {
+BatchSet SparsePageDMatrix::GetColumnBatches(DMatrix* dmat) {
   // Lazily instantiate
   if (!column_source_) {
-    SparsePageSource::CreateColumnPage(this, cache_info_, false);
+    SparsePageSource::CreateColumnPage(dmat, cache_info_, false);
     column_source_.reset(new SparsePageSource(cache_info_, ".col.page"));
   }
   column_source_->BeforeFirst();
@@ -77,11 +77,11 @@ BatchSet SparsePageDMatrix::GetColumnBatches() {
   return BatchSet(begin_iter);
 }
 
-float SparsePageDMatrix::GetColDensity(size_t cidx) {
+float SparsePageDMatrix::GetColDensity(DMatrix* dmat, size_t cidx) {
   // Finds densities if we don't already have them
   if (col_density_.empty()) {
     std::vector<size_t> column_size(this->Info().num_col_);
-    for (const auto &batch : this->GetColumnBatches()) {
+    for (const auto &batch : this->GetColumnBatches(dmat)) {
       for (auto i = 0u; i < batch.Size(); i++) {
         column_size[i] += batch[i].size();
       }

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -19,26 +19,26 @@
 namespace xgboost {
 namespace data {
 // Used for external memory.
-class SparsePageDMatrix : public DMatrix {
+class SparsePageDMatrix {
  public:
   explicit SparsePageDMatrix(std::unique_ptr<DataSource>&& source,
                              std::string cache_info)
       : row_source_(std::move(source)), cache_info_(std::move(cache_info)) {}
   virtual ~SparsePageDMatrix() = default;
 
-  MetaInfo& Info() override;
+  MetaInfo& Info();
 
-  const MetaInfo& Info() const override;
+  const MetaInfo& Info() const;
 
-  BatchSet GetRowBatches() override;
+  BatchSet GetRowBatches();
 
-  BatchSet GetSortedColumnBatches() override;
+  BatchSet GetSortedColumnBatches(DMatrix* dmat);
 
-  BatchSet GetColumnBatches() override;
+  BatchSet GetColumnBatches(DMatrix* dmat);
 
-  float GetColDensity(size_t cidx) override;
+  float GetColDensity(DMatrix* dmat, size_t cidx);
 
-  bool SingleColBlock() const override;
+  bool SingleColBlock() const;
 
  private:
   // source data pointers.


### PR DESCRIPTION
The main goal is to add a template method to `DMatrix`:
```cpp
template<class T>
BatchSet<T> GetBatches(const std::string& format);
```
so that we can get batches of different formats.

@RAMitchell @trivialfis @sriramch 