### PR TITLE
Extract evaluate splits from CPU hist.

### DIFF
--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -21,14 +21,12 @@ namespace xgboost {
 namespace tree {
 
 template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
- public:
+ private:
   struct NodeEntry {
     /*! \brief statics for node entry */
     GradStats stats;
     /*! \brief loss of this node, without split */
     bst_float root_gain{0.0f};
-    /*! \brief weight calculated related to current data */
-    float weight{0.0f};
   };
 
  private:

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -33,7 +33,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
 
  private:
   TrainParam param_;
-  common::ColumnSampler column_sampler_;
+  std::shared_ptr<common::ColumnSampler> column_sampler_;
   TreeEvaluator tree_evaluator_;
   int32_t n_threads_ {0};
   FeatureInteractionConstraintHost interaction_constraints_;
@@ -142,7 +142,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
     for (size_t nidx_in_set = 0; nidx_in_set < entries.size(); ++nidx_in_set) {
       auto nidx = entries[nidx_in_set]->nid;
       features[nidx_in_set] =
-          column_sampler_.GetFeatureSet(tree.GetDepth(nidx));
+          column_sampler_->GetFeatureSet(tree.GetDepth(nidx));
     }
     CHECK(!features.empty());
     const size_t grain_size =
@@ -251,18 +251,20 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
   }
 
  public:
-  HistEvaluator() = default;
+  // The column sampler must be constructed by caller since we need to preserve the rng
+  // for the entire training session.
   explicit HistEvaluator(TrainParam const &param, MetaInfo const &info,
-                         int32_t n_threads, bool skip_0_index = false)
-      : param_{param}, tree_evaluator_{param,
-                                       static_cast<bst_feature_t>(
-                                           info.num_col_),
-                                       GenericParameter::kCpuId},
+                         int32_t n_threads,
+                         std::shared_ptr<common::ColumnSampler> sampler,
+                         bool skip_0_index = false)
+      : param_{param}, column_sampler_{std::move(sampler)},
+        tree_evaluator_{param, static_cast<bst_feature_t>(info.num_col_),
+                        GenericParameter::kCpuId},
         n_threads_{n_threads} {
     interaction_constraints_.Configure(param, info.num_col_);
-    column_sampler_.Init(info.num_col_, info.feature_weigths.HostVector(),
-                         param_.colsample_bynode, param_.colsample_bylevel,
-                         param_.colsample_bytree, skip_0_index);
+    column_sampler_->Init(info.num_col_, info.feature_weigths.HostVector(),
+                          param_.colsample_bynode, param_.colsample_bylevel,
+                          param_.colsample_bytree, skip_0_index);
   }
 };
 }      // namespace tree

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -35,7 +35,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
   TrainParam param_;
   common::ColumnSampler column_sampler_;
   TreeEvaluator tree_evaluator_;
-  int32_t n_threads_;
+  int32_t n_threads_ {0};
   FeatureInteractionConstraintHost interaction_constraints_;
   std::vector<NodeEntry> snode_;
 
@@ -259,18 +259,19 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
     return weight;
   }
 
+ public:
   HistEvaluator() = default;
-  explicit HistEvaluator(TrainParam const& param, MetaInfo const &info,
-                         int32_t n_threads)
-      : param_{std::move(param)}, tree_evaluator_{param,
-                                                  static_cast<bst_feature_t>(
-                                                      info.num_col_),
-                                                  GenericParameter::kCpuId},
+  explicit HistEvaluator(TrainParam const &param, MetaInfo const &info,
+                         int32_t n_threads, bool skip_0_index = false)
+      : param_{param}, tree_evaluator_{param,
+                                       static_cast<bst_feature_t>(
+                                           info.num_col_),
+                                       GenericParameter::kCpuId},
         n_threads_{n_threads} {
     interaction_constraints_.Configure(param, info.num_col_);
     column_sampler_.Init(info.num_col_, info.feature_weigths.HostVector(),
                          param_.colsample_bynode, param_.colsample_bylevel,
-                         param_.colsample_bytree, false);
+                         param_.colsample_bytree, skip_0_index);
   }
 };
 }      // namespace tree

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -146,7 +146,15 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
         entries.size());
     for (size_t nidx_in_set = 0; nidx_in_set < entries.size(); ++nidx_in_set) {
       auto nidx = entries[nidx_in_set]->nid;
-      features[nidx_in_set] = column_sampler_.GetFeatureSet(tree.GetDepth(nidx));
+      std::cout << "nidx: " << nidx << std::endl;
+      features[nidx_in_set] =
+          column_sampler_.GetFeatureSet(tree.GetDepth(nidx));
+      for (auto v : features[nidx_in_set]->HostVector()) {
+        CHECK_NE(v, 0) << " nidx: " << nidx << ", in set:" << nidx_in_set
+                       << std::endl;
+        std::cout << v << ", ";
+      }
+      std::cout << std::endl;
     }
     common::BlockedSpace2d space(entries.size(), [&](size_t nidx_in_set) {
       return features[nidx_in_set]->Size();

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -197,21 +197,15 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
     auto base_weight =
         evaluator.CalcWeight(candidate.nid, param_, GradStats{parent_sum});
 
-    auto left_weight =
-        evaluator.CalcWeight(candidate.nid, param_,
-                             GradStats{candidate.split.left_sum}) *
-        param_.learning_rate;
-    std::cout << "eta:" << param_.learning_rate << ", "
-              << "nidx:" << candidate.nid << ", "
-              << "left:" << candidate.split.left_sum << std::endl;
-    auto right_weight =
-        evaluator.CalcWeight(candidate.nid, param_,
-                             GradStats{candidate.split.right_sum}) *
-        param_.learning_rate;
+    auto left_weight = evaluator.CalcWeight(
+        candidate.nid, param_, GradStats{candidate.split.left_sum});
+    auto right_weight = evaluator.CalcWeight(
+        candidate.nid, param_, GradStats{candidate.split.right_sum});
 
     tree.ExpandNode(candidate.nid, candidate.split.SplitIndex(),
                     candidate.split.split_value, candidate.split.DefaultLeft(),
-                    base_weight, left_weight, right_weight,
+                    base_weight, left_weight * param_.learning_rate,
+                    right_weight * param_.learning_rate,
                     candidate.split.loss_chg, parent_sum.GetHess(),
                     candidate.split.left_sum.GetHess(),
                     candidate.split.right_sum.GetHess());

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -201,6 +201,9 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
         evaluator.CalcWeight(candidate.nid, param_,
                              GradStats{candidate.split.left_sum}) *
         param_.learning_rate;
+    std::cout << "eta:" << param_.learning_rate << ", "
+              << "nidx:" << candidate.nid << ", "
+              << "left:" << candidate.split.left_sum << std::endl;
     auto right_weight =
         evaluator.CalcWeight(candidate.nid, param_,
                              GradStats{candidate.split.right_sum}) *

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -252,7 +252,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
   }
 
   HistEvaluator() = default;
-  explicit HistEvaluator(TrainParam param, MetaInfo const &info,
+  explicit HistEvaluator(TrainParam const& param, MetaInfo const &info,
                          int32_t n_threads)
       : param_{std::move(param)}, tree_evaluator_{param,
                                                   static_cast<bst_feature_t>(

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -1,5 +1,15 @@
+/*!
+ * Copyright 2021 by XGBoost Contributors
+ */
 #ifndef XGBOOST_TREE_HIST_EVALUATE_SPLITS_H_
 #define XGBOOST_TREE_HIST_EVALUATE_SPLITS_H_
+
+#include <algorithm>
+#include <memory>
+#include <limits>
+#include <utility>
+#include <vector>
+
 #include "../param.h"
 #include "../constraints.h"
 #include "../split_evaluator.h"
@@ -12,14 +22,14 @@ namespace tree {
 
 template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
  public:
-   struct NodeEntry {
-     /*! \brief statics for node entry */
-     GradStats stats;
-     /*! \brief loss of this node, without split */
-     bst_float root_gain{0.0f};
-     /*! \brief weight calculated related to current data */
-     float weight{0.0f};
-   };
+  struct NodeEntry {
+    /*! \brief statics for node entry */
+    GradStats stats;
+    /*! \brief loss of this node, without split */
+    bst_float root_gain{0.0f};
+    /*! \brief weight calculated related to current data */
+    float weight{0.0f};
+  };
 
  private:
   TrainParam param_;
@@ -41,7 +51,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
     } else {
       return true;
     }
-  };
+  }
 
   // Enumerate the split values of specific feature
   // Returns the sum of gradients corresponding to the data points that contains

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -31,6 +31,10 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
 
   using GHistRowT = common::GHistRow<GradientSumT>;
 
+  // if sum of statistics for non-missing values in the node
+  // is equal to sum of statistics for all values:
+  // then - there are no missing values
+  // else - there are missing values
   bool static SplitContainsMissingValues(const GradStats e,
                                          const NodeEntry &snode) {
     if (e.GetGrad() == snode.stats.GetGrad() &&
@@ -41,6 +45,9 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
     }
   };
 
+  // Enumerate the split values of specific feature
+  // Returns the sum of gradients corresponding to the data points that contains
+  // a non-missing value for the particular feature fid.
   template <int d_step>
   GradStats EnumerateSplit(
       const GHistIndexMatrix &gmat, const GHistRowT &hist,
@@ -170,7 +177,6 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
       for (auto tidx = 0; tidx < num_threads; ++tidx) {
         entries[nidx_in_set]->split.Update(
             tloc_candidates[num_threads * nidx_in_set + tidx].split);
-        // std::cout << "update: " << tloc_candidates[num_threads * nidx_in_set + tidx].split << std::endl;
       }
     }
   }
@@ -232,7 +238,6 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
     snode_[0].stats = GradStats{root_sum.GetGrad(), root_sum.GetHess()};
     snode_[0].root_gain = root_evaluator.CalcGain(RegTree::kRoot, param_,
                                                   GradStats{snode_[0].stats});
-    // std::cout << "root_gain:" << snode_[0].root_gain << std::endl;
     auto weight = root_evaluator.CalcWeight(RegTree::kRoot, param_,
                                             GradStats{snode_[0].stats});
     return weight;

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -1,0 +1,169 @@
+#ifndef XGBOOST_TREE_HIST_EVALUATE_SPLITS_H_
+#define XGBOOST_TREE_HIST_EVALUATE_SPLITS_H_
+#include "../param.h"
+#include "../constraints.h"
+#include "../split_evaluator.h"
+#include "../../common/random.h"
+#include "../../common/hist_util.h"
+#include "../../data/gradient_index.h"
+
+namespace xgboost {
+namespace tree {
+struct NodeEntry {
+  /*! \brief statics for node entry */
+  GradStats stats;
+  /*! \brief loss of this node, without split */
+  bst_float root_gain;
+  /*! \brief weight calculated related to current data */
+  float weight;
+  /*! \brief current best solution */
+  SplitEntry best;
+  // constructor
+  explicit NodeEntry(const TrainParam &) : root_gain(0.0f), weight(0.0f) {}
+};
+
+template <typename GradientSumT, typename ExpandEntry> class ApproxEvaluator {
+  TrainParam param_;
+  common::ColumnSampler column_sampler_;
+  TreeEvaluator tree_evaluator_;
+  FeatureInteractionConstraintHost interaction_constraints_;
+  std::vector<NodeEntry> snode_;
+
+ public:
+  void EvaluateSplits(const common::HistCollection<GradientSumT> &hist,
+                      GHistIndexMatrix const &gidx, const RegTree &tree,
+                      std::vector<ExpandEntry *> entries) {
+      const size_t grain_size = std::max<size_t>(
+        1,
+        column_sampler_.GetFeatureSet(tree.GetDepth(entries[0]->nid))->Size() /
+        omp_get_max_threads());
+
+    // All nodes are on the same level, so we can store the shared ptr.
+    std::vector<std::shared_ptr<HostDeviceVector<bst_feature_t>>> features(
+        entries.size());
+    for (size_t nidx_in_set = 0; nidx_in_set < entries.size(); ++nidx_in_set) {
+      auto nidx = entries[nidx_in_set]->nid;
+      features[nidx_in_set] = column_sampler_.GetFeatureSet(tree.GetDepth(nidx));
+    }
+    common::BlockedSpace2d space(entries.size(), [&](size_t nidx_in_set) {
+      return features[nidx_in_set]->Size();
+    }, grain_size);
+
+    auto num_threads = omp_get_max_threads();
+    std::vector<ExpandEntry> tloc_candidates(omp_get_max_threads() * entries.size());
+    for (size_t i = 0; i < entries.size(); ++i) {
+      for (decltype(num_threads) j = 0; j < num_threads; ++j) {
+        tloc_candidates[i * num_threads + j] = *entries[i];
+      }
+    }
+    auto evaluator = tree_evaluator_.GetEvaluator();
+
+    common::ParallelFor2d(space, num_threads, [&](size_t nidx_in_set, common::Range1d r) {
+      auto tidx = omp_get_thread_num();
+      auto entry = &tloc_candidates[num_threads * nidx_in_set + tidx];
+      auto best = &entry->split;
+      auto nidx = entry->nid;
+      auto histogram = hist[nidx];
+      auto features_set = features[nidx_in_set]->ConstHostSpan();
+      for (auto fidx_in_set = r.begin(); fidx_in_set < r.end(); fidx_in_set++) {
+        auto fidx = features_set[fidx_in_set];
+        if (interaction_constraints_.Query(nidx, fidx)) {
+          auto grad_stats = EnumerateSplit<common::GHistRow<GradientSumT>,
+                                           NodeEntry, SplitEntry, +1>(
+              gidx, histogram, snode_[nidx], best, nidx, fidx, param_,
+              evaluator);
+          if (SplitContainsMissingValues(grad_stats, snode_[nidx])) {
+            EnumerateSplit<common::GHistRow<GradientSumT>, NodeEntry,
+                           SplitEntry, -1>(gidx, histogram, snode_[nidx], best,
+                                           nidx, fidx, param_, evaluator);
+          }
+        }
+      }
+    });
+
+    for (unsigned nidx_in_set = 0; nidx_in_set < entries.size();
+         ++nidx_in_set) {
+      for (auto tidx = 0; tidx < num_threads; ++tidx) {
+        entries[nidx_in_set]->split.Update(
+            tloc_candidates[num_threads * nidx_in_set + tidx].split);
+      }
+    }
+  }
+
+  void ApplyTreeSplit(ExpandEntry candidate, TrainParam param,
+                      RegTree *p_tree) {
+    auto evaluator = tree_evaluator_.GetEvaluator();
+    RegTree &tree = *p_tree;
+
+    GradStats parent_sum = candidate.split.left_sum;
+    parent_sum.Add(candidate.split.right_sum);
+    auto base_weight =
+        evaluator.CalcWeight(candidate.nid, param, GradStats{parent_sum});
+
+    auto left_weight =
+        evaluator.CalcWeight(candidate.nid, param,
+                             GradStats{candidate.split.left_sum}) *
+        param.learning_rate;
+    auto right_weight =
+        evaluator.CalcWeight(candidate.nid, param,
+                             GradStats{candidate.split.right_sum}) *
+        param.learning_rate;
+
+    tree.ExpandNode(candidate.nid, candidate.split.SplitIndex(),
+                    candidate.split.split_value, candidate.split.DefaultLeft(),
+                    base_weight, left_weight, right_weight,
+                    candidate.split.loss_chg, parent_sum.GetHess(),
+                    candidate.split.left_sum.GetHess(),
+                    candidate.split.right_sum.GetHess());
+
+    // Set up child constraints
+    auto left_child = tree[candidate.nid].LeftChild();
+    auto right_child = tree[candidate.nid].RightChild();
+    tree_evaluator_.AddSplit(candidate.nid, left_child, right_child,
+                             tree[candidate.nid].SplitIndex(), left_weight,
+                             right_weight);
+
+    auto max_node = std::max(left_child, tree[candidate.nid].RightChild());
+    max_node = std::max(candidate.nid, max_node);
+    snode_.resize(tree.GetNodes().size());
+    snode_.at(left_child).stats = candidate.split.left_sum;
+    snode_.at(left_child).root_gain = evaluator.CalcGain(
+        candidate.nid, param, GradStats{candidate.split.left_sum});
+    snode_.at(right_child).stats = candidate.split.right_sum;
+    snode_.at(right_child).root_gain = evaluator.CalcGain(
+        candidate.nid, param, GradStats{candidate.split.right_sum});
+
+    interaction_constraints_.Split(candidate.nid,
+                                   tree[candidate.nid].SplitIndex(), left_child,
+                                   right_child);
+  }
+
+  auto GetEvaluator() const { return tree_evaluator_.GetEvaluator(); }
+  auto const& Stats() const { return snode_; }
+
+  float InitRoot(GradStats const& root_sum) {
+    snode_.resize(1);
+    auto root_evaluator = tree_evaluator_.GetEvaluator();
+
+    snode_[0].stats = GradStats{root_sum.GetGrad(), root_sum.GetHess()};
+    snode_[0].root_gain = root_evaluator.CalcGain(RegTree::kRoot, param_,
+                                                  GradStats{snode_[0].stats});
+    auto weight = root_evaluator.CalcWeight(RegTree::kRoot, param_,
+                                            GradStats{snode_[0].stats});
+    return weight;
+  }
+
+  ApproxEvaluator() = default;
+  explicit ApproxEvaluator(TrainParam param, MetaInfo const &info)
+      : param_{std::move(param)}, tree_evaluator_{
+                                      param,
+                                      static_cast<bst_feature_t>(info.num_col_),
+                                      GenericParameter::kCpuId} {
+    column_sampler_.Init(info.num_col_, info.feature_weigths.HostVector(),
+                         param_.colsample_bynode, param_.colsample_bylevel,
+                         param_.colsample_bytree, false);
+  }
+};
+}      // namespace tree
+}      // namespace xgboost
+#endif  // XGBOOST_TREE_HIST_EVALUATE_SPLITS_H_

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -232,6 +232,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
     snode_[0].stats = GradStats{root_sum.GetGrad(), root_sum.GetHess()};
     snode_[0].root_gain = root_evaluator.CalcGain(RegTree::kRoot, param_,
                                                   GradStats{snode_[0].stats});
+    std::cout << "root_gain:" << snode_[0].root_gain << std::endl;
     auto weight = root_evaluator.CalcWeight(RegTree::kRoot, param_,
                                             GradStats{snode_[0].stats});
     return weight;
@@ -243,6 +244,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
                                       param,
                                       static_cast<bst_feature_t>(info.num_col_),
                                       GenericParameter::kCpuId} {
+    interaction_constraints_.Configure(param, info.num_col_);
     column_sampler_.Init(info.num_col_, info.feature_weigths.HostVector(),
                          param_.colsample_bynode, param_.colsample_bylevel,
                          param_.colsample_bytree, false);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -51,11 +51,8 @@ template<typename GradientSumT>
 void QuantileHistMaker::SetBuilder(const size_t n_trees,
                                    std::unique_ptr<Builder<GradientSumT>>* builder,
                                    DMatrix *dmat) {
-  builder->reset(new Builder<GradientSumT>(
-                n_trees,
-                param_,
-                std::move(pruner_),
-                int_constraint_, dmat));
+  builder->reset(
+      new Builder<GradientSumT>(n_trees, param_, std::move(pruner_), dmat));
   if (rabit::IsDistributed()) {
     (*builder)->SetHistSynchronizer(new DistributedHistSynchronizer<GradientSumT>());
     (*builder)->SetHistRowsAdder(new DistributedHistRowsAdder<GradientSumT>());
@@ -93,7 +90,7 @@ void QuantileHistMaker::Update(HostDeviceVector<GradientPair> *gpair,
   // rescale learning rate according to size of trees
   float lr = param_.learning_rate;
   param_.learning_rate = lr / trees.size();
-  int_constraint_.Configure(param_, dmat->Info().num_col_);
+
   // build tree
   const size_t n_trees = trees.size();
   if (hist_maker_param_.single_precision_histogram) {

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -736,10 +736,10 @@ void QuantileHistMaker::Builder<GradientSumT>::InitData(const GHistIndexMatrix& 
   p_last_tree_ = &tree;
   if (data_layout_ == DataLayout::kDenseDataOneBased) {
     evaluator_.reset(new HistEvaluator<GradientSumT, CPUExpandEntry>{
-        param_, info, this->nthread_, true});
+        param_, info, this->nthread_, column_sampler_, true});
   } else {
     evaluator_.reset(new HistEvaluator<GradientSumT, CPUExpandEntry>{
-        param_, info, this->nthread_, false});
+        param_, info, this->nthread_, column_sampler_, false});
   }
 
   if (data_layout_ == DataLayout::kDenseDataZeroBased

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -396,7 +396,7 @@ void QuantileHistMaker::Builder<GradientSumT>::AddSplitsToTree(
   for (auto const& entry : expand) {
     if (!entry.IsValid(param_, *num_leaves)) {
       nodes_for_apply_split->push_back(entry);
-      evaluator_.ApplyTreeSplit(entry, param_, p_tree);
+      evaluator_.ApplyTreeSplit(entry, p_tree);
       (*num_leaves)++;
     }
   }
@@ -464,7 +464,7 @@ void QuantileHistMaker::Builder<GradientSumT>::ExpandTree(
   Driver<CPUExpandEntry> driver(static_cast<TrainParam::TreeGrowPolicy>(param_.grow_policy));
   std::vector<CPUExpandEntry> expand;
   InitRoot<any_missing>(gmat, *p_fmat, p_tree, gpair_h, &num_leaves, &expand);
-  std::cout << "nid:" << 0 << expand.front().split << std::endl;
+  // std::cout << "nid:" << 0 << expand.front().split << std::endl;
   CHECK((*p_tree)[0].IsLeaf());
   driver.Push(expand[0]);
 
@@ -500,7 +500,7 @@ void QuantileHistMaker::Builder<GradientSumT>::ExpandTree(
 
       for (size_t i = 0; i < nodes_for_apply_split.size(); ++i) {
         CPUExpandEntry left_node = nodes_to_evaluate.at(i * 2 + 0);
-        std::cout << left_node.split << std::endl;
+        // std::cout << left_node.split << std::endl;
         CPUExpandEntry right_node = nodes_to_evaluate.at(i * 2 + 1);
         driver.Push(left_node);
         driver.Push(right_node);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -464,6 +464,7 @@ void QuantileHistMaker::Builder<GradientSumT>::ExpandTree(
   Driver<CPUExpandEntry> driver(static_cast<TrainParam::TreeGrowPolicy>(param_.grow_policy));
   std::vector<CPUExpandEntry> expand;
   InitRoot<any_missing>(gmat, *p_fmat, p_tree, gpair_h, &num_leaves, &expand);
+  std::cout << "nid:" << 0 << expand.front().split << std::endl;
   CHECK((*p_tree)[0].IsLeaf());
   driver.Push(expand[0]);
 
@@ -499,6 +500,7 @@ void QuantileHistMaker::Builder<GradientSumT>::ExpandTree(
 
       for (size_t i = 0; i < nodes_for_apply_split.size(); ++i) {
         CPUExpandEntry left_node = nodes_to_evaluate.at(i * 2 + 0);
+        std::cout << left_node.split << std::endl;
         CPUExpandEntry right_node = nodes_to_evaluate.at(i * 2 + 1);
         driver.Push(left_node);
         driver.Push(right_node);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -475,6 +475,12 @@ void QuantileHistMaker::Builder<GradientSumT>::ExpandTree(
       for (auto& v : nodes_to_evaluate) {
         candidates.push_back(&v);
       }
+
+      std::cout << "constraints: ";
+      for (auto v : evaluator_->Evaluator().constraints) {
+        std::cout << v << ", ";
+      }
+      std::cout << std::endl;
       evaluator_->EvaluateSplits(hist_, gmat, *p_tree, candidates);
 
       for (size_t i = 0; i < nodes_for_apply_split.size(); ++i) {

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -338,7 +338,9 @@ void QuantileHistMaker::Builder<GradientSumT>::InitRoot(
     (*p_tree)[RegTree::kRoot].SetLeaf(param_.learning_rate * weight);
 
     std::vector<CPUExpandEntry> entries{node};
+    builder_monitor_.Start("EvaluateSplits");
     evaluator_->EvaluateSplits(hist_, gmat, *p_tree, &entries);
+    builder_monitor_.Stop("EvaluateSplits");
     node = entries.front();
   }
 
@@ -472,7 +474,9 @@ void QuantileHistMaker::Builder<GradientSumT>::ExpandTree(
         hist_synchronizer_->SyncHistograms(this, starting_index, sync_count, p_tree);
       }
 
+      builder_monitor_.Start("EvaluateSplits");
       evaluator_->EvaluateSplits(hist_, gmat, *p_tree, &nodes_to_evaluate);
+      builder_monitor_.Stop("EvaluateSplits");
 
       for (size_t i = 0; i < nodes_for_apply_split.size(); ++i) {
         CPUExpandEntry left_node = nodes_to_evaluate.at(i * 2 + 0);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -393,7 +393,7 @@ void QuantileHistMaker::Builder<GradientSumT>::AddSplitsToTree(
           int *num_leaves,
           std::vector<CPUExpandEntry>* nodes_for_apply_split) {
   for (auto const& entry : expand) {
-    if (!entry.IsValid(param_, *num_leaves)) {
+    if (entry.IsValid(param_, *num_leaves)) {
       nodes_for_apply_split->push_back(entry);
       evaluator_.ApplyTreeSplit(entry, p_tree);
       (*num_leaves)++;

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -228,15 +228,11 @@ class QuantileHistMaker: public TreeUpdater {
     using GradientPairT = xgboost::detail::GradientPairInternal<GradientSumT>;
     // constructor
     explicit Builder(const size_t n_trees, const TrainParam &param,
-                     std::unique_ptr<TreeUpdater> pruner,
-                     FeatureInteractionConstraintHost int_constraints_,
-                     DMatrix const *fmat)
-        : n_trees_(n_trees), param_(param),
-          pruner_(std::move(pruner)),
+                     std::unique_ptr<TreeUpdater> pruner, DMatrix const *fmat)
+        : n_trees_(n_trees), param_(param), pruner_(std::move(pruner)),
           evaluator_{HistEvaluator<GradientSumT, CPUExpandEntry>{
-              param_, fmat->Info(), omp_get_max_threads()}},
-          p_last_tree_(nullptr),
-          p_last_fmat_(fmat) {
+              param, fmat->Info(), omp_get_max_threads()}},
+          p_last_tree_(nullptr), p_last_fmat_(fmat) {
       builder_monitor_.Init("Quantile::Builder");
     }
     // update one tree, growing
@@ -396,7 +392,6 @@ class QuantileHistMaker: public TreeUpdater {
   std::unique_ptr<Builder<double>> double_builder_;
 
   std::unique_ptr<TreeUpdater> pruner_;
-  FeatureInteractionConstraintHost int_constraint_;
 };
 
 template <typename GradientSumT>

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -323,7 +323,6 @@ class QuantileHistMaker: public TreeUpdater {
     const TrainParam& param_;
     // number of omp thread used during training
     int nthread_;
-    // common::ColumnSampler column_sampler_;
     // the internal row sets
     RowSetCollection row_set_collection_;
     // tree rows that were not used for current training

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -230,8 +230,6 @@ class QuantileHistMaker: public TreeUpdater {
     explicit Builder(const size_t n_trees, const TrainParam &param,
                      std::unique_ptr<TreeUpdater> pruner, DMatrix const *fmat)
         : n_trees_(n_trees), param_(param), pruner_(std::move(pruner)),
-          evaluator_{HistEvaluator<GradientSumT, CPUExpandEntry>{
-              param, fmat->Info(), omp_get_max_threads()}},
           p_last_tree_(nullptr), p_last_fmat_(fmat) {
       builder_monitor_.Init("Quantile::Builder");
     }
@@ -325,7 +323,7 @@ class QuantileHistMaker: public TreeUpdater {
     const TrainParam& param_;
     // number of omp thread used during training
     int nthread_;
-    common::ColumnSampler column_sampler_;
+    // common::ColumnSampler column_sampler_;
     // the internal row sets
     RowSetCollection row_set_collection_;
     // tree rows that were not used for current training
@@ -346,7 +344,7 @@ class QuantileHistMaker: public TreeUpdater {
 
     GHistBuilder<GradientSumT> hist_builder_;
     std::unique_ptr<TreeUpdater> pruner_;
-    HistEvaluator<GradientSumT, CPUExpandEntry> evaluator_;
+    std::unique_ptr<HistEvaluator<GradientSumT, CPUExpandEntry>> evaluator_;
 
     static constexpr size_t kPartitionBlockSize = 2048;
     common::PartitionBuilder<kPartitionBlockSize> partition_builder_;

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -323,6 +323,9 @@ class QuantileHistMaker: public TreeUpdater {
     const TrainParam& param_;
     // number of omp thread used during training
     int nthread_;
+    std::shared_ptr<common::ColumnSampler> column_sampler_{
+        std::make_shared<common::ColumnSampler>()};
+
     std::vector<size_t> unused_rows_;
     // the internal row sets
     RowSetCollection row_set_collection_;

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -323,15 +323,9 @@ class QuantileHistMaker: public TreeUpdater {
     const TrainParam& param_;
     // number of omp thread used during training
     int nthread_;
+    std::vector<size_t> unused_rows_;
     // the internal row sets
     RowSetCollection row_set_collection_;
-    // tree rows that were not used for current training
-    std::vector<size_t> unused_rows_;
-    // feature vectors for subsampled prediction
-    std::vector<RegTree::FVec> feat_vecs_;
-    // the temp space for split
-    std::vector<RowSetCollection::Split> row_split_tloc_;
-    std::vector<SplitEntry> best_split_tloc_;
     std::vector<GradientPair> gpair_local_;
     /*! \brief culmulative histogram of gradients. */
     HistCollection<GradientSumT> hist_;
@@ -352,10 +346,6 @@ class QuantileHistMaker: public TreeUpdater {
     const RegTree* p_last_tree_;
     DMatrix const* const p_last_fmat_;
     DMatrix* p_last_fmat_mutable_;
-
-    using ExpandQueue =
-       std::priority_queue<CPUExpandEntry, std::vector<CPUExpandEntry>,
-                           std::function<bool(CPUExpandEntry, CPUExpandEntry)>>;
 
     // key is the node id which should be calculated by Subtraction Trick, value is the node which
     // provides the evidence for subtraction

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -132,10 +132,10 @@ struct CPUExpandEntry {
   }
 
   bool IsValid(TrainParam const &param, int32_t num_leaves) const {
-    bool ret = split.loss_chg <= kRtEps ||
-               (param.max_depth > 0 && this->depth == param.max_depth) ||
-               (param.max_leaves > 0 && num_leaves == param.max_leaves);
-    return ret;
+    bool invalid = split.loss_chg <= kRtEps ||
+                   (param.max_depth > 0 && this->depth == param.max_depth) ||
+                   (param.max_leaves > 0 && num_leaves == param.max_leaves);
+    return !invalid;
   }
 
   bst_float GetLossChange() const {

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 #include <xgboost/base.h>
-#include "../../../src/tree/hist/evaluate_splits.h"
-#include "../../../src/tree/updater_quantile_hist.h"
-#include "../../../src/common/hist_util.h"
-#include "../helpers.h"
+#include "../../../../src/tree/hist/evaluate_splits.h"
+#include "../../../../src/tree/updater_quantile_hist.h"
+#include "../../../../src/common/hist_util.h"
+#include "../../helpers.h"
 
 namespace xgboost {
 namespace tree {

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -13,6 +13,7 @@ template <typename GradientSumT> void TestEvaluateSplits() {
   auto orig = omp_get_max_threads();
   int32_t n_threads = std::min(omp_get_max_threads(), 4);
   omp_set_num_threads(n_threads);
+  auto sampler = std::make_shared<common::ColumnSampler>();
 
   TrainParam param;
   param.UpdateAllowUnknown(Args{{}});
@@ -22,7 +23,7 @@ template <typename GradientSumT> void TestEvaluateSplits() {
   auto dmat = RandomDataGenerator(kRows, kCols, 0).Seed(3).GenerateDMatrix();
 
   auto evaluator =
-      HistEvaluator<GradientSumT, CPUExpandEntry>{param, dmat->Info(), n_threads};
+      HistEvaluator<GradientSumT, CPUExpandEntry>{param, dmat->Info(), n_threads, sampler};
   common::HistCollection<GradientSumT> hist;
   std::vector<GradientPair> row_gpairs = {
       {1.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f},  {2.27f, 0.28f},
@@ -94,8 +95,9 @@ TEST(HistEvaluator, Apply) {
   TrainParam param;
   param.UpdateAllowUnknown(Args{{}});
   auto dmat = RandomDataGenerator(kNRows, kNCols, 0).Seed(3).GenerateDMatrix();
+  auto sampler = std::make_shared<common::ColumnSampler>();
   auto evaluator_ =
-      HistEvaluator<float, CPUExpandEntry>{param, dmat->Info(), 4};
+      HistEvaluator<float, CPUExpandEntry>{param, dmat->Info(), 4, sampler};
 
   CPUExpandEntry entry{0, 0, 10.0f};
   entry.split.left_sum = GradStats{0.4, 0.6f};

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -10,7 +10,10 @@ namespace tree {
 
 template <typename GradientSumT> void TestEvaluateSplits() {
   int static constexpr kRows = 8, kCols = 16;
-  int32_t n_threads = 4;
+  auto orig = omp_get_max_threads();
+  int32_t n_threads = std::min(omp_get_max_threads(), 4);
+  omp_set_num_threads(n_threads);
+
   TrainParam param;
   param.UpdateAllowUnknown(Args{{}});
   param.min_child_weight = 0;
@@ -76,6 +79,8 @@ template <typename GradientSumT> void TestEvaluateSplits() {
       right.SetSubstract(GradStats{total_gpair}, left);
     }
   }
+
+  omp_set_num_threads(orig);
 }
 
 TEST(HistEvaluator, Evaluate) {

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -58,7 +58,7 @@ template <typename GradientSumT> void TestEvaluateSplits() {
   entries.front().depth = 0;
 
   evaluator.InitRoot(GradStats{total_gpair});
-  evaluator.EvaluateSplits(hist, gmat, tree, {&entries.front()});
+  evaluator.EvaluateSplits(hist, gmat, tree, &entries);
 
   auto best_loss_chg =
       evaluator.Evaluator().CalcSplitGain(

--- a/tests/cpp/tree/test_evaluate_splits.cc
+++ b/tests/cpp/tree/test_evaluate_splits.cc
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <xgboost/base.h>
+#include "../../../src/tree/hist/evaluate_splits.h"
+#include "../../../src/tree/updater_quantile_hist.h"
+#include "../../../src/common/hist_util.h"
+#include "../helpers.h"
+
+namespace xgboost {
+namespace tree {
+
+template <typename GradientSumT> void TestEvaluateSplits() {
+  int static constexpr kRows = 8, kCols = 16;
+  int32_t n_threads = 4;
+  TrainParam param;
+  param.UpdateAllowUnknown(Args{{}});
+  param.min_child_weight = 0;
+  param.reg_lambda = 0;
+
+  auto dmat = RandomDataGenerator(kRows, kCols, 0).Seed(3).GenerateDMatrix();
+
+  auto evaluator =
+      HistEvaluator<GradientSumT, CPUExpandEntry>{param, dmat->Info(), n_threads};
+  common::HistCollection<GradientSumT> hist;
+  std::vector<GradientPair> row_gpairs = {
+      {1.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f},  {2.27f, 0.28f},
+      {0.27f, 0.29f}, {0.37f, 0.39f}, {-0.47f, 0.49f}, {0.57f, 0.59f}};
+
+  size_t constexpr kMaxBins = 4;
+  // dense, no missing values
+
+  GHistIndexMatrix gmat(dmat.get(), kMaxBins);
+  common::RowSetCollection row_set_collection;
+  std::vector<size_t> &row_indices = *row_set_collection.Data();
+  row_indices.resize(kRows);
+  std::iota(row_indices.begin(), row_indices.end(), 0);
+  row_set_collection.Init();
+
+  auto hist_builder = GHistBuilder<GradientSumT>(n_threads, gmat.cut.Ptrs().back());
+  hist.Init(gmat.cut.Ptrs().back());
+  hist.AddHistRow(0);
+  hist.AllocateAllData();
+  hist_builder.template BuildHist<false>(row_gpairs, row_set_collection[0],
+                                         gmat, hist[0]);
+
+  // Compute total gradient for all data points
+  GradientPairPrecise total_gpair;
+  for (const auto &e : row_gpairs) {
+    total_gpair += GradientPairPrecise(e);
+  }
+
+  RegTree tree;
+  std::vector<CPUExpandEntry> entries(1);
+  entries.front().nid = 0;
+  entries.front().depth = 0;
+
+  evaluator.InitRoot(GradStats{total_gpair});
+  evaluator.EvaluateSplits(hist, gmat, tree, {&entries.front()});
+
+  auto best_loss_chg =
+      evaluator.Evaluator().CalcSplitGain(
+          param, 0, entries.front().split.SplitIndex(),
+          entries.front().split.left_sum, entries.front().split.right_sum) -
+      evaluator.Stats().front().root_gain;
+  ASSERT_EQ(entries.front().split.loss_chg, best_loss_chg);
+  ASSERT_GT(entries.front().split.loss_chg, 16.2f);
+
+  // Assert that's the best split
+  for (size_t i = 1; i < gmat.cut.Ptrs().size(); ++i) {
+    GradStats left, right;
+    for (size_t j = gmat.cut.Ptrs()[i-1]; j < gmat.cut.Ptrs()[i]; ++j) {
+      auto loss_chg =
+          evaluator.Evaluator().CalcSplitGain(param, 0, i - 1, left, right) -
+          evaluator.Stats().front().root_gain;
+      ASSERT_GE(best_loss_chg, loss_chg);
+      left.Add(hist[0][j].GetGrad(), hist[0][j].GetHess());
+      right.SetSubstract(GradStats{total_gpair}, left);
+    }
+  }
+}
+
+TEST(HistEvaluator, Evaluate) {
+  TestEvaluateSplits<float>();
+  TestEvaluateSplits<double>();
+}
+
+TEST(HistEvaluator, Apply) {
+  RegTree tree;
+  int static constexpr kNRows = 8, kNCols = 16;
+  TrainParam param;
+  param.UpdateAllowUnknown(Args{{}});
+  auto dmat = RandomDataGenerator(kNRows, kNCols, 0).Seed(3).GenerateDMatrix();
+  auto evaluator_ =
+      HistEvaluator<float, CPUExpandEntry>{param, dmat->Info(), 4};
+
+  CPUExpandEntry entry{0, 0, 10.0f};
+  entry.split.left_sum = GradStats{0.4, 0.6f};
+  entry.split.right_sum = GradStats{0.5, 0.7f};
+
+  evaluator_.ApplyTreeSplit(entry, &tree);
+  ASSERT_EQ(tree.NumExtraNodes(), 2);
+  ASSERT_EQ(tree.Stat(tree[0].LeftChild()).sum_hess, 0.6f);
+  ASSERT_EQ(tree.Stat(tree[0].RightChild()).sum_hess, 0.7f);
+}
+}  // namespace tree
+}  // namespace xgboost

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -26,12 +26,9 @@ class QuantileHistMock : public QuantileHistMaker {
     using RealImpl = QuantileHistMaker::Builder<GradientSumT>;
     using GHistRowT = typename RealImpl::GHistRowT;
 
-    BuilderMock(const TrainParam& param,
-                std::unique_ptr<TreeUpdater> pruner,
-                FeatureInteractionConstraintHost int_constraint,
-                DMatrix const* fmat)
-        : RealImpl(1, param, std::move(pruner),
-          std::move(int_constraint), fmat) {}
+    BuilderMock(const TrainParam &param, std::unique_ptr<TreeUpdater> pruner,
+                DMatrix const *fmat)
+        : RealImpl(1, param, std::move(pruner), fmat) {}
 
    public:
     void TestInitData(const GHistIndexMatrix& gmat,
@@ -426,7 +423,6 @@ class QuantileHistMock : public QuantileHistMaker {
           new BuilderMock<float>(
               param_,
               std::move(pruner_),
-              int_constraint_,
               dmat_.get()));
       if (batch) {
         float_builder_->SetHistSynchronizer(new BatchHistSynchronizer<float>());
@@ -440,7 +436,6 @@ class QuantileHistMock : public QuantileHistMaker {
           new BuilderMock<double>(
               param_,
               std::move(pruner_),
-              int_constraint_,
               dmat_.get()));
       if (batch) {
         double_builder_->SetHistSynchronizer(new BatchHistSynchronizer<double>());

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -396,7 +396,7 @@ class QuantileHistMock : public QuantileHistMaker {
             }
           }
           // Now compute gain (change in loss)
-          auto evaluator = this->tree_evaluator_.GetEvaluator();
+          auto evaluator = RealImpl::evaluator_.GetEvaluator();
           const auto split_gain = evaluator.CalcSplitGain(
               this->param_, 0, fid, GradStats(left_sum), GradStats(right_sum));
           if (split_gain > best_split_gain) {
@@ -408,12 +408,12 @@ class QuantileHistMock : public QuantileHistMaker {
       }
 
       /* Now compare against result given by EvaluateSplit() */
-      CPUExpandEntry node(CPUExpandEntry::kRootNid,
-                          tree.GetDepth(0),
-                          this->snode_[0].best.loss_chg);
-      RealImpl::EvaluateSplits({node}, gmat, this->hist_, tree);
-      ASSERT_EQ(this->snode_[0].best.SplitIndex(), best_split_feature);
-      ASSERT_EQ(this->snode_[0].best.split_value, gmat.cut.Values()[best_split_threshold]);
+      auto& stats = RealImpl::evaluator_.Stats();
+      CPUExpandEntry node(CPUExpandEntry::kRootNid, tree.GetDepth(0),
+                          stats[0].best.loss_chg);
+      RealImpl::EvaluateSplits({&node}, gmat, this->hist_, tree);
+      ASSERT_EQ(stats[0].best.SplitIndex(), best_split_feature);
+      ASSERT_EQ(stats[0].best.split_value, gmat.cut.Values()[best_split_threshold]);
     }
 
     void TestEvaluateSplitParallel(const RegTree &tree) {

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -352,8 +352,6 @@ class QuantileHistMock : public QuantileHistMaker {
       this->hist_builder_.template BuildHist<false>(row_gpairs, this->row_set_collection_[0],
                       gmat, this->hist_[0]);
 
-      RealImpl::InitNewNode(0, gmat, row_gpairs, *dmat, tree);
-
       /* Compute correct split (best_split) using the computed histogram */
       const size_t num_row = dmat->Info().num_row_;
       const size_t num_feature = dmat->Info().num_col_;
@@ -441,7 +439,6 @@ class QuantileHistMock : public QuantileHistMaker {
         RealImpl::InitData(gmat, *dmat, tree, &row_gpairs);
         this->hist_.AddHistRow(0);
         this->hist_.AllocateAllData();
-        RealImpl::InitNewNode(0, gmat, row_gpairs, *dmat, tree);
 
         const size_t num_row = dmat->Info().num_row_;
         // split by feature 0


### PR DESCRIPTION
Other than modularizing the split evaluation function, this PR also removes some more functions including `InitNewNodes` and `BuildNodeStats` among some other unused variables.  Also, scattered code like setting leaf weights is grouped into the split evaluator and `NodeEntry` is simplified and made private.  Another subtle difference with the original implementation is that the modified code doesn't call `tree[nidx].Parent()` to traversal upward.

## perf

I think it's faster after the PR.  URL is only run for 100 rounds, others are 500 rounds.

|        | HIGGS              | covtype           | URL                |
|:-------|:-------------------|:------------------|:-------------------|
| master | 180.24662968399934 | 76.94775568600744 | 196.1527223587036  |
| PR     | 177.9364239120041  | 68.41261254699202 | 180.37877798080444 |
