### PR TITLE
Don't validate feature when number of rows is 0.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2025,6 +2025,9 @@ class Booster(object):
         Validate Booster and data's feature_names are identical.
         Set feature_names and feature_types from DMatrix
         """
+        if data.num_row() == 0:
+            return
+
         if self.feature_names is None:
             self.feature_names = data.feature_names
             self.feature_types = data.feature_types


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/6268 .

The script provided by @pseudotensor still fails due to auc doesn't handle empty dataset.  But that will be tracked in https://github.com/dmlc/xgboost/issues/6272 .