### PR TITLE
Setup github action.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: XGoost-CI
+name: XGBoost-CI
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -8,16 +8,46 @@ on: [push, pull_request]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  test-with-jvm:
+    name: Test JVM on OS ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, windows-2016, ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - name: Test JVM packages
+      run: |
+        cd jvm-packages
+        mvn test -pl :xgboost4j_2.12
+
+
   test-with-R:
     runs-on: ${{ matrix.config.os }}
 
-    name: Test R on OS ${{ matrix.config.os }}, R (${{ matrix.config.r }})
+    name: Test R on OS ${{ matrix.config.os }}, R ${{ matrix.config.r }}, Compiler ${{ matrix.config.compiler }}, Build ${{ matrix.config.build }}
 
     strategy:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'release', compiler: 'msvc', build: 'autotools'}
+          - {os: windows-2016, r: 'release', compiler: 'msvc', build: 'autotools'}
+          - {os: windows-latest, r: 'release', compiler: 'msvc', build: 'cmake'}
+          - {os: windows-2016, r: 'release', compiler: 'msvc', build: 'cmake'}
+          - {os: windows-latest, r: 'release', compiler: 'mingw', build: 'autotools'}
+          - {os: windows-2016, r: 'release', compiler: 'mingw', build: 'autotools'}
+          - {os: windows-latest, r: 'release', compiler: 'mingw', build: 'cmake'}
+          - {os: windows-2016, r: 'release', compiler: 'mingw', build: 'cmake'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
@@ -37,16 +67,11 @@ jobs:
         install.packages(c('XML','igraph'))
         install.packages(c('data.table','magrittr','stringi','ggplot2','DiagrammeR','Ckmeans.1d.dp','vcd','testthat','lintr','knitr','rmarkdown'))
 
-    - name: Config R
-      run: |
-        mkdir build && cd build
-        cmake .. -DCMAKE_CONFIGURATION_TYPES="Release" -DR_LIB=ON
-
-    - name: Build R
-      run: |
-        cmake --build build --target install --config Release
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.6' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
 
     - name: Test R
       run: |
-        cd R-package
-        R.exe -q -e "library(testthat); setwd('tests'); source('testthat.R')"
+        python tests/ci_build/test_r_package.py --compiler="${{ matrix.config.compiler }}" --build-tool="${{ matrix.config.build }}"

--- a/cmake/modules/FindLibR.cmake
+++ b/cmake/modules/FindLibR.cmake
@@ -15,8 +15,8 @@
 #  R_VERSION (for win)
 #  R_ARCH (for win 64 when want 32 bit build)
 #
-# TODO: 
-# - someone to verify OSX detection, 
+# TODO:
+# - someone to verify OSX detection,
 # - possibly, add OSX detection based on current R in PATH or LIBR_EXECUTABLE
 # - improve registry-based R_HOME detection in Windows (from a set of R_VERSION's)
 
@@ -37,8 +37,8 @@ endif()
 # Creates R.lib and R.def in the build directory for linking with MSVC
 function(create_rlib_for_msvc)
   # various checks and warnings
-  if(NOT WIN32 OR NOT MSVC)
-    message(FATAL_ERROR "create_rlib_for_msvc() can only be used with MSVC")
+  if(NOT WIN32 OR (NOT MSVC AND NOT MINGW))
+    message(FATAL_ERROR "create_rlib_for_msvc() can only be used with MSVC or MINGW")
   endif()
   if(NOT EXISTS "${LIBR_LIB_DIR}")
     message(FATAL_ERROR "LIBR_LIB_DIR was not set!")
@@ -90,7 +90,7 @@ if(APPLE)
     set(LIBR_INCLUDE_DIRS "${LIBR_HOME}/include" CACHE PATH "R include directory")
     set(LIBR_LIB_DIR "${LIBR_HOME}/lib" CACHE PATH "R lib directory")
   endif()
-  
+
 # detection for UNIX & Win32
 else()
 
@@ -98,7 +98,7 @@ else()
   if(NOT LIBR_EXECUTABLE)
     find_program(LIBR_EXECUTABLE NAMES R R.exe)
   endif()
-  
+
   if(UNIX)
 
     if(NOT LIBR_EXECUTABLE)
@@ -124,7 +124,7 @@ else()
 
   # Windows
   else()
-    # ask R for R_HOME 
+    # ask R for R_HOME
     if(LIBR_EXECUTABLE)
       execute_process(
         COMMAND ${LIBR_EXECUTABLE} "--slave" "--no-save" "-e" "cat(normalizePath(R.home(),winslash='/'))"
@@ -147,7 +147,7 @@ else()
     # set other R paths based on home path
     set(LIBR_INCLUDE_DIRS "${LIBR_HOME}/include")
     set(LIBR_LIB_DIR "${LIBR_HOME}/bin/${R_ARCH}")
- 
+
 message(STATUS "LIBR_HOME [${LIBR_HOME}]")
 message(STATUS "LIBR_EXECUTABLE [${LIBR_EXECUTABLE}]")
 message(STATUS "LIBR_INCLUDE_DIRS [${LIBR_INCLUDE_DIRS}]")
@@ -158,7 +158,7 @@ message(STATUS "LIBR_CORE_LIBRARY [${LIBR_CORE_LIBRARY}]")
 
 endif()
 
-if(WIN32 AND MSVC)
+if((WIN32 AND MSVC) OR (WIN32 AND MINGW))
   # create a local R.lib import library for R.dll if it doesn't exist
   if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/R.lib")
     create_rlib_for_msvc()

--- a/tests/ci_build/test_r_package.py
+++ b/tests/ci_build/test_r_package.py
@@ -1,0 +1,103 @@
+import argparse
+import os
+import subprocess
+
+ROOT = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.pardir,
+                 os.path.pardir))
+r_package = os.path.join(ROOT, 'R-package')
+
+
+class DirectoryExcursion:
+    def __init__(self, path: os.PathLike):
+        self.path = path
+        self.curdir = os.path.normpath(os.path.abspath(os.path.curdir))
+
+    def __enter__(self):
+        os.chdir(self.path)
+
+    def __exit__(self, *args):
+        os.chdir(self.curdir)
+
+
+def get_mingw_bin():
+    return os.path.join('c:/rtools40/mingw64/', 'bin')
+
+
+def test_with_autotools(args):
+    with DirectoryExcursion(r_package):
+        if args.compiler == 'mingw':
+            mingw_bin = get_mingw_bin()
+            CXX = os.path.join(mingw_bin, 'g++.exe')
+            CC = os.path.join(mingw_bin, 'gcc.exe')
+            cmd = ['R.exe', 'CMD', 'INSTALL', str(os.path.curdir)]
+            env = os.environ.copy()
+            env.update({'CC': CC, 'CXX': CXX})
+            subprocess.check_call(cmd, env=env)
+        elif args.compiler == 'msvc':
+            cmd = ['R.exe', 'CMD', 'INSTALL', str(os.path.curdir)]
+            env = os.environ.copy()
+            # autotool favor mingw by default.
+            env.update({'CC': 'cl.exe', 'CXX': 'cl.exe'})
+            subprocess.check_call(cmd, env=env)
+        else:
+            raise ValueError('Wrong compiler')
+        subprocess.check_call([
+            'R.exe', '-q', '-e',
+            "library(testthat); setwd('tests'); source('testthat.R')"
+        ])
+
+
+def test_with_cmake(args):
+    os.mkdir('build')
+    with DirectoryExcursion('build'):
+        if args.compiler == 'mingw':
+            mingw_bin = get_mingw_bin()
+            CXX = os.path.join(mingw_bin, 'g++.exe')
+            CC = os.path.join(mingw_bin, 'gcc.exe')
+            env = os.environ.copy()
+            env.update({'CC': CC, 'CXX': CXX})
+            subprocess.check_call([
+                'cmake', os.path.pardir, '-DUSE_OPENMP=ON', '-DR_LIB=ON',
+                '-DCMAKE_CONFIGURATION_TYPES=Release', '-G', 'Unix Makefiles',
+            ],
+                                  env=env)
+            subprocess.check_call(['make', '-j', 'install'])
+        elif args.compiler == 'msvc':
+            subprocess.check_call([
+                'cmake', os.path.pardir, '-DUSE_OPENMP=ON', '-DR_LIB=ON',
+                '-DCMAKE_CONFIGURATION_TYPES=Release', '-A', 'x64'
+            ])
+            subprocess.check_call([
+                'cmake', '--build', os.path.curdir, '--target', 'install',
+                '--config', 'Release'
+            ])
+        else:
+            raise ValueError('Wrong compiler')
+    with DirectoryExcursion(r_package):
+        subprocess.check_call([
+            'R.exe', '-q', '-e',
+            "library(testthat); setwd('tests'); source('testthat.R')"
+        ])
+
+
+def main(args):
+    if args.build_tool == 'autotools':
+        test_with_autotools(args)
+    else:
+        test_with_cmake(args)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--compiler',
+                        type=str,
+                        choices=['mingw', 'msvc'],
+                        help='Compiler used for compiling CXX code.')
+    parser.add_argument(
+        '--build-tool',
+        type=str,
+        choices=['cmake', 'autotools'],
+        help='Build tool for compiling CXX code and install R package.')
+    args = parser.parse_args()
+    main(args)

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -94,7 +94,7 @@ TEST(GPUPredictor, ExternalMemoryTest) {
   gpu_predictor->Configure({});
 
   LearnerModelParam param;
-  param.num_feature = 2;
+  param.num_feature = 5;
   const int n_classes = 3;
   param.num_output_group = n_classes;
   param.base_score = 0.5;

--- a/tests/python/test_tracker.py
+++ b/tests/python/test_tracker.py
@@ -3,6 +3,10 @@ import xgboost as xgb
 import pytest
 import testing as tm
 import numpy as np
+import sys
+
+if sys.platform.startswith("win"):
+    pytest.skip("Skipping dask tests on Windows", allow_module_level=True)
 
 
 def test_rabit_tracker():


### PR DESCRIPTION
Existing tests are still here.  I plan to remove appveyor once this PR is approved as a replacement.  Also, it's possible to replace some Jenkins CPU tests.  As proposed by @hcho3, we can run all default tests on action and travis like linting and some CPU tests, and run Jenkins tests only when approved.  This PR should be able to get us closer to that goal.

## Added Tests

* Add tests for R package on Windows, including mingw64, msvc with windows lastest and 2016.
~* Add CPP and Python tests on Windows latest and Ubuntu latest.~
* Add Java tests on Windows latest, Windows 2016 and Ubuntu latest. (no spark)

The test matrix can be changed, suggestions are welcomed.

## Skipped tests

- `SparsePage.PushCSCAfterTranspose'` in gtest is skipped due to an error in external memory.  So far I can't reproduce it on my local machine.  Will investigate further with a tracking issue.
- pydatatable test is skipped due to failing to install on Windows.  I can try adding it back on Ubuntu and open an issue there.
- 32 bit build is not tested.  Maybe we can setup c++ tests for 32 bit, not sure if that's required.  But for other language bindings it's quite troublesome to setup 32 bit toolchain.
- mingw tests are only used for R.  Any other Windows tests are compiled with msvc.  That's because Rtools comes with a copy of mingw and is easy to setup. Please let me know if we should run mingw for all language bindings.
- Only testing against latest R.