### PR TITLE
Reduce Travis environment setup time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
       - libgit2
       - lz4
       - wget
-    update: true
+    update: false
   apt:
     packages:
       - snapd

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ addons:
       - libgit2
       - lz4
       - wget
-    update: false
   apt:
     packages:
       - snapd

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ addons:
       - libgit2
       - lz4
       - wget
-      - r
     update: true
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,8 @@ jobs:
       env: TASK=java_test
 
 # dependent brew packages
+# the dependencies from homebrew is installed manually from setup script due to outdated image from travis.
 addons:
-  homebrew:
-    packages:
-      - cmake
-      - libomp
-      - graphviz
-      - openssl
-      - libgit2
-      - lz4
-      - wget
   apt:
     packages:
       - snapd

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ jobs:
 # dependent brew packages
 # the dependencies from homebrew is installed manually from setup script due to outdated image from travis.
 addons:
+  homebrew:
+    update: false
   apt:
     packages:
       - snapd

--- a/tests/ci_build/conda_env/macos_cpu_test.yml
+++ b/tests/ci_build/conda_env/macos_cpu_test.yml
@@ -15,6 +15,7 @@ dependencies:
 - matplotlib
 - dask
 - distributed
+- graphviz
 - python-graphviz
 - hypothesis
 - astroid

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-make -f dmlc-core/scripts/packages.mk lz4
-
 source $HOME/miniconda/bin/activate
 
 if [ ${TASK} == "python_sdist_test" ]; then

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -41,7 +41,7 @@ if [ ${TASK} == "python_test" ]; then
       mkdir build && cd build
       conda activate python3
       cmake --version
-      cmake .. -DUSE_OPENMP=ON -DCMAKE_VERBOSE_MAKEFILE=ON
+      cmake .. -DUSE_OPENMP=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DPLUGIN_LZ4=ON
       make -j$(nproc)
       cd ../python-package
       python setup.py bdist_wheel

--- a/tests/travis/run_test.sh
+++ b/tests/travis/run_test.sh
@@ -41,7 +41,7 @@ if [ ${TASK} == "python_test" ]; then
       mkdir build && cd build
       conda activate python3
       cmake --version
-      cmake .. -DUSE_OPENMP=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DPLUGIN_LZ4=ON
+      cmake .. -DUSE_OPENMP=ON -DCMAKE_VERBOSE_MAKEFILE=ON
       make -j$(nproc)
       cd ../python-package
       python setup.py bdist_wheel

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/27
-brew install cmake libomp openssl libgit2 lz4 wget
+brew install cmake libomp lz4
 
 
 if [ ${TASK} == "python_test" ] || [ ${TASK} == "python_sdist_test" ]; then

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/27
+brew install cmake libomp graphviz openssl libgit2 lz4 wget
+
+
 if [ ${TASK} == "python_test" ] || [ ${TASK} == "python_sdist_test" ]; then
     if [ ${TRAVIS_OS_NAME} == "osx" ]; then
         wget --no-verbose -O conda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/27
-brew install cmake libomp graphviz openssl libgit2 lz4 wget
+brew install cmake libomp openssl libgit2 lz4 wget
 
 
 if [ ${TASK} == "python_test" ] || [ ${TASK} == "python_sdist_test" ]; then


### PR DESCRIPTION
## Changes
* Remove unused r from travis.
* Don't update homebrew.
* Don't install indirect/unused dependencies like libgit2, wget, openssl.
* Move graphviz installation to conda.

## Issues not solved by this PR

* lz4 test is still omitted.  The test was dropped at some point probably due to oversight.  This PR doesn't restore it due to the Python test is responsible for generating wheels and I can't add an optional dependency into the generated binary.
* Another failure is addressed in https://github.com/dmlc/xgboost/pull/6917.

## Background for homebrew
These are the package updates for homebrew:
```
ansible 2.9.0 -> 3.3.0, boost 1.71.0 -> 1.75.0_3, cgal 4.14.1 -> 5.2.1, geos 3.8.0 -> 3.9.1, git 2.24.0 -> 2.31.1, libevent 2.1.11_1 -> 2.1.12, libgeotiff 1.5.1 -> 1.6.0, libidn2 2.2.0_1 -> 2.3.0, gnutls 3.6.10 -> 3.6.15, gnupg 2.2.17 -> 2.3.1, libpq 11.5_1 -> 13.2, libssh 0.9.1 -> 0.9.5_1, libxml2 2.9.9_2 -> 2.9.10_2, libdap 3.20.4_1 -> 3.20.7, libspatialite 4.3.0a_7 -> 5.0.1, little-cms2 2.9 -> 2.12, mercurial 5.1.2 -> 5.7.1, node 12.12.0 -> 16.0.0_1, numpy 1.17.2 -> 1.20.2, openjpeg 2.3.1 -> 2.4.0, p11-kit 0.23.18.1 -> 0.23.22, poppler 0.81.0 -> 21.04.0, postgresql 11.5_1 -> 13.2_2, pyenv 1.2.15 -> 1.2.26_1, sfcgal 1.3.7_1 -> 1.3.10, tmate 2.3.1 -> 2.4.0, unbound 1.9.4 -> 1.13.1, unixodbc 2.3.7 -> 2.3.9_1, gdal 2.4.2_2 -> 3.2.2_3, postgis 2.5.3 -> 3.1.1_1, wget 1.20.3_1 -> 1.21.1
```

The total time used on setting up homebrew environment is about 25 minutes, while the test time limit is 50 minutes.  We are running into timeout errors quite frequently.  This PR tries to reduce the time used for installing/updating dependencies.

The homebrew update downloads a large dependency tree.  For example, the update for `gnupg` requires the latest `guile`, also qt5 is somehow in the dependency tree.  Removing the update step might help us make better use of our CI time.

## Result
Python test is reduced from 50 minutes to 30 minutes.