### PR TITLE
Grouping features for computing feature contributions (SHAP values)

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -726,6 +726,8 @@ XGB_DLL int XGBoosterEvalOneIter(BoosterHandle handle,
  *    The second scenario applies when you are defining a custom objective function.
  * \param out_len used to store length of returning result
  * \param out_result used to set a pointer to array
+ * \param group_indices group index of features for group of feature contributions 
+ * \param num_feat_group the number of feature groups provided in group_indices
  * \return 0 when success, -1 when failure happens
  */
 XGB_DLL int XGBoosterPredict(BoosterHandle handle,
@@ -734,7 +736,9 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
                              unsigned ntree_limit,
                              int training,
                              bst_ulong *out_len,
-                             const float **out_result);
+                             const float **out_result,
+                             int *group_indices = nullptr,
+                             int num_feat_group = 0);
 /*!
  * \brief Make prediction from DMatrix, replacing `XGBoosterPredict`.
  *
@@ -788,6 +792,8 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle,
  * \param out_shape Shape of output prediction (copy before use).
  * \param out_dim   Dimension of output prediction.
  * \param out_result Buffer storing prediction value (copy before use).
+ * \param group_indices group index of features for group of feature contributions 
+ * \param num_feat_group the number of feature groups provided in group_indices
  *
  * \return 0 when success, -1 when failure happens
  */
@@ -796,7 +802,9 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle,
                                         char const* c_json_config,
                                         bst_ulong const **out_shape,
                                         bst_ulong *out_dim,
-                                        float const **out_result);
+                                        float const **out_result,
+                                        int *group_indices = nullptr,
+                                        int num_feat_group = 0);
 /*
  * \brief Inplace prediction from CPU dense matrix.
  *

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -158,18 +158,22 @@ class GradientBooster : public Model, public Configurable {
    * \param layer_begin Beginning of boosted tree layer used for prediction.
    * \param layer_end   End of booster layer. 0 means do not limit trees.
    * \param approximate use a faster (inconsistent) approximation of SHAP values
+   * \param group_indices group index of features for group of feature contributions 
+   * \param num_feat_group the number of feature groups provided in group_indices
    * \param condition condition on the condition_feature (0=no, -1=cond off, 1=cond on).
    * \param condition_feature feature to condition on (i.e. fix) during calculations
    */
   virtual void PredictContribution(DMatrix* dmat,
                                    HostDeviceVector<bst_float>* out_contribs,
                                    unsigned layer_begin, unsigned layer_end,
-                                   bool approximate = false, int condition = 0,
-                                   unsigned condition_feature = 0) = 0;
+                                   bool approximate = false,
+                                   int *group_indices = nullptr, int num_feat_group = 0,
+                                   int condition = 0, unsigned condition_feature = 0) = 0;
 
   virtual void PredictInteractionContributions(
       DMatrix *dmat, HostDeviceVector<bst_float> *out_contribs,
-      unsigned layer_begin, unsigned layer_end, bool approximate) = 0;
+      unsigned layer_begin, unsigned layer_end, bool approximate,
+      int *group_indices = nullptr, int num_feat_group = 0) = 0;
 
   /*!
    * \brief dump the model in the requested format

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -121,6 +121,8 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    * \param pred_contribs whether to only predict the feature contributions
    * \param approx_contribs whether to approximate the feature contributions for speed
    * \param pred_interactions whether to compute the feature pair contributions
+   * \param group_indices group index of features for group of feature contributions 
+   * \param num_feat_group the number of feature groups provided in group_indices
    */
   virtual void Predict(std::shared_ptr<DMatrix> data,
                        bool output_margin,
@@ -131,7 +133,9 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
                        bool pred_leaf = false,
                        bool pred_contribs = false,
                        bool approx_contribs = false,
-                       bool pred_interactions = false) = 0;
+                       bool pred_interactions = false,
+                       int *group_indices = nullptr,
+                       int num_feat_group = 0) = 0;
 
   /*!
    * \brief Inplace prediction.

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -202,6 +202,8 @@ class Predictor {
    * \param           tree_end           The tree end index.
    * \param           tree_weights       (Optional) Weights to multiply each tree by.
    * \param           approximate        Use fast approximate algorithm.
+   * \param           group_indices      Group index of features for group of feature contributions 
+   * \param           num_feat_group     The number of feature groups provided in group_indices
    * \param           condition          Condition on the condition_feature (0=no, -1=cond off, 1=cond on).
    * \param           condition_feature  Feature to condition on (i.e. fix) during calculations.
    */
@@ -212,6 +214,8 @@ class Predictor {
                                    unsigned tree_end = 0,
                                    std::vector<bst_float>* tree_weights = nullptr,
                                    bool approximate = false,
+                                   int *group_indices = nullptr,
+                                   int num_feat_group = 0,
                                    int condition = 0,
                                    unsigned condition_feature = 0) const = 0;
 
@@ -220,7 +224,9 @@ class Predictor {
                                                const gbm::GBTreeModel& model,
                                                unsigned tree_end = 0,
                                                std::vector<bst_float>* tree_weights = nullptr,
-                                               bool approximate = false) const = 0;
+                                               bool approximate = false,
+                                               int *group_indices = nullptr,
+                                               int num_feat_group = 0) const = 0;
 
 
   /**

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <tuple>
 #include <stack>
+#include <functional>
 
 namespace xgboost {
 
@@ -549,12 +550,14 @@ class RegTree : public Model {
    * \brief calculate the feature contributions (https://arxiv.org/abs/1706.06060) for the tree
    * \param feat dense feature vector, if the feature is missing the field is set to NaN
    * \param out_contribs output vector to hold the contributions
+   * \param group_indices group index of features for group of feature contributions 
+   * \param num_feat_group the number of feature groups provided in group_indices
    * \param condition fix one feature to either off (-1) on (1) or not fixed (0 default)
    * \param condition_feature the index of the feature to fix
    */
-  void CalculateContributions(const RegTree::FVec& feat,
-                              bst_float* out_contribs, int condition = 0,
-                              unsigned condition_feature = 0) const;
+  void CalculateContributions(const RegTree::FVec& feat, bst_float* out_contribs,
+                              int *group_indices = nullptr, int num_feat_group = 0,
+                              int condition = 0, unsigned condition_feature = 0) const;
   /*!
    * \brief Recursive function that computes the feature attributions for a single tree.
    * \param feat dense feature vector, if the feature is missing the field is set to NaN
@@ -568,12 +571,14 @@ class RegTree : public Model {
    * \param condition fix one feature to either off (-1) on (1) or not fixed (0 default)
    * \param condition_feature the index of the feature to fix
    * \param condition_fraction what fraction of the current weight matches our conditioning feature
+   * \param group_index_f function that returns group index of feature
    */
   void TreeShap(const RegTree::FVec& feat, bst_float* phi, unsigned node_index,
                 unsigned unique_depth, PathElement* parent_unique_path,
                 bst_float parent_zero_fraction, bst_float parent_one_fraction,
                 int parent_feature_index, int condition,
-                unsigned condition_feature, bst_float condition_fraction) const;
+                unsigned condition_feature, bst_float condition_fraction,
+                const std::function<unsigned(unsigned)>& group_index_f = [](int i){return i;}) const;
 
   /*!
    * \brief calculate the approximate feature contributions for the given root

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -99,7 +99,8 @@ class XGBoostJNI {
                                                       String[] evnames, String[] eval_info);
 
   public final static native int XGBoosterPredict(long handle, long dmat, int option_mask,
-                                                  int ntree_limit, float[][] predicts);
+                                                  int ntree_limit, float[][] predicts,
+                                                  int[] groupIndices, int numFeatureGroup);
 
   public final static native int XGBoosterLoadModel(long handle, String fname);
 

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -587,14 +587,18 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterEvalOneIt
  * Signature: (JJIJ)[F
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredict
-  (JNIEnv *jenv, jclass jcls, jlong jhandle, jlong jdmat, jint joption_mask, jint jntree_limit, jobjectArray jout) {
+  (JNIEnv *jenv, jclass jcls, jlong jhandle, jlong jdmat, jint joption_mask, jint jntree_limit,
+   jobjectArray jout, jintArray jgroup_indices, jint jnum_feat_group) {
+
   BoosterHandle handle = (BoosterHandle) jhandle;
   DMatrixHandle dmat = (DMatrixHandle) jdmat;
   bst_ulong len;
   float *result;
+  jint *group_indices = nullptr;
+  if (jgroup_indices != nullptr) group_indices = jenv->GetIntArrayElements(jgroup_indices, 0);
   int ret = XGBoosterPredict(handle, dmat, joption_mask, (unsigned int) jntree_limit,
                              /* training = */ 0,  // Currently this parameter is not supported by JVM
-                             &len, (const float **) &result);
+                             &len, (const float **) &result, (int *) group_indices, jnum_feat_group);
   JVM_CHECK_CALL(ret);
   if (len) {
     jsize jlen = (jsize) len;

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.h
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.h
@@ -181,7 +181,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterEvalOneIt
  * Signature: (JJII[[F)I
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredict
-  (JNIEnv *, jclass, jlong, jlong, jint, jint, jobjectArray);
+  (JNIEnv *, jclass, jlong, jlong, jint, jint, jobjectArray, jintArray, jint);
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI

--- a/plugin/updater_oneapi/predictor_oneapi.cc
+++ b/plugin/updater_oneapi/predictor_oneapi.cc
@@ -416,16 +416,18 @@ class PredictorOneAPI : public Predictor {
   void PredictContribution(DMatrix* p_fmat, std::vector<bst_float>* out_contribs,
                            const gbm::GBTreeModel& model, uint32_t ntree_limit,
                            std::vector<bst_float>* tree_weights,
-                           bool approximate, int condition,
-                           unsigned condition_feature) override {
-    cpu_predictor->PredictContribution(p_fmat, out_contribs, model, ntree_limit, tree_weights, approximate, condition, condition_feature);
+                           bool approximate, int *group_indices, int num_feat_group,
+                           int condition, unsigned condition_feature) override {
+    cpu_predictor->PredictContribution(p_fmat, out_contribs, model, ntree_limit, tree_weights, approximate,
+                                       group_indices, num_feat_group, condition, condition_feature);
   }
 
   void PredictInteractionContributions(DMatrix* p_fmat, std::vector<bst_float>* out_contribs,
                                        const gbm::GBTreeModel& model, unsigned ntree_limit,
                                        std::vector<bst_float>* tree_weights,
-                                       bool approximate) override {
-    cpu_predictor->PredictInteractionContributions(p_fmat, out_contribs, model, ntree_limit, tree_weights, approximate);
+                                       bool approximate, int *group_indices, int num_feat_group) override {
+    cpu_predictor->PredictInteractionContributions(p_fmat, out_contribs, model, ntree_limit, tree_weights,
+                                                   approximate, group_indices, num_feat_group);
   }
 
  private:

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -163,7 +163,8 @@ class GBLinear : public GradientBooster {
 
   void PredictContribution(DMatrix* p_fmat,
                            HostDeviceVector<bst_float>* out_contribs,
-                           unsigned layer_begin, unsigned layer_end, bool, int, unsigned) override {
+                           unsigned layer_begin, unsigned layer_end, bool,
+                           int*, int, int, unsigned) override {
     model_.LazyInitModel();
     LinearCheckLayer(layer_begin, layer_end);
     const auto& base_margin = p_fmat->Info().base_margin_.ConstHostVector();
@@ -201,7 +202,8 @@ class GBLinear : public GradientBooster {
 
   void PredictInteractionContributions(DMatrix* p_fmat,
                                        HostDeviceVector<bst_float>* out_contribs,
-                                       unsigned layer_begin, unsigned layer_end, bool) override {
+                                       unsigned layer_begin, unsigned layer_end, bool,
+                                       int*, int) override {
     LinearCheckLayer(layer_begin, layer_end);
     std::vector<bst_float>& contribs = out_contribs->HostVector();
 

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -858,23 +858,26 @@ class Dart : public GBTree {
 
   void PredictContribution(DMatrix* p_fmat,
                            HostDeviceVector<bst_float>* out_contribs,
-                           unsigned layer_begin, unsigned layer_end, bool approximate, int,
-                           unsigned) override {
+                           unsigned layer_begin, unsigned layer_end, bool approximate,
+                           int *group_indices, int num_feat_group, int, unsigned) override {
     CHECK(configured_);
     uint32_t tree_begin, tree_end;
     std::tie(tree_begin, tree_end) = detail::LayerToTree(model_, tparam_, layer_begin, layer_end);
     cpu_predictor_->PredictContribution(p_fmat, out_contribs, model_,
-                                        tree_end, &weight_drop_, approximate);
+                                        tree_end, &weight_drop_, approximate,
+                                        group_indices, num_feat_group);
   }
 
   void PredictInteractionContributions(
       DMatrix *p_fmat, HostDeviceVector<bst_float> *out_contribs,
-      unsigned layer_begin, unsigned layer_end, bool approximate) override {
+      unsigned layer_begin, unsigned layer_end, bool approximate,
+      int *group_indices, int num_feat_group) override {
     CHECK(configured_);
     uint32_t tree_begin, tree_end;
     std::tie(tree_begin, tree_end) = detail::LayerToTree(model_, tparam_, layer_begin, layer_end);
     cpu_predictor_->PredictInteractionContributions(p_fmat, out_contribs, model_,
-                                                    tree_end, &weight_drop_, approximate);
+                                                    tree_end, &weight_drop_, approximate,
+                                                    group_indices, num_feat_group);
   }
 
  protected:

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -318,7 +318,7 @@ class GBTree : public GradientBooster {
   void PredictContribution(DMatrix* p_fmat,
                            HostDeviceVector<bst_float>* out_contribs,
                            uint32_t layer_begin, uint32_t layer_end, bool approximate,
-                           int, unsigned) override {
+                           int *group_indices, int num_feat_group, int, unsigned) override {
     CHECK(configured_);
     uint32_t tree_begin, tree_end;
     std::tie(tree_begin, tree_end) = detail::LayerToTree(model_, tparam_, layer_begin, layer_end);
@@ -326,12 +326,13 @@ class GBTree : public GradientBooster {
         << "Predict contribution supports only iteration end: (0, "
            "n_iteration), using model slicing instead.";
     this->GetPredictor()->PredictContribution(
-        p_fmat, out_contribs, model_, tree_end, nullptr, approximate);
+      p_fmat, out_contribs, model_, tree_end, nullptr, approximate, group_indices, num_feat_group);
   }
 
   void PredictInteractionContributions(
       DMatrix *p_fmat, HostDeviceVector<bst_float> *out_contribs,
-      uint32_t layer_begin, uint32_t layer_end, bool approximate) override {
+      uint32_t layer_begin, uint32_t layer_end, bool approximate,
+      int *group_indices, int num_feat_group) override {
     CHECK(configured_);
     uint32_t tree_begin, tree_end;
     std::tie(tree_begin, tree_end) = detail::LayerToTree(model_, tparam_, layer_begin, layer_end);
@@ -339,7 +340,7 @@ class GBTree : public GradientBooster {
         << "Predict interaction contribution supports only iteration end: (0, "
            "n_iteration), using model slicing instead.";
     this->GetPredictor()->PredictInteractionContributions(
-        p_fmat, out_contribs, model_, tree_end, nullptr, approximate);
+      p_fmat, out_contribs, model_, tree_end, nullptr, approximate, group_indices, num_feat_group);
   }
 
   std::vector<std::string> DumpModel(const FeatureMap& fmap,

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1133,17 +1133,18 @@ class LearnerImpl : public LearnerIO {
                HostDeviceVector<bst_float> *out_preds, unsigned layer_begin,
                unsigned layer_end, bool training,
                bool pred_leaf, bool pred_contribs, bool approx_contribs,
-               bool pred_interactions) override {
+               bool pred_interactions, int *group_indices, int num_feat_group) override {
     int multiple_predictions = static_cast<int>(pred_leaf) +
                                static_cast<int>(pred_interactions) +
                                static_cast<int>(pred_contribs);
     this->Configure();
     CHECK_LE(multiple_predictions, 1) << "Perform one kind of prediction at a time.";
     if (pred_contribs) {
-      gbm_->PredictContribution(data.get(), out_preds, layer_begin, layer_end, approx_contribs);
+      gbm_->PredictContribution(data.get(), out_preds, layer_begin, layer_end, approx_contribs,
+                                group_indices, num_feat_group);
     } else if (pred_interactions) {
       gbm_->PredictInteractionContributions(data.get(), out_preds, layer_begin, layer_end,
-                                            approx_contribs);
+                                            approx_contribs, group_indices, num_feat_group);
     } else if (pred_leaf) {
       gbm_->PredictLeaf(data.get(), out_preds, layer_begin, layer_end);
     } else {

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -684,8 +684,8 @@ class GPUPredictor : public xgboost::Predictor {
                            HostDeviceVector<bst_float>* out_contribs,
                            const gbm::GBTreeModel& model, unsigned tree_end,
                            std::vector<bst_float>*,
-                           bool approximate, int,
-                           unsigned) const override {
+                           bool approximate, int*, int,
+                           int, unsigned) const override {
     if (approximate) {
       LOG(FATAL) << "Approximated contribution is not implemented in GPU Predictor.";
     }
@@ -734,7 +734,7 @@ class GPUPredictor : public xgboost::Predictor {
                                        const gbm::GBTreeModel& model,
                                        unsigned tree_end,
                                        std::vector<bst_float>*,
-                                       bool approximate) const override {
+                                       bool approximate, int*, int) const override {
     if (approximate) {
       LOG(FATAL) << "[Internal error]: " << __func__
                  << " approximate is not implemented in GPU Predictor.";

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -1259,10 +1259,11 @@ void RegTree::CalculateContributions(const RegTree::FVec &feat,
 
   // function for group_index
   std::function<unsigned(unsigned)> group_index_f;
-  if (group_indices == nullptr)
+  if (group_indices == nullptr) {
     group_index_f = [] (unsigned feature_index) { return feature_index; };
-  else
+  } else {
     group_index_f = [&] (unsigned feature_index) { return group_indices[feature_index]; };
+  }
 
   TreeShap(feat, out_contribs, 0, 0, unique_path_data.data(),
            1, 1, -1, condition, condition_feature, 1, group_index_f);


### PR DESCRIPTION
Categorial features are often preprocessed by one-hot encoding. PredictContribution() computes SHAP values for each feature. The issue is if there are one-hot encoded features, it computes SHAP values for each one-hot (yes or no) feature. But what we really want is the SHAP value of the original categorical feature (group of one-hot encoded features).

In this PR, PredictContribution() takes group_indices (array of int) which contains a group index given a feature index. Then, SHAP values are computed for each group of features. 

Moreover, this is useful when there are too many features and feature contributions are hard to interpret. Grouping features gives better interpretability and also saves computation time and memory of TreeSHAP.

I hope this will be implemented for the GPU version in future releases.