### PR TITLE
[dask] Use `DMLC_TASK_ID`.

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -69,6 +69,9 @@ class RabitContext:
     '''A context controling rabit initialization and finalization.'''
     def __init__(self, args):
         self.args = args
+        worker = distributed_get_worker()
+        self.args.append(
+            ('DMLC_TASK_ID=[xgboost.dask]:' + str(worker.address)).encode())
 
     def __enter__(self):
         rabit.init(self.args)


### PR DESCRIPTION
Used to make better logging in rabit.  Without this parameter, it would be:
```
task NULL got new rank 0
```