### PR TITLE
Fix bug when num_row is zero in CSRAdapter

### DIFF
--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -167,7 +167,11 @@ class CSRAdapter : public detail::SingleBatchDataIter<CSRAdapterBatch> {
         num_rows_(num_rows),
         num_columns_(num_features) {}
   const CSRAdapterBatch& Value() const override { return batch_; }
-  size_t NumRows() const { return num_rows_; }
+
+  // JVM package sends 0 as unknown
+  size_t NumRows() const {
+    return num_rows_ == 0 ? kAdapterUnknownSize : num_rows_;
+  }
   size_t NumColumns() const { return num_columns_; }
 
  private:


### PR DESCRIPTION
I noticed a difference in the behavior of `XGDMatrixCreateFromCSREx` and `XGDMatrixCreateFromCSCEx` when I was using c_api.

This PR is a modification to make the `CSRAdapter` behave the same as the `CSCAdapter`.

`CSRAdapter` does not generate an appropriate matrix when `num_row` is zero.  This is not what the documentation says.
This bug creates an empty Matrix and returns, raise error in learning `Booster` for example following.

```
...out/xgboost/src/learner.cc:602: Check failed: mparam_.num_feature != 0 (0 vs. 0) : 0 feature is supplied.  Are you using raw Booster interface?
```

doc: https://xgboost.readthedocs.io/en/latest/dev/c__api_8h.html#a91d3ab5fa109f418a368d66ad2b99d3c
> num_col	number of columns; when it's set to kAdapterUnknownSize, then guess from data