### PR TITLE
[CI] Reduce testing load with RMM

### DIFF
--- a/tests/python-gpu/conftest.py
+++ b/tests/python-gpu/conftest.py
@@ -41,3 +41,16 @@ def local_cuda_cluster(request, pytestconfig):
 
 def pytest_addoption(parser):
     parser.addoption('--use-rmm-pool', action='store_true', default=False, help='Use RMM pool')
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption('--use-rmm-pool'):
+        blocklist = [
+            'python-gpu/test_gpu_with_dask.py::TestDistributedGPU::test_gpu_hist',
+            'python-gpu/test_gpu_demos.py::test_dask_training',
+            'python-gpu/test_gpu_prediction.py::TestGPUPredict::test_shap',
+            'python-gpu/test_gpu_linear.py::TestGPULinear'
+        ]
+        skip_mark = pytest.mark.skip(reason='This test is not run when --use-rmm-pool flag is active')
+        for item in items:
+            if any(item.nodeid.startswith(x) for x in blocklist):
+                item.add_marker(skip_mark)

--- a/tests/python-gpu/conftest.py
+++ b/tests/python-gpu/conftest.py
@@ -45,7 +45,6 @@ def pytest_addoption(parser):
 def pytest_collection_modifyitems(config, items):
     if config.getoption('--use-rmm-pool'):
         blocklist = [
-            'python-gpu/test_gpu_with_dask.py::TestDistributedGPU::test_gpu_hist',
             'python-gpu/test_gpu_demos.py::test_dask_training',
             'python-gpu/test_gpu_prediction.py::TestGPUPredict::test_shap',
             'python-gpu/test_gpu_linear.py::TestGPULinear'


### PR DESCRIPTION
The introduction of the RMM plugin has nearly doubled the size of the Python test suite. Reduce the burden on our CI system by excluding a few heavy unit tests when RMM is enabled (with `--use-rmm-pool` flag to Pytest)