### PR TITLE
Rename `IterativeDMatrix`.

### DIFF
--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -26,7 +26,7 @@
 #include "../common/group_data.h"
 #include "../common/threading_utils.h"
 #include "../data/adapter.h"
-#include "../data/iterative_device_dmatrix.h"
+#include "../data/iterative_dmatrix.h"
 #include "file_iterator.h"
 
 #include "validation.h"
@@ -938,7 +938,7 @@ DMatrix *DMatrix::Create(DataIterHandle iter, DMatrixHandle proxy,
                          XGDMatrixCallbackNext *next, float missing,
                          int nthread,
                          int max_bin) {
-  return new data::IterativeDeviceDMatrix(iter, proxy, reset, next, missing,
+  return new data::IterativeDMatrix(iter, proxy, reset, next, missing,
                                           nthread, max_bin);
 }
 

--- a/src/data/iterative_dmatrix.cu
+++ b/src/data/iterative_dmatrix.cu
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 XGBoost contributors
+ * Copyright 2020-2022 XGBoost contributors
  */
 #include <memory>
 #include <type_traits>
@@ -7,7 +7,7 @@
 
 #include "../common/hist_util.cuh"
 #include "simple_batch_iterator.h"
-#include "iterative_device_dmatrix.h"
+#include "iterative_dmatrix.h"
 #include "sparse_page_source.h"
 #include "ellpack_page.cuh"
 #include "proxy_dmatrix.h"
@@ -16,7 +16,7 @@
 
 namespace xgboost {
 namespace data {
-void IterativeDeviceDMatrix::Initialize(DataIterHandle iter_handle, float missing) {
+void IterativeDMatrix::InitFromCUDA(DataIterHandle iter_handle, float missing) {
   // A handle passed to external iterator.
   DMatrixProxy* proxy = MakeProxy(proxy_);
   CHECK(proxy);
@@ -160,7 +160,7 @@ void IterativeDeviceDMatrix::Initialize(DataIterHandle iter_handle, float missin
   rabit::Allreduce<rabit::op::Max>(&info_.num_col_, 1);
 }
 
-BatchSet<EllpackPage> IterativeDeviceDMatrix::GetEllpackBatches(const BatchParam& param) {
+BatchSet<EllpackPage> IterativeDMatrix::GetEllpackBatches(const BatchParam& param) {
   CHECK(page_);
   // FIXME(Jiamingy): https://github.com/dmlc/xgboost/issues/7976
   if (param.max_bin != batch_param_.max_bin) {

--- a/tests/cpp/data/test_iterative_dmatrix.cu
+++ b/tests/cpp/data/test_iterative_dmatrix.cu
@@ -1,10 +1,10 @@
 /*!
- * Copyright 2020 XGBoost contributors
+ * Copyright 2020-2022 XGBoost contributors
  */
 #include <gtest/gtest.h>
 
 #include "../helpers.h"
-#include "../../../src/data/iterative_device_dmatrix.h"
+#include "../../../src/data/iterative_dmatrix.h"
 #include "../../../src/data/ellpack_page.cuh"
 #include "../../../src/data/device_adapter.cuh"
 
@@ -13,7 +13,7 @@ namespace data {
 
 void TestEquivalent(float sparsity) {
   CudaArrayIterForTest iter{sparsity};
-  IterativeDeviceDMatrix m(
+  IterativeDMatrix m(
       &iter, iter.Proxy(), Reset, Next, std::numeric_limits<float>::quiet_NaN(),
       0, 256);
   size_t offset = 0;
@@ -88,7 +88,7 @@ TEST(IterativeDeviceDMatrix, Basic) {
 
 TEST(IterativeDeviceDMatrix, RowMajor) {
   CudaArrayIterForTest iter(0.0f);
-  IterativeDeviceDMatrix m(
+  IterativeDMatrix m(
       &iter, iter.Proxy(), Reset, Next, std::numeric_limits<float>::quiet_NaN(),
       0, 256);
   size_t n_batches = 0;
@@ -139,7 +139,7 @@ TEST(IterativeDeviceDMatrix, RowMajorMissing) {
       reinterpret_cast<float *>(get<Integer>(j_interface["data"][0])));
   thrust::copy(h_data.cbegin(), h_data.cend(), ptr);
 
-  IterativeDeviceDMatrix m(
+  IterativeDMatrix m(
       &iter, iter.Proxy(), Reset, Next, std::numeric_limits<float>::quiet_NaN(),
       0, 256);
   auto &ellpack = *m.GetBatches<EllpackPage>({0, 256}).begin();
@@ -159,7 +159,7 @@ TEST(IterativeDeviceDMatrix, IsDense) {
   int num_bins = 16;
   auto test = [num_bins] (float sparsity) {
     CudaArrayIterForTest iter(sparsity);
-    IterativeDeviceDMatrix m(
+    IterativeDMatrix m(
         &iter, iter.Proxy(), Reset, Next, std::numeric_limits<float>::quiet_NaN(),
         0, 256);
     if (sparsity == 0.0) {

--- a/tests/cpp/helpers.cu
+++ b/tests/cpp/helpers.cu
@@ -2,7 +2,7 @@
 
 #include "helpers.h"
 #include "../../src/data/device_adapter.cuh"
-#include "../../src/data/iterative_device_dmatrix.h"
+#include "../../src/data/iterative_dmatrix.h"
 
 namespace xgboost {
 
@@ -28,12 +28,10 @@ int CudaArrayIterForTest::Next() {
   return 1;
 }
 
-
 std::shared_ptr<DMatrix> RandomDataGenerator::GenerateDeviceDMatrix() {
   CudaArrayIterForTest iter{this->sparsity_, this->rows_, this->cols_, 1};
-  auto m = std::make_shared<data::IterativeDeviceDMatrix>(
-      &iter, iter.Proxy(), Reset, Next, std::numeric_limits<float>::quiet_NaN(),
-      0, bins_);
+  auto m = std::make_shared<data::IterativeDMatrix>(
+      &iter, iter.Proxy(), Reset, Next, std::numeric_limits<float>::quiet_NaN(), 0, bins_);
   return m;
 }
 }  // namespace xgboost


### PR DESCRIPTION
Rename both files and class to avoid mixing with other future changes.

Related: https://github.com/dmlc/xgboost/issues/7890