### PR TITLE
Fix build on big endian CPUs

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -566,8 +566,7 @@ struct Handler<xgboost::Entry> {
   }
 
   inline static bool Read(Stream* strm, xgboost::Entry* data) {
-    strm->Read(&data->index);
-    strm->Read(&data->fvalue);
+    return strm->Read(&data->index) && strm->Read(&data->fvalue);
   }
 };
 

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -9,6 +9,7 @@
 
 #include <dmlc/base.h>
 #include <dmlc/data.h>
+#include <dmlc/serializer.h>
 #include <rabit/rabit.h>
 #include <xgboost/base.h>
 #include <xgboost/span.h>
@@ -554,5 +555,22 @@ inline BatchSet<EllpackPage> DMatrix::GetBatches(const BatchParam& param) {
 
 namespace dmlc {
 DMLC_DECLARE_TRAITS(is_pod, xgboost::Entry, true);
-}
+
+namespace serializer {
+
+template <>
+struct Handler<xgboost::Entry> {
+  inline static void Write(Stream* strm, const xgboost::Entry& data) {
+    strm->Write(data.index);
+    strm->Write(data.fvalue);
+  }
+
+  inline static bool Read(Stream* strm, xgboost::Entry* data) {
+    strm->Read(&data->index);
+    strm->Read(&data->fvalue);
+  }
+};
+
+}  // namespace serializer
+}  // namespace dmlc
 #endif  // XGBOOST_DATA_H_

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -37,7 +37,7 @@ template <typename T>
 void SaveScalarField(dmlc::Stream *strm, const std::string &name,
                      xgboost::DataType type, const T &field) {
   strm->Write(name);
-  strm->Write(type);
+  strm->Write(static_cast<uint8_t>(type));
   strm->Write(true);  // is_scalar=True
   strm->Write(field);
 }
@@ -47,7 +47,7 @@ void SaveVectorField(dmlc::Stream *strm, const std::string &name,
                      xgboost::DataType type, std::pair<uint64_t, uint64_t> shape,
                      const std::vector<T>& field) {
   strm->Write(name);
-  strm->Write(type);
+  strm->Write(static_cast<uint8_t>(type));
   strm->Write(false);  // is_scalar=False
   strm->Write(shape.first);
   strm->Write(shape.second);
@@ -71,7 +71,9 @@ void LoadScalarField(dmlc::Stream* strm, const std::string& expected_name,
   CHECK(strm->Read(&name)) << invalid;
   CHECK_EQ(name, expected_name)
       << invalid << " Expected field: " << expected_name << ", got: " << name;
-  CHECK(strm->Read(&type)) << invalid;
+  uint8_t type_val;
+  CHECK(strm->Read(&type_val)) << invalid;
+  type = static_cast<xgboost::DataType>(type_val);
   CHECK(type == expected_type)
       << invalid << "Expected field of type: " << static_cast<int>(expected_type) << ", "
       << "got field type: " << static_cast<int>(type);
@@ -91,7 +93,9 @@ void LoadVectorField(dmlc::Stream* strm, const std::string& expected_name,
   CHECK(strm->Read(&name)) << invalid;
   CHECK_EQ(name, expected_name)
     << invalid << " Expected field: " << expected_name << ", got: " << name;
-  CHECK(strm->Read(&type)) << invalid;
+  uint8_t type_val;
+  CHECK(strm->Read(&type_val)) << invalid;
+  type = static_cast<xgboost::DataType>(type_val);
   CHECK(type == expected_type)
     << invalid << "Expected field of type: " << static_cast<int>(expected_type) << ", "
     << "got field type: " << static_cast<int>(type);


### PR DESCRIPTION
Closes #5614.

* DMLC serializer cannot handle POD structs automatically for big endians. The reason is that we have to swap byte orders to serialize bytes in little endian order. Fix: Explicitly define serializer for `xgboost::Entry`.
* For the same reason, DMLC serializer cannot handle enum class. Cast to primitive type using `static_cast<>`.

Tested using s390x Debian docker container.