### PR TITLE
[dask] Add scheduler address to dask config.

### DIFF
--- a/doc/tutorials/dask.rst
+++ b/doc/tutorials/dask.rst
@@ -475,6 +475,8 @@ interface, including callback functions, custom evaluation metric and objective:
     )
 
 
+.. _tracker-ip:
+
 ***************
 Tracker Host IP
 ***************

--- a/doc/tutorials/dask.rst
+++ b/doc/tutorials/dask.rst
@@ -475,6 +475,30 @@ interface, including callback functions, custom evaluation metric and objective:
     )
 
 
+***************
+Tracker Host IP
+***************
+
+.. versionadded:: 1.6.0
+
+In some environments XGBoost might fail to resolve the IP address of the scheduler, a
+symptom is user receiving ``OSError: [Errno 99] Cannot assign requested address`` error
+during training.  A quick workaround is to specify the address explicitly.  To do that
+dask config is used:
+
+.. code-block:: python
+
+    import dask
+    from distributed import Client
+    from xgboost import dask as dxgb
+    # let xgboost know the scheduler address
+    dask.config.set({"xgboost.scheduler_address": "192.0.0.100"})
+
+    with Client(scheduler_file="sched.json") as client:
+        reg = dxgb.DaskXGBRegressor()
+
+XGBoost will read configuration before training.
+
 *****************************************************************************
 Why is the initialization of ``DaskDMatrix``  so slow and throws weird errors
 *****************************************************************************

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -180,9 +180,9 @@ def _try_start_tracker(
 
 def _start_tracker(
     n_workers: int, addr_from_dask: Optional[str], addr_from_user: Optional[str]
-) -> Dict[str, Any]:
+) -> Dict[str, Union[int, str]]:
     """Start Rabit tracker, recurse to try different addresses."""
-    env = _try_start_tracker(n_workers, [get_host_ip(addr_from_user), addr_from_dask])
+    env = _try_start_tracker(n_workers, [addr_from_user, addr_from_dask])
     return env
 
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -3,8 +3,12 @@
 # pylint: disable=too-many-lines, fixme
 # pylint: disable=too-few-public-methods
 # pylint: disable=import-error
-"""Dask extensions for distributed training. See :doc:`Distributed XGBoost with Dask
-</tutorials/dask>` for simple tutorial.  Also xgboost/demo/dask for some examples.
+"""
+Dask extensions for distributed training
+----------------------------------------
+
+See :doc:`Distributed XGBoost with Dask </tutorials/dask>` for simple tutorial.  Also
+:doc:`/python/dask-examples/index` for some examples.
 
 There are two sets of APIs in this module, one is the functional API including
 ``train`` and ``predict`` methods.  Another is stateful Scikit-Learner wrapper
@@ -12,6 +16,17 @@ inherited from single-node Scikit-Learn interface.
 
 The implementation is heavily influenced by dask_xgboost:
 https://github.com/dask/dask-xgboost
+
+Optional dask configuration
+===========================
+
+- **xgboost.scheduler_address**: Specify the scheduler address, see :ref:`tracker-ip`.
+
+  .. versionadded:: 1.6.0
+
+  .. code-block:: python
+
+      dask.config.set({"xgboost.scheduler_address": "192.0.0.100"})
 
 """
 import platform

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -205,6 +205,7 @@ class RabitContext:
 
     def __enter__(self) -> None:
         rabit.init(self.args)
+        assert rabit.is_distributed()
         LOGGER.debug('-------------- rabit say hello ------------------')
 
     def __exit__(self, *args: List) -> None:

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -153,7 +153,7 @@ def _multi_lock() -> Any:
 
 
 def _start_tracker(
-    n_workers: int, addr_from_dask: str, addr_from_user: Optional[str]
+    n_workers: int, addr_from_dask: Optional[str], addr_from_user: Optional[str]
 ) -> Dict[str, Any]:
     """Start Rabit tracker"""
     env: Dict[str, Union[int, str]] = {"DMLC_NUM_WORKER": n_workers}
@@ -162,7 +162,7 @@ def _start_tracker(
             hostIP=get_host_ip(addr_from_user), n_workers=n_workers, use_logger=False
         )
     except socket.error as e:
-        if e.errno != 99:  # not a bind error
+        if e.errno != 99 or addr_from_dask is None:  # not a bind error
             raise
         LOGGER.warning(
             "Failed to bind address: %s, try %s instead.",

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -165,8 +165,9 @@ def _start_tracker(
         if e.errno != 99:  # not a bind error
             raise
         LOGGER.warning(
-            f"Failed to bind address: {get_host_ip(addr_from_user)}, try"
-            f" {addr_from_dask} instead."
+            "Failed to bind address: %s, try %s instead.",
+            str(get_host_ip(addr_from_user)),
+            str(addr_from_dask),
         )
         rabit_context = RabitTracker(
             hostIP=addr_from_dask, n_workers=n_workers, use_logger=False

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -165,7 +165,7 @@ def _start_tracker(
         if e.errno != 99 or addr_from_dask is None:  # not a bind error
             raise
         LOGGER.warning(
-            "Failed to bind address: %s, try %s instead.",
+            "Failed to bind address '%s', trying to use '%s' instead.",
             str(get_host_ip(addr_from_user)),
             str(addr_from_dask),
         )

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -174,8 +174,8 @@ def _try_start_tracker(
             str(addrs[1]),
         )
         env = _try_start_tracker(n_workers, addrs[1:])
-    finally:
-        return env
+
+    return env
 
 
 def _start_tracker(

--- a/python-package/xgboost/tracker.py
+++ b/python-package/xgboost/tracker.py
@@ -192,7 +192,8 @@ class RabitTracker:
         logging.info('start listen on %s:%d', hostIP, self.port)
 
     def __del__(self) -> None:
-        self.sock.close()
+        if hasattr(self, "sock"):
+            self.sock.close()
 
     @staticmethod
     def get_neighbor(rank: int, n_workers: int) -> List[int]:

--- a/tests/python-gpu/test_gpu_with_dask.py
+++ b/tests/python-gpu/test_gpu_with_dask.py
@@ -371,7 +371,7 @@ class TestDistributedGPU:
             m = dxgb.DaskDMatrix(client, X, y, feature_weights=fw)
 
             workers = _get_client_workers(client)
-            rabit_args = client.sync(dxgb._get_rabit_args, len(workers), client)
+            rabit_args = client.sync(dxgb._get_rabit_args, len(workers), None, client)
 
             def worker_fn(worker_addr: str, data_ref: Dict) -> None:
                 with dxgb.RabitContext(rabit_args):
@@ -473,7 +473,7 @@ class TestDistributedGPU:
 
         with Client(local_cuda_cluster) as client:
             workers = _get_client_workers(client)
-            rabit_args = client.sync(dxgb._get_rabit_args, workers, client)
+            rabit_args = client.sync(dxgb._get_rabit_args, workers, None, client)
             futures = client.map(runit,
                                  workers,
                                  pure=False,

--- a/tests/python/test_tracker.py
+++ b/tests/python/test_tracker.py
@@ -28,7 +28,7 @@ def run_rabit_ops(client, n_workers):
     from xgboost import rabit
 
     workers = _get_client_workers(client)
-    rabit_args = client.sync(_get_rabit_args, len(workers), client)
+    rabit_args = client.sync(_get_rabit_args, len(workers), None, client)
     assert not rabit.is_distributed()
     n_workers_from_dask = len(workers)
     assert n_workers == n_workers_from_dask

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -30,6 +30,7 @@ if tm.no_dask()['condition']:
     pytest.skip(msg=tm.no_dask()['reason'], allow_module_level=True)
 
 from distributed import LocalCluster, Client
+import dask
 import dask.dataframe as dd
 import dask.array as da
 from xgboost.dask import DaskDMatrix
@@ -1215,6 +1216,10 @@ class TestWithDask:
 
         os.remove(before_fname)
         os.remove(after_fname)
+
+        with dask.config.set({'xgboost.foo': "bar"}):
+            with pytest.raises(ValueError):
+                xgb.dask.train(client, {}, dtrain, num_boost_round=4)
 
     def run_updater_test(
         self,

--- a/tests/python/test_with_dask.py
+++ b/tests/python/test_with_dask.py
@@ -1315,7 +1315,8 @@ class TestWithDask:
             with Client(cluster) as client:
                 workers = _get_client_workers(client)
                 rabit_args = client.sync(
-                    xgb.dask._get_rabit_args, len(workers), client)
+                    xgb.dask._get_rabit_args, len(workers), None, client
+                )
                 futures = client.map(runit,
                                      workers,
                                      pure=False,
@@ -1443,7 +1444,9 @@ class TestWithDask:
                 n_partitions = X.npartitions
                 m = xgb.dask.DaskDMatrix(client, X, y)
                 workers = _get_client_workers(client)
-                rabit_args = client.sync(xgb.dask._get_rabit_args, len(workers), client)
+                rabit_args = client.sync(
+                    xgb.dask._get_rabit_args, len(workers), None, client
+                )
                 n_workers = len(workers)
 
                 def worker_fn(worker_addr: str, data_ref: Dict) -> None:


### PR DESCRIPTION
See added doc for use case.

- Add user configuration.
- Bring back to the logic of using scheduler address from dask.  This was removed when we were trying to support GKE, now we bring it back and let xgboost try it if direct guess or host IP from user config failed.