### PR TITLE
[R-package] remove stringi from CMake-based installation

### DIFF
--- a/cmake/RPackageInstall.cmake.in
+++ b/cmake/RPackageInstall.cmake.in
@@ -27,7 +27,7 @@ file(WRITE "${build_dir}/R-package/src/Makevars.win" "all:")
 
 # Install dependencies
 set(XGB_DEPS_SCRIPT
-    "deps = setdiff(c('data.table', 'magrittr', 'stringi'), rownames(installed.packages())); if(length(deps)>0) install.packages(deps, repo = 'https://cloud.r-project.org/')")
+    "deps = setdiff(c('data.table', 'magrittr'), rownames(installed.packages())); if(length(deps)>0) install.packages(deps, repo = 'https://cloud.r-project.org/')")
 check_call(COMMAND "${LIBR_EXECUTABLE}" -q -e "${XGB_DEPS_SCRIPT}")
 
 # Install the XGBoost R package

--- a/cmake/RPackageInstall.cmake.in
+++ b/cmake/RPackageInstall.cmake.in
@@ -27,7 +27,7 @@ file(WRITE "${build_dir}/R-package/src/Makevars.win" "all:")
 
 # Install dependencies
 set(XGB_DEPS_SCRIPT
-    "deps = setdiff(c('data.table', 'magrittr'), rownames(installed.packages())); if(length(deps)>0) install.packages(deps, repo = 'https://cloud.r-project.org/')")
+    "deps = setdiff(c('data.table', 'jsonlite', 'magrittr', 'Matrix'), rownames(installed.packages())); if(length(deps)>0) install.packages(deps, repo = 'https://cloud.r-project.org/')")
 check_call(COMMAND "${LIBR_EXECUTABLE}" -q -e "${XGB_DEPS_SCRIPT}")
 
 # Install the XGBoost R package


### PR DESCRIPTION
Looking at the R package tonight, I saw that the dependency on `{stringi}` was removed a few months ago, in #6109.

Since that package is no longer needed for `{xgboost}`, this PR proposes changing `RPackageInstall.cmake.in` to not install it when building the R package with CMake. I think that might help to speed up installs a bit and reduces the risk of a failed install caused by failure to build `{stringi}`.

Thanks for your time and consideration.