### PR TITLE
Use `scikit-learn` in extra dependencies.

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -288,7 +288,7 @@ if __name__ == '__main__':
           },
           extras_require={
               'pandas': ['pandas'],
-              'sklearn': ['sklearn'],
+              'scikit-learn': ['scikit-learn'],
               'dask': ['dask', 'pandas', 'distributed'],
               'datatable': ['datatable'],
               'plotting': ['graphviz', 'matplotlib']


### PR DESCRIPTION
Closes https://github.com/dmlc/xgboost/issues/5309

@victornoel Thanks for raising the issue.