### PR TITLE
Clear configuration cache.

### DIFF
--- a/src/learner.cc
+++ b/src/learner.cc
@@ -397,7 +397,7 @@ class LearnerConfiguration : public Learner {
       this->ValidateParameters();
     }
 
-    // FIXME(trivialfis): Clear the cache once binary IO is gone.
+    cfg_.clear();
     monitor_.Stop("Configure");
   }
 


### PR DESCRIPTION
Need a full test to see if it's possible to clear the cache.  Limiting the scope of a cache can clean up the configuration process.