### PR TITLE
Fix cli dump model.

### DIFF
--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -199,7 +199,7 @@ class Learner : public Model, public Configurable, public rabit::Serializable {
    */
   virtual std::vector<std::string> DumpModel(const FeatureMap& fmap,
                                              bool with_stats,
-                                             std::string format) const = 0;
+                                             std::string format) = 0;
 
   virtual XGBAPIThreadLocalEntry& GetThreadLocal() const = 0;
   /*!

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -663,7 +663,6 @@ inline void XGBoostDumpModelImpl(BoosterHandle handle, const FeatureMap &fmap,
   auto *bst = static_cast<Learner*>(handle);
   std::vector<std::string>& str_vecs = bst->GetThreadLocal().ret_vec_str;
   std::vector<const char*>& charp_vecs = bst->GetThreadLocal().ret_vec_charp;
-  bst->Configure();
   str_vecs = bst->DumpModel(fmap, with_stats != 0, format);
   charp_vecs.resize(str_vecs.size());
   for (size_t i = 0; i < str_vecs.size(); ++i) {

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -897,9 +897,8 @@ class LearnerImpl : public LearnerIO {
 
   std::vector<std::string> DumpModel(const FeatureMap& fmap,
                                      bool with_stats,
-                                     std::string format) const override {
-    CHECK(!this->need_configuration_)
-        << "The model hasn't been built yet.  Are you using raw Booster interface?";
+                                     std::string format) override {
+    this->Configure();
     return gbm_->DumpModel(fmap, with_stats, format);
   }
 


### PR DESCRIPTION
The error shows up by running `demo/regression`, mentioned by a user contacting me via mail.

This forces `Configure` in `DumpModel`, as a result, this function is no-longer const.