### PR TITLE
[CI] Do not mix up stashed executable built for ARM and x86_64 platforms

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,7 +190,7 @@ def BuildCPUARM64() {
       path = ("${BRANCH_NAME}" == 'master') ? '' : "${BRANCH_NAME}/"
       s3Upload bucket: 'xgboost-nightly-builds', path: path, acl: 'PublicRead', workingDir: 'python-package/dist', includePathPattern:'**/*.whl'
     }
-    stash name: 'xgboost_cli', includes: 'xgboost'
+    stash name: 'xgboost_cli_arm64', includes: 'xgboost'
     deleteDir()
   }
 }
@@ -339,7 +339,7 @@ def TestPythonCPUARM64() {
   node('linux && arm64') {
     unstash name: "xgboost_whl_arm64_cpu"
     unstash name: 'srcs'
-    unstash name: 'xgboost_cli'
+    unstash name: 'xgboost_cli_arm64'
     echo "Test Python CPU ARM64"
     def container_type = "aarch64"
     def docker_binary = "docker"


### PR DESCRIPTION
Fix error from https://xgboost-ci.net/blue/organizations/jenkins/xgboost/detail/master/724/pipeline/227:
```
OSError: [Errno 8] Exec format error: '/workspace/xgboost'
```
which is thrown when we try to run an executable built for ARM platform on a x86_64 worker, or vice versa. Every stash name must be unique to avoid the mix up. 