### PR TITLE
Fix model loading from stream

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -61,7 +61,7 @@ public class XGBoost {
       os.write(buf, 0, size);
     }
     in.close();
-    return Booster.loadModel(buf);
+    return Booster.loadModel(os.toByteArray());
   }
 
   /**


### PR DESCRIPTION
Fix bug introduced in 17913713b554d820a8ce94226d854b4a5f1d8bbc (allow loading from byte array)

When loading model from stream, only last buffer read from the input stream is used to construct the model.

This may work for models smaller than 1 MiB (if you are lucky enough to read the whole model at once), but will always fail if the model is larger.