### PR TITLE
Use heuristic to select histogram node, avoid rabit call

### DIFF
--- a/tests/cpp/common/test_device_helpers.cu
+++ b/tests/cpp/common/test_device_helpers.cu
@@ -84,22 +84,3 @@ void TestAllocator() {
 TEST(bulkAllocator, Test) {
   TestAllocator();
 }
-
- // Test thread safe max reduction
-#if defined(XGBOOST_USE_NCCL)
-TEST(AllReducer, MGPU_HostMaxAllReduce) {
-  dh::AllReducer reducer;
-  size_t num_threads = 50;
-  std::vector<std::vector<size_t>> thread_data(num_threads);
-#pragma omp parallel num_threads(num_threads)
-  {
-    int tid = omp_get_thread_num();
-    thread_data[tid] = {size_t(tid)};
-    reducer.HostMaxAllReduce(&thread_data[tid]);
-  }
-
-  for (auto data : thread_data) {
-    ASSERT_EQ(data.front(), num_threads - 1);
-  }
-}
-#endif


### PR DESCRIPTION
This PR considerably improves performance for the distributed GPU algorithm. We use the sum of Hessian in the left and right node to estimate which has fewer training instances instead of using rabit to sync and calculate this exactly. In particular it improves latency.

Performance numbers from training on a DGX-1 with https://github.com/NVIDIA/gbm-bench

| dataset | old     | new      | speedup  |   
|---------|----------|----------|------|
| airline | 68.4073  | 59.2706  | 1.15 |
| bosch   | 20.12437 | 16.1119  | 1.25 |
| covtype | 81.049   | 59.8792  | 1.35 |
| epsilon | 306.2088 | 311.6957 | 0.98 |
| fraud   | 8.3944   | 6.7949   | 1.24 |
| higgs   | 34.4294  | 24.0335  | 1.43 |
| year    | 25.8719  | 15.3342  | 1.69 |

I also removed the old HostAllReduce function, which is redundant now that we no longer manage multiple GPUs with threads.