### PR TITLE
Update plugin instructions for CMake build

### DIFF
--- a/plugin/example/README.md
+++ b/plugin/example/README.md
@@ -9,8 +9,7 @@ There are three steps you need to do to add a plugin to xgboost
   - In this example ```XGBOOST_REGISTER_OBJECTIVE``` in [this line](custom_obj.cc#L78)
 - Add a line to `xgboost/plugin/CMakeLists.txt`:
 ```
-set(PLUGINS_SOURCES ${PLUGINS_SOURCES}
-    ${xgboost_SOURCE_DIR}/plugin/example/custom_obj.cc PARENT_SCOPE)
+target_sources(objxgboost PRIVATE ${xgboost_SOURCE_DIR}/plugin/example/custom_obj.cc)
 ```
 
 Then you can test this plugin by using ```objective=mylogistic``` parameter.


### PR DESCRIPTION
Fixed an example of CMake rule so that it can successfully build a plugin.