### PR TITLE
[CI] Fix hanging Python setup in Windows CI

### DIFF
--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -127,7 +127,7 @@ def TestWin64() {
     bat "build\\testxgboost.exe"
     echo "Installing Python dependencies..."
     def env_name = 'win64_' + UUID.randomUUID().toString().replaceAll('-', '')
-    bat "conda env create -n ${env_name} --file=tests/ci_build/conda_env/win64_test.yml"
+    bat "conda activate && mamba env create -n ${env_name} --file=tests/ci_build/conda_env/win64_test.yml"
     echo "Installing Python wheel..."
     bat """
     conda activate ${env_name} && for /R %%i in (python-package\\dist\\*.whl) DO python -m pip install "%%i"

--- a/tests/ci_build/conda_env/win64_cpu_test.yml
+++ b/tests/ci_build/conda_env/win64_cpu_test.yml
@@ -2,7 +2,7 @@ name: win64_env
 channels:
 - conda-forge
 dependencies:
-- python
+- python=3.8
 - wheel
 - numpy
 - scipy

--- a/tests/ci_build/conda_env/win64_cpu_test.yml
+++ b/tests/ci_build/conda_env/win64_cpu_test.yml
@@ -16,6 +16,5 @@ dependencies:
 - jsonschema
 - hypothesis
 - jsonschema
+- python-graphviz
 - pip
-- pip:
-  - graphviz

--- a/tests/ci_build/conda_env/win64_test.yml
+++ b/tests/ci_build/conda_env/win64_test.yml
@@ -12,8 +12,7 @@ dependencies:
 - boto3
 - hypothesis
 - jsonschema
+- cupy
+- python-graphviz
+- modin-all
 - pip
-- pip:
-  - cupy-cuda101
-  - modin[all]
-  - graphviz

--- a/tests/ci_build/conda_env/win64_test.yml
+++ b/tests/ci_build/conda_env/win64_test.yml
@@ -14,5 +14,5 @@ dependencies:
 - jsonschema
 - cupy
 - python-graphviz
-- modin-all
+- modin-ray
 - pip

--- a/tests/ci_build/conda_env/win64_test.yml
+++ b/tests/ci_build/conda_env/win64_test.yml
@@ -2,7 +2,7 @@ name: win64_env
 channels:
 - conda-forge
 dependencies:
-- python=3.7
+- python=3.8
 - numpy
 - scipy
 - matplotlib


### PR DESCRIPTION
Sometimes, Conda hangs while installing Python packages.

1. Use `mamba` instead, which is a faster method for installing Python packages from Conda.
2. Download all Python packages from Conda. Previously, some packages were being downloaded from PyPI. Why this is a problem? Recently, `pip` became more strict about dependency resolution and download multiple packages upon running into a conflict:

>[2021-08-25T01:35:45.183Z] INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

(https://xgboost-ci.net/blue/organizations/jenkins/xgboost-win64/detail/PR-7185/2/pipeline)

I re-built the image of the Windows CI worker as part of this PR.

Make progress toward #7013 