### PR TITLE
[BREAKING] Cleanup `gpu_id` configuration.

### DIFF
--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -76,8 +76,10 @@ class GBLinear : public GradientBooster {
         << "Set `updater` to `coord_descent` or `gpu_coord_descent` along with "
         << "`gpu_id` to enable GPU acceleration.";
     } else {
-      CHECK_EQ(param_.updater, "coord_descent")
-          << "[Internal Error]: `coord_descent` is used bu `gpu_id` is configured to -1.";
+      CHECK_NE(param_.updater, "gpu_coord_descent")
+          << "[Internal Error]: `gpu_coord_descent` is used but `gpu_id` is "
+             "configured: "
+          << generic_param_->gpu_id;
     }
   }
 
@@ -86,6 +88,11 @@ class GBLinear : public GradientBooster {
       model_.Configure(cfg);
     }
     param_.UpdateAllowUnknown(cfg);
+    if (generic_param_->gpu_id != GenericParameter::kCpuId &&
+        param_.updater == "coord_descent") {
+      param_.updater = "gpu_coord_descent";
+    }
+
     updater_.reset(LinearUpdater::Create(param_.updater, generic_param_));
     updater_->Configure(cfg);
     monitor_.Init("GBLinear");

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -69,14 +69,15 @@ class GBLinear : public GradientBooster {
 
   void ValidateUpdater() {
     if (generic_param_->gpu_id != GenericParameter::kCpuId) {
+      // On GPU.
       CHECK(param_.updater == "gpu_coord_descent" || param_.updater == "coord_descent")
         << "`gpu_id` is set to: " << generic_param_->gpu_id << ".  "
         << "Only coordinate descent supports GPU training.  "
         << "Set `updater` to `coord_descent` or `gpu_coord_descent` along with "
         << "`gpu_id` to enable GPU acceleration.";
     } else {
-      CHECK_EQ(param_.updater, "gpu_coord_descent")
-          << "[Internal Error]: `gpu_coord_descent` is used bu `gpu_id` is not configured.";
+      CHECK_EQ(param_.updater, "coord_descent")
+          << "[Internal Error]: `coord_descent` is used bu `gpu_id` is configured to -1.";
     }
   }
 

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -129,7 +129,7 @@ void GBTree::PerformTreeMethodHeuristic(DMatrix* fmat) {
     // set, since only experts are expected to do so.
     return;
   }
-  if (generic_param_->gpu_id != GenericParameter::kCpuId){
+  if (generic_param_->gpu_id != GenericParameter::kCpuId) {
     // Prevent case that tree method is cpu-based but gpu_id is set.  Ideally we
     // should let `gpu_id` be the single source of determining what algorithms
     // to run, but that will break a lots of existing code.

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -58,10 +58,12 @@
  *   - `tree_method` parameter. `gpu_hist` or not.
  *   - `predictor` parameter: `gpu_predictor` or not.
  *   - data: Whether data is already on device (like cupy, cuDF).
- *   - environment: Does the environment have GPU at all?   This might happen
- *                  after users loading a pickled model on CPU only machine.
+ *   - environment: Does the environment have GPU at all?  This might happen after users
+ *                  loading a pickled model on CPU only machine.
  *   - model: User might continue training on an existing model, in which case we don't
  *            want to pull the data into GPU for initial prediction.
+ *   - custom objective: The gradient returned is on CPU while XGBoost might be running on
+ *                       GPU.
  *
  * As you might have notice those inputs are correlated.  XGBoost sorts them into
  * following relationship, please note that the ordering matters:
@@ -70,9 +72,9 @@
  *  2. `gpu_id` *constraints* tree method and predictor.
  *  3. data and model can *temporarily choose* `predictor`, overriding above conditions.
  *
- * This is high level view, this is what we have in practice:
+ * This is high level view.  What we have in practice are:
  *
- *  1. During call `configure` to, gbm returns `UseGPU` by looking at tree method and
+ *  1. During call to `configure`, gbm returns `UseGPU` by looking at tree method and
  *     predictor, then learner sets the `gpu_id` accordingly.  This is the "decides" part.
  *     After this step, the `gpu_id` should be in a valid state and we can ignore the
  *     existance of `gpu_hist` and `gpu_predictor` during decision making (but will still

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -81,7 +81,7 @@
  *     changed by XGBoost here after.
  *
  *  2. During boost, gbm checks the validity of `predictor` and `tree_method`.  For
- *     instance, if user has provided `gpu_id = 0` and `tree_method = hist`, an error is
+ *     instance, if user has provided `gpu_id = 0` and `tree_method = exact`, an error is
  *     thrown.  This is the "constraints" part.
  *
  *  3. When prediction is called, we want to avoid copying data into GPU if it's training
@@ -224,7 +224,7 @@ void GBTree::PerformTreeMethodHeuristic(DMatrix* fmat) {
     tparam_.tree_method = TreeMethod::kGPUHist;
   } else {
     // This should be configured by Learner.
-    CHECK_NE(tparam_.tree_method, TreeMethod::kGPUHist)
+    CHECK(tparam_.tree_method != TreeMethod::kGPUHist)
         << "[Internal Error]: `gpu_hist` is used bu `gpu_id` is not configured.";
   }
 
@@ -655,7 +655,7 @@ GBTree::GetPredictor(bool is_training, HostDeviceVector<float> const *out_pred,
                       !f_dmat->PageExists<SparsePage>();
     if (is_ellpack) {
       // Only GPU Hist can consume ellpack
-      CHECK_EQ(tparam_.tree_method, TreeMethod::kGPUHist);
+      CHECK(tparam_.tree_method == TreeMethod::kGPUHist);
       // Since this is running with GPU Hist, `gpu_id` must already have been set
     }
     // Another case is data came from device memory, like CuDF or CuPy.  In such cases, we

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -32,6 +32,7 @@
 /**
  * # Notes on the very convoluted `gpu_id` configuration.
  *
+ *
  * ## Good news:
  *
  * Before diving into the issues we have, it might be better to mention a possible
@@ -46,7 +47,14 @@
  * This device id should also incooperate OneAPI proposal from Intel.  Also, we plan to
  * dreprecate the `gpu_hist`, `gpu_predictor`, `oneapi_predictor` and all similar
  * constructs so that the `device_id` will be the only authority on how we run XGBoost
- * internally.
+ * internally.  So for instance, if a user provides:
+ *
+ * ``` python
+ * with xgboost.config_context(device_id = "CUDA:0"):
+ *    xgboost.XGBRegressor(tree_method="hist")
+ * ```
+ * Then XGBoost should run `gpu_hist` on first CUDA device internally.
+ *
  *
  * ## Bad news:
  *

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -289,7 +289,7 @@ class GBTree : public GradientBooster {
       }
       LOG(FATAL) << msg;
     } else {
-      bool success = this->GetPredictor()->InplacePredict(
+      bool success = this->GetPredictor(false)->InplacePredict(
           x, p_m, model_, missing, out_preds, tree_begin, tree_end);
       CHECK(success) << msg;
     }
@@ -312,7 +312,7 @@ class GBTree : public GradientBooster {
     std::tie(tree_begin, tree_end) = detail::LayerToTree(model_, tparam_, layer_begin, layer_end);
     CHECK_EQ(tree_begin, 0) << "Predict leaf supports only iteration end: (0, "
                                "n_iteration), use model slicing instead.";
-    this->GetPredictor()->PredictLeaf(p_fmat, out_preds, model_, tree_end);
+    this->GetPredictor(false)->PredictLeaf(p_fmat, out_preds, model_, tree_end);
   }
 
   void PredictContribution(DMatrix* p_fmat,
@@ -325,7 +325,7 @@ class GBTree : public GradientBooster {
     CHECK_EQ(tree_begin, 0)
         << "Predict contribution supports only iteration end: (0, "
            "n_iteration), using model slicing instead.";
-    this->GetPredictor()->PredictContribution(
+    this->GetPredictor(false)->PredictContribution(
         p_fmat, out_contribs, model_, tree_end, nullptr, approximate);
   }
 
@@ -338,7 +338,7 @@ class GBTree : public GradientBooster {
     CHECK_EQ(tree_begin, 0)
         << "Predict interaction contribution supports only iteration end: (0, "
            "n_iteration), using model slicing instead.";
-    this->GetPredictor()->PredictInteractionContributions(
+    this->GetPredictor(false)->PredictInteractionContributions(
         p_fmat, out_contribs, model_, tree_end, nullptr, approximate);
   }
 
@@ -358,8 +358,10 @@ class GBTree : public GradientBooster {
                      int bst_group,
                      std::vector<std::unique_ptr<RegTree> >* ret);
 
-  std::unique_ptr<Predictor> const& GetPredictor(HostDeviceVector<float> const* out_pred = nullptr,
-                                                 DMatrix* f_dmat = nullptr) const;
+  std::unique_ptr<Predictor> const &
+  GetPredictor(bool is_training,
+               HostDeviceVector<float> const *out_pred = nullptr,
+               DMatrix *f_dmat = nullptr) const;
 
   // commit new trees all at once
   virtual void CommitModel(std::vector<std::vector<std::unique_ptr<RegTree>>>&& new_trees,

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -378,6 +378,7 @@ class GBTree : public GradientBooster {
   Args cfg_;
   // the updaters that can be applied to each of tree
   std::vector<std::unique_ptr<TreeUpdater>> updaters_;
+
   // Predictors
   std::unique_ptr<Predictor> cpu_predictor_;
 #if defined(XGBOOST_USE_CUDA)
@@ -386,6 +387,7 @@ class GBTree : public GradientBooster {
 #if defined(XGBOOST_USE_ONEAPI)
   std::unique_ptr<Predictor> oneapi_predictor_;
 #endif  // defined(XGBOOST_USE_ONEAPI)
+
   common::Monitor monitor_;
 };
 

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -811,7 +811,6 @@ class GPUPredictor : public xgboost::Predictor {
   void PredictLeaf(DMatrix *p_fmat, HostDeviceVector<bst_float> *predictions,
                    const gbm::GBTreeModel &model,
                    unsigned tree_end) const override {
-    dh::safe_cuda(cudaSetDevice(generic_param_->gpu_id));
     auto max_shared_memory_bytes = ConfigureDevice(generic_param_->gpu_id);
 
     const MetaInfo& info = p_fmat->Info();
@@ -877,9 +876,12 @@ class GPUPredictor : public xgboost::Predictor {
   /*! \brief Reconfigure the device when GPU is changed. */
   static size_t ConfigureDevice(int device) {
     if (device >= 0) {
+      dh::safe_cuda(cudaSetDevice(device));
       return dh::MaxSharedMemory(device);
+    } else {
+      dh::safe_cuda(cudaSetDevice(0));
+      return dh::MaxSharedMemory(0);
     }
-    return 0;
   }
 };
 

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -99,6 +99,9 @@ void TestInplacePrediction(dmlc::any x, std::string predictor,
   learner->SetParam("subsample", "0.5");
   learner->SetParam("gpu_id", std::to_string(device));
   learner->SetParam("predictor", predictor);
+  if (predictor == "gpu_predictor") {
+    learner->SetParam("tree_method", "gpu_hist");
+  }
   for (int32_t it = 0; it < 4; ++it) {
     learner->UpdateOneIter(it, m);
   }

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -314,6 +314,11 @@ TEST(Learner, GPUConfiguration) {
     learner->SetParams({Arg{"tree_method", "hist"},
                         Arg{"gpu_id", "0"}});
     learner->UpdateOneIter(0, p_dmat);
+    Json config {Object{}};
+    learner->SaveConfig(&config);
+    CHECK_EQ(get<String>(config["learner"]["gradient_booster"]
+                               ["gbtree_train_param"]["tree_method"]),
+             "gpu_hist");
     ASSERT_EQ(learner->GetGenericParameter().gpu_id, 0);
   }
   {

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -166,7 +166,7 @@ void TestLearnerSerialization(Args args, FeatureMap const& fmap, std::shared_ptr
     learner->Save(&mem_out);
     ASSERT_EQ(model_at_kiter, serialised_model_tmp);
 
-    learner->SetParam("gpu_id", "0");
+    // learner->SetParam("gpu_id", "0");
     // Pull data to device
     for (auto &batch : p_dmat->GetBatches<SparsePage>()) {
       batch.data.SetDevice(0);
@@ -184,9 +184,8 @@ void TestLearnerSerialization(Args args, FeatureMap const& fmap, std::shared_ptr
 
     Json m_0 = Json::Load(StringView{model_at_2kiter.c_str(), model_at_2kiter.size()});
     Json m_1 = Json::Load(StringView{serialised_model_tmp.c_str(), serialised_model_tmp.size()});
-    // GPU ID is changed as data is coming from device.
-    ASSERT_EQ(get<Object>(m_0["Config"]["learner"]["generic_param"]).erase("gpu_id"),
-              get<Object>(m_1["Config"]["learner"]["generic_param"]).erase("gpu_id"));
+    ASSERT_EQ(get<Object>(m_0["Config"]["learner"]["generic_param"]),
+              get<Object>(m_1["Config"]["learner"]["generic_param"]));
   }
 }
 

--- a/tests/python-gpu/test_gpu_basic_models.py
+++ b/tests/python-gpu/test_gpu_basic_models.py
@@ -6,11 +6,13 @@ import pytest
 sys.path.append("tests/python")
 # Don't import the test class, otherwise they will run twice.
 import test_callback as test_cb  # noqa
+import test_basic_models as test_bm
 rng = np.random.RandomState(1994)
 
 
 class TestGPUBasicModels:
-    cputest = test_cb.TestCallbacks()
+    cpu_test_cb = test_cb.TestCallbacks()
+    cpu_test_bm = test_bm.TestModels()
 
     def run_cls(self, X, y, deterministic):
         cls = xgb.XGBClassifier(tree_method='gpu_hist',
@@ -35,9 +37,12 @@ class TestGPUBasicModels:
 
         return hash(model_0), hash(model_1)
 
+    def test_custom_objective(self):
+        self.cpu_test_bm.run_custom_objective("gpu_hist")
+
     def test_eta_decay_gpu_hist(self):
-        self.cputest.run_eta_decay('gpu_hist', True)
-        self.cputest.run_eta_decay('gpu_hist', False)
+        self.cpu_test_cb.run_eta_decay('gpu_hist', True)
+        self.cpu_test_cb.run_eta_decay('gpu_hist', False)
 
     def test_deterministic_gpu_hist(self):
         kRows = 1000

--- a/tests/python-gpu/test_gpu_prediction.py
+++ b/tests/python-gpu/test_gpu_prediction.py
@@ -248,13 +248,16 @@ class TestGPUPredict:
            tm.dataset_strategy, shap_parameter_strategy)
     @settings(deadline=None)
     def test_shap(self, num_rounds, dataset, param):
-        param.update({"predictor": "gpu_predictor", "gpu_id": 0})
+        param.update({"gpu_id": 0})
         param = dataset.set_params(param)
         dmat = dataset.get_dmat()
         bst = xgb.train(param, dmat, num_rounds)
+
         test_dmat = xgb.DMatrix(dataset.X, dataset.y, dataset.w, dataset.margin)
+        bst.set_param({"predictor": "gpu_predictor"})
         shap = bst.predict(test_dmat, pred_contribs=True)
         margin = bst.predict(test_dmat, output_margin=True)
+
         assume(len(dataset.y) > 0)
         assert np.allclose(np.sum(shap, axis=len(shap.shape) - 1), margin, 1e-3, 1e-3)
 

--- a/tests/python-gpu/test_gpu_prediction.py
+++ b/tests/python-gpu/test_gpu_prediction.py
@@ -332,6 +332,7 @@ class TestGPUPredict:
         rmse = mean_squared_error(y_true=y, y_pred=pred, squared=False)
         np.testing.assert_almost_equal(rmse, eval_history['train']['rmse'][-1], decimal=5)
 
+    @pytest.mark.skipif(**tm.no_cupy())
     @pytest.mark.parametrize("n_classes", [2, 3])
     def test_predict_dart(self, n_classes):
         from sklearn.datasets import make_classification

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -138,8 +138,13 @@ class TestModels:
         # behaviour is considered sub-optimal, feel free to change.
         assert booster.num_boosted_rounds() == 4
 
-    def test_custom_objective(self):
-        param = {'max_depth': 2, 'eta': 1, 'objective': 'reg:logistic'}
+    def run_custom_objective(self, tree_method=None):
+        param = {
+            'max_depth': 2,
+            'eta': 1,
+            'objective': 'reg:logistic',
+            "tree_method": tree_method
+        }
         watchlist = [(dtest, 'eval'), (dtrain, 'train')]
         num_round = 10
 
@@ -180,6 +185,9 @@ class TestModels:
         err2 = sum(1 for i in range(len(preds2))
                    if int(preds2[i] > 0.5) != labels[i]) / float(len(preds2))
         assert err == err2
+
+    def test_custom_objective(self):
+        self.run_custom_objective()
 
     def test_multi_eval_metric(self):
         watchlist = [(dtest, 'eval'), (dtrain, 'train')]

--- a/tests/python/test_predict.py
+++ b/tests/python/test_predict.py
@@ -49,12 +49,13 @@ def run_predict_leaf(predictor):
         {
             "num_parallel_tree": num_parallel_tree,
             "num_class": classes,
-            "predictor": predictor,
             "tree_method": "hist",
         },
         m,
         num_boost_round=num_boost_round,
     )
+
+    booster.set_param({"predictor": predictor})
 
     empty = xgb.DMatrix(np.ones(shape=(0, cols)))
     empty_leaf = booster.predict(empty, pred_leaf=True)
@@ -78,6 +79,7 @@ def run_predict_leaf(predictor):
 
     # When there's only 1 tree, the output is a 1 dim vector
     booster = xgb.train({"tree_method": "hist"}, num_boost_round=1, dtrain=m)
+    booster.set_param({"predictor": predictor})
     assert booster.predict(m, pred_leaf=True).shape == (rows, )
 
     return leaf


### PR DESCRIPTION
Recently found a bug that was introduced in updating the prediction cache for `gpu_hist`.  When a custom objective is used, the gradient is on CPU.  This PR fixes it by prioritizing the `gpu_id` parameter.

Other than the bug fix, this PR also tries to cleanup and clarify the configuration of this parameter.  Please see the note in `gbtree.cc` for details.

Here breaking means, one can no longer run into edge cases like having `gpu_id = 0` while running CPU `exact`.  Overall it should not change normal usage.

Todos:
- [x] Correct linear updaters.
- [ ] Add tests for the state transition.