### PR TITLE
Implement Python data handler.

### DIFF
--- a/demo/guide-python/sklearn_examples.py
+++ b/demo/guide-python/sklearn_examples.py
@@ -14,7 +14,7 @@ from sklearn.datasets import load_iris, load_digits, load_boston
 rng = np.random.RandomState(31337)
 
 print("Zeros and Ones from the Digits dataset: binary classification")
-digits = load_digits(2)
+digits = load_digits(n_class=2)
 y = digits['target']
 X = digits['data']
 kf = KFold(n_splits=2, shuffle=True, random_state=rng)

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -107,7 +107,6 @@ except ImportError:
 try:
     from cudf import DataFrame as CUDF_DataFrame
     from cudf import Series as CUDF_Series
-    from cudf import MultiIndex as CUDF_MultiIndex
     from cudf import concat as CUDF_concat
     CUDF_INSTALLED = True
 except ImportError:

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -359,8 +359,6 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
         self.nthread = nthread if nthread is not None else 1
         self.silent = silent
 
-        # FIXME(trvialfis): `None` seems only happens in xgboost builtin cv
-        # method. Eliminate it
         # force into void_p, mac need to pass things in as void_p
         if data is None:
             self.handle = None

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -270,7 +270,8 @@ def _convert_unknown_data(data, meta=None, meta_type=None):
     else:
         import warnings
         warnings.warn(
-            f'Unknown data type {type(data)}, coverting it to csr_matrix')
+            'Unknown data type: ' + str(type(data)) +
+            ', coverting it to csr_matrix')
         try:
             data = scipy.sparse.csr_matrix(data)
         except Exception:

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 # pylint: disable=too-many-arguments, too-many-branches, invalid-name
-# pylint: disable=too-many-branches, too-many-lines, too-many-locals
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-lines, too-many-locals
 """Core XGBoost Library."""
 import collections
 # pylint: disable=no-name-in-module,import-error

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -370,6 +370,7 @@ class DMatrix:
         self.feature_types = feature_types
 
     def get_data_handler(self, data, meta=None, meta_type=None):
+        '''Get data handler for this DMatrix class.'''
         from .data import get_dmatrix_data_handler
         handler = get_dmatrix_data_handler(
             data, self.missing, self.nthread, self.silent, meta, meta_type)
@@ -780,7 +781,7 @@ class DeviceQuantileDMatrix(DMatrix):
                          feature_types=feature_types,
                          nthread=nthread)
 
-    def get_data_handler(self, data):
+    def get_data_handler(self, data, meta=None, meta_type=None):
         from .data import get_device_quantile_dmatrix_data_handler
         return get_device_quantile_dmatrix_data_handler(
             data, self.max_bin, self.missing, self.nthread, self.silent)

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -352,6 +352,15 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
             applicable. If -1, uses maximum threads available on the system.
 
         """
+        if isinstance(data, list):
+            raise TypeError('Input data can not be a list.')
+
+        self.missing = missing if missing is not None else np.nan
+        self.nthread = nthread if nthread is not None else 1
+        self.silent = silent
+
+        # FIXME(trvialfis): `None` seems only happens in xgboost builtin cv
+        # method. Eliminate it
         # force into void_p, mac need to pass things in as void_p
         if data is None:
             self.handle = None
@@ -361,16 +370,6 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
             if feature_types is not None:
                 self._feature_types = feature_types
             return
-
-        if isinstance(data, list):
-            raise TypeError('Input data can not be a list.')
-
-        missing = missing if missing is not None else np.nan
-        nthread = nthread if nthread is not None else 1
-
-        self.missing = missing
-        self.nthread = nthread
-        self.silent = silent
 
         handler = self.get_data_handler(data)
         if handler is None:

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -282,7 +282,7 @@ def _cudf_array_interfaces(df):
     return interfaces_str
 
 
-class DMatrix:
+class DMatrix:                  # pylint: disable=too-many-instance-attributes
     """Data Matrix used in XGBoost.
 
     DMatrix is a internal data structure that used by XGBoost
@@ -357,7 +357,7 @@ class DMatrix:
         handler = self.get_data_handler(data)
         self.handle, feature_names, feature_types = handler.handle_input(
             data, feature_names, feature_types)
-        assert self.handle
+        assert self.handle, 'Failed to construct a DMatrix.'
 
         if label is not None:
             self.set_label(label)
@@ -1137,6 +1137,7 @@ class Booster(object):
         self._validate_features(data)
         return self.eval_set([(data, name)], iteration)
 
+    # pylint: disable=too-many-function-args
     def predict(self,
                 data,
                 output_margin=False,

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -6,7 +6,6 @@ import json
 import warnings
 
 import numpy as np
-import scipy
 
 from .core import c_array, _LIB, _check_call, c_str, _cudf_array_interfaces
 from .compat import lazy_isinstance, STRING_TYPES, os_fspath, os_PathLike
@@ -244,6 +243,7 @@ __dmatrix_registry.register_handler_opaque(
 
 
 class ListHandler(NumpyHandler):
+    '''Handler of builtin list and tuple'''
     def handle_input(self, data, feature_names, feature_types):
         assert self.meta is None, 'List input data is not supported for X'
         data = np.array(data)

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -532,8 +532,8 @@ def get_device_quantile_dmatrix_data_handler(
     '''
     handler = __device_quantile_dmatrix_registry.get_handler(
         data)
-    assert handler, f'Current data type {type(data)} is not supported' + \
-        ' for DeviceQuantileDMatrix'
+    assert handler, 'Current data type ' + str(type(data)) +\
+        ' is not supported for DeviceQuantileDMatrix'
     return handler(max_bin, missing, nthread, silent)
 
 

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -214,11 +214,7 @@ class NumpyHandler(DataHandler):
         return data
 
     def transform(self, data):
-        data = self._maybe_np_slice(data, self.meta_type)
-        flatten = np.array(data.reshape(data.size), copy=False,
-                           dtype=np.float32)
-        self.check_complex(data)
-        return flatten, None, None
+        return self._maybe_np_slice(data, self.meta_type), None, None
 
     def handle_input(self, data, feature_names, feature_types):
         """Initialize data from a 2-D numpy matrix.

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -113,22 +113,7 @@ def get_dmatrix_data_handler(data, missing, nthread, silent,
     '''
     handler = __dmatrix_registry.get_handler(data)
     if handler is None:
-        if meta is not None:
-            try:
-                data = np.array(data)
-                handler = __dmatrix_registry.get_handler(data)
-            except Exception:
-                raise TypeError('Can not handle data from {}'.format(
-                    type(data).__name__))
-        else:
-            warnings.warn(
-                f'Unknown data type {type(data)}, coverting it to csr_matrix')
-            try:
-                data = scipy.sparse.csr_matrix(data)
-                handler = __dmatrix_registry.get_handler(data)
-            except Exception:
-                raise TypeError('Can not initialize DMatrix from'
-                                ' {}'.format(type(data).__name__))
+        return None
     return handler(missing, nthread, silent, meta, meta_type)
 
 

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -1,0 +1,421 @@
+import scipy
+import ctypes
+import abc
+import json
+import warnings
+from .core import c_array, _LIB, _check_call, c_str
+from .compat import lazy_isinstance, STRING_TYPES, os_fspath, os_PathLike
+
+c_bst_ulong = ctypes.c_uint64
+
+
+# Notes:
+# Existing handler functions:
+# - csr
+# - csc
+# - numpy array
+#   + 1d
+#   + 2d
+#   + slice
+# - pandas
+# - cudf
+#   + dataframe
+#   + series
+# - dt
+# - dl-pack
+# - cupy
+
+# To be added:
+# - Arrow
+
+def _cudf_array_interfaces(df):
+    '''Extract CuDF __cuda_array_interface__'''
+    interfaces = []
+    for col in df:
+        interface = df[col].__cuda_array_interface__
+        if 'mask' in interface:
+            interface['mask'] = interface['mask'].__cuda_array_interface__
+        interfaces.append(interface)
+    interfaces_str = bytes(json.dumps(interfaces, indent=2), 'utf-8')
+    return interfaces_str
+
+
+class DataHandler(abc.ABC):
+    __data_handlers = {}
+    __data_handlers_dly = []
+
+    def __init__(self, missing, nthread, silent, meta=None, meta_type=None):
+        self.missing = missing
+        self.threads = nthread
+        self.silent = silent
+
+        self.meta = meta
+        self.meta_type = meta_type
+
+    def transform(self, data):
+        '''Optional method for transforming data before being accepted by
+        other XGBoost API.'''
+        pass
+
+    @classmethod
+    def register_handler(cls, module, name, handler):
+        cls.__data_handlers['.'.join(module, name)] = handler
+
+    @classmethod
+    def register_handler_dly(cls, func, handler):
+        cls.__data_handlers_dly[(func, handler)]
+
+    @abc.abstractmethod
+    def handle(data, feature_names, feature_types):
+        '''Abstract method for handling different data input.'''
+
+    def handle_data_input(self, data, feature_names, feature_types):
+        module, name = type(data).__module__, type(data).__name__
+        handler = None
+        if '.'.join(module, name) in self.__data_handlers.keys():
+            handler = self.__data_handlers['.'.join(module, name)]
+        else:
+            for f, h in self.__data_handlers_dly:
+                if f(data):
+                    handler = h
+                    break
+        assert handler, ('No handler is registered for data with type: %s' %
+                         str(type(data)))
+
+        return handler.handle_input(data, feature_names, feature_types)
+
+
+class FileHandler(DataHandler):
+    def handle_input(self, data, feature_names, feature_types):
+        handle = ctypes.c_void_p()
+        _check_call(_LIB.XGDMatrixCreateFromFile(c_str(os_fspath(data)),
+                                                 ctypes.c_int(self.silent),
+                                                 ctypes.byref(handle)))
+        return handle, feature_names, feature_types
+
+
+DataHandler.register_handler_dly(
+    lambda data: isinstance(data, (STRING_TYPES, os_PathLike)),
+    FileHandler)
+
+
+class CSRHandler(DataHandler):
+    def handle_input(self, data, feature_names, feature_types):
+        ''''''
+        if isinstance(data, scipy.sparse.csr_matrix):
+            if len(data.indices) != len(data.data):
+                raise ValueError('length mismatch: {} vs {}'.format(
+                    len(data.indices), len(data.data)))
+            handle = ctypes.c_void_p()
+            _check_call(_LIB.XGDMatrixCreateFromCSREx(
+                c_array(ctypes.c_size_t, data.indptr),
+                c_array(ctypes.c_uint, data.indices),
+                c_array(ctypes.c_float, data.data),
+                ctypes.c_size_t(len(data.indptr)),
+                ctypes.c_size_t(len(data.data)),
+                ctypes.c_size_t(data.shape[1]),
+                ctypes.byref(handle)))
+            return handle, feature_names, feature_types
+        else:
+            return None
+
+
+DataHandler.register_handler('scipy.sparse.csr', 'csr_matrix', CSRHandler)
+
+
+class CSCHandler(DataHandler):
+    def handle_input(self, csc, feature_names, feature_types):
+        if len(csc.indices) != len(csc.data):
+            raise ValueError('length mismatch: {} vs {}'.format(
+                len(csc.indices), len(csc.data)))
+        handle = ctypes.c_void_p()
+        _check_call(_LIB.XGDMatrixCreateFromCSCEx(
+            c_array(ctypes.c_size_t, csc.indptr),
+            c_array(ctypes.c_uint, csc.indices),
+            c_array(ctypes.c_float, csc.data),
+            ctypes.c_size_t(len(csc.indptr)),
+            ctypes.c_size_t(len(csc.data)),
+            ctypes.c_size_t(csc.shape[0]),
+            ctypes.byref(handle)))
+        return handle, feature_names, feature_types
+
+
+DataHandler.register_handler('scipy.sparse.csc', 'csc_matrix', CSRHandler)
+
+
+class NumpyHandler(DataHandler):
+    def _maybe_np_slice(data, dtype):
+        '''Handle numpy slice.  This can be removed if we use __array_interface__.
+        '''
+        import numpy as np
+        try:
+            if not data.flags.c_contiguous:
+                warnings.warn(
+                    "Use subset (sliced data) of np.ndarray is not recommended " +
+                    "because it will generate extra copies and increase " +
+                    "memory consumption")
+                data = np.array(data, copy=True, dtype=dtype)
+            else:
+                data = np.array(data, copy=False, dtype=dtype)
+        except AttributeError:
+            data = np.array(data, copy=False, dtype=dtype)
+        return data
+
+    def handle_input(self, mat, feature_names, feature_types):
+        """Initialize data from a 2-D numpy matrix.
+
+        If ``mat`` does not have ``order='C'`` (aka row-major) or is
+        not contiguous, a temporary copy will be made.
+
+        If ``mat`` does not have ``dtype=numpy.float32``, a temporary copy will
+        be made.
+
+        So there could be as many as two temporary data copies; be mindful of
+        input layout and type if memory use is a concern.
+
+        """
+        if len(mat.shape) != 2:
+            raise ValueError('Expecting 2 dimensional numpy.ndarray, got: ',
+                             mat.shape)
+        import numpy as np
+        # flatten the array by rows and ensure it is float32.  we try to avoid
+        # data copies if possible (reshape returns a view when possible and we
+        # explicitly tell np.array to try and avoid copying)
+        data = np.array(mat.reshape(mat.size), copy=False, dtype=np.float32)
+        data = self._maybe_np_slice(data, np.float32)
+        handle = ctypes.c_void_p()
+        _check_call(_LIB.XGDMatrixCreateFromMat_omp(
+            data.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+            c_bst_ulong(mat.shape[0]),
+            c_bst_ulong(mat.shape[1]),
+            ctypes.c_float(self.missing),
+            ctypes.byref(handle),
+            ctypes.c_int(self.nthread)))
+        return handle, feature_names, feature_types
+
+
+class PandasHandler(DataHandler):
+    PANDAS_DTYPE_MAPPER = {
+        'int8': 'int',
+        'int16': 'int',
+        'int32': 'int',
+        'int64': 'int',
+        'uint8': 'int',
+        'uint16': 'int',
+        'uint32': 'int',
+        'uint64': 'int',
+        'float16': 'float',
+        'float32': 'float',
+        'float64': 'float',
+        'bool': 'i'
+    }
+
+    def _maybe_pandas_data(self, data, feature_names, feature_types,
+                           meta=None, meta_type=None):
+        """Extract internal data from pd.DataFrame for DMatrix data"""
+        from pandas.api.types import is_sparse
+        from pandas import MultiIndex, Int64Index
+
+        data_dtypes = data.dtypes
+        if not all(dtype.name in self.PANDAS_DTYPE_MAPPER or is_sparse(dtype)
+                   for dtype in data_dtypes):
+            bad_fields = [
+                str(data.columns[i]) for i, dtype in enumerate(data_dtypes)
+                if dtype.name not in self.PANDAS_DTYPE_MAPPER
+            ]
+
+            msg = """DataFrame.dtypes for data must be int, float or bool.
+                    Did not expect the data types in fields """
+            raise ValueError(msg + ', '.join(bad_fields))
+
+        if feature_names is None and meta is None:
+            if isinstance(data.columns, MultiIndex):
+                feature_names = [
+                    ' '.join([str(x) for x in i]) for i in data.columns
+                ]
+            elif isinstance(data.columns, Int64Index):
+                feature_names = list(map(str, data.columns))
+            else:
+                feature_names = data.columns.format()
+
+        if feature_types is None and meta is None:
+            feature_types = []
+            for dtype in data_dtypes:
+                if is_sparse(dtype):
+                    feature_types.append(self.PANDAS_DTYPE_MAPPER[
+                        dtype.subtype.name])
+                else:
+                    feature_types.append(self.PANDAS_DTYPE_MAPPER[dtype.name])
+
+        if meta and len(data.columns) > 1:
+            raise ValueError(
+                'DataFrame for {meta} cannot have multiple columns'.format(
+                    meta=meta))
+
+        dtype = meta_type if meta_type else 'float'
+        data = data.values.astype(dtype)
+
+        return data, feature_names, feature_types
+
+    def handle_input(self, data, feature_names, feature_types):
+        return self._maybe_pandas_data(data, feature_names, feature_types,
+                                       self.meta, self.meta_type)
+
+
+DataHandler.register_handler('pandas.core.frame', 'DataFrame', PandasHandler)
+
+
+class DTHandler(DataHandler):
+    DT_TYPE_MAPPER = {'bool': 'bool', 'int': 'int', 'real': 'float'}
+    DT_TYPE_MAPPER2 = {'bool': 'i', 'int': 'int', 'real': 'float'}
+
+    def _maybe_dt_data(self, data, feature_names, feature_types,
+                       meta=None, meta_type=None):
+        """Validate feature names and types if data table"""
+        import numpy as np
+        if meta and data.shape[1] > 1:
+            raise ValueError(
+                'DataTable for label or weight cannot have multiple columns')
+        if meta:
+            # below requires new dt version
+            # extract first column
+            data = data.to_numpy()[:, 0].astype(meta_type)
+            return data, None, None
+
+        data_types_names = tuple(lt.name for lt in data.ltypes)
+        bad_fields = [data.names[i]
+                      for i, type_name in enumerate(data_types_names)
+                      if type_name not in self.DT_TYPE_MAPPER]
+        if bad_fields:
+            msg = """DataFrame.types for data must be int, float or bool.
+                    Did not expect the data types in fields """
+            raise ValueError(msg + ', '.join(bad_fields))
+
+        if feature_names is None and meta is None:
+            feature_names = data.names
+
+            # always return stypes for dt ingestion
+            if feature_types is not None:
+                raise ValueError(
+                    'DataTable has own feature types, cannot pass them in.')
+            feature_types = np.vectorize(self.DT_TYPE_MAPPER2.get)(
+                data_types_names)
+
+        return data, feature_names, feature_types
+
+    def handle_input(self, data, feature_names, feature_types):
+        data, feature_names, feature_types = self._maybe_dt_data(
+            data, feature_names, feature_types, self.meta, self.meta_type)
+
+        ptrs = (ctypes.c_void_p * data.ncols)()
+        if hasattr(data, "internal") and hasattr(data.internal, "column"):
+            # datatable>0.8.0
+            for icol in range(data.ncols):
+                col = data.internal.column(icol)
+                ptr = col.data_pointer
+                ptrs[icol] = ctypes.c_void_p(ptr)
+        else:
+            # datatable<=0.8.0
+            from datatable.internal import \
+                frame_column_data_r  # pylint: disable=no-name-in-module,import-error
+            for icol in range(data.ncols):
+                ptrs[icol] = frame_column_data_r(data, icol)
+
+        # always return stypes for dt ingestion
+        feature_type_strings = (ctypes.c_char_p * data.ncols)()
+        for icol in range(data.ncols):
+            feature_type_strings[icol] = ctypes.c_char_p(
+                data.stypes[icol].name.encode('utf-8'))
+
+        handle = ctypes.c_void_p()
+        _check_call(_LIB.XGDMatrixCreateFromDT(
+            ptrs, feature_type_strings,
+            c_bst_ulong(data.shape[0]),
+            c_bst_ulong(data.shape[1]),
+            ctypes.byref(handle),
+            ctypes.c_int(self.nthread)))
+        return handle, feature_names, feature_types
+
+
+DataHandler.register_handler('datatable', 'Frame', DTHandler)
+DataHandler.register_handler('datatable', 'DataTable', DTHandler)
+
+
+class ArrayInterfaceHandler(DataHandler):
+    def handle_input(self, data, feature_names, feature_types):
+        """Initialize DMatrix from cupy ndarray."""
+        interface = data.__cuda_array_interface__
+        if 'mask' in interface:
+            interface['mask'] = interface['mask'].__cuda_array_interface__
+        interface_str = bytes(json.dumps(interface, indent=2), 'utf-8')
+
+        handle = ctypes.c_void_p()
+        _check_call(
+            _LIB.XGDMatrixCreateFromArrayInterface(
+                interface_str,
+                ctypes.c_float(self.missing),
+                ctypes.c_int(self.nthread),
+                ctypes.byref(handle)))
+        return handle, feature_names, feature_types
+
+
+DataHandler.register_handler('cupy.core.core', 'ndarray',
+                             ArrayInterfaceHandler)
+
+
+class CudaColumnarHandler(DataHandler):
+    def _maybe_cudf_dataframe(data, feature_names, feature_types):
+        """Extract internal data from cudf.DataFrame for DMatrix data."""
+        if feature_names is None:
+            if lazy_isinstance(data, 'cudf.core.series', 'Series'):
+                feature_names = [data.name]
+            elif lazy_isinstance(
+                    data.columns, 'cudf.core.multiindex', 'MultiIndex'):
+                feature_names = [
+                    ' '.join([str(x) for x in i])
+                    for i in data.columns
+                ]
+            else:
+                feature_names = data.columns.format()
+        if feature_types is None:
+            if lazy_isinstance(data, 'cudf.core.series', 'Series'):
+                dtypes = [data.dtype]
+            else:
+                dtypes = data.dtypes
+            feature_types = [PandasHandler.PANDAS_DTYPE_MAPPER[d.name]
+                             for d in dtypes]
+        return data, feature_names, feature_types
+
+    def handle_input(self, data, feature_names, feature_types):
+        """Initialize DMatrix from columnar memory format."""
+        interfaces_str = _cudf_array_interfaces(data)
+        handle = ctypes.c_void_p()
+        _check_call(
+            _LIB.XGDMatrixCreateFromArrayInterfaceColumns(
+                interfaces_str,
+                ctypes.c_float(self.missing),
+                ctypes.c_int(self.nthread),
+                ctypes.byref(handle)))
+        return handle, feature_names, feature_types
+
+
+DataHandler.register_handler('cudf.core.dataframe', 'DataFrame',
+                             CudaColumnarHandler)
+
+
+class DLPackHandler(ArrayInterfaceHandler):
+    def _maybe_dlpack_data(self, data, feature_names, feature_types):
+        from cupy import fromDlpack  # pylint: disable=E0401
+        data = fromDlpack(data)
+        return data, feature_names, feature_types
+
+    def handle_input(self, data, feature_names, feature_types):
+        data, feature_names, feature_types = self._maybe_dlpack_data(
+            data, feature_names, feature_types)
+        super(ArrayInterfaceHandler, self).handle_input(
+            data, feature_names, feature_types)
+
+
+DataHandler.register_handler_dly(
+    lambda x: 'PyCapsule' in str(type(x)) and "dltensor" in str(x),
+    CudaColumnarHandler)

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -243,6 +243,17 @@ __dmatrix_registry.register_handler_opaque(
     lambda x: hasattr(x, '__array__'), NumpyHandler)
 
 
+class ListHandler(NumpyHandler):
+    def handle_input(self, data, feature_names, feature_types):
+        assert self.meta is None, 'List input data is not supported for X'
+        data = np.array(data)
+        return super().handle_input(data, feature_names, feature_types)
+
+
+__dmatrix_registry.register_handler('builtins', 'list', NumpyHandler)
+__dmatrix_registry.register_handler('builtins', 'tuple', NumpyHandler)
+
+
 class PandasHandler(NumpyHandler):
     '''Handler of data structures defined by `pandas`.'''
     pandas_dtype_mapper = {

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -547,7 +547,7 @@ class DeviceQuantileCudaArrayInterfaceHandler(
         """Initialize DMatrix from cupy ndarray."""
         if not hasattr(data, '__cuda_array_interface__') and hasattr(
                 data, '__array__'):
-            import cupy
+            import cupy         # pylint: disable=import-error
             data = cupy.array(data, copy=False)
 
         interface = data.__cuda_array_interface__
@@ -568,6 +568,8 @@ __device_quantile_dmatrix_registry.register_handler(
     'cupy.core.core', 'ndarray', DeviceQuantileCudaArrayInterfaceHandler)
 __device_quantile_dmatrix_registry.register_handler_opaque(
     lambda x: hasattr(x, '__array__'), NumpyHandler)
+__device_quantile_dmatrix_registry.register_handler_opaque(
+    lambda x: hasattr(x, '__cuda_array_interface__'), NumpyHandler)
 
 
 class DeviceQuantileCudaColumnarHandler(DeviceQuantileDMatrixDataHandler,

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -75,7 +75,7 @@ class DMatrixDataManager:
         return None
 
 
-__dmatrix_registry = DMatrixDataManager()
+__dmatrix_registry = DMatrixDataManager()  # pylint: disable=invalid-name
 
 
 def get_dmatrix_data_handler(data, missing, nthread, silent,
@@ -488,7 +488,7 @@ __dmatrix_registry.register_handler_opaque(
     DLPackHandler)
 
 
-class DeviceQuantileDMatrixDataHandler(DataHandler):
+class DeviceQuantileDMatrixDataHandler(DataHandler):  # pylint: disable=abstract-method
     '''Base class of data handler for `DeviceQuantileDMatrix`.'''
     def __init__(self, max_bin, missing, nthread, silent,
                  meta=None, meta_type=None):
@@ -496,7 +496,7 @@ class DeviceQuantileDMatrixDataHandler(DataHandler):
         super().__init__(missing, nthread, silent, meta, meta_type)
 
 
-__device_quantile_dmatrix_registry = DMatrixDataManager()
+__device_quantile_dmatrix_registry = DMatrixDataManager()  # pylint: disable=invalid-name
 
 
 def get_device_quantile_dmatrix_data_handler(


### PR DESCRIPTION
* Add a factory method for handling various data types.

This PR decouples DMatrix Python interface with various backends.

In the future I want to use the backends for all meta info setters.  This way we have have better support for non-numpy data structures for setting metainfo.