### PR TITLE
[CI] freeze dask version for now.

### DIFF
--- a/tests/ci_build/conda_env/cpu_test.yml
+++ b/tests/ci_build/conda_env/cpu_test.yml
@@ -13,8 +13,8 @@ dependencies:
 - scikit-learn
 - pandas
 - matplotlib
-- dask
-- distributed
+- dask=2021.06.2
+- distributed=2021.06.2
 - python-graphviz
 - hypothesis
 - astroid


### PR DESCRIPTION
Freeze dask to be 06.2 for now to unblock the CI.

I haven't been able to find the root cause of the failure,  will try to bisect it later.  It's just way too weird.