### PR TITLE
Update spark dependency to spark 3.2

### DIFF
--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -34,8 +34,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <flink.version>1.7.2</flink.version>
-        <spark.version>3.0.0</spark.version>
-        <scala.version>2.12.8</scala.version>
+        <spark.version>3.2.0</spark.version>
+        <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <hadoop.version>2.7.3</hadoop.version>
         <maven.wagon.http.retryHandler.count>5</maven.wagon.http.retryHandler.count>


### PR DESCRIPTION
Current xgboost4j released version built with spark 3.0, but the binary jar is incompatible with spark 3.2
This PR update the spark dependency to be spark 3.2