### PR TITLE
[jvm-package] Add case for LongParam.

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -260,6 +260,8 @@ private[spark] trait ParamMapFuncs extends Params {
           set(name, paramValue.toString.toInt)
         case _: FloatParam =>
           set(name, paramValue.toString.toFloat)
+        case _: LongParam =>
+          set(name, paramValue.toString.toLong)
         case _: Param[_] =>
           set(name, paramValue)
       }


### PR DESCRIPTION
To support specifying long parameter as String, the same as other basic
type, such as Int, Double ...