### PR TITLE
[CI] Speed up CPU test pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,7 +132,7 @@ def ClangTidy() {
 }
 
 def BuildCPU() {
-  node('linux && cpu') {
+  node('linux && cpu_build') {
     unstash name: 'srcs'
     echo "Build CPU"
     def container_type = "cpu"
@@ -189,7 +189,7 @@ def BuildCPUARM64() {
 }
 
 def BuildCPUMock() {
-  node('linux && cpu') {
+  node('linux && cpu_build') {
     unstash name: 'srcs'
     echo "Build CPU with rabit mock"
     def container_type = "cpu"


### PR DESCRIPTION
The CPU Python tests are currently sharing a worker machine with a build job. They should run on different machines so that the Python tests don't get slowed down.