### PR TITLE
Wide dataset quantile performance improvement

### DIFF
--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -148,7 +148,7 @@ class GPUSketcher {
       this->SketchBatch(batch, info);
     }
 
-    hmat->Init(&sketch_container_->sketches_, max_bin_);
+    hmat->Init(&sketch_container_->sketches_, max_bin_, info.num_row_);
     return row_stride_;
   }
 

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -244,7 +244,7 @@ class DenseCuts  : public CutsBuilder {
       CutsBuilder(container) {
     monitor_.Init(__FUNCTION__);
   }
-  void Init(std::vector<WQSketch>* sketchs, uint32_t max_num_bins);
+  void Init(std::vector<WQSketch>* sketchs, uint32_t max_num_bins, size_t max_rows);
   void Build(DMatrix* p_fmat, uint32_t max_num_bins) override;
 };
 

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -702,6 +702,7 @@ class QuantileSketchTemplate {
     nlevel = 1;
     while (true) {
       limit_size = static_cast<size_t>(ceil(nlevel / eps)) + 1;
+      limit_size = std::min(maxn, limit_size);
       size_t n = (1ULL << nlevel);
       if (n * limit_size >= maxn) break;
       ++nlevel;
@@ -709,7 +710,8 @@ class QuantileSketchTemplate {
     // check invariant
     size_t n = (1ULL << nlevel);
     CHECK(n * limit_size >= maxn) << "invalid init parameter";
-    CHECK(nlevel <= limit_size * eps) << "invalid init parameter";
+    CHECK(nlevel <= std::max(1, static_cast<int>(limit_size * eps)))
+        << "invalid init parameter";
   }
 
   /*!


### PR DESCRIPTION
This PR bounds the size of sketch data structures when the number of rows is small. Previously, training on even a single row requires allocating >4096 cut samples per feature. Benchmark performance results below, training on 10 rows

![Cut computation time vs  num columns](https://user-images.githubusercontent.com/7307640/74497609-0e53d680-4f43-11ea-98a3-907610bc9322.png)
