### PR TITLE
Distributed optimizations

### DIFF
--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -127,6 +127,7 @@ void QuantileHistMaker::Builder::SyncHistograms(
 
 
     this->histred_.Allreduce(hist_[starting_index].data(), hist_builder_.GetNumBins() * sync_count);
+
   common::BlockedSpace2d space2(nodes_for_subtraction_trick_.size(), [&](size_t node) {
     return nbins;
   }, 1024);
@@ -325,6 +326,7 @@ void QuantileHistMaker::Builder::SplitSiblings(const std::vector<ExpandEntry>& n
                    std::vector<ExpandEntry>* small_siblings,
                    std::vector<ExpandEntry>* big_siblings,
                    RegTree *p_tree) {
+  builder_monitor_.Start("SplitSiblings");
   for (auto const& entry : nodes) {
     int nid = entry.nid;
     RegTree::Node &node = (*p_tree)[nid];
@@ -389,6 +391,7 @@ else
       }
     }*/
   }
+  builder_monitor_.Stop("SplitSiblings");
 }
 
 void QuantileHistMaker::Builder::ExpandWithDepthWise(

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -117,9 +117,9 @@ void QuantileHistMaker::Builder::SyncHistograms(
     if (!(*p_tree)[entry.nid].IsRoot() && entry.sibling_nid > -1 && !isDistributed) {
       auto parent_hist = hist_[(*p_tree)[entry.nid].Parent()];
       auto sibling_hist = hist_[entry.sibling_nid];
-
-//      SubtractionHist(sibling_hist, parent_hist, this_hist, r.begin(), r.end());
-      SubtractionHist(this_hist, parent_hist, sibling_hist, r.begin(), r.end());
+//std::cout << "\n---------------------------SubtractionHist---------------------------\n";
+      SubtractionHist(sibling_hist, parent_hist, this_hist, r.begin(), r.end());
+      //SubtractionHist(this_hist, parent_hist, sibling_hist, r.begin(), r.end());
     }
   });
 

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -234,7 +234,7 @@ void DistributedHistRowsAdder::AddHistRows(int *starting_index, int *sync_count,
       builder_->hist_local_worker_.AddHistRow(nid);
     }
   }
-  (*sync_count) = std::min(1, n_left);
+  (*sync_count) = std::max(1, n_left);
   builder_->builder_monitor_.Stop("AddHistRows");
 }
 

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -77,6 +77,13 @@ void QuantileHistMaker::Update(HostDeviceVector<GradientPair> *gpair,
         std::move(pruner_),
         std::unique_ptr<SplitEvaluator>(spliteval_->GetHostClone()),
         int_constraint_, dmat));
+    if (rabit::IsDistributed()) {
+      builder_->SetHistSynchronizer(new DistributedHistSynchronizer(builder_.get()));
+      builder_->SetHistRowsAdder(new DistributedHistRowsAdder(builder_.get()));
+    } else {
+      builder_->SetHistSynchronizer(new BatchHistSynchronizer(builder_.get()));
+      builder_->SetHistRowsAdder(new BatchHistRowsAdder(builder_.get()));
+    }
   }
   for (auto tree : trees) {
     builder_->Update(gmat_, gmatb_, column_matrix_, gpair, dmat, tree);
@@ -97,72 +104,146 @@ bool QuantileHistMaker::UpdatePredictionCache(
   }
 }
 
-void QuantileHistMaker::Builder::ParallelSubtractionHist(const common::BlockedSpace2d& space,
-                                                         const std::vector<ExpandEntry>& nodes,
-                                                         const RegTree * p_tree) {
-  common::ParallelFor2d(space, this->nthread_, [&](size_t node, common::Range1d r) {
+void BatchHistSynchronizer::SyncHistograms(int starting_index,
+                                           int sync_count,
+                                           RegTree *p_tree) {
+  builder_->builder_monitor_.Start("SyncHistograms");
+  const size_t nbins = builder_->hist_builder_.GetNumBins();
+  common::BlockedSpace2d space(builder_->nodes_for_explicit_hist_build_.size(), [&](size_t node) {
+    return nbins;
+  }, 1024);
+
+  common::ParallelFor2d(space, builder_->nthread_, [&](size_t node, common::Range1d r) {
+    const auto entry = builder_->nodes_for_explicit_hist_build_[node];
+    auto this_hist = builder_->hist_[entry.nid];
+    // Merging histograms from each thread into once
+    builder_->hist_buffer_.ReduceHist(node, r.begin(), r.end());
+
+    if (!(*p_tree)[entry.nid].IsRoot() && entry.sibling_nid > -1) {
+      const size_t parent_id = (*p_tree)[entry.nid].Parent();
+      auto parent_hist = builder_->hist_[parent_id];
+      auto sibling_hist = builder_->hist_[entry.sibling_nid];
+      SubtractionHist(sibling_hist, parent_hist, this_hist, r.begin(), r.end());
+    }
+  });
+  builder_->builder_monitor_.Stop("SyncHistograms");
+}
+
+void DistributedHistSynchronizer::SyncHistograms(int starting_index,
+                                                 int sync_count,
+                                                 RegTree *p_tree) {
+  builder_->builder_monitor_.Start("SyncHistograms");
+  const size_t nbins = builder_->hist_builder_.GetNumBins();
+  common::BlockedSpace2d space(builder_->nodes_for_explicit_hist_build_.size(), [&](size_t node) {
+    return nbins;
+  }, 1024);
+  common::ParallelFor2d(space, builder_->nthread_, [&](size_t node, common::Range1d r) {
+    const auto entry = builder_->nodes_for_explicit_hist_build_[node];
+    auto this_hist = builder_->hist_[entry.nid];
+    // Merging histograms from each thread into once
+    builder_->hist_buffer_.ReduceHist(node, r.begin(), r.end());
+    // Store posible parent node
+    auto this_local = builder_->hist_local_worker_[entry.nid];
+    CopyHist(this_local, this_hist, r.begin(), r.end());
+
+    if (!(*p_tree)[entry.nid].IsRoot() && entry.sibling_nid > -1) {
+      const size_t parent_id = (*p_tree)[entry.nid].Parent();
+      auto parent_hist = builder_->hist_local_worker_[parent_id];
+      auto sibling_hist = builder_->hist_[entry.sibling_nid];
+      SubtractionHist(sibling_hist, parent_hist, this_hist, r.begin(), r.end());
+      // Store posible parent node
+      auto sibling_local = builder_->hist_local_worker_[entry.sibling_nid];
+      CopyHist(sibling_local, sibling_hist, r.begin(), r.end());
+    }
+  });
+  builder_->builder_monitor_.Start("SyncHistogramsAllreduce");
+  this->builder_->histred_.Allreduce(builder_->hist_[starting_index].data(),
+                                    builder_->hist_builder_.GetNumBins() * sync_count);
+  builder_->builder_monitor_.Stop("SyncHistogramsAllreduce");
+
+  ParallelSubtractionHist(space, builder_->nodes_for_explicit_hist_build_, p_tree);
+
+  common::BlockedSpace2d space2(builder_->nodes_for_subtraction_trick_.size(), [&](size_t node) {
+    return nbins;
+  }, 1024);
+  ParallelSubtractionHist(space2, builder_->nodes_for_subtraction_trick_, p_tree);
+  builder_->builder_monitor_.Stop("SyncHistograms");
+}
+
+void DistributedHistSynchronizer::ParallelSubtractionHist(const common::BlockedSpace2d& space,
+                                  const std::vector<QuantileHistMaker::Builder::ExpandEntry>& nodes,
+                                  const RegTree * p_tree) {
+  common::ParallelFor2d(space, builder_->nthread_, [&](size_t node, common::Range1d r) {
     const auto entry = nodes[node];
     if (!((*p_tree)[entry.nid].IsLeftChild())) {
-      auto this_hist = hist_[entry.nid];
+      auto this_hist = builder_->hist_[entry.nid];
 
       if (!(*p_tree)[entry.nid].IsRoot() && entry.sibling_nid > -1) {
-        auto parent_hist = hist_[(*p_tree)[entry.nid].Parent()];
-        auto sibling_hist = hist_[entry.sibling_nid];
+        auto parent_hist = builder_->hist_[(*p_tree)[entry.nid].Parent()];
+        auto sibling_hist = builder_->hist_[entry.sibling_nid];
         SubtractionHist(this_hist, parent_hist, sibling_hist, r.begin(), r.end());
       }
     }
   });
 }
 
-void QuantileHistMaker::Builder::SyncHistograms(
-    int starting_index,
-    int sync_count,
-    RegTree *p_tree) {
-  builder_monitor_.Start("SyncHistograms");
+void BatchHistRowsAdder::AddHistRows(int *starting_index, int *sync_count,
+                                     RegTree *p_tree) {
+  builder_->builder_monitor_.Start("AddHistRows");
 
-  const bool isDistributed = rabit::IsDistributed();
-  const size_t nbins = hist_builder_.GetNumBins();
-  common::BlockedSpace2d space(nodes_for_explicit_hist_build_.size(), [&](size_t node) {
-    return nbins;
-  }, 1024);
-  common::ParallelFor2d(space, this->nthread_, [&](size_t node, common::Range1d r) {
-    const auto entry = nodes_for_explicit_hist_build_[node];
-    auto this_hist = hist_[entry.nid];
-    // Merging histograms from each thread into once
-    hist_buffer_.ReduceHist(node, r.begin(), r.end());
-    if (isDistributed) {
-      // Store posible parent node
-      auto this_local = hist_local_worker_[entry.nid];
-      CopyHist(this_local, this_hist, r.begin(), r.end());
-    }
+  for (auto const& entry : builder_->nodes_for_explicit_hist_build_) {
+    int nid = entry.nid;
+    builder_->hist_.AddHistRow(nid);
+    (*starting_index) = std::min(nid, (*starting_index));
+  }
+  (*sync_count) = builder_->nodes_for_explicit_hist_build_.size();
 
-    if (!(*p_tree)[entry.nid].IsRoot() && entry.sibling_nid > -1) {
-      const size_t parent_id = (*p_tree)[entry.nid].Parent();
-      auto parent_hist = isDistributed ? hist_local_worker_[parent_id] : hist_[parent_id];
-      auto sibling_hist = hist_[entry.sibling_nid];
-      SubtractionHist(sibling_hist, parent_hist, this_hist, r.begin(), r.end());
-      if (isDistributed) {
-        // Store posible parent node
-        auto sibling_local = hist_local_worker_[entry.sibling_nid];
-        CopyHist(sibling_local, sibling_hist, r.begin(), r.end());
-      }
-    }
-  });
-
-  if (isDistributed) {
-    builder_monitor_.Start("SyncHistogramsAllreduce");
-    this->histred_.Allreduce(hist_[starting_index].data(), hist_builder_.GetNumBins() * sync_count);
-    builder_monitor_.Stop("SyncHistogramsAllreduce");
-
-    ParallelSubtractionHist(space, nodes_for_explicit_hist_build_, p_tree);
-
-    common::BlockedSpace2d space2(nodes_for_subtraction_trick_.size(), [&](size_t node) {
-      return nbins;
-    }, 1024);
-    ParallelSubtractionHist(space2, nodes_for_subtraction_trick_, p_tree);
+  for (auto const& node : builder_->nodes_for_subtraction_trick_) {
+    builder_->hist_.AddHistRow(node.nid);
   }
 
-  builder_monitor_.Stop("SyncHistograms");
+  builder_->builder_monitor_.Stop("AddHistRows");
+}
+
+void DistributedHistRowsAdder::AddHistRows(int *starting_index, int *sync_count,
+                                           RegTree *p_tree) {
+  builder_->builder_monitor_.Start("AddHistRows");
+  const size_t explicit_size = builder_->nodes_for_explicit_hist_build_.size();
+  const size_t subtaction_size = builder_->nodes_for_subtraction_trick_.size();
+  std::vector<int> merged_node_ids(explicit_size + subtaction_size);
+  for (size_t i = 0; i < explicit_size; ++i) {
+    merged_node_ids[i] = builder_->nodes_for_explicit_hist_build_[i].nid;
+  }
+  for (size_t i = 0; i < subtaction_size; ++i) {
+    merged_node_ids[explicit_size + i] =
+    builder_->nodes_for_subtraction_trick_[i].nid;
+  }
+  std::sort(merged_node_ids.begin(), merged_node_ids.end());
+  int n_left = 0;
+  for (auto const& nid : merged_node_ids) {
+    if ((*p_tree)[nid].IsLeftChild()) {
+      builder_->hist_.AddHistRow(nid);
+      (*starting_index) = std::min(nid, (*starting_index));
+      n_left++;
+      builder_->hist_local_worker_.AddHistRow(nid);
+    }
+  }
+  for (auto const& nid : merged_node_ids) {
+    if (!((*p_tree)[nid].IsLeftChild())) {
+      builder_->hist_.AddHistRow(nid);
+      builder_->hist_local_worker_.AddHistRow(nid);
+    }
+  }
+  (*sync_count) = std::min(1, n_left);
+  builder_->builder_monitor_.Stop("AddHistRows");
+}
+
+void QuantileHistMaker::Builder::SetHistSynchronizer(HistSynchronizer* sync) {
+  hist_synchronizer_.reset(sync);
+}
+
+void QuantileHistMaker::Builder::SetHistRowsAdder(HistRowsAdder* adder) {
+  hist_rows_adder_.reset(adder);
 }
 
 void QuantileHistMaker::Builder::BuildHistogramsLossGuide(
@@ -183,55 +264,10 @@ void QuantileHistMaker::Builder::BuildHistogramsLossGuide(
   int starting_index = std::numeric_limits<int>::max();
   int sync_count = 0;
 
-  AddHistRows(&starting_index, &sync_count, p_tree);
+  hist_rows_adder_->AddHistRows(&starting_index, &sync_count, p_tree);
   BuildLocalHistograms(gmat, gmatb, p_tree, gpair_h);
-  SyncHistograms(starting_index, sync_count, p_tree);
+  hist_synchronizer_->SyncHistograms(starting_index, sync_count, p_tree);
 }
-
-
-void QuantileHistMaker::Builder::AddHistRows(int *starting_index, int *sync_count,
-                                             RegTree *p_tree) {
-  builder_monitor_.Start("AddHistRows");
-
-  std::vector<int> merged_hist(nodes_for_explicit_hist_build_.size() +
-                                  nodes_for_subtraction_trick_.size());
-  for (size_t i = 0; i < nodes_for_explicit_hist_build_.size(); ++i) {
-    merged_hist[i] = nodes_for_explicit_hist_build_[i].nid;
-  }
-  for (size_t i = 0; i < nodes_for_subtraction_trick_.size(); ++i) {
-    merged_hist[nodes_for_explicit_hist_build_.size() + i] =
-    nodes_for_subtraction_trick_[i].nid;
-  }
-  std::sort(merged_hist.begin(), merged_hist.end());
-  int n_left = 0;
-  for (auto const& nid : merged_hist) {
-    if ((*p_tree)[nid].IsLeftChild()) {
-      hist_.AddHistRow(nid);
-      (*starting_index) = std::min(nid, (*starting_index));
-      n_left++;
-      if (rabit::IsDistributed()) {
-        hist_local_worker_.AddHistRow(nid);
-      }
-    }
-  }
-  for (auto const& nid : merged_hist) {
-    if (!((*p_tree)[nid].IsLeftChild())) {
-      hist_.AddHistRow(nid);
-      if (rabit::IsDistributed()) {
-        hist_local_worker_.AddHistRow(nid);
-      }
-    }
-  }
-
-  if (n_left == 0) {
-    (*sync_count) = 1;
-  } else {
-    (*sync_count) = n_left;
-  }
-
-  builder_monitor_.Stop("AddHistRows");
-}
-
 
 void QuantileHistMaker::Builder::BuildLocalHistograms(
     const GHistIndexMatrix &gmat,
@@ -407,10 +443,9 @@ void QuantileHistMaker::Builder::ExpandWithDepthWise(
     std::vector<ExpandEntry> temp_qexpand_depth;
     SplitSiblings(qexpand_depth_wise_, &nodes_for_explicit_hist_build_,
                   &nodes_for_subtraction_trick_, p_tree);
-    AddHistRows(&starting_index, &sync_count, p_tree);
-
+    hist_rows_adder_->AddHistRows(&starting_index, &sync_count, p_tree);
     BuildLocalHistograms(gmat, gmatb, p_tree, gpair_h);
-    SyncHistograms(starting_index, sync_count, p_tree);
+    hist_synchronizer_->SyncHistograms(starting_index, sync_count, p_tree);
     BuildNodeStats(gmat, p_fmat, p_tree, gpair_h);
 
     EvaluateAndApplySplits(gmat, column_matrix, p_tree, &num_leaves, depth, &timestamp,

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -82,7 +82,7 @@ using xgboost::common::Column;
 class QuantileHistMaker: public TreeUpdater {
  public:
   QuantileHistMaker() {
-    updater_monitor_.Init("Quantile");
+    updater_monitor_.Init("QuantileHistMaker");
   }
   void Configure(const Args& args) override;
 
@@ -281,6 +281,9 @@ class QuantileHistMaker: public TreeUpdater {
     void SyncHistograms(int starting_index,
                         int sync_count,
                         RegTree *p_tree);
+    void ParallelSubtractionHist(const common::BlockedSpace2d& space,
+                                 const std::vector<ExpandEntry>& nodes,
+                                 const RegTree * p_tree);
 
     void BuildNodeStats(const GHistIndexMatrix &gmat,
                         DMatrix *p_fmat,
@@ -334,7 +337,7 @@ class QuantileHistMaker: public TreeUpdater {
     /*! \brief culmulative histogram of gradients. */
     HistCollection hist_;
     /*! \brief culmulative local parent histogram of gradients. */
-    HistCollection phist_local_;
+    HistCollection hist_local_worker_;
 
     /*! \brief feature with least # of bins. to be used for dense specialization
                of InitNewNode() */

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -259,7 +259,7 @@ class QuantileHistMaker: public TreeUpdater {
                               RegTree *p_tree,
                               const std::vector<GradientPair> &gpair_h);
 
-    void AddHistRows(int *starting_index, int *sync_count);
+    void AddHistRows(int *starting_index, int *sync_count, RegTree *p_tree);
 
     void BuildHistogramsLossGuide(
                         ExpandEntry entry,

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -396,64 +396,47 @@ class QuantileHistMaker: public TreeUpdater {
 
 class HistSynchronizer {
  public:
-  explicit HistSynchronizer(QuantileHistMaker::Builder* builder) : builder_(builder) {}
-  virtual void SyncHistograms(int starting_index,
+  virtual void SyncHistograms(QuantileHistMaker::Builder* builder,
+                              int starting_index,
                               int sync_count,
                               RegTree *p_tree) = 0;
-  virtual ~HistSynchronizer() {
-    builder_ = nullptr;
-  }
-
- protected:
-  QuantileHistMaker::Builder* builder_;
 };
 
 class BatchHistSynchronizer: public HistSynchronizer {
  public:
-  explicit BatchHistSynchronizer(QuantileHistMaker::Builder* builder): HistSynchronizer(builder) {}
-
-  void SyncHistograms(int starting_index,
-                              int sync_count,
-                              RegTree *p_tree) override;
+  void SyncHistograms(QuantileHistMaker::Builder* builder,
+                      int starting_index,
+                      int sync_count,
+                      RegTree *p_tree) override;
 };
 
 class DistributedHistSynchronizer: public HistSynchronizer {
  public:
-  explicit DistributedHistSynchronizer(QuantileHistMaker::Builder* builder):
-                                       HistSynchronizer(builder) {}
+  void SyncHistograms(QuantileHistMaker::Builder* builder_,
+                      int starting_index, int sync_count, RegTree *p_tree) override;
 
-  void SyncHistograms(int starting_index,
-                              int sync_count,
-                              RegTree *p_tree) override;
-  void ParallelSubtractionHist(const common::BlockedSpace2d& space,
+  void ParallelSubtractionHist(QuantileHistMaker::Builder* builder,
+                               const common::BlockedSpace2d& space,
                                const std::vector<QuantileHistMaker::Builder::ExpandEntry>& nodes,
                                const RegTree * p_tree);
 };
 
 class HistRowsAdder {
  public:
-  explicit HistRowsAdder(QuantileHistMaker::Builder* builder) : builder_(builder) {}
-  virtual void AddHistRows(int *starting_index, int *sync_count, RegTree *p_tree) = 0;
-  virtual ~HistRowsAdder() {
-    builder_ = nullptr;
-  }
-
- protected:
-  QuantileHistMaker::Builder* builder_;
+  virtual void AddHistRows(QuantileHistMaker::Builder* builder,
+                           int *starting_index, int *sync_count, RegTree *p_tree) = 0;
 };
 
 class BatchHistRowsAdder: public HistRowsAdder {
  public:
-  explicit BatchHistRowsAdder(QuantileHistMaker::Builder* builder) : HistRowsAdder(builder) {}
-
-  void AddHistRows(int *starting_index, int *sync_count, RegTree *p_tree) override;
+  void AddHistRows(QuantileHistMaker::Builder* builder,
+                   int *starting_index, int *sync_count, RegTree *p_tree) override;
 };
 
 class DistributedHistRowsAdder: public HistRowsAdder {
  public:
-  explicit DistributedHistRowsAdder(QuantileHistMaker::Builder* builder) : HistRowsAdder(builder) {}
-
-  void AddHistRows(int *starting_index, int *sync_count, RegTree *p_tree) override;
+  void AddHistRows(QuantileHistMaker::Builder* builder,
+                   int *starting_index, int *sync_count, RegTree *p_tree) override;
 };
 
 

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -331,6 +331,9 @@ class QuantileHistMaker: public TreeUpdater {
     std::vector<NodeEntry> snode_;
     /*! \brief culmulative histogram of gradients. */
     HistCollection hist_;
+    /*! \brief culmulative local parent histogram of gradients. */
+    HistCollection phist_local_;
+
     /*! \brief feature with least # of bins. to be used for dense specialization
                of InitNewNode() */
     uint32_t fid_least_bins_;

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -400,6 +400,9 @@ class HistSynchronizer {
   virtual void SyncHistograms(int starting_index,
                               int sync_count,
                               RegTree *p_tree) = 0;
+  virtual ~HistSynchronizer() {
+    builder_ = nullptr;
+  }
 
  protected:
   QuantileHistMaker::Builder* builder_;
@@ -409,9 +412,9 @@ class BatchHistSynchronizer: public HistSynchronizer {
  public:
   explicit BatchHistSynchronizer(QuantileHistMaker::Builder* builder): HistSynchronizer(builder) {}
 
-  virtual void SyncHistograms(int starting_index,
+  void SyncHistograms(int starting_index,
                               int sync_count,
-                              RegTree *p_tree);
+                              RegTree *p_tree) override;
 };
 
 class DistributedHistSynchronizer: public HistSynchronizer {
@@ -419,9 +422,9 @@ class DistributedHistSynchronizer: public HistSynchronizer {
   explicit DistributedHistSynchronizer(QuantileHistMaker::Builder* builder):
                                        HistSynchronizer(builder) {}
 
-  virtual void SyncHistograms(int starting_index,
+  void SyncHistograms(int starting_index,
                               int sync_count,
-                              RegTree *p_tree);
+                              RegTree *p_tree) override;
   void ParallelSubtractionHist(const common::BlockedSpace2d& space,
                                const std::vector<QuantileHistMaker::Builder::ExpandEntry>& nodes,
                                const RegTree * p_tree);
@@ -431,6 +434,9 @@ class HistRowsAdder {
  public:
   explicit HistRowsAdder(QuantileHistMaker::Builder* builder) : builder_(builder) {}
   virtual void AddHistRows(int *starting_index, int *sync_count, RegTree *p_tree) = 0;
+  virtual ~HistRowsAdder() {
+    builder_ = nullptr;
+  }
 
  protected:
   QuantileHistMaker::Builder* builder_;
@@ -440,14 +446,14 @@ class BatchHistRowsAdder: public HistRowsAdder {
  public:
   explicit BatchHistRowsAdder(QuantileHistMaker::Builder* builder) : HistRowsAdder(builder) {}
 
-  void AddHistRows(int *starting_index, int *sync_count, RegTree *p_tree);
+  void AddHistRows(int *starting_index, int *sync_count, RegTree *p_tree) override;
 };
 
 class DistributedHistRowsAdder: public HistRowsAdder {
  public:
   explicit DistributedHistRowsAdder(QuantileHistMaker::Builder* builder) : HistRowsAdder(builder) {}
 
-  void AddHistRows(int *starting_index, int *sync_count, RegTree *p_tree);
+  void AddHistRows(int *starting_index, int *sync_count, RegTree *p_tree) override;
 };
 
 

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -81,7 +81,9 @@ using xgboost::common::Column;
 /*! \brief construct a tree using quantized feature values */
 class QuantileHistMaker: public TreeUpdater {
  public:
-  QuantileHistMaker() = default;
+  QuantileHistMaker() {
+    updater_monitor_.Init("Quantile");
+  }
   void Configure(const Args& args) override;
 
   void Update(HostDeviceVector<GradientPair>* gpair,
@@ -371,7 +373,7 @@ class QuantileHistMaker: public TreeUpdater {
     common::ParallelGHistBuilder hist_buffer_;
     rabit::Reducer<GradStats, GradStats::Reduce> histred_;
   };
-
+  common::Monitor updater_monitor_;
   std::unique_ptr<Builder> builder_;
   std::unique_ptr<TreeUpdater> pruner_;
   std::unique_ptr<SplitEvaluator> spliteval_;

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -140,7 +140,7 @@ class QuantileHistMock : public QuantileHistMaker {
       nodes_for_subtraction_trick_.emplace_back(5, 6, tree->GetDepth(5), 0.0f, 0);
       nodes_for_subtraction_trick_.emplace_back(6, 5, tree->GetDepth(6), 0.0f, 0);
 
-      hist_rows_adder_->AddHistRows(&starting_index, &sync_count, tree);
+      hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, tree);
       ASSERT_EQ(sync_count, 2);
       ASSERT_EQ(starting_index, 3);
 
@@ -166,7 +166,7 @@ class QuantileHistMock : public QuantileHistMaker {
       nodes_for_subtraction_trick_.clear();
       // level 0
       nodes_for_explicit_hist_build_.emplace_back(0, -1, tree->GetDepth(0), 0.0f, 0);
-      hist_rows_adder_->AddHistRows(&starting_index, &sync_count, tree);
+      hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, tree);
       tree->ExpandNode(0, 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
 
       nodes_for_explicit_hist_build_.clear();
@@ -176,7 +176,7 @@ class QuantileHistMock : public QuantileHistMaker {
                                                 tree->GetDepth(1), 0.0f, 0);
       nodes_for_subtraction_trick_.emplace_back((*tree)[0].RightChild(), (*tree)[0].LeftChild(),
                                               tree->GetDepth(2), 0.0f, 0);
-      hist_rows_adder_->AddHistRows(&starting_index, &sync_count, tree);
+      hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, tree);
       tree->ExpandNode((*tree)[0].LeftChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
       tree->ExpandNode((*tree)[0].RightChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
 
@@ -187,7 +187,7 @@ class QuantileHistMock : public QuantileHistMaker {
       nodes_for_subtraction_trick_.emplace_back(4, 3, tree->GetDepth(4), 0.0f, 0);
       nodes_for_explicit_hist_build_.emplace_back(5, 6, tree->GetDepth(5), 0.0f, 0);
       nodes_for_subtraction_trick_.emplace_back(6, 5, tree->GetDepth(6), 0.0f, 0);
-      hist_rows_adder_->AddHistRows(&starting_index, &sync_count, tree);
+      hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, tree);
 
       const size_t n_nodes = nodes_for_explicit_hist_build_.size();
       ASSERT_EQ(n_nodes, 2);
@@ -233,7 +233,7 @@ class QuantileHistMock : public QuantileHistMaker {
 
       hist_buffer_.Reset(1, n_nodes, space, target_hists);
       // sync hist
-      hist_synchronizer_->SyncHistograms(starting_index, sync_count, tree);
+      hist_synchronizer_->SyncHistograms(this, starting_index, sync_count, tree);
 
       auto check_hist = [] (const GHistRow parent, const GHistRow left,
                             const GHistRow right, size_t begin, size_t end) {
@@ -479,11 +479,11 @@ class QuantileHistMock : public QuantileHistMaker {
             int_constraint_,
             dmat_.get()));
     if (batch) {
-      builder_->SetHistSynchronizer(new BatchHistSynchronizer(builder_.get()));
-      builder_->SetHistRowsAdder(new BatchHistRowsAdder(builder_.get()));
+      builder_->SetHistSynchronizer(new BatchHistSynchronizer());
+      builder_->SetHistRowsAdder(new BatchHistRowsAdder());
     } else {
-      builder_->SetHistSynchronizer(new DistributedHistSynchronizer(builder_.get()));
-      builder_->SetHistRowsAdder(new DistributedHistRowsAdder(builder_.get()));
+      builder_->SetHistSynchronizer(new DistributedHistSynchronizer());
+      builder_->SetHistRowsAdder(new DistributedHistRowsAdder());
     }
   }
   ~QuantileHistMock() override = default;


### PR DESCRIPTION
This PR consists changes to optimize distributed mode of training.

1) depthwise changes: Possibility to build 'smaller' nodes was introduced for distributed mode (before this only left nodes were build)  for more balanced work. Than 'subtraction trick' is applied for 'larger' node.
2) lossguide changes: similar to above.
3) number of rabit::Allreduce calls is the same as before due to structured histograms adding. 
4) Timers were added to track most time consuming parts for distributed also.


**mortgage 3.5Gb** 
6 workers x 8 threads | loss | depth
-- | -- | --
Master | 76.6 | 68.5
This PR | 48.7 | 44

**higgs 10m,  2.7Gb** 
running line: python .../dmlc-core/tracker/dmlc-submit --cluster=local --num-workers=4 --worker-cores=12 python distr_higgs10m.py

4 workers x 12 threads | depth
-- | --
Master | 877.83
This PR | 223.66

