### PR TITLE
[XGBoost4J-Spark] bestIteration and bestScore for early stopping

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -242,15 +242,15 @@ public class XGBoost {
           if (score > bestScore) {
             bestScore = score;
             bestIteration = iter;
-            booster.setAttr("bestIteration", String.valueOf(bestIteration));
-            booster.setAttr("bestScore", String.valueOf(bestScore));
+            booster.setAttr("best_iteration", String.valueOf(bestIteration));
+            booster.setAttr("best_score", String.valueOf(bestScore));
           }
         } else {
           if (score < bestScore) {
             bestScore = score;
             bestIteration = iter;
-            booster.setAttr("bestIteration", String.valueOf(bestIteration));
-            booster.setAttr("bestScore", String.valueOf(bestScore));
+            booster.setAttr("best_iteration", String.valueOf(bestIteration));
+            booster.setAttr("best_score", String.valueOf(bestScore));
           }
         }
         if (earlyStoppingRounds > 0) {

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -242,11 +242,15 @@ public class XGBoost {
           if (score > bestScore) {
             bestScore = score;
             bestIteration = iter;
+            booster.setAttr("bestIteration", String.valueOf(bestIteration));
+            booster.setAttr("bestScore", String.valueOf(bestScore));
           }
         } else {
           if (score < bestScore) {
             bestScore = score;
             bestIteration = iter;
+            booster.setAttr("bestIteration", String.valueOf(bestIteration));
+            booster.setAttr("bestScore", String.valueOf(bestScore));
           }
         }
         if (earlyStoppingRounds > 0) {

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -115,8 +115,6 @@ class XGBoostJNI {
   public final static native int XGBoosterDumpModelExWithFeatures(
     long handle, String[] feature_names, int with_stats, String format, String[][] out_strings);
 
-  public final static native int XGBoosterSlice(long handle, int start, int stop, int step);
-
   public final static native int XGBoosterGetAttrNames(long handle, String[][] out_strings);
   public final static native int XGBoosterGetAttr(long handle, String key, String[] out_string);
   public final static native int XGBoosterSetAttr(long handle, String key, String value);

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -115,6 +115,8 @@ class XGBoostJNI {
   public final static native int XGBoosterDumpModelExWithFeatures(
     long handle, String[] feature_names, int with_stats, String format, String[][] out_strings);
 
+  public final static native int XGBoosterSlice(long handle, int start, int stop, int step);
+
   public final static native int XGBoosterGetAttrNames(long handle, String[][] out_strings);
   public final static native int XGBoosterGetAttr(long handle, String key, String[] out_string);
   public final static native int XGBoosterSetAttr(long handle, String key, String value);

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
@@ -643,7 +643,7 @@ public class BoosterImplTest {
     }});
 
     Map<String, String> attr = booster.getAttrs();
-    TestCase.assertEquals(attr.size(), 4);
+    TestCase.assertEquals(attr.size(), 6);
     TestCase.assertEquals(attr.get("testKey1"), "testValue2");
     TestCase.assertEquals(attr.get("aa"), "AA");
     TestCase.assertEquals(attr.get("bb"), "BB");


### PR DESCRIPTION
As per discussions in #6893, adding bestIteration and bestScore attributes.

sample code snippet to access the attributes
```
.
.
.
val xgbClassificationModel = xgbClassifier.fit(train)

val bestScore = xgbClassificationModel.nativeBooster.getAttr("bestScore")
val bestIteration = xgbClassificationModel.nativeBooster.getAttr("bestIteration")

``` 