### PR TITLE
Softmax hess fix

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,8 @@ Committers are people who have made substantial contribution to the project and 
   - Sergei is a software engineer in Criteo. He contributed mostly in JVM packages.
 * [Scott Lundberg](http://scottlundberg.com/), University of Washington
   - Scott is a Ph.D. student at University of Washington. He is the creator of SHAP, a unified approach to explain the output of machine learning models such as decision tree ensembles. He also helps maintain the XGBoost Julia package.
+* [Egor Smirnov](https://github.com/SmirnovEgorRu), Intel
+  - Egor has led a major effort to improve the performance of XGBoost on multi-core CPUs.
 
 
 Become a Committer

--- a/src/objective/multiclass_obj.cu
+++ b/src/objective/multiclass_obj.cu
@@ -102,7 +102,7 @@ class SoftmaxMultiClassObj : public ObjFunction {
             // Computation duplicated to avoid creating a cache.
             bst_float p = expf(point[k] - wmax) / static_cast<float>(wsum);
             const float eps = 1e-16f;
-            const bst_float h = fmax(2.0f * p * (1.0f - p) * wt, eps);
+            const bst_float h = fmax(p * (1.0f - p) * wt, eps);
             p = label == k ? p - 1.0f : p;
             gpair[idx * nclass + k] = GradientPair(p * wt, h);
           }


### PR DESCRIPTION
Addresses Issue #5769. Just need to remove the `2.0f` and the hessian calculation should be correct.