### PR TITLE
[jvm-packages] fix potential TaskFailedListener's callback won't be called

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -613,8 +613,12 @@ object XGBoost extends Serializable {
           }
         }
         sparkJobThread.setUncaughtExceptionHandler(tracker)
-        sparkJobThread.start()
-        val trackerReturnVal = parallelismTracker.execute(tracker.waitFor(0L))
+
+        val trackerReturnVal = parallelismTracker.execute {
+          sparkJobThread.start()
+          tracker.waitFor(0L)
+        }
+
         logger.info(s"Rabit returns with exit code $trackerReturnVal")
         val (booster, metrics) = postTrackerReturnProcessing(trackerReturnVal,
           boostersAndMetrics, sparkJobThread)


### PR DESCRIPTION
there is a possibility that onJobStart of TaskFailedListener won't be called, if
the job is submitted before the other thread call addSparkListener.

detail can be found at https://github.com/dmlc/xgboost/pull/6019#issuecomment-760937628