### PR TITLE
Write binary header.

### DIFF
--- a/src/learner.cc
+++ b/src/learner.cc
@@ -653,9 +653,6 @@ class LearnerIO : public LearnerConfiguration {
     // read parameter
     CHECK_EQ(fi->Read(&mparam_, sizeof(mparam_)), sizeof(mparam_))
         << "BoostLearner: wrong model format";
-    if (mparam_.base_score + std::numeric_limits<float>::epsilon() == 2.81467e+23) {
-      mparam_.base_score += std::numeric_limits<float>::epsilon();
-    }
 
     CHECK(fi->Read(&tparam_.objective)) << "BoostLearner: wrong model format";
     CHECK(fi->Read(&tparam_.booster)) << "BoostLearner: wrong model format";
@@ -780,11 +777,6 @@ class LearnerIO : public LearnerConfiguration {
       }
       extra_attr.emplace_back("metrics", os.str());
     }
-    if (mparam.base_score == 2.81467e+23) {
-      // The magic number the collides with "binf";
-      mparam.base_score -= std::numeric_limits<float>::epsilon();
-    }
-
     std::string header {"binf"};
     fo->Write(header.data(), 4);
     fo->Write(&mparam, sizeof(LearnerModelParamLegacy));

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -653,6 +653,9 @@ class LearnerIO : public LearnerConfiguration {
     // read parameter
     CHECK_EQ(fi->Read(&mparam_, sizeof(mparam_)), sizeof(mparam_))
         << "BoostLearner: wrong model format";
+    if (mparam_.base_score + std::numeric_limits<float>::epsilon() == 2.81467e+23) {
+      mparam_.base_score += std::numeric_limits<float>::epsilon();
+    }
 
     CHECK(fi->Read(&tparam_.objective)) << "BoostLearner: wrong model format";
     CHECK(fi->Read(&tparam_.booster)) << "BoostLearner: wrong model format";
@@ -777,7 +780,13 @@ class LearnerIO : public LearnerConfiguration {
       }
       extra_attr.emplace_back("metrics", os.str());
     }
+    if (mparam.base_score == 2.81467e+23) {
+      // The magic number the collides with "binf";
+      mparam.base_score -= std::numeric_limits<float>::epsilon();
+    }
 
+    std::string header {"binf"};
+    fo->Write(header.data(), 4);
     fo->Write(&mparam, sizeof(LearnerModelParamLegacy));
     fo->Write(tparam_.objective);
     fo->Write(tparam_.booster);


### PR DESCRIPTION
Fixes #5529 .

XGBoost used to support base64 encoded binary and plain binary, hence there's a 4 bytes header in the binary output model.  Now we reuse it.

Ugly, yes.  I will put more effort into JSON after this release so that we can speed up the process.