### PR TITLE
Use `cudaOccupancyMaxPotentialBlockSize` to calculate the block size.

### DIFF
--- a/src/tree/gpu_hist/histogram.cu
+++ b/src/tree/gpu_hist/histogram.cu
@@ -175,7 +175,11 @@ void BuildGradientHistogram(EllpackDeviceAccessor const& matrix,
   }
 
   // determine the launch configuration
-  unsigned block_threads = shared ? 1024 : 256;
+  int min_grid_size;
+  int block_threads = 1024;
+  dh::safe_cuda(cudaOccupancyMaxPotentialBlockSize(
+      &min_grid_size, &block_threads, kernel, smem_size, 0));
+
   int num_groups = feature_groups.NumGroups();
   int n_mps = 0;
   dh::safe_cuda(cudaDeviceGetAttribute(&n_mps, cudaDevAttrMultiProcessorCount, device));

--- a/src/tree/gpu_hist/histogram.cu
+++ b/src/tree/gpu_hist/histogram.cu
@@ -203,7 +203,8 @@ void BuildGradientHistogram(EllpackDeviceAccessor const& matrix,
   grid_size = common::DivRoundUp(grid_size,
       common::DivRoundUp(num_groups, num_groups_threshold));
 
-  dh::LaunchKernel {dim3(grid_size, num_groups), block_threads, smem_size} (
+  dh::LaunchKernel {
+    dim3(grid_size, num_groups), static_cast<uint32_t>(block_threads), smem_size} (
       kernel,
       matrix, feature_groups, d_ridx, histogram.data(), gpair.data(), rounding,
       shared);


### PR DESCRIPTION
Restoring some perf on gtx 1080 ti:

|        | GPU       | Dataset | Time               |
|--------|-----------|---------|--------------------|
| Before | v100      | Higgs   | 25.431774566997774 |
|        | gtx1080ti | Higgs   | 135.91460225299988 |
|        | v100      | Epsilon | 93.19408854097128  |
|        | gtx1080ti | Epsilon | 272.334376795      |
| After  | v100      | Higgs   | 25.490044657010003 |
|        | gtx1080ti | Higgs   | 83.45110513200052  |
|        | v100      | Epsilon | 94.6916850550333   |
|        | gtx1080ti | Epsilon | 256.336098645      |

Not fully restored yet as previous on 1080ti higgs is `61.58244462100038`, but I don't have alternative solution.