### PR TITLE
[dask] Fix prediction on df with latest dask.

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1000,7 +1000,7 @@ async def _direct_predict_impl(  # pylint: disable=too-many-branches
     output_shape: Tuple[int, ...],
     meta: Dict[int, str],
 ) -> _DaskCollection:
-    columns = list(meta.keys())
+    columns = tuple(meta.keys())
     if len(output_shape) >= 3 and isinstance(data, dd.DataFrame):
         # Without this check, dask will finish the prediction silently even if output
         # dimension is greater than 3.  But during map_partitions, dask passes a


### PR DESCRIPTION
For some unknown reasons in dask 2021.05.0, list is turned into a future for `map_blocks`.  Use tuple instead.