### PR TITLE
Remove tree structure assumption in GetNextNode

### DIFF
--- a/src/predictor/predict_fn.h
+++ b/src/predictor/predict_fn.h
@@ -22,7 +22,7 @@ inline XGBOOST_DEVICE bst_node_t GetNextNode(const RegTree::Node &node, const bs
                  ? node.LeftChild()
                  : node.RightChild();
     } else {
-      return node.LeftChild() + !(fvalue < node.SplitCond());
+      return  fvalue < node.SplitCond() ? node.LeftChild() : node.RightChild();
     }
   }
 }


### PR DESCRIPTION
There is an assumption in predictor/predict_fn.h:GetNextNode that right children are always exactly one after their matching left children.

This isn't enforced elsewhere in the library, and can be false when loading trees from external sources such as json.

This pull request changes the single line that makes the assumption with a line that doesn't make the assumption.

I've also opened an issue regarding the current incorrect logic here: #7903 