### PR TITLE
Use double for GPU Hist node sum.

### DIFF
--- a/src/tree/gpu_hist/evaluate_splits.cu
+++ b/src/tree/gpu_hist/evaluate_splits.cu
@@ -78,7 +78,7 @@ template <typename GradientSumT, typename TempStorageT> struct OneHotBin {
     GradientSumT bin = thread_active
                            ? inputs.gradient_histogram[scan_begin + threadIdx.x]
                            : GradientSumT();
-    auto rest = inputs.parent_sum - GradientPairPrecise{bin} - missing;
+    auto rest = inputs.parent_sum - GradientPairPrecise(bin) - missing;
     return GradientSumT{rest};
   }
 };

--- a/src/tree/gpu_hist/evaluate_splits.cu
+++ b/src/tree/gpu_hist/evaluate_splits.cu
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 by XGBoost Contributors
+ * Copyright 2020-2021 by XGBoost Contributors
  */
 #include <limits>
 #include "evaluate_splits.cuh"
@@ -9,15 +9,13 @@ namespace xgboost {
 namespace tree {
 
 // With constraints
-template <typename GradientPairT>
-XGBOOST_DEVICE float
-LossChangeMissing(const GradientPairT &scan, const GradientPairT &missing,
-                  const GradientPairT &parent_sum,
-                  const GPUTrainingParam &param,
-                  bst_node_t nidx,
-                  bst_feature_t fidx,
-                  TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
-                  bool &missing_left_out) { // NOLINT
+XGBOOST_DEVICE float LossChangeMissing(const GradientPairPrecise &scan,
+                                       const GradientPairPrecise &missing,
+                                       const GradientPairPrecise &parent_sum,
+                                       const GPUTrainingParam &param, bst_node_t nidx,
+                                       bst_feature_t fidx,
+                                       TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
+                                       bool &missing_left_out) {  // NOLINT
   float parent_gain = CalcGain(param, parent_sum);
   float missing_left_gain =
       evaluator.CalcSplitGain(param, nidx, fidx, GradStats(scan + missing),
@@ -72,32 +70,32 @@ ReduceFeature(common::Span<const GradientSumT> feature_histogram,
 }
 
 template <typename GradientSumT, typename TempStorageT> struct OneHotBin {
-  GradientSumT __device__ operator()(
-      bool thread_active, uint32_t scan_begin,
-      SumCallbackOp<GradientSumT>*,
-      GradientSumT const &missing,
-      EvaluateSplitInputs<GradientSumT> const &inputs, TempStorageT *) {
+  GradientSumT __device__ operator()(bool thread_active, uint32_t scan_begin,
+                                     SumCallbackOp<GradientSumT> *,
+                                     GradientPairPrecise const &missing,
+                                     EvaluateSplitInputs<GradientSumT> const &inputs,
+                                     TempStorageT *) {
     GradientSumT bin = thread_active
                            ? inputs.gradient_histogram[scan_begin + threadIdx.x]
                            : GradientSumT();
-    auto rest = inputs.parent_sum - bin - missing;
-    return rest;
+    auto rest = inputs.parent_sum - GradientPairPrecise{bin} - missing;
+    return GradientSumT{rest};
   }
 };
 
 template <typename GradientSumT>
 struct UpdateOneHot {
   void __device__ operator()(bool missing_left, uint32_t scan_begin, float gain,
-                             bst_feature_t fidx, GradientSumT const &missing,
+                             bst_feature_t fidx, GradientPairPrecise const &missing,
                              GradientSumT const &bin,
                              EvaluateSplitInputs<GradientSumT> const &inputs,
                              DeviceSplitCandidate *best_split) {
     int split_gidx = (scan_begin + threadIdx.x);
     float fvalue = inputs.feature_values[split_gidx];
-    GradientSumT left = missing_left ? bin + missing : bin;
-    GradientSumT right = inputs.parent_sum - left;
-    best_split->Update(gain, missing_left ? kLeftDir : kRightDir, fvalue, fidx,
-                       GradientPair(left), GradientPair(right), true,
+    GradientPairPrecise left =
+        missing_left ? GradientPairPrecise{bin} + missing : GradientPairPrecise{bin};
+    GradientPairPrecise right = inputs.parent_sum - left;
+    best_split->Update(gain, missing_left ? kLeftDir : kRightDir, fvalue, fidx, left, right, true,
                        inputs.param);
   }
 };
@@ -105,8 +103,8 @@ struct UpdateOneHot {
 template <typename GradientSumT, typename TempStorageT, typename ScanT>
 struct NumericBin {
   GradientSumT __device__ operator()(bool thread_active, uint32_t scan_begin,
-                                     SumCallbackOp<GradientSumT>* prefix_callback,
-                                     GradientSumT const &missing,
+                                     SumCallbackOp<GradientSumT> *prefix_callback,
+                                     GradientPairPrecise const &missing,
                                      EvaluateSplitInputs<GradientSumT> inputs,
                                      TempStorageT *temp_storage) {
     GradientSumT bin = thread_active
@@ -120,7 +118,7 @@ struct NumericBin {
 template <typename GradientSumT>
 struct UpdateNumeric {
   void __device__ operator()(bool missing_left, uint32_t scan_begin, float gain,
-                             bst_feature_t fidx, GradientSumT const &missing,
+                             bst_feature_t fidx, GradientPairPrecise const &missing,
                              GradientSumT const &bin,
                              EvaluateSplitInputs<GradientSumT> const &inputs,
                              DeviceSplitCandidate *best_split) {
@@ -133,11 +131,11 @@ struct UpdateNumeric {
     } else {
       fvalue = inputs.feature_values[split_gidx];
     }
-    GradientSumT left = missing_left ? bin + missing : bin;
-    GradientSumT right = inputs.parent_sum - left;
-    best_split->Update(gain, missing_left ? kLeftDir : kRightDir, fvalue,
-                       fidx, GradientPair(left), GradientPair(right),
-                       false, inputs.param);
+    GradientPairPrecise left =
+        missing_left ? GradientPairPrecise{bin} + missing : GradientPairPrecise{bin};
+    GradientPairPrecise right = inputs.parent_sum - left;
+    best_split->Update(gain, missing_left ? kLeftDir : kRightDir, fvalue, fidx, left, right, false,
+                       inputs.param);
   }
 };
 
@@ -164,7 +162,7 @@ __device__ void EvaluateFeature(
       ReduceFeature<BLOCK_THREADS, ReduceT, TempStorageT, GradientSumT>(
           feature_hist, temp_storage);
 
-  GradientSumT const missing = inputs.parent_sum - feature_sum;
+  GradientPairPrecise const missing = inputs.parent_sum - GradientPairPrecise{feature_sum};
   float const null_gain = -std::numeric_limits<bst_float>::infinity();
 
   SumCallbackOp<GradientSumT> prefix_op = SumCallbackOp<GradientSumT>();
@@ -177,11 +175,8 @@ __device__ void EvaluateFeature(
     bool missing_left = true;
     float gain = null_gain;
     if (thread_active) {
-      gain = LossChangeMissing(bin, missing, inputs.parent_sum, inputs.param,
-                               inputs.nidx,
-                               fidx,
-                               evaluator,
-                               missing_left);
+      gain = LossChangeMissing(GradientPairPrecise{bin}, missing, inputs.parent_sum, inputs.param,
+                               inputs.nidx, fidx, evaluator, missing_left);
     }
 
     __syncthreads();

--- a/src/tree/gpu_hist/evaluate_splits.cuh
+++ b/src/tree/gpu_hist/evaluate_splits.cuh
@@ -15,7 +15,7 @@ namespace tree {
 template <typename GradientSumT>
 struct EvaluateSplitInputs {
   int nidx;
-  GradientSumT parent_sum;
+  GradientPairPrecise parent_sum;
   GPUTrainingParam param;
   common::Span<const bst_feature_t> feature_set;
   common::Span<FeatureType const> feature_types;

--- a/src/tree/updater_gpu_common.cuh
+++ b/src/tree/updater_gpu_common.cuh
@@ -61,8 +61,8 @@ struct DeviceSplitCandidate {
   float fvalue {0};
   bool is_cat { false };
 
-  GradientPair left_sum;
-  GradientPair right_sum;
+  GradientPairPrecise left_sum;
+  GradientPairPrecise right_sum;
 
   XGBOOST_DEVICE DeviceSplitCandidate() {}  // NOLINT
 
@@ -78,8 +78,8 @@ struct DeviceSplitCandidate {
 
   XGBOOST_DEVICE void Update(float loss_chg_in, DefaultDirection dir_in,
                              float fvalue_in, int findex_in,
-                             GradientPair left_sum_in,
-                             GradientPair right_sum_in,
+                             GradientPairPrecise left_sum_in,
+                             GradientPairPrecise right_sum_in,
                              bool cat,
                              const GPUTrainingParam& param) {
     if (loss_chg_in > loss_chg &&

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -496,12 +496,11 @@ struct GPUHistMakerDevice {
     auto d_ridx = row_partitioner->GetRows();
 
     GPUTrainingParam param_d(param);
-    dh::TemporaryArray<GradientPair> device_node_sum_gradients(node_sum_gradients.size());
+    dh::TemporaryArray<GradientPairPrecise> device_node_sum_gradients(node_sum_gradients.size());
 
-    dh::safe_cuda(
-        cudaMemcpyAsync(device_node_sum_gradients.data().get(), node_sum_gradients.data(),
-                        sizeof(GradientPair) * node_sum_gradients.size(),
-                        cudaMemcpyHostToDevice));
+    dh::safe_cuda(cudaMemcpyAsync(device_node_sum_gradients.data().get(), node_sum_gradients.data(),
+                                  sizeof(GradientPairPrecise) * node_sum_gradients.size(),
+                                  cudaMemcpyHostToDevice));
     auto d_position = row_partitioner->GetPosition();
     auto d_node_sum_gradients = device_node_sum_gradients.data().get();
     auto evaluator = tree_evaluator.GetEvaluator<GPUTrainingParam>();

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -268,16 +268,15 @@ struct GPUHistMakerDevice {
     common::Span<bst_feature_t> feature_set =
         interaction_constraints.Query(sampled_features->DeviceSpan(), nidx);
     auto matrix = page->GetDeviceAccessor(device_id);
-    EvaluateSplitInputs<GradientSumT> inputs{
-        nidx,
-        {root_sum.GetGrad(), root_sum.GetHess()},
-        gpu_param,
-        feature_set,
-        feature_types,
-        matrix.feature_segments,
-        matrix.gidx_fvalue_map,
-        matrix.min_fvalue,
-        hist.GetNodeHistogram(nidx)};
+    EvaluateSplitInputs<GradientSumT> inputs{nidx,
+                                             root_sum,
+                                             gpu_param,
+                                             feature_set,
+                                             feature_types,
+                                             matrix.feature_segments,
+                                             matrix.gidx_fvalue_map,
+                                             matrix.min_fvalue,
+                                             hist.GetNodeHistogram(nidx)};
     auto gain_calc = tree_evaluator.GetEvaluator<GPUTrainingParam>();
     EvaluateSingleSplit(dh::ToSpan(splits_out), gain_calc, inputs);
     std::vector<DeviceSplitCandidate> result(1);
@@ -306,26 +305,24 @@ struct GPUHistMakerDevice {
                                       left_nidx);
     auto matrix = page->GetDeviceAccessor(device_id);
 
-    EvaluateSplitInputs<GradientSumT> left{
-        left_nidx,
-        {candidate.split.left_sum.GetGrad(), candidate.split.left_sum.GetHess()},
-        gpu_param,
-        left_feature_set,
-        feature_types,
-        matrix.feature_segments,
-        matrix.gidx_fvalue_map,
-        matrix.min_fvalue,
-        hist.GetNodeHistogram(left_nidx)};
-    EvaluateSplitInputs<GradientSumT> right{
-        right_nidx,
-        {candidate.split.right_sum.GetGrad(), candidate.split.right_sum.GetHess()},
-        gpu_param,
-        right_feature_set,
-        feature_types,
-        matrix.feature_segments,
-        matrix.gidx_fvalue_map,
-        matrix.min_fvalue,
-        hist.GetNodeHistogram(right_nidx)};
+    EvaluateSplitInputs<GradientSumT> left{left_nidx,
+                                           candidate.split.left_sum,
+                                           gpu_param,
+                                           left_feature_set,
+                                           feature_types,
+                                           matrix.feature_segments,
+                                           matrix.gidx_fvalue_map,
+                                           matrix.min_fvalue,
+                                           hist.GetNodeHistogram(left_nidx)};
+    EvaluateSplitInputs<GradientSumT> right{right_nidx,
+                                            candidate.split.right_sum,
+                                            gpu_param,
+                                            right_feature_set,
+                                            feature_types,
+                                            matrix.feature_segments,
+                                            matrix.gidx_fvalue_map,
+                                            matrix.min_fvalue,
+                                            hist.GetNodeHistogram(right_nidx)};
     auto d_splits_out = dh::ToSpan(splits_out);
     EvaluateSplits(d_splits_out, tree_evaluator.GetEvaluator<GPUTrainingParam>(), left, right);
     dh::TemporaryArray<GPUExpandEntry> entries(2);

--- a/tests/cpp/tree/gpu_hist/test_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_evaluate_splits.cu
@@ -17,7 +17,7 @@ auto ZeroParam() {
 
 void TestEvaluateSingleSplit(bool is_categorical) {
   thrust::device_vector<DeviceSplitCandidate> out_splits(1);
-  GradientPair parent_sum(0.0, 1.0);
+  GradientPairPrecise parent_sum(0.0, 1.0);
   TrainParam tparam = ZeroParam();
   GPUTrainingParam param{tparam};
 
@@ -73,7 +73,7 @@ TEST(GpuHist, EvaluateCategoricalSplit) {
 
 TEST(GpuHist, EvaluateSingleSplitMissing) {
   thrust::device_vector<DeviceSplitCandidate> out_splits(1);
-  GradientPair parent_sum(1.0, 1.5);
+  GradientPairPrecise parent_sum(1.0, 1.5);
   TrainParam tparam = ZeroParam();
   GPUTrainingParam param{tparam};
 
@@ -104,8 +104,8 @@ TEST(GpuHist, EvaluateSingleSplitMissing) {
   EXPECT_EQ(result.findex, 0);
   EXPECT_EQ(result.fvalue, 1.0);
   EXPECT_EQ(result.dir, kRightDir);
-  EXPECT_EQ(result.left_sum, GradientPair(-0.5, 0.5));
-  EXPECT_EQ(result.right_sum, GradientPair(1.5, 1.0));
+  EXPECT_EQ(result.left_sum, GradientPairPrecise(-0.5, 0.5));
+  EXPECT_EQ(result.right_sum, GradientPairPrecise(1.5, 1.0));
 }
 
 TEST(GpuHist, EvaluateSingleSplitEmpty) {
@@ -130,7 +130,7 @@ TEST(GpuHist, EvaluateSingleSplitEmpty) {
 // Feature 0 has a better split, but the algorithm must select feature 1
 TEST(GpuHist, EvaluateSingleSplitFeatureSampling) {
   thrust::device_vector<DeviceSplitCandidate> out_splits(1);
-  GradientPair parent_sum(0.0, 1.0);
+  GradientPairPrecise parent_sum(0.0, 1.0);
   TrainParam tparam = ZeroParam();
   tparam.UpdateAllowUnknown(Args{});
   GPUTrainingParam param{tparam};
@@ -164,14 +164,14 @@ TEST(GpuHist, EvaluateSingleSplitFeatureSampling) {
   DeviceSplitCandidate result = out_splits[0];
   EXPECT_EQ(result.findex, 1);
   EXPECT_EQ(result.fvalue, 11.0);
-  EXPECT_EQ(result.left_sum, GradientPair(-0.5, 0.5));
-  EXPECT_EQ(result.right_sum, GradientPair(0.5, 0.5));
+  EXPECT_EQ(result.left_sum, GradientPairPrecise(-0.5, 0.5));
+  EXPECT_EQ(result.right_sum, GradientPairPrecise(0.5, 0.5));
 }
 
 // Features 0 and 1 have identical gain, the algorithm must select 0
 TEST(GpuHist, EvaluateSingleSplitBreakTies) {
   thrust::device_vector<DeviceSplitCandidate> out_splits(1);
-  GradientPair parent_sum(0.0, 1.0);
+  GradientPairPrecise parent_sum(0.0, 1.0);
   TrainParam tparam = ZeroParam();
   tparam.UpdateAllowUnknown(Args{});
   GPUTrainingParam param{tparam};
@@ -209,7 +209,7 @@ TEST(GpuHist, EvaluateSingleSplitBreakTies) {
 
 TEST(GpuHist, EvaluateSplits) {
   thrust::device_vector<DeviceSplitCandidate> out_splits(2);
-  GradientPair parent_sum(0.0, 1.0);
+  GradientPairPrecise parent_sum(0.0, 1.0);
   TrainParam tparam = ZeroParam();
   tparam.UpdateAllowUnknown(Args{});
   GPUTrainingParam param{tparam};


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/7488 .

* PR

| dataset | algorithm | train_time         | test_time | AUC                | Accuracy           | F1                 | Precision            | Recall              | MeanAbsError      | MeanSquaredError | MedianAbsError  |
|---------|-----------|--------------------|-----------|--------------------|--------------------|--------------------|----------------------|---------------------|-------------------|------------------|-----------------|
| airline | xgb-gpu   | 66.33061233296758  | -na-      | 0.8084086879850008 | 0.6645717066157337 | -na-               | 0.5994090037583283   | 0.883954407897074   | -na-              | -na-             | -na-            |
| bosch   | xgb-gpu   | 12.716636892000679 | -na-      | 0.7026122514402441 | 0.8487687434002112 | -na-               | 0.017325134080251593 | 0.43298245614035086 | -na-              | -na-             | -na-            |
| covtype | xgb-gpu   | 9.73901619296521   | -na-      | -na-               | 0.8544099549925561 | 0.8527474711146924 | 0.8547835196591022   | 0.8544099549925561  | -na-              | -na-             | -na-            |
| epsilon | xgb-gpu   | 53.368427263980266 | -na-      | 0.9257760716786181 | 0.82447            | -na-               | 0.7692627310198112   | 0.9265338804924432  | -na-              | -na-             | -na-            |
| higgs   | xgb-gpu   | 13.124428120034281 | -na-      | 0.8227487305496846 | 0.7137840909090909 | -na-               | 0.6705145586206064   | 0.9045759569757491  | -na-              | -na-             | -na-            |
| year    | xgb-gpu   | 3.2767885500215925 | -na-      | -na-               | -na-               | -na-               | -na-                 | -na-                | 6.345862865447998 | 82.114013671875  | 4.4183349609375 |

* Master

| dataset | algorithm | train_time         | test_time | AUC                | Accuracy           | F1                 | Precision           | Recall              | MeanAbsError      | MeanSquaredError  | MedianAbsError   |
|---------|-----------|--------------------|-----------|--------------------|--------------------|--------------------|---------------------|---------------------|-------------------|-------------------|------------------|
| airline | xgb-gpu   | 67.7054575040238   | -na-      | 0.8086156792469643 | 0.6652941425937233 | -na-               | 0.6001292061604113  | 0.8832127661990112  | -na-              | -na-              | -na-             |
| bosch   | xgb-gpu   | 12.842170813994016 | -na-      | 0.7026268143534231 | 0.8487602956705386 | -na-               | 0.01732416116804717 | 0.43298245614035086 | -na-              | -na-              | -na-             |
| covtype | xgb-gpu   | 10.056393657985609 | -na-      | -na-               | 0.85584709516966   | 0.8541145357093728 | 0.8562489823463981  | 0.85584709516966    | -na-              | -na-              | -na-             |
| epsilon | xgb-gpu   | 55.29348221904365  | -na-      | 0.9257760738786198 | 0.82447            | -na-               | 0.7692627310198112  | 0.9265338804924432  | -na-              | -na-              | -na-             |
| higgs   | xgb-gpu   | 13.158550004998688 | -na-      | 0.8227277244996191 | 0.7137618181818182 | -na-               | 0.6704960606499737  | 0.9045665248416688  | -na-              | -na-              | -na-             |
| year    | xgb-gpu   | 3.2756966720335186 | -na-      | -na-               | -na-               | -na-               | -na-                | -na-                | 6.338248252868652 | 81.90341186523438 | 4.40301513671875 |
