### PR TITLE
[jvm-packages] refine numAliveCores method of SparkParallelismTracker 

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -251,18 +251,17 @@ private[spark] trait ParamMapFuncs extends Params {
           " and grow_histmaker,prune or hist as the updater type")
       }
       val name = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, paramName)
-      params.find(_.name == name) match {
-        case Some(_: DoubleParam) =>
+      params.find(_.name == name).foreach {
+        case _: DoubleParam =>
           set(name, paramValue.toString.toDouble)
-        case Some(_: BooleanParam) =>
+        case _: BooleanParam =>
           set(name, paramValue.toString.toBoolean)
-        case Some(_: IntParam) =>
+        case _: IntParam =>
           set(name, paramValue.toString.toInt)
-        case Some(_: FloatParam) =>
+        case _: FloatParam =>
           set(name, paramValue.toString.toFloat)
-        case Some(_: Param[_]) =>
+        case _: Param[_] =>
           set(name, paramValue)
-        case _ =>
       }
     }
   }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -252,7 +252,6 @@ private[spark] trait ParamMapFuncs extends Params {
       }
       val name = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, paramName)
       params.find(_.name == name) match {
-        case None =>
         case Some(_: DoubleParam) =>
           set(name, paramValue.toString.toDouble)
         case Some(_: BooleanParam) =>
@@ -263,6 +262,7 @@ private[spark] trait ParamMapFuncs extends Params {
           set(name, paramValue.toString.toFloat)
         case Some(_: Param[_]) =>
           set(name, paramValue)
+        case _ =>
       }
     }
   }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/SparkParallelismTracker.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/SparkParallelismTracker.scala
@@ -19,10 +19,6 @@ package org.apache.spark
 import org.apache.commons.logging.LogFactory
 import org.apache.spark.scheduler._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Future, TimeoutException}
-
 /**
  * A tracker that ensures enough number of executor cores are alive.
  * Throws an exception when the number of alive cores is less than nWorkers.
@@ -40,13 +36,7 @@ class SparkParallelismTracker(
   private[this] val logger = LogFactory.getLog("XGBoostSpark")
 
   private[this] def numAliveCores: Int = {
-<<<<<<< Updated upstream
-    //  except master node
-    val aliveWorkers = sc.statusTracker.getExecutorInfos.length - 1
-    aliveWorkers * sc.conf.getInt("spark.executor.cores", 1)
-=======
     sc.statusStore.executorList(true). map(_.totalCores).sum
->>>>>>> Stashed changes
   }
 
   private[this] def waitForCondition(
@@ -91,19 +81,9 @@ class SparkParallelismTracker(
       logger.info("starting training without setting timeout for waiting for resources")
       body
     } else {
-<<<<<<< Updated upstream
-      try {
-        logger.info(s"starting training with timeout set as $timeout ms for waiting for resources")
-        waitForCondition(numAliveCores >= requestedCores, timeout)
-      } catch {
-        case _: TimeoutException =>
-          throw new IllegalStateException(s"Unable to get $requestedCores cores for" +
-            s" XGBoost training")
-=======
       logger.info(s"starting training with timeout set as $timeout ms for waiting for resources")
       if (!waitForCondition(numAliveCores >= requestedCores, timeout)) {
         throw new IllegalStateException(s"Unable to get $requestedCores cores for XGBoost training")
->>>>>>> Stashed changes
       }
       safeExecute(body)
     }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/SparkParallelismTracker.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/SparkParallelismTracker.scala
@@ -40,21 +40,31 @@ class SparkParallelismTracker(
   private[this] val logger = LogFactory.getLog("XGBoostSpark")
 
   private[this] def numAliveCores: Int = {
+<<<<<<< Updated upstream
     //  except master node
     val aliveWorkers = sc.statusTracker.getExecutorInfos.length - 1
     aliveWorkers * sc.conf.getInt("spark.executor.cores", 1)
+=======
+    sc.statusStore.executorList(true). map(_.totalCores).sum
+>>>>>>> Stashed changes
   }
 
   private[this] def waitForCondition(
       condition: => Boolean,
       timeout: Long,
       checkInterval: Long = 100L) = {
-    val monitor = Future {
-      while (!condition) {
-        Thread.sleep(checkInterval)
+    val waitImpl = new ((Long, Boolean) => Boolean) {
+      override def apply(waitedTime: Long, status: Boolean): Boolean = status match {
+        case s if s => true
+        case _ => waitedTime match {
+          case t if t < timeout =>
+            Thread.sleep(checkInterval)
+            apply(t + checkInterval, status = condition)
+          case _ => false
+        }
       }
     }
-    Await.ready(monitor, timeout.millis)
+    waitImpl(0L, condition)
   }
 
   private[this] def safeExecute[T](body: => T): T = {
@@ -81,6 +91,7 @@ class SparkParallelismTracker(
       logger.info("starting training without setting timeout for waiting for resources")
       body
     } else {
+<<<<<<< Updated upstream
       try {
         logger.info(s"starting training with timeout set as $timeout ms for waiting for resources")
         waitForCondition(numAliveCores >= requestedCores, timeout)
@@ -88,6 +99,11 @@ class SparkParallelismTracker(
         case _: TimeoutException =>
           throw new IllegalStateException(s"Unable to get $requestedCores cores for" +
             s" XGBoost training")
+=======
+      logger.info(s"starting training with timeout set as $timeout ms for waiting for resources")
+      if (!waitForCondition(numAliveCores >= requestedCores, timeout)) {
+        throw new IllegalStateException(s"Unable to get $requestedCores cores for XGBoost training")
+>>>>>>> Stashed changes
       }
       safeExecute(body)
     }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/SparkParallelismTracker.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/SparkParallelismTracker.scala
@@ -36,7 +36,7 @@ class SparkParallelismTracker(
   private[this] val logger = LogFactory.getLog("XGBoostSpark")
 
   private[this] def numAliveCores: Int = {
-    sc.statusStore.executorList(true). map(_.totalCores).sum
+    sc.statusStore.executorList(true).map(_.totalCores).sum
   }
 
   private[this] def waitForCondition(


### PR DESCRIPTION
This PR propose a more stable approach to query total number of alive cores; fetch executor information via spark API `sc.statusStore.executorList` directly rather than using restful API of spark WebUI.

In addition,  I found a bug about `waitForCondition`. Query thread wrapped by `Future` will never exit if condition is not satisfied.  Because `Await.ready` will throw an exception without stopping the`Future` thread when timeout is reached. 

@CodingCat can you help to look this?