### PR TITLE
Add info about OS non-determinism to FAQs

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -75,18 +75,20 @@ Different training results between different Operating Systems
 **************************************************************
 Even if you set all seeds and do single-threading training, you will notice that training results will diff between Mac OS and Linux.
 Here is an example in python:
-```
-# Install python dependencies:
-pip3 install pandas sklearn xgboost
+.. code-block:: bash
+  # Install python dependencies:
+  pip3 install pandas sklearn xgboost
 
-# Script for non-deterministic mac-linux results:
-python3 -c "import os; import pandas as pd; from xgboost import XGBClassifier; url = 'https://raw.githubusercontent.com/jbrownlee/Datasets/master/pima-indians-diabetes.data.csv' ; dta = pd.read_csv(url, header=None) ; y = dta.pop(dta.columns[-1]) ; os.environ['OMP_NUM_THREADS'] = '1' ; xgb = XGBClassifier(random_state=42, n_estimators=2, seed=1, nthread=1, colsample_bytree=.25) ; xgb.fit(dta, y) ; [print(line[0]) for line in xgb.predict_proba(dta)]"
-```
+.. code-block:: bash
+  # Script for non-deterministic mac-linux results:
+  python3 -c "import os; import pandas as pd; from xgboost import XGBClassifier; url = 'https://raw.githubusercontent.com/jbrownlee/Datasets/master/pima-indians-diabetes.data.csv' ; dta = pd.read_csv(url, header=None) ; y = dta.pop(dta.columns[-1]) ; os.environ['OMP_NUM_THREADS'] = '1' ; xgb = XGBClassifier(random_state=42, n_estimators=2, seed=1, nthread=1, colsample_bytree=.25) ; xgb.fit(dta, y) ; [print(line[0]) for line in xgb.predict_proba(dta)]"
+
 If you want to make your training to be deterministic across multiple systems, set the parameter `colsample_bytree` to 1.0 :
-```
-# Script for deterministic mac-linux results:
-python3 -c "import os; import pandas as pd; from xgboost import XGBClassifier; url = 'https://raw.githubusercontent.com/jbrownlee/Datasets/master/pima-indians-diabetes.data.csv' ; dta = pd.read_csv(url, header=None) ; y = dta.pop(dta.columns[-1]) ; os.environ['OMP_NUM_THREADS'] = '1' ; xgb = XGBClassifier(random_state=42, n_estimators=2, seed=1, nthread=1, colsample_bytree=1) ; xgb.fit(dta, y) ; [print(line[0]) for line in xgb.predict_proba(dta)]"
-```
+
+.. code-block:: bash
+  # Script for deterministic mac-linux results:
+  python3 -c "import os; import pandas as pd; from xgboost import XGBClassifier; url = 'https://raw.githubusercontent.com/jbrownlee/Datasets/master/pima-indians-diabetes.data.csv' ; dta = pd.read_csv(url, header=None) ; y = dta.pop(dta.columns[-1]) ; os.environ['OMP_NUM_THREADS'] = '1' ; xgb = XGBClassifier(random_state=42, n_estimators=2, seed=1, nthread=1, colsample_bytree=1) ; xgb.fit(dta, y) ; [print(line[0]) for line in xgb.predict_proba(dta)]"
+
 This is related to `this issue in XGBoost <https://github.com/dmlc/xgboost/issues/310>`_.
 
 **********************************************************

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -74,8 +74,20 @@ Though the general accuracy will usually remain the same.
 Different training results between different Operating Systems
 **************************************************************
 Even if you set all seeds and do single-threading training, you will notice that training results will diff between Mac OS and Linux.
-If you want to make your training to be deterministic across multiple systems, set the parameter `colsample_bytree` to 1.0 .
-This is related to `this issue in XGBoost <https://github.com/dmlc/rabit>`_.
+Here is an example in python:
+```
+# Install python dependencies:
+pip3 install pandas sklearn xgboost
+
+# Script for non-deterministic mac-linux results:
+python3 -c "import os; import pandas as pd; from xgboost import XGBClassifier; url = 'https://raw.githubusercontent.com/jbrownlee/Datasets/master/pima-indians-diabetes.data.csv' ; dta = pd.read_csv(url, header=None) ; y = dta.pop(dta.columns[-1]) ; os.environ['OMP_NUM_THREADS'] = '1' ; xgb = XGBClassifier(random_state=42, n_estimators=2, seed=1, nthread=1, colsample_bytree=.25) ; xgb.fit(dta, y) ; [print(line[0]) for line in xgb.predict_proba(dta)]"
+```
+If you want to make your training to be deterministic across multiple systems, set the parameter `colsample_bytree` to 1.0 :
+```
+# Script for deterministic mac-linux results:
+python3 -c "import os; import pandas as pd; from xgboost import XGBClassifier; url = 'https://raw.githubusercontent.com/jbrownlee/Datasets/master/pima-indians-diabetes.data.csv' ; dta = pd.read_csv(url, header=None) ; y = dta.pop(dta.columns[-1]) ; os.environ['OMP_NUM_THREADS'] = '1' ; xgb = XGBClassifier(random_state=42, n_estimators=2, seed=1, nthread=1, colsample_bytree=1) ; xgb.fit(dta, y) ; [print(line[0]) for line in xgb.predict_proba(dta)]"
+```
+This is related to `this issue in XGBoost <https://github.com/dmlc/xgboost/issues/310>`_.
 
 **********************************************************
 Why do I see different results with sparse and dense data?

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -70,6 +70,12 @@ Slightly different result between runs
 This could happen, due to non-determinism in floating point summation order and multi-threading.
 Though the general accuracy will usually remain the same.
 
+*************************************************************
+Slightly different result between different Operating Systems
+*************************************************************
+Even if you set all seeds and do single-threading training, you will notice that training results will diff between Mac OS and Linux.
+If you want to make your training to be deterministic across multiple systems, set the parameter `colsample_bytree` to 1.0 
+
 **********************************************************
 Why do I see different results with sparse and dense data?
 **********************************************************

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -70,11 +70,12 @@ Slightly different result between runs
 This could happen, due to non-determinism in floating point summation order and multi-threading.
 Though the general accuracy will usually remain the same.
 
-*************************************************************
-Slightly different result between different Operating Systems
-*************************************************************
+**************************************************************
+Different training results between different Operating Systems
+**************************************************************
 Even if you set all seeds and do single-threading training, you will notice that training results will diff between Mac OS and Linux.
-If you want to make your training to be deterministic across multiple systems, set the parameter `colsample_bytree` to 1.0 
+If you want to make your training to be deterministic across multiple systems, set the parameter `colsample_bytree` to 1.0 .
+This is related to `this issue in XGBoost <https://github.com/dmlc/rabit>`_.
 
 **********************************************************
 Why do I see different results with sparse and dense data?

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -70,9 +70,9 @@ Slightly different result between runs
 This could happen, due to non-determinism in floating point summation order and multi-threading.
 Though the general accuracy will usually remain the same.
 
-**************************************************************
-Different training results between different Operating Systems
-**************************************************************
+****************************************************
+Different training results between Operating Systems
+****************************************************
 Even if you set all seeds and do single-threading training, you will notice that training results will diff between Mac OS and Linux.
 Here is an example in python:
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -75,17 +75,21 @@ Different training results between different Operating Systems
 **************************************************************
 Even if you set all seeds and do single-threading training, you will notice that training results will diff between Mac OS and Linux.
 Here is an example in python:
+
 .. code-block:: bash
+
   # Install python dependencies:
   pip3 install pandas sklearn xgboost
 
 .. code-block:: bash
+
   # Script for non-deterministic mac-linux results:
   python3 -c "import os; import pandas as pd; from xgboost import XGBClassifier; url = 'https://raw.githubusercontent.com/jbrownlee/Datasets/master/pima-indians-diabetes.data.csv' ; dta = pd.read_csv(url, header=None) ; y = dta.pop(dta.columns[-1]) ; os.environ['OMP_NUM_THREADS'] = '1' ; xgb = XGBClassifier(random_state=42, n_estimators=2, seed=1, nthread=1, colsample_bytree=.25) ; xgb.fit(dta, y) ; [print(line[0]) for line in xgb.predict_proba(dta)]"
 
 If you want to make your training to be deterministic across multiple systems, set the parameter `colsample_bytree` to 1.0 :
 
 .. code-block:: bash
+
   # Script for deterministic mac-linux results:
   python3 -c "import os; import pandas as pd; from xgboost import XGBClassifier; url = 'https://raw.githubusercontent.com/jbrownlee/Datasets/master/pima-indians-diabetes.data.csv' ; dta = pd.read_csv(url, header=None) ; y = dta.pop(dta.columns[-1]) ; os.environ['OMP_NUM_THREADS'] = '1' ; xgb = XGBClassifier(random_state=42, n_estimators=2, seed=1, nthread=1, colsample_bytree=1) ; xgb.fit(dta, y) ; [print(line[0]) for line in xgb.predict_proba(dta)]"
 


### PR DESCRIPTION
This PR adds to the docs useful information in the FAQs about training deterministic XGBoost models with the same data in different Operating Systems.