### PR TITLE
Allow compilation with nvcc 11.4

### DIFF
--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -1329,22 +1329,22 @@ void ArgSort(xgboost::common::Span<U> keys, xgboost::common::Span<IdxT> sorted_i
 
   if (accending) {
     void *d_temp_storage = nullptr;
-    safe_cuda((cub::DispatchRadixSort<false, KeyT, ValueT, size_t>::Dispatch(
+    safe_cuda((cub::DispatchRadixSort<false, KeyT, ValueT, std::ptrdiff_t>::Dispatch(
         d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0,
         sizeof(KeyT) * 8, false, nullptr, false)));
     TemporaryArray<char> storage(bytes);
     d_temp_storage = storage.data().get();
-    safe_cuda((cub::DispatchRadixSort<false, KeyT, ValueT, size_t>::Dispatch(
+    safe_cuda((cub::DispatchRadixSort<false, KeyT, ValueT, std::ptrdiff_t>::Dispatch(
         d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0,
         sizeof(KeyT) * 8, false, nullptr, false)));
   } else {
     void *d_temp_storage = nullptr;
-    safe_cuda((cub::DispatchRadixSort<true, KeyT, ValueT, size_t>::Dispatch(
+    safe_cuda((cub::DispatchRadixSort<true, KeyT, ValueT, std::ptrdiff_t>::Dispatch(
         d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0,
         sizeof(KeyT) * 8, false, nullptr, false)));
     TemporaryArray<char> storage(bytes);
     d_temp_storage = storage.data().get();
-    safe_cuda((cub::DispatchRadixSort<true, KeyT, ValueT, size_t>::Dispatch(
+    safe_cuda((cub::DispatchRadixSort<true, KeyT, ValueT, std::ptrdiff_t>::Dispatch(
         d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0,
         sizeof(KeyT) * 8, false, nullptr, false)));
   }

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -185,10 +185,7 @@ struct TupleScanOp {
 
 // Change the value type of thrust discard iterator so we can use it with cub
 template <typename T>
-class TypedDiscard : public thrust::discard_iterator<T> {
- public:
-  using value_type = T;  // NOLINT
-};
+using TypedDiscard = thrust::discard_iterator<T>;
 
 // Here the data is already correctly ordered and simply needs to be compacted
 // to remove missing data

--- a/src/metric/auc.cu
+++ b/src/metric/auc.cu
@@ -20,10 +20,7 @@ namespace xgboost {
 namespace metric {
 namespace {
 template <typename T>
-class Discard : public thrust::discard_iterator<T>  {
- public:
-  using value_type = T;  // NOLINT
-};
+using Discard = thrust::discard_iterator<T>;
 
 struct GetWeightOp {
   common::Span<float const> weights;

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -5,6 +5,7 @@
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
 #include <thrust/fill.h>
+#include <thrust/host_vector.h>
 #include <GPUTreeShap/gpu_treeshap.h>
 #include <memory>
 

--- a/src/tree/gpu_hist/row_partitioner.cu
+++ b/src/tree/gpu_hist/row_partitioner.cu
@@ -61,10 +61,7 @@ struct WriteResultsFunctor {
 };
 
 // Change the value type of thrust discard iterator so we can use it with cub
-class DiscardOverload : public thrust::discard_iterator<IndexFlagTuple> {
- public:
-  using value_type = IndexFlagTuple;  // NOLINT
-};
+using DiscardOverload = thrust::discard_iterator<IndexFlagTuple>;
 
 // Implement partitioning via single scan operation using transform output to
 // write the result


### PR DESCRIPTION
This allows xgboost to compile with nvcc 11.4

I haven't looked into `dh::ArgSort` fully, but if it requires full 64bit support we can't update to cub 1.12+ due tohttps://github.com/NVIDIA/cub/issues/336. If xgboost is happy with 32bit space we can support cub 1.12+ by updating `ArgSort` to explicitly use `int` for offset type.