### PR TITLE
Use global leave index, small clean up for cpu hist.

### DIFF
--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2014-2019 by Contributors
+ * Copyright 2014-2020 by Contributors
  * \file tree_updater.h
  * \brief General primitive for tree learning,
  *   Updating a collection of trees given the information.
@@ -34,7 +34,7 @@ class TreeUpdater : public Configurable {
 
  public:
   /*! \brief virtual destructor */
-  virtual ~TreeUpdater() = default;
+  ~TreeUpdater() override = default;
   /*!
    * \brief Initialize the updater with given arguments.
    * \param args arguments to the objective function.
@@ -75,6 +75,107 @@ class TreeUpdater : public Configurable {
    * \param name Name of the tree updater.
    */
   static TreeUpdater* Create(const std::string& name, GenericParameter const* tparam);
+
+
+  /** \brief Used to demarcate a contiguous set of row indices associated with
+   * some tree node. */
+  struct Segment {
+    size_t begin {0};
+    size_t end {0};
+
+    Segment(size_t _begin, size_t _end) : begin(_begin), end(_end) {
+      CHECK_GE(end, begin);
+    }
+    Segment() = default;
+    size_t Size() const { return end - begin; }
+  };
+
+  /*!
+   * \brief A cache storing node id -> row indices, used by CPU/GPU histogram algorithm.
+   */
+  class LeafIndexContainer {
+    /*! \brief In here if you want to find the rows belong to a node nid, first you need to
+     * get the indices segment from ridx_segments[nid], then get the row index that
+     * represents position of row in input data X.
+     *
+     * mapping for node id -> rows.
+     * This looks like:
+     * node id      |    1    |    2   |
+     * rid_segments | {0, 3}  | {3, 5} |
+     * row_index    | 3, 5, 1 | 13, 31 |
+     */
+    /*! \brief Range of row index for each node, pointers into ridx below. */
+    std::vector<Segment> ridx_segments_;
+    HostDeviceVector<size_t> row_index_;
+
+   public:
+    using const_iterator = typename std::vector<Segment>::const_iterator; // NOLINT
+    using iterator = typename std::vector<Segment>::iterator;  // NOLINT
+    using value_type = Segment;                                // NOLINT
+    using pointer = value_type*;                               // NOLINT
+    using reference = value_type&;                             // NOLINT
+    using index_type = int32_t;  // NOLINT Node ID type
+
+    LeafIndexContainer() = default;
+
+    std::vector<Segment>::const_iterator cbegin() const {  // NOLINT
+      return ridx_segments_.cbegin();
+    }
+    std::vector<Segment>::const_iterator cend() const {  // NOLINT
+      return ridx_segments_.cend();
+    }
+
+    /*! \brief return corresponding element set given the node_id.  Span points to host
+     *  memory. */
+    common::Span<size_t const> HostRows(int32_t node_id) const;
+    common::Span<size_t> HostRows(int32_t node_id);
+
+    /*! \brief return corresponding element set given the node_id.  Span points to device
+     *  memory. */
+    common::Span<size_t const> DeviceRows(int32_t node_id) const;
+    common::Span<size_t> DeviceRows(int32_t node_id);
+
+    /*! \brief Returns the segment belonging to node id. */
+    Segment NodeSegment(int32_t node_id) const {
+      return ridx_segments_.at(node_id);
+    }
+
+    /*! \brief Initialize the storage.  Due to CPU/GPU hist have their own way of
+     *  initialization.  This only creates the storage and expand a root node which
+     *  specifies total number of rows. */
+    void Init(size_t num_rows, int device);
+    /*! \brief Returns a Span pointing to all row indices in host memory. */
+    common::Span<size_t> GetRows() {
+      auto* ptr = row_index_.HostVector().data();
+      auto size = row_index_.HostVector().size();
+      return common::Span<size_t>{ ptr, size };
+    }
+
+    /*! \brief Returns the row indices as HostDeviceVector. */
+    HostDeviceVector<size_t>& RowIndices() {
+      return this->row_index_;
+    }
+    /*! \brief Returns the row indices segments. */
+    auto RowSegments() -> decltype(this->ridx_segments_)& {
+      return this->ridx_segments_;
+    }
+
+    /*!
+     * \brief  Add a new node split to thie cache.
+     *
+     * \param node_id The node being split.
+     * \param left_count Number of rows assigned to left node.
+     * \param left_node_id left child ID.
+     * \param right_node_id right child ID.
+     */
+    void AddSplit(int32_t node_id, size_t left_count,
+                  int32_t left_node_id, int32_t right_node_id);
+
+    void Clear() {
+      this->row_index_.Resize(0);
+      this->ridx_segments_.clear();
+    }
+  };
 };
 
 /*!

--- a/src/tree/tree_updater.cc
+++ b/src/tree/tree_updater.cc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2015 by Contributors
+ * Copyright 2015-2020 by Contributors
  * \file tree_updater.cc
  * \brief Registry of tree updaters.
  */
@@ -22,6 +22,71 @@ TreeUpdater* TreeUpdater::Create(const std::string& name, GenericParameter const
   auto p_updater = (e->body)();
   p_updater->tparam_ = tparam;
   return p_updater;
+}
+
+
+void TreeUpdater::LeafIndexContainer::Init(size_t num_rows, int device) {
+  this->Clear();
+
+  Segment root {0, num_rows};
+
+  ridx_segments_.emplace_back(root);
+  if (device >= 0) {
+    row_index_.SetDevice(device);
+    row_index_.DeviceSpan();
+  }
+  row_index_.Resize(root.end);
+}
+
+common::Span<size_t const> TreeUpdater::LeafIndexContainer::HostRows(int32_t node_id) const {
+  return const_cast<LeafIndexContainer*>(this)->HostRows(node_id);
+}
+
+common::Span<size_t> TreeUpdater::LeafIndexContainer::HostRows(int32_t node_id) {
+  Segment seg { ridx_segments_.at(node_id) };
+  CHECK_LE(seg.end, this->row_index_.Size()) << "node_id: " << node_id;
+  // Avoids calling __host__ inside __host__ __device__
+  size_t* ptr = row_index_.HostPointer();
+  auto size = row_index_.Size();
+  if (seg.begin == seg.end) {
+    return common::Span<size_t>{};
+  } else {
+    return common::Span<size_t>{ptr, size}.subspan(
+        seg.begin, seg.end - seg.begin);
+  }
+}
+
+common::Span<size_t const> TreeUpdater::LeafIndexContainer::DeviceRows(int32_t node_id) const {
+  return const_cast<LeafIndexContainer*>(this)->DeviceRows(node_id);
+}
+
+common::Span<size_t> TreeUpdater::LeafIndexContainer::DeviceRows(int32_t node_id) {
+  Segment segment { ridx_segments_.at(node_id) };
+  CHECK_LE(segment.end, this->row_index_.Size());
+  auto span = row_index_.DeviceSpan();
+  if (segment.Size() == 0) {
+    return common::Span<size_t>();
+  }
+  return span.subspan(segment.begin, segment.end - segment.begin);
+}
+
+void TreeUpdater::LeafIndexContainer::AddSplit(int32_t node_id, size_t left_count,
+                                            int32_t left_node_id, int32_t right_node_id) {
+  Segment e = ridx_segments_.at(node_id);
+  CHECK_NE(e.end, 0) << "node_id:" << node_id << ", left:" << left_count;
+
+  size_t begin = e.begin;
+  size_t left_end = begin + left_count;
+
+  CHECK_GT(ridx_segments_.size(), 0);
+  ridx_segments_.resize(std::max(static_cast<int32_t>(ridx_segments_.size()),
+                                std::max(left_node_id, right_node_id) + 1), Segment(0, 0));
+
+  // ridx_segments_.
+  CHECK_LE(left_end, this->row_index_.Size());
+  ridx_segments_.at(left_node_id) = Segment(begin, left_end);
+  CHECK_LE(e.end, this->row_index_.Size()) << node_id;
+  ridx_segments_.at(right_node_id) = Segment(left_end, e.end);
 }
 
 }  // namespace xgboost


### PR DESCRIPTION
## Add LeaveIndexCache in TreeUpdater.

Now for both CPU Hist and GPU Hist, the leave cache is stored in gbtree and uses format similar to
original GPU Hist implementation.  Now the cache can be reused by other components that requires the leaf mapping.  As I couldn't find similar structure in approx and exact, so only hist method is implemented.

- Remove node_id from Elem.

In order to align with GPU Hist, also have small drop of memory usage.

- Remove row set collection.

Use LeaveIndexCache instead.

## Small clean up for CPU Hist.

- Remove pruner in CPU Hist.

Use pre-pruning instead of post-pruning.  Possibly fixing #4915 .

- Remove PerfMonitor.

Use common::Monitor instead.

- Remove duplicated dense partition.
- Remove unused variables.