### PR TITLE
Rework Python callback functions.

### DIFF
--- a/demo/guide-python/callbacks.py
+++ b/demo/guide-python/callbacks.py
@@ -22,7 +22,6 @@ class Plotting(xgb.callback.TrainingCallback):
         self.fig = plt.figure()
         self.ax = self.fig.add_subplot(111)
         self.rounds = rounds
-        self.has_lines = False
         self.lines = {}
         self.fig.show()
         self.x = np.linspace(0, self.rounds, self.rounds)

--- a/demo/guide-python/callbacks.py
+++ b/demo/guide-python/callbacks.py
@@ -1,0 +1,41 @@
+import xgboost as xgb
+import tempfile
+import os
+from sklearn.datasets import load_breast_cancer
+
+
+def check_point_callback():
+    X, y = load_breast_cancer(return_X_y=True)
+    m = xgb.DMatrix(X, y)
+    # Check point to a temporary directory for demo
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Use callback class from xgboost.callback
+        # Feel free to subclass/customize it to suite your need.
+        check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
+                                                      rounds=2,
+                                                      name='model')
+        xgb.train({'objective': 'binary:logistic'}, m,
+                  num_boost_round=10,
+                  verbose_eval=False,
+                  callbacks=[check_point])
+        for i in range(0, 10):
+            assert os.path.exists(
+                os.path.join(tmpdir, 'model_' + str(i) + '.json'))
+
+        # This version of checkpoint saves everything including parameters and
+        # model.  See: doc/tutorials/saving_model.rst
+        check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
+                                                      rounds=1,
+                                                      as_pickle=True,
+                                                      name='model')
+        xgb.train({'objective': 'binary:logistic'}, m,
+                  num_boost_round=10,
+                  verbose_eval=False,
+                  callbacks=[check_point])
+        for i in range(0, 10):
+            assert os.path.exists(
+                os.path.join(tmpdir, 'model_' + str(i) + '.pkl'))
+
+
+if __name__ == '__main__':
+    check_point_callback()

--- a/demo/guide-python/callbacks.py
+++ b/demo/guide-python/callbacks.py
@@ -109,7 +109,7 @@ def check_point_callback():
         # This version of checkpoint saves everything including parameters and
         # model.  See: doc/tutorials/saving_model.rst
         check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
-                                                      rounds=rounds,
+                                                      iterations=rounds,
                                                       as_pickle=True,
                                                       name='model')
         xgb.train({'objective': 'binary:logistic'}, m,

--- a/demo/guide-python/callbacks.py
+++ b/demo/guide-python/callbacks.py
@@ -98,7 +98,7 @@ def check_point_callback():
         # Use callback class from xgboost.callback
         # Feel free to subclass/customize it to suit your need.
         check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
-                                                      rounds=rounds,
+                                                      iterations=rounds,
                                                       name='model')
         xgb.train({'objective': 'binary:logistic'}, m,
                   num_boost_round=10,

--- a/demo/guide-python/callbacks.py
+++ b/demo/guide-python/callbacks.py
@@ -10,6 +10,7 @@ import numpy as np
 from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
 from matplotlib import pyplot as plt
+import argparse
 
 
 class Plotting(xgb.callback.TrainingCallback):
@@ -120,5 +121,11 @@ def check_point_callback():
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--plot', default=1, type=int)
+    args = parser.parse_args()
+
     check_point_callback()
-    custom_callback()
+
+    if args.plot:
+        custom_callback()

--- a/demo/guide-python/callbacks.py
+++ b/demo/guide-python/callbacks.py
@@ -1,7 +1,7 @@
 '''
 Demo for using and defining callback functions.
 
-    .. versionadded:: 1.2.0
+    .. versionadded:: 1.3.0
 '''
 import xgboost as xgb
 import tempfile

--- a/demo/guide-python/callbacks.py
+++ b/demo/guide-python/callbacks.py
@@ -97,7 +97,7 @@ def check_point_callback():
     # Check point to a temporary directory for demo
     with tempfile.TemporaryDirectory() as tmpdir:
         # Use callback class from xgboost.callback
-        # Feel free to subclass/customize it to suite your need.
+        # Feel free to subclass/customize it to suit your need.
         check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
                                                       rounds=rounds,
                                                       name='model')

--- a/demo/guide-python/callbacks.py
+++ b/demo/guide-python/callbacks.py
@@ -1,10 +1,96 @@
+'''
+Demo for using and defining callback functions.
+
+    .. versionadded:: 1.2.0
+'''
 import xgboost as xgb
 import tempfile
 import os
+import numpy as np
 from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+from matplotlib import pyplot as plt
+
+
+class Plotting(xgb.callback.TrainingCallback):
+    '''Plot evaluation result during training.  Only for demonstration purpose as it's quite
+    slow to draw.
+
+    '''
+    def __init__(self, rounds):
+        self.fig = plt.figure()
+        self.ax = self.fig.add_subplot(111)
+        self.rounds = rounds
+        self.has_lines = False
+        self.lines = {}
+        self.fig.show()
+        self.x = np.linspace(0, self.rounds, self.rounds)
+        plt.ion()
+
+    def _get_key(self, data, metric):
+        return f'{data}-{metric}'
+
+    def after_iteration(self, model, epoch, evals_log):
+        '''Update the plot.'''
+        if not self.lines:
+            for data, metric in evals_log.items():
+                for metric_name, log in metric.items():
+                    key = self._get_key(data, metric_name)
+                    expanded = log + [0] * (self.rounds - len(log))
+                    self.lines[key],  = self.ax.plot(self.x, expanded, label=key)
+                    self.ax.legend()
+        else:
+            # https://pythonspot.com/matplotlib-update-plot/
+            for data, metric in evals_log.items():
+                for metric_name, log in metric.items():
+                    key = self._get_key(data, metric_name)
+                    expanded = log + [0] * (self.rounds - len(log))
+                    self.lines[key].set_ydata(expanded)
+            self.fig.canvas.draw()
+        # False to indicate training should not stop.
+        return False
+
+
+def custom_callback():
+    '''Demo for defining a custom callback function that plots evaluation result during
+    training.'''
+    X, y = load_breast_cancer(return_X_y=True)
+    X_train, X_valid, y_train, y_valid = train_test_split(X, y, random_state=0)
+
+    D_train = xgb.DMatrix(X_train, y_train)
+    D_valid = xgb.DMatrix(X_valid, y_valid)
+
+    num_boost_round = 100
+    plotting = Plotting(num_boost_round)
+
+    # Pass it to the `callbacks` parameter as a list.
+    xgb.train(
+        {
+            'objective': 'binary:logistic',
+            'eval_metric': ['error', 'rmse'],
+            'tree_method': 'gpu_hist'
+        },
+        D_train,
+        evals=[(D_train, 'Train'), (D_valid, 'Valid')],
+        num_boost_round=num_boost_round,
+        callbacks=[plotting])
 
 
 def check_point_callback():
+    # only for demo, set a larger value (like 100) in practice as checkpointing is quite
+    # slow.
+    rounds = 2
+
+    def check(as_pickle):
+        for i in range(0, 10, rounds):
+            if i == 0:
+                continue
+            if as_pickle:
+                path = os.path.join(tmpdir, 'model_' + str(i) + '.pkl')
+            else:
+                path = os.path.join(tmpdir, 'model_' + str(i) + '.json')
+            assert(os.path.exists(path))
+
     X, y = load_breast_cancer(return_X_y=True)
     m = xgb.DMatrix(X, y)
     # Check point to a temporary directory for demo
@@ -12,30 +98,27 @@ def check_point_callback():
         # Use callback class from xgboost.callback
         # Feel free to subclass/customize it to suite your need.
         check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
-                                                      rounds=2,
+                                                      rounds=rounds,
                                                       name='model')
         xgb.train({'objective': 'binary:logistic'}, m,
                   num_boost_round=10,
                   verbose_eval=False,
                   callbacks=[check_point])
-        for i in range(0, 10):
-            assert os.path.exists(
-                os.path.join(tmpdir, 'model_' + str(i) + '.json'))
+        check(False)
 
         # This version of checkpoint saves everything including parameters and
         # model.  See: doc/tutorials/saving_model.rst
         check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
-                                                      rounds=1,
+                                                      rounds=rounds,
                                                       as_pickle=True,
                                                       name='model')
         xgb.train({'objective': 'binary:logistic'}, m,
                   num_boost_round=10,
                   verbose_eval=False,
                   callbacks=[check_point])
-        for i in range(0, 10):
-            assert os.path.exists(
-                os.path.join(tmpdir, 'model_' + str(i) + '.pkl'))
+        check(True)
 
 
 if __name__ == '__main__':
     check_point_callback()
+    custom_callback()

--- a/demo/guide-python/data_iterator.py
+++ b/demo/guide-python/data_iterator.py
@@ -1,5 +1,7 @@
 '''A demo for defining data iterator.
 
+    .. versionadded:: 1.2.0
+
 The demo that defines a customized iterator for passing batches of data into
 `xgboost.DeviceQuantileDMatrix` and use this `DeviceQuantileDMatrix` for
 training.  The feature is used primarily designed to reduce the required GPU

--- a/doc/python/callbacks.rst
+++ b/doc/python/callbacks.rst
@@ -34,14 +34,15 @@ this callback function directly into XGBoost:
 
     # Specify which dataset and which metric should be used for early stopping.
     early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
-                                            metric=tm.eval_error_metric,
-                                            metric_name='PyError',
-                                            data_name='Valid')
+					    metric_name='PyError',
+					    data_name='Train')
+
     booster = xgb.train(
         {'objective': 'binary:logistic',
          'eval_metric': ['error', 'rmse'],
          'tree_method': 'hist'}, D_train,
         evals=[(D_train, 'Train'), (D_valid, 'Valid')],
+	feval=eval_error_metric,
         num_boost_round=1000,
         callbacks=[early_stop],
         verbose_eval=False)
@@ -53,12 +54,6 @@ this callback function directly into XGBoost:
 Defining your own callback
 ##########################
 
-In here we will define a callback for monitoring shap value changes during training.
-First XGBoost provides an interface class: ``xgboost.callback.TrainingCallback``, user
-defined callbacks should inherit this class and override corresponding methods.
-
-.. code-block:: python
-    pass
-
-
-The full example is in.
+XGBoost provides an callback interface class: ``xgboost.callback.TrainingCallback``, user
+defined callbacks should inherit this class and override corresponding methods.  There's a
+working example in `demo/guide-python/callbacks.py <https://github.com/dmlc/xgboost/tree/master/demo/guide-python/callbacks.py>`_

--- a/doc/python/callbacks.rst
+++ b/doc/python/callbacks.rst
@@ -1,0 +1,64 @@
+##################
+Callback Functions
+##################
+
+This document gives a basic walkthrough of callback function used in XGBoost Python
+package.  In XGBoost 1.3, a new callback interface is designed for Python package, which
+provides the flexiablity of designing various extension for training.  Also, XGBoost has a
+number of pre-defined callbacks for supporting early stopping, checkpoints etc.
+
+#######################
+Using builtin callbacks
+#######################
+
+By default, training methods in XGBoost have parameters like ``early_stopping_rounds`` and
+``verbose``/``verbose_eval``, when specified the training procedure will define the
+corresponding callbacks internally.  For example, when ``early_stopping_rounds`` is
+specified, ``EarlyStopping`` callback is invoked inside iteration loop.  You can also pass
+this callback function directly into XGBoost:
+
+.. code-block:: python
+
+    D_train = xgb.DMatrix(X_train, y_train)
+    D_valid = xgb.DMatrix(X_valid, y_valid)
+
+    # Define a custom evaluation metric used for early stopping.
+    def eval_error_metric(predt, dtrain: xgb.DMatrix):
+        label = dtrain.get_label()
+        r = np.zeros(predt.shape)
+        gt = predt > 0.5
+        r[gt] = 1 - label[gt]
+        le = predt <= 0.5
+        r[le] = label[le]
+        return 'PyError', np.sum(r)
+
+    # Specify which dataset and which metric should be used for early stopping.
+    early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
+                                            metric=tm.eval_error_metric,
+                                            metric_name='PyError',
+                                            data_name='Valid')
+    booster = xgb.train(
+        {'objective': 'binary:logistic',
+         'eval_metric': ['error', 'rmse'],
+         'tree_method': 'hist'}, D_train,
+        evals=[(D_train, 'Train'), (D_valid, 'Valid')],
+        num_boost_round=1000,
+        callbacks=[early_stop],
+        verbose_eval=False)
+
+    dump = booster.get_dump(dump_format='json')
+    assert len(early_stop.stopping_history['Valid']['PyError']) == len(dump)
+
+##########################
+Defining your own callback
+##########################
+
+In here we will define a callback for monitoring shap value changes during training.
+First XGBoost provides an interface class: ``xgboost.callback.TrainingCallback``, user
+defined callbacks should inherit this class and override corresponding methods.
+
+.. code-block:: python
+    pass
+
+
+The full example is in.

--- a/doc/python/callbacks.rst
+++ b/doc/python/callbacks.rst
@@ -34,15 +34,15 @@ this callback function directly into XGBoost:
 
     # Specify which dataset and which metric should be used for early stopping.
     early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
-					    metric_name='PyError',
-					    data_name='Train')
+                                            metric_name='PyError',
+                                            data_name='Train')
 
     booster = xgb.train(
         {'objective': 'binary:logistic',
          'eval_metric': ['error', 'rmse'],
          'tree_method': 'hist'}, D_train,
         evals=[(D_train, 'Train'), (D_valid, 'Valid')],
-	feval=eval_error_metric,
+        feval=eval_error_metric,
         num_boost_round=1000,
         callbacks=[early_stop],
         verbose_eval=False)

--- a/doc/python/callbacks.rst
+++ b/doc/python/callbacks.rst
@@ -4,7 +4,7 @@ Callback Functions
 
 This document gives a basic walkthrough of callback function used in XGBoost Python
 package.  In XGBoost 1.3, a new callback interface is designed for Python package, which
-provides the flexiablity of designing various extension for training.  Also, XGBoost has a
+provides the flexiblity of designing various extension for training.  Also, XGBoost has a
 number of pre-defined callbacks for supporting early stopping, checkpoints etc.
 
 #######################
@@ -30,11 +30,11 @@ this callback function directly into XGBoost:
         r[gt] = 1 - label[gt]
         le = predt <= 0.5
         r[le] = label[le]
-        return 'PyError', np.sum(r)
+        return 'CustomErr', np.sum(r)
 
     # Specify which dataset and which metric should be used for early stopping.
     early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
-                                            metric_name='PyError',
+                                            metric_name='CustomErr',
                                             data_name='Train')
 
     booster = xgb.train(
@@ -48,7 +48,7 @@ this callback function directly into XGBoost:
         verbose_eval=False)
 
     dump = booster.get_dump(dump_format='json')
-    assert len(early_stop.stopping_history['Valid']['PyError']) == len(dump)
+    assert len(early_stop.stopping_history['Valid']['CustomErr']) == len(dump)
 
 ##########################
 Defining your own callback

--- a/doc/python/index.rst
+++ b/doc/python/index.rst
@@ -11,4 +11,5 @@ Contents
 .. toctree::
   python_intro
   python_api
+  callbacks
   Python examples <https://github.com/dmlc/xgboost/tree/master/demo/guide-python>

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -379,8 +379,6 @@ class CallbackContainer:
 
     def after_iteration(self, model, epoch, dtrain, evals):
         '''Function called after training iteration.'''
-        for d, name in evals:
-            assert name.find('-') == -1, 'Dataset name should not contain `-`'
         if self.is_cv:
             scores = model.eval(epoch, self.metric)
             scores = _aggcv(scores)
@@ -388,6 +386,8 @@ class CallbackContainer:
             self._update_history(scores, epoch)
         else:
             evals = [] if evals is None else evals
+            for d, name in evals:
+                assert name.find('-') == -1, 'Dataset name should not contain `-`'
             score = model.eval_set(evals, epoch, self.metric)
             score = score.split()[1:]  # into datasets
             # split up `test-error:0.1234`

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -310,7 +310,7 @@ class CallbackContainer:
 
     '''
     def __init__(self, callbacks, metric=None, is_cv=False):
-        self.callbacks = callbacks
+        self.callbacks = set(callbacks)
         if metric is not None:
             msg = 'metric must be callable object for monitor.  For ' + \
                 'builtin metrics, passing them in training parameter' + \

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -501,7 +501,10 @@ class EvaluationMonitor(TrainingCallback):
     '''
     def __init__(self, metric=None, rank=0):
         if metric is not None:
-            assert callable(metric), 'metric must be callable object.'
+            msg = 'metric must be callable object for monitor.  For ' + \
+                'builtin metrics, passing them in training parameter' + \
+                ' will invoke monitor automatically.'
+            assert callable(metric), msg
         self.metric = metric
         self.printer_rank = rank
         super().__init__()

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -386,7 +386,7 @@ class CallbackContainer:
             self._update_history(scores, epoch)
         else:
             evals = [] if evals is None else evals
-            for d, name in evals:
+            for _, name in evals:
                 assert name.find('-') == -1, 'Dataset name should not contain `-`'
             score = model.eval_set(evals, epoch, self.metric)
             score = score.split()[1:]  # into datasets
@@ -680,11 +680,9 @@ class LegacyCallbacks:
 
     def before_training(self, model):
         '''Nothing to do for legacy callbacks'''
-        pass
 
     def after_training(self, model):
         '''Nothing to do for legacy callbacks'''
-        pass
 
     def before_iteration(self, model, epoch, dtrain, evals):
         '''Called before each iteration.'''

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -680,6 +680,7 @@ class LegacyCallbacks:
         super().__init__()
 
     def before_iteration(self, model, epoch, dtrain, evals):
+        '''Called before each iteration.'''
         for cb in self.callbacks_before_iter:
             rank = rabit.get_rank()
             cb(CallbackEnv(model=model,
@@ -692,6 +693,7 @@ class LegacyCallbacks:
         return False
 
     def after_iteration(self, model, epoch, dtrain, evals):
+        '''Called after each iteration.'''
         evaluation_result_list = []
         if self.evals:
             bst_eval_set = model.eval_set(self.evals, epoch, self.feval)

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -5,17 +5,12 @@
 from abc import ABC
 import collections
 import os
-import numpy
 import pickle
+import numpy
 
 from . import rabit
 from .core import EarlyStopException, DMatrix, CallbackEnv
 from .compat import STRING_TYPES
-
-import sys
-def fprint(*args, **kwargs):
-    print(*args, **kwargs)
-    sys.stdout.flush()
 
 
 def _get_callback_context(env):
@@ -334,7 +329,7 @@ class CallbackContainer(TrainingCallback):
     def after_iteration(self, model, epoch, dtrain, evals):
         '''Function called after training iteration.'''
         ret = any(c.after_iteration(model, epoch, dtrain, evals)
-                   for c in self.callbacks)
+                  for c in self.callbacks)
         for c in self.callbacks:
             self.history.update(c.history)
         return ret
@@ -455,7 +450,7 @@ class EarlyStopping(TrainingCallback):
             label = stopping_data.get_label()
             predt = model.predict(stopping_data)
             score = self.metric(label, predt)
-            score = _allreduce_metric(score, self.maximize)
+            score = _allreduce_metric(score)
             score = [(self.metric_name, score)]
         else:
             score = model.eval(stopping_data)
@@ -473,20 +468,10 @@ class EvaluationMonitor(TrainingCallback):
     Parameters
     ----------
 
-    data
-        Data for evaluation.
-    name : str
-        Name of data.
     metric : str
         Name of metric
     rank : int
         Which worker should be used for printing the result.
-    missing : float
-        Used when data is not a DMatrix.
-    weight
-        Used when data is not a DMatrix.
-    label
-        Used when data is not a DMatrix.
     '''
     def __init__(self, metric=None, rank=0):
         self.metric = metric
@@ -532,8 +517,9 @@ class TrainingCheckPoint(TrainingCallback):
 
     path : os.PathLike
         Output model directory.
-    name : name pattern of output model file.
-        Models will be saved as name_0.json, name_1.json, name_2.json ....
+    name : str
+        pattern of output model file.  Models will be saved as name_0.json,
+        name_1.json, name_2.json ....
     as_pickle : boolean
         When set to Ture, all training parameters will be saved in pickle
         format, instead of saving only the model.
@@ -548,6 +534,7 @@ class TrainingCheckPoint(TrainingCallback):
         self._as_pickle = as_pickle
         self._iterations = rounds
         self._epoch = 0
+        super().__init__()
 
     def after_iteration(self, model, epoch, dtrain, evals):
         self._epoch += 1

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -417,6 +417,7 @@ class EarlyStopping(TrainingCallback):
         assert len(scores) == 1
         score = scores[0]
         metric, s = score[0], score[1]
+        s = _allreduce_metric(s)
         if not self.stopping_history:    # First round
             self.current_rounds = 0
             self.stopping_history[name] = {}

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -362,7 +362,9 @@ class CallbackContainer:
             if self.is_cv:
                 std = float(d[2])
                 s = (s, std)
-            data_name, metric_name = name.split('-')
+            splited_names = name.split('-')
+            data_name = splited_names[0]
+            metric_name = '-'.join(splited_names[1:])
             s = _allreduce_metric(s)
             if data_name in self.history:
                 data_history = self.history[data_name]
@@ -377,6 +379,8 @@ class CallbackContainer:
 
     def after_iteration(self, model, epoch, dtrain, evals):
         '''Function called after training iteration.'''
+        for d, name in evals:
+            assert name.find('-') == -1, 'Dataset name should not contain `-`'
         if self.is_cv:
             scores = model.eval(epoch, self.metric)
             scores = _aggcv(scores)

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -642,7 +642,7 @@ class TrainingCheckPoint(TrainingCallback):
         self._epoch += 1
 
 
-class LegacyCallbacks(TrainingCallback):
+class LegacyCallbacks:
     '''Adapter for legacy callback functions.
 
     .. versionadded:: 1.3.0

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -262,17 +262,18 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
     return callback
 
 
-#
 # The new implementation of callback functions.
 #
 # TODOs
-# - eval_set
-# - cv
-# - tests
-# - doc
-# - enforced best_xxx
-# - merged functionality of es and mon.
-# - make callbacks a set instead of list.
+# - [x] eval_set
+# - [ ] cv
+# - [ ] tests
+# - [ ] doc
+# - [x] enforced best_xxx
+# - [ ] merged functionality of es and mon.
+# - [ ] make callbacks a set instead of list.
+# - [ ] auto detect maximize.
+# - [ ] Correct printing for cv
 
 # Breaking:
 # - reset learning rate no longer accepts total boosting rounds

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -419,7 +419,7 @@ class EarlyStopping(TrainingCallback):
     def _update_rounds(self, scores, name, model, epoch):
         assert len(scores) == 1, 'No matching metric name.'
         score = scores[0]
-        metric, s = score[0], score[1]
+        metric, s = score[0].split('-')[1], score[1]
         s = _allreduce_metric(s)
         if not self.stopping_history:  # First round
             self.current_rounds = 0

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -278,6 +278,9 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
 # - enforced best_xxx
 # - merged functionality of es and mon.
 
+# Breaking:
+# - reset learning rate no longer accepts total boosting rounds
+
 # pylint: disable=unused-argument
 class TrainingCallback(ABC):
     '''Interface for training callback.
@@ -348,7 +351,7 @@ class LearningRateScheduler(TrainingCallback):
     learning_rates : callable/collections.Sequence
         If it's a callable object, then it should accept an integer parameter
         `epoch` and returns the corresponding learning rate.  Otherwise it
-        shoule be a sequence like list or tuple with the same size of boosting
+        should be a sequence like list or tuple with the same size of boosting
         rounds.
 
     '''

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -450,16 +450,6 @@ def _allreduce_metric(score):
     return score[0]
 
 
-def _get_latest_log(evals_log: collections.OrderedDict):
-    '''Given the evaluation log, extract the score of latest iteration.'''
-    result = []
-    for data, metric in evals_log.items():
-        for metric_name, log in metric.items():
-            result.append(
-                {'data': data, 'metric': metric_name, 'score': log[-1]})
-    return result
-
-
 # pylint: disable=too-many-instance-attributes
 class EarlyStopping(TrainingCallback):
     ''' Callback function for early stopping
@@ -639,7 +629,6 @@ class TrainingCheckPoint(TrainingCallback):
         super().__init__()
 
     def after_iteration(self, model, epoch, evals_log):
-        self._epoch += 1
         if self._epoch == self._iterations:
             path = os.path.join(self._path, self._name + '_' + str(epoch) +
                                 ('.pkl' if self._as_pickle else '.json'))
@@ -650,6 +639,7 @@ class TrainingCheckPoint(TrainingCallback):
                         pickle.dump(model, fd)
                 else:
                     model.save_model(path)
+        self._epoch += 1
 
 
 class LegacyCallbacks(TrainingCallback):

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -264,17 +264,6 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
 
 
 # The new implementation of callback functions.
-#
-# TODOs
-# - [x] eval_set
-# - [x] cv
-# - [x] tests
-# - [ ] doc
-# - [x] enforced best_xxx
-# - [x] make callbacks a set instead of list.
-# - [x] auto detect maximize.
-# - [x] Correct printing for cv
-
 # Breaking:
 # - reset learning rate no longer accepts total boosting rounds
 

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -4,6 +4,7 @@
 """Training Library containing training routines."""
 from abc import ABC
 import collections
+import os
 import numpy
 
 from . import rabit
@@ -552,6 +553,32 @@ class EvaluationMonitor(TrainingCallback):
         assert not rabit.is_distributed()
         score = model.eval(self.data, self.name)
         return self._update_history(score, epoch)
+
+
+class TrainingCheckPoint(TrainingCallback):
+    '''Checkpointing operation.
+
+    .. versionadded:: 1.3.0
+
+    Parameters
+    ----------
+
+    path : os.PathLike
+        Output model path.
+    iterations : int
+        Interval of checkpointing.
+    '''
+    def __init__(self, path: os.PathLike, iterations=10):
+        self._path = path
+        self._iterations = iterations
+        self._epoch = 0
+
+    def after_iteration(self, model, epoch):
+        self._epoch += 1
+        if self._epoch == 10:
+            self._epoch = 0
+            if rabit.get_rank() == 0:
+                model.save_model(self._path)
 
 
 class LegacyCallbacks(TrainingCallback):

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -272,6 +272,7 @@ def early_stop(stopping_rounds, maximize=False, verbose=True):
 # - doc
 # - enforced best_xxx
 # - merged functionality of es and mon.
+# - make callbacks a set instead of list.
 
 # Breaking:
 # - reset learning rate no longer accepts total boosting rounds

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1132,7 +1132,8 @@ class DaskXGBRegressor(DaskScikitLearnBase, XGBRegressorBase):
     ['estimators', 'model'])
 class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
     async def _fit_async(self, X, y, sample_weights, base_margin, eval_set,
-                         sample_weight_eval_set, verbose):
+                         sample_weight_eval_set, early_stopping_rounds,
+                         verbose):
         dtrain = await DaskDMatrix(client=self.client,
                                    data=X,
                                    label=y,
@@ -1162,6 +1163,7 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
                               dtrain=dtrain,
                               num_boost_round=self.get_num_boosting_rounds(),
                               evals=evals,
+                              early_stopping_rounds=early_stopping_rounds,
                               verbose_eval=verbose)
         self._Booster = results['booster']
         # pylint: disable=attribute-defined-outside-init

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -130,7 +130,7 @@ def _train_internal(params, dtrain,
 
 
 def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
-          maximize=False, early_stopping_rounds=None, evals_result=None,
+          maximize=None, early_stopping_rounds=None, evals_result=None,
           verbose_eval=True, xgb_model=None, callbacks=None):
     # pylint: disable=too-many-statements,too-many-branches, attribute-defined-outside-init
     """Train a booster with given parameters.
@@ -392,7 +392,7 @@ def aggcv(rlist):
 
 
 def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None,
-       metrics=(), obj=None, feval=None, maximize=False, early_stopping_rounds=None,
+       metrics=(), obj=None, feval=None, maximize=None, early_stopping_rounds=None,
        fpreproc=None, as_pandas=True, verbose_eval=True, show_stdv=True,
        seed=0, callbacks=None, shuffle=True):
     # pylint: disable = invalid-name

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -363,7 +363,7 @@ def mknfold(dall, nfold, param, seed, evals=(), fpreproc=None, stratified=False,
 
 def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None,
        metrics=(), obj=None, feval=None, maximize=None, early_stopping_rounds=None,
-       fpreproc=None, as_pandas=True, verbose_eval=True, show_stdv=True,
+       fpreproc=None, as_pandas=True, verbose_eval=None, show_stdv=True,
        seed=0, callbacks=None, shuffle=True):
     # pylint: disable = invalid-name
     """Cross-validation with given parameters.
@@ -465,7 +465,7 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None
     is_new_callback = [isinstance(c, callback.TrainingCallback)
                        for c in callbacks]
     if any(is_new_callback) or not callbacks:
-        if verbose_eval:
+        if isinstance(verbose_eval, bool) and verbose_eval:
             callbacks.append(callback.EvaluationMonitor(show_stdv=show_stdv))
         if early_stopping_rounds:
             callbacks.append(callback.EarlyStopping(

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -113,7 +113,7 @@ def _train_internal(params, dtrain,
 
     callbacks.after_training(bst)
 
-    if evals_result is not None:
+    if evals_result is not None and any(is_new_callback):
         evals_result.update(callbacks.history)
 
     if bst.attr('best_score') is not None:

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -105,7 +105,7 @@ def _train_internal(params, dtrain,
 
     callbacks.after_training(bst)
 
-    if evals_result:
+    if evals_result is not None:
         evals_result.update(callbacks.history)
 
     if bst.attr('best_score') is not None:

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -11,7 +11,7 @@ from . import callback
 
 def _configure_deprected_callbacks(
         verbose_eval, early_stopping_rounds, maximize, start_iteration,
-        num_boost_round, evals, feval, evals_result, callbacks):
+        num_boost_round, feval, evals_result, callbacks):
     # Most of legacy advanced options becomes callbacks
     if isinstance(verbose_eval, bool) and verbose_eval:
         callbacks.append(callback.print_evaluation())
@@ -87,7 +87,7 @@ def _train_internal(params, dtrain,
     else:
         callbacks = _configure_deprected_callbacks(
             verbose_eval, early_stopping_rounds, maximize, start_iteration,
-            num_boost_round, evals, feval, evals_result, callbacks)
+            num_boost_round, feval, evals_result, callbacks)
 
     callbacks.before_training(bst)
     for i in range(start_iteration, num_boost_round):
@@ -251,6 +251,7 @@ class _PackedBooster:
             f.bst.set_attr(**kwargs)
 
     def attr(self, key):
+        '''Redirect to booster attr.'''
         return self.cvfolds[0].bst.attr(key)
 
     @property

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -83,8 +83,8 @@ def _train_internal(params, dtrain,
             callbacks.append(callback.EvaluationMonitor(metric=feval))
         if early_stopping_rounds:
             callbacks.append(callback.EarlyStopping(
-                rounds=early_stopping_rounds, metric=feval))
-        callbacks = callback.CallbackContainer(callbacks)
+                rounds=early_stopping_rounds))
+        callbacks = callback.CallbackContainer(callbacks, metric=feval)
     else:
         assert False
         callbacks = _configure_deprected_callbacks(

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -9,7 +9,7 @@ from . import rabit
 from . import callback
 
 
-def _configure_deprected_callbacks(
+def _configure_deprecated_callbacks(
         verbose_eval, early_stopping_rounds, maximize, start_iteration,
         num_boost_round, feval, evals_result, callbacks, show_stdv, cvfolds):
     # Most of legacy advanced options becomes callbacks
@@ -93,7 +93,7 @@ def _train_internal(params, dtrain,
                 rounds=early_stopping_rounds, maximize=maximize))
         callbacks = callback.CallbackContainer(callbacks, metric=feval)
     else:
-        callbacks = _configure_deprected_callbacks(
+        callbacks = _configure_deprecated_callbacks(
             verbose_eval, early_stopping_rounds, maximize, start_iteration,
             num_boost_round, feval, evals_result, callbacks,
             show_stdv=False, cvfolds=None)
@@ -486,7 +486,7 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None
                 rounds=early_stopping_rounds, maximize=maximize))
         callbacks = callback.CallbackContainer(callbacks, metric=feval, is_cv=True)
     else:
-        callbacks = _configure_deprected_callbacks(
+        callbacks = _configure_deprecated_callbacks(
             verbose_eval, early_stopping_rounds, maximize, 0,
             num_boost_round, feval, None, callbacks,
             show_stdv=show_stdv, cvfolds=cvfolds)

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -2,6 +2,7 @@
 # pylint: disable=too-many-locals, too-many-arguments, invalid-name
 # pylint: disable=too-many-branches, too-many-statements
 """Training Library containing training routines."""
+import warnings
 import numpy as np
 from .core import Booster, XGBoostError
 from .compat import (SKLEARN_INSTALLED, XGBStratifiedKFold)
@@ -13,7 +14,7 @@ def _configure_deprecated_callbacks(
         verbose_eval, early_stopping_rounds, maximize, start_iteration,
         num_boost_round, feval, evals_result, callbacks, show_stdv, cvfolds):
     link = 'https://xgboost.readthedocs.io/en/latest/python/callbacks.html'
-    raise DeprecationWarning(f'Old style callback is deprecated.  See: {link}')
+    warnings.warn(f'Old style callback is deprecated.  See: {link}', DeprecationWarning)
     # Most of legacy advanced options becomes callbacks
     if early_stopping_rounds is not None:
         callbacks.append(callback.early_stop(early_stopping_rounds,

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -461,7 +461,7 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None
     # setup callbacks
     callbacks = [] if callbacks is None else callbacks
     if verbose_eval:
-        callbacks.append(callback.EvaluationMonitor())
+        callbacks.append(callback.EvaluationMonitor(show_stdv=show_stdv))
     if early_stopping_rounds:
         callbacks.append(callback.EarlyStopping(
             rounds=early_stopping_rounds, maximize=maximize))

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -250,6 +250,9 @@ class _PackedBooster:
         for f in self.cvfolds:
             f.bst.set_attr(**kwargs)
 
+    def attr(self, key):
+        return self.cvfolds[0].bst.attr(key)
+
     @property
     def best_iteration(self):
         '''Get best_iteration'''

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -105,7 +105,9 @@ def _train_internal(params, dtrain,
 
     callbacks.after_training(bst)
 
-    evals_result.update(callbacks.history)
+    if evals_result:
+        evals_result.update(callbacks.history)
+
     if bst.attr('best_score') is not None:
         bst.best_score = float(bst.attr('best_score'))
         bst.best_iteration = int(bst.attr('best_iteration'))

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -233,7 +233,7 @@ class CVPack(object):
         return self.bst.eval_set(self.watchlist, iteration, feval)
 
 
-class PackedBooster:
+class _PackedBooster:
     def __init__(self, cvfolds):
         self.cvfolds = cvfolds
 
@@ -468,7 +468,7 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None
     callbacks = callback.CallbackContainer(callbacks, metric=feval, is_cv=True)
     callbacks.before_training(cvfolds)
 
-    booster = PackedBooster(cvfolds)
+    booster = _PackedBooster(cvfolds)
 
     for i in range(num_boost_round):
         if callbacks.before_iteration(booster, i, dtrain, None):

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -26,7 +26,7 @@ def _configure_deprected_callbacks(
     if evals_result is not None:
         callbacks.append(callback.record_evaluation(evals_result))
     callbacks = callback.LegacyCallbacks(
-        callbacks, start_iteration, num_boost_round, evals, feval)
+        callbacks, start_iteration, num_boost_round, feval)
     return callbacks
 
 
@@ -483,6 +483,8 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None
             if isinstance(verbose_eval, int):
                 callbacks.append(callback.print_evaluation(verbose_eval,
                                                            show_stdv=show_stdv))
+        callbacks = callback.LegacyCallbacks(callbacks, 0, num_boost_round, feval,
+                                             cvfolds=cvfolds)
     callbacks.before_training(cvfolds)
 
     booster = _PackedBooster(cvfolds)

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -70,10 +70,10 @@ def _train_internal(params, dtrain,
     if any(is_new_callback) or not callbacks:
         assert all(is_new_callback), "You can't mix two styles of callbacks."
         if verbose_eval:
-            callbacks.append(callback.EvaluationMonitor())
+            callbacks.append(callback.EvaluationMonitor(metric=feval))
         if early_stopping_rounds:
             callbacks.append(callback.EarlyStopping(
-                rounds=early_stopping_rounds))
+                rounds=early_stopping_rounds, metric=feval))
         callbacks = callback.CallbackContainer(callbacks)
     else:
         assert False

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -72,7 +72,8 @@ def _train_internal(params, dtrain,
         if verbose_eval:
             callbacks.append(callback.EvaluationMonitor())
         if early_stopping_rounds:
-            callbacks.append(callback.EarlyStopping)
+            callbacks.append(callback.EarlyStopping(
+                rounds=early_stopping_rounds))
         callbacks = callback.CallbackContainer(callbacks)
     else:
         assert False

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -68,7 +68,7 @@ def _train_internal(params, dtrain,
 
     callbacks.before_training(bst)
     for i in range(start_iteration, num_boost_round):
-        if callbacks.before_iteration(bst, i):
+        if callbacks.before_iteration(bst, i, dtrain, evals):
             break
         # Distributed code: need to resume to this point.
         # Skip the first update if it is a recovery step.
@@ -81,7 +81,7 @@ def _train_internal(params, dtrain,
 
         nboost += 1
         # check evaluation result.
-        if callbacks.after_iteration(bst, i):
+        if callbacks.after_iteration(bst, i, dtrain, evals):
             break
         # do checkpoint after evaluation, in case evaluation also updates
         # booster.

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -41,6 +41,16 @@ def _train_internal(params, dtrain,
     callbacks = [] if callbacks is None else callbacks
     evals = list(evals)
     params = params.copy()
+
+    if isinstance(params, dict) and 'eval_metric' in params \
+       and isinstance(params['eval_metric'], list):
+        params = dict((k, v) for k, v in params.items())
+        eval_metrics = params['eval_metric']
+        params.pop("eval_metric", None)
+        params = list(params.items())
+        for eval_metric in eval_metrics:
+            params += [('eval_metric', eval_metric)]
+
     bst = Booster(params, [dtrain] + [d[0] for d in evals])
     nboost = 0
     num_parallel_tree = 1

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -12,6 +12,8 @@ from . import callback
 def _configure_deprecated_callbacks(
         verbose_eval, early_stopping_rounds, maximize, start_iteration,
         num_boost_round, feval, evals_result, callbacks, show_stdv, cvfolds):
+    link = 'https://xgboost.readthedocs.io/en/latest/python/callbacks.html'
+    raise DeprecationWarning(f'Old style callback is deprecated.  See: {link}')
     # Most of legacy advanced options becomes callbacks
     if early_stopping_rounds is not None:
         callbacks.append(callback.early_stop(early_stopping_rounds,
@@ -85,7 +87,7 @@ def _train_internal(params, dtrain,
     is_new_callback = _is_new_callback(callbacks)
     if is_new_callback:
         assert all(isinstance(c, callback.TrainingCallback)
-                   for c in callbacks), "You can't mix two styles of callbacks."
+                   for c in callbacks), "You can't mix new and old callback styles."
         if verbose_eval:
             callbacks.append(callback.EvaluationMonitor())
         if early_stopping_rounds:
@@ -478,7 +480,7 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None
     is_new_callback = _is_new_callback(callbacks)
     if is_new_callback:
         assert all(isinstance(c, callback.TrainingCallback)
-                   for c in callbacks), "You can't mix two styles of callbacks."
+                   for c in callbacks), "You can't mix new and old callback styles."
         if isinstance(verbose_eval, bool) and verbose_eval:
             callbacks.append(callback.EvaluationMonitor(show_stdv=show_stdv))
         if early_stopping_rounds:

--- a/tests/python-gpu/test_gpu_basic_models.py
+++ b/tests/python-gpu/test_gpu_basic_models.py
@@ -5,12 +5,12 @@ import numpy as np
 import xgboost as xgb
 sys.path.append("tests/python")
 # Don't import the test class, otherwise they will run twice.
-import test_basic_models as test_bm  # noqa
+import test_callback as test_cb  # noqa
 rng = np.random.RandomState(1994)
 
 
 class TestGPUBasicModels(unittest.TestCase):
-    cputest = test_bm.TestModels()
+    cputest = test_cb.TestCallbacks()
 
     def run_cls(self, X, y, deterministic):
         cls = xgb.XGBClassifier(tree_method='gpu_hist',
@@ -36,7 +36,8 @@ class TestGPUBasicModels(unittest.TestCase):
         return hash(model_0), hash(model_1)
 
     def test_eta_decay_gpu_hist(self):
-        self.cputest.run_eta_decay('gpu_hist')
+        self.cputest.run_eta_decay('gpu_hist', True)
+        self.cputest.run_eta_decay('gpu_hist', False)
 
     def test_deterministic_gpu_hist(self):
         kRows = 1000

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -8,7 +8,7 @@ import pytest
 import locale
 import tempfile
 
-dpath = 'demo/data/'
+dpath = os.path.join(tm.PROJECT_ROOT, 'demo/data/')
 dtrain = xgb.DMatrix(dpath + 'agaricus.txt.train')
 dtest = xgb.DMatrix(dpath + 'agaricus.txt.test')
 
@@ -109,84 +109,6 @@ class TestModels(unittest.TestCase):
         for ii in range(len(preds_list)):
             for jj in range(ii + 1, len(preds_list)):
                 assert np.sum(np.abs(preds_list[ii] - preds_list[jj])) > 0
-
-    def run_eta_decay(self, tree_method):
-        watchlist = [(dtest, 'eval'), (dtrain, 'train')]
-        num_round = 4
-
-        # learning_rates as a list
-        # init eta with 0 to check whether learning_rates work
-        param = {'max_depth': 2, 'eta': 0, 'verbosity': 0,
-                 'objective': 'binary:logistic', 'eval_metric': 'error',
-                 'tree_method': tree_method}
-        evals_result = {}
-        bst = xgb.train(param, dtrain, num_round, watchlist,
-                        callbacks=[xgb.callback.reset_learning_rate([
-                            0.8, 0.7, 0.6, 0.5
-                        ])],
-                        evals_result=evals_result)
-        eval_errors_0 = list(map(float, evals_result['eval']['error']))
-        assert isinstance(bst, xgb.core.Booster)
-        # validation error should decrease, if eta > 0
-        assert eval_errors_0[0] > eval_errors_0[-1]
-
-        # init learning_rate with 0 to check whether learning_rates work
-        param = {'max_depth': 2, 'learning_rate': 0, 'verbosity': 0,
-                 'objective': 'binary:logistic', 'eval_metric': 'error',
-                 'tree_method': tree_method}
-        evals_result = {}
-        bst = xgb.train(param, dtrain, num_round, watchlist,
-                        callbacks=[xgb.callback.reset_learning_rate(
-                            [0.8, 0.7, 0.6, 0.5])],
-                        evals_result=evals_result)
-        eval_errors_1 = list(map(float, evals_result['eval']['error']))
-        assert isinstance(bst, xgb.core.Booster)
-        # validation error should decrease, if learning_rate > 0
-        assert eval_errors_1[0] > eval_errors_1[-1]
-
-        # check if learning_rates override default value of eta/learning_rate
-        param = {
-            'max_depth': 2, 'verbosity': 0, 'objective': 'binary:logistic',
-            'eval_metric': 'error', 'tree_method': tree_method
-        }
-        evals_result = {}
-        bst = xgb.train(param, dtrain, num_round, watchlist,
-                        callbacks=[xgb.callback.reset_learning_rate(
-                            [0, 0, 0, 0]
-                        )],
-                        evals_result=evals_result)
-        eval_errors_2 = list(map(float, evals_result['eval']['error']))
-        assert isinstance(bst, xgb.core.Booster)
-        # validation error should not decrease, if eta/learning_rate = 0
-        assert eval_errors_2[0] == eval_errors_2[-1]
-
-        # learning_rates as a customized decay function
-        def eta_decay(ithround, num_boost_round):
-            return num_boost_round / (ithround + 1)
-
-        evals_result = {}
-        bst = xgb.train(param, dtrain, num_round, watchlist,
-                        callbacks=[
-                            xgb.callback.reset_learning_rate(eta_decay)
-                        ],
-                        evals_result=evals_result)
-        eval_errors_3 = list(map(float, evals_result['eval']['error']))
-
-        assert isinstance(bst, xgb.core.Booster)
-
-        assert eval_errors_3[0] == eval_errors_2[0]
-
-        for i in range(1, len(eval_errors_0)):
-            assert eval_errors_3[i] != eval_errors_2[i]
-
-    def test_eta_decay_hist(self):
-        self.run_eta_decay('hist')
-
-    def test_eta_decay_approx(self):
-        self.run_eta_decay('approx')
-
-    def test_eta_decay_exact(self):
-        self.run_eta_decay('exact')
 
     def test_boost_from_prediction(self):
         # Re-construct dtrain here to avoid modification

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -28,7 +28,8 @@ class TestCallbacks(unittest.TestCase):
         D_valid = xgb.DMatrix(self.X_valid, self.y_valid)
         evals_result = {}
         rounds = 10
-        xgb.train({'objective': 'binary:logistic'}, D_train,
+        xgb.train({'objective': 'binary:logistic',
+                   'eval_metric': 'error'}, D_train,
                   evals=[(D_train, 'Train'), (D_valid, 'Valid')],
                   num_boost_round=rounds,
                   evals_result=evals_result,
@@ -43,7 +44,8 @@ class TestCallbacks(unittest.TestCase):
         evals_result = {}
         rounds = 30
         early_stopping_rounds = 5
-        booster = xgb.train({'objective': 'binary:logistic'}, D_train,
+        booster = xgb.train({'objective': 'binary:logistic',
+                             'eval_metric': 'error'}, D_train,
                             evals=[(D_train, 'Train'), (D_valid, 'Valid')],
                             num_boost_round=rounds,
                             evals_result=evals_result,
@@ -57,6 +59,7 @@ class TestCallbacks(unittest.TestCase):
         D_valid = xgb.DMatrix(self.X_valid, self.y_valid)
         early_stopping_rounds = 5
         booster = xgb.train({'objective': 'binary:logistic',
+                             'eval_metric': 'error',
                              'tree_method': 'hist'}, D_train,
                             evals=[(D_train, 'Train'), (D_valid, 'Valid')],
                             feval=tm.eval_error_metric,
@@ -93,7 +96,7 @@ class TestCallbacks(unittest.TestCase):
         cls = xgb.XGBClassifier()
         early_stopping_rounds = 5
         cls.fit(X, y, eval_set=[(X, y)],
-                early_stopping_rounds=early_stopping_rounds)
+                early_stopping_rounds=early_stopping_rounds, eval_metric='error')
         booster = cls.get_booster()
         dump = booster.get_dump(dump_format='json')
         assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
@@ -104,7 +107,8 @@ class TestCallbacks(unittest.TestCase):
         cls = xgb.XGBClassifier()
         early_stopping_rounds = 5
         cls.fit(X, y, eval_set=[(X, y)],
-                early_stopping_rounds=early_stopping_rounds)
+                early_stopping_rounds=early_stopping_rounds,
+                eval_metric=tm.eval_error_metric)
         booster = cls.get_booster()
         dump = booster.get_dump(dump_format='json')
         assert len(dump) - booster.best_iteration == early_stopping_rounds + 1

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -191,15 +191,18 @@ class TestCallbacks(unittest.TestCase):
             assert eval_errors_3[i] != eval_errors_2[i]
 
     def test_eta_decay_hist(self):
-        # self.run_eta_decay('hist', True)
+        with pytest.deprecated_call():
+            self.run_eta_decay('hist', True)
         self.run_eta_decay('hist', False)
 
     def test_eta_decay_approx(self):
-        # self.run_eta_decay('approx', True)
+        with pytest.deprecated_call():
+            self.run_eta_decay('approx', True)
         self.run_eta_decay('approx', False)
 
     def test_eta_decay_exact(self):
-        # self.run_eta_decay('exact', True)
+        with pytest.deprecated_call():
+            self.run_eta_decay('exact', True)
         self.run_eta_decay('exact', False)
 
     def test_check_point(self):
@@ -219,7 +222,7 @@ class TestCallbacks(unittest.TestCase):
                     os.path.join(tmpdir, 'model_' + str(i) + '.json'))
 
             check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
-                                                          rounds=1,
+                                                          iterations=1,
                                                           as_pickle=True,
                                                           name='model')
             xgb.train({'objective': 'binary:logistic'}, m,

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -2,7 +2,6 @@ import xgboost as xgb
 import pytest
 import os
 import testing as tm
-import numpy as np
 import tempfile
 
 
@@ -24,15 +23,6 @@ def test_early_stopping():
     verify_booster_early_stop(booster)
 
 
-def eval_error_metric(label, predt):
-    r = np.zeros(predt.shape)
-    gt = predt > 0.5
-    r[gt] = 1 - label[gt]
-    le = predt <= 0.5
-    r[le] = label[le]
-    return np.sum(r)
-
-
 @pytest.mark.skipif(**tm.no_sklearn())
 def test_early_stopping_custom_eval():
     from sklearn.datasets import load_breast_cancer
@@ -40,6 +30,7 @@ def test_early_stopping_custom_eval():
     m = xgb.DMatrix(X, y)
     booster = xgb.train({'objective': 'binary:logistic'}, m,
                         evals=[(m, 'Train')],
+                        feval=tm.eval_error_metric,
                         num_boost_round=1000,
                         early_stopping_rounds=5,
                         verbose_eval=False)

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -37,90 +37,87 @@ class TestCallbacks(unittest.TestCase):
         assert len(evals_result['Train']['error']) == rounds
         assert len(evals_result['Valid']['error']) == rounds
 
+    def test_early_stopping(self):
+        D_train = xgb.DMatrix(self.X_train, self.y_train)
+        D_valid = xgb.DMatrix(self.X_valid, self.y_valid)
+        evals_result = {}
+        rounds = 30
+        early_stopping_rounds = 5
+        booster = xgb.train({'objective': 'binary:logistic'}, D_train,
+                            evals=[(D_train, 'Train'), (D_valid, 'Valid')],
+                            num_boost_round=rounds,
+                            evals_result=evals_result,
+                            verbose_eval=True,
+                            early_stopping_rounds=early_stopping_rounds)
+        dump = booster.get_dump(dump_format='json')
+        assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
 
-def verify_booster_early_stop(booster):
-    dump = booster.get_dump(dump_format='json')
-    assert len(dump) == 10      # boosted for 10 rounds.
+    def test_check_point(self):
+        from sklearn.datasets import load_breast_cancer
+        X, y = load_breast_cancer(return_X_y=True)
+        m = xgb.DMatrix(X, y)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
+                                                          rounds=1,
+                                                          name='model')
+            xgb.train({'objective': 'binary:logistic'}, m,
+                      num_boost_round=10,
+                      verbose_eval=False,
+                      callbacks=[check_point])
+            for i in range(0, 10):
+                assert os.path.exists(
+                    os.path.join(tmpdir, 'model_' + str(i) + '.json'))
 
-
-@pytest.mark.skipif(**tm.no_sklearn())
-def test_early_stopping():
-    from sklearn.datasets import load_breast_cancer
-    X, y = load_breast_cancer(return_X_y=True)
-    m = xgb.DMatrix(X, y)
-    booster = xgb.train({'objective': 'binary:logistic'}, m,
-                        evals=[(m, 'Train')],
-                        num_boost_round=1000,
-                        early_stopping_rounds=5,
-                        verbose_eval=False)
-    verify_booster_early_stop(booster)
-
-
-@pytest.mark.skipif(**tm.no_sklearn())
-def test_early_stopping_custom_eval():
-    from sklearn.datasets import load_breast_cancer
-    X, y = load_breast_cancer(return_X_y=True)
-    m = xgb.DMatrix(X, y)
-    early_stopping_rounds = 5
-    booster = xgb.train({'objective': 'binary:logistic',
-                         'tree_method': 'hist'}, m,
-                        evals=[(m, 'Train')],
-                        feval=tm.eval_error_metric,
-                        num_boost_round=1000,
-                        early_stopping_rounds=early_stopping_rounds,
-                        verbose_eval=False)
-    dump = booster.get_dump(dump_format='json')
-    assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
-
-
-@pytest.mark.skipif(**tm.no_sklearn())
-def test_early_stopping_skl():
-    from sklearn.datasets import load_breast_cancer
-    X, y = load_breast_cancer(return_X_y=True)
-    cls = xgb.XGBClassifier()
-    cls.fit(X, y, eval_set=[(X, y)], early_stopping_rounds=5)
-    booster = cls.get_booster()
-    verify_booster_early_stop(booster)
+            check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
+                                                          rounds=1,
+                                                          as_pickle=True,
+                                                          name='model')
+            xgb.train({'objective': 'binary:logistic'}, m,
+                      num_boost_round=10,
+                      verbose_eval=False,
+                      callbacks=[check_point])
+            for i in range(0, 10):
+                assert os.path.exists(
+                    os.path.join(tmpdir, 'model_' + str(i) + '.pkl'))
 
 
-@pytest.mark.skipif(**tm.no_sklearn())
-def test_early_stopping_custom_eval_skl():
-    from sklearn.datasets import load_breast_cancer
-    X, y = load_breast_cancer(return_X_y=True)
-    cls = xgb.XGBClassifier()
-    cls.fit(X, y, eval_set=[(X, y)], early_stopping_rounds=5)
-    booster = cls.get_booster()
-    verify_booster_early_stop(booster)
+
+# @pytest.mark.skipif(**tm.no_sklearn())
+# def test_early_stopping_custom_eval():
+#     from sklearn.datasets import load_breast_cancer
+#     X, y = load_breast_cancer(return_X_y=True)
+#     m = xgb.DMatrix(X, y)
+#     early_stopping_rounds = 5
+#     booster = xgb.train({'objective': 'binary:logistic',
+#                          'tree_method': 'hist'}, m,
+#                         evals=[(m, 'Train')],
+#                         feval=tm.eval_error_metric,
+#                         num_boost_round=1000,
+#                         early_stopping_rounds=early_stopping_rounds,
+#                         verbose_eval=False)
+#     dump = booster.get_dump(dump_format='json')
+#     assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
 
 
-def test_learning_rate_scheduler():
-    pass
+# @pytest.mark.skipif(**tm.no_sklearn())
+# def test_early_stopping_skl():
+#     from sklearn.datasets import load_breast_cancer
+#     X, y = load_breast_cancer(return_X_y=True)
+#     cls = xgb.XGBClassifier()
+#     cls.fit(X, y, eval_set=[(X, y)], early_stopping_rounds=5)
+#     booster = cls.get_booster()
+#     verify_booster_early_stop(booster)
 
 
-def test_check_point():
-    from sklearn.datasets import load_breast_cancer
-    X, y = load_breast_cancer(return_X_y=True)
-    m = xgb.DMatrix(X, y)
-    with tempfile.TemporaryDirectory() as tmpdir:
-        check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
-                                                      rounds=1,
-                                                      name='model')
-        xgb.train({'objective': 'binary:logistic'}, m,
-                  num_boost_round=10,
-                  verbose_eval=False,
-                  callbacks=[check_point])
-        for i in range(0, 10):
-            assert os.path.exists(
-                os.path.join(tmpdir, 'model_' + str(i) + '.json'))
+# @pytest.mark.skipif(**tm.no_sklearn())
+# def test_early_stopping_custom_eval_skl():
+#     from sklearn.datasets import load_breast_cancer
+#     X, y = load_breast_cancer(return_X_y=True)
+#     cls = xgb.XGBClassifier()
+#     cls.fit(X, y, eval_set=[(X, y)], early_stopping_rounds=5)
+#     booster = cls.get_booster()
+#     verify_booster_early_stop(booster)
 
-        check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
-                                                      rounds=1,
-                                                      as_pickle=True,
-                                                      name='model')
-        xgb.train({'objective': 'binary:logistic'}, m,
-                  num_boost_round=10,
-                  verbose_eval=False,
-                  callbacks=[check_point])
-        for i in range(0, 10):
-            assert os.path.exists(
-                os.path.join(tmpdir, 'model_' + str(i) + '.pkl'))
+
+# def test_learning_rate_scheduler():
+#     pass

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -71,7 +71,6 @@ class TestCallbacks(unittest.TestCase):
         D_valid = xgb.DMatrix(self.X_valid, self.y_valid)
         early_stopping_rounds = 5
         early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
-                                                metric=tm.eval_error_metric,
                                                 metric_name='PyError',
                                                 data_name='Train')
         # Specify which dataset and which metric should be used for early stopping.
@@ -80,6 +79,7 @@ class TestCallbacks(unittest.TestCase):
              'eval_metric': ['error', 'rmse'],
              'tree_method': 'hist'}, D_train,
             evals=[(D_train, 'Train'), (D_valid, 'Valid')],
+            feval=tm.eval_error_metric,
             num_boost_round=1000,
             callbacks=[early_stop],
             verbose_eval=False)

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -28,13 +28,16 @@ def test_early_stopping_custom_eval():
     from sklearn.datasets import load_breast_cancer
     X, y = load_breast_cancer(return_X_y=True)
     m = xgb.DMatrix(X, y)
-    booster = xgb.train({'objective': 'binary:logistic'}, m,
+    early_stopping_rounds = 5
+    booster = xgb.train({'objective': 'binary:logistic',
+                         'tree_method': 'hist'}, m,
                         evals=[(m, 'Train')],
                         feval=tm.eval_error_metric,
                         num_boost_round=1000,
-                        early_stopping_rounds=5,
+                        early_stopping_rounds=early_stopping_rounds,
                         verbose_eval=False)
-    verify_booster_early_stop(booster)
+    dump = booster.get_dump(dump_format='json')
+    assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
 
 
 @pytest.mark.skipif(**tm.no_sklearn())

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -74,7 +74,7 @@ class TestCallbacks(unittest.TestCase):
         D_valid = xgb.DMatrix(self.X_valid, self.y_valid)
         early_stopping_rounds = 5
         early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
-                                                metric_name='PyError',
+                                                metric_name='CustomErr',
                                                 data_name='Train')
         # Specify which dataset and which metric should be used for early stopping.
         booster = xgb.train(
@@ -88,7 +88,7 @@ class TestCallbacks(unittest.TestCase):
             verbose_eval=False)
         dump = booster.get_dump(dump_format='json')
         assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
-        assert len(early_stop.stopping_history['Train']['PyError']) == len(dump)
+        assert len(early_stop.stopping_history['Train']['CustomErr']) == len(dump)
 
     def test_early_stopping_skl(self):
         from sklearn.datasets import load_breast_cancer

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -1,8 +1,41 @@
 import xgboost as xgb
+import unittest
 import pytest
 import os
 import testing as tm
 import tempfile
+
+# We use the dataset for tests.
+pytestmark = pytest.mark.skipif(**tm.no_sklearn())
+
+
+class TestCallbacks(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from sklearn.datasets import load_breast_cancer
+        X, y = load_breast_cancer(return_X_y=True)
+        cls.X = X
+        cls.y = y
+
+        split = int(X.shape[0]*0.8)
+        cls.X_train = X[: split, ...]
+        cls.y_train = y[: split, ...]
+        cls.X_valid = X[split:, ...]
+        cls.y_valid = y[split:, ...]
+
+    def test_evaluation_monitor(self):
+        D_train = xgb.DMatrix(self.X_train, self.y_train)
+        D_valid = xgb.DMatrix(self.X_valid, self.y_valid)
+        evals_result = {}
+        rounds = 10
+        xgb.train({'objective': 'binary:logistic'}, D_train,
+                  evals=[(D_train, 'Train'), (D_valid, 'Valid')],
+                  num_boost_round=rounds,
+                  evals_result=evals_result,
+                  verbose_eval=True)
+        print('evals_result:', evals_result)
+        assert len(evals_result['Train']['error']) == rounds
+        assert len(evals_result['Valid']['error']) == rounds
 
 
 def verify_booster_early_stop(booster):

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -208,7 +208,7 @@ class TestCallbacks(unittest.TestCase):
         m = xgb.DMatrix(X, y)
         with tempfile.TemporaryDirectory() as tmpdir:
             check_point = xgb.callback.TrainingCheckPoint(directory=tmpdir,
-                                                          rounds=1,
+                                                          iterations=1,
                                                           name='model')
             xgb.train({'objective': 'binary:logistic'}, m,
                       num_boost_round=10,

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -66,6 +66,28 @@ class TestCallbacks(unittest.TestCase):
         dump = booster.get_dump(dump_format='json')
         assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
 
+    def test_early_stopping_skl(self):
+        from sklearn.datasets import load_breast_cancer
+        X, y = load_breast_cancer(return_X_y=True)
+        cls = xgb.XGBClassifier()
+        early_stopping_rounds = 5
+        cls.fit(X, y, eval_set=[(X, y)],
+                early_stopping_rounds=early_stopping_rounds)
+        booster = cls.get_booster()
+        dump = booster.get_dump(dump_format='json')
+        assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
+
+    def test_early_stopping_custom_eval_skl(self):
+        from sklearn.datasets import load_breast_cancer
+        X, y = load_breast_cancer(return_X_y=True)
+        cls = xgb.XGBClassifier()
+        early_stopping_rounds = 5
+        cls.fit(X, y, eval_set=[(X, y)],
+                early_stopping_rounds=early_stopping_rounds)
+        booster = cls.get_booster()
+        dump = booster.get_dump(dump_format='json')
+        assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
+
     def test_check_point(self):
         from sklearn.datasets import load_breast_cancer
         X, y = load_breast_cancer(return_X_y=True)
@@ -93,31 +115,6 @@ class TestCallbacks(unittest.TestCase):
             for i in range(0, 10):
                 assert os.path.exists(
                     os.path.join(tmpdir, 'model_' + str(i) + '.pkl'))
-
-
-
-# @pytest.mark.skipif(**tm.no_sklearn())
-
-
-# @pytest.mark.skipif(**tm.no_sklearn())
-# def test_early_stopping_skl():
-#     from sklearn.datasets import load_breast_cancer
-#     X, y = load_breast_cancer(return_X_y=True)
-#     cls = xgb.XGBClassifier()
-#     cls.fit(X, y, eval_set=[(X, y)], early_stopping_rounds=5)
-#     booster = cls.get_booster()
-#     verify_booster_early_stop(booster)
-
-
-# @pytest.mark.skipif(**tm.no_sklearn())
-# def test_early_stopping_custom_eval_skl():
-#     from sklearn.datasets import load_breast_cancer
-#     X, y = load_breast_cancer(return_X_y=True)
-#     cls = xgb.XGBClassifier()
-#     cls.fit(X, y, eval_set=[(X, y)], early_stopping_rounds=5)
-#     booster = cls.get_booster()
-#     verify_booster_early_stop(booster)
-
 
 # def test_learning_rate_scheduler():
 #     pass

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -1,0 +1,64 @@
+import xgboost as xgb
+import pytest
+import testing as tm
+import numpy as np
+
+
+def verify_booster_early_stop(booster):
+    dump = booster.get_dump(dump_format='json')
+    assert len(dump) == 10      # boosted for 10 rounds.
+
+
+@pytest.mark.skipif(**tm.no_sklearn())
+def test_early_stopping():
+    from sklearn.datasets import load_breast_cancer
+    X, y = load_breast_cancer(return_X_y=True)
+    m = xgb.DMatrix(X, y)
+    booster = xgb.train({'objective': 'binary:logistic'}, m,
+                        evals=[(m, 'Train')],
+                        num_boost_round=1000,
+                        early_stopping_rounds=5,
+                        verbose_eval=False)
+    verify_booster_early_stop(booster)
+
+
+def eval_error_metric(label, predt):
+    r = np.zeros(predt.shape)
+    gt = predt > 0.5
+    r[gt] = 1 - label[gt]
+    le = predt <= 0.5
+    r[le] = label[le]
+    return np.sum(r)
+
+
+@pytest.mark.skipif(**tm.no_sklearn())
+def test_early_stopping_custom_eval():
+    from sklearn.datasets import load_breast_cancer
+    X, y = load_breast_cancer(return_X_y=True)
+    m = xgb.DMatrix(X, y)
+    booster = xgb.train({'objective': 'binary:logistic'}, m,
+                        evals=[(m, 'Train')],
+                        num_boost_round=1000,
+                        early_stopping_rounds=5,
+                        verbose_eval=False)
+    verify_booster_early_stop(booster)
+
+
+@pytest.mark.skipif(**tm.no_sklearn())
+def test_early_stopping_skl():
+    from sklearn.datasets import load_breast_cancer
+    X, y = load_breast_cancer(return_X_y=True)
+    cls = xgb.XGBClassifier()
+    cls.fit(X, y, eval_set=[(X, y)], early_stopping_rounds=5)
+    booster = cls.get_booster()
+    verify_booster_early_stop(booster)
+
+
+@pytest.mark.skipif(**tm.no_sklearn())
+def test_early_stopping_custom_eval_skl():
+    from sklearn.datasets import load_breast_cancer
+    X, y = load_breast_cancer(return_X_y=True)
+    cls = xgb.XGBClassifier()
+    cls.fit(X, y, eval_set=[(X, y)], early_stopping_rounds=5)
+    booster = cls.get_booster()
+    verify_booster_early_stop(booster)

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -52,6 +52,20 @@ class TestCallbacks(unittest.TestCase):
         dump = booster.get_dump(dump_format='json')
         assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
 
+    def test_early_stopping_custom_eval(self):
+        D_train = xgb.DMatrix(self.X_train, self.y_train)
+        D_valid = xgb.DMatrix(self.X_valid, self.y_valid)
+        early_stopping_rounds = 5
+        booster = xgb.train({'objective': 'binary:logistic',
+                             'tree_method': 'hist'}, D_train,
+                            evals=[(D_train, 'Train'), (D_valid, 'Valid')],
+                            feval=tm.eval_error_metric,
+                            num_boost_round=1000,
+                            early_stopping_rounds=early_stopping_rounds,
+                            verbose_eval=False)
+        dump = booster.get_dump(dump_format='json')
+        assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
+
     def test_check_point(self):
         from sklearn.datasets import load_breast_cancer
         X, y = load_breast_cancer(return_X_y=True)
@@ -83,20 +97,6 @@ class TestCallbacks(unittest.TestCase):
 
 
 # @pytest.mark.skipif(**tm.no_sklearn())
-# def test_early_stopping_custom_eval():
-#     from sklearn.datasets import load_breast_cancer
-#     X, y = load_breast_cancer(return_X_y=True)
-#     m = xgb.DMatrix(X, y)
-#     early_stopping_rounds = 5
-#     booster = xgb.train({'objective': 'binary:logistic',
-#                          'tree_method': 'hist'}, m,
-#                         evals=[(m, 'Train')],
-#                         feval=tm.eval_error_metric,
-#                         num_boost_round=1000,
-#                         early_stopping_rounds=early_stopping_rounds,
-#                         verbose_eval=False)
-#     dump = booster.get_dump(dump_format='json')
-#     assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
 
 
 # @pytest.mark.skipif(**tm.no_sklearn())

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -210,7 +210,7 @@ class TestCallbacks(unittest.TestCase):
                       num_boost_round=10,
                       verbose_eval=False,
                       callbacks=[check_point])
-            for i in range(0, 10):
+            for i in range(1, 10):
                 assert os.path.exists(
                     os.path.join(tmpdir, 'model_' + str(i) + '.json'))
 
@@ -222,6 +222,6 @@ class TestCallbacks(unittest.TestCase):
                       num_boost_round=10,
                       verbose_eval=False,
                       callbacks=[check_point])
-            for i in range(0, 10):
+            for i in range(1, 10):
                 assert os.path.exists(
                     os.path.join(tmpdir, 'model_' + str(i) + '.pkl'))

--- a/tests/python/test_demos.py
+++ b/tests/python/test_demos.py
@@ -119,7 +119,7 @@ def test_aft_demo():
     os.remove('aft_model.json')
 
 
-def test_callbacks():
+def test_callbacks_demo():
     script = os.path.join(PYTHON_DEMO_DIR, 'callbacks.py')
     cmd = ['python', script, '--plot=0']
     subprocess.check_call(cmd)

--- a/tests/python/test_demos.py
+++ b/tests/python/test_demos.py
@@ -119,6 +119,12 @@ def test_aft_demo():
     os.remove('aft_model.json')
 
 
+def test_callbacks():
+    script = os.path.join(PYTHON_DEMO_DIR, 'callbacks.py')
+    cmd = ['python', script, '--plot=0']
+    subprocess.check_call(cmd)
+
+
 # gpu_acceleration is not tested due to covertype dataset is being too huge.
 # gamma regression is not tested as it requires running a R script first.
 # aft viz is not tested due to ploting is not controled

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -667,14 +667,17 @@ class TestWithDask:
         X, y = load_breast_cancer(return_X_y=True)
         X, y = da.from_array(X), da.from_array(y)
         m = xgb.dask.DaskDMatrix(client, X, y)
-        booster = xgb.dask.train(client, {'objective': 'binary:logistic',
-                                          'tree_method': 'hist'}, m,
-                                 evals=[(m, 'Train')],
-                                 feval=tm.eval_error_metric,
-                                 num_boost_round=1000,
-                                 early_stopping_rounds=5)['booster']
+        early_stopping_rounds = 5
+        booster = xgb.dask.train(
+            client, {'objective': 'binary:logistic',
+                     'tree_method': 'hist'}, m,
+            evals=[(m, 'Train')],
+            feval=tm.eval_error_metric,
+            num_boost_round=1000,
+            early_stopping_rounds=early_stopping_rounds)['booster']
         assert hasattr(booster, 'best_score')
-        assert booster.best_iteration == 10
+        dump = booster.get_dump(dump_format='json')
+        assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
 
     def run_quantile(self, name):
         if sys.platform.startswith("win"):

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -715,6 +715,7 @@ class TestDaskCallbacks:
         X, y = da.from_array(X), da.from_array(y)
         m = xgb.dask.DaskDMatrix(client, X, y)
         booster = xgb.dask.train(client, {'objective': 'binary:logistic',
+                                          'eval_metric': 'error',
                                           'tree_method': 'hist'}, m,
                                  evals=[(m, 'Train')],
                                  num_boost_round=1000,
@@ -731,6 +732,7 @@ class TestDaskCallbacks:
         early_stopping_rounds = 5
         booster = xgb.dask.train(
             client, {'objective': 'binary:logistic',
+                     'eval_metric': 'error',
                      'tree_method': 'hist'}, m,
             evals=[(m, 'Train')],
             feval=tm.eval_error_metric,

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -648,6 +648,16 @@ class TestWithDask:
     def test_approx(self, client, params, num_rounds, dataset):
         self.run_updater_test(client, params, num_rounds, dataset, 'approx')
 
+    def test_early_stopping(self, client):
+        from sklearn.datasets import load_breast_cancer
+        X, y = load_breast_cancer(return_X_y=True)
+        m = xgb.dask.DaskDMatrix(X, y)
+        booster = xgb.dask.train({'objective': 'binary:logistic'}, m,
+                                 evals=[(m, 'Train')],
+                                 num_boost_round=1000,
+                                 early_stopping_rounds=5)
+        assert hasattr(booster, 'best_score')
+
     def run_quantile(self, name):
         if sys.platform.startswith("win"):
             pytest.skip("Skipping dask tests on Windows")

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -661,6 +661,21 @@ class TestWithDask:
         assert hasattr(booster, 'best_score')
         assert booster.best_iteration == 10
 
+    @pytest.mark.skipif(**tm.no_sklearn())
+    def test_early_stopping_custom_eval(self, client):
+        from sklearn.datasets import load_breast_cancer
+        X, y = load_breast_cancer(return_X_y=True)
+        X, y = da.from_array(X), da.from_array(y)
+        m = xgb.dask.DaskDMatrix(client, X, y)
+        booster = xgb.dask.train(client, {'objective': 'binary:logistic',
+                                          'tree_method': 'hist'}, m,
+                                 evals=[(m, 'Train')],
+                                 feval=tm.eval_error_metric,
+                                 num_boost_round=1000,
+                                 early_stopping_rounds=5)['booster']
+        assert hasattr(booster, 'best_score')
+        assert booster.best_iteration == 10
+
     def run_quantile(self, name):
         if sys.platform.startswith("win"):
             pytest.skip("Skipping dask tests on Windows")

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -328,7 +328,7 @@ def test_sklearn_grid_search():
             reg.client = client
             model = GridSearchCV(reg, {'max_depth': [2, 4],
                                        'n_estimators': [5, 10]},
-                                 cv=2, verbose=1, iid=True)
+                                 cv=2, verbose=1)
             model.fit(X, y)
             # Expect unique results for each parameter value This confirms
             # sklearn is able to successfully update the parameter
@@ -714,14 +714,17 @@ class TestDaskCallbacks:
         X, y = load_breast_cancer(return_X_y=True)
         X, y = da.from_array(X), da.from_array(y)
         m = xgb.dask.DaskDMatrix(client, X, y)
+        early_stopping_rounds = 5
         booster = xgb.dask.train(client, {'objective': 'binary:logistic',
                                           'eval_metric': 'error',
                                           'tree_method': 'hist'}, m,
                                  evals=[(m, 'Train')],
                                  num_boost_round=1000,
-                                 early_stopping_rounds=5)['booster']
+                                 early_stopping_rounds=early_stopping_rounds)['booster']
         assert hasattr(booster, 'best_score')
         assert booster.best_iteration == 10
+        dump = booster.get_dump(dump_format='json')
+        assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
 
     @pytest.mark.skipif(**tm.no_sklearn())
     def test_early_stopping_custom_eval(self, client):

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -651,12 +651,15 @@ class TestWithDask:
     def test_early_stopping(self, client):
         from sklearn.datasets import load_breast_cancer
         X, y = load_breast_cancer(return_X_y=True)
-        m = xgb.dask.DaskDMatrix(X, y)
-        booster = xgb.dask.train({'objective': 'binary:logistic'}, m,
+        X, y = da.from_array(X), da.from_array(y)
+        m = xgb.dask.DaskDMatrix(client, X, y)
+        booster = xgb.dask.train(client, {'objective': 'binary:logistic',
+                                          'tree_method': 'hist'}, m,
                                  evals=[(m, 'Train')],
                                  num_boost_round=1000,
-                                 early_stopping_rounds=5)
+                                 early_stopping_rounds=5)['booster']
         assert hasattr(booster, 'best_score')
+        assert booster.best_iteration == 10
 
     def run_quantile(self, name):
         if sys.platform.startswith("win"):

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -247,7 +247,7 @@ def eval_error_metric(predt, dtrain: xgb.DMatrix):
     r[gt] = 1 - label[gt]
     le = predt <= 0.5
     r[le] = label[le]
-    return 'PyError', np.sum(r)
+    return 'CustomErr', np.sum(r)
 
 
 CURDIR = os.path.normpath(os.path.abspath(os.path.dirname(__file__)))

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -240,6 +240,16 @@ def non_increasing(L, tolerance=1e-4):
     return all((y - x) < tolerance for x, y in zip(L, L[1:]))
 
 
+def eval_error_metric(predt: np.ndarray, dtrain: xgb.DMatrix):
+    label = dtrain.get_label()
+    r = np.zeros(predt.shape)
+    gt = predt > 0.5
+    r[gt] = 1 - label[gt]
+    le = predt <= 0.5
+    r[le] = label[le]
+    return 'PyError', np.sum(r)
+
+
 CURDIR = os.path.normpath(os.path.abspath(os.path.dirname(__file__)))
 PROJECT_ROOT = os.path.normpath(
     os.path.join(CURDIR, os.path.pardir, os.path.pardir))

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -240,7 +240,7 @@ def non_increasing(L, tolerance=1e-4):
     return all((y - x) < tolerance for x, y in zip(L, L[1:]))
 
 
-def eval_error_metric(predt: np.ndarray, dtrain: xgb.DMatrix):
+def eval_error_metric(predt, dtrain: xgb.DMatrix):
     label = dtrain.get_label()
     r = np.zeros(predt.shape)
     gt = predt > 0.5


### PR DESCRIPTION
This PR adds a new callback function interface for Python, also a new type of callback for checkpointing is added.

Please see documentation and demo for details.  I added a demo for plotting animated evaluation scores, try it out. ;-)

Related https://github.com/dmlc/xgboost/pull/5612 I haven't made the parameter to dask.  The PR is already huge as it is.
Related https://github.com/dmlc/xgboost/issues/3822 this is only for Python.  Other language bindings are not supported.
Close https://github.com/dmlc/xgboost/issues/4955
Close https://github.com/dmlc/xgboost/issues/5495 now we can use early stopping on dask.
