### PR TITLE
[R] Avoid symbol naming conflicts with other packages

### DIFF
--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -17,7 +17,7 @@ endif
 $(foreach v, $(XGB_RFLAGS), $(warning $(v)))
 
 PKG_CPPFLAGS=  -I$(PKGROOT)/include -I$(PKGROOT)/dmlc-core/include -I$(PKGROOT)/rabit/include -I$(PKGROOT) $(XGB_RFLAGS)
-PKG_CXXFLAGS= @OPENMP_CXXFLAGS@ @ENDIAN_FLAG@ -pthread
+PKG_CXXFLAGS= @OPENMP_CXXFLAGS@ @ENDIAN_FLAG@ -pthread $(CXX_VISIBILITY)
 PKG_LIBS = @OPENMP_CXXFLAGS@ @OPENMP_LIB@ @ENDIAN_FLAG@ @BACKTRACE_LIB@ -pthread
 OBJECTS= ./xgboost_R.o ./xgboost_custom.o ./xgboost_assert.o ./init.o \
          $(PKGROOT)/amalgamation/xgboost-all0.o $(PKGROOT)/amalgamation/dmlc-minimum0.o \

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -9,7 +9,7 @@
 #include <Rinternals.h>
 #include <stdlib.h>
 #include <R_ext/Rdynload.h>
-#include <R_ext/Visibility.h.h>
+#include <R_ext/Visibility.h>
 
 /* FIXME:
 Check these declarations against the C/Fortran source code.

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -9,6 +9,7 @@
 #include <Rinternals.h>
 #include <stdlib.h>
 #include <R_ext/Rdynload.h>
+#include <R_ext/Visibility.h.h>
 
 /* FIXME:
 Check these declarations against the C/Fortran source code.
@@ -89,7 +90,7 @@ static const R_CallMethodDef CallEntries[] = {
 #if defined(_WIN32)
 __declspec(dllexport)
 #endif  // defined(_WIN32)
-void R_init_xgboost(DllInfo *dll) {
+void attribute_visible R_init_xgboost(DllInfo *dll) {
   R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
 }

--- a/R-package/src/xgboost-win.def
+++ b/R-package/src/xgboost-win.def
@@ -1,0 +1,3 @@
+LIBRARY xgboost.dll
+EXPORTS
+ R_init_xgboost


### PR DESCRIPTION
I am experiencing an issue with some packages crashing when used in the same session. I'm unable to provide a reproducer, and I don't know exactly what is causing it or which package(s) are at fault, but I suspect it might be due to a symbol naming conflict in the compiled shared objects.

As it is right now, XGBoost registers all its symbols in the R dynamic object when it loads, which can cause issues if multiple packages are loaded and define symbols with the same name. This PR limits the exported symbol visibility to only the necessary - see https://cran.r-project.org/doc/manuals/R-exts.html#Controlling-visibility

Note that it modifies the R file `src/Makevars.in` by adding the R-defined `$(CXX_VISIBILITY)` variable. I don't know how that plays out when using the CMake build system, as I guess it doesn't interact with R in that case, but the R package at least builds fine with `make Rbuild`.