### PR TITLE
Fix Windows 2016 build.

### DIFF
--- a/jvm-packages/create_jni.py
+++ b/jvm-packages/create_jni.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         with cd("build"):
             if sys.platform == "win32":
                 # Force x64 build on Windows.
-                maybe_generator = ' -G"Visual Studio 14 Win64"'
+                maybe_generator = ' -A x64'
             else:
                 maybe_generator = ""
             if sys.platform == "linux":

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -153,6 +153,8 @@ class BuildExt(build_ext.build_ext):  # pylint: disable=too-many-ancestors
                         '%s is used for building Windows distribution.', vs)
                     break
                 except subprocess.CalledProcessError:
+                    shutil.rmtree(build_dir)
+                    os.mkdir(build_dir)
                     continue
         else:
             gen = '-GNinja' if build_tool == 'ninja' else '-GUnix Makefiles'

--- a/src/common/charconv.cc
+++ b/src/common/charconv.cc
@@ -285,7 +285,7 @@ struct RyuPowLogUtils {
 
   static uint32_t FloorLog2(const uint32_t value) {
 #if defined(_MSC_VER)
-    unsigned long index;
+    unsigned long index;  // NOLINT
     return _BitScanReverse(&index, value) ? index : 32;
 #else
     return 31 - __builtin_clz(value);

--- a/src/common/charconv.cc
+++ b/src/common/charconv.cc
@@ -37,11 +37,6 @@
 
 #if defined(_MSC_VER)
 #include <intrin.h>
-namespace {
-inline int32_t __builtin_clzll(uint64_t x) {
-  return static_cast<int32_t>(__lzcnt64(x));
-}
-}  // anonymous namespace
 #endif
 
 /*
@@ -288,8 +283,13 @@ struct RyuPowLogUtils {
     return MulShift(m, kFloatPow5Split[i], j);  // NOLINT
   }
 
-  static uint32_t FloorLog2(const uint64_t value) {
-    return 63 - __builtin_clzll(value);
+  static uint32_t FloorLog2(const uint32_t value) {
+#if defined(_MSC_VER)
+    unsigned long index;
+    return _BitScanReverse(&index, value) ? index : 32;
+#else
+    return 31 - __builtin_clz(value);
+#endif
   }
 
   /*


### PR DESCRIPTION
Found during setting up github action.  There's still an external test `SparsePage, PushCSCAfterTranspose`  failing on latest Ubuntu and Windows.  I can't fix it right now with the complexity of external memory.  So I just port a small fix here.