### PR TITLE
Revert #5755

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -539,8 +539,7 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle, float *values,
   CHECK_EQ(cache_id, 0) << "Cache ID is not supported yet";
   auto *learner = static_cast<xgboost::Learner *>(handle);
 
-  std::shared_ptr<xgboost::data::DenseAdapter> x{
-    new xgboost::data::DenseAdapter(values, n_rows, n_cols)};
+  auto x = xgboost::data::DenseAdapter(values, n_rows, n_cols);
   HostDeviceVector<float>* p_predt { nullptr };
   std::string type { c_type };
   learner->InplacePredict(x, type, missing, &p_predt);
@@ -571,8 +570,7 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle,
   CHECK_EQ(cache_id, 0) << "Cache ID is not supported yet";
   auto *learner = static_cast<xgboost::Learner *>(handle);
 
-  std::shared_ptr<xgboost::data::CSRAdapter> x{
-    new xgboost::data::CSRAdapter(indptr, indices, data, nindptr - 1, nelem, num_col)};
+  auto x = data::CSRAdapter(indptr, indices, data, nindptr - 1, nelem, num_col);
   HostDeviceVector<float>* p_predt { nullptr };
   std::string type { c_type };
   learner->InplacePredict(x, type, missing, &p_predt);

--- a/src/c_api/c_api.cu
+++ b/src/c_api/c_api.cu
@@ -46,7 +46,7 @@ XGB_DLL int XGBoosterPredictFromArrayInterfaceColumns(BoosterHandle handle,
   auto *learner = static_cast<Learner*>(handle);
 
   std::string json_str{c_json_strs};
-  auto x = std::make_shared<data::CudfAdapter>(json_str);
+  auto x = data::CudfAdapter(json_str);
   HostDeviceVector<float>* p_predt { nullptr };
   std::string type { c_type };
   learner->InplacePredict(x, type, missing, &p_predt);
@@ -74,7 +74,7 @@ XGB_DLL int XGBoosterPredictFromArrayInterface(BoosterHandle handle,
   auto *learner = static_cast<Learner*>(handle);
 
   std::string json_str{c_json_strs};
-  auto x = std::make_shared<data::CupyAdapter>(json_str);
+  auto x = data::CupyAdapter(json_str);
   HostDeviceVector<float>* p_predt { nullptr };
   std::string type { c_type };
   learner->InplacePredict(x, type, missing, &p_predt);

--- a/src/data/device_adapter.cuh
+++ b/src/data/device_adapter.cuh
@@ -34,29 +34,44 @@ struct IsValidFunctor : public thrust::unary_function<Entry, bool> {
 };
 
 class CudfAdapterBatch : public detail::NoMetaInfo {
-  friend class CudfAdapter;
-
  public:
   CudfAdapterBatch() = default;
-  CudfAdapterBatch(common::Span<ArrayInterface> columns, size_t num_rows)
+  CudfAdapterBatch(common::Span<ArrayInterface> columns,
+                   common::Span<size_t> column_ptr, size_t num_elements, size_t num_rows)
       : columns_(columns),
+        column_ptr_(column_ptr),
+        num_elements_(num_elements),
         num_rows_(num_rows) {}
-  size_t Size() const { return num_rows_ * columns_.size(); }
+  size_t Size() const { return num_elements_; }
   __device__ COOTuple GetElement(size_t idx) const {
-    size_t column_idx = idx % columns_.size();
-    size_t row_idx = idx / columns_.size();
-    auto const& column = columns_[column_idx];
+    size_t column_idx =
+        thrust::upper_bound(thrust::seq, column_ptr_.begin(), column_ptr_.end(), idx)
+          - column_ptr_.begin() - 1;
+    auto& column = columns_[column_idx];
+    size_t row_idx = idx - column_ptr_[column_idx];
     float value = column.valid.Data() == nullptr || column.valid.Check(row_idx)
                       ? column.GetElement(row_idx)
                       : std::numeric_limits<float>::quiet_NaN();
     return {row_idx, column_idx, value};
   }
+  __device__ float GetValue(size_t ridx, bst_feature_t fidx) const {
+    auto const& column = columns_[fidx];
+    float value = column.valid.Data() == nullptr || column.valid.Check(ridx)
+                      ? column.GetElement(ridx)
+                      : std::numeric_limits<float>::quiet_NaN();
+    return value;
+  }
 
-  XGBOOST_DEVICE bst_row_t NumRows() const { return num_rows_; }
+  XGBOOST_DEVICE bst_row_t NumRows() const { return num_elements_ / columns_.size(); }
   XGBOOST_DEVICE bst_row_t NumCols() const { return columns_.size(); }
+
+  // Cudf is column major
+  bool IsRowMajor() { return false; }
 
  private:
   common::Span<ArrayInterface> columns_;
+  common::Span<size_t> column_ptr_;
+  size_t num_elements_;
   size_t num_rows_;
 };
 
@@ -121,6 +136,7 @@ class CudfAdapter : public detail::SingleBatchDataIter<CudfAdapterBatch> {
     CHECK_EQ(typestr.size(), 3) << ArrayInterfaceErrors::TypestrFormat();
     CHECK_NE(typestr.front(), '>') << ArrayInterfaceErrors::BigEndian();
     std::vector<ArrayInterface> columns;
+    std::vector<size_t> column_ptr({0});
     auto first_column = ArrayInterface(get<Object const>(json_columns[0]));
     num_rows_ = first_column.num_rows;
     if (num_rows_ == 0) {
@@ -134,6 +150,7 @@ class CudfAdapter : public detail::SingleBatchDataIter<CudfAdapterBatch> {
       auto column = ArrayInterface(get<Object const>(json_col));
       columns.push_back(column);
       CHECK_EQ(column.num_cols, 1);
+      column_ptr.emplace_back(column_ptr.back() + column.num_rows);
       num_rows_ = std::max(num_rows_, size_t(column.num_rows));
       CHECK_EQ(device_idx_, dh::CudaGetPointerDevice(column.data))
           << "All columns should use the same device.";
@@ -141,20 +158,23 @@ class CudfAdapter : public detail::SingleBatchDataIter<CudfAdapterBatch> {
           << "All columns should have same number of rows.";
     }
     columns_ = columns;
-    batch_ = CudfAdapterBatch(dh::ToSpan(columns_), num_rows_);
+    column_ptr_ = column_ptr;
+    batch_ = CudfAdapterBatch(dh::ToSpan(columns_), dh::ToSpan(column_ptr_),
+                              column_ptr.back(), num_rows_);
   }
-  const CudfAdapterBatch& Value() const override {
-    CHECK_EQ(batch_.columns_.data(), columns_.data().get());
-    return batch_;
-  }
+  const CudfAdapterBatch& Value() const override { return batch_; }
 
   size_t NumRows() const { return num_rows_; }
   size_t NumColumns() const { return columns_.size(); }
   size_t DeviceIdx() const { return device_idx_; }
 
+  // Cudf is column major
+  bool IsRowMajor() { return false; }
+
  private:
   CudfAdapterBatch batch_;
   dh::device_vector<ArrayInterface> columns_;
+  dh::device_vector<size_t> column_ptr_;  // Exclusive scan of column sizes
   size_t num_rows_{0};
   int device_idx_;
 };
@@ -176,6 +196,9 @@ class CupyAdapterBatch : public detail::NoMetaInfo {
 
   XGBOOST_DEVICE bst_row_t NumRows() const { return array_interface_.num_rows; }
   XGBOOST_DEVICE bst_row_t NumCols() const { return array_interface_.num_cols; }
+
+  // Cupy is row major
+  bool IsRowMajor() { return true; }
 
  private:
   ArrayInterface array_interface_;
@@ -199,6 +222,9 @@ class CupyAdapter : public detail::SingleBatchDataIter<CupyAdapterBatch> {
   size_t NumRows() const { return array_interface_.num_rows; }
   size_t NumColumns() const { return array_interface_.num_cols; }
   size_t DeviceIdx() const { return device_idx_; }
+
+  // Cupy is row major
+  bool IsRowMajor() { return true; }
 
  private:
   ArrayInterface array_interface_;

--- a/src/data/device_adapter.cuh
+++ b/src/data/device_adapter.cuh
@@ -62,7 +62,7 @@ class CudfAdapterBatch : public detail::NoMetaInfo {
     return value;
   }
 
-  XGBOOST_DEVICE bst_row_t NumRows() const { return num_elements_ / columns_.size(); }
+  XGBOOST_DEVICE bst_row_t NumRows() const { return num_rows_; }
   XGBOOST_DEVICE bst_row_t NumCols() const { return columns_.size(); }
 
   // Cudf is column major

--- a/src/data/simple_dmatrix.cu
+++ b/src/data/simple_dmatrix.cu
@@ -35,12 +35,51 @@ void CountRowOffsets(const AdapterBatchT& batch, common::Span<bst_row_t> offset,
       thrust::device_pointer_cast(offset.data()));
 }
 
+template <typename AdapterT>
+void CopyDataColumnMajor(AdapterT* adapter, common::Span<Entry> data,
+                         int device_idx, float missing,
+                         common::Span<size_t> row_ptr) {
+  // Step 1: Get the sizes of the input columns
+  dh::device_vector<size_t> column_sizes(adapter->NumColumns());
+  auto d_column_sizes = column_sizes.data().get();
+  auto& batch = adapter->Value();
+  // Populate column sizes
+  dh::LaunchN(device_idx, batch.Size(), [=] __device__(size_t idx) {
+    const auto& e = batch.GetElement(idx);
+    atomicAdd(reinterpret_cast<unsigned long long*>(  // NOLINT
+                  &d_column_sizes[e.column_idx]),
+              static_cast<unsigned long long>(1));  // NOLINT
+  });
+
+  thrust::host_vector<size_t> host_column_sizes = column_sizes;
+
+  // Step 2: Iterate over columns, place elements in correct row, increment
+  // temporary row pointers
+  dh::device_vector<size_t> temp_row_ptr(
+      thrust::device_pointer_cast(row_ptr.data()),
+      thrust::device_pointer_cast(row_ptr.data() + row_ptr.size()));
+  auto d_temp_row_ptr = temp_row_ptr.data().get();
+  size_t begin = 0;
+  IsValidFunctor is_valid(missing);
+  for (auto size : host_column_sizes) {
+    size_t end = begin + size;
+    dh::LaunchN(device_idx, end - begin, [=] __device__(size_t idx) {
+      const auto& e = batch.GetElement(idx + begin);
+      if (!is_valid(e)) return;
+      data[d_temp_row_ptr[e.row_idx]] = Entry(e.column_idx, e.value);
+      d_temp_row_ptr[e.row_idx] += 1;
+    });
+
+    begin = end;
+  }
+}
+
 // Here the data is already correctly ordered and simply needs to be compacted
 // to remove missing data
 template <typename AdapterT>
-void CopyDataToDMatrix(AdapterT* adapter, common::Span<Entry> data,
-                       int device_idx, float missing,
-                       common::Span<size_t> row_ptr) {
+void CopyDataRowMajor(AdapterT* adapter, common::Span<Entry> data,
+                      int device_idx, float missing,
+                      common::Span<size_t> row_ptr) {
   auto& batch = adapter->Value();
   auto transform_f = [=] __device__(size_t idx) {
     const auto& e = batch.GetElement(idx);
@@ -77,8 +116,13 @@ SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {
   CountRowOffsets(batch, s_offset, adapter->DeviceIdx(), missing);
   info_.num_nonzero_ = sparse_page_.offset.HostVector().back();
   sparse_page_.data.Resize(info_.num_nonzero_);
-  CopyDataToDMatrix(adapter, sparse_page_.data.DeviceSpan(),
-                    adapter->DeviceIdx(), missing, s_offset);
+  if (adapter->IsRowMajor()) {
+    CopyDataRowMajor(adapter, sparse_page_.data.DeviceSpan(),
+                     adapter->DeviceIdx(), missing, s_offset);
+  } else {
+    CopyDataColumnMajor(adapter, sparse_page_.data.DeviceSpan(),
+                        adapter->DeviceIdx(), missing, s_offset);
+  }
 
   info_.num_col_ = adapter->NumColumns();
   info_.num_row_ = adapter->NumRows();

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -269,12 +269,12 @@ class CPUPredictor : public Predictor {
                                 PredictionCacheEntry *out_preds,
                                 uint32_t tree_begin, uint32_t tree_end) const {
     auto threads = omp_get_max_threads();
-    auto m = dmlc::get<std::shared_ptr<Adapter>>(x);
-    CHECK_EQ(m->NumColumns(), model.learner_model_param->num_feature)
+    auto m = dmlc::get<Adapter>(x);
+    CHECK_EQ(m.NumColumns(), model.learner_model_param->num_feature)
         << "Number of columns in data must equal to trained model.";
     MetaInfo info;
-    info.num_col_ = m->NumColumns();
-    info.num_row_ = m->NumRows();
+    info.num_col_ = m.NumColumns();
+    info.num_row_ = m.NumRows();
     this->InitOutPredictions(info, &(out_preds->predictions), model);
     std::vector<Entry> workspace(info.num_col_ * 8 * threads);
     auto &predictions = out_preds->predictions.HostVector();
@@ -282,17 +282,17 @@ class CPUPredictor : public Predictor {
     InitThreadTemp(threads, model.learner_model_param->num_feature, &thread_temp);
     size_t constexpr kUnroll = 8;
     PredictBatchKernel(AdapterView<Adapter, kUnroll>(
-                           m.get(), missing, common::Span<Entry>{workspace}),
+                       &m, missing, common::Span<Entry>{workspace}),
                        &predictions, model, tree_begin, tree_end, &thread_temp);
   }
 
   void InplacePredict(dmlc::any const &x, const gbm::GBTreeModel &model,
                       float missing, PredictionCacheEntry *out_preds,
                       uint32_t tree_begin, unsigned tree_end) const override {
-    if (x.type() == typeid(std::shared_ptr<data::DenseAdapter>)) {
+    if (x.type() == typeid(data::DenseAdapter)) {
       this->DispatchedInplacePredict<data::DenseAdapter>(
           x, model, missing, out_preds, tree_begin, tree_end);
-    } else if (x.type() == typeid(std::shared_ptr<data::CSRAdapter>)) {
+    } else if (x.type() == typeid(data::CSRAdapter)) {
       this->DispatchedInplacePredict<data::CSRAdapter>(
           x, model, missing, out_preds, tree_begin, tree_end);
     } else {

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -126,18 +126,15 @@ struct EllpackLoader {
   }
 };
 
-template <typename Batch>
-struct DeviceAdapterLoader {
-  Batch batch;
+struct CuPyAdapterLoader {
+  data::CupyAdapterBatch batch;
   bst_feature_t columns;
   float* smem;
   bool use_shared;
 
-  using BatchT = Batch;
-
-  XGBOOST_DEV_INLINE DeviceAdapterLoader(Batch const batch, bool use_shared,
-                                         bst_feature_t num_features, bst_row_t num_rows,
-                                         size_t entry_start) :
+  XGBOOST_DEV_INLINE CuPyAdapterLoader(data::CupyAdapterBatch const batch, bool use_shared,
+                                       bst_feature_t num_features, bst_row_t num_rows,
+                                       size_t entry_start) :
     batch{batch},
     columns{num_features},
     use_shared{use_shared} {
@@ -164,6 +161,39 @@ struct DeviceAdapterLoader {
       return smem[threadIdx.x * columns + fidx];
     }
     return batch.GetElement(ridx * columns + fidx).value;
+  }
+};
+
+struct CuDFAdapterLoader {
+  data::CudfAdapterBatch batch;
+  bst_feature_t columns;
+  float* smem;
+  bool use_shared;
+
+  XGBOOST_DEV_INLINE CuDFAdapterLoader(data::CudfAdapterBatch const batch, bool use_shared,
+                                       bst_feature_t num_features,
+                                       bst_row_t num_rows, size_t entry_start)
+      : batch{batch}, columns{num_features}, use_shared{use_shared} {
+    extern __shared__ float _smem[];
+    smem = _smem;
+    if (use_shared) {
+      uint32_t global_idx = blockDim.x * blockIdx.x + threadIdx.x;
+      size_t shared_elements = blockDim.x * num_features;
+      dh::BlockFill(smem, shared_elements, nanf(""));
+      __syncthreads();
+      if (global_idx < num_rows) {
+        for (size_t i = 0; i < columns; ++i) {
+          smem[threadIdx.x * columns + i] = batch.GetValue(global_idx, i);
+        }
+      }
+    }
+    __syncthreads();
+  }
+  XGBOOST_DEV_INLINE float GetElement(size_t ridx, size_t fidx) const {
+    if (use_shared) {
+      return smem[threadIdx.x * columns + fidx];
+    }
+    return batch.GetValue(ridx, fidx);
   }
 };
 
@@ -494,7 +524,7 @@ class GPUPredictor : public xgboost::Predictor {
           out_preds->Size() == dmat->Info().num_row_);
   }
 
-  template <typename Adapter, typename Loader>
+  template <typename Adapter, typename Loader, typename Batch>
   void DispatchedInplacePredict(dmlc::any const &x,
                                 const gbm::GBTreeModel &model, float missing,
                                 PredictionCacheEntry *out_preds,
@@ -504,22 +534,22 @@ class GPUPredictor : public xgboost::Predictor {
     DeviceModel d_model;
     d_model.Init(model, tree_begin, tree_end, this->generic_param_->gpu_id);
 
-    auto m = dmlc::get<std::shared_ptr<Adapter>>(x);
-    CHECK_EQ(m->NumColumns(), model.learner_model_param->num_feature)
+    auto m = dmlc::get<Adapter>(x);
+    CHECK_EQ(m.NumColumns(), model.learner_model_param->num_feature)
         << "Number of columns in data must equal to trained model.";
-    CHECK_EQ(this->generic_param_->gpu_id, m->DeviceIdx())
+    CHECK_EQ(this->generic_param_->gpu_id, m.DeviceIdx())
         << "XGBoost is running on device: " << this->generic_param_->gpu_id << ", "
-        << "but data is on: " << m->DeviceIdx();
+        << "but data is on: " << m.DeviceIdx();
     MetaInfo info;
-    info.num_col_ = m->NumColumns();
-    info.num_row_ = m->NumRows();
+    info.num_col_ = m.NumColumns();
+    info.num_row_ = m.NumRows();
     this->InitOutPredictions(info, &(out_preds->predictions), model);
 
     const uint32_t BLOCK_THREADS = 128;
     auto GRID_SIZE = static_cast<uint32_t>(common::DivRoundUp(info.num_row_, BLOCK_THREADS));
 
     auto shared_memory_bytes =
-        static_cast<size_t>(sizeof(float) * m->NumColumns() * BLOCK_THREADS);
+        static_cast<size_t>(sizeof(float) * m.NumColumns() * BLOCK_THREADS);
     bool use_shared = true;
     if (shared_memory_bytes > max_shared_memory_bytes) {
       shared_memory_bytes = 0;
@@ -528,24 +558,24 @@ class GPUPredictor : public xgboost::Predictor {
     size_t entry_start = 0;
 
     dh::LaunchKernel {GRID_SIZE, BLOCK_THREADS, shared_memory_bytes} (
-        PredictKernel<Loader, typename Loader::BatchT>,
-        m->Value(),
+        PredictKernel<Loader, Batch>,
+        m.Value(),
         d_model.nodes.DeviceSpan(), out_preds->predictions.DeviceSpan(),
         d_model.tree_segments.DeviceSpan(), d_model.tree_group.DeviceSpan(),
-        tree_begin, tree_end, m->NumColumns(), info.num_row_,
+        tree_begin, tree_end, m.NumColumns(), info.num_row_,
         entry_start, use_shared, output_groups);
   }
 
   void InplacePredict(dmlc::any const &x, const gbm::GBTreeModel &model,
                       float missing, PredictionCacheEntry *out_preds,
                       uint32_t tree_begin, unsigned tree_end) const override {
-    if (x.type() == typeid(std::shared_ptr<data::CupyAdapter>)) {
+    if (x.type() == typeid(data::CupyAdapter)) {
       this->DispatchedInplacePredict<
-          data::CupyAdapter, DeviceAdapterLoader<data::CupyAdapterBatch>>(
+          data::CupyAdapter, CuPyAdapterLoader, data::CupyAdapterBatch>(
           x, model, missing, out_preds, tree_begin, tree_end);
-    } else if (x.type() == typeid(std::shared_ptr<data::CudfAdapter>)) {
+    } else if (x.type() == typeid(data::CudfAdapter)) {
       this->DispatchedInplacePredict<
-          data::CudfAdapter, DeviceAdapterLoader<data::CudfAdapterBatch>>(
+          data::CudfAdapter, CuDFAdapterLoader, data::CudfAdapterBatch>(
           x, model, missing, out_preds, tree_begin, tree_end);
     } else {
       LOG(FATAL) << "Only CuPy and CuDF are supported by GPU Predictor.";

--- a/tests/cpp/data/test_device_adapter.cu
+++ b/tests/cpp/data/test_device_adapter.cu
@@ -35,12 +35,13 @@ void TestCudfAdapter()
   EXPECT_NO_THROW({
     dh::LaunchN(0, batch.Size(), [=] __device__(size_t idx) {
       auto element = batch.GetElement(idx);
-      KERNEL_CHECK(element.row_idx == idx / 2);
-      if (idx % 2 == 0) {
+      if (idx < kRowsA) {
         KERNEL_CHECK(element.column_idx == 0);
+        KERNEL_CHECK(element.row_idx == idx);
         KERNEL_CHECK(element.value == element.row_idx * 2.0f);
       } else {
         KERNEL_CHECK(element.column_idx == 1);
+        KERNEL_CHECK(element.row_idx == idx - kRowsA);
         KERNEL_CHECK(element.value == element.row_idx * 2.0f);
       }
     });

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -149,8 +149,7 @@ TEST(CpuPredictor, InplacePredict) {
     HostDeviceVector<float> data;
     gen.GenerateDense(&data);
     ASSERT_EQ(data.Size(), kRows * kCols);
-    std::shared_ptr<data::DenseAdapter> x{
-      new data::DenseAdapter(data.HostPointer(), kRows, kCols)};
+    data::DenseAdapter x{data.HostPointer(), kRows, kCols};
     TestInplacePrediction(x, "cpu_predictor", kRows, kCols, -1);
   }
 
@@ -159,9 +158,8 @@ TEST(CpuPredictor, InplacePredict) {
     HostDeviceVector<bst_row_t> rptrs;
     HostDeviceVector<bst_feature_t> columns;
     gen.GenerateCSR(&data, &rptrs, &columns);
-    std::shared_ptr<data::CSRAdapter> x{new data::CSRAdapter(
-        rptrs.HostPointer(), columns.HostPointer(), data.HostPointer(), kRows,
-        data.Size(), kCols)};
+    data::CSRAdapter x(rptrs.HostPointer(), columns.HostPointer(),
+                       data.HostPointer(), kRows, data.Size(), kCols);
     TestInplacePrediction(x, "cpu_predictor", kRows, kCols, -1);
   }
 }

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -129,7 +129,7 @@ TEST(GPUPredictor, InplacePredictCupy) {
   gen.Device(0);
   HostDeviceVector<float> data;
   std::string interface_str = gen.GenerateArrayInterface(&data);
-  auto x = std::make_shared<data::CupyAdapter>(interface_str);
+  data::CupyAdapter x{interface_str};
   TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 0);
 }
 
@@ -139,7 +139,7 @@ TEST(GPUPredictor, InplacePredictCuDF) {
   gen.Device(0);
   std::vector<HostDeviceVector<float>> storage(kCols);
   auto interface_str = gen.GenerateColumnarArrayInterface(&storage);
-  auto x = std::make_shared<data::CudfAdapter>(interface_str);
+  data::CudfAdapter x {interface_str};
   TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 0);
 }
 
@@ -154,7 +154,7 @@ TEST(GPUPredictor, MGPU_InplacePredict) {  // NOLINT
   gen.Device(1);
   HostDeviceVector<float> data;
   std::string interface_str = gen.GenerateArrayInterface(&data);
-  auto x = std::make_shared<data::CupyAdapter>(interface_str);
+  data::CupyAdapter x{interface_str};
   TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 1);
   EXPECT_THROW(TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 0),
                dmlc::Error);


### PR DESCRIPTION
Temporarily revert #5755 to prevent OOM error in the [e2e mortgage notebook](https://github.com/rapidsai-community/notebooks-contrib/blob/branch-0.14/intermediate_notebooks/E2E/mortgage/mortgage_e2e.ipynb).