### PR TITLE
[WIP] Add C++ API for external applications

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2015~2021 by Contributors
+ * Copyright (c) 2015-2021 by Contributors
  * \file c_api.h
  * \author Tianqi Chen
  * \brief C API of XGBoost, used for interfacing to other languages.

--- a/include/xgboost/cxx_api.h
+++ b/include/xgboost/cxx_api.h
@@ -1,0 +1,89 @@
+/*!
+ * Copyright (c) 2015-2021 by Contributors
+ * \file cxx_api.h
+ * \brief C++ API of XGBoost, which is designed to make it easy for other C++ applications to use
+ * XGBoost.
+ * \author Hyunsu Cho
+ */
+#ifndef XGBOOST_CXX_API_H_
+#define XGBOOST_CXX_API_H_
+
+#include <string>
+#include <utility>
+#include <memory>
+#include <limits>
+#include <exception>
+#include <cstdint>
+
+namespace xgboost {
+namespace cxx_api {
+
+class DMatrixInternal;
+class BoosterInternal;
+
+static_assert(std::numeric_limits<float>::has_quiet_NaN,
+              "Must have a non-signaling NaN");
+
+class XGBoostException : public std::exception {
+ public:
+  XGBoostException(const std::string& msg) : msg_(msg) {}
+	const char* what() const noexcept {
+    return msg_.c_str();
+  }
+
+ private:
+  std::string msg_;
+};
+
+class DMatrix {
+ public:
+  DMatrix();
+  DMatrix(const DMatrix&) = delete;
+  DMatrix(DMatrix&&);
+  ~DMatrix();
+  static DMatrix CreateFromMat(
+      const float* data,
+      uint64_t nrow,
+      uint64_t ncol,
+      float missing = std::numeric_limits<float>::quiet_NaN(),
+      int nthread = -1);
+
+ private:
+  std::unique_ptr<DMatrixInternal> pimpl_;
+
+  friend class Booster;
+};
+
+struct PredictOutput {
+ public:
+  const float* preds;
+  uint64_t ndim;
+  const uint64_t* shape;
+};
+
+class Booster {
+ public:
+  Booster();
+  ~Booster(); 
+  void LoadModel(const std::string& fname);
+
+  PredictOutput Predict(
+      const DMatrix& data,
+      bool output_margin = false,
+      bool pred_leaf = false,
+      bool pred_contribs = false,
+      bool approx_contribs = false,
+      bool pred_interactions = false,
+      bool strict_shape = false,
+      std::pair<int, int> iteration_range = {0, 0},
+      bool training = false
+  );
+
+ private:
+  std::unique_ptr<BoosterInternal> pimpl_;
+};
+
+}  // namespace cxx_api
+}  // namespace xgboost
+
+#endif  // XGBOOST_CXX_API_H_

--- a/src/cxx_api/cxx_api.cc
+++ b/src/cxx_api/cxx_api.cc
@@ -1,0 +1,139 @@
+/*!
+ * Copyright (c) 2021 by Contributors
+ * \file cxx_api.cc
+ * \brief C++ API of XGBoost, which is designed to make it easy for other C++ applications to use
+ * XGBoost.
+ * \author Hyunsu Cho
+ */
+#include "xgboost/c_api.h"
+#include "xgboost/cxx_api.h"
+#include <sstream>
+#include <memory>
+#include <vector>
+#include <type_traits>
+#include <cstdint>
+
+namespace xgboost {
+namespace cxx_api {
+
+static_assert(std::is_same<bst_ulong, uint64_t>::value,
+              "Assumed bst_ulong == uint64_t but failed");
+
+void CAPIGuard(int retval) {
+  if (retval != 0) {
+    throw XGBoostException(std::string(XGBGetLastError()));
+  }
+}
+
+using DMatrixHandle = void*;
+using BoosterHandle = void*;
+
+class DMatrixInternal {
+ private:
+  DMatrixHandle handle_;
+  friend class DMatrix;
+  friend class Booster;
+};
+
+class BoosterInternal {
+ private:
+   BoosterHandle handle_;
+   std::vector<DMatrixHandle> cache_mats;
+   friend class Booster;
+};
+
+DMatrix::DMatrix() : pimpl_(std::make_unique<DMatrixInternal>()) {}
+DMatrix::DMatrix(DMatrix&&) = default;
+DMatrix::~DMatrix() {}
+
+DMatrix DMatrix::CreateFromMat(
+      const float* data,
+      bst_ulong nrow,
+      bst_ulong ncol,
+      float missing,
+      int nthread) {
+  std::string array_interface;
+  {
+    std::ostringstream oss;
+    oss << "{\"data\": [" << reinterpret_cast<std::size_t>(data) << ", true], "
+        << "\"shape\": [" << nrow << ", " << ncol << "], "
+        << "\"typestr\": \"<f4\", \"version\": 3}";
+    array_interface = oss.str();
+  }
+  std::string config = "{\"nthread\": 16, \"missing\": NaN}";
+
+  DMatrixHandle handle;
+  CAPIGuard(XGDMatrixCreateFromDense(array_interface.c_str(), config.c_str(), &handle));
+
+  DMatrix mat;
+  mat.pimpl_->handle_ = handle;
+  return mat;
+}
+
+Booster::Booster() : pimpl_(std::make_unique<BoosterInternal>()) {
+  CAPIGuard(XGBoosterCreate(nullptr, 0, &pimpl_->handle_));
+}
+
+Booster::~Booster() {}
+
+void Booster::LoadModel(const std::string& fname) {
+  CAPIGuard(XGBoosterLoadModel(pimpl_->handle_, fname.c_str()));
+}
+
+PredictOutput Booster::Predict(
+      const DMatrix& data,
+      bool output_margin,
+      bool pred_leaf,
+      bool pred_contribs,
+      bool approx_contribs,
+      bool pred_interactions,
+      bool strict_shape,
+      std::pair<int, int> iteration_range,
+      bool training) {
+
+  int pred_type = 0;
+  auto assign_type = [&pred_type](int t) {
+    if (pred_type != 0) {
+      throw XGBoostException("One type of prediction at a time.");
+    }
+    pred_type = t;
+  };
+  if (output_margin) {
+    assign_type(1);
+  }
+  if (pred_contribs) {
+    assign_type((!approx_contribs ? 2 : 3));
+  }
+  if (pred_interactions) {
+    assign_type((!approx_contribs ? 4 : 5));
+  }
+  if (pred_leaf) {
+    assign_type(6);
+  }
+  
+  std::string args;
+  {
+    std::ostringstream oss;
+    oss << "{\"type\": " << pred_type
+        << ", \"training\": " << (training ? "true" : "false")
+        << ", \"iteration_begin\": " << iteration_range.first
+        << ", \"iteration_end\": " << iteration_range.second
+        << ", \"strict_shape\": " << (strict_shape ? "true" : "false")
+        << "}";
+    args = oss.str();
+  }
+
+  PredictOutput out;
+  CAPIGuard(XGBoosterPredictFromDMatrix(
+        pimpl_->handle_,
+        data.pimpl_->handle_,
+        args.c_str(),
+        &out.shape,
+        &out.ndim,
+        &out.preds));
+  return out;
+}
+
+}  // namespace cxx_api
+}  // namespace xgboost
+


### PR DESCRIPTION
Closes #4895

Goals:
* Ease of use
* Closely model the Python frontend in its design
* Ability to support a variety of C++ matrix libraries, such as Armadillo and Eigen.
* Use the C API for implementation.
  - This will de-couple the C++ API layer from XGBoost internals.
  - The C API is well tested with the Python package, so the maintenance of the Python package also ensures that the C++ API would work.
* Sufficiently flexible so that some property testing can be migrated from pytest to gtest (for the sake of speed).

Non-goals:
* API stability (at least not now)