### PR TITLE
Rename misspelled config parameter for pseudo-Huber

### DIFF
--- a/doc/model.schema
+++ b/doc/model.schema
@@ -207,7 +207,7 @@
         }
       }
     },
-    "pseduo_huber_param": {
+    "pseudo_huber_param": {
       "type": "object",
       "properties": {
         "huber_slope": {

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -171,11 +171,11 @@ class PseudoErrorLoss : public Metric {
  public:
   const char* Name() const override { return "mphe"; }
   void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
-  void LoadConfig(Json const& in) override { FromJson(in["pseduo_huber_param"], &param_); }
+  void LoadConfig(Json const& in) override { FromJson(in["pseudo_huber_param"], &param_); }
   void SaveConfig(Json* p_out) const override {
     auto& out = *p_out;
     out["name"] = String(this->Name());
-    out["pseduo_huber_param"] = ToJson(param_);
+    out["pseudo_huber_param"] = ToJson(param_);
   }
 
   double Eval(const HostDeviceVector<bst_float>& preds, const MetaInfo& info,

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -255,16 +255,16 @@ class PseudoHuberRegression : public ObjFunction {
   void SaveConfig(Json* p_out) const override {
     auto& out = *p_out;
     out["name"] = String("reg:pseudohubererror");
-    out["pseduo_huber_param"] = ToJson(param_);
+    out["pseudo_huber_param"] = ToJson(param_);
   }
 
   void LoadConfig(Json const& in) override {
     auto const& config = get<Object const>(in);
-    if (config.find("pseduo_huber_param") == config.cend()) {
+    if (config.find("pseudo_huber_param") == config.cend()) {
       // The parameter is added in 1.6.
       return;
     }
-    FromJson(in["pseduo_huber_param"], &param_);
+    FromJson(in["pseudo_huber_param"], &param_);
   }
 };
 


### PR DESCRIPTION
Follow-up to https://github.com/dmlc/xgboost/pull/7727.

This is a breaking change in the config. The impact is limited as https://github.com/dmlc/xgboost/pull/7864 disabled loading config for old models.