### PR TITLE
Extra wrapper to split data for `eval_set` to use in scikit-learn model_selection and pipeline

### DIFF
--- a/python-package/xgboost/__init__.py
+++ b/python-package/xgboost/__init__.py
@@ -16,6 +16,7 @@ from . import dask
 try:
     from .sklearn import XGBModel, XGBClassifier, XGBRegressor, XGBRanker
     from .sklearn import XGBRFClassifier, XGBRFRegressor
+    from .wrapper import get_wrapper
     from .plotting import plot_importance, plot_tree, to_graphviz
     from .config import set_config, get_config, config_context
 except ImportError:
@@ -30,5 +31,6 @@ __all__ = ['DMatrix', 'DeviceQuantileDMatrix', 'Booster',
            'RabitTracker',
            'XGBModel', 'XGBClassifier', 'XGBRegressor', 'XGBRanker',
            'XGBRFClassifier', 'XGBRFRegressor',
+           'get_wrapper'
            'plot_importance', 'plot_tree', 'to_graphviz', 'dask',
            'set_config', 'get_config', 'config_context']

--- a/python-package/xgboost/wrapper.py
+++ b/python-package/xgboost/wrapper.py
@@ -1,0 +1,44 @@
+from . import sklearn as xgb_sklearn
+from sklearn import model_selection, base
+
+valid_estimators = ['XGBClassifier',
+                    'XGBRFClassifier',
+                    'XGBRFRegressor',
+                    'XGBRanker',
+                    'XGBRegressor']
+
+
+def get_wrapper(name, **kwargs):
+    if name not in valid_estimators:
+        raise ValueError(name, 'is not a valid estimator. \n Refer to valid_estimators.')
+    subclass = getattr(xgb_sklearn, name)
+
+    class XGBWrapper(subclass):
+        def __init__(self, **_kwargs):
+            super().__init__()
+            super().set_params(**_kwargs)
+
+        def fit(self, X, y, fit_params={'early_stopping_rounds': 5, 'verbose': 0}, validation_fraction=.5):
+            classification = base.is_classifier(subclass)
+
+            if classification:
+                X_train, X_valid, y_train, y_valid = model_selection.train_test_split(X,
+                                                                                      y,
+                                                                                      random_state=1,
+                                                                                      test_size=validation_fraction,
+                                                                                      stratify=y)
+            else:
+                X_train, X_valid, y_train, y_valid = model_selection.train_test_split(X,
+                                                                                      y,
+                                                                                      random_state=1,
+                                                                                      test_size=validation_fraction)
+
+            valids = [X_valid,
+                      y_valid]
+            super().fit(X_train,
+                        y_train,
+                        eval_set=[valids],
+                        **fit_params)
+            return self
+
+    return XGBWrapper(**kwargs)


### PR DESCRIPTION
Wrapper to split data in order to (along with early stopping):
- Utilise scikit-learn hyperparamter tuning
- Utilise scikit-learn cross validation functions with predefined wrappers
- Place xgboost models in scikit-learn pipelines
- Use scikit-learn model evaluation functions like `sklearn.model_selection.learning_curve`