### PR TITLE
- performance fixes for dmatrix construction using adapters

### DIFF
--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -287,8 +287,7 @@ DMatrix* DMatrix::Create(dmlc::Parser<uint32_t>* parser,
                          const size_t page_size) {
   if (cache_prefix.length() == 0) {
     data::FileAdapter adapter(parser);
-    return DMatrix::Create(&adapter, std::numeric_limits<float>::quiet_NaN(),
-                           1);
+    return DMatrix::Create(&adapter, std::numeric_limits<float>::quiet_NaN(), 1);
   } else {
 #if DMLC_ENABLE_STD_THREAD
     if (!data::SparsePageSource<SparsePage>::CacheExist(cache_prefix, ".row.page")) {

--- a/tests/cpp/data/test_adapter.cc
+++ b/tests/cpp/data/test_adapter.cc
@@ -96,6 +96,39 @@ TEST(c_api, CSCAdapter) {
   EXPECT_EQ(inst[0].index, 1);
 }
 
+TEST(c_api, CSCAdapterColsMoreThanRows) {
+  std::vector<float> data = {1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<unsigned> row_idx = {0, 1, 0, 1, 0, 1, 0, 1};
+  std::vector<size_t> col_ptr = {0, 2, 4, 6, 8};
+  // Infer row count
+  data::CSCAdapter adapter(col_ptr.data(), row_idx.data(), data.data(), 4, 0);
+  data::SimpleDMatrix dmat(&adapter, std::numeric_limits<float>::quiet_NaN(), -1);
+  EXPECT_EQ(dmat.Info().num_col_, 4);
+  EXPECT_EQ(dmat.Info().num_row_, 2);
+  EXPECT_EQ(dmat.Info().num_nonzero_, 8);
+
+  auto &batch = *dmat.GetBatches<SparsePage>().begin();
+  auto inst = batch[0];
+  EXPECT_EQ(inst[0].fvalue, 1);
+  EXPECT_EQ(inst[0].index, 0);
+  EXPECT_EQ(inst[1].fvalue, 3);
+  EXPECT_EQ(inst[1].index, 1);
+  EXPECT_EQ(inst[2].fvalue, 5);
+  EXPECT_EQ(inst[2].index, 2);
+  EXPECT_EQ(inst[3].fvalue, 7);
+  EXPECT_EQ(inst[3].index, 3);
+
+  inst = batch[1];
+  EXPECT_EQ(inst[0].fvalue, 2);
+  EXPECT_EQ(inst[0].index, 0);
+  EXPECT_EQ(inst[1].fvalue, 4);
+  EXPECT_EQ(inst[1].index, 1);
+  EXPECT_EQ(inst[2].fvalue, 6);
+  EXPECT_EQ(inst[2].index, 2);
+  EXPECT_EQ(inst[3].fvalue, 8);
+  EXPECT_EQ(inst[3].index, 3);
+}
+
 TEST(c_api, FileAdapter) {
   std::string filename = "test.libsvm";
   CreateBigTestData(filename, 10);

--- a/tests/cpp/data/test_adapter.cc
+++ b/tests/cpp/data/test_adapter.cc
@@ -30,7 +30,7 @@ TEST(c_api, CSRAdapter) {
   EXPECT_EQ(line2 .GetElement(0).row_idx, 2);
   EXPECT_EQ(line2 .GetElement(0).column_idx, 1);
 
-  data::SimpleDMatrix dmat(&adapter, -1, std::nan(""));
+  data::SimpleDMatrix dmat(&adapter, std::nan(""), -1);
   EXPECT_EQ(dmat.Info().num_col_, 2);
   EXPECT_EQ(dmat.Info().num_row_, 3);
   EXPECT_EQ(dmat.Info().num_nonzero_, 5);
@@ -51,7 +51,7 @@ TEST(c_api, DenseAdapter) {
   int n = 2;
   std::vector<float> data = {1, 2, 3, 4, 5, 6};
   data::DenseAdapter adapter(data.data(), m, m*n, n);
-  data::SimpleDMatrix dmat(&adapter,-1,std::numeric_limits<float>::quiet_NaN());
+  data::SimpleDMatrix dmat(&adapter, std::numeric_limits<float>::quiet_NaN(), -1);
   EXPECT_EQ(dmat.Info().num_col_, 2);
   EXPECT_EQ(dmat.Info().num_row_, 3);
   EXPECT_EQ(dmat.Info().num_nonzero_, 6);
@@ -73,7 +73,7 @@ TEST(c_api, CSCAdapter) {
   std::vector<unsigned> row_idx = {0, 1, 0, 1, 2};
   std::vector<size_t> col_ptr = {0, 2, 5};
   data::CSCAdapter adapter(col_ptr.data(), row_idx.data(), data.data(), 2, 3);
-  data::SimpleDMatrix dmat(&adapter,-1,std::numeric_limits<float>::quiet_NaN());
+  data::SimpleDMatrix dmat(&adapter, std::numeric_limits<float>::quiet_NaN(), -1);
   EXPECT_EQ(dmat.Info().num_col_, 2);
   EXPECT_EQ(dmat.Info().num_row_, 3);
   EXPECT_EQ(dmat.Info().num_nonzero_, 5);


### PR DESCRIPTION
  - the parallel group builder isn't amenable for piece wise construction of a dmatrix
    from batches of data. it relies on accumulating data on each thread and consolidating
    at the end of it all. further, it also repeatedly resizes the internal vectors as and
    when new data trickles in. the resizes are extremely expensive, if a row 'x' is attempted
    to be added, where 'x' is large, and when there are little to no elements before 'x'
  - the piece-wise construction exemplifies this issue, when large batches of data are taken in.
    the future batches with large row indices will assume that there are going to be data
    coming in for older rows, and will try to make room for those, by carving out large
    chunks of memory, only to be thrown away very soon when smaller batches of data 
    are processed with large row indices
  - this approach will control the state of the parallel builder by pre-allocating the thread
    vectors and reusing them for every batch. it will further treat each batch as though it
    is the entire data, and once the build is complete, it will consolidate the batch data and the
    offset vectors into the dmatrix's data and offset vectors

without this fix, dmatrix construction of a dataset containing 100m rows takes hours
(i aborted the process after 4 hours). with this fix, it takes 30-40s.

@RAMitchell @trivialfis @rongou please review when you get a chance.