### PR TITLE
[CI] Upgrade to MacOS Mojave image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,15 @@ jobs:
         - docker
     - os: osx
       arch: amd64
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env: TASK=python_test
     - os: osx
       arch: amd64
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env: TASK=python_sdist_test
     - os: osx
       arch: amd64
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env: TASK=java_test
     - os: linux
       arch: s390x

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -44,7 +44,7 @@ if [ ${TASK} == "python_test" ]; then
       cd ../python-package
       python setup.py bdist_wheel
       cd ..
-      TAG=macosx_10_13_x86_64.macosx_10_14_x86_64.macosx_10_15_x86_64
+      TAG=macosx_10_14_x86_64.macosx_10_15_x86_64.macosx_11_0_x86_64
       python tests/ci_build/rename_whl.py python-package/dist/*.whl ${TRAVIS_COMMIT} ${TAG}
     fi
 


### PR DESCRIPTION
Homebrew just added support for MacOS Big Sur (11.0) and dropped High Sierra (10.13), according to their policy of supporting three latest MacOS releases. So we require MacOS Mojave from now on.

@trivialfis This should unblock the CI.