### PR TITLE
Simplify inplace-predict.

### DIFF
--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -111,7 +111,8 @@ class GradientBooster : public Model, public Configurable {
   /*!
    * \brief Inplace prediction.
    *
-   * \param           x                      A type erased data adapter.
+   * \param           p_fmat                 A proxy DMatrix that contains the data and related
+   *                                         meta info.
    * \param           missing                Missing value in the data.
    * \param [in,out]  out_preds              The output preds.
    * \param           layer_begin (Optional) Beginning of boosted tree layer used for prediction.

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -117,9 +117,7 @@ class GradientBooster : public Model, public Configurable {
    * \param           layer_begin (Optional) Beginning of boosted tree layer used for prediction.
    * \param           layer_end   (Optional) End of booster layer. 0 means do not limit trees.
    */
-  virtual void InplacePredict(dmlc::any const &, std::shared_ptr<DMatrix>, float,
-                              PredictionCacheEntry*,
-                              uint32_t,
+  virtual void InplacePredict(std::shared_ptr<DMatrix>, float, PredictionCacheEntry*, uint32_t,
                               uint32_t) const {
     LOG(FATAL) << "Inplace predict is not supported by current booster.";
   }

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -148,12 +148,9 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    * \param          layer_begin Beginning of boosted tree layer used for prediction.
    * \param          layer_end   End of booster layer. 0 means do not limit trees.
    */
-  virtual void InplacePredict(dmlc::any const &x,
-                              std::shared_ptr<DMatrix> p_m,
-                              PredictionType type,
-                              float missing,
-                              HostDeviceVector<bst_float> **out_preds,
-                              uint32_t layer_begin, uint32_t layer_end) = 0;
+  virtual void InplacePredict(std::shared_ptr<DMatrix> p_m, PredictionType type, float missing,
+                              HostDeviceVector<bst_float>** out_preds, uint32_t layer_begin,
+                              uint32_t layer_end) = 0;
 
   /*!
    * \brief Calculate feature score.  See doc in C API for outputs.

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -139,9 +139,7 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
   /*!
    * \brief Inplace prediction.
    *
-   * \param          x           A type erased data adapter.
-   * \param          p_m         An optional Proxy DMatrix object storing meta info like
-   *                             base margin.  Can be nullptr.
+   * \param          p_fmat      A proxy DMatrix that contains the data and related meta info.
    * \param          type        Prediction type.
    * \param          missing     Missing value in the data.
    * \param [in,out] out_preds   Pointer to output prediction vector.

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -145,7 +145,9 @@ class Predictor {
 
   /**
    * \brief Inplace prediction.
-   * \param           x                      Type erased data adapter.
+   *
+   * \param           p_fmat                 A proxy DMatrix that contains the data and related
+   *                                         meta info.
    * \param           model                  The model to predict from.
    * \param           missing                Missing value in the data.
    * \param [in,out]  out_preds              The output preds.
@@ -154,7 +156,7 @@ class Predictor {
    *
    * \return True if the data can be handled by current predictor, false otherwise.
    */
-  virtual bool InplacePredict(std::shared_ptr<DMatrix> p_mat, const gbm::GBTreeModel& model,
+  virtual bool InplacePredict(std::shared_ptr<DMatrix> p_fmat, const gbm::GBTreeModel& model,
                               float missing, PredictionCacheEntry* out_preds,
                               uint32_t tree_begin = 0, uint32_t tree_end = 0) const = 0;
   /**

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -154,11 +154,9 @@ class Predictor {
    *
    * \return True if the data can be handled by current predictor, false otherwise.
    */
-  virtual bool InplacePredict(dmlc::any const &x, std::shared_ptr<DMatrix> p_m,
-                              const gbm::GBTreeModel &model, float missing,
-                              PredictionCacheEntry *out_preds,
-                              uint32_t tree_begin = 0,
-                              uint32_t tree_end = 0) const = 0;
+  virtual bool InplacePredict(std::shared_ptr<DMatrix> p_mat, const gbm::GBTreeModel& model,
+                              float missing, PredictionCacheEntry* out_preds,
+                              uint32_t tree_begin = 0, uint32_t tree_end = 0) const = 0;
   /**
    * \brief online prediction function, predict score for one instance at a time
    * NOTE: use the batch prediction interface if possible, batch prediction is

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -862,7 +862,9 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle, char const *array_in
   } else {
     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);
   }
-  dynamic_cast<data::DMatrixProxy *>(p_m.get())->SetArrayData(array_interface);
+  auto proxy = dynamic_cast<data::DMatrixProxy *>(p_m.get());
+  CHECK(proxy) << "Invalid input type for inplace predict.";
+  proxy->SetArrayData(array_interface);
   auto *learner = static_cast<xgboost::Learner *>(handle);
   InplacePredictImpl(p_m, c_json_config, learner, out_shape, out_dim, out_result);
   API_END();
@@ -881,7 +883,9 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr, ch
   } else {
     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);
   }
-  dynamic_cast<data::DMatrixProxy *>(p_m.get())->SetCSRData(indptr, indices, data, cols, true);
+  auto proxy = dynamic_cast<data::DMatrixProxy *>(p_m.get());
+  CHECK(proxy) << "Invalid input type for inplace predict.";
+  proxy->SetCSRData(indptr, indices, data, cols, true);
   auto *learner = static_cast<xgboost::Learner *>(handle);
   InplacePredictImpl(p_m, c_json_config, learner, out_shape, out_dim, out_result);
   API_END();

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -825,74 +825,67 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle,
   API_END();
 }
 
-template <typename T>
-void InplacePredictImpl(std::shared_ptr<T> x, std::shared_ptr<DMatrix> p_m,
-                        char const *c_json_config, Learner *learner,
-                        size_t n_rows, size_t n_cols,
-                        xgboost::bst_ulong const **out_shape,
-                        xgboost::bst_ulong *out_dim, const float **out_result) {
+void InplacePredictImpl(std::shared_ptr<DMatrix> p_m, char const *c_json_config, Learner *learner,
+                        xgboost::bst_ulong const **out_shape, xgboost::bst_ulong *out_dim,
+                        const float **out_result) {
   auto config = Json::Load(StringView{c_json_config});
   CHECK_EQ(get<Integer const>(config["cache_id"]), 0) << "Cache ID is not supported yet";
 
-  HostDeviceVector<float>* p_predt { nullptr };
+  HostDeviceVector<float> *p_predt{nullptr};
   auto type = PredictionType(RequiredArg<Integer>(config, "type", __func__));
   float missing = GetMissing(config);
-  learner->InplacePredict(x, p_m, type, missing, &p_predt,
+  learner->InplacePredict(p_m, type, missing, &p_predt,
                           RequiredArg<Integer>(config, "iteration_begin", __func__),
                           RequiredArg<Integer>(config, "iteration_end", __func__));
   CHECK(p_predt);
   auto &shape = learner->GetThreadLocal().prediction_shape;
-  auto chunksize = n_rows == 0 ? 0 : p_predt->Size() / n_rows;
+  auto const &info = p_m->Info();
+  auto n_samples = info.num_row_;
+  auto n_features = info.num_col_;
+  auto chunksize = n_samples == 0 ? 0 : p_predt->Size() / n_samples;
   bool strict_shape = RequiredArg<Boolean>(config, "strict_shape", __func__);
-  CalcPredictShape(strict_shape, type, n_rows, n_cols, chunksize, learner->Groups(),
+  CalcPredictShape(strict_shape, type, n_samples, n_features, chunksize, learner->Groups(),
                    learner->BoostedRounds(), &shape, out_dim);
   *out_result = dmlc::BeginPtr(p_predt->HostVector());
   *out_shape = dmlc::BeginPtr(shape);
 }
 
 // A hidden API as cache id is not being supported yet.
-XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle,
-                                      char const *array_interface,
-                                      char const *c_json_config,
-                                      DMatrixHandle m,
+XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle, char const *array_interface,
+                                      char const *c_json_config, DMatrixHandle m,
                                       xgboost::bst_ulong const **out_shape,
-                                      xgboost::bst_ulong *out_dim,
-                                      const float **out_result) {
+                                      xgboost::bst_ulong *out_dim, const float **out_result) {
   API_BEGIN();
   CHECK_HANDLE();
-  std::shared_ptr<xgboost::data::ArrayAdapter> x{
-      new xgboost::data::ArrayAdapter(StringView{array_interface})};
-  std::shared_ptr<DMatrix> p_m {nullptr};
-  if (m) {
+  std::shared_ptr<DMatrix> p_m{nullptr};
+  if (!m) {
+    p_m.reset(new data::DMatrixProxy);
+  } else {
     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);
   }
+  dynamic_cast<data::DMatrixProxy *>(p_m.get())->SetArrayData(array_interface);
   auto *learner = static_cast<xgboost::Learner *>(handle);
-  InplacePredictImpl(x, p_m, c_json_config, learner, x->NumRows(),
-                     x->NumColumns(), out_shape, out_dim, out_result);
+  InplacePredictImpl(p_m, c_json_config, learner, out_shape, out_dim, out_result);
   API_END();
 }
 
 // A hidden API as cache id is not being supported yet.
-XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
-                                    char const *indices, char const *data,
-                                    xgboost::bst_ulong cols,
+XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr, char const *indices,
+                                    char const *data, xgboost::bst_ulong cols,
                                     char const *c_json_config, DMatrixHandle m,
                                     xgboost::bst_ulong const **out_shape,
-                                    xgboost::bst_ulong *out_dim,
-                                    const float **out_result) {
+                                    xgboost::bst_ulong *out_dim, const float **out_result) {
   API_BEGIN();
   CHECK_HANDLE();
-  std::shared_ptr<xgboost::data::CSRArrayAdapter> x{
-      new xgboost::data::CSRArrayAdapter{StringView{indptr},
-                                         StringView{indices}, StringView{data},
-                                         static_cast<size_t>(cols)}};
-  std::shared_ptr<DMatrix> p_m {nullptr};
-  if (m) {
+  std::shared_ptr<DMatrix> p_m{nullptr};
+  if (!m) {
+    p_m.reset(new data::DMatrixProxy);
+  } else {
     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);
   }
+  dynamic_cast<data::DMatrixProxy *>(p_m.get())->SetCSRData(indptr, indices, data, cols, true);
   auto *learner = static_cast<xgboost::Learner *>(handle);
-  InplacePredictImpl(x, p_m, c_json_config, learner, x->NumRows(),
-                     x->NumColumns(), out_shape, out_dim, out_result);
+  InplacePredictImpl(p_m, c_json_config, learner, out_shape, out_dim, out_result);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -300,7 +300,7 @@ XGProxyDMatrixSetDataCudaArrayInterface(DMatrixHandle handle,
   CHECK(p_m);
   auto m =   static_cast<xgboost::data::DMatrixProxy*>(p_m->get());
   CHECK(m) << "Current DMatrix type does not support set data.";
-  m->SetData(c_interface_str);
+  m->SetCUDAArray(c_interface_str);
   API_END();
 }
 
@@ -312,7 +312,7 @@ XGB_DLL int XGProxyDMatrixSetDataCudaColumnar(DMatrixHandle handle,
   CHECK(p_m);
   auto m =   static_cast<xgboost::data::DMatrixProxy*>(p_m->get());
   CHECK(m) << "Current DMatrix type does not support set data.";
-  m->SetData(c_interface_str);
+  m->SetCUDAArray(c_interface_str);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -850,7 +850,6 @@ void InplacePredictImpl(std::shared_ptr<DMatrix> p_m, char const *c_json_config,
   *out_shape = dmlc::BeginPtr(shape);
 }
 
-// A hidden API as cache id is not being supported yet.
 XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle, char const *array_interface,
                                       char const *c_json_config, DMatrixHandle m,
                                       xgboost::bst_ulong const **out_shape,
@@ -869,7 +868,6 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle, char const *array_in
   API_END();
 }
 
-// A hidden API as cache id is not being supported yet.
 XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr, char const *indices,
                                     char const *data, xgboost::bst_ulong cols,
                                     char const *c_json_config, DMatrixHandle m,

--- a/src/c_api/c_api.cu
+++ b/src/c_api/c_api.cu
@@ -1,10 +1,11 @@
-// Copyright (c) 2019-2021 by Contributors
-#include "xgboost/data.h"
-#include "xgboost/c_api.h"
-#include "xgboost/learner.h"
+// Copyright (c) 2019-2022 by Contributors
+#include "../data/device_adapter.cuh"
+#include "../data/proxy_dmatrix.h"
 #include "c_api_error.h"
 #include "c_api_utils.h"
-#include "../data/device_adapter.cuh"
+#include "xgboost/c_api.h"
+#include "xgboost/data.h"
+#include "xgboost/learner.h"
 
 namespace xgboost {
 
@@ -85,37 +86,31 @@ XGB_DLL int XGDMatrixCreateFromCudaArrayInterface(char const *data,
   API_END();
 }
 
-template <typename T>
-int InplacePreidctCuda(BoosterHandle handle, char const *c_json_strs,
-                       char const *c_json_config,
-                       std::shared_ptr<DMatrix> p_m,
-                       xgboost::bst_ulong const **out_shape,
+int InplacePreidctCuda(BoosterHandle handle, char const *c_json_config,
+                       std::shared_ptr<DMatrix> p_m, xgboost::bst_ulong const **out_shape,
                        xgboost::bst_ulong *out_dim, const float **out_result) {
   API_BEGIN();
   CHECK_HANDLE();
   auto config = Json::Load(StringView{c_json_config});
-  CHECK_EQ(get<Integer const>(config["cache_id"]), 0)
-      << "Cache ID is not supported yet";
+  CHECK_EQ(get<Integer const>(config["cache_id"]), 0) << "Cache ID is not supported yet";
   auto *learner = static_cast<Learner *>(handle);
 
-  std::string json_str{c_json_strs};
-  auto x = std::make_shared<T>(json_str);
   HostDeviceVector<float> *p_predt{nullptr};
   auto type = PredictionType(get<Integer const>(config["type"]));
   float missing = GetMissing(config);
 
-  learner->InplacePredict(x, p_m, type, missing, &p_predt,
+  learner->InplacePredict(p_m, type, missing, &p_predt,
                           get<Integer const>(config["iteration_begin"]),
                           get<Integer const>(config["iteration_end"]));
   CHECK(p_predt);
   CHECK(p_predt->DeviceCanRead() && !p_predt->HostCanRead());
 
   auto &shape = learner->GetThreadLocal().prediction_shape;
-  auto chunksize = x->NumRows() == 0 ? 0 : p_predt->Size() / x->NumRows();
+  size_t n_samples = p_m->Info().num_row_;
+  auto chunksize = n_samples == 0 ? 0 : p_predt->Size() / n_samples;
   bool strict_shape = get<Boolean const>(config["strict_shape"]);
-  CalcPredictShape(strict_shape, type, x->NumRows(), x->NumColumns(), chunksize,
-                   learner->Groups(), learner->BoostedRounds(), &shape,
-                   out_dim);
+  CalcPredictShape(strict_shape, type, n_samples, p_m->Info().num_col_, chunksize,
+                   learner->Groups(), learner->BoostedRounds(), &shape, out_dim);
   *out_shape = dmlc::BeginPtr(shape);
   *out_result = p_predt->ConstDevicePointer();
   API_END();
@@ -126,11 +121,13 @@ XGB_DLL int XGBoosterPredictFromCudaColumnar(
     DMatrixHandle m, xgboost::bst_ulong const **out_shape,
     xgboost::bst_ulong *out_dim, const float **out_result) {
   std::shared_ptr<DMatrix> p_m {nullptr};
-  if (m) {
+  if (!m) {
+    p_m.reset(new data::DMatrixProxy);
+  } else {
     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);
   }
-  return InplacePreidctCuda<data::CudfAdapter>(
-      handle, c_json_strs, c_json_config, p_m, out_shape, out_dim, out_result);
+  dynamic_cast<data::DMatrixProxy *>(p_m.get())->SetData(c_json_strs);
+  return InplacePreidctCuda(handle, c_json_config, p_m, out_shape, out_dim, out_result);
 }
 
 XGB_DLL int XGBoosterPredictFromCudaArray(
@@ -138,9 +135,11 @@ XGB_DLL int XGBoosterPredictFromCudaArray(
     DMatrixHandle m, xgboost::bst_ulong const **out_shape,
     xgboost::bst_ulong *out_dim, const float **out_result) {
   std::shared_ptr<DMatrix> p_m {nullptr};
-  if (m) {
+  if (!m) {
+    p_m.reset(new data::DMatrixProxy);
+  } else {
     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);
   }
-  return InplacePreidctCuda<data::CupyAdapter>(
-      handle, c_json_strs, c_json_config, p_m, out_shape, out_dim, out_result);
+  dynamic_cast<data::DMatrixProxy *>(p_m.get())->SetData(c_json_strs);
+  return InplacePreidctCuda(handle, c_json_config, p_m, out_shape, out_dim, out_result);
 }

--- a/src/c_api/c_api.cu
+++ b/src/c_api/c_api.cu
@@ -97,7 +97,7 @@ int InplacePreidctCuda(BoosterHandle handle, char const *c_array_interface,
   }
   auto proxy = dynamic_cast<data::DMatrixProxy *>(p_m.get());
   CHECK(proxy) << "Invalid input type for inplace predict.";
-  proxy->SetData(c_array_interface);
+  proxy->SetCUDAArray(c_array_interface);
 
   auto config = Json::Load(StringView{c_json_config});
   CHECK_EQ(get<Integer const>(config["cache_id"]), 0) << "Cache ID is not supported yet";

--- a/src/data/proxy_dmatrix.h
+++ b/src/data/proxy_dmatrix.h
@@ -55,7 +55,7 @@ class DMatrixProxy : public DMatrix {
  public:
   int DeviceIdx() const { return ctx_.gpu_id; }
 
-  void SetData(char const* c_interface) {
+  void SetCUDAArray(char const* c_interface) {
     common::AssertGPUSupport();
 #if defined(XGBOOST_USE_CUDA)
     std::string interface_str = c_interface;

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -261,8 +261,7 @@ class GBTree : public GradientBooster {
   void PredictBatch(DMatrix *p_fmat, PredictionCacheEntry *out_preds,
                     bool training, unsigned layer_begin, unsigned layer_end) override;
 
-  void InplacePredict(dmlc::any const &x, std::shared_ptr<DMatrix> p_m,
-                      float missing, PredictionCacheEntry *out_preds,
+  void InplacePredict(std::shared_ptr<DMatrix> p_m, float missing, PredictionCacheEntry* out_preds,
                       uint32_t layer_begin, unsigned layer_end) const override {
     CHECK(configured_);
     uint32_t tree_begin, tree_end;
@@ -278,15 +277,14 @@ class GBTree : public GradientBooster {
     if (tparam_.predictor == PredictorType::kAuto) {
       // Try both predictor implementations
       for (auto const &p : predictors) {
-        if (p && p->InplacePredict(x, p_m, model_, missing, out_preds,
-                                   tree_begin, tree_end)) {
+        if (p && p->InplacePredict(p_m, model_, missing, out_preds, tree_begin, tree_end)) {
           return;
         }
       }
       LOG(FATAL) << msg;
     } else {
-      bool success = this->GetPredictor()->InplacePredict(
-          x, p_m, model_, missing, out_preds, tree_begin, tree_end);
+      bool success = this->GetPredictor()->InplacePredict(p_m, model_, missing, out_preds,
+                                                          tree_begin, tree_end);
       CHECK(success) << msg << std::endl
                      << "Current Predictor: "
                      << (tparam_.predictor == PredictorType::kCPUPredictor

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1277,15 +1277,12 @@ class LearnerImpl : public LearnerIO {
     return (*LearnerAPIThreadLocalStore::Get())[this];
   }
 
-  void InplacePredict(dmlc::any const &x, std::shared_ptr<DMatrix> p_m,
-                      PredictionType type, float missing,
-                      HostDeviceVector<bst_float> **out_preds,
-                      uint32_t iteration_begin,
+  void InplacePredict(std::shared_ptr<DMatrix> p_m, PredictionType type, float missing,
+                      HostDeviceVector<bst_float>** out_preds, uint32_t iteration_begin,
                       uint32_t iteration_end) override {
     this->Configure();
     auto& out_predictions = this->GetThreadLocal().prediction_entry;
-    this->gbm_->InplacePredict(x, p_m, missing, &out_predictions,
-                               iteration_begin, iteration_end);
+    this->gbm_->InplacePredict(p_m, missing, &out_predictions, iteration_begin, iteration_end);
     if (type == PredictionType::kValue) {
       obj_->PredTransform(&out_predictions.predictions);
     } else if (type == PredictionType::kMargin) {

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -331,6 +331,7 @@ class CPUPredictor : public Predictor {
                       PredictionCacheEntry *out_preds, uint32_t tree_begin,
                       unsigned tree_end) const override {
     auto proxy = dynamic_cast<data::DMatrixProxy *>(p_m.get());
+    CHECK(proxy)<< "Inplace predict accepts only DMatrixProxy as input.";
     auto x = proxy->Adapter();
     if (x.type() == typeid(std::shared_ptr<data::DenseAdapter>)) {
       this->DispatchedInplacePredict<data::DenseAdapter, kBlockOfRowsSize>(

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -1,27 +1,27 @@
 /*!
  * Copyright by Contributors 2017-2021
  */
-#include <dmlc/omp.h>
 #include <dmlc/any.h>
+#include <dmlc/omp.h>
 
 #include <cstddef>
 #include <limits>
 #include <mutex>
 
+#include "../common/categorical.h"
+#include "../common/math.h"
+#include "../common/threading_utils.h"
+#include "../data/adapter.h"
+#include "../data/proxy_dmatrix.h"
+#include "../gbm/gbtree_model.h"
+#include "predict_fn.h"
 #include "xgboost/base.h"
 #include "xgboost/data.h"
+#include "xgboost/host_device_vector.h"
+#include "xgboost/logging.h"
 #include "xgboost/predictor.h"
 #include "xgboost/tree_model.h"
 #include "xgboost/tree_updater.h"
-#include "xgboost/logging.h"
-#include "xgboost/host_device_vector.h"
-
-#include "predict_fn.h"
-#include "../data/adapter.h"
-#include "../common/math.h"
-#include "../common/threading_utils.h"
-#include "../common/categorical.h"
-#include "../gbm/gbtree_model.h"
 
 namespace xgboost {
 namespace predictor {
@@ -327,22 +327,23 @@ class CPUPredictor : public Predictor {
         &predictions, model, tree_begin, tree_end, &thread_temp, n_threads);
   }
 
-  bool InplacePredict(dmlc::any const &x, std::shared_ptr<DMatrix> p_m,
-                      const gbm::GBTreeModel &model, float missing,
+  bool InplacePredict(std::shared_ptr<DMatrix> p_m, const gbm::GBTreeModel &model, float missing,
                       PredictionCacheEntry *out_preds, uint32_t tree_begin,
                       unsigned tree_end) const override {
+    auto proxy = dynamic_cast<data::DMatrixProxy *>(p_m.get());
+    auto x = proxy->Adapter();
     if (x.type() == typeid(std::shared_ptr<data::DenseAdapter>)) {
       this->DispatchedInplacePredict<data::DenseAdapter, kBlockOfRowsSize>(
           x, p_m, model, missing, out_preds, tree_begin, tree_end);
     } else if (x.type() == typeid(std::shared_ptr<data::CSRAdapter>)) {
-      this->DispatchedInplacePredict<data::CSRAdapter, 1>(
-          x, p_m, model, missing, out_preds, tree_begin, tree_end);
+      this->DispatchedInplacePredict<data::CSRAdapter, 1>(x, p_m, model, missing, out_preds,
+                                                          tree_begin, tree_end);
     } else if (x.type() == typeid(std::shared_ptr<data::ArrayAdapter>)) {
-      this->DispatchedInplacePredict<data::ArrayAdapter, kBlockOfRowsSize> (
+      this->DispatchedInplacePredict<data::ArrayAdapter, kBlockOfRowsSize>(
           x, p_m, model, missing, out_preds, tree_begin, tree_end);
     } else if (x.type() == typeid(std::shared_ptr<data::CSRArrayAdapter>)) {
-      this->DispatchedInplacePredict<data::CSRArrayAdapter, 1> (
-          x, p_m, model, missing, out_preds, tree_begin, tree_end);
+      this->DispatchedInplacePredict<data::CSRArrayAdapter, 1>(x, p_m, model, missing, out_preds,
+                                                               tree_begin, tree_end);
     } else {
       return false;
     }

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -1,28 +1,29 @@
 /*!
  * Copyright 2017-2021 by Contributors
  */
+#include <GPUTreeShap/gpu_treeshap.h>
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
 #include <thrust/fill.h>
 #include <thrust/host_vector.h>
-#include <GPUTreeShap/gpu_treeshap.h>
+
 #include <memory>
 
+#include "../common/bitfield.h"
+#include "../common/categorical.h"
+#include "../common/common.h"
+#include "../common/device_helpers.cuh"
+#include "../data/device_adapter.cuh"
+#include "../data/ellpack_page.cuh"
+#include "../data/proxy_dmatrix.h"
+#include "../gbm/gbtree_model.h"
+#include "predict_fn.h"
 #include "xgboost/data.h"
+#include "xgboost/host_device_vector.h"
 #include "xgboost/predictor.h"
 #include "xgboost/tree_model.h"
 #include "xgboost/tree_updater.h"
-#include "xgboost/host_device_vector.h"
-
-#include "predict_fn.h"
-#include "../gbm/gbtree_model.h"
-#include "../data/ellpack_page.cuh"
-#include "../data/device_adapter.cuh"
-#include "../common/common.h"
-#include "../common/bitfield.h"
-#include "../common/categorical.h"
-#include "../common/device_helpers.cuh"
 
 namespace xgboost {
 namespace predictor {
@@ -789,17 +790,18 @@ class GPUPredictor : public xgboost::Predictor {
         m->NumRows(), entry_start, use_shared, output_groups, missing);
   }
 
-  bool InplacePredict(dmlc::any const &x, std::shared_ptr<DMatrix> p_m,
-                      const gbm::GBTreeModel &model, float missing,
-                      PredictionCacheEntry *out_preds, uint32_t tree_begin,
+  bool InplacePredict(std::shared_ptr<DMatrix> p_m, const gbm::GBTreeModel& model, float missing,
+                      PredictionCacheEntry* out_preds, uint32_t tree_begin,
                       unsigned tree_end) const override {
+    auto proxy = dynamic_cast<data::DMatrixProxy*>(p_m.get());
+    auto x = proxy->Adapter();
     if (x.type() == typeid(std::shared_ptr<data::CupyAdapter>)) {
-      this->DispatchedInplacePredict<
-          data::CupyAdapter, DeviceAdapterLoader<data::CupyAdapterBatch>>(
+      this->DispatchedInplacePredict<data::CupyAdapter,
+                                     DeviceAdapterLoader<data::CupyAdapterBatch>>(
           x, p_m, model, missing, out_preds, tree_begin, tree_end);
     } else if (x.type() == typeid(std::shared_ptr<data::CudfAdapter>)) {
-      this->DispatchedInplacePredict<
-          data::CudfAdapter, DeviceAdapterLoader<data::CudfAdapterBatch>>(
+      this->DispatchedInplacePredict<data::CudfAdapter,
+                                     DeviceAdapterLoader<data::CudfAdapterBatch>>(
           x, p_m, model, missing, out_preds, tree_begin, tree_end);
     } else {
       return false;

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -794,6 +794,7 @@ class GPUPredictor : public xgboost::Predictor {
                       PredictionCacheEntry* out_preds, uint32_t tree_begin,
                       unsigned tree_end) const override {
     auto proxy = dynamic_cast<data::DMatrixProxy*>(p_m.get());
+    CHECK(proxy)<< "Inplace predict accepts only DMatrixProxy as input.";
     auto x = proxy->Adapter();
     if (x.type() == typeid(std::shared_ptr<data::CupyAdapter>)) {
       this->DispatchedInplacePredict<data::CupyAdapter,

--- a/tests/cpp/data/test_proxy_dmatrix.cu
+++ b/tests/cpp/data/test_proxy_dmatrix.cu
@@ -19,7 +19,7 @@ TEST(ProxyDMatrix, DeviceData) {
                     .GenerateColumnarArrayInterface(&label_storage);
 
   DMatrixProxy proxy;
-  proxy.SetData(data.c_str());
+  proxy.SetCUDAArray(data.c_str());
   proxy.SetInfo("label", labels.c_str());
 
   ASSERT_EQ(proxy.Adapter().type(), typeid(std::shared_ptr<CupyAdapter>));
@@ -34,7 +34,7 @@ TEST(ProxyDMatrix, DeviceData) {
   data = RandomDataGenerator(kRows, kCols, 0)
                     .Device(0)
                     .GenerateColumnarArrayInterface(&columnar_storage);
-  proxy.SetData(data.c_str());
+  proxy.SetCUDAArray(data.c_str());
   ASSERT_EQ(proxy.Adapter().type(), typeid(std::shared_ptr<CudfAdapter>));
   ASSERT_EQ(dmlc::get<std::shared_ptr<CudfAdapter>>(proxy.Adapter())->NumRows(),
             kRows);

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -312,13 +312,13 @@ class Dart : public testing::TestWithParam<char const*> {
 
 TEST_P(Dart, Prediction) { this->Run(GetParam()); }
 
-INSTANTIATE_TEST_SUITE_P(PredictorTypes, Dart,
-                         testing::Values("auto", "cpu_predictor"
 #if defined(XGBOOST_USE_CUDA)
-                                         ,
-                                         "gpu_predictor"
+INSTANTIATE_TEST_SUITE_P(PredictorTypes, Dart,
+                         testing::Values("auto", "cpu_predictor", "gpu_predictor"));
+#else
+INSTANTIATE_TEST_SUITE_P(PredictorTypes, Dart, testing::Values("auto", "cpu_predictor"));
 #endif  // defined(XGBOOST_USE_CUDA)
-                                         ));
+
 
 std::pair<Json, Json> TestModelSlice(std::string booster) {
   size_t constexpr kRows = 1000, kCols = 100, kForest = 2, kClasses = 3;

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -313,8 +313,9 @@ class Dart : public testing::TestWithParam<char const*> {
 TEST_P(Dart, Prediction) { this->Run(GetParam()); }
 
 INSTANTIATE_TEST_SUITE_P(PredictorTypes, Dart,
-                         testing::Values("auto", "cpu_predictor",
+                         testing::Values("auto", "cpu_predictor"
 #if defined(XGBOOST_USE_CUDA)
+                                         ,
                                          "gpu_predictor"
 #endif  // defined(XGBOOST_USE_CUDA)
                                          ));

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -138,7 +138,7 @@ TEST(GPUPredictor, InplacePredictCupy) {
   HostDeviceVector<float> data;
   std::string interface_str = gen.GenerateArrayInterface(&data);
   std::shared_ptr<DMatrix> p_fmat{new data::DMatrixProxy};
-  dynamic_cast<data::DMatrixProxy*>(p_fmat.get())->SetData(interface_str.c_str());
+  dynamic_cast<data::DMatrixProxy*>(p_fmat.get())->SetCUDAArray(interface_str.c_str());
   TestInplacePrediction(p_fmat, "gpu_predictor", kRows, kCols, 0);
 }
 
@@ -149,7 +149,7 @@ TEST(GPUPredictor, InplacePredictCuDF) {
   std::vector<HostDeviceVector<float>> storage(kCols);
   auto interface_str = gen.GenerateColumnarArrayInterface(&storage);
   std::shared_ptr<DMatrix> p_fmat{new data::DMatrixProxy};
-  dynamic_cast<data::DMatrixProxy*>(p_fmat.get())->SetData(interface_str.c_str());
+  dynamic_cast<data::DMatrixProxy*>(p_fmat.get())->SetCUDAArray(interface_str.c_str());
   TestInplacePrediction(p_fmat, "gpu_predictor", kRows, kCols, 0);
 }
 
@@ -165,7 +165,7 @@ TEST(GPUPredictor, MGPU_InplacePredict) {  // NOLINT
   HostDeviceVector<float> data;
   std::string interface_str = gen.GenerateArrayInterface(&data);
   std::shared_ptr<DMatrix> p_fmat{new data::DMatrixProxy};
-  dynamic_cast<data::DMatrixProxy*>(p_fmat.get())->SetData(interface_str.c_str());
+  dynamic_cast<data::DMatrixProxy*>(p_fmat.get())->SetCUDAArray(interface_str.c_str());
   TestInplacePrediction(p_fmat, "gpu_predictor", kRows, kCols, 1);
   EXPECT_THROW(TestInplacePrediction(p_fmat, "gpu_predictor", kRows, kCols, 0), dmlc::Error);
 }

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -1,17 +1,19 @@
 /*!
  * Copyright 2017-2020 XGBoost contributors
  */
-#include <gtest/gtest.h>
 #include <dmlc/filesystem.h>
+#include <gtest/gtest.h>
 #include <xgboost/c_api.h>
-#include <xgboost/predictor.h>
-#include <xgboost/logging.h>
 #include <xgboost/learner.h>
+#include <xgboost/logging.h>
+#include <xgboost/predictor.h>
+
 #include <string>
 
-#include "../helpers.h"
-#include "../../../src/gbm/gbtree_model.h"
 #include "../../../src/data/device_adapter.cuh"
+#include "../../../src/data/proxy_dmatrix.h"
+#include "../../../src/gbm/gbtree_model.h"
+#include "../helpers.h"
 #include "test_predictor.h"
 
 namespace xgboost {
@@ -135,8 +137,9 @@ TEST(GPUPredictor, InplacePredictCupy) {
   gen.Device(0);
   HostDeviceVector<float> data;
   std::string interface_str = gen.GenerateArrayInterface(&data);
-  auto x = std::make_shared<data::CupyAdapter>(interface_str);
-  TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 0);
+  std::shared_ptr<DMatrix> p_fmat{new data::DMatrixProxy};
+  dynamic_cast<data::DMatrixProxy*>(p_fmat.get())->SetData(interface_str.c_str());
+  TestInplacePrediction(p_fmat, "gpu_predictor", kRows, kCols, 0);
 }
 
 TEST(GPUPredictor, InplacePredictCuDF) {
@@ -145,8 +148,9 @@ TEST(GPUPredictor, InplacePredictCuDF) {
   gen.Device(0);
   std::vector<HostDeviceVector<float>> storage(kCols);
   auto interface_str = gen.GenerateColumnarArrayInterface(&storage);
-  auto x = std::make_shared<data::CudfAdapter>(interface_str);
-  TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 0);
+  std::shared_ptr<DMatrix> p_fmat{new data::DMatrixProxy};
+  dynamic_cast<data::DMatrixProxy*>(p_fmat.get())->SetData(interface_str.c_str());
+  TestInplacePrediction(p_fmat, "gpu_predictor", kRows, kCols, 0);
 }
 
 TEST(GPUPredictor, MGPU_InplacePredict) {  // NOLINT
@@ -160,10 +164,10 @@ TEST(GPUPredictor, MGPU_InplacePredict) {  // NOLINT
   gen.Device(1);
   HostDeviceVector<float> data;
   std::string interface_str = gen.GenerateArrayInterface(&data);
-  auto x = std::make_shared<data::CupyAdapter>(interface_str);
-  TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 1);
-  EXPECT_THROW(TestInplacePrediction(x, "gpu_predictor", kRows, kCols, 0),
-               dmlc::Error);
+  std::shared_ptr<DMatrix> p_fmat{new data::DMatrixProxy};
+  dynamic_cast<data::DMatrixProxy*>(p_fmat.get())->SetData(interface_str.c_str());
+  TestInplacePrediction(p_fmat, "gpu_predictor", kRows, kCols, 1);
+  EXPECT_THROW(TestInplacePrediction(p_fmat, "gpu_predictor", kRows, kCols, 0), dmlc::Error);
 }
 
 TEST(GpuPredictor, LesserFeatures) {

--- a/tests/cpp/predictor/test_predictor.h
+++ b/tests/cpp/predictor/test_predictor.h
@@ -61,9 +61,8 @@ void TestTrainingPrediction(size_t rows, size_t bins, std::string tree_method,
                             std::shared_ptr<DMatrix> p_full,
                             std::shared_ptr<DMatrix> p_hist);
 
-void TestInplacePrediction(dmlc::any x, std::string predictor,
-                           bst_row_t rows, bst_feature_t cols,
-                           int32_t device = -1);
+void TestInplacePrediction(std::shared_ptr<DMatrix> x, std::string predictor, bst_row_t rows,
+                           bst_feature_t cols, int32_t device = -1);
 
 void TestPredictionWithLesserFeatures(std::string preditor_name);
 


### PR DESCRIPTION
Pass the `X` as part of Proxy DMatrix instead of an independent `dmlc::any`.

I'm preparing to add optimal initialization, when it's ready we need to move `InitOutPrediction` from predictor to objective.