### PR TITLE
Split up test helpers header.

### DIFF
--- a/tests/cpp/data/test_ellpack_page.cu
+++ b/tests/cpp/data/test_ellpack_page.cu
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "../helpers.h"
+#include "../histogram_helpers.h"
 #include "gtest/gtest.h"
 
 #include "../../../src/common/hist_util.h"

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -18,13 +18,9 @@
 #include <xgboost/base.h>
 #include <xgboost/json.h>
 #include <xgboost/generic_parameters.h>
-#include <xgboost/c_api.h>
 
 #include "../../src/common/common.h"
 #include "../../src/gbm/gbtree_model.h"
-#if defined(__CUDACC__)
-#include "../../src/data/ellpack_page.cuh"
-#endif
 
 #if defined(__CUDACC__)
 #define DeclareUnifiedTest(name) GPU ## name
@@ -42,6 +38,7 @@ namespace xgboost {
 class ObjFunction;
 class Metric;
 struct LearnerModelParam;
+class GradientBooster;
 }
 
 bool FileExists(const std::string& filename);
@@ -271,53 +268,5 @@ inline HostDeviceVector<GradientPair> GenerateRandomGradients(const size_t n_row
   HostDeviceVector<GradientPair> gpair(h_gpair);
   return gpair;
 }
-
-#if defined(__CUDACC__)
-namespace {
-class HistogramCutsWrapper : public common::HistogramCuts {
- public:
-  using SuperT = common::HistogramCuts;
-  void SetValues(std::vector<float> cuts) {
-    SuperT::cut_values_.HostVector() = std::move(cuts);
-  }
-  void SetPtrs(std::vector<uint32_t> ptrs) {
-    SuperT::cut_ptrs_.HostVector() = std::move(ptrs);
-  }
-  void SetMins(std::vector<float> mins) {
-    SuperT::min_vals_.HostVector() = std::move(mins);
-  }
-};
-}  //  anonymous namespace
-
-inline std::unique_ptr<EllpackPageImpl> BuildEllpackPage(
-    int n_rows, int n_cols, bst_float sparsity= 0) {
-  auto dmat = RandomDataGenerator(n_rows, n_cols, sparsity).Seed(3).GenerateDMatix();
-  const SparsePage& batch = *dmat->GetBatches<xgboost::SparsePage>().begin();
-
-  HistogramCutsWrapper cmat;
-  cmat.SetPtrs({0, 3, 6, 9, 12, 15, 18, 21, 24});
-  // 24 cut fields, 3 cut fields for each feature (column).
-  cmat.SetValues({0.30f, 0.67f, 1.64f,
-          0.32f, 0.77f, 1.95f,
-          0.29f, 0.70f, 1.80f,
-          0.32f, 0.75f, 1.85f,
-          0.18f, 0.59f, 1.69f,
-          0.25f, 0.74f, 2.00f,
-          0.26f, 0.74f, 1.98f,
-          0.26f, 0.71f, 1.83f});
-  cmat.SetMins({0.1f, 0.2f, 0.3f, 0.1f, 0.2f, 0.3f, 0.2f, 0.2f});
-
-  bst_row_t row_stride = 0;
-  const auto &offset_vec = batch.offset.ConstHostVector();
-  for (size_t i = 1; i < offset_vec.size(); ++i) {
-    row_stride = std::max(row_stride, offset_vec[i] - offset_vec[i-1]);
-  }
-
-  auto page = std::unique_ptr<EllpackPageImpl>(
-      new EllpackPageImpl(0, cmat, batch, dmat->IsDense(), row_stride));
-
-  return page;
-}
-#endif
 }  // namespace xgboost
 #endif

--- a/tests/cpp/histogram_helpers.h
+++ b/tests/cpp/histogram_helpers.h
@@ -1,0 +1,53 @@
+#if defined(__CUDACC__)
+#include "../../src/data/ellpack_page.cuh"
+#endif
+
+namespace xgboost {
+#if defined(__CUDACC__)
+namespace {
+class HistogramCutsWrapper : public common::HistogramCuts {
+ public:
+  using SuperT = common::HistogramCuts;
+  void SetValues(std::vector<float> cuts) {
+    SuperT::cut_values_.HostVector() = std::move(cuts);
+  }
+  void SetPtrs(std::vector<uint32_t> ptrs) {
+    SuperT::cut_ptrs_.HostVector() = std::move(ptrs);
+  }
+  void SetMins(std::vector<float> mins) {
+    SuperT::min_vals_.HostVector() = std::move(mins);
+  }
+};
+}  //  anonymous namespace
+
+inline std::unique_ptr<EllpackPageImpl> BuildEllpackPage(
+    int n_rows, int n_cols, bst_float sparsity= 0) {
+  auto dmat = RandomDataGenerator(n_rows, n_cols, sparsity).Seed(3).GenerateDMatix();
+  const SparsePage& batch = *dmat->GetBatches<xgboost::SparsePage>().begin();
+
+  HistogramCutsWrapper cmat;
+  cmat.SetPtrs({0, 3, 6, 9, 12, 15, 18, 21, 24});
+  // 24 cut fields, 3 cut fields for each feature (column).
+  cmat.SetValues({0.30f, 0.67f, 1.64f,
+          0.32f, 0.77f, 1.95f,
+          0.29f, 0.70f, 1.80f,
+          0.32f, 0.75f, 1.85f,
+          0.18f, 0.59f, 1.69f,
+          0.25f, 0.74f, 2.00f,
+          0.26f, 0.74f, 1.98f,
+          0.26f, 0.71f, 1.83f});
+  cmat.SetMins({0.1f, 0.2f, 0.3f, 0.1f, 0.2f, 0.3f, 0.2f, 0.2f});
+
+  bst_row_t row_stride = 0;
+  const auto &offset_vec = batch.offset.ConstHostVector();
+  for (size_t i = 1; i < offset_vec.size(); ++i) {
+    row_stride = std::max(row_stride, offset_vec[i] - offset_vec[i-1]);
+  }
+
+  auto page = std::unique_ptr<EllpackPageImpl>(
+      new EllpackPageImpl(0, cmat, batch, dmat->IsDense(), row_stride));
+
+  return page;
+}
+#endif
+}  // namespace xgboost

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -1,6 +1,7 @@
 /*!
  * Copyright 2017-2020 XGBoost contributors
  */
+#include <gtest/gtest.h>
 #include <thrust/device_vector.h>
 #include <dmlc/filesystem.h>
 #include <xgboost/base.h>
@@ -9,7 +10,7 @@
 #include <vector>
 
 #include "../helpers.h"
-#include "gtest/gtest.h"
+#include "../histogram_helpers.h"
 
 #include "xgboost/json.h"
 #include "../../../src/data/sparse_page_source.h"


### PR DESCRIPTION
Extracted from #5460 .

This PR splits ellpack page construction into a different header.  As including histogram related header in `helpers.h` includes a lots of file.  Any of them is changed all tests have to be recompiled.