### PR TITLE
Unify the cat split storage for CPU.

### DIFF
--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -440,10 +440,10 @@ class RegTree : public Model {
    * \param right_sum         The sum hess of right leaf.
    */
   void ExpandCategorical(bst_node_t nid, unsigned split_index,
-                         common::Span<uint32_t> split_cat, bool default_left,
+                         common::Span<const uint32_t> split_cat, bool default_left,
                          bst_float base_weight, bst_float left_leaf_weight,
-                         bst_float right_leaf_weight, bst_float loss_change,
-                         float sum_hess, float left_sum, float right_sum);
+                         bst_float right_leaf_weight, bst_float loss_change, float sum_hess,
+                         float left_sum, float right_sum);
 
   bool HasCategoricalSplit() const {
     return !split_categories_.empty();

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -117,8 +117,6 @@ class HistEvaluator {
     }
 
     p_best->Update(best);
-
-    p_best->Update(best);
   }
 
   // Enumerate/Scan the split values of specific feature

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -160,7 +160,7 @@ class TreeEvaluator {
       return;
     }
 
-    auto max_nidx = std::max(leftid, rightid);
+    size_t max_nidx = std::max(leftid, rightid);
     if (lower_bounds_.Size() <= max_nidx) {
       lower_bounds_.Resize(max_nidx * 2 + 1, -std::numeric_limits<float>::max());
     }

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -808,11 +808,9 @@ void RegTree::ExpandNode(bst_node_t nid, unsigned split_index, bst_float split_v
 }
 
 void RegTree::ExpandCategorical(bst_node_t nid, unsigned split_index,
-                                common::Span<uint32_t> split_cat, bool default_left,
-                                bst_float base_weight,
-                                bst_float left_leaf_weight,
-                                bst_float right_leaf_weight,
-                                bst_float loss_change, float sum_hess,
+                                common::Span<const uint32_t> split_cat, bool default_left,
+                                bst_float base_weight, bst_float left_leaf_weight,
+                                bst_float right_leaf_weight, bst_float loss_change, float sum_hess,
                                 float left_sum, float right_sum) {
   this->ExpandNode(nid, split_index, std::numeric_limits<float>::quiet_NaN(),
                    default_left, base_weight,

--- a/tests/python/test_updaters.py
+++ b/tests/python/test_updaters.py
@@ -10,10 +10,10 @@ exact_parameter_strategy = strategies.fixed_dictionaries({
     'nthread': strategies.integers(1, 4),
     'max_depth': strategies.integers(1, 11),
     'min_child_weight': strategies.floats(0.5, 2.0),
-    'alpha': strategies.floats(0.0, 2.0),
+    'alpha': strategies.floats(1e-5, 2.0),
     'lambda': strategies.floats(1e-5, 2.0),
     'eta': strategies.floats(0.01, 0.5),
-    'gamma': strategies.floats(0.0, 2.0),
+    'gamma': strategies.floats(1e-5, 2.0),
     'seed': strategies.integers(0, 10),
     # We cannot enable subsampling as the training loss can increase
     # 'subsample': strategies.floats(0.5, 1.0),


### PR DESCRIPTION
Use the bitset inside the split entry for both OHE split and partition-based split.