### PR TITLE
Support unity build.

### DIFF
--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -85,7 +85,7 @@ def BuildWin64() {
     bat """
     mkdir build
     cd build
-    cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DUSE_DMLC_GTEST=ON -DCMAKE_UNITY_BUILD=ON ${arch_flag}
+    cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DUSE_DMLC_GTEST=ON ${arch_flag}
     """
     bat """
     cd build

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -85,7 +85,7 @@ def BuildWin64() {
     bat """
     mkdir build
     cd build
-    cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DUSE_DMLC_GTEST=ON ${arch_flag}
+    cmake .. -G"Visual Studio 15 2017 Win64" -DUSE_CUDA=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DUSE_DMLC_GTEST=ON -DCMAKE_UNITY_BUILD=ON ${arch_flag}
     """
     bat """
     cd build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,10 @@ list(REMOVE_ITEM CPU_SOURCES ${xgboost_SOURCE_DIR}/src/cli_main.cc)
 # Object library is necessary for jvm-package, which creates its own shared library.
 add_library(objxgboost OBJECT)
 target_sources(objxgboost PRIVATE ${CPU_SOURCES})
+# Skip files with factory object
+set_source_files_properties(
+  predictor/predictor.cc gbm/gbm.cc tree/tree_updater.cc metric/metric.cc objective/objective.cc
+  PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 target_sources(objxgboost PRIVATE ${RABIT_SOURCES})
 
 if (USE_CUDA)

--- a/src/predictor/predictor.cc
+++ b/src/predictor/predictor.cc
@@ -11,8 +11,8 @@
 namespace dmlc {
 DMLC_REGISTRY_ENABLE(::xgboost::PredictorReg);
 }  // namespace dmlc
-namespace xgboost {
 
+namespace xgboost {
 void PredictionContainer::ClearExpiredEntries() {
   std::vector<DMatrix*> expired;
   for (auto& kv : container_) {

--- a/tests/cpp/common/test_span.cu
+++ b/tests/cpp/common/test_span.cu
@@ -64,7 +64,7 @@ __global__ void TestFromOtherKernelConst(Span<float const, 16> span) {
  */
 TEST(GPUSpan, FromOther) {
   thrust::host_vector<float> h_vec (16);
-  InitializeRange(h_vec.begin(), h_vec.end());
+  std::iota(h_vec.begin(), h_vec.end(), 0);
 
   thrust::device_vector<float> d_vec (h_vec.size());
   thrust::copy(h_vec.begin(), h_vec.end(), d_vec.begin());
@@ -123,7 +123,7 @@ TEST(GPUSpan, WithTrust) {
   // Not adviced to initialize span with host_vector, since h_vec.data() is
   // a host function.
   thrust::host_vector<float> h_vec (16);
-  InitializeRange(h_vec.begin(), h_vec.end());
+  std::iota(h_vec.begin(), h_vec.end(), 0);
 
   thrust::device_vector<float> d_vec (h_vec.size());
   thrust::copy(h_vec.begin(), h_vec.end(), d_vec.begin());

--- a/tests/cpp/common/test_transform_range.cc
+++ b/tests/cpp/common/test_transform_range.cc
@@ -18,14 +18,6 @@
 
 #endif
 
-template <typename Iter>
-void InitializeRange(Iter _begin, Iter _end) {
-  float j = 0;
-  for (Iter i = _begin; i != _end; ++i, ++j) {
-    *i = j;
-  }
-}
-
 namespace xgboost {
 namespace common {
 
@@ -41,9 +33,9 @@ TEST(Transform, DeclareUnifiedTest(Basic)) {
   const size_t size {256};
   std::vector<bst_float> h_in(size);
   std::vector<bst_float> h_out(size);
-  InitializeRange(h_in.begin(), h_in.end());
+  std::iota(h_in.begin(), h_in.end(), 0);
   std::vector<bst_float> h_sol(size);
-  InitializeRange(h_sol.begin(), h_sol.end());
+  std::iota(h_sol.begin(), h_sol.end(), 0);
 
   const HostDeviceVector<bst_float> in_vec{h_in, TRANSFORM_GPU};
   HostDeviceVector<bst_float> out_vec{h_out, TRANSFORM_GPU};

--- a/tests/cpp/common/test_transform_range.cu
+++ b/tests/cpp/common/test_transform_range.cu
@@ -15,9 +15,9 @@ TEST(Transform, MGPU_SpecifiedGpuId) {  // NOLINT
   const size_t size {256};
   std::vector<bst_float> h_in(size);
   std::vector<bst_float> h_out(size);
-  InitializeRange(h_in.begin(), h_in.end());
+  std::iota(h_in.begin(), h_in.end(), 0);
   std::vector<bst_float> h_sol(size);
-  InitializeRange(h_sol.begin(), h_sol.end());
+  std::iota(h_sol.begin(), h_sol.end(), 0);
 
   const HostDeviceVector<bst_float> in_vec {h_in, device};
   HostDeviceVector<bst_float> out_vec {h_out, device};


### PR DESCRIPTION
See https://github.com/dmlc/xgboost/issues/6293 for details.  The speedup may help some build machines for distribution, but I don't think it's useful for daily development.  XGBoost's CPU compilation time on my machine is usually within a minute so not much room for improvement.

Update: Will be enabled on Windows CI.

Close https://github.com/dmlc/xgboost/issues/6293 .