### PR TITLE
Cleanup quantile.h

### DIFF
--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -233,14 +233,13 @@ void DenseCuts::Build(DMatrix* p_fmat, uint32_t max_num_bins) {
 
   // safe factor for better accuracy
   constexpr int kFactor = 8;
-  std::vector<WXQSketch> sketchs;
 
   const int nthread = omp_get_max_threads();
 
-  unsigned const nstep =
-      static_cast<unsigned>((info.num_col_ + nthread - 1) / nthread);
-  unsigned const ncol = static_cast<unsigned>(info.num_col_);
-  sketchs.resize(info.num_col_, WXQSketch(info.num_row_, 1.0 / (max_num_bins * kFactor)));
+  unsigned const nstep = static_cast<unsigned>((info.num_col_ + nthread - 1) /
+  nthread); unsigned const ncol = static_cast<unsigned>(info.num_col_);
+  std::vector<WXQSketch> sketchs(info.num_col_, WXQSketch(info.num_row_, 1.0 /
+  (max_num_bins * kFactor)));
 
   // Data groups, used in ranking.
   std::vector<bst_uint> const& group_ptr = info.group_ptr_;

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -9,21 +9,23 @@
 
 #include <dmlc/base.h>
 #include <xgboost/logging.h>
-#include <cmath>
-#include <vector>
-#include <cstring>
 #include <algorithm>
+#include <cmath>
+#include <cstring>
 #include <iostream>
+#include <vector>
 
 namespace xgboost {
 namespace common {
+
 /*!
  * \brief experimental wsummary
  * \tparam DType type of data content
  * \tparam RType type of rank
  */
-template<typename DType, typename RType>
-struct WXQSummary {
+template <typename DType, typename RType>
+class WXQSummary {
+ public:
   /*! \brief an entry in the sketch summary */
   struct Entry {
     /*! \brief minimum rank */
@@ -35,7 +37,7 @@ struct WXQSummary {
     /*! \brief the value of data */
     DType value;
     // constructor
-    XGBOOST_DEVICE Entry() {}  // NOLINT
+    XGBOOST_DEVICE Entry() = default;
     // constructor
     XGBOOST_DEVICE Entry(RType rmin, RType rmax, RType wmin, DType value)
         : rmin(rmin), rmax(rmax), wmin(wmin), value(value) {}
@@ -43,18 +45,14 @@ struct WXQSummary {
      * \brief debug function,  check Valid
      * \param eps the tolerate level for violating the relation
      */
-    inline void CheckValid(RType eps = 0) const {
+    void CheckValid(RType eps = 0) const {
       CHECK(rmin >= 0 && rmax >= 0 && wmin >= 0) << "nonneg constraint";
-      CHECK(rmax- rmin - wmin > -eps) <<  "relation constraint: min/max";
+      CHECK(rmax - rmin - wmin > -eps) << "relation constraint: min/max";
     }
     /*! \return rmin estimation for v strictly bigger than value */
-    XGBOOST_DEVICE inline RType RMinNext() const {
-      return rmin + wmin;
-    }
+    XGBOOST_DEVICE RType RMinNext() const { return rmin + wmin; }
     /*! \return rmax estimation for v strictly smaller than value */
-    XGBOOST_DEVICE inline RType RMaxPrev() const {
-      return rmax - wmin;
-    }
+    XGBOOST_DEVICE RType RMaxPrev() const { return rmax - wmin; }
   };
   /*! \brief input data queue before entering the summary */
   struct Queue {
@@ -67,26 +65,23 @@ struct WXQSummary {
       // default constructor
       QEntry() = default;
       // constructor
-      QEntry(DType value, RType weight)
-          : value(value), weight(weight) {}
+      QEntry(DType value, RType weight) : value(value), weight(weight) {}
       // comparator on value
-      inline bool operator<(const QEntry &b) const {
-        return value < b.value;
-      }
+      bool operator<(const QEntry &b) const { return value < b.value; }
     };
     // the input queue
     std::vector<QEntry> queue;
     // end of the queue
     size_t qtail;
     // push data to the queue
-    inline void Push(DType x, RType w) {
+    void Push(DType x, RType w) {
       if (qtail == 0 || queue[qtail - 1].value != x) {
         queue[qtail++] = QEntry(x, w);
       } else {
         queue[qtail - 1].weight += w;
       }
     }
-    inline void MakeSummary(WXQSummary *out) {
+    void MakeSummary(WXQSummary *out) {
       std::sort(queue.begin(), queue.begin() + qtail);
       out->size = 0;
       // start update sketch
@@ -96,10 +91,12 @@ struct WXQSummary {
         size_t j = i + 1;
         RType w = queue[i].weight;
         while (j < qtail && queue[j].value == queue[i].value) {
-          w += queue[j].weight; ++j;
+          w += queue[j].weight;
+          ++j;
         }
         out->data[out->size++] = Entry(wsum, wsum + w, w, queue[i].value);
-        wsum += w; i = j;
+        wsum += w;
+        i = j;
       }
     }
   };
@@ -108,12 +105,11 @@ struct WXQSummary {
   /*! \brief number of elements in the summary */
   size_t size;
   // constructor
-  WXQSummary(Entry *data, size_t size)
-      : data(data), size(size) {}
+  WXQSummary(Entry *data, size_t size) : data(data), size(size) {}
   /*!
    * \return the maximum error of the Summary
    */
-  inline RType MaxError() const {
+  RType MaxError() const {
     RType res = data[0].rmax - data[0].rmin - data[0].wmin;
     for (size_t i = 1; i < size; ++i) {
       res = std::max(data[i].RMaxPrev() - data[i - 1].RMinNext(), res);
@@ -126,7 +122,7 @@ struct WXQSummary {
    * \param qvalue the value we query for
    * \param istart starting position
    */
-  inline Entry Query(DType qvalue, size_t &istart) const { // NOLINT(*)
+  Entry Query(DType qvalue, size_t &istart) const {  // NOLINT(*)
     while (istart < size && qvalue > data[istart].value) {
       ++istart;
     }
@@ -140,30 +136,18 @@ struct WXQSummary {
       if (istart == 0) {
         return Entry(0.0f, 0.0f, 0.0f, qvalue);
       } else {
-        return Entry(data[istart - 1].RMinNext(),
-                     data[istart].RMaxPrev(),
-                     0.0f, qvalue);
+        return Entry(data[istart - 1].RMinNext(), data[istart].RMaxPrev(), 0.0f,
+                     qvalue);
       }
     }
   }
-  /*! \return maximum rank in the summary */
-  inline RType MaxRank() const {
-    return data[size - 1].rmax;
-  }
-  /*!
-   * \brief copy content from src
-   * \param src source sketch
-   */
-  inline void CopyFrom(const WXQSummary &src) {
-    size = src.size;
-    std::memcpy(data, src.data, sizeof(Entry) * size);
-  }
-  inline void MakeFromSorted(const Entry* entries, size_t n) {
+  void MakeFromSorted(const Entry *entries, size_t n) {
     size = 0;
     for (size_t i = 0; i < n;) {
       size_t j = i + 1;
       // ignore repeated values
-      for (; j < n && entries[j].value == entries[i].value; ++j) {}
+      for (; j < n && entries[j].value == entries[i].value; ++j) {
+      }
       data[size++] = Entry(entries[i].rmin, entries[i].rmax, entries[i].wmin,
                            entries[i].value);
       i = j;
@@ -175,22 +159,22 @@ struct WXQSummary {
    * \param eps the tolerate error level, used when RType is floating point and
    *        some inconsistency could occur due to rounding error
    */
-  inline void CheckValid(RType eps) const {
+  void CheckValid(RType eps) const {
     for (size_t i = 0; i < size; ++i) {
       data[i].CheckValid(eps);
       if (i != 0) {
-        CHECK(data[i].rmin >= data[i - 1].rmin + data[i - 1].wmin) << "rmin range constraint";
-        CHECK(data[i].rmax >= data[i - 1].rmax + data[i].wmin) << "rmax range constraint";
+        CHECK(data[i].rmin >= data[i - 1].rmin + data[i - 1].wmin)
+            << "rmin range constraint";
+        CHECK(data[i].rmax >= data[i - 1].rmax + data[i].wmin)
+            << "rmax range constraint";
       }
     }
   }
-  // check if the block is large chunk
-  inline static bool CheckLarge(const Entry &e, RType chunk) {
-    return  e.RMinNext() > e.RMaxPrev() + chunk;
-  } // set prune
-  inline void SetPrune(const WXQSummary<DType, RType> &src, size_t maxsize) {
+  // set prune
+  void SetPrune(const WXQSummary<DType, RType> &src, size_t maxsize) {
     if (src.size <= maxsize) {
-      this->CopyFrom(src); return;
+      this->CopyFrom(src);
+      return;
     }
     RType begin = src.data[0].rmax;
     // n is number of points exclude the min/max points
@@ -224,11 +208,12 @@ struct WXQSummary {
             // accumulate the range of the rest points
             mrange += src.data[i].RMaxPrev() - src.data[bid].RMinNext();
           }
-          bid = i; ++nbig;
+          bid = i;
+          ++nbig;
         }
       }
       if (bid != src.size - 2) {
-        mrange += src.data[src.size-1].RMaxPrev() - src.data[bid].RMinNext();
+        mrange += src.data[src.size - 1].RMaxPrev() - src.data[bid].RMinNext();
       }
     }
     // assert: there cannot be more than n big data points
@@ -242,7 +227,8 @@ struct WXQSummary {
     }
     this->data[0] = src.data[0];
     this->size = 1;
-    // The counter on the rest of points, to be selected equally from small chunks.
+    // The counter on the rest of points, to be selected equally from small
+    // chunks.
     n = n - nbig;
     // find the rest of point
     size_t bid = 0, k = 1, lastidx = 0;
@@ -252,18 +238,21 @@ struct WXQSummary {
           size_t i = bid;
           RType maxdx2 = src.data[end].RMaxPrev() * 2;
           for (; k < n; ++k) {
-            RType dx2 =  2 * ((k * mrange) / n + begin);
+            RType dx2 = 2 * ((k * mrange) / n + begin);
             if (dx2 >= maxdx2) break;
             while (i < end &&
-                   dx2 >= src.data[i + 1].rmax + src.data[i + 1].rmin) ++i;
+                   dx2 >= src.data[i + 1].rmax + src.data[i + 1].rmin)
+              ++i;
             if (i == end) break;
             if (dx2 < src.data[i].RMinNext() + src.data[i + 1].RMaxPrev()) {
               if (i != lastidx) {
-                this->data[this->size++] = src.data[i]; lastidx = i;
+                this->data[this->size++] = src.data[i];
+                lastidx = i;
               }
             } else {
               if (i + 1 != lastidx) {
-                this->data[this->size++] = src.data[i + 1]; lastidx = i + 1;
+                this->data[this->size++] = src.data[i + 1];
+                lastidx = i + 1;
               }
             }
           }
@@ -284,13 +273,14 @@ struct WXQSummary {
    * \param sa first input summary to be merged
    * \param sb second input summary to be merged
    */
-  inline void SetCombine(const WXQSummary &sa,
-                         const WXQSummary &sb) {
+  void SetCombine(const WXQSummary &sa, const WXQSummary &sb) {
     if (sa.size == 0) {
-      this->CopyFrom(sb); return;
+      this->CopyFrom(sb);
+      return;
     }
     if (sb.size == 0) {
-      this->CopyFrom(sa); return;
+      this->CopyFrom(sa);
+      return;
     }
     CHECK(sa.size > 0 && sb.size > 0);
     const Entry *a = sa.data, *a_end = sa.data + sa.size;
@@ -301,38 +291,41 @@ struct WXQSummary {
     while (a != a_end && b != b_end) {
       // duplicated value entry
       if (a->value == b->value) {
-        *dst = Entry(a->rmin + b->rmin,
-                     a->rmax + b->rmax,
-                     a->wmin + b->wmin, a->value);
+        *dst = Entry(a->rmin + b->rmin, a->rmax + b->rmax, a->wmin + b->wmin,
+                     a->value);
         aprev_rmin = a->RMinNext();
         bprev_rmin = b->RMinNext();
-        ++dst; ++a; ++b;
+        ++dst;
+        ++a;
+        ++b;
       } else if (a->value < b->value) {
-        *dst = Entry(a->rmin + bprev_rmin,
-                     a->rmax + b->RMaxPrev(),
-                     a->wmin, a->value);
+        *dst = Entry(a->rmin + bprev_rmin, a->rmax + b->RMaxPrev(), a->wmin,
+                     a->value);
         aprev_rmin = a->RMinNext();
-        ++dst; ++a;
+        ++dst;
+        ++a;
       } else {
-        *dst = Entry(b->rmin + aprev_rmin,
-                     b->rmax + a->RMaxPrev(),
-                     b->wmin, b->value);
+        *dst = Entry(b->rmin + aprev_rmin, b->rmax + a->RMaxPrev(), b->wmin,
+                     b->value);
         bprev_rmin = b->RMinNext();
-        ++dst; ++b;
+        ++dst;
+        ++b;
       }
     }
     if (a != a_end) {
       RType brmax = (b_end - 1)->rmax;
       do {
         *dst = Entry(a->rmin + bprev_rmin, a->rmax + brmax, a->wmin, a->value);
-        ++dst; ++a;
+        ++dst;
+        ++a;
       } while (a != a_end);
     }
     if (b != b_end) {
       RType armax = (a_end - 1)->rmax;
       do {
         *dst = Entry(b->rmin + aprev_rmin, b->rmax + armax, b->wmin, b->value);
-        ++dst; ++b;
+        ++dst;
+        ++b;
       } while (b != b_end);
     }
     this->size = dst - data;
@@ -340,26 +333,36 @@ struct WXQSummary {
     RType err_mingap, err_maxgap, err_wgap;
     this->FixError(&err_mingap, &err_maxgap, &err_wgap);
     if (err_mingap > tol || err_maxgap > tol || err_wgap > tol) {
-      LOG(INFO) << "mingap=" << err_mingap
-                << ", maxgap=" << err_maxgap
+      LOG(INFO) << "mingap=" << err_mingap << ", maxgap=" << err_maxgap
                 << ", wgap=" << err_wgap;
     }
     CHECK(size <= sa.size + sb.size) << "bug in combine";
   }
   // helper function to print the current content of sketch
-  inline void Print() const {
+  void Print() const {
     for (size_t i = 0; i < this->size; ++i) {
       LOG(CONSOLE) << "[" << i << "] rmin=" << data[i].rmin
-                   << ", rmax=" << data[i].rmax
-                   << ", wmin=" << data[i].wmin
+                   << ", rmax=" << data[i].rmax << ", wmin=" << data[i].wmin
                    << ", v=" << data[i].value;
     }
   }
+  /*!
+   * \brief copy content from src
+   * \param src source sketch
+   */
+  void CopyFrom(const WXQSummary &src) {
+    size = src.size;
+    std::memcpy(data, src.data, sizeof(Entry) * size);
+  }
+
+ private:
+  // check if the block is large chunk
+  static bool CheckLarge(const Entry &e, RType chunk) {
+    return e.RMinNext() > e.RMaxPrev() + chunk;
+  }
   // try to fix rounding error
   // and re-establish invariance
-  inline void FixError(RType *err_mingap,
-                       RType *err_maxgap,
-                       RType *err_wgap) const {
+  void FixError(RType *err_mingap, RType *err_maxgap, RType *err_wgap) const {
     *err_mingap = 0;
     *err_maxgap = 0;
     *err_wgap = 0;
@@ -383,19 +386,6 @@ struct WXQSummary {
       prev_rmax = data[i].rmax;
     }
   }
-  // check consistency of the summary
-  inline bool Check(const char *msg) const {
-    const float tol = 10.0f;
-    for (size_t i = 0; i < this->size; ++i) {
-      if (data[i].rmin + data[i].wmin > data[i].rmax + tol ||
-          data[i].rmin < -1e-6f || data[i].rmax < -1e-6f) {
-        LOG(INFO) << "---------- WQSummary::Check did not pass ----------";
-        this->Print();
-        return false;
-      }
-    }
-    return true;
-  }
 };
 
 /*!
@@ -403,13 +393,12 @@ struct WXQSummary {
  *        that uses merge/prune scheme
  * \tparam DType type of data content
  * \tparam RType type of rank
- * \tparam TSummary actual summary data structure it uses
  */
-template<typename DType, typename RType, class TSummary>
-class QuantileSketchTemplate {
+template <typename DType, typename RType>
+class WXQuantileSketch {
  public:
   /*! \brief type of summary type */
-  using Summary = TSummary;
+  using Summary = WXQSummary<DType, RType>;
   /*! \brief the entry type */
   using Entry = typename Summary::Entry;
   /*! \brief same as summary, but use STL to backup the space */
@@ -419,10 +408,9 @@ class QuantileSketchTemplate {
       this->space = src.space;
       this->data = dmlc::BeginPtr(this->space);
     }
-    SummaryContainer() : Summary(nullptr, 0) {
-    }
+    SummaryContainer() : Summary(nullptr, 0) {}
     /*! \brief reserve space for summary */
-    inline void Reserve(size_t size) {
+    void Reserve(size_t size) {
       if (size > space.size()) {
         space.resize(size);
         this->data = dmlc::BeginPtr(space);
@@ -433,8 +421,7 @@ class QuantileSketchTemplate {
      * \param begin beginning position in the summary array
      * \param end ending position in the Summary array
      */
-    inline void SetMerge(const Summary *begin,
-                         const Summary *end) {
+    void SetMerge(const Summary *begin, const Summary *end) {
       CHECK(begin < end) << "can not set combine to empty instance";
       size_t len = end - begin;
       if (len == 1) {
@@ -458,28 +445,29 @@ class QuantileSketchTemplate {
      * \param src the source summary
      * \param max_nbyte maximum number of byte allowed in here
      */
-    inline void Reduce(const Summary &src, size_t max_nbyte) {
+    void Reduce(const Summary &src, size_t max_nbyte) {
       this->Reserve((max_nbyte - sizeof(this->size)) / sizeof(Entry));
       SummaryContainer temp;
       temp.Reserve(this->size + src.size);
       temp.SetCombine(*this, src);
       this->SetPrune(temp, space.size());
     }
-    /*! \brief return the number of bytes this data structure cost in serialization */
-    inline static size_t CalcMemCost(size_t nentry) {
+    /*! \brief return the number of bytes this data structure cost in
+     * serialization */
+    static size_t CalcMemCost(size_t nentry) {
       return sizeof(size_t) + sizeof(Entry) * nentry;
     }
     /*! \brief save the data structure into stream */
-    template<typename TStream>
-    inline void Save(TStream &fo) const {  // NOLINT(*)
+    template <typename TStream>
+    void Save(TStream &fo) const {  // NOLINT(*)
       fo.Write(&(this->size), sizeof(this->size));
       if (this->size != 0) {
         fo.Write(this->data, this->size * sizeof(Entry));
       }
     }
     /*! \brief load data structure from input stream */
-    template<typename TStream>
-    inline void Load(TStream &fi) {  // NOLINT(*)
+    template <typename TStream>
+    void Load(TStream &fi) {  // NOLINT(*)
       CHECK_EQ(fi.Read(&this->size, sizeof(this->size)), sizeof(this->size));
       this->Reserve(this->size);
       if (this->size != 0) {
@@ -493,19 +481,20 @@ class QuantileSketchTemplate {
    * \param maxn maximum number of data points can be feed into sketch
    * \param eps accuracy level of summary
    */
-  inline void Init(size_t maxn, double eps) {
+  void Init(size_t maxn, double eps) {
     LimitSizeLevel(maxn, eps, &nlevel, &limit_size);
-    // lazy reserve the space, if there is only one value, no need to allocate space
-    inqueue.queue.resize(1);
-    inqueue.qtail = 0;
+    // lazy reserve the space, if there is only one value, no need to allocate
+    // space
+    inqueue_.queue.resize(1);
+    inqueue_.qtail = 0;
     data.clear();
     level.clear();
   }
 
-  inline static void LimitSizeLevel
-    (size_t maxn, double eps, size_t* out_nlevel, size_t* out_limit_size) {
-    size_t& nlevel = *out_nlevel;
-    size_t& limit_size = *out_limit_size;
+  static void LimitSizeLevel(size_t maxn, double eps, size_t *out_nlevel,
+                             size_t *out_limit_size) {
+    size_t &nlevel = *out_nlevel;
+    size_t &limit_size = *out_limit_size;
     nlevel = 1;
     while (true) {
       limit_size = static_cast<size_t>(ceil(nlevel / eps)) + 1;
@@ -524,31 +513,31 @@ class QuantileSketchTemplate {
    * \param x The element added to the sketch
    * \param w The weight of the element.
    */
-  inline void Push(DType x, RType w = 1) {
+  void Push(DType x, RType w = 1) {
     if (w == static_cast<RType>(0)) return;
-    if (inqueue.qtail == inqueue.queue.size()) {
+    if (inqueue_.qtail == inqueue_.queue.size()) {
       // jump from lazy one value to limit_size * 2
-      if (inqueue.queue.size() == 1) {
-        inqueue.queue.resize(limit_size * 2);
+      if (inqueue_.queue.size() == 1) {
+        inqueue_.queue.resize(limit_size * 2);
       } else {
         temp.Reserve(limit_size * 2);
-        inqueue.MakeSummary(&temp);
+        inqueue_.MakeSummary(&temp);
         // cleanup queue
-        inqueue.qtail = 0;
+        inqueue_.qtail = 0;
         this->PushTemp();
       }
     }
-    inqueue.Push(x, w);
+    inqueue_.Push(x, w);
   }
 
-  inline void PushSummary(const Summary& summary) {
+  void PushSummary(const Summary &summary) {
     temp.Reserve(limit_size * 2);
     temp.SetPrune(summary, limit_size * 2);
     PushTemp();
   }
 
   /*! \brief push up temp */
-  inline void PushTemp() {
+  void PushTemp() {
     temp.Reserve(limit_size * 2);
     for (size_t l = 1; true; ++l) {
       this->InitLevel(l + 1);
@@ -565,19 +554,20 @@ class QuantileSketchTemplate {
           level[l].size = 0;
         } else {
           // if merged record is still smaller, no need to send to next level
-          level[l].CopyFrom(temp); break;
+          level[l].CopyFrom(temp);
+          break;
         }
       }
     }
   }
   /*! \brief get the summary after finalize */
-  inline void GetSummary(SummaryContainer *out) {
+  void GetSummary(SummaryContainer *out) {
     if (level.size() != 0) {
       out->Reserve(limit_size * 2);
     } else {
-      out->Reserve(inqueue.queue.size());
+      out->Reserve(inqueue_.queue.size());
     }
-    inqueue.MakeSummary(out);
+    inqueue_.MakeSummary(out);
     if (level.size() != 0) {
       level[0].SetPrune(*out, limit_size);
       for (size_t l = 1; l < level.size(); ++l) {
@@ -599,13 +589,13 @@ class QuantileSketchTemplate {
     }
   }
   // used for debug, check if the sketch is valid
-  inline void CheckValid(RType eps) const {
+  void CheckValid(RType eps) const {
     for (size_t l = 1; l < level.size(); ++l) {
       level[l].CheckValid(eps);
     }
   }
   // initialize level space to at least nlevel
-  inline void InitLevel(size_t nlevel) {
+  void InitLevel(size_t nlevel) {
     if (level.size() >= nlevel) return;
     data.resize(limit_size * nlevel);
     level.resize(nlevel, Summary(nullptr, 0));
@@ -613,8 +603,6 @@ class QuantileSketchTemplate {
       level[l].data = dmlc::BeginPtr(data) + l * limit_size;
     }
   }
-  // input data queue
-  typename Summary::Queue inqueue;
   // number of levels
   size_t nlevel;
   // size of summary in each level
@@ -625,17 +613,12 @@ class QuantileSketchTemplate {
   std::vector<Entry> data;
   // temporal summary, used for temp-merge
   SummaryContainer temp;
+
+ private:
+  // input data queue
+  typename Summary::Queue inqueue_;
 };
 
-/*!
- * \brief Quantile sketch use WXQSummary
- * \tparam DType type of data content
- * \tparam RType type of rank
- */
-template<typename DType, typename RType = unsigned>
-class WXQuantileSketch :
-      public QuantileSketchTemplate<DType, RType, WXQSummary<DType, RType> > {
-};
 }  // namespace common
 }  // namespace xgboost
 #endif  // XGBOOST_COMMON_QUANTILE_H_

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -23,7 +23,7 @@ namespace common {
  * \tparam RType type of rank
  */
 template<typename DType, typename RType>
-struct WQSummary {
+struct WXQSummary {
   /*! \brief an entry in the sketch summary */
   struct Entry {
     /*! \brief minimum rank */
@@ -86,7 +86,7 @@ struct WQSummary {
         queue[qtail - 1].weight += w;
       }
     }
-    inline void MakeSummary(WQSummary *out) {
+    inline void MakeSummary(WXQSummary *out) {
       std::sort(queue.begin(), queue.begin() + qtail);
       out->size = 0;
       // start update sketch
@@ -108,7 +108,7 @@ struct WQSummary {
   /*! \brief number of elements in the summary */
   size_t size;
   // constructor
-  WQSummary(Entry *data, size_t size)
+  WXQSummary(Entry *data, size_t size)
       : data(data), size(size) {}
   /*!
    * \return the maximum error of the Summary
@@ -154,7 +154,7 @@ struct WQSummary {
    * \brief copy content from src
    * \param src source sketch
    */
-  inline void CopyFrom(const WQSummary &src) {
+  inline void CopyFrom(const WXQSummary &src) {
     size = src.size;
     std::memcpy(data, src.data, sizeof(Entry) * size);
   }
@@ -184,51 +184,108 @@ struct WQSummary {
       }
     }
   }
-  /*!
-   * \brief set current summary to be pruned summary of src
-   *        assume data field is already allocated to be at least maxsize
-   * \param src source summary
-   * \param maxsize size we can afford in the pruned sketch
-   */
-
-  inline void SetPrune(const WQSummary &src, size_t maxsize) {
+  // check if the block is large chunk
+  inline static bool CheckLarge(const Entry &e, RType chunk) {
+    return  e.RMinNext() > e.RMaxPrev() + chunk;
+  } // set prune
+  inline void SetPrune(const WXQSummary<DType, RType> &src, size_t maxsize) {
     if (src.size <= maxsize) {
       this->CopyFrom(src); return;
     }
-    const RType begin = src.data[0].rmax;
-    const RType range = src.data[src.size - 1].rmin - src.data[0].rmax;
-    const size_t n = maxsize - 1;
-    data[0] = src.data[0];
-    this->size = 1;
-    // lastidx is used to avoid duplicated records
-    size_t i = 1, lastidx = 0;
-    for (size_t k = 1; k < n; ++k) {
-      RType dx2 =  2 * ((k * range) / n + begin);
-      // find first i such that  d < (rmax[i+1] + rmin[i+1]) / 2
-      while (i < src.size - 1
-             && dx2 >= src.data[i + 1].rmax + src.data[i + 1].rmin) ++i;
-      CHECK(i != src.size - 1);
-      if (dx2 < src.data[i].RMinNext() + src.data[i + 1].RMaxPrev()) {
-        if (i != lastidx) {
-          data[size++] = src.data[i]; lastidx = i;
-        }
-      } else {
-        if (i + 1 != lastidx) {
-          data[size++] = src.data[i + 1]; lastidx = i + 1;
+    RType begin = src.data[0].rmax;
+    // n is number of points exclude the min/max points
+    size_t n = maxsize - 2, nbig = 0;
+    // these is the range of data exclude the min/max point
+    RType range = src.data[src.size - 1].rmin - begin;
+    // prune off zero weights
+    if (range == 0.0f || maxsize <= 2) {
+      // special case, contain only two effective data pts
+      this->data[0] = src.data[0];
+      this->data[1] = src.data[src.size - 1];
+      this->size = 2;
+      return;
+    } else {
+      range = std::max(range, static_cast<RType>(1e-3f));
+    }
+    // Get a big enough chunk size, bigger than range / n
+    // (multiply by 2 is a safe factor)
+    const RType chunk = 2 * range / n;
+    // minimized range
+    RType mrange = 0;
+    {
+      // first scan, grab all the big chunk
+      // moving block index, exclude the two ends.
+      size_t bid = 0;
+      for (size_t i = 1; i < src.size - 1; ++i) {
+        // detect big chunk data point in the middle
+        // always save these data points.
+        if (CheckLarge(src.data[i], chunk)) {
+          if (bid != i - 1) {
+            // accumulate the range of the rest points
+            mrange += src.data[i].RMaxPrev() - src.data[bid].RMinNext();
+          }
+          bid = i; ++nbig;
         }
       }
+      if (bid != src.size - 2) {
+        mrange += src.data[src.size-1].RMaxPrev() - src.data[bid].RMinNext();
+      }
     }
-    if (lastidx != src.size - 1) {
-      data[size++] = src.data[src.size - 1];
+    // assert: there cannot be more than n big data points
+    if (nbig >= n) {
+      // see what was the case
+      LOG(INFO) << " check quantile stats, nbig=" << nbig << ", n=" << n;
+      LOG(INFO) << " srcsize=" << src.size << ", maxsize=" << maxsize
+                << ", range=" << range << ", chunk=" << chunk;
+      src.Print();
+      CHECK(nbig < n) << "quantile: too many large chunk";
+    }
+    this->data[0] = src.data[0];
+    this->size = 1;
+    // The counter on the rest of points, to be selected equally from small chunks.
+    n = n - nbig;
+    // find the rest of point
+    size_t bid = 0, k = 1, lastidx = 0;
+    for (size_t end = 1; end < src.size; ++end) {
+      if (end == src.size - 1 || CheckLarge(src.data[end], chunk)) {
+        if (bid != end - 1) {
+          size_t i = bid;
+          RType maxdx2 = src.data[end].RMaxPrev() * 2;
+          for (; k < n; ++k) {
+            RType dx2 =  2 * ((k * mrange) / n + begin);
+            if (dx2 >= maxdx2) break;
+            while (i < end &&
+                   dx2 >= src.data[i + 1].rmax + src.data[i + 1].rmin) ++i;
+            if (i == end) break;
+            if (dx2 < src.data[i].RMinNext() + src.data[i + 1].RMaxPrev()) {
+              if (i != lastidx) {
+                this->data[this->size++] = src.data[i]; lastidx = i;
+              }
+            } else {
+              if (i + 1 != lastidx) {
+                this->data[this->size++] = src.data[i + 1]; lastidx = i + 1;
+              }
+            }
+          }
+        }
+        if (lastidx != end) {
+          this->data[this->size++] = src.data[end];
+          lastidx = end;
+        }
+        bid = end;
+        // shift base by the gap
+        begin += src.data[bid].RMinNext() - src.data[bid].RMaxPrev();
+      }
     }
   }
+
   /*!
    * \brief set current summary to be merged summary of sa and sb
    * \param sa first input summary to be merged
    * \param sb second input summary to be merged
    */
-  inline void SetCombine(const WQSummary &sa,
-                         const WQSummary &sb) {
+  inline void SetCombine(const WXQSummary &sa,
+                         const WXQSummary &sb) {
     if (sa.size == 0) {
       this->CopyFrom(sb); return;
     }
@@ -338,256 +395,6 @@ struct WQSummary {
       }
     }
     return true;
-  }
-};
-
-/*! \brief try to do efficient pruning */
-template<typename DType, typename RType>
-struct WXQSummary : public WQSummary<DType, RType> {
-  // redefine entry type
-  using Entry = typename WQSummary<DType, RType>::Entry;
-  // constructor
-  WXQSummary(Entry *data, size_t size)
-      : WQSummary<DType, RType>(data, size) {}
-  // check if the block is large chunk
-  inline static bool CheckLarge(const Entry &e, RType chunk) {
-    return  e.RMinNext() > e.RMaxPrev() + chunk;
-  }
-  // set prune
-  inline void SetPrune(const WQSummary<DType, RType> &src, size_t maxsize) {
-    if (src.size <= maxsize) {
-      this->CopyFrom(src); return;
-    }
-    RType begin = src.data[0].rmax;
-    // n is number of points exclude the min/max points
-    size_t n = maxsize - 2, nbig = 0;
-    // these is the range of data exclude the min/max point
-    RType range = src.data[src.size - 1].rmin - begin;
-    // prune off zero weights
-    if (range == 0.0f || maxsize <= 2) {
-      // special case, contain only two effective data pts
-      this->data[0] = src.data[0];
-      this->data[1] = src.data[src.size - 1];
-      this->size = 2;
-      return;
-    } else {
-      range = std::max(range, static_cast<RType>(1e-3f));
-    }
-    // Get a big enough chunk size, bigger than range / n
-    // (multiply by 2 is a safe factor)
-    const RType chunk = 2 * range / n;
-    // minimized range
-    RType mrange = 0;
-    {
-      // first scan, grab all the big chunk
-      // moving block index, exclude the two ends.
-      size_t bid = 0;
-      for (size_t i = 1; i < src.size - 1; ++i) {
-        // detect big chunk data point in the middle
-        // always save these data points.
-        if (CheckLarge(src.data[i], chunk)) {
-          if (bid != i - 1) {
-            // accumulate the range of the rest points
-            mrange += src.data[i].RMaxPrev() - src.data[bid].RMinNext();
-          }
-          bid = i; ++nbig;
-        }
-      }
-      if (bid != src.size - 2) {
-        mrange += src.data[src.size-1].RMaxPrev() - src.data[bid].RMinNext();
-      }
-    }
-    // assert: there cannot be more than n big data points
-    if (nbig >= n) {
-      // see what was the case
-      LOG(INFO) << " check quantile stats, nbig=" << nbig << ", n=" << n;
-      LOG(INFO) << " srcsize=" << src.size << ", maxsize=" << maxsize
-                << ", range=" << range << ", chunk=" << chunk;
-      src.Print();
-      CHECK(nbig < n) << "quantile: too many large chunk";
-    }
-    this->data[0] = src.data[0];
-    this->size = 1;
-    // The counter on the rest of points, to be selected equally from small chunks.
-    n = n - nbig;
-    // find the rest of point
-    size_t bid = 0, k = 1, lastidx = 0;
-    for (size_t end = 1; end < src.size; ++end) {
-      if (end == src.size - 1 || CheckLarge(src.data[end], chunk)) {
-        if (bid != end - 1) {
-          size_t i = bid;
-          RType maxdx2 = src.data[end].RMaxPrev() * 2;
-          for (; k < n; ++k) {
-            RType dx2 =  2 * ((k * mrange) / n + begin);
-            if (dx2 >= maxdx2) break;
-            while (i < end &&
-                   dx2 >= src.data[i + 1].rmax + src.data[i + 1].rmin) ++i;
-            if (i == end) break;
-            if (dx2 < src.data[i].RMinNext() + src.data[i + 1].RMaxPrev()) {
-              if (i != lastidx) {
-                this->data[this->size++] = src.data[i]; lastidx = i;
-              }
-            } else {
-              if (i + 1 != lastidx) {
-                this->data[this->size++] = src.data[i + 1]; lastidx = i + 1;
-              }
-            }
-          }
-        }
-        if (lastidx != end) {
-          this->data[this->size++] = src.data[end];
-          lastidx = end;
-        }
-        bid = end;
-        // shift base by the gap
-        begin += src.data[bid].RMinNext() - src.data[bid].RMaxPrev();
-      }
-    }
-  }
-};
-/*!
- * \brief traditional GK summary
- */
-template<typename DType, typename RType>
-struct GKSummary {
-  /*! \brief an entry in the sketch summary */
-  struct Entry {
-    /*! \brief minimum rank */
-    RType rmin;
-    /*! \brief maximum rank */
-    RType rmax;
-    /*! \brief the value of data */
-    DType value;
-    // constructor
-    Entry() = default;
-    // constructor
-    Entry(RType rmin, RType rmax, DType value)
-        : rmin(rmin), rmax(rmax), value(value) {}
-  };
-  /*! \brief input data queue before entering the summary */
-  struct Queue {
-    // the input queue
-    std::vector<DType> queue;
-    // end of the queue
-    size_t qtail;
-    // push data to the queue
-    inline void Push(DType x, RType w) {
-      queue[qtail++] = x;
-    }
-    inline void MakeSummary(GKSummary *out) {
-      std::sort(queue.begin(), queue.begin() + qtail);
-      out->size = qtail;
-      for (size_t i = 0; i < qtail; ++i) {
-        out->data[i] = Entry(i + 1, i + 1, queue[i]);
-      }
-    }
-  };
-  /*! \brief data field */
-  Entry *data;
-  /*! \brief number of elements in the summary */
-  size_t size;
-  GKSummary(Entry *data, size_t size)
-      : data(data), size(size) {}
-  /*! \brief the maximum error of the summary */
-  inline RType MaxError() const {
-    RType res = 0;
-    for (size_t i = 1; i < size; ++i) {
-      res = std::max(data[i].rmax - data[i-1].rmin, res);
-    }
-    return res;
-  }
-  /*! \return maximum rank in the summary */
-  inline RType MaxRank() const {
-    return data[size - 1].rmax;
-  }
-  /*!
-   * \brief copy content from src
-   * \param src source sketch
-   */
-  inline void CopyFrom(const GKSummary &src) {
-    size = src.size;
-    std::memcpy(data, src.data, sizeof(Entry) * size);
-  }
-  inline void CheckValid(RType eps) const {
-    // assume always valid
-  }
-  /*! \brief used for debug purpose, print the summary */
-  inline void Print() const {
-    for (size_t i = 0; i < size; ++i) {
-      LOG(CONSOLE) << "x=" << data[i].value << "\t"
-                   << "[" << data[i].rmin << "," << data[i].rmax << "]";
-    }
-  }
-  /*!
-   * \brief set current summary to be pruned summary of src
-   *        assume data field is already allocated to be at least maxsize
-   * \param src source summary
-   * \param maxsize size we can afford in the pruned sketch
-   */
-  inline void SetPrune(const GKSummary &src, size_t maxsize) {
-    if (src.size <= maxsize) {
-      this->CopyFrom(src); return;
-    }
-    const RType max_rank = src.MaxRank();
-    this->size = maxsize;
-    data[0] = src.data[0];
-    size_t n = maxsize - 1;
-    RType top = 1;
-    for (size_t i = 1; i < n; ++i) {
-      RType k = (i * max_rank) / n;
-      while (k > src.data[top + 1].rmax) ++top;
-      // assert src.data[top].rmin <= k
-      // because k > src.data[top].rmax >= src.data[top].rmin
-      if ((k - src.data[top].rmin) < (src.data[top+1].rmax - k)) {
-        data[i] = src.data[top];
-      } else {
-        data[i] = src.data[top + 1];
-      }
-    }
-    data[n] = src.data[src.size - 1];
-  }
-  inline void SetCombine(const GKSummary &sa,
-                         const GKSummary &sb) {
-    if (sa.size == 0) {
-      this->CopyFrom(sb); return;
-    }
-    if (sb.size == 0) {
-      this->CopyFrom(sa); return;
-    }
-    CHECK(sa.size > 0 && sb.size > 0) << "invalid input for merge";
-    const Entry *a = sa.data, *a_end = sa.data + sa.size;
-    const Entry *b = sb.data, *b_end = sb.data + sb.size;
-    this->size = sa.size + sb.size;
-    RType aprev_rmin = 0, bprev_rmin = 0;
-    Entry *dst = this->data;
-    while (a != a_end && b != b_end) {
-      if (a->value < b->value) {
-        *dst = Entry(bprev_rmin + a->rmin,
-                     a->rmax + b->rmax - 1, a->value);
-        aprev_rmin = a->rmin;
-        ++dst; ++a;
-      } else {
-        *dst = Entry(aprev_rmin + b->rmin,
-                     b->rmax + a->rmax - 1, b->value);
-        bprev_rmin = b->rmin;
-        ++dst; ++b;
-      }
-    }
-    if (a != a_end) {
-      RType bprev_rmax = (b_end - 1)->rmax;
-      do {
-        *dst = Entry(bprev_rmin + a->rmin, bprev_rmax + a->rmax, a->value);
-        ++dst; ++a;
-      } while (a != a_end);
-    }
-    if (b != b_end) {
-      RType aprev_rmax = (a_end - 1)->rmax;
-      do {
-        *dst = Entry(aprev_rmin + b->rmin, aprev_rmax + b->rmax, b->value);
-        ++dst; ++b;
-      } while (b != b_end);
-    }
-    CHECK(dst == data + size) << "bug in combine";
   }
 };
 
@@ -821,16 +628,6 @@ class QuantileSketchTemplate {
 };
 
 /*!
- * \brief Quantile sketch use WQSummary
- * \tparam DType type of data content
- * \tparam RType type of rank
- */
-template<typename DType, typename RType = unsigned>
-class WQuantileSketch :
-      public QuantileSketchTemplate<DType, RType, WQSummary<DType, RType> > {
-};
-
-/*!
  * \brief Quantile sketch use WXQSummary
  * \tparam DType type of data content
  * \tparam RType type of rank
@@ -838,15 +635,6 @@ class WQuantileSketch :
 template<typename DType, typename RType = unsigned>
 class WXQuantileSketch :
       public QuantileSketchTemplate<DType, RType, WXQSummary<DType, RType> > {
-};
-/*!
- * \brief Quantile sketch use WQSummary
- * \tparam DType type of data content
- * \tparam RType type of rank
- */
-template<typename DType, typename RType = unsigned>
-class GKQuantileSketch :
-      public QuantileSketchTemplate<DType, RType, GKSummary<DType, RType> > {
 };
 }  // namespace common
 }  // namespace xgboost

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -481,14 +481,12 @@ class WXQuantileSketch {
    * \param maxn maximum number of data points can be feed into sketch
    * \param eps accuracy level of summary
    */
-  void Init(size_t maxn, double eps) {
+  WXQuantileSketch(size_t maxn, double eps) {
     LimitSizeLevel(maxn, eps, &nlevel, &limit_size);
     // lazy reserve the space, if there is only one value, no need to allocate
     // space
     inqueue_.queue.resize(1);
     inqueue_.qtail = 0;
-    data.clear();
-    level.clear();
   }
 
   static void LimitSizeLevel(size_t maxn, double eps, size_t *out_nlevel,
@@ -603,6 +601,11 @@ class WXQuantileSketch {
       level[l].data = dmlc::BeginPtr(data) + l * limit_size;
     }
   }
+
+  // temporal summary, used for temp-merge
+  SummaryContainer temp;
+
+ private:
   // number of levels
   size_t nlevel;
   // size of summary in each level
@@ -611,10 +614,6 @@ class WXQuantileSketch {
   std::vector<Summary> level;
   // content of the summary
   std::vector<Entry> data;
-  // temporal summary, used for temp-merge
-  SummaryContainer temp;
-
- private:
   // input data queue
   typename Summary::Queue inqueue_;
 };

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -124,6 +124,18 @@ class WXQSummary {
       }
     }
   }
+  void MakeFromSorted(const Entry *entries, size_t n) {
+    size = 0;
+    for (size_t i = 0; i < n;) {
+      size_t j = i + 1;
+      // ignore repeated values
+      for (; j < n && entries[j].value == entries[i].value; ++j) {
+      }
+      data[size++] = Entry(entries[i].rmin, entries[i].rmax, entries[i].wmin,
+                           entries[i].value);
+      i = j;
+    }
+  }
   // set prune
   void SetPrune(const WXQSummary<DType, RType> &src, size_t maxsize) {
     if (src.size <= maxsize) {

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -37,7 +37,7 @@ class WXQSummary {
     /*! \brief the value of data */
     DType value;
     // constructor
-    XGBOOST_DEVICE Entry() = default;
+    Entry() = default;
     // constructor
     XGBOOST_DEVICE Entry(RType rmin, RType rmax, RType wmin, DType value)
         : rmin(rmin), rmax(rmax), wmin(wmin), value(value) {}
@@ -116,42 +116,6 @@ class WXQSummary {
       res = std::max(data[i].rmax - data[i].rmin - data[i].wmin, res);
     }
     return res;
-  }
-  /*!
-   * \brief query qvalue, start from istart
-   * \param qvalue the value we query for
-   * \param istart starting position
-   */
-  Entry Query(DType qvalue, size_t &istart) const {  // NOLINT(*)
-    while (istart < size && qvalue > data[istart].value) {
-      ++istart;
-    }
-    if (istart == size) {
-      RType rmax = data[size - 1].rmax;
-      return Entry(rmax, rmax, 0.0f, qvalue);
-    }
-    if (qvalue == data[istart].value) {
-      return data[istart];
-    } else {
-      if (istart == 0) {
-        return Entry(0.0f, 0.0f, 0.0f, qvalue);
-      } else {
-        return Entry(data[istart - 1].RMinNext(), data[istart].RMaxPrev(), 0.0f,
-                     qvalue);
-      }
-    }
-  }
-  void MakeFromSorted(const Entry *entries, size_t n) {
-    size = 0;
-    for (size_t i = 0; i < n;) {
-      size_t j = i + 1;
-      // ignore repeated values
-      for (; j < n && entries[j].value == entries[i].value; ++j) {
-      }
-      data[size++] = Entry(entries[i].rmin, entries[i].rmax, entries[i].wmin,
-                           entries[i].value);
-      i = j;
-    }
   }
   /*!
    * \brief debug function, validate whether the summary

--- a/src/tree/updater_histmaker.cc
+++ b/src/tree/updater_histmaker.cc
@@ -398,10 +398,8 @@ class CQHistMaker: public HistMaker {
     }
     const size_t work_set_size = work_set_.size();
 
-    sketchs_.resize(this->qexpand_.size() * work_set_size);
-    for (auto& sketch : sketchs_) {
-      sketch.Init(info.num_row_, this->param_.sketch_eps);
-    }
+    sketchs_.resize(this->qexpand_.size() * work_set_size,
+                    WXQSketch(info.num_row_, this->param_.sketch_eps));
     // intitialize the summary array
     summary_array_.resize(sketchs_.size());
     // setup maximum size

--- a/src/tree/updater_histmaker.cc
+++ b/src/tree/updater_histmaker.cc
@@ -400,6 +400,9 @@ class CQHistMaker: public HistMaker {
 
     sketchs_.resize(this->qexpand_.size() * work_set_size,
                     WXQSketch(info.num_row_, this->param_.sketch_eps));
+    std::fill(sketchs_.begin(), sketchs_.end(),
+              WXQSketch(info.num_row_, this->param_.sketch_eps));
+
     // intitialize the summary array
     summary_array_.resize(sketchs_.size());
     // setup maximum size

--- a/src/tree/updater_skmaker.cc
+++ b/src/tree/updater_skmaker.cc
@@ -129,6 +129,8 @@ class SketchMaker: public BaseMaker {
     const MetaInfo& info = p_fmat->Info();
     sketchs_.resize(this->qexpand_.size() * tree.param.num_feature * 3,
                     WXQSketch(info.num_row_, this->param_.sketch_eps));
+    std::fill(sketchs_.begin(), sketchs_.end(),
+              WXQSketch(info.num_row_, this->param_.sketch_eps));
     thread_sketch_.resize(omp_get_max_threads());
     // number of rows in
     const size_t nrows = p_fmat->Info().num_row_;

--- a/src/tree/updater_skmaker.cc
+++ b/src/tree/updater_skmaker.cc
@@ -127,10 +127,8 @@ class SketchMaker: public BaseMaker {
                           DMatrix *p_fmat,
                           const RegTree &tree) {
     const MetaInfo& info = p_fmat->Info();
-    sketchs_.resize(this->qexpand_.size() * tree.param.num_feature * 3);
-    for (auto & sketch : sketchs_) {
-      sketch.Init(info.num_row_, this->param_.sketch_eps);
-    }
+    sketchs_.resize(this->qexpand_.size() * tree.param.num_feature * 3,
+                    WXQSketch(info.num_row_, this->param_.sketch_eps));
     thread_sketch_.resize(omp_get_max_threads());
     // number of rows in
     const size_t nrows = p_fmat->Info().num_row_;

--- a/src/tree/updater_skmaker.cc
+++ b/src/tree/updater_skmaker.cc
@@ -322,7 +322,7 @@ class SketchMaker: public BaseMaker {
                                      summary.data[istart].RMaxPrev(), 0.0f,
                                      query_value);
   }
-  
+
   inline void EnumerateSplit(const WXQSketch::Summary &pos_grad,
                              const WXQSketch::Summary &neg_grad,
                              const WXQSketch::Summary &sum_hess,

--- a/src/tree/updater_skmaker.cc
+++ b/src/tree/updater_skmaker.cc
@@ -309,18 +309,18 @@ class SketchMaker: public BaseMaker {
     }
     if (istart == summary.size) {
       float rmax = summary.data[summary.size - 1].rmax;
-      return WXQSketch::Summary::Entry(rmax, rmax, 0.0f, query_value);
+      return {rmax, rmax, 0.0f, query_value};
     }
     if (query_value == summary.data[istart].value) {
       return summary.data[istart];
     }
     if (istart == 0) {
-      return WXQSketch::Summary::Entry(0.0f, 0.0f, 0.0f, query_value);
+      return {0.0f, 0.0f, 0.0f, query_value};
     }
 
-    return WXQSketch::Summary::Entry(summary.data[istart - 1].RMinNext(),
-                                     summary.data[istart].RMaxPrev(), 0.0f,
-                                     query_value);
+    return {summary.data[istart - 1].RMinNext(),
+            summary.data[istart].RMaxPrev(), 0.0f,
+                                     query_value };
   }
 
   inline void EnumerateSplit(const WXQSketch::Summary &pos_grad,

--- a/tests/cpp/data/test_quantile.cc
+++ b/tests/cpp/data/test_quantile.cc
@@ -1,0 +1,40 @@
+// Copyright by Contributors
+
+#include <gtest/gtest.h>
+#include "../../../src/common/quantile.h"
+
+namespace xgboost {
+namespace common {
+TEST(Quantile, Basic) {
+  std::vector<float> data = {0, 1, 2, 3, 4};
+  WXQuantileSketch<float, float> sketch(data.size(), 1.0 / data.size());
+  for (auto x : data) {
+    sketch.Push(x);
+  }
+  WXQuantileSketch<float, float>::SummaryContainer summary;
+  sketch.GetSummary(&summary);
+  summary.CheckValid(1e-5);
+  for (auto x : summary.space) {
+    for (auto i = 0ull; i < data.size(); i++) {
+      EXPECT_EQ(summary.data[i].value, data[i]);
+    }
+  }
+  using SketchEntry = WXQuantileSketch<float, float>::SummaryContainer::Entry;
+  EXPECT_TRUE(std::is_sorted(
+      summary.data, summary.data + summary.size,
+      [](SketchEntry a, SketchEntry b) { return a.value < b.value; }));
+}
+
+TEST(Quantile, Repeats) {
+  std::vector<float> data = {0, 1, 0, 1, 0};
+  WXQuantileSketch<float, float> sketch(data.size(), 1.0 / data.size());
+  for (auto x : data) {
+    sketch.Push(x);
+  }
+  WXQuantileSketch<float, float>::SummaryContainer summary;
+  sketch.GetSummary(&summary);
+  summary.CheckValid(1e-5);
+  EXPECT_EQ(summary.size, 2);
+}
+};  // namespace common
+};  // namespace xgboost


### PR DESCRIPTION
I found it difficult to understand what is going on in quantile.h, so I went through and removed dead code, tried to simplify some relationships between classes and tried to make as many methods/variables private as possible. This PR should cause no change in behaviour.

In particular:
- WQSummary is removed as everything seems to use WXQSummary
- QuantileSketchTemplate has been collapsed into WXQuantileSketch as it was the only instance being used

Ideally I wanted something like an interface where I could hide away the internals but still use it in a sketching algorithm. This can't happen yet because this part https://github.com/dmlc/xgboost/blob/44469a0ca9375f3f44bc9b827a38e0eeed37d475/src/tree/updater_basemaker-inl.h#L366 
accesses internal members in many places.