### PR TITLE
Fix auc.cu compilation having no atomicAdd() instance overload.

### DIFF
--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -1371,22 +1371,22 @@ void ArgSort(xgboost::common::Span<U> keys, xgboost::common::Span<IdxT> sorted_i
 
   if (accending) {
     void *d_temp_storage = nullptr;
-    safe_cuda((cub::DispatchRadixSort<false, KeyT, ValueT, std::ptrdiff_t>::Dispatch(
+    safe_cuda((cub::DispatchRadixSort<false, KeyT, ValueT, int32_t>::Dispatch(
         d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0,
         sizeof(KeyT) * 8, false, nullptr, false)));
     TemporaryArray<char> storage(bytes);
     d_temp_storage = storage.data().get();
-    safe_cuda((cub::DispatchRadixSort<false, KeyT, ValueT, std::ptrdiff_t>::Dispatch(
+    safe_cuda((cub::DispatchRadixSort<false, KeyT, ValueT, int32_t>::Dispatch(
         d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0,
         sizeof(KeyT) * 8, false, nullptr, false)));
   } else {
     void *d_temp_storage = nullptr;
-    safe_cuda((cub::DispatchRadixSort<true, KeyT, ValueT, std::ptrdiff_t>::Dispatch(
+    safe_cuda((cub::DispatchRadixSort<true, KeyT, ValueT, int32_t>::Dispatch(
         d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0,
         sizeof(KeyT) * 8, false, nullptr, false)));
     TemporaryArray<char> storage(bytes);
     d_temp_storage = storage.data().get();
-    safe_cuda((cub::DispatchRadixSort<true, KeyT, ValueT, std::ptrdiff_t>::Dispatch(
+    safe_cuda((cub::DispatchRadixSort<true, KeyT, ValueT, int32_t>::Dispatch(
         d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0,
         sizeof(KeyT) * 8, false, nullptr, false)));
   }


### PR DESCRIPTION
This small PR fix compile error of ```auc.cu```:

* The error appears on any cuda == 11.x variants regardless compute arch flags.
* The error appears multiple places in auc.cu when about invoking index sorting:
```
/home/cbalint/rpmbuild/BUILD/xgboost/src/metric/auc.cu(99): here

/usr/local/cuda-11.4/bin/../targets/x86_64-linux/include/cub/device/dispatch/../../
agent/agent_radix_sort_onesweep.cuh(657): error: 
no instance of overloaded function "atomicAdd" matches the argument list
            argument types are: (std::ptrdiff_t *, int)
          detected during:
            instantiation of "cub::AgentRadixSortOnesweep<AgentRadixSortOnesweepPolicy, IS_DESCENDING
```

In basic ```std::ptrdiff_t``` (an elegant intention) is replaced by ```int32_t``` to satisfy cub library.
Another possible solution is a local atomicAdd(pairdiff_t *, int) overload like #7198 .

Cc @trivialfis 