### PR TITLE
[pyspark] Cleanup data processing.

### DIFF
--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -100,7 +100,7 @@ class PartIter(DataIter):
 def create_dmatrix_from_partitions(
     iterator: Iterator[pd.DataFrame],
     feature_cols: Optional[Sequence[str]],
-    kwargs: Dict[str, Any],     # use dict to make sure this parameter is passed.
+    kwargs: Dict[str, Any],  # use dict to make sure this parameter is passed.
 ) -> Tuple[DMatrix, Optional[DMatrix]]:
     """Create DMatrix from spark data partitions. This is not particularly efficient as
     we need to convert the pandas series format to numpy then concatenate all the data.

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -1,194 +1,181 @@
-# type: ignore
-"""Xgboost pyspark integration submodule for data related functions."""
-# pylint: disable=too-many-arguments
-from typing import Iterator
+"""Utilities for processing spark partitions."""
+from collections import defaultdict, namedtuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
+from xgboost.compat import concat
 
-from xgboost import DMatrix
-
-
-def _prepare_train_val_data(
-    data_iterator, has_weight, has_validation, has_fit_base_margin
-):
-    def gen_data_pdf():
-        for pdf in data_iterator:
-            yield pdf
-
-    return _process_data_iter(
-        gen_data_pdf(),
-        train=True,
-        has_weight=has_weight,
-        has_validation=has_validation,
-        has_fit_base_margin=has_fit_base_margin,
-        has_predict_base_margin=False,
-    )
+from xgboost import DataIter, DeviceQuantileDMatrix, DMatrix
 
 
-def _check_feature_dims(num_dims, expected_dims):
-    """
-    Check all feature vectors has the same dimension
-    """
-    if expected_dims is None:
-        return num_dims
-    if num_dims != expected_dims:
-        raise ValueError(
-            f"Rows contain different feature dimensions: Expecting {expected_dims}, got {num_dims}."
-        )
-    return expected_dims
+def stack_series(series: pd.Series) -> np.ndarray:
+    """Stack a series of arrays."""
+    array = series.to_numpy(copy=False)
+    array = np.stack(array)
+    return array
 
 
-def _row_tuple_list_to_feature_matrix_y_w(
-    data_iterator,
-    train,
-    has_weight,
-    has_fit_base_margin,
-    has_predict_base_margin,
-    has_validation: bool = False,
-):
-    """
-    Construct a feature matrix in ndarray format, label array y and weight array w
-    from the row_tuple_list.
-    If train == False, y and w will be None.
-    If has_weight == False, w will be None.
-    If has_base_margin == False, b_m will be None.
-    Note: the row_tuple_list will be cleared during
-    executing for reducing peak memory consumption
-    """
-    # pylint: disable=too-many-locals
-    expected_feature_dims = None
-    label_list, weight_list, base_margin_list = [], [], []
-    label_val_list, weight_val_list, base_margin_val_list = [], [], []
-    values_list, values_val_list = [], []
+# Global constant for defining column alias shared between estimator and data
+# processing procedures.
+Alias = namedtuple("Alias", ("data", "label", "weight", "margin", "valid"))
+alias = Alias("values", "label", "weight", "baseMargin", "validationIndicator")
 
-    # Process rows
-    for pdf in data_iterator:
-        if len(pdf) == 0:
-            continue
-        if train and has_validation:
-            pdf_val = pdf.loc[pdf["validationIndicator"], :]
-            pdf = pdf.loc[~pdf["validationIndicator"], :]
 
-        num_feature_dims = len(pdf["values"].values[0])
+def concat_or_none(seq: Optional[Sequence[np.ndarray]]) -> Optional[np.ndarray]:
+    """Concatenate the data if it's not None."""
+    if seq:
+        return concat(seq)
+    return None
 
-        expected_feature_dims = _check_feature_dims(
-            num_feature_dims, expected_feature_dims
-        )
 
-        # Note: each element in `pdf["values"]` is an numpy array.
-        values_list.append(pdf["values"].to_list())
-        if train:
-            label_list.append(pdf["label"].to_numpy())
-        if has_weight:
-            weight_list.append(pdf["weight"].to_numpy())
-        if has_fit_base_margin or has_predict_base_margin:
-            base_margin_list.append(pdf["baseMargin"].to_numpy())
+def cache_partitions(
+    iterator: Iterator[pd.DataFrame], append: Callable[[pd.DataFrame, str, bool], None]
+) -> None:
+    """Extract partitions from pyspark iterator. `append` is a user defined function for
+    accepting new partition."""
+
+    def make_blob(part: pd.DataFrame, is_valid: bool) -> None:
+        append(part, alias.data, is_valid)
+        append(part, alias.label, is_valid)
+        append(part, alias.weight, is_valid)
+        append(part, alias.margin, is_valid)
+
+    has_validation: Optional[bool] = None
+
+    for part in iterator:
+        if has_validation is None:
+            has_validation = alias.valid in part.columns
+        if has_validation is True:
+            assert alias.valid in part.columns
+
         if has_validation:
-            values_val_list.append(pdf_val["values"].to_list())
-            if train:
-                label_val_list.append(pdf_val["label"].to_numpy())
-            if has_weight:
-                weight_val_list.append(pdf_val["weight"].to_numpy())
-            if has_fit_base_margin or has_predict_base_margin:
-                base_margin_val_list.append(pdf_val["baseMargin"].to_numpy())
+            train = part.loc[~part[alias.valid], :]
+            valid = part.loc[part[alias.valid], :]
+        else:
+            train, valid = part, None
 
-    # Construct feature_matrix
-    if expected_feature_dims is None:
-        return [], [], [], []
+        make_blob(train, False)
+        if valid is not None:
+            make_blob(valid, True)
 
-    # Construct feature_matrix, y and w
-    feature_matrix = np.concatenate(values_list)
-    y = np.concatenate(label_list) if train else None
-    w = np.concatenate(weight_list) if has_weight else None
-    b_m = (
-        np.concatenate(base_margin_list)
-        if (has_fit_base_margin or has_predict_base_margin)
-        else None
-    )
-    if has_validation:
-        feature_matrix_val = np.concatenate(values_val_list)
-        y_val = np.concatenate(label_val_list) if train else None
-        w_val = np.concatenate(weight_val_list) if has_weight else None
-        b_m_val = (
-            np.concatenate(base_margin_val_list)
-            if (has_fit_base_margin or has_predict_base_margin)
-            else None
+
+class PartIter(DataIter):
+    """Iterator for creating Quantile DMatrix from partitions."""
+
+    def __init__(self, data: Dict[str, List], on_device: bool) -> None:
+        self._iter = 0
+        self._cuda = on_device
+        self._data = data
+
+        super().__init__()
+
+    def _fetch(self, data: Optional[Sequence[pd.DataFrame]]) -> Optional[pd.DataFrame]:
+        if not data:
+            return None
+
+        if self._cuda:
+            import cudf  # pylint: disable=import-error
+
+            return cudf.DataFrame(data[self._iter])
+
+        return data[self._iter]
+
+    def next(self, input_data: Callable) -> int:
+        if self._iter == len(self._data[alias.data]):
+            return 0
+        input_data(
+            data=self._fetch(self._data[alias.data]),
+            label=self._fetch(self._data.get(alias.label, None)),
+            weight=self._fetch(self._data.get(alias.weight, None)),
+            base_margin=self._fetch(self._data.get(alias.margin, None)),
         )
-        return feature_matrix, y, w, b_m, feature_matrix_val, y_val, w_val, b_m_val
-    return feature_matrix, y, w, b_m
+        self._iter += 1
+        return 1
+
+    def reset(self) -> None:
+        self._iter = 0
 
 
-def _process_data_iter(
-    data_iterator: Iterator[pd.DataFrame],
-    train: bool,
-    has_weight: bool,
-    has_validation: bool,
-    has_fit_base_margin: bool = False,
-    has_predict_base_margin: bool = False,
-):
+def create_dmatrix_from_partitions(
+    iterator: Iterator[pd.DataFrame],
+    feature_cols: Optional[Sequence[str]],
+    kwargs: Dict[str, Any],     # use dict to make sure this parameter is passed.
+) -> Tuple[DMatrix, Optional[DMatrix]]:
+    """Create DMatrix from spark data partitions. This is not particularly efficient as
+    we need to convert the pandas series format to numpy then concatenate all the data.
+
+    Parameters
+    ----------
+    iterator :
+        Pyspark partition iterator.
+    kwargs :
+        Metainfo for DMatrix.
+
     """
-    If input is for train and has_validation=True, it will split the train data into train dataset
-    and validation dataset, and return (train_X, train_y, train_w, train_b_m <-
-    train base margin, val_X, val_y, val_w, val_b_m <- validation base margin)
-    otherwise return (X, y, w, b_m <- base margin)
-    """
-    return _row_tuple_list_to_feature_matrix_y_w(
-        data_iterator,
-        train,
-        has_weight,
-        has_fit_base_margin,
-        has_predict_base_margin,
-        has_validation,
-    )
 
+    train_data: Dict[str, List[np.ndarray]] = defaultdict(list)
+    valid_data: Dict[str, List[np.ndarray]] = defaultdict(list)
 
-def _convert_partition_data_to_dmatrix(
-    partition_data_iter,
-    has_weight,
-    has_validation,
-    has_base_margin,
-    dmatrix_kwargs=None,
-):
-    # pylint: disable=too-many-locals, unbalanced-tuple-unpacking
-    dmatrix_kwargs = dmatrix_kwargs or {}
-    # if we are not using external storage, we use the standard method of parsing data.
-    train_val_data = _prepare_train_val_data(
-        partition_data_iter, has_weight, has_validation, has_base_margin
-    )
-    if has_validation:
-        (
-            train_x,
-            train_y,
-            train_w,
-            train_b_m,
-            val_x,
-            val_y,
-            val_w,
-            val_b_m,
-        ) = train_val_data
-        training_dmatrix = DMatrix(
-            data=train_x,
-            label=train_y,
-            weight=train_w,
-            base_margin=train_b_m,
-            **dmatrix_kwargs,
+    n_features: int = 0
+
+    def append_m(part: pd.DataFrame, name: str, is_valid: bool) -> None:
+        nonlocal n_features
+        if name in part.columns:
+            array = part[name]
+            if name == alias.data:
+                array = stack_series(array)
+                if n_features == 0:
+                    n_features = array.shape[1]
+                assert n_features == array.shape[1]
+
+            if is_valid:
+                valid_data[name].append(array)
+            else:
+                train_data[name].append(array)
+
+    def append_dqm(part: pd.DataFrame, name: str, is_valid: bool) -> None:
+        """Preprocessing for DeviceQuantileDMatrix"""
+        nonlocal n_features
+        if name == alias.data or name in part.columns:
+            if name == alias.data:
+                cname = feature_cols
+            else:
+                cname = name
+
+            array = part[cname]
+            if name == alias.data:
+                if n_features == 0:
+                    n_features = array.shape[1]
+                assert n_features == array.shape[1]
+
+            if is_valid:
+                valid_data[name].append(array)
+            else:
+                train_data[name].append(array)
+
+    def make(values: Dict[str, List[np.ndarray]], kwargs: Dict[str, Any]) -> DMatrix:
+        data = concat_or_none(values[alias.data])
+        label = concat_or_none(values.get(alias.label, None))
+        weight = concat_or_none(values.get(alias.weight, None))
+        margin = concat_or_none(values.get(alias.margin, None))
+        return DMatrix(
+            data=data, label=label, weight=weight, base_margin=margin, **kwargs
         )
-        val_dmatrix = DMatrix(
-            data=val_x,
-            label=val_y,
-            weight=val_w,
-            base_margin=val_b_m,
-            **dmatrix_kwargs,
-        )
-        return training_dmatrix, val_dmatrix
 
-    train_x, train_y, train_w, train_b_m = train_val_data
-    training_dmatrix = DMatrix(
-        data=train_x,
-        label=train_y,
-        weight=train_w,
-        base_margin=train_b_m,
-        **dmatrix_kwargs,
-    )
-    return training_dmatrix
+    is_dmatrix = feature_cols is None
+    if is_dmatrix:
+        cache_partitions(iterator, append_m)
+        dtrain = make(train_data, kwargs)
+    else:
+        cache_partitions(iterator, append_dqm)
+        it = PartIter(train_data, True)
+        dtrain = DeviceQuantileDMatrix(it, **kwargs)
+
+    dvalid = make(valid_data, kwargs) if len(valid_data) != 0 else None
+
+    assert dtrain.num_col() == n_features
+    if dvalid is not None:
+        assert dvalid.num_col() == dtrain.num_col()
+
+    return dtrain, dvalid

--- a/tests/ci_build/lint_python.py
+++ b/tests/ci_build/lint_python.py
@@ -36,7 +36,8 @@ def run_mypy(rel_path: str) -> bool:
 
 
 class PyLint:
-    """A helper for running pylint, mostly copied from dmlc-core/scripts. """
+    """A helper for running pylint, mostly copied from dmlc-core/scripts."""
+
     def __init__(self) -> None:
         self.pypackage_root = os.path.join(PROJECT_ROOT, "python-package/")
         self.pylint_cats = set(["error", "warning", "convention", "refactor"])

--- a/tests/ci_build/lint_python.py
+++ b/tests/ci_build/lint_python.py
@@ -15,9 +15,7 @@ PROJECT_ROOT = os.path.normpath(os.path.join(CURDIR, os.path.pardir, os.path.par
 def run_formatter(rel_path: str) -> bool:
     path = os.path.join(PROJECT_ROOT, rel_path)
     isort_ret = subprocess.run(["isort", "--check", "--profile=black", path]).returncode
-    black_ret = subprocess.run(
-        ["black", "--check", "./python-package/xgboost/dask.py"]
-    ).returncode
+    black_ret = subprocess.run(["black", "--check", rel_path]).returncode
     if isort_ret != 0 or black_ret != 0:
         msg = (
             "Please run the following command on your machine to address the format"

--- a/tests/ci_build/lint_python.py
+++ b/tests/ci_build/lint_python.py
@@ -21,7 +21,7 @@ def run_formatter(rel_path: str) -> bool:
     if isort_ret != 0 or black_ret != 0:
         msg = (
             "Please run the following command on your machine to address the format"
-            f" errors:\n isort --check --profile=black {rel_path}\n black {rel_path}\n"
+            f" errors:\n isort --profile=black {rel_path}\n black {rel_path}\n"
         )
         print(msg, file=sys.stdout)
         return False
@@ -115,6 +115,8 @@ if __name__ == "__main__":
             for path in [
                 "python-package/xgboost/dask.py",
                 "python-package/xgboost/spark",
+                "tests/python/test_spark/test_data.py",
+                "tests/python-gpu/test_spark_with_gpu/test_data.py",
                 "tests/ci_build/lint_python.py",
             ]
         ):
@@ -128,8 +130,10 @@ if __name__ == "__main__":
                 "demo/guide-python/external_memory.py",
                 "demo/guide-python/cat_in_the_dat.py",
                 "tests/python/test_data_iterator.py",
+                "tests/python/test_spark/test_data.py",
                 "tests/python-gpu/test_gpu_with_dask.py",
                 "tests/python-gpu/test_gpu_data_iterator.py",
+                "tests/python-gpu/test_spark_with_gpu/test_data.py",
                 "tests/ci_build/lint_python.py",
             ]
         ):

--- a/tests/python-gpu/test_spark_with_gpu/test_data.py
+++ b/tests/python-gpu/test_spark_with_gpu/test_data.py
@@ -1,0 +1,23 @@
+import sys
+from typing import List
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append("tests/python")
+
+import testing as tm
+
+if tm.no_spark()["condition"]:
+    pytest.skip(msg=tm.no_spark()["reason"], allow_module_level=True)
+if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
+    pytest.skip("Skipping PySpark tests on Windows", allow_module_level=True)
+
+
+from test_spark.test_data import run_dmatrix_ctor
+
+
+@pytest.mark.skipif(**tm.no_cudf())
+def test_qdm_ctor() -> None:
+    run_dmatrix_ctor(True)

--- a/tests/python/test_spark/test_data.py
+++ b/tests/python/test_spark/test_data.py
@@ -1,11 +1,9 @@
 import sys
-import tempfile
-import shutil
+from typing import List
 
-import pytest
 import numpy as np
 import pandas as pd
-
+import pytest
 import testing as tm
 
 if tm.no_spark()["condition"]:
@@ -13,156 +11,90 @@ if tm.no_spark()["condition"]:
 if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
     pytest.skip("Skipping PySpark tests on Windows", allow_module_level=True)
 
-from xgboost.spark.data import (
-    _row_tuple_list_to_feature_matrix_y_w,
-    _convert_partition_data_to_dmatrix,
-)
-
-from xgboost import DMatrix, XGBClassifier
-from xgboost.training import train as worker_train
-from .utils import SparkTestCase
-import logging
-
-logging.getLogger("py4j").setLevel(logging.INFO)
+from xgboost.spark.data import alias, create_dmatrix_from_partitions, stack_series
 
 
-class DataTest(SparkTestCase):
-    def test_sparse_dense_vector(self):
-        def row_tup_iter(data):
-            pdf = pd.DataFrame(data)
-            yield pdf
+def test_stack() -> None:
+    a = pd.DataFrame({"a": [[1, 2], [3, 4]]})
+    b = stack_series(a["a"])
+    assert b.shape == (2, 2)
 
-        expected_ndarray = np.array([[1.0, 2.0, 3.0], [0.0, 1.0, 5.5]])
-        data = {"values": [[1.0, 2.0, 3.0], [0.0, 1.0, 5.5]]}
-        feature_matrix, y, w, _ = _row_tuple_list_to_feature_matrix_y_w(
-            list(row_tup_iter(data)),
-            train=False,
-            has_weight=False,
-            has_fit_base_margin=False,
-            has_predict_base_margin=False,
+    a = pd.DataFrame({"a": [[1], [3]]})
+    b = stack_series(a["a"])
+    assert b.shape == (2, 1)
+
+    a = pd.DataFrame({"a": [np.array([1, 2]), np.array([3, 4])]})
+    b = stack_series(a["a"])
+    assert b.shape == (2, 2)
+
+    a = pd.DataFrame({"a": [np.array([1]), np.array([3])]})
+    b = stack_series(a["a"])
+    assert b.shape == (2, 1)
+
+
+def run_dmatrix_ctor(is_dqm: bool) -> None:
+    rng = np.random.default_rng(0)
+    dfs: List[pd.DataFrame] = []
+    n_features = 16
+    n_samples_per_batch = 16
+    n_batches = 10
+    feature_types = ["float"] * n_features
+
+    for i in range(n_batches):
+        X = rng.normal(loc=0, size=256).reshape(n_samples_per_batch, n_features)
+        y = rng.normal(loc=0, size=n_samples_per_batch)
+        m = rng.normal(loc=0, size=n_samples_per_batch)
+        w = rng.normal(loc=0.5, scale=0.5, size=n_samples_per_batch)
+        w -= w.min()
+
+        valid = rng.binomial(n=1, p=0.5, size=16).astype(np.bool_)
+
+        df = pd.DataFrame(
+            {alias.label: y, alias.margin: m, alias.weight: w, alias.valid: valid}
         )
-        self.assertIsNone(y)
-        self.assertIsNone(w)
-        self.assertTrue(np.allclose(feature_matrix, expected_ndarray))
+        if is_dqm:
+            for j in range(X.shape[1]):
+                df[f"feat-{j}"] = pd.Series(X[:, j])
+        else:
+            df[alias.data] = pd.Series(list(X))
+        dfs.append(df)
 
-        data["label"] = [1, 0]
-        feature_matrix, y, w, _ = _row_tuple_list_to_feature_matrix_y_w(
-            row_tup_iter(data),
-            train=True,
-            has_weight=False,
-            has_fit_base_margin=False,
-            has_predict_base_margin=False,
-        )
-        self.assertIsNone(w)
-        self.assertTrue(np.allclose(feature_matrix, expected_ndarray))
-        self.assertTrue(np.array_equal(y, np.array(data["label"])))
+    kwargs = {"feature_types": feature_types}
+    if is_dqm:
+        cols = [f"feat-{i}" for i in range(n_features)]
+        train_Xy, valid_Xy = create_dmatrix_from_partitions(iter(dfs), cols, kwargs)
+    else:
+        train_Xy, valid_Xy = create_dmatrix_from_partitions(iter(dfs), None, kwargs)
 
-        data["weight"] = [0.2, 0.8]
-        feature_matrix, y, w, _ = _row_tuple_list_to_feature_matrix_y_w(
-            list(row_tup_iter(data)),
-            train=True,
-            has_weight=True,
-            has_fit_base_margin=False,
-            has_predict_base_margin=False,
-        )
-        self.assertTrue(np.allclose(feature_matrix, expected_ndarray))
-        self.assertTrue(np.array_equal(y, np.array(data["label"])))
-        self.assertTrue(np.array_equal(w, np.array(data["weight"])))
+    assert valid_Xy is not None
+    assert valid_Xy.num_row() + train_Xy.num_row() == n_samples_per_batch * n_batches
+    assert train_Xy.num_col() == n_features
+    assert valid_Xy.num_col() == n_features
 
-    def test_dmatrix_creator(self):
+    df = pd.concat(dfs, axis=0)
+    df_train = df.loc[~df[alias.valid], :]
+    df_valid = df.loc[df[alias.valid], :]
 
-        # This function acts as a pseudo-itertools.chain()
-        def row_tup_iter(data):
-            pdf = pd.DataFrame(data)
-            yield pdf
+    assert df_train.shape[0] == train_Xy.num_row()
+    assert df_valid.shape[0] == valid_Xy.num_row()
 
-        # Standard testing DMatrix creation
-        expected_features = np.array([[1.0, 2.0, 3.0], [0.0, 1.0, 5.5]] * 100)
-        expected_labels = np.array([1, 0] * 100)
-        expected_dmatrix = DMatrix(data=expected_features, label=expected_labels)
+    # margin
+    np.testing.assert_allclose(
+        df_train[alias.margin].to_numpy(), train_Xy.get_base_margin()
+    )
+    np.testing.assert_allclose(
+        df_valid[alias.margin].to_numpy(), valid_Xy.get_base_margin()
+    )
+    # weight
+    np.testing.assert_allclose(df_train[alias.weight].to_numpy(), train_Xy.get_weight())
+    np.testing.assert_allclose(df_valid[alias.weight].to_numpy(), valid_Xy.get_weight())
+    # label
+    np.testing.assert_allclose(df_train[alias.label].to_numpy(), train_Xy.get_label())
+    np.testing.assert_allclose(df_valid[alias.label].to_numpy(), valid_Xy.get_label())
 
-        data = {
-            "values": [[1.0, 2.0, 3.0], [0.0, 1.0, 5.5]] * 100,
-            "label": [1, 0] * 100,
-        }
-        output_dmatrix = _convert_partition_data_to_dmatrix(
-            [pd.DataFrame(data)],
-            has_weight=False,
-            has_validation=False,
-            has_base_margin=False,
-        )
-        # You can't compare DMatrix outputs, so the only way is to predict on the two seperate DMatrices using
-        # the same classifier and making sure the outputs are equal
-        model = XGBClassifier()
-        model.fit(expected_features, expected_labels)
-        expected_preds = model.get_booster().predict(expected_dmatrix)
-        output_preds = model.get_booster().predict(output_dmatrix)
-        self.assertTrue(np.allclose(expected_preds, output_preds, atol=1e-3))
+    np.testing.assert_equal(train_Xy.feature_types, feature_types)
+    np.testing.assert_equal(valid_Xy.feature_types, feature_types)
 
-        # DMatrix creation with weights
-        expected_weight = np.array([0.2, 0.8] * 100)
-        expected_dmatrix = DMatrix(
-            data=expected_features, label=expected_labels, weight=expected_weight
-        )
 
-        data["weight"] = [0.2, 0.8] * 100
-        output_dmatrix = _convert_partition_data_to_dmatrix(
-            [pd.DataFrame(data)],
-            has_weight=True,
-            has_validation=False,
-            has_base_margin=False,
-        )
-
-        model.fit(expected_features, expected_labels, sample_weight=expected_weight)
-        expected_preds = model.get_booster().predict(expected_dmatrix)
-        output_preds = model.get_booster().predict(output_dmatrix)
-        self.assertTrue(np.allclose(expected_preds, output_preds, atol=1e-3))
-
-    def test_external_storage(self):
-        # Instantiating base data (features, labels)
-        features = np.array([[1.0, 2.0, 3.0], [0.0, 1.0, 5.5]] * 100)
-        labels = np.array([1, 0] * 100)
-        normal_dmatrix = DMatrix(features, labels)
-        test_dmatrix = DMatrix(features)
-
-        data = {
-            "values": [[1.0, 2.0, 3.0], [0.0, 1.0, 5.5]] * 100,
-            "label": [1, 0] * 100,
-        }
-
-        # Creating the dmatrix based on storage
-        temporary_path = tempfile.mkdtemp()
-        storage_dmatrix = _convert_partition_data_to_dmatrix(
-            [pd.DataFrame(data)],
-            has_weight=False,
-            has_validation=False,
-            has_base_margin=False,
-        )
-
-        # Testing without weights
-        normal_booster = worker_train({}, normal_dmatrix)
-        storage_booster = worker_train({}, storage_dmatrix)
-        normal_preds = normal_booster.predict(test_dmatrix)
-        storage_preds = storage_booster.predict(test_dmatrix)
-        self.assertTrue(np.allclose(normal_preds, storage_preds, atol=1e-3))
-        shutil.rmtree(temporary_path)
-
-        # Testing weights
-        weights = np.array([0.2, 0.8] * 100)
-        normal_dmatrix = DMatrix(data=features, label=labels, weight=weights)
-        data["weight"] = [0.2, 0.8] * 100
-
-        temporary_path = tempfile.mkdtemp()
-        storage_dmatrix = _convert_partition_data_to_dmatrix(
-            [pd.DataFrame(data)],
-            has_weight=True,
-            has_validation=False,
-            has_base_margin=False,
-        )
-
-        normal_booster = worker_train({}, normal_dmatrix)
-        storage_booster = worker_train({}, storage_dmatrix)
-        normal_preds = normal_booster.predict(test_dmatrix)
-        storage_preds = storage_booster.predict(test_dmatrix)
-        self.assertTrue(np.allclose(normal_preds, storage_preds, atol=1e-3))
-        shutil.rmtree(temporary_path)
+def test_dmatrix_ctor() -> None:
+    run_dmatrix_ctor(False)

--- a/tests/python/test_spark/test_spark_local.py
+++ b/tests/python/test_spark/test_spark_local.py
@@ -765,23 +765,22 @@ class XgboostLocalTest(SparkTestCase):
             self.reg_df_test_with_eval_weight
         ).collect()
         for row in pred_result_with_weight:
-            self.assertTrue(
-                np.isclose(
-                    row.prediction, row.expected_prediction_with_weight, atol=1e-3
-                )
+            assert np.isclose(
+                row.prediction, row.expected_prediction_with_weight, atol=1e-3
             )
+
         # with eval
         regressor_with_eval = SparkXGBRegressor(**self.reg_params_with_eval)
         model_with_eval = regressor_with_eval.fit(self.reg_df_train_with_eval_weight)
-        self.assertTrue(
-            np.isclose(
-                model_with_eval._xgb_sklearn_model.best_score,
-                self.reg_with_eval_best_score,
-                atol=1e-3,
-            ),
-            f"Expected best score: {self.reg_with_eval_best_score}, "
-            f"but get {model_with_eval._xgb_sklearn_model.best_score}",
+        assert np.isclose(
+            model_with_eval._xgb_sklearn_model.best_score,
+            self.reg_with_eval_best_score,
+            atol=1e-3,
+        ), (
+            f"Expected best score: {self.reg_with_eval_best_score}, but ",
+            f"get {model_with_eval._xgb_sklearn_model.best_score}",
         )
+
         pred_result_with_eval = model_with_eval.transform(
             self.reg_df_test_with_eval_weight
         ).collect()
@@ -905,7 +904,7 @@ class XgboostLocalTest(SparkTestCase):
         # Check that regardless of what booster, _convert_to_model converts to the correct class type
         sklearn_classifier = classifier._convert_to_sklearn_model(
             clf_model.get_booster().save_raw("json"),
-            clf_model.get_booster().save_config()
+            clf_model.get_booster().save_config(),
         )
         assert isinstance(sklearn_classifier, XGBClassifier)
         assert sklearn_classifier.n_estimators == 200
@@ -915,7 +914,7 @@ class XgboostLocalTest(SparkTestCase):
 
         sklearn_regressor = regressor._convert_to_sklearn_model(
             reg_model.get_booster().save_raw("json"),
-            reg_model.get_booster().save_config()
+            reg_model.get_booster().save_config(),
         )
         assert isinstance(sklearn_regressor, XGBRegressor)
         assert sklearn_regressor.n_estimators == 200


### PR DESCRIPTION
This PR does some cleanups for the data processing precedures for the newly gained pyspark interface.

- Use numpy stack for handling list of arrays.
- Reuse concat function from dask.
- Remove unused code.
- Use iterator for prediction to avoid initializing xgboost model (pickle is not cheap).

To-dos:
- [ ] Test for different types of inputs.

I'm not entirely sure how to work with sparse data since it hasn't been supported yet in current codebase.

@WeichenXu123 