### PR TITLE
Support for all primitive types from array.

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -142,7 +142,7 @@ XGB_DLL int XGDMatrixCreateFromCSR(char const *indptr,
  * \param out created dmatrix
  * \return 0 when success, -1 when failure happens
  */
-XGB_DLL int XGDMatrixCreateFromArray(char const *data,
+XGB_DLL int XGDMatrixCreateFromDense(char const *data,
                                      char const *json_config,
                                      DMatrixHandle *out);
 

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -421,7 +421,7 @@ def _transform_cupy_array(data):
     if not hasattr(data, '__cuda_array_interface__') and hasattr(
             data, '__array__'):
         data = cupy.array(data, copy=False)
-    if data.dtype in [cupy.float16, cupy.bool_]:
+    if data.dtype.hasobject or data.dtype in [cupy.float16, cupy.bool_]:
         data = data.astype(cupy.float32, copy=False)
     return data
 

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -141,7 +141,7 @@ def _from_numpy_array(data, missing, nthread, feature_names, feature_types):
     }
     config = bytes(json.dumps(args), "utf-8")
     _check_call(
-        _LIB.XGDMatrixCreateFromArray(
+        _LIB.XGDMatrixCreateFromDense(
             _array_interface(data),
             config,
             ctypes.byref(handle),

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -261,7 +261,7 @@ XGB_DLL int XGDMatrixCreateFromCSR(char const *indptr,
   API_END();
 }
 
-XGB_DLL int XGDMatrixCreateFromArray(char const *data,
+XGB_DLL int XGDMatrixCreateFromDense(char const *data,
                                      char const *c_json_config,
                                      DMatrixHandle *out) {
   API_BEGIN();

--- a/src/data/array_interface.h
+++ b/src/data/array_interface.h
@@ -138,7 +138,7 @@ class ArrayInterfaceHandler {
     }
 
     auto typestr = get<String const>(array.at("typestr"));
-    CHECK(typestr.size() == 3 || typestr.size() == 4) << ArrayInterfaceErrors::TypestrFormat();;
+    CHECK(typestr.size() == 3 || typestr.size() == 4) << ArrayInterfaceErrors::TypestrFormat();
     CHECK_NE(typestr.front(), '>') << ArrayInterfaceErrors::BigEndian();
 
     if (array.find("shape") == array.cend()) {

--- a/src/data/array_interface.h
+++ b/src/data/array_interface.h
@@ -371,7 +371,7 @@ class ArrayInterface {
       return func(reinterpret_cast<float *>(data));
     case kF8:
       return func(reinterpret_cast<double *>(data));
-#ifndef __CUDA_ARCH__
+#ifdef __CUDA_ARCH__
     case kF16: {
       // CUDA device code doesn't support long double.
       SPAN_CHECK(false);

--- a/src/data/array_interface.h
+++ b/src/data/array_interface.h
@@ -42,7 +42,8 @@ struct ArrayInterfaceErrors {
     return str.c_str();
   }
   static char const* Version() {
-    return "Only version <= 3 of `__cuda_array_interface__' are supported.";
+    return "Only version <= 3 of "
+           "`__cuda_array_interface__/__array_interface__' are supported.";
   }
   static char const* OfType(std::string const& type) {
     static std::string str;
@@ -81,7 +82,7 @@ struct ArrayInterfaceErrors {
         return "Other";
       default:
         LOG(FATAL) << "Invalid type code: " << c << " in `typestr' of input array."
-                   << "\nPlease verify the `__cuda_array_interface__' "
+                   << "\nPlease verify the `__cuda_array_interface__/__array_interface__' "
                    << "of your input data complies to: "
                    << "https://docs.scipy.org/doc/numpy/reference/arrays.interface.html"
                    << "\nOr open an issue.";
@@ -90,7 +91,7 @@ struct ArrayInterfaceErrors {
   }
 
   static std::string UnSupportedType(StringView typestr) {
-    return TypeStr(typestr[1]) + " is not supported.";
+    return TypeStr(typestr[1]) + "-" + typestr[2] + " is not supported.";
   }
 };
 

--- a/src/data/array_interface.h
+++ b/src/data/array_interface.h
@@ -372,6 +372,12 @@ class ArrayInterface {
     case kF8:
       return func(reinterpret_cast<double *>(data));
 #ifndef __CUDA_ARCH__
+    case kF16: {
+      // CUDA device code doesn't support long double.
+      SPAN_CHECK(false);
+      return func(reinterpret_cast<double *>(data));
+    }
+#else
     case kF16:
       return func(reinterpret_cast<long double *>(data));
 #endif

--- a/tests/ci_build/conda_env/macos_cpu_test.yml
+++ b/tests/ci_build/conda_env/macos_cpu_test.yml
@@ -13,8 +13,8 @@ dependencies:
 - scikit-learn
 - pandas
 - matplotlib
-- dask
-- distributed
+- dask=2021.05.0
+- distributed=2021.05.0
 - graphviz
 - python-graphviz
 - hypothesis

--- a/tests/python-gpu/test_gpu_prediction.py
+++ b/tests/python-gpu/test_gpu_prediction.py
@@ -379,6 +379,7 @@ class TestGPUPredict:
         copied = cp.array(copied)
         cp.testing.assert_allclose(inplace, copied, atol=1e-6)
 
+    @pytest.mark.skipif(**tm.no_cupy())
     def test_dtypes(self):
         import cupy as cp
         rows = 1000

--- a/tests/python-gpu/test_gpu_prediction.py
+++ b/tests/python-gpu/test_gpu_prediction.py
@@ -204,6 +204,7 @@ class TestGPUPredict:
         cpu_predt = reg.predict(X)
         np.testing.assert_allclose(gpu_predt, cpu_predt, atol=1e-6)
 
+    @pytest.mark.skipif(**tm.no_cupy())
     @pytest.mark.skipif(**tm.no_cudf())
     def test_inplace_predict_cudf(self):
         import cupy as cp
@@ -332,6 +333,7 @@ class TestGPUPredict:
         rmse = mean_squared_error(y_true=y, y_pred=pred, squared=False)
         np.testing.assert_almost_equal(rmse, eval_history['train']['rmse'][-1], decimal=5)
 
+    @pytest.mark.skipif(**tm.no_cupy())
     @pytest.mark.parametrize("n_classes", [2, 3])
     def test_predict_dart(self, n_classes):
         from sklearn.datasets import make_classification

--- a/tests/python/test_predict.py
+++ b/tests/python/test_predict.py
@@ -281,7 +281,6 @@ class TestInplacePredict:
             np.string_,
             np.complex64,
             np.complex128,
-            np.complex256,
         ]:
             X = np.array(orig, dtype=dtype)
             with pytest.raises(ValueError):

--- a/tests/python/test_predict.py
+++ b/tests/python/test_predict.py
@@ -237,3 +237,52 @@ class TestInplacePredict:
         dtrain = xgb.DMatrix(self.X, self.y, base_margin=base_margin)
         from_dmatrix = booster.predict(dtrain)
         np.testing.assert_allclose(from_dmatrix, from_inplace)
+
+    def test_dtypes(self):
+        orig = self.rng.randint(low=0, high=127, size=self.rows * self.cols).reshape(
+            self.rows, self.cols
+        )
+        predt_orig = self.booster.inplace_predict(orig)
+        # all primitive types in numpy
+        for dtype in [
+            np.signedinteger,
+            np.byte,
+            np.short,
+            np.intc,
+            np.int_,
+            np.longlong,
+            np.unsignedinteger,
+            np.ubyte,
+            np.ushort,
+            np.uintc,
+            np.uint,
+            np.ulonglong,
+            np.floating,
+            np.half,
+            np.single,
+            np.double,
+        ]:
+            X = np.array(orig, dtype=dtype)
+            predt = self.booster.inplace_predict(X)
+            np.testing.assert_allclose(predt, predt_orig)
+
+        # boolean
+        orig = self.rng.binomial(1, 0.5, size=self.rows * self.cols).reshape(
+            self.rows, self.cols
+        )
+        predt_orig = self.booster.inplace_predict(orig)
+        for dtype in [np.bool8, np.bool_]:
+            X = np.array(orig, dtype=dtype)
+            predt = self.booster.inplace_predict(X)
+            np.testing.assert_allclose(predt, predt_orig)
+
+        # unsupported types
+        for dtype in [
+            np.string_,
+            np.complex64,
+            np.complex128,
+            np.complex256,
+        ]:
+            X = np.array(orig, dtype=dtype)
+            with pytest.raises(ValueError):
+                self.booster.inplace_predict(X)


### PR DESCRIPTION
* Add native support for CPU 128 float.  cupy doesn't have float128, and CUDA treats long double as double in device code.
* Convert boolean and float16 in Python.
* The C API for constructing DMatrix from numpy array added in https://github.com/dmlc/xgboost/pull/6998 is renamed from `Array` to `Dense` for consistency.

Close https://github.com/dmlc/xgboost/issues/6999 .