### PR TITLE
Simplify CSRAdapter

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -150,11 +150,11 @@ XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,
                                      const unsigned* indices,
                                      const bst_float* data,
                                      size_t nindptr,
-                                     size_t nelem,
+                                     size_t nelem, // unused
                                      size_t num_col,
                                      DMatrixHandle* out) {
   API_BEGIN();
-  data::CSRAdapter adapter(indptr, indices, data, nindptr - 1, nelem, num_col);
+  data::CSRAdapter adapter(indptr, indices, data, nindptr - 1, num_col);
   *out = new std::shared_ptr<DMatrix>(DMatrix::Create(&adapter, std::nan(""), 1));
   API_END();
 }
@@ -546,7 +546,7 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle,
                                     const unsigned* indices,
                                     const bst_float* data,
                                     size_t nindptr,
-                                    size_t nelem,
+                                    size_t nelem, // unusued
                                     size_t num_col,
                                     float missing,
                                     unsigned iteration_begin,
@@ -561,7 +561,7 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle,
   auto *learner = static_cast<xgboost::Learner *>(handle);
 
   std::shared_ptr<xgboost::data::CSRAdapter> x{
-    new xgboost::data::CSRAdapter(indptr, indices, data, nindptr - 1, nelem, num_col)};
+    new xgboost::data::CSRAdapter(indptr, indices, data, nindptr - 1, num_col)};
   HostDeviceVector<float>* p_predt { nullptr };
   std::string type { c_type };
   learner->InplacePredict(x, type, missing, &p_predt);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -150,7 +150,7 @@ XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,
                                      const unsigned* indices,
                                      const bst_float* data,
                                      size_t nindptr,
-                                     size_t nelem, // unused
+                                     size_t nelem,  // unused
                                      size_t num_col,
                                      DMatrixHandle* out) {
   API_BEGIN();
@@ -546,7 +546,7 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle,
                                     const unsigned* indices,
                                     const bst_float* data,
                                     size_t nindptr,
-                                    size_t nelem, // unusued
+                                    size_t nelem,  // unusued
                                     size_t num_col,
                                     float missing,
                                     unsigned iteration_begin,

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -136,8 +136,7 @@ class CSRAdapterBatch : public detail::NoMetaInfo {
     const float* values_;
   };
   CSRAdapterBatch(const size_t* row_ptr, const unsigned* feature_idx,
-                  const float* values, size_t num_rows, size_t num_elements,
-                  size_t num_features)
+                  const float* values, size_t num_rows, size_t num_features)
       : row_ptr_(row_ptr),
         feature_idx_(feature_idx),
         values_(values),
@@ -160,10 +159,8 @@ class CSRAdapterBatch : public detail::NoMetaInfo {
 class CSRAdapter : public detail::SingleBatchDataIter<CSRAdapterBatch> {
  public:
   CSRAdapter(const size_t* row_ptr, const unsigned* feature_idx,
-             const float* values, size_t num_rows, size_t num_elements,
-             size_t num_features)
-      : batch_(row_ptr, feature_idx, values, num_rows, num_elements,
-               num_features),
+             const float* values, size_t num_rows, size_t num_features)
+      : batch_(row_ptr, feature_idx, values, num_rows, num_features),
         num_rows_(num_rows),
         num_columns_(num_features) {}
   const CSRAdapterBatch& Value() const override { return batch_; }

--- a/tests/cpp/data/test_adapter.cc
+++ b/tests/cpp/data/test_adapter.cc
@@ -18,7 +18,7 @@ TEST(Adapter, CSRAdapter) {
   std::vector<unsigned> feature_idx = {0, 1, 0, 1, 1};
   std::vector<size_t> row_ptr = {0, 2, 4, 5};
   data::CSRAdapter adapter(row_ptr.data(), feature_idx.data(), data.data(),
-                           row_ptr.size() - 1, data.size(), n);
+                           row_ptr.size() - 1, n);
   adapter.Next();
   auto & batch = adapter.Value();
   auto line0 = batch.GetLine(0);

--- a/tests/cpp/data/test_simple_dmatrix.cc
+++ b/tests/cpp/data/test_simple_dmatrix.cc
@@ -72,7 +72,7 @@ TEST(SimpleDMatrix, Empty) {
   std::vector<size_t> row_ptr = {};
 
   data::CSRAdapter csr_adapter(row_ptr.data(), feature_idx.data(), data.data(),
-                               0, 0, 0);
+                               0, 0);
   std::unique_ptr<data::SimpleDMatrix> dmat(new data::SimpleDMatrix(
       &csr_adapter, std::numeric_limits<float>::quiet_NaN(), 1));
   CHECK_EQ(dmat->Info().num_nonzero_, 0);
@@ -109,7 +109,7 @@ TEST(SimpleDMatrix, MissingData) {
   std::vector<size_t> row_ptr = {0, 2, 3};
 
   data::CSRAdapter adapter(row_ptr.data(), feature_idx.data(), data.data(), 2,
-                           3, 2);
+                           2);
   std::unique_ptr<data::SimpleDMatrix> dmat{new data::SimpleDMatrix{
       &adapter, std::numeric_limits<float>::quiet_NaN(), 1}};
   CHECK_EQ(dmat->Info().num_nonzero_, 2);
@@ -123,7 +123,7 @@ TEST(SimpleDMatrix, EmptyRow) {
   std::vector<size_t> row_ptr = {0, 2, 2};
 
   data::CSRAdapter adapter(row_ptr.data(), feature_idx.data(), data.data(), 2,
-                           2, 2);
+                           2);
   data::SimpleDMatrix dmat(&adapter, std::numeric_limits<float>::quiet_NaN(),
                            1);
   CHECK_EQ(dmat.Info().num_nonzero_, 2);

--- a/tests/cpp/data/test_sparse_page_dmatrix.cc
+++ b/tests/cpp/data/test_sparse_page_dmatrix.cc
@@ -131,7 +131,7 @@ TEST(SparsePageDMatrix, Empty) {
 
   {
     data::CSRAdapter csr_adapter(row_ptr.data(), feature_idx.data(),
-                                 data.data(), 0, 0, 0);
+                                 data.data(), 0, 0);
     data::SparsePageDMatrix dmat(
         &csr_adapter, std::numeric_limits<float>::quiet_NaN(), 1, tmp_file);
     EXPECT_EQ(dmat.Info().num_nonzero_, 0);
@@ -174,7 +174,7 @@ TEST(SparsePageDMatrix, MissingData) {
   std::vector<size_t> row_ptr = {0, 2, 3};
 
   data::CSRAdapter adapter(row_ptr.data(), feature_idx.data(), data.data(), 2,
-                           3, 2);
+                           2);
   data::SparsePageDMatrix dmat(
       &adapter, std::numeric_limits<float>::quiet_NaN(), 1, tmp_file);
   EXPECT_EQ(dmat.Info().num_nonzero_, 2);
@@ -192,7 +192,7 @@ TEST(SparsePageDMatrix, EmptyRow) {
   std::vector<size_t> row_ptr = {0, 2, 2};
 
   data::CSRAdapter adapter(row_ptr.data(), feature_idx.data(), data.data(), 2,
-                           2, 2);
+                           2);
   data::SparsePageDMatrix dmat(
       &adapter, std::numeric_limits<float>::quiet_NaN(), 1, tmp_file);
   EXPECT_EQ(dmat.Info().num_nonzero_, 2);

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -322,7 +322,7 @@ RandomDataGenerator::GenerateDMatrix(bool with_label, bool float_label,
   HostDeviceVector<bst_feature_t> columns;
   this->GenerateCSR(&data, &rptrs, &columns);
   data::CSRAdapter adapter(rptrs.HostPointer(), columns.HostPointer(),
-                           data.HostPointer(), rows_, data.Size(), cols_);
+                           data.HostPointer(), rows_, cols_);
   std::shared_ptr<DMatrix> out{
       DMatrix::Create(&adapter, std::numeric_limits<float>::quiet_NaN(), 1)};
 

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -161,7 +161,7 @@ TEST(CpuPredictor, InplacePredict) {
     gen.GenerateCSR(&data, &rptrs, &columns);
     std::shared_ptr<data::CSRAdapter> x{new data::CSRAdapter(
         rptrs.HostPointer(), columns.HostPointer(), data.HostPointer(), kRows,
-        data.Size(), kCols)};
+        kCols)};
     TestInplacePrediction(x, "cpu_predictor", kRows, kCols, -1);
   }
 }


### PR DESCRIPTION
Whilst working on #5854, I noticed that the nelem argument supplied to
`XGDMatrixCreateFromCSREx` seems to have no effect whatsoever.

`CSRAdapterBatch` currently doesn't seem to store this field, let alone
do anything with it.

As such, it seems like it can be removed entirely.

This PR removes references to it from CSRAdapter and CSRAdapterBatch.
The signature of the C API functions has not been modified to ensure
backwards compatibility.