### PR TITLE
[jvm-packages] Fix build for JVM packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -423,10 +423,7 @@ def DeployJVMPackages(args) {
     if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('release')) {
       echo 'Deploying to xgboost-maven-repo S3 repo...'
       sh """
-      ${dockerRun} jvm docker tests/ci_build/deploy_jvm_packages.sh ${args.spark_version} 0
-      """
-      sh """
-      ${dockerRun} jvm_gpu_build docker --build-arg CUDA_VERSION_ARG=10.0 tests/ci_build/deploy_jvm_packages.sh ${args.spark_version} 1
+      ${dockerRun} jvm_gpu_build docker --build-arg CUDA_VERSION_ARG=10.0 tests/ci_build/deploy_jvm_packages.sh ${args.spark_version}
       """
     }
     deleteDir()

--- a/jvm-packages/xgboost4j-gpu/src
+++ b/jvm-packages/xgboost4j-gpu/src
@@ -1,0 +1,1 @@
+../xgboost4j/src/

--- a/jvm-packages/xgboost4j-spark-gpu/src
+++ b/jvm-packages/xgboost4j-spark-gpu/src
@@ -1,0 +1,1 @@
+../xgboost4j-spark/src/

--- a/jvm-packages/xgboost4j/pom.xml
+++ b/jvm-packages/xgboost4j/pom.xml
@@ -86,8 +86,6 @@
                             <argument>create_jni.py</argument>
                             <argument>--log-capi-invocation</argument>
                             <argument>${log.capi.invocation}</argument>
-                            <argument>--use-cuda</argument>
-                            <argument>${use.cuda}</argument>
                           </arguments>
                           <workingDirectory>${user.dir}</workingDirectory>
                       </configuration>

--- a/tests/ci_build/deploy_jvm_packages.sh
+++ b/tests/ci_build/deploy_jvm_packages.sh
@@ -3,13 +3,12 @@
 set -e
 set -x
 
-if [ $# -ne 2 ]; then
-  echo "Usage: $0 [spark version] [build_gpu? 0 or 1]"
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 [spark version]"
   exit 1
 fi
 
 spark_version=$1
-build_gpu=$2
 
 # Initialize local Maven repository
 ./tests/ci_build/initialize_maven.sh
@@ -20,15 +19,7 @@ rm -rf ../build/
 
 # Re-build package without Mock Rabit
 # Deploy to S3 bucket xgboost-maven-repo
-if [[ "$build_gpu" == "0" ]]
-then
-  # Build CPU artifact
-  mvn --no-transfer-progress package deploy -P release-to-s3 -Dspark.version=${spark_version} -DskipTests
-else
-  # Build GPU artifact
-  sed -i -e 's/<artifactId>xgboost\(.*\)_\(.*\)<\/artifactId>/<artifactId>xgboost\1-gpu_\2<\/artifactId>/' $(find . -name pom.xml)
-  mvn --no-transfer-progress package deploy -Duse.cuda=ON -P release-to-s3 -Dspark.version=${spark_version} -DskipTests
-fi
+mvn --no-transfer-progress package deploy -Duse.cuda=ON -P release-to-s3 -Dspark.version=${spark_version} -DskipTests
 
 set +x
 set +e


### PR DESCRIPTION
* Fix the error
```
[WARNING] JAR will be empty - no content was marked for inclusion!
Building jar: /workspace/jvm-packages/xgboost4j-gpu/target/xgboost4j-gpu_2.12-1.3.0-SNAPSHOT.jar
...
Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:3.0.2:jar (default-jar) on project
xgboost4j-gpu_2.12: You have to use a classifier to attach supplemental artifacts to the project instead of
replacing them
```
by adding the symlink for the source in `xgboost4j-gpu` directory. 
* Ensure that a single build command (`mvn package`) can build `xgboost4j` and `xgboost4j-gpu` simultaneously, with `xgboost4j` having CPU code and `xgboost4j-gpu` having GPU code. 

* Fix SNAPSHOT build on the `master` branch.

@wbo4958 @CodingCat Can you review?