### PR TITLE
[jvm-packages] fix eval sets can't work when featuresCols is using

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostClassifierSuite.scala
@@ -370,6 +370,7 @@ class XGBoostClassifierSuite extends FunSuite with PerTest {
     val xgbClassifier = new XGBoostClassifier(paramMap)
       .setFeaturesCol(featuresName)
       .setLabelCol("label")
+      .setEvalSets(Map("eval" -> xgbInput))
 
     val model = xgbClassifier.fit(xgbInput)
     assert(model.getFeaturesCols.sameElements(featuresName))

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressorSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostRegressorSuite.scala
@@ -273,6 +273,7 @@ class XGBoostRegressorSuite extends FunSuite with PerTest {
     val xgbClassifier = new XGBoostRegressor(paramMap)
       .setFeaturesCol(featuresName)
       .setLabelCol("label")
+      .setEvalSets(Map("eval" -> xgbInput))
 
     val model = xgbClassifier.fit(xgbInput)
     assert(model.getFeaturesCols.sameElements(featuresName))


### PR DESCRIPTION
when set the feature columns by setFeatureCols(value: Array[String]), the evalSets will not work, since the dataset specified by evalSets has not been vectorized.

This PR add vectorizing for eval datasets.

@trivialfis this PR should be backported to 1.6.0

Sorry for that