### PR TITLE
Quick fix for memory leak in CPU Hist.

### DIFF
--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -80,7 +80,7 @@ using xgboost::common::Column;
 /*! \brief construct a tree using quantized feature values */
 class QuantileHistMaker: public TreeUpdater {
  public:
-  QuantileHistMaker() : is_gmat_initialized_{ false } {}
+  QuantileHistMaker() {}
   void Configure(const Args& args) override;
 
   void Update(HostDeviceVector<GradientPair>* gpair,
@@ -112,7 +112,7 @@ class QuantileHistMaker: public TreeUpdater {
   GHistIndexBlockMatrix gmatb_;
   // column accessor
   ColumnMatrix column_matrix_;
-  bool is_gmat_initialized_;
+  std::unordered_map<DMatrix*, bool> is_gmat_initialized_;
 
   // data structure
   struct NodeEntry {

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -13,6 +13,7 @@
 #include "../../../src/tree/param.h"
 #include "../../../src/tree/updater_quantile_hist.h"
 #include "../../../src/tree/split_evaluator.h"
+#include "xgboost/data.h"
 
 namespace xgboost {
 namespace tree {
@@ -26,8 +27,9 @@ class QuantileHistMock : public QuantileHistMaker {
     BuilderMock(const TrainParam& param,
                 std::unique_ptr<TreeUpdater> pruner,
                 std::unique_ptr<SplitEvaluator> spliteval,
-                FeatureInteractionConstraintHost int_constraint)
-        : RealImpl(param, std::move(pruner), std::move(spliteval), std::move(int_constraint)) {}
+                FeatureInteractionConstraintHost int_constraint,
+                DMatrix const* fmat)
+        : RealImpl(param, std::move(pruner), std::move(spliteval), std::move(int_constraint), fmat) {}
 
    public:
     void TestInitData(const GHistIndexMatrix& gmat,
@@ -236,13 +238,14 @@ class QuantileHistMock : public QuantileHistMaker {
       cfg_{args} {
     QuantileHistMaker::Configure(args);
     spliteval_->Init(&param_);
+    dmat_ = CreateDMatrix(kNRows, kNCols, 0.8, 3);
     builder_.reset(
         new BuilderMock(
             param_,
             std::move(pruner_),
             std::unique_ptr<SplitEvaluator>(spliteval_->GetHostClone()),
-            int_constraint_));
-    dmat_ = CreateDMatrix(kNRows, kNCols, 0.8, 3);
+            int_constraint_,
+            dmat_->get()));
   }
   ~QuantileHistMock() override { delete dmat_; }
 


### PR DESCRIPTION
Closes https://github.com/dmlc/xgboost/issues/3579 .

The proper fix is putting quantiles in `DMatrix`, which we have already done for GPU Hist.  See https://github.com/dmlc/xgboost/issues/5143 for related future roadmap.  This PR is a band-aid for fixing the old issue as we want a fully working 1.0 release.