### PR TITLE
[WIP] Remove bin compression in column matrix.

### DIFF
--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -31,10 +31,7 @@ enum ColumnType : uint8_t { kDenseColumn, kSparseColumn };
     to reduce the memory usage. */
 class Column {
  public:
-  static constexpr bst_bin_t kMissingId = -1;
-  static constexpr bst_bin_t MissingIdx() {
-    return kMissingId;
-  }
+  static constexpr bst_bin_t MissingIdx() { return -1; }
 
   Column(ColumnType type, common::Span<bst_bin_t const> index, const bst_bin_t index_base)
       : type_(type), index_(index), index_base_{index_base} {}
@@ -73,7 +70,7 @@ class SparseColumn : public Column {
   bst_bin_t GetBinIdx(size_t rid, size_t* state) const {
     const size_t column_size = this->Size();
     if (!((*state) < column_size)) {
-      return this->kMissingId;
+      return MissingIdx();
     }
     while ((*state) < column_size && GetRowIdx(*state) < rid) {
       ++(*state);
@@ -81,7 +78,7 @@ class SparseColumn : public Column {
     if (((*state) < column_size) && GetRowIdx(*state) == rid) {
       return this->GetGlobalBinIdx(*state);
     } else {
-      return this->kMissingId;
+      return MissingIdx();
     }
   }
 

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -29,25 +29,22 @@ enum ColumnType : uint8_t { kDenseColumn, kSparseColumn };
     bin id is stored as index[i] + index_base.
     Different types of column index for each column allow
     to reduce the memory usage. */
-template <typename BinIdxType>
 class Column {
  public:
-  static constexpr int32_t kMissingId = -1;
+  static constexpr bst_bin_t kMissingId = -1;
+  static constexpr bst_bin_t MissingIdx() {
+    return kMissingId;
+  }
 
-  Column(ColumnType type, common::Span<const BinIdxType> index, const bst_bin_t index_base)
+  Column(ColumnType type, common::Span<bst_bin_t const> index, const bst_bin_t index_base)
       : type_(type), index_(index), index_base_{index_base} {}
 
   virtual ~Column() = default;
 
-  uint32_t GetGlobalBinIdx(size_t idx) const {
-    return index_base_ + static_cast<uint32_t>(index_[idx]);
-  }
-
-  BinIdxType GetFeatureBinIdx(size_t idx) const { return index_[idx]; }
-
-  uint32_t GetBaseIdx() const { return index_base_; }
-
-  common::Span<const BinIdxType> GetFeatureBinIdxPtr() const { return index_; }
+  bst_bin_t GetGlobalBinIdx(size_t idx) const { return index_base_ + index_[idx]; }
+  bst_bin_t GetFeatureBinIdx(size_t idx) const { return index_[idx]; }
+  bst_bin_t GetBaseIdx() const { return index_base_; }
+  common::Span<bst_bin_t const> GetFeatureBinIdxPtr() const { return index_; }
 
   ColumnType GetType() const { return type_; }
 
@@ -58,17 +55,16 @@ class Column {
   /* type of column */
   ColumnType type_;
   /* bin indexes in range [0, max_bins - 1] */
-  common::Span<const BinIdxType> index_;
+  common::Span<bst_bin_t const> index_;
   /* bin index offset for specific feature */
   bst_bin_t const index_base_;
 };
 
-template <typename BinIdxType>
-class SparseColumn : public Column<BinIdxType> {
+class SparseColumn : public Column {
  public:
-  SparseColumn(ColumnType type, common::Span<const BinIdxType> index, bst_bin_t index_base,
+  SparseColumn(ColumnType type, common::Span<bst_bin_t const> index, bst_bin_t index_base,
                common::Span<const size_t> row_ind)
-      : Column<BinIdxType>(type, index, index_base), row_ind_(row_ind) {}
+      : Column(type, index, index_base), row_ind_(row_ind) {}
 
   const size_t* GetRowData() const { return row_ind_.data(); }
 
@@ -103,30 +99,14 @@ class SparseColumn : public Column<BinIdxType> {
   common::Span<const size_t> row_ind_;
 };
 
-template <typename BinIdxType, bool any_missing>
-class DenseColumn : public Column<BinIdxType> {
+template <bool any_missing>
+class DenseColumn : public Column {
  public:
-  DenseColumn(ColumnType type, common::Span<const BinIdxType> index, uint32_t index_base,
-              const std::vector<bool>& missing_flags, size_t feature_offset)
-      : Column<BinIdxType>(type, index, index_base),
-        missing_flags_(missing_flags),
-        feature_offset_(feature_offset) {}
-  bool IsMissing(size_t idx) const { return missing_flags_[feature_offset_ + idx]; }
+  DenseColumn(ColumnType type, common::Span<int32_t const> index, uint32_t index_base)
+      : Column(type, index, index_base) {}
 
-  int32_t GetBinIdx(size_t idx, size_t* state) const {
-    if (any_missing) {
-      return IsMissing(idx) ? this->kMissingId : this->GetGlobalBinIdx(idx);
-    } else {
-      return this->GetGlobalBinIdx(idx);
-    }
-  }
-
+  bst_bin_t GetBinIdx(size_t idx, size_t* state) const { return this->GetGlobalBinIdx(idx); }
   size_t GetInitialState(const size_t first_row_id) const { return 0; }
-
- private:
-  /* flags for missing values in dense columns */
-  const std::vector<bool>& missing_flags_;
-  size_t feature_offset_;
 };
 
 /*! \brief a collection of columns, with support for construction from
@@ -142,18 +122,19 @@ class ColumnMatrix {
     auto const nfeature = static_cast<bst_feature_t>(gmat.cut.Ptrs().size() - 1);
     const size_t nrow = gmat.row_ptr.size() - 1;
     // identify type of each column
-    feature_counts_.resize(nfeature);
+    std::vector<size_t> feature_counts;
+    feature_counts.resize(nfeature);
     type_.resize(nfeature);
-    std::fill(feature_counts_.begin(), feature_counts_.end(), 0);
+    std::fill(feature_counts.begin(), feature_counts.end(), 0);
     uint32_t max_val = std::numeric_limits<uint32_t>::max();
     for (bst_feature_t fid = 0; fid < nfeature; ++fid) {
       CHECK_LE(gmat.cut.Ptrs()[fid + 1] - gmat.cut.Ptrs()[fid], max_val);
     }
     bool all_dense = gmat.IsDense();
-    gmat.GetFeatureCounts(&feature_counts_[0]);
+    gmat.GetFeatureCounts(&feature_counts[0]);
     // classify features
     for (bst_feature_t fid = 0; fid < nfeature; ++fid) {
-      if (static_cast<double>(feature_counts_[fid]) < sparse_threshold * nrow) {
+      if (static_cast<double>(feature_counts[fid]) < sparse_threshold * nrow) {
         type_[fid] = kSparseColumn;
         all_dense = false;
       } else {
@@ -164,20 +145,18 @@ class ColumnMatrix {
     // want to compute storage boundary for each feature
     // using variants of prefix sum scan
     feature_offsets_.resize(nfeature + 1);
-    size_t accum_index_ = 0;
-    feature_offsets_[0] = accum_index_;
+    size_t accum_index = 0;
+    feature_offsets_[0] = accum_index;
     for (bst_feature_t fid = 1; fid < nfeature + 1; ++fid) {
       if (type_[fid - 1] == kDenseColumn) {
-        accum_index_ += static_cast<size_t>(nrow);
+        accum_index += static_cast<size_t>(nrow);
       } else {
-        accum_index_ += feature_counts_[fid - 1];
+        accum_index += feature_counts[fid - 1];
       }
-      feature_offsets_[fid] = accum_index_;
+      feature_offsets_[fid] = accum_index;
     }
 
-    SetTypeSize(gmat.max_num_bins);
-
-    index_.resize(feature_offsets_[nfeature] * bins_type_size_, 0);
+    index_.resize(feature_offsets_[nfeature], Column::MissingIdx());
     if (!all_dense) {
       row_ind_.resize(feature_offsets_[nfeature]);
     }
@@ -187,13 +166,6 @@ class ColumnMatrix {
 
     const bool noMissingValues = NoMissingValues(gmat.row_ptr[nrow], nrow, nfeature);
     any_missing_ = !noMissingValues;
-
-    missing_flags_.clear();
-    if (noMissingValues) {
-      missing_flags_.resize(feature_offsets_[nfeature], false);
-    } else {
-      missing_flags_.resize(feature_offsets_[nfeature], true);
-    }
 
     // pre-fill index_ for dense columns
     if (all_dense) {
@@ -212,47 +184,25 @@ class ColumnMatrix {
       /* For sparse DMatrix gmat.index.getBinTypeSize() returns always kUint32BinsTypeSize
          but for ColumnMatrix we still have a chance to reduce the memory consumption */
     } else {
-      if (bins_type_size_ == kUint8BinsTypeSize) {
-        SetIndex<uint8_t>(page, gmat.index.data<uint32_t>(), gmat, nfeature);
-      } else if (bins_type_size_ == kUint16BinsTypeSize) {
-        SetIndex<uint16_t>(page, gmat.index.data<uint32_t>(), gmat, nfeature);
-      } else {
-        CHECK_EQ(bins_type_size_, kUint32BinsTypeSize);
-        SetIndex<uint32_t>(page, gmat.index.data<uint32_t>(), gmat, nfeature);
-      }
-    }
-  }
-
-  /* Set the number of bytes based on numeric limit of maximum number of bins provided by user */
-  void SetTypeSize(size_t max_num_bins) {
-    if ((max_num_bins - 1) <= static_cast<int>(std::numeric_limits<uint8_t>::max())) {
-      bins_type_size_ = kUint8BinsTypeSize;
-    } else if ((max_num_bins - 1) <= static_cast<int>(std::numeric_limits<uint16_t>::max())) {
-      bins_type_size_ = kUint16BinsTypeSize;
-    } else {
-      bins_type_size_ = kUint32BinsTypeSize;
+      SetIndex<uint32_t>(page, gmat.index.data<uint32_t>(), gmat, nfeature);
     }
   }
 
   /* Fetch an individual column. This code should be used with type swith
      to determine type of bin id's */
-  template <typename BinIdxType, bool any_missing>
-  std::unique_ptr<const Column<BinIdxType> > GetColumn(unsigned fid) const {
-    CHECK_EQ(sizeof(BinIdxType), bins_type_size_);
-
+  template <bool any_missing>
+  std::unique_ptr<const Column> GetColumn(unsigned fid) const {
     const size_t feature_offset = feature_offsets_[fid];  // to get right place for certain feature
     const size_t column_size = feature_offsets_[fid + 1] - feature_offset;
-    common::Span<const BinIdxType> bin_index = {
-        reinterpret_cast<const BinIdxType*>(&index_[feature_offset * bins_type_size_]),
-        column_size};
-    std::unique_ptr<const Column<BinIdxType> > res;
+    common::Span<const int32_t> bin_index = {
+        reinterpret_cast<const int32_t*>(&index_[feature_offset]), column_size};
+    std::unique_ptr<const Column> res;
     if (type_[fid] == ColumnType::kDenseColumn) {
       CHECK_EQ(any_missing, any_missing_);
-      res.reset(new DenseColumn<BinIdxType, any_missing>(type_[fid], bin_index, index_base_[fid],
-                                                         missing_flags_, feature_offset));
+      res.reset(new DenseColumn<any_missing>(type_[fid], bin_index, index_base_[fid]));
     } else {
-      res.reset(new SparseColumn<BinIdxType>(type_[fid], bin_index, index_base_[fid],
-                                             {&row_ind_[feature_offset], column_size}));
+      res.reset(new SparseColumn(type_[fid], bin_index, index_base_[fid],
+                                 {&row_ind_[feature_offset], column_size}));
     }
     return res;
   }
@@ -261,7 +211,7 @@ class ColumnMatrix {
   inline void SetIndexAllDense(SparsePage const& page, T const* index, const GHistIndexMatrix& gmat,
                                const size_t nrow, const size_t nfeature, const bool noMissingValues,
                                int32_t n_threads) {
-    T* local_index = reinterpret_cast<T*>(&index_[0]);
+    bst_bin_t* local_index = index_.data();
 
     /* missing values make sense only for column with type kDenseColumn,
        and if no missing values were observed it could be handled much faster. */
@@ -272,18 +222,15 @@ class ColumnMatrix {
         size_t j = 0;
         for (size_t i = ibegin; i < iend; ++i, ++j) {
           const size_t idx = feature_offsets_[j];
-          local_index[idx + rid] = index[i];
+          local_index[idx + rid] = static_cast<bst_bin_t>(index[i]);
         }
       });
     } else {
       /* to handle rows in all batches, sum of all batch sizes equal to gmat.row_ptr.size() - 1 */
       auto get_bin_idx = [&](auto bin_id, auto rid, bst_feature_t fid) {
-        // T* begin = &local_index[feature_offsets_[fid]];
         const size_t idx = feature_offsets_[fid];
         /* rbegin allows to store indexes from specific SparsePage batch */
-        local_index[idx + rid] = bin_id;
-
-        missing_flags_[idx + rid] = false;
+        local_index[idx + rid] = static_cast<bst_bin_t>(bin_id);
       };
       this->SetIndexSparse(page, index, gmat, nfeature, get_bin_idx);
     }
@@ -330,7 +277,6 @@ class ColumnMatrix {
       if (type_[fid] == kDenseColumn) {
         T* begin = &local_index[feature_offsets_[fid]];
         begin[rid] = bin_id - index_base_[fid];
-        missing_flags_[feature_offsets_[fid] + rid] = false;
       } else {
         T* begin = &local_index[feature_offsets_[fid]];
         begin[num_nonzeros[fid]] = bin_id - index_base_[fid];
@@ -340,8 +286,6 @@ class ColumnMatrix {
     };
     this->SetIndexSparse(page, index, gmat, nfeature, get_bin_idx);
   }
-
-  BinTypeSize GetTypeSize() const { return bins_type_size_; }
 
   // This is just an utility function
   bool NoMissingValues(const size_t n_elements, const size_t n_row, const size_t n_features) {
@@ -354,7 +298,6 @@ class ColumnMatrix {
   // IO procedures for external memory.
   bool Read(dmlc::SeekStream* fi, uint32_t const* index_base) {
     fi->Read(&index_);
-    fi->Read(&feature_counts_);
 #if !DMLC_LITTLE_ENDIAN
     // s390x
     std::vector<std::underlying_type<ColumnType>::type> int_types;
@@ -370,13 +313,6 @@ class ColumnMatrix {
     fi->Read(&row_ind_);
     fi->Read(&feature_offsets_);
     index_base_ = index_base;
-#if !DMLC_LITTLE_ENDIAN
-    std::underlying_type<BinTypeSize>::type v;
-    fi->Read(&v);
-    bins_type_size_ = static_cast<BinTypeSize>(v);
-#else
-    fi->Read(&bins_type_size_);
-#endif
 
     fi->Read(&any_missing_);
     return true;
@@ -391,7 +327,6 @@ class ColumnMatrix {
                sizeof(uint64_t);
     };
     write_vec(index_);
-    write_vec(feature_counts_);
 #if !DMLC_LITTLE_ENDIAN
     // s390x
     std::vector<std::underlying_type<ColumnType>::type> int_types(type_.size());
@@ -405,13 +340,6 @@ class ColumnMatrix {
     write_vec(row_ind_);
     write_vec(feature_offsets_);
 
-#if !DMLC_LITTLE_ENDIAN
-    auto v = static_cast<std::underlying_type<BinTypeSize>::type>(bins_type_size_);
-    fo->Write(v);
-#else
-    fo->Write(bins_type_size_);
-#endif  // DMLC_LITTLE_ENDIAN
-    bytes += sizeof(bins_type_size_);
     fo->Write(any_missing_);
     bytes += sizeof(any_missing_);
 
@@ -419,9 +347,8 @@ class ColumnMatrix {
   }
 
  private:
-  std::vector<uint8_t> index_;
+  std::vector<bst_bin_t> index_;
 
-  std::vector<size_t> feature_counts_;
   std::vector<ColumnType> type_;
   std::vector<size_t> row_ind_;
   /* indicate where each column's index and row_ind is stored. */
@@ -429,8 +356,6 @@ class ColumnMatrix {
 
   // index_base_[fid]: least bin id for feature fid
   uint32_t const* index_base_;
-  std::vector<bool> missing_flags_;
-  BinTypeSize bins_type_size_;
   bool any_missing_;
 };
 }  // namespace common

--- a/src/common/partition_builder.h
+++ b/src/common/partition_builder.h
@@ -69,7 +69,7 @@ class PartitionBuilder {
     for (size_t i = 0; i < n_samples; ++i) {
       auto rid = p_row_indices[i];
       const int32_t bin_id = column.GetBinIdx(rid - base_rowid, &state);
-      if (any_missing && bin_id == ColumnType::kMissingId) {
+      if (any_missing && bin_id == common::Column::MissingIdx()) {
         if (default_left) {
           p_left_part[nleft_elems++] = rid;
         } else {

--- a/src/common/partition_builder.h
+++ b/src/common/partition_builder.h
@@ -106,7 +106,7 @@ class PartitionBuilder {
     return {nleft_elems, nright_elems};
   }
 
-  template <typename BinIdxType, bool any_missing, bool any_cat>
+  template <bool any_missing, bool any_cat>
   void Partition(const size_t node_in_set, const size_t nid, const common::Range1d range,
                  const int32_t split_cond, GHistIndexMatrix const& gmat,
                  const ColumnMatrix& column_matrix, const RegTree& tree, const size_t* rid) {
@@ -115,7 +115,7 @@ class PartitionBuilder {
     common::Span<size_t> right = GetRightBuffer(node_in_set, range.begin(), range.end());
     const bst_uint fid = tree[nid].SplitIndex();
     const bool default_left = tree[nid].DefaultLeft();
-    const auto column_ptr = column_matrix.GetColumn<BinIdxType, any_missing>(fid);
+    const auto column_ptr = column_matrix.GetColumn<any_missing>(fid);
 
     bool is_cat = tree.GetSplitTypes()[nid] == FeatureType::kCategorical;
     auto node_cats = tree.NodeCats(nid);
@@ -147,8 +147,8 @@ class PartitionBuilder {
 
     std::pair<size_t, size_t> child_nodes_sizes;
     if (column_ptr->GetType() == xgboost::common::kDenseColumn) {
-      const common::DenseColumn<BinIdxType, any_missing>& column =
-            static_cast<const common::DenseColumn<BinIdxType, any_missing>& >(*(column_ptr.get()));
+      const common::DenseColumn<any_missing>& column =
+          static_cast<const common::DenseColumn<any_missing>&>(*(column_ptr.get()));
       if (default_left) {
         child_nodes_sizes = PartitionKernel<true, any_missing>(column, rid_span, left, right,
                                                                gmat.base_rowid, pred);
@@ -158,8 +158,8 @@ class PartitionBuilder {
       }
     } else {
       CHECK_EQ(any_missing, true);
-      const common::SparseColumn<BinIdxType>& column
-        = static_cast<const common::SparseColumn<BinIdxType>& >(*(column_ptr.get()));
+      const common::SparseColumn& column =
+          static_cast<const common::SparseColumn&>(*(column_ptr.get()));
       if (default_left) {
         child_nodes_sizes = PartitionKernel<true, any_missing>(column, rid_span, left, right,
                                                                gmat.base_rowid, pred);

--- a/src/tree/updater_quantile_hist.h
+++ b/src/tree/updater_quantile_hist.h
@@ -157,26 +157,9 @@ class HistRowPartitioner {
       const int32_t nid = nodes[node_in_set].nid;
       const size_t task_id = partition_builder_.GetTaskIdx(node_in_set, begin);
       partition_builder_.AllocateForTask(task_id);
-      switch (column_matrix.GetTypeSize()) {
-        case common::kUint8BinsTypeSize:
-          partition_builder_.template Partition<uint8_t, any_missing, any_cat>(
-              node_in_set, nid, r, split_conditions[node_in_set], gmat, column_matrix, *p_tree,
-              row_set_collection_[nid].begin);
-          break;
-        case common::kUint16BinsTypeSize:
-          partition_builder_.template Partition<uint16_t, any_missing, any_cat>(
-              node_in_set, nid, r, split_conditions[node_in_set], gmat, column_matrix, *p_tree,
-              row_set_collection_[nid].begin);
-          break;
-        case common::kUint32BinsTypeSize:
-          partition_builder_.template Partition<uint32_t, any_missing, any_cat>(
-              node_in_set, nid, r, split_conditions[node_in_set], gmat, column_matrix, *p_tree,
-              row_set_collection_[nid].begin);
-          break;
-        default:
-          // no default behavior
-          CHECK(false) << column_matrix.GetTypeSize();
-      }
+      partition_builder_.template Partition<any_missing, any_cat>(
+          node_in_set, nid, r, split_conditions[node_in_set], gmat, column_matrix, *p_tree,
+          row_set_collection_[nid].begin);
     });
     // 3. Compute offsets to copy blocks of row-indexes
     // from partition_builder_ to row_set_collection_

--- a/tests/cpp/data/test_gradient_index_page_raw_format.cc
+++ b/tests/cpp/data/test_gradient_index_page_raw_format.cc
@@ -39,8 +39,6 @@ TEST(GHistIndexPageRawFormat, IO) {
     ASSERT_TRUE(std::equal(loaded.index.begin(), loaded.index.end(), page.index.begin()));
     ASSERT_TRUE(std::equal(loaded.index.Offset(), loaded.index.Offset() + loaded.index.OffsetSize(),
                            page.index.Offset()));
-
-    ASSERT_EQ(loaded.Transpose().GetTypeSize(), loaded.Transpose().GetTypeSize());
   }
 }
 } // namespace data


### PR DESCRIPTION
Memory usage is slightly increased, but makes https://github.com/dmlc/xgboost/issues/7890 easier to implement as we don't need to dispatch the data type in other places like predictor.

- n_samples: 1e6
- n_features: 32

- todo: profile result.