### PR TITLE
Purge device_helpers.cuh

### DIFF
--- a/src/tree/gpu_hist/gradient_based_sampler.cu
+++ b/src/tree/gpu_hist/gradient_based_sampler.cu
@@ -187,9 +187,10 @@ ExternalMemoryUniformSampling::ExternalMemoryUniformSampling(EllpackPageImpl* pa
                                                              size_t n_rows,
                                                              const BatchParam& batch_param,
                                                              float subsample)
-    : original_page_(page), batch_param_(batch_param), subsample_(subsample) {
-  ba_.Allocate(batch_param_.gpu_id, &sample_row_index_, n_rows);
-}
+    : original_page_(page),
+      batch_param_(batch_param),
+      subsample_(subsample),
+      sample_row_index_(n_rows) {}
 
 GradientBasedSample ExternalMemoryUniformSampling::Sample(common::Span<GradientPair> gpair,
                                                           DMatrix* dmat) {
@@ -207,12 +208,12 @@ GradientBasedSample ExternalMemoryUniformSampling::Sample(common::Span<GradientP
   thrust::copy_if(dh::tbegin(gpair), dh::tend(gpair), gpair_.begin(), IsNonZero());
 
   // Index the sample rows.
-  thrust::transform(dh::tbegin(gpair), dh::tend(gpair), dh::tbegin(sample_row_index_), IsNonZero());
-  thrust::exclusive_scan(dh::tbegin(sample_row_index_), dh::tend(sample_row_index_),
-                         dh::tbegin(sample_row_index_));
+  thrust::transform(dh::tbegin(gpair), dh::tend(gpair), sample_row_index_.begin(), IsNonZero());
+  thrust::exclusive_scan(sample_row_index_.begin(), sample_row_index_.end(),
+                         sample_row_index_.begin());
   thrust::transform(dh::tbegin(gpair), dh::tend(gpair),
-                    dh::tbegin(sample_row_index_),
-                    dh::tbegin(sample_row_index_),
+                    sample_row_index_.begin(),
+                    sample_row_index_.begin(),
                     ClearEmptyRows());
 
   // Create a new ELLPACK page with empty rows.
@@ -224,7 +225,7 @@ GradientBasedSample ExternalMemoryUniformSampling::Sample(common::Span<GradientP
   // Compact the ELLPACK pages into the single sample page.
   thrust::fill(dh::tbegin(page_->gidx_buffer), dh::tend(page_->gidx_buffer), 0);
   for (auto& batch : dmat->GetBatches<EllpackPage>(batch_param_)) {
-    page_->Compact(batch_param_.gpu_id, batch.Impl(), sample_row_index_);
+    page_->Compact(batch_param_.gpu_id, batch.Impl(), dh::ToSpan(sample_row_index_));
   }
 
   return {sample_rows, page_.get(), dh::ToSpan(gpair_)};
@@ -233,23 +234,23 @@ GradientBasedSample ExternalMemoryUniformSampling::Sample(common::Span<GradientP
 GradientBasedSampling::GradientBasedSampling(EllpackPageImpl* page,
                                              size_t n_rows,
                                              const BatchParam& batch_param,
-                                             float subsample) : page_(page), subsample_(subsample) {
-  ba_.Allocate(batch_param.gpu_id,
-               &threshold_, n_rows + 1,
-               &grad_sum_, n_rows);
-}
+                                             float subsample)
+    : page_(page),
+      subsample_(subsample),
+      threshold_(n_rows + 1, 0.0f),
+      grad_sum_(n_rows, 0.0f) {}
 
 GradientBasedSample GradientBasedSampling::Sample(common::Span<GradientPair> gpair,
                                                   DMatrix* dmat) {
   size_t n_rows = dmat->Info().num_row_;
   size_t threshold_index = GradientBasedSampler::CalculateThresholdIndex(
-      gpair, threshold_, grad_sum_, n_rows * subsample_);
+      gpair, dh::ToSpan(threshold_), dh::ToSpan(grad_sum_), n_rows * subsample_);
 
   // Perform Poisson sampling in place.
   thrust::transform(dh::tbegin(gpair), dh::tend(gpair),
                     thrust::counting_iterator<size_t>(0),
                     dh::tbegin(gpair),
-                    PoissonSampling(threshold_,
+                    PoissonSampling(dh::ToSpan(threshold_),
                                     threshold_index,
                                     RandomWeight(common::GlobalRandom()())));
   return {n_rows, page_, gpair};
@@ -259,24 +260,25 @@ ExternalMemoryGradientBasedSampling::ExternalMemoryGradientBasedSampling(
     EllpackPageImpl* page,
     size_t n_rows,
     const BatchParam& batch_param,
-    float subsample) : original_page_(page), batch_param_(batch_param), subsample_(subsample) {
-  ba_.Allocate(batch_param.gpu_id,
-               &threshold_, n_rows + 1,
-               &grad_sum_, n_rows,
-               &sample_row_index_, n_rows);
-}
+    float subsample)
+    : original_page_(page),
+      batch_param_(batch_param),
+      subsample_(subsample),
+      threshold_(n_rows + 1, 0.0f),
+      grad_sum_(n_rows, 0.0f),
+      sample_row_index_(n_rows) {}
 
 GradientBasedSample ExternalMemoryGradientBasedSampling::Sample(common::Span<GradientPair> gpair,
                                                                 DMatrix* dmat) {
   size_t n_rows = dmat->Info().num_row_;
   size_t threshold_index = GradientBasedSampler::CalculateThresholdIndex(
-      gpair, threshold_, grad_sum_, n_rows * subsample_);
+      gpair, dh::ToSpan(threshold_), dh::ToSpan(grad_sum_), n_rows * subsample_);
 
   // Perform Poisson sampling in place.
   thrust::transform(dh::tbegin(gpair), dh::tend(gpair),
                     thrust::counting_iterator<size_t>(0),
                     dh::tbegin(gpair),
-                    PoissonSampling(threshold_,
+                    PoissonSampling(dh::ToSpan(threshold_),
                                     threshold_index,
                                     RandomWeight(common::GlobalRandom()())));
 
@@ -288,12 +290,12 @@ GradientBasedSample ExternalMemoryGradientBasedSampling::Sample(common::Span<Gra
   thrust::copy_if(dh::tbegin(gpair), dh::tend(gpair), gpair_.begin(), IsNonZero());
 
   // Index the sample rows.
-  thrust::transform(dh::tbegin(gpair), dh::tend(gpair), dh::tbegin(sample_row_index_), IsNonZero());
-  thrust::exclusive_scan(dh::tbegin(sample_row_index_), dh::tend(sample_row_index_),
-                         dh::tbegin(sample_row_index_));
+  thrust::transform(dh::tbegin(gpair), dh::tend(gpair), sample_row_index_.begin(), IsNonZero());
+  thrust::exclusive_scan(sample_row_index_.begin(), sample_row_index_.end(),
+    sample_row_index_.begin());
   thrust::transform(dh::tbegin(gpair), dh::tend(gpair),
-                    dh::tbegin(sample_row_index_),
-                    dh::tbegin(sample_row_index_),
+                    sample_row_index_.begin(),
+                    sample_row_index_.begin(),
                     ClearEmptyRows());
 
   // Create a new ELLPACK page with empty rows.
@@ -305,7 +307,7 @@ GradientBasedSample ExternalMemoryGradientBasedSampling::Sample(common::Span<Gra
   // Compact the ELLPACK pages into the single sample page.
   thrust::fill(dh::tbegin(page_->gidx_buffer), dh::tend(page_->gidx_buffer), 0);
   for (auto& batch : dmat->GetBatches<EllpackPage>(batch_param_)) {
-    page_->Compact(batch_param_.gpu_id, batch.Impl(), sample_row_index_);
+    page_->Compact(batch_param_.gpu_id, batch.Impl(), dh::ToSpan(sample_row_index_));
   }
 
   return {sample_rows, page_.get(), dh::ToSpan(gpair_)};
@@ -358,21 +360,21 @@ GradientBasedSample GradientBasedSampler::Sample(common::Span<GradientPair> gpai
   return sample;
 }
 
-size_t GradientBasedSampler::CalculateThresholdIndex(common::Span<GradientPair> gpair,
-                                                     common::Span<float> threshold,
-                                                     common::Span<float> grad_sum,
-                                                     size_t sample_rows) {
-  thrust::fill(dh::tend(threshold) - 1, dh::tend(threshold), std::numeric_limits<float>::max());
-  thrust::transform(dh::tbegin(gpair), dh::tend(gpair),
-                    dh::tbegin(threshold),
+size_t GradientBasedSampler::CalculateThresholdIndex(
+    common::Span<GradientPair> gpair, common::Span<float> threshold,
+    common::Span<float> grad_sum, size_t sample_rows) {
+  thrust::fill(dh::tend(threshold) - 1, dh::tend(threshold),
+               std::numeric_limits<float>::max());
+  thrust::transform(dh::tbegin(gpair), dh::tend(gpair), dh::tbegin(threshold),
                     CombineGradientPair());
   thrust::sort(dh::tbegin(threshold), dh::tend(threshold) - 1);
-  thrust::inclusive_scan(dh::tbegin(threshold), dh::tend(threshold) - 1, dh::tbegin(grad_sum));
+  thrust::inclusive_scan(dh::tbegin(threshold), dh::tend(threshold) - 1,
+                         dh::tbegin(grad_sum));
   thrust::transform(dh::tbegin(grad_sum), dh::tend(grad_sum),
-                    thrust::counting_iterator<size_t>(0),
-                    dh::tbegin(grad_sum),
+                    thrust::counting_iterator<size_t>(0), dh::tbegin(grad_sum),
                     SampleRateDelta(threshold, gpair.size(), sample_rows));
-  thrust::device_ptr<float> min = thrust::min_element(dh::tbegin(grad_sum), dh::tend(grad_sum));
+  thrust::device_ptr<float> min =
+      thrust::min_element(dh::tbegin(grad_sum), dh::tend(grad_sum));
   return thrust::distance(dh::tbegin(grad_sum), min) + 1;
 }
 

--- a/src/tree/gpu_hist/gradient_based_sampler.cuh
+++ b/src/tree/gpu_hist/gradient_based_sampler.cuh
@@ -73,13 +73,12 @@ class ExternalMemoryUniformSampling : public SamplingStrategy {
   GradientBasedSample Sample(common::Span<GradientPair> gpair, DMatrix* dmat) override;
 
  private:
-  dh::BulkAllocator ba_;
   EllpackPageImpl* original_page_;
   BatchParam batch_param_;
   float subsample_;
   std::unique_ptr<EllpackPageImpl> page_;
   dh::device_vector<GradientPair> gpair_{};
-  common::Span<size_t> sample_row_index_;
+  dh::caching_device_vector<size_t> sample_row_index_;
 };
 
 /*! \brief Gradient-based sampling in in-memory mode.. */
@@ -94,9 +93,8 @@ class GradientBasedSampling : public SamplingStrategy {
  private:
   EllpackPageImpl* page_;
   float subsample_;
-  dh::BulkAllocator ba_;
-  common::Span<float> threshold_;
-  common::Span<float> grad_sum_;
+  dh::caching_device_vector<float> threshold_;
+  dh::caching_device_vector<float> grad_sum_;
 };
 
 /*! \brief Gradient-based sampling in external memory mode.. */
@@ -109,15 +107,14 @@ class ExternalMemoryGradientBasedSampling : public SamplingStrategy {
   GradientBasedSample Sample(common::Span<GradientPair> gpair, DMatrix* dmat) override;
 
  private:
-  dh::BulkAllocator ba_;
   EllpackPageImpl* original_page_;
   BatchParam batch_param_;
   float subsample_;
-  common::Span<float> threshold_;
-  common::Span<float> grad_sum_;
+  dh::caching_device_vector<float> threshold_;
+  dh::caching_device_vector<float> grad_sum_;
   std::unique_ptr<EllpackPageImpl> page_;
   dh::device_vector<GradientPair> gpair_;
-  common::Span<size_t> sample_row_index_;
+  dh::caching_device_vector<size_t> sample_row_index_;
 };
 
 /*! \brief Draw a sample of rows from a DMatrix.

--- a/tests/cpp/common/test_device_helpers.cu
+++ b/tests/cpp/common/test_device_helpers.cu
@@ -27,62 +27,11 @@ void CreateTestData(xgboost::bst_uint num_rows, int max_row_size,
   }
 }
 
-void TestLbs() {
-  srand(17);
-  dh::CubMemory temp_memory;
-
-  std::vector<int> test_rows = {4, 100, 1000};
-  std::vector<int> test_max_row_sizes = {4, 100, 1300};
-
-  for (auto num_rows : test_rows) {
-    for (auto max_row_size : test_max_row_sizes) {
-      thrust::host_vector<int> h_row_ptr;
-      thrust::host_vector<xgboost::bst_uint> h_rows;
-      CreateTestData(num_rows, max_row_size, &h_row_ptr, &h_rows);
-      thrust::device_vector<size_t> row_ptr = h_row_ptr;
-      thrust::device_vector<int> output_row(h_rows.size());
-      auto d_output_row = output_row.data();
-
-      dh::TransformLbs(0, &temp_memory, h_rows.size(), dh::Raw(row_ptr),
-                       row_ptr.size() - 1, false,
-                       [=] __device__(size_t idx, size_t ridx) {
-                         d_output_row[idx] = ridx;
-                       });
-
-      dh::safe_cuda(cudaDeviceSynchronize());
-      ASSERT_TRUE(h_rows == output_row);
-    }
-  }
-}
-
-TEST(CubLBS, Test) {
-  TestLbs();
-}
-
 TEST(SumReduce, Test) {
   thrust::device_vector<float> data(100, 1.0f);
   dh::CubMemory temp;
-  auto sum = dh::SumReduction(&temp, dh::Raw(data), data.size());
+  auto sum = dh::SumReduction(&temp, data.data().get(), data.size());
   ASSERT_NEAR(sum, 100.0f, 1e-5);
-}
-
-void TestAllocator() {
-  int n = 10;
-  Span<float> a;
-  Span<int> b;
-  Span<size_t> c;
-  dh::BulkAllocator ba;
-  ba.Allocate(0, &a, n, &b, n, &c, n);
-
-  // Should be no illegal memory accesses
-  dh::LaunchN(0, n, [=] __device__(size_t idx) { c[idx] = a[idx] + b[idx]; });
-
-  dh::safe_cuda(cudaDeviceSynchronize());
-}
-
-// Define the test in a function so we can use device lambda
-TEST(BulkAllocator, Test) {
-  TestAllocator();
 }
 
 template <typename T, typename Comp = thrust::less<T>>

--- a/tests/cpp/data/test_array_interface.h
+++ b/tests/cpp/data/test_array_interface.h
@@ -23,7 +23,7 @@ Json GenerateDenseColumn(std::string const& typestr, size_t kRows,
   d_data.resize(kRows);
   thrust::sequence(thrust::device, d_data.begin(), d_data.end(), 0.0f, 2.0f);
 
-  auto p_d_data = dh::Raw(d_data);
+  auto p_d_data = d_data.data().get();
 
   std::vector<Json> j_data {
     Json(Integer(reinterpret_cast<Integer::Int>(p_d_data))),
@@ -49,7 +49,7 @@ Json GenerateSparseColumn(std::string const& typestr, size_t kRows,
     d_data[i] = i * 2.0;
   }
 
-  auto p_d_data = dh::Raw(d_data);
+  auto p_d_data = d_data.data().get();
 
   std::vector<Json> j_data {
     Json(Integer(reinterpret_cast<Integer::Int>(p_d_data))),

--- a/tests/cpp/data/test_metainfo.cu
+++ b/tests/cpp/data/test_metainfo.cu
@@ -25,7 +25,7 @@ std::string PrepareData(std::string typestr, thrust::device_vector<T>* out, cons
   column["version"] = Integer(static_cast<Integer::Int>(1));
   column["typestr"] = String(typestr);
 
-  auto p_d_data = dh::Raw(d_data);
+  auto p_d_data = d_data.data().get();
   std::vector<Json> j_data {
         Json(Integer(reinterpret_cast<Integer::Int>(p_d_data))),
         Json(Boolean(false))};


### PR DESCRIPTION
This PR removes unused and obsolete functions from device helpers.

Bulk allocator was still used in a couple of places and has been converted to new caching device vectors.

No change in behaviour or performance is expected.