### PR TITLE
Force tree order in JSON.

### DIFF
--- a/src/gbm/gbtree_model.cc
+++ b/src/gbm/gbtree_model.cc
@@ -49,7 +49,7 @@ void GBTreeModel::SaveModel(Json* p_out) const {
     auto const& tree = trees[t];
     Json tree_json{Object()};
     tree->SaveModel(&tree_json);
-    tree_json["id"] = Integer(t);
+    tree_json["id"] = Integer(static_cast<Integer::Int>(t));
     trees_json[t] = std::move(tree_json);
   }
 

--- a/src/gbm/gbtree_model.cc
+++ b/src/gbm/gbtree_model.cc
@@ -1,10 +1,11 @@
 /*!
- * Copyright 2019 by Contributors
+ * Copyright 2019-2020 by Contributors
  */
+#include <utility>
+
 #include "xgboost/json.h"
 #include "xgboost/logging.h"
 #include "gbtree_model.h"
-#include <utility>
 
 namespace xgboost {
 namespace gbm {

--- a/src/gbm/gbtree_model.cc
+++ b/src/gbm/gbtree_model.cc
@@ -45,8 +45,7 @@ void GBTreeModel::SaveModel(Json* p_out) const {
   out["gbtree_model_param"] = ToJson(param);
   std::vector<Json> trees_json(trees.size());
 
-#pragma omp parallel for
-  for (omp_ulong t = 0; t < trees.size(); ++t) {
+  for (size_t t = 0; t < trees.size(); ++t) {
     auto const& tree = trees[t];
     Json tree_json{Object()};
     tree->SaveModel(&tree_json);
@@ -72,8 +71,7 @@ void GBTreeModel::LoadModel(Json const& in) {
   auto const& trees_json = get<Array const>(in["trees"]);
   trees.resize(trees_json.size());
 
-#pragma omp parallel for
-  for (omp_ulong t = 0; t < trees_json.size(); ++t) {  // NOLINT
+  for (size_t t = 0; t < trees_json.size(); ++t) {  // NOLINT
     auto tree_id = get<Integer>(trees_json[t]["id"]);
     trees.at(tree_id).reset(new RegTree());
     trees.at(tree_id)->LoadModel(trees_json[t]);

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -148,7 +148,16 @@ TEST(Learner, JsonModelIO) {
     Json out { Object() };
     learner->SaveModel(&out);
 
-    learner->LoadModel(out);
+    dmlc::TemporaryDirectory tmpdir;
+
+    std::ofstream fout (tmpdir.path + "/model.json");
+    fout << out;
+    fout.close();
+
+    auto loaded_str = common::LoadSequentialFile(tmpdir.path + "/model.json");
+    Json loaded = Json::Load(StringView{loaded_str.c_str(), loaded_str.size()});
+
+    learner->LoadModel(loaded);
     learner->Configure();
 
     Json new_in { Object() };


### PR DESCRIPTION
It's not a bug.  Right now the order is implicitly enforced, this PR makes it explicit.  Marked as blocking because with explicit behaviour, we can be sure there's no chance for mistake.

* Put in omp parallel.  On large number of trees this is about 20% faster, not very impressive so I can revert it if needed.