### PR TITLE
Fix document build with scikit-learn

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,6 +2,7 @@ sphinx>=4.4.0
 mock
 sphinx_rtd_theme>=1.0.0
 breathe
+scikit-learn
 sh>=1.12.14
 matplotlib>=2.1
 graphviz

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=4.2.0
+sphinx>=4.4.0
 mock
 sphinx_rtd_theme>=1.0.0
 breathe


### PR DESCRIPTION
- Update sphinx, this is not necessary.
- Install sklearn when building the doc.

Close https://github.com/dmlc/xgboost/issues/6433 .