### PR TITLE
Require Python 3.6+; drop Python 3.5 from CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -305,7 +305,6 @@ def TestPythonCPU() {
     def docker_binary = "docker"
     sh """
     ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/test_python.sh cpu
-    ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/test_python.sh cpu-py35
     """
     deleteDir()
   }

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -309,11 +309,10 @@ if __name__ == '__main__':
                        'Operating System :: OS Independent',
                        'Programming Language :: Python',
                        'Programming Language :: Python :: 3',
-                       'Programming Language :: Python :: 3.5',
                        'Programming Language :: Python :: 3.6',
                        'Programming Language :: Python :: 3.7',
                        'Programming Language :: Python :: 3.8'],
-          python_requires='>=3.5',
+          python_requires='>=3.6',
           url='https://github.com/dmlc/xgboost')
 
     clean_up()

--- a/python-package/xgboost/__init__.py
+++ b/python-package/xgboost/__init__.py
@@ -22,12 +22,6 @@ try:
 except ImportError:
     pass
 
-if sys.version_info[:2] == (3, 5):
-    warnings.warn(
-        'Python 3.5 support is deprecated; XGBoost will require Python 3.6+ in the near future. ' +
-        'Consider upgrading to Python 3.6+.',
-        FutureWarning)
-
 VERSION_FILE = os.path.join(os.path.dirname(__file__), 'VERSION')
 with open(VERSION_FILE) as f:
     __version__ = f.read().strip()

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -19,12 +19,6 @@ ENV PATH=/opt/python/bin:$PATH
 
 ENV GOSU_VERSION 1.10
 
-# Create new Conda environment with Python 3.5
-RUN conda create -n py35 python=3.5 && \
-    source activate py35 && \
-    pip install numpy pytest scipy scikit-learn pandas matplotlib wheel kubernetes urllib3 graphviz && \
-    source deactivate
-
 # Install Python packages in default env
 RUN \
     pip install pyyaml cpplint pylint astroid sphinx numpy scipy pandas matplotlib sh \

--- a/tests/ci_build/test_python.sh
+++ b/tests/ci_build/test_python.sh
@@ -65,14 +65,8 @@ case "$suite" in
     ./runtests.sh
     ;;
 
-  cpu-py35)
-    source activate py35
-    install_xgboost
-    pytest -v -s --fulltrace tests/python
-    ;;
-
   *)
-    echo "Usage: $0 {gpu|mgpu|cudf|cpu|cpu-py35}"
+    echo "Usage: $0 {gpu|mgpu|cudf|cpu}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
Extracted from #5388. We can now opt into new features introduced by Python 3.6, such as f-strings and numeric literals with underscores.