### PR TITLE
Add a general parameter for XGBoost4j-Spark to allow skipping missing value processing

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -261,6 +261,7 @@ class XGBoostClassificationModel private[ml](
     val dm = new DMatrix(XGBoost.processMissingValues(
       Iterator(features.asXGB),
       $(missing),
+      $(skipProcessingMissing),
       $(allowNonZeroForMissing)
     ))
     val probability = _booster.predict(data = dm)(0).map(_.toDouble)
@@ -321,6 +322,7 @@ class XGBoostClassificationModel private[ml](
             XGBoost.processMissingValues(
               features.map(_.asXGB),
               $(missing),
+              $(skipProcessingMissing),
               $(allowNonZeroForMissing)
             ),
             cacheInfo)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -250,6 +250,11 @@ class XGBoostClassificationModel private[ml](
     value
   )
 
+  def setSkipProcessingMissing(value: Boolean): this.type = set(
+    skipProcessingMissing,
+    value
+  )
+
   def setInferBatchSize(value: Int): this.type = set(inferBatchSize, value)
 
   /**

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -241,6 +241,11 @@ class XGBoostRegressionModel private[ml] (
 
   def setMissing(value: Float): this.type = set(missing, value)
 
+  def setSkipProcessingMissing(value: Boolean): this.type = set(
+    skipProcessingMissing,
+    value
+  )
+
   def setAllowZeroForMissingValue(value: Boolean): this.type = set(
     allowNonZeroForMissing,
     value

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -257,6 +257,7 @@ class XGBoostRegressionModel private[ml] (
     val dm = new DMatrix(XGBoost.processMissingValues(
       Iterator(features.asXGB),
       $(missing),
+      $(skipProcessingMissing),
       $(allowNonZeroForMissing)
     ))
     _booster.predict(data = dm)(0)(0)
@@ -299,6 +300,7 @@ class XGBoostRegressionModel private[ml] (
             XGBoost.processMissingValues(
               features.map(_.asXGB),
               $(missing),
+              $(skipProcessingMissing),
               $(allowNonZeroForMissing)
             ),
             cacheInfo)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -106,6 +106,18 @@ private[spark] trait GeneralParams extends Params {
   final def getMissing: Float = $(missing)
 
   /**
+   * Allows for skipping processing of missing values. default: false
+   */
+  final val skipProcessingMissing = new BooleanParam(
+    this,
+    "skipProcessingMissing",
+    "Allow to skip processing missing values in the input. " +
+      "Should only be used if th input is known to contain no missing values."
+  )
+
+  final def getSkipProcessingMissing: Boolean = $(skipProcessingMissing)
+
+  /**
     * Allows for having a non-zero value for missing when training on prediction
     * on a Sparse or Empty vector.
     */

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GeneralParams.scala
@@ -203,6 +203,7 @@ private[spark] trait GeneralParams extends Params {
     customObj -> null, customEval -> null, missing -> Float.NaN,
     trackerConf -> TrackerConf(), seed -> 0, timeoutRequestWorkers -> 30 * 60 * 1000L,
     checkpointPath -> "", checkpointInterval -> -1,
+    skipProcessingMissing -> false,
     allowNonZeroForMissing -> false)
 }
 


### PR DESCRIPTION
This PR adds a boolean parameter 'skipProcessingMissing' to allow skipping missing value processing when the input is known to contain no missing values. If, before being passed to XGBoost, the input is already pre-processed so that missing values are removed or transformed, then there is no need for XGBoost to search for and process missing values again. In our experiment using a pre-processed "mortgage" dataset (600M+ rows, 46 columns), this parameter can save the run time substantially on Spark clusters:

Cluster size | Run time reduced on average
------------  | ---------------------------------
3 nodes, 21 workers | 55 seconds
4 nodes, 28 workers | 41 seconds