### PR TITLE
[jvm-packages] XGBoost Spark should deal with NaN when parsing evaluation output

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -242,7 +242,14 @@ public class Booster implements Serializable, KryoSerializable {
     String stringFormat = evalSet(evalMatrixs, evalNames, iter);
     String[] metricPairs = stringFormat.split("\t");
     for (int i = 1; i < metricPairs.length; i++) {
-      metricsOut[i - 1] = Float.valueOf(metricPairs[i].split(":")[1]);
+      String value = metricPairs[i].split(":")[1];
+      if (value.equalsIgnoreCase("nan")) {
+        metricsOut[i - 1] = Float.NaN;
+      } else if (value.equalsIgnoreCase("-nan")) {
+        metricsOut[i - 1] = -Float.NaN;
+      } else {
+        metricsOut[i - 1] = Float.valueOf(value);
+      }
     }
     return stringFormat;
   }


### PR DESCRIPTION
According to the [doc](https://xgboost.readthedocs.io/en/latest/parameter.html), `rmsle` eval_metric can possibly output nan when prediction value is less than -1. Currently training with XGBoost Spark encounters following error when paring the output value:

```
2020-04-16 06:08:31 ERROR XGBoostTaskFailedListener:100 - Training Task Failed during XGBoost Training: ExceptionFailure(java.lang.NumberFormatException,For input string: "-nan",[Ljava.lang.StackTraceElement;@6107940c,java.lang.NumberFormatException: For input string: "-nan"
	at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2043)
	at sun.misc.FloatingDecimal.parseFloat(FloatingDecimal.java:122)
	at java.lang.Float.parseFloat(Float.java:451)
	at java.lang.Float.valueOf(Float.java:416)
	at ml.dmlc.xgboost4j.java.Booster.evalSet(Booster.java:245)
	at ml.dmlc.xgboost4j.java.XGBoost.trainAndSaveCheckpoint(XGBoost.java:215)
	at ml.dmlc.xgboost4j.java.XGBoost.train(XGBoost.java:284)
	at ml.dmlc.xgboost4j.scala.XGBoost$$anonfun$3.apply(XGBoost.scala:61)
	at ml.dmlc.xgboost4j.scala.XGBoost$$anonfun$3.apply(XGBoost.scala:61)
	at scala.Option.getOrElse(Option.scala:121)
	at ml.dmlc.xgboost4j.scala.XGBoost$.trainAndSaveCheckpoint(XGBoost.scala:60)
	at ml.dmlc.xgboost4j.scala.XGBoost$.train(XGBoost.scala:104)
       ...
```