### PR TITLE
Parameter validation

### DIFF
--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -359,9 +359,7 @@ class Dart : public GBTree {
 
   void Configure(const Args& cfg) override {
     GBTree::Configure(cfg);
-    if (model_.trees.size() == 0) {
-      dparam_.UpdateAllowUnknown(cfg);
-    }
+    dparam_.UpdateAllowUnknown(cfg);
   }
 
   void SaveModel(Json *p_out) const override {

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -236,7 +236,6 @@ class LearnerImpl : public Learner {
   }
 
   void ValidateParameters() {
-    std::vector<Json> parameters;
     std::vector<std::string> keys;
 
     Json config { Object() };

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -250,11 +250,11 @@ class LearnerImpl : public Learner {
     // Extract all parameters
     std::vector<std::string> keys;
     while (!stack.empty()) {
-      auto obj = stack.top();
+      auto j_obj = stack.top();
       stack.pop();
-      auto &o = get<Object>(obj);
+      auto const &obj = get<Object const>(j_obj);
 
-      for (auto const &kv : o) {
+      for (auto const &kv : obj) {
         if (is_parameter(kv.first)) {
           auto parameter = get<Object const>(kv.second);
           std::transform(parameter.begin(), parameter.end(), std::back_inserter(keys),

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -215,7 +215,6 @@ class LearnerImpl : public Learner {
       tparam_.dsplit = DataSplitMode::kRow;
     }
 
-
     // set seed only before the model is initialized
     common::GlobalRandom().seed(generic_parameters_.seed);
     // must precede configure gbm since num_features is required for gbm
@@ -232,27 +231,31 @@ class LearnerImpl : public Learner {
 
     this->need_configuration_ = false;
     this->ValidateParameters();
+    // FIXME(trivialfis): Clear the cache once binary IO is gone.
     monitor_.Stop("Configure");
   }
 
   void ValidateParameters() {
-    std::vector<std::string> keys;
-
     Json config { Object() };
     this->SaveConfig(&config);
     std::stack<Json> stack;
     stack.push(config);
-    std::string postfix{"_param"};
+    std::string const postfix{"_param"};
+
+    auto is_parameter = [&postfix](std::string const &key) {
+      return key.size() > postfix.size() &&
+             std::equal(postfix.rbegin(), postfix.rend(), key.rbegin());
+    };
 
     // Extract all parameters
+    std::vector<std::string> keys;
     while (!stack.empty()) {
       auto obj = stack.top();
       stack.pop();
       auto &o = get<Object>(obj);
 
       for (auto const &kv : o) {
-        if (kv.first.size() > postfix.size() &&
-            std::equal(postfix.rbegin(), postfix.rend(), kv.first.rbegin())) {
+        if (is_parameter(kv.first)) {
           auto parameter = get<Object const>(kv.second);
           std::transform(parameter.begin(), parameter.end(), std::back_inserter(keys),
                          [](std::pair<std::string const&, Json const&> const& kv) {
@@ -270,7 +273,7 @@ class LearnerImpl : public Learner {
     for (auto const &kv : cfg_) {
       // `num_feature` and `num_class` are automatically added due to legacy reason.
       // `verbosity` in logger is not saved, we should move it into generic_param_.
-      // TODO(trivialfis): Make eval_metric a training parameter.
+      // FIXME(trivialfis): Make eval_metric a training parameter.
       if (kv.first != "num_feature" && kv.first != "verbosity" &&
           kv.first != "num_class" && kv.first != kEvalMetric) {
         provided.push_back(kv.first);

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -56,14 +56,10 @@ struct TrainParam : public XGBoostParameter<TrainParam> {
   float colsample_bylevel;
   // whether to subsample columns during tree construction
   float colsample_bytree;
-  // speed optimization for dense column
-  float opt_dense_col;
   // accuracy of sketch
   float sketch_eps;
   // accuracy of sketch
   float sketch_ratio;
-  // option for parallelization
-  int parallel_option;
   // option to open cacheline optimization
   bool cache_opt;
   // whether refresh updater needs to update the leaf values
@@ -160,10 +156,6 @@ struct TrainParam : public XGBoostParameter<TrainParam> {
         .set_range(0.0f, 1.0f)
         .set_default(1.0f)
         .describe("Subsample ratio of columns, resample on each tree construction.");
-    DMLC_DECLARE_FIELD(opt_dense_col)
-        .set_range(0.0f, 1.0f)
-        .set_default(1.0f)
-        .describe("EXP Param: speed optimization for dense column.");
     DMLC_DECLARE_FIELD(sketch_eps)
         .set_range(0.0f, 1.0f)
         .set_default(0.03f)
@@ -172,9 +164,6 @@ struct TrainParam : public XGBoostParameter<TrainParam> {
         .set_lower_bound(0.0f)
         .set_default(2.0f)
         .describe("EXP Param: Sketch accuracy related parameter of approximate algorithm.");
-    DMLC_DECLARE_FIELD(parallel_option)
-        .set_default(0)
-        .describe("Different types of parallelization algorithm.");
     DMLC_DECLARE_FIELD(cache_opt)
         .set_default(true)
         .describe("EXP Param: Cache aware optimization.");
@@ -218,16 +207,7 @@ struct TrainParam : public XGBoostParameter<TrainParam> {
     DMLC_DECLARE_ALIAS(min_split_loss, gamma);
     DMLC_DECLARE_ALIAS(learning_rate, eta);
   }
-  /*! \brief whether need forward small to big search: default right */
-  inline bool NeedForwardSearch(float col_density, bool indicator) const {
-    return this->default_direction == 2 ||
-           (default_direction == 0 && (col_density < opt_dense_col) &&
-            !indicator);
-  }
-  /*! \brief whether need backward big to small search: default left */
-  inline bool NeedBackwardSearch(float col_density, bool indicator) const {
-    return this->default_direction != 2;
-  }
+
   /*! \brief given the loss change, whether we need to invoke pruning */
   inline bool NeedPrune(double loss_chg, int depth) const {
     return loss_chg < this->min_split_loss;

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -30,6 +30,25 @@ TEST(Learner, Basic) {
   static_assert(std::is_integral<decltype(patch)>::value, "Wrong patch version type");
 }
 
+TEST(Learner, ParameterValidation) {
+  size_t constexpr kRows = 1;
+  size_t constexpr kCols = 1;
+  auto pp_mat = CreateDMatrix(kRows, kCols, 0);
+  auto& p_mat = *pp_mat;
+
+  auto learner = std::unique_ptr<Learner>(Learner::Create({p_mat}));
+  learner->SetParam("Knock Knock", "Who's there?");
+  learner->SetParam("Silence", "....");
+  learner->SetParam("tree_method", "exact");
+
+  testing::internal::CaptureStderr();
+  learner->Configure();
+  std::string output = testing::internal::GetCapturedStderr();
+
+  ASSERT_TRUE(output.find("Parameters: { Knock Knock, Silence } are not used.") != std::string::npos);
+  delete pp_mat;
+}
+
 TEST(Learner, CheckGroup) {
   using Arg = std::pair<std::string, std::string>;
   size_t constexpr kNumGroups = 4;


### PR DESCRIPTION
Related issue: https://github.com/dmlc/xgboost/issues/4211

Using the first option described in: https://github.com/dmlc/xgboost/issues/4211#issuecomment-568661064 

Note the parameter validation is not strict, because we have a lots of parameters packed into `TrainParam` and each tree method uses only a selected subset.  But to me this is a good starting point for future development.  The difficult part of getting it work is refactoring `approx`.

I didn't split the parameters exclusive to CPU Hist, as I think some of them are useful to GPU in the future.