### PR TITLE
[jvm-packges] set the correct objective if user doesn't explicitly set it

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -178,17 +178,15 @@ class XGBoostClassifier (
     }
 
     if (_numClasses == 2) {
-      if (getObjective != "binary:logistic") {
-        throw new IllegalArgumentException("when num class = 2, the objective must be set to" +
-          s" binary:logistic, found $getObjective")
+      if (!isDefined(objective)) {
+        // If user doesn't set objective, force it to binary:logistic
+        setObjective("binary:logistic")
       }
     } else if (_numClasses > 2) {
-      if (getObjective != "multi:softprob" && getObjective != "multi:softmax") {
-        throw new IllegalArgumentException("when num class > 2, the objective must be set to " +
-          s"multi:softprob or multi:softmax, Found: $getObjective")
+      if (!isDefined(objective)) {
+        // If user doesn't set objective, force it to multi:softprob
+        setObjective("multi:softprob")
       }
-    } else {
-      throw new RuntimeException(s"The number of classes [${_numClasses}] is not correct")
     }
 
     if (!isDefined(evalMetric) || $(evalMetric).isEmpty) {

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifier.scala
@@ -179,15 +179,13 @@ class XGBoostClassifier (
 
     if (_numClasses == 2) {
       if (getObjective != "binary:logistic") {
-        logWarning(s"Incorrect objective [${getObjective}] for classification " +
-          "when num class = 2, force to binary:logistic")
-        setObjective("binary:logistic")
+        throw new IllegalArgumentException("when num class = 2, the objective must be set to" +
+          s" binary:logistic, found $getObjective")
       }
     } else if (_numClasses > 2) {
       if (getObjective != "multi:softprob" && getObjective != "multi:softmax") {
-        logWarning(s"Incorrect objective [${getObjective}] for classification " +
-          s"when num class > 2, force to multi:softprob")
-        setObjective("multi:softprob")
+        throw new IllegalArgumentException("when num class > 2, the objective must be set to " +
+          s"multi:softprob or multi:softmax, Found: $getObjective")
       }
     } else {
       throw new RuntimeException(s"The number of classes [${_numClasses}] is not correct")

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressor.scala
@@ -171,6 +171,11 @@ class XGBoostRegressor (
 
   override protected def train(dataset: Dataset[_]): XGBoostRegressionModel = {
 
+    if (!isDefined(objective)) {
+      // If user doesn't set objective, force it to reg:squarederror
+      setObjective("reg:squarederror")
+    }
+
     if (!isDefined(evalMetric) || $(evalMetric).isEmpty) {
       set(evalMetric, setupDefaultEvalMetric())
     }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/LearningTaskParams.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2014 by Contributors
+ Copyright (c) 2014-2022 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ private[spark] trait LearningTaskParams extends Params {
 
   final def getMaximizeEvaluationMetrics: Boolean = $(maximizeEvaluationMetrics)
 
-  setDefault(objective -> "reg:squarederror", baseScore -> 0.5, trainTestRatio -> 1.0,
+  setDefault(baseScore -> 0.5, trainTestRatio -> 1.0,
     numEarlyStoppingRounds -> 0, cacheTrainingSet -> false)
 }
 

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/ParameterSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/ParameterSuite.scala
@@ -40,18 +40,6 @@ class ParameterSuite extends FunSuite with PerTest with BeforeAndAfterAll {
     assert(xgbCopy2.MLlib2XGBoostParams("eval_metric").toString === "logloss")
   }
 
-  test("fail training elegantly with unsupported objective function") {
-    val paramMap = Map("eta" -> "0.1", "max_depth" -> "6", "silent" -> "1",
-      "objective" -> "wrong_objective_function", "num_class" -> "6", "num_round" -> 5,
-      "num_workers" -> numWorkers)
-    val trainingDF = buildDataFrame(MultiClassification.train)
-    val xgb = new XGBoostClassifier(paramMap)
-    intercept[SparkException] {
-      xgb.fit(trainingDF)
-    }
-
-  }
-
   test("fail training elegantly with unsupported eval metrics") {
     val paramMap = Map("eta" -> "0.1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "multi:softmax", "num_class" -> "6", "num_round" -> 5,

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/ParameterSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/ParameterSuite.scala
@@ -40,6 +40,18 @@ class ParameterSuite extends FunSuite with PerTest with BeforeAndAfterAll {
     assert(xgbCopy2.MLlib2XGBoostParams("eval_metric").toString === "logloss")
   }
 
+  test("fail training elegantly with unsupported objective function") {
+    val paramMap = Map("eta" -> "0.1", "max_depth" -> "6", "silent" -> "1",
+      "objective" -> "wrong_objective_function", "num_class" -> "6", "num_round" -> 5,
+      "num_workers" -> numWorkers)
+    val trainingDF = buildDataFrame(MultiClassification.train)
+    val xgb = new XGBoostClassifier(paramMap)
+    intercept[SparkException] {
+      xgb.fit(trainingDF)
+    }
+
+  }
+
   test("fail training elegantly with unsupported eval metrics") {
     val paramMap = Map("eta" -> "0.1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "multi:softmax", "num_class" -> "6", "num_round" -> 5,

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/PersistenceSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/PersistenceSuite.scala
@@ -138,7 +138,7 @@ class PersistenceSuite extends FunSuite with TmpFolderPerSuite with PerTest {
     val testDM = new DMatrix(Classification.test.iterator)
     val paramMap = Map("eta" -> "0.1", "max_depth" -> "6", "silent" -> "1",
       "custom_eval" -> new EvalError, "custom_obj" -> new CustomObj(1),
-      "num_round" -> "10", "num_workers" -> numWorkers)
+      "num_round" -> "10", "num_workers" -> numWorkers, "objective" -> "binary:logistic")
 
     val xgbc = new XGBoostClassifier(paramMap)
     val xgbcPath = new File(tempDir.toFile, "xgbc").getPath

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
@@ -109,28 +109,24 @@ class XGBoostClassifierSuite extends FunSuite with PerTest {
     assert(!transformedDf.columns.contains("probability"))
   }
 
-  test("objective should be set correctly") {
+  test("throw exception when objective is not set correctly") {
     val training = buildDataFrame(Classification.train)
     val paramMap = Map("eta" -> "1", "max_depth" -> "6", "objective" -> "multi:softprob",
       "num_round" -> 5, "num_workers" -> numWorkers,
       "tree_method" -> treeMethod)
-
     val xgb = new XGBoostClassifier(paramMap)
-    assert(xgb.getObjective == "multi:softprob")
-    val model = xgb.fit(training)
-    assert(xgb.getObjective == "binary:logistic")
-    assert(model.getObjective == "binary:logistic")
+    intercept[IllegalArgumentException] {
+      xgb.fit(training)
+    }
 
     val paramMap1 = Map("eta" -> "0.1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "binary:logistic", "num_class" -> "6", "num_round" -> 5,
       "num_workers" -> numWorkers, "tree_method" -> treeMethod)
     val trainingDF = buildDataFrame(MultiClassification.train)
     val xgb1 = new XGBoostClassifier(paramMap1)
-    assert(xgb1.getObjective == "binary:logistic")
-    val model1 = xgb1.fit(trainingDF)
-    // after train, XGBoostClassifier has changed the objective to multi:softprob
-    assert(xgb1.getObjective == "multi:softprob")
-    assert(model1.getObjective == "multi:softprob")
+    intercept[IllegalArgumentException] {
+      xgb1.fit(trainingDF)
+    }
   }
 
   test("use base margin") {

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
@@ -109,6 +109,30 @@ class XGBoostClassifierSuite extends FunSuite with PerTest {
     assert(!transformedDf.columns.contains("probability"))
   }
 
+  test("objective should be set correctly") {
+    val training = buildDataFrame(Classification.train)
+    val paramMap = Map("eta" -> "1", "max_depth" -> "6", "objective" -> "multi:softprob",
+      "num_round" -> 5, "num_workers" -> numWorkers,
+      "tree_method" -> treeMethod)
+
+    val xgb = new XGBoostClassifier(paramMap)
+    assert(xgb.getObjective == "multi:softprob")
+    val model = xgb.fit(training)
+    assert(xgb.getObjective == "binary:logistic")
+    assert(model.getObjective == "binary:logistic")
+
+    val paramMap1 = Map("eta" -> "0.1", "max_depth" -> "6", "silent" -> "1",
+      "objective" -> "binary:logistic", "num_class" -> "6", "num_round" -> 5,
+      "num_workers" -> numWorkers, "tree_method" -> treeMethod)
+    val trainingDF = buildDataFrame(MultiClassification.train)
+    val xgb1 = new XGBoostClassifier(paramMap1)
+    assert(xgb1.getObjective == "binary:logistic")
+    val model1 = xgb1.fit(trainingDF)
+    // after train, XGBoostClassifier has changed the objective to multi:softprob
+    assert(xgb1.getObjective == "multi:softprob")
+    assert(model1.getObjective == "multi:softprob")
+  }
+
   test("use base margin") {
     val training1 = buildDataFrame(Classification.train)
     val training2 = training1.withColumn("margin", functions.rand())

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressorSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressorSuite.scala
@@ -146,6 +146,24 @@ class XGBoostRegressorSuite extends FunSuite with PerTest {
     prediction.foreach(x => assert(math.abs(x.getAs[Double]("prediction") - first) <= 0.01f))
   }
 
+  test("objective will be set if not specifying it") {
+    val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
+      "num_round" -> 5, "num_workers" -> numWorkers, "tree_method" -> treeMethod)
+    val training = buildDataFrame(Regression.train)
+    val xgb = new XGBoostRegressor(paramMap)
+    assert(!xgb.isDefined(xgb.objective))
+    xgb.fit(training)
+    assert(xgb.getObjective == "reg:squarederror")
+
+    val paramMap1 = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
+      "num_round" -> 5, "num_workers" -> numWorkers, "tree_method" -> treeMethod,
+      "objective" -> "reg:squaredlogerror")
+    val xgb1 = new XGBoostRegressor(paramMap1)
+    assert(xgb1.getObjective == "reg:squaredlogerror")
+    xgb1.fit(training)
+    assert(xgb1.getObjective == "reg:squaredlogerror")
+  }
+
   test("test predictionLeaf") {
     val paramMap = Map("eta" -> "1", "max_depth" -> "6", "silent" -> "1",
       "objective" -> "reg:squarederror", "num_round" -> 5, "num_workers" -> numWorkers,


### PR DESCRIPTION
This PR deletes the default value of "objective" and sets it correctly if the user does not explicitly set it.

For example, If the user does not see objective 
- XGBoostClassifier will set the objective according to the num class
- XGBoostRegressor will default the objective to "reg:squarederror"

