### PR TITLE
[python-package] remove unused imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ Debug
 #.Rbuildignore
 R-package.Rproj
 *.cache*
+.mypy_cache/
 # java
 java/xgboost4j/target
 java/xgboost4j/tmp

--- a/doc/sphinx_util.py
+++ b/doc/sphinx_util.py
@@ -2,7 +2,6 @@
 """Helper utility function for customization."""
 import sys
 import os
-import docutils
 import subprocess
 
 READTHEDOCS_BUILD = (os.environ.get('READTHEDOCS', None) is not None)

--- a/python-package/xgboost/__init__.py
+++ b/python-package/xgboost/__init__.py
@@ -5,8 +5,6 @@ Contributors: https://github.com/dmlc/xgboost/blob/master/CONTRIBUTORS.md
 """
 
 import os
-import sys
-import warnings
 
 from .core import DMatrix, DeviceQuantileDMatrix, Booster
 from .training import train, cv

--- a/tests/benchmark/benchmark_linear.py
+++ b/tests/benchmark/benchmark_linear.py
@@ -1,5 +1,5 @@
 #pylint: skip-file
-import sys, argparse
+import argparse
 import xgboost as xgb
 import numpy as np
 from sklearn.datasets import make_classification


### PR DESCRIPTION
This pull request proposes removing some unused imports in Python code.

I ran two linters over the Python code in this project tonight, hoping I could find some things that could be fixed.

First, I ran `flake8`. This returned a bunch of issues that I think are minor and should be left to maintainers...things like extra blank lines, missing spaces around operators, and other whitespace and minor style things.

```shell
flake8 \
    ---ignore=W503,E501,E202,E231,E241,W504,E226,E271,E251,E121,E221,E111,E302,E305,E303,W293,E201,E211,W291,E261,E203,E402,E306,E225,E266,E265,E128,E127,W391
```

Next, I ran `mypy` to look for type mismatches. That didn't turn up anything obvious (it's more useful on projects that make heavy use of Python type hints), but might be worth it for maintainers to try some time.

```shell
mypy python-package \
    | grep -v "Cannot find implementation or library" \
    | grep -v "found module but no type hints"
```

Thanks for your time and consideration!
