### PR TITLE
Simple fix for PredictRaw kernel performance

### DIFF
--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -154,7 +154,7 @@ void PredictBatchByBlockOfRowsKernel(DataView batch, std::vector<bst_float> *out
   const auto nsize = static_cast<bst_omp_uint>(batch.Size());
 
   const bst_omp_uint n_row_blocks = (nsize) / block_of_rows_size + !!((nsize) % block_of_rows_size);
-#pragma omp parallel for schedule(guided)
+#pragma omp parallel for schedule(static)
   for (bst_omp_uint block_id = 0; block_id < n_row_blocks; ++block_id) {
     const size_t batch_offset = block_id * block_of_rows_size;
     const size_t block_size = std::min(nsize - batch_offset, block_of_rows_size);


### PR DESCRIPTION
guided schedule affects predict by each tree during training 

santander, train |  guided, s | static, s | Speedup
-- | -- | -- | --
PredictRaw| 97.4115 | 50.663 | 1.92
Full train | 324.56 | 271.57 | 1.2

No significant impact on full (usage of all trees in model) predict stage.
