### PR TITLE
Disallow importing non-dask estimators from xgboost.dask

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -73,14 +73,15 @@ except ImportError:
 __all__ = [
     "RabitContext",
     "DaskDMatrix",
-    "DaskPartitionIter",
     "DaskDeviceQuantileDMatrix",
-    "DaskScikitLearnBase",
     "DaskXGBRegressor",
     "DaskXGBClassifier",
     "DaskXGBRanker",
     "DaskXGBRFRegressor",
     "DaskXGBRFClassifier",
+    "train",
+    "predict",
+    "inplace_predict",
 ]
 
 # TODOs:

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -48,7 +48,6 @@ from .sklearn import xgboost_model_doc
 from .sklearn import _cls_predict_proba
 from .sklearn import XGBRanker
 
-
 if TYPE_CHECKING:
     from dask import dataframe as dd
     from dask import array as da
@@ -70,6 +69,19 @@ try:
     })
 except ImportError:
     TrainReturnT = Dict[str, Any]  # type:ignore
+
+__all__ = [
+    "RabitContext",
+    "DaskDMatrix",
+    "DaskPartitionIter",
+    "DaskDeviceQuantileDMatrix",
+    "DaskScikitLearnBase",
+    "DaskXGBRegressor",
+    "DaskXGBClassifier",
+    "DaskXGBRanker",
+    "DaskXGBRFRegressor",
+    "DaskXGBRFClassifier",
+]
 
 # TODOs:
 #   - CV


### PR DESCRIPTION
This is mostly a style change, but also avoids a user error (that I have
committed on a few occasions).  Since `XGBRegressor` and `XGBClassifier`
are imported as parent classes for the `dask` estimators, without
defining an `__all__`, autocomplete (or muscle) memory will produce the
following with little prompting:

```
from xgboost.dask import XGBClassifier
```

There's nothing inherently wrong with that, but given that
`XGBClassifier` is not `dask` enabled, it can lead to confusing behavior
until you figure out you should've typed

```
from xgboost.dask import DaskXGBClassifier
```

Another option is to alias import the existing non-dask estimators.