### PR TITLE
[HOTFIX] distributed training with hist method 

### DIFF
--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -48,6 +48,7 @@ void HistogramCuts::Build(DMatrix* dmat, uint32_t const max_num_bins) {
     DenseCuts cuts(this);
     cuts.Build(dmat, max_num_bins);
   }
+  LOG(INFO) << "Total number of hist bins: " << cut_ptrs_.back();
 }
 
 bool CutsBuilder::UseGroup(DMatrix* dmat) {

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -1079,7 +1079,8 @@ void QuantileHistMaker::Builder::EvaluateSplitsBatch(
   // partial results
   std::vector<std::pair<SplitEntry, SplitEntry>> splits(tasks.size());
   // parallel enumeration
-#pragma omp parallel for schedule(guided)
+  const auto nthread = omp_get_num_threads();
+  #pragma omp parallel for schedule(dynamic) num_threads(nthread)
   for (omp_ulong i = 0; i < tasks.size(); ++i) {
     // node_idx : offset within `nodes` list
     const int32_t  node_idx    = tasks[i].first;

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -556,7 +556,7 @@ void QuantileHistMaker::Builder::BuildHistsBatch(const std::vector<ExpandEntry>&
       reinterpret_cast<const GradientPair::ValueT*>(gpair.data());
 
   // 2. Build partial histograms for each node
-  #pragma omp parallel for schedule(guided)
+  #pragma omp parallel for schedule(static)
   for (int32_t itask = 0; itask < n_hist_buidling_tasks; ++itask) {
     const size_t tid = omp_get_thread_num();
     const int32_t nid = task_nid[itask];
@@ -856,7 +856,7 @@ bool QuantileHistMaker::Builder::UpdatePredictionCache(
     }
   }
 
-#pragma omp parallel for schedule(guided)
+#pragma omp parallel for schedule(static)
   for (omp_ulong k = 0; k < tasks_elem.size(); ++k) {
     const RowSetCollection::Elem rowset = tasks_elem[k];
     if (rowset.begin != nullptr && rowset.end != nullptr && rowset.node_id != -1) {
@@ -1079,8 +1079,7 @@ void QuantileHistMaker::Builder::EvaluateSplitsBatch(
   // partial results
   std::vector<std::pair<SplitEntry, SplitEntry>> splits(tasks.size());
   // parallel enumeration
-  const auto nthread = omp_get_num_threads();  // NOLINT(*)
-  #pragma omp parallel for schedule(dynamic) num_threads(nthread)
+  #pragma omp parallel for schedule(static)
   for (omp_ulong i = 0; i < tasks.size(); ++i) {
     // node_idx : offset within `nodes` list
     const int32_t  node_idx    = tasks[i].first;

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -1079,7 +1079,7 @@ void QuantileHistMaker::Builder::EvaluateSplitsBatch(
   // partial results
   std::vector<std::pair<SplitEntry, SplitEntry>> splits(tasks.size());
   // parallel enumeration
-  const auto nthread = omp_get_num_threads();
+  const auto nthread = omp_get_num_threads();  // NOLINT(*)
   #pragma omp parallel for schedule(dynamic) num_threads(nthread)
   for (omp_ulong i = 0; i < tasks.size(); ++i) {
     // node_idx : offset within `nodes` list

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -225,6 +225,14 @@ class QuantileHistMock : public QuantileHistMaker {
 
       delete dmat;
     }
+
+    void TestEvaluateSplitParallel(const GHistIndexBlockMatrix &quantile_index_block,
+                                   const RegTree &tree) {
+      omp_set_num_threads(2);
+      TestEvaluateSplit(quantile_index_block, tree);
+      omp_set_num_threads(1);
+    }
+
   };
 
   int static constexpr kNRows = 8, kNCols = 16;

--- a/tests/python/test_openmp.py
+++ b/tests/python/test_openmp.py
@@ -51,9 +51,9 @@ class TestOMP(unittest.TestCase):
         assert auc1 == auc3
         assert err1 == err3
 
-        # use depth-guide grow policy to train a tree
+        # use depth-wise grow policy to train a tree
         param.update({
-            'grow_policy': 'depthguide',
+            'grow_policy': 'depthwise',
             'max_depth': 5,
             'max_leaves': 0,
             'nthread': 1

--- a/tests/python/test_openmp.py
+++ b/tests/python/test_openmp.py
@@ -22,13 +22,13 @@ class TestOMP(unittest.TestCase):
                  'nthread': 3}
 
         watchlist = [(dtest, 'eval'), (dtrain, 'train')]
-        num_round = 5
+        num_round = 10
 
         def run_trial():
             res = {}
             bst = xgb.train(param, dtrain, num_round, watchlist, evals_result=res)
-            auc = res['eval']['auc'][-1]
-            # assert auc > 0.99
+            auc = [res['train']['auc'][-1], res['eval']['auc'][-1]]
+            assert auc[0] > 0.99 and auc[1] > 0.99
             preds = bst.predict(dtest)
             labels = dtest.get_label()
             err = sum(1 for i in range(len(preds))

--- a/tests/python/test_openmp.py
+++ b/tests/python/test_openmp.py
@@ -16,7 +16,7 @@ class TestOMP(unittest.TestCase):
                  'objective': 'binary:logistic',
                  'grow_policy': 'lossguide',
                  'tree_method': 'hist',
-                 'eval_metric': 'auc',
+                 'eval_metric': 'error',
                  'max_depth': 0,
                  'max_leaves': 1024,
                  'min_child_weight': 0,
@@ -28,15 +28,14 @@ class TestOMP(unittest.TestCase):
         def run_trial():
             res = {}
             bst = xgb.train(param, dtrain, num_round, watchlist, evals_result=res)
-            auc = [res['train']['auc'][-1], res['eval']['auc'][-1]]
-            assert auc[0] > 0.99 and auc[1] > 0.99
+            metrics = [res['train']['error'][-1], res['eval']['error'][-1]]
             preds = bst.predict(dtest)
             labels = dtest.get_label()
             err = sum(1 for i in range(len(preds))
                       if int(preds[i] > 0.5) != labels[i]) / float(len(preds))
             # error must be smaller than 10%
             assert err < 0.1
-            return auc, preds
+            return metrics, preds
 
         auc1, pred1 = run_trial()
 

--- a/tests/python/test_openmp.py
+++ b/tests/python/test_openmp.py
@@ -2,6 +2,7 @@
 from scipy.sparse import csr_matrix
 import xgboost as xgb
 import unittest
+import numpy as np
 
 
 class TestOMP(unittest.TestCase):
@@ -30,26 +31,24 @@ class TestOMP(unittest.TestCase):
             auc = [res['train']['auc'][-1], res['eval']['auc'][-1]]
             assert auc[0] > 0.99 and auc[1] > 0.99
             preds = bst.predict(dtest)
-            labels = dtest.get_label()
             err = sum(1 for i in range(len(preds))
                       if int(preds[i] > 0.5) != labels[i]) / float(len(preds))
             # error must be smaller than 10%
             assert err < 0.1
+            return auc, preds
 
-            return auc, err
-
-        auc1, err1 = run_trial()
+        auc1, pred1 = run_trial()
 
         # vary number of threads and test whether you get the same result
         param['nthread'] = 1
-        auc2, err2 = run_trial()
+        auc2, pred2 = run_trial()
         assert auc1 == auc2
-        assert err1 == err2
+        assert np.array_equal(pred1, pred2)
 
         param['nthread'] = 2
-        auc3, err3 = run_trial()
+        auc3, pred3 = run_trial()
         assert auc1 == auc3
-        assert err1 == err3
+        assert np.array_equal(pred1, pred3)
 
         # use depth-wise grow policy to train a tree
         param.update({
@@ -58,10 +57,10 @@ class TestOMP(unittest.TestCase):
             'max_leaves': 0,
             'nthread': 3
         })
-        auc1, err1 = run_trial()
+        auc1, pred1 = run_trial()
 
         # vary number of threads and test whether you get the same result
         param['nthread'] = 1
-        auc2, err2 = run_trial()
+        auc2, pred2 = run_trial()
         assert auc1 == auc2
-        assert err1 == err2
+        assert np.array_equal(pred1, pred2)

--- a/tests/python/test_openmp.py
+++ b/tests/python/test_openmp.py
@@ -20,7 +20,7 @@ class TestOMP(unittest.TestCase):
                  'max_depth': 0,
                  'max_leaves': 1024,
                  'min_child_weight': 0,
-                 'nthread': 3}
+                 'nthread': 1}
 
         watchlist = [(dtest, 'eval'), (dtrain, 'train')]
         num_round = 5

--- a/tests/python/test_openmp.py
+++ b/tests/python/test_openmp.py
@@ -31,6 +31,7 @@ class TestOMP(unittest.TestCase):
             auc = [res['train']['auc'][-1], res['eval']['auc'][-1]]
             assert auc[0] > 0.99 and auc[1] > 0.99
             preds = bst.predict(dtest)
+            labels = dtest.get_label()
             err = sum(1 for i in range(len(preds))
                       if int(preds[i] > 0.5) != labels[i]) / float(len(preds))
             # error must be smaller than 10%

--- a/tests/python/test_openmp.py
+++ b/tests/python/test_openmp.py
@@ -22,7 +22,7 @@ class TestOMP(unittest.TestCase):
                  'nthread': 3}
 
         watchlist = [(dtest, 'eval'), (dtrain, 'train')]
-        num_round = 10
+        num_round = 5
 
         def run_trial():
             res = {}
@@ -56,12 +56,12 @@ class TestOMP(unittest.TestCase):
             'grow_policy': 'depthwise',
             'max_depth': 5,
             'max_leaves': 0,
-            'nthread': 1
+            'nthread': 3
         })
         auc1, err1 = run_trial()
 
         # vary number of threads and test whether you get the same result
-        param['nthread'] = 2
+        param['nthread'] = 1
         auc2, err2 = run_trial()
         assert auc1 == auc2
         assert err1 == err2


### PR DESCRIPTION
Problem: 
- Distributed training with hist method will stop working when synchronizing histograms of different machines.

Debug Stack:
-   Size of `expand_nodes` in different workers are not equal, because one node may be a leaf node on one worker, but it is still splitable on other workers.
-  Results of `SplitEvaluation` are inconsistent on different workers (machines).
-  Inconsistent split results will be observed only when `nthread > 1`.
-  When I changed OPENMP schedule policy of `EvaluateSplitsBatch` from `schedule(guided)` to `schedule(dynamic) num_threads(nthread)`,  everything works.
