### PR TITLE
[CI] Enable faulthandler to show details when 0xC0000005 error occurs

### DIFF
--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -153,9 +153,9 @@ def TestWin64() {
     conda activate ${env_name} && for /R %%i in (python-package\\dist\\*.whl) DO python -m pip install "%%i"
     """
     echo "Running Python tests..."
-    bat "conda activate ${env_name} && python -m pytest -v -s -rxXs --fulltrace tests\\python"
+    bat "conda activate ${env_name} && python -X faulthandler -m pytest -v -s -rxXs --fulltrace tests\\python"
     bat """
-    conda activate ${env_name} && python -m pytest -v -s -rxXs --fulltrace -m "(not slow) and (not mgpu)" tests\\python-gpu
+    conda activate ${env_name} && python -X faulthandler -m pytest -v -s -rxXs --fulltrace -m "(not slow) and (not mgpu)" tests\\python-gpu
     """
     bat "conda env remove --name ${env_name}"
     deleteDir()

--- a/tests/ci_build/conda_env/win64_test.yml
+++ b/tests/ci_build/conda_env/win64_test.yml
@@ -8,13 +8,13 @@ dependencies:
 - matplotlib
 - scikit-learn
 - pandas
+- matplotlib
 - pytest
 - boto3
 - hypothesis
 - jsonschema
 - cupy
 - python-graphviz
-- modin-ray
 - pip
 - py-ubjson
 - cffi

--- a/tests/ci_build/conda_env/win64_test.yml
+++ b/tests/ci_build/conda_env/win64_test.yml
@@ -8,7 +8,6 @@ dependencies:
 - matplotlib
 - scikit-learn
 - pandas
-- matplotlib
 - pytest
 - boto3
 - hypothesis


### PR DESCRIPTION
From https://xgboost-ci.net/blue/organizations/jenkins/xgboost-win64/detail/release_1.6.0/2/pipeline:
```
=========================== short test summary info ===========================
SKIPPED [1] tests\python\test_tracker.py:9: Skipping dask tests on Windows
SKIPPED [1] tests\python\test_with_dask.py:28: Skipping dask tests on Windows
SKIPPED [1] tests\python\test_demos.py:160: Test requires sh execution.
SKIPPED [1] tests\python\test_dt.py:21: Datatable is not installed. or Pandas is not installed.
SKIPPED [1] tests\python\test_with_shap.py:16: Requires shap package
========== 277 passed, 5 skipped, 144 warnings in 411.14s (0:06:51) ===========

script returned exit code -1073741819
```

To show more details, enable the faulthandler in Python (see https://github.com/pytest-dev/pytest/issues/7634).