### PR TITLE
Support FreeBSD

### DIFF
--- a/src/common/json.cc
+++ b/src/common/json.cc
@@ -69,7 +69,7 @@ void JsonWriter::Visit(JsonNull const* null) {
   this->Write("null");
 }
 
-void JsonWriter::Visit(JsonString const* str) {
+fvoid JsonWriter::Visit(JsonString const* str) {
   std::string buffer;
   buffer += '"';
   auto const& string = str->getString();
@@ -630,13 +630,13 @@ Json JsonReader::ParseNumber() {
     // multiply zero by inf which gives nan.
     if (f != 0.0) {
       // Only use exp10 from libc on gcc+linux
-#if !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
+#if !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || !defined(__linux__)
 #define exp10(val) std::pow(10, (val))
-#endif  // !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
+#endif  // !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || !defined(__linux__)
       f *= exp10(exponent);
-#if !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
+#if !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || !defined(__linux__)
 #undef exp10
-#endif  // !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
+#endif  // !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || !defined(__linux__)
     }
   }
 

--- a/src/common/json.cc
+++ b/src/common/json.cc
@@ -630,13 +630,13 @@ Json JsonReader::ParseNumber() {
     // multiply zero by inf which gives nan.
     if (f != 0.0) {
       // Only use exp10 from libc on gcc+linux
-#if !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__)
+#if !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
 #define exp10(val) std::pow(10, (val))
-#endif  // !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__)
+#endif  // !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
       f *= exp10(exponent);
-#if !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__)
+#if !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
 #undef exp10
-#endif  // !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__)
+#endif  // !defined(__GNUC__) || defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
     }
   }
 

--- a/src/common/json.cc
+++ b/src/common/json.cc
@@ -69,7 +69,7 @@ void JsonWriter::Visit(JsonNull const* null) {
   this->Write("null");
 }
 
-fvoid JsonWriter::Visit(JsonString const* str) {
+void JsonWriter::Visit(JsonString const* str) {
   std::string buffer;
   buffer += '"';
   auto const& string = str->getString();

--- a/src/common/timer.cc
+++ b/src/common/timer.cc
@@ -44,8 +44,9 @@ std::vector<Monitor::StatMap> Monitor::CollectFromOtherRanks() const {
     statistic[kv.first] = Object();
     auto& j_pair = statistic[kv.first];
     j_pair["count"] = Integer(kv.second.count);
-    j_pair["elapsed"] = Integer(std::chrono::duration_cast<std::chrono::microseconds>(
-        kv.second.timer.elapsed).count());
+    j_pair["elapsed"] = Integer(static_cast<int64_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+        kv.second.timer.elapsed).count()));
   }
 
   std::stringstream ss;


### PR DESCRIPTION
* `exp10` is a GNU extension and is missing on FreeBSD. Add `__FreeBSD__` guard to disable use of `exp10`. In the long run, we may want to add a feature testing for `exp10` to the build system.
* `std::chrono::duration_cast<...>.count()` implementation returns `long long` type, which `JsonInteger` does not accept. Explicitly cast the result into `int64_t`.

Depends on https://github.com/dmlc/rabit/pull/133.

Closes https://github.com/dmlc/xgboost/issues/5117.
