### PR TITLE
Force auc.cc to be statically linked

### DIFF
--- a/src/metric/auc.cc
+++ b/src/metric/auc.cc
@@ -25,6 +25,8 @@
 
 namespace xgboost {
 namespace metric {
+// tag the this file, used by force static link later.
+DMLC_REGISTRY_FILE_TAG(auc);
 /**
  * Calculate AUC for binary classification problem.  This function does not normalize the
  * AUC by 1 / (num_positive * num_negative), instead it returns a tuple for caller to

--- a/src/metric/metric.cc
+++ b/src/metric/metric.cc
@@ -78,6 +78,7 @@ DMLC_REGISTRY_ENABLE(::xgboost::MetricGPUReg);
 namespace xgboost {
 namespace metric {
 // List of files that will be force linked in static links.
+DMLC_REGISTRY_LINK_TAG(auc);
 DMLC_REGISTRY_LINK_TAG(elementwise_metric);
 DMLC_REGISTRY_LINK_TAG(multiclass_metric);
 DMLC_REGISTRY_LINK_TAG(survival_metric);


### PR DESCRIPTION
So that its registration logic can be run, and thus 'auc' metric function can be found.

discuss.xgboost.ai discussion: [Should src/metric/auc.{h,cc,cu} be forced to be linked statically?](https://discuss.xgboost.ai/t/should-src-metric-auc-h-cc-cu-be-forced-to-be-linked-statically/2830)