### PR TITLE
Throw error when using unsupported objective with `predict_proba`.

### DIFF
--- a/doc/prediction.rst
+++ b/doc/prediction.rst
@@ -32,8 +32,8 @@ After 1.4 release, we added a new parameter called ``strict_shape``, one can set
 - When using ``output_margin`` to avoid transformation and ``strict_shape`` is set to ``True``:
 
   Similar to the previous case, output is a 2-dim array, except for that ``multi:softmax``
-  has equivalent output of ``multi:softprob`` due to dropped transformation.  If strict
-  shape is set to False then output can have 1 or 2 dim depending on used model.
+  has equivalent output shape of ``multi:softprob`` due to dropped transformation.  If
+  strict shape is set to False then output can have 1 or 2 dim depending on used model.
 
 - When using ``preds_contribs`` with ``strict_shape`` set to ``True``:
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1793,7 +1793,6 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
     ) -> _DaskCollection:
         predts = await super()._predict_async(
             data=X,
-            output_margin=self.objective == "multi:softmax",
             validate_features=validate_features,
             base_margin=base_margin,
             iteration_range=iteration_range,
@@ -1801,7 +1800,9 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
         vstack = update_wrapper(
             partial(da.vstack, allow_unknown_chunksizes=True), da.vstack
         )
-        return _cls_predict_proba(getattr(self, "n_classes_", None), predts, vstack)
+        return _cls_predict_proba(
+            self.objective, getattr(self, "n_classes_", None), predts, vstack
+        )
 
     # pylint: disable=missing-function-docstring
     def predict_proba(

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -96,6 +96,14 @@ def test_multiclass_classification():
     )
     cls.fit(X, y)
     assert cls.objective == "multi:softprob"
+    cls.set_params(objective="multi:softmax")
+    classes_by_softprob = cls.predict(X)
+
+    with pytest.raises(ValueError):
+        cls.predict_proba(X)
+
+    classes_by_softmax = cls.predict(X)
+    np.testing.assert_allclose(classes_by_softprob, classes_by_softmax)
 
 
 def test_best_ntree_limit():

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -91,6 +91,12 @@ def test_multiclass_classification():
     assert proba.shape[0] == X.shape[0]
     assert proba.shape[1] == cls.n_classes_
 
+    cls = xgb.XGBClassifier(
+        objective="multi:softmax", n_estimators=1, use_label_encoder=False
+    )
+    cls.fit(X, y)
+    assert cls.objective == "multi:softprob"
+
 
 def test_best_ntree_limit():
     from sklearn.datasets import load_iris


### PR DESCRIPTION
This partially reverts https://github.com/dmlc/xgboost/pull/6817 on the use of `softmax`.  Looking into it more thoroughly, the `softmax` function can never appear in training due to automatic configuration in `fit`.  But the objective can still be invalid for predict_proba (like `softmax`) as illustrated in the test as an edge case.  Previously I let those functions pass and may return an incorrect result.  This PR reverts that part and throws a ValueError.  Other than that fixes in linked PR are still useful and kept.