### PR TITLE
[jvm-packages] Fix deterministic partitioning with dataset containing Double.NaN

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/DataUtils.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/DataUtils.scala
@@ -103,7 +103,8 @@ object DataUtils extends Serializable {
       case sparseVector: SparseVector =>
         featureValueOfSparseVector(rowHashCode, sparseVector)
     }
-    math.abs((rowHashCode.toLong + featureValue).toString.hashCode % numPartitions)
+    val nonNaNFeatureValue = if (featureValue.isNaN) { 0.0f } else { featureValue }
+    math.abs((rowHashCode.toLong + nonNaNFeatureValue).toString.hashCode % numPartitions)
   }
 
   private def attachPartitionKey(


### PR DESCRIPTION
The functions featureValueOfSparseVector or featureValueOfDenseVector could return a Float.NaN if the input vector was containing any missing values. This would make fail the partition key computation and most of the rows would end up in the same partition and therefore leading to memory issues on one of the executor. We fixed this by avoid returning a NaN and simply use the row HashCode in this case.
We added a test to ensure that the repartition is indeed now uniform on input dataset containing missing values by checking that the partitions size variance is below a certain threshold.

Another remark about the computation of the key:
- If the values contained in your DataFrame are only below let's say 1e-4 / 1e-5, then this computation:
`rowHashCode.toLong + featureValue` is equivalent to `rowHashCode.toLong`, wouldn't it better to make it more random by computing `featureValue.toString().hashCode()` ? It would even fix what I did here too. WDYT ?