### PR TITLE
Fix R package build with CMake 3.13

### DIFF
--- a/R-package/CMakeLists.txt
+++ b/R-package/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(xgboost-r
   ${PROJECT_SOURCE_DIR}/include
   ${PROJECT_SOURCE_DIR}/dmlc-core/include
   ${PROJECT_SOURCE_DIR}/rabit/include)
-target_link_libraries(xgboost-r PRIVATE ${LIBR_CORE_LIBRARY})
+target_link_libraries(xgboost-r PUBLIC ${LIBR_CORE_LIBRARY})
 set_target_properties(
   xgboost-r PROPERTIES
   CXX_STANDARD 14

--- a/R-package/CMakeLists.txt
+++ b/R-package/CMakeLists.txt
@@ -22,6 +22,10 @@ target_include_directories(xgboost-r
   ${PROJECT_SOURCE_DIR}/dmlc-core/include
   ${PROJECT_SOURCE_DIR}/rabit/include)
 target_link_libraries(xgboost-r PUBLIC ${LIBR_CORE_LIBRARY})
+if (USE_OPENMP)
+  find_package(OpenMP REQUIRED)
+  target_link_libraries(xgboost-r PUBLIC OpenMP::OpenMP_CXX OpenMP::OpenMP_C)
+endif (USE_OPENMP)
 set_target_properties(
   xgboost-r PROPERTIES
   CXX_STANDARD 14


### PR DESCRIPTION
Fixes #5894. 

The dependency graph in XGBoost build looks like this:
```
xgboost-r  ---> objxgboost  ---> xgboost
```
Previously, the R lib was linked to `xgboost-r` with `PRIVATE` designation, and if CMake 3.13 was used, the R lib requirement would not be progagated to `xgboost` target, so that is why the build failed in #5894.

This PR make the R lib a `PUBLIC` requirement of `xgboost-r`, so the build will work correctly with CMake 3.13.

Note that the fix does not apply to CMake 3.14 or newer. The Release Note for CMake 3.14 says:
> Object library linking has been fixed to propagate private link libraries of object libraries to consuming targets.