### PR TITLE
Support `_estimator_type`.

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -493,8 +493,8 @@ class XGBModel(XGBModelBase):
             if k == "_estimator_type":
                 if self._estimator_type != v:
                     raise TypeError(
-                        "Loading an estimator with different type "
-                        f"{self._estimator_type}, {v}"
+                        "Loading an estimator with different type. "
+                        f"Expecting: {self._estimator_type}, got: {v}"
                     )
                 continue
             states[k] = v

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -304,9 +304,6 @@ class XGBModel(XGBModelBase):
         '''Tags used for scikit-learn data validation.'''
         return {'allow_nan': True, 'no_validation': True}
 
-    def _model_type(self):
-        raise NotImplementedError("Base model doesn't have model type.")
-
     def get_booster(self):
         """Get the underlying xgboost Booster of this model.
 
@@ -856,9 +853,6 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
     def __init__(self, *, objective="binary:logistic", use_label_encoder=True, **kwargs):
         self.use_label_encoder = use_label_encoder
         super().__init__(objective=objective, **kwargs)
-
-    def _model_type(self) -> str:
-        return "cls"
 
     @_deprecate_positional_args
     def fit(self, X, y, *, sample_weight=None, base_margin=None,

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -415,8 +415,9 @@ class XGBModel(XGBModelBase):
 
     def _get_type(self) -> str:
         if not hasattr(self, '_estimator_type'):
-            raise AttributeError(
-                '`_estimator_type` undefined.  Please use appropriate mixin.'
+            raise TypeError(
+                "`_estimator_type` undefined.  "
+                "Please use appropriate mixin to define estimator type."
             )
         return self._estimator_type  # pylint: disable=no-member
 

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -448,6 +448,7 @@ class XGBModel(XGBModelBase):
                 meta[k] = v
             except TypeError:
                 warnings.warn(str(k) + ' is not saved in Scikit-Learn meta.')
+        meta['_estimator_type'] = self._estimator_type
         meta_str = json.dumps(meta)
         self.get_booster().set_attr(scikit_learn=meta_str)
         self.get_booster().save_model(fname)
@@ -495,6 +496,7 @@ class XGBModel(XGBModelBase):
                         "Loading an estimator with different type "
                         f"{self._estimator_type}, {v}"
                     )
+                continue
             states[k] = v
         self.__dict__.update(states)
         # Delete the attribute after load

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -1107,3 +1107,18 @@ def test_estimator_type():
     assert xgb.XGBRegressor._estimator_type == "regressor"
     assert xgb.XGBRFRegressor._estimator_type == "regressor"
     assert xgb.XGBRanker._estimator_type == "ranker"
+
+    from sklearn.datasets import load_digits
+
+    X, y = load_digits(n_class=2, return_X_y=True)
+    cls = xgb.XGBClassifier(n_estimators=2).fit(X, y)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "cls.json")
+        cls.save_model(path)
+
+        reg = xgb.XGBRegressor()
+        with pytest.raises(TypeError):
+            reg.load_model(path)
+
+        cls = xgb.XGBClassifier()
+        cls.load_model(path)  # no error

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -1099,3 +1099,11 @@ def test_boost_from_prediction_approx():
 @pytest.mark.skipif(**tm.no_sklearn())
 def test_boost_from_prediction_exact():
     run_boost_from_prediction('exact')
+
+
+def test_estimator_type():
+    assert xgb.XGBClassifier._estimator_type == "classifier"
+    assert xgb.XGBRFClassifier._estimator_type == "classifier"
+    assert xgb.XGBRegressor._estimator_type == "regressor"
+    assert xgb.XGBRFRegressor._estimator_type == "regressor"
+    assert xgb.XGBRanker._estimator_type == "ranker"


### PR DESCRIPTION
For more info, see: https://scikit-learn.org/stable/developers/develop.html#estimator-types

* Model trained from dask can be loaded by single node skl interface.  Close https://github.com/dmlc/xgboost/issues/6547 .