### PR TITLE
Add missing Pytest marks to AsyncIO unit test

### DIFF
--- a/tests/python-gpu/test_gpu_with_dask.py
+++ b/tests/python-gpu/test_gpu_with_dask.py
@@ -272,6 +272,8 @@ async def run_from_dask_array_asyncio(scheduler_address):
         return output
 
 
+@pytest.mark.skipif(**tm.no_dask())
+@pytest.mark.mgpu
 def test_with_asyncio():
     with LocalCUDACluster() as cluster:
         with Client(cluster) as client:


### PR DESCRIPTION
Mark `tests/python-gpu/test_gpu_with_dask:: test_with_asyncio` as `mgpu` so that it will run in a multi-GPU machine.