### PR TITLE
The requirements for the CMAKE version in the document are wrong.

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -66,7 +66,7 @@ on the binding you choose).  For building language specific package, see corresp
 sections in this document.  The minimal building requirement is
 
 - A recent C++ compiler supporting C++11 (g++-5.0 or higher)
-- CMake 3.12 or higher.
+- CMake 3.13 or higher.
 
 For a list of CMake options, see ``#-- Options`` in CMakeLists.txt on top level of source tree.
 

--- a/doc/jvm/index.rst
+++ b/doc/jvm/index.rst
@@ -154,7 +154,7 @@ To enable the GPU algorithm (``tree_method='gpu_hist'``), use artifacts ``xgboos
 Installation from source
 ========================
 
-Building XGBoost4J using Maven requires Maven 3 or newer, Java 7+ and CMake 3.3+ for compiling the JNI bindings.
+Building XGBoost4J using Maven requires Maven 3 or newer, Java 7+ and CMake 3.13+ for compiling the JNI bindings.
 
 Before you install XGBoost4J, you need to define environment variable ``JAVA_HOME`` as your JDK directory to ensure that your compiler can find ``jni.h`` correctly, since XGBoost4J relies on JNI to implement the interaction between the JVM and native libraries.
 


### PR DESCRIPTION
The latest xgboost 1.2.0 request cmake 3.13+, but the document has not been updated

![微信图片_20200916155942](https://user-images.githubusercontent.com/52202080/93309128-bb723280-f835-11ea-89f3-224887c2d4fe.png)

