### PR TITLE
Simplify list2mat call from lapply in callbacks.R

### DIFF
--- a/R-package/R/callbacks.R
+++ b/R-package/R/callbacks.R
@@ -647,7 +647,7 @@ cb.gblinear.history <- function(sparse=FALSE) {
           X = seq_along(coefs[[1]]),
           FUN = function(i) lapply(coefs, "[[", i)
         ),
-        FUN = function(x) list2mat(x)
+        FUN = list2mat
       )
     }
   }


### PR DESCRIPTION
`list2mat` is a function of one argument, so the call can be simplified.