### PR TITLE
skip missing lookup if nothing is missing in CPU hist partition kernel.

### DIFF
--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -152,6 +152,7 @@ class ColumnMatrix {
     index_base_ = const_cast<uint32_t*>(gmat.cut.Ptrs().data());
 
     const bool noMissingValues = NoMissingValues(gmat.row_ptr[nrow], nrow, nfeature);
+    any_missing_ = !noMissingValues;
 
     if (noMissingValues) {
       missing_flags_.resize(feature_offsets_[nfeature], false);
@@ -311,9 +312,16 @@ class ColumnMatrix {
   const BinTypeSize GetTypeSize() const {
     return bins_type_size_;
   }
+
+  // This is just an utility function
   const bool NoMissingValues(const size_t n_elements,
                              const size_t n_row, const size_t n_features) {
     return n_elements == n_features * n_row;
+  }
+
+  // And this returns part of state
+  const bool AnyMissing() const {
+    return any_missing_;
   }
 
  private:
@@ -329,6 +337,7 @@ class ColumnMatrix {
   uint32_t* index_base_;
   std::vector<bool> missing_flags_;
   BinTypeSize bins_type_size_;
+  bool any_missing_;
 };
 
 }  // namespace common

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -826,7 +826,7 @@ void QuantileHistMaker::Builder::EvaluateSplits(const std::vector<ExpandEntry>& 
 // on comparison of indexes values (idx_span) and split point (split_cond)
 // Handle dense columns
 // Analog of std::stable_partition, but in no-inplace manner
-template <bool default_left, typename BinIdxType>
+template <bool default_left, bool any_missing, typename BinIdxType>
 inline std::pair<size_t, size_t> PartitionDenseKernel(const common::DenseColumn<BinIdxType>& column,
       common::Span<const size_t> rid_span, const int32_t split_cond,
       common::Span<size_t> left_part, common::Span<size_t> right_part) {
@@ -837,14 +837,24 @@ inline std::pair<size_t, size_t> PartitionDenseKernel(const common::DenseColumn<
   size_t nleft_elems = 0;
   size_t nright_elems = 0;
 
-  for (auto rid : rid_span) {
-    if (column.IsMissing(rid)) {
-      if (default_left) {
-        p_left_part[nleft_elems++] = rid;
+  if (any_missing) {
+    for (auto rid : rid_span) {
+      if (column.IsMissing(rid)) {
+        if (default_left) {
+          p_left_part[nleft_elems++] = rid;
+        } else {
+          p_right_part[nright_elems++] = rid;
+        }
       } else {
-        p_right_part[nright_elems++] = rid;
+        if ((static_cast<int32_t>(idx[rid]) + offset) <= split_cond) {
+          p_left_part[nleft_elems++] = rid;
+        } else {
+          p_right_part[nright_elems++] = rid;
+        }
       }
-    } else {
+    }
+  } else {
+    for (auto rid : rid_span)  {
       if ((static_cast<int32_t>(idx[rid]) + offset) <= split_cond) {
         p_left_part[nleft_elems++] = rid;
       } else {
@@ -934,9 +944,17 @@ void QuantileHistMaker::Builder::PartitionKernel(
     const common::DenseColumn<BinIdxType>& column =
           static_cast<const common::DenseColumn<BinIdxType>& >(*(column_ptr.get()));
     if (default_left) {
-      child_nodes_sizes = PartitionDenseKernel<true>(column, rid_span, split_cond, left, right);
+      if (column_matrix.AnyMissing()) {
+        child_nodes_sizes = PartitionDenseKernel<true, true>(column, rid_span, split_cond, left, right); 
+      } else {
+        child_nodes_sizes = PartitionDenseKernel<true, false>(column, rid_span, split_cond, left, right);
+      }
     } else {
-      child_nodes_sizes = PartitionDenseKernel<false>(column, rid_span, split_cond, left, right);
+      if (column_matrix.AnyMissing()) {
+        child_nodes_sizes = PartitionDenseKernel<false, true>(column, rid_span, split_cond, left, right); 
+      } else {
+        child_nodes_sizes = PartitionDenseKernel<false, false>(column, rid_span, split_cond, left, right);
+      }
     }
   } else {
     const common::SparseColumn<BinIdxType>& column

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -929,6 +929,7 @@ void QuantileHistMaker::Builder::PartitionKernel(
     const size_t node_in_set, const size_t nid, common::Range1d range,
     const int32_t split_cond, const ColumnMatrix& column_matrix, const RegTree& tree) {
   const size_t* rid = row_set_collection_[nid].begin;
+
   common::Span<const size_t> rid_span(rid + range.begin(), rid + range.end());
   common::Span<size_t> left  = partition_builder_.GetLeftBuffer(node_in_set,
                                                                 range.begin(), range.end());
@@ -945,15 +946,19 @@ void QuantileHistMaker::Builder::PartitionKernel(
           static_cast<const common::DenseColumn<BinIdxType>& >(*(column_ptr.get()));
     if (default_left) {
       if (column_matrix.AnyMissing()) {
-        child_nodes_sizes = PartitionDenseKernel<true, true>(column, rid_span, split_cond, left, right); 
+        child_nodes_sizes = PartitionDenseKernel<true, true>(column, rid_span, split_cond,
+                                                             left, right);
       } else {
-        child_nodes_sizes = PartitionDenseKernel<true, false>(column, rid_span, split_cond, left, right);
+        child_nodes_sizes = PartitionDenseKernel<true, false>(column, rid_span, split_cond,
+                                                              left, right);
       }
     } else {
       if (column_matrix.AnyMissing()) {
-        child_nodes_sizes = PartitionDenseKernel<false, true>(column, rid_span, split_cond, left, right); 
+        child_nodes_sizes = PartitionDenseKernel<false, true>(column, rid_span, split_cond,
+                                                              left, right);
       } else {
-        child_nodes_sizes = PartitionDenseKernel<false, false>(column, rid_span, split_cond, left, right);
+        child_nodes_sizes = PartitionDenseKernel<false, false>(column, rid_span, split_cond,
+                                                               left, right);
       }
     }
   } else {

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -251,14 +251,14 @@ class QuantileHistMock : public QuantileHistMaker {
     }
 
     void TestApplySplit(const GHistIndexBlockMatrix& quantile_index_block,
-                        RegTree& tree) {
+                        const RegTree& tree) {
       std::vector<GradientPair> row_gpairs =
           { {1.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f}, {2.27f, 0.28f},
             {0.27f, 0.29f}, {0.37f, 0.39f}, {-0.47f, 0.49f}, {0.57f, 0.59f} };
       size_t constexpr kMaxBins = 4;
 
       // try out different sparsity to get different number of missing values
-      for (double sparsity = 0.0; sparsity < 0.25; sparsity += 0.1) {
+      for (double sparsity : {0.0, 0.1, 0.2}) {
         // kNRows samples with kNCols features
         auto dmat = RandomDataGenerator(kNRows, kNCols, sparsity).Seed(3).GenerateDMatrix();
 


### PR DESCRIPTION
While looking at the profile, I noticed that PartitionDenseKernel was taking surprising %% of time;
Looking at it a bit, large part of the cost comes from the column.IsMissing check; This check:
1) does lookup in `vector<bool>`
2) adds one more condition to the hot loop
3) fills the caches with the data from that vector<bool>

In my use-cases, as well as in several publicly available datasets (like
higgs), nothing is missing, so we can use that information and create a
separate path which won't do this check at all.

Benchmarking on higgs dataset (10m samples, 28 features, 100 trees, 256 leaves, 256 bins) on 4 core macbook pro (Kaby Lake Core i5) shows ~10% improvement in training time.
I do not have other machine to test it on, so I cannot really claim how much of the win will hold on other systems/other datasets.

My results by running 10 runs of old/new:
Old:
```
[21:54:18] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 18.651 sec in all
[21:55:00] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 18.7015 sec in all
[21:55:42] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 18.6216 sec in all
[21:56:24] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 19.4026 sec in all
[21:57:05] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 18.0353 sec in all
[21:57:45] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 18.0898 sec in all
[21:58:26] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 18.457 sec in all
[21:59:07] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 18.1343 sec in all
[21:59:49] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 18.2275 sec in all
[22:00:30] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 18.3709 sec in all
```

**Avg = 18.46s**

New:

```
[21:53:56] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 16.3706 sec in all
[21:54:38] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 17.1902 sec in all
[21:55:20] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 17.0527 sec in all
[21:56:01] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 16.6894 sec in all
[21:56:44] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 16.6933 sec in all
[21:57:24] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 16.8017 sec in all
[21:58:05] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 16.6709 sec in all
[21:58:46] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 16.9324 sec in all
[21:59:27] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 16.9194 sec in all
[22:00:08] INFO: /Users/oleksandr/projects/xgboost/src/cli_main.cc:283: update end, 16.5891 sec in all
```

**Avg = 16.79s** 

A few further improvements in the same area to consider doing later:
1) make it per column, so that one column with missing values won't cause IsMissing calls for all other columns
2) do not even store that vector<bool> if it's unused; While not terribly huge, it will be still ~(samples * features / 8) bytes;