### PR TITLE
[CI] Add ARM64 test to Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,6 +179,9 @@ def BuildCPUARM64() {
     ${dockerRun} ${container_type} ${docker_binary} bash -c "cd python-package && rm -rf dist/* && python setup.py bdist_wheel --universal"
     ${dockerRun} ${container_type} ${docker_binary} python tests/ci_build/rename_whl.py python-package/dist/*.whl ${commit_id} ${wheel_tag}
     ${dockerRun} ${container_type} ${docker_binary} auditwheel repair --plat ${wheel_tag} python-package/dist/*.whl
+    mv -v wheelhouse/*.whl python-package/dist/
+    # Make sure that libgomp.so is vendored in the wheel
+    ${dockerRun} ${container_type} ${docker_binary} bash -c "unzip -l python-package/dist/*.whl | grep libgomp  || exit -1"
     """
     echo 'Stashing Python wheel...'
     stash name: "xgboost_whl_arm64_cpu", includes: 'python-package/dist/*.whl'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,7 +167,7 @@ def BuildCPU() {
 }
 
 def BuildCPUARM64() {
-  node('linux && cpu && arm64') {
+  node('linux && arm64') {
     unstash name: 'srcs'
     echo "Build CPU ARM64"
     def container_type = "aarch64"
@@ -336,7 +336,7 @@ def TestPythonCPU() {
 }
 
 def TestPythonCPUARM64() {
-  node('linux && cpu && arm64') {
+  node('linux && arm64') {
     unstash name: "xgboost_whl_arm64_cpu"
     unstash name: 'srcs'
     unstash name: 'xgboost_cli'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,7 @@ pipeline {
           parallel ([
             'clang-tidy': { ClangTidy() },
             'build-cpu': { BuildCPU() },
+            'build-cpu-arm64': { BuildCPUARM64() },
             'build-cpu-rabit-mock': { BuildCPUMock() },
             // Build reference, distribution-ready Python wheel with CUDA 10.0
             // using CentOS 6 image
@@ -77,6 +78,7 @@ pipeline {
         script {
           parallel ([
             'test-python-cpu': { TestPythonCPU() },
+            'test-python-cpu-arm64': { TestPythonCPUARM64() },
             // artifact_cuda_version doesn't apply to RMM tests; RMM tests will always match CUDA version between artifact and host env
             'test-python-gpu-cuda10.2': { TestPythonGPU(artifact_cuda_version: '10.0', host_cuda_version: '10.2', test_rmm: true) },
             'test-python-gpu-cuda11.0-cross': { TestPythonGPU(artifact_cuda_version: '10.0', host_cuda_version: '11.0') },
@@ -159,6 +161,32 @@ def BuildCPU() {
     ${docker_extra_params} ${dockerRun} ${container_type} ${docker_binary} bash -c "cd build && ctest --exclude-regex AllTestsInDMLCUnitTests --extra-verbose"
     """
 
+    stash name: 'xgboost_cli', includes: 'xgboost'
+    deleteDir()
+  }
+}
+
+def BuildCPUARM64() {
+  node('linux && cpu && arm64') {
+    unstash name: 'srcs'
+    echo "Build CPU ARM64"
+    def container_type = "aarch64"
+    def docker_binary = "docker"
+    def wheel_tag = "manylinux2014_aarch64"
+    sh """
+    ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/build_via_cmake.sh --conda-env=aarch64_test -DOPEN_MP:BOOL=ON -DHIDE_CXX_SYMBOL=ON
+    ${dockerRun} ${container_type} ${docker_binary} bash -c "cd build && ctest --extra-verbose"
+    ${dockerRun} ${container_type} ${docker_binary} bash -c "cd python-package && rm -rf dist/* && python setup.py bdist_wheel --universal"
+    ${dockerRun} ${container_type} ${docker_binary} python tests/ci_build/rename_whl.py python-package/dist/*.whl ${commit_id} ${wheel_tag}
+    ${dockerRun} ${container_type} ${docker_binary} auditwheel repair --plat ${wheel_tag} python-package/dist/*.whl
+    """
+    echo 'Stashing Python wheel...'
+    stash name: "xgboost_whl_arm64_cpu", includes: 'python-package/dist/*.whl'
+    if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('release')) {
+      echo 'Uploading Python wheel...'
+      path = ("${BRANCH_NAME}" == 'master') ? '' : "${BRANCH_NAME}/"
+      s3Upload bucket: 'xgboost-nightly-builds', path: path, acl: 'PublicRead', workingDir: 'python-package/dist', includePathPattern:'**/*.whl'
+    }
     stash name: 'xgboost_cli', includes: 'xgboost'
     deleteDir()
   }
@@ -296,6 +324,21 @@ def TestPythonCPU() {
     unstash name: 'xgboost_cli'
     echo "Test Python CPU"
     def container_type = "cpu"
+    def docker_binary = "docker"
+    sh """
+    ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/test_python.sh cpu
+    """
+    deleteDir()
+  }
+}
+
+def TestPythonCPUARM64() {
+  node('linux && cpu && arm64') {
+    unstash name: "xgboost_whl_arm64_cpu"
+    unstash name: 'srcs'
+    unstash name: 'xgboost_cli'
+    echo "Test Python CPU ARM64"
+    def container_type = "aarch64"
     def docker_binary = "docker"
     sh """
     ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/test_python.sh cpu

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -344,7 +344,7 @@ def TestPythonCPUARM64() {
     def container_type = "aarch64"
     def docker_binary = "docker"
     sh """
-    ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/test_python.sh cpu
+    ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/test_python.sh cpu-arm64
     """
     deleteDir()
   }

--- a/tests/ci_build/test_python.sh
+++ b/tests/ci_build/test_python.sh
@@ -66,8 +66,15 @@ case "$suite" in
     uninstall_xgboost
     ;;
 
+  cpu-arm64)
+    source activate aarch64_test
+    install_xgboost
+    pytest -v -s -rxXs --fulltrace --durations=0 ${args} tests/python/test_basic.py tests/python/test_basic_models.py tests/python/test_model_compatibility.py
+    uninstall_xgboost
+    ;;
+
   *)
-    echo "Usage: $0 {gpu|mgpu|cpu} [extra args to pass to pytest]"
+    echo "Usage: $0 {gpu|mgpu|cpu|cpu-arm64} [extra args to pass to pytest]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
Follow-up to #6641 

Use AWS's ARM64 offering to build and run XGBoost Python package for the ARM64 platform.