### PR TITLE
Implement slice via adapters

### DIFF
--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -363,6 +363,9 @@ template DMatrix* DMatrix::Create<data::DataTableAdapter>(
 template DMatrix* DMatrix::Create<data::FileAdapter>(
     data::FileAdapter* adapter, float missing, int nthread,
     const std::string& cache_prefix, size_t page_size);
+template DMatrix* DMatrix::Create<data::DMatrixSliceAdapter>(
+    data::DMatrixSliceAdapter* adapter, float missing, int nthread,
+    const std::string& cache_prefix, size_t page_size);
 
 SparsePage SparsePage::GetTranspose(int num_columns) const {
   SparsePage transpose;

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -111,6 +111,11 @@ SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {
       weights.insert(weights.end(), batch.Weights(),
                      batch.Weights() + batch.Size());
     }
+    if (batch.BaseMargin() != nullptr) {
+      auto& base_margin = mat.info.base_margin_.HostVector();
+      base_margin.insert(base_margin.end(), batch.BaseMargin(),
+                     batch.BaseMargin() + batch.Size());
+    }
     if (batch.Qid() != nullptr) {
       qids.insert(qids.end(), batch.Qid(), batch.Qid() + batch.Size());
       // get group
@@ -165,6 +170,8 @@ template SimpleDMatrix::SimpleDMatrix(CSCAdapter* adapter, float missing,
 template SimpleDMatrix::SimpleDMatrix(DataTableAdapter* adapter, float missing,
                                      int nthread);
 template SimpleDMatrix::SimpleDMatrix(FileAdapter* adapter, float missing,
+                                     int nthread);
+template SimpleDMatrix::SimpleDMatrix(DMatrixSliceAdapter* adapter, float missing,
                                      int nthread);
 }  // namespace data
 }  // namespace xgboost

--- a/src/data/sparse_page_source.h
+++ b/src/data/sparse_page_source.h
@@ -222,6 +222,11 @@ class SparsePageSource : public DataSource<T> {
           weights.insert(weights.end(), batch.Weights(),
                          batch.Weights() + batch.Size());
         }
+        if (batch.BaseMargin() != nullptr) {
+          auto& base_margin = info.base_margin_.HostVector();
+          base_margin.insert(base_margin.end(), batch.BaseMargin(),
+                             batch.BaseMargin() + batch.Size());
+        }
         if (batch.Qid() != nullptr) {
           qids.insert(qids.end(), batch.Qid(), batch.Qid() + batch.Size());
           // get group

--- a/tests/cpp/data/test_adapter.cc
+++ b/tests/cpp/data/test_adapter.cc
@@ -61,3 +61,31 @@ TEST(adapter, CSCAdapterColsMoreThanRows) {
   EXPECT_EQ(inst[3].fvalue, 8);
   EXPECT_EQ(inst[3].index, 3);
 }
+
+TEST(c_api, DMatrixSliceAdapterFromSimpleDMatrix) {
+  auto pp_dmat = CreateDMatrix(6, 2, 1.0);
+  auto p_dmat = *pp_dmat;
+
+  std::vector<int> ridx_set = {1, 3, 5};
+  data::DMatrixSliceAdapter adapter(p_dmat.get(),
+                                    {ridx_set.data(), ridx_set.size()});
+  EXPECT_EQ(adapter.NumRows(), ridx_set.size());
+
+  adapter.BeforeFirst();
+  for (auto &batch : p_dmat->GetBatches<SparsePage>()) {
+    adapter.Next();
+    auto &adapter_batch = adapter.Value();
+    for (auto i = 0ull; i < adapter_batch.Size(); i++) {
+      auto inst = batch[ridx_set[i]];
+      auto line = adapter_batch.GetLine(i);
+      ASSERT_EQ(inst.size(), line.Size());
+      for (auto j = 0ull; j < line.Size(); j++) {
+        EXPECT_EQ(inst[j].fvalue, line.GetElement(j).value);
+        EXPECT_EQ(inst[j].index, line.GetElement(j).column_idx);
+        EXPECT_EQ(i, line.GetElement(j).row_idx);
+      }
+    }
+  }
+
+  delete pp_dmat;
+}


### PR DESCRIPTION
This PR allows us to consolidate further constructions of DMatrix into a single constructor path.