### PR TITLE
oneAPI DPC++-based plugin: Data Management

### DIFF
--- a/plugin/updater_oneapi/data_oneapi.h
+++ b/plugin/updater_oneapi/data_oneapi.h
@@ -117,9 +117,7 @@ public:
         qu.memcpy(data_old.get(), data_.get(), size_old);
       }
       if (size_new > size_old) {
-        qu.submit([&](cl::sycl::handler& cgh) {
-          cgh.fill(data_.get() + size_old, v, size_new - size_old);
-        }).wait();
+        qu.fill(data_.get() + size_old, v, size_new - size_old);
       }
     }
   }

--- a/plugin/updater_oneapi/data_oneapi.h
+++ b/plugin/updater_oneapi/data_oneapi.h
@@ -99,9 +99,7 @@ public:
       size_ = size_new;
       data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
       if (size_old > 0) {
-        qu.submit([&](cl::sycl::handler& cgh) {
-          cgh.memcpy(data_old.get(), data_.get(), size_old);
-        }).wait();
+        qu.memcpy(data_old.get(), data_.get(), size_old);
       }
     }
   }
@@ -116,9 +114,7 @@ public:
       size_ = size_new;
       data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
       if (size_old > 0) {
-        qu.submit([&](cl::sycl::handler& cgh) {
-          cgh.memcpy(data_old.get(), data_.get(), size_old);
-        }).wait();
+        qu.memcpy(data_old.get(), data_.get(), size_old);
       }
       if (size_new > size_old) {
         qu.submit([&](cl::sycl::handler& cgh) {

--- a/plugin/updater_oneapi/data_oneapi.h
+++ b/plugin/updater_oneapi/data_oneapi.h
@@ -47,9 +47,7 @@ public:
 
   USMVector(cl::sycl::queue qu, size_t size, T v) : qu_(qu), size_(size) {
     data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
-    qu.submit([&](cl::sycl::handler& cgh) {
-      cgh.fill(data_.get(), v, size_);
-    }).wait();
+    qu_.fill(data_.get(), v, size_);
   }
 
   USMVector(cl::sycl::queue qu, const std::vector<T> &vec) : qu_(qu) {
@@ -99,7 +97,7 @@ public:
       size_ = size_new;
       data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
       if (size_old > 0) {
-        qu.memcpy(data_old.get(), data_.get(), size_old);
+        qu_.memcpy(data_old.get(), data_.get(), size_old);
       }
     }
   }
@@ -114,10 +112,10 @@ public:
       size_ = size_new;
       data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
       if (size_old > 0) {
-        qu.memcpy(data_old.get(), data_.get(), size_old);
+        qu_.memcpy(data_old.get(), data_.get(), size_old);
       }
       if (size_new > size_old) {
-        qu.fill(data_.get() + size_old, v, size_new - size_old);
+        qu_.fill(data_.get() + size_old, v, size_new - size_old);
       }
     }
   }

--- a/plugin/updater_oneapi/data_oneapi.h
+++ b/plugin/updater_oneapi/data_oneapi.h
@@ -1,0 +1,228 @@
+/*!
+ * Copyright by Contributors 2017-2020
+ */
+#ifndef XGBOOST_COMMON_DATA_ONEAPI_H_
+#define XGBOOST_COMMON_DATA_ONEAPI_H_
+
+#include <cstddef>
+#include <limits>
+#include <mutex>
+
+#include "xgboost/base.h"
+#include "xgboost/data.h"
+#include "xgboost/logging.h"
+#include "xgboost/host_device_vector.h"
+
+#include "CL/sycl.hpp"
+
+namespace xgboost {
+
+template <typename T>
+class USMDeleter {
+public:
+  explicit USMDeleter(cl::sycl::queue qu) : qu_(qu) {}
+
+  void operator()(T* data) const {
+    cl::sycl::free(data, qu_);    
+  }
+
+private:
+  cl::sycl::queue qu_;
+};
+
+
+template <typename T>
+class USMVector {
+  static_assert(std::is_standard_layout<T>::value, "USMVector admits only POD types");
+
+public:
+  USMVector() : size_(0), data_(nullptr) {}
+
+  USMVector(cl::sycl::queue qu) : qu_(qu), size_(0), data_(nullptr) {}
+
+  USMVector(cl::sycl::queue qu, size_t size) : qu_(qu), size_(size) {
+    data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
+  }
+
+  USMVector(cl::sycl::queue qu, size_t size, T v) : qu_(qu), size_(size) {
+    data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
+    std::fill(data_.get(), data_.get() + size_, v);
+    // switch to handler fill after moving to new compiler
+    /*
+    qu.submit([&](cl::sycl::handler& cgh) {
+      cgh.fill(data_.get(), v, size_);
+    }).wait();
+    */
+  }
+
+  USMVector(cl::sycl::queue qu, const std::vector<T> &vec) : qu_(qu) {
+    size_ = vec.size();
+    data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
+    std::copy(vec.begin (), vec.end (), data_.get());
+  }
+
+  USMVector(const USMVector<T>& other) : qu_(other.qu_), size_(other.size_), data_(other.data_) {
+  }
+
+  ~USMVector() {
+  }
+
+  USMVector<T>& operator=(const USMVector<T>& other) {
+    qu_ = other.qu_;
+    size_ = other.size_;
+    data_ = other.data_;
+    return *this;
+  }
+
+  T* Data() { return data_.get(); }
+  const T* DataConst() const { return data_.get(); }
+
+  size_t Size() const { return size_; }
+
+  T& operator[] (size_t i) { return data_.get()[i]; }
+  const T& operator[] (size_t i) const { return data_.get()[i]; }
+
+  T* Begin () const { return data_.get(); }
+  T* End () const { return data_.get() + size_; }
+
+  bool Empty() const { return (size_ == 0); }
+
+  void Clear() {
+    data_.reset();
+    size_ = 0;
+  }
+
+  void Resize(cl::sycl::queue qu, size_t new_size) {
+    qu_ = qu;
+    if (new_size <= size_) {
+      size_ = new_size;
+    } else {
+      size_t old_size = size_;
+      auto data_old = data_;
+      size_ = new_size;
+      data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
+      if (old_size > 0) {
+        std::copy(data_old.get(), data_old.get() + old_size, data_.get());
+        // switch to handler copy after moving to new compiler
+        /*
+        qu.submit([&](cl::sycl::handler& cgh) {
+          cgh.copy(data_old.get(), data_.get(), old_size);
+        }).wait();
+        */
+      }
+    }
+  }
+
+  void Resize(cl::sycl::queue qu, size_t new_size, T v) {
+    qu_ = qu;
+    if (new_size <= size_) {
+      size_ = new_size;
+    } else {
+      size_t old_size = size_;
+      auto data_old = data_;
+      size_ = new_size;
+      data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
+      if (old_size > 0) {
+        std::copy(data_old.get(), data_old.get() + old_size, data_.get());
+        // switch to handler copy after moving to new compiler
+        /*
+        qu.submit([&](cl::sycl::handler& cgh) {
+          cgh.copy(data_old.get(), data_.get(), old_size);
+        }).wait();
+        */
+      }
+      if (new_size > old_size) {
+        std::fill(data_.get() + old_size, data_.get() + new_size, v);
+      }
+    }
+  }
+
+  void Init(cl::sycl::queue qu, const std::vector<T> &vec) {
+    qu_ = qu;
+    size_ = vec.size();
+    data_ = std::shared_ptr<T>(cl::sycl::malloc_shared<T>(size_, qu_), USMDeleter<T>(qu_));
+    std::copy(vec.begin(), vec.end(), data_.get());
+  }
+
+  using value_type = T;  // NOLINT
+
+private:
+  cl::sycl::queue qu_;
+  size_t size_;
+  std::shared_ptr<T> data_;
+};
+
+/*! \brief Element from a sparse vector */
+struct EntryOneAPI {
+  /*! \brief feature index */
+  bst_feature_t index;
+  /*! \brief feature value */
+  bst_float fvalue;
+  /*! \brief default constructor */
+  EntryOneAPI() = default;
+  /*!
+   * \brief constructor with index and value
+   * \param index The feature or row index.
+   * \param fvalue The feature value.
+   */
+  EntryOneAPI(bst_feature_t index, bst_float fvalue) : index(index), fvalue(fvalue) {}
+
+  EntryOneAPI(const Entry& entry) : index(entry.index), fvalue(entry.fvalue) {}
+
+  /*! \brief reversely compare feature values */
+  inline static bool CmpValue(const EntryOneAPI& a, const EntryOneAPI& b) {
+    return a.fvalue < b.fvalue;
+  }
+  inline bool operator==(const EntryOneAPI& other) const {
+    return (this->index == other.index && this->fvalue == other.fvalue);
+  }
+};
+
+struct DeviceMatrixOneAPI {
+  DMatrix* p_mat;  // Pointer to the original matrix on the host
+  cl::sycl::queue qu_;
+  USMVector<size_t> row_ptr;
+  USMVector<EntryOneAPI> data;
+  size_t total_offset;
+
+  DeviceMatrixOneAPI(cl::sycl::queue qu, DMatrix* dmat) : p_mat(dmat), qu_(qu) {
+    size_t num_row = 0;
+    size_t num_nonzero = 0;
+    for (auto &batch : dmat->GetBatches<SparsePage>()) {
+      const auto& data_vec = batch.data.HostVector();
+      const auto& offset_vec = batch.offset.HostVector();
+      num_nonzero += data_vec.size();
+      num_row += batch.Size();
+    }
+
+    row_ptr.Resize(qu_, num_row + 1);
+    data.Resize(qu_, num_nonzero);
+
+    size_t data_offset = 0;
+    for (auto &batch : dmat->GetBatches<SparsePage>()) {
+      const auto& data_vec = batch.data.HostVector();
+      const auto& offset_vec = batch.offset.HostVector();
+      size_t batch_size = batch.Size();
+      if (batch_size > 0) {
+        std::copy(offset_vec.data(), offset_vec.data() + batch_size,
+                  row_ptr.Data() + batch.base_rowid);
+        if (batch.base_rowid > 0) {
+          for(size_t i = 0; i < batch_size; i++)
+            row_ptr[i + batch.base_rowid] += batch.base_rowid;
+        }
+        std::copy(data_vec.data(), data_vec.data() + offset_vec[batch_size],
+                  data.Data() + data_offset);
+        data_offset += offset_vec[batch_size];
+      }
+    }
+    row_ptr[num_row] = data_offset;
+    total_offset = data_offset;
+  }
+
+  ~DeviceMatrixOneAPI() {
+  }
+};
+
+}  // namespace xgboost
+
+#endif

--- a/plugin/updater_oneapi/row_set_oneapi.h
+++ b/plugin/updater_oneapi/row_set_oneapi.h
@@ -1,0 +1,225 @@
+/*!
+ * Copyright 2017-2020 XGBoost contributors
+ */
+#ifndef XGBOOST_COMMON_ROW_SET_ONEAPI_H_
+#define XGBOOST_COMMON_ROW_SET_ONEAPI_H_
+
+#include <xgboost/data.h>
+#include <algorithm>
+#include <vector>
+#include <utility>
+
+#include "data_oneapi.h"
+
+#include "CL/sycl.hpp"
+
+namespace xgboost {
+namespace common {
+
+/*! \brief collection of rowset */
+class RowSetCollectionOneAPI {
+ public:
+  /*! \brief data structure to store an instance set, a subset of
+   *  rows (instances) associated with a particular node in a decision
+   *  tree. */
+  struct Elem {
+    const size_t* begin{nullptr};
+    const size_t* end{nullptr};
+    bst_node_t node_id{-1};
+      // id of node associated with this instance set; -1 means uninitialized
+    Elem()
+         = default;
+    Elem(const size_t* begin,
+         const size_t* end,
+         bst_node_t node_id = -1)
+        : begin(begin), end(end), node_id(node_id) {}
+
+    inline size_t Size() const {
+      return end - begin;
+    }
+  };
+  /* \brief specifies how to split a rowset into two */
+  struct Split {
+    std::vector<size_t> left;
+    std::vector<size_t> right;
+  };
+
+  inline std::vector<Elem>::const_iterator begin() const {  // NOLINT
+    return elem_of_each_node_.begin();
+  }
+
+  inline std::vector<Elem>::const_iterator end() const {  // NOLINT
+    return elem_of_each_node_.end();
+  }
+
+  /*! \brief return corresponding element set given the node_id */
+  inline const Elem& operator[](unsigned node_id) const {
+    const Elem& e = elem_of_each_node_[node_id];
+    CHECK(e.begin != nullptr)
+        << "access element that is not in the set";
+    return e;
+  }
+
+  /*! \brief return corresponding element set given the node_id */
+  inline Elem& operator[](unsigned node_id) {
+    Elem& e = elem_of_each_node_[node_id];
+    return e;
+  }
+
+  // clear up things
+  inline void Clear() {
+    elem_of_each_node_.clear();
+  }
+  // initialize node id 0->everything
+  inline void Init() {
+    CHECK_EQ(elem_of_each_node_.size(), 0U);
+
+    if (row_indices_.Empty()) {  // edge case: empty instance set
+      // assign arbitrary address here, to bypass nullptr check
+      // (nullptr usually indicates a nonexistent rowset, but we want to
+      //  indicate a valid rowset that happens to have zero length and occupies
+      //  the whole instance set)
+      // this is okay, as BuildHist will compute (end-begin) as the set size
+      const size_t* begin = reinterpret_cast<size_t*>(20);
+      const size_t* end = begin;
+      elem_of_each_node_.emplace_back(Elem(begin, end, 0));
+      return;
+    }
+
+    const size_t* begin = row_indices_.Begin();
+    const size_t* end = row_indices_.End();
+    elem_of_each_node_.emplace_back(Elem(begin, end, 0));
+  }
+
+  USMVector<size_t>& Data() { return row_indices_; }
+
+  // split rowset into two
+  inline void AddSplit(unsigned node_id,
+                       unsigned left_node_id,
+                       unsigned right_node_id,
+                       size_t n_left,
+                       size_t n_right) {
+    const Elem e = elem_of_each_node_[node_id];
+    CHECK(e.begin != nullptr);
+    size_t* all_begin = row_indices_.Begin();
+    size_t* begin = all_begin + (e.begin - all_begin);
+
+    CHECK_EQ(n_left + n_right, e.Size());
+    CHECK_LE(begin + n_left, e.end);
+    CHECK_EQ(begin + n_left + n_right, e.end);
+
+    if (left_node_id >= elem_of_each_node_.size()) {
+      elem_of_each_node_.resize(left_node_id + 1, Elem(nullptr, nullptr, -1));
+    }
+    if (right_node_id >= elem_of_each_node_.size()) {
+      elem_of_each_node_.resize(right_node_id + 1, Elem(nullptr, nullptr, -1));
+    }
+
+    elem_of_each_node_[left_node_id] = Elem(begin, begin + n_left, left_node_id);
+    elem_of_each_node_[right_node_id] = Elem(begin + n_left, e.end, right_node_id);
+    elem_of_each_node_[node_id] = Elem(nullptr, nullptr, -1);
+  }
+
+ private:
+  // stores the row indexes in the set
+  USMVector<size_t> row_indices_;
+  // vector: node_id -> elements
+  std::vector<Elem> elem_of_each_node_;
+};
+
+// The builder is required for samples partition to left and rights children for set of nodes
+class PartitionBuilderOneAPI {
+ public:
+  static constexpr size_t maxLocalSums = 256;
+  static constexpr size_t subgroupSize = 16;
+
+  template<typename Func>
+  void Init(cl::sycl::queue qu, size_t n_nodes, Func funcNTaks) {
+    qu_ = qu;
+    left_right_nodes_sizes_.resize(n_nodes);
+    nodes_offsets_.resize(n_nodes+1);
+    result_left_rows_.resize(n_nodes);
+    result_right_rows_.resize(n_nodes);
+
+    nodes_offsets_[0] = 0;
+    for (size_t i = 1; i < n_nodes+1; ++i) {
+      nodes_offsets_[i] = nodes_offsets_[i-1] + funcNTaks(i-1);
+    }
+
+    if (left_data_.Size() < nodes_offsets_[n_nodes]) {
+      left_data_.Resize(qu_, nodes_offsets_[n_nodes]);
+      right_data_.Resize(qu_, nodes_offsets_[n_nodes]);
+    }
+    prefix_sums_.Resize(qu, maxLocalSums);
+  }
+
+  common::Span<size_t> GetLeftData(int nid) {
+    return { left_data_.Data() + nodes_offsets_[nid], nodes_offsets_[nid + 1] - nodes_offsets_[nid] };
+  }
+
+  common::Span<size_t> GetRightData(int nid) {
+    return { right_data_.Data() + nodes_offsets_[nid], nodes_offsets_[nid + 1] - nodes_offsets_[nid] };
+  }
+
+  common::Span<size_t> GetPrefixSums() {
+    return { prefix_sums_.Data(), prefix_sums_.Size() };
+  }
+
+  size_t GetLocalSize(const common::Range1d& range) {
+    size_t range_size = range.end() - range.begin();
+    size_t local_subgroups = range_size / (maxLocalSums * subgroupSize) + !!(range_size % (maxLocalSums * subgroupSize));
+    return subgroupSize * local_subgroups;
+  }
+
+  size_t GetSubgroupSize() {
+    return subgroupSize;
+  }
+
+  void SetNLeftElems(int nid, size_t n_left) {
+    result_left_rows_[nid] = n_left;
+  }
+
+  void SetNRightElems(int nid, size_t n_right) {
+    result_right_rows_[nid] = n_right;
+  }
+
+  size_t GetNLeftElems(int nid) const {
+    return left_right_nodes_sizes_[nid].first;
+  }
+
+  size_t GetNRightElems(int nid) const {
+    return left_right_nodes_sizes_[nid].second;
+  }
+
+  void CalculateRowOffsets() {
+    for (size_t i = 0; i < nodes_offsets_.size()-1; ++i) {
+      left_right_nodes_sizes_[i] = {result_left_rows_[i], result_right_rows_[i]};
+    }
+  }
+
+  void MergeToArray(int nid, size_t* rows_indexes) {
+    size_t* left_result  = rows_indexes;
+
+    const size_t* left = left_data_.Data() + nodes_offsets_[nid];
+    
+    if (result_left_rows_[nid] + result_right_rows_[nid] > 0) qu_.memcpy(left_result, left, sizeof(size_t) * (result_left_rows_[nid] + result_right_rows_[nid]));
+  }
+
+ protected:
+  std::vector<std::pair<size_t, size_t>> left_right_nodes_sizes_;
+  std::vector<size_t> nodes_offsets_;
+  std::vector<size_t> result_left_rows_;
+  std::vector<size_t> result_right_rows_;
+
+  USMVector<size_t> left_data_;
+  USMVector<size_t> right_data_;
+
+  USMVector<size_t> prefix_sums_;
+
+  cl::sycl::queue qu_;
+};
+
+}  // namespace common
+}  // namespace xgboost
+
+#endif  // XGBOOST_COMMON_ROW_SET_H_


### PR DESCRIPTION
Continuation of the original PRs: [5659](https://github.com/dmlc/xgboost/pull/5659), [6212](https://github.com/dmlc/xgboost/pull/6212).

Part of the oneAPI plugin, containing:
- common USMVector class for storing and synchronization of device memory based on DPC++ USM buffer;
- wrapper for DMatrix to store data on target device and avoid additional data synchronization on each iteration;
- USM-based version of ColumnMatrix to store columnar data on target device;
- USM-based version of RowSet collection to store rows indices on target device;