### PR TITLE
[R] Address warnings to comply with CRAN submission policy

### DIFF
--- a/R-package/vignettes/xgboostPresentation.Rmd
+++ b/R-package/vignettes/xgboostPresentation.Rmd
@@ -410,7 +410,7 @@ In some very specific cases, like when you want to pilot **XGBoost** from `caret
 
 ```{r saveLoadRBinVectorModel, message=F, warning=F}
 # save model to R's raw vector
-rawVec <- xgb.save.raw(bst)
+rawVec <- xgb.serialize(bst)
 
 # print class
 print(class(rawVec))

--- a/include/xgboost/span.h
+++ b/include/xgboost/span.h
@@ -85,9 +85,11 @@ namespace common {
     }                                                                          \
   } while (0);
 
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__)
 #define SPAN_CHECK KERNEL_CHECK
-#else
+#elif defined(XGBOOST_STRICT_R_MODE) && XGBOOST_STRICT_R_MODE == 1  // R package
+#define SPAN_CHECK CHECK  // check from dmlc
+#else  // not CUDA, not R
 #define SPAN_CHECK(cond)                                                       \
   do {                                                                         \
     if (XGBOOST_EXPECT(!(cond), false)) {                                      \

--- a/include/xgboost/span.h
+++ b/include/xgboost/span.h
@@ -30,6 +30,7 @@
 #define XGBOOST_SPAN_H_
 
 #include <xgboost/base.h>
+#include <xgboost/logging.h>
 
 #include <cinttypes>          // size_t
 #include <limits>             // numeric_limits


### PR DESCRIPTION
```
* checking compiled code ... NOTE
File ‘xgboost/libs/xgboost.so’:
  Found ‘stderr’, possibly from ‘stderr’ (C)
    Object: ‘./amalgamation/xgboost-all0.o’

Compiled code should not call entry points which might terminate R nor
write to stdout/stderr instead of to the console, nor use Fortran I/O
nor system RNGs.

See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.

--- re-building ‘xgboostPresentation.Rmd’ using rmarkdown
Loading required package: xgboost
Quitting from lines 412-424 (xgboostPresentation.Rmd)
Error: processing vignette 'xgboostPresentation.Rmd' failed with diagnostics:
[01:06:51] amalgamation/../src/learner.cc:506: Check failed: mparam_.num_feature != 0 (0 vs. 0) : 0 feature is supplied.  Are you using raw Booster interface?
Stack trace:
  [bt] (0) /home/phcho/Desktop/xgboost/xgboost.Rcheck/xgboost/libs/xgboost.so(dmlc::LogMessageFatal::~LogMessageFatal()+0x7c) [0x7f33473da05c]
  [bt] (1) /home/phcho/Desktop/xgboost/xgboost.Rcheck/xgboost/libs/xgboost.so(xgboost::LearnerConfiguration::ConfigureNumFeatures()+0xeb) [0x7f33474932ab]
  [bt] (2) /home/phcho/Desktop/xgboost/xgboost.Rcheck/xgboost/libs/xgboost.so(xgboost::LearnerConfiguration::Configure()+0x3ba) [0x7f33474d363a]
  [bt] (3) /home/phcho/Desktop/xgboost/xgboost.Rcheck/xgboost/libs/xgboost.so(xgboost::LearnerImpl::Predict(std::shared_ptr<xgboost::DMatrix>, bool, xgboost::HostDeviceV
ector<float>*, unsigned int, bool, bool, bool, bool, bool)+0x78) [0x7f3347491b98]
  [bt] (4) /home/phcho/Desktop/xgboost/xgboost.Rcheck/xgboost/libs/xgboost.so(XGBoosterPredict+0xef) [0x7f33473ef86f]
--- failed re-building ‘xgboostPresentation.Rmd’
```

Also created tracking issue #5599, so that future releases would be easier.