### PR TITLE
Small optimization on GPU Hist.

### DIFF
--- a/include/xgboost/span.h
+++ b/include/xgboost/span.h
@@ -98,19 +98,8 @@ namespace common {
       fflush(stderr);  /* It seems stderr on Windows is beffered? */           \
       std::terminate();                                                        \
     }                                                                          \
-  } while (0);
+  } while (0)
 #endif  // __CUDA_ARCH__
-
-#if defined(__CUDA_ARCH__)
-#define SPAN_LT(lhs, rhs)                                                      \
-  if (!((lhs) < (rhs))) {                                                      \
-    printf("[xgboost] Condition: %lu < %lu failed\n",                          \
-           static_cast<size_t>(lhs), static_cast<size_t>(rhs));                \
-    asm("trap;");                                                              \
-  }
-#else
-#define SPAN_LT(lhs, rhs) SPAN_CHECK((lhs) < (rhs))
-#endif  // defined(__CUDA_ARCH__)
 
 namespace detail {
 /*!
@@ -526,7 +515,7 @@ class Span {
   }
 
   XGBOOST_DEVICE reference operator[](index_type _idx) const {
-    SPAN_LT(_idx, size());
+    SPAN_CHECK(_idx < size());
     return data()[_idx];
   }
 

--- a/src/common/bitfield.h
+++ b/src/common/bitfield.h
@@ -167,7 +167,7 @@ struct BitFieldContainer {
 
   XGBOOST_DEVICE bool Check(Pos pos_v) const {
     pos_v = Direction::Shift(pos_v);
-    SPAN_LT(pos_v.int_pos, bits_.size());
+    SPAN_CHECK(pos_v.int_pos < bits_.size());
     value_type const value = bits_[pos_v.int_pos];
     value_type const test_bit = kOne << pos_v.bit_pos;
     value_type result = test_bit & value;

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -660,7 +660,6 @@ struct GPUHistMakerDevice {
     auto d_split_out = dh::ToSpan(split_out);
     this->EvaluateRootSplit(root_sum, d_split_out);
 
-    // auto split = this->EvaluateRootSplit(root_sum);
     dh::TemporaryArray<ExpandEntry> entries(1);
     auto d_entries = entries.data().get();
     auto evaluator = tree_evaluator.GetEvaluator<GPUTrainingParam>();

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -256,7 +256,9 @@ TEST(GpuHist, EvaluateRootSplit) {
   info.num_row_ = kNRows;
   info.num_col_ = kNCols;
 
-  DeviceSplitCandidate res = maker.EvaluateRootSplit({6.4f, 12.8f});
+  thrust::device_vector<DeviceSplitCandidate> split_out(1);
+  maker.EvaluateRootSplit({6.4f, 12.8f}, dh::ToSpan(split_out));
+  DeviceSplitCandidate res = split_out.front();
 
   ASSERT_EQ(res.findex, 7);
   ASSERT_NEAR(res.fvalue, 0.26, xgboost::kRtEps);


### PR DESCRIPTION
- Remove 1 copy in root node evaluation.
- Use pointer in `inclusive_scan`.
- Remove `SPAN_LT`.  Somehow this has the most significant impact.