### PR TITLE
Cache binary search result for GPU cat evaluation.

### DIFF
--- a/src/tree/gpu_hist/evaluate_splits.cuh
+++ b/src/tree/gpu_hist/evaluate_splits.cuh
@@ -51,6 +51,8 @@ class GPUHistEvaluator {
   dh::CUDAStream copy_stream_;
   // storage for sorted index of feature histogram, used for sort based splits.
   dh::device_vector<bst_feature_t> cat_sorted_idx_;
+  // cache of feature index for each thread in sorting.
+  dh::device_vector<bst_feature_t> fidx_;
   TrainParam param_;
   // whether the input data requires sort based split, which is more complicated so we try
   // to avoid it if possible.


### PR DESCRIPTION
This slightly reduces the time used for the thrust stable sort.  Using the cat_in_the_dat example in demo, the time is reduced from about 4.2 seconds to 3 seconds (32 rounds only).  It's a small dataset so might not be representative.

To have good performance for GPU, I think in the future we either have to choose a different algorithm that doesn't require sorting, or we continue our path to fuse the kernels for multiple nodes.