### PR TITLE
Re-enable categorical data tests.

### DIFF
--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -85,7 +85,6 @@ class TestGPUUpdaters:
     @settings(deadline=None)
     @pytest.mark.skipif(**tm.no_pandas())
     def test_categorical(self, rows, cols, rounds, cats):
-        pytest.xfail(reason='TestGPUUpdaters::test_categorical is flaky')
         self.run_categorical_basic(rows, cols, rounds, cats)
 
     def test_categorical_32_cat(self):


### PR DESCRIPTION
I collected some falsifying examples from hypothesis, they are no longer reproducible on my system.  It would be great if I can see them on CI again.