### PR TITLE
Small cleanup to gradient index and hist.

### DIFF
--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -266,9 +266,9 @@ class ColumnMatrix {
   }
 
   template <typename T>
-  inline void SetIndexAllDense(T *index, const GHistIndexMatrix &gmat,
-                               const size_t nrow, const size_t nfeature,
-                               const bool noMissingValues, int32_t n_threads) {
+  inline void SetIndexAllDense(T const* index, const GHistIndexMatrix& gmat, const size_t nrow,
+                               const size_t nfeature, const bool noMissingValues,
+                               int32_t n_threads) {
     T* local_index = reinterpret_cast<T*>(&index_[0]);
 
     /* missing values make sense only for column with type kDenseColumn,
@@ -313,7 +313,7 @@ class ColumnMatrix {
   }
 
   template<typename T>
-  inline void SetIndex(uint32_t* index, const GHistIndexMatrix& gmat,
+  inline void SetIndex(uint32_t const* index, const GHistIndexMatrix& gmat,
                        const size_t nfeature) {
     std::vector<size_t> num_nonzeros;
     num_nonzeros.resize(nfeature);

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -197,19 +197,27 @@ enum BinTypeSize : uint32_t {
   kUint32BinsTypeSize = 4
 };
 
+/**
+ * \brief Optionally compressed gradient index. The compression works only with dense
+ *        data.
+ *
+ *   The main body of construction code is in gradient_index.cc, this struct is only a
+ *   storage class.
+ */
 struct Index {
-  Index() {
-    SetBinTypeSize(binTypeSize_);
-  }
+  Index() { SetBinTypeSize(binTypeSize_); }
   Index(const Index& i) = delete;
   Index& operator=(Index i) = delete;
   Index(Index&& i) = delete;
   Index& operator=(Index&& i) = delete;
   uint32_t operator[](size_t i) const {
-    if (offset_ptr_ != nullptr) {
-      return func_(data_ptr_, i) + offset_ptr_[i%p_];
+    if (!bin_offset_.empty()) {
+      // dense, compressed
+      auto fidx = i % bin_offset_.size();
+      // restore the index by adding back its feature offset.
+      return func_(data_.data(), i) + bin_offset_[fidx];
     } else {
-      return func_(data_ptr_, i);
+      return func_(data_.data(), i);
     }
   }
   void SetBinTypeSize(BinTypeSize binTypeSize) {
@@ -225,35 +233,32 @@ struct Index {
         func_ = &GetValueFromUint32;
         break;
       default:
-        CHECK(binTypeSize == kUint8BinsTypeSize  ||
-              binTypeSize == kUint16BinsTypeSize ||
+        CHECK(binTypeSize == kUint8BinsTypeSize || binTypeSize == kUint16BinsTypeSize ||
               binTypeSize == kUint32BinsTypeSize);
     }
   }
   BinTypeSize GetBinTypeSize() const {
     return binTypeSize_;
   }
-  template<typename T>
-  T* data() const {  // NOLINT
-    return static_cast<T*>(data_ptr_);
+  template <typename T>
+  T const* data() const {  // NOLINT
+    return reinterpret_cast<T const*>(data_.data());
   }
-  uint32_t* Offset() const {
-    return offset_ptr_;
+  template <typename T>
+  T* data() {  // NOLINT
+    return reinterpret_cast<T*>(data_.data());
   }
-  size_t OffsetSize() const {
-    return offset_.size();
+  uint32_t const* Offset() const { return bin_offset_.data(); }
+  size_t OffsetSize() const { return bin_offset_.size(); }
+  size_t Size() const { return data_.size() / (binTypeSize_); }
+
+  void Resize(const size_t n_bytes) {
+    data_.resize(n_bytes);
   }
-  size_t Size() const {
-    return data_.size() / (binTypeSize_);
-  }
-  void Resize(const size_t nBytesData) {
-    data_.resize(nBytesData);
-    data_ptr_ = reinterpret_cast<void*>(data_.data());
-  }
-  void ResizeOffset(const size_t nDisps) {
-    offset_.resize(nDisps);
-    offset_ptr_ = offset_.data();
-    p_ = nDisps;
+  // set the offset used in compression, cut_ptrs is the CSC indptr in HistogramCuts
+  void SetBinOffset(std::vector<uint32_t> const& cut_ptrs) {
+    bin_offset_.resize(cut_ptrs.size() - 1);  // resize to number of features.
+    std::copy_n(cut_ptrs.begin(), bin_offset_.size(), bin_offset_.begin());
   }
   std::vector<uint8_t>::const_iterator begin() const {  // NOLINT
     return data_.begin();
@@ -270,24 +275,23 @@ struct Index {
   }
 
  private:
-  static uint32_t GetValueFromUint8(void *t, size_t i) {
-    return reinterpret_cast<uint8_t*>(t)[i];
+  // Functions to decompress the index.
+  static uint32_t GetValueFromUint8(uint8_t const* t, size_t i) { return t[i]; }
+  static uint32_t GetValueFromUint16(uint8_t const* t, size_t i) {
+    return reinterpret_cast<uint16_t const*>(t)[i];
   }
-  static uint32_t GetValueFromUint16(void* t, size_t i) {
-    return reinterpret_cast<uint16_t*>(t)[i];
-  }
-  static uint32_t GetValueFromUint32(void* t, size_t i) {
-    return reinterpret_cast<uint32_t*>(t)[i];
+  static uint32_t GetValueFromUint32(uint8_t const* t, size_t i) {
+    return reinterpret_cast<uint32_t const*>(t)[i];
   }
 
-  using Func = uint32_t (*)(void*, size_t);
+  using Func = uint32_t (*)(uint8_t const*, size_t);
 
   std::vector<uint8_t> data_;
-  std::vector<uint32_t> offset_;  // size of this field is equal to number of features
-  void* data_ptr_;
+  // starting position of each feature inside the cut values (the indptr of the CSC cut matrix
+  // HistogramCuts without the last entry.) Used for bin compression.
+  std::vector<uint32_t> bin_offset_;
+
   BinTypeSize binTypeSize_ {kUint8BinsTypeSize};
-  size_t p_ {1};
-  uint32_t* offset_ptr_ {nullptr};
   Func func_;
 };
 
@@ -304,9 +308,11 @@ int32_t XGBOOST_HOST_DEV_INLINE BinarySearchBin(size_t begin, size_t end,
     }
     previous_middle = middle;
 
+    // index into all the bins
     auto gidx = data[middle];
 
     if (gidx >= fidx_begin && gidx < fidx_end) {
+      // Found the intersection.
       return static_cast<int32_t>(gidx);
     } else if (gidx < fidx_begin) {
       begin = middle;
@@ -635,42 +641,6 @@ class GHistBuilder {
  private:
   /*! \brief number of all bins over all features */
   uint32_t nbins_ { 0 };
-};
-
-/*!
- * \brief A C-style array with in-stack allocation. As long as the array is smaller than
- * MaxStackSize, it will be allocated inside the stack. Otherwise, it will be
- * heap-allocated.
- */
-template<typename T, size_t MaxStackSize>
-class MemStackAllocator {
- public:
-  explicit MemStackAllocator(size_t required_size): required_size_(required_size) {
-  }
-
-  T* Get() {
-    if (!ptr_) {
-      if (MaxStackSize >= required_size_) {
-        ptr_ = stack_mem_;
-      } else {
-        ptr_ =  reinterpret_cast<T*>(malloc(required_size_ * sizeof(T)));
-        do_free_ = true;
-      }
-    }
-
-    return ptr_;
-  }
-
-  ~MemStackAllocator() {
-    if (do_free_) free(ptr_);
-  }
-
-
- private:
-  T* ptr_ = nullptr;
-  bool do_free_ = false;
-  size_t required_size_;
-  T stack_mem_[MaxStackSize];
 };
 }  // namespace common
 }  // namespace xgboost

--- a/src/tree/updater_approx.h
+++ b/src/tree/updater_approx.h
@@ -35,14 +35,12 @@ class ApproxRowPartitioner {
                              std::vector<uint32_t> const &cut_ptrs,
                              std::vector<float> const &cut_values) {
     int32_t gidx = -1;
-    auto const &row_ptr = index.row_ptr;
-    auto get_rid = [&](size_t ridx) { return row_ptr[ridx - index.base_rowid]; };
-
     if (index.IsDense()) {
-      gidx = index.index[get_rid(ridx) + fidx];
+      // RowIdx returns the starting pos of this row
+      gidx = index.index[index.RowIdx(ridx) + fidx];
     } else {
-      auto begin = get_rid(ridx);
-      auto end = get_rid(ridx + 1);
+      auto begin = index.RowIdx(ridx);
+      auto end = index.RowIdx(ridx + 1);
       auto f_begin = cut_ptrs[fidx];
       auto f_end = cut_ptrs[fidx + 1];
       gidx = common::BinarySearchBin(begin, end, index.index, f_begin, f_end);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -135,7 +135,7 @@ void QuantileHistMaker::Builder<GradientSumT>::InitRoot(
 
   {
     auto nid = RegTree::kRoot;
-    GHistRowT hist = this->histogram_builder_->Histogram()[nid];
+    auto hist = this->histogram_builder_->Histogram()[nid];
     GradientPairT grad_stat;
     if (data_layout_ == DataLayout::kDenseDataZeroBased ||
         data_layout_ == DataLayout::kDenseDataOneBased) {
@@ -149,7 +149,7 @@ void QuantileHistMaker::Builder<GradientSumT>::InitRoot(
         grad_stat.Add(et.GetGrad(), et.GetHess());
       }
     } else {
-      const RowSetCollection::Elem e = row_set_collection_[nid];
+      const common::RowSetCollection::Elem e = row_set_collection_[nid];
       for (const size_t *it = e.begin; it < e.end; ++it) {
         grad_stat.Add(gpair_h[*it].GetGrad(), gpair_h[*it].GetHess());
       }
@@ -229,7 +229,7 @@ template<typename GradientSumT>
 template <bool any_missing>
 void QuantileHistMaker::Builder<GradientSumT>::ExpandTree(
     const GHistIndexMatrix& gmat,
-    const ColumnMatrix& column_matrix,
+    const common::ColumnMatrix& column_matrix,
     DMatrix* p_fmat,
     RegTree* p_tree,
     const std::vector<GradientPair>& gpair_h) {

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -147,7 +147,7 @@ class QuantileHistMaker: public TreeUpdater {
   // training parameter
   TrainParam param_;
   // column accessor
-  ColumnMatrix column_matrix_;
+  common::ColumnMatrix column_matrix_;
   DMatrix const* p_last_dmat_ {nullptr};
   bool is_gmat_initialized_ {false};
 
@@ -155,7 +155,6 @@ class QuantileHistMaker: public TreeUpdater {
   template<typename GradientSumT>
   struct Builder {
    public:
-    using GHistRowT = GHistRow<GradientSumT>;
     using GradientPairT = xgboost::detail::GradientPairInternal<GradientSumT>;
     // constructor
     explicit Builder(const size_t n_trees, const TrainParam& param,
@@ -164,7 +163,6 @@ class QuantileHistMaker: public TreeUpdater {
         : n_trees_(n_trees),
           param_(param),
           pruner_(std::move(pruner)),
-          p_last_tree_(nullptr),
           p_last_fmat_(fmat),
           histogram_builder_{new HistogramBuilder<GradientSumT, CPUExpandEntry>},
           task_{task},
@@ -172,7 +170,7 @@ class QuantileHistMaker: public TreeUpdater {
       builder_monitor_.Init("Quantile::Builder");
     }
     // update one tree, growing
-    void Update(const GHistIndexMatrix& gmat, const ColumnMatrix& column_matrix,
+    void Update(const GHistIndexMatrix& gmat, const common::ColumnMatrix& column_matrix,
                 HostDeviceVector<GradientPair>* gpair, DMatrix* p_fmat, RegTree* p_tree);
 
     bool UpdatePredictionCache(const DMatrix* data,

--- a/tests/cpp/common/test_hist_util.cc
+++ b/tests/cpp/common/test_hist_util.cc
@@ -306,8 +306,8 @@ TEST(HistUtil, IndexBinBound) {
 }
 
 template <typename T>
-void CheckIndexData(T* data_ptr, uint32_t* offsets,
-                    const GHistIndexMatrix& hmat, size_t n_cols) {
+void CheckIndexData(T const* data_ptr, uint32_t const* offsets, const GHistIndexMatrix& hmat,
+                    size_t n_cols) {
   for (size_t i = 0; i < hmat.index.Size(); ++i) {
     EXPECT_EQ(data_ptr[i] + offsets[i % n_cols], hmat.index[i]);
   }
@@ -323,7 +323,7 @@ TEST(HistUtil, IndexBinData) {
   for (auto max_bin : kBinSizes) {
     auto p_fmat = RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
     GHistIndexMatrix hmat(p_fmat.get(), max_bin, 0.5, false, common::OmpGetNumThreads(0));
-    uint32_t* offsets = hmat.index.Offset();
+    uint32_t const* offsets = hmat.index.Offset();
     EXPECT_EQ(hmat.index.Size(), kRows*kCols);
     switch (max_bin) {
       case kBinSizes[0]:

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -24,7 +24,6 @@ class QuantileHistMock : public QuantileHistMaker {
   template <typename GradientSumT>
   struct BuilderMock : public QuantileHistMaker::Builder<GradientSumT> {
     using RealImpl = QuantileHistMaker::Builder<GradientSumT>;
-    using GHistRowT = typename RealImpl::GHistRowT;
 
     BuilderMock(const TrainParam &param, std::unique_ptr<TreeUpdater> pruner,
                 DMatrix const *fmat, GenericParameter const* ctx)


### PR DESCRIPTION
Extracted from https://github.com/dmlc/xgboost/pull/7659

* Code comments.
* Const accessor to index.
* Remove/rename some variables in the `Index` class.
* Simplify the `MemStackAllocator`.