### PR TITLE
[dask] Fix empty partition with pandas input.

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1062,6 +1062,9 @@ def _maybe_dataframe(
                 prediction, columns=columns, dtype=numpy.float32, index=index
             )
         else:
+            if prediction.size == 0:
+                return DataFrame({}, columns=columns, dtype=numpy.float32, index=index)
+
             prediction = DataFrame(
                 prediction, columns=columns, dtype=numpy.float32, index=index
             )

--- a/src/predictor/predictor.cc
+++ b/src/predictor/predictor.cc
@@ -85,12 +85,9 @@ void Predictor::InitOutPredictions(const MetaInfo& info, HostDeviceVector<bst_fl
     ValidateBaseMarginShape(info.base_margin_, info.num_row_, n_classes);
     out_preds->Copy(*base_margin);
   } else {
-    if (out_preds->Empty()) {
-      out_preds->Resize(n, model.learner_model_param->base_score);
-    } else {
-      out_preds->Resize(n);
-      out_preds->Fill(model.learner_model_param->base_score);
-    }
+    out_preds->Resize(n);
+    // cannot rely on the Resize to fill as it might skip if the size is already correct.
+    out_preds->Fill(model.learner_model_param->base_score);
   }
 }
 }  // namespace xgboost


### PR DESCRIPTION
Empty partition is different from empty dataset.  For the former case, each worker has
non-empty dask collections, but each collection might contain empty partitions.

Close https://github.com/dmlc/xgboost/issues/7639 .