### PR TITLE
Fix exception causes all over the codebase

### DIFF
--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -63,13 +63,13 @@ else:
         path_type = type(path)
         try:
             path_repr = path_type.__fspath__(path)
-        except AttributeError:
+        except AttributeError as e:
             if hasattr(path_type, '__fspath__'):
                 raise
             if issubclass(path_type, PurePath):
                 return _PurePath__fspath__(path)
             raise TypeError("expected str, bytes or os.PathLike object, "
-                            "not " + path_type.__name__)
+                            "not " + path_type.__name__) from e
         if isinstance(path_repr, (str, bytes)):
             return path_repr
         raise TypeError("expected {}.__fspath__() to return str or bytes, "

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -263,9 +263,9 @@ def _convert_unknown_data(data, meta=None, meta_type=None):
     if meta is not None:
         try:
             data = np.array(data, dtype=meta_type)
-        except Exception:
+        except Exception as e:
             raise TypeError('Can not handle data from {}'.format(
-                type(data).__name__))
+                type(data).__name__)) from e
     else:
         import warnings
         warnings.warn(
@@ -273,9 +273,9 @@ def _convert_unknown_data(data, meta=None, meta_type=None):
             ', coverting it to csr_matrix')
         try:
             data = scipy.sparse.csr_matrix(data)
-        except Exception:
+        except Exception as e:
             raise TypeError('Can not initialize DMatrix from'
-                            ' {}'.format(type(data).__name__))
+                            ' {}'.format(type(data).__name__)) from e
     return data
 
 

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -56,8 +56,8 @@ def plot_importance(booster, ax=None, height=0.2,
     """
     try:
         import matplotlib.pyplot as plt
-    except ImportError:
-        raise ImportError('You must install matplotlib to plot importance')
+    except ImportError as e:
+        raise ImportError('You must install matplotlib to plot importance') from e
 
     if isinstance(booster, XGBModel):
         importance = booster.get_booster().get_score(
@@ -168,8 +168,8 @@ def to_graphviz(booster, fmap='', num_trees=0, rankdir=None,
     """
     try:
         from graphviz import Source
-    except ImportError:
-        raise ImportError('You must install graphviz to plot tree')
+    except ImportError as e:
+        raise ImportError('You must install graphviz to plot tree') from e
     if isinstance(booster, XGBModel):
         booster = booster.get_booster()
 
@@ -237,8 +237,8 @@ def plot_tree(booster, fmap='', num_trees=0, rankdir=None, ax=None, **kwargs):
     try:
         from matplotlib import pyplot as plt
         from matplotlib import image
-    except ImportError:
-        raise ImportError('You must install matplotlib to plot tree')
+    except ImportError as e:
+        raise ImportError('You must install matplotlib to plot tree') from e
 
     if ax is None:
         _, ax = plt.subplots(1, 1)


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 