### PR TITLE
[jvm-packages] Switch Task mode to OpenMP mode after data conversion

### DIFF
--- a/doc/jvm/xgboost4j_spark_tutorial.rst
+++ b/doc/jvm/xgboost4j_spark_tutorial.rst
@@ -492,10 +492,11 @@ This parameter controls how many parallel workers we want to have when training 
   By default, we allocate a core per each XGBoost worker. Therefore, the OpenMP optimization within each XGBoost worker does not take effect and the parallelization of training is achieved
   by running multiple workers (i.e. Spark tasks) at the same time.
 
-  If you do want OpenMP optimization, you have to
+  On the other hand, OpenMP parallelization can improve performance for training tasks on CPUs, especially when using large datasets. If you do want OpenMP parallelization, you can
 
   1. set ``nthread`` to a value larger than 1 when creating XGBoostClassifier/XGBoostRegressor
-  2. set ``spark.task.cpus`` in Spark to the same value as ``nthread``
+  2. set ``spark.executor.cores`` in Spark to the same value as ``nthread``
+  3. set ``spark.task.cpus`` in Spark to 1.
 
 Gang Scheduling
 ===============

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -364,6 +364,20 @@ XGB_DLL int XGDMatrixSliceDMatrixEx(DMatrixHandle handle,
                                     bst_ulong len,
                                     DMatrixHandle *out,
                                     int allow_groups);
+
+
+/*!
+ * \brief combine right dmatrix into left, return the left
+ * \param handle_left instance of data matrix to be merged into
+ * \param handle right instance of data matrix to be merged
+ * \param out the left instance of data matrix
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixCombineDMatrix(DMatrixHandle handle_left,
+                                  DMatrixHandle handle_right,
+                                  uint64_t total_size,
+                                  DMatrixHandle* out);
+
 /*!
  * \brief free space in data matrix
  * \return 0 when success, -1 when failure happens

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -569,6 +569,14 @@ XGB_DLL int XGDMatrixGetUIntInfo(const DMatrixHandle handle,
 XGB_DLL int XGDMatrixNumRow(DMatrixHandle handle,
                             bst_ulong *out);
 /*!
+ * \brief get data vector size.
+ * \param handle the handle to the DMatrix
+ * \param out The address to hold data vector size
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixDataVecSize(DMatrixHandle handle,
+                            bst_ulong *out);
+/*!
  * \brief get number of columns
  * \param handle the handle to the DMatrix
  * \param out The output of number of columns

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -187,7 +187,8 @@ struct Entry {
   /*! \brief feature value */
   bst_float fvalue;
   /*! \brief default constructor */
-  Entry(){};
+  Entry() {
+  }
   /*!
    * \brief constructor with index and value
    * \param index The feature or row index.

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -187,8 +187,7 @@ struct Entry {
   /*! \brief feature value */
   bst_float fvalue;
   /*! \brief default constructor */
-  Entry() {
-  }
+  Entry() = default;
   /*!
    * \brief constructor with index and value
    * \param index The feature or row index.

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -187,7 +187,7 @@ struct Entry {
   /*! \brief feature value */
   bst_float fvalue;
   /*! \brief default constructor */
-  Entry() = default;
+  Entry(){};
   /*!
    * \brief constructor with index and value
    * \param index The feature or row index.
@@ -549,6 +549,11 @@ class DMatrix {
                          int max_bin);
 
   virtual DMatrix *Slice(common::Span<int32_t const> ridxs) = 0;
+  virtual DMatrix* Combine(DMatrix* right, uint64_t total_size) {
+    CHECK(false) << " this type of DMatrix not supported";
+    return this;
+  }
+
   /*! \brief page size 32 MB */
   static const size_t kPageSize = 32UL << 20UL;
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/DataUtils.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/DataUtils.scala
@@ -92,10 +92,15 @@ object DataUtils extends Serializable {
       }
     } else {
       arrayOfRDDs.map(rdd => {
-        if (rdd.getNumPartitions % numWorkers != 0 ) {
-          val partitions = rdd.getNumPartitions +
-            numWorkers - (rdd.getNumPartitions % numWorkers)
-          rdd.map(_._2).repartition(partitions)
+        val nPartitions = if (rdd.sparkContext.isLocal) numWorkers else {
+          if (rdd.getNumPartitions % numWorkers != 0) {
+            rdd.getNumPartitions + numWorkers - (rdd.getNumPartitions % numWorkers)
+          } else {
+            rdd.getNumPartitions
+          }
+        }
+        if (rdd.getNumPartitions != nPartitions) {
+          rdd.map(_._2).repartition(nPartitions)
         } else {
           rdd.map(_._2)
         }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/DataUtils.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/DataUtils.scala
@@ -92,8 +92,10 @@ object DataUtils extends Serializable {
       }
     } else {
       arrayOfRDDs.map(rdd => {
-        if (rdd.getNumPartitions != numWorkers) {
-          rdd.map(_._2).repartition(numWorkers)
+        if (rdd.getNumPartitions % numWorkers != 0 ) {
+          val partitions = rdd.getNumPartitions +
+            numWorkers - (rdd.getNumPartitions % numWorkers)
+          rdd.map(_._2).repartition(partitions)
         } else {
           rdd.map(_._2)
         }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -35,6 +35,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.{SparkContext, SparkParallelismTracker, TaskContext, TaskFailedListener}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.rdd.ExecutorInProcessCoalescePartitioner
 
 
 /**
@@ -133,13 +134,13 @@ private[this] class XGBoostExecutionParamsFactory(rawParams: Map[String, Any], s
   private def overrideParams(
       params: Map[String, Any],
       sc: SparkContext): Map[String, Any] = {
-    val coresPerTask = sc.getConf.getInt("spark.task.cpus", 1)
+    val coresPerTask = sc.getConf.getInt("spark.executor.cores", 1)
     var overridedParams = params
     if (overridedParams.contains("nthread")) {
       val nThread = overridedParams("nthread").toString.toInt
-      require(nThread <= coresPerTask,
-        s"the nthread configuration ($nThread) must be no larger than " +
-          s"spark.task.cpus ($coresPerTask)")
+//      require(nThread <= coresPerTask,
+//        s"the nthread configuration ($nThread) must be no larger than " +
+//          s"spark.task.cpus ($coresPerTask)")
     } else {
       overridedParams = overridedParams + ("nthread" -> coresPerTask)
     }
@@ -405,14 +406,15 @@ object XGBoost extends Serializable {
         logger.info("Leveraging gpu device " + gpuId + " to train")
         params = params + ("gpu_id" -> gpuId)
       }
+      val watchesmap = watches.toMap
       val booster = if (makeCheckpoint) {
         SXGBoost.trainAndSaveCheckpoint(
-          watches.toMap("train"), params, numRounds,
-          watches.toMap, metrics, obj, eval,
+          watchesmap("train"), params, numRounds,
+          watchesmap, metrics, obj, eval,
           earlyStoppingRound = numEarlyStoppingRounds, prevBooster, externalCheckpointParams)
       } else {
-        SXGBoost.train(watches.toMap("train"), params, numRounds,
-          watches.toMap, metrics, obj, eval,
+        SXGBoost.train(watchesmap("train"), params, numRounds,
+          watchesmap, metrics, obj, eval,
           earlyStoppingRound = numEarlyStoppingRounds, prevBooster)
       }
       Iterator(booster -> watches.toMap.keys.zip(metrics).toMap)
@@ -490,11 +492,47 @@ object XGBoost extends Serializable {
       prevBooster: Booster,
       evalSetsMap: Map[String, RDD[XGBLabeledPoint]]): RDD[(Booster, Map[String, Array[Float]])] = {
     if (evalSetsMap.isEmpty) {
-      trainingData.mapPartitions(labeledPoints => {
+      val watchrdd = trainingData.mapPartitions(labeledPoints => {
         val watches = Watches.buildWatches(xgbExecutionParams,
           processMissingValues(labeledPoints, xgbExecutionParams.missing,
             xgbExecutionParams.allowNonZeroForMissing),
           getCacheDirName(xgbExecutionParams.useExternalMemory))
+        Iterator(watches)
+      }).filter( watches => {
+        val tomap = watches.toMap
+        if (tomap.size == 0) {
+          watches.delete()
+        }
+        tomap.size>0
+      }).cache()
+
+      watchrdd.foreachPartition(() => _)
+      watchrdd.count()
+
+      val iscls = watchrdd.sparkContext.getConf.getInt("spark.xgboost.coalesce", 0)
+      val coalescedrdd = if ( iscls==0 ) watchrdd else watchrdd.coalesce(1,
+          partitionCoalescer = Some(new ExecutorInProcessCoalescePartitioner()))
+
+      val reducedrdd = coalescedrdd.mapPartitions { iter =>
+          val totalsize = iter.foldLeft(Map("train" -> 0L, "test" -> 0L)) {
+           (l, r) =>
+             val merged = l.toSeq ++ r.rowNumMap.toSeq
+             merged.groupBy(_._1).mapValues(_.map(_._2).sum)
+          }
+          totalsize.foreach( iter => System.out.println("xgbtck reduce_total "
+            + iter._1 + " " + iter._2 ))
+          Iterator( iter.reduce { (l, r) =>
+            val rst = l.combine(r, totalsize)
+            l.delete()
+            r.delete()
+            rst
+            }
+            )}.cache()
+//      reducedrdd.foreachPartition(() => _)
+      watchrdd.unpersist()
+
+      reducedrdd.mapPartitions(iter => {
+        val watches = iter.next
         buildDistributedBooster(watches, xgbExecutionParams, rabitEnv, xgbExecutionParams.obj,
           xgbExecutionParams.eval, prevBooster)
       }).cache()
@@ -751,17 +789,34 @@ private class Watches private(
     val names: Array[String],
     val cacheDirName: Option[String]) {
 
-  def toMap: Map[String, DMatrix] = {
+  val toMap: Map[String, DMatrix] = {
     names.zip(datasets).toMap.filter { case (_, matrix) => matrix.rowNum > 0 }
   }
 
-  def size: Int = toMap.size
+  val rowNumMap: Map[String, Long] = {
+    toMap.map{ case (key, matrix) => (key, matrix.rowNum) }
+  }
+
+  val size: Int = toMap.size
 
   def delete(): Unit = {
-    toMap.values.foreach(_.delete())
+    datasets.foreach(_.delete())
     cacheDirName.foreach { name =>
       FileUtils.deleteDirectory(new File(name))
     }
+  }
+
+  def combine(rightWatches: Watches, rowMap: Map[String, Long]): Watches = {
+
+    val namemap = rightWatches.toMap
+    val result = toMap.map( ndpair => {
+      ndpair._2.combine(namemap(ndpair._1), rowMap(ndpair._1))
+    }).toArray
+    return new Watches(result, toMap.keys.toArray, cacheDirName)
+  }
+
+  def trainSize(): Seq[Long] = {
+    Seq(toMap("train").rowNum, toMap("test").rowNum)
   }
 
   override def toString: String = toMap.toString

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -517,7 +517,7 @@ object XGBoost extends Serializable {
           val matcharr = iter.toArray
           val totalsize = matcharr.foldLeft(Map("train" -> 0L, "test" -> 0L)) {
            (l, r) =>
-             val merged = l.toSeq ++ r.rowNumMap.toSeq
+             val merged = l.toSeq ++ r.dataVecSizeMap.toSeq
              merged.groupBy(_._1).mapValues(_.map(_._2).sum)
           }
           totalsize.foreach( iter => System.out.println("xgbtck reduce_total "
@@ -795,8 +795,8 @@ private class Watches private(
     names.zip(datasets).toMap.filter { case (_, matrix) => matrix.rowNum > 0 }
   }
 
-  val rowNumMap: Map[String, Long] = {
-    toMap.map{ case (key, matrix) => (key, matrix.rowNum) }
+  val dataVecSizeMap: Map[String, Long] = {
+    toMap.map{ case (key, matrix) => (key, matrix.dataVecSize) }
   }
 
   val size: Int = toMap.size

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -136,11 +136,8 @@ private[this] class XGBoostExecutionParamsFactory(rawParams: Map[String, Any], s
       params: Map[String, Any],
       sc: SparkContext): Map[String, Any] = {
     val coresPerTask = sc.getConf.getInt("spark.executor.cores", 1)
-    val cpusPerTask = sc.getConf.getInt("spark.task.cpus", 1)
     var overridedParams = params
-    if (isLocal) {
-      overridedParams = overridedParams + ("nthread" -> cpusPerTask)
-    } else if (overridedParams.contains("nthread")) {
+    if (overridedParams.contains("nthread")) {
       val nThread = overridedParams("nthread").toString.toInt
       require(nThread <= coresPerTask,
         s"the nthread configuration ($nThread) must be no larger than " +
@@ -520,23 +517,15 @@ object XGBoost extends Serializable {
           throw new XGBoostError("Building watches failed")
       }
 
-      if (xgbExecutionParams.isLocal) {
-        watchrdd.mapPartitions(iter => {
-          val watches = iter.next
-          buildDistributedBooster(watches, xgbExecutionParams, rabitEnv, xgbExecutionParams.obj,
-            xgbExecutionParams.eval, prevBooster)
-        }).cache()
-      } else {
-        val reducedrdd = processWatchesRDD(watchrdd, xgbExecutionParams.numWorkers).cache()
-        reducedrdd.count()
-        watchrdd.unpersist()
+      val reducedrdd = processWatchesRDD(watchrdd, xgbExecutionParams.numWorkers).cache()
+      reducedrdd.count()
+      watchrdd.unpersist()
 
-        reducedrdd.mapPartitions(iter => {
-          val watches = iter.next
-          buildDistributedBooster(watches, xgbExecutionParams, rabitEnv, xgbExecutionParams.obj,
-            xgbExecutionParams.eval, prevBooster)
-        }).cache()
-      }
+      reducedrdd.mapPartitions(iter => {
+        val watches = iter.next
+        buildDistributedBooster(watches, xgbExecutionParams, rabitEnv, xgbExecutionParams.obj,
+          xgbExecutionParams.eval, prevBooster)
+      }).cache()
     } else {
       val nPartitions = if (xgbExecutionParams.isLocal) {
         xgbExecutionParams.numWorkers
@@ -569,23 +558,15 @@ object XGBoost extends Serializable {
           throw new XGBoostError("Building watches failed")
       }
 
-      if (xgbExecutionParams.isLocal) {
-        watchrdd.mapPartitions(iter => {
-          val watches = iter.next
-          buildDistributedBooster(watches, xgbExecutionParams, rabitEnv, xgbExecutionParams.obj,
-            xgbExecutionParams.eval, prevBooster)
-        }).cache()
-      } else {
-        val reducedrdd = processWatchesRDD(watchrdd, xgbExecutionParams.numWorkers).cache()
-        reducedrdd.count()
-        watchrdd.unpersist()
+      val reducedrdd = processWatchesRDD(watchrdd, xgbExecutionParams.numWorkers).cache()
+      reducedrdd.count()
+      watchrdd.unpersist()
 
-        reducedrdd.mapPartitions(iter => {
-          val watches = iter.next
-          buildDistributedBooster(watches, xgbExecutionParams, rabitEnv, xgbExecutionParams.obj,
-            xgbExecutionParams.eval, prevBooster)
-        }).cache()
-      }
+      reducedrdd.mapPartitions(iter => {
+        val watches = iter.next
+        buildDistributedBooster(watches, xgbExecutionParams, rabitEnv, xgbExecutionParams.obj,
+          xgbExecutionParams.eval, prevBooster)
+      }).cache()
     }
   }
 
@@ -622,22 +603,26 @@ object XGBoost extends Serializable {
   }
 
   private def processWatchesRDD(watchrdd: RDD[Watches], numWorkers: Int): RDD[Watches] = {
-    val coalescedrdd = watchrdd.coalesce(1,
+    if (watchrdd.sparkContext.isLocal) {
+      watchrdd.coalesce(numWorkers)
+    } else {
+      val coalescedrdd = watchrdd.coalesce(1,
         partitionCoalescer = Some(new ExecutorInProcessCoalescePartitioner()))
-    coalescedrdd.mapPartitions { iter =>
-        val matcharr = iter.toArray
-        val totalsize = matcharr.foldLeft(Map("train" -> 0L)) {
-           (l, r) => {
-             val merged = l.toSeq ++ r.dataVecSizeMap.toSeq
-             merged.groupBy(_._1).mapValues(_.map(_._2).sum)
-           }
-        }
-        Iterator( matcharr.reduce { (l, r) =>
-          val rst = l.combineDMatrix(r, totalsize)
-          l.delete()
-          r.delete()
-          rst
-       })
+      coalescedrdd.mapPartitions { iter =>
+          val matcharr = iter.toArray
+          val totalsize = matcharr.foldLeft(Map("train" -> 0L)) {
+             (l, r) => {
+               val merged = l.toSeq ++ r.dataVecSizeMap.toSeq
+               merged.groupBy(_._1).mapValues(_.map(_._2).sum)
+             }
+          }
+          Iterator( matcharr.reduce { (l, r) =>
+            val rst = l.combineDMatrix(r, totalsize)
+            l.delete()
+            r.delete()
+            rst
+         })
+      }
     }
   }
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -508,8 +508,14 @@ object XGBoost extends Serializable {
         tomap.size>0
       }).cache()
 
-      watchrdd.foreachPartition(() => _)
-      watchrdd.count()
+      try {
+        watchrdd.foreachPartition(() => _)
+        watchrdd.count()
+      } catch {
+        case t: Throwable =>
+          logger.error("building watches failed due to ", t)
+          throw new XGBoostError("Building watches failed")
+      }
       val reducedrdd = processWatchesRDD(watchrdd, xgbExecutionParams.numWorkers).cache()
       watchrdd.unpersist()
 
@@ -537,8 +543,14 @@ object XGBoost extends Serializable {
             tomap.size>0
           }).cache()
 
-      watchrdd.foreachPartition(() => _)
-      watchrdd.count()
+      try {
+        watchrdd.foreachPartition(() => _)
+        watchrdd.count()
+      } catch {
+        case t: Throwable =>
+          logger.error("building watches failed due to ", t)
+          throw new XGBoostError("Building watches failed")
+      }
       val reducedrdd = processWatchesRDD(watchrdd, xgbExecutionParams.numWorkers).cache()
       watchrdd.unpersist()
 

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -517,7 +517,7 @@ object XGBoost extends Serializable {
           throw new XGBoostError("Building watches failed")
       }
       val reducedrdd = processWatchesRDD(watchrdd, xgbExecutionParams.numWorkers).cache()
-      watchrdd.unpersist()
+      // watchrdd.unpersist()
 
       reducedrdd.mapPartitions(iter => {
         val watches = iter.next
@@ -552,7 +552,7 @@ object XGBoost extends Serializable {
           throw new XGBoostError("Building watches failed")
       }
       val reducedrdd = processWatchesRDD(watchrdd, xgbExecutionParams.numWorkers).cache()
-      watchrdd.unpersist()
+      // watchrdd.unpersist()
 
       reducedrdd.mapPartitions(iter => {
         val watches = iter.next
@@ -598,9 +598,7 @@ object XGBoost extends Serializable {
     val coalescedrdd = watchrdd.coalesce(1,
         partitionCoalescer = Some(new ExecutorInProcessCoalescePartitioner()))
     if (coalescedrdd.getNumPartitions < numWorkers) {
-      logger.info("ExecutorInProcessCoalesce fails to create enough partitions. " +
-        "Fall back to regular coalesce.")
-      watchrdd.coalesce(numWorkers)
+      watchrdd
     } else {
       coalescedrdd.mapPartitions { iter =>
           val matcharr = iter.toArray

--- a/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/rdd/ExecutorInProcessCoalescePartitioner.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/rdd/ExecutorInProcessCoalescePartitioner.scala
@@ -1,0 +1,80 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import org.apache.commons.logging.LogFactory
+
+import org.apache.spark.Partition
+import org.apache.spark.SparkException
+import org.apache.spark.scheduler.ExecutorCacheTaskLocation
+import org.apache.spark.scheduler.TaskLocation
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+class ExecutorInProcessCoalescePartitioner(val balanceSlack: Double = 0.10)
+  extends PartitionCoalescer with Serializable {
+  private val logger = LogFactory.getLog("ExecutorInProcessCoalescePartitioner")
+
+  def coalesce(maxPartitions: Int, prev: RDD[_]): Array[PartitionGroup] = {
+    val map = new mutable.HashMap[String, mutable.HashSet[Partition]]()
+
+    // System.out.println("xgbtck rddname " + prev.getClass.getName
+    //  + "\n " + prev.toDebugString)
+    // System.out.println("xgbtck rddname " + prev.prev().getClass.getName)
+    // System.out.println("xgbtck rddname " + prev.prev().prev().getClass.getName)
+
+    val groupArr = ArrayBuffer[PartitionGroup]()
+    prev.partitions.foreach(p => {
+      val loc = prev.context.getPreferredLocs(prev, p.index)
+      loc.foreach{
+      case location : ExecutorCacheTaskLocation =>
+        // System.out.println("xgbtck partitionloc " + location.getClass.getName)
+        val execLoc = "executor_" + location.host + "_" + location.executorId
+        val partValue = map.getOrElse(execLoc, new mutable.HashSet[Partition]())
+        partValue.add(p)
+        map.put(execLoc, partValue)
+        // System.out.println("xgbtck coalescePartitioner partid"
+        //  +  String.valueOf(p.index)
+        //  + " location = " + execLoc)
+
+      case loc : TaskLocation =>
+        System.out.println("xgbtck partitionloc " + loc.getClass.getName)
+        System.out.println("xgbtck partitionloc " + loc.host)
+        logger.error("Invalid location : ")
+      }
+    })
+    map.foreach(x => {
+      val pg = new PartitionGroup(Some(x._1))
+      val list = x._2.toList.sortWith(_.index < _.index);
+      list.foreach(part => pg.partitions += part)
+      groupArr += pg
+    })
+    if (groupArr.length == 0) throw new SparkException("No partitions or" +
+      " no locations for partitions found.")
+
+    val sortedGroupArr = groupArr.sortWith(_.partitions(0).index < _.partitions(0).index)
+
+    sortedGroupArr.foreach(pg => {
+      System.out.print(" xgbtck executorcoalesce " + pg.prefLoc + " : ")
+      pg.partitions.foreach(part => System.out.print(String.valueOf(part.index) + " "))
+      System.out.print("\n")
+    })
+    return sortedGroupArr.toArray
+  }
+}
+

--- a/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/rdd/ExecutorInProcessCoalescePartitioner.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/rdd/ExecutorInProcessCoalescePartitioner.scala
@@ -26,11 +26,10 @@ import org.apache.spark.scheduler.TaskLocation
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-class ExecutorInProcessCoalescePartitioner(val balanceSlack: Double = 0.10)
-  extends PartitionCoalescer with Serializable {
+class ExecutorInProcessCoalescePartitioner() extends PartitionCoalescer with Serializable {
   private val logger = LogFactory.getLog("ExecutorInProcessCoalescePartitioner")
 
-  def coalesce(maxPartitions: Int, prev: RDD[_]): Array[PartitionGroup] = {
+  override def coalesce(maxPartitions: Int, prev: RDD[_]): Array[PartitionGroup] = {
     val map = new mutable.HashMap[String, mutable.HashSet[Partition]]()
 
     // System.out.println("xgbtck rddname " + prev.getClass.getName
@@ -53,9 +52,8 @@ class ExecutorInProcessCoalescePartitioner(val balanceSlack: Double = 0.10)
         //  + " location = " + execLoc)
 
       case loc : TaskLocation =>
-        System.out.println("xgbtck partitionloc " + loc.getClass.getName)
-        System.out.println("xgbtck partitionloc " + loc.host)
-        logger.error("Invalid location : ")
+        throw new SparkException("Invalid partition location: " +
+          loc.getClass.getName + loc.host)
       }
     })
     map.foreach(x => {

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostConfigureSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostConfigureSuite.scala
@@ -29,15 +29,19 @@ class XGBoostConfigureSuite extends FunSuite with PerTest {
       .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .config("spark.kryo.classesToRegister", classOf[Booster].getName)
 
-  test("nthread configuration must be no larger than spark.task.cpus") {
-    val training = buildDataFrame(Classification.train)
-    val paramMap = Map("eta" -> "1", "max_depth" -> "2", "verbosity" -> "1",
-      "objective" -> "binary:logistic", "num_workers" -> numWorkers,
-      "nthread" -> (sc.getConf.getInt("spark.task.cpus", 1) + 1))
-    intercept[IllegalArgumentException] {
-      new XGBoostClassifier(paramMap ++ Seq("num_round" -> 2)).fit(training)
-    }
-  }
+  /*
+   * Disable this test because PR 5774 allows nthread to be larger than
+   * spark.task.cpus.
+   */
+  // test("nthread configuration must be no larger than spark.task.cpus") {
+  //   val training = buildDataFrame(Classification.train)
+  //   val paramMap = Map("eta" -> "1", "max_depth" -> "2", "verbosity" -> "1",
+  //     "objective" -> "binary:logistic", "num_workers" -> numWorkers,
+  //     "nthread" -> (sc.getConf.getInt("spark.task.cpus", 1) + 1))
+  //   intercept[IllegalArgumentException] {
+  //     new XGBoostClassifier(paramMap ++ Seq("num_round" -> 2)).fit(training)
+  //   }
+  // }
 
   test("kryoSerializer test") {
     // TODO write an isolated test for Booster.

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -326,6 +326,18 @@ public class DMatrix {
   }
 
   /**
+   * get the data vector size of DMatrix
+   *
+   * @return size of data vector
+   * @throws XGBoostError native error
+   */
+  public long dataVecSize() throws XGBoostError {
+    long[] size = new long[1];
+    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixDataVecSize(handle, size));
+    return size[0];
+  }
+  
+  /**
    * save DMatrix to filePath
    */
   public void saveBinary(String filePath) {

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -302,10 +302,6 @@ public class DMatrix {
     long[] out = new long[1];
     XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCombineDMatrix(handle, dmx.handle, totalSize, out));
     long sHandle = out[0];
-    System.out.println("xgbtck javacombin " + String.valueOf(handle)
-        + " " + String.valueOf(dmx.handle)
-        + " " + String.valueOf(sHandle));
-
     DMatrix sMatrix = new DMatrix(sHandle);
 
     // Release the right handler.

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -49,6 +49,7 @@ public class DMatrix {
     }
     // 32k as batch size
     int batchSize = 32 << 10;
+    // int batchSize = 719928/2;
     Iterator<DataBatch> batchIter = new DataBatch.BatchIterator(iter, batchSize);
     long[] out = new long[1];
     XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCreateFromDataIter(batchIter, cacheInfo, out));
@@ -336,7 +337,7 @@ public class DMatrix {
     XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixDataVecSize(handle, size));
     return size[0];
   }
-  
+
   /**
    * save DMatrix to filePath
    */

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -292,6 +292,28 @@ public class DMatrix {
   }
 
   /**
+   * Combine Two DMatrix into one
+   *
+   * @return combined DMatrix
+   * @throws XGBoostError native error
+   */
+  public DMatrix combine(DMatrix dmx, long totalSize) throws XGBoostError {
+    long[] out = new long[1];
+    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCombineDMatrix(handle, dmx.handle, totalSize, out));
+    long sHandle = out[0];
+    System.out.println("xgbtck javacombin " + String.valueOf(handle)
+        + " " + String.valueOf(dmx.handle)
+        + " " + String.valueOf(sHandle));
+
+    DMatrix sMatrix = new DMatrix(sHandle);
+
+    // Release the right handler.
+    // dmx.dispose();
+
+    return sMatrix;
+  }
+
+  /**
    * get the row number of DMatrix
    *
    * @return number of rows

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -87,6 +87,8 @@ class XGBoostJNI {
 
   public final static native int XGDMatrixNumRow(long handle, long[] row);
 
+  public final static native int XGDMatrixDataVecSize(long handle, long[] row);
+  
   public final static native int XGBoosterCreate(long[] handles, long[] out);
 
   public final static native int XGBoosterFree(long handle);

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -70,6 +70,9 @@ class XGBoostJNI {
 
   public final static native int XGDMatrixSliceDMatrix(long handle, int[] idxset, long[] out);
 
+  public final static native int XGDMatrixCombineDMatrix(long handleLeft, long handleRight,
+		                                                 long totalSize, long[] out);
+
   public final static native int XGDMatrixFree(long handle);
 
   public final static native int XGDMatrixSaveBinary(long handle, String fname, int silent);

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
@@ -220,6 +220,16 @@ class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
   }
 
   /**
+   * get the data vector size of DMatrix
+   *
+   * @return size of data vector
+   */
+  @throws(classOf[XGBoostError])
+  def dataVecSize: Long = {
+    jDMatrix.dataVecSize
+  }
+
+  /**
    * save DMatrix to filePath
    *
    * @param filePath file path

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
@@ -199,6 +199,17 @@ class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
   }
 
   /**
+   * Combine the DMatrix and return this DMatrix.
+   *
+   * @param rightDmatrix DMatrix to be merged
+   * @return this DMatrix
+   */
+  @throws(classOf[XGBoostError])
+  def combine(rightDMatrix: DMatrix, totalSize: Long): DMatrix = {
+    new DMatrix(jDMatrix.combine(rightDMatrix.jDMatrix, totalSize))
+  }
+
+  /**
    * get the row number of DMatrix
    *
    * @return number of rows

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -476,6 +476,21 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixNumRow
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGDMatrixDataVecSize
+ * Signature: (J)J
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixDataVecSize
+  (JNIEnv *jenv, jclass jcls, jlong jhandle, jlongArray jout) {
+  DMatrixHandle handle = (DMatrixHandle) jhandle;
+  bst_ulong result[1];
+  int ret = (jint) XGDMatrixDataVecSize(handle, result);
+  JVM_CHECK_CALL(ret);
+  jenv->SetLongArrayRegion(jout, 0, 1, (const jlong *) result);
+  return ret;
+}
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGBoosterCreate
  * Signature: ([J)J
  */

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -331,6 +331,24 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSliceDMat
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGDMatrixCombineDMatrix
+ * Signature: (JJ[J)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCombineDMatrix
+  (JNIEnv *jenv, jclass jcls, jlong jhandle, jlong jhandle_right, jlong totalsize, jlongArray jout) {
+  DMatrixHandle result;
+  DMatrixHandle handle = (DMatrixHandle) jhandle;
+  DMatrixHandle handle_right = (DMatrixHandle) jhandle_right;
+
+  jint ret = (jint) XGDMatrixCombineDMatrix(handle, handle_right, totalsize, &result);
+  JVM_CHECK_CALL(ret);
+  setHandle(jenv, jout, result);
+
+  return ret;
+}
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGDMatrixFree
  * Signature: (J)V
  */

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.h
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.h
@@ -137,6 +137,14 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixNumRow
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGDMatrixDataVecSize
+ * Signature: (J[J)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixDataVecSize
+  (JNIEnv *, jclass, jlong, jlongArray);
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGBoosterCreate
  * Signature: ([J[J)I
  */

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.h
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.h
@@ -73,6 +73,14 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSliceDMat
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGDMatrixCombineDMatrix
+ * Signature: (JJ[J)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCombineDMatrix
+  (JNIEnv *, jclass, jlong, jlong, jlong, jlongArray);
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGDMatrixFree
  * Signature: (J)I
  */

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -381,10 +381,18 @@ XGB_DLL int XGDMatrixNumRow(const DMatrixHandle handle,
   API_BEGIN();
   CHECK_HANDLE();
   *out = static_cast<xgboost::bst_ulong>(
-      static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info().num_row_);
+      static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info().num_nonzero_());
   API_END();
 }
 
+XGB_DLL int XGDMatrixDataVecSize(const DMatrixHandle handle,
+                            xgboost::bst_ulong *out) {
+  API_BEGIN();
+  CHECK_HANDLE();
+  *out = static_cast<xgboost::bst_ulong>(
+      static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info().num_row_);
+  API_END();
+}
 XGB_DLL int XGDMatrixNumCol(const DMatrixHandle handle,
                             xgboost::bst_ulong *out) {
   API_BEGIN();

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -243,7 +243,8 @@ XGB_DLL int XGDMatrixCombineDMatrix(DMatrixHandle handle_left,
   DMatrix* dmat_right = static_cast<std::shared_ptr<DMatrix>*>(handle_right)->get();
 
   dmat->Combine(dmat_right, total_size);
-  *out = new std::shared_ptr<DMatrix>(*(static_cast<std::shared_ptr<DMatrix>*>(handle_left)));
+  // *out = new std::shared_ptr<DMatrix>(*(static_cast<std::shared_ptr<DMatrix>*>(handle_left)));
+  *out = handle_left;
 
   API_END();
 }

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -244,7 +244,6 @@ XGB_DLL int XGDMatrixCombineDMatrix(DMatrixHandle handle_left,
 
   dmat->Combine(dmat_right, total_size);
   *out = new std::shared_ptr<DMatrix>(*(static_cast<std::shared_ptr<DMatrix>*>(handle_left)));
-  
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -243,9 +243,8 @@ XGB_DLL int XGDMatrixCombineDMatrix(DMatrixHandle handle_left,
   DMatrix* dmat_right = static_cast<std::shared_ptr<DMatrix>*>(handle_right)->get();
 
   dmat->Combine(dmat_right, total_size);
-  // *out = new std::shared_ptr<DMatrix>(*(static_cast<std::shared_ptr<DMatrix>*>(handle_left)));
-  *out = handle_left;
-
+  *out = new std::shared_ptr<DMatrix>(*(static_cast<std::shared_ptr<DMatrix>*>(handle_left)));
+  
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -381,7 +381,7 @@ XGB_DLL int XGDMatrixNumRow(const DMatrixHandle handle,
   API_BEGIN();
   CHECK_HANDLE();
   *out = static_cast<xgboost::bst_ulong>(
-      static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info().num_nonzero_());
+      static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info().num_row_);
   API_END();
 }
 
@@ -390,7 +390,7 @@ XGB_DLL int XGDMatrixDataVecSize(const DMatrixHandle handle,
   API_BEGIN();
   CHECK_HANDLE();
   *out = static_cast<xgboost::bst_ulong>(
-      static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info().num_row_);
+      static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info().num_nonzero_);
   API_END();
 }
 XGB_DLL int XGDMatrixNumCol(const DMatrixHandle handle,

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -232,6 +232,22 @@ XGB_DLL int XGDMatrixSliceDMatrixEx(DMatrixHandle handle,
   API_END();
 }
 
+XGB_DLL int XGDMatrixCombineDMatrix(DMatrixHandle handle_left,
+                                  DMatrixHandle handle_right,
+                                  uint64_t total_size,
+                                  DMatrixHandle* out) {
+  API_BEGIN();
+  CHECK_HANDLE_BY_NAME(handle_left);
+  CHECK_HANDLE_BY_NAME(handle_right);
+  DMatrix* dmat = static_cast<std::shared_ptr<DMatrix>*>(handle_left)->get();
+  DMatrix* dmat_right = static_cast<std::shared_ptr<DMatrix>*>(handle_right)->get();
+
+  dmat->Combine(dmat_right, total_size);
+  *out = new std::shared_ptr<DMatrix>(*(static_cast<std::shared_ptr<DMatrix>*>(handle_left)));
+
+  API_END();
+}
+
 XGB_DLL int XGDMatrixFree(DMatrixHandle handle) {
   API_BEGIN();
   CHECK_HANDLE();

--- a/src/c_api/c_api_error.h
+++ b/src/c_api/c_api_error.h
@@ -21,6 +21,9 @@
 #define API_END() } catch(dmlc::Error &_except_) { return XGBAPIHandleException(_except_); } return 0;  // NOLINT(*)
 #define CHECK_HANDLE() if (handle == nullptr) \
   LOG(FATAL) << "DMatrix/Booster has not been intialized or has already been disposed.";
+#define CHECK_HANDLE_BY_NAME(handle) if (handle == nullptr) \
+  LOG(FATAL) << "DMatrix/Booster has not been intialized or has already been disposed.";
+
 /*!
  * \brief every function starts with API_BEGIN();
  *   and finishes with API_END() or API_END_HANDLE_ERROR

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -832,9 +832,9 @@ void SparsePage::Push(const SparsePage &batch) {
               sizeof(Entry) * batch.data.Size());
   size_t begin = offset.Size();
   offset_vec.resize(begin + batch.Size());
-  for (size_t i = 0; i < batch.Size(); ++i) {
-    offset_vec[i + begin] = top + batch_offset_vec[i + 1];
-  }
+  std::transform(std::next(batch_offset_vec.begin()), batch_offset_vec.end(), &offset_vec[begin],
+        [top](const size_t r) { return r+top;} );
+
 }
 
 template <typename AdapterBatchT>

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -834,7 +834,6 @@ void SparsePage::Push(const SparsePage &batch) {
   offset_vec.resize(begin + batch.Size());
   std::transform(std::next(batch_offset_vec.begin()), batch_offset_vec.end(), &offset_vec[begin],
         [top](const size_t r) { return r+top;} );
-
 }
 
 template <typename AdapterBatchT>

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -60,7 +60,7 @@ DMatrix* SimpleDMatrix::Combine(DMatrix* right, uint64_t total_size) {
   Info().weights_.Append(right->Info().weights_);
   Info().base_margin_.Append(right->Info().base_margin_);
 
-//groups not support yet.
+// groups not support yet.
 //
   return this;
 }

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -56,10 +56,9 @@ DMatrix* SimpleDMatrix::Combine(DMatrix* right, uint64_t total_size) {
   CHECK_EQ(this->Info().num_col_, right->Info().num_col_)
           << "Inconsistent num columns";
   this->Info().num_nonzero_ = out_page.offset.HostVector().back();
-  Info().labels_.Append(right->Info().labels_);
-  Info().base_margin_.Append(right->Info().base_margin_);
-  Info().weights_.Append(right->Info().weights_);
-
+  Info().labels_.Extend(right->Info().labels_);
+  Info().base_margin_.Extend(right->Info().base_margin_);
+  Info().weights_.Extend(right->Info().weights_);
   /*
    * TODO: Currently, the Combine method doesn't support the learning-to-rank
    * usecase. Combining group_ptr_ vectors is therefore disabled.
@@ -71,7 +70,6 @@ DMatrix* SimpleDMatrix::Combine(DMatrix* right, uint64_t total_size) {
   *                right_grp.begin(), right_grp.end(), gptr.begin());
   * Info().group_ptr_.swap(gptr);
    */
-  
   return this;
 }
 

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -59,9 +59,12 @@ DMatrix* SimpleDMatrix::Combine(DMatrix* right, uint64_t total_size) {
   Info().labels_.Append(right->Info().labels_);
   Info().weights_.Append(right->Info().weights_);
   Info().base_margin_.Append(right->Info().base_margin_);
-
-// groups not support yet.
-//
+  // update group_ptr_
+  auto& right_grp = right->Info().group_ptr_;
+  std::vector<bst_group_t> gptr;
+  std::set_union(Info().group_ptr_.begin(), Info().group_ptr_.end(),
+                 right_grp.begin(), right_grp.end(), gptr.begin());
+  Info().group_ptr_.swap(gptr);
   return this;
 }
 

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -57,14 +57,21 @@ DMatrix* SimpleDMatrix::Combine(DMatrix* right, uint64_t total_size) {
           << "Inconsistent num columns";
   this->Info().num_nonzero_ = out_page.offset.HostVector().back();
   Info().labels_.Append(right->Info().labels_);
-  Info().weights_.Append(right->Info().weights_);
   Info().base_margin_.Append(right->Info().base_margin_);
-  // update group_ptr_
-  auto& right_grp = right->Info().group_ptr_;
-  std::vector<bst_group_t> gptr;
-  std::set_union(Info().group_ptr_.begin(), Info().group_ptr_.end(),
-                 right_grp.begin(), right_grp.end(), gptr.begin());
-  Info().group_ptr_.swap(gptr);
+  Info().weights_.Append(right->Info().weights_);
+
+  /*
+   * TODO: Currently, the Combine method doesn't support the learning-to-rank
+   * usecase. Combining group_ptr_ vectors is therefore disabled.
+  * auto& right_grp = right->Info().group_ptr_;
+  * std::vector<bst_group_t> gptr;
+  * std::sort(Info().group_ptr_.begin(), Info().group_ptr_.end());
+  * std::sort(right_grp.begin(), right_grp.end());
+  * std::set_union(Info().group_ptr_.begin(), Info().group_ptr_.end(),
+  *                right_grp.begin(), right_grp.end(), gptr.begin());
+  * Info().group_ptr_.swap(gptr);
+   */
+  
   return this;
 }
 

--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -35,6 +35,8 @@ class SimpleDMatrix : public DMatrix {
   bool SingleColBlock() const override { return true; }
   DMatrix* Slice(common::Span<int32_t const> ridxs) override;
 
+  DMatrix* Combine(DMatrix* right, uint64_t total_size) override;
+
   /*! \brief magic number used to identify SimpleDMatrix binary files */
   static const int kMagic = 0xffffab01;
 


### PR DESCRIPTION
One big issue of current xgboost training on Spark is that ETL usually run in task mode which sets spark.task.cpus = 1. But xgboost training is more efficient on openMP mode which sets spark.task.cpus = spark.executor.cores = xgbparam.nthread. We usually save the ETL result into a parquet file, then start a new spark context with task.cpus=nthreads, then we load the data, convert into DMatrix, start training. In this way the conversion has to run in little threads and takes very long time. e.g. a conversion of 150M Row x 46 columns takes about 870s on a 2x28 config, takes ~250s on a 7x8 config.  Even worse, the inference is more efficient on task mode, so we have to save the model and start another new context to do inference.

It's really not a good solution. The patch gives a way to swich task mode to OMP mode AFTER data conversion, then the training run in OMP mode, then the inference goes back to task mode. It solved the model swtich issue, accelerately the data conversion process greatly and be able to use one or two executor per node which is more efficient for training.

The basic logic is as below:
    1. repartition input data set to N x executor#. N is integer.
    2. Create DMatrix in each task thread of executor
    3. Force caching the Watches[DMatrix*] in executor's block manager
    4. Use a customized coalescePartitioner to combine the Watches[DMatrix*] into a large DMatrix. Set preferred location to the executor
    5. Train xgboost from the large DMatrix in task thread of an executor

Because we cached the pointer of DMatrix in block manager instead of the converted data itself, so we must make sure the training stage must be scheduled to the same executor. we can set spark.locality.wait.process to a large number for this. Spark3.0's stage level resource management can change task.cpus at run time but it doesn't solve the issue automatically. We still need to combine the converted DMatrix of each executor into a large one. It either can't solve the data locality issue, we still need to set wait time a large number.

Here is the result, with 7x8 configuration, the patch can decrease the data conversion time from 250s to 70s. with 2x28 configuration, it can decrease from 870s to 160s. It's possible to further optimize later.

![image](https://user-images.githubusercontent.com/47296334/84233478-427d7500-aaa7-11ea-9e9d-75592f06f6f4.png)

It only support trainForNonRanking and evalSetsMap.isEmpty now. I will add other 3 cases.
