### PR TITLE
Implement feature score in GBTree.

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2015~2020 by Contributors
+ * Copyright (c) 2015~2021 by Contributors
  * \file c_api.h
  * \author Tianqi Chen
  * \brief C API of XGBoost, used for interfacing to other languages.
@@ -1193,4 +1193,28 @@ XGB_DLL int XGBoosterSetStrFeatureInfo(BoosterHandle handle, const char *field,
 XGB_DLL int XGBoosterGetStrFeatureInfo(BoosterHandle handle, const char *field,
                                        bst_ulong *len,
                                        const char ***out_features);
+
+/*!
+ * \brief Calculate feature scores for tree models.
+ *
+ * \param handle        An instance of Booster
+ * \param json_config   Parameters for computing scores.  Accepted JSON keys are:
+ *   - importance_type: A JSON string with following possible values:
+ *       * 'weight': the number of times a feature is used to split the data across all trees.
+ *       * 'gain': the average gain across all splits the feature is used in.
+ *       * 'cover': the average coverage across all splits the feature is used in.
+ *       * 'total_gain': the total gain across all splits the feature is used in.
+ *       * 'total_cover': the total coverage across all splits the feature is used in.
+ *   - feature_map: An optional JSON string with URI or path to the feature map file.
+ *
+ * \param out_length    Length of output arrays.
+ * \param out_features  An array of string as feature names, ordered the same as output scores.
+ * \param out_scores    An array of floating point as feature scores.
+ *
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterFeatureScore(BoosterHandle handle, const char *json_config,
+                                  bst_ulong *out_length,
+                                  const char ***out_features,
+                                  float **out_scores);
 #endif  // XGBOOST_C_API_H_

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -181,6 +181,12 @@ class GradientBooster : public Model, public Configurable {
   virtual std::vector<std::string> DumpModel(const FeatureMap& fmap,
                                              bool with_stats,
                                              std::string format) const = 0;
+
+  virtual void FeatureScore(std::string const &importance_type,
+                            std::vector<bst_feature_t> *features,
+                            std::vector<float> *scores) const {
+    LOG(FATAL) << "`feature_score` is not implemented for current booster.";
+  }
   /*!
    * \brief Whether the current booster uses GPU.
    */

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -46,8 +46,6 @@ struct XGBAPIThreadLocalEntry {
   std::string ret_str;
   /*! \brief result holder for returning strings */
   std::vector<std::string> ret_vec_str;
-  /*! \brief result holder for returning unsigned integers */
-  std::vector<uint32_t> ret_vec_uint32;
   /*! \brief result holder for returning string pointers */
   std::vector<const char *> ret_vec_charp;
   /*! \brief returning float vector. */

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -46,6 +46,8 @@ struct XGBAPIThreadLocalEntry {
   std::string ret_str;
   /*! \brief result holder for returning strings */
   std::vector<std::string> ret_vec_str;
+  /*! \brief result holder for returning unsigned integers */
+  std::vector<uint32_t> ret_vec_uint32;
   /*! \brief result holder for returning string pointers */
   std::vector<const char *> ret_vec_charp;
   /*! \brief returning float vector. */
@@ -151,6 +153,13 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
                               float missing,
                               HostDeviceVector<bst_float> **out_preds,
                               uint32_t layer_begin, uint32_t layer_end) = 0;
+
+  /*!
+   * \brief Calculate feature score.  See doc in C API for outputs.
+   */
+  virtual void CalcFeatureScore(std::string const &importance_type,
+                                std::vector<bst_feature_t> *features,
+                                std::vector<float> *scores) = 0;
 
   /*
    * \brief Get number of boosted rounds from gradient booster.

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1098,5 +1098,47 @@ XGB_DLL int XGBoosterGetStrFeatureInfo(BoosterHandle handle, const char *field,
   API_END();
 }
 
+XGB_DLL int XGBoosterFeatureScore(BoosterHandle handle,
+                                  const char *json_config,
+                                  xgboost::bst_ulong* out_length,
+                                  const char ***out_features,
+                                  float **out_scores) {
+  API_BEGIN();
+  CHECK_HANDLE();
+  auto *learner = static_cast<Learner *>(handle);
+  auto config = Json::Load(StringView{json_config});
+  auto importance = get<String const>(config["importance_type"]);
+  std::string feature_map_uri;
+  if (!IsA<Null>(config["feature_map"])) {
+    feature_map_uri = get<String const>(config["feature_map"]);
+  }
+  FeatureMap feature_map = LoadFeatureMap(feature_map_uri);
+
+  auto& scores = learner->GetThreadLocal().ret_vec_float;
+  auto& features = learner->GetThreadLocal().ret_vec_uint32;
+  learner->CalcFeatureScore(importance, &features, &scores);
+
+  auto n_features = learner->GetNumFeature();
+  GenerateFeatureMap(learner, n_features, &feature_map);
+  CHECK_LE(features.size(), n_features);
+
+  auto& feature_names = learner->GetThreadLocal().ret_vec_str;
+  feature_names.resize(features.size());
+  auto& feature_names_c = learner->GetThreadLocal().ret_vec_charp;
+  feature_names_c.resize(features.size());
+
+  for (bst_feature_t i = 0; i < features.size(); ++i) {
+    feature_names[i] = feature_map.Name(features[i]);
+    feature_names_c[i] = feature_names[i].data();
+  }
+
+  CHECK_EQ(scores.size(), features.size());
+  CHECK_EQ(scores.size(), feature_names.size());
+  *out_length  = scores.size();
+  *out_scores = scores.data();
+  *out_features = dmlc::BeginPtr(feature_names_c);
+  API_END();
+}
+
 // force link rabit
 static DMLC_ATTRIBUTE_UNUSED int XGBOOST_LINK_RABIT_C_API_ = RabitLinkTag();

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1115,7 +1115,7 @@ XGB_DLL int XGBoosterFeatureScore(BoosterHandle handle,
   FeatureMap feature_map = LoadFeatureMap(feature_map_uri);
 
   auto& scores = learner->GetThreadLocal().ret_vec_float;
-  auto& features = learner->GetThreadLocal().ret_vec_uint32;
+  std::vector<bst_feature_t> features;
   learner->CalcFeatureScore(importance, &features, &scores);
 
   auto n_features = learner->GetNumFeature();

--- a/src/c_api/c_api_utils.h
+++ b/src/c_api/c_api_utils.h
@@ -206,8 +206,14 @@ inline void GenerateFeatureMap(Learner const *learner,
     // Use the feature names and types from booster.
     std::vector<std::string> feature_names;
     learner->GetFeatureNames(&feature_names);
+    if (!feature_names.empty()) {
+      CHECK_EQ(feature_names.size(), n_features) << "Incorrect number of feature names.";
+    }
     std::vector<std::string> feature_types;
     learner->GetFeatureTypes(&feature_types);
+    if (!feature_types.empty()) {
+      CHECK_EQ(feature_types.size(), n_features) << "Incorrect number of feature types.";
+    }
     for (size_t i = 0; i < n_features; ++i) {
       feature_map.PushBack(
           i,

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1193,6 +1193,30 @@ class LearnerImpl : public LearnerIO {
     *out_preds = &out_predictions.predictions;
   }
 
+  void CalcFeatureScore(std::string const &importance_type,
+                        std::vector<bst_feature_t> *features,
+                        std::vector<float> *scores) override {
+    this->Configure();
+    std::vector<std::string> allowed_importance_type = {
+        "weight", "total_gain", "total_cover", "gain", "cover"
+    };
+    if (std::find(allowed_importance_type.begin(),
+                  allowed_importance_type.end(),
+                  importance_type) == allowed_importance_type.end()) {
+      std::stringstream ss;
+      ss << "importance_type mismatch, got: " << importance_type
+         << "`, expected one of ";
+      for (size_t i = 0; i < allowed_importance_type.size(); ++i) {
+        ss << "`" << allowed_importance_type[i] << "`";
+        if (i != allowed_importance_type.size() - 1) {
+          ss << ", ";
+        }
+      }
+      LOG(FATAL) << ss.str();
+    }
+    gbm_->FeatureScore(importance_type, features, scores);
+  }
+
   const std::map<std::string, std::string>& GetConfigurationArguments() const override {
     return cfg_;
   }

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019-2020 XGBoost contributors
+ * Copyright 2019-2021 XGBoost contributors
  */
 #include <gtest/gtest.h>
 #include <dmlc/filesystem.h>
@@ -409,5 +409,44 @@ TEST(Dart, Slice) {
   auto const& weights = get<Array const>(model["learner"]["gradient_booster"]["weight_drop"]);
   auto const& trees = get<Array const>(model["learner"]["gradient_booster"]["gbtree"]["model"]["trees"]);
   ASSERT_EQ(weights.size(), trees.size());
+}
+
+TEST(GBTree, FeatureScore) {
+  size_t n_samples = 1000, n_features = 10;
+  auto m = RandomDataGenerator{n_samples, n_features, 0.5}.GenerateDMatrix(true, false, 4);
+
+  std::unique_ptr<Learner> learner{ Learner::Create({m}) };
+  learner->SetParam("num_class", "4");
+
+  learner->Configure();
+  for (size_t i = 0; i < 2; ++i) {
+    learner->UpdateOneIter(i, m);
+  }
+
+  Json model {Object{}};
+  learner->SaveModel(&model);
+  std::vector<bst_feature_t> features_weight;
+  std::vector<float> scores_weight;
+  learner->CalcFeatureScore("weight", &features_weight, &scores_weight);
+  ASSERT_EQ(features_weight.size(), scores_weight.size());
+  ASSERT_LE(features_weight.size(), learner->GetNumFeature());
+  ASSERT_TRUE(std::is_sorted(features_weight.begin(), features_weight.end()));
+
+  auto test_eq = [&learner, &scores_weight](std::string type) {
+    std::vector<bst_feature_t> features;
+    std::vector<float> scores;
+    learner->CalcFeatureScore(type, &features, &scores);
+
+    std::vector<bst_feature_t> features_total;
+    std::vector<float> scores_total;
+    learner->CalcFeatureScore("total_" + type, &features_total, &scores_total);
+
+    for (size_t i = 0; i < scores_weight.size(); ++i) {
+      ASSERT_LE(RelError(scores_total[i] / scores[i], scores_weight[i]), kRtEps);
+    }
+  };
+
+  test_eq("gain");
+  test_eq("cover");
 }
 }  // namespace xgboost

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -412,19 +412,17 @@ TEST(Dart, Slice) {
 }
 
 TEST(GBTree, FeatureScore) {
-  size_t n_samples = 1000, n_features = 10;
-  auto m = RandomDataGenerator{n_samples, n_features, 0.5}.GenerateDMatrix(true, false, 4);
+  size_t n_samples = 1000, n_features = 10, n_classes = 4;
+  auto m = RandomDataGenerator{n_samples, n_features, 0.5}.GenerateDMatrix(true, false, n_classes);
 
   std::unique_ptr<Learner> learner{ Learner::Create({m}) };
-  learner->SetParam("num_class", "4");
+  learner->SetParam("num_class", std::to_string(n_classes));
 
   learner->Configure();
   for (size_t i = 0; i < 2; ++i) {
     learner->UpdateOneIter(i, m);
   }
 
-  Json model {Object{}};
-  learner->SaveModel(&model);
   std::vector<bst_feature_t> features_weight;
   std::vector<float> scores_weight;
   learner->CalcFeatureScore("weight", &features_weight, &scores_weight);

--- a/tests/python/test_basic.py
+++ b/tests/python/test_basic.py
@@ -154,6 +154,23 @@ class TestBasic:
         dump4j = json.loads(dump4[0])
         assert 'gain' in dump4j, "Expected 'gain' to be dumped in JSON."
 
+    def test_feature_score(self):
+        rng = np.random.RandomState(0)
+        data = rng.randn(100, 2)
+        target = np.array([0, 1] * 50)
+        features = ["F0"]
+        with pytest.raises(ValueError):
+            xgb.DMatrix(data, label=target, feature_names=features)
+
+        params = {"objective": "binary:logistic"}
+        dm = xgb.DMatrix(data, label=target, feature_names=["F0", "F1"])
+        booster = xgb.train(params, dm, num_boost_round=1)
+        # no error since feature names might be assigned before the booster seeing data
+        # and booster doesn't known about the actual number of features.
+        booster.feature_names = ["F0"]
+        with pytest.raises(ValueError):
+            booster.get_fscore()
+
     def test_load_file_invalid(self):
         with pytest.raises(xgb.core.XGBoostError):
             xgb.Booster(model_file='incorrect_path')


### PR DESCRIPTION
Related: https://github.com/dmlc/xgboost/issues/6091 .

Other than eliminating parsing, this is also for categorical data support.  The old text parsing implementation doesn't understand categorical split outputs.