### PR TITLE
Fix CMake build with BUILD_STATIC_LIB option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ include(GNUInstallDirs)
 install(DIRECTORY ${xgboost_SOURCE_DIR}/include/xgboost
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(TARGETS xgboost runxgboost
+install(TARGETS xgboost runxgboost objxgboost
   EXPORT XGBoostTargets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,9 @@ if (ENABLE_ALL_WARNINGS)
     message(SEND_ERROR "ENABLE_ALL_WARNINGS is only available for Clang and GCC.")
   endif ((NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang") AND (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
 endif (ENABLE_ALL_WARNINGS)
+if (BUILD_STATIC_LIB AND (R_LIB OR JVM_BINDINGS))
+  message(SEND_ERROR "Cannot build a static library libxgboost.a when R or JVM packages are enabled.")
+endif (BUILD_STATIC_LIB AND (R_LIB OR JVM_BINDINGS))
 
 #-- Sanitizer
 if (USE_SANITIZER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,20 @@ include(GNUInstallDirs)
 install(DIRECTORY ${xgboost_SOURCE_DIR}/include/xgboost
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(TARGETS xgboost runxgboost objxgboost
+# Install libraries. If `xgboost` is a static lib, specify `objxgboost` also, to avoid the
+# following error:
+#
+#  > install(EXPORT ...) includes target "xgboost" which requires target "objxgboost" that is not
+#  > in any export set.
+#
+# https://github.com/dmlc/xgboost/issues/6085
+if (BUILD_STATIC_LIB)
+  set(INSTALL_TARGETS xgboost runxgboost objxgboost)
+else (BUILD_STATIC_LIB)
+  set(INSTALL_TARGETS xgboost runxgboost)
+endif (BUILD_STATIC_LIB)
+
+install(TARGETS ${INSTALL_TARGETS}
   EXPORT XGBoostTargets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
Fixes #6085 by adding `objxgboost` to the install targets. Adding `objxgboost` to `install(TARGETS)` has no real impact but keeps CMake configuration happy:
* The `install(TARGETS)` command in line 277 does not specify any `DESTINATION` for `OBJECTS` targets, so object libraries will not be actually installed into the system prefix.
* We still need to specify `objxgboost`, according to the rule of `install(TARGETS)`: whenever we export a static library target, we need to export every dependency of it. Since `xgboost` is a static library, we need to also export `objxgboost`.

Here are the files that are installed by CMake:

<details><summary>BUILD_STATIC_LIB=ON</summary>
<p>

```
include/xgboost
include/xgboost/data.h
include/xgboost/tree_updater.h
include/xgboost/host_device_vector.h
include/xgboost/linear_updater.h
include/xgboost/metric.h
include/xgboost/gbm.h
include/xgboost/tree_model.h
include/xgboost/feature_map.h
include/xgboost/version_config.h
include/xgboost/learner.h
include/xgboost/c_api.h
include/xgboost/objective.h
include/xgboost/generic_parameters.h
include/xgboost/predictor.h
include/xgboost/json_io.h
include/xgboost/logging.h
include/xgboost/base.h
include/xgboost/parameter.h
include/xgboost/model.h
include/xgboost/span.h
include/xgboost/json.h
lib/libxgboost.a
bin/xgboost
lib/cmake/xgboost/XGBoostTargets.cmake
lib/cmake/xgboost/XGBoostTargets-release.cmake
lib/cmake/xgboost/xgboost-config.cmake
lib/cmake/xgboost/xgboost-config-version.cmake
lib/pkgconfig/xgboost.pc
include/dmlc
include/dmlc/data.h
include/dmlc/lua.h
include/dmlc/any.h
include/dmlc/concurrency.h
include/dmlc/io.h
include/dmlc/timer.h
include/dmlc/build_config_default.h
include/dmlc/serializer.h
include/dmlc/memory_io.h
include/dmlc/filesystem.h
include/dmlc/type_traits.h
include/dmlc/thread_local.h
include/dmlc/input_split_shuffle.h
include/dmlc/common.h
include/dmlc/recordio.h
include/dmlc/thread_group.h
include/dmlc/memory.h
include/dmlc/config.h
include/dmlc/concurrentqueue.h
include/dmlc/threadediter.h
include/dmlc/logging.h
include/dmlc/optional.h
include/dmlc/base.h
include/dmlc/parameter.h
include/dmlc/omp.h
include/dmlc/json.h
include/dmlc/blockingconcurrentqueue.h
include/dmlc/registry.h
include/dmlc/strtonum.h
include/dmlc/endian.h
include/dmlc/array_view.h
include/dmlc/build_config.h
lib/libdmlc.a
lib/cmake/dmlc/DMLCTargets.cmake
lib/cmake/dmlc/DMLCTargets-release.cmake
lib/cmake/dmlc/dmlc-config.cmake
lib/cmake/dmlc/dmlc-config-version.cmake
lib/librabit.a
lib/librabit_base.a
lib/librabit_empty.a
lib/librabit_mock.so
lib/librabit_mock_static.a
include/rabit
include/rabit/serializable.h
include/rabit/c_api.h
include/rabit/rabit.h
include/rabit/base.h
include/rabit/internal
include/rabit/internal/rabit-inl.h
include/rabit/internal/io.h
include/rabit/internal/timer.h
include/rabit/internal/thread_local.h
include/rabit/internal/socket.h
include/rabit/internal/utils.h
include/rabit/internal/engine.h
lib/cmake/rabit/rabitConfig.cmake
lib/cmake/rabit/rabitConfigVersion.cmake
lib/cmake/rabit/rabitTargets.cmake
lib/cmake/rabit/rabitTargets-release.cmake
```

</p>
</details>


<details><summary>BUILD_STATIC_LIB=OFF</summary>
<p>

```
include/xgboost
include/xgboost/data.h
include/xgboost/tree_updater.h
include/xgboost/host_device_vector.h
include/xgboost/linear_updater.h
include/xgboost/metric.h
include/xgboost/gbm.h
include/xgboost/tree_model.h
include/xgboost/feature_map.h
include/xgboost/version_config.h
include/xgboost/learner.h
include/xgboost/c_api.h
include/xgboost/objective.h
include/xgboost/generic_parameters.h
include/xgboost/predictor.h
include/xgboost/json_io.h
include/xgboost/logging.h
include/xgboost/base.h
include/xgboost/parameter.h
include/xgboost/model.h
include/xgboost/span.h
include/xgboost/json.h
lib/libxgboost.so
bin/xgboost
lib/cmake/xgboost/XGBoostTargets.cmake
lib/cmake/xgboost/XGBoostTargets-release.cmake
lib/cmake/xgboost/xgboost-config.cmake
lib/cmake/xgboost/xgboost-config-version.cmake
lib/pkgconfig/xgboost.pc
include/dmlc
include/dmlc/data.h
include/dmlc/lua.h
include/dmlc/any.h
include/dmlc/concurrency.h
include/dmlc/io.h
include/dmlc/timer.h
include/dmlc/build_config_default.h
include/dmlc/serializer.h
include/dmlc/memory_io.h
include/dmlc/filesystem.h
include/dmlc/type_traits.h
include/dmlc/thread_local.h
include/dmlc/input_split_shuffle.h
include/dmlc/common.h
include/dmlc/recordio.h
include/dmlc/thread_group.h
include/dmlc/memory.h
include/dmlc/config.h
include/dmlc/concurrentqueue.h
include/dmlc/threadediter.h
include/dmlc/logging.h
include/dmlc/optional.h
include/dmlc/base.h
include/dmlc/parameter.h
include/dmlc/omp.h
include/dmlc/json.h
include/dmlc/blockingconcurrentqueue.h
include/dmlc/registry.h
include/dmlc/strtonum.h
include/dmlc/endian.h
include/dmlc/array_view.h
include/dmlc/build_config.h
lib/libdmlc.a
lib/cmake/dmlc/DMLCTargets.cmake
lib/cmake/dmlc/DMLCTargets-release.cmake
lib/cmake/dmlc/dmlc-config.cmake
lib/cmake/dmlc/dmlc-config-version.cmake
lib/librabit.a
lib/librabit_base.a
lib/librabit_empty.a
lib/librabit_mock.so
lib/librabit_mock_static.a
include/rabit
include/rabit/serializable.h
include/rabit/c_api.h
include/rabit/rabit.h
include/rabit/base.h
include/rabit/internal
include/rabit/internal/rabit-inl.h
include/rabit/internal/io.h
include/rabit/internal/timer.h
include/rabit/internal/thread_local.h
include/rabit/internal/socket.h
include/rabit/internal/utils.h
include/rabit/internal/engine.h
lib/cmake/rabit/rabitConfig.cmake
lib/cmake/rabit/rabitConfigVersion.cmake
lib/cmake/rabit/rabitTargets.cmake
lib/cmake/rabit/rabitTargets-release.cmake
```

</p>
</details>