### PR TITLE
attempt to fix repeated split and 0 cover nodes

### DIFF
--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -413,7 +413,7 @@ class ColMaker: public TreeUpdater {
               if ( proposed_split == fvalue ) {
                 e.best.Update(loss_chg, fid, e.last_fvalue,
                             d_step == -1, c, e.stats);
-              } else { 
+              } else {
                 e.best.Update(loss_chg, fid, proposed_split,
                             d_step == -1, c, e.stats);
               }
@@ -425,7 +425,7 @@ class ColMaker: public TreeUpdater {
               if ( proposed_split == fvalue ) {
                 e.best.Update(loss_chg, fid, e.last_fvalue,
                             d_step == -1, e.stats, c);
-              } else { 
+              } else {
                 e.best.Update(loss_chg, fid, proposed_split,
                             d_step == -1, e.stats, c);
               }

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -409,14 +409,26 @@ class ColMaker: public TreeUpdater {
               loss_chg = static_cast<bst_float>(
                   spliteval_->ComputeSplitScore(nid, fid, c, e.stats) -
                   snode_[nid].root_gain);
-              e.best.Update(loss_chg, fid, (fvalue + e.last_fvalue) * 0.5f,
+              bst_float proposed_split = (fvalue + e.last_fvalue) * 0.5f;
+              if ( proposed_split == fvalue ) {
+                e.best.Update(loss_chg, fid, e.last_fvalue,
                             d_step == -1, c, e.stats);
+              } else { 
+                e.best.Update(loss_chg, fid, proposed_split,
+                            d_step == -1, c, e.stats);
+              }
             } else {
               loss_chg = static_cast<bst_float>(
                   spliteval_->ComputeSplitScore(nid, fid, e.stats, c) -
                   snode_[nid].root_gain);
-              e.best.Update(loss_chg, fid, (fvalue + e.last_fvalue) * 0.5f,
+              bst_float proposed_split = (fvalue + e.last_fvalue) * 0.5f;
+              if ( proposed_split == fvalue ) {
+                e.best.Update(loss_chg, fid, e.last_fvalue,
                             d_step == -1, e.stats, c);
+              } else { 
+                e.best.Update(loss_chg, fid, proposed_split,
+                            d_step == -1, e.stats, c);
+              }
             }
           }
         }


### PR DESCRIPTION
This patch addresses the issue raised in https://github.com/dmlc/xgboost/issues/3826

I was able to determine that this situation arises when there is "spike" of data at a single floating point number having a slight increase in gain to split away.  The lack of numerical precision causes the split point calculation to fail to resolve between the observed values.  Then, the "<" logic of scoring the tree is different from the sort and split logic of the search.  

In this patch, I've simply tried to catch the loss of resolution and propose a different split in that situation.  Testing this on the example provided in the issue above, the split leading to the 0-cover nodes is shifted slightly (the tree structure below is similar to the previous tree), and the nodes on the other side of the tree are left unaffected.  See the new split values below.

0:C2 < -0.00652099587
1: **C1 < 27.9683361**
3:C0 < 526.223633
7:C0 < 2.30000001e-08
4:C0 < 1.49999995e-08
10:C2 < -0.00678067794
2:C1 < 23.9683456
5:C1 < 19.1684093
11:C0 < 9.99999972e-10
12:C2 < 0.006448247
6:C1 < 26.7018356
13:C2 < 0.0112791462
14:C0 < 0.524977624


For reference, here is the original tree structure:
0:C2 < -0.00652099587
1: **C1 < 27.9683342**
2:C1 < 23.9683456
3:C2 < -0.0164765697
4:C0 < 1.49999995e-08
5:C1 < 19.1684074
6:C1 < 26.7018356
8:C0 < 2.30000001e-08
10: **C1 < 27.9683342**
11:C0 < 9.99999972e-10
12:C2 < 0.006448247
13:C2 < 0.0112791462
14:C0 < 0.524977624