### PR TITLE
Fixed incorrect feature mismatch error message

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1907,7 +1907,7 @@ class Booster(object):
             if len(data.shape) != 1 and self.num_features() != data.shape[1]:
                 raise ValueError(
                     f"Feature shape mismatch, expected: {self.num_features()}, "
-                    f"got {data.shape[0]}"
+                    f"got {data.shape[1]}"
                 )
 
         if isinstance(data, np.ndarray):


### PR DESCRIPTION
data.shape[0] denotes the number of samples, data.shape[1] is the number of features