### PR TITLE
Add minimal emscripten build support

### DIFF
--- a/python-package/xgboost/libpath.py
+++ b/python-package/xgboost/libpath.py
@@ -43,8 +43,7 @@ def find_lib_path() -> List[str]:
             # directory here
             dll_path.append(os.path.join(curr_path, './windows/Release/'))
         dll_path = [os.path.join(p, 'xgboost.dll') for p in dll_path]
-    elif sys.platform.startswith('linux') or sys.platform.startswith(
-            'freebsd'):
+    elif sys.platform.startswith(('linux', 'freebsd', 'emscripten')):
         dll_path = [os.path.join(p, 'libxgboost.so') for p in dll_path]
     elif sys.platform == 'darwin':
         dll_path = [os.path.join(p, 'libxgboost.dylib') for p in dll_path]

--- a/src/common/host_device_vector.cc
+++ b/src/common/host_device_vector.cc
@@ -180,13 +180,16 @@ template class HostDeviceVector<uint64_t>;  // bst_row_t
 template class HostDeviceVector<uint32_t>;  // bst_feature_t
 template class HostDeviceVector<RegTree::Segment>;
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__EMSCRIPTEN__)
 /*
  * On OSX:
  *
  * typedef unsigned int         uint32_t;
  * typedef unsigned long long   uint64_t;
  * typedef unsigned long       __darwin_size_t;
+ *
+ * On Emscripten:
+ * typedef unsigned long        size_t;
  */
 template class HostDeviceVector<std::size_t>;
 #endif  // defined(__APPLE__)


### PR DESCRIPTION
Hi, I'm from the [Pyodide project](https://github.com/pyodide/pyodide) and I would like to add some build patches to support the WebAssembly(Emscripten) build of XGboost.

These patches are applied in https://github.com/pyodide/pyodide/pull/2537.