### PR TITLE
Initial support for external memory in gradient index.

### DIFF
--- a/amalgamation/xgboost-all0.cc
+++ b/amalgamation/xgboost-all0.cc
@@ -38,6 +38,8 @@
 #include "../src/data/sparse_page_raw_format.cc"
 #include "../src/data/ellpack_page.cc"
 #include "../src/data/gradient_index.cc"
+#include "../src/data/gradient_index_page_source.cc"
+#include "../src/data/gradient_index_format.cc"
 #include "../src/data/sparse_page_dmatrix.cc"
 #include "../src/data/proxy_dmatrix.cc"
 

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -214,9 +214,14 @@ struct BatchParam {
   int gpu_id;
   /*! \brief Maximum number of bins per feature for histograms. */
   int max_bin{0};
+  /*! \brief Gradient pairs, used for sketching with future approx implementation. */
+  common::Span<GradientPair> gpair;
+
   BatchParam() = default;
   BatchParam(int32_t device, int32_t max_bin)
       : gpu_id{device}, max_bin{max_bin} {}
+  BatchParam(int32_t device, int32_t max_bin, common::Span<GradientPair> gpair)
+      : gpu_id{device}, max_bin{max_bin}, gpair{gpair} {}
 
   bool operator!=(const BatchParam& other) const {
     return gpu_id != other.gpu_id || max_bin != other.max_bin;

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2015 by Contributors
+ * Copyright (c) 2015-2021 by Contributors
  * \file data.h
  * \brief The input data structure of xgboost.
  * \author Tianqi Chen
@@ -216,6 +216,8 @@ struct BatchParam {
   int max_bin{0};
   /*! \brief Hessian, used for sketching with future approx implementation. */
   common::Span<float> hess;
+  /*! \brief Whether should DMatrix regenerate the batch.  Only used for GHistIndex. */
+  bool regen {false};
 
   BatchParam() = default;
   BatchParam(int32_t device, int32_t max_bin)
@@ -224,11 +226,12 @@ struct BatchParam {
    * \brief Get batch with sketch weighted by hessian.  The batch will be regenerated if
    *        the span is changed, so caller should keep the span for each iteration.
    */
-  BatchParam(int32_t device, int32_t max_bin, common::Span<float> hessian)
-      : gpu_id{device}, max_bin{max_bin}, hess{hessian} {}
+  BatchParam(int32_t device, int32_t max_bin, common::Span<float> hessian,
+             bool regenerate = false)
+      : gpu_id{device}, max_bin{max_bin}, hess{hessian}, regen{regenerate} {}
 
   bool operator!=(const BatchParam& other) const {
-    return gpu_id != other.gpu_id || max_bin != other.max_bin;
+    return gpu_id != other.gpu_id || max_bin != other.max_bin || hess != other.hess;
   }
 };
 

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -231,6 +231,9 @@ struct BatchParam {
       : gpu_id{device}, max_bin{max_bin}, hess{hessian}, regen{regenerate} {}
 
   bool operator!=(const BatchParam& other) const {
+    if (hess.empty() && other.hess.empty()) {
+      return gpu_id != other.gpu_id || max_bin != other.max_bin;
+    }
     return gpu_id != other.gpu_id || max_bin != other.max_bin || hess != other.hess;
   }
 };

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -234,7 +234,7 @@ struct BatchParam {
     if (hess.empty() && other.hess.empty()) {
       return gpu_id != other.gpu_id || max_bin != other.max_bin;
     }
-    return gpu_id != other.gpu_id || max_bin != other.max_bin || hess != other.hess;
+    return gpu_id != other.gpu_id || max_bin != other.max_bin || hess.data() != other.hess.data();
   }
 };
 

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -214,14 +214,18 @@ struct BatchParam {
   int gpu_id;
   /*! \brief Maximum number of bins per feature for histograms. */
   int max_bin{0};
-  /*! \brief Gradient pairs, used for sketching with future approx implementation. */
-  common::Span<GradientPair> gpair;
+  /*! \brief Hessian, used for sketching with future approx implementation. */
+  common::Span<float> hess;
 
   BatchParam() = default;
   BatchParam(int32_t device, int32_t max_bin)
       : gpu_id{device}, max_bin{max_bin} {}
-  BatchParam(int32_t device, int32_t max_bin, common::Span<GradientPair> gpair)
-      : gpu_id{device}, max_bin{max_bin}, gpair{gpair} {}
+  /**
+   * \brief Get batch with sketch weighted by hessian.  The batch will be regenerated if
+   *        the span is changed, so caller should keep the span for each iteration.
+   */
+  BatchParam(int32_t device, int32_t max_bin, common::Span<float> hessian)
+      : gpu_id{device}, max_bin{max_bin}, hess{hessian} {}
 
   bool operator!=(const BatchParam& other) const {
     return gpu_id != other.gpu_id || max_bin != other.max_bin;

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -111,7 +111,7 @@ class HistogramCuts {
 };
 
 inline HistogramCuts SketchOnDMatrix(DMatrix *m, int32_t max_bins,
-                                     std::vector<float> const &hessian = {}) {
+                                     Span<float> const hessian = {}) {
   HistogramCuts out;
   auto const& info = m->Info();
   const auto threads = omp_get_max_threads();

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -136,7 +136,7 @@ inline HistogramCuts SketchOnDMatrix(DMatrix *m, int32_t max_bins,
   return out;
 }
 
-enum BinTypeSize {
+enum BinTypeSize : uint32_t {
   kUint8BinsTypeSize  = 1,
   kUint16BinsTypeSize = 2,
   kUint32BinsTypeSize = 4

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -207,6 +207,13 @@ struct Index {
     return data_.end();
   }
 
+  std::vector<uint8_t>::iterator begin() {  // NOLINT
+    return data_.begin();
+  }
+  std::vector<uint8_t>::iterator end() {  // NOLINT
+    return data_.end();
+  }
+
  private:
   static uint32_t GetValueFromUint8(void *t, size_t i) {
     return reinterpret_cast<uint8_t*>(t)[i];

--- a/src/common/quantile.cc
+++ b/src/common/quantile.cc
@@ -111,9 +111,8 @@ std::vector<float> MergeWeights(MetaInfo const &info,
       }
     }
   } else {
-    auto const &sample_weights = info.weights_.HostVector();
     ParallelFor(hessian.size(), n_threads, Sched::Auto(),
-                [&](auto i) { results[i] = hessian[i] * sample_weights[i]; });
+                [&](auto i) { results[i] = hessian[i] * info.GetWeight(i); });
   }
   return results;
 }

--- a/src/common/quantile.cc
+++ b/src/common/quantile.cc
@@ -94,7 +94,7 @@ std::vector<bst_feature_t> HostSketchContainer::LoadBalance(
 namespace {
 // Function to merge hessian and sample weights
 std::vector<float> MergeWeights(MetaInfo const &info,
-                                std::vector<float> const &hessian,
+                                Span<float> const hessian,
                                 bool use_group, int32_t n_threads) {
   CHECK_EQ(hessian.size(), info.num_row_);
   std::vector<float> results(hessian.size());
@@ -141,7 +141,7 @@ std::vector<float> UnrollGroupWeights(MetaInfo const &info) {
 }  // anonymous namespace
 
 void HostSketchContainer::PushRowPage(
-    SparsePage const &page, MetaInfo const &info, std::vector<float> const &hessian) {
+    SparsePage const &page, MetaInfo const &info, Span<float> hessian) {
   monitor_.Start(__func__);
   bst_feature_t n_columns = info.num_col_;
   auto is_dense = info.num_nonzero_ == info.num_col_ * info.num_row_;

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -760,7 +760,7 @@ class HostSketchContainer {
 
   /* \brief Push a CSR matrix. */
   void PushRowPage(SparsePage const &page, MetaInfo const &info,
-                   std::vector<float> const &hessian = {});
+                   Span<float> const hessian = {});
 
   void MakeCuts(HistogramCuts* cuts);
 };

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -1090,5 +1090,6 @@ namespace data {
 
 // List of files that will be force linked in static links.
 DMLC_REGISTRY_LINK_TAG(sparse_page_raw_format);
+DMLC_REGISTRY_LINK_TAG(gradient_index_format);
 }  // namespace data
 }  // namespace xgboost

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -32,6 +32,7 @@ DMLC_REGISTRY_ENABLE(::xgboost::data::SparsePageFormatReg<::xgboost::SparsePage>
 DMLC_REGISTRY_ENABLE(::xgboost::data::SparsePageFormatReg<::xgboost::CSCPage>);
 DMLC_REGISTRY_ENABLE(::xgboost::data::SparsePageFormatReg<::xgboost::SortedCSCPage>);
 DMLC_REGISTRY_ENABLE(::xgboost::data::SparsePageFormatReg<::xgboost::EllpackPage>);
+DMLC_REGISTRY_ENABLE(::xgboost::data::SparsePageFormatReg<::xgboost::GHistIndexMatrix>);
 }  // namespace dmlc
 
 namespace {

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -32,7 +32,7 @@ class EllpackPageSource : public PageSourceIncMixIn<EllpackPage> {
       size_t row_stride, common::Span<FeatureType const> feature_types,
       std::shared_ptr<SparsePageSource> source)
       : PageSourceIncMixIn(missing, nthreads, n_features, n_batches, cache),
-        is_dense_{is_dense}, row_stride_{row_stride}, param_{param},
+        is_dense_{is_dense}, row_stride_{row_stride}, param_{std::move(param)},
         feature_types_{feature_types}, cuts_{std::move(cuts)} {
     this->source_ = source;
     this->Fetch();

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -147,8 +147,129 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins) {
   }
 }
 
-void GHistIndexMatrix::Init(SparsePage const& batch, common::HistogramCuts const& cuts) {
+void GHistIndexMatrix::Init(SparsePage const &batch,
+                            common::HistogramCuts const &cuts, bool isDense, int32_t n_threads) {
+  base_rowid = batch.base_rowid;
+  isDense_ = isDense;
 
+  // The number of threads is pegged to the batch size. If the OMP
+  // block is parallelized on anything other than the batch/block size,
+  // it should be reassigned
+  const size_t batch_threads =
+      std::max(size_t(1), std::min(batch.Size(),
+                                   static_cast<size_t>(omp_get_max_threads())));
+  auto page = batch.GetView();
+  common::MemStackAllocator<size_t, 128> partial_sums(batch_threads);
+  size_t *p_part = partial_sums.Get();
+  row_ptr.resize(page.Size() + 1, 0);
+
+  size_t block_size = batch.Size() / batch_threads;
+  const uint32_t nbins = cut.Ptrs().back();
+  size_t rbegin = 0;
+  size_t prev_sum = 0;
+
+  dmlc::OMPException exc;
+#pragma omp parallel num_threads(batch_threads)
+  {
+#pragma omp for
+    for (omp_ulong tid = 0; tid < batch_threads; ++tid) {
+      exc.Run([&]() {
+        size_t ibegin = block_size * tid;
+        size_t iend = (tid == (batch_threads - 1) ? batch.Size()
+                                                  : (block_size * (tid + 1)));
+
+        size_t sum = 0;
+        for (size_t i = ibegin; i < iend; ++i) {
+          sum += page[i].size();
+          row_ptr[rbegin + 1 + i] = sum;
+        }
+      });
+    }
+
+#pragma omp single
+    {
+      exc.Run([&]() {
+        p_part[0] = prev_sum;
+        for (size_t i = 1; i < batch_threads; ++i) {
+          p_part[i] = p_part[i - 1] + row_ptr[rbegin + i * block_size];
+        }
+      });
+    }
+
+#pragma omp for
+    for (omp_ulong tid = 0; tid < batch_threads; ++tid) {
+      exc.Run([&]() {
+        size_t ibegin = block_size * tid;
+        size_t iend = (tid == (batch_threads - 1) ? batch.Size()
+                                                  : (block_size * (tid + 1)));
+
+        for (size_t i = ibegin; i < iend; ++i) {
+          row_ptr[rbegin + 1 + i] += p_part[tid];
+        }
+      });
+    }
+  }
+  exc.Rethrow();
+
+  const size_t n_offsets = cut.Ptrs().size() - 1;
+  const size_t n_index = row_ptr[rbegin + batch.Size()];
+  ResizeIndex(n_index, isDense);
+
+  CHECK_GT(cut.Values().size(), 0U);
+
+  uint32_t *offsets = nullptr;
+  if (isDense) {
+    index.ResizeOffset(n_offsets);
+    offsets = index.Offset();
+    for (size_t i = 0; i < n_offsets; ++i) {
+      offsets[i] = cut.Ptrs()[i];
+    }
+  }
+
+  if (isDense) {
+    common::BinTypeSize curent_bin_size = index.GetBinTypeSize();
+    if (curent_bin_size == common::kUint8BinsTypeSize) {
+      common::Span<uint8_t> index_data_span = {index.data<uint8_t>(), n_index};
+      SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
+                   [offsets](auto idx, auto j) {
+                     return static_cast<uint8_t>(idx - offsets[j]);
+                   });
+
+    } else if (curent_bin_size == common::kUint16BinsTypeSize) {
+      common::Span<uint16_t> index_data_span = {index.data<uint16_t>(),
+                                                n_index};
+      SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
+                   [offsets](auto idx, auto j) {
+                     return static_cast<uint16_t>(idx - offsets[j]);
+                   });
+    } else {
+      CHECK_EQ(curent_bin_size, common::kUint32BinsTypeSize);
+      common::Span<uint32_t> index_data_span = {index.data<uint32_t>(),
+                                                n_index};
+      SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
+                   [offsets](auto idx, auto j) {
+                     return static_cast<uint32_t>(idx - offsets[j]);
+                   });
+    }
+
+    /* For sparse DMatrix we have to store index of feature for each bin
+       in index field to chose right offset. So offset is nullptr and index is
+       not reduced */
+  } else {
+    common::Span<uint32_t> index_data_span = {index.data<uint32_t>(), n_index};
+    SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
+                 [](auto idx, auto) { return idx; });
+  }
+
+  common::ParallelFor(bst_omp_uint(nbins), n_threads, [&](bst_omp_uint idx) {
+    for (int32_t tid = 0; tid < n_threads; ++tid) {
+      hit_count[idx] += hit_count_tloc_[tid * nbins + idx];
+      hit_count_tloc_[tid * nbins + idx] = 0; // reset for next batch
+    }
+  });
+
+  prev_sum = row_ptr[rbegin + batch.Size()];
+  rbegin += batch.Size();
 }
 
 void GHistIndexMatrix::ResizeIndex(const size_t n_index,

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -8,169 +8,21 @@
 #include "../common/hist_util.h"
 
 namespace xgboost {
-void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins) {
-  cut = common::SketchOnDMatrix(p_fmat, max_bins);
 
-  max_num_bins = max_bins;
-  const int32_t nthread = omp_get_max_threads();
-  const uint32_t nbins = cut.Ptrs().back();
-  hit_count.resize(nbins, 0);
-  hit_count_tloc_.resize(nthread * nbins, 0);
-
-  this->p_fmat = p_fmat;
-  size_t new_size = 1;
-  for (const auto &batch : p_fmat->GetBatches<SparsePage>()) {
-    new_size += batch.Size();
-  }
-
-  row_ptr.resize(new_size);
-  row_ptr[0] = 0;
-
-  size_t rbegin = 0;
-  size_t prev_sum = 0;
-  const bool isDense = p_fmat->IsDense();
-  this->isDense_ = isDense;
-
-  for (const auto &batch : p_fmat->GetBatches<SparsePage>()) {
-    // The number of threads is pegged to the batch size. If the OMP
-    // block is parallelized on anything other than the batch/block size,
-    // it should be reassigned
-    const size_t batch_threads = std::max(
-        size_t(1),
-        std::min(batch.Size(), static_cast<size_t>(omp_get_max_threads())));
-    auto page = batch.GetView();
-    common::MemStackAllocator<size_t, 128> partial_sums(batch_threads);
-    size_t* p_part = partial_sums.Get();
-
-    size_t block_size =  batch.Size() / batch_threads;
-
-    dmlc::OMPException exc;
-    #pragma omp parallel num_threads(batch_threads)
-    {
-      #pragma omp for
-      for (omp_ulong tid = 0; tid < batch_threads; ++tid) {
-        exc.Run([&]() {
-          size_t ibegin = block_size * tid;
-          size_t iend = (tid == (batch_threads-1) ? batch.Size() : (block_size * (tid+1)));
-
-          size_t sum = 0;
-          for (size_t i = ibegin; i < iend; ++i) {
-            sum += page[i].size();
-            row_ptr[rbegin + 1 + i] = sum;
-          }
-        });
-      }
-
-      #pragma omp single
-      {
-        exc.Run([&]() {
-          p_part[0] = prev_sum;
-          for (size_t i = 1; i < batch_threads; ++i) {
-            p_part[i] = p_part[i - 1] + row_ptr[rbegin + i*block_size];
-          }
-        });
-      }
-
-      #pragma omp for
-      for (omp_ulong tid = 0; tid < batch_threads; ++tid) {
-        exc.Run([&]() {
-          size_t ibegin = block_size * tid;
-          size_t iend = (tid == (batch_threads-1) ? batch.Size() : (block_size * (tid+1)));
-
-          for (size_t i = ibegin; i < iend; ++i) {
-            row_ptr[rbegin + 1 + i] += p_part[tid];
-          }
-        });
-      }
-    }
-    exc.Rethrow();
-
-    const size_t n_offsets = cut.Ptrs().size() - 1;
-    const size_t n_index = row_ptr[rbegin + batch.Size()];
-    ResizeIndex(n_index, isDense);
-
-    CHECK_GT(cut.Values().size(), 0U);
-
-    uint32_t* offsets = nullptr;
-    if (isDense) {
-      index.ResizeOffset(n_offsets);
-      offsets = index.Offset();
-      for (size_t i = 0; i < n_offsets; ++i) {
-        offsets[i] = cut.Ptrs()[i];
-      }
-    }
-
-    if (isDense) {
-      common::BinTypeSize curent_bin_size = index.GetBinTypeSize();
-      if (curent_bin_size == common::kUint8BinsTypeSize) {
-        common::Span<uint8_t> index_data_span = {index.data<uint8_t>(),
-                                                 n_index};
-        SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
-                     [offsets](auto idx, auto j) {
-                       return static_cast<uint8_t>(idx - offsets[j]);
-                     });
-
-      } else if (curent_bin_size == common::kUint16BinsTypeSize) {
-        common::Span<uint16_t> index_data_span = {index.data<uint16_t>(),
-                                                  n_index};
-        SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
-                     [offsets](auto idx, auto j) {
-                       return static_cast<uint16_t>(idx - offsets[j]);
-                     });
-      } else {
-        CHECK_EQ(curent_bin_size, common::kUint32BinsTypeSize);
-        common::Span<uint32_t> index_data_span = {index.data<uint32_t>(),
-                                                  n_index};
-        SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
-                     [offsets](auto idx, auto j) {
-                       return static_cast<uint32_t>(idx - offsets[j]);
-                     });
-      }
-
-    /* For sparse DMatrix we have to store index of feature for each bin
-       in index field to chose right offset. So offset is nullptr and index is not reduced */
-    } else {
-      common::Span<uint32_t> index_data_span = {index.data<uint32_t>(), n_index};
-      SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
-                   [](auto idx, auto) { return idx; });
-    }
-
-    common::ParallelFor(bst_omp_uint(nbins), nthread, [&](bst_omp_uint idx) {
-      for (int32_t tid = 0; tid < nthread; ++tid) {
-        hit_count[idx] += hit_count_tloc_[tid * nbins + idx];
-        hit_count_tloc_[tid * nbins + idx] = 0;  // reset for next batch
-      }
-    });
-
-    prev_sum = row_ptr[rbegin + batch.Size()];
-    rbegin += batch.Size();
-  }
-}
-
-void GHistIndexMatrix::Init(SparsePage const &batch,
-                            common::HistogramCuts const &cuts, bool isDense, int32_t n_threads) {
-  CHECK_GE(n_threads, 1);
-  base_rowid = batch.base_rowid;
-  isDense_ = isDense;
-  cut = cuts;
-
+void GHistIndexMatrix::PushBatch(SparsePage const &batch, size_t rbegin,
+                                 size_t prev_sum, uint32_t nbins,
+                                 int32_t n_threads) {
   // The number of threads is pegged to the batch size. If the OMP
   // block is parallelized on anything other than the batch/block size,
   // it should be reassigned
-  const size_t batch_threads = std::max(
-      size_t(1), std::min(batch.Size(), static_cast<size_t>(n_threads)));
+  const size_t batch_threads =
+      std::max(size_t(1), std::min(batch.Size(),
+                                   static_cast<size_t>(n_threads)));
   auto page = batch.GetView();
   common::MemStackAllocator<size_t, 128> partial_sums(batch_threads);
   size_t *p_part = partial_sums.Get();
-  row_ptr.resize(page.Size() + 1, 0);
 
   size_t block_size = batch.Size() / batch_threads;
-  const uint32_t nbins = cut.Ptrs().back();
-  hit_count.resize(nbins, 0);
-  hit_count_tloc_.resize(n_threads * nbins, 0);
-
-  size_t rbegin = 0;
-  size_t prev_sum = 0;
 
   dmlc::OMPException exc;
 #pragma omp parallel num_threads(batch_threads)
@@ -217,12 +69,12 @@ void GHistIndexMatrix::Init(SparsePage const &batch,
 
   const size_t n_offsets = cut.Ptrs().size() - 1;
   const size_t n_index = row_ptr[rbegin + batch.Size()];
-  ResizeIndex(n_index, isDense);
+  ResizeIndex(n_index, isDense_);
 
   CHECK_GT(cut.Values().size(), 0U);
 
   uint32_t *offsets = nullptr;
-  if (isDense) {
+  if (isDense_) {
     index.ResizeOffset(n_offsets);
     offsets = index.Offset();
     for (size_t i = 0; i < n_offsets; ++i) {
@@ -230,7 +82,7 @@ void GHistIndexMatrix::Init(SparsePage const &batch,
     }
   }
 
-  if (isDense) {
+  if (isDense_) {
     common::BinTypeSize curent_bin_size = index.GetBinTypeSize();
     if (curent_bin_size == common::kUint8BinsTypeSize) {
       common::Span<uint8_t> index_data_span = {index.data<uint8_t>(), n_index};
@@ -271,9 +123,58 @@ void GHistIndexMatrix::Init(SparsePage const &batch,
       hit_count_tloc_[tid * nbins + idx] = 0; // reset for next batch
     }
   });
+}
 
-  prev_sum = row_ptr[rbegin + batch.Size()];
-  rbegin += batch.Size();
+void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins) {
+  cut = common::SketchOnDMatrix(p_fmat, max_bins);
+
+  max_num_bins = max_bins;
+  const int32_t nthread = omp_get_max_threads();
+  const uint32_t nbins = cut.Ptrs().back();
+  hit_count.resize(nbins, 0);
+  hit_count_tloc_.resize(nthread * nbins, 0);
+
+  this->p_fmat = p_fmat;
+  size_t new_size = 1;
+  for (const auto &batch : p_fmat->GetBatches<SparsePage>()) {
+    new_size += batch.Size();
+  }
+
+  row_ptr.resize(new_size);
+  row_ptr[0] = 0;
+
+  size_t rbegin = 0;
+  size_t prev_sum = 0;
+  const bool isDense = p_fmat->IsDense();
+  this->isDense_ = isDense;
+
+  for (const auto &batch : p_fmat->GetBatches<SparsePage>()) {
+    this->PushBatch(batch, rbegin, prev_sum, nbins, nthread);
+    prev_sum = row_ptr[rbegin + batch.Size()];
+    rbegin += batch.Size();
+  }
+}
+
+void GHistIndexMatrix::Init(SparsePage const &batch,
+                            common::HistogramCuts const &cuts, bool isDense,
+                            int32_t n_threads) {
+  CHECK_GE(n_threads, 1);
+  base_rowid = batch.base_rowid;
+  isDense_ = isDense;
+  cut = cuts;
+
+  // The number of threads is pegged to the batch size. If the OMP
+  // block is parallelized on anything other than the batch/block size,
+  // it should be reassigned
+  row_ptr.resize(batch.Size() + 1, 0);
+  const uint32_t nbins = cut.Ptrs().back();
+  hit_count.resize(nbins, 0);
+  hit_count_tloc_.resize(n_threads * nbins, 0);
+
+  size_t rbegin = 0;
+  size_t prev_sum = 0;
+
+  this->PushBatch(batch, rbegin, prev_sum, nbins, n_threads);
 }
 
 void GHistIndexMatrix::ResizeIndex(const size_t n_index,

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -147,6 +147,9 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins) {
   }
 }
 
+void GHistIndexMatrix::Init(SparsePage const& batch, common::HistogramCuts const& cuts) {
+
+}
 
 void GHistIndexMatrix::ResizeIndex(const size_t n_index,
                                    const bool isDense) {

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -120,7 +120,7 @@ void GHistIndexMatrix::PushBatch(SparsePage const &batch, size_t rbegin,
   common::ParallelFor(bst_omp_uint(nbins), n_threads, [&](bst_omp_uint idx) {
     for (int32_t tid = 0; tid < n_threads; ++tid) {
       hit_count[idx] += hit_count_tloc_[tid * nbins + idx];
-      hit_count_tloc_[tid * nbins + idx] = 0; // reset for next batch
+      hit_count_tloc_[tid * nbins + idx] = 0;  // reset for next batch
     }
   });
 }
@@ -156,13 +156,15 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins, common::Span<float> h
 }
 
 void GHistIndexMatrix::Init(SparsePage const &batch,
-                            common::HistogramCuts const &cuts, bool isDense,
+                            common::HistogramCuts const &cuts,
+                            int32_t max_bins_per_feat, bool isDense,
                             int32_t n_threads) {
   CHECK_GE(n_threads, 1);
   base_rowid = batch.base_rowid;
   isDense_ = isDense;
   cut = cuts;
-
+  max_num_bins = max_bins_per_feat;
+  CHECK_EQ(row_ptr.size(), 0);
   // The number of threads is pegged to the batch size. If the OMP
   // block is parallelized on anything other than the batch/block size,
   // it should be reassigned

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -125,8 +125,8 @@ void GHistIndexMatrix::PushBatch(SparsePage const &batch, size_t rbegin,
   });
 }
 
-void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins) {
-  cut = common::SketchOnDMatrix(p_fmat, max_bins);
+void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins, common::Span<float> hess) {
+  cut = common::SketchOnDMatrix(p_fmat, max_bins, hess);
 
   max_num_bins = max_bins;
   const int32_t nthread = omp_get_max_threads();

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -37,6 +37,7 @@ class GHistIndexMatrix {
   }
   // Create a global histogram matrix, given cut
   void Init(DMatrix* p_fmat, int max_num_bins);
+  void Init(SparsePage const& page, common::HistogramCuts const& cuts);
 
   // specific method for sparse data as no possibility to reduce allocated memory
   template <typename BinIdxType, typename GetOffset>

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -35,11 +35,11 @@ class GHistIndexMatrix {
   size_t base_rowid{0};
 
   GHistIndexMatrix() = default;
-  GHistIndexMatrix(DMatrix* x, int32_t max_bin) {
-    this->Init(x, max_bin);
+  GHistIndexMatrix(DMatrix* x, int32_t max_bin, common::Span<float> hess = {}) {
+    this->Init(x, max_bin, hess);
   }
   // Create a global histogram matrix, given cut
-  void Init(DMatrix* p_fmat, int max_num_bins);
+  void Init(DMatrix* p_fmat, int max_num_bins, common::Span<float> hess);
   void Init(SparsePage const &page, common::HistogramCuts const &cuts,
             bool is_dense, int32_t n_threads);
 

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -37,7 +37,7 @@ class GHistIndexMatrix {
   }
   // Create a global histogram matrix, given cut
   void Init(DMatrix* p_fmat, int max_num_bins);
-  void Init(SparsePage const& page, common::HistogramCuts const& cuts);
+  void Init(SparsePage const& page, common::HistogramCuts const& cuts, bool is_dense, int32_t n_threads);
 
   // specific method for sparse data as no possibility to reduce allocated memory
   template <typename BinIdxType, typename GetOffset>

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -41,7 +41,7 @@ class GHistIndexMatrix {
   // Create a global histogram matrix, given cut
   void Init(DMatrix* p_fmat, int max_num_bins, common::Span<float> hess);
   void Init(SparsePage const &page, common::HistogramCuts const &cuts,
-            bool is_dense, int32_t n_threads);
+            int32_t max_bins_per_feat, bool is_dense, int32_t n_threads);
 
   // specific method for sparse data as no possibility to reduce allocated memory
   template <typename BinIdxType, typename GetOffset>
@@ -83,6 +83,11 @@ class GHistIndexMatrix {
   }
   inline bool IsDense() const {
     return isDense_;
+  }
+  void SetDense(bool is_dense) { isDense_ = is_dense; }
+
+  bst_row_t Size() const {
+    return row_ptr.empty() ? 0 : row_ptr.size() - 1;
   }
 
  private:

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -29,7 +29,9 @@ class GHistIndexMatrix {
   common::HistogramCuts cut;
   DMatrix* p_fmat;
   size_t max_num_bins;
+  size_t base_rowid{0};
 
+  GHistIndexMatrix() = default;
   GHistIndexMatrix(DMatrix* x, int32_t max_bin) {
     this->Init(x, max_bin);
   }

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -55,15 +55,15 @@ class GHistIndexMatrix {
     BinIdxType* index_data = index_data_span.data();
     common::ParallelFor(omp_ulong(batch_size), batch_threads, [&](omp_ulong i) {
       const int tid = omp_get_thread_num();
-      size_t ibegin = row_ptr.at(rbegin + i);
-      size_t iend = row_ptr.at(rbegin + i + 1);
-      const size_t size = offset_vec.at(i + 1) - offset_vec[i];
+      size_t ibegin = row_ptr[rbegin + i];
+      size_t iend = row_ptr[rbegin + i + 1];
+      const size_t size = offset_vec[i + 1] - offset_vec[i];
       SparsePage::Inst inst = {data_ptr + offset_vec[i], size};
       CHECK_EQ(ibegin + inst.size(), iend);
       for (bst_uint j = 0; j < inst.size(); ++j) {
         uint32_t idx = cut.SearchBin(inst[j]);
         index_data[ibegin + j] = get_offset(idx, j);
-        ++hit_count_tloc_.at(tid * nbins + idx);
+        ++hit_count_tloc_[tid * nbins + idx];
       }
     });
   }

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -18,6 +18,9 @@ namespace xgboost {
  *  index for CPU histogram.  On GPU ellpack page is used.
  */
 class GHistIndexMatrix {
+  void PushBatch(SparsePage const &batch, size_t rbegin, size_t prev_sum,
+                 uint32_t nbins, int32_t n_threads);
+
  public:
   /*! \brief row pointer to rows by element position */
   std::vector<size_t> row_ptr;
@@ -38,8 +41,6 @@ class GHistIndexMatrix {
   // Create a global histogram matrix, given cut
   void Init(DMatrix* p_fmat, int max_num_bins);
   void Init(SparsePage const& page, common::HistogramCuts const& cuts, bool is_dense, int32_t n_threads);
-
-  void PushBatch(SparsePage const& batch, size_t rbegin, size_t prev_sum, uint32_t nbins, int32_t n_threads);
 
   // specific method for sparse data as no possibility to reduce allocated memory
   template <typename BinIdxType, typename GetOffset>

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -40,7 +40,8 @@ class GHistIndexMatrix {
   }
   // Create a global histogram matrix, given cut
   void Init(DMatrix* p_fmat, int max_num_bins);
-  void Init(SparsePage const& page, common::HistogramCuts const& cuts, bool is_dense, int32_t n_threads);
+  void Init(SparsePage const &page, common::HistogramCuts const &cuts,
+            bool is_dense, int32_t n_threads);
 
   // specific method for sparse data as no possibility to reduce allocated memory
   template <typename BinIdxType, typename GetOffset>

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -39,6 +39,8 @@ class GHistIndexMatrix {
   void Init(DMatrix* p_fmat, int max_num_bins);
   void Init(SparsePage const& page, common::HistogramCuts const& cuts, bool is_dense, int32_t n_threads);
 
+  void PushBatch(SparsePage const& batch, size_t rbegin, size_t prev_sum, uint32_t nbins, int32_t n_threads);
+
   // specific method for sparse data as no possibility to reduce allocated memory
   template <typename BinIdxType, typename GetOffset>
   void SetIndexData(common::Span<BinIdxType> index_data_span,
@@ -51,15 +53,15 @@ class GHistIndexMatrix {
     BinIdxType* index_data = index_data_span.data();
     common::ParallelFor(omp_ulong(batch_size), batch_threads, [&](omp_ulong i) {
       const int tid = omp_get_thread_num();
-      size_t ibegin = row_ptr[rbegin + i];
-      size_t iend = row_ptr[rbegin + i + 1];
-      const size_t size = offset_vec[i + 1] - offset_vec[i];
+      size_t ibegin = row_ptr.at(rbegin + i);
+      size_t iend = row_ptr.at(rbegin + i + 1);
+      const size_t size = offset_vec.at(i + 1) - offset_vec[i];
       SparsePage::Inst inst = {data_ptr + offset_vec[i], size};
       CHECK_EQ(ibegin + inst.size(), iend);
       for (bst_uint j = 0; j < inst.size(); ++j) {
         uint32_t idx = cut.SearchBin(inst[j]);
         index_data[ibegin + j] = get_offset(idx, j);
-        ++hit_count_tloc_[tid * nbins + idx];
+        ++hit_count_tloc_.at(tid * nbins + idx);
       }
     });
   }

--- a/src/data/gradient_index_format.cc
+++ b/src/data/gradient_index_format.cc
@@ -1,0 +1,84 @@
+#include "sparse_page_writer.h"
+#include "gradient_index.h"
+namespace xgboost {
+namespace data {
+
+class GHistIndexRawFormat : public SparsePageFormat<GHistIndexMatrix> {
+ public:
+  bool Read(GHistIndexMatrix* page, dmlc::SeekStream* fi) override {
+    // indptr
+    fi->Read(&page->row_ptr);
+    // offset
+    using OffsetT = std::iterator_traits<decltype(page->index.Offset())>::value_type;
+    std::vector<OffsetT> offset;
+    if (!fi->Read(&offset)) {
+      return false;
+    }
+    page->index.ResizeOffset(offset.size());
+    std::copy(offset.begin(), offset.end(), page->index.Offset());
+    // data
+    std::vector<uint8_t> data;
+    if (!fi->Read(&data)) {
+      return false;
+    }
+    page->index.Resize(data.size());
+    std::copy(data.cbegin(), data.cend(), page->index.begin());
+    // bin type
+    common::BinTypeSize size_type;
+    if (!fi->Read(&size_type)) {
+      return false;
+    }
+    page->index.SetBinTypeSize(size_type);
+    // hit count
+    if (!fi->Read(&page->hit_count)) {
+      return false;
+    }
+    if (!fi->Read(&page->max_num_bins)) {
+      return false;
+    }
+    if (!fi->Read(&page->base_rowid)) {
+      return false;
+    }
+    return true;
+  }
+
+  size_t Write(GHistIndexMatrix const &page, dmlc::Stream *fo) override {
+    size_t bytes = 0;
+    // indptr
+    fo->Write(page.row_ptr);
+    bytes += page.row_ptr.size() * sizeof(decltype(page.row_ptr)::value_type) +
+             sizeof(uint64_t);
+    // offset
+    using OffsetT = std::iterator_traits<decltype(page.index.Offset())>::value_type;
+    std::vector<OffsetT> offset(page.index.OffsetSize());
+    std::copy(page.index.Offset(),
+              page.index.Offset() + page.index.OffsetSize(), offset.begin());
+    fo->Write(offset);
+    bytes += page.index.OffsetSize() * sizeof(OffsetT) + sizeof(uint64_t);
+    // data
+    std::vector<uint8_t> data(page.index.begin(), page.index.end());
+    fo->Write(data);
+    bytes += data.size() * sizeof(decltype(data)::value_type) + sizeof(uint64_t);
+    // bin type
+    fo->Write(page.index.GetBinTypeSize());
+    bytes += sizeof(page.index.GetBinTypeSize());
+    // hit count
+    fo->Write(page.hit_count);
+    bytes +=
+        page.hit_count.size() * sizeof(decltype(page.hit_count)::value_type) +
+        sizeof(uint64_t);
+    // max_bins, base row
+    fo->Write(page.max_num_bins);
+    bytes += sizeof(page.max_num_bins);
+    fo->Write(page.base_rowid);
+    bytes += sizeof(page.base_rowid);
+    return bytes;
+  }
+};
+
+XGBOOST_REGISTER_GHIST_INDEX_PAGE_FORMAT(raw)
+    .describe("Raw GHistIndex binary data format.")
+    .set_body([]() { return new GHistIndexRawFormat(); });
+
+}  // namespace data
+}  // namespace xgboost

--- a/src/data/gradient_index_format.cc
+++ b/src/data/gradient_index_format.cc
@@ -47,6 +47,11 @@ class GHistIndexRawFormat : public SparsePageFormat<GHistIndexMatrix> {
     if (!fi->Read(&page->base_rowid)) {
       return false;
     }
+    bool is_dense = false;
+    if (!fi->Read(&is_dense)) {
+      return false;
+    }
+    page->SetDense(is_dense);
     return true;
   }
 
@@ -76,11 +81,13 @@ class GHistIndexRawFormat : public SparsePageFormat<GHistIndexMatrix> {
     bytes +=
         page.hit_count.size() * sizeof(decltype(page.hit_count)::value_type) +
         sizeof(uint64_t);
-    // max_bins, base row
+    // max_bins, base row, is_dense
     fo->Write(page.max_num_bins);
     bytes += sizeof(page.max_num_bins);
     fo->Write(page.base_rowid);
     bytes += sizeof(page.base_rowid);
+    fo->Write(page.IsDense());
+    bytes += sizeof(page.IsDense());
     return bytes;
   }
 };

--- a/src/data/gradient_index_format.cc
+++ b/src/data/gradient_index_format.cc
@@ -32,10 +32,13 @@ class GHistIndexRawFormat : public SparsePageFormat<GHistIndexMatrix> {
     page->index.Resize(data.size());
     std::copy(data.cbegin(), data.cend(), page->index.begin());
     // bin type
-    common::BinTypeSize size_type;
-    if (!fi->Read(&size_type)) {
+    // Old gcc doesn't support reading from enum.
+    std::underlying_type_t<common::BinTypeSize> uint_bin_type{0};
+    if (!fi->Read(&uint_bin_type)) {
       return false;
     }
+    common::BinTypeSize size_type =
+        static_cast<common::BinTypeSize>(uint_bin_type);
     page->index.SetBinTypeSize(size_type);
     // hit count
     if (!fi->Read(&page->hit_count)) {
@@ -74,7 +77,9 @@ class GHistIndexRawFormat : public SparsePageFormat<GHistIndexMatrix> {
     fo->Write(data);
     bytes += data.size() * sizeof(decltype(data)::value_type) + sizeof(uint64_t);
     // bin type
-    fo->Write(page.index.GetBinTypeSize());
+    std::underlying_type_t<common::BinTypeSize> uint_bin_type =
+        page.index.GetBinTypeSize();
+    fo->Write(uint_bin_type);
     bytes += sizeof(page.index.GetBinTypeSize());
     // hit count
     fo->Write(page.hit_count);

--- a/src/data/gradient_index_format.cc
+++ b/src/data/gradient_index_format.cc
@@ -97,6 +97,8 @@ class GHistIndexRawFormat : public SparsePageFormat<GHistIndexMatrix> {
   }
 };
 
+DMLC_REGISTRY_FILE_TAG(gradient_index_format);
+
 XGBOOST_REGISTER_GHIST_INDEX_PAGE_FORMAT(raw)
     .describe("Raw GHistIndex binary data format.")
     .set_body([]() { return new GHistIndexRawFormat(); });

--- a/src/data/gradient_index_page_source.cc
+++ b/src/data/gradient_index_page_source.cc
@@ -6,6 +6,7 @@ void GradientIndexPageSource::Fetch() {
   if (!this->ReadCache()) {
     auto const& csr = source_->Page();
     this->page_.reset(new GHistIndexMatrix());
+    CHECK_NE(cuts_.Values().size(), 0);
     this->page_->Init(*csr, cuts_, is_dense_, nthreads_);
     this->WriteCache();
   }

--- a/src/data/gradient_index_page_source.cc
+++ b/src/data/gradient_index_page_source.cc
@@ -1,3 +1,6 @@
+/*!
+ * Copyright 2021 by XGBoost Contributors
+ */
 #include "gradient_index_page_source.h"
 
 namespace xgboost {

--- a/src/data/gradient_index_page_source.cc
+++ b/src/data/gradient_index_page_source.cc
@@ -1,0 +1,15 @@
+#include "gradient_index_page_source.h"
+
+namespace xgboost {
+namespace data {
+void GradientIndexPageSource::Fetch() {
+  if (!this->ReadCache()) {
+    auto const& csr = source_->Page();
+    this->page_.reset(new GHistIndexMatrix());
+    this->page_->Init(*csr, cuts_);
+    this->page_->base_rowid = csr->base_rowid;
+    this->WriteCache();
+  }
+}
+}  // namespace data
+}  // namespace xgboost

--- a/src/data/gradient_index_page_source.cc
+++ b/src/data/gradient_index_page_source.cc
@@ -6,8 +6,7 @@ void GradientIndexPageSource::Fetch() {
   if (!this->ReadCache()) {
     auto const& csr = source_->Page();
     this->page_.reset(new GHistIndexMatrix());
-    this->page_->Init(*csr, cuts_);
-    this->page_->base_rowid = csr->base_rowid;
+    this->page_->Init(*csr, cuts_, is_dense_, nthreads_);
     this->WriteCache();
   }
 }

--- a/src/data/gradient_index_page_source.cc
+++ b/src/data/gradient_index_page_source.cc
@@ -10,7 +10,7 @@ void GradientIndexPageSource::Fetch() {
     auto const& csr = source_->Page();
     this->page_.reset(new GHistIndexMatrix());
     CHECK_NE(cuts_.Values().size(), 0);
-    this->page_->Init(*csr, cuts_, is_dense_, nthreads_);
+    this->page_->Init(*csr, cuts_, max_bin_per_feat_, is_dense_, nthreads_);
     this->WriteCache();
   }
 }

--- a/src/data/gradient_index_page_source.h
+++ b/src/data/gradient_index_page_source.h
@@ -1,9 +1,11 @@
 /*!
  * Copyright 2021 by XGBoost Contributors
  */
-
 #ifndef XGBOOST_DATA_GRADIENT_INDEX_PAGE_SOURCE_H_
 #define XGBOOST_DATA_GRADIENT_INDEX_PAGE_SOURCE_H_
+
+#include <memory>
+#include <utility>
 
 #include "sparse_page_source.h"
 #include "gradient_index.h"

--- a/src/data/gradient_index_page_source.h
+++ b/src/data/gradient_index_page_source.h
@@ -15,15 +15,17 @@ namespace data {
 class GradientIndexPageSource : public PageSourceIncMixIn<GHistIndexMatrix> {
   common::HistogramCuts cuts_;
   bool is_dense_;
+  int32_t max_bin_per_feat_;
 
  public:
-  GradientIndexPageSource(
-      float missing, int nthreads, bst_feature_t n_features, size_t n_batches,
-      std::shared_ptr<Cache> cache, BatchParam param,
-      common::HistogramCuts cuts, bool is_dense,
-      std::shared_ptr<SparsePageSource> source)
+  GradientIndexPageSource(float missing, int nthreads, bst_feature_t n_features,
+                          size_t n_batches, std::shared_ptr<Cache> cache,
+                          BatchParam param, common::HistogramCuts cuts,
+                          bool is_dense, int32_t max_bin_per_feat,
+                          std::shared_ptr<SparsePageSource> source)
       : PageSourceIncMixIn(missing, nthreads, n_features, n_batches, cache),
-        cuts_{std::move(cuts)}, is_dense_{is_dense} {
+        cuts_{std::move(cuts)}, is_dense_{is_dense}, max_bin_per_feat_{
+                                                         max_bin_per_feat} {
     this->source_ = source;
     this->Fetch();
   }

--- a/src/data/gradient_index_page_source.h
+++ b/src/data/gradient_index_page_source.h
@@ -1,0 +1,32 @@
+/*!
+ * Copyright 2021 by XGBoost Contributors
+ */
+
+#ifndef XGBOOST_DATA_GRADIENT_INDEX_PAGE_SOURCE_H_
+#define XGBOOST_DATA_GRADIENT_INDEX_PAGE_SOURCE_H_
+
+#include "sparse_page_source.h"
+#include "gradient_index.h"
+
+namespace xgboost {
+namespace data {
+class GradientIndexPageSource : public PageSourceIncMixIn<GHistIndexMatrix> {
+  common::HistogramCuts cuts_;
+
+ public:
+  GradientIndexPageSource(
+      float missing, int nthreads, bst_feature_t n_features, size_t n_batches,
+      std::shared_ptr<Cache> cache, BatchParam param,
+      common::HistogramCuts cuts, bool is_dense,
+      std::shared_ptr<SparsePageSource> source)
+      : PageSourceIncMixIn(missing, nthreads, n_features, n_batches, cache),
+        cuts_{std::move(cuts)} {
+    this->source_ = source;
+    this->Fetch();
+  }
+
+  void Fetch() final;
+};
+}      // namespace data
+}      // namespace xgboost
+#endif  // XGBOOST_DATA_GRADIENT_INDEX_PAGE_SOURCE_H_

--- a/src/data/gradient_index_page_source.h
+++ b/src/data/gradient_index_page_source.h
@@ -12,6 +12,7 @@ namespace xgboost {
 namespace data {
 class GradientIndexPageSource : public PageSourceIncMixIn<GHistIndexMatrix> {
   common::HistogramCuts cuts_;
+  bool is_dense_;
 
  public:
   GradientIndexPageSource(
@@ -20,7 +21,7 @@ class GradientIndexPageSource : public PageSourceIncMixIn<GHistIndexMatrix> {
       common::HistogramCuts cuts, bool is_dense,
       std::shared_ptr<SparsePageSource> source)
       : PageSourceIncMixIn(missing, nthreads, n_features, n_batches, cache),
-        cuts_{std::move(cuts)} {
+        cuts_{std::move(cuts)}, is_dense_{is_dense} {
     this->source_ = source;
     this->Fetch();
   }

--- a/src/data/histogram_cut_format.h
+++ b/src/data/histogram_cut_format.h
@@ -1,7 +1,11 @@
 /*!
  * Copyright 2021 XGBoost contributors
  */
+#ifndef XGBOOST_DATA_HISTOGRAM_CUT_FORMAT_H_
+#define XGBOOST_DATA_HISTOGRAM_CUT_FORMAT_H_
+
 #include "../common/hist_util.h"
+
 namespace xgboost {
 namespace data {
 inline bool ReadHistogramCuts(common::HistogramCuts *cuts, dmlc::SeekStream *fi) {
@@ -29,3 +33,4 @@ inline size_t WriteHistogramCuts(common::HistogramCuts const &cuts, dmlc::Stream
 }
 }  // namespace data
 }  // namespace xgboost
+#endif  // XGBOOST_DATA_HISTOGRAM_CUT_FORMAT_H_

--- a/src/data/histogram_cut_format.h
+++ b/src/data/histogram_cut_format.h
@@ -1,0 +1,31 @@
+/*!
+ * Copyright 2021 XGBoost contributors
+ */
+#include "../common/hist_util.h"
+namespace xgboost {
+namespace data {
+inline bool ReadHistogramCuts(common::HistogramCuts *cuts, dmlc::SeekStream *fi) {
+  if (!fi->Read(&cuts->cut_values_.HostVector())) {
+    return false;
+  }
+  if (!fi->Read(&cuts->cut_ptrs_.HostVector())) {
+    return false;
+  }
+  if (!fi->Read(&cuts->min_vals_.HostVector())) {
+    return false;
+  }
+  return true;
+}
+
+inline size_t WriteHistogramCuts(common::HistogramCuts const &cuts, dmlc::Stream *fo) {
+  size_t bytes = 0;
+  fo->Write(cuts.cut_values_.ConstHostVector());
+  bytes += cuts.cut_values_.ConstHostSpan().size_bytes() + sizeof(uint64_t);
+  fo->Write(cuts.cut_ptrs_.ConstHostVector());
+  bytes += cuts.cut_ptrs_.ConstHostSpan().size_bytes() + sizeof(uint64_t);
+  fo->Write(cuts.min_vals_.ConstHostVector());
+  bytes += cuts.min_vals_.ConstHostSpan().size_bytes() + sizeof(uint64_t);
+  return bytes;
+}
+}  // namespace data
+}  // namespace xgboost

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -96,7 +96,7 @@ BatchSet<GHistIndexMatrix> SimpleDMatrix::GetGradientIndex(const BatchParam& par
   }
   if (!gradient_index_  || (batch_param_ != param && param != BatchParam{})) {
     CHECK_GE(param.max_bin, 2);
-    gradient_index_.reset(new GHistIndexMatrix(this, param.max_bin));
+    gradient_index_.reset(new GHistIndexMatrix(this, param.max_bin, param.hess));
     batch_param_ = param;
   }
   auto begin_iter = BatchIterator<GHistIndexMatrix>(

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -94,10 +94,12 @@ BatchSet<GHistIndexMatrix> SimpleDMatrix::GetGradientIndex(const BatchParam& par
   if (!(batch_param_ != BatchParam{})) {
     CHECK(param != BatchParam{}) << "Batch parameter is not initialized.";
   }
-  if (!gradient_index_  || (batch_param_ != param && param != BatchParam{})) {
+  if (!gradient_index_  || (batch_param_ != param && param != BatchParam{}) || param.regen) {
     CHECK_GE(param.max_bin, 2);
+    CHECK_EQ(param.gpu_id, -1);
     gradient_index_.reset(new GHistIndexMatrix(this, param.max_bin, param.hess));
     batch_param_ = param;
+    CHECK_EQ(batch_param_.hess.data(), param.hess.data());
   }
   auto begin_iter = BatchIterator<GHistIndexMatrix>(
       new SimpleBatchIteratorImpl<GHistIndexMatrix>(gradient_index_));

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -158,9 +158,6 @@ BatchSet<SortedCSCPage> SparsePageDMatrix::GetSortedColumnBatches() {
 
 BatchSet<GHistIndexMatrix> SparsePageDMatrix::GetGradientIndex(const BatchParam& param) {
   CHECK_GE(param.max_bin, 2);
-  auto id = MakeCache(this, ".gradient_index.page", cache_prefix_, &cache_info_);
-  this->InitializeSparsePage();
-
   if (param.hess.empty()) {
     // hist method doesn't support full external memory implementation, so we concatenate
     // all index here.
@@ -175,6 +172,8 @@ BatchSet<GHistIndexMatrix> SparsePageDMatrix::GetGradientIndex(const BatchParam&
     return BatchSet<GHistIndexMatrix>(begin_iter);
   }
 
+  auto id = MakeCache(this, ".gradient_index.page", cache_prefix_, &cache_info_);
+  this->InitializeSparsePage();
   if (!cache_info_.at(id)->written || (batch_param_ != param && param != BatchParam{})) {
     cache_info_.erase(id);
     MakeCache(this, ".gradient_index.page", cache_prefix_, &cache_info_);

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -168,6 +168,7 @@ BatchSet<GHistIndexMatrix> SparsePageDMatrix::GetGradientIndex(const BatchParam&
 
     batch_param_ = param;
     ghist_index_source_.reset();
+    CHECK_NE(cuts.Values().size(), 0);
     ghist_index_source_.reset(new GradientIndexPageSource(
         this->missing_, this->nthreads_, this->Info().num_col_,
         this->n_batches_, cache_info_.at(id), param, std::move(cuts),

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -162,7 +162,7 @@ BatchSet<GHistIndexMatrix> SparsePageDMatrix::GetGradientIndex(const BatchParam&
   if (param.hess.empty()) {
     // hist method doesn't support full external memory implementation, so we concatenate
     // all index here.
-    if (!ghist_index_source_ || (param != batch_param_ && param != BatchParam{})) {
+    if (!ghist_index_page_ || (param != batch_param_ && param != BatchParam{})) {
       this->InitializeSparsePage();
       ghist_index_page_.reset(new GHistIndexMatrix{this, param.max_bin});
       this->InitializeSparsePage();

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -177,7 +177,7 @@ BatchSet<GHistIndexMatrix> SparsePageDMatrix::GetGradientIndex(const BatchParam&
   if (!cache_info_.at(id)->written || (batch_param_ != param && param != BatchParam{})) {
     cache_info_.erase(id);
     MakeCache(this, ".gradient_index.page", cache_prefix_, &cache_info_);
-    auto cuts = common::SketchOnDMatrix(this, param.max_bin);
+    auto cuts = common::SketchOnDMatrix(this, param.max_bin, param.hess);
     this->InitializeSparsePage();  // reset after use.
 
     batch_param_ = param;

--- a/src/data/sparse_page_dmatrix.cu
+++ b/src/data/sparse_page_dmatrix.cu
@@ -31,7 +31,7 @@ BatchSet<EllpackPage> SparsePageDMatrix::GetEllpackBatches(const BatchParam& par
     auto ft = this->info_.feature_types.ConstDeviceSpan();
     ellpack_page_source_.reset();  // release resources.
     ellpack_page_source_.reset(new EllpackPageSource(
-        this->missing_, this->nthreads_, this->Info().num_col_,
+        this->missing_, this->ctx_.Threads(), this->Info().num_col_,
         this->n_batches_, cache_info_.at(id), param, std::move(cuts),
         this->IsDense(), row_stride, ft, sparse_page_source_));
   } else {

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -8,6 +8,7 @@
 #define XGBOOST_DATA_SPARSE_PAGE_DMATRIX_H_
 
 #include <xgboost/data.h>
+#include <xgboost/logging.h>
 #include <algorithm>
 #include <memory>
 #include <string>
@@ -145,6 +146,7 @@ MakeCache(SparsePageDMatrix *ptr, std::string format, std::string prefix,
   auto it = cache_info.find(id);
   if (it == cache_info.cend()) {
     cache_info[id].reset(new Cache{false, name, format});
+    LOG(INFO) << "Make cache:" << name << std::endl;
   }
   return id;
 }

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -119,6 +119,7 @@ class SparsePageDMatrix : public DMatrix {
   std::shared_ptr<EllpackPageSource> ellpack_page_source_;
   std::shared_ptr<CSCPageSource> column_source_;
   std::shared_ptr<SortedCSCPageSource> sorted_column_source_;
+  std::shared_ptr<GHistIndexMatrix> ghist_index_page_;  // hist
   std::shared_ptr<GradientIndexPageSource> ghist_index_source_;
 
   bool EllpackExists() const override {

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -68,7 +68,7 @@ class SparsePageDMatrix : public DMatrix {
   XGDMatrixCallbackNext *next_;
 
   float missing_;
-  int nthreads_;
+  GenericParameter ctx_;
   std::string cache_prefix_;
   uint32_t n_batches_ {0};
   // sparse page is the source to other page types, we make a special member function.

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -16,6 +16,7 @@
 #include <map>
 
 #include "ellpack_page_source.h"
+#include "gradient_index_page_source.h"
 #include "sparse_page_source.h"
 
 namespace xgboost {
@@ -118,7 +119,7 @@ class SparsePageDMatrix : public DMatrix {
   std::shared_ptr<EllpackPageSource> ellpack_page_source_;
   std::shared_ptr<CSCPageSource> column_source_;
   std::shared_ptr<SortedCSCPageSource> sorted_column_source_;
-  std::shared_ptr<GHistIndexMatrix> ghist_index_source_;
+  std::shared_ptr<GradientIndexPageSource> ghist_index_source_;
 
   bool EllpackExists() const override {
     return static_cast<bool>(ellpack_page_source_);

--- a/src/data/sparse_page_writer.h
+++ b/src/data/sparse_page_writer.h
@@ -98,7 +98,12 @@ struct SparsePageFormatReg
 
 #define EllpackPageFmt SparsePageFormat<EllpackPage>
 #define XGBOOST_REGISTER_ELLPACK_PAGE_FORMAT(Name)                       \
-  DMLC_REGISTRY_REGISTER(SparsePageFormatReg<EllpackPage>, EllpackPageFm, Name)
+  DMLC_REGISTRY_REGISTER(SparsePageFormatReg<EllpackPage>, EllpackPageFmt, Name)
+
+#define GHistIndexPageFmt SparsePageFormat<GHistIndexMatrix>
+#define XGBOOST_REGISTER_GHIST_INDEX_PAGE_FORMAT(Name)                         \
+  DMLC_REGISTRY_REGISTER(SparsePageFormatReg<GHistIndexMatrix>,                \
+                         GHistIndexPageFmt, Name)
 
 }  // namespace data
 }  // namespace xgboost

--- a/src/tree/gpu_hist/gradient_based_sampler.cu
+++ b/src/tree/gpu_hist/gradient_based_sampler.cu
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <utility>
 
 #include "../../common/compressed_iterator.h"
 #include "../../common/random.h"

--- a/src/tree/gpu_hist/gradient_based_sampler.cu
+++ b/src/tree/gpu_hist/gradient_based_sampler.cu
@@ -186,10 +186,10 @@ GradientBasedSample UniformSampling::Sample(common::Span<GradientPair> gpair, DM
 
 ExternalMemoryUniformSampling::ExternalMemoryUniformSampling(EllpackPageImpl const* page,
                                                              size_t n_rows,
-                                                             const BatchParam& batch_param,
+                                                             BatchParam batch_param,
                                                              float subsample)
     : original_page_(page),
-      batch_param_(batch_param),
+      batch_param_(std::move(batch_param)),
       subsample_(subsample),
       sample_row_index_(n_rows) {}
 

--- a/src/tree/gpu_hist/gradient_based_sampler.cu
+++ b/src/tree/gpu_hist/gradient_based_sampler.cu
@@ -259,10 +259,10 @@ GradientBasedSample GradientBasedSampling::Sample(common::Span<GradientPair> gpa
 ExternalMemoryGradientBasedSampling::ExternalMemoryGradientBasedSampling(
     EllpackPageImpl const* page,
     size_t n_rows,
-    const BatchParam& batch_param,
+    BatchParam batch_param,
     float subsample)
     : original_page_(page),
-      batch_param_(batch_param),
+      batch_param_(std::move(batch_param)),
       subsample_(subsample),
       threshold_(n_rows + 1, 0.0f),
       grad_sum_(n_rows, 0.0f),

--- a/src/tree/gpu_hist/gradient_based_sampler.cuh
+++ b/src/tree/gpu_hist/gradient_based_sampler.cuh
@@ -102,7 +102,7 @@ class ExternalMemoryGradientBasedSampling : public SamplingStrategy {
  public:
   ExternalMemoryGradientBasedSampling(EllpackPageImpl const* page,
                                       size_t n_rows,
-                                      const BatchParam& batch_param,
+                                      BatchParam batch_param,
                                       float subsample);
   GradientBasedSample Sample(common::Span<GradientPair> gpair, DMatrix* dmat) override;
 

--- a/src/tree/gpu_hist/gradient_based_sampler.cuh
+++ b/src/tree/gpu_hist/gradient_based_sampler.cuh
@@ -68,7 +68,7 @@ class ExternalMemoryUniformSampling : public SamplingStrategy {
  public:
   ExternalMemoryUniformSampling(EllpackPageImpl const* page,
                                 size_t n_rows,
-                                const BatchParam& batch_param,
+                                BatchParam batch_param,
                                 float subsample);
   GradientBasedSample Sample(common::Span<GradientPair> gpair, DMatrix* dmat) override;
 

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -209,7 +209,7 @@ struct GPUHistMakerDevice {
         tree_evaluator(param, n_features, _device_id),
         column_sampler(column_sampler_seed),
         interaction_constraints(param, n_features),
-        batch_param(_batch_param) {
+        batch_param(std::move(_batch_param)) {
     sampler.reset(new GradientBasedSampler(
         page, _n_rows, batch_param, param.subsample, param.sampling_method));
     if (!param.monotone_constraints.empty()) {

--- a/tests/cpp/data/test_gradient_index.cc
+++ b/tests/cpp/data/test_gradient_index.cc
@@ -1,0 +1,25 @@
+/*!
+ * Copyright 2021 XGBoost contributors
+ */
+#include <gtest/gtest.h>
+#include <xgboost/data.h>
+
+#include "../helpers.h"
+#include "../../../src/data/gradient_index.h"
+
+namespace xgboost {
+namespace data {
+TEST(GradientIndex, ExternalMemory) {
+  std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix(10000);
+  std::vector<size_t> base_rowids;
+  for (auto const& page : dmat->GetBatches<GHistIndexMatrix>({0, 64})) {
+    base_rowids.push_back(page.base_rowid);
+  }
+  size_t i = 0;
+  for (auto const& page : dmat->GetBatches<SparsePage>()) {
+    ASSERT_EQ(base_rowids[i], page.base_rowid);
+    ++i;
+  }
+}
+}  // namespace data
+}  // namespace xgboost

--- a/tests/cpp/data/test_gradient_index.cc
+++ b/tests/cpp/data/test_gradient_index.cc
@@ -12,7 +12,8 @@ namespace data {
 TEST(GradientIndex, ExternalMemory) {
   std::unique_ptr<DMatrix> dmat = CreateSparsePageDMatrix(10000);
   std::vector<size_t> base_rowids;
-  for (auto const& page : dmat->GetBatches<GHistIndexMatrix>({0, 64})) {
+  std::vector<float> hessian(dmat->Info().num_row_, 1);
+  for (auto const& page : dmat->GetBatches<GHistIndexMatrix>({0, 64, hessian})) {
     base_rowids.push_back(page.base_rowid);
   }
   size_t i = 0;

--- a/tests/cpp/data/test_gradient_index_page_raw_format.cc
+++ b/tests/cpp/data/test_gradient_index_page_raw_format.cc
@@ -1,0 +1,39 @@
+/*!
+ * Copyright 2021 XGBoost contributors
+ */
+#include <gtest/gtest.h>
+
+#include "../../../src/data/sparse_page_source.h"
+#include "../../../src/data/gradient_index.h"
+#include "../helpers.h"
+
+namespace xgboost {
+namespace data {
+TEST(GHistIndexPageRawFormat, IO) {
+  std::unique_ptr<SparsePageFormat<GHistIndexMatrix>> format{
+      CreatePageFormat<GHistIndexMatrix>("raw")};
+  auto m = RandomDataGenerator{100, 14, 0.5}.GenerateDMatrix();
+  dmlc::TemporaryDirectory tmpdir;
+  std::string path = tmpdir.path + "/ghistindex.page";
+
+  {
+    std::unique_ptr<dmlc::Stream> fo{dmlc::Stream::Create(path.c_str(), "w")};
+    for (auto const &index : m->GetBatches<GHistIndexMatrix>({0, 256})) {
+      format->Write(index, fo.get());
+    }
+  }
+
+  GHistIndexMatrix page;
+  std::unique_ptr<dmlc::SeekStream> fi{dmlc::SeekStream::CreateForRead(path.c_str())};
+  format->Read(&page, fi.get());
+
+  for (auto const &gidx : m->GetBatches<GHistIndexMatrix>({0, 256})) {
+    auto const& loaded = gidx;
+    ASSERT_EQ(loaded.cut.Ptrs(), page.cut.Ptrs());
+    ASSERT_EQ(loaded.cut.MinValues(), page.cut.MinValues());
+    ASSERT_EQ(loaded.cut.Values(), page.cut.Values());
+    ASSERT_EQ(loaded.base_rowid, page.base_rowid);
+  }
+}
+} // namespace data
+} // namespace xgboost

--- a/tests/cpp/data/test_gradient_index_page_raw_format.cc
+++ b/tests/cpp/data/test_gradient_index_page_raw_format.cc
@@ -3,8 +3,8 @@
  */
 #include <gtest/gtest.h>
 
-#include "../../../src/data/sparse_page_source.h"
 #include "../../../src/data/gradient_index.h"
+#include "../../../src/data/sparse_page_source.h"
 #include "../helpers.h"
 
 namespace xgboost {
@@ -24,15 +24,21 @@ TEST(GHistIndexPageRawFormat, IO) {
   }
 
   GHistIndexMatrix page;
-  std::unique_ptr<dmlc::SeekStream> fi{dmlc::SeekStream::CreateForRead(path.c_str())};
+  std::unique_ptr<dmlc::SeekStream> fi{
+      dmlc::SeekStream::CreateForRead(path.c_str())};
   format->Read(&page, fi.get());
 
   for (auto const &gidx : m->GetBatches<GHistIndexMatrix>({0, 256})) {
-    auto const& loaded = gidx;
+    auto const &loaded = gidx;
     ASSERT_EQ(loaded.cut.Ptrs(), page.cut.Ptrs());
     ASSERT_EQ(loaded.cut.MinValues(), page.cut.MinValues());
     ASSERT_EQ(loaded.cut.Values(), page.cut.Values());
     ASSERT_EQ(loaded.base_rowid, page.base_rowid);
+    ASSERT_TRUE(std::equal(loaded.index.begin(), loaded.index.end(),
+                           page.index.begin()));
+    ASSERT_TRUE(std::equal(loaded.index.Offset(),
+                           loaded.index.Offset() + loaded.index.OffsetSize(),
+                           page.index.Offset()));
   }
 }
 } // namespace data

--- a/tests/cpp/data/test_gradient_index_page_raw_format.cc
+++ b/tests/cpp/data/test_gradient_index_page_raw_format.cc
@@ -18,7 +18,8 @@ TEST(GHistIndexPageRawFormat, IO) {
 
   {
     std::unique_ptr<dmlc::Stream> fo{dmlc::Stream::Create(path.c_str(), "w")};
-    for (auto const &index : m->GetBatches<GHistIndexMatrix>({0, 256})) {
+    for (auto const &index :
+         m->GetBatches<GHistIndexMatrix>({GenericParameter::kCpuId, 256})) {
       format->Write(index, fo.get());
     }
   }
@@ -28,12 +29,14 @@ TEST(GHistIndexPageRawFormat, IO) {
       dmlc::SeekStream::CreateForRead(path.c_str())};
   format->Read(&page, fi.get());
 
-  for (auto const &gidx : m->GetBatches<GHistIndexMatrix>({0, 256})) {
+  for (auto const &gidx :
+       m->GetBatches<GHistIndexMatrix>({GenericParameter::kCpuId, 256})) {
     auto const &loaded = gidx;
     ASSERT_EQ(loaded.cut.Ptrs(), page.cut.Ptrs());
     ASSERT_EQ(loaded.cut.MinValues(), page.cut.MinValues());
     ASSERT_EQ(loaded.cut.Values(), page.cut.Values());
     ASSERT_EQ(loaded.base_rowid, page.base_rowid);
+    ASSERT_EQ(loaded.IsDense(), page.IsDense());
     ASSERT_TRUE(std::equal(loaded.index.begin(), loaded.index.end(),
                            page.index.begin()));
     ASSERT_TRUE(std::equal(loaded.index.Offset(),

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -370,7 +370,7 @@ std::unique_ptr<DMatrix> CreateSparsePageDMatrix(size_t n_entries,
 
   std::unique_ptr<DMatrix> dmat{DMatrix::Create(
       static_cast<DataIterHandle>(&iter), iter.Proxy(), Reset, Next,
-      std::numeric_limits<float>::quiet_NaN(), 1, prefix)};
+      std::numeric_limits<float>::quiet_NaN(), omp_get_max_threads(), prefix)};
   auto row_page_path =
       data::MakeId(prefix,
                    dynamic_cast<data::SparsePageDMatrix *>(dmat.get())) +


### PR DESCRIPTION
* Add hessian to batch param in preparasion of new approx impl.
* Extract a push method for gradient index matrix.
* Use span instead of vector ref for hessian in sketching.
* Create a binary format for gradient index.