### PR TITLE
[BLOCKING] Handle empty rows in data iterators correctly

### DIFF
--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -833,9 +833,9 @@ uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread
   uint64_t max_columns = 0;
 
   // First-pass over the batch counting valid elements
-  size_t num_lines = batch.Size();
+  size_t batch_size = batch.Size();
 #pragma omp parallel for schedule(static)
-  for (omp_ulong i = 0; i < static_cast<omp_ulong>(num_lines);
+  for (omp_ulong i = 0; i < static_cast<omp_ulong>(batch_size);
        ++i) {  // NOLINT(*)
     int tid = omp_get_thread_num();
     auto line = batch.GetLine(i);
@@ -847,7 +847,7 @@ uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread
         size_t key = element.row_idx - base_rowid;
         // Adapter row index is absolute, here we want it relative to
         // current page
-        CHECK_GE(key,  builder_base_row_offset);
+        CHECK_GE(key, builder_base_row_offset);
         builder.AddBudget(key, tid);
       }
     }
@@ -856,7 +856,7 @@ uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread
 
   // Second pass over batch, placing elements in correct position
 #pragma omp parallel for schedule(static)
-  for (omp_ulong i = 0; i < static_cast<omp_ulong>(num_lines);
+  for (omp_ulong i = 0; i < static_cast<omp_ulong>(batch_size);
        ++i) {  // NOLINT(*)
     int tid = omp_get_thread_num();
     auto line = batch.GetLine(i);

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -164,9 +164,12 @@ SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {
   if (adapter->NumRows() == kAdapterUnknownSize) {
     using IteratorAdapterT
       = IteratorAdapter<DataIterHandle, XGBCallbackDataIterNext, XGBoostBatchCSR>;
+    // If AdapterT is either IteratorAdapter or FileAdapter type, use the total batch size to
+    // determine the correct number of rows, as offset_vec may be too short
     if (std::is_same<AdapterT, IteratorAdapterT>::value
         || std::is_same<AdapterT, FileAdapter>::value) {
       info_.num_row_ = total_batch_size;
+      // Ensure offset_vec.size() - 1 == [number of rows]
       while (offset_vec.size() - 1 < total_batch_size) {
         offset_vec.emplace_back(offset_vec.back());
       }

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -6,6 +6,7 @@
  */
 #include <vector>
 #include <limits>
+#include <type_traits>
 #include <algorithm>
 
 #include "xgboost/data.h"
@@ -103,6 +104,8 @@ SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {
   auto& offset_vec = sparse_page_.offset.HostVector();
   auto& data_vec = sparse_page_.data.HostVector();
   uint64_t inferred_num_columns = 0;
+  uint64_t total_batch_size = 0;
+    // batch_size is either number of rows or cols, depending on data layout
 
   adapter->BeforeFirst();
   // Iterate over batches of input data
@@ -110,6 +113,7 @@ SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {
     auto& batch = adapter->Value();
     auto batch_max_columns = sparse_page_.Push(batch, missing, nthread);
     inferred_num_columns = std::max(batch_max_columns, inferred_num_columns);
+    total_batch_size += batch.Size();
     // Append meta information if available
     if (batch.Labels() != nullptr) {
       auto& labels = info_.labels_.HostVector();
@@ -153,16 +157,27 @@ SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {
     info_.num_col_ = adapter->NumColumns();
   }
 
+
   // Synchronise worker columns
   rabit::Allreduce<rabit::op::Max>(&info_.num_col_, 1);
 
   if (adapter->NumRows() == kAdapterUnknownSize) {
-    info_.num_row_ = offset_vec.size() - 1;
+    using IteratorAdapterT
+      = IteratorAdapter<DataIterHandle, XGBCallbackDataIterNext, XGBoostBatchCSR>;
+    if (std::is_same<AdapterT, IteratorAdapterT>::value
+        || std::is_same<AdapterT, FileAdapter>::value) {
+      info_.num_row_ = total_batch_size;
+      while (offset_vec.size() - 1 < total_batch_size) {
+        offset_vec.emplace_back(offset_vec.back());
+      }
+    } else {
+      CHECK((std::is_same<AdapterT, CSCAdapter>::value)) << "Expecting CSCAdapter";
+      info_.num_row_ = offset_vec.size() - 1;
+    }
   } else {
     if (offset_vec.empty()) {
       offset_vec.emplace_back(0);
     }
-
     while (offset_vec.size() - 1 < adapter->NumRows()) {
       offset_vec.emplace_back(offset_vec.back());
     }

--- a/tests/cpp/data/test_simple_dmatrix.cc
+++ b/tests/cpp/data/test_simple_dmatrix.cc
@@ -190,12 +190,12 @@ TEST(SimpleDMatrix, FromFile) {
     std::ofstream fo(filename, std::ios::app | std::ios::out);
     fo << "0\n";
   }
-  constexpr size_t expected_nrow = 6;
+  constexpr size_t kExpectedNumRow = 6;
   std::unique_ptr<dmlc::Parser<uint32_t>> parser(
       dmlc::Parser<uint32_t>::Create(filename.c_str(), 0, 1, "auto"));
 
-  auto verify_batch = [](SparsePage const &batch) {
-    EXPECT_EQ(batch.Size(), expected_nrow);
+  auto verify_batch = [kExpectedNumRow](SparsePage const &batch) {
+    EXPECT_EQ(batch.Size(), kExpectedNumRow);
     EXPECT_EQ(batch.offset.HostVector(),
               std::vector<bst_row_t>({0, 3, 6, 9, 12, 15, 15}));
     EXPECT_EQ(batch.base_rowid, 0);

--- a/tests/cpp/data/test_simple_dmatrix.cc
+++ b/tests/cpp/data/test_simple_dmatrix.cc
@@ -185,16 +185,22 @@ TEST(SimpleDMatrix, FromCSC) {
 TEST(SimpleDMatrix, FromFile) {
   std::string filename = "test.libsvm";
   CreateBigTestData(filename, 3 * 5);
+  // Add an empty row at the end of the matrix
+  {
+    std::ofstream fo(filename, std::ios::app | std::ios::out);
+    fo << "0\n";
+  }
+  constexpr size_t expected_nrow = 6;
   std::unique_ptr<dmlc::Parser<uint32_t>> parser(
       dmlc::Parser<uint32_t>::Create(filename.c_str(), 0, 1, "auto"));
 
   auto verify_batch = [](SparsePage const &batch) {
-    EXPECT_EQ(batch.Size(), 5);
+    EXPECT_EQ(batch.Size(), expected_nrow);
     EXPECT_EQ(batch.offset.HostVector(),
-              std::vector<bst_row_t>({0, 3, 6, 9, 12, 15}));
+              std::vector<bst_row_t>({0, 3, 6, 9, 12, 15, 15}));
     EXPECT_EQ(batch.base_rowid, 0);
 
-    for (auto i = 0ull; i < batch.Size(); i++) {
+    for (auto i = 0ull; i < batch.Size() - 1; i++) {
       if (i % 2 == 0) {
         EXPECT_EQ(batch[i][0].index, 0);
         EXPECT_EQ(batch[i][1].index, 1);


### PR DESCRIPTION
Fixes #5848.

Diagnosis: https://github.com/dmlc/xgboost/issues/5848#issuecomment-662767268, https://github.com/dmlc/xgboost/issues/5848#issuecomment-662802416. The bug occurs whenever a CSR sparse matrix has empty rows at its end. (Empty rows in the middle of the matrix don't matter.)

Fix. Create a special logic for `IteratorAdapter` and `FileAdapter`, so that the empty rows at the end of the matrix are properly accounted for. I added test cases in Google Test.