### PR TITLE
Relax linear test.

### DIFF
--- a/tests/python/test_linear.py
+++ b/tests/python/test_linear.py
@@ -32,7 +32,7 @@ class TestLinear:
         param.update(coord_param)
         param = dataset.set_params(param)
         result = train_result(param, dataset.get_dmat(), num_rounds)['train'][dataset.metric]
-        assert tm.non_increasing(result)
+        assert tm.non_increasing(result, 5e-4)
 
     # Loss is not guaranteed to always decrease because of regularisation parameters
     # We test a weaker condition that the loss has not increased between the first and last
@@ -65,7 +65,7 @@ class TestLinear:
             sampled_result[-1] = result[-1]  # make sure the last one is used
         else:
             sampled_result = result
-        assert tm.non_increasing(sampled_result)
+        assert tm.non_increasing(sampled_result, 1e-3)
 
     @given(parameter_strategy, strategies.integers(10, 50),
            tm.dataset_strategy, strategies.floats(1e-5, 2.0),


### PR DESCRIPTION
* Increased error in coordinate is mostly due to floating point error.
* Shotgun uses Hogwild!, which is non-deterministic and can have even greater
floating point error.

Closes #5845 .

If shotgun test is still flaky after the PR, we will have to adopt a more sparse sampled result.