### PR TITLE
Use double precision in metric calculation.

### DIFF
--- a/include/xgboost/metric.h
+++ b/include/xgboost/metric.h
@@ -58,9 +58,8 @@ class Metric : public Configurable {
    *        the average statistics across all the node,
    *        this is only supported by some metrics
    */
-  virtual bst_float Eval(const HostDeviceVector<bst_float>& preds,
-                         const MetaInfo& info,
-                         bool distributed) = 0;
+  virtual double Eval(const HostDeviceVector<bst_float> &preds,
+                      const MetaInfo &info, bool distributed) = 0;
   /*! \return name of metric */
   virtual const char* Name() const = 0;
   /*! \brief virtual destructor */

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1110,6 +1110,7 @@ class LearnerImpl : public LearnerIO {
     this->Configure();
 
     std::ostringstream os;
+    os.precision(std::numeric_limits<double>::max_digits10);
     os << '[' << iter << ']' << std::setiosflags(std::ios::fixed);
     if (metrics_.size() == 0 && tparam_.disable_default_eval_metric <= 0) {
       auto warn_default_eval_metric = [](const std::string& objective, const std::string& before,

--- a/src/metric/auc.cc
+++ b/src/metric/auc.cc
@@ -407,7 +407,7 @@ GPURankingAUC(common::Span<float const> predts, MetaInfo const &info,
 struct DeviceAUCCache {};
 #endif  // !defined(XGBOOST_USE_CUDA)
 
-class EvalAUCPR : public EvalAUC<EvalAUCPR> {
+class EvalPRAUC : public EvalAUC<EvalPRAUC> {
   std::shared_ptr<DeviceAUCCache> d_cache_;
 
  public:
@@ -462,7 +462,7 @@ class EvalAUCPR : public EvalAUC<EvalAUCPR> {
 
 XGBOOST_REGISTER_METRIC(AUCPR, "aucpr")
     .describe("Area under PR curve for both classification and rank.")
-    .set_body([](char const *) { return new EvalAUCPR{}; });
+    .set_body([](char const *) { return new EvalPRAUC{}; });
 
 #if !defined(XGBOOST_USE_CUDA)
 std::tuple<double, double, double>

--- a/src/metric/multiclass_metric.cu
+++ b/src/metric/multiclass_metric.cu
@@ -167,9 +167,8 @@ class MultiClassMetricsReduction {
  */
 template<typename Derived>
 struct EvalMClassBase : public Metric {
-  bst_float Eval(const HostDeviceVector<bst_float> &preds,
-                 const MetaInfo &info,
-                 bool distributed) override {
+  double Eval(const HostDeviceVector<float> &preds, const MetaInfo &info,
+              bool distributed) override {
     if (info.labels_.Size() == 0) {
       CHECK_EQ(preds.Size(), 0);
     } else {
@@ -206,7 +205,7 @@ struct EvalMClassBase : public Metric {
    * \param esum the sum statistics returned by EvalRow
    * \param wsum sum of weight
    */
-  inline static bst_float GetFinal(bst_float esum, bst_float wsum) {
+  inline static double GetFinal(double esum, double wsum) {
     return esum / wsum;
   }
 

--- a/src/metric/rank_metric.cu
+++ b/src/metric/rank_metric.cu
@@ -29,9 +29,8 @@ DMLC_REGISTRY_FILE_TAG(rank_metric_gpu);
 template <typename EvalMetricT>
 struct EvalRankGpu : public Metric, public EvalRankConfig {
  public:
-  bst_float Eval(const HostDeviceVector<bst_float> &preds,
-                 const MetaInfo &info,
-                 bool distributed) override {
+  double Eval(const HostDeviceVector<bst_float> &preds, const MetaInfo &info,
+              bool distributed) override {
     // Sanity check is done by the caller
     std::vector<unsigned> tgptr(2, 0);
     tgptr[1] = static_cast<unsigned>(preds.Size());

--- a/src/metric/survival_metric.cu
+++ b/src/metric/survival_metric.cu
@@ -206,9 +206,8 @@ template <typename Policy> struct EvalEWiseSurvivalBase : public Metric {
     CHECK(tparam_);
   }
 
-  bst_float Eval(const HostDeviceVector<bst_float>& preds,
-                 const MetaInfo& info,
-                 bool distributed) override {
+  double Eval(const HostDeviceVector<float> &preds, const MetaInfo &info,
+              bool distributed) override {
     CHECK_EQ(preds.Size(), info.labels_lower_bound_.Size());
     CHECK_EQ(preds.Size(), info.labels_upper_bound_.Size());
     CHECK(tparam_);
@@ -221,7 +220,7 @@ template <typename Policy> struct EvalEWiseSurvivalBase : public Metric {
     if (distributed) {
       rabit::Allreduce<rabit::op::Sum>(dat, 2);
     }
-    return static_cast<bst_float>(Policy::GetFinal(dat[0], dat[1]));
+    return Policy::GetFinal(dat[0], dat[1]);
   }
 
   const char* Name() const override {
@@ -241,9 +240,8 @@ struct AFTNLogLikDispatcher : public Metric {
     return "aft-nloglik";
   }
 
-  bst_float Eval(const HostDeviceVector<bst_float>& preds,
-                 const MetaInfo& info,
-                 bool distributed) override {
+  double Eval(const HostDeviceVector<bst_float> &preds, const MetaInfo &info,
+              bool distributed) override {
     CHECK(metric_) << "AFT metric must be configured first, with distribution type and scale";
     return metric_->Eval(preds, info, distributed);
   }

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -106,7 +106,7 @@ bool IsNear(std::vector<xgboost::bst_float>::const_iterator _beg1,
  */
 class SimpleLCG {
  private:
-  using StateType = int64_t;
+  using StateType = uint64_t;
   static StateType constexpr kDefaultInit = 3;
   static StateType constexpr default_alpha_ = 61;
   static StateType constexpr max_value_ = ((StateType)1 << 32) - 1;
@@ -217,7 +217,7 @@ class RandomDataGenerator {
   float upper_;
 
   int32_t device_;
-  int32_t seed_;
+  uint64_t seed_;
   SimpleLCG lcg_;
 
   size_t bins_;
@@ -242,7 +242,7 @@ class RandomDataGenerator {
     device_ = d;
     return *this;
   }
-  RandomDataGenerator& Seed(int32_t s) {
+  RandomDataGenerator& Seed(uint64_t s) {
     seed_ = s;
     lcg_.Seed(seed_);
     return *this;

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -106,7 +106,7 @@ bool IsNear(std::vector<xgboost::bst_float>::const_iterator _beg1,
  */
 class SimpleLCG {
  private:
-  using StateType = uint64_t;
+  using StateType = int64_t;
   static StateType constexpr kDefaultInit = 3;
   static StateType constexpr default_alpha_ = 61;
   static StateType constexpr max_value_ = ((StateType)1 << 32) - 1;
@@ -217,7 +217,7 @@ class RandomDataGenerator {
   float upper_;
 
   int32_t device_;
-  uint64_t seed_;
+  int32_t seed_;
   SimpleLCG lcg_;
 
   size_t bins_;
@@ -242,7 +242,7 @@ class RandomDataGenerator {
     device_ = d;
     return *this;
   }
-  RandomDataGenerator& Seed(uint64_t s) {
+  RandomDataGenerator& Seed(int32_t s) {
     seed_ = s;
     lcg_.Seed(seed_);
     return *this;

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -1331,8 +1331,11 @@ def test_evaluation_metric():
     )
     clf.fit(X, y, eval_set=[(X, y)])
     internal = clf.evals_result()
+
     np.testing.assert_allclose(
-        custom["validation_0"]["merror"], internal["validation_0"]["merror"]
+        custom["validation_0"]["merror"],
+        internal["validation_0"]["merror"],
+        atol=1e-6
     )
 
     clf = xgb.XGBRFClassifier(


### PR DESCRIPTION
~Stacked on top of https://github.com/dmlc/xgboost/pull/7362 so marked as draft.~

This PR replaces some variables that store accumulated results from float to double-precision, for instance, the reduction result from elementwise metric and FP/TP in AUC.

The result is still serialized by `std::stringstream`, which is a little bit weird since if we use scientific notation with precision then it might contain trailing zeros.  But the `to_chars` implementation in XGBoost handles only float at the moment.


Close https://github.com/dmlc/xgboost/issues/7340 .
Close https://github.com/dmlc/xgboost/issues/4665 .