### PR TITLE
Show partition status in dask error.

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -313,7 +313,7 @@ class DaskDMatrix:
         await distributed.wait(parts)  # async wait for parts to be computed
 
         for part in parts:
-            assert part.status == 'finished'
+            assert part.status == 'finished', part.status
 
         # Preserving the partition order for prediction.
         self.partition_order = {}


### PR DESCRIPTION
Related https://github.com/dmlc/xgboost/issues/6364 .  Let the assert error show partition status for easier debugging in the future.