### PR TITLE
[R] `xgb.get.handle` now checks all class listed of `object`

### DIFF
--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -51,11 +51,13 @@ is.null.handle <- function(handle) {
 # Return a verified to be valid handle out of either xgb.Booster.handle or xgb.Booster
 # internal utility function
 xgb.get.handle <- function(object) {
-  handle <- switch(class(object)[1],
-    xgb.Booster = object$handle,
-    xgb.Booster.handle = object,
+  if (inherits(object, "xgb.Booster")) {
+    handle <- object$handle
+  } else if (inherits(object, "xgb.Booster.handle")) {
+    handle <- object
+  } else {
     stop("argument must be of either xgb.Booster or xgb.Booster.handle class")
-  )
+  }
   if (is.null.handle(handle)) {
     stop("invalid xgb.Booster.handle")
   }


### PR DESCRIPTION
Previously `xgb.get.handle` was only checking the first class of the provided object.
Now it checks all its class to guess if it s a handler or if it s a model
fix #4764