### PR TITLE
[Breaking] Fix .predict() method and add .predict_proba() in xgboost.dask.DaskXGBClassifier

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1080,6 +1080,8 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
                                 eval_set, sample_weight_eval_set, verbose)
 
     async def _predict_proba_async(self, data):
+        _assert_dask_support()
+
         test_dmatrix = await DaskDMatrix(client=self.client, data=data,
                                          missing=self.missing)
         pred_probs = await predict(client=self.client,

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1086,7 +1086,7 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
                                    model=self.get_booster(), data=test_dmatrix)
         return pred_probs
 
-    def predict_proba(self, data):  # pylint: disable=arguments-differ
+    def predict_proba(self, data):  # pylint: disable=arguments-differ,missing-docstring
         _assert_dask_support()
         return self.client.sync(self._predict_proba_async, data)
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1078,12 +1078,31 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
         return self.client.sync(self._fit_async, X, y, sample_weights,
                                 eval_set, sample_weight_eval_set, verbose)
 
-    async def _predict_async(self, data):
+    async def _predict_proba_async(self, data):
         test_dmatrix = await DaskDMatrix(client=self.client, data=data,
                                          missing=self.missing)
         pred_probs = await predict(client=self.client,
                                    model=self.get_booster(), data=test_dmatrix)
         return pred_probs
+
+    def predict_proba(self, data):  # pylint: disable=arguments-differ
+        _assert_dask_support()
+        return self.client.sync(self._predict_proba_async, data)
+
+    async def _predict_async(self, data):
+        _assert_dask_support()
+
+        test_dmatrix = await DaskDMatrix(client=self.client, data=data,
+                                         missing=self.missing)
+        pred_probs = await predict(client=self.client,
+                                   model=self.get_booster(), data=test_dmatrix)
+
+        if self.n_classes_ == 2:
+            preds = (pred_probs > 0.5).astype(int)
+        else:
+            preds = da.argmax(pred_probs, axis=1)
+
+        return preds
 
     def predict(self, data):  # pylint: disable=arguments-differ
         _assert_dask_support()

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -144,12 +144,12 @@ def test_dask_missing_value_cls():
                                              missing=0.0)
             cls.client = client
             cls.fit(X, y, eval_set=[(X, y)])
-            dd_predt = cls.predict(X).compute()
+            dd_pred_proba = cls.predict_proba(X).compute()
 
             np_X = X.compute()
-            np_predt = cls.get_booster().predict(
+            np_pred_proba = cls.get_booster().predict(
                 xgb.DMatrix(np_X, missing=0.0))
-            np.testing.assert_allclose(np_predt, dd_predt)
+            np.testing.assert_allclose(np_pred_proba, dd_pred_proba)
 
             cls = xgb.dask.DaskXGBClassifier()
             assert hasattr(cls, 'missing')
@@ -202,6 +202,9 @@ def test_dask_classifier():
             assert len(history['validation_0']['merror']) == 2
 
             assert classifier.n_classes_ == 10
+
+            probas = classifier.predict_proba(X)
+            assert probas.shape[1] == classifier.n_classes_
 
             # Test with dataframe.
             X_d = dd.from_dask_array(X)

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -209,7 +209,7 @@ def test_dask_classifier():
             classifier.fit(X, y,  eval_set=[(X, y)])
             prediction = classifier.predict(X)
 
-            assert prediction.ndim == 2
+            assert prediction.ndim == 1
             assert prediction.shape[0] == kRows
 
             history = classifier.evals_result()
@@ -222,10 +222,12 @@ def test_dask_classifier():
             assert len(list(history['validation_0'])) == 1
             assert len(history['validation_0']['merror']) == 2
 
-            assert classifier.n_classes_ == 10
-
+            # Test .predict_proba()
             probas = classifier.predict_proba(X)
-            assert probas.shape[1] == classifier.n_classes_
+            assert classifier.n_classes_ == 10
+            assert probas.ndim == 2
+            assert probas.shape[0] == kRows
+            assert probas.shape[1] == 10
 
             # Test with dataframe.
             X_d = dd.from_dask_array(X)
@@ -235,7 +237,7 @@ def test_dask_classifier():
             assert classifier.n_classes_ == 10
             prediction = classifier.predict(X_d)
 
-            assert prediction.ndim == 2
+            assert prediction.ndim == 1
             assert prediction.shape[0] == kRows
 
 
@@ -410,7 +412,7 @@ async def run_dask_classifier_asyncio(scheduler_address):
         await classifier.fit(X, y,  eval_set=[(X, y)])
         prediction = await classifier.predict(X)
 
-        assert prediction.ndim == 2
+        assert prediction.ndim == 1
         assert prediction.shape[0] == kRows
 
         history = classifier.evals_result()
@@ -423,7 +425,13 @@ async def run_dask_classifier_asyncio(scheduler_address):
         assert len(list(history['validation_0'])) == 1
         assert len(history['validation_0']['merror']) == 2
 
+        # Test .predict_proba()
+        probas = await classifier.predict_proba(X)
         assert classifier.n_classes_ == 10
+        assert probas.ndim == 2
+        assert probas.shape[0] == kRows
+        assert probas.shape[1] == 10
+
 
         # Test with dataframe.
         X_d = dd.from_dask_array(X)
@@ -433,9 +441,8 @@ async def run_dask_classifier_asyncio(scheduler_address):
         assert classifier.n_classes_ == 10
         prediction = await classifier.predict(X_d)
 
-        assert prediction.ndim == 2
+        assert prediction.ndim == 1
         assert prediction.shape[0] == kRows
-        assert prediction.shape[1] == 10
 
 
 def test_with_asyncio():

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -229,6 +229,12 @@ def test_dask_classifier():
             assert probas.shape[0] == kRows
             assert probas.shape[1] == 10
 
+            cls_booster = classifier.get_booster()
+            single_node_proba = cls_booster.inplace_predict(X.compute())
+
+            np.testing.assert_allclose(single_node_proba,
+                                       probas.compute())
+
             # Test with dataframe.
             X_d = dd.from_dask_array(X)
             y_d = dd.from_dask_array(y)


### PR DESCRIPTION
Fixes #5985

This is cannot be merged before #5984 is resolved because [this line](https://github.com/jameskrach/xgboost/blob/fix-dask-sklearn-api/python-package/xgboost/dask.py#L1103) will raise an exception about there not being another axis if the model is a multiclass classifier.
