### PR TITLE
[CI] Locate vcomp140.dll from System32 directory

### DIFF
--- a/tests/ci_build/insert_vcomp140.py
+++ b/tests/ci_build/insert_vcomp140.py
@@ -7,7 +7,7 @@ if len(sys.argv) != 2:
     print('Usage: {} [wheel]'.format(sys.argv[0]))
     sys.exit(1)
 
-vcomp140_path = 'C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\14.0\\VC\\redist\\x64\\Microsoft.VC140.OpenMP\\vcomp140.dll'
+vcomp140_path = 'C:\\Windows\\System32\\vcomp140.dll'
 
 for wheel_path in sorted(glob.glob(sys.argv[1])):
     m = re.search(r'xgboost-(.*)-py2.py3', wheel_path)


### PR DESCRIPTION
After I re-built Jenkins testing pipeline from scratch, I found out that I cannot always expect the path `C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\14.0\\VC\\redist\\x64\\Microsoft.VC140.OpenMP\\vcomp140.dll` to exist. Since vcomp140.dll is a system lib, it's better to use `C:\\Windows\\System32\\vcomp140.dll`