### PR TITLE
Define _CRT_SECURE_NO_WARNINGS to remove unneeded warnings in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,14 @@ set_target_properties(dmlc PROPERTIES
   CXX_STANDARD_REQUIRED ON
   POSITION_INDEPENDENT_CODE ON)
 list(APPEND LINKED_LIBRARIES_PRIVATE dmlc)
+if (MSVC)
+  target_compile_options(dmlc PRIVATE
+                         -D_CRT_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE)
+  if (TARGET dmlc_unit_tests)
+    target_compile_options(dmlc_unit_tests PRIVATE
+                           -D_CRT_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE)
+  endif (TARGET dmlc_unit_tests)
+endif (MSVC)
 
 # rabit
 set(RABIT_BUILD_DMLC OFF)
@@ -120,8 +128,16 @@ add_subdirectory(rabit)
 
 if (RABIT_MOCK)
   list(APPEND LINKED_LIBRARIES_PRIVATE rabit_mock_static)
+  if (MSVC)
+    target_compile_options(rabit_mock_static PRIVATE
+                           -D_CRT_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE)
+  endif (MSVC)
 else()
   list(APPEND LINKED_LIBRARIES_PRIVATE rabit)
+  if (MSVC)
+    target_compile_options(rabit PRIVATE
+                           -D_CRT_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE)
+  endif (MSVC)
 endif(RABIT_MOCK)
 
 # Exports some R specific definitions and objects

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,8 @@ endif (WIN32 AND MINGW)
 if (MSVC)
   target_compile_options(objxgboost PRIVATE
     $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/utf-8>
+    -D_CRT_SECURE_NO_WARNINGS
+    -D_CRT_SECURE_NO_DEPRECATE
   )
 endif (MSVC)
 

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -53,6 +53,8 @@ endif (USE_CUDA)
 if (MSVC)
   target_compile_options(testxgboost PRIVATE
     $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/utf-8>
+    -D_CRT_SECURE_NO_WARNINGS
+    -D_CRT_SECURE_NO_DEPRECATE
   )
 endif (MSVC)
 


### PR DESCRIPTION
MSVC prints out warnings like
* `warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead.`
* `warning C4996: 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead.`

We cannot use `fopen_s` or `_dupenv_s` because they are Microsoft extensions and are not supported by POSIX-like OSes (including Linux).

Fix: Define `_CRT_SECURE_NO_WARNINGS` macro to ignore such warnings. The effect will be to declutter build logs and to speed up builds slightly (console printing on Windows is slow).

Depends on https://github.com/dmlc/rabit/pull/136.