### PR TITLE
[CI] Upload Doxygen doc to correct destination

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -279,7 +279,7 @@ jobs:
       run: |
         cd build/
         tar cvjf ${{ steps.extract_branch.outputs.branch }}.tar.bz2 doc_doxygen/
-        python -m awscli s3 cp ./${{ steps.extract_branch.outputs.branch }}.tar.bz2 s3://xgboost-docs/ --acl public-read
+        python -m awscli s3 cp ./${{ steps.extract_branch.outputs.branch }}.tar.bz2 s3://xgboost-docs/doxygen/ --acl public-read
       if: github.ref == 'refs/heads/master' || contains(github.ref, 'refs/heads/release_')
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_IAM_S3_UPLOADER }}


### PR DESCRIPTION
The link for the C API doc was not working: https://xgboost.readthedocs.io/en/stable/dev/c__api_8h.html. When we ported the Doxygen build from Jenkins to GitHub Actions, we made a small typo that broke the C API doc.

This commit has already been ported to `release_1.3.0` and `release_1.4.0` and now the links are back online:
* https://xgboost.readthedocs.io/en/release_1.3.0/dev/c__api_8h.html
* https://xgboost.readthedocs.io/en/release_1.4.0/dev/c__api_8h.html