### PR TITLE
[POC] Implement callback for dask.

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -380,12 +380,14 @@ class EarlyStopping(TrainingCallback):
     '''
     def __init__(self, data, name, rounds, metric=None, metric_name='metric',
                  maximize=False, missing=numpy.nan, weight=None, label=None):
-        self.data = self._make_dmatrix(data, label, weight, missing)
-
         if callable(metric):
+            self.data = data
             self.label = label
+            assert weight is None, 'Weight is not supported by custom metric'
         else:
+            self.data = self._make_dmatrix(data, label, weight, missing)
             self.label = None
+            self.weight = None
 
         self.data_id = id(self.data)
         self.name = name
@@ -458,8 +460,8 @@ Use distributed version instead.  For dask users:
 >>>  from xgboost.dask import EarlyStopping
 '''
         if callable(self.metric):
-            predt = model.predict(self.data)
-            score = self.metric(predt, self.label)
+            predt = model.inplace_predict(self.data)
+            score = self.metric(self.label, predt)
             score = [(self.metric_name, score)]
         else:
             score = model.eval(self.data)

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -1,9 +1,14 @@
 # coding: utf-8
-# pylint: disable=invalid-name, too-many-statements
+# pylint: disable=invalid-name, too-many-statements, no-self-use
+# pylint: disable=too-many-arguments
 """Training Library containing training routines."""
+from abc import ABC
+import collections
+import numpy
 
 from . import rabit
-from .core import EarlyStopException
+from .core import EarlyStopException, DMatrix, CallbackEnv
+from .compat import STRING_TYPES
 
 
 def _get_callback_context(env):
@@ -23,7 +28,7 @@ def _fmt_metric(value, show_stdv=True):
         if show_stdv:
             return  '{0}:{1:.5f}+{2:.5f}'.format(value[0], value[1], value[2])
         return '{0}:{1:.5f}'.format(value[0], value[1])
-    raise ValueError("wrong metric value")
+    raise ValueError("wrong metric value", value)
 
 
 def print_evaluation(period=1, show_stdv=True):
@@ -253,3 +258,348 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
                 rabit.tracker_print(msg.format(best_msg))
             raise EarlyStopException(best_iteration)
     return callback
+
+
+#
+# The new implementation of callback functions.
+#
+# TODOs
+# - eval_set
+# - cv
+# - tests
+# - doc
+# - enforced best_xxx
+# - merged functionality of es and mon.
+
+# pylint: disable=unused-argument
+class TrainingCallback(ABC):
+    '''Interface for training callback.
+
+    .. versionadded:: 1.2.0
+
+    '''
+    def __init__(self):
+        self.history = {}
+
+    def before_training(self, model):
+        '''Run before training starts.'''
+
+    def after_training(self, model):
+        '''Run after training is finished.'''
+
+    def before_iteration(self, model, epoch):
+        '''Run before each iteration.'''
+        return False
+
+    def after_iteration(self, model, epoch):
+        '''Run after each iteration.'''
+        return False
+
+
+class CallbackContainer(TrainingCallback):
+    '''A container for list of callbacks.
+
+    .. versionadded:: 1.2.0
+
+    '''
+    def __init__(self, callbacks):
+        self.callbacks = callbacks
+        super().__init__()
+
+    def before_training(self, model):
+        for c in self.callbacks:
+            c.before_training(model)
+
+    def after_training(self, model):
+        for c in self.callbacks:
+            c.after_training(model)
+
+    def before_iteration(self, model, epoch):
+        return any(c.before_iteration(model, epoch)
+                   for c in self.callbacks)
+
+    def after_iteration(self, model, epoch):
+        return any(c.after_iteration(model, epoch)
+                   for c in self.callbacks)
+
+
+class LearningRateScheduler(TrainingCallback):
+    '''Callback function for scheduling learning rate.
+
+    .. versionadded:: 1.2.0
+
+    Parameters
+    ----------
+
+    learning_rates : callable/collections.Sequence
+        If it's a callable object, then it should accept an integer parameter
+        `epoch` and returns the corresponding learning rate.  Otherwise it
+        shoule be a sequence like list or tuple with the same size of boosting
+        rounds.
+
+    '''
+    def __init__(self, learning_rates):
+        assert callable(learning_rates) or \
+            isinstance(learning_rates, collections.Sequence)
+        if callable(learning_rates):
+            self.learning_rates = learning_rates
+        else:
+            self.learning_rates = lambda epoch: learning_rates[epoch]
+        super().__init__()
+
+    def after_iteration(self, model, epoch):
+        model.set_param('learning_rate', self.learning_rates(epoch))
+
+
+# pylint: disable=too-many-instance-attributes
+class EarlyStopping(TrainingCallback):
+    ''' Callback function for early stopping
+
+    .. versionadded:: 1.2.0
+
+    Parameters
+    ----------
+    data
+        data for evaluation.
+    name : str
+        Name of data.
+    metric : str/callable
+        Name of metric.
+    rounds : int
+        Early stopping rounds.
+    metric_name : str
+        Name of metric, used when metric is a callable object.
+    maximize : bool
+        Whether to maximize evaluation metric.
+    missing : float
+        Same as missing for DMatrix, used when input is not a DMatrix.
+    wegiht
+        Same as label for DMatrix, used when input is not a DMatrix.
+    label
+        Same as weight for DMatrix, used when input is not a DMatrix.
+    '''
+    def __init__(self, data, name, metric, rounds,
+                 metric_name='metric',
+                 maximize=False, missing=numpy.nan, weight=None, label=None):
+        self.data = self._make_dmatrix(data, label, weight, missing)
+
+        if callable(metric):
+            self.label = label
+        else:
+            self.label = None
+
+        self.data_id = id(self.data)
+        self.name = name
+        self.metric = metric
+        self.rounds = rounds
+        self.metric_name = metric_name
+        self.maximize = maximize
+
+        if self.maximize:
+            self.improve_op = lambda x, y: x > y
+        else:
+            self.improve_op = lambda x, y: x < y
+
+        self.current_rounds = 0
+        super().__init__()
+
+    def _make_dmatrix(self, data, label, weight, missing):
+        if not isinstance(data, DMatrix):
+            assert label is not None
+            data = DMatrix(data, label=label, weight=weight, missing=missing)
+        else:
+            assert label is None and weight is None and numpy.isnan(missing), (
+                'label, weight and missing are only used when input is not ' +
+                'a DMatrix'
+            )
+        return data
+
+    def before_training(self, model):
+        if not callable(self.metric):
+            model.set_param({'eval_metric': self.metric})
+
+    def after_training(self, model):
+        model.best_iteration = self.rounds
+        model.set_attr(best_iteration=str(self.rounds))
+
+    def _update_rounds(self, score, model, epoch):
+        if not self.history:
+            self.current_rounds = 0
+            self.history[self.name] = [score]
+        elif not self.improve_op(score, self.history[self.name][-1]):
+            self.current_rounds += 1
+        else:                   # Improved
+            self.history[self.name].append(score)
+            model.set_attr(best_score=self.history[-1],
+                           best_iteration=epoch)
+
+        if self.current_rounds >= self.rounds:
+            return True
+        return False
+
+    def after_iteration(self, model, epoch):
+        assert not rabit.is_distributed()
+        if callable(self.metric):
+            predt = model.predict(self.data)
+            score = self.metric(predt, self.label)
+            score = [(self.metric_name, score)]
+        else:
+            score = model.eval(self.data)
+            score = [s.split(':') for s in score.split()]
+            score = [(k, float(v)) for k, v in score[1:]]
+
+        return self._update_rounds(score, model, epoch)
+
+
+class EvaluationMonitor(TrainingCallback):
+    '''Print the evaluation result at each iteration.
+
+    .. versionadded:: 1.2.0
+
+    Parameters
+    ----------
+
+    data
+        Data for evaluation.
+    name : str
+        Name of data.
+    metric : str
+        Name of metric
+    rank : int
+        Which worker should be used for printing the result.
+    missing : float
+        Used when data is not a DMatrix.
+    weight
+        Used when data is not a DMatrix.
+    label
+        Used when data is not a DMatrix.
+    '''
+    def __init__(self, data, name,
+                 metric=None, rank=0, missing=numpy.nan,
+                 weight=None, label=None):
+        data = self._make_dmatrix(data, label, weight, missing)
+        self.data = data
+        self.data_id = id(self.data)
+
+        self.name = name
+        self.metric = metric
+        self.label = label
+        self.printer_rank = rank
+        super().__init__()
+
+    def _make_dmatrix(self, data, label, weight, missing):
+        if not isinstance(data, DMatrix):
+            assert label is not None
+            data = DMatrix(data, label=label, weight=weight, missing=missing)
+        else:
+            assert label is None and weight is None and numpy.isnan(missing), (
+                'label, weight and missing are only used when input is not ' +
+                'a DMatrix'
+            )
+        return data
+
+    def before_training(self, model):
+        model.set_param({'eval_metric': self.metric})
+
+    def _update_history(self, score, epoch):
+        score = [s.split(':') for s in score.split()]
+        score = [(k, float(v)) for k, v in score[1:]]
+
+        if rabit.get_rank() == self.printer_rank:
+            msg = _fmt_metric(score[0])
+            rabit.tracker_print('[%d]\t%s\n' % (epoch, msg))
+
+        def metric_name():
+            if self.metric:
+                return self.metric
+            name = score[0][0]
+            pos = name.index('-')
+            name = name[pos+1:]
+            return name
+
+        if not self.history:
+            self.history[metric_name()] = [score[0][1]]
+        else:
+            self.history[metric_name()].append(score[0][1])
+
+        return False
+
+    def after_iteration(self, model, epoch):
+        assert not rabit.is_distributed()
+        score = model.eval(self.data, self.name)
+        return self._update_history(score, epoch)
+
+
+class LegacyCallbacks(TrainingCallback):
+    '''Adapter for legacy callback functions.
+
+    .. versionadded:: 1.2.0
+
+    Parameters
+    ----------
+
+    callbacks : Sequence
+        A sequence of legacy callbacks (callbacks that are not instance of
+        TrainingCallback)
+    start_iteration : int
+        Begining iteration.
+    end_iteration : int
+        End iteration, normally is the number of boosting rounds.
+    evals : Sequence
+        Sequence of evaluation dataset tuples.
+    feval : Custom evaluation metric.
+    '''
+    def __init__(self, callbacks, start_iteration, end_iteration,
+                 evals, feval):
+        self.callbacks_before_iter = [
+            cb for cb in callbacks
+            if cb.__dict__.get('before_iteration', False)]
+        self.callbacks_after_iter = [
+            cb for cb in callbacks
+            if not cb.__dict__.get('before_iteration', False)]
+
+        self.start_iteration = start_iteration
+        self.end_iteration = end_iteration
+
+        self.evals = evals
+        self.feval = feval
+        assert self.feval is None or callable(self.feval)
+
+        super().__init__()
+
+    def before_iteration(self, model, epoch):
+        for cb in self.callbacks_before_iter:
+            rank = rabit.get_rank()
+            cb(CallbackEnv(model=model,
+                           cvfolds=None,
+                           iteration=epoch,
+                           begin_iteration=self.start_iteration,
+                           end_iteration=self.end_iteration,
+                           rank=rank,
+                           evaluation_result_list=None))
+        return False
+
+    def after_iteration(self, model, epoch):
+        evaluation_result_list = []
+        if self.evals:
+            bst_eval_set = model.eval_set(self.evals, epoch, self.feval)
+            if isinstance(bst_eval_set, STRING_TYPES):
+                msg = bst_eval_set
+            else:
+                msg = bst_eval_set.decode()
+            res = [x.split(':') for x in msg.split()]
+            evaluation_result_list = [(k, float(v)) for k, v in res[1:]]
+        try:
+            for cb in self.callbacks_after_iter:
+                rank = rabit.get_rank()
+                cb(CallbackEnv(model=model,
+                               cvfolds=None,
+                               iteration=epoch,
+                               begin_iteration=self.start_iteration,
+                               end_iteration=self.end_iteration,
+                               rank=rank,
+                               evaluation_result_list=evaluation_result_list))
+        except EarlyStopException:
+            return True
+
+        return False

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -4,7 +4,7 @@
 """Core XGBoost Library."""
 import collections
 # pylint: disable=no-name-in-module,import-error
-from collections.abc import Mapping  # Python 3
+from collections.abc import Mapping
 # pylint: enable=no-name-in-module,import-error
 import ctypes
 import os
@@ -834,6 +834,16 @@ class Booster(object):
             if not isinstance(d, DMatrix):
                 raise TypeError('invalid cache item: {}'.format(type(d).__name__), cache)
             self._validate_features(d)
+
+        if isinstance(params, dict) \
+                and 'eval_metric' in params \
+                and isinstance(params['eval_metric'], list):
+            params = dict((k, v) for k, v in params.items())
+            eval_metrics = params['eval_metric']
+            params.pop("eval_metric", None)
+            params = list(params.items())
+            for eval_metric in eval_metrics:
+                params += [('eval_metric', eval_metric)]
 
         dmats = c_array(ctypes.c_void_p, [d.handle for d in cache])
         self.handle = ctypes.c_void_p()

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -438,7 +438,11 @@ class EarlyStopping(SingleNodeEarlyStopping):
         _uncache_data(model)
 
     def after_iteration(self, model, epoch):
-        assert rabit.is_distributed()
+        assert rabit.is_distributed(), '''
+Use single node version instead:
+
+>>>  from xgboost.callback import EarlyStopping
+'''
         worker = distributed_get_worker()
         if hasattr(self, 'data'):
             _cache_data(model, self.data, self.data_id, worker)

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -18,16 +18,6 @@ def _train_internal(params, dtrain,
     callbacks = [] if callbacks is None else callbacks
     evals = list(evals)
     params = params.copy()
-    if isinstance(params, dict) \
-            and 'eval_metric' in params \
-            and isinstance(params['eval_metric'], list):
-        params = dict((k, v) for k, v in params.items())
-        eval_metrics = params['eval_metric']
-        params.pop("eval_metric", None)
-        params = list(params.items())
-        for eval_metric in eval_metrics:
-            params += [('eval_metric', eval_metric)]
-
     bst = Booster(params, [dtrain] + [d[0] for d in evals])
     nboost = 0
     num_parallel_tree = 1
@@ -49,26 +39,22 @@ def _train_internal(params, dtrain,
     # Distributed code: Load the checkpoint from rabit.
     version = bst.load_rabit_checkpoint()
     assert rabit.get_world_size() != 1 or version == 0
-    rank = rabit.get_rank()
     start_iteration = int(version / 2)
     nboost += start_iteration
 
-    callbacks_before_iter = [
-        cb for cb in callbacks
-        if cb.__dict__.get('before_iteration', False)]
-    callbacks_after_iter = [
-        cb for cb in callbacks
-        if not cb.__dict__.get('before_iteration', False)]
+    is_new_callback = [isinstance(c, callback.TrainingCallback)
+                       for c in callbacks]
+    if any(is_new_callback):
+        assert all(is_new_callback), "You can't mix two styles of callbacks."
+        callbacks = callback.CallbackContainer(callbacks)
+    else:
+        callbacks = callback.LegacyCallbacks(
+            callbacks, start_iteration, num_boost_round, evals, feval)
 
+    callbacks.before_training(bst)
     for i in range(start_iteration, num_boost_round):
-        for cb in callbacks_before_iter:
-            cb(CallbackEnv(model=bst,
-                           cvfolds=None,
-                           iteration=i,
-                           begin_iteration=start_iteration,
-                           end_iteration=num_boost_round,
-                           rank=rank,
-                           evaluation_result_list=None))
+        if callbacks.before_iteration(bst, i):
+            break
         # Distributed code: need to resume to this point.
         # Skip the first update if it is a recovery step.
         if version % 2 == 0:
@@ -79,30 +65,15 @@ def _train_internal(params, dtrain,
         assert rabit.get_world_size() == 1 or version == rabit.version_number()
 
         nboost += 1
-        evaluation_result_list = []
         # check evaluation result.
-        if evals:
-            bst_eval_set = bst.eval_set(evals, i, feval)
-            if isinstance(bst_eval_set, STRING_TYPES):
-                msg = bst_eval_set
-            else:
-                msg = bst_eval_set.decode()
-            res = [x.split(':') for x in msg.split()]
-            evaluation_result_list = [(k, float(v)) for k, v in res[1:]]
-        try:
-            for cb in callbacks_after_iter:
-                cb(CallbackEnv(model=bst,
-                               cvfolds=None,
-                               iteration=i,
-                               begin_iteration=start_iteration,
-                               end_iteration=num_boost_round,
-                               rank=rank,
-                               evaluation_result_list=evaluation_result_list))
-        except EarlyStopException:
+        if callbacks.after_iteration(bst, i):
             break
-        # do checkpoint after evaluation, in case evaluation also updates booster.
+        # do checkpoint after evaluation, in case evaluation also updates
+        # booster.
         bst.save_rabit_checkpoint()
         version += 1
+
+    callbacks.after_training(bst)
 
     if bst.attr('best_score') is not None:
         bst.best_score = float(bst.attr('best_score'))
@@ -111,8 +82,15 @@ def _train_internal(params, dtrain,
         bst.best_iteration = nboost - 1
     bst.best_ntree_limit = (bst.best_iteration + 1) * num_parallel_tree
 
-    # Copy to serialise and unserialise booster to reset state and free training memory
-    return bst.copy()
+    evals_history = {}
+    if any(is_new_callback):
+        for c in callbacks:
+            if isinstance(c, callback.EvaluationMonitor):
+                evals_history[c.name] = c.history
+
+    # Copy to serialise and unserialise booster to reset state and free
+    # training memory
+    return bst.copy(), evals_history
 
 
 def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
@@ -205,11 +183,14 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
     if evals_result is not None:
         callbacks.append(callback.record_evaluation(evals_result))
 
-    return _train_internal(params, dtrain,
-                           num_boost_round=num_boost_round,
-                           evals=evals,
-                           obj=obj, feval=feval,
-                           xgb_model=xgb_model, callbacks=callbacks)
+    bst, history = _train_internal(params, dtrain,
+                                   num_boost_round=num_boost_round,
+                                   evals=evals,
+                                   obj=obj, feval=feval,
+                                   xgb_model=xgb_model, callbacks=callbacks)
+    if evals_result is not None:
+        evals_result.update(history)
+    return bst
 
 
 class CVPack(object):

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -1,0 +1,83 @@
+import xgboost as xgb
+import pytest
+import testing as tm
+import numpy as np
+
+
+def verify_booster_early_stop(booster, early_stop):
+    dump = booster.get_dump(dump_format='json')
+    assert early_stop.current_rounds == 5  # no improvement in 5 rounds
+    assert len(dump) == 10      # boosted for 10 rounds.
+
+    assert (len(early_stop.history['Train']['eval-error']) -
+            len(early_stop.best_scores['Train']['eval-error']) == 5)
+    eval_error = early_stop.history['Train']['eval-error']
+    eval_error = eval_error[5:]
+    for e in eval_error:
+        assert e == eval_error[0]
+
+
+@pytest.mark.skipif(**tm.no_sklearn())
+def test_early_stopping():
+    from sklearn.datasets import load_breast_cancer
+    X, y = load_breast_cancer(return_X_y=True)
+    m = xgb.DMatrix(X, y)
+    early_stop = xgb.callback.EarlyStopping(data=m, name='Train', rounds=5)
+    booster = xgb.train({'objective': 'binary:logistic'}, m,
+                        num_boost_round=1000,
+                        verbose_eval=False,
+                        callbacks=[early_stop])
+    verify_booster_early_stop(booster, early_stop)
+
+
+def eval_error_metric(label, predt):
+    r = np.zeros(predt.shape)
+    gt = predt > 0.5
+    r[gt] = 1 - label[gt]
+    le = predt <= 0.5
+    r[le] = label[le]
+    return np.sum(r)
+
+
+@pytest.mark.skipif(**tm.no_sklearn())
+def test_early_stopping_custom_eval():
+    from sklearn.datasets import load_breast_cancer
+    X, y = load_breast_cancer(return_X_y=True)
+    m = xgb.DMatrix(X, y)
+    early_stop = xgb.callback.EarlyStopping(data=X, label=y,
+                                            name='Train',
+                                            rounds=5,
+                                            metric=eval_error_metric,
+                                            metric_name='eval-error')
+    booster = xgb.train({'objective': 'binary:logistic'}, m,
+                        num_boost_round=1000,
+                        verbose_eval=False,
+                        callbacks=[early_stop])
+    verify_booster_early_stop(booster, early_stop)
+
+
+@pytest.mark.skipif(**tm.no_sklearn())
+def test_early_stopping_skl():
+    from sklearn.datasets import load_breast_cancer
+    X, y = load_breast_cancer(return_X_y=True)
+    early_stop = xgb.callback.EarlyStopping(data=X, name='Train', rounds=5,
+                                            label=y)
+    cls = xgb.XGBClassifier()
+    cls.fit(X, y, callbacks=[early_stop])
+    booster = cls.get_booster()
+    verify_booster_early_stop(booster, early_stop)
+
+
+@pytest.mark.skipif(**tm.no_sklearn())
+def test_early_stopping_custom_eval_skl():
+    from sklearn.datasets import load_breast_cancer
+    X, y = load_breast_cancer(return_X_y=True)
+    early_stop = xgb.callback.EarlyStopping(data=X, label=y,
+                                            name='Train',
+                                            rounds=5,
+                                            metric=eval_error_metric,
+                                            metric_name='eval-error')
+    cls = xgb.XGBClassifier()
+    cls.fit(X, y, callbacks=[early_stop])
+    booster = cls.get_booster()
+    verify_booster_early_stop(booster, early_stop)

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -103,6 +103,7 @@ def test_from_dask_array():
             assert np.all(single_node_predt == from_arr.compute())
 
 
+@pytest.mark.skipif(**tm.no_sklearn())
 def test_dask_missing_value_reg():
     with LocalCluster(n_workers=5) as cluster:
         with Client(cluster) as client:
@@ -127,6 +128,7 @@ def test_dask_missing_value_reg():
             np.testing.assert_allclose(np_predt, dd_predt)
 
 
+@pytest.mark.skipif(**tm.no_sklearn())
 def test_dask_missing_value_cls():
     # Multi-class doesn't handle empty DMatrix well.  So we use lesser workers.
     with LocalCluster(n_workers=2) as cluster:
@@ -155,6 +157,7 @@ def test_dask_missing_value_cls():
             assert hasattr(cls, 'missing')
 
 
+@pytest.mark.skipif(**tm.no_sklearn())
 def test_dask_regressor():
     with LocalCluster(n_workers=5) as cluster:
         with Client(cluster) as client:
@@ -177,6 +180,7 @@ def test_dask_regressor():
             assert len(history['validation_0']['rmse']) == 2
 
 
+@pytest.mark.skipif(**tm.no_sklearn())
 def test_dask_classifier():
     with LocalCluster(n_workers=5) as cluster:
         with Client(cluster) as client:


### PR DESCRIPTION
Proof of concept implementation for dask training callback.  As it is not consistent with single node implementation, this is an early PR for review and discussion.

The rational behind a new style of callback function is that, the original one is modelled after R implementation.  The R impl uses language environment for storing states, while Python doesn't have such facility so the original callback creates an artificial one to be consistent with R.  I believe the new style is cleaner, native to Python, and easier customize.  With the new interface, https://github.com/dmlc/xgboost/pull/5238 and #5495 can be easily implemented.

To provide a short introduction to new callback function, here is its interface:
``` python
class Callback:
    def __init__(self):
        self.history = {}
        pass

    def before_training(self, model):
        pass

    def after_training(self, model):
        pass

    def before_iteration(self, model, epoch):
        return False

    def after_iteration(self, model, epoch):
        return False
```

All the other callbacks is sub-class of this `Callback`.  This interface is suitable for both single node and distributed training.  Function return value is whether training should be stopped,  `False` if not.  By using a return value, we can deprecate `EarlyStopException`, which is created for one particular callback.


To-dos:
- [ ] Make sure no data copy is performed.
- [ ] Get correct starting rounds: https://github.com/dmlc/xgboost/pull/5511 is closed so I need to figure out a way to get correct starting round.
- [x] Be compatible with original callback function.  The new `Callback` can be a wrapper of original callback, I need to port the implementation to non-dask training.
- [ ] Support user defined metric.
- [ ] Tests.

## Future plan

If the new design is approved, I would like to deprecate the following parameters:
- In scikit-learn interface `fit` function `eval_set`, `eval_metric`, `early_stopping_rounds`, `verbose`, `sample_weight_eval_set`, 
- From `train` function `evals`, `feval`, `maximize`, `early_stopping_rounds`, `evals_result`, `verbose_eval=True` 
- lastly corresponding parameters in dask.

## Related:

#4955
#3822