### PR TITLE
Fix docstring of config.py to use correct versionadded

### DIFF
--- a/python-package/xgboost/config.py
+++ b/python-package/xgboost/config.py
@@ -35,7 +35,7 @@ def config_doc(*, header=None, extra_note=None, parameters=None, returns=None,
 
     {extra_note}
 
-    .. versionadded:: 1.3.0
+    .. versionadded:: 1.4.0
     """
 
     common_example = """


### PR DESCRIPTION
Follow-up to #6414

The `versionadded` field of `set_config` should be 1.4.0, since global configuration won't be part of the upcoming 1.3.0 release.