### PR TITLE
[CI] Use separate Docker cache for each CUDA version

### DIFF
--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -90,7 +90,7 @@ WORKSPACE="${WORKSPACE:-${SCRIPT_DIR}/../../}"
 DOCKER_IMG_NAME="xgb-ci.${CONTAINER_TYPE}"
 
 # Append cuda version if available
-CUDA_VERSION=$(echo "${CI_DOCKER_BUILD_ARG}" | grep -o -E 'CUDA_VERSION=[0-9]+\.[0-9]+' | grep -o -E '[0-9]+\.[0-9]+')
+CUDA_VERSION=$(echo "${CI_DOCKER_BUILD_ARG}" | grep -o -E 'CUDA_VERSION_ARG=[0-9]+\.[0-9]+' | grep -o -E '[0-9]+\.[0-9]+')
 # Append jdk version if available
 JDK_VERSION=$(echo "${CI_DOCKER_BUILD_ARG}" | grep -o -E 'JDK_VERSION=[0-9]+' | grep -o -E '[0-9]+')
 # Append cmake version if available


### PR DESCRIPTION
Closes #6301. This will greatly reduce the number of times the Docker container images are re-built.

#6202 introduced a subtle bug that pushed all GPU containers to the same registry `xgb-ci.gpu`, regardless of their CUDA version used. With this patch, GPU containers will be pushed to appropriate registries that are labeled with CUDA versions: `xgb-ci.gpu10.0`, `xgb-ci.gpu10.2`, and `xgb-ci.gpu11.0`.