### PR TITLE
[Breaking][jvm-packages] make classification model be xgboost-compatible

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/DefaultXGBoostParamsReader.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/DefaultXGBoostParamsReader.scala
@@ -51,7 +51,8 @@ private[spark] object DefaultXGBoostParamsReader {
       sparkVersion: String,
       params: JValue,
       metadata: JValue,
-      metadataJson: String) {
+      metadataJson: String,
+      xgboostVersion: Option[String] = None) {
 
     /**
      * Get the JSON value of the [[org.apache.spark.ml.param.Param]] of the given name.
@@ -108,8 +109,8 @@ private[spark] object DefaultXGBoostParamsReader {
       require(className == expectedClassName, s"Error loading metadata: Expected class name" +
         s" $expectedClassName but found class name $className")
     }
-
-    Metadata(className, uid, timestamp, sparkVersion, params, metadata, metadataStr)
+    val xgboostVersion = (metadata \ "xgboostVersion").extractOpt[String]
+    Metadata(className, uid, timestamp, sparkVersion, params, metadata, metadataStr, xgboostVersion)
   }
 
   private def handleBrokenlyChangedValue[T](paramName: String, value: T): T = {

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/DefaultXGBoostParamsWriter.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/DefaultXGBoostParamsWriter.scala
@@ -22,8 +22,8 @@ import org.apache.spark.SparkContext
 import org.apache.spark.ml.param.{ParamPair, Params}
 import org.json4s.jackson.JsonMethods._
 import org.json4s.{JArray, JBool, JDouble, JField, JInt, JNothing, JObject, JString, JValue}
-
 import JsonDSLXGBoost._
+import ml.dmlc.xgboost4j.scala.spark
 
 // This originates from apache-spark DefaultPramsWriter copy paste
 private[spark] object DefaultXGBoostParamsWriter {
@@ -78,6 +78,7 @@ private[spark] object DefaultXGBoostParamsWriter {
       ("timestamp" -> System.currentTimeMillis()) ~
       ("sparkVersion" -> sc.version) ~
       ("uid" -> uid) ~
+      ("xgboostVersion" -> spark.VERSION) ~
       ("paramMap" -> jsonParams)
     val metadata = extraMetadata match {
       case Some(jObject) =>


### PR DESCRIPTION
To fix https://github.com/dmlc/xgboost/issues/7895.

It's a breaking issue. The trained xgboost classification model in 2.0.0 can't be loaded by the previous xgboost version, but xgboost 2.0.0 still can load the previous model.