### PR TITLE
Use default allocator in sketching.

### DIFF
--- a/src/common/quantile.cu
+++ b/src/common/quantile.cu
@@ -310,7 +310,7 @@ void SketchContainer::Push(Span<Entry const> entries, Span<size_t> columns_ptr,
                            common::Span<OffsetT const> cuts_ptr,
                            size_t total_cuts, Span<float> weights) {
   Span<SketchEntry> out;
-  dh::caching_device_vector<SketchEntry> cuts;
+  dh::device_vector<SketchEntry> cuts;
   bool first_window = this->Current().empty();
   if (!first_window) {
     cuts.resize(total_cuts);

--- a/src/common/quantile.cuh
+++ b/src/common/quantile.cuh
@@ -36,31 +36,31 @@ class SketchContainer {
   int32_t device_;
 
   // Double buffer as neither prune nor merge can be performed inplace.
-  dh::caching_device_vector<SketchEntry> entries_a_;
-  dh::caching_device_vector<SketchEntry> entries_b_;
+  dh::device_vector<SketchEntry> entries_a_;
+  dh::device_vector<SketchEntry> entries_b_;
   bool current_buffer_ {true};
   // The container is just a CSC matrix.
   HostDeviceVector<OffsetT> columns_ptr_;
   HostDeviceVector<OffsetT> columns_ptr_b_;
 
-  dh::caching_device_vector<SketchEntry>& Current() {
+  dh::device_vector<SketchEntry>& Current() {
     if (current_buffer_) {
       return entries_a_;
     } else {
       return entries_b_;
     }
   }
-  dh::caching_device_vector<SketchEntry>& Other() {
+  dh::device_vector<SketchEntry>& Other() {
     if (!current_buffer_) {
       return entries_a_;
     } else {
       return entries_b_;
     }
   }
-  dh::caching_device_vector<SketchEntry> const& Current() const {
+  dh::device_vector<SketchEntry> const& Current() const {
     return const_cast<SketchContainer*>(this)->Current();
   }
-  dh::caching_device_vector<SketchEntry> const& Other() const {
+  dh::device_vector<SketchEntry> const& Other() const {
     return const_cast<SketchContainer*>(this)->Other();
   }
   void Alternate() {


### PR DESCRIPTION
* Revert RMM allocator detection on caching allocator.
* Use `thrust::device_vector` for sketching, the perf doesn't seem to have any visible change.

This means even if compiled with RMM, XGBoost will continue to allocate a small runtime memory outside of RMM pool.  This seems to be the cleanest way to proceed.  Other options are discussed in https://github.com/rapidsai/rmm/issues/583 .

cc @hcho3 @RAMitchell 