### PR TITLE
Link to valid tree_method values in docs 

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -106,7 +106,7 @@ __model_doc = f'''
         Specify which tree method to use.  Default to auto.  If this parameter
         is set to default, XGBoost will choose the most conservative option
         available.  It's recommended to study this option from parameters
-        document.
+        document: https://xgboost.readthedocs.io/en/latest/treemethod.html.
     n_jobs : Optional[int]
         Number of parallel threads used to run xgboost.  When used with other Scikit-Learn
         algorithms like grid search, you may choose which algorithm to parallelize and

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -105,7 +105,7 @@ __model_doc = f'''
     tree_method: Optional[str]
         Specify which tree method to use.  Default to auto.  If this parameter
         is set to default, XGBoost will choose the most conservative option
-        available.  It's recommended to study this option from parameters
+        available.  It's recommended to study this option from the parameters
         document: https://xgboost.readthedocs.io/en/latest/treemethod.html.
     n_jobs : Optional[int]
         Number of parallel threads used to run xgboost.  When used with other Scikit-Learn


### PR DESCRIPTION
Within the Python sklearn API reference it's mentioned that `tree_method` should come from the parameters document, but there doesn't appear to be an easy way to find that document. I'm assuming this is what's meant, in which case I think it would be helpful to provide a link in the docstring: https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn