### PR TITLE
Sort sparse page index when constructing DMatrix.

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -201,6 +201,9 @@ struct Entry {
   inline static bool CmpValue(const Entry& a, const Entry& b) {
     return a.fvalue < b.fvalue;
   }
+  static bool CmpIndex(Entry const& a, Entry const& b) {
+    return a.index < b.index;
+  }
   inline bool operator==(const Entry& other) const {
     return (this->index == other.index && this->fvalue == other.fvalue);
   }
@@ -313,6 +316,7 @@ class SparsePage {
 
   SparsePage GetTranspose(int num_columns, int32_t n_threads) const;
 
+  void SortIndices(int32_t n_threads);
   void SortRows(int32_t n_threads);
 
   /**

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -316,7 +316,15 @@ class SparsePage {
 
   SparsePage GetTranspose(int num_columns, int32_t n_threads) const;
 
+  /**
+   * \brief Sort the column index.
+   */
   void SortIndices(int32_t n_threads);
+  /**
+   * \brief Check wether the column index is sorted.
+   */
+  bool IsIndicesSorted(int32_t n_threads) const;
+
   void SortRows(int32_t n_threads);
 
   /**

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -1045,8 +1045,8 @@ bool SparsePage::IsIndicesSorted(int32_t n_threads) const {
     is_sorted_tloc[omp_get_thread_num()] +=
         !!std::is_sorted(h_data.begin() + beg, h_data.begin() + end, Entry::CmpIndex);
   });
-  auto is_sorted =
-      std::accumulate(is_sorted_tloc.cbegin(), is_sorted_tloc.cend(), 0) == this->Size();
+  auto is_sorted = std::accumulate(is_sorted_tloc.cbegin(), is_sorted_tloc.cend(),
+                                   static_cast<size_t>(0)) == this->Size();
   return is_sorted;
 }
 

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -1035,6 +1035,16 @@ SparsePage SparsePage::GetTranspose(int num_columns, int32_t n_threads) const {
   return transpose;
 }
 
+void SparsePage::SortIndices(int32_t n_threads) {
+  auto& h_offset = this->offset.HostVector();
+  auto& h_data = this->data.HostVector();
+  common::ParallelFor(this->Size(), n_threads, [&](auto i) {
+    auto beg = h_offset[i];
+    auto end = h_offset[i + 1];
+    std::sort(h_data.begin() + beg, h_data.begin() + end, Entry::CmpIndex);
+  });
+}
+
 void SparsePage::SortRows(int32_t n_threads) {
   auto& h_offset = this->offset.HostVector();
   auto& h_data = this->data.HostVector();
@@ -1160,7 +1170,6 @@ uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread
     });
   }
   exec.Rethrow();
-
   return max_columns;
 }
 

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -212,7 +212,10 @@ SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {
   }
   info_.num_nonzero_ = data_vec.size();
 
-  sparse_page_->SortIndices(this->ctx_.Threads());
+  // Sort the index for row partitioners used by variuos tree methods.
+  if (!sparse_page_->IsIndicesSorted(this->ctx_.Threads())) {
+    sparse_page_->SortIndices(this->ctx_.Threads());
+  }
 }
 
 SimpleDMatrix::SimpleDMatrix(dmlc::Stream* in_stream) {

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -211,6 +211,8 @@ SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, int nthread) {
     info_.num_row_ = adapter->NumRows();
   }
   info_.num_nonzero_ = data_vec.size();
+
+  sparse_page_->SortIndices(this->ctx_.Threads());
 }
 
 SimpleDMatrix::SimpleDMatrix(dmlc::Stream* in_stream) {


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/7729 .
Close https://github.com/dmlc/xgboost/issues/5301 .

GPU DMatrix constructor is unaffected as it doesn't support cupyx yet, all the other inputs are dense.

This might hit performance, another way to fix the issue with scipy sparse is to sort the index in Python instead of the low-level constructor, however, it won't prevent issues with other inputs.  Lastly, we can simply check for sorted data and raise an error for unsorted inputs.