### PR TITLE
[backport] Move skl `eval_metric` and `early_stopping rounds`

### DIFF
--- a/demo/guide-python/custom_rmsle.py
+++ b/demo/guide-python/custom_rmsle.py
@@ -144,7 +144,7 @@ def py_rmsle(dtrain: xgb.DMatrix, dtest: xgb.DMatrix) -> Dict:
               dtrain=dtrain,
               num_boost_round=kBoostRound,
               obj=squared_log,
-              feval=rmsle,
+              custom_metric=rmsle,
               evals=[(dtrain, 'dtrain'), (dtest, 'dtest')],
               evals_result=results)
 

--- a/doc/tutorials/custom_metric_obj.rst
+++ b/doc/tutorials/custom_metric_obj.rst
@@ -2,6 +2,16 @@
 Custom Objective and Evaluation Metric
 ######################################
 
+**Contents**
+
+.. contents::
+  :backlinks: none
+  :local:
+
+********
+Overview
+********
+
 XGBoost is designed to be an extensible library.  One way to extend it is by providing our
 own objective function for training and corresponding metric for performance monitoring.
 This document introduces implementing a customized elementwise evaluation metric and
@@ -11,12 +21,8 @@ concepts should be readily applicable to other language bindings.
 .. note::
 
    * The ranking task does not support customized functions.
-   * The customized functions defined here are only applicable to single node training.
-     Distributed environment requires syncing with ``xgboost.rabit``, the interface is
-     subject to change hence beyond the scope of this tutorial.
-   * We also plan to improve the interface for multi-classes objective in the future.
 
-In the following sections, we will provide a step by step walk through of implementing
+In the following two sections, we will provide a step by step walk through of implementing
 ``Squared Log Error(SLE)`` objective function:
 
 .. math::
@@ -30,7 +36,10 @@ and its default metric ``Root Mean Squared Log Error(RMSLE)``:
 Although XGBoost has native support for said functions, using it for demonstration
 provides us the opportunity of comparing the result from our own implementation and the
 one from XGBoost internal for learning purposes.  After finishing this tutorial, we should
-be able to provide our own functions for rapid experiments.
+be able to provide our own functions for rapid experiments.  And at the end, we will
+provide some notes on non-identy link function along with examples of using custom metric
+and objective with `scikit-learn` interface.
+with scikit-learn interface.
 
 *****************************
 Customized Objective Function
@@ -125,12 +134,12 @@ We will be able to see XGBoost printing something like:
 
 .. code-block:: none
 
-    [0]	dtrain-PyRMSLE:1.37153	dtest-PyRMSLE:1.31487
-    [1]	dtrain-PyRMSLE:1.26619	dtest-PyRMSLE:1.20899
-    [2]	dtrain-PyRMSLE:1.17508	dtest-PyRMSLE:1.11629
-    [3]	dtrain-PyRMSLE:1.09836	dtest-PyRMSLE:1.03871
-    [4]	dtrain-PyRMSLE:1.03557	dtest-PyRMSLE:0.977186
-    [5]	dtrain-PyRMSLE:0.985783	dtest-PyRMSLE:0.93057
+    [0] dtrain-PyRMSLE:1.37153  dtest-PyRMSLE:1.31487
+    [1] dtrain-PyRMSLE:1.26619  dtest-PyRMSLE:1.20899
+    [2] dtrain-PyRMSLE:1.17508  dtest-PyRMSLE:1.11629
+    [3] dtrain-PyRMSLE:1.09836  dtest-PyRMSLE:1.03871
+    [4] dtrain-PyRMSLE:1.03557  dtest-PyRMSLE:0.977186
+    [5] dtrain-PyRMSLE:0.985783 dtest-PyRMSLE:0.93057
     ...
 
 Notice that the parameter ``disable_default_eval_metric`` is used to suppress the default metric
@@ -138,11 +147,164 @@ in XGBoost.
 
 For fully reproducible source code and comparison plots, see `custom_rmsle.py <https://github.com/dmlc/xgboost/tree/master/demo/guide-python/custom_rmsle.py>`_.
 
+*********************
+Reverse Link Function
+*********************
 
-******************************
-Multi-class objective function
-******************************
+When using builtin objective, the raw prediction is transformed according to the objective
+function.  When custom objective is provided XGBoost doesn't know its link function so the
+user is responsible for making the transformation for both objective and custom evaluation
+metric.  For objective with identiy link like ``squared error`` this is trivial, but for
+other link functions like log link or inverse link the difference is significant.
 
-A similar demo for multi-class objective function is also available, see
-`demo/guide-python/custom_softmax.py <https://github.com/dmlc/xgboost/tree/master/demo/guide-python/custom_softmax.py>`_
-for details.
+For the Python package, the behaviour of prediction can be controlled by the
+``output_margin`` parameter in ``predict`` function.  When using the ``custom_metric``
+parameter without a custom objective, the metric function will receive transformed
+prediction since the objective is defined by XGBoost. However, when custom objective is
+also provided along with that metric, then both the objective and custom metric will
+recieve raw prediction.  Following example provides a comparison between two different
+behavior with a multi-class classification model. Firstly we define 2 different Python
+metric functions implementing the same underlying metric for comparison,
+`merror_with_transform` is used when custom objective is also used, otherwise the simpler
+`merror` is preferred since XGBoost can perform the transformation itself.
+
+.. code-block:: python
+
+    import xgboost as xgb
+    import numpy as np
+
+    def merror_with_transform(predt: np.ndarray, dtrain: xgb.DMatrix):
+        """Used when custom objective is supplied."""
+        y = dtrain.get_label()
+        n_classes = predt.size // y.shape[0]
+        # Like custom objective, the predt is untransformed leaf weight when custom objective
+        # is provided.
+
+        # With the use of `custom_metric` parameter in train function, custom metric receives
+        # raw input only when custom objective is also being used.  Otherwise custom metric
+        # will receive transformed prediction.
+        assert predt.shape == (d_train.num_row(), n_classes)
+        out = np.zeros(dtrain.num_row())
+        for r in range(predt.shape[0]):
+            i = np.argmax(predt[r])
+            out[r] = i
+
+        assert y.shape == out.shape
+
+        errors = np.zeros(dtrain.num_row())
+        errors[y != out] = 1.0
+        return 'PyMError', np.sum(errors) / dtrain.num_row()
+
+The above function is only needed when we want to use custom objective and XGBoost doesn't
+know how to transform the prediction.  The normal implementation for multi-class error
+function is:
+
+.. code-block:: python
+
+    def merror(predt: np.ndarray, dtrain: xgb.DMatrix):
+        """Used when there's no custom objective."""
+        # No need to do transform, XGBoost handles it internally.
+        errors = np.zeros(dtrain.num_row())
+        errors[y != out] = 1.0
+        return 'PyMError', np.sum(errors) / dtrain.num_row()
+
+
+Next we need the custom softprob objective:
+
+.. code-block:: python
+
+    def softprob_obj(predt: np.ndarray, data: xgb.DMatrix):
+        """Loss function.  Computing the gradient and approximated hessian (diagonal).
+        Reimplements the `multi:softprob` inside XGBoost.
+        """
+
+        # Full implementation is available in the Python demo script linked below
+        ...
+
+        return grad, hess
+
+Lastly we can train the model using ``obj`` and ``custom_metric`` parameters:
+
+.. code-block:: python
+
+    Xy = xgb.DMatrix(X, y)
+    booster = xgb.train(
+        {"num_class": kClasses, "disable_default_eval_metric": True},
+        m,
+        num_boost_round=kRounds,
+        obj=softprob_obj,
+        custom_metric=merror_with_transform,
+        evals_result=custom_results,
+        evals=[(m, "train")],
+    )
+
+Or if you don't need the custom objective and just want to supply a metric that's not
+available in XGBoost:
+
+.. code-block:: python
+
+    booster = xgb.train(
+        {
+            "num_class": kClasses,
+            "disable_default_eval_metric": True,
+            "objective": "multi:softmax",
+        },
+        m,
+        num_boost_round=kRounds,
+        # Use a simpler metric implementation.
+        custom_metric=merror,
+        evals_result=custom_results,
+        evals=[(m, "train")],
+    )
+
+We use ``multi:softmax`` to illustrate the differences of transformed prediction.  With
+``softprob`` the output prediction array has shape ``(n_samples, n_classes)`` while for
+``softmax`` it's ``(n_samples, )``. A demo for multi-class objective function is also
+available at `demo/guide-python/custom_softmax.py
+<https://github.com/dmlc/xgboost/tree/master/demo/guide-python/custom_softmax.py>`_
+
+
+**********************
+Scikit-Learn Interface
+**********************
+
+
+The scikit-learn interface of XGBoost has some utilities to improve the integration with
+standard scikit-learn functions.  For instance, after XGBoost 1.5.1 users can use the cost
+function (not scoring functions) from scikit-learn out of the box:
+
+.. code-block:: python
+
+    from sklearn.datasets import load_diabetes
+    from sklearn.metrics import mean_absolute_error
+    X, y = load_diabetes(return_X_y=True)
+    reg = xgb.XGBRegressor(
+        tree_method="hist",
+        eval_metric=mean_absolute_error,
+    )
+    reg.fit(X, y, eval_set=[(X, y)])
+
+Also, for custom objective function, users can define the objective without having to
+access ``DMatrix``:
+
+.. code-block:: python
+
+    def softprob_obj(labels: np.ndarray, predt: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        rows = labels.shape[0]
+        grad = np.zeros((rows, classes), dtype=float)
+        hess = np.zeros((rows, classes), dtype=float)
+        eps = 1e-6
+        for r in range(predt.shape[0]):
+            target = labels[r]
+            p = softmax(predt[r, :])
+            for c in range(predt.shape[1]):
+                g = p[c] - 1.0 if c == target else p[c]
+                h = max((2.0 * p[c] * (1.0 - p[c])).item(), eps)
+                grad[r, c] = g
+                hess[r, c] = h
+
+        grad = grad.reshape((rows * classes, 1))
+        hess = hess.reshape((rows * classes, 1))
+        return grad, hess
+
+    clf = xgb.XGBClassifier(tree_method="hist", objective=softprob_obj)

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1713,7 +1713,7 @@ class Booster(object):
                                                c_array(ctypes.c_float, hess),
                                                c_bst_ulong(len(grad))))
 
-    def eval_set(self, evals, iteration=0, feval=None):
+    def eval_set(self, evals, iteration=0, feval=None, output_margin=True):
         # pylint: disable=invalid-name
         """Evaluate a set of data.
 
@@ -1741,24 +1741,30 @@ class Booster(object):
         dmats = c_array(ctypes.c_void_p, [d[0].handle for d in evals])
         evnames = c_array(ctypes.c_char_p, [c_str(d[1]) for d in evals])
         msg = ctypes.c_char_p()
-        _check_call(_LIB.XGBoosterEvalOneIter(self.handle,
-                                              ctypes.c_int(iteration),
-                                              dmats, evnames,
-                                              c_bst_ulong(len(evals)),
-                                              ctypes.byref(msg)))
+        _check_call(
+            _LIB.XGBoosterEvalOneIter(
+                self.handle,
+                ctypes.c_int(iteration),
+                dmats,
+                evnames,
+                c_bst_ulong(len(evals)),
+                ctypes.byref(msg),
+            )
+        )
         res = msg.value.decode()  # pylint: disable=no-member
         if feval is not None:
             for dmat, evname in evals:
-                feval_ret = feval(self.predict(dmat, training=False,
-                                               output_margin=True), dmat)
+                feval_ret = feval(
+                    self.predict(dmat, training=False, output_margin=output_margin), dmat
+                )
                 if isinstance(feval_ret, list):
                     for name, val in feval_ret:
                         # pylint: disable=consider-using-f-string
-                        res += '\t%s-%s:%f' % (evname, name, val)
+                        res += "\t%s-%s:%f" % (evname, name, val)
                 else:
                     name, val = feval_ret
                     # pylint: disable=consider-using-f-string
-                    res += '\t%s-%s:%f' % (evname, name, val)
+                    res += "\t%s-%s:%f" % (evname, name, val)
         return res
 
     def eval(self, data, name='eval', iteration=0):

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -4,8 +4,12 @@
 """Training Library containing training routines."""
 import warnings
 import copy
+from typing import Optional, List
+
 import numpy as np
 from .core import Booster, XGBoostError, _get_booster_layer_trees
+from .core import _deprecate_positional_args
+from .core import Objective, Metric
 from .compat import (SKLEARN_INSTALLED, XGBStratifiedKFold)
 from . import callback
 
@@ -38,21 +42,48 @@ def _is_new_callback(callbacks):
                for c in callbacks) or not callbacks
 
 
-def _train_internal(params, dtrain,
-                    num_boost_round=10, evals=(),
-                    obj=None, feval=None,
-                    xgb_model=None, callbacks=None,
-                    evals_result=None, maximize=None,
-                    verbose_eval=None, early_stopping_rounds=None):
+def _configure_custom_metric(
+    feval: Optional[Metric], custom_metric: Optional[Metric]
+) -> Optional[Metric]:
+    if feval is not None:
+        link = "https://xgboost.readthedocs.io/en/latest/tutorials/custom_metric_obj.html"
+        warnings.warn(
+            "`feval` is deprecated, use `custom_metric` instead.  They have "
+            "different behavior when custom objective is also used."
+            f"See {link} for details on the `custom_metric`."
+        )
+    if feval is not None and custom_metric is not None:
+        raise ValueError(
+            "Bost `feval` and `custom_metric` are supplied.  Use `custom_metric` instead."
+        )
+    eval_metric = custom_metric if custom_metric is not None else feval
+    return eval_metric
+
+
+def _train_internal(
+    params,
+    dtrain,
+    num_boost_round=10,
+    evals=(),
+    obj=None,
+    feval=None,
+    custom_metric=None,
+    xgb_model=None,
+    callbacks=None,
+    evals_result=None,
+    maximize=None,
+    verbose_eval=None,
+    early_stopping_rounds=None,
+):
     """internal training function"""
     callbacks = [] if callbacks is None else copy.copy(callbacks)
+    metric_fn = _configure_custom_metric(feval, custom_metric)
     evals = list(evals)
 
     bst = Booster(params, [dtrain] + [d[0] for d in evals])
 
     if xgb_model is not None:
-        bst = Booster(params, [dtrain] + [d[0] for d in evals],
-                      model_file=xgb_model)
+        bst = Booster(params, [dtrain] + [d[0] for d in evals], model_file=xgb_model)
 
     start_iteration = 0
 
@@ -66,12 +97,20 @@ def _train_internal(params, dtrain,
         if early_stopping_rounds:
             callbacks.append(callback.EarlyStopping(
                 rounds=early_stopping_rounds, maximize=maximize))
-        callbacks = callback.CallbackContainer(callbacks, metric=feval)
+        callbacks = callback.CallbackContainer(
+            callbacks,
+            metric=metric_fn,
+            # For old `feval` parameter, the behavior is unchanged.  For the new
+            # `custom_metric`, it will receive proper prediction result when custom objective
+            # is not used.
+            output_margin=callable(obj) or metric_fn is feval,
+        )
     else:
         callbacks = _configure_deprecated_callbacks(
             verbose_eval, early_stopping_rounds, maximize, start_iteration,
             num_boost_round, feval, evals_result, callbacks,
-            show_stdv=False, cvfolds=None)
+            show_stdv=False, cvfolds=None
+        )
 
     bst = callbacks.before_training(bst)
 
@@ -112,9 +151,23 @@ def _train_internal(params, dtrain,
     return bst.copy()
 
 
-def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
-          maximize=None, early_stopping_rounds=None, evals_result=None,
-          verbose_eval=True, xgb_model=None, callbacks=None):
+@_deprecate_positional_args
+def train(
+    params,
+    dtrain,
+    num_boost_round=10,
+    *,
+    evals=(),
+    obj: Optional[Objective] = None,
+    feval=None,
+    maximize=None,
+    early_stopping_rounds=None,
+    evals_result=None,
+    verbose_eval=True,
+    xgb_model=None,
+    callbacks=None,
+    custom_metric: Optional[Metric] = None,
+):
     # pylint: disable=too-many-statements,too-many-branches, attribute-defined-outside-init
     """Train a booster with given parameters.
 
@@ -129,10 +182,13 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
     evals: list of pairs (DMatrix, string)
         List of validation sets for which metrics will evaluated during training.
         Validation metrics will help us track the performance of the model.
-    obj : function
-        Customized objective function.
-    feval : function
-        Customized evaluation function.
+    obj
+        Custom objective function.  See `Custom Objective
+        <https://xgboost.readthedocs.io/en/latest/tutorials/custom_metric_obj.html>`_ for
+        details.
+    feval :
+        .. deprecated:: 1.5.1
+            Use `custom_metric` instead.
     maximize : bool
         Whether to maximize feval.
     early_stopping_rounds: int
@@ -181,23 +237,37 @@ def train(params, dtrain, num_boost_round=10, evals=(), obj=None, feval=None,
 
             [xgb.callback.LearningRateScheduler(custom_rates)]
 
+    custom_metric:
+
+        .. versionadded 1.5.1
+
+        Custom metric function.  See `Custom Metric
+        <https://xgboost.readthedocs.io/en/latest/tutorials/custom_metric_obj.html>`_ for
+        details.
+
     Returns
     -------
     Booster : a trained booster model
     """
-    bst = _train_internal(params, dtrain,
-                          num_boost_round=num_boost_round,
-                          evals=evals,
-                          obj=obj, feval=feval,
-                          xgb_model=xgb_model, callbacks=callbacks,
-                          verbose_eval=verbose_eval,
-                          evals_result=evals_result,
-                          maximize=maximize,
-                          early_stopping_rounds=early_stopping_rounds)
+    bst = _train_internal(
+        params,
+        dtrain,
+        num_boost_round=num_boost_round,
+        evals=evals,
+        obj=obj,
+        feval=feval,
+        xgb_model=xgb_model,
+        callbacks=callbacks,
+        verbose_eval=verbose_eval,
+        evals_result=evals_result,
+        maximize=maximize,
+        early_stopping_rounds=early_stopping_rounds,
+        custom_metric=custom_metric,
+    )
     return bst
 
 
-class CVPack(object):
+class CVPack:
     """"Auxiliary datastruct to hold one fold of CV."""
     def __init__(self, dtrain, dtest, param):
         """"Initialize the CVPack"""
@@ -215,9 +285,9 @@ class CVPack(object):
         """"Update the boosters for one iteration"""
         self.bst.update(self.dtrain, iteration, fobj)
 
-    def eval(self, iteration, feval):
+    def eval(self, iteration, feval, output_margin):
         """"Evaluate the CVPack for one iteration."""
-        return self.bst.eval_set(self.watchlist, iteration, feval)
+        return self.bst.eval_set(self.watchlist, iteration, feval, output_margin)
 
 
 class _PackedBooster:
@@ -229,9 +299,9 @@ class _PackedBooster:
         for fold in self.cvfolds:
             fold.update(iteration, obj)
 
-    def eval(self, iteration, feval):
+    def eval(self, iteration, feval, output_margin):
         '''Iterate through folds for eval'''
-        result = [f.eval(iteration, feval) for f in self.cvfolds]
+        result = [f.eval(iteration, feval, output_margin) for f in self.cvfolds]
         return result
 
     def set_attr(self, **kwargs):
@@ -368,9 +438,10 @@ def mknfold(dall, nfold, param, seed, evals=(), fpreproc=None, stratified=False,
 
 
 def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None,
-       metrics=(), obj=None, feval=None, maximize=None, early_stopping_rounds=None,
+       metrics=(), obj: Optional[Objective] = None,
+       feval=None, maximize=None, early_stopping_rounds=None,
        fpreproc=None, as_pandas=True, verbose_eval=None, show_stdv=True,
-       seed=0, callbacks=None, shuffle=True):
+       seed=0, callbacks=None, shuffle=True, custom_metric: Optional[Metric] = None):
     # pylint: disable = invalid-name
     """Cross-validation with given parameters.
 
@@ -395,10 +466,15 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None
         indices to be used as the testing samples for the ``n`` th fold.
     metrics : string or list of strings
         Evaluation metrics to be watched in CV.
-    obj : function
-        Custom objective function.
+    obj :
+
+        Custom objective function.  See `Custom Objective
+        <https://xgboost.readthedocs.io/en/latest/tutorials/custom_metric_obj.html>`_ for
+        details.
+
     feval : function
-        Custom evaluation function.
+        .. deprecated:: 1.5.1
+            Use `custom_metric` instead.
     maximize : bool
         Whether to maximize feval.
     early_stopping_rounds: int
@@ -435,6 +511,13 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None
             [xgb.callback.LearningRateScheduler(custom_rates)]
     shuffle : bool
         Shuffle data before creating folds.
+    custom_metric :
+
+        .. versionadded 1.5.1
+
+        Custom metric function.  See `Custom Metric
+        <https://xgboost.readthedocs.io/en/latest/tutorials/custom_metric_obj.html>`_ for
+        details.
 
     Returns
     -------
@@ -466,6 +549,8 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None
     cvfolds = mknfold(dtrain, nfold, params, seed, metrics, fpreproc,
                       stratified, folds, shuffle)
 
+    metric_fn = _configure_custom_metric(feval, custom_metric)
+
     # setup callbacks
     callbacks = [] if callbacks is None else callbacks
     is_new_callback = _is_new_callback(callbacks)
@@ -481,12 +566,18 @@ def cv(params, dtrain, num_boost_round=10, nfold=3, stratified=False, folds=None
             callbacks.append(
                 callback.EarlyStopping(rounds=early_stopping_rounds, maximize=maximize)
             )
-        callbacks = callback.CallbackContainer(callbacks, metric=feval, is_cv=True)
+        callbacks = callback.CallbackContainer(
+            callbacks,
+            metric=feval,
+            is_cv=True,
+            output_margin=callable(obj) or metric_fn is feval,
+        )
     else:
         callbacks = _configure_deprecated_callbacks(
             verbose_eval, early_stopping_rounds, maximize, 0,
             num_boost_round, feval, None, callbacks,
             show_stdv=show_stdv, cvfolds=cvfolds)
+
     booster = _PackedBooster(cvfolds)
     callbacks.before_training(booster)
 

--- a/tests/python/test_early_stopping.py
+++ b/tests/python/test_early_stopping.py
@@ -7,7 +7,6 @@ rng = np.random.RandomState(1994)
 
 
 class TestEarlyStopping:
-
     @pytest.mark.skipif(**tm.no_sklearn())
     def test_early_stopping_nonparallel(self):
         from sklearn.datasets import load_digits

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -1661,11 +1661,16 @@ class TestDaskCallbacks:
 
         valid_X, valid_y = load_breast_cancer(return_X_y=True)
         valid_X, valid_y = da.from_array(valid_X), da.from_array(valid_y)
-        cls = xgb.dask.DaskXGBClassifier(objective='binary:logistic', tree_method='hist',
-                                         n_estimators=1000)
+        cls = xgb.dask.DaskXGBClassifier(
+            objective='binary:logistic',
+            tree_method='hist',
+            n_estimators=1000,
+            eval_metric=tm.eval_error_metric_skl
+        )
         cls.client = client
-        cls.fit(X, y, early_stopping_rounds=early_stopping_rounds,
-                eval_set=[(valid_X, valid_y)], eval_metric=tm.eval_error_metric)
+        cls.fit(
+            X, y, early_stopping_rounds=early_stopping_rounds, eval_set=[(valid_X, valid_y)]
+        )
         booster = cls.get_booster()
         dump = booster.get_dump(dump_format='json')
         assert len(dump) - booster.best_iteration == early_stopping_rounds + 1

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -1275,3 +1275,76 @@ def test_prediction_config():
 
     reg.set_params(booster="gblinear")
     assert reg._can_use_inplace_predict() is False
+
+
+def test_evaluation_metric():
+    from sklearn.datasets import load_diabetes, load_digits
+    from sklearn.metrics import mean_absolute_error
+    X, y = load_diabetes(return_X_y=True)
+    n_estimators = 16
+
+    with tm.captured_output() as (out, err):
+        reg = xgb.XGBRegressor(
+            tree_method="hist",
+            eval_metric=mean_absolute_error,
+            n_estimators=n_estimators,
+        )
+        reg.fit(X, y, eval_set=[(X, y)])
+        lines = out.getvalue().strip().split('\n')
+
+    assert len(lines) == n_estimators
+    for line in lines:
+        assert line.find("mean_absolute_error") != -1
+
+    def metric(predt: np.ndarray, Xy: xgb.DMatrix):
+        y = Xy.get_label()
+        return "m", np.abs(predt - y).sum()
+
+    with pytest.warns(UserWarning):
+        reg = xgb.XGBRegressor(
+            tree_method="hist",
+            n_estimators=1,
+        )
+        reg.fit(X, y, eval_set=[(X, y)], eval_metric=metric)
+
+    def merror(y_true: np.ndarray, predt: np.ndarray):
+        n_samples = y_true.shape[0]
+        assert n_samples == predt.size
+        errors = np.zeros(y_true.shape[0])
+        errors[y != predt] = 1.0
+        return np.sum(errors) / n_samples
+
+    X, y = load_digits(n_class=10, return_X_y=True)
+
+    clf = xgb.XGBClassifier(
+        use_label_encoder=False,
+        tree_method="hist",
+        eval_metric=merror,
+        n_estimators=16,
+        objective="multi:softmax"
+    )
+    clf.fit(X, y, eval_set=[(X, y)])
+    custom = clf.evals_result()
+
+    clf = xgb.XGBClassifier(
+        use_label_encoder=False,
+        tree_method="hist",
+        eval_metric="merror",
+        n_estimators=16,
+        objective="multi:softmax"
+    )
+    clf.fit(X, y, eval_set=[(X, y)])
+    internal = clf.evals_result()
+    np.testing.assert_allclose(
+        custom["validation_0"]["merror"], internal["validation_0"]["merror"]
+    )
+
+    clf = xgb.XGBRFClassifier(
+        use_label_encoder=False,
+        tree_method="hist", n_estimators=16,
+        objective=tm.softprob_obj(10),
+        eval_metric=merror,
+    )
+    with pytest.raises(AssertionError):
+        # shape check inside the `merror` function
+        clf.fit(X, y, eval_set=[(X, y)])

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -338,6 +338,7 @@ def non_increasing(L, tolerance=1e-4):
 
 
 def eval_error_metric(predt, dtrain: xgb.DMatrix):
+    """Evaluation metric for xgb.train"""
     label = dtrain.get_label()
     r = np.zeros(predt.shape)
     gt = predt > 0.5
@@ -347,6 +348,16 @@ def eval_error_metric(predt, dtrain: xgb.DMatrix):
     le = predt <= 0.5
     r[le] = label[le]
     return 'CustomErr', np.sum(r)
+
+
+def eval_error_metric_skl(y_true: np.ndarray, y_score: np.ndarray) -> float:
+    """Evaluation metric that looks like metrics provided by sklearn."""
+    r = np.zeros(y_score.shape)
+    gt = y_score > 0.5
+    r[gt] = 1 - y_true[gt]
+    le = y_score <= 0.5
+    r[le] = y_true[le]
+    return np.sum(r)
 
 
 def softmax(x):


### PR DESCRIPTION
(#6751)

A new parameter `custom_metric` is added to `train` and `cv` to distinguish the behaviour from the old `feval`.  And `feval` is deprecated.  The new `custom_metric` receives transformed prediction when the built-in objective is used.  This enables XGBoost to use cost functions from other libraries like scikit-learn directly without going through the definition of the link function.

`eval_metric` and `early_stopping_rounds` in sklearn interface are moved from `fit` to `__init__` and is now saved as part of the scikit-learn model.  The old ones in `fit` function are now deprecated. The new `eval_metric` in `__init__` has the same new behaviour as `custom_metric`.

Added more detailed documents for the behaviour of custom objective and metric.