### PR TITLE
[R] Fix duplicated libomp.dylib error on Mac OSX

### DIFF
--- a/R-package/configure
+++ b/R-package/configure
@@ -2710,7 +2710,7 @@ fi
 if test `uname -s` = "Darwin"
 then
   OPENMP_CXXFLAGS='-Xclang -fopenmp'
-  OPENMP_LIB='/usr/local/lib/libomp.dylib'
+  OPENMP_LIB='-lomp'
   ac_pkg_openmp=no
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenMP will work in a package" >&5
 $as_echo_n "checking whether OpenMP will work in a package... " >&6; }

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -29,7 +29,7 @@ fi
 if test `uname -s` = "Darwin"
 then
   OPENMP_CXXFLAGS='-Xclang -fopenmp'
-  OPENMP_LIB='/usr/local/lib/libomp.dylib'
+  OPENMP_LIB='-lomp'
   ac_pkg_openmp=no
   AC_MSG_CHECKING([whether OpenMP will work in a package])
   AC_LANG_CONFTEST([AC_LANG_PROGRAM([[#include <omp.h>]], [[ return (omp_get_max_threads() <= 1); ]])])


### PR DESCRIPTION
Addresses #5496. The relevant error is

```
OMP: Error #15: Initializing libomp.dylib, but found libomp.dylib already initialized.
OMP: Hint This means that multiple copies of the OpenMP runtime have been linked into the program.
```