### PR TITLE
Simplify Span checks.

### DIFF
--- a/include/xgboost/span.h
+++ b/include/xgboost/span.h
@@ -38,6 +38,10 @@
 #include <type_traits>
 #include <cstdio>
 
+#if defined(__CUDACC__)
+#include <cuda_runtime.h>
+#endif  // defined(__CUDACC__)
+
 /*!
  * The version number 1910 is picked up from GSL.
  *
@@ -71,45 +75,29 @@
 namespace xgboost {
 namespace common {
 
-// Usual logging facility is not available inside device code.
-// assert is not supported in mac as of CUDA 10.0
-#define KERNEL_CHECK(cond)                                                     \
-  do {                                                                         \
-    if (!(cond)) {                                                             \
-      printf("\nKernel error:\n"                                               \
-             "In: %s: %d\n"                                                    \
-             "\t%s\n\tExpecting: %s\n"                                         \
-             "\tBlock: [%d, %d, %d], Thread: [%d, %d, %d]\n\n",                \
-             __FILE__, __LINE__, __PRETTY_FUNCTION__, #cond, blockIdx.x,       \
-             blockIdx.y, blockIdx.z, threadIdx.x, threadIdx.y, threadIdx.z);   \
-      asm("trap;");                                                            \
-    }                                                                          \
-  } while (0);
-
 #if defined(__CUDA_ARCH__)
+// Usual logging facility is not available inside device code.
+#define __ASSERT_STR_HELPER(x) #x
+
+#define KERNEL_CHECK(e)                                                        \
+  ((e) ? static_cast<void>(0)                                                  \
+       : __assert_fail(__ASSERT_STR_HELPER(e), __FILE__, __LINE__,             \
+                       __PRETTY_FUNCTION__))
+
 #define SPAN_CHECK KERNEL_CHECK
-#elif defined(XGBOOST_STRICT_R_MODE) && XGBOOST_STRICT_R_MODE == 1  // R package
-#define SPAN_CHECK CHECK  // check from dmlc
-#else  // not CUDA, not R
-#define SPAN_CHECK(cond)                                                       \
-  do {                                                                         \
-    if (XGBOOST_EXPECT(!(cond), false)) {                                      \
-      fprintf(stderr, "[xgboost] Condition %s failed.\n", #cond);              \
-      fflush(stderr);  /* It seems stderr on Windows is beffered? */           \
-      std::terminate();                                                        \
-    }                                                                          \
-  } while (0);
+
+#else  // not CUDA
+
+#define KERNEL_CHECK(cond) ((cond) ? static_cast<void>(0) : std::terminate())
+
+#define SPAN_CHECK(cond) KERNEL_CHECK(cond)
+
 #endif  // __CUDA_ARCH__
 
 #if defined(__CUDA_ARCH__)
-#define SPAN_LT(lhs, rhs)                                                      \
-  if (!((lhs) < (rhs))) {                                                      \
-    printf("[xgboost] Condition: %lu < %lu failed\n",                          \
-           static_cast<size_t>(lhs), static_cast<size_t>(rhs));                \
-    asm("trap;");                                                              \
-  }
+#define SPAN_LT(lhs, rhs) KERNEL_CHECK((lhs) < (rhs))
 #else
-#define SPAN_LT(lhs, rhs) SPAN_CHECK((lhs) < (rhs))
+#define SPAN_LT(lhs, rhs) KERNEL_CHECK((lhs) < (rhs))
 #endif  // defined(__CUDA_ARCH__)
 
 namespace detail {

--- a/tests/cpp/common/test_span.cc
+++ b/tests/cpp/common/test_span.cc
@@ -122,7 +122,7 @@ TEST(SpanDeathTest, FromPtrLen) {
   InitializeRange(arr, arr+16);
   {
     auto lazy = [=]() {Span<float const, 16> tmp (arr, 5);};
-    EXPECT_DEATH(lazy(), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(lazy(), "");
   }
 }
 
@@ -296,11 +296,11 @@ TEST(SpanDeathTest, ElementAccess) {
   InitializeRange(arr, arr + 16);
 
   Span<float> s (arr);
-  EXPECT_DEATH(s[16], "\\[xgboost\\] Condition .* failed.\n");
-  EXPECT_DEATH(s[-1], "\\[xgboost\\] Condition .* failed.\n");
+  EXPECT_DEATH(s[16], "");
+  EXPECT_DEATH(s[-1], "");
 
-  EXPECT_DEATH(s(16), "\\[xgboost\\] Condition .* failed.\n");
-  EXPECT_DEATH(s(-1), "\\[xgboost\\] Condition .* failed.\n");
+  EXPECT_DEATH(s(16), "");
+  EXPECT_DEATH(s(-1), "");
 }
 
 TEST(Span, Obversers) {
@@ -327,13 +327,13 @@ TEST(Span, FrontBack) {
 TEST(SpanDeathTest, FrontBack) {
   {
     Span<float, 0> s;
-    EXPECT_DEATH(s.front(), "\\[xgboost\\] Condition .* failed.\n");
-    EXPECT_DEATH(s.back(), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.front(), "");
+    EXPECT_DEATH(s.back(), "");
   }
   {
     Span<float> s;
-    EXPECT_DEATH(s.front(), "\\[xgboost\\] Condition .* failed.\n");
-    EXPECT_DEATH(s.back(), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.front(), "");
+    EXPECT_DEATH(s.back(), "");
   }
 }
 
@@ -411,9 +411,9 @@ TEST(SpanDeathTest, FirstLast) {
 
     Span<float> s (arr);
     auto constexpr kOne = static_cast<Span<float, 4>::index_type>(-1);
-    EXPECT_DEATH(s.first<kOne>(), "\\[xgboost\\] Condition .* failed.\n");
-    EXPECT_DEATH(s.first<17>(), "\\[xgboost\\] Condition .* failed.\n");
-    EXPECT_DEATH(s.first<32>(), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.first<kOne>(), "");
+    EXPECT_DEATH(s.first<17>(), "");
+    EXPECT_DEATH(s.first<32>(), "");
   }
 
   {
@@ -422,9 +422,9 @@ TEST(SpanDeathTest, FirstLast) {
 
     Span<float> s (arr);
     auto constexpr kOne = static_cast<Span<float, 4>::index_type>(-1);
-    EXPECT_DEATH(s.last<kOne>(), "\\[xgboost\\] Condition .* failed.\n");
-    EXPECT_DEATH(s.last<17>(), "\\[xgboost\\] Condition .* failed.\n");
-    EXPECT_DEATH(s.last<32>(), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.last<kOne>(), "");
+    EXPECT_DEATH(s.last<17>(), "");
+    EXPECT_DEATH(s.last<32>(), "");
   }
 
   // dynamic extent
@@ -432,9 +432,9 @@ TEST(SpanDeathTest, FirstLast) {
     float *arr = new float[16];
     InitializeRange(arr, arr + 16);
     Span<float> s (arr, 16);
-    EXPECT_DEATH(s.first(-1), "\\[xgboost\\] Condition .* failed.\n");
-    EXPECT_DEATH(s.first(17), "\\[xgboost\\] Condition .* failed.\n");
-    EXPECT_DEATH(s.first(32), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.first(-1), "");
+    EXPECT_DEATH(s.first(17), "");
+    EXPECT_DEATH(s.first(32), "");
 
     delete [] arr;
   }
@@ -443,9 +443,9 @@ TEST(SpanDeathTest, FirstLast) {
     float *arr = new float[16];
     InitializeRange(arr, arr + 16);
     Span<float> s (arr, 16);
-    EXPECT_DEATH(s.last(-1), "\\[xgboost\\] Condition .* failed.\n");
-    EXPECT_DEATH(s.last(17), "\\[xgboost\\] Condition .* failed.\n");
-    EXPECT_DEATH(s.last(32), "\\[xgboost\\] Condition .* failed.\n");
+    EXPECT_DEATH(s.last(-1), "");
+    EXPECT_DEATH(s.last(17), "");
+    EXPECT_DEATH(s.last(32), "");
 
     delete [] arr;
   }
@@ -469,12 +469,12 @@ TEST(Span, Subspan) {
 TEST(SpanDeathTest, Subspan) {
   int arr[16] {0};
   Span<int> s1 (arr);
-  EXPECT_DEATH(s1.subspan(-1, 0), "\\[xgboost\\] Condition .* failed.\n");
-  EXPECT_DEATH(s1.subspan(17, 0), "\\[xgboost\\] Condition .* failed.\n");
+  EXPECT_DEATH(s1.subspan(-1, 0), "");
+  EXPECT_DEATH(s1.subspan(17, 0), "");
 
   auto constexpr kOne = static_cast<Span<int, 4>::index_type>(-1);
-  EXPECT_DEATH(s1.subspan<kOne>(), "\\[xgboost\\] Condition .* failed.\n");
-  EXPECT_DEATH(s1.subspan<17>(),   "\\[xgboost\\] Condition .* failed.\n");
+  EXPECT_DEATH(s1.subspan<kOne>(), "");
+  EXPECT_DEATH(s1.subspan<17>(), "");
 }
 
 TEST(Span, Compare) {
@@ -523,7 +523,7 @@ TEST(SpanDeathTest, Empty) {
   std::vector<float> data(1, 0);
   ASSERT_TRUE(data.data());
   Span<float> s{data.data(), Span<float>::index_type(0)};  // ok to define 0 size span.
-  EXPECT_DEATH(s[0], "\\[xgboost\\] Condition .* failed.\n");  // not ok to use it.
+  EXPECT_DEATH(s[0], "");  // not ok to use it.
 }
 
 }  // namespace common


### PR DESCRIPTION
* Stop printing out messages.
* Remove R specialization.

The printed message is not really useful anyway, without a reproducible example
there's no way to fix it.  But if there's a reproducible example, we can always
obtain this information by a debugger.  Removing the `printf` function avoids
creating the context in kernels.