### PR TITLE
Check input value is duplicated when quantile queue is full

### DIFF
--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -575,7 +575,7 @@ class QuantileSketchTemplate {
    */
   inline void Push(DType x, RType w = 1) {
     if (w == static_cast<RType>(0)) return;
-    if (inqueue.qtail == inqueue.queue.size()) {
+    if (inqueue.qtail == inqueue.queue.size() && inqueue.queue[inqueue.qtail - 1].value != x) {
       // jump from lazy one value to limit_size * 2
       if (inqueue.queue.size() == 1) {
         inqueue.queue.resize(limit_size * 2);


### PR DESCRIPTION
When the last value of `queue` is equal to the input value `x`, its weight is added to the weight of the last entry of `queue` instead of creating a new entry. However, this is ignored when the `queue` is full.