### PR TITLE
[CI] Raise timeout threshold in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
   options {
     ansiColor('xterm')
     timestamps()
-    timeout(time: 120, unit: 'MINUTES')
+    timeout(time: 240, unit: 'MINUTES')
     buildDiscarder(logRotator(numToKeepStr: '10'))
     preserveStashes()
   }


### PR DESCRIPTION
Raise timeout from 120 minutes to 240 minutes. I don't expect the actual tests to take this long, but sometimes, it takes a while for GPU workers to be allocated. I raised the limit for multi-GPU workers to ameliorate the bottleneck (*), but at the same time, we should raise the timeout just to be safe.

cc @trivialfis @RAMitchell 

(*) The limit is now 3. Thankfully, G4 instances are about 2x more affordable as P2 instances.