### PR TITLE
Fix Python callback.

### DIFF
--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -4,6 +4,7 @@
 """Training Library containing training routines."""
 import warnings
 import numpy as np
+import copy
 from .core import Booster, XGBoostError
 from .compat import (SKLEARN_INSTALLED, XGBStratifiedKFold)
 from . import rabit
@@ -57,7 +58,7 @@ def _train_internal(params, dtrain,
                     evals_result=None, maximize=None,
                     verbose_eval=None, early_stopping_rounds=None):
     """internal training function"""
-    callbacks = [] if callbacks is None else callbacks
+    callbacks = [] if callbacks is None else copy.copy(callbacks)
     evals = list(evals)
     params = _configure_metrics(params.copy())
 

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -3,8 +3,9 @@
 # pylint: disable=too-many-branches, too-many-statements
 """Training Library containing training routines."""
 import warnings
-import numpy as np
 import copy
+
+import numpy as np
 from .core import Booster, XGBoostError
 from .compat import (SKLEARN_INSTALLED, XGBStratifiedKFold)
 from . import rabit

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -232,3 +232,16 @@ class TestCallbacks(unittest.TestCase):
             for i in range(1, 10):
                 assert os.path.exists(
                     os.path.join(tmpdir, 'model_' + str(i) + '.pkl'))
+
+    def test_callback_list(self):
+        X, y = tm.get_boston()
+        m = xgb.DMatrix(X, y)
+        callbacks = [xgb.callback.EarlyStopping(rounds=10)]
+        for i in range(4):
+            xgb.train({'objective': 'reg:squarederror',
+                       'eval_metric': 'rmse'}, m,
+                      evals=[(m, 'Train')],
+                      num_boost_round=1,
+                      verbose_eval=True,
+                      callbacks=callbacks)
+        assert len(callbacks) == 1


### PR DESCRIPTION
Copy the user provided callback parameter.  Python is pass by reference, manipulating parameter directly has unexpected result.

Close https://github.com/dmlc/xgboost/issues/6319 .