### PR TITLE
[dask] Extend tree stats tests.

### DIFF
--- a/tests/python-gpu/test_gpu_with_dask.py
+++ b/tests/python-gpu/test_gpu_with_dask.py
@@ -28,6 +28,7 @@ from test_with_dask import _get_client_workers        # noqa
 from test_with_dask import generate_array             # noqa
 from test_with_dask import kCols as random_cols       # noqa
 from test_with_dask import suppress                   # noqa
+from test_with_dask import run_tree_stats             # noqa
 import testing as tm                                  # noqa
 
 
@@ -492,6 +493,17 @@ class TestDistributedGPU:
 
         for rn, drn in zip(ranker_names, dranker_names):
             assert rn == drn
+
+    def test_tree_stats(self):
+        with LocalCUDACluster(n_workers=1) as cluster:
+            with Client(cluster) as client:
+                local = run_tree_stats(client, "gpu_hist")
+
+        with LocalCUDACluster(n_workers=2) as cluster:
+            with Client(cluster) as client:
+                distributed = run_tree_stats(client, "gpu_hist")
+
+        assert local == distributed
 
     def run_quantile(self, name: str, local_cuda_cluster: LocalCUDACluster) -> None:
         if sys.platform.startswith("win"):

--- a/tests/python-gpu/test_gpu_with_dask.py
+++ b/tests/python-gpu/test_gpu_with_dask.py
@@ -494,7 +494,7 @@ class TestDistributedGPU:
         for rn, drn in zip(ranker_names, dranker_names):
             assert rn == drn
 
-    def test_tree_stats(self):
+    def test_tree_stats(self) -> None:
         with LocalCUDACluster(n_workers=1) as cluster:
             with Client(cluster) as client:
                 local = run_tree_stats(client, "gpu_hist")


### PR DESCRIPTION
* Add tests to GPU.
* Assert cover in children sums up to parent.


Related https://github.com/dmlc/xgboost/issues/7114 .
Extends tests created by @ShvetsKS to more cases.