### PR TITLE
[R] allow xgb.plot.importance() calls to fill a grid (fixes #4863)

### DIFF
--- a/R-package/R/xgb.plot.importance.R
+++ b/R-package/R/xgb.plot.importance.R
@@ -99,8 +99,12 @@ xgb.plot.importance <- function(importance_matrix = NULL, top_n = NULL, measure 
   }
 
   if (plot) {
-    op <- par(no.readonly = TRUE)
-    mar <- op$mar
+    original_mar <- par()$mar
+
+    # reset margins so this function doesn't have side effects
+    on.exit({par(mar = original_mar)})
+
+    mar <- original_mar
     if (!is.null(left_margin))
       mar[2] <- left_margin
     par(mar = mar)
@@ -109,11 +113,6 @@ xgb.plot.importance <- function(importance_matrix = NULL, top_n = NULL, measure 
     importance_matrix[rev(seq_len(nrow(importance_matrix))),
                       barplot(Importance, horiz = TRUE, border = NA, cex.names = cex,
                               names.arg = Feature, las = 1, ...)]
-    grid(NULL, NA)
-    # redraw over the grid
-    importance_matrix[rev(seq_len(nrow(importance_matrix))),
-                      barplot(Importance, horiz = TRUE, border = NA, add = TRUE)]
-    par(op)
   }
 
   invisible(importance_matrix)


### PR DESCRIPTION
Closes #4863

I was looking for [issues tagged r-package](https://github.com/dmlc/xgboost/issues?q=is%3Aopen+is%3Aissue+label%3A%22type%3A+r-package%22) tonight and found #4863 . I think this PR fixes it.

Currently, `xgb.plot.importance()` overwrites all of the graphical parameters when it exits, which means that consecutive calls don't respect `par(mfcol)`, and don't fill a grid. This PR changes that, and just resets the specific value `mar` in the parameters.

Here are the results on 4 consecutive calls of `xgb.plot.importance()`:

**before**

![image](https://user-images.githubusercontent.com/7608904/97261842-b073d000-17ed-11eb-83a7-037d039f7aea.png)

**after**

![image](https://user-images.githubusercontent.com/7608904/97261800-989c4c00-17ed-11eb-8ed3-639ef59bbe46.png)

### Reproducible example

<details><summary>code (click me)</summary>

```r
library(data.table)

data(agaricus.train, package = "xgboost")

bst <- xgboost::xgboost(
    data = agaricus.train$data
    , label = agaricus.train$label
    , max_depth = 3
    , eta = 1
    , nthread = 2
    , nrounds = 2
    , objective = "binary:logistic"
)

importance_matrix <- xgboost::xgb.importance(
    colnames(agaricus.train$data)
    , model = bst
)

par(mfrow = c(2,2))
for (i in seq_len(4)) {
    xgboost::xgb.plot.importance(
        importance_matrix
        , rel_to_first = TRUE
        , xlab = "Relative importance"
        , left_margin = 10
    )
}
```

</details>

### How this improves `{xgboost}`

This allows the results of this function to be arranged in a grid, which could be useful for comparing feature importances across different models.

Thanks for your time and consideration