### PR TITLE
[JVM] Update jvm dev Dockefile and shell script

### DIFF
--- a/jvm-packages/dev/Dockerfile
+++ b/jvm-packages/dev/Dockerfile
@@ -16,21 +16,21 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM centos:6
+FROM centos:7
 
 # Install all basic requirements
 RUN \
     yum -y update && \
-    yum install -y tar unzip wget xz git centos-release-scl yum-utils java-1.8.0-openjdk-devel && \
+    yum install -y bzip2 make tar unzip wget xz git centos-release-scl yum-utils java-1.8.0-openjdk-devel && \
     yum-config-manager --enable centos-sclo-rh-testing && \
     yum -y update && \
-    yum install -y devtoolset-6-gcc devtoolset-6-binutils devtoolset-6-gcc-c++ && \
+    yum install -y devtoolset-7-gcc devtoolset-7-binutils devtoolset-7-gcc-c++ && \
     # Python
     wget https://repo.continuum.io/miniconda/Miniconda3-4.5.12-Linux-x86_64.sh && \
     bash Miniconda3-4.5.12-Linux-x86_64.sh -b -p /opt/python && \
     # CMake
-    wget -nv -nc https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.sh --no-check-certificate && \
-    bash cmake-3.12.0-Linux-x86_64.sh --skip-license --prefix=/usr && \
+    wget -nv -nc https://cmake.org/files/v3.18/cmake-3.18.3-Linux-x86_64.sh --no-check-certificate && \
+    bash cmake-3.18.3-Linux-x86_64.sh --skip-license --prefix=/usr && \
     # Maven
     wget https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz && \
     tar xvf apache-maven-3.6.1-bin.tar.gz -C /opt && \
@@ -38,9 +38,9 @@ RUN \
 
 # Set the required environment variables
 ENV PATH=/opt/python/bin:/opt/maven/bin:$PATH
-ENV CC=/opt/rh/devtoolset-6/root/usr/bin/gcc
-ENV CXX=/opt/rh/devtoolset-6/root/usr/bin/c++
-ENV CPP=/opt/rh/devtoolset-6/root/usr/bin/cpp
+ENV CC=/opt/rh/devtoolset-7/root/usr/bin/gcc
+ENV CXX=/opt/rh/devtoolset-7/root/usr/bin/c++
+ENV CPP=/opt/rh/devtoolset-7/root/usr/bin/cpp
 ENV JAVA_HOME=/usr/lib/jvm/java
 
 # Install Python packages

--- a/jvm-packages/dev/build-linux.cmd
+++ b/jvm-packages/dev/build-linux.cmd
@@ -34,9 +34,9 @@ docker build -t dmlc/xgboost4j-build %BASEDIR%
 docker run^
  -it^
  --rm^
- --memory 8g^
- --env JAVA_OPTS="-Xmx6g"^
- --env MAVEN_OPTS="-Xmx2g"^
+ --memory 12g^
+ --env JAVA_OPTS="-Xmx9g"^
+ --env MAVEN_OPTS="-Xmx3g"^
  --ulimit core=-1^
  --volume %BASEDIR%\..\..:/xgboost^
  --volume %M2DIR%:/root/.m2^

--- a/jvm-packages/dev/build-linux.sh
+++ b/jvm-packages/dev/build-linux.sh
@@ -24,9 +24,9 @@ docker build -t dmlc/xgboost4j-build "${BASEDIR}" # build and tag the Dockerfile
 docker run \
   -it \
   --rm  \
-  --memory 8g \
-  --env JAVA_OPTS="-Xmx6g" \
-  --env MAVEN_OPTS="-Xmx2g" \
+  --memory 12g \
+  --env JAVA_OPTS="-Xmx9g" \
+  --env MAVEN_OPTS="-Xmx3g" \
   --ulimit core=-1 \
   --volume "${BASEDIR}/../..":/xgboost \
   --volume "${BASEDIR}/.m2":/root/.m2 \


### PR DESCRIPTION
Since centos:6 has come to its end of life. Bump the centos version to centos:7  and meanwhile bump the devtoolset to 7 as well