### PR TITLE
Expand categorical node.

### DIFF
--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -245,11 +245,12 @@ test_that("training continuation works", {
     expect_equal(bst$raw, bst2$raw)
   expect_equal(dim(bst2$evaluation_log), c(2, 2))
   # test continuing from a model in file
-  xgb.save(bst1, "xgboost.model")
-  bst2 <- xgb.train(param, dtrain, nrounds = 2, watchlist, verbose = 0, xgb_model = "xgboost.model")
+  xgb.save(bst1, "xgboost.json")
+  bst2 <- xgb.train(param, dtrain, nrounds = 2, watchlist, verbose = 0, xgb_model = "xgboost.json")
   if (!windows_flag && !solaris_flag)
     expect_equal(bst$raw, bst2$raw)
   expect_equal(dim(bst2$evaluation_log), c(2, 2))
+  file.remove("xgboost.json")
 })
 
 test_that("model serialization works", {

--- a/R-package/tests/testthat/test_callbacks.R
+++ b/R-package/tests/testthat/test_callbacks.R
@@ -173,16 +173,16 @@ test_that("cb.reset.parameters works as expected", {
 })
 
 test_that("cb.save.model works as expected", {
-  files <- c('xgboost_01.model', 'xgboost_02.model', 'xgboost.model')
+  files <- c('xgboost_01.json', 'xgboost_02.json', 'xgboost.json')
   for (f in files) if (file.exists(f)) file.remove(f)
 
   bst <- xgb.train(param, dtrain, nrounds = 2, watchlist, eta = 1, verbose = 0,
-                   save_period = 1, save_name = "xgboost_%02d.model")
-  expect_true(file.exists('xgboost_01.model'))
-  expect_true(file.exists('xgboost_02.model'))
-  b1 <- xgb.load('xgboost_01.model')
+                   save_period = 1, save_name = "xgboost_%02d.json")
+  expect_true(file.exists('xgboost_01.json'))
+  expect_true(file.exists('xgboost_02.json'))
+  b1 <- xgb.load('xgboost_01.json')
   expect_equal(xgb.ntree(b1), 1)
-  b2 <- xgb.load('xgboost_02.model')
+  b2 <- xgb.load('xgboost_02.json')
   expect_equal(xgb.ntree(b2), 2)
 
   xgb.config(b2) <- xgb.config(bst)
@@ -191,9 +191,9 @@ test_that("cb.save.model works as expected", {
 
   # save_period = 0 saves the last iteration's model
   bst <- xgb.train(param, dtrain, nrounds = 2, watchlist, eta = 1, verbose = 0,
-                   save_period = 0)
-  expect_true(file.exists('xgboost.model'))
-  b2 <- xgb.load('xgboost.model')
+                   save_period = 0, save_name = 'xgboost.json')
+  expect_true(file.exists('xgboost.json'))
+  b2 <- xgb.load('xgboost.json')
   xgb.config(b2) <- xgb.config(bst)
   expect_equal(bst$raw, b2$raw)
 

--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -109,7 +109,8 @@ using bst_int = int32_t;    // NOLINT
 using bst_ulong = uint64_t;  // NOLINT
 /*! \brief float type, used for storing statistics */
 using bst_float = float;  // NOLINT
-
+/*! \brief Categorical value type. */
+using bst_cat_t = int32_t;  // NOLINT
 /*! \brief Type for data column (feature) index. */
 using bst_feature_t = uint32_t;  // NOLINT
 /*! \brief Type for data row index.

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -35,7 +35,8 @@ enum class DataType : uint8_t {
 };
 
 enum class FeatureType : uint8_t {
-  kNumerical
+  kNumerical,
+  kCategorical
 };
 
 /*!
@@ -308,12 +309,6 @@ class SparsePage {
       }
     }
   }
-
-  /*!
-   * \brief Push row block into the page.
-   * \param batch the row batch.
-   */
-  void Push(const dmlc::RowBlock<uint32_t>& batch);
 
   /**
    * \brief Pushes external data batch onto this page

--- a/include/xgboost/span.h
+++ b/include/xgboost/span.h
@@ -528,7 +528,6 @@ class Span {
 
   XGBOOST_DEVICE reference operator[](index_type _idx) const {
     SPAN_LT(_idx, size());
-    SPAN_CHECK(_idx < size());
     return data()[_idx];
   }
 
@@ -588,7 +587,6 @@ class Span {
            detail::ExtentValue<Extent, Offset, Count>::value> {
     SPAN_CHECK((Count == dynamic_extent) ?
                (Offset <= size()) : (Offset + Count <= size()));
-
     return {data() + Offset, Count == dynamic_extent ? size() - Offset : Count};
   }
 

--- a/include/xgboost/span.h
+++ b/include/xgboost/span.h
@@ -101,6 +101,18 @@ namespace common {
   } while (0);
 #endif  // __CUDA_ARCH__
 
+#if defined(__CUDA_ARCH__)
+#define SPAN_LT(lhs, rhs)                                                      \
+  if (!((lhs) < (rhs))) {                                                      \
+    printf("%lu < %lu failed\n", static_cast<size_t>(lhs),                     \
+           static_cast<size_t>(rhs));                                          \
+    asm("trap;");                                                              \
+  }
+#else
+#define SPAN_LT(lhs, rhs)                       \
+  SPAN_CHECK((lhs) < (rhs))
+#endif  // defined(__CUDA_ARCH__)
+
 namespace detail {
 /*!
  * By default, XGBoost uses uint32_t for indexing data. int64_t covers all
@@ -515,6 +527,7 @@ class Span {
   }
 
   XGBOOST_DEVICE reference operator[](index_type _idx) const {
+    SPAN_LT(_idx, size());
     SPAN_CHECK(_idx < size());
     return data()[_idx];
   }

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -318,6 +318,8 @@ class RegTree : public Model {
     param.num_deleted = 0;
     nodes_.resize(param.num_nodes);
     stats_.resize(param.num_nodes);
+    split_types_.resize(param.num_nodes, FeatureType::kNumerical);
+    split_categories_segments_.resize(param.num_nodes);
     for (int i = 0; i < param.num_nodes; i ++) {
       nodes_[i].SetLeaf(0.0f);
       nodes_[i].SetParent(kInvalidNodeId);
@@ -412,30 +414,18 @@ class RegTree : public Model {
    * \param leaf_right_child  The right child index of leaf, by default kInvalidNodeId,
    *                          some updaters use the right child index of leaf as a marker
    */
-  void ExpandNode(int nid, unsigned split_index, bst_float split_value,
+  void ExpandNode(bst_node_t nid, unsigned split_index, bst_float split_value,
                   bool default_left, bst_float base_weight,
                   bst_float left_leaf_weight, bst_float right_leaf_weight,
                   bst_float loss_change, float sum_hess, float left_sum,
                   float right_sum,
-                  bst_node_t leaf_right_child = kInvalidNodeId) {
-    int pleft = this->AllocNode();
-    int pright = this->AllocNode();
-    auto &node = nodes_[nid];
-    CHECK(node.IsLeaf());
-    node.SetLeftChild(pleft);
-    node.SetRightChild(pright);
-    nodes_[node.LeftChild()].SetParent(nid, true);
-    nodes_[node.RightChild()].SetParent(nid, false);
-    node.SetSplit(split_index, split_value,
-                  default_left);
+                  bst_node_t leaf_right_child = kInvalidNodeId);
 
-    nodes_[pleft].SetLeaf(left_leaf_weight, leaf_right_child);
-    nodes_[pright].SetLeaf(right_leaf_weight, leaf_right_child);
-
-    this->Stat(nid)    = {loss_change, sum_hess, base_weight};
-    this->Stat(pleft)  = {0.0f, left_sum, left_leaf_weight};
-    this->Stat(pright) = {0.0f, right_sum, right_leaf_weight};
-  }
+  void ExpandCategorical(bst_node_t nid, unsigned split_index,
+                         common::Span<uint32_t> split_cat, bool default_left,
+                         bst_float base_weight, bst_float left_leaf_weight,
+                         bst_float right_leaf_weight, bst_float loss_change,
+                         float sum_hess, float left_sum, float right_sum);
 
   /*!
    * \brief get current depth
@@ -588,6 +578,25 @@ class RegTree : public Model {
    * \brief calculate the mean value for each node, required for feature contributions
    */
   void FillNodeMeanValues();
+  /*!
+   * \brief Get split type for a node.
+   * \param nidx Index of node.
+   * \return The type of this split.  For leaf node it's always kNumerical.
+   */
+  FeatureType NodeSplitType(bst_node_t nidx) const {
+    return split_types_.at(nidx);
+  }
+  /*!
+   * \brief Get split types for all nodes.
+   */
+  std::vector<FeatureType> const &GetSplitTypes() const { return split_types_; }
+  common::Span<uint32_t const> GetSplitCategories() const { return split_categories_; }
+  auto const& GetSplitCategoriesPtr() const { return split_categories_segments_; }
+
+  struct Segment {
+    size_t beg {0};
+    size_t size {0};
+  };
 
  private:
   // vector of nodes
@@ -597,9 +606,15 @@ class RegTree : public Model {
   // stats of nodes
   std::vector<RTreeNodeStat> stats_;
   std::vector<bst_float> node_mean_values_;
+  std::vector<FeatureType> split_types_;
+
+  // Categories for each internal node.
+  std::vector<uint32_t> split_categories_;
+  std::vector<Segment> split_categories_segments_;
+
   // allocate a new node,
   // !!!!!! NOTE: may cause BUG here, nodes.resize
-  int AllocNode() {
+  bst_node_t AllocNode() {
     if (param.num_deleted != 0) {
       int nid = deleted_nodes_.back();
       deleted_nodes_.pop_back();
@@ -612,6 +627,8 @@ class RegTree : public Model {
         << "number of nodes in the tree exceed 2^31";
     nodes_.resize(param.num_nodes);
     stats_.resize(param.num_nodes);
+    split_types_.resize(param.num_nodes, FeatureType::kNumerical);
+    split_categories_segments_.resize(param.num_nodes);
     return nd;
   }
   // delete a tree node, keep the parent field to allow trace back

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -608,6 +608,9 @@ class RegTree : public Model {
   common::Span<uint32_t const> GetSplitCategories() const { return split_categories_; }
   auto const& GetSplitCategoriesPtr() const { return split_categories_segments_; }
 
+  // The fields of split_categories_segments_[i] are set such that
+  // the range split_categories_[beg:(beg+size)] stores the bitset for
+  // the matching categories for the i-th node.
   struct Segment {
     size_t beg {0};
     size_t size {0};

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -421,6 +421,21 @@ class RegTree : public Model {
                   float right_sum,
                   bst_node_t leaf_right_child = kInvalidNodeId);
 
+  /**
+   * \brief Expands a leaf node with categories
+   *
+   * \param nid               The node index to expand.
+   * \param split_index       Feature index of the split.
+   * \param split_cat         The bitset containing categories
+   * \param default_left      True to default left.
+   * \param base_weight       The base weight, before learning rate.
+   * \param left_leaf_weight  The left leaf weight for prediction, modified by learning rate.
+   * \param right_leaf_weight The right leaf weight for prediction, modified by learning rate.
+   * \param loss_change       The loss change.
+   * \param sum_hess          The sum hess.
+   * \param left_sum          The sum hess of left leaf.
+   * \param right_sum         The sum hess of right leaf.
+   */
   void ExpandCategorical(bst_node_t nid, unsigned split_index,
                          common::Span<uint32_t> split_cat, bool default_left,
                          bst_float base_weight, bst_float left_leaf_weight,
@@ -610,6 +625,7 @@ class RegTree : public Model {
 
   // Categories for each internal node.
   std::vector<uint32_t> split_categories_;
+  // Ptr to split categories of each node.
   std::vector<Segment> split_categories_segments_;
 
   // allocate a new node,

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -40,7 +40,7 @@ class EarlyStopException(Exception):
     """
 
     def __init__(self, best_iteration):
-        super(EarlyStopException, self).__init__()
+        super().__init__()
         self.best_iteration = best_iteration
 
 

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -1022,7 +1022,7 @@ class XGBRFClassifier(XGBClassifier):
                          **kwargs)
 
     def get_xgb_params(self):
-        params = super(XGBRFClassifier, self).get_xgb_params()
+        params = super().get_xgb_params()
         params['num_parallel_tree'] = self.n_estimators
         return params
 
@@ -1051,7 +1051,7 @@ class XGBRFRegressor(XGBRegressor):
                          reg_lambda=reg_lambda, **kwargs)
 
     def get_xgb_params(self):
-        params = super(XGBRFRegressor, self).get_xgb_params()
+        params = super().get_xgb_params()
         params['num_parallel_tree'] = self.n_estimators
         return params
 

--- a/src/common/categorical.h
+++ b/src/common/categorical.h
@@ -1,0 +1,47 @@
+/*!
+ * Copyright 2020 by XGBoost Contributors
+ * \file categorical.h
+ */
+#ifndef XGBOOST_COMMON_CATEGORICAL_H_
+#define XGBOOST_COMMON_CATEGORICAL_H_
+
+#include "xgboost/base.h"
+#include "xgboost/data.h"
+#include "xgboost/span.h"
+#include "xgboost/parameter.h"
+#include "bitfield.h"
+
+namespace xgboost {
+namespace common {
+// Cast the categorical type.
+template <typename T>
+XGBOOST_DEVICE bst_cat_t AsCat(T const& v) {
+  return static_cast<bst_cat_t>(v);
+}
+
+/* \brief Whether is fidx a categorical feature.
+ *
+ * \param ft   Feature type for all features.
+ * \param fidx Feature index.
+ * \return Whether feature pointed by fidx is categorical feature.
+ */
+inline XGBOOST_DEVICE bool IsCat(Span<FeatureType const> ft, bst_feature_t fidx) {
+  return !ft.empty() && ft[fidx] == FeatureType::kCategorical;
+}
+
+/* \brief Whether should it traverse to left branch of a tree.
+ *
+ *  For one hot split, go to left if it's NOT the matching category.
+ */
+inline XGBOOST_DEVICE bool Decision(common::Span<uint32_t const> cats, bst_cat_t cat) {
+  auto pos = CLBitField32::ToBitPos(cat);
+  if (pos.int_pos >= cats.size()) {
+    return true;
+  }
+  CLBitField32 const s_cats(cats);
+  return !s_cats.Check(cat);
+}
+}  // namespace common
+}  // namespace xgboost
+
+#endif  // XGBOOST_COMMON_CATEGORICAL_H_

--- a/src/common/categorical.h
+++ b/src/common/categorical.h
@@ -41,6 +41,9 @@ inline XGBOOST_DEVICE bool Decision(common::Span<uint32_t const> cats, bst_cat_t
   CLBitField32 const s_cats(cats);
   return !s_cats.Check(cat);
 }
+
+using CatBitField = LBitField32;
+using KCatBitField = CLBitField32;
 }  // namespace common
 }  // namespace xgboost
 

--- a/src/common/json.cc
+++ b/src/common/json.cc
@@ -275,6 +275,9 @@ Json& JsonNumber::operator[](int ind) {
 
 bool JsonNumber::operator==(Value const& rhs) const {
   if (!IsA<JsonNumber>(&rhs)) { return false; }
+  if (std::isinf(number_)) {
+    return std::isinf(Cast<JsonNumber const>(&rhs)->GetNumber());
+  }
   return std::abs(number_ - Cast<JsonNumber const>(&rhs)->GetNumber()) < kRtEps;
 }
 

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -199,8 +199,10 @@ void LoadFeatureType(std::vector<std::string>const& type_names, std::vector<Feat
       types->emplace_back(FeatureType::kNumerical);
     } else if (elem == "q") {
       types->emplace_back(FeatureType::kNumerical);
+    } else if (elem == "categorical") {
+      types->emplace_back(FeatureType::kCategorical);
     } else {
-      LOG(FATAL) << "All feature_types must be {int, float, i, q}";
+      LOG(FATAL) << "All feature_types must be one of {int, float, i, q, categorical}.";
     }
   }
 }

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -921,6 +921,8 @@ void RegTree::SaveModel(Json* p_out) const {
     conds[i] = n.SplitCond();
     default_left[i] = n.DefaultLeft();
 
+    // This condition is only for being compatibale with older version of XGBoost model
+    // that doesn't have categorical data support.
     if (self.GetSplitTypes().size() == static_cast<size_t>(n_nodes)) {
       CHECK_EQ(self.split_categories_segments_.size(), param.num_nodes);
       split_type[i] = static_cast<I>(self.NodeSplitType(i));

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -803,6 +803,7 @@ void RegTree::LoadModel(Json const& in) {
   std::vector<Json> split_type;
   std::vector<Json> categories;
   if (has_cat) {
+    split_type = get<Array const>(in["split_type"]);
     categories = get<Array const>(in["categories"]);
   }
 

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -897,14 +897,9 @@ void RegTree::SaveModel(Json* p_out) const {
   std::vector<Json> default_left(n_nodes);
   std::vector<Json> split_type(n_nodes);
 
-  std::vector<Json> cat_seg_begin(n_nodes);
-  std::vector<Json> cat_seg_size(n_nodes);
   std::vector<Json> categories(n_nodes);
 
   auto& self = *this;
-
-  std::vector<Json> categories_temp;
-
   for (bst_node_t i = 0; i < n_nodes; ++i) {
     auto const& s = stats_[i];
     loss_changes[i] = s.loss_chg;
@@ -927,10 +922,9 @@ void RegTree::SaveModel(Json* p_out) const {
       split_type[i] = static_cast<I>(self.NodeSplitType(i));
       auto beg = self.split_categories_segments_.at(i).beg;
       auto size = self.split_categories_segments_.at(i).size;
-      cat_seg_begin[i] = static_cast<I>(beg);
-      cat_seg_size[i] = static_cast<I>(size);
       auto node_categories = self.GetSplitCategories().subspan(beg, size);
       common::KCatBitField const cat_bits(node_categories);
+      std::vector<Json> categories_temp;
       for (size_t i = 0; i < cat_bits.Size(); ++i) {
         if (cat_bits.Check(i)) {
           categories_temp.emplace_back(static_cast<Integer::Int>(i));

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -850,7 +850,8 @@ void RegTree::LoadModel(Json const& in) {
       }
       auto begin = split_categories_.size();
       split_categories_.resize(begin + cat_bits_storage.size());
-      std::copy(cat_bits_storage.begin(), cat_bits_storage.end(), split_categories_.begin() + begin);
+      std::copy(cat_bits_storage.begin(), cat_bits_storage.end(),
+                split_categories_.begin() + begin);
       split_categories_segments_[i].beg = begin;
       split_categories_segments_[i].size = cat_bits_storage.size();
     }

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -901,7 +901,6 @@ void RegTree::SaveModel(Json* p_out) const {
 
   std::vector<Json> categories(n_nodes);
 
-  auto& self = *this;
   for (bst_node_t i = 0; i < n_nodes; ++i) {
     auto const& s = stats_[i];
     loss_changes[i] = s.loss_chg;
@@ -920,12 +919,12 @@ void RegTree::SaveModel(Json* p_out) const {
     std::vector<Json> categories_temp;
     // This condition is only for being compatibale with older version of XGBoost model
     // that doesn't have categorical data support.
-    if (self.GetSplitTypes().size() == static_cast<size_t>(n_nodes)) {
-      CHECK_EQ(self.split_categories_segments_.size(), param.num_nodes);
-      split_type[i] = static_cast<I>(self.NodeSplitType(i));
-      auto beg = self.split_categories_segments_.at(i).beg;
-      auto size = self.split_categories_segments_.at(i).size;
-      auto node_categories = self.GetSplitCategories().subspan(beg, size);
+    if (this->GetSplitTypes().size() == static_cast<size_t>(n_nodes)) {
+      CHECK_EQ(this->GetSplitCategoriesPtr().size(), param.num_nodes);
+      split_type[i] = static_cast<I>(this->NodeSplitType(i));
+      auto beg = this->GetSplitCategoriesPtr().at(i).beg;
+      auto size = this->GetSplitCategoriesPtr().at(i).size;
+      auto node_categories = this->GetSplitCategories().subspan(beg, size);
       common::KCatBitField const cat_bits(node_categories);
       for (size_t i = 0; i < cat_bits.Size(); ++i) {
         if (cat_bits.Check(i)) {
@@ -950,7 +949,7 @@ void RegTree::SaveModel(Json* p_out) const {
 
   out["categories"] = categories;
 
-  if (self.GetSplitTypes().size() == static_cast<size_t>(n_nodes)) {
+  if (this->GetSplitTypes().size() == static_cast<size_t>(n_nodes)) {
     out["split_type"] = std::move(split_type);
   }
 }

--- a/tests/cpp/tree/test_tree_model.cc
+++ b/tests/cpp/tree/test_tree_model.cc
@@ -113,11 +113,11 @@ TEST(Tree, ExpandCategoricalFeature) {
                            /*left_sum=*/3.0, /*right_sum=*/4.0);
     ASSERT_EQ(tree.GetNodes().size(), 3ul);
     ASSERT_EQ(tree.GetNumLeaves(), 2);
-    ASSERT_EQ(tree.GetSplitTypes().size(), 3);
+    ASSERT_EQ(tree.GetSplitTypes().size(), 3ul);
     ASSERT_EQ(tree.GetSplitTypes()[0], FeatureType::kCategorical);
     ASSERT_EQ(tree.GetSplitTypes()[1], FeatureType::kNumerical);
     ASSERT_EQ(tree.GetSplitTypes()[2], FeatureType::kNumerical);
-    ASSERT_EQ(tree.GetSplitCategories().size(), 0);
+    ASSERT_EQ(tree.GetSplitCategories().size(), 0ul);
     ASSERT_TRUE(std::isnan(tree[0].SplitCond()));
   }
   {
@@ -138,6 +138,15 @@ TEST(Tree, ExpandCategoricalFeature) {
 
     RegTree loaded_tree;
     loaded_tree.LoadModel(out);
+
+    auto const& cat_ptr = loaded_tree.GetSplitCategoriesPtr();
+    ASSERT_EQ(cat_ptr.size(), 3ul);
+    ASSERT_EQ(cat_ptr[0].beg, 0ul);
+    ASSERT_EQ(cat_ptr[0].size, 2ul);
+
+    auto loaded_categories = loaded_tree.GetSplitCategories();
+    auto loaded_root = loaded_categories.subspan(cat_ptr[0].beg, cat_ptr[0].size);
+    ASSERT_TRUE(std::equal(loaded_root.begin(), loaded_root.end(), split_cats.begin()));
   }
 }
 
@@ -171,14 +180,14 @@ TEST(Tree, DumpJson) {
   while ((iter = str.find("leaf", iter + 1)) != std::string::npos) {
     n_leaves++;
   }
-  ASSERT_EQ(n_leaves, 4);
+  ASSERT_EQ(n_leaves, 4ul);
 
   size_t n_conditions = 0;
   iter = 0;
   while ((iter = str.find("split_condition", iter + 1)) != std::string::npos) {
     n_conditions++;
   }
-  ASSERT_EQ(n_conditions, 3);
+  ASSERT_EQ(n_conditions, 3ul);
 
   fmap.PushBack(0, "feat_0", "i");
   fmap.PushBack(1, "feat_1", "q");
@@ -194,7 +203,7 @@ TEST(Tree, DumpJson) {
 
 
   auto j_tree = Json::Load({str.c_str(), str.size()});
-  ASSERT_EQ(get<Array>(j_tree["children"]).size(), 2);
+  ASSERT_EQ(get<Array>(j_tree["children"]).size(), 2ul);
 }
 
 TEST(Tree, DumpText) {
@@ -206,14 +215,14 @@ TEST(Tree, DumpText) {
   while ((iter = str.find("leaf", iter + 1)) != std::string::npos) {
     n_leaves++;
   }
-  ASSERT_EQ(n_leaves, 4);
+  ASSERT_EQ(n_leaves, 4ul);
 
   iter = 0;
   size_t n_conditions = 0;
   while ((iter = str.find("gain", iter + 1)) != std::string::npos) {
     n_conditions++;
   }
-  ASSERT_EQ(n_conditions, 3);
+  ASSERT_EQ(n_conditions, 3ul);
 
   ASSERT_NE(str.find("[f0<0]"), std::string::npos);
   ASSERT_NE(str.find("[f1<1]"), std::string::npos);
@@ -242,14 +251,14 @@ TEST(Tree, DumpDot) {
   while ((iter = str.find("leaf", iter + 1)) != std::string::npos) {
     n_leaves++;
   }
-  ASSERT_EQ(n_leaves, 4);
+  ASSERT_EQ(n_leaves, 4ul);
 
   size_t n_edges = 0;
   iter = 0;
   while ((iter = str.find("->", iter + 1)) != std::string::npos) {
     n_edges++;
   }
-  ASSERT_EQ(n_edges, 6);
+  ASSERT_EQ(n_edges, 6ul);
 
   fmap.PushBack(0, "feat_0", "i");
   fmap.PushBack(1, "feat_1", "q");
@@ -276,12 +285,12 @@ TEST(Tree, JsonIO) {
   ASSERT_EQ(get<String>(tparam["num_nodes"]), "3");
   ASSERT_EQ(get<String>(tparam["size_leaf_vector"]), "0");
 
-  ASSERT_EQ(get<Array const>(j_tree["left_children"]).size(), 3);
-  ASSERT_EQ(get<Array const>(j_tree["right_children"]).size(), 3);
-  ASSERT_EQ(get<Array const>(j_tree["parents"]).size(), 3);
-  ASSERT_EQ(get<Array const>(j_tree["split_indices"]).size(), 3);
-  ASSERT_EQ(get<Array const>(j_tree["split_conditions"]).size(), 3);
-  ASSERT_EQ(get<Array const>(j_tree["default_left"]).size(), 3);
+  ASSERT_EQ(get<Array const>(j_tree["left_children"]).size(), 3ul);
+  ASSERT_EQ(get<Array const>(j_tree["right_children"]).size(), 3ul);
+  ASSERT_EQ(get<Array const>(j_tree["parents"]).size(), 3ul);
+  ASSERT_EQ(get<Array const>(j_tree["split_indices"]).size(), 3ul);
+  ASSERT_EQ(get<Array const>(j_tree["split_conditions"]).size(), 3ul);
+  ASSERT_EQ(get<Array const>(j_tree["default_left"]).size(), 3ul);
 
   RegTree loaded_tree;
   loaded_tree.LoadModel(j_tree);

--- a/tests/cpp/tree/test_tree_model.cc
+++ b/tests/cpp/tree/test_tree_model.cc
@@ -83,7 +83,7 @@ TEST(Tree, Load) {
   tree.Load(fi.get());
   EXPECT_EQ(tree.GetDepth(1), 1);
   EXPECT_EQ(tree[0].SplitCond(), 0.5f);
-  EXPECT_EQ(tree[0].SplitIndex(), 5);
+  EXPECT_EQ(tree[0].SplitIndex(), 5ul);
   EXPECT_EQ(tree[1].LeafValue(), 0.1f);
   EXPECT_TRUE(tree[1].IsLeaf());
 }
@@ -111,7 +111,7 @@ TEST(Tree, ExpandCategoricalFeature) {
     RegTree tree;
     tree.ExpandCategorical(0, 0, {}, true, 1.0, 2.0, 3.0, 11.0, 2.0,
                            /*left_sum=*/3.0, /*right_sum=*/4.0);
-    ASSERT_EQ(tree.GetNodes().size(), 3);
+    ASSERT_EQ(tree.GetNodes().size(), 3ul);
     ASSERT_EQ(tree.GetNumLeaves(), 2);
     ASSERT_EQ(tree.GetSplitTypes().size(), 3);
     ASSERT_EQ(tree.GetSplitTypes()[0], FeatureType::kCategorical);
@@ -132,6 +132,12 @@ TEST(Tree, ExpandCategoricalFeature) {
     auto segments = tree.GetSplitCategoriesPtr();
     auto got = categories.subspan(segments[0].beg, segments[0].size);
     ASSERT_TRUE(std::equal(got.cbegin(), got.cend(), split_cats.cbegin()));
+
+    Json out{Object()};
+    tree.SaveModel(&out);
+
+    RegTree loaded_tree;
+    loaded_tree.LoadModel(out);
   }
 }
 


### PR DESCRIPTION
This PR includes expanding tree on categorical feature, saving/loading such trees.  It's partly extracted from https://github.com/dmlc/xgboost/pull/5949 , with changes that now the saved tree model contains actual categories instead of bitsets.