### PR TITLE
Remove f-string, since it's not supported by Python 3.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,6 +273,7 @@ def TestPythonCPU() {
     def docker_binary = "docker"
     sh """
     ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/test_python.sh cpu
+    ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/test_python.sh cpu-py35
     """
     deleteDir()
   }

--- a/python-package/xgboost/__init__.py
+++ b/python-package/xgboost/__init__.py
@@ -5,6 +5,8 @@ Contributors: https://github.com/dmlc/xgboost/blob/master/CONTRIBUTORS.md
 """
 
 import os
+import sys
+import warnings
 
 from .core import DMatrix, Booster
 from .training import train, cv
@@ -18,6 +20,12 @@ try:
     from .plotting import plot_importance, plot_tree, to_graphviz
 except ImportError:
     pass
+
+if sys.version_info[:2] == (3, 5):
+    warnings.warn(
+      'Python 3.5 support is deprecated and XGBoost will require Python 3.6+ in the near future. ' +
+      'Consider upgrading to Python 3.6+.',
+      FutureWarning)
 
 VERSION_FILE = os.path.join(os.path.dirname(__file__), 'VERSION')
 with open(VERSION_FILE) as f:

--- a/python-package/xgboost/__init__.py
+++ b/python-package/xgboost/__init__.py
@@ -23,7 +23,7 @@ except ImportError:
 
 if sys.version_info[:2] == (3, 5):
     warnings.warn(
-        'Python 3.5 support is deprecated and XGBoost will require Python 3.6+ in the near future. ' +
+        'Python 3.5 support is deprecated; XGBoost will require Python 3.6+ in the near future. ' +
         'Consider upgrading to Python 3.6+.',
         FutureWarning)
 

--- a/python-package/xgboost/__init__.py
+++ b/python-package/xgboost/__init__.py
@@ -23,9 +23,9 @@ except ImportError:
 
 if sys.version_info[:2] == (3, 5):
     warnings.warn(
-      'Python 3.5 support is deprecated and XGBoost will require Python 3.6+ in the near future. ' +
-      'Consider upgrading to Python 3.6+.',
-      FutureWarning)
+        'Python 3.5 support is deprecated and XGBoost will require Python 3.6+ in the near future. ' +
+        'Consider upgrading to Python 3.6+.',
+        FutureWarning)
 
 VERSION_FILE = os.path.join(os.path.dirname(__file__), 'VERSION')
 with open(VERSION_FILE) as f:

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -434,8 +434,8 @@ class XGBModel(XGBModelBase):
                 self.classes_ = np.array(v)
                 continue
             if k == 'type' and type(self).__name__ != v:
-                msg = f'Current model type: {type(self).__name__}, ' + \
-                    f'type of model in file: {v}'
+                msg = 'Current model type: {}, '.format(type(self).__name__) + \
+                      'type of model in file: {}'.format(v)
                 raise TypeError(msg)
             if k == 'type':
                 continue

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -29,7 +29,7 @@ RUN conda create -n py35 python=3.5 && \
 # Install Python packages in default env
 RUN \
     pip install pyyaml cpplint pylint astroid sphinx numpy scipy pandas matplotlib sh \
-    		recommonmark guzzle_sphinx_theme mock breathe matplotlib graphviz \
+    		recommonmark guzzle_sphinx_theme mock breathe graphviz \
 		pytest scikit-learn wheel kubernetes urllib3 jsonschema boto3 && \
     pip install https://h2o-release.s3.amazonaws.com/datatable/stable/datatable-0.7.0/datatable-0.7.0-cp37-cp37m-linux_x86_64.whl && \
     pip install "dask[complete]"

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -3,6 +3,7 @@ ARG CMAKE_VERSION=3.12
 
 # Environment
 ENV DEBIAN_FRONTEND noninteractive
+SHELL ["/bin/bash", "-c"]   # Use Bash as shell
 
 # Install all basic requirements
 RUN \
@@ -19,7 +20,13 @@ ENV PATH=/opt/python/bin:$PATH
 
 ENV GOSU_VERSION 1.10
 
-# Install Python packages
+# Create new Conda environment with Python 3.5
+RUN conda create -n py35 python=3.5 && \
+    source activate py35 && \
+    pip install numpy pytest scipy scikit-learn pandas matplotlib wheel kubernetes urllib3 graphviz && \
+    source deactivate
+
+# Install Python packages in default env
 RUN \
     pip install pyyaml cpplint pylint astroid sphinx numpy scipy pandas matplotlib sh \
     		recommonmark guzzle_sphinx_theme mock breathe matplotlib graphviz \

--- a/tests/ci_build/test_python.sh
+++ b/tests/ci_build/test_python.sh
@@ -5,31 +5,35 @@ set -x
 suite=$1
 
 # Install XGBoost Python package
-wheel_found=0
-for file in python-package/dist/*.whl
-do
-  if [ -e "${file}" ]
+function install_xgboost {
+  wheel_found=0
+  for file in python-package/dist/*.whl
+  do
+    if [ -e "${file}" ]
+    then
+      pip install --user "${file}"
+      wheel_found=1
+      break  # need just one
+    fi
+  done
+  if [ "$wheel_found" -eq 0 ]
   then
-    pip install --user "${file}"
-    wheel_found=1
-    break  # need just one
+    pushd .
+    cd python-package
+    python setup.py install --user
+    popd
   fi
-done
-if [ "$wheel_found" -eq 0 ]
-then
-  pushd .
-  cd python-package
-  python setup.py install --user
-  popd
-fi
+}
 
 # Run specified test suite
 case "$suite" in
   gpu)
+    install_xgboost
     pytest -v -s --fulltrace -m "not mgpu" tests/python-gpu
     ;;
 
   mgpu)
+    install_xgboost
     pytest -v -s --fulltrace -m "mgpu" tests/python-gpu
     cd tests/distributed
     ./runtests-gpu.sh
@@ -39,17 +43,25 @@ case "$suite" in
 
   cudf)
     source activate cudf_test
+    install_xgboost
     pytest -v -s --fulltrace -m "not mgpu" tests/python-gpu/test_from_columnar.py tests/python-gpu/test_from_cupy.py
     ;;
 
   cpu)
+    install_xgboost
     pytest -v -s --fulltrace tests/python
     cd tests/distributed
     ./runtests.sh
     ;;
 
+  cpu-py35)
+    source activate py35
+    install_xgboost
+    pytest -v -s --fulltrace tests/python
+    ;;
+
   *)
-    echo "Usage: $0 {gpu|mgpu|cudf|cpu}"
+    echo "Usage: $0 {gpu|mgpu|cudf|cpu|cpu-py35}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
Closes #5328. Also add Python 3.5 to CI so that f-string does not get accidentally added to the codebase again.

I will need to make a patch and create 1.0.1 patch release.

Aside: Dask now requites Python 3.6+, so I do not run Dask integration tests with Python 3.5.