### PR TITLE
Make `pip install xgboost*.tar.gz` work by fixing build-python.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,32 @@ sudo: required
 
 # Enabling test OS X
 os:
+  - linux
   - osx
 
 osx_image: xcode10.3
+dist: bionic
 
 # Use Build Matrix to do lint and build seperately
 env:
   matrix:
     # python package test
     - TASK=python_test
+    # test installation of Python source distribution
+    - TASK=python_sdist_test
     # java package test
     - TASK=java_test
     # cmake test
     - TASK=cmake_test
+
+matrix:
+  exclude:
+    - os: linux
+      env: TASK=python_test
+    - os: linux
+      env: TASK=java_test
+    - os: linux
+      env: TASK=cmake_test
 
 # dependent brew packages
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ addons:
 
 before_install:
   - source dmlc-core/scripts/travis/travis_setup_env.sh
-  - export PYTHONPATH=${PYTHONPATH}:${PWD}/python-package
+  - if [ "${TASK}" != "python_sdist_test" ]; then export PYTHONPATH=${PYTHONPATH}:${PWD}/python-package; fi
   - echo "MAVEN_OPTS='-Xmx2g -XX:MaxPermSize=1024m -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=error'" > ~/.mavenrc
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,9 @@ pippack: clean_all
 	rm -rf python-package/xgboost/rabit
 	rm -rf python-package/xgboost/src
 	cp -r python-package xgboost-python
-	cp -r Makefile xgboost-python/xgboost/
+	cp -r CMakeLists.txt xgboost-python/xgboost/
+	cp -r cmake xgboost-python/xgboost/
+	cp -r plugin xgboost-python/xgboost/
 	cp -r make xgboost-python/xgboost/
 	cp -r src xgboost-python/xgboost/
 	cp -r tests xgboost-python/xgboost/

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -98,11 +98,11 @@ Building on OSX
 Install with pip: simple method
 --------------------------------
 
-First, obtain ``gcc-9`` and ``OpenMP`` with Homebrew (https://brew.sh/) to enable multi-threading (i.e. using multiple CPU threads for training). The default Apple Clang compiler does not support OpenMP, so using the default compiler would have disabled multi-threading.
+First, obtain the OpenMP library (``libomp``) with Homebrew (https://brew.sh/) to enable multi-threading (i.e. using multiple CPU threads for training):
 
 .. code-block:: bash
 
-  brew install gcc@9 libomp
+  brew install libomp
 
 Then install XGBoost with ``pip``:
 
@@ -115,11 +115,11 @@ You might need to run the command with ``--user`` flag if you run into permissio
 Build from the source code - advanced method
 --------------------------------------------
 
-Obtain ``gcc-9`` and ``OpenMP`` from Homebrew:
+Obtain ``libomp`` from Homebrew:
 
 .. code-block:: bash
 
-  brew install gcc@9 libomp
+  brew install libomp
 
 
 Now clone the repository:
@@ -128,13 +128,13 @@ Now clone the repository:
 
   git clone --recursive https://github.com/dmlc/xgboost
 
-Create the ``build/`` directory and invoke CMake. Make sure to add ``CC=gcc-9 CXX=g++-9`` so that Homebrew GCC is selected. After invoking CMake, you can build XGBoost with ``make``:
+Create the ``build/`` directory and invoke CMake. After invoking CMake, you can build XGBoost with ``make``:
 
 .. code-block:: bash
 
   mkdir build
   cd build
-  CC=gcc-9 CXX=g++-9 cmake ..
+  cmake ..
   make -j4
 
 You may now continue to `Python Package Installation`_.

--- a/python-package/xgboost/build-python.sh
+++ b/python-package/xgboost/build-python.sh
@@ -18,9 +18,6 @@ cd ./xgboost/
 #remove the pre-compiled .so and trigger the system's on-the-fly compiling
 mkdir -p build
 cd build
-if [ -f * ]; then
-  rm -r *
-fi
 if cmake .. && make -j4; then
     echo "Successfully built multi-thread xgboost"
 else

--- a/python-package/xgboost/build-python.sh
+++ b/python-package/xgboost/build-python.sh
@@ -12,29 +12,8 @@
 set -e
 set -x
 
-#pushd xgboost
 oldpath=`pwd`
 cd ./xgboost/
-
-GCC_PATH=""
-if echo "${OSTYPE}" | grep -q "darwin"; then
-  # Use OpenMP-capable compiler if possible
-  if [ "v"`sw_vers -buildVersion` -ge "v17G65" ]; then
-    if which g++-9; then
-      GCC_PATH="CC=gcc-9 CXX=g++-9"
-    else
-      echo "For MacOS version higher than High Sierra, please install gcc@9 first."
-    fi
-  elif which g++-5; then
-    GCC_PATH="CC=gcc-5 CXX=g++-5"
-  elif which g++-7; then
-    GCC_PATH="CC=gcc-7 CXX=g++-7"
-  elif which g++-8; then
-    GCC_PATH="CC=gcc-8 CXX=g++-8"
-  elif which clang++; then
-    GCC_PATH="CC=clang CXX=clang++"
-  fi
-fi
 
 #remove the pre-compiled .so and trigger the system's on-the-fly compiling
 mkdir -p build
@@ -42,17 +21,16 @@ cd build
 if [ -f * ]; then
   rm -r *
 fi
-if eval $GCC_PATH" cmake .." && eval $GCC_PATH" make -j4"; then
-    echo "Successfully build multi-thread xgboost"
+if cmake .. && make -j4; then
+    echo "Successfully built multi-thread xgboost"
 else
     echo "-----------------------------"
     echo "Building multi-thread xgboost failed"
     echo "Start to build single-thread xgboost"
-    eval $GCC_PATH" cmake .. -DUSE_OPENMP=0"
-    eval $GCC_PATH" make -j4"
-    echo "Successfully build single-thread xgboost"
-    echo "If you want multi-threaded version"
-    echo "See additional instructions in doc/build.md"
+    cmake .. -DUSE_OPENMP=0
+    make -j4
+    echo "Successfully built single-thread xgboost; training speed may be suboptimal."
+    echo "To use all CPU cores for training jobs, install libomp package from Homebrew and re-install XGBoost"
 fi
 cd $oldpath
 

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -13,6 +13,7 @@ if [ ${TASK} == "python_sdist_test" ]; then
     conda install numpy scipy
 
     python -m pip install xgboost-*.tar.gz -v --user
+    python -c 'import xgboost' || exit -1
 fi
 
 if [ ${TASK} == "python_test" ]; then

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -4,6 +4,17 @@ make -f dmlc-core/scripts/packages.mk lz4
 
 source $HOME/miniconda/bin/activate
 
+if [ ${TASK} == "python_sdist_test"]; then
+    set -e
+    make pippack
+
+    conda activate python3
+    python --version
+    conda install numpy scipy
+
+    python -m pip install xgboost-*.tar.gz -v --user
+fi
+
 if [ ${TASK} == "python_test" ]; then
     set -e
     # Build/test

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -4,7 +4,7 @@ make -f dmlc-core/scripts/packages.mk lz4
 
 source $HOME/miniconda/bin/activate
 
-if [ ${TASK} == "python_sdist_test"]; then
+if [ ${TASK} == "python_sdist_test" ]; then
     set -e
     make pippack
 

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-if [ ${TASK} == "python_test" ]; then
+if [ ${TASK} == "python_test" ] || [ ${TASK} == "python_sdist_test" ]; then
     if [ ${TRAVIS_OS_NAME} == "osx" ]; then
         wget -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
     else
-        echo "We are no longer running Linux test on Travis."
-        exit 1
+        wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
     fi
     bash conda.sh -b -p $HOME/miniconda
     source $HOME/miniconda/bin/activate


### PR DESCRIPTION
This PR makes a few fixes so that users can install Python XGBoost from a source tarball `xgboost-1.0.0-SNAPSHOT.tar.gz`. This is important for users of Mac OSX, FreeBSD, and other platforms where we do not offer pre-built wheels.

Note that #5146 enabled the use of AppleClang (default compiler on OSX), so we no longer require Homebrew GCC. Thus, we can simplify the installation doc considerably.

How to test:
```bash
# Pack XGBoost source file into a tarball
make pippack 
# Install XGBoost source distribution
pip3 install xgboost-1.0.0-SNAPSHOT.tar.gz --user
```