### PR TITLE
Check cuDF lazily

### DIFF
--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -745,11 +745,7 @@ def _from_cudf_df(
 
 
 def _is_cudf_ser(data: DataType) -> bool:
-    try:
-        import cudf
-    except ImportError:
-        return False
-    return isinstance(data, cudf.Series)
+    return lazy_isinstance(data, "cudf.core.series", "Series")
 
 
 def _is_cupy_array(data: DataType) -> bool:


### PR DESCRIPTION
In some cases the "import cudf" can raise a RuntimeError or other errors while loading. Doing a lazy check is safer for these cases. Similiar to #7752.

Example of RuntimeError that could be generated by import:
```python
Traceback (most recent call last):
  File "cuda/_cuda/ccuda.pyx", line 3671, in cuda._cuda.ccuda._cuInit
  File "cuda/_cuda/ccuda.pyx", line 435, in cuda._cuda.ccuda.cuPythonInit
RuntimeError: Failed to dlopen libcuda.so
```