### PR TITLE
Device dmatrix

### DIFF
--- a/python-package/xgboost/__init__.py
+++ b/python-package/xgboost/__init__.py
@@ -8,12 +8,13 @@ import os
 import sys
 import warnings
 
-from .core import DMatrix, Booster
+from .core import DMatrix, DeviceDMatrix, Booster
 from .training import train, cv
-from . import rabit                   # noqa
+from . import rabit  # noqa
 from . import tracker  # noqa
 from .tracker import RabitTracker  # noqa
 from . import dask
+
 try:
     from .sklearn import XGBModel, XGBClassifier, XGBRegressor, XGBRanker
     from .sklearn import XGBRFClassifier, XGBRFRegressor
@@ -31,7 +32,7 @@ VERSION_FILE = os.path.join(os.path.dirname(__file__), 'VERSION')
 with open(VERSION_FILE) as f:
     __version__ = f.read().strip()
 
-__all__ = ['DMatrix', 'Booster',
+__all__ = ['DMatrix', 'DeviceDMatrix', 'Booster',
            'train', 'cv',
            'RabitTracker',
            'XGBModel', 'XGBClassifier', 'XGBRegressor', 'XGBRanker',

--- a/python-package/xgboost/__init__.py
+++ b/python-package/xgboost/__init__.py
@@ -8,7 +8,7 @@ import os
 import sys
 import warnings
 
-from .core import DMatrix, DeviceDMatrix, Booster
+from .core import DMatrix, DeviceQuantileDMatrix, Booster
 from .training import train, cv
 from . import rabit  # noqa
 from . import tracker  # noqa
@@ -32,7 +32,7 @@ VERSION_FILE = os.path.join(os.path.dirname(__file__), 'VERSION')
 with open(VERSION_FILE) as f:
     __version__ = f.read().strip()
 
-__all__ = ['DMatrix', 'DeviceDMatrix', 'Booster',
+__all__ = ['DMatrix', 'DeviceQuantileDMatrix', 'Booster',
            'train', 'cv',
            'RabitTracker',
            'XGBModel', 'XGBClassifier', 'XGBRegressor', 'XGBRanker',

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1001,7 +1001,7 @@ class DMatrix(object):
         self._feature_types = feature_types
 
 
-class DeviceDMatrix(DMatrix):
+class DeviceQuantileDMatrix(DMatrix):
     """Device memory Data Matrix used in XGBoost.
 
     DMatrix is a internal data structure that used by XGBoost

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1002,10 +1002,13 @@ class DMatrix(object):
 
 
 class DeviceQuantileDMatrix(DMatrix):
-    """Device memory Data Matrix used in XGBoost.
+    """Device memory Data Matrix used in XGBoost for training with tree_method='gpu_hist'. Do not
+    use this for test/validation tasks as some information may be lost in quantisation. This
+    DMatrix is primarily designed to save memory in training and avoids intermediate steps,
+    directly creating a compressed representation for training without allocating additional
+    memory. Implementation does not currently consider weights in quantisation process(unlike
+    DMatrix).
 
-    DMatrix is a internal data structure that used by XGBoost
-    which is optimized for both memory efficiency and training speed.
     You can construct DeviceDMatrix from cupy/cudf
     """
 
@@ -1018,7 +1021,6 @@ class DeviceQuantileDMatrix(DMatrix):
         self.max_bin = max_bin
         if not (hasattr(data, "__cuda_array_interface__") or (
                 CUDF_INSTALLED and isinstance(data, CUDF_DataFrame))):
-            print(type(data))
             raise ValueError('Only cupy/cudf currently supported for DeviceDMatrix')
 
         super().__init__(data, label=label, weight=weight, base_margin=base_margin,

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1021,13 +1021,12 @@ class DeviceDMatrix(DMatrix):
             print(type(data))
             raise ValueError('Only cupy/cudf currently supported for DeviceDMatrix')
 
-
-        super().__init__(data,label=label,weight=weight, base_margin=base_margin,
-                 missing=missing,
-                 silent=silent,
-                 feature_names=feature_names,
-                 feature_types=feature_types,
-                 nthread=nthread)
+        super().__init__(data, label=label, weight=weight, base_margin=base_margin,
+                         missing=missing,
+                         silent=silent,
+                         feature_names=feature_names,
+                         feature_types=feature_types,
+                         nthread=nthread)
 
     def _init_from_array_interface(self, data, missing, nthread):
         """Initialize DMatrix from cupy ndarray."""

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1006,8 +1006,28 @@ class DeviceDMatrix(DMatrix):
 
     DMatrix is a internal data structure that used by XGBoost
     which is optimized for both memory efficiency and training speed.
-    You can construct DeviceDMatrix from cupy/cu.f
+    You can construct DeviceDMatrix from cupy/cudf
     """
+
+    def __init__(self, data, label=None, weight=None, base_margin=None,
+                 missing=None,
+                 silent=False,
+                 feature_names=None,
+                 feature_types=None,
+                 nthread=None):
+
+        if not (hasattr(data, "__cuda_array_interface__") or (
+                CUDF_INSTALLED and isinstance(data, CUDF_DataFrame))):
+            print(type(data))
+            raise ValueError('Only cupy/cudf currently supported for DeviceDMatrix')
+
+
+        super().__init__(data,label=label,weight=weight, base_margin=base_margin,
+                 missing=missing,
+                 silent=silent,
+                 feature_names=feature_names,
+                 feature_types=feature_types,
+                 nthread=nthread)
 
     def _init_from_array_interface(self, data, missing, nthread):
         """Initialize DMatrix from cupy ndarray."""

--- a/src/c_api/c_api.cu
+++ b/src/c_api/c_api.cu
@@ -31,25 +31,24 @@ XGB_DLL int XGDMatrixCreateFromArrayInterface(char const* c_json_strs,
   API_END();
 }
 
-XGB_DLL int XGDeviceDMatrixCreateFromArrayInterfaceColumns(char const* c_json_strs,
-  bst_float missing,
-  int nthread,
+XGB_DLL int XGDeviceQuantileDMatrixCreateFromArrayInterfaceColumns(char const* c_json_strs,
+  bst_float missing, int nthread, int max_bin,
   DMatrixHandle* out) {
   API_BEGIN();
   std::string json_str{c_json_strs};
   data::CudfAdapter adapter(json_str);
   *out =
-    new std::shared_ptr<DMatrix>(new data::DeviceDMatrix(&adapter, missing, nthread));
+    new std::shared_ptr<DMatrix>(new data::DeviceDMatrix(&adapter, missing, nthread, max_bin));
   API_END();
 }
 
-XGB_DLL int XGDeviceDMatrixCreateFromArrayInterface(char const* c_json_strs,
-  bst_float missing, int nthread,
+XGB_DLL int XGDeviceQuantileDMatrixCreateFromArrayInterface(char const* c_json_strs,
+  bst_float missing, int nthread, int max_bin,
   DMatrixHandle* out) {
   API_BEGIN();
   std::string json_str{c_json_strs};
   data::CupyAdapter adapter(json_str);
   *out =
-    new std::shared_ptr<DMatrix>(new data::DeviceDMatrix(&adapter, missing, nthread));
+    new std::shared_ptr<DMatrix>(new data::DeviceDMatrix(&adapter, missing, nthread, max_bin));
   API_END();
 }

--- a/src/c_api/c_api.cu
+++ b/src/c_api/c_api.cu
@@ -4,6 +4,7 @@
 #include "xgboost/learner.h"
 #include "c_api_error.h"
 #include "../data/device_adapter.cuh"
+#include "../data/device_dmatrix.h"
 
 using namespace xgboost;  // NOLINT
 
@@ -27,5 +28,28 @@ XGB_DLL int XGDMatrixCreateFromArrayInterface(char const* c_json_strs,
   data::CupyAdapter adapter(json_str);
   *out =
       new std::shared_ptr<DMatrix>(DMatrix::Create(&adapter, missing, nthread));
+  API_END();
+}
+
+XGB_DLL int XGDeviceDMatrixCreateFromArrayInterfaceColumns(char const* c_json_strs,
+  bst_float missing,
+  int nthread,
+  DMatrixHandle* out) {
+  API_BEGIN();
+  std::string json_str{c_json_strs};
+  data::CudfAdapter adapter(json_str);
+  *out =
+    new std::shared_ptr<DMatrix>(new data::DeviceDMatrix(&adapter, missing, nthread));
+  API_END();
+}
+
+XGB_DLL int XGDeviceDMatrixCreateFromArrayInterface(char const* c_json_strs,
+  bst_float missing, int nthread,
+  DMatrixHandle* out) {
+  API_BEGIN();
+  std::string json_str{c_json_strs};
+  data::CupyAdapter adapter(json_str);
+  *out =
+    new std::shared_ptr<DMatrix>(new data::DeviceDMatrix(&adapter, missing, nthread));
   API_END();
 }

--- a/src/common/compressed_iterator.h
+++ b/src/common/compressed_iterator.h
@@ -32,8 +32,8 @@ static const int kPadding = 4;  // Assign padding so we can read slightly off
                                // the beginning of the array
 
 // The number of bits required to represent a given unsigned range
-static size_t SymbolBits(size_t num_symbols) {
-  auto bits = std::ceil(std::log2(num_symbols));
+inline XGBOOST_DEVICE size_t SymbolBits(size_t num_symbols) {
+  auto bits = std::ceil(log2(double(num_symbols)));
   return std::max(static_cast<size_t>(bits), size_t(1));
 }
 }  // namespace detail
@@ -50,13 +50,10 @@ static size_t SymbolBits(size_t num_symbols) {
  */
 
 class CompressedBufferWriter {
- private:
   size_t symbol_bits_;
-  size_t offset_;
 
  public:
-  explicit CompressedBufferWriter(size_t num_symbols) : offset_(0) {
-    symbol_bits_ = detail::SymbolBits(num_symbols);
+  XGBOOST_DEVICE explicit CompressedBufferWriter(size_t num_symbols):symbol_bits_(detail::SymbolBits(num_symbols))  {
   }
 
   /**
@@ -159,18 +156,15 @@ class CompressedBufferWriter {
   }
 };
 
-template <typename T>
-
 /**
- * \class CompressedIterator
- *
- * \brief Read symbols from a bit compressed memory buffer. Usable on device and
- * host.
+ * \brief Read symbols from a bit compressed memory buffer. Usable on device and host.
  *
  * \author  Rory
  * \date  7/9/2017
+ *
+ * \tparam  T Generic type parameter.
  */
-
+template <typename T>
 class CompressedIterator {
  public:
   // Type definitions for thrust

--- a/src/common/compressed_iterator.h
+++ b/src/common/compressed_iterator.h
@@ -33,7 +33,7 @@ static const int kPadding = 4;  // Assign padding so we can read slightly off
 
 // The number of bits required to represent a given unsigned range
 inline XGBOOST_DEVICE size_t SymbolBits(size_t num_symbols) {
-  auto bits = std::ceil(log2(double(num_symbols)));
+  auto bits = std::ceil(log2(static_cast<double>(num_symbols)));
   return std::max(static_cast<size_t>(bits), size_t(1));
 }
 }  // namespace detail
@@ -53,8 +53,8 @@ class CompressedBufferWriter {
   size_t symbol_bits_;
 
  public:
-  XGBOOST_DEVICE explicit CompressedBufferWriter(size_t num_symbols):symbol_bits_(detail::SymbolBits(num_symbols))  {
-  }
+  XGBOOST_DEVICE explicit CompressedBufferWriter(size_t num_symbols)
+      : symbol_bits_(detail::SymbolBits(num_symbols)) {}
 
   /**
    * \fn  static size_t CompressedBufferWriter::CalculateBufferSize(int

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -1540,4 +1540,12 @@ DEV_INLINE void AtomicAddGpair(OutputGradientT* dest,
             static_cast<typename OutputGradientT::ValueT>(gpair.GetHess()));
 }
 
+
+// Thrust version of this function causes error on Windows
+template <typename ReturnT, typename IterT, typename FuncT>
+thrust::transform_iterator<FuncT, IterT, ReturnT> MakeTransformIterator(
+  IterT iter, FuncT func) {
+  return thrust::transform_iterator<FuncT, IterT, ReturnT>(iter, func);
+}
+
 }  // namespace dh

--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -356,13 +356,6 @@ struct IsValidFunctor : public thrust::unary_function<Entry, bool> {
   }
 };
 
-// Thrust version of this function causes error on Windows
-template <typename ReturnT, typename IterT, typename FuncT>
-thrust::transform_iterator<FuncT, IterT, ReturnT> MakeTransformIterator(
-  IterT iter, FuncT func) {
-  return thrust::transform_iterator<FuncT, IterT, ReturnT>(iter, func);
-}
-
 template <typename AdapterT>
 void ProcessBatch(AdapterT* adapter, size_t begin, size_t end, float missing,
                   SketchContainer* sketch_container, int num_cuts) {
@@ -372,10 +365,10 @@ void ProcessBatch(AdapterT* adapter, size_t begin, size_t end, float missing,
   auto &batch = adapter->Value();
   // Enforce single batch
   CHECK(!adapter->Next());
-  auto batch_iter = MakeTransformIterator<data::COOTuple>(
+  auto batch_iter = dh::MakeTransformIterator<data::COOTuple>(
     thrust::make_counting_iterator(0llu),
     [=] __device__(size_t idx) { return batch.GetElement(idx); });
-  auto entry_iter = MakeTransformIterator<Entry>(
+  auto entry_iter = dh::MakeTransformIterator<Entry>(
       thrust::make_counting_iterator(0llu), [=] __device__(size_t idx) {
         return Entry(batch.GetElement(idx).column_idx,
                      batch.GetElement(idx).value);

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -105,10 +105,10 @@ class HistogramCuts {
     auto end = cut_ptrs_.ConstHostVector().at(column_id + 1);
     const auto &values = cut_values_.ConstHostVector();
     auto it = std::upper_bound(values.cbegin() + beg, values.cbegin() + end, value);
-    if (it == values.cend()) {
-      it = values.cend() - 1;
-    }
     BinIdx idx = it - values.cbegin();
+    if (idx == end) {
+      idx -= 1;
+    }
     return idx;
   }
 

--- a/src/data/data.cu
+++ b/src/data/data.cu
@@ -10,7 +10,7 @@
 #include "array_interface.h"
 #include "../common/device_helpers.cuh"
 #include "device_adapter.cuh"
-#include "simple_dmatrix.h"
+#include "device_dmatrix.h"
 
 namespace xgboost {
 
@@ -75,7 +75,7 @@ DMatrix* DMatrix::Create(AdapterT* adapter, float missing, int nthread,
   CHECK_EQ(cache_prefix.size(), 0)
       << "Device memory construction is not currently supported with external "
          "memory.";
-  return new data::SimpleDMatrix(adapter, missing, nthread);
+  return new data::DeviceDMatrix(adapter, missing, nthread);
 }
 
 template DMatrix* DMatrix::Create<data::CudfAdapter>(

--- a/src/data/data.cu
+++ b/src/data/data.cu
@@ -75,7 +75,7 @@ DMatrix* DMatrix::Create(AdapterT* adapter, float missing, int nthread,
   CHECK_EQ(cache_prefix.size(), 0)
       << "Device memory construction is not currently supported with external "
          "memory.";
-  return new data::DeviceDMatrix(adapter, missing, nthread);
+  return new data::SimpleDMatrix(adapter, missing, nthread);
 }
 
 template DMatrix* DMatrix::Create<data::CudfAdapter>(

--- a/src/data/device_adapter.cuh
+++ b/src/data/device_adapter.cuh
@@ -8,11 +8,30 @@
 #include <memory>
 #include <string>
 #include "../common/device_helpers.cuh"
+#include "../common/math.h"
 #include "adapter.h"
 #include "array_interface.h"
 
 namespace xgboost {
 namespace data {
+
+struct IsValidFunctor : public thrust::unary_function<Entry, bool> {
+  explicit IsValidFunctor(float missing) : missing(missing) {}
+
+  float missing;
+  __device__ bool operator()(const data::COOTuple& e) const {
+    if (common::CheckNAN(e.value) || e.value == missing) {
+      return false;
+    }
+    return true;
+  }
+  __device__ bool operator()(const Entry& e) const {
+    if (common::CheckNAN(e.fvalue) || e.fvalue == missing) {
+      return false;
+    }
+    return true;
+  }
+};
 
 class CudfAdapterBatch : public detail::NoMetaInfo {
  public:

--- a/src/data/device_dmatrix.cu
+++ b/src/data/device_dmatrix.cu
@@ -12,7 +12,6 @@
 #include <memory>
 #include <utility>
 #include "../common/hist_util.h"
-#include "../common/math.h"
 #include "adapter.h"
 #include "device_adapter.cuh"
 #include "ellpack_page.cuh"
@@ -20,18 +19,6 @@
 
 namespace xgboost {
 namespace data {
-
-struct IsValidFunctor : public thrust::unary_function<Entry, bool> {
-  explicit IsValidFunctor(float missing) : missing(missing) {}
-
-  float missing;
-  __device__ bool operator()(const data::COOTuple& e) const {
-    if (common::CheckNAN(e.value) || e.value == missing) {
-      return false;
-    }
-    return true;
-  }
-};
 
 // Returns maximum row length
 template <typename AdapterBatchT>

--- a/src/data/device_dmatrix.cu
+++ b/src/data/device_dmatrix.cu
@@ -8,11 +8,15 @@
 #include <xgboost/data.h>
 
 #include <memory>
+#include <thrust/execution_policy.h>
 
+#include <thrust/iterator/transform_output_iterator.h>
+#include <thrust/iterator/discard_iterator.h>
 #include "adapter.h"
 #include "simple_dmatrix.h"
 #include "device_dmatrix.h"
 #include "device_adapter.cuh"
+#include "ellpack_page.cuh"
 #include "../common/hist_util.h"
 #include "../common/math.h"
 
@@ -35,67 +39,213 @@ struct IsValidFunctor : public thrust::unary_function<Entry, bool> {
 template <typename AdapterBatchT>
 size_t CountRowOffsets(const AdapterBatchT& batch, common::Span<size_t> offset,
                      int device_idx, float missing) {
+  IsValidFunctor is_valid(missing);
   // Count elements per row
   dh::LaunchN(device_idx, batch.Size(), [=] __device__(size_t idx) {
     auto element = batch.GetElement(idx);
-    if (IsValid(element.value, missing)) {
+    if (is_valid(element)) {
       atomicAdd(reinterpret_cast<unsigned long long*>(  // NOLINT
                     &offset[element.row_idx]),
                 static_cast<unsigned long long>(1));  // NOLINT
     }
   });
-  size_t row_stride = thrust::reduce(dh::tbegin(offset), dh::tend(offset), thrust::maximum <size_t >());
-
   dh::XGBCachingDeviceAllocator<char> alloc;
+  size_t row_stride = thrust::reduce(
+      thrust::cuda::par(alloc), thrust::device_pointer_cast(offset.data()),
+      thrust::device_pointer_cast(offset.data()) + offset.size(),
+                     size_t(0),
+                     thrust::maximum<size_t>());
+
   thrust::exclusive_scan(thrust::cuda::par(alloc),
       thrust::device_pointer_cast(offset.data()),
       thrust::device_pointer_cast(offset.data() + offset.size()),
       thrust::device_pointer_cast(offset.data()));
   return row_stride;
 }
+template <typename FunctionT>
+class LauncherItr {
+public:
+  int idx;
+  XGBOOST_DEVICE LauncherItr() : idx(0) {}
+  XGBOOST_DEVICE LauncherItr(int idx) : idx(idx){}
+  XGBOOST_DEVICE LauncherItr &operator=(int output) {
+    FunctionT f;
+    f(idx, output);
+    return *this;
+  }
+};
+
+/**
+* \brief Thrust compatible iterator type - discards algorithm output and launches device lambda
+*        with the index of the output and the algorithm output as arguments.
+*
+* \author  Rory
+* \date  7/9/2017
+*
+* \tparam  FunctionT Type of the function t.
+*/
+template <typename FunctionT>
+class DiscardLambdaItr {
+public:
+  // Required iterator traits
+  using self_type = DiscardLambdaItr<FunctionT>;  // NOLINT
+  using difference_type = ptrdiff_t;   // NOLINT
+  using value_type = void;       // NOLINT
+  using pointer = value_type *;  // NOLINT
+  using reference = LauncherItr<FunctionT>;  // NOLINT
+  using iterator_category = typename thrust::detail::iterator_facade_category<
+    thrust::any_system_tag, thrust::random_access_traversal_tag, value_type,
+    reference>::type;  // NOLINT
+private:
+  difference_type offset_;
+public:
+  XGBOOST_DEVICE explicit DiscardLambdaItr() : offset_(0){}
+  XGBOOST_DEVICE explicit DiscardLambdaItr(size_t offset) : offset_(offset){}
+  XGBOOST_DEVICE self_type operator+(const int &b) const {
+    return self_type(offset_ + b);
+  }
+  XGBOOST_DEVICE self_type operator++() {
+    offset_++;
+    return *this;
+  }
+  XGBOOST_DEVICE self_type operator++(int) {
+    self_type retval = *this;
+    offset_++;
+    return retval;
+  }
+  XGBOOST_DEVICE self_type &operator+=(const int &b) {
+    offset_ += b;
+    return *this;
+  }
+  XGBOOST_DEVICE reference operator*() const {
+    return LauncherItr<FunctionT>(offset_);
+  }
+  XGBOOST_DEVICE reference operator[](int idx) {
+    self_type offset = (*this) + idx;
+    return *offset;
+  }
+};
+
+  template <typename AdapterBatchT>
+struct WriteCompressedEllpackFunctor
+{
+  WriteCompressedEllpackFunctor(common::CompressedByteT* buffer,
+    const common::CompressedBufferWriter& writer, const AdapterBatchT& batch,const EllpackDeviceAccessor& accessor,const IsValidFunctor&is_valid)
+    :
+      d_buffer(buffer),
+      writer(writer),
+      batch(batch),accessor(accessor),is_valid(is_valid)
+  {
+  }
+
+  common::CompressedByteT* d_buffer;
+  common::CompressedBufferWriter writer;
+  AdapterBatchT batch;
+  EllpackDeviceAccessor accessor;
+  IsValidFunctor is_valid;
+
+  using Tuple = thrust::tuple<size_t, size_t, size_t>;
+  __device__ size_t operator()(Tuple  out)
+  {
+    auto e = batch.GetElement(out.get<2>());
+    if (is_valid(e)) {
+      size_t output_position = accessor.row_stride * e.row_idx + out.get<1>() - 1;
+      auto bin_idx = accessor.SearchBin(e.value, e.column_idx);
+      writer.AtomicWriteSymbol(d_buffer, bin_idx, output_position);
+    }
+    return 0;
+    
+  }
+};
 
 // Here the data is already correctly ordered and simply needs to be compacted
 // to remove missing data
 template <typename AdapterBatchT>
 void CopyDataRowMajor(const AdapterBatchT& batch, EllpackPageImpl*dst,
-                      int device_idx, float missing,
-                      common::Span<size_t> row_ptr) {
-  auto transform_f = [=] __device__(size_t idx) {
-    const auto& e = batch.GetElement(idx);
-    return Entry(e.column_idx, e.value);
-  };  // NOLINT
+                      int device_idx, float missing) {
   auto counting = thrust::make_counting_iterator(0llu);
-  thrust::transform_iterator<decltype(transform_f), decltype(counting), Entry>
-      transform_iter(counting, transform_f);
+  IsValidFunctor is_valid(missing);
+  auto key_iter = dh::MakeTransformIterator<size_t >(counting,[=]__device__ (size_t idx)
+  {
+    return batch.GetElement(idx).row_idx;
+  });
+  auto value_iter = dh::MakeTransformIterator<size_t>(
+      counting,
+      [=]__device__ (size_t idx) -> size_t 
+  {
+    return is_valid(batch.GetElement(idx));
+  });
+
+  auto key_value_index_iter = thrust::make_zip_iterator(thrust::make_tuple(key_iter, value_iter, counting));
+  using Tuple = thrust::tuple<size_t , size_t , size_t >;
+
+  auto device_accessor = dst->GetDeviceAccessor(device_idx);
+  common::CompressedBufferWriter writer(device_accessor.NumSymbols());
+  auto d_compressed_buffer = dst->gidx_buffer.DevicePointer();
+
+  WriteCompressedEllpackFunctor<AdapterBatchT> functor(d_compressed_buffer, writer,
+                                        batch, device_accessor, is_valid);
+  thrust::discard_iterator<size_t> discard;
+  thrust::transform_output_iterator<
+      WriteCompressedEllpackFunctor<AdapterBatchT>, decltype(discard)>
+      out(discard, functor);
   dh::XGBCachingDeviceAllocator<char> alloc;
-  thrust::copy_if(
-      thrust::cuda::par(alloc), transform_iter, transform_iter + batch.Size(),
-      thrust::device_pointer_cast(data.data()), IsValidFunctor(missing));
+  thrust::inclusive_scan(
+      thrust::cuda::par(alloc), key_value_index_iter, key_value_index_iter + batch.Size(), out,
+                         [=] __device__(Tuple a, Tuple b) {
+                           // Key equal
+                           if (a.get<0>() == b.get<0>()) {
+                             b.get<1>() += a.get<1>();
+                             return b;
+                           }
+                           // Not equal
+                           return b;
+                         });
 }
 
+//void RedirectScan() {
+//  int n = 5;
+//  thrust::device_vector<int> x(n, 2);
+//  auto counting = thrust::make_counting_iterator(0llu);
+//  using Tuple = thrust::tuple<size_t , size_t >;
+//  auto zip = thrust::make_zip_iterator(thrust::make_tuple(x.begin(), counting));
+//  thrust::discard_iterator<int > discard;
+//  thrust::transform_output_iterator<Functor,decltype(discard)> out(discard,Functor());
+//  thrust::inclusive_scan(thrust::device, zip, zip + x.size(), out,[=]__device__ (Tuple a ,Tuple b)
+//  {
+//    b.get<0>() +=a.get<0>();
+//    //b.get<1>() = b.get<1>() + 1;
+//    return b;
+//  });
+//}
+//
 // Does not currently support metainfo as no on-device data source contains this
 // Current implementation assumes a single batch. More batches can
 // be supported in future. Does not currently support inferring row/column size
   template <typename AdapterT>
 DeviceDMatrix::DeviceDMatrix(AdapterT* adapter, float missing, int nthread) {
+  //RedirectScan();
   common::HistogramCuts cuts = common::AdapterDeviceSketch(adapter, 256, missing);
   auto & batch = adapter->Value();
   // Work out how many valid entries we have in each row
   dh::caching_device_vector<size_t> row_ptr(adapter->NumRows() + 1,
                                                       0);
   common::Span<size_t > row_ptr_span( row_ptr.data().get(),row_ptr.size() );
-  size_t row_stride=CountRowOffsets(batch, row_ptr_span, adapter->DeviceIdx(), missing);
+  // TODO: are these offsets actually needed? or just the stride
+  size_t row_stride =
+      CountRowOffsets(batch, row_ptr_span, adapter->DeviceIdx(), missing);
 
   info.num_nonzero_ = row_ptr.back();// Device to host copy
   info.num_col_ = adapter->NumColumns();
   info.num_row_ = adapter->NumRows();
   ellpack_page_.reset(new EllpackPage());
-  auto impl = ellpack_page_->Impl(adapter->DeviceIdx(),cuts,this->IsDense(),row_stride, adapter->NumRows());
+  *ellpack_page_->Impl() =
+      EllpackPageImpl(adapter->DeviceIdx(), cuts, this->IsDense(), row_stride,
+                      adapter->NumRows());
   if (adapter->IsRowMajor()) {
-    CopyDataRowMajor(batch, impl, adapter->DeviceIdx(), row_ptr_span);
+    CopyDataRowMajor(batch, ellpack_page_->Impl(), adapter->DeviceIdx(), missing);
   }
 
-  //*impl = EllpackPageImpl(adapter->DeviceIdx(),cuts ,info.num_nonzero_==info.num_col_*info.num_row_,,info.num_row_);
   // Synchronise worker columns
   rabit::Allreduce<rabit::op::Max>(&info.num_col_, 1);
 }

--- a/src/data/device_dmatrix.cu
+++ b/src/data/device_dmatrix.cu
@@ -4,20 +4,19 @@
  * \brief Device-memory version of DMatrix.
  */
 
+#include <thrust/execution_policy.h>
+#include <thrust/iterator/discard_iterator.h>
+#include <thrust/iterator/transform_output_iterator.h>
 #include <xgboost/base.h>
 #include <xgboost/data.h>
-
 #include <memory>
-#include <thrust/execution_policy.h>
-
-#include <thrust/iterator/transform_output_iterator.h>
-#include <thrust/iterator/discard_iterator.h>
-#include "adapter.h"
-#include "device_dmatrix.h"
-#include "device_adapter.cuh"
-#include "ellpack_page.cuh"
+#include <utility>
 #include "../common/hist_util.h"
 #include "../common/math.h"
+#include "adapter.h"
+#include "device_adapter.cuh"
+#include "ellpack_page.cuh"
+#include "device_dmatrix.h"
 
 namespace xgboost {
 namespace data {
@@ -37,7 +36,7 @@ struct IsValidFunctor : public thrust::unary_function<Entry, bool> {
 // Returns maximum row length
 template <typename AdapterBatchT>
 size_t GetRowCounts(const AdapterBatchT& batch, common::Span<size_t> offset,
-                     int device_idx, float missing) {
+                    int device_idx, float missing) {
   IsValidFunctor is_valid(missing);
   // Count elements per row
   dh::LaunchN(device_idx, batch.Size(), [=] __device__(size_t idx) {
@@ -51,23 +50,23 @@ size_t GetRowCounts(const AdapterBatchT& batch, common::Span<size_t> offset,
   dh::XGBCachingDeviceAllocator<char> alloc;
   size_t row_stride = thrust::reduce(
       thrust::cuda::par(alloc), thrust::device_pointer_cast(offset.data()),
-      thrust::device_pointer_cast(offset.data()) + offset.size(),
-                     size_t(0),
-                     thrust::maximum<size_t>());
+      thrust::device_pointer_cast(offset.data()) + offset.size(), size_t(0),
+      thrust::maximum<size_t>());
   return row_stride;
 }
 
-  template <typename AdapterBatchT>
-struct WriteCompressedEllpackFunctor
-{
+template <typename AdapterBatchT>
+struct WriteCompressedEllpackFunctor {
   WriteCompressedEllpackFunctor(common::CompressedByteT* buffer,
-    const common::CompressedBufferWriter& writer, const AdapterBatchT& batch,const EllpackDeviceAccessor& accessor,const IsValidFunctor&is_valid)
-    :
-      d_buffer(buffer),
-      writer(writer),
-      batch(batch),accessor(accessor),is_valid(is_valid)
-  {
-  }
+                                const common::CompressedBufferWriter& writer,
+                                const AdapterBatchT& batch,
+                                EllpackDeviceAccessor accessor,
+                                const IsValidFunctor& is_valid)
+      : d_buffer(buffer),
+        writer(writer),
+        batch(batch),
+        accessor(std::move(accessor)),
+        is_valid(is_valid) {}
 
   common::CompressedByteT* d_buffer;
   common::CompressedBufferWriter writer;
@@ -76,55 +75,57 @@ struct WriteCompressedEllpackFunctor
   IsValidFunctor is_valid;
 
   using Tuple = thrust::tuple<size_t, size_t, size_t>;
-  __device__ size_t operator()(Tuple  out)
-  {
+  __device__ size_t operator()(Tuple out) {
     auto e = batch.GetElement(out.get<2>());
     if (is_valid(e)) {
       // -1 because the scan is inclusive
-      size_t output_position = accessor.row_stride * e.row_idx + out.get<1>() - 1; 
+      size_t output_position =
+          accessor.row_stride * e.row_idx + out.get<1>() - 1;
       auto bin_idx = accessor.SearchBin(e.value, e.column_idx);
       writer.AtomicWriteSymbol(d_buffer, bin_idx, output_position);
     }
     return 0;
-    
   }
 };
 
 // Here the data is already correctly ordered and simply needs to be compacted
 // to remove missing data
 template <typename AdapterBatchT>
-void CopyDataRowMajor(const AdapterBatchT& batch, EllpackPageImpl*dst,
-                      int device_idx, float missing,common::Span<size_t> row_counts) {
+void CopyDataRowMajor(const AdapterBatchT& batch, EllpackPageImpl* dst,
+                      int device_idx, float missing,
+                      common::Span<size_t> row_counts) {
   // Some witchcraft happens here
-  // The goal is to copy valid elements out of the input to an ellpack matrix with a given row stride, using no extra working memory
-  // Standard stream compaction needs to be modified to do this, so we manually define a segmented stream compaction via operators on an inclusive scan. The output of this inclusive scan is fed to a custom function which works out the correct output position
+  // The goal is to copy valid elements out of the input to an ellpack matrix
+  // with a given row stride, using no extra working memory Standard stream
+  // compaction needs to be modified to do this, so we manually define a
+  // segmented stream compaction via operators on an inclusive scan. The output
+  // of this inclusive scan is fed to a custom function which works out the
+  // correct output position
   auto counting = thrust::make_counting_iterator(0llu);
   IsValidFunctor is_valid(missing);
-  auto key_iter = dh::MakeTransformIterator<size_t >(counting,[=]__device__ (size_t idx)
-  {
-    return batch.GetElement(idx).row_idx;
-  });
-  auto value_iter = dh::MakeTransformIterator<size_t>(
+  auto key_iter = dh::MakeTransformIterator<size_t>(
       counting,
-      [=]__device__ (size_t idx) -> size_t 
-  {
-    return is_valid(batch.GetElement(idx));
-  });
+      [=] __device__(size_t idx) { return batch.GetElement(idx).row_idx; });
+  auto value_iter = dh::MakeTransformIterator<size_t>(
+      counting, [=] __device__(size_t idx) -> size_t {
+        return is_valid(batch.GetElement(idx));
+      });
 
-  auto key_value_index_iter = thrust::make_zip_iterator(thrust::make_tuple(key_iter, value_iter, counting));
+  auto key_value_index_iter = thrust::make_zip_iterator(
+      thrust::make_tuple(key_iter, value_iter, counting));
 
   // Tuple[0] = The row index of the input, used as a key to define segments
   // Tuple[1] = Scanned flags of valid elements for each row
   // Tuple[2] = The index in the input data
-  using Tuple = thrust::tuple<size_t , size_t , size_t >;
+  using Tuple = thrust::tuple<size_t, size_t, size_t>;
 
   auto device_accessor = dst->GetDeviceAccessor(device_idx);
   common::CompressedBufferWriter writer(device_accessor.NumSymbols());
   auto d_compressed_buffer = dst->gidx_buffer.DevicePointer();
 
   // We redirect the scan output into this functor to do the actual writing
-  WriteCompressedEllpackFunctor<AdapterBatchT> functor(d_compressed_buffer, writer,
-                                        batch, device_accessor, is_valid);
+  WriteCompressedEllpackFunctor<AdapterBatchT> functor(
+      d_compressed_buffer, writer, batch, device_accessor, is_valid);
   thrust::discard_iterator<size_t> discard;
   thrust::transform_output_iterator<
       WriteCompressedEllpackFunctor<AdapterBatchT>, decltype(discard)>
@@ -153,8 +154,8 @@ void CopyDataColumnMajor(AdapterT* adapter, const AdapterBatchT& batch,
   dh::LaunchN(adapter->DeviceIdx(), batch.Size(), [=] __device__(size_t idx) {
     const auto& e = batch.GetElement(idx);
     atomicAdd(reinterpret_cast<unsigned long long*>(  // NOLINT
-      &d_column_sizes[e.column_idx]),
-      static_cast<unsigned long long>(1));  // NOLINT
+                  &d_column_sizes[e.column_idx]),
+              static_cast<unsigned long long>(1));  // NOLINT
   });
 
   thrust::host_vector<size_t> host_column_sizes = column_sizes;
@@ -173,12 +174,14 @@ void CopyDataColumnMajor(AdapterT* adapter, const AdapterBatchT& batch,
     size_t end = begin + size;
     dh::LaunchN(adapter->DeviceIdx(), end - begin, [=] __device__(size_t idx) {
       auto writer_non_const =
-        writer;  // For some reason this variable gets captured as const 
+          writer;  // For some reason this variable gets captured as const
       const auto& e = batch.GetElement(idx + begin);
       if (!is_valid(e)) return;
-      size_t output_position = e.row_idx * row_stride + d_temp_row_ptr[e.row_idx];
+      size_t output_position =
+          e.row_idx * row_stride + d_temp_row_ptr[e.row_idx];
       auto bin_idx = device_accessor.SearchBin(e.value, e.column_idx);
-      writer_non_const.AtomicWriteSymbol(d_compressed_buffer, bin_idx, output_position);
+      writer_non_const.AtomicWriteSymbol(d_compressed_buffer, bin_idx,
+                                         output_position);
       d_temp_row_ptr[e.row_idx] += 1;
     });
 
@@ -186,46 +189,42 @@ void CopyDataColumnMajor(AdapterT* adapter, const AdapterBatchT& batch,
   }
 }
 
-void WriteNullValues(EllpackPageImpl*dst,
-                      int device_idx, common::Span<size_t> row_counts)
-{
-   // Write the null values
+void WriteNullValues(EllpackPageImpl* dst, int device_idx,
+                     common::Span<size_t> row_counts) {
+  // Write the null values
   auto device_accessor = dst->GetDeviceAccessor(device_idx);
   common::CompressedBufferWriter writer(device_accessor.NumSymbols());
   auto d_compressed_buffer = dst->gidx_buffer.DevicePointer();
   auto row_stride = dst->row_stride;
-  dh::LaunchN(device_idx, row_stride * dst->n_rows, [=] __device__(size_t idx)
-  {
+  dh::LaunchN(device_idx, row_stride * dst->n_rows, [=] __device__(size_t idx) {
     auto writer_non_const =
-        writer;  // For some reason this variable gets captured as const 
+        writer;  // For some reason this variable gets captured as const
     size_t row_idx = idx / row_stride;
     size_t row_offset = idx % row_stride;
-    if (row_offset >= row_counts[row_idx])
-    {
+    if (row_offset >= row_counts[row_idx]) {
       writer_non_const.AtomicWriteSymbol(d_compressed_buffer,
                                          device_accessor.NullValue(), idx);
     }
   });
-
-} 
+}
 // Does not currently support metainfo as no on-device data source contains this
 // Current implementation assumes a single batch. More batches can
 // be supported in future. Does not currently support inferring row/column size
-  template <typename AdapterT>
+template <typename AdapterT>
 DeviceDMatrix::DeviceDMatrix(AdapterT* adapter, float missing, int nthread) {
-  common::HistogramCuts cuts = common::AdapterDeviceSketch(adapter, 256, missing);
-  auto & batch = adapter->Value();
+  common::HistogramCuts cuts =
+      common::AdapterDeviceSketch(adapter, 256, missing);
+  auto& batch = adapter->Value();
   // Work out how many valid entries we have in each row
-  dh::caching_device_vector<size_t> row_counts(adapter->NumRows() + 1,
-                                                      0);
-  common::Span<size_t > row_counts_span( row_counts.data().get(),row_counts.size() );
+  dh::caching_device_vector<size_t> row_counts(adapter->NumRows() + 1, 0);
+  common::Span<size_t> row_counts_span(row_counts.data().get(),
+                                       row_counts.size());
   size_t row_stride =
       GetRowCounts(batch, row_counts_span, adapter->DeviceIdx(), missing);
 
   dh::XGBCachingDeviceAllocator<char> alloc;
   info.num_nonzero_ = thrust::reduce(thrust::cuda::par(alloc),
-                                     row_counts.begin(),
-                                     row_counts.end());
+                                     row_counts.begin(), row_counts.end());
   info.num_col_ = adapter->NumColumns();
   info.num_row_ = adapter->NumRows();
   ellpack_page_.reset(new EllpackPage());
@@ -239,8 +238,7 @@ DeviceDMatrix::DeviceDMatrix(AdapterT* adapter, float missing, int nthread) {
     CopyDataColumnMajor(adapter, batch, ellpack_page_->Impl(), missing);
   }
 
-  WriteNullValues(ellpack_page_->Impl(), adapter->DeviceIdx(),
-    row_counts_span);
+  WriteNullValues(ellpack_page_->Impl(), adapter->DeviceIdx(), row_counts_span);
 
   // Synchronise worker columns
   rabit::Allreduce<rabit::op::Max>(&info.num_col_, 1);

--- a/src/data/device_dmatrix.cu
+++ b/src/data/device_dmatrix.cu
@@ -92,8 +92,7 @@ struct WriteCompressedEllpackFunctor {
 // to remove missing data
 template <typename AdapterBatchT>
 void CopyDataRowMajor(const AdapterBatchT& batch, EllpackPageImpl* dst,
-                      int device_idx, float missing,
-                      common::Span<size_t> row_counts) {
+                      int device_idx, float missing) {
   // Some witchcraft happens here
   // The goal is to copy valid elements out of the input to an ellpack matrix
   // with a given row stride, using no extra working memory Standard stream
@@ -207,6 +206,7 @@ void WriteNullValues(EllpackPageImpl* dst, int device_idx,
     }
   });
 }
+
 // Does not currently support metainfo as no on-device data source contains this
 // Current implementation assumes a single batch. More batches can
 // be supported in future. Does not currently support inferring row/column size
@@ -233,7 +233,7 @@ DeviceDMatrix::DeviceDMatrix(AdapterT* adapter, float missing, int nthread, int 
                       adapter->NumRows());
   if (adapter->IsRowMajor()) {
     CopyDataRowMajor(batch, ellpack_page_->Impl(), adapter->DeviceIdx(),
-                     missing, row_counts_span);
+                     missing);
   } else {
     CopyDataColumnMajor(adapter, batch, ellpack_page_->Impl(), missing);
   }

--- a/src/data/device_dmatrix.cu
+++ b/src/data/device_dmatrix.cu
@@ -1,0 +1,107 @@
+/*!
+ * Copyright 2020 by Contributors
+ * \file device_dmatrix.cu
+ * \brief Device-memory version of DMatrix.
+ */
+
+#include <xgboost/base.h>
+#include <xgboost/data.h>
+
+#include <memory>
+
+#include "adapter.h"
+#include "simple_dmatrix.h"
+#include "device_dmatrix.h"
+#include "device_adapter.cuh"
+#include "../common/hist_util.h"
+#include "../common/math.h"
+
+namespace xgboost {
+namespace data {
+
+struct IsValidFunctor : public thrust::unary_function<Entry, bool> {
+  explicit IsValidFunctor(float missing) : missing(missing) {}
+
+  float missing;
+  __device__ bool operator()(const data::COOTuple& e) const {
+    if (common::CheckNAN(e.value) || e.value == missing) {
+      return false;
+    }
+    return true;
+  }
+};
+
+// Returns maximum row length
+template <typename AdapterBatchT>
+size_t CountRowOffsets(const AdapterBatchT& batch, common::Span<size_t> offset,
+                     int device_idx, float missing) {
+  // Count elements per row
+  dh::LaunchN(device_idx, batch.Size(), [=] __device__(size_t idx) {
+    auto element = batch.GetElement(idx);
+    if (IsValid(element.value, missing)) {
+      atomicAdd(reinterpret_cast<unsigned long long*>(  // NOLINT
+                    &offset[element.row_idx]),
+                static_cast<unsigned long long>(1));  // NOLINT
+    }
+  });
+  size_t row_stride = thrust::reduce(dh::tbegin(offset), dh::tend(offset), thrust::maximum <size_t >());
+
+  dh::XGBCachingDeviceAllocator<char> alloc;
+  thrust::exclusive_scan(thrust::cuda::par(alloc),
+      thrust::device_pointer_cast(offset.data()),
+      thrust::device_pointer_cast(offset.data() + offset.size()),
+      thrust::device_pointer_cast(offset.data()));
+  return row_stride;
+}
+
+// Here the data is already correctly ordered and simply needs to be compacted
+// to remove missing data
+template <typename AdapterBatchT>
+void CopyDataRowMajor(const AdapterBatchT& batch, EllpackPageImpl*dst,
+                      int device_idx, float missing,
+                      common::Span<size_t> row_ptr) {
+  auto transform_f = [=] __device__(size_t idx) {
+    const auto& e = batch.GetElement(idx);
+    return Entry(e.column_idx, e.value);
+  };  // NOLINT
+  auto counting = thrust::make_counting_iterator(0llu);
+  thrust::transform_iterator<decltype(transform_f), decltype(counting), Entry>
+      transform_iter(counting, transform_f);
+  dh::XGBCachingDeviceAllocator<char> alloc;
+  thrust::copy_if(
+      thrust::cuda::par(alloc), transform_iter, transform_iter + batch.Size(),
+      thrust::device_pointer_cast(data.data()), IsValidFunctor(missing));
+}
+
+// Does not currently support metainfo as no on-device data source contains this
+// Current implementation assumes a single batch. More batches can
+// be supported in future. Does not currently support inferring row/column size
+  template <typename AdapterT>
+DeviceDMatrix::DeviceDMatrix(AdapterT* adapter, float missing, int nthread) {
+  common::HistogramCuts cuts = common::AdapterDeviceSketch(adapter, 256, missing);
+  auto & batch = adapter->Value();
+  // Work out how many valid entries we have in each row
+  dh::caching_device_vector<size_t> row_ptr(adapter->NumRows() + 1,
+                                                      0);
+  common::Span<size_t > row_ptr_span( row_ptr.data().get(),row_ptr.size() );
+  size_t row_stride=CountRowOffsets(batch, row_ptr_span, adapter->DeviceIdx(), missing);
+
+  info.num_nonzero_ = row_ptr.back();// Device to host copy
+  info.num_col_ = adapter->NumColumns();
+  info.num_row_ = adapter->NumRows();
+  ellpack_page_.reset(new EllpackPage());
+  auto impl = ellpack_page_->Impl(adapter->DeviceIdx(),cuts,this->IsDense(),row_stride, adapter->NumRows());
+  if (adapter->IsRowMajor()) {
+    CopyDataRowMajor(batch, impl, adapter->DeviceIdx(), row_ptr_span);
+  }
+
+  //*impl = EllpackPageImpl(adapter->DeviceIdx(),cuts ,info.num_nonzero_==info.num_col_*info.num_row_,,info.num_row_);
+  // Synchronise worker columns
+  rabit::Allreduce<rabit::op::Max>(&info.num_col_, 1);
+}
+template DeviceDMatrix::DeviceDMatrix(CudfAdapter* adapter, float missing,
+                                      int nthread);
+template DeviceDMatrix::DeviceDMatrix(CupyAdapter* adapter, float missing,
+                                      int nthread);
+}  // namespace data
+}  // namespace xgboost

--- a/src/data/device_dmatrix.cu
+++ b/src/data/device_dmatrix.cu
@@ -211,9 +211,9 @@ void WriteNullValues(EllpackPageImpl* dst, int device_idx,
 // Current implementation assumes a single batch. More batches can
 // be supported in future. Does not currently support inferring row/column size
 template <typename AdapterT>
-DeviceDMatrix::DeviceDMatrix(AdapterT* adapter, float missing, int nthread) {
+DeviceDMatrix::DeviceDMatrix(AdapterT* adapter, float missing, int nthread, int max_bin) {
   common::HistogramCuts cuts =
-      common::AdapterDeviceSketch(adapter, 256, missing);
+      common::AdapterDeviceSketch(adapter, max_bin, missing);
   auto& batch = adapter->Value();
   // Work out how many valid entries we have in each row
   dh::caching_device_vector<size_t> row_counts(adapter->NumRows() + 1, 0);
@@ -244,8 +244,8 @@ DeviceDMatrix::DeviceDMatrix(AdapterT* adapter, float missing, int nthread) {
   rabit::Allreduce<rabit::op::Max>(&info.num_col_, 1);
 }
 template DeviceDMatrix::DeviceDMatrix(CudfAdapter* adapter, float missing,
-                                      int nthread);
+                                      int nthread, int max_bin);
 template DeviceDMatrix::DeviceDMatrix(CupyAdapter* adapter, float missing,
-                                      int nthread);
+                                      int nthread, int max_bin);
 }  // namespace data
 }  // namespace xgboost

--- a/src/data/device_dmatrix.cu
+++ b/src/data/device_dmatrix.cu
@@ -13,7 +13,6 @@
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/iterator/discard_iterator.h>
 #include "adapter.h"
-#include "simple_dmatrix.h"
 #include "device_dmatrix.h"
 #include "device_adapter.cuh"
 #include "ellpack_page.cuh"

--- a/src/data/device_dmatrix.h
+++ b/src/data/device_dmatrix.h
@@ -1,0 +1,62 @@
+/*!
+ * Copyright 2020 by Contributors
+ * \file device_dmatrix.h
+ * \brief Device-memory version of DMatrix.
+ */
+#ifndef XGBOOST_DATA_DEVICE_DMATRIX_H_
+#define XGBOOST_DATA_DEVICE_DMATRIX_H_
+
+#include <xgboost/base.h>
+#include <xgboost/data.h>
+
+#include <memory>
+
+#include "adapter.h"
+#include "simple_dmatrix.h"
+#include "simple_batch_iterator.h"
+
+namespace xgboost {
+namespace data {
+
+class DeviceDMatrix : public DMatrix {
+ public:
+  template <typename AdapterT>
+  explicit DeviceDMatrix(AdapterT* adapter, float missing, int nthread);
+  
+  MetaInfo& Info() override { return info; }
+
+  const MetaInfo& Info() const override { return info; }
+
+  bool SingleColBlock() const override { return true; }
+
+  bool EllpackExists() const override { return true; }
+  bool SparsePageExists() const override { return false; }
+ private:
+  BatchSet<SparsePage> GetRowBatches()override
+  {
+    LOG(FATAL) << "Not implemented.";
+    return BatchSet<SparsePage>(BatchIterator<SparsePage>(nullptr));
+  }
+  BatchSet<CSCPage> GetColumnBatches()override
+  {
+    LOG(FATAL) << "Not implemented.";
+    return BatchSet<CSCPage>(BatchIterator<CSCPage>(nullptr));
+  }
+  BatchSet<SortedCSCPage> GetSortedColumnBatches()override
+  {
+    LOG(FATAL) << "Not implemented.";
+    return BatchSet<SortedCSCPage>(BatchIterator<SortedCSCPage>(nullptr));
+  }
+  BatchSet<EllpackPage> GetEllpackBatches(const BatchParam& param) override {
+    auto begin_iter = BatchIterator<EllpackPage>(
+        new SimpleBatchIteratorImpl<EllpackPage>(ellpack_page_.get()));
+    return BatchSet<EllpackPage>(begin_iter);
+  }
+
+  MetaInfo info;
+  // source data pointer.
+  std::unique_ptr<EllpackPage> ellpack_page_;
+};
+}  // namespace data
+}  // namespace xgboost
+#endif // XGBOOST_DATA_DEVICE_DMATRIX_H_

--- a/src/data/device_dmatrix.h
+++ b/src/data/device_dmatrix.h
@@ -12,8 +12,8 @@
 #include <memory>
 
 #include "adapter.h"
-#include "simple_dmatrix.h"
 #include "simple_batch_iterator.h"
+#include "simple_dmatrix.h"
 
 namespace xgboost {
 namespace data {
@@ -22,7 +22,7 @@ class DeviceDMatrix : public DMatrix {
  public:
   template <typename AdapterT>
   explicit DeviceDMatrix(AdapterT* adapter, float missing, int nthread);
-  
+
   MetaInfo& Info() override { return info; }
 
   const MetaInfo& Info() const override { return info; }
@@ -31,19 +31,17 @@ class DeviceDMatrix : public DMatrix {
 
   bool EllpackExists() const override { return true; }
   bool SparsePageExists() const override { return false; }
+
  private:
-  BatchSet<SparsePage> GetRowBatches() override
-  {
+  BatchSet<SparsePage> GetRowBatches() override {
     LOG(FATAL) << "Not implemented.";
     return BatchSet<SparsePage>(BatchIterator<SparsePage>(nullptr));
   }
-  BatchSet<CSCPage> GetColumnBatches()override
-  {
+  BatchSet<CSCPage> GetColumnBatches() override {
     LOG(FATAL) << "Not implemented.";
     return BatchSet<CSCPage>(BatchIterator<CSCPage>(nullptr));
   }
-  BatchSet<SortedCSCPage> GetSortedColumnBatches()override
-  {
+  BatchSet<SortedCSCPage> GetSortedColumnBatches() override {
     LOG(FATAL) << "Not implemented.";
     return BatchSet<SortedCSCPage>(BatchIterator<SortedCSCPage>(nullptr));
   }
@@ -59,4 +57,4 @@ class DeviceDMatrix : public DMatrix {
 };
 }  // namespace data
 }  // namespace xgboost
-#endif // XGBOOST_DATA_DEVICE_DMATRIX_H_
+#endif  // XGBOOST_DATA_DEVICE_DMATRIX_H_

--- a/src/data/device_dmatrix.h
+++ b/src/data/device_dmatrix.h
@@ -21,7 +21,7 @@ namespace data {
 class DeviceDMatrix : public DMatrix {
  public:
   template <typename AdapterT>
-  explicit DeviceDMatrix(AdapterT* adapter, float missing, int nthread);
+  explicit DeviceDMatrix(AdapterT* adapter, float missing, int nthread, int max_bin);
 
   MetaInfo& Info() override { return info; }
 

--- a/src/data/device_dmatrix.h
+++ b/src/data/device_dmatrix.h
@@ -32,7 +32,7 @@ class DeviceDMatrix : public DMatrix {
   bool EllpackExists() const override { return true; }
   bool SparsePageExists() const override { return false; }
  private:
-  BatchSet<SparsePage> GetRowBatches()override
+  BatchSet<SparsePage> GetRowBatches() override
   {
     LOG(FATAL) << "Not implemented.";
     return BatchSet<SparsePage>(BatchIterator<SparsePage>(nullptr));

--- a/src/data/ellpack_page.cc
+++ b/src/data/ellpack_page.cc
@@ -26,11 +26,17 @@ void EllpackPage::SetBaseRowId(size_t row_id) {
   LOG(FATAL) << "Internal Error: XGBoost is not compiled with CUDA but "
                 "EllpackPage is required";
 }
+<<<<<<< HEAD
 
 size_t EllpackPage::Size() const {
   LOG(FATAL) << "Internal Error: XGBoost is not compiled with CUDA but "
                 "EllpackPage is required";
   return 0;
+=======
+size_t EllpackPage::Size() const {
+  LOG(FATAL) << "Internal Error: XGBoost is not compiled with CUDA but "
+                "EllpackPage is required";
+>>>>>>> Lint
 }
 
 }  // namespace xgboost

--- a/src/data/ellpack_page.cc
+++ b/src/data/ellpack_page.cc
@@ -26,17 +26,10 @@ void EllpackPage::SetBaseRowId(size_t row_id) {
   LOG(FATAL) << "Internal Error: XGBoost is not compiled with CUDA but "
                 "EllpackPage is required";
 }
-<<<<<<< HEAD
-
 size_t EllpackPage::Size() const {
   LOG(FATAL) << "Internal Error: XGBoost is not compiled with CUDA but "
                 "EllpackPage is required";
   return 0;
-=======
-size_t EllpackPage::Size() const {
-  LOG(FATAL) << "Internal Error: XGBoost is not compiled with CUDA but "
-                "EllpackPage is required";
->>>>>>> Lint
 }
 
 }  // namespace xgboost

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -74,7 +74,6 @@ EllpackPageImpl::EllpackPageImpl(int device, common::HistogramCuts cuts,
   monitor_.StartCuda("InitCompressedData");
   InitCompressedData(device);
   monitor_.StopCuda("InitCompressedData");
-  // InitDevice();
 }
 
 size_t GetRowStride(DMatrix* dmat) {
@@ -102,12 +101,7 @@ EllpackPageImpl::EllpackPageImpl(DMatrix* dmat, const BatchParam& param)
   monitor_.StartCuda("Quantiles");
   // Create the quantile sketches for the dmatrix and initialize HistogramCuts.
   row_stride = GetRowStride(dmat);
-<<<<<<< HEAD
   cuts_ = common::DeviceSketch(param.gpu_id, dmat, param.max_bin);
-=======
-  cuts_ = common::DeviceSketch(param.gpu_id, dmat, param.max_bin,
-                                   param.gpu_batch_nrows);
->>>>>>> Rebase
   monitor_.StopCuda("Quantiles");
 
   monitor_.StartCuda("InitCompressedData");
@@ -294,7 +288,6 @@ size_t EllpackPageImpl::MemCostBytes(size_t num_rows, size_t row_stride,
 
 EllpackDeviceAccessor EllpackPageImpl::GetDeviceAccessor(int device) const {
   gidx_buffer.SetDevice(device);
-<<<<<<< HEAD
   return EllpackDeviceAccessor(
       device, cuts_, is_dense, row_stride, base_rowid, n_rows,
       common::CompressedIterator<uint32_t>(gidx_buffer.ConstDevicePointer(),
@@ -305,18 +298,6 @@ EllpackPageImpl::EllpackPageImpl(int device, common::HistogramCuts cuts,
                                  const SparsePage& page, bool is_dense,
                                  size_t row_stride)
     : cuts_(std::move(cuts)),
-=======
-  return EllpackDeviceAccessor(device, cuts_, is_dense, row_stride, base_rowid,
-                               n_rows,
-                               common::CompressedIterator<uint32_t>(
-                                   gidx_buffer.ConstDevicePointer(), NumSymbols()));
-}
-
-EllpackPageImpl::EllpackPageImpl(int device, const common::HistogramCuts& cuts,
-                                 const SparsePage& page, bool is_dense,
-                                 size_t row_stride)
-    : cuts_(cuts),
->>>>>>> Rebase
       is_dense(is_dense),
       n_rows(page.Size()),
       row_stride(row_stride) {

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -74,6 +74,7 @@ EllpackPageImpl::EllpackPageImpl(int device, common::HistogramCuts cuts,
   monitor_.StartCuda("InitCompressedData");
   InitCompressedData(device);
   monitor_.StopCuda("InitCompressedData");
+  // InitDevice();
 }
 
 size_t GetRowStride(DMatrix* dmat) {
@@ -101,7 +102,12 @@ EllpackPageImpl::EllpackPageImpl(DMatrix* dmat, const BatchParam& param)
   monitor_.StartCuda("Quantiles");
   // Create the quantile sketches for the dmatrix and initialize HistogramCuts.
   row_stride = GetRowStride(dmat);
+<<<<<<< HEAD
   cuts_ = common::DeviceSketch(param.gpu_id, dmat, param.max_bin);
+=======
+  cuts_ = common::DeviceSketch(param.gpu_id, dmat, param.max_bin,
+                                   param.gpu_batch_nrows);
+>>>>>>> Rebase
   monitor_.StopCuda("Quantiles");
 
   monitor_.StartCuda("InitCompressedData");
@@ -288,6 +294,7 @@ size_t EllpackPageImpl::MemCostBytes(size_t num_rows, size_t row_stride,
 
 EllpackDeviceAccessor EllpackPageImpl::GetDeviceAccessor(int device) const {
   gidx_buffer.SetDevice(device);
+<<<<<<< HEAD
   return EllpackDeviceAccessor(
       device, cuts_, is_dense, row_stride, base_rowid, n_rows,
       common::CompressedIterator<uint32_t>(gidx_buffer.ConstDevicePointer(),
@@ -298,6 +305,18 @@ EllpackPageImpl::EllpackPageImpl(int device, common::HistogramCuts cuts,
                                  const SparsePage& page, bool is_dense,
                                  size_t row_stride)
     : cuts_(std::move(cuts)),
+=======
+  return EllpackDeviceAccessor(device, cuts_, is_dense, row_stride, base_rowid,
+                               n_rows,
+                               common::CompressedIterator<uint32_t>(
+                                   gidx_buffer.ConstDevicePointer(), NumSymbols()));
+}
+
+EllpackPageImpl::EllpackPageImpl(int device, const common::HistogramCuts& cuts,
+                                 const SparsePage& page, bool is_dense,
+                                 size_t row_stride)
+    : cuts_(cuts),
+>>>>>>> Rebase
       is_dense(is_dense),
       n_rows(page.Size()),
       row_stride(row_stride) {

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -204,22 +204,29 @@ void EllpackPageImpl::Compact(int device, EllpackPageImpl* page,
   monitor_.StopCuda("Compact");
 }
 
-// Initialize the buffer to stored compressed features.
-void EllpackPageImpl::InitCompressedData(int device) {
-  size_t num_symbols = NumSymbols();
+  // Needs to be a public function due to device lambda
+void WriteNullBuffer(int device, EllpackPageImpl* impl) {
+  size_t num_symbols = impl->NumSymbols();
 
   // Required buffer size for storing data matrix in ELLPack format.
   size_t compressed_size_bytes =
-      common::CompressedBufferWriter::CalculateBufferSize(row_stride * n_rows,
-                                                          num_symbols);
-  gidx_buffer.SetDevice(device);
-  // Don't call fill unnecessarily
-  if (gidx_buffer.Size() == 0) {
-    gidx_buffer.Resize(compressed_size_bytes, 0);
-  } else {
-    gidx_buffer.Resize(compressed_size_bytes, 0);
-    thrust::fill(dh::tbegin(gidx_buffer), dh::tend(gidx_buffer), 0);
-  }
+      common::CompressedBufferWriter::CalculateBufferSize(
+          impl->row_stride * impl->n_rows, num_symbols);
+  impl->gidx_buffer.SetDevice(device);
+  impl->gidx_buffer.Resize(compressed_size_bytes, 0);
+  auto d_buffer = impl->gidx_buffer.DevicePointer();
+  // Initialise the buffer to null value
+  auto accessor = impl->GetDeviceAccessor(device);
+  dh::LaunchN(device, impl->n_rows * impl->row_stride,
+              [=] __device__(size_t idx) {
+                common::CompressedBufferWriter writer(accessor.NumSymbols());
+                writer.AtomicWriteSymbol(d_buffer, accessor.NullValue(), idx);
+              });
+}
+
+// Initialize the buffer to stored compressed features.
+void EllpackPageImpl::InitCompressedData(int device) {
+  WriteNullBuffer(device, this);
 }
 
 // Compress a CSR page into ELLPACK.

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -48,6 +48,10 @@ struct EllpackDeviceAccessor {
   bool is_dense;
   /*! \brief Row length for ELLPack, equal to number of features. */
   size_t row_stride;
+<<<<<<< HEAD
+=======
+  //EllpackInfo info;
+>>>>>>> Rebase
   size_t base_rowid{};
   size_t n_rows{};
   common::CompressedIterator<uint32_t> gidx_iter;

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -95,11 +95,10 @@ struct EllpackDeviceAccessor {
   __device__ uint32_t SearchBin(float value, size_t column_id) const {
     auto beg = feature_segments[column_id];
     auto end = feature_segments[column_id + 1];
-    auto values = gidx_fvalue_map.data();
     auto it =
-        thrust::upper_bound(thrust::seq, values + beg, values + end, value);
-    uint32_t idx = it - values;
-    if (idx == gidx_fvalue_map.size()) {
+        thrust::upper_bound(thrust::seq, gidx_fvalue_map.cbegin()+ beg, gidx_fvalue_map.cbegin() + end, value);
+    uint32_t idx = it - gidx_fvalue_map.cbegin();
+    if (idx == end) {
       idx -= 1;
     }
     return idx;

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -48,10 +48,6 @@ struct EllpackDeviceAccessor {
   bool is_dense;
   /*! \brief Row length for ELLPack, equal to number of features. */
   size_t row_stride;
-<<<<<<< HEAD
-=======
-  //EllpackInfo info;
->>>>>>> Rebase
   size_t base_rowid{};
   size_t n_rows{};
   common::CompressedIterator<uint32_t> gidx_iter;

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -119,7 +119,7 @@ struct EllpackDeviceAccessor {
   }
   /*! \brief Return the total number of symbols (total number of bins plus 1 for
    * not found). */
-  size_t NumSymbols() const { return gidx_fvalue_map.size() + 1; }
+  XGBOOST_DEVICE size_t NumSymbols() const { return gidx_fvalue_map.size() + 1; }
 
   size_t NullValue() const { return gidx_fvalue_map.size(); }
 

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -401,8 +401,8 @@ GBTree::GetPredictor(HostDeviceVector<float> const *out_pred,
       (f_dmat->PageExists<EllpackPage>() ||
       (*(f_dmat->GetBatches<SparsePage>().begin())).data.DeviceCanRead());
 
-  // Use GPU Predictor if data is already on device.
-  if (on_device) {
+  // Use GPU Predictor if data is already on device and gpu_id is set.
+  if (on_device && generic_param_->gpu_id >= 0) {
 #if defined(XGBOOST_USE_CUDA)
     CHECK(gpu_predictor_);
     return gpu_predictor_;

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -398,7 +398,8 @@ GBTree::GetPredictor(HostDeviceVector<float> const *out_pred,
 
   auto on_device =
       f_dmat &&
-      (*(f_dmat->GetBatches<SparsePage>().begin())).data.DeviceCanRead();
+      (f_dmat->PageExists<EllpackPage>() ||
+      (*(f_dmat->GetBatches<SparsePage>().begin())).data.DeviceCanRead());
 
   // Use GPU Predictor if data is already on device.
   if (on_device) {

--- a/src/tree/gpu_hist/gradient_based_sampler.cu
+++ b/src/tree/gpu_hist/gradient_based_sampler.cu
@@ -299,16 +299,9 @@ GradientBasedSample ExternalMemoryGradientBasedSampling::Sample(common::Span<Gra
 
   // Create a new ELLPACK page with empty rows.
   page_.reset();  // Release the device memory first before reallocating
-<<<<<<< HEAD
   page_.reset(new EllpackPageImpl(batch_param_.gpu_id, original_page_->cuts_,
                                   original_page_->is_dense,
                                   original_page_->row_stride, sample_rows));
-=======
-  page_.reset(
-      new EllpackPageImpl(batch_param_.gpu_id, original_page_->cuts_,
-                          original_page_->is_dense, original_page_->row_stride,
-                          original_page_->n_rows));
->>>>>>> Rebase
 
   // Compact the ELLPACK pages into the single sample page.
   thrust::fill(dh::tbegin(page_->gidx_buffer), dh::tend(page_->gidx_buffer), 0);

--- a/src/tree/gpu_hist/gradient_based_sampler.cu
+++ b/src/tree/gpu_hist/gradient_based_sampler.cu
@@ -299,9 +299,16 @@ GradientBasedSample ExternalMemoryGradientBasedSampling::Sample(common::Span<Gra
 
   // Create a new ELLPACK page with empty rows.
   page_.reset();  // Release the device memory first before reallocating
+<<<<<<< HEAD
   page_.reset(new EllpackPageImpl(batch_param_.gpu_id, original_page_->cuts_,
                                   original_page_->is_dense,
                                   original_page_->row_stride, sample_rows));
+=======
+  page_.reset(
+      new EllpackPageImpl(batch_param_.gpu_id, original_page_->cuts_,
+                          original_page_->is_dense, original_page_->row_stride,
+                          original_page_->n_rows));
+>>>>>>> Rebase
 
   // Compact the ELLPACK pages into the single sample page.
   thrust::fill(dh::tbegin(page_->gidx_buffer), dh::tend(page_->gidx_buffer), 0);

--- a/tests/ci_build/test_python.sh
+++ b/tests/ci_build/test_python.sh
@@ -44,7 +44,7 @@ case "$suite" in
   cudf)
     source activate cudf_test
     install_xgboost
-    pytest -v -s --fulltrace -m "not mgpu" tests/python-gpu/test_from_columnar.py tests/python-gpu/test_from_cupy.py
+    pytest -v -s --fulltrace -m "not mgpu" tests/python-gpu/test_from_cudf.py tests/python-gpu/test_from_cupy.py
     ;;
 
   cpu)

--- a/tests/cpp/data/test_device_dmatrix.cu
+++ b/tests/cpp/data/test_device_dmatrix.cu
@@ -23,7 +23,7 @@ TEST(DeviceDMatrix, RowMajor) {
   auto adapter = common::AdapterFromData(x_device, num_rows, num_columns);
 
   data::DeviceDMatrix dmat(&adapter,
-                                  std::numeric_limits<float>::quiet_NaN(), 1);
+                                  std::numeric_limits<float>::quiet_NaN(), 1, 256);
 
   auto &batch = *dmat.GetBatches<EllpackPage>({0, 256, 0}).begin();
   auto impl = batch.Impl();
@@ -51,7 +51,7 @@ TEST(DeviceDMatrix, RowMajorMissing) {
   auto x_device = thrust::device_vector<float>(x);
   auto adapter = common::AdapterFromData(x_device, num_rows, num_columns);
 
-  data::DeviceDMatrix dmat(&adapter, kMissing, 1);
+  data::DeviceDMatrix dmat(&adapter, kMissing, 1, 256);
 
   auto &batch = *dmat.GetBatches<EllpackPage>({0, 256, 0}).begin();
   auto impl = batch.Impl();
@@ -84,7 +84,7 @@ TEST(DeviceDMatrix, ColumnMajor) {
 
   data::CudfAdapter adapter(str);
   data::DeviceDMatrix dmat(&adapter, std::numeric_limits<float>::quiet_NaN(),
-                           -1);
+                           -1, 256);
   auto &batch = *dmat.GetBatches<EllpackPage>({0, 256, 0}).begin();
   auto impl = batch.Impl();
   common::CompressedIterator<uint32_t> iterator(

--- a/tests/cpp/data/test_device_dmatrix.cu
+++ b/tests/cpp/data/test_device_dmatrix.cu
@@ -3,18 +3,20 @@
 #include <gtest/gtest.h>
 #include <xgboost/data.h>
 #include "../../../src/data/adapter.h"
+#include "../../../src/data/ellpack_page.cuh"
 #include "../../../src/data/device_dmatrix.h"
 #include "../helpers.h"
 #include <thrust/device_vector.h>
 #include "../../../src/data/device_adapter.cuh"
 #include "../../../src/gbm/gbtree_model.h"
 #include "../common/test_hist_util.h"
-#include <xgboost/predictor.h>
+#include "../../../src/common/compressed_iterator.h"
+#include "../../../src/common/math.h"
 using namespace xgboost;  // NOLINT
 
 TEST(DeviceDMatrix, Simple) {
-  int num_rows = 10;
-  int num_columns = 2;
+  int num_rows = 1000;
+  int num_columns = 50;
   auto x = common::GenerateRandom(num_rows, num_columns);
   auto x_device = thrust::device_vector<float>(x);
   auto adapter = common::AdapterFromData(x_device, num_rows, num_columns);
@@ -23,17 +25,36 @@ TEST(DeviceDMatrix, Simple) {
                                   std::numeric_limits<float>::quiet_NaN(), 1);
 
   auto &batch = *device_dmat.GetBatches<EllpackPage>({0, 256, 0}).begin();
+  auto impl = batch.Impl();
+  common::CompressedIterator<uint32_t> iterator(
+      impl->gidx_buffer.HostVector().data(), impl->NumSymbols());
+  for(auto i = 0ull; i < x.size(); i++)
+  {
+    int column_idx = i % num_columns;
+    EXPECT_EQ(impl->cuts_.SearchBin(x[i], column_idx), iterator[i]);
+  }
 
-  auto gpu_lparam = CreateEmptyGenericParam(0);
+}
 
-  std::unique_ptr<Predictor> gpu_predictor = std::unique_ptr<Predictor>(
-      Predictor::Create("gpu_predictor", &gpu_lparam));
+TEST(DeviceDMatrix, Missing) {
+ const  float kMissing=std::numeric_limits<float>::quiet_NaN();
+  int num_rows = 10;
+  int num_columns = 2;
+  auto x = common::GenerateRandom(num_rows, num_columns);
+  x[1] = kMissing;
+  x[5] = kMissing;
+  x[6] = kMissing;
+  auto x_device = thrust::device_vector<float>(x);
+  auto adapter = common::AdapterFromData(x_device, num_rows, num_columns);
 
-  gpu_predictor->Configure({});
-  LearnerModelParam param;
-  param.num_output_group = 1;
-  gbm::GBTreeModel model = CreateTestModel(&param);
-  HostDeviceVector<float> predictions(num_rows);
-  PredictionCacheEntry entry;
-  gpu_predictor->PredictBatch(&device_dmat, &entry, model, 0);
+  data::DeviceDMatrix device_dmat(&adapter, kMissing, 1);
+
+  auto &batch = *device_dmat.GetBatches<EllpackPage>({0, 256, 0}).begin();
+  auto impl = batch.Impl();
+  common::CompressedIterator<uint32_t> iterator(
+      impl->gidx_buffer.HostVector().data(), impl->NumSymbols());
+  EXPECT_EQ(iterator[1], impl->GetDeviceAccessor(0).NullValue());
+  EXPECT_EQ(iterator[5], impl->GetDeviceAccessor(0).NullValue());
+  EXPECT_EQ(iterator[7], impl->GetDeviceAccessor(0).NullValue()); // null values get placed after
+
 }

--- a/tests/cpp/data/test_device_dmatrix.cu
+++ b/tests/cpp/data/test_device_dmatrix.cu
@@ -1,0 +1,39 @@
+
+// Copyright (c) 2019 by Contributors
+#include <gtest/gtest.h>
+#include <xgboost/data.h>
+#include "../../../src/data/adapter.h"
+#include "../../../src/data/device_dmatrix.h"
+#include "../helpers.h"
+#include <thrust/device_vector.h>
+#include "../../../src/data/device_adapter.cuh"
+#include "../../../src/gbm/gbtree_model.h"
+#include "../common/test_hist_util.h"
+#include <xgboost/predictor.h>
+using namespace xgboost;  // NOLINT
+
+TEST(DeviceDMatrix, Simple) {
+  int num_rows = 10;
+  int num_columns = 2;
+  auto x = common::GenerateRandom(num_rows, num_columns);
+  auto x_device = thrust::device_vector<float>(x);
+  auto adapter = common::AdapterFromData(x_device, num_rows, num_columns);
+
+  data::DeviceDMatrix device_dmat(&adapter,
+                                  std::numeric_limits<float>::quiet_NaN(), 1);
+
+  auto &batch = *device_dmat.GetBatches<EllpackPage>({0, 256, 0}).begin();
+
+  auto gpu_lparam = CreateEmptyGenericParam(0);
+
+  std::unique_ptr<Predictor> gpu_predictor = std::unique_ptr<Predictor>(
+      Predictor::Create("gpu_predictor", &gpu_lparam));
+
+  gpu_predictor->Configure({});
+  LearnerModelParam param;
+  param.num_output_group = 1;
+  gbm::GBTreeModel model = CreateTestModel(&param);
+  HostDeviceVector<float> predictions(num_rows);
+  PredictionCacheEntry entry;
+  gpu_predictor->PredictBatch(&device_dmat, &entry, model, 0);
+}

--- a/tests/cpp/data/test_device_dmatrix.cu
+++ b/tests/cpp/data/test_device_dmatrix.cu
@@ -12,19 +12,20 @@
 #include "../common/test_hist_util.h"
 #include "../../../src/common/compressed_iterator.h"
 #include "../../../src/common/math.h"
+#include "test_array_interface.h"
 using namespace xgboost;  // NOLINT
 
-TEST(DeviceDMatrix, Simple) {
+TEST(DeviceDMatrix, RowMajor) {
   int num_rows = 1000;
   int num_columns = 50;
   auto x = common::GenerateRandom(num_rows, num_columns);
   auto x_device = thrust::device_vector<float>(x);
   auto adapter = common::AdapterFromData(x_device, num_rows, num_columns);
 
-  data::DeviceDMatrix device_dmat(&adapter,
+  data::DeviceDMatrix dmat(&adapter,
                                   std::numeric_limits<float>::quiet_NaN(), 1);
 
-  auto &batch = *device_dmat.GetBatches<EllpackPage>({0, 256, 0}).begin();
+  auto &batch = *dmat.GetBatches<EllpackPage>({0, 256, 0}).begin();
   auto impl = batch.Impl();
   common::CompressedIterator<uint32_t> iterator(
       impl->gidx_buffer.HostVector().data(), impl->NumSymbols());
@@ -33,11 +34,14 @@ TEST(DeviceDMatrix, Simple) {
     int column_idx = i % num_columns;
     EXPECT_EQ(impl->cuts_.SearchBin(x[i], column_idx), iterator[i]);
   }
+  EXPECT_EQ(dmat.Info().num_col_, num_columns);
+  EXPECT_EQ(dmat.Info().num_row_, num_rows);
+  EXPECT_EQ(dmat.Info().num_nonzero_, num_rows * num_columns);
 
 }
 
-TEST(DeviceDMatrix, Missing) {
- const  float kMissing=std::numeric_limits<float>::quiet_NaN();
+TEST(DeviceDMatrix, RowMajorMissing) {
+  const float kMissing = std::numeric_limits<float>::quiet_NaN();
   int num_rows = 10;
   int num_columns = 2;
   auto x = common::GenerateRandom(num_rows, num_columns);
@@ -47,14 +51,56 @@ TEST(DeviceDMatrix, Missing) {
   auto x_device = thrust::device_vector<float>(x);
   auto adapter = common::AdapterFromData(x_device, num_rows, num_columns);
 
-  data::DeviceDMatrix device_dmat(&adapter, kMissing, 1);
+  data::DeviceDMatrix dmat(&adapter, kMissing, 1);
 
-  auto &batch = *device_dmat.GetBatches<EllpackPage>({0, 256, 0}).begin();
+  auto &batch = *dmat.GetBatches<EllpackPage>({0, 256, 0}).begin();
   auto impl = batch.Impl();
   common::CompressedIterator<uint32_t> iterator(
       impl->gidx_buffer.HostVector().data(), impl->NumSymbols());
   EXPECT_EQ(iterator[1], impl->GetDeviceAccessor(0).NullValue());
   EXPECT_EQ(iterator[5], impl->GetDeviceAccessor(0).NullValue());
-  EXPECT_EQ(iterator[7], impl->GetDeviceAccessor(0).NullValue()); // null values get placed after
+  // null values get placed after valid values in a row
+  EXPECT_EQ(iterator[7], impl->GetDeviceAccessor(0).NullValue()); 
+  EXPECT_EQ(dmat.Info().num_col_, num_columns);
+  EXPECT_EQ(dmat.Info().num_row_, num_rows);
+  EXPECT_EQ(dmat.Info().num_nonzero_, num_rows*num_columns-3);
+
+}
+
+TEST(DeviceDMatrix, ColumnMajor) {
+  constexpr size_t kRows{100};
+  std::vector<Json> columns;
+  thrust::device_vector<double> d_data_0(kRows);
+  thrust::device_vector<uint32_t> d_data_1(kRows);
+
+  columns.emplace_back(GenerateDenseColumn<double>("<f8", kRows, &d_data_0));
+  columns.emplace_back(GenerateDenseColumn<uint32_t>("<u4", kRows, &d_data_1));
+
+  Json column_arr{columns};
+
+  std::stringstream ss;
+  Json::Dump(column_arr, &ss);
+  std::string str = ss.str();
+
+  data::CudfAdapter adapter(str);
+  data::DeviceDMatrix dmat(&adapter, std::numeric_limits<float>::quiet_NaN(),
+                           -1);
+  auto &batch = *dmat.GetBatches<EllpackPage>({0, 256, 0}).begin();
+  auto impl = batch.Impl();
+  common::CompressedIterator<uint32_t> iterator(
+      impl->gidx_buffer.HostVector().data(), impl->NumSymbols());
+
+  for (auto i = 0ull; i < kRows; i++) {
+    for (auto j = 0ull; j < columns.size(); j++) {
+      if (j == 0) {
+        EXPECT_EQ(iterator[i * 2 + j], impl->cuts_.SearchBin(d_data_0[i], j));
+      } else {
+        EXPECT_EQ(iterator[i * 2 + j], impl->cuts_.SearchBin(d_data_1[i], j));
+      }
+    }
+  }
+  EXPECT_EQ(dmat.Info().num_col_, 2);
+  EXPECT_EQ(dmat.Info().num_row_, kRows);
+  EXPECT_EQ(dmat.Info().num_nonzero_, kRows*2);
 
 }

--- a/tests/python-gpu/test_from_columnar.py
+++ b/tests/python-gpu/test_from_columnar.py
@@ -7,7 +7,7 @@ sys.path.append("tests/python")
 import testing as tm
 
 
-def dmatrix_from_cudf(input_type, missing=np.NAN):
+def dmatrix_from_cudf(input_type, DMatrixT, missing=np.NAN):
     '''Test constructing DMatrix from cudf'''
     import cudf
     import pandas as pd
@@ -31,9 +31,116 @@ def dmatrix_from_cudf(input_type, missing=np.NAN):
     cd = cudf.from_pandas(pa)
     cd_label = cudf.from_pandas(pa_label).iloc[:, 0]
 
-    dtrain = xgb.DMatrix(cd, missing=missing, label=cd_label)
+    dtrain = DMatrixT(cd, missing=missing, label=cd_label)
     assert dtrain.num_col() == kCols
     assert dtrain.num_row() == kRows
+
+
+def _test_from_cudf(DMatrixT):
+    '''Test constructing DMatrix from cudf'''
+    import cudf
+    dmatrix_from_cudf(np.float32, DMatrixT, np.NAN)
+    dmatrix_from_cudf(np.float64, DMatrixT, np.NAN)
+
+    dmatrix_from_cudf(np.int8, DMatrixT, 2)
+    dmatrix_from_cudf(np.int32, DMatrixT, -2)
+    dmatrix_from_cudf(np.int64, DMatrixT, -3)
+
+    cd = cudf.DataFrame({'x': [1, 2, 3], 'y': [0.1, 0.2, 0.3]})
+    dtrain = DMatrixT(cd)
+
+    assert dtrain.feature_names == ['x', 'y']
+    assert dtrain.feature_types == ['int', 'float']
+
+    series = cudf.DataFrame({'x': [1, 2, 3]}).iloc[:, 0]
+    assert isinstance(series, cudf.Series)
+    dtrain = DMatrixT(series)
+
+    assert dtrain.feature_names == ['x']
+    assert dtrain.feature_types == ['int']
+
+    with pytest.raises(Exception):
+        dtrain = DMatrixT(cd, label=cd)
+
+    # Test when number of elements is less than 8
+    X = cudf.DataFrame({'x': cudf.Series([0, 1, 2, np.NAN, 4],
+                                         dtype=np.int32)})
+    dtrain = DMatrixT(X)
+    assert dtrain.num_col() == 1
+    assert dtrain.num_row() == 5
+
+    # Boolean is not supported.
+    X_boolean = cudf.DataFrame({'x': cudf.Series([True, False])})
+    with pytest.raises(Exception):
+        dtrain = DMatrixT(X_boolean)
+
+    y_boolean = cudf.DataFrame({
+        'x': cudf.Series([True, False, True, True, True])})
+    with pytest.raises(Exception):
+        dtrain = DMatrixT(X_boolean, label=y_boolean)
+
+
+def _test_cudf_training(DMatrixT):
+    from cudf import DataFrame as df
+    import pandas as pd
+    np.random.seed(1)
+    X = pd.DataFrame(np.random.randn(50, 10))
+    y = pd.DataFrame(np.random.randn(50))
+    weights = np.random.random(50) + 1.0
+    cudf_weights = df.from_pandas(pd.DataFrame(weights))
+    base_margin = np.random.random(50)
+    cudf_base_margin = df.from_pandas(pd.DataFrame(base_margin))
+
+    evals_result_cudf = {}
+    dtrain_cudf = DMatrixT(df.from_pandas(X), df.from_pandas(y), weight=cudf_weights,
+                           base_margin=cudf_base_margin)
+    params = {'gpu_id': 0, 'tree_method': 'gpu_hist'}
+    xgb.train(params, dtrain_cudf, evals=[(dtrain_cudf, "train")],
+              evals_result=evals_result_cudf)
+    evals_result_np = {}
+    dtrain_np = xgb.DMatrix(X, y, weight=weights, base_margin=base_margin)
+    xgb.train(params, dtrain_np, evals=[(dtrain_np, "train")],
+              evals_result=evals_result_np)
+    assert np.array_equal(evals_result_cudf["train"]["rmse"], evals_result_np["train"]["rmse"])
+
+
+def _test_cudf_metainfo(DMatrixT):
+    from cudf import DataFrame as df
+    import pandas as pd
+    n = 100
+    X = np.random.random((n, 2))
+    dmat_cudf = DMatrixT(df.from_pandas(pd.DataFrame(X)))
+    dmat = xgb.DMatrix(X)
+    floats = np.random.random(n)
+    uints = np.array([4, 2, 8]).astype("uint32")
+    cudf_floats = df.from_pandas(pd.DataFrame(floats))
+    cudf_uints = df.from_pandas(pd.DataFrame(uints))
+    dmat.set_float_info('weight', floats)
+    dmat.set_float_info('label', floats)
+    dmat.set_float_info('base_margin', floats)
+    dmat.set_uint_info('group', uints)
+    dmat_cudf.set_interface_info('weight', cudf_floats)
+    dmat_cudf.set_interface_info('label', cudf_floats)
+    dmat_cudf.set_interface_info('base_margin', cudf_floats)
+    dmat_cudf.set_interface_info('group', cudf_uints)
+
+    # Test setting info with cudf DataFrame
+    assert np.array_equal(dmat.get_float_info('weight'), dmat_cudf.get_float_info('weight'))
+    assert np.array_equal(dmat.get_float_info('label'), dmat_cudf.get_float_info('label'))
+    assert np.array_equal(dmat.get_float_info('base_margin'),
+                          dmat_cudf.get_float_info('base_margin'))
+    assert np.array_equal(dmat.get_uint_info('group_ptr'), dmat_cudf.get_uint_info('group_ptr'))
+
+    # Test setting info with cudf Series
+    dmat_cudf.set_interface_info('weight', cudf_floats[cudf_floats.columns[0]])
+    dmat_cudf.set_interface_info('label', cudf_floats[cudf_floats.columns[0]])
+    dmat_cudf.set_interface_info('base_margin', cudf_floats[cudf_floats.columns[0]])
+    dmat_cudf.set_interface_info('group', cudf_uints[cudf_uints.columns[0]])
+    assert np.array_equal(dmat.get_float_info('weight'), dmat_cudf.get_float_info('weight'))
+    assert np.array_equal(dmat.get_float_info('label'), dmat_cudf.get_float_info('label'))
+    assert np.array_equal(dmat.get_float_info('base_margin'),
+                          dmat_cudf.get_float_info('base_margin'))
+    assert np.array_equal(dmat.get_uint_info('group_ptr'), dmat_cudf.get_uint_info('group_ptr'))
 
 
 class TestFromColumnar:
@@ -41,108 +148,25 @@ class TestFromColumnar:
 Arrow specification.'''
 
     @pytest.mark.skipif(**tm.no_cudf())
-    def test_from_cudf(self):
-        '''Test constructing DMatrix from cudf'''
-        import cudf
-        dmatrix_from_cudf(np.float32, np.NAN)
-        dmatrix_from_cudf(np.float64, np.NAN)
-
-        dmatrix_from_cudf(np.int8, 2)
-        dmatrix_from_cudf(np.int32, -2)
-        dmatrix_from_cudf(np.int64, -3)
-
-        cd = cudf.DataFrame({'x': [1, 2, 3], 'y': [0.1, 0.2, 0.3]})
-        dtrain = xgb.DMatrix(cd)
-
-        assert dtrain.feature_names == ['x', 'y']
-        assert dtrain.feature_types == ['int', 'float']
-
-        series = cudf.DataFrame({'x': [1, 2, 3]}).iloc[:, 0]
-        assert isinstance(series, cudf.Series)
-        dtrain = xgb.DMatrix(series)
-
-        assert dtrain.feature_names == ['x']
-        assert dtrain.feature_types == ['int']
-
-        with pytest.raises(Exception):
-            dtrain = xgb.DMatrix(cd, label=cd)
-
-        # Test when number of elements is less than 8
-        X = cudf.DataFrame({'x': cudf.Series([0, 1, 2, np.NAN, 4],
-                                             dtype=np.int32)})
-        dtrain = xgb.DMatrix(X)
-        assert dtrain.num_col() == 1
-        assert dtrain.num_row() == 5
-
-        # Boolean is not supported.
-        X_boolean = cudf.DataFrame({'x': cudf.Series([True, False])})
-        with pytest.raises(Exception):
-            dtrain = xgb.DMatrix(X_boolean)
-
-        y_boolean = cudf.DataFrame({
-            'x': cudf.Series([True, False, True, True, True])})
-        with pytest.raises(Exception):
-            dtrain = xgb.DMatrix(X_boolean, label=y_boolean)
+    def test_simple_dmatrix_from_cudf(self):
+        _test_from_cudf(xgb.DMatrix)
 
     @pytest.mark.skipif(**tm.no_cudf())
-    def test_cudf_training(self):
-        from cudf import DataFrame as df
-        import pandas as pd
-        np.random.seed(1)
-        X = pd.DataFrame(np.random.randn(50, 10))
-        y = pd.DataFrame(np.random.randn(50))
-        weights = np.random.random(50) + 1.0
-        cudf_weights = df.from_pandas(pd.DataFrame(weights))
-        base_margin = np.random.random(50)
-        cudf_base_margin = df.from_pandas(pd.DataFrame(base_margin))
-
-        evals_result_cudf = {}
-        dtrain_cudf = xgb.DMatrix(df.from_pandas(X), df.from_pandas(y), weight=cudf_weights,
-                                  base_margin=cudf_base_margin)
-        params = {'gpu_id': 0}
-        xgb.train(params, dtrain_cudf, evals=[(dtrain_cudf, "train")],
-                  evals_result=evals_result_cudf)
-        evals_result_np = {}
-        dtrain_np = xgb.DMatrix(X, y, weight=weights, base_margin=base_margin)
-        xgb.train(params, dtrain_np, evals=[(dtrain_np, "train")],
-                  evals_result=evals_result_np)
-        assert np.array_equal(evals_result_cudf["train"]["rmse"], evals_result_np["train"]["rmse"])
+    def test_device_dmatrix_from_cudf(self):
+        _test_from_cudf(xgb.DeviceDMatrix)
 
     @pytest.mark.skipif(**tm.no_cudf())
-    def test_cudf_metainfo(self):
-        from cudf import DataFrame as df
-        import pandas as pd
-        n = 100
-        X = np.random.random((n, 2))
-        dmat_cudf = xgb.DMatrix(X)
-        dmat = xgb.DMatrix(X)
-        floats = np.random.random(n)
-        uints = np.array([4, 2, 8]).astype("uint32")
-        cudf_floats = df.from_pandas(pd.DataFrame(floats))
-        cudf_uints = df.from_pandas(pd.DataFrame(uints))
-        dmat.set_float_info('weight', floats)
-        dmat.set_float_info('label', floats)
-        dmat.set_float_info('base_margin', floats)
-        dmat.set_uint_info('group', uints)
-        dmat_cudf.set_interface_info('weight', cudf_floats)
-        dmat_cudf.set_interface_info('label', cudf_floats)
-        dmat_cudf.set_interface_info('base_margin', cudf_floats)
-        dmat_cudf.set_interface_info('group', cudf_uints)
+    def test_cudf_training_simple_dmatrix(self):
+        _test_cudf_training(xgb.DMatrix)
 
-        # Test setting info with cudf DataFrame
-        assert np.array_equal(dmat.get_float_info('weight'), dmat_cudf.get_float_info('weight'))
-        assert np.array_equal(dmat.get_float_info('label'), dmat_cudf.get_float_info('label'))
-        assert np.array_equal(dmat.get_float_info('base_margin'),
-                              dmat_cudf.get_float_info('base_margin'))
-        assert np.array_equal(dmat.get_uint_info('group_ptr'), dmat_cudf.get_uint_info('group_ptr'))
+    @pytest.mark.skipif(**tm.no_cudf())
+    def test_cudf_training_device_dmatrix(self):
+        _test_cudf_training(xgb.DeviceDMatrix)
 
-        # Test setting info with cudf Series
-        dmat_cudf.set_interface_info('weight', cudf_floats[cudf_floats.columns[0]])
-        dmat_cudf.set_interface_info('label', cudf_floats[cudf_floats.columns[0]])
-        dmat_cudf.set_interface_info('base_margin', cudf_floats[cudf_floats.columns[0]])
-        dmat_cudf.set_interface_info('group', cudf_uints[cudf_uints.columns[0]])
-        assert np.array_equal(dmat.get_float_info('weight'), dmat_cudf.get_float_info('weight'))
-        assert np.array_equal(dmat.get_float_info('label'), dmat_cudf.get_float_info('label'))
-        assert np.array_equal(dmat.get_float_info('base_margin'),
-                              dmat_cudf.get_float_info('base_margin'))
-        assert np.array_equal(dmat.get_uint_info('group_ptr'), dmat_cudf.get_uint_info('group_ptr'))
+    @pytest.mark.skipif(**tm.no_cudf())
+    def test_cudf_metainfo_simple_dmatrix(self):
+        _test_cudf_metainfo(xgb.DMatrix)
+
+    @pytest.mark.skipif(**tm.no_cudf())
+    def test_cudf_metainfo_device_dmatrix(self):
+        _test_cudf_metainfo(xgb.DeviceDMatrix)

--- a/tests/python-gpu/test_from_cudf.py
+++ b/tests/python-gpu/test_from_cudf.py
@@ -153,7 +153,7 @@ Arrow specification.'''
 
     @pytest.mark.skipif(**tm.no_cudf())
     def test_device_dmatrix_from_cudf(self):
-        _test_from_cudf(xgb.DeviceDMatrix)
+        _test_from_cudf(xgb.DeviceQuantileDMatrix)
 
     @pytest.mark.skipif(**tm.no_cudf())
     def test_cudf_training_simple_dmatrix(self):
@@ -161,7 +161,7 @@ Arrow specification.'''
 
     @pytest.mark.skipif(**tm.no_cudf())
     def test_cudf_training_device_dmatrix(self):
-        _test_cudf_training(xgb.DeviceDMatrix)
+        _test_cudf_training(xgb.DeviceQuantileDMatrix)
 
     @pytest.mark.skipif(**tm.no_cudf())
     def test_cudf_metainfo_simple_dmatrix(self):
@@ -169,4 +169,4 @@ Arrow specification.'''
 
     @pytest.mark.skipif(**tm.no_cudf())
     def test_cudf_metainfo_device_dmatrix(self):
-        _test_cudf_metainfo(xgb.DeviceDMatrix)
+        _test_cudf_metainfo(xgb.DeviceQuantileDMatrix)

--- a/tests/python-gpu/test_from_cupy.py
+++ b/tests/python-gpu/test_from_cupy.py
@@ -7,7 +7,7 @@ sys.path.append("tests/python")
 import testing as tm
 
 
-def dmatrix_from_cupy(input_type, missing=np.NAN):
+def dmatrix_from_cupy(input_type, DMatrixT, missing=np.NAN):
     '''Test constructing DMatrix from cupy'''
     import cupy as cp
 
@@ -19,10 +19,80 @@ def dmatrix_from_cupy(input_type, missing=np.NAN):
     X[5, 0] = missing
     X[3, 1] = missing
     y = cp.random.randn(kRows).astype(dtype=input_type)
-    dtrain = xgb.DMatrix(X, missing=missing, label=y)
+    dtrain = DMatrixT(X, missing=missing, label=y)
     assert dtrain.num_col() == kCols
     assert dtrain.num_row() == kRows
     return dtrain
+
+
+def _test_from_cupy(DMatrixT):
+    '''Test constructing DMatrix from cupy'''
+    import cupy as cp
+    dmatrix_from_cupy(np.float32, DMatrixT, np.NAN)
+    dmatrix_from_cupy(np.float64, DMatrixT, np.NAN)
+
+    dmatrix_from_cupy(np.uint8, DMatrixT, 2)
+    dmatrix_from_cupy(np.uint32, DMatrixT, 3)
+    dmatrix_from_cupy(np.uint64, DMatrixT, 4)
+
+    dmatrix_from_cupy(np.int8, DMatrixT, 2)
+    dmatrix_from_cupy(np.int32, DMatrixT, -2)
+    dmatrix_from_cupy(np.int64, DMatrixT, -3)
+
+    with pytest.raises(Exception):
+        X = cp.random.randn(2, 2, dtype="float32")
+        dtrain = DMatrixT(X, label=X)
+
+
+def _test_cupy_training(DMatrixT):
+    import cupy as cp
+    np.random.seed(1)
+    cp.random.seed(1)
+    X = cp.random.randn(50, 10, dtype="float32")
+    y = cp.random.randn(50, dtype="float32")
+    weights = np.random.random(50) + 1
+    cupy_weights = cp.array(weights)
+    base_margin = np.random.random(50)
+    cupy_base_margin = cp.array(base_margin)
+
+    evals_result_cupy = {}
+    dtrain_cp = DMatrixT(X, y, weight=cupy_weights, base_margin=cupy_base_margin)
+    params = {'gpu_id': 0, 'nthread': 1, 'tree_method': 'gpu_hist'}
+    xgb.train(params, dtrain_cp, evals=[(dtrain_cp, "train")],
+              evals_result=evals_result_cupy)
+    evals_result_np = {}
+    dtrain_np = xgb.DMatrix(cp.asnumpy(X), cp.asnumpy(y), weight=weights,
+                            base_margin=base_margin)
+    xgb.train(params, dtrain_np, evals=[(dtrain_np, "train")],
+              evals_result=evals_result_np)
+    assert np.array_equal(evals_result_cupy["train"]["rmse"], evals_result_np["train"]["rmse"])
+
+
+def _test_cupy_metainfo(DMatrixT):
+    import cupy as cp
+    n = 100
+    X = np.random.random((n, 2))
+    dmat_cupy = DMatrixT(X)
+    dmat = xgb.DMatrix(X)
+    floats = np.random.random(n)
+    uints = np.array([4, 2, 8]).astype("uint32")
+    cupy_floats = cp.array(floats)
+    cupy_uints = cp.array(uints)
+    dmat.set_float_info('weight', floats)
+    dmat.set_float_info('label', floats)
+    dmat.set_float_info('base_margin', floats)
+    dmat.set_uint_info('group', uints)
+    dmat_cupy.set_interface_info('weight', cupy_floats)
+    dmat_cupy.set_interface_info('label', cupy_floats)
+    dmat_cupy.set_interface_info('base_margin', cupy_floats)
+    dmat_cupy.set_interface_info('group', cupy_uints)
+
+    # Test setting info with cupy
+    assert np.array_equal(dmat.get_float_info('weight'), dmat_cupy.get_float_info('weight'))
+    assert np.array_equal(dmat.get_float_info('label'), dmat_cupy.get_float_info('label'))
+    assert np.array_equal(dmat.get_float_info('base_margin'),
+                          dmat_cupy.get_float_info('base_margin'))
+    assert np.array_equal(dmat.get_uint_info('group_ptr'), dmat_cupy.get_uint_info('group_ptr'))
 
 
 class TestFromArrayInterface:
@@ -30,71 +100,25 @@ class TestFromArrayInterface:
 Arrow specification.'''
 
     @pytest.mark.skipif(**tm.no_cupy())
-    def test_from_cupy(self):
-        '''Test constructing DMatrix from cupy'''
-        import cupy as cp
-        dmatrix_from_cupy(np.float32, np.NAN)
-        dmatrix_from_cupy(np.float64, np.NAN)
-
-        dmatrix_from_cupy(np.uint8, 2)
-        dmatrix_from_cupy(np.uint32, 3)
-        dmatrix_from_cupy(np.uint64, 4)
-
-        dmatrix_from_cupy(np.int8, 2)
-        dmatrix_from_cupy(np.int32, -2)
-        dmatrix_from_cupy(np.int64, -3)
-
-        with pytest.raises(Exception):
-            X = cp.random.randn(2, 2, dtype="float32")
-            dtrain = xgb.DMatrix(X, label=X)
+    def test_simple_dmat_from_cupy(self):
+        _test_from_cupy(xgb.DMatrix)
 
     @pytest.mark.skipif(**tm.no_cupy())
-    def test_cupy_training(self):
-        import cupy as cp
-        np.random.seed(1)
-        cp.random.seed(1)
-        X = cp.random.randn(50, 10, dtype="float32")
-        y = cp.random.randn(50, dtype="float32")
-        weights = np.random.random(50) + 1
-        cupy_weights = cp.array(weights)
-        base_margin = np.random.random(50)
-        cupy_base_margin = cp.array(base_margin)
-
-        evals_result_cupy = {}
-        dtrain_cp = xgb.DMatrix(X, y, weight=cupy_weights, base_margin=cupy_base_margin)
-        params = {'gpu_id': 0, 'nthread': 1}
-        xgb.train(params, dtrain_cp, evals=[(dtrain_cp, "train")],
-                  evals_result=evals_result_cupy)
-        evals_result_np = {}
-        dtrain_np = xgb.DMatrix(cp.asnumpy(X), cp.asnumpy(y), weight=weights,
-                                base_margin=base_margin)
-        xgb.train(params, dtrain_np, evals=[(dtrain_np, "train")],
-                  evals_result=evals_result_np)
-        assert np.array_equal(evals_result_cupy["train"]["rmse"], evals_result_np["train"]["rmse"])
+    def test_device_dmat_from_cupy(self):
+        _test_from_cupy(xgb.DeviceDMatrix)
 
     @pytest.mark.skipif(**tm.no_cupy())
-    def test_cupy_metainfo(self):
-        import cupy as cp
-        n = 100
-        X = np.random.random((n, 2))
-        dmat_cupy = xgb.DMatrix(X)
-        dmat = xgb.DMatrix(X)
-        floats = np.random.random(n)
-        uints = np.array([4, 2, 8]).astype("uint32")
-        cupy_floats = cp.array(floats)
-        cupy_uints = cp.array(uints)
-        dmat.set_float_info('weight', floats)
-        dmat.set_float_info('label', floats)
-        dmat.set_float_info('base_margin', floats)
-        dmat.set_uint_info('group', uints)
-        dmat_cupy.set_interface_info('weight', cupy_floats)
-        dmat_cupy.set_interface_info('label', cupy_floats)
-        dmat_cupy.set_interface_info('base_margin', cupy_floats)
-        dmat_cupy.set_interface_info('group', cupy_uints)
+    def test_cupy_training_device_dmat(self):
+        _test_cupy_training(xgb.DeviceDMatrix)
 
-        # Test setting info with cupy 
-        assert np.array_equal(dmat.get_float_info('weight'), dmat_cupy.get_float_info('weight'))
-        assert np.array_equal(dmat.get_float_info('label'), dmat_cupy.get_float_info('label'))
-        assert np.array_equal(dmat.get_float_info('base_margin'),
-                              dmat_cupy.get_float_info('base_margin'))
-        assert np.array_equal(dmat.get_uint_info('group_ptr'), dmat_cupy.get_uint_info('group_ptr'))
+    @pytest.mark.skipif(**tm.no_cupy())
+    def test_cupy_training_simple_dmat(self):
+        _test_cupy_training(xgb.DMatrix)
+
+    @pytest.mark.skipif(**tm.no_cupy())
+    def test_cupy_metainfo_simple_dmat(self):
+        _test_cupy_metainfo(xgb.DMatrix)
+
+    @pytest.mark.skipif(**tm.no_cupy())
+    def test_cupy_metainfo_device_dmat(self):
+        _test_cupy_metainfo(xgb.DeviceDMatrix)

--- a/tests/python-gpu/test_from_cupy.py
+++ b/tests/python-gpu/test_from_cupy.py
@@ -72,7 +72,7 @@ def _test_cupy_metainfo(DMatrixT):
     import cupy as cp
     n = 100
     X = np.random.random((n, 2))
-    dmat_cupy = DMatrixT(X)
+    dmat_cupy = DMatrixT(cp.array(X))
     dmat = xgb.DMatrix(X)
     floats = np.random.random(n)
     uints = np.array([4, 2, 8]).astype("uint32")
@@ -105,11 +105,11 @@ Arrow specification.'''
 
     @pytest.mark.skipif(**tm.no_cupy())
     def test_device_dmat_from_cupy(self):
-        _test_from_cupy(xgb.DeviceDMatrix)
+        _test_from_cupy(xgb.DeviceQuantileDMatrix)
 
     @pytest.mark.skipif(**tm.no_cupy())
     def test_cupy_training_device_dmat(self):
-        _test_cupy_training(xgb.DeviceDMatrix)
+        _test_cupy_training(xgb.DeviceQuantileDMatrix)
 
     @pytest.mark.skipif(**tm.no_cupy())
     def test_cupy_training_simple_dmat(self):
@@ -121,4 +121,4 @@ Arrow specification.'''
 
     @pytest.mark.skipif(**tm.no_cupy())
     def test_cupy_metainfo_device_dmat(self):
-        _test_cupy_metainfo(xgb.DeviceDMatrix)
+        _test_cupy_metainfo(xgb.DeviceQuantileDMatrix)

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -43,22 +43,13 @@ class TestGPU(unittest.TestCase):
 
     @pytest.mark.skipif(**tm.no_cupy())
     def test_gpu_hist_device_dmatrix(self):
-        # Cannot vary max_bin yet
-        device_dmatrix_test_param = parameter_combinations({
-            'gpu_id': [0],
-            'max_depth': [2, 8],
-            'max_leaves': [255, 4],
-            'max_bin': [256],
-            'grow_policy': ['lossguide'],
-            'single_precision_histogram': [True],
-            'min_child_weight': [0],
-            'lambda': [0]})
         # DeviceDMatrix does not currently accept sparse formats
         device_dmatrix_datasets = ["Boston", "Cancer", "Digits"]
-        for param in device_dmatrix_test_param:
+        for param in test_param:
             param['tree_method'] = 'gpu_hist'
             gpu_results_device_dmatrix = run_suite(param, select_datasets=device_dmatrix_datasets,
-                                                   DMatrixT=xgb.DeviceDMatrix)
+                                                   DMatrixT=xgb.DeviceQuantileDMatrix,
+                                                   dmatrix_params={'max_bin': param['max_bin']})
             assert_results_non_increasing(gpu_results_device_dmatrix, 1e-2)
             gpu_results = run_suite(param, select_datasets=device_dmatrix_datasets)
             assert_gpu_results(gpu_results, gpu_results_device_dmatrix)

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -40,6 +40,7 @@ class TestGPU(unittest.TestCase):
             cpu_results = run_suite(param, select_datasets=datasets)
             assert_gpu_results(cpu_results, gpu_results)
 
+    @pytest.mark.skipif(**tm.no_cupy())
     def test_gpu_hist_device_dmatrix(self):
         # Cannot vary max_bin yet
         device_dmatrix_test_param = parameter_combinations({

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -5,6 +5,7 @@ import pytest
 import xgboost as xgb
 
 sys.path.append("tests/python")
+import testing as tm
 from regression_test_utilities import run_suite, parameter_combinations, \
     assert_results_non_increasing
 

--- a/tests/python/regression_test_utilities.py
+++ b/tests/python/regression_test_utilities.py
@@ -101,7 +101,7 @@ def train_dataset(dataset, param_in, num_rounds=10, scale_features=False, DMatri
                    delimiter=',')
         dtrain = DMatrixT('tmptmp_1234.csv?format=csv&label_column=0#tmptmp_',
                              weight=dataset.w)
-    if DMatrixT is xgb.DeviceDMatrix:
+    elif DMatrixT is xgb.DeviceDMatrix:
         import cupy as cp
         dtrain = DMatrixT(cp.array(X), dataset.y, weight=dataset.w)
     else:

--- a/tests/python/regression_test_utilities.py
+++ b/tests/python/regression_test_utilities.py
@@ -84,7 +84,7 @@ def get_weights_regression(min_weight, max_weight):
     return X, y, w
 
 
-def train_dataset(dataset, param_in, num_rounds=10, scale_features=False):
+def train_dataset(dataset, param_in, num_rounds=10, scale_features=False, DMatrixT=xgb.DMatrix):
     param = param_in.copy()
     param["objective"] = dataset.objective
     if dataset.objective == "multi:softmax":
@@ -99,10 +99,13 @@ def train_dataset(dataset, param_in, num_rounds=10, scale_features=False):
     if dataset.use_external_memory:
         np.savetxt('tmptmp_1234.csv', np.hstack((dataset.y.reshape(len(dataset.y), 1), X)),
                    delimiter=',')
-        dtrain = xgb.DMatrix('tmptmp_1234.csv?format=csv&label_column=0#tmptmp_',
+        dtrain = DMatrixT('tmptmp_1234.csv?format=csv&label_column=0#tmptmp_',
                              weight=dataset.w)
+    if DMatrixT is xgb.DeviceDMatrix:
+        import cupy as cp
+        dtrain = DMatrixT(cp.array(X), dataset.y, weight=dataset.w)
     else:
-        dtrain = xgb.DMatrix(X, dataset.y, weight=dataset.w)
+        dtrain = DMatrixT(X, dataset.y, weight=dataset.w)
 
     print("Training on dataset: " + dataset.name, file=sys.stderr)
     print("Using parameters: " + str(param), file=sys.stderr)
@@ -139,7 +142,7 @@ def parameter_combinations(variable_param):
     return result
 
 
-def run_suite(param, num_rounds=10, select_datasets=None, scale_features=False):
+def run_suite(param, num_rounds=10, select_datasets=None, scale_features=False, DMatrixT=xgb.DMatrix):
     """
     Run the given parameters on a range of datasets. Objective and eval metric will be automatically set
     """
@@ -162,7 +165,8 @@ def run_suite(param, num_rounds=10, select_datasets=None, scale_features=False):
     for d in datasets:
         if select_datasets is None or d.name in select_datasets:
             results.append(
-                train_dataset(d, param, num_rounds=num_rounds, scale_features=scale_features))
+                train_dataset(d, param, num_rounds=num_rounds, scale_features=scale_features,
+                              DMatrixT=DMatrixT))
     return results
 
 


### PR DESCRIPTION
This is a proof of concept for a DMatrix class that only contains an EllPack page and may be created efficiently from cupy/cudf inputs. See #5143 for roadmap.

Issues to be resolved:
- The DeviceDMatrix currently has no way to get the parameter `max_bin` so is fixed on 256 bins. 
- I directly exposed the DMatrix class in python. Not sure if this is necessary or the best way to do things.
- 2 new C API functions are added. Again not sure if this is the best approach or we should pass parameters into existing functions to select DMatrix type.