### PR TITLE
avoid hang when some workers fail but spark context still live

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/SparkParallelismTracker.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/SparkParallelismTracker.scala
@@ -62,13 +62,7 @@ class SparkParallelismTracker(
   }
 
   private[this] def safeExecute[T](body: => T): T = {
-    val listener = new TaskFailedListener(killSparkContextOnWorkerFailure)
-    sc.addSparkListener(listener)
-    try {
-      body
-    } finally {
-      sc.removeSparkListener(listener)
-    }
+    body
   }
 
   /**


### PR DESCRIPTION
sparkJobThread.start will start the process of applying for resources and submitting jobs
parallelismTracker.execute will add TaskFailedListener to SparkContext
If a Job is submitted before TaskFailedListener is added to SparkContext, it will not be killed when the event TaskFailedListener.onTaskEnd is executed, because it is not added to jobIdToStageIds when it is started. When Track starts again, it will get stuck
My editor ensures that sparkJobThread.start will not be started until TaskFailedListener is added to SparkContext.