### PR TITLE
[R-package] fixed inconsistency in R -e calls in FindLibR.cmake

### DIFF
--- a/cmake/modules/FindLibR.cmake
+++ b/cmake/modules/FindLibR.cmake
@@ -103,12 +103,12 @@ else()
     )
     # ask R for the include dir
     execute_process(
-      COMMAND ${LIBR_EXECUTABLE} "--slave" "--no-save" "-e" "cat(R.home('include'))"
+      COMMAND ${LIBR_EXECUTABLE} "--slave" "--vanilla" "-e" "cat(R.home('include'))"
       OUTPUT_VARIABLE LIBR_INCLUDE_DIRS
     )
     # ask R for the lib dir
     execute_process(
-      COMMAND ${LIBR_EXECUTABLE} "--slave" "--no-save" "-e" "cat(R.home('lib'))"
+      COMMAND ${LIBR_EXECUTABLE} "--slave" "--vanilla" "-e" "cat(R.home('lib'))"
       OUTPUT_VARIABLE LIBR_LIB_DIR
     )
 


### PR DESCRIPTION
In this PR, I want to propose cleaning up an inconsistency in `FindLibR.cmake` to make installation of the R package more reliable.

I think that the searches for `LIBR_INCLUDE_DIRS` and `LIBR_LIB_DIR` should use `--vanilla`  to ignore any `.Rprofile` files and the calling environment. This will reduce the chance that a user's particular R setup could cause failures in these calls.

Thanks for your consideration!