### PR TITLE
Calling XGBModel.fit() should clear the Booster by default

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -501,8 +501,7 @@ class XGBModel(XGBModelBase):
         eval_metric: Optional[Union[Callable, str, List[str]]],
         params: Dict[str, Any],
     ) -> Tuple[Booster, Optional[Union[Callable, str, List[str]]], Dict[str, Any]]:
-        model = self._Booster if hasattr(self, "_Booster") else None
-        model = booster if booster is not None else model
+        model = booster if booster is not None else None
         feval = eval_metric if callable(eval_metric) else None
         if eval_metric is not None:
             if callable(eval_metric):

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -501,6 +501,7 @@ class XGBModel(XGBModelBase):
         eval_metric: Optional[Union[Callable, str, List[str]]],
         params: Dict[str, Any],
     ) -> Tuple[Booster, Optional[Union[Callable, str, List[str]]], Dict[str, Any]]:
+        # pylint: disable=protected-access, no-self-use
         model = booster
         if hasattr(model, '_Booster'):
             model = model._Booster  # Handle the case when xgb_model is a sklearn model object
@@ -1333,7 +1334,7 @@ class XGBRanker(XGBModel):
             params.update({'eval_metric': eval_metric})
         if hasattr(xgb_model, '_Booster'):
             # Handle the case when xgb_model is a sklearn model object
-            xgb_model = xgb_model._Booster
+            xgb_model = xgb_model._Booster  # pylint: disable=protected-access
 
         self._Booster = train(params, train_dmatrix,
                               self.n_estimators,

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -517,7 +517,11 @@ class XGBModel(XGBModelBase):
             feature_weights=None,
             callbacks=None):
         # pylint: disable=invalid-name,attribute-defined-outside-init
-        """Fit gradient boosting model
+        """Fit gradient boosting model.
+
+        Note that calling ``fit()`` multiple times will cause the model object to be re-fit from
+        scratch. To resume training from a previous checkpoint, explicitly pass ``xgb_model``
+        argument.
 
         Parameters
         ----------
@@ -1210,6 +1214,10 @@ class XGBRanker(XGBModel):
             feature_weights=None, callbacks=None):
         # pylint: disable = attribute-defined-outside-init,arguments-differ
         """Fit gradient boosting ranker
+
+        Note that calling ``fit()`` multiple times will cause the model object to be re-fit from
+        scratch. To resume training from a previous checkpoint, explicitly pass ``xgb_model``
+        argument.
 
         Parameters
         ----------

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -501,7 +501,9 @@ class XGBModel(XGBModelBase):
         eval_metric: Optional[Union[Callable, str, List[str]]],
         params: Dict[str, Any],
     ) -> Tuple[Booster, Optional[Union[Callable, str, List[str]]], Dict[str, Any]]:
-        model = booster if booster is not None else None
+        model = booster
+        if hasattr(model, '_Booster'):
+            model = model._Booster  # Handle the case when xgb_model is a sklearn model object
         feval = eval_metric if callable(eval_metric) else None
         if eval_metric is not None:
             if callable(eval_metric):
@@ -1329,6 +1331,9 @@ class XGBRanker(XGBModel):
                 raise ValueError(
                     'Custom evaluation metric is not yet supported for XGBRanker.')
             params.update({'eval_metric': eval_metric})
+        if hasattr(xgb_model, '_Booster'):
+            # Handle the case when xgb_model is a sklearn model object
+            xgb_model = xgb_model._Booster
 
         self._Booster = train(params, train_dmatrix,
                               self.n_estimators,


### PR DESCRIPTION
Closes #6536

Calling `fit()` twice with a scikit-learn model object should cause the model to be cleared, e.g.

```python
import xgboost as xgb
from sklearn.datasets import load_boston

X, y = load_boston(return_X_y=True)

clf = xgb.XGBRegressor(n_estimators=5, max_depth=3, tree_method='hist', objective='reg:squarederror')
clf.fit(X, y, eval_set=[(X, y)])
clf.fit(X, y, eval_set=[(X, y)])  # should start training from scratch
```

Expected output:
```
[0]	validation_0-rmse:17.08995
[1]	validation_0-rmse:12.32976
[2]	validation_0-rmse:9.03587
[3]	validation_0-rmse:6.76642
[4]	validation_0-rmse:5.22241
[0]	validation_0-rmse:17.08995
[1]	validation_0-rmse:12.32976
[2]	validation_0-rmse:9.03587
[3]	validation_0-rmse:6.76642
[4]	validation_0-rmse:5.22241
```

Currently, XGBoost will automatically pick up the existing Booster object and use it as a checkpoint:
```
[0]	validation_0-rmse:17.08995
[1]	validation_0-rmse:12.32976
[2]	validation_0-rmse:9.03587
[3]	validation_0-rmse:6.76642
[4]	validation_0-rmse:5.22241
[0]	validation_0-rmse:4.18100
[1]	validation_0-rmse:3.46472
[2]	validation_0-rmse:3.02611
[3]	validation_0-rmse:2.74987
[4]	validation_0-rmse:2.54619
```
This behavior is not desired for most use cases of scikit-learn. For example, scikit-learn's cross-validation method will call `fit()` multiple times, with the expectation that the underlying model to be cleared for every invocation of `fit()`.

This PR fixes the behavior of `fit()` as follows:
* Calling `fit()` will clear any existing model. This behavior is now documented in the docstring of `fit()`.
* Users must explicitly specify the parameter `xgb_model` to resume training from a checkpoint.
* The `xgb_model` parameter can now be `XGBModel` object.