### PR TITLE
Group builder modified for incremental building

### DIFF
--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -51,9 +51,10 @@ class SimpleDMatrix : public DMatrix {
     // Iterate over batches of input data
     while (adapter->Next()) {
       auto &batch = adapter->Value();
+
       common::ParallelGroupBuilder<
         Entry, std::remove_reference<decltype(offset_vec)>::type::value_type>
-        builder(&offset_vec, &data_vec);
+          builder(&offset_vec, &data_vec, offset_vec.size() - 1);
       builder.InitBudget(0, nthread);
 
       // First-pass over the batch counting valid elements

--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -52,10 +52,20 @@ class SimpleDMatrix : public DMatrix {
     while (adapter->Next()) {
       auto &batch = adapter->Value();
 
+      size_t base_row_offset = offset_vec.empty() ? 0 : offset_vec.size() - 1;
       common::ParallelGroupBuilder<
         Entry, std::remove_reference<decltype(offset_vec)>::type::value_type>
-          builder(&offset_vec, &data_vec, offset_vec.size() - 1);
-      builder.InitBudget(0, nthread);
+          builder(&offset_vec, &data_vec, base_row_offset);
+      // Estimate expected number of rows by using last element in batch
+      // This is not required to be exact but prevents unnecessary resizing
+      size_t expected_rows = 0;
+      if (batch.Size() > 0) {
+        auto last_line = batch.GetLine(batch.Size() - 1);
+        if (last_line.Size() > 0) {
+          expected_rows = last_line.GetElement(last_line.Size() - 1).row_idx;
+        }
+      }
+      builder.InitBudget(expected_rows, nthread);
 
       // First-pass over the batch counting valid elements
       size_t num_lines = batch.Size();

--- a/tests/cpp/common/test_group_data.cc
+++ b/tests/cpp/common/test_group_data.cc
@@ -35,7 +35,8 @@ TEST(group_data, ParallelGroupBuilder) {
   EXPECT_EQ(offsets, expected_offsets);
 
   // Create new builder, add one more row given already populated offsets/data
-  ParallelGroupBuilder<Entry, size_t> builder2(&offsets, &data);
+  ParallelGroupBuilder<Entry, size_t> builder2(&offsets, &data,
+                                               offsets.size() - 1);
   builder2.InitBudget(0, 1);
   builder2.AddBudget(2, 0, 2);
   builder2.InitStorage();

--- a/tests/cpp/data/test_adapter.cc
+++ b/tests/cpp/data/test_adapter.cc
@@ -30,7 +30,7 @@ TEST(c_api, CSRAdapter) {
   EXPECT_EQ(line2 .GetElement(0).row_idx, 2);
   EXPECT_EQ(line2 .GetElement(0).column_idx, 1);
 
-  data::SimpleDMatrix dmat(&adapter, -1, std::nan(""));
+  data::SimpleDMatrix dmat(&adapter, std::nan(""), -1);
   EXPECT_EQ(dmat.Info().num_col_, 2);
   EXPECT_EQ(dmat.Info().num_row_, 3);
   EXPECT_EQ(dmat.Info().num_nonzero_, 5);
@@ -51,7 +51,7 @@ TEST(c_api, DenseAdapter) {
   int n = 2;
   std::vector<float> data = {1, 2, 3, 4, 5, 6};
   data::DenseAdapter adapter(data.data(), m, m*n, n);
-  data::SimpleDMatrix dmat(&adapter,-1,std::numeric_limits<float>::quiet_NaN());
+  data::SimpleDMatrix dmat(&adapter, std::numeric_limits<float>::quiet_NaN(), -1);
   EXPECT_EQ(dmat.Info().num_col_, 2);
   EXPECT_EQ(dmat.Info().num_row_, 3);
   EXPECT_EQ(dmat.Info().num_nonzero_, 6);
@@ -73,7 +73,7 @@ TEST(c_api, CSCAdapter) {
   std::vector<unsigned> row_idx = {0, 1, 0, 1, 2};
   std::vector<size_t> col_ptr = {0, 2, 5};
   data::CSCAdapter adapter(col_ptr.data(), row_idx.data(), data.data(), 2, 3);
-  data::SimpleDMatrix dmat(&adapter,-1,std::numeric_limits<float>::quiet_NaN());
+  data::SimpleDMatrix dmat(&adapter, std::numeric_limits<float>::quiet_NaN(), -1);
   EXPECT_EQ(dmat.Info().num_col_, 2);
   EXPECT_EQ(dmat.Info().num_row_, 3);
   EXPECT_EQ(dmat.Info().num_nonzero_, 5);
@@ -94,6 +94,39 @@ TEST(c_api, CSCAdapter) {
   inst = batch[2];
   EXPECT_EQ(inst[0].fvalue, 5);
   EXPECT_EQ(inst[0].index, 1);
+}
+
+TEST(c_api, CSCAdapterColsMoreThanRows) {
+  std::vector<float> data = {1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<unsigned> row_idx = {0, 1, 0, 1, 0, 1, 0, 1};
+  std::vector<size_t> col_ptr = {0, 2, 4, 6, 8};
+  // Infer row count
+  data::CSCAdapter adapter(col_ptr.data(), row_idx.data(), data.data(), 4, 0);
+  data::SimpleDMatrix dmat(&adapter, std::numeric_limits<float>::quiet_NaN(), -1);
+  EXPECT_EQ(dmat.Info().num_col_, 4);
+  EXPECT_EQ(dmat.Info().num_row_, 2);
+  EXPECT_EQ(dmat.Info().num_nonzero_, 8);
+
+  auto &batch = *dmat.GetBatches<SparsePage>().begin();
+  auto inst = batch[0];
+  EXPECT_EQ(inst[0].fvalue, 1);
+  EXPECT_EQ(inst[0].index, 0);
+  EXPECT_EQ(inst[1].fvalue, 3);
+  EXPECT_EQ(inst[1].index, 1);
+  EXPECT_EQ(inst[2].fvalue, 5);
+  EXPECT_EQ(inst[2].index, 2);
+  EXPECT_EQ(inst[3].fvalue, 7);
+  EXPECT_EQ(inst[3].index, 3);
+
+  inst = batch[1];
+  EXPECT_EQ(inst[0].fvalue, 2);
+  EXPECT_EQ(inst[0].index, 0);
+  EXPECT_EQ(inst[1].fvalue, 4);
+  EXPECT_EQ(inst[1].index, 1);
+  EXPECT_EQ(inst[2].fvalue, 6);
+  EXPECT_EQ(inst[2].index, 2);
+  EXPECT_EQ(inst[3].fvalue, 8);
+  EXPECT_EQ(inst[3].index, 3);
 }
 
 TEST(c_api, FileAdapter) {


### PR DESCRIPTION
This is an alternative fix to #5097, it addresses the issue of slow performance when building large files due to the group builder repeatedly creating large temporary vectors.

It adds the optional parameter of base_row_offset_, so when building incrementally, temporary thread vectors are sized relative to this instead of 0.

I used the following test (not committed) to measure performance:
```c++
TEST(SimpleDMatrix, Performance) {
  std::string filename = "test.libsvm";
  CreateBigTestData(filename, 100000000);
  std::unique_ptr<dmlc::Parser<uint32_t>> parser(
    dmlc::Parser<uint32_t>::Create(filename.c_str(), 0, 1, "auto"));
  data::FileAdapter adapter(parser.get());
  common::Timer t;
  data::SimpleDMatrix dmat(&adapter, std::numeric_limits<float>::quiet_NaN(),
    1);
  t.Stop();
  t.PrintElapsed("SimpleDMatrix");
  }
}
```

In this example it goes from 25s->6.9s.

@sriramch can you check performance on your example please?