### PR TITLE
Remove warning when NumPy slice is used

### DIFF
--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -116,11 +116,6 @@ def _maybe_np_slice(data, dtype):
     '''
     try:
         if not data.flags.c_contiguous:
-            warnings.warn(
-                "Use of np.ndarray subsets (sliced data) is not recommended " +
-                "because it will generate extra copies and increase " +
-                "memory consumption. Consider using np.ascontiguousarray to " +
-                "make the array contiguous.")
             data = np.array(data, copy=True, dtype=dtype)
         else:
             data = np.array(data, copy=False, dtype=dtype)


### PR DESCRIPTION
Context: https://github.com/dmlc/xgboost/issues/6908#issuecomment-834658652

Scikit-learn's grid search CV send sliced NumPy arrays into XGBoost, leading to many warnings of form
```
Use of np.ndarray subsets (sliced data) is not recommended
because it will generate extra copies and increase 
memory consumption. Consider using np.ascontiguousarray to
make the array contiguous.
```

Users have no way to control the behavior of scikit-learn, so the warnings only serve to annoy the user. For now, just remove the warning.

To really address the increased memory consumption caused by copying sliced arrays, we will need to implement #6908 (Use array interface in NumPy) in order to ingest sliced arrays without making copies.