### PR TITLE
Change shebang used in CLI demo.

### DIFF
--- a/demo/CLI/binary_classification/mapfeat.py
+++ b/demo/CLI/binary_classification/mapfeat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 def loadfmap( fname ):
     fmap = {}

--- a/demo/CLI/binary_classification/mknfold.py
+++ b/demo/CLI/binary_classification/mknfold.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+
 import sys
 import random
 
@@ -26,4 +27,3 @@ for l in fi:
 fi.close()
 ftr.close()
 fte.close()
-

--- a/demo/CLI/regression/mapfeat.py
+++ b/demo/CLI/regression/mapfeat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 fo = open('machine.txt', 'w')
 cnt = 6

--- a/demo/CLI/regression/mknfold.py
+++ b/demo/CLI/regression/mknfold.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+
 import sys
 import random
 

--- a/demo/CLI/yearpredMSD/csv2libsvm.py
+++ b/demo/CLI/yearpredMSD/csv2libsvm.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 fo = open(sys.argv[2], 'w')
 


### PR DESCRIPTION
Change from system Python to environment python3.  For Ubuntu 20.04, only `python3` is
available and there's no `python`.  So at least `python3` is consistent with Python
virtual env, Ubuntu and anaconda.

Related https://github.com/dmlc/xgboost/issues/7384 .