### PR TITLE
[R] Fix R package installation via CMake

### DIFF
--- a/cmake/RPackageInstallTargetSetup.cmake
+++ b/cmake/RPackageInstallTargetSetup.cmake
@@ -6,8 +6,8 @@ function(setup_rpackage_install_target rlib_target build_dir)
   install(
     DIRECTORY "${xgboost_SOURCE_DIR}/R-package"
     DESTINATION "${build_dir}"
-    REGEX "src/*" EXCLUDE
-    REGEX "R-package/configure" EXCLUDE
+    PATTERN "src/*" EXCLUDE
+    PATTERN "R-package/configure" EXCLUDE
   )
   install(TARGETS ${rlib_target}
     LIBRARY DESTINATION "${build_dir}/R-package/src/"


### PR DESCRIPTION
Closes #6421 

The expression `src/*` is a globbing pattern and not a regular expression. So in the `install` command, we need to use the `PATTERN` keyword to specify the exclusion pattern `src/*`.

**Why did we not find the bug so far?**
The `src/*` expression is an ill-formed regular expression and thus triggers a platform-specific behavior, which broke installation of the R package only on some platforms:
* On Ubuntu and MacOS, `src/*` was interpreted as the set of all files under the `src/` directory. So only the files under `src/` directory got excluded from copying. With this behavior, installation works fine:
```
Install the project...
-- Install configuration: "Release"
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/cleanup
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/man
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/man/dimnames.xgb.DMatrix.Rd
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/man/agaricus.test.Rd
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/man/xgb.plot.deepness.Rd
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/man/normalize.Rd
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/man/cb.reset.parameters.Rd
....
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/inst/make-r-def.R
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/CMakeLists.txt
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/configure.win
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/DESCRIPTION
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/NAMESPACE
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/.Rbuildignore
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/src/xgboost.so
-- Set runtime path of "/home/hcho3/src/xgboost/build/R-package-install/R-package/src/xgboost.so" to ""
Command: /usr/bin/R -q -e deps = setdiff(c('data.table', 'magrittr', 'stringi'), rownames(installed.packages()))\  if(length(deps)>0) install.packages(deps, repo = 'https://cloud.r-project.org/')
Command: /usr/bin/R CMD INSTALL --no-multiarch --build /home/hcho/src/xgboost/build/R-package-install/R-package
```
* On the other hand, on Febora, `src/*` was interpreted as the set of all files everywhere. So all the files got excluded from copying and led to empty `R-package-install` directory. This breaks installation.
```
Install the project...
-- Install configuration: "Release"
-- Installing: /home/hcho3/src/xgboost/build/R-package-install/R-package/src/xgboost.so
-- Set runtime path of "/home/hcho3/src/xgboost/build/R-package-install/R-package/src/xgboost.so" to ""
Command: /usr/bin/R -q -e deps = setdiff(c('data.table', 'magrittr', 'stringi'), rownames(installed.packages()))\  if(length(deps)>0) install.packages(deps, repo = 'https://cloud.r-project.org/')
Command: /usr/bin/R CMD INSTALL --no-multiarch --build /home/hcho3/src/xgboost/build/R-package-install/R-package
CMake Error at RPackageInstall.cmake:16 (message):
  out: , err: Warning: invalid package
  ‘/home/hcho3/src/xgboost/build/R-package-install/R-package’

  Error: ERROR: no packages specified

  , res: 1
```

Treating `src/*` as a globbing pattern avoids the undefined behavior.

Special thanks to @adatum who lent me SSH access to his machine. I was able to quickly reproduce the reported issue and find the fix.