### PR TITLE
Time GPU Python tests on CI.

### DIFF
--- a/tests/ci_build/test_python.sh
+++ b/tests/ci_build/test_python.sh
@@ -43,14 +43,14 @@ case "$suite" in
   gpu)
     source activate gpu_test
     install_xgboost
-    pytest -v -s -rxXs --fulltrace -m "not mgpu" ${args} tests/python-gpu
+    pytest -v -s -rxXs --fulltrace --durations=0 -m "not mgpu" ${args} tests/python-gpu
     uninstall_xgboost
     ;;
 
   mgpu)
     source activate gpu_test
     install_xgboost
-    pytest -v -s -rxXs --fulltrace -m "mgpu" ${args} tests/python-gpu
+    pytest -v -s -rxXs --fulltrace --durations=0 -m "mgpu" ${args} tests/python-gpu
 
     cd tests/distributed
     ./runtests-gpu.sh


### PR DESCRIPTION
I noticed that some tests are running too slow on CI recently.  This PR adds timing for each test.