### PR TITLE
Rename build info function to be consistent with rest of the API.

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -49,7 +49,7 @@ XGB_DLL void XGBoostVersion(int* major, int* minor, int* patch);
  *
  * \return 0 for success, -1 for failure
  */
-XGB_DLL int XGBBuildInfo(char const **out);
+XGB_DLL int XGBuildInfo(char const **out);
 
 /*!
  * \brief get string message of the last error

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -202,7 +202,7 @@ def build_info() -> dict:
 
     """
     j_info = ctypes.c_char_p()
-    _check_call(_LIB.XGBBuildInfo(ctypes.byref(j_info)))
+    _check_call(_LIB.XGBuildInfo(ctypes.byref(j_info)))
     assert j_info.value is not None
     res = json.loads(j_info.value.decode())  # pylint: disable=no-member
     return res

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -55,7 +55,7 @@ void XGBBuildInfoDevice(Json *p_info) {
 }  // namespace xgboost
 #endif
 
-XGB_DLL int XGBBuildInfo(char const **out) {
+XGB_DLL int XGBuildInfo(char const **out) {
   API_BEGIN();
   CHECK(out) << "Invalid input pointer";
   Json info{Object{}};

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -283,7 +283,7 @@ TEST(CAPI, XGBGlobalConfig) {
 
 TEST(CAPI, BuildInfo) {
   char const* out;
-  XGBBuildInfo(&out);
+  XGBuildInfo(&out);
   auto loaded = Json::Load(StringView{out});
   ASSERT_TRUE(get<Object const>(loaded).find("USE_OPENMP") != get<Object const>(loaded).cend());
   ASSERT_TRUE(get<Object const>(loaded).find("USE_CUDA") != get<Object const>(loaded).cend());


### PR DESCRIPTION
This is not a breaking change as it was introduced in this version.