### PR TITLE
Support for building DMatrix from Apache Arrow data format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(USE_OPENMP "Build with OpenMP support." ON)
 option(BUILD_STATIC_LIB "Build static library" OFF)
 option(FORCE_SHARED_CRT "Build with dynamic CRT on Windows (/MD)" OFF)
 option(RABIT_BUILD_MPI "Build MPI" OFF)
+option(USE_ARROW "Build with Apache Arrow data format support" OFF)
 ## Bindings
 option(JVM_BINDINGS "Build JVM bindings" OFF)
 option(R_LIB "Build shared library for R package" OFF)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,7 +147,7 @@ def BuildCPU() {
       # This step is not necessary, but here we include it, to ensure that DMLC_CORE_USE_CMAKE flag is correctly propagated
       # We want to make sure that we use the configured header build/dmlc/build_config.h instead of include/dmlc/build_config_default.h.
       # See discussion at https://github.com/dmlc/xgboost/issues/5510
-    ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/build_via_cmake.sh -DPLUGIN_DENSE_PARSER=ON
+    ${dockerRun} ${container_type} ${docker_binary} tests/ci_build/build_via_cmake.sh -DUSE_ARROW=ON -DPLUGIN_DENSE_PARSER=ON
     ${dockerRun} ${container_type} ${docker_binary} bash -c "cd build && ctest --extra-verbose"
     """
     // Sanitizer test

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -501,6 +501,10 @@ XGB_DLL int XGDMatrixCreateFromArrowCallback(
     XGDMatrixCallbackNext *next,
     float missing,
     int nthread,
+    const char* label_col_name,
+    const char* weight_col_name,
+    const char* base_margin_col_name,
+    const char* qid_col_name,
     DMatrixHandle *out);
 #endif
 /*

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -502,6 +502,8 @@ XGB_DLL int XGDMatrixCreateFromArrowCallback(
     float missing,
     int nthread,
     const char* label_col_name,
+    const char* label_lb_col_name,
+    const char* label_ub_col_name,
     const char* weight_col_name,
     const char* base_margin_col_name,
     const char* qid_col_name,

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -494,11 +494,18 @@ XGB_DLL int XGProxyDMatrixSetDataCSR(DMatrixHandle handle, char const *indptr,
                                      bst_ulong ncol);
 
 
+#if defined(XGBOOST_BUILD_ARROW_SUPPORT)
+XGB_DLL int XGImportRecordBatch(DataIterHandle data_handle, void* ptr_array, void* ptr_schema);
+
+XGB_DLL int XGDMatrixCreateFromArrowCallback(
+    XGDMatrixCallbackNext *next,
+    float missing,
+    int nthread,
+    DMatrixHandle *out);
+#endif
 /*
  * ==========================- End data callback APIs ==========================
  */
-
-
 
 /*!
  * \brief create a new dmatrix from sliced content of existing matrix
@@ -724,6 +731,9 @@ XGB_DLL int XGDMatrixNumRow(DMatrixHandle handle,
  */
 XGB_DLL int XGDMatrixNumCol(DMatrixHandle handle,
                             bst_ulong *out);
+
+XGB_DLL int XGDMatricesEqual(DMatrixHandle lmat, DMatrixHandle rmat, bst_ulong *out);
+
 // --- start XGBoost class
 /*!
  * \brief create xgboost learner

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -735,9 +735,6 @@ XGB_DLL int XGDMatrixNumRow(DMatrixHandle handle,
  */
 XGB_DLL int XGDMatrixNumCol(DMatrixHandle handle,
                             bst_ulong *out);
-
-XGB_DLL int XGDMatricesEqual(DMatrixHandle lmat, DMatrixHandle rmat, bst_ulong *out);
-
 // --- start XGBoost class
 /*!
  * \brief create xgboost learner

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -178,22 +178,6 @@ class MetaInfo {
    */
   void Extend(MetaInfo const& that, bool accumulate_rows, bool check_column);
 
-  bool operator==(const MetaInfo& rhs) const {
-    return (num_row_ == rhs.num_row_ &&
-            num_col_ == rhs.num_col_ &&
-            num_nonzero_ == rhs.num_nonzero_ &&
-            labels_.HostVector() == rhs.labels_.HostVector() &&
-            group_ptr_ == rhs.group_ptr_ &&
-            weights_.HostVector() == rhs.weights_.HostVector() &&
-            base_margin_.HostVector() == rhs.base_margin_.HostVector() &&
-            labels_lower_bound_.HostVector() == rhs.labels_lower_bound_.HostVector() &&
-            labels_upper_bound_.HostVector() == rhs.labels_upper_bound_.HostVector() &&
-            // feature_type_names == rhs.feature_type_names &&
-            // feature_names == rhs.feature_names &&
-            // feature_types.HostVector() == rhs.feature_types.HostVector() &&
-            feature_weigths.HostVector() == rhs.feature_weigths.HostVector());
-  }
-
  private:
   /*! \brief argsort of labels */
   mutable std::vector<size_t> label_order_cache_;

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -190,7 +190,7 @@ struct Entry {
   /*! \brief feature value */
   bst_float fvalue;
   /*! \brief default constructor */
-#if defined(XGBOOST_BUILD_ARROW_SUPPORT)
+#if defined(XGBOOST_BUILD_ARROW_SUPPORT) && !defined(__CUDA__) && !defined(__CUDACC__)
   Entry() {} // NOLINT: Allow empty default constructor for performance reasons
 #else
   Entry() = default;

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -192,9 +192,9 @@ class MetaInfo {
             base_margin_.HostVector() == rhs.base_margin_.HostVector() &&
             labels_lower_bound_.HostVector() == rhs.labels_lower_bound_.HostVector() &&
             labels_upper_bound_.HostVector() == rhs.labels_upper_bound_.HostVector() &&
-            //feature_type_names == rhs.feature_type_names &&
-            //feature_names == rhs.feature_names &&
-            //feature_types.HostVector() == rhs.feature_types.HostVector() &&
+            // feature_type_names == rhs.feature_type_names &&
+            // feature_names == rhs.feature_names &&
+            // feature_types.HostVector() == rhs.feature_types.HostVector() &&
             feature_weigths.HostVector() == rhs.feature_weigths.HostVector());
   }
 

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -25,10 +25,6 @@ namespace xgboost {
 // forward declare dmatrix.
 class DMatrix;
 
-namespace data {
-class ArrowColumnarBatch;
-};
-
 /*! \brief data type accepted by xgboost interface */
 enum class DataType : uint8_t {
   kFloat32 = 1,
@@ -210,7 +206,11 @@ struct Entry {
   /*! \brief feature value */
   bst_float fvalue;
   /*! \brief default constructor */
+#if defined(XGBOOST_BUILD_ARROW_SUPPORT)
+  Entry() {} // NOLINT: Allow empty default constructor for performance reasons
+#else
   Entry() = default;
+#endif
   /*!
    * \brief constructor with index and value
    * \param index The feature or row index.
@@ -353,12 +353,6 @@ class SparsePage {
    */
   template <typename AdapterBatchT>
   uint64_t Push(const AdapterBatchT& batch, float missing, int nthread);
-
-  /*!
-   * \brief Overload Push for ArrowColumnarBatch
-   */
-  uint64_t Push(const data::ArrowColumnarBatch& batch, float missing, int nthread);
-
   /*!
    * \brief Push a sparse page
    * \param batch the row page

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -25,6 +25,10 @@ namespace xgboost {
 // forward declare dmatrix.
 class DMatrix;
 
+namespace data {
+class ArrowColumnarBatch;
+};
+
 /*! \brief data type accepted by xgboost interface */
 enum class DataType : uint8_t {
   kFloat32 = 1,
@@ -177,6 +181,22 @@ class MetaInfo {
    *                     columns.
    */
   void Extend(MetaInfo const& that, bool accumulate_rows, bool check_column);
+
+  bool operator==(const MetaInfo& rhs) const {
+    return (num_row_ == rhs.num_row_ &&
+            num_col_ == rhs.num_col_ &&
+            num_nonzero_ == rhs.num_nonzero_ &&
+            labels_.HostVector() == rhs.labels_.HostVector() &&
+            group_ptr_ == rhs.group_ptr_ &&
+            weights_.HostVector() == rhs.weights_.HostVector() &&
+            base_margin_.HostVector() == rhs.base_margin_.HostVector() &&
+            labels_lower_bound_.HostVector() == rhs.labels_lower_bound_.HostVector() &&
+            labels_upper_bound_.HostVector() == rhs.labels_upper_bound_.HostVector() &&
+            //feature_type_names == rhs.feature_type_names &&
+            //feature_names == rhs.feature_names &&
+            //feature_types.HostVector() == rhs.feature_types.HostVector() &&
+            feature_weigths.HostVector() == rhs.feature_weigths.HostVector());
+  }
 
  private:
   /*! \brief argsort of labels */
@@ -333,6 +353,11 @@ class SparsePage {
    */
   template <typename AdapterBatchT>
   uint64_t Push(const AdapterBatchT& batch, float missing, int nthread);
+
+  /*!
+   * \brief Overload Push for ArrowColumnarBatch
+   */
+  uint64_t Push(const data::ArrowColumnarBatch& batch, float missing, int nthread);
 
   /*!
    * \brief Push a sparse page

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -133,7 +133,7 @@ except ImportError:
     arrow_dataset = None
     ffi = None
     PYARROW_INSTALLED = False
-   
+
 
 # Modified from tensorflow with added caching.  There's a `LazyLoader` in
 # `importlib.utils`, except it's unclear from its document on how to use it.  This one

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -123,6 +123,18 @@ except ImportError:
     SCIPY_INSTALLED = False
 
 
+try:
+    import pyarrow as pa
+    from pyarrow import dataset as arrow_dataset
+    from pyarrow.cffi import ffi
+    PYARROW_INSTALLED = True
+except ImportError:
+    pa = None
+    arrow_dataset = None
+    ffi = None
+    PYARROW_INSTALLED = False
+   
+
 # Modified from tensorflow with added caching.  There's a `LazyLoader` in
 # `importlib.utils`, except it's unclear from its document on how to use it.  This one
 # seems to be easy to understand and works out of box.

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -20,7 +20,7 @@ import numpy as np
 import scipy.sparse
 
 from .compat import (STRING_TYPES, DataFrame, py_str, PANDAS_INSTALLED,
-                     lazy_isinstance, ffi, pa)
+                     lazy_isinstance, ffi)
 from .libpath import find_lib_path
 
 # c_bst_ulong corresponds to bst_ulong defined in xgboost/c_api.h

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -434,8 +434,8 @@ class RecordBatchDataIter:
 
     def __init__(self, data_iter):
         self.data_iter = data_iter      # an iterator for Arrow record batches
-        self.c_schema = ffi.new("struct ArrowSchema*")
-        self.c_array = ffi.new("struct ArrowArray*")
+        self.c_schemas = []
+        self.c_arrays = []
 
     def reset(self): # pylint: disable=missing-function-docstring
         raise NotImplementedError()
@@ -443,8 +443,10 @@ class RecordBatchDataIter:
     def next(self, data_handle): # pylint: disable=missing-function-docstring
         try:
             batch = next(self.data_iter)
-            ptr_schema = int(ffi.cast("uintptr_t", self.c_schema))
-            ptr_array = int(ffi.cast("uintptr_t", self.c_array))
+            self.c_schemas.append(ffi.new("struct ArrowSchema*"))
+            self.c_arrays.append(ffi.new("struct ArrowArray*"))
+            ptr_schema = int(ffi.cast("uintptr_t", self.c_schemas[-1]))
+            ptr_array = int(ffi.cast("uintptr_t", self.c_arrays[-1]))
             # pylint: disable=protected-access
             batch._export_to_c(ptr_array, ptr_schema)
             _check_call(_LIB.XGImportRecordBatch(

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1149,13 +1149,6 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
                 None,
                 c_bst_ulong(0)))
 
-    def __eq__(self, other):
-        ret = c_bst_ulong()
-        _check_call(_LIB.XGDMatricesEqual(self.handle, other.handle,
-                                        ctypes.byref(ret)))
-        return bool(ret.value)
-
-
 
 class _ProxyDMatrix(DMatrix):
     """A placeholder class when DMatrix cannot be constructed (DeviceQuantileDMatrix,

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -638,7 +638,7 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
                 base_margin is None or isinstance(base_margin, str),
                 qid is None or isinstance(qid, str))):
                 raise ValueError(
-                    'label, label_lower_bound, label_upper_bound, weight, ' + 
+                    'label, label_lower_bound, label_upper_bound, weight, ' +
                     'base_margin, and qid must be column names in string')
 
             rb_iter = iter(data.to_batches())

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -636,7 +636,8 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
 
             rb_iter = iter(data.to_batches())
             it = RecordBatchDataIter(rb_iter)
-            self._init_from_arrow(it, label, weight, base_margin, qid)
+            self._init_from_arrow(it, label, label_lower_bound,
+                    label_upper_bound, weight, base_margin, qid)
             assert self.handle is not None
             return
 
@@ -671,6 +672,8 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
             self,
             iterator: RecordBatchDataIter,
             label: str,
+            label_lower_bound: str,
+            label_upper_bound: str,
             weight: str,
             base_margin: str,
             qid: str):
@@ -678,17 +681,23 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
         next_callback = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_void_p)(iterator.next)
         plabel = (ctypes.POINTER(ctypes.c_char_p)() if label is None else
                 bytes(label, "utf-8"))
+        plabel_lb = (ctypes.POINTER(ctypes.c_char_p)() if label_lower_bound is None else
+                bytes(label_lower_bound, "utf-8"))
+        plabel_ub = (ctypes.POINTER(ctypes.c_char_p)() if label_upper_bound is None else
+                bytes(label_upper_bound, "utf-8"))
         pweight = (ctypes.POINTER(ctypes.c_char_p)() if weight is None else
-                bytes(label, "utf-8"))
+                bytes(weight, "utf-8"))
         pbase_margin = (ctypes.POINTER(ctypes.c_char_p)() if base_margin is None else
-                bytes(label, "utf-8"))
+                bytes(base_margin, "utf-8"))
         pqid = (ctypes.POINTER(ctypes.c_char_p)() if qid is None else
-                bytes(label, "utf-8"))
+                bytes(qid, "utf-8"))
         ret = _LIB.XGDMatrixCreateFromArrowCallback(
             next_callback,
             ctypes.c_float(self.missing),
             ctypes.c_int(self.nthread),
             plabel,
+            plabel_lb,
+            plabel_ub,
             pweight,
             pbase_margin,
             pqid,

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -623,16 +623,23 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
                 raise ValueError(
                     'Features in dataset can only be integers or floating point number')
 
+            if feature_names is not None:
+                raise ValueError(
+                    'feature_names must be set separately using DMatrix.set_info()')
+
             if feature_types is not None:
                 raise ValueError(
-                    'Arrow dataset has own feature types, cannot pass them in')
+                    'feature_types must be set separately using DMatrix.set_info()')
 
             if not all((label is None or isinstance(label, str),
+                label_lower_bound is None or isinstance(label_lower_bound, str),
+                label_upper_bound is None or isinstance(label_upper_bound, str),
                 weight is None or isinstance(weight, str),
                 base_margin is None or isinstance(base_margin, str),
                 qid is None or isinstance(qid, str))):
                 raise ValueError(
-                    'label, weight, base_margin, and qid must be column names in string')
+                    'label, label_lower_bound, label_upper_bound, weight, ' + 
+                    'base_margin, and qid must be column names in string')
 
             rb_iter = iter(data.to_batches())
             it = RecordBatchDataIter(rb_iter)

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -12,7 +12,7 @@ import numpy as np
 from .core import c_array, _LIB, _check_call, c_str
 from .core import _cuda_array_interface
 from .core import DataIter, _ProxyDMatrix, DMatrix
-from .compat import lazy_isinstance, DataFrame
+from .compat import lazy_isinstance, DataFrame, PYARROW_INSTALLED, pa, arrow_dataset
 
 c_bst_ulong = ctypes.c_uint64   # pylint: disable=invalid-name
 
@@ -199,6 +199,43 @@ def _is_modin_df(data):
     except ImportError:
         return False
     return isinstance(data, pd.DataFrame)
+
+
+def _is_arrow(data):
+    if not PYARROW_INSTALLED:
+        return False
+    return (isinstance(data, pa.lib.Table)
+            or isinstance(data, arrow_dataset.FileSystemDataset))
+
+
+def _transfrom_arrow(data, feature_types):
+    if not all(pa.types.is_integer(t) or pa.types.is_floating(t)
+                for t in data.schema.types):
+        raise ValueError(
+            'Features in dataset can only be integers or floating point number')
+
+    if feature_types is not None:
+        raise ValueError(
+            'Arrow dataset has own feature types, cannot pass them in')
+
+    return iter(data.to_batches())
+
+
+def _from_arrow(data, missing, nthread, feature_names, feature_types):
+    batches = _transfrom_arrow(data, feature_types)
+
+    from .core import RecordBatchDataIter
+    handle = ctypes.c_void_p()
+    it = RecordBatchDataIter(batches)
+    next_callback = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_void_p)(it.next)
+    ret = _LIB.XGDMatrixCreateFromArrowCallback(
+        next_callback,
+        ctypes.c_float(missing),
+        ctypes.c_int(nthread),
+        ctypes.byref(handle)
+    )
+    _check_call(ret)
+    return handle, feature_names, feature_types
 
 
 _pandas_dtype_mapper = {
@@ -793,6 +830,9 @@ def dispatch_data_backend(
         return _from_dt_df(
             data, missing, threads, feature_names, feature_types, enable_categorical
         )
+    if _is_arrow(data):
+        return _from_arrow(data, missing, threads, feature_names,
+                            feature_types)
     if _is_modin_df(data):
         return _from_pandas_df(data, enable_categorical, missing, threads,
                                feature_names, feature_types)

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -799,9 +799,6 @@ def dispatch_data_backend(
         return _from_dt_df(
             data, missing, threads, feature_names, feature_types, enable_categorical
         )
-    if _is_arrow(data):
-        return _from_arrow(data, missing, threads, feature_names,
-                            feature_types)
     if _is_modin_df(data):
         return _from_pandas_df(data, enable_categorical, missing, threads,
                                feature_names, feature_types)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,10 @@ if (LOG_CAPI_INVOCATION)
   target_compile_definitions(objxgboost PRIVATE -DLOG_CAPI_INVOCATION=1)
 endif (LOG_CAPI_INVOCATION)
 
+if (USE_ARROW)
+  target_compile_options(objxgboost PRIVATE -DXGBOOST_BUILD_ARROW_SUPPORT)
+endif (USE_ARROW)
+
 # For MSVC: Call msvc_use_static_runtime() once again to completely
 # replace /MD with /MT. See https://github.com/dmlc/xgboost/issues/4462
 # for issues caused by mixing of /MD and /MT flags

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -566,24 +566,6 @@ XGB_DLL int XGDMatrixNumCol(const DMatrixHandle handle,
   API_END();
 }
 
-XGB_DLL int XGDMatricesEqual(DMatrixHandle lmat, DMatrixHandle rmat, bst_ulong *out) {
-  API_BEGIN();
-  DMatrixHandle handle = lmat;
-  CHECK_HANDLE();
-  handle = rmat;
-  CHECK_HANDLE();
-  auto ldmat = static_cast<std::shared_ptr<DMatrix>*>(lmat)->get();
-  auto rdmat = static_cast<std::shared_ptr<DMatrix>*>(rmat)->get();
-  data::SimpleDMatrix *lhs, *rhs;
-  if ((lhs = dynamic_cast<data::SimpleDMatrix*>(ldmat)) &&
-      (rhs = dynamic_cast<data::SimpleDMatrix*>(rdmat))) {
-    *out = (*lhs == *rhs);
-  } else {
-    LOG(FATAL) << "equality comparison only supported by SimpleDMatrix";
-  }
-  API_END();
-}
-
 // xgboost implementation
 XGB_DLL int XGBoosterCreate(const DMatrixHandle dmats[],
                             xgboost::bst_ulong len,

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -376,6 +376,8 @@ XGB_DLL int XGDMatrixCreateFromArrowCallback(
     float missing,
     int nthread,
     const char* label_col_name,
+    const char* label_lb_col_name,
+    const char* label_ub_col_name,
     const char* weight_col_name,
     const char* base_margin_col_name,
     const char* qid_col_name,
@@ -383,6 +385,8 @@ XGB_DLL int XGDMatrixCreateFromArrowCallback(
   API_BEGIN();
   data::RecordBatchesIterAdapter adapter(next,
                                       label_col_name,
+                                      label_lb_col_name,
+                                      label_ub_col_name,
                                       weight_col_name,
                                       base_margin_col_name,
                                       qid_col_name);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -365,7 +365,7 @@ XGB_DLL int XGDMatrixCreateFromDT(void** data, const char** feature_stypes,
 #if defined(XGBOOST_BUILD_ARROW_SUPPORT)
 XGB_DLL int XGImportRecordBatch(DataIterHandle data_handle, void* ptr_array, void* ptr_schema) {
   API_BEGIN();
-  static_cast<data::RecordBatchIterAdapter *>(data_handle)->SetData(
+  static_cast<data::RecordBatchesIterAdapter *>(data_handle)->SetData(
       static_cast<struct ArrowArray *>(ptr_array),
       static_cast<struct ArrowSchema *>(ptr_schema));
   API_END();
@@ -381,7 +381,7 @@ XGB_DLL int XGDMatrixCreateFromArrowCallback(
     const char* qid_col_name,
     DMatrixHandle *out) {
   API_BEGIN();
-  data::RecordBatchIterAdapter adapter(next,
+  data::RecordBatchesIterAdapter adapter(next,
                                       label_col_name,
                                       weight_col_name,
                                       base_margin_col_name,

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -375,9 +375,17 @@ XGB_DLL int XGDMatrixCreateFromArrowCallback(
     XGDMatrixCallbackNext *next,
     float missing,
     int nthread,
+    const char* label_col_name,
+    const char* weight_col_name,
+    const char* base_margin_col_name,
+    const char* qid_col_name,
     DMatrixHandle *out) {
   API_BEGIN();
-  data::RecordBatchIterAdapter adapter(next);
+  data::RecordBatchIterAdapter adapter(next,
+                                      label_col_name,
+                                      weight_col_name,
+                                      base_margin_col_name,
+                                      qid_col_name);
   *out = new std::shared_ptr<DMatrix>(
       DMatrix::Create(&adapter, missing, nthread));
   API_END();

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -22,9 +22,11 @@
 #include "xgboost/span.h"
 
 #include "array_interface.h"
-#include "arrow-cdi.h"
 #include "../c_api/c_api_error.h"
 #include "../common/math.h"
+#if defined(XGBOOST_BUILD_ARROW_SUPPORT)
+#include "arrow-cdi.h"
+#endif
 
 namespace xgboost {
 namespace data {

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -864,7 +864,7 @@ class PrimitiveColumn : public Column {
 
  private:
   const T* data_;
-  float missing_; // user specified missing value
+  float missing_;  // user specified missing value
 };
 
 struct ColumnarMetaInfo {

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -902,14 +902,6 @@ struct ArrowSchemaImporter {
     }
   }
 
-  void Clear() {
-    columns_.clear();
-    label_info_ = ColumnarMetaInfo();
-    weight_info_ = ColumnarMetaInfo();
-    base_margin_info_ = ColumnarMetaInfo();
-    qid_info_ = ColumnarMetaInfo();
-  }
-
   void Import(struct ArrowSchema *schema,
               const char* label_col_name = nullptr,
               const char* weight_col_name = nullptr,
@@ -917,7 +909,7 @@ struct ArrowSchemaImporter {
               const char* qid_col_name = nullptr) {
     if (schema) {
       CHECK(std::string(schema->format) == "+s");
-      Clear();
+      CHECK(columns_.empty());
       for (auto i = 0; i < schema->n_children; ++i) {
         std::string name{schema->children[i]->name};
         ColumnDType type = format_map(schema->children[i]->format);

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -826,7 +826,10 @@ class Column {
   const uint8_t* bitmap_;
 };
 
-// only columns of primitive types are supported
+// Only columns of primitive types are supported. An ArrowColumnarBatch is a
+// collection of std::shared_ptr<PrimitiveColumn>. These columns can be of different data types.
+// Hence, PrimitiveColumn is a class template; and all concrete PrimitiveColumns
+// derive from the abstract class Column.
 template <typename T>
 class PrimitiveColumn : public Column {
   static constexpr float nan = std::numeric_limits<float>::quiet_NaN();

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -1201,6 +1201,7 @@ class RecordBatchesIterAdapter: public dmlc::DataIter<ArrowColumnarBatchVec> {
       }
     }
     if (rb) {
+      std::cout << "";
       batches_.push_back(std::make_unique<ArrowColumnarBatch>(rb, &schema_));
     }
   }

--- a/src/data/arrow-cdi.h
+++ b/src/data/arrow-cdi.h
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+struct ArrowSchema {
+  // Array type description
+  const char* format;
+  const char* name;
+  const char* metadata;
+  int64_t flags;
+  int64_t n_children;
+  struct ArrowSchema** children;
+  struct ArrowSchema* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowSchema*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+struct ArrowArray {
+  // Array data description
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+  int64_t n_buffers;
+  int64_t n_children;
+  const void** buffers;
+  struct ArrowArray** children;
+  struct ArrowArray* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowArray*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/data/arrow-cdi.h
+++ b/src/data/arrow-cdi.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -866,6 +866,12 @@ DMatrix::Create(data::IteratorAdapter<DataIterHandle, XGBCallbackDataIterNext,
                                       XGBoostBatchCSR> *adapter,
                 float missing, int nthread, const std::string &cache_prefix);
 
+#if defined(XGBOOST_BUILD_ARROW_SUPPORT)
+template DMatrix* DMatrix::Create<data::RecordBatchIterAdapter>(
+    data::RecordBatchIterAdapter* adapter, float missing, int nthread,
+    const std::string&, size_t);
+#endif
+
 SparsePage SparsePage::GetTranspose(int num_columns) const {
   SparsePage transpose;
   common::ParallelGroupBuilder<Entry, bst_row_t> builder(&transpose.offset.HostVector(),
@@ -1023,6 +1029,70 @@ uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread
 
   return max_columns;
 }
+
+#if defined(XGBOOST_BUILD_ARROW_SUPPORT)
+uint64_t SparsePage::Push(const data::ArrowColumnarBatch& batch, float missing, int nthread) {
+  // Set number of threads but keep old value so we can reset it after
+  int nthread_original = common::OmpSetNumThreadsWithoutHT(&nthread);
+
+  uint64_t num_columns{batch.NumColumns()};
+  size_t batch_size{batch.Size()};
+  size_t batch_nnn{0};
+  auto& data_vec = data.HostVector();
+  auto& offset_vec = offset.HostVector();
+
+  // Compute the starting location for every row in data_vec
+  std::vector<size_t> row_begins(batch_size + 1, 0);
+  row_begins[0] = offset_vec.empty() ? 0 : offset_vec.back();
+#pragma omp parallel for reduction(+:batch_nnn) if(batch_size > (1 << 18))
+  for (size_t i = 0; i < batch_size; ++i) {
+    for (size_t j = 0; j < num_columns; ++j) {
+      auto element = batch.GetColumn(j).GetElement(i);
+      if (!std::isnan(element.value) && element.value != missing) {
+        row_begins[i+1]++;
+        batch_nnn++;
+      }
+    }
+  }
+  // prefix sum
+  std::vector<size_t> temp(batch_size + 1, row_begins[0]);
+  for (size_t j = 0; j < log2(row_begins.size()); ++j) {
+#pragma omp parallel for if(batch_size > (1 << 18))
+    for (size_t i = 1 << j; i < row_begins.size(); ++i) {
+      temp[i] = row_begins[i] + row_begins[i - (1 << j)];
+    }
+#pragma omp parallel for if(batch_size > (1 << 18))
+    for (size_t i = 1 << j; i < row_begins.size(); ++i) {
+      row_begins[i] = temp[i];
+    }
+  }
+
+  CHECK(row_begins.back() - row_begins.front() == batch_nnn);
+
+  // Place elements in correct locations
+  size_t cum_size = data_vec.size() + batch_nnn;
+  data_vec.resize(cum_size);
+#pragma omp parallel for schedule(static)
+  for (size_t i = 0; i < batch_size; ++i) {
+    size_t begin = row_begins[i];
+    for (size_t j = 0; j < num_columns; ++j) {
+      auto element = batch.GetColumn(j).GetElement(i);
+      if (!std::isnan(element.value) && element.value != missing) {
+        data_vec[begin++] = Entry(element.column_idx, element.value);
+      }
+    }
+  }
+
+  // Set offset
+  offset_vec.insert(offset_vec.end(), row_begins.begin() + 1, row_begins.end());
+  CHECK(offset_vec.back() == data_vec.size());
+
+  // Restore omp_num_threads
+  omp_set_num_threads(nthread_original);
+
+  return num_columns;
+}
+#endif
 
 void SparsePage::PushCSC(const SparsePage &batch) {
   std::vector<xgboost::Entry>& self_data = data.HostVector();

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -355,15 +355,5 @@ SimpleDMatrix::SimpleDMatrix(RecordBatchesIterAdapter* adapter,
 }
 #endif
 
-bool SimpleDMatrix::operator==(const SimpleDMatrix& rhs) const {
-  auto& my_info = info_;
-  auto& your_info = rhs.info_;
-  auto& my_offset = sparse_page_->offset.HostVector();
-  auto& your_offset = rhs.sparse_page_->offset.HostVector();
-  auto& my_data = sparse_page_->data.HostVector();
-  auto& your_data = rhs.sparse_page_->data.HostVector();
-  return (my_info == your_info && my_offset == your_offset && my_data == your_data);
-}
-
 }  // namespace data
 }  // namespace xgboost

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -262,7 +262,7 @@ SimpleDMatrix::SimpleDMatrix(RecordBatchesIterAdapter* adapter,
     size_t num_elements = 0;
     size_t num_rows = 0;
     // Import Arrow RecordBatches
-#pragma omp parallel for reduction(+:num_elements,num_rows) num_threads(nthread)
+#pragma omp parallel for reduction(+:num_elements, num_rows) num_threads(nthread)
     for (int i = 0; i < batches.size(); ++i) {
       num_elements += batches[i]->Import(missing);
       num_rows += batches[i]->Size();
@@ -299,7 +299,7 @@ SimpleDMatrix::SimpleDMatrix(RecordBatchesIterAdapter* adapter,
       base_margin.resize(total_batch_size);
     }
     // Copy data into DMatrix
-#pragma omp parallel num_threads(nthread) 
+#pragma omp parallel num_threads(nthread)
     {
 #pragma omp for nowait
     for (int i = 0; i < batches.size(); ++i) {
@@ -335,11 +335,11 @@ SimpleDMatrix::SimpleDMatrix(RecordBatchesIterAdapter* adapter,
       }
       if (batches[i]->Weights() != nullptr) {
         std::copy(batches[i]->Weights(), batches[i]->Weights() + batches[i]->Size(),
-            weights.begin() + batch_offsets[i]); 
+            weights.begin() + batch_offsets[i]);
       }
       if (batches[i]->BaseMargin() != nullptr) {
         std::copy(batches[i]->BaseMargin(), batches[i]->BaseMargin() + batches[i]->Size(),
-            base_margin.begin() + batch_offsets[i]); 
+            base_margin.begin() + batch_offsets[i]);
       }
     }
     }

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -247,6 +247,8 @@ SimpleDMatrix::SimpleDMatrix(RecordBatchesIterAdapter* adapter,
   auto& offset_vec = sparse_page_->offset.HostVector();
   auto& data_vec = sparse_page_->data.HostVector();
   auto& labels = info_.labels_.HostVector();
+  auto& labels_lb = info_.labels_lower_bound_.HostVector();
+  auto& labels_ub = info_.labels_upper_bound_.HostVector();
   auto& weights = info_.weights_.HostVector();
   auto& base_margin = info_.base_margin_.HostVector();
   uint64_t total_batch_size = 0;
@@ -284,6 +286,12 @@ SimpleDMatrix::SimpleDMatrix(RecordBatchesIterAdapter* adapter,
     if (adapter->HasLabelColumn()) {
       labels.resize(total_batch_size);
     }
+    if (adapter->HasLabelLBColumn()) {
+      labels_lb.resize(total_batch_size);
+    }
+    if (adapter->HasLabelUBColumn()) {
+      labels_ub.resize(total_batch_size);
+    }
     if (adapter->HasWeightColumn()) {
       weights.resize(total_batch_size);
     }
@@ -314,6 +322,16 @@ SimpleDMatrix::SimpleDMatrix(RecordBatchesIterAdapter* adapter,
       if (batches[i]->Labels() != nullptr) {
         std::copy(batches[i]->Labels(), batches[i]->Labels() + batches[i]->Size(),
             labels.begin() + batch_offsets[i]);
+      }
+      if (batches[i]->LabelsLowerBound() != nullptr) {
+        std::copy(batches[i]->LabelsLowerBound(),
+            batches[i]->LabelsLowerBound() + batches[i]->Size(),
+            labels_lb.begin() + batch_offsets[i]);
+      }
+      if (batches[i]->LabelsUpperBound() != nullptr) {
+        std::copy(batches[i]->LabelsUpperBound(),
+            batches[i]->LabelsUpperBound() + batches[i]->Size(),
+            labels_ub.begin() + batch_offsets[i]);
       }
       if (batches[i]->Weights() != nullptr) {
         std::copy(batches[i]->Weights(), batches[i]->Weights() + batches[i]->Size(),

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -246,10 +246,10 @@ template SimpleDMatrix::SimpleDMatrix(RecordBatchIterAdapter* adapter, float mis
 bool SimpleDMatrix::operator==(const SimpleDMatrix& rhs) const {
   auto& my_info = info_;
   auto& your_info = rhs.info_;
-  auto& my_offset = sparse_page_.offset.HostVector();
-  auto& your_offset = rhs.sparse_page_.offset.HostVector();
-  auto& my_data = sparse_page_.data.HostVector();
-  auto& your_data = rhs.sparse_page_.data.HostVector();
+  auto& my_offset = sparse_page_->offset.HostVector();
+  auto& your_offset = rhs.sparse_page_->offset.HostVector();
+  auto& my_data = sparse_page_->data.HostVector();
+  auto& your_data = rhs.sparse_page_->data.HostVector();
   return (my_info == your_info && my_offset == your_offset && my_data == your_data);
 }
 

--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -36,6 +36,8 @@ class SimpleDMatrix : public DMatrix {
   bool SingleColBlock() const override { return true; }
   DMatrix* Slice(common::Span<int32_t const> ridxs) override;
 
+  bool operator==(const SimpleDMatrix& rhs) const;
+
   /*! \brief magic number used to identify SimpleDMatrix binary files */
   static const int kMagic = 0xffffab01;
 

--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -36,8 +36,6 @@ class SimpleDMatrix : public DMatrix {
   bool SingleColBlock() const override { return true; }
   DMatrix* Slice(common::Span<int32_t const> ridxs) override;
 
-  bool operator==(const SimpleDMatrix& rhs) const;
-
   /*! \brief magic number used to identify SimpleDMatrix binary files */
   static const int kMagic = 0xffffab01;
 

--- a/tests/ci_build/conda_env/cpu_test.yml
+++ b/tests/ci_build/conda_env/cpu_test.yml
@@ -32,6 +32,7 @@ dependencies:
 - awscli
 - numba
 - llvmlite
+- pyarrow
 - pip:
   - shap
   - ipython                     # required by shap at import time.

--- a/tests/python/test_with_arrow.py
+++ b/tests/python/test_with_arrow.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+import unittest
+import pytest
+import numpy as np
+import testing as tm
+import xgboost as xgb
+
+try:
+    import pyarrow as pa
+    import pyarrow.csv as pc
+    import pyarrow.dataset as ds
+    import pandas as pd
+except ImportError:
+    pass
+
+pytestmark = pytest.mark.skipif(
+    tm.no_arrow()['condition'] or tm.no_pandas()['condition'],
+    reason=tm.no_arrow()['reason'] + ' or ' + tm.no_pandas()['reason'])
+
+dpath = 'demo/data/'
+
+class TestArrowTable(unittest.TestCase):
+
+    def test_arrow_table(self):
+        df = pd.DataFrame([[0, 1, 2., 3.], [1, 2, 3., 4.]],
+                          columns=['a', 'b', 'c', 'd'])
+        table = pa.Table.from_pandas(df)
+        dm = xgb.DMatrix(table)
+        assert dm.num_row() == 2
+        assert dm.num_col() == 4
+
+    def test_arrow_table_with_label(self):
+        df = pd.DataFrame([[1, 2., 3.], [2, 3., 4.]],
+                          columns=['a', 'b', 'c'])
+        table = pa.Table.from_pandas(df)
+        label = np.array([0, 1])
+        dm = xgb.DMatrix(table)
+        dm.set_label(label)
+        assert dm.num_row() == 2
+        assert dm.num_col() == 3
+        np.testing.assert_array_equal(dm.get_label(), np.array([0, 1]))
+
+    def test_arrow_table_with_label_name(self):
+        df = pd.DataFrame([[1, 2., 3., 0], [2, 3., 4., 1]],
+                          columns=['a', 'b', 'c', 'd'])
+        table = pa.Table.from_pandas(df)
+        dm = xgb.DMatrix(table, label='d')
+        assert dm.num_row() == 2
+        assert dm.num_col() == 3
+        np.testing.assert_array_equal(dm.get_label(), np.array([0, 1]))
+
+    def test_arrow_table_from_np(self):
+        coldata = np.array([[1., 1., 0., 0.],
+                            [2., 0., 1., 0.],
+                            [3., 0., 0., 1.]])
+        cols = list(map(pa.array, coldata))
+        table = pa.Table.from_arrays(cols, ['a', 'b', 'c'])
+        dm = xgb.DMatrix(table)
+        assert dm.num_row() == 4
+        assert dm.num_col() == 3
+
+    def test_arrow_table_from_csv(self):
+        dfile = dpath + 'veterans_lung_cancer.csv'
+        table = pc.read_csv(dfile)
+        dm = xgb.DMatrix(table)
+        assert dm.num_row() == 137
+        assert dm.num_col() == 13
+
+    def test_arrow_dataset_from_csv(self):
+        dfile = dpath + 'veterans_lung_cancer.csv'
+        data = ds.dataset(dfile, format='csv')
+        dm = xgb.DMatrix(data)
+        assert dm.num_row() == 137
+        assert dm.num_col() == 13
+
+    def test_arrow_train(self):
+        import pandas as pd
+        rows = 100
+        X = pd.DataFrame(
+            {"A": np.random.randint(0, 10, size=rows),
+             "B": np.random.randn(rows),
+             "C": np.random.permutation([1, 0] * (rows // 2))})
+        y = pd.Series(np.random.randn(rows))
+        table = pa.Table.from_pandas(X)
+        dtrain1 = xgb.DMatrix(table)
+        dtrain1.set_label(y)
+        bst1 = xgb.train({}, dtrain1, num_boost_round=10)
+        preds1 = bst1.predict(xgb.DMatrix(X))
+        dtrain2 = xgb.DMatrix(X, y)
+        bst2 = xgb.train({}, dtrain2, num_boost_round=10)
+        preds2 = bst2.predict(xgb.DMatrix(X))
+        np.testing.assert_allclose(preds1, preds2)
+
+    def test_arrow_survival(self):
+        dfile = dpath + 'veterans_lung_cancer.csv'
+        table = pc.read_csv(dfile)
+        dtrain = xgb.DMatrix(table,
+                label_lower_bound='Survival_label_lower_bound',
+                label_upper_bound='Survival_label_upper_bound')
+
+        base_params = {'verbosity': 0,
+                       'objective': 'survival:aft',
+                       'eval_metric': 'aft-nloglik',
+                       'tree_method': 'hist',
+                       'learning_rate': 0.05,
+                       'aft_loss_distribution_scale': 1.20,
+                       'max_depth': 6,
+                       'lambda': 0.01,
+                       'alpha': 0.02}
+        nloglik_rec = {}
+        dists = ['normal', 'logistic', 'extreme']
+        for dist in dists:
+            params = base_params
+            params.update({'aft_loss_distribution': dist})
+            evals_result = {}
+            bst = xgb.train(params, dtrain, num_boost_round=500, evals=[(dtrain, 'train')],
+                            evals_result=evals_result)
+            nloglik_rec[dist] = evals_result['train']['aft-nloglik']
+            # AFT metric (negative log likelihood) improve monotonically
+            assert all(p >= q for p, q in zip(nloglik_rec[dist], nloglik_rec[dist][:1]))
+        # For this data, normal distribution works the best
+        assert nloglik_rec['normal'][-1] < 4.9
+        assert nloglik_rec['logistic'][-1] > 4.9
+        assert nloglik_rec['extreme'][-1] > 4.9

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from io import StringIO
 from xgboost.compat import SKLEARN_INSTALLED, PANDAS_INSTALLED
 from xgboost.compat import DASK_INSTALLED
+from xgboost.compat import PYARROW_INSTALLED
 import pytest
 import gc
 import xgboost as xgb
@@ -447,3 +448,7 @@ except ImportError:
 CURDIR = os.path.normpath(os.path.abspath(os.path.dirname(__file__)))
 PROJECT_ROOT = os.path.normpath(
     os.path.join(CURDIR, os.path.pardir, os.path.pardir))
+
+def no_arrow():
+    return {'condition': not PYARROW_INSTALLED,
+            'reason': 'pyarrow is not installed'}


### PR DESCRIPTION
Apache Arrow defines a columnar memory format, which allows zero-copy read and lighting fast data access ([link](https://arrow.apache.org)). This PR adds support for building xgboost DMatrix from the Apache Arrow data format. 

This is a rework of #5667, which is now closed and all discussion should continue here. 

### Features:

- A new adapter class in C++ that accepts input data in the format defined by [the Arrow C data interface ](https://arrow.apache.org/docs/format/CDataInterface.html).
- A new template specialization for the `SimpleDMatrix` class constructor that creates a DMatrix instance from Arrow data.
- No dependence on the Arrow API or the Arrow libraries. It only requires the input data to be in the Arrow format.
- Works with any data source that can export data following the Arrow C data interface specification.
- The xgboost Python interface supports building DMatrix from pyarrow data source, including `pyarrow.Table` and `pyarrow.dataset`. It provides better performance in building DMatrix than using the existing pandas interface. 
- Supports a data iterator interface to allow input data to be provided in a batch-by-batch fashion. This helps to reduce peak memory consumption when reading large data. This also makes it easier to work with other components that expect input data in mini batches, for example, the JVM packages. 
- Tested with Arrow 3.0, 4.0, and 5.0. 

### Performance of building DMatrix (Timing measured on Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz with 56 cores): 

Dataset | File format | Data size | From pandas dataframe | From Arrow format (using pyarrow)|
-- | -- | -- | -- | -- |
HIGGS | csv | 2 million rows, 29 features | 8.43 sec | 0.96 sec |
Mortgage | parquet | 36 million rows, 47 features | 14.31 sec | 2.61 sec |

### Peak memory during DMatrix building (Using a Mortgage dataset with 150 million rows as an example):

Data source | Peak mem |
-- | --  |
pandas.dataframe | 170 GB |
pyarrow.Table | 152 GB |
pyarrow.dataset | 105 GB |

The final DMatrix memory size is 58 GB.  

### How to build:

- Configure the build by passing `-DUSE_ARROW=ON` to the cmake command.

### Usage (python):

A DMatrix can be built from either a `pyarrow.Table` or a `pyarrow.dataset`. For example,
```python
import xgboost as xgb
from pyarrow import csv
import pyarrow.dataset as ds

# Reading CSV input as pyarrow.Table
table = csv.read_csv('/path/to/csv/input')
dmat = xgb.DMatrix(table)

# Reading parquet input as pyarrow.dataset
data = ds.dataset('/path/to/parquet/intput', format='parquet')
dmat = xgb.DMatrix(data)
```
