### PR TITLE
Fix release degradation

### DIFF
--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -41,10 +41,11 @@ struct RegLossParam : public XGBoostParameter<RegLossParam> {
 template<typename Loss>
 class RegLossObj : public ObjFunction {
  protected:
-  HostDeviceVector<int> label_correct_;
+  HostDeviceVector<float> additional_input_;
 
  public:
-  RegLossObj() = default;
+  // 0 - label_correct flag, 1 - scale_pos_weight, 2 - is_null_weight
+  RegLossObj(): additional_input_(3) {}
 
   void Configure(const std::vector<std::pair<std::string, std::string> >& args) override {
     param_.UpdateAllowUnknown(args);
@@ -64,8 +65,7 @@ class RegLossObj : public ObjFunction {
     size_t const ndata = preds.Size();
     out_gpair->Resize(ndata);
     auto device = tparam_->gpu_id;
-    label_correct_.Resize(1);
-    label_correct_.Fill(1);
+    additional_input_.HostVector().begin()[0] = 1;  // Fill the label_correct flag
 
     bool is_null_weight = info.weights_.Size() == 0;
     if (!is_null_weight) {
@@ -73,44 +73,37 @@ class RegLossObj : public ObjFunction {
           << "Number of weights should be equal to number of data points.";
     }
     auto scale_pos_weight = param_.scale_pos_weight;
-    HostDeviceVector<float> scale_pos_weight_;
-    scale_pos_weight_.Resize(1);
-    scale_pos_weight_.Fill(scale_pos_weight);
-    HostDeviceVector<int> is_null_weight_;
-    is_null_weight_.Resize(1);
-    is_null_weight_.Fill(is_null_weight);
+    additional_input_.HostVector().begin()[1] = scale_pos_weight;
+    additional_input_.HostVector().begin()[2] = is_null_weight;
 
     common::Transform<>::Init([] XGBOOST_DEVICE(size_t _idx,
-                           common::Span<int> _label_correct,
+                           common::Span<float> _additional_input,
                            common::Span<GradientPair> _out_gpair,
                            common::Span<const bst_float> _preds,
                            common::Span<const bst_float> _labels,
-                           common::Span<const bst_float> _weights,
-                           common::Span<int> _is_null_weight,
-                           common::Span<float> _scale_pos_weight) {
+                           common::Span<const bst_float> _weights) {
+          const float _scale_pos_weight = _additional_input[1];
+          const bool _is_null_weight = _additional_input[2];
+
           bst_float p = Loss::PredTransform(_preds[_idx]);
-          bst_float w = _is_null_weight[0] ? 1.0f : _weights[_idx];
+          bst_float w = _is_null_weight ? 1.0f : _weights[_idx];
           bst_float label = _labels[_idx];
           if (label == 1.0f) {
-            w *= _scale_pos_weight[0];
+            w *= _scale_pos_weight;
           }
           if (!Loss::CheckLabel(label)) {
             // If there is an incorrect label, the host code will know.
-            _label_correct[0] = 0;
+            _additional_input[0] = 0;
           }
           _out_gpair[_idx] = GradientPair(Loss::FirstOrderGradient(p, label) * w,
                                           Loss::SecondOrderGradient(p, label) * w);
         },
         common::Range{0, static_cast<int64_t>(ndata)}, device).Eval(
-            &label_correct_, out_gpair, &preds, &info.labels_, &info.weights_,
-            &is_null_weight_, &scale_pos_weight_);
+            &additional_input_, out_gpair, &preds, &info.labels_, &info.weights_);
 
-    // copy "label correct" flags back to host
-    std::vector<int>& label_correct_h = label_correct_.HostVector();
-    for (auto const flag : label_correct_h) {
-      if (flag == 0) {
-        LOG(FATAL) << Loss::LabelErrorMsg();
-      }
+    auto const flag = additional_input_.HostVector().begin()[0];
+    if (flag == 0) {
+      LOG(FATAL) << Loss::LabelErrorMsg();
     }
   }
 


### PR DESCRIPTION
fix related to #5666

this PR reduce gaps between -DUSE_CUDA=ON and -DUSE_CUDA=OFF

dataset |  -DUSE_CUDA=ON | -DUSE_CUDA=OFF
-- | -- | --
higgs1m | 16.07s  | 15.9s
mortgage1Q | 17.9s | 17.67s

After profiling it was discovered that `GetGradient` step computational time was increased ~5x what introduce 25% degradation for full training.
Fix is related to lambda capturing (when this function was compiled with cuda, its performance was worse than with g++ usage). Without capturing performance is similar.
