### PR TITLE
[WIP] Handle degenerate cases that result in NAN's in leaf outputs

### DIFF
--- a/src/learner.cc
+++ b/src/learner.cc
@@ -826,7 +826,6 @@ class LearnerImpl : public Learner {
       gbm_->PredictLeaf(data, &out_preds->HostVector(), ntree_limit);
     } else {
       this->PredictRaw(data, out_preds, training, ntree_limit);
-      this->AssertPredictionIsFinite(out_preds);  // Scan for INFs and NANs
       if (!output_margin) {
         obj_->PredTransform(out_preds);
       }
@@ -853,29 +852,6 @@ class LearnerImpl : public Learner {
         << "Predict must happen after Load or configuration";
     this->ValidateDMatrix(data);
     gbm_->PredictBatch(data, out_preds, training, ntree_limit);
-  }
-
-  /*!
-   * \brief Scan prediction vector for any INFs and NANs and throws error if INF/NAN is found
-   * \param preds vector containing predictions
-   */
-  void AssertPredictionIsFinite(HostDeviceVector<bst_float>* preds) {
-    for (auto e : preds->ConstHostVector()) {
-      if (XGBOOST_EXPECT(!std::isfinite(e), false)) {
-        std::ostringstream oss;
-        FeatureMap fmap;
-        int tree_id = 0;
-        for (const std::string& e : gbm_->DumpModel(fmap, false, "text")) {
-          oss << "\nbooster[" << (tree_id++) << "]:\n" << e;
-        }
-        LOG(FATAL) << "Detected an INF or NAN in prediction value from the fitted model."
-                   << "\n*****************************************************************"
-                   << "\nText dump of your model"
-                   << "\n-----------------------------------------------------------------"
-                   << oss.str()
-                   << "*****************************************************************";
-      }
-    }
   }
 
   void ConfigureObjective(LearnerTrainParam const& old, Args* p_args) {

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -325,9 +325,9 @@ class GPUPredictor : public xgboost::Predictor {
 
     DevicePredictInternal(dmat, out_preds, model, tree_begin, tree_end);
 
-    auto cache_emtry = this->FindCache(dmat);
-    if (cache_emtry == cache_->cend()) { return; }
-    if (cache_emtry->second.predictions.Size() == 0) {
+    auto cache_entry = this->FindCache(dmat);
+    if (cache_entry == cache_->cend()) { return; }
+    if (cache_entry->second.predictions.Size() == 0) {
       // Initialise the cache on first iteration, this comes useful
       // when performing training continuation:
       //
@@ -337,10 +337,10 @@ class GPUPredictor : public xgboost::Predictor {
       //
       // If we don't initialise this cache, the 2 step will recieve an invalid cache as
       // the first step only modifies prediction store in learner without following code.
-      InitOutPredictions(cache_emtry->second.data->Info(),
-                         &(cache_emtry->second.predictions), model);
-      CHECK_EQ(cache_emtry->second.predictions.Size(), out_preds->Size());
-      cache_emtry->second.predictions.Copy(*out_preds);
+      InitOutPredictions(cache_entry->second.data->Info(),
+                         &(cache_entry->second.predictions), model);
+      CHECK_EQ(cache_entry->second.predictions.Size(), out_preds->Size());
+      cache_entry->second.predictions.Copy(*out_preds);
     }
   }
 

--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -119,7 +119,11 @@ class ElasticNet final : public SplitEvaluator {
 
   bst_float ComputeWeight(bst_uint parentID, const GradStats& stats)
       const override {
-    bst_float w = -ThresholdL1(stats.sum_grad) / (stats.sum_hess + params_->reg_lambda);
+    const double denominator = stats.sum_hess + params_->reg_lambda;
+    if (denominator == 0.0) {
+      return 0.0f;
+    }
+    bst_float w = -ThresholdL1(stats.sum_grad) / denominator;
     if (params_->max_delta_step != 0.0f && std::abs(w) > params_->max_delta_step) {
       w = std::copysign(params_->max_delta_step, w);
     }

--- a/src/tree/split_evaluator.cc
+++ b/src/tree/split_evaluator.cc
@@ -14,6 +14,7 @@
 #include <string>
 #include <sstream>
 #include <utility>
+#include <cmath>
 
 #include "xgboost/logging.h"
 #include "xgboost/parameter.h"
@@ -120,11 +121,11 @@ class ElasticNet final : public SplitEvaluator {
   bst_float ComputeWeight(bst_uint parentID, const GradStats& stats)
       const override {
     const double denominator = stats.sum_hess + params_->reg_lambda;
-    if (denominator == 0.0) {
-      return 0.0f;
+    if (std::fabs(denominator) < kRtEps) {
+      denominator = std::copysign(kRtEps, denominator);
     }
     bst_float w = -ThresholdL1(stats.sum_grad) / denominator;
-    if (params_->max_delta_step != 0.0f && std::abs(w) > params_->max_delta_step) {
+    if (params_->max_delta_step != 0.0f && std::fabs(w) > params_->max_delta_step) {
       w = std::copysign(params_->max_delta_step, w);
     }
     return w;


### PR DESCRIPTION
See discussion at https://discuss.xgboost.ai/t/still-getting-unexplained-nans-new-replication-code/1383?u=hcho3.

In certain degenerate cases, both the hessian sum and `reg_lambda` can be zero, leading to NANs in leaf outputs.

This PR eliminates NANs, by returning 0.0 whenever both hessian sum and `reg_lambda` are zero.

~It also adds a check in the Learner class to ensure that there is no INF or NAN in the prediction result vector.~ I left out the check for now, since performance impact is uncertain.

~Note: I think NANs in the prediction is a serious bug, so its fix should be part of 1.0.0 release.~ Will return after 1.0.0 release.

@dan-stromberg