### PR TITLE
Add parquet build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(GPU_COMPUTE_VER "" CACHE STRING
 option(USE_HDFS "Build with HDFS support" OFF)
 option(USE_AZURE "Build with AZURE support" OFF)
 option(USE_S3 "Build with S3 support" OFF)
+option(USE_PARQUET "Build with Arrow Parquet" OFF)
 ## Sanitizers
 option(USE_SANITIZER "Use santizer flags" OFF)
 option(SANITIZER_PATH "Path to sanitizes.")


### PR DESCRIPTION
With the [newly added Parquet support to dmlc-core](https://github.com/dmlc/dmlc-core/pull/653), we only need to add the build flag in CMakeLists to enable this feature in XGBoost as well. 
Related: #6719 , although we already have an iterator interface solution. 