### PR TITLE
Improved InitSampling function speed by 2.12 times

### DIFF
--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -691,8 +691,8 @@ void QuantileHistMaker::Builder<GradientSumT>::InitSampling(const std::vector<Gr
     r = rnd;
   }
   const size_t discard_size = info.num_row_ / nthread;
-  uint32_t coin_flip_border = static_cast<uint32_t>(std::numeric_limits<uint32_t>::max()
-                                                    * param_.subsample);
+  auto upper_border = static_cast<float>(std::numeric_limits<uint32_t>::max());
+  uint32_t coin_flip_border = static_cast<uint32_t>(upper_border * param_.subsample);
   #pragma omp parallel num_threads(nthread)
   {
     const size_t tid = omp_get_thread_num();

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -691,17 +691,18 @@ void QuantileHistMaker::Builder<GradientSumT>::InitSampling(const std::vector<Gr
     r = rnd;
   }
   const size_t discard_size = info.num_row_ / nthread;
+  uint32_t coin_flip_border = static_cast<uint32_t>(std::numeric_limits<uint32_t>::max()
+                                                    * param_.subsample);
   #pragma omp parallel num_threads(nthread)
   {
     const size_t tid = omp_get_thread_num();
     const size_t ibegin = tid * discard_size;
     const size_t iend = (tid == (nthread - 1)) ?
                         info.num_row_ : ibegin + discard_size;
-    std::bernoulli_distribution coin_flip(param_.subsample);
 
-    rnds[tid].discard(2*discard_size * tid);
+    rnds[tid].discard(discard_size * tid);
     for (size_t i = ibegin; i < iend; ++i) {
-      if (gpair[i].GetHess() >= 0.0f && coin_flip(rnds[tid])) {
+      if (gpair[i].GetHess() >= 0.0f && rnds[tid]() < coin_flip_border) {
         p_row_indices[ibegin + row_offsets[tid]++] = i;
       }
     }


### PR DESCRIPTION
This PR is connected with #6411 
Discarding elements from generators takes up most of the working time in `InitSampling`.
Since stdlibc++ doesn't have any random engines with o(n) complexity (little-o), we only can optimize the number of discarded elements.
 `std::bernoulli_distribution` requires 64-bit input, so in previous version we had to discard twice as much elements as now.
This little optimization gives us ~2.12 speed up of `InitSampling` time, which translates into up to 16% speed up of the whole training time when `subsampling < 1`
The quality remains the same:


Mortgage dataset |  |  |
-- | -- | --
version | training time | RMSE
original | 35.479 | 0.009271
optimized | 30.538 | 0.009262


Santander dataset |   |   |  | |
-- | -- | -- | -- | --
version | training time, s | InitData time, s | init improvement, % | Log Loss
original | 249.196 | 28.784 | 0.00 | 0.16607
optimized | 239.298 | 17.173 | 67.61 | 0.16610
no discard | 224.347 | 11.221 | 156.51 | 0.16613


Higgs dataset |  |  |  |  |
-- | -- | -- | -- | --
version | training time, s | InitData time, s | init improvement, % | Log Loss
original | 34.235 | 14.373 | 0.00 | 0.09339
optimized | 29.201 | 8.316 | 72.84 | 0.09409