### PR TITLE
[TEST][MINOR] Add skipif no_matplotlib for test_callbacks_demo

### DIFF
--- a/tests/python/test_demos.py
+++ b/tests/python/test_demos.py
@@ -115,6 +115,7 @@ def test_aft_demo():
     os.remove('aft_model.json')
 
 
+@pytest.mark.skipif(**tm.no_matplotlib())
 def test_callbacks_demo():
     script = os.path.join(PYTHON_DEMO_DIR, 'callbacks.py')
     cmd = ['python', script, '--plot=0']


### PR DESCRIPTION
callbacks.py is using matplotlib, the test will be failed if matplotlib is not available.