### PR TITLE
[JVM-Packages] Remove synchronized in java predict function.

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -285,11 +285,11 @@ public class Booster implements Serializable, KryoSerializable {
    * @param predContribs prediction feature contributions
    * @return predict results
    */
-  private synchronized float[][] predict(DMatrix data,
-                                         boolean outputMargin,
-                                         int treeLimit,
-                                         boolean predLeaf,
-                                         boolean predContribs) throws XGBoostError {
+  private float[][] predict(DMatrix data,
+                            boolean outputMargin,
+                            int treeLimit,
+                            boolean predLeaf,
+                            boolean predContribs) throws XGBoostError {
     int optionMask = 0;
     if (outputMargin) {
       optionMask = 1;


### PR DESCRIPTION
We have made the predict function thread safe in 1.4.

Follow up on https://github.com/dmlc/xgboost/pull/6021 .  Related https://github.com/dmlc/xgboost/issues/5951 .