### PR TITLE
fix: reset hit counter for next batch

### DIFF
--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -423,6 +423,7 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_num_bins) {
     for (bst_omp_uint idx = 0; idx < bst_omp_uint(nbins); ++idx) {
       for (size_t tid = 0; tid < nthread; ++tid) {
         hit_count[idx] += hit_count_tloc_[tid * nbins + idx];
+        hit_count_tloc_[tid * nbins + idx] = 0;  // reset for next batch
       }
     }
 


### PR DESCRIPTION
In `GHistIndexMatrix::Init` reset the temporary `hit_count_tloc_` for reuse in next loop iteration.
The bug is only triggered if there are multiple pages.

While there are no automated test case, this fix resulted in matching `hit_count` (and learning results) when comparing `SimpleDMatrix` and my custom multipage `DMatrix` implementation.