### PR TITLE
Implement unified update prediction cache for (gpu_)hist.

### DIFF
--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -14,6 +14,11 @@
 #include <algorithm>
 
 namespace xgboost {
+/*!
+ * \brief A veiw over a matrix on contigious storage.
+ *
+ * \tparam T data type of matrix
+ */
 template <typename T> class MatrixView {
   int32_t device_;
   common::Span<T> values_;
@@ -21,6 +26,12 @@ template <typename T> class MatrixView {
   size_t shape_[2];
 
  public:
+  /*!
+   * \param vec     storage.
+   * \param strides Strides for matrix.
+   * \param shape   Rows anc columns.
+   * \param device  Where the data is stored in.
+   */
   MatrixView(HostDeviceVector<T> *vec, std::array<size_t, 2> strides,
              std::array<size_t, 2> shape, int32_t device)
       : device_{device}, values_{device == GenericParameter::kCpuId
@@ -53,7 +64,8 @@ template <typename T> class MatrixView {
   auto DeviceIdx() const { return device_; }
 };
 
-template <typename T, bool is_column = true> class VectorView {
+/*! \brief A slice for 1 column of MatrixView.  Can be extended to row if needed. */
+template <typename T> class VectorView {
   MatrixView<T> matrix_;
   size_t column_;
 

--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -1,0 +1,72 @@
+/*!
+ * Copyright 2021 by Contributors
+ * \file linalg.h
+ * \brief  Linear algebra related utilities.
+ */
+#ifndef XGBOOST_LINALG_H_
+#define XGBOOST_LINALG_H_
+
+#include <xgboost/span.h>
+#include <xgboost/host_device_vector.h>
+#include <xgboost/generic_parameters.h>
+
+#include <array>
+
+namespace xgboost {
+template <typename T> class MatrixView {
+  common::Span<T> values_;
+  size_t strides_[2];
+  size_t shape_[2];
+
+ public:
+  MatrixView(HostDeviceVector<T> *vec, std::array<size_t, 2> strides,
+             std::array<size_t, 2> shape, int32_t device)
+      : values_{device == GenericParameter::kCpuId ? vec->HostSpan()
+                                                   : vec->DeviceSpan()} {
+    std::copy(strides.cbegin(), strides.cend(), strides_);
+    std::copy(shape.cbegin(), shape.cend(), shape_);
+  }
+  MatrixView(HostDeviceVector<std::remove_const_t<T>> const *vec, std::array<size_t, 2> strides,
+             std::array<size_t, 2> shape, int32_t device)
+      : values_{device == GenericParameter::kCpuId ? vec->HostSpan()
+                                                   : vec->DeviceSpan()} {
+    std::copy(strides.cbegin(), strides.cend(), strides_);
+    std::copy(shape.cbegin(), shape.cend(), shape_);
+  }
+  XGBOOST_DEVICE T const &operator()(size_t r, size_t c) const {
+    return values_[strides_[0] * r + strides_[1] * c];
+  }
+
+  auto Strides() const { return strides_; }
+  auto Shape() const { return shape_; }
+  auto Values() const { return values_; }
+  auto Size() const { return shape_[0] * shape_[1]; }
+};
+
+template <typename T, bool is_column = true> class VectorView {
+  size_t strides_[2];
+  size_t shape_[2];
+  common::Span<T> values_;
+  size_t column_;
+  static_assert(is_column, "Only column view over row matrix is implemented.");
+
+ public:
+  explicit VectorView(MatrixView<T> matrix, size_t column) {
+    std::memcpy(strides_, matrix.Strides(), sizeof(strides_));
+    std::memcpy(shape_, matrix.Shape(), sizeof(shape_));
+    values_ = matrix.Values();
+    column_ = column;
+  }
+
+  XGBOOST_DEVICE T &operator[](size_t i) {
+    return values_[strides_[0] * i + strides_[1] * column_];
+  }
+
+  XGBOOST_DEVICE T const &operator[](size_t i) const {
+    return values_[strides_[0] * i + strides_[1] * column_];
+  }
+
+  size_t Size() { return is_column ? shape_[0] : shape_[1]; }
+};
+} // namespace xgboost
+#endif  // XGBOOST_LINALG_H_

--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -12,6 +12,7 @@
 
 #include <array>
 #include <algorithm>
+#include <utility>
 
 namespace xgboost {
 /*!

--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -11,6 +11,7 @@
 #include <xgboost/generic_parameters.h>
 
 #include <array>
+#include <algorithm>
 
 namespace xgboost {
 template <typename T> class MatrixView {
@@ -68,5 +69,5 @@ template <typename T, bool is_column = true> class VectorView {
 
   size_t Size() { return is_column ? shape_[0] : shape_[1]; }
 };
-} // namespace xgboost
+}       // namespace xgboost
 #endif  // XGBOOST_LINALG_H_

--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -71,7 +71,7 @@ template <typename T> class VectorView {
 
  public:
   explicit VectorView(MatrixView<T> matrix, size_t column)
-      : matrix_{matrix}, column_{column} {}
+      : matrix_{std::move(matrix)}, column_{column} {}
 
   XGBOOST_DEVICE T &operator[](size_t i) {
     return matrix_(i, column_);

--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -77,5 +77,5 @@ template <typename T, bool is_column = true> class VectorView {
   size_t Size() { return is_column ? shape_[0] : shape_[1]; }
   int32_t DeviceIdx() const { return device_; }
 };
-} // namespace xgboost
+}       // namespace xgboost
 #endif  // XGBOOST_LINALG_H_

--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -15,6 +15,7 @@
 #include <xgboost/generic_parameters.h>
 #include <xgboost/host_device_vector.h>
 #include <xgboost/model.h>
+#include <xgboost/linalg.h>
 
 #include <functional>
 #include <vector>
@@ -70,14 +71,8 @@ class TreeUpdater : public Configurable {
    *         the prediction cache. If true, the prediction cache will have been
    *         updated by the time this function returns.
    */
-  virtual bool UpdatePredictionCache(const DMatrix* /*data*/,
-                                     HostDeviceVector<bst_float>* /*out_preds*/) {
-    return false;
-  }
-
-  virtual bool UpdatePredictionCacheMulticlass(const DMatrix* /*data*/,
-                                               HostDeviceVector<bst_float>* /*out_preds*/,
-                                               const int /*gid*/, const int /*ngroup*/) {
+  virtual bool UpdatePredictionCache(const DMatrix * /*data*/,
+                                     VectorView<float> /*out_preds*/) {
     return false;
   }
 

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -229,10 +229,9 @@ void GBTree::DoBoost(DMatrix* p_fmat,
   auto device = tparam_.tree_method != TreeMethod::kGPUHist
                     ? GenericParameter::kCpuId
                     : in_gpair->DeviceIdx();
-  auto out =
-      MatrixView<float>(&predt->predictions, {static_cast<size_t>(ngroup), 1},
-                        {p_fmat->Info().num_row_, static_cast<size_t>(ngroup)},
-                        device);
+  auto out = MatrixView<float>(
+      &predt->predictions,
+      {p_fmat->Info().num_row_, static_cast<size_t>(ngroup)}, device);
   CHECK_NE(ngroup, 0);
   if (ngroup == 1) {
     std::vector<std::unique_ptr<RegTree>> ret;

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -194,7 +194,7 @@ void GPUCopyGradient(HostDeviceVector<GradientPair> const *in_gpair,
                      bst_group_t n_groups, bst_group_t group_id,
                      HostDeviceVector<GradientPair> *out_gpair)
 #if defined(XGBOOST_USE_CUDA)
-    ;
+;  // NOLINT
 #else
 {
   common::AssertGPUSupport();

--- a/src/gbm/gbtree.cu
+++ b/src/gbm/gbtree.cu
@@ -2,10 +2,28 @@
  * Copyright 2021 by Contributors
  */
 #include "xgboost/span.h"
+#include "xgboost/generic_parameters.h"
+#include "xgboost/linalg.h"
 #include "../common/device_helpers.cuh"
 
 namespace xgboost {
 namespace gbm {
+
+void GPUCopyGradient(HostDeviceVector<GradientPair> const *in_gpair,
+                     bst_group_t n_groups, bst_group_t group_id,
+                     HostDeviceVector<GradientPair> *out_gpair) {
+  MatrixView<GradientPair const> in{
+      in_gpair,
+      {n_groups, 1ul},
+      {in_gpair->Size() / n_groups, static_cast<size_t>(n_groups)},
+      in_gpair->DeviceIdx()};
+  auto v_in = VectorView<GradientPair const>{in, group_id};
+  out_gpair->Resize(v_in.Size());
+  auto d_out = out_gpair->DeviceSpan();
+  dh::LaunchN(dh::CurrentDevice(), v_in.Size(),
+              [=] __device__(size_t i) { d_out[i] = v_in[i]; });
+}
+
 void GPUDartPredictInc(common::Span<float> out_predts,
                        common::Span<float> predts, float tree_w, size_t n_rows,
                        bst_group_t n_groups, bst_group_t group) {

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -530,6 +530,7 @@ struct GPUHistMakerDevice {
 
   void UpdatePredictionCache(VectorView<float> out_preds_d) {
     dh::safe_cuda(cudaSetDevice(device_id));
+    CHECK_EQ(out_preds_d.DeviceIdx(), device_id);
     auto d_ridx = row_partitioner->GetRows();
 
     GPUTrainingParam param_d(param);

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -273,9 +273,9 @@ struct GPUHistMakerDevice {
     if (d_gpair.size() != dh_gpair->Size()) {
       d_gpair.resize(dh_gpair->Size());
     }
-    thrust::copy(thrust::device, dh_gpair->ConstDevicePointer(),
-                 dh_gpair->ConstDevicePointer() + dh_gpair->Size(),
-                 d_gpair.begin());
+    dh::safe_cuda(cudaMemcpyAsync(
+        d_gpair.data().get(), dh_gpair->ConstDevicePointer(),
+        dh_gpair->Size() * sizeof(GradientPair), cudaMemcpyDeviceToDevice));
     auto sample = sampler->Sample(dh::ToSpan(d_gpair), dmat);
     page = sample.page;
     gpair = sample.gpair;
@@ -528,7 +528,7 @@ struct GPUHistMakerDevice {
         });
   }
 
-  void UpdatePredictionCache(common::Span<bst_float> out_preds_d) {
+  void UpdatePredictionCache(VectorView<float> out_preds_d) {
     dh::safe_cuda(cudaSetDevice(device_id));
     auto d_ridx = row_partitioner->GetRows();
 
@@ -543,14 +543,14 @@ struct GPUHistMakerDevice {
     auto d_node_sum_gradients = device_node_sum_gradients.data().get();
     auto evaluator = tree_evaluator.GetEvaluator<GPUTrainingParam>();
 
-    dh::LaunchN(
-        device_id, out_preds_d.size(), [=] __device__(int local_idx) {
-          int pos = d_position[local_idx];
-          bst_float weight = evaluator.CalcWeight(pos, param_d,
-                                                  GradStats{d_node_sum_gradients[pos]});
-          out_preds_d[d_ridx[local_idx]] +=
-              weight * param_d.learning_rate;
-        });
+    dh::LaunchN(device_id, d_ridx.size(), [=] __device__(int local_idx) {
+      int pos = d_position[local_idx];
+      bst_float weight = evaluator.CalcWeight(
+          pos, param_d, GradStats{d_node_sum_gradients[pos]});
+      static_assert(!std::is_const<decltype(out_preds_d)>::value, "");
+      auto v_predt = out_preds_d;  // for some reaon out_preds_d is const by both nvcc and clang.
+      v_predt[d_ridx[local_idx]] += weight * param_d.learning_rate;
+    });
     row_partitioner.reset();
   }
 
@@ -862,13 +862,12 @@ class GPUHistMakerSpecialised {
     maker->UpdateTree(gpair, p_fmat, p_tree, &reducer_);
   }
 
-  bool UpdatePredictionCache(const DMatrix* data, HostDeviceVector<bst_float>* p_out_preds) {
+  bool UpdatePredictionCache(const DMatrix* data, VectorView<bst_float> p_out_preds) {
     if (maker == nullptr || p_last_fmat_ == nullptr || p_last_fmat_ != data) {
       return false;
     }
     monitor_.Start("UpdatePredictionCache");
-    p_out_preds->SetDevice(device_);
-    maker->UpdatePredictionCache(p_out_preds->DeviceSpan());
+    maker->UpdatePredictionCache(p_out_preds);
     monitor_.Stop("UpdatePredictionCache");
     return true;
   }
@@ -947,8 +946,8 @@ class GPUHistMaker : public TreeUpdater {
     }
   }
 
-  bool UpdatePredictionCache(
-      const DMatrix* data, HostDeviceVector<bst_float>* p_out_preds) override {
+  bool UpdatePredictionCache(const DMatrix *data,
+                             VectorView<bst_float> p_out_preds) override {
     if (hist_maker_param_.single_precision_histogram) {
       return float_maker_->UpdatePredictionCache(data, p_out_preds);
     } else {

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -632,7 +632,7 @@ bool QuantileHistMaker::Builder<GradientSumT>::UpdatePredictionCache(
   common::BlockedSpace2d space(n_nodes, [&](size_t node) {
     return row_set_collection_[node].Size();
   }, 1024);
-
+  CHECK_EQ(out_preds.DeviceIdx(), GenericParameter::kCpuId);
   common::ParallelFor2d(space, this->nthread_, [&](size_t node, common::Range1d r) {
     const RowSetCollection::Elem rowset = row_set_collection_[node];
     if (rowset.begin != nullptr && rowset.end != nullptr) {

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -118,11 +118,8 @@ class QuantileHistMaker: public TreeUpdater {
               DMatrix* dmat,
               const std::vector<RegTree*>& trees) override;
 
-  bool UpdatePredictionCache(const DMatrix* data,
-                             HostDeviceVector<bst_float>* out_preds) override;
-  bool UpdatePredictionCacheMulticlass(const DMatrix* data,
-                                       HostDeviceVector<bst_float>* out_preds,
-                                       const int gid, const int ngroup) override;
+  bool UpdatePredictionCache(const DMatrix *data,
+                             VectorView<float> out_preds) override;
 
   void LoadConfig(Json const& in) override {
     auto const& config = get<Object const>(in);
@@ -245,8 +242,7 @@ class QuantileHistMaker: public TreeUpdater {
     }
 
     bool UpdatePredictionCache(const DMatrix* data,
-                               HostDeviceVector<bst_float>* p_out_preds,
-                               const int gid = 0, const int ngroup = 1);
+                               VectorView<float> out_preds);
 
     void SetHistSynchronizer(HistSynchronizer<GradientSumT>* sync);
     void SetHistRowsAdder(HistRowsAdder<GradientSumT>* adder);

--- a/tests/cpp/common/test_linalg.cc
+++ b/tests/cpp/common/test_linalg.cc
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include <xgboost/linalg.h>
+#include <numeric>
+
+namespace xgboost {
+
+auto MakeMatrixFromTest(HostDeviceVector<float> *storage, size_t n_rows, size_t n_cols) {
+  storage->Resize(n_rows * n_cols);
+  auto& h_storage = storage->HostVector();
+
+  std::iota(h_storage.begin(), h_storage.end(), 0);
+
+  auto m = MatrixView<float>{storage, {n_cols, 1}, {n_rows, n_cols}, -1};
+  return m;
+
+}
+
+TEST(Linalg, Matrix) {
+  size_t kRows = 31, kCols = 77;
+  HostDeviceVector<float> storage;
+  auto m = MakeMatrixFromTest(&storage, kRows, kCols);
+  ASSERT_EQ(m.DeviceIdx(), GenericParameter::kCpuId);
+  ASSERT_EQ(m(0, 0), 0);
+  ASSERT_EQ(m(kRows - 1, kCols - 1), storage.Size() - 1);
+}
+
+TEST(Linalg, Vector) {
+  size_t kRows = 31, kCols = 77;
+  HostDeviceVector<float> storage;
+  auto m = MakeMatrixFromTest(&storage, kRows, kCols);
+  auto v = VectorView<float>(m, 3);
+  for (size_t i = 0; i < v.Size(); ++i) {
+    ASSERT_EQ(v[i], m(i, 3));
+  }
+
+  ASSERT_EQ(v[0], 3);
+}
+} // namespace xgboost

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -295,6 +295,13 @@ TEST(Learner, GPUConfiguration) {
     ASSERT_EQ(learner->GetGenericParameter().gpu_id, 0);
   }
   {
+    std::unique_ptr<Learner> learner {Learner::Create(mat)};
+    learner->SetParams({Arg{"tree_method", "gpu_hist"},
+                        Arg{"gpu_id", "-1"}});
+    learner->UpdateOneIter(0, p_dmat);
+    ASSERT_EQ(learner->GetGenericParameter().gpu_id, 0);
+  }
+  {
     // with CPU algorithm
     std::unique_ptr<Learner> learner {Learner::Create(mat)};
     learner->SetParams({Arg{"tree_method", "hist"}});

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -392,9 +392,8 @@ void UpdateTree(HostDeviceVector<GradientPair>* gpair, DMatrix* dmat,
   hist_maker.Update(gpair, dmat, {tree});
   hist_maker.UpdatePredictionCache(
       dmat,
-      VectorView<float>{MatrixView<float>(preds, {1, 1}, {preds->Size(), 1},
-                                          preds->DeviceIdx()),
-                        0});
+      VectorView<float>{
+          MatrixView<float>(preds, {preds->Size(), 1}, preds->DeviceIdx()), 0});
 }
 
 TEST(GpuHist, UniformSampling) {

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -390,7 +390,11 @@ void UpdateTree(HostDeviceVector<GradientPair>* gpair, DMatrix* dmat,
   hist_maker.Configure(args, &generic_param);
 
   hist_maker.Update(gpair, dmat, {tree});
-  hist_maker.UpdatePredictionCache(dmat, preds);
+  hist_maker.UpdatePredictionCache(
+      dmat,
+      VectorView<float>{MatrixView<float>(preds, {1, 1}, {preds->Size(), 1},
+                                          preds->DeviceIdx()),
+                        0});
 }
 
 TEST(GpuHist, UniformSampling) {


### PR DESCRIPTION
* Optimize the perf for gpu multi-class.
* Implement some utilities for slicing matrix.
* Remove the `update prediction cache multi class` function.

TODOs:
- [x] Add unittest for new utilities.


### Perf for gpu_hist:

100 rounds for covtype:
Before:
22.598s

After:
15.911s