### PR TITLE
[CI] Fix broken installation of Pandas

### DIFF
--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -24,7 +24,7 @@ RUN \
     pip install pyyaml cpplint pylint astroid sphinx numpy scipy pandas matplotlib sh recommonmark guzzle_sphinx_theme mock \
                 breathe matplotlib graphviz pytest scikit-learn wheel kubernetes urllib3 && \
     pip install https://h2o-release.s3.amazonaws.com/datatable/stable/datatable-0.7.0/datatable-0.7.0-cp37-cp37m-linux_x86_64.whl && \
-    conda install dask=2.0.0
+    pip install "dask[complete]==2.0.0"
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \


### PR DESCRIPTION
Many pull requests (#4698, #4701, #4699, #4697) are currently failing with the following cryptic error:
```
>       return arith_flex, comp_flex, arith_special, comp_special, bool_special
E       UnboundLocalError: local variable 'arith_flex' referenced before assignment
/opt/python/lib/python3.7/site-packages/pandas/core/ops/__init__.py:719: UnboundLocalError
!!!!!!!!!!!!!!!!!!! Interrupted: 20 errors during collection !!!!!!!!!!!!!!!!!!!
=========================== 20 error in 5.70 seconds ===========================
```

I found out that the command `conda install dask=2.0.0` silently pulls in Pandas 0.24.2 from Anaconda, and that causes conflict with previously installed Pandas 0.25.0 (installed via Pip). The error disappears when I install only one copy of Pandas, whether it's 0.24.2 or 0.25.0.

Fix. Use only Pip to install all Python packages, so that we get only one copy of Pandas.

@sriramch @rongou @hetong007 

Side note. [Pandas on Anaconda](https://anaconda.org/anaconda/pandas) is stuck at version 0.24.2.