### PR TITLE
[R] Use `type` argument to control prediction types

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -151,7 +151,7 @@ xgb.iter.update <- function(booster_handle, dtrain, iter, obj = NULL) {
   if (is.null(obj)) {
     .Call(XGBoosterUpdateOneIter_R, booster_handle, as.integer(iter), dtrain)
   } else {
-    pred <- predict(booster_handle, dtrain, outputmargin = TRUE, training = TRUE,
+    pred <- predict(booster_handle, dtrain, type = "margin", training = TRUE,
                     ntreelimit = 0)
     gpair <- obj(pred, dtrain)
     .Call(XGBoosterBoostOneIter_R, booster_handle, dtrain, gpair$grad, gpair$hess)
@@ -179,7 +179,7 @@ xgb.iter.eval <- function(booster_handle, watchlist, iter, feval = NULL) {
     res <- sapply(seq_along(watchlist), function(j) {
       w <- watchlist[[j]]
       ## predict using all trees
-      preds <- predict(booster_handle, w, outputmargin = TRUE, iterationrange = c(1, 1))
+      preds <- predict(booster_handle, w, type = "margin", iterationrange = c(1, 1))
       eval_res <- feval(preds, w)
       out <- eval_res$value
       names(out) <- paste0(evnames[j], "-", eval_res$metric)

--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -188,7 +188,9 @@ xgb.Booster.complete <- function(object, saveraw = TRUE) {
 #'             \item "contrib" will return feature contributions to individual predictions (see Details).
 #'             \item "interaction" will return contributions of feature interactions to individual
 #'                   predictions (see Details).
-#' }
+#'             }
+#'
+#'             Note that, when using custom objective functions, "link" and "response" will default to "raw".
 #' @param missing Missing is only used when input is dense matrix. Pick a float value that represents
 #'        missing values in data (e.g., sometimes 0 or some other extreme value is used).
 #' @param ntreelimit Deprecated, use \code{iterationrange} instead.

--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -393,6 +393,34 @@ predict.xgb.Booster <- function(object, newdata,
     type = box(as.integer(0))
   )
 
+  if (length(list(...))) {
+    extra_args <- list(...)
+    extra_argnames <- names(extra_args)
+    is_default_type <- head(type, 1) == "link"
+
+    old_args_for_type <- list(
+      "outputmargin" = "margin",
+      "predleaf" = "leaf",
+      "predcontrib" = "contrib",
+      "predinteraction" = "interaction"
+    )
+
+    for (arg in names(old_args_for_type)) {
+      if (arg %in% extra_argnames) {
+        warning(
+          paste(
+            sprintf("Argument '%s' is deprecated and will be removed in a future version.", arg),
+            sprintf("Use type='%s' instead.", old_args_for_type[[arg]]),
+            sep = " "
+          )
+        )
+        if (is_default_type) {
+          type <- old_args_for_type[[arg]]
+        }
+      }
+    }
+  }
+
   set_type <- function(type) {
     if (args$type != 0) {
       stop("One type of prediction at a time.")

--- a/R-package/R/xgb.create.features.R
+++ b/R-package/R/xgb.create.features.R
@@ -81,7 +81,7 @@
 #' @export
 xgb.create.features <- function(model, data, ...){
   check.deprecation(...)
-  pred_with_leaf <- predict(model, data, predleaf = TRUE)
+  pred_with_leaf <- predict(model, data, type = "leaf")
   cols <- lapply(as.data.frame(pred_with_leaf), factor)
   cbind(data, sparse.model.matrix(~ . -1, cols)) # nolint
 }

--- a/R-package/R/xgb.plot.shap.R
+++ b/R-package/R/xgb.plot.shap.R
@@ -79,7 +79,7 @@
 #'                method = "hist", objective = "binary:logistic", nthread = 2, verbose = 0)
 #'
 #' xgb.plot.shap(agaricus.test$data, model = bst, features = "odor=none")
-#' contr <- predict(bst, agaricus.test$data, predcontrib = TRUE)
+#' contr <- predict(bst, agaricus.test$data, type = "contrib")
 #' xgb.plot.shap(agaricus.test$data, contr, model = bst, top_n = 12, n_col = 3)
 #' xgb.ggplot.shap.summary(agaricus.test$data, contr, model = bst, top_n = 12)  # Summary plot
 #'
@@ -259,7 +259,7 @@ xgb.shap.data <- function(data, shap_contrib = NULL, features = NULL, top_n = 1,
       colnames(shap_contrib) <- paste0("X", seq_len(ncol(data)))
     }
   } else {
-    shap_contrib <- predict(model, newdata = data, predcontrib = TRUE, approxcontrib = approxcontrib)
+    shap_contrib <- predict(model, newdata = data, type = "contrib", approxcontrib = approxcontrib)
     if (is.list(shap_contrib)) { # multiclass: either choose a class or merge
       shap_contrib <- if (!is.null(target_class)) shap_contrib[[target_class + 1]] else Reduce("+", lapply(shap_contrib, abs))
     }

--- a/R-package/demo/boost_from_prediction.R
+++ b/R-package/demo/boost_from_prediction.R
@@ -15,8 +15,8 @@ param <- list(max_depth = 2, eta = 1, nthread = 2, objective = 'binary:logistic'
 bst <- xgb.train(param, dtrain, 1, watchlist)
 # Note: we need the margin value instead of transformed prediction in set_base_margin
 # do predict with output_margin=TRUE, will always give you margin values before logistic transformation
-ptrain <- predict(bst, dtrain, outputmargin = TRUE)
-ptest  <- predict(bst, dtest, outputmargin = TRUE)
+ptrain <- predict(bst, dtrain, type = "margin")
+ptest  <- predict(bst, dtest, type = "margin")
 # set the base_margin property of dtrain and dtest
 # base margin is the base prediction we will boost from
 setinfo(dtrain, "base_margin", ptrain)

--- a/R-package/demo/predict_leaf_indices.R
+++ b/R-package/demo/predict_leaf_indices.R
@@ -21,11 +21,11 @@ accuracy.before <- (sum((predict(bst, agaricus.test$data) >= 0.5) == agaricus.te
                     / length(agaricus.test$label))
 
 # by default, we predict using all the trees
-pred_with_leaf <- predict(bst, dtest, predleaf = TRUE)
+pred_with_leaf <- predict(bst, dtest, type = "leaf")
 head(pred_with_leaf)
 
 create.new.tree.features <- function(model, original.features){
-  pred_with_leaf <- predict(model, original.features, predleaf = TRUE)
+  pred_with_leaf <- predict(model, original.features, type = "leaf")
   cols <- list()
   for (i in 1:model$niter) {
     # max is not the real max but it s not important for the purpose of adding features

--- a/R-package/man/predict.xgb.Booster.Rd
+++ b/R-package/man/predict.xgb.Booster.Rd
@@ -8,13 +8,10 @@
 \method{predict}{xgb.Booster}(
   object,
   newdata,
+  type = c("link", "response", "margin", "leaf", "contrib", "interaction"),
   missing = NA,
-  outputmargin = FALSE,
   ntreelimit = NULL,
-  predleaf = FALSE,
-  predcontrib = FALSE,
   approxcontrib = FALSE,
-  predinteraction = FALSE,
   reshape = FALSE,
   training = FALSE,
   iterationrange = NULL,
@@ -33,26 +30,39 @@
        For single-row predictions on sparse data, it's recommended to use CSR format. If passing
        a sparse vector, it will take it as a row vector.}
 
+\item{type}{Type of prediction to make:\itemize{
+            \item "link" will return the predicted values according to the objective function being optimized for
+                  (after applying the corresponding link function) - for example, for
+                  \code{objective="binary:logistic"}, it will return predicted probabilities, while for
+                  \code{objective="reg:squarederror"}, it will return predicted values as no link function is
+                  applied to such predictions.
+
+                  \bold{Note:} \code{"link"} will not output the link-function values for
+                  \code{objective="multi:softmax"} (i.e. it will not output predicted probabilities),
+                  sticking instead to predicted class. Use \code{objective="multi:softprob"} for obtaining
+                  multi-class classification probabilities.
+            \item "response" will return the predicted class in classification objectives, and the predicted value
+                  in regression and other objectives.
+            \item "margin" will return the original untransformed sum of predictions from boosting
+                  iterations' results. E.g., setting \code{type="margin"} for logistic regression
+                  (\code{objective="binary:logistic"}) would result in predictions for log-odds instead of
+                  probabilities.
+            \item "leaf" will return leaf indices for each tree.
+            \item "contrib" will return feature contributions to individual predictions (see Details).
+            \item "interaction" will return contributions of feature interactions to individual
+                  predictions (see Details).
+}}
+
 \item{missing}{Missing is only used when input is dense matrix. Pick a float value that represents
 missing values in data (e.g., sometimes 0 or some other extreme value is used).}
 
-\item{outputmargin}{whether the prediction should be returned in the for of original untransformed
-sum of predictions from boosting iterations' results. E.g., setting \code{outputmargin=TRUE} for
-logistic regression would result in predictions for log-odds instead of probabilities.}
-
 \item{ntreelimit}{Deprecated, use \code{iterationrange} instead.}
-
-\item{predleaf}{whether predict leaf index.}
-
-\item{predcontrib}{whether to return feature contributions to individual predictions (see Details).}
 
 \item{approxcontrib}{whether to use a fast approximation for feature contributions (see Details).}
 
-\item{predinteraction}{whether to return contributions of feature interactions to individual predictions (see Details).}
-
 \item{reshape}{whether to reshape the vector of predictions to a matrix form when there are several
-prediction outputs per case. This option has no effect when either of predleaf, predcontrib,
-or predinteraction flags is TRUE.}
+prediction outputs per case. This option has no effect when supplying prediction types
+\code{"leaf"}, \code{"contrib"}, or \code{"interaction"}.}
 
 \item{training}{whether is the prediction result used for training.  For dart booster,
 training predicting will perform dropout.}
@@ -75,29 +85,30 @@ For multiclass classification, either a \code{num_class * nrows(newdata)} vector
 a \code{(nrows(newdata), num_class)} dimension matrix is returned, depending on
 the \code{reshape} value.
 
-When \code{predleaf = TRUE}, the output is a matrix object with the
+When \code{type="leaf"}, the output is a matrix object with the
 number of columns corresponding to the number of trees.
 
-When \code{predcontrib = TRUE} and it is not a multiclass setting, the output is a matrix object with
+When \code{type="contrib"} and it is not a multiclass setting, the output is a matrix object with
 \code{num_features + 1} columns. The last "+ 1" column in a matrix corresponds to bias.
 For a multiclass case, a list of \code{num_class} elements is returned, where each element is
 such a matrix. The contribution values are on the scale of untransformed margin
 (e.g., for binary classification would mean that the contributions are log-odds deviations from bias).
 
-When \code{predinteraction = TRUE} and it is not a multiclass setting, the output is a 3d array with
+When \code{type="interaction"} and it is not a multiclass setting, the output is a 3d array with
 dimensions \code{c(nrow, num_features + 1, num_features + 1)}. The off-diagonal (in the last two dimensions)
 elements represent different features interaction contributions. The array is symmetric WRT the last
 two dimensions. The "+ 1" columns corresponds to bias. Summing this array along the last dimension should
-produce practically the same result as predict with \code{predcontrib = TRUE}.
+produce practically the same result as predict with \code{type="contrib"}.
 For a multiclass case, a list of \code{num_class} elements is returned, where each element is
 such an array.
 
-When \code{strict_shape} is set to \code{TRUE}, the output is always an array.  For
-normal prediction, the output is a 2-dimension array \code{(num_class, nrow(newdata))}.
+When \code{strict_shape} is set to \code{TRUE}, the output is always a matrix.  For
+normal prediction (\code{type="link"}), the output is a 2-dimension matrix with dimensions
+\code{(num_class, nrow(newdata))}, while for \code{type="response"} it reduces to \code{(1, nrow(newdata))}.
 
-For \code{predcontrib = TRUE}, output is \code{(ncol(newdata) + 1, num_class, nrow(newdata))}
-For \code{predinteraction = TRUE}, output is \code{(ncol(newdata) + 1, ncol(newdata) + 1, num_class, nrow(newdata))}
-For \code{predleaf = TRUE}, output is \code{(n_trees_in_forest, num_class, n_iterations, nrow(newdata))}
+For \code{type="contrib"}, output is \code{(ncol(newdata) + 1, num_class, nrow(newdata))}
+For \code{type="interaction"}, output is \code{(ncol(newdata) + 1, ncol(newdata) + 1, num_class, nrow(newdata))}
+For \code{type="leaf"}, output is \code{(n_trees_in_forest, num_class, n_iterations, nrow(newdata))}
 }
 \description{
 Predicted values based on either xgboost model or model handle object.
@@ -106,11 +117,11 @@ Predicted values based on either xgboost model or model handle object.
 Note that \code{iterationrange} would currently do nothing for predictions from gblinear,
 since gblinear doesn't keep its boosting history.
 
-One possible practical applications of the \code{predleaf} option is to use the model
+One possible practical applications of the \code{type="leaf"} option is to use the model
 as a generator of new features which capture non-linearity and interactions,
 e.g., as implemented in \code{\link{xgb.create.features}}.
 
-Setting \code{predcontrib = TRUE} allows to calculate contributions of each feature to
+Setting \code{type="contrib"} allows to calculate contributions of each feature to
 individual predictions. For "gblinear" booster, feature contributions are simply linear terms
 (feature_beta * feature_value). For "gbtree" booster, feature contributions are SHAP
 values (Lundberg 2017) that sum to the difference between the expected output
@@ -118,7 +129,7 @@ of the model and the current prediction (where the hessian weights are used to c
 Setting \code{approxcontrib = TRUE} approximates these values following the idea explained
 in \url{http://blog.datadive.net/interpreting-random-forests/}.
 
-With \code{predinteraction = TRUE}, SHAP values of contributions of interaction of each pair of features
+With \code{type="interaction"}, SHAP values of contributions of interaction of each pair of features
 are computed. Note that this operation might be rather expensive in terms of compute and memory.
 Since it quadratically depends on the number of features, it is recommended to perform selection
 of the most important features first. See below about the format of the returned results.
@@ -140,12 +151,12 @@ pred1 <- predict(bst, test$data, iterationrange = c(1, 2))
 
 # Predicting tree leafs:
 # the result is an nsamples X ntrees matrix
-pred_leaf <- predict(bst, test$data, predleaf = TRUE)
+pred_leaf <- predict(bst, test$data, type = "leaf")
 str(pred_leaf)
 
 # Predicting feature contributions to predictions:
 # the result is an nsamples X (nfeatures + 1) matrix
-pred_contr <- predict(bst, test$data, predcontrib = TRUE)
+pred_contr <- predict(bst, test$data, type = "contrib")
 str(pred_contr)
 # verify that contributions' sums are equal to log-odds of predictions (up to float precision):
 summary(rowSums(pred_contr) - qlogis(pred))

--- a/R-package/man/predict.xgb.Booster.Rd
+++ b/R-package/man/predict.xgb.Booster.Rd
@@ -51,7 +51,9 @@
             \item "contrib" will return feature contributions to individual predictions (see Details).
             \item "interaction" will return contributions of feature interactions to individual
                   predictions (see Details).
-}}
+            }
+
+            Note that, when using custom objective functions, "link" and "response" will default to "raw".}
 
 \item{missing}{Missing is only used when input is dense matrix. Pick a float value that represents
 missing values in data (e.g., sometimes 0 or some other extreme value is used).}

--- a/R-package/man/predict.xgb.Booster.Rd
+++ b/R-package/man/predict.xgb.Booster.Rd
@@ -8,7 +8,7 @@
 \method{predict}{xgb.Booster}(
   object,
   newdata,
-  type = c("link", "response", "margin", "leaf", "contrib", "interaction"),
+  type = c("response", "class", "margin", "leaf", "contrib", "interaction"),
   missing = NA,
   ntreelimit = NULL,
   approxcontrib = FALSE,
@@ -31,17 +31,17 @@
        a sparse vector, it will take it as a row vector.}
 
 \item{type}{Type of prediction to make:\itemize{
-            \item "link" will return the predicted values according to the objective function being optimized for
+            \item "response" will return the predicted values according to the objective function being optimized for
                   (after applying the corresponding link function) - for example, for
                   \code{objective="binary:logistic"}, it will return predicted probabilities, while for
                   \code{objective="reg:squarederror"}, it will return predicted values as no link function is
                   applied to such predictions.
 
-                  \bold{Note:} \code{"link"} will not output the link-function values for
+                  \bold{Note:} \code{"response"} will not output the link-function values for
                   \code{objective="multi:softmax"} (i.e. it will not output predicted probabilities),
                   sticking instead to predicted class. Use \code{objective="multi:softprob"} for obtaining
                   multi-class classification probabilities.
-            \item "response" will return the predicted class in classification objectives, and the predicted value
+            \item "class" will return the predicted class in classification objectives, and the predicted value
                   in regression and other objectives.
             \item "margin" will return the original untransformed sum of predictions from boosting
                   iterations' results. E.g., setting \code{type="margin"} for logistic regression
@@ -53,7 +53,7 @@
                   predictions (see Details).
             }
 
-            Note that, when using custom objective functions, "link" and "response" will default to "raw".}
+            Note that, when using custom objective functions, "response" and "class" will default to "margin".}
 
 \item{missing}{Missing is only used when input is dense matrix. Pick a float value that represents
 missing values in data (e.g., sometimes 0 or some other extreme value is used).}
@@ -105,8 +105,8 @@ For a multiclass case, a list of \code{num_class} elements is returned, where ea
 such an array.
 
 When \code{strict_shape} is set to \code{TRUE}, the output is always a matrix.  For
-normal prediction (\code{type="link"}), the output is a 2-dimension matrix with dimensions
-\code{(num_class, nrow(newdata))}, while for \code{type="response"} it reduces to \code{(1, nrow(newdata))}.
+normal prediction (\code{type="response"}), the output is a 2-dimension matrix with dimensions
+\code{(num_class, nrow(newdata))}, while for \code{type="class"} it reduces to \code{(1, nrow(newdata))}.
 
 For \code{type="contrib"}, output is \code{(ncol(newdata) + 1, num_class, nrow(newdata))}
 For \code{type="interaction"}, output is \code{(ncol(newdata) + 1, ncol(newdata) + 1, num_class, nrow(newdata))}

--- a/R-package/man/xgb.plot.shap.Rd
+++ b/R-package/man/xgb.plot.shap.Rd
@@ -129,7 +129,7 @@ bst <- xgboost(agaricus.train$data, agaricus.train$label, nrounds = 50,
                method = "hist", objective = "binary:logistic", nthread = 2, verbose = 0)
 
 xgb.plot.shap(agaricus.test$data, model = bst, features = "odor=none")
-contr <- predict(bst, agaricus.test$data, predcontrib = TRUE)
+contr <- predict(bst, agaricus.test$data, type = "contrib")
 xgb.plot.shap(agaricus.test$data, contr, model = bst, top_n = 12, n_col = 3)
 xgb.ggplot.shap.summary(agaricus.test$data, contr, model = bst, top_n = 12)  # Summary plot
 

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -416,7 +416,7 @@ test_that("strict_shape works", {
     contri <- predict(bst, X, type = "contrib", strict_shape = TRUE)
     interact <- predict(bst, X, type = "interaction", strict_shape = TRUE)
     leaf <- predict(bst, X, type = "leaf", strict_shape = TRUE)
-    response <- predict(bst, X, type = "response", strict_shape = TRUE)
+    classpred <- predict(bst, X, type = "class", strict_shape = TRUE)
 
     n_rows <- nrow(X)
     n_cols <- ncol(X)
@@ -426,7 +426,7 @@ test_that("strict_shape works", {
     expect_equal(dim(contri), c(n_cols + 1, n_groups, n_rows))
     expect_equal(dim(interact), c(n_cols + 1, n_cols + 1, n_groups, n_rows))
     expect_equal(dim(leaf), c(1, n_groups, n_rounds, n_rows))
-    expect_equal(dim(response), c(1L, n_rows))
+    expect_equal(dim(classpred), c(1L, n_rows))
 
     if (n_groups != 1) {
       for (g in seq_len(n_groups)) {
@@ -478,19 +478,19 @@ test_that("'predict' accepts CSR data", {
   expect_equal(p_csc, p_spv)
 })
 
-test_that("'predict' with 'type=response' returns correct outputs", {
+test_that("'predict' with 'type=class' returns correct outputs", {
   X <- agaricus.train$data
   y <- agaricus.train$label
   bst_classif <- xgboost(data = X, label = y, objective = "binary:logistic",
                          nrounds = 5L, verbose = FALSE)
-  pred <- predict(bst_classif, X, type = "response")
+  pred <- predict(bst_classif, X, type = "class")
   expect_true(is.vector(pred))
   expect_equal(length(pred), nrow(X))
   expect_true(all(pred %in% c(0, 1)))
 
   bst_regr <- xgboost(data = X, label = y, objective = "reg:squarederror",
                       nrounds = 5L, verbose = FALSE)
-  pred <- predict(bst_regr, X, type = "response")
+  pred <- predict(bst_regr, X, type = "class")
   expect_true(is.vector(pred))
   expect_equal(length(pred), nrow(X))
   expect_true(all(!(pred %in% c(0, 1))))
@@ -499,7 +499,7 @@ test_that("'predict' with 'type=response' returns correct outputs", {
   y <- as.numeric(iris$Species) - 1
   bst_multi <- xgboost(data = X, label = y, objective = "multi:softprob",
                        nrounds = 5L, verbose = FALSE, num_class = 3L)
-  pred <- predict(bst_multi, X, type = "response")
+  pred <- predict(bst_multi, X, type = "class")
   expect_true(is.vector(pred))
   expect_equal(length(pred), nrow(X))
   expect_true(all(pred %in% c(0, 1, 2)))

--- a/R-package/tests/testthat/test_interactions.R
+++ b/R-package/tests/testthat/test_interactions.R
@@ -25,10 +25,10 @@ test_that("predict feature interactions works", {
   param <- list(eta = 0.1, max_depth = 4, base_score = mean(y), lambda = 0, nthread = 2)
   b <- xgb.train(param, dm, 100)
 
-  pred <- predict(b, dm, outputmargin = TRUE)
+  pred <- predict(b, dm, type = "margin")
 
   # SHAP contributions:
-  cont <- predict(b, dm, predcontrib = TRUE)
+  cont <- predict(b, dm, type = "contrib")
   expect_equal(dim(cont), c(N, P + 1))
   # make sure for each row they add up to marginal predictions
   expect_lt(max(abs(rowSums(cont) - pred)), 0.001)
@@ -44,7 +44,7 @@ test_that("predict feature interactions works", {
 
 
   # SHAP interaction contributions:
-  intr <- predict(b, dm, predinteraction = TRUE)
+  intr <- predict(b, dm, type = "interaction")
   expect_equal(dim(intr), c(N, P + 1, P + 1))
   # check assigned colnames
   cn <- c(letters[1:P], "BIAS")
@@ -109,7 +109,7 @@ test_that("SHAP contribution values are not NAN", {
 
   shaps <- as.data.frame(predict(fit,
     newdata = as.matrix(subset(d, fold == 1)[, ivs]),
-    predcontrib = TRUE))
+    type = "contrib"))
   result <- cbind(shaps, sum = rowSums(shaps), pred = predict(fit,
       newdata = as.matrix(subset(d, fold == 1)[, ivs])))
 
@@ -123,13 +123,13 @@ test_that("multiclass feature interactions work", {
   b <- xgb.train(param, dm, 40)
   pred <- t(
     array(
-      data = predict(b, dm, outputmargin = TRUE),
+      data = predict(b, dm, type = "margin"),
       dim = c(3, 150)
     )
   )
 
   # SHAP contributions:
-  cont <- predict(b, dm, predcontrib = TRUE)
+  cont <- predict(b, dm, type = "contrib")
   expect_length(cont, 3)
   # rewrap them as a 3d array
   cont <- array(
@@ -141,7 +141,7 @@ test_that("multiclass feature interactions work", {
   expect_lt(max(abs(apply(cont, c(1, 3), sum) - pred)), 0.001)
 
   # SHAP interaction contributions:
-  intr <- predict(b, dm, predinteraction = TRUE)
+  intr <- predict(b, dm, type = "interaction")
   expect_length(intr, 3)
   # rewrap them as a 4d array
   intr <- aperm(
@@ -172,13 +172,13 @@ test_that("SHAP single sample works", {
 
   predt <- predict(
     booster,
-    newdata = train$data[1, , drop = FALSE], predcontrib = TRUE
+    newdata = train$data[1, , drop = FALSE], type = "contrib"
   )
   expect_equal(dim(predt), c(1, dim(train$data)[2] + 1))
 
   predt <- predict(
     booster,
-    newdata = train$data[1, , drop = FALSE], predinteraction = TRUE
+    newdata = train$data[1, , drop = FALSE], type = "interaction"
   )
   expect_equal(dim(predt), c(1, dim(train$data)[2] + 1, dim(train$data)[2] + 1))
 })

--- a/R-package/vignettes/xgboostfromJSON.Rmd
+++ b/R-package/vignettes/xgboostfromJSON.Rmd
@@ -78,7 +78,7 @@ cat(bst_json)
 The tree JSON shown by the above code-chunk tells us that if the data is less than 20180132, the tree will output the value in the first leaf.  Otherwise it will output the value in the second leaf.  Let's try to reproduce this manually with the data we have and confirm that it matches the model predictions we've already calculated.
 
 ```{r}
-bst_preds_logodds <- predict(bst,as.matrix(data$dates), outputmargin = TRUE)
+bst_preds_logodds <- predict(bst,as.matrix(data$dates), type = "margin")
 
 # calculate the logodds values using the JSON representation
 bst_from_json_logodds <- ifelse(data$dates<node$split_condition,


### PR DESCRIPTION
ref #7906 

In R packages for statistical modeling, the `predict` functions for model objects tend to allow switching between different prediction types such as probabilities or classes through a parameter `type` (for example, base R's `predict.glm` does it like that).

`xgboost` offers several mutually exclusive parameters to control prediction types (`outputmargin`, `precontrib`, `predinteraction`, `predleaf`). This PR merges them all into a single `type` parameter in line with base R and other popular packages, adding an option to predict classes for classification objectives.

Note however that objective `multi:softmax` is problematic in this scenario, since it doesn't allow switching between probabilities and classes on the fly, so an exception about it is mentioned in the docs.

Right now the code logic is to check the objective and determine if and how it should determine the predicted class from the outputs, but:
* I wasn't able to find any C-level function to extract the booster's objective, and am not sure that the way is done in this PR is ideal.
* It currently lists a set of objectives which allow class prediction from the original output, but I think a better approach would be to check if the objective starts with `binary` or `multi` - problem with such approach right now is that `multi:softmax` doesn't output probabilities.

Disclaimer: this is likely to cause several breakages in R packages that depend on `xgboost`.