### PR TITLE
[backport] Fix evaluation result for XGBRanker. (#6594)

### DIFF
--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -122,6 +122,8 @@ def test_ranking():
     model = xgb.sklearn.XGBRanker(**params)
     model.fit(x_train, y_train, group=train_group,
               eval_set=[(x_valid, y_valid)], eval_group=[valid_group])
+    assert model.evals_result()
+
     pred = model.predict(x_test)
 
     train_data = xgb.DMatrix(x_train, y_train)


### PR DESCRIPTION
* Remove duplicated code, which fixes typo `evals_result` -> `evals_result_`.