### PR TITLE
[dask] Add a dummy sample to infer output shape.

### DIFF
--- a/doc/tutorials/dask.rst
+++ b/doc/tutorials/dask.rst
@@ -108,10 +108,9 @@ computation a bit faster when meta information like ``base_margin`` is not neede
   prediction = xgb.dask.inplace_predict(client, output, X)
 
 Here ``prediction`` is a dask ``Array`` object containing predictions from model if input
-is a ``DaskDMatrix`` or ``da.Array``.  For ``dd.DataFrame`` input, the return value is a
-either a ``dd.Series`` or ``dd.DataFrame`` for normal prediction, depending on the output
-shape of prediction.  When shap based prediction is used, the return value can exceed 2
-dimension, in such cases an ``Array`` is returned.
+is a ``DaskDMatrix`` or ``da.Array``.  When putting dask collection directly into the
+``predict`` function or using ``inplace_predict``, the output type depends on input data.
+See next section for details.
 
 Alternatively, XGBoost also implements the Scikit-Learn interface with ``DaskXGBClassifier``
 and ``DaskXGBRegressor``. See ``xgboost/demo/dask`` for more examples.
@@ -145,23 +144,23 @@ Also for inplace prediction:
 .. code-block:: python
 
   booster.set_param({'predictor': 'gpu_predictor'})
-  # where X is a dask DataFrame or dask Array.
+  # where X is a dask DataFrame or dask Array containing cupy or cuDF backed data.
   prediction = xgb.dask.inplace_predict(client, booster, X)
 
+When input is ``da.Array`` object, output is always ``da.Array``.  However, if the input
+type is ``dd.DataFrame``, output can be ``dd.Series``, ``dd.DataFrame`` or ``da.Array``,
+depending on output shape.  For example, when shap based prediction is used, the return
+value can have 3 or 4 dimensions , in such cases an ``Array`` is always returned.
 
-The performance of running prediction directly on dask collection, either using
-``predict`` or ``inplace_predict``, is particularly sensitive to number of blocks.
-Internally, it's implemented using ``da.map_blocks`` or ``dd.map_partitions``.  When
-number of partitions is large and each of them have only small amount of data, the
-overhead of calling predict becomes huge.  On the other hand, if not using GPU, the number
-of threads used for prediction on each block matters.  If the number of blocks on each
-workers is small, then the CPU workers might not be fully utilized.  Right now, xgboost
-just use single thread for each partition.
+The performance of running prediction, either using ``predict`` or ``inplace_predict``, is
+sensitive to number of blocks.  Internally, it's implemented using ``da.map_blocks`` or
+``dd.map_partitions``.  When number of partitions is large and each of them have only
+small amount of data, the overhead of calling predict becomes visible.  On the other hand,
+if not using GPU, the number of threads used for prediction on each block matters.  Right
+now, xgboost uses single thread for each partition.  If the number of blocks on each
+workers is smaller than number of cores, then the CPU workers might not be fully utilized.
 
-When putting dask collection directly into the ``predict`` function or using
-``inplace_predict``, the output type depends on input data.  When input is ``da.Array``
-object, output is always ``da.Array``.  However, if the input type is ``dd.DataFrame``,
-output can be ``dd.Series`` or ``dd.DataFrame``, depending on output shape.
+
 
 ***************************
 Working with other clusters

--- a/doc/tutorials/dask.rst
+++ b/doc/tutorials/dask.rst
@@ -113,10 +113,6 @@ either a ``dd.Series`` or ``dd.DataFrame`` for normal prediction, depending on t
 shape of prediction.  When shap based prediction is used, the return value can exceed 2
 dimension, in such cases an ``Array`` is returned.
 
-The performance of running prediction is sensitive to number of parations/blocks for each
-input dataset.  Internally it's implemented as running local prediction on each data
-partition.
-
 Alternatively, XGBoost also implements the Scikit-Learn interface with ``DaskXGBClassifier``
 and ``DaskXGBRegressor``. See ``xgboost/demo/dask`` for more examples.
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1008,12 +1008,9 @@ def _infer_predict_output(
     rng = numpy.random.RandomState(1994)
     test_sample = rng.randn(1, features)
     if inplace:
-        predictor = json.loads(booster.save_config())["learner"]["gradient_booster"][
-            "gbtree_train_param"
-        ]["predictor"]
-        booster.set_param({"predictor": "cpu_predictor"})
+        # clear the state to avoid gpu_id, gpu_predictor
+        booster = Booster(model_file=booster.save_raw())
         test_predt = booster.inplace_predict(test_sample, **kwargs)
-        booster.set_param({"predictor": predictor})
     else:
         m = DMatrix(test_sample)
         test_predt = booster.predict(m, **kwargs)

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -19,7 +19,6 @@ import logging
 from collections import defaultdict
 from collections.abc import Sequence
 from threading import Thread
-import json
 from typing import TYPE_CHECKING, List, Tuple, Callable, Optional, Any, Union, Dict, Set
 from typing import Awaitable, Generator, TypeVar
 


### PR DESCRIPTION
This is for inferring shape with direct prediction (without DaskDMatrix).
There are a few things that requires known output shape before carrying out
actual prediction, including dask meta data, output dataframe columns.

* Infer output shape based on local prediction.
* Remove set param in predict function as it's not thread safe nor necessary as
we now let dask to decide the parallelism.
* Simplify prediction on `DaskDMatrix`.
* Remove unnecessary serialization.

A small part extracted from https://github.com/dmlc/xgboost/pull/6638 with added test and remove redundant serialization.