### PR TITLE
[jvm-packages] Refactor XGBoost.scala to put all params processing in one place

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -60,7 +60,7 @@ object TrackerConf {
 private[this] case class XGBoostExecutionEarlyStoppingParams(numEarlyStoppingRounds: Int,
                                                              maximizeEvalMetrics: Boolean)
 
-private[this] case class XGBoostExecutionInputParams(trainTestRatio: Float, seed: Long)
+private[this] case class XGBoostExecutionInputParams(trainTestRatio: Double, seed: Long)
 
 private[this] case class XGBoostExecutionParams(
     numWorkers: Int,
@@ -196,8 +196,8 @@ private[this] class XGBoostExecutionParamsFactory(rawParams: Map[String, Any], s
     val checkpointParam =
       CheckpointManager.extractParams(overridedParams)
 
-    val trainTestRatio = overridedParams.getOrElse("train_test_ratio", 1.0f)
-      .asInstanceOf[Float]
+    val trainTestRatio = overridedParams.getOrElse("train_test_ratio", 1.0)
+      .asInstanceOf[Double]
     val seed = overridedParams.getOrElse("seed", System.nanoTime()).asInstanceOf[Long]
     val inputParams = XGBoostExecutionInputParams(trainTestRatio, seed)
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -60,8 +60,7 @@ object TrackerConf {
 private[this] case class XGBoostExecutionEarlyStoppingParams(numEarlyStoppingRounds: Int,
                                                              maximizeEvalMetrics: Boolean)
 
-private[this] case class XGBoostExecutionInputParams(
-    trainTestSplitRatio: Float, seed: Long)
+private[this] case class XGBoostExecutionInputParams(trainTestRatio: Float, seed: Long)
 
 private[this] case class XGBoostExecutionParams(
     numWorkers: Int,
@@ -197,10 +196,10 @@ private[this] class XGBoostExecutionParamsFactory(rawParams: Map[String, Any], s
     val checkpointParam =
       CheckpointManager.extractParams(overridedParams)
 
-    val trainTestSplit = overridedParams.getOrElse("train_test_split", 1.0f)
+    val trainTestRatio = overridedParams.getOrElse("train_test_ratio", 1.0f)
       .asInstanceOf[Float]
     val seed = overridedParams.getOrElse("seed", System.nanoTime()).asInstanceOf[Long]
-    val inputParams = XGBoostExecutionInputParams(trainTestSplit, seed)
+    val inputParams = XGBoostExecutionInputParams(trainTestRatio, seed)
 
     val earlyStoppingRounds = overridedParams.getOrElse(
       "num_early_stopping_rounds", 0).asInstanceOf[Int]
@@ -740,7 +739,7 @@ private object Watches {
       xgbExecutionParams: XGBoostExecutionParams,
       labeledPoints: Iterator[XGBLabeledPoint],
       cacheDirName: Option[String]): Watches = {
-    val trainTestRatio = xgbExecutionParams.xgbInputParams.trainTestSplitRatio
+    val trainTestRatio = xgbExecutionParams.xgbInputParams.trainTestRatio
     val seed = xgbExecutionParams.xgbInputParams.seed
     val r = new Random(seed)
     val testPoints = mutable.ArrayBuffer.empty[XGBLabeledPoint]
@@ -810,7 +809,7 @@ private object Watches {
       xgbExecutionParams: XGBoostExecutionParams,
       labeledPointGroups: Iterator[Array[XGBLabeledPoint]],
       cacheDirName: Option[String]): Watches = {
-    val trainTestRatio = xgbExecutionParams.xgbInputParams.trainTestSplitRatio
+    val trainTestRatio = xgbExecutionParams.xgbInputParams.trainTestRatio
     val seed = xgbExecutionParams.xgbInputParams.seed
     val r = new Random(seed)
     val testPoints = mutable.ArrayBuilder.make[XGBLabeledPoint]

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -144,8 +144,8 @@ private[this] object XGBoostNativeParamsFactory {
       overridedParams = overridedParams + ("nthread" -> coresPerTask)
     }
 
-    val numEarlyStoppingRounds = overridedParams.getOrElse[Int](
-      "num_early_stopping_rounds", 0)
+    val numEarlyStoppingRounds = overridedParams.getOrElse(
+      "num_early_stopping_rounds", 0).asInstanceOf[Int]
     overridedParams += "num_early_stopping_rounds" -> numEarlyStoppingRounds
     if (numEarlyStoppingRounds > 0 &&
       !overridedParams.contains("maximize_evaluation_metrics")) {
@@ -204,18 +204,20 @@ private[this] object XGBoostNativeParamsFactory {
     val checkpointParam =
       CheckpointManager.extractParams(overridedParams)
 
-    val trainTestSplit = overridedParams.getOrElse[Float]("train_test_split", 1.0f)
-    val seed = overridedParams.getOrElse[Long]("seed", System.nanoTime())
+    val trainTestSplit = overridedParams.getOrElse("train_test_split", 1.0f)
+      .asInstanceOf[Float]
+    val seed = overridedParams.getOrElse("seed", System.nanoTime()).asInstanceOf[Long]
     val inputParams = XGBoostExecutionInputParams(trainTestSplit, seed)
 
-    val earlyStoppingRounds = overridedParams.getOrElse[Int](
-      "num_early_stopping_rounds", 0)
-    val maximizeEvalMetrics = overridedParams.getOrElse[Boolean](
-      "maximize_evaluation_metrics", true)
+    val earlyStoppingRounds = overridedParams.getOrElse(
+      "num_early_stopping_rounds", 0).asInstanceOf[Int]
+    val maximizeEvalMetrics = overridedParams.getOrElse(
+      "maximize_evaluation_metrics", true).asInstanceOf[Boolean]
     val xgbExecEarlyStoppingParams = XGBoostExecutionEarlyStoppingParams(earlyStoppingRounds,
       maximizeEvalMetrics)
 
-    val cacheTrainingSet = overridedParams.getOrElse[Boolean]("cache_training_set", false)
+    val cacheTrainingSet = overridedParams.getOrElse("cache_training_set", false)
+      .asInstanceOf[Boolean]
 
     val xgbExecParam = XGBoostExecutionParams(nWorkers, round, useExternalMemory, obj, eval,
       missing, trackerConf,

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/CheckpointManagerSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/CheckpointManagerSuite.scala
@@ -87,7 +87,7 @@ class CheckpointManagerSuite extends FunSuite with TmpFolderPerSuite with PerTes
     def error(model: Booster): Float = eval.eval(
       model.predict(testDM, outPutMargin = true), testDM)
 
-    if(skipCleanCheckpoint) {
+    if (skipCleanCheckpoint) {
       // Check only one model is kept after training
       val files = FileSystem.get(sc.hadoopConfiguration).listStatus(new Path(tmpPath))
       assert(files.length == 1)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/CheckpointManagerSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/CheckpointManagerSuite.scala
@@ -87,7 +87,7 @@ class CheckpointManagerSuite extends FunSuite with TmpFolderPerSuite with PerTes
     def error(model: Booster): Float = eval.eval(
       model.predict(testDM, outPutMargin = true), testDM)
 
-    if (skipCleanCheckpoint) {
+    if(skipCleanCheckpoint) {
       // Check only one model is kept after training
       val files = FileSystem.get(sc.hadoopConfiguration).listStatus(new Path(tmpPath))
       assert(files.length == 1)


### PR DESCRIPTION
several pattern matching needs to be changed when adding a new param now, e.g. https://github.com/dmlc/xgboost/pull/4805


this PR is to refactor XGBoost.scala to make code cleaner