### PR TITLE
[CI] Fix CTest by running it in a correct directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,7 +159,7 @@ def BuildCPU() {
     sh """
     ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/build_via_cmake.sh -DUSE_SANITIZER=ON -DENABLED_SANITIZERS="address;leak;undefined" \
       -DCMAKE_BUILD_TYPE=Debug -DSANITIZER_PATH=/usr/lib/x86_64-linux-gnu/
-    ${docker_extra_params} ${dockerRun} ${container_type} ${docker_binary} bash -c "cd build && ctest --extra-verbose"
+    ${docker_extra_params} ${dockerRun} ${container_type} ${docker_binary} bash -c "cd build && ctest --exclude-regex AllTestsInDMLCUnitTests --extra-verbose"
     """
 
     stash name: 'xgboost_cli', includes: 'xgboost'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,14 +152,14 @@ def BuildCPU() {
       # We want to make sure that we use the configured header build/dmlc/build_config.h instead of include/dmlc/build_config_default.h.
       # See discussion at https://github.com/dmlc/xgboost/issues/5510
     ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/build_via_cmake.sh -DPLUGIN_LZ4=ON -DPLUGIN_DENSE_PARSER=ON
-    ${dockerRun} ${container_type} ${docker_binary} ctest
+    ${dockerRun} ${container_type} ${docker_binary} bash -c "cd build && ctest --extra-verbose"
     """
     // Sanitizer test
     def docker_extra_params = "CI_DOCKER_EXTRA_PARAMS_INIT='-e ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer -e ASAN_OPTIONS=symbolize=1 -e UBSAN_OPTIONS=print_stacktrace=1:log_path=ubsan_error.log --cap-add SYS_PTRACE'"
     sh """
     ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/build_via_cmake.sh -DUSE_SANITIZER=ON -DENABLED_SANITIZERS="address;leak;undefined" \
       -DCMAKE_BUILD_TYPE=Debug -DSANITIZER_PATH=/usr/lib/x86_64-linux-gnu/
-    ${docker_extra_params} ${dockerRun} ${container_type} ${docker_binary} ctest
+    ${docker_extra_params} ${dockerRun} ${container_type} ${docker_binary} bash -c "cd build && ctest --extra-verbose"
     """
 
     stash name: 'xgboost_cli', includes: 'xgboost'
@@ -193,7 +193,7 @@ def BuildCPUNonOmp() {
     """
     echo "Running Non-OpenMP C++ test..."
     sh """
-    ${dockerRun} ${container_type} ${docker_binary} ctest
+    ${dockerRun} ${container_type} ${docker_binary} bash -c "cd build && ctest --extra-verbose"
     """
     deleteDir()
   }


### PR DESCRIPTION
#6096 merged Rabit's gtest into XGBoost's gtest, and as part of that Rabit's standalone test executables are now invoked by the CTest command.

CTest command is currently not working because it is run in the wrong working directory:
```
[2020-09-09T04:35:54.022Z] *********************************
[2020-09-09T04:35:54.022Z] No test configuration file found!
[2020-09-09T04:35:54.022Z] *********************************
[2020-09-09T04:35:54.022Z] Usage
[2020-09-09T04:35:54.022Z] 
[2020-09-09T04:35:54.022Z]   ctest [options]
[2020-09-09T04:35:54.022Z]
```
(https://xgboost-ci.net/blue/organizations/jenkins/xgboost/detail/master/471/pipeline/58)


So change to the correct working directory before running CTest.