### PR TITLE
[WIP] Bypass threaded iter in external memory.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15]
+        os: [macos-10.15, ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -549,8 +549,8 @@ class DMatrix {
                          int max_bin);
 
   virtual DMatrix *Slice(common::Span<int32_t const> ridxs) = 0;
-  /*! \brief page size 32 MB */
-  static const size_t kPageSize = 32UL << 20UL;
+  /*! \brief page size 128 MB */
+  static const size_t kPageSize = 32UL << 22UL;
 
  protected:
   virtual BatchSet<SparsePage> GetRowBatches() = 0;

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -478,6 +478,7 @@ class FileAdapter : dmlc::DataIter<FileAdapterBatch> {
     row_offset_ = 0;
   }
   bool Next() override {
+    std::cout << "Call next file adapter" << std::endl;
     bool next = parser_->Next();
     batch_.reset(new FileAdapterBatch(&parser_->Value(), row_offset_));
     row_offset_ += parser_->Value().size;

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -478,7 +478,6 @@ class FileAdapter : dmlc::DataIter<FileAdapterBatch> {
     row_offset_ = 0;
   }
   bool Next() override {
-    std::cout << "Call next file adapter" << std::endl;
     bool next = parser_->Next();
     batch_.reset(new FileAdapterBatch(&parser_->Value(), row_offset_));
     row_offset_ += parser_->Value().size;

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -684,7 +684,7 @@ DMatrix* DMatrix::Load(const std::string& uri,
 
   try {
     dmat = DMatrix::Create(&adapter, std::numeric_limits<float>::quiet_NaN(), 1,
-                           cache_file, page_size);
+                           cache_file, 1024);
   } catch (dmlc::Error& e) {
     std::vector<std::string> splited = common::Split(fname, '#');
     std::vector<std::string> args = common::Split(splited.front(), '?');

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -685,7 +685,6 @@ DMatrix* DMatrix::Load(const std::string& uri,
   try {
     dmat = DMatrix::Create(&adapter, std::numeric_limits<float>::quiet_NaN(), 1,
                            cache_file, page_size);
-                           cache_file, 1024);
   } catch (dmlc::Error& e) {
     std::vector<std::string> splited = common::Split(fname, '#');
     std::vector<std::string> args = common::Split(splited.front(), '?');

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -14,6 +14,7 @@
 #include "xgboost/learner.h"
 #include "sparse_page_writer.h"
 #include "simple_dmatrix.h"
+#include "parser.h"
 
 #include "../common/io.h"
 #include "../common/math.h"
@@ -675,8 +676,9 @@ DMatrix* DMatrix::Load(const std::string& uri,
     }
   }
 
-  std::unique_ptr<dmlc::Parser<uint32_t> > parser(
-      dmlc::Parser<uint32_t>::Create(fname.c_str(), partid, npart, file_format.c_str()));
+  std::unique_ptr<dmlc::Parser<uint32_t, float>> parser{
+      data::CreateParser<uint32_t>(fname.c_str(), partid, npart,
+                                   file_format.c_str())};
   data::FileAdapter adapter(parser.get());
   DMatrix* dmat {nullptr};
 

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -684,6 +684,7 @@ DMatrix* DMatrix::Load(const std::string& uri,
 
   try {
     dmat = DMatrix::Create(&adapter, std::numeric_limits<float>::quiet_NaN(), 1,
+                           cache_file, page_size);
                            cache_file, 1024);
   } catch (dmlc::Error& e) {
     std::vector<std::string> splited = common::Split(fname, '#');

--- a/src/data/parser.h
+++ b/src/data/parser.h
@@ -1,0 +1,121 @@
+#ifndef XGBOOST_DATA_PARSER_H_
+#define XGBOOST_DATA_PARSER_H_
+#include <dmlc/io.h>
+#include "../../dmlc-core/src/io/single_threaded_input_split.h"
+#include "../../dmlc-core/src/io/single_file_split.h"
+#include "../../dmlc-core/src/io/uri_spec.h"
+#include "../../dmlc-core/src/io/line_split.h"
+#include "../../dmlc-core/src/io/indexed_recordio_split.h"
+#include "../../dmlc-core/src/io/recordio_split.h"
+#include "../../dmlc-core/src/io/cached_input_split.h"
+#include "../../dmlc-core/src/data/csv_parser.h"
+#include "../../dmlc-core/src/data/libfm_parser.h"
+#include "../../dmlc-core/src/data/libsvm_parser.h"
+
+#include "xgboost/logging.h"
+
+namespace xgboost {
+namespace data {
+inline dmlc::InputSplit *
+CreateInputSplit(const char *uri_, const char *index_uri_, unsigned part,
+                 unsigned nsplit, const char *type, const bool shuffle = false,
+                 const int seed = 0, const size_t batch_size = 256,
+                 const bool recurse_directories = false) {
+  namespace io = dmlc::io;
+  io::URISpec spec(uri_, part, nsplit);
+  if (!strcmp(spec.uri.c_str(), "stdin")) {
+    return new io::SingleFileSplit(spec.uri.c_str());
+  }
+  CHECK(part < nsplit) << "invalid input parameter for InputSplit::Create";
+  io::URI path(spec.uri.c_str());
+  io::InputSplitBase *split = nullptr;
+  if (!strcmp(type, "text")) {
+    split = new io::LineSplitter(io::FileSystem::GetInstance(path),
+                                 spec.uri.c_str(), part, nsplit);
+  } else if (!strcmp(type, "indexed_recordio")) {
+    if (index_uri_ != nullptr) {
+      io::URISpec index_spec(index_uri_, part, nsplit);
+      split = new io::IndexedRecordIOSplitter(
+          io::FileSystem::GetInstance(path), spec.uri.c_str(),
+          index_spec.uri.c_str(), part, nsplit, batch_size, shuffle, seed);
+    } else {
+      LOG(FATAL) << "need to pass index file to use IndexedRecordIO";
+    }
+  } else if (!strcmp(type, "recordio")) {
+    split = new io::RecordIOSplitter(io::FileSystem::GetInstance(path),
+                                     spec.uri.c_str(), part, nsplit,
+                                     recurse_directories);
+  } else {
+    LOG(FATAL) << "unknown input split type " << type;
+  }
+  if (spec.cache_file.length() == 0) {
+    return new io::SingleThreadedInputSplit(split, batch_size);
+  } else {
+    return new io::CachedInputSplit(split, spec.cache_file.c_str());
+  }
+}
+
+template<typename IndexType, typename DType = float>
+dmlc::Parser<IndexType, DType> *
+CreateCSVParser(const std::string& path,
+                const std::map<std::string, std::string>& args,
+                unsigned part_index,
+                unsigned num_parts) {
+  dmlc::InputSplit *source =
+      CreateInputSplit(path.c_str(), nullptr, part_index, num_parts, "text");
+  return new dmlc::data::CSVParser<IndexType, DType>(source, args, 2);
+}
+
+template<typename IndexType, typename DType = float>
+dmlc::Parser<IndexType> *
+CreateLibSVMParser(const std::string& path,
+                   const std::map<std::string, std::string>& args,
+                   unsigned part_index,
+                   unsigned num_parts) {
+  dmlc::InputSplit *source =
+      CreateInputSplit(path.c_str(), nullptr, part_index, num_parts, "text");
+  dmlc::data::ParserImpl<IndexType> *parser =
+      new dmlc::data::LibSVMParser<IndexType>(source, args, 2);
+  return parser;
+}
+
+template<typename IndexType, typename DType = float>
+dmlc::Parser<IndexType> *
+CreateLibFMParser(const std::string& path,
+                  const std::map<std::string, std::string>& args,
+                  unsigned part_index,
+                  unsigned num_parts) {
+  dmlc::InputSplit *source =
+      CreateInputSplit(path.c_str(), nullptr, part_index, num_parts, "text");
+  dmlc::data::ParserImpl<IndexType> *parser =
+      new dmlc::data::LibFMParser<IndexType>(source, args, 2);
+  return parser;
+}
+
+template <typename IndexType, typename DType = float>
+inline dmlc::Parser<IndexType, DType> *
+CreateParser(const char *uri_, unsigned part_index, unsigned num_parts,
+             const char *type) {
+  std::string ptype = type;
+  dmlc::io::URISpec spec(uri_, part_index, num_parts);
+  if (ptype == "auto") {
+    if (spec.args.count("format") != 0) {
+      ptype = spec.args.at("format");
+    } else {
+      ptype = "libsvm";
+    }
+  }
+
+  const dmlc::ParserFactoryReg<IndexType, DType> *e =
+      dmlc::Registry<dmlc::ParserFactoryReg<IndexType, DType>>::Get()->Find(
+          ptype);
+  if (e == NULL) {
+    LOG(FATAL) << "Unknown data type " << ptype;
+  }
+  // create parser
+  return (*e->body)(spec.uri, spec.args, part_index, num_parts);
+}
+}  // namespace data
+}  // namespace xgboost
+
+#endif  // XGBOOST_DATA_PARSER_H_

--- a/src/data/parser.h
+++ b/src/data/parser.h
@@ -188,16 +188,15 @@ CreateLibFMParser(const std::string& path,
 
 template <typename IndexType, typename DType = float>
 inline dmlc::Parser<IndexType, DType> *
-CreateParser(const char *uri_, unsigned part_index, unsigned num_parts,
-             const char *type) {
-  std::string ptype = type;
-  dmlc::io::URISpec spec(uri_, part_index, num_parts);
+CreateParser(std::string uri, unsigned part_index, unsigned num_parts,
+             std::string type) {
+  dmlc::io::URISpec spec(uri.c_str(), part_index, num_parts);
   size_t batch_size = 256;
-  if (ptype == "auto") {
+  if (type == "auto") {
     if (spec.args.count("format") != 0) {
-      ptype = spec.args.at("format");
+      type = spec.args.at("format");
     } else {
-      ptype = "libsvm";
+      type = "libsvm";
     }
     if (spec.args.count("batch_size")) {
       try {
@@ -212,17 +211,17 @@ CreateParser(const char *uri_, unsigned part_index, unsigned num_parts,
   CHECK_GT(batch_size, 0);
 
   // create parser
-  if (ptype == "csv") {
+  if (type == "csv") {
     return CreateCSVParser<IndexType, DType>(spec.uri, spec.args, part_index,
-                                             num_parts, batch_size);
-  } else if (ptype == "libsvm") {
+                                              num_parts, batch_size);
+  } else if (type == "libsvm") {
     return CreateLibSVMParser<IndexType, DType>(spec.uri, spec.args, part_index,
                                                 num_parts, batch_size);
-  } else if (ptype == "libfm") {
+  } else if (type == "libfm") {
     return CreateLibFMParser<IndexType, DType>(spec.uri, spec.args, part_index,
                                                num_parts, batch_size);
   } else {
-    LOG(FATAL) << "Unknown file format: " << ptype;
+    LOG(FATAL) << "Unknown file format: " << type;
     return nullptr;
   }
 }

--- a/src/data/parser.h
+++ b/src/data/parser.h
@@ -102,6 +102,9 @@ inline dmlc::InputSplit *CreateInputSplit(std::string const& uri, unsigned part,
 template <typename IndexType, typename DType = float>
 void ConcatBlocks(
     std::vector<dmlc::data::RowBlockContainer<IndexType, DType>> *data) {
+  if (data->empty()) {
+    return;
+  }
   auto &block = data->front();
   for (size_t i = 1; i < data->size(); ++i) {
     block.Push(data->at(i).GetBlock());
@@ -118,9 +121,6 @@ class CSVParser : public dmlc::data::CSVParser<IndexType, DType> {
 
   bool ParseNext(std::vector<dmlc::data::RowBlockContainer<IndexType, DType> > *data) override {
     auto ret = TextParserBase::FillData(data);
-    if (data->empty()) {
-      return ret;
-    }
     ConcatBlocks(data);
     return ret;
   }
@@ -133,9 +133,6 @@ class LibFMParser : public dmlc::data::LibFMParser<IndexType, DType> {
 
   bool ParseNext(std::vector<dmlc::data::RowBlockContainer<IndexType, DType> > *data) override {
     auto ret = TextParserBase::FillData(data);
-    if (data->empty()) {
-      return ret;
-    }
     ConcatBlocks(data);
     return ret;
   }
@@ -148,9 +145,6 @@ class LibSVMParser : public dmlc::data::LibSVMParser<IndexType, DType> {
 
   bool ParseNext(std::vector<dmlc::data::RowBlockContainer<IndexType, DType> > *data) override {
     auto ret = TextParserBase::FillData(data);
-    if (data->empty()) {
-      return ret;
-    }
     ConcatBlocks(data);
     return ret;
   }

--- a/src/data/parser.h
+++ b/src/data/parser.h
@@ -1,3 +1,8 @@
+/*!
+ * Copyright 2020 by XGBoost Contributors
+ * \file parser.h
+ */
+
 #ifndef XGBOOST_DATA_PARSER_H_
 #define XGBOOST_DATA_PARSER_H_
 #include <dmlc/io.h>

--- a/src/data/parser.h
+++ b/src/data/parser.h
@@ -13,7 +13,7 @@
  * - Batch size is not respected in dmlc-core, instead it has a buffer size.
  *
  * In general, the infrastructure in dmlc-core is more concerned with
- * performance/parallelism, but here we need consistency and deterministic for data
+ * performance/parallelism, but here we need consistency and determinism for data
  * partitioning and memory usage.
  */
 
@@ -33,7 +33,7 @@
 namespace xgboost {
 namespace data {
 
-// A spliter that respects batch size.
+// A spliter that respects batch size and doesn't use thread.
 class TextInputSplit : public dmlc::InputSplit {
   dmlc::io::InputSplitBase::Chunk *tmp_chunk_;
   std::unique_ptr<dmlc::io::InputSplitBase> base_;

--- a/src/data/sparse_page_source.h
+++ b/src/data/sparse_page_source.h
@@ -143,9 +143,6 @@ class FileBatchIter {
   bool Next(Page** page) {
     return next_(page);
   }
-  void Recycle(Page** page) {
-    LOG(FATAL) << "w?";
-  }
 
   void BeforeFirst() {
     before_first_();
@@ -206,11 +203,6 @@ class ExternalMemoryPrefetcher : dmlc::DataIter<PageT> {
   bool Next() override {
     CHECK(mutex_.try_lock()) << "Multiple threads attempting to use prefetcher";
     // doing clock rotation over shards.
-    if (page_ != nullptr) {
-      size_t n = prefetchers_.size();
-      prefetchers_[(clock_ptr_ + n - 1) % n]->Recycle(&page_);
-    }
-
     if (prefetchers_[clock_ptr_]->Next(&page_)) {
       page_->SetBaseRowId(base_rowid_);
       base_rowid_ += page_->Size();

--- a/src/data/sparse_page_source.h
+++ b/src/data/sparse_page_source.h
@@ -203,7 +203,6 @@ class ExternalMemoryPrefetcher : dmlc::DataIter<PageT> {
   bool Next() override {
     CHECK(mutex_.try_lock()) << "Multiple threads attempting to use prefetcher";
     // doing clock rotation over shards.
-    std::cout << "Next" << std::endl;
     if (prefetchers_[clock_ptr_]->Next(&page_)) {
       page_->SetBaseRowId(base_rowid_);
       base_rowid_ += page_->Size();
@@ -220,7 +219,6 @@ class ExternalMemoryPrefetcher : dmlc::DataIter<PageT> {
   // implement BeforeFirst
   void BeforeFirst() override {
     CHECK(mutex_.try_lock()) << "Multiple threads attempting to use prefetcher";
-    std::cout << "Before first" << std::endl;
     base_rowid_ = 0;
     clock_ptr_ = 0;
     for (auto& p : prefetchers_) {

--- a/src/data/sparse_page_source.h
+++ b/src/data/sparse_page_source.h
@@ -203,6 +203,7 @@ class ExternalMemoryPrefetcher : dmlc::DataIter<PageT> {
   bool Next() override {
     CHECK(mutex_.try_lock()) << "Multiple threads attempting to use prefetcher";
     // doing clock rotation over shards.
+    std::cout << "Next" << std::endl;
     if (prefetchers_[clock_ptr_]->Next(&page_)) {
       page_->SetBaseRowId(base_rowid_);
       base_rowid_ += page_->Size();
@@ -219,6 +220,7 @@ class ExternalMemoryPrefetcher : dmlc::DataIter<PageT> {
   // implement BeforeFirst
   void BeforeFirst() override {
     CHECK(mutex_.try_lock()) << "Multiple threads attempting to use prefetcher";
+    std::cout << "Before first" << std::endl;
     base_rowid_ = 0;
     clock_ptr_ = 0;
     for (auto& p : prefetchers_) {

--- a/tests/cpp/data/test_parser.cc
+++ b/tests/cpp/data/test_parser.cc
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+#include <dmlc/filesystem.h>
+#include <fstream>
+#include "../../../src/data/parser.h"
+
+namespace xgboost {
+namespace data {
+TEST(Parser, Format) {
+  dmlc::TemporaryDirectory tmpdir;
+  auto path = tmpdir.path + "/data";
+  auto uri = tmpdir.path + "/data?format=csv";
+  std::ofstream fout(path);
+  fout << "1,2,3,4,5";
+  fout.flush();
+
+  std::unique_ptr<dmlc::Parser<uint32_t, float>> parser{
+      CreateParser<uint32_t, float>(uri, 0, 1, "auto")};
+  auto csv = dynamic_cast<CSVParser<uint32_t, float>*>(parser.get());
+  ASSERT_TRUE(csv);
+
+  // default to libsvm
+  parser.reset(CreateParser<uint32_t, float>(path, 0, 1, "auto"));
+  auto svm = dynamic_cast<LibSVMParser<uint32_t, float>*>(parser.get());
+  ASSERT_TRUE(svm);
+
+  uri = path + "?format=libfm";
+  parser.reset(CreateParser<uint32_t, float>(uri, 0, 1, "auto"));
+  auto fm = dynamic_cast<LibFMParser<uint32_t, float>*>(parser.get());
+  ASSERT_TRUE(fm);
+}
+}  // namespace data
+}  // namespace xgboost

--- a/tests/cpp/data/test_sparse_page_dmatrix.cc
+++ b/tests/cpp/data/test_sparse_page_dmatrix.cc
@@ -85,7 +85,6 @@ TEST(SparsePageDMatrix, ExistingCacheFile) {
   });
 }
 
-#if defined(_OPENMP)
 TEST(SparsePageDMatrix, ThreadSafetyException) {
   dmlc::TemporaryDirectory tmpdir;
   std::string filename = tmpdir.path + "/test";
@@ -105,7 +104,6 @@ TEST(SparsePageDMatrix, ThreadSafetyException) {
   }
   EXPECT_TRUE(exception);
 }
-#endif
 
 // Multi-batches access
 TEST(SparsePageDMatrix, ColAccessBatches) {

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -373,12 +373,8 @@ std::unique_ptr<DMatrix> CreateSparsePageDMatrix(
     batch_count++;
     row_count += batch.Size();
   }
-#if defined(_OPENMP)
   EXPECT_GE(batch_count, 2);
   EXPECT_EQ(row_count, dmat->Info().num_row_);
-#else
-#warning "External memory doesn't work with Non-OpenMP build "
-#endif  // defined(_OPENMP)
   return dmat;
 }
 


### PR DESCRIPTION
* Remove the dependency on threaded iterator.
* Make data partitioning deterministic.
* Add Ubuntu to gtest GitHub action job.

Close: https://github.com/dmlc/xgboost/issues/5063

Possibly related: https://github.com/dmlc/xgboost/issues/6167