### PR TITLE
[dask] Fix nthread config with dask sklearn wrapper.

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -944,7 +944,7 @@ async def _train_async(
                 LOGGER.info("Overriding `nthreads` defined in dask worker.")
                 n_threads = local_param[p]
                 break
-        if n_threads == 0:
+        if n_threads == 0 or n_threads is None:
             n_threads = worker.nthreads
         local_param.update({"nthread": n_threads, "n_jobs": n_threads})
 


### PR DESCRIPTION
This affects using sklearn wrapper on local cluster with n_workers > 1.