### PR TITLE
[PySpark] change the returning model type to string from binary

### DIFF
--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -409,12 +409,13 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
     def _create_pyspark_model(self, xgb_model):
         return self._pyspark_model_cls()(xgb_model)
 
-    def _convert_to_sklearn_model(self, booster):
+    def _convert_to_sklearn_model(self, booster: bytearray, config: str):
         xgb_sklearn_params = self._gen_xgb_params_dict(
             gen_xgb_sklearn_estimator_param=True
         )
         sklearn_model = self._xgb_cls()(**xgb_sklearn_params)
         sklearn_model.load_model(booster)
+        sklearn_model._Booster.load_config(config)
         return sklearn_model
 
     def _query_plan_contains_valid_repartition(self, dataset):
@@ -629,17 +630,26 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
 
             if context.partitionId() == 0:
                 yield pd.DataFrame(
-                    data={"booster_string": [booster.save_raw("json").decode("utf-8")]}
+                    data={
+                        "config": [booster.save_config()],
+                        "booster": [booster.save_raw("json").decode("utf-8")]
+                    }
                 )
 
-        result_ser_booster = (
-            dataset.mapInPandas(_train_booster, schema="booster_string string")
-            .rdd.barrier()
-            .mapPartitions(lambda x: x)
-            .collect()[0][0]
-        )
+        def _run_job():
+            ret = (
+                dataset.mapInPandas(_train_booster, schema="config string, booster string")
+                .rdd.barrier()
+                .mapPartitions(lambda x: x)
+                .collect()[0]
+            )
+            return ret[0], ret[1]
+
+        (config, booster) = _run_job()
+
         result_xgb_model = self._convert_to_sklearn_model(
-            bytearray(result_ser_booster, "utf-8")
+            bytearray(booster, "utf-8"),
+            config
         )
         return self._copyValues(self._create_pyspark_model(result_xgb_model))
 

--- a/tests/python/test_spark/test_spark_local.py
+++ b/tests/python/test_spark/test_spark_local.py
@@ -904,7 +904,8 @@ class XgboostLocalTest(SparkTestCase):
 
         # Check that regardless of what booster, _convert_to_model converts to the correct class type
         sklearn_classifier = classifier._convert_to_sklearn_model(
-            clf_model.get_booster().save_raw("json")
+            clf_model.get_booster().save_raw("json"),
+            clf_model.get_booster().save_config()
         )
         assert isinstance(sklearn_classifier, XGBClassifier)
         assert sklearn_classifier.n_estimators == 200
@@ -912,7 +913,10 @@ class XgboostLocalTest(SparkTestCase):
         assert sklearn_classifier.max_depth == 3
         assert sklearn_classifier.get_params()["sketch_eps"] == 0.5
 
-        sklearn_regressor = regressor._convert_to_sklearn_model(reg_model.get_booster().save_raw("json"))
+        sklearn_regressor = regressor._convert_to_sklearn_model(
+            reg_model.get_booster().save_raw("json"),
+            reg_model.get_booster().save_config()
+        )
         assert isinstance(sklearn_regressor, XGBRegressor)
         assert sklearn_regressor.n_estimators == 200
         assert sklearn_regressor.missing == 2.0

--- a/tests/python/test_spark/test_spark_local.py
+++ b/tests/python/test_spark/test_spark_local.py
@@ -904,7 +904,7 @@ class XgboostLocalTest(SparkTestCase):
 
         # Check that regardless of what booster, _convert_to_model converts to the correct class type
         sklearn_classifier = classifier._convert_to_sklearn_model(
-            clf_model.get_booster()
+            clf_model.get_booster().save_raw("json")
         )
         assert isinstance(sklearn_classifier, XGBClassifier)
         assert sklearn_classifier.n_estimators == 200
@@ -912,7 +912,7 @@ class XgboostLocalTest(SparkTestCase):
         assert sklearn_classifier.max_depth == 3
         assert sklearn_classifier.get_params()["sketch_eps"] == 0.5
 
-        sklearn_regressor = regressor._convert_to_sklearn_model(reg_model.get_booster())
+        sklearn_regressor = regressor._convert_to_sklearn_model(reg_model.get_booster().save_raw("json"))
         assert isinstance(sklearn_regressor, XGBRegressor)
         assert sklearn_regressor.n_estimators == 200
         assert sklearn_regressor.missing == 2.0


### PR DESCRIPTION
 [RAPIDS Accelerator](https://nvidia.github.io/spark-rapids/) is a Spark plugin that leverages the GPUs to accelerate the spark SQL and dataframe API.  But not all types can be supported by RAPIDS Accelerator. For example, It has not supported the `BINARY type` when doing mapInPandas.

``` console
22/07/17 09:06:41 WARN GpuOverrides: 
!Exec <MapInPandasExec> cannot run even partially on the GPU because unsupported data types in output: BinaryType [booster_bytes#31]; not all expressions can be replaced
  !Expression <AttributeReference> booster_bytes#31 cannot run on GPU because expression AttributeReference booster_bytes#31 produces an unsupported type BinaryType
  !Expression <PythonUDF> _train_booster(values#15, label#14) blocks running on GPU because expression PythonUDF _train_booster(values#15, label#14) produces an unsupported type StructType(StructField(booster_bytes,BinaryType,true))
    @Expression <AttributeReference> values#15 could run on GPU
    @Expression <AttributeReference> label#14 could run on GPU
  *Exec <ShuffleExchangeExec> will run on GPU
    *Partitioning <SinglePartition$> will run on GPU
    *Exec <ProjectExec> will run on GPU
      *Expression <Alias> cast(array(sepal_length#0, sepal_width#1, petal_length#2, petal_width#3) as array<float>) AS values#15 will run on GPU
        *Expression <Cast> cast(array(sepal_length#0, sepal_width#1, petal_length#2, petal_width#3) as array<float>) will run on GPU
          *Expression <CreateArray> array(sepal_length#0, sepal_width#1, petal_length#2, petal_width#3) will run on GPU
      *Expression <Alias> cast(class#4 as float) AS label#14 will run on GPU
        *Expression <Cast> cast(class#4 as float) will run on GPU
      *Exec <FileSourceScanExec> will run on GPU
```

So this PR changes returning model from "bytes" to "string", which can make RAPIDS Accelerator speed up XGBoost PySpark seamlessly. And there is no side effect for the XGBoost PySpark itself.

``` console
*Exec <MapInPandasExec> will partially run on GPU
  *Expression <PythonUDF> _train_booster(values#15, label#14) will not block GPU acceleration
  *Exec <ShuffleExchangeExec> will run on GPU
    *Partitioning <SinglePartition$> will run on GPU
    *Exec <ProjectExec> will run on GPU
      *Expression <Alias> cast(array(sepal_length#0, sepal_width#1, petal_length#2, petal_width#3) as array<float>) AS values#15 will run on GPU
        *Expression <Cast> cast(array(sepal_length#0, sepal_width#1, petal_length#2, petal_width#3) as array<float>) will run on GPU
          *Expression <CreateArray> array(sepal_length#0, sepal_width#1, petal_length#2, petal_width#3) will run on GPU
      *Expression <Alias> cast(class#4 as float) AS label#14 will run on GPU
        *Expression <Cast> cast(class#4 as float) will run on GPU
      *Exec <FileSourceScanExec> will run on GPU
```

I have a rough performance test, XGBoost PySpark can have ~35% improvement when using RAPIDS Accelerator.
