### PR TITLE
Move skl `eval_metric` and `early_stopping rounds` to model params.

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1776,9 +1776,9 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
 """,
     ["estimators", "model"],
     end_note="""
-        Note
-        ----
-        For dask implementation, group is not supported, use qid instead.
+        .. note::
+
+            For dask implementation, group is not supported, use qid instead.
 """,
 )
 class DaskXGBRanker(DaskScikitLearnBase, XGBRankerMixIn):

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1549,8 +1549,8 @@ class DaskXGBRegressor(DaskScikitLearnBase, XGBRegressorBase):
             obj = _objective_decorator(self.objective)
         else:
             obj = None
-        model, metric, params = self._configure_fit(
-            booster=xgb_model, eval_metric=eval_metric, params=params
+        model, metric, params, early_stopping_rounds = self._configure_fit(
+            xgb_model, eval_metric, params, early_stopping_rounds
         )
         results = await train(
             client=self.client,
@@ -1648,8 +1648,8 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
             obj = _objective_decorator(self.objective)
         else:
             obj = None
-        model, metric, params = self._configure_fit(
-            booster=xgb_model, eval_metric=eval_metric, params=params
+        model, metric, params, early_stopping_rounds = self._configure_fit(
+            xgb_model, eval_metric, params, early_stopping_rounds
         )
         results = await train(
             client=self.client,
@@ -1835,8 +1835,8 @@ class DaskXGBRanker(DaskScikitLearnBase, XGBRankerMixIn):
                 raise ValueError(
                     "Custom evaluation metric is not yet supported for XGBRanker."
                 )
-        model, metric, params = self._configure_fit(
-            booster=xgb_model, eval_metric=eval_metric, params=params
+        model, metric, params, early_stopping_rounds = self._configure_fit(
+            xgb_model, eval_metric, params, early_stopping_rounds
         )
         results = await train(
             client=self.client,

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -59,6 +59,23 @@ def _objective_decorator(func):
     return inner
 
 
+def _metric_decorator(func: Callable) -> Metric:
+    """Decorate a metric function from sklearn.
+
+    Converts an objective function using the typical sklearn metrics signature so that it
+    is usable with ``xgboost.training.train``
+
+    """
+    def inner(y_score: np.ndarray, dmatrix: DMatrix) -> float:
+        y_true = dmatrix.get_label()
+        try:
+            return func.__name__, func(y_true, y_score)
+        except Exception:
+            # compatible with old impl.
+            return func(y_true, y_score)
+    return inner
+
+
 __estimator_doc = '''
     n_estimators : int
         Number of gradient boosted trees.  Equivalent to number of boosting
@@ -138,6 +155,42 @@ __model_doc = '''
         Device ordinal.
     validate_parameters :
         Give warnings for unknown parameter.
+    scoring :
+        Metric used for monitoring the training result and early stopping.  This can be a
+        string of list of string names of predefined metric in XGBoost (See
+        doc/parameter.rst), one of the metrics in :py:mod:`sklearn.metrics`, or any other
+        user defined metric that looks like `sklearn.metrics`.  Unlike scikit-learn, when
+        a callable object is provided in scikit-learn interface, it's assumed to be a cost
+        function and XGBoost will minimize the result by default. For advanced usage on
+        Early stopping like directly choosing to maximize instead of minimize, see
+        :py:obj:`xgboost.callbacks.EarlyStopping`.
+
+        .. versionadded:: 1.5.0
+
+        .. note::
+
+            This parameter replaces `eval_metric` in
+            :py:meth:`xgboost.sklearn.XGBModel.fit` method.
+
+     n_iter_no_change :
+        Activates early stopping. Validation metric needs to improve at least once in
+        every **n_iter_no_change** round(s) to continue training.  Requires at least
+        one item in **eval_set** in :py:meth:`xgboost.sklearn.XGBModel.fit`.
+
+        The method returns the model from the last iteration (not the best one).  If
+        there's more than one item in **eval_set**, the last entry will be used for early
+        stopping.  If there's more than one metric in **scoring**, the last metric will be
+        used for early stopping.
+
+        If early stopping occurs, the model will have three additional fields:
+        ``clf.best_score``, ``clf.best_iteration`` and ``clf.best_ntree_limit``.
+
+        .. versionadded:: 1.5.0
+
+        .. note::
+
+            This parameter replaces `early_stopping_rounds` in
+            :py:meth:`xgboost.sklearn.XGBModel.fit` method.
 
     \\*\\*kwargs : dict, optional
         Keyword arguments for XGBoost Booster object.  Full documentation of
@@ -343,6 +396,8 @@ class XGBModel(XGBModelBase):
         importance_type="gain",
         gpu_id=None,
         validate_parameters=None,
+        scoring: Optional[str, Callable] = None,
+        n_iter_no_change: Optional[int] = None,
         **kwargs
     ):
         if not SKLEARN_INSTALLED:
@@ -378,6 +433,8 @@ class XGBModel(XGBModelBase):
         self.importance_type = importance_type
         self.gpu_id = gpu_id
         self.validate_parameters = validate_parameters
+        self.scoring = scoring
+        self.n_iter_no_change = n_iter_no_change
 
     def _more_tags(self):
         '''Tags used for scikit-learn data validation.'''
@@ -481,7 +538,14 @@ class XGBModel(XGBModelBase):
         params = self.get_params()
         # Parameters that should not go into native learner.
         wrapper_specific = {
-            'importance_type', 'kwargs', 'missing', 'n_estimators', 'use_label_encoder'}
+            'importance_type',
+            'kwargs',
+            'missing',
+            'n_estimators',
+            'use_label_encoder',
+            "scoring",
+            "n_iter_no_change"
+        }
         filtered = dict()
         for k, v in params.items():
             if k not in wrapper_specific and not callable(v):
@@ -501,24 +565,6 @@ class XGBModel(XGBModelBase):
         return self._estimator_type  # pylint: disable=no-member
 
     def save_model(self, fname: str):
-        """Save the model to a file.
-
-        The model is saved in an XGBoost internal format which is universal
-        among the various XGBoost interfaces. Auxiliary attributes of the
-        Python Booster object (such as feature names) will not be saved.
-
-          .. note::
-
-            See:
-
-            https://xgboost.readthedocs.io/en/latest/tutorials/saving_model.html
-
-        Parameters
-        ----------
-        fname : string
-            Output file name
-
-        """
         meta = dict()
         for k, v in self.__dict__.items():
             if k == '_le':
@@ -542,20 +588,10 @@ class XGBModel(XGBModelBase):
         # Delete the attribute after save
         self.get_booster().set_attr(scikit_learn=None)
 
+    save_model.__doc__ = Booster.save_model.__doc__
+
     def load_model(self, fname):
         # pylint: disable=attribute-defined-outside-init
-        """Load the model from a file.
-
-        The model is loaded from an XGBoost internal format which is universal
-        among the various XGBoost interfaces. Auxiliary attributes of the
-        Python Booster object (such as feature names) will not be loaded.
-
-        Parameters
-        ----------
-        fname : string
-            Input file name.
-
-        """
         if not hasattr(self, '_Booster'):
             self._Booster = Booster({'n_jobs': self.n_jobs})
         self._Booster.load_model(fname)
@@ -589,22 +625,50 @@ class XGBModel(XGBModelBase):
         # Delete the attribute after load
         self.get_booster().set_attr(scikit_learn=None)
 
+    load_model.__doc__ = Booster.load_model.__doc__
+
     def _configure_fit(
         self,
         booster: Optional[Union[Booster, "XGBModel"]],
         eval_metric: Optional[Union[Callable, str, List[str]]],
         params: Dict[str, Any],
+        early_stopping_rounds: Optional[int],
     ) -> Tuple[Booster, Optional[Metric], Dict[str, Any]]:
-        # pylint: disable=protected-access, no-self-use
+        # pylint: disable=protected-access
         model = booster
         if hasattr(model, '_Booster'):
-            model = model._Booster  # Handle the case when xgb_model is a sklearn model object
-        feval = eval_metric if callable(eval_metric) else None
+            # Handle the case when xgb_model is a sklearn model object
+            model = model._Booster
+
+        if eval_metric is not None:
+            warnings.warn(
+                "eval_metric for `fit` method is deprecated, use `scoring` in "
+                "constructor or `set_params` instead.",
+                UserWarning
+            )
+        feval = _metric_decorator(eval_metric) if callable(eval_metric) else None
+        if self.scoring is not None and feval is not None:
+            warnings.warn("Overriding `eval_metric` with `scoring`", UserWarning)
+        feval = _metric_decorator(self.scoring) if callable(self.scoring) else feval
+
         if eval_metric is not None:
             if callable(eval_metric):
                 eval_metric = None
             else:
                 params.update({"eval_metric": eval_metric})
+
+        if early_stopping_rounds is not None:
+            warnings.warn(
+                "`early_stopping_rounds` is deprecated, use `n_iter_no_change` "
+                "in constructor instead.",
+                UserWarning,
+            )
+        early_stopping_rounds = (
+            self.n_iter_no_change
+            if self.n_iter_no_change is not None
+            else early_stopping_rounds
+        )
+
         return model, feval, params
 
     def _set_evaluation_result(self, evals_result: Optional[dict]) -> None:
@@ -654,26 +718,9 @@ class XGBModel(XGBModelBase):
             metrics will be computed.
             Validation metrics will help us track the performance of the model.
         eval_metric : str, list of str, or callable, optional
-            If a str, should be a built-in evaluation metric to use. See
-            doc/parameter.rst.
-            If a list of str, should be the list of multiple built-in evaluation metrics
-            to use.
-            If callable, a custom evaluation metric. The call signature is
-            ``func(y_predicted, y_true)`` where ``y_true`` will be a DMatrix object such
-            that you may need to call the ``get_label`` method. It must return a str,
-            value pair where the str is a name for the evaluation and value is the value
-            of the evaluation function. The callable custom objective is always minimized.
+            Deprecated, use `scoring` in constructor instead.
         early_stopping_rounds : int
-            Activates early stopping. Validation metric needs to improve at least once in
-            every **early_stopping_rounds** round(s) to continue training.
-            Requires at least one item in **eval_set**.
-            The method returns the model from the last iteration (not the best one).
-            If there's more than one item in **eval_set**, the last entry will be used
-            for early stopping.
-            If there's more than one metric in **eval_metric**, the last metric will be
-            used for early stopping.
-            If early stopping occurs, the model will have three additional fields:
-            ``clf.best_score``, ``clf.best_iteration`` and ``clf.best_ntree_limit``.
+            Deprecated, use `n_iter_no_change` in constructor instead.
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation metric
             measured on the validation set to stderr.
@@ -728,7 +775,9 @@ class XGBModel(XGBModelBase):
         else:
             obj = None
 
-        model, feval, params = self._configure_fit(xgb_model, eval_metric, params)
+        model, feval, params, early_stopping_rounds = self._configure_fit(
+            xgb_model, eval_metric, params, early_stopping_rounds
+        )
         self._Booster = train(
             params,
             train_dmatrix,
@@ -1148,7 +1197,9 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         else:
             label_transform = lambda x: x
 
-        model, feval, params = self._configure_fit(xgb_model, eval_metric, params)
+        model, feval, params, early_stopping_rounds = self._configure_fit(
+            xgb_model, eval_metric, params, early_stopping_rounds
+        )
         if len(X.shape) != 2:
             # Simply raise an error here since there might be many
             # different ways of reshaping
@@ -1277,8 +1328,9 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
 
         If **eval_set** is passed to the `fit` function, you can call
         ``evals_result()`` to get evaluation results for all passed **eval_sets**.
-        When **eval_metric** is also passed to the `fit` function, the
-        **evals_result** will contain the **eval_metrics** passed to the `fit` function.
+
+        When **scoring** is also passed as a parameter, the **evals_result** will contain
+        the **scoring** passed to the `fit` function.
 
         Returns
         -------
@@ -1289,13 +1341,14 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
 
         .. code-block:: python
 
-            param_dist = {'objective':'binary:logistic', 'n_estimators':2}
+            param_dist = {
+                'objective':'binary:logistic', 'n_estimators':2, scoring="logloss"
+            }
 
             clf = xgb.XGBClassifier(**param_dist)
 
             clf.fit(X_train, y_train,
                     eval_set=[(X_train, y_train), (X_test, y_test)],
-                    eval_metric='logloss',
                     verbose=True)
 
             evals_result = clf.evals_result()
@@ -1500,21 +1553,9 @@ class XGBRanker(XGBModel, XGBRankerMixIn):
             A list in which ``eval_qid[i]`` is the array containing query ID of ``i``-th
             pair in **eval_set**.
         eval_metric : str, list of str, optional
-            If a str, should be a built-in evaluation metric to use. See
-            doc/parameter.rst.
-            If a list of str, should be the list of multiple built-in evaluation metrics
-            to use. The custom evaluation metric is not yet supported for the ranker.
+            The custom evaluation metric is not yet supported for the ranker.
         early_stopping_rounds : int
-            Activates early stopping. Validation metric needs to improve at least once in
-            every **early_stopping_rounds** round(s) to continue training.  Requires at
-            least one item in **eval_set**.
-            The method returns the model from the last iteration (not the best one).  If
-            there's more than one item in **eval_set**, the last entry will be used for
-            early stopping.
-            If there's more than one metric in **eval_metric**, the last metric will be
-            used for early stopping.
-            If early stopping occurs, the model will have three additional fields:
-            ``clf.best_score``, ``clf.best_iteration`` and ``clf.best_ntree_limit``.
+            Deprecated, use `n_iter_no_change` in constructor instead.
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation metric
             measured on the validation set to stderr.
@@ -1578,7 +1619,9 @@ class XGBRanker(XGBModel, XGBRankerMixIn):
         evals_result = {}
         params = self.get_xgb_params()
 
-        model, feval, params = self._configure_fit(xgb_model, eval_metric, params)
+        model, feval, params, early_stopping_rounds = self._configure_fit(
+            xgb_model, eval_metric, params, early_stopping_rounds
+        )
         if callable(feval):
             raise ValueError(
                 'Custom evaluation metric is not yet supported for XGBRanker.'

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -151,41 +151,44 @@ __model_doc = '''
     importance_type: string, default "gain"
         The feature importance type for the feature_importances\\_ property:
         either "gain", "weight", "cover", "total_gain" or "total_cover".
-    gpu_id :
+    gpu_id : Optional[int]
         Device ordinal.
-    validate_parameters :
+    validate_parameters : Optional[bool]
         Give warnings for unknown parameter.
-    scoring :
-        Metric used for monitoring the training result and early stopping.  This can be a
-        string of list of string names of predefined metric in XGBoost (See
+    eval_metric : Optional[Union[str, List[str], Callable]]
+        Metric used for monitoring the training result and early stopping.  It can be a
+        string or list of strings as names of predefined metric in XGBoost (See
         doc/parameter.rst), one of the metrics in :py:mod:`sklearn.metrics`, or any other
-        user defined metric that looks like `sklearn.metrics`.  Unlike scikit-learn, when
-        a callable object is provided in scikit-learn interface, it's assumed to be a cost
-        function and XGBoost will minimize the result by default. For advanced usage on
-        Early stopping like directly choosing to maximize instead of minimize, see
-        :py:obj:`xgboost.callbacks.EarlyStopping`.
+        user defined metric that looks like `sklearn.metrics`.
 
-        .. versionadded:: 1.5.0
+        Unlike scikit-learn `scoring` parameter, when a callable object is provided, it's
+        assumed to be a cost function and by default XGBoost will minimize the result
+        during early stopping.
+
+        For advanced usage on Early stopping like directly choosing to maximize instead of
+        minimize, see :py:obj:`xgboost.callback.EarlyStopping`.
+
+        .. versionadded:: 1.4.0
 
         .. note::
 
-            This parameter replaces `eval_metric` in
-            :py:meth:`xgboost.sklearn.XGBModel.fit` method.
+             This parameter replaces `eval_metric` in
+             :py:meth:`xgboost.sklearn.XGBModel.fit` method.
 
-     n_iter_no_change :
+    early_stopping_rounds : Optional[int]
         Activates early stopping. Validation metric needs to improve at least once in
-        every **n_iter_no_change** round(s) to continue training.  Requires at least
+        every **early_stopping_rounds** round(s) to continue training.  Requires at least
         one item in **eval_set** in :py:meth:`xgboost.sklearn.XGBModel.fit`.
 
         The method returns the model from the last iteration (not the best one).  If
         there's more than one item in **eval_set**, the last entry will be used for early
-        stopping.  If there's more than one metric in **scoring**, the last metric will be
-        used for early stopping.
+        stopping.  If there's more than one metric in **eval_metric**, the last metric
+        will be used for early stopping.
 
         If early stopping occurs, the model will have three additional fields:
         ``clf.best_score``, ``clf.best_iteration`` and ``clf.best_ntree_limit``.
 
-        .. versionadded:: 1.5.0
+        .. versionadded:: 1.4.0
 
         .. note::
 
@@ -396,8 +399,8 @@ class XGBModel(XGBModelBase):
         importance_type="gain",
         gpu_id=None,
         validate_parameters=None,
-        scoring: Optional[str, Callable] = None,
-        n_iter_no_change: Optional[int] = None,
+        eval_metric=None,
+        early_stopping_rounds=None,
         **kwargs
     ):
         if not SKLEARN_INSTALLED:
@@ -433,8 +436,8 @@ class XGBModel(XGBModelBase):
         self.importance_type = importance_type
         self.gpu_id = gpu_id
         self.validate_parameters = validate_parameters
-        self.scoring = scoring
-        self.n_iter_no_change = n_iter_no_change
+        self.eval_metric = eval_metric
+        self.early_stopping_rounds = early_stopping_rounds
 
     def _more_tags(self):
         '''Tags used for scikit-learn data validation.'''
@@ -543,8 +546,7 @@ class XGBModel(XGBModelBase):
             'missing',
             'n_estimators',
             'use_label_encoder',
-            "scoring",
-            "n_iter_no_change"
+            "early_stopping_rounds"
         }
         filtered = dict()
         for k, v in params.items():
@@ -642,14 +644,15 @@ class XGBModel(XGBModelBase):
 
         if eval_metric is not None:
             warnings.warn(
-                "eval_metric for `fit` method is deprecated, use `scoring` in "
+                "eval_metric for `fit` method is deprecated, use `eval_metric` in "
                 "constructor or `set_params` instead.",
                 UserWarning
             )
         feval = _metric_decorator(eval_metric) if callable(eval_metric) else None
-        if self.scoring is not None and feval is not None:
-            warnings.warn("Overriding `eval_metric` with `scoring`", UserWarning)
-        feval = _metric_decorator(self.scoring) if callable(self.scoring) else feval
+        if self.eval_metric is not None and feval is not None:
+            warnings.warn("Overriding `eval_metric` with `eval_metric`", UserWarning)
+        if callable(self.eval_metric):
+            feval = _metric_decorator(self.eval_metric)
 
         if eval_metric is not None:
             if callable(eval_metric):
@@ -659,13 +662,13 @@ class XGBModel(XGBModelBase):
 
         if early_stopping_rounds is not None:
             warnings.warn(
-                "`early_stopping_rounds` is deprecated, use `n_iter_no_change` "
-                "in constructor instead.",
+                "`early_stopping_rounds` is deprecated, use `early_stopping_rounds` "
+                "in constructor or `set_params` instead.",
                 UserWarning,
             )
         early_stopping_rounds = (
-            self.n_iter_no_change
-            if self.n_iter_no_change is not None
+            self.early_stopping_rounds
+            if self.early_stopping_rounds is not None
             else early_stopping_rounds
         )
 
@@ -718,9 +721,9 @@ class XGBModel(XGBModelBase):
             metrics will be computed.
             Validation metrics will help us track the performance of the model.
         eval_metric : str, list of str, or callable, optional
-            Deprecated, use `scoring` in constructor instead.
+            Deprecated, use `eval_metric` in constructor or `set_params` instead.
         early_stopping_rounds : int
-            Deprecated, use `n_iter_no_change` in constructor instead.
+            Deprecated, use `early_stopping_rounds` in constructor instead.
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation metric
             measured on the validation set to stderr.
@@ -1329,8 +1332,8 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         If **eval_set** is passed to the `fit` function, you can call
         ``evals_result()`` to get evaluation results for all passed **eval_sets**.
 
-        When **scoring** is also passed as a parameter, the **evals_result** will contain
-        the **scoring** passed to the `fit` function.
+        When **eval_metric** is also passed as a parameter, the **evals_result** will
+        contain the **eval_metric** passed to the `fit` function.
 
         Returns
         -------
@@ -1342,7 +1345,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
         .. code-block:: python
 
             param_dist = {
-                'objective':'binary:logistic', 'n_estimators':2, scoring="logloss"
+                'objective':'binary:logistic', 'n_estimators':2, eval_metric="logloss"
             }
 
             clf = xgb.XGBClassifier(**param_dist)
@@ -1359,6 +1362,7 @@ class XGBClassifier(XGBModel, XGBClassifierBase):
 
             {'validation_0': {'logloss': ['0.604835', '0.531479']},
             'validation_1': {'logloss': ['0.41965', '0.17686']}}
+
         """
         if self.evals_result_:
             evals_result = self.evals_result_
@@ -1442,15 +1446,15 @@ class XGBRFRegressor(XGBRegressor):
     'Implementation of the Scikit-Learn API for XGBoost Ranking.',
     ['estimators', 'model'],
     end_note='''
-        Note
-        ----
-        A custom objective function is currently not supported by XGBRanker.
-        Likewise, a custom metric function is not supported either.
+        .. note::
 
-        Note
-        ----
-        Query group information is required for ranking tasks by either using the `group`
-        parameter or `qid` parameter in `fit` method.
+            A custom objective function is currently not supported by XGBRanker.
+            Likewise, a custom metric function is not supported either.
+
+        .. note::
+
+            Query group information is required for ranking tasks by either using the
+            `group` parameter or `qid` parameter in `fit` method.
 
         Before fitting the model, your data need to be sorted by query group. When fitting
         the model, you need to provide an additional array that contains the size of each
@@ -1555,7 +1559,7 @@ class XGBRanker(XGBModel, XGBRankerMixIn):
         eval_metric : str, list of str, optional
             The custom evaluation metric is not yet supported for the ranker.
         early_stopping_rounds : int
-            Deprecated, use `n_iter_no_change` in constructor instead.
+            Deprecated, use `early_stopping_rounds` in constructor instead.
         verbose : bool
             If `verbose` and an evaluation set is used, writes the evaluation metric
             measured on the validation set to stderr.

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -638,7 +638,7 @@ class XGBModel(XGBModelBase):
     ) -> Tuple[Booster, Optional[Metric], Dict[str, Any]]:
         # pylint: disable=protected-access
         model = booster
-        if hasattr(model, '_Booster'):
+        if hasattr(model, "_Booster"):
             # Handle the case when xgb_model is a sklearn model object
             model = model._Booster
 
@@ -646,7 +646,7 @@ class XGBModel(XGBModelBase):
             warnings.warn(
                 "eval_metric for `fit` method is deprecated, use `eval_metric` in "
                 "constructor or `set_params` instead.",
-                UserWarning
+                UserWarning,
             )
         feval = _metric_decorator(eval_metric) if callable(eval_metric) else None
         if self.eval_metric is not None and feval is not None:
@@ -666,13 +666,19 @@ class XGBModel(XGBModelBase):
                 "in constructor or `set_params` instead.",
                 UserWarning,
             )
+            if (
+                self.early_stopping_rounds is not None
+                and self.early_stopping_rounds != early_stopping_rounds
+            ):
+                raise ValueError("2 different `early_stopping_rounds` are provided.")
+
         early_stopping_rounds = (
             self.early_stopping_rounds
             if self.early_stopping_rounds is not None
             else early_stopping_rounds
         )
 
-        return model, feval, params
+        return model, feval, params, early_stopping_rounds
 
     def _set_evaluation_result(self, evals_result: Optional[dict]) -> None:
         if evals_result:

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -129,10 +129,11 @@ class TestCallbacks:
     def test_early_stopping_skl(self):
         from sklearn.datasets import load_breast_cancer
         X, y = load_breast_cancer(return_X_y=True)
-        cls = xgb.XGBClassifier()
         early_stopping_rounds = 5
-        cls.fit(X, y, eval_set=[(X, y)],
-                early_stopping_rounds=early_stopping_rounds, eval_metric='error')
+        cls = xgb.XGBClassifier(
+            early_stopping_rounds=early_stopping_rounds, eval_metric='error'
+        )
+        cls.fit(X, y, eval_set=[(X, y)])
         booster = cls.get_booster()
         dump = booster.get_dump(dump_format='json')
         assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
@@ -140,12 +141,10 @@ class TestCallbacks:
     def test_early_stopping_custom_eval_skl(self):
         from sklearn.datasets import load_breast_cancer
         X, y = load_breast_cancer(return_X_y=True)
-        cls = xgb.XGBClassifier()
+        cls = xgb.XGBClassifier(eval_metric=tm.eval_error_metric_skl)
         early_stopping_rounds = 5
         early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds)
-        cls.fit(X, y, eval_set=[(X, y)],
-                eval_metric=tm.eval_error_metric_skl,
-                callbacks=[early_stop])
+        cls.fit(X, y, eval_set=[(X, y)], callbacks=[early_stop])
         booster = cls.get_booster()
         dump = booster.get_dump(dump_format='json')
         assert len(dump) - booster.best_iteration == early_stopping_rounds + 1
@@ -154,41 +153,40 @@ class TestCallbacks:
         from sklearn.datasets import load_breast_cancer
         X, y = load_breast_cancer(return_X_y=True)
         n_estimators = 100
-        cls = xgb.XGBClassifier(n_estimators=n_estimators)
+        cls = xgb.XGBClassifier(
+            n_estimators=n_estimators, eval_metric=tm.eval_error_metric_skl
+        )
         early_stopping_rounds = 5
         early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
                                                 save_best=True)
-        cls.fit(X, y, eval_set=[(X, y)],
-                eval_metric=tm.eval_error_metric_skl, callbacks=[early_stop])
+        cls.fit(X, y, eval_set=[(X, y)], callbacks=[early_stop])
         booster = cls.get_booster()
         dump = booster.get_dump(dump_format='json')
         assert len(dump) == booster.best_iteration + 1
 
         early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
                                                 save_best=True)
-        cls = xgb.XGBClassifier(booster='gblinear', n_estimators=10)
+        cls = xgb.XGBClassifier(
+            booster='gblinear', n_estimators=10, eval_metric=tm.eval_error_metric_skl
+        )
         with pytest.raises(ValueError):
-            cls.fit(X, y, eval_set=[(X, y)], eval_metric=tm.eval_error_metric_skl,
-                    callbacks=[early_stop])
+            cls.fit(X, y, eval_set=[(X, y)], callbacks=[early_stop])
 
         # No error
         early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
                                                 save_best=False)
-        xgb.XGBClassifier(booster='gblinear', n_estimators=10).fit(
-            X, y, eval_set=[(X, y)],
-            eval_metric=tm.eval_error_metric_skl,
-            callbacks=[early_stop])
+        xgb.XGBClassifier(
+            booster='gblinear', n_estimators=10, eval_metric=tm.eval_error_metric_skl
+        ).fit(X, y, eval_set=[(X, y)], callbacks=[early_stop])
 
     def test_early_stopping_continuation(self):
         from sklearn.datasets import load_breast_cancer
         X, y = load_breast_cancer(return_X_y=True)
-        cls = xgb.XGBClassifier()
+        cls = xgb.XGBClassifier(eval_metric=tm.eval_error_metric_skl)
         early_stopping_rounds = 5
         early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
                                                 save_best=True)
-        cls.fit(X, y, eval_set=[(X, y)],
-                eval_metric=tm.eval_error_metric_skl,
-                callbacks=[early_stop])
+        cls.fit(X, y, eval_set=[(X, y)], callbacks=[early_stop])
         booster = cls.get_booster()
         assert booster.num_boosted_rounds() == booster.best_iteration + 1
 
@@ -199,8 +197,8 @@ class TestCallbacks:
             cls.load_model(path)
             assert cls._Booster is not None
             early_stopping_rounds = 3
-            cls.fit(X, y, eval_set=[(X, y)], eval_metric=tm.eval_error_metric_skl,
-                    early_stopping_rounds=early_stopping_rounds)
+            cls.set_params(eval_metric=tm.eval_error_metric_skl)
+            cls.fit(X, y, eval_set=[(X, y)], early_stopping_rounds=early_stopping_rounds)
             booster = cls.get_booster()
             assert booster.num_boosted_rounds() == \
                 booster.best_iteration + early_stopping_rounds + 1

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -144,7 +144,7 @@ class TestCallbacks:
         early_stopping_rounds = 5
         early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds)
         cls.fit(X, y, eval_set=[(X, y)],
-                eval_metric=tm.eval_error_metric,
+                eval_metric=tm.eval_error_metric_skl,
                 callbacks=[early_stop])
         booster = cls.get_booster()
         dump = booster.get_dump(dump_format='json')
@@ -159,7 +159,7 @@ class TestCallbacks:
         early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
                                                 save_best=True)
         cls.fit(X, y, eval_set=[(X, y)],
-                eval_metric=tm.eval_error_metric, callbacks=[early_stop])
+                eval_metric=tm.eval_error_metric_skl, callbacks=[early_stop])
         booster = cls.get_booster()
         dump = booster.get_dump(dump_format='json')
         assert len(dump) == booster.best_iteration + 1
@@ -168,7 +168,7 @@ class TestCallbacks:
                                                 save_best=True)
         cls = xgb.XGBClassifier(booster='gblinear', n_estimators=10)
         with pytest.raises(ValueError):
-            cls.fit(X, y, eval_set=[(X, y)], eval_metric=tm.eval_error_metric,
+            cls.fit(X, y, eval_set=[(X, y)], eval_metric=tm.eval_error_metric_skl,
                     callbacks=[early_stop])
 
         # No error
@@ -176,7 +176,7 @@ class TestCallbacks:
                                                 save_best=False)
         xgb.XGBClassifier(booster='gblinear', n_estimators=10).fit(
             X, y, eval_set=[(X, y)],
-            eval_metric=tm.eval_error_metric,
+            eval_metric=tm.eval_error_metric_skl,
             callbacks=[early_stop])
 
     def test_early_stopping_continuation(self):
@@ -187,7 +187,7 @@ class TestCallbacks:
         early_stop = xgb.callback.EarlyStopping(rounds=early_stopping_rounds,
                                                 save_best=True)
         cls.fit(X, y, eval_set=[(X, y)],
-                eval_metric=tm.eval_error_metric,
+                eval_metric=tm.eval_error_metric_skl,
                 callbacks=[early_stop])
         booster = cls.get_booster()
         assert booster.num_boosted_rounds() == booster.best_iteration + 1
@@ -199,7 +199,7 @@ class TestCallbacks:
             cls.load_model(path)
             assert cls._Booster is not None
             early_stopping_rounds = 3
-            cls.fit(X, y, eval_set=[(X, y)], eval_metric=tm.eval_error_metric,
+            cls.fit(X, y, eval_set=[(X, y)], eval_metric=tm.eval_error_metric_skl,
                     early_stopping_rounds=early_stopping_rounds)
             booster = cls.get_booster()
             assert booster.num_boosted_rounds() == \

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -1355,7 +1355,7 @@ class TestDaskCallbacks:
                                          n_estimators=1000)
         cls.client = client
         cls.fit(X, y, early_stopping_rounds=early_stopping_rounds,
-                eval_set=[(valid_X, valid_y)], eval_metric=tm.eval_error_metric)
+                eval_set=[(valid_X, valid_y)], eval_metric=tm.eval_error_metric_skl)
         booster = cls.get_booster()
         dump = booster.get_dump(dump_format='json')
         assert len(dump) - booster.best_iteration == early_stopping_rounds + 1

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -269,6 +269,7 @@ def non_increasing(L, tolerance=1e-4):
 
 
 def eval_error_metric(predt, dtrain: xgb.DMatrix):
+    """Evaluation metric for xgb.train"""
     label = dtrain.get_label()
     r = np.zeros(predt.shape)
     gt = predt > 0.5
@@ -276,6 +277,16 @@ def eval_error_metric(predt, dtrain: xgb.DMatrix):
     le = predt <= 0.5
     r[le] = label[le]
     return 'CustomErr', np.sum(r)
+
+
+def eval_error_metric_skl(y_true, y_score):
+    """Evaluation metric that looks like metrics provided by sklearn."""
+    r = np.zeros(y_score.shape)
+    gt = y_score > 0.5
+    r[gt] = 1 - y_true[gt]
+    le = y_score <= 0.5
+    r[le] = y_true[le]
+    return np.sum(r)
 
 
 def softmax(x):


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/6735.

* These 2 parameters are now model parameters that can be set at constructor and
`set_params` method.
* Define a decorator.

TODO
- [ ] Make it non-breaking.