### PR TITLE
Testing hist_util

### DIFF
--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -70,7 +70,6 @@ void SparseCuts::SingleThreadBuild(SparsePage const& page, MetaInfo const& info,
                                    bool const use_group_ind,
                                    uint32_t beg_col, uint32_t end_col,
                                    uint32_t thread_id) {
-  using WXQSketch = common::WXQuantileSketch<bst_float, bst_float>;
   CHECK_GE(end_col, beg_col);
   constexpr float kFactor = 8;
 
@@ -80,7 +79,7 @@ void SparseCuts::SingleThreadBuild(SparsePage const& page, MetaInfo const& info,
 
   for (uint32_t col_id = beg_col; col_id < page.Size() && col_id < end_col; ++col_id) {
     // Using a local variable makes things easier, but at the cost of memory trashing.
-    WXQSketch sketch;
+    WQSketch sketch;
     common::Span<xgboost::Entry const> const column = page[col_id];
     uint32_t const n_bins = std::min(static_cast<uint32_t>(column.size()),
                                      max_num_bins);
@@ -104,9 +103,9 @@ void SparseCuts::SingleThreadBuild(SparsePage const& page, MetaInfo const& info,
       sketch.Push(entry.fvalue, info.GetWeight(weight_ind));
     }
 
-    WXQSketch::SummaryContainer out_summary;
+    WQSketch::SummaryContainer out_summary;
     sketch.GetSummary(&out_summary);
-    WXQSketch::SummaryContainer summary;
+    WQSketch::SummaryContainer summary;
     summary.Reserve(n_bins);
     summary.SetPrune(out_summary, n_bins);
 
@@ -115,7 +114,7 @@ void SparseCuts::SingleThreadBuild(SparsePage const& page, MetaInfo const& info,
     float mval = summary.data[0].value;
     p_cuts_->min_vals_[col_id - beg_col]  = mval - (fabs(mval) + 1e-5);
 
-    this->AddCutPoint(summary);
+    this->AddCutPoint(summary, max_num_bins);
 
     bst_float cpt = (summary.size > 0) ?
                     summary.data[summary.size - 1].value :
@@ -234,7 +233,7 @@ void DenseCuts::Build(DMatrix* p_fmat, uint32_t max_num_bins) {
 
   // safe factor for better accuracy
   constexpr int kFactor = 8;
-  std::vector<WXQSketch> sketchs;
+  std::vector<WQSketch> sketchs;
 
   const int nthread = omp_get_max_threads();
 
@@ -292,34 +291,34 @@ void DenseCuts::Build(DMatrix* p_fmat, uint32_t max_num_bins) {
 }
 
 void DenseCuts::Init
-(std::vector<WXQSketch>* in_sketchs, uint32_t max_num_bins) {
+(std::vector<WQSketch>* in_sketchs, uint32_t max_num_bins) {
   monitor_.Start(__func__);
-  std::vector<WXQSketch>& sketchs = *in_sketchs;
+  std::vector<WQSketch>& sketchs = *in_sketchs;
   constexpr int kFactor = 8;
   // gather the histogram data
-  rabit::SerializeReducer<WXQSketch::SummaryContainer> sreducer;
-  std::vector<WXQSketch::SummaryContainer> summary_array;
+  rabit::SerializeReducer<WQSketch::SummaryContainer> sreducer;
+  std::vector<WQSketch::SummaryContainer> summary_array;
   summary_array.resize(sketchs.size());
   for (size_t i = 0; i < sketchs.size(); ++i) {
-    WXQSketch::SummaryContainer out;
+    WQSketch::SummaryContainer out;
     sketchs[i].GetSummary(&out);
     summary_array[i].Reserve(max_num_bins * kFactor);
     summary_array[i].SetPrune(out, max_num_bins * kFactor);
   }
   CHECK_EQ(summary_array.size(), in_sketchs->size());
-  size_t nbytes = WXQSketch::SummaryContainer::CalcMemCost(max_num_bins * kFactor);
+  size_t nbytes = WQSketch::SummaryContainer::CalcMemCost(max_num_bins * kFactor);
   // TODO(chenqin): rabit failure recovery assumes no boostrap onetime call after loadcheckpoint
   // we need to move this allreduce before loadcheckpoint call in future
   sreducer.Allreduce(dmlc::BeginPtr(summary_array), nbytes, summary_array.size());
   p_cuts_->min_vals_.resize(sketchs.size());
 
   for (size_t fid = 0; fid < summary_array.size(); ++fid) {
-    WXQSketch::SummaryContainer a;
-    a.Reserve(max_num_bins);
-    a.SetPrune(summary_array[fid], max_num_bins);
+    WQSketch::SummaryContainer a;
+    a.Reserve(max_num_bins + 1);
+    a.SetPrune(summary_array[fid], max_num_bins + 1);
     const bst_float mval = a.data[0].value;
     p_cuts_->min_vals_[fid] = mval - (fabs(mval) + 1e-5);
-    AddCutPoint(a);
+    AddCutPoint(a, max_num_bins);
     // push a value that is greater than anything
     const bst_float cpt
       = (a.size > 0) ? a.data[a.size - 1].value : p_cuts_->min_vals_[fid];

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -106,8 +106,8 @@ void SparseCuts::SingleThreadBuild(SparsePage const& page, MetaInfo const& info,
     WQSketch::SummaryContainer out_summary;
     sketch.GetSummary(&out_summary);
     WQSketch::SummaryContainer summary;
-    summary.Reserve(n_bins);
-    summary.SetPrune(out_summary, n_bins);
+    summary.Reserve(n_bins + 1);
+    summary.SetPrune(out_summary, n_bins + 1);
 
     // Can be use data[1] as the min values so that we don't need to
     // store another array?

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -147,7 +147,7 @@ class HistogramCuts {
 
   size_t TotalBins() const { return cut_ptrs_.back(); }
 
-  BinIdx SearchBin(float value, uint32_t column_id) {
+  BinIdx SearchBin(float value, uint32_t column_id) const {
     auto beg = cut_ptrs_.at(column_id);
     auto end = cut_ptrs_.at(column_id + 1);
     auto it = std::upper_bound(cut_values_.cbegin() + beg, cut_values_.cbegin() + end, value);
@@ -171,7 +171,7 @@ class HistogramCuts {
  */
 class CutsBuilder {
  public:
-  using WXQSketch = common::WXQuantileSketch<bst_float, bst_float>;
+  using WQSketch = common::WQuantileSketch<bst_float, bst_float>;
 
  protected:
   HistogramCuts* p_cuts_;
@@ -195,8 +195,9 @@ class CutsBuilder {
     return group_ind;
   }
 
-  void AddCutPoint(WXQSketch::SummaryContainer const& summary) {
-    for (size_t i = 1; i < summary.size; ++i) {
+  void AddCutPoint(WQSketch::SummaryContainer const& summary, int max_bin) {
+    int required_cuts = std::min(static_cast<int>(summary.size), max_bin);
+    for (size_t i = 1; i < required_cuts; ++i) {
       bst_float cpt = summary.data[i].value;
       if (i == 1 || cpt > p_cuts_->cut_values_.back()) {
         p_cuts_->cut_values_.push_back(cpt);
@@ -240,7 +241,7 @@ class DenseCuts  : public CutsBuilder {
       CutsBuilder(container) {
     monitor_.Init(__FUNCTION__);
   }
-  void Init(std::vector<WXQSketch>* sketchs, uint32_t max_num_bins);
+  void Init(std::vector<WQSketch>* sketchs, uint32_t max_num_bins);
   void Build(DMatrix* p_fmat, uint32_t max_num_bins) override;
 };
 

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -196,20 +196,10 @@ class CutsBuilder {
   }
 
   void AddCutPoint(WXQSketch::SummaryContainer const& summary) {
-    if (summary.size > 1 && summary.size <= 16) {
-      /* specialized code categorial / ordinal data -- use midpoints */
-      for (size_t i = 1; i < summary.size; ++i) {
-        bst_float cpt = (summary.data[i].value + summary.data[i - 1].value) / 2.0f;
-        if (i == 1 || cpt > p_cuts_->cut_values_.back()) {
-          p_cuts_->cut_values_.push_back(cpt);
-        }
-      }
-    } else {
-      for (size_t i = 1; i < summary.size; ++i) {
-        bst_float cpt = summary.data[i].value;
-        if (i == 1 || cpt > p_cuts_->cut_values_.back()) {
-          p_cuts_->cut_values_.push_back(cpt);
-        }
+    for (size_t i = 1; i < summary.size; ++i) {
+      bst_float cpt = summary.data[i].value;
+      if (i == 1 || cpt > p_cuts_->cut_values_.back()) {
+        p_cuts_->cut_values_.push_back(cpt);
       }
     }
   }

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -101,6 +101,7 @@ struct SimpleArray {
 using GHistIndexRow = Span<uint32_t const>;
 
 // A CSC matrix representing histogram cuts, used in CPU quantile hist.
+// The cut values represent upper bounds of bins containing approximately equal numbers of elements
 class HistogramCuts {
   // Using friends to avoid creating a virtual class, since HistogramCuts is used as value
   // object in many places.
@@ -147,6 +148,8 @@ class HistogramCuts {
 
   size_t TotalBins() const { return cut_ptrs_.back(); }
 
+  // Return the index of a cut point that is strictly greater than the input
+  // value, or the last available index if none exists
   BinIdx SearchBin(float value, uint32_t column_id) const {
     auto beg = cut_ptrs_.at(column_id);
     auto end = cut_ptrs_.at(column_id + 1);

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -205,9 +205,9 @@ class CutsBuilder {
         }
       }
     } else {
-      for (size_t i = 2; i < summary.size; ++i) {
-        bst_float cpt = summary.data[i - 1].value;
-        if (i == 2 || cpt > p_cuts_->cut_values_.back()) {
+      for (size_t i = 1; i < summary.size; ++i) {
+        bst_float cpt = summary.data[i].value;
+        if (i == 1 || cpt > p_cuts_->cut_values_.back()) {
           p_cuts_->cut_values_.push_back(cpt);
         }
       }

--- a/tests/cpp/common/test_hist_util.cc
+++ b/tests/cpp/common/test_hist_util.cc
@@ -266,6 +266,24 @@ TEST(hist_util, DenseCutsAccuracyTest) {
   }
 }
 
+TEST(hist_util, DenseCutsExternalMemory) {
+  int bin_sizes[] = {2, 16, 256, 512};
+  int sizes[] = {100, 1000, 1500};
+  int num_columns = 5;
+  for (auto num_rows : sizes) {
+    auto x = GenerateRandom(num_rows, num_columns);
+    dmlc::TemporaryDirectory tmpdir;
+    auto dmat =
+        GetExternalMemoryDMatrixFromData(x, num_rows, num_columns, 50, tmpdir);
+    for (auto num_bins : bin_sizes) {
+      HistogramCuts cuts;
+      DenseCuts dense(&cuts);
+      dense.Build(dmat.get(), num_bins);
+      ValidateCuts(cuts, x, num_rows, num_columns, num_bins);
+    }
+  }
+}
+
 TEST(hist_util, SparseCutsAccuracyTest) {
   int bin_sizes[] = {2, 16, 256, 512};
   int sizes[] = {100, 1000, 1500};
@@ -300,6 +318,24 @@ TEST(hist_util, SparseCutsCategorical) {
       EXPECT_GT(cuts_from_sketch.front(), x_sorted.front());
       EXPECT_GE(cuts_from_sketch.back(), x_sorted.back());
       EXPECT_EQ(cuts_from_sketch.size(), num_categories);
+    }
+  }
+}
+
+TEST(hist_util, SparseCutsExternalMemory) {
+  int bin_sizes[] = {2, 16, 256, 512};
+  int sizes[] = {100, 1000, 1500};
+  int num_columns = 5;
+  for (auto num_rows : sizes) {
+    auto x = GenerateRandom(num_rows, num_columns);
+    dmlc::TemporaryDirectory tmpdir;
+    auto dmat =
+        GetExternalMemoryDMatrixFromData(x, num_rows, num_columns, 50, tmpdir);
+    for (auto num_bins : bin_sizes) {
+      HistogramCuts cuts;
+      SparseCuts dense(&cuts);
+      dense.Build(dmat.get(), num_bins);
+      ValidateCuts(cuts, x, num_rows, num_columns, num_bins);
     }
   }
 }

--- a/tests/cpp/common/test_hist_util.cc
+++ b/tests/cpp/common/test_hist_util.cc
@@ -266,5 +266,42 @@ TEST(hist_util, DenseCutsAccuracyTest) {
   }
 }
 
+TEST(hist_util, SparseCutsAccuracyTest) {
+  int bin_sizes[] = {2, 16, 256, 512};
+  int sizes[] = {100, 1000, 1500};
+  int num_columns = 5;
+  for (auto num_rows : sizes) {
+    auto x = GenerateRandom(num_rows, num_columns);
+    auto dmat = GetDMatrixFromData(x, num_rows, num_columns);
+    for (auto num_bins : bin_sizes) {
+      HistogramCuts cuts;
+      SparseCuts sparse(&cuts);
+      sparse.Build(&dmat, num_bins);
+      ValidateCuts(cuts, x, num_rows, num_columns, num_bins);
+    }
+  }
+}
+
+TEST(hist_util, SparseCutsCategorical) {
+  int categorical_sizes[] = {2, 6, 8, 12};
+  int num_bins = 256;
+  int sizes[] = {25, 100, 1000};
+  for (auto n : sizes) {
+    for (auto num_categories : categorical_sizes) {
+      auto x = GenerateRandomCategoricalSingleColumn(n, num_categories);
+      std::vector<float> x_sorted(x);
+      std::sort(x_sorted.begin(), x_sorted.end());
+      auto dmat = GetDMatrixFromData(x, n, 1);
+      HistogramCuts cuts;
+      SparseCuts sparse(&cuts);
+      sparse.Build(&dmat, num_bins);
+      auto cuts_from_sketch = cuts.Values();
+      EXPECT_LT(cuts.MinValues()[0], x_sorted.front());
+      EXPECT_GT(cuts_from_sketch.front(), x_sorted.front());
+      EXPECT_GE(cuts_from_sketch.back(), x_sorted.back());
+      EXPECT_EQ(cuts_from_sketch.size(), num_categories);
+    }
+  }
+}
 }  // namespace common
 }  // namespace xgboost

--- a/tests/cpp/common/test_hist_util.h
+++ b/tests/cpp/common/test_hist_util.h
@@ -1,0 +1,35 @@
+
+#include <gtest/gtest.h>
+#include "../../../src/data/simple_dmatrix.h"
+
+namespace xgboost {
+namespace common {
+
+std::vector<float> GenerateRandomSingleColumn(int n, float low = -100,
+                                              float high = 100) {
+  std::vector<float> x(n);
+  std::mt19937 rng(0);
+  std::uniform_real_distribution<float> dist(low, high);
+  std::generate(x.begin(), x.end(), [&]() { return dist(rng); });
+  return x;
+}
+
+data::SimpleDMatrix GetDMatrixFromData(const std::vector<float>& x) {
+  data::DenseAdapter adapter(x.data(), x.size(), x.size(), 1);
+  return data::SimpleDMatrix(&adapter, std::numeric_limits<float>::quiet_NaN(),
+                             1);
+}
+
+std::vector<float> CutsFromSort(const std::vector<float>& x_sorted,
+                                int num_bins) {
+  if (x_sorted.size() <= num_bins) return x_sorted;
+  std::vector<float> cuts(num_bins);
+  for(auto i = 0ull; i < num_bins; i++)
+  {
+    double rank = double(i)/num_bins;
+    cuts[i] = x_sorted[size_t(rank*x_sorted.size())];
+  }
+  return cuts;
+}
+}  // namespace common
+}  // namespace xgboost

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -228,17 +228,23 @@ std::unique_ptr<DMatrix> CreateSparsePageDMatrixWithRC(
     std::stringstream row_data;
     size_t j = 0;
     if (rem_cols > 0) {
-       for (; j < std::min(static_cast<size_t>(rem_cols), cols_per_row); ++j) {
-         row_data << label(*gen) << " " << (col_idx+j) << ":" << (col_idx+j+1)*10*i;
-       }
-       rem_cols -= cols_per_row;
+      for (; j < std::min(static_cast<size_t>(rem_cols), cols_per_row); ++j) {
+        row_data << label(*gen) << " " << (col_idx + j) << ":"
+                 << (col_idx + j + 1) * 10 * i;
+      }
+      rem_cols -= cols_per_row;
     } else {
-       // Take some random number of colums in [1, n_cols] and slot them here
-       size_t ncols = dis(*gen);
-       for (; j < ncols; ++j) {
-         size_t fid = (col_idx+j) % n_cols;
-         row_data << label(*gen) << " " << fid << ":" << (fid+1)*10*i;
-       }
+      // Take some random number of colums in [1, n_cols] and slot them here
+      std::vector<size_t> random_columns;
+      size_t ncols = dis(*gen);
+      for (; j < ncols; ++j) {
+        size_t fid = (col_idx + j) % n_cols;
+        random_columns.push_back(fid);
+      }
+      std::sort(random_columns.begin(), random_columns.end());
+      for (auto fid : random_columns) {
+        row_data << label(*gen) << " " << fid << ":" << (fid + 1) * 10 * i;
+      }
     }
     col_idx += j;
 

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -13,7 +13,7 @@ def assert_gpu_results(cpu_results, gpu_results):
     for cpu_res, gpu_res in zip(cpu_results, gpu_results):
         # Check final eval result roughly equivalent
         assert np.allclose(cpu_res["eval"][-1],
-                           gpu_res["eval"][-1], 1e-2, 1e-2)
+                           gpu_res["eval"][-1], 1e-1, 1e-1)
 
 
 datasets = ["Boston", "Cancer", "Digits", "Sparse regression",
@@ -23,7 +23,7 @@ test_param = parameter_combinations({
     'gpu_id': [0],
     'max_depth': [2, 8],
     'max_leaves': [255, 4],
-    'max_bin': [2, 256],
+    'max_bin': [4, 256],
     'grow_policy': ['lossguide'],
     'single_precision_histogram': [True],
     'min_child_weight': [0],

--- a/tests/python/regression_test_utilities.py
+++ b/tests/python/regression_test_utilities.py
@@ -132,8 +132,8 @@ def run_suite(param, num_rounds=10, select_datasets=None, scale_features=False):
     """
     datasets = [
         Dataset("Boston", get_boston, "reg:squarederror", "rmse"),
-        Dataset("Digits", get_digits, "multi:softmax", "merror"),
-        Dataset("Cancer", get_cancer, "binary:logistic", "error"),
+        Dataset("Digits", get_digits, "multi:softmax", "mlogloss"),
+        Dataset("Cancer", get_cancer, "binary:logistic", "logloss"),
         Dataset("Sparse regression", get_sparse, "reg:squarederror", "rmse"),
         Dataset("Sparse regression with weights", get_sparse_weights,
                 "reg:squarederror", "rmse", has_weights=True),

--- a/tests/python/test_linear.py
+++ b/tests/python/test_linear.py
@@ -53,7 +53,7 @@ def assert_classification_result(results):
                               r["param"]["objective"] != "reg:squarederror"]
     for res in classification_results:
         # Check accuracy  is reasonable
-        assert res["eval"][-1] < 0.5, (res["dataset"].name, res["eval"][-1])
+        assert res["eval"][-1] < 2.0, (res["dataset"].name, res["eval"][-1])
 
 
 class TestLinear(unittest.TestCase):


### PR DESCRIPTION
This PR is for adding more tests for quantile generation in hist/gpu_hist. Part of the motivation is to create some absolute tests of accuracy for GPU sketching, instead of comparing against existing CPU algorithms.

So far I have tested the following expected behaviours with respect to a single feature:
- The histogram cut `min_value` should be less than all inputs
- The last histogram cut value should be greater than all inputs
- The rank of quantile cuts from the sketch should not exceed error ~0.01 as compared to rank from sorted values
- And input of k < num_bins unique values should output k unique bins. i.e. it should be possible to split over each unique value

I also expected that number of cuts (excluding the minimum value) should equal the number of bins requested if the unique input size is greater than num_bins. This is true for categorical features with <= unique values but not for continuous features. This currently means that if you ask for 256 bins you get 254 actual bins, which seems like a bug. Two of the samples get lost here (https://github.com/dmlc/xgboost/blob/472ded549d2a335bc807819ddb09349d5831610f/src/common/hist_util.h#L208), one value gets added afterwards to be larger than everything. Another sample seems to get lost here (https://github.com/dmlc/xgboost/blob/472ded549d2a335bc807819ddb09349d5831610f/src/common/hist_util.cc#L319), where 256 samples go into SetPrune and 255 come out, despite max_num_bins being set at 256.

After resolving this I also want to add tests comparing the rank of the output quantiles against the correct rank by sorting the input.

I would also like to clarify the need for specialised cut points for categorical variables, implemented here (https://github.com/dmlc/xgboost/blob/472ded549d2a335bc807819ddb09349d5831610f/src/common/hist_util.h#L200) and discussed in #5095.

@hcho3 any comments would be much appreciated.