### PR TITLE
add credentials to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,13 @@ dask-worker-space/
 
 # Jupyter notebook checkpoints
 .ipynb_checkpoints/
+
+# credentials and key material
+config
+credentials
+credentials.csv
+*.env
+*.pem
+*.pub
+*.rdp
+*_rsa


### PR DESCRIPTION
This PR proposes adding some rules to `.gitignore` to prevent sensitive information like passwords and access keys from being checked into source control.

I've added common extensions for key material, plus the specific files that the AWS CLI docs encourage people to create: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html.

Thanks for your time and consideration.