### PR TITLE
Fixes small typo in sklearn documentation

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -85,7 +85,7 @@ __model_doc = '''
     n_jobs : int
         Number of parallel threads used to run xgboost.  When used with other Scikit-Learn
         algorithms like grid search, you may choose which algorithm to parallelize and
-        balance the threads.  Creating thread contention will significantly slow dowm both
+        balance the threads.  Creating thread contention will significantly slow down both
         algorithms.
     gamma : float
         Minimum loss reduction required to make a further partition on a leaf


### PR DESCRIPTION
Replaces "dowm" with "down" on parameter n_jobs