### PR TITLE
Fix uninitialized value bug in xgboost callback

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -209,6 +209,10 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
             state['best_score'] = float('-inf')
         else:
             state['best_score'] = float('inf')
+        msg = '[%d]\t%s' % (
+              env.iteration,
+              '\t'.join([_fmt_metric(x) for x in env.evaluation_result_list]))
+        state['best_msg'] = msg
 
         if bst is not None:
             if bst.attr('best_score') is not None:

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -210,8 +210,8 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
         else:
             state['best_score'] = float('inf')
         msg = '[%d]\t%s' % (
-              env.iteration,
-              '\t'.join([_fmt_metric(x) for x in env.evaluation_result_list]))
+            env.iteration,
+            '\t'.join([_fmt_metric(x) for x in env.evaluation_result_list]))
         state['best_msg'] = msg
 
         if bst is not None:


### PR DESCRIPTION
Issue: [Dictionary key referenced before assignment during early stop](https://github.com/dmlc/xgboost/issues/5424)  Closes #5424 .

Bug in early stopping rounds callback function when calling xgboost.cv() where dictionary value is never set. In the case where the model makes no improvements starting in the first iteration, state['best_msg'] is never set and there is a KeyError when the callback function returns after the early stopping rounds. I added an initial value (default message) for state['best_msg'] in the place where state['best_score'], etc get initial values.