### PR TITLE
[WIP] [Breaking] Default to hist `tree_method`.

### DIFF
--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -104,21 +104,16 @@ Parameters for Tree Booster
 
 * ``tree_method`` string [default= ``auto``]
 
-  - The tree construction algorithm used in XGBoost. See description in the `reference paper <http://arxiv.org/abs/1603.02754>`_.
+  - The tree construction algorithm used in XGBoost. See description in the `reference paper <http://arxiv.org/abs/1603.02754>`_.  This is a combination of different ``updaters``.
   - XGBoost supports  ``approx``, ``hist`` and ``gpu_hist`` for distributed training.  Experimental support for external memory is available for ``approx`` and ``gpu_hist``.
-  - Choices: ``auto``, ``exact``, ``approx``, ``hist``, ``gpu_hist``
+  - Choices: ``auto``, ``exact``, ``approx``, ``hist``, ``gpu_hist``, ``refresh``
 
     - ``auto``: Use heuristic to choose the fastest method.
-
-      - For small to medium dataset, exact greedy (``exact``) will be used.
-      - For very large dataset, approximate algorithm (``approx``) will be chosen.
-      - Because old behavior is always use exact greedy in single machine,
-        user will get a message when approximate algorithm is chosen to notify this choice.
-
     - ``exact``: Exact greedy algorithm.
     - ``approx``: Approximate greedy algorithm using quantile sketch and gradient histogram.
     - ``hist``: Fast histogram optimized approximate greedy algorithm. It uses some performance improvements such as bins caching.
     - ``gpu_hist``: GPU implementation of ``hist`` algorithm.
+    - ``refresh``: Refreshing tree statistic.
 
 * ``sketch_eps`` [default=0.03]
 

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
@@ -53,7 +53,8 @@ class XGBoostClassifierSuite extends FunSuite with PerTest {
       "eta" -> "1",
       "max_depth" -> "6",
       "silent" -> "1",
-      "objective" -> "binary:logistic")
+      "objective" -> "binary:logistic",
+      "tree_method" -> "hist")
 
     val model1 = ScalaXGBoost.train(trainingDM, paramMap, round)
     val prediction1 = model1.predict(testDM)

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -641,7 +641,8 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             obj = None
 
         if self.n_classes_ > 2:
-            # Switch to using a multiclass objective in the underlying XGB instance
+            # Switch to using a multiclass objective in the underlying
+            # XGB instance
             xgb_options["objective"] = "multi:softprob"
             xgb_options['num_class'] = self.n_classes_
 
@@ -659,7 +660,8 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             if sample_weight_eval_set is None:
                 sample_weight_eval_set = [None] * len(eval_set)
             evals = list(
-                DMatrix(eval_set[i][0], label=self._le.transform(eval_set[i][1]),
+                DMatrix(eval_set[i][0],
+                        label=self._le.transform(eval_set[i][1]),
                         missing=self.missing, weight=sample_weight_eval_set[i],
                         nthread=self.n_jobs)
                 for i in range(len(eval_set))
@@ -680,8 +682,10 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
                                 base_margin=base_margin,
                                 missing=self.missing, nthread=self.n_jobs)
 
-        self._Booster = train(xgb_options, train_dmatrix, self.get_num_boosting_rounds(),
-                              evals=evals, early_stopping_rounds=early_stopping_rounds,
+        self._Booster = train(xgb_options, train_dmatrix,
+                              num_boost_round=self.get_num_boosting_rounds(),
+                              evals=evals,
+                              early_stopping_rounds=early_stopping_rounds,
                               evals_result=evals_result, obj=obj, feval=feval,
                               verbose_eval=verbose, xgb_model=xgb_model,
                               callbacks=callbacks)
@@ -690,7 +694,8 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         if evals_result:
             for val in evals_result.items():
                 evals_result_key = list(val[1].keys())[0]
-                evals_result[val[0]][evals_result_key] = val[1][evals_result_key]
+                evals_result[val[0]][evals_result_key] = val[1][
+                    evals_result_key]
             self.evals_result_ = evals_result
 
         if early_stopping_rounds is not None:

--- a/src/common/observer.h
+++ b/src/common/observer.h
@@ -71,6 +71,12 @@ class TrainingObserver {
     auto const& h_vec = vec.HostVector();
     this->Observe(h_vec, name);
   }
+  template <typename T>
+  void Observe(HostDeviceVector<T>* vec, std::string name) const {
+    if (XGBOOST_EXPECT(!observe_, true)) { return; }
+    this->Observe(*vec, name);
+  }
+
   /*\brief Observe objects with `XGBoostParamer' type. */
   template <typename Parameter,
             typename std::enable_if<

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -312,10 +312,8 @@ template <typename AdapterT>
 DMatrix* DMatrix::Create(AdapterT* adapter, float missing, int nthread,
                          const std::string& cache_prefix,  size_t page_size ) {
   if (cache_prefix.length() == 0) {
-    auto data = new data::SimpleDMatrix(adapter, missing, nthread);
     // Data split mode is fixed to be row right now.
-    rabit::Allreduce<rabit::op::Max>(&data->Info().num_col_, 1);
-    return data;
+    return new data::SimpleDMatrix(adapter, missing, nthread);
   } else {
 #if DMLC_ENABLE_STD_THREAD
     return new data::SparsePageDMatrix(adapter, missing, nthread, cache_prefix,

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -101,20 +101,18 @@ void GBTree::PerformTreeMethodHeuristic() {
   if (tparam_.tree_method != TreeMethod::kAuto) {
     if (rabit::IsDistributed() && tparam_.tree_method == TreeMethod::kExact) {
       LOG(FATAL) << R"(Distributed training is supported by following tree methods:
-  - gpu_hist
-  - hist
-  - approx
+  - `gpu_hist`
+  - `hist`
+  - `approx`
 )";
     }
-    return;
+  } else {
+    // Default tree method.
+    tparam_.tree_method = TreeMethod::kHist;
   }
-
-  // Default tree method.
-  tparam_.tree_method = TreeMethod::kHist;
 
   switch (tparam_.tree_method) {
     case TreeMethod::kAuto: {
-      LOG(FATAL) << "[Internal error]: tree method is not configured.";
       break;
     }
     case TreeMethod::kApprox: {
@@ -132,6 +130,10 @@ void GBTree::PerformTreeMethodHeuristic() {
     case TreeMethod::kGPUHist: {
       this->AssertGPUSupport();
       tparam_.updater_seq = "grow_gpu_hist";
+      break;
+    }
+    case TreeMethod::kRefresh: {
+      tparam_.updater_seq = "refresh";
       break;
     }
     default:

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -165,7 +165,7 @@ class GBTree : public GradientBooster {
   void Configure(const Args& cfg) override;
 
   void ValidateTreeMethod(DMatrix const* fmat) const {
-    if (!fmat->SingleColBlock() &&
+    if (!fmat->SingleColBlock() && !specified_updater_ &&
         (tparam_.tree_method != TreeMethod::kApprox) &&
         (tparam_.tree_method != TreeMethod::kGPUHist) &&
         (tparam_.tree_method != TreeMethod::kExact)) {

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -32,7 +32,7 @@
 namespace xgboost {
 enum class TreeMethod : int {
   kAuto = 0, kApprox = 1, kExact = 2, kHist = 3,
-  kGPUHist = 5
+  kGPUHist = 5, kRefresh = 6
 };
 
 // boosting process types
@@ -169,9 +169,11 @@ class GBTree : public GradientBooster {
         (tparam_.tree_method != TreeMethod::kApprox) &&
         (tparam_.tree_method != TreeMethod::kGPUHist) &&
         (tparam_.tree_method != TreeMethod::kExact)) {
-      LOG(FATAL) << "External memory data matrix is used (out of core).  Use "
-                 << "`tree_method=approx` for CPU based external memory training, and "
-                 << "`tree_method=gpu_hist` for GPU based external memory training.";
+      LOG(FATAL) << R"(
+External memory data matrix is used (out of core training).  Set `tree_method` to:
+  - `approx` for CPU based out of core training.
+  - `gpu_hist` for GPU based out of core training.
+)";
     }
   }
 

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -915,6 +915,9 @@ class LearnerImpl : public Learner {
           << "num rows: "     << p_fmat->Info().num_row_   << "\n"
           << "Number of weights should be equal to number of groups in ranking task.";
     }
+    if (tparam_.dsplit == DataSplitMode::kRow || tparam_.dsplit == DataSplitMode::kAuto) {
+      CHECK_EQ(learner_model_param_.num_feature, p_fmat->Info().num_col_);
+    }
   }
 
   // model parameter

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -60,6 +60,10 @@ class ColMaker: public TreeUpdater {
       spliteval_.reset(SplitEvaluator::Create(param_.split_evaluator));
     }
     spliteval_->Init(&param_);
+
+    if (rabit::IsDistributed()) {
+      LOG(FATAL) << "Updater `grow_colmaker` Exact doesn't support distributed training.";
+    }
   }
 
   void LoadConfig(Json const& in) override {

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -88,8 +88,7 @@ TEST(Learner, CheckGroup) {
   delete pp_mat;
 }
 
-TEST(Learner, SLOW_CheckMultiBatch) {
-  using Arg = std::pair<std::string, std::string>;
+TEST(Learner, SLOW_CheckMultiBatch) {  // NOLINT
   // Create sufficiently large data to make two row pages
   dmlc::TemporaryDirectory tempdir;
   const std::string tmp_file = tempdir.path + "/big.libsvm";
@@ -105,7 +104,7 @@ TEST(Learner, SLOW_CheckMultiBatch) {
   dmat->Info().SetInfo("label", labels.data(), DataType::kFloat32, num_row);
   std::vector<std::shared_ptr<DMatrix>> mat{dmat};
   auto learner = std::unique_ptr<Learner>(Learner::Create(mat));
-  learner->SetParams({Arg{"objective", "binary:logistic"}, Arg{"verbosity", "3"}});
+  learner->SetParams(Args{{"objective", "binary:logistic"}, {"tree_method", "approx"}});
   learner->UpdateOneIter(0, dmat.get());
 }
 

--- a/tests/python-gpu/test_gpu_pickling.py
+++ b/tests/python-gpu/test_gpu_pickling.py
@@ -6,7 +6,6 @@ import subprocess
 import os
 import json
 import pytest
-import copy
 
 import xgboost as xgb
 from xgboost import XGBClassifier

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -16,9 +16,6 @@ def assert_gpu_results(cpu_results, gpu_results):
                            gpu_res["eval"][-1], 1e-2, 1e-2)
 
 
-datasets = ["Boston", "Cancer", "Digits", "Sparse regression",
-            "Sparse regression with weights", "Small weights regression"]
-
 test_param = parameter_combinations({
     'gpu_id': [0],
     'max_depth': [2, 8],
@@ -34,21 +31,24 @@ class TestGPU(unittest.TestCase):
     def test_gpu_hist(self):
         for param in test_param:
             param['tree_method'] = 'gpu_hist'
-            gpu_results = run_suite(param, select_datasets=datasets)
+            gpu_results = run_suite(param, out_of_core=False)
             assert_results_non_increasing(gpu_results, 1e-2)
             param['tree_method'] = 'hist'
-            cpu_results = run_suite(param, select_datasets=datasets)
+            cpu_results = run_suite(param, out_of_core=False)
             assert_gpu_results(cpu_results, gpu_results)
 
-    # NOTE(rongou): Because the `Boston` dataset is too small, this only tests external memory mode
-    # with a single page. To test multiple pages, set DMatrix::kPageSize to, say, 1024.
+    # NOTE(rongou): Because the `Boston` dataset is too small, this only tests
+    # external memory mode
+    # with a single page. To test multiple pages, set DMatrix::kPageSize to,
+    # say, 1024.
     def test_external_memory(self):
         for param in reversed(test_param):
             param['tree_method'] = 'gpu_hist'
             param['gpu_page_size'] = 1024
             gpu_results = run_suite(param, select_datasets=["Boston"])
             assert_results_non_increasing(gpu_results, 1e-2)
-            ext_mem_results = run_suite(param, select_datasets=["Boston External Memory"])
+            ext_mem_results = run_suite(param, select_datasets=[
+                "Boston External Memory"])
             assert_results_non_increasing(ext_mem_results, 1e-2)
             assert_gpu_results(gpu_results, ext_mem_results)
             break
@@ -87,5 +87,5 @@ class TestGPU(unittest.TestCase):
                           'grow_policy': ['lossguide'],
                           'tree_method': ['gpu_hist']}
         for param in parameter_combinations(variable_param):
-            gpu_results = run_suite(param, select_datasets=datasets)
+            gpu_results = run_suite(param, out_of_core=False)
             assert_results_non_increasing(gpu_results, 1e-2)

--- a/tests/python-gpu/test_gpu_with_sklearn.py
+++ b/tests/python-gpu/test_gpu_with_sklearn.py
@@ -2,9 +2,11 @@ import xgboost as xgb
 import pytest
 import sys
 import numpy as np
+import unittest
 
 sys.path.append("tests/python")
-import testing as tm
+import testing as tm               # noqa
+import test_with_sklearn as twskl  # noqa
 
 pytestmark = pytest.mark.skipif(**tm.no_sklearn())
 
@@ -29,3 +31,10 @@ def test_gpu_binary_classification():
             err = sum(1 for i in range(len(preds))
                       if int(preds[i] > 0.5) != labels[i]) / float(len(preds))
             assert err < 0.1
+
+
+class TestGPUBoostFromPrediction(unittest.TestCase):
+    cpu_test = twskl.TestBoostFromPrediction()
+
+    def test_boost_from_prediction_gpu_hist(self):
+        self.cpu_test.run_boost_from_prediction('gpu_hist')

--- a/tests/python/regression_test_utilities.py
+++ b/tests/python/regression_test_utilities.py
@@ -126,9 +126,11 @@ def parameter_combinations(variable_param):
     return result
 
 
-def run_suite(param, num_rounds=10, select_datasets=None, scale_features=False):
-    """
-    Run the given parameters on a range of datasets. Objective and eval metric will be automatically set
+def run_suite(param, num_rounds=10, select_datasets=None, scale_features=False,
+              out_of_core=True):
+    """Run the given parameters on a range of datasets. Objective and eval metric
+    will be automatically set
+
     """
     datasets = [
         Dataset("Boston", get_boston, "reg:squarederror", "rmse"),
@@ -139,13 +141,15 @@ def run_suite(param, num_rounds=10, select_datasets=None, scale_features=False):
                 "reg:squarederror", "rmse", has_weights=True),
         Dataset("Small weights regression", get_small_weights,
                 "reg:squarederror", "rmse", has_weights=True),
-        Dataset("Boston External Memory", get_boston,
-                "reg:squarederror", "rmse",
-                use_external_memory=True)
     ]
+    if out_of_core:
+        datasets.append(
+            Dataset("Boston External Memory", get_boston,
+                    "reg:squarederror", "rmse",
+                    use_external_memory=True)
+        )
 
-    results = [
-    ]
+    results = []
     for d in datasets:
         if select_datasets is None or d.name in select_datasets:
             results.append(

--- a/tests/python/test_ranking.py
+++ b/tests/python/test_ranking.py
@@ -115,7 +115,6 @@ class TestRanking(unittest.TestCase):
         # model training parameters
         cls.params = {'objective': 'rank:pairwise',
                       'booster': 'gbtree',
-                      'silent': 0,
                       'eval_metric': ['ndcg']
                       }
 

--- a/tests/python/test_updaters.py
+++ b/tests/python/test_updaters.py
@@ -23,7 +23,7 @@ class TestUpdaters(unittest.TestCase):
     def test_colmaker(self):
         variable_param = {'updater': ['grow_colmaker'], 'max_depth': [2, 8]}
         for param in parameter_combinations(variable_param):
-            result = run_suite(param)
+            result = run_suite(param, out_of_core=False)
             assert_results_non_increasing(result, 1e-2)
 
     @pytest.mark.skipif(**tm.no_sklearn())
@@ -35,7 +35,7 @@ class TestUpdaters(unittest.TestCase):
                           'max_leaves': [64, 0],
                           'verbosity': [0]}
         for param in parameter_combinations(variable_param):
-            result = run_suite(param)
+            result = run_suite(param, out_of_core=False)
             assert_results_non_increasing(result, 1e-2)
 
         # hist must be same as exact on all-categorial data

--- a/tests/python/test_updaters.py
+++ b/tests/python/test_updaters.py
@@ -23,7 +23,7 @@ class TestUpdaters(unittest.TestCase):
     def test_colmaker(self):
         variable_param = {'updater': ['grow_colmaker'], 'max_depth': [2, 8]}
         for param in parameter_combinations(variable_param):
-            result = run_suite(param, out_of_core=False)
+            result = run_suite(param)
             assert_results_non_increasing(result, 1e-2)
 
     @pytest.mark.skipif(**tm.no_sklearn())

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -243,7 +243,7 @@ def test_parameter_tuning():
     boston = load_boston()
     y = boston['target']
     X = boston['data']
-    xgb_model = xgb.XGBRegressor()
+    xgb_model = xgb.XGBRegressor(tree_method='approx')
     clf = GridSearchCV(xgb_model, {'max_depth': [2, 4, 6],
                                    'n_estimators': [50, 100, 200]},
                        cv=3, verbose=1, iid=True)

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -718,7 +718,7 @@ class TestBoostFromPrediction(unittest.TestCase):
             learning_rate=0.3, random_state=0, n_estimators=8,
             tree_method=tree_method)
         cls_2.fit(X=X, y=y)
-        predictions_2 = cls_2.predict(X, base_margin=margin)
+        predictions_2 = cls_2.predict(X)
         assert np.all(predictions_1 == predictions_2)
 
     @pytest.mark.skipif(**tm.no_sklearn())


### PR DESCRIPTION
Currently XGBoost defaults to exact and approx for larger dataset.  But as `hist` tree method is more efficient, we may want to set it as default in 1.0.

- Set `hist` to default.
- Don't test external memory training on unsupported tree methods.
- Requires users to set appropriate tree method in distributed environment and external memory training, removing auto configurations.
- Add `refresh` as a tree method.

Passed all tests in C++/Python/R on my local machine, expecting some glitches on JVM side.