### PR TITLE
[CI] Reduce load on Windows CI pipeline

### DIFF
--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -41,7 +41,6 @@ pipeline {
         script {
           parallel ([
             'test-win64-cpu': { TestWin64CPU() },
-            'test-win64-gpu-cuda10.0': { TestWin64GPU(cuda_target: 'cuda10_0') },
             'test-win64-gpu-cuda10.1': { TestWin64GPU(cuda_target: 'cuda10_1') }
           ])
         }


### PR DESCRIPTION
As discussed in #5891, tests for the Windows platform cost a disproportionate amount of the expenses, even though a majority of the tests overall run in Linux:
![Screen Shot 2020-07-14 at 4 23 14 AM](https://user-images.githubusercontent.com/2532981/87420276-d7cdc680-c589-11ea-8995-7741fa18e2ce.png)

Until a better solution is found, we reduce the load by removing CUDA 10.0 target from the Jenkins pipeline for Windows.