### PR TITLE
Reduce span check overhead.

### DIFF
--- a/include/xgboost/span.h
+++ b/include/xgboost/span.h
@@ -96,7 +96,7 @@ namespace common {
       std::terminate();                                                        \
     }                                                                          \
   } while (0);
-#endif // __CUDA_ARCH__
+#endif  // __CUDA_ARCH__
 
 namespace detail {
 /*!

--- a/include/xgboost/span.h
+++ b/include/xgboost/span.h
@@ -93,9 +93,9 @@ namespace common {
     if (XGBOOST_EXPECT(!(cond), false)) {                                      \
       fprintf(stderr, "[xgboost] Condition %s failed.\n", #cond);              \
       std::terminate();                                                        \
-    };                                                                         \
+    }                                                                          \
   } while (0);
-#endif // __CUDA_ARCH__
+#endif  // __CUDA_ARCH__
 
 namespace detail {
 /*!

--- a/include/xgboost/span.h
+++ b/include/xgboost/span.h
@@ -92,10 +92,11 @@ namespace common {
   do {                                                                         \
     if (XGBOOST_EXPECT(!(cond), false)) {                                      \
       fprintf(stderr, "[xgboost] Condition %s failed.\n", #cond);              \
+      fflush(stderr);  /* It seems stderr on Windows is beffered? */           \
       std::terminate();                                                        \
     }                                                                          \
   } while (0);
-#endif  // __CUDA_ARCH__
+#endif // __CUDA_ARCH__
 
 namespace detail {
 /*!

--- a/tests/cpp/common/test_span.cc
+++ b/tests/cpp/common/test_span.cc
@@ -99,7 +99,7 @@ TEST(Span, FromPtrLen) {
 
   {
     auto lazy = [=]() {Span<float const, 16> tmp (arr, 5);};
-    EXPECT_ANY_THROW(lazy());
+    EXPECT_DEATH(lazy(), "\\[xgboost\\] Condition .* failed.\n");
   }
 
   // dynamic extent
@@ -286,11 +286,11 @@ TEST(Span, ElementAccess) {
     ++j;
   }
 
-  EXPECT_ANY_THROW(s[16]);
-  EXPECT_ANY_THROW(s[-1]);
+  EXPECT_DEATH(s[16], "\\[xgboost\\] Condition .* failed.\n");
+  EXPECT_DEATH(s[-1], "\\[xgboost\\] Condition .* failed.\n");
 
-  EXPECT_ANY_THROW(s(16));
-  EXPECT_ANY_THROW(s(-1));
+  EXPECT_DEATH(s(16), "\\[xgboost\\] Condition .* failed.\n");
+  EXPECT_DEATH(s(-1), "\\[xgboost\\] Condition .* failed.\n");
 }
 
 TEST(Span, Obversers) {
@@ -315,13 +315,13 @@ TEST(Span, FrontBack) {
 
   {
     Span<float, 0> s;
-    EXPECT_ANY_THROW(s.front());
-    EXPECT_ANY_THROW(s.back());
+    EXPECT_DEATH(s.front(), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.back(), "\\[xgboost\\] Condition .* failed.\n");
   }
   {
     Span<float> s;
-    EXPECT_ANY_THROW(s.front());
-    EXPECT_ANY_THROW(s.back());
+    EXPECT_DEATH(s.front(), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.back(), "\\[xgboost\\] Condition .* failed.\n");
   }
 }
 
@@ -341,9 +341,9 @@ TEST(Span, FirstLast) {
       ASSERT_EQ(first[i], arr[i]);
     }
     auto constexpr kOne = static_cast<Span<float, 4>::index_type>(-1);
-    EXPECT_ANY_THROW(s.first<kOne>());
-    EXPECT_ANY_THROW(s.first<17>());
-    EXPECT_ANY_THROW(s.first<32>());
+    EXPECT_DEATH(s.first<kOne>(), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.first<17>(), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.first<32>(), "\\[xgboost\\] Condition .* failed.\n");
   }
 
   {
@@ -360,9 +360,9 @@ TEST(Span, FirstLast) {
       ASSERT_EQ(last[i], arr[i+12]);
     }
     auto constexpr kOne = static_cast<Span<float, 4>::index_type>(-1);
-    EXPECT_ANY_THROW(s.last<kOne>());
-    EXPECT_ANY_THROW(s.last<17>());
-    EXPECT_ANY_THROW(s.last<32>());
+    EXPECT_DEATH(s.last<kOne>(), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.last<17>(), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.last<32>(), "\\[xgboost\\] Condition .* failed.\n");
   }
 
   // dynamic extent
@@ -379,9 +379,9 @@ TEST(Span, FirstLast) {
       ASSERT_EQ(first[i], s[i]);
     }
 
-    EXPECT_ANY_THROW(s.first(-1));
-    EXPECT_ANY_THROW(s.first(17));
-    EXPECT_ANY_THROW(s.first(32));
+    EXPECT_DEATH(s.first(-1), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.first(17), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.first(32), "\\[xgboost\\] Condition .* failed.\n");
 
     delete [] arr;
   }
@@ -399,9 +399,9 @@ TEST(Span, FirstLast) {
       ASSERT_EQ(s[12 + i], last[i]);
     }
 
-    EXPECT_ANY_THROW(s.last(-1));
-    EXPECT_ANY_THROW(s.last(17));
-    EXPECT_ANY_THROW(s.last(32));
+    EXPECT_DEATH(s.last(-1), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.last(17), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.last(32), "\\[xgboost\\] Condition .* failed.\n");
 
     delete [] arr;
   }
@@ -421,12 +421,12 @@ TEST(Span, Subspan) {
   ASSERT_EQ(s1.data() + 2, s4.data());
   ASSERT_EQ(s4.size(), s1.size() - 2);
 
-  EXPECT_ANY_THROW(s1.subspan(-1, 0));
-  EXPECT_ANY_THROW(s1.subspan(16, 0));
+  EXPECT_DEATH(s1.subspan(-1, 0), "\\[xgboost\\] Condition .* failed.\n");
+  EXPECT_DEATH(s1.subspan(16, 0), "\\[xgboost\\] Condition .* failed.\n");
 
   auto constexpr kOne = static_cast<Span<int, 4>::index_type>(-1);
-  EXPECT_ANY_THROW(s1.subspan<kOne>());
-  EXPECT_ANY_THROW(s1.subspan<16>());
+  EXPECT_DEATH(s1.subspan<kOne>(), "\\[xgboost\\] Condition .* failed.\n");
+  EXPECT_DEATH(s1.subspan<16>(), "\\[xgboost\\] Condition .* failed.\n");
 }
 
 TEST(Span, Compare) {

--- a/tests/cpp/common/test_transform_range.cc
+++ b/tests/cpp/common/test_transform_range.cc
@@ -63,11 +63,11 @@ TEST(Transform, Exception) {
   size_t const kSize {16};
   std::vector<bst_float> h_in(kSize);
   const HostDeviceVector<bst_float> in_vec{h_in, -1};
-  EXPECT_ANY_THROW({
+  EXPECT_DEATH({
     Transform<>::Init([](size_t idx, common::Span<float const> _in) { _in[idx + 1]; },
                       Range(0, static_cast<Range::DifferenceType>(kSize)), -1)
         .Eval(&in_vec);
-  });
+    }, "");
 }
 #endif
 


### PR DESCRIPTION
Related: #5461

From my bench having span check is about 10% slower with higgs dataset (a dense dataset is be good enough for this case)  running https://github.com/NVIDIA/gbm-bench .  This PR drops it to 5% while still keeping the possibility of printing out error message.

I still want to keep the check as there are always surprises in real world.