### PR TITLE
Speed up python test

### DIFF
--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -566,10 +566,6 @@ class DeviceQuantileCudaArrayInterfaceHandler(
 
 __device_quantile_dmatrix_registry.register_handler(
     'cupy.core.core', 'ndarray', DeviceQuantileCudaArrayInterfaceHandler)
-__device_quantile_dmatrix_registry.register_handler_opaque(
-    lambda x: hasattr(x, '__array__'), NumpyHandler)
-__device_quantile_dmatrix_registry.register_handler_opaque(
-    lambda x: hasattr(x, '__cuda_array_interface__'), NumpyHandler)
 
 
 class DeviceQuantileCudaColumnarHandler(DeviceQuantileDMatrixDataHandler,

--- a/tests/python-gpu/test_device_quantile_dmatrix.py
+++ b/tests/python-gpu/test_device_quantile_dmatrix.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+import xgboost as xgb
+import unittest
+import pytest
+import cupy as cp
+
+
+class TestDeviceQuantileDMatrix(unittest.TestCase):
+    def test_dmatrix_numpy_init(self):
+        data = np.random.randn(5, 5)
+        with pytest.raises(AssertionError, match='is not supported for DeviceQuantileDMatrix'):
+            dm = xgb.DeviceQuantileDMatrix(data, np.ones(5, dtype=np.float64))
+
+    def test_dmatrix_cupy_init(self):
+        data = cp.random.randn(5, 5)
+        dm = xgb.DeviceQuantileDMatrix(data, cp.ones(5, dtype=np.float64))

--- a/tests/python-gpu/test_device_quantile_dmatrix.py
+++ b/tests/python-gpu/test_device_quantile_dmatrix.py
@@ -3,7 +3,10 @@ import numpy as np
 import xgboost as xgb
 import unittest
 import pytest
-import cupy as cp
+import sys
+
+sys.path.append("tests/python")
+import testing as tm
 
 
 class TestDeviceQuantileDMatrix(unittest.TestCase):
@@ -12,6 +15,8 @@ class TestDeviceQuantileDMatrix(unittest.TestCase):
         with pytest.raises(AssertionError, match='is not supported for DeviceQuantileDMatrix'):
             dm = xgb.DeviceQuantileDMatrix(data, np.ones(5, dtype=np.float64))
 
+    @pytest.mark.skipif(**tm.no_cupy())
     def test_dmatrix_cupy_init(self):
+        import cupy as cp
         data = cp.random.randn(5, 5)
         dm = xgb.DeviceQuantileDMatrix(data, cp.ones(5, dtype=np.float64))

--- a/tests/python-gpu/test_gpu_linear.py
+++ b/tests/python-gpu/test_gpu_linear.py
@@ -3,12 +3,11 @@ import pytest
 import unittest
 
 sys.path.append('tests/python/')
-import test_linear              # noqa: E402
-import testing as tm            # noqa: E402
+import test_linear  # noqa: E402
+import testing as tm  # noqa: E402
 
 
 class TestGPULinear(unittest.TestCase):
-
     datasets = ["Boston", "Digits", "Cancer", "Sparse regression"]
     common_param = {
         'booster': ['gblinear'],
@@ -16,7 +15,7 @@ class TestGPULinear(unittest.TestCase):
         'eta': [0.5],
         'top_k': [10],
         'tolerance': [1e-5],
-        'alpha': [.005, .1],
+        'alpha': [.1],
         'lambda': [0.005],
         'coordinate_selection': ['cyclic', 'random', 'greedy']}
 
@@ -26,6 +25,6 @@ class TestGPULinear(unittest.TestCase):
         parameters['gpu_id'] = [0]
         for param in test_linear.parameter_combinations(parameters):
             results = test_linear.run_suite(
-                param, 150, self.datasets, scale_features=True)
+                param, 100, self.datasets, scale_features=True)
             test_linear.assert_regression_result(results, 1e-2)
             test_linear.assert_classification_result(results)

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -47,6 +47,7 @@ class TestGPU(unittest.TestCase):
         device_dmatrix_datasets = ["Boston", "Cancer", "Digits"]
         for param in test_param:
             param['tree_method'] = 'gpu_hist'
+            
             gpu_results_device_dmatrix = run_suite(param, select_datasets=device_dmatrix_datasets,
                                                    DMatrixT=xgb.DeviceQuantileDMatrix,
                                                    dmatrix_params={'max_bin': param['max_bin']})

--- a/tests/python/regression_test_utilities.py
+++ b/tests/python/regression_test_utilities.py
@@ -65,7 +65,7 @@ def get_sparse():
     n = 2000
     sparsity = 0.75
     X, y = datasets.make_regression(n, random_state=rng)
-    flag = np.random.binomial(1, sparsity, X.shape)
+    flag = rng.binomial(1, sparsity, X.shape)
     for i in range(X.shape[0]):
         for j in range(X.shape[1]):
             if flag[i, j]:
@@ -85,16 +85,16 @@ def get_small_weights():
 
 @memory.cache
 def get_weights_regression(min_weight, max_weight):
-    np.random.seed(199)
+    rng = np.random.RandomState(199)
     n = 2000
     sparsity = 0.25
-    X, y = datasets.make_regression(n, random_state=199)
-    flag = np.random.binomial(1, sparsity, X.shape)
+    X, y = datasets.make_regression(n, random_state=rng)
+    flag = rng.binomial(1, sparsity, X.shape)
     for i in range(X.shape[0]):
         for j in range(X.shape[1]):
             if flag[i, j]:
                 X[i, j] = np.nan
-    w = np.random.uniform(min_weight, max_weight, n)
+    w = rng.uniform(min_weight, max_weight, n)
     return X, y, w
 
 

--- a/tests/python/regression_test_utilities.py
+++ b/tests/python/regression_test_utilities.py
@@ -111,7 +111,7 @@ def train_dataset(dataset, param_in, num_rounds=10, scale_features=False, DMatri
                           weight=dataset.w)
     elif DMatrixT is xgb.DeviceQuantileDMatrix:
         import cupy as cp
-        dtrain = DMatrixT(cp.array(X), dataset.y, weight=dataset.w, **dmatrix_params)
+        dtrain = DMatrixT(cp.array(X), cp.array(dataset.y), weight=None if dataset.w is None else cp.array(dataset.w), **dmatrix_params)
     else:
         dtrain = DMatrixT(X, dataset.y, weight=dataset.w, **dmatrix_params)
 


### PR DESCRIPTION
This PR speeds up tests to a more reasonable level, while maintaining most of the test coverage.

`pytest -s -v --profile tests/python-gpu/test_gpu_updaters.py` goes from around 120s to 22s.

I had a failing test for DeviceQuantileDMatrix as well where passing a label with type float64 was passing doubles directly into xgboost and reading them as floats. The root cause was the data handler refactor which was incorrectly handling types in this case. I also noticed that it is possible to create a DeviceQuantileDMatrix using numpy without causing the expected error. For now I have disabled numpy inputs to DeviceQuantileDMatrix altogether.