### PR TITLE
Enable compiling with system cub.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option(HIDE_CXX_SYMBOLS "Build shared library and hide all C++ symbols" OFF)
 option(USE_CUDA  "Build with GPU acceleration" OFF)
 option(USE_NCCL  "Build with NCCL to enable distributed GPU support." OFF)
 option(BUILD_WITH_SHARED_NCCL "Build with shared NCCL library." OFF)
+option(BUILD_WITH_CUDA_CUB "Build with cub in CUDA installation" OFF)
 set(GPU_COMPUTE_VER "" CACHE STRING
   "Semicolon separated list of compute versions to be built against, e.g. '35;61'")
 ## Copied From dmlc

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -154,8 +154,13 @@ function(xgboost_set_cuda_flags target)
     enable_nvtx(${target})
   endif (USE_NVTX)
 
-  target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_CUDA=1 -DTHRUST_IGNORE_CUB_VERSION_CHECK=1)
-  target_include_directories(${target} PRIVATE ${xgboost_SOURCE_DIR}/cub/ ${xgboost_SOURCE_DIR}/gputreeshap)
+  if (NOT BUILD_WITH_CUDA_CUB)
+    target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_CUDA=1 -DTHRUST_IGNORE_CUB_VERSION_CHECK=1)
+    target_include_directories(${target} PRIVATE ${xgboost_SOURCE_DIR}/cub/ ${xgboost_SOURCE_DIR}/gputreeshap)
+  else ()
+    target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_CUDA=1)
+    target_include_directories(${target} PRIVATE ${xgboost_SOURCE_DIR}/gputreeshap)
+  endif (NOT BUILD_WITH_CUDA_CUB)
 
   if (MSVC)
     target_compile_options(${target} PRIVATE

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -183,10 +183,6 @@ struct TupleScanOp {
   }
 };
 
-// Change the value type of thrust discard iterator so we can use it with cub
-template <typename T>
-using TypedDiscard = thrust::discard_iterator<T>;
-
 // Here the data is already correctly ordered and simply needs to be compacted
 // to remove missing data
 template <typename AdapterBatchT>
@@ -229,7 +225,7 @@ void CopyDataToEllpack(const AdapterBatchT &batch,
   WriteCompressedEllpackFunctor<AdapterBatchT> functor(
       d_compressed_buffer, writer, batch, device_accessor, feature_types,
       is_valid);
-  TypedDiscard<Tuple> discard;
+  dh::TypedDiscard<Tuple> discard;
   thrust::transform_output_iterator<
     WriteCompressedEllpackFunctor<AdapterBatchT>, decltype(discard)>
       out(discard, functor);

--- a/src/metric/auc.cu
+++ b/src/metric/auc.cu
@@ -521,7 +521,7 @@ GPURankingAUC(common::Span<float const> predts, MetaInfo const &info,
   dh::TemporaryArray<float> d_auc(group_ptr.size() - 1);
   auto s_d_auc = dh::ToSpan(d_auc);
   auto out = thrust::make_transform_output_iterator(
-      Discard<RankScanItem>(), [=] __device__(RankScanItem const &item) -> RankScanItem {
+      dh::TypedDiscard<RankScanItem>{}, [=] __device__(RankScanItem const &item) -> RankScanItem {
         auto group_id = item.group_id;
         assert(group_id < d_group_ptr.size());
         auto data_group_begin = d_group_ptr[group_id];

--- a/src/metric/auc.cu
+++ b/src/metric/auc.cu
@@ -230,14 +230,6 @@ float ScaleClasses(common::Span<float> results, common::Span<float> local_area,
   return auc_sum;
 }
 
-namespace {
-struct Triple2Pair {
-  auto __device__ operator()(thrust::tuple<uint32_t, float, float> const &t) {
-    return thrust::make_pair(thrust::get<1>(t), thrust::get<2>(t));
-  }
-};
-}  // anonymous namespace
-
 /**
  * MultiClass implementation is similar to binary classification, except we need to split
  * up each class in all kernels.
@@ -339,22 +331,25 @@ float GPUMultiClassAUCOVR(common::Span<float const> predts, MetaInfo const &info
   // expand to tuple to include class id
   auto fptp_it_in = dh::MakeTransformIterator<Triple>(
       thrust::make_counting_iterator(0), [=] __device__(size_t i) {
-        uint32_t class_id = i / n_samples;
-        return thrust::make_tuple(class_id, d_fptp[i].first, d_fptp[i].second);
+        return thrust::make_tuple(i, d_fptp[i].first, d_fptp[i].second);
       });
   // shrink down to pair
-  auto fptp_it_out =
-      thrust::make_transform_output_iterator(dh::tbegin(d_fptp), Triple2Pair{});
+  auto fptp_it_out = thrust::make_transform_output_iterator(
+      dh::TypedDiscard<Triple>{}, [d_fptp] __device__(Triple const &t) {
+        d_fptp[thrust::get<0>(t)] =
+            thrust::make_pair(thrust::get<1>(t), thrust::get<2>(t));
+        return t;
+      });
   dh::InclusiveScan(
       fptp_it_in, fptp_it_out,
       [=] __device__(Triple const &l, Triple const &r) {
-        uint32_t l_cid = thrust::get<0>(l);
-        uint32_t r_cid = thrust::get<0>(r);
+        uint32_t l_cid = thrust::get<0>(l) / n_samples;
+        uint32_t r_cid = thrust::get<0>(r) / n_samples;
         if (l_cid != r_cid) {
           return r;
         }
 
-        return Triple(r_cid,                                   // class_id
+        return Triple(thrust::get<0>(r),
                       thrust::get<1>(l) + thrust::get<1>(r),   // fp
                       thrust::get<2>(l) + thrust::get<2>(r));  // tp
       },

--- a/src/tree/gpu_hist/row_partitioner.cu
+++ b/src/tree/gpu_hist/row_partitioner.cu
@@ -50,9 +50,6 @@ struct WriteResultsFunctor {
   }
 };
 
-// Change the value type of thrust discard iterator so we can use it with cub
-using DiscardOverload = thrust::discard_iterator<IndexFlagTuple>;
-
 // Implement partitioning via single scan operation using transform output to
 // write the result
 void RowPartitioner::SortPosition(common::Span<bst_node_t> position,
@@ -64,7 +61,7 @@ void RowPartitioner::SortPosition(common::Span<bst_node_t> position,
   WriteResultsFunctor write_results{left_nidx, position, position_out,
                                     ridx,      ridx_out, d_left_count};
   auto discard_write_iterator =
-      thrust::make_transform_output_iterator(DiscardOverload(), write_results);
+      thrust::make_transform_output_iterator(dh::TypedDiscard<IndexFlagTuple>(), write_results);
   auto counting = thrust::make_counting_iterator(0llu);
   auto input_iterator = dh::MakeTransformIterator<IndexFlagTuple>(
       counting, [=] __device__(size_t idx) {


### PR DESCRIPTION
~- This works only with CUDA 11.4, for CUDA 11.2 there are some obscure errors with inclusive scan and custom iterators.~

- Tested with all CUDA 11.x.
- Workaround cub scan by using discard iterator in AUC.
- Limit the size of Argsort when compiled with CUDA cub.