### PR TITLE
Fix cox objective test by using XGBOOST_PARALLEL_STABLE_SORT

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -124,7 +124,7 @@ class MetaInfo {
     label_order_cache_.resize(labels.Size());
     std::iota(label_order_cache_.begin(), label_order_cache_.end(), 0);
     const auto& l = labels.Data()->HostVector();
-    XGBOOST_PARALLEL_SORT(label_order_cache_.begin(), label_order_cache_.end(),
+    XGBOOST_PARALLEL_STABLE_SORT(label_order_cache_.begin(), label_order_cache_.end(),
               [&l](size_t i1, size_t i2) {return std::abs(l[i1]) < std::abs(l[i2]);});
 
     return label_order_cache_;


### PR DESCRIPTION
XGBOOST_PARALLEL_SORT cannot preserve the original order of
equal elements. It causes flaky failure for the cox regression
unittest. Use stable sort to make sure the result is deterministic.

Fix #7754