### PR TITLE
[jvm-packages] [CI] Publish XGBoost4J JARs with Scala 2.11 and 2.12

### DIFF
--- a/tests/ci_build/deploy_jvm_packages.sh
+++ b/tests/ci_build/deploy_jvm_packages.sh
@@ -15,11 +15,21 @@ spark_version=$1
 
 rm -rf build/
 cd jvm-packages
-# re-build package without Mock Rabit
-mvn --no-transfer-progress package -Dspark.version=${spark_version} -DskipTests
 
-# deploy to S3 bucket xgboost-maven-repo
-mvn --no-transfer-progress deploy -P release-to-s3 -DskipTests
+# Re-build package without Mock Rabit
+# Deploy to S3 bucket xgboost-maven-repo
+mvn --no-transfer-progress package deploy -P release-to-s3 -Dspark.version=${spark_version} -DskipTests
+
+# Compile XGBoost4J with Scala 2.11 too
+mvn clean
+# Rename artifactId of all XGBoost4J packages with suffix _2.11
+sed -i -e 's/<artifactId>xgboost\(.*\)_[0-9\.]\+/<artifactId>xgboost\1_2.11/' $(find . -name pom.xml)
+# Modify scala.version and scala.binary.version fields
+sed -i -e 's/<scala\.version>[0-9\.]\+/<scala.version>2.11.12/' $(find . -name pom.xml)
+sed -i -e 's/<scala\.binary\.version>[0-9\.]\+/<scala.binary.version>2.11/' $(find . -name pom.xml)
+
+# Re-build and deploy
+mvn --no-transfer-progress package deploy -P release-to-s3 -Dspark.version=${spark_version} -DskipTests
 
 set +x
 set +e


### PR DESCRIPTION
With #5533, XGBoost4J JARs are compiled with Scala 2.12. Per [this request](https://discuss.xgboost.ai/t/xgboost4j-spark-1-0-x-availability/1474/9?u=hcho3), we will now publish two variants of XGBoost4J JARs, one that uses Scala 2.11 and another that uses Scala 2.12.