### PR TITLE
Correct a mistake in Setting Parameters section

### DIFF
--- a/doc/python/python_intro.rst
+++ b/doc/python/python_intro.rst
@@ -147,7 +147,7 @@ XGBoost can use either a list of pairs or a dictionary to set :doc:`parameters <
 
   .. code-block:: python
 
-    evallist = [(dtest, 'eval'), (dtrain, 'train')]
+    evallist = [(dtrain, 'train'), (dtest, 'eval')]
 
 Training
 --------


### PR DESCRIPTION
Users who follow the code of specify validations set ( evallist = [(dtest, 'eval'), (dtrain, 'train')] ) in the Setting Parameters section will make the train score rather than the eval score as the criteria of early stopping, therefore propose reverse the order as 、evallist = [(dtrain, 'train'), (dtest, 'eval')]、.

Closes #7878