### PR TITLE
Fix warning on Windows.

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -734,8 +734,9 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
   API_BEGIN();
   CHECK_HANDLE();
   std::shared_ptr<xgboost::data::CSRArrayAdapter> x{
-      new xgboost::data::CSRArrayAdapter{
-          StringView{indptr}, StringView{indices}, StringView{data}, cols}};
+      new xgboost::data::CSRArrayAdapter{StringView{indptr},
+                                         StringView{indices}, StringView{data},
+                                         static_cast<size_t>(cols)}};
   std::shared_ptr<DMatrix> p_m {nullptr};
   if (m) {
     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);


### PR DESCRIPTION
Targeted at 1.4 branch, will port to master once merged.  Address warning found by @hetong007  in https://github.com/dmlc/xgboost/issues/6793#issuecomment-823849915 .


Do not merge until all tests on R-hub have passed.  (Huge thanks to R-hub).  Progress can be tracked here:

- [x] macOS 10.13.6 High Sierra, R-release, CRAN's setup
https://builder.r-hub.io/status/xgboost_1.4.1.1.tar.gz-0c3c8a0f078d60e5fb1d1b19430036d9

- [x] Windows Server 2008 R2 SP1, R-release, 32/64 bit
https://builder.r-hub.io/status/xgboost_1.4.1.1.tar.gz-bc2de41bceddd51493632f62f3434c78

- [x] Oracle Solaris 10, x86, 32 bit, R-release
https://builder.r-hub.io/status/xgboost_1.4.1.1.tar.gz-66c959222fbaf97afac3f721205f9ae4

- [ ] Oracle Solaris 10, x86, 32 bit, R-release, Oracle Developer Studio 12.6
Failing due to compiler couldn't infer dispatching type.
https://builder.r-hub.io/status/xgboost_1.4.1.1.tar.gz-bdf750d127a041e6fcc77bba0017480c

- [x] Debian Linux, R-release, GCC
https://builder.r-hub.io/status/xgboost_1.4.1.1.tar.gz-bc0161ccee0b610ce564d0f2b51892e4

* [ ] CentOS 8, stock R from EPEL
Failing in dependency compilation.  `boost` required by `readr` is failing to compile.
https://builder.r-hub.io/status/xgboost_1.4.1.1.tar.gz-c2a2446e658c69a1891508cb3a7afbf4