### PR TITLE
[dask] Fix ddqdm with empty partition.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1071,7 +1071,7 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes
                 c_feature_types,
                 c_bst_ulong(len(feature_types))))
 
-            if len(feature_types) != self.num_col():
+            if len(feature_types) != self.num_col() and self.num_col() != 0:
                 msg = 'feature_types must have the same length as data'
                 raise ValueError(msg)
         else:

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1015,6 +1015,8 @@ def _maybe_dataframe(
         index = getattr(data, "index", None)
         if lazy_isinstance(data, "cudf.core.dataframe", "DataFrame"):
             import cudf
+            if prediction.size == 0:
+                return cudf.DataFrame({}, columns=columns, dtype=numpy.float32)
 
             prediction = cudf.DataFrame(
                 prediction, columns=columns, dtype=numpy.float32, index=index

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -599,7 +599,7 @@ void MetaInfo::GetInfo(char const* key, bst_ulong* out_len, DataType dtype,
 }
 
 void MetaInfo::SetFeatureInfo(const char* key, const char **info, const bst_ulong size) {
-  if (size != 0) {
+  if (size != 0 && this->num_col_ != 0) {
     CHECK_EQ(size, this->num_col_)
         << "Length of " << key << " must be equal to number of columns.";
   }

--- a/src/data/device_adapter.cuh
+++ b/src/data/device_adapter.cuh
@@ -39,7 +39,7 @@ class CudfAdapterBatch : public detail::NoMetaInfo {
 
  private:
   common::Span<ArrayInterface<1>> columns_;
-  size_t num_rows_;
+  size_t num_rows_{0};
 };
 
 /*!

--- a/src/data/simple_dmatrix.cu
+++ b/src/data/simple_dmatrix.cu
@@ -16,8 +16,8 @@ namespace data {
 // be supported in future. Does not currently support inferring row/column size
 template <typename AdapterT>
 SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {
-  auto device =
-      adapter->DeviceIdx() < 0 ? dh::CurrentDevice() : adapter->DeviceIdx();
+  auto device = (adapter->DeviceIdx() < 0 || adapter->NumRows() == 0) ? dh::CurrentDevice()
+                                                                      : adapter->DeviceIdx();
   CHECK_GE(device, 0);
   dh::safe_cuda(cudaSetDevice(device));
 

--- a/tests/cpp/data/test_metainfo.cc
+++ b/tests/cpp/data/test_metainfo.cc
@@ -56,7 +56,7 @@ TEST(MetaInfo, GetSetFeature) {
   std::vector<char const*> c_types(kCols);
   std::transform(types.cbegin(), types.cend(), c_types.begin(),
                  [](auto const &str) { return str.c_str(); });
-  // Info has 0 column
+  info.num_col_ = 1;
   EXPECT_THROW(
       info.SetFeatureInfo(u8"feature_type", c_types.data(), c_types.size()),
       dmlc::Error);

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -503,12 +503,12 @@ def test_empty_dmatrix_training_continuation(client: "Client") -> None:
     kRows, kCols = 1, 97
     X = dd.from_array(np.random.randn(kRows, kCols))
     y = dd.from_array(np.random.rand(kRows))
-    X.columns = ['X' + str(i) for i in range(0, 97)]
+    X.columns = ['X' + str(i) for i in range(0, kCols)]
     dtrain = xgb.dask.DaskDMatrix(client, X, y)
 
     kRows += 1000
     X = dd.from_array(np.random.randn(kRows, kCols), chunksize=10)
-    X.columns = ['X' + str(i) for i in range(0, 97)]
+    X.columns = ['X' + str(i) for i in range(0, kCols)]
     y = dd.from_array(np.random.rand(kRows), chunksize=10)
     valid = xgb.dask.DaskDMatrix(client, X, y)
 


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/7494 .

Empty partition is different from empty DMatrix, the former has only some partitions that are empty, but the dataset on each worker as a whole is not empty.