### PR TITLE
fix objective parameter issue

### DIFF
--- a/src/learner.cc
+++ b/src/learner.cc
@@ -289,6 +289,7 @@ class LearnerImpl : public Learner {
     }
     cfg_["num_class"] = common::ToString(mparam_.num_class);
     cfg_["num_feature"] = common::ToString(mparam_.num_feature);
+    cfg_["objective"] = common::ToString(tparam_.objective);
 
     gbm_->Configure({cfg_.cbegin(), cfg_.cend()});
     obj_->Configure({cfg_.begin(), cfg_.end()});

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -287,9 +287,12 @@ class LearnerImpl : public Learner {
         metrics_.emplace_back(Metric::Create(name, &generic_param_));
       }
     }
-    cfg_["num_class"] = common::ToString(mparam_.num_class);
-    cfg_["num_feature"] = common::ToString(mparam_.num_feature);
-    cfg_["objective"] = common::ToString(tparam_.objective);
+
+    auto m = mparam_.__DICT__();
+    cfg_.insert(m.cbegin(), m.cend());
+
+    auto n = tparam_.__DICT__();
+    cfg_.insert(n.cbegin(), n.cend());
 
     gbm_->Configure({cfg_.cbegin(), cfg_.cend()});
     obj_->Configure({cfg_.begin(), cfg_.end()});

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -288,8 +288,8 @@ class LearnerImpl : public Learner {
       }
     }
 
-    auto m = mparam_.__DICT__();
-    cfg_.insert(m.cbegin(), m.cend());
+    cfg_["num_class"] = common::ToString(mparam_.num_class);
+    cfg_["num_feature"] = common::ToString(mparam_.num_feature);
 
     auto n = tparam_.__DICT__();
     cfg_.insert(n.cbegin(), n.cend());

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -146,6 +146,8 @@ TEST(Learner, ObjectiveParameter) {
   learner1->Load(fi.get());
   auto attr_names1 = learner1->GetConfigurationArguments();
   ASSERT_EQ(attr_names1.at("objective"), "multi:softprob");
+
+  delete pp_dmat;
 }
 
 #if defined(XGBOOST_USE_CUDA)

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -111,6 +111,43 @@ TEST(Learner, Configuration) {
   }
 }
 
+TEST(Learner, ObjectiveParameter) {
+  using Arg = std::pair<std::string, std::string>;
+  size_t constexpr kRows = 10;
+  auto pp_dmat = CreateDMatrix(kRows, 10, 0);
+  auto p_dmat = *pp_dmat;
+
+  std::vector<bst_float> labels(kRows);
+  for (size_t i = 0; i < labels.size(); ++i) {
+    labels[i] = i;
+  }
+  p_dmat->Info().labels_.HostVector() = labels;
+  std::vector<std::shared_ptr<DMatrix>> mat {p_dmat};
+
+  std::unique_ptr<Learner> learner {Learner::Create(mat)};
+  learner->SetParams({Arg{"tree_method", "auto"},
+                      Arg{"objective", "multi:softprob"},
+                      Arg{"num_class", "10"}});
+  learner->UpdateOneIter(0, p_dmat.get());
+  auto attr_names = learner->GetConfigurationArguments();
+  ASSERT_EQ(attr_names.at("objective"), "multi:softprob");
+
+  dmlc::TemporaryDirectory tempdir;
+  const std::string fname = tempdir.path + "/model_para.bst";
+
+  {
+    // Create a scope to close the stream before next read.
+    std::unique_ptr<dmlc::Stream> fo(dmlc::Stream::Create(fname.c_str(), "w"));
+    learner->Save(fo.get());
+  }
+
+  std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(fname.c_str(), "r"));
+  std::unique_ptr<Learner> learner1 {Learner::Create(mat)};
+  learner1->Load(fi.get());
+  auto attr_names1 = learner1->GetConfigurationArguments();
+  ASSERT_EQ(attr_names1.at("objective"), "multi:softprob");
+}
+
 #if defined(XGBOOST_USE_CUDA)
 
 TEST(Learner, IO) {


### PR DESCRIPTION
Issue repro step:
1. load a model (naming A) from disk,
2. invoke A.setParam() to set a parameter
3. Learner.configured_ will be set to false
4. A.Predict()
5. learner.Configure()
    then tparam_.objective will set to default (reg:squarederror)
6. learner.ConfigureObjective() will use incorrect objective

For example
in train phase, objective is multi:softprob
but after before 6 steps, in predict phase, objective will be multi:softmax