### PR TITLE
Add explicit template specialization for portability

### DIFF
--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -941,6 +941,8 @@ template uint64_t
 SparsePage::Push(const data::CSCAdapterBatch& batch, float missing, int nthread);
 template uint64_t
 SparsePage::Push(const data::DataTableAdapterBatch& batch, float missing, int nthread);
+template uint64_t
+SparsePage::Push(const data::FileAdapterBatch& batch, float missing, int nthread);
 
 namespace data {
 

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -933,7 +933,17 @@ void SparsePage::PushCSC(const SparsePage &batch) {
   self_offset = std::move(offset);
 }
 
+template uint64_t
+SparsePage::Push(const data::DenseAdapterBatch& batch, float missing, int nthread);
+template uint64_t
+SparsePage::Push(const data::CSRAdapterBatch& batch, float missing, int nthread);
+template uint64_t
+SparsePage::Push(const data::CSCAdapterBatch& batch, float missing, int nthread);
+template uint64_t
+SparsePage::Push(const data::DataTableAdapterBatch& batch, float missing, int nthread);
+
 namespace data {
+
 // List of files that will be force linked in static links.
 DMLC_REGISTRY_LINK_TAG(sparse_page_raw_format);
 }  // namespace data

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -282,21 +282,12 @@ void QuantileHistMaker::Builder<GradientSumT>::SetHistSynchronizer(
                                                HistSynchronizer<GradientSumT>* sync) {
   hist_synchronizer_.reset(sync);
 }
-template void QuantileHistMaker::Builder<double>::SetHistSynchronizer(
-                                                  HistSynchronizer<double>* sync);
-template void QuantileHistMaker::Builder<float>::SetHistSynchronizer(
-                                                  HistSynchronizer<float>* sync);
 
 template<typename GradientSumT>
 void QuantileHistMaker::Builder<GradientSumT>::SetHistRowsAdder(
                                                HistRowsAdder<GradientSumT>* adder) {
   hist_rows_adder_.reset(adder);
 }
-template void QuantileHistMaker::Builder<double>::SetHistRowsAdder(
-                                                  HistRowsAdder<double>* sync);
-template void QuantileHistMaker::Builder<float>::SetHistRowsAdder(
-                                                 HistRowsAdder<float>* sync);
-
 template<typename GradientSumT>
 void QuantileHistMaker::Builder<GradientSumT>::BuildHistogramsLossGuide(
                         ExpandEntry entry,
@@ -1355,6 +1346,27 @@ GradStats QuantileHistMaker::Builder<GradientSumT>::EnumerateSplit(
 
   return e;
 }
+
+template struct QuantileHistMaker::Builder<float>;
+template struct QuantileHistMaker::Builder<double>;
+template void QuantileHistMaker::Builder<float>::PartitionKernel<uint8_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrix& column_matrix, const RegTree& tree);
+template void QuantileHistMaker::Builder<float>::PartitionKernel<uint16_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrix& column_matrix, const RegTree& tree);
+template void QuantileHistMaker::Builder<float>::PartitionKernel<uint32_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrix& column_matrix, const RegTree& tree);
+template void QuantileHistMaker::Builder<double>::PartitionKernel<uint8_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrix& column_matrix, const RegTree& tree);
+template void QuantileHistMaker::Builder<double>::PartitionKernel<uint16_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrix& column_matrix, const RegTree& tree);
+template void QuantileHistMaker::Builder<double>::PartitionKernel<uint32_t>(
+    const size_t node_in_set, const size_t nid, common::Range1d range,
+    const int32_t split_cond, const ColumnMatrix& column_matrix, const RegTree& tree);
 
 XGBOOST_REGISTER_TREE_UPDATER(FastHistMaker, "grow_fast_histmaker")
 .describe("(Deprecated, use grow_quantile_histmaker instead.)"


### PR DESCRIPTION
According to rules of the Standard C++, the implementation of a template class must be available in a header:
* https://isocpp.org/wiki/faq/templates#templates-defn-vs-decl
* https://docs.microsoft.com/en-us/cpp/cpp/source-code-organization-cpp-templates?view=vs-2019

Many member functions of the template class `QuantileHistMaker::Builder` are implemented in the source `updater_quantile_hist.cc`, in violation of the guideline above. Both `updater_quantile_hist.cc` and `test_quantile_hist.cc` use `QuantileHistMaker::Builder`, and we'd get a link error when we compile `test_quantile_hist.cc`. When I tried building `testxgboost` with the code from #5825, I got
```
tests/cpp/CMakeFiles/testxgboost.dir/tree/test_quantile_hist.cc.o: In function `xgboost::tree::QuantileHistMock::TestInitData()':                           
test_quantile_hist.cc:(.text._ZN7xgboost4tree16QuantileHistMock12TestInitDataEv[_ZN7xgboost4tree16QuantileHistMock12TestInitDataEv]+0x1d3): undefined reference to `xgboost::tree::QuantileHistMaker::Builder<double>::InitData(xgboost::common::GHistIndexMatrix const&, std::vector<xgboost::detail::GradientPairInternal<float>, std::allocator<xgboost::detail::GradientPairInternal<float> > > const&, xgboost::DMatrix const&, xgboost::RegTree const&)'                      
test_quantile_hist.cc:(.text._ZN7xgboost4tree16QuantileHistMock12TestInitDataEv[_ZN7xgboost4tree16QuantileHistMock12TestInitDataEv]+0x272): undefined reference to `xgboost::tree::QuantileHistMaker::Builder<float>::InitData(xgboost::common::GHistIndexMatrix const&, std::vector<xgboost::detail::GradientPairInternal<float>, std::allocator<xgboost::detail::GradientPairInternal<float> > > const&, xgboost::DMatrix const&, xgboost::RegTree const&)'
....
```
Somehow the Intel compiler show this error, whereas GCC does not.

~To make our codebase portable, I moved all the implementations to the header. (All implementation details are collected in the header `src/tree/updater_quantile_hist_impl.h`)~ I took the alternative approach, where I explicitly specify all possible instantiations of template classes. This technique is known as explicit instantiation. See https://docs.microsoft.com/en-us/cpp/cpp/source-code-organization-cpp-templates?view=vs-2019 for more details.