### PR TITLE
[Breaking] Remove `max_delta_step` from Poisson.

### DIFF
--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -352,10 +352,7 @@ Specify the learning task and the corresponding learning objective. The objectiv
   - ``binary:logistic``: logistic regression for binary classification, output probability
   - ``binary:logitraw``: logistic regression for binary classification, output score before logistic transformation
   - ``binary:hinge``: hinge loss for binary classification. This makes predictions of 0 or 1, rather than producing probabilities.
-  - ``count:poisson`` --poisson regression for count data, output mean of Poisson distribution
-
-    - ``max_delta_step`` is set to 0.7 by default in Poisson regression (used to safeguard optimization)
-
+  - ``count:poisson`` : poisson regression with log link for count data, output mean of Poisson distribution.
   - ``survival:cox``: Cox regression for right censored survival time data (negative values are considered right censored).
     Note that predictions are returned on the hazard ratio scale (i.e., as HR = exp(marginal_prediction) in the proportional hazard function ``h(t) = h0(t) * HR``).
   - ``survival:aft``: Accelerated failure time model for censored survival time data.

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -46,11 +46,6 @@
 #include "common/version.h"
 #include "common/threading_utils.h"
 
-namespace {
-
-const char* kMaxDeltaStepDefaultValue = "0.7";
-}  // anonymous namespace
-
 namespace xgboost {
 
 enum class DataSplitMode : int {
@@ -624,13 +619,6 @@ class LearnerConfiguration : public Learner {
       }
     }
 
-    if (cfg_.find("max_delta_step") == cfg_.cend() &&
-        cfg_.find("objective") != cfg_.cend() &&
-        tparam_.objective == "count:poisson") {
-      // max_delta_step is a duplicated parameter in Poisson regression and tree param.
-      // Rename one of them once binary IO is gone.
-      cfg_["max_delta_step"] = kMaxDeltaStepDefaultValue;
-    }
     if (obj_ == nullptr || tparam_.objective != old.objective) {
       obj_.reset(ObjFunction::Create(tparam_.objective, &generic_parameters_));
     }
@@ -807,14 +795,6 @@ class LearnerIO : public LearnerConfiguration {
       attributes_ = std::map<std::string, std::string>(attr.begin(), attr.end());
     }
     bool warn_old_model { false };
-    if (attributes_.find("count_poisson_max_delta_step") != attributes_.cend()) {
-      // Loading model from < 1.0.0, objective is not saved.
-      cfg_["max_delta_step"] = attributes_.at("count_poisson_max_delta_step");
-      attributes_.erase("count_poisson_max_delta_step");
-      warn_old_model = true;
-    } else {
-      warn_old_model = false;
-    }
 
     if (mparam_.major_version < 1) {
       // Before 1.0.0, base_score is saved as a transformed value, and there's no version

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -257,7 +257,10 @@ class PoissonRegression : public ObjFunction {
     return "poisson-nloglik";
   }
 
-  void SaveConfig(Json* p_out) const override {}
+  void SaveConfig(Json* p_out) const override {
+    auto& out = *p_out;
+    out["name"] = String("count:poisson");
+  }
   void LoadConfig(Json const& in) override {}
 
  private:

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -83,12 +83,13 @@ void CheckObjFunctionImpl(std::unique_ptr<xgboost::ObjFunction> const& obj,
 
   ASSERT_EQ(gpair.size(), in_preds.Size());
   for (int i = 0; i < static_cast<int>(gpair.size()); ++i) {
+    auto w = weights.empty() ? 1.0 : weights[i];
     EXPECT_NEAR(gpair[i].GetGrad(), out_grad[i], 0.01)
       << "Unexpected grad for pred=" << preds[i] << " label=" << labels[i]
-      << " weight=" << weights[i];
+      << " weight=" << w;
     EXPECT_NEAR(gpair[i].GetHess(), out_hess[i], 0.01)
       << "Unexpected hess for pred=" << preds[i] << " label=" << labels[i]
-      << " weight=" << weights[i];
+      << " weight=" << w;
   }
 }
 

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -83,13 +83,10 @@ void CheckObjFunctionImpl(std::unique_ptr<xgboost::ObjFunction> const& obj,
 
   ASSERT_EQ(gpair.size(), in_preds.Size());
   for (int i = 0; i < static_cast<int>(gpair.size()); ++i) {
-    auto w = weights.empty() ? 1.0 : weights[i];
     EXPECT_NEAR(gpair[i].GetGrad(), out_grad[i], 0.01)
-      << "Unexpected grad for pred=" << preds[i] << " label=" << labels[i]
-      << " weight=" << w;
+        << "Unexpected grad for pred=" << preds[i] << " label=" << labels[i];
     EXPECT_NEAR(gpair[i].GetHess(), out_hess[i], 0.01)
-      << "Unexpected hess for pred=" << preds[i] << " label=" << labels[i]
-      << " weight=" << w;
+        << "Unexpected hess for pred=" << preds[i] << " label=" << labels[i];
   }
 }
 

--- a/tests/cpp/objective/test_regression_obj.cc
+++ b/tests/cpp/objective/test_regression_obj.cc
@@ -151,19 +151,22 @@ TEST(Objective, DeclareUnifiedTest(PoissonRegressionGPair)) {
 
   args.emplace_back(std::make_pair("max_delta_step", "0.1f"));
   obj->Configure(args);
+  std::vector<float> predt {   0,  0.1f,  0.9f,    1,    0,  0.1f,  0.9f,    1};
+  std::vector<float> hess (predt.size());
+  std::transform(predt.cbegin(), predt.cend(), hess.begin(), expf);
 
   CheckObjFunction(obj,
-                   {   0,  0.1f,  0.9f,    1,    0,  0.1f,  0.9f,    1},
+                   predt,
                    {   0,    0,    0,    0,    1,    1,    1,    1},
                    {   1,    1,    1,    1,    1,    1,    1,    1},
                    {   1, 1.10f, 2.45f, 2.71f,    0, 0.10f, 1.45f, 1.71f},
-                   {1.10f, 1.22f, 2.71f, 3.00f, 1.10f, 1.22f, 2.71f, 3.00f});
+                   hess);
   CheckObjFunction(obj,
-                   {   0,  0.1f,  0.9f,    1,    0,  0.1f,  0.9f,    1},
+                   predt,
                    {   0,    0,    0,    0,    1,    1,    1,    1},
                    {},  // Empty weight
                    {   1, 1.10f, 2.45f, 2.71f,    0, 0.10f, 1.45f, 1.71f},
-                   {1.10f, 1.22f, 2.71f, 3.00f, 1.10f, 1.22f, 2.71f, 3.00f});
+                   hess);
 }
 
 TEST(Objective, DeclareUnifiedTest(PoissonRegressionBasic)) {

--- a/tests/cpp/objective/test_regression_obj.cc
+++ b/tests/cpp/objective/test_regression_obj.cc
@@ -149,7 +149,6 @@ TEST(Objective, DeclareUnifiedTest(PoissonRegressionGPair)) {
     ObjFunction::Create("count:poisson", &lparam)
   };
 
-  args.emplace_back(std::make_pair("max_delta_step", "0.1f"));
   obj->Configure(args);
   std::vector<float> predt {   0,  0.1f,  0.9f,    1,    0,  0.1f,  0.9f,    1};
   std::vector<float> hess (predt.size());


### PR DESCRIPTION
User can use the parameter with same name `max_delta_step` in tree method to control leaf weights, no
need to manipulate hessian values.