### PR TITLE
Allow using RandomState object from NumPy

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -230,6 +230,8 @@ class XGBModel(XGBModelBase):
             params['missing'] = None  # sklearn doesn't handle nan. see #4725
         if not params.get('eval_metric', True):
             del params['eval_metric']  # don't give as None param to Booster
+        if isinstance(params['random_state'], np.random.RandomState):
+            params['random_state'] = params['random_state'].randint(np.iinfo(np.int32).max)
         return params
 
     def get_xgb_params(self):

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -444,11 +444,21 @@ def test_split_value_histograms():
 
 
 def test_sklearn_random_state():
+    from sklearn.datasets import load_iris
+
     clf = xgb.XGBClassifier(random_state=402)
     assert clf.get_xgb_params()['random_state'] == 402
 
     clf = xgb.XGBClassifier(random_state=401)
     assert clf.get_xgb_params()['random_state'] == 401
+
+    random_state = np.random.RandomState(seed = 403)
+    iris = load_iris()
+    clf = xgb.XGBClassifier(booster='gblinear', n_estimators=100, random_state=random_state)
+    clf.fit(iris.data, iris.target)
+    random_state = np.random.RandomState(seed = 403)
+    assert isinstance(clf.get_xgb_params()['random_state'], int)
+
 
 
 def test_sklearn_n_jobs():


### PR DESCRIPTION
Trying to fix issue: https://github.com/dmlc/xgboost/issues/5030

Sometimes, SciKit Learn will pass a parameter `random_state` to model objects which is not an integer, but rather an instance of NumPy's MT19937 random state class. Objects from SciKit-Learn such as `RandomForestRegressor` are able to use this type of random state in addition to random seeds, but XGB at the time of writing only takes integers.

This is particularly problematic when trying to use XGBoost in pipelines - e.g. `IterativeImputer` from SciKit-Learn will fail to fit with objects from XGBoost's sklearn module.

This quick fix "solves" the issue by using the NumPy RandomState object to draw a random integer which is used as seed for XGBoost, rather than trying to copy this random state back and forth with the C++ MT19937 which is used by default by XGBoost.

(I wasn't able to compile and test, so I'm hoping that this PR will pass automatic tests once it's created)