### PR TITLE
Removing the wrong gamma-deviance metric

### DIFF
--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -270,21 +270,6 @@ struct EvalPoissonNegLogLik {
   }
 };
 
-struct EvalGammaDeviance {
-  const char *Name() const {
-    return "gamma-deviance";
-  }
-
-  XGBOOST_DEVICE bst_float EvalRow(bst_float label, bst_float pred) const {
-    bst_float epsilon = 1.0e-9;
-    bst_float tmp = label / (pred + epsilon);
-    return tmp - std::log(tmp) - 1;
-  }
-  static bst_float GetFinal(bst_float esum, bst_float wsum) {
-    return 2 * esum;
-  }
-};
-
 struct EvalGammaNLogLik {
   static const char *Name() {
     return "gamma-nloglik";
@@ -398,10 +383,6 @@ XGBOOST_REGISTER_METRIC(LogLoss, "logloss")
 XGBOOST_REGISTER_METRIC(PossionNegLoglik, "poisson-nloglik")
 .describe("Negative loglikelihood for poisson regression.")
 .set_body([](const char* param) { return new EvalEWiseBase<EvalPoissonNegLogLik>(); });
-
-XGBOOST_REGISTER_METRIC(GammaDeviance, "gamma-deviance")
-.describe("Residual deviance for gamma regression.")
-.set_body([](const char* param) { return new EvalEWiseBase<EvalGammaDeviance>(); });
 
 XGBOOST_REGISTER_METRIC(GammaNLogLik, "gamma-nloglik")
 .describe("Negative log-likelihood for gamma regression.")


### PR DESCRIPTION
Corrected version, but without checking the condition `label>0 && pred>0`:
```c++
struct EvalGammaDeviance {
  const char *Name() const {
    return "gamma-deviance";
  }

  XGBOOST_DEVICE bst_float EvalRow(bst_float label, bst_float pred) const {
    const bst_float eps = 1e-16f;
    return 2 * (std::log(pred/(label+eps)) + label/(pred+eps) - 1);
  }
  static bst_float GetFinal(bst_float esum, bst_float wsum) {
    return wsum == 0 ? esum : esum / wsum;
  }
};
```
