### PR TITLE
[Breaking] Rename Quantile DMatrix C API.

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -234,8 +234,8 @@ XGB_DLL int XGDMatrixCreateFromDT(void** data,
  * - XGProxyDMatrixCreate
  * - XGDMatrixCallbackNext
  * - DataIterResetCallback
- * - XGDeviceQuantileDMatrixSetDataCudaArrayInterface
- * - XGDeviceQuantileDMatrixSetDataCudaColumnar
+ * - XGProxyDMatrixSetDataCudaArrayInterface
+ * - XGProxyDMatrixSetDataCudaColumnar
  * - ... (data setters)
  */
 
@@ -371,9 +371,10 @@ XGB_DLL int XGDeviceQuantileDMatrixCreateFromCallback(
  *
  * \return 0 when success, -1 when failure happens
  */
-XGB_DLL int XGDeviceQuantileDMatrixSetDataCudaArrayInterface(
-    DMatrixHandle handle,
-    const char* c_interface_str);
+XGB_DLL int
+XGProxyDMatrixSetDataCudaArrayInterface(DMatrixHandle handle,
+                                        const char *c_interface_str);
+
 /*!
  * \brief Set data on a DMatrix proxy.
  *
@@ -383,9 +384,9 @@ XGB_DLL int XGDeviceQuantileDMatrixSetDataCudaArrayInterface(
  *
  * \return 0 when success, -1 when failure happens
  */
-XGB_DLL int XGDeviceQuantileDMatrixSetDataCudaColumnar(
-    DMatrixHandle handle,
-    const char* c_interface_str);
+XGB_DLL int XGProxyDMatrixSetDataCudaColumnar(DMatrixHandle handle,
+                                              const char *c_interface_str);
+
 /*
  * ==========================- End data callback APIs ==========================
  */
@@ -563,7 +564,7 @@ XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
  * \return 0 when success, -1 when failure happens
  */
 XGB_DLL int XGDMatrixSetDenseInfo(DMatrixHandle handle, const char *field,
-                                  void *data, bst_ulong size, int type);
+                                  void const *data, bst_ulong size, int type);
 
 /*!
  * \brief (deprecated) Use XGDMatrixSetUIntInfo instead. Set group of the training matrix

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -322,6 +322,7 @@ class DataIter:
         self._handle = _ProxyDMatrix()
         self.exception = None
         self.enable_categorical = False
+        self._allow_host = False
 
     @property
     def proxy(self):
@@ -349,12 +350,12 @@ class DataIter:
             feature_types=None,
             **kwargs
         ):
-            from .data import dispatch_device_quantile_dmatrix_set_data
-            from .data import _device_quantile_transform
-            data, feature_names, feature_types = _device_quantile_transform(
+            from .data import dispatch_proxy_set_data
+            from .data import _proxy_transform
+            data, feature_names, feature_types = _proxy_transform(
                 data, feature_names, feature_types, self.enable_categorical,
             )
-            dispatch_device_quantile_dmatrix_set_data(self.proxy, data)
+            dispatch_proxy_set_data(self.proxy, data, self._allow_host)
             self.proxy.set_info(
                 feature_names=feature_names,
                 feature_types=feature_types,
@@ -1009,18 +1010,18 @@ class _ProxyDMatrix(DMatrix):
         interface = data.__cuda_array_interface__
         interface_str = bytes(json.dumps(interface, indent=2), 'utf-8')
         _check_call(
-            _LIB.XGDeviceQuantileDMatrixSetDataCudaArrayInterface(
+            _LIB.XGProxyDMatrixSetDataCudaArrayInterface(
                 self.handle,
                 interface_str
             )
         )
 
     def _set_data_from_cuda_columnar(self, data):
-        '''Set data from CUDA columnar format.1'''
+        '''Set data from CUDA columnar format.'''
         from .data import _cudf_array_interfaces
         _, interfaces_str = _cudf_array_interfaces(data)
         _check_call(
-            _LIB.XGDeviceQuantileDMatrixSetDataCudaColumnar(
+            _LIB.XGProxyDMatrixSetDataCudaColumnar(
                 self.handle,
                 interfaces_str
             )

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -775,7 +775,7 @@ class SingleBatchInternalIter(DataIter):  # pylint: disable=R0902
         self.it = 0
 
 
-def _device_quantile_transform(data, feature_names, feature_types, enable_categorical):
+def _proxy_transform(data, feature_names, feature_types, enable_categorical):
     if _is_cudf_df(data) or _is_cudf_ser(data):
         return _transform_cudf_df(
             data, feature_names, feature_types, enable_categorical
@@ -788,8 +788,8 @@ def _device_quantile_transform(data, feature_names, feature_types, enable_catego
     raise TypeError("Value type is not supported for data iterator:" + str(type(data)))
 
 
-def dispatch_device_quantile_dmatrix_set_data(proxy: _ProxyDMatrix, data: Any) -> None:
-    '''Dispatch for DeviceQuantileDMatrix.'''
+def dispatch_proxy_set_data(proxy: _ProxyDMatrix, data: Any, allow_host: bool) -> None:
+    """Dispatch for DeviceQuantileDMatrix."""
     if _is_cudf_df(data):
         proxy._set_data_from_cuda_columnar(data)  # pylint: disable=W0212
         return
@@ -803,5 +803,7 @@ def dispatch_device_quantile_dmatrix_set_data(proxy: _ProxyDMatrix, data: Any) -
         data = _transform_dlpack(data)
         proxy._set_data_from_cuda_interface(data)  # pylint: disable=W0212
         return
+    # Part of https://github.com/dmlc/xgboost/pull/7070
+    assert allow_host is False, "host data is not yet supported."
     raise TypeError('Value type is not supported for data iterator:' +
                     str(type(data)))

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -197,8 +197,8 @@ XGB_DLL int XGProxyDMatrixCreate(DMatrixHandle* out) {
 }
 
 XGB_DLL int
-XGDeviceQuantileDMatrixSetDataCudaArrayInterface(DMatrixHandle handle,
-                                                 char const *c_interface_str) {
+XGProxyDMatrixSetDataCudaArrayInterface(DMatrixHandle handle,
+                                        char const *c_interface_str) {
   API_BEGIN();
   CHECK_HANDLE();
   auto p_m = static_cast<std::shared_ptr<xgboost::DMatrix> *>(handle);
@@ -209,9 +209,8 @@ XGDeviceQuantileDMatrixSetDataCudaArrayInterface(DMatrixHandle handle,
   API_END();
 }
 
-XGB_DLL int
-XGDeviceQuantileDMatrixSetDataCudaColumnar(DMatrixHandle handle,
-                                           char const *c_interface_str) {
+XGB_DLL int XGProxyDMatrixSetDataCudaColumnar(DMatrixHandle handle,
+                                              char const *c_interface_str) {
   API_BEGIN();
   CHECK_HANDLE();
   auto p_m = static_cast<std::shared_ptr<xgboost::DMatrix> *>(handle);
@@ -433,7 +432,7 @@ XGB_DLL int XGDMatrixGetStrFeatureInfo(DMatrixHandle handle, const char *field,
 }
 
 XGB_DLL int XGDMatrixSetDenseInfo(DMatrixHandle handle, const char *field,
-                                  void *data, xgboost::bst_ulong size,
+                                  void const *data, xgboost::bst_ulong size,
                                   int type) {
   API_BEGIN();
   CHECK_HANDLE();

--- a/tests/cpp/helpers.cu
+++ b/tests/cpp/helpers.cu
@@ -23,7 +23,7 @@ int CudaArrayIterForTest::Next() {
   if (iter_ == n_batches_) {
     return 0;
   }
-  XGDeviceQuantileDMatrixSetDataCudaArrayInterface(proxy_, batches_[iter_].c_str());
+  XGProxyDMatrixSetDataCudaArrayInterface(proxy_, batches_[iter_].c_str());
   iter_++;
   return 1;
 }


### PR DESCRIPTION
The role of `ProxyDMatrix` is extended to beyond what it was designed.  Now it's used by both
`QuantileDeviceDMatrix` and `inplace prediction`.  After the refactoring of `SparseDMatrix`, it
will also be used for external memory support.  Renaming the C API to extract it from
`QuantileDeviceDMatrix`.

Part of https://github.com/dmlc/xgboost/pull/7070 .