### PR TITLE
Work around a compiler bug in MacOS AppleClang 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,30 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  gtest-cpu:
+    name: Test Google C++ test (CPU)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-10.15]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    - name: Install system packages
+      run: |
+        brew install lz4 ninja
+    - name: Build gtest binary
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DGOOGLE_TEST=ON -DUSE_OPENMP=ON -DUSE_DMLC_GTEST=ON -DPLUGIN_LZ4=ON -DPLUGIN_DENSE_PARSER=ON -GNinja
+        ninja -v
+    - name: Run gtest binary
+      run: |
+        cd build
+        ctest --extra-verbose
   test-with-jvm:
     name: Test JVM on OS ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         submodules: 'true'
     - name: Install system packages
       run: |
-        brew install lz4 ninja
+        brew install lz4 ninja libomp
     - name: Build gtest binary
       run: |
         mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
 
-osx_image: xcode10.1
 dist: bionic
 
 env:
@@ -15,15 +14,23 @@ jobs:
       env: TASK=python_sdist_test
     - os: osx
       arch: amd64
+      osx_image: xcode10.1
       env: TASK=python_test
     - os: osx
       arch: amd64
+      osx_image: xcode10.1
       env: TASK=python_sdist_test
     - os: osx
       arch: amd64
+      osx_image: xcode10.1
       env: TASK=java_test
     - os: osx
       arch: amd64
+      osx_image: xcode10.1
+      env: TASK=cmake_test
+    - os: osx
+      arch: amd64
+      osx_image: xcode11.6
       env: TASK=cmake_test
     - os: linux
       arch: s390x

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,6 @@ jobs:
       arch: amd64
       osx_image: xcode10.1
       env: TASK=java_test
-    - os: osx
-      arch: amd64
-      osx_image: xcode10.1
-      env: TASK=cmake_test
-    - os: osx
-      arch: amd64
-      osx_image: xcode11.6
-      env: TASK=cmake_test
     - os: linux
       arch: s390x
       env: TASK=s390x_test

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -1,6 +1,11 @@
 if (PLUGIN_LZ4)
   target_sources(objxgboost PRIVATE ${xgboost_SOURCE_DIR}/plugin/lz4/sparse_page_lz4_format.cc)
-  target_link_libraries(objxgboost PUBLIC lz4)
+  find_path(LIBLZ4_INCLUDE_DIR lz4.h)
+  find_library(LIBLZ4_LIBRARY NAMES lz4)
+  message(STATUS "LIBLZ4_INCLUDE_DIR = ${LIBLZ4_INCLUDE_DIR}")
+  message(STATUS "LIBLZ4_LIBRARY = ${LIBLZ4_LIBRARY}")
+  target_include_directories(objxgboost PUBLIC ${LIBLZ4_INCLUDE_DIR})
+  target_link_libraries(objxgboost PUBLIC ${LIBLZ4_LIBRARY})
 endif (PLUGIN_LZ4)
 
 if (PLUGIN_DENSE_PARSER)

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -17,6 +17,12 @@ if [ ${TASK} == "python_sdist_test" ]; then
 fi
 
 if [ ${TASK} == "python_test" ]; then
+    if grep -n -R '<<<.*>>>\(.*\)' src include | grep --invert "NOLINT"; then
+        echo 'Do not use raw CUDA execution configuration syntax with <<<blocks, threads>>>.' \
+             'try `dh::LaunchKernel`'
+        exit -1
+    fi
+
     set -e
     # Build/test
     rm -rf build
@@ -67,26 +73,6 @@ if [ ${TASK} == "java_test" ]; then
     cd jvm-packages
     mvn -q clean install -DskipTests -Dmaven.test.skip
     mvn -q test
-fi
-
-if [ ${TASK} == "cmake_test" ]; then
-    set -e
-
-    if grep -n -R '<<<.*>>>\(.*\)' src include | grep --invert "NOLINT"; then
-        echo 'Do not use raw CUDA execution configuration syntax with <<<blocks, threads>>>.' \
-             'try `dh::LaunchKernel`'
-        exit -1
-    fi
-
-    # Build/test
-    rm -rf build
-    mkdir build && cd build
-    PLUGINS="-DPLUGIN_LZ4=ON -DPLUGIN_DENSE_PARSER=ON"
-    cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DUSE_OPENMP=ON -DUSE_DMLC_GTEST=ON ${PLUGINS}
-    make -j$(nproc)
-    ./testxgboost
-    cd ..
-    rm -rf build
 fi
 
 if [ ${TASK} == "s390x_test" ]; then

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -16,10 +16,6 @@ if [ ${TASK} == "python_test" ] || [ ${TASK} == "python_sdist_test" ]; then
     conda create -n python3 python=3.7
 fi
 
-if [ ${TASK} == "cmake_test" ] && [ ${TRAVIS_OS_NAME} == "osx" ]; then
-    sudo softwareupdate -i "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.3"
-fi
-
 if [ ${TASK} == "s390x_test" ] && [ ${TRAVIS_CPU_ARCH} == "s390x" ]; then
     sudo snap install cmake --channel=3.17/beta --classic
     export PATH=/snap/bin:${PATH}


### PR DESCRIPTION
Fixes #6102 by avoiding a variable capture in `xgboost::common::ParallelFor2d`. This works around a compiler bug in AppleClang 11.0.3 while preserving the semantics.

Also, add MacOS Catalina to the testing matrix, which has AppleClang 11.0.3.