### PR TITLE
[R] remove warning in configure.ac (fixes #6151)

### DIFF
--- a/R-package/configure
+++ b/R-package/configure
@@ -2732,7 +2732,7 @@ $as_echo "${ac_pkg_openmp}" >&6; }
     OPENMP_CXXFLAGS=''
     OPENMP_LIB=''
     echo '*****************************************************************************************'
-    echo 'WARNING: OpenMP is unavailable on this Mac OSX system. Training speed may be suboptimal.'
+    echo '         OpenMP is unavailable on this Mac OSX system. Training speed may be suboptimal.'
     echo '         To use all CPU cores for training jobs, you should install OpenMP by running\n'
     echo '             brew install libomp'
     echo '*****************************************************************************************'

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -39,7 +39,7 @@ then
     OPENMP_CXXFLAGS=''
     OPENMP_LIB=''
     echo '*****************************************************************************************'
-    echo 'WARNING: OpenMP is unavailable on this Mac OSX system. Training speed may be suboptimal.'
+    echo '         OpenMP is unavailable on this Mac OSX system. Training speed may be suboptimal.'
     echo '         To use all CPU cores for training jobs, you should install OpenMP by running\n'
     echo '             brew install libomp'
     echo '*****************************************************************************************'


### PR DESCRIPTION
This PR proposes a fix for #6151 . I think it will resolve the WARNING on https://cran.r-project.org/web/checks/check_results_xgboost.html

![image](https://user-images.githubusercontent.com/7608904/93962253-fd144900-fd1f-11ea-853d-3048edb2713e.png)

```text
Version: 1.2.0.1
Check: whether package can be installed
Result: WARN
    Found the following significant warnings:
     WARNING: OpenMP is unavailable on this Mac OSX system. Training speed may be suboptimal.
Flavor: r-release-macos-x86_64
```