### PR TITLE
Fix `gpu_id` with custom objective.

### DIFF
--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -228,7 +228,7 @@ void GBTree::DoBoost(DMatrix* p_fmat,
   // break a lots of existing code.
   auto device = tparam_.tree_method != TreeMethod::kGPUHist
                     ? GenericParameter::kCpuId
-                    : in_gpair->DeviceIdx();
+                    : generic_param_->gpu_id;
   auto out = MatrixView<float>(
       &predt->predictions,
       {static_cast<size_t>(p_fmat->Info().num_row_), static_cast<size_t>(ngroup)}, device);

--- a/tests/python-gpu/test_gpu_basic_models.py
+++ b/tests/python-gpu/test_gpu_basic_models.py
@@ -6,11 +6,13 @@ import pytest
 sys.path.append("tests/python")
 # Don't import the test class, otherwise they will run twice.
 import test_callback as test_cb  # noqa
+import test_basic_models as test_bm
 rng = np.random.RandomState(1994)
 
 
 class TestGPUBasicModels:
-    cputest = test_cb.TestCallbacks()
+    cpu_test_cb = test_cb.TestCallbacks()
+    cpu_test_bm = test_bm.TestModels()
 
     def run_cls(self, X, y, deterministic):
         cls = xgb.XGBClassifier(tree_method='gpu_hist',
@@ -35,9 +37,12 @@ class TestGPUBasicModels:
 
         return hash(model_0), hash(model_1)
 
+    def test_custom_objective(self):
+        self.cpu_test_bm.run_custom_objective("gpu_hist")
+
     def test_eta_decay_gpu_hist(self):
-        self.cputest.run_eta_decay('gpu_hist', True)
-        self.cputest.run_eta_decay('gpu_hist', False)
+        self.cpu_test_cb.run_eta_decay('gpu_hist', True)
+        self.cpu_test_cb.run_eta_decay('gpu_hist', False)
 
     def test_deterministic_gpu_hist(self):
         kRows = 1000

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -138,8 +138,13 @@ class TestModels:
         # behaviour is considered sub-optimal, feel free to change.
         assert booster.num_boosted_rounds() == 4
 
-    def test_custom_objective(self):
-        param = {'max_depth': 2, 'eta': 1, 'objective': 'reg:logistic'}
+    def run_custom_objective(self, tree_method=None):
+        param = {
+            'max_depth': 2,
+            'eta': 1,
+            'objective': 'reg:logistic',
+            "tree_method": tree_method
+        }
         watchlist = [(dtest, 'eval'), (dtrain, 'train')]
         num_round = 10
 
@@ -180,6 +185,9 @@ class TestModels:
         err2 = sum(1 for i in range(len(preds2))
                    if int(preds2[i] > 0.5) != labels[i]) / float(len(preds2))
         assert err == err2
+
+    def test_custom_objective(self):
+        self.run_custom_objective()
 
     def test_multi_eval_metric(self):
         watchlist = [(dtest, 'eval'), (dtrain, 'train')]


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/6989 .

https://github.com/dmlc/xgboost/pull/6971 tries to have a more rigid configuration for `gpu_id`, but turns out to be impossible.  This PR is a hot fix for the custom objective issue.