### PR TITLE
Relax test for decision stump in distributed environment.

### DIFF
--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -1023,7 +1023,14 @@ class TestWithDask:
                                  evals=[(m, 'train')])['history']
         note(history)
         history = history['train'][dataset.metric]
-        assert tm.non_increasing(history)
+
+        def is_stump():
+            return params["max_depth"] == 1 or params["max_leaves"] == 1
+
+        if params["max_bin"] == 2 and is_stump():
+            assert tm.non_increasing(history, tolerance=1e-3)
+        else:
+            assert tm.non_increasing(history)
         # Make sure that it's decreasing
         assert history[-1] < history[0]
 

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -1027,7 +1027,10 @@ class TestWithDask:
         def is_stump():
             return params["max_depth"] == 1 or params["max_leaves"] == 1
 
-        if params["max_bin"] == 2 and is_stump():
+        def minimum_bin():
+            return "max_bin" in params and params["max_bin"] == 2
+
+        if minimum_bin() and is_stump():
             assert tm.non_increasing(history, tolerance=1e-3)
         else:
             assert tm.non_increasing(history)


### PR DESCRIPTION
This relaxes the test when the `max_bin` is set to `2` and trees are limited to stumps.  In this case, the floating-point error can overweight the learning result.

https://xgboost-ci.net/blue/organizations/jenkins/xgboost/detail/PR-6901/6/pipeline