### PR TITLE
Add link to GPU documentation

### DIFF
--- a/plugin/updater_gpu/README.md
+++ b/plugin/updater_gpu/README.md
@@ -1,0 +1,3 @@
+# XGBoost GPU algorithms
+
+GPU algorithms are no longer a plugin and are included in official releases. [See documentation for more details](https://xgboost.readthedocs.io/en/latest/gpu/).


### PR DESCRIPTION
There is a broken URL to GPU algorithms in this paper:
Mitchell, R., & Frank, E. (2017). Accelerating the XGBoost algorithm using GPU computing. PeerJ Computer Science, 3, e127.