### PR TITLE
Avoid rabit calls in learner configuration

### DIFF
--- a/src/learner.cc
+++ b/src/learner.cc
@@ -494,6 +494,17 @@ class LearnerConfiguration : public Learner {
           << std::numeric_limits<unsigned>::max() << " features or greater";
       num_feature = std::max(num_feature, static_cast<uint32_t>(num_col));
     }
+
+    try {
+      // try run allreduce on num_feature to find the maximum value
+      rabit::Allreduce<rabit::op::Max>(&num_feature, 1, nullptr, nullptr,
+                                       "num_feature");
+    } catch (...) {
+      LOG(WARNING)
+          << "AllReduce call in learner configuration failed. Distributed code "
+             "should configure all workers synchronously.";
+    }
+
     if (num_feature > mparam_.num_feature) {
       mparam_.num_feature = num_feature;
     }

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -494,8 +494,6 @@ class LearnerConfiguration : public Learner {
           << std::numeric_limits<unsigned>::max() << " features or greater";
       num_feature = std::max(num_feature, static_cast<uint32_t>(num_col));
     }
-    // run allreduce on num_feature to find the maximum value
-    rabit::Allreduce<rabit::op::Max>(&num_feature, 1, nullptr, nullptr, "num_feature");
     if (num_feature > mparam_.num_feature) {
       mparam_.num_feature = num_feature;
     }

--- a/tests/distributed/test_basic.py
+++ b/tests/distributed/test_basic.py
@@ -20,8 +20,9 @@ num_round = 20
 bst = xgb.train(param, dtrain, num_round, watchlist, early_stopping_rounds=2)
 
 # Save the model, only ask process 0 to save the model.
-bst.save_model("test.model{}".format(xgb.rabit.get_rank()))
-xgb.rabit.tracker_print("Finished training\n")
+if xgb.rabit.get_rank() == 0:
+    bst.save_model("test.model")
+    xgb.rabit.tracker_print("Finished training\n")
 
 # Notify the tracker all training has been successful
 # This is only needed in distributed training.

--- a/tests/distributed/test_issue3402.py
+++ b/tests/distributed/test_issue3402.py
@@ -70,8 +70,9 @@ watchlist  = [(dtrain,'train')]
 num_round = 2
 bst = xgb.train(param, dtrain, num_round, watchlist)
 
-bst.save_model("test_issue3402.model{}".format(xgb.rabit.get_rank()))
-xgb.rabit.tracker_print("Finished training\n")
+if xgb.rabit.get_rank() == 0:
+  bst.save_model("test_issue3402.model")
+  xgb.rabit.tracker_print("Finished training\n")
 
 # Notify the tracker all training has been successful
 # This is only needed in distributed training.


### PR DESCRIPTION
I had an issue in #5484 where trying to save the model only on one distributed worker resulted in a rabit error, in that case I modified the tests, but came across the same error today when running the cover type dataset with gbm-bench. 

I traced this back to learner.Configure() being called when the model is saved and then calling rabit allreduce to synchronise number of features. This rabit call should be unnecessary as DMatrix constructors are responsible for making sure they correctly set number of columns in distributed environments.