### PR TITLE
[dask] remove outdated comment

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -69,13 +69,6 @@ try:
 except ImportError:
     TrainReturnT = Dict[str, Any]  # type:ignore
 
-# Current status is considered as initial support, many features are not properly
-# supported yet.
-#
-# TODOs:
-#   - CV
-#   - Ranking
-#
 # Note for developers:
 #
 #   As of writing asyncio is still a new feature of Python and in depth documentation is

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -69,6 +69,9 @@ try:
 except ImportError:
     TrainReturnT = Dict[str, Any]  # type:ignore
 
+# TODOs:
+#   - CV
+#
 # Note for developers:
 #
 #   As of writing asyncio is still a new feature of Python and in depth documentation is


### PR DESCRIPTION
I was reading through the Dask module today and noticed a comment that I think is outdated. It mentions CV and Ranking as TODOs, but both of these features exist in `xgboost.dask`.

This PR proposes removing that comment.