### PR TITLE
Initial support for multi-output regression.

### DIFF
--- a/demo/guide-python/multioutput_regression.py
+++ b/demo/guide-python/multioutput_regression.py
@@ -1,0 +1,45 @@
+"""A demo adopted from scikit-learn for multi-output regression.
+
+https://scikit-learn.org/stable/auto_examples/ensemble/plot_random_forest_regression_multioutput.html#sphx-glr-auto-examples-ensemble-plot-random-forest-regression-multioutput-py
+
+"""
+import numpy as np
+import xgboost as xgb
+import argparse
+from matplotlib import pyplot as plt
+
+
+def plot_predt(y, y_predt, name):
+    s = 25
+    plt.scatter(y[:, 0], y[:, 1], c="navy", s=s,
+                edgecolor="black", label="data")
+    plt.scatter(y_predt[:, 0], y_predt[:, 1], c="cornflowerblue", s=s,
+                edgecolor="black")
+    plt.xlim([-1, 2])
+    plt.ylim([-1, 2])
+    plt.show()
+
+
+def main(plot_result: bool):
+    """Draw a circle with 2-dim coordinate as target variables."""
+    rng = np.random.RandomState(1994)
+    X = np.sort(200 * rng.rand(100, 1) - 100, axis=0)
+    y = np.array([np.pi * np.sin(X).ravel(), np.pi * np.cos(X).ravel()]).T
+    y[::5, :] += (0.5 - rng.rand(20, 2))
+    y = y - y.min()
+    y = y / y.max()
+
+    # Train a regressor on it
+    reg = xgb.XGBMultiOutputRegressor(tree_method="hist", n_estimators=32)
+    reg.fit(X, y)
+
+    y_predt = reg.predict(X)
+    if plot_result:
+        plot_predt(y, y_predt, 'multi')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--plot", choices=[0, 1], type=int, default=1)
+    args = parser.parse_args()
+    main(args.plot == 1)

--- a/python-package/xgboost/__init__.py
+++ b/python-package/xgboost/__init__.py
@@ -16,19 +16,36 @@ from . import dask
 try:
     from .sklearn import XGBModel, XGBClassifier, XGBRegressor, XGBRanker
     from .sklearn import XGBRFClassifier, XGBRFRegressor
+    from .sklearn import XGBMultiOutputRegressor
     from .plotting import plot_importance, plot_tree, to_graphviz
     from .config import set_config, get_config, config_context
 except ImportError:
     pass
 
-VERSION_FILE = os.path.join(os.path.dirname(__file__), 'VERSION')
+VERSION_FILE = os.path.join(os.path.dirname(__file__), "VERSION")
 with open(VERSION_FILE, encoding="ascii") as f:
     __version__ = f.read().strip()
 
-__all__ = ['DMatrix', 'DeviceQuantileDMatrix', 'Booster', 'DataIter',
-           'train', 'cv',
-           'RabitTracker',
-           'XGBModel', 'XGBClassifier', 'XGBRegressor', 'XGBRanker',
-           'XGBRFClassifier', 'XGBRFRegressor',
-           'plot_importance', 'plot_tree', 'to_graphviz', 'dask',
-           'set_config', 'get_config', 'config_context']
+__all__ = [
+    "DMatrix",
+    "DeviceQuantileDMatrix",
+    "Booster",
+    "DataIter",
+    "train",
+    "cv",
+    "RabitTracker",
+    "XGBModel",
+    "XGBClassifier",
+    "XGBRegressor",
+    "XGBMultiOutputRegressor",
+    "XGBRanker",
+    "XGBRFClassifier",
+    "XGBRFRegressor",
+    "plot_importance",
+    "plot_tree",
+    "to_graphviz",
+    "dask",
+    "set_config",
+    "get_config",
+    "config_context",
+]

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -601,8 +601,8 @@ void MetaInfo::Validate(int32_t device) const {
     return;
   }
   if (labels_.Size() != 0) {
-    CHECK_EQ(labels_.Size(), num_row_)
-        << "Size of labels must equal to number of rows.";
+    CHECK_EQ(labels_.Size() % num_row_, 0)
+        << "Size of labels must be multiple to the number of rows.";
     check_device(labels_);
     return;
   }

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -138,7 +138,8 @@ class GBLinear : public GradientBooster {
                HostDeviceVector<GradientPair> *in_gpair,
                PredictionCacheEntry*) override {
     monitor_.Start("DoBoost");
-
+    auto y_size = p_fmat->Info().labels_.Size();
+    CHECK_EQ(y_size, p_fmat->Info().num_row_) << "Invalid size of labels";
     model_.LazyInitModel();
     this->LazySumWeights(p_fmat);
 

--- a/tests/python-gpu/test_from_cupy.py
+++ b/tests/python-gpu/test_from_cupy.py
@@ -49,9 +49,10 @@ def _test_from_cupy(DMatrixT):
     dmatrix_from_cupy(np.int32, DMatrixT, -2)
     dmatrix_from_cupy(np.int64, DMatrixT, -3)
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         X = cp.random.randn(2, 2, dtype="float32")
-        DMatrixT(X, label=X)
+        y = cp.random.randn(2, 2, 3, dtype="float32")
+        DMatrixT(X, label=y)
 
 
 def _test_cupy_training(DMatrixT):
@@ -75,7 +76,9 @@ def _test_cupy_training(DMatrixT):
                             base_margin=base_margin)
     xgb.train(params, dtrain_np, evals=[(dtrain_np, "train")],
               evals_result=evals_result_np)
-    assert np.array_equal(evals_result_cupy["train"]["rmse"], evals_result_np["train"]["rmse"])
+    assert np.array_equal(
+        evals_result_cupy["train"]["rmse"], evals_result_np["train"]["rmse"]
+    )
 
 
 def _test_cupy_metainfo(DMatrixT):

--- a/tests/python/test_demos.py
+++ b/tests/python/test_demos.py
@@ -127,6 +127,11 @@ def test_continuation_demo():
     subprocess.check_call(cmd)
 
 
+def test_multi_reg_demo():
+    script = os.path.join(PYTHON_DEMO_DIR, 'multioutput_regression.py')
+    cmd = ['python', script, "--plot=0"]
+    subprocess.check_call(cmd)
+
 # gpu_acceleration is not tested due to covertype dataset is being too huge.
 # gamma regression is not tested as it requires running a R script first.
 # aft viz is not tested due to ploting is not controled


### PR DESCRIPTION
* Implemented as 1 model per target.
* Not available for classification yet.


I will follow up with R and dask implementations if this PR is approved.

Related: https://github.com/dmlc/xgboost/issues/2087 .

Todos:
- [x] Verify data types other than numpy array.
- [ ] Have better specification for return shape.