### PR TITLE
update early stop callback check for improvement with tolerance

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -539,10 +539,10 @@ class EarlyStopping(TrainingCallback):
             return x[0] if isinstance(x, tuple) else x
 
         def maximize(new, best):
-            return numpy.greater(get_s(new) + self._tol, get_s(best))
+            return numpy.greater(get_s(new), get_s(best) + self._tol)
 
         def minimize(new, best):
-            return numpy.greater(get_s(best) + self._tol, get_s(new))
+            return numpy.greater(get_s(best), get_s(new) + self._tol)
 
         if self.maximize is None:
             # Just to be compatibility with old behavior before 1.3.  We should let


### PR DESCRIPTION
Fixing the improvement with tolerance check, e.g. for maximize, the new score has improvement if it at least improved by {tolerance} compared to the best score, i.e. for the new score to be considered as an improvement, new has to be > best + tolerance, and vice versa for minimize. 