### PR TITLE
Make some GPU tests deterministic

### DIFF
--- a/tests/python-gpu/test_from_columnar.py
+++ b/tests/python-gpu/test_from_columnar.py
@@ -88,9 +88,10 @@ Arrow specification.'''
     def test_cudf_training(self):
         from cudf import DataFrame as df
         import pandas as pd
+        np.random.seed(1)
         X = pd.DataFrame(np.random.randn(50, 10))
         y = pd.DataFrame(np.random.randn(50))
-        weights = np.random.random(50)
+        weights = np.random.random(50) + 1.0
         cudf_weights = df.from_pandas(pd.DataFrame(weights))
         base_margin = np.random.random(50)
         cudf_base_margin = df.from_pandas(pd.DataFrame(base_margin))
@@ -98,11 +99,12 @@ Arrow specification.'''
         evals_result_cudf = {}
         dtrain_cudf = xgb.DMatrix(df.from_pandas(X), df.from_pandas(y), weight=cudf_weights,
                                   base_margin=cudf_base_margin)
-        xgb.train({'gpu_id': 0}, dtrain_cudf, evals=[(dtrain_cudf, "train")],
+        params = {'gpu_id': 0, 'nthread': 1}
+        xgb.train(params, dtrain_cudf, evals=[(dtrain_cudf, "train")],
                   evals_result=evals_result_cudf)
         evals_result_np = {}
         dtrain_np = xgb.DMatrix(X, y, weight=weights, base_margin=base_margin)
-        xgb.train({}, dtrain_np, evals=[(dtrain_np, "train")],
+        xgb.train(params, dtrain_np, evals=[(dtrain_np, "train")],
                   evals_result=evals_result_np)
         assert np.array_equal(evals_result_cudf["train"]["rmse"], evals_result_np["train"]["rmse"])
 

--- a/tests/python-gpu/test_from_cupy.py
+++ b/tests/python-gpu/test_from_cupy.py
@@ -51,21 +51,23 @@ Arrow specification.'''
     @pytest.mark.skipif(**tm.no_cupy())
     def test_cupy_training(self):
         import cupy as cp
+        np.random.seed(1)
         X = cp.random.randn(50, 10, dtype="float32")
         y = cp.random.randn(50, dtype="float32")
         weights = np.random.random(50)
-        cupy_weights = cp.array(weights)
+        cupy_weights = cp.array(weights) + 1
         base_margin = np.random.random(50)
         cupy_base_margin = cp.array(base_margin)
 
         evals_result_cupy = {}
         dtrain_cp = xgb.DMatrix(X, y, weight=cupy_weights, base_margin=cupy_base_margin)
-        xgb.train({'gpu_id': 0}, dtrain_cp, evals=[(dtrain_cp, "train")],
+        params = {'gpu_id': 0, 'nthread': 1}
+        xgb.train(params, dtrain_cp, evals=[(dtrain_cp, "train")],
                   evals_result=evals_result_cupy)
         evals_result_np = {}
         dtrain_np = xgb.DMatrix(cp.asnumpy(X), cp.asnumpy(y), weight=weights,
                                 base_margin=base_margin)
-        xgb.train({'gpu_id': 0}, dtrain_np, evals=[(dtrain_np, "train")],
+        xgb.train(params, dtrain_np, evals=[(dtrain_np, "train")],
                   evals_result=evals_result_np)
         assert np.array_equal(evals_result_cupy["train"]["rmse"], evals_result_np["train"]["rmse"])
 

--- a/tests/python-gpu/test_from_cupy.py
+++ b/tests/python-gpu/test_from_cupy.py
@@ -52,10 +52,11 @@ Arrow specification.'''
     def test_cupy_training(self):
         import cupy as cp
         np.random.seed(1)
+        cp.random.seed(1)
         X = cp.random.randn(50, 10, dtype="float32")
         y = cp.random.randn(50, dtype="float32")
-        weights = np.random.random(50)
-        cupy_weights = cp.array(weights) + 1
+        weights = np.random.random(50) + 1
+        cupy_weights = cp.array(weights)
         base_margin = np.random.random(50)
         cupy_base_margin = cp.array(base_margin)
 


### PR DESCRIPTION
We observed an intermittent test failure, with a small difference and accuracy between two subsequent training calls.

This PR makes random numbers consistent, prevents weights from getting close to 0 and enforces a single thread.