### PR TITLE
Add base margin dask

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1134,7 +1134,7 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
         _assert_dask_support()
 
         test_dmatrix = await DaskDMatrix(
-            client=self.client, data=data,base_margin=base_margin,
+            client=self.client, data=data, base_margin=base_margin,
             missing=self.missing
         )
         pred_probs = await predict(client=self.client,

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -178,6 +178,8 @@ class DaskDMatrix:
         to be present as a missing value. If None, defaults to np.nan.
     weight : dask.array.Array/dask.dataframe.DataFrame
         Weight for each instance.
+    base_margin : dask.array.Array/dask.dataframe.DataFrame
+        A base margin of booster to start from
     feature_names : list, optional
         Set names for features.
     feature_types : list, optional

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -134,6 +134,48 @@ def test_dask_predict_shape_infer():
             assert preds.shape[1] == preds.compute().shape[1]
 
 
+@pytest.mark.parametrize("tree_method", ["hist", "approx"])
+def test_boost_from_prediction(tree_method):
+    from sklearn.datasets import load_breast_cancer
+
+    with LocalCluster(n_workers=4) as cluster:
+        with Client(cluster) as client:
+            X, y = load_breast_cancer(return_X_y=True)
+            X_ = dd.from_array(X, chunksize=100)
+            y_ = dd.from_array(y, chunksize=100)
+
+            from sklearn.datasets import load_breast_cancer
+
+            X, y = load_breast_cancer(return_X_y=True)
+            model_0 = xgb.dask.DaskXGBClassifier(
+                learning_rate=0.3,
+                random_state=0,
+                n_estimators=4,
+                tree_method=tree_method,
+            )
+            model_0.fit(X=X_, y=y_)
+            margin = model_0.predict_proba(X_)
+
+            model_1 = xgb.dask.DaskXGBClassifier(
+                learning_rate=0.3,
+                random_state=0,
+                n_estimators=4,
+                tree_method=tree_method,
+            )
+            model_1.fit(X=X_, y=y_, base_margin=margin)
+            predictions_1 = model_1.predict(X_, base_margin=margin)
+
+            cls_2 = xgb.dask.DaskXGBClassifier(
+                learning_rate=0.3,
+                random_state=0,
+                n_estimators=8,
+                tree_method=tree_method,
+            )
+            cls_2.fit(X=X_, y=y_)
+            predictions_2 = cls_2.predict(X_)
+            np.testing.assert_equal(predictions_1.compute(), predictions_2.compute())
+
+
 def test_dask_missing_value_reg():
     with LocalCluster(n_workers=kWorkers) as cluster:
         with Client(cluster) as client:


### PR DESCRIPTION
**What**

This adds base_margin support for the following:

- DaskDMatrix
- DaskPartitionIter
- DaskDeviceQuantileDMatrix
- DaskXGBClassifier (fit and predict)
- DaskXGBRegressor (fit and predict)

**Why**

For api consistency between dask and non-dask xgboost