### PR TITLE
Add noexcept to JSON objects.

### DIFF
--- a/include/xgboost/json.h
+++ b/include/xgboost/json.h
@@ -82,7 +82,7 @@ class JsonString : public Value {
   JsonString() : Value(ValueKind::kString) {}
   JsonString(std::string const& str) :  // NOLINT
       Value(ValueKind::kString), str_{str} {}
-  JsonString(std::string&& str) :  // NOLINT
+  JsonString(std::string&& str) noexcept :  // NOLINT
       Value(ValueKind::kString), str_{std::move(str)} {}
   JsonString(JsonString&& str) noexcept :  // NOLINT
       Value(ValueKind::kString), str_{std::move(str.str_)} {}
@@ -109,12 +109,12 @@ class JsonArray : public Value {
 
  public:
   JsonArray() : Value(ValueKind::kArray) {}
-  JsonArray(std::vector<Json>&& arr) :  // NOLINT
+  JsonArray(std::vector<Json>&& arr) noexcept :  // NOLINT
       Value(ValueKind::kArray), vec_{std::move(arr)} {}
   JsonArray(std::vector<Json> const& arr) :  // NOLINT
       Value(ValueKind::kArray), vec_{arr} {}
   JsonArray(JsonArray const& that) = delete;
-  JsonArray(JsonArray && that);
+  JsonArray(JsonArray && that) noexcept;
 
   void Save(JsonWriter* writer) override;
 
@@ -138,9 +138,9 @@ class JsonObject : public Value {
 
  public:
   JsonObject() : Value(ValueKind::kObject) {}
-  JsonObject(std::map<std::string, Json>&& object);  // NOLINT
+  JsonObject(std::map<std::string, Json>&& object) noexcept;  // NOLINT
   JsonObject(JsonObject const& that) = delete;
-  JsonObject(JsonObject && that);
+  JsonObject(JsonObject && that) noexcept;
 
   void Save(JsonWriter* writer) override;
 
@@ -419,9 +419,9 @@ class Json {
   Json(Json const& other) = default;
   Json& operator=(Json const& other);
   // move
-  Json(Json&& other) : ptr_{std::move(other.ptr_)} {}
-  Json& operator=(Json&& other) {
-    ptr_ = std::move(other.ptr_);
+  Json(Json &&other) noexcept { std::swap(this->ptr_, other.ptr_); }
+  Json &operator=(Json &&other) noexcept {
+    std::swap(this->ptr_, other.ptr_);
     return *this;
   }
 

--- a/src/common/json.cc
+++ b/src/common/json.cc
@@ -751,4 +751,9 @@ std::ostream &operator<<(std::ostream &os, StringView const v) {
   }
   return os;
 }
+
+static_assert(std::is_nothrow_move_constructible<Json>::value, "");
+static_assert(std::is_nothrow_move_constructible<Object>::value, "");
+static_assert(std::is_nothrow_move_constructible<Array>::value, "");
+static_assert(std::is_nothrow_move_constructible<String>::value, "");
 }  // namespace xgboost

--- a/src/common/json.cc
+++ b/src/common/json.cc
@@ -169,10 +169,10 @@ Json& DummyJsonObject() {
 }
 
 // Json Object
-JsonObject::JsonObject(JsonObject && that) :
+JsonObject::JsonObject(JsonObject && that) noexcept :
     Value(ValueKind::kObject), object_{std::move(that.object_)} {}
 
-JsonObject::JsonObject(std::map<std::string, Json>&& object)
+JsonObject::JsonObject(std::map<std::string, Json> &&object) noexcept
     : Value(ValueKind::kObject), object_{std::move(object)} {}
 
 Json& JsonObject::operator[](std::string const & key) {
@@ -233,7 +233,7 @@ void JsonString::Save(JsonWriter* writer) {
 }
 
 // Json Array
-JsonArray::JsonArray(JsonArray && that) :
+JsonArray::JsonArray(JsonArray && that) noexcept :
     Value(ValueKind::kArray), vec_{std::move(that.vec_)} {}
 
 Json& JsonArray::operator[](std::string const& ) {
@@ -406,7 +406,7 @@ Json JsonReader::Parse() {
       Error("Unknown construct");
     }
   }
-  return Json();
+  return {};
 }
 
 Json JsonReader::Load() {

--- a/tests/cpp/common/test_json.cc
+++ b/tests/cpp/common/test_json.cc
@@ -332,7 +332,7 @@ TEST(Json, AssigningObjects) {
     auto str = JsonString("1");
     auto& k = json_object["1"];
     k  = std::move(str);
-    ASSERT_TRUE(str.GetString().empty());
+    ASSERT_TRUE(str.GetString().empty());  // NOLINT
     auto& m = json_object["1"];
     std::string value = get<JsonString>(m);
     ASSERT_EQ(value, "1");

--- a/tests/cpp/common/test_json.cc
+++ b/tests/cpp/common/test_json.cc
@@ -332,6 +332,7 @@ TEST(Json, AssigningObjects) {
     auto str = JsonString("1");
     auto& k = json_object["1"];
     k  = std::move(str);
+    ASSERT_TRUE(str.GetString().empty());
     auto& m = json_object["1"];
     std::string value = get<JsonString>(m);
     ASSERT_EQ(value, "1");


### PR DESCRIPTION
Performance doesn't change much, just for better code.  For max_depth=12, round=500, HIGGS:

* Master
Load average: 3.6808622678120932
Save average: 3.2464772860209146

* No except
Load average: 3.1963095664978027
Save average: 3.3569795290629068