### PR TITLE
Move dask tutorial closer other distributed tutorials

### DIFF
--- a/doc/tutorials/index.rst
+++ b/doc/tutorials/index.rst
@@ -14,6 +14,7 @@ See `Awesome XGBoost <https://github.com/dmlc/xgboost/tree/master/demo>`_ for mo
   Distributed XGBoost with AWS YARN <aws_yarn>
   kubernetes
   Distributed XGBoost with XGBoost4J-Spark <https://xgboost.readthedocs.io/en/latest/jvm/xgboost4j_spark_tutorial.html>
+  dask
   dart
   monotonic
   rf
@@ -23,4 +24,3 @@ See `Awesome XGBoost <https://github.com/dmlc/xgboost/tree/master/demo>`_ for mo
   param_tuning
   external_memory
   custom_metric_obj
-  dask


### PR DESCRIPTION
These tutorials on distributed XGBoost should be bundled closer to each other.