### PR TITLE
Add sponsors link to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 open_collective: xgboost
+custom: https://xgboost.ai/sponsors


### PR DESCRIPTION
Since the website contains some additional information and [GitHub allows to display custom links](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository), we should probably add this to the sponsors button as well.