### PR TITLE
Correct xgboost-config directory for inclusion in other projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,7 @@ write_basic_package_version_file(
   COMPATIBILITY AnyNewerVersion)
 install(
   FILES
-  ${CMAKE_BINARY_DIR}/cmake/xgboost-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/xgboost-config.cmake
   ${CMAKE_BINARY_DIR}/cmake/xgboost-config-version.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/xgboost)
 


### PR DESCRIPTION
Currently, `xgboost-config.cmake` is created in the `CMAKE_CURRENT_BINARY_DIR` directory, but we attempt to install it from the `CMAKE_BINARY_DIR` directory. For downstream projects attempting to consume xgboost from e.g. CPM, this prevents the install from going through successfully.