### PR TITLE
Define metainfo for all DMatrix interfaces.

### DIFF
--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -737,16 +737,28 @@ class SingleBatchInternalIter(DataIter):  # pylint: disable=R0902
     area for meta info.
 
     '''
-    def __init__(self, data, label, weight, base_margin, group,
-                 label_lower_bound, label_upper_bound,
-                 feature_names, feature_types):
+    def __init__(
+        self, data,
+        label,
+        weight,
+        base_margin,
+        group,
+        qid,
+        label_lower_bound,
+        label_upper_bound,
+        feature_weights,
+        feature_names,
+        feature_types
+    ):
         self.data = data
         self.label = label
         self.weight = weight
         self.base_margin = base_margin
         self.group = group
+        self.qid = qid
         self.label_lower_bound = label_lower_bound
         self.label_upper_bound = label_upper_bound
+        self.feature_weights = feature_weights
         self.feature_names = feature_names
         self.feature_types = feature_types
         self.it = 0             # pylint: disable=invalid-name
@@ -759,8 +771,10 @@ class SingleBatchInternalIter(DataIter):  # pylint: disable=R0902
         input_data(data=self.data, label=self.label,
                    weight=self.weight, base_margin=self.base_margin,
                    group=self.group,
+                   qid=self.qid,
                    label_lower_bound=self.label_lower_bound,
                    label_upper_bound=self.label_upper_bound,
+                   feature_weights=self.feature_weights,
                    feature_names=self.feature_names,
                    feature_types=self.feature_types)
         return 1
@@ -770,7 +784,8 @@ class SingleBatchInternalIter(DataIter):  # pylint: disable=R0902
 
 
 def init_device_quantile_dmatrix(
-        data, missing, max_bin, threads, feature_names, feature_types, **meta):
+        data, missing, max_bin, threads, feature_names, feature_types, **meta
+):
     '''Constructor for DeviceQuantileDMatrix.'''
     if not any([_is_cudf_df(data), _is_cudf_ser(data), _is_cupy_array(data),
                 _is_dlpack(data), _is_iter(data)]):

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -556,7 +556,7 @@ class XGBModel(XGBModelBase):
 
     def _configure_fit(
         self,
-        booster: Optional[Booster],
+        booster: Optional[Union[Booster, "XGBModel"]],
         eval_metric: Optional[Union[Callable, str, List[str]]],
         params: Dict[str, Any],
     ) -> Tuple[Booster, Optional[Metric], Dict[str, Any]]:
@@ -631,7 +631,7 @@ class XGBModel(XGBModelBase):
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation
             metric measured on the validation set to stderr.
-        xgb_model : str
+        xgb_model : Union[str, Booster, XGBModel]
             file name of stored XGBoost model or 'Booster' instance XGBoost model to be
             loaded before training (allows training continuation).
         sample_weight_eval_set : list, optional
@@ -942,10 +942,22 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         super().__init__(objective=objective, **kwargs)
 
     @_deprecate_positional_args
-    def fit(self, X, y, *, sample_weight=None, base_margin=None,
-            eval_set=None, eval_metric=None,
-            early_stopping_rounds=None, verbose=True, xgb_model=None,
-            sample_weight_eval_set=None, feature_weights=None, callbacks=None):
+    def fit(
+        self,
+        X,
+        y,
+        *,
+        sample_weight=None,
+        base_margin=None,
+        eval_set=None,
+        eval_metric=None,
+        early_stopping_rounds=None,
+        verbose=True,
+        xgb_model=None,
+        sample_weight_eval_set=None,
+        feature_weights=None,
+        callbacks=None
+    ):
         # pylint: disable = attribute-defined-outside-init,arguments-differ,too-many-statements
 
         can_use_label_encoder = True
@@ -1283,7 +1295,10 @@ class XGBRanker(XGBModel, XGBRankerMixIn):
 
     @_deprecate_positional_args
     def fit(
-        self, X, y, *,
+        self,
+        X,
+        y,
+        *,
         group=None,
         qid=None,
         sample_weight=None,
@@ -1372,7 +1387,7 @@ class XGBRanker(XGBModel, XGBRankerMixIn):
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation
             metric measured on the validation set to stderr.
-        xgb_model : str
+        xgb_model : Union[str, Booster, XGBModel]
             file name of stored XGBoost model or 'Booster' instance XGBoost
             model to be loaded before training (allows training continuation).
         feature_weights: array_like
@@ -1391,9 +1406,8 @@ class XGBRanker(XGBModel, XGBRankerMixIn):
                                                         save_best=True)]
 
         """
-        # check if group information is provided
-        if group is None:
-            raise ValueError("group is required for ranking task")
+        if group is None and qid is None:
+            raise ValueError("group or qid is required for ranking task")
 
         if eval_set is not None:
             if eval_group is None and eval_qid is None:

--- a/tests/python-gpu/test_device_quantile_dmatrix.py
+++ b/tests/python-gpu/test_device_quantile_dmatrix.py
@@ -34,3 +34,25 @@ class TestDeviceQuantileDMatrix:
         import cupy as cp
         data = cp.random.randn(5, 5)
         xgb.DeviceQuantileDMatrix(data, cp.ones(5, dtype=np.float64))
+
+    @pytest.mark.skipif(**tm.no_cupy())
+    def test_metainfo(self) -> None:
+        import cupy as cp
+        rng = cp.random.RandomState(1994)
+
+        rows = 10
+        cols = 3
+        data = rng.randn(rows, cols)
+
+        labels = rng.randn(rows)
+
+        fw = rng.randn(rows)
+        fw -= fw.min()
+
+        m = xgb.DeviceQuantileDMatrix(data=data, label=labels, feature_weights=fw)
+
+        got_fw = m.get_float_info("feature_weights")
+        got_labels = m.get_label()
+
+        cp.testing.assert_allclose(fw, got_fw)
+        cp.testing.assert_allclose(labels, got_labels)


### PR DESCRIPTION
A small part extracted from https://github.com/dmlc/xgboost/pull/6591 to ease reviewing.

* Add check for consistency between 4 different DMatrix types.  They should share a number of common arguments in constructor with correct ordering.