### PR TITLE
Define _CRT_SECURE_NO_WARNINGS to remove unneeded warnings in MSVC

### DIFF
--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -69,6 +69,10 @@
 #define XGBOOST_PARALLEL_STABLE_SORT(X, Y, Z) std::stable_sort((X), (Y), (Z))
 #endif  // GLIBC VERSION
 
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+#define _CRT_SECURE_NO_WARNINGS
+#endif  //  defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+
 #if defined(__GNUC__)
 #define XGBOOST_EXPECT(cond, ret)  __builtin_expect((cond), (ret))
 #else


### PR DESCRIPTION
MSVC prints out warnings like
* `warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead.`
* `warning C4996: 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead.`

We cannot use `fopen_s` or `_dupenv_s` because they are Microsoft extensions and are not supported by POSIX-like OSes (including Linux).

Fix: Define `_CRT_SECURE_NO_WARNINGS` macro to ignore such warnings. The effect will be to declutter build logs and to speed up builds slightly (console printing on Windows is slow).

TODO: File a PR to dmlc-core and rabit to define  `_CRT_SECURE_NO_WARNINGS` there too.