### PR TITLE
Predict improvement

### DIFF
--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -1155,7 +1155,7 @@ void QuantileHistMaker::Builder<GradientSumT>::AddSplitsToRowSet(
     const int32_t nid = nodes[i].nid;
     const size_t n_left = partition_builder_.GetNLeftElems(i);
     const size_t n_right = partition_builder_.GetNRightElems(i);
-
+    CHECK_EQ((*p_tree)[nid].LeftChild() + 1, (*p_tree)[nid].RightChild());
     row_set_collection_.AddSplit(nid, (*p_tree)[nid].LeftChild(),
         (*p_tree)[nid].RightChild(), n_left, n_right);
   }


### PR DESCRIPTION
the main idea of this PR is keeping cache locality for predicted rows.

Results:

Data set | predict time (master), s | predict time (this PR), s | Speedup
-- | -- | -- | --
 higgs1m | 4.12 | 1.32 | 3.12
 msrank |  13.9 | 6.07 |  2.29

without Dmatrix create:
Data set | predict time (master), s | predict time (this PR), s | Speedup
-- | -- | -- | --
 higgs1m | 4.12 - 0.25 | 1.32 - 0.25 | 3.62
 msrank |  13.9 - 2.6 | 6.07 - 2.6 |  3.25


Data set | logloss (master) | logloss (this PR) 
-- | -- | -- 
 higgs1m | 0.4036675 | 0.4036675 
 msrank |  0.8550638 | 0.8550638



