### PR TITLE
[jvm-packages] Support specifying features via multiple columns

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/DataUtils.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/DataUtils.scala
@@ -182,7 +182,7 @@ object DataUtils extends Serializable {
 
   private[spark] def convertDataFrameToXGBLabeledPointRDDs(
       labelCol: Column,
-      featuresCols: Array[Column],
+      featuresCols: Seq[Column],
       weight: Column,
       baseMargin: Column,
       group: Option[Column],

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/DataUtils.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/DataUtils.scala
@@ -17,7 +17,6 @@
 package ml.dmlc.xgboost4j.scala.spark
 
 import ml.dmlc.xgboost4j.{LabeledPoint => XGBLabeledPoint}
-
 import org.apache.spark.HashPartitioner
 import org.apache.spark.ml.feature.{LabeledPoint => MLLabeledPoint}
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
@@ -26,6 +25,8 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Column, DataFrame, Row}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{FloatType, IntegerType}
+
+import scala.collection.mutable
 
 object DataUtils extends Serializable {
   private[spark] implicit class XGBLabeledPointFeatures(
@@ -180,7 +181,38 @@ object DataUtils extends Serializable {
     repartitionRDDs(deterministicPartition, numWorkers, arrayOfRDDs)
   }
 
+  private[spark] def compressValues(
+      rawValues: Seq[Any],
+      missing: Float): (Array[Int], Array[Float]) = {
+    val indices = mutable.ArrayBuilder.make[Int]
+    val values = mutable.ArrayBuilder.make[Float]
+    var featureIdx = 0
+    def keepCondition = (v: Float) => if (missing.isNaN) !v.isNaN else v != missing
+    // Build sparse array based on missing value directly from the raw rows
+    rawValues.foreach {rv =>
+      if (rv != null) {
+        val typedValue = rv match {
+          case _: Float => rv.asInstanceOf[Float]
+          case _: Double => rv.asInstanceOf[Double].toFloat
+          case _: Byte => rv.asInstanceOf[Byte].toFloat
+          case _: Short => rv.asInstanceOf[Short].toFloat
+          case _: Int => rv.asInstanceOf[Int].toFloat
+          case _: Long => rv.asInstanceOf[Long].toFloat
+          case _ => throw new RuntimeException(s"Unsupported type of feature value @index" +
+            s" $featureIdx, only numeric is allowed.")
+        }
+        if (keepCondition(typedValue)) {
+          indices += featureIdx
+          values += typedValue
+        }
+      } // else { Always remove null values }
+      featureIdx += 1
+    }
+    (indices.result, values.result)
+  }
+
   private[spark] def convertDataFrameToXGBLabeledPointRDDs(
+      missing: Float,
       labelCol: Column,
       featuresCols: Seq[Column],
       weight: Column,
@@ -205,13 +237,13 @@ object DataUtils extends Serializable {
     val arrayOfRDDs = dataFrames.toArray.map {
       df => df.select(selectedColumns: _*).rdd.map (row => {
         val (label, weight, baseMargin) = (row.getFloat(0), row.getFloat(1), row.getFloat(2))
-        val values = (fStartPos until fStartPos + featureSize).map(row.getAs[Float](_)).toArray
-        val xgbLp = hasGroup match {
-          // All are treated as Dense Data
-          case true => val group = row.getInt(row.size - 1)
-            XGBLabeledPoint(label, null, values, weight, group, baseMargin)
-          case false =>
-            XGBLabeledPoint(label, null, values, weight, baseMargin = baseMargin)
+        val rawValues = (fStartPos until fStartPos + featureSize).map(row.get)
+        val (indices, values) = compressValues(rawValues, missing)
+        val xgbLp = if (hasGroup) {
+          val group = row.getInt(row.size - 1)
+          XGBLabeledPoint(label, indices, values, weight, group, baseMargin)
+        } else {
+          XGBLabeledPoint(label, indices, values, weight, baseMargin = baseMargin)
         }
         attachPartitionKey(row, deterministicPartition, numWorkers, xgbLp)
       })

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -192,7 +192,9 @@ class XGBoostClassifier (
 
     val trainingSet: RDD[XGBLabeledPoint] = if ($(featuresCols).nonEmpty) {
       // Prefer multiple columns for features
-      DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)), $(featuresCols).map(col(_)),
+      val featureCols = dataset.schema.filter(sf => $(featuresCols).contains(sf.name))
+        .map(sf => col(sf.name))
+      DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)), featureCols,
         weight, baseMargin, None, $(numWorkers), needDeterministicRepartitioning,
         dataset.asInstanceOf[DataFrame]).head
     } else {
@@ -203,13 +205,13 @@ class XGBoostClassifier (
     val evalRDDMap = getEvalSets(xgboostParams).map {
       case (name, dataFrame) => (name,
         if ($(featuresCols).nonEmpty) {
-          DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)),
-            $(featuresCols).map(col(_)),
+          val featureCols = dataset.schema.filter(sf => $(featuresCols).contains(sf.name))
+            .map(sf => col(sf.name))
+          DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)), featureCols,
             weight, baseMargin, None, $(numWorkers), needDeterministicRepartitioning,
             dataFrame).head
         } else {
-          DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)),
-            col($(featuresCol)),
+          DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)), col($(featuresCol)),
             weight, baseMargin, None, $(numWorkers), needDeterministicRepartitioning,
             dataFrame).head
         })

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -187,7 +187,9 @@ class XGBoostRegressor (
     }
     val group = if (!isDefined(groupCol) || $(groupCol).isEmpty) lit(-1) else col($(groupCol))
     val trainingSet: RDD[XGBLabeledPoint] = if ($(featuresCols).nonEmpty) {
-      DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)), $(featuresCols).map(col(_)),
+      val featureCols = dataset.schema.filter(sf => $(featuresCols).contains(sf.name))
+        .map(sf => col(sf.name))
+      DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)), featureCols,
         weight, baseMargin, Some(group), $(numWorkers), needDeterministicRepartitioning,
         dataset.asInstanceOf[DataFrame]).head
     } else {
@@ -198,13 +200,13 @@ class XGBoostRegressor (
     val evalRDDMap = getEvalSets(xgboostParams).map {
       case (name, dataFrame) => (name,
         if ($(featuresCols).nonEmpty) {
-          DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)),
-            $(featuresCols).map(col(_)),
+          val featureCols = dataset.schema.filter(sf => $(featuresCols).contains(sf.name))
+            .map(sf => col(sf.name))
+          DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)), featureCols,
             weight, baseMargin, Some(group), $(numWorkers), needDeterministicRepartitioning,
             dataFrame).head
         } else {
-          DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)),
-            col($(featuresCol)),
+          DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)), col($(featuresCol)),
             weight, baseMargin, Some(group), $(numWorkers), needDeterministicRepartitioning,
             dataFrame).head
         })

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -56,6 +56,20 @@ class XGBoostRegressor (
 
   XGBoost2MLlibParams(xgboostParams)
 
+  protected override def validateAndTransformSchema(
+      schema: StructType,
+      fitting: Boolean,
+      featuresDataType: DataType): StructType = {
+    if ($(featuresCols).nonEmpty) {
+      super.validateAndTransformSchema(schema, fitting, $(labelCol))
+    } else {
+      super.validateAndTransformSchema(schema, fitting, featuresDataType)
+    }
+  }
+
+  // An overloaded version to support multiple columns for features.
+  def setFeaturesCol(value: Array[String]): this.type = set(featuresCols, value)
+
   def setWeightCol(value: String): this.type = set(weightCol, value)
 
   def setBaseMarginCol(value: String): this.type = set(baseMarginCol, value)
@@ -172,14 +186,28 @@ class XGBoostRegressor (
       col($(baseMarginCol))
     }
     val group = if (!isDefined(groupCol) || $(groupCol).isEmpty) lit(-1) else col($(groupCol))
-    val trainingSet: RDD[XGBLabeledPoint] = DataUtils.convertDataFrameToXGBLabeledPointRDDs(
-      col($(labelCol)), col($(featuresCol)), weight, baseMargin, Some(group),
-      $(numWorkers), needDeterministicRepartitioning, dataset.asInstanceOf[DataFrame]).head
+    val trainingSet: RDD[XGBLabeledPoint] = if ($(featuresCols).nonEmpty) {
+      DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)), $(featuresCols).map(col(_)),
+        weight, baseMargin, Some(group), $(numWorkers), needDeterministicRepartitioning,
+        dataset.asInstanceOf[DataFrame]).head
+    } else {
+      DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)), col($(featuresCol)),
+        weight, baseMargin, Some(group), $(numWorkers), needDeterministicRepartitioning,
+        dataset.asInstanceOf[DataFrame]).head
+    }
     val evalRDDMap = getEvalSets(xgboostParams).map {
       case (name, dataFrame) => (name,
-        DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)), col($(featuresCol)),
-          weight, baseMargin, Some(group), $(numWorkers), needDeterministicRepartitioning,
-          dataFrame).head)
+        if ($(featuresCols).nonEmpty) {
+          DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)),
+            $(featuresCols).map(col(_)),
+            weight, baseMargin, Some(group), $(numWorkers), needDeterministicRepartitioning,
+            dataFrame).head
+        } else {
+          DataUtils.convertDataFrameToXGBLabeledPointRDDs(col($(labelCol)),
+            col($(featuresCol)),
+            weight, baseMargin, Some(group), $(numWorkers), needDeterministicRepartitioning,
+            dataFrame).head
+        })
     }
     transformSchema(dataset.schema, logging = true)
     val derivedXGBParamMap = MLlib2XGBoostParams
@@ -233,6 +261,20 @@ class XGBoostRegressionModel private[ml] (
     this
   }
 
+  protected override def validateAndTransformSchema(
+      schema: StructType,
+      fitting: Boolean,
+      featuresDataType: DataType): StructType = {
+    if ($(featuresCols).nonEmpty) {
+      super.validateAndTransformSchema(schema, fitting, $(labelCol))
+    } else {
+      super.validateAndTransformSchema(schema, fitting, featuresDataType)
+    }
+  }
+
+  // An overloaded version to support multiple columns for features.
+  def setFeaturesCol(value: Array[String]): this.type = set(featuresCols, value)
+
   def setLeafPredictionCol(value: String): this.type = set(leafPredictionCol, value)
 
   def setContribPredictionCol(value: String): this.type = set(contribPredictionCol, value)
@@ -274,9 +316,18 @@ class XGBoostRegressionModel private[ml] (
             Rabit.init(rabitEnv.asJava)
           }
 
-          val features = batchRow.iterator.map(row => row.getAs[Vector]($(featuresCol)))
-
           import DataUtils._
+          val features = batchRow.iterator.map(row =>
+            if ($(featuresCols).nonEmpty) {
+              // Prefer multiple columns for features
+              val values = row.schema.filter(f => $(featuresCols).contains(f.name))
+                .map(f => row.get(row.schema.fieldIndex(f.name)).toString.toFloat).toArray
+              // All are treated as dense data
+              XGBLabeledPoint(0.0f, null, values)
+            } else {
+              row.getAs[Vector]($(featuresCol)).asXGB
+            })
+
           val cacheInfo = {
             if ($(useExternalMemory)) {
               s"$appName-${TaskContext.get().stageId()}-dtest_cache-" +
@@ -287,7 +338,7 @@ class XGBoostRegressionModel private[ml] (
           }
 
           val dm = new DMatrix(
-            XGBoost.processMissingValues(features.map(_.asXGB), $(missing)),
+            XGBoost.processMissingValues(features, $(missing)),
             cacheInfo)
           try {
             val Array(rawPredictionItr, predLeafItr, predContribItr) =

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -239,6 +239,27 @@ trait HasNumClass extends Params {
   final def getNumClass: Int = $(numClass)
 }
 
+/**
+ * Trait for param featuresCols. (default: Array.empty[String]) This trait may be changed or
+ * removed between minor versions.
+ *
+ * This is to support multiple columns for features.
+ */
+trait HasFeaturesCols extends Params {
+
+  /**
+   * Param for names of the multiple columns for features
+   * @group param
+   */
+  final val featuresCols: StringArrayParam = new StringArrayParam(this, "featuresCols",
+    "names of the multiple columns for features")
+
+  setDefault(featuresCols, Array.empty[String])
+
+  /** @group getParam */
+  final def getFeaturesCols: Array[String] = $(featuresCols)
+}
+
 private[spark] trait ParamMapFuncs extends Params {
 
   def XGBoost2MLlibParams(xgboostParams: Map[String, Any]): Unit = {

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/Utils.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/Utils.scala
@@ -16,6 +16,8 @@
 
 package ml.dmlc.xgboost4j.scala.spark.params
 
+import org.apache.spark.sql.types._
+
 // based on org.apache.spark.util copy /paste
 private[spark] object Utils {
 
@@ -29,5 +31,24 @@ private[spark] object Utils {
   def classForName(className: String): Class[_] = {
     Class.forName(className, true, getContextOrSparkClassLoader)
     // scalastyle:on classforname
+  }
+}
+
+// based on org.apache.spark.ml.util copy /paste
+private[spark] object SchemaUtils {
+
+  /**
+    * Check whether the given schema contains a column of the numeric data type.
+    * @param colName  column name
+    */
+  def checkNumericType(
+      schema: StructType,
+      colName: String,
+      msg: String = ""): Unit = {
+    val actualDataType = schema(colName).dataType
+    val message = if (msg != null && msg.trim.length > 0) " " + msg else ""
+    require(actualDataType.isInstanceOf[NumericType],
+      s"Column $colName must be of type numeric but was actually of type " +
+        s"${actualDataType.catalogString}.$message")
   }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/PerTest.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/PerTest.scala
@@ -21,6 +21,7 @@ import java.io.File
 import ml.dmlc.xgboost4j.{LabeledPoint => XGBLabeledPoint}
 import org.apache.spark.{SparkConf, SparkContext, TaskFailedListener}
 import org.apache.spark.sql._
+import org.apache.spark.sql.types._
 import org.scalatest.{BeforeAndAfterEach, FunSuite}
 
 import scala.math.min
@@ -106,5 +107,20 @@ trait PerTest extends BeforeAndAfterEach { self: FunSuite =>
 
     ss.createDataFrame(sc.parallelize(it.toList, numPartitions))
       .toDF("id", "label", "features", "group")
+  }
+
+  protected def buildDataFrameWithMulti(
+      labeledPoints: Seq[XGBLabeledPoint],
+      featureNames: Array[String],
+      numPartitions: Int = numWorkers): DataFrame = {
+    val it: Iterator[Row] = labeledPoints.iterator.zipWithIndex.map {
+      case (lp: XGBLabeledPoint, id: Int) => Row.merge(Row(id), Row(lp.label), Row(lp.values: _*))
+    }
+    val schema = StructType(
+      StructField("id", IntegerType)::
+      StructField("label", FloatType)::
+      featureNames.map(StructField(_, FloatType)).toList
+    )
+    ss.createDataFrame(sc.parallelize(it.toList, numPartitions), schema)
   }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/PerTest.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/PerTest.scala
@@ -123,4 +123,21 @@ trait PerTest extends BeforeAndAfterEach { self: FunSuite =>
     )
     ss.createDataFrame(sc.parallelize(it.toList, numPartitions), schema)
   }
+
+  protected def buildDataFrameWithMultiGroup(
+      labeledPoints: Seq[XGBLabeledPoint],
+      featureNames: Array[String],
+      numPartitions: Int = numWorkers): DataFrame = {
+    val it: Iterator[Row] = labeledPoints.iterator.zipWithIndex.map {
+      case (lp: XGBLabeledPoint, id: Int) =>
+        Row.merge(Row(id, lp.group), Row(lp.label), Row(lp.values: _*))
+    }
+    val schema = StructType(
+      StructField("id", IntegerType)::
+        StructField("group", IntegerType)::
+        StructField("label", FloatType)::
+        featureNames.map(StructField(_, FloatType)).toList
+    )
+    ss.createDataFrame(sc.parallelize(it.toList, numPartitions), schema)
+  }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/TrainTestData.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/TrainTestData.scala
@@ -99,6 +99,8 @@ object Ranking extends TrainTestData {
   private def getGroups(resource: String): Seq[Int] = {
     getResourceLines(resource).map(_.toInt).toList
   }
+
+  override def featureColNames: Array[String] = (1 to 3).map(i => s"feature$i").toArray
 }
 
 object Synthetic extends {

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/TrainTestData.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/TrainTestData.scala
@@ -59,6 +59,8 @@ trait TrainTestData {
       XGBLabeledPoint(label, null, values, 1f, group, Float.NaN)
     }.toList
   }
+
+  def featureColNames: Array[String] = (1 to 126).map(i => s"feature$i").toArray
 }
 
 object Classification extends TrainTestData {

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
@@ -320,6 +320,7 @@ class XGBoostClassifierSuite extends FunSuite with PerTest {
 
     val paramMap = Map(
       "eta" -> "1",
+      "missing" -> 0,
       "max_depth" -> "6",
       "silent" -> "1",
       "objective" -> "binary:logistic",

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
@@ -308,4 +308,43 @@ class XGBoostClassifierSuite extends FunSuite with PerTest {
     val xgb = new XGBoostClassifier(paramMap)
     xgb.fit(repartitioned)
   }
+
+  test("XGBoostClassifier using multiple columns should output the same probabilities with" +
+      " that of single column") {
+    // multiple feature columns version
+    val mTrainingDF = buildDataFrameWithMulti(Classification.train, Classification.featureColNames)
+    val mTestDF = buildDataFrameWithMulti(Classification.test, Classification.featureColNames)
+    // single feature column
+    val sTrainingDF = buildDataFrame(Classification.train)
+    val sTestDF = buildDataFrame(Classification.test)
+
+    val paramMap = Map(
+      "eta" -> "1",
+      "max_depth" -> "6",
+      "silent" -> "1",
+      "objective" -> "binary:logistic",
+      "num_round" -> 5,
+      "num_workers" -> numWorkers)
+
+    val mModel = new XGBoostClassifier(paramMap)
+      .setFeaturesCol(Classification.featureColNames)
+      .fit(mTrainingDF)
+    val mPrediction = mModel.transform(mTestDF).collect()
+      .map(row => (row.getAs[Int]("id"), row.getAs[DenseVector]("probability"))).toMap
+
+    val sModel = new XGBoostClassifier(paramMap).fit(sTrainingDF)
+    val sPrediction = sModel.transform(sTestDF).collect()
+      .map(row => (row.getAs[Int]("id"), row.getAs[DenseVector]("probability"))).toMap
+
+    assert(mPrediction.size === mTestDF.count)
+    assert(mPrediction.size === sPrediction.size)
+    (0 until mPrediction.size).foreach {
+      i =>
+        val mLen = mPrediction(i).values.length
+        assert(mLen === sPrediction(i).values.length)
+        (0 until mLen).foreach {
+          j => assert(mPrediction(i)(j) === sPrediction(i)(j))
+        }
+    }
+  }
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressorSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressorSuite.scala
@@ -217,6 +217,7 @@ class XGBoostRegressorSuite extends FunSuite with PerTest {
 
     val paramMap = Map(
       "eta" -> "1",
+      "missing" -> 0,
       "max_depth" -> "6",
       "silent" -> "1",
       "objective" -> "reg:squarederror",
@@ -242,7 +243,7 @@ class XGBoostRegressorSuite extends FunSuite with PerTest {
 
   test("ranking: using multiple columns should output the same predictions with" +
     " that of single column") {
-    val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
+    val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1", "missing" -> 0,
       "objective" -> "rank:pairwise", "num_workers" -> numWorkers, "num_round" -> 5,
       "group_col" -> "group")
 


### PR DESCRIPTION
**Why this PR?**
There are always more features than one in a classification/regression task, but currently the API to specify feature columns in Classifier/Regressor only supports one single column, which requires users to assemble the multiple feature columns into a `org.apache.spark.ml.linalg.Vector` before fitting to train/transform. It looks like somewhat complicated.

This PR aims at eliminating the step of vectorization for feature columns, then users can fit the loaded dataset directly by specifying the feature columns as an `Array[String]`. It not only makes the XGBoost-Spark easier to use, but also saves a lot of time to learn other transformers for vectorization, especially for novices at ML.

**What this PR?**
This PR introduces a new API `setFeaturesCol(value: Array[String]`, along with its implementation and related support.