### PR TITLE
[CI] Test C API demo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,47 @@ jobs:
       run: |
         cd build
         ctest --extra-verbose
+  c-api-demo:
+    name: Test installing XGBoost lib + building the C API demo
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.8"]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    - name: Install system packages
+      run: |
+        sudo apt-get install -y --no-install-recommends ninja-build
+    - uses: conda-incubator/setup-miniconda@v1
+      with:
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
+    - name: Display Conda env
+      shell: bash -l {0}
+      run: |
+        conda info
+        conda list
+    - name: Build and install XGBoost
+      shell: bash -l {0}
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DBUILD_STATIC_LIB=ON -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -GNinja
+        ninja -v install
+    - name: Build and run C API demo
+      shell: bash -l {0}
+      run: |
+        cd demo/c-api/
+        mkdir build
+        cd build
+        cmake .. -GNinja -DCMAKE_PREFIX_PATH=$CONDA_PREFIX
+        ninja -v
+        cd ..
+        ./build/api-demo
   test-with-jvm:
     name: Test JVM on OS ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,7 +284,7 @@ install(DIRECTORY ${xgboost_SOURCE_DIR}/include/xgboost
 #
 # https://github.com/dmlc/xgboost/issues/6085
 if (BUILD_STATIC_LIB)
-  set(INSTALL_TARGETS xgboost runxgboost objxgboost rabit)
+  set(INSTALL_TARGETS xgboost runxgboost objxgboost rabit dmlc)
 else (BUILD_STATIC_LIB)
   set(INSTALL_TARGETS xgboost runxgboost)
 endif (BUILD_STATIC_LIB)

--- a/cmake/xgboost-config.cmake.in
+++ b/cmake/xgboost-config.cmake.in
@@ -1,5 +1,24 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
+set(USE_OPENMP @USE_OPENMP@)
+set(USE_CUDA @USE_CUDA@)
+set(USE_NCCL @USE_NCCL@)
+
+find_dependency(Threads)
+if(USE_OPENMP)
+  find_dependency(OpenMP)
+endif()
+if(USE_CUDA)
+  find_dependency(CUDA)
+endif()
+if(USE_NCCL)
+  find_dependency(Nccl)
+endif()
+
 if(NOT TARGET xgboost::xgboost)
   include(${CMAKE_CURRENT_LIST_DIR}/XGBoostTargets.cmake)
 endif()
+
+message(STATUS "Found XGBoost (found version \"${xgboost_VERSION}\")")

--- a/demo/c-api/CMakeLists.txt
+++ b/demo/c-api/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
+project(api-demo LANGUAGES C CXX VERSION 0.0.1)
 find_package(xgboost REQUIRED)
 add_executable(api-demo c-api-demo.c)
-target_link_libraries(api-demo xgboost::xgboost)
+target_link_libraries(api-demo PRIVATE xgboost::xgboost)

--- a/demo/c-api/c-api-demo.c
+++ b/demo/c-api/c-api-demo.c
@@ -62,7 +62,7 @@ int main(int argc, char** argv) {
 
   bst_ulong num_feature = 0;
   safe_xgboost(XGBoosterGetNumFeature(booster, &num_feature));
-  printf("num_feature: %llu\n", num_feature);
+  printf("num_feature: %lu\n", (unsigned long)(num_feature));
 
   // predict
   bst_ulong out_len = 0;


### PR DESCRIPTION
Closes #5910

* Fix building the static library with `BUILD_STATIC_LIB` option. The dmlc-core lib should also be installed.
* Revise `xgboost-config.cmake.in` to account of dependencies of XGBoost, such as OpenMP and Threads. We need to specify the dependencies so that applications linking with XGBoost will also link with these dependencies. Also log the XGBoost version when `find_package(xgboost)` is run:
```
-- Found XGBoost (found version "1.3.0")
```
* Update CMakeLists.txt in the C API demo to follow modern CMake practices.
* In CI, build and install the static library `libxgboost.a` into a system prefix. (Conda is used as an "sandboxed" prefix.)
* In CI, build and run the C API demo to make sure that we won't break it in the future.