### PR TITLE
Work around a segfault observed in SparsePage::Push()

### DIFF
--- a/.github/workflows/r_tests.yml
+++ b/.github/workflows/r_tests.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   R_PACKAGES: c('XML', 'igraph', 'data.table', 'ggplot2', 'DiagrammeR', 'Ckmeans.1d.dp', 'vcd', 'testthat', 'lintr', 'knitr', 'rmarkdown', 'e1071', 'cplm', 'devtools', 'float', 'titanic')
+  GITHUB_PAT: ${{ secrets.PUBLIC_REPO_ACCESS_GITHUB_PAT }}
 
 jobs:
   lintr:

--- a/.github/workflows/r_tests.yml
+++ b/.github/workflows/r_tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   R_PACKAGES: c('XML', 'igraph', 'data.table', 'ggplot2', 'DiagrammeR', 'Ckmeans.1d.dp', 'vcd', 'testthat', 'lintr', 'knitr', 'rmarkdown', 'e1071', 'cplm', 'devtools', 'float', 'titanic')
-  GITHUB_PAT: ${{ secrets.PUBLIC_REPO_ACCESS_GITHUB_PAT }}
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   lintr:

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -943,7 +943,7 @@ uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread
   const size_t thread_size = batch_size / nthread;
 
   builder.InitBudget(expected_rows, nthread);
-  std::vector<std::vector<uint64_t>> max_columns_vector(nthread);
+  std::vector<std::vector<uint64_t>> max_columns_vector(nthread, std::vector<uint64_t>{0});
   dmlc::OMPException exec;
   std::atomic<bool> valid{true};
   // First-pass over the batch counting valid elements
@@ -953,7 +953,6 @@ uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread
       int tid = omp_get_thread_num();
       size_t begin = tid*thread_size;
       size_t end = tid != (nthread-1) ? (tid+1)*thread_size : batch_size;
-      max_columns_vector[tid].resize(1, 0);
       uint64_t& max_columns_local = max_columns_vector[tid][0];
 
       for (size_t i = begin; i < end; ++i) {

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -943,15 +943,18 @@ uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread
   const size_t thread_size = batch_size / nthread;
 
   builder.InitBudget(expected_rows, nthread);
+  std::vector<std::vector<uint64_t>> max_columns_vector(nthread);
   dmlc::OMPException exec;
   std::atomic<bool> valid{true};
   // First-pass over the batch counting valid elements
-#pragma omp parallel num_threads(nthread) reduction(max : max_columns)
+#pragma omp parallel num_threads(nthread)
   {
     exec.Run([&]() {
       int tid = omp_get_thread_num();
       size_t begin = tid*thread_size;
       size_t end = tid != (nthread-1) ? (tid+1)*thread_size : batch_size;
+      max_columns_vector[tid].resize(1, 0);
+      uint64_t& max_columns_local = max_columns_vector[tid][0];
 
       for (size_t i = begin; i < end; ++i) {
         auto line = batch.GetLine(i);
@@ -962,8 +965,8 @@ uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread
           }
           const size_t key = element.row_idx - base_rowid;
           CHECK_GE(key,  builder_base_row_offset);
-          max_columns =
-              std::max(max_columns, static_cast<uint64_t>(element.column_idx + 1));
+          max_columns_local =
+              std::max(max_columns_local, static_cast<uint64_t>(element.column_idx + 1));
 
           if (!common::CheckNAN(element.value) && element.value != missing) {
             // Adapter row index is absolute, here we want it relative to
@@ -976,6 +979,9 @@ uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread
   }
   exec.Rethrow();
   CHECK(valid) << "Input data contains `inf` or `nan`";
+  for (const auto & max : max_columns_vector) {
+    max_columns = std::max(max_columns, max[0]);
+  }
 
   builder.InitStorage();
 


### PR DESCRIPTION
Work around #7156, by removing `resize()` of the thread-local vector inside the OpenMP block.