### PR TITLE
Fix type conversion warning.

### DIFF
--- a/src/tree/driver.h
+++ b/src/tree/driver.h
@@ -101,7 +101,7 @@ class Driver {
 
  private:
   TrainParam param_;
-  std::size_t num_leaves_ = 1;
+  bst_node_t num_leaves_ = 1;
   std::size_t max_node_batch_size_;
   ExpandQueue queue_;
 };


### PR DESCRIPTION
```
warning: comparison of integer expressions of different signedness: ‘std::size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
   63 |     if (param_.max_leaves > 0 && num_leaves_ >= param_.max_leaves) return false;
```