### PR TITLE
[jvm-packages] [CI] Create a Maven repository to host SNAPSHOT JARs

### DIFF
--- a/doc/jvm/index.rst
+++ b/doc/jvm/index.rst
@@ -8,14 +8,142 @@ XGBoost JVM Package
   <img alt="Build Status" src="https://travis-ci.org/dmlc/xgboost.svg?branch=master">
   </a>
   <a href="https://github.com/dmlc/xgboost/blob/master/LICENSE">
-  <img alt="GitHub license" src="http://dmlc.github.io/img/apache2.svg">
+  <img alt="GitHub license" src="https://dmlc.github.io/img/apache2.svg">
   </a>
 
 You have found the XGBoost JVM Package!
 
+.. _install_jvm_packages:
+
 ************
 Installation
 ************
+
+.. contents::
+  :local:
+  :backlinks: none
+
+Installation from Maven repository
+==================================
+
+Access release version
+----------------------
+You can use XGBoost4J in your Java/Scala application by adding XGBoost4J as a dependency:
+
+.. code-block:: xml
+  :caption: Maven
+
+  <properties>
+    ...
+    <!-- Specify Scala version in package name -->
+    <scala.binary.version>2.12</scala.binary.version>
+  </properties>
+
+  <dependencies>
+    ...
+    <dependency>
+        <groupId>ml.dmlc</groupId>
+        <artifactId>xgboost4j_${scala.binary.version}</artifactId>
+        <version>latest_version_num</version>
+    </dependency>
+    <dependency>
+        <groupId>ml.dmlc</groupId>
+        <artifactId>xgboost4j-spark_${scala.binary.version}</artifactId>
+        <version>latest_version_num</version>
+    </dependency>
+  </dependencies>
+
+.. code-block:: scala
+  :caption: sbt
+
+  libraryDependencies ++= Seq(
+    "ml.dmlc" %% "xgboost4j" % "latest_version_num",
+    "ml.dmlc" %% "xgboost4j-spark" % "latest_version_num"
+  )
+
+This will check out the latest stable version from the Maven Central.
+
+For the latest release version number, please check `here <https://github.com/dmlc/xgboost/releases>`_.
+
+.. note:: Using Maven repository hosted by the XGBoost project
+
+  There may be some delay until a new release becomes available to Maven Central. If you would like to access the latest release immediately, add the Maven repository hosted by the XGBoost project:
+
+  .. code-block:: xml
+    :caption: Maven
+
+    <repository>
+      <id>XGBoost4J Release Repo</id>
+      <name>XGBoost4J Release Repo</name>
+      <url>https://s3-us-west-2.amazonaws.com/xgboost-maven-repo/release/</url>
+    </repository>
+
+  .. code-block:: scala
+    :caption: sbt
+
+    resolvers += "XGBoost4J Release Repo" at "https://s3-us-west-2.amazonaws.com/xgboost-maven-repo/release/"
+
+Access SNAPSHOT version
+-----------------------
+
+First add the following Maven repository hosted by the XGBoost project:
+
+.. code-block:: xml
+  :caption: Maven
+
+  <repository>
+    <id>XGBoost4J Snapshot Repo</id>
+    <name>XGBoost4J Snapshot Repo</name>
+    <url>https://s3-us-west-2.amazonaws.com/xgboost-maven-repo/snapshot/</url>
+  </repository>
+
+.. code-block:: scala
+  :caption: sbt
+
+  resolvers += "XGBoost4J Snapshot Repo" at "https://s3-us-west-2.amazonaws.com/xgboost-maven-repo/snapshot/"
+
+Then add XGBoost4J as a dependency:
+
+.. code-block:: xml
+  :caption: maven
+
+  <properties>
+    ...
+    <!-- Specify Scala version in package name -->
+    <scala.binary.version>2.12</scala.binary.version>
+  </properties>
+
+  <dependencies>
+    ...
+    <dependency>
+        <groupId>ml.dmlc</groupId>
+        <artifactId>xgboost4j_${scala.binary.version}</artifactId>
+        <version>latest_version_num-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+        <groupId>ml.dmlc</groupId>
+        <artifactId>xgboost4j-spark_${scala.binary.version}</artifactId>
+        <version>latest_version_num-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+.. code-block:: scala
+  :caption: sbt
+
+  libraryDependencies ++= Seq(
+    "ml.dmlc" %% "xgboost4j" % "latest_version_num-SNAPSHOT",
+    "ml.dmlc" %% "xgboost4j-spark" % "latest_version_num-SNAPSHOT"
+  )
+
+Look up the ``version`` field in `pom.xml <https://github.com/dmlc/xgboost/blob/master/jvm-packages/pom.xml>`_ to get the correct version number.
+
+The SNAPSHOT JARs are hosted by the XGBoost project. Every commit in the ``master`` branch will automatically trigger generation of a new SNAPSHOT JAR. You can control how often Maven should upgrade your SNAPSHOT installation by specifying ``updatePolicy``. See `here <http://maven.apache.org/pom.html#Repositories>`_ for details.
+
+You can browse the file listing of the Maven repository at https://s3-us-west-2.amazonaws.com/xgboost-maven-repo/list.html.
+
+.. note:: Windows not supported by published JARs
+
+  The published JARs from the Maven Central and GitHub currently only supports Linux and MacOS. Windows users should consider building XGBoost4J / XGBoost4J-Spark from the source. Alternatively, checkout pre-built JARs from `criteo-forks/xgboost-jars <https://github.com/criteo-forks/xgboost-jars>`_.
 
 Installation from source
 ========================
@@ -63,73 +191,6 @@ If you want to use XGBoost4J-Spark, replace ``xgboost4j`` with ``xgboost4j-spark
   XGBoost4J-Spark now requires **Apache Spark 2.3+**. Latest versions of XGBoost4J-Spark uses facilities of `org.apache.spark.ml.param.shared` extensively to provide for a tight integration with Spark MLLIB framework, and these facilities are not fully available on earlier versions of Spark.
 
   Also, make sure to install Spark directly from `Apache website <https://spark.apache.org/>`_. **Upstream XGBoost is not guaranteed to work with third-party distributions of Spark, such as Cloudera Spark.** Consult appropriate third parties to obtain their distribution of XGBoost.
-
-Installation from maven repo
-============================
-
-Access release version
-----------------------
-
-.. code-block:: xml
-  :caption: maven
-
-  <dependency>
-      <groupId>ml.dmlc</groupId>
-      <artifactId>xgboost4j</artifactId>
-      <version>latest_version_num</version>
-  </dependency>
-
-.. code-block:: scala
-  :caption: sbt
-
-  "ml.dmlc" % "xgboost4j" % "latest_version_num"
-
-This will checkout the latest stable version from the Maven Central.
-
-For the latest release version number, please check `here <https://github.com/dmlc/xgboost/releases>`_.
-
-if you want to use XGBoost4J-Spark, replace ``xgboost4j`` with ``xgboost4j-spark``.
-
-Access SNAPSHOT version
------------------------
-
-You need to add GitHub as repo:
-
-.. code-block:: xml
-  :caption: maven
-
-  <repository>
-    <id>GitHub Repo</id>
-    <name>GitHub Repo</name>
-    <url>https://raw.githubusercontent.com/CodingCat/xgboost/maven-repo/</url>
-  </repository>
-
-.. code-block:: scala
-  :caption: sbt
-
-  resolvers += "GitHub Repo" at "https://raw.githubusercontent.com/CodingCat/xgboost/maven-repo/"
-
-Then add dependency as following:
-
-.. code-block:: xml
-  :caption: maven
-
-  <dependency>
-      <groupId>ml.dmlc</groupId>
-      <artifactId>xgboost4j</artifactId>
-      <version>latest_version_num</version>
-  </dependency>
-
-.. code-block:: scala
-  :caption: sbt
-
-  "ml.dmlc" % "xgboost4j" % "latest_version_num"
-
-For the latest release version number, please check `here <https://github.com/CodingCat/xgboost/tree/maven-repo/ml/dmlc/xgboost4j>`_.
-
-.. note:: Windows not supported by published JARs
-
-  The published JARs from the Maven Central and GitHub currently only supports Linux and MacOS. Windows users should consider building XGBoost4J / XGBoost4J-Spark from the source. Alternatively, checkout pre-built JARs from `criteo-forks/xgboost-jars <https://github.com/criteo-forks/xgboost-jars>`_.
 
 Enabling OpenMP for Mac OS
 --------------------------

--- a/doc/jvm/xgboost4j_spark_tutorial.rst
+++ b/doc/jvm/xgboost4j_spark_tutorial.rst
@@ -27,39 +27,7 @@ Build an ML Application with XGBoost4J-Spark
 Refer to XGBoost4J-Spark Dependency
 ===================================
 
-Before we go into the tour of how to use XGBoost4J-Spark, we would bring a brief introduction about how to build a machine learning application with XGBoost4J-Spark. The first thing you need to do is to refer to the dependency in Maven Central.
-
-You can add the following dependency in your ``pom.xml``.
-
-.. code-block:: xml
-
-  <dependency>
-    <groupId>ml.dmlc</groupId>
-    <artifactId>xgboost4j-spark</artifactId>
-    <version>latest_version_num</version>
-  </dependency>
-
-For the latest release version number, please check `here <https://github.com/dmlc/xgboost/releases>`_.
-
-We also publish some functionalities which would be included in the coming release in the form of snapshot version. To access these functionalities, you can add dependency to the snapshot artifacts. We publish snapshot version in github-based repo, so you can add the following repo in ``pom.xml``:
-
-.. code-block:: xml
-
-  <repository>
-    <id>XGBoost4J-Spark Snapshot Repo</id>
-    <name>XGBoost4J-Spark Snapshot Repo</name>
-    <url>https://raw.githubusercontent.com/CodingCat/xgboost/maven-repo/</url>
-  </repository>
-
-and then refer to the snapshot dependency by adding:
-
-.. code-block:: xml
-
-  <dependency>
-      <groupId>ml.dmlc</groupId>
-      <artifactId>xgboost4j-spark</artifactId>
-      <version>next_version_num-SNAPSHOT</version>
-  </dependency>
+Before we go into the tour of how to use XGBoost4J-Spark, you should first consult :ref:`Installation from Maven repository <install_jvm_packages>` in order to add XGBoost4J-Spark as a dependency for your project. We provide both stable releases and snapshots.
 
 .. note:: XGBoost4J-Spark requires Apache Spark 2.4+
 

--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -205,6 +205,29 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>release-to-s3</id>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>maven-s3-snapshot-repo</id>
+                    <url>s3://xgboost-maven-repo/snapshot</url>
+                </snapshotRepository>
+                <repository>
+                    <id>maven-s3-release-repo</id>
+                    <url>s3://xgboost-maven-repo/release</url>
+                </repository>
+            </distributionManagement>
+            <repositories>
+                <repository>
+                    <id>maven-s3-snapshot-repo</id>
+                    <url>https://s3.amazonaws.com/xgboost-maven-repo/snapshot</url>
+                </repository>
+                <repository>
+                    <id>maven-s3-release-repo</id>
+                    <url>https://s3.amazonaws.com/xgboost-maven-repo/release</url>
+                </repository>
+            </repositories>
+        </profile>
     </profiles>
     <distributionManagement>
         <snapshotRepository>
@@ -324,6 +347,13 @@
                 </executions>
             </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <groupId>org.kuali.maven.wagons</groupId>
+                <artifactId>maven-s3-wagon</artifactId>
+                <version>1.2.1</version>
+            </extension>
+        </extensions>
     </build>
     <reporting>
         <plugins>

--- a/tests/ci_build/deploy_jvm_packages.sh
+++ b/tests/ci_build/deploy_jvm_packages.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 [spark version]"
+  exit 1
+fi
+
+spark_version=$1
+
+# Initialize local Maven repository
+./tests/ci_build/initialize_maven.sh
+
+rm -rf build/
+cd jvm-packages
+# re-build package without Mock Rabit
+mvn --no-transfer-progress package -Dspark.version=${spark_version} -DskipTests
+
+# deploy to S3 bucket xgboost-maven-repo
+mvn --no-transfer-progress deploy -P release-to-s3 -DskipTests
+
+set +x
+set +e


### PR DESCRIPTION
Closes #4752.
Closes #5494.

Jenkins will now deploy freshly made JAR packages to a public S3 bucket `xgboost-maven-repo`.  Users can now access SNAPSHOT JARs by adding
```xml
<repository>
  <id>XGBoost4J Snapshot Repo</id>
  <name>XGBoost4J Snapshot Repo</name>
  <url>https://s3-us-west-2.amazonaws.com/xgboost-maven-repo/snapshot/</url>
</repository>
```
to their pom.xml.

[Updated installation instructions](https://xgboost.readthedocs.io/en/release_1.0.0/jvm/index.html#installation-from-maven-repository)
[File listing of `xgboost-maven-repo`](https://s3-us-west-2.amazonaws.com/xgboost-maven-repo/list.html)

Pinging @trams @CodingCat @trivialfis @sperlingxx @wbo4958 @WeichenXu123 @chenqin who might be interested.