### PR TITLE
Removed discard from InitSampling

### DIFF
--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -691,8 +691,8 @@ void QuantileHistMaker::Builder<GradientSumT>::InitSampling(const std::vector<Gr
     r = std::mt19937(rnd());
   }
   const size_t discard_size = info.num_row_ / nthread;
-  uint32_t coin_flip_border = static_cast<uint32_t>(std::numeric_limits<uint32_t>::max()
-                                                    * param_.subsample);
+  auto upper_border = static_cast<float>(std::numeric_limits<uint32_t>::max());
+  uint32_t coin_flip_border = static_cast<uint32_t>(upper_border * param_.subsample);
 
   #pragma omp parallel num_threads(nthread)
   {


### PR DESCRIPTION
This PR is connected with #6410 
We can avoid discarding if use different seeds for each generator. This is not quite the right approach, but the quality does not suffer much.

Mortgage dataset |   |   |  |
-- | -- | -- | --
version | training time, s | improvement, % | RMSE
original | 35.479 | 0.00 | 0.00927
optimized | 30.538 | 16.18 | 0.00926
no discard | 26.994 | 31.43 | 0.00925


Santander dataset |   |   |  | |
-- | -- | -- | -- | --
version | training time, s | InitData time, s | init improvement, % | Log Loss
original | 249.196 | 28.784 | 0.00 | 0.16607
optimized | 239.298 | 17.173 | 67.61 | 0.16610
no discard | 224.347 | 11.221 | 156.51 | 0.16613


Higgs dataset |   |   |  | |
-- | -- | -- | -- | --
version | training time, s | InitData time, s | init improvement, % | Log Loss
original | 34.235 | 14.373 | 0.00 | 0.09339
optimized | 29.201 | 8.316 | 72.84 | 0.09409
no discard | 25.916 | 5.160 | 178.54 | 0.09475