### PR TITLE
Add c-api-demo to .gitignore

### DIFF
--- a/demo/c-api/.gitignore
+++ b/demo/c-api/.gitignore
@@ -1,0 +1,1 @@
+c-api-demo


### PR DESCRIPTION
When running the C usage example we build the `c-api-demo` binary in `demo/c-api`.
As this file isn't listed in `.gitignore`, this is a bit annoying as one has to be careful about not accidentally checking it in.

This fixes it by adding a corresponding `.gitignore`.