### PR TITLE
[CI] Use latest dask

### DIFF
--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -24,7 +24,7 @@ RUN \
     pip install pyyaml cpplint pylint astroid sphinx numpy scipy pandas matplotlib sh recommonmark guzzle_sphinx_theme mock \
                 breathe matplotlib graphviz pytest scikit-learn wheel kubernetes urllib3 && \
     pip install https://h2o-release.s3.amazonaws.com/datatable/stable/datatable-0.7.0/datatable-0.7.0-cp37-cp37m-linux_x86_64.whl && \
-    pip install "dask[complete]==2.6.0"
+    pip install "dask[complete]"
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -24,7 +24,7 @@ RUN \
     pip install pyyaml cpplint pylint astroid sphinx numpy scipy pandas matplotlib sh recommonmark guzzle_sphinx_theme mock \
                 breathe matplotlib graphviz pytest scikit-learn wheel kubernetes urllib3 && \
     pip install https://h2o-release.s3.amazonaws.com/datatable/stable/datatable-0.7.0/datatable-0.7.0-cp37-cp37m-linux_x86_64.whl && \
-    pip install "dask[complete]==2.0.0" distributed==2.0.1
+    pip install "dask[complete]==2.6.0"
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -24,7 +24,7 @@ RUN \
     pip install pyyaml cpplint pylint astroid sphinx numpy scipy pandas matplotlib sh recommonmark guzzle_sphinx_theme mock \
                 breathe matplotlib graphviz pytest scikit-learn wheel kubernetes urllib3 && \
     pip install https://h2o-release.s3.amazonaws.com/datatable/stable/datatable-0.7.0/datatable-0.7.0-cp37-cp37m-linux_x86_64.whl && \
-    pip install "dask[complete]==2.0.0"
+    pip install "dask[complete]==2.0.0" distributed==2.0.1
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.cudf
+++ b/tests/ci_build/Dockerfile.cudf
@@ -18,7 +18,7 @@ ENV PATH=/opt/python/bin:$PATH
 # Create new Conda environment with cuDF and dask
 RUN \
     conda create -n cudf_test -c rapidsai -c nvidia -c numba -c conda-forge -c anaconda \
-        cudf=0.9 python=3.7 anaconda::cudatoolkit=$CUDA_VERSION dask=2.6.0
+        cudf=0.9 python=3.7 anaconda::cudatoolkit=$CUDA_VERSION dask
 
 # Install other Python packages
 RUN \

--- a/tests/ci_build/Dockerfile.cudf
+++ b/tests/ci_build/Dockerfile.cudf
@@ -18,7 +18,7 @@ ENV PATH=/opt/python/bin:$PATH
 # Create new Conda environment with cuDF and dask
 RUN \
     conda create -n cudf_test -c rapidsai -c nvidia -c numba -c conda-forge -c anaconda \
-        cudf=0.9 python=3.7 anaconda::cudatoolkit=$CUDA_VERSION dask=2.0.0
+        cudf=0.9 python=3.7 anaconda::cudatoolkit=$CUDA_VERSION dask=2.6.0
 
 # Install other Python packages
 RUN \

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -17,7 +17,7 @@ ENV PATH=/opt/python/bin:$PATH
 # Install Python packages
 RUN \
     pip install numpy pytest scipy scikit-learn pandas matplotlib wheel kubernetes urllib3 graphviz && \
-    pip install "dask[complete]==2.0.0"
+    pip install "dask[complete]==2.0.0" distributed==2.0.1
 
 ENV GOSU_VERSION 1.10
 

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -17,7 +17,7 @@ ENV PATH=/opt/python/bin:$PATH
 # Install Python packages
 RUN \
     pip install numpy pytest scipy scikit-learn pandas matplotlib wheel kubernetes urllib3 graphviz && \
-    pip install "dask[complete]==2.6.0"
+    pip install "dask[complete]"
 
 ENV GOSU_VERSION 1.10
 

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -17,7 +17,7 @@ ENV PATH=/opt/python/bin:$PATH
 # Install Python packages
 RUN \
     pip install numpy pytest scipy scikit-learn pandas matplotlib wheel kubernetes urllib3 graphviz && \
-    pip install "dask[complete]==2.0.0" distributed==2.0.1
+    pip install "dask[complete]==2.6.0"
 
 ENV GOSU_VERSION 1.10
 


### PR DESCRIPTION
Dask tests are stuck and timing out due to dask/dask#5465: https://xgboost-ci.net/blue/organizations/jenkins/xgboost/detail/PR-4971/2/pipeline/40/#step-75-log-1677. The cause of the timeout is because one of dependencies of Dask, `distributed`, changed its semantics in recent versions in ways that are not compatible with Dask 2.0.0. Fix: Pin version of `distributed`.