### PR TITLE
[CI] Upload master branch artifacts to S3 root

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,7 +224,7 @@ def BuildCUDA(args) {
     if (args.cuda_version == '9.0') {
       echo 'Stashing Python wheel...'
       stash name: 'xgboost_whl_cuda9', includes: 'python-package/dist/*.whl'
-      path = ("${BRANCH_NAME}" == 'master') ? '/' : "${BRANCH_NAME}/"
+      path = ("${BRANCH_NAME}" == 'master') ? '' : "${BRANCH_NAME}/"
       s3Upload bucket: 'xgboost-nightly-builds', path: path, acl: 'PublicRead', workingDir: 'python-package/dist', includePathPattern:'**/*.whl'
       echo 'Stashing C++ test executable (testxgboost)...'
       stash name: 'xgboost_cpp_tests', includes: 'build/testxgboost'

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -92,7 +92,7 @@ def BuildWin64() {
     """
     echo 'Stashing Python wheel...'
     stash name: 'xgboost_whl', includes: 'python-package/dist/*.whl'
-    path = ("${BRANCH_NAME}" == 'master') ? '/' : "${BRANCH_NAME}/"
+    path = ("${BRANCH_NAME}" == 'master') ? '' : "${BRANCH_NAME}/"
     s3Upload bucket: 'xgboost-nightly-builds', path: path, acl: 'PublicRead', workingDir: 'python-package/dist', includePathPattern:'**/*.whl'
     echo 'Stashing C++ test executable (testxgboost)...'
     stash name: 'xgboost_cpp_tests', includes: 'build/testxgboost.exe'


### PR DESCRIPTION
This is a follow-up to #4976.

According to [this link](https://issues.jenkins-ci.org/browse/JENKINS-44835?focusedCommentId=302882&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-302882), path to root directory should be set as `""` (empty string), not `"/"`. The latter just creates a directory called `/`.