### PR TITLE
Add XGBoosterGetNumFeature

### DIFF
--- a/demo/c-api/c-api-demo.c
+++ b/demo/c-api/c-api-demo.c
@@ -60,6 +60,10 @@ int main(int argc, char** argv) {
     printf("%s\n", eval_result);
   }
 
+  bst_ulong num_feature = 0;
+  safe_xgboost(XGBoosterGetNumFeature(booster, &num_feature));
+  printf("num_feature: %llu\n", num_feature);
+
   // predict
   bst_ulong out_len = 0;
   const float* out_result = NULL;

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -367,6 +367,14 @@ XGB_DLL int XGBoosterSetParam(BoosterHandle handle,
                               const char *value);
 
 /*!
+ * \brief get number of features
+ * \param out number of features
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterGetNumFeature(BoosterHandle handle,
+                                   bst_ulong *out);
+
+/*!
  * \brief update the model in one round using dtrain
  * \param handle handle
  * \param iter current iteration rounds

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -159,6 +159,12 @@ class Learner : public Model, public Configurable, public rabit::Serializable {
   virtual void SetParam(const std::string& key, const std::string& value) = 0;
 
   /*!
+   * \brief Get the number of features of the booster.
+   * \return number of features
+   */
+  virtual uint32_t GetNumFeature() = 0;
+
+  /*!
    * \brief Set additional attribute to the Booster.
    *
    *  The property will be saved along the booster.

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -340,6 +340,14 @@ XGB_DLL int XGBoosterSetParam(BoosterHandle handle,
   API_END();
 }
 
+XGB_DLL int XGBoosterGetNumFeature(BoosterHandle handle,
+                                   xgboost::bst_ulong *out) {
+  API_BEGIN();
+  CHECK_HANDLE();
+  *out = static_cast<Learner*>(handle)->GetNumFeature();
+  API_END();
+}
+
 XGB_DLL int XGBoosterLoadJsonConfig(BoosterHandle handle, char const* json_parameters) {
   API_BEGIN();
   CHECK_HANDLE();

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -384,6 +384,10 @@ class LearnerConfiguration : public Learner {
     }
   }
 
+  uint32_t GetNumFeature() override {
+    return learner_model_param_.num_feature;
+  }
+
   void SetAttr(const std::string& key, const std::string& value) override {
     attributes_[key] = value;
     mparam_.contain_extra_attrs = 1;

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -113,9 +113,10 @@ TEST(CAPI, ConfigIO) {
 
 TEST(CAPI, JsonModelIO) {
   size_t constexpr kRows = 10;
+  size_t constexpr kCols = 10;
   dmlc::TemporaryDirectory tempdir;
 
-  auto p_dmat = RandomDataGenerator(kRows, 10, 0).GenerateDMatrix();
+  auto p_dmat = RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
   std::vector<std::shared_ptr<DMatrix>> mat {p_dmat};
   std::vector<bst_float> labels(kRows);
   for (size_t i = 0; i < labels.size(); ++i) {
@@ -131,6 +132,10 @@ TEST(CAPI, JsonModelIO) {
   std::string modelfile_0 = tempdir.path + "/model_0.json";
   XGBoosterSaveModel(handle, modelfile_0.c_str());
   XGBoosterLoadModel(handle, modelfile_0.c_str());
+
+  bst_ulong num_feature {0};
+  ASSERT_EQ(XGBoosterGetNumFeature(handle, &num_feature), 0);
+  ASSERT_EQ(num_feature, kCols);
 
   std::string modelfile_1 = tempdir.path + "/model_1.json";
   XGBoosterSaveModel(handle, modelfile_1.c_str());


### PR DESCRIPTION
- add `GetNumFeature` to `Learner`
- add `XGBoosterGetNumFeature` to C API
- update `c-api-demo` accordingly

## Why?

Currently, it doesn't look like there is a way to obtain the number of features of a given `BoosterHandle` via the C API (without manually parsing the JSON model file).

This seems to be a bit limiting in practice.

For example, imagine one is attempting to deploy a pre-trained model via the C API. The model itself has 127 features, but not all of them are present for each sample.

Let's say we're given the following line:

```
1:1 9:1 19:1 21:1 24:1 34:1 36:1 39:1 42:1 53:1 56:1 65:1 69:1 77:1 86:1 88:1 92:1 95:1 102:1 106:1 117:1 122:1
```

As the model expects 127 columns, we'd somehow have to pad the resulting matrix. Otherwise, we'd get the following error:

```
c-api-demo.c:59: error in XGBoosterEvalOneIter(booster, i, eval_dmats, eval_names, 2, &eval_result): [18:34:47] /Users/alex/xgboost/src/learner.cc:1079: Check failed: learner_model_param_.num_feature == p_fmat->Info().num_col_ (127 vs. 123) : Number of columns does not match number of features in booster.
Stack trace:
  [bt] (0) 1   libxgboost.dylib                    0x0000000108a8d040 dmlc::LogMessageFatal::~LogMessageFatal() + 112
  [bt] (1) 2   libxgboost.dylib                    0x0000000108b36b3b xgboost::LearnerImpl::ValidateDMatrix(xgboost::DMatrix*) const + 283
  [bt] (2) 3   libxgboost.dylib                    0x0000000108b270f9 xgboost::LearnerImpl::EvalOneIter(int, std::__1::vector<std::__1::shared_ptr<xgboost::DMatrix>, std::__1::allocator<std::__1::shared_ptr<xgboost::DMatrix> > > const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) + 1049
  [bt] (3) 4   libxgboost.dylib                    0x0000000108a85b38 XGBoosterEvalOneIter + 600
  [bt] (4) 5   c-api-demo                          0x0000000108a78381 main + 433
  [bt] (5) 6   libdyld.dylib                       0x00007fffd5793235 start + 1


make: *** [run] Error 1
```

In order to determine how many columns we're missing, we'd have to call `XGBoosterGetNumFeature`, which is the function that this PR introduces.

## Test Plan

Updated C API usage example. Notice that we now print the number of features ("num_feature: 127").

```
alexanders-mbp:c-api alex$ make run
cc -O3 -I../../include -I../../dmlc-core/include -I../../rabit/include -L../../lib -o c-api-demo c-api-demo.c -lxgboost
LD_LIBRARY_PATH=../../lib ./c-api-demo
[18:31:48] 6513x127 matrix with 143286 entries loaded from ../data/agaricus.txt.train
[18:31:48] 1611x127 matrix with 35442 entries loaded from ../data/agaricus.txt.test
[0]     train-error:0.014433    test-error:0.016139
[1]     train-error:0.014433    test-error:0.016139
[2]     train-error:0.014433    test-error:0.016139
[3]     train-error:0.008598    test-error:0.009932
[4]     train-error:0.001228    test-error:0.000000
[5]     train-error:0.001228    test-error:0.000000
[6]     train-error:0.001228    test-error:0.000000
[7]     train-error:0.001228    test-error:0.000000
[8]     train-error:0.001228    test-error:0.000000
[9]     train-error:0.001228    test-error:0.000000
num_feature: 127
y_pred: 0.0239 0.9544 0.0239 0.0239 0.0490 0.1056 0.9544 0.0288 0.9544 0.0242 
y_test: 0.0000 1.0000 0.0000 0.0000 0.0000 0.0000 1.0000 0.0000 1.0000 0.0000
```

Also updated `tests/cpp/c_api/test_c_api.cc` to add a test case for the newly added function.