### PR TITLE
Update base margin dask

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -880,7 +880,6 @@ def predict(client, model, data, missing=numpy.nan, **kwargs):
     '''
     _assert_dask_support()
     client = _xgb_get_client(client)
-    LOGGER.warning(kwargs)
     return client.sync(_predict_async, client, model, data,
                        missing=missing, **kwargs)
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -814,8 +814,12 @@ async def _predict_async(client: Client, model, data, missing=numpy.nan, **kwarg
         '''Get shape of data in each worker.'''
         LOGGER.info('Get shape on %d', worker_id)
         worker = distributed_get_worker()
-        list_of_parts = _get_worker_parts_ordered(False, worker_map,
-                                              partition_order, worker)
+        list_of_parts = _get_worker_parts_ordered(
+            False,
+            worker_map,
+            partition_order,
+            worker
+        )
         shapes = [(part.shape, order) for part, _, order in list_of_parts]
         return shapes
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -337,14 +337,22 @@ class DaskDMatrix:
                 'is_quantile': self.is_quantile}
 
 
-def _get_worker_x_ordered(worker_map, partition_order, worker):
+def _get_worker_parts_ordered(has_base_margin, worker_map,
+                          partition_order, worker):
     list_of_parts = worker_map[worker.address]
     client = get_client()
     list_of_parts_value = client.gather(list_of_parts)
+
     result = []
+
     for i, part in enumerate(list_of_parts):
-        result.append((list_of_parts_value[i][0],
-                       partition_order[part.key]))
+        data = list_of_parts_value[i][0]
+        if has_base_margin:
+            base_margin = list_of_parts_value[i][1]
+        else:
+            base_margin = None
+        result.append((data, base_margin, partition_order[part.key]))
+
     return result
 
 
@@ -740,9 +748,8 @@ async def _direct_predict_impl(client, data, predict_fn):
 
 
 # pylint: disable=too-many-statements
-async def _predict_async(client: Client, model, data, missing=numpy.nan,
-                         **kwargs):
-
+async def _predict_async(client: Client, model, data, output_margin,
+                         missing=numpy.nan, **kwargs):
     if isinstance(model, Booster):
         booster = model
     elif isinstance(model, dict):
@@ -775,21 +782,29 @@ async def _predict_async(client: Client, model, data, missing=numpy.nan,
     feature_names = data.feature_names
     feature_types = data.feature_types
     missing = data.missing
+    has_base_margin = data.has_base_margin
 
     def dispatched_predict(worker_id):
         '''Perform prediction on each worker.'''
         LOGGER.info('Predicting on %d', worker_id)
+
         worker = distributed_get_worker()
-        list_of_parts = _get_worker_x_ordered(worker_map, partition_order,
-                                              worker)
+        list_of_parts = _get_worker_parts_ordered(has_base_margin,
+            worker_map, partition_order, worker
+        )
         predictions = []
         booster.set_param({'nthread': worker.nthreads})
-        for part, order in list_of_parts:
-            local_x = DMatrix(part, feature_names=feature_names,
-                              feature_types=feature_types,
-                              missing=missing, nthread=worker.nthreads)
-            predt = booster.predict(data=local_x,
-                                    validate_features=local_x.num_row() != 0,
+        for data, base_margin, order in list_of_parts:
+            local_part = DMatrix(
+                data,
+                base_margin=base_margin,
+                feature_names=feature_names,
+                feature_types=feature_types,
+                missing=missing,
+                nthread=worker.nthreads
+            )
+            predt = booster.predict(data=local_part,
+                                    validate_features=local_part.num_row() != 0,
                                     **kwargs)
             columns = 1 if len(predt.shape) == 1 else predt.shape[1]
             ret = ((delayed(predt), columns), order)
@@ -800,9 +815,9 @@ async def _predict_async(client: Client, model, data, missing=numpy.nan,
         '''Get shape of data in each worker.'''
         LOGGER.info('Get shape on %d', worker_id)
         worker = distributed_get_worker()
-        list_of_parts = _get_worker_x_ordered(worker_map,
+        list_of_parts = _get_worker_parts_ordered(False, worker_map,
                                               partition_order, worker)
-        shapes = [(part.shape, order) for part, order in list_of_parts]
+        shapes = [(part.shape, order) for part, _, order in list_of_parts]
         return shapes
 
     async def map_function(func):
@@ -1143,7 +1158,7 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
             sample_weight_eval_set, verbose
         )
 
-    async def _predict_proba_async(self, data, base_margin=None):
+    async def _predict_proba_async(self, data, output_margin=False, base_margin=None):
         _assert_dask_support()
 
         test_dmatrix = await DaskDMatrix(
@@ -1151,14 +1166,16 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
             missing=self.missing
         )
         pred_probs = await predict(client=self.client,
-                                   model=self.get_booster(), data=test_dmatrix)
+                                   model=self.get_booster(),
+                                   data=test_dmatrix,
+                                   output_margin=output_margin)
         return pred_probs
 
-    def predict_proba(self, data, base_margin=None):  # pylint: disable=arguments-differ,missing-docstring
+    def predict_proba(self, data, output_margin=False, base_margin=None):  # pylint: disable=arguments-differ,missing-docstring
         _assert_dask_support()
-        return self.client.sync(self._predict_proba_async, data, base_margin)
+        return self.client.sync(self._predict_proba_async, data, output_margin, base_margin)
 
-    async def _predict_async(self, data, base_margin=None):
+    async def _predict_async(self, data, output_margin=False, base_margin=None):
         _assert_dask_support()
 
         test_dmatrix = await DaskDMatrix(
@@ -1166,7 +1183,9 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
             missing=self.missing
         )
         pred_probs = await predict(client=self.client,
-                                   model=self.get_booster(), data=test_dmatrix)
+                                   model=self.get_booster(),
+                                   data=test_dmatrix,
+                                   output_margin=output_margin)
 
         if self.n_classes_ == 2:
             preds = (pred_probs > 0.5).astype(int)
@@ -1175,6 +1194,6 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
 
         return preds
 
-    def predict(self, data, base_margin=None):  # pylint: disable=arguments-differ
+    def predict(self, data, output_margin=False, base_margin=None):  # pylint: disable=arguments-differ
         _assert_dask_support()
-        return self.client.sync(self._predict_async, data, base_margin)
+        return self.client.sync(self._predict_async, data, output_margin, base_margin)

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1147,7 +1147,7 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
         _assert_dask_support()
 
         test_dmatrix = await DaskDMatrix(
-            client=self.client, data=data,base_margin=base_margin,
+            client=self.client, data=data, base_margin=base_margin,
             missing=self.missing
         )
         pred_probs = await predict(client=self.client,

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -175,10 +175,25 @@ def test_boost_from_prediction(tree_method):
             predictions_2 = cls_2.predict(X_)
             proba_2 = cls_2.predict_proba(X_)
 
-            np.testing.assert_equal(predictions_1.compute(), predictions_2.compute())
+            cls_3 = xgb.dask.DaskXGBClassifier(
+                learning_rate=0.3,
+                random_state=123,
+                n_estimators=8,
+                tree_method=tree_method,
+            )
+            cls_3.fit(X=X_, y=y_)
+            predictions_3 = cls_3.predict(X_)
+            proba_3 = cls_3.predict_proba(X_)
 
-            # This won't pass for approx
-            if tree_method != "approx":
+            # compute variance between two of the same model, use this to check
+            # to make sure approx is functioning within normal parameters
+            variance = np.max(np.abs(proba_3 - proba_2)).compute()
+
+            if variance > 0:
+                print("variance > 0")
+                assert np.all(np.abs(proba_2 - proba_1) <= variance)
+            else:
+                np.testing.assert_equal(predictions_1.compute(), predictions_2.compute())
                 np.testing.assert_almost_equal(proba_1.compute(), proba_2.compute())
 
 

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -179,7 +179,6 @@ def test_boost_from_prediction(tree_method):
                 tree_method=tree_method,
             )
             cls_3.fit(X=X_, y=y_)
-            predictions_3 = cls_3.predict(X_)
             proba_3 = cls_3.predict_proba(X_)
 
             # compute variance of probability percentages between two of the

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -148,31 +148,38 @@ def test_boost_from_prediction(tree_method):
             X, y = load_breast_cancer(return_X_y=True)
             model_0 = xgb.dask.DaskXGBClassifier(
                 learning_rate=0.3,
-                random_state=0,
+                random_state=123,
                 n_estimators=4,
                 tree_method=tree_method,
             )
             model_0.fit(X=X_, y=y_)
-            margin = model_0.predict_proba(X_)
+            margin = model_0.predict_proba(X_, output_margin=True)
 
             model_1 = xgb.dask.DaskXGBClassifier(
                 learning_rate=0.3,
-                random_state=0,
+                random_state=123,
                 n_estimators=4,
                 tree_method=tree_method,
             )
             model_1.fit(X=X_, y=y_, base_margin=margin)
             predictions_1 = model_1.predict(X_, base_margin=margin)
+            proba_1 = model_1.predict_proba(X_, base_margin=margin)
 
             cls_2 = xgb.dask.DaskXGBClassifier(
                 learning_rate=0.3,
-                random_state=0,
+                random_state=123,
                 n_estimators=8,
                 tree_method=tree_method,
             )
             cls_2.fit(X=X_, y=y_)
             predictions_2 = cls_2.predict(X_)
+            proba_2 = cls_2.predict_proba(X_)
+
             np.testing.assert_equal(predictions_1.compute(), predictions_2.compute())
+
+            # This won't pass for approx
+            if tree_method != "approx":
+                np.testing.assert_almost_equal(proba_1.compute(), proba_2.compute())
 
 
 def test_dask_missing_value_reg():


### PR DESCRIPTION
Add `base_margin` to sklearn predict and predict_proba
Add `output_margin` to sklearn predict and predict_proba
Add `base_margin` to sklearn fit
Update `_get_worker_x_ordered` to `_get_worker_parts_ordered`. This allows us to get ordered base_margin to create the DMatrix object used for dispatched_predict
Add dask test to confirm this is functioning correctly. Mirrors the same test in `test_with_sklearn`

