### PR TITLE
Remove deprecated `n_gpus` parameter.

### DIFF
--- a/include/xgboost/generic_parameters.h
+++ b/include/xgboost/generic_parameters.h
@@ -33,13 +33,6 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
   size_t gpu_page_size;
   bool validate_parameters {false};
 
-  void CheckDeprecated() {
-    if (this->n_gpus != 0) {
-      LOG(WARNING)
-          << "\nn_gpus: "
-          << this->__MANAGER__()->Find("n_gpus")->GetFieldInfo().description;
-    }
-  }
   /*!
    * \brief Configure the parameter `gpu_id'.
    *
@@ -76,18 +69,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
     DMLC_DECLARE_FIELD(validate_parameters)
         .set_default(false)
         .describe("Enable checking whether parameters are used or not.");
-    DMLC_DECLARE_FIELD(n_gpus)
-        .set_default(0)
-        .set_range(0, 1)
-        .describe(
-"\n\tDeprecated. Single process multi-GPU training is no longer supported."
-"\n\tPlease switch to distributed training with one process per GPU."
-"\n\tThis can be done using Dask or Spark.  See documentation for details.");
   }
-
- private:
-  // number of devices to use (deprecated).
-  int n_gpus {0};  // NOLINT
 };
 }  // namespace xgboost
 

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -302,7 +302,6 @@ class LearnerConfiguration : public Learner {
     auto initialized = generic_parameters_.GetInitialised();
     auto old_seed = generic_parameters_.seed;
     generic_parameters_.UpdateAllowUnknown(args);
-    generic_parameters_.CheckDeprecated();
 
     ConsoleLogger::Configure(args);
     common::OmpSetNumThreads(&generic_parameters_.nthread);


### PR DESCRIPTION
Deprecated and disabled in 1.0 https://github.com/dmlc/xgboost/pull/4749