### PR TITLE
Fix BinarySearchBin() argument types

### DIFF
--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -295,13 +295,13 @@ struct GHistIndexMatrix {
 };
 
 template <typename GradientIndex>
-int32_t XGBOOST_HOST_DEV_INLINE BinarySearchBin(bst_uint begin, bst_uint end,
+int32_t XGBOOST_HOST_DEV_INLINE BinarySearchBin(size_t begin, size_t end,
                                                 GradientIndex const &data,
                                                 uint32_t const fidx_begin,
                                                 uint32_t const fidx_end) {
-  uint32_t previous_middle = std::numeric_limits<uint32_t>::max();
+  size_t previous_middle = std::numeric_limits<size_t>::max();
   while (end != begin) {
-    auto middle = begin + (end - begin) / 2;
+    size_t middle = begin + (end - begin) / 2;
     if (middle == previous_middle) {
       break;
     }


### PR DESCRIPTION
Fix for bug described in #7025.

With this fix, training as described in #7025 with tree_method=gpu_hist produces results comparable to tree_method=hist.

Dev/Test environment:
Linux: Linux acfa9079b903 4.15.0-142-generic #146-Ubuntu SMP Tue Apr 13 01:11:19 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
CUDA: NVIDIA-SMI 460.80, Driver Version: 460.80, CUDA Version: 11.2 
