### PR TITLE
[WIP] Use model slicing for copy.

### DIFF
--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -259,6 +259,11 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
   virtual Learner *Slice(int32_t begin_layer, int32_t end_layer, int32_t step,
                          bool *out_of_bound) = 0;
   /*!
+   * \brief Copy the learner.
+   */
+  virtual Learner* Copy() const = 0;
+
+  /*!
    * \brief dump the model in the requested format
    * \param fmap feature map that may help give interpretations of feature
    * \param with_stats extra statistics while dumping model

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -556,6 +556,25 @@ XGB_DLL int XGBoosterFree(BoosterHandle handle) {
   API_END();
 }
 
+XGB_DLL int XGBoosterCopy(BoosterHandle in, BoosterHandle* out) {
+  API_BEGIN();
+  if (!in) {
+    LOG(FATAL) << "Booster has not been initialized or has already been disposed.";
+  }
+  if (!out) {
+    LOG(FATAL) << "Invalid input for `out`.";
+  }
+  auto in_learner = static_cast<Learner*>(in);
+  Json config{Object{}};
+  in_learner->SaveConfig(&config);
+  bool out_of_bound = false;
+  CHECK(!out_of_bound);
+  auto out_learner = in_learner->Slice(0, 0, 1, &out_of_bound);
+  out_learner->LoadConfig(config);
+  *out = out_learner;
+  API_END();
+}
+
 XGB_DLL int XGBoosterSetParam(BoosterHandle handle,
                               const char *name,
                               const char *value) {

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -342,8 +342,9 @@ void GBTree::BoostNewTrees(HostDeviceVector<GradientPair>* gpair,
           << "No more tree left for updating.  For updating existing trees, "
           << "boosting rounds can not exceed previous training rounds";
       // move an existing tree from trees_to_update
-      auto t = std::move(model_.trees_to_update[model_.trees.size() +
-                                                bst_group * tparam_.num_parallel_tree + i]);
+      auto t = std::move(
+          model_.trees_to_update[model_.trees.size() +
+                                 bst_group * tparam_.num_parallel_tree + i]);
       new_trees.push_back(t.get());
       ret->push_back(std::move(t));
     }
@@ -447,7 +448,7 @@ void GBTree::Slice(int32_t layer_begin, int32_t layer_end, int32_t step,
   CHECK_NE(layer_trees, 0);
 
   layer_end = layer_end == 0 ? model_.trees.size() / layer_trees : layer_end;
-  CHECK_GT(layer_end, layer_begin);
+  CHECK_GE(layer_end, layer_begin);
   CHECK_GE(step, 1);
   int32_t n_layers = (layer_end - layer_begin) / step;
   std::vector<std::unique_ptr<RegTree>> &out_trees = out_model.trees;

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1023,6 +1023,7 @@ class LearnerImpl : public LearnerIO {
 
   Learner *Slice(int32_t begin_layer, int32_t end_layer, int32_t step,
                  bool *out_of_bound) override {
+    CHECK_NE(this->learner_model_param_.num_feature, 0);
     this->Configure();
     CHECK_NE(this->learner_model_param_.num_feature, 0);
     CHECK_GE(begin_layer, 0);
@@ -1045,16 +1046,6 @@ class LearnerImpl : public LearnerIO {
     out_impl->Configure();
     CHECK_EQ(out_impl->learner_model_param_.num_feature, this->learner_model_param_.num_feature);
     CHECK_NE(out_impl->learner_model_param_.num_feature, 0);
-
-    auto erase_attr = [&](std::string attr) {
-      // Erase invalid attributes.
-      auto attr_it = out_impl->attributes_.find(attr);
-      if (attr_it != out_impl->attributes_.cend()) {
-        out_impl->attributes_.erase(attr_it);
-      }
-    };
-    erase_attr("best_iteration");
-    erase_attr("best_score");
     return out_impl;
   }
 

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1049,6 +1049,12 @@ class LearnerImpl : public LearnerIO {
     return out_impl;
   }
 
+  Learner* Copy() const override {
+    auto *out_impl = new LearnerImpl({});
+    CHECK(!this->need_configuration_);
+    return out_impl;
+  }
+
   void UpdateOneIter(int iter, std::shared_ptr<DMatrix> train) override {
     monitor_.Start("UpdateOneIter");
     TrainingObserver::Instance().Update(iter);

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -131,12 +131,14 @@ class TestModels:
         booster = xgb.train({'tree_method': 'hist'}, X, num_boost_round=4,
                             xgb_model=booster)
         assert booster.num_boosted_rounds() == 8
-        booster = xgb.train({'updater': 'prune', 'process_type': 'update'}, X,
-                            num_boost_round=4, xgb_model=booster)
-        # Trees are moved for update, the rounds is reduced.  This test is
-        # written for being compatible with current code (1.0.0).  If the
-        # behaviour is considered sub-optimal, feel free to change.
-        assert booster.num_boosted_rounds() == 4
+        with pytest.raises(ValueError, match="4 trees"):
+            # Must update all the trees.
+            xgb.train(
+                {'updater': 'prune', 'process_type': 'update'},
+                X,
+                num_boost_round=4,
+                xgb_model=booster
+            )
 
     def run_custom_objective(self, tree_method=None):
         param = {
@@ -413,9 +415,6 @@ class TestModels:
         with pytest.raises(ValueError, match=r'>= 0'):
             booster[-1: 0]
 
-        # we do not accept empty slice.
-        with pytest.raises(ValueError):
-            booster[1:1]
         # stop can not be smaller than begin
         with pytest.raises(ValueError, match=r'Invalid.*'):
             booster[3:0]

--- a/tests/python/test_updaters.py
+++ b/tests/python/test_updaters.py
@@ -67,8 +67,7 @@ class TestTreeMethod:
         grown = str(booster.get_dump())
 
         params = {'updater': 'prune', 'process_type': 'update', 'gamma': '0.2'}
-        booster = xgb.train(params, dtrain=dtrain, num_boost_round=10,
-                            xgb_model=booster)
+        booster = xgb.train(params, dtrain=dtrain, num_boost_round=10, xgb_model=booster)
         after_prune = str(booster.get_dump())
         assert grown != after_prune
 


### PR DESCRIPTION
Related: https://github.com/dmlc/xgboost/issues/7138 https://github.com/dmlc/xgboost/issues/6697

Avoid serializing into JSON during copy.  By default, XGBoost makes a copy after training for releasing memory.  This PR optimizes the copy function to use model slicing instead of serialization.  This helps when creating many large models using scikit-learn grid search.