### PR TITLE
Corrected lapply comment in callbacks.R

### DIFF
--- a/R-package/R/callbacks.R
+++ b/R-package/R/callbacks.R
@@ -641,7 +641,7 @@ cb.gblinear.history <- function(sparse=FALSE) {
     if (!is.null(env$bst)) { # # xgb.train:
       coefs <<- list2mat(coefs)
     } else { # xgb.cv:
-      # first lapply transposes the list
+      # second lapply transposes the list
       coefs <<- lapply(
         X = lapply(
           X = seq_along(coefs[[1]]),


### PR DESCRIPTION
The comment was made false by the removal of the pipes. What was originally the first `lapply` is now the second. I've done what I can on my own machine to confirm that the second call is indeed doing the job, although one could argue that it's actually the second and the third that are doing the job.

Given that we're using two `lapply`s for one job, I can't help but think that there is an `mapply` or `Map` way to do this better. However, I've tried my best and come up with nothing.