### PR TITLE
Mimic cuda assert output in span check.

### DIFF
--- a/src/common/span.h
+++ b/src/common/span.h
@@ -70,15 +70,18 @@ namespace common {
 // Usual logging facility is not available inside device code.
 // TODO(trivialfis): Make dmlc check more generic.
 // assert is not supported in mac as of CUDA 10.0
-#define KERNEL_CHECK(cond)                                                     \
-  do {                                                                         \
-    if (!(cond)) {                                                             \
-      printf("\nKernel error:\n"                                               \
-             "In: %s, \tline: %d\n"                                            \
-             "\t%s\n\tExpecting: %s\n",                                        \
-             __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond);                  \
-      asm("trap;");                                                            \
-    }                                                                          \
+#define KERNEL_CHECK(cond)                                      \
+  do {                                                          \
+    if (!(cond)) {                                              \
+      printf("\nKernel error:\n"                                \
+             "In: %s: %d\n"                                     \
+             "\t%s\n\tExpecting: %s\n"                          \
+             "\tBlock: [%d, %d, %d], Thread: [%d, %d, %d]\n\n", \
+             __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond,    \
+             blockIdx.x, blockIdx.y, blockIdx.z,                \
+             threadIdx.x, threadIdx.y, threadIdx.z);            \
+      asm("trap;");                                             \
+    }                                                           \
   } while (0);
 
 #ifdef __CUDA_ARCH__


### PR DESCRIPTION
`KERNEL_CHECK`:
```
Kernel error:
In: /home/fis/Workspace/cuDf/xgboost/tests/cpp/common/test_span.cu: 327
	void xgboost::common::TestAssert2(xgboost::common::Span<unsigned long, -1L>)
	Expecting: _span.size() > 3
	Block: [0, 0, 0], Thread: [0, 0, 0]
```

Official cuda `assert`:
```
/home/fis/Workspace/cuDf/xgboost/tests/cpp/common/test_span.cu:324: void xgboost::common::TestAssert(xgboost::common::Span<unsigned long, -1L>): block: [0,0,0], thread: [0,0,0] Assertion `_span.size() > 3` failed.
```