### PR TITLE
Resolve dask performance issues

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -369,6 +369,7 @@ def train(client, params, dtrain, *args, evals=(), **kwargs):
 
     futures = client.map(dispatched_train,
                          range(len(worker_map)),
+                         pure=False,
                          workers=list(worker_map.keys()))
     results = client.gather(futures)
     return list(filter(lambda ret: ret is not None, results))[0]
@@ -420,6 +421,7 @@ def predict(client, model, data, *args):
 
     futures = client.map(dispatched_predict,
                          range(len(worker_map)),
+                         pure=False,
                          workers=list(worker_map.keys()))
 
     def dispatched_get_shape(worker_id):
@@ -433,6 +435,7 @@ def predict(client, model, data, *args):
     # See https://docs.dask.org/en/latest/array-creation.html
     futures_shape = client.map(dispatched_get_shape,
                                range(len(worker_map)),
+                               pure=False,
                                workers=list(worker_map.keys()))
     shapes = client.gather(futures_shape)
     arrays = []

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -137,8 +137,6 @@ class DaskDMatrix:
 
         if len(data.shape) != 2:
             _expect('2 dimensions input', data.shape)
-        self.n_rows = data.shape[0]
-        self.n_cols = data.shape[1]
 
         if not any(isinstance(data, t) for t in (dd.DataFrame, da.Array)):
             raise TypeError(_expect((dd.DataFrame, da.Array), type(data)))
@@ -276,12 +274,6 @@ class DaskDMatrix:
             rows += shape[0]
             cols += shape[1]
         return (rows, cols)
-
-    def num_row(self):
-        return self.n_rows
-
-    def num_col(self):
-        return self.n_cols
 
 
 def _get_rabit_args(worker_map, client):

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -249,7 +249,6 @@ public:
     int current_device;
     safe_cuda(cudaGetDevice(&current_device));
     stats_.RegisterAllocation(ptr, n);
-    CHECK_LE(stats_.peak_allocated_bytes, dh::TotalMemory(current_device));
   }
   void RegisterDeallocation(void *ptr, size_t n) {
     if (!xgboost::ConsoleLogger::ShouldLog(xgboost::ConsoleLogger::LV::kDebug))


### PR DESCRIPTION
Resolves performance bug where dask attempts to generate hashes from nested functions with large arguments in client.map.

On the YearPredictMSD dataset this reduces runtime from 90s to 45s when using dask.