### PR TITLE
[Doc] Add instruction to install XGBoost for Apple Silicon using Conda

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -41,6 +41,14 @@ into permission errors.  Python pre-built binary capability for each platform:
 | Windows           | |tick|  |  |cross|             |
 +-------------------+---------+----------------------+
 
+If you are using **Apple Silicon**, please use the Conda packaging manager to install XGBoost:
+
+.. code-block:: bash
+
+   conda install -c conda-forge xgboost
+
+Visit the `Miniconda website <https://docs.conda.io/en/latest/miniconda.html>`_ to obtain Conda.
+
 R
 -
 


### PR DESCRIPTION
https://github.com/conda-forge/xgboost-feedstock/pull/79 added a build for `osx-arm64`. This build is a cross-build, using Azure Pipelines to build a binary for Apple Silicon. Given the high complexity of setting up a cross-build, we won't be able to replicate it ourselves. As a result, we won't upload a M1-native Python wheel on PyPI. Instead, we'll tell Apple Silicon users to use Conda to install XGBoost.