### PR TITLE
[native] [jvm-packages] allow rebuild prediction cache when it is not initialized

### DIFF
--- a/include/xgboost/generic_parameters.h
+++ b/include/xgboost/generic_parameters.h
@@ -30,7 +30,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
   bool enable_experimental_json_serialization {false};
   bool validate_parameters {false};
   bool validate_features {true};
-  bool adding_all_to_cache {true};
+  bool adding_all_to_cache {false};
 
   void CheckDeprecated() {
     if (this->n_gpus != 0) {
@@ -87,7 +87,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
 "\n\tPlease switch to distributed training with one process per GPU."
 "\n\tThis can be done using Dask or Spark.  See documentation for details.");
     DMLC_DECLARE_FIELD(adding_all_to_cache)
-      .set_default(true)
+      .set_default(false)
       .describe("adding prediction results for all dmatrix to prediction cache");
   }
 

--- a/include/xgboost/generic_parameters.h
+++ b/include/xgboost/generic_parameters.h
@@ -30,6 +30,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
   bool enable_experimental_json_serialization {false};
   bool validate_parameters {false};
   bool validate_features {true};
+  bool adding_all_to_cache{false};
 
   void CheckDeprecated() {
     if (this->n_gpus != 0) {
@@ -85,6 +86,9 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
 "\n\tDeprecated. Single process multi-GPU training is no longer supported."
 "\n\tPlease switch to distributed training with one process per GPU."
 "\n\tThis can be done using Dask or Spark.  See documentation for details.");
+    DMLC_DECLARE_FIELD(adding_all_to_cache)
+      .set_default(false)
+      .describe("adding prediction results for all dmatrix to prediction cache");
   }
 
  private:

--- a/include/xgboost/generic_parameters.h
+++ b/include/xgboost/generic_parameters.h
@@ -30,7 +30,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
   bool enable_experimental_json_serialization {false};
   bool validate_parameters {false};
   bool validate_features {true};
-  bool adding_all_to_cache{true};
+  bool adding_all_to_cache {true};
 
   void CheckDeprecated() {
     if (this->n_gpus != 0) {

--- a/include/xgboost/generic_parameters.h
+++ b/include/xgboost/generic_parameters.h
@@ -30,7 +30,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
   bool enable_experimental_json_serialization {false};
   bool validate_parameters {false};
   bool validate_features {true};
-  bool adding_all_to_cache{false};
+  bool adding_all_to_cache{true};
 
   void CheckDeprecated() {
     if (this->n_gpus != 0) {
@@ -87,7 +87,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
 "\n\tPlease switch to distributed training with one process per GPU."
 "\n\tThis can be done using Dask or Spark.  See documentation for details.");
     DMLC_DECLARE_FIELD(adding_all_to_cache)
-      .set_default(false)
+      .set_default(true)
       .describe("adding prediction results for all dmatrix to prediction cache");
   }
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -155,7 +155,10 @@ private[this] class XGBoostExecutionParamsFactory(rawParams: Map[String, Any], s
       overridedParams += ("maximize_evaluation_metrics" -> maximize)
     }
 
-    if (params.contains("checkpoint_path") && params.contains("checkpoint_interval")) {
+    if (params.contains("checkpoint_path") && params.contains("checkpoint_interval") &&
+      params("checkpoint_path") != null &&
+      params("checkpoint_path").asInstanceOf[String].length > 0 &&
+      params("checkpoint_interval").asInstanceOf[Int] > 0) {
       overridedParams += "adding_all_to_cache" -> true
     }
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -156,7 +156,7 @@ private[this] class XGBoostExecutionParamsFactory(rawParams: Map[String, Any], s
     }
 
     if (params.contains("checkpoint_path") && params.contains("checkpoint_interval")) {
-      overridedParams += "adding_all_to_cache" -> true
+      overridedParams += "adding_all_to_cache" -> false
     }
 
     overridedParams

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -154,6 +154,11 @@ private[this] class XGBoostExecutionParamsFactory(rawParams: Map[String, Any], s
       logger.info("parameter \"maximize_evaluation_metrics\" is set to " + maximize)
       overridedParams += ("maximize_evaluation_metrics" -> maximize)
     }
+
+    if (params.contains("checkpoint_path") && params.contains("checkpoint_interval")) {
+      overridedParams += "adding_all_to_cache" -> true
+    }
+
     overridedParams
   }
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -156,7 +156,7 @@ private[this] class XGBoostExecutionParamsFactory(rawParams: Map[String, Any], s
     }
 
     if (params.contains("checkpoint_path") && params.contains("checkpoint_interval")) {
-      overridedParams += "adding_all_to_cache" -> false
+      overridedParams += "adding_all_to_cache" -> true
     }
 
     overridedParams

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -678,7 +678,7 @@ public class Booster implements Serializable, KryoSerializable {
    */
   private void init(DMatrix[] cacheMats) throws XGBoostError {
     long[] handles = null;
-    if (cacheMats != null) {
+    if (cacheMats != null && cacheMats.length > 0) {
       handles = dmatrixsToHandles(cacheMats);
     }
     long[] out = new long[1];

--- a/jvm-packages/xgboost4j/src/main/resources/xgboost4j-version.properties
+++ b/jvm-packages/xgboost4j/src/main/resources/xgboost4j-version.properties
@@ -1,1 +1,0 @@
-version=${project.version}

--- a/jvm-packages/xgboost4j/src/main/resources/xgboost4j-version.properties
+++ b/jvm-packages/xgboost4j/src/main/resources/xgboost4j-version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -202,6 +202,7 @@ class LearnerImpl : public Learner {
     tparam_.UpdateAllowUnknown(args);
     mparam_.UpdateAllowUnknown(args);
     generic_parameters_.UpdateAllowUnknown(args);
+    std::cout << "all_to_prediction_cache:" << generic_parameters_.adding_all_to_cache << "\n";
     generic_parameters_.CheckDeprecated();
 
     ConsoleLogger::Configure(args);

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -704,6 +704,7 @@ class LearnerImpl : public Learner {
     this->ValidateDMatrix(train);
 
     monitor_.Start("PredictRaw");
+    std::cout << "calling UpdateOneIter\n";
     this->PredictRaw(train, &preds_[train], true);
     monitor_.Stop("PredictRaw");
     TrainingObserver::Instance().Observe(preds_[train], "Predictions");
@@ -745,6 +746,7 @@ class LearnerImpl : public Learner {
     for (size_t i = 0; i < data_sets.size(); ++i) {
       DMatrix * dmat = data_sets[i];
       this->ValidateDMatrix(dmat);
+      std::cout << "calling EvalOneIter\n";
       this->PredictRaw(data_sets[i], &preds_[dmat], false);
       obj_->EvalTransform(&preds_[dmat]);
       for (auto& ev : metrics_) {

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -171,7 +171,7 @@ class CPUPredictor : public Predictor {
     if (ntree_limit == 0 || ntree_limit > model.trees.size()) {
       ntree_limit = static_cast<unsigned>(model.trees.size());
     }
-
+    std::cout << "run PredLoopInternal in PredictBatch\n";
     this->PredLoopInternal(dmat, &out_preds->HostVector(), model,
                            tree_begin, ntree_limit);
 

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -176,8 +176,11 @@ class CPUPredictor : public Predictor {
                            tree_begin, ntree_limit);
 
     auto cache_entry = this->FindCache(dmat);
-    if (cache_entry == cache_->cend()) {
+    if (!generic_param_->adding_all_to_cache && cache_entry == cache_->cend()) {
       return;
+    } else if (generic_param_->adding_all_to_cache) {
+      auto * new_cache_entry = new PredictionCacheEntry();
+      (*cache_)[dmat] = (*new_cache_entry);
     }
     if (cache_entry->second.predictions.Size() == 0) {
       // See comment in GPUPredictor::PredictBatch.

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -179,7 +179,7 @@ class CPUPredictor : public Predictor {
     if (!generic_param_->adding_all_to_cache && cache_entry == cache_->cend()) {
       return;
     } else if (generic_param_->adding_all_to_cache) {
-      (*cache_)[dmat].data = std::make_shared<DMatrix>(dmat);
+      (*cache_)[dmat].data = static_cast<std::shared_ptr<DMatrix>>(dmat);
     }
     if (cache_entry->second.predictions.Size() == 0) {
       // See comment in GPUPredictor::PredictBatch.

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -198,7 +198,7 @@ class CPUPredictor : public Predictor {
 
       if (e.predictions.Size() == 0) {
         InitOutPredictions(e.data->Info(), &(e.predictions), model);
-        std::cout << "calling PredLoopInternal in UpdatePredictionCache\n";
+        std::cout << "calling PredLoopInternal in UpdatePredictionCache_1\n";
         PredLoopInternal(e.data.get(), &(e.predictions.HostVector()), model, 0,
                          model.trees.size());
       } else if (model.learner_model_param_->num_output_group == 1 && updaters->size() > 0 &&
@@ -207,6 +207,7 @@ class CPUPredictor : public Predictor {
                                                          &(e.predictions))) {
         {}  // do nothing
       } else {
+        std::cout << "calling PredLoopInternal in UpdatePredictionCache_2\n";
         PredLoopInternal(e.data.get(), &(e.predictions.HostVector()), model, old_ntree,
                          model.trees.size());
       }

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -189,7 +189,7 @@ class CPUPredictor : public Predictor {
     if (cache_entry->second.predictions.Size() == 0) {
       // See comment in GPUPredictor::PredictBatch.
       InitOutPredictions(cache_entry->second.data->Info(),
-                         &(cache_entry->second.predictions), model);
+              &(cache_entry->second.predictions), model);
       cache_entry->second.predictions.Copy(*out_preds);
     }
   }

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -177,6 +177,7 @@ class CPUPredictor : public Predictor {
 
     auto cache_entry = this->FindCache(dmat);
     if (cache_entry == cache_->cend()) {
+      std::cout << "cannot find cache\n";
       if (!generic_param_->adding_all_to_cache) {
         return;
       } else {

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -176,6 +176,7 @@ class CPUPredictor : public Predictor {
                            tree_begin, ntree_limit);
 
     auto cache_entry = this->FindCache(dmat);
+    std::cout << "adding_all_to_cache: " << generic_param_->adding_all_to_cache << "\n";
     if (cache_entry == cache_->cend()) {
       if (!generic_param_->adding_all_to_cache) {
         return;

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -176,10 +176,12 @@ class CPUPredictor : public Predictor {
                            tree_begin, ntree_limit);
 
     auto cache_entry = this->FindCache(dmat);
-    if (!generic_param_->adding_all_to_cache && cache_entry == cache_->cend()) {
-      return;
-    } else if (generic_param_->adding_all_to_cache) {
-      (*cache_)[dmat].data = static_cast<std::shared_ptr<DMatrix>>(dmat);
+    if (cache_entry == cache_->cend()) {
+      if (!generic_param_->adding_all_to_cache) {
+        return;
+      } else {
+        (*cache_)[dmat].data = static_cast<std::shared_ptr<DMatrix>>(dmat);
+      }
     }
     if (cache_entry->second.predictions.Size() == 0) {
       // See comment in GPUPredictor::PredictBatch.

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -198,6 +198,7 @@ class CPUPredictor : public Predictor {
 
       if (e.predictions.Size() == 0) {
         InitOutPredictions(e.data->Info(), &(e.predictions), model);
+        std::cout << "calling PredLoopInternal in UpdatePredictionCache\n";
         PredLoopInternal(e.data.get(), &(e.predictions.HostVector()), model, 0,
                          model.trees.size());
       } else if (model.learner_model_param_->num_output_group == 1 && updaters->size() > 0 &&

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -179,8 +179,7 @@ class CPUPredictor : public Predictor {
     if (!generic_param_->adding_all_to_cache && cache_entry == cache_->cend()) {
       return;
     } else if (generic_param_->adding_all_to_cache) {
-      auto * new_cache_entry = new PredictionCacheEntry();
-      (*cache_)[dmat] = (*new_cache_entry);
+      (*cache_)[dmat].data = std::make_shared<DMatrix>(dmat);
     }
     if (cache_entry->second.predictions.Size() == 0) {
       // See comment in GPUPredictor::PredictBatch.

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -178,11 +178,12 @@ class CPUPredictor : public Predictor {
     auto cache_entry = this->FindCache(dmat);
     if (cache_entry == cache_->cend()) {
       std::cout << "cannot find cache\n";
-      if (!generic_param_->adding_all_to_cache) {
+      if (!generic_param_->adding_all_to_cache || !(*cache_).empty()) {
         return;
       } else {
         std::cout << "adding dmatrix to cache\n";
         (*cache_)[dmat].data = static_cast<std::shared_ptr<DMatrix>>(dmat);
+        return;
       }
     }
     if (cache_entry->second.predictions.Size() == 0) {

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -176,11 +176,11 @@ class CPUPredictor : public Predictor {
                            tree_begin, ntree_limit);
 
     auto cache_entry = this->FindCache(dmat);
-    std::cout << "adding_all_to_cache: " << generic_param_->adding_all_to_cache << "\n";
     if (cache_entry == cache_->cend()) {
       if (!generic_param_->adding_all_to_cache) {
         return;
       } else {
+        std::cout << "adding dmatrix to cache\n";
         (*cache_)[dmat].data = static_cast<std::shared_ptr<DMatrix>>(dmat);
       }
     }


### PR DESCRIPTION
the major purpose is to fix the performance issue when training based on a checkpoint 

We need to call prediction in 3 places, UpdateOneIter for residual, evaluation and update prediction cache. Because of the existence of pred cache, we only really perform prediction when update prediction cache and leverage the produced results in the other two places. 

the performance degradation comes from the fact that when we train based on a checkpoint we lost the prediction cache. As s result, we will call in UpdateOneIter and EvalOneIter (since we lost cache, we will not call when updating cache)

this PR fixes the issue by adding DMatrix to cache when cache has been lost (this behavior only happens in JVM and only when checkpoint is set)


relevant issues

https://github.com/dmlc/xgboost/issues/3946

https://github.com/dmlc/xgboost/issues/4786

https://github.com/dmlc/xgboost/issues/4774

