### PR TITLE
Add swift package reference

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -26,6 +26,7 @@ Contents
   R package <R-package/index>
   JVM package <jvm/index>
   Ruby package <https://github.com/ankane/xgb>
+  Swift package <https://github.com/kongzii/SwiftXGBoost>
   Julia package <julia>
   C Package <c>
   C++ Interface <c++>


### PR DESCRIPTION
Please do not take this PR violently.

I made an announcement at [forum](https://discuss.xgboost.ai/t/xgboost-for-swift), and I would love to get Swift into one of the supported languages at official XGBoost documentation, and I thought that Github would be actually a better place to ask this.

[SwiftXGBoost](https://github.com/kongzii/SwiftXGBoost) currently support core features with more to come. Documentation is auto-generated, and tests are done against Python implementation.

Is there any checklist or previous discussion (when bindings for other languages were proposed) that I could look at in order to get this PR eventually merged?

Thanks.
