### PR TITLE
Use `UpdateAllowUnknown' for non-model related parameter.

### DIFF
--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -225,7 +225,7 @@ using GradientPairInteger = detail::GradientPairInternal<int64_t>;
 using Args = std::vector<std::pair<std::string, std::string> >;
 
 /*! \brief small eps gap for minimum split decision. */
-const bst_float kRtEps = 1e-6f;
+constexpr bst_float kRtEps = 1e-6f;
 
 /*! \brief define unsigned long for openmp loop */
 using omp_ulong = dmlc::omp_ulong;  // NOLINT

--- a/include/xgboost/generic_parameters.h
+++ b/include/xgboost/generic_parameters.h
@@ -5,14 +5,13 @@
 #ifndef XGBOOST_GENERIC_PARAMETERS_H_
 #define XGBOOST_GENERIC_PARAMETERS_H_
 
-#include <dmlc/parameter.h>
 #include <xgboost/logging.h>
 #include <xgboost/parameter.h>
 
 #include <string>
 
 namespace xgboost {
-struct GenericParameter : public dmlc::Parameter<GenericParameter> {
+struct GenericParameter : public XGBoostParameter<GenericParameter> {
   // stored random seed
   int seed;
   // whether seed the PRNG each iteration

--- a/include/xgboost/json.h
+++ b/include/xgboost/json.h
@@ -5,6 +5,7 @@
 #define XGBOOST_JSON_H_
 
 #include <xgboost/logging.h>
+#include <xgboost/parameter.h>
 #include <string>
 
 #include <map>
@@ -533,7 +534,7 @@ using Null    = JsonNull;
 // Utils tailored for XGBoost.
 
 template <typename Type>
-Object toJson(dmlc::Parameter<Type> const& param) {
+Object toJson(XGBoostParameter<Type> const& param) {
   Object obj;
   for (auto const& kv : param.__DICT__()) {
     obj[kv.first] = kv.second;
@@ -542,13 +543,13 @@ Object toJson(dmlc::Parameter<Type> const& param) {
 }
 
 template <typename Type>
-void fromJson(Json const& obj, dmlc::Parameter<Type>* param) {
+void fromJson(Json const& obj, XGBoostParameter<Type>* param) {
   auto const& j_param = get<Object const>(obj);
   std::map<std::string, std::string> m;
   for (auto const& kv : j_param) {
     m[kv.first] = get<String const>(kv.second);
   }
-  param->InitAllowUnknown(m);
+  param->UpdateAllowUnknown(m);
 }
 }  // namespace xgboost
 #endif  // XGBOOST_JSON_H_

--- a/include/xgboost/logging.h
+++ b/include/xgboost/logging.h
@@ -9,9 +9,10 @@
 #define XGBOOST_LOGGING_H_
 
 #include <dmlc/logging.h>
-#include <dmlc/parameter.h>
 #include <dmlc/thread_local.h>
+
 #include <xgboost/base.h>
+#include <xgboost/parameter.h>
 
 #include <sstream>
 #include <map>
@@ -35,7 +36,7 @@ class BaseLogger {
 };
 
 // Parsing both silent and debug_verbose is to provide backward compatibility.
-struct ConsoleLoggerParam : public dmlc::Parameter<ConsoleLoggerParam> {
+struct ConsoleLoggerParam : public XGBoostParameter<ConsoleLoggerParam> {
   bool silent;  // deprecated.
   int verbosity;
 

--- a/plugin/example/custom_obj.cc
+++ b/plugin/example/custom_obj.cc
@@ -5,7 +5,7 @@
  *  This plugin defines the additional metric function.
  */
 #include <xgboost/base.h>
-#include <dmlc/parameter.h>
+#include <xgboost/parameter.h>
 #include <xgboost/objective.h>
 #include <xgboost/json.h>
 
@@ -16,7 +16,7 @@ namespace obj {
 // You do not have to use it.
 // see http://dmlc-core.readthedocs.org/en/latest/parameter.html
 // for introduction of this module.
-struct MyLogisticParam : public dmlc::Parameter<MyLogisticParam> {
+struct MyLogisticParam : public XGBoostParameter<MyLogisticParam> {
   float scale_neg_weight;
   // declare parameters
   DMLC_DECLARE_PARAMETER(MyLogisticParam) {
@@ -32,7 +32,7 @@ DMLC_REGISTER_PARAMETER(MyLogisticParam);
 class MyLogistic : public ObjFunction {
  public:
   void Configure(const std::vector<std::pair<std::string, std::string> >& args) override {
-    param_.InitAllowUnknown(args);
+    param_.UpdateAllowUnknown(args);
   }
   void GetGradient(const HostDeviceVector<bst_float> &preds,
                    const MetaInfo &info,

--- a/plugin/lz4/sparse_page_lz4_format.cc
+++ b/plugin/lz4/sparse_page_lz4_format.cc
@@ -3,10 +3,11 @@
  * \file sparse_page_lz4_format.cc
  *  XGBoost Plugin to enable LZ4 compressed format on the external memory pages.
  */
+#include <dmlc/registry.h>
+
 #include <xgboost/data.h>
 #include <xgboost/logging.h>
-#include <dmlc/registry.h>
-#include <dmlc/parameter.h>
+#include <xgboost/parameter.h>
 #include <lz4.h>
 #include <lz4hc.h>
 #include "../../src/data/sparse_page_writer.h"

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # pylint: disable= invalid-name,  unused-import
-"""For compatibility"""
+"""For compatibility and optional dependencies."""
 
 from __future__ import absolute_import
 
@@ -16,22 +16,22 @@ if PY3:
     # pylint: disable=invalid-name, redefined-builtin
     STRING_TYPES = (str,)
 
-
     def py_str(x):
         """convert c string back to python string"""
         return x.decode('utf-8')
 else:
     STRING_TYPES = (basestring,)  # pylint: disable=undefined-variable
 
-
     def py_str(x):
         """convert c string back to python string"""
         return x
 
-########################################################################################
+
+###############################################################################
 # START NUMPY PATHLIB ATTRIBUTION
-########################################################################################
-# os.PathLike compatibility used in  Numpy: https://github.com/numpy/numpy/tree/v1.17.0
+###############################################################################
+# os.PathLike compatibility used in  Numpy:
+# https://github.com/numpy/numpy/tree/v1.17.0
 # Attribution:
 # https://github.com/numpy/numpy/blob/v1.17.0/numpy/compat/py3k.py#L188-L247
 # Backport os.fs_path, os.PathLike, and PurePath.__fspath__
@@ -55,7 +55,6 @@ else:
             if issubclass(subclass, PurePath):
                 return True
             return hasattr(subclass, '__fspath__')
-
 
     def os_fspath(path):
         """Return the path representation of a path-like object.
@@ -84,9 +83,9 @@ else:
         raise TypeError("expected {}.__fspath__() to return str or bytes, "
                         "not {}".format(path_type.__name__,
                                         type(path_repr).__name__))
-########################################################################################
+###############################################################################
 # END NUMPY PATHLIB ATTRIBUTION
-########################################################################################
+###############################################################################
 
 # pickle
 try:

--- a/src/cli_main.cc
+++ b/src/cli_main.cc
@@ -12,6 +12,8 @@
 #include <xgboost/learner.h>
 #include <xgboost/data.h>
 #include <xgboost/logging.h>
+#include <xgboost/parameter.h>
+
 #include <dmlc/timer.h>
 #include <iomanip>
 #include <ctime>
@@ -30,7 +32,7 @@ enum CLITask {
   kPredict = 2
 };
 
-struct CLIParam : public dmlc::Parameter<CLIParam> {
+struct CLIParam : public XGBoostParameter<CLIParam> {
   /*! \brief the task name */
   int task;
   /*! \brief whether evaluate training statistics */
@@ -123,7 +125,7 @@ struct CLIParam : public dmlc::Parameter<CLIParam> {
   // customized configure function of CLIParam
   inline void Configure(const std::vector<std::pair<std::string, std::string> >& _cfg) {
     this->cfg = _cfg;
-    this->InitAllowUnknown(_cfg);
+    this->UpdateAllowUnknown(_cfg);
     for (const auto& kv : _cfg) {
       if (!strncmp("eval[", kv.first.c_str(), 5)) {
         char evname[256];

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -25,7 +25,7 @@ namespace gbm {
 DMLC_REGISTRY_FILE_TAG(gblinear);
 
 // training parameters
-struct GBLinearTrainParam : public dmlc::Parameter<GBLinearTrainParam> {
+struct GBLinearTrainParam : public XGBoostParameter<GBLinearTrainParam> {
   std::string updater;
   float tolerance;
   size_t max_row_perbatch;
@@ -64,7 +64,7 @@ class GBLinear : public GradientBooster {
     if (model_.weight.size() == 0) {
       model_.param.InitAllowUnknown(cfg);
     }
-    param_.InitAllowUnknown(cfg);
+    param_.UpdateAllowUnknown(cfg);
     updater_.reset(LinearUpdater::Create(param_.updater, learner_param_));
     updater_->Configure(cfg);
     monitor_.Init("GBLinear");

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -34,7 +34,7 @@ DMLC_REGISTRY_FILE_TAG(gbtree);
 
 void GBTree::Configure(const Args& cfg) {
   this->cfg_ = cfg;
-  tparam_.InitAllowUnknown(cfg);
+  tparam_.UpdateAllowUnknown(cfg);
 
   model_.Configure(cfg);
 
@@ -295,7 +295,7 @@ class Dart : public GBTree {
   void Configure(const Args& cfg) override {
     GBTree::Configure(cfg);
     if (model_.trees.size() == 0) {
-      dparam_.InitAllowUnknown(cfg);
+      dparam_.UpdateAllowUnknown(cfg);
     }
   }
 

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -48,7 +48,7 @@ namespace xgboost {
 namespace gbm {
 
 /*! \brief training parameters */
-struct GBTreeTrainParam : public dmlc::Parameter<GBTreeTrainParam> {
+struct GBTreeTrainParam : public XGBoostParameter<GBTreeTrainParam> {
   /*!
    * \brief number of parallel trees constructed each iteration
    *  use this option to support boosted random forest
@@ -95,7 +95,7 @@ struct GBTreeTrainParam : public dmlc::Parameter<GBTreeTrainParam> {
 };
 
 /*! \brief training parameters */
-struct DartTrainParam : public dmlc::Parameter<DartTrainParam> {
+struct DartTrainParam : public XGBoostParameter<DartTrainParam> {
   /*! \brief type of sampling algorithm */
   int sample_type;
   /*! \brief type of normalization algorithm */

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -5,13 +5,8 @@
  * \author Tianqi Chen
  */
 #include <dmlc/io.h>
-#include <dmlc/timer.h>
-#include <dmlc/any.h>
-#include <xgboost/feature_map.h>
-#include <xgboost/learner.h>
-#include <xgboost/base.h>
-#include <xgboost/logging.h>
-#include <xgboost/generic_parameters.h>
+#include <dmlc/parameter.h>
+
 #include <algorithm>
 #include <iomanip>
 #include <limits>
@@ -21,6 +16,12 @@
 #include <utility>
 #include <vector>
 
+#include "xgboost/feature_map.h"
+#include "xgboost/learner.h"
+#include "xgboost/base.h"
+#include "xgboost/parameter.h"
+#include "xgboost/logging.h"
+#include "xgboost/generic_parameters.h"
 #include "xgboost/host_device_vector.h"
 #include "common/common.h"
 #include "common/io.h"
@@ -103,7 +104,7 @@ struct LearnerModelParam : public dmlc::Parameter<LearnerModelParam> {
   }
 };
 
-struct LearnerTrainParam : public dmlc::Parameter<LearnerTrainParam> {
+struct LearnerTrainParam : public XGBoostParameter<LearnerTrainParam> {
   // data split mode, can be row, col, or none.
   DataSplitMode dsplit;
   // flag to disable default metric
@@ -155,9 +156,9 @@ class LearnerImpl : public Learner {
     auto old_tparam = tparam_;
     Args args = {cfg_.cbegin(), cfg_.cend()};
 
-    tparam_.InitAllowUnknown(args);
+    tparam_.UpdateAllowUnknown(args);
 
-    generic_param_.InitAllowUnknown(args);
+    generic_param_.UpdateAllowUnknown(args);
     generic_param_.CheckDeprecated();
 
     ConsoleLogger::Configure(args);
@@ -208,7 +209,7 @@ class LearnerImpl : public Learner {
   }
 
   void Load(dmlc::Stream* fi) override {
-    generic_param_.InitAllowUnknown(Args{});
+    generic_param_.UpdateAllowUnknown(Args{});
     tparam_.Init(std::vector<std::pair<std::string, std::string>>{});
     // TODO(tqchen) mark deprecation of old format.
     common::PeekableInStream fp(fi);
@@ -314,7 +315,7 @@ class LearnerImpl : public Learner {
     cfg_.insert(n.cbegin(), n.cend());
 
     Args args = {cfg_.cbegin(), cfg_.cend()};
-    generic_param_.InitAllowUnknown(args);
+    generic_param_.UpdateAllowUnknown(args);
     gbm_->Configure(args);
     obj_->Configure({cfg_.begin(), cfg_.end()});
 

--- a/src/linear/coordinate_common.h
+++ b/src/linear/coordinate_common.h
@@ -10,6 +10,7 @@
 #include <limits>
 
 #include "xgboost/data.h"
+#include "xgboost/parameter.h"
 #include "./param.h"
 #include "../gbm/gblinear_model.h"
 #include "../common/random.h"
@@ -17,7 +18,7 @@
 namespace xgboost {
 namespace linear {
 
-struct CoordinateParam : public dmlc::Parameter<CoordinateParam> {
+struct CoordinateParam : public XGBoostParameter<CoordinateParam> {
   int top_k;
   DMLC_DECLARE_PARAMETER(CoordinateParam) {
     DMLC_DECLARE_FIELD(top_k)

--- a/src/linear/param.h
+++ b/src/linear/param.h
@@ -5,7 +5,7 @@
  */
 #ifndef XGBOOST_LINEAR_PARAM_H_
 #define XGBOOST_LINEAR_PARAM_H_
-#include <dmlc/parameter.h>
+#include "xgboost/parameter.h"
 
 namespace xgboost {
 namespace linear {
@@ -20,7 +20,7 @@ enum FeatureSelectorEnum {
   kRandom
 };
 
-struct LinearTrainParam : public dmlc::Parameter<LinearTrainParam> {
+struct LinearTrainParam : public XGBoostParameter<LinearTrainParam> {
   /*! \brief learning_rate */
   float learning_rate;
   /*! \brief regularization weight for L2 norm */

--- a/src/linear/updater_coordinate.cc
+++ b/src/linear/updater_coordinate.cc
@@ -26,9 +26,9 @@ class CoordinateUpdater : public LinearUpdater {
   // set training parameter
   void Configure(Args const& args) override {
     const std::vector<std::pair<std::string, std::string> > rest {
-      tparam_.InitAllowUnknown(args)
+      tparam_.UpdateAllowUnknown(args)
     };
-    cparam_.InitAllowUnknown(rest);
+    cparam_.UpdateAllowUnknown(rest);
     selector_.reset(FeatureSelector::Create(tparam_.feature_selector));
     monitor_.Init("CoordinateUpdater");
   }

--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018 by Contributors
+ * Copyright 2018-2019 by Contributors
  * \author Rory Mitchell
  */
 
@@ -36,7 +36,7 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
 
   // set training parameter
   void Configure(Args const& args) override {
-    tparam_.InitAllowUnknown(args);
+    tparam_.UpdateAllowUnknown(args);
     selector_.reset(FeatureSelector::Create(tparam_.feature_selector));
     monitor_.Init("GPUCoordinateUpdater");
   }

--- a/src/linear/updater_shotgun.cc
+++ b/src/linear/updater_shotgun.cc
@@ -15,7 +15,7 @@ class ShotgunUpdater : public LinearUpdater {
  public:
   // set training parameter
   void Configure(Args const& args) override {
-    param_.InitAllowUnknown(args);
+    param_.UpdateAllowUnknown(args);
     if (param_.feature_selector != kCyclic &&
         param_.feature_selector != kShuffle) {
       LOG(FATAL) << "Unsupported feature selector for shotgun updater.\n"

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -5,11 +5,12 @@
  * \author Tianqi Chen
  */
 #include <rabit/rabit.h>
-#include <dmlc/parameter.h>
-#include <xgboost/logging.h>
 
 #include <iostream>
 #include <map>
+
+#include "xgboost/parameter.h"
+#include "xgboost/logging.h"
 
 #if !defined(XGBOOST_STRICT_R_MODE) || XGBOOST_STRICT_R_MODE == 0
 // Override logging mechanism for non-R interfaces
@@ -51,7 +52,7 @@ bool ConsoleLogger::ShouldLog(LogVerbosity verbosity) {
 }
 
 void ConsoleLogger::Configure(Args const& args) {
-  param_.InitAllowUnknown(args);
+  param_.UpdateAllowUnknown(args);
   // Deprecated, but when trying to display deprecation message some R
   // tests trying to catch stdout will fail.
   if (param_.silent) {

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -327,7 +327,6 @@ struct EvalEWiseBase : public Metric {
     CHECK_EQ(preds.Size(), info.labels_.Size())
         << "label and prediction size not match, "
         << "hint: use merror or mlogloss for multi-class classification";
-    const auto ndata = static_cast<omp_ulong>(info.labels_.Size());
     int device = tparam_->gpu_id;
 
     auto result =

--- a/src/metric/metric_common.h
+++ b/src/metric/metric_common.h
@@ -5,7 +5,6 @@
 #ifndef XGBOOST_METRIC_METRIC_COMMON_H_
 #define XGBOOST_METRIC_METRIC_COMMON_H_
 
-#include <dmlc/parameter.h>
 #include "../common/common.h"
 
 namespace xgboost {

--- a/src/metric/multiclass_metric.cu
+++ b/src/metric/multiclass_metric.cu
@@ -172,7 +172,6 @@ struct EvalMClassBase : public Metric {
     CHECK_GE(nclass, 1U)
         << "mlogloss and merror are only used for multi-class classification,"
         << " use logloss for binary classification";
-    const auto ndata = static_cast<bst_omp_uint>(info.labels_.Size());
 
     int device = tparam_->gpu_id;
     auto result = reducer_.Reduce(*tparam_, device, nclass, info.weights_, info.labels_, preds);

--- a/src/objective/multiclass_obj.cu
+++ b/src/objective/multiclass_obj.cu
@@ -5,16 +5,18 @@
  * \author Tianqi Chen
  */
 #include <dmlc/omp.h>
-#include <dmlc/parameter.h>
-#include <xgboost/data.h>
-#include <xgboost/logging.h>
-#include <xgboost/objective.h>
+
 #include <vector>
 #include <algorithm>
 #include <limits>
 #include <utility>
 
+#include "xgboost/parameter.h"
+#include "xgboost/data.h"
+#include "xgboost/logging.h"
+#include "xgboost/objective.h"
 #include "xgboost/json.h"
+
 #include "../common/common.h"
 #include "../common/math.h"
 #include "../common/transform.h"

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -1,13 +1,13 @@
 /*!
  * Copyright 2017-2018 by Contributors
  */
-#include <dmlc/parameter.h>
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
 #include <thrust/fill.h>
 #include <memory>
 
+#include "xgboost/parameter.h"
 #include "xgboost/data.h"
 #include "xgboost/predictor.h"
 #include "xgboost/tree_model.h"

--- a/src/tree/gpu_hist/row_partitioner.cu
+++ b/src/tree/gpu_hist/row_partitioner.cu
@@ -1,4 +1,3 @@
-
 /*!
  * Copyright 2017-2019 XGBoost contributors
  */

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -7,20 +7,20 @@
 #ifndef XGBOOST_TREE_PARAM_H_
 #define XGBOOST_TREE_PARAM_H_
 
-#include <dmlc/parameter.h>
-#include <xgboost/data.h>
 #include <cmath>
 #include <cstring>
 #include <limits>
 #include <string>
 #include <vector>
 
+#include "xgboost/parameter.h"
+#include "xgboost/data.h"
 
 namespace xgboost {
 namespace tree {
 
 /*! \brief training parameters for regression tree */
-struct TrainParam : public dmlc::Parameter<TrainParam> {
+struct TrainParam : public XGBoostParameter<TrainParam> {
   // learning step size for a time
   float learning_rate;
   // minimum loss change required for a split

--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -5,6 +5,7 @@
  */
 #include <dmlc/json.h>
 #include <dmlc/registry.h>
+
 #include <algorithm>
 #include <unordered_set>
 #include <vector>
@@ -15,7 +16,8 @@
 #include <utility>
 
 #include "xgboost/logging.h"
-#include "xgboost/host_device_vector.h"
+#include "xgboost/parameter.h"
+
 #include "param.h"
 #include "split_evaluator.h"
 #include "../common/common.h"
@@ -67,7 +69,7 @@ bool SplitEvaluator::CheckFeatureConstraint(bst_uint nodeid, bst_uint featureid)
 }
 
 //! \brief Encapsulates the parameters for ElasticNet
-struct ElasticNetParams : public dmlc::Parameter<ElasticNetParams> {
+struct ElasticNetParams : public XGBoostParameter<ElasticNetParams> {
   bst_float reg_lambda;
   bst_float reg_alpha;
   // maximum delta update we can add in weight estimation
@@ -105,7 +107,7 @@ class ElasticNet final : public SplitEvaluator {
     }
   }
   void Init(const Args& args) override {
-    params_.InitAllowUnknown(args);
+    params_.UpdateAllowUnknown(args);
   }
 
   SplitEvaluator* GetHostClone() const override {
@@ -185,7 +187,7 @@ XGBOOST_REGISTER_SPLIT_EVALUATOR(ElasticNet, "elastic_net")
         split evaluator
 */
 struct MonotonicConstraintParams
-    : public dmlc::Parameter<MonotonicConstraintParams> {
+    : public XGBoostParameter<MonotonicConstraintParams> {
   std::vector<bst_int> monotone_constraints;
 
   DMLC_DECLARE_PARAMETER(MonotonicConstraintParams) {
@@ -212,7 +214,7 @@ class MonotonicConstraint final : public SplitEvaluator {
   void Init(const Args& args)
       override {
     inner_->Init(args);
-    params_.InitAllowUnknown(args);
+    params_.UpdateAllowUnknown(args);
     Reset();
   }
 
@@ -337,7 +339,7 @@ XGBOOST_REGISTER_SPLIT_EVALUATOR(MonotonicConstraint, "monotonic")
         split evaluator
 */
 struct InteractionConstraintParams
-    : public dmlc::Parameter<InteractionConstraintParams> {
+    : public XGBoostParameter<InteractionConstraintParams> {
   std::string interaction_constraints;
   bst_uint num_feature;
 
@@ -371,7 +373,7 @@ class InteractionConstraint final : public SplitEvaluator {
   void Init(const Args& args)
       override {
     inner_->Init(args);
-    params_.InitAllowUnknown(args);
+    params_.UpdateAllowUnknown(args);
     Reset();
   }
 

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -423,7 +423,7 @@ XGBOOST_REGISTER_TREE_IO(JsonGenerator, "json")
             return new JsonGenerator(fmap, attrs, with_stats);
           });
 
-struct GraphvizParam : public dmlc::Parameter<GraphvizParam> {
+struct GraphvizParam : public XGBoostParameter<GraphvizParam> {
   std::string yes_color;
   std::string no_color;
   std::string rankdir;
@@ -462,7 +462,7 @@ class GraphvizGenerator : public TreeGenerator {
  public:
   GraphvizGenerator(FeatureMap const& fmap, std::string const& attrs, bool with_stats) :
       TreeGenerator(fmap, with_stats) {
-    param_.InitAllowUnknown(std::map<std::string, std::string>{});
+    param_.UpdateAllowUnknown(std::map<std::string, std::string>{});
     using KwArg = std::map<std::string, std::map<std::string, std::string>>;
     KwArg kwargs;
     if (attrs.length() != 0) {

--- a/src/tree/updater_basemaker-inl.h
+++ b/src/tree/updater_basemaker-inl.h
@@ -31,7 +31,7 @@ namespace tree {
 class BaseMaker: public TreeUpdater {
  public:
   void Configure(const Args& args) override {
-    param_.InitAllowUnknown(args);
+    param_.UpdateAllowUnknown(args);
   }
 
  protected:

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -26,7 +26,7 @@ DMLC_REGISTRY_FILE_TAG(updater_colmaker);
 class ColMaker: public TreeUpdater {
  public:
   void Configure(const Args& args) override {
-    param_.InitAllowUnknown(args);
+    param_.UpdateAllowUnknown(args);
     spliteval_.reset(SplitEvaluator::Create(param_.split_evaluator));
     spliteval_->Init(args);
   }
@@ -773,7 +773,7 @@ class ColMaker: public TreeUpdater {
 class DistColMaker : public ColMaker {
  public:
   void Configure(const Args& args) override {
-    param_.InitAllowUnknown(args);
+    param_.UpdateAllowUnknown(args);
     pruner_.reset(TreeUpdater::Create("prune", tparam_));
     pruner_->Configure(args);
     spliteval_.reset(SplitEvaluator::Create(param_.split_evaluator));

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "xgboost/host_device_vector.h"
+#include "xgboost/parameter.h"
 #include "xgboost/span.h"
 
 #include "../common/common.h"
@@ -38,7 +39,7 @@ DMLC_REGISTRY_FILE_TAG(updater_gpu_hist);
 
 // training parameters specific to this algorithm
 struct GPUHistMakerTrainParam
-    : public dmlc::Parameter<GPUHistMakerTrainParam> {
+    : public XGBoostParameter<GPUHistMakerTrainParam> {
   bool single_precision_histogram;
   // number of rows in a single GPU batch
   int gpu_batch_nrows;
@@ -969,9 +970,9 @@ class GPUHistMakerSpecialised {
  public:
   GPUHistMakerSpecialised() : initialised_{false}, p_last_fmat_{nullptr} {}
   void Configure(const Args& args, GenericParameter const* generic_param) {
-    param_.InitAllowUnknown(args);
+    param_.UpdateAllowUnknown(args);
     generic_param_ = generic_param;
-    hist_maker_param_.InitAllowUnknown(args);
+    hist_maker_param_.UpdateAllowUnknown(args);
     device_ = generic_param_->gpu_id;
     CHECK_GE(device_, 0) << "Must have at least one device";
 
@@ -1107,7 +1108,7 @@ class GPUHistMakerSpecialised {
 class GPUHistMaker : public TreeUpdater {
  public:
   void Configure(const Args& args) override {
-    hist_maker_param_.InitAllowUnknown(args);
+    hist_maker_param_.UpdateAllowUnknown(args);
     float_maker_.reset();
     double_maker_.reset();
     if (hist_maker_param_.single_precision_histogram) {

--- a/src/tree/updater_prune.cc
+++ b/src/tree/updater_prune.cc
@@ -30,7 +30,7 @@ class TreePruner: public TreeUpdater {
 
   // set training parameter
   void Configure(const Args& args) override {
-    param_.InitAllowUnknown(args);
+    param_.UpdateAllowUnknown(args);
     syncher_->Configure(args);
   }
   // update the tree, do pruning

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -38,7 +38,7 @@ void QuantileHistMaker::Configure(const Args& args) {
     pruner_.reset(TreeUpdater::Create("prune", tparam_));
   }
   pruner_->Configure(args);
-  param_.InitAllowUnknown(args);
+  param_.UpdateAllowUnknown(args);
   is_gmat_initialized_ = false;
 
   // initialize the split evaluator

--- a/src/tree/updater_refresh.cc
+++ b/src/tree/updater_refresh.cc
@@ -22,7 +22,7 @@ DMLC_REGISTRY_FILE_TAG(updater_refresh);
 class TreeRefresher: public TreeUpdater {
  public:
   void Configure(const Args& args) override {
-    param_.InitAllowUnknown(args);
+    param_.UpdateAllowUnknown(args);
   }
   char const* Name() const override {
     return "refresh";

--- a/tests/ci_build/tidy.py
+++ b/tests/ci_build/tidy.py
@@ -244,7 +244,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Run clang-tidy.')
     parser.add_argument('--cpp', type=int, default=1)
     parser.add_argument('--cuda', type=int, default=1)
-    parser.add_argument('--use-dmlc-gtest', type=int, default=0,
+    parser.add_argument('--use-dmlc-gtest', type=int, default=1,
                         help='Whether to use gtest bundled in dmlc-core.')
     args = parser.parse_args()
 

--- a/tests/cpp/common/test_monitor.cc
+++ b/tests/cpp/common/test_monitor.cc
@@ -16,6 +16,8 @@ TEST(Monitor, Logging) {
 
   Args args = {std::make_pair("verbosity", "3")};
   ConsoleLogger::Configure(args);
+  ASSERT_EQ(ConsoleLogger::GlobalVerbosity(), ConsoleLogger::LogVerbosity::kDebug);
+
   testing::internal::CaptureStderr();
   run_monitor();
   std::string output = testing::internal::GetCapturedStderr();
@@ -28,6 +30,8 @@ TEST(Monitor, Logging) {
   run_monitor();
   output = testing::internal::GetCapturedStderr();
   ASSERT_EQ(output.size(), 0);
+
+  ConsoleLogger::Configure(Args{{"verbosity", "1"}});
 }
 }  // namespace common
 }  // namespace xgboost

--- a/tests/cpp/common/test_parameter.cc
+++ b/tests/cpp/common/test_parameter.cc
@@ -1,5 +1,9 @@
-#include <dmlc/parameter.h>
+/*!
+ * Copyright (c) by Contributors 2019
+ */
 #include <gtest/gtest.h>
+
+#include <xgboost/base.h>
 #include <xgboost/parameter.h>
 
 enum class Foo : int {
@@ -8,10 +12,10 @@ enum class Foo : int {
 
 DECLARE_FIELD_ENUM_CLASS(Foo);
 
-struct MyParam : dmlc::Parameter<MyParam> {
+struct MyEnumParam : xgboost::XGBoostParameter<MyEnumParam> {
   Foo foo;
   int bar;
-  DMLC_DECLARE_PARAMETER(MyParam) {
+  DMLC_DECLARE_PARAMETER(MyEnumParam) {
     DMLC_DECLARE_FIELD(foo)
       .set_default(Foo::kBar)
       .add_enum("bar", Foo::kBar)
@@ -23,10 +27,10 @@ struct MyParam : dmlc::Parameter<MyParam> {
   }
 };
 
-DMLC_REGISTER_PARAMETER(MyParam);
+DMLC_REGISTER_PARAMETER(MyEnumParam);
 
 TEST(EnumClassParam, Basic) {
-  MyParam param;
+  MyEnumParam param;
   std::map<std::string, std::string> kwargs{
     {"foo", "frog"}, {"bar", "10"}
   };
@@ -52,4 +56,45 @@ TEST(EnumClassParam, Basic) {
   // try setting non-existent enum value
   kwargs["foo"] = "human";
   ASSERT_THROW(param.Init(kwargs), dmlc::ParamError);
+}
+
+struct UpdatableParam : xgboost::XGBoostParameter<UpdatableParam> {
+  float f { 0.0f };
+  double d { 0.0 };
+
+  DMLC_DECLARE_PARAMETER(UpdatableParam) {
+    DMLC_DECLARE_FIELD(f)
+        .set_default(11.0f);
+    DMLC_DECLARE_FIELD(d)
+        .set_default(2.71828f);
+  }
+};
+
+DMLC_REGISTER_PARAMETER(UpdatableParam);
+
+TEST(XGBoostParameter, Update) {
+  {
+    UpdatableParam p;
+    auto constexpr kRtEps = xgboost::kRtEps;
+
+    p.UpdateAllowUnknown(xgboost::Args{});
+    // When it's not initialized, perform set_default.
+    ASSERT_NEAR(p.f, 11.0f, kRtEps);
+    ASSERT_NEAR(p.d, 2.71828f, kRtEps);
+
+    p.d = 3.14149;
+
+    p.UpdateAllowUnknown(xgboost::Args{{"f", "2.71828"}});
+    ASSERT_NEAR(p.f, 2.71828f, kRtEps);
+
+    // p.d is un-effected by the update.
+    ASSERT_NEAR(p.d, 3.14149, kRtEps);
+  }
+  {
+    UpdatableParam p;
+    auto constexpr kRtEps = xgboost::kRtEps;
+    p.UpdateAllowUnknown(xgboost::Args{{"f", "2.71828"}});
+    ASSERT_NEAR(p.f, 2.71828f, kRtEps);
+    ASSERT_NEAR(p.d, 2.71828, kRtEps);  // default
+  }
 }

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -11,7 +11,7 @@ TEST(GBTree, SelectTreeMethod) {
   size_t constexpr kCols = 10;
 
   GenericParameter generic_param;
-  generic_param.InitAllowUnknown(Args{});
+  generic_param.UpdateAllowUnknown(Args{});
   std::unique_ptr<GradientBooster> p_gbm{
     GradientBooster::Create("gbtree", &generic_param, {}, 0)};
   auto& gbtree = dynamic_cast<gbm::GBTree&> (*p_gbm);
@@ -36,7 +36,7 @@ TEST(GBTree, SelectTreeMethod) {
   ASSERT_EQ(tparam.predictor, "cpu_predictor");
 
 #ifdef XGBOOST_USE_CUDA
-  generic_param.InitAllowUnknown(Args{{"gpu_id", "0"}});
+  generic_param.UpdateAllowUnknown(Args{{"gpu_id", "0"}});
   gbtree.Configure({{"tree_method", "gpu_hist"}, {"num_feature", n_feat}});
   ASSERT_EQ(tparam.updater_seq, "grow_gpu_hist");
   ASSERT_EQ(tparam.predictor, "gpu_predictor");
@@ -64,7 +64,7 @@ TEST(GBTree, ChoosePredictor) {
   std::string n_feat = std::to_string(kCols);
   Args args {{"tree_method", "approx"}, {"num_feature", n_feat}};
   GenericParameter generic_param;
-  generic_param.InitAllowUnknown(Args{{"gpu_id", "0"}});
+  generic_param.UpdateAllowUnknown(Args{{"gpu_id", "0"}});
 
   auto& data = (*(p_mat->GetBatches<SparsePage>().begin())).data;
 

--- a/tests/cpp/objective/test_objective.cc
+++ b/tests/cpp/objective/test_objective.cc
@@ -9,7 +9,7 @@ TEST(Objective, UnknownFunction) {
   xgboost::ObjFunction* obj = nullptr;
   xgboost::GenericParameter tparam;
   std::vector<std::pair<std::string, std::string>> args;
-  tparam.InitAllowUnknown(args);
+  tparam.UpdateAllowUnknown(args);
 
   EXPECT_ANY_THROW(obj = xgboost::ObjFunction::Create("unknown_name", &tparam));
   EXPECT_NO_THROW(obj = xgboost::ObjFunction::Create("reg:squarederror", &tparam));

--- a/tests/cpp/objective/test_ranking_obj.cc
+++ b/tests/cpp/objective/test_ranking_obj.cc
@@ -38,7 +38,7 @@ TEST(Objective, DeclareUnifiedTest(PairwiseRankingGPair)) {
 
 TEST(Objective, DeclareUnifiedTest(NDCG_Json_IO)) {
   xgboost::GenericParameter tparam;
-  tparam.InitAllowUnknown(Args{});
+  tparam.UpdateAllowUnknown(Args{});
 
   std::unique_ptr<xgboost::ObjFunction> obj {
     xgboost::ObjFunction::Create("rank:ndcg", &tparam)

--- a/tests/cpp/test_logging.cc
+++ b/tests/cpp/test_logging.cc
@@ -53,6 +53,7 @@ TEST(Logging, Basic) {
   output = testing::internal::GetCapturedStderr();
   ASSERT_NE(output.find("Test Log Console"), std::string::npos);
 
+  args["silent"] = "False";
   args["verbosity"] = "1";  // restore
   ConsoleLogger::Configure({args.cbegin(), args.cend()});
 }

--- a/tests/cpp/tree/test_prune.cc
+++ b/tests/cpp/tree/test_prune.cc
@@ -33,7 +33,7 @@ TEST(Updater, Prune) {
 
   // prepare tree
   RegTree tree = RegTree();
-  tree.param.InitAllowUnknown(cfg);
+  tree.param.UpdateAllowUnknown(cfg);
   std::vector<RegTree*> trees {&tree};
   // prepare pruner
   std::unique_ptr<TreeUpdater> pruner(TreeUpdater::Create("prune", &lparam));

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -262,7 +262,7 @@ class QuantileHistMock : public QuantileHistMaker {
     gmat.Init((*dmat_).get(), kMaxBins);
 
     RegTree tree = RegTree();
-    tree.param.InitAllowUnknown(cfg_);
+    tree.param.UpdateAllowUnknown(cfg_);
 
     std::vector<GradientPair> gpair =
         { {0.23f, 0.24f}, {0.23f, 0.24f}, {0.23f, 0.24f}, {0.23f, 0.24f},
@@ -273,7 +273,7 @@ class QuantileHistMock : public QuantileHistMaker {
 
   void TestBuildHist() {
     RegTree tree = RegTree();
-    tree.param.InitAllowUnknown(cfg_);
+    tree.param.UpdateAllowUnknown(cfg_);
 
     size_t constexpr kMaxBins = 4;
     common::GHistIndexMatrix gmat;
@@ -284,7 +284,7 @@ class QuantileHistMock : public QuantileHistMaker {
 
   void TestEvaluateSplit() {
     RegTree tree = RegTree();
-    tree.param.InitAllowUnknown(cfg_);
+    tree.param.UpdateAllowUnknown(cfg_);
 
     builder_->TestEvaluateSplit(gmatb_, tree);
   }

--- a/tests/cpp/tree/test_refresh.cc
+++ b/tests/cpp/tree/test_refresh.cc
@@ -28,7 +28,7 @@ TEST(Updater, Refresh) {
 
   RegTree tree = RegTree();
   auto lparam = CreateEmptyGenericParam(GPUIDX);
-  tree.param.InitAllowUnknown(cfg);
+  tree.param.UpdateAllowUnknown(cfg);
   std::vector<RegTree*> trees {&tree};
   std::unique_ptr<TreeUpdater> refresher(TreeUpdater::Create("refresh", &lparam));
 


### PR DESCRIPTION
Model parameter can not pack an additional boolean value due to binary IO
format.  This commit deals only with non-model related parameter configuration.