### PR TITLE
Silent some warnings for unused variable.

### DIFF
--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -43,6 +43,7 @@ class EllpackPageSource : public PageSourceIncMixIn<EllpackPage> {
 
 #if !defined(XGBOOST_USE_CUDA)
 inline void EllpackPageSource::Fetch() {
+  // silent the warning about unused variables.
   (void)(row_stride_);
   (void)(is_dense_);
   common::AssertGPUSupport();

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -43,6 +43,8 @@ class EllpackPageSource : public PageSourceIncMixIn<EllpackPage> {
 
 #if !defined(XGBOOST_USE_CUDA)
 inline void EllpackPageSource::Fetch() {
+  (void)(row_stride_);
+  (void)(is_dense_);
   common::AssertGPUSupport();
 }
 #endif  // !defined(XGBOOST_USE_CUDA)

--- a/src/data/iterative_device_dmatrix.h
+++ b/src/data/iterative_device_dmatrix.h
@@ -79,6 +79,9 @@ class IterativeDeviceDMatrix : public DMatrix {
 
 #if !defined(XGBOOST_USE_CUDA)
 inline void IterativeDeviceDMatrix::Initialize(DataIterHandle iter, float missing, int nthread) {
+  (void)(proxy_);
+  (void)(reset_);
+  (void)(next_);
   common::AssertGPUSupport();
 }
 inline BatchSet<EllpackPage> IterativeDeviceDMatrix::GetEllpackBatches(const BatchParam& param) {

--- a/src/data/iterative_device_dmatrix.h
+++ b/src/data/iterative_device_dmatrix.h
@@ -79,6 +79,7 @@ class IterativeDeviceDMatrix : public DMatrix {
 
 #if !defined(XGBOOST_USE_CUDA)
 inline void IterativeDeviceDMatrix::Initialize(DataIterHandle iter, float missing, int nthread) {
+  // silent the warning about unused variables.
   (void)(proxy_);
   (void)(reset_);
   (void)(next_);


### PR DESCRIPTION
Some variables are not used if XGBoost is not compiled with CUDA.