### PR TITLE
Update python install script to fix MacOS build error (#4933).

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -98,11 +98,11 @@ Building on OSX
 Install with pip: simple method
 --------------------------------
 
-First, obtain ``gcc-8`` with Homebrew (https://brew.sh/) to enable multi-threading (i.e. using multiple CPU threads for training). The default Apple Clang compiler does not support OpenMP, so using the default compiler would have disabled multi-threading.
+First, obtain ``gcc-9`` and ``OpenMP`` with Homebrew (https://brew.sh/) to enable multi-threading (i.e. using multiple CPU threads for training). The default Apple Clang compiler does not support OpenMP, so using the default compiler would have disabled multi-threading.
 
 .. code-block:: bash
 
-  brew install gcc@8
+  brew install gcc@9 libomp
 
 Then install XGBoost with ``pip``:
 
@@ -128,7 +128,7 @@ Now clone the repository:
 
   git clone --recursive https://github.com/dmlc/xgboost
 
-Create the ``build/`` directory and invoke CMake. Make sure to add ``CC=gcc-8 CXX=g++-8`` so that Homebrew GCC is selected. After invoking CMake, you can build XGBoost with ``make``:
+Create the ``build/`` directory and invoke CMake. Make sure to add ``CC=gcc-9 CXX=g++-9`` so that Homebrew GCC is selected. After invoking CMake, you can build XGBoost with ``make``:
 
 .. code-block:: bash
 
@@ -359,11 +359,11 @@ If all fails, try `Building the shared library`_ to see whether a problem is spe
 Installing R package on Mac OSX with multi-threading
 ----------------------------------------------------
 
-First, obtain ``gcc-8`` with Homebrew (https://brew.sh/) to enable multi-threading (i.e. using multiple CPU threads for training). The default Apple Clang compiler does not support OpenMP, so using the default compiler would have disabled multi-threading.
+First, obtain ``gcc-9`` and ``OpenMP`` with Homebrew (https://brew.sh/) to enable multi-threading (i.e. using multiple CPU threads for training). The default Apple Clang compiler does not support OpenMP, so using the default compiler would have disabled multi-threading.
 
 .. code-block:: bash
 
-  brew install gcc@8
+  brew install gcc@9 libomp
 
 Now, clone the repository:
 
@@ -371,13 +371,13 @@ Now, clone the repository:
 
   git clone --recursive https://github.com/dmlc/xgboost
 
-Create the ``build/`` directory and invoke CMake with option ``R_LIB=ON``. Make sure to add ``CC=gcc-8 CXX=g++-8`` so that Homebrew GCC is selected. After invoking CMake, you can install the R package by running ``make`` and ``make install``:
+Create the ``build/`` directory and invoke CMake with option ``R_LIB=ON``. Make sure to add ``CC=gcc-9 CXX=g++-9`` so that Homebrew GCC is selected. After invoking CMake, you can install the R package by running ``make`` and ``make install``:
 
 .. code-block:: bash
 
   mkdir build
   cd build
-  CC=gcc-8 CXX=g++-8 cmake .. -DR_LIB=ON
+  CC=gcc-9 CXX=g++-9 cmake .. -DR_LIB=ON
   make -j4
   make install
 

--- a/python-package/xgboost/build-python.sh
+++ b/python-package/xgboost/build-python.sh
@@ -16,36 +16,40 @@ set -x
 oldpath=`pwd`
 cd ./xgboost/
 
+GCC_PATH=""
 if echo "${OSTYPE}" | grep -q "darwin"; then
-  LIB_XGBOOST=libxgboost.dylib
   # Use OpenMP-capable compiler if possible
-  if which g++-5; then
-    export CC=gcc-5
-    export CXX=g++-5
+  if [ "v"`sw_vers -buildVersion` -ge "v17G65" ]; then
+    if which g++-9; then
+      GCC_PATH="CC=gcc-9 CXX=g++-9"
+    else
+      echo "For MacOS version higher than High Sierra, please install gcc@9 first."
+    fi
+  elif which g++-5; then
+    GCC_PATH="CC=gcc-5 CXX=g++-5"
   elif which g++-7; then
-    export CC=gcc-7
-    export CXX=g++-7
+    GCC_PATH="CC=gcc-7 CXX=g++-7"
   elif which g++-8; then
-    export CC=gcc-8
-    export CXX=g++-8
+    GCC_PATH="CC=gcc-8 CXX=g++-8"
   elif which clang++; then
-    export CC=clang
-    export CXX=clang++
+    GCC_PATH="CC=clang CXX=clang++"
   fi
-else
-  LIB_XGBOOST=libxgboost.so
 fi
 
 #remove the pre-compiled .so and trigger the system's on-the-fly compiling
-make clean
-if make lib/${LIB_XGBOOST} -j4; then
+mkdir -p build
+cd build
+if [ -f * ]; then
+  rm -r *
+fi
+if eval $GCC_PATH" cmake .." && eval $GCC_PATH" make -j4"; then
     echo "Successfully build multi-thread xgboost"
 else
     echo "-----------------------------"
     echo "Building multi-thread xgboost failed"
     echo "Start to build single-thread xgboost"
-    make clean
-    make lib/${LIB_XGBOOST} -j4 USE_OPENMP=0
+    eval $GCC_PATH" cmake .. -DUSE_OPENMP=0"
+    eval $GCC_PATH" make -j4"
     echo "Successfully build single-thread xgboost"
     echo "If you want multi-threaded version"
     echo "See additional instructions in doc/build.md"


### PR DESCRIPTION
The build documentation and python installation script is updated to resolve the installation issue in MacOS versions higher than High Sierra. see #4933.