### PR TITLE
[R] don't remove CMakeLists in cleanup

### DIFF
--- a/R-package/cleanup
+++ b/R-package/cleanup
@@ -1,4 +1,3 @@
 #!/bin/sh
 
 rm -f src/Makevars
-rm -f CMakeLists.txt


### PR DESCRIPTION
currently installing the R-pacakge will leave the repo in dirty state, since
`CmakeLists.txt` is already checked in. This fixes the `cleanup`
script to not delete this file.