### PR TITLE
Use argsort for GPU sketching.

### DIFF
--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -55,8 +55,9 @@ size_t SketchBatchNumElements(size_t sketch_batch_num_elements, size_t nnz) {
   // Use total memory if compiled with rmm.
 #if defined(XGBOOST_USE_RMM) && XGBOOST_USE_RMM == 1
   auto total = dh::TotalMemory(dh::CurrentDevice());
-#endif  // defined(XGBOOST_USE_RMM) && XGBOOST_USE_RMM == 1
+#else
   double total = dh::AvailableMemory(dh::CurrentDevice());
+#endif  // defined(XGBOOST_USE_RMM) && XGBOOST_USE_RMM == 1
   double constexpr kGB{1024 * 1024 * 1024};
   double constexpr kRatio = 0.8;
   size_t up;

--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -62,9 +62,13 @@ size_t SketchBatchNumElements(size_t sketch_batch_num_elements, size_t nnz) {
   } else if (total < 8 * kFactor) {
     // 0.5G elements, about 4 GB memory using u32 as sorted index.
     up = std::numeric_limits<int32_t>::max() / 4 * 0.8;
-  } else {
+  } else if (total < 16 * kFactor) {
     // 1G elements, about 8 GB memory using u32 as sorted index.
     up = std::numeric_limits<int32_t>::max() / 2 * 0.8;
+  } else if (total < 32 * kFactor) {
+    up = std::numeric_limits<int32_t>::max() * 0.8;
+  } else {
+    up = std::numeric_limits<uint32_t>::max() * 0.8;
   }
   if (sketch_batch_num_elements == 0) {
     return std::min(nnz, up);

--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -218,7 +218,8 @@ void ProcessWeightedBatch(int device, const SparsePage& page,
                          h_cuts_ptr.back(), dh::ToSpan(temp_weights));
 }
 
-HistogramCuts DeviceSketch(int device, DMatrix* dmat, int max_bins, size_t sketch_batch_num_elements) {
+HistogramCuts DeviceSketch(int device, DMatrix* dmat, int max_bins,
+                           size_t sketch_batch_num_elements) {
   dh::safe_cuda(cudaSetDevice(device));
   dmat->Info().feature_types.SetDevice(device);
   dmat->Info().feature_types.ConstDevicePointer();  // pull to device early

--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -89,10 +89,9 @@ size_t RequiredMemory(bst_row_t num_rows, bst_feature_t num_columns, size_t nnz,
   return peak;
 }
 
-size_t SketchBatchNumElements(size_t sketch_batch_num_elements,
-                              bst_row_t num_rows, bst_feature_t columns,
-                              size_t nnz, int device,
-                              size_t num_cuts, bool has_weight) {
+size_t SketchBatchNumElements(size_t sketch_batch_num_elements, bst_row_t num_rows,
+                              bst_feature_t columns, size_t nnz, int device, size_t num_cuts,
+                              bool has_weight) {
 #if defined(XGBOOST_USE_RMM) && XGBOOST_USE_RMM == 1
   // device available memory is not accurate when rmm is used.
   return nnz;
@@ -108,7 +107,8 @@ size_t SketchBatchNumElements(size_t sketch_batch_num_elements,
       sketch_batch_num_elements = std::min(num_rows * static_cast<size_t>(columns), nnz);
     }
   }
-  return sketch_batch_num_elements;
+  return std::min(sketch_batch_num_elements,
+                  static_cast<size_t>(std::numeric_limits<uint32_t>::max()));
 }
 
 template <typename Batch>

--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -43,18 +43,10 @@ size_t RequiredSampleCutsPerColumn(int max_bins, size_t num_rows) {
   return std::min(num_cuts, num_rows);
 }
 
-size_t RequiredSampleCuts(bst_row_t num_rows, bst_feature_t num_columns,
-                          size_t max_bins, size_t nnz) {
-  auto per_column = RequiredSampleCutsPerColumn(max_bins, num_rows);
-  auto if_dense = num_columns * per_column;
-  auto result = std::min(nnz, if_dense);
-  return result;
-}
-
 size_t SketchBatchNumElements(size_t sketch_batch_num_elements, size_t nnz) {
   // Use total memory if compiled with rmm.
 #if defined(XGBOOST_USE_RMM) && XGBOOST_USE_RMM == 1
-  auto total = dh::TotalMemory(dh::CurrentDevice());
+  double total = dh::TotalMemory(dh::CurrentDevice());
 #else
   double total = dh::AvailableMemory(dh::CurrentDevice());
 #endif  // defined(XGBOOST_USE_RMM) && XGBOOST_USE_RMM == 1
@@ -62,8 +54,8 @@ size_t SketchBatchNumElements(size_t sketch_batch_num_elements, size_t nnz) {
   double constexpr kRatio = 0.8;
   size_t up;
   auto factor = [](int32_t f) { return (1u << f) * kRatio; };
-  if (total < kGB / 4) {                                   // 256 MB available mem
-    up = std::numeric_limits<int32_t>::max() / factor(7);  // 102 MB for sorting
+  if (total < kGB / 4) {  // 256 MB available mem
+    up = std::numeric_limits<int32_t>::max() / factor(7);
   } else if (total < kGB / 2) {
     up = std::numeric_limits<int32_t>::max() / factor(6);
   } else if (total < kGB) {

--- a/src/common/hist_util.cuh
+++ b/src/common/hist_util.cuh
@@ -98,11 +98,11 @@ void MakeEntriesFromAdapter(AdapterBatch const& batch, BatchIter batch_iter, Ran
   dh::XGBCachingDeviceAllocator<char> alloc;
   auto entry_iter = thrust::make_counting_iterator<uint32_t>(0u);
   sorted_idx->resize(num_valid);
-  auto copyif_op = [=] XGBOOST_DEVICE(uint32_t idx) {
-    auto check = data::IsValidFunctor{missing};
-    return check(batch.GetElement(idx).value);
-  };
-  dh::CopyIf(entry_iter + range.begin(), entry_iter + range.end(), sorted_idx->begin(), copyif_op);
+  dh::CopyIf(entry_iter + range.begin(), entry_iter + range.end(), sorted_idx->begin(),
+             [=] XGBOOST_DEVICE(uint32_t idx) {
+               auto check = data::IsValidFunctor{missing};
+               return check(batch.GetElement(idx).value);
+             });
 }
 
 template <typename Batch>

--- a/src/common/hist_util.cuh
+++ b/src/common/hist_util.cuh
@@ -82,24 +82,6 @@ size_t SketchBatchNumElements(size_t sketch_batch_num_elements, size_t nnz);
 // We take more cuts than needed and then reduce them later
 size_t RequiredSampleCutsPerColumn(int max_bins, size_t num_rows);
 
-/* \brief Estimate required memory for each sliding window.
- *
- *   It's not precise as to obtain exact memory usage for sparse dataset we need to walk
- *   through the whole dataset first.  Also if data is from host DMatrix, we copy the
- *   weight, group and offset on first batch, which is not considered in the function.
- *
- * \param num_rows     Number of rows in this worker.
- * \param num_columns  Number of columns for this dataset.
- * \param nnz          Number of non-zero element.  Put in something greater than rows *
- *                     cols if nnz is unknown.
- * \param num_bins     Number of histogram bins.
- * \param with_weights Whether weight is used, works the same for ranking and other models.
- *
- * \return The estimated bytes
- */
-size_t RequiredMemory(bst_row_t num_rows, bst_feature_t num_columns, size_t nnz,
-                      size_t num_bins, bool with_weights);
-
 // Count the valid entries in each column and copy them out.
 template <typename AdapterBatch, typename BatchIter>
 void MakeEntriesFromAdapter(AdapterBatch const& batch, BatchIter batch_iter, Range1d range,

--- a/src/common/hist_util.cuh
+++ b/src/common/hist_util.cuh
@@ -126,7 +126,11 @@ void MakeEntriesFromAdapter(AdapterBatch const& batch, BatchIter batch_iter, Ran
   dh::XGBCachingDeviceAllocator<char> alloc;
   auto entry_iter = thrust::make_counting_iterator<uint32_t>(0u);
   sorted_idx->resize(num_valid);
-  dh::CopyIf(entry_iter + range.begin(), entry_iter + range.end(), sorted_idx->begin(), is_valid);
+  auto copyif_op = [=] XGBOOST_DEVICE(uint32_t idx) {
+    auto check = data::IsValidFunctor{missing};
+    return check(batch.GetElement(idx).value);
+  };
+  dh::CopyIf(entry_iter + range.begin(), entry_iter + range.end(), sorted_idx->begin(), copyif_op);
 }
 
 template <typename Batch>

--- a/src/common/hist_util.cuh
+++ b/src/common/hist_util.cuh
@@ -28,6 +28,21 @@ struct EntryCompareOp {
   }
 };
 
+template <typename Batch>
+struct SortIdxOp {
+  Batch batch;
+  bool XGBOOST_DEVICE operator()(uint32_t l, uint32_t r) {
+    auto le = batch.GetElement(l);
+    auto re = batch.GetElement(r);
+    // sort between columns
+    if (le.column_idx != re.column_idx) {
+      return le.column_idx < re.column_idx;
+    }
+    // sort within columns
+    return le.value < re.value;
+  }
+};
+
 // Get column size from adapter batch and for output cuts.
 template <typename Iter>
 void GetColumnSizesScan(int device, size_t num_columns, size_t num_cuts_per_feature,
@@ -97,38 +112,73 @@ size_t RequiredMemory(bst_row_t num_rows, bst_feature_t num_columns, size_t nnz,
 
 // Count the valid entries in each column and copy them out.
 template <typename AdapterBatch, typename BatchIter>
-void MakeEntriesFromAdapter(AdapterBatch const& batch, BatchIter batch_iter,
-                            Range1d range, float missing,
-                            size_t columns, size_t cuts_per_feature, int device,
+void MakeEntriesFromAdapter(AdapterBatch const& batch, BatchIter batch_iter, Range1d range,
+                            float missing, size_t columns, size_t cuts_per_feature, int device,
                             HostDeviceVector<SketchContainer::OffsetT>* cut_sizes_scan,
                             dh::caching_device_vector<size_t>* column_sizes_scan,
-                            dh::device_vector<Entry>* sorted_entries) {
-  auto entry_iter = dh::MakeTransformIterator<Entry>(
-      thrust::make_counting_iterator(0llu), [=] __device__(size_t idx) {
-        return Entry(batch.GetElement(idx).column_idx,
-                     batch.GetElement(idx).value);
-      });
+                            dh::device_vector<uint32_t>* sorted_idx) {
   data::IsValidFunctor is_valid(missing);
   // Work out how many valid entries we have in each column
-  GetColumnSizesScan(device, columns, cuts_per_feature,
-                     batch_iter, is_valid,
-                     range.begin(), range.end(),
-                     cut_sizes_scan,
-                     column_sizes_scan);
+  GetColumnSizesScan(device, columns, cuts_per_feature, batch_iter, is_valid, range.begin(),
+                     range.end(), cut_sizes_scan, column_sizes_scan);
   size_t num_valid = column_sizes_scan->back();
   // Copy current subset of valid elements into temporary storage and sort
-  sorted_entries->resize(num_valid);
-  dh::CopyIf(entry_iter + range.begin(), entry_iter + range.end(),
-             sorted_entries->begin(), is_valid);
+  dh::XGBCachingDeviceAllocator<char> alloc;
+  auto entry_iter = thrust::make_counting_iterator<uint32_t>(0u);
+  sorted_idx->resize(num_valid);
+  dh::CopyIf(entry_iter + range.begin(), entry_iter + range.end(), sorted_idx->begin(), is_valid);
 }
 
-void SortByWeight(dh::device_vector<float>* weights,
-                  dh::device_vector<Entry>* sorted_entries);
+template <typename Batch>
+void RemoveDuplicatedCategories(Batch batch, MetaInfo const& info, Span<bst_row_t> d_cuts_ptr,
+                                  dh::device_vector<uint32_t>* p_sorted_idx,
+                                  dh::caching_device_vector<size_t>* p_column_sizes_scan) {
+  auto d_feature_types = info.feature_types.ConstDeviceSpan();
+  CHECK(!d_feature_types.empty());
+  auto& column_sizes_scan = *p_column_sizes_scan;
+  auto& sorted_idx = *p_sorted_idx;
+  // Removing duplicated entries in categorical features.
+  dh::caching_device_vector<size_t> new_column_scan(column_sizes_scan.size());
+  dh::SegmentedUnique(column_sizes_scan.data().get(),
+                      column_sizes_scan.data().get() + column_sizes_scan.size(), sorted_idx.begin(),
+                      sorted_idx.end(), new_column_scan.data().get(), sorted_idx.begin(),
+                      [=] __device__(uint32_t const& l, uint32_t const& r) {
+                        auto const& le = batch.GetElement(l);
+                        auto const& re = batch.GetElement(r);
+                        if (le.column_idx == batch.GetElement(r).column_idx) {
+                          if (IsCat(d_feature_types, le.column_idx)) {
+                            return le.value == re.value;
+                          }
+                        }
+                        return false;
+                      });
 
-void RemoveDuplicatedCategories(
-    int32_t device, MetaInfo const &info, Span<bst_row_t> d_cuts_ptr,
-    dh::device_vector<Entry> *p_sorted_entries,
-    dh::caching_device_vector<size_t> *p_column_sizes_scan);
+  // Renew the column scan and cut scan based on categorical data.
+  auto d_old_column_sizes_scan = dh::ToSpan(column_sizes_scan);
+  dh::caching_device_vector<SketchContainer::OffsetT> new_cuts_size(info.num_col_ + 1);
+  CHECK_EQ(new_column_scan.size(), new_cuts_size.size());
+  dh::LaunchN(new_column_scan.size(),
+              [=, d_new_cuts_size = dh::ToSpan(new_cuts_size),
+               d_old_column_sizes_scan = dh::ToSpan(column_sizes_scan),
+               d_new_columns_ptr = dh::ToSpan(new_column_scan)] __device__(size_t idx) {
+                d_old_column_sizes_scan[idx] = d_new_columns_ptr[idx];
+                if (idx == d_new_columns_ptr.size() - 1) {
+                  return;
+                }
+                if (IsCat(d_feature_types, idx)) {
+                  // Cut size is the same as number of categories in input.
+                  d_new_cuts_size[idx] = d_new_columns_ptr[idx + 1] - d_new_columns_ptr[idx];
+                } else {
+                  d_new_cuts_size[idx] = d_cuts_ptr[idx + 1] - d_cuts_ptr[idx];
+                }
+              });
+  // Turn size into ptr.
+  thrust::exclusive_scan(thrust::device, new_cuts_size.cbegin(), new_cuts_size.cend(),
+                         d_cuts_ptr.data());
+}
+
+template <typename Batch>
+void SortWithWeight(Batch batch, Span<uint32_t> sorted_idx, Span<float> weights);
 }  // namespace detail
 
 // Compute sketch on DMatrix.
@@ -137,41 +187,37 @@ HistogramCuts DeviceSketch(int device, DMatrix* dmat, int max_bins,
                            size_t sketch_batch_num_elements = 0);
 
 template <typename AdapterBatch>
-void ProcessSlidingWindow(AdapterBatch const &batch, MetaInfo const &info,
-                          int device, size_t columns, size_t begin, size_t end,
-                          float missing, SketchContainer *sketch_container,
-                          int num_cuts) {
+void ProcessSlidingWindow(AdapterBatch const& batch, MetaInfo const& info, int device,
+                          size_t columns, size_t begin, size_t end, float missing,
+                          SketchContainer* sketch_container, int num_cuts) {
+  dh::safe_cuda(cudaSetDevice(device));
   // Copy current subset of valid elements into temporary storage and sort
-  dh::device_vector<Entry> sorted_entries;
   dh::caching_device_vector<size_t> column_sizes_scan;
   auto batch_iter = dh::MakeTransformIterator<data::COOTuple>(
       thrust::make_counting_iterator(0llu),
       [=] __device__(size_t idx) { return batch.GetElement(idx); });
   HostDeviceVector<SketchContainer::OffsetT> cuts_ptr;
   cuts_ptr.SetDevice(device);
-  detail::MakeEntriesFromAdapter(batch, batch_iter, {begin, end}, missing,
-                                 columns, num_cuts, device,
-                                 &cuts_ptr,
-                                 &column_sizes_scan,
-                                 &sorted_entries);
+  dh::device_vector<uint32_t> sorted_idx;
+  detail::MakeEntriesFromAdapter(batch, batch_iter, {begin, end}, missing, columns, num_cuts,
+                                 device, &cuts_ptr, &column_sizes_scan, &sorted_idx);
   dh::XGBDeviceAllocator<char> alloc;
-  thrust::sort(thrust::cuda::par(alloc), sorted_entries.begin(),
-               sorted_entries.end(), detail::EntryCompareOp());
+  thrust::sort(thrust::cuda::par(alloc), sorted_idx.begin(), sorted_idx.end(),
+               detail::SortIdxOp<AdapterBatch>{batch});
 
   if (sketch_container->HasCategorical()) {
     auto d_cuts_ptr = cuts_ptr.DeviceSpan();
-    detail::RemoveDuplicatedCategories(device, info, d_cuts_ptr,
-                                       &sorted_entries, &column_sizes_scan);
+    info.feature_types.SetDevice(device);
+    detail::RemoveDuplicatedCategories(batch, info, d_cuts_ptr, &sorted_idx, &column_sizes_scan);
   }
 
   auto d_cuts_ptr = cuts_ptr.DeviceSpan();
-  auto const &h_cuts_ptr = cuts_ptr.HostVector();
+  auto const& h_cuts_ptr = cuts_ptr.HostVector();
   // Extract the cuts from all columns concurrently
-  sketch_container->Push(dh::ToSpan(sorted_entries),
-                         dh::ToSpan(column_sizes_scan), d_cuts_ptr,
+  sketch_container->Push(batch, dh::ToSpan(sorted_idx), dh::ToSpan(column_sizes_scan), d_cuts_ptr,
                          h_cuts_ptr.back());
-  sorted_entries.clear();
-  sorted_entries.shrink_to_fit();
+  sorted_idx.clear();
+  sorted_idx.shrink_to_fit();
 }
 
 template <typename Batch>
@@ -190,18 +236,15 @@ void ProcessWeightedSlidingWindow(Batch batch, MetaInfo const& info,
   auto batch_iter = dh::MakeTransformIterator<data::COOTuple>(
     thrust::make_counting_iterator(0llu),
     [=] __device__(size_t idx) { return batch.GetElement(idx); });
-  dh::device_vector<Entry> sorted_entries;
+  dh::device_vector<uint32_t> sorted_idx;
   dh::caching_device_vector<size_t> column_sizes_scan;
   HostDeviceVector<SketchContainer::OffsetT> cuts_ptr;
-  detail::MakeEntriesFromAdapter(batch, batch_iter,
-                                 {begin, end}, missing,
-                                 columns, num_cuts_per_feature, device,
-                                 &cuts_ptr,
-                                 &column_sizes_scan,
-                                 &sorted_entries);
+  detail::MakeEntriesFromAdapter(batch, batch_iter, {begin, end}, missing, columns,
+                                 num_cuts_per_feature, device, &cuts_ptr, &column_sizes_scan,
+                                 &sorted_idx);
   data::IsValidFunctor is_valid(missing);
 
-  dh::device_vector<float> temp_weights(sorted_entries.size());
+  dh::device_vector<float> temp_weights(sorted_idx.size());
   auto d_temp_weights = dh::ToSpan(temp_weights);
 
   if (is_ranking) {
@@ -233,23 +276,22 @@ void ProcessWeightedSlidingWindow(Batch batch, MetaInfo const& info,
     CHECK_EQ(retit - d_temp_weights.data(), d_temp_weights.size());
   }
 
-  detail::SortByWeight(&temp_weights, &sorted_entries);
+  detail::SortWithWeight(batch, dh::ToSpan(sorted_idx), dh::ToSpan(temp_weights));
 
   if (sketch_container->HasCategorical()) {
     auto d_cuts_ptr = cuts_ptr.DeviceSpan();
-    detail::RemoveDuplicatedCategories(device, info, d_cuts_ptr,
-                                       &sorted_entries, &column_sizes_scan);
+    info.feature_types.SetDevice(device);
+    detail::RemoveDuplicatedCategories(batch, info, d_cuts_ptr, &sorted_idx, &column_sizes_scan);
   }
 
   auto const& h_cuts_ptr = cuts_ptr.ConstHostVector();
   auto d_cuts_ptr = cuts_ptr.DeviceSpan();
 
   // Extract cuts
-  sketch_container->Push(dh::ToSpan(sorted_entries),
-                         dh::ToSpan(column_sizes_scan), d_cuts_ptr,
+  sketch_container->Push(batch, dh::ToSpan(sorted_idx), dh::ToSpan(column_sizes_scan), d_cuts_ptr,
                          h_cuts_ptr.back(), dh::ToSpan(temp_weights));
-  sorted_entries.clear();
-  sorted_entries.shrink_to_fit();
+  sorted_idx.clear();
+  sorted_idx.shrink_to_fit();
 }
 
 /*

--- a/src/common/hist_util.cuh
+++ b/src/common/hist_util.cuh
@@ -77,7 +77,7 @@ void GetColumnSizesScan(int device, size_t num_columns, size_t num_cuts_per_feat
 inline size_t constexpr BytesPerElement(bool has_weight) {
   // Double the memory usage for sorting.  We need to assign weight for each element, so
   // sizeof(float) is added to all elements.
-  return (has_weight ? sizeof(Entry) + sizeof(float) : sizeof(Entry)) * 2;
+  return (has_weight ? sizeof(uint32_t) + sizeof(float) : sizeof(uint32_t)) * 2;
 }
 
 /* \brief Calcuate the length of sliding window. Returns `sketch_batch_num_elements`

--- a/src/common/quantile.cu
+++ b/src/common/quantile.cu
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 by XGBoost Contributors
+ * Copyright 2020-2022, XGBoost Contributors
  */
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>

--- a/src/common/quantile.cuh
+++ b/src/common/quantile.cuh
@@ -1,3 +1,6 @@
+/*!
+ * Copyright 2020-2022, XGBoost Contributors
+ */
 #ifndef XGBOOST_COMMON_QUANTILE_CUH_
 #define XGBOOST_COMMON_QUANTILE_CUH_
 

--- a/src/common/quantile.cuh
+++ b/src/common/quantile.cuh
@@ -141,16 +141,13 @@ class SketchContainer {
 
   /* \brief Push sorted entries.
    *
-   * \param entries Sorted entries.
+   * \param batch Batch from adapter that implements `GetElement`.
+   * \param sorted_idx Sorted entries.
    * \param columns_ptr CSC pointer for entries.
    * \param cuts_ptr CSC pointer for cuts.
    * \param total_cuts Total number of cuts, equal to the back of cuts_ptr.
    * \param weights (optional) data weights.
    */
-  void Push(Span<Entry const> entries, Span<size_t> columns_ptr,
-            common::Span<OffsetT> cuts_ptr, size_t total_cuts,
-            Span<float> weights = {});
-
   template <typename Batch>
   void Push(Batch batch, Span<uint32_t const> sorted_idx, Span<size_t> columns_ptr,
             Span<OffsetT> cuts_ptr, size_t total_cuts, Span<float> weights = {});

--- a/tests/cpp/common/test_hist_util.cu
+++ b/tests/cpp/common/test_hist_util.cu
@@ -47,25 +47,6 @@ TEST(HistUtil, DeviceSketch) {
   EXPECT_EQ(device_cuts.MinValues(), host_cuts.MinValues());
 }
 
-TEST(HistUtil, DeviceSketchWeightsMemory) {
-  int num_columns = 100;
-  int num_rows = 1000;
-  int num_bins = 256;
-  auto x = GenerateRandom(num_rows, num_columns);
-  auto dmat = GetDMatrixFromData(x, num_rows, num_columns);
-  dmat->Info().weights_.HostVector() = GenerateRandomWeights(num_rows);
-
-  dh::GlobalMemoryLogger().Clear();
-  ConsoleLogger::Configure({{"verbosity", "3"}});
-  auto device_cuts = DeviceSketch(0, dmat.get(), num_bins);
-  ConsoleLogger::Configure({{"verbosity", "0"}});
-
-  size_t bytes_required = detail::RequiredMemory(
-      num_rows, num_columns, num_rows * num_columns, num_bins, true);
-  EXPECT_LE(dh::GlobalMemoryLogger().PeakMemory(), bytes_required * 1.05);
-  EXPECT_GE(dh::GlobalMemoryLogger().PeakMemory(), bytes_required);
-}
-
 TEST(HistUtil, DeviceSketchDeterminism) {
   int num_rows = 500;
   int num_columns = 5;

--- a/tests/python-gpu/test_large_input.py
+++ b/tests/python-gpu/test_large_input.py
@@ -1,8 +1,11 @@
+import sys
 import numpy as np
 import xgboost as xgb
 import cupy as cp
-import time
 import pytest
+
+sys.path.append("tests/python")
+import testing as tm
 
 
 # Test for integer overflow or out of memory exceptions
@@ -12,10 +15,20 @@ def test_large_input():
     required_bytes = 1.5e+10
     if available_bytes < required_bytes:
         pytest.skip("Not enough memory on this device")
+
     n = 1000
     m = ((1 << 31) + n - 1) // n
     assert (np.log2(m * n) > 31)
     X = cp.ones((m, n), dtype=np.float32)
     y = cp.ones(m)
     dmat = xgb.DeviceQuantileDMatrix(X, y)
-    xgb.train({"tree_method": "gpu_hist", "max_depth": 1}, dmat, 1)
+    result = {}
+    xgb.train(
+        {"tree_method": "gpu_hist", "max_depth": 2},
+        dmat,
+        4,
+        evals=[(dmat, "Train")],
+        evals_result=result
+    )
+
+    tm.non_increasing(result["Train"]["rmse"])


### PR DESCRIPTION
* Sort `uint32_t` index instead of `xgboost::Entry`, which is half of the size.
* Replace the memory tracking code with something simpler.

I think this is the most memory-efficient way to perform the sort, unless we go down even further to `uint16_t`.

For dense cupy array using `DeviceQuantileDMatrix`, this can save up to 33% GPU memory for f64 and 40% memory for f32 inputs.

Close https://github.com/dmlc/xgboost/issues/6759 .