### PR TITLE
[CI] Use libomp 13.0.0 to test XGBoost on MacOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,7 @@ jobs:
         submodules: 'true'
     - name: Install system packages
       run: |
-        # Use libomp 11.1.0: https://github.com/dmlc/xgboost/issues/7039
-        wget https://raw.githubusercontent.com/Homebrew/homebrew-core/679923b4eb48a8dc7ecc1f05d06063cd79b3fc00/Formula/libomp.rb -O $(find $(brew --repository) -name libomp.rb)
         brew install ninja libomp
-        brew pin libomp
     - name: Build gtest binary
       run: |
         mkdir build

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -17,10 +17,7 @@ jobs:
     - name: Install osx system dependencies
       if: matrix.os == 'macos-10.15'
       run: |
-        # Use libomp 11.1.0: https://github.com/dmlc/xgboost/issues/7039
-        wget https://raw.githubusercontent.com/Homebrew/homebrew-core/679923b4eb48a8dc7ecc1f05d06063cd79b3fc00/Formula/libomp.rb -O $(find $(brew --repository) -name libomp.rb)
         brew install ninja libomp
-        brew pin libomp
     - name: Install Ubuntu system dependencies
       if: matrix.os == 'ubuntu-latest'
       run: |
@@ -120,9 +117,7 @@ jobs:
 
     - name: Build XGBoost on macos
       run: |
-        wget https://raw.githubusercontent.com/Homebrew/homebrew-core/679923b4eb48a8dc7ecc1f05d06063cd79b3fc00/Formula/libomp.rb -O $(find $(brew --repository) -name libomp.rb)
         brew install ninja libomp
-        brew pin libomp
 
         mkdir build
         cd build

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -116,6 +116,7 @@ jobs:
         conda list
 
     - name: Build XGBoost on macos
+      shell: bash -l {0}
       run: |
         brew install ninja
 

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -117,11 +117,14 @@ jobs:
 
     - name: Build XGBoost on macos
       run: |
-        brew install ninja libomp
+        brew install ninja
 
         mkdir build
         cd build
-        cmake .. -GNinja -DGOOGLE_TEST=ON -DUSE_DMLC_GTEST=ON
+        # Set prefix, to use OpenMP library from Conda env
+        # See https://github.com/dmlc/xgboost/issues/7039#issuecomment-1025038228
+        # to learn why we don't use libomp from Homebrew.
+        cmake .. -GNinja -DGOOGLE_TEST=ON -DUSE_DMLC_GTEST=ON -DCMAKE_PREFIX_PATH=$CONDA_PREFIX
         ninja
 
     - name: Install Python package

--- a/tests/ci_build/conda_env/macos_cpu_test.yml
+++ b/tests/ci_build/conda_env/macos_cpu_test.yml
@@ -10,6 +10,7 @@ dependencies:
 - pylint
 - numpy
 - scipy
+- llvm-openmp
 - scikit-learn
 - pandas
 - matplotlib


### PR DESCRIPTION
Closes #7039 

TODOs
- [ ] In the installation doc, add a warning: "If you are using Conda in MacOS, do not use `pip install xgboost`; this may lead to random crashes. Install XGBoost using Conda for best results."