### PR TITLE
VM-Packages: Adding support for detecting musl-based Linux

### DIFF
--- a/jvm-packages/xgboost4j-tester/generate_pom.py
+++ b/jvm-packages/xgboost4j-tester/generate_pom.py
@@ -98,7 +98,7 @@ pom_template = """
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jvm-packages/xgboost4j-tester/generate_pom.py
+++ b/jvm-packages/xgboost4j-tester/generate_pom.py
@@ -102,6 +102,12 @@ pom_template = """
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-lambda</artifactId>
+      <version>1.2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ml.dmlc</groupId>
       <artifactId>xgboost4j_${{scala.binary.version}}</artifactId>
       <version>{xgboost4j_version}</version>

--- a/jvm-packages/xgboost4j-tester/generate_pom.py
+++ b/jvm-packages/xgboost4j-tester/generate_pom.py
@@ -102,12 +102,6 @@ pom_template = """
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-lambda</artifactId>
-      <version>1.2.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>ml.dmlc</groupId>
       <artifactId>xgboost4j_${{scala.binary.version}}</artifactId>
       <version>{xgboost4j_version}</version>

--- a/jvm-packages/xgboost4j/pom.xml
+++ b/jvm-packages/xgboost4j/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jvm-packages/xgboost4j/pom.xml
+++ b/jvm-packages/xgboost4j/pom.xml
@@ -32,6 +32,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-lambda</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-actor_${scala.binary.version}</artifactId>
             <version>2.5.23</version>

--- a/jvm-packages/xgboost4j/pom.xml
+++ b/jvm-packages/xgboost4j/pom.xml
@@ -32,12 +32,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-lambda</artifactId>
-            <version>1.2.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-actor_${scala.binary.version}</artifactId>
             <version>2.5.23</version>

--- a/jvm-packages/xgboost4j/pom.xml
+++ b/jvm-packages/xgboost4j/pom.xml
@@ -35,6 +35,7 @@
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-lambda</artifactId>
             <version>1.2.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
@@ -115,7 +115,7 @@ class NativeLibLoader {
    *   <li>Supported OS: macOS, Windows, Linux, Solaris.</li>
    *   <li>Supported Architectures: x86_64, aarch64, sparc.</li>
    * </ul>
-   * Throws UnsatisfiedLinkError if the library failed to load it's dependencies.
+   * Throws UnsatisfiedLinkError if the library failed to load its dependencies.
    * @throws IOException If the library could not be extracted from the jar.
    */
   static synchronized void initXGBoost() throws IOException {

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
@@ -88,9 +89,17 @@ class NativeLibLoader {
      */
     static boolean isMuslBased() {
       try (Stream<Path> dirStream = Files.list(mappedFilesBaseDir)) {
-        return dirStream
-          .map(OS::toRealPath)
-          .anyMatch(s -> s.toLowerCase().contains("musl"));
+        Optional<String> muslRelatedMemoryMappedFilename = dirStream
+            .map(OS::toRealPath)
+            .filter(s -> s.toLowerCase().contains("musl"))
+            .findFirst();
+
+        muslRelatedMemoryMappedFilename.ifPresent(muslFilename -> {
+          logger.debug("Assuming that detected Linux OS is musl-based, "
+              + "because a memory-mapped file '" + muslFilename + "' was found.");
+        });
+
+        return muslRelatedMemoryMappedFilename.isPresent();
       } catch (IOException ignored) {
         // ignored
       }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
@@ -45,7 +45,7 @@ class NativeLibLoader {
 
     final String name;
 
-    private OS(String name) {
+    OS(String name) {
       this.name = name;
     }
 
@@ -80,7 +80,7 @@ class NativeLibLoader {
 
     final String name;
 
-    private Arch(String name) {
+    Arch(String name) {
       this.name = name;
     }
 

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
@@ -175,18 +175,37 @@ class NativeLibLoader {
               platform + "/" + System.mapLibraryName(libName);
           loadLibraryFromJar(libraryPathInJar);
         } catch (UnsatisfiedLinkError ule) {
-          logger.error("Failed to load " + libName + " due to missing native dependencies for " +
-              "platform " + platform + ", this is likely due to a missing OpenMP dependency");
+          String failureMessageIncludingOpenMPHint = "Failed to load " + libName + " " +
+              "due to missing native dependencies for " +
+              "platform " + platform + ", " +
+              "this is likely due to a missing OpenMP dependency";
+
           switch (os) {
             case WINDOWS:
+              logger.error(failureMessageIncludingOpenMPHint);
               logger.error("You may need to install 'vcomp140.dll' or 'libgomp-1.dll'");
               break;
             case MACOS:
-              logger.error("You may need to install 'libomp.dylib', via `brew install libomp`" +
-                  " or similar");
+              logger.error(failureMessageIncludingOpenMPHint);
+              logger.error("You may need to install 'libomp.dylib', via `brew install libomp` " +
+                  "or similar");
               break;
             case LINUX:
+              logger.error(failureMessageIncludingOpenMPHint);
+              logger.error("You may need to install 'libgomp.so' (or glibc) via your package " +
+                  "manager.");
+              logger.error("Alternatively, your Linux OS is musl-based " +
+                  "but wasn't detected as such.");
+              break;
+            case LINUX_MUSL:
+              logger.error(failureMessageIncludingOpenMPHint);
+              logger.error("You may need to install 'libgomp.so' (or glibc) via your package " +
+                  "manager.");
+              logger.error("Alternatively, your Linux OS was wrongly detected as musl-based, " +
+                  "although it is not.");
+              break;
             case SOLARIS:
+              logger.error(failureMessageIncludingOpenMPHint);
               logger.error("You may need to install 'libgomp.so' (or glibc) via your package " +
                   "manager.");
               break;

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
@@ -27,7 +27,6 @@ import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.stream.Stream;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -57,7 +56,6 @@ class NativeLibLoader {
       this.name = name;
     }
 
-    @VisibleForTesting
     static void setMappedFilesBaseDir(Path baseDir) {
       mappedFilesBaseDir = baseDir;
     }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
@@ -84,7 +84,7 @@ class NativeLibLoader {
 
     /**
      * Checks if the Linux OS is musl based. For this, we check the memory-mapped
-     * files and see if one of those contains the string "musl".
+     * filenames and see if one of those contains the string "musl".
      *
      * @return true if the Linux OS is musl based, false otherwise.
      */

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/ArchDetectionTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/ArchDetectionTest.java
@@ -23,7 +23,6 @@ import org.junit.runners.Parameterized.Parameters;
 
 import java.util.Collection;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemProperties;
 import static java.util.Arrays.asList;
 import static junit.framework.TestCase.assertSame;
 import static ml.dmlc.xgboost4j.java.NativeLibLoader.Arch.X86_64;
@@ -63,8 +62,8 @@ public class ArchDetectionTest {
     }
 
     @Test
-    public void testArch() throws Exception {
-      restoreSystemProperties(() -> {
+    public void testArch() {
+      executeAndRestoreProperty(() -> {
         System.setProperty(OS_ARCH_PROPERTY, osArchValue);
         assertSame(detectArch(), expectedArch);
       });
@@ -74,11 +73,25 @@ public class ArchDetectionTest {
   public static class UnsupportedArchDetectionTest {
 
     @Test
-    public void testUnsupportedArch() throws Exception {
-      restoreSystemProperties(() -> {
+    public void testUnsupportedArch() {
+      executeAndRestoreProperty(() -> {
         System.setProperty(OS_ARCH_PROPERTY, "unsupported");
         assertThrows(IllegalStateException.class, NativeLibLoader.Arch::detectArch);
       });
+    }
+  }
+
+  private static void executeAndRestoreProperty(Runnable action) {
+    String oldValue = System.getProperty(OS_ARCH_PROPERTY);
+
+    try {
+      action.run();
+    } finally {
+      if (oldValue != null) {
+        System.setProperty(OS_ARCH_PROPERTY, oldValue);
+      } else {
+        System.clearProperty(OS_ARCH_PROPERTY);
+      }
     }
   }
 

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/ArchDetectionTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/ArchDetectionTest.java
@@ -1,0 +1,85 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+package ml.dmlc.xgboost4j.java;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Collection;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemProperties;
+import static java.util.Arrays.asList;
+import static junit.framework.TestCase.assertSame;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.Arch.X86_64;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.Arch.AARCH64;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.Arch.SPARC;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.Arch.detectArch;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Test cases for {@link NativeLibLoader.Arch}.
+ */
+@RunWith(Enclosed.class)
+public class ArchDetectionTest {
+
+  private static final String OS_ARCH_PROPERTY = "os.arch";
+
+  @RunWith(Parameterized.class)
+  public static class ParameterizedArchDetectionTest {
+
+    private final String osArchValue;
+    private final NativeLibLoader.Arch expectedArch;
+
+    public ParameterizedArchDetectionTest(String osArchValue, NativeLibLoader.Arch expectedArch) {
+      this.osArchValue = osArchValue;
+      this.expectedArch = expectedArch;
+    }
+
+    @Parameters
+    public static Collection<Object[]> data() {
+      return asList(new Object[][]{
+        {"x86_64", X86_64},
+        {"amd64", X86_64},
+        {"aarch64", AARCH64},
+        {"arm64", AARCH64},
+        {"sparc64", SPARC}
+      });
+    }
+
+    @Test
+    public void testArch() throws Exception {
+      restoreSystemProperties(() -> {
+        System.setProperty(OS_ARCH_PROPERTY, osArchValue);
+        assertSame(detectArch(), expectedArch);
+      });
+    }
+  }
+
+  public static class UnsupportedArchDetectionTest {
+
+    @Test
+    public void testUnsupportedArch() throws Exception {
+      restoreSystemProperties(() -> {
+        System.setProperty(OS_ARCH_PROPERTY, "unsupported");
+        assertThrows(IllegalStateException.class, NativeLibLoader.Arch::detectArch);
+      });
+    }
+  }
+
+}

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/OsDetectionTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/OsDetectionTest.java
@@ -1,0 +1,85 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+package ml.dmlc.xgboost4j.java;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Collection;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemProperties;
+import static java.util.Arrays.asList;
+import static junit.framework.TestCase.assertSame;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.WINDOWS;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.MACOS;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.LINUX;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.SOLARIS;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.detectOS;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Test cases for {@link NativeLibLoader.OS}.
+ */
+@RunWith(Enclosed.class)
+public class OsDetectionTest {
+
+  private static final String OS_NAME_PROPERTY = "os.name";
+
+  @RunWith(Parameterized.class)
+  public static class ParameterizedOSDetectionTest {
+
+    private final String osNameValue;
+    private final NativeLibLoader.OS expectedOS;
+
+    public ParameterizedOSDetectionTest(String osNameValue, NativeLibLoader.OS expectedOS) {
+      this.osNameValue = osNameValue;
+      this.expectedOS = expectedOS;
+    }
+
+    @Parameters
+    public static Collection<Object[]> data() {
+      return asList(new Object[][]{
+        {"windows", WINDOWS},
+        {"mac", MACOS},
+        {"darwin", MACOS},
+        {"linux", LINUX},
+        {"sunos", SOLARIS}
+      });
+    }
+
+    @Test
+    public void getOS() throws Exception {
+      restoreSystemProperties(() -> {
+        System.setProperty(OS_NAME_PROPERTY, osNameValue);
+        assertSame(detectOS(), expectedOS);
+      });
+    }
+  }
+
+  public static class UnsupportedOSDetectionTest {
+
+    @Test
+    public void testUnsupportedOs() throws Exception {
+      restoreSystemProperties(() -> {
+        System.setProperty(OS_NAME_PROPERTY, "unsupported");
+        assertThrows(IllegalStateException.class, NativeLibLoader.OS::detectOS);
+      });
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for detecting musl-based Linux operating systems, when the NativeLibLoader tries to determine the path of the XGBoost4j shared library to load.

The solution for detecting a musl-based Linux system is based on how the the [sqlite-jdbc](https://github.com/xerial/sqlite-jdbc) project does it [here](https://github.com/xerial/sqlite-jdbc/blob/ada2b147dc858ef557a995e2f4ef25f7c65fc6a7/src/main/java/org/sqlite/util/OSInfo.java#L115-L131): it lists the memory-mapped files of a Linux system and checks whether any name contains the string "musl". If that's the case, the OS is considered a musl-based Linux system.

The path of the shared library for a regular Linux-based system for x86_64 architecture is still linux/x86_64/libxgboost4j.so. For a musl-based system this would now be linux-musl/x86_64/libxgboost4j.so.

This even works for Arm-based versions, where the path would be linux-musl/aarch64/libxgboost4j.so.

Note: This feature was initially discussed in the public forums [here](https://discuss.xgboost.ai/t/xgboost4j-support-for-alpine-linux-and-or-macos-arm64-planned/2623).