### PR TITLE
Extensible binary serialization format for DMatrix::MetaInfo

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -38,6 +38,9 @@ enum class DataType : uint8_t {
  */
 class MetaInfo {
  public:
+  /*! \brief number of data fields in MetaInfo */
+  static constexpr uint32_t kNumField = 7;
+
   /*! \brief number of rows in the data */
   uint64_t num_row_{0};
   /*! \brief number of columns in the data */
@@ -133,6 +136,12 @@ class MetaInfo {
  private:
   /*! \brief argsort of labels */
   mutable std::vector<size_t> label_order_cache_;
+
+  /* Facilities to binary serialization of DMatrix::MetaInfo */
+  struct FieldRecord {
+    std::string name;
+    uint64_t offset;
+  };
 };
 
 /*! \brief Element from a sparse vector */

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -39,7 +39,7 @@ enum class DataType : uint8_t {
 class MetaInfo {
  public:
   /*! \brief number of data fields in MetaInfo */
-  static constexpr uint32_t kNumField = 7;
+  static constexpr uint64_t kNumField = 7;
 
   /*! \brief number of rows in the data */
   uint64_t num_row_{0};

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -136,12 +136,6 @@ class MetaInfo {
  private:
   /*! \brief argsort of labels */
   mutable std::vector<size_t> label_order_cache_;
-
-  /* Facilities to binary serialization of DMatrix::MetaInfo */
-  struct FieldRecord {
-    std::string name;
-    uint64_t offset;
-  };
 };
 
 /*! \brief Element from a sparse vector */

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -26,7 +26,7 @@ namespace xgboost {
 class DMatrix;
 
 /*! \brief data type accepted by xgboost interface */
-enum DataType {
+enum class DataType : uint8_t {
   kFloat32 = 1,
   kDouble = 2,
   kUInt32 = 3,

--- a/include/xgboost/host_device_vector.h
+++ b/include/xgboost/host_device_vector.h
@@ -127,6 +127,8 @@ class HostDeviceVector {
 
   void Resize(size_t new_size, T v = T());
 
+  using value_type = T;
+
  private:
   HostDeviceVectorImpl<T>* impl_;
 };

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -361,7 +361,7 @@ XGB_DLL int XGDMatrixSetFloatInfo(DMatrixHandle handle,
   API_BEGIN();
   CHECK_HANDLE();
   static_cast<std::shared_ptr<DMatrix>*>(handle)
-      ->get()->Info().SetInfo(field, info, kFloat32, len);
+      ->get()->Info().SetInfo(field, info, xgboost::DataType::kFloat32, len);
   API_END();
 }
 
@@ -382,7 +382,7 @@ XGB_DLL int XGDMatrixSetUIntInfo(DMatrixHandle handle,
   API_BEGIN();
   CHECK_HANDLE();
   static_cast<std::shared_ptr<DMatrix>*>(handle)
-      ->get()->Info().SetInfo(field, info, kUInt32, len);
+      ->get()->Info().SetInfo(field, info, xgboost::DataType::kUInt32, len);
   API_END();
 }
 
@@ -393,7 +393,7 @@ XGB_DLL int XGDMatrixSetGroup(DMatrixHandle handle,
   CHECK_HANDLE();
   LOG(WARNING) << "XGDMatrixSetGroup is deprecated, use `XGDMatrixSetUIntInfo` instead.";
   static_cast<std::shared_ptr<DMatrix>*>(handle)
-      ->get()->Info().SetInfo("group", group, kUInt32, len);
+      ->get()->Info().SetInfo("group", group, xgboost::DataType::kUInt32, len);
   API_END();
 }
 

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -109,10 +109,10 @@ void LoadVectorField(dmlc::Stream* strm, const std::string& expected_name,
 }
 
 template <typename T>
-void LoadVectorField(dmlc::Stream* strm, const std::string& expected_field_name,
-                     xgboost::DataType expected_field_type,
+void LoadVectorField(dmlc::Stream* strm, const std::string& expected_name,
+                     xgboost::DataType expected_type,
                      xgboost::HostDeviceVector<T>* field) {
-  LoadVectorField(strm, expected_field_name, expected_field_type, &field->HostVector());
+  LoadVectorField(strm, expected_name, expected_type, &field->HostVector());
 }
 
 }  // anonymous namespace
@@ -133,7 +133,7 @@ void MetaInfo::Clear() {
 /*
  * Binary serialization format for MetaInfo:
  *
- * | name        | type     | is_vector | num_row | num_col | value           |
+ * | name        | type     | is_scalar | num_row | num_col | value           |
  * |-------------+----------+-----------+---------+---------+-----------------|
  * | num_row     | kUInt64  | True      | NA      |      NA | ${num_row_}     |
  * | num_col     | kUInt64  | True      | NA      |      NA | ${num_col_}     |
@@ -143,7 +143,7 @@ void MetaInfo::Clear() {
  * | weights     | kFloat32 | False     | ${size} |       1 | ${weights_}     |
  * | base_margin | kFloat32 | False     | ${size} |       1 | ${base_margin_} |
  *
- * Note that the scalar fields (is_vector=True) will have num_row and num_col missing.
+ * Note that the scalar fields (is_scalar=True) will have num_row and num_col missing.
  * Also notice the difference between the saved name and the name used in `SetInfo':
  * the former uses the plural form.
  */

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -62,7 +62,6 @@ void MetaInfo::SaveBinary(dmlc::Stream *fo) const {
   fo->Write(std::string(u8"weights")); fo->Write(offset);
   offset += sizeof(decltype(weights_)::value_type) * weights_.Size(); ++field_cnt;
   fo->Write(std::string(u8"base_margin")); fo->Write(offset);
-  offset += sizeof(decltype(base_margin_)::value_type) * base_margin_.Size(); ++field_cnt;
   CHECK(field_cnt == kNumField) << "Wrong number of fields";
 
   /* Write data */

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -98,7 +98,7 @@ inline void LoadField(dmlc::Stream* strm, const std::string& expected_field_name
   LoadField(strm, expected_field_name, expected_field_type, &field->HostVector());
 }
 
-}  // namespace anonymous
+}  // anonymous namespace
 
 namespace xgboost {
 // implementation of inline functions
@@ -153,7 +153,6 @@ void MetaInfo::LoadBinary(dmlc::Stream *fi) {
   LoadField(fi, u8"group_ptr", DataType::kUInt32, &group_ptr_);
   LoadField(fi, u8"weights", DataType::kFloat32, &weights_);
   LoadField(fi, u8"base_margin", DataType::kFloat32, &base_margin_);
-
 }
 
 // try to load group information from file, if exists

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -102,19 +102,19 @@ inline bool MetaTryLoadFloatInfo(const std::string& fname,
 // macro to dispatch according to specified pointer types
 #define DISPATCH_CONST_PTR(dtype, old_ptr, cast_ptr, proc)              \
   switch (dtype) {                                                      \
-    case kFloat32: {                                                    \
+    case xgboost::DataType::kFloat32: {                                 \
       auto cast_ptr = reinterpret_cast<const float*>(old_ptr); proc; break; \
     }                                                                   \
-    case kDouble: {                                                     \
+    case xgboost::DataType::kDouble: {                                  \
       auto cast_ptr = reinterpret_cast<const double*>(old_ptr); proc; break; \
     }                                                                   \
-    case kUInt32: {                                                     \
+    case xgboost::DataType::kUInt32: {                                  \
       auto cast_ptr = reinterpret_cast<const uint32_t*>(old_ptr); proc; break; \
     }                                                                   \
-    case kUInt64: {                                                     \
+    case xgboost::DataType::kUInt64: {                                  \
       auto cast_ptr = reinterpret_cast<const uint64_t*>(old_ptr); proc; break; \
     }                                                                   \
-    default: LOG(FATAL) << "Unknown data type" << dtype;                \
+    default: LOG(FATAL) << "Unknown data type" << static_cast<uint8_t>(dtype); \
   }                                                                     \
 
 void MetaInfo::SetInfo(const char* key, const void* dptr, DataType dtype, size_t num) {

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -62,6 +62,7 @@ void MetaInfo::SaveBinary(dmlc::Stream *fo) const {
   fo->Write(std::string(u8"weights")); fo->Write(offset);
   offset += sizeof(decltype(weights_)::value_type) * weights_.Size(); ++field_cnt;
   fo->Write(std::string(u8"base_margin")); fo->Write(offset);
+  ++field_cnt;
   CHECK(field_cnt == kNumField) << "Wrong number of fields";
 
   /* Write data */

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -29,19 +29,11 @@ DMLC_REGISTRY_ENABLE(::xgboost::data::SparsePageFormatReg<::xgboost::SortedCSCPa
 DMLC_REGISTRY_ENABLE(::xgboost::data::SparsePageFormatReg<::xgboost::EllpackPage>);
 }  // namespace dmlc
 
-namespace xgboost {
-// implementation of inline functions
-void MetaInfo::Clear() {
-  num_row_ = num_col_ = num_nonzero_ = 0;
-  labels_.HostVector().clear();
-  group_ptr_.clear();
-  weights_.HostVector().clear();
-  base_margin_.HostVector().clear();
-}
+namespace {
 
 template <typename T>
 inline void SaveField(dmlc::Stream* strm, const std::string& field_name,
-                      DataType field_type, const T& field) {
+                      xgboost::DataType field_type, const T& field) {
   const uint64_t sz = 1;
   strm->Write(field_name);
   strm->Write(field_type);
@@ -51,7 +43,7 @@ inline void SaveField(dmlc::Stream* strm, const std::string& field_name,
 
 template <typename T>
 inline void SaveField(dmlc::Stream* strm, const std::string& field_name,
-                      DataType field_type, const std::vector<T>& field) {
+                      xgboost::DataType field_type, const std::vector<T>& field) {
   strm->Write(field_name);
   strm->Write(field_type);
   strm->Write(field);
@@ -59,15 +51,15 @@ inline void SaveField(dmlc::Stream* strm, const std::string& field_name,
 
 template <typename T>
 inline void SaveField(dmlc::Stream* strm, const std::string& field_name,
-                      DataType field_type, const HostDeviceVector<T>& field) {
+                      xgboost::DataType field_type, const xgboost::HostDeviceVector<T>& field) {
   SaveField(strm, field_name, field_type, field.ConstHostVector());
 }
 
 template <typename T>
 inline void LoadField(dmlc::Stream* strm, const std::string& expected_field_name,
-                      DataType expected_field_type, T* field) {
+                      xgboost::DataType expected_field_type, T* field) {
   std::string field_name;
-  DataType field_type;
+  xgboost::DataType field_type;
   uint64_t sz;
   CHECK(strm->Read(&field_name)) << "MetaInfo: invalid format";
   CHECK_EQ(field_name, expected_field_name)
@@ -86,9 +78,9 @@ inline void LoadField(dmlc::Stream* strm, const std::string& expected_field_name
 
 template <typename T>
 inline void LoadField(dmlc::Stream* strm, const std::string& expected_field_name,
-                      DataType expected_field_type, std::vector<T>* field) {
+                      xgboost::DataType expected_field_type, std::vector<T>* field) {
   std::string field_name;
-  DataType field_type;
+  xgboost::DataType field_type;
   CHECK(strm->Read(&field_name)) << "MetaInfo: invalid format";
   CHECK_EQ(field_name, expected_field_name)
     << "MetaInfo: invalid format; expected field " << expected_field_name
@@ -102,8 +94,20 @@ inline void LoadField(dmlc::Stream* strm, const std::string& expected_field_name
 
 template <typename T>
 inline void LoadField(dmlc::Stream* strm, const std::string& expected_field_name,
-                      DataType expected_field_type, HostDeviceVector<T>* field) {
+                      xgboost::DataType expected_field_type, xgboost::HostDeviceVector<T>* field) {
   LoadField(strm, expected_field_name, expected_field_type, &field->HostVector());
+}
+
+}  // namespace anonymous
+
+namespace xgboost {
+// implementation of inline functions
+void MetaInfo::Clear() {
+  num_row_ = num_col_ = num_nonzero_ = 0;
+  labels_.HostVector().clear();
+  group_ptr_.clear();
+  weights_.HostVector().clear();
+  base_margin_.HostVector().clear();
 }
 
 void MetaInfo::SaveBinary(dmlc::Stream *fo) const {

--- a/tests/cpp/data/test_metainfo.cc
+++ b/tests/cpp/data/test_metainfo.cc
@@ -47,11 +47,11 @@ TEST(MetaInfo, SaveLoadBinary) {
                      static float f = 0;
                      return f++;
                    };
-  std::vector<float> values { kRows };
+  std::vector<float> values (kRows);
   std::generate(values.begin(), values.end(), generator);
-  info.SetInfo("label", values.data(), xgboost::DataType::kFloat32, 2);
-  info.SetInfo("weight", values.data(), xgboost::DataType::kFloat32, 2);
-  info.SetInfo("base_margin", values.data(), xgboost::DataType::kFloat32, 2);
+  info.SetInfo("label", values.data(), xgboost::DataType::kFloat32, kRows);
+  info.SetInfo("weight", values.data(), xgboost::DataType::kFloat32, kRows);
+  info.SetInfo("base_margin", values.data(), xgboost::DataType::kFloat32, kRows);
   info.num_row_ = kRows;
   info.num_col_ = kCols;
 
@@ -71,9 +71,12 @@ TEST(MetaInfo, SaveLoadBinary) {
     };
     xgboost::MetaInfo inforead;
     inforead.LoadBinary(fs.get());
+    ASSERT_EQ(inforead.num_row_, kRows);
     EXPECT_EQ(inforead.num_row_, info.num_row_);
     EXPECT_EQ(inforead.num_col_, info.num_col_);
     EXPECT_EQ(inforead.num_nonzero_, info.num_nonzero_);
+
+    ASSERT_EQ(inforead.labels_.HostVector(), values);
     EXPECT_EQ(inforead.labels_.HostVector(), info.labels_.HostVector());
     EXPECT_EQ(inforead.group_ptr_, info.group_ptr_);
     EXPECT_EQ(inforead.weights_.HostVector(), info.weights_.HostVector());

--- a/tests/cpp/data/test_metainfo.cc
+++ b/tests/cpp/data/test_metainfo.cc
@@ -14,23 +14,23 @@ TEST(MetaInfo, GetSet) {
   double double2[2] = {1.0, 2.0};
 
   EXPECT_EQ(info.labels_.Size(), 0);
-  info.SetInfo("label", double2, xgboost::kFloat32, 2);
+  info.SetInfo("label", double2, xgboost::DataType::kFloat32, 2);
   EXPECT_EQ(info.labels_.Size(), 2);
 
   float float2[2] = {1.0f, 2.0f};
   EXPECT_EQ(info.GetWeight(1), 1.0f)
     << "When no weights are given, was expecting default value 1";
-  info.SetInfo("weight", float2, xgboost::kFloat32, 2);
+  info.SetInfo("weight", float2, xgboost::DataType::kFloat32, 2);
   EXPECT_EQ(info.GetWeight(1), 2.0f);
 
   uint32_t uint32_t2[2] = {1U, 2U};
   EXPECT_EQ(info.base_margin_.Size(), 0);
-  info.SetInfo("base_margin", uint32_t2, xgboost::kUInt32, 2);
+  info.SetInfo("base_margin", uint32_t2, xgboost::DataType::kUInt32, 2);
   EXPECT_EQ(info.base_margin_.Size(), 2);
 
   uint64_t uint64_t2[2] = {1U, 2U};
   EXPECT_EQ(info.group_ptr_.size(), 0);
-  info.SetInfo("group", uint64_t2, xgboost::kUInt64, 2);
+  info.SetInfo("group", uint64_t2, xgboost::DataType::kUInt64, 2);
   ASSERT_EQ(info.group_ptr_.size(), 3);
   EXPECT_EQ(info.group_ptr_[2], 3);
 
@@ -41,7 +41,7 @@ TEST(MetaInfo, GetSet) {
 TEST(MetaInfo, SaveLoadBinary) {
   xgboost::MetaInfo info;
   double vals[2] = {1.0, 2.0};
-  info.SetInfo("label", vals, xgboost::kDouble, 2);
+  info.SetInfo("label", vals, xgboost::DataType::kDouble, 2);
   info.num_row_ = 2;
   info.num_col_ = 1;
 

--- a/tests/cpp/data/test_metainfo.cc
+++ b/tests/cpp/data/test_metainfo.cc
@@ -55,8 +55,6 @@ TEST(MetaInfo, SaveLoadBinary) {
     info.SaveBinary(fs.get());
   }
 
-  const auto tmp_file_size = GetFileSize(tmp_file);
-
   {
     // Inspect content of header
     std::unique_ptr<dmlc::Stream> fs{


### PR DESCRIPTION
This PR implements a brand-new way to serialize DMatrix::MetaInfo into a binary stream. See discussion for new binary format in #4956. The idea is to add a header consisting of field names as well as byte offsets. The header makes it easy to add a new field over time.

The layout of the file is as follows:
* Header
  - Name of field 0, Byte offset of field 0
  - Name of field 1, Byte offset of field 1
  - ...
* Data
  - Byte representation of field 0
  - Byte representation of field 1
  - ...

**Assumptions**
* We assume that fields are added and never removed (unless we bump up the major version). The order of existing fields does not change. (So Field 0 will always correspond to `num_row`, Field 3 to `labels`, and so forth.) New fields are appended at the end of the list. Currently, we have 7 fields:
  - Field 0: `num_row`
  - Field 1: `num_col`
  - Field 2: `num_nonzero`
  - Field 3: `labels`
  - Field 4: `group_ptr`
  - Field 5: `weights`
  - Field 6: `base_margin`
* Byte offset is counted from the end of the header.

For now, I'm only using the field name to validate existence of each field. Since `dmlc::Stream` is sequential (no seeking allowed), we are unable to make use of byte offsets to jump to a particular field.

Closes #4956.
Unblocks the Survival Analysis PR #4763.

@trivialfis @RAMitchell 