### PR TITLE
Pass correct split_type to GPU predictor

### DIFF
--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -272,7 +272,11 @@ PredictKernel(Data data, common::Span<const RegTree::Node> d_nodes,
           d_categories.subspan(d_cat_tree_segments[tree_idx - tree_begin],
                                d_cat_tree_segments[tree_idx - tree_begin + 1] -
                                d_cat_tree_segments[tree_idx - tree_begin]);
-      float leaf = GetLeafWeight(global_idx, d_tree, d_tree_split_types,
+      auto tree_split_types =
+          d_tree_split_types.subspan(d_tree_segments[tree_idx - tree_begin],
+                                     d_tree_segments[tree_idx - tree_begin + 1] -
+                                     d_tree_segments[tree_idx - tree_begin]);
+      float leaf = GetLeafWeight(global_idx, d_tree, tree_split_types,
                                  tree_cat_ptrs,
                                  tree_categories,
                                  &loader);


### PR DESCRIPTION
The GPU predictor was producing incorrect prediction for models with categorical splits, because the whole `d_tree_split_types` span was being passed to the `GetLeafWeight` kernel, when the kernel had expected a subspan corresponding to a single tree.

This PR also adds a test example that fails with the current code and passes with the proposed patch.