### PR TITLE
set log level as ERROR when trackerProcess has some stderr output

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/RabitTracker.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/RabitTracker.java
@@ -58,8 +58,12 @@ public class RabitTracker implements IRabitTracker {
           trackerProcessLogger.error(line);
         }
         trackerProcess.get().waitFor();
-        trackerProcessLogger.info("Tracker Process ends with exit code " +
-                trackerProcess.get().exitValue());
+        int exitValue = trackerProcess.get().exitValue();
+        if (exitValue != 0) {
+          trackerProcessLogger.error("Tracker Process ends with exit code " + exitValue);
+        } else {
+          trackerProcessLogger.info("Tracker Process ends with exit code " + exitValue);
+        }
       } catch (IOException ex) {
         trackerProcessLogger.error(ex.toString());
       } catch (InterruptedException ie) {

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/RabitTracker.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/RabitTracker.java
@@ -55,7 +55,7 @@ public class RabitTracker implements IRabitTracker {
       String line;
       try {
         while ((line = reader.readLine()) != null) {
-          trackerProcessLogger.info(line);
+          trackerProcessLogger.error(line);
         }
         trackerProcess.get().waitFor();
         trackerProcessLogger.info("Tracker Process ends with exit code " +


### PR DESCRIPTION
Generally, in order to avoid too many spark logs, we usually do
`val sc = new SparkContext(conf)
       sc.setLogLevel("WARN")`

Using XGBoostClassifier by Spark Application, there are nothing error logs when lacking python3 in cluster environment, 
and we can see the following log when set log info level.
I think it is more useful to find error when loging stderr using error level.
> 22/05/23 15:11:02 WARN XGBoostSpark: train_test_ratio is deprecated since XGBoost 0.82, we recommend to explicitly pass a training and multiple evaluation datasets by passing 'eval_sets' and 'eval_set_names'
22/05/23 15:11:03 INFO RabitTracker$TrackerProcessLogger:   File "/mnt/sata05/hadoop/yarn/local/usercache/ubd_obx_test/appcache/application_1653287501496_0002/container_e29_1653287501496_0002_01_000001/tmp/tracker4901044343178211783.py", line 24
22/05/23 15:11:03 INFO RabitTracker$TrackerProcessLogger:     def __init__(self, sock: socket.socket) -> None:
22/05/23 15:11:03 INFO RabitTracker$TrackerProcessLogger:                            ^
22/05/23 15:11:03 INFO RabitTracker$TrackerProcessLogger: SyntaxError: invalid syntax
22/05/23 15:11:03 INFO RabitTracker$TrackerProcessLogger: Tracker Process ends with exit code 1
22/05/23 15:11:03 INFO SparkContext: Starting job: collect at XGBoost.scala:431
22/05/23 15:11:03 INFO DAGScheduler: Registering RDD 149 (repartition at DataUtils.scala:96) as input to shuffle 9
22/05/23 15:11:03 INFO DAGScheduler: Got job 24 (collect at XGBoost.scala:431) with 1 output partitions
22/05/23 15:11:03 INFO DAGScheduler: Final stage: ResultStage 34 (collect at XGBoost.scala:431)
22/05/23 15:11:03 INFO DAGScheduler: Parents of final stage: List(ShuffleMapStage 33)
22/05/23 15:11:03 INFO DAGScheduler: Missing parents: List(ShuffleMapStage 33)
22/05/23 15:11:03 INFO DAGScheduler: Submitting ShuffleMapStage 33 (MapPartitionsRDD[149] at repartition at DataUtils.scala:96), which has no missing parents