### PR TITLE
Move feature names and types of DMatrix from Python to C++.

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -428,6 +428,17 @@ XGB_DLL int XGDMatrixSetUIntInfo(DMatrixHandle handle,
  * \param size      Size of `features` pointer (number of strings passed in).
  *
  * \return 0 when success, -1 when failure happens
+ *
+ * \code
+ *
+ *   char const* feat_names [] {"feat_0", "feat_1"};
+ *   XGDMatrixSetStrFeatureInfo(handle, "feature_name", feat_names, 2);
+ *
+ *   // i for integer, q for quantitive.  Similarly "int" and "float" are also recognized.
+ *   char const* feat_types [] {"i", "q"};
+ *   XGDMatrixSetStrFeatureInfo(handle, "feature_type", feat_types, 2);
+ *
+ * \endcode
  */
 XGB_DLL int XGDMatrixSetStrFeatureInfo(DMatrixHandle handle, const char *field,
                                        const char **features,
@@ -440,7 +451,8 @@ XGB_DLL int XGDMatrixSetStrFeatureInfo(DMatrixHandle handle, const char *field,
  *   - feature_name
  *   - feature_type
  *
- * Caller is responsible for copying out the data, before next call to any API in XGBoost.
+ * Caller is responsible for copying out the data, before next call to any API function of
+ * XGBoost.
  *
  * \param handle       An instance of data matrix
  * \param field        Feild name
@@ -454,6 +466,8 @@ XGB_DLL int XGDMatrixSetStrFeatureInfo(DMatrixHandle handle, const char *field,
  *
  *  char const **c_out_features = NULL;
  *  bst_ulong out_size = 0;
+ *
+ *  // Asumming the feature names are already set by `XGDMatrixSetStrFeatureInfo`.
  *  XGDMatrixGetStrFeatureInfo(handle, "feature_name", &out_size,
  *                             &c_out_features)
  *
@@ -462,6 +476,8 @@ XGB_DLL int XGDMatrixSetStrFeatureInfo(DMatrixHandle handle, const char *field,
  *    // useful after print.
  *    printf("feature %lu: %s\n", i, c_out_features[i]);
  *  }
+ *
+ * \endcode
  */
 XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
                                        bst_ulong *size,
@@ -627,8 +643,9 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
  *
  * - Functions with the term "Model" handles saving/loading XGBoost model like trees or
  *   linear weights.  Striping out parameters configuration like training algorithms or
- *   CUDA device ID helps user to reuse the trained model for different tasks, examples
- *   are prediction, training continuation or interpretation.
+ *   CUDA device ID.  These functions are designed to let users reuse the trained model
+ *   for different tasks, examples are prediction, training continuation or model
+ *   interpretation.
  *
  * - Functions with the term "Config" handles save/loading configuration.  It helps user
  *   to study the internal of XGBoost.  Also user can use the load method for specifying
@@ -644,7 +661,7 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
 /*!
  * \brief Load model from existing file
  * \param handle handle
- * \param fname file name
+ * \param fname File URI or file name.
 * \return 0 when success, -1 when failure happens
  */
 XGB_DLL int XGBoosterLoadModel(BoosterHandle handle,
@@ -652,7 +669,7 @@ XGB_DLL int XGBoosterLoadModel(BoosterHandle handle,
 /*!
  * \brief Save model into existing file
  * \param handle handle
- * \param fname file name
+ * \param fname File URI or file name.
  * \return 0 when success, -1 when failure happens
  */
 XGB_DLL int XGBoosterSaveModel(BoosterHandle handle,

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -416,6 +416,58 @@ XGB_DLL int XGDMatrixSetUIntInfo(DMatrixHandle handle,
                                  bst_ulong len);
 
 /*!
+ * \brief Set string encoded information of all features.
+ *
+ * Accepted fields are:
+ *   - feature_name
+ *   - feature_type
+ *
+ * \param handle    An instance of data matrix
+ * \param field     Feild name
+ * \param features  Pointer to array of strings.
+ * \param size      Size of `features` pointer (number of strings passed in).
+ *
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixSetStrFeatureInfo(DMatrixHandle handle, const char *field,
+                                       const char **features,
+                                       const bst_ulong size);
+
+/*!
+ * \brief Get string encoded information of all features.
+ *
+ * Accepted fields are:
+ *   - feature_name
+ *   - feature_type
+ *
+ * Caller is responsible for copying out the data, before next call to any API in XGBoost.
+ *
+ * \param handle       An instance of data matrix
+ * \param field        Feild name
+ * \param size         Size of output pointer `features` (number of strings returned).
+ * \param out_features Address of a pointer to array of strings.  Result is stored in
+ *                     thread local memory.
+ *
+ * \return 0 when success, -1 when failure happens
+ *
+ * \code
+ *
+ *  char const **c_out_features = NULL;
+ *  bst_ulong out_size = 0;
+ *  XGDMatrixGetStrFeatureInfo(handle, "feature_name", &out_size,
+ *                             &c_out_features)
+ *
+ *  for (bst_ulong i = 0; i < out_len; ++i) {
+ *    // Here we are simply printing the string.  Copy it out if the feature name is
+ *    // useful after print.
+ *    printf("feature %lu: %s\n", i, c_out_features[i]);
+ *  }
+ */
+XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
+                                       bst_ulong *size,
+                                       const char ***out_features);
+
+/*!
  * \brief (deprecated) Use XGDMatrixSetUIntInfo instead. Set group of the training matrix
  * \param handle a instance of data matrix
  * \param group pointer to group size

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -471,9 +471,9 @@ XGB_DLL int XGDMatrixSetStrFeatureInfo(DMatrixHandle handle, const char *field,
  *  XGDMatrixGetStrFeatureInfo(handle, "feature_name", &out_size,
  *                             &c_out_features)
  *
- *  for (bst_ulong i = 0; i < out_len; ++i) {
+ *  for (bst_ulong i = 0; i < out_size; ++i) {
  *    // Here we are simply printing the string.  Copy it out if the feature name is
- *    // useful after print.
+ *    // useful after printing.
  *    printf("feature %lu: %s\n", i, c_out_features[i]);
  *  }
  *

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -31,7 +31,12 @@ enum class DataType : uint8_t {
   kFloat32 = 1,
   kDouble = 2,
   kUInt32 = 3,
-  kUInt64 = 4
+  kUInt64 = 4,
+  kChar = 5
+};
+
+enum class FeatureType : uint8_t {
+  kNumerical
 };
 
 /*!
@@ -40,7 +45,7 @@ enum class DataType : uint8_t {
 class MetaInfo {
  public:
   /*! \brief number of data fields in MetaInfo */
-  static constexpr uint64_t kNumField = 9;
+  static constexpr uint64_t kNumField = 11;
 
   /*! \brief number of rows in the data */
   uint64_t num_row_{0};  // NOLINT
@@ -71,6 +76,19 @@ class MetaInfo {
    * \brief upper bound of the label, to be used for survival analysis (censored regression)
    */
   HostDeviceVector<bst_float> labels_upper_bound_;  // NOLINT
+
+  /*!
+   * \brief Name of type for each feature provided by users. Eg. "int"/"float"/"i"/"q"
+   */
+  std::vector<std::string> feature_type_names;
+  /*!
+   * \brief Name for each feature.
+   */
+  std::vector<std::string> feature_names;
+  /*
+   * \brief Type of each feature.  Automatically set when feature_type_names is specifed.
+   */
+  HostDeviceVector<FeatureType> feature_types;
 
   /*! \brief default constructor */
   MetaInfo()  = default;
@@ -157,6 +175,12 @@ class MetaInfo {
    *        Right now only 1 column is permitted.
    */
   void SetInfo(const char* key, std::string const& interface_str);
+
+  void GetInfo(char const* key, bst_row_t* out_len, DataType dtype,
+               const void** out_dptr) const;
+
+  void SetFeatureInfo(const char *key, const char **info, const bst_ulong size);
+  void GetFeatureInfo(const char *field, std::vector<std::string>* out_str_vecs) const;
 
   /*
    * \brief Extend with other MetaInfo.

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -176,7 +176,7 @@ class MetaInfo {
    */
   void SetInfo(const char* key, std::string const& interface_str);
 
-  void GetInfo(char const* key, bst_row_t* out_len, DataType dtype,
+  void GetInfo(char const* key, bst_ulong* out_len, DataType dtype,
                const void** out_dptr) const;
 
   void SetFeatureInfo(const char *key, const char **info, const bst_ulong size);

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -32,7 +32,7 @@ enum class DataType : uint8_t {
   kDouble = 2,
   kUInt32 = 3,
   kUInt64 = 4,
-  kChar = 5
+  kStr = 5
 };
 
 enum class FeatureType : uint8_t {

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -456,6 +456,8 @@ class BatchSet {
   BatchIterator<T> begin_iter_;
 };
 
+struct XGBAPIThreadLocalEntry;
+
 /*!
  * \brief Internal data structured used by XGBoost during training.
  */
@@ -474,6 +476,10 @@ class DMatrix {
   }
   /*! \brief meta information of the dataset */
   virtual const MetaInfo& Info() const = 0;
+
+  /*! \brief Get thread local memory for returning data from DMatrix. */
+  XGBAPIThreadLocalEntry& GetThreadLocal() const;
+
   /**
    * \brief Gets batches. Use range based for loop over BatchSet to access individual batches.
    */
@@ -486,7 +492,7 @@ class DMatrix {
   /*! \return Whether the data columns single column block. */
   virtual bool SingleColBlock() const = 0;
   /*! \brief virtual destructor */
-  virtual ~DMatrix() = default;
+  virtual ~DMatrix();
 
   /*! \brief Whether the matrix is dense. */
   bool IsDense() const {

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -768,7 +768,9 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
             Labels for features. None will reset existing feature names
         """
         if feature_types is not None:
-            assert isinstance(feature_types, (list, str)), feature_types
+            if not isinstance(feature_types, (list, str)):
+                raise TypeError(
+                    'feature_types must be string or list of strings')
             if isinstance(feature_types, STRING_TYPES):
                 # single string will be applied to all columns
                 feature_types = [feature_types] * self.num_col()

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -729,7 +729,7 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
                 c_bst_ulong(len(feature_names))))
         else:
             # reset feature_types also
-            _check_call(_LIB.XGDMatrixSetStrUFeatureInfo(
+            _check_call(_LIB.XGDMatrixSetStrFeatureInfo(
                 self.handle,
                 c_str('feature_name'),
                 None,
@@ -783,7 +783,7 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
                                for f in feature_types]
             c_feature_types = (ctypes.c_char_p *
                                len(c_feature_types))(*c_feature_types)
-            _check_call(_LIB.XGDMatrixSetStrUFeatureInfo(
+            _check_call(_LIB.XGDMatrixSetStrFeatureInfo(
                 self.handle, c_str('feature_type'),
                 c_feature_types,
                 c_bst_ulong(len(feature_types))))
@@ -793,7 +793,7 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
                 raise ValueError(msg)
         else:
             # Reset.
-            _check_call(_LIB.XGDMatrixSetStrUFeatureInfo(
+            _check_call(_LIB.XGDMatrixSetStrFeatureInfo(
                 self.handle,
                 c_str('feature_type'),
                 None,

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -723,7 +723,7 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
                                for f in feature_names]
             c_feature_names = (ctypes.c_char_p *
                                len(c_feature_names))(*c_feature_names)
-            _check_call(_LIB.XGDMatrixSetStrUFeatureInfo(
+            _check_call(_LIB.XGDMatrixSetStrFeatureInfo(
                 self.handle, c_str('feature_name'),
                 c_feature_names,
                 c_bst_ulong(len(feature_names))))

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -372,7 +372,7 @@ class DTHandler(DataHandler):
                 raise ValueError(
                     'DataTable has own feature types, cannot pass them in.')
             feature_types = np.vectorize(self.dt_type_mapper2.get)(
-                data_types_names)
+                data_types_names).tolist()
 
         return data, feature_names, feature_types
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -293,13 +293,6 @@ XGB_DLL int XGDMatrixSetStrUFeatureInfo(DMatrixHandle handle, const char *field,
   API_END();
 }
 
-using DMatrixThreadLocal =
-    dmlc::ThreadLocalStore<std::map<DMatrix const *, XGBAPIThreadLocalEntry>>;
-
-XGBAPIThreadLocalEntry& GetDMatrixThreadLocal(std::shared_ptr<DMatrix> m) {
-  return (*DMatrixThreadLocal::Get())[m.get()];
-}
-
 XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
                                        xgboost::bst_ulong *len,
                                        const char ***out_features) {
@@ -308,8 +301,8 @@ XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
   auto m = *static_cast<std::shared_ptr<DMatrix>*>(handle);
   auto &info = static_cast<std::shared_ptr<DMatrix> *>(handle)->get()->Info();
 
-  std::vector<const char *> &charp_vecs = GetDMatrixThreadLocal(m).ret_vec_charp;
-  std::vector<std::string> &str_vecs = GetDMatrixThreadLocal(m).ret_vec_str;
+  std::vector<const char *> &charp_vecs = m->GetThreadLocal().ret_vec_charp;
+  std::vector<std::string> &str_vecs = m->GetThreadLocal().ret_vec_str;
 
   info.GetFeatureInfo(field, &str_vecs);
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -283,9 +283,9 @@ XGB_DLL int XGDMatrixSetUIntInfo(DMatrixHandle handle,
   API_END();
 }
 
-XGB_DLL int XGDMatrixSetStrUFeatureInfo(DMatrixHandle handle, const char *field,
-                                        const char **c_info,
-                                        const xgboost::bst_ulong size) {
+XGB_DLL int XGDMatrixSetStrFeatureInfo(DMatrixHandle handle, const char *field,
+                                       const char **c_info,
+                                       const xgboost::bst_ulong size) {
   API_BEGIN();
   CHECK_HANDLE();
   auto &info = static_cast<std::shared_ptr<DMatrix> *>(handle)->get()->Info();

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -283,6 +283,45 @@ XGB_DLL int XGDMatrixSetUIntInfo(DMatrixHandle handle,
   API_END();
 }
 
+XGB_DLL int XGDMatrixSetStrUFeatureInfo(DMatrixHandle handle, const char *field,
+                                        const char **c_info,
+                                        const xgboost::bst_ulong size) {
+  API_BEGIN();
+  CHECK_HANDLE();
+  auto &info = static_cast<std::shared_ptr<DMatrix> *>(handle)->get()->Info();
+  info.SetFeatureInfo(field, c_info, size);
+  API_END();
+}
+
+using DMatrixThreadLocal =
+    dmlc::ThreadLocalStore<std::map<DMatrix const *, XGBAPIThreadLocalEntry>>;
+
+XGBAPIThreadLocalEntry& GetDMatrixThreadLocal(std::shared_ptr<DMatrix> m) {
+  return (*DMatrixThreadLocal::Get())[m.get()];
+}
+
+XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
+                                       xgboost::bst_ulong *len,
+                                       const char ***out_features) {
+  API_BEGIN();
+  CHECK_HANDLE();
+  auto m = *static_cast<std::shared_ptr<DMatrix>*>(handle);
+  auto &info = static_cast<std::shared_ptr<DMatrix> *>(handle)->get()->Info();
+
+  std::vector<const char *> &charp_vecs = GetDMatrixThreadLocal(m).ret_vec_charp;
+  std::vector<std::string> &str_vecs = GetDMatrixThreadLocal(m).ret_vec_str;
+
+  info.GetFeatureInfo(field, &str_vecs);
+
+  charp_vecs.resize(str_vecs.size());
+  for (size_t i = 0; i < str_vecs.size(); ++i) {
+    charp_vecs[i] = str_vecs[i].c_str();
+  }
+  *out_features = dmlc::BeginPtr(charp_vecs);
+  *len = static_cast<xgboost::bst_ulong>(charp_vecs.size());
+  API_END();
+}
+
 XGB_DLL int XGDMatrixSetGroup(DMatrixHandle handle,
                               const unsigned* group,
                               xgboost::bst_ulong len) {
@@ -301,22 +340,7 @@ XGB_DLL int XGDMatrixGetFloatInfo(const DMatrixHandle handle,
   API_BEGIN();
   CHECK_HANDLE();
   const MetaInfo& info = static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info();
-  const std::vector<bst_float>* vec = nullptr;
-  if (!std::strcmp(field, "label")) {
-    vec = &info.labels_.HostVector();
-  } else if (!std::strcmp(field, "weight")) {
-    vec = &info.weights_.HostVector();
-  } else if (!std::strcmp(field, "base_margin")) {
-    vec = &info.base_margin_.HostVector();
-  } else if (!std::strcmp(field, "label_lower_bound")) {
-    vec = &info.labels_lower_bound_.HostVector();
-  } else if (!std::strcmp(field, "label_upper_bound")) {
-    vec = &info.labels_upper_bound_.HostVector();
-  } else {
-    LOG(FATAL) << "Unknown float field name " << field;
-  }
-  *out_len = static_cast<xgboost::bst_ulong>(vec->size());  // NOLINT
-  *out_dptr = dmlc::BeginPtr(*vec);
+  info.GetInfo(field, out_len, DataType::kFloat32, reinterpret_cast<void const**>(out_dptr));
   API_END();
 }
 
@@ -327,14 +351,7 @@ XGB_DLL int XGDMatrixGetUIntInfo(const DMatrixHandle handle,
   API_BEGIN();
   CHECK_HANDLE();
   const MetaInfo& info = static_cast<std::shared_ptr<DMatrix>*>(handle)->get()->Info();
-  const std::vector<unsigned>* vec = nullptr;
-  if (!std::strcmp(field, "group_ptr")) {
-    vec = &info.group_ptr_;
-  } else {
-    LOG(FATAL) << "Unknown uint field name " << field;
-  }
-  *out_len = static_cast<xgboost::bst_ulong>(vec->size());
-  *out_dptr = dmlc::BeginPtr(*vec);
+  info.GetInfo(field, out_len, DataType::kUInt32, reinterpret_cast<void const**>(out_dptr));
   API_END();
 }
 

--- a/src/common/host_device_vector.cc
+++ b/src/common/host_device_vector.cc
@@ -171,6 +171,8 @@ void HostDeviceVector<T>::SetDevice(int device) const {}
 template class HostDeviceVector<bst_float>;
 template class HostDeviceVector<GradientPair>;
 template class HostDeviceVector<int32_t>;   // bst_node_t
+template class HostDeviceVector<uint8_t>;
+template class HostDeviceVector<FeatureType>;
 template class HostDeviceVector<Entry>;
 template class HostDeviceVector<uint64_t>;  // bst_row_t
 template class HostDeviceVector<uint32_t>;  // bst_feature_t

--- a/src/common/host_device_vector.cu
+++ b/src/common/host_device_vector.cu
@@ -398,6 +398,7 @@ template class HostDeviceVector<bst_float>;
 template class HostDeviceVector<GradientPair>;
 template class HostDeviceVector<int32_t>;   // bst_node_t
 template class HostDeviceVector<uint8_t>;
+template class HostDeviceVector<FeatureType>;
 template class HostDeviceVector<Entry>;
 template class HostDeviceVector<uint64_t>;  // bst_row_t
 template class HostDeviceVector<uint32_t>;  // bst_feature_t

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -177,9 +177,9 @@ void MetaInfo::SaveBinary(dmlc::Stream *fo) const {
   SaveVectorField(fo, u8"labels_upper_bound", DataType::kFloat32,
                   {labels_upper_bound_.Size(), 1}, labels_upper_bound_); ++field_cnt;
 
-  SaveVectorField(fo, u8"feature_name", DataType::kChar,
+  SaveVectorField(fo, u8"feature_name", DataType::kStr,
                   {feature_names.size(), 1}, feature_names); ++field_cnt;
-  SaveVectorField(fo, u8"feature_type", DataType::kChar,
+  SaveVectorField(fo, u8"feature_type", DataType::kStr,
                   {feature_type_names.size(), 1}, feature_type_names); ++field_cnt;
 
   CHECK_EQ(field_cnt, kNumField) << "Wrong number of fields";
@@ -241,8 +241,8 @@ void MetaInfo::LoadBinary(dmlc::Stream *fi) {
   LoadVectorField(fi, u8"labels_lower_bound", DataType::kFloat32, &labels_lower_bound_);
   LoadVectorField(fi, u8"labels_upper_bound", DataType::kFloat32, &labels_upper_bound_);
 
-  LoadVectorField(fi, u8"feature_name", DataType::kChar, &feature_names);
-  LoadVectorField(fi, u8"feature_type", DataType::kChar, &feature_type_names);
+  LoadVectorField(fi, u8"feature_name", DataType::kStr, &feature_names);
+  LoadVectorField(fi, u8"feature_type", DataType::kStr, &feature_type_names);
   LoadFeatureType(feature_type_names, &feature_types.HostVector());
 }
 

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -554,7 +554,7 @@ using DMatrixThreadLocal =
 
 XGBAPIThreadLocalEntry& DMatrix::GetThreadLocal() const {
   return (*DMatrixThreadLocal::Get())[this];
-};
+}
 
 DMatrix::~DMatrix() {
   auto local_map = DMatrixThreadLocal::Get();

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -148,8 +148,10 @@ void MetaInfo::Clear() {
  * | group_ptr          | kUInt32  | False     | ${size} |       1 | ${group_ptr_}           |
  * | weights            | kFloat32 | False     | ${size} |       1 | ${weights_}             |
  * | base_margin        | kFloat32 | False     | ${size} |       1 | ${base_margin_}         |
- * | labels_lower_bound | kFloat32 | False     | ${size} |       1 | ${labels_lower_bound__} |
- * | labels_upper_bound | kFloat32 | False     | ${size} |       1 | ${labels_upper_bound__} |
+ * | labels_lower_bound | kFloat32 | False     | ${size} |       1 | ${labels_lower_bound_}  |
+ * | labels_upper_bound | kFloat32 | False     | ${size} |       1 | ${labels_upper_bound_}  |
+ * | feature_names      | kStr     | False     | ${size} |       1 | ${feature_names}        |
+ * | feature_types      | kStr     | False     | ${size} |       1 | ${feature_types}        |
  *
  * Note that the scalar fields (is_scalar=True) will have num_row and num_col missing.
  * Also notice the difference between the saved name and the name used in `SetInfo':
@@ -177,9 +179,9 @@ void MetaInfo::SaveBinary(dmlc::Stream *fo) const {
   SaveVectorField(fo, u8"labels_upper_bound", DataType::kFloat32,
                   {labels_upper_bound_.Size(), 1}, labels_upper_bound_); ++field_cnt;
 
-  SaveVectorField(fo, u8"feature_name", DataType::kStr,
+  SaveVectorField(fo, u8"feature_names", DataType::kStr,
                   {feature_names.size(), 1}, feature_names); ++field_cnt;
-  SaveVectorField(fo, u8"feature_type", DataType::kStr,
+  SaveVectorField(fo, u8"feature_types", DataType::kStr,
                   {feature_type_names.size(), 1}, feature_type_names); ++field_cnt;
 
   CHECK_EQ(field_cnt, kNumField) << "Wrong number of fields";
@@ -241,8 +243,8 @@ void MetaInfo::LoadBinary(dmlc::Stream *fi) {
   LoadVectorField(fi, u8"labels_lower_bound", DataType::kFloat32, &labels_lower_bound_);
   LoadVectorField(fi, u8"labels_upper_bound", DataType::kFloat32, &labels_upper_bound_);
 
-  LoadVectorField(fi, u8"feature_name", DataType::kStr, &feature_names);
-  LoadVectorField(fi, u8"feature_type", DataType::kStr, &feature_type_names);
+  LoadVectorField(fi, u8"feature_names", DataType::kStr, &feature_names);
+  LoadVectorField(fi, u8"feature_types", DataType::kStr, &feature_type_names);
   LoadFeatureType(feature_type_names, &feature_types.HostVector());
 }
 

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -382,7 +382,7 @@ void MetaInfo::SetInfo(const char* key, const void* dptr, DataType dtype, size_t
   }
 }
 
-void MetaInfo::GetInfo(char const *key, bst_row_t *out_len, DataType dtype,
+void MetaInfo::GetInfo(char const *key, bst_ulong *out_len, DataType dtype,
                        const void **out_dptr) const {
   if (dtype == DataType::kFloat32) {
     const std::vector<bst_float>* vec = nullptr;

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -200,7 +200,7 @@ void LoadFeatureType(std::vector<std::string>const& type_names, std::vector<Feat
     } else if (elem == "q") {
       types->emplace_back(FeatureType::kNumerical);
     } else {
-      LOG(FATAL) << "All feature_names must be {int, float, i, q}";
+      LOG(FATAL) << "All feature_types must be {int, float, i, q}";
     }
   }
 }

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -202,7 +202,7 @@ void GenericParameter::ConfigureGpuId(bool require_gpu) {
 #endif  // defined(XGBOOST_USE_CUDA)
 }
 
-using XGBAPIThreadLocalStore =
+using LearnerAPIThreadLocalStore =
     dmlc::ThreadLocalStore<std::map<Learner const *, XGBAPIThreadLocalEntry>>;
 
 class LearnerConfiguration : public Learner {
@@ -895,7 +895,7 @@ class LearnerImpl : public LearnerIO {
   explicit LearnerImpl(std::vector<std::shared_ptr<DMatrix> > cache)
       : LearnerIO{cache} {}
   ~LearnerImpl() override {
-    auto local_map = XGBAPIThreadLocalStore::Get();
+    auto local_map = LearnerAPIThreadLocalStore::Get();
     if (local_map->find(this) != local_map->cend()) {
       local_map->erase(this);
     }
@@ -1023,7 +1023,7 @@ class LearnerImpl : public LearnerIO {
   }
 
   XGBAPIThreadLocalEntry& GetThreadLocal() const override {
-    return (*XGBAPIThreadLocalStore::Get())[this];
+    return (*LearnerAPIThreadLocalStore::Get())[this];
   }
 
   void InplacePredict(dmlc::any const &x, std::string const &type,

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -180,7 +180,7 @@ TEST(CAPI, DMatrixSetFeatureName) {
   }
 
   char const* feat_types [] {"i", "q"};
-  static_assert(sizeof(feat_types)/ sizeof(nullptr) == kCols, "");
+  static_assert(sizeof(feat_types)/ sizeof(feat_types[0]) == kCols, "");
   XGDMatrixSetStrFeatureInfo(handle, "feature_type", feat_types, kCols);
   char const **c_out_types;
   XGDMatrixGetStrFeatureInfo(handle, u8"feature_type", &out_len,

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -148,8 +148,8 @@ TEST(CAPI, CatchDMLCError) {
 }
 
 TEST(CAPI, DMatrixSetFeatureName) {
-  size_t constexpr kRows = 50;
-  bst_feature_t constexpr kCols = 50;
+  size_t constexpr kRows = 10;
+  bst_feature_t constexpr kCols = 2;
 
   DMatrixHandle handle;
   std::vector<float> data(kCols * kRows, 1.5);
@@ -177,6 +177,16 @@ TEST(CAPI, DMatrixSetFeatureName) {
   std::vector<std::string> out_features;
   for (bst_ulong i = 0; i < out_len; ++i) {
     ASSERT_EQ(std::to_string(i), c_out_features[i]);
+  }
+
+  char const* feat_types [] {"i", "q"};
+  static_assert(sizeof(feat_types)/ sizeof(nullptr) == kCols, "");
+  XGDMatrixSetStrFeatureInfo(handle, "feature_type", feat_types, kCols);
+  char const **c_out_types;
+  XGDMatrixGetStrFeatureInfo(handle, u8"feature_type", &out_len,
+                             &c_out_types);
+  for (bst_ulong i = 0; i < out_len; ++i) {
+    ASSERT_STREQ(feat_types[i], c_out_types[i]);
   }
 
   XGDMatrixFree(handle);

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -168,7 +168,7 @@ TEST(CAPI, DMatrixSetFeatureName) {
                  [](auto const &str) { return str.c_str(); });
   XGDMatrixSetStrFeatureInfo(handle, u8"feature_name", c_feature_names.data(),
                              c_feature_names.size());
-  size_t out_len = 0;
+  bst_ulong out_len = 0;
   char const **c_out_features;
   XGDMatrixGetStrFeatureInfo(handle, u8"feature_name", &out_len,
                              &c_out_features);

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -10,7 +10,6 @@
 #include "../helpers.h"
 #include "../../../src/common/io.h"
 
-
 TEST(CAPI, XGDMatrixCreateFromMatDT) {
   std::vector<int> col0 = {0, -1, 3};
   std::vector<float> col1 = {-4.0f, 2.0f, 0.0f};
@@ -179,5 +178,7 @@ TEST(CAPI, DMatrixSetFeatureName) {
   for (bst_ulong i = 0; i < out_len; ++i) {
     ASSERT_EQ(std::to_string(i), c_out_features[i]);
   }
+
+  XGDMatrixFree(handle);
 }
 }  // namespace xgboost

--- a/tests/python/test_dmatrix.py
+++ b/tests/python/test_dmatrix.py
@@ -115,6 +115,7 @@ class TestDMatrix(unittest.TestCase):
         dm.feature_names = list('abcde')
         assert dm.feature_names == list('abcde')
 
+        assert dm.slice([0, 1]).num_col() == dm.num_col()
         assert dm.slice([0, 1]).feature_names == dm.feature_names
 
         dm.feature_types = 'q'


### PR DESCRIPTION
This way native code knows what data types we are dealing with.

* Add thread local return entry for DMatrix.
* Feature name is also moved.
* Save feature name and feature type in binary file.