### PR TITLE
Handle `OMP_THREAD_LIMIT` in environment.

### DIFF
--- a/R-package/R/xgboost.R
+++ b/R-package/R/xgboost.R
@@ -9,8 +9,8 @@ xgboost <- function(data = NULL, label = NULL, missing = NA, weight = NULL,
                     early_stopping_rounds = NULL, maximize = NULL,
                     save_period = NULL, save_name = "xgboost.model",
                     xgb_model = NULL, callbacks = list(), ...) {
-
-  dtrain <- xgb.get.DMatrix(data, label, missing, weight, nthread = params$nthread)
+  merged <- check.booster.params(params, ...)
+  dtrain <- xgb.get.DMatrix(data, label, missing, weight, nthread = merged$nthread)
 
   watchlist <- list(train = dtrain)
 

--- a/src/common/threading_utils.h
+++ b/src/common/threading_utils.h
@@ -24,7 +24,7 @@ inline int32_t omp_get_thread_limit() __GOMP_NOTHROW { return 1; }  // NOLINT
 // MSVC doesn't implement the thread limit.
 #if defined(_OPENMP) && defined(_MSC_VER)
 extern "C" {
-inline int32_t omp_get_thread_limit() __GOMP_NOTHROW { return omp_get_max_threads(); }  // NOLINT
+inline int32_t omp_get_thread_limit() { return omp_get_max_threads(); }  // NOLINT
 }
 #endif  // defined(_MSC_VER)
 

--- a/src/common/threading_utils.h
+++ b/src/common/threading_utils.h
@@ -24,7 +24,7 @@ inline int32_t omp_get_thread_limit() __GOMP_NOTHROW { return 1; }  // NOLINT
 // MSVC doesn't implement the thread limit.
 #if defined(_OPENMP) && defined(_MSC_VER)
 extern "C" {
-inline int32_t omp_get_thread_limit() { return omp_get_max_threads(); }  // NOLINT
+inline int32_t omp_get_thread_limit() { return std::numeric_limit<int32_t>::max(); }  // NOLINT
 }
 #endif  // defined(_MSC_VER)
 

--- a/src/common/threading_utils.h
+++ b/src/common/threading_utils.h
@@ -10,6 +10,7 @@
 #include <dmlc/omp.h>
 
 #include <algorithm>
+#include <limits>
 #include <type_traits>  // std::is_signed
 #include <vector>
 
@@ -24,7 +25,7 @@ inline int32_t omp_get_thread_limit() __GOMP_NOTHROW { return 1; }  // NOLINT
 // MSVC doesn't implement the thread limit.
 #if defined(_OPENMP) && defined(_MSC_VER)
 extern "C" {
-inline int32_t omp_get_thread_limit() { return std::numeric_limit<int32_t>::max(); }  // NOLINT
+inline int32_t omp_get_thread_limit() { return std::numeric_limits<int32_t>::max(); }  // NOLINT
 }
 #endif  // defined(_MSC_VER)
 
@@ -169,7 +170,7 @@ struct Sched {
 };
 
 template <typename Index, typename Func>
-void ParallelFor(Index size, size_t n_threads, Sched sched, Func fn) {
+void ParallelFor(Index size, int32_t n_threads, Sched sched, Func fn) {
 #if defined(_MSC_VER)
   // msvc doesn't support unsigned integer as openmp index.
   using OmpInd = std::conditional_t<std::is_signed<Index>::value, Index, omp_ulong>;

--- a/tests/python/test_openmp.py
+++ b/tests/python/test_openmp.py
@@ -1,6 +1,11 @@
-# -*- coding: utf-8 -*-
+from multiprocessing import Process, Queue
+import os
+
 import xgboost as xgb
 import numpy as np
+import pytest
+
+import testing as tm
 
 
 class TestOMP:
@@ -71,3 +76,29 @@ class TestOMP:
         assert auc_1 == auc_2 == auc_3
         assert np.array_equal(auc_1, auc_2)
         assert np.array_equal(auc_1, auc_3)
+
+    @pytest.mark.skipif(**tm.no_sklearn())
+    def test_with_omp_thread_limit(self):
+        def test_fn(q: Queue, limit: int):
+            from sklearn.datasets import load_iris
+            from sklearn.metrics import roc_auc_score
+            os.environ["OMP_THREAD_LIMIT"] = str(limit)
+            X, y = load_iris(return_X_y=True)
+            Xy = xgb.DMatrix(X, y, nthread=16)
+            booster = xgb.train({"num_class": 3, "objective": "multi:softprob"}, Xy, num_boost_round=8)
+            score = booster.predict(Xy)
+            print(y.shape, score.shape)
+            auc = roc_auc_score(y, score, average="weighted", multi_class="ovr")
+            q.put(auc)
+
+        queue = Queue()
+        processes = []
+        for i in (1, 2, 16):
+            p = Process(target=test_fn, args=(queue, i))
+            p.start()
+            processes.append(p)
+
+        for p in processes:
+            p.join()
+            score = queue.get()
+            print("score:", score)

--- a/tests/python/with_omp_limit.py
+++ b/tests/python/with_omp_limit.py
@@ -1,0 +1,26 @@
+import os
+import xgboost as xgb
+from sklearn.datasets import make_classification
+from sklearn.metrics import roc_auc_score
+import sys
+
+
+def test_fn(output_path: str):
+    X, y = make_classification(
+        n_samples=200, n_features=32, n_classes=3, n_informative=8
+    )
+    Xy = xgb.DMatrix(X, y, nthread=16)
+    booster = xgb.train(
+        {"num_class": 3, "objective": "multi:softprob", "n_jobs": 16},
+        Xy,
+        num_boost_round=8,
+    )
+    score = booster.predict(Xy)
+    auc = roc_auc_score(y, score, average="weighted", multi_class="ovr")
+    with open(output_path, "w") as fd:
+        fd.write(str(auc))
+
+
+if __name__ == "__main__":
+    out = sys.argv[1]
+    test_fn(out)

--- a/tests/python/with_omp_limit.py
+++ b/tests/python/with_omp_limit.py
@@ -5,7 +5,7 @@ from sklearn.metrics import roc_auc_score
 import sys
 
 
-def test_fn(output_path: str):
+def run_omp(output_path: str):
     X, y = make_classification(
         n_samples=200, n_features=32, n_classes=3, n_informative=8
     )
@@ -23,4 +23,4 @@ def test_fn(output_path: str):
 
 if __name__ == "__main__":
     out = sys.argv[1]
-    test_fn(out)
+    run_omp(out)


### PR DESCRIPTION
Fixes R win builder.

cc @hetong007 

Details, `OMP_THREAD_LIMIT` is an environment variable defined by OpenMP standard.  Users can set it to limit the number of threads in each thread group.  However, the `omp_get_max_threads()` function used by XGBoost is not affected by this env var.  So when the env var is set, XGBoost naively thought it can obtain `omp_get_max_threads()` number of threads, while the received number of threads is much smaller.

I ran it on win builder for a quick test https://win-builder.r-project.org/vCrjkrlXZE0l/00check.log we should run it again after backporting to 1.5 branch.