### PR TITLE
Avoid print for R package.

### DIFF
--- a/include/xgboost/span.h
+++ b/include/xgboost/span.h
@@ -106,12 +106,7 @@ namespace common {
 
 #if defined(XGBOOST_STRICT_R_MODE) && XGBOOST_STRICT_R_MODE == 1
 
-#define KERNEL_CHECK(cond)                \
-  do {                                    \
-    if (XGBOOST_EXPECT(!(cond), false)) { \
-      printf("[xgboost] fatal error.\n"); \
-    }                                     \
-  } while (0)
+#define KERNEL_CHECK(cond)
 
 #define SPAN_CHECK(cond) KERNEL_CHECK(cond)
 


### PR DESCRIPTION
My mistake, didn't remember R package doesn't like standard output.  For now, the span doesn't perform any check for the R package.