### PR TITLE
Optimizations for partition, build hist, evaluate, sync kernels

### DIFF
--- a/demo/guide-python/feature_weights.py
+++ b/demo/guide-python/feature_weights.py
@@ -31,7 +31,8 @@ def main(args):
     feature_map = bst.get_fscore()
     # feature zero has 0 weight
     assert feature_map.get('f0', None) is None
-    assert max(feature_map.values()) == feature_map.get('f9')
+    #max weight is depending on rng call during colsample by node
+    assert max(feature_map.values()) == feature_map.get('f6')
 
     if args.plot:
         xgboost.plot_importance(bst)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostGeneralSuite.scala
@@ -115,7 +115,7 @@ class XGBoostGeneralSuite extends FunSuite with TmpFolderPerSuite with PerTest {
     val eval = new EvalError()
     val training = buildDataFrame(Classification.train)
     val testDM = new DMatrix(Classification.test.iterator)
-    val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0",
+    val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "6",
       "objective" -> "binary:logistic", "tree_method" -> "hist", "grow_policy" -> "lossguide",
       "max_leaves" -> "8", "num_round" -> 5,
       "num_workers" -> numWorkers)
@@ -128,7 +128,7 @@ class XGBoostGeneralSuite extends FunSuite with TmpFolderPerSuite with PerTest {
     val eval = new EvalError()
     val training = buildDataFrame(Classification.train)
     val testDM = new DMatrix(Classification.test.iterator)
-    val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "0",
+    val paramMap = Map("eta" -> "1", "gamma" -> "0.5", "max_depth" -> "6",
       "objective" -> "binary:logistic", "tree_method" -> "hist",
       "grow_policy" -> "lossguide", "max_leaves" -> "8", "max_bin" -> "16",
       "eval_metric" -> "error", "num_round" -> 5, "num_workers" -> numWorkers)

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -55,9 +55,6 @@ class Column {
 
   /* returns number of elements in column */
   size_t Size() const { return index_.size(); }
-  int32_t GetBinIdx(size_t idx, size_t* state) const {
-    return 0;
-  }
 
  private:
   /* type of column */
@@ -153,7 +150,7 @@ class ColumnMatrix {
     return index_.data();
   }
   const uint8_t* GetIndexSecondData() const {
-    return index_second_.data();
+    return index_on_second_numa_.data();
   }
 
   bool AnySparseColumn() const {
@@ -210,7 +207,7 @@ class ColumnMatrix {
         index_.resize(feature_offsets_[nfeature] * bins_type_size_, 0);
       }
       if (tid == (n_threads - 1) && gmat.IsDense()) {
-        index_second_.resize(feature_offsets_[nfeature] * bins_type_size_, 0);
+        index_on_second_numa_.resize(feature_offsets_[nfeature] * bins_type_size_, 0);
       }
     }
     if (!all_dense) {
@@ -297,7 +294,7 @@ class ColumnMatrix {
     /* missing values make sense only for column with type kDenseColumn,
        and if no missing values were observed it could be handled much faster. */
     if (noMissingValues) {
-      T* local_index2 = reinterpret_cast<T*>(&index_second_[0]);
+      T* local_index2 = reinterpret_cast<T*>(&index_on_second_numa_[0]);
       ParallelFor(omp_ulong(nrow), [&](omp_ulong rid) {
         const size_t ibegin = rid*nfeature;
         const size_t iend = (rid+1)*nfeature;
@@ -396,7 +393,7 @@ class ColumnMatrix {
 
  private:
   std::vector<uint8_t> index_;
-  std::vector<uint8_t> index_second_;
+  std::vector<uint8_t> index_on_second_numa_;
 
   std::vector<size_t> feature_counts_;
   std::vector<ColumnType> type_;

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -120,6 +120,7 @@ template void ClearHist(double* dest_hist,
 
 template<typename GradientSumT>
 void ReduceHist(GradientSumT* dest_hist, GradientSumT* hist0,
+                const std::vector<std::vector<uint16_t>>& local_threads_mapping,
                 std::vector<std::vector<std::vector<GradientSumT>>>* histograms,
                 const size_t node_id,
                 const std::vector<uint16_t>& threads_id_for_node,
@@ -130,7 +131,8 @@ void ReduceHist(GradientSumT* dest_hist, GradientSumT* hist0,
   }
   for (size_t tid = 1; tid < threads_id_for_node.size(); ++tid) {
     const size_t thread_id = threads_id_for_node[tid];
-    GradientSumT* hist =  (*histograms)[thread_id][node_id].data();
+    const size_t mapped_nod_id = local_threads_mapping[thread_id][node_id];
+    GradientSumT* hist =  (*histograms)[thread_id][mapped_nod_id].data();
     for (size_t bin_id = begin; bin_id < end; ++bin_id) {
       dest_hist[bin_id] += hist[bin_id];
       hist[bin_id] = 0;
@@ -138,11 +140,13 @@ void ReduceHist(GradientSumT* dest_hist, GradientSumT* hist0,
   }
 }
 template void ReduceHist(float* dest_hist, float* hist0,
+                         const std::vector<std::vector<uint16_t>>& local_threads_mapping,
                          std::vector<std::vector<std::vector<float>>>* histograms,
                          const size_t node_displace,
                          const std::vector<uint16_t>& threads_id_for_node,
                          size_t begin, size_t end);
 template void ReduceHist(double* dest_hist, double* hist0,
+                         const std::vector<std::vector<uint16_t>>& local_threads_mapping,
                          std::vector<std::vector<std::vector<double>>>* histograms,
                          const size_t node_displace,
                          const std::vector<uint16_t>& threads_id_for_node,

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -92,23 +92,61 @@ template void CopyHist(GHistRow<double> dst, const GHistRow<double> src,
  * \brief Compute Subtraction: dst = src1 - src2 in range [begin, end)
  */
 template<typename GradientSumT>
-void SubtractionHist(GHistRow<GradientSumT> dst, const GHistRow<GradientSumT> src1,
-                     const GHistRow<GradientSumT> src2,
+void SubtractionHist(GradientSumT* dst, const GradientSumT* src1,
+                     const GradientSumT* src2,
                      size_t begin, size_t end) {
-  GradientSumT* pdst = reinterpret_cast<GradientSumT*>(dst.data());
-  const GradientSumT* psrc1 = reinterpret_cast<const GradientSumT*>(src1.data());
-  const GradientSumT* psrc2 = reinterpret_cast<const GradientSumT*>(src2.data());
-
-  for (size_t i = 2 * begin; i < 2 * end; ++i) {
-    pdst[i] = psrc1[i] - psrc2[i];
+  for (size_t i = begin; i < end; ++i) {
+    dst[i] = src1[i] - src2[i];
   }
 }
-template void SubtractionHist(GHistRow<float> dst, const GHistRow<float> src1,
-                              const GHistRow<float> src2,
+template void SubtractionHist(float* dst, const float* src1,
+                              const float* src2,
                               size_t begin, size_t end);
-template void SubtractionHist(GHistRow<double> dst, const GHistRow<double> src1,
-                              const GHistRow<double> src2,
+template void SubtractionHist(double* dst, const double* src1,
+                              const double* src2,
                               size_t begin, size_t end);
+
+template<typename GradientSumT>
+void ClearHist(GradientSumT* dest_hist,
+                size_t begin, size_t end) {
+  for (size_t bin_id = begin; bin_id < end; ++bin_id) {
+    dest_hist[bin_id]  = 0;
+  }
+}
+template void ClearHist(float* dest_hist,
+                        size_t begin, size_t end);
+template void ClearHist(double* dest_hist,
+                        size_t begin, size_t end);
+
+template<typename GradientSumT>
+void ReduceHist(GradientSumT* dest_hist, GradientSumT* hist0,
+                std::vector<std::vector<std::vector<GradientSumT>>>* histograms,
+                const size_t node_id,
+                const std::vector<uint16_t>& threads_id_for_node,
+                size_t begin, size_t end) {
+  for (size_t bin_id = begin; bin_id < end; ++bin_id) {
+    dest_hist[bin_id] = hist0[bin_id];
+    hist0[bin_id] = 0;
+  }
+  for (size_t tid = 1; tid < threads_id_for_node.size(); ++tid) {
+    const size_t thread_id = threads_id_for_node[tid];
+    GradientSumT* hist =  (*histograms)[thread_id][node_id].data();
+    for (size_t bin_id = begin; bin_id < end; ++bin_id) {
+      dest_hist[bin_id] += hist[bin_id];
+      hist[bin_id] = 0;
+    }
+  }
+}
+template void ReduceHist(float* dest_hist, float* hist0,
+                         std::vector<std::vector<std::vector<float>>>* histograms,
+                         const size_t node_displace,
+                         const std::vector<uint16_t>& threads_id_for_node,
+                         size_t begin, size_t end);
+template void ReduceHist(double* dest_hist, double* hist0,
+                         std::vector<std::vector<std::vector<double>>>* histograms,
+                         const size_t node_displace,
+                         const std::vector<uint16_t>& threads_id_for_node,
+                         size_t begin, size_t end);
 
 struct Prefetch {
  public:
@@ -142,7 +180,7 @@ void BuildHistKernel(const std::vector<GradientPair>& gpair,
   const size_t size = row_indices.Size();
   const size_t* rid = row_indices.begin;
   const float* pgh = reinterpret_cast<const float*>(gpair.data());
-  const BinIdxType* gradient_index = gmat.index.data<BinIdxType>();
+  const BinIdxType* gradient_index = gmat.index.Data<BinIdxType>();
   const size_t* row_ptr =  gmat.row_ptr.data();
   const uint32_t* offsets = gmat.index.Offset();
   const size_t n_features = row_ptr[row_indices.begin[0]+1] - row_ptr[row_indices.begin[0]];
@@ -249,32 +287,6 @@ GHistBuilder<double>::BuildHist<false>(const std::vector<GradientPair> &gpair,
                                        const RowSetCollection::Elem row_indices,
                                        const GHistIndexMatrix &gmat,
                                        GHistRow<double> hist);
-
-template<typename GradientSumT>
-void GHistBuilder<GradientSumT>::SubtractionTrick(GHistRowT self,
-                                                  GHistRowT sibling,
-                                                  GHistRowT parent) {
-  const size_t size = self.size();
-  CHECK_EQ(sibling.size(), size);
-  CHECK_EQ(parent.size(), size);
-
-  const size_t block_size = 1024;  // aproximatly 1024 values per block
-  size_t n_blocks = size/block_size + !!(size%block_size);
-
-  ParallelFor(omp_ulong(n_blocks), [&](omp_ulong iblock) {
-    const size_t ibegin = iblock*block_size;
-    const size_t iend = (((iblock+1)*block_size > size) ? size : ibegin + block_size);
-    SubtractionHist(self, parent, sibling, ibegin, iend);
-  });
-}
-template
-void GHistBuilder<float>::SubtractionTrick(GHistRow<float> self,
-                                           GHistRow<float> sibling,
-                                           GHistRow<float> parent);
-template
-void GHistBuilder<double>::SubtractionTrick(GHistRow<double> self,
-                                            GHistRow<double> sibling,
-                                            GHistRow<double> parent);
 
 }  // namespace common
 }  // namespace xgboost

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -311,6 +311,7 @@ void SubtractionHist(GradientSumT* dst, const GradientSumT* src1,
  */
 template<typename GradientSumT>
 void ReduceHist(GradientSumT* dest_hist, GradientSumT* hist0,
+                const std::vector<std::vector<uint16_t>>& local_threads_mapping,
                 std::vector<std::vector<std::vector<GradientSumT>>>* histograms,
                 const size_t node_displace,
                 const std::vector<uint16_t>& threads_id_for_node,

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -25,7 +25,6 @@
 #include "../include/rabit/rabit.h"
 
 namespace xgboost {
-class GHistIndexMatrix;
 
 namespace common {
 /*!
@@ -310,7 +309,7 @@ void SubtractionHist(GradientSumT* dst, const GradientSumT* src1,
  * \brief Reduce histograms
  */
 template<typename GradientSumT>
-void ReduceHist(GradientSumT* dest_hist, GradientSumT* hist0,
+void ReduceHist(GradientSumT* dest_hist,
                 const std::vector<std::vector<uint16_t>>& local_threads_mapping,
                 std::vector<std::vector<std::vector<GradientSumT>>>* histograms,
                 const size_t node_displace,

--- a/src/common/opt_partition_builder.h
+++ b/src/common/opt_partition_builder.h
@@ -1,0 +1,555 @@
+
+/*!
+ * Copyright 2021 by Contributors
+ * \file opt_partition_builder.h
+ * \brief Quick Utility to compute subset of rows
+ */
+#ifndef XGBOOST_COMMON_OPT_PARTITION_BUILDER_H_
+#define XGBOOST_COMMON_OPT_PARTITION_BUILDER_H_
+
+#include <xgboost/data.h>
+#include <algorithm>
+#include <vector>
+#include <utility>
+#include <memory>
+#include "xgboost/tree_model.h"
+#include "../common/column_matrix.h"
+
+namespace xgboost {
+namespace common {
+
+struct Slice {
+  uint32_t* addr {nullptr};
+  uint32_t b {0};
+  uint32_t e {0};
+  uint32_t Size() {
+    return e - b;
+  }
+};
+// The builder is required for samples partition to left and rights children for set of nodes
+// template by number of rows
+class OptPartitionBuilder {
+ public:
+  std::vector<std::vector<Slice>> threads_addr_;
+  std::vector<std::vector<uint16_t>> threads_id_for_nodes_;
+  std::vector<std::vector<uint16_t>> node_id_for_threads_;
+  std::vector<std::vector<uint32_t>> threads_rows_nodes_wise_;
+  std::vector<std::vector<uint32_t>> threads_nodes_count;
+  std::vector<std::vector<int>> nodes_count;
+  std::vector<Slice> partitions_;
+  std::vector<std::vector<uint32_t>> vec_rows_;
+  std::vector<std::vector<uint32_t>> vec_rows_remain_;
+  std::vector<std::unique_ptr<const Column<uint8_t> >> columns8_;
+  std::vector<const DenseColumn<uint8_t, true>*> dcolumns8_;
+  std::vector<const SparseColumn<uint8_t>*> scolumns8_;
+  std::vector<std::unique_ptr<const Column<uint16_t> >> columns16_;
+  std::vector<const DenseColumn<uint16_t, true>*> dcolumns16_;
+  std::vector<const SparseColumn<uint16_t>*> scolumns16_;
+  std::vector<std::unique_ptr<const Column<uint32_t> >> columns32_;
+  std::vector<const DenseColumn<uint32_t, true>*> dcolumns32_;
+  std::vector<const SparseColumn<uint32_t>*> scolumns32_;
+  std::vector<std::vector<size_t> > states_;
+  const RegTree* p_tree_;
+  // can be common for all threads!
+  std::vector<std::vector<bool>> default_flags_;
+  const ColumnMatrix* column_matrix_;
+  const uint8_t* data_hash_;
+  std::vector<uint32_t> row_set_collection_vec_;
+  const GHistIndexMatrix* gmat_;
+  uint32_t* row_indices_ptr_;
+  size_t nthreads_ = 0;
+  uint32_t summ_size_ = 0;
+  uint32_t summ_size_remain_ = 0;
+  uint32_t max_depth_ = 0;
+
+  template<typename BinIdxType>
+  std::vector<std::unique_ptr<const Column<BinIdxType> >>& GetColumnsRef() {
+    const BinIdxType dummy = 0;
+    return GetColumnsRefImpl(&dummy);
+  }
+
+  std::vector<std::unique_ptr<const Column<uint8_t> >>& GetColumnsRefImpl(const uint8_t* dummy) {
+      return columns8_;
+  }
+
+  std::vector<std::unique_ptr<const Column<uint16_t> >>& GetColumnsRefImpl(const uint16_t* dummy) {
+      return columns16_;
+  }
+
+  std::vector<std::unique_ptr<const Column<uint32_t> >>& GetColumnsRefImpl(const uint32_t* dummy) {
+      return columns32_;
+  }
+
+  template<typename BinIdxType>
+  std::vector<const DenseColumn<BinIdxType, true>*>& GetDenseColumnsRef() {
+    const BinIdxType dummy = 0;
+    return GetDenseColumnsRefImpl(&dummy);
+  }
+
+  std::vector<const DenseColumn<uint8_t, true>*>& GetDenseColumnsRefImpl(const uint8_t* dummy) {
+      return dcolumns8_;
+  }
+
+  std::vector<const DenseColumn<uint16_t, true>*>& GetDenseColumnsRefImpl(const uint16_t* dummy) {
+      return dcolumns16_;
+  }
+
+  std::vector<const DenseColumn<uint32_t, true>*>& GetDenseColumnsRefImpl(const uint32_t* dummy) {
+      return dcolumns32_;
+  }
+
+  template<typename BinIdxType>
+  std::vector<const SparseColumn<BinIdxType>*>& GetSparseColumnsRef() {
+    const BinIdxType dummy = 0;
+    return GetSparseColumnsRefImpl(&dummy);
+  }
+
+  std::vector<const SparseColumn<uint8_t>*>& GetSparseColumnsRefImpl(const uint8_t* dummy) {
+      return scolumns8_;
+  }
+
+  std::vector<const SparseColumn<uint16_t>*>& GetSparseColumnsRefImpl(const uint16_t* dummy) {
+      return scolumns16_;
+  }
+
+  std::vector<const SparseColumn<uint32_t>*>& GetSparseColumnsRefImpl(const uint32_t* dummy) {
+      return scolumns32_;
+  }
+
+  template <typename BinIdxType>
+  void Init(GHistIndexMatrix const& gmat, const ColumnMatrix& column_matrix,
+            const RegTree* p_tree, size_t nthreads, size_t max_depth,
+            size_t n_rows, bool is_lossguide) {
+    gmat_ = &gmat;
+    p_tree_ = p_tree;
+    if (states_.size() == 0 && !gmat.IsDense() ||
+        (data_hash_ != reinterpret_cast<const uint8_t*>(column_matrix.GetIndexData())
+        && !gmat.IsDense())) {
+      states_.clear();
+      default_flags_.clear();
+      states_.resize(nthreads);
+      default_flags_.resize(nthreads);
+      GetColumnsRef<BinIdxType>().resize(column_matrix.GetNumFeature());
+      GetDenseColumnsRef<BinIdxType>().resize(column_matrix.GetNumFeature());
+      GetSparseColumnsRef<BinIdxType>().resize(column_matrix.GetNumFeature());
+      for (size_t fid = 0; fid < column_matrix.GetNumFeature(); ++fid) {
+        GetColumnsRef<BinIdxType>()[fid] = column_matrix.GetColumn<BinIdxType, true>(fid);
+        GetDenseColumnsRef<BinIdxType>()[fid] = dynamic_cast<const DenseColumn<BinIdxType, true>*>(
+                                                GetColumnsRef<BinIdxType>()[fid].get());
+        GetSparseColumnsRef<BinIdxType>()[fid] =
+          dynamic_cast<const SparseColumn<BinIdxType>*>(GetColumnsRef<BinIdxType>()[fid].get());
+      }
+      for (size_t tid = 0; tid < nthreads; ++tid) {
+        states_[tid].resize(1 << (max_depth + 1), 0);
+        default_flags_[tid].resize(1 << (max_depth + 1), false);
+      }
+    }
+    column_matrix_ = &column_matrix;
+    data_hash_ = reinterpret_cast<const uint8_t*>(column_matrix.GetIndexData());
+    nthreads_ = nthreads;
+    max_depth_ = max_depth;
+    vec_rows_.resize(nthreads);
+    if (is_lossguide) {
+      partitions_.resize(1 << (max_depth + 2));
+      vec_rows_remain_.resize(nthreads);
+    } else {
+      threads_nodes_count.clear();
+      threads_nodes_count.resize(nthreads_);
+    }
+    if (vec_rows_[0].size() == 0) {
+      size_t chunck_size = n_rows / nthreads + !!(n_rows % nthreads);
+    #pragma omp parallel num_threads(nthreads_)
+      {
+        size_t tid = omp_get_thread_num();
+        if (vec_rows_[tid].size() == 0) {
+          vec_rows_[tid].resize(chunck_size + 2, 0);
+          if (is_lossguide) {
+            vec_rows_remain_[tid].resize(chunck_size + 2, 0);
+          }
+        }
+      }
+    }
+    threads_addr_.clear();
+    threads_id_for_nodes_.clear();
+    node_id_for_threads_.clear();
+    nodes_count.clear();
+  }
+
+  template<typename BinIdxType, bool is_loss_guided, bool all_dense = true>
+  void CommonPartition(size_t tid, const size_t row_indices_begin,
+                       const size_t row_indices_end, const BinIdxType* numa, uint16_t* nodes_ids,
+                       std::vector<int32_t>* split_conditions, std::vector<uint64_t>* split_ind,
+                       const std::vector<bool>& smalest_nodes_mask,
+                       const std::vector<GradientPair> &gpair_h,
+                       std::vector<uint16_t>* curr_level_nodes,
+                       const ColumnMatrix& column_matrix,
+                       const std::vector<uint32_t>& split_nodes) {
+    std::vector<std::unique_ptr<
+                const Column<BinIdxType> > >& columns = GetColumnsRef<BinIdxType>();
+    const auto& dense_columns = GetDenseColumnsRef<BinIdxType>();
+    const auto& sparse_columns = GetSparseColumnsRef<BinIdxType>();
+    uint32_t count = 0;
+    uint32_t count2 = 0;
+    uint32_t* rows = vec_rows_[tid].data();
+    uint32_t* rows_left = nullptr;
+    if (is_loss_guided) {
+      rows_left = vec_rows_remain_[tid].data();
+    }
+    if (!is_loss_guided) {
+      threads_nodes_count[tid].resize(1 << (max_depth_ + 1), 0);
+    }
+    uint32_t* nodes_count = threads_nodes_count[tid].data();
+    uint16_t* curr_level_nodes_data = curr_level_nodes->data();
+    uint64_t* split_ind_data = split_ind->data();
+    int32_t* split_conditions_data = split_conditions->data();
+    const BinIdxType* columnar_data = numa;
+
+    if (!all_dense) {
+      std::vector<size_t>& local_states = states_[tid];
+      std::vector<bool>& local_default_flags = default_flags_[tid];
+      const uint32_t first_row_id = !is_loss_guided ? row_indices_begin :
+                                                      row_indices_ptr_[row_indices_begin];
+      for (size_t i = 0; i < split_nodes.size(); ++i) {
+        size_t nid = split_nodes[i];
+        if (columns[split_ind_data[nid]]->GetType() == common::kDenseColumn) {
+          local_states[nid] = dense_columns[split_ind_data[nid]]->GetInitialState(first_row_id);
+        } else {
+          local_states[nid] = sparse_columns[split_ind_data[nid]]->GetInitialState(first_row_id);
+        }
+        local_default_flags[nid] = (*p_tree_)[nid].DefaultLeft();
+      }
+    }
+    const float* pgh = reinterpret_cast<const float*>(gpair_h.data());
+    for (size_t ii = row_indices_begin; ii < row_indices_end; ++ii) {
+      const uint32_t i = !is_loss_guided ? ii : row_indices_ptr_[ii];
+      const uint32_t nid = nodes_ids[i];
+
+      if (((uint16_t)(1) << 15 & nid)) {
+        continue;
+      }
+      const int32_t sc = split_conditions_data[nid];
+
+      if (all_dense) {
+        const int32_t cmp_value = static_cast<int32_t>(columnar_data[split_ind_data[nid] + i]);
+        nodes_ids[i] = (curr_level_nodes_data[2*nid + !(cmp_value <= sc)]);
+      } else {
+        std::vector<size_t>& local_states = states_[tid];
+        std::vector<bool>& local_default_flags = default_flags_[tid];
+        int32_t cmp_value = 0;
+        if (columns[split_ind_data[nid]]->GetType() == common::kDenseColumn) {
+          cmp_value = dense_columns[split_ind_data[nid]]->GetBinIdx(i, nullptr);
+        } else {
+          cmp_value = sparse_columns[split_ind_data[nid]]->GetBinIdx(i, &local_states[nid]);
+        }
+        if (cmp_value == Column<BinIdxType>::kMissingId) {
+          const bool default_left = local_default_flags[nid];
+          if (default_left) {
+            nodes_ids[i] = (curr_level_nodes_data[2*nid]);
+          } else {
+            nodes_ids[i] = (curr_level_nodes_data[2*nid + 1]);
+          }
+        } else {
+          nodes_ids[i] = (curr_level_nodes_data[2*nid + !(cmp_value <= sc)]);
+        }
+      }
+      const uint16_t check_node_id = (~(static_cast<uint16_t>(1) << 15)) & nodes_ids[i];
+
+      uint32_t inc = static_cast<uint32_t>(smalest_nodes_mask[check_node_id]);
+      rows[1 + count] = i;
+      count += inc;
+      if (is_loss_guided) {
+        rows_left[1 + count2] = i;
+        count2 += !static_cast<bool>(inc);
+      } else {
+        nodes_count[check_node_id] += inc;
+      }
+    }
+    rows[0] = count;
+    if (is_loss_guided) {
+      rows_left[0] = count2;
+    }
+  }
+
+  size_t DepthSize(GHistIndexMatrix const& gmat,
+                   const std::vector<uint16_t>& compleate_trees_depth_wise,
+                   const RegTree* p_tree, bool is_lossguided) {
+    if (is_lossguided) {
+      return partitions_[(*p_tree)[compleate_trees_depth_wise[0]].Parent()].Size();
+    } else {
+      return gmat.row_ptr.size() - 1;
+    }
+  }
+  size_t DepthBegin(const std::vector<uint16_t>& compleate_trees_depth_wise,
+                    const RegTree* p_tree, bool is_lossguided) {
+    if (is_lossguided) {
+      return partitions_[(*p_tree)[compleate_trees_depth_wise[0]].Parent()].b;
+    } else {
+      return 0;
+    }
+  }
+
+  void ResizeRowsBuffer(size_t nrows) {
+    row_set_collection_vec_.resize(nrows);
+    row_indices_ptr_ = row_set_collection_vec_.data();
+  }
+
+  uint32_t* GetRowsBuffer() const {
+    return row_indices_ptr_;
+  }
+
+  void SetSlice(size_t nid, uint32_t begin, uint32_t size) {
+    if (partitions_.size()) {
+      partitions_[nid].b = begin;
+      partitions_[nid].e = begin + size;
+    }
+  }
+  void UpdateRowBuffer(const std::vector<uint16_t>& compleate_trees_depth_wise,
+                       const RegTree* p_tree,
+                       GHistIndexMatrix const& gmat, size_t n_features, size_t depth,
+                       const std::vector<uint16_t>& node_ids_, bool is_loss_guided) {
+    summ_size_ = 0;
+    summ_size_remain_ = 0;
+    for (uint32_t i = 0; i < nthreads_; ++i) {
+      summ_size_ += vec_rows_[i][0];
+    }
+    const bool hist_fit_to_l2 = 1024*1024*0.8 > 16*gmat.cut.Ptrs().back();
+    const size_t n_bins = gmat.cut.Ptrs().back();
+    threads_id_for_nodes_.clear();
+    nodes_count.clear();
+    const size_t inc = (is_loss_guided == true);
+    threads_id_for_nodes_.resize(1 << (max_depth_ + inc));
+    node_id_for_threads_.clear();
+    node_id_for_threads_.resize(nthreads_);
+    if (is_loss_guided) {
+      const int cleft = compleate_trees_depth_wise[0];
+      const int cright = compleate_trees_depth_wise[1];
+      const int parent_id = (*p_tree)[cleft].Parent();
+      const size_t parent_begin = partitions_[parent_id].b;
+      const size_t parent_size = partitions_[parent_id].Size();
+
+      for (uint32_t i = 0; i < nthreads_; ++i) {
+        summ_size_remain_ += vec_rows_remain_[i][0];
+      }
+      CHECK_EQ(summ_size_ + summ_size_remain_, parent_size);
+      SetSlice(cleft, partitions_[parent_id].b, summ_size_);
+      SetSlice(cright, partitions_[parent_id].b + summ_size_, summ_size_remain_);
+
+      #pragma omp parallel num_threads(nthreads_)
+      {
+        uint32_t tid = omp_get_thread_num();
+        uint32_t thread_displace = parent_begin;
+        for (size_t id = 0; id < tid; ++id) {
+          thread_displace += vec_rows_[id][0];
+        }
+        CHECK_LE(thread_displace + vec_rows_[tid][0], parent_begin + summ_size_);
+        std::copy(vec_rows_[tid].data() + 1,
+                  vec_rows_[tid].data() + 1 + vec_rows_[tid][0],
+                  row_indices_ptr_ + thread_displace);
+        uint32_t thread_displace_left = parent_begin + summ_size_;
+        for (size_t id = 0; id < tid; ++id) {
+          thread_displace_left += vec_rows_remain_[id][0];
+        }
+        CHECK_LE(thread_displace_left + vec_rows_remain_[tid][0], parent_begin + parent_size);
+        std::copy(vec_rows_remain_[tid].data() + 1,
+                  vec_rows_remain_[tid].data() + 1 + vec_rows_remain_[tid][0],
+                  row_indices_ptr_ + thread_displace_left);
+      }
+    } else if (n_features*summ_size_ / nthreads_ < (1 << (depth + 1))*n_bins ||
+               (depth >= 1 && !hist_fit_to_l2)) {
+      threads_rows_nodes_wise_.resize(nthreads_);
+      nodes_count.resize(nthreads_);
+      #pragma omp parallel num_threads(nthreads_)
+      {
+        size_t tid = omp_get_thread_num();
+        if (threads_rows_nodes_wise_[tid].size() == 0) {
+          threads_rows_nodes_wise_[tid].resize(vec_rows_[tid].size(), 0);
+        }
+        nodes_count[tid].resize((1 << (max_depth_)) + 1, 0);
+        for (size_t i = 1; i < (1 << (max_depth_)); ++i) {
+          nodes_count[tid][i + 1] += nodes_count[tid][i] + threads_nodes_count[tid][i-1];
+        }
+        for (size_t i = 0; i < vec_rows_[tid][0]; ++i) {
+          const uint32_t row_id = vec_rows_[tid][i + 1];
+          const uint32_t nod_id = node_ids_[row_id];
+          threads_rows_nodes_wise_[tid][nodes_count[tid][nod_id + 1]++] = row_id;
+        }
+      }
+    }
+  }
+  void UpdateThreadsWork(const std::vector<uint16_t>& compleate_trees_depth_wise,
+                         GHistIndexMatrix const& gmat,
+                         size_t n_features, size_t depth, bool is_loss_guided) {
+    const size_t n_bins = gmat.cut.Ptrs().back();
+    threads_addr_.clear();
+    threads_addr_.resize(nthreads_);
+    const bool hist_fit_to_l2 = 1024*1024*0.8 > 16*gmat.cut.Ptrs().back();
+    if (is_loss_guided) {
+      const int cleft = compleate_trees_depth_wise[0];
+      const int cright = compleate_trees_depth_wise[1];
+      // template!
+      const uint32_t min_node_size = std::min(summ_size_, summ_size_remain_);
+      const uint32_t min_node_id = summ_size_ <= summ_size_remain_ ? cleft : cright;
+      uint32_t thread_size = std::max((uint32_t)(min_node_size/nthreads_ +
+                                      !!(min_node_size%nthreads_)),
+                                      std::min(min_node_size, (uint32_t)512));
+      for (size_t tid = 0; tid <  nthreads_; ++tid) {
+        uint32_t th_begin = thread_size * tid;
+        uint32_t th_end = std::min(th_begin + thread_size, min_node_size);
+        if (th_end > th_begin) {
+          threads_addr_[tid].push_back({row_indices_ptr_, partitions_[min_node_id].b + th_begin,
+                                       partitions_[min_node_id].b + th_end});
+          CHECK_LT(min_node_id, threads_id_for_nodes_.size());
+          threads_id_for_nodes_[min_node_id].push_back(tid);
+          node_id_for_threads_[tid].push_back(min_node_id);
+        }
+      }
+    } else if (n_features*summ_size_ / nthreads_ < (1 << (depth + 1))*n_bins
+               || (depth >= 1 && !hist_fit_to_l2)) {
+      uint32_t block_size = std::max((uint32_t)(summ_size_/nthreads_ + !!(summ_size_%nthreads_)),
+                                     std::min(summ_size_, (uint32_t)512));
+      uint32_t node_id = 0;
+      uint32_t curr_thread_size = block_size;
+      uint32_t curr_node_disp = 0;
+      uint32_t curr_thread_id = 0;
+      for (uint32_t i = 0; i < nthreads_; ++i) {
+        while (curr_thread_size != 0) {
+          const uint32_t curr_thread_node_size = threads_nodes_count[curr_thread_id%
+                                                                     nthreads_][node_id];
+          if (curr_thread_node_size == 0) {
+            ++curr_thread_id;
+            node_id = curr_thread_id / nthreads_;
+          } else if (curr_thread_node_size > 0 && curr_thread_node_size <= curr_thread_size) {
+            const uint32_t begin = nodes_count[curr_thread_id%nthreads_][node_id];
+            CHECK_EQ(nodes_count[curr_thread_id%nthreads_][node_id] + curr_thread_node_size,
+                    nodes_count[curr_thread_id%nthreads_][node_id+1]);
+            threads_addr_[i].push_back({
+              threads_rows_nodes_wise_[curr_thread_id%nthreads_].data(), begin,
+              begin + curr_thread_node_size
+            });
+            if (threads_id_for_nodes_[node_id].size() != 0) {
+              if (threads_id_for_nodes_[node_id].back() != i) {
+                threads_id_for_nodes_[node_id].push_back(i);
+                node_id_for_threads_[i].push_back(node_id);
+              }
+            } else {
+              threads_id_for_nodes_[node_id].push_back(i);
+              node_id_for_threads_[i].push_back(node_id);
+            }
+            threads_nodes_count[curr_thread_id%nthreads_][node_id] = 0;
+            curr_thread_size -= curr_thread_node_size;
+            ++curr_thread_id;
+            node_id = curr_thread_id / nthreads_;
+          } else {
+            const uint32_t begin = nodes_count[curr_thread_id%nthreads_][node_id];
+            CHECK_EQ(nodes_count[curr_thread_id%nthreads_][node_id] + curr_thread_node_size,
+                    nodes_count[curr_thread_id%nthreads_][node_id+1]);
+
+            threads_addr_[i].push_back({
+              threads_rows_nodes_wise_[curr_thread_id%nthreads_].data(), begin,
+              begin + curr_thread_size
+            });
+            if (threads_id_for_nodes_[node_id].size() != 0) {
+              if (threads_id_for_nodes_[node_id].back() != i) {
+                threads_id_for_nodes_[node_id].push_back(i);
+                node_id_for_threads_[i].push_back(node_id);
+              }
+            } else {
+              threads_id_for_nodes_[node_id].push_back(i);
+              node_id_for_threads_[i].push_back(node_id);
+            }
+            threads_nodes_count[curr_thread_id%nthreads_][node_id] -= curr_thread_size;
+            nodes_count[curr_thread_id%nthreads_][node_id] += curr_thread_size;
+            curr_thread_size = 0;
+          }
+        }
+        curr_thread_size = std::min(block_size,
+                                    summ_size_ > block_size*(i+1) ?
+                                    summ_size_ - block_size*(i+1) : 0);
+      }
+    } else {
+      uint32_t block_size = summ_size_/nthreads_ + !!(summ_size_%nthreads_);
+      uint32_t curr_vec_rows_id = 0;
+      uint32_t curr_vec_rows_size = vec_rows_[curr_vec_rows_id][0];
+      uint32_t curr_thread_size = block_size;
+      for (uint32_t i = 0; i < nthreads_; ++i) {
+        std::vector<uint32_t> borrowed_work;
+        while (curr_thread_size != 0) {
+          if (curr_vec_rows_size > curr_thread_size) {
+            threads_addr_[i].push_back({
+              vec_rows_[curr_vec_rows_id].data(),
+              1 + vec_rows_[curr_vec_rows_id][0] - curr_vec_rows_size,
+              1 + vec_rows_[curr_vec_rows_id][0] - curr_vec_rows_size + curr_thread_size});
+            borrowed_work.push_back(curr_vec_rows_id);
+            curr_vec_rows_size -= curr_thread_size;
+            curr_thread_size = 0;
+          } else if (curr_vec_rows_size == curr_thread_size) {
+            threads_addr_[i].push_back({
+              vec_rows_[curr_vec_rows_id].data(),
+              1 + vec_rows_[curr_vec_rows_id][0] - curr_vec_rows_size,
+              1 + vec_rows_[curr_vec_rows_id][0] - curr_vec_rows_size + curr_thread_size});
+            borrowed_work.push_back(curr_vec_rows_id);
+            curr_vec_rows_id += (curr_vec_rows_id < (nthreads_ - 1));
+            curr_vec_rows_size = vec_rows_[curr_vec_rows_id][0];
+            curr_thread_size = 0;
+          } else {
+            threads_addr_[i].push_back({vec_rows_[curr_vec_rows_id].data(),
+                                      1 + vec_rows_[curr_vec_rows_id][0] - curr_vec_rows_size,
+                                      1 + vec_rows_[curr_vec_rows_id][0]});
+            borrowed_work.push_back(curr_vec_rows_id);
+            curr_thread_size -= curr_vec_rows_size;
+            curr_vec_rows_id += (curr_vec_rows_id < (nthreads_ - 1));
+            curr_vec_rows_size = vec_rows_[curr_vec_rows_id][0];
+          }
+        }
+        curr_thread_size = std::min(block_size,
+                                    summ_size_ > block_size*(i+1) ?
+                                    summ_size_ - block_size*(i+1) : 0);
+        for (uint32_t id = 0; id < borrowed_work.size(); ++id) {
+          size_t borrowed_tid = borrowed_work[id];
+          for (size_t nid = 0; nid < compleate_trees_depth_wise.size(); ++nid) {
+            size_t node_id = compleate_trees_depth_wise[nid];
+            if (threads_nodes_count[borrowed_tid][node_id] != 0) {
+              if (threads_id_for_nodes_[node_id].size() != 0) {
+                if (threads_id_for_nodes_[node_id].back() != i) {
+                  threads_id_for_nodes_[node_id].push_back(i);
+                  node_id_for_threads_[i].push_back(node_id);
+                }
+              } else {
+                threads_id_for_nodes_[node_id].push_back(i);
+                node_id_for_threads_[i].push_back(node_id);
+            }
+            }
+          }
+        }
+      }
+    }
+    threads_nodes_count.clear();
+    threads_nodes_count.resize(nthreads_);
+    nodes_count.clear();
+  }
+  // template for uint32_t
+  void UpdateRootThreadWork(bool is_dense) {
+    threads_addr_.clear();
+    threads_addr_.resize(nthreads_);
+    threads_id_for_nodes_.clear();
+    threads_id_for_nodes_.resize(1);
+    node_id_for_threads_.clear();
+    node_id_for_threads_.resize(nthreads_);
+    const uint32_t n_rows = gmat_->row_ptr.size() - 1;
+    const uint32_t block_size = n_rows / nthreads_ + !!(n_rows % nthreads_);
+    for (uint32_t tid = 0; tid < nthreads_; ++tid) {
+      const uint32_t begin = tid * block_size;
+      const uint32_t end = std::min(begin + block_size, n_rows);
+      if (end > begin) {
+        threads_addr_[tid].push_back({nullptr, begin, end});
+        threads_id_for_nodes_[0].push_back(tid);
+        node_id_for_threads_[tid].push_back(0);
+      }
+    }
+  }
+};
+
+}  // namespace common
+}  // namespace xgboost
+
+#endif  // XGBOOST_COMMON_OPT_PARTITION_BUILDER_H_

--- a/src/common/opt_partition_builder.h
+++ b/src/common/opt_partition_builder.h
@@ -30,37 +30,36 @@ struct Slice {
 // template by number of rows
 class OptPartitionBuilder {
  public:
-  std::vector<std::vector<Slice>> threads_addr_;
-  std::vector<std::vector<uint16_t>> threads_id_for_nodes_;
-  std::vector<std::vector<uint16_t>> node_id_for_threads_;
-  std::vector<std::vector<uint32_t>> threads_rows_nodes_wise_;
+  std::vector<std::vector<Slice>> threads_addr;
+  std::vector<std::vector<uint16_t>> threads_id_for_nodes;
+  std::vector<std::vector<uint16_t>> node_id_for_threads;
+  std::vector<std::vector<uint32_t>> threads_rows_nodes_wise;
   std::vector<std::vector<uint32_t>> threads_nodes_count;
   std::vector<std::vector<int>> nodes_count;
-  std::vector<Slice> partitions_;
-  std::vector<std::vector<uint32_t>> vec_rows_;
-  std::vector<std::vector<uint32_t>> vec_rows_remain_;
-  std::vector<std::unique_ptr<const Column<uint8_t> >> columns8_;
-  std::vector<const DenseColumn<uint8_t, true>*> dcolumns8_;
-  std::vector<const SparseColumn<uint8_t>*> scolumns8_;
-  std::vector<std::unique_ptr<const Column<uint16_t> >> columns16_;
-  std::vector<const DenseColumn<uint16_t, true>*> dcolumns16_;
-  std::vector<const SparseColumn<uint16_t>*> scolumns16_;
-  std::vector<std::unique_ptr<const Column<uint32_t> >> columns32_;
-  std::vector<const DenseColumn<uint32_t, true>*> dcolumns32_;
-  std::vector<const SparseColumn<uint32_t>*> scolumns32_;
-  std::vector<std::vector<size_t> > states_;
-  const RegTree* p_tree_;
+  std::vector<Slice> partitions;
+  std::vector<std::vector<uint32_t>> vec_rows;
+  std::vector<std::vector<uint32_t>> vec_rows_remain;
+  std::vector<std::unique_ptr<const Column<uint8_t> >> columns8;
+  std::vector<const DenseColumn<uint8_t, true>*> dcolumns8;
+  std::vector<const SparseColumn<uint8_t>*> scolumns8;
+  std::vector<std::unique_ptr<const Column<uint16_t> >> columns16;
+  std::vector<const DenseColumn<uint16_t, true>*> dcolumns16;
+  std::vector<const SparseColumn<uint16_t>*> scolumns16;
+  std::vector<std::unique_ptr<const Column<uint32_t> >> columns32;
+  std::vector<const DenseColumn<uint32_t, true>*> dcolumns32;
+  std::vector<const SparseColumn<uint32_t>*> scolumns32;
+  std::vector<std::vector<size_t> > states;
+  const RegTree* p_tree;
   // can be common for all threads!
-  std::vector<std::vector<bool>> default_flags_;
-  const ColumnMatrix* column_matrix_;
-  const uint8_t* data_hash_;
-  std::vector<uint32_t> row_set_collection_vec_;
-  const GHistIndexMatrix* gmat_;
-  uint32_t* row_indices_ptr_;
-  size_t nthreads_ = 0;
-  uint32_t summ_size_ = 0;
-  uint32_t summ_size_remain_ = 0;
-  uint32_t max_depth_ = 0;
+  std::vector<std::vector<bool>> default_flags;
+  const uint8_t* data_hash;
+  std::vector<uint32_t> row_set_collection_vec;
+  uint32_t gmat_n_rows;
+  uint32_t* row_indices_ptr;
+  size_t n_threads = 0;
+  uint32_t summ_size = 0;
+  uint32_t summ_size_remain = 0;
+  uint32_t max_depth = 0;
 
   template<typename BinIdxType>
   std::vector<std::unique_ptr<const Column<BinIdxType> >>& GetColumnsRef() {
@@ -69,15 +68,15 @@ class OptPartitionBuilder {
   }
 
   std::vector<std::unique_ptr<const Column<uint8_t> >>& GetColumnsRefImpl(const uint8_t* dummy) {
-      return columns8_;
+      return columns8;
   }
 
   std::vector<std::unique_ptr<const Column<uint16_t> >>& GetColumnsRefImpl(const uint16_t* dummy) {
-      return columns16_;
+      return columns16;
   }
 
   std::vector<std::unique_ptr<const Column<uint32_t> >>& GetColumnsRefImpl(const uint32_t* dummy) {
-      return columns32_;
+      return columns32;
   }
 
   template<typename BinIdxType>
@@ -87,15 +86,15 @@ class OptPartitionBuilder {
   }
 
   std::vector<const DenseColumn<uint8_t, true>*>& GetDenseColumnsRefImpl(const uint8_t* dummy) {
-      return dcolumns8_;
+      return dcolumns8;
   }
 
   std::vector<const DenseColumn<uint16_t, true>*>& GetDenseColumnsRefImpl(const uint16_t* dummy) {
-      return dcolumns16_;
+      return dcolumns16;
   }
 
   std::vector<const DenseColumn<uint32_t, true>*>& GetDenseColumnsRefImpl(const uint32_t* dummy) {
-      return dcolumns32_;
+      return dcolumns32;
   }
 
   template<typename BinIdxType>
@@ -105,30 +104,30 @@ class OptPartitionBuilder {
   }
 
   std::vector<const SparseColumn<uint8_t>*>& GetSparseColumnsRefImpl(const uint8_t* dummy) {
-      return scolumns8_;
+      return scolumns8;
   }
 
   std::vector<const SparseColumn<uint16_t>*>& GetSparseColumnsRefImpl(const uint16_t* dummy) {
-      return scolumns16_;
+      return scolumns16;
   }
 
   std::vector<const SparseColumn<uint32_t>*>& GetSparseColumnsRefImpl(const uint32_t* dummy) {
-      return scolumns32_;
+      return scolumns32;
   }
 
   template <typename BinIdxType>
   void Init(GHistIndexMatrix const& gmat, const ColumnMatrix& column_matrix,
-            const RegTree* p_tree, size_t nthreads, size_t max_depth,
+            const RegTree* p_tree_local, size_t nthreads, size_t max_depth,
             size_t n_rows, bool is_lossguide) {
-    gmat_ = &gmat;
-    p_tree_ = p_tree;
-    if (states_.size() == 0 && !gmat.IsDense() ||
-        (data_hash_ != reinterpret_cast<const uint8_t*>(column_matrix.GetIndexData())
+    gmat_n_rows = gmat.row_ptr.size() - 1;
+    p_tree = p_tree_local;
+    if ((states.size() == 0 && !gmat.IsDense()) ||
+        (data_hash != reinterpret_cast<const uint8_t*>(column_matrix.GetIndexData())
         && !gmat.IsDense())) {
-      states_.clear();
-      default_flags_.clear();
-      states_.resize(nthreads);
-      default_flags_.resize(nthreads);
+      states.clear();
+      default_flags.clear();
+      states.resize(nthreads);
+      default_flags.resize(nthreads);
       GetColumnsRef<BinIdxType>().resize(column_matrix.GetNumFeature());
       GetDenseColumnsRef<BinIdxType>().resize(column_matrix.GetNumFeature());
       GetSparseColumnsRef<BinIdxType>().resize(column_matrix.GetNumFeature());
@@ -140,38 +139,37 @@ class OptPartitionBuilder {
           dynamic_cast<const SparseColumn<BinIdxType>*>(GetColumnsRef<BinIdxType>()[fid].get());
       }
       for (size_t tid = 0; tid < nthreads; ++tid) {
-        states_[tid].resize(1 << (max_depth + 1), 0);
-        default_flags_[tid].resize(1 << (max_depth + 1), false);
+        states[tid].resize(1 << (max_depth + 1), 0);
+        default_flags[tid].resize(1 << (max_depth + 1), false);
       }
     }
-    column_matrix_ = &column_matrix;
-    data_hash_ = reinterpret_cast<const uint8_t*>(column_matrix.GetIndexData());
-    nthreads_ = nthreads;
-    max_depth_ = max_depth;
-    vec_rows_.resize(nthreads);
+    data_hash = reinterpret_cast<const uint8_t*>(column_matrix.GetIndexData());
+    n_threads = nthreads;
+    this->max_depth = max_depth;
+    vec_rows.resize(nthreads);
     if (is_lossguide) {
-      partitions_.resize(1 << (max_depth + 2));
-      vec_rows_remain_.resize(nthreads);
+      partitions.resize(1 << (max_depth + 2));
+      vec_rows_remain.resize(nthreads);
     } else {
       threads_nodes_count.clear();
-      threads_nodes_count.resize(nthreads_);
+      threads_nodes_count.resize(n_threads);
     }
-    if (vec_rows_[0].size() == 0) {
+    if (vec_rows[0].size() == 0) {
       size_t chunck_size = n_rows / nthreads + !!(n_rows % nthreads);
-    #pragma omp parallel num_threads(nthreads_)
+    #pragma omp parallel num_threads(n_threads)
       {
         size_t tid = omp_get_thread_num();
-        if (vec_rows_[tid].size() == 0) {
-          vec_rows_[tid].resize(chunck_size + 2, 0);
+        if (vec_rows[tid].size() == 0) {
+          vec_rows[tid].resize(chunck_size + 2, 0);
           if (is_lossguide) {
-            vec_rows_remain_[tid].resize(chunck_size + 2, 0);
+            vec_rows_remain[tid].resize(chunck_size + 2, 0);
           }
         }
       }
     }
-    threads_addr_.clear();
-    threads_id_for_nodes_.clear();
-    node_id_for_threads_.clear();
+    threads_addr.clear();
+    threads_id_for_nodes.clear();
+    node_id_for_threads.clear();
     nodes_count.clear();
   }
 
@@ -190,13 +188,13 @@ class OptPartitionBuilder {
     const auto& sparse_columns = GetSparseColumnsRef<BinIdxType>();
     uint32_t count = 0;
     uint32_t count2 = 0;
-    uint32_t* rows = vec_rows_[tid].data();
+    uint32_t* rows = vec_rows[tid].data();
     uint32_t* rows_left = nullptr;
     if (is_loss_guided) {
-      rows_left = vec_rows_remain_[tid].data();
+      rows_left = vec_rows_remain[tid].data();
     }
     if (!is_loss_guided) {
-      threads_nodes_count[tid].resize(1 << (max_depth_ + 1), 0);
+      threads_nodes_count[tid].resize(1 << (max_depth + 1), 0);
     }
     uint32_t* nodes_count = threads_nodes_count[tid].data();
     uint16_t* curr_level_nodes_data = curr_level_nodes->data();
@@ -205,26 +203,25 @@ class OptPartitionBuilder {
     const BinIdxType* columnar_data = numa;
 
     if (!all_dense) {
-      std::vector<size_t>& local_states = states_[tid];
-      std::vector<bool>& local_default_flags = default_flags_[tid];
+      std::vector<size_t>& local_states = states[tid];
+      std::vector<bool>& local_default_flags = default_flags[tid];
       const uint32_t first_row_id = !is_loss_guided ? row_indices_begin :
-                                                      row_indices_ptr_[row_indices_begin];
-      for (size_t i = 0; i < split_nodes.size(); ++i) {
-        size_t nid = split_nodes[i];
+                                                      row_indices_ptr[row_indices_begin];
+      for (const auto& nid : split_nodes) {
         if (columns[split_ind_data[nid]]->GetType() == common::kDenseColumn) {
           local_states[nid] = dense_columns[split_ind_data[nid]]->GetInitialState(first_row_id);
         } else {
           local_states[nid] = sparse_columns[split_ind_data[nid]]->GetInitialState(first_row_id);
         }
-        local_default_flags[nid] = (*p_tree_)[nid].DefaultLeft();
+        local_default_flags[nid] = (*p_tree)[nid].DefaultLeft();
       }
     }
     const float* pgh = reinterpret_cast<const float*>(gpair_h.data());
     for (size_t ii = row_indices_begin; ii < row_indices_end; ++ii) {
-      const uint32_t i = !is_loss_guided ? ii : row_indices_ptr_[ii];
+      const uint32_t i = !is_loss_guided ? ii : row_indices_ptr[ii];
       const uint32_t nid = nodes_ids[i];
 
-      if (((uint16_t)(1) << 15 & nid)) {
+      if ((static_cast<uint16_t>(1) << 15 & nid)) {
         continue;
       }
       const int32_t sc = split_conditions_data[nid];
@@ -233,8 +230,8 @@ class OptPartitionBuilder {
         const int32_t cmp_value = static_cast<int32_t>(columnar_data[split_ind_data[nid] + i]);
         nodes_ids[i] = (curr_level_nodes_data[2*nid + !(cmp_value <= sc)]);
       } else {
-        std::vector<size_t>& local_states = states_[tid];
-        std::vector<bool>& local_default_flags = default_flags_[tid];
+        std::vector<size_t>& local_states = states[tid];
+        std::vector<bool>& local_default_flags = default_flags[tid];
         int32_t cmp_value = 0;
         if (columns[split_ind_data[nid]]->GetType() == common::kDenseColumn) {
           cmp_value = dense_columns[split_ind_data[nid]]->GetBinIdx(i, nullptr);
@@ -274,7 +271,7 @@ class OptPartitionBuilder {
                    const std::vector<uint16_t>& compleate_trees_depth_wise,
                    const RegTree* p_tree, bool is_lossguided) {
     if (is_lossguided) {
-      return partitions_[(*p_tree)[compleate_trees_depth_wise[0]].Parent()].Size();
+      return partitions[(*p_tree)[compleate_trees_depth_wise[0]].Parent()].Size();
     } else {
       return gmat.row_ptr.size() - 1;
     }
@@ -282,96 +279,96 @@ class OptPartitionBuilder {
   size_t DepthBegin(const std::vector<uint16_t>& compleate_trees_depth_wise,
                     const RegTree* p_tree, bool is_lossguided) {
     if (is_lossguided) {
-      return partitions_[(*p_tree)[compleate_trees_depth_wise[0]].Parent()].b;
+      return partitions[(*p_tree)[compleate_trees_depth_wise[0]].Parent()].b;
     } else {
       return 0;
     }
   }
 
   void ResizeRowsBuffer(size_t nrows) {
-    row_set_collection_vec_.resize(nrows);
-    row_indices_ptr_ = row_set_collection_vec_.data();
+    row_set_collection_vec.resize(nrows);
+    row_indices_ptr = row_set_collection_vec.data();
   }
 
   uint32_t* GetRowsBuffer() const {
-    return row_indices_ptr_;
+    return row_indices_ptr;
   }
 
   void SetSlice(size_t nid, uint32_t begin, uint32_t size) {
-    if (partitions_.size()) {
-      partitions_[nid].b = begin;
-      partitions_[nid].e = begin + size;
+    if (partitions.size()) {
+      partitions[nid].b = begin;
+      partitions[nid].e = begin + size;
     }
   }
   void UpdateRowBuffer(const std::vector<uint16_t>& compleate_trees_depth_wise,
                        const RegTree* p_tree,
                        GHistIndexMatrix const& gmat, size_t n_features, size_t depth,
                        const std::vector<uint16_t>& node_ids_, bool is_loss_guided) {
-    summ_size_ = 0;
-    summ_size_remain_ = 0;
-    for (uint32_t i = 0; i < nthreads_; ++i) {
-      summ_size_ += vec_rows_[i][0];
+    summ_size = 0;
+    summ_size_remain = 0;
+    for (uint32_t i = 0; i < n_threads; ++i) {
+      summ_size += vec_rows[i][0];
     }
     const bool hist_fit_to_l2 = 1024*1024*0.8 > 16*gmat.cut.Ptrs().back();
     const size_t n_bins = gmat.cut.Ptrs().back();
-    threads_id_for_nodes_.clear();
+    threads_id_for_nodes.clear();
     nodes_count.clear();
     const size_t inc = (is_loss_guided == true);
-    threads_id_for_nodes_.resize(1 << (max_depth_ + inc));
-    node_id_for_threads_.clear();
-    node_id_for_threads_.resize(nthreads_);
+    threads_id_for_nodes.resize(1 << (max_depth + inc));
+    node_id_for_threads.clear();
+    node_id_for_threads.resize(n_threads);
     if (is_loss_guided) {
       const int cleft = compleate_trees_depth_wise[0];
       const int cright = compleate_trees_depth_wise[1];
       const int parent_id = (*p_tree)[cleft].Parent();
-      const size_t parent_begin = partitions_[parent_id].b;
-      const size_t parent_size = partitions_[parent_id].Size();
+      const size_t parent_begin = partitions[parent_id].b;
+      const size_t parent_size = partitions[parent_id].Size();
 
-      for (uint32_t i = 0; i < nthreads_; ++i) {
-        summ_size_remain_ += vec_rows_remain_[i][0];
+      for (uint32_t i = 0; i < n_threads; ++i) {
+        summ_size_remain += vec_rows_remain[i][0];
       }
-      CHECK_EQ(summ_size_ + summ_size_remain_, parent_size);
-      SetSlice(cleft, partitions_[parent_id].b, summ_size_);
-      SetSlice(cright, partitions_[parent_id].b + summ_size_, summ_size_remain_);
+      CHECK_EQ(summ_size + summ_size_remain, parent_size);
+      SetSlice(cleft, partitions[parent_id].b, summ_size);
+      SetSlice(cright, partitions[parent_id].b + summ_size, summ_size_remain);
 
-      #pragma omp parallel num_threads(nthreads_)
+      #pragma omp parallel num_threads(n_threads)
       {
         uint32_t tid = omp_get_thread_num();
         uint32_t thread_displace = parent_begin;
         for (size_t id = 0; id < tid; ++id) {
-          thread_displace += vec_rows_[id][0];
+          thread_displace += vec_rows[id][0];
         }
-        CHECK_LE(thread_displace + vec_rows_[tid][0], parent_begin + summ_size_);
-        std::copy(vec_rows_[tid].data() + 1,
-                  vec_rows_[tid].data() + 1 + vec_rows_[tid][0],
-                  row_indices_ptr_ + thread_displace);
-        uint32_t thread_displace_left = parent_begin + summ_size_;
+        CHECK_LE(thread_displace + vec_rows[tid][0], parent_begin + summ_size);
+        std::copy(vec_rows[tid].data() + 1,
+                  vec_rows[tid].data() + 1 + vec_rows[tid][0],
+                  row_indices_ptr + thread_displace);
+        uint32_t thread_displace_left = parent_begin + summ_size;
         for (size_t id = 0; id < tid; ++id) {
-          thread_displace_left += vec_rows_remain_[id][0];
+          thread_displace_left += vec_rows_remain[id][0];
         }
-        CHECK_LE(thread_displace_left + vec_rows_remain_[tid][0], parent_begin + parent_size);
-        std::copy(vec_rows_remain_[tid].data() + 1,
-                  vec_rows_remain_[tid].data() + 1 + vec_rows_remain_[tid][0],
-                  row_indices_ptr_ + thread_displace_left);
+        CHECK_LE(thread_displace_left + vec_rows_remain[tid][0], parent_begin + parent_size);
+        std::copy(vec_rows_remain[tid].data() + 1,
+                  vec_rows_remain[tid].data() + 1 + vec_rows_remain[tid][0],
+                  row_indices_ptr + thread_displace_left);
       }
-    } else if (n_features*summ_size_ / nthreads_ < (1 << (depth + 1))*n_bins ||
+    } else if (n_features*summ_size / n_threads < (1 << (depth + 1))*n_bins ||
                (depth >= 1 && !hist_fit_to_l2)) {
-      threads_rows_nodes_wise_.resize(nthreads_);
-      nodes_count.resize(nthreads_);
-      #pragma omp parallel num_threads(nthreads_)
+      threads_rows_nodes_wise.resize(n_threads);
+      nodes_count.resize(n_threads);
+      #pragma omp parallel num_threads(n_threads)
       {
         size_t tid = omp_get_thread_num();
-        if (threads_rows_nodes_wise_[tid].size() == 0) {
-          threads_rows_nodes_wise_[tid].resize(vec_rows_[tid].size(), 0);
+        if (threads_rows_nodes_wise[tid].size() == 0) {
+          threads_rows_nodes_wise[tid].resize(vec_rows[tid].size(), 0);
         }
-        nodes_count[tid].resize((1 << (max_depth_)) + 1, 0);
-        for (size_t i = 1; i < (1 << (max_depth_)); ++i) {
+        nodes_count[tid].resize((1 << (max_depth)) + 1, 0);
+        for (size_t i = 1; i < (1 << (max_depth)); ++i) {
           nodes_count[tid][i + 1] += nodes_count[tid][i] + threads_nodes_count[tid][i-1];
         }
-        for (size_t i = 0; i < vec_rows_[tid][0]; ++i) {
-          const uint32_t row_id = vec_rows_[tid][i + 1];
+        for (size_t i = 0; i < vec_rows[tid][0]; ++i) {
+          const uint32_t row_id = vec_rows[tid][i + 1];
           const uint32_t nod_id = node_ids_[row_id];
-          threads_rows_nodes_wise_[tid][nodes_count[tid][nod_id + 1]++] = row_id;
+          threads_rows_nodes_wise[tid][nodes_count[tid][nod_id + 1]++] = row_id;
         }
       }
     }
@@ -380,143 +377,142 @@ class OptPartitionBuilder {
                          GHistIndexMatrix const& gmat,
                          size_t n_features, size_t depth, bool is_loss_guided) {
     const size_t n_bins = gmat.cut.Ptrs().back();
-    threads_addr_.clear();
-    threads_addr_.resize(nthreads_);
+    threads_addr.clear();
+    threads_addr.resize(n_threads);
     const bool hist_fit_to_l2 = 1024*1024*0.8 > 16*gmat.cut.Ptrs().back();
     if (is_loss_guided) {
       const int cleft = compleate_trees_depth_wise[0];
       const int cright = compleate_trees_depth_wise[1];
       // template!
-      const uint32_t min_node_size = std::min(summ_size_, summ_size_remain_);
-      const uint32_t min_node_id = summ_size_ <= summ_size_remain_ ? cleft : cright;
-      uint32_t thread_size = std::max((uint32_t)(min_node_size/nthreads_ +
-                                      !!(min_node_size%nthreads_)),
-                                      std::min(min_node_size, (uint32_t)512));
-      for (size_t tid = 0; tid <  nthreads_; ++tid) {
+      const uint32_t min_node_size = std::min(summ_size, summ_size_remain);
+      const uint32_t min_node_id = summ_size <= summ_size_remain ? cleft : cright;
+      uint32_t thread_size = std::max(static_cast<uint32_t>(min_node_size/n_threads +
+                                      !!(min_node_size%n_threads)),
+                                      std::min(min_node_size, static_cast<uint32_t>(512)));
+      for (size_t tid = 0; tid <  n_threads; ++tid) {
         uint32_t th_begin = thread_size * tid;
         uint32_t th_end = std::min(th_begin + thread_size, min_node_size);
         if (th_end > th_begin) {
-          threads_addr_[tid].push_back({row_indices_ptr_, partitions_[min_node_id].b + th_begin,
-                                       partitions_[min_node_id].b + th_end});
-          CHECK_LT(min_node_id, threads_id_for_nodes_.size());
-          threads_id_for_nodes_[min_node_id].push_back(tid);
-          node_id_for_threads_[tid].push_back(min_node_id);
+          threads_addr[tid].push_back({row_indices_ptr, partitions[min_node_id].b + th_begin,
+                                       partitions[min_node_id].b + th_end});
+          CHECK_LT(min_node_id, threads_id_for_nodes.size());
+          threads_id_for_nodes[min_node_id].push_back(tid);
+          node_id_for_threads[tid].push_back(min_node_id);
         }
       }
-    } else if (n_features*summ_size_ / nthreads_ < (1 << (depth + 1))*n_bins
+    } else if (n_features*summ_size / n_threads < (1 << (depth + 1))*n_bins
                || (depth >= 1 && !hist_fit_to_l2)) {
-      uint32_t block_size = std::max((uint32_t)(summ_size_/nthreads_ + !!(summ_size_%nthreads_)),
-                                     std::min(summ_size_, (uint32_t)512));
+      uint32_t block_size = std::max(static_cast<uint32_t>(summ_size/n_threads +
+                                     !!(summ_size%n_threads)),
+                                     std::min(summ_size, static_cast<uint32_t>(512)));
       uint32_t node_id = 0;
       uint32_t curr_thread_size = block_size;
       uint32_t curr_node_disp = 0;
       uint32_t curr_thread_id = 0;
-      for (uint32_t i = 0; i < nthreads_; ++i) {
+      for (uint32_t i = 0; i < n_threads; ++i) {
         while (curr_thread_size != 0) {
           const uint32_t curr_thread_node_size = threads_nodes_count[curr_thread_id%
-                                                                     nthreads_][node_id];
+                                                                     n_threads][node_id];
           if (curr_thread_node_size == 0) {
             ++curr_thread_id;
-            node_id = curr_thread_id / nthreads_;
+            node_id = curr_thread_id / n_threads;
           } else if (curr_thread_node_size > 0 && curr_thread_node_size <= curr_thread_size) {
-            const uint32_t begin = nodes_count[curr_thread_id%nthreads_][node_id];
-            CHECK_EQ(nodes_count[curr_thread_id%nthreads_][node_id] + curr_thread_node_size,
-                    nodes_count[curr_thread_id%nthreads_][node_id+1]);
-            threads_addr_[i].push_back({
-              threads_rows_nodes_wise_[curr_thread_id%nthreads_].data(), begin,
+            const uint32_t begin = nodes_count[curr_thread_id%n_threads][node_id];
+            CHECK_EQ(nodes_count[curr_thread_id%n_threads][node_id] + curr_thread_node_size,
+                    nodes_count[curr_thread_id%n_threads][node_id+1]);
+            threads_addr[i].push_back({
+              threads_rows_nodes_wise[curr_thread_id%n_threads].data(), begin,
               begin + curr_thread_node_size
             });
-            if (threads_id_for_nodes_[node_id].size() != 0) {
-              if (threads_id_for_nodes_[node_id].back() != i) {
-                threads_id_for_nodes_[node_id].push_back(i);
-                node_id_for_threads_[i].push_back(node_id);
+            if (threads_id_for_nodes[node_id].size() != 0) {
+              if (threads_id_for_nodes[node_id].back() != i) {
+                threads_id_for_nodes[node_id].push_back(i);
+                node_id_for_threads[i].push_back(node_id);
               }
             } else {
-              threads_id_for_nodes_[node_id].push_back(i);
-              node_id_for_threads_[i].push_back(node_id);
+              threads_id_for_nodes[node_id].push_back(i);
+              node_id_for_threads[i].push_back(node_id);
             }
-            threads_nodes_count[curr_thread_id%nthreads_][node_id] = 0;
+            threads_nodes_count[curr_thread_id%n_threads][node_id] = 0;
             curr_thread_size -= curr_thread_node_size;
             ++curr_thread_id;
-            node_id = curr_thread_id / nthreads_;
+            node_id = curr_thread_id / n_threads;
           } else {
-            const uint32_t begin = nodes_count[curr_thread_id%nthreads_][node_id];
-            CHECK_EQ(nodes_count[curr_thread_id%nthreads_][node_id] + curr_thread_node_size,
-                    nodes_count[curr_thread_id%nthreads_][node_id+1]);
+            const uint32_t begin = nodes_count[curr_thread_id%n_threads][node_id];
+            CHECK_EQ(nodes_count[curr_thread_id%n_threads][node_id] + curr_thread_node_size,
+                    nodes_count[curr_thread_id%n_threads][node_id+1]);
 
-            threads_addr_[i].push_back({
-              threads_rows_nodes_wise_[curr_thread_id%nthreads_].data(), begin,
+            threads_addr[i].push_back({
+              threads_rows_nodes_wise[curr_thread_id%n_threads].data(), begin,
               begin + curr_thread_size
             });
-            if (threads_id_for_nodes_[node_id].size() != 0) {
-              if (threads_id_for_nodes_[node_id].back() != i) {
-                threads_id_for_nodes_[node_id].push_back(i);
-                node_id_for_threads_[i].push_back(node_id);
+            if (threads_id_for_nodes[node_id].size() != 0) {
+              if (threads_id_for_nodes[node_id].back() != i) {
+                threads_id_for_nodes[node_id].push_back(i);
+                node_id_for_threads[i].push_back(node_id);
               }
             } else {
-              threads_id_for_nodes_[node_id].push_back(i);
-              node_id_for_threads_[i].push_back(node_id);
+              threads_id_for_nodes[node_id].push_back(i);
+              node_id_for_threads[i].push_back(node_id);
             }
-            threads_nodes_count[curr_thread_id%nthreads_][node_id] -= curr_thread_size;
-            nodes_count[curr_thread_id%nthreads_][node_id] += curr_thread_size;
+            threads_nodes_count[curr_thread_id%n_threads][node_id] -= curr_thread_size;
+            nodes_count[curr_thread_id%n_threads][node_id] += curr_thread_size;
             curr_thread_size = 0;
           }
         }
         curr_thread_size = std::min(block_size,
-                                    summ_size_ > block_size*(i+1) ?
-                                    summ_size_ - block_size*(i+1) : 0);
+                                    summ_size > block_size*(i+1) ?
+                                    summ_size - block_size*(i+1) : 0);
       }
     } else {
-      uint32_t block_size = summ_size_/nthreads_ + !!(summ_size_%nthreads_);
-      uint32_t curr_vec_rows_id = 0;
-      uint32_t curr_vec_rows_size = vec_rows_[curr_vec_rows_id][0];
+      uint32_t block_size = summ_size/n_threads + !!(summ_size%n_threads);
+      uint32_t curr_vec_rowsid = 0;
+      uint32_t curr_vec_rowssize = vec_rows[curr_vec_rowsid][0];
       uint32_t curr_thread_size = block_size;
-      for (uint32_t i = 0; i < nthreads_; ++i) {
+      for (uint32_t i = 0; i < n_threads; ++i) {
         std::vector<uint32_t> borrowed_work;
         while (curr_thread_size != 0) {
-          if (curr_vec_rows_size > curr_thread_size) {
-            threads_addr_[i].push_back({
-              vec_rows_[curr_vec_rows_id].data(),
-              1 + vec_rows_[curr_vec_rows_id][0] - curr_vec_rows_size,
-              1 + vec_rows_[curr_vec_rows_id][0] - curr_vec_rows_size + curr_thread_size});
-            borrowed_work.push_back(curr_vec_rows_id);
-            curr_vec_rows_size -= curr_thread_size;
+          if (curr_vec_rowssize > curr_thread_size) {
+            threads_addr[i].push_back({
+              vec_rows[curr_vec_rowsid].data(),
+              1 + vec_rows[curr_vec_rowsid][0] - curr_vec_rowssize,
+              1 + vec_rows[curr_vec_rowsid][0] - curr_vec_rowssize + curr_thread_size});
+            borrowed_work.push_back(curr_vec_rowsid);
+            curr_vec_rowssize -= curr_thread_size;
             curr_thread_size = 0;
-          } else if (curr_vec_rows_size == curr_thread_size) {
-            threads_addr_[i].push_back({
-              vec_rows_[curr_vec_rows_id].data(),
-              1 + vec_rows_[curr_vec_rows_id][0] - curr_vec_rows_size,
-              1 + vec_rows_[curr_vec_rows_id][0] - curr_vec_rows_size + curr_thread_size});
-            borrowed_work.push_back(curr_vec_rows_id);
-            curr_vec_rows_id += (curr_vec_rows_id < (nthreads_ - 1));
-            curr_vec_rows_size = vec_rows_[curr_vec_rows_id][0];
+          } else if (curr_vec_rowssize == curr_thread_size) {
+            threads_addr[i].push_back({
+              vec_rows[curr_vec_rowsid].data(),
+              1 + vec_rows[curr_vec_rowsid][0] - curr_vec_rowssize,
+              1 + vec_rows[curr_vec_rowsid][0] - curr_vec_rowssize + curr_thread_size});
+            borrowed_work.push_back(curr_vec_rowsid);
+            curr_vec_rowsid += (curr_vec_rowsid < (n_threads - 1));
+            curr_vec_rowssize = vec_rows[curr_vec_rowsid][0];
             curr_thread_size = 0;
           } else {
-            threads_addr_[i].push_back({vec_rows_[curr_vec_rows_id].data(),
-                                      1 + vec_rows_[curr_vec_rows_id][0] - curr_vec_rows_size,
-                                      1 + vec_rows_[curr_vec_rows_id][0]});
-            borrowed_work.push_back(curr_vec_rows_id);
-            curr_thread_size -= curr_vec_rows_size;
-            curr_vec_rows_id += (curr_vec_rows_id < (nthreads_ - 1));
-            curr_vec_rows_size = vec_rows_[curr_vec_rows_id][0];
+            threads_addr[i].push_back({vec_rows[curr_vec_rowsid].data(),
+                                      1 + vec_rows[curr_vec_rowsid][0] - curr_vec_rowssize,
+                                      1 + vec_rows[curr_vec_rowsid][0]});
+            borrowed_work.push_back(curr_vec_rowsid);
+            curr_thread_size -= curr_vec_rowssize;
+            curr_vec_rowsid += (curr_vec_rowsid < (n_threads - 1));
+            curr_vec_rowssize = vec_rows[curr_vec_rowsid][0];
           }
         }
         curr_thread_size = std::min(block_size,
-                                    summ_size_ > block_size*(i+1) ?
-                                    summ_size_ - block_size*(i+1) : 0);
-        for (uint32_t id = 0; id < borrowed_work.size(); ++id) {
-          size_t borrowed_tid = borrowed_work[id];
-          for (size_t nid = 0; nid < compleate_trees_depth_wise.size(); ++nid) {
-            size_t node_id = compleate_trees_depth_wise[nid];
+                                    summ_size > block_size*(i+1) ?
+                                    summ_size - block_size*(i+1) : 0);
+        for (const auto& borrowed_tid : borrowed_work) {
+          for (const auto& node_id : compleate_trees_depth_wise) {
             if (threads_nodes_count[borrowed_tid][node_id] != 0) {
-              if (threads_id_for_nodes_[node_id].size() != 0) {
-                if (threads_id_for_nodes_[node_id].back() != i) {
-                  threads_id_for_nodes_[node_id].push_back(i);
-                  node_id_for_threads_[i].push_back(node_id);
+              if (threads_id_for_nodes[node_id].size() != 0) {
+                if (threads_id_for_nodes[node_id].back() != i) {
+                  threads_id_for_nodes[node_id].push_back(i);
+                  node_id_for_threads[i].push_back(node_id);
                 }
               } else {
-                threads_id_for_nodes_[node_id].push_back(i);
-                node_id_for_threads_[i].push_back(node_id);
+                threads_id_for_nodes[node_id].push_back(i);
+                node_id_for_threads[i].push_back(node_id);
             }
             }
           }
@@ -524,26 +520,26 @@ class OptPartitionBuilder {
       }
     }
     threads_nodes_count.clear();
-    threads_nodes_count.resize(nthreads_);
+    threads_nodes_count.resize(n_threads);
     nodes_count.clear();
   }
   // template for uint32_t
   void UpdateRootThreadWork(bool is_dense) {
-    threads_addr_.clear();
-    threads_addr_.resize(nthreads_);
-    threads_id_for_nodes_.clear();
-    threads_id_for_nodes_.resize(1);
-    node_id_for_threads_.clear();
-    node_id_for_threads_.resize(nthreads_);
-    const uint32_t n_rows = gmat_->row_ptr.size() - 1;
-    const uint32_t block_size = n_rows / nthreads_ + !!(n_rows % nthreads_);
-    for (uint32_t tid = 0; tid < nthreads_; ++tid) {
+    threads_addr.clear();
+    threads_addr.resize(n_threads);
+    threads_id_for_nodes.clear();
+    threads_id_for_nodes.resize(1);
+    node_id_for_threads.clear();
+    node_id_for_threads.resize(n_threads);
+    const uint32_t n_rows = gmat_n_rows;
+    const uint32_t block_size = n_rows / n_threads + !!(n_rows % n_threads);
+    for (uint32_t tid = 0; tid < n_threads; ++tid) {
       const uint32_t begin = tid * block_size;
       const uint32_t end = std::min(begin + block_size, n_rows);
       if (end > begin) {
-        threads_addr_[tid].push_back({nullptr, begin, end});
-        threads_id_for_nodes_[0].push_back(tid);
-        node_id_for_threads_[tid].push_back(0);
+        threads_addr[tid].push_back({nullptr, begin, end});
+        threads_id_for_nodes[0].push_back(tid);
+        node_id_for_threads[tid].push_back(0);
       }
     }
   }

--- a/src/common/prefetch.h
+++ b/src/common/prefetch.h
@@ -1,0 +1,46 @@
+/*!
+ * Copyright 2017-2021 by Contributors
+ * \file prefetch.h
+ */
+#ifndef XGBOOST_COMMON_PREFETCH_H_
+#define XGBOOST_COMMON_PREFETCH_H_
+
+#include <algorithm>
+#include "../data/gradient_index.h"
+
+#if defined(XGBOOST_MM_PREFETCH_PRESENT)
+  #include <xmmintrin.h>
+  #define PREFETCH_READ_T0(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
+#elif defined(XGBOOST_BUILTIN_PREFETCH_PRESENT)
+  #define PREFETCH_READ_T0(addr) __builtin_prefetch(reinterpret_cast<const char*>(addr), 0, 3)
+#else  // no SW pre-fetching available; PREFETCH_READ_T0 is no-op
+  #define PREFETCH_READ_T0(addr) do {} while (0)
+#endif  // defined(XGBOOST_MM_PREFETCH_PRESENT)
+
+namespace xgboost {
+namespace common {
+
+struct Prefetch {
+ public:
+  static constexpr size_t kCacheLineSize = 64;
+  static constexpr size_t kPrefetchOffset = 10;
+
+ private:
+  static constexpr size_t kNoPrefetchSize =
+      kPrefetchOffset + kCacheLineSize /
+      sizeof(decltype(GHistIndexMatrix::row_ptr)::value_type);
+
+ public:
+  static size_t NoPrefetchSize(size_t rows) {
+    return std::min(rows, kNoPrefetchSize);
+  }
+
+  template <typename T>
+  static constexpr size_t GetPrefetchStep() {
+    return Prefetch::kCacheLineSize / sizeof(T);
+  }
+};
+
+}  // namespace common
+}  // namespace xgboost
+#endif  // XGBOOST_COMMON_PREFETCH_H_

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -9,6 +9,7 @@
 
 namespace xgboost {
 void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins) {
+  monitor_.Start("GHistIndexMatrix::Init");
   cut = common::SketchOnDMatrix(p_fmat, max_bins);
 
   max_num_bins = max_bins;
@@ -103,36 +104,58 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins) {
     if (isDense) {
       common::BinTypeSize curent_bin_size = index.GetBinTypeSize();
       if (curent_bin_size == common::kUint8BinsTypeSize) {
-        common::Span<uint8_t> index_data_span = {index.data<uint8_t>(),
+        common::Span<uint8_t> index_data_span = {index.Data<uint8_t>(),
                                                  n_index};
-        SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
-                     [offsets](auto idx, auto j) {
-                       return static_cast<uint8_t>(idx - offsets[j]);
-                     });
+        common::Span<uint8_t> index_second_data_span = {index.SecondData<uint8_t>(),
+                                                 n_index};
+        auto get_offset = [offsets](auto idx, auto j) {
+          return static_cast<uint8_t>(idx - offsets[j]);
+        };
+        SetIndexData<uint8_t, decltype(get_offset), true>(index_data_span,
+                                                         index_second_data_span,
+                                                         batch_threads, batch,
+                                                         rbegin, nbins,
+                                                         get_offset);
 
       } else if (curent_bin_size == common::kUint16BinsTypeSize) {
-        common::Span<uint16_t> index_data_span = {index.data<uint16_t>(),
+        common::Span<uint16_t> index_data_span = {index.Data<uint16_t>(),
                                                   n_index};
-        SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
-                     [offsets](auto idx, auto j) {
-                       return static_cast<uint16_t>(idx - offsets[j]);
-                     });
+        common::Span<uint16_t> index_second_data_span = {index.SecondData<uint16_t>(),
+                                                  n_index};
+        auto get_offset = [offsets](auto idx, auto j) {
+          return static_cast<uint16_t>(idx - offsets[j]);
+        };
+        SetIndexData<uint16_t, decltype(get_offset), true>(index_data_span,
+                                                          index_second_data_span,
+                                                          batch_threads, batch,
+                                                          rbegin, nbins, get_offset);
       } else {
         CHECK_EQ(curent_bin_size, common::kUint32BinsTypeSize);
-        common::Span<uint32_t> index_data_span = {index.data<uint32_t>(),
+        common::Span<uint32_t> index_data_span = {index.Data<uint32_t>(),
                                                   n_index};
-        SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
-                     [offsets](auto idx, auto j) {
-                       return static_cast<uint32_t>(idx - offsets[j]);
-                     });
+        common::Span<uint32_t> index_second_data_span = {index.SecondData<uint32_t>(),
+                                                  n_index};
+        auto get_offset = [offsets](auto idx, auto j) {
+          return static_cast<uint32_t>(idx - offsets[j]);
+        };
+        SetIndexData<uint32_t, decltype(get_offset), true>(index_data_span,
+                                                          index_second_data_span,
+                                                          batch_threads, batch,
+                                                          rbegin, nbins, get_offset);
       }
 
     /* For sparse DMatrix we have to store index of feature for each bin
        in index field to chose right offset. So offset is nullptr and index is not reduced */
     } else {
-      common::Span<uint32_t> index_data_span = {index.data<uint32_t>(), n_index};
-      SetIndexData(index_data_span, batch_threads, batch, rbegin, nbins,
-                   [](auto idx, auto) { return idx; });
+      common::Span<uint32_t> index_data_span = {index.Data<uint32_t>(), n_index};
+      common::Span<uint32_t> index_second_data_span = {index.Data<uint32_t>(), n_index};
+      auto get_offset = [offsets](auto idx, auto) {
+        return idx;
+      };
+      SetIndexData<uint32_t, decltype(get_offset), false>(index_data_span,
+                                                        index_second_data_span,
+                                                        batch_threads, batch,
+                                                        rbegin, nbins, get_offset);
     }
 
     common::ParallelFor(bst_omp_uint(nbins), nthread, [&](bst_omp_uint idx) {
@@ -145,6 +168,7 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins) {
     prev_sum = row_ptr[rbegin + batch.Size()];
     rbegin += batch.Size();
   }
+  monitor_.Stop("GHistIndexMatrix::Init");
 }
 
 
@@ -152,14 +176,14 @@ void GHistIndexMatrix::ResizeIndex(const size_t n_index,
                                    const bool isDense) {
   if ((max_num_bins - 1 <= static_cast<int>(std::numeric_limits<uint8_t>::max())) && isDense) {
     index.SetBinTypeSize(common::kUint8BinsTypeSize);
-    index.Resize((sizeof(uint8_t)) * n_index);
+    index.Resize((sizeof(uint8_t)) * n_index, isDense);
   } else if ((max_num_bins - 1 > static_cast<int>(std::numeric_limits<uint8_t>::max())  &&
     max_num_bins - 1 <= static_cast<int>(std::numeric_limits<uint16_t>::max())) && isDense) {
     index.SetBinTypeSize(common::kUint16BinsTypeSize);
-    index.Resize((sizeof(uint16_t)) * n_index);
+    index.Resize((sizeof(uint16_t)) * n_index, isDense);
   } else {
     index.SetBinTypeSize(common::kUint32BinsTypeSize);
-    index.Resize((sizeof(uint32_t)) * n_index);
+    index.Resize((sizeof(uint32_t)) * n_index, isDense);
   }
 }
 }  // namespace xgboost

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -9,7 +9,7 @@
 
 namespace xgboost {
 void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins) {
-  monitor_.Start("GHistIndexMatrix::Init");
+  monitor.Start("GHistIndexMatrix::Init");
   cut = common::SketchOnDMatrix(p_fmat, max_bins);
 
   max_num_bins = max_bins;
@@ -168,7 +168,7 @@ void GHistIndexMatrix::Init(DMatrix* p_fmat, int max_bins) {
     prev_sum = row_ptr[rbegin + batch.Size()];
     rbegin += batch.Size();
   }
-  monitor_.Stop("GHistIndexMatrix::Init");
+  monitor.Stop("GHistIndexMatrix::Init");
 }
 
 

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -19,7 +19,7 @@ namespace xgboost {
  */
 class GHistIndexMatrix {
  public:
-  common::Monitor monitor_;
+  common::Monitor monitor;
   /*! \brief row pointer to rows by element position */
   std::vector<size_t> row_ptr;
   /*! \brief The index data */

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -75,7 +75,7 @@ class RegLossObj : public ObjFunction {
 
     const size_t nthreads = omp_get_max_threads();
     const size_t n_data_blocks = nthreads;
-    common::Transform<>::Init([&ndata, &nthreads] XGBOOST_DEVICE(size_t data_block_idx,
+    common::Transform<>::Init([ndata, nthreads] XGBOOST_DEVICE(size_t data_block_idx,
                            common::Span<float> _additional_input,
                            common::Span<GradientPair> _out_gpair,
                            common::Span<const bst_float> _preds,

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -73,29 +73,43 @@ class RegLossObj : public ObjFunction {
     additional_input_.HostVector().begin()[1] = scale_pos_weight;
     additional_input_.HostVector().begin()[2] = is_null_weight;
 
-    common::Transform<>::Init([] XGBOOST_DEVICE(size_t _idx,
+    const size_t nthreads = omp_get_max_threads();
+    const size_t n_data_blocks = nthreads;
+    common::Transform<>::Init([&ndata, &nthreads] XGBOOST_DEVICE(size_t data_block_idx,
                            common::Span<float> _additional_input,
                            common::Span<GradientPair> _out_gpair,
                            common::Span<const bst_float> _preds,
                            common::Span<const bst_float> _labels,
                            common::Span<const bst_float> _weights) {
+          const bst_float* preds_ptr = _preds.data();
+          const bst_float* labels_ptr = _labels.data();
+          const bst_float* weights_ptr = _weights.data();
+          GradientPair* out_gpair_ptr = _out_gpair.data();
+          const size_t block_size = ndata/nthreads + !!(ndata%nthreads);
+          const size_t begin = data_block_idx*block_size;
+          const size_t end = std::min(ndata, begin + block_size);
           const float _scale_pos_weight = _additional_input[1];
           const bool _is_null_weight = _additional_input[2];
 
-          bst_float p = Loss::PredTransform(_preds[_idx]);
-          bst_float w = _is_null_weight ? 1.0f : _weights[_idx];
-          bst_float label = _labels[_idx];
-          if (label == 1.0f) {
-            w *= _scale_pos_weight;
+          for (size_t idx = begin; idx < end; ++idx) {
+            bst_float p = Loss::PredTransform(preds_ptr[idx]);
+            bst_float w = _is_null_weight ? 1.0f : weights_ptr[idx];
+            bst_float label = labels_ptr[idx];
+            if (label == 1.0f) {
+              w *= _scale_pos_weight;
+            }
+            if (!Loss::CheckLabel(label)) {
+              // If there is an incorrect label, the host code will know.
+              _additional_input[0] = 0;
+            }
+            out_gpair_ptr[idx] = GradientPair(Loss::FirstOrderGradient(p, label) * w,
+                                            Loss::SecondOrderGradient(p, label) * w);
+            if (out_gpair_ptr[idx].GetHess() < 0.0f) {
+              out_gpair_ptr[idx] = GradientPair(0);
+            }
           }
-          if (!Loss::CheckLabel(label)) {
-            // If there is an incorrect label, the host code will know.
-            _additional_input[0] = 0;
-          }
-          _out_gpair[_idx] = GradientPair(Loss::FirstOrderGradient(p, label) * w,
-                                          Loss::SecondOrderGradient(p, label) * w);
         },
-        common::Range{0, static_cast<int64_t>(ndata)}, device).Eval(
+        common::Range{0, static_cast<int64_t>(n_data_blocks)}, device).Eval(
             &additional_input_, out_gpair, &preds, &info.labels_, &info.weights_);
 
     auto const flag = additional_input_.HostVector().begin()[0];

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -230,9 +230,9 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
       size_t end = 2*cut_ptr[features_set[r.end()-1] + 1];
 
       GradientSumT* dest_hist = reinterpret_cast<GradientSumT*>(histogram.data());
-      if (p_opt_partition_builder->threads_id_for_nodes_[nidx].size() != 0
+      if (p_opt_partition_builder->threads_id_for_nodes[nidx].size() != 0
           && !is_distributed_ && !is_dense_and_root && !colsample_enabled) {
-        const size_t first_thread_id = p_opt_partition_builder->threads_id_for_nodes_[nidx][0];
+        const size_t first_thread_id = p_opt_partition_builder->threads_id_for_nodes[nidx][0];
         const size_t node_id = nodes_mapping.data()[nidx];
         GradientSumT* hist0 =  histograms[first_thread_id][node_id].data();
 
@@ -243,7 +243,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
           size_t local_begin = begin + block_id*local_block_size;
           size_t local_end = std::min(local_begin + local_block_size, end);
           common::ReduceHist(dest_hist, hist0, &histograms,
-                             node_id, p_opt_partition_builder->threads_id_for_nodes_[nidx],
+                             node_id, p_opt_partition_builder->threads_id_for_nodes[nidx],
                              local_begin, local_end);
           if (entries_sub.size() != 0) {
             // subtric large
@@ -251,7 +251,7 @@ template <typename GradientSumT, typename ExpandEntry> class HistEvaluator {
                             local_begin, local_end);
           }
         }
-      } else if (p_opt_partition_builder->threads_id_for_nodes_[nidx].size() == 0
+      } else if (p_opt_partition_builder->threads_id_for_nodes[nidx].size() == 0
                  && !is_distributed_ && !is_dense_and_root && !colsample_enabled) {
         common::ClearHist(dest_hist, begin, end);
         if (entries_sub.size() != 0) {

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -169,8 +169,8 @@ void BuildHistKernel(const std::vector<GradientPair>& gpair,
     const float* pgh = reinterpret_cast<const float*>(gpair.data());
     const BinIdxType* gradient_index = any_missing ? gmat.index.Data<BinIdxType>() : numa;
 
-    const size_t feature_block_size = feature_blocking ? static_cast<size_t>(13) : n_features;   // NOLINT
-    const size_t nb = n_features / feature_block_size + !!(n_features % feature_block_size);
+    const size_t feature_block_size = feature_blocking ? static_cast<size_t>(13) : n_features;
+    const size_t nb = n_features / feature_block_size + !!(n_features % feature_block_size);   // NOLINT
     const size_t size_with_prefetch = (is_root || feature_blocking) ? 0 :
                                       ((row_size > Prefetch1::kPrefetchOffset) ?
                                       (row_size - Prefetch1::kPrefetchOffset) : 0);

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -8,29 +8,218 @@
 #include <limits>
 #include <vector>
 
+#include <memory>
 #include "rabit/rabit.h"
 #include "xgboost/tree_model.h"
 #include "../../common/hist_util.h"
+#include "../../common/column_matrix.h"
+#include "../../common/opt_partition_builder.h"
+#include "../../common/random.h"
+
+#if defined(XGBOOST_MM_PREFETCH_PRESENT)
+  #include <xmmintrin.h>
+  #define PREFETCH_READ_T0(addr) _mm_prefetch(reinterpret_cast<const char*>(addr), _MM_HINT_T0)
+#elif defined(XGBOOST_BUILTIN_PREFETCH_PRESENT)
+  #define PREFETCH_READ_T0(addr) __builtin_prefetch(reinterpret_cast<const char*>(addr), 0, 3)
+#else  // no SW pre-fetching available; PREFETCH_READ_T0 is no-op
+  #define PREFETCH_READ_T0(addr) do {} while (0)
+#endif  // defined(XGBOOST_MM_PREFETCH_PRESENT)
 
 namespace xgboost {
 namespace tree {
+
+struct Prefetch1 {
+ public:
+  static constexpr size_t kCacheLineSize = 64;
+  static constexpr size_t kPrefetchOffset = 10;
+
+ private:
+  static constexpr size_t kNoPrefetchSize1 =
+      kPrefetchOffset + kCacheLineSize /
+      sizeof(decltype(GHistIndexMatrix::row_ptr)::value_type);
+
+ public:
+  static size_t NoPrefetchSize(size_t rows) {
+    return std::min(rows, kNoPrefetchSize1);
+  }
+
+  template <typename T>
+  static constexpr size_t GetPrefetchStep() {
+    return Prefetch1::kCacheLineSize / sizeof(T);
+  }
+};
+
+template<bool do_prefetch,
+         typename BinIdxType,
+         bool feature_blocking,
+         bool is_root,
+         bool any_missing,
+         bool is_single>
+inline void RowsWiseBuildHist(const BinIdxType* gradient_index,
+                              const uint32_t* rows,
+                              const size_t* row_ptr,
+                              const uint32_t row_begin,
+                              const uint32_t row_end,
+                              const size_t n_features,
+                              uint16_t* nodes_ids,
+                              const std::vector<std::vector<uint64_t>>& offsets640,
+                              const uint16_t* nodes_mapping_ids,
+                              const float* pgh, const size_t ib) {
+  const uint32_t two {2};
+  for (size_t ri = row_begin; ri < row_end; ++ri) {
+    const size_t i = is_root ? ri : rows[ri];
+    const size_t icol_start = any_missing ? row_ptr[i] : i * n_features;
+    const size_t icol_end = any_missing ? row_ptr[i + 1] : icol_start + n_features;
+    const size_t row_sizes = any_missing ? icol_end - icol_start : n_features;
+    const BinIdxType* gr_index_local = gradient_index + icol_start;
+    const size_t idx_gh = two * i;
+
+    const uint32_t nid = is_root ? 0 : nodes_mapping_ids[nodes_ids[i]];
+    if (do_prefetch) {
+      const size_t icol_start_prefetch = any_missing ?
+                                         row_ptr[rows[ri + Prefetch1::kPrefetchOffset]] :
+                                         rows[ri + Prefetch1::kPrefetchOffset] * n_features;
+      const size_t icol_end_prefetch = any_missing ?
+                                       row_ptr[rows[ri + Prefetch1::kPrefetchOffset] + 1] :
+                                       (icol_start_prefetch + n_features);
+
+      PREFETCH_READ_T0(pgh + two * rows[ri + Prefetch1::kPrefetchOffset]);
+      PREFETCH_READ_T0(0 + rows[ri + Prefetch1::kPrefetchOffset]);
+      for (size_t j = icol_start_prefetch; j < icol_end_prefetch;
+          j += Prefetch1::GetPrefetchStep<BinIdxType>()) {
+        PREFETCH_READ_T0(gradient_index + j);
+      }
+    } else if (is_root) {
+      nodes_ids[i] = 0;
+    }
+    const uint64_t* offsets64 = offsets640[nid].data();
+    const size_t begin = feature_blocking ? ib*13 : 0;
+    const size_t end = feature_blocking ? std::min(begin + 13, n_features) : row_sizes;
+    const double pgh_d[] = {pgh[idx_gh], pgh[idx_gh + 1]};
+    for (size_t jb = begin;  jb < end; ++jb) {
+      if (is_single) {
+        float* hist_local = reinterpret_cast<float*>(
+          offsets64[jb] + (static_cast<size_t>(gr_index_local[jb])) * 8);
+        *(hist_local) +=  pgh[idx_gh];
+        *(hist_local + 1) +=  pgh[idx_gh + 1];
+      } else {
+        double* hist_local = reinterpret_cast<double*>(
+          offsets64[jb] + (static_cast<size_t>(gr_index_local[jb])) * 16);
+        *(hist_local) +=  pgh_d[0];
+        *(hist_local + 1) +=  pgh_d[1];
+      }
+    }
+  }
+}
+
+template<typename GradientSumT, typename BinIdxType,
+         bool read_by_column, bool feature_blocking,
+         bool is_root, bool any_missing, bool column_sampling>
+void BuildHistKernel(const std::vector<GradientPair>& gpair,
+                          const uint32_t* rows,
+                          const uint32_t row_begin,
+                          const uint32_t row_end,
+                          const GHistIndexMatrix& gmat,
+                          const size_t n_features, const BinIdxType* numa,
+                          uint16_t* nodes_ids, const std::vector<std::vector<uint64_t>>& offsets640,
+                          const common::ColumnMatrix *column_matrix,
+                          const uint16_t* nodes_mapping_ids, const std::vector<int>& fids) {
+  constexpr bool is_single = static_cast<bool>(sizeof(GradientSumT) == 4);
+
+  if (read_by_column) {
+    using DenseColumnT = common::DenseColumn<BinIdxType, any_missing>;
+    const float* pgh = reinterpret_cast<const float*>(gpair.data());
+    const size_t n_columns = column_sampling ? fids.size() : n_features;
+    for (size_t cid = 0; cid < n_columns; ++cid) {
+      const size_t local_cid = column_sampling ? fids[cid] : cid;
+      const DenseColumnT* column = dynamic_cast<const DenseColumnT*>(
+        column_matrix->GetColumn<BinIdxType, any_missing>(local_cid).get());
+      CHECK_NE(column, static_cast<const DenseColumnT*>(nullptr));
+      const BinIdxType* gr_index_local = column->GetFeatureBinIdxPtr().data();
+      const size_t base_idx = column->GetBaseIdx();
+      for (size_t ii = row_begin; ii < row_end; ++ii) {
+        const size_t row_id = is_root ? ii : rows[ii];
+        if (is_root && (cid == 0)) {
+          nodes_ids[row_id] = 0;
+        }
+        if (!any_missing || (any_missing && !column->IsMissing(row_id))) {
+          const uint32_t nid = is_root ? 0 :nodes_mapping_ids[nodes_ids[row_id]];
+          const size_t idx_gh = row_id << 1;
+          const uint64_t* offsets64 = offsets640[nid].data();
+          const double pgh_d[2] = {pgh[idx_gh], pgh[idx_gh + 1]};
+          if (is_single) {
+            float* hist_local = reinterpret_cast<float*>(
+              offsets64[local_cid] + (static_cast<size_t>(gr_index_local[row_id])) * 8 +
+              (any_missing ? base_idx * 8 : 0));
+            *(hist_local) +=  pgh[idx_gh];
+            *(hist_local + 1) +=  pgh[idx_gh + 1];
+          } else {
+            double* hist_local = reinterpret_cast<double*>(
+              offsets64[local_cid] + (static_cast<size_t>(gr_index_local[row_id])) * 16 +
+              (any_missing ? base_idx * 16 : 0));
+            *(hist_local) +=  pgh_d[0];
+            *(hist_local + 1) +=  pgh_d[1];
+          }
+        }
+      }
+    }
+  } else {
+    const size_t row_size = row_end - row_begin;
+    const size_t* row_ptr =  gmat.row_ptr.data();
+    const float* pgh = reinterpret_cast<const float*>(gpair.data());
+    const BinIdxType* gradient_index = any_missing ? gmat.index.Data<BinIdxType>() : numa;
+
+    const size_t feature_block_size = feature_blocking ? 13 : n_features;
+    const size_t nb = n_features / feature_block_size + !!(n_features % feature_block_size);
+    const size_t size_with_prefetch = (is_root || feature_blocking) ? 0 :
+                                      ((row_size > Prefetch1::kPrefetchOffset) ?
+                                      (row_size - Prefetch1::kPrefetchOffset) : 0);
+    for (size_t ib = 0; ib < nb; ++ib) {
+      RowsWiseBuildHist<true, BinIdxType,
+                        feature_blocking,
+                        is_root, any_missing,
+                        is_single> (gradient_index, rows, row_ptr, row_begin,
+                                    row_begin + size_with_prefetch,
+                                    n_features, nodes_ids,
+                                    offsets640, nodes_mapping_ids, pgh, ib);
+      RowsWiseBuildHist<false, BinIdxType,
+                        feature_blocking,
+                        is_root, any_missing,
+                        is_single> (gradient_index, rows, row_ptr, row_begin + size_with_prefetch,
+                                    row_end, n_features, nodes_ids,
+                                    offsets640, nodes_mapping_ids, pgh, ib);
+    }
+  }
+}
+
 template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
   using GradientPairT = xgboost::detail::GradientPairInternal<GradientSumT>;
   using GHistRowT = common::GHistRow<GradientSumT>;
-
+  common::Monitor builder_monitor_;
   /*! \brief culmulative histogram of gradients. */
   common::HistCollection<GradientSumT> hist_;
   /*! \brief culmulative local parent histogram of gradients. */
   common::HistCollection<GradientSumT> hist_local_worker_;
   common::GHistBuilder<GradientSumT> builder_;
   common::ParallelGHistBuilder<GradientSumT> buffer_;
+  std::vector<std::vector<std::vector<uint64_t>>> offsets64_;
   rabit::Reducer<GradientPairT, GradientPairT::Reduce> reducer_;
   int32_t max_bin_ {-1};
   int32_t n_threads_ {-1};
+  int32_t max_depth_ {1};
+  float colsample_bytree_ {1.0};
+  float colsample_bylevel_ {1.0};
+  float colsample_bynode_ {1.0};
+  size_t n_bins_ {0};
+  std::shared_ptr<common::ColumnSampler> column_sampler_;
   // Whether XGBoost is running in distributed environment.
   bool is_distributed_ {false};
 
  public:
+  std::vector<std::vector<std::vector<GradientSumT>>> histograms_buffer_;
+  std::vector<std::vector<std::vector<GradientSumT>>>* GetHistBuffer() {
+    return &histograms_buffer_;
+  }
   /**
    * \param total_bins       Total number of bins across all features
    * \param max_bin_per_feat Maximum number of bins per feature, same as the `max_bin`
@@ -39,7 +228,12 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
    * \param is_distributed   Mostly used for testing to allow injecting parameters instead
    *                         of using global rabit variable.
    */
-  void Reset(uint32_t total_bins, int32_t max_bin_per_feat, int32_t n_threads,
+  void Reset(uint32_t total_bins,
+             int32_t max_bin_per_feat, int32_t n_threads,
+             int32_t n_features, int32_t max_depth,
+             float colsample_bytree, float colsample_bylevel, float colsample_bynode,
+             std::shared_ptr<common::ColumnSampler> column_sampler,
+             const uint32_t* offsets = nullptr, const bool is_dense = true,
              bool is_distributed = rabit::IsDistributed()) {
     CHECK_GE(n_threads, 1);
     n_threads_ = n_threads;
@@ -50,49 +244,158 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
     buffer_.Init(total_bins);
     builder_ = common::GHistBuilder<GradientSumT>(n_threads, total_bins);
     is_distributed_ = is_distributed;
+    max_depth_ = std::max(max_depth, 1);
+    colsample_bytree_ = colsample_bytree;
+    colsample_bylevel_ = colsample_bylevel;
+    colsample_bynode_ = colsample_bynode;
+    column_sampler_ = column_sampler;
+    if (histograms_buffer_.size() == 0) {
+      n_bins_ = total_bins;
+      histograms_buffer_.resize(n_threads);
+      offsets64_.resize(n_threads);
+      #pragma omp parallel num_threads(n_threads)
+      {
+        const size_t tid = omp_get_thread_num();
+        histograms_buffer_[tid].resize((1 << (max_depth_ - 1)));
+        offsets64_[tid].resize((1 << (max_depth_ - 1)));
+      }
+    }
   }
 
-  template <bool any_missing>
-  void
-  BuildLocalHistograms(DMatrix *p_fmat,
-                       std::vector<ExpandEntry> nodes_for_explicit_hist_build,
-                       common::RowSetCollection const &row_set_collection,
-                       const std::vector<GradientPair> &gpair_h) {
-    const size_t n_nodes = nodes_for_explicit_hist_build.size();
-
-    // create space of size (# rows in each node)
-    common::BlockedSpace2d space(
-        n_nodes,
-        [&](size_t node) {
-          const int32_t nid = nodes_for_explicit_hist_build[node].nid;
-          return row_set_collection[nid].Size();
-        },
-        256);
-
-    std::vector<GHistRowT> target_hists(n_nodes);
-    for (size_t i = 0; i < n_nodes; ++i) {
-      const int32_t nid = nodes_for_explicit_hist_build[i].nid;
-      target_hists[i] = hist_[nid];
+  template<typename BinIdxType, bool any_missing, bool hist_fit_to_l2, typename BuildHistFunc>
+  BuildHistFunc GetBuildHistSrategy(int depth, const bool any_sparse_column) {
+    // now column sampling supported only for missings due to fid_least_bins_ set
+    if (any_missing
+        && (colsample_bytree_ < 0.1 || colsample_bylevel_ < 0.1)
+        && !any_sparse_column
+        && colsample_bynode_ == 1) {
+      if (depth == 0) {
+        return BuildHistKernel<GradientSumT, BinIdxType,
+                               /*read_by_column*/   true,
+                               /*feature_blocking*/ false,
+                               /*is_root*/          true,
+                               /*any_missing*/      any_missing,
+                               /*column_sampling*/  true>;
+      } else {
+        return BuildHistKernel<GradientSumT, BinIdxType,
+                               /*read_by_column*/   true,
+                               /*feature_blocking*/ false,
+                               /*is_root*/          false,
+                               /*any_missing*/      any_missing,
+                               /*column_sampling*/  true>;
+      }
+    } else {
+      if (depth == 0) {
+        return BuildHistKernel<GradientSumT, BinIdxType,
+                               /*read_by_column*/   !hist_fit_to_l2 && !any_missing,
+                               /*feature_blocking*/ false,
+                               /*is_root*/          true,
+                               /*any_missing*/      any_missing,
+                               /*column_sampling*/  false>;
+      } else {
+        if (depth == 1) {  // make 1st depth 33% faster for hist not fitted to L2 cache
+          return BuildHistKernel<GradientSumT, BinIdxType,
+                                 /*read_by_column*/   !hist_fit_to_l2 && !any_missing,
+                                 /*feature_blocking*/ false,
+                                 /*is_root*/          false,
+                                 /*any_missing*/      any_missing,
+                                 /*column_sampling*/  false>;
+        } else {
+          return BuildHistKernel<GradientSumT, BinIdxType,
+                                 /*read_by_column*/   false,
+                                 /*feature_blocking*/ !hist_fit_to_l2 && !any_missing,
+                                 /*is_root*/          false,
+                                 /*any_missing*/      any_missing,
+                                 /*column_sampling*/  false>;
+        }
+      }
     }
-    buffer_.Reset(this->n_threads_, n_nodes, space, target_hists);
+  }
 
+  template <typename BinIdxType, bool any_missing, bool hist_fit_to_l2>
+  void BuildLocalHistograms(DMatrix *p_fmat, const GHistIndexMatrix &gmat,
+                            const std::vector<GradientPair> &gpair_h,
+                            int depth,
+                            const common::ColumnMatrix& column_matrix,
+                            const common::OptPartitionBuilder* p_opt_partition_builder,
+                            // template?
+                            const std::vector<uint16_t>* p_nodes_mapping,
+                            std::vector<uint16_t>* node_ids) {
+    // std::string depth_str = std::to_string(depth);
+    const std::vector<uint16_t>& nodes_mapping = *p_nodes_mapping;
+    const common::OptPartitionBuilder& opt_partition_builder_ = *p_opt_partition_builder;
+    std::vector<uint16_t>& node_ids_ = *node_ids;
+    using BuildHistFunc = void(*)(const std::vector<GradientPair>&,
+                                  const uint32_t*,
+                                  const uint32_t,
+                                  const uint32_t,
+                                  const GHistIndexMatrix&,
+                                  const size_t,
+                                  const BinIdxType*, uint16_t*,
+                                  const std::vector<std::vector<uint64_t>>&,
+                                  const common::ColumnMatrix*, const uint16_t*,
+                                  const std::vector<int>&);
+    BuildHistFunc build_hist_func = GetBuildHistSrategy<BinIdxType,
+                                                        any_missing,
+                                                        hist_fit_to_l2,
+                                                        BuildHistFunc>(
+                                                          depth, column_matrix.AnySparseColumn());
+    builder_monitor_.Start("BuildLocalHistograms");
+    const size_t n_features = gmat.cut.Ptrs().size() - 1;
+    int nthreads = this->n_threads_;
+
+    std::vector<int> fids;
+    // now column sampling supported only for missings due to fid_least_bins_ set
+    if (any_missing
+        && (colsample_bytree_ < 0.1 || colsample_bylevel_ < 0.1)
+        && !column_matrix.AnySparseColumn()
+        && colsample_bynode_ == 1) {
+      const size_t n_sampled_features = column_sampler_->GetFeatureSet(depth)->Size();
+      fids.resize(n_sampled_features, 0);
+      for (size_t i = 0; i < n_sampled_features; ++i) {
+        fids[i] = column_sampler_->GetFeatureSet(depth)->ConstHostVector()[i];
+      }
+    }
     // Parallel processing by nodes and data in each node
-    for (auto const &gmat : p_fmat->GetBatches<GHistIndexMatrix>(
+    for (auto const &gmat_local : p_fmat->GetBatches<GHistIndexMatrix>(
              BatchParam{GenericParameter::kCpuId, max_bin_})) {
-      common::ParallelFor2d(
-          space, this->n_threads_, [&](size_t nid_in_set, common::Range1d r) {
-            const auto tid = static_cast<unsigned>(omp_get_thread_num());
-            const int32_t nid = nodes_for_explicit_hist_build[nid_in_set].nid;
-
-            auto start_of_row_set = row_set_collection[nid].begin;
-            auto rid_set = common::RowSetCollection::Elem(
-                start_of_row_set + r.begin(), start_of_row_set + r.end(), nid);
-            builder_.template BuildHist<any_missing>(
-                gpair_h, rid_set, gmat,
-                buffer_.GetInitializedHist(tid, nid_in_set));
-          });
+      #pragma omp parallel num_threads(nthreads)
+      {
+        size_t tid = omp_get_thread_num();
+        const BinIdxType* numa = tid < nthreads/2 ?  gmat_local.index.Data<BinIdxType>() :
+                                                    gmat_local.index.SecondData<BinIdxType>();
+        const std::vector<common::Slice>& local_thread_addr =
+          opt_partition_builder_.threads_addr_[tid];
+        const size_t thread_size = opt_partition_builder_.node_id_for_threads_[tid].size();
+        for (size_t nid = 0; nid < thread_size; ++nid) {
+          const size_t node_id = opt_partition_builder_.node_id_for_threads_[tid][nid];
+          const int32_t mapped_node_id = nodes_mapping.data()[node_id];
+          if (offsets64_[tid][mapped_node_id].size() == 0) {
+            offsets64_[tid][mapped_node_id].resize(n_features, 0);
+            histograms_buffer_[tid][mapped_node_id].resize(n_bins_*2, 0);
+            uint64_t* offsets640 = offsets64_[tid][mapped_node_id].data();
+            const uint32_t* offsets = gmat_local.index.Offset();
+            for (size_t i = 0; i < n_features; ++i) {
+              offsets640[i] = !any_missing ?
+                reinterpret_cast<uint64_t>(histograms_buffer_[tid][mapped_node_id].data()) +
+                sizeof(GradientSumT)*2*static_cast<uint64_t>(offsets[i]) :
+                reinterpret_cast<uint64_t>(histograms_buffer_[tid][mapped_node_id].data());
+            }
+          }
+        }
+        for (uint32_t block_id = 0; block_id < local_thread_addr.size(); ++block_id) {
+          const uint32_t* rows = local_thread_addr[block_id].addr;
+          build_hist_func(gpair_h, rows, local_thread_addr[block_id].b,
+                          local_thread_addr[block_id].e, gmat_local, n_features,
+                          numa, node_ids_.data(), offsets64_[tid],
+                          &column_matrix, nodes_mapping.data(), fids);
+        }
+      }
     }
+
+    builder_monitor_.Stop("BuildLocalHistograms");
   }
+
 
   void
   AddHistRows(int *starting_index, int *sync_count,
@@ -111,107 +414,131 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
   }
 
   /* Main entry point of this class, build histogram for tree nodes. */
-  void BuildHist(DMatrix *p_fmat, RegTree *p_tree,
-                 common::RowSetCollection const &row_set_collection,
+  template <typename BinIdxType, bool any_missing, bool hist_fit_to_l2>
+  void BuildHist(DMatrix *p_fmat, const GHistIndexMatrix &gmat, RegTree *p_tree,
+                 std::vector<GradientPair> const &gpair,
+                 int depth, const common::ColumnMatrix& column_matrix,
                  std::vector<ExpandEntry> const &nodes_for_explicit_hist_build,
                  std::vector<ExpandEntry> const &nodes_for_subtraction_trick,
-                 std::vector<GradientPair> const &gpair) {
+                 const common::OptPartitionBuilder* p_opt_partition_builder,
+                 // template?
+                 std::vector<uint16_t>* p_nodes_mapping,
+                 std::vector<uint16_t>* node_ids) {
     int starting_index = std::numeric_limits<int>::max();
     int sync_count = 0;
     this->AddHistRows(&starting_index, &sync_count,
                       nodes_for_explicit_hist_build,
                       nodes_for_subtraction_trick, p_tree);
-    if (p_fmat->IsDense()) {
-      BuildLocalHistograms<false>(p_fmat, nodes_for_explicit_hist_build,
-                                  row_set_collection, gpair);
+    if (!any_missing
+        || (any_missing && (colsample_bytree_ < 0.1
+        || colsample_bylevel_ < 0.1)
+        && !column_matrix.AnySparseColumn() && colsample_bynode_ == 1)) {
+      BuildLocalHistograms<BinIdxType,
+                           any_missing, hist_fit_to_l2>(p_fmat, gmat, gpair, depth, column_matrix,
+                                                        p_opt_partition_builder,
+                                                        p_nodes_mapping, node_ids);
     } else {
-      BuildLocalHistograms<true>(p_fmat, nodes_for_explicit_hist_build,
-                                 row_set_collection, gpair);
+      BuildLocalHistograms<uint32_t,
+                           any_missing, hist_fit_to_l2>(p_fmat, gmat, gpair, depth, column_matrix,
+                                                        p_opt_partition_builder,
+                                                        p_nodes_mapping, node_ids);
     }
+
     if (is_distributed_) {
-      this->SyncHistogramDistributed(p_tree, nodes_for_explicit_hist_build,
+      this->template SyncHistograms<true>(gmat, p_tree, nodes_for_explicit_hist_build,
                                      nodes_for_subtraction_trick,
-                                     starting_index, sync_count);
-    } else {
-      this->SyncHistogramLocal(p_tree, nodes_for_explicit_hist_build,
-                               nodes_for_subtraction_trick, starting_index,
-                               sync_count);
+                                     starting_index, sync_count,
+                                     p_opt_partition_builder, p_nodes_mapping);
+    } else if ((gmat.IsDense() && depth == 0)
+               || colsample_bylevel_ != 1 || colsample_bynode_ != 1 || colsample_bytree_ != 1) {
+      this->template SyncHistograms<false>(gmat, p_tree, nodes_for_explicit_hist_build,
+                               nodes_for_subtraction_trick,
+                               starting_index, sync_count,
+                               p_opt_partition_builder, p_nodes_mapping);
     }
   }
 
-  void SyncHistogramDistributed(
+  template<bool is_distributed>
+  void SyncHistograms(
+      const GHistIndexMatrix &gmat,
       RegTree *p_tree,
       std::vector<ExpandEntry> const &nodes_for_explicit_hist_build,
       std::vector<ExpandEntry> const &nodes_for_subtraction_trick,
-      int starting_index, int sync_count) {
+      int starting_index, int sync_count,
+      const common::OptPartitionBuilder* p_opt_partition_builder,
+      const std::vector<uint16_t>* p_nodes_mapping) {
+    const std::vector<uint16_t>& nodes_mapping = *p_nodes_mapping;
+    const common::OptPartitionBuilder& opt_partition_builder = *p_opt_partition_builder;
     const size_t nbins = builder_.GetNumBins();
     common::BlockedSpace2d space(
         nodes_for_explicit_hist_build.size(), [&](size_t) { return nbins; },
-        1024);
+        512);
+
     common::ParallelFor2d(
         space, n_threads_, [&](size_t node, common::Range1d r) {
           const auto &entry = nodes_for_explicit_hist_build[node];
           auto this_hist = this->hist_[entry.nid];
           // Merging histograms from each thread into once
-          buffer_.ReduceHist(node, r.begin(), r.end());
+
+          GradientSumT* dest_hist = reinterpret_cast<GradientSumT*>(this_hist.data());
+          if (opt_partition_builder.threads_id_for_nodes_[entry.nid].size() != 0) {
+            const int32_t node_id = nodes_mapping.data()[entry.nid];
+            const size_t first_thread_id =
+              opt_partition_builder.threads_id_for_nodes_[entry.nid][0];
+            GradientSumT* hist0 =  histograms_buffer_[first_thread_id][node_id].data();
+            common::ReduceHist(dest_hist,
+                               hist0,
+                               &histograms_buffer_,
+                               node_id,
+                               opt_partition_builder.threads_id_for_nodes_[entry.nid],
+                               2 * r.begin(), 2 * r.end());
+          } else {
+            common::ClearHist(dest_hist, 2 * r.begin(), 2 * r.end());
+          }
           // Store posible parent node
-          auto this_local = hist_local_worker_[entry.nid];
-          common::CopyHist(this_local, this_hist, r.begin(), r.end());
+          if (is_distributed) {
+            auto this_local = hist_local_worker_[entry.nid];
+            common::CopyHist(this_local, this_hist, r.begin(), r.end());
+          }
 
           if (!(*p_tree)[entry.nid].IsRoot()) {
             const size_t parent_id = (*p_tree)[entry.nid].Parent();
             const int subtraction_node_id =
                 nodes_for_subtraction_trick[node].nid;
-            auto parent_hist = this->hist_local_worker_[parent_id];
-            auto sibling_hist = this->hist_[subtraction_node_id];
-            common::SubtractionHist(sibling_hist, parent_hist, this_hist,
-                                    r.begin(), r.end());
+            GradientSumT* parent_hist = nullptr;
+            if (is_distributed) {
+              parent_hist = reinterpret_cast<GradientSumT*>(
+                this->hist_local_worker_[parent_id].data());
+            } else {
+              parent_hist = reinterpret_cast<GradientSumT*>(
+                this->hist_[parent_id].data());
+            }
+            GradientSumT* largest_hist =
+              reinterpret_cast<GradientSumT*>(this->hist_[subtraction_node_id].data());
+            // subtric large
+            common::SubtractionHist(largest_hist, parent_hist, dest_hist,
+                                    2 * r.begin(), 2 * r.end());
             // Store posible parent node
-            auto sibling_local = hist_local_worker_[subtraction_node_id];
-            common::CopyHist(sibling_local, sibling_hist, r.begin(), r.end());
+            if (is_distributed) {
+              auto sibling_local = hist_local_worker_[subtraction_node_id];
+              common::CopyHist(sibling_local, this->hist_[subtraction_node_id], r.begin(), r.end());
+            }
           }
         });
 
-    reducer_.Allreduce(this->hist_[starting_index].data(),
-                       builder_.GetNumBins() * sync_count);
+    if (is_distributed) {
+      reducer_.Allreduce(this->hist_[starting_index].data(),
+                        builder_.GetNumBins() * sync_count);
 
-    ParallelSubtractionHist(space, nodes_for_explicit_hist_build,
-                            nodes_for_subtraction_trick, p_tree);
+      ParallelSubtractionHist(space, nodes_for_explicit_hist_build,
+                              nodes_for_subtraction_trick, p_tree);
 
-    common::BlockedSpace2d space2(
-        nodes_for_subtraction_trick.size(), [&](size_t) { return nbins; },
-        1024);
-    ParallelSubtractionHist(space2, nodes_for_subtraction_trick,
-                            nodes_for_explicit_hist_build, p_tree);
-  }
-
-  void SyncHistogramLocal(
-      RegTree *p_tree,
-      std::vector<ExpandEntry> const &nodes_for_explicit_hist_build,
-      std::vector<ExpandEntry> const &nodes_for_subtraction_trick,
-      int starting_index, int sync_count) {
-    const size_t nbins = this->builder_.GetNumBins();
-    common::BlockedSpace2d space(
-        nodes_for_explicit_hist_build.size(), [&](size_t) { return nbins; },
-        1024);
-
-    common::ParallelFor2d(
-        space, this->n_threads_, [&](size_t node, common::Range1d r) {
-          const auto &entry = nodes_for_explicit_hist_build[node];
-          auto this_hist = this->hist_[entry.nid];
-          // Merging histograms from each thread into once
-          this->buffer_.ReduceHist(node, r.begin(), r.end());
-
-          if (!(*p_tree)[entry.nid].IsRoot()) {
-            const size_t parent_id = (*p_tree)[entry.nid].Parent();
-            const int subtraction_node_id =
-                nodes_for_subtraction_trick[node].nid;
-            auto parent_hist = this->hist_[parent_id];
-            auto sibling_hist = this->hist_[subtraction_node_id];
-            common::SubtractionHist(sibling_hist, parent_hist, this_hist,
-                                    r.begin(), r.end());
-          }
-        });
+      common::BlockedSpace2d space2(
+          nodes_for_subtraction_trick.size(), [&](size_t) { return nbins; },
+          1024);
+      ParallelSubtractionHist(space2, nodes_for_subtraction_trick,
+                              nodes_for_explicit_hist_build, p_tree);
+    }
   }
 
  public:
@@ -228,20 +555,22 @@ template <typename GradientSumT, typename ExpandEntry> class HistogramBuilder {
                           const std::vector<ExpandEntry> &subtraction_nodes,
                           const RegTree *p_tree) {
     common::ParallelFor2d(
-        space, this->n_threads_, [&](size_t node, common::Range1d r) {
-          const auto &entry = nodes[node];
-          if (!((*p_tree)[entry.nid].IsLeftChild())) {
-            auto this_hist = this->hist_[entry.nid];
-
-            if (!(*p_tree)[entry.nid].IsRoot()) {
-              const int subtraction_node_id = subtraction_nodes[node].nid;
-              auto parent_hist = hist_[(*p_tree)[entry.nid].Parent()];
-              auto sibling_hist = hist_[subtraction_node_id];
-              common::SubtractionHist(this_hist, parent_hist, sibling_hist,
-                                      r.begin(), r.end());
-            }
+      space, this->n_threads_, [&](size_t node, common::Range1d r) {
+        const auto &entry = nodes[node];
+        if (!((*p_tree)[entry.nid].IsLeftChild())) {
+          auto this_hist = this->hist_[entry.nid];
+          GradientSumT* dest_hist = reinterpret_cast<GradientSumT*>(this_hist.data());
+          if (!(*p_tree)[entry.nid].IsRoot()) {
+            const int subtraction_node_id = subtraction_nodes[node].nid;
+            GradientSumT* parent_hist = reinterpret_cast<GradientSumT*>(
+              this->hist_[(*p_tree)[entry.nid].Parent()].data());
+            GradientSumT* largest_hist = reinterpret_cast<GradientSumT*>(
+              this->hist_[subtraction_node_id].data());
+            common::SubtractionHist(dest_hist, parent_hist, largest_hist,
+                                  2 * r.begin(), 2 * r.end());
           }
-        });
+        }
+      });
   }
 
   // Add a tree node to histogram buffer in local training environment.

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -169,10 +169,7 @@ void BuildHistKernel(const std::vector<GradientPair>& gpair,
     const float* pgh = reinterpret_cast<const float*>(gpair.data());
     const BinIdxType* gradient_index = any_missing ? gmat.index.Data<BinIdxType>() : numa;
 
-    size_t feature_block_size = n_features;
-    if (feature_blocking) {
-      feature_block_size = 13;
-    }
+    const size_t feature_block_size = feature_blocking ? static_cast<size_t>(13) : n_features;   // NOLINT
     const size_t nb = n_features / feature_block_size + !!(n_features % feature_block_size);
     const size_t size_with_prefetch = (is_root || feature_blocking) ? 0 :
                                       ((row_size > Prefetch1::kPrefetchOffset) ?

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -169,7 +169,10 @@ void BuildHistKernel(const std::vector<GradientPair>& gpair,
     const float* pgh = reinterpret_cast<const float*>(gpair.data());
     const BinIdxType* gradient_index = any_missing ? gmat.index.Data<BinIdxType>() : numa;
 
-    const size_t feature_block_size = feature_blocking ? static_cast<size_t>(13) : n_features;
+    size_t feature_block_size = n_features;
+    if (feature_blocking) {
+      feature_block_size = 13;
+    }
     const size_t nb = n_features / feature_block_size + !!(n_features % feature_block_size);
     const size_t size_with_prefetch = (is_root || feature_blocking) ? 0 :
                                       ((row_size > Prefetch1::kPrefetchOffset) ?

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -549,8 +549,6 @@ void QuantileHistMaker::Builder<GradientSumT>::InitData(const GHistIndexMatrix& 
   const auto& info = fmat.Info();
 
   {
-    // initialize the row set
-    // row_set_collection_.Clear();
     // initialize histogram collection
     uint32_t nbins = gmat.cut.Ptrs().back();
     // initialize histogram builder
@@ -604,23 +602,6 @@ void QuantileHistMaker::Builder<GradientSumT>::InitData(const GHistIndexMatrix& 
 
     // mark subsample and build list of member rows
     const size_t block_size = info.num_row_ / this->nthread_ + !!(info.num_row_ % this->nthread_);
-
-    // #pragma omp parallel num_threads(this->nthread_)
-    // {
-    //   exc.Run([&]() {
-    //     const size_t tid = omp_get_thread_num();
-    //     const size_t ibegin = tid * block_size;
-    //     const size_t iend = std::min(static_cast<size_t>(ibegin + block_size),
-    //         static_cast<size_t>(info.num_row_));
-
-    //     for (size_t i = ibegin; i < iend; ++i) {
-    //       if ((*gpair)[i].GetHess() < 0.0f) {
-    //         (*gpair)[i] = GradientPair(0);
-    //       }
-    //     }
-    //   });
-    // }
-    // exc.Rethrow();
 
     if (is_lossguide) {
       opt_partition_builder_.ResizeRowsBuffer(info.num_row_);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -118,21 +118,31 @@ bool QuantileHistMaker::UpdatePredictionCache(
 template <typename GradientSumT>
 QuantileHistMaker::Builder<GradientSumT>::~Builder() = default;
 
-
 template <typename GradientSumT>
-template <bool any_missing>
+template <typename BinIdxType, bool any_missing, bool hist_fit_to_l2>
 void QuantileHistMaker::Builder<GradientSumT>::InitRoot(
-    DMatrix *p_fmat, RegTree *p_tree, const std::vector<GradientPair> &gpair_h,
-    int *num_leaves, std::vector<CPUExpandEntry> *expand) {
+    const GHistIndexMatrix &gmat, DMatrix* p_fmat, RegTree *p_tree,
+    const std::vector<GradientPair> &gpair_h, int *num_leaves,
+    std::vector<CPUExpandEntry> *expand, common::BlockedSpace2d* space_ptr,
+    const ColumnMatrix& column_matrix, bool is_loss_guide) {
   CPUExpandEntry node(CPUExpandEntry::kRootNid, p_tree->GetDepth(0), 0.0f);
 
   nodes_for_explicit_hist_build_.clear();
   nodes_for_subtraction_trick_.clear();
   nodes_for_explicit_hist_build_.push_back(node);
 
-  this->histogram_builder_->BuildHist(p_fmat, p_tree, row_set_collection_,
-                                      nodes_for_explicit_hist_build_,
-                                      nodes_for_subtraction_trick_, gpair_h);
+  int starting_index = std::numeric_limits<int>::max();
+  int sync_count = 0;
+  opt_partition_builder_.UpdateRootThreadWork(gmat.IsDense());
+
+  this->histogram_builder_->template BuildHist<BinIdxType,
+                                               any_missing,
+                                               hist_fit_to_l2>(p_fmat, gmat, p_tree,
+                                                               gpair_h, 0, column_matrix,
+                                                               nodes_for_explicit_hist_build_,
+                                                               nodes_for_subtraction_trick_,
+                                                               &opt_partition_builder_,
+                                                               &nodes_mapping_, &node_ids_);
 
   {
     auto nid = CPUExpandEntry::kRootNid;
@@ -140,10 +150,6 @@ void QuantileHistMaker::Builder<GradientSumT>::InitRoot(
     GradientPairT grad_stat;
     if (data_layout_ == DataLayout::kDenseDataZeroBased ||
         data_layout_ == DataLayout::kDenseDataOneBased) {
-      auto const &gmat = *(p_fmat
-                               ->GetBatches<GHistIndexMatrix>(BatchParam{
-                                   GenericParameter::kCpuId, param_.max_bin})
-                               .begin());
       const std::vector<uint32_t> &row_ptr = gmat.cut.Ptrs();
       const uint32_t ibegin = row_ptr[fid_least_bins_];
       const uint32_t iend = row_ptr[fid_least_bins_ + 1];
@@ -153,12 +159,13 @@ void QuantileHistMaker::Builder<GradientSumT>::InitRoot(
         grad_stat.Add(et.GetGrad(), et.GetHess());
       }
     } else {
-      const RowSetCollection::Elem e = row_set_collection_[nid];
-      for (const size_t *it = e.begin; it < e.end; ++it) {
-        grad_stat.Add(gpair_h[*it].GetGrad(), gpair_h[*it].GetHess());
+      builder_monitor_.Start("RootStatsCalculation");
+      for (size_t it = 0; it < gpair_h.size(); ++it) {
+        grad_stat.Add(gpair_h[it].GetGrad(), gpair_h[it].GetHess());
       }
       rabit::Allreduce<rabit::op::Sum, GradientSumT>(
           reinterpret_cast<GradientSumT *>(&grad_stat), 2);
+      builder_monitor_.Stop("RootStatsCalculation");
     }
 
     auto weight = evaluator_->InitRoot(GradStats{grad_stat});
@@ -168,9 +175,16 @@ void QuantileHistMaker::Builder<GradientSumT>::InitRoot(
 
     std::vector<CPUExpandEntry> entries{node};
     builder_monitor_.Start("EvaluateSplits");
-    for (auto const &gmat : p_fmat->GetBatches<GHistIndexMatrix>(
+    for (auto const &gmat_local : p_fmat->GetBatches<GHistIndexMatrix>(
              BatchParam{GenericParameter::kCpuId, param_.max_bin})) {
-      evaluator_->EvaluateSplits(histogram_builder_->Histogram(), gmat, *p_tree, &entries);
+      evaluator_->EvaluateSplits(histogram_builder_->Histogram(), gmat_local,
+                                *p_tree, &nodes_for_explicit_hist_build_,
+                                &nodes_for_subtraction_trick_, &entries,
+                                histogram_builder_->GetHistBuffer(),
+                                &opt_partition_builder_, &nodes_mapping_, p_tree,
+                                param_.colsample_bylevel != 1 ||
+                                param_.colsample_bynode  != 1 ||
+                                param_.colsample_bytree  != 1);
     }
     builder_monitor_.Stop("EvaluateSplits");
     node = entries.front();
@@ -185,14 +199,40 @@ void QuantileHistMaker::Builder<GradientSumT>::AddSplitsToTree(
           const std::vector<CPUExpandEntry>& expand,
           RegTree *p_tree,
           int *num_leaves,
-          std::vector<CPUExpandEntry>* nodes_for_apply_split) {
+          std::vector<CPUExpandEntry>* nodes_for_apply_split,
+          std::vector<bool>* smalest_nodes_mask_ptr) {
+  std::vector<bool>& smalest_nodes_mask = *smalest_nodes_mask_ptr;
+  const bool is_loss_guided = static_cast<TrainParam::TreeGrowPolicy>(param_.grow_policy)
+                              != TrainParam::kDepthWise;
+  size_t i = 0;
+  std::vector<uint16_t> compleate_node_ids;
   for (auto const& entry : expand) {
     if (entry.IsValid(param_, *num_leaves)) {
       nodes_for_apply_split->push_back(entry);
       evaluator_->ApplyTreeSplit(entry, p_tree);
       (*num_leaves)++;
+      nodes_mapping_[(*p_tree)[entry.nid].LeftChild()] = is_loss_guided ? 0 : i;
+      ++i;
+      nodes_mapping_[(*p_tree)[entry.nid].RightChild()] = is_loss_guided ? 0 : i;
+      ++i;
+      curr_level_nodes_[2*entry.nid] = (*p_tree)[entry.nid].LeftChild();
+      curr_level_nodes_[2*entry.nid + 1] = (*p_tree)[entry.nid].RightChild();
+      compleate_node_ids.push_back((*p_tree)[entry.nid].LeftChild());
+      compleate_node_ids.push_back((*p_tree)[entry.nid].RightChild());
+      if (entry.split.left_sum.GetHess() <= entry.split.right_sum.GetHess() || is_loss_guided) {
+        smalest_nodes_mask[curr_level_nodes_[2*entry.nid]] = true;
+        // std::cout << "small is " << curr_level_nodes_[2*entry.nid] << std::endl;
+      } else {
+        smalest_nodes_mask[curr_level_nodes_[2*entry.nid + 1]] = true;
+        // std::cout << "small is " << curr_level_nodes_[2*entry.nid + 1] << std::endl;
+      }
+    } else {
+      is_compleate_tree_ = false;
+      curr_level_nodes_[2*entry.nid] = (uint16_t)(1) << 15 | (uint16_t)(entry.nid);
+      curr_level_nodes_[2*entry.nid + 1] = (uint16_t)(1) << 15 | (uint16_t)(entry.nid);
     }
   }
+  compleate_trees_depth_wise_ = compleate_node_ids;
 }
 
 // Split nodes to 2 sets depending on amount of rows in each node
@@ -215,20 +255,32 @@ void QuantileHistMaker::Builder<GradientSumT>::SplitSiblings(
     const CPUExpandEntry right_node = CPUExpandEntry(cright, p_tree->GetDepth(cright), 0.0);
     nodes_to_evaluate->push_back(left_node);
     nodes_to_evaluate->push_back(right_node);
-    if (row_set_collection_[cleft].Size() < row_set_collection_[cright].Size()) {
-      nodes_for_explicit_hist_build_.push_back(left_node);
-      nodes_for_subtraction_trick_.push_back(right_node);
+    bool is_loss_guide =  static_cast<TrainParam::TreeGrowPolicy>(param_.grow_policy) ==
+                          TrainParam::kDepthWise ? false : true;
+    if (is_loss_guide) {
+      if (opt_partition_builder_.partitions_[cleft].Size() <=
+          opt_partition_builder_.partitions_[cright].Size()) {
+        nodes_for_explicit_hist_build_.push_back(left_node);
+        nodes_for_subtraction_trick_.push_back(right_node);
+      } else {
+        nodes_for_explicit_hist_build_.push_back(right_node);
+        nodes_for_subtraction_trick_.push_back(left_node);
+      }
     } else {
-      nodes_for_explicit_hist_build_.push_back(right_node);
-      nodes_for_subtraction_trick_.push_back(left_node);
+      if (entry.split.left_sum.GetHess() <= entry.split.right_sum.GetHess()) {
+        nodes_for_explicit_hist_build_.push_back(left_node);
+        nodes_for_subtraction_trick_.push_back(right_node);
+      } else {
+        nodes_for_explicit_hist_build_.push_back(right_node);
+        nodes_for_subtraction_trick_.push_back(left_node);
+      }
     }
   }
-  CHECK_EQ(nodes_for_subtraction_trick_.size(), nodes_for_explicit_hist_build_.size());
   builder_monitor_.Stop("SplitSiblings");
 }
 
 template<typename GradientSumT>
-template <bool any_missing>
+template <typename BinIdxType, bool any_missing, bool hist_fit_to_l2>
 void QuantileHistMaker::Builder<GradientSumT>::ExpandTree(
     const GHistIndexMatrix& gmat,
     const ColumnMatrix& column_matrix,
@@ -237,44 +289,89 @@ void QuantileHistMaker::Builder<GradientSumT>::ExpandTree(
     const std::vector<GradientPair>& gpair_h) {
   builder_monitor_.Start("ExpandTree");
   int num_leaves = 0;
+  saved_split_ind_.clear();
+  saved_split_ind_.resize(1 << (param_.max_depth + 1), 0);
+  split_conditions_.clear();
+  split_ind_.clear();
+  is_compleate_tree_ = true;
 
   Driver<CPUExpandEntry> driver(static_cast<TrainParam::TreeGrowPolicy>(param_.grow_policy));
   std::vector<CPUExpandEntry> expand;
-  InitRoot<any_missing>(p_fmat, p_tree, gpair_h, &num_leaves, &expand);
-  driver.Push(expand[0]);
 
-  int32_t depth = 0;
+  std::vector<size_t>& row_indices = *row_set_collection_.Data();
+  const size_t size_threads = row_indices.size() == 0 ?
+                              (gmat.row_ptr.size() - 1) : row_indices.size();
+
+  opt_partition_builder_.SetSlice(0, 0, size_threads);
+  const size_t n_threads = omp_get_max_threads();
+  opt_partition_builder_.nthreads_ = n_threads;
+  node_ids_.resize(size_threads, 0);
+  bool is_loss_guide = static_cast<TrainParam::TreeGrowPolicy>(param_.grow_policy) ==
+                       TrainParam::kDepthWise ? false : true;
+  int depth = 0;
+  curr_level_nodes_.clear();
+  curr_level_nodes_.resize(1 << (param_.max_depth + 2), 0);
+  nodes_mapping_.resize(1 << (param_.max_depth + 2), 0);
+  nodes_mapping_[0] = 0;
+  InitRoot<BinIdxType, any_missing, hist_fit_to_l2>(gmat, p_fmat, p_tree, gpair_h,
+                                                    &num_leaves, &expand, nullptr,
+                                                    column_matrix, is_loss_guide);
+  driver.Push(expand[0]);
+  compleate_trees_depth_wise_.clear();
+  compleate_trees_depth_wise_.emplace_back(0);
   while (!driver.IsEmpty()) {
+    std::vector<bool> smalest_nodes_mask(1 << (param_.max_depth + 2), false);
     expand = driver.Pop();
     depth = expand[0].depth + 1;
+
     std::vector<CPUExpandEntry> nodes_for_apply_split;
     std::vector<CPUExpandEntry> nodes_to_evaluate;
     nodes_for_explicit_hist_build_.clear();
     nodes_for_subtraction_trick_.clear();
 
-    AddSplitsToTree(expand, p_tree, &num_leaves, &nodes_for_apply_split);
-
+    AddSplitsToTree(expand, p_tree, &num_leaves, &nodes_for_apply_split, &smalest_nodes_mask);
     if (nodes_for_apply_split.size() != 0) {
-      ApplySplit<any_missing>(nodes_for_apply_split, gmat, column_matrix, p_tree);
-      SplitSiblings(nodes_for_apply_split, &nodes_to_evaluate, p_tree);
-
-      if (depth < param_.max_depth) {
-        this->histogram_builder_->BuildHist(
-            p_fmat, p_tree, row_set_collection_, nodes_for_explicit_hist_build_,
-            nodes_for_subtraction_trick_, gpair_h);
+      if (is_loss_guide) {
+        ApplySplit<any_missing, BinIdxType, true>(nodes_for_apply_split,
+                                                  gmat, column_matrix,
+                                                  this->histogram_builder_->Histogram(),
+                                                  p_tree, depth, &smalest_nodes_mask,
+                                                  gpair_h, is_loss_guide);
       } else {
-        int starting_index = std::numeric_limits<int>::max();
-        int sync_count = 0;
-        this->histogram_builder_->AddHistRows(
-            &starting_index, &sync_count, nodes_for_explicit_hist_build_,
-            nodes_for_subtraction_trick_, p_tree);
+        ApplySplit<any_missing, BinIdxType, false>(nodes_for_apply_split,
+                                                   gmat, column_matrix,
+                                                   this->histogram_builder_->Histogram(),
+                                                   p_tree, depth, &smalest_nodes_mask,
+                                                   gpair_h, is_loss_guide);
       }
 
-      builder_monitor_.Start("EvaluateSplits");
-      evaluator_->EvaluateSplits(this->histogram_builder_->Histogram(), gmat,
-                                 *p_tree, &nodes_to_evaluate);
-      builder_monitor_.Stop("EvaluateSplits");
-
+      SplitSiblings(nodes_for_apply_split, &nodes_to_evaluate, p_tree);
+      int starting_index = std::numeric_limits<int>::max();
+      int sync_count = 0;
+      if (depth < param_.max_depth) {
+        this->histogram_builder_->template BuildHist<BinIdxType,
+                                                     any_missing,
+                                                     hist_fit_to_l2>(p_fmat, gmat, p_tree,
+                                                                     gpair_h, depth,
+                                                                     column_matrix,
+                                                                     nodes_for_explicit_hist_build_,
+                                                                     nodes_for_subtraction_trick_,
+                                                                     &opt_partition_builder_,
+                                                                     &nodes_mapping_, &node_ids_);
+        builder_monitor_.Start("EvaluateSplits");
+        for (auto const &gmat_local : p_fmat->GetBatches<GHistIndexMatrix>(
+             BatchParam{GenericParameter::kCpuId, param_.max_bin})) {
+          evaluator_->EvaluateSplits(this->histogram_builder_->Histogram(),
+                                    gmat_local, *p_tree, &nodes_for_explicit_hist_build_,
+                                    &nodes_for_subtraction_trick_, &nodes_to_evaluate,
+                                    histogram_builder_->GetHistBuffer(), &opt_partition_builder_,
+                                    &nodes_mapping_, p_tree,
+                                    param_.colsample_bylevel != 1 ||
+                                    param_.colsample_bynode  != 1 ||
+                                    param_.colsample_bytree  != 1);
+        }
+        builder_monitor_.Stop("EvaluateSplits");
+      }
       for (size_t i = 0; i < nodes_for_apply_split.size(); ++i) {
         CPUExpandEntry left_node = nodes_to_evaluate.at(i * 2 + 0);
         CPUExpandEntry right_node = nodes_to_evaluate.at(i * 2 + 1);
@@ -303,18 +400,63 @@ void QuantileHistMaker::Builder<GradientSumT>::Update(
   }
   p_last_fmat_mutable_ = p_fmat;
 
-  this->InitData(gmat, *p_fmat, *p_tree, gpair_ptr);
-
-  if (column_matrix.AnyMissing()) {
-    ExpandTree<true>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
-  } else {
-    ExpandTree<false>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+  this->InitData(gmat, column_matrix, *p_fmat, *p_tree, gpair_ptr);
+  CHECK_EQ(!column_matrix.AnyMissing(), gmat.IsDense());
+  const bool hist_fit_to_l2 = 1024*1024*0.8 > 16*gmat.cut.Ptrs().back();
+  switch (column_matrix.GetTypeSize()) {
+    case common::kUint8BinsTypeSize:
+      if (column_matrix.AnyMissing()) {
+        if (hist_fit_to_l2) {
+          ExpandTree<uint8_t, true, true>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        } else {
+          ExpandTree<uint8_t, true, false>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        }
+      } else {
+        if (hist_fit_to_l2) {
+          ExpandTree<uint8_t, false, true>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        } else {
+          ExpandTree<uint8_t, false, false>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        }
+      }
+      break;
+    case common::kUint16BinsTypeSize:
+      if (column_matrix.AnyMissing()) {
+        if (hist_fit_to_l2) {
+          ExpandTree<uint16_t, true, true>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        } else {
+          ExpandTree<uint16_t, true, false>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        }
+      } else {
+        if (hist_fit_to_l2) {
+          ExpandTree<uint16_t, false, true>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        } else {
+          ExpandTree<uint16_t, false, false>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        }
+      }
+      break;
+    case common::kUint32BinsTypeSize:
+      if (column_matrix.AnyMissing()) {
+        if (hist_fit_to_l2) {
+          ExpandTree<uint32_t, true, true>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        } else {
+          ExpandTree<uint32_t, true, false>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        }
+      } else {
+        if (hist_fit_to_l2) {
+          ExpandTree<uint32_t, false, true>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        } else {
+          ExpandTree<uint32_t, false, false>(gmat, column_matrix, p_fmat, p_tree, *gpair_ptr);
+        }
+      }
+      break;
+    default:
+      CHECK(false);  // no default behavior
   }
+
   pruner_->Update(gpair, p_fmat, std::vector<RegTree*>{p_tree});
 
   builder_monitor_.Stop("Update");
 }
-
 template<typename GradientSumT>
 bool QuantileHistMaker::Builder<GradientSumT>::UpdatePredictionCache(
     const DMatrix* data,
@@ -329,33 +471,28 @@ bool QuantileHistMaker::Builder<GradientSumT>::UpdatePredictionCache(
 
   CHECK_GT(out_preds.Size(), 0U);
 
-  size_t n_nodes = row_set_collection_.end() - row_set_collection_.begin();
-
-  common::BlockedSpace2d space(n_nodes, [&](size_t node) {
-    return row_set_collection_[node].Size();
-  }, 1024);
-  CHECK_EQ(out_preds.DeviceIdx(), GenericParameter::kCpuId);
-  common::ParallelFor2d(space, this->nthread_, [&](size_t node, common::Range1d r) {
-    const RowSetCollection::Elem rowset = row_set_collection_[node];
-    if (rowset.begin != nullptr && rowset.end != nullptr) {
-      int nid = rowset.node_id;
-      bst_float leaf_value;
-      // if a node is marked as deleted by the pruner, traverse upward to locate
-      // a non-deleted leaf.
-      if ((*p_last_tree_)[nid].IsDeleted()) {
-        while ((*p_last_tree_)[nid].IsDeleted()) {
-          nid = (*p_last_tree_)[nid].Parent();
+    common::BlockedSpace2d space(1, [&](size_t node) {
+      return node_ids_.size();
+    }, 1024);
+    common::ParallelFor2d(space, this->nthread_, [&](size_t node, common::Range1d r) {
+      int tid = omp_get_thread_num();
+      for (size_t it = r.begin(); it <  r.end(); ++it) {
+        bst_float leaf_value;
+        // if a node is marked as deleted by the pruner, traverse upward to locate
+        // a non-deleted leaf.
+        int nid = (~((uint16_t)(1) << 15)) & node_ids_[it];
+        if ((*p_last_tree_)[nid].IsDeleted()) {
+          while ((*p_last_tree_)[nid].IsDeleted()) {
+            nid = (*p_last_tree_)[nid].Parent();
+          }
+          CHECK((*p_last_tree_)[nid].IsLeaf());
         }
-        CHECK((*p_last_tree_)[nid].IsLeaf());
+        leaf_value = (*p_last_tree_)[nid].LeafValue();
+        out_preds[it] += leaf_value;
+        // CHECK_LT(nid,  nodes_count[tid].size());
+        // nodes_count[tid][nid] += 1;
       }
-      leaf_value = (*p_last_tree_)[nid].LeafValue();
-
-      for (const size_t* it = rowset.begin + r.begin(); it < rowset.begin + r.end(); ++it) {
-        out_preds[*it] += leaf_value;
-      }
-    }
-  });
-
+    });
   builder_monitor_.Stop("UpdatePredictionCache");
   return true;
 }
@@ -403,10 +540,12 @@ size_t QuantileHistMaker::Builder<GradientSumT>::GetNumberOfTrees() {
   return n_trees_;
 }
 
-template <typename GradientSumT>
-void QuantileHistMaker::Builder<GradientSumT>::InitData(
-    const GHistIndexMatrix &gmat, const DMatrix &fmat, const RegTree &tree,
-    std::vector<GradientPair> *gpair) {
+template<typename GradientSumT>
+void QuantileHistMaker::Builder<GradientSumT>::InitData(const GHistIndexMatrix& gmat,
+                                          const ColumnMatrix& column_matrix,
+                                          const DMatrix& fmat,
+                                          const RegTree& tree,
+                                          std::vector<GradientPair>* gpair) {
   CHECK((param_.max_depth > 0 || param_.max_leaves > 0))
       << "max_depth or max_leaves cannot be both 0 (unlimited); "
       << "at least one should be a positive quantity.";
@@ -419,7 +558,7 @@ void QuantileHistMaker::Builder<GradientSumT>::InitData(
 
   {
     // initialize the row set
-    row_set_collection_.Clear();
+    // row_set_collection_.Clear();
     // initialize histogram collection
     uint32_t nbins = gmat.cut.Ptrs().back();
     // initialize histogram builder
@@ -431,64 +570,69 @@ void QuantileHistMaker::Builder<GradientSumT>::InitData(
       });
     }
     exc.Rethrow();
-    this->histogram_builder_->Reset(nbins, param_.max_bin, this->nthread_);
-
-    std::vector<size_t>& row_indices = *row_set_collection_.Data();
-    row_indices.resize(info.num_row_);
-    size_t* p_row_indices = row_indices.data();
-    // mark subsample and build list of member rows
-
+    this->histogram_builder_->Reset(nbins, param_.max_bin, this->nthread_,
+                                    gmat.cut.Ptrs().size() - 1, param_.max_depth,
+                                    param_.colsample_bytree, param_.colsample_bylevel,
+                                    param_.colsample_bynode,
+                                    column_sampler_, gmat.index.Offset(), gmat.IsDense());
     if (param_.subsample < 1.0f) {
       CHECK_EQ(param_.sampling_method, TrainParam::kUniform)
         << "Only uniform sampling is supported, "
         << "gradient-based sampling is only support by GPU Hist.";
       builder_monitor_.Start("InitSampling");
-      InitSampling(fmat, gpair, &row_indices);
+      InitSampling(fmat, gpair, nullptr);
       builder_monitor_.Stop("InitSampling");
-      CHECK_EQ(row_indices.size(), info.num_row_);
       // We should check that the partitioning was done correctly
       // and each row of the dataset fell into exactly one of the categories
     }
-    common::MemStackAllocator<bool, 128> buff(this->nthread_);
-    bool* p_buff = buff.Get();
-    std::fill(p_buff, p_buff + this->nthread_, false);
+    const bool is_lossguide = static_cast<TrainParam::TreeGrowPolicy>(param_.grow_policy) !=
+                              TrainParam::kDepthWise;
 
+    switch (column_matrix.GetTypeSize()) {
+      case common::kUint8BinsTypeSize:
+        opt_partition_builder_.Init<uint8_t>(gmat, column_matrix, &tree,
+                                             this->nthread_, param_.max_depth,
+                                             info.num_row_, is_lossguide);
+
+        break;
+      case common::kUint16BinsTypeSize:
+        opt_partition_builder_.Init<uint16_t>(gmat, column_matrix, &tree,
+                                              this->nthread_, param_.max_depth,
+                                              info.num_row_, is_lossguide);
+
+        break;
+      case common::kUint32BinsTypeSize:
+        opt_partition_builder_.Init<uint32_t>(gmat, column_matrix, &tree,
+                                              this->nthread_, param_.max_depth,
+                                              info.num_row_, is_lossguide);
+        break;
+      default:
+        CHECK(false);  // no default behavior
+    }
+
+    // mark subsample and build list of member rows
     const size_t block_size = info.num_row_ / this->nthread_ + !!(info.num_row_ % this->nthread_);
 
-    #pragma omp parallel num_threads(this->nthread_)
-    {
-      exc.Run([&]() {
-        const size_t tid = omp_get_thread_num();
-        const size_t ibegin = tid * block_size;
-        const size_t iend = std::min(static_cast<size_t>(ibegin + block_size),
-            static_cast<size_t>(info.num_row_));
+    // #pragma omp parallel num_threads(this->nthread_)
+    // {
+    //   exc.Run([&]() {
+    //     const size_t tid = omp_get_thread_num();
+    //     const size_t ibegin = tid * block_size;
+    //     const size_t iend = std::min(static_cast<size_t>(ibegin + block_size),
+    //         static_cast<size_t>(info.num_row_));
 
-        for (size_t i = ibegin; i < iend; ++i) {
-          if ((*gpair)[i].GetHess() < 0.0f) {
-            p_buff[tid] = true;
-            break;
-          }
-        }
-      });
-    }
-    exc.Rethrow();
+    //     for (size_t i = ibegin; i < iend; ++i) {
+    //       if ((*gpair)[i].GetHess() < 0.0f) {
+    //         (*gpair)[i] = GradientPair(0);
+    //       }
+    //     }
+    //   });
+    // }
+    // exc.Rethrow();
 
-    bool has_neg_hess = false;
-    for (int32_t tid = 0; tid < this->nthread_; ++tid) {
-      if (p_buff[tid]) {
-        has_neg_hess = true;
-      }
-    }
-
-    if (has_neg_hess) {
-      size_t j = 0;
-      for (size_t i = 0; i < info.num_row_; ++i) {
-        if ((*gpair)[i].GetHess() >= 0.0f) {
-          p_row_indices[j++] = i;
-        }
-      }
-      row_indices.resize(j);
-    } else {
+    if (is_lossguide) {
+      opt_partition_builder_.ResizeRowsBuffer(info.num_row_);
+      uint32_t* row_set_collection_vec_p = opt_partition_builder_.GetRowsBuffer();
       #pragma omp parallel num_threads(this->nthread_)
       {
         exc.Run([&]() {
@@ -497,15 +641,13 @@ void QuantileHistMaker::Builder<GradientSumT>::InitData(
           const size_t iend = std::min(static_cast<size_t>(ibegin + block_size),
               static_cast<size_t>(info.num_row_));
           for (size_t i = ibegin; i < iend; ++i) {
-            p_row_indices[i] = i;
+            row_set_collection_vec_p[i] = i;
           }
         });
       }
       exc.Rethrow();
     }
   }
-
-  row_set_collection_.Init();
 
   {
     /* determine layout of data */
@@ -566,8 +708,6 @@ void QuantileHistMaker::Builder<GradientSumT>::FindSplitConditions(
                                                      const GHistIndexMatrix& gmat,
                                                      std::vector<int32_t>* split_conditions) {
   const size_t n_nodes = nodes.size();
-  split_conditions->resize(n_nodes);
-
   for (size_t i = 0; i < nodes.size(); ++i) {
     const int32_t nid = nodes[i].nid;
     const bst_uint fid = tree[nid].SplitIndex();
@@ -584,88 +724,85 @@ void QuantileHistMaker::Builder<GradientSumT>::FindSplitConditions(
         split_cond = static_cast<int32_t>(bound);
       }
     }
-    (*split_conditions)[i] = split_cond;
-  }
-}
-template <typename GradientSumT>
-void QuantileHistMaker::Builder<GradientSumT>::AddSplitsToRowSet(
-                                               const std::vector<CPUExpandEntry>& nodes,
-                                               RegTree* p_tree) {
-  const size_t n_nodes = nodes.size();
-  for (unsigned int i = 0; i < n_nodes; ++i) {
-    const int32_t nid = nodes[i].nid;
-    const size_t n_left = partition_builder_.GetNLeftElems(i);
-    const size_t n_right = partition_builder_.GetNRightElems(i);
-    CHECK_EQ((*p_tree)[nid].LeftChild() + 1, (*p_tree)[nid].RightChild());
-    row_set_collection_.AddSplit(nid, (*p_tree)[nid].LeftChild(),
-        (*p_tree)[nid].RightChild(), n_left, n_right);
+
+    (*split_conditions)[nid] = split_cond;
+    saved_split_ind_[nid] = split_cond;
   }
 }
 
 template <typename GradientSumT>
-template <bool any_missing>
+template <bool any_missing, typename BinIdxType, bool is_loss_guided>
 void QuantileHistMaker::Builder<GradientSumT>::ApplySplit(const std::vector<CPUExpandEntry> nodes,
-                                            const GHistIndexMatrix& gmat,
-                                            const ColumnMatrix& column_matrix,
-                                            RegTree* p_tree) {
+                                                          const GHistIndexMatrix& gmat,
+                                                          const ColumnMatrix& column_matrix,
+                                                          const HistCollection<GradientSumT>& hist,
+                                                          RegTree* p_tree, int depth,
+                                                          std::vector<bool>* smalest_nodes_mask_ptr,
+                                                          const std::vector<GradientPair> &gpair_h,
+                                                          bool loss_guide) {
   builder_monitor_.Start("ApplySplit");
   // 1. Find split condition for each split
   const size_t n_nodes = nodes.size();
-  std::vector<int32_t> split_conditions;
+  split_conditions_.resize(1 << (param_.max_depth + 1), 0);
+  std::vector<int32_t>& split_conditions = split_conditions_;
   FindSplitConditions(nodes, *p_tree, gmat, &split_conditions);
   // 2.1 Create a blocked space of size SUM(samples in each node)
-  common::BlockedSpace2d space(n_nodes, [&](size_t node_in_set) {
-    int32_t nid = nodes[node_in_set].nid;
-    return row_set_collection_[nid].Size();
-  }, kPartitionBlockSize);
-  // 2.2 Initialize the partition builder
-  // allocate buffers for storage intermediate results by each thread
-  partition_builder_.Init(space.Size(), n_nodes, [&](size_t node_in_set) {
-    const int32_t nid = nodes[node_in_set].nid;
-    const size_t size = row_set_collection_[nid].Size();
-    const size_t n_tasks = size / kPartitionBlockSize + !!(size % kPartitionBlockSize);
-    return n_tasks;
-  });
-  // 2.3 Split elements of row_set_collection_ to left and right child-nodes for each node
-  // Store results in intermediate buffers from partition_builder_
-  common::ParallelFor2d(space, this->nthread_, [&](size_t node_in_set, common::Range1d r) {
-    size_t begin = r.begin();
-    const int32_t nid = nodes[node_in_set].nid;
-    const size_t task_id = partition_builder_.GetTaskIdx(node_in_set, begin);
-    partition_builder_.AllocateForTask(task_id);
-      switch (column_matrix.GetTypeSize()) {
-      case common::kUint8BinsTypeSize:
-        partition_builder_.template Partition<uint8_t, any_missing>(node_in_set, nid, r,
-                  split_conditions[node_in_set], column_matrix,
-                  *p_tree, row_set_collection_[nid].begin);
-        break;
-      case common::kUint16BinsTypeSize:
-        partition_builder_.template Partition<uint16_t, any_missing>(node_in_set, nid, r,
-                  split_conditions[node_in_set], column_matrix,
-                  *p_tree, row_set_collection_[nid].begin);
-        break;
-      case common::kUint32BinsTypeSize:
-        partition_builder_.template Partition<uint32_t, any_missing>(node_in_set, nid, r,
-                  split_conditions[node_in_set], column_matrix,
-                  *p_tree, row_set_collection_[nid].begin);
-        break;
-      default:
-        CHECK(false);  // no default behavior
-    }
-    });
-  // 3. Compute offsets to copy blocks of row-indexes
-  // from partition_builder_ to row_set_collection_
-  partition_builder_.CalculateRowOffsets();
+  split_ind_.resize(split_conditions.size(), 0);
+  std::vector<uint64_t>& split_ind = split_ind_;
+  const uint32_t* offsets = gmat.index.Offset();
+  const uint64_t rows_offset = gmat.row_ptr.size() - 1;
+  std::vector<uint32_t> split_nodes(n_nodes, 0);
+  for (size_t i = 0; i < n_nodes; ++i) {
+      const int32_t nid = nodes[i].nid;
+      split_nodes[i] = nid;
+      const uint64_t fid = (*p_tree)[nid].SplitIndex();
+      split_ind[nid] = fid*((gmat.IsDense() ? rows_offset : 1));
+      split_conditions[nid] = split_conditions[nid] - gmat.cut.Ptrs()[fid];
+  }
+  const size_t max_depth = param_.max_depth;
 
-  // 4. Copy elements from partition_builder_ to row_set_collection_ back
-  // with updated row-indexes for each tree-node
-  common::ParallelFor2d(space, this->nthread_, [&](size_t node_in_set, common::Range1d r) {
-    const int32_t nid = nodes[node_in_set].nid;
-    partition_builder_.MergeToArray(node_in_set, r.begin(),
-        const_cast<size_t*>(row_set_collection_[nid].begin));
-  });
-  // 5. Add info about splits into row_set_collection_
-  AddSplitsToRowSet(nodes, p_tree);
+  const size_t n_features = gmat.cut.Ptrs().size() - 1;
+  int nthreads = this->nthread_;
+  nthreads = std::min(nthreads, omp_get_max_threads());
+  nthreads = std::max(nthreads, 1);
+
+  const size_t depth_begin = opt_partition_builder_.DepthBegin(compleate_trees_depth_wise_,
+                                                               p_tree, loss_guide);
+  const size_t depth_size = opt_partition_builder_.DepthSize(gmat, compleate_trees_depth_wise_,
+                                                             p_tree, loss_guide);
+  std::vector<bool>& smalest_nodes_mask = *smalest_nodes_mask_ptr;
+#pragma omp parallel num_threads(nthreads)
+  {
+    size_t tid = omp_get_thread_num();
+    const BinIdxType* numa = tid < nthreads/2 ?
+      reinterpret_cast<const BinIdxType*>(column_matrix.GetIndexData()) :
+      reinterpret_cast<const BinIdxType*>(column_matrix.GetIndexSecondData());
+    size_t chunck_size = depth_size / nthreads + !!(depth_size % nthreads);
+    size_t thread_size = chunck_size;
+    size_t begin = thread_size * tid;
+    size_t end = std::min(begin + thread_size, depth_size);
+    begin += depth_begin;
+    end += depth_begin;
+    opt_partition_builder_.template CommonPartition<BinIdxType,
+                                                    is_loss_guided,
+                                                    !any_missing>(tid, begin, end, numa,
+                                                                  node_ids_.data(),
+                                                                  &split_conditions,
+                                                                  &split_ind,
+                                                                  smalest_nodes_mask, gpair_h,
+                                                                  &curr_level_nodes_,
+                                                                  column_matrix, split_nodes);
+  }
+
+  if (depth != max_depth || loss_guide) {
+    builder_monitor_.Start("UpdateRowBuffer&UpdateThreadsWork");
+    opt_partition_builder_.UpdateRowBuffer(compleate_trees_depth_wise_,
+                                           p_tree, gmat, n_features, depth,
+                                           node_ids_, is_loss_guided);
+    opt_partition_builder_.UpdateThreadsWork(compleate_trees_depth_wise_, gmat,
+                                             n_features, depth, is_loss_guided);
+    builder_monitor_.Stop("UpdateRowBuffer&UpdateThreadsWork");
+  }
   builder_monitor_.Stop("ApplySplit");
 }
 

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -221,7 +221,6 @@ void QuantileHistMaker::Builder<GradientSumT>::AddSplitsToTree(
         smalest_nodes_mask[curr_level_nodes_[2*entry.nid + 1]] = true;
       }
     } else {
-      is_compleate_tree_ = false;
       curr_level_nodes_[2*entry.nid] = static_cast<uint16_t>(1) << 15 |
                                        static_cast<uint16_t>(entry.nid);
       curr_level_nodes_[2*entry.nid + 1] = curr_level_nodes_[2*entry.nid];
@@ -284,11 +283,8 @@ void QuantileHistMaker::Builder<GradientSumT>::ExpandTree(
     const std::vector<GradientPair>& gpair_h) {
   builder_monitor_.Start("ExpandTree");
   int num_leaves = 0;
-  saved_split_ind_.clear();
-  saved_split_ind_.resize(1 << (param_.max_depth + 1), 0);
   split_conditions_.clear();
   split_ind_.clear();
-  is_compleate_tree_ = true;
 
   Driver<CPUExpandEntry> driver(static_cast<TrainParam::TreeGrowPolicy>(param_.grow_policy));
   std::vector<CPUExpandEntry> expand;
@@ -698,7 +694,6 @@ void QuantileHistMaker::Builder<GradientSumT>::FindSplitConditions(
     }
 
     (*split_conditions)[nid] = split_cond;
-    saved_split_ind_[nid] = split_cond;
   }
 }
 

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -281,7 +281,6 @@ class QuantileHistMaker: public TreeUpdater {
     RowSetCollection row_set_collection_;
     std::vector<uint16_t> node_ids_;
     std::vector<uint16_t> curr_level_nodes_;
-    std::vector<uint16_t> nodes_mapping_;
     std::vector<int32_t> saved_split_ind_;
     std::vector<int32_t> split_conditions_;
     std::vector<uint64_t> split_ind_;

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -32,6 +32,7 @@
 #include "../common/hist_util.h"
 #include "../common/row_set.h"
 #include "../common/partition_builder.h"
+#include "../common/opt_partition_builder.h"
 #include "../common/column_matrix.h"
 
 namespace xgboost {
@@ -218,6 +219,7 @@ class QuantileHistMaker: public TreeUpdater {
    protected:
     // initialize temp data structure
     void InitData(const GHistIndexMatrix& gmat,
+                  const ColumnMatrix& column_matrix,
                   const DMatrix& fmat,
                   const RegTree& tree,
                   std::vector<GradientPair>* gpair);
@@ -228,23 +230,24 @@ class QuantileHistMaker: public TreeUpdater {
                       std::vector<GradientPair>* gpair,
                       std::vector<size_t>* row_indices);
 
-    template <bool any_missing>
+    template <bool any_missing, typename BinIdxType, bool is_loss_guided>
     void ApplySplit(std::vector<CPUExpandEntry> nodes,
-                        const GHistIndexMatrix& gmat,
-                        const ColumnMatrix& column_matrix,
-                        RegTree* p_tree);
-
-    void AddSplitsToRowSet(const std::vector<CPUExpandEntry>& nodes, RegTree* p_tree);
-
+                    const GHistIndexMatrix& gmat,
+                    const ColumnMatrix& column_matrix,
+                    const HistCollection<GradientSumT>& hist,
+                    RegTree* p_tree, int depth,
+                    std::vector<bool>* smalest_nodes_mask_ptr,
+                    const std::vector<GradientPair> &gpair_h, const bool loss_guide);
 
     void FindSplitConditions(const std::vector<CPUExpandEntry>& nodes, const RegTree& tree,
                              const GHistIndexMatrix& gmat, std::vector<int32_t>* split_conditions);
 
-    template <bool any_missing>
-    void InitRoot(DMatrix* p_fmat,
-                  RegTree *p_tree,
-                  const std::vector<GradientPair> &gpair_h,
-                  int *num_leaves, std::vector<CPUExpandEntry> *expand);
+
+    template <typename BinIdxType, bool any_missing, bool hist_fit_to_l2>
+    void InitRoot(const GHistIndexMatrix &gmat, DMatrix* fmat, RegTree *p_tree,
+                  const std::vector<GradientPair> &gpair_h, int *num_leaves,
+                  std::vector<CPUExpandEntry> *expand, common::BlockedSpace2d* space_ptr,
+                  const ColumnMatrix& column_matrix, bool is_loss_guide);
 
     // Split nodes to 2 sets depending on amount of rows in each node
     // Histograms for small nodes will be built explicitly
@@ -256,9 +259,10 @@ class QuantileHistMaker: public TreeUpdater {
     void AddSplitsToTree(const std::vector<CPUExpandEntry>& expand,
                          RegTree *p_tree,
                          int *num_leaves,
-                         std::vector<CPUExpandEntry>* nodes_for_apply_split);
+                         std::vector<CPUExpandEntry>* nodes_for_apply_split,
+                         std::vector<bool>* smalest_nodes_mask_ptr);
 
-    template <bool any_missing>
+    template <typename BinIdxType, bool any_missing, bool hist_fit_to_l2>
     void ExpandTree(const GHistIndexMatrix& gmat,
                     const ColumnMatrix& column_matrix,
                     DMatrix* p_fmat,
@@ -273,9 +277,18 @@ class QuantileHistMaker: public TreeUpdater {
     std::shared_ptr<common::ColumnSampler> column_sampler_{
         std::make_shared<common::ColumnSampler>()};
 
-    std::vector<size_t> unused_rows_;
     // the internal row sets
     RowSetCollection row_set_collection_;
+    std::vector<uint16_t> node_ids_;
+    std::vector<uint16_t> curr_level_nodes_;
+    std::vector<uint16_t> nodes_mapping_;
+    std::vector<int32_t> saved_split_ind_;
+    std::vector<int32_t> split_conditions_;
+    std::vector<uint64_t> split_ind_;
+    std::vector<uint16_t> compleate_trees_depth_wise_;
+    bool is_compleate_tree_ = true;
+
+
     std::vector<GradientPair> gpair_local_;
 
     /*! \brief feature with least # of bins. to be used for dense specialization
@@ -287,7 +300,7 @@ class QuantileHistMaker: public TreeUpdater {
 
     static constexpr size_t kPartitionBlockSize = 2048;
     common::PartitionBuilder<kPartitionBlockSize> partition_builder_;
-
+    common::OptPartitionBuilder opt_partition_builder_;
     // back pointers to tree and data matrix
     const RegTree* p_last_tree_;
     DMatrix const* const p_last_fmat_;

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -281,12 +281,9 @@ class QuantileHistMaker: public TreeUpdater {
     RowSetCollection row_set_collection_;
     std::vector<uint16_t> node_ids_;
     std::vector<uint16_t> curr_level_nodes_;
-    std::vector<int32_t> saved_split_ind_;
     std::vector<int32_t> split_conditions_;
     std::vector<uint64_t> split_ind_;
     std::vector<uint16_t> compleate_trees_depth_wise_;
-    bool is_compleate_tree_ = true;
-
 
     std::vector<GradientPair> gpair_local_;
 

--- a/tests/cpp/common/test_hist_util.cc
+++ b/tests/cpp/common/test_hist_util.cc
@@ -317,15 +317,15 @@ TEST(HistUtil, IndexBinData) {
     EXPECT_EQ(hmat.index.Size(), kRows*kCols);
     switch (max_bin) {
       case kBinSizes[0]:
-        CheckIndexData(hmat.index.data<uint8_t>(),
+        CheckIndexData(hmat.index.Data<uint8_t>(),
                        offsets, hmat, kCols);
         break;
       case kBinSizes[1]:
-        CheckIndexData(hmat.index.data<uint16_t>(),
+        CheckIndexData(hmat.index.Data<uint16_t>(),
                        offsets, hmat, kCols);
         break;
       case kBinSizes[2]:
-        CheckIndexData(hmat.index.data<uint32_t>(),
+        CheckIndexData(hmat.index.Data<uint32_t>(),
                        offsets, hmat, kCols);
         break;
     }

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -58,7 +58,31 @@ template <typename GradientSumT> void TestEvaluateSplits() {
   entries.front().depth = 0;
 
   evaluator.InitRoot(GradStats{total_gpair});
-  evaluator.EvaluateSplits(hist, gmat, tree, &entries);
+  std::vector<CPUExpandEntry> entries_sub;
+  std::vector<std::vector<std::vector<GradientSumT>>> histograms;
+
+  ColumnMatrix column_matrix;
+  column_matrix.Init(gmat, 1);
+
+  // create partitioner
+  common::OptPartitionBuilder opt_partition_builder;
+  opt_partition_builder.template Init<uint8_t>(gmat,
+                                      column_matrix,
+                                      &tree,
+                                      omp_get_max_threads(),
+                                      1,
+                                      kRows,
+                                      false);
+  opt_partition_builder.UpdateRootThreadWork(true);
+
+  std::vector<uint16_t> nodes_mapping;
+  RegTree* p_tree = nullptr;
+
+  std::cout << "EvaluateSplits" << std::endl;
+  evaluator.EvaluateSplits(hist, gmat, tree, &entries, &entries_sub,
+                           &entries, &histograms, &opt_partition_builder,
+                           &nodes_mapping, p_tree, true);
+  std::cout << "EvaluateSplits finished" << std::endl;
 
   auto best_loss_chg =
       evaluator.Evaluator().CalcSplitGain(

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -76,13 +76,13 @@ template <typename GradientSumT> void TestEvaluateSplits() {
   opt_partition_builder.UpdateRootThreadWork(true);
 
   std::vector<uint16_t> nodes_mapping;
+  std::vector<std::vector<uint16_t>> local_threads_mapping;
   RegTree* p_tree = nullptr;
 
-  std::cout << "EvaluateSplits" << std::endl;
   evaluator.EvaluateSplits(hist, gmat, tree, &entries, &entries_sub,
-                           &entries, &histograms, &opt_partition_builder,
-                           &nodes_mapping, p_tree, true);
-  std::cout << "EvaluateSplits finished" << std::endl;
+                           &entries, &histograms, &local_threads_mapping,
+                           &opt_partition_builder,
+                           p_tree, true);
 
   auto best_loss_chg =
       evaluator.Evaluator().CalcSplitGain(

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -186,19 +186,18 @@ void TestSyncHist(bool is_distributed) {
   // sync hist
   common::OptPartitionBuilder opt_partition_builder;
   opt_partition_builder.threads_id_for_nodes.resize(nodes_for_explicit_hist_build_[nodes_for_explicit_hist_build_.size() - 1].nid + 1);
-  const std::vector<uint16_t> nodes_mapping;
 
   if (is_distributed) {
     histogram.template SyncHistograms<true>(gmat, &tree, nodes_for_explicit_hist_build_,
                                             nodes_for_subtraction_trick_,
                                             starting_index, sync_count,
-                                            &opt_partition_builder, &nodes_mapping);
+                                            &opt_partition_builder);
 
   } else {
     histogram.template SyncHistograms<false>(gmat, &tree, nodes_for_explicit_hist_build_,
                                              nodes_for_subtraction_trick_,
                                              starting_index, sync_count,
-                                             &opt_partition_builder, &nodes_mapping);
+                                             &opt_partition_builder);
   }
 
   using GHistRowT = common::GHistRow<GradientSumT>;
@@ -294,7 +293,6 @@ void TestBuildHistogram(bool is_distributed) {
                                       kNRows,
                                       false);
   opt_partition_builder.UpdateRootThreadWork(true);
-  std::vector<uint16_t> nodes_mapping(1, 0);
   std::vector<uint16_t> node_ids(kNRows, 0);
 
 
@@ -302,7 +300,6 @@ void TestBuildHistogram(bool is_distributed) {
                       nodes_for_explicit_hist_build_,
                       nodes_for_subtraction_trick_,
                       &opt_partition_builder,
-                      &nodes_mapping,
                       &node_ids);
 
   // Check if number of histogram bins is correct

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -185,7 +185,7 @@ void TestSyncHist(bool is_distributed) {
 
   // sync hist
   common::OptPartitionBuilder opt_partition_builder;
-  opt_partition_builder.threads_id_for_nodes_.resize(nodes_for_explicit_hist_build_[nodes_for_explicit_hist_build_.size() - 1].nid + 1);
+  opt_partition_builder.threads_id_for_nodes.resize(nodes_for_explicit_hist_build_[nodes_for_explicit_hist_build_.size() - 1].nid + 1);
   const std::vector<uint16_t> nodes_mapping;
 
   if (is_distributed) {

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -135,8 +135,8 @@ class QuantileHistMock : public QuantileHistMaker {
         ColumnMatrix column_matrix;
         column_matrix.Init(gmat, 1);
         RealImpl::InitData(gmat, column_matrix, *p_fmat, tree, gpair);
-        for (size_t i = 0; i < unused_rows.size(); ++i) {
-          ASSERT_EQ((*gpair)[unused_rows[i]], GradientPair(0));
+        for (const size_t unused_row : unused_rows) {
+          ASSERT_EQ((*gpair)[unused_row], GradientPair(0));
         }
       }
       omp_set_num_threads(nthreads);
@@ -237,8 +237,8 @@ class QuantileHistMock : public QuantileHistMaker {
           RealImpl::opt_partition_builder_.UpdateRowBuffer(node_ids, &tree,
                                                            gmat, gmat.cut.Ptrs().size() - 1,
                                                            0, node_ids, false);
-          ASSERT_EQ(RealImpl::opt_partition_builder_.summ_size_, left_cnt);
-          ASSERT_EQ(num_row - RealImpl::opt_partition_builder_.summ_size_, right_cnt);
+          ASSERT_EQ(RealImpl::opt_partition_builder_.summ_size, left_cnt);
+          ASSERT_EQ(num_row - RealImpl::opt_partition_builder_.summ_size, right_cnt);
         }
       }
       omp_set_num_threads(initial_nthreads);


### PR DESCRIPTION
Here is several optimizations of cpu hist method mostly applicable for large datasets like Airline(100M), Higgs(10m), Epsilon(2k X 400k) to increase hw utilization (as for such large data it's better to read bin matrix in not random sequence while building histograms that's why optimized partition was implemented). Summary of this PR:

- sync and evaluate kernels were merged (helped to improve "elavuate+sync" kernels performance for wide histogram (bosch, santander, epsilon) by 2x), added guided scheduling instead of static as each feature has unique number of bins.
- improved partition kernel: allowed to prepare work for thread build hist with **not random** memory access for nodes levels below root, reduced merge indexes time.
- improved build hist kernel with supporting different strategies: reading by rows/columns to keep cache locality, simple columnar sampling support.
- improved objective function calculation (reduced number of blocks and avoided overheads of `operator[]` helped to decrease objective func. computation time almost 5x).
- improved `UpdatePredictionCache` as optimized partition consists position info (node ids) for each training row.

Final results:

|            | airline | epsilon | higgs | bosch (consist missings)  | santander (consist missings) | url (consist missings)| mortgage | airline-ohe | msrank |
|------------|---------|---------|-------|--------|-----------|-------|----------|-------------|--------|
| master, s  | 403.61  | 772.716 | 53.73 | 44.102 | 121.94    | 93.28 | 11.35    | 35.04       | 66.44  |
| this PR, s | 109.49  | 248.44  | 23.77 | 30.3   | 25.16     | 52.3 | 6.9      | 23.58       | 46.14  |
| speedup    | 3.69    | 3.11    | 2.26  | 1.47   | 4.85      | 1.79 | 1.64     | 1.49        | 1.44   |

There is no difference in log loss, rmse, ... metrics for disabled `colsampling_by_node` sampling.
Only small difference in case of enabled 'colsampling_by_node' is just due to changed rng call sequence (that's why changes were introduced into `feature_weights.py` demo).

Of course refactoring is required, but I wanted to start it after a brief overview.