### PR TITLE
[backport] Fix prediction with cat data in sklearn interface. (#7306)

### DIFF
--- a/tests/python-gpu/test_gpu_with_sklearn.py
+++ b/tests/python-gpu/test_gpu_with_sklearn.py
@@ -59,6 +59,7 @@ def test_categorical():
     )
     X = pd.DataFrame(X.todense()).astype("category")
     clf.fit(X, y)
+    assert not clf._can_use_inplace_predict()
 
     with tempfile.TemporaryDirectory() as tempdir:
         model = os.path.join(tempdir, "categorial.json")


### PR DESCRIPTION
* Specify DMatrix parameter for pre-processing dataframe.
* Add document about the behaviour of prediction.