### PR TITLE
Disable HT for DMatrix creation

### DIFF
--- a/src/common/threading_utils.h
+++ b/src/common/threading_utils.h
@@ -160,6 +160,16 @@ inline int32_t OmpSetNumThreads(int32_t* p_threads) {
   omp_set_num_threads(threads);
   return nthread_original;
 }
+inline int32_t OmpSetNumThreadsWithoutHT(int32_t* p_threads) {
+  auto& threads = *p_threads;
+  int32_t nthread_original = omp_get_max_threads();
+  if (threads <= 0) {
+    threads = nthread_original;
+  }
+  omp_set_num_threads(threads);
+  return nthread_original;
+}
+
 }  // namespace common
 }  // namespace xgboost
 

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -22,7 +22,6 @@
 #include "../common/threading_utils.h"
 #include "../data/adapter.h"
 #include "../data/iterative_device_dmatrix.h"
-
 #if DMLC_ENABLE_STD_THREAD
 #include "./sparse_page_source.h"
 #include "./sparse_page_dmatrix.h"
@@ -844,7 +843,7 @@ void SparsePage::Push(const SparsePage &batch) {
 template <typename AdapterBatchT>
 uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread) {
   // Set number of threads but keep old value so we can reset it after
-  int nthread_original = common::OmpSetNumThreads(&nthread);
+  int nthread_original = common::OmpSetNumThreadsWithoutHT(&nthread);
   auto& offset_vec = offset.HostVector();
   auto& data_vec = data.HostVector();
 

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -22,6 +22,7 @@
 #include "../common/threading_utils.h"
 #include "../data/adapter.h"
 #include "../data/iterative_device_dmatrix.h"
+
 #if DMLC_ENABLE_STD_THREAD
 #include "./sparse_page_source.h"
 #include "./sparse_page_dmatrix.h"

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -17,7 +17,6 @@
 #include "../common/random.h"
 #include "../common/threading_utils.h"
 #include "adapter.h"
-
 namespace xgboost {
 namespace data {
 MetaInfo& SimpleDMatrix::Info() { return info_; }
@@ -93,7 +92,7 @@ BatchSet<EllpackPage> SimpleDMatrix::GetEllpackBatches(const BatchParam& param) 
 template <typename AdapterT>
 SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {
   // Set number of threads but keep old value so we can reset it after
-  int nthread_original = common::OmpSetNumThreads(&nthread);
+  int nthread_original = common::OmpSetNumThreadsWithoutHT(&nthread);
 
   std::vector<uint64_t> qids;
   uint64_t default_max = std::numeric_limits<uint64_t>::max();

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -17,6 +17,7 @@
 #include "../common/random.h"
 #include "../common/threading_utils.h"
 #include "adapter.h"
+
 namespace xgboost {
 namespace data {
 MetaInfo& SimpleDMatrix::Info() { return info_; }


### PR DESCRIPTION
Recently introduced `OmpSetNumThreads` function brings up to 2x slowdown on HW with enabled Hyper-threading.

DMatrix create time| master, s | this PR, s | Speedup
-- | -- | -- | --
mortgage | 11.67 | 5.68 | 2.05
higgs | 0.96 | 0.51 | 1.88
msrank | 4.36 | 3.53 | 1.23

It significantly affects inference stage as was mentioned in https://github.com/dmlc/xgboost/issues/6283.

Reason: there is still overheads on memory allocation\initialization (`InitBudget`, `InitStorage`) so there is no gain from usage HT here.
