### PR TITLE
[CI] Enforce daily budget in Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
   // Build stages
   stages {
     stage('Jenkins Linux: Initialize') {
-      agent { label 'master' }
+      agent { label 'job_initializer' }
       steps {
         script {
           checkoutSrcs()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,13 +31,14 @@ pipeline {
 
   // Build stages
   stages {
-    stage('Jenkins Linux: Get sources') {
-      agent { label 'linux && cpu' }
+    stage('Jenkins Linux: Initialize') {
+      agent { label 'master' }
       steps {
         script {
           checkoutSrcs()
           commit_id = "${GIT_COMMIT}"
         }
+        sh 'python3 tests/jenkins_get_approval.py'
         stash name: 'srcs'
         milestone ordinal: 1
       }

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -12,13 +12,14 @@ pipeline {
   agent none
   // Build stages
   stages {
-    stage('Jenkins Win64: Get sources') {
-      agent { label 'win64 && build' }
+    stage('Jenkins Win64: Initialize') {
+      agent { label 'master' }
       steps {
         script {
           checkoutSrcs()
           commit_id = "${GIT_COMMIT}"
         }
+        sh 'python3 tests/jenkins_get_approval.py'
         stash name: 'srcs'
         milestone ordinal: 1
       }

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -13,7 +13,7 @@ pipeline {
   // Build stages
   stages {
     stage('Jenkins Win64: Initialize') {
-      agent { label 'master' }
+      agent { label 'job_initializer' }
       steps {
         script {
           checkoutSrcs()

--- a/tests/jenkins_get_approval.py
+++ b/tests/jenkins_get_approval.py
@@ -1,0 +1,26 @@
+import boto3
+import json
+
+lambda_client = boto3.client('lambda', region_name='us-west-2')
+
+# Source code for the Lambda function is available at https://github.com/hcho3/xgboost-devops
+r = lambda_client.invoke(
+    FunctionName='XGBoostCICostWatcher',
+    InvocationType='RequestResponse',
+    Payload='{}'.encode('utf-8')
+)
+
+payload = r['Payload'].read().decode('utf-8')
+if 'FunctionError' in r:
+    msg = 'Error when invoking the Lambda function. Stack trace:\n'
+    error = json.loads(payload)
+    msg += f"    {error['errorType']}: {error['errorMessage']}\n"
+    for trace in error['stackTrace']:
+        for line in trace.split('\n'):
+            msg += f'    {line}\n'
+    raise RuntimeError(msg)
+response = json.loads(payload)
+if response['approved']:
+    print(f"Testing approved. Reason: {response['reason']}")
+else:
+    raise RuntimeError(f"Testing rejected. Reason: {response['reason']}")


### PR DESCRIPTION
Fixes #5176 by enforcing a daily budget in Jenkins CI. @dmlc/xgboost-committer 

How it works: For each incoming pull request, Jenkins will first call the AWS Lambda (*) function `XGBoostCICostWatcher`. The Lambda function determines whether the expense incurred for today (\*\*) is under [the specified daily budget](https://github.com/hcho3/xgboost-devops/blob/c358525299489c0e1285bc525817e791aa46ef55/cost_watcher/metadata.py#L1-L2). The function returns `true` when today's expense did not yet exceed the budget; the function returns `false` if the expense exceeds the budget. When the expense is found to exceed the daily budget, all testing jobs for incoming pull requests gets terminated preemptively so that the CI server stops incurring more cloud expenses.

EC2 (compute) comprises the vast majority of the cloud cost, so we only keep track of the expenses for EC2.

The content of `XGBoostCICostWatcher` is found at https://github.com/hcho3/xgboost-devops/tree/mainline/cost_watcher.

Expected message (when limit is not yet reached)
```
Testing approved. Reason: Today's spending (8.85 USD) is within the budget (33.00 USD) allocated for today.
```

Expected message (when limit is reached)
```
Testing rejected. Reason: Today's spending (35.00 USD) exceeded the budget (33.00 USD) allocated for today!
```

How it was tested: I ran the Lambda function `XGBoostCICostWatcher` once every minute for 24 hours. No error was reported.

(*) AWS Lambda is a service that lets you host and run a small function that runs for a short while.
(\*\*) Each day starts at midnight UTC and ends at 23:59:59 UTC. So the spending limit gets reset every midnight UTC.