### PR TITLE
Forbid overlap in feature interaction constraints

### DIFF
--- a/src/tree/param.cc
+++ b/src/tree/param.cc
@@ -2,6 +2,7 @@
  * Copyright by Contributors 2019
  */
 #include <iostream>
+#include <algorithm>
 #include <vector>
 #include <utility>
 
@@ -103,6 +104,18 @@ void ParseInteractionConstraint(
       } else {
         LOG(FATAL) << "Unknown value type for interaction constraint:"
                    << v.GetValue().TypeStr();
+      }
+    }
+  }
+  // Check for overlaps. Interaction constraint lists with overlaps are forbidden
+  // https://github.com/dmlc/xgboost/issues/7115
+  for (size_t i = 0; i < out.size(); ++i) {
+    for (auto v : out[i]) {
+      for (size_t j = i + 1; j < out.size(); ++j) {
+        if (std::any_of(out[j].begin(), out[j].end(), [v](auto e) { return (e == v); })) {
+          LOG(FATAL) << "Found an duplicate element in constraint lists " << i << " and " << j
+              << ": " << v << ". Lists for feature interaction constraint must be disjoint.";
+        }
       }
     }
   }

--- a/tests/python/test_interaction_constraints.py
+++ b/tests/python/test_interaction_constraints.py
@@ -87,7 +87,7 @@ class TestInteractionConstraints:
             'max_depth': 6,
             'objective': 'binary:logistic',
             'tree_method': tree_method,
-            'interaction_constraints': '[[1,2], [2,3,4]]'
+            'interaction_constraints': '[[1,2], [3,4]]'
         }
         num_boost_round = 5
 


### PR DESCRIPTION
Closes #7115

I see this as a short-term fix, until we can figure out a better way to handle interaction constraints with overlapping members.

Ideally, we want to keep track of all feature IDs that appear in the path from the root node to each leaf node, like LightGBM: https://github.com/microsoft/LightGBM/issues/4481. Current XGBoost implementation only considers the immediate node that are being split.

cc @mayer79 