### PR TITLE
[CI] Update lint configuration to support latest pylint convention

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -375,7 +375,7 @@ Create the ``build/`` directory and invoke CMake with option ``R_LIB=ON``. Make 
 
   mkdir build
   cd build
-  CC=gcc-7 CXX=g++-7 cmake .. -DR_LIB=ON
+  CC=gcc-8 CXX=g++-8 cmake .. -DR_LIB=ON
   make -j4
   make install
 

--- a/python-package/.pylintrc
+++ b/python-package/.pylintrc
@@ -4,7 +4,7 @@ ignore=tests
 
 extension-pkg-whitelist=numpy
 
-disable=unexpected-special-method-signature,too-many-nested-blocks,useless-object-inheritance
+disable=unexpected-special-method-signature,too-many-nested-blocks,useless-object-inheritance,import-outside-toplevel,unsubscriptable-object
 
 dummy-variables-rgx=(unused|)_.*
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -984,7 +984,7 @@ class DMatrix(object):
             # validate feature name
             try:
                 if not isinstance(feature_names, str):
-                    feature_names = [n for n in iter(feature_names)]
+                    feature_names = list(feature_names)
                 else:
                     feature_names = [feature_names]
             except TypeError:
@@ -1028,7 +1028,7 @@ class DMatrix(object):
 
             try:
                 if not isinstance(feature_types, str):
-                    feature_types = [n for n in iter(feature_types)]
+                    feature_types = list(feature_types)
                 else:
                     feature_types = [feature_types]
             except TypeError:

--- a/python-package/xgboost/tracker.py
+++ b/python-package/xgboost/tracker.py
@@ -153,8 +153,7 @@ class RabitTracker(object):
             except socket.error as e:
                 if e.errno in [98, 48]:
                     continue
-                else:
-                    raise
+                raise
         sock.listen(256)
         self.sock = sock
         self.hostIP = hostIP


### PR DESCRIPTION
As reported in https://github.com/dmlc/xgboost/pull/4873#issuecomment-544680495, the latest master branch is failing the lint check, probably because `pylint` package has been updated. This PR updates `.pylintrc` (with a few cosmetic code changes) to make the lint check pass again.

Also closes #4969, by using GCC 8 throughout the installation doc.