### PR TITLE
Fix external memory, gpu_hist and subsampling combination bug. (#7476)

### DIFF
--- a/src/tree/gpu_hist/gradient_based_sampler.cuh
+++ b/src/tree/gpu_hist/gradient_based_sampler.cuh
@@ -66,14 +66,12 @@ class UniformSampling : public SamplingStrategy {
 /*! \brief No sampling in external memory mode. */
 class ExternalMemoryUniformSampling : public SamplingStrategy {
  public:
-  ExternalMemoryUniformSampling(EllpackPageImpl const* page,
-                                size_t n_rows,
+  ExternalMemoryUniformSampling(size_t n_rows,
                                 BatchParam batch_param,
                                 float subsample);
   GradientBasedSample Sample(common::Span<GradientPair> gpair, DMatrix* dmat) override;
 
  private:
-  EllpackPageImpl const* original_page_;
   BatchParam batch_param_;
   float subsample_;
   std::unique_ptr<EllpackPageImpl> page_;
@@ -100,14 +98,12 @@ class GradientBasedSampling : public SamplingStrategy {
 /*! \brief Gradient-based sampling in external memory mode.. */
 class ExternalMemoryGradientBasedSampling : public SamplingStrategy {
  public:
-  ExternalMemoryGradientBasedSampling(EllpackPageImpl const* page,
-                                      size_t n_rows,
+  ExternalMemoryGradientBasedSampling(size_t n_rows,
                                       BatchParam batch_param,
                                       float subsample);
   GradientBasedSample Sample(common::Span<GradientPair> gpair, DMatrix* dmat) override;
 
  private:
-  EllpackPageImpl const* original_page_;
   BatchParam batch_param_;
   float subsample_;
   dh::caching_device_vector<float> threshold_;

--- a/tests/python-gpu/test_gpu_data_iterator.py
+++ b/tests/python-gpu/test_gpu_data_iterator.py
@@ -26,15 +26,14 @@ def test_gpu_single_batch() -> None:
 def test_gpu_data_iterator(
     n_samples_per_batch: int, n_features: int, n_batches: int, subsample: bool
 ) -> None:
-    subsample_rate = 0.5 if subsample else 1.0
     run_data_iterator(
-        n_samples_per_batch, n_features, n_batches, "gpu_hist", subsample_rate, True
+        n_samples_per_batch, n_features, n_batches, "gpu_hist", subsample, True
     )
     run_data_iterator(
-        n_samples_per_batch, n_features, n_batches, "gpu_hist", subsample_rate, False
+        n_samples_per_batch, n_features, n_batches, "gpu_hist", subsample, False
     )
 
 
 def test_cpu_data_iterator() -> None:
     """Make sure CPU algorithm can handle GPU inputs"""
-    run_data_iterator(1024, 2, 3, "approx", 1.0, True)
+    run_data_iterator(1024, 2, 3, "approx", False, True)

--- a/tests/python-gpu/test_gpu_data_iterator.py
+++ b/tests/python-gpu/test_gpu_data_iterator.py
@@ -7,7 +7,7 @@ import sys
 sys.path.append("tests/python")
 from test_data_iterator import SingleBatch, make_batches
 from test_data_iterator import test_single_batch as cpu_single_batch
-from test_data_iterator import run_data_iterator
+from test_data_iterator import run_data_iterator, run_data_iterator_subsample
 from testing import IteratorForTest, no_cupy
 
 
@@ -25,7 +25,10 @@ def test_gpu_data_iterator(
 ) -> None:
     run_data_iterator(n_samples_per_batch, n_features, n_batches, "gpu_hist", True)
     run_data_iterator(n_samples_per_batch, n_features, n_batches, "gpu_hist", False)
-
+    run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", True, 0.25, "gradient_based")
+    run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", False, 0.25, "gradient_based")
+    run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", True, 0.25, "uniform")
+    run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", False, 0.25, "uniform")
 
 def test_cpu_data_iterator() -> None:
     """Make sure CPU algorithm can handle GPU inputs"""

--- a/tests/python-gpu/test_gpu_data_iterator.py
+++ b/tests/python-gpu/test_gpu_data_iterator.py
@@ -7,7 +7,7 @@ import sys
 sys.path.append("tests/python")
 from test_data_iterator import SingleBatch, make_batches
 from test_data_iterator import test_single_batch as cpu_single_batch
-from test_data_iterator import run_data_iterator, run_data_iterator_subsample
+from test_data_iterator import run_data_iterator
 from testing import IteratorForTest, no_cupy
 
 
@@ -17,28 +17,24 @@ def test_gpu_single_batch() -> None:
 
 @pytest.mark.skipif(**no_cupy())
 @given(
-    strategies.integers(0, 1024), strategies.integers(1, 7), strategies.integers(0, 13)
+    strategies.integers(0, 1024),
+    strategies.integers(1, 7),
+    strategies.integers(0, 13),
+    strategies.booleans(),
 )
 @settings(deadline=None)
 def test_gpu_data_iterator(
-    n_samples_per_batch: int, n_features: int, n_batches: int
+    n_samples_per_batch: int, n_features: int, n_batches: int, subsample: bool
 ) -> None:
-    run_data_iterator(n_samples_per_batch, n_features, n_batches, "gpu_hist", True)
-    run_data_iterator(n_samples_per_batch, n_features, n_batches, "gpu_hist", False)
+    subsample_rate = 0.5 if subsample else 1.0
+    run_data_iterator(
+        n_samples_per_batch, n_features, n_batches, "gpu_hist", subsample_rate, True
+    )
+    run_data_iterator(
+        n_samples_per_batch, n_features, n_batches, "gpu_hist", subsample_rate, False
+    )
 
-@pytest.mark.skipif(**no_cupy())
-@given(
-    strategies.integers(0, 1024), strategies.integers(1, 7), strategies.integers(0, 13)
-)
-@settings(deadline=None)
-def test_gpu_data_iterator_subsample(
-    n_samples_per_batch: int, n_features: int, n_batches: int
-) -> None:
-    run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", True, 0.25, "gradient_based")
-    run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", False, 0.25, "gradient_based")
-    run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", True, 0.25, "uniform")
-    run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", False, 0.25, "uniform")
 
 def test_cpu_data_iterator() -> None:
     """Make sure CPU algorithm can handle GPU inputs"""
-    run_data_iterator(1024, 2, 3, "approx", True)
+    run_data_iterator(1024, 2, 3, "approx", 1.0, True)

--- a/tests/python-gpu/test_gpu_data_iterator.py
+++ b/tests/python-gpu/test_gpu_data_iterator.py
@@ -25,6 +25,15 @@ def test_gpu_data_iterator(
 ) -> None:
     run_data_iterator(n_samples_per_batch, n_features, n_batches, "gpu_hist", True)
     run_data_iterator(n_samples_per_batch, n_features, n_batches, "gpu_hist", False)
+
+@pytest.mark.skipif(**no_cupy())
+@given(
+    strategies.integers(0, 1024), strategies.integers(1, 7), strategies.integers(0, 13)
+)
+@settings(deadline=None)
+def test_gpu_data_iterator_subsample(
+    n_samples_per_batch: int, n_features: int, n_batches: int
+) -> None:
     run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", True, 0.25, "gradient_based")
     run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", False, 0.25, "gradient_based")
     run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", True, 0.25, "uniform")

--- a/tests/python/test_data_iterator.py
+++ b/tests/python/test_data_iterator.py
@@ -121,7 +121,11 @@ def run_data_iterator(
         rtol = 1e-1  # flaky
     else:
         # Model can be sensitive to quantiles, use 1e-2 to relax the test.
-        np.testing.assert_allclose(it_predt, arr_predt, rtol=1e-2)
+        # Increase tolerance according to subsample value
+        rtol = 1e-2
+        if subsample > 0.0 and subsample < 1.0:
+            rtol /= subsample
+        np.testing.assert_allclose(it_predt, arr_predt, rtol=rtol)
         rtol = 1e-6
 
     np.testing.assert_allclose(

--- a/tests/python/test_data_iterator.py
+++ b/tests/python/test_data_iterator.py
@@ -118,7 +118,8 @@ def run_data_iterator_subsample(
         rtol = 1e-1  # flaky
     else:
         # Model can be sensitive to quantiles, use 1e-2 to relax the test.
-        np.testing.assert_allclose(it_predt, arr_predt, rtol=1e-2)
+        # rtol=1e-2 makes test fail (because of subsampling) we use 5e-2
+        np.testing.assert_allclose(it_predt, arr_predt, rtol=5e-2)
         rtol = 1e-6
 
     np.testing.assert_allclose(

--- a/tests/python/test_data_iterator.py
+++ b/tests/python/test_data_iterator.py
@@ -73,8 +73,8 @@ def run_data_iterator(
 ) -> None:
     n_rounds = 2
     # The test is more difficult to pass if the subsample rate is smaller as the root_sum
-    # is accumulated in parallel, different number of entries in gradient vector causes
-    # floating error.
+    # is accumulated in parallel.  Reductions with different number of entries lead to
+    # different floating point errors.
     subsample_rate = 0.8 if subsample else 1.0
 
     it = IteratorForTest(

--- a/tests/python/test_data_iterator.py
+++ b/tests/python/test_data_iterator.py
@@ -1,7 +1,7 @@
 import xgboost as xgb
 from xgboost.data import SingleBatchInternalIter as SingleBatch
 import numpy as np
-from testing import IteratorForTest, mismatch_rate
+from testing import IteratorForTest
 from typing import Tuple, List
 import pytest
 from hypothesis import given, strategies, settings
@@ -129,11 +129,9 @@ def run_data_iterator(
     if tree_method != "gpu_hist":
         rtol = 1e-1  # flaky
     else:
-        # Model can be sensitive to quantiles, use both mismatch rate and floating point
-        # tolerance to relax the test.
-        rtol = 1e-4
-        mismatch = mismatch_rate(it_predt, arr_predt, rtol=rtol)
-        assert mismatch < 1e-2
+        # Model can be sensitive to quantiles, use 1e-2 to relax the test.
+        np.testing.assert_allclose(it_predt, arr_predt, rtol=1e-2)
+        rtol = 1e-6
 
     np.testing.assert_allclose(
         results_from_it["Train"]["rmse"],

--- a/tests/python/test_data_iterator.py
+++ b/tests/python/test_data_iterator.py
@@ -62,6 +62,69 @@ def test_single_batch(tree_method: str = "approx") -> None:
     from_np = xgb.train({"tree_method": tree_method}, Xy, num_boost_round=n_rounds)
     assert from_np.get_dump() == from_it.get_dump()
 
+def run_data_iterator_subsample(
+    n_samples_per_batch: int,
+    n_features: int,
+    n_batches: int,
+    tree_method: str,
+    use_cupy: bool,
+    subsample_value: float,
+) -> None:
+    n_rounds = 2
+
+    it = IteratorForTest(
+        *make_batches(n_samples_per_batch, n_features, n_batches, use_cupy)
+    )
+    if n_batches == 0:
+        with pytest.raises(ValueError, match="1 batch"):
+            Xy = xgb.DMatrix(it)
+        return
+
+    Xy = xgb.DMatrix(it)
+    assert Xy.num_row() == n_samples_per_batch * n_batches
+    assert Xy.num_col() == n_features
+
+    results_from_it: xgb.callback.EvaluationMonitor.EvalsLog = {}
+    from_it = xgb.train(
+        {"tree_method": tree_method, "max_depth": 2, 
+         "subsample": subsample_value },
+        Xy,
+        num_boost_round=n_rounds,
+        evals=[(Xy, "Train")],
+        evals_result=results_from_it,
+        verbose_eval=False,
+    )
+    it_predt = from_it.predict(Xy)
+
+    X, y = it.as_arrays()
+    Xy = xgb.DMatrix(X, y)
+    assert Xy.num_row() == n_samples_per_batch * n_batches
+    assert Xy.num_col() == n_features
+
+    results_from_arrays: xgb.callback.EvaluationMonitor.EvalsLog = {}
+    from_arrays = xgb.train(
+        {"tree_method": tree_method, "max_depth": 2, 
+         "subsample": subsample_value},
+        Xy,
+        num_boost_round=n_rounds,
+        evals=[(Xy, "Train")],
+        evals_result=results_from_arrays,
+        verbose_eval=False,
+    )
+    arr_predt = from_arrays.predict(Xy)
+
+    if tree_method != "gpu_hist":
+        rtol = 1e-1  # flaky
+    else:
+        # Model can be sensitive to quantiles, use 1e-2 to relax the test.
+        np.testing.assert_allclose(it_predt, arr_predt, rtol=1e-2)
+        rtol = 1e-6
+
+    np.testing.assert_allclose(
+        results_from_it["Train"]["rmse"],
+        results_from_arrays["Train"]["rmse"],
+        rtol=rtol,
+    )
 
 def run_data_iterator(
     n_samples_per_batch: int,
@@ -134,3 +197,4 @@ def test_data_iterator(
 ) -> None:
     run_data_iterator(n_samples_per_batch, n_features, n_batches, "approx", False)
     run_data_iterator(n_samples_per_batch, n_features, n_batches, "hist", False)
+    run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", False, 0.25)

--- a/tests/python/test_data_iterator.py
+++ b/tests/python/test_data_iterator.py
@@ -69,6 +69,7 @@ def run_data_iterator_subsample(
     tree_method: str,
     use_cupy: bool,
     subsample_value: float,
+    sampling_method: str,
 ) -> None:
     n_rounds = 2
 
@@ -87,7 +88,7 @@ def run_data_iterator_subsample(
     results_from_it: xgb.callback.EvaluationMonitor.EvalsLog = {}
     from_it = xgb.train(
         {"tree_method": tree_method, "max_depth": 2, 
-         "subsample": subsample_value },
+         "subsample": subsample_value, "sampling_method": sampling_method},
         Xy,
         num_boost_round=n_rounds,
         evals=[(Xy, "Train")],
@@ -104,7 +105,7 @@ def run_data_iterator_subsample(
     results_from_arrays: xgb.callback.EvaluationMonitor.EvalsLog = {}
     from_arrays = xgb.train(
         {"tree_method": tree_method, "max_depth": 2, 
-         "subsample": subsample_value},
+         "subsample": subsample_value, "sampling_method": sampling_method},
         Xy,
         num_boost_round=n_rounds,
         evals=[(Xy, "Train")],
@@ -197,4 +198,3 @@ def test_data_iterator(
 ) -> None:
     run_data_iterator(n_samples_per_batch, n_features, n_batches, "approx", False)
     run_data_iterator(n_samples_per_batch, n_features, n_batches, "hist", False)
-    run_data_iterator_subsample(n_samples_per_batch, n_features, n_batches, "gpu_hist", False, 0.25)

--- a/tests/python/test_data_iterator.py
+++ b/tests/python/test_data_iterator.py
@@ -120,13 +120,11 @@ def run_data_iterator(
     if tree_method != "gpu_hist":
         rtol = 1e-1  # flaky
     else:
-        # Model can be sensitive to quantiles, use 1e-2 to relax the test.
-        # Increase tolerance according to subsample value
-        rtol = 1e-2
-        if subsample > 0.0 and subsample < 1.0:
-            rtol /= subsample
-        np.testing.assert_allclose(it_predt, arr_predt, rtol=rtol)
-        rtol = 1e-6
+        # Model can be sensitive to quantiles, use both mismatch rate and floating point
+        # tolerance to relax the test.
+        rtol = 1e-4
+        mismatch = ((1.0 - it_predt / arr_predt) > rtol).sum() / it_predt.size
+        assert mismatch < 1e-2
 
     np.testing.assert_allclose(
         results_from_it["Train"]["rmse"],

--- a/tests/python/test_data_iterator.py
+++ b/tests/python/test_data_iterator.py
@@ -1,7 +1,7 @@
 import xgboost as xgb
 from xgboost.data import SingleBatchInternalIter as SingleBatch
 import numpy as np
-from testing import IteratorForTest
+from testing import IteratorForTest, mismatch_rate
 from typing import Tuple, List
 import pytest
 from hypothesis import given, strategies, settings
@@ -123,7 +123,7 @@ def run_data_iterator(
         # Model can be sensitive to quantiles, use both mismatch rate and floating point
         # tolerance to relax the test.
         rtol = 1e-4
-        mismatch = ((1.0 - it_predt / arr_predt) > rtol).sum() / it_predt.size
+        mismatch = mismatch_rate(it_predt, arr_predt, rtol=rtol)
         assert mismatch < 1e-2
 
     np.testing.assert_allclose(

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -362,6 +362,12 @@ def non_increasing(L, tolerance=1e-4):
     return all((y - x) < tolerance for x, y in zip(L, L[1:]))
 
 
+def mismatch_rate(a: np.ndarray, b: np.ndarray, rtol: float) -> float:
+    """Number of mismatching items. rtol is tolernace of relative error."""
+    assert a.shape == b.shape
+    return ((1.0 - a / b) > rtol).sum() / b.size if b.size != 0 else 0
+
+
 def eval_error_metric(predt, dtrain: xgb.DMatrix):
     """Evaluation metric for xgb.train"""
     label = dtrain.get_label()

--- a/tests/python/testing.py
+++ b/tests/python/testing.py
@@ -362,12 +362,6 @@ def non_increasing(L, tolerance=1e-4):
     return all((y - x) < tolerance for x, y in zip(L, L[1:]))
 
 
-def mismatch_rate(a: np.ndarray, b: np.ndarray, rtol: float) -> float:
-    """Number of mismatching items. rtol is tolernace of relative error."""
-    assert a.shape == b.shape
-    return ((1.0 - a / b) > rtol).sum() / b.size if b.size != 0 else 0
-
-
 def eval_error_metric(predt, dtrain: xgb.DMatrix):
     """Evaluation metric for xgb.train"""
     label = dtrain.get_label()


### PR DESCRIPTION
- The error happens because when reading from external memory the batch is
  reassembled for every new iteration. The variable `original_page_` is
  initialized from the first batch, when the constructor of `GradiendBasedSample`
  is called. After iterating through the batches the original memory is not
  accessible, so when trying to access the memory pointed by `original_page_`
  causes an error.

- The solution is instead of accessing data from the `original_page_`, to access
  the data from the first page of the available batch.

fix #7476