### PR TITLE
[jvm-packages] Make it easier to release GPU/CPU code artifacts to Maven Central

### DIFF
--- a/jvm-packages/create_jni.py
+++ b/jvm-packages/create_jni.py
@@ -84,8 +84,9 @@ if __name__ == "__main__":
 
     print("building Java wrapper")
     with cd(".."):
-        maybe_makedirs("build")
-        with cd("build"):
+        build_dir = 'build-gpu' if cli_args.use_cuda == 'ON' else 'build'
+        maybe_makedirs(build_dir)
+        with cd(build_dir):
             if sys.platform == "win32":
                 # Force x64 build on Windows.
                 maybe_generator = ' -A x64'
@@ -114,6 +115,9 @@ if __name__ == "__main__":
             if gpu_arch_flag is not None:
                 args.append("%s" % gpu_arch_flag)
 
+            lib_dir = os.path.join(os.pardir, 'lib')
+            if os.path.exists(lib_dir):
+                shutil.rmtree(lib_dir)
             run("cmake .. " + " ".join(args) + maybe_generator)
             run("cmake --build . --config Release" + maybe_parallel_build)
 

--- a/jvm-packages/xgboost4j-gpu/src
+++ b/jvm-packages/xgboost4j-gpu/src
@@ -1,1 +1,0 @@
-../xgboost4j/src/

--- a/jvm-packages/xgboost4j-gpu/src/main/java
+++ b/jvm-packages/xgboost4j-gpu/src/main/java
@@ -1,0 +1,1 @@
+../../../xgboost4j/src/main/java/

--- a/jvm-packages/xgboost4j-gpu/src/main/resources/xgboost4j-version.properties
+++ b/jvm-packages/xgboost4j-gpu/src/main/resources/xgboost4j-version.properties
@@ -1,0 +1,1 @@
+../../../../xgboost4j/src/main/resources/xgboost4j-version.properties

--- a/jvm-packages/xgboost4j-gpu/src/main/scala
+++ b/jvm-packages/xgboost4j-gpu/src/main/scala
@@ -1,0 +1,1 @@
+../../../xgboost4j/src/main/scala/

--- a/jvm-packages/xgboost4j-gpu/src/native
+++ b/jvm-packages/xgboost4j-gpu/src/native
@@ -1,0 +1,1 @@
+../../xgboost4j/src/native

--- a/jvm-packages/xgboost4j-gpu/src/test
+++ b/jvm-packages/xgboost4j-gpu/src/test
@@ -1,0 +1,1 @@
+../../xgboost4j/src/test

--- a/jvm-packages/xgboost4j-spark-gpu/src
+++ b/jvm-packages/xgboost4j-spark-gpu/src
@@ -1,1 +1,0 @@
-../xgboost4j-spark/src/

--- a/jvm-packages/xgboost4j-spark-gpu/src/main/scala
+++ b/jvm-packages/xgboost4j-spark-gpu/src/main/scala
@@ -1,0 +1,1 @@
+../../../xgboost4j-spark/src/main/scala

--- a/jvm-packages/xgboost4j-spark-gpu/src/test
+++ b/jvm-packages/xgboost4j-spark-gpu/src/test
@@ -1,0 +1,1 @@
+../../xgboost4j-spark/src/test


### PR DESCRIPTION
When I was running the following commands, 
```
mvn package -Dspark.version=3.0.0 -DskipTests -Duse.cuda=ON -Pgpu-with-gpu-tests
mvn deploy -Prelease -DskipTests
```
I expected to have two JAR files, `xgboost4j_2.12-1.4.1.jar` and `xgboost4j-gpu_2.12-1.4.1.jar`, the second of which contains CUDA code and the first does not. As a result, the second JAR is expected to be bigger than the first (160 MB vs 4.4 MB). But when I ran the commands, I often ended up with two JAR files with equal size (160 MB), indicating a mix-up.

This PR ensures that `xgboost4j-gpu_2.12-1.4.1.jar` gets the bigger `libxgboost4j.so` with CUDA code and that `xgboost4j_2.12-1.4.1.jar` gets the smaller `libxgboost4j.so` without CUDA code.