### PR TITLE
corrected spelling of 'list'

### DIFF
--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -101,7 +101,7 @@
 #'         (only available with early stopping).
 #'   \item \code{pred} CV prediction values available when \code{prediction} is set.
 #'         It is either vector or matrix (see \code{\link{cb.cv.predict}}).
-#'   \item \code{models} a liost of the CV folds' models. It is only available with the explicit
+#'   \item \code{models} a list of the CV folds' models. It is only available with the explicit
 #'         setting of the \code{cb.cv.predict(save_models = TRUE)} callback.
 #' }
 #'


### PR DESCRIPTION
Corrected spelling in `xgb.cv.R`. 

I'd be happy to rebuild the documentation... but I'm having issues.
Are `roxygen2::roxygenise()` or `devtools::document()` used? Both fail with the following:
```
 xgboost_R.cc:2:10:fatal error: logging.h: No such file or directory
    #include <dmlc/logging.h>
             ^~~~~~~~~~~~~~~~
   compilation terminated.
   /usr/lib/R/etc/Makeconf:175: recipe for target 'xgboost_R.o' failed
   make: *** [xgboost_R.o] Error 1
   ERROR: compilation failed for package `xgboost`
```

I tried the `make html` from the doc folder, but I get the perplexing:
```
sphinx-build -b html -d _build/doctrees   . _build/html
Traceback (most recent call last):
  File "/usr/bin/sphinx-build", line 14, in <module>
    from sphinx import main
ImportError: cannot import name 'main'
Makefile:55: recipe for target 'html' failed
make: *** [html] Error 1
```