### PR TITLE
Reduce device synchronisation

### DIFF
--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -503,6 +503,15 @@ struct PinnedMemory {
     return xgboost::common::Span<T>(static_cast<T *>(temp_storage), size);
   }
 
+  template <typename T>
+  xgboost::common::Span<T> GetSpan(size_t size, T init) {
+    auto result = this->GetSpan<T>(size);
+    for (auto &e : result) {
+      e = init;
+    }
+    return result;
+  }
+
   void Free() {
     if (temp_storage != nullptr) {
       safe_cuda(cudaFreeHost(temp_storage));

--- a/src/tree/gpu_hist/driver.cuh
+++ b/src/tree/gpu_hist/driver.cuh
@@ -1,0 +1,121 @@
+/*!
+ * Copyright 2020 by XGBoost Contributors
+ */
+#ifndef DRIVER_CUH_
+#define DRIVER_CUH_
+#include <xgboost/span.h>
+#include <queue>
+#include "../param.h"
+#include "evaluate_splits.cuh"
+
+namespace xgboost {
+namespace tree {
+struct ExpandEntry {
+  int nid;
+  int depth;
+  DeviceSplitCandidate split;
+  ExpandEntry() = default;
+  ExpandEntry(int nid, int depth, DeviceSplitCandidate split
+              )
+      : nid(nid), depth(depth), split(std::move(split)){}
+  bool IsValid(const TrainParam& param, int num_leaves) const {
+    if (split.loss_chg <= kRtEps) return false;
+    if (split.left_sum.GetHess() == 0 || split.right_sum.GetHess() == 0) {
+      return false;
+    }
+    if (split.loss_chg < param.min_split_loss) {
+      return false;
+    }
+    if (param.max_depth > 0 && depth == param.max_depth) {
+      return false;
+    }
+    if (param.max_leaves > 0 && num_leaves == param.max_leaves) {
+      return false;
+    }
+    return true;
+  }
+
+  static bool ChildIsValid(const TrainParam& param, int depth, int num_leaves) {
+    if (param.max_depth > 0 && depth >= param.max_depth) return false;
+    if (param.max_leaves > 0 && num_leaves >= param.max_leaves) return false;
+    return true;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const ExpandEntry& e) {
+    os << "ExpandEntry: \n";
+    os << "nidx: " << e.nid << "\n";
+    os << "depth: " << e.depth << "\n";
+    os << "loss: " << e.split.loss_chg << "\n";
+    os << "left_sum: " << e.split.left_sum << "\n";
+    os << "right_sum: " << e.split.right_sum << "\n";
+    return os;
+  }
+};
+
+inline bool DepthWise(const ExpandEntry& lhs, const ExpandEntry& rhs) {
+  return lhs.depth > rhs.depth;  // favor small depth
+}
+
+inline bool LossGuide(const ExpandEntry& lhs, const ExpandEntry& rhs) {
+  if (lhs.split.loss_chg == rhs.split.loss_chg) {
+    return lhs.nid > rhs.nid;  // favor small timestamp
+  } else {
+    return lhs.split.loss_chg < rhs.split.loss_chg;  // favor large loss_chg
+  }
+}
+
+// Drives execution of tree building on device
+class Driver {
+  using ExpandQueue =
+      std::priority_queue<ExpandEntry, std::vector<ExpandEntry>,
+                          std::function<bool(ExpandEntry, ExpandEntry)>>;
+
+ public:
+  explicit Driver(TrainParam::TreeGrowPolicy policy)
+      : policy(policy),
+        queue(policy == TrainParam::kDepthWise ? DepthWise : LossGuide) {}
+  template <typename EntryIterT>
+  void Push(EntryIterT begin,EntryIterT end) {
+    for (auto it = begin; it != end; ++it) {
+      const ExpandEntry& e = *it;
+      if (e.split.loss_chg > kRtEps) {
+        queue.push(e);
+      }
+    }
+  }
+  void Push(const std::vector<ExpandEntry> &entries) {
+    this->Push(entries.begin(), entries.end());
+  }
+  // Return the set of nodes to be expanded
+  // This set has no dependencies between entries so they may be expanded in
+  // parallel or asynchronously
+  std::vector<ExpandEntry> Pop() {
+    if (queue.empty()) return {};
+    // Return a single entry for loss guided mode
+    if (policy == TrainParam::kLossGuide) {
+      ExpandEntry e = queue.top();
+      queue.pop();
+      return {e};
+    }
+    // Return nodes on same level for depth wise
+    std::vector<ExpandEntry> result;
+    ExpandEntry e = queue.top();
+    int level = e.depth;
+    while (e.depth == level && !queue.empty()) {
+      queue.pop();
+      result.emplace_back(e);
+      if (!queue.empty()) {
+        e = queue.top();
+      }
+    }
+    return result;
+  }
+
+ private:
+  TrainParam::TreeGrowPolicy policy;
+  ExpandQueue queue;
+};
+}  // namespace tree
+}  // namespace xgboost
+
+#endif  // DRIVER_CUH_

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -631,7 +631,9 @@ struct GPUHistMakerDevice {
     // The set of leaves that can be expanded asynchronously
     auto expand_set = driver.Pop();
     while (!expand_set.empty()) {
-      auto new_candidates = pinned.GetSpan<ExpandEntry>(expand_set.size() * 2);
+      auto new_candidates =
+          pinned.GetSpan<ExpandEntry>(expand_set.size() * 2, ExpandEntry());
+
       for (auto i = 0ull; i < expand_set.size(); i++) {
         auto candidate = expand_set.at(i);
         if (!candidate.IsValid(param, num_leaves)) {

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -264,7 +264,7 @@ TEST_F(SerializationTest, CPUCoordDescent) {
 }
 
 #if defined(XGBOOST_USE_CUDA)
-TEST_F(SerializationTest, GPUHist) {
+TEST_F(SerializationTest, GpuHist) {
   TestLearnerSerialization({{"booster", "gbtree"},
                             {"seed", "0"},
                             {"enable_experimental_json_serialization", "1"},
@@ -441,7 +441,7 @@ TEST_F(LogitSerializationTest, CPUCoordDescent) {
 }
 
 #if defined(XGBOOST_USE_CUDA)
-TEST_F(LogitSerializationTest, GPUHist) {
+TEST_F(LogitSerializationTest, GpuHist) {
   TestLearnerSerialization({{"booster", "gbtree"},
                             {"objective", "binary:logistic"},
                             {"seed", "0"},
@@ -596,7 +596,7 @@ TEST_F(MultiClassesSerializationTest, CPUCoordDescent) {
 }
 
 #if defined(XGBOOST_USE_CUDA)
-TEST_F(MultiClassesSerializationTest, GPUHist) {
+TEST_F(MultiClassesSerializationTest, GpuHist) {
   TestLearnerSerialization({{"booster", "gbtree"},
                             {"num_class", std::to_string(kClasses)},
                             {"seed", "0"},

--- a/tests/cpp/tree/gpu_hist/test_driver.cu
+++ b/tests/cpp/tree/gpu_hist/test_driver.cu
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+#include "../../../../src/tree/gpu_hist/driver.cuh"
+
+namespace xgboost {
+namespace tree {
+
+TEST(GpuHist, DriverDepthWise) {
+  Driver driver(TrainParam::kDepthWise);
+  EXPECT_TRUE(driver.Pop().empty());
+  DeviceSplitCandidate split;
+  split.loss_chg = 1.0f;
+  ExpandEntry root(0, 0, split);
+  driver.Push({root});
+  EXPECT_EQ(driver.Pop().front().nid, 0);
+  driver.Push({ExpandEntry{1, 1, split}});
+  driver.Push({ExpandEntry{2, 1, split}});
+  driver.Push({ExpandEntry{3, 2, split}});
+  // Should return entries from level 1
+  auto res = driver.Pop();
+  EXPECT_EQ(res.size(), 2);
+  for (auto &e : res) {
+    EXPECT_EQ(e.depth, 1);
+  }
+  res = driver.Pop();
+  EXPECT_EQ(res[0].depth, 2);
+  EXPECT_TRUE(driver.Pop().empty());
+}
+
+TEST(GpuHist, DriverLossGuided) {
+  DeviceSplitCandidate high_gain;
+  high_gain.loss_chg = 5.0f;
+  DeviceSplitCandidate low_gain;
+  low_gain.loss_chg = 1.0f;
+
+  Driver driver(TrainParam::kLossGuide);
+  EXPECT_TRUE(driver.Pop().empty());
+  ExpandEntry root(0, 0, high_gain);
+  driver.Push({root});
+  EXPECT_EQ(driver.Pop().front().nid, 0);
+  // Select high gain first
+  driver.Push({ExpandEntry{1, 1, low_gain}});
+  driver.Push({ExpandEntry{2, 2, high_gain}});
+  auto res = driver.Pop();
+  EXPECT_EQ(res.size(), 1);
+  EXPECT_EQ(res[0].nid, 2);
+  res = driver.Pop();
+  EXPECT_EQ(res.size(), 1);
+  EXPECT_EQ(res[0].nid, 1);
+
+  // If equal gain, use nid
+  driver.Push({ExpandEntry{2, 1, low_gain}});
+  driver.Push({ExpandEntry{1, 1, low_gain}});
+  res = driver.Pop();
+  EXPECT_EQ(res[0].nid, 1);
+  res = driver.Pop();
+  EXPECT_EQ(res[0].nid, 2);
+}
+}  // namespace tree
+}  // namespace xgboost

--- a/tests/cpp/tree/test_tree_stat.cc
+++ b/tests/cpp/tree/test_tree_stat.cc
@@ -40,7 +40,7 @@ class UpdaterTreeStatTest : public ::testing::Test {
 };
 
 #if defined(XGBOOST_USE_CUDA)
-TEST_F(UpdaterTreeStatTest, GPUHist) {
+TEST_F(UpdaterTreeStatTest, GpuHist) {
   this->RunTest("grow_gpu_hist");
 }
 #endif  // defined(XGBOOST_USE_CUDA)


### PR DESCRIPTION
Creates a data structure called Driver which is a slightly more custom priority queue, returning batches of nodes that may be executed asynchronously.

With this we don't have to wait for the device to host copy at the end of split evaluation before starting construction on the next node in many cases.

I also fixed a slight performance bug in row_partitioner where a memory copy was not asynchronous because the memory was not pinned.