### PR TITLE
[WIP] [dask] Use inplace prediction by default.

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1543,16 +1543,13 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
         output_margin: bool,
         base_margin: Optional[_DaskCollection]
     ) -> _DaskCollection:
-        test_dmatrix = await DaskDMatrix(
-            client=self.client, data=X, base_margin=base_margin,
-            missing=self.missing
+        predt = await super()._predict_async(
+            X=X,
+            output_margin=output_margin,
+            base_margin=base_margin,
+            validate_features=validate_features
         )
-        pred_probs = await predict(client=self.client,
-                                   model=self.get_booster(),
-                                   data=test_dmatrix,
-                                   validate_features=validate_features,
-                                   output_margin=output_margin)
-        return _cls_predict_proba(self.objective, pred_probs, da.vstack)
+        return _cls_predict_proba(self.objective, predt, da.vstack)
 
     # pylint: disable=missing-docstring
     def predict_proba(

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1277,7 +1277,7 @@ class DaskScikitLearnBase(XGBModel):
                 base_margin=base_margin,
                 missing=self.missing,
             )
-            pred_probs = await predict(
+            predt = await predict(
                 client=self.client,
                 model=self.get_booster(),
                 data=test_dmatrix,
@@ -1285,14 +1285,14 @@ class DaskScikitLearnBase(XGBModel):
                 validate_features=validate_features,
             )
         else:
-            pred_probs = await inplace_predict(
+            predt = await inplace_predict(
                 client=self.client,
                 model=self.get_booster(),
                 data=data,
                 predict_type="margin" if output_margin else "value",
                 missing=self.missing,
             )
-        return pred_probs
+        return predt
 
     def predict(
         self,

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1543,7 +1543,7 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
         output_margin: bool,
         base_margin: Optional[_DaskCollection]
     ) -> _DaskCollection:
-        predt = await super()._predict_async(
+        predt = await self._predict_async(
             X=X,
             output_margin=output_margin,
             base_margin=base_margin,
@@ -1572,13 +1572,13 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
         )
 
     async def _predict_async(
-        self, data: _DaskCollection,
+        self, X: _DaskCollection,
         output_margin: bool = False,
         validate_features: bool = True,
         base_margin: Optional[_DaskCollection] = None
     ) -> _DaskCollection:
         pred_probs = await super()._predict_async(
-            data, output_margin, validate_features, base_margin
+            X, output_margin, validate_features, base_margin
         )
         if output_margin:
             return pred_probs


### PR DESCRIPTION
* Use inplace predict for dask skl interface.
* Fix https://github.com/dmlc/xgboost/issues/6553 by using `best_iteration`.  The issue was caused by ignoring `ntree_limit`, but this argument is confusing in the context of forest and multi-class, so I decided to avoid it for any new code.

To-do:
- [ ] Add tests for early stopping.