### PR TITLE
Let XGBoostError inherit ValueError.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -26,7 +26,7 @@ from .libpath import find_lib_path
 c_bst_ulong = ctypes.c_uint64
 
 
-class XGBoostError(Exception):
+class XGBoostError(ValueError):
     """Error thrown by xgboost trainer."""
 
 

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -537,16 +537,13 @@ class XGBModel(XGBModelBase):
             else:
                 params.update({'eval_metric': eval_metric})
 
-        try:
-            self._Booster = train(params, train_dmatrix,
-                                  self.get_num_boosting_rounds(), evals=evals,
-                                  early_stopping_rounds=early_stopping_rounds,
-                                  evals_result=evals_result,
-                                  obj=obj, feval=feval,
-                                  verbose_eval=verbose, xgb_model=xgb_model,
-                                  callbacks=callbacks)
-        except XGBoostError as e:
-            raise ValueError(e)
+        self._Booster = train(params, train_dmatrix,
+                              self.get_num_boosting_rounds(), evals=evals,
+                              early_stopping_rounds=early_stopping_rounds,
+                              evals_result=evals_result,
+                              obj=obj, feval=feval,
+                              verbose_eval=verbose, xgb_model=xgb_model,
+                              callbacks=callbacks)
 
         if evals_result:
             for val in evals_result.items():
@@ -1230,16 +1227,13 @@ class XGBRanker(XGBModel):
                     'Custom evaluation metric is not yet supported for XGBRanker.')
             params.update({'eval_metric': eval_metric})
 
-        try:
-            self._Booster = train(params, train_dmatrix,
-                                  self.n_estimators,
-                                  early_stopping_rounds=early_stopping_rounds,
-                                  evals=evals,
-                                  evals_result=evals_result, feval=feval,
-                                  verbose_eval=verbose, xgb_model=xgb_model,
-                                  callbacks=callbacks)
-        except XGBoostError as e:
-            raise ValueError(e)
+        self._Booster = train(params, train_dmatrix,
+                              self.n_estimators,
+                              early_stopping_rounds=early_stopping_rounds,
+                              evals=evals,
+                              evals_result=evals_result, feval=feval,
+                              verbose_eval=verbose, xgb_model=xgb_model,
+                              callbacks=callbacks)
 
         self.objective = params["objective"]
 


### PR DESCRIPTION
scikit learn catches `ValueError` instead of `Exception`.  Also I believe it's better to let user use `ValueError` as it's more common.

This is not entirely a breaking change as old code that catches XGBoostError or Exception will continue to work unless you catch ValueError and have another handler for XGBoostError.