### PR TITLE
[blocking] fix parallel eval_split of hist updater

### DIFF
--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -556,7 +556,7 @@ void QuantileHistMaker::Builder::BuildHistsBatch(const std::vector<ExpandEntry>&
       reinterpret_cast<const GradientPair::ValueT*>(gpair.data());
 
   // 2. Build partial histograms for each node
-  #pragma omp parallel for schedule(guided)
+  #pragma omp parallel for schedule(static)
   for (int32_t itask = 0; itask < n_hist_buidling_tasks; ++itask) {
     const size_t tid = omp_get_thread_num();
     const int32_t nid = task_nid[itask];
@@ -856,7 +856,7 @@ bool QuantileHistMaker::Builder::UpdatePredictionCache(
     }
   }
 
-#pragma omp parallel for schedule(guided)
+#pragma omp parallel for schedule(static)
   for (omp_ulong k = 0; k < tasks_elem.size(); ++k) {
     const RowSetCollection::Elem rowset = tasks_elem[k];
     if (rowset.begin != nullptr && rowset.end != nullptr && rowset.node_id != -1) {
@@ -1083,9 +1083,9 @@ void QuantileHistMaker::Builder::EvaluateSplitsBatch(
   // parallel enumeration
   #pragma omp parallel for schedule(static)
   for (omp_ulong i = 0; i < tasks.size(); ++i) {
+    // node_idx : offset within `nodes` list
     const int32_t  node_idx    = tasks[i].first;
-    const size_t   fid         // node_idx : offset within `nodes` list
-        = tasks[i].second;
+    const size_t   fid         = tasks[i].second;
     const int32_t  nid         = nodes[node_idx].nid;  // usually node_idx != nid
     const int32_t  sibling_nid = nodes[node_idx].sibling_nid;
     const int32_t  parent_nid  = nodes[node_idx].parent_nid;

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -1092,13 +1092,13 @@ void QuantileHistMaker::Builder::EvaluateSplitsBatch(
 
     // reduce needed part of a hist here to have it in cache before enumeration
     if (!isDistributed) {
-      common::GradStatHist::GradType* hist_data =
-          reinterpret_cast<common::GradStatHist::GradType*>(hist_[nid].data());
-      common::GradStatHist::GradType* sibling_hist_data = sibling_nid > -1 ?
-                                                          reinterpret_cast<common::GradStatHist::GradType*>(
-                                                              hist_[sibling_nid].data()) : nullptr;
-      common::GradStatHist::GradType* parent_hist_data  = sibling_nid > -1 ?
-                                                          reinterpret_cast<common::GradStatHist::GradType*>(hist_[parent_nid].data()) : nullptr;
+      auto hist_data = reinterpret_cast<common::GradStatHist::GradType *>(hist_[nid].data());
+      auto sibling_hist_data = sibling_nid > -1 ?
+                               reinterpret_cast<common::GradStatHist::GradType *>(
+                                   hist_[sibling_nid].data()) : nullptr;
+      auto parent_hist_data = sibling_nid > -1 ?
+                              reinterpret_cast<common::GradStatHist::GradType *>(
+                                  hist_[parent_nid].data()) : nullptr;
 
       const std::vector<uint32_t>& cut_ptr = gmat.cut.Ptrs();
       const size_t ibegin = 2 * cut_ptr[fid];

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -556,7 +556,7 @@ void QuantileHistMaker::Builder::BuildHistsBatch(const std::vector<ExpandEntry>&
       reinterpret_cast<const GradientPair::ValueT*>(gpair.data());
 
   // 2. Build partial histograms for each node
-  #pragma omp parallel for schedule(static)
+  #pragma omp parallel for schedule(guided)
   for (int32_t itask = 0; itask < n_hist_buidling_tasks; ++itask) {
     const size_t tid = omp_get_thread_num();
     const int32_t nid = task_nid[itask];
@@ -856,7 +856,7 @@ bool QuantileHistMaker::Builder::UpdatePredictionCache(
     }
   }
 
-#pragma omp parallel for schedule(static)
+#pragma omp parallel for schedule(guided)
   for (omp_ulong k = 0; k < tasks_elem.size(); ++k) {
     const RowSetCollection::Elem rowset = tasks_elem[k];
     if (rowset.begin != nullptr && rowset.end != nullptr && rowset.node_id != -1) {
@@ -1074,16 +1074,22 @@ void QuantileHistMaker::Builder::EvaluateSplitsBatch(
     for (size_t j = 0; j < nfeature; ++j) {
       tasks.emplace_back(i, feature_set[j]);
     }
+
+    // pre-allocate all memory of HistCollection before parallel execution
+    hist_.AddHistRow(nodes[i].nid);
+    if (nodes[i].sibling_nid > -1) {
+      hist_.AddHistRow(nodes[i].sibling_nid);
+    }
   }
 
   // partial results
   std::vector<std::pair<SplitEntry, SplitEntry>> splits(tasks.size());
   // parallel enumeration
-  #pragma omp parallel for schedule(static)
+  #pragma omp parallel for schedule(guided)
   for (omp_ulong i = 0; i < tasks.size(); ++i) {
-    // node_idx : offset within `nodes` list
     const int32_t  node_idx    = tasks[i].first;
-    const size_t   fid         = tasks[i].second;
+    const size_t   fid         // node_idx : offset within `nodes` list
+        = tasks[i].second;
     const int32_t  nid         = nodes[node_idx].nid;  // usually node_idx != nid
     const int32_t  sibling_nid = nodes[node_idx].sibling_nid;
     const int32_t  parent_nid  = nodes[node_idx].parent_nid;


### PR DESCRIPTION
In #4716,  we modified schedule policy of OPENMP from `guided` to `static`. But I caught same problem after this fix.  
After a lot of debug work, I found the `rabit::IsDistributed` method, which is in parallel body of OPENMP,  is not thread safe.  Because [rabit::GetEngine](https://github.com/dmlc/rabit/blob/dba32d54d1668033356a2ad505c239411d660821/src/engine.cc#L74) is thread local.