### PR TITLE
Remove unnecessary DMatrix methods

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -438,6 +438,9 @@ class DMatrix {
    */
   template<typename T>
   BatchSet<T> GetBatches(const BatchParam& param = {});
+  // the following are column meta data, should be able to answer them fast.
+  /*! \return Whether the data columns single column block. */
+  virtual bool SingleColBlock() const = 0;
   /*! \brief virtual destructor */
   virtual ~DMatrix() = default;
 

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -438,11 +438,6 @@ class DMatrix {
    */
   template<typename T>
   BatchSet<T> GetBatches(const BatchParam& param = {});
-  // the following are column meta data, should be able to answer them fast.
-  /*! \return Whether the data columns single column block. */
-  virtual bool SingleColBlock() const = 0;
-  /*! \brief get column density */
-  virtual float GetColDensity(size_t cidx) = 0;
   /*! \brief virtual destructor */
   virtual ~DMatrix() = default;
 

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -16,21 +16,6 @@ MetaInfo& SimpleDMatrix::Info() { return info; }
 
 const MetaInfo& SimpleDMatrix::Info() const { return info; }
 
-float SimpleDMatrix::GetColDensity(size_t cidx) {
-  size_t column_size = 0;
-  // Use whatever version of column batches already exists
-  if (sorted_column_page_) {
-    auto batch = this->GetBatches<SortedCSCPage>();
-    column_size = (*batch.begin())[cidx].size();
-  } else {
-    auto batch = this->GetBatches<CSCPage>();
-    column_size = (*batch.begin())[cidx].size();
-  }
-
-  size_t nmiss = this->Info().num_row_ - column_size;
-  return 1.0f - (static_cast<float>(nmiss)) / this->Info().num_row_;
-}
-
 BatchSet<SparsePage> SimpleDMatrix::GetRowBatches() {
   // since csr is the default data structure so `source_` is always available.
   auto begin_iter = BatchIterator<SparsePage>(
@@ -71,8 +56,6 @@ BatchSet<EllpackPage> SimpleDMatrix::GetEllpackBatches(const BatchParam& param) 
       BatchIterator<EllpackPage>(new SimpleBatchIteratorImpl<EllpackPage>(ellpack_page_.get()));
   return BatchSet<EllpackPage>(begin_iter);
 }
-
-bool SimpleDMatrix::SingleColBlock() const { return true; }
 
 template <typename AdapterT>
 SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {

--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -30,10 +30,6 @@ class SimpleDMatrix : public DMatrix {
 
   const MetaInfo& Info() const override;
 
-  float GetColDensity(size_t cidx) override;
-
-  bool SingleColBlock() const override;
-
   /*! \brief magic number used to identify SimpleDMatrix binary files */
   static const int kMagic = 0xffffab01;
 

--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -30,6 +30,8 @@ class SimpleDMatrix : public DMatrix {
 
   const MetaInfo& Info() const override;
 
+  bool SingleColBlock() const override { return true; }
+
   /*! \brief magic number used to identify SimpleDMatrix binary files */
   static const int kMagic = 0xffffab01;
 

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -92,28 +92,6 @@ BatchSet<EllpackPage> SparsePageDMatrix::GetEllpackBatches(const BatchParam& par
   return BatchSet<EllpackPage>(begin_iter);
 }
 
-float SparsePageDMatrix::GetColDensity(size_t cidx) {
-  // Finds densities if we don't already have them
-  if (col_density_.empty()) {
-    std::vector<size_t> column_size(this->Info().num_col_);
-    for (const auto &batch : this->GetBatches<CSCPage>()) {
-      for (auto i = 0u; i < batch.Size(); i++) {
-        column_size[i] += batch[i].size();
-      }
-    }
-    col_density_.resize(column_size.size());
-    for (auto i = 0u; i < col_density_.size(); i++) {
-      size_t nmiss = this->Info().num_row_ - column_size[i];
-      col_density_[i] =
-          1.0f - (static_cast<float>(nmiss)) / this->Info().num_row_;
-    }
-  }
-  return col_density_.at(cidx);
-}
-
-bool SparsePageDMatrix::SingleColBlock() const {
-  return false;
-}
 }  // namespace data
 }  // namespace xgboost
 #endif  // DMLC_ENABLE_STD_THREAD

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -46,10 +46,6 @@ class SparsePageDMatrix : public DMatrix {
 
   const MetaInfo& Info() const override;
 
-  float GetColDensity(size_t cidx) override;
-
-  bool SingleColBlock() const override;
-
  private:
   BatchSet<SparsePage> GetRowBatches() override;
   BatchSet<CSCPage> GetColumnBatches() override;

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -46,6 +46,8 @@ class SparsePageDMatrix : public DMatrix {
 
   const MetaInfo& Info() const override;
 
+  bool SingleColBlock() const override { return false; }
+
  private:
   BatchSet<SparsePage> GetRowBatches() override;
   BatchSet<CSCPage> GetColumnBatches() override;

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -27,6 +27,7 @@
 #include "../common/common.h"
 #include "../common/random.h"
 #include "../common/timer.h"
+#include "../data/sparse_page_dmatrix.h"
 
 namespace xgboost {
 namespace gbm {
@@ -130,7 +131,7 @@ void GBTree::PerformTreeMethodHeuristic(DMatrix* fmat) {
       "Tree method is automatically selected to be 'approx' "
       "for distributed training.";
     tparam_.tree_method = TreeMethod::kApprox;
-  } else if (!fmat->SingleColBlock()) {
+  } else if (dynamic_cast<data::SparsePageDMatrix*>(fmat)) {
     LOG(WARNING) << "Tree method is automatically set to 'approx' "
                     "since external-memory data matrix is used.";
     tparam_.tree_method = TreeMethod::kApprox;

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -27,7 +27,6 @@
 #include "../common/common.h"
 #include "../common/random.h"
 #include "../common/timer.h"
-#include "../data/sparse_page_dmatrix.h"
 
 namespace xgboost {
 namespace gbm {

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -131,7 +131,7 @@ void GBTree::PerformTreeMethodHeuristic(DMatrix* fmat) {
       "Tree method is automatically selected to be 'approx' "
       "for distributed training.";
     tparam_.tree_method = TreeMethod::kApprox;
-  } else if (dynamic_cast<data::SparsePageDMatrix*>(fmat)) {
+  } else if (!fmat->SingleColBlock()) {
     LOG(WARNING) << "Tree method is automatically set to 'approx' "
                     "since external-memory data matrix is used.";
     tparam_.tree_method = TreeMethod::kApprox;

--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -59,9 +59,8 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
 
     num_row_ = static_cast<size_t>(p_fmat->Info().num_row_);
 
-    SparsePage const &batch = *p_fmat->GetBatches<CSCPage>().begin();
-    CHECK(!dynamic_cast<data::SparsePageDMatrix *>(p_fmat))
-        << "External memory not supported";
+    CHECK(p_fmat->SingleColBlock());
+    SparsePage const& batch = *(p_fmat->GetBatches<CSCPage>().begin());
 
     if (IsEmpty()) {
       return;

--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -14,7 +14,6 @@
 #include "../common/device_helpers.cuh"
 #include "../common/timer.h"
 #include "./param.h"
-#include "../data/sparse_page_dmatrix.h"
 
 namespace xgboost {
 namespace linear {

--- a/tests/cpp/data/test_simple_dmatrix.cc
+++ b/tests/cpp/data/test_simple_dmatrix.cc
@@ -51,6 +51,8 @@ TEST(SimpleDMatrix, ColAccessWithoutBatches) {
   CreateSimpleTestData(tmp_file);
   xgboost::DMatrix *dmat = xgboost::DMatrix::Load(tmp_file, true, false);
 
+  ASSERT_TRUE(dmat->SingleColBlock());
+
   // Loop over the batches and assert the data is as expected
   int64_t num_col_batch = 0;
   for (const auto &batch : dmat->GetBatches<xgboost::SortedCSCPage>()) {

--- a/tests/cpp/data/test_simple_dmatrix.cc
+++ b/tests/cpp/data/test_simple_dmatrix.cc
@@ -51,11 +51,6 @@ TEST(SimpleDMatrix, ColAccessWithoutBatches) {
   CreateSimpleTestData(tmp_file);
   xgboost::DMatrix *dmat = xgboost::DMatrix::Load(tmp_file, true, false);
 
-  // Sorted column access
-  EXPECT_EQ(dmat->GetColDensity(0), 1);
-  EXPECT_EQ(dmat->GetColDensity(1), 0.5);
-  ASSERT_TRUE(dmat->SingleColBlock());
-
   // Loop over the batches and assert the data is as expected
   int64_t num_col_batch = 0;
   for (const auto &batch : dmat->GetBatches<xgboost::SortedCSCPage>()) {

--- a/tests/cpp/data/test_sparse_page_dmatrix.cc
+++ b/tests/cpp/data/test_sparse_page_dmatrix.cc
@@ -47,9 +47,6 @@ TEST(SparsePageDMatrix, ColAccess) {
   xgboost::DMatrix * dmat = xgboost::DMatrix::Load(
     tmp_file + "#" + tmp_file + ".cache", true, false);
 
-  EXPECT_EQ(dmat->GetColDensity(0), 1);
-  EXPECT_EQ(dmat->GetColDensity(1), 0.5);
-
   // Loop over the batches and assert the data is as expected
   for (auto const& col_batch : dmat->GetBatches<xgboost::SortedCSCPage>()) {
     EXPECT_EQ(col_batch.Size(), dmat->Info().num_col_);

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -96,9 +96,11 @@ TEST(Learner, SLOW_CheckMultiBatch) {
   // Create sufficiently large data to make two row pages
   dmlc::TemporaryDirectory tempdir;
   const std::string tmp_file = tempdir.path + "/big.libsvm";
-  CreateBigTestData(tmp_file, 5000000);
-  std::shared_ptr<DMatrix> dmat(xgboost::DMatrix::Load( tmp_file + "#" + tmp_file + ".cache", true, false));
+  CreateBigTestData(tmp_file, 50000);
+  std::shared_ptr<DMatrix> dmat(xgboost::DMatrix::Load(
+      tmp_file + "#" + tmp_file + ".cache", true, false, "auto", 100));
   EXPECT_TRUE(FileExists(tmp_file + ".cache.row.page"));
+  EXPECT_FALSE(dmat->SingleColBlock());
   size_t num_row = dmat->Info().num_row_;
   std::vector<bst_float> labels(num_row);
   for (size_t i = 0; i < num_row; ++i) {

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -99,7 +99,6 @@ TEST(Learner, SLOW_CheckMultiBatch) {
   CreateBigTestData(tmp_file, 5000000);
   std::shared_ptr<DMatrix> dmat(xgboost::DMatrix::Load( tmp_file + "#" + tmp_file + ".cache", true, false));
   EXPECT_TRUE(FileExists(tmp_file + ".cache.row.page"));
-  EXPECT_FALSE(dmat->SingleColBlock());
   size_t num_row = dmat->Info().num_row_;
   std::vector<bst_float> labels(num_row);
   for (size_t i = 0; i < num_row; ++i) {


### PR DESCRIPTION
Two methods are removed that do not provide broadly useful functionality:
DMatrix::GetColumnDensity
DMatrix::SingleColumnBlock

Column density is only needed by the exact algorithm, so I compute it in the updater itself. Single column block can be established by other means.