### PR TITLE
Add link to Ruby XGBoost gem

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,6 +25,7 @@ Contents
   Python package <python/index>
   R package <R-package/index>
   JVM package <jvm/index>
+  Ruby package <https://github.com/ankane/xgb>
   Julia package <julia>
   CLI interface <cli>
   contrib/index


### PR DESCRIPTION
From https://discuss.xgboost.ai/t/ruby-library-for-xgboost/1133, I learned that there is now a Ruby binding for XGBoost. 

Announcement: https://ankane.org/xgboost-lightgbm-come-to-ruby

cc @ankane