### PR TITLE
Enforce correct data shape.

### DIFF
--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -112,18 +112,26 @@ Parameters for Tree Booster
 
   - The tree construction algorithm used in XGBoost. See description in the `reference paper <http://arxiv.org/abs/1603.02754>`_.
   - XGBoost supports  ``approx``, ``hist`` and ``gpu_hist`` for distributed training.  Experimental support for external memory is available for ``approx`` and ``gpu_hist``.
-  - Choices: ``auto``, ``exact``, ``approx``, ``hist``, ``gpu_hist``
+
+  - Choices: ``auto``, ``exact``, ``approx``, ``hist``, ``gpu_hist``, this is a
+    combination of commonly used updaters.  For other updaters like ``refresh``, set the
+    parameter ``updater`` directly.
 
     - ``auto``: Use heuristic to choose the fastest method.
 
-      - For small to medium dataset, exact greedy (``exact``) will be used.
-      - For very large dataset, approximate algorithm (``approx``) will be chosen.
-      - Because old behavior is always use exact greedy in single machine,
-        user will get a message when approximate algorithm is chosen to notify this choice.
+      - For small dataset, exact greedy (``exact``) will be used.
+      - For larger dataset, approximate algorithm (``approx``) will be chosen.  It's
+        recommended to try ``hist`` and ``gpu_hist`` for higher performance with large
+        dataset.  The reasons they aren't default yet are because XGBoost has some
+        existing tests tied to ``approx``, and only GPU version of ``hist``
+        (``gpu_hist``)has support for ``external memory``.
 
-    - ``exact``: Exact greedy algorithm.
+      - Because old behavior is always use exact greedy in single machine, user will get a
+        message when approximate algorithm is chosen to notify this choice.
+    - ``exact``: Exact greedy algorithm.  Enumerates all split candidates.
     - ``approx``: Approximate greedy algorithm using quantile sketch and gradient histogram.
-    - ``hist``: Fast histogram optimized approximate greedy algorithm. It uses some performance improvements such as bins caching.
+    - ``hist``: Faster histogram optimized approximate greedy algorithm. It uses some
+      performance improvements such as bins caching.
     - ``gpu_hist``: GPU implementation of ``hist`` algorithm.
 
 * ``sketch_eps`` [default=0.03]

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -122,16 +122,14 @@ Parameters for Tree Booster
       - For small dataset, exact greedy (``exact``) will be used.
       - For larger dataset, approximate algorithm (``approx``) will be chosen.  It's
         recommended to try ``hist`` and ``gpu_hist`` for higher performance with large
-        dataset.  The reasons they aren't default yet are because XGBoost has some
-        existing tests tied to ``approx``, and only GPU version of ``hist``
+        dataset.
         (``gpu_hist``)has support for ``external memory``.
 
       - Because old behavior is always use exact greedy in single machine, user will get a
         message when approximate algorithm is chosen to notify this choice.
     - ``exact``: Exact greedy algorithm.  Enumerates all split candidates.
     - ``approx``: Approximate greedy algorithm using quantile sketch and gradient histogram.
-    - ``hist``: Faster histogram optimized approximate greedy algorithm. It uses some
-      performance improvements such as bins caching.
+    - ``hist``: Faster histogram optimized approximate greedy algorithm.
     - ``gpu_hist``: GPU implementation of ``hist`` algorithm.
 
 * ``sketch_eps`` [default=0.03]

--- a/doc/tutorials/param_tuning.rst
+++ b/doc/tutorials/param_tuning.rst
@@ -38,6 +38,11 @@ There are in general two ways that you can control overfitting in XGBoost:
   - This includes ``subsample`` and ``colsample_bytree``.
   - You can also reduce stepsize ``eta``. Remember to increase ``num_round`` when you do so.
 
+***************************
+Faster training performance
+***************************
+There's a parameter called ``tree_method``, set it to ``hist`` or ``gpu_hist`` for faster computation.
+
 *************************
 Handle Imbalanced Dataset
 *************************

--- a/include/xgboost/generic_parameters.h
+++ b/include/xgboost/generic_parameters.h
@@ -29,6 +29,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
   size_t gpu_page_size;
   bool enable_experimental_json_serialization {false};
   bool validate_parameters {false};
+  bool validate_features {true};
 
   void CheckDeprecated() {
     if (this->n_gpus != 0) {
@@ -73,7 +74,10 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
                   "rabit checkpoints etc.).");
     DMLC_DECLARE_FIELD(validate_parameters)
         .set_default(false)
-        .describe("Enable to check whether parameters are used or not.");
+        .describe("Enable checking whether parameters are used or not.");
+    DMLC_DECLARE_FIELD(validate_features)
+        .set_default(false)
+        .describe("Enable validating input DMatrix.");
     DMLC_DECLARE_FIELD(n_gpus)
         .set_default(0)
         .set_range(0, 1)

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -49,7 +49,7 @@ public class Booster implements Serializable, KryoSerializable {
    */
   Booster(Map<String, Object> params, DMatrix[] cacheMats) throws XGBoostError {
     init(cacheMats);
-    setParam("seed", "0");
+    setParam("validate_features", "0");
     setParams(params);
   }
 

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -49,7 +49,7 @@ public class Booster implements Serializable, KryoSerializable {
    */
   Booster(Map<String, Object> params, DMatrix[] cacheMats) throws XGBoostError {
     init(cacheMats);
-    setParam("validate_features", "0");
+    setParam("seed", "0");
     setParams(params);
   }
 

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -22,11 +22,6 @@
 #include <vector>
 #include <string>
 
-#define JVM_CHECK_CALL(__errcode)                   \
-  if ((__errcode) != 0) {                       \
-    return __errcode;                           \
-  }
-
 // helper functions
 // set handle
 void setHandle(JNIEnv *jenv, jlongArray jhandle, void* handle) {
@@ -182,7 +177,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   }
   int ret = XGDMatrixCreateFromDataIter(
       jiter, XGBoost4jCallbackDataIterNext, cache_info, &result);
-  JVM_CHECK_CALL(ret);
   if (cache_info) {
     jenv->ReleaseStringUTFChars(jcache_info, cache_info);
   }
@@ -200,7 +194,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   DMatrixHandle result;
   const char* fname = jenv->GetStringUTFChars(jfname, 0);
   int ret = XGDMatrixCreateFromFile(fname, jsilent, &result);
-  JVM_CHECK_CALL(ret);
   if (fname) {
     jenv->ReleaseStringUTFChars(jfname, fname);
   }
@@ -221,11 +214,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   jfloat* data = jenv->GetFloatArrayElements(jdata, 0);
   bst_ulong nindptr = (bst_ulong)jenv->GetArrayLength(jindptr);
   bst_ulong nelem = (bst_ulong)jenv->GetArrayLength(jdata);
-  jint ret = (jint) XGDMatrixCreateFromCSREx((size_t const *)indptr,
-                                             (unsigned int const *)indices,
-                                             (float const *)data,
-                                             nindptr, nelem, jcol, &result);
-  JVM_CHECK_CALL(ret);
+  jint ret = (jint) XGDMatrixCreateFromCSREx((size_t const *)indptr, (unsigned int const *)indices, (float const *)data, nindptr, nelem, jcol, &result);
   setHandle(jenv, jout, result);
   //Release
   jenv->ReleaseLongArrayElements(jindptr, indptr, 0);
@@ -248,11 +237,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   bst_ulong nindptr = (bst_ulong)jenv->GetArrayLength(jindptr);
   bst_ulong nelem = (bst_ulong)jenv->GetArrayLength(jdata);
 
-  jint ret = (jint) XGDMatrixCreateFromCSCEx((size_t const *)indptr,
-                                             (unsigned int const *)indices,
-                                             (float const *)data,
-                                             nindptr, nelem, jrow, &result);
-  JVM_CHECK_CALL(ret);
+  jint ret = (jint) XGDMatrixCreateFromCSCEx((size_t const *)indptr, (unsigned int const *)indices, (float const *)data, nindptr, nelem, jrow, &result);
   setHandle(jenv, jout, result);
   //release
   jenv->ReleaseLongArrayElements(jindptr, indptr, 0);
@@ -273,7 +258,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   bst_ulong nrow = (bst_ulong)jnrow;
   bst_ulong ncol = (bst_ulong)jncol;
   jint ret = (jint) XGDMatrixCreateFromMat((float const *)jdataRef, nrow, ncol, jmiss, &result);
-  JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   return ret;
 }
@@ -291,7 +275,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   bst_ulong nrow = (bst_ulong)jnrow;
   bst_ulong ncol = (bst_ulong)jncol;
   jint ret = (jint) XGDMatrixCreateFromMat((float const *)data, nrow, ncol, jmiss, &result);
-  JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   //release
   jenv->ReleaseFloatArrayElements(jdata, data, 0);
@@ -313,7 +296,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSliceDMat
 
   // default to not allowing slicing with group ID specified -- feel free to add if necessary
   jint ret = (jint) XGDMatrixSliceDMatrixEx(handle, (int const *)indexset, len, &result, 0);
-  JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   //release
   jenv->ReleaseIntArrayElements(jindexset, indexset, 0);
@@ -343,7 +325,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSaveBinar
   DMatrixHandle handle = (DMatrixHandle) jhandle;
   const char* fname = jenv->GetStringUTFChars(jfname, 0);
   int ret = XGDMatrixSaveBinary(handle, fname, jsilent);
-  JVM_CHECK_CALL(ret);
   if (fname) jenv->ReleaseStringUTFChars(jfname, (const char *)fname);
   return ret;
 }
@@ -361,7 +342,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetFloatI
   jfloat* array = jenv->GetFloatArrayElements(jarray, NULL);
   bst_ulong len = (bst_ulong)jenv->GetArrayLength(jarray);
   int ret = XGDMatrixSetFloatInfo(handle, field, (float const *)array, len);
-  JVM_CHECK_CALL(ret);
   //release
   if (field) jenv->ReleaseStringUTFChars(jfield, field);
   jenv->ReleaseFloatArrayElements(jarray, array, 0);
@@ -380,7 +360,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetUIntIn
   jint* array = jenv->GetIntArrayElements(jarray, NULL);
   bst_ulong len = (bst_ulong)jenv->GetArrayLength(jarray);
   int ret = XGDMatrixSetUIntInfo(handle, (char const *)field, (unsigned int const *)array, len);
-  JVM_CHECK_CALL(ret);
   //release
   if (field) jenv->ReleaseStringUTFChars(jfield, (const char *)field);
   jenv->ReleaseIntArrayElements(jarray, array, 0);
@@ -400,7 +379,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetFloatI
   bst_ulong len;
   float *result;
   int ret = XGDMatrixGetFloatInfo(handle, field, &len, (const float**) &result);
-  JVM_CHECK_CALL(ret);
   if (field) jenv->ReleaseStringUTFChars(jfield, field);
 
   jsize jlen = (jsize) len;
@@ -423,7 +401,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetUIntIn
   bst_ulong len;
   unsigned int *result;
   int ret = (jint) XGDMatrixGetUIntInfo(handle, field, &len, (const unsigned int **) &result);
-  JVM_CHECK_CALL(ret);
   if (field) jenv->ReleaseStringUTFChars(jfield, field);
 
   jsize jlen = (jsize) len;
@@ -443,7 +420,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixNumRow
   DMatrixHandle handle = (DMatrixHandle) jhandle;
   bst_ulong result[1];
   int ret = (jint) XGDMatrixNumRow(handle, result);
-  JVM_CHECK_CALL(ret);
   jenv->SetLongArrayRegion(jout, 0, 1, (const jlong *) result);
   return ret;
 }
@@ -466,7 +442,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterCreate
   }
   BoosterHandle result;
   int ret = XGBoosterCreate(dmlc::BeginPtr(handles), handles.size(), &result);
-  JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   return ret;
 }
@@ -494,7 +469,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetParam
   const char* name = jenv->GetStringUTFChars(jname, 0);
   const char* value = jenv->GetStringUTFChars(jvalue, 0);
   int ret = XGBoosterSetParam(handle, name, value);
-  JVM_CHECK_CALL(ret);
   //release
   if (name) jenv->ReleaseStringUTFChars(jname, name);
   if (value) jenv->ReleaseStringUTFChars(jvalue, value);
@@ -526,7 +500,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterBoostOneI
   jfloat* hess = jenv->GetFloatArrayElements(jhess, 0);
   bst_ulong len = (bst_ulong)jenv->GetArrayLength(jgrad);
   int ret = XGBoosterBoostOneIter(handle, dtrain, grad, hess, len);
-  JVM_CHECK_CALL(ret);
   //release
   jenv->ReleaseFloatArrayElements(jgrad, grad, 0);
   jenv->ReleaseFloatArrayElements(jhess, hess, 0);
@@ -564,7 +537,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterEvalOneIt
                                  dmlc::BeginPtr(dmats),
                                  dmlc::BeginPtr(evchars),
                                  len, &result);
-  JVM_CHECK_CALL(ret);
   jstring jinfo = nullptr;
   if (result != nullptr) {
     jinfo = jenv->NewStringUTF(result);
@@ -585,7 +557,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredict
   bst_ulong len;
   float *result;
   int ret = XGBoosterPredict(handle, dmat, joption_mask, (unsigned int) jntree_limit, &len, (const float **) &result);
-  JVM_CHECK_CALL(ret);
   if (len) {
     jsize jlen = (jsize) len;
     jfloatArray jarray = jenv->NewFloatArray(jlen);
@@ -606,10 +577,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterLoadModel
   const char* fname = jenv->GetStringUTFChars(jfname, 0);
 
   int ret = XGBoosterLoadModel(handle, fname);
-  JVM_CHECK_CALL(ret);
-  if (fname) {
-    jenv->ReleaseStringUTFChars(jfname,fname);
-  }
+  if (fname) jenv->ReleaseStringUTFChars(jfname,fname);
   return ret;
 }
 
@@ -624,10 +592,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSaveModel
   const char*  fname = jenv->GetStringUTFChars(jfname, 0);
 
   int ret = XGBoosterSaveModel(handle, fname);
-  JVM_CHECK_CALL(ret);
-  if (fname) {
-    jenv->ReleaseStringUTFChars(jfname, fname);
-  }
+  if (fname) jenv->ReleaseStringUTFChars(jfname, fname);
   return ret;
 }
 
@@ -642,7 +607,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterLoadModel
   jbyte* buffer = jenv->GetByteArrayElements(jbytes, 0);
   int ret = XGBoosterLoadModelFromBuffer(
       handle, buffer, jenv->GetArrayLength(jbytes));
-  JVM_CHECK_CALL(ret);
   jenv->ReleaseByteArrayElements(jbytes, buffer, 0);
   return ret;
 }
@@ -658,7 +622,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetModelR
   bst_ulong len = 0;
   const char* result;
   int ret = XGBoosterGetModelRaw(handle, &len, &result);
-  JVM_CHECK_CALL(ret);
 
   if (result) {
     jbyteArray jarray = jenv->NewByteArray(len);
@@ -682,7 +645,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModel
   char **result;
 
   int ret = XGBoosterDumpModelEx(handle, fmap, jwith_stats, format, &len, (const char ***) &result);
-  JVM_CHECK_CALL(ret);
 
   jsize jlen = (jsize) len;
   jobjectArray jinfos = jenv->NewObjectArray(jlen, jenv->FindClass("java/lang/String"), jenv->NewStringUTF(""));
@@ -734,7 +696,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModel
                                              (const char **) dmlc::BeginPtr(feature_names_char),
                                              (const char **) dmlc::BeginPtr(feature_types_char),
                                              jwith_stats, format, &len, (const char ***) &result);
-  JVM_CHECK_CALL(ret);
 
   jsize jlen = (jsize) len;
   jobjectArray jinfos = jenv->NewObjectArray(jlen, jenv->FindClass("java/lang/String"), jenv->NewStringUTF(""));
@@ -757,7 +718,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetAttrNa
   bst_ulong len = 0;
   char **result;
   int ret = XGBoosterGetAttrNames(handle, &len, (const char ***) &result);
-  JVM_CHECK_CALL(ret);
 
   jsize jlen = (jsize) len;
   jobjectArray jinfos = jenv->NewObjectArray(jlen, jenv->FindClass("java/lang/String"), jenv->NewStringUTF(""));
@@ -781,7 +741,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetAttr
   const char* result;
   int success;
   int ret = XGBoosterGetAttr(handle, key, &result, &success);
-  JVM_CHECK_CALL(ret);
   //release
   if (key) jenv->ReleaseStringUTFChars(jkey, key);
 
@@ -804,7 +763,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetAttr
   const char* key = jenv->GetStringUTFChars(jkey, 0);
   const char* value = jenv->GetStringUTFChars(jvalue, 0);
   int ret = XGBoosterSetAttr(handle, key, value);
-  JVM_CHECK_CALL(ret);
   //release
   if (key) jenv->ReleaseStringUTFChars(jkey, key);
   if (value) jenv->ReleaseStringUTFChars(jvalue, value);
@@ -821,7 +779,6 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterLoadRabit
   BoosterHandle handle = (BoosterHandle) jhandle;
   int version;
   int ret = XGBoosterLoadRabitCheckpoint(handle, &version);
-  JVM_CHECK_CALL(ret);
   jint jversion = version;
   jenv->SetIntArrayRegion(jout, 0, 1, &jversion);
   return ret;

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -22,6 +22,11 @@
 #include <vector>
 #include <string>
 
+#define JVM_CHECK_CALL(__errcode)                   \
+  if ((__errcode) != 0) {                       \
+    return __errcode;                           \
+  }
+
 // helper functions
 // set handle
 void setHandle(JNIEnv *jenv, jlongArray jhandle, void* handle) {
@@ -177,6 +182,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   }
   int ret = XGDMatrixCreateFromDataIter(
       jiter, XGBoost4jCallbackDataIterNext, cache_info, &result);
+  JVM_CHECK_CALL(ret);
   if (cache_info) {
     jenv->ReleaseStringUTFChars(jcache_info, cache_info);
   }
@@ -194,6 +200,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   DMatrixHandle result;
   const char* fname = jenv->GetStringUTFChars(jfname, 0);
   int ret = XGDMatrixCreateFromFile(fname, jsilent, &result);
+  JVM_CHECK_CALL(ret);
   if (fname) {
     jenv->ReleaseStringUTFChars(jfname, fname);
   }
@@ -214,7 +221,11 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   jfloat* data = jenv->GetFloatArrayElements(jdata, 0);
   bst_ulong nindptr = (bst_ulong)jenv->GetArrayLength(jindptr);
   bst_ulong nelem = (bst_ulong)jenv->GetArrayLength(jdata);
-  jint ret = (jint) XGDMatrixCreateFromCSREx((size_t const *)indptr, (unsigned int const *)indices, (float const *)data, nindptr, nelem, jcol, &result);
+  jint ret = (jint) XGDMatrixCreateFromCSREx((size_t const *)indptr,
+                                             (unsigned int const *)indices,
+                                             (float const *)data,
+                                             nindptr, nelem, jcol, &result);
+  JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   //Release
   jenv->ReleaseLongArrayElements(jindptr, indptr, 0);
@@ -237,7 +248,11 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   bst_ulong nindptr = (bst_ulong)jenv->GetArrayLength(jindptr);
   bst_ulong nelem = (bst_ulong)jenv->GetArrayLength(jdata);
 
-  jint ret = (jint) XGDMatrixCreateFromCSCEx((size_t const *)indptr, (unsigned int const *)indices, (float const *)data, nindptr, nelem, jrow, &result);
+  jint ret = (jint) XGDMatrixCreateFromCSCEx((size_t const *)indptr,
+                                             (unsigned int const *)indices,
+                                             (float const *)data,
+                                             nindptr, nelem, jrow, &result);
+  JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   //release
   jenv->ReleaseLongArrayElements(jindptr, indptr, 0);
@@ -258,6 +273,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   bst_ulong nrow = (bst_ulong)jnrow;
   bst_ulong ncol = (bst_ulong)jncol;
   jint ret = (jint) XGDMatrixCreateFromMat((float const *)jdataRef, nrow, ncol, jmiss, &result);
+  JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   return ret;
 }
@@ -275,6 +291,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   bst_ulong nrow = (bst_ulong)jnrow;
   bst_ulong ncol = (bst_ulong)jncol;
   jint ret = (jint) XGDMatrixCreateFromMat((float const *)data, nrow, ncol, jmiss, &result);
+  JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   //release
   jenv->ReleaseFloatArrayElements(jdata, data, 0);
@@ -296,6 +313,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSliceDMat
 
   // default to not allowing slicing with group ID specified -- feel free to add if necessary
   jint ret = (jint) XGDMatrixSliceDMatrixEx(handle, (int const *)indexset, len, &result, 0);
+  JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   //release
   jenv->ReleaseIntArrayElements(jindexset, indexset, 0);
@@ -325,6 +343,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSaveBinar
   DMatrixHandle handle = (DMatrixHandle) jhandle;
   const char* fname = jenv->GetStringUTFChars(jfname, 0);
   int ret = XGDMatrixSaveBinary(handle, fname, jsilent);
+  JVM_CHECK_CALL(ret);
   if (fname) jenv->ReleaseStringUTFChars(jfname, (const char *)fname);
   return ret;
 }
@@ -342,6 +361,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetFloatI
   jfloat* array = jenv->GetFloatArrayElements(jarray, NULL);
   bst_ulong len = (bst_ulong)jenv->GetArrayLength(jarray);
   int ret = XGDMatrixSetFloatInfo(handle, field, (float const *)array, len);
+  JVM_CHECK_CALL(ret);
   //release
   if (field) jenv->ReleaseStringUTFChars(jfield, field);
   jenv->ReleaseFloatArrayElements(jarray, array, 0);
@@ -360,6 +380,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetUIntIn
   jint* array = jenv->GetIntArrayElements(jarray, NULL);
   bst_ulong len = (bst_ulong)jenv->GetArrayLength(jarray);
   int ret = XGDMatrixSetUIntInfo(handle, (char const *)field, (unsigned int const *)array, len);
+  JVM_CHECK_CALL(ret);
   //release
   if (field) jenv->ReleaseStringUTFChars(jfield, (const char *)field);
   jenv->ReleaseIntArrayElements(jarray, array, 0);
@@ -379,6 +400,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetFloatI
   bst_ulong len;
   float *result;
   int ret = XGDMatrixGetFloatInfo(handle, field, &len, (const float**) &result);
+  JVM_CHECK_CALL(ret);
   if (field) jenv->ReleaseStringUTFChars(jfield, field);
 
   jsize jlen = (jsize) len;
@@ -401,6 +423,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetUIntIn
   bst_ulong len;
   unsigned int *result;
   int ret = (jint) XGDMatrixGetUIntInfo(handle, field, &len, (const unsigned int **) &result);
+  JVM_CHECK_CALL(ret);
   if (field) jenv->ReleaseStringUTFChars(jfield, field);
 
   jsize jlen = (jsize) len;
@@ -420,6 +443,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixNumRow
   DMatrixHandle handle = (DMatrixHandle) jhandle;
   bst_ulong result[1];
   int ret = (jint) XGDMatrixNumRow(handle, result);
+  JVM_CHECK_CALL(ret);
   jenv->SetLongArrayRegion(jout, 0, 1, (const jlong *) result);
   return ret;
 }
@@ -442,6 +466,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterCreate
   }
   BoosterHandle result;
   int ret = XGBoosterCreate(dmlc::BeginPtr(handles), handles.size(), &result);
+  JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   return ret;
 }
@@ -469,6 +494,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetParam
   const char* name = jenv->GetStringUTFChars(jname, 0);
   const char* value = jenv->GetStringUTFChars(jvalue, 0);
   int ret = XGBoosterSetParam(handle, name, value);
+  JVM_CHECK_CALL(ret);
   //release
   if (name) jenv->ReleaseStringUTFChars(jname, name);
   if (value) jenv->ReleaseStringUTFChars(jvalue, value);
@@ -500,6 +526,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterBoostOneI
   jfloat* hess = jenv->GetFloatArrayElements(jhess, 0);
   bst_ulong len = (bst_ulong)jenv->GetArrayLength(jgrad);
   int ret = XGBoosterBoostOneIter(handle, dtrain, grad, hess, len);
+  JVM_CHECK_CALL(ret);
   //release
   jenv->ReleaseFloatArrayElements(jgrad, grad, 0);
   jenv->ReleaseFloatArrayElements(jhess, hess, 0);
@@ -537,6 +564,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterEvalOneIt
                                  dmlc::BeginPtr(dmats),
                                  dmlc::BeginPtr(evchars),
                                  len, &result);
+  JVM_CHECK_CALL(ret);
   jstring jinfo = nullptr;
   if (result != nullptr) {
     jinfo = jenv->NewStringUTF(result);
@@ -557,6 +585,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredict
   bst_ulong len;
   float *result;
   int ret = XGBoosterPredict(handle, dmat, joption_mask, (unsigned int) jntree_limit, &len, (const float **) &result);
+  JVM_CHECK_CALL(ret);
   if (len) {
     jsize jlen = (jsize) len;
     jfloatArray jarray = jenv->NewFloatArray(jlen);
@@ -577,7 +606,10 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterLoadModel
   const char* fname = jenv->GetStringUTFChars(jfname, 0);
 
   int ret = XGBoosterLoadModel(handle, fname);
-  if (fname) jenv->ReleaseStringUTFChars(jfname,fname);
+  JVM_CHECK_CALL(ret);
+  if (fname) {
+    jenv->ReleaseStringUTFChars(jfname,fname);
+  }
   return ret;
 }
 
@@ -592,7 +624,10 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSaveModel
   const char*  fname = jenv->GetStringUTFChars(jfname, 0);
 
   int ret = XGBoosterSaveModel(handle, fname);
-  if (fname) jenv->ReleaseStringUTFChars(jfname, fname);
+  JVM_CHECK_CALL(ret);
+  if (fname) {
+    jenv->ReleaseStringUTFChars(jfname, fname);
+  }
   return ret;
 }
 
@@ -607,6 +642,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterLoadModel
   jbyte* buffer = jenv->GetByteArrayElements(jbytes, 0);
   int ret = XGBoosterLoadModelFromBuffer(
       handle, buffer, jenv->GetArrayLength(jbytes));
+  JVM_CHECK_CALL(ret);
   jenv->ReleaseByteArrayElements(jbytes, buffer, 0);
   return ret;
 }
@@ -622,6 +658,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetModelR
   bst_ulong len = 0;
   const char* result;
   int ret = XGBoosterGetModelRaw(handle, &len, &result);
+  JVM_CHECK_CALL(ret);
 
   if (result) {
     jbyteArray jarray = jenv->NewByteArray(len);
@@ -645,6 +682,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModel
   char **result;
 
   int ret = XGBoosterDumpModelEx(handle, fmap, jwith_stats, format, &len, (const char ***) &result);
+  JVM_CHECK_CALL(ret);
 
   jsize jlen = (jsize) len;
   jobjectArray jinfos = jenv->NewObjectArray(jlen, jenv->FindClass("java/lang/String"), jenv->NewStringUTF(""));
@@ -696,6 +734,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModel
                                              (const char **) dmlc::BeginPtr(feature_names_char),
                                              (const char **) dmlc::BeginPtr(feature_types_char),
                                              jwith_stats, format, &len, (const char ***) &result);
+  JVM_CHECK_CALL(ret);
 
   jsize jlen = (jsize) len;
   jobjectArray jinfos = jenv->NewObjectArray(jlen, jenv->FindClass("java/lang/String"), jenv->NewStringUTF(""));
@@ -718,6 +757,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetAttrNa
   bst_ulong len = 0;
   char **result;
   int ret = XGBoosterGetAttrNames(handle, &len, (const char ***) &result);
+  JVM_CHECK_CALL(ret);
 
   jsize jlen = (jsize) len;
   jobjectArray jinfos = jenv->NewObjectArray(jlen, jenv->FindClass("java/lang/String"), jenv->NewStringUTF(""));
@@ -741,6 +781,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetAttr
   const char* result;
   int success;
   int ret = XGBoosterGetAttr(handle, key, &result, &success);
+  JVM_CHECK_CALL(ret);
   //release
   if (key) jenv->ReleaseStringUTFChars(jkey, key);
 
@@ -763,6 +804,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetAttr
   const char* key = jenv->GetStringUTFChars(jkey, 0);
   const char* value = jenv->GetStringUTFChars(jvalue, 0);
   int ret = XGBoosterSetAttr(handle, key, value);
+  JVM_CHECK_CALL(ret);
   //release
   if (key) jenv->ReleaseStringUTFChars(jkey, key);
   if (value) jenv->ReleaseStringUTFChars(jvalue, value);
@@ -779,6 +821,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterLoadRabit
   BoosterHandle handle = (BoosterHandle) jhandle;
   int version;
   int ret = XGBoosterLoadRabitCheckpoint(handle, &version);
+  JVM_CHECK_CALL(ret);
   jint jversion = version;
   jenv->SetIntArrayRegion(jout, 0, 1, &jversion);
   return ret;

--- a/src/common/observer.h
+++ b/src/common/observer.h
@@ -71,6 +71,12 @@ class TrainingObserver {
     auto const& h_vec = vec.HostVector();
     this->Observe(h_vec, name);
   }
+  template <typename T>
+  void Observe(HostDeviceVector<T>* vec, std::string name) const {
+    if (XGBOOST_EXPECT(!observe_, true)) { return; }
+    this->Observe(*vec, name);
+  }
+
   /*\brief Observe objects with `XGBoostParamer' type. */
   template <typename Parameter,
             typename std::enable_if<

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -295,32 +295,8 @@ void DMatrix::SaveToLocalFile(const std::string& fname) {
 DMatrix* DMatrix::Create(std::unique_ptr<DataSource<SparsePage>>&& source,
                          const std::string& cache_prefix) {
   if (cache_prefix.length() == 0) {
-    // FIXME(trivialfis): Currently distcol is broken so we here check for number of rows.
-    // If we bring back column split this check will break.
-    bool is_distributed { rabit::IsDistributed() };
-    if (is_distributed) {
-      auto world_size = rabit::GetWorldSize();
-      auto rank = rabit::GetRank();
-      std::vector<uint64_t> ncols(world_size, 0);
-      ncols[rank] = source->info.num_col_;
-      rabit::Allreduce<rabit::op::Sum>(ncols.data(), ncols.size());
-      auto max_cols = std::max_element(ncols.cbegin(), ncols.cend());
-      auto max_ind = std::distance(ncols.cbegin(), max_cols);
-      // FIXME(trivialfis): This is a hack, we should store a reference to global shape if possible.
-      if (source->info.num_col_ == 0 && source->info.num_row_ == 0) {
-        LOG(WARNING) << "DMatrix at rank: " << rank << " worker is empty.";
-        source->info.num_col_ = *max_cols;
-      }
-
-      // validate the number of columns across all workers.
-      for (size_t i = 0; i < ncols.size(); ++i) {
-        auto v = ncols[i];
-        CHECK(v == 0 || v == *max_cols)
-            << "DMatrix at rank: " << i << " worker "
-            << "has different number of columns than rank: " << max_ind << " worker. "
-            << "(" << v << " vs. " << *max_cols << ")";
-      }
-    }
+    // Data split mode is fixed to be row right now.
+    rabit::Allreduce<rabit::op::Max>(&source->info.num_col_, 1);
     return new data::SimpleDMatrix(std::move(source));
   } else {
 #if DMLC_ENABLE_STD_THREAD
@@ -336,6 +312,7 @@ template <typename AdapterT>
 DMatrix* DMatrix::Create(AdapterT* adapter, float missing, int nthread,
                          const std::string& cache_prefix,  size_t page_size ) {
   if (cache_prefix.length() == 0) {
+    // Data split mode is fixed to be row right now.
     return new data::SimpleDMatrix(adapter, missing, nthread);
   } else {
 #if DMLC_ENABLE_STD_THREAD

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -124,7 +124,6 @@ void GBTree::PerformTreeMethodHeuristic(DMatrix* fmat) {
     return;
   }
 
-  tparam_.updater_seq = "grow_histmaker,prune";
   if (rabit::IsDistributed()) {
     LOG(WARNING) <<
       "Tree method is automatically selected to be 'approx' "

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -925,6 +925,25 @@ class LearnerImpl : public Learner {
           << "num rows: "     << p_fmat->Info().num_row_   << "\n"
           << "Number of weights should be equal to number of groups in ranking task.";
     }
+
+    auto const row_based_split = [this]() {
+      return tparam_.dsplit == DataSplitMode::kRow ||
+             tparam_.dsplit == DataSplitMode::kAuto;
+    };
+    bool const valid_features =
+        !row_based_split() ||
+        (learner_model_param_.num_feature == p_fmat->Info().num_col_);
+    std::string const msg {
+      "Number of columns does not match number of features in booster."
+    };
+    if (generic_parameters_.validate_features) {
+      CHECK_EQ(learner_model_param_.num_feature, p_fmat->Info().num_col_) << msg;
+    } else if (!valid_features) {
+      // Remove this and make the equality check fatal once spark can fix all failing tests.
+      LOG(WARNING) << msg << " "
+                   << "Columns: " << p_fmat->Info().num_col_ << " "
+                   << "Features: " << learner_model_param_.num_feature;
+    }
   }
 
   // model parameter

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -60,6 +60,10 @@ class ColMaker: public TreeUpdater {
       spliteval_.reset(SplitEvaluator::Create(param_.split_evaluator));
     }
     spliteval_->Init(&param_);
+
+    if (rabit::IsDistributed()) {
+      LOG(FATAL) << "Updater `grow_colmaker` Exact doesn't support distributed training.";
+    }
   }
 
   void LoadConfig(Json const& in) override {

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -60,10 +60,6 @@ class ColMaker: public TreeUpdater {
       spliteval_.reset(SplitEvaluator::Create(param_.split_evaluator));
     }
     spliteval_->Init(&param_);
-
-    if (rabit::IsDistributed()) {
-      LOG(FATAL) << "Updater `grow_colmaker` Exact doesn't support distributed training.";
-    }
   }
 
   void LoadConfig(Json const& in) override {
@@ -84,6 +80,10 @@ class ColMaker: public TreeUpdater {
   void Update(HostDeviceVector<GradientPair> *gpair,
               DMatrix* dmat,
               const std::vector<RegTree*> &trees) override {
+    if (rabit::IsDistributed()) {
+      LOG(FATAL) << "Updater `grow_colmaker` or `exact` tree method doesn't "
+                    "support distributed training.";
+    }
     // rescale learning rate according to size of trees
     float lr = param_.learning_rate;
     param_.learning_rate = lr / trees.size();

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -91,7 +91,6 @@ TEST(Learner, CheckGroup) {
 }
 
 TEST(Learner, SLOW_CheckMultiBatch) {
-  using Arg = std::pair<std::string, std::string>;
   // Create sufficiently large data to make two row pages
   dmlc::TemporaryDirectory tempdir;
   const std::string tmp_file = tempdir.path + "/big.libsvm";
@@ -107,7 +106,7 @@ TEST(Learner, SLOW_CheckMultiBatch) {
   dmat->Info().SetInfo("label", labels.data(), DataType::kFloat32, num_row);
   std::vector<std::shared_ptr<DMatrix>> mat{dmat};
   auto learner = std::unique_ptr<Learner>(Learner::Create(mat));
-  learner->SetParams({Arg{"objective", "binary:logistic"}, Arg{"verbosity", "3"}});
+  learner->SetParams(Args{{"objective", "binary:logistic"}});
   learner->UpdateOneIter(0, dmat.get());
 }
 

--- a/tests/python-gpu/test_gpu_pickling.py
+++ b/tests/python-gpu/test_gpu_pickling.py
@@ -6,7 +6,6 @@ import subprocess
 import os
 import json
 import pytest
-import copy
 
 import xgboost as xgb
 from xgboost import XGBClassifier

--- a/tests/python-gpu/test_gpu_with_sklearn.py
+++ b/tests/python-gpu/test_gpu_with_sklearn.py
@@ -2,9 +2,11 @@ import xgboost as xgb
 import pytest
 import sys
 import numpy as np
+import unittest
 
 sys.path.append("tests/python")
-import testing as tm
+import testing as tm               # noqa
+import test_with_sklearn as twskl  # noqa
 
 pytestmark = pytest.mark.skipif(**tm.no_sklearn())
 
@@ -29,3 +31,10 @@ def test_gpu_binary_classification():
             err = sum(1 for i in range(len(preds))
                       if int(preds[i] > 0.5) != labels[i]) / float(len(preds))
             assert err < 0.1
+
+
+class TestGPUBoostFromPrediction(unittest.TestCase):
+    cpu_test = twskl.TestBoostFromPrediction()
+
+    def test_boost_from_prediction_gpu_hist(self):
+        self.cpu_test.run_boost_from_prediction('gpu_hist')

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -5,6 +5,7 @@ import tempfile
 import os
 import shutil
 import pytest
+import unittest
 
 rng = np.random.RandomState(1994)
 
@@ -697,21 +698,37 @@ def test_XGBClassifier_resume():
         assert log_loss1 > log_loss2
 
 
-def test_boost_from_prediction():
-    from sklearn.datasets import load_breast_cancer
-    X, y = load_breast_cancer(return_X_y=True)
-    model_0 = xgb.XGBClassifier(
-        learning_rate=0.3, random_state=0, n_estimators=4)
-    model_0.fit(X=X, y=y)
-    margin = model_0.predict(X, output_margin=True)
+class TestBoostFromPrediction(unittest.TestCase):
+    def run_boost_from_prediction(self, tree_method):
+        from sklearn.datasets import load_breast_cancer
+        X, y = load_breast_cancer(return_X_y=True)
+        model_0 = xgb.XGBClassifier(
+            learning_rate=0.3, random_state=0, n_estimators=4,
+            tree_method=tree_method)
+        model_0.fit(X=X, y=y)
+        margin = model_0.predict(X, output_margin=True)
 
-    model_1 = xgb.XGBClassifier(
-        learning_rate=0.3, random_state=0, n_estimators=4)
-    model_1.fit(X=X, y=y, base_margin=margin)
-    predictions_1 = model_1.predict(X, base_margin=margin)
+        model_1 = xgb.XGBClassifier(
+            learning_rate=0.3, random_state=0, n_estimators=4,
+            tree_method=tree_method)
+        model_1.fit(X=X, y=y, base_margin=margin)
+        predictions_1 = model_1.predict(X, base_margin=margin)
 
-    cls_2 = xgb.XGBClassifier(
-        learning_rate=0.3, random_state=0, n_estimators=8)
-    cls_2.fit(X=X, y=y)
-    predictions_2 = cls_2.predict(X, base_margin=margin)
-    assert np.all(predictions_1 == predictions_2)
+        cls_2 = xgb.XGBClassifier(
+            learning_rate=0.3, random_state=0, n_estimators=8,
+            tree_method=tree_method)
+        cls_2.fit(X=X, y=y)
+        predictions_2 = cls_2.predict(X)
+        assert np.all(predictions_1 == predictions_2)
+
+    @pytest.mark.skipif(**tm.no_sklearn())
+    def test_boost_from_prediction_hist(self):
+        self.run_boost_from_prediction('hist')
+
+    @pytest.mark.skipif(**tm.no_sklearn())
+    def test_boost_from_prediction_approx(self):
+        self.run_boost_from_prediction('approx')
+
+    @pytest.mark.skipif(**tm.no_sklearn())
+    def test_boost_from_prediction_exact(self):
+        self.run_boost_from_prediction('exact')


### PR DESCRIPTION
Some related fixes ported from https://github.com/dmlc/xgboost/pull/5178 .

* Added a check call macro in jvm package, prevents executing other functions from jvm when error occurred in XGBoost.  For example, when prediction fails jvm should not try to allocate memory based on the output prediction size.
* Update doc to recommend `hist`/`gpu_hist` algorithm.
* Add a parameter `validate_features` and enable it for `R/Python/C` except for `jvm`.
* Sync maximum number of columns in DMatrix across workers.  This also fixes empty dask cudf dataframe.