### PR TITLE
[jvm-packages] fix potential unit test suites aborted issue

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/test/scala/org/apache/spark/SparkContextUtils.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/org/apache/spark/SparkContextUtils.scala
@@ -1,0 +1,22 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+package org.apache.spark
+
+object SparkContextUtils {
+  def getActiveSparkContext: Option[SparkContext] = {
+    SparkContext.getActive
+  }
+}


### PR DESCRIPTION
  **Background:**
  1. XGBoost has enabled Stopping SparkContext by default while tasks run into exceptions,
  2. The Stopping SparkContext (`SparkContext.getOrCreate().stop()`) is called in a separate
     thread differring with thread running unit tests
  3. The unit tests are executed one by one in the same thread.
  
  Consider this situation, **TEST B** follows **TEST A** (**TEST A** will throw an exception in the worker)
 -  a) **TEST A** triggers [`SparkContext.getOrCreate().stop()`](https://github.com/dmlc/xgboost/blob/master/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/SparkParallelismTracker.scala#L158) which takes long time to be finished
         in a separate thread
-   b) **TEST A** calls [afterEach](https://github.com/dmlc/xgboost/blob/master/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/PerTest.scala#L47) which tries to stop SparkContext which is stopping because of **a)**
-  c) **TEST B** runs. first, calling [beforeEach](https://github.com/dmlc/xgboost/blob/master/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/PerTest.scala#L45) which creates SparkSession by wrapping a [SparkContext
       called by SparkContext.getOrCreate()](https://github.com/apache/spark/blob/branch-3.0/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala#L934), Since SparkContext is a singleTon and kept by
       [activeContext](https://github.com/apache/spark/blob/branch-3.0/core/src/main/scala/org/apache/spark/SparkContext.scala#L2584) which was defined in SparkContext,
  
  But **SparkContext.stop** will clear activeContext in the last of stop code by [SparkContext.clearActiveContext()](https://github.com/apache/spark/blob/branch-3.0/core/src/main/scala/org/apache/spark/SparkContext.scala#L2038)
  **Here is the issue,**
  The newly created Sparksession of **TEST B** will wrap the SparkContext which is stopping by
  **TEST A**, which will result [sparkContext.assertNotStopped()](https://github.com/apache/spark/blob/branch-3.0/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala#L103) throw exception and block the
   following unit tests in SparkSession.