### PR TITLE
Warn when _validate_features sets feature_names

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1819,6 +1819,9 @@ class Booster(object):
         Set feature_names and feature_types from DMatrix
         """
         if self.feature_names is None:
+            warnings.warn("Booster's feature_names did not exist. Booster's "
+                          "feature_names and feature_types are being set to "
+                          "match the data.")
             self.feature_names = data.feature_names
             self.feature_types = data.feature_types
         else:


### PR DESCRIPTION
- Current behavior silently sets feature_names of Booster to
  match data when Booster.predict(X) is called on a loaded model
- Add warning to relevant section of Booster._validate_features
  so user is aware it is happening.
- Warning text: "Booster's feature_names did not exist. Booster's
  feature_names and feature_types are being set to match the data."
- Closes #4854