### PR TITLE
[Dask] Automatically unbox 0d NumPy array containing another object

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -90,7 +90,7 @@ class RabitContext:
 
 def concat(value):              # pylint: disable=too-many-return-statements
     '''To be replaced with dask builtin.'''
-    def unbox_0d_array(x):
+    def unbox_0d_array(x):  # pylint: disable=invalid-name
         if isinstance(x, numpy.ndarray) and x.dtype == numpy.object and x.shape == ():
             return x[()]
         return x

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -90,6 +90,11 @@ class RabitContext:
 
 def concat(value):              # pylint: disable=too-many-return-statements
     '''To be replaced with dask builtin.'''
+    def unbox_0d_array(x):
+        if isinstance(x, numpy.ndarray) and x.dtype == numpy.object and x.shape == ():
+            return x[()]
+        return x
+    value = tuple(unbox_0d_array(x) for x in value)
     if isinstance(value[0], numpy.ndarray):
         return numpy.concatenate(value, axis=0)
     if scipy_sparse and isinstance(value[0], scipy_sparse.spmatrix):


### PR DESCRIPTION
The following script does not work with the current XGBoost (master branch):
```python
import dask
from dask.distributed import Client, LocalCluster

import xgboost as xgb
import numpy as np
from scipy.sparse import csr_matrix

params = {'objective': 'binary:logistic', 'max_depth': 1, 'eval_metric': 'logloss'}

def main(client):
    np.random.seed(0)
    nrow = 1000
    ncol = 10

    data = np.random.uniform(size=(nrow, ncol)).flatten().astype(np.float32)
    row_ind = np.array([([i] * ncol) for i in range(nrow)]).flatten()
    col_ind = np.array([list(range(ncol)) for i in range(nrow)]).flatten()
    X = csr_matrix((data, (row_ind, col_ind)), shape=(nrow, ncol), dtype=np.float32)
    y = np.random.choice(2, size=(nrow,), replace=True)
    weight = np.ones(shape=(nrow,), dtype=np.float32)
    X[400:600,:] = 0
    X.eliminate_zeros()
    X = dask.array.from_array(X, chunks=(nrow // 2, ncol))
    y = dask.array.from_array(y, chunks=(nrow // 2,))
    weight = dask.array.from_array(weight, chunks=(nrow // 2,))
    
    dtrain = xgb.dask.DaskDMatrix(client, X, label=y, weight=weight)
    output = xgb.dask.train(client, params, dtrain, num_boost_round=10, evals=[(dtrain, 'train')])
    print(output['history'])

if __name__ == '__main__':
    with LocalCluster(n_workers=2, threads_per_worker=1) as cluster:
        with Client(cluster) as client:
            main(client)
```

It crashes with the following error message:
```
Traceback (most recent call last):
  File "test.py", line 35, in <module>
    main(client)
  File "test.py", line 29, in main
    output = xgb.dask.train(client, params, dtrain, num_boost_round=10, evals=[(dtrain, 'train')])
  File "/home/phcho/tmp/xgboost/python-package/xgboost/dask.py", line 602, in train
    results = client.gather(futures)
  File "/home/phcho/miniconda3/envs/cuml_dev/lib/python3.8/site-packages/distributed/client.py", line 1982, in gather
    return self.sync(
  File "/home/phcho/miniconda3/envs/cuml_dev/lib/python3.8/site-packages/distributed/client.py", line 832, in sync
    return sync(
  File "/home/phcho/miniconda3/envs/cuml_dev/lib/python3.8/site-packages/distributed/utils.py", line 339, in sync
    raise exc.with_traceback(tb)
  File "/home/phcho/miniconda3/envs/cuml_dev/lib/python3.8/site-packages/distributed/utils.py", line 323, in f
    result[0] = yield future
  File "/home/phcho/miniconda3/envs/cuml_dev/lib/python3.8/site-packages/tornado/gen.py", line 735, in run
    value = future.result()
  File "/home/phcho/miniconda3/envs/cuml_dev/lib/python3.8/site-packages/distributed/client.py", line 1847, in _gather
    raise exception.with_traceback(traceback)
  File "/home/phcho/tmp/xgboost/python-package/xgboost/dask.py", line 561, in dispatched_train
    local_dtrain = dtrain.get_worker_data(worker)
  File "/home/phcho/tmp/xgboost/python-package/xgboost/dask.py", line 325, in get_worker_data
    data = concat(data)
  File "/home/phcho/tmp/xgboost/python-package/xgboost/dask.py", line 94, in concat
    return numpy.concatenate(value, axis=0)
  File "<__array_function__ internals>", line 5, in concatenate
ValueError: zero-dimensional arrays cannot be concatenated
```

Diagnosis: for some reason, Dask sends XGBoost a zero-dimensional NumPy array that contains the object we want, like `scipy.sparse`. The array doesn't automatically degrade to a scalar, so this PR writes a pass to convert all zero-dimensional NumPy arrays.