### PR TITLE
add new attribute for number of features

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -499,6 +499,7 @@ class XGBModel(XGBModelBase):
 
                 [xgb.callback.reset_learning_rate(custom_rates)]
         """
+        self.n_features_in_ = X.shape[1]
         train_dmatrix = DMatrix(data=X, label=y, weight=sample_weight,
                                 base_margin=base_margin,
                                 missing=self.missing,
@@ -813,6 +814,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             raise ValueError(
                 'Please reshape the input data X into 2-dimensional matrix.')
         self._features_count = X.shape[1]
+        self.n_features_in_ = self._features_count
         train_dmatrix = DMatrix(X, label=training_labels, weight=sample_weight,
                                 base_margin=base_margin,
                                 missing=self.missing, nthread=self.n_jobs)

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -500,6 +500,7 @@ class XGBModel(XGBModelBase):
                 [xgb.callback.reset_learning_rate(custom_rates)]
         """
         self.n_features_in_ = X.shape[1]
+        
         train_dmatrix = DMatrix(data=X, label=y, weight=sample_weight,
                                 base_margin=base_margin,
                                 missing=self.missing,
@@ -813,8 +814,10 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             # different ways of reshaping
             raise ValueError(
                 'Please reshape the input data X into 2-dimensional matrix.')
+        
         self._features_count = X.shape[1]
         self.n_features_in_ = self._features_count
+
         train_dmatrix = DMatrix(X, label=training_labels, weight=sample_weight,
                                 base_margin=base_margin,
                                 missing=self.missing, nthread=self.n_jobs)
@@ -1196,6 +1199,8 @@ class XGBRanker(XGBModel):
             ret = DMatrix(**params)
             ret.set_group(group)
             return ret
+
+        self.n_features_in_ = X.shape[1]
 
         train_dmatrix = DMatrix(data=X, label=y, weight=sample_weight,
                                 base_margin=base_margin,

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -500,7 +500,7 @@ class XGBModel(XGBModelBase):
                 [xgb.callback.reset_learning_rate(custom_rates)]
         """
         self.n_features_in_ = X.shape[1]
-        
+
         train_dmatrix = DMatrix(data=X, label=y, weight=sample_weight,
                                 base_margin=base_margin,
                                 missing=self.missing,
@@ -814,7 +814,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             # different ways of reshaping
             raise ValueError(
                 'Please reshape the input data X into 2-dimensional matrix.')
-        
+
         self._features_count = X.shape[1]
         self.n_features_in_ = self._features_count
 

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -136,9 +136,6 @@ def test_stacking_regression():
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
     reg.fit(X_train, y_train).score(X_test, y_test)
 
-    # test number of input features
-    assert reg.n_features_in_ == 10
-
 
 def test_stacking_classification():
     from sklearn.model_selection import train_test_split
@@ -161,9 +158,6 @@ def test_stacking_classification():
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
     clf.fit(X_train, y_train).score(X_test, y_test)
-
-    # test number of input features
-    assert clf.n_features_in_ == 4
 
 
 @pytest.mark.skipif(**tm.no_pandas())

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -115,6 +115,56 @@ def test_ranking():
     np.testing.assert_almost_equal(pred, pred_orig)
 
 
+def test_stacking_regression():
+    from sklearn.model_selection import train_test_split
+    from sklearn.datasets import load_diabetes
+    from sklearn.linear_model import RidgeCV
+    from sklearn.ensemble import RandomForestRegressor
+    from sklearn.ensemble import StackingRegressor
+
+    X, y = load_diabetes(return_X_y=True)
+    estimators = [
+        ('gbm', xgb.XGBRegressor(objective='reg:squarederror')), ('lr', RidgeCV())
+    ]
+    reg = StackingRegressor(
+        estimators=estimators,
+        final_estimator=RandomForestRegressor(n_estimators=10,
+                                              random_state=42)
+    )
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+    reg.fit(X_train, y_train).score(X_test, y_test)
+
+    # test number of input features
+    assert reg.n_features_in_ == 10
+
+
+def test_stacking_classification():
+    from sklearn.model_selection import train_test_split
+    from sklearn.datasets import load_iris
+    from sklearn.svm import LinearSVC
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.preprocessing import StandardScaler
+    from sklearn.pipeline import make_pipeline
+    from sklearn.ensemble import StackingClassifier
+
+    X, y = load_iris(return_X_y=True)
+    estimators = [
+        ('gbm', xgb.XGBClassifier()),
+        ('svr', make_pipeline(StandardScaler(),
+                              LinearSVC(random_state=42)))
+    ]
+    clf = StackingClassifier(
+        estimators=estimators, final_estimator=LogisticRegression()
+    )
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+    clf.fit(X_train, y_train).score(X_test, y_test)
+
+    # test number of input features
+    assert clf.n_features_in_ == 4
+
+
 @pytest.mark.skipif(**tm.no_pandas())
 def test_feature_importances_weight():
     from sklearn.datasets import load_digits

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -124,7 +124,8 @@ def test_stacking_regression():
 
     X, y = load_diabetes(return_X_y=True)
     estimators = [
-        ('gbm', xgb.XGBRegressor(objective='reg:squarederror')), ('lr', RidgeCV())
+        ('gbm', xgb.sklearn.XGBRegressor(objective='reg:squarederror')),
+        ('lr', RidgeCV())
     ]
     reg = StackingRegressor(
         estimators=estimators,
@@ -150,7 +151,7 @@ def test_stacking_classification():
 
     X, y = load_iris(return_X_y=True)
     estimators = [
-        ('gbm', xgb.XGBClassifier()),
+        ('gbm', xgb.sklearn.XGBClassifier()),
         ('svr', make_pipeline(StandardScaler(),
                               LinearSVC(random_state=42)))
     ]


### PR DESCRIPTION
Fixes an issue related to [#17353](https://github.com/scikit-learn/scikit-learn/issues/17353) in scikit-learn and [#3129](https://github.com/microsoft/LightGBM/pull/3129) in LightGBM (see [SLEP010](https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep010/proposal.html) for further details). It also fixes an issue related to the behavior of ```StackingClassifier```, where the returned error is ```AttributeError: 'XGBClassifier' object has no attribute 'n_features_in_'``` (see code below).

```
import xgboost as xgb
from sklearn.model_selection import train_test_split
from sklearn.datasets import load_iris
from sklearn.svm import LinearSVC
from sklearn.linear_model import LogisticRegression
from sklearn.preprocessing import StandardScaler
from sklearn.pipeline import make_pipeline
from sklearn.ensemble import StackingClassifier

X, y = load_iris(return_X_y=True)
estimators = [
    ('gbm', xgb.XGBClassifier()),
    ('svr', make_pipeline(StandardScaler(),
                          LinearSVC(random_state=42)))
]
clf = StackingClassifier(
    estimators=estimators, final_estimator=LogisticRegression()
)

X_train, X_test, y_train, y_test = train_test_split(
    X, y, random_state=42
)
clf.fit(X_train, y_train).score(X_test, y_test)
```