### PR TITLE
Fix unstable results in hist method

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,9 +2,9 @@ Contributors of DMLC/XGBoost
 ============================
 XGBoost has been developed and used by a group of active community. Everyone is more than welcomed to is a great way to make the project better and more accessible to more users.
 
-Project Management Committee(PMC) 
+Project Management Committee(PMC)
 ----------
-The Project Management Committee(PMC) consists group of active committers that moderate the discussion, manage the project release, and proposes new committer/PMC members. 
+The Project Management Committee(PMC) consists group of active committers that moderate the discussion, manage the project release, and proposes new committer/PMC members.
 
 * [Tianqi Chen](https://github.com/tqchen), University of Washington
   - Tianqi is a Ph.D. student working on large-scale machine learning. He is the creator of the project.
@@ -17,9 +17,9 @@ The Project Management Committee(PMC) consists group of active committers that m
 * [Jiaming Yuan](https://github.com/trivialfis)
   - Jiaming contributed to the GPU algorithms. He has also introduced new abstractions to improve the quality of the C++ codebase.
 * [Hyunsu Cho](http://hyunsu-cho.io/), Amazon AI
-  - Hyunsu is an applied scientist in Amazon AI. He is the maintainer of the XGBoost Python package. He also manages the Jenkins continuous integration system (https://xgboost-ci.net/). He is the initial author of the CPU 'hist' updater.   
+  - Hyunsu is an applied scientist in Amazon AI. He is the maintainer of the XGBoost Python package. He also manages the Jenkins continuous integration system (https://xgboost-ci.net/). He is the initial author of the CPU 'hist' updater.
 * [Rory Mitchell](https://github.com/RAMitchell), University of Waikato
-  - Rory is a Ph.D. student at University of Waikato. He is the original creator of the GPU training algorithms. He improved the CMake build system and continuous integration. 
+  - Rory is a Ph.D. student at University of Waikato. He is the original creator of the GPU training algorithms. He improved the CMake build system and continuous integration.
 * [Hongliang Liu](https://github.com/phunterlau)
 
 
@@ -100,3 +100,5 @@ List of Contributors
 * [Bryan Woods](https://github.com/bryan-woods)
   - Bryan added support for cross-validation for the ranking objective
 * [Haoda Fu](https://github.com/fuhaoda)
+* [Egor Smirnov](https://github.com/SmirnovEgorRu)
+  - Egor optimized 'hist' tree method for Intel CPUs

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -556,7 +556,7 @@ void QuantileHistMaker::Builder::BuildHistsBatch(const std::vector<ExpandEntry>&
       reinterpret_cast<const GradientPair::ValueT*>(gpair.data());
 
   // 2. Build partial histograms for each node
-  #pragma omp parallel for schedule(guided)
+  #pragma omp parallel for schedule(static)
   for (int32_t itask = 0; itask < n_hist_buidling_tasks; ++itask) {
     const size_t tid = omp_get_thread_num();
     const int32_t nid = task_nid[itask];


### PR DESCRIPTION
After my [changes](https://github.com/dmlc/xgboost/pull/4529) I observed some small differences in results from run to run.
For example, log-loss for HIGGS data set:
1 run: 0.807342768946606615
2 run: 0.807342768708895875

The reason was so easy - guided scheduling instead of static in OpenMP loop. It leads to non-deterministic operations with floating-point numbers.

I have fixed it and now log-loss:
1 run: 0.807342767697801778
2 run: 0.807342767697801778
3 run: 0.807342767697801778

Training time is the same as it were before:
Before time: 2951ms
After time: 2903ms