### PR TITLE
Use type name for data type check.

### DIFF
--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -79,6 +79,14 @@ else:
 # END NUMPY PATHLIB ATTRIBUTION
 ###############################################################################
 
+
+def lazy_isinstance(instance, module, name):
+    '''Use string representation to identify a type.'''
+    module = type(instance).__module__ == module
+    name = type(instance).__name__ == name
+    return module and name
+
+
 # pandas
 try:
     from pandas import DataFrame, Series
@@ -94,27 +102,6 @@ except ImportError:
     Series = object
     pandas_concat = None
     PANDAS_INSTALLED = False
-
-# dt
-try:
-    # Workaround for #4473, compatibility with dask
-    if sys.__stdin__ is not None and sys.__stdin__.closed:
-        sys.__stdin__ = None
-    import datatable
-
-    if hasattr(datatable, "Frame"):
-        DataTable = datatable.Frame
-    else:
-        DataTable = datatable.DataTable
-    DT_INSTALLED = True
-except ImportError:
-
-    # pylint: disable=too-few-public-methods
-    class DataTable(object):
-        """ dummy for datatable.DataTable """
-
-    DT_INSTALLED = False
-
 
 # cudf
 try:

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -19,9 +19,9 @@ import scipy.sparse
 
 from .compat import (
     STRING_TYPES, DataFrame, MultiIndex, Int64Index, py_str,
-    PANDAS_INSTALLED, DataTable,
-    CUDF_INSTALLED, CUDF_DataFrame, CUDF_Series, CUDF_MultiIndex,
-    os_fspath, os_PathLike)
+    PANDAS_INSTALLED, CUDF_INSTALLED,
+    CUDF_DataFrame, CUDF_Series, CUDF_MultiIndex,
+    os_fspath, os_PathLike, lazy_isinstance)
 from .libpath import find_lib_path
 
 # c_bst_ulong corresponds to bst_ulong defined in xgboost/c_api.h
@@ -319,7 +319,8 @@ DT_TYPE_MAPPER2 = {'bool': 'i', 'int': 'int', 'real': 'float'}
 def _maybe_dt_data(data, feature_names, feature_types,
                    meta=None, meta_type=None):
     """Validate feature names and types if data table"""
-    if not isinstance(data, DataTable):
+    if (not lazy_isinstance(data, 'datatable', 'Frame') and
+            not lazy_isinstance(data, 'datatable', 'DataTable')):
         return data, feature_names, feature_types
 
     if meta and data.shape[1] > 1:
@@ -470,7 +471,7 @@ class DMatrix(object):
             self._init_from_csc(data)
         elif isinstance(data, np.ndarray):
             self._init_from_npy2d(data, missing, nthread)
-        elif isinstance(data, DataTable):
+        elif lazy_isinstance(data, 'datatable', 'Frame'):
             self._init_from_dt(data, nthread)
         elif hasattr(data, "__cuda_array_interface__"):
             self._init_from_array_interface(data, missing, nthread)

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -36,6 +36,11 @@ def captured_output():
 
 
 class TestBasic(unittest.TestCase):
+    def test_compat(self):
+        from xgboost.compat import lazy_isinstance
+        a = np.array([1, 2, 3])
+        assert lazy_isinstance(a, 'numpy', 'ndarray')
+        assert not lazy_isinstance(a, 'numpy', 'dataframe')
 
     def test_basic(self):
         dtrain = xgb.DMatrix(dpath + 'agaricus.txt.train')

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from xgboost.compat import SKLEARN_INSTALLED, PANDAS_INSTALLED, DT_INSTALLED
+from xgboost.compat import SKLEARN_INSTALLED, PANDAS_INSTALLED
 from xgboost.compat import CUDF_INSTALLED, DASK_INSTALLED
 
 
@@ -19,7 +19,9 @@ def no_pandas():
 
 
 def no_dt():
-    return {'condition': not DT_INSTALLED,
+    import importlib.util
+    spec = importlib.util.find_spec('datatable')
+    return {'condition': spec is None,
             'reason': 'Datatable is not installed.'}
 
 


### PR DESCRIPTION
I replaced explicit import for datatable with simple string.  The trick should also work with other packages.  But I'm keeping this PR to be minimum so that others can raise concerns around the new compatibility check.

Should close https://github.com/dmlc/xgboost/issues/5363 .  @brydag Could you please try this patch?  I can't reproduce it as there are some specific libraries in your dependencies that are using `sys.__stdin__`.

@RAMitchell  Just tried importing dask + datatable, it seems they still don't play well with each others.  But I don't think XGBoost is a good place to workaround the limitation.

@hcho3