### PR TITLE
[R] Parse splits on inf in xgb.model.dt.tree (#3900)

### DIFF
--- a/R-package/R/xgb.model.dt.tree.R
+++ b/R-package/R/xgb.model.dt.tree.R
@@ -95,7 +95,7 @@ xgb.model.dt.tree <- function(feature_names = NULL, model = NULL, text = NULL,
 
   add.tree.id <- function(node, tree) if (use_int_id) node else paste(tree, node, sep = "-")
 
-  anynumber_regex <- "[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?"
+  anynumber_regex <- "[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?|[-+]?[Ii]nf"
 
   td <- data.table(t = text)
   td[position, Tree := 1L]

--- a/R-package/R/xgb.model.dt.tree.R
+++ b/R-package/R/xgb.model.dt.tree.R
@@ -95,7 +95,7 @@ xgb.model.dt.tree <- function(feature_names = NULL, model = NULL, text = NULL,
 
   add.tree.id <- function(node, tree) if (use_int_id) node else paste(tree, node, sep = "-")
 
-  anynumber_regex <- "[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?|[-+]?[Ii]nf"
+  anynumber_regex <- "[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?|[-+]?[Ii]nf|[nN]a[nN]"
 
   td <- data.table(t = text)
   td[position, Tree := 1L]

--- a/R-package/tests/testthat/test_helpers.R
+++ b/R-package/tests/testthat/test_helpers.R
@@ -281,6 +281,18 @@ test_that("xgb.model.dt.tree throws error for gblinear", {
   expect_error(xgb.model.dt.tree(model = bst.GLM))
 })
 
+test_that("xgb.model.dt.tree works with splits on inf", {
+  tree.dump <- c(
+    "booster[0]",
+    "0:[f1<inf] yes=1,no=3,missing=3,gain=0.1,cover=3",
+    "1:[f2<-inf] yes=2,no=3,missing=3,gain=0.1,cover=1",
+    "2:[f1<2] yes=4,no=3,missing=3,gain=0.3,cover=4",
+    "3:leaf=0.2,cover=1",
+    "4:leaf=0.5,cover=1"
+  )
+  expect_equal(xgb.model.dt.tree(text = tree.dump)$Split, c(Inf, -Inf, 2, NA, NA))
+})
+
 test_that("xgb.importance works with and without feature names", {
   importance.Tree <- xgb.importance(feature_names = feature.names, model = bst.Tree)
   if (!flag_32bit)

--- a/R-package/tests/testthat/test_helpers.R
+++ b/R-package/tests/testthat/test_helpers.R
@@ -293,6 +293,18 @@ test_that("xgb.model.dt.tree works with splits on inf", {
   expect_equal(xgb.model.dt.tree(text = tree.dump)$Split, c(Inf, -Inf, 2, NA, NA))
 })
 
+test_that("xgb.model.dt.tree works with splits on nan", {
+  tree.dump <- c(
+    "booster[0]",
+    "0:[f1<nan] yes=1,no=3,missing=3,gain=0.1,cover=3",
+    "1:[f2<nan] yes=2,no=3,missing=3,gain=0.1,cover=1",
+    "2:[f1<2] yes=4,no=3,missing=3,gain=0.3,cover=4",
+    "3:leaf=0.2,cover=1",
+    "4:leaf=0.5,cover=1"
+  )
+  expect_equal(xgb.model.dt.tree(text = tree.dump)$Split, c(NaN, NaN, 2, NA, NA))
+})
+
 test_that("xgb.importance works with and without feature names", {
   importance.Tree <- xgb.importance(feature_names = feature.names, model = bst.Tree)
   if (!flag_32bit)


### PR DESCRIPTION
As per the discussion on (#3900) splits on `inf` were previously being incorrectly parsed with `NA`s due to a failed regex match.

Since the change (#6109 Sep 2020) to remove `stringi` dependency, the handling of failed regex matches has changed and can now cause a number of different errors (detailed below).

I have added `inf` to the regex and added a simple test case that fails for previous versions.

## Problem

If you have `inf` splits you now get one of three undesirable behaviours detailed below using dummy tree dumps.

Note: This code was run on Windows 10 using xgboost 1.3.2.1 and R 4.0.3.

#### 1. If you have multiple non-inf splits you get a data.table error
This seems to be the most common case, and was the error I stumbled upon that led me here.
```
xgb.model.dt.tree(
  text = c(
    "booster[0]",
    "0:[f1<inf] yes=1,no=3,missing=3,gain=0.1,cover=3",
    "1:[f2<3] yes=2,no=3,missing=3,gain=0.1,cover=1",
    "2:[f1<2] yes=4,no=3,missing=3,gain=0.3,cover=4",
    "3:leaf=0.2,cover=1",
    "4:leaf=0.5,cover=1"
  )
)

# Error in `[.data.table`(td, isLeaf == FALSE, `:=`((branch_cols), { : 
#  Supplied 2 items to be assigned to 3 items of column 'Feature'. If you wish to 'recycle'
#  the RHS please use rep() to make this intent clear to readers of your code.
```

The following cases are both improbable in practice but included for reference, **3** being particularly misleading

#### 2. If you only have only inf splits, you get a subscript out of bounds error
```
xgb.model.dt.tree(
  text = c(
    "booster[0]",
    "0:[f1<inf] yes=1,no=2,missing=2,gain=0.5,cover=4",
    "2:leaf=0.2,cover=1"
  )
)

# Error in do.call(rbind, matches)[, c(2, 3, 5, 6, 7, 8, 10), drop = FALSE] : 
#   subscript out of bounds
```

#### 3. If you only have only 1 non-inf split, then it's details get copied onto all rows
This is the special case of recycling that data.table allows (avoiding the error in **1**)
```
xgb.model.dt.tree(
  text = c(
    "booster[0]",
    "0:[f1<inf] yes=1,no=3,missing=3,gain=0.1,cover=3",
    "1:[f2<3] yes=2,no=3,missing=3,gain=0.5,cover=1",
    "2:leaf=0.2,cover=1",
    "3:leaf=0.5,cover=1"
  )
)

#    Tree Node  ID Feature Split  Yes   No Missing Quality Cover
# 1:    0    0 0-0       2     3  0-2  0-3     0-3     0.5     1
# 2:    0    1 0-1       2     3  0-2  0-3     0-3     0.5     1
# 3:    0    2 0-2    Leaf    NA <NA> <NA>    <NA>     0.2     1
# 4:    0    3 0-3    Leaf    NA <NA> <NA>    <NA>     0.5     1
```

## Cause

As discussed above, the nodes are not parsed correctly as `anynumber_regex` does not match `inf`.

The code change on lines `121-125` of `R-package/R/xgb.model.dt.tree.R` uses 
```
(A)  matches <- regmatches(t, regexec(branch_rx, t))
     #skip some indices with spurious capture groups from anynumber_regex
     xtr <- do.call(rbind, matches)[, c(2, 3, 5, 6, 7, 8, 10), drop = FALSE]
```
to replace the old line
```
(B)  xtr <- stri_match_first_regex(t, branch_rx)[, c(2, 3, 5, 6, 7, 8, 10), drop = FALSE]
```
This code change has altered the behaviour when the regex fails to find a match, for example
```
txt = c(
  "booster[0]",
  "0:[f1<inf] yes=1,no=3,missing=3,gain=0.1,cover=3",
  "1:[f2<3] yes=2,no=3,missing=3,gain=0.5,cover=1",
  "2:leaf=0.2,cover=1",
  "3:leaf=0.5,cover=1"
)

anynumber_regex <- "[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?"
branch_rx <- paste0(
  "f(\\d+)<(", anynumber_regex, ")\\] yes=(\\d+),no=(\\d+),missing=(\\d+),",
  "gain=(", anynumber_regex, "),cover=(", anynumber_regex, ")"
)

(A) do.call(rbind, regmatches(txt[2:3], regexec(branch_rx, txt[2:3])))[, c(2, 3, 5, 6, 7, 8, 10), drop = FALSE]

#      [,1] [,2] [,3] [,4] [,5] [,6]  [,7]
# [1,] "2"  "3"  "2"  "3"  "3"  "0.5" "1" 

(B) stringi::stri_match_first_regex(txt[2:3], branch_rx)[, c(2, 3, 5, 6, 7, 8, 10), drop = FALSE]

#      [,1] [,2] [,3] [,4] [,5] [,6]  [,7]
# [1,] NA   NA   NA   NA   NA   NA    NA  
# [2,] "2"  "3"  "2"  "3"  "3"  "0.5" "1" 

```

## Solution 

As suggested by @dshopin and seconded by @hcho3 in #3900 I have changed the `anynumber_regex` to include `inf`:
```
anynumber_regex <- "[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?|[-+]?[Ii]nf"
```
