### PR TITLE
lazy_isinstance(): use .__class__ for type checking

### DIFF
--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -20,9 +20,13 @@ def py_str(x):
 
 
 def lazy_isinstance(instance, module, name):
-    '''Use string representation to identify a type.'''
-    module = type(instance).__module__ == module
-    name = type(instance).__name__ == name
+    """Use string representation to identify a type."""
+
+    # Notice, we use .__class__ as opposed to type() in order
+    # to support object proxies such as weakref.proxy
+    cls = instance.__class__
+    module = cls.__module__ == module
+    name = cls.__name__ == name
     return module and name
 
 


### PR DESCRIPTION
In order to support object wrappers/proxies like [`weakref.proxy`](https://docs.python.org/3/library/weakref.html#weakref.proxy) and rapidsai/dask-cuda#451, this PR implements type checking using `x.__class__` instead of `type(x)`.

This PR shouldn't change any semantic other than the support of proxies.

We did something similar in Dask, for a detailed discussion of the difference between  `__class__` and `type` see https://github.com/dask/dask/pull/6981

This change is motivated by https://github.com/rapidsai/dask-cuda/issues/610

cc @trivialfis @VibhuJawa