### PR TITLE
Initialize TreeUpdater ctx_ with nullptr

### DIFF
--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -32,7 +32,7 @@ class Json;
  */
 class TreeUpdater : public Configurable {
  protected:
-  GenericParameter const* ctx_;
+  GenericParameter const* ctx_ = nullptr;
 
  public:
   /*! \brief virtual destructor */


### PR DESCRIPTION
MemorySanitizer build complains that https://github.com/dmlc/xgboost/blob/a62a3d991d8826719e13f6e7b502b9c0409bbaac/src/tree/updater_prune.cc#L27 use-of-uninitialized-value.