### PR TITLE
Enforce input data is not `object`.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -233,8 +233,6 @@ def _numpy2ctypes_type(dtype):
 
 
 def _array_interface(data: np.ndarray) -> bytes:
-    if data.dtype.hasobject:
-        data = data.astype(float, copy=False)
     interface = data.__array_interface__
     if "mask" in interface:
         interface["mask"] = interface["mask"].__array_interface__
@@ -1910,8 +1908,8 @@ class Booster(object):
                 )
 
         if isinstance(data, np.ndarray):
-            from .data import _maybe_np_slice
-            data = _maybe_np_slice(data, data.dtype)
+            from .data import _ensure_np_dtype
+            data, dtype = _ensure_np_dtype(data, data.dtype)
             _check_call(
                 _LIB.XGBoosterPredictFromDense(
                     self.handle,

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1909,7 +1909,7 @@ class Booster(object):
 
         if isinstance(data, np.ndarray):
             from .data import _ensure_np_dtype
-            data, dtype = _ensure_np_dtype(data, data.dtype)
+            data, _ = _ensure_np_dtype(data, data.dtype)
             _check_call(
                 _LIB.XGBoosterPredictFromDense(
                     self.handle,

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -233,6 +233,9 @@ def _numpy2ctypes_type(dtype):
 
 
 def _array_interface(data: np.ndarray) -> bytes:
+    assert (
+        data.dtype.hasobject is False
+    ), "Input data contains `object` dtype.  Expecting numeric data."
     interface = data.__array_interface__
     if "mask" in interface:
         interface["mask"] = interface["mask"].__array_interface__

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -233,6 +233,8 @@ def _numpy2ctypes_type(dtype):
 
 
 def _array_interface(data: np.ndarray) -> bytes:
+    if data.dtype.hasobject:
+        data = data.astype(float, copy=False)
     interface = data.__array_interface__
     if "mask" in interface:
         interface["mask"] = interface["mask"].__array_interface__

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -114,7 +114,6 @@ def _ensure_np_dtype(data, dtype):
 def _maybe_np_slice(data, dtype):
     '''Handle numpy slice.  This can be removed if we use __array_interface__.
     '''
-    data, dtype = _ensure_np_dtype(data, dtype)
     try:
         if not data.flags.c_contiguous:
             warnings.warn(
@@ -126,6 +125,7 @@ def _maybe_np_slice(data, dtype):
             data = np.array(data, copy=False, dtype=dtype)
     except AttributeError:
         data = np.array(data, copy=False, dtype=dtype)
+    data, dtype = _ensure_np_dtype(data, dtype)
     return data
 
 

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -104,9 +104,17 @@ def _is_numpy_array(data):
     return isinstance(data, (np.ndarray, np.matrix))
 
 
+def _ensure_np_dtype(data, dtype):
+    if data.dtype.hasobject:
+        data = data.astype(np.float32, copy=False)
+        dtype = np.float32
+    return data, dtype
+
+
 def _maybe_np_slice(data, dtype):
     '''Handle numpy slice.  This can be removed if we use __array_interface__.
     '''
+    data, dtype = _ensure_np_dtype(data, dtype)
     try:
         if not data.flags.c_contiguous:
             warnings.warn(

--- a/src/data/array_interface.h
+++ b/src/data/array_interface.h
@@ -231,7 +231,9 @@ class ArrayInterfaceHandler {
     }
 
     auto valid = rows * strides[0] + cols * strides[1] >= (rows * cols);
-    CHECK(valid) << "Invalid strides in array." << "  strides: (" << strides[0] << "," << strides[1] << "), shape: (" << rows << ", " << cols << ")";
+    CHECK(valid) << "Invalid strides in array."
+                 << "  strides: (" << strides[0] << "," << strides[1]
+                 << "), shape: (" << rows << ", " << cols << ")";
   }
 
   static void* ExtractData(std::map<std::string, Json> const &column,

--- a/src/data/array_interface.h
+++ b/src/data/array_interface.h
@@ -229,8 +229,9 @@ class ArrayInterfaceHandler {
       }
       strides[1] = n;
     }
-    auto valid = (rows - 1) * strides[0] + (cols - 1) * strides[1] == (rows * cols) - 1;
-    CHECK(valid) << "Invalid strides in array.";
+
+    auto valid = rows * strides[0] + cols * strides[1] >= (rows * cols);
+    CHECK(valid) << "Invalid strides in array." << "  strides: (" << strides[0] << "," << strides[1] << "), shape: (" << rows << ", " << cols << ")";
   }
 
   static void* ExtractData(std::map<std::string, Json> const &column,

--- a/tests/python/test_predict.py
+++ b/tests/python/test_predict.py
@@ -200,8 +200,13 @@ class TestInplacePredict:
         arr_predt = booster.inplace_predict(X)
         dmat_predt = booster.predict(xgb.DMatrix(X))
 
+        X = df.values
+        X = np.asfortranarray(X)
+        fort_predt = booster.inplace_predict(X)
+
         np.testing.assert_allclose(dmat_predt, arr_predt)
         np.testing.assert_allclose(df_predt, arr_predt)
+        np.testing.assert_allclose(fort_predt, arr_predt)
 
     def test_base_margin(self):
         booster = self.booster

--- a/tests/python/test_predict.py
+++ b/tests/python/test_predict.py
@@ -155,6 +155,14 @@ class TestInplacePredict:
         predt_from_array = booster.inplace_predict(X[:10, ...], missing=self.missing)
         predt_from_dmatrix = booster.predict(test)
 
+        X_obj = X.copy().astype(object)
+
+        assert X_obj.dtype.hasobject is True
+        assert X.dtype.hasobject is False
+        np.testing.assert_allclose(
+            booster.inplace_predict(X_obj), booster.inplace_predict(X)
+        )
+
         np.testing.assert_allclose(predt_from_dmatrix, predt_from_array)
 
         predt_from_array = booster.inplace_predict(


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/6925 .

For some reason, panda returns an array of `object` when dataframe contains boolean values.  When the data is `object` array interface doesn't specify its `itemsize`, leading to error reported from the above issue.

Will be backported 1.4.2.