### PR TITLE
Further improvements and savings in Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -247,8 +247,12 @@ def BuildCUDA(args) {
     def container_type = "gpu_build"
     def docker_binary = "docker"
     def docker_args = "--build-arg CUDA_VERSION=${args.cuda_version}"
+    def arch_flag = ""
+    if (env.BRANCH_NAME != 'master' && !(env.BRANCH_NAME.startsWith('release'))) {
+      arch_flag = "-DGPU_COMPUTE_VER=75"
+    }
     sh """
-    ${dockerRun} ${container_type} ${docker_binary} ${docker_args} tests/ci_build/build_via_cmake.sh -DUSE_CUDA=ON -DUSE_NCCL=ON -DOPEN_MP:BOOL=ON -DHIDE_CXX_SYMBOLS=ON
+    ${dockerRun} ${container_type} ${docker_binary} ${docker_args} tests/ci_build/build_via_cmake.sh -DUSE_CUDA=ON -DUSE_NCCL=ON -DOPEN_MP:BOOL=ON -DHIDE_CXX_SYMBOLS=ON ${arch_flag}
     ${dockerRun} ${container_type} ${docker_binary} ${docker_args} bash -c "cd python-package && rm -rf dist/* && python setup.py bdist_wheel --universal"
     ${dockerRun} ${container_type} ${docker_binary} ${docker_args} python3 tests/ci_build/rename_whl.py python-package/dist/*.whl ${commit_id} manylinux2010_x86_64
     """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,8 +173,10 @@ def Doxygen() {
     sh """
     ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/doxygen.sh ${BRANCH_NAME}
     """
-    echo 'Uploading doc...'
-    s3Upload file: "build/${BRANCH_NAME}.tar.bz2", bucket: 'xgboost-docs', acl: 'PublicRead', path: "doxygen/${BRANCH_NAME}.tar.bz2"
+    if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('release')) {
+      echo 'Uploading doc...'
+      s3Upload file: "build/${BRANCH_NAME}.tar.bz2", bucket: 'xgboost-docs', acl: 'PublicRead', path: "doxygen/${BRANCH_NAME}.tar.bz2"
+    }
     deleteDir()
   }
 }
@@ -254,8 +256,11 @@ def BuildCUDA(args) {
     if (args.cuda_version == '10.0') {
       echo 'Stashing Python wheel...'
       stash name: 'xgboost_whl_cuda10', includes: 'python-package/dist/*.whl'
-      path = ("${BRANCH_NAME}" == 'master') ? '' : "${BRANCH_NAME}/"
-      s3Upload bucket: 'xgboost-nightly-builds', path: path, acl: 'PublicRead', workingDir: 'python-package/dist', includePathPattern:'**/*.whl'
+      if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('release')) {
+        echo 'Uploading Python wheel...'
+        path = ("${BRANCH_NAME}" == 'master') ? '' : "${BRANCH_NAME}/"
+        s3Upload bucket: 'xgboost-nightly-builds', path: path, acl: 'PublicRead', workingDir: 'python-package/dist', includePathPattern:'**/*.whl'
+      }
       echo 'Stashing C++ test executable (testxgboost)...'
       stash name: 'xgboost_cpp_tests', includes: 'build/testxgboost'
     }
@@ -289,8 +294,10 @@ def BuildJVMDoc() {
     sh """
     ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/build_jvm_doc.sh ${BRANCH_NAME}
     """
-    echo 'Uploading doc...'
-    s3Upload file: "jvm-packages/${BRANCH_NAME}.tar.bz2", bucket: 'xgboost-docs', acl: 'PublicRead', path: "${BRANCH_NAME}.tar.bz2"
+    if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('release')) {
+      echo 'Uploading doc...'
+      s3Upload file: "jvm-packages/${BRANCH_NAME}.tar.bz2", bucket: 'xgboost-docs', acl: 'PublicRead', path: "${BRANCH_NAME}.tar.bz2"
+    }
     deleteDir()
   }
 }

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -125,21 +125,19 @@ def TestWin64() {
     bat "nvcc --version"
     echo "Running C++ tests..."
     bat "build\\testxgboost.exe"
-    echo "Installing Python wheel..."
-    bat "conda activate && (python -m pip uninstall -y xgboost || cd .)"
-    bat """
-    conda activate && for /R %%i in (python-package\\dist\\*.whl) DO python -m pip install "%%i"
-    """
     echo "Installing Python dependencies..."
+    def env_name = 'win64_' + UUID.randomUUID().toString().replaceAll('-', '')
+    bat "conda env create -n ${env_name} --file=tests/ci_build/win64_conda_env.yml"
+    echo "Installing Python wheel..."
     bat """
-     conda activate && conda install -y hypothesis jsonschema && conda upgrade scikit-learn pandas numpy hypothesis  && python -m pip install cupy-cuda101
+    conda activate ${env_name} && for /R %%i in (python-package\\dist\\*.whl) DO python -m pip install "%%i"
     """
     echo "Running Python tests..."
-    bat "conda activate && python -m pytest -v -s -rxXs --fulltrace tests\\python"
+    bat "conda activate ${env_name} && python -m pytest -v -s -rxXs --fulltrace tests\\python"
     bat """
-    conda activate && python -m pytest -v -s -rxXs --fulltrace -m "(not slow) and (not mgpu)" tests\\python-gpu
+    conda activate ${env_name} && python -m pytest -v -s -rxXs --fulltrace -m "(not slow) and (not mgpu)" tests\\python-gpu
     """
-    bat "conda activate && python -m pip uninstall -y xgboost"
+    bat "conda env remove --name ${env_name}"
     deleteDir()
   }
 }

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -132,7 +132,7 @@ def TestWin64() {
     """
     echo "Installing Python dependencies..."
     bat """
-     conda activate && conda install -y hypothesis && conda upgrade scikit-learn pandas numpy hypothesis  && python -m pip install cupy-cuda101
+     conda activate && conda install -y hypothesis jsonschema && conda upgrade scikit-learn pandas numpy hypothesis  && python -m pip install cupy-cuda101
     """
     echo "Running Python tests..."
     bat "conda activate && python -m pytest -v -s -rxXs --fulltrace tests\\python"

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -120,6 +120,7 @@ def TestWin64() {
     unstash name: 'srcs'
     unstash name: 'xgboost_whl'
     unstash name: 'xgboost_cli'
+    unstash name: 'xgboost_cpp_tests'
     echo "Test Win64"
     bat "nvcc --version"
     echo "Running C++ tests..."

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -132,7 +132,7 @@ def TestWin64() {
     """
     echo "Installing Python dependencies..."
     bat """
-     conda activate && conda install -y hypothesis && conda upgrade scikit-learn pandas numpy hypothesis  && python -m pip install cupy-cuda100
+     conda activate && conda install -y hypothesis && conda upgrade scikit-learn pandas numpy hypothesis  && python -m pip install cupy-cuda101
     """
     echo "Running Python tests..."
     bat "conda activate && python -m pytest -v -s -rxXs --fulltrace tests\\python"

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -70,10 +70,14 @@ def BuildWin64() {
     unstash name: 'srcs'
     echo "Building XGBoost for Windows AMD64 target..."
     bat "nvcc --version"
+    def arch_flag = ""
+    if (env.BRANCH_NAME != 'master' && !(env.BRANCH_NAME.startsWith('release'))) {
+      arch_flag = "-DGPU_COMPUTE_VER=75"
+    }
     bat """
     mkdir build
     cd build
-    cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DUSE_DMLC_GTEST=ON
+    cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DUSE_DMLC_GTEST=ON ${arch_flag}
     """
     bat """
     cd build

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -10,6 +10,15 @@ def commit_id   // necessary to pass a variable from one stage to another
 
 pipeline {
   agent none
+
+  // Setup common job properties
+  options {
+    timestamps()
+    timeout(time: 240, unit: 'MINUTES')
+    buildDiscarder(logRotator(numToKeepStr: '10'))
+    preserveStashes()
+  }
+
   // Build stages
   stages {
     stage('Jenkins Win64: Initialize') {
@@ -40,8 +49,7 @@ pipeline {
       steps {
         script {
           parallel ([
-            'test-win64-cpu': { TestWin64CPU() },
-            'test-win64-gpu-cuda10.1': { TestWin64GPU(cuda_target: 'cuda10_1') }
+            'test-win64-cuda10.0': { TestWin64() },
           ])
         }
         milestone ordinal: 3
@@ -66,7 +74,7 @@ def checkoutSrcs() {
 }
 
 def BuildWin64() {
-  node('win64 && build && cuda10') {
+  node('win64 && cuda10_unified') {
     unstash name: 'srcs'
     echo "Building XGBoost for Windows AMD64 target..."
     bat "nvcc --version"
@@ -107,12 +115,12 @@ def BuildWin64() {
   }
 }
 
-def TestWin64CPU() {
-  node('win64 && cpu') {
+def TestWin64() {
+  node('win64 && cuda10_unified') {
     unstash name: 'srcs'
     unstash name: 'xgboost_whl'
     unstash name: 'xgboost_cli'
-    echo "Test Win64 CPU"
+    echo "Test Win64"
     echo "Installing Python wheel..."
     bat "conda activate && (python -m pip uninstall -y xgboost || cd .)"
     bat """
@@ -120,35 +128,10 @@ def TestWin64CPU() {
     """
     echo "Installing Python dependencies..."
     bat """
-     conda activate && conda install -y hypothesis && conda upgrade scikit-learn pandas numpy hypothesis
+     conda activate && conda install -y hypothesis && conda upgrade scikit-learn pandas numpy hypothesis  && python -m pip install cupy-cuda100
     """
     echo "Running Python tests..."
     bat "conda activate && python -m pytest -v -s --fulltrace tests\\python"
-    bat "conda activate && python -m pip uninstall -y xgboost"
-    deleteDir()
-  }
-}
-
-def TestWin64GPU(args) {
-  node("win64 && gpu && ${args.cuda_target}") {
-    unstash name: 'srcs'
-    unstash name: 'xgboost_whl'
-    unstash name: 'xgboost_cpp_tests'
-    echo "Test Win64 GPU (${args.cuda_target})"
-    bat "nvcc --version"
-    echo "Running C++ tests..."
-    bat "build\\testxgboost.exe"
-    echo "Installing Python wheel..."
-    bat "conda activate && (python -m pip uninstall -y xgboost || cd .)"
-    bat """
-    conda activate && for /R %%i in (python-package\\dist\\*.whl) DO python -m pip install "%%i"
-    """
-    echo "Installing Python dependencies..."
-    def cuda_short_ver = args.cuda_target.replaceAll('_', '')
-    bat """
-     conda activate && conda install -y hypothesis && conda upgrade scikit-learn pandas numpy hypothesis  && python -m pip install cupy-${cuda_short_ver}
-    """
-    echo "Running Python tests..."
     bat """
     conda activate && python -m pytest -v -s --fulltrace -m "(not slow) and (not mgpu)" tests\\python-gpu
     """

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -121,6 +121,9 @@ def TestWin64() {
     unstash name: 'xgboost_whl'
     unstash name: 'xgboost_cli'
     echo "Test Win64"
+    bat "nvcc --version"
+    echo "Running C++ tests..."
+    bat "build\\testxgboost.exe"
     echo "Installing Python wheel..."
     bat "conda activate && (python -m pip uninstall -y xgboost || cd .)"
     bat """

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -91,8 +91,11 @@ def BuildWin64() {
     """
     echo 'Stashing Python wheel...'
     stash name: 'xgboost_whl', includes: 'python-package/dist/*.whl'
-    path = ("${BRANCH_NAME}" == 'master') ? '' : "${BRANCH_NAME}/"
-    s3Upload bucket: 'xgboost-nightly-builds', path: path, acl: 'PublicRead', workingDir: 'python-package/dist', includePathPattern:'**/*.whl'
+    if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('release')) {
+      echo 'Uploading Python wheel...'
+      path = ("${BRANCH_NAME}" == 'master') ? '' : "${BRANCH_NAME}/"
+      s3Upload bucket: 'xgboost-nightly-builds', path: path, acl: 'PublicRead', workingDir: 'python-package/dist', includePathPattern:'**/*.whl'
+    }
     echo 'Stashing C++ test executable (testxgboost)...'
     stash name: 'xgboost_cpp_tests', includes: 'build/testxgboost.exe'
     stash name: 'xgboost_cli', includes: 'xgboost.exe'

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -38,7 +38,7 @@ pipeline {
       steps {
         script {
           parallel ([
-            'build-win64-cuda10.0': { BuildWin64() }
+            'build-win64-cuda10.1': { BuildWin64() }
           ])
         }
         milestone ordinal: 2
@@ -49,7 +49,7 @@ pipeline {
       steps {
         script {
           parallel ([
-            'test-win64-cuda10.0': { TestWin64() },
+            'test-win64-cuda10.1': { TestWin64() },
           ])
         }
         milestone ordinal: 3

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -131,9 +131,9 @@ def TestWin64() {
      conda activate && conda install -y hypothesis && conda upgrade scikit-learn pandas numpy hypothesis  && python -m pip install cupy-cuda100
     """
     echo "Running Python tests..."
-    bat "conda activate && python -m pytest -v -s --fulltrace tests\\python"
+    bat "conda activate && python -m pytest -v -s -rxXs --fulltrace tests\\python"
     bat """
-    conda activate && python -m pytest -v -s --fulltrace -m "(not slow) and (not mgpu)" tests\\python-gpu
+    conda activate && python -m pytest -v -s -rxXs --fulltrace -m "(not slow) and (not mgpu)" tests\\python-gpu
     """
     bat "conda activate && python -m pip uninstall -y xgboost"
     deleteDir()

--- a/tests/ci_build/deploy_jvm_packages.sh
+++ b/tests/ci_build/deploy_jvm_packages.sh
@@ -20,16 +20,5 @@ cd jvm-packages
 # Deploy to S3 bucket xgboost-maven-repo
 mvn --no-transfer-progress package deploy -P release-to-s3 -Dspark.version=${spark_version} -DskipTests
 
-# Compile XGBoost4J with Scala 2.11 too
-mvn clean
-# Rename artifactId of all XGBoost4J packages with suffix _2.11
-sed -i -e 's/<artifactId>xgboost\(.*\)_[0-9\.]\+/<artifactId>xgboost\1_2.11/' $(find . -name pom.xml)
-# Modify scala.version and scala.binary.version fields
-sed -i -e 's/<scala\.version>[0-9\.]\+/<scala.version>2.11.12/' $(find . -name pom.xml)
-sed -i -e 's/<scala\.binary\.version>[0-9\.]\+/<scala.binary.version>2.11/' $(find . -name pom.xml)
-
-# Re-build and deploy
-mvn --no-transfer-progress package deploy -P release-to-s3 -Dspark.version=${spark_version} -DskipTests
-
 set +x
 set +e

--- a/tests/ci_build/win64_conda_env.yml
+++ b/tests/ci_build/win64_conda_env.yml
@@ -1,0 +1,18 @@
+name: win64_env
+channels:
+- conda-forge
+dependencies:
+- python=3.7
+- numpy
+- scipy
+- matplotlib
+- scikit-learn
+- pandas
+- pytest
+- python-graphviz
+- boto3
+- hypothesis
+- jsonschema
+- pip
+- pip:
+  - cupy-cuda101

--- a/tests/python-gpu/test_gpu_demos.py
+++ b/tests/python-gpu/test_gpu_demos.py
@@ -1,10 +1,13 @@
 import os
 import subprocess
 import sys
+import pytest
 sys.path.append("tests/python")
+import testing as tm
 import test_demos as td         # noqa
 
 
+@pytest.mark.skipif(**tm.no_cupy())
 def test_data_iterator():
     script = os.path.join(td.PYTHON_DEMO_DIR, 'data_iterator.py')
     cmd = ['python', script]

--- a/tests/python/test_plotting.py
+++ b/tests/python/test_plotting.py
@@ -15,7 +15,7 @@ except ImportError:
     pass
 
 
-pytestmark = pytest.mark.skipif(**tm.no_matplotlib())
+pytestmark = pytest.mark.skipif(**tm.no_multiple(tm.no_matplotlib(), tm.no_graphviz()))
 
 
 dpath = 'demo/data/'

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -436,7 +436,8 @@ def test_sklearn_api_gblinear():
     assert err < 0.5
 
 
-@pytest.mark.skipif(**tm.no_multiple(tm.no_matplotlib(), tm.no_graphviz()))
+@pytest.mark.skipif(**tm.no_matplotlib())
+@pytest.mark.skipif(**tm.no_graphviz())
 def test_sklearn_plotting():
     from sklearn.datasets import load_iris
 

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -436,7 +436,7 @@ def test_sklearn_api_gblinear():
     assert err < 0.5
 
 
-@pytest.mark.skipif(**tm.no_matplotlib())
+@pytest.mark.skipif(**tm.no_multiple(tm.no_matplotlib(), tm.no_graphviz()))
 def test_sklearn_plotting():
     from sklearn.datasets import load_iris
 

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -98,6 +98,26 @@ def no_json_schema():
         return {'condition': True, 'reason': reason}
 
 
+def no_graphviz():
+    reason = 'graphviz is not installed'
+    try:
+        import graphviz  # noqa
+        return {'condition': False, 'reason': reason}
+    except ImportError:
+        return {'condition': True, 'reason': reason}
+
+
+def no_multiple(*args):
+    condition = False
+    reason = ''
+    for arg in args:
+        condition = (condition or arg['condition'])
+        if arg['condition']:
+            reason = arg['reason']
+            break
+    return {'condition': condition, 'reason': reason}
+
+
 # Contains a dataset in numpy format as well as the relevant objective and metric
 class TestDataset:
     def __init__(self, name, get_dataset, objective, metric


### PR DESCRIPTION
- [x] Reduce the number of machine images (AMIs) with Windows OS down to 1. All Windows jobs will run in the same kind of worker. **This change reduces the unit cost of the Windows test pipeline by 2/3 (66%).** To understand how this dramatic saving is achieved, we should understand [how AWS bills for EC2 machines](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-instance-hour-billing/). Quote from the official doc:

> Each partial instance hour consumed is billed per-second for Linux instances and as a full hour for all other instance types.

For example, if we launch a Linux EC2 instance, run it for 10 minutes and shut it down, then we only pay 1/6 of the hourly price. On the other hand, if we launch a Windows instance and shut it down 10 minutes later, then we have to pay the full hourly price, since 10 minutes gets rounded up to the next full hour. The difference is more dramatic if we launch multiple machines. Using two Linux instances for 10 minutes each costs 1/3 of the hourly price, whereas using two Windows instances for 10 minutes each cost twice the hourly price!

Now let's look at how the Windows testing pipeline is Jenkins is affected by the hourly pricing. Since all steps in the pipeline are at most 15 minutes long, we end up wasting a lot of money:

  * Before this PR.
![Screen Shot 2020-07-17 at 7 18 06 PM](https://user-images.githubusercontent.com/2532981/87842767-f7a00b80-c863-11ea-9365-7a427d3fccfd.png)

Cost for running the pipeline = Two hours C5a4xlarge worker-hour + One G4dnxlarge worker-hour = $1.352 * 2 + $0.71 = **$3.414**

  * After this PR.
![Screen Shot 2020-07-17 at 7 26 51 PM](https://user-images.githubusercontent.com/2532981/87842769-f969cf00-c863-11ea-90a8-b551a3381ae9.png)

Cost for running the pipeline = One G4dn2xlarge worker-hour = **$1.12**

- [x] Do not publish artifacts if the job is associated with a pull request. This measure saves space in S3.
- [x] Build CUDA code for Compute Capability 7.5 only, if the job is associated with a pull request. This measure speeds up the build.
- [x] Build nightly XGBoost4J SNAPSHOT JARs with Scala 2.12 only, now that Spark 3.0.0 dropped support for Scala 2.11.
- [x] Show skipped Python tests on Windows
- [x] Make Graphviz optional for Python tests