### PR TITLE
Add CMake option to run Undefined Behavior Sanitizer (UBSan)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,10 +180,10 @@ def BuildCPU() {
     ${dockerRun} ${container_type} ${docker_binary} build/testxgboost
     """
     // Sanitizer test
-    def docker_extra_params = "CI_DOCKER_EXTRA_PARAMS_INIT='-e ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer -e ASAN_OPTIONS=symbolize=1 --cap-add SYS_PTRACE'"
+    def docker_extra_params = "CI_DOCKER_EXTRA_PARAMS_INIT='-e ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer -e ASAN_OPTIONS=symbolize=1 -e UBSAN_OPTIONS=print_stacktrace=1:log_path=ubsan_error.log --cap-add SYS_PTRACE'"
     def docker_args = "--build-arg CMAKE_VERSION=3.12"
     sh """
-    ${dockerRun} ${container_type} ${docker_binary} ${docker_args} tests/ci_build/build_via_cmake.sh -DUSE_SANITIZER=ON -DENABLED_SANITIZERS="address" \
+    ${dockerRun} ${container_type} ${docker_binary} ${docker_args} tests/ci_build/build_via_cmake.sh -DUSE_SANITIZER=ON -DENABLED_SANITIZERS="address;leak;undefined" \
       -DCMAKE_BUILD_TYPE=Debug -DSANITIZER_PATH=/usr/lib/x86_64-linux-gnu/
     ${docker_extra_params} ${dockerRun} ${container_type} ${docker_binary} build/testxgboost
     """

--- a/cmake/Sanitizer.cmake
+++ b/cmake/Sanitizer.cmake
@@ -4,24 +4,29 @@
 #  enable_sanitizers("address;leak")
 
 # Add flags
-macro(enable_sanitizer santizer)
-  if(${santizer} MATCHES "address")
+macro(enable_sanitizer sanitizer)
+  if(${sanitizer} MATCHES "address")
     find_package(ASan REQUIRED)
     set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=address")
     link_libraries(${ASan_LIBRARY})
 
-  elseif(${santizer} MATCHES "thread")
+  elseif(${sanitizer} MATCHES "thread")
     find_package(TSan REQUIRED)
     set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=thread")
     link_libraries(${TSan_LIBRARY})
 
-  elseif(${santizer} MATCHES "leak")
+  elseif(${sanitizer} MATCHES "leak")
     find_package(LSan REQUIRED)
     set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=leak")
     link_libraries(${LSan_LIBRARY})
 
+  elseif(${sanitizer} MATCHES "undefined")
+    find_package(UBSan REQUIRED)
+    set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=undefined -fno-sanitize-recover=undefined")
+    link_libraries(${UBSan_LIBRARY})
+
   else()
-    message(FATAL_ERROR "Santizer ${santizer} not supported.")
+    message(FATAL_ERROR "Santizer ${sanitizer} not supported.")
   endif()
 endmacro()
 

--- a/cmake/modules/FindUBSan.cmake
+++ b/cmake/modules/FindUBSan.cmake
@@ -1,0 +1,13 @@
+set(UBSan_LIB_NAME UBSan)
+
+find_library(UBSan_LIBRARY
+  NAMES libubsan.so libubsan.so.5 libubsan.so.4 libubsan.so.3 libubsan.so.2 libubsan.so.1 libubsan.so.0
+  PATHS ${SANITIZER_PATH} /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib ${CMAKE_PREFIX_PATH}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(UBSan DEFAULT_MSG
+  UBSan_LIBRARY)
+
+mark_as_advanced(
+  UBSan_LIBRARY
+  UBSan_LIB_NAME)

--- a/src/common/compressed_iterator.h
+++ b/src/common/compressed_iterator.h
@@ -209,7 +209,7 @@ class CompressedIterator {
         (bits_per_byte - ((offset_ + 1) * symbol_bits_)) % bits_per_byte;
     tmp >>= bit_shift;
     // Mask off unneeded bits
-    uint64_t mask = (1 << symbol_bits_) - 1;
+    uint64_t mask = (static_cast<uint64_t>(1) << symbol_bits_) - 1;
     return static_cast<T>(tmp & mask);
   }
 

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -31,14 +31,17 @@ namespace common {
 template<typename T>
 struct SimpleArray {
   ~SimpleArray() {
-    free(ptr_);
+    std::free(ptr_);
     ptr_ = nullptr;
   }
 
   void resize(size_t n) {
-    T* ptr = static_cast<T*>(malloc(n*sizeof(T)));
-    memcpy(ptr, ptr_, n_ * sizeof(T));
-    free(ptr_);
+    T* ptr = static_cast<T*>(std::malloc(n * sizeof(T)));
+    CHECK(ptr) << "Failed to allocate memory";
+    if (ptr_) {
+      std::memcpy(ptr, ptr_, n_ * sizeof(T));
+      std::free(ptr_);
+    }
     ptr_ = ptr;
     n_ = n;
   }


### PR DESCRIPTION
This PR adds an CMake option to run UBSan (Undefined Behavior Sanitizer). It is motivated by https://news.ycombinator.com/item?id=22063849.

Also:

* Add UBSan to CI
* Fix some undefined behavior in the C++ codebase.
* Update dmlc-core, to pick up dmlc/dmlc-core#591.

This PR depends on dmlc/dmlc-core#591.

Example output:
```
/workspace/tests/cpp/common/../../../src/common/hist_util.h:40:11: runtime error: null pointer passed as argument 2, which is dec$
ared to never be null
    #0 0x5607d5de33c6 in xgboost::common::SimpleArray<unsigned int>::resize(unsigned long) /workspace/src/tree/./../common/hist_u$
il.h:40
    #1 0x5607d5dde9fd in xgboost::common::ColumnMatrix::Init(xgboost::common::GHistIndexMatrix const&, double) (/workspace/build/$
estxgboost+0x26b19fd)
    #2 0x5607d5dd89e5 in xgboost::common::DenseColumn_Test_Test::TestBody() /workspace/tests/cpp/common/test_column_matrix.cc:16
    #3 0x5607d6914a88 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void
(testing::Test::*)(), char const*) /workspace/build/googletest-src/googletest/src/gtest.cc:2443
    #4 0x5607d68ff70e in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (te
sting::Test::*)(), char const*) /workspace/build/googletest-src/googletest/src/gtest.cc:2479
    #5 0x5607d687466f in testing::Test::Run() /workspace/build/googletest-src/googletest/src/gtest.cc:2517
    #6 0x5607d6877160 in testing::TestInfo::Run() /workspace/build/googletest-src/googletest/src/gtest.cc:2693
    #7 0x5607d6879355 in testing::TestCase::Run() /workspace/build/googletest-src/googletest/src/gtest.cc:2811
    #8 0x5607d68ac3b6 in testing::internal::UnitTestImpl::RunAllTests() /workspace/build/googletest-src/googletest/src/gtest.cc:51
77
    #9 0x5607d6918e57 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(tes
ting::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspace/build/googletest-src/googletes
t/src/gtest.cc:2443
    #10 0x5607d6903013 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testi
ng::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspace/build/googletest-src/googletest/
src/gtest.cc:2479
    #11 0x5607d68a2309 in testing::UnitTest::Run() /workspace/build/googletest-src/googletest/src/gtest.cc:4786
    #12 0x5607d6178cd0 in RUN_ALL_TESTS() /workspace/build/googletest-src/googletest/include/gtest/gtest.h:2341
    #13 0x5607d61788f0 in main /workspace/tests/cpp/test_main.cc:14
    #14 0x7f9151aa3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
    #15 0x5607d5da1869 in _start (/workspace/build/testxgboost+0x2674869)
```