### PR TITLE
Change type for GradStats to avoid conversion for hist method

### DIFF
--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -425,7 +425,11 @@ struct SplitEntryContainer {
    * \param split_index the feature index where the split is on
    */
   bool NeedReplace(bst_float new_loss_chg, unsigned split_index) const {
-    if (this->SplitIndex() <= split_index) {
+    if (std::isinf(new_loss_chg)) {  // in some cases new_loss_chg can be NaN or Inf,
+                                         // for example when lambda = 0 & min_child_weight = 0
+                                         // skip value in this case
+      return false;
+    } else if (this->SplitIndex() <= split_index) {
       return new_loss_chg > this->loss_chg;
     } else {
       return !(this->loss_chg > new_loss_chg);


### PR DESCRIPTION
This PR is supposed to change internal type of GradStats to avoid conversion for hist method. Also bug related to numerical instability in `NeedReplace` method.

Accuracy ~ the same as was with double type, and ex. for mnist data set was even improved:

mnist| log-loss
-- | --
Master |  0.07304085
This PR | 0.07301824

  

Similar changes were provided in PR:#4529 but full scope of  changes was reverted in https://github.com/dmlc/xgboost/pull/5008.

Performance improvements (**1.5x** for BuildHist):
santander| full train | InitData | BuildHist | SyncHist | PredictRaw
-- | -- | -- | -- |  -- | --
Master | 179.71 | 47.24 | 58.01 | 14 | 46.48
This PR | 162.94| 47.51 | 38.12 | 8.08| 54.7

santander| full train | BuildHist | SyncHist | ApplySplit
-- | -- | -- | -- |  --
Master | 78.511  | 34.82 | 23.29 | 1.28
This PR | 62.92 | 22.98 | 9.89| 1.14