### PR TITLE
Clarify docstring for XGBoosterPredict() C API

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -418,7 +418,8 @@ XGB_DLL int XGBoosterEvalOneIter(BoosterHandle handle,
  *          4:output feature contributions to individual predictions
  * \param ntree_limit limit number of trees used for prediction, this is only valid for boosted trees
  *    when the parameter is set to 0, we will use all the trees
- * \param training Whether the prediction value is used for training.
+ * \param training Whether the prediction value is used for training. This can effect dart booster,
+ *    which performs dropouts during training iterations.
  * \param out_len used to store length of returning result
  * \param out_result used to set a pointer to array
  * \return 0 when success, -1 when failure happens


### PR DESCRIPTION
Clarify the meaning of `training` parameter to the C API function `XGBoosterPredict()`.

Closes #5601.

@glycerine Can you review?