### PR TITLE
Extract histogram builder from CPU Hist.

### DIFF
--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -301,7 +301,7 @@ class HistCollection {
   // access histogram for i-th node
   GHistRowT operator[](bst_uint nid) const {
     constexpr uint32_t kMax = std::numeric_limits<uint32_t>::max();
-    const size_t id = row_ptr_[nid];
+    const size_t id = row_ptr_.at(nid);
     CHECK_NE(id, kMax);
     GradientPairT* ptr = nullptr;
     if (contiguous_allocation_) {

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -33,7 +33,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
 
   template <bool any_missing>
   void BuildLocalHistograms(
-      DMatrix *p_fmat, RegTree *p_tree,
+      DMatrix *p_fmat,
       std::vector<ExpandEntry> nodes_for_explicit_hist_build,
       common::RowSetCollection const &row_set_collection,
       const std::vector<GradientPair> &gpair_h) {
@@ -146,10 +146,10 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
     }
 
     if (p_fmat->IsDense()) {
-      BuildLocalHistograms<false>(p_fmat, p_tree, nodes_for_explicit_hist_build,
+      BuildLocalHistograms<false>(p_fmat, nodes_for_explicit_hist_build,
                                   row_set_collection, gpair);
     } else {
-      BuildLocalHistograms<true>(p_fmat, p_tree, nodes_for_explicit_hist_build,
+      BuildLocalHistograms<true>(p_fmat, nodes_for_explicit_hist_build,
                                  row_set_collection, gpair);
     }
     if (rabit::IsDistributed()) {

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -263,6 +263,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
   common::HistCollection<GradientSumT> const& Histogram() {
     return hist_;
   }
+  auto& Buffer() { return buffer_; }
 };
 }  // namespace tree
 } // namespace xgboost

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -1,0 +1,269 @@
+/*!
+ * Copyright 2021 by XGBoost Contributors
+ */
+#ifndef XGBOOST_TREE_HIST_HISTOGRAM_H_
+#define XGBOOST_TREE_HIST_HISTOGRAM_H_
+#include "xgboost/tree_model.h"
+#include "../../common/hist_util.h"
+
+namespace xgboost {
+namespace tree {
+template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
+  using GradientPairT = xgboost::detail::GradientPairInternal<GradientSumT>;
+  using GHistRowT = common::GHistRow<GradientSumT>;
+
+  /*! \brief culmulative histogram of gradients. */
+  common::HistCollection<GradientSumT> hist_;
+  /*! \brief culmulative local parent histogram of gradients. */
+  common::HistCollection<GradientSumT> hist_local_worker_;
+  common::GHistBuilder<GradientSumT> builder_;
+  common::ParallelGHistBuilder<GradientSumT> buffer_;
+  rabit::Reducer<GradientPairT, GradientPairT::Reduce> reducer_;
+  int32_t n_threads_;
+
+ public:
+  void Reset(uint32_t n_bins, int32_t n_threads) {
+    CHECK_GE(n_threads, 1);
+    n_threads_ = n_threads;
+    hist_.Init(n_bins);
+    hist_local_worker_.Init(n_bins);
+    buffer_.Init(n_bins);
+    builder_ = common::GHistBuilder<GradientSumT>(n_threads, n_bins);
+  }
+
+  template <bool any_missing>
+  void BuildLocalHistograms(
+      DMatrix *p_fmat, RegTree *p_tree,
+      std::vector<ExpandEntry> nodes_for_explicit_hist_build,
+      common::RowSetCollection const &row_set_collection,
+      const std::vector<GradientPair> &gpair_h) {
+
+    const size_t n_nodes = nodes_for_explicit_hist_build.size();
+
+    // create space of size (# rows in each node)
+    common::BlockedSpace2d space(
+        n_nodes,
+        [&](size_t node) {
+          const int32_t nid = nodes_for_explicit_hist_build[node].nid;
+          return row_set_collection[nid].Size();
+        },
+        256);
+
+    std::vector<GHistRowT> target_hists(n_nodes);
+    for (size_t i = 0; i < n_nodes; ++i) {
+      const int32_t nid = nodes_for_explicit_hist_build[i].nid;
+      target_hists[i] = hist_[nid];
+    }
+
+    CHECK_LE(this->n_threads_, 16);
+    buffer_.Reset(this->n_threads_, n_nodes, space, target_hists);
+
+    // Parallel processing by nodes and data in each node
+    for (auto const &gmat : p_fmat->GetBatches<GHistIndexMatrix>()) {
+      common::ParallelFor2d(
+          space, this->n_threads_, [&](size_t nid_in_set, common::Range1d r) {
+            const auto tid = static_cast<unsigned>(omp_get_thread_num());
+            const int32_t nid = nodes_for_explicit_hist_build[nid_in_set].nid;
+
+            auto start_of_row_set = row_set_collection[nid].begin;
+            auto rid_set = common::RowSetCollection::Elem(
+                start_of_row_set + r.begin(), start_of_row_set + r.end(), nid);
+            builder_.template BuildHist<any_missing>(
+                gpair_h, rid_set, gmat,
+                buffer_.GetInitializedHist(tid, nid_in_set));
+          });
+    }
+  }
+
+  void AddHistRowsLocal(
+      int *starting_index, int *sync_count,
+      std::vector<ExpandEntry> const &nodes_for_explicit_hist_build,
+      std::vector<ExpandEntry> const &nodes_for_subtraction_trick) {
+    for (auto const &entry : nodes_for_explicit_hist_build) {
+      int nid = entry.nid;
+      this->hist_.AddHistRow(nid);
+      (*starting_index) = std::min(nid, (*starting_index));
+    }
+    (*sync_count) = nodes_for_explicit_hist_build.size();
+
+    for (auto const &node : nodes_for_subtraction_trick) {
+      this->hist_.AddHistRow(node.nid);
+    }
+    this->hist_.AllocateAllData();
+  };
+
+  void AddHistRowsDistributed(
+      int *starting_index, int *sync_count,
+      std::vector<ExpandEntry> const &nodes_for_explicit_hist_build,
+      std::vector<ExpandEntry> const &nodes_for_subtraction_trick,
+      RegTree *p_tree) {
+    const size_t explicit_size = nodes_for_explicit_hist_build.size();
+    const size_t subtaction_size = nodes_for_subtraction_trick.size();
+    std::vector<int> merged_node_ids(explicit_size + subtaction_size);
+    for (size_t i = 0; i < explicit_size; ++i) {
+      merged_node_ids[i] = nodes_for_explicit_hist_build[i].nid;
+    }
+    for (size_t i = 0; i < subtaction_size; ++i) {
+      merged_node_ids[explicit_size + i] = nodes_for_subtraction_trick[i].nid;
+    }
+    std::sort(merged_node_ids.begin(), merged_node_ids.end());
+    int n_left = 0;
+    for (auto const &nid : merged_node_ids) {
+      if ((*p_tree)[nid].IsLeftChild()) {
+        this->hist_.AddHistRow(nid);
+        (*starting_index) = std::min(nid, (*starting_index));
+        n_left++;
+        this->hist_local_worker_.AddHistRow(nid);
+      }
+    }
+    for (auto const &nid : merged_node_ids) {
+      if (!((*p_tree)[nid].IsLeftChild())) {
+        this->hist_.AddHistRow(nid);
+        this->hist_local_worker_.AddHistRow(nid);
+      }
+    }
+    this->hist_.AllocateAllData();
+    this->hist_local_worker_.AllocateAllData();
+    (*sync_count) = std::max(1, n_left);
+  }
+
+  void
+  BuildHist(DMatrix *p_fmat, RegTree *p_tree,
+            common::RowSetCollection const &row_set_collection,
+            std::vector<ExpandEntry> const &nodes_for_explicit_hist_build,
+            std::vector<ExpandEntry> const &nodes_for_subtraction_trick,
+            std::vector<GradientPair> const &gpair) {
+    int starting_index = std::numeric_limits<int>::max();
+    int sync_count = 0;
+    if (rabit::IsDistributed()) {
+      this->AddHistRowsDistributed(&starting_index, &sync_count,
+                                   nodes_for_explicit_hist_build,
+                                   nodes_for_subtraction_trick, p_tree);
+    } else {
+      this->AddHistRowsLocal(&starting_index, &sync_count,
+                             nodes_for_explicit_hist_build,
+                             nodes_for_subtraction_trick);
+    }
+
+    if (p_fmat->IsDense()) {
+      BuildLocalHistograms<false>(p_fmat, p_tree, nodes_for_explicit_hist_build,
+                                  row_set_collection, gpair);
+    } else {
+      BuildLocalHistograms<true>(p_fmat, p_tree, nodes_for_explicit_hist_build,
+                                 row_set_collection, gpair);
+    }
+    if (rabit::IsDistributed()) {
+      this->SyncHistogramDistributed(p_tree, nodes_for_explicit_hist_build,
+                                     nodes_for_subtraction_trick,
+                                     starting_index, sync_count);
+    } else {
+      this->SyncHistogramLocal(p_tree, nodes_for_explicit_hist_build,
+                               nodes_for_subtraction_trick, starting_index,
+                               sync_count);
+    }
+  }
+
+  void SyncHistogramDistributed(
+      RegTree *p_tree,
+      std::vector<ExpandEntry> const &nodes_for_explicit_hist_build,
+      std::vector<ExpandEntry> const &nodes_for_subtraction_trick,
+      int starting_index, int sync_count) {
+    const size_t nbins = builder_.GetNumBins();
+    common::BlockedSpace2d space(
+        nodes_for_explicit_hist_build.size(), [&](size_t) { return nbins; },
+        1024);
+    common::ParallelFor2d(
+        space, n_threads_, [&](size_t node, common::Range1d r) {
+          const auto &entry = nodes_for_explicit_hist_build[node];
+          auto this_hist = this->hist_[entry.nid];
+          // Merging histograms from each thread into once
+          buffer_.ReduceHist(node, r.begin(), r.end());
+          // Store posible parent node
+          auto this_local = hist_local_worker_[entry.nid];
+          common::CopyHist(this_local, this_hist, r.begin(), r.end());
+
+          if (!(*p_tree)[entry.nid].IsRoot()) {
+            const size_t parent_id = (*p_tree)[entry.nid].Parent();
+            const int subtraction_node_id =
+                nodes_for_subtraction_trick[node].nid;
+            auto parent_hist = this->hist_local_worker_[parent_id];
+            auto sibling_hist = this->hist_[subtraction_node_id];
+            common::SubtractionHist(sibling_hist, parent_hist, this_hist,
+                                    r.begin(), r.end());
+            // Store posible parent node
+            auto sibling_local = hist_local_worker_[subtraction_node_id];
+            common::CopyHist(sibling_local, sibling_hist, r.begin(), r.end());
+          }
+        });
+
+    reducer_.Allreduce(this->hist_[starting_index].data(),
+                       builder_.GetNumBins() * sync_count);
+
+    ParallelSubtractionHist(space, nodes_for_explicit_hist_build,
+                            nodes_for_subtraction_trick, p_tree);
+
+    common::BlockedSpace2d space2(
+        nodes_for_subtraction_trick.size(), [&](size_t) { return nbins; },
+        1024);
+    ParallelSubtractionHist(space2, nodes_for_subtraction_trick,
+                            nodes_for_explicit_hist_build, p_tree);
+  }
+
+  void SyncHistogramLocal(
+      RegTree *p_tree,
+      std::vector<ExpandEntry> const &nodes_for_explicit_hist_build,
+      std::vector<ExpandEntry> const &nodes_for_subtraction_trick,
+      int starting_index, int sync_count) {
+    const size_t nbins = this->builder_.GetNumBins();
+    common::BlockedSpace2d space(
+        nodes_for_explicit_hist_build.size(), [&](size_t) { return nbins; },
+        1024);
+
+    common::ParallelFor2d(
+        space, this->n_threads_, [&](size_t node, common::Range1d r) {
+          const auto &entry = nodes_for_explicit_hist_build[node];
+          auto this_hist = this->hist_[entry.nid];
+          // Merging histograms from each thread into once
+          this->buffer_.ReduceHist(node, r.begin(), r.end());
+
+          if (!(*p_tree)[entry.nid].IsRoot()) {
+            const size_t parent_id = (*p_tree)[entry.nid].Parent();
+            const int subtraction_node_id =
+                nodes_for_subtraction_trick[node].nid;
+            auto parent_hist = this->hist_[parent_id];
+            auto sibling_hist = this->hist_[subtraction_node_id];
+            common::SubtractionHist(sibling_hist, parent_hist, this_hist,
+                                    r.begin(), r.end());
+          }
+        });
+  }
+
+  void
+  ParallelSubtractionHist(const common::BlockedSpace2d &space,
+                          const std::vector<ExpandEntry> &nodes,
+                          const std::vector<ExpandEntry> &subtraction_nodes,
+                          const RegTree *p_tree) {
+    common::ParallelFor2d(
+        space, this->n_threads_, [&](size_t node, common::Range1d r) {
+          const auto &entry = nodes[node];
+          if (!((*p_tree)[entry.nid].IsLeftChild())) {
+            auto this_hist = this->hist_[entry.nid];
+
+            if (!(*p_tree)[entry.nid].IsRoot()) {
+              const int subtraction_node_id = subtraction_nodes[node].nid;
+              auto parent_hist = hist_[(*p_tree)[entry.nid].Parent()];
+              auto sibling_hist = hist_[subtraction_node_id];
+              SubtractionHist(this_hist, parent_hist, sibling_hist, r.begin(),
+                              r.end());
+            }
+          }
+        });
+  }
+
+  common::HistCollection<GradientSumT> const& Histogram() {
+    return hist_;
+  }
+};
+}  // namespace tree
+} // namespace xgboost
+#endif  // XGBOOST_TREE_HIST_HISTOGRAM_H_

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -253,8 +253,8 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
               const int subtraction_node_id = subtraction_nodes[node].nid;
               auto parent_hist = hist_[(*p_tree)[entry.nid].Parent()];
               auto sibling_hist = hist_[subtraction_node_id];
-              SubtractionHist(this_hist, parent_hist, sibling_hist, r.begin(),
-                              r.end());
+              common::SubtractionHist(this_hist, parent_hist, sibling_hist,
+                                      r.begin(), r.end());
             }
           }
         });

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -3,6 +3,11 @@
  */
 #ifndef XGBOOST_TREE_HIST_HISTOGRAM_H_
 #define XGBOOST_TREE_HIST_HISTOGRAM_H_
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
 #include "xgboost/tree_model.h"
 #include "../../common/hist_util.h"
 
@@ -37,7 +42,6 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
       std::vector<ExpandEntry> nodes_for_explicit_hist_build,
       common::RowSetCollection const &row_set_collection,
       const std::vector<GradientPair> &gpair_h) {
-
     const size_t n_nodes = nodes_for_explicit_hist_build.size();
 
     // create space of size (# rows in each node)
@@ -90,7 +94,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
       this->hist_.AddHistRow(node.nid);
     }
     this->hist_.AllocateAllData();
-  };
+  }
 
   void AddHistRowsDistributed(
       int *starting_index, int *sync_count,
@@ -265,6 +269,6 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
   }
   auto& Buffer() { return buffer_; }
 };
-}  // namespace tree
-} // namespace xgboost
+}      // namespace tree
+}      // namespace xgboost
 #endif  // XGBOOST_TREE_HIST_HISTOGRAM_H_

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -58,8 +58,6 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
       const int32_t nid = nodes_for_explicit_hist_build[i].nid;
       target_hists[i] = hist_[nid];
     }
-
-    CHECK_LE(this->n_threads_, 16);
     buffer_.Reset(this->n_threads_, n_nodes, space, target_hists);
 
     // Parallel processing by nodes and data in each node

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -53,13 +53,6 @@ void QuantileHistMaker::SetBuilder(const size_t n_trees,
                                    DMatrix *dmat) {
   builder->reset(
       new Builder<GradientSumT>(n_trees, param_, std::move(pruner_), dmat));
-  if (rabit::IsDistributed()) {
-    (*builder)->SetHistSynchronizer(new DistributedHistSynchronizer<GradientSumT>());
-    (*builder)->SetHistRowsAdder(new DistributedHistRowsAdder<GradientSumT>());
-  } else {
-    (*builder)->SetHistSynchronizer(new BatchHistSynchronizer<GradientSumT>());
-    (*builder)->SetHistRowsAdder(new BatchHistRowsAdder<GradientSumT>());
-  }
 }
 
 template<typename GradientSumT>
@@ -96,7 +89,7 @@ void QuantileHistMaker::Update(HostDeviceVector<GradientPair> *gpair,
   const size_t n_trees = trees.size();
   if (hist_maker_param_.single_precision_histogram) {
     if (!float_builder_) {
-      SetBuilder(n_trees, &float_builder_, dmat);
+      this->SetBuilder(n_trees, &float_builder_, dmat);
     }
     CallBuilderUpdate(float_builder_, gpair, dmat, gmat, trees);
   } else {
@@ -123,174 +116,8 @@ bool QuantileHistMaker::UpdatePredictionCache(
 }
 
 template <typename GradientSumT>
-void BatchHistSynchronizer<GradientSumT>::SyncHistograms(BuilderT *builder,
-                                                         int,
-                                                         int,
-                                                         RegTree *p_tree) {
-  // const size_t nbins = builder->hist_builder_.GetNumBins();
-  // common::BlockedSpace2d space(builder->nodes_for_explicit_hist_build_.size(), [&](size_t) {
-  //   return nbins;
-  // }, 1024);
-
-  // common::ParallelFor2d(space, builder->nthread_, [&](size_t node, common::Range1d r) {
-  //   const auto& entry = builder->nodes_for_explicit_hist_build_[node];
-  //   auto this_hist = builder->hist_[entry.nid];
-  //   // Merging histograms from each thread into once
-  //   builder->hist_buffer_.ReduceHist(node, r.begin(), r.end());
-
-  //   if (!(*p_tree)[entry.nid].IsRoot()) {
-  //     const size_t parent_id = (*p_tree)[entry.nid].Parent();
-  //     const int subtraction_node_id = builder->nodes_for_subtraction_trick_[node].nid;
-  //     auto parent_hist = builder->hist_[parent_id];
-  //     auto sibling_hist = builder->hist_[subtraction_node_id];
-  //     SubtractionHist(sibling_hist, parent_hist, this_hist, r.begin(), r.end());
-  //   }
-  // });
-}
-
-template <typename GradientSumT>
-void DistributedHistSynchronizer<GradientSumT>::SyncHistograms(BuilderT* builder,
-                                                 int starting_index,
-                                                 int sync_count,
-                                                 RegTree *p_tree) {
-  builder->builder_monitor_.Start("SyncHistograms");
-  // const size_t nbins = builder->hist_builder_.GetNumBins();
-  // common::BlockedSpace2d space(builder->nodes_for_explicit_hist_build_.size(), [&](size_t) {
-  //   return nbins;
-  // }, 1024);
-  // common::ParallelFor2d(space, builder->nthread_, [&](size_t node, common::Range1d r) {
-  //   const auto& entry = builder->nodes_for_explicit_hist_build_[node];
-  //   auto this_hist = builder->hist_[entry.nid];
-  //   // Merging histograms from each thread into once
-  //   builder->hist_buffer_.ReduceHist(node, r.begin(), r.end());
-  //   // Store posible parent node
-  //   auto this_local = builder->hist_local_worker_[entry.nid];
-  //   common::CopyHist(this_local, this_hist, r.begin(), r.end());
-
-  //   if (!(*p_tree)[entry.nid].IsRoot()) {
-  //     const size_t parent_id = (*p_tree)[entry.nid].Parent();
-  //     const int subtraction_node_id = builder->nodes_for_subtraction_trick_[node].nid;
-  //     auto parent_hist = builder->hist_local_worker_[parent_id];
-  //     auto sibling_hist = builder->hist_[subtraction_node_id];
-  //     common::SubtractionHist(sibling_hist, parent_hist, this_hist, r.begin(), r.end());
-  //     // Store posible parent node
-  //     auto sibling_local = builder->hist_local_worker_[subtraction_node_id];
-  //     common::CopyHist(sibling_local, sibling_hist, r.begin(), r.end());
-  //   }
-  // });
-  // builder->builder_monitor_.Start("SyncHistogramsAllreduce");
-
-  // builder->histred_.Allreduce(builder->hist_[starting_index].data(),
-  //                                   builder->hist_builder_.GetNumBins() * sync_count);
-
-  // builder->builder_monitor_.Stop("SyncHistogramsAllreduce");
-
-  // ParallelSubtractionHist(builder, space, builder->nodes_for_explicit_hist_build_,
-  //                         builder->nodes_for_subtraction_trick_, p_tree);
-
-  // common::BlockedSpace2d space2(builder->nodes_for_subtraction_trick_.size(), [&](size_t) {
-  //   return nbins;
-  // }, 1024);
-  // ParallelSubtractionHist(builder, space2, builder->nodes_for_subtraction_trick_,
-  //                         builder->nodes_for_explicit_hist_build_, p_tree);
-  builder->builder_monitor_.Stop("SyncHistograms");
-}
-
-template <typename GradientSumT>
-void DistributedHistSynchronizer<GradientSumT>::ParallelSubtractionHist(
-                                  BuilderT* builder,
-                                  const common::BlockedSpace2d& space,
-                                  const std::vector<CPUExpandEntry>& nodes,
-                                  const std::vector<CPUExpandEntry>& subtraction_nodes,
-                                  const RegTree * p_tree) {
-  // common::ParallelFor2d(space, builder->nthread_, [&](size_t node, common::Range1d r) {
-  //   const auto& entry = nodes[node];
-  //   if (!((*p_tree)[entry.nid].IsLeftChild())) {
-  //     auto this_hist = builder->hist_[entry.nid];
-
-  //     if (!(*p_tree)[entry.nid].IsRoot()) {
-  //       const int subtraction_node_id = subtraction_nodes[node].nid;
-  //       auto parent_hist = builder->hist_[(*p_tree)[entry.nid].Parent()];
-  //       auto sibling_hist = builder->hist_[subtraction_node_id];
-  //       SubtractionHist(this_hist, parent_hist, sibling_hist, r.begin(), r.end());
-  //     }
-  //   }
-  // });
-}
-
-template <typename GradientSumT>
-void BatchHistRowsAdder<GradientSumT>::AddHistRows(BuilderT *builder,
-                                                   int *starting_index,
-                                                   int *sync_count,
-                                                   RegTree *) {
-  builder->builder_monitor_.Start("AddHistRows");
-
-  // for (auto const& entry : builder->nodes_for_explicit_hist_build_) {
-  //   int nid = entry.nid;
-  //   builder->hist_.AddHistRow(nid);
-  //   (*starting_index) = std::min(nid, (*starting_index));
-  // }
-  // (*sync_count) = builder->nodes_for_explicit_hist_build_.size();
-
-  // for (auto const& node : builder->nodes_for_subtraction_trick_) {
-  //   builder->hist_.AddHistRow(node.nid);
-  // }
-  // builder->hist_.AllocateAllData();
-  builder->builder_monitor_.Stop("AddHistRows");
-}
-
-template <typename GradientSumT>
-void DistributedHistRowsAdder<GradientSumT>::AddHistRows(BuilderT *builder,
-                                                         int *starting_index,
-                                                         int *sync_count,
-                                                         RegTree *p_tree) {
-  builder->builder_monitor_.Start("AddHistRows");
-  // const size_t explicit_size = builder->nodes_for_explicit_hist_build_.size();
-  // const size_t subtaction_size = builder->nodes_for_subtraction_trick_.size();
-  // std::vector<int> merged_node_ids(explicit_size + subtaction_size);
-  // for (size_t i = 0; i < explicit_size; ++i) {
-  //   merged_node_ids[i] = builder->nodes_for_explicit_hist_build_[i].nid;
-  // }
-  // for (size_t i = 0; i < subtaction_size; ++i) {
-  //   merged_node_ids[explicit_size + i] =
-  //   builder->nodes_for_subtraction_trick_[i].nid;
-  // }
-  // std::sort(merged_node_ids.begin(), merged_node_ids.end());
-  // int n_left = 0;
-  // for (auto const& nid : merged_node_ids) {
-  //   if ((*p_tree)[nid].IsLeftChild()) {
-  //     builder->hist_.AddHistRow(nid);
-  //     (*starting_index) = std::min(nid, (*starting_index));
-  //     n_left++;
-  //     builder->hist_local_worker_.AddHistRow(nid);
-  //   }
-  // }
-  // for (auto const& nid : merged_node_ids) {
-  //   if (!((*p_tree)[nid].IsLeftChild())) {
-  //     builder->hist_.AddHistRow(nid);
-  //     builder->hist_local_worker_.AddHistRow(nid);
-  //   }
-  // }
-  // builder->hist_.AllocateAllData();
-  // builder->hist_local_worker_.AllocateAllData();
-  // (*sync_count) = std::max(1, n_left);
-  builder->builder_monitor_.Stop("AddHistRows");
-}
-
-template <typename GradientSumT>
-void QuantileHistMaker::Builder<GradientSumT>::SetHistSynchronizer(
-    HistSynchronizer<GradientSumT> *sync) {
-  // hist_synchronizer_.reset(sync);
-}
-
-template <typename GradientSumT>
 QuantileHistMaker::Builder<GradientSumT>::~Builder() = default;
 
-template <typename GradientSumT>
-void QuantileHistMaker::Builder<GradientSumT>::SetHistRowsAdder(
-    HistRowsAdder<GradientSumT> *adder) {
-  // hist_rows_adder_.reset(adder);
-}
 
 template <typename GradientSumT>
 template <bool any_missing>
@@ -357,46 +184,6 @@ void QuantileHistMaker::Builder<GradientSumT>::InitRoot(
 
   expand->push_back(node);
   ++(*num_leaves);
-}
-
-template<typename GradientSumT>
-template <bool any_missing>
-void QuantileHistMaker::Builder<GradientSumT>::BuildLocalHistograms(
-    const GHistIndexMatrix &gmat,
-    RegTree *p_tree,
-    const std::vector<GradientPair> &gpair_h) {
-  builder_monitor_.Start("BuildLocalHistograms");
-
-  // const size_t n_nodes = nodes_for_explicit_hist_build_.size();
-
-  // // create space of size (# rows in each node)
-  // common::BlockedSpace2d space(n_nodes, [&](size_t node) {
-  //   const int32_t nid = nodes_for_explicit_hist_build_[node].nid;
-  //   return row_set_collection_[nid].Size();
-  // }, 256);
-
-  // std::vector<GHistRowT> target_hists(n_nodes);
-  // for (size_t i = 0; i < n_nodes; ++i) {
-  //   const int32_t nid = nodes_for_explicit_hist_build_[i].nid;
-  //   target_hists[i] = hist_[nid];
-  // }
-
-  // hist_buffer_.Reset(this->nthread_, n_nodes, space, target_hists);
-
-  // // Parallel processing by nodes and data in each node
-  // common::ParallelFor2d(space, this->nthread_, [&](size_t nid_in_set, common::Range1d r) {
-  //   const auto tid = static_cast<unsigned>(omp_get_thread_num());
-  //   const int32_t nid = nodes_for_explicit_hist_build_[nid_in_set].nid;
-
-  //   auto start_of_row_set = row_set_collection_[nid].begin;
-  //   auto rid_set = RowSetCollection::Elem(start_of_row_set + r.begin(),
-  //                                     start_of_row_set + r.end(),
-  //                                     nid);
-  //   hist_builder_.template BuildHist<any_missing>(gpair_h, rid_set, gmat,
-  //                                                 hist_buffer_.GetInitializedHist(tid, nid_in_set));
-  // });
-
-  builder_monitor_.Stop("BuildLocalHistograms");
 }
 
 template<typename GradientSumT>

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -267,9 +267,9 @@ void QuantileHistMaker::Builder<GradientSumT>::ExpandTree(
       // int starting_index = std::numeric_limits<int>::max();
       // int sync_count = 0;
       // hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, p_tree);
-        this->histogram_builder_->BuildHist(
-            p_fmat, p_tree, row_set_collection_, nodes_for_explicit_hist_build_,
-            nodes_for_subtraction_trick_, gpair_h);
+      this->histogram_builder_->BuildHist(
+          p_fmat, p_tree, row_set_collection_, nodes_for_explicit_hist_build_,
+          nodes_for_subtraction_trick_, gpair_h);
       if (depth < param_.max_depth) {
 
         // BuildLocalHistograms<any_missing>(gmat, p_tree, gpair_h);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -649,8 +649,7 @@ void QuantileHistMaker::Builder<GradientSumT>::InitData(
       });
     }
     exc.Rethrow();
-    this->histogram_builder_.reset(
-        new HistogramBuilder<GradientSumT>(nbins, this->nthread_));
+    this->histogram_builder_->Reset(nbins, this->nthread_);
     // hist_builder_ = GHistBuilder<GradientSumT>(this->nthread_, nbins);
 
     std::vector<size_t>& row_indices = *row_set_collection_.Data();

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -422,7 +422,7 @@ void QuantileHistMaker::Builder<GradientSumT>::InitData(
       });
     }
     exc.Rethrow();
-    this->histogram_builder_->Reset(nbins, this->nthread_);
+    this->histogram_builder_->Reset(nbins, param_.max_bin, this->nthread_);
 
     std::vector<size_t>& row_indices = *row_set_collection_.Data();
     row_indices.resize(info.num_row_);

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -233,7 +233,7 @@ class QuantileHistMaker: public TreeUpdater {
     explicit Builder(const size_t n_trees, const TrainParam &param,
                      std::unique_ptr<TreeUpdater> pruner, DMatrix const *fmat)
         : n_trees_(n_trees), param_(param), pruner_(std::move(pruner)),
-          p_last_tree_(nullptr), p_last_fmat_(fmat) {
+          p_last_tree_(nullptr), p_last_fmat_(fmat), histogram_builder_{new HistogramBuilder<GradientSumT>} {
       builder_monitor_.Init("Quantile::Builder");
     }
     ~Builder();
@@ -456,8 +456,9 @@ template <typename GradientSumT> class HistogramBuilder {
   int32_t n_threads_;
 
  public:
-  HistogramBuilder(uint32_t n_bins, int32_t n_threads) : n_threads_{n_threads} {
+  void Reset(uint32_t n_bins, int32_t n_threads) {
     CHECK_GE(n_threads, 1);
+    n_threads_ = n_threads;
     hist_.Init(n_bins);
     hist_local_worker_.Init(n_bins);
     buffer_.Init(n_bins);

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -151,6 +151,9 @@ struct CPUExpandEntry {
   }
 };
 
+template <typename GradientSumT>
+class HistogramBuilder;
+
 /*! \brief construct a tree using quantized feature values */
 class QuantileHistMaker: public TreeUpdater {
  public:
@@ -233,6 +236,7 @@ class QuantileHistMaker: public TreeUpdater {
           p_last_tree_(nullptr), p_last_fmat_(fmat) {
       builder_monitor_.Init("Quantile::Builder");
     }
+    ~Builder();
     // update one tree, growing
     virtual void Update(const GHistIndexMatrix& gmat,
                         const ColumnMatrix& column_matrix,
@@ -244,7 +248,7 @@ class QuantileHistMaker: public TreeUpdater {
                                  GHistRowT sibling,
                                  GHistRowT parent) {
       builder_monitor_.Start("SubtractionTrick");
-      hist_builder_.SubtractionTrick(self, sibling, parent);
+      // hist_builder_.SubtractionTrick(self, sibling, parent);
       builder_monitor_.Stop("SubtractionTrick");
     }
 
@@ -278,7 +282,6 @@ class QuantileHistMaker: public TreeUpdater {
     void ApplySplit(std::vector<CPUExpandEntry> nodes,
                         const GHistIndexMatrix& gmat,
                         const ColumnMatrix& column_matrix,
-                        const HistCollection<GradientSumT>& hist,
                         RegTree* p_tree);
 
     void AddSplitsToRowSet(const std::vector<CPUExpandEntry>& nodes, RegTree* p_tree);
@@ -293,8 +296,7 @@ class QuantileHistMaker: public TreeUpdater {
                               RegTree *p_tree,
                               const std::vector<GradientPair> &gpair_h);
     template <bool any_missing>
-    void InitRoot(const GHistIndexMatrix &gmat,
-                  const DMatrix& fmat,
+    void InitRoot(DMatrix* p_fmat,
                   RegTree *p_tree,
                   const std::vector<GradientPair> &gpair_h,
                   int *num_leaves, std::vector<CPUExpandEntry> *expand);
@@ -330,15 +332,11 @@ class QuantileHistMaker: public TreeUpdater {
     // the internal row sets
     RowSetCollection row_set_collection_;
     std::vector<GradientPair> gpair_local_;
-    /*! \brief culmulative histogram of gradients. */
-    HistCollection<GradientSumT> hist_;
-    /*! \brief culmulative local parent histogram of gradients. */
-    HistCollection<GradientSumT> hist_local_worker_;
+
     /*! \brief feature with least # of bins. to be used for dense specialization
                of InitNewNode() */
     uint32_t fid_least_bins_;
 
-    GHistBuilder<GradientSumT> hist_builder_;
     std::unique_ptr<TreeUpdater> pruner_;
     std::unique_ptr<HistEvaluator<GradientSumT, CPUExpandEntry>> evaluator_;
 
@@ -358,12 +356,9 @@ class QuantileHistMaker: public TreeUpdater {
 
     enum class DataLayout { kDenseDataZeroBased, kDenseDataOneBased, kSparseData };
     DataLayout data_layout_;
+    std::unique_ptr<HistogramBuilder<GradientSumT>> histogram_builder_;
 
     common::Monitor builder_monitor_;
-    common::ParallelGHistBuilder<GradientSumT> hist_buffer_;
-    rabit::Reducer<GradientPairT, GradientPairT::Reduce> histred_;
-    std::unique_ptr<HistSynchronizer<GradientSumT>> hist_synchronizer_;
-    std::unique_ptr<HistRowsAdder<GradientSumT>> hist_rows_adder_;
   };
   common::Monitor updater_monitor_;
 
@@ -447,7 +442,261 @@ class DistributedHistRowsAdder: public HistRowsAdder<GradientSumT> {
                    int *sync_count, RegTree *p_tree) override;
 };
 
+template <typename GradientSumT> class HistogramBuilder {
+  using GradientPairT = xgboost::detail::GradientPairInternal<GradientSumT>;
+  using GHistRowT = GHistRow<GradientSumT>;
 
+  /*! \brief culmulative histogram of gradients. */
+  HistCollection<GradientSumT> hist_;
+  /*! \brief culmulative local parent histogram of gradients. */
+  HistCollection<GradientSumT> hist_local_worker_;
+  GHistBuilder<GradientSumT> builder_;
+  common::ParallelGHistBuilder<GradientSumT> buffer_;
+  rabit::Reducer<GradientPairT, GradientPairT::Reduce> reducer_;
+  int32_t n_threads_;
+
+ public:
+  HistogramBuilder(uint32_t n_bins, int32_t n_threads) : n_threads_{n_threads} {
+    CHECK_GE(n_threads, 1);
+    hist_.Init(n_bins);
+    hist_local_worker_.Init(n_bins);
+    buffer_.Init(n_bins);
+    builder_ = GHistBuilder<GradientSumT>(n_threads, n_bins);
+  }
+
+  template <bool any_missing>
+  void BuildLocalHistograms(
+      DMatrix *p_fmat, RegTree *p_tree,
+      std::vector<CPUExpandEntry> nodes_for_explicit_hist_build,
+      RowSetCollection const &row_set_collection,
+      const std::vector<GradientPair> &gpair_h) {
+
+    const size_t n_nodes = nodes_for_explicit_hist_build.size();
+
+    // create space of size (# rows in each node)
+    common::BlockedSpace2d space(
+        n_nodes,
+        [&](size_t node) {
+          const int32_t nid = nodes_for_explicit_hist_build[node].nid;
+          return row_set_collection[nid].Size();
+        },
+        256);
+
+    std::vector<GHistRowT> target_hists(n_nodes);
+    for (size_t i = 0; i < n_nodes; ++i) {
+      const int32_t nid = nodes_for_explicit_hist_build[i].nid;
+      target_hists[i] = hist_[nid];
+    }
+
+    CHECK_LE(this->n_threads_, 16);
+    buffer_.Reset(this->n_threads_, n_nodes, space, target_hists);
+
+    // Parallel processing by nodes and data in each node
+    for (auto const &gmat : p_fmat->GetBatches<GHistIndexMatrix>()) {
+      common::ParallelFor2d(
+          space, this->n_threads_, [&](size_t nid_in_set, common::Range1d r) {
+            const auto tid = static_cast<unsigned>(omp_get_thread_num());
+            const int32_t nid = nodes_for_explicit_hist_build[nid_in_set].nid;
+
+            auto start_of_row_set = row_set_collection[nid].begin;
+            auto rid_set = RowSetCollection::Elem(
+                start_of_row_set + r.begin(), start_of_row_set + r.end(), nid);
+            builder_.template BuildHist<any_missing>(
+                gpair_h, rid_set, gmat,
+                buffer_.GetInitializedHist(tid, nid_in_set));
+          });
+    }
+  }
+
+  void AddHistRowsLocal(
+      int *starting_index, int *sync_count,
+      std::vector<CPUExpandEntry> const &nodes_for_explicit_hist_build,
+      std::vector<CPUExpandEntry> const &nodes_for_subtraction_trick) {
+    for (auto const &entry : nodes_for_explicit_hist_build) {
+      int nid = entry.nid;
+      this->hist_.AddHistRow(nid);
+      (*starting_index) = std::min(nid, (*starting_index));
+    }
+    (*sync_count) = nodes_for_explicit_hist_build.size();
+
+    for (auto const &node : nodes_for_subtraction_trick) {
+      this->hist_.AddHistRow(node.nid);
+    }
+    this->hist_.AllocateAllData();
+  };
+
+  void AddHistRowsDistributed(
+      int *starting_index, int *sync_count,
+      std::vector<CPUExpandEntry> const &nodes_for_explicit_hist_build,
+      std::vector<CPUExpandEntry> const &nodes_for_subtraction_trick,
+      RegTree *p_tree) {
+    const size_t explicit_size = nodes_for_explicit_hist_build.size();
+    const size_t subtaction_size = nodes_for_subtraction_trick.size();
+    std::vector<int> merged_node_ids(explicit_size + subtaction_size);
+    for (size_t i = 0; i < explicit_size; ++i) {
+      merged_node_ids[i] = nodes_for_explicit_hist_build[i].nid;
+    }
+    for (size_t i = 0; i < subtaction_size; ++i) {
+      merged_node_ids[explicit_size + i] = nodes_for_subtraction_trick[i].nid;
+    }
+    std::sort(merged_node_ids.begin(), merged_node_ids.end());
+    int n_left = 0;
+    for (auto const &nid : merged_node_ids) {
+      if ((*p_tree)[nid].IsLeftChild()) {
+        this->hist_.AddHistRow(nid);
+        (*starting_index) = std::min(nid, (*starting_index));
+        n_left++;
+        this->hist_local_worker_.AddHistRow(nid);
+      }
+    }
+    for (auto const &nid : merged_node_ids) {
+      if (!((*p_tree)[nid].IsLeftChild())) {
+        this->hist_.AddHistRow(nid);
+        this->hist_local_worker_.AddHistRow(nid);
+      }
+    }
+    this->hist_.AllocateAllData();
+    this->hist_local_worker_.AllocateAllData();
+    (*sync_count) = std::max(1, n_left);
+  }
+
+  void
+  BuildHist(DMatrix *p_fmat, RegTree *p_tree,
+            RowSetCollection const &row_set_collection,
+            std::vector<CPUExpandEntry> const &nodes_for_explicit_hist_build,
+            std::vector<CPUExpandEntry> const &nodes_for_subtraction_trick,
+            std::vector<GradientPair> const &gpair) {
+    int starting_index = std::numeric_limits<int>::max();
+    int sync_count = 0;
+    if (rabit::IsDistributed()) {
+      this->AddHistRowsDistributed(&starting_index, &sync_count,
+                                   nodes_for_explicit_hist_build,
+                                   nodes_for_subtraction_trick, p_tree);
+    } else {
+      this->AddHistRowsLocal(&starting_index, &sync_count,
+                             nodes_for_explicit_hist_build,
+                             nodes_for_subtraction_trick);
+    }
+
+    if (p_fmat->IsDense()) {
+      BuildLocalHistograms<false>(p_fmat, p_tree, nodes_for_explicit_hist_build,
+                                  row_set_collection, gpair);
+    } else {
+      BuildLocalHistograms<true>(p_fmat, p_tree, nodes_for_explicit_hist_build,
+                                 row_set_collection, gpair);
+    }
+    if (rabit::IsDistributed()) {
+      this->SyncHistogramDistributed(p_tree, nodes_for_explicit_hist_build,
+                                     nodes_for_subtraction_trick,
+                                     starting_index, sync_count);
+    } else {
+      this->SyncHistogramLocal(p_tree, nodes_for_explicit_hist_build,
+                               nodes_for_subtraction_trick, starting_index,
+                               sync_count);
+    }
+  }
+
+  void SyncHistogramDistributed(
+      RegTree *p_tree,
+      std::vector<CPUExpandEntry> const &nodes_for_explicit_hist_build,
+      std::vector<CPUExpandEntry> const &nodes_for_subtraction_trick,
+      int starting_index, int sync_count) {
+    const size_t nbins = builder_.GetNumBins();
+    common::BlockedSpace2d space(
+        nodes_for_explicit_hist_build.size(), [&](size_t) { return nbins; },
+        1024);
+    common::ParallelFor2d(
+        space, n_threads_, [&](size_t node, common::Range1d r) {
+          const auto &entry = nodes_for_explicit_hist_build[node];
+          auto this_hist = this->hist_[entry.nid];
+          // Merging histograms from each thread into once
+          buffer_.ReduceHist(node, r.begin(), r.end());
+          // Store posible parent node
+          auto this_local = hist_local_worker_[entry.nid];
+          common::CopyHist(this_local, this_hist, r.begin(), r.end());
+
+          if (!(*p_tree)[entry.nid].IsRoot()) {
+            const size_t parent_id = (*p_tree)[entry.nid].Parent();
+            const int subtraction_node_id =
+                nodes_for_subtraction_trick[node].nid;
+            auto parent_hist = this->hist_local_worker_[parent_id];
+            auto sibling_hist = this->hist_[subtraction_node_id];
+            common::SubtractionHist(sibling_hist, parent_hist, this_hist,
+                                    r.begin(), r.end());
+            // Store posible parent node
+            auto sibling_local = hist_local_worker_[subtraction_node_id];
+            common::CopyHist(sibling_local, sibling_hist, r.begin(), r.end());
+          }
+        });
+
+    reducer_.Allreduce(this->hist_[starting_index].data(),
+                       builder_.GetNumBins() * sync_count);
+
+    ParallelSubtractionHist(space, nodes_for_explicit_hist_build,
+                            nodes_for_subtraction_trick, p_tree);
+
+    common::BlockedSpace2d space2(
+        nodes_for_subtraction_trick.size(), [&](size_t) { return nbins; },
+        1024);
+    ParallelSubtractionHist(space2, nodes_for_subtraction_trick,
+                            nodes_for_explicit_hist_build, p_tree);
+  }
+
+  void SyncHistogramLocal(
+      RegTree *p_tree,
+      std::vector<CPUExpandEntry> const &nodes_for_explicit_hist_build,
+      std::vector<CPUExpandEntry> const &nodes_for_subtraction_trick,
+      int starting_index, int sync_count) {
+    const size_t nbins = this->builder_.GetNumBins();
+    common::BlockedSpace2d space(
+        nodes_for_explicit_hist_build.size(), [&](size_t) { return nbins; },
+        1024);
+
+    common::ParallelFor2d(
+        space, this->n_threads_, [&](size_t node, common::Range1d r) {
+          const auto &entry = nodes_for_explicit_hist_build[node];
+          auto this_hist = this->hist_[entry.nid];
+          // Merging histograms from each thread into once
+          this->buffer_.ReduceHist(node, r.begin(), r.end());
+
+          if (!(*p_tree)[entry.nid].IsRoot()) {
+            const size_t parent_id = (*p_tree)[entry.nid].Parent();
+            const int subtraction_node_id =
+                nodes_for_subtraction_trick[node].nid;
+            auto parent_hist = this->hist_[parent_id];
+            auto sibling_hist = this->hist_[subtraction_node_id];
+            common::SubtractionHist(sibling_hist, parent_hist, this_hist,
+                                    r.begin(), r.end());
+          }
+        });
+  }
+
+  void
+  ParallelSubtractionHist(const common::BlockedSpace2d &space,
+                          const std::vector<CPUExpandEntry> &nodes,
+                          const std::vector<CPUExpandEntry> &subtraction_nodes,
+                          const RegTree *p_tree) {
+    common::ParallelFor2d(
+        space, this->n_threads_, [&](size_t node, common::Range1d r) {
+          const auto &entry = nodes[node];
+          if (!((*p_tree)[entry.nid].IsLeftChild())) {
+            auto this_hist = this->hist_[entry.nid];
+
+            if (!(*p_tree)[entry.nid].IsRoot()) {
+              const int subtraction_node_id = subtraction_nodes[node].nid;
+              auto parent_hist = hist_[(*p_tree)[entry.nid].Parent()];
+              auto sibling_hist = hist_[subtraction_node_id];
+              SubtractionHist(this_hist, parent_hist, sibling_hist, r.begin(),
+                              r.end());
+            }
+          }
+        });
+  }
+
+  HistCollection<GradientSumT> const& Histogram() {
+    return hist_;
+  }
+};
 }  // namespace tree
 }  // namespace xgboost
 

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -22,6 +22,7 @@
 #include "xgboost/json.h"
 
 #include "hist/evaluate_splits.h"
+#include "hist/histogram.h"
 #include "constraints.h"
 #include "./param.h"
 #include "./driver.h"
@@ -133,9 +134,6 @@ struct CPUExpandEntry {
   }
 };
 
-template <typename GradientSumT>
-class HistogramBuilder;
-
 /*! \brief construct a tree using quantized feature values */
 class QuantileHistMaker: public TreeUpdater {
  public:
@@ -215,7 +213,9 @@ class QuantileHistMaker: public TreeUpdater {
     explicit Builder(const size_t n_trees, const TrainParam &param,
                      std::unique_ptr<TreeUpdater> pruner, DMatrix const *fmat)
         : n_trees_(n_trees), param_(param), pruner_(std::move(pruner)),
-          p_last_tree_(nullptr), p_last_fmat_(fmat), histogram_builder_{new HistogramBuilder<GradientSumT>} {
+          p_last_tree_(nullptr), p_last_fmat_(fmat),
+          histogram_builder_{
+              new HistogramBuilder<GradientSumT, CPUExpandEntry>} {
       builder_monitor_.Init("Quantile::Builder");
     }
     ~Builder();
@@ -323,7 +323,8 @@ class QuantileHistMaker: public TreeUpdater {
 
     enum class DataLayout { kDenseDataZeroBased, kDenseDataOneBased, kSparseData };
     DataLayout data_layout_;
-    std::unique_ptr<HistogramBuilder<GradientSumT>> histogram_builder_;
+    std::unique_ptr<HistogramBuilder<GradientSumT, CPUExpandEntry>>
+        histogram_builder_;
 
     common::Monitor builder_monitor_;
   };
@@ -344,263 +345,6 @@ class QuantileHistMaker: public TreeUpdater {
   std::unique_ptr<Builder<double>> double_builder_;
 
   std::unique_ptr<TreeUpdater> pruner_;
-};
-
-template <typename GradientSumT> class HistogramBuilder {
-  using GradientPairT = xgboost::detail::GradientPairInternal<GradientSumT>;
-  using GHistRowT = GHistRow<GradientSumT>;
-
-  /*! \brief culmulative histogram of gradients. */
-  HistCollection<GradientSumT> hist_;
-  /*! \brief culmulative local parent histogram of gradients. */
-  HistCollection<GradientSumT> hist_local_worker_;
-  GHistBuilder<GradientSumT> builder_;
-  common::ParallelGHistBuilder<GradientSumT> buffer_;
-  rabit::Reducer<GradientPairT, GradientPairT::Reduce> reducer_;
-  int32_t n_threads_;
-
- public:
-  void Reset(uint32_t n_bins, int32_t n_threads) {
-    CHECK_GE(n_threads, 1);
-    n_threads_ = n_threads;
-    hist_.Init(n_bins);
-    hist_local_worker_.Init(n_bins);
-    buffer_.Init(n_bins);
-    builder_ = GHistBuilder<GradientSumT>(n_threads, n_bins);
-  }
-
-  template <bool any_missing>
-  void BuildLocalHistograms(
-      DMatrix *p_fmat, RegTree *p_tree,
-      std::vector<CPUExpandEntry> nodes_for_explicit_hist_build,
-      RowSetCollection const &row_set_collection,
-      const std::vector<GradientPair> &gpair_h) {
-
-    const size_t n_nodes = nodes_for_explicit_hist_build.size();
-
-    // create space of size (# rows in each node)
-    common::BlockedSpace2d space(
-        n_nodes,
-        [&](size_t node) {
-          const int32_t nid = nodes_for_explicit_hist_build[node].nid;
-          return row_set_collection[nid].Size();
-        },
-        256);
-
-    std::vector<GHistRowT> target_hists(n_nodes);
-    for (size_t i = 0; i < n_nodes; ++i) {
-      const int32_t nid = nodes_for_explicit_hist_build[i].nid;
-      target_hists[i] = hist_[nid];
-    }
-
-    CHECK_LE(this->n_threads_, 16);
-    buffer_.Reset(this->n_threads_, n_nodes, space, target_hists);
-
-    // Parallel processing by nodes and data in each node
-    for (auto const &gmat : p_fmat->GetBatches<GHistIndexMatrix>()) {
-      common::ParallelFor2d(
-          space, this->n_threads_, [&](size_t nid_in_set, common::Range1d r) {
-            const auto tid = static_cast<unsigned>(omp_get_thread_num());
-            const int32_t nid = nodes_for_explicit_hist_build[nid_in_set].nid;
-
-            auto start_of_row_set = row_set_collection[nid].begin;
-            auto rid_set = RowSetCollection::Elem(
-                start_of_row_set + r.begin(), start_of_row_set + r.end(), nid);
-            builder_.template BuildHist<any_missing>(
-                gpair_h, rid_set, gmat,
-                buffer_.GetInitializedHist(tid, nid_in_set));
-          });
-    }
-  }
-
-  void AddHistRowsLocal(
-      int *starting_index, int *sync_count,
-      std::vector<CPUExpandEntry> const &nodes_for_explicit_hist_build,
-      std::vector<CPUExpandEntry> const &nodes_for_subtraction_trick) {
-    for (auto const &entry : nodes_for_explicit_hist_build) {
-      int nid = entry.nid;
-      this->hist_.AddHistRow(nid);
-      (*starting_index) = std::min(nid, (*starting_index));
-    }
-    (*sync_count) = nodes_for_explicit_hist_build.size();
-
-    for (auto const &node : nodes_for_subtraction_trick) {
-      this->hist_.AddHistRow(node.nid);
-    }
-    this->hist_.AllocateAllData();
-  };
-
-  void AddHistRowsDistributed(
-      int *starting_index, int *sync_count,
-      std::vector<CPUExpandEntry> const &nodes_for_explicit_hist_build,
-      std::vector<CPUExpandEntry> const &nodes_for_subtraction_trick,
-      RegTree *p_tree) {
-    const size_t explicit_size = nodes_for_explicit_hist_build.size();
-    const size_t subtaction_size = nodes_for_subtraction_trick.size();
-    std::vector<int> merged_node_ids(explicit_size + subtaction_size);
-    for (size_t i = 0; i < explicit_size; ++i) {
-      merged_node_ids[i] = nodes_for_explicit_hist_build[i].nid;
-    }
-    for (size_t i = 0; i < subtaction_size; ++i) {
-      merged_node_ids[explicit_size + i] = nodes_for_subtraction_trick[i].nid;
-    }
-    std::sort(merged_node_ids.begin(), merged_node_ids.end());
-    int n_left = 0;
-    for (auto const &nid : merged_node_ids) {
-      if ((*p_tree)[nid].IsLeftChild()) {
-        this->hist_.AddHistRow(nid);
-        (*starting_index) = std::min(nid, (*starting_index));
-        n_left++;
-        this->hist_local_worker_.AddHistRow(nid);
-      }
-    }
-    for (auto const &nid : merged_node_ids) {
-      if (!((*p_tree)[nid].IsLeftChild())) {
-        this->hist_.AddHistRow(nid);
-        this->hist_local_worker_.AddHistRow(nid);
-      }
-    }
-    this->hist_.AllocateAllData();
-    this->hist_local_worker_.AllocateAllData();
-    (*sync_count) = std::max(1, n_left);
-  }
-
-  void
-  BuildHist(DMatrix *p_fmat, RegTree *p_tree,
-            RowSetCollection const &row_set_collection,
-            std::vector<CPUExpandEntry> const &nodes_for_explicit_hist_build,
-            std::vector<CPUExpandEntry> const &nodes_for_subtraction_trick,
-            std::vector<GradientPair> const &gpair) {
-    int starting_index = std::numeric_limits<int>::max();
-    int sync_count = 0;
-    if (rabit::IsDistributed()) {
-      this->AddHistRowsDistributed(&starting_index, &sync_count,
-                                   nodes_for_explicit_hist_build,
-                                   nodes_for_subtraction_trick, p_tree);
-    } else {
-      this->AddHistRowsLocal(&starting_index, &sync_count,
-                             nodes_for_explicit_hist_build,
-                             nodes_for_subtraction_trick);
-    }
-
-    if (p_fmat->IsDense()) {
-      BuildLocalHistograms<false>(p_fmat, p_tree, nodes_for_explicit_hist_build,
-                                  row_set_collection, gpair);
-    } else {
-      BuildLocalHistograms<true>(p_fmat, p_tree, nodes_for_explicit_hist_build,
-                                 row_set_collection, gpair);
-    }
-    if (rabit::IsDistributed()) {
-      this->SyncHistogramDistributed(p_tree, nodes_for_explicit_hist_build,
-                                     nodes_for_subtraction_trick,
-                                     starting_index, sync_count);
-    } else {
-      this->SyncHistogramLocal(p_tree, nodes_for_explicit_hist_build,
-                               nodes_for_subtraction_trick, starting_index,
-                               sync_count);
-    }
-  }
-
-  void SyncHistogramDistributed(
-      RegTree *p_tree,
-      std::vector<CPUExpandEntry> const &nodes_for_explicit_hist_build,
-      std::vector<CPUExpandEntry> const &nodes_for_subtraction_trick,
-      int starting_index, int sync_count) {
-    const size_t nbins = builder_.GetNumBins();
-    common::BlockedSpace2d space(
-        nodes_for_explicit_hist_build.size(), [&](size_t) { return nbins; },
-        1024);
-    common::ParallelFor2d(
-        space, n_threads_, [&](size_t node, common::Range1d r) {
-          const auto &entry = nodes_for_explicit_hist_build[node];
-          auto this_hist = this->hist_[entry.nid];
-          // Merging histograms from each thread into once
-          buffer_.ReduceHist(node, r.begin(), r.end());
-          // Store posible parent node
-          auto this_local = hist_local_worker_[entry.nid];
-          common::CopyHist(this_local, this_hist, r.begin(), r.end());
-
-          if (!(*p_tree)[entry.nid].IsRoot()) {
-            const size_t parent_id = (*p_tree)[entry.nid].Parent();
-            const int subtraction_node_id =
-                nodes_for_subtraction_trick[node].nid;
-            auto parent_hist = this->hist_local_worker_[parent_id];
-            auto sibling_hist = this->hist_[subtraction_node_id];
-            common::SubtractionHist(sibling_hist, parent_hist, this_hist,
-                                    r.begin(), r.end());
-            // Store posible parent node
-            auto sibling_local = hist_local_worker_[subtraction_node_id];
-            common::CopyHist(sibling_local, sibling_hist, r.begin(), r.end());
-          }
-        });
-
-    reducer_.Allreduce(this->hist_[starting_index].data(),
-                       builder_.GetNumBins() * sync_count);
-
-    ParallelSubtractionHist(space, nodes_for_explicit_hist_build,
-                            nodes_for_subtraction_trick, p_tree);
-
-    common::BlockedSpace2d space2(
-        nodes_for_subtraction_trick.size(), [&](size_t) { return nbins; },
-        1024);
-    ParallelSubtractionHist(space2, nodes_for_subtraction_trick,
-                            nodes_for_explicit_hist_build, p_tree);
-  }
-
-  void SyncHistogramLocal(
-      RegTree *p_tree,
-      std::vector<CPUExpandEntry> const &nodes_for_explicit_hist_build,
-      std::vector<CPUExpandEntry> const &nodes_for_subtraction_trick,
-      int starting_index, int sync_count) {
-    const size_t nbins = this->builder_.GetNumBins();
-    common::BlockedSpace2d space(
-        nodes_for_explicit_hist_build.size(), [&](size_t) { return nbins; },
-        1024);
-
-    common::ParallelFor2d(
-        space, this->n_threads_, [&](size_t node, common::Range1d r) {
-          const auto &entry = nodes_for_explicit_hist_build[node];
-          auto this_hist = this->hist_[entry.nid];
-          // Merging histograms from each thread into once
-          this->buffer_.ReduceHist(node, r.begin(), r.end());
-
-          if (!(*p_tree)[entry.nid].IsRoot()) {
-            const size_t parent_id = (*p_tree)[entry.nid].Parent();
-            const int subtraction_node_id =
-                nodes_for_subtraction_trick[node].nid;
-            auto parent_hist = this->hist_[parent_id];
-            auto sibling_hist = this->hist_[subtraction_node_id];
-            common::SubtractionHist(sibling_hist, parent_hist, this_hist,
-                                    r.begin(), r.end());
-          }
-        });
-  }
-
-  void
-  ParallelSubtractionHist(const common::BlockedSpace2d &space,
-                          const std::vector<CPUExpandEntry> &nodes,
-                          const std::vector<CPUExpandEntry> &subtraction_nodes,
-                          const RegTree *p_tree) {
-    common::ParallelFor2d(
-        space, this->n_threads_, [&](size_t node, common::Range1d r) {
-          const auto &entry = nodes[node];
-          if (!((*p_tree)[entry.nid].IsLeftChild())) {
-            auto this_hist = this->hist_[entry.nid];
-
-            if (!(*p_tree)[entry.nid].IsRoot()) {
-              const int subtraction_node_id = subtraction_nodes[node].nid;
-              auto parent_hist = hist_[(*p_tree)[entry.nid].Parent()];
-              auto sibling_hist = hist_[subtraction_node_id];
-              SubtractionHist(this_hist, parent_hist, sibling_hist, r.begin(),
-                              r.end());
-            }
-          }
-        });
-  }
-
-  HistCollection<GradientSumT> const& Histogram() {
-    return hist_;
-  }
 };
 }  // namespace tree
 }  // namespace xgboost

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -212,14 +212,6 @@ class QuantileHistMaker: public TreeUpdater {
                         DMatrix* p_fmat,
                         RegTree* p_tree);
 
-    inline void SubtractionTrick(GHistRowT self,
-                                 GHistRowT sibling,
-                                 GHistRowT parent) {
-      builder_monitor_.Start("SubtractionTrick");
-      // hist_builder_.SubtractionTrick(self, sibling, parent);
-      builder_monitor_.Stop("SubtractionTrick");
-    }
-
     bool UpdatePredictionCache(const DMatrix* data,
                                VectorView<float> out_preds);
 

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -181,20 +181,6 @@ class QuantileHistMaker: public TreeUpdater {
   }
 
  protected:
-  template <typename GradientSumT>
-  friend class HistSynchronizer;
-  template <typename GradientSumT>
-  friend class BatchHistSynchronizer;
-  template <typename GradientSumT>
-  friend class DistributedHistSynchronizer;
-
-  template <typename GradientSumT>
-  friend class HistRowsAdder;
-  template <typename GradientSumT>
-  friend class BatchHistRowsAdder;
-  template <typename GradientSumT>
-  friend class DistributedHistRowsAdder;
-
   CPUHistMakerTrainParam hist_maker_param_;
   // training parameter
   TrainParam param_;

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -1,0 +1,200 @@
+/*!
+ * Copyright 2018-2021 by Contributors
+ */
+#include <gtest/gtest.h>
+#include "../../../../src/tree/hist/histogram.h"
+#include "../../../../src/tree/updater_quantile_hist.h"
+
+namespace xgboost {
+namespace tree {
+void TestAddHistRows() {
+  std::vector<CPUExpandEntry> nodes_for_explicit_hist_build_;
+  std::vector<CPUExpandEntry> nodes_for_subtraction_trick_;
+  int starting_index = std::numeric_limits<int>::max();
+  int sync_count = 0;
+
+  RegTree tree;
+
+  tree.ExpandNode(0, 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+  tree.ExpandNode(tree[0].LeftChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+  tree.ExpandNode(tree[0].RightChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+  nodes_for_explicit_hist_build_.emplace_back(3, tree.GetDepth(3), 0.0f);
+  nodes_for_explicit_hist_build_.emplace_back(4, tree.GetDepth(4), 0.0f);
+  nodes_for_subtraction_trick_.emplace_back(5, tree.GetDepth(5), 0.0f);
+  nodes_for_subtraction_trick_.emplace_back(6, tree.GetDepth(6), 0.0f);
+
+  HistogramBuilder<float, CPUExpandEntry> histogram_builder;
+  histogram_builder.AddHistRowsLocal(&starting_index, &sync_count,
+                                     nodes_for_explicit_hist_build_,
+                                     nodes_for_subtraction_trick_);
+  ASSERT_EQ(sync_count, 2);
+  ASSERT_EQ(starting_index, 3);
+
+  for (const CPUExpandEntry &node : nodes_for_explicit_hist_build_) {
+    ASSERT_EQ(histogram_builder.Histogram().RowExists(node.nid), true);
+  }
+  for (const CPUExpandEntry &node : nodes_for_subtraction_trick_) {
+    ASSERT_EQ(histogram_builder.Histogram().RowExists(node.nid), true);
+  }
+}
+
+
+TEST(CPUHistogram, AddRows) {
+  TestAddHistRows();
+}
+
+void TestSyncHist() {
+  std::vector<CPUExpandEntry> nodes_for_explicit_hist_build_;
+  std::vector<CPUExpandEntry> nodes_for_subtraction_trick_;
+  int starting_index = std::numeric_limits<int>::max();
+  int sync_count = 0;
+  RegTree tree;
+
+  // level 0
+  nodes_for_explicit_hist_build_.emplace_back(0, tree.GetDepth(0), 0.0f);
+  this->hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, tree);
+  tree.ExpandNode(0, 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+
+  // level 1
+  nodes_for_explicit_hist_build_.emplace_back(tree[0].LeftChild(),
+                                              tree.GetDepth(1), 0.0f);
+  nodes_for_subtraction_trick_.emplace_back(tree[0].RightChild(),
+                                            tree.GetDepth(2), 0.0f);
+  this->hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, tree);
+  tree.ExpandNode(tree[0].LeftChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+  tree.ExpandNode(tree[0].RightChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+
+  nodes_for_explicit_hist_build_.clear();
+  nodes_for_subtraction_trick_.clear();
+  // level 2
+  nodes_for_explicit_hist_build_.emplace_back(3, tree.GetDepth(3), 0.0f);
+  nodes_for_subtraction_trick_.emplace_back(4, tree.GetDepth(4), 0.0f);
+  nodes_for_explicit_hist_build_.emplace_back(5, tree.GetDepth(5), 0.0f);
+  nodes_for_subtraction_trick_.emplace_back(6, tree.GetDepth(6), 0.0f);
+  this->hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, tree);
+
+  const size_t n_nodes = this->nodes_for_explicit_hist_build_.size();
+  ASSERT_EQ(n_nodes, 2ul);
+  this->row_set_collection_.AddSplit(0, tree[0].LeftChild(),
+                                     tree[0].RightChild(), 4, 4);
+  this->row_set_collection_.AddSplit(1, tree[1].LeftChild(),
+                                     tree[1].RightChild(), 2, 2);
+  this->row_set_collection_.AddSplit(2, tree[2].LeftChild(),
+                                     tree[2].RightChild(), 2, 2);
+
+  common::BlockedSpace2d space(
+      n_nodes,
+      [&](size_t node) {
+        const int32_t nid = nodes_for_explicit_hist_build_[node].nid;
+        return this->row_set_collection_[nid].Size();
+      },
+      256);
+
+  std::vector<common::GHistRowT> target_hists(n_nodes);
+  for (size_t i = 0; i < this->nodes_for_explicit_hist_build_.size(); ++i) {
+    const int32_t nid = this->nodes_for_explicit_hist_build_[i].nid;
+    target_hists[i] = this->hist_[nid];
+  }
+
+  const size_t nbins = this->hist_builder_.GetNumBins();
+  // set values to specific nodes hist
+  std::vector<size_t> n_ids = {1, 2};
+  for (size_t i : n_ids) {
+    auto this_hist = this->hist_[i];
+    GradientSumT *p_hist = reinterpret_cast<GradientSumT *>(this_hist.data());
+    for (size_t bin_id = 0; bin_id < 2 * nbins; ++bin_id) {
+      p_hist[bin_id] = 2 * bin_id;
+    }
+  }
+  n_ids[0] = 3;
+  n_ids[1] = 5;
+  for (size_t i : n_ids) {
+    auto this_hist = this->hist_[i];
+    GradientSumT *p_hist = reinterpret_cast<GradientSumT *>(this_hist.data());
+    for (size_t bin_id = 0; bin_id < 2 * nbins; ++bin_id) {
+      p_hist[bin_id] = bin_id;
+    }
+  }
+
+  this->hist_buffer_.Reset(1, n_nodes, space, target_hists);
+  // sync hist
+  this->hist_synchronizer_->SyncHistograms(this, starting_index, sync_count,
+                                           tree);
+
+  auto check_hist = [](const GHistRowT parent, const GHistRowT left,
+                       const GHistRowT right, size_t begin, size_t end) {
+    const GradientSumT *p_parent =
+        reinterpret_cast<const GradientSumT *>(parent.data());
+    const GradientSumT *p_left =
+        reinterpret_cast<const GradientSumT *>(left.data());
+    const GradientSumT *p_right =
+        reinterpret_cast<const GradientSumT *>(right.data());
+    for (size_t i = 2 * begin; i < 2 * end; ++i) {
+      ASSERT_EQ(p_parent[i], p_left[i] + p_right[i]);
+    }
+  };
+  size_t node_id = 0;
+  for (const CPUExpandEntry &node : this->nodes_for_explicit_hist_build_) {
+    auto this_hist = this->hist_[node.nid];
+    const size_t parent_id = tree[node.nid].Parent();
+    const size_t subtraction_node_id =
+        this->nodes_for_subtraction_trick_[node_id].nid;
+    auto parent_hist = this->hist_[parent_id];
+    auto sibling_hist = this->hist_[subtraction_node_id];
+
+    check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
+    ++node_id;
+  }
+  node_id = 0;
+  for (const CPUExpandEntry &node : this->nodes_for_subtraction_trick_) {
+    auto this_hist = this->hist_[node.nid];
+    const size_t parent_id = tree[node.nid].Parent();
+    const size_t subtraction_node_id =
+        this->nodes_for_explicit_hist_build_[node_id].nid;
+    auto parent_hist = this->hist_[parent_id];
+    auto sibling_hist = this->hist_[subtraction_node_id];
+
+    check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
+    ++node_id;
+  }
+}
+
+void TestBuildHistogram() {
+  std::vector<GradientPair> gpair = {
+      {0.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f}, {0.27f, 0.28f},
+      {0.27f, 0.29f}, {0.37f, 0.39f}, {0.47f, 0.49f}, {0.57f, 0.59f}};
+  RealImpl::InitData(gmat, fmat, tree, &gpair);
+  this->hist_.AddHistRow(nid);
+  this->hist_.AllocateAllData();
+  this->hist_builder_.template BuildHist<true>(
+      gpair, this->row_set_collection_[nid], gmat, this->hist_[nid]);
+
+  // Check if number of histogram bins is correct
+  ASSERT_EQ(this->hist_[nid].size(), gmat.cut.Ptrs().back());
+  std::vector<GradientPairPrecise> histogram_expected(this->hist_[nid].size());
+
+  // Compute the correct histogram (histogram_expected)
+  const size_t num_row = fmat.Info().num_row_;
+  CHECK_EQ(gpair.size(), num_row);
+  for (size_t rid = 0; rid < num_row; ++rid) {
+    const size_t ibegin = gmat.row_ptr[rid];
+    const size_t iend = gmat.row_ptr[rid + 1];
+    for (size_t i = ibegin; i < iend; ++i) {
+      const size_t bin_id = gmat.index[i];
+      histogram_expected[bin_id] += GradientPairPrecise(gpair[rid]);
+    }
+  }
+
+  // Now validate the computed histogram returned by BuildHist
+  for (size_t i = 0; i < this->hist_[nid].size(); ++i) {
+    GradientPairPrecise sol = histogram_expected[i];
+    ASSERT_NEAR(sol.GetGrad(), this->hist_[nid][i].GetGrad(), kEps);
+    ASSERT_NEAR(sol.GetHess(), this->hist_[nid][i].GetHess(), kEps);
+  }
+}
+
+TEST(CPUHistogram, BuildHist) {
+  TestBuildHistogram();
+}
+}  // namespace tree
+}  // namespace xgboost

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -44,129 +44,148 @@ TEST(CPUHistogram, AddRows) {
   TestAddHistRows();
 }
 
-// template <typename GradientSumT>
-// void TestSyncHist() {
-//   std::vector<CPUExpandEntry> nodes_for_explicit_hist_build_;
-//   std::vector<CPUExpandEntry> nodes_for_subtraction_trick_;
-//   int starting_index = std::numeric_limits<int>::max();
-//   int sync_count = 0;
-//   RegTree tree;
+template <typename GradientSumT>
+void TestSyncHist() {
+  size_t constexpr kNRows = 8, kNCols = 16;
+  size_t constexpr kMaxBins = 4;
 
-//   HistogramBuilder<float, CPUExpandEntry> histogram;
-//   // level 0
-//   nodes_for_explicit_hist_build_.emplace_back(0, tree.GetDepth(0), 0.0f);
-//   histogram.AddHistRowsLocal(&starting_index, &sync_count,
-//                              nodes_for_explicit_hist_build_,
-//                              nodes_for_subtraction_trick_);
-//   tree.ExpandNode(0, 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+  std::vector<CPUExpandEntry> nodes_for_explicit_hist_build_;
+  std::vector<CPUExpandEntry> nodes_for_subtraction_trick_;
+  int starting_index = std::numeric_limits<int>::max();
+  int sync_count = 0;
+  RegTree tree;
 
-//   // level 1
-//   nodes_for_explicit_hist_build_.emplace_back(tree[0].LeftChild(),
-//                                               tree.GetDepth(1), 0.0f);
-//   nodes_for_subtraction_trick_.emplace_back(tree[0].RightChild(),
-//                                             tree.GetDepth(2), 0.0f);
-//   histogram.AddHistRowsLocal(&starting_index, &sync_count,
-//                              nodes_for_explicit_hist_build_,
-//                              nodes_for_subtraction_trick_);
-//   tree.ExpandNode(tree[0].LeftChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
-//   tree.ExpandNode(tree[0].RightChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+  HistogramBuilder<GradientSumT, CPUExpandEntry> histogram;
+  histogram.Reset();
 
-//   nodes_for_explicit_hist_build_.clear();
-//   nodes_for_subtraction_trick_.clear();
-//   // level 2
-//   nodes_for_explicit_hist_build_.emplace_back(3, tree.GetDepth(3), 0.0f);
-//   nodes_for_subtraction_trick_.emplace_back(4, tree.GetDepth(4), 0.0f);
-//   nodes_for_explicit_hist_build_.emplace_back(5, tree.GetDepth(5), 0.0f);
-//   nodes_for_subtraction_trick_.emplace_back(6, tree.GetDepth(6), 0.0f);
-//   histogram.AddHistRowsLocal(&starting_index, &sync_count,
-//                              nodes_for_explicit_hist_build_,
-//                              nodes_for_subtraction_trick_);
+  RowSetCollection row_set_collection_;
+  {
+    row_set_collection_.Clear();
+    std::vector<size_t> &row_indices = *row_set_collection_.Data();
+    row_indices.resize(kNRows);
+    std::iota(row_indices.begin(), row_indices.end(), 0);
+    row_set_collection_.Init();
+  }
 
-//   const size_t n_nodes = nodes_for_explicit_hist_build_.size();
-//   ASSERT_EQ(n_nodes, 2ul);
-//   this->row_set_collection_.AddSplit(0, tree[0].LeftChild(),
-//                                      tree[0].RightChild(), 4, 4);
-//   this->row_set_collection_.AddSplit(1, tree[1].LeftChild(),
-//                                      tree[1].RightChild(), 2, 2);
-//   this->row_set_collection_.AddSplit(2, tree[2].LeftChild(),
-//                                      tree[2].RightChild(), 2, 2);
+  // level 0
+  nodes_for_explicit_hist_build_.emplace_back(0, tree.GetDepth(0), 0.0f);
+  histogram.AddHistRowsLocal(&starting_index, &sync_count,
+                             nodes_for_explicit_hist_build_,
+                             nodes_for_subtraction_trick_);
+  tree.ExpandNode(0, 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
 
-//   common::BlockedSpace2d space(
-//       n_nodes,
-//       [&](size_t node) {
-//         const int32_t nid = nodes_for_explicit_hist_build_[node].nid;
-//         return this->row_set_collection_[nid].Size();
-//       },
-//       256);
+  // level 1
+  nodes_for_explicit_hist_build_.emplace_back(tree[0].LeftChild(),
+                                              tree.GetDepth(1), 0.0f);
+  nodes_for_subtraction_trick_.emplace_back(tree[0].RightChild(),
+                                            tree.GetDepth(2), 0.0f);
+  histogram.AddHistRowsLocal(&starting_index, &sync_count,
+                             nodes_for_explicit_hist_build_,
+                             nodes_for_subtraction_trick_);
+  tree.ExpandNode(tree[0].LeftChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+  tree.ExpandNode(tree[0].RightChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
 
-//   std::vector<common::GHistRow<GradientSumT>> target_hists(n_nodes);
-//   for (size_t i = 0; i < nodes_for_explicit_hist_build_.size(); ++i) {
-//     const int32_t nid = nodes_for_explicit_hist_build_[i].nid;
-//     target_hists[i] = histogram.Histogram()[nid];
-//   }
+  nodes_for_explicit_hist_build_.clear();
+  nodes_for_subtraction_trick_.clear();
+  // level 2
+  nodes_for_explicit_hist_build_.emplace_back(3, tree.GetDepth(3), 0.0f);
+  nodes_for_subtraction_trick_.emplace_back(4, tree.GetDepth(4), 0.0f);
+  nodes_for_explicit_hist_build_.emplace_back(5, tree.GetDepth(5), 0.0f);
+  nodes_for_subtraction_trick_.emplace_back(6, tree.GetDepth(6), 0.0f);
+  histogram.AddHistRowsLocal(&starting_index, &sync_count,
+                             nodes_for_explicit_hist_build_,
+                             nodes_for_subtraction_trick_);
 
-//   const size_t nbins = this->hist_builder_.GetNumBins();
-//   // set values to specific nodes hist
-//   std::vector<size_t> n_ids = {1, 2};
-//   for (size_t i : n_ids) {
-//     auto this_hist = histogram.Histogram()[i];
-//     GradientSumT *p_hist = reinterpret_cast<GradientSumT *>(this_hist.data());
-//     for (size_t bin_id = 0; bin_id < 2 * nbins; ++bin_id) {
-//       p_hist[bin_id] = 2 * bin_id;
-//     }
-//   }
-//   n_ids[0] = 3;
-//   n_ids[1] = 5;
-//   for (size_t i : n_ids) {
-//     auto this_hist = histogram.Histogram()[i];
-//     GradientSumT *p_hist = reinterpret_cast<GradientSumT *>(this_hist.data());
-//     for (size_t bin_id = 0; bin_id < 2 * nbins; ++bin_id) {
-//       p_hist[bin_id] = bin_id;
-//     }
-//   }
+  const size_t n_nodes = nodes_for_explicit_hist_build_.size();
+  ASSERT_EQ(n_nodes, 2ul);
+  row_set_collection_.AddSplit(0, tree[0].LeftChild(), tree[0].RightChild(), 4,
+                               4);
+  row_set_collection_.AddSplit(1, tree[1].LeftChild(), tree[1].RightChild(), 2,
+                               2);
+  row_set_collection_.AddSplit(2, tree[2].LeftChild(), tree[2].RightChild(), 2,
+                               2);
 
-//   this->hist_buffer_.Reset(1, n_nodes, space, target_hists);
-//   // sync hist
-//   this->hist_synchronizer_->SyncHistograms(this, starting_index, sync_count,
-//                                            tree);
-//   using GHistRowT = common::GHistRow<GradientSumT>;
-//   auto check_hist = [](const GHistRowT parent, const GHistRowT left,
-//                        const GHistRowT right, size_t begin, size_t end) {
-//     const GradientSumT *p_parent =
-//         reinterpret_cast<const GradientSumT *>(parent.data());
-//     const GradientSumT *p_left =
-//         reinterpret_cast<const GradientSumT *>(left.data());
-//     const GradientSumT *p_right =
-//         reinterpret_cast<const GradientSumT *>(right.data());
-//     for (size_t i = 2 * begin; i < 2 * end; ++i) {
-//       ASSERT_EQ(p_parent[i], p_left[i] + p_right[i]);
-//     }
-//   };
-//   size_t node_id = 0;
-//   for (const CPUExpandEntry &node : nodes_for_explicit_hist_build_) {
-//     auto this_hist = histogram.Histogram()[node.nid];
-//     const size_t parent_id = tree[node.nid].Parent();
-//     const size_t subtraction_node_id =
-//         nodes_for_subtraction_trick_[node_id].nid;
-//     auto parent_hist = histogram.Histogram()[parent_id];
-//     auto sibling_hist = histogram.Histogram()[subtraction_node_id];
+  common::BlockedSpace2d space(
+      n_nodes,
+      [&](size_t node) {
+        const int32_t nid = nodes_for_explicit_hist_build_[node].nid;
+        return row_set_collection_[nid].Size();
+      },
+      256);
 
-//     check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
-//     ++node_id;
-//   }
-//   node_id = 0;
-//   for (const CPUExpandEntry &node : nodes_for_subtraction_trick_) {
-//     auto this_hist = histogram.Histogram()[node.nid];
-//     const size_t parent_id = tree[node.nid].Parent();
-//     const size_t subtraction_node_id =
-//         nodes_for_explicit_hist_build_[node_id].nid;
-//     auto parent_hist = histogram.Histogram()[parent_id];
-//     auto sibling_hist = histogram.Histogram()[subtraction_node_id];
+  std::vector<common::GHistRow<GradientSumT>> target_hists(n_nodes);
+  for (size_t i = 0; i < nodes_for_explicit_hist_build_.size(); ++i) {
+    const int32_t nid = nodes_for_explicit_hist_build_[i].nid;
+    target_hists[i] = histogram.Histogram()[nid];
+  }
 
-//     check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
-//     ++node_id;
-//   }
-// }
+  const size_t nbins = this->hist_builder_.GetNumBins();
+  // set values to specific nodes hist
+  std::vector<size_t> n_ids = {1, 2};
+  for (size_t i : n_ids) {
+    auto this_hist = histogram.Histogram()[i];
+    GradientSumT *p_hist = reinterpret_cast<GradientSumT *>(this_hist.data());
+    for (size_t bin_id = 0; bin_id < 2 * nbins; ++bin_id) {
+      p_hist[bin_id] = 2 * bin_id;
+    }
+  }
+  n_ids[0] = 3;
+  n_ids[1] = 5;
+  for (size_t i : n_ids) {
+    auto this_hist = histogram.Histogram()[i];
+    GradientSumT *p_hist = reinterpret_cast<GradientSumT *>(this_hist.data());
+    for (size_t bin_id = 0; bin_id < 2 * nbins; ++bin_id) {
+      p_hist[bin_id] = bin_id;
+    }
+  }
+
+  this->hist_buffer_.Reset(1, n_nodes, space, target_hists);
+  // sync hist
+  this->hist_synchronizer_->SyncHistograms(this, starting_index, sync_count,
+                                           tree);
+  using GHistRowT = common::GHistRow<GradientSumT>;
+  auto check_hist = [](const GHistRowT parent, const GHistRowT left,
+                       const GHistRowT right, size_t begin, size_t end) {
+    const GradientSumT *p_parent =
+        reinterpret_cast<const GradientSumT *>(parent.data());
+    const GradientSumT *p_left =
+        reinterpret_cast<const GradientSumT *>(left.data());
+    const GradientSumT *p_right =
+        reinterpret_cast<const GradientSumT *>(right.data());
+    for (size_t i = 2 * begin; i < 2 * end; ++i) {
+      ASSERT_EQ(p_parent[i], p_left[i] + p_right[i]);
+    }
+  };
+  size_t node_id = 0;
+  for (const CPUExpandEntry &node : nodes_for_explicit_hist_build_) {
+    auto this_hist = histogram.Histogram()[node.nid];
+    const size_t parent_id = tree[node.nid].Parent();
+    const size_t subtraction_node_id =
+        nodes_for_subtraction_trick_[node_id].nid;
+    auto parent_hist = histogram.Histogram()[parent_id];
+    auto sibling_hist = histogram.Histogram()[subtraction_node_id];
+
+    check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
+    ++node_id;
+  }
+  node_id = 0;
+  for (const CPUExpandEntry &node : nodes_for_subtraction_trick_) {
+    auto this_hist = histogram.Histogram()[node.nid];
+    const size_t parent_id = tree[node.nid].Parent();
+    const size_t subtraction_node_id =
+        nodes_for_explicit_hist_build_[node_id].nid;
+    auto parent_hist = histogram.Histogram()[parent_id];
+    auto sibling_hist = histogram.Histogram()[subtraction_node_id];
+
+    check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
+    ++node_id;
+  }
+}
+
+TEST(CPUHistogram, SyncHist) {
+  TestSyncHist<float>();
+  TestSyncHist<double>();
+}
 
 template <typename GradientSumT>
 void TestBuildHistogram() {

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -49,7 +49,7 @@ TEST(CPUHistogram, AddRows) {
 template <typename GradientSumT>
 void TestSyncHist() {
   size_t constexpr kNRows = 8, kNCols = 16;
-  size_t constexpr kMaxBins = 4;
+  int32_t constexpr kMaxBins = 4;
 
   std::vector<CPUExpandEntry> nodes_for_explicit_hist_build_;
   std::vector<CPUExpandEntry> nodes_for_subtraction_trick_;
@@ -202,7 +202,7 @@ TEST(CPUHistogram, SyncHist) {
 template <typename GradientSumT>
 void TestBuildHistogram() {
   size_t constexpr kNRows = 8, kNCols = 16;
-  size_t constexpr kMaxBins = 4;
+  int32_t constexpr kMaxBins = 4;
   auto p_fmat =
       RandomDataGenerator(kNRows, kNCols, 0.8).Seed(3).GenerateDMatrix();
   auto const &gmat = *(p_fmat

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -2,6 +2,7 @@
  * Copyright 2018-2021 by Contributors
  */
 #include <gtest/gtest.h>
+#include "../../helpers.h"
 #include "../../../../src/tree/hist/histogram.h"
 #include "../../../../src/tree/updater_quantile_hist.h"
 
@@ -43,151 +44,173 @@ TEST(CPUHistogram, AddRows) {
   TestAddHistRows();
 }
 
-template <typename GradientSumT>
-void TestSyncHist() {
-  std::vector<CPUExpandEntry> nodes_for_explicit_hist_build_;
-  std::vector<CPUExpandEntry> nodes_for_subtraction_trick_;
-  int starting_index = std::numeric_limits<int>::max();
-  int sync_count = 0;
-  RegTree tree;
+// template <typename GradientSumT>
+// void TestSyncHist() {
+//   std::vector<CPUExpandEntry> nodes_for_explicit_hist_build_;
+//   std::vector<CPUExpandEntry> nodes_for_subtraction_trick_;
+//   int starting_index = std::numeric_limits<int>::max();
+//   int sync_count = 0;
+//   RegTree tree;
 
-  HistogramBuilder<float, CPUExpandEntry> histogram;
-  // level 0
-  nodes_for_explicit_hist_build_.emplace_back(0, tree.GetDepth(0), 0.0f);
-  histogram.AddHistRowsLocal(&starting_index, &sync_count,
-                             nodes_for_explicit_hist_build_,
-                             nodes_for_subtraction_trick_);
-  tree.ExpandNode(0, 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+//   HistogramBuilder<float, CPUExpandEntry> histogram;
+//   // level 0
+//   nodes_for_explicit_hist_build_.emplace_back(0, tree.GetDepth(0), 0.0f);
+//   histogram.AddHistRowsLocal(&starting_index, &sync_count,
+//                              nodes_for_explicit_hist_build_,
+//                              nodes_for_subtraction_trick_);
+//   tree.ExpandNode(0, 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
 
-  // level 1
-  nodes_for_explicit_hist_build_.emplace_back(tree[0].LeftChild(),
-                                              tree.GetDepth(1), 0.0f);
-  nodes_for_subtraction_trick_.emplace_back(tree[0].RightChild(),
-                                            tree.GetDepth(2), 0.0f);
-  histogram.AddHistRowsLocal(&starting_index, &sync_count,
-                             nodes_for_explicit_hist_build_,
-                             nodes_for_subtraction_trick_);
-  tree.ExpandNode(tree[0].LeftChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
-  tree.ExpandNode(tree[0].RightChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+//   // level 1
+//   nodes_for_explicit_hist_build_.emplace_back(tree[0].LeftChild(),
+//                                               tree.GetDepth(1), 0.0f);
+//   nodes_for_subtraction_trick_.emplace_back(tree[0].RightChild(),
+//                                             tree.GetDepth(2), 0.0f);
+//   histogram.AddHistRowsLocal(&starting_index, &sync_count,
+//                              nodes_for_explicit_hist_build_,
+//                              nodes_for_subtraction_trick_);
+//   tree.ExpandNode(tree[0].LeftChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
+//   tree.ExpandNode(tree[0].RightChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
 
-  nodes_for_explicit_hist_build_.clear();
-  nodes_for_subtraction_trick_.clear();
-  // level 2
-  nodes_for_explicit_hist_build_.emplace_back(3, tree.GetDepth(3), 0.0f);
-  nodes_for_subtraction_trick_.emplace_back(4, tree.GetDepth(4), 0.0f);
-  nodes_for_explicit_hist_build_.emplace_back(5, tree.GetDepth(5), 0.0f);
-  nodes_for_subtraction_trick_.emplace_back(6, tree.GetDepth(6), 0.0f);
-  histogram.AddHistRowsLocal(&starting_index, &sync_count,
-                             nodes_for_explicit_hist_build_,
-                             nodes_for_subtraction_trick_);
+//   nodes_for_explicit_hist_build_.clear();
+//   nodes_for_subtraction_trick_.clear();
+//   // level 2
+//   nodes_for_explicit_hist_build_.emplace_back(3, tree.GetDepth(3), 0.0f);
+//   nodes_for_subtraction_trick_.emplace_back(4, tree.GetDepth(4), 0.0f);
+//   nodes_for_explicit_hist_build_.emplace_back(5, tree.GetDepth(5), 0.0f);
+//   nodes_for_subtraction_trick_.emplace_back(6, tree.GetDepth(6), 0.0f);
+//   histogram.AddHistRowsLocal(&starting_index, &sync_count,
+//                              nodes_for_explicit_hist_build_,
+//                              nodes_for_subtraction_trick_);
 
-  const size_t n_nodes = this->nodes_for_explicit_hist_build_.size();
-  ASSERT_EQ(n_nodes, 2ul);
-  this->row_set_collection_.AddSplit(0, tree[0].LeftChild(),
-                                     tree[0].RightChild(), 4, 4);
-  this->row_set_collection_.AddSplit(1, tree[1].LeftChild(),
-                                     tree[1].RightChild(), 2, 2);
-  this->row_set_collection_.AddSplit(2, tree[2].LeftChild(),
-                                     tree[2].RightChild(), 2, 2);
+//   const size_t n_nodes = nodes_for_explicit_hist_build_.size();
+//   ASSERT_EQ(n_nodes, 2ul);
+//   this->row_set_collection_.AddSplit(0, tree[0].LeftChild(),
+//                                      tree[0].RightChild(), 4, 4);
+//   this->row_set_collection_.AddSplit(1, tree[1].LeftChild(),
+//                                      tree[1].RightChild(), 2, 2);
+//   this->row_set_collection_.AddSplit(2, tree[2].LeftChild(),
+//                                      tree[2].RightChild(), 2, 2);
 
-  common::BlockedSpace2d space(
-      n_nodes,
-      [&](size_t node) {
-        const int32_t nid = nodes_for_explicit_hist_build_[node].nid;
-        return this->row_set_collection_[nid].Size();
-      },
-      256);
+//   common::BlockedSpace2d space(
+//       n_nodes,
+//       [&](size_t node) {
+//         const int32_t nid = nodes_for_explicit_hist_build_[node].nid;
+//         return this->row_set_collection_[nid].Size();
+//       },
+//       256);
 
-  std::vector<common::GHistRow<GradientSumT>> target_hists(n_nodes);
-  for (size_t i = 0; i < this->nodes_for_explicit_hist_build_.size(); ++i) {
-    const int32_t nid = this->nodes_for_explicit_hist_build_[i].nid;
-    target_hists[i] = histogram.Histogram()[nid];
-  }
+//   std::vector<common::GHistRow<GradientSumT>> target_hists(n_nodes);
+//   for (size_t i = 0; i < nodes_for_explicit_hist_build_.size(); ++i) {
+//     const int32_t nid = nodes_for_explicit_hist_build_[i].nid;
+//     target_hists[i] = histogram.Histogram()[nid];
+//   }
 
-  const size_t nbins = this->hist_builder_.GetNumBins();
-  // set values to specific nodes hist
-  std::vector<size_t> n_ids = {1, 2};
-  for (size_t i : n_ids) {
-    auto this_hist = histogram.Histogram()[i];
-    GradientSumT *p_hist = reinterpret_cast<GradientSumT *>(this_hist.data());
-    for (size_t bin_id = 0; bin_id < 2 * nbins; ++bin_id) {
-      p_hist[bin_id] = 2 * bin_id;
-    }
-  }
-  n_ids[0] = 3;
-  n_ids[1] = 5;
-  for (size_t i : n_ids) {
-    auto this_hist = histogram.Histogram()[i];
-    GradientSumT *p_hist = reinterpret_cast<GradientSumT *>(this_hist.data());
-    for (size_t bin_id = 0; bin_id < 2 * nbins; ++bin_id) {
-      p_hist[bin_id] = bin_id;
-    }
-  }
+//   const size_t nbins = this->hist_builder_.GetNumBins();
+//   // set values to specific nodes hist
+//   std::vector<size_t> n_ids = {1, 2};
+//   for (size_t i : n_ids) {
+//     auto this_hist = histogram.Histogram()[i];
+//     GradientSumT *p_hist = reinterpret_cast<GradientSumT *>(this_hist.data());
+//     for (size_t bin_id = 0; bin_id < 2 * nbins; ++bin_id) {
+//       p_hist[bin_id] = 2 * bin_id;
+//     }
+//   }
+//   n_ids[0] = 3;
+//   n_ids[1] = 5;
+//   for (size_t i : n_ids) {
+//     auto this_hist = histogram.Histogram()[i];
+//     GradientSumT *p_hist = reinterpret_cast<GradientSumT *>(this_hist.data());
+//     for (size_t bin_id = 0; bin_id < 2 * nbins; ++bin_id) {
+//       p_hist[bin_id] = bin_id;
+//     }
+//   }
 
-  this->hist_buffer_.Reset(1, n_nodes, space, target_hists);
-  // sync hist
-  this->hist_synchronizer_->SyncHistograms(this, starting_index, sync_count,
-                                           tree);
-  using GHistRowT = common::GHistRow<GradientSumT>;
-  auto check_hist = [](const GHistRowT parent, const GHistRowT left,
-                       const GHistRowT right, size_t begin, size_t end) {
-    const GradientSumT *p_parent =
-        reinterpret_cast<const GradientSumT *>(parent.data());
-    const GradientSumT *p_left =
-        reinterpret_cast<const GradientSumT *>(left.data());
-    const GradientSumT *p_right =
-        reinterpret_cast<const GradientSumT *>(right.data());
-    for (size_t i = 2 * begin; i < 2 * end; ++i) {
-      ASSERT_EQ(p_parent[i], p_left[i] + p_right[i]);
-    }
-  };
-  size_t node_id = 0;
-  for (const CPUExpandEntry &node : nodes_for_explicit_hist_build_) {
-    auto this_hist = histogram.Histogram()[node.nid];
-    const size_t parent_id = tree[node.nid].Parent();
-    const size_t subtraction_node_id =
-        nodes_for_subtraction_trick_[node_id].nid;
-    auto parent_hist = histogram.Histogram()[parent_id];
-    auto sibling_hist = histogram.Histogram()[subtraction_node_id];
+//   this->hist_buffer_.Reset(1, n_nodes, space, target_hists);
+//   // sync hist
+//   this->hist_synchronizer_->SyncHistograms(this, starting_index, sync_count,
+//                                            tree);
+//   using GHistRowT = common::GHistRow<GradientSumT>;
+//   auto check_hist = [](const GHistRowT parent, const GHistRowT left,
+//                        const GHistRowT right, size_t begin, size_t end) {
+//     const GradientSumT *p_parent =
+//         reinterpret_cast<const GradientSumT *>(parent.data());
+//     const GradientSumT *p_left =
+//         reinterpret_cast<const GradientSumT *>(left.data());
+//     const GradientSumT *p_right =
+//         reinterpret_cast<const GradientSumT *>(right.data());
+//     for (size_t i = 2 * begin; i < 2 * end; ++i) {
+//       ASSERT_EQ(p_parent[i], p_left[i] + p_right[i]);
+//     }
+//   };
+//   size_t node_id = 0;
+//   for (const CPUExpandEntry &node : nodes_for_explicit_hist_build_) {
+//     auto this_hist = histogram.Histogram()[node.nid];
+//     const size_t parent_id = tree[node.nid].Parent();
+//     const size_t subtraction_node_id =
+//         nodes_for_subtraction_trick_[node_id].nid;
+//     auto parent_hist = histogram.Histogram()[parent_id];
+//     auto sibling_hist = histogram.Histogram()[subtraction_node_id];
 
-    check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
-    ++node_id;
-  }
-  node_id = 0;
-  for (const CPUExpandEntry &node : nodes_for_subtraction_trick_) {
-    auto this_hist = histogram.Histogram()[node.nid];
-    const size_t parent_id = tree[node.nid].Parent();
-    const size_t subtraction_node_id =
-        nodes_for_explicit_hist_build_[node_id].nid;
-    auto parent_hist = histogram.Histogram()[parent_id];
-    auto sibling_hist = histogram.Histogram()[subtraction_node_id];
+//     check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
+//     ++node_id;
+//   }
+//   node_id = 0;
+//   for (const CPUExpandEntry &node : nodes_for_subtraction_trick_) {
+//     auto this_hist = histogram.Histogram()[node.nid];
+//     const size_t parent_id = tree[node.nid].Parent();
+//     const size_t subtraction_node_id =
+//         nodes_for_explicit_hist_build_[node_id].nid;
+//     auto parent_hist = histogram.Histogram()[parent_id];
+//     auto sibling_hist = histogram.Histogram()[subtraction_node_id];
 
-    check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
-    ++node_id;
-  }
-}
+//     check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
+//     ++node_id;
+//   }
+// }
 
 template <typename GradientSumT>
 void TestBuildHistogram() {
+  size_t constexpr kNRows = 8, kNCols = 16;
+  size_t constexpr kMaxBins = 4;
+  auto p_fmat =
+      RandomDataGenerator(kNRows, kNCols, 0.8).Seed(3).GenerateDMatrix();
+  auto const &gmat = *(p_fmat
+                           ->GetBatches<GHistIndexMatrix>(
+                               BatchParam{GenericParameter::kCpuId, kMaxBins})
+                           .begin());
+  uint32_t total_bins = gmat.cut.Ptrs().back();
+
   static double constexpr kEps = 1e-6;
   std::vector<GradientPair> gpair = {
       {0.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f}, {0.27f, 0.28f},
       {0.27f, 0.29f}, {0.37f, 0.39f}, {0.47f, 0.49f}, {0.57f, 0.59f}};
 
+  bst_node_t nid = 0;
   HistogramBuilder<GradientSumT, CPUExpandEntry> histogram;
-  this->hist_.AddHistRow(nid);
-  this->hist_.AllocateAllData();
-  this->hist_builder_.template BuildHist<true>(
-      gpair, this->row_set_collection_[nid], gmat, this->hist_[nid]);
+  histogram.Reset(total_bins, omp_get_max_threads());
+
+  RegTree tree;
+
+  RowSetCollection row_set_collection_;
+  row_set_collection_.Clear();
+  std::vector<size_t> &row_indices = *row_set_collection_.Data();
+  row_indices.resize(kNRows);
+  std::iota(row_indices.begin(), row_indices.end(), 0);
+  row_set_collection_.Init();
+
+  CPUExpandEntry node(CPUExpandEntry::kRootNid, tree.GetDepth(0), 0.0f);
+  std::vector<CPUExpandEntry> nodes_for_explicit_hist_build_;
+  nodes_for_explicit_hist_build_.push_back(node);
+  histogram.BuildHist(p_fmat.get(), &tree, row_set_collection_,
+                      nodes_for_explicit_hist_build_, {}, gpair);
 
   // Check if number of histogram bins is correct
   ASSERT_EQ(histogram.Histogram()[nid].size(), gmat.cut.Ptrs().back());
   std::vector<GradientPairPrecise> histogram_expected(histogram.Histogram()[nid].size());
 
   // Compute the correct histogram (histogram_expected)
-  const size_t num_row = fmat.Info().num_row_;
-  CHECK_EQ(gpair.size(), num_row);
-  for (size_t rid = 0; rid < num_row; ++rid) {
+  CHECK_EQ(gpair.size(), kNRows);
+  for (size_t rid = 0; rid < kNRows; ++rid) {
     const size_t ibegin = gmat.row_ptr[rid];
     const size_t iend = gmat.row_ptr[rid + 1];
     for (size_t i = ibegin; i < iend; ++i) {
@@ -205,7 +228,8 @@ void TestBuildHistogram() {
 }
 
 TEST(CPUHistogram, BuildHist) {
-  TestBuildHistogram();
+  TestBuildHistogram<float>();
+  TestBuildHistogram<double>();
 }
 }  // namespace tree
 }  // namespace xgboost

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -66,7 +66,7 @@ void TestSyncHist() {
 
   HistogramBuilder<GradientSumT, CPUExpandEntry> histogram;
   uint32_t total_bins = gmat.cut.Ptrs().back();
-  histogram.Reset(total_bins, omp_get_max_threads());
+  histogram.Reset(total_bins, kMaxBins, omp_get_max_threads());
 
   RowSetCollection row_set_collection_;
   {
@@ -218,7 +218,7 @@ void TestBuildHistogram() {
 
   bst_node_t nid = 0;
   HistogramBuilder<GradientSumT, CPUExpandEntry> histogram;
-  histogram.Reset(total_bins, omp_get_max_threads());
+  histogram.Reset(total_bins, kMaxBins, omp_get_max_threads());
 
   RegTree tree;
 

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -168,9 +168,6 @@ class QuantileHistMock : public QuantileHistMaker {
         // treat everything as dense, as this is what we intend to test here
         cm.Init(gmat, 0.0);
         RealImpl::InitData(gmat, *dmat, tree, &row_gpairs);
-        // this->hist_.AddHistRow(0);
-        // this->hist_.AllocateAllData();
-
         const size_t num_row = dmat->Info().num_row_;
         // split by feature 0
         const size_t bin_id_min = gmat.cut.Ptrs()[0];

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -151,187 +151,42 @@ class QuantileHistMock : public QuantileHistMaker {
       omp_set_num_threads(nthreads);
     }
 
-    void TestAddHistRows(const GHistIndexMatrix& gmat,
-                         std::vector<GradientPair>* gpair,
-                         DMatrix* p_fmat,
-                         RegTree* tree) {
-      RealImpl::InitData(gmat, *p_fmat, *tree, gpair);
+    // void TestBuildHist(int nid,
+    //                    const GHistIndexMatrix& gmat,
+    //                    const DMatrix& fmat,
+    //                    const RegTree& tree) {
+    //   std::vector<GradientPair> gpair =
+    //       { {0.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f}, {0.27f, 0.28f},
+    //         {0.27f, 0.29f}, {0.37f, 0.39f}, {0.47f, 0.49f}, {0.57f, 0.59f} };
+    //   RealImpl::InitData(gmat, fmat, tree, &gpair);
+    //   this->hist_.AddHistRow(nid);
+    //   this->hist_.AllocateAllData();
+    //   this->hist_builder_.template BuildHist<true>(gpair, this->row_set_collection_[nid],
+    //                   gmat, this->hist_[nid]);
 
-      int starting_index = std::numeric_limits<int>::max();
-      int sync_count = 0;
-      this->nodes_for_explicit_hist_build_.clear();
-      this->nodes_for_subtraction_trick_.clear();
+    //   // Check if number of histogram bins is correct
+    //   ASSERT_EQ(this->hist_[nid].size(), gmat.cut.Ptrs().back());
+    //   std::vector<GradientPairPrecise> histogram_expected(this->hist_[nid].size());
 
-      tree->ExpandNode(0, 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
-      tree->ExpandNode((*tree)[0].LeftChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
-      tree->ExpandNode((*tree)[0].RightChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
-      this->nodes_for_explicit_hist_build_.emplace_back(3, tree->GetDepth(3), 0.0f);
-      this->nodes_for_explicit_hist_build_.emplace_back(4, tree->GetDepth(4), 0.0f);
-      this->nodes_for_subtraction_trick_.emplace_back(5, tree->GetDepth(5), 0.0f);
-      this->nodes_for_subtraction_trick_.emplace_back(6, tree->GetDepth(6), 0.0f);
+    //   // Compute the correct histogram (histogram_expected)
+    //   const size_t num_row = fmat.Info().num_row_;
+    //   CHECK_EQ(gpair.size(), num_row);
+    //   for (size_t rid = 0; rid < num_row; ++rid) {
+    //     const size_t ibegin = gmat.row_ptr[rid];
+    //     const size_t iend = gmat.row_ptr[rid + 1];
+    //     for (size_t i = ibegin; i < iend; ++i) {
+    //       const size_t bin_id = gmat.index[i];
+    //       histogram_expected[bin_id] += GradientPairPrecise(gpair[rid]);
+    //     }
+    //   }
 
-      this->hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, tree);
-      ASSERT_EQ(sync_count, 2);
-      ASSERT_EQ(starting_index, 3);
-
-      for (const CPUExpandEntry& node : this->nodes_for_explicit_hist_build_) {
-        ASSERT_EQ(this->hist_.RowExists(node.nid), true);
-      }
-      for (const CPUExpandEntry& node : this->nodes_for_subtraction_trick_) {
-        ASSERT_EQ(this->hist_.RowExists(node.nid), true);
-      }
-    }
-
-
-    void TestSyncHistograms(const GHistIndexMatrix& gmat,
-                            std::vector<GradientPair>* gpair,
-                            DMatrix* p_fmat,
-                            RegTree* tree) {
-      // init
-      RealImpl::InitData(gmat, *p_fmat, *tree, gpair);
-
-      int starting_index = std::numeric_limits<int>::max();
-      int sync_count = 0;
-      this->nodes_for_explicit_hist_build_.clear();
-      this->nodes_for_subtraction_trick_.clear();
-      // level 0
-      this->nodes_for_explicit_hist_build_.emplace_back(0, tree->GetDepth(0), 0.0f);
-      this->hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, tree);
-      tree->ExpandNode(0, 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
-
-      this->nodes_for_explicit_hist_build_.clear();
-      this->nodes_for_subtraction_trick_.clear();
-      // level 1
-      this->nodes_for_explicit_hist_build_.emplace_back((*tree)[0].LeftChild(),
-                                                tree->GetDepth(1), 0.0f);
-      this->nodes_for_subtraction_trick_.emplace_back((*tree)[0].RightChild(),
-                                              tree->GetDepth(2), 0.0f);
-      this->hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, tree);
-      tree->ExpandNode((*tree)[0].LeftChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
-      tree->ExpandNode((*tree)[0].RightChild(), 0, 0, false, 0, 0, 0, 0, 0, 0, 0);
-
-      this->nodes_for_explicit_hist_build_.clear();
-      this->nodes_for_subtraction_trick_.clear();
-      // level 2
-      this->nodes_for_explicit_hist_build_.emplace_back(3, tree->GetDepth(3), 0.0f);
-      this->nodes_for_subtraction_trick_.emplace_back(4, tree->GetDepth(4), 0.0f);
-      this->nodes_for_explicit_hist_build_.emplace_back(5, tree->GetDepth(5), 0.0f);
-      this->nodes_for_subtraction_trick_.emplace_back(6, tree->GetDepth(6), 0.0f);
-      this->hist_rows_adder_->AddHistRows(this, &starting_index, &sync_count, tree);
-
-      const size_t n_nodes = this->nodes_for_explicit_hist_build_.size();
-      ASSERT_EQ(n_nodes, 2ul);
-      this->row_set_collection_.AddSplit(0, (*tree)[0].LeftChild(),
-          (*tree)[0].RightChild(), 4, 4);
-      this->row_set_collection_.AddSplit(1, (*tree)[1].LeftChild(),
-          (*tree)[1].RightChild(), 2, 2);
-      this->row_set_collection_.AddSplit(2, (*tree)[2].LeftChild(),
-          (*tree)[2].RightChild(), 2, 2);
-
-      common::BlockedSpace2d space(n_nodes, [&](size_t node) {
-        const int32_t nid = this->nodes_for_explicit_hist_build_[node].nid;
-        return this->row_set_collection_[nid].Size();
-      }, 256);
-
-      std::vector<GHistRowT> target_hists(n_nodes);
-      for (size_t i = 0; i < this->nodes_for_explicit_hist_build_.size(); ++i) {
-        const int32_t nid = this->nodes_for_explicit_hist_build_[i].nid;
-        target_hists[i] = this->hist_[nid];
-      }
-
-      const size_t nbins = this->hist_builder_.GetNumBins();
-      // set values to specific nodes hist
-      std::vector<size_t> n_ids = {1, 2};
-      for (size_t i : n_ids) {
-        auto this_hist = this->hist_[i];
-        GradientSumT* p_hist = reinterpret_cast<GradientSumT*>(this_hist.data());
-        for (size_t bin_id = 0; bin_id < 2*nbins; ++bin_id) {
-          p_hist[bin_id] = 2*bin_id;
-        }
-      }
-      n_ids[0] = 3;
-      n_ids[1] = 5;
-      for (size_t i : n_ids) {
-        auto this_hist = this->hist_[i];
-        GradientSumT* p_hist = reinterpret_cast<GradientSumT*>(this_hist.data());
-        for (size_t bin_id = 0; bin_id < 2*nbins; ++bin_id) {
-          p_hist[bin_id] = bin_id;
-        }
-      }
-
-      this->hist_buffer_.Reset(1, n_nodes, space, target_hists);
-      // sync hist
-      this->hist_synchronizer_->SyncHistograms(this, starting_index, sync_count, tree);
-
-      auto check_hist = [] (const GHistRowT parent, const GHistRowT left,
-                            const GHistRowT right, size_t begin, size_t end) {
-        const GradientSumT* p_parent = reinterpret_cast<const GradientSumT*>(parent.data());
-        const GradientSumT* p_left = reinterpret_cast<const GradientSumT*>(left.data());
-        const GradientSumT* p_right = reinterpret_cast<const GradientSumT*>(right.data());
-        for (size_t i = 2 * begin; i < 2 * end; ++i) {
-          ASSERT_EQ(p_parent[i], p_left[i] + p_right[i]);
-        }
-      };
-      size_t node_id = 0;
-      for (const CPUExpandEntry& node : this->nodes_for_explicit_hist_build_) {
-        auto this_hist = this->hist_[node.nid];
-        const size_t parent_id = (*tree)[node.nid].Parent();
-        const size_t subtraction_node_id = this->nodes_for_subtraction_trick_[node_id].nid;
-        auto parent_hist =  this->hist_[parent_id];
-        auto sibling_hist = this->hist_[subtraction_node_id];
-
-        check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
-        ++node_id;
-      }
-      node_id = 0;
-      for (const CPUExpandEntry& node : this->nodes_for_subtraction_trick_) {
-        auto this_hist = this->hist_[node.nid];
-        const size_t parent_id = (*tree)[node.nid].Parent();
-        const size_t subtraction_node_id = this->nodes_for_explicit_hist_build_[node_id].nid;
-        auto parent_hist =  this->hist_[parent_id];
-        auto sibling_hist = this->hist_[subtraction_node_id];
-
-        check_hist(parent_hist, this_hist, sibling_hist, 0, nbins);
-        ++node_id;
-      }
-    }
-
-    void TestBuildHist(int nid,
-                       const GHistIndexMatrix& gmat,
-                       const DMatrix& fmat,
-                       const RegTree& tree) {
-      std::vector<GradientPair> gpair =
-          { {0.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f}, {0.27f, 0.28f},
-            {0.27f, 0.29f}, {0.37f, 0.39f}, {0.47f, 0.49f}, {0.57f, 0.59f} };
-      RealImpl::InitData(gmat, fmat, tree, &gpair);
-      this->hist_.AddHistRow(nid);
-      this->hist_.AllocateAllData();
-      this->hist_builder_.template BuildHist<true>(gpair, this->row_set_collection_[nid],
-                      gmat, this->hist_[nid]);
-
-      // Check if number of histogram bins is correct
-      ASSERT_EQ(this->hist_[nid].size(), gmat.cut.Ptrs().back());
-      std::vector<GradientPairPrecise> histogram_expected(this->hist_[nid].size());
-
-      // Compute the correct histogram (histogram_expected)
-      const size_t num_row = fmat.Info().num_row_;
-      CHECK_EQ(gpair.size(), num_row);
-      for (size_t rid = 0; rid < num_row; ++rid) {
-        const size_t ibegin = gmat.row_ptr[rid];
-        const size_t iend = gmat.row_ptr[rid + 1];
-        for (size_t i = ibegin; i < iend; ++i) {
-          const size_t bin_id = gmat.index[i];
-          histogram_expected[bin_id] += GradientPairPrecise(gpair[rid]);
-        }
-      }
-
-      // Now validate the computed histogram returned by BuildHist
-      for (size_t i = 0; i < this->hist_[nid].size(); ++i) {
-        GradientPairPrecise sol = histogram_expected[i];
-        ASSERT_NEAR(sol.GetGrad(), this->hist_[nid][i].GetGrad(), kEps);
-        ASSERT_NEAR(sol.GetHess(), this->hist_[nid][i].GetHess(), kEps);
-      }
-    }
+    //   // Now validate the computed histogram returned by BuildHist
+    //   for (size_t i = 0; i < this->hist_[nid].size(); ++i) {
+    //     GradientPairPrecise sol = histogram_expected[i];
+    //     ASSERT_NEAR(sol.GetGrad(), this->hist_[nid][i].GetGrad(), kEps);
+    //     ASSERT_NEAR(sol.GetHess(), this->hist_[nid][i].GetHess(), kEps);
+    //   }
+    // }
 
     void TestApplySplit(const RegTree& tree) {
       std::vector<GradientPair> row_gpairs =
@@ -350,8 +205,8 @@ class QuantileHistMock : public QuantileHistMaker {
         // treat everything as dense, as this is what we intend to test here
         cm.Init(gmat, 0.0);
         RealImpl::InitData(gmat, *dmat, tree, &row_gpairs);
-        this->hist_.AddHistRow(0);
-        this->hist_.AllocateAllData();
+        // this->hist_.AddHistRow(0);
+        // this->hist_.AllocateAllData();
 
         const size_t num_row = dmat->Info().num_row_;
         // split by feature 0
@@ -424,26 +279,12 @@ class QuantileHistMock : public QuantileHistMaker {
               param_,
               std::move(pruner_),
               dmat_.get()));
-      if (batch) {
-        float_builder_->SetHistSynchronizer(new BatchHistSynchronizer<float>());
-        float_builder_->SetHistRowsAdder(new BatchHistRowsAdder<float>());
-      } else {
-        float_builder_->SetHistSynchronizer(new DistributedHistSynchronizer<float>());
-        float_builder_->SetHistRowsAdder(new DistributedHistRowsAdder<float>());
-      }
     } else {
       double_builder_.reset(
           new BuilderMock<double>(
               param_,
               std::move(pruner_),
               dmat_.get()));
-      if (batch) {
-        double_builder_->SetHistSynchronizer(new BatchHistSynchronizer<double>());
-        double_builder_->SetHistRowsAdder(new BatchHistRowsAdder<double>());
-      } else {
-        double_builder_->SetHistSynchronizer(new DistributedHistSynchronizer<double>());
-        double_builder_->SetHistRowsAdder(new DistributedHistRowsAdder<double>());
-      }
     }
   }
   ~QuantileHistMock() override = default;
@@ -484,51 +325,35 @@ class QuantileHistMock : public QuantileHistMaker {
     }
   }
 
-  void TestAddHistRows() {
-    size_t constexpr kMaxBins = 4;
-    GHistIndexMatrix gmat(dmat_.get(), kMaxBins);
+  // void TestSyncHistograms() {
+  //   size_t constexpr kMaxBins = 4;
+  //   GHistIndexMatrix gmat(dmat_.get(), kMaxBins);
 
-    RegTree tree = RegTree();
-    tree.param.UpdateAllowUnknown(cfg_);
-    std::vector<GradientPair> gpair =
-        { {0.23f, 0.24f}, {0.23f, 0.24f}, {0.23f, 0.24f}, {0.23f, 0.24f},
-          {0.27f, 0.29f}, {0.27f, 0.29f}, {0.27f, 0.29f}, {0.27f, 0.29f} };
-    if (double_builder_) {
-      double_builder_->TestAddHistRows(gmat, &gpair, dmat_.get(), &tree);
-    } else {
-      float_builder_->TestAddHistRows(gmat, &gpair, dmat_.get(), &tree);
-    }
-  }
-
-  void TestSyncHistograms() {
-    size_t constexpr kMaxBins = 4;
-    GHistIndexMatrix gmat(dmat_.get(), kMaxBins);
-
-    RegTree tree = RegTree();
-    tree.param.UpdateAllowUnknown(cfg_);
-    std::vector<GradientPair> gpair =
-        { {0.23f, 0.24f}, {0.23f, 0.24f}, {0.23f, 0.24f}, {0.23f, 0.24f},
-          {0.27f, 0.29f}, {0.27f, 0.29f}, {0.27f, 0.29f}, {0.27f, 0.29f} };
-    if (double_builder_) {
-      double_builder_->TestSyncHistograms(gmat, &gpair, dmat_.get(), &tree);
-    } else {
-      float_builder_->TestSyncHistograms(gmat, &gpair, dmat_.get(), &tree);
-    }
-  }
+  //   RegTree tree = RegTree();
+  //   tree.param.UpdateAllowUnknown(cfg_);
+  //   std::vector<GradientPair> gpair =
+  //       { {0.23f, 0.24f}, {0.23f, 0.24f}, {0.23f, 0.24f}, {0.23f, 0.24f},
+  //         {0.27f, 0.29f}, {0.27f, 0.29f}, {0.27f, 0.29f}, {0.27f, 0.29f} };
+  //   if (double_builder_) {
+  //     double_builder_->TestSyncHistograms(gmat, &gpair, dmat_.get(), &tree);
+  //   } else {
+  //     float_builder_->TestSyncHistograms(gmat, &gpair, dmat_.get(), &tree);
+  //   }
+  // }
 
 
-  void TestBuildHist() {
-    RegTree tree = RegTree();
-    tree.param.UpdateAllowUnknown(cfg_);
+  // void TestBuildHist() {
+  //   RegTree tree = RegTree();
+  //   tree.param.UpdateAllowUnknown(cfg_);
 
-    size_t constexpr kMaxBins = 4;
-    GHistIndexMatrix gmat(dmat_.get(), kMaxBins);
-    if (double_builder_) {
-      double_builder_->TestBuildHist(0, gmat, *dmat_, tree);
-    } else {
-      float_builder_->TestBuildHist(0, gmat, *dmat_, tree);
-    }
-  }
+  //   size_t constexpr kMaxBins = 4;
+  //   GHistIndexMatrix gmat(dmat_.get(), kMaxBins);
+  //   if (double_builder_) {
+  //     double_builder_->TestBuildHist(0, gmat, *dmat_, tree);
+  //   } else {
+  //     float_builder_->TestBuildHist(0, gmat, *dmat_, tree);
+  //   }
+  // }
 
   void TestApplySplit() {
     RegTree tree = RegTree();
@@ -563,56 +388,56 @@ TEST(QuantileHist, InitDataSampling) {
   maker_float.TestInitDataSampling();
 }
 
-TEST(QuantileHist, AddHistRows) {
-  std::vector<std::pair<std::string, std::string>> cfg
-      {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
-  QuantileHistMock maker(cfg);
-  maker.TestAddHistRows();
-  const bool single_precision_histogram = true;
-  QuantileHistMock maker_float(cfg, single_precision_histogram);
-  maker_float.TestAddHistRows();
-}
+// TEST(QuantileHist, AddHistRows) {
+//   std::vector<std::pair<std::string, std::string>> cfg
+//       {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
+//   QuantileHistMock maker(cfg);
+//   maker.TestAddHistRows();
+//   const bool single_precision_histogram = true;
+//   QuantileHistMock maker_float(cfg, single_precision_histogram);
+//   maker_float.TestAddHistRows();
+// }
 
-TEST(QuantileHist, SyncHistograms) {
-  std::vector<std::pair<std::string, std::string>> cfg
-      {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
-  QuantileHistMock maker(cfg);
-  maker.TestSyncHistograms();
-  const bool single_precision_histogram = true;
-  QuantileHistMock maker_float(cfg, single_precision_histogram);
-  maker_float.TestSyncHistograms();
-}
+// TEST(QuantileHist, SyncHistograms) {
+//   std::vector<std::pair<std::string, std::string>> cfg
+//       {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
+//   QuantileHistMock maker(cfg);
+//   maker.TestSyncHistograms();
+//   const bool single_precision_histogram = true;
+//   QuantileHistMock maker_float(cfg, single_precision_histogram);
+//   maker_float.TestSyncHistograms();
+// }
 
-TEST(QuantileHist, DistributedAddHistRows) {
-  std::vector<std::pair<std::string, std::string>> cfg
-      {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
-  QuantileHistMock maker(cfg, false);
-  maker.TestAddHistRows();
-  const bool single_precision_histogram = true;
-  QuantileHistMock maker_float(cfg, single_precision_histogram);
-  maker_float.TestAddHistRows();
-}
+// TEST(QuantileHist, DistributedAddHistRows) {
+//   std::vector<std::pair<std::string, std::string>> cfg
+//       {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
+//   QuantileHistMock maker(cfg, false);
+//   maker.TestAddHistRows();
+//   const bool single_precision_histogram = true;
+//   QuantileHistMock maker_float(cfg, single_precision_histogram);
+//   maker_float.TestAddHistRows();
+// }
 
-TEST(QuantileHist, DistributedSyncHistograms) {
-  std::vector<std::pair<std::string, std::string>> cfg
-      {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
-  QuantileHistMock maker(cfg, false);
-  maker.TestSyncHistograms();
-  const bool single_precision_histogram = true;
-  QuantileHistMock maker_float(cfg, single_precision_histogram);
-  maker_float.TestSyncHistograms();
-}
+// TEST(QuantileHist, DistributedSyncHistograms) {
+//   std::vector<std::pair<std::string, std::string>> cfg
+//       {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
+//   QuantileHistMock maker(cfg, false);
+//   maker.TestSyncHistograms();
+//   const bool single_precision_histogram = true;
+//   QuantileHistMock maker_float(cfg, single_precision_histogram);
+//   maker_float.TestSyncHistograms();
+// }
 
-TEST(QuantileHist, BuildHist) {
-  // Don't enable feature grouping
-  std::vector<std::pair<std::string, std::string>> cfg
-      {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
-  QuantileHistMock maker(cfg);
-  maker.TestBuildHist();
-  const bool single_precision_histogram = true;
-  QuantileHistMock maker_float(cfg, single_precision_histogram);
-  maker_float.TestBuildHist();
-}
+// TEST(QuantileHist, BuildHist) {
+//   // Don't enable feature grouping
+//   std::vector<std::pair<std::string, std::string>> cfg
+//       {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
+//   QuantileHistMock maker(cfg);
+//   maker.TestBuildHist();
+//   const bool single_precision_histogram = true;
+//   QuantileHistMock maker_float(cfg, single_precision_histogram);
+//   maker_float.TestBuildHist();
+// }
 
 TEST(QuantileHist, ApplySplit) {
   std::vector<std::pair<std::string, std::string>> cfg

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -151,43 +151,6 @@ class QuantileHistMock : public QuantileHistMaker {
       omp_set_num_threads(nthreads);
     }
 
-    // void TestBuildHist(int nid,
-    //                    const GHistIndexMatrix& gmat,
-    //                    const DMatrix& fmat,
-    //                    const RegTree& tree) {
-    //   std::vector<GradientPair> gpair =
-    //       { {0.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f}, {0.27f, 0.28f},
-    //         {0.27f, 0.29f}, {0.37f, 0.39f}, {0.47f, 0.49f}, {0.57f, 0.59f} };
-    //   RealImpl::InitData(gmat, fmat, tree, &gpair);
-    //   this->hist_.AddHistRow(nid);
-    //   this->hist_.AllocateAllData();
-    //   this->hist_builder_.template BuildHist<true>(gpair, this->row_set_collection_[nid],
-    //                   gmat, this->hist_[nid]);
-
-    //   // Check if number of histogram bins is correct
-    //   ASSERT_EQ(this->hist_[nid].size(), gmat.cut.Ptrs().back());
-    //   std::vector<GradientPairPrecise> histogram_expected(this->hist_[nid].size());
-
-    //   // Compute the correct histogram (histogram_expected)
-    //   const size_t num_row = fmat.Info().num_row_;
-    //   CHECK_EQ(gpair.size(), num_row);
-    //   for (size_t rid = 0; rid < num_row; ++rid) {
-    //     const size_t ibegin = gmat.row_ptr[rid];
-    //     const size_t iend = gmat.row_ptr[rid + 1];
-    //     for (size_t i = ibegin; i < iend; ++i) {
-    //       const size_t bin_id = gmat.index[i];
-    //       histogram_expected[bin_id] += GradientPairPrecise(gpair[rid]);
-    //     }
-    //   }
-
-    //   // Now validate the computed histogram returned by BuildHist
-    //   for (size_t i = 0; i < this->hist_[nid].size(); ++i) {
-    //     GradientPairPrecise sol = histogram_expected[i];
-    //     ASSERT_NEAR(sol.GetGrad(), this->hist_[nid][i].GetGrad(), kEps);
-    //     ASSERT_NEAR(sol.GetHess(), this->hist_[nid][i].GetHess(), kEps);
-    //   }
-    // }
-
     void TestApplySplit(const RegTree& tree) {
       std::vector<GradientPair> row_gpairs =
           { {1.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f}, {2.27f, 0.28f},
@@ -325,36 +288,6 @@ class QuantileHistMock : public QuantileHistMaker {
     }
   }
 
-  // void TestSyncHistograms() {
-  //   size_t constexpr kMaxBins = 4;
-  //   GHistIndexMatrix gmat(dmat_.get(), kMaxBins);
-
-  //   RegTree tree = RegTree();
-  //   tree.param.UpdateAllowUnknown(cfg_);
-  //   std::vector<GradientPair> gpair =
-  //       { {0.23f, 0.24f}, {0.23f, 0.24f}, {0.23f, 0.24f}, {0.23f, 0.24f},
-  //         {0.27f, 0.29f}, {0.27f, 0.29f}, {0.27f, 0.29f}, {0.27f, 0.29f} };
-  //   if (double_builder_) {
-  //     double_builder_->TestSyncHistograms(gmat, &gpair, dmat_.get(), &tree);
-  //   } else {
-  //     float_builder_->TestSyncHistograms(gmat, &gpair, dmat_.get(), &tree);
-  //   }
-  // }
-
-
-  // void TestBuildHist() {
-  //   RegTree tree = RegTree();
-  //   tree.param.UpdateAllowUnknown(cfg_);
-
-  //   size_t constexpr kMaxBins = 4;
-  //   GHistIndexMatrix gmat(dmat_.get(), kMaxBins);
-  //   if (double_builder_) {
-  //     double_builder_->TestBuildHist(0, gmat, *dmat_, tree);
-  //   } else {
-  //     float_builder_->TestBuildHist(0, gmat, *dmat_, tree);
-  //   }
-  // }
-
   void TestApplySplit() {
     RegTree tree = RegTree();
     tree.param.UpdateAllowUnknown(cfg_);
@@ -387,57 +320,6 @@ TEST(QuantileHist, InitDataSampling) {
   QuantileHistMock maker_float(cfg, single_precision_histogram);
   maker_float.TestInitDataSampling();
 }
-
-// TEST(QuantileHist, AddHistRows) {
-//   std::vector<std::pair<std::string, std::string>> cfg
-//       {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
-//   QuantileHistMock maker(cfg);
-//   maker.TestAddHistRows();
-//   const bool single_precision_histogram = true;
-//   QuantileHistMock maker_float(cfg, single_precision_histogram);
-//   maker_float.TestAddHistRows();
-// }
-
-// TEST(QuantileHist, SyncHistograms) {
-//   std::vector<std::pair<std::string, std::string>> cfg
-//       {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
-//   QuantileHistMock maker(cfg);
-//   maker.TestSyncHistograms();
-//   const bool single_precision_histogram = true;
-//   QuantileHistMock maker_float(cfg, single_precision_histogram);
-//   maker_float.TestSyncHistograms();
-// }
-
-// TEST(QuantileHist, DistributedAddHistRows) {
-//   std::vector<std::pair<std::string, std::string>> cfg
-//       {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
-//   QuantileHistMock maker(cfg, false);
-//   maker.TestAddHistRows();
-//   const bool single_precision_histogram = true;
-//   QuantileHistMock maker_float(cfg, single_precision_histogram);
-//   maker_float.TestAddHistRows();
-// }
-
-// TEST(QuantileHist, DistributedSyncHistograms) {
-//   std::vector<std::pair<std::string, std::string>> cfg
-//       {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
-//   QuantileHistMock maker(cfg, false);
-//   maker.TestSyncHistograms();
-//   const bool single_precision_histogram = true;
-//   QuantileHistMock maker_float(cfg, single_precision_histogram);
-//   maker_float.TestSyncHistograms();
-// }
-
-// TEST(QuantileHist, BuildHist) {
-//   // Don't enable feature grouping
-//   std::vector<std::pair<std::string, std::string>> cfg
-//       {{"num_feature", std::to_string(QuantileHistMock::GetNumColumns())}};
-//   QuantileHistMock maker(cfg);
-//   maker.TestBuildHist();
-//   const bool single_precision_histogram = true;
-//   QuantileHistMock maker_float(cfg, single_precision_histogram);
-//   maker_float.TestBuildHist();
-// }
 
 TEST(QuantileHist, ApplySplit) {
   std::vector<std::pair<std::string, std::string>> cfg


### PR DESCRIPTION
- Fixes incorrect tests where distributed methods are not actually tested.
- Extract histogram builder to be a reusable module.


## Perf
|        | Dataset | Train time         | Accuracy           |
|--------|:--------|:-------------------|:-------------------|
| Before | HIGGS   | 191.195842235989   | 0.7342790909090909 |
|        | covtype | 74.0480548529886   | 0.9398466476769103 |
| After  | HIGGS   | 184.16188054496888 | 0.7342790909090909 |
|        | covtype | 68.06914013501955  | 0.9398466476769103 |
