### PR TITLE
Remove win2016 jvm github action test.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, windows-2016, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
It's constantly failing on PR with network errors.  After the removal we still have win-latest.  Suggestions are welcomed.