### PR TITLE
Deprecate positional arguments.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -12,6 +12,8 @@ import re
 import sys
 import json
 import warnings
+from functools import wraps
+from inspect import signature, Parameter
 
 import numpy as np
 import scipy.sparse
@@ -367,6 +369,43 @@ class DataIter:
 
         '''
         raise NotImplementedError()
+
+
+def _deprecate_positional_args(f):
+    """Decorator for methods that issues warnings for positional arguments
+
+    Modifed from sklearn utils.validation.
+
+    Parameters
+    ----------
+    f : function
+        function to check arguments on
+    """
+    sig = signature(f)
+    kwonly_args = []
+    all_args = []
+
+    for name, param in sig.parameters.items():
+        if param.kind == Parameter.POSITIONAL_OR_KEYWORD:
+            all_args.append(name)
+        elif param.kind == Parameter.KEYWORD_ONLY:
+            kwonly_args.append(name)
+
+    @wraps(f)
+    def inner_f(*args, **kwargs):
+        extra_args = len(args) - len(all_args)
+        if extra_args > 0:
+            # ignore first 'self' argument for instance methods
+            args_msg = ['{}={}'.format(name, arg)
+                        for name, arg in zip(kwonly_args[:extra_args],
+                                             args[-extra_args:])]
+            warnings.warn("Pass {} as keyword args. From version 0.25 "
+                          "passing these as positional arguments will "
+                          "result in an error".format(", ".join(args_msg)),
+                          FutureWarning)
+        kwargs.update({k: arg for k, arg in zip(sig.parameters, args)})
+        return f(**kwargs)
+    return inner_f
 
 
 class DMatrix:                  # pylint: disable=too-many-instance-attributes

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -409,11 +409,11 @@ def _deprecate_positional_args(f):
         if extra_args > 0:
             # ignore first 'self' argument for instance methods
             args_msg = [
-                '{}={}'.format(name, arg) for name, arg in zip(
+                '{}'.format(name) for name, _ in zip(
                     kwonly_args[:extra_args], args[-extra_args:])
             ]
             warnings.warn(
-                "Pass {} as keyword args.  Passing these as positional "
+                "Pass `{}` as keyword args.  Passing these as positional "
                 "arguments will be considered as error in future releases.".
                 format(", ".join(args_msg)), FutureWarning)
         for k, arg in zip(sig.parameters, args):

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -396,15 +396,17 @@ def _deprecate_positional_args(f):
         extra_args = len(args) - len(all_args)
         if extra_args > 0:
             # ignore first 'self' argument for instance methods
-            args_msg = ['{}={}'.format(name, arg)
-                        for name, arg in zip(kwonly_args[:extra_args],
-                                             args[-extra_args:])]
-            warnings.warn("Pass {} as keyword args. From version 0.25 "
-                          "passing these as positional arguments will "
-                          "result in an error".format(", ".join(args_msg)),
-                          FutureWarning)
+            args_msg = [
+                '{}={}'.format(name, arg) for name, arg in zip(
+                    kwonly_args[:extra_args], args[-extra_args:])
+            ]
+            warnings.warn(
+                "Pass {} as keyword args.  Passing these as positional "
+                "arguments will be considered as error in uture releases.".
+                format(", ".join(args_msg)), FutureWarning)
         kwargs.update({k: arg for k, arg in zip(sig.parameters, args)})
         return f(**kwargs)
+
     return inner_f
 
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -502,6 +502,7 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
             _check_call(_LIB.XGDMatrixFree(self.handle))
             self.handle = None
 
+    @_deprecate_positional_args
     def set_info(self,
                  label=None, weight=None, base_margin=None,
                  group=None,

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -404,7 +404,8 @@ def _deprecate_positional_args(f):
                 "Pass {} as keyword args.  Passing these as positional "
                 "arguments will be considered as error in uture releases.".
                 format(", ".join(args_msg)), FutureWarning)
-        kwargs.update({k: arg for k, arg in zip(sig.parameters, args)})
+        for k, arg in zip(sig.parameters, args):
+            kwargs[k] = arg
         return f(**kwargs)
 
     return inner_f

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -503,7 +503,7 @@ class DMatrix:                  # pylint: disable=too-many-instance-attributes
             self.handle = None
 
     @_deprecate_positional_args
-    def set_info(self,
+    def set_info(self, *,
                  label=None, weight=None, base_margin=None,
                  group=None,
                  label_lower_bound=None,

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -371,8 +371,20 @@ class DataIter:
         raise NotImplementedError()
 
 
+# Notice for `_deprecate_positional_args`
+# Authors: Olivier Grisel
+#          Gael Varoquaux
+#          Andreas Mueller
+#          Lars Buitinck
+#          Alexandre Gramfort
+#          Nicolas Tresegnie
+#          Sylvain Marie
+# License: BSD 3 clause
 def _deprecate_positional_args(f):
     """Decorator for methods that issues warnings for positional arguments
+
+    Using the keyword-only argument syntax in pep 3102, arguments after the
+    * will issue a warning when passed as a positional argument.
 
     Modifed from sklearn utils.validation.
 
@@ -402,7 +414,7 @@ def _deprecate_positional_args(f):
             ]
             warnings.warn(
                 "Pass {} as keyword args.  Passing these as positional "
-                "arguments will be considered as error in uture releases.".
+                "arguments will be considered as error in future releases.".
                 format(", ".join(args_msg)), FutureWarning)
         for k, arg in zip(sig.parameters, args):
             kwargs[k] = arg

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -31,6 +31,7 @@ from .compat import CUDF_concat
 from .compat import lazy_isinstance
 
 from .core import DMatrix, DeviceQuantileDMatrix, Booster, _expect, DataIter
+from .core import _deprecate_positional_args
 from .training import train as worker_train
 from .tracker import RabitTracker
 from .sklearn import XGBModel, XGBRegressorBase, XGBClassifierBase
@@ -1015,7 +1016,8 @@ class DaskScikitLearnBase(XGBModel):
     _client = None
 
     # pylint: disable=arguments-differ
-    def fit(self, X, y,
+    @_deprecate_positional_args
+    def fit(self, X, y, *,
             sample_weight=None,
             base_margin=None,
             eval_set=None,
@@ -1039,6 +1041,8 @@ class DaskScikitLearnBase(XGBModel):
         sample_weight_eval_set : list, optional
             A list of the form [L_1, L_2, ..., L_n], where each L_i is a list
             of group weights on the i-th validation set.
+        early_stopping_rounds : int
+            Activates early stopping.
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation
             metric measured on the validation set to stderr.'''
@@ -1101,9 +1105,11 @@ class DaskXGBRegressor(DaskScikitLearnBase, XGBRegressorBase):
         return self
 
     # pylint: disable=missing-docstring
+    @_deprecate_positional_args
     def fit(self,
             X,
             y,
+            *,
             sample_weight=None,
             base_margin=None,
             eval_set=None,
@@ -1183,9 +1189,11 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
         self.evals_result_ = results['history']
         return self
 
+    @_deprecate_positional_args
     def fit(self,
             X,
             y,
+            *,
             sample_weight=None,
             base_margin=None,
             eval_set=None,

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -776,7 +776,7 @@ class XGBModel(XGBModelBase):
 class XGBClassifier(XGBModel, XGBClassifierBase):
     # pylint: disable=missing-docstring,invalid-name,too-many-instance-attributes
     @_deprecate_positional_args
-    def __init__(self, objective="binary:logistic", use_label_encoder=True, **kwargs):
+    def __init__(self, *, objective="binary:logistic", use_label_encoder=True, **kwargs):
         self.use_label_encoder = use_label_encoder
         super().__init__(objective=objective, **kwargs)
 
@@ -1067,7 +1067,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
 class XGBRFClassifier(XGBClassifier):
     # pylint: disable=missing-docstring
     @_deprecate_positional_args
-    def __init__(self,
+    def __init__(self, *,
                  learning_rate=1,
                  subsample=0.8,
                  colsample_bynode=0.8,
@@ -1096,7 +1096,7 @@ class XGBRFClassifier(XGBClassifier):
 class XGBRegressor(XGBModel, XGBRegressorBase):
     # pylint: disable=missing-docstring
     @_deprecate_positional_args
-    def __init__(self, objective="reg:squarederror", **kwargs):
+    def __init__(self, *, objective="reg:squarederror", **kwargs):
         super().__init__(objective=objective, **kwargs)
 
 
@@ -1109,7 +1109,7 @@ class XGBRegressor(XGBModel, XGBRegressorBase):
 class XGBRFRegressor(XGBRegressor):
     # pylint: disable=missing-docstring
     @_deprecate_positional_args
-    def __init__(self, learning_rate=1, subsample=0.8, colsample_bynode=0.8,
+    def __init__(self, *, learning_rate=1, subsample=0.8, colsample_bynode=0.8,
                  reg_lambda=1e-5, **kwargs):
         super().__init__(learning_rate=learning_rate, subsample=subsample,
                          colsample_bynode=colsample_bynode,
@@ -1166,7 +1166,7 @@ class XGBRFRegressor(XGBRegressor):
 class XGBRanker(XGBModel):
     # pylint: disable=missing-docstring,too-many-arguments,invalid-name
     @_deprecate_positional_args
-    def __init__(self, objective='rank:pairwise', **kwargs):
+    def __init__(self, *, objective='rank:pairwise', **kwargs):
         super().__init__(objective=objective, **kwargs)
         if callable(self.objective):
             raise ValueError(

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -5,7 +5,7 @@ import copy
 import warnings
 import json
 import numpy as np
-from .core import Booster, DMatrix, XGBoostError
+from .core import Booster, DMatrix, XGBoostError, _deprecate_positional_args
 from .training import train
 from .data import _is_cudf_df, _is_cudf_ser, _is_cupy_array
 
@@ -445,6 +445,7 @@ class XGBModel(XGBModelBase):
         # Delete the attribute after load
         self.get_booster().set_attr(scikit_learn=None)
 
+    @_deprecate_positional_args
     def fit(self, X, y, sample_weight=None, base_margin=None,
             eval_set=None, eval_metric=None, early_stopping_rounds=None,
             verbose=True, xgb_model=None, sample_weight_eval_set=None,
@@ -778,6 +779,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         self.use_label_encoder = use_label_encoder
         super().__init__(objective=objective, **kwargs)
 
+    @_deprecate_positional_args
     def fit(self, X, y, sample_weight=None, base_margin=None,
             eval_set=None, eval_metric=None,
             early_stopping_rounds=None, verbose=True, xgb_model=None,
@@ -1167,6 +1169,7 @@ class XGBRanker(XGBModel):
         if "rank:" not in self.objective:
             raise ValueError("please use XGBRanker for ranking task")
 
+    @_deprecate_positional_args
     def fit(self, X, y, group, sample_weight=None, base_margin=None,
             eval_set=None, sample_weight_eval_set=None,
             eval_group=None, eval_metric=None,

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -263,17 +263,18 @@ class XGBModel(XGBModelBase):
                 assert len(sample_weight_eval_set) == len(eval_set)
 
             evals = []
-            for i in range(len(eval_set)):
-                if eval_set[i][0] is X and eval_set[i][1] is y and \
+            for i, (valid_X, valid_y) in enumerate(eval_set):
+                if valid_X is X and valid_y is y and \
                    sample_weight_eval_set[i] is sample_weight and eval_group[i] is group:
                     evals.append(train_dmatrix)
                 else:
-                    m = DMatrix(eval_set[i][0],
-                                label=label_transform(eval_set[i][1]),
+                    m = DMatrix(valid_X,
+                                label=label_transform(valid_y),
                                 missing=self.missing, weight=sample_weight_eval_set[i],
                                 nthread=self.n_jobs)
                     m.set_info(group=eval_group[i])
                     evals.append(m)
+
             nevals = len(evals)
             eval_names = ["validation_{}".format(i) for i in range(nevals)]
             evals = list(zip(evals, eval_names))

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -775,6 +775,7 @@ class XGBModel(XGBModelBase):
 ''')
 class XGBClassifier(XGBModel, XGBClassifierBase):
     # pylint: disable=missing-docstring,invalid-name,too-many-instance-attributes
+    @_deprecate_positional_args
     def __init__(self, objective="binary:logistic", use_label_encoder=True, **kwargs):
         self.use_label_encoder = use_label_encoder
         super().__init__(objective=objective, **kwargs)
@@ -1065,6 +1066,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
 ''')
 class XGBRFClassifier(XGBClassifier):
     # pylint: disable=missing-docstring
+    @_deprecate_positional_args
     def __init__(self,
                  learning_rate=1,
                  subsample=0.8,
@@ -1093,6 +1095,7 @@ class XGBRFClassifier(XGBClassifier):
     ['estimators', 'model', 'objective'])
 class XGBRegressor(XGBModel, XGBRegressorBase):
     # pylint: disable=missing-docstring
+    @_deprecate_positional_args
     def __init__(self, objective="reg:squarederror", **kwargs):
         super().__init__(objective=objective, **kwargs)
 
@@ -1105,6 +1108,7 @@ class XGBRegressor(XGBModel, XGBRegressorBase):
 ''')
 class XGBRFRegressor(XGBRegressor):
     # pylint: disable=missing-docstring
+    @_deprecate_positional_args
     def __init__(self, learning_rate=1, subsample=0.8, colsample_bynode=0.8,
                  reg_lambda=1e-5, **kwargs):
         super().__init__(learning_rate=learning_rate, subsample=subsample,
@@ -1161,6 +1165,7 @@ class XGBRFRegressor(XGBRegressor):
 ''')
 class XGBRanker(XGBModel):
     # pylint: disable=missing-docstring,too-many-arguments,invalid-name
+    @_deprecate_positional_args
     def __init__(self, objective='rank:pairwise', **kwargs):
         super().__init__(objective=objective, **kwargs)
         if callable(self.objective):

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -480,7 +480,7 @@ class XGBModel(XGBModelBase):
         self.get_booster().set_attr(scikit_learn=None)
 
     @_deprecate_positional_args
-    def fit(self, X, y, sample_weight=None, base_margin=None,
+    def fit(self, *, X, y, sample_weight=None, base_margin=None,
             eval_set=None, eval_metric=None, early_stopping_rounds=None,
             verbose=True, xgb_model=None, sample_weight_eval_set=None,
             feature_weights=None,
@@ -803,7 +803,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         super().__init__(objective=objective, **kwargs)
 
     @_deprecate_positional_args
-    def fit(self, X, y, sample_weight=None, base_margin=None,
+    def fit(self, *, X, y, sample_weight=None, base_margin=None,
             eval_set=None, eval_metric=None,
             early_stopping_rounds=None, verbose=True, xgb_model=None,
             sample_weight_eval_set=None, feature_weights=None, callbacks=None):
@@ -1183,7 +1183,7 @@ class XGBRanker(XGBModel):
             raise ValueError("please use XGBRanker for ranking task")
 
     @_deprecate_positional_args
-    def fit(self, X, y, group, sample_weight=None, base_margin=None,
+    def fit(self, *, X, y, group, sample_weight=None, base_margin=None,
             eval_set=None, sample_weight_eval_set=None,
             eval_group=None, eval_metric=None,
             early_stopping_rounds=None, verbose=False, xgb_model=None,

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -255,6 +255,8 @@ class XGBModel(XGBModelBase):
         '''Convert array_like evaluation matrices into DMatrix'''
         if eval_group is None and eval_set is not None:
             eval_group = [None] * len(eval_set)
+        else:
+            assert len(eval_group) == len(eval_set)
 
         if eval_set is not None:
             if sample_weight_eval_set is None:

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -32,7 +32,7 @@ def test_binary_classification():
     from sklearn.datasets import load_digits
     from sklearn.model_selection import KFold
 
-    digits = load_digits(2)
+    digits = load_digits(n_class=2)
     y = digits['target']
     X = digits['data']
     kf = KFold(n_splits=2, shuffle=True, random_state=rng)
@@ -166,7 +166,7 @@ def test_stacking_classification():
 def test_feature_importances_weight():
     from sklearn.datasets import load_digits
 
-    digits = load_digits(2)
+    digits = load_digits(n_class=2)
     y = digits['target']
     X = digits['data']
     xgb_model = xgb.XGBClassifier(random_state=0,
@@ -204,7 +204,7 @@ def test_feature_importances_weight():
 def test_feature_importances_gain():
     from sklearn.datasets import load_digits
 
-    digits = load_digits(2)
+    digits = load_digits(n_class=2)
     y = digits['target']
     X = digits['data']
     xgb_model = xgb.XGBClassifier(
@@ -243,7 +243,7 @@ def test_feature_importances_gain():
 def test_select_feature():
     from sklearn.datasets import load_digits
     from sklearn.feature_selection import SelectFromModel
-    digits = load_digits(2)
+    digits = load_digits(n_class=2)
     y = digits['target']
     X = digits['data']
     cls = xgb.XGBClassifier()
@@ -376,7 +376,7 @@ def test_classification_with_custom_objective():
         hess = y_pred * (1.0 - y_pred)
         return grad, hess
 
-    digits = load_digits(2)
+    digits = load_digits(n_class=2)
     y = digits['target']
     X = digits['data']
     kf = KFold(n_splits=2, shuffle=True, random_state=rng)
@@ -473,7 +473,7 @@ def test_sklearn_nfolds_cv():
     from sklearn.datasets import load_digits
     from sklearn.model_selection import StratifiedKFold
 
-    digits = load_digits(3)
+    digits = load_digits(n_class=3)
     X = digits['data']
     y = digits['target']
     dm = xgb.DMatrix(X, label=y)
@@ -505,7 +505,7 @@ def test_sklearn_nfolds_cv():
 def test_split_value_histograms():
     from sklearn.datasets import load_digits
 
-    digits_2class = load_digits(2)
+    digits_2class = load_digits(n_class=2)
 
     X = digits_2class['data']
     y = digits_2class['target']
@@ -591,7 +591,7 @@ def test_sklearn_clone():
 
 def test_sklearn_get_default_params():
     from sklearn.datasets import load_digits
-    digits_2class = load_digits(2)
+    digits_2class = load_digits(n_class=2)
     X = digits_2class['data']
     y = digits_2class['target']
     cls = xgb.XGBClassifier()

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -96,7 +96,7 @@ def test_ranking():
               'learning_rate': 0.1, 'gamma': 1.0, 'min_child_weight': 0.1,
               'max_depth': 6, 'n_estimators': 4}
     model = xgb.sklearn.XGBRanker(**params)
-    model.fit(x_train, y_train, train_group,
+    model.fit(x_train, y_train, group=train_group,
               eval_set=[(x_valid, y_valid)], eval_group=[valid_group])
     pred = model.predict(x_test)
 

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -889,6 +889,11 @@ def test_parameter_validation():
     assert len(output) == 0
 
 
+def test_deprecate_position_arg():
+    with pytest.warns(FutureWarning):
+        xgb.XGBRegressor(3, learning_rate=0.1)
+
+
 @pytest.mark.skipif(**tm.no_pandas())
 def test_pandas_input():
     import pandas as pd

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -890,8 +890,39 @@ def test_parameter_validation():
 
 
 def test_deprecate_position_arg():
+    from sklearn.datasets import load_digits
+    X, y = load_digits(return_X_y=True, n_class=2)
+    w = y
     with pytest.warns(FutureWarning):
         xgb.XGBRegressor(3, learning_rate=0.1)
+    model = xgb.XGBRegressor(n_estimators=1)
+    with pytest.warns(FutureWarning):
+        model.fit(X, y, w)
+
+    with pytest.warns(FutureWarning):
+        xgb.XGBClassifier(1, use_label_encoder=False)
+    model = xgb.XGBClassifier(n_estimators=1, use_label_encoder=False)
+    with pytest.warns(FutureWarning):
+        model.fit(X, y, w)
+
+    with pytest.warns(FutureWarning):
+        xgb.XGBRanker('rank:ndcg', learning_rate=0.1)
+    model = xgb.XGBRanker(n_estimators=1)
+    group = np.repeat(1, X.shape[0])
+    with pytest.warns(FutureWarning):
+        model.fit(X, y, group)
+
+    with pytest.warns(FutureWarning):
+        xgb.XGBRFRegressor(1, learning_rate=0.1)
+    model = xgb.XGBRFRegressor(n_estimators=1)
+    with pytest.warns(FutureWarning):
+        model.fit(X, y, w)
+
+    with pytest.warns(FutureWarning):
+        xgb.XGBRFClassifier(1, use_label_encoder=True)
+    model = xgb.XGBRFClassifier(n_estimators=1)
+    with pytest.warns(FutureWarning):
+        model.fit(X, y, w)
 
 
 @pytest.mark.skipif(**tm.no_pandas())


### PR DESCRIPTION
Deprecate positional arguments in following functions:

- `__init__` for all classes in sklearn module.
- `fit` method for all classes in sklearn module.
- `set_info` for `DMatrix` class.

Refactor the evaluation matrices handling.

Close https://github.com/dmlc/xgboost/issues/6172 .