### PR TITLE
Explicitly use UTF-8 codepage when using MSVC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,12 @@ if (USE_CUDA)
     $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
   )
 
+  if (MSVC)
+    target_compile_options(objxgboost PRIVATE
+      $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/utf-8>
+    )
+  endif (MSVC)
+
   set_target_properties(objxgboost PROPERTIES
     CUDA_SEPARABLE_COMPILATION OFF)
 else (USE_CUDA)
@@ -53,7 +59,9 @@ if (WIN32 AND MINGW)
 endif (WIN32 AND MINGW)
 
 if (MSVC)
-  target_compile_options(objxgboost PRIVATE "/utf-8")
+  target_compile_options(objxgboost PRIVATE
+    $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/utf-8>
+  )
 endif (MSVC)
 
 set_target_properties(objxgboost PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,10 @@ if (WIN32 AND MINGW)
   target_compile_options(objxgboost PUBLIC -static-libstdc++)
 endif (WIN32 AND MINGW)
 
+if (MSVC)
+  target_compile_options(objxgboost PRIVATE "/utf-8")
+endif (MSVC)
+
 set_target_properties(objxgboost PROPERTIES
   POSITION_INDEPENDENT_CODE ON
   CXX_STANDARD 11

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -43,10 +43,17 @@ if (USE_CUDA)
     target_include_directories(testxgboost PRIVATE "${NVTX_HEADER_DIR}")
     target_compile_definitions(testxgboost PRIVATE -DXGBOOST_USE_NVTX=1)
   endif (USE_NVTX)
+  if (MSVC)
+    target_compile_options(testxgboost PRIVATE
+      $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/utf-8>
+    )
+  endif (MSVC)
 endif (USE_CUDA)
 
 if (MSVC)
-  target_compile_options(objxgboost PRIVATE "/utf-8")
+  target_compile_options(testxgboost PRIVATE
+    $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/utf-8>
+  )
 endif (MSVC)
 
 target_include_directories(testxgboost

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -45,6 +45,10 @@ if (USE_CUDA)
   endif (USE_NVTX)
 endif (USE_CUDA)
 
+if (MSVC)
+  target_compile_options(objxgboost PRIVATE "/utf-8")
+endif (MSVC)
+
 target_include_directories(testxgboost
   PRIVATE
   ${GTEST_INCLUDE_DIRS}


### PR DESCRIPTION
One of C++ tests contain non-ASCII letters:
https://github.com/dmlc/xgboost/blob/8cbcc53ccbd3d2c4c74ef35fcec018be64d084cd/tests/cpp/common/test_config.cc#L154-L156

Microsoft Visual C++ (MSVC) uses the system codepage by default when compiling C++ sources. This resulted in error `Error C2001: Newline in constant` when I compiled XGBoost on my Windows laptop, which had Korean (CP949) locale.

This PR explicitly sets the compilation flag `/utf-8` so that MSVC always uses UTF-8 encoding. See related discussion at https://github.com/libusb/libusb/issues/207.