### PR TITLE
[CI] Upgrade cuDF and RMM to 0.16 nightlies; upgrade to Ubuntu 18.04

### DIFF
--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -1,5 +1,5 @@
 ARG CUDA_VERSION
-FROM nvidia/cuda:$CUDA_VERSION-runtime-ubuntu16.04
+FROM nvidia/cuda:$CUDA_VERSION-runtime-ubuntu18.04
 
 # Environment
 ENV DEBIAN_FRONTEND noninteractive

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -18,7 +18,7 @@ ENV PATH=/opt/python/bin:$PATH
 # Create new Conda environment with cuDF, Dask, and cuPy
 RUN \
     conda create -n gpu_test -c rapidsai-nightly -c rapidsai -c nvidia -c conda-forge -c defaults \
-        python=3.7 cudf=0.15* rmm=0.15* cudatoolkit=$CUDA_VERSION dask dask-cuda dask-cudf cupy \
+        python=3.7 cudf=0.16* rmm=0.16* cudatoolkit=$CUDA_VERSION dask dask-cuda dask-cudf cupy \
         numpy pytest scipy scikit-learn pandas matplotlib wheel python-kubernetes urllib3 graphviz hypothesis
 
 ENV GOSU_VERSION 1.10

--- a/tests/ci_build/Dockerfile.rmm
+++ b/tests/ci_build/Dockerfile.rmm
@@ -29,7 +29,7 @@ ENV PATH=/opt/python/bin:$PATH
 # Create new Conda environment with RMM
 RUN \
     conda create -n gpu_test -c nvidia -c rapidsai-nightly -c rapidsai -c conda-forge -c defaults \
-        python=3.7 rmm=0.15* cudatoolkit=$CUDA_VERSION
+        python=3.7 rmm=0.16* cudatoolkit=$CUDA_VERSION
 
 ENV GOSU_VERSION 1.10
 

--- a/tests/ci_build/Dockerfile.rmm
+++ b/tests/ci_build/Dockerfile.rmm
@@ -1,5 +1,5 @@
 ARG CUDA_VERSION
-FROM nvidia/cuda:$CUDA_VERSION-devel-ubuntu16.04
+FROM nvidia/cuda:$CUDA_VERSION-devel-ubuntu18.04
 ARG CUDA_VERSION
 
 # Environment


### PR DESCRIPTION
Follow-up to #6146 

This will ensure that XGBoost is compatible with RAPIDS 0.16.