### PR TITLE
Prediction by indices (subsample < 1)

### DIFF
--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -695,7 +695,8 @@ bool QuantileHistMaker::Builder<GradientSumT>::UpdatePredictionCache(
       // CHECK_EQ(model.param.size_leaf_vector, 0)
       //   << "size_leaf_vector is enforced to 0 so far";
 
-      common::ParallelFor(unused_rows_.size(), [&](bst_omp_uint block_id) {
+      const auto num_parallel_ops = static_cast<bst_omp_uint>(unused_rows_.size());
+      common::ParallelFor(num_parallel_ops, [&](bst_omp_uint block_id) {
         RegTree::FVec &feats = feat_vecs_[omp_get_thread_num()];
         const SparsePage::Inst inst = batch_view[unused_rows_[block_id]];
         feats.Fill(inst);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017-2020 by Contributors
+ * Copyright 2017-2021 by Contributors
  * \file updater_quantile_hist.cc
  * \brief use quantized feature values to construct a tree
  * \author Philip Cho, Tianqi Checn, Egor Smirnov
@@ -7,15 +7,15 @@
 #include <dmlc/timer.h>
 #include <rabit/rabit.h>
 
-#include <cmath>
-#include <memory>
-#include <vector>
 #include <algorithm>
-#include <queue>
+#include <cmath>
 #include <iomanip>
+#include <memory>
 #include <numeric>
+#include <queue>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "xgboost/logging.h"
 #include "xgboost/tree_updater.h"
@@ -111,32 +111,24 @@ void QuantileHistMaker::Update(HostDeviceVector<GradientPair> *gpair,
 
 bool QuantileHistMaker::UpdatePredictionCache(
     const DMatrix* data, HostDeviceVector<bst_float>* out_preds) {
-  if (param_.subsample < 1.0f) {
-    return false;
+  if (hist_maker_param_.single_precision_histogram && float_builder_) {
+      return float_builder_->UpdatePredictionCache(data, out_preds);
+  } else if (double_builder_) {
+      return double_builder_->UpdatePredictionCache(data, out_preds);
   } else {
-    if (hist_maker_param_.single_precision_histogram && float_builder_) {
-        return float_builder_->UpdatePredictionCache(data, out_preds);
-    } else if (double_builder_) {
-        return double_builder_->UpdatePredictionCache(data, out_preds);
-    } else {
-       return false;
-    }
+      return false;
   }
 }
 
 bool QuantileHistMaker::UpdatePredictionCacheMulticlass(
     const DMatrix* data,
     HostDeviceVector<bst_float>* out_preds, const int gid, const int ngroup) {
-  if (param_.subsample < 1.0f) {
-    return false;
+  if (hist_maker_param_.single_precision_histogram && float_builder_) {
+      return float_builder_->UpdatePredictionCache(data, out_preds, gid, ngroup);
+  } else if (double_builder_) {
+      return double_builder_->UpdatePredictionCache(data, out_preds, gid, ngroup);
   } else {
-    if (hist_maker_param_.single_precision_histogram && float_builder_) {
-        return float_builder_->UpdatePredictionCache(data, out_preds, gid, ngroup);
-    } else if (double_builder_) {
-        return double_builder_->UpdatePredictionCache(data, out_preds, gid, ngroup);
-    } else {
-       return false;
-    }
+      return false;
   }
 }
 
@@ -615,6 +607,7 @@ void QuantileHistMaker::Builder<GradientSumT>::Update(
   tree_evaluator_ =
       TreeEvaluator(param_, p_fmat->Info().num_col_, GenericParameter::kCpuId);
   interaction_constraints_.Reset();
+  p_last_fmat_mutable_ = p_fmat;
 
   this->InitData(gmat, gpair_h, *p_fmat, *p_tree);
   if (param_.grow_policy == TrainParam::kLossGuide) {
@@ -633,23 +626,33 @@ void QuantileHistMaker::Builder<GradientSumT>::Update(
   builder_monitor_.Stop("Update");
 }
 
+template <size_t kUnrollLen = 8>
+struct SparsePageView {
+  bst_row_t base_rowid;
+  HostSparsePageView view;
+  static size_t constexpr kUnroll = kUnrollLen;
+
+  explicit SparsePageView(SparsePage const *p)
+      : base_rowid{p->base_rowid} {
+    view = p->GetView();
+  }
+  SparsePage::Inst operator[](size_t i) { return view[i]; }
+  size_t Size() const { return view.Size(); }
+};
+
 template<typename GradientSumT>
 bool QuantileHistMaker::Builder<GradientSumT>::UpdatePredictionCache(
     const DMatrix* data,
     HostDeviceVector<bst_float>* p_out_preds, const int gid, const int ngroup) {
   // p_last_fmat_ is a valid pointer as long as UpdatePredictionCache() is called in
   // conjunction with Update().
-  if (!p_last_fmat_ || !p_last_tree_ || data != p_last_fmat_) {
+  if (!p_last_fmat_ || !p_last_tree_ || data != p_last_fmat_ ||
+      p_last_fmat_ != p_last_fmat_mutable_) {
     return false;
   }
   builder_monitor_.Start("UpdatePredictionCache");
 
   std::vector<bst_float>& out_preds = p_out_preds->HostVector();
-
-  if (leaf_value_cache_.empty()) {
-    leaf_value_cache_.resize(p_last_tree_->param.num_nodes,
-                             std::numeric_limits<float>::infinity());
-  }
 
   CHECK_GT(out_preds.size(), 0U);
 
@@ -680,30 +683,62 @@ bool QuantileHistMaker::Builder<GradientSumT>::UpdatePredictionCache(
     }
   });
 
+  if (param_.subsample < 1.0f) {
+    // Making real prediction for the remaining rows
+    size_t fvecs_size = feat_vecs_.size();
+    feat_vecs_.resize(omp_get_max_threads(), RegTree::FVec());
+    while (fvecs_size < feat_vecs_.size()) {
+      feat_vecs_[fvecs_size++].Init(data->Info().num_col_);
+    }
+    for (auto&& batch : p_last_fmat_mutable_->GetBatches<SparsePage>()) {
+      auto batch_view = SparsePageView<>{&batch};
+      // CHECK_EQ(model.param.size_leaf_vector, 0)
+      //   << "size_leaf_vector is enforced to 0 so far";
+
+      common::ParallelFor(unused_rows_.size(), [&](bst_omp_uint block_id) {
+        RegTree::FVec &feats = feat_vecs_[omp_get_thread_num()];
+        const SparsePage::Inst inst = batch_view[unused_rows_[block_id]];
+        feats.Fill(inst);
+
+        const size_t row_num = unused_rows_[block_id] + batch_view.base_rowid;
+        const int lid = feats.HasMissing() ? p_last_tree_->GetLeafIndex<true>(feats) :
+                                            p_last_tree_->GetLeafIndex<false>(feats);
+        out_preds[row_num * ngroup + gid] += (*p_last_tree_)[lid].LeafValue();
+
+        feats.Drop(inst);
+      });
+    }
+  }
   builder_monitor_.Stop("UpdatePredictionCache");
   return true;
 }
+
 template<typename GradientSumT>
 void QuantileHistMaker::Builder<GradientSumT>::InitSampling(const std::vector<GradientPair>& gpair,
                                                 const DMatrix& fmat,
                                                 std::vector<size_t>* row_indices) {
   const auto& info = fmat.Info();
   auto& rnd = common::GlobalRandom();
-  std::vector<size_t>& row_indices_local = *row_indices;
-  size_t* p_row_indices = row_indices_local.data();
+  unused_rows_.resize(info.num_row_);
+  size_t* p_row_indices_used = row_indices->data();
+  size_t* p_row_indices_unused = unused_rows_.data();
 #if XGBOOST_CUSTOMIZE_GLOBAL_PRNG
   std::bernoulli_distribution coin_flip(param_.subsample);
-  size_t j = 0;
+  size_t used = 0, unused = 0;
   for (size_t i = 0; i < info.num_row_; ++i) {
     if (gpair[i].GetHess() >= 0.0f && coin_flip(rnd)) {
-      p_row_indices[j++] = i;
+      p_row_indices_used[used++] = i;
+    } else {
+      p_row_indices_unused[unused++] = i;
     }
   }
   /* resize row_indices to reduce memory */
-  row_indices_local.resize(j);
+  row_indices->resize(used);
+  unused_rows_.resize(unused);
 #else
   const size_t nthread = this->nthread_;
-  std::vector<size_t> row_offsets(nthread, 0);
+  std::vector<size_t> row_offsets_used(nthread, 0);
+  std::vector<size_t> row_offsets_unused(nthread, 0);
   /* usage of mt19937_64 give 2x speed up for subsampling */
   std::vector<std::mt19937> rnds(nthread);
   /* create engine for each thread */
@@ -725,27 +760,51 @@ void QuantileHistMaker::Builder<GradientSumT>::InitSampling(const std::vector<Gr
       rnds[tid].discard(discard_size * tid);
       for (size_t i = ibegin; i < iend; ++i) {
         if (gpair[i].GetHess() >= 0.0f && rnds[tid]() < coin_flip_border) {
-          p_row_indices[ibegin + row_offsets[tid]++] = i;
+          p_row_indices_used[ibegin + row_offsets_used[tid]++] = i;
+        } else {
+          p_row_indices_unused[ibegin + row_offsets_unused[tid]++] = i;
         }
+      }
+
+      #pragma omp barrier
+
+      if (tid == 0ul) {
+        size_t prefix_sum_used = row_offsets_used[0];
+        for (size_t i = 1; i < nthread; ++i) {
+          const size_t ibegin = i * discard_size;
+
+          for (size_t k = 0; k < row_offsets_used[i]; ++k) {
+            p_row_indices_used[prefix_sum_used + k] = p_row_indices_used[ibegin + k];
+          }
+
+          prefix_sum_used += row_offsets_used[i];
+        }
+        /* resize row_indices to reduce memory */
+        row_indices->resize(prefix_sum_used);
+      }
+
+      if (nthread == 1ul || tid == 1ul) {
+        size_t prefix_sum_unused = row_offsets_unused[0];
+        for (size_t i = 1; i < nthread; ++i) {
+          const size_t ibegin = i * discard_size;
+
+          for (size_t k = 0; k < row_offsets_unused[i]; ++k) {
+            p_row_indices_unused[prefix_sum_unused + k] = p_row_indices_unused[ibegin + k];
+          }
+
+          prefix_sum_unused += row_offsets_unused[i];
+        }
+        /* resize row_indices to reduce memory */
+        unused_rows_.resize(prefix_sum_unused);
       }
     });
   }
   exc.Rethrow();
   /* discard global engine */
   rnd = rnds[nthread - 1];
-  size_t prefix_sum = row_offsets[0];
-  for (size_t i = 1; i < nthread; ++i) {
-    const size_t ibegin = i * discard_size;
-
-    for (size_t k = 0; k < row_offsets[i]; ++k) {
-      row_indices_local[prefix_sum + k] = row_indices_local[ibegin + k];
-    }
-    prefix_sum += row_offsets[i];
-  }
-  /* resize row_indices to reduce memory */
-  row_indices_local.resize(prefix_sum);
 #endif  // XGBOOST_CUSTOMIZE_GLOBAL_PRNG
 }
+
 template<typename GradientSumT>
 void QuantileHistMaker::Builder<GradientSumT>::InitData(const GHistIndexMatrix& gmat,
                                           const std::vector<GradientPair>& gpair,
@@ -764,8 +823,6 @@ void QuantileHistMaker::Builder<GradientSumT>::InitData(const GHistIndexMatrix& 
   {
     // initialize the row set
     row_set_collection_.Clear();
-    // clear local prediction cache
-    leaf_value_cache_.clear();
     // initialize histogram collection
     uint32_t nbins = gmat.cut.Ptrs().back();
     hist_.Init(nbins);
@@ -793,6 +850,9 @@ void QuantileHistMaker::Builder<GradientSumT>::InitData(const GHistIndexMatrix& 
         << "Only uniform sampling is supported, "
         << "gradient-based sampling is only support by GPU Hist.";
       InitSampling(gpair, fmat, &row_indices);
+      // We should check that the partitioning was done correctly
+      // and each row of the dataset fell into exactly one of the categories
+      CHECK_EQ(row_indices.size() + unused_rows_.size(), info.num_row_);
     } else {
       MemStackAllocator<bool, 128> buff(this->nthread_);
       bool* p_buff = buff.Get();

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -183,7 +183,7 @@ TEST(CpuPredictor, InplacePredict) {
   }
 }
 
-TEST(CpuPredictor, UpdatePredictionCache) {
+void TestUpdatePredictionCache(bool use_subsampling) {
   size_t constexpr kRows = 64, kCols = 16, kClasses = 4;
   LearnerModelParam mparam;
   mparam.num_feature = kCols;
@@ -224,6 +224,11 @@ TEST(CpuPredictor, UpdatePredictionCache) {
   for (size_t i = 0; i < out_predictions_h.size(); ++i) {
     ASSERT_NEAR(out_predictions_h[i], predtion_cache_from_train[i], kRtEps);
   }
+}
+
+TEST(CpuPredictor, UpdatePredictionCache) {
+    TestUpdatePredictionCache(false);
+    TestUpdatePredictionCache(true);
 }
 
 TEST(CpuPredictor, LesserFeatures) {

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -198,6 +198,9 @@ void TestUpdatePredictionCache(bool use_subsampling) {
   std::map<std::string, std::string> cfg;
   cfg["tree_method"] = "hist";
   cfg["predictor"]   = "cpu_predictor";
+  if (use_subsampling) {
+    cfg["subsample"] = "0.5";
+  }
   Args args = {cfg.cbegin(), cfg.cend()};
   gbm->Configure(args);
 

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -121,8 +121,8 @@ class QuantileHistMock : public QuantileHistMaker {
         for (auto&& row_indice : second) {
           ++arr_union[row_indice];
         }
-        for (size_t i = 0; i < nrows; ++i) {
-          ASSERT_EQ(arr_union[i], 1ul);
+        for (auto&& row_cnt : arr_union) {
+          ASSERT_EQ(row_cnt, 1ul);
         }
       };
       check_each_row_occurs_in_one_of_arrays(row_indices_initial, unused_row_indices_initial,

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2018-2019 by Contributors
+ * Copyright 2018-2021 by Contributors
  */
 #include <xgboost/host_device_vector.h>
 #include <xgboost/tree_updater.h>
@@ -107,19 +107,45 @@ class QuantileHistMock : public QuantileHistMaker {
       const size_t nthreads = omp_get_num_threads();
       // save state of global rng engine
       auto initial_rnd = common::GlobalRandom();
+      std::vector<size_t> unused_rows_cpy = this->unused_rows_;
       RealImpl::InitData(gmat, gpair, *p_fmat, tree);
       std::vector<size_t> row_indices_initial = *(this->row_set_collection_.Data());
+      std::vector<size_t> unused_row_indices_initial = this->unused_rows_;
+      auto check_each_row_occurs_in_one_of_arrays = [](const std::vector<size_t>& first,
+                                                       const std::vector<size_t>& second,
+                                                       size_t nrows) {
+        std::vector<size_t> arr_union(nrows);
+        for (auto&& row_indice : first) {
+          ++arr_union[row_indice];
+        }
+        for (auto&& row_indice : second) {
+          ++arr_union[row_indice];
+        }
+        for (size_t i = 0; i < nrows; ++i) {
+          ASSERT_EQ(arr_union[i], 1ul);
+        }
+      };
+      check_each_row_occurs_in_one_of_arrays(row_indices_initial, unused_row_indices_initial,
+                                             p_fmat->Info().num_row_);
 
       for (size_t i_nthreads = 1; i_nthreads < 4; ++i_nthreads) {
         omp_set_num_threads(i_nthreads);
         // return initial state of global rng engine
         common::GlobalRandom() = initial_rnd;
+        this->unused_rows_ = unused_rows_cpy;
         RealImpl::InitData(gmat, gpair, *p_fmat, tree);
         std::vector<size_t>& row_indices = *(this->row_set_collection_.Data());
         ASSERT_EQ(row_indices_initial.size(), row_indices.size());
         for (size_t i = 0; i < row_indices_initial.size(); ++i) {
           ASSERT_EQ(row_indices_initial[i], row_indices[i]);
         }
+        std::vector<size_t>& unused_row_indices = this->unused_rows_;
+        ASSERT_EQ(unused_row_indices_initial.size(), unused_row_indices.size());
+        for (size_t i = 0; i < unused_row_indices_initial.size(); ++i) {
+          ASSERT_EQ(unused_row_indices_initial[i], unused_row_indices[i]);
+        }
+        check_each_row_occurs_in_one_of_arrays(row_indices, unused_row_indices,
+                                               p_fmat->Info().num_row_);
       }
       omp_set_num_threads(nthreads);
     }


### PR DESCRIPTION
Currently, the prediction cache is not enabled for models with `subsample < 1`, so a full prediction is made after each training iteration. This PR allows to partially update the predictions using the existing cache and make the actual prediction only on the rows that were not used for training.

We noticed an almost 2x acceleration for the `PredictRaw` section (on santander, where `subsample == 0.5`)
We also encountered a slowdown in the `InitData` section, where we now do more calculations (this will only be observed on `subsample < 1` datasets). This could be improved in future updates.

**UPD:**
Here are some measurements:
| Higgs, 1m, `subsample == 0.9` | PredictRaw | InitData | Overall time |
| ----------------------------- | ---------- | -------- | ------------ |
| current master branch, s      | 2.57       | 7.12     | 24.70        |
| #6683, s                      | 1.51       | 8.51     | 24.86        |
| speedup, ratio                | 1.7x       | 0.84x    | 0.994x       |

| Airline, 1m, `subsample == 0.9` | PredictRaw | InitData | Overall time |
| ------------------------------- | ---------- | -------- | ------------ |
| current master branch, s        | 37.48      | 7.46     | 81.47        |
| #6683, s                        | 8.17       | 8.67     | 51.71        |
| speedup, ratio                  | 4.59x      | 0.86x    | 1.58x        |

| Mortgage, 9m, `subsample == 0.9` | PredictRaw | InitData | Overall time |
| ------------------------------- | ---------- | -------- | ------------ |
| current master branch, s        | 5.19       | 6.4      | 25.93        |
| #6683, s                        | 1.73       | 7.6      | 23.48        |
| speedup, ratio                  | 3x         | 0.84x    | 1.1x         |

| Santander, `subsample == 0.5` | PredictRaw | InitData | Overall time |
| --------------------------------- | ---------- | -------- | ------------ |
| master just before #6696, s       | 79.11      | 14.08    | 163.41       |
| current master branch, s          | 56.81      | 15.78    | 145.52       |
| #6683, s                          | 37.77      | 21.40    | 129.41       |
| total speedup, ratio              | 2.1x       | 0.66x    | 1.26x        |