### PR TITLE
Fix handling of print period in EvaluationMonitor

### DIFF
--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -154,7 +154,7 @@ void PredictBatchByBlockOfRowsKernel(DataView batch, std::vector<bst_float> *out
   const auto nsize = static_cast<bst_omp_uint>(batch.Size());
 
   const bst_omp_uint n_row_blocks = (nsize) / block_of_rows_size + !!((nsize) % block_of_rows_size);
-#pragma omp parallel for schedule(static)
+#pragma omp parallel for schedule(guided)
   for (bst_omp_uint block_id = 0; block_id < n_row_blocks; ++block_id) {
     const size_t batch_offset = block_id * block_of_rows_size;
     const size_t block_size = std::min(nsize - batch_offset, block_of_rows_size);


### PR DESCRIPTION
Currently `verbose_eval` parameter is not taking into account due simple typo in callback.py
If we set `verbose_eval=100` print log is:

[1]     eval-auc:0.54791        train-auc:0.54620
...
[98]   eval-auc:0.88926        train-auc:0.90105
[99]   eval-auc:0.88921        train-auc:0.90110
[101]  eval-auc:0.88928        train-auc:0.90114
...

After fix:
[0]     eval-auc:0.53902        train-auc:0.53251
[100]  eval-auc:0.88931        train-auc:0.90116
...

Similar to 1.2.0 print log