### PR TITLE
Use long key id.

### DIFF
--- a/tests/ci_build/Dockerfile.rproject
+++ b/tests/ci_build/Dockerfile.rproject
@@ -9,7 +9,7 @@ RUN \
     apt-get update && \
     apt-get install -y software-properties-common tar unzip wget git build-essential doxygen graphviz libcurl4-openssl-dev libssl-dev libxml2-dev && \
     if [ $USE_R35 -eq 1 ]; then \
-      apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 && \
+      apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
       add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/' && \
       apt-get update; \
     fi && \


### PR DESCRIPTION
See https://rubuntu.netlify.com/post/changes-to-cran-ubuntu-webpage-regarding-apt-secure-key/ and https://cran.r-project.org/bin/linux/ubuntu/ .


This unblocks the current CI.