### PR TITLE
Fix compilation on Mac OSX High Sierra (10.13)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - linux
   - osx
 
-osx_image: xcode10.3
+osx_image: xcode10.1
 dist: bionic
 
 # Use Build Matrix to do lint and build seperately

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ env:
     # cmake test
     - TASK=cmake_test
 
+  global:
+    - secure: "PR16i9F8QtNwn99C5NDp8nptAS+97xwDtXEJJfEiEVhxPaaRkOp0MPWhogCaK0Eclxk1TqkgWbdXFknwGycX620AzZWa/A1K3gAs+GrpzqhnPMuoBJ0Z9qxXTbSJvCyvMbYwVrjaxc/zWqdMU8waWz8A7iqKGKs/SqbQ3rO6v7c="
+    - secure: "dAGAjBokqm/0nVoLMofQni/fWIBcYSmdq4XvCBX1ZAMDsWnuOfz/4XCY6h2lEI1rVHZQ+UdZkc9PioOHGPZh5BnvE49/xVVWr9c4/61lrDOlkD01ZjSAeoV0fAZq+93V/wPl4QV+MM+Sem9hNNzFSbN5VsQLAiWCSapWsLdKzqA="
+
 matrix:
   exclude:
     - os: linux

--- a/src/metric/survival_metric.cc
+++ b/src/metric/survival_metric.cc
@@ -70,8 +70,7 @@ struct EvalAFT : public Metric {
 
     double nloglik_sum = 0.0;
     double weight_sum = 0.0;
-    #pragma omp parallel for default(none) \
-     firstprivate(nsize, is_null_weight, aft_loss_distribution_scale) \
+    #pragma omp parallel for \
      shared(weights, y_lower, y_upper, yhat) reduction(+:nloglik_sum, weight_sum)
     for (omp_ulong i = 0; i < nsize; ++i) {
       // If weights are empty, data is unweighted so we use 1.0 everywhere

--- a/src/objective/aft_obj.cc
+++ b/src/objective/aft_obj.cc
@@ -56,8 +56,7 @@ class AFTObj : public ObjFunction {
     const omp_ulong nsize = static_cast<omp_ulong>(yhat.size());
     const float aft_loss_distribution_scale = param_.aft_loss_distribution_scale;
 
-    #pragma omp parallel for default(none) \
-      firstprivate(nsize, is_null_weight, aft_loss_distribution_scale) \
+    #pragma omp parallel for \
       shared(weights, y_lower, y_upper, yhat, gpair)
     for (omp_ulong i = 0; i < nsize; ++i) {
       // If weights are empty, data is unweighted so we use 1.0 everywhere
@@ -74,7 +73,7 @@ class AFTObj : public ObjFunction {
     // Trees give us a prediction in log scale, so exponentiate
     std::vector<bst_float> &preds = io_preds->HostVector();
     const long ndata = static_cast<long>(preds.size()); // NOLINT(*)
-    #pragma omp parallel for default(none) firstprivate(ndata) shared(preds)
+    #pragma omp parallel for shared(preds)
     for (long j = 0; j < ndata; ++j) {  // NOLINT(*)
       preds[j] = std::exp(preds[j]);
     }

--- a/tests/ci_build/rename_whl.py
+++ b/tests/ci_build/rename_whl.py
@@ -21,8 +21,6 @@ whl_path = sys.argv[1]
 commit_id = sys.argv[2]
 platform_tag = sys.argv[3]
 
-assert platform_tag in ['manylinux1_x86_64', 'manylinux2010_x86_64', 'win_amd64']
-
 dirname, basename = os.path.dirname(whl_path), os.path.basename(whl_path)
 
 with cd(dirname):

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -23,18 +23,42 @@ if [ ${TASK} == "python_test" ]; then
     mkdir build && cd build
     cmake .. -DUSE_OPENMP=ON -DCMAKE_VERBOSE_MAKEFILE=ON
     make -j$(nproc)
-    cd ..
 
     echo "-------------------------------"
     conda activate python3
     conda --version
     python --version
 
+    # Build binary wheel
+    cd ../python-package
+    python setup.py bdist_wheel
+    TAG=macosx_10_13_x86_64.macosx_10_14_x86_64.macosx_10_15_x86_64
+    python ../tests/ci_build/rename_whl.py dist/*.whl ${TRAVIS_COMMIT} ${TAG}
+    python -m pip install ./dist/xgboost-*-py3-none-${TAG}.whl
+
+    # Run unit tests
+    cd ..
     python -m pip install graphviz pytest pytest-cov codecov
     python -m pip install datatable
     python -m pip install numpy scipy pandas matplotlib scikit-learn dask[complete]
     python -m pytest -v --fulltrace -s tests/python --cov=python-package/xgboost || exit -1
     codecov
+
+    # Deploy binary wheel to S3
+    python -m pip install awscli
+    if [ "${TRAVIS_PULL_REQUEST}" != "false" ]
+    then
+        S3_DEST="s3://xgboost-nightly-builds/PR-${TRAVIS_PULL_REQUEST}/"
+    else
+        if [ "${TRAVIS_BRANCH}" == "master" ]
+        then
+            S3_DEST="s3://xgboost-nightly-builds/"
+        elif [ -z "${TRAVIS_TAG}" ]
+        then
+            S3_DEST="s3://xgboost-nightly-builds/${TRAVIS_BRANCH}/"
+        fi
+    fi
+    python -m awscli s3 cp python-package/dist/*.whl "${S3_DEST}" || true
 fi
 
 if [ ${TASK} == "java_test" ]; then


### PR DESCRIPTION
Closes #5595.

* The `default(none)` clause of OpenMP has unclear semantics when const variables are present. Remove all occurrences of `default(none)` from the codebase to maintain portability.
* [CI] Run tests using Mac OSX High Sierra (10.13). Previously, we only tested with Mac OSX Mojave (10.14).
* [CI] Upload binary wheels for Mac OSX. Fixes #5586. The wheel name will be of form `xgboost-[version]-py3-none-macosx_10_13_x86_64.macosx_10_14_x86_64.macosx_10_15_x86_64.whl`. The goal is to support High Sierra (10.13), Mojave (10.14), and Catalina (10.15).