### PR TITLE
Support shared library in system path.

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -320,6 +320,26 @@ is a simple bash script does that:
   cd ../python-package
   pip install -e .  # or equivalently python setup.py develop
 
+3. Use ``libxgboost.so`` on system path.
+
+This is for distributing xgboost in a language independent manner, where ``libxgboost.so``
+is separately packaged with Python package.  Assuming `libxgboost.so` is already presented
+in system library path, which can be queried via:
+
+.. code-block:: python
+
+  import sys
+  import os
+  os.path.join(sys.prefix, 'lib')
+
+Then one only needs to provide an user option when installing Python package to reuse the
+shared object in system path:
+
+.. code-block:: bash
+
+  cd xgboost/python-package
+  python setup.py install --use-system-libxgboost
+
 .. _mingw_python:
 
 Building XGBoost library for Python for Windows with MinGW-w64 (Advanced)

--- a/python-package/xgboost/libpath.py
+++ b/python-package/xgboost/libpath.py
@@ -24,7 +24,11 @@ def find_lib_path():
         os.path.join(curr_path, 'lib'),
         # editable installation, no copying is performed.
         os.path.join(curr_path, os.path.pardir, os.path.pardir, 'lib'),
+        # use libxgboost from a system prefix, if available.  This should be the last
+        # option.
+        os.path.join(sys.prefix, 'lib'),
     ]
+
     if sys.platform == 'win32':
         if platform.architecture()[0] == '64bit':
             dll_path.append(


### PR DESCRIPTION
Another attempt on https://github.com/dmlc/xgboost/pull/6292 .  Differences:

- `sysconfig.get_config_var('LIBDIR')` in #6292 is not used here as I think `sys.prefix + 'lib'` should be sufficient although I haven't tested it on freebsd.  `sys.prefix` can be altered by `virtualenv` while `sysconfig` is invariant.
- `setup.py` is changed to omit building or copying `libxgboost.so` when the user option `--use-system-libxgboost` is specified.  So the Python package will not contain a redundant shared object.  Combined with the ordering of candidate paths in `find_lib`, correct `libxgboost.so` should be loaded.

Closes #6291 
Closes #5705