### PR TITLE
remove some unused functions as reported by cppcheck

### DIFF
--- a/src/common/bitmap.h
+++ b/src/common/bitmap.h
@@ -47,7 +47,7 @@ struct BitMap {
     for (bst_omp_uint i = 0; i < nsize; ++i) {
       uint32_t res = 0;
       for (int k = 0; k < 32; ++k) {
-        int bit = vec[(i << 5) | k];
+        uint32_t bit = vec[(i << 5) | k];
         res |= (bit << k);
       }
       data[i] = res;

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -31,13 +31,13 @@ const char* kMaxDeltaStepDefaultValue = "0.7";
 
 inline bool IsFloat(const std::string& str) {
   std::stringstream ss(str);
-  float f;
+  float f{};
   return !((ss >> std::noskipws >> f).rdstate() ^ std::ios_base::eofbit);
 }
 
 inline bool IsInt(const std::string& str) {
   std::stringstream ss(str);
-  int i;
+  int i{};
   return !((ss >> std::noskipws >> i).rdstate() ^ std::ios_base::eofbit);
 }
 
@@ -530,9 +530,6 @@ class LearnerImpl : public Learner {
     this->ValidateDMatrix(data);
     gbm_->PredictBatch(data, out_preds, ntree_limit);
   }
-
-  // return whether model is already initialized.
-  bool ModelInitialized() const { return configured_; }
 
   void ConfigureObjective(LearnerTrainParam const& old, Args* p_args) {
     if (cfg_.find("num_class") != cfg_.cend() && cfg_.at("num_class") != "0") {

--- a/src/objective/rank_obj.cc
+++ b/src/objective/rank_obj.cc
@@ -146,10 +146,6 @@ class LambdaRankObj : public ObjFunction {
     inline static bool CmpPred(const ListEntry &a, const ListEntry &b) {
       return a.pred > b.pred;
     }
-    // comparator by label
-    inline static bool CmpLabel(const ListEntry &a, const ListEntry &b) {
-      return a.label > b.label;
-    }
   };
   /*! \brief a pair in the lambda rank */
   struct LambdaPair {

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -817,9 +817,6 @@ class DistColMaker : public ColMaker {
         this->position_[ridx] = nid;
       }
     }
-    inline const int* GetLeafPosition() const {
-      return dmlc::BeginPtr(this->position_);
-    }
 
    protected:
     void SetNonDefaultPosition(const std::vector<int> &qexpand, DMatrix *p_fmat,

--- a/src/tree/updater_histmaker.cc
+++ b/src/tree/updater_histmaker.cc
@@ -96,16 +96,6 @@ class HistMaker: public BaseMaker {
         hset[tid].data.resize(cut.size(), GradStats());
       }
     }
-    // aggregate all statistics to hset[0]
-    inline void Aggregate() {
-      bst_omp_uint nsize = static_cast<bst_omp_uint>(cut.size());
-      #pragma omp parallel for schedule(static)
-      for (bst_omp_uint i = 0; i < nsize; ++i) {
-        for (size_t tid = 1; tid < hset.size(); ++tid) {
-          hset[0].data[i].Add(hset[tid].data[i]);
-        }
-      }
-    }
     /*! \brief clear the workspace */
     inline void Clear() {
       cut.clear(); rptr.resize(1); rptr[0] = 0;


### PR DESCRIPTION
After removing `gpu_hist`, I ran cppcheck to see if it can find more dead code, but it found a few random functions.

@RAMitchell @trivialfis @hcho3 