### PR TITLE
Hide symbols in CI build + hide symbols for C and CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,9 @@ endif (USE_CUDA)
 #-- Hide all C++ symbols
 if (HIDE_CXX_SYMBOLS)
   foreach(target objxgboost xgboost dmlc)
+    set_target_properties(${target} PROPERTIES C_VISIBILITY_PRESET hidden)
     set_target_properties(${target} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    set_target_properties(${target} PROPERTIES CUDA_VISIBILITY_PRESET hidden)
   endforeach()
 endif (HIDE_CXX_SYMBOLS)
 

--- a/tests/ci_build/build_via_cmake.sh
+++ b/tests/ci_build/build_via_cmake.sh
@@ -17,7 +17,7 @@ fi
 rm -rf build
 mkdir build
 cd build
-cmake .. ${cmake_args} -DGOOGLE_TEST=ON -DUSE_DMLC_GTEST=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DENABLE_ALL_WARNINGS=ON -GNinja ${cmake_prefix_flag}
+cmake .. ${cmake_args} -DGOOGLE_TEST=ON -DUSE_DMLC_GTEST=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DENABLE_ALL_WARNINGS=ON -GNinja ${cmake_prefix_flag} -DHIDE_CXX_SYMBOLS=ON
 ninja clean
 time ninja -v
 cd ..


### PR DESCRIPTION
Recently I ran into an issue where `cub::DeviceRadixSort` runs into a cuda invalid value error when used with cuDF.  I believe it's due to mixed C++ symbols exported from both libraries.  ~This might also be the cause of https://github.com/rapidsai/cudf/issues/7722~.  This PR enables "hidden" visibility for all c++ symbols by default on our CI build.