### PR TITLE
Optimizations of distributed 'hist' mode for CPUs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -102,3 +102,5 @@ List of Contributors
 * [Haoda Fu](https://github.com/fuhaoda)
 * [Evan Kepner](https://github.com/EvanKepner)
   - Evan Kepner added support for os.PathLike file paths in Python
+* [Egor Smirnov](https://github.com/SmirnovEgorRu)
+  - Egor optimized 'hist' tree method for Intel CPUs

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -463,7 +463,7 @@ void QuantileHistMaker::Builder::CreateNewNodesBatch(
       rabit::Allreduce<rabit::op::Sum>(&node_sizes[0], 2);
     }
 
-    if (node_sizes[0] < node_sizes[1]) { // left size < right size
+    if (node_sizes[0] < node_sizes[1]) {  // left size < right size
       temp_qexpand_depth->push_back(ExpandEntry(left_id, right_id, nid,
             depth + 1, 0.0, (*timestamp)++));
     } else {

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -249,7 +249,8 @@ class QuantileHistMaker: public TreeUpdater {
         const std::vector<ExpandEntry>& nodes,
         std::vector<std::vector<common::GradStatHist::GradType*>>* hist_buffers,
         std::vector<std::vector<uint8_t>>* hist_is_init,
-        const std::vector<std::vector<common::GradStatHist>>& grad_stats);
+        const std::vector<std::vector<common::GradStatHist>>& grad_stats,
+        const GHistIndexMatrix &gmat);
 
      void ExpandWithDepthWise(const GHistIndexMatrix &gmat,
                               const GHistIndexBlockMatrix &gmatb,


### PR DESCRIPTION
I observed that distributed XGBoost on 1 node is slower than non-distributed (Batch) XGBoost. Difference is 1.5-3x times depending on data set and parameters. The reasons of this:
- We took always left tree node for complex histogram computation and right node - computed by subtraction trick. But I added choosing of the smallest tree node across of computation nodes.
- Poor threading for histogram reduction in distributed case - also fixed.

Performance measurements:

Data set  | higgs1m
-- | --
1 node   (before), s | 5.29
1 node (this   PR), s | 3.66
Batch mode, s | 3.53

So, we see 1.5x speedup against prev version and similar time as in Batch mode.
