### PR TITLE
Make federated plugin work with cmake 3.16.3

### DIFF
--- a/plugin/federated/CMakeLists.txt
+++ b/plugin/federated/CMakeLists.txt
@@ -1,6 +1,6 @@
 # gRPC needs to be installed first. See README.md.
-find_package(Protobuf REQUIRED)
-find_package(gRPC REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
+find_package(gRPC CONFIG REQUIRED)
 find_package(Threads)
 
 # Generated code from the protobuf definition.
@@ -18,7 +18,8 @@ protobuf_generate(
     PLUGIN "protoc-gen-grpc=${grpc_cpp_plugin_location}")
 
 # Wrapper for the gRPC client.
-add_library(federated_client INTERFACE federated_client.h)
+add_library(federated_client INTERFACE)
+target_sources(federated_client INTERFACE federated_client.h)
 target_link_libraries(federated_client INTERFACE federated_proto)
 
 # Rabit engine for Federated Learning.

--- a/plugin/federated/README.md
+++ b/plugin/federated/README.md
@@ -7,7 +7,7 @@ Install gRPC
 ------------
 ```shell
 sudo apt-get install build-essential autoconf libtool pkg-config cmake ninja-build
-git clone -b v1.45.2 https://github.com/grpc/grpc
+git clone -b v1.47.0 https://github.com/grpc/grpc
 cd grpc
 git submodule update --init
 cmake -S . -B build -GNinja -DABSL_PROPAGATE_CXX_STD=ON


### PR DESCRIPTION
Ubuntu 20.04 defaults to cmake 3.16.3, which has two issues with the current `CMakeLists.txt`:

* `An interface library target may be created with source files` was added in cmake 3.19.
* Older cmake requires `CONFIG` when finding `ProtoBuf` and `gPPC`: https://www.f-ax.de/dev/2020/11/08/grpc-plugin-cmake-support.html

@trivialfis 

