### PR TITLE
[R-package] fixed uses of class()

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -28,7 +28,7 @@ NVL <- function(x, val) {
 # Merges booster params with whatever is provided in ...
 # plus runs some checks
 check.booster.params <- function(params, ...) {
-  if (typeof(params) != "list")
+  if (!identical(class(params), "list"))
     stop("params must be a list")
 
   # in R interface, allow for '.' instead of '_' in parameter names
@@ -78,7 +78,7 @@ check.booster.params <- function(params, ...) {
   if (!is.null(params[['interaction_constraints']]) &&
       typeof(params[['interaction_constraints']]) != "character"){
     # check input class
-    if (class(params[['interaction_constraints']]) != 'list') stop('interaction_constraints should be class list')
+    if (!identical(class(params[['interaction_constraints']]),'list')) stop('interaction_constraints should be class list')
     if (!all(unique(sapply(params[['interaction_constraints']], class)) %in% c('numeric','integer'))) {
       stop('interaction_constraints should be a list of numeric/integer vectors')
     }


### PR DESCRIPTION
In this PR, I'd like to propose a minor change in the R package. I found two passes where `typeof(x) == 'list` or `typeof(x) != 'list'` is being used to check that something is a list.

This check isn't totally safe, since `data.table` or `data.frame` objects will pass this check.

>  typeof(data.frame())
> > [1] "list"
>
> typeof(data.table::data.table())
> > [1] "list"
>

In this PR, I propose changing to a stricter check, `identical(class(x)) == 'list'`.

Thanks for your time and consideration!