### PR TITLE
Added conda environment file for building docs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,3 +6,4 @@ sh>=1.12.14
 matplotlib>=2.1
 graphviz
 numpy
+recommonmark

--- a/doc/xgboost_doc.yml
+++ b/doc/xgboost_doc.yml
@@ -1,0 +1,15 @@
+name: xgboost_docs
+dependencies:
+  - python
+  - pip
+  - pygraphviz
+  - sphinx
+  - recommonmark
+  - mock
+  - sh
+  - matplotlib
+  - pip:
+    - breathe
+    - guzzle_sphinx_theme
+    - pydot-ng
+    - graphviz


### PR DESCRIPTION
The formatting for the R package docs is [broken](https://xgboost.readthedocs.io/en/latest/R-package/xgboostPresentation.html), as mentioned in #5293. I want to work on fixing this. To get started, I followed the [instructions for building the docs](https://xgboost.readthedocs.io/en/latest/R-package/xgboostPresentation.html). I had a few issues getting the dependencies installed correctly, and figured I would share my conda environment to make building the docs easier.

If this PR is accepted, I can update the instructions to mention how to use this environment file to install the dependencies for the docs. I will likely address the issues with the R package formatting in the original issue as well.