### PR TITLE
Better error message for updating.

### DIFF
--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -279,7 +279,9 @@ void GBTree::BoostNewTrees(HostDeviceVector<GradientPair>* gpair,
           << "can not be used to modify existing trees. "
           << "Set `process_type` to `default` if you want to build new trees.";
       }
-      CHECK_LT(model_.trees.size(), model_.trees_to_update.size());
+      CHECK_LT(model_.trees.size(), model_.trees_to_update.size())
+          << "No more tree left for updating.  For updating existing trees, "
+          << "boosting rounds can not exceed previous training rounds";
       // move an existing tree from trees_to_update
       auto t = std::move(model_.trees_to_update[model_.trees.size() +
                                                 bst_group * tparam_.num_parallel_tree + i]);


### PR DESCRIPTION
Closes https://github.com/dmlc/xgboost/issues/4700, specifically https://github.com/dmlc/xgboost/issues/4700#issuecomment-599041332 by @kevinkvothe .

Early stopping could reduce the number of built trees in training.  So using the same `boost_rounds` for updating might result in error.