### PR TITLE
[WIP] [CI] Add CUDA 10.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,8 +64,8 @@ pipeline {
             'build-cpu': { BuildCPU() },
             'build-cpu-rabit-mock': { BuildCPUMock() },
             'build-gpu-cuda9.0': { BuildCUDA(cuda_version: '9.0') },
-            'build-gpu-cuda10.0': { BuildCUDA(cuda_version: '10.0') },
             'build-gpu-cuda10.1': { BuildCUDA(cuda_version: '10.1') },
+            'build-gpu-cuda10.2': { BuildCUDA(cuda_version: '10.2') },
             'build-jvm-packages': { BuildJVMPackages(spark_version: '2.4.3') },
             'build-jvm-doc': { BuildJVMDoc() }
           ])
@@ -80,9 +80,9 @@ pipeline {
           parallel ([
             'test-python-cpu': { TestPythonCPU() },
             'test-python-gpu-cuda9.0': { TestPythonGPU(cuda_version: '9.0') },
-            'test-python-gpu-cuda10.0': { TestPythonGPU(cuda_version: '10.0') },
             'test-python-gpu-cuda10.1': { TestPythonGPU(cuda_version: '10.1') },
-            'test-python-mgpu-cuda10.1': { TestPythonGPU(cuda_version: '10.1', multi_gpu: true) },
+            'test-python-gpu-cuda10.2': { TestPythonGPU(cuda_version: '10.2') },
+            'test-python-mgpu-cuda10.2': { TestPythonGPU(cuda_version: '10.2', multi_gpu: true) },
             'test-cpp-gpu': { TestCppGPU(cuda_version: '10.1') },
             'test-cpp-mgpu': { TestCppGPU(cuda_version: '10.1', multi_gpu: true) },
             'test-jvm-jdk8': { CrossTestJVMwithJDK(jdk_version: '8', spark_version: '2.4.3') },

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -41,8 +41,8 @@ pipeline {
           parallel ([
             'test-win64-cpu': { TestWin64CPU() },
             'test-win64-gpu-cuda9.0': { TestWin64GPU(cuda_target: 'cuda9') },
-            'test-win64-gpu-cuda10.0': { TestWin64GPU(cuda_target: 'cuda10_0') },
-            'test-win64-gpu-cuda10.1': { TestWin64GPU(cuda_target: 'cuda10_1') }
+            'test-win64-gpu-cuda10.1': { TestWin64GPU(cuda_target: 'cuda10_1') },
+            'test-win64-gpu-cuda10.2': { TestWin64GPU(cuda_target: 'cuda10_2') }
           ])
         }
         milestone ordinal: 3


### PR DESCRIPTION
* Add CUDA 10.2
* Remove CUDA 10.0: mostly to conserve CI resource. Also: CUDA 10.0 is incompatible with G4 instance type on Windows, and we'd like to use G4 if at all possible (much better bang for the buck than P2)

@rongou @sriramch 