### PR TITLE
dynamically allocate gpu device

### DIFF
--- a/demo/dask/dask_gpu_auto_demo.py
+++ b/demo/dask/dask_gpu_auto_demo.py
@@ -1,0 +1,43 @@
+from dask.distributed import Client, LocalCluster
+import dask.dataframe as dd
+import dask.array as da
+import numpy as np
+import xgboost as xgb
+import GPUtil
+import time
+
+
+# Define the function to be executed on each worker
+def train(X, y):
+    dtrain = xgb.dask.create_worker_dmatrix(X, y)
+    # Specify the GPU algorithm
+    # If set GPU to be EXCLUSIVE mode by nvidia-smi -c EXCLUSIVE_PROCESS, native will
+    # auto-allocate gpu for each worker
+    params = {"tree_method": "gpu_hist"}
+    print("Worker {} starting training on {} rows".format(xgb.rabit.get_rank(), dtrain.num_row()))
+    start = time.time()
+    xgb.train(params, dtrain, num_boost_round=500)
+    end = time.time()
+    print("Worker {} finished training in {:0.2f}s".format(xgb.rabit.get_rank(), end - start))
+
+
+def main():
+    max_devices = 16
+    # Check which devices we have locally
+    available_devices = GPUtil.getAvailable(limit=max_devices)
+    # Use one worker per device
+    cluster = LocalCluster(n_workers=len(available_devices), threads_per_worker=4)
+    client = Client(cluster)
+
+    # Set up a relatively large regression problem
+    n = 100
+    m = 10000000
+    partition_size = 100000
+    X = da.random.random((m, n), partition_size)
+    y = da.random.random(m, partition_size)
+
+    xgb.dask.run(client, train, X, y)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/common/common.cc
+++ b/src/common/common.cc
@@ -28,6 +28,10 @@ GlobalRandomEngine& GlobalRandom() {
 int AllVisibleImpl::AllVisible() {
   return 0;
 }
+
+int AllVisibleImpl::AllocateGPUDeviceId() {
+  return -1;
+}
 #endif  // !defined(XGBOOST_USE_CUDA)
 
 constexpr GPUSet::GpuIdType GPUSet::kAll;

--- a/src/common/common.cu
+++ b/src/common/common.cu
@@ -17,4 +17,41 @@ int AllVisibleImpl::AllVisible() {
   return n_visgpus;
 }
 
+int AllVisibleImpl::AllocateGPUDeviceId() {
+  int device_ordinal;
+  int n_devices;
+  cudaError_t error = cudaFree(0);
+  if (error != cudaSuccess) {
+    dh::safe_cuda(cudaGetDeviceCount(&n_devices));
+    // TODO - could add more checks here about usable devices
+    // loop twice just in case hit race with someone else
+    int n_iters = n_devices * 2;
+    device_ordinal = 0;
+    while (n_iters > 0) {
+      dh::safe_cuda(cudaSetDevice(device_ordinal));
+      // initialize a context
+      error = cudaFree(0);
+      if (error == cudaSuccess) {
+        return device_ordinal;
+      } else if (error == cudaErrorDevicesUnavailable) {
+        // assume we lost the race or all are in use so try again
+      } else {
+        LOG(FATAL) << thrust::system_error(error, thrust::cuda_category(),
+                                   std::string{__FILE__} + ": " +  // NOLINT
+                                   std::to_string(__LINE__)).what();
+      }
+      n_iters--;
+      if ((device_ordinal >= n_devices - 1) || (device_ordinal < 0)) {
+        device_ordinal= 0;
+      } else {
+        device_ordinal++;
+      }
+    }
+    LOG(FATAL) << "Error: could not allocate a GPU!" << std::endl;
+    return 0;
+  }
+  dh::safe_cuda(cudaGetDevice(&device_ordinal));
+  return device_ordinal;
+}
+
 }  // namespace xgboost

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -144,6 +144,7 @@ class Range {
 
 struct AllVisibleImpl {
   static int AllVisible();
+  static int AllocateGPUDeviceId();
 };
 /* \brief set of devices across which HostDeviceVector can be distributed.
  *

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -580,6 +580,10 @@ class LearnerImpl : public Learner {
     gbm_->Configure(args);
 
     if (this->gbm_->UseGPU() && cfg_.find("n_gpus") == cfg_.cend()) {
+      if (cfg_.find("gpu_id") == cfg_.cend()) {
+        generic_param_.gpu_id = AllVisibleImpl::AllocateGPUDeviceId();
+        LOG(INFO) << "Allocated GPU device id: " << generic_param_.gpu_id;
+      }
       generic_param_.n_gpus = 1;
     }
   }


### PR DESCRIPTION
Prerequisite: GPU must be configured as EXCLUSIVE_PROCESS by
"nvidia-smi -c EXCLUSIVE_PROCESS"

when detecting that gpu will be used and gpu_id is not be specified as well,
then auto allocate a GPU for current worker.