### PR TITLE
Make driver reusable.

### DIFF
--- a/src/tree/driver.h
+++ b/src/tree/driver.h
@@ -1,7 +1,13 @@
+/*!
+ * Copyright 2020 by Contributors
+ */
 #ifndef XGBOOST_TREE_DRIVER_H_
 #define XGBOOST_TREE_DRIVER_H_
 #include <functional>
 #include <queue>
+#include <limits>
+#include <vector>
+#include <utility>
 #include "param.h"
 
 namespace xgboost {
@@ -78,9 +84,10 @@ class DriverContainer {
  public:
   explicit DriverContainer(TrainParam::TreeGrowPolicy policy)
       : policy_(policy),
-        queue_(policy == TrainParam::kDepthWise ? DepthWise<ExpandEntry> : LossGuide<ExpandEntry>) {}
+        queue_(policy == TrainParam::kDepthWise ? DepthWise<ExpandEntry>
+                                                : LossGuide<ExpandEntry>) {}
   template <typename EntryIterT>
-  void Push(EntryIterT begin,EntryIterT end) {
+  void Push(EntryIterT begin, EntryIterT end) {
     for (auto it = begin; it != end; ++it) {
       const ExpandEntry& e = *it;
       if (e.split.loss_chg > kRtEps) {

--- a/src/tree/gpu_hist/evaluate_splits.cuh
+++ b/src/tree/gpu_hist/evaluate_splits.cuh
@@ -24,12 +24,12 @@ struct EvaluateSplitInputs {
   common::Span<const GradientSumT> gradient_histogram;
 };
 template <typename GradientSumT>
-void EvaluateSplits(common::Span<DeviceSplitCandidate> out_splits,
+void EvaluateSplits(common::Span<SplitEntry> out_splits,
                     TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
                     EvaluateSplitInputs<GradientSumT> left,
                     EvaluateSplitInputs<GradientSumT> right);
 template <typename GradientSumT>
-void EvaluateSingleSplit(common::Span<DeviceSplitCandidate> out_split,
+void EvaluateSingleSplit(common::Span<SplitEntry> out_split,
                          TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
                          EvaluateSplitInputs<GradientSumT> input);
 }  // namespace tree

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -394,7 +394,7 @@ struct XGBOOST_ALIGNAS(16) GradStats {
 template<typename GradientT>
 struct SplitEntryContainer {
   /*! \brief loss change after split this node */
-  bst_float loss_chg {0.0f};
+  bst_float loss_chg  {-std::numeric_limits<float>::max()};
   /*! \brief split index */
   bst_feature_t sindex{0};
   bst_float split_value{0.0f};
@@ -432,9 +432,9 @@ struct SplitEntryContainer {
                                          // skip value in this case
       return false;
     } else if (this->SplitIndex() <= split_index) {
-      return new_loss_chg > this->loss_chg;
+      return new_loss_chg > this->loss_chg && new_loss_chg > 0;
     } else {
-      return !(this->loss_chg > new_loss_chg);
+      return !(this->loss_chg > new_loss_chg) && new_loss_chg > 0;
     }
   }
   /*!

--- a/tests/cpp/tree/gpu_hist/test_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_evaluate_splits.cu
@@ -108,7 +108,7 @@ TEST(GpuHist, EvaluateSingleSplitEmpty) {
                       EvaluateSplitInputs<GradientPair>{});
 
   SplitEntry result = out_split[0];
-  EXPECT_EQ(result.SplitIndex(), -1);
+  EXPECT_EQ(result.SplitIndex(), 0);
   EXPECT_LT(result.loss_chg, 0.0f);
 }
 

--- a/tests/cpp/tree/test_driver.cc
+++ b/tests/cpp/tree/test_driver.cc
@@ -1,13 +1,14 @@
 #include <gtest/gtest.h>
-#include "../../../../src/tree/gpu_hist/driver.cuh"
+#include "../../../src/tree/driver.h"
 
 namespace xgboost {
 namespace tree {
 
 TEST(GpuHist, DriverDepthWise) {
+  using Driver = DriverContainer<ExpandEntry>;
   Driver driver(TrainParam::kDepthWise);
   EXPECT_TRUE(driver.Pop().empty());
-  DeviceSplitCandidate split;
+  SplitEntry split;
   split.loss_chg = 1.0f;
   ExpandEntry root(0, 0, split, .0f, .0f, .0f);
   driver.Push({root});
@@ -27,9 +28,10 @@ TEST(GpuHist, DriverDepthWise) {
 }
 
 TEST(GpuHist, DriverLossGuided) {
-  DeviceSplitCandidate high_gain;
+  using Driver = DriverContainer<ExpandEntry>;
+  SplitEntry high_gain;
   high_gain.loss_chg = 5.0f;
-  DeviceSplitCandidate low_gain;
+  SplitEntry low_gain;
   low_gain.loss_chg = 1.0f;
 
   Driver driver(TrainParam::kLossGuide);

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -215,10 +215,10 @@ TEST(GpuHist, EvaluateRootSplit) {
   info.num_row_ = kNRows;
   info.num_col_ = kNCols;
 
-  DeviceSplitCandidate res = maker.EvaluateRootSplit({6.4f, 12.8f});
+  SplitEntry res = maker.EvaluateRootSplit({6.4f, 12.8f});
 
-  ASSERT_EQ(res.findex, 7);
-  ASSERT_NEAR(res.fvalue, 0.26, xgboost::kRtEps);
+  ASSERT_EQ(res.SplitIndex(), 7);
+  ASSERT_NEAR(res.split_value, 0.26, xgboost::kRtEps);
 }
 
 void TestHistogramIndexImpl() {


### PR DESCRIPTION
* Move driver into tree directory.
* Remove `DeviceSplitCandidate`.

Now `GradStats` is used in some places.  Will post benchmark later.