### PR TITLE
[breaking] Save booster feature info in JSON, remove feature name generation.

### DIFF
--- a/doc/model.schema
+++ b/doc/model.schema
@@ -88,6 +88,12 @@
                       "type": "number"
                     }
                   },
+                  "split_type": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
                   "default_left": {
                     "type": "array",
                     "items": {
@@ -247,6 +253,18 @@
     "learner": {
       "type": "object",
       "properties": {
+        "feature_names": {
+          "type": "array",
+          "items": {
+              "type": "string"
+          }
+        },
+        "feature_types": {
+          "type": "array",
+          "items": {
+              "type": "string"
+          }
+        },
         "gradient_booster": {
           "oneOf": [
             {

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -1132,4 +1132,46 @@ XGB_DLL int XGBoosterSetAttr(BoosterHandle handle,
 XGB_DLL int XGBoosterGetAttrNames(BoosterHandle handle,
                                   bst_ulong* out_len,
                                   const char*** out);
+
+/*!
+ * \brief Set string encoded feature info in Booster, similar to the feature
+ *        info in DMatrix.
+ *
+ * Accepted fields are:
+ *   - feature_name
+ *   - feature_type
+ *
+ * \param handle    An instance of Booster
+ * \param field     Feild name
+ * \param features  Pointer to array of strings.
+ * \param size      Size of `features` pointer (number of strings passed in).
+ *
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterSetStrFeatureInfo(BoosterHandle handle, const char *field,
+                                       const char **features,
+                                       const bst_ulong size);
+
+/*!
+ * \brief Get string encoded feature info from Booster, similar to feature info
+ *        in DMatrix.
+ *
+ * Accepted fields are:
+ *   - feature_name
+ *   - feature_type
+ *
+ * Caller is responsible for copying out the data, before next call to any API
+ * function of XGBoost.
+ *
+ * \param handle       An instance of Booster
+ * \param field        Feild name
+ * \param size         Size of output pointer `features` (number of strings returned).
+ * \param out_features Address of a pointer to array of strings. Result is stored in
+ *        thread local memory.
+ *
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterGetStrFeatureInfo(BoosterHandle handle, const char *field,
+                                       bst_ulong *len,
+                                       const char ***out_features);
 #endif  // XGBOOST_C_API_H_

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -214,6 +214,27 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    */
   virtual std::vector<std::string> GetAttrNames() const = 0;
   /*!
+   * \brief Set the feature names for current booster.
+   * \param fn Input feature names
+   */
+  virtual  void SetFeatureNames(std::vector<std::string> const& fn) = 0;
+  /*!
+   * \brief Get the feature names for current booster.
+   * \param fn Output feature names
+   */
+  virtual void GetFeatureNames(std::vector<std::string>* fn) const = 0;
+  /*!
+   * \brief Set the feature types for current booster.
+   * \param ft Input feature types.
+   */
+  virtual void SetFeatureTypes(std::vector<std::string> const& ft) = 0;
+  /*!
+   * \brief Get the feature types for current booster.
+   * \param fn Output feature types
+   */
+  virtual void GetFeatureTypes(std::vector<std::string>* ft) const = 0;
+
+  /*!
    * \return whether the model allow lazy checkpoint in rabit.
    */
   bool AllowLazyCheckPoint() const;

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1181,17 +1181,13 @@ class Booster(object):
         """
         for d in cache:
             if not isinstance(d, DMatrix):
-                raise TypeError(
-                    "invalid cache item: {}".format(type(d).__name__), cache
-                )
+                raise TypeError('invalid cache item: {}'.format(type(d).__name__), cache)
+            self._validate_features(d)
 
         dmats = c_array(ctypes.c_void_p, [d.handle for d in cache])
         self.handle = ctypes.c_void_p()
-        _check_call(
-            _LIB.XGBoosterCreate(
-                dmats, c_bst_ulong(len(cache)), ctypes.byref(self.handle)
-            )
-        )
+        _check_call(_LIB.XGBoosterCreate(dmats, c_bst_ulong(len(cache)),
+                                         ctypes.byref(self.handle)))
         for d in cache:
             # Validate feature only after the feature names are saved into booster.
             self._validate_features(d)
@@ -1402,7 +1398,8 @@ class Booster(object):
                 if not isinstance(value, STRING_TYPES):
                     raise ValueError("Set Attr only accepts string values")
                 value = c_str(str(value))
-            _check_call(_LIB.XGBoosterSetAttr(self.handle, c_str(key), value))
+            _check_call(_LIB.XGBoosterSetAttr(
+                self.handle, c_str(key), value))
 
     def _get_feature_info(self, field: str):
         length = c_bst_ulong()

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1182,7 +1182,6 @@ class Booster(object):
         for d in cache:
             if not isinstance(d, DMatrix):
                 raise TypeError('invalid cache item: {}'.format(type(d).__name__), cache)
-            self._validate_features(d)
 
         dmats = c_array(ctypes.c_void_p, [d.handle for d in cache])
         self.handle = ctypes.c_void_p()

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -958,9 +958,13 @@ class XGBModel(XGBModelBase):
             raise AttributeError(
                 'Feature importance is not defined for Booster type {}'
                 .format(self.booster))
-        b = self.get_booster()
+        b: Booster = self.get_booster()
         score = b.get_score(importance_type=self.importance_type)
-        all_features = [score.get(f, 0.) for f in b.feature_names]
+        if b.feature_names is None:
+            feature_names = ["f{0}".format(i) for i in range(self.n_features_in_)]
+        else:
+            feature_names = b.feature_names
+        all_features = [score.get(f, 0.) for f in feature_names]
         all_features = np.array(all_features, dtype=np.float32)
         total = all_features.sum()
         if total == 0:

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -689,15 +689,17 @@ class LearnerIO : public LearnerConfiguration {
     }
 
     // feature names and types are saved in xgboost 1.4
-    if (learner.find("feature_names") != learner.cend()) {
-      auto const &feature_names = get<Array const>(learner.at("feature_names"));
+    auto it = learner.find("feature_names");
+    if (it != learner.cend()) {
+      auto const &feature_names = get<Array const>(it->second);
       feature_names_.clear();
       for (auto const &name : feature_names) {
         feature_names_.emplace_back(get<String const>(name));
       }
     }
-    if (learner.find("feature_types") != learner.cend()) {
-      auto const &feature_types = get<Array const>(learner.at("feature_types"));
+    it = learner.find("feature_types");
+    if (it != learner.cend()) {
+      auto const &feature_types = get<Array const>(it->second);
       feature_types_.clear();
       for (auto const &name : feature_types) {
         auto type = get<String const>(name);

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -256,6 +256,11 @@ class LearnerConfiguration : public Learner {
   std::map<std::string, std::string> cfg_;
   // Stores information like best-iteration for early stopping.
   std::map<std::string, std::string> attributes_;
+  // Name of each feature, usually set from DMatrix.
+  std::vector<std::string> feature_names_;
+  // Type of each feature, usually set from DMatrix.
+  std::vector<std::string> feature_types_;
+
   common::Monitor monitor_;
   LearnerModelParamLegacy mparam_;
   LearnerModelParam learner_model_param_;
@@ -458,6 +463,23 @@ class LearnerConfiguration : public Learner {
     if (it == attributes_.end()) { return false; }
     attributes_.erase(it);
     return true;
+  }
+
+  void SetFeatureNames(std::vector<std::string> const& fn) override {
+    feature_names_ = fn;
+  }
+
+  void GetFeatureNames(std::vector<std::string>* fn) const override {
+    *fn = feature_names_;
+  }
+
+  void SetFeatureTypes(std::vector<std::string> const& ft) override {
+    this->feature_types_ = ft;
+  }
+
+  void GetFeatureTypes(std::vector<std::string>* p_ft) const override {
+    auto& ft = *p_ft;
+    ft = this->feature_types_;
   }
 
   std::vector<std::string> GetAttrNames() const override {
@@ -666,6 +688,23 @@ class LearnerIO : public LearnerConfiguration {
       attributes_[kv.first] = get<String const>(kv.second);
     }
 
+    // feature names and types are saved in xgboost 1.4
+    if (learner.find("feature_names") != learner.cend()) {
+      auto const &feature_names = get<Array const>(learner.at("feature_names"));
+      feature_names_.clear();
+      for (auto const &name : feature_names) {
+        feature_names_.emplace_back(get<String const>(name));
+      }
+    }
+    if (learner.find("feature_types") != learner.cend()) {
+      auto const &feature_types = get<Array const>(learner.at("feature_types"));
+      feature_types_.clear();
+      for (auto const &name : feature_types) {
+        auto type = get<String const>(name);
+        feature_types_.emplace_back(type);
+      }
+    }
+
     this->need_configuration_ = true;
   }
 
@@ -690,6 +729,17 @@ class LearnerIO : public LearnerConfiguration {
     learner["attributes"] = Object();
     for (auto const& kv : attributes_) {
       learner["attributes"][kv.first] = String(kv.second);
+    }
+
+    learner["feature_names"] = Array();
+    auto& feature_names = get<Array>(learner["feature_names"]);
+    for (auto const& name : feature_names_) {
+      feature_names.emplace_back(name);
+    }
+    learner["feature_types"] = Array();
+    auto& feature_types = get<Array>(learner["feature_types"]);
+    for (auto const& type : feature_types_) {
+      feature_types.emplace_back(type);
     }
   }
   // About to be deprecated by JSON format

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -385,7 +385,7 @@ class JsonGenerator : public TreeGenerator {
   std::string PlainNode(RegTree const& tree, int32_t nid, uint32_t depth) const override {
     auto cond = tree[nid].SplitCond();
     static std::string const kNodeTemplate =
-        R"I( "nodeid": {nid}, "depth": {depth}, "split": {fname}, )I"
+        R"I( "nodeid": {nid}, "depth": {depth}, "split": "{fname}", )I"
         R"I("split_condition": {cond}, "yes": {left}, "no": {right}, )I"
         R"I("missing": {missing})I";
     return SplitNodeImpl(tree, nid, kNodeTemplate, SuperT::ToStr(cond), depth);

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -360,4 +360,60 @@ TEST(Learner, ConstantSeed) {
     CHECK_EQ(v_0, v_2);
   }
 }
+
+TEST(Learner, FeatureInfo) {
+  size_t constexpr kCols = 10;
+  auto m = RandomDataGenerator{10, kCols, 0}.GenerateDMatrix(true);
+  std::vector<std::string> names(kCols);
+  for (size_t i = 0; i < kCols; ++i) {
+    names[i] = ("f" + std::to_string(i));
+  }
+
+  std::vector<std::string> types(kCols);
+  for (size_t i = 0; i < kCols; ++i) {
+    types[i] = "q";
+  }
+  types[8] = "f";
+  types[0] = "int";
+  types[3] = "i";
+  types[7] = "i";
+
+  std::vector<char const*> c_names(kCols);
+  for (size_t i = 0; i < names.size(); ++i) {
+    c_names[i] = names[i].c_str();
+  }
+  std::vector<char const*> c_types(kCols);
+  for (size_t i = 0; i < types.size(); ++i) {
+    c_types[i] = names[i].c_str();
+  }
+
+  std::vector<std::string> out_names;
+  std::vector<std::string> out_types;
+
+  Json model{Object()};
+  {
+    std::unique_ptr<Learner> learner{Learner::Create({m})};
+    learner->Configure();
+    learner->SetFeatureNames(names);
+    learner->GetFeatureNames(&out_names);
+
+    learner->SetFeatureTypes(types);
+    learner->GetFeatureTypes(&out_types);
+
+    ASSERT_TRUE(std::equal(out_names.begin(), out_names.end(), names.begin()));
+    ASSERT_TRUE(std::equal(out_types.begin(), out_types.end(), types.begin()));
+
+    learner->SaveModel(&model);
+  }
+
+  {
+    std::unique_ptr<Learner> learner{Learner::Create({m})};
+    learner->LoadModel(model);
+
+    learner->GetFeatureNames(&out_names);
+    learner->GetFeatureTypes(&out_types);
+    ASSERT_TRUE(std::equal(out_names.begin(), out_names.end(), names.begin()));
+    ASSERT_TRUE(std::equal(out_types.begin(), out_types.end(), types.begin()));
+  }
+}
 }  // namespace xgboost

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -95,6 +95,11 @@ eval[test] = {data_path}
             }
             data = xgboost.DMatrix(data_path)
             booster = xgboost.train(parameters, data, num_boost_round=10)
+
+            # CLI model doesn't contain feature info.
+            booster.feature_names = None
+            booster.feature_types = None
+
             booster.save_model(model_out_py)
             py_predt = booster.predict(data)
 

--- a/tests/python/test_dmatrix.py
+++ b/tests/python/test_dmatrix.py
@@ -180,7 +180,7 @@ class TestDMatrix:
 
         # reset
         dm.feature_names = None
-        assert dm.feature_names == ['f0', 'f1', 'f2', 'f3', 'f4']
+        assert dm.feature_names is None
         assert dm.feature_types is None
 
     def test_feature_names(self):


### PR DESCRIPTION
* [breaking] Remove feature name generation.
* Pass feature names and types into libxgboost.
* Save them in JSON model.

~The feature name generation is still preserved as many other places like `feature_importance_` and `plotting` are depending on it.~

One concern of this PR is it might introduce overhead in wide datasets, some sparse datasets can scale to millions of features.

Close https://github.com/dmlc/xgboost/issues/6520