### PR TITLE
[CI] make container be able to re-attached

### DIFF
--- a/tests/ci_build/entrypoint.sh
+++ b/tests/ci_build/entrypoint.sh
@@ -20,9 +20,9 @@ else
 fi
 
 if [[ -n $CI_BUILD_UID ]] && [[ -n $CI_BUILD_GID ]]; then
-    groupadd -o -g "${CI_BUILD_GID}" "${CI_BUILD_GROUP}"
+    groupadd -o -g "${CI_BUILD_GID}" "${CI_BUILD_GROUP}" || true
     useradd -o -m -g "${CI_BUILD_GID}" -u "${CI_BUILD_UID}" \
-        "${CI_BUILD_USER}"
+        "${CI_BUILD_USER}" || true
     export HOME="/home/${CI_BUILD_USER}"
     shopt -s dotglob
     cp -r /root/* "$HOME/"


### PR DESCRIPTION
When re-starting the container, it will fail in entrypoint.sh which
will exit when adding an existing group or user