### PR TITLE
Fix a typo in is_arm() in testing.py

### DIFF
--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -24,7 +24,7 @@ memory = Memory('./cachedir', verbose=0)
 
 
 def is_arm():
-    return {'condition': platform.machine().lower().find('arm') != 1,
+    return {'condition': platform.machine().lower().find('arm') != -1,
             'reason': 'Skipping expensive tests on ARM.'}
 
 def no_sklearn():


### PR DESCRIPTION
The current typo causes the scikit-learn test suite to be skipped on x86-64. Sorry for not catching this typo in my last review.