### PR TITLE
Wrapping global verbosity variable in loggic with atomic to ensure threadsafety.

### DIFF
--- a/include/xgboost/logging.h
+++ b/include/xgboost/logging.h
@@ -14,6 +14,7 @@
 #include <xgboost/base.h>
 #include <xgboost/parameter.h>
 
+#include <atomic>
 #include <sstream>
 #include <map>
 #include <string>
@@ -60,7 +61,7 @@ class ConsoleLogger : public BaseLogger {
   using LV = LogVerbosity;
 
  private:
-  static LogVerbosity global_verbosity_;
+  static std::atomic<LogVerbosity> global_verbosity_;
   static ConsoleLoggerParam param_;
 
   LogVerbosity cur_verbosity_;

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -42,8 +42,8 @@ namespace xgboost {
 
 DMLC_REGISTER_PARAMETER(ConsoleLoggerParam);
 
-ConsoleLogger::LogVerbosity ConsoleLogger::global_verbosity_ =
-    ConsoleLogger::DefaultVerbosity();
+std::atomic<ConsoleLogger::LogVerbosity> ConsoleLogger::global_verbosity_{
+    ConsoleLogger::DefaultVerbosity()};
 
 ConsoleLoggerParam ConsoleLogger::param_ = ConsoleLoggerParam();
 


### PR DESCRIPTION
This came up when running xgboost with a thread sanitizer. It looks like a couple of code paths repeatedly call `ConsoleLogger::Configure`. The result is two different threads might be setting `global_verbosity_`. Atomic seemed like the most straightforward way to fix the issue without refactoring a more things.