### PR TITLE
[breaking] Add prediction fucntion for DMatrix and use inplace predict for dask.

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -741,7 +741,7 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
  *      scenario.  The second scenario applies when you are defining a custom objective
  *      function.
  *    "iteration_begin": int
- *      Begining iteration of prediction.
+ *      Beginning iteration of prediction.
  *    "iteration_end": int
  *      End iteration of prediction.  Set to 0 this will become the size of tree model.
  *    "strict_shape": bool
@@ -777,7 +777,7 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle,
  * \brief Inplace prediction from CPU dense matrix.
  *
  * \param handle        Booster handle.
- * \param values        JSON encoded__array_interface__ to values.
+ * \param values        JSON encoded __array_interface__ to values.
  * \param c_json_config See `XGBoosterPredictFromDMatrix` for more info.
  *
  *   Additional fields for inplace prediction are:
@@ -804,9 +804,9 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle,
  * \brief Inplace prediction from CPU CSR matrix.
  *
  * \param handle        Booster handle.
- * \param indptr        JSON encoded__array_interface__ to row pointer in CSR.
- * \param indices       JSON encoded__array_interface__ to column indices in CSR.
- * \param values        JSON encoded__array_interface__ to values in CSR..
+ * \param indptr        JSON encoded __array_interface__ to row pointer in CSR.
+ * \param indices       JSON encoded __array_interface__ to column indices in CSR.
+ * \param values        JSON encoded __array_interface__ to values in CSR..
  * \param ncol          Number of features in data.
  * \param c_json_config See `XGBoosterPredictFromDMatrix` for more info.
  *   Additional fields for inplace prediction are:
@@ -838,6 +838,8 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
  *   Additional fields for inplace prediction are:
  *     "missing": float
  *
+ * \param m             An optional (NULL if not available) proxy DMatrix instance
+ *                      storing meta info.
  * \param out_shape     See `XGBoosterPredictFromDMatrix` for more info.
  * \param out_dim       See `XGBoosterPredictFromDMatrix` for more info.
  * \param out_result    See `XGBoosterPredictFromDMatrix` for more info.
@@ -858,6 +860,8 @@ XGB_DLL int XGBoosterPredictFromCudaArray(
  *   Additional fields for inplace prediction are:
  *     "missing": float
  *
+ * \param m             An optional (NULL if not available) proxy DMatrix instance
+ *                      storing meta info.
  * \param out_shape     See `XGBoosterPredictFromDMatrix` for more info.
  * \param out_dim       See `XGBoosterPredictFromDMatrix` for more info.
  * \param out_result    See `XGBoosterPredictFromDMatrix` for more info.

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -683,8 +683,9 @@ XGB_DLL int XGBoosterEvalOneIter(BoosterHandle handle,
                                  const char *evnames[],
                                  bst_ulong len,
                                  const char **out_result);
+
 /*!
- * \brief make prediction based on dmat
+ * \brief make prediction based on dmat (deprecated, use `XGBoosterPredictFromDMatrix` instead)
  * \param handle handle
  * \param dmat data matrix
  * \param option_mask bit-mask of options taken in prediction, possible values
@@ -713,6 +714,161 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
                              int training,
                              bst_ulong *out_len,
                              const float **out_result);
+/*!
+ * \brief Make prediction from DMatrix, replacing `XGBoosterPredict`.
+ *
+ * \param handle Booster handle
+ * \param dmat   DMatrix handle
+ * \param c_json_config String encoded predict configuration in JSON format.
+ *
+ *    "type": [0, 5]
+ *      0: normal prediction
+ *      1: output margin
+ *      2: predict contribution
+ *      3: predict approxmated contribution
+ *      4: predict feature interaction
+ *      5: predict leaf
+ *    "training": bool
+ *      Whether the prediction function is used as part of a training loop.  **Not used
+ *      for inplace prediction**.
+ *
+ *      Prediction can be run in 2 scenarios:
+ *        1. Given data matrix X, obtain prediction y_pred from the model.
+ *        2. Obtain the prediction for computing gradients. For example, DART booster performs dropout
+ *           during training, and the prediction result will be different from the one obtained by normal
+ *           inference step due to dropped trees.
+ *      Set training=false for the first scenario. Set training=true for the second
+ *      scenario.  The second scenario applies when you are defining a custom objective
+ *      function.
+ *    "iteration_begin": int
+ *      Begining iteration of prediction.
+ *    "iteration_end": int
+ *      End iteration of prediction.  Set to 0 this will become the size of tree model.
+ *    "strict_shape": bool
+ *      Whether should we reshape the output with stricter rules.  If set to true,
+ *      normal/margin/contrib/interaction predict will output consistent shape
+ *      disregarding the use of multi-class model, and leaf prediction will output 4-dim
+ *      array representing: (n_samples, n_iterations, n_classes, n_trees_in_forest)
+ *
+ *   Run a normal prediction with strict output shape, 2 dim for softprob , 1 dim for others.
+ *   \code
+ *      {
+ *         "type": 0,
+ *         "training": False,
+ *         "iteration_begin": 0,
+ *         "iteration_end": 0,
+ *         "strict_shape": true,
+ *     }
+ *   \endcode
+ *
+ * \param out_shape Shape of output prediction (copy before use).
+ * \param out_dim   Dimension of output prediction.
+ * \param out_result Buffer storing prediction value (copy before use).
+ *
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle,
+                                        DMatrixHandle dmat,
+                                        char const* c_json_config,
+                                        bst_ulong const **out_shape,
+                                        bst_ulong *out_dim,
+                                        float const **out_result);
+/*
+ * \brief Inplace prediction from CPU dense matrix.
+ *
+ * \param handle        Booster handle.
+ * \param values        JSON encoded__array_interface__ to values.
+ * \param c_json_config See `XGBoosterPredictFromDMatrix` for more info.
+ *
+ *   Additional fields for inplace prediction are:
+ *     "missing": float
+ *
+ * \param m             An optional (NULL if not available) proxy DMatrix instance
+ *                      storing meta info.
+ *
+ * \param out_shape     See `XGBoosterPredictFromDMatrix` for more info.
+ * \param out_dim       See `XGBoosterPredictFromDMatrix` for more info.
+ * \param out_result    See `XGBoosterPredictFromDMatrix` for more info.
+ *
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle,
+                                      char const *values,
+                                      char const *c_json_config,
+                                      DMatrixHandle m,
+                                      bst_ulong const **out_shape,
+                                      bst_ulong *out_dim,
+                                      const float **out_result);
+
+/*
+ * \brief Inplace prediction from CPU CSR matrix.
+ *
+ * \param handle        Booster handle.
+ * \param indptr        JSON encoded__array_interface__ to row pointer in CSR.
+ * \param indices       JSON encoded__array_interface__ to column indices in CSR.
+ * \param values        JSON encoded__array_interface__ to values in CSR..
+ * \param ncol          Number of features in data.
+ * \param c_json_config See `XGBoosterPredictFromDMatrix` for more info.
+ *   Additional fields for inplace prediction are:
+ *     "missing": float
+ *
+ * \param m             An optional (NULL if not available) proxy DMatrix instance
+ *                      storing meta info.
+ *
+ * \param out_shape     See `XGBoosterPredictFromDMatrix` for more info.
+ * \param out_dim       See `XGBoosterPredictFromDMatrix` for more info.
+ * \param out_result    See `XGBoosterPredictFromDMatrix` for more info.
+ *
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
+                                    char const *indices, char const *values,
+                                    bst_ulong ncol,
+                                    char const *c_json_config, DMatrixHandle m,
+                                    bst_ulong const **out_shape,
+                                    bst_ulong *out_dim,
+                                    const float **out_result);
+
+/*
+ * \brief Inplace prediction from CUDA Dense matrix (cupy in Python).
+ *
+ * \param handle        Booster handle
+ * \param values        JSON encoded __cuda_array_interface__ to values.
+ * \param c_json_config See `XGBoosterPredictFromDMatrix` for more info.
+ *   Additional fields for inplace prediction are:
+ *     "missing": float
+ *
+ * \param out_shape     See `XGBoosterPredictFromDMatrix` for more info.
+ * \param out_dim       See `XGBoosterPredictFromDMatrix` for more info.
+ * \param out_result    See `XGBoosterPredictFromDMatrix` for more info.
+ *
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterPredictFromCudaArray(
+    BoosterHandle handle, char const *values, char const *c_json_config,
+    DMatrixHandle m, bst_ulong const **out_shape, bst_ulong *out_dim,
+    const float **out_result);
+
+/*
+ * \brief Inplace prediction from CUDA dense dataframe (cuDF in Python).
+ *
+ * \param handle        Booster handle
+ * \param values        List of __cuda_array_interface__ for all columns encoded in JSON list.
+ * \param c_json_config See `XGBoosterPredictFromDMatrix` for more info.
+ *   Additional fields for inplace prediction are:
+ *     "missing": float
+ *
+ * \param out_shape     See `XGBoosterPredictFromDMatrix` for more info.
+ * \param out_dim       See `XGBoosterPredictFromDMatrix` for more info.
+ * \param out_result    See `XGBoosterPredictFromDMatrix` for more info.
+ *
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterPredictFromCudaColumnar(
+    BoosterHandle handle, char const *values, char const *c_json_config,
+    DMatrixHandle m, bst_ulong const **out_shape, bst_ulong *out_dim,
+    const float **out_result);
+
 
 /*
  * ========================== Begin Serialization APIs =========================

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -99,15 +99,14 @@ class GradientBooster : public Model, public Configurable {
    * \param out_preds output vector to hold the predictions
    * \param training Whether the prediction value is used for training.  For dart booster
    *                 drop out is performed during training.
-   * \param ntree_limit limit the number of trees used in prediction,
-   *                    when it equals 0, this means we do not limit
-   *                    number of trees, this parameter is only valid
-   *                    for gbtree, but not for gblinear
+   * \param layer_begin Begining of boosted tree layer used for prediction.
+   * \param layer_end   End of booster layer. 0 means do not limit trees.
    */
   virtual void PredictBatch(DMatrix* dmat,
                             PredictionCacheEntry* out_preds,
                             bool training,
-                            unsigned ntree_limit = 0) = 0;
+                            unsigned layer_begin,
+                            unsigned layer_end) = 0;
 
   /*!
    * \brief Inplace prediction.
@@ -132,44 +131,45 @@ class GradientBooster : public Model, public Configurable {
    *
    * \param inst the instance you want to predict
    * \param out_preds output vector to hold the predictions
-   * \param ntree_limit limit the number of trees used in prediction
+   * \param layer_begin Begining of boosted tree layer used for prediction.
+   * \param layer_end   End of booster layer. 0 means do not limit trees.
    * \sa Predict
    */
   virtual void PredictInstance(const SparsePage::Inst& inst,
                                std::vector<bst_float>* out_preds,
-                               unsigned ntree_limit = 0) = 0;
+                               unsigned layer_begin, unsigned layer_end) = 0;
   /*!
    * \brief predict the leaf index of each tree, the output will be nsample * ntree vector
    *        this is only valid in gbtree predictor
    * \param dmat feature matrix
    * \param out_preds output vector to hold the predictions
-   * \param ntree_limit limit the number of trees used in prediction, when it equals 0, this means
-   *    we do not limit number of trees, this parameter is only valid for gbtree, but not for gblinear
+   * \param layer_begin Begining of boosted tree layer used for prediction.
+   * \param layer_end   End of booster layer. 0 means do not limit trees.
    */
-  virtual void PredictLeaf(DMatrix* dmat,
-                           HostDeviceVector<bst_float>* out_preds,
-                           unsigned ntree_limit = 0) = 0;
+  virtual void PredictLeaf(DMatrix *dmat,
+                           HostDeviceVector<bst_float> *out_preds,
+                           unsigned layer_begin, unsigned layer_end) = 0;
 
   /*!
    * \brief feature contributions to individual predictions; the output will be a vector
    *         of length (nfeats + 1) * num_output_group * nsample, arranged in that order
    * \param dmat feature matrix
    * \param out_contribs output vector to hold the contributions
-   * \param ntree_limit limit the number of trees used in prediction, when it equals 0, this means
-   *    we do not limit number of trees
+   * \param layer_begin Begining of boosted tree layer used for prediction.
+   * \param layer_end   End of booster layer. 0 means do not limit trees.
    * \param approximate use a faster (inconsistent) approximation of SHAP values
    * \param condition condition on the condition_feature (0=no, -1=cond off, 1=cond on).
    * \param condition_feature feature to condition on (i.e. fix) during calculations
    */
   virtual void PredictContribution(DMatrix* dmat,
                                    HostDeviceVector<bst_float>* out_contribs,
-                                   unsigned ntree_limit = 0,
+                                   unsigned layer_begin, unsigned layer_end,
                                    bool approximate = false, int condition = 0,
                                    unsigned condition_feature = 0) = 0;
 
-  virtual void PredictInteractionContributions(DMatrix* dmat,
-                                               HostDeviceVector<bst_float>* out_contribs,
-                                               unsigned ntree_limit, bool approximate) = 0;
+  virtual void PredictInteractionContributions(
+      DMatrix *dmat, HostDeviceVector<bst_float> *out_contribs,
+      unsigned layer_begin, unsigned layer_end, bool approximate) = 0;
 
   /*!
    * \brief dump the model in the requested format

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -63,7 +63,7 @@ class GradientBooster : public Model, public Configurable {
   /*!
    * \brief Slice a model using boosting index. The slice m:n indicates taking all trees
    *        that were fit during the boosting rounds m, (m+1), (m+2), ..., (n-1).
-   * \param layer_begin Begining of boosted tree layer used for prediction.
+   * \param layer_begin Beginning of boosted tree layer used for prediction.
    * \param layer_end   End of booster layer. 0 means do not limit trees.
    * \param out         Output gradient booster
    */
@@ -99,7 +99,7 @@ class GradientBooster : public Model, public Configurable {
    * \param out_preds output vector to hold the predictions
    * \param training Whether the prediction value is used for training.  For dart booster
    *                 drop out is performed during training.
-   * \param layer_begin Begining of boosted tree layer used for prediction.
+   * \param layer_begin Beginning of boosted tree layer used for prediction.
    * \param layer_end   End of booster layer. 0 means do not limit trees.
    */
   virtual void PredictBatch(DMatrix* dmat,
@@ -114,7 +114,7 @@ class GradientBooster : public Model, public Configurable {
    * \param           x                      A type erased data adapter.
    * \param           missing                Missing value in the data.
    * \param [in,out]  out_preds              The output preds.
-   * \param           layer_begin (Optional) Begining of boosted tree layer used for prediction.
+   * \param           layer_begin (Optional) Beginning of boosted tree layer used for prediction.
    * \param           layer_end   (Optional) End of booster layer. 0 means do not limit trees.
    */
   virtual void InplacePredict(dmlc::any const &, std::shared_ptr<DMatrix>, float,
@@ -131,7 +131,7 @@ class GradientBooster : public Model, public Configurable {
    *
    * \param inst the instance you want to predict
    * \param out_preds output vector to hold the predictions
-   * \param layer_begin Begining of boosted tree layer used for prediction.
+   * \param layer_begin Beginning of boosted tree layer used for prediction.
    * \param layer_end   End of booster layer. 0 means do not limit trees.
    * \sa Predict
    */
@@ -143,7 +143,7 @@ class GradientBooster : public Model, public Configurable {
    *        this is only valid in gbtree predictor
    * \param dmat feature matrix
    * \param out_preds output vector to hold the predictions
-   * \param layer_begin Begining of boosted tree layer used for prediction.
+   * \param layer_begin Beginning of boosted tree layer used for prediction.
    * \param layer_end   End of booster layer. 0 means do not limit trees.
    */
   virtual void PredictLeaf(DMatrix *dmat,
@@ -155,7 +155,7 @@ class GradientBooster : public Model, public Configurable {
    *         of length (nfeats + 1) * num_output_group * nsample, arranged in that order
    * \param dmat feature matrix
    * \param out_contribs output vector to hold the contributions
-   * \param layer_begin Begining of boosted tree layer used for prediction.
+   * \param layer_begin Beginning of boosted tree layer used for prediction.
    * \param layer_end   End of booster layer. 0 means do not limit trees.
    * \param approximate use a faster (inconsistent) approximation of SHAP values
    * \param condition condition on the condition_feature (0=no, -1=cond off, 1=cond on).

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -113,8 +113,8 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    * \param data input data
    * \param output_margin whether to only predict margin value instead of transformed prediction
    * \param out_preds output vector that stores the prediction
-   * \param ntree_limit limit number of trees used for boosted tree
-   *   predictor, when it equals 0, this means we are using all the trees
+   * \param layer_begin Begining of boosted tree layer used for prediction.
+   * \param layer_end   End of booster layer. 0 means do not limit trees.
    * \param training Whether the prediction result is used for training
    * \param pred_leaf whether to only predict the leaf index of each tree in a boosted tree predictor
    * \param pred_contribs whether to only predict the feature contributions
@@ -124,7 +124,8 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
   virtual void Predict(std::shared_ptr<DMatrix> data,
                        bool output_margin,
                        HostDeviceVector<bst_float> *out_preds,
-                       unsigned ntree_limit = 0,
+                       unsigned layer_begin,
+                       unsigned layer_end,
                        bool training = false,
                        bool pred_leaf = false,
                        bool pred_contribs = false,

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -113,7 +113,7 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    * \param data input data
    * \param output_margin whether to only predict margin value instead of transformed prediction
    * \param out_preds output vector that stores the prediction
-   * \param layer_begin Begining of boosted tree layer used for prediction.
+   * \param layer_begin Beginning of boosted tree layer used for prediction.
    * \param layer_end   End of booster layer. 0 means do not limit trees.
    * \param training Whether the prediction result is used for training
    * \param pred_leaf whether to only predict the leaf index of each tree in a boosted tree predictor
@@ -141,7 +141,7 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    * \param          type        Prediction type.
    * \param          missing     Missing value in the data.
    * \param [in,out] out_preds   Pointer to output prediction vector.
-   * \param          layer_begin Begining of boosted tree layer used for prediction.
+   * \param          layer_begin Beginning of boosted tree layer used for prediction.
    * \param          layer_end   End of booster layer. 0 means do not limit trees.
    */
   virtual void InplacePredict(dmlc::any const &x,

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -127,12 +127,11 @@ class Predictor {
    * \param [in,out]  out_preds   The output preds.
    * \param           model       The model to predict from.
    * \param           tree_begin  The tree begin index.
-   * \param           ntree_limit (Optional) The ntree limit. 0 means do not
-   *                              limit trees.
+   * \param           tree_end    The tree end index.
    */
   virtual void PredictBatch(DMatrix* dmat, PredictionCacheEntry* out_preds,
-                            const gbm::GBTreeModel& model, int tree_begin,
-                            uint32_t const ntree_limit = 0) const = 0;
+                            const gbm::GBTreeModel& model, uint32_t tree_begin,
+                            uint32_t tree_end = 0) const = 0;
 
   /**
    * \brief Inplace prediction.
@@ -159,13 +158,13 @@ class Predictor {
    * \param           inst        The instance to predict.
    * \param [in,out]  out_preds   The output preds.
    * \param           model       The model to predict from
-   * \param           ntree_limit (Optional) The ntree limit.
+   * \param           tree_end    (Optional) The tree end index.
    */
 
   virtual void PredictInstance(const SparsePage::Inst& inst,
                                std::vector<bst_float>* out_preds,
                                const gbm::GBTreeModel& model,
-                               unsigned ntree_limit = 0) const = 0;
+                               unsigned tree_end = 0) const = 0;
 
   /**
    * \brief predict the leaf index of each tree, the output will be nsample *
@@ -174,18 +173,14 @@ class Predictor {
    * \param [in,out]  dmat        The input feature matrix.
    * \param [in,out]  out_preds   The output preds.
    * \param           model       Model to make predictions from.
-   * \param           ntree_limit (Optional) The ntree limit.
+   * \param           tree_end    (Optional) The tree end index.
    */
 
   virtual void PredictLeaf(DMatrix* dmat, HostDeviceVector<bst_float>* out_preds,
                            const gbm::GBTreeModel& model,
-                           unsigned ntree_limit = 0) const = 0;
+                           unsigned tree_end = 0) const = 0;
 
   /**
-   * \fn  virtual void Predictor::PredictContribution( DMatrix* dmat,
-   * std::vector<bst_float>* out_contribs, const gbm::GBTreeModel& model,
-   * unsigned ntree_limit = 0) = 0;
-   *
    * \brief feature contributions to individual predictions; the output will be
    * a vector of length (nfeats + 1) * num_output_group * nsample, arranged in
    * that order.
@@ -193,7 +188,7 @@ class Predictor {
    * \param [in,out]  dmat               The input feature matrix.
    * \param [in,out]  out_contribs       The output feature contribs.
    * \param           model              Model to make predictions from.
-   * \param           ntree_limit        (Optional) The ntree limit.
+   * \param           tree_end           The tree end index.
    * \param           tree_weights       (Optional) Weights to multiply each tree by.
    * \param           approximate        Use fast approximate algorithm.
    * \param           condition          Condition on the condition_feature (0=no, -1=cond off, 1=cond on).
@@ -203,7 +198,7 @@ class Predictor {
   virtual void PredictContribution(DMatrix* dmat,
                                    HostDeviceVector<bst_float>* out_contribs,
                                    const gbm::GBTreeModel& model,
-                                   unsigned ntree_limit = 0,
+                                   unsigned tree_end = 0,
                                    std::vector<bst_float>* tree_weights = nullptr,
                                    bool approximate = false,
                                    int condition = 0,
@@ -212,7 +207,7 @@ class Predictor {
   virtual void PredictInteractionContributions(DMatrix* dmat,
                                                HostDeviceVector<bst_float>* out_contribs,
                                                const gbm::GBTreeModel& model,
-                                               unsigned ntree_limit = 0,
+                                               unsigned tree_end = 0,
                                                std::vector<bst_float>* tree_weights = nullptr,
                                                bool approximate = false) const = 0;
 

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -139,7 +139,7 @@ class Predictor {
    * \param           model                  The model to predict from.
    * \param           missing                Missing value in the data.
    * \param [in,out]  out_preds              The output preds.
-   * \param           tree_begin (Optional) Begining of boosted trees used for prediction.
+   * \param           tree_begin (Optional) Beginning of boosted trees used for prediction.
    * \param           tree_end   (Optional) End of booster trees. 0 means do not limit trees.
    *
    * \return True if the data can be handled by current predictor, false otherwise.

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -881,7 +881,7 @@ async def _train_async(
     return list(filter(lambda ret: ret is not None, results))[0]
 
 
-def train(
+def train(                      # pylint: disable=unused-argument
     client: "distributed.Client",
     params: Dict[str, Any],
     dtrain: DaskDMatrix,
@@ -892,16 +892,17 @@ def train(
     early_stopping_rounds: Optional[int] = None,
     xgb_model: Optional[Booster] = None,
     verbose_eval: Union[int, bool] = True,
-    callbacks: Optional[List[TrainingCallback]] = None
+    callbacks: Optional[List[TrainingCallback]] = None,
 ) -> Any:
-    '''Train XGBoost model.
+    """Train XGBoost model.
 
     .. versionadded:: 1.0.0
 
     .. note::
 
-        Other parameters are the same as `xgboost.train` except for `evals_result`, which
-        is returned as part of function return value instead of argument.
+        Other parameters are the same as :py:func:`xgboost.train` except for
+        `evals_result`, which is returned as part of function return value instead of
+        argument.
 
     Parameters
     ----------
@@ -920,29 +921,17 @@ def train(
             {'booster': xgboost.Booster,
              'history': {'train': {'logloss': ['0.48253', '0.35953']},
                          'eval': {'logloss': ['0.480385', '0.357756']}}}
-    '''
+
+    """
     _assert_dask_support()
     client = _xgb_get_client(client)
     # Get global configuration before transferring computation to another thread or
     # process.
-    global_config = config.get_config()
-    return client.sync(_train_async,
-                       client=client,
-                       global_config=global_config,
-                       num_boost_round=num_boost_round,
-                       obj=obj,
-                       feval=feval,
-                       params=params,
-                       dtrain=dtrain,
-                       evals=evals,
-                       early_stopping_rounds=early_stopping_rounds,
-                       verbose_eval=verbose_eval,
-                       xgb_model=xgb_model,
-                       callbacks=callbacks)
+    return client.sync(_train_async, global_config=config.get_config(), **locals())
 
 
-def _can_output_df(data: _DaskCollection, output_shape: Tuple) -> bool:
-    return isinstance(data, dd.DataFrame) and len(output_shape) <= 2
+def _can_output_df(is_df: bool, output_shape: Tuple) -> bool:
+    return is_df and len(output_shape) <= 2
 
 
 async def _direct_predict_impl(
@@ -954,8 +943,9 @@ async def _direct_predict_impl(
     meta: Dict[int, str],
 ) -> _DaskCollection:
     columns = list(meta.keys())
-    if _can_output_df(data, output_shape):
+    if _can_output_df(isinstance(data, dd.DataFrame), output_shape):
         if base_margin is not None and isinstance(base_margin, da.Array):
+            # Easier for map_partitions
             base_margin_df: Optional[dd.DataFrame] = base_margin.to_dask_dataframe()
         else:
             base_margin_df = base_margin
@@ -975,17 +965,21 @@ async def _direct_predict_impl(
         if base_margin is not None and isinstance(
             base_margin, (dd.Series, dd.DataFrame)
         ):
+            # Easier for map_blocks
             base_margin_array: Optional[da.Array] = base_margin.to_dask_array()
         else:
             base_margin_array = base_margin
         # Input data is 2-dim array, output can be 1(reg, binary)/2(multi-class,
-        # contrib)/3(contrib)/4(interaction) dims.
+        # contrib)/3(contrib, interaction)/4(interaction) dims.
         if len(output_shape) == 1:
             drop_axis: Union[int, List[int]] = [1]  # drop from 2 to 1 dim.
             new_axis: Union[int, List[int]] = []
         else:
             drop_axis = []
-            new_axis = [i + 2 for i in range(len(output_shape) - 2)]
+            if isinstance(data, dd.DataFrame):
+                new_axis = list(range(len(output_shape) - 2))
+            else:
+                new_axis = [i + 2 for i in range(len(output_shape) - 2)]
         predictions = da.map_blocks(
             mapped_predict,
             booster,
@@ -1001,28 +995,22 @@ async def _direct_predict_impl(
 
 
 def _infer_predict_output(
-    booster: Booster,
-    data: Union[DaskDMatrix,  _DaskCollection],
-    inplace: bool,
-    **kwargs: Any
+    booster: Booster, features: int, is_df: bool, inplace: bool, **kwargs: Any
 ) -> Tuple[Tuple[int, ...], Dict[int, str]]:
     """Create a dummy test sample to infer output shape for prediction."""
-    if isinstance(data, DaskDMatrix):
-        features = data.num_col()
-    else:
-        features = data.shape[1]
+    assert isinstance(features, int)
     rng = numpy.random.RandomState(1994)
     test_sample = rng.randn(1, features)
     if inplace:
-        # clear the state to avoid gpu_id, gpu_predictor
-        booster = Booster(model_file=booster.save_raw())
-        test_predt = booster.inplace_predict(test_sample, **kwargs)
-    else:
-        m = DMatrix(test_sample)
-        test_predt = booster.predict(m, **kwargs)
+        kwargs = kwargs.copy()
+        if kwargs["predict_type"] == "margin":
+            kwargs["output_margin"] = True
+        del kwargs["predict_type"]
+    m = DMatrix(test_sample)
+    test_predt = booster.predict(m, validate_features=False, **kwargs)
     n_columns = test_predt.shape[1] if len(test_predt.shape) > 1 else 1
     meta: Dict[int, str] = {}
-    if _can_output_df(data, test_predt.shape):
+    if _can_output_df(is_df, test_predt.shape):
         for i in range(n_columns):
             meta[i] = "f4"
     return test_predt.shape, meta
@@ -1034,7 +1022,7 @@ async def _get_model_future(
     if isinstance(model, Booster):
         booster = await client.scatter(model, broadcast=True)
     elif isinstance(model, dict):
-        booster = await client.scatter(model["booster"])
+        booster = await client.scatter(model["booster"], broadcast=True)
     elif isinstance(model, distributed.Future):
         booster = model
         if booster.type is not Booster:
@@ -1059,6 +1047,8 @@ async def _predict_async(
     approx_contribs: bool,
     pred_interactions: bool,
     validate_features: bool,
+    iteration_range: Tuple[int, int],
+    strict_shape: bool,
 ) -> _DaskCollection:
     _booster = await _get_model_future(client, model)
     if not isinstance(data, (DaskDMatrix, da.Array, dd.DataFrame)):
@@ -1077,43 +1067,51 @@ async def _predict_async(
                 approx_contribs=approx_contribs,
                 pred_interactions=pred_interactions,
                 validate_features=validate_features,
+                iteration_range=iteration_range,
+                strict_shape=strict_shape,
             )
-            if is_df and len(predt.shape) <= 2:
+            if _can_output_df(is_df, predt.shape):
                 if lazy_isinstance(partition, "cudf", "core.dataframe.DataFrame"):
                     import cudf
 
-                    predt = cudf.DataFrame(predt, columns=columns)
+                    predt = cudf.DataFrame(predt, columns=columns, dtype=numpy.float32)
                 else:
-                    predt = DataFrame(predt, columns=columns)
+                    predt = DataFrame(predt, columns=columns, dtype=numpy.float32)
             return predt
 
     # Predict on dask collection directly.
     if isinstance(data, (da.Array, dd.DataFrame)):
-        _output_shape, meta = _infer_predict_output(
-            await _booster.result(),
-            data,
+        _output_shape, meta = await client.compute(
+            client.submit(
+                _infer_predict_output,
+                _booster,
+                features=data.shape[1],
+                is_df=isinstance(data, dd.DataFrame),
+                inplace=False,
+                output_margin=output_margin,
+                pred_leaf=pred_leaf,
+                pred_contribs=pred_contribs,
+                approx_contribs=approx_contribs,
+                pred_interactions=pred_interactions,
+            )
+        )
+        return await _direct_predict_impl(
+            mapped_predict, _booster, data, None, _output_shape, meta
+        )
+
+    output_shape, _ = await client.compute(
+        client.submit(
+            _infer_predict_output,
+            booster=_booster,
+            features=data.num_col(),
+            is_df=False,
             inplace=False,
             output_margin=output_margin,
             pred_leaf=pred_leaf,
             pred_contribs=pred_contribs,
             approx_contribs=approx_contribs,
             pred_interactions=pred_interactions,
-            validate_features=False,
         )
-        return await _direct_predict_impl(
-            mapped_predict, _booster, data, None, _output_shape, meta
-        )
-
-    output_shape, _ = _infer_predict_output(
-        booster=await _booster.result(),
-        data=data,
-        inplace=False,
-        output_margin=output_margin,
-        pred_leaf=pred_leaf,
-        pred_contribs=pred_contribs,
-        approx_contribs=approx_contribs,
-        pred_interactions=pred_interactions,
-        validate_features=False,
     )
     # Prediction on dask DMatrix.
     partition_order = data.partition_order
@@ -1180,7 +1178,7 @@ async def _predict_async(
                 futures[i], shape=(rows,) + output_shape[1:], dtype=numpy.float32
             )
         )
-    predictions = await da.concatenate(arrays, axis=0)
+    predictions = da.concatenate(arrays, axis=0)
     return predictions
 
 
@@ -1194,15 +1192,19 @@ def predict(                    # pylint: disable=unused-argument
     pred_contribs: bool = False,
     approx_contribs: bool = False,
     pred_interactions: bool = False,
-    validate_features: bool = True
+    validate_features: bool = True,
+    iteration_range: Tuple[int, int] = (0, 0),
+    strict_shape: bool = False,
 ) -> Any:
     '''Run prediction with a trained booster.
 
     .. note::
 
-        Using ``inplace_predict `` might be faster when meta information like
-        ``base_margin`` is not needed. For other parameters, please see
-        ``Booster.predict``.
+        Using ``inplace_predict`` might be faster when some features are not needed.  See
+        :py:meth:`xgboost.Booster.predict` for details on various parameters.  When using
+        ``pred_interactions`` with mutli-class model, input should be ``da.Array`` or
+        ``DaskDMatrix`` due to limitation in ``da.map_blocks``.
+
 
     .. versionadded:: 1.0.0
 
@@ -1232,69 +1234,83 @@ def predict(                    # pylint: disable=unused-argument
     '''
     _assert_dask_support()
     client = _xgb_get_client(client)
-    return client.sync(
-        _predict_async, global_config=config.get_config(), **locals()
-    )
+    return client.sync(_predict_async, global_config=config.get_config(), **locals())
 
 
-async def _inplace_predict_async(
+async def _inplace_predict_async(  # pylint: disable=too-many-branches
     client: "distributed.Client",
     global_config: Dict[str, Any],
     model: Union[Booster, Dict, "distributed.Future"],
     data: _DaskCollection,
-    iteration_range: Tuple[int, int] = (0, 0),
-    predict_type: str = 'value',
-    missing: float = numpy.nan
+    iteration_range: Tuple[int, int],
+    predict_type: str,
+    missing: float,
+    validate_features: bool,
+    base_margin: Optional[_DaskCollection],
+    strict_shape: bool,
 ) -> _DaskCollection:
     client = _xgb_get_client(client)
     booster = await _get_model_future(client, model)
     if not isinstance(data, (da.Array, dd.DataFrame)):
         raise TypeError(_expect([da.Array, dd.DataFrame], type(data)))
+    if base_margin is not None and not isinstance(
+        data, (da.Array, dd.DataFrame, dd.Series)
+    ):
+        raise TypeError(_expect([da.Array, dd.DataFrame, dd.Series], type(base_margin)))
 
     def mapped_predict(
-        booster: Booster, data: Any, is_df: bool, columns: List[int], _: Any
+        booster: Booster, data: Any, is_df: bool, columns: List[int], base_margin: Any
     ) -> Any:
         with config.config_context(**global_config):
             prediction = booster.inplace_predict(
                 data,
                 iteration_range=iteration_range,
                 predict_type=predict_type,
-                missing=missing
+                missing=missing,
+                base_margin=base_margin,
+                validate_features=validate_features,
+                strict_shape=strict_shape,
             )
-        if is_df and len(prediction.shape) <= 2:
-            if lazy_isinstance(data, 'cudf.core.dataframe', 'DataFrame'):
+        if _can_output_df(is_df, prediction.shape):
+            if lazy_isinstance(data, "cudf.core.dataframe", "DataFrame"):
                 import cudf
+
                 prediction = cudf.DataFrame(
                     prediction, columns=columns, dtype=numpy.float32
                 )
             else:
-                # If it's  from pandas, the partition is a numpy array
-                prediction = DataFrame(
-                    prediction, columns=columns, dtype=numpy.float32
-                )
+                # If it's from pandas, the partition is a numpy array
+                prediction = DataFrame(prediction, columns=columns, dtype=numpy.float32)
         return prediction
-
-    shape, meta = _infer_predict_output(
-        await booster.result(),
-        data,
-        True,
-        predict_type=predict_type,
-        iteration_range=iteration_range
+    # await turns future into value.
+    shape, meta = await client.compute(
+        client.submit(
+            _infer_predict_output,
+            booster,
+            features=data.shape[1],
+            is_df=isinstance(data, dd.DataFrame),
+            inplace=True,
+            predict_type=predict_type,
+            iteration_range=iteration_range,
+        )
     )
     return await _direct_predict_impl(
-        mapped_predict, booster, data, None, shape, meta
+        mapped_predict, booster, data, base_margin, shape, meta
     )
 
 
-def inplace_predict(            # pylint: disable=unused-argument
+def inplace_predict(  # pylint: disable=unused-argument
     client: "distributed.Client",
     model: Union[TrainReturnT, Booster, "distributed.Future"],
     data: _DaskCollection,
     iteration_range: Tuple[int, int] = (0, 0),
-    predict_type: str = 'value',
-    missing: float = numpy.nan
+    predict_type: str = "value",
+    missing: float = numpy.nan,
+    validate_features: bool = True,
+    base_margin: Optional[_DaskCollection] = None,
+    strict_shape: bool = False,
 ) -> Any:
-    '''Inplace prediction.
+    """Inplace prediction. See doc in :py:meth:`xgboost.Booster.inplace_predict` for details.
 
     .. versionadded:: 1.1.0
 
@@ -1304,16 +1320,27 @@ def inplace_predict(            # pylint: disable=unused-argument
         Specify the dask client used for training.  Use default client
         returned from dask if it's set to None.
     model:
-        The trained model.  It can be a distributed.Future so user can
-        pre-scatter it onto all workers.
+        See :py:func:`xgboost.dask.predict` for details.
+    data :
+        dask collection.
     iteration_range:
-        Specify the range of trees used for prediction.
+        See :py:meth:`xgboost.Booster.predict` for details.
     predict_type:
-        * 'value': Normal prediction result.
-        * 'margin': Output the raw untransformed margin value.
+        See :py:meth:`xgboost.Booster.inplace_predict` for details.
     missing:
         Value in the input data which needs to be present as a missing
         value. If None, defaults to np.nan.
+    base_margin:
+        See :py:obj:`xgboost.DMatrix` for details. Right now classifier is not well
+        supported with base_margin as it requires the size of base margin to be `n_classes
+        * n_samples`.
+
+        .. versionadded:: 1.4.0
+
+    strict_shape:
+        See :py:meth:`xgboost.Booster.predict` for details.
+
+        .. versionadded:: 1.4.0
 
     Returns
     -------
@@ -1322,7 +1349,7 @@ def inplace_predict(            # pylint: disable=unused-argument
         data is ``dask.dataframe.DataFrame``, return value can be
         ``dask.dataframe.Series``, ``dask.dataframe.DataFrame`` or ``dask.array.Array``,
         depending on the output shape.
-    '''
+    """
     _assert_dask_support()
     client = _xgb_get_client(client)
     return client.sync(
@@ -1334,9 +1361,11 @@ async def _async_wrap_evaluation_matrices(
     client: "distributed.Client", **kwargs: Any
 ) -> Tuple[DaskDMatrix, Optional[List[Tuple[DaskDMatrix, str]]]]:
     """A switch function for async environment."""
+
     def _inner(**kwargs: Any) -> DaskDMatrix:
         m = DaskDMatrix(client=client, **kwargs)
         return m
+
     train_dmatrix, evals = _wrap_evaluation_matrices(create_dmatrix=_inner, **kwargs)
     train_dmatrix = await train_dmatrix
     if evals is None:
@@ -1351,25 +1380,45 @@ async def _async_wrap_evaluation_matrices(
 
 
 class DaskScikitLearnBase(XGBModel):
-    '''Base class for implementing scikit-learn interface with Dask'''
+    """Base class for implementing scikit-learn interface with Dask"""
 
     _client = None
 
     async def _predict_async(
-        self, data: _DaskCollection,
-        output_margin: bool = False,
-        validate_features: bool = True,
-        base_margin: Optional[_DaskCollection] = None
+        self,
+        data: _DaskCollection,
+        output_margin: bool,
+        validate_features: bool,
+        base_margin: Optional[_DaskCollection],
+        iteration_range: Optional[Tuple[int, int]],
     ) -> Any:
-        test_dmatrix = await DaskDMatrix(
-            client=self.client, data=data, base_margin=base_margin,
-            missing=self.missing
-        )
-        pred_probs = await predict(client=self.client,
-                                   model=self.get_booster(), data=test_dmatrix,
-                                   output_margin=output_margin,
-                                   validate_features=validate_features)
-        return pred_probs
+        iteration_range = self._get_iteration_range(iteration_range)
+        if self._can_use_inplace_predict():
+            predts = await inplace_predict(
+                client=self.client,
+                model=self.get_booster(),
+                data=data,
+                iteration_range=iteration_range,
+                predict_type="margin" if output_margin else "value",
+                missing=self.missing,
+                base_margin=base_margin,
+                validate_features=validate_features,
+            )
+            if isinstance(predts, dd.DataFrame):
+                predts = predts.to_dask_array()
+        else:
+            test_dmatrix = await DaskDMatrix(
+                self.client, data=data, base_margin=base_margin, missing=self.missing
+            )
+            predts = await predict(
+                self.client,
+                model=self.get_booster(),
+                data=test_dmatrix,
+                output_margin=output_margin,
+                validate_features=validate_features,
+                iteration_range=iteration_range,
+            )
+        return predts
 
     def predict(
         self,
@@ -1377,26 +1426,56 @@ class DaskScikitLearnBase(XGBModel):
         output_margin: bool = False,
         ntree_limit: Optional[int] = None,
         validate_features: bool = True,
-        base_margin: Optional[_DaskCollection] = None
+        base_margin: Optional[_DaskCollection] = None,
+        iteration_range: Optional[Tuple[int, int]] = None,
     ) -> Any:
         _assert_dask_support()
-        msg = '`ntree_limit` is not supported on dask, use model slicing instead.'
+        msg = "`ntree_limit` is not supported on dask, use `iteration_range` instead."
         assert ntree_limit is None, msg
         return self.client.sync(
             self._predict_async,
             X,
             output_margin=output_margin,
             validate_features=validate_features,
-            base_margin=base_margin
+            base_margin=base_margin,
+            iteration_range=iteration_range,
         )
+
+    async def _apply_async(
+        self,
+        X: _DaskCollection,
+        iteration_range: Optional[Tuple[int, int]] = None,
+    ) -> Any:
+        iteration_range = self._get_iteration_range(iteration_range)
+        test_dmatrix = await DaskDMatrix(self.client, data=X, missing=self.missing)
+        predts = await predict(
+            self.client,
+            model=self.get_booster(),
+            data=test_dmatrix,
+            pred_leaf=True,
+            iteration_range=iteration_range,
+        )
+        return predts
+
+    def apply(
+        self,
+        X: _DaskCollection,
+        ntree_limit: Optional[int] = None,
+        iteration_range: Optional[Tuple[int, int]] = None,
+    ) -> Any:
+        _assert_dask_support()
+        msg = "`ntree_limit` is not supported on dask, use `iteration_range` instead."
+        assert ntree_limit is None, msg
+        return self.client.sync(self._apply_async, X, iteration_range=iteration_range)
 
     def __await__(self) -> Awaitable[Any]:
         # Generate a coroutine wrapper to make this class awaitable.
         async def _() -> Awaitable[Any]:
             return self
+
         return self.client.sync(_).__await__()
 
-    def __getstate__(self):
+    def __getstate__(self) -> Dict:
         this = self.__dict__.copy()
         if "_client" in this.keys():
             del this["_client"]
@@ -1404,7 +1483,7 @@ class DaskScikitLearnBase(XGBModel):
 
     @property
     def client(self) -> "distributed.Client":
-        '''The dask client used in this model.'''
+        """The dask client used in this model."""
         client = _xgb_get_client(self._client)
         return client
 
@@ -1494,7 +1573,7 @@ class DaskXGBRegressor(DaskScikitLearnBase, XGBRegressorBase):
         sample_weight_eval_set: Optional[List[_DaskCollection]] = None,
         base_margin_eval_set: Optional[List[_DaskCollection]] = None,
         feature_weights: Optional[_DaskCollection] = None,
-        callbacks: Optional[List[TrainingCallback]] = None
+        callbacks: Optional[List[TrainingCallback]] = None,
     ) -> "DaskXGBRegressor":
         _assert_dask_support()
         args = {k: v for k, v in locals().items() if k != "self"}
@@ -1556,9 +1635,7 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
         else:
             obj = None
         model, metric, params = self._configure_fit(
-            booster=xgb_model,
-            eval_metric=eval_metric,
-            params=params
+            booster=xgb_model, eval_metric=eval_metric, params=params
         )
         results = await train(
             client=self.client,
@@ -1610,18 +1687,19 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
         X: _DaskCollection,
         validate_features: bool,
         output_margin: bool,
-        base_margin: Optional[_DaskCollection]
+        base_margin: Optional[_DaskCollection],
+        iteration_range: Optional[Tuple[int, int]],
     ) -> _DaskCollection:
-        test_dmatrix = await DaskDMatrix(
-            client=self.client, data=X, base_margin=base_margin,
-            missing=self.missing
+        if iteration_range is None:
+            iteration_range = (0, 0)
+        predts = await super()._predict_async(
+            data=X,
+            output_margin=output_margin,
+            validate_features=validate_features,
+            base_margin=base_margin,
+            iteration_range=iteration_range,
         )
-        pred_probs = await predict(client=self.client,
-                                   model=self.get_booster(),
-                                   data=test_dmatrix,
-                                   validate_features=validate_features,
-                                   output_margin=output_margin)
-        return _cls_predict_proba(self.objective, pred_probs, da.vstack)
+        return _cls_predict_proba(self.objective, predts, da.vstack)
 
     # pylint: disable=missing-function-docstring
     def predict_proba(
@@ -1630,37 +1708,49 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
         ntree_limit: Optional[int] = None,
         validate_features: bool = True,
         output_margin: bool = False,
-        base_margin: Optional[_DaskCollection] = None
+        base_margin: Optional[_DaskCollection] = None,
+        iteration_range: Optional[Tuple[int, int]] = None,
     ) -> Any:
         _assert_dask_support()
-        msg = '`ntree_limit` is not supported on dask, use model slicing instead.'
+        msg = "`ntree_limit` is not supported on dask, use `iteration_range` instead."
         assert ntree_limit is None, msg
         return self.client.sync(
             self._predict_proba_async,
             X=X,
             validate_features=validate_features,
             output_margin=output_margin,
-            base_margin=base_margin
+            base_margin=base_margin,
+            iteration_range=iteration_range,
         )
+
     predict_proba.__doc__ = XGBClassifier.predict_proba.__doc__
 
     async def _predict_async(
-        self, data: _DaskCollection,
-        output_margin: bool = False,
-        validate_features: bool = True,
-        base_margin: Optional[_DaskCollection] = None
+        self,
+        data: _DaskCollection,
+        output_margin: bool,
+        validate_features: bool,
+        base_margin: Optional[_DaskCollection],
+        iteration_range: Optional[Tuple[int, int]],
     ) -> _DaskCollection:
         pred_probs = await super()._predict_async(
-            data, output_margin, validate_features, base_margin
+            data, output_margin, validate_features, base_margin, iteration_range
         )
         if output_margin:
             return pred_probs
 
-        if self.n_classes_ == 2:
+        if len(pred_probs.shape) == 1:
             preds = (pred_probs > 0.5).astype(int)
         else:
-            preds = da.argmax(pred_probs, axis=1)
+            assert len(pred_probs.shape) == 2
+            assert isinstance(pred_probs, da.Array)
+            # when using da.argmax directly, dask will construct a numpy based return
+            # array, which runs into error when computing GPU based prediction.
 
+            def _argmax(x: Any) -> Any:
+                return x.argmax(axis=1)
+
+            preds = da.map_blocks(_argmax, pred_probs, drop_axis=1)
         return preds
 
 
@@ -1770,7 +1860,7 @@ class DaskXGBRanker(DaskScikitLearnBase, XGBRankerMixIn):
         callbacks: Optional[List[TrainingCallback]] = None
     ) -> "DaskXGBRanker":
         _assert_dask_support()
-        args = {k: v for k, v in locals().items() if k != 'self'}
+        args = {k: v for k, v in locals().items() if k != "self"}
         return self.client.sync(self._fit_async, **args)
 
     # FIXME(trivialfis): arguments differ due to additional parameters like group and qid.

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -254,6 +254,7 @@ class DaskDMatrix:
             raise TypeError(_expect((dd.DataFrame, da.Array, dd.Series), type(label)))
 
         self._n_cols = data.shape[1]
+        assert isinstance(self._n_cols, int)
         self.worker_map: Dict[str, "distributed.Future"] = defaultdict(list)
         self.is_quantile: bool = False
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1003,9 +1003,8 @@ def _infer_predict_output(
     test_sample = rng.randn(1, features)
     if inplace:
         kwargs = kwargs.copy()
-        if kwargs["predict_type"] == "margin":
+        if kwargs.pop("predict_type") == "margin":
             kwargs["output_margin"] = True
-        del kwargs["predict_type"]
     m = DMatrix(test_sample)
     test_predt = booster.predict(m, validate_features=False, **kwargs)
     n_columns = test_predt.shape[1] if len(test_predt.shape) > 1 else 1

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -6,7 +6,8 @@ import warnings
 import json
 from typing import Union, Optional, List, Dict, Callable, Tuple, Any
 import numpy as np
-from .core import Booster, DMatrix, XGBoostError, _deprecate_positional_args
+from .core import Booster, DMatrix, XGBoostError
+from .core import _deprecate_positional_args, _convert_ntree_limit
 from .core import Metric
 from .training import train
 from .data import _is_cudf_df, _is_cudf_ser, _is_cupy_array
@@ -413,8 +414,8 @@ class XGBModel(XGBModelBase):
             # Simple optimization to gain speed (inspect is slow)
             return self
 
-        # this concatenates kwargs into paraemters, enabling `get_params` for
-        # obtaining parameters from keyword paraemters.
+        # this concatenates kwargs into parameters, enabling `get_params` for
+        # obtaining parameters from keyword parameters.
         for key, value in params.items():
             if hasattr(self, key):
                 setattr(self, key, value)
@@ -747,26 +748,45 @@ class XGBModel(XGBModelBase):
         self._set_evaluation_result(evals_result)
         return self
 
+    def _can_use_inplace_predict(self) -> bool:
+        # When predictor is explicitly set, using `inplace_predict` might result into
+        # error with incompatible data type.
+        # Inplace predict doesn't handle as many data types as DMatrix, but it's
+        # sufficient for dask interface where input is simpiler.
+        params = self.get_params()
+        booster = self.booster
+        if params.get("predictor", None) is None and (
+            booster is None or booster == "gbtree"
+        ):
+            return True
+        return False
+
+    def _get_iteration_range(
+        self, iteration_range: Optional[Tuple[int, int]]
+    ) -> Tuple[int, int]:
+        if (iteration_range is None or iteration_range[1] == 0):
+            # Use best_iteration if defined.
+            try:
+                iteration_range = (0, self.best_iteration + 1)
+            except AttributeError:
+                iteration_range = (0, 0)
+        if self.booster == "gblinear":
+            iteration_range = (0, 0)
+        return iteration_range
+
     def predict(
         self,
         X,
         output_margin=False,
         ntree_limit=None,
         validate_features=True,
-        base_margin=None
+        base_margin=None,
+        iteration_range=None,
     ):
         """
         Predict with `X`.
 
-        .. note:: This function is not thread safe.
-
-          For each booster object, predict can only be called from one thread.
-          If you want to run prediction using multiple thread, call ``xgb.copy()`` to make copies
-          of model object and then call ``predict()``.
-
-          .. code-block:: python
-
-            preds = bst.predict(dtest, ntree_limit=num_round)
+        .. note:: This function is only thread safe for `gbtree`
 
         Parameters
         ----------
@@ -775,37 +795,40 @@ class XGBModel(XGBModelBase):
         output_margin : bool
             Whether to output the raw untransformed margin value.
         ntree_limit : int
-            Limit number of trees in the prediction; defaults to best_ntree_limit if
-            defined (i.e. it has been trained with early stopping), otherwise 0 (use all
-            trees).
+            Deprecated, use `iteration_range` instead.
         validate_features : bool
-            When this is True, validate that the Booster's and data's feature_names are identical.
-            Otherwise, it is assumed that the feature_names are the same.
+            When this is True, validate that the Booster's and data's feature_names are
+            identical.  Otherwise, it is assumed that the feature_names are the same.
         base_margin : array_like
             Margin added to prediction.
+        iteration_range :
+            Specifies which layer of trees are used in prediction.  For example, if a
+            random forest is trained with 100 rounds.  Specifying `iteration_range=(10,
+            20)`, then only the forests built during [10, 20) (half open set) rounds are
+            used in this prediction.
 
+            .. versionadded:: 1.4.0
         Returns
         -------
         prediction : numpy array
         """
-        # pylint: disable=missing-docstring,invalid-name
-        test_dmatrix = DMatrix(X, base_margin=base_margin,
-                               missing=self.missing, nthread=self.n_jobs)
-        # get ntree_limit to use - if none specified, default to
-        # best_ntree_limit if defined, otherwise 0.
-        if ntree_limit is None:
-            try:
-                ntree_limit = self.best_ntree_limit
-            except AttributeError:
-                ntree_limit = 0
+        iteration_range = _convert_ntree_limit(
+            self.get_booster(), ntree_limit, iteration_range
+        )
+        iteration_range = self._get_iteration_range(iteration_range)
+        test = DMatrix(
+            X, base_margin=base_margin, missing=self.missing, nthread=self.n_jobs
+        )
         return self.get_booster().predict(
-            test_dmatrix,
+            data=test,
+            iteration_range=iteration_range,
             output_margin=output_margin,
-            ntree_limit=ntree_limit,
-            validate_features=validate_features
+            validate_features=validate_features,
         )
 
-    def apply(self, X, ntree_limit=0):
+    def apply(
+        self, X, ntree_limit: int = 0, iteration_range: Optional[Tuple[int, int]] = None
+    ) -> np.ndarray:
         """Return the predicted leaf every tree for each sample.
 
         Parameters
@@ -823,10 +846,16 @@ class XGBModel(XGBModelBase):
             leaf x ends up in. Leaves are numbered within
             ``[0; 2**(self.max_depth+1))``, possibly with gaps in the numbering.
         """
+        iteration_range = _convert_ntree_limit(
+            self.get_booster(), ntree_limit, iteration_range
+        )
+        iteration_range = self._get_iteration_range(iteration_range)
         test_dmatrix = DMatrix(X, missing=self.missing, nthread=self.n_jobs)
-        return self.get_booster().predict(test_dmatrix,
-                                          pred_leaf=True,
-                                          ntree_limit=ntree_limit)
+        return self.get_booster().predict(
+            test_dmatrix,
+            pred_leaf=True,
+            iteration_range=iteration_range
+        )
 
     def evals_result(self):
         """Return the evaluation results.
@@ -945,8 +974,7 @@ class XGBModel(XGBModelBase):
                 'Coefficients are not defined for Booster type {}'
                 .format(self.booster))
         b = self.get_booster()
-        coef = np.array(json.loads(
-            b.get_dump(dump_format='json')[0])['weight'])
+        coef = np.array(json.loads(b.get_dump(dump_format='json')[0])['weight'])
         # Logic for multiclass classification
         n_classes = getattr(self, 'n_classes_', None)
         if n_classes is not None:
@@ -1157,14 +1185,16 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         output_margin=False,
         ntree_limit=None,
         validate_features=True,
-        base_margin=None
+        base_margin=None,
+        iteration_range: Optional[Tuple[int, int]] = None,
     ):
         class_probs = super().predict(
             X=X,
             output_margin=output_margin,
             ntree_limit=ntree_limit,
             validate_features=validate_features,
-            base_margin=base_margin
+            base_margin=base_margin,
+            iteration_range=iteration_range,
         )
         if output_margin:
             # If output_margin is active, simply return the scores
@@ -1180,29 +1210,34 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             return self._le.inverse_transform(column_indexes)
         return column_indexes
 
-    def predict_proba(self, X, ntree_limit=None, validate_features=False,
-                      base_margin=None):
+    def predict_proba(
+        self,
+        X,
+        ntree_limit=None,
+        validate_features=False,
+        base_margin=None,
+        iteration_range: Optional[Tuple[int, int]] = None,
+    ) -> np.ndarray:
         """ Predict the probability of each `X` example being of a given class.
 
-        .. note:: This function is not thread safe
-
-            For each booster object, predict can only be called from one
-            thread.  If you want to run prediction using multiple thread, call
-            ``xgb.copy()`` to make copies of model object and then call predict
+        .. note:: This function is only thread safe for `gbtree`
 
         Parameters
         ----------
         X : array_like
             Feature matrix.
         ntree_limit : int
-            Limit number of trees in the prediction; defaults to best_ntree_limit if
-            defined (i.e. it has been trained with early stopping), otherwise 0 (use all
-            trees).
+            Deprecated, use `iteration_range` instead.
         validate_features : bool
             When this is True, validate that the Booster's and data's feature_names are
             identical.  Otherwise, it is assumed that the feature_names are the same.
         base_margin : array_like
             Margin added to prediction.
+        iteration_range :
+            Specifies which layer of trees are used in prediction.  For example, if a
+            random forest is trained with 100 rounds.  Specifying `iteration_range=(10,
+            20)`, then only the forests built during [10, 20) (half open set) rounds are
+            used in this prediction.
 
         Returns
         -------
@@ -1215,7 +1250,8 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
             output_margin=False,
             ntree_limit=ntree_limit,
             validate_features=validate_features,
-            base_margin=base_margin
+            base_margin=base_margin,
+            iteration_range=iteration_range
         )
         return _cls_predict_proba(self.objective, class_probs, np.vstack)
 

--- a/src/c_api/c_api.cu
+++ b/src/c_api/c_api.cu
@@ -66,8 +66,7 @@ int InplacePreidctCuda(BoosterHandle handle, char const *c_json_strs,
   API_END();
 }
 
-// A hidden API as cache id is not being supported yet.
-XGB_DLL int XGBoosterPredictFromArrayInterfaceColumns(
+XGB_DLL int XGBoosterPredictFromCudaColumnar(
     BoosterHandle handle, char const *c_json_strs, char const *c_json_config,
     DMatrixHandle m, xgboost::bst_ulong const **out_shape,
     xgboost::bst_ulong *out_dim, const float **out_result) {
@@ -79,8 +78,7 @@ XGB_DLL int XGBoosterPredictFromArrayInterfaceColumns(
       handle, c_json_strs, c_json_config, p_m, out_shape, out_dim, out_result);
 }
 
-// A hidden API as cache id is not being supported yet.
-XGB_DLL int XGBoosterPredictFromArrayInterface(
+XGB_DLL int XGBoosterPredictFromCudaArray(
     BoosterHandle handle, char const *c_json_strs, char const *c_json_config,
     DMatrixHandle m, xgboost::bst_ulong const **out_shape,
     xgboost::bst_ulong *out_dim, const float **out_result) {

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -22,6 +22,7 @@
 
 #include "dmlc/any.h"
 #include "xgboost/base.h"
+#include "xgboost/c_api.h"
 #include "xgboost/data.h"
 #include "xgboost/model.h"
 #include "xgboost/predictor.h"
@@ -996,7 +997,7 @@ class LearnerImpl : public LearnerIO {
     auto& predt = local_cache->Cache(train, generic_parameters_.gpu_id);
 
     monitor_.Start("PredictRaw");
-    this->PredictRaw(train.get(), &predt, true);
+    this->PredictRaw(train.get(), &predt, true, 0, 0);
     TrainingObserver::Instance().Observe(predt.predictions, "Predictions");
     monitor_.Stop("PredictRaw");
 
@@ -1057,7 +1058,7 @@ class LearnerImpl : public LearnerIO {
       std::shared_ptr<DMatrix> m = data_sets[i];
       auto &predt = local_cache->Cache(m, generic_parameters_.gpu_id);
       this->ValidateDMatrix(m.get(), false);
-      this->PredictRaw(m.get(), &predt, false);
+      this->PredictRaw(m.get(), &predt, false, 0, 0);
 
       auto &out = output_predictions_.Cache(m, generic_parameters_.gpu_id).predictions;
       out.Resize(predt.predictions.Size());
@@ -1075,8 +1076,8 @@ class LearnerImpl : public LearnerIO {
   }
 
   void Predict(std::shared_ptr<DMatrix> data, bool output_margin,
-               HostDeviceVector<bst_float>* out_preds, unsigned ntree_limit,
-               bool training,
+               HostDeviceVector<bst_float> *out_preds, unsigned layer_begin,
+               unsigned layer_end, bool training,
                bool pred_leaf, bool pred_contribs, bool approx_contribs,
                bool pred_interactions) override {
     int multiple_predictions = static_cast<int>(pred_leaf) +
@@ -1085,16 +1086,16 @@ class LearnerImpl : public LearnerIO {
     this->Configure();
     CHECK_LE(multiple_predictions, 1) << "Perform one kind of prediction at a time.";
     if (pred_contribs) {
-      gbm_->PredictContribution(data.get(), out_preds, ntree_limit, approx_contribs);
+      gbm_->PredictContribution(data.get(), out_preds, layer_begin, layer_end, approx_contribs);
     } else if (pred_interactions) {
-      gbm_->PredictInteractionContributions(data.get(), out_preds, ntree_limit,
+      gbm_->PredictInteractionContributions(data.get(), out_preds, layer_begin, layer_end,
                                             approx_contribs);
     } else if (pred_leaf) {
-      gbm_->PredictLeaf(data.get(), out_preds, ntree_limit);
+      gbm_->PredictLeaf(data.get(), out_preds, layer_begin, layer_end);
     } else {
       auto local_cache = this->GetPredictionCache();
       auto& prediction = local_cache->Cache(data, generic_parameters_.gpu_id);
-      this->PredictRaw(data.get(), &prediction, training, ntree_limit);
+      this->PredictRaw(data.get(), &prediction, training, layer_begin, layer_end);
       // Copy the prediction cache to output prediction. out_preds comes from C API
       out_preds->SetDevice(generic_parameters_.gpu_id);
       out_preds->Resize(prediction.predictions.Size());
@@ -1151,12 +1152,11 @@ class LearnerImpl : public LearnerIO {
    *   predictor, when it equals 0, this means we are using all the trees
    * \param training allow dropout when the DART booster is being used
    */
-  void PredictRaw(DMatrix* data, PredictionCacheEntry* out_preds,
-                  bool training,
-                  unsigned ntree_limit = 0) const {
+  void PredictRaw(DMatrix *data, PredictionCacheEntry *out_preds, bool training,
+                  unsigned layer_begin, unsigned layer_end) const {
     CHECK(gbm_ != nullptr) << "Predict must happen after Load or configuration";
     this->ValidateDMatrix(data, false);
-    gbm_->PredictBatch(data, out_preds, training, ntree_limit);
+    gbm_->PredictBatch(data, out_preds, training, layer_begin, layer_end);
   }
 
   void ValidateDMatrix(DMatrix* p_fmat, bool is_training) const {

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -251,6 +251,9 @@ class CPUPredictor : public Predictor {
       // built at the 0^th iterator.
       this->InitOutPredictions(dmat->Info(), out_preds, model);
     }
+    if (tree_end - tree_begin == 0) {
+      return;
+    }
     this->PredictDMatrix(dmat, &out_preds->HostVector(), model, tree_begin,
                          tree_end);
   }

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -536,6 +536,7 @@ class GPUPredictor : public xgboost::Predictor {
     const uint32_t BLOCK_THREADS = 256;
     size_t num_rows = batch.n_rows;
     auto GRID_SIZE = static_cast<uint32_t>(common::DivRoundUp(num_rows, BLOCK_THREADS));
+    DeviceModel d_model;
 
     bool use_shared = false;
     size_t entry_start = 0;
@@ -593,54 +594,24 @@ class GPUPredictor : public xgboost::Predictor {
   }
 
   void PredictBatch(DMatrix* dmat, PredictionCacheEntry* predts,
-                    const gbm::GBTreeModel& model, int tree_begin,
-                    unsigned ntree_limit = 0) const override {
-    // This function is duplicated with CPU predictor PredictBatch, see comments in there.
-    // FIXME(trivialfis): Remove the duplication.
+                    const gbm::GBTreeModel& model, uint32_t tree_begin,
+                    uint32_t tree_end = 0) const override {
     int device = generic_param_->gpu_id;
     CHECK_GE(device, 0) << "Set `gpu_id' to positive value for processing GPU data.";
-    ConfigureDevice(device);
-
-    CHECK_EQ(tree_begin, 0);
     auto* out_preds = &predts->predictions;
-    CHECK_GE(predts->version, tree_begin);
+
     if (out_preds->Size() == 0 && dmat->Info().num_row_ != 0) {
       CHECK_EQ(predts->version, 0);
     }
+    if (tree_end == 0) {
+      tree_end = model.trees.size();
+    }
     if (predts->version == 0) {
+      // out_preds->Size() can be non-zero as it's initialized here before any tree is
+      // built at the 0^th iterator.
       this->InitOutPredictions(dmat->Info(), out_preds, model);
     }
-
-    uint32_t const output_groups =  model.learner_model_param->num_output_group;
-    CHECK_NE(output_groups, 0);
-
-    uint32_t real_ntree_limit = ntree_limit * output_groups;
-    if (real_ntree_limit == 0 || real_ntree_limit > model.trees.size()) {
-      real_ntree_limit = static_cast<uint32_t>(model.trees.size());
-    }
-
-    uint32_t const end_version = (tree_begin + real_ntree_limit) / output_groups;
-
-    if (predts->version > end_version) {
-      CHECK_NE(ntree_limit, 0);
-      this->InitOutPredictions(dmat->Info(), out_preds, model);
-      predts->version = 0;
-    }
-    uint32_t const beg_version = predts->version;
-    CHECK_LE(beg_version, end_version);
-
-    if (beg_version < end_version) {
-      this->DevicePredictInternal(dmat, out_preds, model,
-                                  beg_version * output_groups,
-                                  end_version * output_groups);
-    }
-
-    uint32_t delta = end_version - beg_version;
-    CHECK_LE(delta, model.trees.size());
-    predts->Update(delta);
-
-    CHECK(out_preds->Size() == output_groups * dmat->Info().num_row_ ||
-          out_preds->Size() == dmat->Info().num_row_);
+    this->DevicePredictInternal(dmat, out_preds, model, tree_begin, tree_end);
   }
 
   template <typename Adapter, typename Loader>
@@ -648,15 +619,12 @@ class GPUPredictor : public xgboost::Predictor {
                                 const gbm::GBTreeModel &model, float,
                                 PredictionCacheEntry *out_preds,
                                 uint32_t tree_begin, uint32_t tree_end) const {
-    auto max_shared_memory_bytes = dh::MaxSharedMemory(this->generic_param_->gpu_id);
     uint32_t const output_groups =  model.learner_model_param->num_output_group;
-    DeviceModel d_model;
-    d_model.Init(model, tree_begin, tree_end, this->generic_param_->gpu_id);
 
     auto m = dmlc::get<std::shared_ptr<Adapter>>(x);
     CHECK_EQ(m->NumColumns(), model.learner_model_param->num_feature)
         << "Number of columns in data must equal to trained model.";
-    CHECK_EQ(this->generic_param_->gpu_id, m->DeviceIdx())
+    CHECK_EQ(dh::CurrentDevice(), m->DeviceIdx())
         << "XGBoost is running on device: " << this->generic_param_->gpu_id << ", "
         << "but data is on: " << m->DeviceIdx();
     if (p_m) {
@@ -667,12 +635,17 @@ class GPUPredictor : public xgboost::Predictor {
       info.num_row_ = m->NumRows();
       this->InitOutPredictions(info, &(out_preds->predictions), model);
     }
+    out_preds->predictions.SetDevice(m->DeviceIdx());
 
     const uint32_t BLOCK_THREADS = 128;
     auto GRID_SIZE = static_cast<uint32_t>(common::DivRoundUp(m->NumRows(), BLOCK_THREADS));
 
+    auto max_shared_memory_bytes = dh::MaxSharedMemory(m->DeviceIdx());
     size_t shared_memory_bytes =
         SharedMemoryBytes<BLOCK_THREADS>(m->NumColumns(), max_shared_memory_bytes);
+    DeviceModel d_model;
+    d_model.Init(model, tree_begin, tree_end, m->DeviceIdx());
+
     bool use_shared = shared_memory_bytes != 0;
     size_t entry_start = 0;
 
@@ -707,20 +680,17 @@ class GPUPredictor : public xgboost::Predictor {
 
   void PredictContribution(DMatrix* p_fmat,
                            HostDeviceVector<bst_float>* out_contribs,
-                           const gbm::GBTreeModel& model, unsigned ntree_limit,
+                           const gbm::GBTreeModel& model, unsigned tree_end,
                            std::vector<bst_float>*,
                            bool approximate, int,
                            unsigned) const override {
     if (approximate) {
       LOG(FATAL) << "Approximated contribution is not implemented in GPU Predictor.";
     }
-
     dh::safe_cuda(cudaSetDevice(generic_param_->gpu_id));
     out_contribs->SetDevice(generic_param_->gpu_id);
-    uint32_t real_ntree_limit =
-        ntree_limit * model.learner_model_param->num_output_group;
-    if (real_ntree_limit == 0 || real_ntree_limit > model.trees.size()) {
-      real_ntree_limit = static_cast<uint32_t>(model.trees.size());
+    if (tree_end == 0 || tree_end > model.trees.size()) {
+      tree_end = static_cast<uint32_t>(model.trees.size());
     }
 
     const int ngroup = model.learner_model_param->num_output_group;
@@ -734,8 +704,7 @@ class GPUPredictor : public xgboost::Predictor {
     auto phis = out_contribs->DeviceSpan();
 
     dh::device_vector<gpu_treeshap::PathElement> device_paths;
-    ExtractPaths(&device_paths, model, real_ntree_limit,
-                 generic_param_->gpu_id);
+    ExtractPaths(&device_paths, model, tree_end, generic_param_->gpu_id);
     for (auto& batch : p_fmat->GetBatches<SparsePage>()) {
       batch.data.SetDevice(generic_param_->gpu_id);
       batch.offset.SetDevice(generic_param_->gpu_id);
@@ -761,20 +730,17 @@ class GPUPredictor : public xgboost::Predictor {
   void PredictInteractionContributions(DMatrix* p_fmat,
                                        HostDeviceVector<bst_float>* out_contribs,
                                        const gbm::GBTreeModel& model,
-                                       unsigned ntree_limit,
+                                       unsigned tree_end,
                                        std::vector<bst_float>*,
                                        bool approximate) const override {
     if (approximate) {
       LOG(FATAL) << "[Internal error]: " << __func__
                  << " approximate is not implemented in GPU Predictor.";
     }
-
     dh::safe_cuda(cudaSetDevice(generic_param_->gpu_id));
     out_contribs->SetDevice(generic_param_->gpu_id);
-    uint32_t real_ntree_limit =
-        ntree_limit * model.learner_model_param->num_output_group;
-    if (real_ntree_limit == 0 || real_ntree_limit > model.trees.size()) {
-      real_ntree_limit = static_cast<uint32_t>(model.trees.size());
+    if (tree_end == 0 || tree_end > model.trees.size()) {
+      tree_end = static_cast<uint32_t>(model.trees.size());
     }
 
     const int ngroup = model.learner_model_param->num_output_group;
@@ -789,8 +755,7 @@ class GPUPredictor : public xgboost::Predictor {
     auto phis = out_contribs->DeviceSpan();
 
     dh::device_vector<gpu_treeshap::PathElement> device_paths;
-    ExtractPaths(&device_paths, model, real_ntree_limit,
-                 generic_param_->gpu_id);
+    ExtractPaths(&device_paths, model, tree_end, generic_param_->gpu_id);
     for (auto& batch : p_fmat->GetBatches<SparsePage>()) {
       batch.data.SetDevice(generic_param_->gpu_id);
       batch.offset.SetDevice(generic_param_->gpu_id);
@@ -841,29 +806,28 @@ class GPUPredictor : public xgboost::Predictor {
                << " is not implemented in GPU Predictor.";
   }
 
-  void PredictLeaf(DMatrix* p_fmat, HostDeviceVector<bst_float>* predictions,
-                   const gbm::GBTreeModel& model,
-                   unsigned ntree_limit) const override {
+  void PredictLeaf(DMatrix *p_fmat, HostDeviceVector<bst_float> *predictions,
+                   const gbm::GBTreeModel &model,
+                   unsigned tree_end) const override {
     dh::safe_cuda(cudaSetDevice(generic_param_->gpu_id));
     auto max_shared_memory_bytes = ConfigureDevice(generic_param_->gpu_id);
 
     const MetaInfo& info = p_fmat->Info();
     constexpr uint32_t kBlockThreads = 128;
-    size_t shared_memory_bytes =
-        SharedMemoryBytes<kBlockThreads>(info.num_col_, max_shared_memory_bytes);
+    size_t shared_memory_bytes = SharedMemoryBytes<kBlockThreads>(
+        info.num_col_, max_shared_memory_bytes);
     bool use_shared = shared_memory_bytes != 0;
     bst_feature_t num_features = info.num_col_;
     bst_row_t num_rows = info.num_row_;
     size_t entry_start = 0;
 
-    uint32_t real_ntree_limit = ntree_limit * model.learner_model_param->num_output_group;
-    if (real_ntree_limit == 0 || real_ntree_limit > model.trees.size()) {
-      real_ntree_limit = static_cast<uint32_t>(model.trees.size());
+    if (tree_end == 0 || tree_end > model.trees.size()) {
+      tree_end = static_cast<uint32_t>(model.trees.size());
     }
     predictions->SetDevice(generic_param_->gpu_id);
-    predictions->Resize(num_rows * real_ntree_limit);
+    predictions->Resize(num_rows * tree_end);
     DeviceModel d_model;
-    d_model.Init(model, 0, real_ntree_limit, this->generic_param_->gpu_id);
+    d_model.Init(model, 0, tree_end, this->generic_param_->gpu_id);
 
     if (p_fmat->PageExists<SparsePage>()) {
       for (auto const& batch : p_fmat->GetBatches<SparsePage>()) {

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -611,6 +611,9 @@ class GPUPredictor : public xgboost::Predictor {
       // built at the 0^th iterator.
       this->InitOutPredictions(dmat->Info(), out_preds, model);
     }
+    if (tree_end - tree_begin == 0) {
+      return;
+    }
     this->DevicePredictInternal(dmat, out_preds, model, tree_begin, tree_end);
   }
 

--- a/tests/ci_build/conda_env/cpu_test.yml
+++ b/tests/ci_build/conda_env/cpu_test.yml
@@ -34,6 +34,7 @@ dependencies:
 - llvmlite
 - pip:
   - shap
+  - ipython                     # required by shap at import time.
   - guzzle_sphinx_theme
   - datatable
   - modin[all]

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -32,7 +32,7 @@ TEST(CpuPredictor, Basic) {
   // Test predict batch
   PredictionCacheEntry out_predictions;
   cpu_predictor->PredictBatch(dmat.get(), &out_predictions, model, 0);
-  ASSERT_EQ(model.trees.size(), out_predictions.version);
+
   std::vector<float>& out_predictions_h = out_predictions.predictions.HostVector();
   for (size_t i = 0; i < out_predictions.predictions.Size(); i++) {
     ASSERT_EQ(out_predictions_h[i], 1.5);
@@ -215,7 +215,7 @@ TEST(CpuPredictor, UpdatePredictionCache) {
 
   PredictionCacheEntry out_predictions;
   // perform fair prediction on the same input data, should be equal to cached result
-  gbm->PredictBatch(dmat.get(), &out_predictions, false, 0);
+  gbm->PredictBatch(dmat.get(), &out_predictions, false, 0, 0);
 
   std::vector<float> &out_predictions_h = out_predictions.predictions.HostVector();
   std::vector<float> &predtion_cache_from_train = predtion_cache.predictions.HostVector();

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -45,7 +45,6 @@ TEST(GPUPredictor, Basic) {
     PredictionCacheEntry cpu_out_predictions;
 
     gpu_predictor->PredictBatch(dmat.get(), &gpu_out_predictions, model, 0);
-    ASSERT_EQ(model.trees.size(), gpu_out_predictions.version);
     cpu_predictor->PredictBatch(dmat.get(), &cpu_out_predictions, model, 0);
 
     std::vector<float>& gpu_out_predictions_h = gpu_out_predictions.predictions.HostVector();

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -64,10 +64,10 @@ void TestTrainingPrediction(size_t rows, size_t bins,
     }
 
     HostDeviceVector<float> from_full;
-    learner->Predict(p_full, false, &from_full);
+    learner->Predict(p_full, false, &from_full, 0, 0);
 
     HostDeviceVector<float> from_hist;
-    learner->Predict(p_hist, false, &from_hist);
+    learner->Predict(p_hist, false, &from_hist, 0, 0);
 
     for (size_t i = 0; i < rows; ++i) {
       EXPECT_NEAR(from_hist.ConstHostVector()[i],
@@ -157,20 +157,20 @@ void TestPredictionWithLesserFeatures(std::string predictor_name) {
   learner->SaveConfig(&config);
   ASSERT_EQ(get<String>(config["learner"]["gradient_booster"]["gbtree_train_param"]["predictor"]), predictor_name);
 
-  learner->Predict(m_test, false, &prediction);
+  learner->Predict(m_test, false, &prediction, 0, 0);
   ASSERT_EQ(prediction.Size(), kRows);
 
   auto m_invalid = RandomDataGenerator(kRows, kTrainCols + 1, 0.5).GenerateDMatrix(false);
-  ASSERT_THROW({learner->Predict(m_invalid, false, &prediction);}, dmlc::Error);
+  ASSERT_THROW({learner->Predict(m_invalid, false, &prediction, 0, 0);}, dmlc::Error);
 
 #if defined(XGBOOST_USE_CUDA)
   HostDeviceVector<float> from_cpu;
   learner->SetParam("predictor", "cpu_predictor");
-  learner->Predict(m_test, false, &from_cpu);
+  learner->Predict(m_test, false, &from_cpu, 0, 0);
 
   HostDeviceVector<float> from_cuda;
   learner->SetParam("predictor", "gpu_predictor");
-  learner->Predict(m_test, false, &from_cuda);
+  learner->Predict(m_test, false, &from_cuda, 0, 0);
 
   auto const& h_cpu = from_cpu.ConstHostVector();
   auto const& h_gpu = from_cuda.ConstHostVector();

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -221,9 +221,10 @@ TEST(Learner, MultiThreadedPredict) {
       auto &entry = learner->GetThreadLocal().prediction_entry;
       HostDeviceVector<float> predictions;
       for (size_t iter = 0; iter < kIters; ++iter) {
-        learner->Predict(p_data, false, &entry.predictions);
-        learner->Predict(p_data, false, &predictions, 0, true);  // leaf
-        learner->Predict(p_data, false, &predictions, 0, false, true);  // contribs
+        learner->Predict(p_data, false, &entry.predictions, 0, 0);
+
+        learner->Predict(p_data, false, &predictions, 0, 0, false, true);  // leaf
+        learner->Predict(p_data, false, &predictions, 0, 0, false, false, true);  // contribs
       }
     });
   }

--- a/tests/python-gpu/test_from_cupy.py
+++ b/tests/python-gpu/test_from_cupy.py
@@ -112,17 +112,24 @@ def _test_cupy_metainfo(DMatrixT):
 @pytest.mark.skipif(**tm.no_sklearn())
 def test_cupy_training_with_sklearn():
     import cupy as cp
+
     np.random.seed(1)
     cp.random.seed(1)
-    X = cp.random.randn(50, 10, dtype='float32')
-    y = (cp.random.randn(50, dtype='float32') > 0).astype('int8')
+    X = cp.random.randn(50, 10, dtype="float32")
+    y = (cp.random.randn(50, dtype="float32") > 0).astype("int8")
     weights = np.random.random(50) + 1
     cupy_weights = cp.array(weights)
     base_margin = np.random.random(50)
     cupy_base_margin = cp.array(base_margin)
 
-    clf = xgb.XGBClassifier(gpu_id=0, tree_method='gpu_hist', use_label_encoder=False)
-    clf.fit(X, y, sample_weight=cupy_weights, base_margin=cupy_base_margin, eval_set=[(X, y)])
+    clf = xgb.XGBClassifier(gpu_id=0, tree_method="gpu_hist", use_label_encoder=False)
+    clf.fit(
+        X,
+        y,
+        sample_weight=cupy_weights,
+        base_margin=cupy_base_margin,
+        eval_set=[(X, y)],
+    )
     pred = clf.predict(X)
     assert np.array_equal(np.unique(pred), np.array([0, 1]))
 

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -434,7 +434,13 @@ class TestModels:
             booster[...:end] = booster
 
         sliced_0 = booster[1:3]
+        np.testing.assert_allclose(
+            booster.predict(dtrain, iteration_range=(1, 3)), sliced_0.predict(dtrain)
+        )
         sliced_1 = booster[3:7]
+        np.testing.assert_allclose(
+            booster.predict(dtrain, iteration_range=(3, 7)), sliced_1.predict(dtrain)
+        )
 
         predt_0 = sliced_0.predict(dtrain, output_margin=True)
         predt_1 = sliced_1.predict(dtrain, output_margin=True)

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -951,9 +951,9 @@ class TestWithDask:
                 train = xgb.dask.DaskDMatrix(client, dX, dy)
 
                 dX = dd.from_array(X)
-                dX = client.persist(dX, workers={dX: workers[1]})
+                dX = client.persist(dX, workers=workers[1])
                 dy = dd.from_array(y)
-                dy = client.persist(dy, workers={dy: workers[1]})
+                dy = client.persist(dy, workers=workers[1])
                 valid = xgb.dask.DaskDMatrix(client, dX, dy)
 
                 merged = xgb.dask._get_workers_from_data(train, evals=[(valid, 'Valid')])

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -159,12 +159,9 @@ def test_dask_predict_shape_infer(client: "Client") -> None:
     assert prediction.shape[1] == 3
 
 
-@pytest.mark.parametrize("tree_method", ["hist", "approx"])
-def test_boost_from_prediction(tree_method: str, client: "Client") -> None:
-    from sklearn.datasets import load_breast_cancer
-    X_, y_ = load_breast_cancer(return_X_y=True)
-
-    X, y = dd.from_array(X_, chunksize=100), dd.from_array(y_, chunksize=100)
+def run_boost_from_prediction(
+    X: xgb.dask._DaskCollection, y: xgb.dask._DaskCollection, tree_method: str, client: "Client"
+) -> None:
     model_0 = xgb.dask.DaskXGBClassifier(
         learning_rate=0.3, random_state=0, n_estimators=4,
         tree_method=tree_method)
@@ -200,6 +197,30 @@ def test_boost_from_prediction(tree_method: str, client: "Client") -> None:
     for i in range(len(margined_res)):
         # margined is correct one, so smaller error.
         assert margined_res[i] < unmargined_res[i]
+
+
+@pytest.mark.parametrize("tree_method", ["hist", "approx"])
+def test_boost_from_prediction(tree_method: str, client: "Client") -> None:
+    from sklearn.datasets import load_breast_cancer
+    X_, y_ = load_breast_cancer(return_X_y=True)
+    X, y = dd.from_array(X_, chunksize=100), dd.from_array(y_, chunksize=100)
+    run_boost_from_prediction(X, y, tree_method, client)
+
+
+def test_inplace_predict(client: "Client") -> None:
+    from sklearn.datasets import load_boston
+    X_, y_ = load_boston(return_X_y=True)
+    X, y = dd.from_array(X_, chunksize=32), dd.from_array(y_, chunksize=32)
+    reg = xgb.dask.DaskXGBRegressor(n_estimators=4).fit(X, y)
+    booster = reg.get_booster()
+    base_margin = y
+
+    inplace = xgb.dask.inplace_predict(
+        client, booster, X, base_margin=base_margin
+    ).compute()
+    Xy = xgb.dask.DaskDMatrix(client, X, base_margin=base_margin)
+    copied = xgb.dask.predict(client, booster, Xy).compute()
+    np.testing.assert_allclose(inplace, copied)
 
 
 def test_dask_missing_value_reg(client: "Client") -> None:
@@ -288,10 +309,13 @@ def test_dask_regressor(model: str, client: "Client") -> None:
         assert forest == 2
 
 
-@pytest.mark.parametrize("model", ["boosting", "rf"])
-def test_dask_classifier(model: str, client: "Client") -> None:
-    X, y, w = generate_array(with_weights=True)
-    y = (y * 10).astype(np.int32)
+def run_dask_classifier(
+    X: xgb.dask._DaskCollection,
+    y: xgb.dask._DaskCollection,
+    w: xgb.dask._DaskCollection,
+    model: str,
+    client: "Client",
+) -> None:
     if model == "boosting":
         classifier = xgb.dask.DaskXGBClassifier(
             verbosity=1, n_estimators=2, eval_metric="merror"
@@ -306,14 +330,13 @@ def test_dask_classifier(model: str, client: "Client") -> None:
 
     classifier.client = client
     classifier.fit(X, y, sample_weight=w, eval_set=[(X, y)])
-    prediction = classifier.predict(X)
+    prediction = classifier.predict(X).compute()
 
     assert prediction.ndim == 1
     assert prediction.shape[0] == kRows
 
     history = classifier.evals_result()
 
-    assert isinstance(prediction, da.Array)
     assert isinstance(history, dict)
 
     assert list(history.keys())[0] == "validation_0"
@@ -332,7 +355,7 @@ def test_dask_classifier(model: str, client: "Client") -> None:
         assert forest == 2
 
     # Test .predict_proba()
-    probas = classifier.predict_proba(X)
+    probas = classifier.predict_proba(X).compute()
     assert classifier.n_classes_ == 10
     assert probas.ndim == 2
     assert probas.shape[0] == kRows
@@ -341,18 +364,33 @@ def test_dask_classifier(model: str, client: "Client") -> None:
     cls_booster = classifier.get_booster()
     single_node_proba = cls_booster.inplace_predict(X.compute())
 
-    np.testing.assert_allclose(single_node_proba, probas.compute())
+    # test shared by CPU and GPU
+    if isinstance(single_node_proba, np.ndarray):
+        np.testing.assert_allclose(single_node_proba, probas)
+    else:
+        import cupy
+        cupy.testing.assert_allclose(single_node_proba, probas)
 
-    # Test with dataframe.
-    X_d = dd.from_dask_array(X)
-    y_d = dd.from_dask_array(y)
-    classifier.fit(X_d, y_d)
+    # Test with dataframe, not shared with GPU as cupy doesn't work well with da.unique.
+    if isinstance(X, da.Array):
+        X_d: dd.DataFrame = X.to_dask_dataframe()
 
-    assert classifier.n_classes_ == 10
-    prediction = classifier.predict(X_d).compute()
+        assert classifier.n_classes_ == 10
+        prediction_df = classifier.predict(X_d).compute()
 
-    assert prediction.ndim == 1
-    assert prediction.shape[0] == kRows
+        assert prediction_df.ndim == 1
+        assert prediction_df.shape[0] == kRows
+        np.testing.assert_allclose(prediction_df, prediction)
+
+        probas = classifier.predict_proba(X).compute()
+        np.testing.assert_allclose(single_node_proba, probas)
+
+
+@pytest.mark.parametrize("model", ["boosting", "rf"])
+def test_dask_classifier(model: str, client: "Client") -> None:
+    X, y, w = generate_array(with_weights=True)
+    y = (y * 10).astype(np.int32)
+    run_dask_classifier(X, y, w, model, client)
 
 
 @pytest.mark.skipif(**tm.no_sklearn())
@@ -1059,6 +1097,16 @@ class TestWithDask:
         margin = xgb.dask.predict(client, booster, X, output_margin=True).compute()
         assert_shape(shap.shape)
         assert np.allclose(np.sum(shap, axis=len(shap.shape) - 1), margin, 1e-5, 1e-5)
+
+        X = dd.from_dask_array(X).repartition(npartitions=32)
+        y = dd.from_dask_array(y).repartition(npartitions=32)
+        shap_df = xgb.dask.predict(
+            client, booster, X, pred_contribs=True, validate_features=False
+        ).compute()
+        assert_shape(shap_df.shape)
+        assert np.allclose(
+            np.sum(shap_df, axis=len(shap_df.shape) - 1), margin, 1e-5, 1e-5
+        )
 
     def run_shap_cls_sklearn(self, X: Any, y: Any, client: "Client") -> None:
         X, y = da.from_array(X, chunks=(32, -1)), da.from_array(y, chunks=32)


### PR DESCRIPTION
This PR is about to wrap up https://github.com/dmlc/xgboost/pull/6638, only that `sklearn` is still using `DMatrix` for prediction by default instead of `inplace_predict`.

* Add a new API function for predicting on `DMatrix`.  This function aligns with rest of the `InplacePredictFrom*` functions on semantic of function arguments.
* Purge `ntree_limit` from libxgboost, use iteration instead.
* [dask] Use `inplace_predict` by default for dask sklearn models.
* [dask] Run prediction shape inference on worker instead of client.

The breaking change is in the Python sklearn `apply` function, I made it to be consistent with other prediction functions where `best_iteration` is used by default. Also, close https://github.com/dmlc/xgboost/issues/6553