### PR TITLE
Remove use of std::cout from R package

### DIFF
--- a/src/common/observer.h
+++ b/src/common/observer.h
@@ -15,12 +15,23 @@
 #include "xgboost/base.h"
 #include "xgboost/tree_model.h"
 
+#if defined(XGBOOST_STRICT_R_MODE)
+#define OBSERVER_PRINT LOG(INFO)
+#define OBSERVER_ENDL ""
+#define OBSERVER_NEWLINE ""
+#else
+#define OBSERVER_PRINT std::cout
+#define OBSERVER_ENDL std::endl
+#define OBSERVER_NEWLINE "\n"
+#endif  // defined(XGBOOST_STRICT_R_MODE)
+
 namespace xgboost {
 /*\brief  An observer for logging internal data structures.
  *
  *  This class is designed to be `diff` tool friendly, which means it uses plain
  *  `std::cout` for printing to avoid the time information emitted by `LOG(DEBUG)` or
- *  similiar facilities.
+ *  similiar facilities. Exception: use `LOG(INFO)` for the R package, to comply
+ *  with CRAN policy.
  */
 class TrainingObserver {
 #if defined(XGBOOST_USE_DEBUG_OUTPUT)
@@ -32,17 +43,17 @@ class TrainingObserver {
  public:
   void Update(int32_t iter) const {
     if (XGBOOST_EXPECT(!observe_, true)) { return; }
-    std::cout << "Iter: " << iter << std::endl;
+    OBSERVER_PRINT << "Iter: " << iter << OBSERVER_ENDL;
   }
   /*\brief Observe tree. */
   void Observe(RegTree const& tree) {
     if (XGBOOST_EXPECT(!observe_, true)) { return; }
-    std::cout << "Tree:" << std::endl;
+    OBSERVER_PRINT << "Tree:" << OBSERVER_ENDL;
     Json j_tree {Object()};
     tree.SaveModel(&j_tree);
     std::string str;
     Json::Dump(j_tree, &str, true);
-    std::cout << str << std::endl;
+    OBSERVER_PRINT << str << OBSERVER_ENDL;
   }
   /*\brief Observe tree. */
   void Observe(RegTree const* p_tree) {
@@ -54,15 +65,15 @@ class TrainingObserver {
   template <typename T>
   void Observe(std::vector<T> const& h_vec, std::string name) const {
     if (XGBOOST_EXPECT(!observe_, true)) { return; }
-    std::cout << "Procedure: " << name << std::endl;
+    OBSERVER_PRINT << "Procedure: " << name << OBSERVER_ENDL;
 
     for (size_t i = 0; i < h_vec.size(); ++i) {
-      std::cout << h_vec[i] << ", ";
+      OBSERVER_PRINT << h_vec[i] << ", ";
       if (i % 8 == 0) {
-        std::cout << '\n';
+        OBSERVER_PRINT << OBSERVER_NEWLINE;
       }
     }
-    std::cout << std::endl;
+    OBSERVER_PRINT << OBSERVER_ENDL;
   }
   /*\brief Observe data hosted by `HostDeviceVector'. */
   template <typename T>
@@ -85,16 +96,16 @@ class TrainingObserver {
     if (XGBOOST_EXPECT(!observe_, true)) { return; }
 
     Json obj {toJson(p)};
-    std::cout << "Parameter: " << name << ":\n" << obj << std::endl;
+    OBSERVER_PRINT << "Parameter: " << name << ":\n" << obj << OBSERVER_ENDL;
   }
   /*\brief Observe parameters provided by users. */
   void Observe(Args const& args) const {
     if (XGBOOST_EXPECT(!observe_, true)) { return; }
 
     for (auto kv : args) {
-      std::cout << kv.first << ": " << kv.second << "\n";
+      OBSERVER_PRINT << kv.first << ": " << kv.second << OBSERVER_NEWLINE;
     }
-    std::cout << std::endl;
+    OBSERVER_PRINT << OBSERVER_ENDL;
   }
 
   /*\brief Get a global instance. */

--- a/src/common/timer.cc
+++ b/src/common/timer.cc
@@ -89,10 +89,10 @@ void Monitor::PrintStatistics(StatMap const& statistics) const {
           "Timer for " << kv.first << " did not get stopped properly.";
       continue;
     }
-    std::cout << kv.first << ": " << static_cast<double>(kv.second.second) / 1e+6
-              << "s, " << kv.second.first << " calls @ "
-              << kv.second.second
-              << "us" << std::endl;
+    LOG(CONSOLE) << kv.first << ": " << static_cast<double>(kv.second.second) / 1e+6
+                 << "s, " << kv.second.first << " calls @ "
+                 << kv.second.second
+                 << "us" << std::endl;
   }
 }
 
@@ -107,10 +107,9 @@ void Monitor::Print() const {
     if (rabit::GetRank() == 0) {
       LOG(CONSOLE) << "======== Monitor: " << label << " ========";
       for (size_t i = 0; i < world.size(); ++i) {
-        std::cout << "From rank: " << i << ": " << std::endl;
+        LOG(CONSOLE) << "From rank: " << i << ": " << std::endl;
         auto const& statistic = world[i];
         this->PrintStatistics(statistic);
-        std::cout << std::endl;
       }
     }
   } else {
@@ -123,7 +122,6 @@ void Monitor::Print() const {
     LOG(CONSOLE) << "======== Monitor: " << label << " ========";
     this->PrintStatistics(stat_map);
   }
-  std::cout << std::endl;
 }
 
 }  // namespace common


### PR DESCRIPTION
R packages cannot use `std::cout` for printing, per CRAN policy.

```
* checking compiled code ... NOTE
File ‘xgboost/libs/xgboost.so’:
  Found ‘_ZSt4cout’, possibly from ‘std::cout’ (C++)
    Object: ‘./amalgamation/xgboost-all0.o’

Compiled code should not call entry points which might terminate R nor
write to stdout/stderr instead of to the console, nor use Fortran I/O
nor system RNGs.

See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
```

* `src/common/timer.cc`: Replace `std::cout` with `LOG(CONSOLE)`.
* `src/common/observer.h`: Replace `std::cout` with `LOG(INFO)` (only when `XGBOOST_STRICT_R_MODE` macro is active).