### PR TITLE
[dask] speed up tests

### DIFF
--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -28,7 +28,6 @@ if tm.no_dask()['condition']:
     pytest.skip(msg=tm.no_dask()['reason'], allow_module_level=True)
 
 from distributed import LocalCluster, Client
-from distributed.utils_test import client, loop, cluster_fixture
 import dask.dataframe as dd
 import dask.array as da
 from xgboost.dask import DaskDMatrix
@@ -38,6 +37,20 @@ if hasattr(HealthCheck, 'function_scoped_fixture'):
     suppress = [HealthCheck.function_scoped_fixture]
 else:
     suppress = hypothesis.utils.conventions.not_set  # type:ignore
+
+
+@pytest.fixture(scope='module')
+def cluster():
+    with LocalCluster(
+        n_workers=2, threads_per_worker=2, dashboard_address=None
+    ) as dask_cluster:
+        yield dask_cluster
+
+
+@pytest.fixture
+def client(cluster):
+    with Client(cluster) as dask_client:
+        yield dask_client
 
 
 kRows = 1000


### PR DESCRIPTION
This aims to reduce the runtime of the dask tests. Following https://github.com/dmlc/xgboost/issues/6816#issuecomment-852831437, the first step was to replace the `client` fixture with one that reuses the same cluster and just creates new clients in every test, and makes the least changes to the existing code. 

There are some other tests that are building clusters instead of using the `client` fixture that could be benefited by this, however adding this only reduced the runtime by about a minute, so I ran `pytest` with `--durations=0` and got this:
```
=============================================================== slowest durations ================================================================
155.91s call     python/test_with_dask.py::TestWithDask::test_approx
138.92s call     python/test_with_dask.py::TestWithDask::test_hist
22.91s call     python/test_with_dask.py::test_from_dask_array
9.20s call     python/test_with_dask.py::TestWithDask::test_feature_weights
7.02s call     python/test_with_dask.py::test_dask_ranking
6.61s call     python/test_with_dask.py::test_with_asyncio
6.44s call     python/test_with_dask.py::test_parallel_submit_multi_clients
```
Will investigate the ones that take the most time.
