### PR TITLE
Don't link imported target.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ if (USE_CUDA)
     CUDA_STANDARD 14
     CUDA_STANDARD_REQUIRED ON
     CUDA_SEPARABLE_COMPILATION OFF)
-  target_link_libraries(objxgboost PRIVATE GPUTreeShap::GPUTreeShap)
+  target_link_libraries(objxgboost PRIVATE GPUTreeShap)
 endif (USE_CUDA)
 
 target_include_directories(objxgboost


### PR DESCRIPTION
On cmake 3.18 this will generate an error as `GPUTreeShap::GPUTreeShap` is an imported target and we didn't import it explicitly with `find_package`.