### PR TITLE
Add Optuna badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![GitHub license](http://dmlc.github.io/img/apache2.svg)](./LICENSE)
 [![CRAN Status Badge](http://www.r-pkg.org/badges/version/xgboost)](http://cran.r-project.org/web/packages/xgboost)
 [![PyPI version](https://badge.fury.io/py/xgboost.svg)](https://pypi.python.org/pypi/xgboost/)
-[![Optuna](https://img.shields.io/badge/Optuna-integrated-blue)](https://www.optuna.org)
+[![Optuna](https://img.shields.io/badge/Optuna-integrated-blue)](https://optuna.org)
 
 [Community](https://xgboost.ai/community) |
 [Documentation](https://xgboost.readthedocs.org) |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![GitHub license](http://dmlc.github.io/img/apache2.svg)](./LICENSE)
 [![CRAN Status Badge](http://www.r-pkg.org/badges/version/xgboost)](http://cran.r-project.org/web/packages/xgboost)
 [![PyPI version](https://badge.fury.io/py/xgboost.svg)](https://pypi.python.org/pypi/xgboost/)
+[![Optuna](https://img.shields.io/badge/Optuna-integrated-blue)](https://www.optuna.org)
 
 [Community](https://xgboost.ai/community) |
 [Documentation](https://xgboost.readthedocs.org) |


### PR DESCRIPTION
Hi!

[Optuna]( (optuna.org) ) is a new hyperparameter optimization library, and we've written an integration module for XGBoost to make it easy to use Optuna to search for good hyperparameter settings and prune unpromising trials. We're looking for ways to let users of XGboost know this is available and thought a badge to show Optuna integration is available would be helpful.

If there are other ways you would recommend reaching out to XGBoost users to let them know about Optuna, please let us know.

Thanks!