### PR TITLE
[R-package] changed FindLibR to take advantage of CMake cache

### DIFF
--- a/cmake/modules/FindLibR.cmake
+++ b/cmake/modules/FindLibR.cmake
@@ -50,10 +50,10 @@ function(create_rlib_for_msvc)
       \nDo you have Rtools installed with its MinGW's bin/ in PATH?")
   endif()  
   # extract symbols from R.dll into R.def and R.lib import library
-  execute_process(COMMAND gendef
+  execute_process(COMMAND ${GENDEF_EXE}
     "-" "${LIBR_LIB_DIR}/R.dll"
     OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/R.def")
-  execute_process(COMMAND dlltool
+  execute_process(COMMAND ${DLLTOOL_EXE}
     "--input-def" "${CMAKE_CURRENT_BINARY_DIR}/R.def"
     "--output-lib" "${CMAKE_CURRENT_BINARY_DIR}/R.lib")
 endfunction(create_rlib_for_msvc)


### PR DESCRIPTION
I've been using this project's `FindLibR.cmake` as a reference, and noticed something that I think could be improved.

According to the [cmake docs](https://cmake.org/cmake/help/v3.12/command/find_program.html):

> This command is used to find a program. A cache entry named by <VAR> is created to store the result of this command. If the program is found the result is stored in the variable and the search will not be repeated unless the variable is cleared. If nothing is found, the result will be <VAR>-NOTFOUND, and the search will be attempted again the next time find_program is invoked with the same variable.

As far as I can tell right now, this script's uses of `find_program()` for `gendef` and `dlltool` isn't taking advantage of that caching, and is repeating the search for those programs when it calls `execute_process()`. In this PR, I propose directly reading the path to those executables from the cache.

Thanks for your time and consideration!