### PR TITLE
VM-Packages: Auto-detection of MUSL is replaced by system properties

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
@@ -32,6 +32,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import static ml.dmlc.xgboost4j.java.NativeLibLoader.LibraryPathProvider.getLibraryPathFor;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.LibraryPathProvider.getPropertyNameForLibrary;
 
 /**
  * class to load native library
@@ -156,10 +157,13 @@ class NativeLibLoader {
     private static final String nativeResourcePath = "/lib";
     private static final String customNativeLibraryPathPropertyPrefix = "xgboostruntime.native.";
 
+    static String getPropertyNameForLibrary(String libName) {
+      return customNativeLibraryPathPropertyPrefix + libName;
+    }
+
     static String getLibraryPathFor(OS os, Arch arch, String libName) {
 
-      String customNativeLibraryPathProperty = customNativeLibraryPathPropertyPrefix + libName;
-      String libraryPath = System.getProperty(customNativeLibraryPathProperty);
+      String libraryPath = System.getProperty(getPropertyNameForLibrary(libName));
 
       if (libraryPath == null) {
         libraryPath = nativeResourcePath + "/" +
@@ -216,8 +220,9 @@ class NativeLibLoader {
               logger.error(failureMessageIncludingOpenMPHint);
               logger.error("You may need to install 'libgomp.so' (or glibc) via your package " +
                   "manager.");
-              logger.error("Alternatively, your Linux OS is musl-based " +
-                  "but wasn't detected as such.");
+              logger.error("Alternatively, if your Linux OS is musl-based, you should set " +
+                      "the path for the native library " + libName + " " +
+                      "via the system property " + getPropertyNameForLibrary(libName));
               break;
             case LINUX_MUSL:
               logger.error(failureMessageIncludingOpenMPHint);

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
@@ -154,11 +154,22 @@ class NativeLibLoader {
   static class LibraryPathProvider {
 
     private static final String nativeResourcePath = "/lib";
+    private static final String customNativeLibraryPathPropertyPrefix = "xgboostruntime.native.";
 
     static String getLibraryPathFor(OS os, Arch arch, String libName) {
-      return nativeResourcePath + "/" +
-        getPlatformFor(os, arch) + "/" +
-        System.mapLibraryName(libName);
+
+      String customNativeLibraryPathProperty = customNativeLibraryPathPropertyPrefix + libName;
+      String libraryPath = System.getProperty(customNativeLibraryPathProperty);
+
+      if (libraryPath == null) {
+        libraryPath = nativeResourcePath + "/" +
+                getPlatformFor(os, arch) + "/" +
+                System.mapLibraryName(libName);
+      }
+
+      logger.debug("Using path " + libraryPath + " for library with name " + libName);
+
+      return libraryPath;
     }
 
   }

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
@@ -67,6 +67,7 @@ class NativeLibLoader {
     /**
      * Detects the OS using the system properties.
      * Throws IllegalStateException if the OS is not recognized.
+     *
      * @return The OS.
      */
     static OS detectOS() {
@@ -152,6 +153,9 @@ class NativeLibLoader {
     }
   }
 
+  /**
+   * Utility class to determine the path of a native library.
+   */
   static class LibraryPathProvider {
 
     private static final String nativeResourcePath = "/lib";
@@ -161,6 +165,13 @@ class NativeLibLoader {
       return customNativeLibraryPathPropertyPrefix + libName;
     }
 
+    /**
+     * If a library-specific system property is set, this value is
+     * being used without further processing.
+     * Otherwise, the library path depends on the OS and architecture.
+     *
+     * @return path of the native library
+     */
     static String getLibraryPathFor(OS os, Arch arch, String libName) {
 
       String libraryPath = System.getProperty(getPropertyNameForLibrary(libName));

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/LibraryPathProviderTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/LibraryPathProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
 package ml.dmlc.xgboost4j.java;
 
 import org.junit.Test;

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/LibraryPathProviderTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/LibraryPathProviderTest.java
@@ -2,6 +2,7 @@ package ml.dmlc.xgboost4j.java;
 
 import org.junit.Test;
 
+import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static ml.dmlc.xgboost4j.java.NativeLibLoader.Arch.X86_64;
 import static ml.dmlc.xgboost4j.java.NativeLibLoader.LibraryPathProvider.getLibraryPathFor;
@@ -10,10 +11,36 @@ import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.LINUX;
 public class LibraryPathProviderTest {
 
   @Test
-  public void testLibraryPathProvider() {
+  public void testLibraryPathProviderUsesOsAndArchToResolvePath() {
     String libraryPath = getLibraryPathFor(LINUX, X86_64, "someLibrary");
 
     assertTrue(libraryPath.startsWith("/lib/linux/x86_64/"));
+  }
+
+  @Test
+  public void testLibraryPathProviderUsesPropertyValueForPathIfPresent() {
+    String propertyName = "xgboostruntime.native.library";
+
+    executeAndRestoreProperty(propertyName, () -> {
+      System.setProperty(propertyName, "/my/custom/path/to/my/library");
+      String libraryPath = getLibraryPathFor(LINUX, X86_64, "library");
+
+      assertEquals("/my/custom/path/to/my/library", libraryPath);
+    });
+  }
+
+  private static void executeAndRestoreProperty(String propertyName, Runnable action) {
+    String oldValue = System.getProperty(propertyName);
+
+    try {
+      action.run();
+    } finally {
+      if (oldValue != null) {
+        System.setProperty(propertyName, oldValue);
+      } else {
+        System.clearProperty(propertyName);
+      }
+    }
   }
 
 }

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/LibraryPathProviderTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/LibraryPathProviderTest.java
@@ -1,0 +1,19 @@
+package ml.dmlc.xgboost4j.java;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.Arch.X86_64;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.LibraryPathProvider.getLibraryPathFor;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.LINUX;
+
+public class LibraryPathProviderTest {
+
+  @Test
+  public void testLibraryPathProvider() {
+    String libraryPath = getLibraryPathFor(LINUX, X86_64, "someLibrary");
+
+    assertTrue(libraryPath.startsWith("/lib/linux/x86_64/"));
+  }
+
+}

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/OsDetectionTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/OsDetectionTest.java
@@ -16,10 +16,8 @@
 package ml.dmlc.xgboost4j.java;
 
 import ml.dmlc.xgboost4j.java.NativeLibLoader.OS;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -40,12 +38,12 @@ public class OsDetectionTest {
   private static final String OS_NAME_PROPERTY = "os.name";
 
   @RunWith(Parameterized.class)
-  public static class ParameterizedOSDetectionTest {
+  public static class SupportedOSDetectionTest {
 
     private final String osNameValue;
     private final OS expectedOS;
 
-    public ParameterizedOSDetectionTest(String osNameValue, OS expectedOS) {
+    public SupportedOSDetectionTest(String osNameValue, OS expectedOS) {
       this.osNameValue = osNameValue;
       this.expectedOS = expectedOS;
     }
@@ -70,32 +68,7 @@ public class OsDetectionTest {
     }
   }
 
-  public static class NonParameterizedOSDetectionTest {
-
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
-
-    @Test
-    public void testForRegularLinux() throws Exception {
-      setMappedFilesBaseDir(folder.getRoot().toPath());
-      folder.newFile("ld-2.23.so");
-
-      executeAndRestoreProperty(() -> {
-        System.setProperty(OS_NAME_PROPERTY, "linux");
-        assertSame(detectOS(), LINUX);
-      });
-    }
-
-    @Test
-    public void testForMuslBasedLinux() throws Exception {
-      setMappedFilesBaseDir(folder.getRoot().toPath());
-      folder.newFile("ld-musl-x86_64.so.1");
-
-      executeAndRestoreProperty(() -> {
-        System.setProperty(OS_NAME_PROPERTY, "linux");
-        assertSame(detectOS(), LINUX_MUSL);
-      });
-    }
+  public static class UnsupportedOSDetectionTest {
 
     @Test
     public void testUnsupportedOs() {


### PR DESCRIPTION
This PR removes auto-detection of MUSL-based Linux systems in favor of system properties the user can set to configure a specific path for a native library.

At the moment, there's only a single library with the name `xgboost4j` that we need. A user who wants to configure a specific path, has to set the system property `xgboostruntime.native.xgboost4j`. If this system property is present, its value is used as a library path inside the JAR.

A user who runs xgboost4j on a MUSL-based Linux system, will get an additional error message `Alternatively, if your Linux OS is musl-based, you should set the path for the native library xgboost4j via the system property xgboostruntime.native.xgboost4j`.

Resolves #7915 
