### PR TITLE
Use dynamic types for array interface columns instead of templates

### DIFF
--- a/src/data/columnar.h
+++ b/src/data/columnar.h
@@ -228,6 +228,7 @@ class Columnar {
   explicit Columnar(std::map<std::string, Json> const& column) {
     ArrayInterfaceHandler::Validate(column);
     data = ArrayInterfaceHandler::GetPtrFromArrayData<void*>(column);
+    CHECK(data) << "Column is null";
     size = ArrayInterfaceHandler::ExtractLength(column);
 
     common::Span<RBitField8::value_type> s_mask;

--- a/src/data/columnar.h
+++ b/src/data/columnar.h
@@ -85,8 +85,8 @@ struct ColumnarErrors {
     }
   }
 
-  static std::string UnSupportedType(std::string const& typestr) {
-    return TypeStr(typestr.at(1)) + " is not supported.";
+  static std::string UnSupportedType(const char (&typestr)[3]) {
+    return TypeStr(typestr[1]) + " is not supported.";
   }
 };
 
@@ -245,6 +245,34 @@ class Columnar {
     type[0] = typestr.at(0);
     type[1] = typestr.at(1);
     type[2] = typestr.at(2);
+    this->CheckType();
+  }
+
+  void CheckType() const {
+    if (type[1] == 'f' && type[2] == '4') {
+      return;
+    } else if (type[1] == 'f' && type[2] == '8') {
+      return;
+    } else if (type[1] == 'i' && type[2] == '1') {
+      return;
+    } else if (type[1] == 'i' && type[2] == '2') {
+      return;
+    } else if (type[1] == 'i' && type[2] == '4') {
+      return;
+    } else if (type[1] == 'i' && type[2] == '8') {
+      return;
+    } else if (type[1] == 'u' && type[2] == '1') {
+      return;
+    } else if (type[1] == 'u' && type[2] == '2') {
+      return;
+    } else if (type[1] == 'u' && type[2] == '4') {
+      return;
+    } else if (type[1] == 'u' && type[2] == '8') {
+      return;
+    } else {
+      LOG(FATAL) << ColumnarErrors::UnSupportedType(type);
+      return;
+    }
   }
 
   XGBOOST_DEVICE float GetElement(size_t idx) const {
@@ -269,7 +297,6 @@ class Columnar {
     } else if (type[1] == 'u' && type[2] == '8') {
       return reinterpret_cast<uint64_t*>(data)[idx];
     } else {
-      // TODO(Rory): Is this the best way to raise an error on device?
       SPAN_CHECK(false);
       return 0;
     }

--- a/src/data/data.cu
+++ b/src/data/data.cu
@@ -45,9 +45,7 @@ void MetaInfo::SetInfo(const char * c_key, std::string const& interface_str) {
   }
   auto const& typestr = get<String const>(j_arr_obj.at("typestr"));
 
-  if (key == "root_index") {
-    LOG(FATAL) << "root index for columnar data is not supported.";
-  } else if (key == "label") {
+  if (key == "label") {
     CopyInfoImpl(j_arr_obj, &labels_);
   } else if (key == "weight") {
     CopyInfoImpl(j_arr_obj, &weights_);

--- a/tests/cpp/data/test_simple_csr_source.cu
+++ b/tests/cpp/data/test_simple_csr_source.cu
@@ -23,21 +23,21 @@ TEST(ArrayInterfaceHandler, Error) {
 
   auto const& column_obj = get<Object>(column);
   // missing version
-  EXPECT_THROW(ArrayInterfaceHandler::ExtractArray<float>(column_obj), dmlc::Error);
+  EXPECT_THROW(Columnar c(column_obj), dmlc::Error);
   column["version"] = Integer(static_cast<Integer::Int>(1));
   // missing data
-  EXPECT_THROW(ArrayInterfaceHandler::ExtractArray<float>(column_obj), dmlc::Error);
+  EXPECT_THROW(Columnar c(column_obj), dmlc::Error);
   column["data"] = j_data;
   // missing typestr
-  EXPECT_THROW(ArrayInterfaceHandler::ExtractArray<float>(column_obj), dmlc::Error);
+  EXPECT_THROW(Columnar c(column_obj), dmlc::Error);
   column["typestr"] = String("<f4");
   // nullptr is not valid
-  EXPECT_THROW(ArrayInterfaceHandler::ExtractArray<float>(column_obj), dmlc::Error);
+  EXPECT_THROW(Columnar c(column_obj), dmlc::Error);
   thrust::device_vector<float> d_data(kRows);
   j_data = {Json(Integer(reinterpret_cast<Integer::Int>(d_data.data().get()))),
             Json(Boolean(false))};
   column["data"] = j_data;
-  EXPECT_NO_THROW(ArrayInterfaceHandler::ExtractArray<float>(column_obj));
+  EXPECT_NO_THROW(Columnar c(column_obj));
 
   std::vector<Json> j_mask_shape {Json(Integer(static_cast<Integer::Int>(kRows - 1)))};
   column["mask"] = Object();
@@ -46,7 +46,7 @@ TEST(ArrayInterfaceHandler, Error) {
   column["mask"]["typestr"] = String("<i1");
   column["mask"]["version"] = Integer(static_cast<Integer::Int>(1));
   // shape of mask and data doesn't match.
-  EXPECT_THROW(ArrayInterfaceHandler::ExtractArray<float>(column_obj), dmlc::Error);
+  EXPECT_THROW(Columnar c(column_obj), dmlc::Error);
 }
 
 template <typename T>

--- a/tests/cpp/data/test_simple_csr_source.cu
+++ b/tests/cpp/data/test_simple_csr_source.cu
@@ -75,6 +75,23 @@ Json GenerateDenseColumn(std::string const& typestr, size_t kRows,
   return column;
 }
 
+void TestGetElement() {
+  thrust::device_vector<float> data;
+  auto j_column = GenerateDenseColumn("<f4", 3, &data);
+  auto const& column_obj = get<Object const>(j_column);
+  Columnar foreign_column(column_obj);
+
+  EXPECT_NO_THROW({
+    dh::LaunchN(0, 1, [=] __device__(size_t idx) {
+      KERNEL_CHECK(foreign_column.GetElement(0) == 0.0f);
+      KERNEL_CHECK(foreign_column.GetElement(1) == 2.0f);
+      KERNEL_CHECK(foreign_column.GetElement(2) == 4.0f);
+    });
+  });
+}
+
+TEST(Columnar, GetElement) { TestGetElement(); }
+
 void TestDenseColumn(std::unique_ptr<data::SimpleCSRSource> const& source,
                      size_t n_rows, size_t n_cols) {
   auto const& data = source->page_.data.HostVector();


### PR DESCRIPTION
This PR changes the way we process inputs from array interface, where each column in the input may have a different type.

The current implementation processes one column at a time and dispatches templated functions. This is limiting because we cannot access more than one column at a time inside a kernel.

This PR implements dynamic type dispatching. The idea is, in future we will wrap adapters around these columns and they will be processed in batches potentially containing many columns with generic matrix construction code.