### PR TITLE
[dask] Fix union of workers.

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -626,7 +626,7 @@ def _get_workers_from_data(dtrain: DaskDMatrix, evals=()):
             assert len(e) == 2
             assert isinstance(e[0], DaskDMatrix) and isinstance(e[1], str)
             worker_map = set(e[0].worker_map.keys())
-            X_worker_map.union(worker_map)
+            X_worker_map = X_worker_map.union(worker_map)
     return X_worker_map
 
 

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -777,6 +777,26 @@ class TestDaskCallbacks:
         dump = booster.get_dump(dump_format='json')
         assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
 
+    def test_n_workers(self):
+        with LocalCluster(n_workers=2) as cluster:
+            with Client(cluster) as client:
+                workers = list(_get_client_workers(client).keys())
+                from sklearn.datasets import load_breast_cancer
+                X, y = load_breast_cancer(return_X_y=True)
+                dX = client.submit(da.from_array, X, workers=[workers[0]]).result()
+                dy = client.submit(da.from_array, y, workers=[workers[0]]).result()
+                train = xgb.dask.DaskDMatrix(client, dX, dy)
+
+                dX = dd.from_array(X)
+                dX = client.persist(dX, workers={dX: workers[1]})
+                dy = dd.from_array(y)
+                dy = client.persist(dy, workers={dy: workers[1]})
+                valid = xgb.dask.DaskDMatrix(client, dX, dy)
+
+                merged = xgb.dask._get_workers_from_data(train, evals=[(valid, 'Valid')])
+                assert len(merged) == 2
+
+
     def test_data_initialization(self):
         '''Assert each worker has the correct amount of data, and DMatrix initialization doesn't
         generate unnecessary copies of data.

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -796,6 +796,7 @@ class TestDaskCallbacks:
                 merged = xgb.dask._get_workers_from_data(train, evals=[(valid, 'Valid')])
                 assert len(merged) == 2
 
+
     def test_data_initialization(self):
         '''Assert each worker has the correct amount of data, and DMatrix initialization doesn't
         generate unnecessary copies of data.
@@ -812,16 +813,16 @@ class TestDaskCallbacks:
 
                 def worker_fn(worker_addr, data_ref):
                     with xgb.dask.RabitContext(rabit_args):
-                        total = np.array([data_ref.num_row()])
+                        local_dtrain = xgb.dask._dmatrix_from_list_of_parts(**data_ref)
+                        total = np.array([local_dtrain.num_row()])
                         total = xgb.rabit.allreduce(total, xgb.rabit.Op.SUM)
                         assert total[0] == kRows
 
                 futures = []
                 for i in range(len(workers)):
-                    futures.append(client.submit(
-                        worker_fn, workers[i],
-                        xgb.dask._init_dmatrix(m, workers[i], client), pure=False,
-                        workers=[workers[i]]))
+                    futures.append(client.submit(worker_fn, workers[i],
+                                                 m.create_fn_args(workers[i]), pure=False,
+                                                 workers=[workers[i]]))
                 client.gather(futures)
 
                 has_what = client.has_what()


### PR DESCRIPTION
* Fix union of workers.
* Submit with future of `DMatrix` directly, simplifying training.
* Avoid the use of `**kwargs`.