### PR TITLE
Update the comments

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -81,7 +81,7 @@ XGB_DLL int XGDMatrixCreateFromFile(const char *fname,
  * \param data fvalue
  * \param nindptr number of rows in the matrix + 1
  * \param nelem number of nonzero elements in the matrix
- * \param num_col number of columns; when it's set to 0, then guess from data
+ * \param num_col number of columns; when it's set to kAdapterUnknownSize, then guess from data
  * \param out created dmatrix
  * \return 0 when success, -1 when failure happens
  */


### PR DESCRIPTION
After upgrading XGBoost to the master version, I found that when I set the param num_col to 0 as usual in `XGDMatrixCreateFromFile`, it could not get the correct columns. 
Signed-off-by: Hao Ziyu <haoziyu@qiyi.com>