### PR TITLE
Support Solaris.

### DIFF
--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -55,7 +55,7 @@
 #endif  // defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 8) || __GNUC__ > 4)
 
 #if defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 8) || __GNUC__ > 4) && \
-    !defined(__CUDACC__)
+    !defined(__CUDACC__) && !defined(__sun) && !defined(sun)
 #include <parallel/algorithm>
 #define XGBOOST_PARALLEL_SORT(X, Y, Z) __gnu_parallel::sort((X), (Y), (Z))
 #define XGBOOST_PARALLEL_STABLE_SORT(X, Y, Z) \

--- a/rabit/include/rabit/internal/socket.h
+++ b/rabit/include/rabit/internal/socket.h
@@ -25,6 +25,10 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 
+#if defined(__sun)
+#include <sys/sockio.h>
+#endif  // defined(__sun)
+
 #endif  // defined(_WIN32)
 
 #include <string>

--- a/rabit/include/rabit/internal/socket.h
+++ b/rabit/include/rabit/internal/socket.h
@@ -29,6 +29,10 @@
 #include <sys/sockio.h>
 #endif  // defined(__sun)
 
+#if defined(__sun) || defined(sun)
+#include <sys/sockio.h>
+#endif  // defined(__sun) || defined(sun)
+
 #endif  // defined(_WIN32)
 
 #include <string>

--- a/rabit/include/rabit/internal/socket.h
+++ b/rabit/include/rabit/internal/socket.h
@@ -25,10 +25,6 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 
-#if defined(__sun)
-#include <sys/sockio.h>
-#endif  // defined(__sun)
-
 #if defined(__sun) || defined(sun)
 #include <sys/sockio.h>
 #endif  // defined(__sun) || defined(sun)


### PR DESCRIPTION
Related: https://github.com/dmlc/xgboost/issues/6542

I ran a test on https://builder.r-hub.io/ mentioned by @hcho3 .  The rabit issue is fixed, but the toolchain itself on the test machine seems a bit weird.

os: Oracle Solaris 10, x86, 32 bit, R-release.  A snippet of log is copied here, complete log is uploaded at the end.

```
./dmlc-core/include/dmlc/./base.h:207:65: note: #pragma message: Warning: FILE OFFSET BITS defined to be 32 bit
 #pragma message("Warning: FILE OFFSET BITS defined to be 32 bit")
                                                                 ^
In file included from /opt/csw/include/c++/5.5.0/tr1/random:46:0,
                 from /opt/csw/include/c++/5.5.0/parallel/random_number.h:36,
                 from /opt/csw/include/c++/5.5.0/parallel/partition.h:38,
                 from /opt/csw/include/c++/5.5.0/parallel/quicksort.h:36,
                 from /opt/csw/include/c++/5.5.0/parallel/sort.h:48,
                 from /opt/csw/include/c++/5.5.0/parallel/algo.h:45,
                 from /opt/csw/include/c++/5.5.0/parallel/algorithm:37,
                 from ./include/xgboost/base.h:59,
                 from ./include/xgboost/logging.h:14,
                 from xgboost_custom.cc:5:
/opt/csw/include/c++/5.5.0/tr1/cmath: In function ‘float std::tr1::acosh(float)’:
/opt/csw/include/c++/5.5.0/tr1/cmath:424:18: error: ‘float std::tr1::acosh(float)’ conflicts with a previous declaration
   acosh(float __x)
                  ^
In file included from /opt/csw/lib/gcc/i386-pc-solaris2.10/5.5.0/include-fixed/math.h:23:0,
                 from /opt/csw/include/c++/5.5.0/cmath:44,
                 from ./include/xgboost/base.h:11,
                 from ./include/xgboost/logging.h:14,
                 from xgboost_custom.cc:5:
/usr/include/iso/math_c99.h:754:15: note: previous declaration ‘float std::acosh(float)’
  inline float acosh(float __X) { return __acoshf(__X); }
               ^
In file included from /opt/csw/include/c++/5.5.0/tr1/random:46:0,
                 from /opt/csw/include/c++/5.5.0/parallel/random_number.h:36,
                 from /opt/csw/include/c++/5.5.0/parallel/partition.h:38,
                 from /opt/csw/include/c++/5.5.0/parallel/quicksort.h:36,
                 from /opt/csw/include/c++/5.5.0/parallel/sort.h:48,
                 from /opt/csw/include/c++/5.5.0/parallel/algo.h:45,
                 from /opt/csw/include/c++/5.5.0/parallel/algorithm:37,
                 from ./include/xgboost/base.h:59,
                 from ./include/xgboost/logging.h:14,
                 from xgboost_custom.cc:5:
/opt/csw/include/c++/5.5.0/tr1/cmath: In function ‘long double std::tr1::acosh(long double)’:
/opt/csw/include/c++/5.5.0/tr1/cmath:428:24: error: ‘long double std::tr1::acosh(long double)’ conflicts with a previous declaration
   acosh(long double __x)
                        ^
In file included from /opt/csw/lib/gcc/i386-pc-solaris2.10/5.5.0/include-fixed/math.h:23:0,
                 from /opt/csw/include/c++/5.5.0/cmath:44,
                 from ./include/xgboost/base.h:11,
                 from ./include/xgboost/logging.h:14,
                 from xgboost_custom.cc:5:
/usr/include/iso/math_c99.h:796:21: note: previous declaration ‘long double std::acosh(long double)’
  inline long double acosh(long double __X) { return __acoshl(__X); }
```

[log.zip](https://github.com/dmlc/xgboost/files/5777874/log.zip)