### PR TITLE
[jvm-packages] Deprecate constructors with implicit missing value.

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -119,6 +119,33 @@ public class DMatrix {
 
   /**
    * create DMatrix from dense matrix
+   *
+   * @param data data values
+   * @param nrow number of rows
+   * @param ncol number of columns
+   * @throws XGBoostError native error
+   *
+   * @deprecated Please specify the missing value explicitly
+   */
+  @Deprecated
+  public DMatrix(float[] data, int nrow, int ncol) throws XGBoostError {
+    long[] out = new long[1];
+    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCreateFromMat(data, nrow, ncol, 0.0f, out));
+    handle = out[0];
+  }
+
+  /**
+   * create DMatrix from a BigDenseMatrix
+   *
+   * @param matrix instance of BigDenseMatrix
+   * @throws XGBoostError native error
+   */
+  public DMatrix(BigDenseMatrix matrix) throws XGBoostError {
+    this(matrix, 0.0f);
+  }
+
+  /**
+   * create DMatrix from dense matrix
    * @param data data values
    * @param nrow number of rows
    * @param ncol number of columns

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -119,30 +119,6 @@ public class DMatrix {
 
   /**
    * create DMatrix from dense matrix
-   *
-   * @param data data values
-   * @param nrow number of rows
-   * @param ncol number of columns
-   * @throws XGBoostError native error
-   */
-  public DMatrix(float[] data, int nrow, int ncol) throws XGBoostError {
-    long[] out = new long[1];
-    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCreateFromMat(data, nrow, ncol, 0.0f, out));
-    handle = out[0];
-  }
-
-  /**
-   * create DMatrix from a BigDenseMatrix
-   *
-   * @param matrix instance of BigDenseMatrix
-   * @throws XGBoostError native error
-   */
-  public DMatrix(BigDenseMatrix matrix) throws XGBoostError {
-    this(matrix, 0.0f);
-  }
-
-  /**
-   * create DMatrix from dense matrix
    * @param data data values
    * @param nrow number of rows
    * @param ncol number of columns

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -125,7 +125,8 @@ public class DMatrix {
    * @param ncol number of columns
    * @throws XGBoostError native error
    *
-   * @deprecated Please specify the missing value explicitly
+   * @deprecated Please specify the missing value explicitly using
+   * {@link DMatrix(float[], int, int, float)}
    */
   @Deprecated
   public DMatrix(float[] data, int nrow, int ncol) throws XGBoostError {

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
@@ -78,6 +78,19 @@ class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
    * @param data data values
    * @param nrow number of rows
    * @param ncol number of columns
+   */
+  @deprecated("Please specify the missing value explicitly", "XGBoost 1.5")
+  @throws(classOf[XGBoostError])
+  def this(data: Array[Float], nrow: Int, ncol: Int) {
+    this(new JDMatrix(data, nrow, ncol))
+  }
+
+  /**
+   * create DMatrix from dense matrix
+   *
+   * @param data data values
+   * @param nrow number of rows
+   * @param ncol number of columns
    * @param missing the specified value to represent the missing value
    */
   @throws(classOf[XGBoostError])

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
@@ -78,18 +78,6 @@ class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
    * @param data data values
    * @param nrow number of rows
    * @param ncol number of columns
-   */
-  @throws(classOf[XGBoostError])
-  def this(data: Array[Float], nrow: Int, ncol: Int) {
-    this(new JDMatrix(data, nrow, ncol))
-  }
-
-  /**
-   * create DMatrix from dense matrix
-   *
-   * @param data data values
-   * @param nrow number of rows
-   * @param ncol number of columns
    * @param missing the specified value to represent the missing value
    */
   @throws(classOf[XGBoostError])

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/DMatrixTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/DMatrixTest.java
@@ -212,7 +212,7 @@ public class DMatrixTest {
       label0[i] = random.nextFloat();
     }
 
-    DMatrix dmat0 = new DMatrix(data0, nrow, ncol);
+    DMatrix dmat0 = new DMatrix(data0, nrow, ncol, Float.NaN);
     dmat0.setLabel(label0);
 
     //check
@@ -281,7 +281,7 @@ public class DMatrixTest {
         label0[i] = random.nextFloat();
       }
 
-      dmat0 = new DMatrix(data0);
+      dmat0 = new DMatrix(data0, Float.NaN);
       dmat0.setLabel(label0);
 
       //check
@@ -318,7 +318,7 @@ public class DMatrixTest {
         for (int j = 0; j < data0.ncol; j++)
           data0.set(i, j, data[i][j]);
 
-      trainMat = new DMatrix(data0);
+      trainMat = new DMatrix(data0, Float.NaN);
       trainMat.setLabel(new float[]{1f, 2f, 3f});
 
       HashMap<String, Object> params = new HashMap<>();
@@ -338,7 +338,7 @@ public class DMatrixTest {
       // (3,1) -> 2
       // (2,3) -> 3
       for (int i = 0; i < 3; i++) {
-        float[][] preds = booster.predict(new DMatrix(data[i], 1, 2));
+        float[][] preds = booster.predict(new DMatrix(data[i], 1, 2, Float.NaN));
         assertEquals(1, preds.length);
         assertArrayEquals(new float[]{(float) (i + 1)}, preds[0], 1e-2f);
       }

--- a/jvm-packages/xgboost4j/src/test/scala/ml/dmlc/xgboost4j/scala/DMatrixSuite.scala
+++ b/jvm-packages/xgboost4j/src/test/scala/ml/dmlc/xgboost4j/scala/DMatrixSuite.scala
@@ -130,7 +130,7 @@ class DMatrixSuite extends FunSuite {
     for (i <- label0.indices) {
       label0(i) = Random.nextFloat()
     }
-    val dmat0 = new DMatrix(data0, nrow, ncol)
+    val dmat0 = new DMatrix(data0, nrow, ncol, Float.NaN)
     dmat0.setLabel(label0)
     // check
     assert(dmat0.rowNum === 10)


### PR DESCRIPTION
During debugging https://github.com/dmlc/xgboost/issues/7210 , I found the java implementation has a constructor the uses 0 as the default value for `missing`, which doesn't make sense since 0 is a meaningful input for XGBoost.  `NaN` would be a better choice and is in fact used by both Python and R.  However, I don't think it's a good idea for us to swap the missing value silently.  Therefore, I propose that we deprecate those constructors and let users specify `missing` explicitly.