### PR TITLE
[jvm-packages] unify the set features API

### DIFF
--- a/jvm-packages/xgboost4j-spark-gpu/src/test/scala/ml/dmlc/xgboost4j/scala/rapids/spark/GpuXGBoostClassifierSuite.scala
+++ b/jvm-packages/xgboost4j-spark-gpu/src/test/scala/ml/dmlc/xgboost4j/scala/rapids/spark/GpuXGBoostClassifierSuite.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021 by Contributors
+ Copyright (c) 2021-2022 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ class GpuXGBoostClassifierSuite extends GpuTestSuite {
     StructField("f10", FloatType), StructField("f11", FloatType), StructField("f12", FloatType),
     StructField(labelName, FloatType)
   ))
-  val featureNames = schema.fieldNames.filter(s => !s.equals(labelName)).toSeq
+  val featureNames = schema.fieldNames.filter(s => !s.equals(labelName))
 
   test("The transform result should be same for several runs on same model") {
     withGpuSparkSession(enableCsvConf()) { spark =>
@@ -90,7 +90,7 @@ class GpuXGBoostClassifierSuite extends GpuTestSuite {
         .csv(dataPath).randomSplit(Array(0.7, 0.3), seed = 1)
 
       val classifier = new XGBoostClassifier(xgbParam)
-        .setFeaturesCols(featureNames)
+        .setFeaturesCol(featureNames)
         .setLabelCol(labelName)
         .setTreeMethod("gpu_hist")
       (classifier.fit(rawInput), testDf)
@@ -155,12 +155,12 @@ class GpuXGBoostClassifierSuite extends GpuTestSuite {
         "please refer to setFeaturesCols"))
 
       val left = cpuModel
-        .setFeaturesCols(featureNames)
+        .setFeaturesCol(featureNames)
         .transform(testDf)
         .collect()
 
       val right = cpuModelFromFile
-        .setFeaturesCols(featureNames)
+        .setFeaturesCol(featureNames)
         .transform(testDf)
         .collect()
 
@@ -177,7 +177,7 @@ class GpuXGBoostClassifierSuite extends GpuTestSuite {
         .csv(dataPath).randomSplit(Array(0.7, 0.3), seed = 1)
 
       val classifier = new XGBoostClassifier(xgbParam)
-        .setFeaturesCols(featureNames)
+        .setFeaturesCol(featureNames)
         .setLabelCol(labelName)
         .setTreeMethod("gpu_hist")
       classifier.fit(rawInput)

--- a/jvm-packages/xgboost4j-spark-gpu/src/test/scala/ml/dmlc/xgboost4j/scala/rapids/spark/GpuXGBoostRegressorSuite.scala
+++ b/jvm-packages/xgboost4j-spark-gpu/src/test/scala/ml/dmlc/xgboost4j/scala/rapids/spark/GpuXGBoostRegressorSuite.scala
@@ -35,7 +35,7 @@ class GpuXGBoostRegressorSuite extends GpuTestSuite {
     StructField("f3", FloatType),
     StructField(groupName, IntegerType)))
   val featureNames = schema.fieldNames.filter(s =>
-    !(s.equals(labelName) || s.equals(groupName))).toSeq
+    !(s.equals(labelName) || s.equals(groupName)))
 
   test("The transform result should be same for several runs on same model") {
     withGpuSparkSession(enableCsvConf()) { spark =>

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2014,2021 by Contributors
+ Copyright (c) 2014-2022 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -148,7 +148,7 @@ class XGBoostClassifier (
    *  This API is only used in GPU train pipeline of xgboost4j-spark-gpu, which requires
    *  all feature columns must be numeric types.
    */
-  def setFeaturesCols(value: Seq[String]): this.type =
+  def setFeaturesCol(value: Array[String]): this.type =
     set(featuresCols, value)
 
   // called at the start of fit/train when 'eval_metric' is not defined
@@ -264,7 +264,7 @@ class XGBoostClassificationModel private[ml](
    *  This API is only used in GPU train pipeline of xgboost4j-spark-gpu, which requires
    *  all feature columns must be numeric types.
    */
-  def setFeaturesCols(value: Seq[String]): this.type =
+  def setFeaturesCol(value: Array[String]): this.type =
     set(featuresCols, value)
 
   /**

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2014,2021 by Contributors
+ Copyright (c) 2014-2022 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -150,7 +150,7 @@ class XGBoostRegressor (
    *  This API is only used in GPU train pipeline of xgboost4j-spark-gpu, which requires
    *  all feature columns must be numeric types.
    */
-  def setFeaturesCols(value: Seq[String]): this.type =
+  def setFeaturesCols(value: Array[String]): this.type =
     set(featuresCols, value)
 
   // called at the start of fit/train when 'eval_metric' is not defined
@@ -257,7 +257,7 @@ class XGBoostRegressionModel private[ml] (
    *  This API is only used in GPU train pipeline of xgboost4j-spark-gpu, which requires
    *  all feature columns must be numeric types.
    */
-  def setFeaturesCols(value: Seq[String]): this.type =
+  def setFeaturesCols(value: Array[String]): this.type =
     set(featuresCols, value)
 
   /**

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GpuParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/GpuParams.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021 by Contributors
+ Copyright (c) 2021-2022 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -16,38 +16,19 @@
 
 package ml.dmlc.xgboost4j.scala.spark.params
 
-import org.json4s.DefaultFormats
-import org.json4s.jackson.JsonMethods.{compact, parse, render}
-
-import org.apache.spark.ml.param.{BooleanParam, Param, Params}
+import org.apache.spark.ml.param.{Params, StringArrayParam}
 
 trait GpuParams extends Params {
   /**
-   * Param for the names of feature columns.
+   * Param for the names of feature columns for GPU pipeline.
    * @group param
    */
-  final val featuresCols: StringSeqParam = new StringSeqParam(this, "featuresCols",
-    "a sequence of feature column names.")
+  final val featuresCols: StringArrayParam = new StringArrayParam(this, "featuresCols",
+    "an array of feature column names for GPU pipeline.")
 
-  setDefault(featuresCols, Seq.empty[String])
+  setDefault(featuresCols, Array.empty[String])
 
   /** @group getParam */
-  final def getFeaturesCols: Seq[String] = $(featuresCols)
+  final def getFeaturesCols: Array[String] = $(featuresCols)
 
-}
-
-class StringSeqParam(
-  parent: Params,
-  name: String,
-  doc: String) extends Param[Seq[String]](parent, name, doc) {
-
-  override def jsonEncode(value: Seq[String]): String = {
-    import org.json4s.JsonDSL._
-    compact(render(value))
-  }
-
-  override def jsonDecode(json: String): Seq[String] = {
-    implicit val formats = DefaultFormats
-    parse(json).extract[Seq[String]]
-  }
 }


### PR DESCRIPTION
For now, xgboost4j-spark has provided 2 APIs for setting features, 1 API for CPU, another for GPU, which may cause user confusion.

This PR deleted the GPU API and added an override CPU API  setFeaturesCol to accept Array[String] parameters.