### PR TITLE
Clarify meaning of `training` parameter in XGBoosterPredict()

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -418,12 +418,14 @@ XGB_DLL int XGBoosterEvalOneIter(BoosterHandle handle,
  *          4:output feature contributions to individual predictions
  * \param ntree_limit limit number of trees used for prediction, this is only valid for boosted trees
  *    when the parameter is set to 0, we will use all the trees
- * \param training_dart_use_dropout Whether the prediction value is used for training under DART.
- *    For most use cases, set it to 0. Set this parameter to 1 only if ALL of the following
- *    conditions hold:
- *    1) you are writing a training loop (inference doesn't apply);
- *    2) you are using DART;
- *    3) you are using a customized objective function.
+ * \param training Whether the prediction function is used as part of a training loop.
+ *    1. If you are running prediction to obtain a metric (not gradient pairs), set training=False.
+ *    2. When should you set training=true?
+ *       Normally, you don't need to use XGBoosterPredict() in your training loop, since you are
+ *       probably using XGBoosterUpdateOneIter(), which calls XGBoosterPredict() internally. The one
+ *       case you should use XGBoosterPredict() in your training loop is when you wrote a customized
+ *       objective. In this case, call XGBoosterPredict() with training=true and then invoke your
+ *       customized objective fobj(predicted_label, true_label) to obtain the gradient pairs.
  * \param out_len used to store length of returning result
  * \param out_result used to set a pointer to array
  * \return 0 when success, -1 when failure happens
@@ -432,7 +434,7 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
                              DMatrixHandle dmat,
                              int option_mask,
                              unsigned ntree_limit,
-                             int training_dart_use_dropout,
+                             int training,
                              bst_ulong *out_len,
                              const float **out_result);
 /*

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -419,15 +419,11 @@ XGB_DLL int XGBoosterEvalOneIter(BoosterHandle handle,
  * \param ntree_limit limit number of trees used for prediction, this is only valid for boosted trees
  *    when the parameter is set to 0, we will use all the trees
  * \param training_dart_use_dropout Whether the prediction value is used for training under DART.
- *        If you are not using DART, just set it to 0 and ignore rest of this discussion.
- *        Setting training_dart_use_dropout=1 will cause the prediction function to perform 
- *        dropout, evaluating only a subset of the trees in the ensemble. Setting it to 0 will 
- *        evaluate all trees.
- *        XGBoosterPredict() is used in two places:
- *	  a) When you are training a tree ensemble. Here, you want to perform dropout.
- *        b) When you are done training and now would like to evaluate the model on a new dataset.
- *           In this second case, you do not want dropout.
- *	  Are you using XGBoosterPredict() after you are done training your model? Then set training=0 (false).
+ *    For most use cases, set it to 0. Set this parameter to 1 only if ALL of the following
+ *    conditions hold:
+ *    1) you are writing a training loop (inference doesn't apply);
+ *    2) you are using DART;
+ *    3) you are using a customized objective function.
  * \param out_len used to store length of returning result
  * \param out_result used to set a pointer to array
  * \return 0 when success, -1 when failure happens

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -419,13 +419,13 @@ XGB_DLL int XGBoosterEvalOneIter(BoosterHandle handle,
  * \param ntree_limit limit number of trees used for prediction, this is only valid for boosted trees
  *    when the parameter is set to 0, we will use all the trees
  * \param training Whether the prediction function is used as part of a training loop.
- *    1. If you are running prediction to obtain a metric (not gradient pairs), set training=False.
- *    2. When should you set training=true?
- *       Normally, you don't need to use XGBoosterPredict() in your training loop, since you are
- *       probably using XGBoosterUpdateOneIter(), which calls XGBoosterPredict() internally. The one
- *       case you should use XGBoosterPredict() in your training loop is when you wrote a customized
- *       objective. In this case, call XGBoosterPredict() with training=true and then invoke your
- *       customized objective fobj(predicted_label, true_label) to obtain the gradient pairs.
+ *    Prediction can be run in 2 scenarios:
+ *    1. Given data matrix X, obtain prediction y_pred from the model.
+ *    2. Obtain the prediction for computing gradients. For example, DART booster performs dropout
+ *       during training, and the prediction result will be different from the one obtained by normal
+ *       inference step due to dropped trees.
+ *    Set training=false for the first scenario. Set training=true for the second scenario.
+ *    The second scenario applies when you are defining a custom objective function.
  * \param out_len used to store length of returning result
  * \param out_result used to set a pointer to array
  * \return 0 when success, -1 when failure happens

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -418,7 +418,16 @@ XGB_DLL int XGBoosterEvalOneIter(BoosterHandle handle,
  *          4:output feature contributions to individual predictions
  * \param ntree_limit limit number of trees used for prediction, this is only valid for boosted trees
  *    when the parameter is set to 0, we will use all the trees
- * \param training Whether the prediction value is used for training.
+ * \param training_dart_use_dropout Whether the prediction value is used for training under DART.
+ *        If you are not using DART, just set it to 0 and ignore rest of this discussion.
+ *        Setting training_dart_use_dropout=1 will cause the prediction function to perform 
+ *        dropout, evaluating only a subset of the trees in the ensemble. Setting it to 0 will 
+ *        evaluate all trees.
+ *        XGBoosterPredict() is used in two places:
+ *	  a) When you are training a tree ensemble. Here, you want to perform dropout.
+ *        b) When you are done training and now would like to evaluate the model on a new dataset.
+ *           In this second case, you do not want dropout.
+ *	  Are you using XGBoosterPredict() after you are done training your model? Then set training=0 (false).
  * \param out_len used to store length of returning result
  * \param out_result used to set a pointer to array
  * \return 0 when success, -1 when failure happens
@@ -427,7 +436,7 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
                              DMatrixHandle dmat,
                              int option_mask,
                              unsigned ntree_limit,
-                             int training,
+                             int training_dart_use_dropout,
                              bst_ulong *out_len,
                              const float **out_result);
 /*

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -426,7 +426,7 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
                              DMatrixHandle dmat,
                              int option_mask,
                              unsigned ntree_limit,
-                             int32_t training,
+                             int training,
                              xgboost::bst_ulong *len,
                              const bst_float **out_result) {
   API_BEGIN();


### PR DESCRIPTION
fixes #5601 . Pre-empts questions about the breaking API change for v1.1.0 that downstream maintainers will have.