### PR TITLE
[py-skl] Raise import error if sklearn is not installed.

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -547,7 +547,7 @@ class XGBModel(XGBModelBase):
         **kwargs: Any
     ) -> None:
         if not SKLEARN_INSTALLED:
-            raise XGBoostError(
+            raise ImportError(
                 "sklearn needs to be installed in order to use this module"
             )
         self.n_estimators = n_estimators


### PR DESCRIPTION
We are adding more optional dependencies (dask, pyspark), this unifies the error being raised when a dependency is not met. 