### PR TITLE
Obtain num boosted rounds directly from booster.

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -356,6 +356,15 @@ XGB_DLL int XGBoosterCreate(const DMatrixHandle dmats[],
 XGB_DLL int XGBoosterFree(BoosterHandle handle);
 
 /*!
+ * \brief Get number of boosted rounds from gradient booster.  When process_type is
+ *        update, this number might drop due to removed tree.
+ * \param handle Handle to booster.
+ * \param out Pointer to output integer.
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterBoostedRounds(BoosterHandle handle, int* out);
+
+/*!
  * \brief set parameters
  * \param handle handle
  * \param name  parameter name

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -68,6 +68,9 @@ class GradientBooster : public Model, public Configurable {
   virtual bool AllowLazyCheckPoint() const {
     return false;
   }
+  /*! \brief Return number of boosted rounds.
+   */
+  virtual int32_t BoostedRounds() const = 0;
   /*!
    * \brief perform update to the model(boosting)
    * \param p_fmat feature matrix that provide access to features

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -135,6 +135,10 @@ class Learner : public Model, public Configurable, public rabit::Serializable {
                               float missing,
                               HostDeviceVector<bst_float> **out_preds,
                               uint32_t layer_begin = 0, uint32_t layer_end = 0) = 0;
+  /*
+   * \brief Get number of boosted rounds from gradient booster.
+   */
+  virtual int32_t BoostedRounds() const = 0;
 
   void LoadModel(Json const& in) override = 0;
   void SaveModel(Json* out) const override = 0;

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -204,7 +204,7 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
             rabit.tracker_print(msg.format(metric_label, stopping_rounds))
 
         state['maximize_score'] = maximize_score
-        state['best_iteration'] = 0
+
         if maximize_score:
             state['best_score'] = float('-inf')
         else:
@@ -216,9 +216,11 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
                 state['best_iteration'] = int(bst.attr('best_iteration'))
                 state['best_msg'] = bst.attr('best_msg')
             else:
+                state['best_iteration'] = 0
                 bst.set_attr(best_iteration=str(state['best_iteration']))
                 bst.set_attr(best_score=str(state['best_score']))
         else:
+            state['best_iteration'] = 0
             assert env.cvfolds is not None
 
     def callback(env):

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1787,6 +1787,10 @@ class Booster(object):
             raise TypeError('Unknown file type: ', fname)
 
     def num_boosted_rounds(self):
+        '''Get number of boosted rounds.  For gblinear this is reset to 0 after
+        serializing the model.
+
+        '''
         rounds = ctypes.c_int()
         assert self.handle is not None
         _check_call(_LIB.XGBoosterBoostedRounds(

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1786,6 +1786,13 @@ class Booster(object):
         else:
             raise TypeError('Unknown file type: ', fname)
 
+    def num_boosted_rounds(self):
+        rounds = ctypes.c_int()
+        assert self.handle is not None
+        _check_call(_LIB.XGBoosterBoostedRounds(
+            self.handle, ctypes.byref(rounds)))
+        return rounds.value
+
     def dump_model(self, fout, fmap='', with_stats=False, dump_format="text"):
         """Dump model into a text or JSON file.
 

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -96,8 +96,11 @@ def _train_internal(params, dtrain,
         bst.best_iteration = int(bst.attr('best_iteration'))
     else:
         bst.best_iteration = bst.num_boosted_rounds()
-    num_parallel_tree = int(json.loads(bst.save_config())['learner'][
-        'gradient_booster']['gbtree_train_param']['num_parallel_tree'])
+    try:
+        num_parallel_tree = int(json.loads(bst.save_config())['learner'][
+            'gradient_booster']['gbtree_train_param']['num_parallel_tree'])
+    except KeyError:            # gblinear
+        num_parallel_tree = 1
     bst.best_ntree_limit = (bst.best_iteration + 1) * num_parallel_tree
     return bst
 

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -2,6 +2,7 @@
 # pylint: disable=too-many-locals, too-many-arguments, invalid-name
 # pylint: disable=too-many-branches, too-many-statements
 """Training Library containing training routines."""
+import json
 import numpy as np
 from .core import Booster, STRING_TYPES, XGBoostError, CallbackEnv
 from .core import EarlyStopException
@@ -28,7 +29,6 @@ def _train_internal(params, dtrain,
             params += [('eval_metric', eval_metric)]
 
     bst = Booster(params, [dtrain] + [d[0] for d in evals])
-    num_parallel_tree = 1
 
     if xgb_model is not None:
         bst = Booster(params, [dtrain] + [d[0] for d in evals],
@@ -96,6 +96,8 @@ def _train_internal(params, dtrain,
         bst.best_iteration = int(bst.attr('best_iteration'))
     else:
         bst.best_iteration = bst.num_boosted_rounds()
+    num_parallel_tree = int(json.loads(bst.save_config())['learner'][
+        'gradient_booster']['gbtree_train_param']['num_parallel_tree'])
     bst.best_ntree_limit = (bst.best_iteration + 1) * num_parallel_tree
     return bst
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -343,6 +343,14 @@ XGB_DLL int XGBoosterSetParam(BoosterHandle handle,
   API_END();
 }
 
+XGB_DLL int XGBoosterBoostedRounds(BoosterHandle handle, int* out) {
+  API_BEGIN();
+  CHECK_HANDLE();
+  static_cast<Learner*>(handle)->Configure();
+  *out = static_cast<Learner*>(handle)->BoostedRounds();
+  API_END();
+}
+
 XGB_DLL int XGBoosterLoadJsonConfig(BoosterHandle handle, char const* json_parameters) {
   API_BEGIN();
   CHECK_HANDLE();

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -73,6 +73,10 @@ class GBLinear : public GradientBooster {
     }
   }
 
+  int32_t BoostedRounds() const override {
+    return model_.num_boosted_rounds;
+  }
+
   void Load(dmlc::Stream* fi) override {
     model_.Load(fi);
   }
@@ -122,7 +126,7 @@ class GBLinear : public GradientBooster {
     if (!this->CheckConvergence()) {
       updater_->Update(in_gpair, p_fmat, &model_, sum_instance_weight_);
     }
-
+    model_.num_boosted_rounds ++;
     monitor_.Stop("DoBoost");
   }
 

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -126,7 +126,7 @@ class GBLinear : public GradientBooster {
     if (!this->CheckConvergence()) {
       updater_->Update(in_gpair, p_fmat, &model_, sum_instance_weight_);
     }
-    model_.num_boosted_rounds ++;
+    model_.num_boosted_rounds++;
     monitor_.Stop("DoBoost");
   }
 

--- a/src/gbm/gblinear_model.h
+++ b/src/gbm/gblinear_model.h
@@ -44,11 +44,12 @@ class GBLinearModel : public Model {
   DeprecatedGBLinearModelParam param_;
 
  public:
+  int32_t num_boosted_rounds;
   LearnerModelParam const* learner_model_param;
 
  public:
   explicit GBLinearModel(LearnerModelParam const* learner_model_param) :
-      learner_model_param {learner_model_param} {}
+      num_boosted_rounds{0}, learner_model_param {learner_model_param} {}
   void Configure(Args const &cfg) { }
 
   // weight for each of feature, bias is the last one

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -198,6 +198,14 @@ class GBTree : public GradientBooster {
     return model_.learner_model_param->num_output_group == 1;
   }
 
+  int32_t BoostedRounds() const override {
+    CHECK_NE(tparam_.num_parallel_tree, 0);
+    CHECK_NE(model_.learner_model_param->num_output_group, 0);
+    return model_.trees.size() /
+           model_.learner_model_param->num_output_group /
+           tparam_.num_parallel_tree;
+  }
+
   void PredictBatch(DMatrix* p_fmat,
                     PredictionCacheEntry* out_preds,
                     bool training,

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1005,7 +1005,7 @@ class LearnerImpl : public LearnerIO {
   }
 
   int32_t BoostedRounds() const override {
-    if (!this->gbm_) { return 0; } // haven't call train or LoadModel.
+    if (!this->gbm_) { return 0; }  // haven't call train or LoadModel.
     CHECK(!this->need_configuration_);
     return this->gbm_->BoostedRounds();
   }

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1004,6 +1004,12 @@ class LearnerImpl : public LearnerIO {
     }
   }
 
+  int32_t BoostedRounds() const override {
+    if (!this->gbm_) { return 0; } // haven't call train or LoadModel.
+    CHECK(!this->need_configuration_);
+    return this->gbm_->BoostedRounds();
+  }
+
   XGBAPIThreadLocalEntry& GetThreadLocal() const override {
     return (*XGBAPIThreadLocalStore::Get())[this];
   }

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -8,6 +8,7 @@
 #include <xgboost/learner.h>
 #include <xgboost/gbm.h>
 #include <xgboost/json.h>
+#include <xgboost/c_api.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -196,6 +196,20 @@ class TestModels(unittest.TestCase):
         predt_2 = bst.predict(dtrain)
         assert np.all(np.abs(predt_2 - predt_1) < 1e-6)
 
+    def test_boost_from_existing_model(self):
+        X = xgb.DMatrix(dpath + 'agaricus.txt.train')
+        booster = xgb.train({'tree_method': 'hist'}, X, num_boost_round=4)
+        assert booster.num_boosted_rounds() == 4
+        booster = xgb.train({'tree_method': 'hist'}, X, num_boost_round=4,
+                            xgb_model=booster)
+        assert booster.num_boosted_rounds() == 8
+        booster = xgb.train({'updater': 'prune', 'process_type': 'update'}, X,
+                            num_boost_round=4, xgb_model=booster)
+        # Trees are moved for update, the rounds is reduced.  This test is
+        # written for being compatible with current code (1.0.0).  If the
+        # behaviour is considered sub-optimal, feel free to change.
+        assert booster.num_boosted_rounds() == 4
+
     def test_custom_objective(self):
         param = {'max_depth': 2, 'eta': 1, 'verbosity': 0}
         watchlist = [(dtest, 'eval'), (dtrain, 'train')]

--- a/tests/python/test_early_stopping.py
+++ b/tests/python/test_early_stopping.py
@@ -47,7 +47,7 @@ class TestEarlyStopping(unittest.TestCase):
     @staticmethod
     def assert_metrics_length(cv, expected_length):
         for key, value in cv.items():
-          assert len(value) == expected_length
+            assert len(value) == expected_length
 
     @pytest.mark.skipif(**tm.no_sklearn())
     def test_cv_early_stopping(self):

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -64,6 +64,8 @@ def test_multiclass_classification():
     kf = KFold(n_splits=2, shuffle=True, random_state=rng)
     for train_index, test_index in kf.split(X, y):
         xgb_model = xgb.XGBClassifier().fit(X[train_index], y[train_index])
+        assert (xgb_model.get_booster().num_boosted_rounds() ==
+                xgb_model.n_estimators)
         preds = xgb_model.predict(X[test_index])
         # test other params in XGBClassifier().fit
         preds2 = xgb_model.predict(X[test_index], output_margin=True,


### PR DESCRIPTION
The PR tries to remove the hack for obtaining number of boosted rounds in Python.  I implemented the getter in c++ which directly counts the number of trees.

Most of the tests are already in `tests/python/test_training_continuation.py`, where `best_ntree_limit` is heavily tested.