### PR TITLE
[dask] ignore files from local Dask development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,9 @@ R-package/src/Makevars
 
 # Python joblib.Memory used in pytest.
 cachedir/
+
+# Files from local Dask work
+dask-worker-space/
+
+# Jupyter notebook checkpoints
+.ipynb_checkpoints/


### PR DESCRIPTION
While working on #6345 , I found that some files generated by running the code in https://xgboost.readthedocs.io/en/latest/tutorials/dask.html#overview aren't ignored by `.gitignore`, and I think they should be.

* `dask-worker-space/`: directory automatically created by Dask for when it needs to spill to disk
* `.ipynb_checkpoints`: checkpoint files or Jupyter notebooks

I just made the same PR over in LightGBM (https://github.com/microsoft/LightGBM/pull/3527) 😀 

Thanks for your time and consideration.