### PR TITLE
Support more input types for categorical data.

### DIFF
--- a/demo/guide-python/categorical.py
+++ b/demo/guide-python/categorical.py
@@ -44,7 +44,8 @@ def make_categorical(
 
 def main() -> None:
     # Use builtin categorical data support
-    # Must be pandas DataFrame or cudf DataFrame with categorical data
+    # For scikit-learn interface, the input data must be pandas DataFrame or cudf
+    # DataFrame with categorical features
     X, y = make_categorical(100, 10, 4, False)
     # Specify `enable_categorical` to True.
     reg = xgb.XGBRegressor(tree_method="gpu_hist", enable_categorical=True)

--- a/include/xgboost/feature_map.h
+++ b/include/xgboost/feature_map.h
@@ -83,7 +83,7 @@ class FeatureMap {
     if (!strcmp("q", tname)) return kQuantitive;
     if (!strcmp("int", tname)) return kInteger;
     if (!strcmp("float", tname)) return kFloat;
-    if (!strcmp("categorical", tname)) return kCategorical;
+    if (!strcmp("c", tname)) return kCategorical;
     LOG(FATAL) << "unknown feature type, use i for indicator and q for quantity";
     return kIndicator;
   }

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2474,8 +2474,13 @@ class Booster(object):
 
             raise ValueError(msg.format(self.feature_names, data.feature_names))
 
-    def get_split_value_histogram(self, feature, fmap='', bins=None,
-                                  as_pandas=True):
+    def get_split_value_histogram(
+        self,
+        feature: str,
+        fmap: Union[os.PathLike, str] = '',
+        bins: Optional[int] = None,
+        as_pandas: bool = True
+    ):
         """Get split value histogram of a feature
 
         Parameters
@@ -2523,7 +2528,7 @@ class Booster(object):
             except (ValueError, AttributeError, TypeError):
                 # None.index: attr err, None[0]: type err, fn.index(-1): value err
                 feature_t = None
-            if feature_t == "categorical":
+            if feature_t == "c":  # categorical
                 raise ValueError(
                     "Split value historgam doesn't support categorical split."
                 )

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -518,8 +518,8 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
         base_margin=None,
         missing: Optional[float] = None,
         silent=False,
-        feature_names=None,
-        feature_types=None,
+        feature_names: Optional[List[str]] = None,
+        feature_types: Optional[List[str]] = None,
         nthread: Optional[int] = None,
         group=None,
         qid=None,
@@ -558,8 +558,17 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
             Whether print messages during construction
         feature_names : list, optional
             Set names for features.
-        feature_types : list, optional
-            Set types for features.
+        feature_types :
+
+            Set types for features.  When `enable_categorical` is set to `True`, string
+            "c" represents categorical data type.  For numerical data, it can be one for
+            the following:
+
+                - "q" for quantitive
+                - "float" for float
+                - "i" for indicator
+                - "int" for integer
+
         nthread : integer, optional
             Number of threads to use for loading data when parallelization is
             applicable. If -1, uses maximum threads available on the system.
@@ -673,8 +682,8 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
         qid=None,
         label_lower_bound=None,
         label_upper_bound=None,
-        feature_names=None,
-        feature_types=None,
+        feature_names: Optional[List[str]] = None,
+        feature_types: Optional[List[str]] = None,
         feature_weights=None
     ) -> None:
         """Set meta info for DMatrix.  See doc string for :py:obj:`xgboost.DMatrix`."""
@@ -945,7 +954,7 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
         return res
 
     @property
-    def feature_names(self) -> List[str]:
+    def feature_names(self) -> Optional[List[str]]:
         """Get feature names (column labels).
 
         Returns
@@ -1033,17 +1042,21 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
         return res
 
     @feature_types.setter
-    def feature_types(self, feature_types: Optional[Union[List[Any], Any]]) -> None:
+    def feature_types(self, feature_types: Optional[Union[List[str], str]]) -> None:
         """Set feature types (column types).
 
-        This is for displaying the results and unrelated
-        to the learning process.
+        This is for displaying the results and categorical data support.  See doc string
+        of :py:obj:`xgboost.DMatrix` for details.
 
         Parameters
         ----------
         feature_types : list or None
             Labels for features. None will reset existing feature names
+
         """
+        # For compatibility reason this function wraps single str input into a list.  But
+        # we should not promote such usage since other than visualization, the field is
+        # also used for specifying categorical data type.
         if feature_types is not None:
             if not isinstance(feature_types, (list, str)):
                 raise TypeError(

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -561,13 +561,7 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
         feature_types :
 
             Set types for features.  When `enable_categorical` is set to `True`, string
-            "c" represents categorical data type.  For numerical data, it can be one for
-            the following:
-
-                - "q" for quantitive
-                - "float" for float
-                - "i" for indicator
-                - "int" for integer
+            "c" represents categorical data type.
 
         nthread : integer, optional
             Number of threads to use for loading data when parallelization is
@@ -586,11 +580,10 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
 
             .. versionadded:: 1.3.0
 
-            Experimental support of specializing for categorical features.  Do
-            not set to True unless you are interested in development.
-            Currently it's only available for `gpu_hist` tree method with 1 vs
-            rest (one hot) categorical split.  Also, JSON serialization format,
-            `gpu_predictor` and pandas input are required.
+            Experimental support of specializing for categorical features.  Do not set to
+            True unless you are interested in development.  Currently it's only available
+            for `gpu_hist` tree method with 1 vs rest (one hot) categorical split.  Also,
+            JSON serialization format is required.
 
         """
         if group is not None and qid is not None:

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -16,7 +16,7 @@ from .compat import lazy_isinstance
 
 c_bst_ulong = ctypes.c_uint64   # pylint: disable=invalid-name
 
-cat_t = "c"
+CAT_T = "c"
 
 
 def _warn_unused_missing(data, missing):
@@ -260,7 +260,7 @@ def _transform_pandas_df(
                 feature_types.append(_pandas_dtype_mapper[
                     dtype.subtype.name])
             elif is_categorical_dtype(dtype) and enable_categorical:
-                feature_types.append(cat_t)
+                feature_types.append(CAT_T)
             else:
                 feature_types.append(_pandas_dtype_mapper[dtype.name])
 
@@ -469,7 +469,7 @@ def _transform_cudf_df(
             dtypes = data.dtypes
         for dtype in dtypes:
             if is_categorical_dtype(dtype) and enable_categorical:
-                feature_types.append(cat_t)
+                feature_types.append(CAT_T)
             else:
                 feature_types.append(_pandas_dtype_mapper[dtype.name])
     return data, feature_names, feature_types

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -174,8 +174,7 @@ __model_doc = f'''
         .. versionadded:: 1.5.0
 
         Experimental support for categorical data.  Do not set to true unless you are
-        interested in development. Only valid when `gpu_hist` and pandas dataframe are
-        used.
+        interested in development. Only valid when `gpu_hist` and dataframe are used.
 
     kwargs : dict, optional
         Keyword arguments for XGBoost Booster object.  Full documentation of

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -200,8 +200,6 @@ void LoadFeatureType(std::vector<std::string>const& type_names, std::vector<Feat
       types->emplace_back(FeatureType::kNumerical);
     } else if (elem == "q") {
       types->emplace_back(FeatureType::kNumerical);
-    } else if (elem == "categorical") {
-      types->emplace_back(FeatureType::kCategorical);
     } else if (elem == "c") {
       types->emplace_back(FeatureType::kCategorical);
     } else {

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -203,7 +203,7 @@ void LoadFeatureType(std::vector<std::string>const& type_names, std::vector<Feat
     } else if (elem == "c") {
       types->emplace_back(FeatureType::kCategorical);
     } else {
-      LOG(FATAL) << "All feature_types must be one of {int, float, i, q, categorical, c}.";
+      LOG(FATAL) << "All feature_types must be one of {int, float, i, q, c}.";
     }
   }
 }

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -202,8 +202,10 @@ void LoadFeatureType(std::vector<std::string>const& type_names, std::vector<Feat
       types->emplace_back(FeatureType::kNumerical);
     } else if (elem == "categorical") {
       types->emplace_back(FeatureType::kCategorical);
+    } else if (elem == "c") {
+      types->emplace_back(FeatureType::kCategorical);
     } else {
-      LOG(FATAL) << "All feature_types must be one of {int, float, i, q, categorical}.";
+      LOG(FATAL) << "All feature_types must be one of {int, float, i, q, categorical, c}.";
     }
   }
 }

--- a/tests/cpp/tree/test_tree_model.cc
+++ b/tests/cpp/tree/test_tree_model.cc
@@ -285,7 +285,7 @@ void TestCategoricalTreeDump(std::string format, std::string sep) {
   pos = str.find(cond_str, pos + 1);
   ASSERT_NE(pos, std::string::npos);
 
-  fmap.PushBack(0, "feat_0", "categorical");
+  fmap.PushBack(0, "feat_0", "c");
   fmap.PushBack(1, "feat_1", "q");
   fmap.PushBack(2, "feat_2", "int");
 

--- a/tests/python-gpu/test_from_cudf.py
+++ b/tests/python-gpu/test_from_cudf.py
@@ -172,7 +172,7 @@ Arrow specification.'''
         _test_cudf_metainfo(xgb.DeviceQuantileDMatrix)
 
     @pytest.mark.skipif(**tm.no_cudf())
-    def test_categorical(self):
+    def test_cudf_categorical(self):
         import cudf
         _X, _y = tm.make_categorical(100, 30, 17, False)
         X = cudf.from_pandas(_X)
@@ -180,11 +180,11 @@ Arrow specification.'''
 
         Xy = xgb.DMatrix(X, y, enable_categorical=True)
         assert len(Xy.feature_types) == X.shape[1]
-        assert all(t == "categorical" for t in Xy.feature_types)
+        assert all(t == "c" for t in Xy.feature_types)
 
         Xy = xgb.DeviceQuantileDMatrix(X, y, enable_categorical=True)
         assert len(Xy.feature_types) == X.shape[1]
-        assert all(t == "categorical" for t in Xy.feature_types)
+        assert all(t == "c" for t in Xy.feature_types)
 
 
 @pytest.mark.skipif(**tm.no_cudf())

--- a/tests/python-gpu/test_from_cupy.py
+++ b/tests/python-gpu/test_from_cupy.py
@@ -170,6 +170,19 @@ Arrow specification.'''
         xgb.DMatrix(X.toDlpack())
 
     @pytest.mark.skipif(**tm.no_cupy())
+    def test_cupy_categorical(self):
+        import cupy as cp
+        n_features = 10
+        X, y = tm.make_categorical(10, n_features, n_categories=4, onehot=False)
+        X = cp.asarray(X.values.astype(cp.float32))
+        y = cp.array(y)
+        feature_types = ['c'] * n_features
+
+        assert isinstance(X, cp.ndarray)
+        Xy = xgb.DMatrix(X, y, feature_types=feature_types)
+        np.testing.assert_equal(np.array(Xy.feature_types), np.array(feature_types))
+
+    @pytest.mark.skipif(**tm.no_cupy())
     def test_dlpack_device_dmat(self):
         import cupy as cp
         n = 100

--- a/tests/python/test_dmatrix.py
+++ b/tests/python/test_dmatrix.py
@@ -339,3 +339,44 @@ class TestDMatrix:
         Xy = xgb.DMatrix(X, y)
         assert Xy.num_row() == 10
         assert Xy.num_col() == 10
+
+    @pytest.mark.skipif(**tm.no_pandas())
+    def test_np_categorical(self):
+        n_features = 10
+        X, y = tm.make_categorical(10, n_features, n_categories=4, onehot=False)
+        X = X.values.astype(np.float32)
+        feature_types = ['c'] * n_features
+
+        assert isinstance(X, np.ndarray)
+        Xy = xgb.DMatrix(X, y, feature_types=feature_types)
+        np.testing.assert_equal(np.array(Xy.feature_types), np.array(feature_types))
+
+    def test_scipy_categorical(self):
+        from scipy import sparse
+        n_features = 10
+        X, y = tm.make_categorical(10, n_features, n_categories=4, onehot=False)
+        X = X.values.astype(np.float32)
+        feature_types = ['c'] * n_features
+
+        X[1, 3] = np.NAN
+        X[2, 4] = np.NAN
+        X = sparse.csr_matrix(X)
+
+        Xy = xgb.DMatrix(X, y, feature_types=feature_types)
+        np.testing.assert_equal(np.array(Xy.feature_types), np.array(feature_types))
+
+        X = sparse.csc_matrix(X)
+
+        Xy = xgb.DMatrix(X, y, feature_types=feature_types)
+        np.testing.assert_equal(np.array(Xy.feature_types), np.array(feature_types))
+
+        X = sparse.coo_matrix(X)
+
+        Xy = xgb.DMatrix(X, y, feature_types=feature_types)
+        np.testing.assert_equal(np.array(Xy.feature_types), np.array(feature_types))
+
+    def test_uri_categorical(self):
+        path = os.path.join(dpath, 'agaricus.txt.train')
+        feature_types = ["q"] * 5 + ["c"] + ["q"] * 120
+        Xy = xgb.DMatrix(path + "?indexing_mode=1", feature_types=feature_types)
+        np.testing.assert_equal(np.array(Xy.feature_types), np.array(feature_types))

--- a/tests/python/test_with_pandas.py
+++ b/tests/python/test_with_pandas.py
@@ -128,7 +128,7 @@ class TestPandas:
         X = pd.DataFrame({'f0': X})
         y = rng.randn(rows)
         m = xgb.DMatrix(X, y, enable_categorical=True)
-        assert m.feature_types[0] == 'categorical'
+        assert m.feature_types[0] == 'c'
 
     def test_pandas_sparse(self):
         import pandas as pd


### PR DESCRIPTION
* Shorten the type name from "categorical" to "c".
* Tests for np/cp array, scipy csr/csc/coo and uri.
* Specify the type for feature info.

Remaining type:
- pydatatable, xgboost will throw an error when categorical data is specified.