### PR TITLE
[dask] Accept user defined tracker address.

### DIFF
--- a/demo/dask/cpu_training.py
+++ b/demo/dask/cpu_training.py
@@ -3,10 +3,12 @@ from xgboost.dask import DaskDMatrix
 from dask.distributed import Client
 from dask.distributed import LocalCluster
 from dask import array as da
+import logging
 
 
 def main(client):
     # generate some random data for demonstration
+    logging.basicConfig(level=logging.INFO)
     m = 100000
     n = 100
     X = da.random.random(size=(m, n), chunks=100)

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -226,7 +226,7 @@ Parameters for Tree Booster
     See tutorial for more information
 
 Additional parameters for `hist` and 'gpu_hist' tree method
-================================================
+===========================================================
 
 * ``single_precision_histogram``, [default=``false``]
 

--- a/doc/tutorials/saving_model.rst
+++ b/doc/tutorials/saving_model.rst
@@ -121,7 +121,7 @@ or in R:
 
 Will print out something similiar to (not actual output as it's too long for demonstration):
 
-.. code-block:: json
+.. code-block:: js
 
     {
       "Learner": {
@@ -201,7 +201,7 @@ Difference between saving model and dumping model
 XGBoost has a function called ``dump_model`` in Booster object, which lets you to export
 the model in a readable format like ``text``, ``json`` or ``dot`` (graphviz).  The primary
 use case for it is for model interpretation or visualization, and is not supposed to be
-loaded back to XGBoost.  The JSON version has a `schema
+loaded back to XGBoost.  The JSON version has a `Schema
 <https://github.com/dmlc/xgboost/blob/master/doc/dump.schema>`_.  See next section for
 more info.
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -34,6 +34,11 @@ from .tracker import RabitTracker
 from .sklearn import XGBModel, XGBRegressorBase, XGBClassifierBase
 from .sklearn import xgboost_model_doc
 
+try:
+    from distributed import Client
+except ImportError:
+    Client = None
+
 # Current status is considered as initial support, many features are
 # not properly supported yet.
 #
@@ -360,7 +365,7 @@ class DaskDMatrix:
             cols = c
         return (rows, cols)
 
-from distributed import Client
+
 def _get_rabit_args(worker_map, client: Client, host_ip=None, port=None):
     '''Get rabit context arguments from data distribution in DaskDMatrix.'''
     msg = 'Please provide both IP and port'


### PR DESCRIPTION
``` python
    output = xgb.dask.train(client,
                            {},
                            dtrain,
                            tracker_ip='127.0.0.1',
                            tracker_port=32809)
```