### PR TITLE
Use DART tree weights when computing SHAPs

### DIFF
--- a/amalgamation/xgboost-all0.cc
+++ b/amalgamation/xgboost-all0.cc
@@ -30,6 +30,7 @@
 // data
 #include "../src/data/data.cc"
 #include "../src/data/ellpack_page.cc"
+#include "../src/data/ellpack_page_source.cc"
 #include "../src/data/simple_csr_source.cc"
 #include "../src/data/simple_dmatrix.cc"
 #include "../src/data/sparse_page_raw_format.cc"

--- a/amalgamation/xgboost-all0.cc
+++ b/amalgamation/xgboost-all0.cc
@@ -29,8 +29,6 @@
 
 // data
 #include "../src/data/data.cc"
-#include "../src/data/ellpack_page.cc"
-#include "../src/data/ellpack_page_source.cc"
 #include "../src/data/simple_csr_source.cc"
 #include "../src/data/simple_dmatrix.cc"
 #include "../src/data/sparse_page_raw_format.cc"
@@ -41,6 +39,8 @@
 
 #if DMLC_ENABLE_STD_THREAD
 #include "../src/data/sparse_page_dmatrix.cc"
+#include "../src/data/ellpack_page.cc"
+#include "../src/data/ellpack_page_source.cc"
 #endif
 
 // tress

--- a/amalgamation/xgboost-all0.cc
+++ b/amalgamation/xgboost-all0.cc
@@ -32,6 +32,8 @@
 #include "../src/data/simple_csr_source.cc"
 #include "../src/data/simple_dmatrix.cc"
 #include "../src/data/sparse_page_raw_format.cc"
+#include "../src/data/ellpack_page.cc"
+#include "../src/data/ellpack_page_source.cc"
 
 // prediction
 #include "../src/predictor/predictor.cc"
@@ -39,8 +41,6 @@
 
 #if DMLC_ENABLE_STD_THREAD
 #include "../src/data/sparse_page_dmatrix.cc"
-#include "../src/data/ellpack_page.cc"
-#include "../src/data/ellpack_page_source.cc"
 #endif
 
 // tress

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -168,6 +168,7 @@ class Predictor {
                                    std::vector<bst_float>* out_contribs,
                                    const gbm::GBTreeModel& model,
                                    unsigned ntree_limit = 0,
+                                   std::vector<bst_float>* tree_weights = nullptr,
                                    bool approximate = false) = 0;
 
   /**

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -149,6 +149,7 @@ class Predictor {
    * \param [in,out]  out_contribs       The output feature contribs.
    * \param           model              Model to make predictions from.
    * \param           ntree_limit        (Optional) The ntree limit.
+   * \param           tree_weights       (Optional) Weights to multiply each tree by.
    * \param           approximate        Use fast approximate algorithm.
    * \param           condition          Condition on the condition_feature (0=no, -1=cond off, 1=cond on).
    * \param           condition_feature  Feature to condition on (i.e. fix) during calculations.
@@ -158,6 +159,7 @@ class Predictor {
                                    std::vector<bst_float>* out_contribs,
                                    const gbm::GBTreeModel& model,
                                    unsigned ntree_limit = 0,
+                                   std::vector<bst_float>* tree_weights = nullptr,
                                    bool approximate = false,
                                    int condition = 0,
                                    unsigned condition_feature = 0) = 0;

--- a/make/mingw64.mk
+++ b/make/mingw64.mk
@@ -25,6 +25,3 @@ USE_AZURE = 0
 # - librabit.a Normal distributed version.
 # - librabit_empty.a Non distributed mock version,
 LIB_RABIT = librabit_empty.a
-
-DMLC_CFLAGS = -DDMLC_ENABLE_STD_THREAD=0
-ADD_CFLAGS = -DDMLC_ENABLE_STD_THREAD=0

--- a/src/data/ellpack_page.cc
+++ b/src/data/ellpack_page.cc
@@ -10,6 +10,8 @@ namespace xgboost {
 
 class EllpackPageImpl {};
 
+EllpackPage::EllpackPage() = default;
+
 EllpackPage::EllpackPage(DMatrix* dmat, const BatchParam& param) {
   LOG(FATAL) << "Internal Error: XGBoost is not compiled with CUDA but EllpackPage is required";
 }

--- a/src/data/ellpack_page_source.cc
+++ b/src/data/ellpack_page_source.cc
@@ -3,8 +3,8 @@
  */
 #ifndef XGBOOST_USE_CUDA
 
+#include <xgboost/data.h>
 #include "ellpack_page_source.h"
-
 namespace xgboost {
 namespace data {
 

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -1,14 +1,14 @@
 /*!
  * Copyright 2019 XGBoost contributors
  */
-
-#include "ellpack_page_source.h"
-
 #include <memory>
 #include <utility>
 #include <vector>
 
 #include "../common/hist_util.h"
+
+#include "ellpack_page_source.h"
+#include "sparse_page_source.h"
 #include "ellpack_page.cuh"
 
 namespace xgboost {

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -9,7 +9,6 @@
 #include <memory>
 #include <string>
 
-#include "sparse_page_source.h"
 #include "../common/timer.h"
 
 namespace xgboost {

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -348,6 +348,14 @@ class Dart : public GBTree {
     return GBTree::UseGPU();
   }
 
+  void PredictContribution(DMatrix* p_fmat,
+                           std::vector<bst_float>* out_contribs,
+                           unsigned ntree_limit, bool approximate, int condition,
+                           unsigned condition_feature) override {
+    CHECK(configured_);
+    cpu_predictor_->PredictContribution(p_fmat, out_contribs, model_, ntree_limit, &weight_drop_, approximate);
+  }
+
  protected:
   friend class GBTree;
   // internal prediction loop

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -356,6 +356,14 @@ class Dart : public GBTree {
     cpu_predictor_->PredictContribution(p_fmat, out_contribs, model_, ntree_limit, &weight_drop_, approximate);
   }
 
+  void PredictInteractionContributions(DMatrix* p_fmat,
+                                       std::vector<bst_float>* out_contribs,
+                                       unsigned ntree_limit, bool approximate) override {
+    CHECK(configured_);
+    cpu_predictor_->PredictInteractionContributions(p_fmat, out_contribs, model_,
+                                                    ntree_limit, &weight_drop_, approximate);
+  }
+
  protected:
   friend class GBTree;
   // internal prediction loop

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -353,7 +353,8 @@ class Dart : public GBTree {
                            unsigned ntree_limit, bool approximate, int condition,
                            unsigned condition_feature) override {
     CHECK(configured_);
-    cpu_predictor_->PredictContribution(p_fmat, out_contribs, model_, ntree_limit, &weight_drop_, approximate);
+    cpu_predictor_->PredictContribution(p_fmat, out_contribs, model_,
+                                        ntree_limit, &weight_drop_, approximate);
   }
 
   void PredictInteractionContributions(DMatrix* p_fmat,

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -224,7 +224,7 @@ class GBTree : public GradientBooster {
                                        unsigned ntree_limit, bool approximate) override {
     CHECK(configured_);
     cpu_predictor_->PredictInteractionContributions(p_fmat, out_contribs, model_,
-                                                    ntree_limit, approximate);
+                                                    ntree_limit, nullptr, approximate);
   }
 
   std::vector<std::string> DumpModel(const FeatureMap& fmap,

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -216,7 +216,7 @@ class GBTree : public GradientBooster {
                            unsigned ntree_limit, bool approximate, int condition,
                            unsigned condition_feature) override {
     CHECK(configured_);
-    cpu_predictor_->PredictContribution(p_fmat, out_contribs, model_, ntree_limit, approximate);
+    cpu_predictor_->PredictContribution(p_fmat, out_contribs, model_, ntree_limit, nullptr, approximate);
   }
 
   void PredictInteractionContributions(DMatrix* p_fmat,

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -216,7 +216,8 @@ class GBTree : public GradientBooster {
                            unsigned ntree_limit, bool approximate, int condition,
                            unsigned condition_feature) override {
     CHECK(configured_);
-    cpu_predictor_->PredictContribution(p_fmat, out_contribs, model_, ntree_limit, nullptr, approximate);
+    cpu_predictor_->PredictContribution(p_fmat, out_contribs, model_,
+                                        ntree_limit, nullptr, approximate);
   }
 
   void PredictInteractionContributions(DMatrix* p_fmat,

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -349,10 +349,13 @@ class CPUPredictor : public Predictor {
     // Compute the difference in effects when conditioning on each of the features on and off
     // see: Axiomatic characterizations of probabilistic and
     //      cardinal-probabilistic interaction indices
-    PredictContribution(p_fmat, &contribs_diag, model, ntree_limit, tree_weights, approximate, 0, 0);
+    PredictContribution(p_fmat, &contribs_diag, model, ntree_limit,
+                        tree_weights, approximate, 0, 0);
     for (size_t i = 0; i < ncolumns + 1; ++i) {
-      PredictContribution(p_fmat, &contribs_off, model, ntree_limit, tree_weights, approximate, -1, i);
-      PredictContribution(p_fmat, &contribs_on, model, ntree_limit, tree_weights, approximate, 1, i);
+      PredictContribution(p_fmat, &contribs_off, model, ntree_limit,
+                          tree_weights, approximate, -1, i);
+      PredictContribution(p_fmat, &contribs_on, model, ntree_limit,
+                          tree_weights, approximate, 1, i);
 
       for (size_t j = 0; j < info.num_row_; ++j) {
         for (int l = 0; l < ngroup; ++l) {

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -330,6 +330,7 @@ class CPUPredictor : public Predictor {
 
   void PredictInteractionContributions(DMatrix* p_fmat, std::vector<bst_float>* out_contribs,
                                        const gbm::GBTreeModel& model, unsigned ntree_limit,
+                                       std::vector<bst_float>* tree_weights,
                                        bool approximate) override {
     const MetaInfo& info = p_fmat->Info();
     const int ngroup = model.param.num_output_group;
@@ -348,10 +349,10 @@ class CPUPredictor : public Predictor {
     // Compute the difference in effects when conditioning on each of the features on and off
     // see: Axiomatic characterizations of probabilistic and
     //      cardinal-probabilistic interaction indices
-    PredictContribution(p_fmat, &contribs_diag, model, ntree_limit, nullptr, approximate, 0, 0);
+    PredictContribution(p_fmat, &contribs_diag, model, ntree_limit, tree_weights, approximate, 0, 0);
     for (size_t i = 0; i < ncolumns + 1; ++i) {
-      PredictContribution(p_fmat, &contribs_off, model, ntree_limit, nullptr, approximate, -1, i);
-      PredictContribution(p_fmat, &contribs_on, model, ntree_limit, nullptr, approximate, 1, i);
+      PredictContribution(p_fmat, &contribs_off, model, ntree_limit, tree_weights, approximate, -1, i);
+      PredictContribution(p_fmat, &contribs_on, model, ntree_limit, tree_weights, approximate, 1, i);
 
       for (size_t j = 0; j < info.num_row_; ++j) {
         for (int l = 0; l < ngroup; ++l) {

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -408,6 +408,7 @@ class GPUPredictor : public xgboost::Predictor {
                                        std::vector<bst_float>* out_contribs,
                                        const gbm::GBTreeModel& model,
                                        unsigned ntree_limit,
+                                       std::vector<bst_float>* tree_weights,
                                        bool approximate) override {
     LOG(FATAL) << "Internal error: " << __func__
                << " is not implemented in GPU Predictor.";

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -397,6 +397,7 @@ class GPUPredictor : public xgboost::Predictor {
   void PredictContribution(DMatrix* p_fmat,
                            std::vector<bst_float>* out_contribs,
                            const gbm::GBTreeModel& model, unsigned ntree_limit,
+                           std::vector<bst_float>* tree_weights,
                            bool approximate, int condition,
                            unsigned condition_feature) override {
     LOG(FATAL) << "Internal error: " << __func__


### PR DESCRIPTION
Fixes #5036.

I edited `CPUPredictor::PredictContribution` to multiply each tree's contributions by the tree's DART weight before adding them. This makes SHAP sums equal predictions, as expected. ~~The bug likely still exists for the GPU predictor and for interaction SHAPs.~~ Both non-interaction SHAPs and interaction SHAPs are affected.

This PR contains a commit from #5058 in order to get it to compile. The commit can be rebased out once #5058 is merged.