### PR TITLE
Enable OpenMP with Apple Clang (Mac default compiler)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ env:
 addons:
   homebrew:
     packages:
-      - gcc@9
+      - cmake
+      - libomp
       - graphviz
       - openssl
       - libgit2
-      - cmake
       - wget
       - r
     update: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,12 @@ endif ((${CMAKE_VERSION} VERSION_GREATER 3.13) OR (${CMAKE_VERSION} VERSION_EQUA
 
 message(STATUS "CMake version ${CMAKE_VERSION}")
 
+if (APPLE)
+  # Require CMake 3.16+ on Mac OSX, as previous versions of CMake had trouble locating
+  # OpenMP on Mac. See https://github.com/dmlc/xgboost/pull/5146#issuecomment-568312706
+  cmake_minimum_required(VERSION 3.16)
+endif (APPLE)
+
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
   message(FATAL_ERROR "GCC version must be at least 5.0!")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.9)
 project(xgboost LANGUAGES CXX C VERSION 1.0.0)
 include(cmake/Utils.cmake)
 list(APPEND CMAKE_MODULE_PATH "${xgboost_SOURCE_DIR}/cmake/modules")
@@ -10,6 +10,7 @@ endif ((${CMAKE_VERSION} VERSION_GREATER 3.13) OR (${CMAKE_VERSION} VERSION_EQUA
 
 message(STATUS "CMake version ${CMAKE_VERSION}")
 if (MSVC)
+  # Require CMake 3.11+ with Visual Studio to use COMPILE_LANGUAGE generator expression
   cmake_minimum_required(VERSION 3.11)
 endif (MSVC)
 
@@ -99,6 +100,14 @@ if (USE_CUDA)
   message(STATUS "CUDA GEN_CODE: ${GEN_CODE}")
 endif (USE_CUDA)
 
+if (USE_OPENMP)
+  if (APPLE)
+    # Require CMake 3.12+ on Mac OSX to support OpenMP
+    cmake_minimum_required(VERSION 3.12)
+  endif (APPLE)
+  find_package(OpenMP REQUIRED)
+endif (USE_OPENMP)
+
 # dmlc-core
 msvc_use_static_runtime()
 add_subdirectory(${xgboost_SOURCE_DIR}/dmlc-core)
@@ -146,11 +155,6 @@ endif (JVM_BINDINGS)
 
 #-- CLI for xgboost
 add_executable(runxgboost ${xgboost_SOURCE_DIR}/src/cli_main.cc ${XGBOOST_OBJ_SOURCES})
-# For cli_main.cc only
-if (USE_OPENMP)
-  find_package(OpenMP REQUIRED)
-  target_compile_options(runxgboost PRIVATE ${OpenMP_CXX_FLAGS})
-endif (USE_OPENMP)
 
 target_include_directories(runxgboost
   PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,6 @@ endif ((${CMAKE_VERSION} VERSION_GREATER 3.13) OR (${CMAKE_VERSION} VERSION_EQUA
 
 message(STATUS "CMake version ${CMAKE_VERSION}")
 
-if (APPLE)
-  # Require CMake 3.16+ on Mac OSX, as previous versions of CMake had trouble locating
-  # OpenMP on Mac. See https://github.com/dmlc/xgboost/pull/5146#issuecomment-568312706
-  cmake_minimum_required(VERSION 3.16)
-endif (APPLE)
-
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
   message(FATAL_ERROR "GCC version must be at least 5.0!")
 endif()
@@ -100,6 +94,11 @@ if (USE_CUDA)
 endif (USE_CUDA)
 
 if (USE_OPENMP)
+  if (APPLE)
+    # Require CMake 3.16+ on Mac OSX, as previous versions of CMake had trouble locating
+    # OpenMP on Mac. See https://github.com/dmlc/xgboost/pull/5146#issuecomment-568312706
+    cmake_minimum_required(VERSION 3.16)
+  endif (APPLE)
   find_package(OpenMP REQUIRED)
 endif (USE_OPENMP)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.12)
 project(xgboost LANGUAGES CXX C VERSION 1.0.0)
 include(cmake/Utils.cmake)
 list(APPEND CMAKE_MODULE_PATH "${xgboost_SOURCE_DIR}/cmake/modules")
@@ -9,10 +9,6 @@ if ((${CMAKE_VERSION} VERSION_GREATER 3.13) OR (${CMAKE_VERSION} VERSION_EQUAL 3
 endif ((${CMAKE_VERSION} VERSION_GREATER 3.13) OR (${CMAKE_VERSION} VERSION_EQUAL 3.13))
 
 message(STATUS "CMake version ${CMAKE_VERSION}")
-if (MSVC)
-  # Require CMake 3.11+ with Visual Studio to use COMPILE_LANGUAGE generator expression
-  cmake_minimum_required(VERSION 3.11)
-endif (MSVC)
 
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
   message(FATAL_ERROR "GCC version must be at least 5.0!")
@@ -81,14 +77,11 @@ endif (USE_AVX)
 
 #-- Sanitizer
 if (USE_SANITIZER)
-  # Older CMake versions have had troubles with Sanitizer
-  cmake_minimum_required(VERSION 3.12)
   include(cmake/Sanitizer.cmake)
   enable_sanitizers("${ENABLED_SANITIZERS}")
 endif (USE_SANITIZER)
 
 if (USE_CUDA)
-  cmake_minimum_required(VERSION 3.12)
   SET(USE_OPENMP ON CACHE BOOL "CUDA requires OpenMP" FORCE)
   # `export CXX=' is ignored by CMake CUDA.
   set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
@@ -101,10 +94,6 @@ if (USE_CUDA)
 endif (USE_CUDA)
 
 if (USE_OPENMP)
-  if (APPLE)
-    # Require CMake 3.12+ on Mac OSX to support OpenMP
-    cmake_minimum_required(VERSION 3.12)
-  endif (APPLE)
   find_package(OpenMP REQUIRED)
 endif (USE_OPENMP)
 

--- a/demo/c-api/CMakeLists.txt
+++ b/demo/c-api/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.12)
 find_package(xgboost REQUIRED)
 add_executable(api-demo c-api-demo.c)
 target_link_libraries(api-demo xgboost::xgboost)

--- a/demo/c-api/CMakeLists.txt
+++ b/demo/c-api/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.9)
 find_package(xgboost REQUIRED)
 add_executable(api-demo c-api-demo.c)
 target_link_libraries(api-demo xgboost::xgboost)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,8 +80,8 @@ if (USE_OPENMP OR USE_CUDA)  # CUDA requires OpenMP
   find_package(OpenMP REQUIRED)
   list(APPEND SRC_LIBS OpenMP::OpenMP_CXX)
   set(LINKED_LIBRARIES_PRIVATE "${LINKED_LIBRARIES_PRIVATE};${SRC_LIBS}" PARENT_SCOPE)
-  target_link_libraries(objxgboost PUBLIC OpenMP::OpenMP_CXX)
-endif ()
+  target_link_libraries(objxgboost PRIVATE OpenMP::OpenMP_CXX)
+endif (USE_OPENMP OR USE_CUDA)
 
 # For MSVC: Call msvc_use_static_runtime() once again to completely
 # replace /MD with /MT. See https://github.com/dmlc/xgboost/issues/4462

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,12 +29,6 @@ if (USE_CUDA)
     target_compile_definitions(objxgboost PRIVATE -DXGBOOST_USE_NVTX=1)
   endif (USE_NVTX)
 
-  # OpenMP is mandatory for cuda version
-  find_package(OpenMP REQUIRED)
-  target_compile_options(objxgboost PRIVATE
-    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
-  )
-
   set_target_properties(objxgboost PROPERTIES
     CUDA_SEPARABLE_COMPILATION OFF)
 else (USE_CUDA)
@@ -78,17 +72,12 @@ if (XGBOOST_BUILTIN_PREFETCH_PRESENT)
     -DXGBOOST_BUILTIN_PREFETCH_PRESENT=1)
 endif (XGBOOST_BUILTIN_PREFETCH_PRESENT)
 
-if (USE_OPENMP)
+if (USE_OPENMP OR USE_CUDA)  # CUDA requires OpenMP
   find_package(OpenMP REQUIRED)
-  if (OpenMP_CXX_FOUND OR OPENMP_FOUND)
-    target_compile_options(objxgboost PRIVATE  $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
-    if ((NOT OpenMP_CXX_LIBRARIES) AND (NOT MSVC))  # old CMake doesn't define this variable
-      set(OpenMP_CXX_LIBRARIES "gomp;pthread")
-    endif ((NOT OpenMP_CXX_LIBRARIES) AND (NOT MSVC))
-    list(APPEND SRC_LIBS ${OpenMP_CXX_LIBRARIES})
-    set(LINKED_LIBRARIES_PRIVATE "${LINKED_LIBRARIES_PRIVATE};${SRC_LIBS}" PARENT_SCOPE)
-  endif (OpenMP_CXX_FOUND OR OPENMP_FOUND)
-endif (USE_OPENMP)
+  list(APPEND SRC_LIBS OpenMP::OpenMP_CXX)
+  set(LINKED_LIBRARIES_PRIVATE "${LINKED_LIBRARIES_PRIVATE};${SRC_LIBS}" PARENT_SCOPE)
+  target_link_libraries(objxgboost PUBLIC OpenMP::OpenMP_CXX)
+endif ()
 
 # For MSVC: Call msvc_use_static_runtime() once again to completely
 # replace /MD with /MT. See https://github.com/dmlc/xgboost/issues/4462

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,10 @@ if (USE_CUDA)
     target_compile_definitions(objxgboost PRIVATE -DXGBOOST_USE_NVTX=1)
   endif (USE_NVTX)
 
+  target_compile_options(objxgboost PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
+  )
+
   set_target_properties(objxgboost PROPERTIES
     CUDA_SEPARABLE_COMPILATION OFF)
 else (USE_CUDA)

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-ARG CMAKE_VERSION=3.9
+ARG CMAKE_VERSION=3.12
 
 # Environment
 ENV DEBIAN_FRONTEND noninteractive

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-ARG CMAKE_VERSION=3.3
+ARG CMAKE_VERSION=3.9
 
 # Environment
 ENV DEBIAN_FRONTEND noninteractive

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -25,7 +25,6 @@ if (USE_CUDA)
     $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>
     $<$<COMPILE_LANGUAGE:CUDA>:-lineinfo>
     $<$<AND:$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<COMPILE_LANGUAGE:CUDA>>:--std=c++11>
-    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
     $<$<COMPILE_LANGUAGE:CUDA>:${GEN_CODE}>)
   target_compile_definitions(testxgboost
     PRIVATE -DXGBOOST_USE_CUDA=1)
@@ -55,18 +54,12 @@ set_target_properties(
   testxgboost PROPERTIES
   CXX_STANDARD 11
   CXX_STANDARD_REQUIRED ON)
-if ((NOT OpenMP_CXX_LIBRARIES) AND (NOT MSVC))  # old CMake doesn't define this variable
-  set(OpenMP_CXX_LIBRARIES "gomp;pthread")
-endif ((NOT OpenMP_CXX_LIBRARIES) AND (NOT MSVC))
 target_link_libraries(testxgboost
   PRIVATE
   ${GTEST_LIBRARIES}
   ${LINKED_LIBRARIES_PRIVATE}
-  ${OpenMP_CXX_LIBRARIES})
+  OpenMP::OpenMP_CXX)
 target_compile_definitions(testxgboost PRIVATE ${XGBOOST_DEFINITIONS})
-if (USE_OPENMP)
-  target_compile_options(testxgboost PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
-endif (USE_OPENMP)
 set_output_directory(testxgboost ${xgboost_BINARY_DIR})
 
 # This grouping organises source files nicely in visual studio

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -25,6 +25,7 @@ if (USE_CUDA)
     $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>
     $<$<COMPILE_LANGUAGE:CUDA>:-lineinfo>
     $<$<AND:$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<COMPILE_LANGUAGE:CUDA>>:--std=c++11>
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
     $<$<COMPILE_LANGUAGE:CUDA>:${GEN_CODE}>)
   target_compile_definitions(testxgboost
     PRIVATE -DXGBOOST_USE_CUDA=1)

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -10,7 +10,7 @@ if [ ${TASK} == "python_test" ]; then
     rm -rf build
     mkdir build && cd build
     cmake .. -DUSE_OPENMP=ON -DCMAKE_VERBOSE_MAKEFILE=ON
-    make -j2
+    make -j$(nproc)
     cd ..
 
     echo "-------------------------------"
@@ -47,7 +47,7 @@ if [ ${TASK} == "cmake_test" ]; then
     mkdir build && cd build
     PLUGINS="-DPLUGIN_LZ4=ON -DPLUGIN_DENSE_PARSER=ON"
     cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DUSE_OPENMP=ON -DUSE_DMLC_GTEST=ON ${PLUGINS}
-    make -j2
+    make -j$(nproc)
     ./testxgboost
     cd ..
     rm -rf build

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
-cp make/travis.mk config.mk
 make -f dmlc-core/scripts/packages.mk lz4
 
-if [ ${TRAVIS_OS_NAME} == "osx" ]; then
-    echo 'USE_OPENMP=0' >> config.mk
-fi
-
 if [ ${TASK} == "python_test" ]; then
-    make all || exit -1
+    set -e
+    # Build/test
+    rm -rf build
+    mkdir build && cd build
+    cmake .. -DUSE_OPENMP=ON
+    make -j2
+    cd ..
+
     echo "-------------------------------"
     conda activate python3
     python --version
@@ -42,8 +44,8 @@ if [ ${TASK} == "cmake_test" ]; then
     rm -rf build
     mkdir build && cd build
     PLUGINS="-DPLUGIN_LZ4=ON -DPLUGIN_DENSE_PARSER=ON"
-    CC=gcc-9 CXX=g++-9 cmake .. -DGOOGLE_TEST=ON -DUSE_OPENMP=ON -DUSE_DMLC_GTEST=ON ${PLUGINS}
-    make
+    cmake .. -DGOOGLE_TEST=ON -DUSE_OPENMP=ON -DUSE_DMLC_GTEST=ON ${PLUGINS}
+    make -j2
     ./testxgboost
     cd ..
     rm -rf build

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -7,7 +7,7 @@ if [ ${TASK} == "python_test" ]; then
     # Build/test
     rm -rf build
     mkdir build && cd build
-    cmake .. -DUSE_OPENMP=ON
+    cmake .. -DUSE_OPENMP=ON -DCMAKE_VERBOSE_MAKEFILE=ON
     make -j2
     cd ..
 
@@ -44,7 +44,7 @@ if [ ${TASK} == "cmake_test" ]; then
     rm -rf build
     mkdir build && cd build
     PLUGINS="-DPLUGIN_LZ4=ON -DPLUGIN_DENSE_PARSER=ON"
-    cmake .. -DGOOGLE_TEST=ON -DUSE_OPENMP=ON -DUSE_DMLC_GTEST=ON ${PLUGINS}
+    cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DUSE_OPENMP=ON -DUSE_DMLC_GTEST=ON ${PLUGINS}
     make -j2
     ./testxgboost
     cd ..

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -2,6 +2,8 @@
 
 make -f dmlc-core/scripts/packages.mk lz4
 
+source $HOME/miniconda/bin/activate
+
 if [ ${TASK} == "python_test" ]; then
     set -e
     # Build/test

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -4,11 +4,11 @@ if [ ${TASK} == "python_test" ]; then
     if [ ${TRAVIS_OS_NAME} == "osx" ]; then
         wget -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
     else
-	echo "We are no longer running Linux test on Travis."
+        echo "We are no longer running Linux test on Travis."
         exit 1
     fi
     bash conda.sh -b -p $HOME/miniconda
-    export PATH="$HOME/miniconda/bin:$PATH"
+    source $HOME/miniconda/bin/activate
     hash -r
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda


### PR DESCRIPTION
Simplify logic for importing OpenMP into the CMake build by treating OpenMP as a target. We no longer have to set compiler flags; all it takes is to import target `OpenMP::OpenMP_CXX` via `target_link_libraries()`. See https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html for more information.

This will be especially useful for Mac OSX users. The old way requires them to use Homebrew GCC, which is a heavy dependency (*). The new way allows them to use Apple Clang (default system compiler) instead, provided that they install OpenMP library via Homebrew (`brew install libomp`). Furthermore, we can release XGBoost 1.0.0 on Homebrew with OpenMP enabled.

CMake version is raised to ~3.9~ 3.12 to access `OpenMP::OpenMP_CXX` target. 3.12 is needed to use `target_link_libraries()` with object target `objxgboost`. Note that we've been already requiring 3.12 for the GPU algorithms.

Closes #4477.
Depends on https://github.com/dmlc/dmlc-core/pull/586

(*) See discussion at Homebrew/homebrew-core#43246, where Homebrew maintainers asked to remove GCC dependency from XGBoost.