### PR TITLE
Remove `omp_get_max_threads` in CPU predictor.

### DIFF
--- a/include/xgboost/generic_parameters.h
+++ b/include/xgboost/generic_parameters.h
@@ -24,7 +24,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
   bool seed_per_iteration;
   // number of threads to use if OpenMP is enabled
   // if equals 0, use system default
-  int nthread;
+  int nthread{0};
   // primary device, -1 means no gpu.
   int gpu_id;
   // fail when gpu_id is invalid

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -105,11 +105,11 @@ class Predictor {
   /*
    * \brief Runtime parameters.
    */
-  GenericParameter const* generic_param_;
+  GenericParameter const* ctx_;
 
  public:
-  explicit Predictor(GenericParameter const* generic_param) :
-      generic_param_{generic_param} {}
+  explicit Predictor(GenericParameter const* ctx) : ctx_{ctx} {}
+
   virtual ~Predictor() = default;
 
   /**

--- a/src/predictor/predictor.cc
+++ b/src/predictor/predictor.cc
@@ -77,8 +77,8 @@ void Predictor::InitOutPredictions(const MetaInfo& info, HostDeviceVector<bst_fl
   size_t n_classes = model.learner_model_param->num_output_group;
   size_t n = n_classes * info.num_row_;
   const HostDeviceVector<bst_float>* base_margin = info.base_margin_.Data();
-  if (generic_param_->gpu_id >= 0) {
-    out_preds->SetDevice(generic_param_->gpu_id);
+  if (ctx_->gpu_id >= 0) {
+    out_preds->SetDevice(ctx_->gpu_id);
   }
   if (base_margin->Size() != 0) {
     out_preds->Resize(n);

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -217,10 +217,9 @@ void TestCategoricalPrediction(std::string name) {
   gbm::GBTreeModel model(&param);
   GBTreeModelForTest(&model, split_ind, split_cat, left_weight, right_weight);
 
-  GenericParameter runtime;
-  runtime.gpu_id = 0;
-  std::unique_ptr<Predictor> predictor{
-      Predictor::Create(name.c_str(), &runtime)};
+  GenericParameter ctx;
+  ctx.UpdateAllowUnknown(Args{{"gpu_id", "0"}});
+  std::unique_ptr<Predictor> predictor{Predictor::Create(name.c_str(), &ctx)};
 
   std::vector<float> row(kCols);
   row[split_ind] = split_cat;


### PR DESCRIPTION
This is part of the ongoing effort to remove the dependency on global omp variables.

Rename the `generic_param_` to `ctx_` (as context) to better reflect its usage.