### PR TITLE
Remove `omp_get_max_threads` in gbm and linear.

### DIFF
--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -38,7 +38,7 @@ class PredictionContainer;
  */
 class GradientBooster : public Model, public Configurable {
  protected:
-  GenericParameter const* generic_param_;
+  GenericParameter const* ctx_;
 
  public:
   /*! \brief virtual destructor */

--- a/include/xgboost/linear_updater.h
+++ b/include/xgboost/linear_updater.h
@@ -29,7 +29,7 @@ class GBLinearModel;
  */
 class LinearUpdater : public Configurable {
  protected:
-  GenericParameter const* learner_param_;
+  GenericParameter const* ctx_;
 
  public:
   /*! \brief virtual destructor */

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -86,7 +86,7 @@ class GBLinear : public GradientBooster {
     }
     param_.UpdateAllowUnknown(cfg);
     param_.CheckGPUSupport();
-    updater_.reset(LinearUpdater::Create(param_.updater, generic_param_));
+    updater_.reset(LinearUpdater::Create(param_.updater, ctx_));
     updater_->Configure(cfg);
     monitor_.Init("GBLinear");
   }
@@ -120,7 +120,7 @@ class GBLinear : public GradientBooster {
     CHECK_EQ(get<String>(in["name"]), "gblinear");
     FromJson(in["gblinear_train_param"], &param_);
     param_.CheckGPUSupport();
-    updater_.reset(LinearUpdater::Create(param_.updater, generic_param_));
+    updater_.reset(LinearUpdater::Create(param_.updater, ctx_));
     this->updater_->LoadConfig(in["updater"]);
   }
   void SaveConfig(Json* p_out) const override {

--- a/src/gbm/gbm.cc
+++ b/src/gbm/gbm.cc
@@ -26,7 +26,7 @@ GradientBooster* GradientBooster::Create(
     LOG(FATAL) << "Unknown gbm type " << name;
   }
   auto p_bst =  (e->body)(learner_model_param);
-  p_bst->generic_param_ = generic_param;
+  p_bst->ctx_ = generic_param;
   return p_bst;
 }
 }  // namespace xgboost

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -49,14 +49,14 @@ void GBTree::Configure(const Args& cfg) {
   // configure predictors
   if (!cpu_predictor_) {
     cpu_predictor_ = std::unique_ptr<Predictor>(
-        Predictor::Create("cpu_predictor", this->generic_param_));
+        Predictor::Create("cpu_predictor", this->ctx_));
   }
   cpu_predictor_->Configure(cfg);
 #if defined(XGBOOST_USE_CUDA)
   auto n_gpus = common::AllVisibleGPUs();
   if (!gpu_predictor_ && n_gpus != 0) {
     gpu_predictor_ = std::unique_ptr<Predictor>(
-        Predictor::Create("gpu_predictor", this->generic_param_));
+        Predictor::Create("gpu_predictor", this->ctx_));
   }
   if (n_gpus != 0) {
     gpu_predictor_->Configure(cfg);
@@ -228,7 +228,7 @@ void GBTree::DoBoost(DMatrix* p_fmat,
   // break a lots of existing code.
   auto device = tparam_.tree_method != TreeMethod::kGPUHist
                     ? GenericParameter::kCpuId
-                    : generic_param_->gpu_id;
+                    : ctx_->gpu_id;
   auto out = linalg::TensorView<float, 2>{
       device == GenericParameter::kCpuId ? predt->predictions.HostSpan()
                                          : predt->predictions.DeviceSpan(),
@@ -310,7 +310,7 @@ void GBTree::InitUpdater(Args const& cfg) {
   // create new updaters
   for (const std::string& pstr : ups) {
     std::unique_ptr<TreeUpdater> up(
-        TreeUpdater::Create(pstr.c_str(), generic_param_, model_.learner_model_param->task));
+        TreeUpdater::Create(pstr.c_str(), ctx_, model_.learner_model_param->task));
     up->Configure(cfg);
     updaters_.push_back(std::move(up));
   }
@@ -396,7 +396,7 @@ void GBTree::LoadConfig(Json const& in) {
   updaters_.clear();
   for (auto const& kv : j_updaters) {
     std::unique_ptr<TreeUpdater> up(
-        TreeUpdater::Create(kv.first, generic_param_, model_.learner_model_param->task));
+        TreeUpdater::Create(kv.first, ctx_, model_.learner_model_param->task));
     up->LoadConfig(kv.second);
     updaters_.push_back(std::move(up));
   }
@@ -562,7 +562,7 @@ GBTree::GetPredictor(HostDeviceVector<float> const *out_pred,
   auto on_device = is_ellpack || is_from_device;
 
   // Use GPU Predictor if data is already on device and gpu_id is set.
-  if (on_device && generic_param_->gpu_id >= 0) {
+  if (on_device && ctx_->gpu_id >= 0) {
 #if defined(XGBOOST_USE_CUDA)
     CHECK_GE(common::AllVisibleGPUs(), 1) << "No visible GPU is found for XGBoost.";
     CHECK(gpu_predictor_);
@@ -728,8 +728,8 @@ class Dart : public GBTree {
     auto n_groups = model_.learner_model_param->num_output_group;
 
     PredictionCacheEntry predts;  // temporary storage for prediction
-    if (generic_param_->gpu_id != GenericParameter::kCpuId) {
-      predts.predictions.SetDevice(generic_param_->gpu_id);
+    if (ctx_->gpu_id != GenericParameter::kCpuId) {
+      predts.predictions.SetDevice(ctx_->gpu_id);
     }
     predts.predictions.Resize(p_fmat->Info().num_row_ * n_groups, 0);
 

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -413,10 +413,9 @@ class GBTree : public GradientBooster {
         p_fmat, out_contribs, model_, tree_end, nullptr, approximate);
   }
 
-  std::vector<std::string> DumpModel(const FeatureMap& fmap,
-                                     bool with_stats,
+  std::vector<std::string> DumpModel(const FeatureMap& fmap, bool with_stats,
                                      std::string format) const override {
-    return model_.DumpModel(fmap, with_stats, format);
+    return model_.DumpModel(fmap, with_stats, this->ctx_->Threads(), format);
   }
 
  protected:

--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -109,12 +109,11 @@ struct GBTreeModel : public Model {
   void SaveModel(Json* p_out) const override;
   void LoadModel(Json const& p_out) override;
 
-  std::vector<std::string> DumpModel(const FeatureMap &fmap, bool with_stats,
+  std::vector<std::string> DumpModel(const FeatureMap& fmap, bool with_stats, int32_t n_threads,
                                      std::string format) const {
     std::vector<std::string> dump(trees.size());
-    common::ParallelFor(static_cast<omp_ulong>(trees.size()), [&](size_t i) {
-      dump[i] = trees[i]->DumpModel(fmap, with_stats, format);
-    });
+    common::ParallelFor(trees.size(), n_threads,
+                        [&](size_t i) { dump[i] = trees[i]->DumpModel(fmap, with_stats, format); });
     return dump;
   }
   void CommitModel(std::vector<std::unique_ptr<RegTree> >&& new_trees,

--- a/src/linear/linear_updater.cc
+++ b/src/linear/linear_updater.cc
@@ -17,7 +17,7 @@ LinearUpdater* LinearUpdater::Create(const std::string& name, GenericParameter c
     LOG(FATAL) << "Unknown linear updater " << name;
   }
   auto p_linear = (e->body)();
-  p_linear->learner_param_ = lparam;
+  p_linear->ctx_ = lparam;
   return p_linear;
 }
 

--- a/src/linear/updater_coordinate.cc
+++ b/src/linear/updater_coordinate.cc
@@ -30,7 +30,7 @@ class CoordinateUpdater : public LinearUpdater {
       tparam_.UpdateAllowUnknown(args)
     };
     cparam_.UpdateAllowUnknown(rest);
-    selector_.reset(FeatureSelector::Create(tparam_.feature_selector));
+    selector_.reset(FeatureSelector::Create(tparam_.feature_selector, ctx_->Threads()));
     monitor_.Init("CoordinateUpdater");
   }
 
@@ -51,13 +51,13 @@ class CoordinateUpdater : public LinearUpdater {
     const int ngroup = model->learner_model_param->num_output_group;
     // update bias
     for (int group_idx = 0; group_idx < ngroup; ++group_idx) {
-      auto grad = GetBiasGradientParallel(group_idx, ngroup,
-                                          in_gpair->ConstHostVector(), p_fmat);
+      auto grad = GetBiasGradientParallel(group_idx, ngroup, in_gpair->ConstHostVector(), p_fmat,
+                                          ctx_->Threads());
       auto dbias = static_cast<float>(tparam_.learning_rate *
                                       CoordinateDeltaBias(grad.first, grad.second));
       model->Bias()[group_idx] += dbias;
-      UpdateBiasResidualParallel(group_idx, ngroup,
-                                 dbias, &in_gpair->HostVector(), p_fmat);
+      UpdateBiasResidualParallel(group_idx, ngroup, dbias, &in_gpair->HostVector(), p_fmat,
+                                 ctx_->Threads());
     }
     // prepare for updating the weights
     selector_->Setup(*model, in_gpair->ConstHostVector(), p_fmat,
@@ -80,14 +80,15 @@ class CoordinateUpdater : public LinearUpdater {
                             DMatrix *p_fmat, gbm::GBLinearModel *model) {
     const int ngroup = model->learner_model_param->num_output_group;
     bst_float &w = (*model)[fidx][group_idx];
-    auto gradient = GetGradientParallel(learner_param_, group_idx, ngroup, fidx,
+    auto gradient = GetGradientParallel(ctx_, group_idx, ngroup, fidx,
                                         *in_gpair, p_fmat);
     auto dw = static_cast<float>(
         tparam_.learning_rate *
         CoordinateDelta(gradient.first, gradient.second, w, tparam_.reg_alpha_denorm,
                         tparam_.reg_lambda_denorm));
     w += dw;
-    UpdateResidualParallel(fidx, group_idx, ngroup, dw, in_gpair, p_fmat);
+    UpdateResidualParallel(fidx, group_idx, ngroup, dw, in_gpair, p_fmat,
+                           ctx_->Threads());
   }
 
  private:

--- a/src/linear/updater_shotgun.cc
+++ b/src/linear/updater_shotgun.cc
@@ -21,7 +21,7 @@ class ShotgunUpdater : public LinearUpdater {
       LOG(FATAL) << "Unsupported feature selector for shotgun updater.\n"
                  << "Supported options are: {cyclic, shuffle}";
     }
-    selector_.reset(FeatureSelector::Create(param_.feature_selector));
+    selector_.reset(FeatureSelector::Create(param_.feature_selector, ctx_->Threads()));
   }
   void LoadConfig(Json const& in) override {
     auto const& config = get<Object const>(in);
@@ -40,12 +40,13 @@ class ShotgunUpdater : public LinearUpdater {
 
     // update bias
     for (int gid = 0; gid < ngroup; ++gid) {
-      auto grad = GetBiasGradientParallel(gid, ngroup,
-                                          in_gpair->ConstHostVector(), p_fmat);
+      auto grad = GetBiasGradientParallel(gid, ngroup, in_gpair->ConstHostVector(), p_fmat,
+                                          ctx_->Threads());
       auto dbias = static_cast<bst_float>(param_.learning_rate *
                                CoordinateDeltaBias(grad.first, grad.second));
       model->Bias()[gid] += dbias;
-      UpdateBiasResidualParallel(gid, ngroup, dbias, &in_gpair->HostVector(), p_fmat);
+      UpdateBiasResidualParallel(gid, ngroup, dbias, &in_gpair->HostVector(), p_fmat,
+                                 ctx_->Threads());
     }
 
     // lock-free parallel updates of weights
@@ -54,42 +55,35 @@ class ShotgunUpdater : public LinearUpdater {
     for (const auto &batch : p_fmat->GetBatches<CSCPage>()) {
       auto page = batch.GetView();
       const auto nfeat = static_cast<bst_omp_uint>(batch.Size());
-      dmlc::OMPException exc;
-#pragma omp parallel for schedule(static)
-      for (bst_omp_uint i = 0; i < nfeat; ++i) {
-        exc.Run([&]() {
-          int ii = selector_->NextFeature
-            (i, *model, 0, in_gpair->ConstHostVector(), p_fmat, param_.reg_alpha_denorm,
-            param_.reg_lambda_denorm);
-          if (ii < 0) return;
-          const bst_uint fid = ii;
-          auto col = page[ii];
-          for (int gid = 0; gid < ngroup; ++gid) {
-            double sum_grad = 0.0, sum_hess = 0.0;
-            for (auto& c : col) {
-              const GradientPair &p = gpair[c.index * ngroup + gid];
-              if (p.GetHess() < 0.0f) continue;
-              const bst_float v = c.fvalue;
-              sum_grad += p.GetGrad() * v;
-              sum_hess += p.GetHess() * v * v;
-            }
-            bst_float &w = (*model)[fid][gid];
-            auto dw = static_cast<bst_float>(
-                param_.learning_rate *
-                CoordinateDelta(sum_grad, sum_hess, w, param_.reg_alpha_denorm,
-                                param_.reg_lambda_denorm));
-            if (dw == 0.f) continue;
-            w += dw;
-            // update grad values
-            for (auto& c : col) {
-              GradientPair &p = gpair[c.index * ngroup + gid];
-              if (p.GetHess() < 0.0f) continue;
-              p += GradientPair(p.GetHess() * c.fvalue * dw, 0);
-            }
+      common::ParallelFor(nfeat, ctx_->Threads(), [&](auto i) {
+        int ii = selector_->NextFeature(i, *model, 0, in_gpair->ConstHostVector(), p_fmat,
+                                        param_.reg_alpha_denorm, param_.reg_lambda_denorm);
+        if (ii < 0) return;
+        const bst_uint fid = ii;
+        auto col = page[ii];
+        for (int gid = 0; gid < ngroup; ++gid) {
+          double sum_grad = 0.0, sum_hess = 0.0;
+          for (auto &c : col) {
+            const GradientPair &p = gpair[c.index * ngroup + gid];
+            if (p.GetHess() < 0.0f) continue;
+            const bst_float v = c.fvalue;
+            sum_grad += p.GetGrad() * v;
+            sum_hess += p.GetHess() * v * v;
           }
-        });
-      }
-      exc.Rethrow();
+          bst_float &w = (*model)[fid][gid];
+          auto dw = static_cast<bst_float>(
+              param_.learning_rate * CoordinateDelta(sum_grad, sum_hess, w, param_.reg_alpha_denorm,
+                                                     param_.reg_lambda_denorm));
+          if (dw == 0.f) continue;
+          w += dw;
+          // update grad values
+          for (auto &c : col) {
+            GradientPair &p = gpair[c.index * ngroup + gid];
+            if (p.GetHess() < 0.0f) continue;
+            p += GradientPair(p.GetHess() * c.fvalue * dw, 0);
+          }
+        }
+      });
     }
   }
 


### PR DESCRIPTION
This is part of the ongoing effort to remove the dependency on global omp variables.

Rename the `generic_param_` to `ctx_` (as context) to better reflect its usage.