### PR TITLE
[dask] Use `distributed.MultiLock`

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -98,7 +98,7 @@ def _multi_lock():
     """MultiLock is only available on latest distributed."""
     try:
         from distributed import MultiLock
-    except AttributeError:
+    except ImportError:
         msg = (
             "`distributed.MultiLock` is not available, training multiple models "
             "in parallel might hang."

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1571,7 +1571,7 @@ class DaskScikitLearnBase(XGBModel):
                         return ret
                     return ret
 
-        return self.client.sync(func, **kwargs)
+        return self.client.sync(func, **kwargs, asynchronous=asynchronous)
 
 
 @xgboost_model_doc(

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -94,7 +94,7 @@ except ImportError:
 LOGGER = logging.getLogger('[xgboost.dask]')
 
 
-def _multi_lock():
+def _multi_lock() -> Any:
     """MultiLock is only available on latest distributed."""
     try:
         from distributed import MultiLock
@@ -105,7 +105,7 @@ def _multi_lock():
         )
         LOGGER.warning(msg)
 
-        class MultiLock:
+        class MultiLock:        # type:ignore
             def __init__(self, *args: Any, **kwargs: Any) -> None:
                 pass
 
@@ -115,10 +115,10 @@ def _multi_lock():
             def __exit__(self, *args: Any, **kwargs: Any) -> None:
                 return
 
-            async def __aenter__(self):
+            async def __aenter__(self) -> "MultiLock":
                 return self
 
-            async def __aexit__(self, *args, **kwargs):
+            async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
                 return
 
     return MultiLock
@@ -801,7 +801,7 @@ async def _get_rabit_args(n_workers: int, client: "distributed.Client") -> List[
 def _get_workers_from_data(
     dtrain: DaskDMatrix,
     evals: Optional[List[Tuple[DaskDMatrix, str]]]
-) -> Set[str]:
+) -> List[str]:
     X_worker_map: Set[str] = set(dtrain.worker_map.keys())
     if evals:
         for e in evals:
@@ -1429,7 +1429,7 @@ async def _async_wrap_evaluation_matrices(
 @contextmanager
 def _set_worker_client(
     model: "DaskScikitLearnBase", client: "distributed.Client"
-) -> "DaskScikitLearnBase":
+) -> Generator:
     """Temporarily set the client for sklearn model."""
     try:
         model.client = client
@@ -1552,7 +1552,7 @@ class DaskScikitLearnBase(XGBModel):
         self._asynchronous = clt.asynchronous if clt is not None else False
         self._client = clt
 
-    def _client_sync(self, func: Callable, **kwargs) -> Any:
+    def _client_sync(self, func: Callable, **kwargs: Any) -> Any:
         """Get the correct client, when method is invoked inside a worker we
         should use `worker_client' instead of default client.
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -99,11 +99,11 @@ def _multi_lock():
     try:
         from distributed import MultiLock
     except AttributeError:
-        LOGGER.warn(
+        msg = (
             "`distributed.MultiLock` is not available, training multiple models "
-            "in parallel might hang.",
-            UserWarning,
+            "in parallel might hang."
         )
+        LOGGER.warning(msg)
 
         class MultiLock:
             def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1916,6 +1916,7 @@ class DaskXGBRanker(DaskScikitLearnBase, XGBRankerMixIn):
             dtrain=dtrain,
             num_boost_round=self.get_num_boosting_rounds(),
             evals=evals,
+            obj=None,
             feval=metric,
             verbose_eval=verbose,
             early_stopping_rounds=early_stopping_rounds,

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -95,16 +95,14 @@ LOGGER = logging.getLogger('[xgboost.dask]')
 
 
 def _multi_lock() -> Any:
-    """MultiLock is only available on latest distributed."""
+    """MultiLock is only available on latest distributed.  See:
+
+    https://github.com/dask/distributed/pull/4503
+
+"""
     try:
         from distributed import MultiLock
     except ImportError:
-        msg = (
-            "`distributed.MultiLock` is not available, training multiple models "
-            "in parallel might hang."
-        )
-        LOGGER.warning(msg)
-
         class MultiLock:        # type:ignore
             def __init__(self, *args: Any, **kwargs: Any) -> None:
                 pass

--- a/tests/python-gpu/test_gpu_with_dask.py
+++ b/tests/python-gpu/test_gpu_with_dask.py
@@ -293,7 +293,7 @@ class TestDistributedGPU:
             fw = fw - fw.min()
             m = dxgb.DaskDMatrix(client, X, y, feature_weights=fw)
 
-            workers = list(_get_client_workers(client).keys())
+            workers = _get_client_workers(client)
             rabit_args = client.sync(dxgb._get_rabit_args, len(workers), client)
 
             def worker_fn(worker_addr: str, data_ref: Dict) -> None:
@@ -384,7 +384,7 @@ class TestDistributedGPU:
             return subprocess.run([str(exe), test], env=env, stdout=subprocess.PIPE)
 
         with Client(local_cuda_cluster) as client:
-            workers = list(_get_client_workers(client).keys())
+            workers = _get_client_workers(client)
             rabit_args = client.sync(dxgb._get_rabit_args, workers, client)
             futures = client.map(runit,
                                  workers,

--- a/tests/python/test_tracker.py
+++ b/tests/python/test_tracker.py
@@ -27,7 +27,7 @@ def run_rabit_ops(client, n_workers):
     from xgboost.dask import RabitContext, _get_rabit_args
     from xgboost import rabit
 
-    workers = list(_get_client_workers(client).keys())
+    workers = _get_client_workers(client)
     rabit_args = client.sync(_get_rabit_args, len(workers), client)
     assert not rabit.is_distributed()
     n_workers_from_dask = len(workers)

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -1286,10 +1286,13 @@ def test_dask_unsupported_features(client: "Client") -> None:
         )
 
 
-@pytest.mark.skipimport("distributed.MultiLock")
 def test_parallel_submits(client: "Client") -> None:
     """Test for running multiple train simultaneously from single clients."""
-    from distributed import MultiLock
+    try:
+        from distributed import MultiLock  # NOQA
+    except ImportError:
+        pytest.skip("`distributed.MultiLock' is not available")
+
     from sklearn.datasets import load_digits
 
     futures = []
@@ -1314,9 +1317,13 @@ def test_parallel_submits(client: "Client") -> None:
         assert cls.get_booster().num_boosted_rounds() == i + 1
 
 
-@pytest.mark.skipimport("distributed.MultiLock")
-def test_parallel_submits_multi_clients() -> None:
+def test_parallel_submit_multi_clients() -> None:
     """Test for running multiple train simultaneously from multiple clients."""
+    try:
+        from distributed import MultiLock  # NOQA
+    except ImportError:
+        pytest.skip("`distributed.MultiLock' is not available")
+
     from sklearn.datasets import load_digits
 
     with LocalCluster(n_workers=4) as cluster:

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -647,7 +647,7 @@ def test_with_asyncio() -> None:
 
 
 async def generate_concurrent_trainings() -> None:
-    async def train():
+    async def train() -> None:
         async with LocalCluster(n_workers=2,
                                 threads_per_worker=1,
                                 asynchronous=True,
@@ -1286,7 +1286,7 @@ def test_dask_unsupported_features(client: "Client") -> None:
         )
 
 
-def test_parallel_submits(client: "Client"):
+def test_parallel_submits(client: "Client") -> None:
     """Test for running multiple train simultaneously from single clients."""
     try:
         from distributed import MultiLock  # NOQA
@@ -1317,7 +1317,7 @@ def test_parallel_submits(client: "Client"):
         assert cls.get_booster().num_boosted_rounds() == i + 1
 
 
-def test_parallel_submit_multi_clients():
+def test_parallel_submit_multi_clients() -> None:
     """Test for running multiple train simultaneously from multiple clients."""
     try:
         from distributed import MultiLock  # NOQA
@@ -1352,7 +1352,7 @@ def test_parallel_submit_multi_clients():
         t_futures = []
         with ThreadPoolExecutor(max_workers=16) as e:
             for i in range(n_submits):
-                def _():
+                def _() -> xgb.dask.DaskXGBClassifier:
                     return futures[i][0].compute(futures[i][1]).result()
 
                 f = e.submit(_)

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -1286,13 +1286,10 @@ def test_dask_unsupported_features(client: "Client") -> None:
         )
 
 
+@pytest.mark.skipimport("distributed.MultiLock")
 def test_parallel_submits(client: "Client") -> None:
     """Test for running multiple train simultaneously from single clients."""
-    try:
-        from distributed import MultiLock  # NOQA
-    except ImportError:
-        pytest.skip("`distributed.MultiLock' is not available")
-
+    from distributed import MultiLock
     from sklearn.datasets import load_digits
 
     futures = []
@@ -1317,13 +1314,9 @@ def test_parallel_submits(client: "Client") -> None:
         assert cls.get_booster().num_boosted_rounds() == i + 1
 
 
-def test_parallel_submit_multi_clients() -> None:
+@pytest.mark.skipimport("distributed.MultiLock")
+def test_parallel_submits_multi_clients() -> None:
     """Test for running multiple train simultaneously from multiple clients."""
-    try:
-        from distributed import MultiLock  # NOQA
-    except ImportError:
-        pytest.skip("`distributed.MultiLock' is not available")
-
     from sklearn.datasets import load_digits
 
     with LocalCluster(n_workers=4) as cluster:

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -1288,6 +1288,11 @@ def test_dask_unsupported_features(client: "Client") -> None:
 
 def test_parallel_submits(client: "Client"):
     """Test for running multiple train simultaneously from single clients."""
+    try:
+        from distributed import MultiLock  # NOQA
+    except ImportError:
+        pytest.skip("`distributed.MultiLock' is not available")
+
     from sklearn.datasets import load_digits
 
     futures = []
@@ -1314,6 +1319,11 @@ def test_parallel_submits(client: "Client"):
 
 def test_parallel_submit_multi_clients():
     """Test for running multiple train simultaneously from multiple clients."""
+    try:
+        from distributed import MultiLock  # NOQA
+    except ImportError:
+        pytest.skip("`distributed.MultiLock' is not available")
+
     from sklearn.datasets import load_digits
 
     with LocalCluster(n_workers=4) as cluster:


### PR DESCRIPTION
This enables training multiple models in parallel.

* Conditionally import `MultiLock`.
* Use async train directly in scikit learn interface.
* Use `worker_client` when available.

Close https://github.com/dmlc/xgboost/issues/6649 Close https://github.com/dmlc/xgboost/pull/6677 .

Currently depends on https://github.com/dask/distributed/pull/4503 .