### PR TITLE
Support dmatrix construction from cupy array

### DIFF
--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -129,14 +129,6 @@ except ImportError:
     CUDF_INSTALLED = False
     CUDF_concat = None
 
-# cupy
-try:
-    from cupy import ndarray as CUPY_Array
-    CUPY_INSTALLED = True
-except ImportError:
-    CUPY_INSTALLED = False
-    CUPY_Array = object
-
 # sklearn
 try:
     from sklearn.base import BaseEstimator

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -115,6 +115,7 @@ except ImportError:
     DT_INSTALLED = False
 
 
+# cudf
 try:
     from cudf import DataFrame as CUDF_DataFrame
     from cudf import Series as CUDF_Series
@@ -127,6 +128,14 @@ except ImportError:
     CUDF_MultiIndex = object
     CUDF_INSTALLED = False
     CUDF_concat = None
+
+# cudf
+try:
+    from cupy import ndarray as CUPY_Array
+    CUPY_INSTALLED = True
+except ImportError:
+    CUPY_INSTALLED = False
+    CUPY_Array = object
 
 # sklearn
 try:

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -129,7 +129,7 @@ except ImportError:
     CUDF_INSTALLED = False
     CUDF_concat = None
 
-# cudf
+# cupy
 try:
     from cupy import ndarray as CUPY_Array
     CUPY_INSTALLED = True

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -20,7 +20,7 @@ import scipy.sparse
 from .compat import (
     STRING_TYPES, DataFrame, MultiIndex, Int64Index, py_str,
     PANDAS_INSTALLED, DataTable,
-    CUDF_INSTALLED, CUDF_DataFrame, CUDF_Series, CUDF_MultiIndex, CUPY_Array,
+    CUDF_INSTALLED, CUDF_DataFrame, CUDF_Series, CUDF_MultiIndex,
     os_fspath, os_PathLike)
 from .libpath import find_lib_path
 
@@ -502,7 +502,7 @@ class DMatrix(object):
             self._init_from_dt(data, nthread)
         elif _use_columnar_initializer(data):
             self._init_from_columnar(data, missing, nthread)
-        elif isinstance(data, CUPY_Array):
+        elif hasattr(data, "__cuda_array_interface__"):
             self._init_from_cupy(data, missing, nthread)
         else:
             try:
@@ -709,14 +709,11 @@ class DMatrix(object):
                                                c_bst_ulong(len(data))))
 
     def set_interface_info(self, field, data):
-        """Set info type peoperty into DMatrix."""
-        if isinstance(data, CUPY_Array):
-            interfaces = bytes(json.dumps([data.__cuda_array_interface__], indent=2), 'utf-8')
-        else:
-            interfaces = _extract_interface_from_cudf(data)
+        """Set info type property into DMatrix."""
+        interface = bytes(json.dumps([data.__cuda_array_interface__], indent=2), 'utf-8')
         _check_call(_LIB.XGDMatrixSetInfoFromInterface(self.handle,
                                                        c_str(field),
-                                                       interfaces))
+                                                       interface))
 
     def set_float_info_npy2d(self, field, data):
         """Set float type property into the DMatrix

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -226,7 +226,7 @@ def c_str(string):
 def c_array(ctype, values):
     """Convert a python string to c array."""
     if (isinstance(values, np.ndarray)
-        and values.dtype.itemsize == ctypes.sizeof(ctype)):
+            and values.dtype.itemsize == ctypes.sizeof(ctype)):
         return (ctype * len(values)).from_buffer_copy(values)
     return (ctype * len(values))(*values)
 
@@ -433,7 +433,7 @@ class DMatrix(object):
         """Parameters
         ----------
         data : os.PathLike/string/numpy.array/scipy.sparse/pd.DataFrame/
-               dt.Frame/cudf.DataFrame
+               dt.Frame/cudf.DataFrame/cupy.array
             Data source of DMatrix.
             When data is string or os.PathLike type, it represents the path
             libsvm format txt file, csv file (by specifying uri parameter

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -206,12 +206,24 @@ int XGDMatrixCreateFromDataIter(
 }
 
 #ifndef XGBOOST_USE_CUDA
-XGB_DLL int XGDMatrixCreateFromArrayInterfaces(
-  char const* c_json_strs, bst_int has_missing, bst_float missing, DMatrixHandle* out) {
+XGB_DLL int XGDMatrixCreateFromArrayInterfaceColumns(char const* c_json_strs,
+                                                     bst_float missing,
+                                                     int nthread,
+                                                     DMatrixHandle* out) {
   API_BEGIN();
   LOG(FATAL) << "Xgboost not compiled with cuda";
   API_END();
 }
+
+XGB_DLL int XGDMatrixCreateFromArrayInterface(char const* c_json_strs,
+                                                     bst_float missing,
+                                                     int nthread,
+                                                     DMatrixHandle* out) {
+  API_BEGIN();
+  LOG(FATAL) << "Xgboost not compiled with cuda";
+  API_END();
+}
+
 #endif
 
 XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,

--- a/src/c_api/c_api.cu
+++ b/src/c_api/c_api.cu
@@ -20,9 +20,8 @@ XGB_DLL int XGDMatrixCreateFromArrayInterfaceColumns(char const* c_json_strs,
 }
 
 XGB_DLL int XGDMatrixCreateFromArrayInterface(char const* c_json_strs,
-                                                     bst_float missing,
-                                                     int nthread,
-                                                     DMatrixHandle* out) {
+                                              bst_float missing, int nthread,
+                                              DMatrixHandle* out) {
   API_BEGIN();
   std::string json_str{c_json_strs};
   data::CupyAdapter adapter(json_str);

--- a/src/c_api/c_api.cu
+++ b/src/c_api/c_api.cu
@@ -7,14 +7,28 @@
 #include "../data/device_adapter.cuh"
 
 namespace xgboost {
-XGB_DLL int XGDMatrixCreateFromArrayInterfaces(char const* c_json_strs,
-                                               bst_int has_missing,
-                                               bst_float missing,
-                                               DMatrixHandle* out) {
+XGB_DLL int XGDMatrixCreateFromArrayInterfaceColumns(char const* c_json_strs,
+                                                     bst_float missing,
+                                                     int nthread,
+                                                     DMatrixHandle* out) {
   API_BEGIN();
   std::string json_str{c_json_strs};
   data::CudfAdapter adapter(json_str);
-  *out = new std::shared_ptr<DMatrix>(DMatrix::Create(&adapter, missing, 1));
+  *out =
+      new std::shared_ptr<DMatrix>(DMatrix::Create(&adapter, missing, nthread));
   API_END();
 }
+
+XGB_DLL int XGDMatrixCreateFromArrayInterface(char const* c_json_strs,
+                                                     bst_float missing,
+                                                     int nthread,
+                                                     DMatrixHandle* out) {
+  API_BEGIN();
+  std::string json_str{c_json_strs};
+  data::CupyAdapter adapter(json_str);
+  *out =
+      new std::shared_ptr<DMatrix>(DMatrix::Create(&adapter, missing, nthread));
+  API_END();
+}
+
 }  // namespace xgboost

--- a/src/data/data.cu
+++ b/src/data/data.cu
@@ -7,7 +7,7 @@
 #include "xgboost/data.h"
 #include "xgboost/logging.h"
 #include "xgboost/json.h"
-#include "columnar.h"
+#include "array_interface.h"
 #include "../common/device_helpers.cuh"
 #include "device_adapter.cuh"
 #include "simple_dmatrix.h"
@@ -22,15 +22,15 @@ void CopyInfoImpl(std::map<std::string, Json> const& column, HostDeviceVector<fl
     dh::safe_cuda(cudaSetDevice(ptr_device));
     return ptr_device;
   };
-  Columnar foreign_column(column);
+  ArrayInterface foreign_column(column);
   auto ptr_device = SetDeviceToPtr(foreign_column.data);
 
   out->SetDevice(ptr_device);
-  out->Resize(foreign_column.size);
+  out->Resize(foreign_column.num_rows);
 
   auto p_dst = thrust::device_pointer_cast(out->DevicePointer());
 
-  dh::LaunchN(ptr_device, foreign_column.size, [=] __device__(size_t idx) {
+  dh::LaunchN(ptr_device, foreign_column.num_rows, [=] __device__(size_t idx) {
     p_dst[idx] = foreign_column.GetElement(idx);
   });
 }
@@ -38,7 +38,7 @@ void CopyInfoImpl(std::map<std::string, Json> const& column, HostDeviceVector<fl
 void MetaInfo::SetInfo(const char * c_key, std::string const& interface_str) {
   Json j_interface = Json::Load({interface_str.c_str(), interface_str.size()});
   auto const& j_arr = get<Array>(j_interface);
-  CHECK_EQ(j_arr.size(), 1) << "MetaInfo: " << c_key << ". " << ColumnarErrors::Dimension(1);;
+  CHECK_EQ(j_arr.size(), 1) << "MetaInfo: " << c_key << ". " << ArrayInterfaceErrors::Dimension(1);;
   auto const& j_arr_obj = get<Object const>(j_arr[0]);
   std::string key {c_key};
   ArrayInterfaceHandler::Validate(j_arr_obj);
@@ -81,5 +81,8 @@ DMatrix* DMatrix::Create(AdapterT* adapter, float missing, int nthread,
 
 template DMatrix* DMatrix::Create<data::CudfAdapter>(
     data::CudfAdapter* adapter, float missing, int nthread,
+    const std::string& cache_prefix, size_t page_size);
+template DMatrix* DMatrix::Create<data::CupyAdapter>(
+    data::CupyAdapter* adapter, float missing, int nthread,
     const std::string& cache_prefix, size_t page_size);
 }  // namespace xgboost

--- a/src/data/device_adapter.cuh
+++ b/src/data/device_adapter.cuh
@@ -7,9 +7,9 @@
 #include <limits>
 #include <memory>
 #include <string>
-#include "columnar.h"
-#include "adapter.h"
 #include "../common/device_helpers.cuh"
+#include "adapter.h"
+#include "array_interface.h"
 
 namespace xgboost {
 namespace data {
@@ -17,12 +17,13 @@ namespace data {
 class CudfAdapterBatch : public detail::NoMetaInfo {
  public:
   CudfAdapterBatch() = default;
-  CudfAdapterBatch(common::Span<Columnar> columns,
+  CudfAdapterBatch(common::Span<ArrayInterface> columns,
                    common::Span<size_t> column_ptr, size_t num_elements)
-      : columns_(columns),column_ptr_(column_ptr), num_elements(num_elements) {}
-  size_t Size()const  { return num_elements; }
-  __device__ COOTuple GetElement(size_t idx)const
-  {
+      : columns_(columns),
+        column_ptr_(column_ptr),
+        num_elements(num_elements) {}
+  size_t Size() const { return num_elements; }
+  __device__ COOTuple GetElement(size_t idx) const {
     size_t column_idx =
         dh::UpperBound(column_ptr_.data(), column_ptr_.size(), idx) - 1;
     auto& column = columns_[column_idx];
@@ -34,22 +35,23 @@ class CudfAdapterBatch : public detail::NoMetaInfo {
   }
 
  private:
-  common::Span<Columnar> columns_;
+  common::Span<ArrayInterface> columns_;
   common::Span<size_t> column_ptr_;
   size_t num_elements;
 };
 
 /*!
- * Please be careful that, in official specification, the only three required fields are
- * `shape', `version' and `typestr'.  Any other is optional, including `data'.  But here
- * we have one additional requirements for input data:
+ * Please be careful that, in official specification, the only three required
+ * fields are `shape', `version' and `typestr'.  Any other is optional,
+ * including `data'.  But here we have one additional requirements for input
+ * data:
  *
- * - `data' field is required, passing in an empty dataset is not accepted, as most (if
- *   not all) of our algorithms don't have test for empty dataset.  An error is better
- *   than a crash.
+ * - `data' field is required, passing in an empty dataset is not accepted, as
+ * most (if not all) of our algorithms don't have test for empty dataset.  An
+ * error is better than a crash.
  *
- * What if invalid value from dataframe is 0 but I specify missing=NaN in XGBoost?  Since
- * validity mask is ignored, all 0s are preserved in XGBoost.
+ * What if invalid value from dataframe is 0 but I specify missing=NaN in
+ * XGBoost?  Since validity mask is ignored, all 0s are preserved in XGBoost.
  *
  * FIXME(trivialfis): Put above into document after we have a consistent way for
  * processing input data.
@@ -96,23 +98,23 @@ class CudfAdapter : public detail::SingleBatchDataIter<CudfAdapterBatch> {
     CHECK_GT(n_columns, 0) << "Number of columns must not equal to 0.";
 
     auto const& typestr = get<String const>(json_columns[0]["typestr"]);
-    CHECK_EQ(typestr.size(), 3) << ColumnarErrors::TypestrFormat();
-    CHECK_NE(typestr.front(), '>') << ColumnarErrors::BigEndian();
-    std::vector<Columnar> columns;
+    CHECK_EQ(typestr.size(), 3) << ArrayInterfaceErrors::TypestrFormat();
+    CHECK_NE(typestr.front(), '>') << ArrayInterfaceErrors::BigEndian();
+    std::vector<ArrayInterface> columns;
     std::vector<size_t> column_ptr({0});
-    auto first_column = Columnar(get<Object const>(json_columns[0]));
+    auto first_column = ArrayInterface(get<Object const>(json_columns[0]));
     device_idx_ = dh::CudaGetPointerDevice(first_column.data);
     CHECK_NE(device_idx_, -1);
     dh::safe_cuda(cudaSetDevice(device_idx_));
-    num_rows_ = first_column.size;
+    num_rows_ = first_column.num_rows;
     for (auto& json_col : json_columns) {
-      auto column = Columnar(get<Object const>(json_col));
+      auto column = ArrayInterface(get<Object const>(json_col));
       columns.push_back(column);
-      column_ptr.emplace_back(column_ptr.back() + column.size);
-      num_rows_ = std::max(num_rows_, size_t(column.size));
+      column_ptr.emplace_back(column_ptr.back() + column.num_rows);
+      num_rows_ = std::max(num_rows_, size_t(column.num_rows));
       CHECK_EQ(device_idx_, dh::CudaGetPointerDevice(column.data))
           << "All columns should use the same device.";
-      CHECK_EQ(num_rows_, column.size)
+      CHECK_EQ(num_rows_, column.num_rows)
           << "All columns should have same number of rows.";
     }
     columns_ = columns;
@@ -124,19 +126,65 @@ class CudfAdapter : public detail::SingleBatchDataIter<CudfAdapterBatch> {
 
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return columns_.size(); }
-  size_t DeviceIdx()const {
-    return device_idx_;
-  }
+  size_t DeviceIdx() const { return device_idx_; }
 
   // Cudf is column major
   bool IsRowMajor() { return false; }
+
  private:
   CudfAdapterBatch batch;
-  dh::device_vector<Columnar> columns_;
+  dh::device_vector<ArrayInterface> columns_;
   dh::device_vector<size_t> column_ptr_;  // Exclusive scan of column sizes
   size_t num_rows_{0};
   int device_idx_;
 };
+
+class CupyAdapterBatch : public detail::NoMetaInfo {
+ public:
+  CupyAdapterBatch() = default;
+  CupyAdapterBatch(ArrayInterface array_interface)
+      : array_interface_(array_interface) {}
+  size_t Size() const {
+    return array_interface_.num_rows * array_interface_.num_cols;
+  }
+  __device__ COOTuple GetElement(size_t idx) const {
+    size_t column_idx = idx % array_interface_.num_cols;
+    size_t row_idx = idx / array_interface_.num_cols;
+    float value = array_interface_.valid.Data() == nullptr ||
+                          array_interface_.valid.Check(row_idx)
+                      ? array_interface_.GetElement(idx)
+                      : std::numeric_limits<float>::quiet_NaN();
+    return COOTuple(row_idx, column_idx, value);
+  }
+
+ private:
+  ArrayInterface array_interface_;
+};
+
+class CupyAdapter : public detail::SingleBatchDataIter<CupyAdapterBatch> {
+ public:
+  explicit CupyAdapter(std::string cuda_interface_str) {
+    Json json_array_interface =
+        Json::Load({cuda_interface_str.c_str(), cuda_interface_str.size()});
+    array_interface = ArrayInterface(get<Object const>(json_array_interface));
+    device_idx_ = dh::CudaGetPointerDevice(array_interface.data);
+    CHECK_NE(device_idx_, -1);
+    batch = CupyAdapterBatch(array_interface);
+  }
+  const CupyAdapterBatch& Value() const override { return batch; }
+
+  size_t NumRows() const { return array_interface.num_rows; }
+  size_t NumColumns() const { return array_interface.num_cols; }
+  size_t DeviceIdx() const { return device_idx_; }
+
+  bool IsRowMajor() { return true; }
+
+ private:
+  ArrayInterface array_interface;
+  CupyAdapterBatch batch;
+  int device_idx_;
+};
+
 };  // namespace data
 }  // namespace xgboost
 #endif  // XGBOOST_DATA_DEVICE_ADAPTER_H_

--- a/src/data/simple_csr_source.cc
+++ b/src/data/simple_csr_source.cc
@@ -7,7 +7,6 @@
 #include <xgboost/json.h>
 
 #include "simple_csr_source.h"
-#include "columnar.h"
 
 namespace xgboost {
 namespace data {

--- a/src/data/simple_dmatrix.cu
+++ b/src/data/simple_dmatrix.cu
@@ -137,6 +137,8 @@ SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {
     CopyDataColumnMajor(adapter, mat.page_.data.DeviceSpan(),
                         adapter->DeviceIdx(), missing, s_offset);
   }
+  // Sync
+  mat.page_.data.HostVector();
 
   mat.info.num_col_ = adapter->NumColumns();
   mat.info.num_row_ = adapter->NumRows();

--- a/tests/ci_build/Dockerfile.cudf
+++ b/tests/ci_build/Dockerfile.cudf
@@ -18,7 +18,7 @@ ENV PATH=/opt/python/bin:$PATH
 # Create new Conda environment with cuDF and dask
 RUN \
     conda create -n cudf_test -c rapidsai -c nvidia -c numba -c conda-forge -c anaconda \
-        cudf=0.9 python=3.7 anaconda::cudatoolkit=$CUDA_VERSION dask dask-cuda
+        cudf=0.9 python=3.7 anaconda::cudatoolkit=$CUDA_VERSION dask dask-cuda cupy
 
 # Install other Python packages
 RUN \

--- a/tests/ci_build/test_python.sh
+++ b/tests/ci_build/test_python.sh
@@ -39,7 +39,7 @@ case "$suite" in
 
   cudf)
     source activate cudf_test
-    pytest -v -s --fulltrace -m "not mgpu" tests/python-gpu/test_from_columnar.py tests\python-gpu\test_from_cupy.py
+    pytest -v -s --fulltrace -m "not mgpu" tests/python-gpu/test_from_columnar.py tests/python-gpu/test_from_cupy.py
     ;;
 
   cpu)

--- a/tests/ci_build/test_python.sh
+++ b/tests/ci_build/test_python.sh
@@ -39,7 +39,7 @@ case "$suite" in
 
   cudf)
     source activate cudf_test
-    pytest -v -s --fulltrace -m "not mgpu" tests/python-gpu/test_from_columnar.py
+    pytest -v -s --fulltrace -m "not mgpu" tests/python-gpu/test_from_columnar.py tests\python-gpu\test_from_cupy.py
     ;;
 
   cpu)

--- a/tests/cpp/data/test_array_interface.h
+++ b/tests/cpp/data/test_array_interface.h
@@ -8,7 +8,6 @@
 #include "../../../src/common/bitfield.h"
 #include "../../../src/common/device_helpers.cuh"
 #include "../../../src/data/simple_csr_source.h"
-#include "../../../src/data/columnar.h"
 
 namespace xgboost {
 
@@ -62,4 +61,24 @@ Json GenerateSparseColumn(std::string const& typestr, size_t kRows,
   column["typestr"] = String(typestr);
   return column;
 }
+
+template <typename T>
+Json Generate2dArrayInterface(int rows, int cols, std::string typestr,
+                                thrust::device_vector<T>* p_data) {
+  auto& data = *p_data;
+  thrust::sequence(data.begin(), data.end());
+
+  Json array_interface{Object()};
+  std::vector<Json> shape = {Json(static_cast<Integer::Int>(rows)),
+                             Json(static_cast<Integer::Int>(cols))};
+  array_interface["shape"] = Array(shape);
+  std::vector<Json> j_data{
+      Json(Integer(reinterpret_cast<Integer::Int>(data.data().get()))),
+      Json(Boolean(false))};
+  array_interface["data"] = j_data;
+  array_interface["version"] = Integer(static_cast<Integer::Int>(1));
+  array_interface["typestr"] = String(typestr);
+  return array_interface;
+}
+
 }  // namespace xgboost

--- a/tests/cpp/data/test_device_adapter.cu
+++ b/tests/cpp/data/test_device_adapter.cu
@@ -7,7 +7,7 @@
 #include "../helpers.h"
 #include <thrust/device_vector.h>
 #include "../../../src/data/device_adapter.cuh"
-#include "test_columnar.h"
+#include "test_array_interface.h"
 using namespace xgboost;  // NOLINT
 
 void TestCudfAdapter()

--- a/tests/cpp/data/test_metainfo.cu
+++ b/tests/cpp/data/test_metainfo.cu
@@ -9,8 +9,7 @@
 namespace xgboost {
 
 template <typename T>
-std::string PrepareData(std::string typestr, thrust::device_vector<T>* out) {
-  constexpr size_t kRows = 16;
+std::string PrepareData(std::string typestr, thrust::device_vector<T>* out, const size_t kRows=16) {
   out->resize(kRows);
   auto& d_data = *out;
 
@@ -66,7 +65,15 @@ TEST(MetaInfo, FromInterface) {
     ASSERT_EQ(h_base_margin[i], d_data[i]);
   }
 
-  EXPECT_ANY_THROW({info.SetInfo("group", str.c_str());});
+  thrust::device_vector<int> d_group_data;
+  std::string group_str = PrepareData<int>("<i4", &d_group_data, 4);
+  d_group_data[0] = 4;
+  d_group_data[1] = 3;
+  d_group_data[2] = 2;
+  d_group_data[3] = 1;
+  info.SetInfo("group", group_str.c_str());
+  std::vector<bst_group_t> expected_group_ptr = {0, 4, 7, 9, 10};
+  EXPECT_EQ(info.group_ptr_, expected_group_ptr);
 }
 
 TEST(MetaInfo, Group) {

--- a/tests/python-gpu/test_from_columnar.py
+++ b/tests/python-gpu/test_from_columnar.py
@@ -2,6 +2,7 @@ import numpy as np
 import xgboost as xgb
 import sys
 import pytest
+
 sys.path.append("tests/python")
 import testing as tm
 
@@ -86,3 +87,64 @@ Arrow specification.'''
             'x': cudf.Series([True, False, True, True, True])})
         with pytest.raises(Exception):
             dtrain = xgb.DMatrix(X_boolean, label=y_boolean)
+
+    @pytest.mark.skipif(**tm.no_cudf())
+    def test_cudf_training(self):
+        from cudf import DataFrame as df
+        import pandas as pd
+        X = pd.DataFrame(np.random.randn(50, 10))
+        y = pd.DataFrame(np.random.randn(50))
+        weights = np.random.random(50)
+        cudf_weights = df.from_pandas(pd.DataFrame(weights))
+        base_margin = np.random.random(50)
+        cudf_base_margin = df.from_pandas(pd.DataFrame(base_margin))
+
+        evals_result_cudf = {}
+        dtrain_cudf = xgb.DMatrix(df.from_pandas(X), df.from_pandas(y), weight=cudf_weights,
+                                  base_margin=cudf_base_margin)
+        xgb.train({'gpu_id': 0}, dtrain_cudf, evals=[(dtrain_cudf, "train")],
+                  evals_result=evals_result_cudf)
+        evals_result_np = {}
+        dtrain_np = xgb.DMatrix(X, y, weight=weights, base_margin=base_margin)
+        xgb.train({}, dtrain_np, evals=[(dtrain_np, "train")],
+                  evals_result=evals_result_np)
+        assert np.array_equal(evals_result_cudf["train"]["rmse"], evals_result_np["train"]["rmse"])
+
+    @pytest.mark.skipif(**tm.no_cudf())
+    def test_cudf_metainfo(self):
+        from cudf import DataFrame as df
+        import pandas as pd
+        n = 100
+        X = np.random.random((n, 2))
+        dmat_cudf = xgb.DMatrix(X)
+        dmat = xgb.DMatrix(X)
+        floats = np.random.random(n)
+        uints = np.array([4, 2, 8]).astype("uint32")
+        cudf_floats = df.from_pandas(pd.DataFrame(floats))
+        cudf_uints = df.from_pandas(pd.DataFrame(uints))
+        dmat.set_float_info('weight', floats)
+        dmat.set_float_info('label', floats)
+        dmat.set_float_info('base_margin', floats)
+        dmat.set_uint_info('group', uints)
+        dmat_cudf.set_interface_info('weight', cudf_floats)
+        dmat_cudf.set_interface_info('label', cudf_floats)
+        dmat_cudf.set_interface_info('base_margin', cudf_floats)
+        dmat_cudf.set_interface_info('group', cudf_uints)
+
+        # Test setting info with cudf DataFrame
+        assert np.array_equal(dmat.get_float_info('weight'), dmat_cudf.get_float_info('weight'))
+        assert np.array_equal(dmat.get_float_info('label'), dmat_cudf.get_float_info('label'))
+        assert np.array_equal(dmat.get_float_info('base_margin'),
+                              dmat_cudf.get_float_info('base_margin'))
+        assert np.array_equal(dmat.get_uint_info('group_ptr'), dmat_cudf.get_uint_info('group_ptr'))
+
+        # Test setting info with cudf Series
+        dmat_cudf.set_interface_info('weight', cudf_floats[cudf_floats.columns[0]])
+        dmat_cudf.set_interface_info('label', cudf_floats[cudf_floats.columns[0]])
+        dmat_cudf.set_interface_info('base_margin', cudf_floats[cudf_floats.columns[0]])
+        dmat_cudf.set_interface_info('group', cudf_uints[cudf_uints.columns[0]])
+        assert np.array_equal(dmat.get_float_info('weight'), dmat_cudf.get_float_info('weight'))
+        assert np.array_equal(dmat.get_float_info('label'), dmat_cudf.get_float_info('label'))
+        assert np.array_equal(dmat.get_float_info('base_margin'),
+                              dmat_cudf.get_float_info('base_margin'))
+        assert np.array_equal(dmat.get_uint_info('group_ptr'), dmat_cudf.get_uint_info('group_ptr'))

--- a/tests/python-gpu/test_from_cupy.py
+++ b/tests/python-gpu/test_from_cupy.py
@@ -1,0 +1,47 @@
+import numpy as np
+import xgboost as xgb
+import sys
+import pytest
+sys.path.append("tests/python")
+import testing as tm
+
+
+def dmatrix_from_cupy(input_type, missing=np.NAN):
+    '''Test constructing DMatrix from cupy'''
+    import cupy as cp
+
+    kRows = 80
+    kCols = 3
+
+    np_X = np.random.randn(kRows, kCols).astype(dtype=input_type)
+    X = cp.array(np_X)
+    X[5, 0] = missing
+    X[3, 1] = missing
+    y = cp.random.randn(kRows).astype(dtype=input_type)
+    dtrain = xgb.DMatrix(X, missing=missing, label=y)
+    assert dtrain.num_col() == kCols
+    assert dtrain.num_row() == kRows
+
+
+class TestFromArrayInterface:
+    '''Tests for constructing DMatrix from data structure conforming Apache
+Arrow specification.'''
+
+    @pytest.mark.skipif(**tm.no_cupy())
+    def test_from_cupy(self):
+        '''Test constructing DMatrix from cudf'''
+        import cupy
+        dmatrix_from_cupy(np.float32, np.NAN)
+        dmatrix_from_cupy(np.float64, np.NAN)
+
+        dmatrix_from_cupy(np.uint8, 2)
+        dmatrix_from_cupy(np.uint32, 3)
+        dmatrix_from_cupy(np.uint64, 4)
+
+        dmatrix_from_cupy(np.int8, 2)
+        dmatrix_from_cupy(np.int32, -2)
+        dmatrix_from_cupy(np.int64, -3)
+
+        with pytest.raises(Exception):
+            np_X = cp.random.randn(2, 2, dtype="float32")
+            dtrain = xgb.DMatrix(X, label=X)

--- a/tests/python-gpu/test_from_cupy.py
+++ b/tests/python-gpu/test_from_cupy.py
@@ -31,7 +31,7 @@ Arrow specification.'''
 
     @pytest.mark.skipif(**tm.no_cupy())
     def test_from_cupy(self):
-        '''Test constructing DMatrix from cudf'''
+        '''Test constructing DMatrix from cupy'''
         import cupy as cp
         dmatrix_from_cupy(np.float32, np.NAN)
         dmatrix_from_cupy(np.float64, np.NAN)
@@ -53,13 +53,45 @@ Arrow specification.'''
         import cupy as cp
         X = cp.random.randn(50, 10, dtype="float32")
         y = cp.random.randn(50, dtype="float32")
+        weights = np.random.random(50)
+        cupy_weights = cp.array(weights)
+        base_margin = np.random.random(50)
+        cupy_base_margin = cp.array(base_margin)
 
         evals_result_cupy = {}
-        dtrain_cp = xgb.DMatrix(X, y)
+        dtrain_cp = xgb.DMatrix(X, y, weight=cupy_weights, base_margin=cupy_base_margin)
         xgb.train({'gpu_id': 0}, dtrain_cp, evals=[(dtrain_cp, "train")],
                   evals_result=evals_result_cupy)
         evals_result_np = {}
-        dtrain_np = xgb.DMatrix(cp.asnumpy(X), cp.asnumpy(y))
+        dtrain_np = xgb.DMatrix(cp.asnumpy(X), cp.asnumpy(y), weight=weights,
+                                base_margin=base_margin)
         xgb.train({'gpu_id': 0}, dtrain_np, evals=[(dtrain_np, "train")],
                   evals_result=evals_result_np)
         assert np.array_equal(evals_result_cupy["train"]["rmse"], evals_result_np["train"]["rmse"])
+
+    @pytest.mark.skipif(**tm.no_cupy())
+    def test_cupy_metainfo(self):
+        import cupy as cp
+        n = 100
+        X = np.random.random((n, 2))
+        dmat_cupy = xgb.DMatrix(X)
+        dmat = xgb.DMatrix(X)
+        floats = np.random.random(n)
+        uints = np.array([4, 2, 8]).astype("uint32")
+        cupy_floats = cp.array(floats)
+        cupy_uints = cp.array(uints)
+        dmat.set_float_info('weight', floats)
+        dmat.set_float_info('label', floats)
+        dmat.set_float_info('base_margin', floats)
+        dmat.set_uint_info('group', uints)
+        dmat_cupy.set_interface_info('weight', cupy_floats)
+        dmat_cupy.set_interface_info('label', cupy_floats)
+        dmat_cupy.set_interface_info('base_margin', cupy_floats)
+        dmat_cupy.set_interface_info('group', cupy_uints)
+
+        # Test setting info with cupy 
+        assert np.array_equal(dmat.get_float_info('weight'), dmat_cupy.get_float_info('weight'))
+        assert np.array_equal(dmat.get_float_info('label'), dmat_cupy.get_float_info('label'))
+        assert np.array_equal(dmat.get_float_info('base_margin'),
+                              dmat_cupy.get_float_info('base_margin'))
+        assert np.array_equal(dmat.get_uint_info('group_ptr'), dmat_cupy.get_uint_info('group_ptr'))

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 from xgboost.compat import SKLEARN_INSTALLED, PANDAS_INSTALLED, DT_INSTALLED
-from xgboost.compat import CUDF_INSTALLED, DASK_INSTALLED
+from xgboost.compat import CUDF_INSTALLED, CUPY_INSTALLED, DASK_INSTALLED
 
 
 def no_sklearn():
@@ -46,6 +46,11 @@ def no_dask_cuda():
 def no_cudf():
     return {'condition': not CUDF_INSTALLED,
             'reason': 'CUDF is not installed'}
+
+
+def no_cupy():
+    return {'condition': not CUPY_INSTALLED,
+            'reason': 'cupy is not installed'}
 
 
 def no_dask_cudf():

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 from xgboost.compat import SKLEARN_INSTALLED, PANDAS_INSTALLED, DT_INSTALLED
-from xgboost.compat import CUDF_INSTALLED, CUPY_INSTALLED, DASK_INSTALLED
+from xgboost.compat import CUDF_INSTALLED, DASK_INSTALLED
 
 
 def no_sklearn():
@@ -49,8 +49,12 @@ def no_cudf():
 
 
 def no_cupy():
-    return {'condition': not CUPY_INSTALLED,
-            'reason': 'cupy is not installed'}
+    reason = 'cupy is not installed.'
+    try:
+        import cupy as _   # noqa
+        return {'condition': False, 'reason': reason}
+    except ImportError:
+        return {'condition': True, 'reason': reason}
 
 
 def no_dask_cudf():

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -16,10 +16,9 @@ if [ ${TASK} == "python_test" ]; then
     echo "-------------------------------"
     conda activate python3
     python --version
-    conda install numpy scipy pandas matplotlib scikit-learn
+    conda install numpy scipy pandas matplotlib scikit-learn dask
 
     python -m pip install graphviz pytest pytest-cov codecov
-    python -m pip install dask distributed dask[dataframe]
     python -m pip install datatable
     python -m pytest -v --fulltrace -s tests/python --cov=python-package/xgboost || exit -1
     codecov


### PR DESCRIPTION
A few things left to do:

- [x] Correctly construct labels/info
- [x] Add an integration test for training
- [x] Mention cupy in documentation

@trivialfis I removed the check for array interface version as I found I could get version 0 by installing cupy from conda or 2 by installing from pip, but not 1. Does this break anything for cudf?