### PR TITLE
Expose global verbosity in shared library but do not export in R Package

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -7,6 +7,14 @@
 # General helper utilities ----------------------------------------------------
 #
 
+# Set global xgboost verbosity
+xgb.set.global.verbosity <- function(verbosity = c("warning","silent","info","debug")) {
+  verbosity <- match.arg(verbosity)
+  verbosity <- switch(verbosity, "silent" = "0", "warning" = "1", "info" = "2","debug" = "3")
+  .Call(XGSetGlobalVerbosity_R, verbosity)
+  return(invisible(verbosity))
+}
+
 # SQL-style NVL shortcut.
 NVL <- function(x, val) {
   if (is.null(x))

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -43,6 +43,7 @@ extern SEXP XGDMatrixNumRow_R(SEXP);
 extern SEXP XGDMatrixSaveBinary_R(SEXP, SEXP, SEXP);
 extern SEXP XGDMatrixSetInfo_R(SEXP, SEXP, SEXP);
 extern SEXP XGDMatrixSliceDMatrix_R(SEXP, SEXP);
+extern SEXP XGSetGlobalVerbosity_R(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"XGBoosterBoostOneIter_R",     (DL_FUNC) &XGBoosterBoostOneIter_R,     4},
@@ -73,6 +74,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"XGDMatrixSaveBinary_R",       (DL_FUNC) &XGDMatrixSaveBinary_R,       3},
   {"XGDMatrixSetInfo_R",          (DL_FUNC) &XGDMatrixSetInfo_R,          3},
   {"XGDMatrixSliceDMatrix_R",     (DL_FUNC) &XGDMatrixSliceDMatrix_R,     2},
+  {"XGSetGlobalVerbosity_R",      (DL_FUNC) &XGSetGlobalVerbosity_R,      1},
   {NULL, NULL, 0}
 };
 

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -2,12 +2,14 @@
 #include <dmlc/logging.h>
 #include <dmlc/omp.h>
 #include <xgboost/c_api.h>
+#include <xgboost/logging.h>
 #include <vector>
 #include <string>
 #include <utility>
 #include <cstring>
 #include <cstdio>
 #include <sstream>
+#include <map>
 #include "./xgboost_R.h"
 
 /*!
@@ -34,6 +36,14 @@
     error(XGBGetLastError());                   \
   }
 
+using namespace xgboost;
+  
+SEXP XGSetGlobalVerbosity_R(SEXP verbosity) {
+  std::map<std::string, std::string> args {};
+  args["verbosity"] = CHAR(asChar(verbosity))[0];
+  ConsoleLogger::Configure({args.cbegin(), args.cend()});
+  return R_NilValue;
+}
 
 using namespace dmlc;
 

--- a/R-package/src/xgboost_R.h
+++ b/R-package/src/xgboost_R.h
@@ -15,6 +15,13 @@
 #include <xgboost/c_api.h>
 
 /*!
+ * \brief Set xgboost global verbosity
+ * \param verbosity
+ * \return verbosity
+ */
+XGB_DLL SEXP XGSetGlobalVerbosity_R(SEXP verbosity);
+
+/*!
  * \brief check whether a handle is NULL
  * \param handle
  * \return whether it is null ptr


### PR DESCRIPTION
There was no way to make xgboost silent from the R Package (none that I could find) so what do think about exposing ConsoleLogger::Configure in R?

Thoughts?

It is mainly to reduce the amount of 
```
...
Loading model from XGBoost < 1.0.0, consider saving it again for improved compatibility
...
```

I get in the server log while people call some R Api repeatedly.