### PR TITLE
Use UserWarning for old callback, as DeprecationWarning is not visible

### DIFF
--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -14,7 +14,7 @@ def _configure_deprecated_callbacks(
         verbose_eval, early_stopping_rounds, maximize, start_iteration,
         num_boost_round, feval, evals_result, callbacks, show_stdv, cvfolds):
     link = 'https://xgboost.readthedocs.io/en/latest/python/callbacks.html'
-    warnings.warn(f'Old style callback is deprecated.  See: {link}', DeprecationWarning)
+    warnings.warn(f'Old style callback is deprecated.  See: {link}', UserWarning)
     # Most of legacy advanced options becomes callbacks
     if early_stopping_rounds is not None:
         callbacks.append(callback.early_stop(early_stopping_rounds,

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -191,17 +191,17 @@ class TestCallbacks(unittest.TestCase):
             assert eval_errors_3[i] != eval_errors_2[i]
 
     def test_eta_decay_hist(self):
-        with pytest.deprecated_call():
+        with pytest.warns(UserWarning):
             self.run_eta_decay('hist', True)
         self.run_eta_decay('hist', False)
 
     def test_eta_decay_approx(self):
-        with pytest.deprecated_call():
+        with pytest.warns(UserWarning):
             self.run_eta_decay('approx', True)
         self.run_eta_decay('approx', False)
 
     def test_eta_decay_exact(self):
-        with pytest.deprecated_call():
+        with pytest.warns(UserWarning):
             self.run_eta_decay('exact', True)
         self.run_eta_decay('exact', False)
 


### PR DESCRIPTION
`DeprecationWarning` is not visible by default, so use `UserWarning` when the old-style callback is used.