### PR TITLE
Remove column major specialization.

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -463,8 +463,8 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle, float *values,
   CHECK_EQ(cache_id, 0) << "Cache ID is not supported yet";
   auto *learner = static_cast<xgboost::Learner *>(handle);
 
-  auto x =
-      std::make_shared<xgboost::data::DenseAdapter>(values, n_rows, n_cols);
+  std::shared_ptr<xgboost::data::DenseAdapter> x{
+    new xgboost::data::DenseAdapter(values, n_rows, n_cols)};
   HostDeviceVector<float>* p_predt { nullptr };
   std::string type { c_type };
   learner->InplacePredict(x, type, missing, &p_predt);
@@ -495,8 +495,8 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle,
   CHECK_EQ(cache_id, 0) << "Cache ID is not supported yet";
   auto *learner = static_cast<xgboost::Learner *>(handle);
 
-  auto x = std::make_shared<data::CSRAdapter>(indptr, indices, data,
-                                              nindptr - 1, nelem, num_col);
+  std::shared_ptr<xgboost::data::CSRAdapter> x{
+    new xgboost::data::CSRAdapter(indptr, indices, data, nindptr - 1, nelem, num_col)};
   HostDeviceVector<float>* p_predt { nullptr };
   std::string type { c_type };
   learner->InplacePredict(x, type, missing, &p_predt);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -463,7 +463,8 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle, float *values,
   CHECK_EQ(cache_id, 0) << "Cache ID is not supported yet";
   auto *learner = static_cast<xgboost::Learner *>(handle);
 
-  auto x = xgboost::data::DenseAdapter(values, n_rows, n_cols);
+  auto x =
+      std::make_shared<xgboost::data::DenseAdapter>(values, n_rows, n_cols);
   HostDeviceVector<float>* p_predt { nullptr };
   std::string type { c_type };
   learner->InplacePredict(x, type, missing, &p_predt);
@@ -494,7 +495,8 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle,
   CHECK_EQ(cache_id, 0) << "Cache ID is not supported yet";
   auto *learner = static_cast<xgboost::Learner *>(handle);
 
-  auto x = data::CSRAdapter(indptr, indices, data, nindptr - 1, nelem, num_col);
+  auto x = std::make_shared<data::CSRAdapter>(indptr, indices, data,
+                                              nindptr - 1, nelem, num_col);
   HostDeviceVector<float>* p_predt { nullptr };
   std::string type { c_type };
   learner->InplacePredict(x, type, missing, &p_predt);

--- a/src/c_api/c_api.cu
+++ b/src/c_api/c_api.cu
@@ -69,7 +69,7 @@ XGB_DLL int XGBoosterPredictFromArrayInterfaceColumns(BoosterHandle handle,
   auto *learner = static_cast<Learner*>(handle);
 
   std::string json_str{c_json_strs};
-  auto x = data::CudfAdapter(json_str);
+  auto x = std::make_shared<data::CudfAdapter>(json_str);
   HostDeviceVector<float>* p_predt { nullptr };
   std::string type { c_type };
   learner->InplacePredict(x, type, missing, &p_predt);
@@ -97,7 +97,7 @@ XGB_DLL int XGBoosterPredictFromArrayInterface(BoosterHandle handle,
   auto *learner = static_cast<Learner*>(handle);
 
   std::string json_str{c_json_strs};
-  auto x = data::CupyAdapter(json_str);
+  auto x = std::make_shared<data::CupyAdapter>(json_str);
   HostDeviceVector<float>* p_predt { nullptr };
   std::string type { c_type };
   learner->InplacePredict(x, type, missing, &p_predt);

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -109,6 +109,7 @@ class NoMetaInfo {
   const float* Weights() const { return nullptr; }
   const uint64_t* Qid() const { return nullptr; }
   const float* BaseMargin() const { return nullptr; }
+  virtual ~NoMetaInfo() = default;
 };
 
 };  // namespace detail
@@ -150,6 +151,8 @@ class CSRAdapterBatch : public detail::NoMetaInfo {
   }
   size_t Size() const { return num_rows_; }
 
+  ~CSRAdapterBatch() noexcept override = default;
+
  private:
   const size_t* row_ptr_;
   const unsigned* feature_idx_;
@@ -169,6 +172,7 @@ class CSRAdapter : public detail::SingleBatchDataIter<CSRAdapterBatch> {
   const CSRAdapterBatch& Value() const override { return batch_; }
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
+  ~CSRAdapter() noexcept override = default;
 
  private:
   CSRAdapterBatch batch_;
@@ -205,6 +209,7 @@ class DenseAdapterBatch : public detail::NoMetaInfo {
   const Line GetLine(size_t idx) const {
     return Line(values_ + idx * num_features_, num_features_, idx);
   }
+  ~DenseAdapterBatch() noexcept override = default;
 
  private:
   const float* values_;
@@ -222,6 +227,7 @@ class DenseAdapter : public detail::SingleBatchDataIter<DenseAdapterBatch> {
 
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
+  ~DenseAdapter() noexcept override = default;
 
  private:
   DenseAdapterBatch batch_;

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -169,7 +169,7 @@ class CSRAdapter : public detail::SingleBatchDataIter<CSRAdapterBatch> {
   const CSRAdapterBatch& Value() const override { return batch_; }
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  ~CSRAdapter() noexcept(false) override = default;
+  ~CSRAdapter() noexcept override = default;
 
  private:
   CSRAdapterBatch batch_;
@@ -223,7 +223,7 @@ class DenseAdapter : public detail::SingleBatchDataIter<DenseAdapterBatch> {
 
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  ~DenseAdapter() noexcept(false) override = default;
+  ~DenseAdapter() noexcept override = default;
 
  private:
   DenseAdapterBatch batch_;

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -169,7 +169,6 @@ class CSRAdapter : public detail::SingleBatchDataIter<CSRAdapterBatch> {
   const CSRAdapterBatch& Value() const override { return batch_; }
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  ~CSRAdapter() noexcept(false) override = default;
 
  private:
   CSRAdapterBatch batch_;
@@ -223,7 +222,6 @@ class DenseAdapter : public detail::SingleBatchDataIter<DenseAdapterBatch> {
 
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  ~DenseAdapter() noexcept(false) override = default;
 
  private:
   DenseAdapterBatch batch_;

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -169,6 +169,7 @@ class CSRAdapter : public detail::SingleBatchDataIter<CSRAdapterBatch> {
   const CSRAdapterBatch& Value() const override { return batch_; }
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
+  ~CSRAdapter() noexcept(false) override = default;
 
  private:
   CSRAdapterBatch batch_;
@@ -222,6 +223,7 @@ class DenseAdapter : public detail::SingleBatchDataIter<DenseAdapterBatch> {
 
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
+  ~DenseAdapter() noexcept(false) override = default;
 
  private:
   DenseAdapterBatch batch_;

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -169,7 +169,7 @@ class CSRAdapter : public detail::SingleBatchDataIter<CSRAdapterBatch> {
   const CSRAdapterBatch& Value() const override { return batch_; }
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  ~CSRAdapter() noexcept override = default;
+  ~CSRAdapter() noexcept(false) override = default;
 
  private:
   CSRAdapterBatch batch_;
@@ -223,7 +223,7 @@ class DenseAdapter : public detail::SingleBatchDataIter<DenseAdapterBatch> {
 
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  ~DenseAdapter() noexcept override = default;
+  ~DenseAdapter() noexcept(false) override = default;
 
  private:
   DenseAdapterBatch batch_;

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -169,7 +169,7 @@ class CSRAdapter : public detail::SingleBatchDataIter<CSRAdapterBatch> {
   const CSRAdapterBatch& Value() const override { return batch_; }
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  ~CSRAdapter() noexcept override = default;
+  virtual ~CSRAdapter() noexcept(false) override = default;
 
  private:
   CSRAdapterBatch batch_;
@@ -223,7 +223,7 @@ class DenseAdapter : public detail::SingleBatchDataIter<DenseAdapterBatch> {
 
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  ~DenseAdapter() noexcept override = default;
+  virtual ~DenseAdapter() noexcept(false) override = default;
 
  private:
   DenseAdapterBatch batch_;

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -169,7 +169,7 @@ class CSRAdapter : public detail::SingleBatchDataIter<CSRAdapterBatch> {
   const CSRAdapterBatch& Value() const override { return batch_; }
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  virtual ~CSRAdapter() noexcept(false) override = default;
+  ~CSRAdapter() noexcept override = default;
 
  private:
   CSRAdapterBatch batch_;
@@ -223,7 +223,7 @@ class DenseAdapter : public detail::SingleBatchDataIter<DenseAdapterBatch> {
 
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  virtual ~DenseAdapter() noexcept(false) override = default;
+  ~DenseAdapter() noexcept override = default;
 
  private:
   DenseAdapterBatch batch_;

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -109,7 +109,6 @@ class NoMetaInfo {
   const float* Weights() const { return nullptr; }
   const uint64_t* Qid() const { return nullptr; }
   const float* BaseMargin() const { return nullptr; }
-  virtual ~NoMetaInfo() = default;
 };
 
 };  // namespace detail
@@ -151,8 +150,6 @@ class CSRAdapterBatch : public detail::NoMetaInfo {
   }
   size_t Size() const { return num_rows_; }
 
-  ~CSRAdapterBatch() noexcept override = default;
-
  private:
   const size_t* row_ptr_;
   const unsigned* feature_idx_;
@@ -172,7 +169,6 @@ class CSRAdapter : public detail::SingleBatchDataIter<CSRAdapterBatch> {
   const CSRAdapterBatch& Value() const override { return batch_; }
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  ~CSRAdapter() noexcept override = default;
 
  private:
   CSRAdapterBatch batch_;
@@ -209,7 +205,6 @@ class DenseAdapterBatch : public detail::NoMetaInfo {
   const Line GetLine(size_t idx) const {
     return Line(values_ + idx * num_features_, num_features_, idx);
   }
-  ~DenseAdapterBatch() noexcept override = default;
 
  private:
   const float* values_;
@@ -227,7 +222,6 @@ class DenseAdapter : public detail::SingleBatchDataIter<DenseAdapterBatch> {
 
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return num_columns_; }
-  ~DenseAdapter() noexcept override = default;
 
  private:
   DenseAdapterBatch batch_;

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -154,8 +154,8 @@ struct WriteCompressedEllpackFunctor {
 // Here the data is already correctly ordered and simply needs to be compacted
 // to remove missing data
 template <typename AdapterBatchT>
-void CopyDataRowMajor(const AdapterBatchT& batch, EllpackPageImpl* dst,
-                      int device_idx, float missing) {
+void CopyDataToEllpack(const AdapterBatchT& batch, EllpackPageImpl* dst,
+                       int device_idx, float missing) {
   // Some witchcraft happens here
   // The goal is to copy valid elements out of the input to an ellpack matrix
   // with a given row stride, using no extra working memory Standard stream
@@ -209,51 +209,6 @@ void CopyDataRowMajor(const AdapterBatchT& batch, EllpackPageImpl* dst,
                          });
 }
 
-template <typename AdapterT, typename AdapterBatchT>
-void CopyDataColumnMajor(AdapterT* adapter, const AdapterBatchT& batch,
-                         EllpackPageImpl* dst, float missing) {
-  // Step 1: Get the sizes of the input columns
-  dh::caching_device_vector<size_t> column_sizes(adapter->NumColumns(), 0);
-  auto d_column_sizes = column_sizes.data().get();
-  // Populate column sizes
-  dh::LaunchN(adapter->DeviceIdx(), batch.Size(), [=] __device__(size_t idx) {
-      const auto& e = batch.GetElement(idx);
-      atomicAdd(reinterpret_cast<unsigned long long*>(  // NOLINT
-          &d_column_sizes[e.column_idx]),
-                static_cast<unsigned long long>(1));  // NOLINT
-    });
-
-  thrust::host_vector<size_t> host_column_sizes = column_sizes;
-
-  // Step 2: Iterate over columns, place elements in correct row, increment
-  // temporary row pointers
-  dh::caching_device_vector<size_t> temp_row_ptr(adapter->NumRows(), 0);
-  auto d_temp_row_ptr = temp_row_ptr.data().get();
-  auto row_stride = dst->row_stride;
-  size_t begin = 0;
-  auto device_accessor = dst->GetDeviceAccessor(adapter->DeviceIdx());
-  common::CompressedBufferWriter writer(device_accessor.NumSymbols());
-  auto d_compressed_buffer = dst->gidx_buffer.DevicePointer();
-  data::IsValidFunctor is_valid(missing);
-  for (auto size : host_column_sizes) {
-    size_t end = begin + size;
-    dh::LaunchN(adapter->DeviceIdx(), end - begin, [=] __device__(size_t idx) {
-        auto writer_non_const =
-            writer;  // For some reason this variable gets captured as const
-        const auto& e = batch.GetElement(idx + begin);
-        if (!is_valid(e)) return;
-        size_t output_position =
-            e.row_idx * row_stride + d_temp_row_ptr[e.row_idx];
-        auto bin_idx = device_accessor.SearchBin(e.value, e.column_idx);
-        writer_non_const.AtomicWriteSymbol(d_compressed_buffer, bin_idx,
-                                           output_position);
-        d_temp_row_ptr[e.row_idx] += 1;
-      });
-
-    begin = end;
-  }
-}
-
 void WriteNullValues(EllpackPageImpl* dst, int device_idx,
                      common::Span<size_t> row_counts) {
   // Write the null values
@@ -284,12 +239,7 @@ EllpackPageImpl::EllpackPageImpl(AdapterT* adapter, float missing, bool is_dense
 
   *this = EllpackPageImpl(adapter->DeviceIdx(), cuts, is_dense, row_stride,
                           adapter->NumRows());
-  if (adapter->IsRowMajor()) {
-    CopyDataRowMajor(batch, this, adapter->DeviceIdx(), missing);
-  } else {
-    CopyDataColumnMajor(adapter, batch, this, missing);
-  }
-
+  CopyDataToEllpack(batch, this, adapter->DeviceIdx(), missing);
   WriteNullValues(this, adapter->DeviceIdx(), row_counts_span);
 }
 

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -271,12 +271,12 @@ class CPUPredictor : public Predictor {
                                 PredictionCacheEntry *out_preds,
                                 uint32_t tree_begin, uint32_t tree_end) const {
     auto threads = omp_get_max_threads();
-    auto m = dmlc::get<Adapter>(x);
-    CHECK_EQ(m.NumColumns(), model.learner_model_param->num_feature)
+    auto m = dmlc::get<std::shared_ptr<Adapter>>(x);
+    CHECK_EQ(m->NumColumns(), model.learner_model_param->num_feature)
         << "Number of columns in data must equal to trained model.";
     MetaInfo info;
-    info.num_col_ = m.NumColumns();
-    info.num_row_ = m.NumRows();
+    info.num_col_ = m->NumColumns();
+    info.num_row_ = m->NumRows();
     this->InitOutPredictions(info, &(out_preds->predictions), model);
     std::vector<Entry> workspace(info.num_col_ * 8 * threads);
     auto &predictions = out_preds->predictions.HostVector();
@@ -284,17 +284,17 @@ class CPUPredictor : public Predictor {
     InitThreadTemp(threads, model.learner_model_param->num_feature, &thread_temp);
     size_t constexpr kUnroll = 8;
     PredictBatchKernel(AdapterView<Adapter, kUnroll>(
-                           &m, missing, common::Span<Entry>{workspace}),
+                           m.get(), missing, common::Span<Entry>{workspace}),
                        &predictions, model, tree_begin, tree_end, &thread_temp);
   }
 
   void InplacePredict(dmlc::any const &x, const gbm::GBTreeModel &model,
                       float missing, PredictionCacheEntry *out_preds,
                       uint32_t tree_begin, unsigned tree_end) const override {
-    if (x.type() == typeid(data::DenseAdapter)) {
+    if (x.type() == typeid(std::shared_ptr<data::DenseAdapter>)) {
       this->DispatchedInplacePredict<data::DenseAdapter>(
           x, model, missing, out_preds, tree_begin, tree_end);
-    } else if (x.type() == typeid(data::CSRAdapter)) {
+    } else if (x.type() == typeid(std::shared_ptr<data::CSRAdapter>)) {
       this->DispatchedInplacePredict<data::CSRAdapter>(
           x, model, missing, out_preds, tree_begin, tree_end);
     } else {

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -118,14 +118,18 @@ struct EllpackLoader {
   }
 };
 
-struct CuPyAdapterLoader {
-  data::CupyAdapterBatch batch;
+template <typename Batch>
+struct DeviceAdapterLoader {
+  Batch batch;
   bst_feature_t columns;
   float* smem;
   bool use_shared;
 
-  DEV_INLINE CuPyAdapterLoader(data::CupyAdapterBatch const batch, bool use_shared,
-                               bst_feature_t num_features, bst_row_t num_rows, size_t entry_start) :
+  using BatchT = Batch;
+
+  DEV_INLINE DeviceAdapterLoader(Batch const batch, bool use_shared,
+                                 bst_feature_t num_features, bst_row_t num_rows,
+                                 size_t entry_start) :
     batch{batch},
     columns{num_features},
     use_shared{use_shared} {
@@ -152,39 +156,6 @@ struct CuPyAdapterLoader {
       return smem[threadIdx.x * columns + fidx];
     }
     return batch.GetElement(ridx * columns + fidx).value;
-  }
-};
-
-struct CuDFAdapterLoader {
-  data::CudfAdapterBatch batch;
-  bst_feature_t columns;
-  float* smem;
-  bool use_shared;
-
-  DEV_INLINE CuDFAdapterLoader(data::CudfAdapterBatch const batch, bool use_shared,
-                               bst_feature_t num_features,
-                               bst_row_t num_rows, size_t entry_start)
-      : batch{batch}, columns{num_features}, use_shared{use_shared} {
-    extern __shared__ float _smem[];
-    smem = _smem;
-    if (use_shared) {
-      uint32_t global_idx = blockDim.x * blockIdx.x + threadIdx.x;
-      size_t shared_elements = blockDim.x * num_features;
-      dh::BlockFill(smem, shared_elements, nanf(""));
-      __syncthreads();
-      if (global_idx < num_rows) {
-        for (size_t i = 0; i < columns; ++i) {
-          smem[threadIdx.x * columns + i] = batch.GetValue(global_idx, i);
-        }
-      }
-    }
-    __syncthreads();
-  }
-  DEV_INLINE float GetFvalue(bst_row_t ridx, bst_feature_t fidx) const {
-    if (use_shared) {
-      return smem[threadIdx.x * columns + fidx];
-    }
-    return batch.GetValue(ridx, fidx);
   }
 };
 
@@ -429,7 +400,7 @@ class GPUPredictor : public xgboost::Predictor {
           out_preds->Size() == dmat->Info().num_row_);
   }
 
-  template <typename Adapter, typename Loader, typename Batch>
+  template <typename Adapter, typename Loader>
   void DispatchedInplacePredict(dmlc::any const &x,
                                 const gbm::GBTreeModel &model, float missing,
                                 PredictionCacheEntry *out_preds,
@@ -439,22 +410,22 @@ class GPUPredictor : public xgboost::Predictor {
     DeviceModel d_model;
     d_model.Init(model, tree_begin, tree_end, this->generic_param_->gpu_id);
 
-    auto m = dmlc::get<Adapter>(x);
-    CHECK_EQ(m.NumColumns(), model.learner_model_param->num_feature)
+    auto m = dmlc::get<std::shared_ptr<Adapter>>(x);
+    CHECK_EQ(m->NumColumns(), model.learner_model_param->num_feature)
         << "Number of columns in data must equal to trained model.";
-    CHECK_EQ(this->generic_param_->gpu_id, m.DeviceIdx())
+    CHECK_EQ(this->generic_param_->gpu_id, m->DeviceIdx())
         << "XGBoost is running on device: " << this->generic_param_->gpu_id << ", "
-        << "but data is on: " << m.DeviceIdx();
+        << "but data is on: " << m->DeviceIdx();
     MetaInfo info;
-    info.num_col_ = m.NumColumns();
-    info.num_row_ = m.NumRows();
+    info.num_col_ = m->NumColumns();
+    info.num_row_ = m->NumRows();
     this->InitOutPredictions(info, &(out_preds->predictions), model);
 
     const uint32_t BLOCK_THREADS = 128;
     auto GRID_SIZE = static_cast<uint32_t>(common::DivRoundUp(info.num_row_, BLOCK_THREADS));
 
     auto shared_memory_bytes =
-        static_cast<size_t>(sizeof(float) * m.NumColumns() * BLOCK_THREADS);
+        static_cast<size_t>(sizeof(float) * m->NumColumns() * BLOCK_THREADS);
     bool use_shared = true;
     if (shared_memory_bytes > max_shared_memory_bytes) {
       shared_memory_bytes = 0;
@@ -463,22 +434,24 @@ class GPUPredictor : public xgboost::Predictor {
     size_t entry_start = 0;
 
     dh::LaunchKernel {GRID_SIZE, BLOCK_THREADS, shared_memory_bytes} (
-        PredictKernel<Loader, Batch>,
-        m.Value(),
+        PredictKernel<Loader, typename Loader::BatchT>,
+        m->Value(),
         dh::ToSpan(d_model.nodes), out_preds->predictions.DeviceSpan(),
         dh::ToSpan(d_model.tree_segments), dh::ToSpan(d_model.tree_group),
-        tree_begin, tree_end, m.NumColumns(), info.num_row_,
+        tree_begin, tree_end, m->NumColumns(), info.num_row_,
         entry_start, use_shared, output_groups);
   }
 
   void InplacePredict(dmlc::any const &x, const gbm::GBTreeModel &model,
                       float missing, PredictionCacheEntry *out_preds,
                       uint32_t tree_begin, unsigned tree_end) const override {
-    if (x.type() == typeid(data::CupyAdapter)) {
-      this->DispatchedInplacePredict<data::CupyAdapter, CuPyAdapterLoader, data::CupyAdapterBatch>(
+    if (x.type() == typeid(std::shared_ptr<data::CupyAdapter>)) {
+      this->DispatchedInplacePredict<
+          data::CupyAdapter, DeviceAdapterLoader<data::CupyAdapterBatch>>(
           x, model, missing, out_preds, tree_begin, tree_end);
-    } else if (x.type() == typeid(data::CudfAdapter)) {
-      this->DispatchedInplacePredict<data::CudfAdapter, CuDFAdapterLoader, data::CudfAdapterBatch>(
+    } else if (x.type() == typeid(std::shared_ptr<data::CudfAdapter>)) {
+      this->DispatchedInplacePredict<
+          data::CudfAdapter, DeviceAdapterLoader<data::CudfAdapterBatch>>(
           x, model, missing, out_preds, tree_begin, tree_end);
     } else {
       LOG(FATAL) << "Only CuPy and CuDF are supported by GPU Predictor.";

--- a/tests/cpp/data/test_device_adapter.cu
+++ b/tests/cpp/data/test_device_adapter.cu
@@ -36,13 +36,12 @@ void TestCudfAdapter()
   EXPECT_NO_THROW({
     dh::LaunchN(0, batch.Size(), [=] __device__(size_t idx) {
       auto element = batch.GetElement(idx);
-      if (idx < kRowsA) {
+      KERNEL_CHECK(element.row_idx == idx / 2);
+      if (idx % 2 == 0) {
         KERNEL_CHECK(element.column_idx == 0);
-        KERNEL_CHECK(element.row_idx == idx);
         KERNEL_CHECK(element.value == element.row_idx * 2.0f);
       } else {
         KERNEL_CHECK(element.column_idx == 1);
-        KERNEL_CHECK(element.row_idx == idx - kRowsA);
         KERNEL_CHECK(element.value == element.row_idx * 2.0f);
       }
     });

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -149,7 +149,7 @@ TEST(CpuPredictor, InplacePredict) {
     HostDeviceVector<float> data;
     gen.GenerateDense(&data);
     ASSERT_EQ(data.Size(), kRows * kCols);
-    data::DenseAdapter x{data.HostPointer(), kRows, kCols};
+    auto x = std::make_shared<data::DenseAdapter>(data.HostPointer(), kRows, kCols);
     TestInplacePrediction(x, "cpu_predictor", kRows, kCols, -1);
   }
 
@@ -158,8 +158,9 @@ TEST(CpuPredictor, InplacePredict) {
     HostDeviceVector<bst_row_t> rptrs;
     HostDeviceVector<bst_feature_t> columns;
     gen.GenerateCSR(&data, &rptrs, &columns);
-    data::CSRAdapter x(rptrs.HostPointer(), columns.HostPointer(),
-                       data.HostPointer(), kRows, data.Size(), kCols);
+    auto x = std::make_shared<data::CSRAdapter>(
+        rptrs.HostPointer(), columns.HostPointer(), data.HostPointer(), kRows,
+        data.Size(), kCols);
     TestInplacePrediction(x, "cpu_predictor", kRows, kCols, -1);
   }
 }

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -149,7 +149,8 @@ TEST(CpuPredictor, InplacePredict) {
     HostDeviceVector<float> data;
     gen.GenerateDense(&data);
     ASSERT_EQ(data.Size(), kRows * kCols);
-    auto x = std::make_shared<data::DenseAdapter>(data.HostPointer(), kRows, kCols);
+    std::shared_ptr<data::DenseAdapter> x{
+      new data::DenseAdapter(data.HostPointer(), kRows, kCols)};
     TestInplacePrediction(x, "cpu_predictor", kRows, kCols, -1);
   }
 
@@ -158,9 +159,9 @@ TEST(CpuPredictor, InplacePredict) {
     HostDeviceVector<bst_row_t> rptrs;
     HostDeviceVector<bst_feature_t> columns;
     gen.GenerateCSR(&data, &rptrs, &columns);
-    auto x = std::make_shared<data::CSRAdapter>(
+    std::shared_ptr<data::CSRAdapter> x{new data::CSRAdapter(
         rptrs.HostPointer(), columns.HostPointer(), data.HostPointer(), kRows,
-        data.Size(), kCols);
+        data.Size(), kCols)};
     TestInplacePrediction(x, "cpu_predictor", kRows, kCols, -1);
   }
 }

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -129,7 +129,7 @@ TEST(GPUPredictor, InplacePredictCupy) {
   gen.Device(0);
   HostDeviceVector<float> data;
   std::string interface_str = gen.GenerateArrayInterface(&data);
-  data::CupyAdapter x{interface_str};
+  auto x = std::make_shared<data::CupyAdapter>(interface_str);
   TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 0);
 }
 
@@ -139,7 +139,7 @@ TEST(GPUPredictor, InplacePredictCuDF) {
   gen.Device(0);
   std::vector<HostDeviceVector<float>> storage(kCols);
   auto interface_str = gen.GenerateColumnarArrayInterface(&storage);
-  data::CudfAdapter x {interface_str};
+  auto x = std::make_shared<data::CudfAdapter>(interface_str);
   TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 0);
 }
 
@@ -154,7 +154,7 @@ TEST(GPUPredictor, MGPU_InplacePredict) {  // NOLINT
   gen.Device(1);
   HostDeviceVector<float> data;
   std::string interface_str = gen.GenerateArrayInterface(&data);
-  data::CupyAdapter x{interface_str};
+  auto x = std::make_shared<data::CupyAdapter>(interface_str);
   TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 1);
   EXPECT_THROW(TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 0),
                dmlc::Error);


### PR DESCRIPTION
As cuDF is actually dense data, removing all the specializations.

* Use shared pointer for inplace prediction.  Using `dmlc::any` with `ArrayInterface` might lead to some subtle bugs as `dmlc::any` needs to copy the underlying value, while `ArrayInterface` contains stack allocated memory `char type[3]`.