### PR TITLE
[jvm-packages] default objective to binary:logistic for XGBoostClassifier

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimatorCommon.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimatorCommon.scala
@@ -20,8 +20,8 @@ import ml.dmlc.xgboost4j.scala.spark.params._
 
 import org.apache.spark.ml.param.shared.HasWeightCol
 
-private[spark] sealed trait XGBoostEstimatorCommon extends GeneralParams with LearningTaskParams
-  with BoosterParams with RabitParams with ParamMapFuncs with NonParamVariables {
+private[spark] sealed trait XGBoostEstimatorCommon extends GeneralParams with BoosterParams
+  with RabitParams with ParamMapFuncs with NonParamVariables {
 
   def needDeterministicRepartitioning: Boolean = {
     getCheckpointPath != null && getCheckpointPath.nonEmpty && getCheckpointInterval > 0
@@ -30,8 +30,8 @@ private[spark] sealed trait XGBoostEstimatorCommon extends GeneralParams with Le
 
 private[spark] trait XGBoostClassifierParams extends HasWeightCol with HasBaseMarginCol
   with HasNumClass with HasLeafPredictionCol with HasContribPredictionCol
-  with XGBoostEstimatorCommon
+  with ClassificationLearningTaskParams with XGBoostEstimatorCommon
 
 private[spark] trait XGBoostRegressorParams extends HasBaseMarginCol with HasWeightCol
   with HasGroupCol with HasLeafPredictionCol with HasContribPredictionCol
-  with XGBoostEstimatorCommon
+  with RegressionLearningTaskParams with XGBoostEstimatorCommon

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -105,8 +105,17 @@ private[spark] trait LearningTaskParams extends Params {
 
   final def getMaximizeEvaluationMetrics: Boolean = $(maximizeEvaluationMetrics)
 
-  setDefault(objective -> "reg:squarederror", baseScore -> 0.5,
-    trainTestRatio -> 1.0, numEarlyStoppingRounds -> 0, cacheTrainingSet -> false)
+  setDefault(baseScore -> 0.5, trainTestRatio -> 1.0, numEarlyStoppingRounds -> 0,
+    cacheTrainingSet -> false)
+}
+
+
+private[spark] trait ClassificationLearningTaskParams extends LearningTaskParams {
+  setDefault(objective -> "binary:logistic")
+}
+
+private[spark] trait RegressionLearningTaskParams extends LearningTaskParams {
+  setDefault(objective -> "reg:squarederror")
 }
 
 private[spark] object LearningTaskParams {

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/ParameterSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/ParameterSuite.scala
@@ -23,6 +23,16 @@ import org.apache.spark.ml.param.ParamMap
 
 class ParameterSuite extends FunSuite with PerTest with BeforeAndAfterAll {
 
+  test("XGBoost default objective parameter") {
+    val xgbParamMap: Map[String, Any] = Map.empty
+    // from xgboost params to spark params
+    val classifier = new XGBoostClassifier(xgbParamMap)
+    assert(classifier.getObjective === "binary:logistic")
+
+    val regressor = new XGBoostRegressor(xgbParamMap)
+    assert(regressor.getObjective === "reg:squarederror")
+  }
+
   test("XGBoost and Spark parameters synchronize correctly") {
     val xgbParamMap = Map("eta" -> "1", "objective" -> "binary:logistic",
       "objective_type" -> "classification")


### PR DESCRIPTION
Currently, the default objective for both XGBoostClassifier and
XGBoostRegressor is "reg:squarederror". 

So this PR is to default objective to binary:logistic for XGBoostClassifier.