### PR TITLE
Improve warning when using np.ndarray subsets

### DIFF
--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -117,9 +117,10 @@ def _maybe_np_slice(data, dtype):
     try:
         if not data.flags.c_contiguous:
             warnings.warn(
-                "Use subset (sliced data) of np.ndarray is not recommended " +
+                "Use of np.ndarray subsets (sliced data) is not recommended " +
                 "because it will generate extra copies and increase " +
-                "memory consumption")
+                "memory consumption. Consider using np.ascontiguousarray to " +
+                "make the array contiguous.")
             data = np.array(data, copy=True, dtype=dtype)
         else:
             data = np.array(data, copy=False, dtype=dtype)


### PR DESCRIPTION
The UserWarning prompted when using numpy subsets was a bit difficult to understand. I also added a suggestion on how to fix the warning.