### PR TITLE
Initial support for one hot split.

### DIFF
--- a/include/xgboost/feature_map.h
+++ b/include/xgboost/feature_map.h
@@ -82,7 +82,9 @@ class FeatureMap {
     if (!strcmp("q", tname)) return kQuantitive;
     if (!strcmp("int", tname)) return kInteger;
     if (!strcmp("float", tname)) return kFloat;
-    LOG(FATAL) << "unknown feature type, use i for indicator and q for quantity";
+    if (!strcmp("categorical", tname)) return kInteger;
+    LOG(FATAL) << "unknown feature type, use i for indicator, q for quantity "
+                  "and categorical for categorical split.";
     return kIndicator;
   }
   /*! \brief name of the feature */

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -384,7 +384,8 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
                  silent=False,
                  feature_names=None,
                  feature_types=None,
-                 nthread=None):
+                 nthread=None,
+                 enable_categorical=False):
         """Parameters
         ----------
         data : os.PathLike/string/numpy.array/scipy.sparse/pd.DataFrame/
@@ -419,6 +420,17 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
             Number of threads to use for loading data when parallelization is
             applicable. If -1, uses maximum threads available on the system.
 
+        enable_categorical: boolean, optional
+
+            .. versionadded:: 1.3.0
+
+            Experimental support of specializing for categorical features.  Do
+            not set to True unless you are interested in development.
+            Currently it's only available for `gpu_hist` tree method with 1 vs
+            rest (one hot) categorical split.  Also, JSON serialization format,
+            `enable_experimental_json_serialization`, `gpu_predictor` and
+            pandas input are required.
+
         """
         if isinstance(data, list):
             raise TypeError('Input data can not be a list.')
@@ -437,7 +449,8 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
             data, missing=self.missing,
             threads=self.nthread,
             feature_names=feature_names,
-            feature_types=feature_types)
+            feature_types=feature_types,
+            enable_categorical=enable_categorical)
         assert handle is not None
         self.handle = handle
 

--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -178,7 +178,7 @@ void ProcessBatch(int device, MetaInfo const &info, const SparsePage &page,
   dh::XGBCachingDeviceAllocator<char> alloc;
   const auto& host_data = page.data.ConstHostVector();
   dh::device_vector<Entry> sorted_entries(host_data.begin() + begin,
-                                                  host_data.begin() + end);
+                                          host_data.begin() + end);
   thrust::sort(thrust::cuda::par(alloc), sorted_entries.begin(),
                sorted_entries.end(), detail::EntryCompareOp());
 

--- a/src/common/host_device_vector.cc
+++ b/src/common/host_device_vector.cc
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <memory>
 #include <utility>
+#include "xgboost/tree_model.h"
 #include "xgboost/host_device_vector.h"
 
 namespace xgboost {
@@ -176,6 +177,7 @@ template class HostDeviceVector<FeatureType>;
 template class HostDeviceVector<Entry>;
 template class HostDeviceVector<uint64_t>;  // bst_row_t
 template class HostDeviceVector<uint32_t>;  // bst_feature_t
+template class HostDeviceVector<RegTree::Segment>;
 
 #if defined(__APPLE__)
 /*

--- a/src/common/host_device_vector.cu
+++ b/src/common/host_device_vector.cu
@@ -404,6 +404,7 @@ template class HostDeviceVector<Entry>;
 template class HostDeviceVector<uint64_t>;  // bst_row_t
 template class HostDeviceVector<uint32_t>;  // bst_feature_t
 template class HostDeviceVector<RegTree::Node>;
+template class HostDeviceVector<RegTree::Segment>;
 template class HostDeviceVector<RTreeNodeStat>;
 
 #if defined(__APPLE__)

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -68,7 +68,7 @@ namespace data {
 /** \brief An adapter can return this value for number of rows or columns
  * indicating that this value is currently unknown and should be inferred while
  * passing over the data. */
-constexpr size_t kAdapterUnknownSize = std::numeric_limits<size_t >::max();
+constexpr size_t kAdapterUnknownSize = std::numeric_limits<bst_row_t>::max();
 
 struct COOTuple {
   COOTuple() = default;

--- a/src/data/iterative_device_dmatrix.cu
+++ b/src/data/iterative_device_dmatrix.cu
@@ -98,6 +98,9 @@ void IterativeDeviceDMatrix::Initialize(DataIterHandle iter_handle, float missin
         }));
     nnz += thrust::reduce(thrust::cuda::par(alloc), row_counts.begin(),
                           row_counts.end());
+
+    this->Info().feature_types.Resize(proxy->Info().feature_types.Size());
+    this->Info().feature_types.Copy(proxy->Info().feature_types);
     batches++;
   }
   iter.Reset();

--- a/src/tree/gpu_hist/evaluate_splits.cuh
+++ b/src/tree/gpu_hist/evaluate_splits.cuh
@@ -18,6 +18,7 @@ struct EvaluateSplitInputs {
   GradientSumT parent_sum;
   GPUTrainingParam param;
   common::Span<const bst_feature_t> feature_set;
+  common::Span<FeatureType const> feature_types;
   common::Span<const uint32_t> feature_segments;
   common::Span<const float> feature_values;
   common::Span<const float> min_fvalue;

--- a/src/tree/gpu_hist/feature_groups.cu
+++ b/src/tree/gpu_hist/feature_groups.cu
@@ -23,13 +23,13 @@ FeatureGroups::FeatureGroups(const common::HistogramCuts& cuts, bool is_dense,
     return;
   }
 
-  std::vector<int>& feature_segments_h = feature_segments.HostVector();
+  std::vector<size_t>& feature_segments_h = feature_segments.HostVector();
   std::vector<int>& bin_segments_h = bin_segments.HostVector();
   feature_segments_h.push_back(0);
   bin_segments_h.push_back(0);
 
   const std::vector<uint32_t>& cut_ptrs = cuts.Ptrs();
-  int max_shmem_bins = shm_size / bin_size;
+  size_t max_shmem_bins = shm_size / bin_size;
   max_group_bins = 0;
 
   for (size_t i = 2; i < cut_ptrs.size(); ++i) {
@@ -49,7 +49,7 @@ FeatureGroups::FeatureGroups(const common::HistogramCuts& cuts, bool is_dense,
 }
 
 void FeatureGroups::InitSingle(const common::HistogramCuts& cuts) {
-  std::vector<int>& feature_segments_h = feature_segments.HostVector();
+  std::vector<size_t>& feature_segments_h = feature_segments.HostVector();
   feature_segments_h.push_back(0);
   feature_segments_h.push_back(cuts.Ptrs().size() - 1);
 

--- a/src/tree/gpu_hist/feature_groups.cuh
+++ b/src/tree/gpu_hist/feature_groups.cuh
@@ -20,7 +20,7 @@ namespace tree {
     consecutive feature indices, and also contains a range of all bin indices
     associated with those features. */
 struct FeatureGroup {
-  __host__ __device__ FeatureGroup(int start_feature_, int num_features_,
+  __host__ __device__ FeatureGroup(size_t start_feature_, size_t num_features_,
                                    int start_bin_, int num_bins_) :
     start_feature(start_feature_), num_features(num_features_),
     start_bin(start_bin_), num_bins(num_bins_) {}
@@ -36,24 +36,24 @@ struct FeatureGroup {
 
 /** \brief FeatureGroupsAccessor is a non-owning accessor for FeatureGroups. */
 struct FeatureGroupsAccessor {
-  FeatureGroupsAccessor(common::Span<const int> feature_segments_,
+  FeatureGroupsAccessor(common::Span<const size_t> feature_segments_,
                        common::Span<const int> bin_segments_, int max_group_bins_) :
     feature_segments(feature_segments_), bin_segments(bin_segments_),
     max_group_bins(max_group_bins_) {}
-  
-  common::Span<const int> feature_segments;
+
+  common::Span<const size_t> feature_segments;
   common::Span<const int> bin_segments;
   int max_group_bins;
-  
+
   /** \brief Gets the number of feature groups. */
-  __host__ __device__ int NumGroups() const {
+  __host__ __device__ size_t NumGroups() const {
     return feature_segments.size() - 1;
   }
 
   /** \brief Gets the information about a feature group with index i. */
   __host__ __device__ FeatureGroup operator[](int i) const {
     return {feature_segments[i], feature_segments[i + 1] - feature_segments[i],
-        bin_segments[i], bin_segments[i + 1] - bin_segments[i]};
+          bin_segments[i], bin_segments[i + 1] - bin_segments[i]};
   }
 };
 
@@ -78,13 +78,13 @@ struct FeatureGroupsAccessor {
 */
 struct FeatureGroups {
   /** Group cuts for features. Size equals to (number of groups + 1). */
-  HostDeviceVector<int> feature_segments;
+  HostDeviceVector<size_t> feature_segments;
   /** Group cuts for bins. Size equals to (number of groups + 1)  */
   HostDeviceVector<int> bin_segments;
   /** Maximum number of bins in a group. Useful to compute the amount of dynamic
       shared memory when launching a kernel. */
   int max_group_bins;
-  
+
   /** Creates feature groups by splitting features into groups.
       \param cuts Histogram cuts that given the number of bins per feature.
       \param is_dense Whether the data matrix is dense.
@@ -106,12 +106,12 @@ struct FeatureGroups {
     feature_segments.SetDevice(device);
     bin_segments.SetDevice(device);
     return {feature_segments.ConstDeviceSpan(), bin_segments.ConstDeviceSpan(),
-        max_group_bins};
+          max_group_bins};
   }
 
 private:
   void InitSingle(const common::HistogramCuts& cuts);
-}; 
+};
 
 }  // namespace tree
 }  // namespace xgboost

--- a/src/tree/updater_gpu_common.cuh
+++ b/src/tree/updater_gpu_common.cuh
@@ -59,6 +59,7 @@ struct DeviceSplitCandidate {
   DefaultDirection dir {kLeftDir};
   int findex {-1};
   float fvalue {0};
+  bool is_cat { false };
 
   GradientPair left_sum;
   GradientPair right_sum;
@@ -79,6 +80,7 @@ struct DeviceSplitCandidate {
                              float fvalue_in, int findex_in,
                              GradientPair left_sum_in,
                              GradientPair right_sum_in,
+                             bool cat,
                              const GPUTrainingParam& param) {
     if (loss_chg_in > loss_chg &&
         left_sum_in.GetHess() >= param.min_child_weight &&
@@ -86,6 +88,7 @@ struct DeviceSplitCandidate {
       loss_chg = loss_chg_in;
       dir = dir_in;
       fvalue = fvalue_in;
+      is_cat = cat;
       left_sum = left_sum_in;
       right_sum = right_sum_in;
       findex = findex_in;
@@ -98,6 +101,7 @@ struct DeviceSplitCandidate {
        << "dir: " << c.dir << ", "
        << "findex: " << c.findex << ", "
        << "fvalue: " << c.fvalue << ", "
+       << "is_cat: " << c.is_cat << ", "
        << "left sum: " << c.left_sum << ", "
        << "right sum: " << c.right_sum << std::endl;
     return os;

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -19,7 +19,9 @@
 #include "../common/io.h"
 #include "../common/device_helpers.cuh"
 #include "../common/hist_util.h"
+#include "../common/bitfield.h"
 #include "../common/timer.h"
+#include "../common/categorical.h"
 #include "../data/ellpack_page.cuh"
 
 #include "param.h"
@@ -161,6 +163,7 @@ template <typename GradientSumT>
 struct GPUHistMakerDevice {
   int device_id;
   EllpackPageImpl* page;
+  common::Span<FeatureType const> feature_types;
   BatchParam batch_param;
 
   std::unique_ptr<RowPartitioner> row_partitioner;
@@ -191,9 +194,12 @@ struct GPUHistMakerDevice {
   std::unique_ptr<GradientBasedSampler> sampler;
 
   std::unique_ptr<FeatureGroups> feature_groups;
+  // Storing split categories for 1 node.
+  dh::caching_device_vector<uint32_t> node_categories;
 
   GPUHistMakerDevice(int _device_id,
                      EllpackPageImpl* _page,
+                     common::Span<FeatureType const> _feature_types,
                      bst_uint _n_rows,
                      TrainParam _param,
                      uint32_t column_sampler_seed,
@@ -202,6 +208,7 @@ struct GPUHistMakerDevice {
                      BatchParam _batch_param)
       : device_id(_device_id),
         page(_page),
+        feature_types{_feature_types},
         param(std::move(_param)),
         tree_evaluator(param, n_features, _device_id),
         column_sampler(column_sampler_seed),
@@ -293,6 +300,7 @@ struct GPUHistMakerDevice {
         {root_sum.GetGrad(), root_sum.GetHess()},
         gpu_param,
         feature_set,
+        feature_types,
         matrix.feature_segments,
         matrix.gidx_fvalue_map,
         matrix.min_fvalue,
@@ -331,6 +339,7 @@ struct GPUHistMakerDevice {
             candidate.split.left_sum.GetHess()},
           gpu_param,
           left_feature_set,
+          feature_types,
           matrix.feature_segments,
           matrix.gidx_fvalue_map,
           matrix.min_fvalue,
@@ -341,6 +350,7 @@ struct GPUHistMakerDevice {
          candidate.split.right_sum.GetHess()},
         gpu_param,
         right_feature_set,
+        feature_types,
         matrix.feature_segments,
         matrix.gidx_fvalue_map,
         matrix.min_fvalue,
@@ -399,8 +409,11 @@ struct GPUHistMakerDevice {
            hist.HistogramExists(nidx_parent);
   }
 
-  void UpdatePosition(int nidx, RegTree::Node split_node) {
+  void UpdatePosition(int nidx, RegTree* p_tree) {
+    RegTree::Node split_node = (*p_tree)[nidx];
+    auto split_type = p_tree->NodeSplitType(nidx);
     auto d_matrix = page->GetDeviceAccessor(device_id);
+    auto node_cats = dh::ToSpan(node_categories);
 
     row_partitioner->UpdatePosition(
         nidx, split_node.LeftChild(), split_node.RightChild(),
@@ -409,11 +422,17 @@ struct GPUHistMakerDevice {
           bst_float cut_value =
               d_matrix.GetFvalue(ridx, split_node.SplitIndex());
           // Missing value
-          int new_position = 0;
+          bst_node_t new_position = 0;
           if (isnan(cut_value)) {
             new_position = split_node.DefaultChild();
           } else {
-            if (cut_value <= split_node.SplitCond()) {
+            bool go_left = true;
+            if (split_type == FeatureType::kCategorical) {
+              go_left = common::Decision(node_cats, common::AsCat(cut_value));
+            } else {
+              go_left = cut_value <= split_node.SplitCond();
+            }
+            if (go_left) {
               new_position = split_node.LeftChild();
             } else {
               new_position = split_node.RightChild();
@@ -428,48 +447,77 @@ struct GPUHistMakerDevice {
   // prediction cache
   void FinalisePosition(RegTree const* p_tree, DMatrix* p_fmat) {
     dh::TemporaryArray<RegTree::Node> d_nodes(p_tree->GetNodes().size());
-    dh::safe_cuda(cudaMemcpy(d_nodes.data().get(), p_tree->GetNodes().data(),
-                             d_nodes.size() * sizeof(RegTree::Node),
-                             cudaMemcpyHostToDevice));
+    dh::safe_cuda(cudaMemcpyAsync(d_nodes.data().get(), p_tree->GetNodes().data(),
+                                  d_nodes.size() * sizeof(RegTree::Node),
+                                  cudaMemcpyHostToDevice));
+    auto const& h_split_types = p_tree->GetSplitTypes();
+    auto const& categories = p_tree->GetSplitCategories();
+    auto const& categories_segments = p_tree->GetSplitCategoriesPtr();
+
+    dh::device_vector<FeatureType> d_split_types;
+    dh::device_vector<uint32_t> d_categories;
+    dh::device_vector<RegTree::Segment> d_categories_segments;
+
+    dh::CopyToD(h_split_types, &d_split_types);
+    dh::CopyToD(categories, &d_categories);
+    dh::CopyToD(categories_segments, &d_categories_segments);
 
     if (row_partitioner->GetRows().size() != p_fmat->Info().num_row_) {
       row_partitioner.reset();  // Release the device memory first before reallocating
       row_partitioner.reset(new RowPartitioner(device_id, p_fmat->Info().num_row_));
     }
     if (page->n_rows == p_fmat->Info().num_row_) {
-      FinalisePositionInPage(page, dh::ToSpan(d_nodes));
+      FinalisePositionInPage(page, dh::ToSpan(d_nodes),
+                             dh::ToSpan(d_split_types), dh::ToSpan(d_categories),
+                             dh::ToSpan(d_categories_segments));
     } else {
       for (auto& batch : p_fmat->GetBatches<EllpackPage>(batch_param)) {
-        FinalisePositionInPage(batch.Impl(), dh::ToSpan(d_nodes));
+        FinalisePositionInPage(batch.Impl(), dh::ToSpan(d_nodes),
+                               dh::ToSpan(d_split_types), dh::ToSpan(d_categories),
+                               dh::ToSpan(d_categories_segments));
       }
     }
   }
 
-  void FinalisePositionInPage(EllpackPageImpl* page, const common::Span<RegTree::Node> d_nodes) {
+  void FinalisePositionInPage(EllpackPageImpl *page,
+                              const common::Span<RegTree::Node> d_nodes,
+                              common::Span<FeatureType const> d_feature_types,
+                              common::Span<uint32_t const> categories,
+                              common::Span<RegTree::Segment> categories_segments) {
     auto d_matrix = page->GetDeviceAccessor(device_id);
     row_partitioner->FinalisePosition(
         [=] __device__(size_t row_id, int position) {
-      if (!d_matrix.IsInRange(row_id)) {
-        return RowPartitioner::kIgnoredTreePosition;
-      }
-      auto node = d_nodes[position];
-
-      while (!node.IsLeaf()) {
-        bst_float element = d_matrix.GetFvalue(row_id, node.SplitIndex());
-        // Missing value
-        if (isnan(element)) {
-          position = node.DefaultChild();
-        } else {
-          if (element <= node.SplitCond()) {
-            position = node.LeftChild();
-          } else {
-            position = node.RightChild();
+          // What happens if user prune the tree?
+          if (!d_matrix.IsInRange(row_id)) {
+            return RowPartitioner::kIgnoredTreePosition;
           }
-        }
-        node = d_nodes[position];
-      }
-      return position;
-    });
+          auto node = d_nodes[position];
+
+          while (!node.IsLeaf()) {
+            bst_float element = d_matrix.GetFvalue(row_id, node.SplitIndex());
+            // Missing value
+            if (isnan(element)) {
+              position = node.DefaultChild();
+            } else {
+              bool go_left = true;
+              if (common::IsCat(d_feature_types, position)) {
+                auto node_cats =
+                    categories.subspan(categories_segments[position].beg,
+                                       categories_segments[position].size);
+                go_left = common::Decision(node_cats, common::AsCat(element));
+              } else {
+                go_left = element <= node.SplitCond();
+              }
+              if (go_left) {
+                position = node.LeftChild();
+              } else {
+                position = node.RightChild();
+              }
+            }
+            node = d_nodes[position];
+          }
+          return position;
+        });
   }
 
   void UpdatePredictionCache(bst_float* out_preds_d) {
@@ -561,11 +609,30 @@ struct GPUHistMakerDevice {
     auto left_weight = candidate.left_weight * param.learning_rate;
     auto right_weight = candidate.right_weight * param.learning_rate;
 
-    tree.ExpandNode(candidate.nid, candidate.split.findex,
-                    candidate.split.fvalue, candidate.split.dir == kLeftDir,
-                    base_weight, left_weight, right_weight,
-                    candidate.split.loss_chg, parent_sum.GetHess(),
-                    candidate.split.left_sum.GetHess(), candidate.split.right_sum.GetHess());
+    auto is_cat = candidate.split.is_cat;
+    if (is_cat) {
+      auto cat = common::AsCat(candidate.split.fvalue);
+      std::vector<uint32_t> split_cats(LBitField32::ComputeStorageSize(std::max(cat+1, 1)));
+      LBitField32 cats_bits(split_cats);
+      cats_bits.Set(cat);
+      node_categories.resize(split_cats.size());
+      dh::safe_cuda(cudaMemcpyAsync(
+          node_categories.data().get(), split_cats.data(),
+          split_cats.size() * sizeof(uint32_t), cudaMemcpyHostToDevice));
+      tree.ExpandCategorical(
+          candidate.nid, candidate.split.findex, split_cats,
+          candidate.split.dir == kLeftDir, base_weight, left_weight,
+          right_weight, candidate.split.loss_chg, parent_sum.GetHess(),
+          candidate.split.left_sum.GetHess(),
+          candidate.split.right_sum.GetHess());
+    } else {
+      tree.ExpandNode(candidate.nid, candidate.split.findex,
+                      candidate.split.fvalue, candidate.split.dir == kLeftDir,
+                      base_weight, left_weight, right_weight,
+                      candidate.split.loss_chg, parent_sum.GetHess(),
+                      candidate.split.left_sum.GetHess(),
+                      candidate.split.right_sum.GetHess());
+    }
 
     // Set up child constraints
     auto left_child = tree[candidate.nid].LeftChild();
@@ -664,7 +731,7 @@ struct GPUHistMakerDevice {
         if (ExpandEntry::ChildIsValid(param, tree.GetDepth(left_child_nidx),
                                       num_leaves)) {
           monitor.Start("UpdatePosition");
-          this->UpdatePosition(candidate.nid, (*p_tree)[candidate.nid]);
+          this->UpdatePosition(candidate.nid, p_tree);
           monitor.Stop("UpdatePosition");
 
           monitor.Start("BuildHist");
@@ -752,8 +819,10 @@ class GPUHistMakerSpecialised {
     };
     auto page = (*dmat->GetBatches<EllpackPage>(batch_param).begin()).Impl();
     dh::safe_cuda(cudaSetDevice(device_));
+    info_->feature_types.SetDevice(device_);
     maker.reset(new GPUHistMakerDevice<GradientSumT>(device_,
                                                      page,
+                                                     info_->feature_types.ConstDeviceSpan(),
                                                      info_->num_row_,
                                                      param_,
                                                      column_sampling_seed,

--- a/tests/cpp/common/test_quantile.cu
+++ b/tests/cpp/common/test_quantile.cu
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "test_quantile.h"
 #include "../helpers.h"
+#include "test_quantile.h"
 #include "../../../src/common/hist_util.cuh"
 #include "../../../src/common/quantile.cuh"
 
@@ -95,8 +96,7 @@ void TestQuantileElemRank(int32_t device, Span<SketchEntry const> in,
 
 TEST(GPUQuantile, Prune) {
   constexpr size_t kRows = 1000, kCols = 100;
-  RunWithSeedsAndBins(kRows, [=](int32_t seed, size_t n_bins,
-                                 MetaInfo const &info) {
+  RunWithSeedsAndBins(kRows, [=](int32_t seed, size_t n_bins, MetaInfo const& info) {
     HostDeviceVector<FeatureType> ft;
     SketchContainer sketch(ft, n_bins, kCols, kRows, 0);
 
@@ -293,9 +293,8 @@ TEST(GPUQuantile, AllReduceBasic) {
   }
 
   constexpr size_t kRows = 1000, kCols = 100;
-  RunWithSeedsAndBins(kRows, [=](int32_t seed, size_t n_bins,
-                                 MetaInfo const &info) {
-    // Set up single node version
+  RunWithSeedsAndBins(kRows, [=](int32_t seed, size_t n_bins, MetaInfo const& info) {
+    // Set up single node version;
     HostDeviceVector<FeatureType> ft;
     SketchContainer sketch_on_single_node(ft, n_bins, kCols, kRows, 0);
 
@@ -443,6 +442,18 @@ TEST(GPUQuantile, SameOnAllWorkers) {
   LOG(WARNING) << msg;
   return;
 #endif  // !defined(__linux__) && defined(XGBOOST_USE_NCCL)
+}
+
+TEST(GPUQuantile, FromOneHot) {
+  std::vector<float> x = BasicOneHotEncodedData();
+  auto m = GetDMatrixFromData(x, 5, 3);
+  int32_t max_bins = 16;
+  auto cuts = DeviceSketch(0, m.get(), max_bins);
+
+  std::vector<uint32_t> const& h_cuts_ptr = cuts.Ptrs();
+  std::vector<float> h_cuts_values = cuts.Values();
+
+  ValidateBasicOneHot(h_cuts_ptr, h_cuts_values);
 }
 }  // namespace common
 }  // namespace xgboost

--- a/tests/cpp/common/test_quantile.h
+++ b/tests/cpp/common/test_quantile.h
@@ -1,4 +1,9 @@
+#ifndef XGBOOST_TEST_QUANTILE_H_
+#define XGBOOST_TEST_QUANTILE_H_
+
 #include <rabit/rabit.h>
+#include <gtest/gtest.h>
+
 #include <algorithm>
 #include <string>
 #include <vector>
@@ -50,5 +55,33 @@ template <typename Fn> void RunWithSeedsAndBins(size_t rows, Fn fn) {
     }
   }
 }
+inline auto BasicOneHotEncodedData() {
+  std::vector<float> x {
+    0, 1, 0,
+    0, 1, 0,
+    0, 1, 0,
+    0, 0, 1,
+    1, 0, 0
+  };
+  return x;
+}
+
+inline void ValidateBasicOneHot(std::vector<uint32_t> const &h_cuts_ptr,
+                                std::vector<float> const &h_cuts_values) {
+  size_t const cols = 3;
+  ASSERT_EQ(h_cuts_ptr.size(),  cols + 1);
+  ASSERT_EQ(h_cuts_values.size(), cols * 2);
+
+  for (size_t i = 1; i < h_cuts_ptr.size(); ++i) {
+    auto feature =
+        common::Span<float const>(h_cuts_values)
+            .subspan(h_cuts_ptr[i - 1], h_cuts_ptr[i] - h_cuts_ptr[i - 1]);
+    EXPECT_EQ(feature.size(), 2);
+    // 0 is discarded as min value.
+    EXPECT_EQ(feature[0], 1.0f);
+    EXPECT_GT(feature[1], 1.0f);
+  }
+}
 }  // namespace common
 }  // namespace xgboost
+#endif  // XGBOOST_TEST_QUANTILE_H_

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -160,9 +160,11 @@ TEST(GPUPredictor, MGPU_InplacePredict) {  // NOLINT
                dmlc::Error);
 }
 
+
 TEST(GpuPredictor, LesserFeatures) {
   TestPredictionWithLesserFeatures("gpu_predictor");
 }
+
 // Very basic test of empty model
 TEST(GPUPredictor, ShapStump) {
   cudaSetDevice(0);
@@ -189,6 +191,7 @@ TEST(GPUPredictor, ShapStump) {
   EXPECT_EQ(phis[4], 0.0);
   EXPECT_EQ(phis[5], param.base_score);
 }
+
 TEST(GPUPredictor, Shap) {
   LearnerModelParam param;
   param.num_feature = 1;
@@ -219,5 +222,8 @@ TEST(GPUPredictor, Shap) {
   }
 }
 
+TEST(GPUPredictor, CategoricalPrediction) {
+  TestCategoricalPrediction("gpu_predictor");
+}
 }  // namespace predictor
 }  // namespace xgboost

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -12,6 +12,8 @@
 
 #include "../helpers.h"
 #include "../../../src/common/io.h"
+#include "../../../src/common/categorical.h"
+#include "../../../src/common/bitfield.h"
 
 namespace xgboost {
 TEST(Predictor, PredictionCache) {
@@ -27,7 +29,7 @@ TEST(Predictor, PredictionCache) {
   };
 
   add_cache();
-  ASSERT_EQ(container.Container().size(), 0);
+  ASSERT_EQ(container.Container().size(), 0ul);
   add_cache();
   EXPECT_ANY_THROW(container.Entry(m));
 }
@@ -173,5 +175,56 @@ void TestPredictionWithLesserFeatures(std::string predictor_name) {
     ASSERT_NEAR(h_cpu[i], h_gpu[i], kRtEps);
   }
 #endif  // defined(XGBOOST_USE_CUDA)
+}
+
+void TestCategoricalPrediction(std::string name) {
+  size_t constexpr kCols = 10;
+  PredictionCacheEntry out_predictions;
+
+  LearnerModelParam param;
+  param.num_feature = kCols;
+  param.num_output_group = 1;
+  param.base_score = 0.5;
+
+  gbm::GBTreeModel model(&param);
+
+  std::vector<std::unique_ptr<RegTree>> trees;
+  trees.push_back(std::unique_ptr<RegTree>(new RegTree));
+  auto& p_tree = trees.front();
+
+  uint32_t split_ind = 3;
+  bst_cat_t split_cat = 4;
+  float left_weight = 1.3f;
+  float right_weight = 1.7f;
+
+  std::vector<uint32_t> split_cats(LBitField32::ComputeStorageSize(split_cat));
+  LBitField32 cats_bits(split_cats);
+  cats_bits.Set(split_cat);
+
+  p_tree->ExpandCategorical(0, split_ind, split_cats, true, 1.5f,
+                            left_weight, right_weight,
+                            3.0f, 2.2f, 7.0f, 9.0f);
+  model.CommitModel(std::move(trees), 0);
+
+  GenericParameter runtime;
+  runtime.gpu_id = 0;
+  std::unique_ptr<Predictor> predictor{
+      Predictor::Create(name.c_str(), &runtime)};
+
+  std::vector<float> row(kCols);
+  row[split_ind] = split_cat;
+  auto m = GetDMatrixFromData(row, 1, kCols);
+
+  predictor->PredictBatch(m.get(), &out_predictions, model, 0);
+  ASSERT_EQ(out_predictions.predictions.Size(), 1ul);
+  ASSERT_EQ(out_predictions.predictions.HostVector()[0],
+            right_weight + param.base_score);
+
+  row[split_ind] = split_cat + 1;
+  m = GetDMatrixFromData(row, 1, kCols);
+  out_predictions.version = 0;
+  predictor->PredictBatch(m.get(), &out_predictions, model, 0);
+  ASSERT_EQ(out_predictions.predictions.HostVector()[0],
+            left_weight + param.base_score);
 }
 }  // namespace xgboost

--- a/tests/cpp/predictor/test_predictor.h
+++ b/tests/cpp/predictor/test_predictor.h
@@ -61,6 +61,8 @@ void TestInplacePrediction(dmlc::any x, std::string predictor,
                            int32_t device = -1);
 
 void TestPredictionWithLesserFeatures(std::string preditor_name);
+
+void TestCategoricalPrediction(std::string name);
 }  // namespace xgboost
 
 #endif  // XGBOOST_TEST_PREDICTOR_H_

--- a/tests/cpp/tree/gpu_hist/test_histogram.cu
+++ b/tests/cpp/tree/gpu_hist/test_histogram.cu
@@ -4,6 +4,7 @@
 #include "../../../../src/common/categorical.h"
 #include "../../../../src/tree/gpu_hist/row_partitioner.cuh"
 #include "../../../../src/tree/gpu_hist/histogram.cuh"
+#include "../../../../src/common/categorical.h"
 
 namespace xgboost {
 namespace tree {

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -80,7 +80,7 @@ void TestBuildHist(bool use_shared_memory_histograms) {
   param.Init(args);
   auto page = BuildEllpackPage(kNRows, kNCols);
   BatchParam batch_param{};
-  GPUHistMakerDevice<GradientSumT> maker(0, page.get(), kNRows, param, kNCols, kNCols,
+  GPUHistMakerDevice<GradientSumT> maker(0, page.get(), {}, kNRows, param, kNCols, kNCols,
                                          true, batch_param);
   xgboost::SimpleLCG gen;
   xgboost::SimpleRealUniformDistribution<bst_float> dist(0.0f, 1.0f);
@@ -154,19 +154,18 @@ TEST(GpuHist, EvaluateRootSplit) {
 
   TrainParam param;
 
-  std::vector<std::pair<std::string, std::string>> args {
-    {"max_depth", "1"},
-  {"max_leaves", "0"},
+  std::vector<std::pair<std::string, std::string>> args{
+      {"max_depth", "1"},
+      {"max_leaves", "0"},
 
-  // Disable all other parameters.
-  {"colsample_bynode", "1"},
-  {"colsample_bylevel", "1"},
-  {"colsample_bytree", "1"},
-  {"min_child_weight", "0.01"},
-  {"reg_alpha", "0"},
-  {"reg_lambda", "0"},
-  {"max_delta_step", "0"}
-  };
+      // Disable all other parameters.
+      {"colsample_bynode", "1"},
+      {"colsample_bylevel", "1"},
+      {"colsample_bytree", "1"},
+      {"min_child_weight", "0.01"},
+      {"reg_alpha", "0"},
+      {"reg_lambda", "0"},
+      {"max_delta_step", "0"}};
   param.Init(args);
   for (size_t i = 0; i < kNCols; ++i) {
     param.monotone_constraints.emplace_back(0);
@@ -178,7 +177,7 @@ TEST(GpuHist, EvaluateRootSplit) {
   auto page = BuildEllpackPage(kNRows, kNCols);
   BatchParam batch_param{};
   GPUHistMakerDevice<GradientPairPrecise>
-    maker(0, page.get(), kNRows, param, kNCols, kNCols, true, batch_param);
+      maker(0, page.get(), {}, kNRows, param, kNCols, kNCols, true, batch_param);
   // Initialize GPUHistMakerDevice::node_sum_gradients
   maker.node_sum_gradients = {};
 
@@ -257,7 +256,6 @@ void TestHistogramIndexImpl() {
 
   ASSERT_EQ(maker->page->Cuts().TotalBins(), maker_ext->page->Cuts().TotalBins());
   ASSERT_EQ(maker->page->gidx_buffer.Size(), maker_ext->page->gidx_buffer.Size());
-
 }
 
 TEST(GpuHist, TestHistogramIndex) {

--- a/tests/python-gpu/test_gpu_with_dask.py
+++ b/tests/python-gpu/test_gpu_with_dask.py
@@ -165,7 +165,8 @@ class TestDistributedGPU:
     @settings(deadline=duration(seconds=120))
     @pytest.mark.skipif(**tm.no_dask())
     @pytest.mark.skipif(**tm.no_dask_cuda())
-    @pytest.mark.parametrize('local_cuda_cluster', [{'n_workers': 2}], indirect=['local_cuda_cluster'])
+    @pytest.mark.parametrize('local_cuda_cluster', [{'n_workers': 2}],
+                             indirect=['local_cuda_cluster'])
     @pytest.mark.mgpu
     def test_gpu_hist(self, params, num_rounds, dataset, local_cuda_cluster):
         with Client(local_cuda_cluster) as client:

--- a/tests/python/test_with_pandas.py
+++ b/tests/python/test_with_pandas.py
@@ -67,7 +67,8 @@ class TestPandas(unittest.TestCase):
         # 0  1    1    0    0
         # 1  2    0    1    0
         # 2  3    0    0    1
-        result, _, _ = xgb.data._transform_pandas_df(dummies)
+        result, _, _ = xgb.data._transform_pandas_df(dummies,
+                                                     enable_categorical=False)
         exp = np.array([[1., 1., 0., 0.],
                         [2., 0., 1., 0.],
                         [3., 0., 0., 1.]])
@@ -109,6 +110,16 @@ class TestPandas(unittest.TestCase):
         assert dm.num_row() == 2
         assert dm.num_col() == 6
 
+    def test_pandas_categorical(self):
+        rng = np.random.RandomState(1994)
+        rows = 100
+        X = rng.randint(3, 7, size=rows)
+        X = pd.Series(X, dtype="category")
+        X = pd.DataFrame({'f0': X})
+        y = rng.randn(rows)
+        m = xgb.DMatrix(X, y, enable_categorical=True)
+        assert m.feature_types[0] == 'categorical'
+
     def test_pandas_sparse(self):
         import pandas as pd
         rows = 100
@@ -129,15 +140,15 @@ class TestPandas(unittest.TestCase):
         # label must be a single column
         df = pd.DataFrame({'A': ['X', 'Y', 'Z'], 'B': [1, 2, 3]})
         self.assertRaises(ValueError, xgb.data._transform_pandas_df, df,
-                          None, None, 'label', 'float')
+                          False, None, None, 'label', 'float')
 
         # label must be supported dtype
         df = pd.DataFrame({'A': np.array(['a', 'b', 'c'], dtype=object)})
         self.assertRaises(ValueError, xgb.data._transform_pandas_df, df,
-                          None, None, 'label', 'float')
+                          False, None, None, 'label', 'float')
 
         df = pd.DataFrame({'A': np.array([1, 2, 3], dtype=int)})
-        result, _, _ = xgb.data._transform_pandas_df(df, None, None,
+        result, _, _ = xgb.data._transform_pandas_df(df, False, None, None,
                                                      'label', 'float')
         np.testing.assert_array_equal(result, np.array([[1.], [2.], [3.]],
                                                        dtype=float))

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -53,6 +53,17 @@ def no_dt():
             'reason': 'Datatable is not installed.'}
 
 
+def no_cupy():
+    reason = 'cupy is not installed.'
+    try:
+        import cupy       # noqa
+        return {'condition': False,
+                'reason': reason}
+    except ImportError:
+        return {'condition': True,
+                'reason': reason}
+
+
 def no_matplotlib():
     reason = 'Matplotlib is not installed.'
     try:


### PR DESCRIPTION
This PR aims to have a working pipeline for categorical data, but the support is very limited at current form.  To run tests, one needs to:

- Use Python interface.
- Use `gbtree`.
- Use `gpu_hist` tree method.  Other tree methods are coming.
- Use `DMatrix`, `DeviceQuantileDMatrix` is not yet supported.
- Specify `enable_categorical` for `DMatrix`.
- Do **not** use weights.
- Use pandas with categorical feature type.
- Set `gpu_predictor` explicitly.
- Use JSON for model persistent.
- Specify `enable_experimental_json_serialization` even if you don't use pickle.

## Limitations
- The support is limited to 1 vs rest categorical split.  Other categorical specializations are coming.
- There's no mapping between categorical value and histogram bin.  So memory usage might be sub-optimal when categories are sparse.