### PR TITLE
Get `DeviceIdx` from DMatrix.

### DIFF
--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -124,8 +124,8 @@ class CSRAdapterBatch : public detail::NoMetaInfo {
       : row_ptr(row_ptr),
         feature_idx(feature_idx),
         values(values),
-        num_rows(num_rows),
         num_elements(num_elements),
+        num_rows(num_rows),
         num_features(num_features) {}
   const Line GetLine(size_t idx) const {
     size_t begin_offset = row_ptr[idx];
@@ -167,10 +167,11 @@ class DenseAdapterBatch : public detail::NoMetaInfo {
  public:
   DenseAdapterBatch(const float* values, size_t num_rows, size_t num_elements,
                     size_t num_features)
-      : num_features(num_features),
-        num_rows(num_rows),
+
+      : values(values),
         num_elements(num_elements),
-        values(values) {}
+        num_rows(num_rows),
+        num_features(num_features) {}
 
  private:
   class Line {

--- a/src/data/ellpack_page.cc
+++ b/src/data/ellpack_page.cc
@@ -12,6 +12,10 @@ class EllpackPageImpl {};
 
 EllpackPage::EllpackPage() = default;
 
+int32_t EllpackPage::DeviceIdx() const {
+  return -1;
+}
+
 EllpackPage::EllpackPage(DMatrix* dmat, const BatchParam& param) {
   LOG(FATAL) << "Internal Error: XGBoost is not compiled with CUDA but EllpackPage is required";
 }

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -2,7 +2,8 @@
  * Copyright 2019 XGBoost contributors
  */
 
-#include <xgboost/data.h>
+#include "xgboost/data.h"
+#include "xgboost/logging.h"
 
 #include "./ellpack_page.cuh"
 #include "../common/hist_util.h"
@@ -19,6 +20,12 @@ EllpackPage::~EllpackPage() = default;
 
 size_t EllpackPage::Size() const {
   return impl_->Size();
+}
+
+int32_t EllpackPage::DeviceIdx() const {
+  CHECK(impl_);
+  auto info = impl_->Info();
+  return info.device;
 }
 
 void EllpackPage::SetBaseRowId(size_t row_id) {
@@ -102,7 +109,7 @@ EllpackInfo::EllpackInfo(int device,
                          size_t row_stride,
                          const common::HistogramCuts& hmat,
                          dh::BulkAllocator* ba)
-    : is_dense(is_dense), row_stride(row_stride), n_bins(hmat.Ptrs().back()) {
+    : is_dense(is_dense), row_stride(row_stride), n_bins(hmat.Ptrs().back()), device{device} {
 
   ba->Allocate(device,
                &feature_segments, hmat.Ptrs().size(),

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -54,6 +54,8 @@ struct EllpackInfo {
   common::Span<uint32_t> feature_segments;
   /*! \brief Histogram cut values. Size equals to (bins per feature * number of features). */
   common::Span<bst_float> gidx_fvalue_map;
+  /*! \brief The GPU ID of stored data. */
+  int32_t device;
 
   EllpackInfo() = default;
 
@@ -220,6 +222,12 @@ class EllpackPageImpl {
    * @param hmat The histogram cuts of all the features.
    */
   void InitInfo(int device, bool is_dense, size_t row_stride, const common::HistogramCuts& hmat);
+  /*!
+   * \brief Return EllpackInfo of current Ellpack matrix.
+   */
+  EllpackInfo Info() const {
+    return matrix.info;
+  }
 
   /*!
    * \brief Initialize the buffer to store compressed features.

--- a/src/data/ellpack_page_source.cc
+++ b/src/data/ellpack_page_source.cc
@@ -29,15 +29,19 @@ bool EllpackPageSource::Next() {
 EllpackPage& EllpackPageSource::Value() {
   LOG(FATAL) << "Internal Error: "
                 "XGBoost is not compiled with CUDA but EllpackPageSource is required";
-  EllpackPage* page;
+  EllpackPage* page {nullptr};
   return *page;
 }
 
 const EllpackPage& EllpackPageSource::Value() const {
   LOG(FATAL) << "Internal Error: "
                 "XGBoost is not compiled with CUDA but EllpackPageSource is required";
-  EllpackPage* page;
+  EllpackPage* page {nullptr};
   return *page;
+}
+
+int32_t EllpackPageSource::DeviceIdx() const {
+  return -1;
 }
 
 }  // namespace data

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -32,6 +32,8 @@ class EllpackPageSourceImpl : public DataSource<EllpackPage> {
   EllpackPage& Value();
   const EllpackPage& Value() const override;
 
+  int32_t DeviceIdx() const { return device_; }
+
  private:
   /*! \brief Write Ellpack pages after accumulating them in memory. */
   void WriteEllpackPages(DMatrix* dmat, const std::string& cache_info) const;
@@ -68,6 +70,10 @@ EllpackPage& EllpackPageSource::Value() {
 
 const EllpackPage& EllpackPageSource::Value() const {
   return impl_->Value();
+}
+
+int32_t EllpackPageSource::DeviceIdx() const {
+  return impl_->DeviceIdx();
 }
 
 // Build the quantile sketch across the whole input data, then use the histogram cuts to compress

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -40,6 +40,7 @@ class EllpackPageSource : public DataSource<EllpackPage> {
   EllpackPage& Value();
   const EllpackPage& Value() const override;
 
+  int32_t DeviceIdx() const;
   const EllpackPageSourceImpl* Impl() const { return impl_.get(); }
   EllpackPageSourceImpl* Impl() { return impl_.get(); }
 

--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -152,6 +152,31 @@ class SimpleDMatrix : public DMatrix {
 
   bool SingleColBlock() const override;
 
+  int32_t DeviceIdx() const override {
+    CHECK(source_);
+    if (!!ellpack_page_) {
+      return ellpack_page_->DeviceIdx();
+    } else if (!!column_page_) {
+      return column_page_->DeviceIdx();
+    } else if (!!sorted_column_page_) {
+      return sorted_column_page_->DeviceIdx();
+    } else  {
+      return dynamic_cast<SimpleCSRSource*>(source_.get())->page_.DeviceIdx();
+    }
+  }
+
+  bool DeviceCanRead() const override {
+    if (!!ellpack_page_) {
+      return true;
+    } else if (!!column_page_) {
+      return column_page_->DeviceCanRead();
+    } else if (!!sorted_column_page_) {
+      return sorted_column_page_->DeviceCanRead();
+    } else {
+      return dynamic_cast<SimpleCSRSource*>(source_.get())->page_.DeviceCanRead();
+    }
+  }
+
  private:
   BatchSet<SparsePage> GetRowBatches() override;
   BatchSet<CSCPage> GetColumnBatches() override;

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -41,6 +41,20 @@ class SparsePageDMatrix : public DMatrix {
   BatchSet<SortedCSCPage> GetSortedColumnBatches() override;
   BatchSet<EllpackPage> GetEllpackBatches(const BatchParam& param) override;
 
+  int32_t DeviceIdx() const override {
+    if (!!ellpack_source_) {
+      return ellpack_source_->DeviceIdx();
+    }
+    return -1;
+  }
+
+  bool DeviceCanRead() const override {
+    if (!!ellpack_source_) {
+      return true;
+    }
+    return false;
+  }
+
   // source data pointers.
   std::unique_ptr<DataSource<SparsePage>> row_source_;
   std::unique_ptr<SparsePageSource<CSCPage>> column_source_;

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -247,7 +247,7 @@ class GBTree : public GradientBooster {
   std::unique_ptr<Predictor> const& GetPredictor(HostDeviceVector<float> const* out_pred = nullptr,
                                                  DMatrix* f_dmat = nullptr) const {
     CHECK(configured_);
-    auto on_device = f_dmat && (*(f_dmat->GetBatches<SparsePage>().begin())).data.DeviceCanRead();
+    auto on_device = f_dmat && (*(f_dmat->GetBatches<SparsePage>().begin())).DeviceCanRead();
 #if defined(XGBOOST_USE_CUDA)
     // Use GPU Predictor if data is already on device.
     if (!specified_predictor_ && on_device) {

--- a/tests/cpp/data/test_adapter.cc
+++ b/tests/cpp/data/test_adapter.cc
@@ -9,7 +9,6 @@
 #include "../helpers.h"
 using namespace xgboost;  // NOLINT
 TEST(c_api, CSRAdapter) {
-  int m = 3;
   int n = 2;
   std::vector<float> data = {1, 2, 3, 4, 5};
   std::vector<unsigned> feature_idx = {0, 1, 0, 1, 1};

--- a/tests/cpp/data/test_data.cc
+++ b/tests/cpp/data/test_data.cc
@@ -135,6 +135,8 @@ TEST(DMatrix, DeviceIdx) {
   auto pp_dmat = CreateDMatrix(kRows, kCols, 0);
   auto& p_dmat = *pp_dmat;
   ASSERT_EQ(p_dmat->DeviceIdx(), -1);
+
+#if defined(XGBOOST_USE_CUDA)
   auto& data = (*p_dmat->GetBatches<SparsePage>().begin()).data;
   data.SetDevice(0);
   auto& offset = (*p_dmat->GetBatches<SparsePage>().begin()).offset;
@@ -150,6 +152,7 @@ TEST(DMatrix, DeviceIdx) {
   data.HostVector();
   offset.HostVector();
   ASSERT_FALSE(p_dmat->DeviceCanRead());
+#endif  // defined(XGBOOST_USE_CUDA)
 
   delete pp_dmat;
 }

--- a/tests/cpp/data/test_simple_csr_source.cu
+++ b/tests/cpp/data/test_simple_csr_source.cu
@@ -117,6 +117,7 @@ TEST(SimpleCSRSource, FromColumnarDense) {
   {
     std::unique_ptr<data::SimpleCSRSource> source (new data::SimpleCSRSource());
     source->CopyFrom(str.c_str(), false);
+    ASSERT_EQ(source->page_.DeviceIdx(), 0);
     TestDenseColumn(source, kRows, kCols);
   }
 
@@ -124,6 +125,7 @@ TEST(SimpleCSRSource, FromColumnarDense) {
   {
     std::unique_ptr<data::SimpleCSRSource> source (new data::SimpleCSRSource());
     source->CopyFrom(str.c_str(), true, 4.0);
+    ASSERT_EQ(source->page_.DeviceIdx(), 0);
 
     auto const& data = source->page_.data.HostVector();
     auto const& offset = source->page_.offset.HostVector();
@@ -143,6 +145,7 @@ TEST(SimpleCSRSource, FromColumnarDense) {
     d_data_0[3] = std::numeric_limits<float>::quiet_NaN();
     ASSERT_TRUE(std::isnan(d_data_0[3]));  // removes 6.0
     source->CopyFrom(str.c_str(), false);
+    ASSERT_EQ(source->page_.DeviceIdx(), 0);
 
     auto const& data = source->page_.data.HostVector();
     auto const& offset = source->page_.offset.HostVector();
@@ -217,6 +220,7 @@ TEST(SimpleCSRSource, FromColumnarWithEmptyRows) {
   std::string str = ss.str();
   std::unique_ptr<data::SimpleCSRSource> source (new data::SimpleCSRSource());
   source->CopyFrom(str.c_str(), false);
+  ASSERT_EQ(source->page_.DeviceIdx(), 0);
 
   auto const& data = source->page_.data.HostVector();
   auto const& offset = source->page_.offset.HostVector();
@@ -356,6 +360,8 @@ TEST(SimpleCSRSource, FromColumnarSparse) {
     source->CopyFrom(str.c_str(), true,
                      /*missing=*/std::numeric_limits<float>::quiet_NaN());
 
+    ASSERT_EQ(source->page_.DeviceIdx(), 0);
+
     auto const& data = source->page_.data.HostVector();
     ASSERT_EQ(data.size(), kRows * kCols - 1);
     ASSERT_EQ(data[8].fvalue, 4.0);
@@ -381,6 +387,8 @@ TEST(SimpleCSRSource, Types) {
 
   std::unique_ptr<data::SimpleCSRSource> source (new data::SimpleCSRSource());
   source->CopyFrom(str.c_str(), false);
+  ASSERT_EQ(source->page_.DeviceIdx(), 0);
+
   TestDenseColumn(source, kRows, kCols);
 }
 

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -49,6 +49,7 @@ TEST(GBTree, SelectTreeMethod) {
 
 #ifdef XGBOOST_USE_CUDA
 TEST(GBTree, ChoosePredictor) {
+  // This test ensures data doesn't get copied into GPU.
   size_t constexpr kNumRows = 17;
   size_t constexpr kCols = 15;
   auto pp_mat = CreateDMatrix(kNumRows, kCols, 0);
@@ -67,6 +68,7 @@ TEST(GBTree, ChoosePredictor) {
   generic_param.UpdateAllowUnknown(Args{{"gpu_id", "0"}});
 
   auto& data = (*(p_mat->GetBatches<SparsePage>().begin())).data;
+  auto& offset = (*(p_mat->GetBatches<SparsePage>().begin())).offset;
 
   auto learner = std::unique_ptr<Learner>(Learner::Create(mat));
   learner->SetParams(Args{{"tree_method", "gpu_hist"}});
@@ -96,6 +98,7 @@ TEST(GBTree, ChoosePredictor) {
 
   // pull data into device.
   data = HostDeviceVector<Entry>(data.HostVector(), 0);
+  offset = HostDeviceVector<bst_row_t>(offset.HostVector(), 0);
   data.DeviceSpan();
   ASSERT_FALSE(data.HostCanWrite());
 


### PR DESCRIPTION
As previously discussed with @RAMitchell , we need a way to query whether data is on device.  Also to resolve| #5003 , we need a precise documentable way to configure the GPU ID without incurring memory copy.  Right now the `gpu_id` is effected by:

1. User provided parameter `gpu_id`.
2. Input data, when input is from device (cudf), the `gpu_id` is set to the one found from input pointer.
3. Tree method.  When tree method is set to `gpu_hist`, without above conditions, `gpu_id` is set to 0.
4. Predictor.  When predictor is set to `gpu_predictor`, without 1 and 2, `gpu_id` is set to 0.
5. Loaded pickle, which may contain `gpu_id`, `tree_method`, `predictor`....

I don't have a clear plan for how to deal with this configuration yet.  As what if a user put in a cudf dataframe then set tree method to cpu hist?  How do we choose the predictor?

So this PR deals with adding APIs for observing device id from input data, which should be useful for whatever heuristics we want to adopt in the future.