### PR TITLE
Pass infomation about objective to tree methods.

### DIFF
--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -11,15 +11,16 @@
 #include <dmlc/any.h>
 #include <xgboost/base.h>
 #include <xgboost/feature_map.h>
-#include <xgboost/predictor.h>
 #include <xgboost/generic_parameters.h>
 #include <xgboost/host_device_vector.h>
 #include <xgboost/model.h>
+#include <xgboost/predictor.h>
+#include <xgboost/task.h>
 
-#include <utility>
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace xgboost {
@@ -307,11 +308,13 @@ struct LearnerModelParam {
   uint32_t num_feature { 0 };
   /* \brief number of classes, if it is multi-class classification  */
   uint32_t num_output_group { 0 };
+  /* \brief Current task, determined by objective. */
+  ObjInfo task{ObjInfo::kRegression};
 
   LearnerModelParam() = default;
   // As the old `LearnerModelParamLegacy` is still used by binary IO, we keep
   // this one as an immutable copy.
-  LearnerModelParam(LearnerModelParamLegacy const& user_param, float base_margin);
+  LearnerModelParam(LearnerModelParamLegacy const& user_param, float base_margin, ObjInfo t);
   /* \brief Whether this parameter is initialized with LearnerModelParamLegacy. */
   bool Initialized() const { return num_feature != 0; }
 };

--- a/include/xgboost/objective.h
+++ b/include/xgboost/objective.h
@@ -13,6 +13,7 @@
 #include <xgboost/model.h>
 #include <xgboost/generic_parameters.h>
 #include <xgboost/host_device_vector.h>
+#include <xgboost/task.h>
 
 #include <vector>
 #include <utility>
@@ -72,6 +73,11 @@ class ObjFunction : public Configurable {
   virtual bst_float ProbToMargin(bst_float base_score) const {
     return base_score;
   }
+  /*!
+   * \brief Return task of this objective.
+   */
+  virtual struct ObjInfo Task() const = 0;
+
   /*!
    * \brief Create an objective function according to name.
    * \param tparam Generic parameters.

--- a/include/xgboost/task.h
+++ b/include/xgboost/task.h
@@ -12,10 +12,9 @@ namespace xgboost {
  *        not used by any algorithm yet, only for future development like categorical
  *        split.
  *
- * The task field is useful for tree split finding, also for some metrics like auc.  While
- * const_hess is useful for algorithms like adaptive tree where one needs to update the
- * leaf value after building the tree.  Lastly, knowing whether hessian is constant can
- * allow some optimizations like skipping the quantile sketching.
+ * The task field is useful for tree split finding, also for some metrics like auc.
+ * Lastly, knowing whether hessian is constant can allow some optimizations like skipping
+ * the quantile sketching.
  *
  * This struct should not be serialized since it can be recovered from objective function,
  * hence it doesn't need to be stable.

--- a/include/xgboost/task.h
+++ b/include/xgboost/task.h
@@ -1,0 +1,37 @@
+/*!
+ * Copyright 2021 by XGBoost Contributors
+ */
+#ifndef XGBOOST_TASK_H_
+#define XGBOOST_TASK_H_
+
+#include <cinttypes>
+
+namespace xgboost {
+/*!
+ * \brief A struct returned by objective, which determines task at hand.  The struct is
+ *        not used by any algorithm yet, only for future development like categorical
+ *        split.
+ *
+ * The task field is useful for tree split finding, also for some metrics like auc.  While
+ * const_hess is useful for algorithms like adaptive tree where one needs to update the
+ * leaf value after building the tree.  Lastly, knowing whether hessian is constant can
+ * allow some optimizations like skipping the quantile sketching.
+ *
+ * This struct should not be serialized since it can be recovered from objective function,
+ * hence it doesn't need to be stable.
+ */
+struct ObjInfo {
+  // What kind of problem are we trying to solve
+  enum : uint8_t {
+    kRegression = 0,
+    kBinary = 1,
+    kClassification = 2,
+    kSurvival = 3,
+    kRanking = 4,
+    kOther = 5,
+  } task;
+  // Does the objective have constant hessian value?
+  bool const_hess{false};
+};
+}  // namespace xgboost
+#endif  // XGBOOST_TASK_H_

--- a/include/xgboost/task.h
+++ b/include/xgboost/task.h
@@ -22,7 +22,7 @@ namespace xgboost {
  */
 struct ObjInfo {
   // What kind of problem are we trying to solve
-  enum : uint8_t {
+  enum Task : uint8_t {
     kRegression = 0,
     kBinary = 1,
     kClassification = 2,
@@ -32,6 +32,9 @@ struct ObjInfo {
   } task;
   // Does the objective have constant hessian value?
   bool const_hess{false};
+
+  explicit ObjInfo(Task t) : task{t} {}
+  ObjInfo(Task t, bool khess) : const_hess{khess} {}
 };
 }  // namespace xgboost
 #endif  // XGBOOST_TASK_H_

--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -91,7 +91,8 @@ class TreeUpdater : public Configurable {
  * \brief Registry entry for tree updater.
  */
 struct TreeUpdaterReg
-    : public dmlc::FunctionRegEntryBase<TreeUpdaterReg, std::function<TreeUpdater*(ObjInfo task)> > {};
+    : public dmlc::FunctionRegEntryBase<TreeUpdaterReg,
+                                        std::function<TreeUpdater*(ObjInfo task)> > {};
 
 /*!
  * \brief Macro to register tree updater.

--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -11,16 +11,17 @@
 #include <dmlc/registry.h>
 #include <xgboost/base.h>
 #include <xgboost/data.h>
-#include <xgboost/tree_model.h>
 #include <xgboost/generic_parameters.h>
 #include <xgboost/host_device_vector.h>
-#include <xgboost/model.h>
 #include <xgboost/linalg.h>
+#include <xgboost/model.h>
+#include <xgboost/task.h>
+#include <xgboost/tree_model.h>
 
 #include <functional>
-#include <vector>
-#include <utility>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace xgboost {
 
@@ -83,16 +84,14 @@ class TreeUpdater : public Configurable {
    * \param name Name of the tree updater.
    * \param tparam A global runtime parameter
    */
-  static TreeUpdater* Create(const std::string& name, GenericParameter const* tparam);
+  static TreeUpdater* Create(const std::string& name, GenericParameter const* tparam, ObjInfo task);
 };
 
 /*!
  * \brief Registry entry for tree updater.
  */
 struct TreeUpdaterReg
-    : public dmlc::FunctionRegEntryBase<TreeUpdaterReg,
-                                        std::function<TreeUpdater* ()> > {
-};
+    : public dmlc::FunctionRegEntryBase<TreeUpdaterReg, std::function<TreeUpdater*(ObjInfo task)> > {};
 
 /*!
  * \brief Macro to register tree updater.

--- a/plugin/example/custom_obj.cc
+++ b/plugin/example/custom_obj.cc
@@ -34,6 +34,11 @@ class MyLogistic : public ObjFunction {
   void Configure(const std::vector<std::pair<std::string, std::string> >& args) override {
     param_.UpdateAllowUnknown(args);
   }
+
+  struct ObjInfo Task() const override {
+    return {ObjInfo::kRegression, false};
+  }
+
   void GetGradient(const HostDeviceVector<bst_float> &preds,
                    const MetaInfo &info,
                    int iter,

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -306,7 +306,8 @@ void GBTree::InitUpdater(Args const& cfg) {
 
   // create new updaters
   for (const std::string& pstr : ups) {
-    std::unique_ptr<TreeUpdater> up(TreeUpdater::Create(pstr.c_str(), generic_param_));
+    std::unique_ptr<TreeUpdater> up(
+        TreeUpdater::Create(pstr.c_str(), generic_param_, model_.learner_model_param->task));
     up->Configure(cfg);
     updaters_.push_back(std::move(up));
   }
@@ -391,7 +392,8 @@ void GBTree::LoadConfig(Json const& in) {
   auto const& j_updaters = get<Object const>(in["updater"]);
   updaters_.clear();
   for (auto const& kv : j_updaters) {
-    std::unique_ptr<TreeUpdater> up(TreeUpdater::Create(kv.first, generic_param_));
+    std::unique_ptr<TreeUpdater> up(
+        TreeUpdater::Create(kv.first, generic_param_, model_.learner_model_param->task));
     up->LoadConfig(kv.second);
     updaters_.push_back(std::move(up));
   }

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -159,13 +159,12 @@ struct LearnerModelParamLegacy : public dmlc::Parameter<LearnerModelParamLegacy>
   }
 };
 
-LearnerModelParam::LearnerModelParam(
-    LearnerModelParamLegacy const &user_param, float base_margin)
-    : base_score{base_margin}, num_feature{user_param.num_feature},
-      num_output_group{user_param.num_class == 0
-                       ? 1
-                       : static_cast<uint32_t>(user_param.num_class)}
-{}
+LearnerModelParam::LearnerModelParam(LearnerModelParamLegacy const& user_param, float base_margin,
+                                     ObjInfo t)
+    : base_score{base_margin},
+      num_feature{user_param.num_feature},
+      num_output_group{user_param.num_class == 0 ? 1 : static_cast<uint32_t>(user_param.num_class)},
+      task{t} {}
 
 struct LearnerTrainParam : public XGBoostParameter<LearnerTrainParam> {
   // data split mode, can be row, col, or none.
@@ -339,8 +338,8 @@ class LearnerConfiguration : public Learner {
     // - model is created from scratch.
     // - model is configured second time due to change of parameter
     if (!learner_model_param_.Initialized() || mparam_.base_score != mparam_backup.base_score) {
-      learner_model_param_ = LearnerModelParam(mparam_,
-                                               obj_->ProbToMargin(mparam_.base_score));
+      learner_model_param_ =
+          LearnerModelParam(mparam_, obj_->ProbToMargin(mparam_.base_score), obj_->Task());
     }
 
     this->ConfigureGBM(old_tparam, args);
@@ -832,7 +831,7 @@ class LearnerIO : public LearnerConfiguration {
     }
 
     learner_model_param_ =
-        LearnerModelParam(mparam_, obj_->ProbToMargin(mparam_.base_score));
+        LearnerModelParam(mparam_, obj_->ProbToMargin(mparam_.base_score), obj_->Task());
     if (attributes_.find("objective") != attributes_.cend()) {
       auto obj_str = attributes_.at("objective");
       auto j_obj = Json::Load({obj_str.c_str(), obj_str.size()});

--- a/src/objective/aft_obj.cu
+++ b/src/objective/aft_obj.cu
@@ -38,6 +38,8 @@ class AFTObj : public ObjFunction {
     param_.UpdateAllowUnknown(args);
   }
 
+  ObjInfo Task() const override { return {ObjInfo::kSurvival, false}; }
+
   template <typename Distribution>
   void GetGradientImpl(const HostDeviceVector<bst_float> &preds,
                        const MetaInfo &info,

--- a/src/objective/hinge.cu
+++ b/src/objective/hinge.cu
@@ -27,6 +27,8 @@ class HingeObj : public ObjFunction {
   void Configure(
       const std::vector<std::pair<std::string, std::string> > &args) override {}
 
+  ObjInfo Task() const override { return {ObjInfo::kRegression, false}; }
+
   void GetGradient(const HostDeviceVector<bst_float> &preds,
                    const MetaInfo &info,
                    int iter,

--- a/src/objective/multiclass_obj.cu
+++ b/src/objective/multiclass_obj.cu
@@ -45,6 +45,9 @@ class SoftmaxMultiClassObj : public ObjFunction {
   void Configure(Args const& args) override {
     param_.UpdateAllowUnknown(args);
   }
+
+  ObjInfo Task() const override { return {ObjInfo::kClassification, false}; }
+
   void GetGradient(const HostDeviceVector<bst_float>& preds,
                    const MetaInfo& info,
                    int iter,

--- a/src/objective/rank_obj.cu
+++ b/src/objective/rank_obj.cu
@@ -754,6 +754,8 @@ class LambdaRankObj : public ObjFunction {
     param_.UpdateAllowUnknown(args);
   }
 
+  ObjInfo Task() const override { return {ObjInfo::kRanking, false}; }
+
   void GetGradient(const HostDeviceVector<bst_float>& preds,
                    const MetaInfo& info,
                    int iter,

--- a/src/objective/regression_loss.h
+++ b/src/objective/regression_loss.h
@@ -7,6 +7,8 @@
 #include <dmlc/omp.h>
 #include <xgboost/logging.h>
 #include <algorithm>
+
+#include "xgboost/task.h"
 #include "../common/math.h"
 
 namespace xgboost {
@@ -36,6 +38,7 @@ struct LinearSquareLoss {
   static const char* DefaultEvalMetric() { return "rmse"; }
 
   static const char* Name() { return "reg:squarederror"; }
+  static ObjInfo Info() { return {ObjInfo::kRegression, true}; }
 };
 
 struct SquaredLogError {
@@ -61,6 +64,8 @@ struct SquaredLogError {
   static const char* DefaultEvalMetric() { return "rmsle"; }
 
   static const char* Name() { return "reg:squaredlogerror"; }
+
+  static ObjInfo Info() { return {ObjInfo::kRegression, false}; }
 };
 
 // logistic loss for probability regression task
@@ -96,6 +101,8 @@ struct LogisticRegression {
   static const char* DefaultEvalMetric() { return "rmse"; }
 
   static const char* Name() { return "reg:logistic"; }
+
+  static ObjInfo Info() { return {ObjInfo::kRegression, false}; }
 };
 
 struct PseudoHuberError {
@@ -127,12 +134,14 @@ struct PseudoHuberError {
   static const char* Name() {
     return "reg:pseudohubererror";
   }
+  static ObjInfo Info() { return {ObjInfo::kRegression, false}; }
 };
 
 // logistic loss for binary classification task
 struct LogisticClassification : public LogisticRegression {
   static const char* DefaultEvalMetric() { return "logloss"; }
   static const char* Name() { return "binary:logistic"; }
+  static ObjInfo Info() { return {ObjInfo::kBinary, false}; }
 };
 
 // logistic loss, but predict un-transformed margin
@@ -168,6 +177,8 @@ struct LogisticRaw : public LogisticRegression {
   static const char* DefaultEvalMetric() { return "logloss"; }
 
   static const char* Name() { return "binary:logitraw"; }
+
+  static ObjInfo Info() { return {ObjInfo::kRegression, false}; }
 };
 
 }  // namespace obj

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -52,6 +52,10 @@ class RegLossObj : public ObjFunction {
     param_.UpdateAllowUnknown(args);
   }
 
+  struct ObjInfo Task() const override {
+    return Loss::Info();
+  }
+
   void GetGradient(const HostDeviceVector<bst_float>& preds,
                    const MetaInfo &info, int,
                    HostDeviceVector<GradientPair>* out_gpair) override {
@@ -207,6 +211,10 @@ class PoissonRegression : public ObjFunction {
     param_.UpdateAllowUnknown(args);
   }
 
+  struct ObjInfo Task() const override {
+    return {ObjInfo::kRegression, false};
+  }
+
   void GetGradient(const HostDeviceVector<bst_float>& preds,
                    const MetaInfo &info, int,
                    HostDeviceVector<GradientPair> *out_gpair) override {
@@ -297,6 +305,10 @@ class CoxRegression : public ObjFunction {
  public:
   void Configure(
       const std::vector<std::pair<std::string, std::string> >&) override {}
+
+  struct ObjInfo Task() const override {
+    return {ObjInfo::kRegression, false};
+  }
 
   void GetGradient(const HostDeviceVector<bst_float>& preds,
                    const MetaInfo &info, int,
@@ -395,6 +407,10 @@ class GammaRegression : public ObjFunction {
   void Configure(
       const std::vector<std::pair<std::string, std::string> >&) override {}
 
+  struct ObjInfo Task() const override {
+    return {ObjInfo::kRegression, false};
+  }
+
   void GetGradient(const HostDeviceVector<bst_float> &preds,
                    const MetaInfo &info, int,
                    HostDeviceVector<GradientPair> *out_gpair) override {
@@ -489,6 +505,10 @@ class TweedieRegression : public ObjFunction {
     std::ostringstream os;
     os << "tweedie-nloglik@" << param_.tweedie_variance_power;
     metric_ = os.str();
+  }
+
+  struct ObjInfo Task() const override {
+    return {ObjInfo::kRegression, false};
   }
 
   void GetGradient(const HostDeviceVector<bst_float>& preds,

--- a/src/tree/tree_updater.cc
+++ b/src/tree/tree_updater.cc
@@ -14,12 +14,13 @@ DMLC_REGISTRY_ENABLE(::xgboost::TreeUpdaterReg);
 
 namespace xgboost {
 
-TreeUpdater* TreeUpdater::Create(const std::string& name, GenericParameter const* tparam) {
-  auto *e = ::dmlc::Registry< ::xgboost::TreeUpdaterReg>::Get()->Find(name);
+TreeUpdater* TreeUpdater::Create(const std::string& name, GenericParameter const* tparam,
+                                 ObjInfo task) {
+  auto* e = ::dmlc::Registry< ::xgboost::TreeUpdaterReg>::Get()->Find(name);
   if (e == nullptr) {
     LOG(FATAL) << "Unknown tree updater " << name;
   }
-  auto p_updater = (e->body)();
+  auto p_updater = (e->body)(task);
   p_updater->tparam_ = tparam;
   return p_updater;
 }

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -628,7 +628,7 @@ class ColMaker: public TreeUpdater {
 
 XGBOOST_REGISTER_TREE_UPDATER(ColMaker, "grow_colmaker")
 .describe("Grow tree with parallelization over columns.")
-.set_body([]() {
+.set_body([](ObjInfo) {
     return new ColMaker();
   });
 }  // namespace tree

--- a/src/tree/updater_histmaker.cc
+++ b/src/tree/updater_histmaker.cc
@@ -750,14 +750,14 @@ class GlobalProposalHistMaker: public CQHistMaker {
 
 XGBOOST_REGISTER_TREE_UPDATER(LocalHistMaker, "grow_local_histmaker")
 .describe("Tree constructor that uses approximate histogram construction.")
-.set_body([]() {
+.set_body([](ObjInfo) {
     return new CQHistMaker();
   });
 
 // The updater for approx tree method.
 XGBOOST_REGISTER_TREE_UPDATER(HistMaker, "grow_histmaker")
 .describe("Tree constructor that uses approximate global of histogram construction.")
-.set_body([]() {
+.set_body([](ObjInfo) {
     return new GlobalProposalHistMaker();
   });
 }  // namespace tree

--- a/src/tree/updater_prune.cc
+++ b/src/tree/updater_prune.cc
@@ -23,8 +23,8 @@ DMLC_REGISTRY_FILE_TAG(updater_prune);
 /*! \brief pruner that prunes a tree after growing finishes */
 class TreePruner: public TreeUpdater {
  public:
-  TreePruner() {
-    syncher_.reset(TreeUpdater::Create("sync", tparam_));
+  explicit TreePruner(ObjInfo task) {
+    syncher_.reset(TreeUpdater::Create("sync", tparam_, task));
     pruner_monitor_.Init("TreePruner");
   }
   char const* Name() const override {
@@ -113,8 +113,8 @@ class TreePruner: public TreeUpdater {
 
 XGBOOST_REGISTER_TREE_UPDATER(TreePruner, "prune")
 .describe("Pruner that prune the tree according to statistics.")
-.set_body([]() {
-    return new TreePruner();
+.set_body([](ObjInfo task) {
+    return new TreePruner(task);
   });
 }  // namespace tree
 }  // namespace xgboost

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -95,7 +95,7 @@ using xgboost::common::Column;
 /*! \brief construct a tree using quantized feature values */
 class QuantileHistMaker: public TreeUpdater {
  public:
-  explicit QuantileHistMaker(ObjInfo task) {
+  explicit QuantileHistMaker(ObjInfo task) : task_{task} {
     updater_monitor_.Init("QuantileHistMaker");
   }
   void Configure(const Args& args) override;

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -95,7 +95,7 @@ using xgboost::common::Column;
 /*! \brief construct a tree using quantized feature values */
 class QuantileHistMaker: public TreeUpdater {
  public:
-  QuantileHistMaker() {
+  explicit QuantileHistMaker(ObjInfo task) {
     updater_monitor_.Init("QuantileHistMaker");
   }
   void Configure(const Args& args) override;
@@ -154,12 +154,15 @@ class QuantileHistMaker: public TreeUpdater {
     using GHistRowT = GHistRow<GradientSumT>;
     using GradientPairT = xgboost::detail::GradientPairInternal<GradientSumT>;
     // constructor
-    explicit Builder(const size_t n_trees, const TrainParam &param,
-                     std::unique_ptr<TreeUpdater> pruner, DMatrix const *fmat)
-        : n_trees_(n_trees), param_(param), pruner_(std::move(pruner)),
-          p_last_tree_(nullptr), p_last_fmat_(fmat),
-          histogram_builder_{
-              new HistogramBuilder<GradientSumT, CPUExpandEntry>} {
+    explicit Builder(const size_t n_trees, const TrainParam& param,
+                     std::unique_ptr<TreeUpdater> pruner, DMatrix const* fmat, ObjInfo task)
+        : n_trees_(n_trees),
+          param_(param),
+          pruner_(std::move(pruner)),
+          p_last_tree_(nullptr),
+          p_last_fmat_(fmat),
+          histogram_builder_{new HistogramBuilder<GradientSumT, CPUExpandEntry>},
+          task_{task} {
       builder_monitor_.Init("Quantile::Builder");
     }
     ~Builder();
@@ -261,6 +264,7 @@ class QuantileHistMaker: public TreeUpdater {
     DataLayout data_layout_;
     std::unique_ptr<HistogramBuilder<GradientSumT, CPUExpandEntry>>
         histogram_builder_;
+    ObjInfo task_;
 
     common::Monitor builder_monitor_;
   };
@@ -281,6 +285,7 @@ class QuantileHistMaker: public TreeUpdater {
   std::unique_ptr<Builder<double>> double_builder_;
 
   std::unique_ptr<TreeUpdater> pruner_;
+  ObjInfo task_;
 };
 }  // namespace tree
 }  // namespace xgboost

--- a/src/tree/updater_refresh.cc
+++ b/src/tree/updater_refresh.cc
@@ -161,7 +161,7 @@ class TreeRefresher: public TreeUpdater {
 
 XGBOOST_REGISTER_TREE_UPDATER(TreeRefresher, "refresh")
 .describe("Refresher that refreshes the weight and statistics according to data.")
-.set_body([]() {
+.set_body([](ObjInfo) {
     return new TreeRefresher();
   });
 }  // namespace tree

--- a/src/tree/updater_sync.cc
+++ b/src/tree/updater_sync.cc
@@ -53,7 +53,7 @@ class TreeSyncher: public TreeUpdater {
 
 XGBOOST_REGISTER_TREE_UPDATER(TreeSyncher, "sync")
 .describe("Syncher that synchronize the tree in all distributed nodes.")
-.set_body([]() {
+.set_body([](ObjInfo) {
     return new TreeSyncher();
   });
 }  // namespace tree

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -275,7 +275,8 @@ void TestHistogramIndexImpl() {
   int constexpr kNRows = 1000, kNCols = 10;
 
   // Build 2 matrices and build a histogram maker with that
-  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker, hist_maker_ext;
+  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{{ObjInfo::kRegression, true}},
+      hist_maker_ext{{ObjInfo::kRegression, true}};
   std::unique_ptr<DMatrix> hist_maker_dmat(
     CreateSparsePageDMatrixWithRC(kNRows, kNCols, 0, true));
 
@@ -333,7 +334,7 @@ int32_t TestMinSplitLoss(DMatrix* dmat, float gamma, HostDeviceVector<GradientPa
     {"gamma", std::to_string(gamma)}
   };
 
-  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker;
+  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{{ObjInfo::kRegression, true}};
   GenericParameter generic_param(CreateEmptyGenericParam(0));
   hist_maker.Configure(args, &generic_param);
 
@@ -394,7 +395,7 @@ void UpdateTree(HostDeviceVector<GradientPair>* gpair, DMatrix* dmat,
       {"sampling_method", sampling_method},
   };
 
-  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker;
+  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{{ObjInfo::kRegression, true}};
   GenericParameter generic_param(CreateEmptyGenericParam(0));
   hist_maker.Configure(args, &generic_param);
 
@@ -539,7 +540,8 @@ TEST(GpuHist, ExternalMemoryWithSampling) {
 
 TEST(GpuHist, ConfigIO) {
   GenericParameter generic_param(CreateEmptyGenericParam(0));
-  std::unique_ptr<TreeUpdater> updater {TreeUpdater::Create("grow_gpu_hist", &generic_param) };
+  std::unique_ptr<TreeUpdater> updater{
+      TreeUpdater::Create("grow_gpu_hist", &generic_param, {ObjInfo::kRegression, true})};
   updater->Configure(Args{});
 
   Json j_updater { Object() };

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -275,8 +275,8 @@ void TestHistogramIndexImpl() {
   int constexpr kNRows = 1000, kNCols = 10;
 
   // Build 2 matrices and build a histogram maker with that
-  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{{ObjInfo::kRegression, true}},
-      hist_maker_ext{{ObjInfo::kRegression, true}};
+  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{ObjInfo{ObjInfo::kRegression}},
+      hist_maker_ext{ObjInfo{ObjInfo::kRegression}};
   std::unique_ptr<DMatrix> hist_maker_dmat(
     CreateSparsePageDMatrixWithRC(kNRows, kNCols, 0, true));
 
@@ -334,7 +334,7 @@ int32_t TestMinSplitLoss(DMatrix* dmat, float gamma, HostDeviceVector<GradientPa
     {"gamma", std::to_string(gamma)}
   };
 
-  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{{ObjInfo::kRegression, true}};
+  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{ObjInfo{ObjInfo::kRegression}};
   GenericParameter generic_param(CreateEmptyGenericParam(0));
   hist_maker.Configure(args, &generic_param);
 
@@ -395,7 +395,7 @@ void UpdateTree(HostDeviceVector<GradientPair>* gpair, DMatrix* dmat,
       {"sampling_method", sampling_method},
   };
 
-  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{{ObjInfo::kRegression, true}};
+  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{ObjInfo{ObjInfo::kRegression}};
   GenericParameter generic_param(CreateEmptyGenericParam(0));
   hist_maker.Configure(args, &generic_param);
 
@@ -541,7 +541,7 @@ TEST(GpuHist, ExternalMemoryWithSampling) {
 TEST(GpuHist, ConfigIO) {
   GenericParameter generic_param(CreateEmptyGenericParam(0));
   std::unique_ptr<TreeUpdater> updater{
-      TreeUpdater::Create("grow_gpu_hist", &generic_param, {ObjInfo::kRegression, true})};
+      TreeUpdater::Create("grow_gpu_hist", &generic_param, ObjInfo{ObjInfo::kRegression})};
   updater->Configure(Args{});
 
   Json j_updater { Object() };

--- a/tests/cpp/tree/test_histmaker.cc
+++ b/tests/cpp/tree/test_histmaker.cc
@@ -35,7 +35,7 @@ TEST(GrowHistMaker, InteractionConstraint) {
     tree.param.num_feature = kCols;
 
     std::unique_ptr<TreeUpdater> updater{
-        TreeUpdater::Create("grow_histmaker", &param, {ObjInfo::kRegression, true})};
+        TreeUpdater::Create("grow_histmaker", &param, ObjInfo{ObjInfo::kRegression})};
     updater->Configure(Args{
         {"interaction_constraints", "[[0, 1]]"},
         {"num_feature", std::to_string(kCols)}});
@@ -53,7 +53,7 @@ TEST(GrowHistMaker, InteractionConstraint) {
     tree.param.num_feature = kCols;
 
     std::unique_ptr<TreeUpdater> updater{
-        TreeUpdater::Create("grow_histmaker", &param, {ObjInfo::kRegression, true})};
+        TreeUpdater::Create("grow_histmaker", &param, ObjInfo{ObjInfo::kRegression})};
     updater->Configure(Args{{"num_feature", std::to_string(kCols)}});
     updater->Update(&gradients, p_dmat.get(), {&tree});
 

--- a/tests/cpp/tree/test_histmaker.cc
+++ b/tests/cpp/tree/test_histmaker.cc
@@ -34,7 +34,8 @@ TEST(GrowHistMaker, InteractionConstraint) {
     RegTree tree;
     tree.param.num_feature = kCols;
 
-    std::unique_ptr<TreeUpdater> updater { TreeUpdater::Create("grow_histmaker", &param) };
+    std::unique_ptr<TreeUpdater> updater{
+        TreeUpdater::Create("grow_histmaker", &param, {ObjInfo::kRegression, true})};
     updater->Configure(Args{
         {"interaction_constraints", "[[0, 1]]"},
         {"num_feature", std::to_string(kCols)}});
@@ -51,7 +52,8 @@ TEST(GrowHistMaker, InteractionConstraint) {
     RegTree tree;
     tree.param.num_feature = kCols;
 
-    std::unique_ptr<TreeUpdater> updater { TreeUpdater::Create("grow_histmaker", &param) };
+    std::unique_ptr<TreeUpdater> updater{
+        TreeUpdater::Create("grow_histmaker", &param, {ObjInfo::kRegression, true})};
     updater->Configure(Args{{"num_feature", std::to_string(kCols)}});
     updater->Update(&gradients, p_dmat.get(), {&tree});
 

--- a/tests/cpp/tree/test_prune.cc
+++ b/tests/cpp/tree/test_prune.cc
@@ -38,7 +38,8 @@ TEST(Updater, Prune) {
   tree.param.UpdateAllowUnknown(cfg);
   std::vector<RegTree*> trees {&tree};
   // prepare pruner
-  std::unique_ptr<TreeUpdater> pruner(TreeUpdater::Create("prune", &lparam));
+  std::unique_ptr<TreeUpdater> pruner(
+      TreeUpdater::Create("prune", &lparam, {ObjInfo::kRegression, true}));
   pruner->Configure(cfg);
 
   // loss_chg < min_split_loss;

--- a/tests/cpp/tree/test_prune.cc
+++ b/tests/cpp/tree/test_prune.cc
@@ -39,7 +39,7 @@ TEST(Updater, Prune) {
   std::vector<RegTree*> trees {&tree};
   // prepare pruner
   std::unique_ptr<TreeUpdater> pruner(
-      TreeUpdater::Create("prune", &lparam, {ObjInfo::kRegression, true}));
+      TreeUpdater::Create("prune", &lparam, ObjInfo{ObjInfo::kRegression}));
   pruner->Configure(cfg);
 
   // loss_chg < min_split_loss;

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -28,7 +28,7 @@ class QuantileHistMock : public QuantileHistMaker {
 
     BuilderMock(const TrainParam &param, std::unique_ptr<TreeUpdater> pruner,
                 DMatrix const *fmat)
-        : RealImpl(1, param, std::move(pruner), fmat) {}
+        : RealImpl(1, param, std::move(pruner), fmat, {ObjInfo::kRegression, true}) {}
 
    public:
     void TestInitData(const GHistIndexMatrix& gmat,
@@ -230,7 +230,7 @@ class QuantileHistMock : public QuantileHistMaker {
   explicit QuantileHistMock(
       const std::vector<std::pair<std::string, std::string> >& args,
       const bool single_precision_histogram = false, bool batch = true) :
-      cfg_{args} {
+      QuantileHistMaker{{ObjInfo::kRegression, true}}, cfg_{args} {
     QuantileHistMaker::Configure(args);
     dmat_ = RandomDataGenerator(kNRows, kNCols, 0.8).Seed(3).GenerateDMatrix();
     if (single_precision_histogram) {

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -28,7 +28,7 @@ class QuantileHistMock : public QuantileHistMaker {
 
     BuilderMock(const TrainParam &param, std::unique_ptr<TreeUpdater> pruner,
                 DMatrix const *fmat)
-        : RealImpl(1, param, std::move(pruner), fmat, {ObjInfo::kRegression, true}) {}
+        : RealImpl(1, param, std::move(pruner), fmat, ObjInfo{ObjInfo::kRegression}) {}
 
    public:
     void TestInitData(const GHistIndexMatrix& gmat,
@@ -230,7 +230,7 @@ class QuantileHistMock : public QuantileHistMaker {
   explicit QuantileHistMock(
       const std::vector<std::pair<std::string, std::string> >& args,
       const bool single_precision_histogram = false, bool batch = true) :
-      QuantileHistMaker{{ObjInfo::kRegression, true}}, cfg_{args} {
+      QuantileHistMaker{ObjInfo{ObjInfo::kRegression}}, cfg_{args} {
     QuantileHistMaker::Configure(args);
     dmat_ = RandomDataGenerator(kNRows, kNCols, 0.8).Seed(3).GenerateDMatrix();
     if (single_precision_histogram) {

--- a/tests/cpp/tree/test_refresh.cc
+++ b/tests/cpp/tree/test_refresh.cc
@@ -33,7 +33,7 @@ TEST(Updater, Refresh) {
   tree.param.UpdateAllowUnknown(cfg);
   std::vector<RegTree*> trees {&tree};
   std::unique_ptr<TreeUpdater> refresher(
-      TreeUpdater::Create("refresh", &lparam, {ObjInfo::kRegression, true}));
+      TreeUpdater::Create("refresh", &lparam, ObjInfo{ObjInfo::kRegression}));
 
   tree.ExpandNode(0, 2, 0.2f, false, 0.0, 0.2f, 0.8f, 0.0f, 0.0f,
                   /*left_sum=*/0.0f, /*right_sum=*/0.0f);

--- a/tests/cpp/tree/test_refresh.cc
+++ b/tests/cpp/tree/test_refresh.cc
@@ -32,7 +32,8 @@ TEST(Updater, Refresh) {
   auto lparam = CreateEmptyGenericParam(GPUIDX);
   tree.param.UpdateAllowUnknown(cfg);
   std::vector<RegTree*> trees {&tree};
-  std::unique_ptr<TreeUpdater> refresher(TreeUpdater::Create("refresh", &lparam));
+  std::unique_ptr<TreeUpdater> refresher(
+      TreeUpdater::Create("refresh", &lparam, {ObjInfo::kRegression, true}));
 
   tree.ExpandNode(0, 2, 0.2f, false, 0.0, 0.2f, 0.8f, 0.0f, 0.0f,
                   /*left_sum=*/0.0f, /*right_sum=*/0.0f);

--- a/tests/cpp/tree/test_tree_stat.cc
+++ b/tests/cpp/tree/test_tree_stat.cc
@@ -23,7 +23,7 @@ class UpdaterTreeStatTest : public ::testing::Test {
   void RunTest(std::string updater) {
     auto tparam = CreateEmptyGenericParam(0);
     auto up = std::unique_ptr<TreeUpdater>{
-        TreeUpdater::Create(updater, &tparam, {ObjInfo::kRegression, true})};
+        TreeUpdater::Create(updater, &tparam, ObjInfo{ObjInfo::kRegression})};
     up->Configure(Args{});
     RegTree tree;
     tree.param.num_feature = kCols;

--- a/tests/cpp/tree/test_tree_stat.cc
+++ b/tests/cpp/tree/test_tree_stat.cc
@@ -23,7 +23,7 @@ class UpdaterTreeStatTest : public ::testing::Test {
   void RunTest(std::string updater) {
     auto tparam = CreateEmptyGenericParam(0);
     auto up = std::unique_ptr<TreeUpdater>{
-        TreeUpdater::Create(updater, &tparam)};
+        TreeUpdater::Create(updater, &tparam, {ObjInfo::kRegression, true})};
     up->Configure(Args{});
     RegTree tree;
     tree.param.num_feature = kCols;


### PR DESCRIPTION
This PR adds a new struct for obtaining some information about the objective. The struct is not used yet but is required for the future development of categorical split.  In https://github.com/dmlc/xgboost/pull/7214 , the optimal partitioning is only available for binary classification and regression.  Copying inlined comment here:
```
 * The task field is useful for tree split finding, also for some metrics like auc.
 * While const_hess is useful for algorithms like adaptive tree where one needs to update
 * the leaf value after building the tree.  Lastly, knowing whether hessian is constant
 * can allow some optimizations like skipping the quantile sketching.
```

* Define `ObjInfo`.
* Pass it to tree methods.