### PR TITLE
Pass infomration about objective to metrics.

### DIFF
--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -11,15 +11,16 @@
 #include <dmlc/any.h>
 #include <xgboost/base.h>
 #include <xgboost/feature_map.h>
-#include <xgboost/predictor.h>
 #include <xgboost/generic_parameters.h>
 #include <xgboost/host_device_vector.h>
 #include <xgboost/model.h>
+#include <xgboost/predictor.h>
+#include <xgboost/task.h>
 
-#include <utility>
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace xgboost {
@@ -307,11 +308,13 @@ struct LearnerModelParam {
   uint32_t num_feature { 0 };
   /* \brief number of classes, if it is multi-class classification  */
   uint32_t num_output_group { 0 };
+  /* \brief Current task, determined by objective. */
+  ObjInfo task{ObjInfo::kRegression};
 
   LearnerModelParam() = default;
   // As the old `LearnerModelParamLegacy` is still used by binary IO, we keep
   // this one as an immutable copy.
-  LearnerModelParam(LearnerModelParamLegacy const& user_param, float base_margin);
+  LearnerModelParam(LearnerModelParamLegacy const& user_param, float base_margin, ObjInfo t);
   /* \brief Whether this parameter is initialized with LearnerModelParamLegacy. */
   bool Initialized() const { return num_feature != 0; }
 };

--- a/include/xgboost/metric.h
+++ b/include/xgboost/metric.h
@@ -13,6 +13,7 @@
 #include <xgboost/data.h>
 #include <xgboost/base.h>
 #include <xgboost/host_device_vector.h>
+#include <xgboost/task.h>
 
 #include <vector>
 #include <string>
@@ -73,7 +74,7 @@ class Metric : public Configurable {
    * \param tparam A global generic parameter
    * \return the created metric.
    */
-  static Metric* Create(const std::string& name, GenericParameter const* tparam);
+  static Metric* Create(const std::string& name, GenericParameter const* tparam, ObjInfo task);
 };
 
 /*!
@@ -83,7 +84,7 @@ class Metric : public Configurable {
  */
 struct MetricReg
     : public dmlc::FunctionRegEntryBase<MetricReg,
-                                        std::function<Metric* (const char*)> > {
+                                        std::function<Metric* (const char*, ObjInfo task)> > {
 };
 
 /*!

--- a/include/xgboost/objective.h
+++ b/include/xgboost/objective.h
@@ -13,6 +13,7 @@
 #include <xgboost/model.h>
 #include <xgboost/generic_parameters.h>
 #include <xgboost/host_device_vector.h>
+#include <xgboost/task.h>
 
 #include <vector>
 #include <utility>
@@ -72,6 +73,11 @@ class ObjFunction : public Configurable {
   virtual bst_float ProbToMargin(bst_float base_score) const {
     return base_score;
   }
+  /*!
+   * \brief Return task of this objective.
+   */
+  virtual struct ObjInfo Task() const = 0;
+
   /*!
    * \brief Create an objective function according to name.
    * \param tparam Generic parameters.

--- a/include/xgboost/task.h
+++ b/include/xgboost/task.h
@@ -5,6 +5,7 @@
 #define XGBOOST_TASK_H_
 
 #include <cinttypes>
+#include <exception>
 
 namespace xgboost {
 /*!
@@ -32,6 +33,25 @@ struct ObjInfo {
   } task;
   // Does the objective have constant hessian value?
   bool const_hess{false};
+
+  char const* TaskStr() const {
+    switch (task) {
+      case kRegression:
+        return "regression";
+      case kBinary:
+        return "binary classification";
+      case kClassification:
+        return "multi-class classification";
+      case kSurvival:
+        return "survival";
+      case kRanking:
+        return "learning to rank";
+      case kOther:
+        return "unknown";
+      default:
+        std::terminate();
+    }
+  }
 };
 }  // namespace xgboost
 #endif  // XGBOOST_TASK_H_

--- a/include/xgboost/task.h
+++ b/include/xgboost/task.h
@@ -1,0 +1,37 @@
+/*!
+ * Copyright 2021 by XGBoost Contributors
+ */
+#ifndef XGBOOST_TASK_H_
+#define XGBOOST_TASK_H_
+
+#include <cinttypes>
+
+namespace xgboost {
+/*!
+ * \brief A struct returned by objective, which determines task at hand.  The struct is
+ *        not used by any algorithm yet, only for future development like categorical
+ *        split.
+ *
+ * The task field is useful for tree split finding, also for some metrics like auc.  While
+ * const_hess is useful for algorithms like adaptive tree where one needs to update the
+ * leaf value after building the tree.  Lastly, knowing whether hessian is constant can
+ * allow some optimizations like skipping the quantile sketching.
+ *
+ * This struct should not be serialized since it can be recovered from objective function,
+ * hence it doesn't need to be stable.
+ */
+struct ObjInfo {
+  // What kind of problem are we trying to solve
+  enum : uint8_t {
+    kRegression = 0,
+    kBinary = 1,
+    kClassification = 2,
+    kSurvival = 3,
+    kRanking = 4,
+    kOther = 5,
+  } task;
+  // Does the objective have constant hessian value?
+  bool const_hess{false};
+};
+}  // namespace xgboost
+#endif  // XGBOOST_TASK_H_

--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -91,7 +91,8 @@ class TreeUpdater : public Configurable {
  * \brief Registry entry for tree updater.
  */
 struct TreeUpdaterReg
-    : public dmlc::FunctionRegEntryBase<TreeUpdaterReg, std::function<TreeUpdater*(ObjInfo task)> > {};
+    : public dmlc::FunctionRegEntryBase<TreeUpdaterReg,
+                                        std::function<TreeUpdater*(ObjInfo task)> > {};
 
 /*!
  * \brief Macro to register tree updater.

--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -11,16 +11,17 @@
 #include <dmlc/registry.h>
 #include <xgboost/base.h>
 #include <xgboost/data.h>
-#include <xgboost/tree_model.h>
 #include <xgboost/generic_parameters.h>
 #include <xgboost/host_device_vector.h>
-#include <xgboost/model.h>
 #include <xgboost/linalg.h>
+#include <xgboost/model.h>
+#include <xgboost/task.h>
+#include <xgboost/tree_model.h>
 
 #include <functional>
-#include <vector>
-#include <utility>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace xgboost {
 
@@ -83,16 +84,14 @@ class TreeUpdater : public Configurable {
    * \param name Name of the tree updater.
    * \param tparam A global runtime parameter
    */
-  static TreeUpdater* Create(const std::string& name, GenericParameter const* tparam);
+  static TreeUpdater* Create(const std::string& name, GenericParameter const* tparam, ObjInfo task);
 };
 
 /*!
  * \brief Registry entry for tree updater.
  */
 struct TreeUpdaterReg
-    : public dmlc::FunctionRegEntryBase<TreeUpdaterReg,
-                                        std::function<TreeUpdater* ()> > {
-};
+    : public dmlc::FunctionRegEntryBase<TreeUpdaterReg, std::function<TreeUpdater*(ObjInfo task)> > {};
 
 /*!
  * \brief Macro to register tree updater.

--- a/plugin/example/custom_obj.cc
+++ b/plugin/example/custom_obj.cc
@@ -34,6 +34,11 @@ class MyLogistic : public ObjFunction {
   void Configure(const std::vector<std::pair<std::string, std::string> >& args) override {
     param_.UpdateAllowUnknown(args);
   }
+
+  struct ObjInfo Task() const override {
+    return {ObjInfo::kRegression, false};
+  }
+
   void GetGradient(const HostDeviceVector<bst_float> &preds,
                    const MetaInfo &info,
                    int iter,

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -306,7 +306,8 @@ void GBTree::InitUpdater(Args const& cfg) {
 
   // create new updaters
   for (const std::string& pstr : ups) {
-    std::unique_ptr<TreeUpdater> up(TreeUpdater::Create(pstr.c_str(), generic_param_));
+    std::unique_ptr<TreeUpdater> up(
+        TreeUpdater::Create(pstr.c_str(), generic_param_, model_.learner_model_param->task));
     up->Configure(cfg);
     updaters_.push_back(std::move(up));
   }
@@ -391,7 +392,8 @@ void GBTree::LoadConfig(Json const& in) {
   auto const& j_updaters = get<Object const>(in["updater"]);
   updaters_.clear();
   for (auto const& kv : j_updaters) {
-    std::unique_ptr<TreeUpdater> up(TreeUpdater::Create(kv.first, generic_param_));
+    std::unique_ptr<TreeUpdater> up(
+        TreeUpdater::Create(kv.first, generic_param_, model_.learner_model_param->task));
     up->LoadConfig(kv.second);
     updaters_.push_back(std::move(up));
   }

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -159,13 +159,12 @@ struct LearnerModelParamLegacy : public dmlc::Parameter<LearnerModelParamLegacy>
   }
 };
 
-LearnerModelParam::LearnerModelParam(
-    LearnerModelParamLegacy const &user_param, float base_margin)
-    : base_score{base_margin}, num_feature{user_param.num_feature},
-      num_output_group{user_param.num_class == 0
-                       ? 1
-                       : static_cast<uint32_t>(user_param.num_class)}
-{}
+LearnerModelParam::LearnerModelParam(LearnerModelParamLegacy const& user_param, float base_margin,
+                                     ObjInfo t)
+    : base_score{base_margin},
+      num_feature{user_param.num_feature},
+      num_output_group{user_param.num_class == 0 ? 1 : static_cast<uint32_t>(user_param.num_class)},
+      task{t} {}
 
 struct LearnerTrainParam : public XGBoostParameter<LearnerTrainParam> {
   // data split mode, can be row, col, or none.
@@ -339,8 +338,8 @@ class LearnerConfiguration : public Learner {
     // - model is created from scratch.
     // - model is configured second time due to change of parameter
     if (!learner_model_param_.Initialized() || mparam_.base_score != mparam_backup.base_score) {
-      learner_model_param_ = LearnerModelParam(mparam_,
-                                               obj_->ProbToMargin(mparam_.base_score));
+      learner_model_param_ =
+          LearnerModelParam(mparam_, obj_->ProbToMargin(mparam_.base_score), obj_->Task());
     }
 
     this->ConfigureGBM(old_tparam, args);
@@ -832,7 +831,7 @@ class LearnerIO : public LearnerConfiguration {
     }
 
     learner_model_param_ =
-        LearnerModelParam(mparam_, obj_->ProbToMargin(mparam_.base_score));
+        LearnerModelParam(mparam_, obj_->ProbToMargin(mparam_.base_score), obj_->Task());
     if (attributes_.find("objective") != attributes_.cend()) {
       auto obj_str = attributes_.at("objective");
       auto j_obj = Json::Load({obj_str.c_str(), obj_str.size()});

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -389,7 +389,7 @@ class LearnerConfiguration : public Learner {
     for (size_t i = 0; i < n_metrics; ++i) {
       metric_names_[i]= get<String>(j_metrics[i]);
       metrics_[i] = std::unique_ptr<Metric>(
-          Metric::Create(metric_names_[i], &generic_parameters_));
+          Metric::Create(metric_names_[i], &generic_parameters_, obj_->Task()));
     }
 
     FromJson(learner_parameters.at("generic_param"), &generic_parameters_);
@@ -644,7 +644,8 @@ class LearnerConfiguration : public Learner {
                         return m->Name() != name;
                       };
       if (std::all_of(metrics_.begin(), metrics_.end(), DupCheck)) {
-        metrics_.emplace_back(std::unique_ptr<Metric>(Metric::Create(name, &generic_parameters_)));
+        metrics_.emplace_back(
+            std::unique_ptr<Metric>(Metric::Create(name, &generic_parameters_, obj_->Task())));
         mparam_.contain_eval_metrics = 1;
       }
     }
@@ -1121,7 +1122,8 @@ class LearnerImpl : public LearnerIO {
       if (tparam_.objective == "binary:logitraw") {
         warn_default_eval_metric(tparam_.objective, "auc", "logloss", "1.4.0");
       }
-      metrics_.emplace_back(Metric::Create(obj_->DefaultEvalMetric(), &generic_parameters_));
+      metrics_.emplace_back(
+          Metric::Create(obj_->DefaultEvalMetric(), &generic_parameters_, obj_->Task()));
       metrics_.back()->Configure({cfg_.begin(), cfg_.end()});
     }
 

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -386,48 +386,48 @@ struct EvalEWiseBase : public Metric {
 };
 
 XGBOOST_REGISTER_METRIC(RMSE, "rmse")
-.describe("Rooted mean square error.")
-.set_body([](const char* param) { return new EvalEWiseBase<EvalRowRMSE>(); });
+    .describe("Rooted mean square error.")
+    .set_body([](const char* param, ObjInfo) { return new EvalEWiseBase<EvalRowRMSE>(); });
 
 XGBOOST_REGISTER_METRIC(RMSLE, "rmsle")
 .describe("Rooted mean square log error.")
-.set_body([](const char* param) { return new EvalEWiseBase<EvalRowRMSLE>(); });
+.set_body([](const char* param, ObjInfo) { return new EvalEWiseBase<EvalRowRMSLE>(); });
 
 XGBOOST_REGISTER_METRIC(MAE, "mae")
 .describe("Mean absolute error.")
-.set_body([](const char* param) { return new EvalEWiseBase<EvalRowMAE>(); });
+.set_body([](const char* param, ObjInfo) { return new EvalEWiseBase<EvalRowMAE>(); });
 
 XGBOOST_REGISTER_METRIC(MAPE, "mape")
     .describe("Mean absolute percentage error.")
-    .set_body([](const char* param) { return new EvalEWiseBase<EvalRowMAPE>(); });
+    .set_body([](const char* param, ObjInfo) { return new EvalEWiseBase<EvalRowMAPE>(); });
 
 XGBOOST_REGISTER_METRIC(MPHE, "mphe")
 .describe("Mean Pseudo Huber error.")
-.set_body([](const char* param) { return new EvalEWiseBase<EvalRowMPHE>(); });
+.set_body([](const char* param, ObjInfo) { return new EvalEWiseBase<EvalRowMPHE>(); });
 
 XGBOOST_REGISTER_METRIC(LogLoss, "logloss")
 .describe("Negative loglikelihood for logistic regression.")
-.set_body([](const char* param) { return new EvalEWiseBase<EvalRowLogLoss>(); });
+.set_body([](const char* param, ObjInfo) { return new EvalEWiseBase<EvalRowLogLoss>(); });
 
 XGBOOST_REGISTER_METRIC(PossionNegLoglik, "poisson-nloglik")
 .describe("Negative loglikelihood for poisson regression.")
-.set_body([](const char* param) { return new EvalEWiseBase<EvalPoissonNegLogLik>(); });
+.set_body([](const char* param, ObjInfo) { return new EvalEWiseBase<EvalPoissonNegLogLik>(); });
 
 XGBOOST_REGISTER_METRIC(GammaDeviance, "gamma-deviance")
 .describe("Residual deviance for gamma regression.")
-.set_body([](const char* param) { return new EvalEWiseBase<EvalGammaDeviance>(); });
+.set_body([](const char* param, ObjInfo) { return new EvalEWiseBase<EvalGammaDeviance>(); });
 
 XGBOOST_REGISTER_METRIC(GammaNLogLik, "gamma-nloglik")
 .describe("Negative log-likelihood for gamma regression.")
-.set_body([](const char* param) { return new EvalEWiseBase<EvalGammaNLogLik>(); });
+.set_body([](const char* param, ObjInfo) { return new EvalEWiseBase<EvalGammaNLogLik>(); });
 
 XGBOOST_REGISTER_METRIC(Error, "error")
 .describe("Binary classification error.")
-.set_body([](const char* param) { return new EvalEWiseBase<EvalError>(param); });
+.set_body([](const char* param, ObjInfo) { return new EvalEWiseBase<EvalError>(param); });
 
 XGBOOST_REGISTER_METRIC(TweedieNLogLik, "tweedie-nloglik")
 .describe("tweedie-nloglik@rho for tweedie regression.")
-.set_body([](const char* param) {
+.set_body([](const char* param, ObjInfo) {
   return new EvalEWiseBase<EvalTweedieNLogLik>(param);
 });
 

--- a/src/metric/metric_common.h
+++ b/src/metric/metric_common.h
@@ -9,6 +9,8 @@
 #include <string>
 
 #include "../common/common.h"
+#include "xgboost/metric.h"
+#include "xgboost/task.h"
 
 namespace xgboost {
 
@@ -16,7 +18,8 @@ namespace xgboost {
 // present already. This is created when there is a device ordinal present and if xgboost
 // is compiled with CUDA support
 struct GPUMetric : Metric {
-  static Metric *CreateGPUMetric(const std::string& name, GenericParameter const* tparam);
+  static Metric *CreateGPUMetric(const std::string &name, GenericParameter const *tparam,
+                                 ObjInfo task);
 };
 
 /*!
@@ -25,9 +28,8 @@ struct GPUMetric : Metric {
  *  For example, metric map@3, then: param == "3".
  */
 struct MetricGPUReg
-  : public dmlc::FunctionRegEntryBase<MetricGPUReg,
-                                      std::function<Metric * (const char*)> > {
-};
+    : public dmlc::FunctionRegEntryBase<MetricGPUReg,
+                                        std::function<Metric *(const char *, ObjInfo task)> > {};
 
 /*!
  * \brief Macro to register metric computed on GPU.

--- a/src/metric/rank_metric.cu
+++ b/src/metric/rank_metric.cu
@@ -276,14 +276,14 @@ struct EvalMAPGpu {
 
 XGBOOST_REGISTER_GPU_METRIC(PrecisionGpu, "pre")
 .describe("precision@k for rank computed on GPU.")
-.set_body([](const char* param) { return new EvalRankGpu<EvalPrecisionGpu>("pre", param); });
+.set_body([](const char* param, ObjInfo) { return new EvalRankGpu<EvalPrecisionGpu>("pre", param); });
 
 XGBOOST_REGISTER_GPU_METRIC(NDCGGpu, "ndcg")
 .describe("ndcg@k for rank computed on GPU.")
-.set_body([](const char* param) { return new EvalRankGpu<EvalNDCGGpu>("ndcg", param); });
+.set_body([](const char* param, ObjInfo) { return new EvalRankGpu<EvalNDCGGpu>("ndcg", param); });
 
 XGBOOST_REGISTER_GPU_METRIC(MAPGpu, "map")
 .describe("map@k for rank computed on GPU.")
-.set_body([](const char* param) { return new EvalRankGpu<EvalMAPGpu>("map", param); });
+.set_body([](const char* param, ObjInfo) { return new EvalRankGpu<EvalMAPGpu>("map", param); });
 }  // namespace metric
 }  // namespace xgboost

--- a/src/metric/survival_metric.cu
+++ b/src/metric/survival_metric.cu
@@ -288,13 +288,13 @@ struct AFTNLogLikDispatcher : public Metric {
 
 XGBOOST_REGISTER_METRIC(AFTNLogLik, "aft-nloglik")
 .describe("Negative log likelihood of Accelerated Failure Time model.")
-.set_body([](const char* param) {
+.set_body([](const char* param, ObjInfo) {
   return new AFTNLogLikDispatcher();
 });
 
 XGBOOST_REGISTER_METRIC(IntervalRegressionAccuracy, "interval-regression-accuracy")
 .describe("")
-.set_body([](const char* param) {
+.set_body([](const char* param, ObjInfo) {
   return new EvalEWiseSurvivalBase<EvalIntervalRegressionAccuracy>();
 });
 

--- a/src/objective/aft_obj.cu
+++ b/src/objective/aft_obj.cu
@@ -38,6 +38,8 @@ class AFTObj : public ObjFunction {
     param_.UpdateAllowUnknown(args);
   }
 
+  ObjInfo Task() const override { return {ObjInfo::kSurvival, false}; }
+
   template <typename Distribution>
   void GetGradientImpl(const HostDeviceVector<bst_float> &preds,
                        const MetaInfo &info,

--- a/src/objective/hinge.cu
+++ b/src/objective/hinge.cu
@@ -27,6 +27,8 @@ class HingeObj : public ObjFunction {
   void Configure(
       const std::vector<std::pair<std::string, std::string> > &args) override {}
 
+  ObjInfo Task() const override { return {ObjInfo::kRegression, false}; }
+
   void GetGradient(const HostDeviceVector<bst_float> &preds,
                    const MetaInfo &info,
                    int iter,

--- a/src/objective/multiclass_obj.cu
+++ b/src/objective/multiclass_obj.cu
@@ -45,6 +45,9 @@ class SoftmaxMultiClassObj : public ObjFunction {
   void Configure(Args const& args) override {
     param_.UpdateAllowUnknown(args);
   }
+
+  ObjInfo Task() const override { return {ObjInfo::kClassification, false}; }
+
   void GetGradient(const HostDeviceVector<bst_float>& preds,
                    const MetaInfo& info,
                    int iter,

--- a/src/objective/rank_obj.cu
+++ b/src/objective/rank_obj.cu
@@ -754,6 +754,8 @@ class LambdaRankObj : public ObjFunction {
     param_.UpdateAllowUnknown(args);
   }
 
+  ObjInfo Task() const override { return {ObjInfo::kRanking, false}; }
+
   void GetGradient(const HostDeviceVector<bst_float>& preds,
                    const MetaInfo& info,
                    int iter,

--- a/src/objective/regression_loss.h
+++ b/src/objective/regression_loss.h
@@ -7,6 +7,8 @@
 #include <dmlc/omp.h>
 #include <xgboost/logging.h>
 #include <algorithm>
+
+#include "xgboost/task.h"
 #include "../common/math.h"
 
 namespace xgboost {
@@ -36,6 +38,7 @@ struct LinearSquareLoss {
   static const char* DefaultEvalMetric() { return "rmse"; }
 
   static const char* Name() { return "reg:squarederror"; }
+  static ObjInfo Info() { return {ObjInfo::kRegression, true}; }
 };
 
 struct SquaredLogError {
@@ -61,6 +64,8 @@ struct SquaredLogError {
   static const char* DefaultEvalMetric() { return "rmsle"; }
 
   static const char* Name() { return "reg:squaredlogerror"; }
+
+  static ObjInfo Info() { return {ObjInfo::kRegression, false}; }
 };
 
 // logistic loss for probability regression task
@@ -96,6 +101,8 @@ struct LogisticRegression {
   static const char* DefaultEvalMetric() { return "rmse"; }
 
   static const char* Name() { return "reg:logistic"; }
+
+  static ObjInfo Info() { return {ObjInfo::kRegression, false}; }
 };
 
 struct PseudoHuberError {
@@ -127,12 +134,14 @@ struct PseudoHuberError {
   static const char* Name() {
     return "reg:pseudohubererror";
   }
+  static ObjInfo Info() { return {ObjInfo::kRegression, false}; }
 };
 
 // logistic loss for binary classification task
 struct LogisticClassification : public LogisticRegression {
   static const char* DefaultEvalMetric() { return "logloss"; }
   static const char* Name() { return "binary:logistic"; }
+  static ObjInfo Info() { return {ObjInfo::kBinary, false}; }
 };
 
 // logistic loss, but predict un-transformed margin
@@ -168,6 +177,8 @@ struct LogisticRaw : public LogisticRegression {
   static const char* DefaultEvalMetric() { return "logloss"; }
 
   static const char* Name() { return "binary:logitraw"; }
+
+  static ObjInfo Info() { return {ObjInfo::kRegression, false}; }
 };
 
 }  // namespace obj

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -52,6 +52,10 @@ class RegLossObj : public ObjFunction {
     param_.UpdateAllowUnknown(args);
   }
 
+  struct ObjInfo Task() const override {
+    return Loss::Info();
+  }
+
   void GetGradient(const HostDeviceVector<bst_float>& preds,
                    const MetaInfo &info, int,
                    HostDeviceVector<GradientPair>* out_gpair) override {
@@ -207,6 +211,10 @@ class PoissonRegression : public ObjFunction {
     param_.UpdateAllowUnknown(args);
   }
 
+  struct ObjInfo Task() const override {
+    return {ObjInfo::kRegression, false};
+  }
+
   void GetGradient(const HostDeviceVector<bst_float>& preds,
                    const MetaInfo &info, int,
                    HostDeviceVector<GradientPair> *out_gpair) override {
@@ -297,6 +305,10 @@ class CoxRegression : public ObjFunction {
  public:
   void Configure(
       const std::vector<std::pair<std::string, std::string> >&) override {}
+
+  struct ObjInfo Task() const override {
+    return {ObjInfo::kRegression, false};
+  }
 
   void GetGradient(const HostDeviceVector<bst_float>& preds,
                    const MetaInfo &info, int,
@@ -395,6 +407,10 @@ class GammaRegression : public ObjFunction {
   void Configure(
       const std::vector<std::pair<std::string, std::string> >&) override {}
 
+  struct ObjInfo Task() const override {
+    return {ObjInfo::kRegression, false};
+  }
+
   void GetGradient(const HostDeviceVector<bst_float> &preds,
                    const MetaInfo &info, int,
                    HostDeviceVector<GradientPair> *out_gpair) override {
@@ -489,6 +505,10 @@ class TweedieRegression : public ObjFunction {
     std::ostringstream os;
     os << "tweedie-nloglik@" << param_.tweedie_variance_power;
     metric_ = os.str();
+  }
+
+  struct ObjInfo Task() const override {
+    return {ObjInfo::kRegression, false};
   }
 
   void GetGradient(const HostDeviceVector<bst_float>& preds,

--- a/src/tree/tree_updater.cc
+++ b/src/tree/tree_updater.cc
@@ -14,12 +14,13 @@ DMLC_REGISTRY_ENABLE(::xgboost::TreeUpdaterReg);
 
 namespace xgboost {
 
-TreeUpdater* TreeUpdater::Create(const std::string& name, GenericParameter const* tparam) {
-  auto *e = ::dmlc::Registry< ::xgboost::TreeUpdaterReg>::Get()->Find(name);
+TreeUpdater* TreeUpdater::Create(const std::string& name, GenericParameter const* tparam,
+                                 ObjInfo task) {
+  auto* e = ::dmlc::Registry< ::xgboost::TreeUpdaterReg>::Get()->Find(name);
   if (e == nullptr) {
     LOG(FATAL) << "Unknown tree updater " << name;
   }
-  auto p_updater = (e->body)();
+  auto p_updater = (e->body)(task);
   p_updater->tparam_ = tparam;
   return p_updater;
 }

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -628,7 +628,7 @@ class ColMaker: public TreeUpdater {
 
 XGBOOST_REGISTER_TREE_UPDATER(ColMaker, "grow_colmaker")
 .describe("Grow tree with parallelization over columns.")
-.set_body([]() {
+.set_body([](ObjInfo) {
     return new ColMaker();
   });
 }  // namespace tree

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -696,7 +696,7 @@ struct GPUHistMakerDevice {
         int right_child_nidx = tree[candidate.nid].RightChild();
         // Only create child entries if needed
         if (GPUExpandEntry::ChildIsValid(param, tree.GetDepth(left_child_nidx),
-                                      num_leaves)) {
+                                         num_leaves)) {
           monitor.Start("UpdatePosition");
           this->UpdatePosition(candidate.nid, p_tree);
           monitor.Stop("UpdatePosition");
@@ -730,7 +730,7 @@ struct GPUHistMakerDevice {
 template <typename GradientSumT>
 class GPUHistMakerSpecialised {
  public:
-  GPUHistMakerSpecialised() = default;
+  explicit GPUHistMakerSpecialised(ObjInfo task) : task_{task} {};
   void Configure(const Args& args, GenericParameter const* generic_param) {
     param_.UpdateAllowUnknown(args);
     generic_param_ = generic_param;
@@ -857,12 +857,14 @@ class GPUHistMakerSpecialised {
 
   DMatrix* p_last_fmat_ { nullptr };
   int device_{-1};
+  ObjInfo task_;
 
   common::Monitor monitor_;
 };
 
 class GPUHistMaker : public TreeUpdater {
  public:
+  explicit GPUHistMaker(ObjInfo task) : task_{task} {}
   void Configure(const Args& args) override {
     // Used in test to count how many configurations are performed
     LOG(DEBUG) << "[GPU Hist]: Configure";
@@ -876,11 +878,11 @@ class GPUHistMaker : public TreeUpdater {
       param = double_maker_->param_;
     }
     if (hist_maker_param_.single_precision_histogram) {
-      float_maker_.reset(new GPUHistMakerSpecialised<GradientPair>());
+      float_maker_.reset(new GPUHistMakerSpecialised<GradientPair>(task_));
       float_maker_->param_ = param;
       float_maker_->Configure(args, tparam_);
     } else {
-      double_maker_.reset(new GPUHistMakerSpecialised<GradientPairPrecise>());
+      double_maker_.reset(new GPUHistMakerSpecialised<GradientPairPrecise>(task_));
       double_maker_->param_ = param;
       double_maker_->Configure(args, tparam_);
     }
@@ -890,10 +892,10 @@ class GPUHistMaker : public TreeUpdater {
     auto const& config = get<Object const>(in);
     FromJson(config.at("gpu_hist_train_param"), &this->hist_maker_param_);
     if (hist_maker_param_.single_precision_histogram) {
-      float_maker_.reset(new GPUHistMakerSpecialised<GradientPair>());
+      float_maker_.reset(new GPUHistMakerSpecialised<GradientPair>(task_));
       FromJson(config.at("train_param"), &float_maker_->param_);
     } else {
-      double_maker_.reset(new GPUHistMakerSpecialised<GradientPairPrecise>());
+      double_maker_.reset(new GPUHistMakerSpecialised<GradientPairPrecise>(task_));
       FromJson(config.at("train_param"), &double_maker_->param_);
     }
   }
@@ -931,6 +933,7 @@ class GPUHistMaker : public TreeUpdater {
 
  private:
   GPUHistMakerTrainParam hist_maker_param_;
+  ObjInfo task_;
   std::unique_ptr<GPUHistMakerSpecialised<GradientPair>> float_maker_;
   std::unique_ptr<GPUHistMakerSpecialised<GradientPairPrecise>> double_maker_;
 };
@@ -938,7 +941,7 @@ class GPUHistMaker : public TreeUpdater {
 #if !defined(GTEST_TEST)
 XGBOOST_REGISTER_TREE_UPDATER(GPUHistMaker, "grow_gpu_hist")
     .describe("Grow tree with GPU.")
-    .set_body([]() { return new GPUHistMaker(); });
+    .set_body([](ObjInfo task) { return new GPUHistMaker(task); });
 #endif  // !defined(GTEST_TEST)
 
 }  // namespace tree

--- a/src/tree/updater_histmaker.cc
+++ b/src/tree/updater_histmaker.cc
@@ -750,14 +750,14 @@ class GlobalProposalHistMaker: public CQHistMaker {
 
 XGBOOST_REGISTER_TREE_UPDATER(LocalHistMaker, "grow_local_histmaker")
 .describe("Tree constructor that uses approximate histogram construction.")
-.set_body([]() {
+.set_body([](ObjInfo) {
     return new CQHistMaker();
   });
 
 // The updater for approx tree method.
 XGBOOST_REGISTER_TREE_UPDATER(HistMaker, "grow_histmaker")
 .describe("Tree constructor that uses approximate global of histogram construction.")
-.set_body([]() {
+.set_body([](ObjInfo) {
     return new GlobalProposalHistMaker();
   });
 }  // namespace tree

--- a/src/tree/updater_prune.cc
+++ b/src/tree/updater_prune.cc
@@ -23,8 +23,8 @@ DMLC_REGISTRY_FILE_TAG(updater_prune);
 /*! \brief pruner that prunes a tree after growing finishes */
 class TreePruner: public TreeUpdater {
  public:
-  TreePruner() {
-    syncher_.reset(TreeUpdater::Create("sync", tparam_));
+  explicit TreePruner(ObjInfo task) {
+    syncher_.reset(TreeUpdater::Create("sync", tparam_, task));
     pruner_monitor_.Init("TreePruner");
   }
   char const* Name() const override {
@@ -113,8 +113,8 @@ class TreePruner: public TreeUpdater {
 
 XGBOOST_REGISTER_TREE_UPDATER(TreePruner, "prune")
 .describe("Pruner that prune the tree according to statistics.")
-.set_body([]() {
-    return new TreePruner();
+.set_body([](ObjInfo task) {
+    return new TreePruner(task);
   });
 }  // namespace tree
 }  // namespace xgboost

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -95,7 +95,7 @@ using xgboost::common::Column;
 /*! \brief construct a tree using quantized feature values */
 class QuantileHistMaker: public TreeUpdater {
  public:
-  QuantileHistMaker() {
+  explicit QuantileHistMaker(ObjInfo task) {
     updater_monitor_.Init("QuantileHistMaker");
   }
   void Configure(const Args& args) override;
@@ -154,12 +154,15 @@ class QuantileHistMaker: public TreeUpdater {
     using GHistRowT = GHistRow<GradientSumT>;
     using GradientPairT = xgboost::detail::GradientPairInternal<GradientSumT>;
     // constructor
-    explicit Builder(const size_t n_trees, const TrainParam &param,
-                     std::unique_ptr<TreeUpdater> pruner, DMatrix const *fmat)
-        : n_trees_(n_trees), param_(param), pruner_(std::move(pruner)),
-          p_last_tree_(nullptr), p_last_fmat_(fmat),
-          histogram_builder_{
-              new HistogramBuilder<GradientSumT, CPUExpandEntry>} {
+    explicit Builder(const size_t n_trees, const TrainParam& param,
+                     std::unique_ptr<TreeUpdater> pruner, DMatrix const* fmat, ObjInfo task)
+        : n_trees_(n_trees),
+          param_(param),
+          pruner_(std::move(pruner)),
+          p_last_tree_(nullptr),
+          p_last_fmat_(fmat),
+          histogram_builder_{new HistogramBuilder<GradientSumT, CPUExpandEntry>},
+          task_{task} {
       builder_monitor_.Init("Quantile::Builder");
     }
     ~Builder();
@@ -261,6 +264,7 @@ class QuantileHistMaker: public TreeUpdater {
     DataLayout data_layout_;
     std::unique_ptr<HistogramBuilder<GradientSumT, CPUExpandEntry>>
         histogram_builder_;
+    ObjInfo task_;
 
     common::Monitor builder_monitor_;
   };
@@ -281,6 +285,7 @@ class QuantileHistMaker: public TreeUpdater {
   std::unique_ptr<Builder<double>> double_builder_;
 
   std::unique_ptr<TreeUpdater> pruner_;
+  ObjInfo task_;
 };
 }  // namespace tree
 }  // namespace xgboost

--- a/src/tree/updater_refresh.cc
+++ b/src/tree/updater_refresh.cc
@@ -161,7 +161,7 @@ class TreeRefresher: public TreeUpdater {
 
 XGBOOST_REGISTER_TREE_UPDATER(TreeRefresher, "refresh")
 .describe("Refresher that refreshes the weight and statistics according to data.")
-.set_body([]() {
+.set_body([](ObjInfo) {
     return new TreeRefresher();
   });
 }  // namespace tree

--- a/src/tree/updater_sync.cc
+++ b/src/tree/updater_sync.cc
@@ -53,7 +53,7 @@ class TreeSyncher: public TreeUpdater {
 
 XGBOOST_REGISTER_TREE_UPDATER(TreeSyncher, "sync")
 .describe("Syncher that synchronize the tree in all distributed nodes.")
-.set_body([]() {
+.set_body([](ObjInfo) {
     return new TreeSyncher();
   });
 }  // namespace tree

--- a/tests/cpp/metric/test_elementwise_metric.cc
+++ b/tests/cpp/metric/test_elementwise_metric.cc
@@ -13,7 +13,8 @@ namespace xgboost {
 namespace {
 inline void CheckDeterministicMetricElementWise(StringView name, int32_t device) {
   auto lparam = CreateEmptyGenericParam(device);
-  std::unique_ptr<Metric> metric{Metric::Create(name.c_str(), &lparam)};
+  std::unique_ptr<Metric> metric{
+      Metric::Create(name.c_str(), &lparam, {ObjInfo::kRegression, true})};
 
   HostDeviceVector<float> predts;
   MetaInfo info;
@@ -40,9 +41,11 @@ inline void CheckDeterministicMetricElementWise(StringView name, int32_t device)
 }  // anonymous namespace
 }  // namespace xgboost
 
+using xgboost::ObjInfo;
+
 TEST(Metric, DeclareUnifiedTest(RMSE)) {
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  xgboost::Metric * metric = xgboost::Metric::Create("rmse", &lparam);
+  xgboost::Metric *metric = xgboost::Metric::Create("rmse", &lparam, {ObjInfo::kRegression, true});
   metric->Configure({});
   ASSERT_STREQ(metric->Name(), "rmse");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 0, 1e-10);
@@ -67,7 +70,7 @@ TEST(Metric, DeclareUnifiedTest(RMSE)) {
 
 TEST(Metric, DeclareUnifiedTest(RMSLE)) {
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  xgboost::Metric * metric = xgboost::Metric::Create("rmsle", &lparam);
+  xgboost::Metric *metric = xgboost::Metric::Create("rmsle", &lparam, {ObjInfo::kRegression, true});
   metric->Configure({});
   ASSERT_STREQ(metric->Name(), "rmsle");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 0, 1e-10);
@@ -92,7 +95,7 @@ TEST(Metric, DeclareUnifiedTest(RMSLE)) {
 
 TEST(Metric, DeclareUnifiedTest(MAE)) {
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  xgboost::Metric * metric = xgboost::Metric::Create("mae", &lparam);
+  xgboost::Metric *metric = xgboost::Metric::Create("mae", &lparam, {ObjInfo::kRegression, true});
   metric->Configure({});
   ASSERT_STREQ(metric->Name(), "mae");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 0, 1e-10);
@@ -117,7 +120,7 @@ TEST(Metric, DeclareUnifiedTest(MAE)) {
 
 TEST(Metric, DeclareUnifiedTest(MAPE)) {
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  xgboost::Metric * metric = xgboost::Metric::Create("mape", &lparam);
+  xgboost::Metric *metric = xgboost::Metric::Create("mape", &lparam, {ObjInfo::kRegression, true});
   metric->Configure({});
   ASSERT_STREQ(metric->Name(), "mape");
   EXPECT_NEAR(GetMetricEval(metric, {150, 300}, {100, 200}), 0.5f, 1e-10);
@@ -142,7 +145,7 @@ TEST(Metric, DeclareUnifiedTest(MAPE)) {
 
 TEST(Metric, DeclareUnifiedTest(MPHE)) {
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  xgboost::Metric * metric = xgboost::Metric::Create("mphe", &lparam);
+  xgboost::Metric *metric = xgboost::Metric::Create("mphe", &lparam, {ObjInfo::kRegression, true});
   metric->Configure({});
   ASSERT_STREQ(metric->Name(), "mphe");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 0, 1e-10);
@@ -167,7 +170,7 @@ TEST(Metric, DeclareUnifiedTest(MPHE)) {
 
 TEST(Metric, DeclareUnifiedTest(LogLoss)) {
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  xgboost::Metric * metric = xgboost::Metric::Create("logloss", &lparam);
+  xgboost::Metric *metric = xgboost::Metric::Create("logloss", &lparam, {ObjInfo::kBinary, true});
   metric->Configure({});
   ASSERT_STREQ(metric->Name(), "logloss");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 0, 1e-10);
@@ -196,7 +199,7 @@ TEST(Metric, DeclareUnifiedTest(LogLoss)) {
 
 TEST(Metric, DeclareUnifiedTest(Error)) {
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  xgboost::Metric * metric = xgboost::Metric::Create("error", &lparam);
+  xgboost::Metric *metric = xgboost::Metric::Create("error", &lparam, {ObjInfo::kBinary, true});
   metric->Configure({});
   ASSERT_STREQ(metric->Name(), "error");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 0, 1e-10);
@@ -215,16 +218,16 @@ TEST(Metric, DeclareUnifiedTest(Error)) {
                             {  1,   2,   9,   8}),
               0.55f, 0.001f);
 
-  EXPECT_ANY_THROW(xgboost::Metric::Create("error@abc", &lparam));
+  EXPECT_ANY_THROW(xgboost::Metric::Create("error@abc", &lparam, {ObjInfo::kBinary, true}));
   delete metric;
 
-  metric = xgboost::Metric::Create("error@0.5f", &lparam);
+  metric = xgboost::Metric::Create("error@0.5f", &lparam, {ObjInfo::kBinary, true});
   metric->Configure({});
   EXPECT_STREQ(metric->Name(), "error");
 
   delete metric;
 
-  metric = xgboost::Metric::Create("error@0.1", &lparam);
+  metric = xgboost::Metric::Create("error@0.1", &lparam, {ObjInfo::kBinary, true});
   metric->Configure({});
   ASSERT_STREQ(metric->Name(), "error@0.1");
   EXPECT_STREQ(metric->Name(), "error@0.1");
@@ -250,7 +253,8 @@ TEST(Metric, DeclareUnifiedTest(Error)) {
 
 TEST(Metric, DeclareUnifiedTest(PoissionNegLogLik)) {
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  xgboost::Metric * metric = xgboost::Metric::Create("poisson-nloglik", &lparam);
+  xgboost::Metric *metric =
+      xgboost::Metric::Create("poisson-nloglik", &lparam, {ObjInfo::kBinary, true});
   metric->Configure({});
   ASSERT_STREQ(metric->Name(), "poisson-nloglik");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 0.5f, 1e-10);

--- a/tests/cpp/metric/test_metric.cc
+++ b/tests/cpp/metric/test_metric.cc
@@ -1,19 +1,23 @@
 // Copyright by Contributors
 #include <xgboost/metric.h>
+#include <xgboost/task.h>
 
 #include "../helpers.h"
 
 TEST(Metric, UnknownMetric) {
   auto tparam = xgboost::CreateEmptyGenericParam(GPUIDX);
   xgboost::Metric * metric = nullptr;
-  EXPECT_ANY_THROW(metric = xgboost::Metric::Create("unknown_name", &tparam));
-  EXPECT_NO_THROW(metric = xgboost::Metric::Create("rmse", &tparam));
+  using xgboost::ObjInfo;
+  EXPECT_ANY_THROW(metric =
+                       xgboost::Metric::Create("unknown_name", &tparam, {ObjInfo::kOther, true}));
+  EXPECT_NO_THROW(metric = xgboost::Metric::Create("rmse", &tparam, {ObjInfo::kOther, true}));
   if (metric) {
     delete metric;
   }
   metric = nullptr;
-  EXPECT_ANY_THROW(metric = xgboost::Metric::Create("unknown_name@1", &tparam));
-  EXPECT_NO_THROW(metric = xgboost::Metric::Create("error@0.5f", &tparam));
+  EXPECT_ANY_THROW(metric =
+                       xgboost::Metric::Create("unknown_name@1", &tparam, {ObjInfo::kOther, true}));
+  EXPECT_NO_THROW(metric = xgboost::Metric::Create("error@0.5f", &tparam, {ObjInfo::kOther, true}));
   if (metric) {
     delete metric;
   }

--- a/tests/cpp/metric/test_multiclass_metric.cc
+++ b/tests/cpp/metric/test_multiclass_metric.cc
@@ -7,7 +7,8 @@
 namespace xgboost {
 inline void CheckDeterministicMetricMultiClass(StringView name, int32_t device) {
   auto lparam = CreateEmptyGenericParam(device);
-  std::unique_ptr<Metric> metric{Metric::Create(name.c_str(), &lparam)};
+  std::unique_ptr<Metric> metric{
+      Metric::Create(name.c_str(), &lparam, {ObjInfo::kClassification, true})};
 
   HostDeviceVector<float> predts;
   MetaInfo info;
@@ -41,10 +42,13 @@ inline void CheckDeterministicMetricMultiClass(StringView name, int32_t device) 
 }
 }  // namespace xgboost
 
+using xgboost::ObjInfo;
+
 inline void TestMultiClassError(int device) {
   auto lparam = xgboost::CreateEmptyGenericParam(device);
   lparam.gpu_id = device;
-  xgboost::Metric * metric = xgboost::Metric::Create("merror", &lparam);
+  xgboost::Metric *metric =
+      xgboost::Metric::Create("merror", &lparam, {ObjInfo::kClassification, true});
   metric->Configure({});
   ASSERT_STREQ(metric->Name(), "merror");
   EXPECT_ANY_THROW(GetMetricEval(metric, {0}, {0, 0}));
@@ -65,7 +69,8 @@ TEST(Metric, DeclareUnifiedTest(MultiClassError)) {
 inline void TestMultiClassLogLoss(int device) {
   auto lparam = xgboost::CreateEmptyGenericParam(device);
   lparam.gpu_id = device;
-  xgboost::Metric * metric = xgboost::Metric::Create("mlogloss", &lparam);
+  xgboost::Metric *metric =
+      xgboost::Metric::Create("mlogloss", &lparam, {ObjInfo::kClassification, true});
   metric->Configure({});
   ASSERT_STREQ(metric->Name(), "mlogloss");
   EXPECT_ANY_THROW(GetMetricEval(metric, {0}, {0, 0}));

--- a/tests/cpp/metric/test_rank_metric.cc
+++ b/tests/cpp/metric/test_rank_metric.cc
@@ -3,11 +3,12 @@
 
 #include "../helpers.h"
 
+using xgboost::ObjInfo;
 #if !defined(__CUDACC__)
 TEST(Metric, AMS) {
   auto tparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  EXPECT_ANY_THROW(xgboost::Metric::Create("ams", &tparam));
-  xgboost::Metric * metric = xgboost::Metric::Create("ams@0.5f", &tparam);
+  EXPECT_ANY_THROW(xgboost::Metric::Create("ams", &tparam, {ObjInfo::kRanking, true}));
+  xgboost::Metric* metric = xgboost::Metric::Create("ams@0.5f", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "ams@0.5");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 0.311f, 0.001f);
   EXPECT_NEAR(GetMetricEval(metric,
@@ -16,7 +17,7 @@ TEST(Metric, AMS) {
               0.29710f, 0.001f);
 
   delete metric;
-  metric = xgboost::Metric::Create("ams@0", &tparam);
+  metric = xgboost::Metric::Create("ams@0", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "ams@0");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 0.311f, 0.001f);
 
@@ -29,7 +30,7 @@ TEST(Metric, DeclareUnifiedTest(Precision)) {
   // std::numeric_limits<unsigned>::max(); hence all values are very small
   // NOTE(AbdealiJK): Maybe this should be fixed to be num_row by default.
   auto tparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  xgboost::Metric * metric = xgboost::Metric::Create("pre", &tparam);
+  xgboost::Metric * metric = xgboost::Metric::Create("pre", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "pre");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 0, 1e-7);
   EXPECT_NEAR(GetMetricEval(metric,
@@ -38,7 +39,7 @@ TEST(Metric, DeclareUnifiedTest(Precision)) {
               0, 1e-7);
 
   delete metric;
-  metric = xgboost::Metric::Create("pre@2", &tparam);
+  metric = xgboost::Metric::Create("pre@2", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "pre@2");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 0.5f, 1e-7);
   EXPECT_NEAR(GetMetricEval(metric,
@@ -53,7 +54,7 @@ TEST(Metric, DeclareUnifiedTest(Precision)) {
 
 TEST(Metric, DeclareUnifiedTest(NDCG)) {
   auto tparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  xgboost::Metric * metric = xgboost::Metric::Create("ndcg", &tparam);
+  xgboost::Metric* metric = xgboost::Metric::Create("ndcg", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "ndcg");
   EXPECT_ANY_THROW(GetMetricEval(metric, {0, 1}, {}));
   EXPECT_NEAR(GetMetricEval(metric,
@@ -66,7 +67,7 @@ TEST(Metric, DeclareUnifiedTest(NDCG)) {
               0.6509f, 0.001f);
 
   delete metric;
-  metric = xgboost::Metric::Create("ndcg@2", &tparam);
+  metric = xgboost::Metric::Create("ndcg@2", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "ndcg@2");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 1, 1e-10);
   EXPECT_NEAR(GetMetricEval(metric,
@@ -75,7 +76,7 @@ TEST(Metric, DeclareUnifiedTest(NDCG)) {
               0.3868f, 0.001f);
 
   delete metric;
-  metric = xgboost::Metric::Create("ndcg@-", &tparam);
+  metric = xgboost::Metric::Create("ndcg@-", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "ndcg-");
   EXPECT_NEAR(GetMetricEval(metric,
                             xgboost::HostDeviceVector<xgboost::bst_float>{},
@@ -86,7 +87,7 @@ TEST(Metric, DeclareUnifiedTest(NDCG)) {
                             {  0,   0,   1,   1}),
               0.6509f, 0.001f);
   delete metric;
-  metric = xgboost::Metric::Create("ndcg-", &tparam);
+  metric = xgboost::Metric::Create("ndcg-", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "ndcg-");
   EXPECT_NEAR(GetMetricEval(metric,
                             xgboost::HostDeviceVector<xgboost::bst_float>{},
@@ -98,7 +99,7 @@ TEST(Metric, DeclareUnifiedTest(NDCG)) {
               0.6509f, 0.001f);
 
   delete metric;
-  metric = xgboost::Metric::Create("ndcg@2-", &tparam);
+  metric = xgboost::Metric::Create("ndcg@2-", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "ndcg@2-");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 1, 1e-10);
   EXPECT_NEAR(GetMetricEval(metric,
@@ -111,7 +112,7 @@ TEST(Metric, DeclareUnifiedTest(NDCG)) {
 
 TEST(Metric, DeclareUnifiedTest(MAP)) {
   auto tparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  xgboost::Metric * metric = xgboost::Metric::Create("map", &tparam);
+  xgboost::Metric* metric = xgboost::Metric::Create("map", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "map");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 1, 1e-10);
   EXPECT_NEAR(GetMetricEval(metric,
@@ -131,21 +132,21 @@ TEST(Metric, DeclareUnifiedTest(MAP)) {
               0.8611f, 0.001f);
 
   delete metric;
-  metric = xgboost::Metric::Create("map@-", &tparam);
+  metric = xgboost::Metric::Create("map@-", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "map-");
   EXPECT_NEAR(GetMetricEval(metric,
                             xgboost::HostDeviceVector<xgboost::bst_float>{},
                             {}), 0, 1e-10);
 
   delete metric;
-  metric = xgboost::Metric::Create("map-", &tparam);
+  metric = xgboost::Metric::Create("map-", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "map-");
   EXPECT_NEAR(GetMetricEval(metric,
                             xgboost::HostDeviceVector<xgboost::bst_float>{},
                             {}), 0, 1e-10);
 
   delete metric;
-  metric = xgboost::Metric::Create("map@2", &tparam);
+  metric = xgboost::Metric::Create("map@2", &tparam, {ObjInfo::kRanking, true});
   ASSERT_STREQ(metric->Name(), "map@2");
   EXPECT_NEAR(GetMetricEval(metric, {0, 1}, {0, 1}), 1, 1e-10);
   EXPECT_NEAR(GetMetricEval(metric,

--- a/tests/cpp/metric/test_survival_metric.cu
+++ b/tests/cpp/metric/test_survival_metric.cu
@@ -14,7 +14,7 @@ namespace common {
 namespace {
 inline void CheckDeterministicMetricElementWise(StringView name, int32_t device) {
   auto lparam = CreateEmptyGenericParam(device);
-  std::unique_ptr<Metric> metric{Metric::Create(name.c_str(), &lparam)};
+  std::unique_ptr<Metric> metric{Metric::Create(name.c_str(), &lparam, {ObjInfo::kSurvival, true})};
   metric->Configure(Args{});
 
   HostDeviceVector<float> predts;
@@ -69,7 +69,8 @@ TEST(Metric, DeclareUnifiedTest(AFTNegLogLik)) {
   };
   for (const auto& test_case : std::vector<TestCase>{ {"normal", 2.1508f}, {"logistic", 2.1804f},
                                                       {"extreme", 2.0706f} }) {
-    std::unique_ptr<Metric> metric(Metric::Create("aft-nloglik", &lparam));
+    std::unique_ptr<Metric> metric(
+        Metric::Create("aft-nloglik", &lparam, {ObjInfo::kSurvival, true}));
     metric->Configure({ {"aft_loss_distribution", test_case.dist_type},
                         {"aft_loss_distribution_scale", "1.0"} });
     EXPECT_NEAR(metric->Eval(preds, info, false), test_case.reference_value, 1e-4);
@@ -86,7 +87,8 @@ TEST(Metric, DeclareUnifiedTest(IntervalRegressionAccuracy)) {
   info.weights_.HostVector() = std::vector<bst_float>();
   HostDeviceVector<bst_float> preds(4, std::log(60.0f));
 
-  std::unique_ptr<Metric> metric(Metric::Create("interval-regression-accuracy", &lparam));
+  std::unique_ptr<Metric> metric(
+      Metric::Create("interval-regression-accuracy", &lparam, {ObjInfo::kSurvival, true}));
   EXPECT_FLOAT_EQ(metric->Eval(preds, info, false), 0.75f);
   info.labels_lower_bound_.HostVector()[2] = 70.0f;
   EXPECT_FLOAT_EQ(metric->Eval(preds, info, false), 0.50f);
@@ -103,7 +105,8 @@ TEST(Metric, DeclareUnifiedTest(IntervalRegressionAccuracy)) {
 // Test configuration of AFT metric
 TEST(AFTNegLogLikMetric, DeclareUnifiedTest(Configuration)) {
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  std::unique_ptr<Metric> metric(Metric::Create("aft-nloglik", &lparam));
+  std::unique_ptr<Metric> metric(
+      Metric::Create("aft-nloglik", &lparam, {ObjInfo::kSurvival, true}));
   metric->Configure({{"aft_loss_distribution", "normal"}, {"aft_loss_distribution_scale", "10"}});
 
   // Configuration round-trip test

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -275,7 +275,8 @@ void TestHistogramIndexImpl() {
   int constexpr kNRows = 1000, kNCols = 10;
 
   // Build 2 matrices and build a histogram maker with that
-  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker, hist_maker_ext;
+  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{{ObjInfo::kRegression, true}},
+      hist_maker_ext{{ObjInfo::kRegression, true}};
   std::unique_ptr<DMatrix> hist_maker_dmat(
     CreateSparsePageDMatrixWithRC(kNRows, kNCols, 0, true));
 
@@ -333,7 +334,7 @@ int32_t TestMinSplitLoss(DMatrix* dmat, float gamma, HostDeviceVector<GradientPa
     {"gamma", std::to_string(gamma)}
   };
 
-  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker;
+  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{{ObjInfo::kRegression, true}};
   GenericParameter generic_param(CreateEmptyGenericParam(0));
   hist_maker.Configure(args, &generic_param);
 
@@ -394,7 +395,7 @@ void UpdateTree(HostDeviceVector<GradientPair>* gpair, DMatrix* dmat,
       {"sampling_method", sampling_method},
   };
 
-  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker;
+  tree::GPUHistMakerSpecialised<GradientPairPrecise> hist_maker{{ObjInfo::kRegression, true}};
   GenericParameter generic_param(CreateEmptyGenericParam(0));
   hist_maker.Configure(args, &generic_param);
 
@@ -539,7 +540,8 @@ TEST(GpuHist, ExternalMemoryWithSampling) {
 
 TEST(GpuHist, ConfigIO) {
   GenericParameter generic_param(CreateEmptyGenericParam(0));
-  std::unique_ptr<TreeUpdater> updater {TreeUpdater::Create("grow_gpu_hist", &generic_param) };
+  std::unique_ptr<TreeUpdater> updater{
+      TreeUpdater::Create("grow_gpu_hist", &generic_param, {ObjInfo::kRegression, true})};
   updater->Configure(Args{});
 
   Json j_updater { Object() };

--- a/tests/cpp/tree/test_histmaker.cc
+++ b/tests/cpp/tree/test_histmaker.cc
@@ -34,7 +34,8 @@ TEST(GrowHistMaker, InteractionConstraint) {
     RegTree tree;
     tree.param.num_feature = kCols;
 
-    std::unique_ptr<TreeUpdater> updater { TreeUpdater::Create("grow_histmaker", &param) };
+    std::unique_ptr<TreeUpdater> updater{
+        TreeUpdater::Create("grow_histmaker", &param, {ObjInfo::kRegression, true})};
     updater->Configure(Args{
         {"interaction_constraints", "[[0, 1]]"},
         {"num_feature", std::to_string(kCols)}});
@@ -51,7 +52,8 @@ TEST(GrowHistMaker, InteractionConstraint) {
     RegTree tree;
     tree.param.num_feature = kCols;
 
-    std::unique_ptr<TreeUpdater> updater { TreeUpdater::Create("grow_histmaker", &param) };
+    std::unique_ptr<TreeUpdater> updater{
+        TreeUpdater::Create("grow_histmaker", &param, {ObjInfo::kRegression, true})};
     updater->Configure(Args{{"num_feature", std::to_string(kCols)}});
     updater->Update(&gradients, p_dmat.get(), {&tree});
 

--- a/tests/cpp/tree/test_prune.cc
+++ b/tests/cpp/tree/test_prune.cc
@@ -38,7 +38,8 @@ TEST(Updater, Prune) {
   tree.param.UpdateAllowUnknown(cfg);
   std::vector<RegTree*> trees {&tree};
   // prepare pruner
-  std::unique_ptr<TreeUpdater> pruner(TreeUpdater::Create("prune", &lparam));
+  std::unique_ptr<TreeUpdater> pruner(
+      TreeUpdater::Create("prune", &lparam, {ObjInfo::kRegression, true}));
   pruner->Configure(cfg);
 
   // loss_chg < min_split_loss;

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -28,7 +28,7 @@ class QuantileHistMock : public QuantileHistMaker {
 
     BuilderMock(const TrainParam &param, std::unique_ptr<TreeUpdater> pruner,
                 DMatrix const *fmat)
-        : RealImpl(1, param, std::move(pruner), fmat) {}
+        : RealImpl(1, param, std::move(pruner), fmat, {ObjInfo::kRegression, true}) {}
 
    public:
     void TestInitData(const GHistIndexMatrix& gmat,
@@ -230,7 +230,7 @@ class QuantileHistMock : public QuantileHistMaker {
   explicit QuantileHistMock(
       const std::vector<std::pair<std::string, std::string> >& args,
       const bool single_precision_histogram = false, bool batch = true) :
-      cfg_{args} {
+      QuantileHistMaker{{ObjInfo::kRegression, true}}, cfg_{args} {
     QuantileHistMaker::Configure(args);
     dmat_ = RandomDataGenerator(kNRows, kNCols, 0.8).Seed(3).GenerateDMatrix();
     if (single_precision_histogram) {

--- a/tests/cpp/tree/test_refresh.cc
+++ b/tests/cpp/tree/test_refresh.cc
@@ -32,7 +32,8 @@ TEST(Updater, Refresh) {
   auto lparam = CreateEmptyGenericParam(GPUIDX);
   tree.param.UpdateAllowUnknown(cfg);
   std::vector<RegTree*> trees {&tree};
-  std::unique_ptr<TreeUpdater> refresher(TreeUpdater::Create("refresh", &lparam));
+  std::unique_ptr<TreeUpdater> refresher(
+      TreeUpdater::Create("refresh", &lparam, {ObjInfo::kRegression, true}));
 
   tree.ExpandNode(0, 2, 0.2f, false, 0.0, 0.2f, 0.8f, 0.0f, 0.0f,
                   /*left_sum=*/0.0f, /*right_sum=*/0.0f);

--- a/tests/cpp/tree/test_tree_stat.cc
+++ b/tests/cpp/tree/test_tree_stat.cc
@@ -23,7 +23,7 @@ class UpdaterTreeStatTest : public ::testing::Test {
   void RunTest(std::string updater) {
     auto tparam = CreateEmptyGenericParam(0);
     auto up = std::unique_ptr<TreeUpdater>{
-        TreeUpdater::Create(updater, &tparam)};
+        TreeUpdater::Create(updater, &tparam, {ObjInfo::kRegression, true})};
     up->Configure(Args{});
     RegTree tree;
     tree.param.num_feature = kCols;


### PR DESCRIPTION
Stacked on https://github.com/dmlc/xgboost/pull/7385 .

This PR passes task into metric evaluation.  For general metrics like AUC, this provides
robust dispatching instead of relying on checking the shape of meta info along with error
checking.