### PR TITLE
[CI] Fix custom metric test with empty dataset.

### DIFF
--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -272,6 +272,8 @@ def eval_error_metric(predt, dtrain: xgb.DMatrix):
     label = dtrain.get_label()
     r = np.zeros(predt.shape)
     gt = predt > 0.5
+    if predt.size == 0:
+        return "CustomErr", 0
     r[gt] = 1 - label[gt]
     le = predt <= 0.5
     r[le] = label[le]


### PR DESCRIPTION
In numpy `1.20.2`, for an empty array `predt` with shape `[]`, the comparison of `predt < 0.5` returns a 2-dim array with shape `(0, 1)`.  This causes later indexing error.