### PR TITLE
Fix handling of print period in EvaluationMonitor

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -621,7 +621,7 @@ class EvaluationMonitor(TrainingCallback):
                     msg += self._fmt_metric(data, metric_name, score, stdv)
             msg += '\n'
 
-            if (epoch % self.period) != 0 or self.period == 1:
+            if (epoch % self.period) == 0 or self.period == 1:
                 rabit.tracker_print(msg)
                 self._latest = None
             else:


### PR DESCRIPTION
Currently `verbose_eval` parameter is not taking into account due simple typo in callback.py
If we set `verbose_eval=100` print log is:

[1] eval-auc:0.54791 train-auc:0.54620
...
[98] eval-auc:0.88926 train-auc:0.90105
[99] eval-auc:0.88921 train-auc:0.90110
[101] eval-auc:0.88928 train-auc:0.90114
...

After fix:
[0] eval-auc:0.53902 train-auc:0.53251
[100] eval-auc:0.88931 train-auc:0.90116
...

Similar to v1.2.0 print log