### PR TITLE
Fix compiler error in x86 building - 2nd request

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -734,8 +734,9 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
   API_BEGIN();
   CHECK_HANDLE();
   std::shared_ptr<xgboost::data::CSRArrayAdapter> x{
-      new xgboost::data::CSRArrayAdapter{
-          StringView{indptr}, StringView{indices}, StringView{data}, (size_t)cols}};
+      new xgboost::data::CSRArrayAdapter{StringView{indptr},
+                                         StringView{indices}, StringView{data},
+                                         static_cast<size_t>(cols)}};
   std::shared_ptr<DMatrix> p_m {nullptr};
   if (m) {
     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -735,7 +735,7 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
   CHECK_HANDLE();
   std::shared_ptr<xgboost::data::CSRArrayAdapter> x{
       new xgboost::data::CSRArrayAdapter{
-          StringView{indptr}, StringView{indices}, StringView{data}, cols}};
+          StringView{indptr}, StringView{indices}, StringView{data}, (size_t)cols}};
   std::shared_ptr<DMatrix> p_m {nullptr};
   if (m) {
     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -231,7 +231,7 @@ void GBTree::DoBoost(DMatrix* p_fmat,
                     : in_gpair->DeviceIdx();
   auto out = MatrixView<float>(
       &predt->predictions,
-      {p_fmat->Info().num_row_, static_cast<size_t>(ngroup)}, device);
+      {static_cast<size_t>(p_fmat->Info().num_row_), static_cast<size_t>(ngroup)}, device);
   CHECK_NE(ngroup, 0);
   if (ngroup == 1) {
     std::vector<std::unique_ptr<RegTree>> ret;


### PR DESCRIPTION
Following `size_t` conversion errors were fixed in x86 release build:
```
Error C2398: Element '4': conversion from 'xgboost::bst_ulong' to 'size_t' requires a narrowing conversion, xgboost\src\c_api\c_api.cc 738	
Error C2397: conversion from 'uint64_t' to '_Ty' requires a narrowing conversion, xgboost\src\gbm\gbtree.cc 234
```