### PR TITLE
[CI] Clear workspace after budget check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,7 @@ pipeline {
         }
         sh 'python3 tests/jenkins_get_approval.py'
         stash name: 'srcs'
+        deleteDir()
       }
     }
     stage('Jenkins Linux: Build') {

--- a/Jenkinsfile-win64
+++ b/Jenkinsfile-win64
@@ -33,6 +33,7 @@ pipeline {
         }
         sh 'python3 tests/jenkins_get_approval.py'
         stash name: 'srcs'
+        deleteDir()
       }
     }
     stage('Jenkins Win64: Build') {


### PR DESCRIPTION
Clear the workspace after performing the budget check in the CI. This ensures that clutters don't accumulate in the `job_initializer` node.