### PR TITLE
Feature weights

### DIFF
--- a/amalgamation/xgboost-all0.cc
+++ b/amalgamation/xgboost-all0.cc
@@ -68,6 +68,7 @@
 #include "../src/learner.cc"
 #include "../src/logging.cc"
 #include "../src/common/common.cc"
+#include "../src/common/random.cc"
 #include "../src/common/charconv.cc"
 #include "../src/common/timer.cc"
 #include "../src/common/quantile.cc"

--- a/demo/guide-python/feature_weights.py
+++ b/demo/guide-python/feature_weights.py
@@ -22,7 +22,7 @@ def main(args):
         fw[i] *= float(i)
 
     dtrain = xgboost.DMatrix(X, y)
-    dtrain.feature_weights = fw
+    dtrain.set_info(feature_weights=fw)
 
     bst = xgboost.train({'tree_method': 'hist',
                          'colsample_bynode': 0.5},

--- a/demo/guide-python/feature_weights.py
+++ b/demo/guide-python/feature_weights.py
@@ -1,0 +1,49 @@
+'''Using feature weight to change column sampling.
+
+    .. versionadded:: 1.3.0
+'''
+
+import numpy as np
+import xgboost
+from matplotlib import pyplot as plt
+import argparse
+
+
+def main(args):
+    rng = np.random.RandomState(1994)
+
+    kRows = 1000
+    kCols = 10
+
+    X = rng.randn(kRows, kCols)
+    y = rng.randn(kRows)
+    fw = np.ones(shape=(kCols,))
+    for i in range(kCols):
+        fw[i] *= float(i)
+
+    dtrain = xgboost.DMatrix(X, y)
+    dtrain.feature_weights = fw
+
+    bst = xgboost.train({'tree_method': 'hist',
+                         'colsample_bynode': 0.5},
+                        dtrain, num_boost_round=10,
+                        evals=[(dtrain, 'd')])
+    featue_map = bst.get_fscore()
+    # feature zero has 0 weight
+    assert featue_map.get('f0', None) is None
+    assert max(featue_map.values()) == featue_map.get('f9')
+
+    if args.plot:
+        xgboost.plot_importance(bst)
+        plt.show()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--plot',
+        type=int,
+        default=1,
+        help='Set to 0 to disable plotting the evaluation history.')
+    args = parser.parse_args()
+    main(args)

--- a/demo/json-model/json_parser.py
+++ b/demo/json-model/json_parser.py
@@ -94,7 +94,7 @@ class Tree:
 
 class Model:
     '''Gradient boosted tree model.'''
-    def __init__(self, m: dict):
+    def __init__(self, model: dict):
         '''Construct the Model from JSON object.
 
          parameters

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -108,7 +108,8 @@ Parameters for Tree Booster
     each split.
 
     On Python interface, one can set the ``feature_weights`` for DMatrix to define the
-    probability of each feature being selected when using column sampling.
+    probability of each feature being selected when using column sampling.  There's a
+    similar parameter for ``fit`` method in sklearn interface.
 
 * ``lambda`` [default=1, alias: ``reg_lambda``]
 
@@ -227,7 +228,7 @@ Parameters for Tree Booster
     list is a group of indices of features that are allowed to interact with each other.
     See tutorial for more information
 
-Additional parameters for ``hist`` and ```gpu_hist`` tree method
+Additional parameters for ``hist`` and ``gpu_hist`` tree method
 ================================================================
 
 * ``single_precision_histogram``, [default=``false``]

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -107,6 +107,9 @@ Parameters for Tree Booster
     'colsample_bynode':0.5}`` with 64 features will leave 8 features to choose from at
     each split.
 
+    On Python interface, one can set the ``feature_weights`` for DMatrix to define the
+    probability of each feature being selected when using column sampling.
+
 * ``lambda`` [default=1, alias: ``reg_lambda``]
 
   - L2 regularization term on weights. Increasing this value will make model more conservative.

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -502,29 +502,8 @@ XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
  *
  * \return 0 when success, -1 when failure happens
  */
-XGB_DLL int XGDMatrixSetFeatureInfo(DMatrixHandle handle, const char *field,
-                                    void *data, bst_ulong size, int type);
-
-/*!
- * \brief Get feature info in a thread local buffer.
- *
- * Caller is responsible for copying out the data, before next call to any API function of
- * XGBoost.  The data is always on CPU thread local storage.
- *
- * \param handle   An instance of data matrix.
- * \param field    Field name.
- * \param out_type Type of this field.  This is defined in xgboost::DataType enum class.
- * \param out_size Length of output data, this is relative to size of out_type.  (Meaning
- *                 NOT number of bytes.)
- * \param out_dptr Pointer to output buffer.
- *
- * \return 0 when success, -1 when failure happens
- */
-XGB_DLL int XGDMatrixGetFeatureInfo(DMatrixHandle handle,
-                                    const char* field,
-                                    int* out_type,
-                                    bst_ulong* out_size,
-                                    const void** out_dptr);
+XGB_DLL int XGDMatrixSetDenseInfo(DMatrixHandle handle, const char *field,
+                                  void *data, bst_ulong size, int type);
 
 /*!
  * \brief (deprecated) Use XGDMatrixSetUIntInfo instead. Set group of the training matrix

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -484,9 +484,15 @@ XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
                                        const char ***out_features);
 
 /*!
- * \brief Set feature info that's not strings.  Currently accepted fields are:
+ * \brief Set meta info from dense matrix.  Valid field names are:
  *
- * - feature_weight
+ *  - label
+ *  - weight
+ *  - base_margin
+ *  - group
+ *  - label_lower_bound
+ *  - label_upper_bound
+ *  - feature_weights
  *
  * \param handle An instance of data matrix
  * \param field  Feild name

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -484,6 +484,49 @@ XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
                                        const char ***out_features);
 
 /*!
+ * \brief Set feature info that's not strings.  Currently accepted fields are:
+ *
+ * - feature_weight
+ *
+ * \param handle An instance of data matrix
+ * \param field  Feild name
+ * \param data   Pointer to consecutive memory storing data.
+ * \param size   Size of the data, this is relative to size of type.  (Meaning NOT number
+ *               of bytes.)
+ * \param type   Indicator of data type.  This is defined in xgboost::DataType enum class.
+ *
+ *    float    = 1
+ *    double   = 2
+ *    uint32_t = 3
+ *    uint64_t = 4
+ *
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixSetFeatureInfo(DMatrixHandle handle, const char *field,
+                                    void *data, bst_ulong size, int type);
+
+/*!
+ * \brief Get feature info in a thread local buffer.
+ *
+ * Caller is responsible for copying out the data, before next call to any API function of
+ * XGBoost.  The data is always on CPU thread local storage.
+ *
+ * \param handle   An instance of data matrix.
+ * \param field    Field name.
+ * \param out_type Type of this field.  This is defined in xgboost::DataType enum class.
+ * \param out_size Length of output data, this is relative to size of out_type.  (Meaning
+ *                 NOT number of bytes.)
+ * \param out_dptr Pointer to output buffer.
+ *
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixGetFeatureInfo(DMatrixHandle handle,
+                                    const char* field,
+                                    int* out_type,
+                                    bst_ulong* out_size,
+                                    const void** out_dptr);
+
+/*!
  * \brief (deprecated) Use XGDMatrixSetUIntInfo instead. Set group of the training matrix
  * \param handle a instance of data matrix
  * \param group pointer to group size

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -163,9 +163,6 @@ class MetaInfo {
 
   void SetFeatureInfo(const char *key, const char **info, const bst_ulong size);
   void GetFeatureInfo(const char *field, std::vector<std::string>* out_str_vecs) const;
-  void SetFeatureInfo(const char *field, const void *info, DataType type,
-                      bst_ulong size);
-  void GetFeatureInfo(const char *field, DataType *out_type, std::vector<float>* out) const;
 
   /*
    * \brief Extend with other MetaInfo.

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -88,34 +88,17 @@ class MetaInfo {
    * \brief Type of each feature.  Automatically set when feature_type_names is specifed.
    */
   HostDeviceVector<FeatureType> feature_types;
+  /*
+   * \brief Weight of each feature, used to define the probability of each feature being
+   *        selected when using column sampling.
+   */
+  HostDeviceVector<float> feature_weigths;
 
   /*! \brief default constructor */
   MetaInfo()  = default;
   MetaInfo(MetaInfo&& that) = default;
   MetaInfo& operator=(MetaInfo&& that) = default;
-  MetaInfo& operator=(MetaInfo const& that) {
-    this->num_row_ = that.num_row_;
-    this->num_col_ = that.num_col_;
-    this->num_nonzero_ = that.num_nonzero_;
-
-    this->labels_.Resize(that.labels_.Size());
-    this->labels_.Copy(that.labels_);
-
-    this->group_ptr_ = that.group_ptr_;
-
-    this->weights_.Resize(that.weights_.Size());
-    this->weights_.Copy(that.weights_);
-
-    this->base_margin_.Resize(that.base_margin_.Size());
-    this->base_margin_.Copy(that.base_margin_);
-
-    this->labels_lower_bound_.Resize(that.labels_lower_bound_.Size());
-    this->labels_lower_bound_.Copy(that.labels_lower_bound_);
-
-    this->labels_upper_bound_.Resize(that.labels_upper_bound_.Size());
-    this->labels_upper_bound_.Copy(that.labels_upper_bound_);
-    return *this;
-  }
+  MetaInfo& operator=(MetaInfo const& that) = delete;
 
   /*!
    * \brief Validate all metainfo.
@@ -180,6 +163,9 @@ class MetaInfo {
 
   void SetFeatureInfo(const char *key, const char **info, const bst_ulong size);
   void GetFeatureInfo(const char *field, std::vector<std::string>* out_str_vecs) const;
+  void SetFeatureInfo(const char *field, const void *info, DataType type,
+                      bst_ulong size);
+  void GetFeatureInfo(const char *field, DataType *out_type, std::vector<float>* out) const;
 
   /*
    * \brief Extend with other MetaInfo.

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -476,8 +476,6 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
             self.feature_types = feature_types
         if feature_weights is not None:
             from .data import dispatch_meta_backend
-            # feature weight API is newer than the others and it accepts
-            # general data type instead of float only.
             dispatch_meta_backend(matrix=self, data=feature_weights,
                                   name='feature_weights')
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -841,6 +841,45 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
                 None,
                 c_bst_ulong(0)))
 
+    @property
+    def feature_weights(self):
+        '''Weight for each feature, defines the probability of each feature
+        being selected when colsample is being used.  All values must
+        be greater than 0, otherwise a `XGBoostError` is thrown.
+
+        .. versionadded:: 1.3.0
+
+        '''
+        length = c_bst_ulong()
+        ret = ctypes.POINTER(ctypes.c_void_p)()
+        out_type = ctypes.c_int()
+        _check_call(_LIB.XGDMatrixGetFeatureInfo(
+            self.handle,
+            c_str('feature_weight'),
+            ctypes.byref(out_type),
+            ctypes.byref(length),
+            ctypes.byref(ret)
+        ))
+        to_data_type = {1: np.float32, 2: np.float64, 3: np.uint32,
+                        4: np.uint64}
+        to_c_type = {1: ctypes.c_float, 2: ctypes.c_double, 3: ctypes.c_uint32,
+                     4: ctypes.c_uint64}
+        dtype = to_data_type[out_type.value]
+        ptr = ctypes.cast(ret, ctypes.POINTER(to_c_type[out_type.value]))
+        return ctypes2numpy(ptr, length.value, dtype)
+
+    @feature_weights.setter
+    def feature_weights(self, array):
+        '''Setter for feature weights.  Clear the feature weights if array is
+        None.
+
+        '''
+        from .data import dispatch_meta_backend
+        if array is None:
+            array = np.empty((0, 0))
+        dispatch_meta_backend(matrix=self, data=array, name='feature_weight',
+                              is_feature=True)
+
 
 class DeviceQuantileDMatrix(DMatrix):
     """Device memory Data Matrix used in XGBoost for training with

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -530,31 +530,52 @@ def dispatch_data_backend(data, missing, threads,
     raise TypeError('Not supported type for data.' + str(type(data)))
 
 
-def _meta_from_numpy(data, field, dtype, handle):
-    data = _maybe_np_slice(data, dtype)
-    if dtype == 'uint32':
-        c_data = c_array(ctypes.c_uint32, data)
-        _check_call(_LIB.XGDMatrixSetUIntInfo(handle,
-                                              c_str(field),
-                                              c_array(ctypes.c_uint, data),
-                                              c_bst_ulong(len(data))))
-    elif dtype == 'float':
-        c_data = c_array(ctypes.c_float, data)
-        _check_call(_LIB.XGDMatrixSetFloatInfo(handle,
-                                               c_str(field),
-                                               c_data,
-                                               c_bst_ulong(len(data))))
+def _to_data_type(dtype: str):
+    dtype_map = {'float32': 1, 'float64': 2, 'uint32': 3, 'uint64': 4}
+    return dtype_map[dtype]
+
+
+def _meta_from_numpy(data, field, dtype, handle, is_feature: bool = False):
+    if is_feature:
+        data = _maybe_np_slice(data, dtype)
+        interface = data.__array_interface__
+        assert interface.get('mask', None) is None
+        size = data.shape[0]
+        c_type = _to_data_type(str(data.dtype))
+        data = interface['data']
+        data = ctypes.c_void_p(data[0])
+        _check_call(_LIB.XGDMatrixSetFeatureInfo(
+            handle,
+            c_str(field),
+            data,
+            size,
+            c_type
+        ))
     else:
-        raise TypeError('Unsupported type ' + str(dtype) + ' for:' + field)
+        data = _maybe_np_slice(data, dtype)
+        if dtype == 'uint32':
+            c_data = c_array(ctypes.c_uint32, data)
+            _check_call(_LIB.XGDMatrixSetUIntInfo(handle,
+                                                  c_str(field),
+                                                  c_array(ctypes.c_uint, data),
+                                                  c_bst_ulong(len(data))))
+        elif dtype == 'float':
+            c_data = c_array(ctypes.c_float, data)
+            _check_call(_LIB.XGDMatrixSetFloatInfo(handle,
+                                                   c_str(field),
+                                                   c_data,
+                                                   c_bst_ulong(len(data))))
+        else:
+            raise TypeError('Unsupported type ' + str(dtype) + ' for:' + field)
 
 
-def _meta_from_list(data, field, dtype, handle):
+def _meta_from_list(data, field, dtype, handle, is_feature):
     data = np.array(data)
-    _meta_from_numpy(data, field, dtype, handle)
+    _meta_from_numpy(data, field, dtype, handle, is_feature)
 
 
-def _meta_from_tuple(data, field, dtype, handle):
-    return _meta_from_list(data, field, dtype, handle)
+def _meta_from_tuple(data, field, dtype, handle, is_feature):
+    return _meta_from_list(data, field, dtype, handle, is_feature)
 
 
 def _meta_from_cudf_df(data, field, handle):
@@ -592,28 +613,29 @@ def _meta_from_dt(data, field, dtype, handle):
     _meta_from_numpy(data, field, dtype, handle)
 
 
-def dispatch_meta_backend(matrix: DMatrix, data, name: str, dtype: str = None):
+def dispatch_meta_backend(matrix: DMatrix, data, name: str, dtype: str = None,
+                          is_feature: bool = False):
     '''Dispatch for meta info.'''
     handle = matrix.handle
     if data is None:
         return
     if _is_list(data):
-        _meta_from_list(data, name, dtype, handle)
+        _meta_from_list(data, name, dtype, handle, is_feature)
         return
     if _is_tuple(data):
-        _meta_from_tuple(data, name, dtype, handle)
+        _meta_from_tuple(data, name, dtype, handle, is_feature)
         return
     if _is_numpy_array(data):
-        _meta_from_numpy(data, name, dtype, handle)
+        _meta_from_numpy(data, name, dtype, handle, is_feature)
         return
     if _is_pandas_df(data):
         data, _, _ = _transform_pandas_df(data, meta=name, meta_type=dtype)
-        _meta_from_numpy(data, name, dtype, handle)
+        _meta_from_numpy(data, name, dtype, handle, is_feature)
         return
     if _is_pandas_series(data):
         data = data.values.astype('float')
         assert len(data.shape) == 1 or data.shape[1] == 0 or data.shape[1] == 1
-        _meta_from_numpy(data, name, dtype, handle)
+        _meta_from_numpy(data, name, dtype, handle, is_feature)
         return
     if _is_dlpack(data):
         data = _transform_dlpack(data)

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -511,7 +511,7 @@ class XGBModel(XGBModelBase):
                                 base_margin=base_margin,
                                 missing=self.missing,
                                 nthread=self.n_jobs)
-        train_dmatrix.feature_weights = feature_weights
+        train_dmatrix.set_info(feature_weights=feature_weights)
 
         evals_result = {}
 
@@ -828,7 +828,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         train_dmatrix = DMatrix(X, label=training_labels, weight=sample_weight,
                                 base_margin=base_margin,
                                 missing=self.missing, nthread=self.n_jobs)
-        train_dmatrix.feature_weights = feature_weights
+        train_dmatrix.set_info(feature_weights=feature_weights)
 
         self._Booster = train(xgb_options, train_dmatrix,
                               self.get_num_boosting_rounds(),
@@ -1217,7 +1217,7 @@ class XGBRanker(XGBModel):
         train_dmatrix = DMatrix(data=X, label=y, weight=sample_weight,
                                 base_margin=base_margin,
                                 missing=self.missing, nthread=self.n_jobs)
-        train_dmatrix.feature_weights = feature_weights
+        train_dmatrix.set_info(feature_weights=feature_weights)
         train_dmatrix.set_group(group)
 
         evals_result = {}

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -316,34 +316,13 @@ XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
   API_END();
 }
 
-XGB_DLL int XGDMatrixSetFeatureInfo(DMatrixHandle handle, const char *field,
-                                    void *data, xgboost::bst_ulong size,
-                                    int type) {
+XGB_DLL int XGDMatrixSetDenseInfo(DMatrixHandle handle, const char *field,
+                                  void *data, xgboost::bst_ulong size,
+                                  int type) {
   API_BEGIN();
   CHECK_HANDLE();
   auto &info = static_cast<std::shared_ptr<DMatrix> *>(handle)->get()->Info();
-  info.SetFeatureInfo(field, data, static_cast<DataType>(type), size);
-  API_END();
-}
-
-XGB_DLL int XGDMatrixGetFeatureInfo(DMatrixHandle handle,
-                                    const char* field,
-                                    int* out_type,
-                                    xgboost::bst_ulong* out_len,
-                                    const void** out_dptr) {
-  API_BEGIN();
-  CHECK_HANDLE();
-  auto m = *static_cast<std::shared_ptr<DMatrix>*>(handle);
-  auto &info = static_cast<std::shared_ptr<DMatrix> *>(handle)->get()->Info();
-  DataType out_t;
-
-  // Right now only float for feature weights is used.  If other data types are rquired,
-  // we can pass in a general memory buffer.
-  auto& float_vec = m->GetThreadLocal().ret_vec_float;
-  info.GetFeatureInfo(field, &out_t, &float_vec);
-  *out_type = static_cast<int>(out_t);
-  *out_len = float_vec.size();
-  *out_dptr = float_vec.data();
+  info.SetInfo(field, data, static_cast<DataType>(type), size);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -322,6 +322,7 @@ XGB_DLL int XGDMatrixSetDenseInfo(DMatrixHandle handle, const char *field,
   API_BEGIN();
   CHECK_HANDLE();
   auto &info = static_cast<std::shared_ptr<DMatrix> *>(handle)->get()->Info();
+  CHECK(type >= 1 && type <= 4);
   info.SetInfo(field, data, static_cast<DataType>(type), size);
   API_END();
 }

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -316,6 +316,37 @@ XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
   API_END();
 }
 
+XGB_DLL int XGDMatrixSetFeatureInfo(DMatrixHandle handle, const char *field,
+                                    void *data, xgboost::bst_ulong size,
+                                    int type) {
+  API_BEGIN();
+  CHECK_HANDLE();
+  auto &info = static_cast<std::shared_ptr<DMatrix> *>(handle)->get()->Info();
+  info.SetFeatureInfo(field, data, static_cast<DataType>(type), size);
+  API_END();
+}
+
+XGB_DLL int XGDMatrixGetFeatureInfo(DMatrixHandle handle,
+                                    const char* field,
+                                    int* out_type,
+                                    xgboost::bst_ulong* out_len,
+                                    const void** out_dptr) {
+  API_BEGIN();
+  CHECK_HANDLE();
+  auto m = *static_cast<std::shared_ptr<DMatrix>*>(handle);
+  auto &info = static_cast<std::shared_ptr<DMatrix> *>(handle)->get()->Info();
+  DataType out_t;
+
+  // Right now only float for feature weights is used.  If other data types are rquired,
+  // we can pass in a general memory buffer.
+  auto& float_vec = m->GetThreadLocal().ret_vec_float;
+  info.GetFeatureInfo(field, &out_t, &float_vec);
+  *out_type = static_cast<int>(out_t);
+  *out_len = float_vec.size();
+  *out_dptr = float_vec.data();
+  API_END();
+}
+
 XGB_DLL int XGDMatrixSetGroup(DMatrixHandle handle,
                               const unsigned* group,
                               xgboost::bst_ulong len) {

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -9,12 +9,15 @@
 #include <xgboost/base.h>
 #include <xgboost/logging.h>
 
+#include <algorithm>
 #include <exception>
+#include <functional>
 #include <limits>
 #include <type_traits>
 #include <vector>
 #include <string>
 #include <sstream>
+#include <numeric>
 
 #if defined(__CUDACC__)
 #include <thrust/system/cuda/error.h>
@@ -160,6 +163,15 @@ inline void AssertOneAPISupport() {
 #endif  // XGBOOST_USE_ONEAPI
 }
 
+template <typename Idx, typename V, typename Comp = std::less<V>>
+std::vector<Idx> ArgSort(std::vector<V> const &array, Comp comp = std::less<V>{}) {
+  std::vector<Idx> result(array.size());
+  std::iota(result.begin(), result.end(), 0);
+  std::stable_sort(
+      result.begin(), result.end(),
+      [&array, comp](Idx const &l, Idx const &r) { return comp(array[l], array[r]); });
+  return result;
+}
 }  // namespace common
 }  // namespace xgboost
 #endif  // XGBOOST_COMMON_COMMON_H_

--- a/src/common/random.cc
+++ b/src/common/random.cc
@@ -1,0 +1,38 @@
+/*!
+ * Copyright 2020 by XGBoost Contributors
+ * \file random.cc
+ */
+#include "random.h"
+
+namespace xgboost {
+namespace common {
+std::shared_ptr<HostDeviceVector<bst_feature_t>> ColumnSampler::ColSample(
+    std::shared_ptr<HostDeviceVector<bst_feature_t>> p_features,
+    float colsample) {
+  if (colsample == 1.0f) {
+    return p_features;
+  }
+  const auto &features = p_features->HostVector();
+  CHECK_GT(features.size(), 0);
+
+  int n = std::max(1, static_cast<int>(colsample * features.size()));
+  auto p_new_features = std::make_shared<HostDeviceVector<bst_feature_t>>();
+  auto &new_features = *p_new_features;
+
+  if (feature_weights_.size() != 0) {
+    new_features.HostVector() = WeightedSamplingWithoutReplacement(
+        p_features->HostVector(), feature_weights_, n);
+  } else {
+    new_features.Resize(features.size());
+    std::copy(features.begin(), features.end(),
+              new_features.HostVector().begin());
+    std::shuffle(new_features.HostVector().begin(),
+                 new_features.HostVector().end(), rng_);
+    new_features.Resize(n);
+  }
+  std::sort(new_features.HostVector().begin(), new_features.HostVector().end());
+  return p_new_features;
+}
+
+}  // namespace common
+}  // namespace xgboost

--- a/src/common/random.h
+++ b/src/common/random.h
@@ -78,6 +78,13 @@ using GlobalRandomEngine = RandomEngine;
  */
 GlobalRandomEngine& GlobalRandom(); // NOLINT(*)
 
+/*
+ * Original paper:
+ * Weighted Random Sampling (2005; Efraimidis, Spirakis)
+ *
+ * Blog:
+ * https://timvieira.github.io/blog/post/2019/09/16/algorithms-for-sampling-without-replacement/
+*/
 template <typename T>
 std::vector<T> WeightedSamplingWithoutReplacement(
     std::vector<T> const &array, std::vector<float> const &weights, size_t n) {

--- a/src/common/random.h
+++ b/src/common/random.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2015 by Contributors
+ * Copyright 2015-2020 by Contributors
  * \file random.h
  * \brief Utility related to random.
  * \author Tianqi Chen
@@ -10,14 +10,17 @@
 #include <rabit/rabit.h>
 #include <xgboost/logging.h>
 #include <algorithm>
+#include <functional>
 #include <vector>
 #include <limits>
 #include <map>
 #include <memory>
 #include <numeric>
 #include <random>
+#include <utility>
 
 #include "xgboost/host_device_vector.h"
+#include "common.h"
 
 namespace xgboost {
 namespace common {
@@ -75,6 +78,31 @@ using GlobalRandomEngine = RandomEngine;
  */
 GlobalRandomEngine& GlobalRandom(); // NOLINT(*)
 
+template <typename T>
+std::vector<T> WeightedSamplingWithoutReplacement(
+    std::vector<T> const &array, std::vector<float> const &weights, size_t n) {
+  // ES sampling.
+  CHECK_EQ(array.size(), weights.size());
+  std::vector<float> keys(weights.size());
+  std::uniform_real_distribution<float> dist;
+  auto& rng = GlobalRandom();
+  for (size_t i = 0; i < array.size(); ++i) {
+    auto w = std::max(weights.at(i), kRtEps);
+    auto u = dist(rng);
+    auto k = std::log(u) / w;
+    keys[i] = k;
+  }
+  auto ind = ArgSort<size_t>(keys, std::greater<>{});
+  ind.resize(n);
+
+  std::vector<T> results(ind.size());
+  for (size_t k = 0; k < ind.size(); ++k) {
+    auto idx = ind[k];
+    results[k] = array[idx];
+  }
+  return results;
+}
+
 /**
  * \class ColumnSampler
  *
@@ -82,36 +110,18 @@ GlobalRandomEngine& GlobalRandom(); // NOLINT(*)
  * colsample_bynode parameters. Should be initialised before tree construction and to
  * reset when tree construction is completed.
  */
-
 class ColumnSampler {
   std::shared_ptr<HostDeviceVector<bst_feature_t>> feature_set_tree_;
   std::map<int, std::shared_ptr<HostDeviceVector<bst_feature_t>>> feature_set_level_;
+  std::vector<float> feature_weights_;
   float colsample_bylevel_{1.0f};
   float colsample_bytree_{1.0f};
   float colsample_bynode_{1.0f};
   GlobalRandomEngine rng_;
 
-  std::shared_ptr<HostDeviceVector<bst_feature_t>> ColSample(
-      std::shared_ptr<HostDeviceVector<bst_feature_t>> p_features, float colsample) {
-    if (colsample == 1.0f) return p_features;
-    const auto& features = p_features->HostVector();
-    CHECK_GT(features.size(), 0);
-    int n = std::max(1, static_cast<int>(colsample * features.size()));
-    auto p_new_features = std::make_shared<HostDeviceVector<bst_feature_t>>();
-    auto& new_features = *p_new_features;
-    new_features.Resize(features.size());
-    std::copy(features.begin(), features.end(),
-              new_features.HostVector().begin());
-    std::shuffle(new_features.HostVector().begin(),
-                 new_features.HostVector().end(), rng_);
-    new_features.Resize(n);
-    std::sort(new_features.HostVector().begin(),
-              new_features.HostVector().end());
-
-    return p_new_features;
-  }
-
  public:
+  std::shared_ptr<HostDeviceVector<bst_feature_t>> ColSample(
+      std::shared_ptr<HostDeviceVector<bst_feature_t>> p_features, float colsample);
   /**
    * \brief Column sampler constructor.
    * \note This constructor manually sets the rng seed
@@ -139,8 +149,10 @@ class ColumnSampler {
    * \param colsample_bytree
    * \param skip_index_0      (Optional) True to skip index 0.
    */
-  void Init(int64_t num_col, float colsample_bynode, float colsample_bylevel,
+  void Init(int64_t num_col, std::vector<float> feature_weights,
+            float colsample_bynode, float colsample_bylevel,
             float colsample_bytree, bool skip_index_0 = false) {
+    feature_weights_ = std::move(feature_weights);
     colsample_bylevel_ = colsample_bylevel;
     colsample_bytree_ = colsample_bytree;
     colsample_bynode_ = colsample_bynode;

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -235,8 +235,10 @@ class ColMaker: public TreeUpdater {
         }
       }
       {
-        column_sampler_.Init(fmat.Info().num_col_, param_.colsample_bynode,
-                             param_.colsample_bylevel, param_.colsample_bytree);
+        column_sampler_.Init(fmat.Info().num_col_,
+                             fmat.Info().feature_weigths.ConstHostVector(),
+                             param_.colsample_bynode, param_.colsample_bylevel,
+                             param_.colsample_bytree);
       }
       {
         // setup temp space for each thread

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -266,8 +266,10 @@ struct GPUHistMakerDevice {
   // Note that the column sampler must be passed by value because it is not
   // thread safe
   void Reset(HostDeviceVector<GradientPair>* dh_gpair, DMatrix* dmat, int64_t num_columns) {
-    this->column_sampler.Init(num_columns, param.colsample_bynode,
-      param.colsample_bylevel, param.colsample_bytree);
+    auto const& info = dmat->Info();
+    this->column_sampler.Init(num_columns, info.feature_weigths.HostVector(),
+                              param.colsample_bynode, param.colsample_bylevel,
+                              param.colsample_bytree);
     dh::safe_cuda(cudaSetDevice(device_id));
     this->interaction_constraints.Reset();
     std::fill(node_sum_gradients.begin(), node_sum_gradients.end(),

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -841,11 +841,13 @@ void QuantileHistMaker::Builder<GradientSumT>::InitData(const GHistIndexMatrix& 
   // store a pointer to the tree
   p_last_tree_ = &tree;
   if (data_layout_ == kDenseDataOneBased) {
-    column_sampler_.Init(info.num_col_, param_.colsample_bynode, param_.colsample_bylevel,
-            param_.colsample_bytree, true);
+    column_sampler_.Init(info.num_col_, info.feature_weigths.ConstHostVector(),
+                         param_.colsample_bynode, param_.colsample_bylevel,
+                         param_.colsample_bytree, true);
   } else {
-    column_sampler_.Init(info.num_col_, param_.colsample_bynode, param_.colsample_bylevel,
-            param_.colsample_bytree,  false);
+    column_sampler_.Init(info.num_col_, info.feature_weigths.ConstHostVector(),
+                         param_.colsample_bynode, param_.colsample_bylevel,
+                         param_.colsample_bytree, false);
   }
   if (data_layout_ == kDenseDataZeroBased || data_layout_ == kDenseDataOneBased) {
     /* specialized code for dense data:

--- a/tests/cpp/common/test_common.cc
+++ b/tests/cpp/common/test_common.cc
@@ -1,0 +1,13 @@
+#include <gtest/gtest.h>
+#include "../../../src/common/common.h"
+
+namespace xgboost {
+namespace common {
+TEST(ArgSort, Basic) {
+  std::vector<float> inputs {3.0, 2.0, 1.0};
+  auto ret = ArgSort<bst_feature_t>(inputs);
+  std::vector<bst_feature_t> sol{2, 1, 0};
+  ASSERT_EQ(ret, sol);
+}
+}  // namespace common
+}  // namespace xgboost

--- a/tests/cpp/common/test_random.cc
+++ b/tests/cpp/common/test_random.cc
@@ -8,9 +8,10 @@ namespace common {
 TEST(ColumnSampler, Test) {
   int n = 128;
   ColumnSampler cs;
+  std::vector<float> feature_weights;
 
   // No node sampling
-  cs.Init(n, 1.0f, 0.5f, 0.5f);
+  cs.Init(n, feature_weights, 1.0f, 0.5f, 0.5f);
   auto set0 = cs.GetFeatureSet(0);
   ASSERT_EQ(set0->Size(), 32);
 
@@ -23,7 +24,7 @@ TEST(ColumnSampler, Test) {
   ASSERT_EQ(set2->Size(), 32);
 
   // Node sampling
-  cs.Init(n, 0.5f, 1.0f, 0.5f);
+  cs.Init(n, feature_weights, 0.5f, 1.0f, 0.5f);
   auto set3 = cs.GetFeatureSet(0);
   ASSERT_EQ(set3->Size(), 32);
 
@@ -33,19 +34,19 @@ TEST(ColumnSampler, Test) {
   ASSERT_EQ(set4->Size(), 32);
 
   // No level or node sampling, should be the same at different depth
-  cs.Init(n, 1.0f, 1.0f, 0.5f);
+  cs.Init(n, feature_weights, 1.0f, 1.0f, 0.5f);
   ASSERT_EQ(cs.GetFeatureSet(0)->HostVector(),
             cs.GetFeatureSet(1)->HostVector());
 
-  cs.Init(n, 1.0f, 1.0f, 1.0f);
+  cs.Init(n, feature_weights, 1.0f, 1.0f, 1.0f);
   auto set5 = cs.GetFeatureSet(0);
   ASSERT_EQ(set5->Size(), n);
-  cs.Init(n, 1.0f, 1.0f, 1.0f);
+  cs.Init(n, feature_weights, 1.0f, 1.0f, 1.0f);
   auto set6 = cs.GetFeatureSet(0);
   ASSERT_EQ(set5->HostVector(), set6->HostVector());
 
   // Should always be a minimum of one feature
-  cs.Init(n, 1e-16f, 1e-16f, 1e-16f);
+  cs.Init(n, feature_weights, 1e-16f, 1e-16f, 1e-16f);
   ASSERT_EQ(cs.GetFeatureSet(0)->Size(), 1);
 }
 
@@ -56,13 +57,13 @@ TEST(ColumnSampler, ThreadSynchronisation) {
   size_t iterations = 10;
   size_t levels = 5;
   std::vector<bst_feature_t> reference_result;
-  bool success =
-      true;  // Cannot use google test asserts in multithreaded region
+  std::vector<float> feature_weights;
+  bool success = true; // Cannot use google test asserts in multithreaded region
 #pragma omp parallel num_threads(num_threads)
   {
     for (auto j = 0ull; j < iterations; j++) {
       ColumnSampler cs(j);
-      cs.Init(n, 0.5f, 0.5f, 0.5f);
+      cs.Init(n, feature_weights, 0.5f, 0.5f, 0.5f);
       for (auto level = 0ull; level < levels; level++) {
         auto result = cs.GetFeatureSet(level)->ConstHostVector();
 #pragma omp single
@@ -75,6 +76,55 @@ TEST(ColumnSampler, ThreadSynchronisation) {
     }
   }
   ASSERT_TRUE(success);
+}
+
+TEST(ColumnSampler, WeightedSampling) {
+  auto test_basic = [](int first) {
+    std::vector<float> feature_weights(2);
+    feature_weights[0] = std::abs(first - 1.0f);
+    feature_weights[1] = first - 0.0f;
+    ColumnSampler cs{0};
+    cs.Init(2, feature_weights, 1.0, 1.0, 0.5);
+    auto feature_sets = cs.GetFeatureSet(0);
+    auto const &h_feat_set = feature_sets->HostVector();
+    ASSERT_EQ(h_feat_set.size(), 1);
+    ASSERT_EQ(h_feat_set[0], first - 0);
+  };
+
+  test_basic(0);
+  test_basic(1);
+
+  size_t constexpr kCols = 64;
+  std::vector<float> feature_weights(kCols);
+  SimpleLCG rng;
+  SimpleRealUniformDistribution<float> dist(.0f, 12.0f);
+  std::generate(feature_weights.begin(), feature_weights.end(), [&]() { return dist(&rng); });
+  ColumnSampler cs{0};
+  cs.Init(kCols, feature_weights, 0.5f, 1.0f, 1.0f);
+  std::vector<bst_feature_t> features(kCols);
+  std::iota(features.begin(), features.end(), 0);
+  std::vector<float> freq(kCols, 0);
+  for (size_t i = 0; i < 1024; ++i) {
+    auto fset = cs.GetFeatureSet(0);
+    ASSERT_EQ(kCols * 0.5, fset->Size());
+    auto const& h_fset = fset->HostVector();
+    for (auto f : h_fset) {
+      freq[f] += 1.0f;
+    }
+  }
+
+  auto norm = std::accumulate(freq.cbegin(), freq.cend(), .0f);
+  for (auto& f : freq) {
+    f /= norm;
+  }
+  norm = std::accumulate(feature_weights.cbegin(), feature_weights.cend(), .0f);
+  for (auto& f : feature_weights) {
+    f /= norm;
+  }
+
+  for (size_t i = 0; i < feature_weights.size(); ++i) {
+    EXPECT_NEAR(freq[i], feature_weights[i], 1e-2);
+  }
 }
 }  // namespace common
 }  // namespace xgboost

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -204,12 +204,11 @@ TEST(GpuHist, EvaluateRootSplit) {
   ASSERT_EQ(maker.hist.Data().size(), hist.size());
   thrust::copy(hist.begin(), hist.end(),
     maker.hist.Data().begin());
+  std::vector<float> feature_weights;
 
-  maker.column_sampler.Init(kNCols,
-    param.colsample_bynode,
-    param.colsample_bylevel,
-    param.colsample_bytree,
-    false);
+  maker.column_sampler.Init(kNCols, feature_weights, param.colsample_bynode,
+                            param.colsample_bylevel, param.colsample_bytree,
+                            false);
 
   RegTree tree;
   MetaInfo info;

--- a/tests/python-gpu/test_device_quantile_dmatrix.py
+++ b/tests/python-gpu/test_device_quantile_dmatrix.py
@@ -17,6 +17,20 @@ class TestDeviceQuantileDMatrix(unittest.TestCase):
             xgb.DeviceQuantileDMatrix(data, np.ones(5, dtype=np.float64))
 
     @pytest.mark.skipif(**tm.no_cupy())
+    def test_dmatrix_feature_weights(self):
+        import cupy as cp
+        rng = cp.random.RandomState(1994)
+        data = rng.randn(5, 5)
+        m = xgb.DMatrix(data)
+
+        feature_weights = rng.uniform(size=5)
+        m.set_info(feature_weights=feature_weights)
+
+        cp.testing.assert_array_equal(
+            cp.array(m.get_float_info('feature_weights')),
+            feature_weights.astype(np.float32))
+
+    @pytest.mark.skipif(**tm.no_cupy())
     def test_dmatrix_cupy_init(self):
         import cupy as cp
         data = cp.random.randn(5, 5)

--- a/tests/python/test_demos.py
+++ b/tests/python/test_demos.py
@@ -1,12 +1,10 @@
 import os
 import subprocess
-import sys
 import pytest
 import testing as tm
 
 
-CURRENT_DIR = os.path.dirname(__file__)
-ROOT_DIR = os.path.dirname(os.path.dirname(CURRENT_DIR))
+ROOT_DIR = tm.PROJECT_ROOT
 DEMO_DIR = os.path.join(ROOT_DIR, 'demo')
 PYTHON_DEMO_DIR = os.path.join(DEMO_DIR, 'guide-python')
 
@@ -19,17 +17,23 @@ def test_basic_walkthrough():
     os.remove('dump.raw.txt')
 
 
+@pytest.mark.skipif(**tm.no_matplotlib())
 def test_custom_multiclass_objective():
     script = os.path.join(PYTHON_DEMO_DIR, 'custom_softmax.py')
     cmd = ['python', script, '--plot=0']
     subprocess.check_call(cmd)
 
 
+@pytest.mark.skipif(**tm.no_matplotlib())
 def test_custom_rmsle_objective():
-    major, minor = sys.version_info[:2]
-    if minor < 6:
-        pytest.skip('Skipping RMLSE test due to Python version being too low.')
     script = os.path.join(PYTHON_DEMO_DIR, 'custom_rmsle.py')
+    cmd = ['python', script, '--plot=0']
+    subprocess.check_call(cmd)
+
+
+@pytest.mark.skipif(**tm.no_matplotlib())
+def test_feature_weights_demo():
+    script = os.path.join(PYTHON_DEMO_DIR, 'feature_weights.py')
     cmd = ['python', script, '--plot=0']
     subprocess.check_call(cmd)
 

--- a/tests/python/test_dmatrix.py
+++ b/tests/python/test_dmatrix.py
@@ -112,13 +112,6 @@ class TestDMatrix(unittest.TestCase):
         predt = booster.predict(d)
         predt = predt.reshape(100 * 3, 1)
 
-        i = 0
-        import os
-        while os.path.exists(f'test_predict-{i}.txt'):
-            i += 1
-        with open(f'test_predict-{i}.txt', 'w') as fd:
-            print(predt, 'pred', file=fd)
-
         d.set_base_margin(predt)
 
         ridxs = [1, 2, 3, 4, 5, 6]
@@ -127,12 +120,6 @@ class TestDMatrix(unittest.TestCase):
         sliced_margin = sliced.get_float_info('base_margin')
         assert sliced_margin.shape[0] == len(ridxs) * 3
 
-        i = 0
-        while os.path.exists(f'test_slice-{i}.dmatrix'):
-            i += 1
-        d.save_binary(f'd_test_slice-{i}.dmatrix')
-        sliced.save_binary(f'test_slice-{i}.dmatrix')
-
         eval_res_1 = {}
         xgb.train({'num_class': 3, 'objective': 'multi:softprob'}, sliced,
                   num_boost_round=2, evals=[(sliced, 'd')],
@@ -140,9 +127,6 @@ class TestDMatrix(unittest.TestCase):
 
         eval_res_0 = eval_res_0['d']['merror']
         eval_res_1 = eval_res_1['d']['merror']
-
-        np.savetxt('test_sliced-X.txt', X)
-        np.savetxt('test_sliced-y.txt', y)
 
         for i in range(len(eval_res_0)):
             assert abs(eval_res_0[i] - eval_res_1[i]) < 0.02

--- a/tests/python/test_dmatrix.py
+++ b/tests/python/test_dmatrix.py
@@ -96,18 +96,13 @@ class TestDMatrix(unittest.TestCase):
         assert (from_view == from_array).all()
 
     def test_slice(self):
-        # 2887052510386eb7d12e09c859529a4f2b01ba35b847c807f95cbaddbb5eea7a
         X = rng.randn(100, 100)
-        # 85a40616f6748d98e59baf2961b655e0ebb2fc8ac298fc638a173e434073a0f9
         y = rng.randint(low=0, high=3, size=100)
-        # ab7b1162766f953935c244dd73d663ac0b79e4bd0a914a64e5b0fe66ae55b7ef
-        # failed:
-        # 33d8eee9310c7f6ff57f0c876b5977f39f7e450eb7c71513cc4c133c57921a6
         d = xgb.DMatrix(X, y)
         np.testing.assert_equal(d.get_label(), y.astype(np.float32))
 
-        # fw = rng.uniform(size=100).astype(np.float32)
-        # d.set_info(feature_weights=fw)
+        fw = rng.uniform(size=100).astype(np.float32)
+        d.set_info(feature_weights=fw)
 
         eval_res_0 = {}
         booster = xgb.train(
@@ -127,12 +122,7 @@ class TestDMatrix(unittest.TestCase):
         d.set_base_margin(predt)
 
         ridxs = [1, 2, 3, 4, 5, 6]
-        # failed:
-        # f3459dc754e30ff09e91c9660789cef53d998d6256f8ee81cc9c304cc54fbf40
-        # passed:
-        # ab7b1162766f953935c244dd73d663ac0b79e4bd0a914a64e5b0fe66ae55b7ef
         sliced = d.slice(ridxs)
-        # np.testing.assert_equal(sliced.get_float_info('feature_weights'), fw)
 
         sliced_margin = sliced.get_float_info('base_margin')
         assert sliced_margin.shape[0] == len(ridxs) * 3


### PR DESCRIPTION
Closes #3754, closes #5308 .  Currently supported tree methods: `exact`, `hist`, `gpu_hist`.

I spent some time on looking through the code base in hist, and want to unify it with `approx` and `grow_local_histmaker` in coming release.  So right now only 3 tree methods that use column sampler are supported.

- [x] High level tests.  Column sampling is difficult to have precise test, I need to figure out a way to have better tests for it.

The API also handles 4 different data types including f32, f64, uint32, uint64.  It can be further extended, but the important point is I think we should move toward more general data backend, otherwise we will be making an extra copy every time user specifies a different type than f32.  (the default type for numpy is f64).