### PR TITLE
Add DMatrix usage examples to c-api-demo

### DIFF
--- a/demo/c-api/c-api-demo.c
+++ b/demo/c-api/c-api-demo.c
@@ -93,10 +93,34 @@ int main(int argc, char** argv) {
       1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
       0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0,
       1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      1, 0, 0, 0, 0, 1};
+      1, 0, 0, 0, 0, 1, 0, 0, 0, 0};
 
     DMatrixHandle dmat;
     safe_xgboost(XGDMatrixCreateFromMat(values, 1, 127, 0.0, &dmat));
+
+    bst_ulong out_len = 0;
+    const float* out_result = NULL;
+
+    safe_xgboost(XGBoosterPredict(booster, dmat, 0, 0, 0, &out_len,
+          &out_result));
+    assert(out_len == 1);
+
+    printf("%1.4f \n", out_result[0]);
+    safe_xgboost(XGDMatrixFree(dmat));
+  }
+
+  {
+    printf("Sparse Matrix Example (XGDMatrixCreateFromCSREx): ");
+
+    const size_t indptr[] = {0, 22};
+    const unsigned indices[] = {1, 9, 19, 21, 24, 34, 36, 39, 42, 53, 56, 65,
+      69, 77, 86, 88, 92, 95, 102, 106, 117, 122};
+    const float data[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+    DMatrixHandle dmat;
+    safe_xgboost(XGDMatrixCreateFromCSREx(indptr, indices, data, 2, 22, 127,
+      &dmat));
 
     bst_ulong out_len = 0;
     const float* out_result = NULL;

--- a/demo/c-api/c-api-demo.c
+++ b/demo/c-api/c-api-demo.c
@@ -133,6 +133,38 @@ int main(int argc, char** argv) {
     safe_xgboost(XGDMatrixFree(dmat));
   }
 
+  {
+    printf("Sparse Matrix Example (XGDMatrixCreateFromCSCEx): ");
+
+    const size_t col_ptr[] = {0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2,
+      2, 2, 2, 2, 3, 3, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 7, 7, 7, 8,
+      8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 11, 11, 11, 11, 11, 11,
+      11, 11, 11, 12, 12, 12, 12, 13, 13, 13, 13, 13, 13, 13, 13, 14, 14, 14,
+      14, 14, 14, 14, 14, 14, 15, 15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18,
+      18, 18, 18, 18, 19, 19, 19, 19, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20,
+      20, 21, 21, 21, 21, 21, 22, 22, 22, 22, 22};
+
+    const unsigned indices[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0};
+
+    const float data[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+      1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+    DMatrixHandle dmat;
+    safe_xgboost(XGDMatrixCreateFromCSCEx(col_ptr, indices, data, 128, 22, 1,
+      &dmat));
+
+    bst_ulong out_len = 0;
+    const float* out_result = NULL;
+
+    safe_xgboost(XGBoosterPredict(booster, dmat, 0, 0, 0, &out_len,
+          &out_result));
+    assert(out_len == 1);
+
+    printf("%1.4f \n", out_result[0]);
+    safe_xgboost(XGDMatrixFree(dmat));
+  }
+
   // free everything
   safe_xgboost(XGBoosterFree(booster));
   safe_xgboost(XGDMatrixFree(dtrain));

--- a/demo/c-api/c-api-demo.c
+++ b/demo/c-api/c-api-demo.c
@@ -5,6 +5,7 @@
  * \brief A simple example of using xgboost C API.
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <xgboost/c_api.h>
@@ -83,6 +84,30 @@ int main(int argc, char** argv) {
     printf("%1.4f ", out_result[i]);
   }
   printf("\n");
+
+  {
+    printf("Dense Matrix Example (XGDMatrixCreateFromMat): ");
+
+    const float values[] = {0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0,
+      1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+      0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0,
+      1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      1, 0, 0, 0, 0, 1};
+
+    DMatrixHandle dmat;
+    safe_xgboost(XGDMatrixCreateFromMat(values, 1, 127, 0.0, &dmat));
+
+    bst_ulong out_len = 0;
+    const float* out_result = NULL;
+
+    safe_xgboost(XGBoosterPredict(booster, dmat, 0, 0, 0, &out_len,
+          &out_result));
+    assert(out_len == 1);
+
+    printf("%1.4f \n", out_result[0]);
+    safe_xgboost(XGDMatrixFree(dmat));
+  }
 
   // free everything
   safe_xgboost(XGBoosterFree(booster));


### PR DESCRIPTION
I had a bit of a hard time using the C API given that there aren't that many usage examples, so maybe this will be useful for people.

This PR extends the C API demo to construct a dense matrix using `XGDMatrixCreateFromMat`. I'm planning on adding additional examples for `XGDMatrixCreateFromCSREx`, `XGDMatrixCreateFromCSCEx`, but unfortunately I haven't been able to get those working yet.

The matrix being constructed is equivalent to the first line of the test data.z

### Test Plan

```
alexanders-mbp:c-api alex$ make run
cc -O3 -I../../include -I../../dmlc-core/include -I../../rabit/include -L../../lib -o c-api-demo c-api-demo.c -lxgboost
LD_LIBRARY_PATH=../../lib ./c-api-demo
[17:32:50] 6513x127 matrix with 143286 entries loaded from ../data/agaricus.txt.train
[17:32:50] 1611x127 matrix with 35442 entries loaded from ../data/agaricus.txt.test
[0]     train-error:0.014433    test-error:0.016139
[1]     train-error:0.014433    test-error:0.016139
[2]     train-error:0.014433    test-error:0.016139
[3]     train-error:0.008598    test-error:0.009932
[4]     train-error:0.001228    test-error:0.000000
[5]     train-error:0.001228    test-error:0.000000
[6]     train-error:0.001228    test-error:0.000000
[7]     train-error:0.001228    test-error:0.000000
[8]     train-error:0.001228    test-error:0.000000
[9]     train-error:0.001228    test-error:0.000000
y_pred: 0.0239 0.9544 0.0239 0.0239 0.0490 0.1056 0.9544 0.0288 0.9544 0.0242 
y_test: 0.0000 1.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 1.0000 0.0000 
Dense Matrix Example (XGDMatrixCreateFromMat): 0.0239 
```