### PR TITLE
Calculate `base_score` based on input labels.

### DIFF
--- a/amalgamation/xgboost-all0.cc
+++ b/amalgamation/xgboost-all0.cc
@@ -75,7 +75,6 @@
 #include "../src/collective/communicator.cc"
 
 // common
-#include "../src/common/algorithm.cc"
 #include "../src/common/charconv.cc"
 #include "../src/common/column_matrix.cc"
 #include "../src/common/common.cc"
@@ -83,6 +82,7 @@
 #include "../src/common/host_device_vector.cc"
 #include "../src/common/io.cc"
 #include "../src/common/json.cc"
+#include "../src/common/numeric.cc"
 #include "../src/common/pseudo_huber.cc"
 #include "../src/common/quantile.cc"
 #include "../src/common/random.cc"

--- a/amalgamation/xgboost-all0.cc
+++ b/amalgamation/xgboost-all0.cc
@@ -75,19 +75,20 @@
 #include "../src/collective/communicator.cc"
 
 // common
-#include "../src/common/common.cc"
-#include "../src/common/column_matrix.cc"
-#include "../src/common/random.cc"
+#include "../src/common/algorithm.cc"
 #include "../src/common/charconv.cc"
-#include "../src/common/timer.cc"
-#include "../src/common/quantile.cc"
-#include "../src/common/host_device_vector.cc"
+#include "../src/common/column_matrix.cc"
+#include "../src/common/common.cc"
 #include "../src/common/hist_util.cc"
+#include "../src/common/host_device_vector.cc"
 #include "../src/common/io.cc"
 #include "../src/common/json.cc"
 #include "../src/common/pseudo_huber.cc"
+#include "../src/common/quantile.cc"
+#include "../src/common/random.cc"
 #include "../src/common/survival_util.cc"
 #include "../src/common/threading_utils.cc"
+#include "../src/common/timer.cc"
 #include "../src/common/version.cc"
 
 // c_api

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -17,6 +17,7 @@
 #include <xgboost/predictor.h>
 #include <xgboost/task.h>
 
+#include <limits>  // std::numeric_limit
 #include <map>
 #include <memory>
 #include <string>
@@ -299,7 +300,7 @@ struct LearnerModelParamLegacy;
  */
 struct LearnerModelParam {
   /* \brief global bias */
-  bst_float base_score { 0.5f };
+  bst_float base_score { std::numeric_limits<float>::quiet_NaN() };
   /* \brief number of features  */
   uint32_t num_feature { 0 };
   /* \brief number of classes, if it is multi-class classification  */
@@ -312,7 +313,7 @@ struct LearnerModelParam {
   // this one as an immutable copy.
   LearnerModelParam(LearnerModelParamLegacy const& user_param, float base_margin, ObjInfo t);
   /* \brief Whether this parameter is initialized with LearnerModelParamLegacy. */
-  bool Initialized() const { return num_feature != 0; }
+  bool Initialized() const { return num_feature != 0 && !std::isnan(base_score); }
 };
 
 }  // namespace xgboost

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -8,16 +8,14 @@
 #ifndef XGBOOST_LEARNER_H_
 #define XGBOOST_LEARNER_H_
 
-#include <dmlc/any.h>
 #include <xgboost/base.h>
 #include <xgboost/feature_map.h>
-#include <xgboost/generic_parameters.h>
+#include <xgboost/generic_parameters.h>  // Context
 #include <xgboost/host_device_vector.h>
 #include <xgboost/model.h>
 #include <xgboost/predictor.h>
 #include <xgboost/task.h>
 
-#include <limits>  // std::numeric_limit
 #include <map>
 #include <memory>
 #include <string>
@@ -275,7 +273,7 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
   /**
    * \brief Return the context object of this Booster.
    */
-  virtual GenericParameter const* Ctx() const = 0;
+  virtual Context const* Ctx() const = 0;
   /*!
    * \brief Get configuration arguments currently stored by the learner
    * \return Key-value pairs representing configuration arguments

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -300,7 +300,10 @@ struct LearnerModelParamLegacy;
  */
 struct LearnerModelParam {
  private:
-  /* \brief global bias */
+  /**
+   * \brief Global bias, this is just a scalar value but can be extended to vector when we
+   *        support multi-class and multi-target.
+   */
   linalg::Tensor<float, 1> base_score_;
 
  public:

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -85,7 +85,7 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
   /*!
    * \brief Configure Learner based on set parameters.
    */
-  virtual void Configure(DMatrix const* p_fmat = nullptr) = 0;
+  virtual void Configure() = 0;
   /*!
    * \brief update the model for one iteration
    *  With the specified objective function.

--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -679,7 +679,7 @@ class Tensor {
     }
     if (device >= 0) {
       data_.SetDevice(device);
-      data_.DevicePointer();  // Pull to device;
+      data_.ConstDevicePointer();  // Pull to device;
     }
     CHECK_EQ(data_.Size(), detail::CalcSize(shape_));
   }

--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -8,6 +8,7 @@
 
 #include <dmlc/endian.h>
 #include <xgboost/base.h>
+#include <xgboost/generic_parameters.h>
 #include <xgboost/host_device_vector.h>
 #include <xgboost/json.h>
 #include <xgboost/span.h>
@@ -214,6 +215,22 @@ LINALG_HD decltype(auto) constexpr Apply(Fn &&f, Tup &&t) {
   constexpr auto kSize = std::tuple_size<Tup>::value;
   return Apply(std::forward<Fn>(f), std::forward<Tup>(t), std::make_index_sequence<kSize>{});
 }
+
+/**
+ * C++ 17 conjunction
+ */
+template <class...>
+struct Conjunction : std::true_type {};
+template <class B1>
+struct Conjunction<B1> : B1 {};
+template <class B1, class... Bn>
+struct Conjunction<B1, Bn...> : std::conditional_t<bool(B1::value), Conjunction<Bn...>, B1> {};
+
+template <typename... Index>
+using IsAllIntegral = Conjunction<std::is_integral<std::remove_reference_t<Index>>...>;
+
+template <typename... Index>
+using EnableIfIntegral = std::enable_if_t<IsAllIntegral<Index...>::value>;
 }  // namespace detail
 
 /**
@@ -407,7 +424,7 @@ class TensorView {
    *
    * \endcode
    */
-  template <typename... Index>
+  template <typename... Index, detail::EnableIfIntegral<Index...> * = nullptr>
   LINALG_HD T &operator()(Index &&...index) {
     static_assert(sizeof...(index) <= kDim, "Invalid index.");
     size_t offset = detail::Offset<0ul>(stride_, 0ul, std::forward<Index>(index)...);
@@ -417,12 +434,17 @@ class TensorView {
   /**
    * \brief Index the tensor to obtain a scalar value.
    */
-  template <typename... Index>
+  template <typename... Index, detail::EnableIfIntegral<Index...> * = nullptr>
   LINALG_HD T const &operator()(Index &&...index) const {
     static_assert(sizeof...(index) <= kDim, "Invalid index.");
     size_t offset = detail::Offset<0ul>(stride_, 0ul, std::forward<Index>(index)...);
     assert(offset < data_.size() && "Out of bound access.");
     return ptr_[offset];
+  }
+
+  template <typename... S, std::enable_if_t<!detail::IsAllIntegral<S...>::value> * = nullptr>
+  LINALG_HD auto operator()(S &&...slices) const {
+    return this->Slice(std::forward<S>(slices)...);
   }
 
   /**
@@ -703,11 +725,28 @@ class Tensor {
   }
 
   template <typename I, int32_t D>
-  explicit Tensor(std::initializer_list<T> data, I const (&shape)[D], int32_t device) {
+  explicit Tensor(std::initializer_list<T> data, I const (&shape)[D],
+                  int32_t device = Context::kCpuId) {
     auto &h_vec = data_.HostVector();
     h_vec = data;
     // shape
     this->Initialize(shape, device);
+  }
+  /**
+   * \brief Index operator. Not thread safe, should not be used in performance critical
+   *        region. For more efficient indexing, consider getting a view first.
+   */
+  template <typename... Index>
+  T &operator()(Index &&...idx) {
+    return this->HostView()(std::forward<Index>(idx)...);
+  }
+  /**
+   * \brief Index operator. Not thread safe, should not be used in performance critical
+   *        region. For more efficient indexing, consider getting a view first.
+   */
+  template <typename... Index>
+  T const &operator()(Index &&...idx) const {
+    return this->HostView()(std::forward<Index>(idx)...);
   }
 
   /**
@@ -762,7 +801,8 @@ class Tensor {
    *
    *    If the total size is changed, then data in this tensor is no longer valid.
    */
-  template <typename... S>
+  template <typename... S, std::enable_if_t<detail::Conjunction<
+                               std::is_integral<std::remove_reference_t<S>>...>::value> * = nullptr>
   void Reshape(S &&...s) {
     static_assert(sizeof...(S) <= kDim, "Invalid shape.");
     detail::ReshapeImpl<0>(shape_, std::forward<S>(s)...);
@@ -778,13 +818,18 @@ class Tensor {
    *
    *    If the total size is changed, then data in this tensor is no longer valid.
    */
-  template <int32_t D>
-  void Reshape(size_t (&shape)[D]) {
+  template <size_t D>
+  void Reshape(common::Span<size_t const, D> shape) {
     static_assert(D <= kDim, "Invalid shape.");
-    std::copy(shape, shape + D, this->shape_);
+    std::copy(shape.data(), shape.data() + D, this->shape_);
     std::fill(shape_ + D, shape_ + kDim, 1);
     auto n = detail::CalcSize(shape_);
     data_.Resize(n);
+  }
+
+  template <size_t D>
+  void Reshape(size_t (&shape)[D]) {
+    this->Reshape(common::Span<size_t const, D>{shape});
   }
 
   /**

--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <limits>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -442,11 +442,6 @@ class TensorView {
     return ptr_[offset];
   }
 
-  template <typename... S, std::enable_if_t<!detail::IsAllIntegral<S...>::value> * = nullptr>
-  LINALG_HD auto operator()(S &&...slices) const {
-    return this->Slice(std::forward<S>(slices)...);
-  }
-
   /**
    * \brief Slice the tensor.  The returned tensor has inferred dim and shape.  Scalar
    *        result is not supported.
@@ -801,8 +796,7 @@ class Tensor {
    *
    *    If the total size is changed, then data in this tensor is no longer valid.
    */
-  template <typename... S, std::enable_if_t<detail::Conjunction<
-                               std::is_integral<std::remove_reference_t<S>>...>::value> * = nullptr>
+  template <typename... S, detail::EnableIfIntegral<S...> * = nullptr>
   void Reshape(S &&...s) {
     static_assert(sizeof...(S) <= kDim, "Invalid shape.");
     detail::ReshapeImpl<0>(shape_, std::forward<S>(s)...);

--- a/include/xgboost/objective.h
+++ b/include/xgboost/objective.h
@@ -28,7 +28,9 @@ class RegTree;
 class ObjFunction : public Configurable {
  protected:
   Context const* ctx_;
-  static constexpr float DefaultBaseScore() { return 0.5; };
+
+ public:
+  static constexpr float DefaultBaseScore() { return 0.5f; };
 
  public:
   /*! \brief virtual destructor */
@@ -80,10 +82,9 @@ class ObjFunction : public Configurable {
    * \brief Make initialize estimation of prediction.
    *
    * \param info MetaInfo that contains label.
-   *
-   * \return NaN if there's no initial estimation.
+   * \param base_score Output estimation.
    */
-  virtual float InitEstimation(MetaInfo const& info) const;
+  virtual void InitEstimation(MetaInfo const& info, HostDeviceVector<float>* base_score) const;
   /*!
    * \brief Return task of this objective.
    */

--- a/include/xgboost/objective.h
+++ b/include/xgboost/objective.h
@@ -30,7 +30,7 @@ class ObjFunction : public Configurable {
   Context const* ctx_;
 
  public:
-  static constexpr float DefaultBaseScore() { return 0.5f; };
+  static constexpr float DefaultBaseScore() { return 0.5f; }
 
  public:
   /*! \brief virtual destructor */

--- a/include/xgboost/objective.h
+++ b/include/xgboost/objective.h
@@ -27,7 +27,8 @@ class RegTree;
 /*! \brief interface of objective function */
 class ObjFunction : public Configurable {
  protected:
-  GenericParameter const* ctx_;
+  Context const* ctx_;
+  static constexpr float DefaultBaseScore() { return 0.5; };
 
  public:
   /*! \brief virtual destructor */

--- a/include/xgboost/objective.h
+++ b/include/xgboost/objective.h
@@ -75,6 +75,14 @@ class ObjFunction : public Configurable {
   virtual bst_float ProbToMargin(bst_float base_score) const {
     return base_score;
   }
+  /**
+   * \brief Make initialize estimation of prediction.
+   *
+   * \param info MetaInfo that contains label.
+   *
+   * \return NaN if there's no initial estimation.
+   */
+  virtual float InitEstimation(MetaInfo const& info) const;
   /*!
    * \brief Return task of this objective.
    */

--- a/include/xgboost/objective.h
+++ b/include/xgboost/objective.h
@@ -84,7 +84,7 @@ class ObjFunction : public Configurable {
    * \param info MetaInfo that contains label.
    * \param base_score Output estimation.
    */
-  virtual void InitEstimation(MetaInfo const& info, HostDeviceVector<float>* base_score) const;
+  virtual void InitEstimation(MetaInfo const& info, linalg::Tensor<float, 1>* base_score) const;
   /*!
    * \brief Return task of this objective.
    */

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -102,13 +102,10 @@ class PredictionContainer {
  */
 class Predictor {
  protected:
-  /*
-   * \brief Runtime parameters.
-   */
-  GenericParameter const* ctx_;
+  Context const* ctx_;
 
  public:
-  explicit Predictor(GenericParameter const* ctx) : ctx_{ctx} {}
+  explicit Predictor(Context const* ctx) : ctx_{ctx} {}
 
   virtual ~Predictor() = default;
 

--- a/src/common/algorithm.cc
+++ b/src/common/algorithm.cc
@@ -1,0 +1,27 @@
+/*!
+ * Copyright 2022 by XGBoost Contributors
+ */
+#include "algorithm.h"
+
+#include <numeric>
+
+#include "threading_utils.h"
+#include "xgboost/generic_parameters.h"  // Context
+#include "xgboost/host_device_vector.h"  // HostDeviceVector
+
+namespace xgboost {
+namespace common {
+double Reduce(Context const* ctx, HostDeviceVector<float> const& values) {
+  if (ctx->IsCPU()) {
+    auto const& h_values = values.ConstHostVector();
+    MemStackAllocator<double, 128> result_tloc(ctx->Threads(), 0);
+    ParallelFor(h_values.size(), ctx->Threads(),
+                [&](auto i) { result_tloc[omp_get_thread_num()] = values[i]; });
+    auto result = std::accumulate(result_tloc.cbegin(), result_tloc.cend(), 0.0);
+    static_assert(std::is_same<decltype(result), double>::value, "");
+    return result;
+  }
+  return cuda::Reduce(ctx, values);
+}
+}  // namespace common
+}  // namespace xgboost

--- a/src/common/algorithm.cu
+++ b/src/common/algorithm.cu
@@ -1,0 +1,24 @@
+/*!
+ * Copyright 2022 by XGBoost Contributors
+ */
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>  // thrust:plus
+
+#include "algorithm.h"
+#include "device_helpers.cuh"            // dh::Reduce
+#include "xgboost/generic_parameters.h"  // Context
+#include "xgboost/host_device_vector.h"  // HostDeviceVector
+
+namespace xgboost {
+namespace common {
+namespace cuda {
+double Reduce(Context const* ctx, HostDeviceVector<float> const& values) {
+  auto const d_values = values.ConstDeviceSpan();
+  dh::XGBCachingDeviceAllocator<char> alloc;
+  auto res = dh::Reduce(thrust::cuda::par(alloc), d_values.data(),
+                        d_values.data() + d_values.size(), 0.0, thrust::plus<double>{});
+  return res;
+}
+}  // namespace cuda
+}  // namespace common
+}  // namespace xgboost

--- a/src/common/algorithm.h
+++ b/src/common/algorithm.h
@@ -6,9 +6,6 @@
 #include <algorithm>  // std::upper_bound
 #include <cinttypes>  // std::size_t
 
-#include "xgboost/generic_parameters.h"  // Context
-#include "xgboost/host_device_vector.h"  // HostDeviceVector
-
 namespace xgboost {
 namespace common {
 template <typename It, typename Idx>
@@ -16,15 +13,6 @@ auto SegmentId(It first, It last, Idx idx) {
   std::size_t segment_id = std::upper_bound(first, last, idx) - 1 - first;
   return segment_id;
 }
-
-namespace cuda {
-double Reduce(Context const* ctx, HostDeviceVector<float> const& values);
-}
-
-/**
- * \brief Reduction with summation.
- */
-double Reduce(Context const* ctx, HostDeviceVector<float> const& values);
 }  // namespace common
 }  // namespace xgboost
 #endif  // XGBOOST_COMMON_ALGORITHM_H_

--- a/src/common/algorithm.h
+++ b/src/common/algorithm.h
@@ -1,9 +1,13 @@
 /*!
  * Copyright 2022 by XGBoost Contributors
  */
-#pragma once
+#ifndef XGBOOST_COMMON_ALGORITHM_H_
+#define XGBOOST_COMMON_ALGORITHM_H_
 #include <algorithm>  // std::upper_bound
 #include <cinttypes>  // std::size_t
+
+#include "xgboost/generic_parameters.h"  // Context
+#include "xgboost/host_device_vector.h"  // HostDeviceVector
 
 namespace xgboost {
 namespace common {
@@ -12,5 +16,15 @@ auto SegmentId(It first, It last, Idx idx) {
   std::size_t segment_id = std::upper_bound(first, last, idx) - 1 - first;
   return segment_id;
 }
+
+namespace cuda {
+double Reduce(Context const* ctx, HostDeviceVector<float> const& values);
+}
+
+/**
+ * \brief Reduction with summation.
+ */
+double Reduce(Context const* ctx, HostDeviceVector<float> const& values);
 }  // namespace common
 }  // namespace xgboost
+#endif  // XGBOOST_COMMON_ALGORITHM_H_

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -277,7 +277,7 @@ XGBOOST_DEVICE size_t LastOf(size_t group, Indexable const &indptr) {
 }
 
 /**
- * @brief A CRTP (curiously recurring template pattern) helper function.
+ * \brief A CRTP (curiously recurring template pattern) helper function.
  *
  * https://www.fluentcpp.com/2017/05/19/crtp-helper/
  *
@@ -285,7 +285,7 @@ XGBOOST_DEVICE size_t LastOf(size_t group, Indexable const &indptr) {
  * 1. Makes "crtp" explicit in the inheritance structure of a CRTP base class.
  * 2. Avoids having to `static_cast` in a lot of places.
  *
- * @tparam T The derived class in a CRTP hierarchy.
+ * \tparam T The derived class in a CRTP hierarchy.
  */
 template <typename T>
 struct Crtp {
@@ -293,6 +293,13 @@ struct Crtp {
   T const &Underlying() const { return static_cast<T const &>(*this); }
 };
 
+/**
+ * \brief C++17 std::as_const
+ */
+template <typename T>
+typename std::add_const<T>::type &AsConst(T &v) noexcept {
+  return v;
+}
 }  // namespace common
 }  // namespace xgboost
 #endif  // XGBOOST_COMMON_COMMON_H_

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -297,7 +297,7 @@ struct Crtp {
  * \brief C++17 std::as_const
  */
 template <typename T>
-typename std::add_const<T>::type &AsConst(T &v) noexcept {
+typename std::add_const<T>::type &AsConst(T &v) noexcept {  // NOLINT(runtime/references)
   return v;
 }
 }  // namespace common

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -265,6 +265,7 @@ struct OptionalWeights {
   explicit OptionalWeights(float w) : dft{w} {}
 
   XGBOOST_DEVICE float operator[](size_t i) const { return weights.empty() ? dft : weights[i]; }
+  auto Empty() const { return weights.empty(); }
 };
 
 /**

--- a/src/common/linalg_op.h
+++ b/src/common/linalg_op.h
@@ -4,6 +4,7 @@
 #ifndef XGBOOST_COMMON_LINALG_OP_H_
 #define XGBOOST_COMMON_LINALG_OP_H_
 #include <type_traits>
+#include <cstdint>  // std::int32_t
 
 #include "common.h"
 #include "threading_utils.h"
@@ -60,7 +61,7 @@ void ElementWiseKernel(GenericParameter const* ctx, linalg::TensorView<T, D> t, 
 }
 #endif  // !defined(XGBOOST_USE_CUDA)
 
-template <typename T, int32_t kDim>
+template <typename T, std::int32_t kDim>
 auto cbegin(TensorView<T, kDim> v) {  // NOLINT
   auto it = common::MakeIndexTransformIter([&](size_t i) -> std::remove_cv_t<T> const& {
     return linalg::detail::Apply(v, linalg::UnravelIndex(i, v.Shape()));
@@ -68,19 +69,19 @@ auto cbegin(TensorView<T, kDim> v) {  // NOLINT
   return it;
 }
 
-template <typename T, int32_t kDim>
+template <typename T, std::int32_t kDim>
 auto cend(TensorView<T, kDim> v) {  // NOLINT
   return cbegin(v) + v.Size();
 }
 
-template <typename T, int32_t kDim>
+template <typename T, std::int32_t kDim>
 auto begin(TensorView<T, kDim> v) {  // NOLINT
   auto it = common::MakeIndexTransformIter(
       [&](size_t i) -> T& { return linalg::detail::Apply(v, linalg::UnravelIndex(i, v.Shape())); });
   return it;
 }
 
-template <typename T, int32_t kDim>
+template <typename T, std::int32_t kDim>
 auto end(TensorView<T, kDim> v) {  // NOLINT
   return begin(v) + v.Size();
 }

--- a/src/common/linalg_op.h
+++ b/src/common/linalg_op.h
@@ -59,6 +59,7 @@ void ElementWiseKernel(GenericParameter const* ctx, linalg::TensorView<T, D> t, 
   ElementWiseKernelHost(t, ctx->Threads(), fn);
 }
 #endif  // !defined(XGBOOST_USE_CUDA)
+
 }  // namespace linalg
 }  // namespace xgboost
 #endif  // XGBOOST_COMMON_LINALG_OP_H_

--- a/src/common/linalg_op.h
+++ b/src/common/linalg_op.h
@@ -60,6 +60,30 @@ void ElementWiseKernel(GenericParameter const* ctx, linalg::TensorView<T, D> t, 
 }
 #endif  // !defined(XGBOOST_USE_CUDA)
 
+template <typename T, int32_t kDim>
+auto cbegin(TensorView<T, kDim> v) {  // NOLINT
+  auto it = common::MakeIndexTransformIter([&](size_t i) -> std::remove_cv_t<T> const& {
+    return linalg::detail::Apply(v, linalg::UnravelIndex(i, v.Shape()));
+  });
+  return it;
+}
+
+template <typename T, int32_t kDim>
+auto cend(TensorView<T, kDim> v) {  // NOLINT
+  return cbegin(v) + v.Size();
+}
+
+template <typename T, int32_t kDim>
+auto begin(TensorView<T, kDim> v) {  // NOLINT
+  auto it = common::MakeIndexTransformIter(
+      [&](size_t i) -> T& { return linalg::detail::Apply(v, linalg::UnravelIndex(i, v.Shape())); });
+  return it;
+}
+
+template <typename T, int32_t kDim>
+auto end(TensorView<T, kDim> v) {  // NOLINT
+  return begin(v) + v.Size();
+}
 }  // namespace linalg
 }  // namespace xgboost
 #endif  // XGBOOST_COMMON_LINALG_OP_H_

--- a/src/common/numeric.cc
+++ b/src/common/numeric.cc
@@ -17,7 +17,7 @@ double Reduce(Context const* ctx, HostDeviceVector<float> const& values) {
     auto const& h_values = values.ConstHostVector();
     MemStackAllocator<double, DefaultMaxThreads()> result_tloc(ctx->Threads(), 0);
     ParallelFor(h_values.size(), ctx->Threads(),
-                [&](auto i) { result_tloc[omp_get_thread_num()] = h_values[i]; });
+                [&](auto i) { result_tloc[omp_get_thread_num()] += h_values[i]; });
     auto result = std::accumulate(result_tloc.cbegin(), result_tloc.cend(), 0.0);
     static_assert(std::is_same<decltype(result), double>::value, "");
     return result;

--- a/src/common/numeric.cu
+++ b/src/common/numeric.cu
@@ -4,18 +4,16 @@
 #include <thrust/execution_policy.h>
 #include <thrust/functional.h>  // thrust:plus
 
-#include "device_helpers.cuh"  // dh::Reduce
+#include "device_helpers.cuh"  // dh::Reduce, safe_cuda, dh::XGBCachingDeviceAllocator
 #include "numeric.h"
 #include "xgboost/generic_parameters.h"  // Context
 #include "xgboost/host_device_vector.h"  // HostDeviceVector
-#include "xgboost/logging.h"             // CHECK_GE
 
 namespace xgboost {
 namespace common {
 namespace cuda {
 double Reduce(Context const* ctx, HostDeviceVector<float> const& values) {
-  CHECK_GE(ctx->gpu_id, 0);
-  dh::safe_cuda(cudaSetDevice(ctx->gpu_id));
+  values.SetDevice(ctx->gpu_id);
   auto const d_values = values.ConstDeviceSpan();
   dh::XGBCachingDeviceAllocator<char> alloc;
   auto res = dh::Reduce(thrust::cuda::par(alloc), d_values.data(),

--- a/src/common/numeric.cu
+++ b/src/common/numeric.cu
@@ -4,15 +4,18 @@
 #include <thrust/execution_policy.h>
 #include <thrust/functional.h>  // thrust:plus
 
-#include "algorithm.h"
-#include "device_helpers.cuh"            // dh::Reduce
+#include "device_helpers.cuh"  // dh::Reduce
+#include "numeric.h"
 #include "xgboost/generic_parameters.h"  // Context
 #include "xgboost/host_device_vector.h"  // HostDeviceVector
+#include "xgboost/logging.h"             // CHECK_GE
 
 namespace xgboost {
 namespace common {
 namespace cuda {
 double Reduce(Context const* ctx, HostDeviceVector<float> const& values) {
+  CHECK_GE(ctx->gpu_id, 0);
+  dh::safe_cuda(cudaSetDevice(ctx->gpu_id));
   auto const d_values = values.ConstDeviceSpan();
   dh::XGBCachingDeviceAllocator<char> alloc;
   auto res = dh::Reduce(thrust::cuda::par(alloc), d_values.data(),

--- a/src/common/numeric.h
+++ b/src/common/numeric.h
@@ -8,6 +8,7 @@
 #include <iterator>   // std::iterator_traits
 #include <vector>
 
+#include "common.h"                      // AssertGPUSupport
 #include "threading_utils.h"             // MemStackAllocator, DefaultMaxThreads
 #include "xgboost/generic_parameters.h"  // Context
 #include "xgboost/host_device_vector.h"  // HostDeviceVector
@@ -94,7 +95,13 @@ void PartialSum(int32_t n_threads, InIt begin, InIt end, T init, OutIt out_it) {
 
 namespace cuda {
 double Reduce(Context const* ctx, HostDeviceVector<float> const& values);
+#if !defined(XGBOOST_USE_CUDA)
+inline double Reduce(Context const*, HostDeviceVector<float> const&) {
+  AssertGPUSupport();
+  return 0;
 }
+#endif  // !defined(XGBOOST_USE_CUDA)
+}  // namespace cuda
 /**
  * \brief Reduction with summation.
  */

--- a/src/common/stats.cu
+++ b/src/common/stats.cu
@@ -1,0 +1,44 @@
+/*!
+ * Copyright 2022 by XGBoost Contributors
+ */
+
+#include "common.h"
+#include "stats.cuh"
+#include "xgboost/generic_parameters.h"
+#include "xgboost/host_device_vector.h"
+#include "xgboost/linalg.h"
+
+namespace xgboost {
+namespace common {
+namespace cuda {
+float Median(Context const* ctx, linalg::TensorView<float const, 2> t,
+             common::OptionalWeights weights) {
+  HostDeviceVector<size_t> segments{0, t.Size()};
+  segments.SetDevice(ctx->gpu_id);
+  auto d_segments = segments.ConstDeviceSpan();
+  auto val_it = dh::MakeTransformIterator<float>(
+      thrust::make_counting_iterator(0ul), [=] XGBOOST_DEVICE(size_t i) {
+        return linalg::detail::Apply(t, linalg::UnravelIndex(i, t.Shape()));
+      });
+
+  HostDeviceVector<float> quantile{0};
+  quantile.SetDevice(ctx->gpu_id);
+  if (weights.Empty()) {
+    common::SegmentedQuantile(ctx, 0.5, dh::tcbegin(d_segments), dh::tcend(d_segments), val_it,
+                              val_it + t.Size(), &quantile);
+  } else {
+    CHECK_NE(t.Shape(1), 0);
+    auto w_it = dh::MakeTransformIterator<float>(thrust::make_counting_iterator(0ul),
+                                                 [=] XGBOOST_DEVICE(size_t i) {
+                                                   auto sample_idx = i / t.Shape(1);
+                                                   return weights[sample_idx];
+                                                 });
+    common::SegmentedWeightedQuantile(ctx, 0.5, dh::tcbegin(d_segments), dh::tcend(d_segments),
+                                      val_it, val_it + t.Size(), w_it, w_it + t.Size(), &quantile);
+  }
+  CHECK_EQ(quantile.Size(), 1);
+  return quantile.HostVector().front();
+}
+}  // namespace cuda
+}  // namespace common
+}  // namespace xgboost

--- a/src/common/stats.cu
+++ b/src/common/stats.cu
@@ -2,11 +2,14 @@
  * Copyright 2022 by XGBoost Contributors
  */
 
-#include "common.h"
-#include "stats.cuh"
-#include "xgboost/generic_parameters.h"
-#include "xgboost/host_device_vector.h"
-#include "xgboost/linalg.h"
+#include <thrust/iterator/counting_iterator.h>  // thrust::make_counting_iterator
+
+#include "common.h"            // common::OptionalWeights
+#include "device_helpers.cuh"  // dh::MakeTransformIterator, tcbegin, tcend
+#include "stats.cuh"           // common::SegmentedQuantile, common::SegmentedWeightedQuantile
+#include "xgboost/generic_parameters.h"  // Context
+#include "xgboost/host_device_vector.h"  // HostDeviceVector
+#include "xgboost/linalg.h"              // linalg::TensorView, UnravelIndex, Apply
 
 namespace xgboost {
 namespace common {

--- a/src/common/stats.h
+++ b/src/common/stats.h
@@ -8,7 +8,7 @@
 #include <limits>
 #include <vector>
 
-#include "common.h"
+#include "common.h"  // AssertGPUSupport
 #include "xgboost/generic_parameters.h"
 #include "xgboost/linalg.h"
 
@@ -97,7 +97,7 @@ float Median(Context const* ctx, linalg::TensorView<float const, 2> t,
              common::OptionalWeights weights);
 #if !defined(XGBOOST_USE_CUDA)
 inline float Median(Context const*, linalg::TensorView<float const, 2>, common::OptionalWeights) {
-  common::AssertGPUSupport();
+  AssertGPUSupport();
   return 0;
 }
 #endif  // !defined(XGBOOST_USE_CUDA)

--- a/src/common/stats.h
+++ b/src/common/stats.h
@@ -103,23 +103,29 @@ inline float Median(Context const*, linalg::TensorView<float const, 2>, common::
 #endif  // !defined(XGBOOST_USE_CUDA)
 }  // namespace cuda
 
-inline float Median(Context const* ctx, linalg::TensorView<float const, 2> t,
-                    common::OptionalWeights weights) {
+inline float Median(Context const* ctx, linalg::Tensor<float, 2> const& t,
+                    HostDeviceVector<float> const& weights) {
   if (!ctx->IsCPU()) {
-    return cuda::Median(ctx, t, weights);
+    weights.SetDevice(ctx->gpu_id);
+    auto opt_weights = OptionalWeights(weights.ConstDeviceSpan());
+    auto t_v = t.View(ctx->gpu_id);
+    return cuda::Median(ctx, t_v, opt_weights);
   }
+
+  auto opt_weights = OptionalWeights(weights.ConstHostSpan());
+  auto t_v = t.HostView();
   auto iter = common::MakeIndexTransformIter(
-      [&](size_t i) { return linalg::detail::Apply(t, linalg::UnravelIndex(i, t.Shape())); });
+      [&](size_t i) { return linalg::detail::Apply(t_v, linalg::UnravelIndex(i, t_v.Shape())); });
   float q{0};
-  if (weights.weights.empty()) {
-    q = common::Quantile(0.5, iter, iter + t.Size());
+  if (opt_weights.Empty()) {
+    q = common::Quantile(0.5, iter, iter + t_v.Size());
   } else {
-    CHECK_NE(t.Shape(1), 0);
+    CHECK_NE(t_v.Shape(1), 0);
     auto w_it = common::MakeIndexTransformIter([&](size_t i) {
-      auto sample_idx = i / t.Shape(1);
-      return weights[sample_idx];
+      auto sample_idx = i / t_v.Shape(1);
+      return opt_weights[sample_idx];
     });
-    q = common::WeightedQuantile(0.5, iter, iter + t.Size(), w_it);
+    q = common::WeightedQuantile(0.5, iter, iter + t_v.Size(), w_it);
   }
   return q;
 }

--- a/src/common/stats.h
+++ b/src/common/stats.h
@@ -93,14 +93,15 @@ float WeightedQuantile(double alpha, Iter begin, Iter end, WeightIter weights) {
 }
 
 namespace cuda {
-float Median(Context const* ctx, linalg::TensorView<float const, 2> t, common::OptionalWeights weights);
+float Median(Context const* ctx, linalg::TensorView<float const, 2> t,
+             common::OptionalWeights weights);
 #if !defined(XGBOOST_USE_CUDA)
 inline float Median(Context const*, linalg::TensorView<float const, 2>, common::OptionalWeights) {
   common::AssertGPUSupport();
   return 0;
 }
 #endif  // !defined(XGBOOST_USE_CUDA)
-}
+}  // namespace cuda
 
 inline float Median(Context const* ctx, linalg::TensorView<float const, 2> t,
                     common::OptionalWeights weights) {

--- a/src/common/threading_utils.h
+++ b/src/common/threading_utils.h
@@ -8,6 +8,7 @@
 #include <dmlc/omp.h>
 
 #include <algorithm>
+#include <cstdint>  // std::int32_t
 #include <limits>
 #include <type_traits>  // std::is_signed
 #include <vector>
@@ -253,7 +254,7 @@ inline int32_t OmpGetNumThreads(int32_t n_threads) {
  * MaxStackSize, it will be allocated inside the stack. Otherwise, it will be
  * heap-allocated.
  */
-template <typename T, size_t MaxStackSize>
+template <typename T, std::size_t MaxStackSize>
 class MemStackAllocator {
  public:
   explicit MemStackAllocator(size_t required_size) : required_size_(required_size) {
@@ -290,6 +291,11 @@ class MemStackAllocator {
   size_t required_size_;
   T stack_mem_[MaxStackSize];
 };
+
+/**
+ * \brief Constant that can be used for initializing static thread local memory.
+ */
+std::int32_t constexpr DefaultMaxThreads() { return 128; }
 }  // namespace common
 }  // namespace xgboost
 

--- a/src/common/threading_utils.h
+++ b/src/common/threading_utils.h
@@ -278,6 +278,13 @@ class MemStackAllocator {
   T& operator[](size_t i) { return ptr_[i]; }
   T const& operator[](size_t i) const { return ptr_[i]; }
 
+  auto data() const { return ptr_; }                   // NOLINT
+  auto data() { return ptr_; }                         // NOLINT
+  std::size_t size() const { return required_size_; }  // NOLINT
+
+  auto cbegin() const { return data(); }         // NOLINT
+  auto cend() const { return data() + size(); }  // NOLINT
+
  private:
   T* ptr_ = nullptr;
   size_t required_size_;

--- a/src/data/array_interface.h
+++ b/src/data/array_interface.h
@@ -345,8 +345,8 @@ struct ToDType<int64_t> {
 };
 
 #if !defined(XGBOOST_USE_CUDA)
-inline void ArrayInterfaceHandler::SyncCudaStream(int64_t stream) { common::AssertGPUSupport(); }
-inline bool ArrayInterfaceHandler::IsCudaPtr(void const *ptr) { return false; }
+inline void ArrayInterfaceHandler::SyncCudaStream(int64_t) { common::AssertGPUSupport(); }
+inline bool ArrayInterfaceHandler::IsCudaPtr(void const *) { return false; }
 #endif  // !defined(XGBOOST_USE_CUDA)
 
 /**

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -270,12 +270,12 @@ class GBLinear : public GradientBooster {
     monitor_.Start("PredictBatchInternal");
     model_.LazyInitModel();
     std::vector<bst_float> &preds = *out_preds;
-    auto base_margin = p_fmat->Info().base_margin_.View(GenericParameter::kCpuId);
+    auto base_margin = p_fmat->Info().base_margin_.View(Context::kCpuId);
     // start collecting the prediction
     const int ngroup = model_.learner_model_param->num_output_group;
     preds.resize(p_fmat->Info().num_row_ * ngroup);
 
-    auto base_score = learner_model_param_->BaseScore(ctx_);
+    auto base_score = learner_model_param_->BaseScore(Context::kCpuId);
     for (const auto &page : p_fmat->GetBatches<SparsePage>()) {
       auto const& batch = page.GetView();
       // output convention: nrow * k, where nrow is number of rows

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -161,10 +161,10 @@ class GBLinear : public GradientBooster {
                        uint32_t layer_begin, uint32_t) override {
     LinearCheckLayer(layer_begin);
     const int ngroup = model_.learner_model_param->num_output_group;
-    CHECK_EQ(learner_model_param_->base_score.Size(), 1);
-    auto base_score = learner_model_param_->base_score.HostVector().front();
+
+    auto base_score = learner_model_param_->BaseScore(ctx_);
     for (int gid = 0; gid < ngroup; ++gid) {
-      this->Pred(inst, dmlc::BeginPtr(*out_preds), gid, base_score);
+      this->Pred(inst, dmlc::BeginPtr(*out_preds), gid, base_score(0));
     }
   }
 
@@ -185,8 +185,7 @@ class GBLinear : public GradientBooster {
     contribs.resize(p_fmat->Info().num_row_ * ncolumns * ngroup);
     // make sure contributions is zeroed, we could be reusing a previously allocated one
     std::fill(contribs.begin(), contribs.end(), 0);
-    CHECK_EQ(learner_model_param_->base_score.Size(), 1);
-    auto base_score = learner_model_param_->base_score.HostVector().front();
+    auto base_score = learner_model_param_->BaseScore(ctx_);
     // start collecting the contributions
     for (const auto &batch : p_fmat->GetBatches<SparsePage>()) {
       // parallel over local batch
@@ -206,7 +205,7 @@ class GBLinear : public GradientBooster {
           // add base margin to BIAS
           p_contribs[ncolumns - 1] =
               model_.Bias()[gid] +
-              ((base_margin.Size() != 0) ? base_margin(row_idx, gid) : base_score);
+              ((base_margin.Size() != 0) ? base_margin(row_idx, gid) : base_score(0));
         }
       });
     }
@@ -275,8 +274,8 @@ class GBLinear : public GradientBooster {
     // start collecting the prediction
     const int ngroup = model_.learner_model_param->num_output_group;
     preds.resize(p_fmat->Info().num_row_ * ngroup);
-    CHECK_EQ(learner_model_param_->base_score.Size(), 1);
-    auto base_score = learner_model_param_->base_score.HostVector().front();
+
+    auto base_score = learner_model_param_->BaseScore(ctx_);
     for (const auto &page : p_fmat->GetBatches<SparsePage>()) {
       auto const& batch = page.GetView();
       // output convention: nrow * k, where nrow is number of rows
@@ -290,7 +289,7 @@ class GBLinear : public GradientBooster {
         const size_t ridx = page.base_rowid + i;
         // loop over output groups
         for (int gid = 0; gid < ngroup; ++gid) {
-          float margin = (base_margin.Size() != 0) ? base_margin(ridx, gid) : base_score;
+          float margin = (base_margin.Size() != 0) ? base_margin(ridx, gid) : base_score(0);
           this->Pred(batch[i], &preds[ridx * ngroup], gid, margin);
         }
       });

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -638,10 +638,10 @@ void GPUDartPredictInc(common::Span<float> out_predts,
 }
 #endif
 
-void GPUDartInplacePredictInc(common::Span<float> out_predts, common::Span<float> predts,
-                              float tree_w, size_t n_rows,
-                              HostDeviceVector<float> const& base_score, bst_group_t n_groups,
-                              bst_group_t group)
+void GPUDartInplacePredictInc(common::Span<float> /*out_predts*/, common::Span<float> /*predts*/,
+                              float /*tree_w*/, size_t /*n_rows*/,
+                              linalg::TensorView<float const, 1> /*base_score*/,
+                              bst_group_t /*n_groups*/, bst_group_t /*group*/)
 #if defined(XGBOOST_USE_CUDA)
     ;  // NOLINT
 #else
@@ -849,18 +849,17 @@ class Dart : public GBTree {
       size_t n_rows = p_fmat->Info().num_row_;
       if (predts.predictions.DeviceIdx() != Context::kCpuId) {
         p_out_preds->predictions.SetDevice(predts.predictions.DeviceIdx());
-        model_.learner_model_param->base_score.SetDevice(predts.predictions.DeviceIdx());
+        auto base_score = model_.learner_model_param->BaseScore(predts.predictions.DeviceIdx());
         GPUDartInplacePredictInc(p_out_preds->predictions.DeviceSpan(),
-                                 predts.predictions.DeviceSpan(), w, n_rows,
-                                 model_.learner_model_param->base_score, n_groups, group);
+                                 predts.predictions.DeviceSpan(), w, n_rows, base_score, n_groups,
+                                 group);
       } else {
-        CHECK_EQ(model_.learner_model_param->base_score.Size(), 1);
-        auto base_score = model_.learner_model_param->base_score.HostVector().front();
+        auto base_score = model_.learner_model_param->BaseScore(Context::kCpuId);
         auto& h_predts = predts.predictions.HostVector();
         auto& h_out_predts = p_out_preds->predictions.HostVector();
         common::ParallelFor(n_rows, ctx_->Threads(), [&](auto ridx) {
           const size_t offset = ridx * n_groups + group;
-          h_out_predts[offset] += (h_predts[offset] - base_score) * w;
+          h_out_predts[offset] += (h_predts[offset] - base_score(0)) * w;
         });
       }
     }

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -638,13 +638,12 @@ void GPUDartPredictInc(common::Span<float> out_predts,
 }
 #endif
 
-void GPUDartInplacePredictInc(common::Span<float> out_predts,
-                              common::Span<float> predts, float tree_w,
-                              size_t n_rows, float base_score,
-                              bst_group_t n_groups,
+void GPUDartInplacePredictInc(common::Span<float> out_predts, common::Span<float> predts,
+                              float tree_w, size_t n_rows,
+                              HostDeviceVector<float> const& base_score, bst_group_t n_groups,
                               bst_group_t group)
 #if defined(XGBOOST_USE_CUDA)
-;  // NOLINT
+    ;  // NOLINT
 #else
 {
   common::AssertGPUSupport();
@@ -850,15 +849,18 @@ class Dart : public GBTree {
       size_t n_rows = p_fmat->Info().num_row_;
       if (predts.predictions.DeviceIdx() != Context::kCpuId) {
         p_out_preds->predictions.SetDevice(predts.predictions.DeviceIdx());
+        model_.learner_model_param->base_score.SetDevice(predts.predictions.DeviceIdx());
         GPUDartInplacePredictInc(p_out_preds->predictions.DeviceSpan(),
                                  predts.predictions.DeviceSpan(), w, n_rows,
                                  model_.learner_model_param->base_score, n_groups, group);
       } else {
+        CHECK_EQ(model_.learner_model_param->base_score.Size(), 1);
+        auto base_score = model_.learner_model_param->base_score.HostVector().front();
         auto& h_predts = predts.predictions.HostVector();
         auto& h_out_predts = p_out_preds->predictions.HostVector();
         common::ParallelFor(n_rows, ctx_->Threads(), [&](auto ridx) {
           const size_t offset = ridx * n_groups + group;
-          h_out_predts[offset] += (h_predts[offset] - model_.learner_model_param->base_score) * w;
+          h_out_predts[offset] += (h_predts[offset] - base_score) * w;
         });
       }
     }

--- a/src/gbm/gbtree.cu
+++ b/src/gbm/gbtree.cu
@@ -33,13 +33,12 @@ void GPUDartPredictInc(common::Span<float> out_predts,
 
 void GPUDartInplacePredictInc(common::Span<float> out_predts, common::Span<float> predts,
                               float tree_w, size_t n_rows,
-                              HostDeviceVector<float> const &base_score, bst_group_t n_groups,
+                              linalg::TensorView<float const, 1> base_score, bst_group_t n_groups,
                               bst_group_t group) {
-  auto const* d_score = base_score.ConstDevicePointer();
   CHECK_EQ(base_score.Size(), 1);
   dh::LaunchN(n_rows, [=] XGBOOST_DEVICE(size_t ridx) {
     const size_t offset = ridx * n_groups + group;
-    out_predts[offset] += (predts[offset] - *d_score) * tree_w;
+    out_predts[offset] += (predts[offset] - base_score(0)) * tree_w;
   });
 }
 }  // namespace gbm

--- a/src/gbm/gbtree.cu
+++ b/src/gbm/gbtree.cu
@@ -31,13 +31,15 @@ void GPUDartPredictInc(common::Span<float> out_predts,
   });
 }
 
-void GPUDartInplacePredictInc(common::Span<float> out_predts,
-                              common::Span<float> predts, float tree_w,
-                              size_t n_rows, float base_score,
-                              bst_group_t n_groups, bst_group_t group) {
+void GPUDartInplacePredictInc(common::Span<float> out_predts, common::Span<float> predts,
+                              float tree_w, size_t n_rows,
+                              HostDeviceVector<float> const &base_score, bst_group_t n_groups,
+                              bst_group_t group) {
+  auto const* d_score = base_score.ConstDevicePointer();
+  CHECK_EQ(base_score.Size(), 1);
   dh::LaunchN(n_rows, [=] XGBOOST_DEVICE(size_t ridx) {
     const size_t offset = ridx * n_groups + group;
-    out_predts[offset] += (predts[offset] - base_score) * tree_w;
+    out_predts[offset] += (predts[offset] - *d_score) * tree_w;
   });
 }
 }  // namespace gbm

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -222,14 +222,14 @@ LearnerModelParam::LearnerModelParam(Context const* ctx, LearnerModelParamLegacy
 }
 
 linalg::TensorView<float const, 1> LearnerModelParam::BaseScore(int32_t device) const {
-  // multi-class is not supported yet.
+  // multi-class is not yet supported.
   CHECK_EQ(base_score_.Size(), 1);
   if (device == Context::kCpuId) {
-    // Make sure that we won't run it race condition.
+    // Make sure that we won't run into race condition.
     CHECK(base_score_.Data()->HostCanRead());
     return base_score_.HostView();
   }
-  // Make sure that we won't run it race condition.
+  // Make sure that we won't run into race condition.
   CHECK(base_score_.Data()->DeviceCanRead());
   auto v = base_score_.View(device);
   CHECK(base_score_.Data()->HostCanRead());  // make sure read access is not removed.

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1302,7 +1302,8 @@ class LearnerImpl : public LearnerIO {
                     HostDeviceVector<GradientPair>* in_gpair) override {
     monitor_.Start("BoostOneIter");
     this->Configure();
-    this->InitBaseScore(train.get());
+    // Should have been set to default in the first prediction.
+    CHECK(!std::isnan(mparam_.base_score));
 
     if (ctx_.seed_per_iteration) {
       common::GlobalRandom().seed(ctx_.seed * kRandSeedMagic + iter);

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1315,7 +1315,7 @@ class LearnerImpl : public LearnerIO {
     monitor_.Start("BoostOneIter");
     this->Configure();
     // Should have been set to default in the first prediction.
-    CHECK(!std::isnan(mparam_.base_score));
+    CHECK(mparam_.base_score_estimated);
 
     if (ctx_.seed_per_iteration) {
       common::GlobalRandom().seed(ctx_.seed * kRandSeedMagic + iter);

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -224,7 +224,7 @@ void LearnerModelParam::Copy(LearnerModelParam const& that) {
   if (that.base_score_.DeviceIdx() != Context::kCpuId) {
     common::AsConst(base_score_).View(that.base_score_.DeviceIdx());
   }
-  CHECK(base_score_.Data()->DeviceCanRead());
+  CHECK_EQ(base_score_.Data()->DeviceCanRead(), that.base_score_.Data()->DeviceCanRead());
   CHECK(base_score_.Data()->HostCanRead());
 
   num_feature = that.num_feature;
@@ -461,7 +461,7 @@ class LearnerConfiguration : public Learner {
     } else {
       // lastly, if data is not available (prediction for custom objective), use default.
       base_score_.Reshape(1);
-      base_score_(0) = obj_->ProbToMargin(ObjFunction::DefaultBaseScore());
+      base_score_(0) = ObjFunction::DefaultBaseScore();
     }
 
     auto task = obj_->Task();

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -99,12 +99,13 @@ struct LearnerModelParamLegacy : public dmlc::Parameter<LearnerModelParamLegacy>
     static_assert(sizeof(LearnerModelParamLegacy) == 136,
                   "Do not change the size of this struct, as it will break binary IO.");
   }
+
   // Skip other legacy fields.
   Json ToJson() const {
     Object obj;
     char floats[NumericLimits<float>::kToCharsSize];
     auto ret = to_chars(floats, floats + NumericLimits<float>::kToCharsSize, base_score);
-    CHECK(ret.ec == std::errc());
+    CHECK(ret.ec == std::errc{});
     obj["base_score"] = std::string{floats, static_cast<size_t>(std::distance(floats, ret.ptr))};
 
     char integers[NumericLimits<int64_t>::kToCharsSize];
@@ -493,7 +494,7 @@ class LearnerConfiguration : public Learner {
   }
 
   void CheckModelInitialized() const {
-    CHECK(learner_model_param_.Initialized()) << "Model not fit.";
+    CHECK(learner_model_param_.Initialized()) << "Model not yet initialized.";
     CHECK_NE(learner_model_param_.BaseScore(this->Ctx()).Size(), 0);
   }
 

--- a/src/objective/adaptive.h
+++ b/src/objective/adaptive.h
@@ -7,6 +7,7 @@
 #include <limits>
 #include <vector>
 
+#include "../common/common.h"
 #include "rabit/rabit.h"
 #include "xgboost/generic_parameters.h"
 #include "xgboost/host_device_vector.h"

--- a/src/objective/objective.cc
+++ b/src/objective/objective.cc
@@ -31,7 +31,11 @@ ObjFunction* ObjFunction::Create(const std::string& name, GenericParameter const
   return pobj;
 }
 
-float ObjFunction::InitEstimation(MetaInfo const&) const { return DefaultBaseScore(); }
+void ObjFunction::InitEstimation(MetaInfo const&, HostDeviceVector<float>* base_score) const {
+  CHECK(base_score);
+  base_score->Resize(1);
+  base_score->Fill(DefaultBaseScore());
+}
 }  // namespace xgboost
 
 namespace xgboost {

--- a/src/objective/objective.cc
+++ b/src/objective/objective.cc
@@ -31,7 +31,7 @@ ObjFunction* ObjFunction::Create(const std::string& name, GenericParameter const
   return pobj;
 }
 
-float ObjFunction::InitEstimation(MetaInfo const&) const { return 0.5; }
+float ObjFunction::InitEstimation(MetaInfo const&) const { return DefaultBaseScore(); }
 }  // namespace xgboost
 
 namespace xgboost {

--- a/src/objective/objective.cc
+++ b/src/objective/objective.cc
@@ -1,10 +1,10 @@
 /*!
- * Copyright 2015 by Contributors
+ * Copyright 2015-2022 by Contributors
  * \file objective.cc
  * \brief Registry of all objective functions.
  */
-#include <xgboost/objective.h>
 #include <dmlc/registry.h>
+#include <xgboost/objective.h>
 
 #include <sstream>
 
@@ -31,6 +31,7 @@ ObjFunction* ObjFunction::Create(const std::string& name, GenericParameter const
   return pobj;
 }
 
+float ObjFunction::InitEstimation(MetaInfo const&) const { return 0.5; }
 }  // namespace xgboost
 
 namespace xgboost {

--- a/src/objective/objective.cc
+++ b/src/objective/objective.cc
@@ -31,10 +31,10 @@ ObjFunction* ObjFunction::Create(const std::string& name, GenericParameter const
   return pobj;
 }
 
-void ObjFunction::InitEstimation(MetaInfo const&, HostDeviceVector<float>* base_score) const {
+void ObjFunction::InitEstimation(MetaInfo const&, linalg::Tensor<float, 1>* base_score) const {
   CHECK(base_score);
-  base_score->Resize(1);
-  base_score->Fill(DefaultBaseScore());
+  base_score->Reshape(1);
+  (*base_score)(0) = DefaultBaseScore();
 }
 }  // namespace xgboost
 

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -716,7 +716,7 @@ class MeanAbsoluteError : public ObjFunction {
       w = common::Reduce(ctx_, info.weights_);
     }
 
-    if (info.num_row_) {
+    if (info.num_row_ == 0) {
       out(0) = 0;
     } else {
       // weighted avg

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -13,9 +13,9 @@
 #include <memory>
 #include <vector>
 
-#include "../common/algorithm.h"  // reduce
 #include "../common/common.h"
 #include "../common/linalg_op.h"
+#include "../common/numeric.h"  // Reduce
 #include "../common/pseudo_huber.h"
 #include "../common/stats.h"
 #include "../common/threading_utils.h"

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -13,6 +13,7 @@
 #include <memory>
 #include <vector>
 
+#include "../common/algorithm.h"  // reduce
 #include "../common/common.h"
 #include "../common/linalg_op.h"
 #include "../common/pseudo_huber.h"
@@ -707,22 +708,27 @@ class MeanAbsoluteError : public ObjFunction {
     CheckInitInputs(info);
     base_margin->Reshape(1);
     auto out = base_margin->HostView();
-    std::int32_t invalid{0};
-    if (info.num_row_ == 0) {
-      out(0) = 0;
-      invalid++;
+
+    double w{0.0};
+    if (info.weights_.Empty()) {
+      w = static_cast<double>(info.num_row_);
     } else {
-      out(0) = common::Median(ctx_, info.labels, info.weights_);
+      w = common::Reduce(ctx_, info.weights_);
     }
 
-    auto world = static_cast<float>(rabit::GetWorldSize());
-    rabit::Allreduce<rabit::op::Sum>(&invalid, 1);  // number of empty workers
-    world -= static_cast<float>(invalid);           // number of non-empty workers
+    if (info.num_row_) {
+      out(0) = 0;
+    } else {
+      // weighted avg
+      out(0) = common::Median(ctx_, info.labels, info.weights_) * w;
+    }
 
-    // average base score across all valid workers
+    // Weighted average base score across all workers
     rabit::Allreduce<rabit::op::Sum>(out.Values().data(), out.Values().size());
+    rabit::Allreduce<rabit::op::Sum>(&w, 1);
+
     std::transform(linalg::cbegin(out), linalg::cend(out), linalg::begin(out),
-                   [world](float v) { return v / world; });
+                   [w](float v) { return v / w; });
   }
 
   void UpdateTreeLeaf(HostDeviceVector<bst_node_t> const& position, MetaInfo const& info,

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -711,13 +711,8 @@ class MeanAbsoluteError : public ObjFunction {
     if (info.num_row_ == 0) {
       out(0) = 0;
       invalid++;
-    } else if (ctx_->IsCPU()) {
-      out(0) = common::Median(ctx_, info.labels.HostView(),
-                              common::OptionalWeights{info.weights_.ConstHostSpan()});
     } else {
-      info.weights_.SetDevice(ctx_->gpu_id);
-      out(0) = common::Median(ctx_, info.labels.View(ctx_->gpu_id),
-                              common::OptionalWeights{info.weights_.DeviceSpan()});
+      out(0) = common::Median(ctx_, info.labels, info.weights_);
     }
 
     auto world = static_cast<float>(rabit::GetWorldSize());

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -707,6 +707,11 @@ class MeanAbsoluteError : public ObjFunction {
     CheckInitInputs(info);
     base_margin->Reshape(1);
     auto h_base_margin = base_margin->HostView();
+    if (info.num_row_ == 0) {
+      h_base_margin(0) = DefaultBaseScore();
+      return;
+    }
+
     if (ctx_->IsCPU()) {
       h_base_margin(0) = common::Median(ctx_, info.labels.HostView(),
                                         common::OptionalWeights{info.weights_.ConstHostSpan()});

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -703,17 +703,17 @@ class MeanAbsoluteError : public ObjFunction {
     });
   }
 
-  void InitEstimation(MetaInfo const& info, HostDeviceVector<float>* base_margin) const override {
+  void InitEstimation(MetaInfo const& info, linalg::Tensor<float, 1>* base_margin) const override {
     CheckInitInputs(info);
-    auto& h_base_margin = base_margin->HostVector();
-    h_base_margin.resize(1);
+    base_margin->Reshape(1);
+    auto h_base_margin = base_margin->HostView();
     if (ctx_->IsCPU()) {
-      h_base_margin.front() = common::Median(
-          ctx_, info.labels.HostView(), common::OptionalWeights{info.weights_.ConstHostSpan()});
+      h_base_margin(0) = common::Median(ctx_, info.labels.HostView(),
+                                        common::OptionalWeights{info.weights_.ConstHostSpan()});
     } else {
       info.weights_.SetDevice(ctx_->gpu_id);
-      h_base_margin.front() = common::Median(ctx_, info.labels.View(ctx_->gpu_id),
-                                             common::OptionalWeights{info.weights_.DeviceSpan()});
+      h_base_margin(0) = common::Median(ctx_, info.labels.View(ctx_->gpu_id),
+                                        common::OptionalWeights{info.weights_.DeviceSpan()});
     }
   }
 

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -38,13 +38,17 @@
 namespace xgboost {
 namespace obj {
 namespace {
-void CheckRegInputs(MetaInfo const& info, HostDeviceVector<bst_float> const& preds) {
+void CheckInitInputs(MetaInfo const& info) {
   CHECK_EQ(info.labels.Shape(0), info.num_row_) << "Invalid shape of labels.";
-  CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
   if (!info.weights_.Empty()) {
     CHECK_EQ(info.weights_.Size(), info.num_row_)
         << "Number of weights should be equal to number of data points.";
   }
+}
+
+void CheckRegInputs(MetaInfo const& info, HostDeviceVector<bst_float> const& preds) {
+  CheckInitInputs(info);
+  CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
 }
 }  // anonymous namespace
 
@@ -700,6 +704,7 @@ class MeanAbsoluteError : public ObjFunction {
   }
 
   float InitEstimation(MetaInfo const& info) const override {
+    CheckInitInputs(info);
     if (ctx_->IsCPU()) {
       return common::Median(ctx_, info.labels.HostView(),
                             common::OptionalWeights{info.weights_.ConstHostSpan()});

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -505,8 +505,8 @@ class CPUPredictor : public Predictor {
     common::ParallelFor(ntree_limit, n_threads, [&](bst_omp_uint i) {
       FillNodeMeanValues(model.trees[i].get(), &(mean_values[i]));
     });
-    auto base_margin = info.base_margin_.View(GenericParameter::kCpuId);
-    auto base_score = model.learner_model_param->BaseScore(ctx_)(0);
+    auto base_margin = info.base_margin_.View(Context::kCpuId);
+    auto base_score = model.learner_model_param->BaseScore(Context::kCpuId)(0);
     // start collecting the contributions
     for (const auto &batch : p_fmat->GetBatches<SparsePage>()) {
       auto page = batch.GetView();

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -429,7 +429,7 @@ class CPUPredictor : public Predictor {
     }
     out_preds->resize(model.learner_model_param->num_output_group *
                       (model.param.size_leaf_vector + 1));
-    auto const& base_score = model.learner_model_param->base_score.HostVector().front();
+    auto base_score = model.learner_model_param->BaseScore(ctx_)(0);
     // loop over output groups
     for (uint32_t gid = 0; gid < model.learner_model_param->num_output_group; ++gid) {
       (*out_preds)[gid] =
@@ -506,8 +506,7 @@ class CPUPredictor : public Predictor {
       FillNodeMeanValues(model.trees[i].get(), &(mean_values[i]));
     });
     auto base_margin = info.base_margin_.View(GenericParameter::kCpuId);
-    CHECK_EQ(model.learner_model_param->base_score.Size(), 1);
-    auto base_score = model.learner_model_param->base_score.HostVector().front();
+    auto base_score = model.learner_model_param->BaseScore(ctx_)(0);
     // start collecting the contributions
     for (const auto &batch : p_fmat->GetBatches<SparsePage>()) {
       auto page = batch.GetView();

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -511,7 +511,7 @@ void ExtractPaths(
           n = d_nodes[n.Parent() + tree_offset];
           path_length++;
         }
-        return PathInfo{int64_t(idx), path_length, tree_idx};
+        return PathInfo{static_cast<int64_t>(idx), path_length, tree_idx};
       });
   auto end = thrust::copy_if(
       thrust::cuda::par(alloc), nodes_transform,
@@ -859,13 +859,14 @@ class GPUPredictor : public xgboost::Predictor {
     // Add the base margin term to last column
     p_fmat->Info().base_margin_.SetDevice(ctx_->gpu_id);
     const auto margin = p_fmat->Info().base_margin_.Data()->ConstDeviceSpan();
-    float base_score = model.learner_model_param->base_score;
-    dh::LaunchN(
-        p_fmat->Info().num_row_ * model.learner_model_param->num_output_group,
-        [=] __device__(size_t idx) {
-          phis[(idx + 1) * contributions_columns - 1] +=
-              margin.empty() ? base_score : margin[idx];
-        });
+    CHECK_EQ(model.learner_model_param->base_score.Size(), 1);
+    model.learner_model_param->base_score.SetDevice(ctx_->gpu_id);
+    float const* base_score = model.learner_model_param->base_score.ConstDevicePointer();
+    dh::LaunchN(p_fmat->Info().num_row_ * model.learner_model_param->num_output_group,
+                [=] __device__(size_t idx) {
+                  phis[(idx + 1) * contributions_columns - 1] +=
+                      margin.empty() ? *base_score : margin[idx];
+                });
   }
 
   void PredictInteractionContributions(DMatrix* p_fmat,
@@ -918,17 +919,19 @@ class GPUPredictor : public xgboost::Predictor {
     // Add the base margin term to last column
     p_fmat->Info().base_margin_.SetDevice(ctx_->gpu_id);
     const auto margin = p_fmat->Info().base_margin_.Data()->ConstDeviceSpan();
-    float base_score = model.learner_model_param->base_score;
+
+    CHECK_EQ(model.learner_model_param->base_score.Size(), 1);
+    model.learner_model_param->base_score.SetDevice(ctx_->gpu_id);
+    float const* base_score = model.learner_model_param->base_score.ConstDevicePointer();
     size_t n_features = model.learner_model_param->num_feature;
-    dh::LaunchN(
-        p_fmat->Info().num_row_ * model.learner_model_param->num_output_group,
-        [=] __device__(size_t idx) {
-          size_t group = idx % ngroup;
-          size_t row_idx = idx / ngroup;
-          phis[gpu_treeshap::IndexPhiInteractions(
-              row_idx, ngroup, group, n_features, n_features, n_features)] +=
-              margin.empty() ? base_score : margin[idx];
-        });
+    dh::LaunchN(p_fmat->Info().num_row_ * model.learner_model_param->num_output_group,
+                [=] __device__(size_t idx) {
+                  size_t group = idx % ngroup;
+                  size_t row_idx = idx / ngroup;
+                  phis[gpu_treeshap::IndexPhiInteractions(row_idx, ngroup, group, n_features,
+                                                          n_features, n_features)] +=
+                      margin.empty() ? *base_score : margin[idx];
+                });
   }
 
   void PredictInstance(const SparsePage::Inst&,

--- a/src/predictor/predictor.cc
+++ b/src/predictor/predictor.cc
@@ -80,16 +80,17 @@ void Predictor::InitOutPredictions(const MetaInfo& info, HostDeviceVector<bst_fl
   if (ctx_->gpu_id >= 0) {
     out_preds->SetDevice(ctx_->gpu_id);
   }
-  if (base_margin->Size() != 0) {
+  if (!base_margin->Empty()) {
     out_preds->Resize(n);
     ValidateBaseMarginShape(info.base_margin_, info.num_row_, n_classes);
     out_preds->Copy(*base_margin);
   } else {
-    out_preds->Resize(n);
     // cannot rely on the Resize to fill as it might skip if the size is already correct.
-    auto base_score = model.learner_model_param->base_score;
-    CHECK(!std::isnan(base_score));
-    out_preds->Fill(base_score);
+    out_preds->Resize(n);
+    auto const& base_score = model.learner_model_param->base_score;
+    CHECK_EQ(base_score.Size(), 1);
+    // FIXME(jiamingy): Support multi-class
+    out_preds->Fill(base_score.HostVector().front());
   }
 }
 }  // namespace xgboost

--- a/src/predictor/predictor.cc
+++ b/src/predictor/predictor.cc
@@ -87,10 +87,8 @@ void Predictor::InitOutPredictions(const MetaInfo& info, HostDeviceVector<bst_fl
   } else {
     // cannot rely on the Resize to fill as it might skip if the size is already correct.
     out_preds->Resize(n);
-    auto const& base_score = model.learner_model_param->base_score;
-    CHECK_EQ(base_score.Size(), 1);
-    // FIXME(jiamingy): Support multi-class
-    out_preds->Fill(base_score.HostVector().front());
+    auto base_score = model.learner_model_param->BaseScore(Context::kCpuId)(0);
+    out_preds->Fill(base_score);
   }
 }
 }  // namespace xgboost

--- a/src/predictor/predictor.cc
+++ b/src/predictor/predictor.cc
@@ -87,7 +87,9 @@ void Predictor::InitOutPredictions(const MetaInfo& info, HostDeviceVector<bst_fl
   } else {
     out_preds->Resize(n);
     // cannot rely on the Resize to fill as it might skip if the size is already correct.
-    out_preds->Fill(model.learner_model_param->base_score);
+    auto base_score = model.learner_model_param->base_score;
+    CHECK(!std::isnan(base_score));
+    out_preds->Fill(base_score);
   }
 }
 }  // namespace xgboost

--- a/tests/cpp/common/test_linalg.cc
+++ b/tests/cpp/common/test_linalg.cc
@@ -59,7 +59,7 @@ TEST(Linalg, TensorView) {
   float v = t(0, 1, 2);
   ASSERT_EQ(v, 6);
 
-  auto s = t(1, All(), All());
+  auto s = t.Slice(1, All(), All());
   ASSERT_EQ(s.Shape().size(), 2);
   ASSERT_EQ(s.Shape()[0], 3);
   ASSERT_EQ(s.Shape()[1], 4);
@@ -86,9 +86,9 @@ TEST(Linalg, TensorView) {
   {
     // as matrix
     TensorView<double, 2> mat(data, {6, 4}, -1);
-    auto s = mat(2, All());
+    auto s = mat.Slice(2, All());
     ASSERT_EQ(s.Shape().size(), 1);
-    s = mat(All(), 1);
+    s = mat.Slice(All(), 1);
     ASSERT_EQ(s.Shape().size(), 1);
   }
 
@@ -107,7 +107,7 @@ TEST(Linalg, TensorView) {
     // Don't assign the initial dimension, tensor should be able to deduce the correct dim
     // for Slice.
     auto t = MakeTensorView(data, {2, 3, 4}, 0);
-    auto s = t(1, 2, All());
+    auto s = t.Slice(1, 2, All());
     static_assert(decltype(s)::kDimension == 1, "");
   }
   {

--- a/tests/cpp/common/test_linalg.cc
+++ b/tests/cpp/common/test_linalg.cc
@@ -59,7 +59,7 @@ TEST(Linalg, TensorView) {
   float v = t(0, 1, 2);
   ASSERT_EQ(v, 6);
 
-  auto s = t.Slice(1, All(), All());
+  auto s = t(1, All(), All());
   ASSERT_EQ(s.Shape().size(), 2);
   ASSERT_EQ(s.Shape()[0], 3);
   ASSERT_EQ(s.Shape()[1], 4);
@@ -86,9 +86,9 @@ TEST(Linalg, TensorView) {
   {
     // as matrix
     TensorView<double, 2> mat(data, {6, 4}, -1);
-    auto s = mat.Slice(2, All());
+    auto s = mat(2, All());
     ASSERT_EQ(s.Shape().size(), 1);
-    s = mat.Slice(All(), 1);
+    s = mat(All(), 1);
     ASSERT_EQ(s.Shape().size(), 1);
   }
 
@@ -107,7 +107,7 @@ TEST(Linalg, TensorView) {
     // Don't assign the initial dimension, tensor should be able to deduce the correct dim
     // for Slice.
     auto t = MakeTensorView(data, {2, 3, 4}, 0);
-    auto s = t.Slice(1, 2, All());
+    auto s = t(1, 2, All());
     static_assert(decltype(s)::kDimension == 1, "");
   }
   {

--- a/tests/cpp/common/test_numeric.cc
+++ b/tests/cpp/common/test_numeric.cc
@@ -29,5 +29,15 @@ TEST(Numeric, PartialSum) {
     ASSERT_EQ(sol, result);
   }
 }
+
+TEST(Numeric, Reduce) {
+  Context ctx;
+  ASSERT_TRUE(ctx.IsCPU());
+  HostDeviceVector<float> values(20);
+  auto& h_values = values.HostVector();
+  std::iota(h_values.begin(), h_values.end(), 0.0f);
+  auto sum = Reduce(&ctx, values);
+  ASSERT_EQ(sum, (values.Size() - 1) * values.Size() / 2);
+}
 }  // namespace common
 }  // namespace xgboost

--- a/tests/cpp/common/test_stats.cc
+++ b/tests/cpp/common/test_stats.cc
@@ -54,5 +54,20 @@ TEST(Stats, WeightedQuantile) {
   q = WeightedQuantile(1.0, beg, end, w);
   ASSERT_EQ(q, 5);
 }
+
+TEST(Stats, Median) {
+  linalg::Tensor<float, 2> values{{.0f, .0f, 1.f, 2.f}, {4}, Context::kCpuId};
+  Context ctx;
+  HostDeviceVector<float> weights;
+  auto m = Median(&ctx, values, weights);
+  ASSERT_EQ(m, .5f);
+
+#if defined(XGBOOST_USE_CUDA)
+  ctx.gpu_id = 0;
+  ASSERT_FALSE(ctx.IsCPU());
+  m = Median(&ctx, values, weights);
+  ASSERT_EQ(m, .5f);
+#endif  // defined(XGBOOST_USE_CUDA)
+}
 }  // namespace common
 }  // namespace xgboost

--- a/tests/cpp/gbm/test_gblinear.cc
+++ b/tests/cpp/gbm/test_gblinear.cc
@@ -19,15 +19,11 @@ namespace gbm {
 TEST(GBLinear, JsonIO) {
   size_t constexpr kRows = 16, kCols = 16;
 
-  LearnerModelParam param;
-  param.num_feature = kCols;
-  param.num_output_group = 1;
+  Context ctx;
+  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
 
-  GenericParameter gparam;
-  gparam.Init(Args{});
-
-  std::unique_ptr<GradientBooster> gbm {
-    CreateTrainedGBM("gblinear", Args{}, kRows, kCols, &param, &gparam) };
+  std::unique_ptr<GradientBooster> gbm{
+      CreateTrainedGBM("gblinear", Args{}, kRows, kCols, &mparam, &ctx)};
   Json model { Object() };
   gbm->SaveModel(&model);
   ASSERT_TRUE(IsA<Object>(model));

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -18,15 +18,11 @@ namespace xgboost {
 TEST(GBTree, SelectTreeMethod) {
   size_t constexpr kCols = 10;
 
-  GenericParameter generic_param;
-  generic_param.UpdateAllowUnknown(Args{});
-  LearnerModelParam mparam;
-  mparam.base_score.Resize(1, 0.5);
-  mparam.num_feature = kCols;
-  mparam.num_output_group = 1;
+  Context ctx;
+  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> p_gbm {
-    GradientBooster::Create("gbtree", &generic_param, &mparam)};
+    GradientBooster::Create("gbtree", &ctx, &mparam)};
   auto& gbtree = dynamic_cast<gbm::GBTree&> (*p_gbm);
 
   // Test if `tree_method` can be set
@@ -45,7 +41,7 @@ TEST(GBTree, SelectTreeMethod) {
   ASSERT_EQ(tparam.updater_seq, "grow_quantile_histmaker");
 
 #ifdef XGBOOST_USE_CUDA
-  generic_param.UpdateAllowUnknown(Args{{"gpu_id", "0"}});
+  ctx.UpdateAllowUnknown(Args{{"gpu_id", "0"}});
   gbtree.Configure({{"tree_method", "gpu_hist"}});
   ASSERT_EQ(tparam.updater_seq, "grow_gpu_hist");
   gbtree.Configure({{"booster", "dart"}, {"tree_method", "gpu_hist"}});
@@ -55,15 +51,11 @@ TEST(GBTree, SelectTreeMethod) {
 
 TEST(GBTree, PredictionCache) {
   size_t constexpr kRows = 100, kCols = 10;
-  GenericParameter generic_param;
-  generic_param.UpdateAllowUnknown(Args{});
-  LearnerModelParam mparam;
-  mparam.base_score.Resize(1, 0.5);
-  mparam.num_feature = kCols;
-  mparam.num_output_group = 1;
+  Context ctx;
+  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> p_gbm {
-    GradientBooster::Create("gbtree", &generic_param, &mparam)};
+    GradientBooster::Create("gbtree", &ctx, &mparam)};
   auto& gbtree = dynamic_cast<gbm::GBTree&> (*p_gbm);
 
   gbtree.Configure({{"tree_method", "hist"}});
@@ -176,16 +168,11 @@ TEST(GBTree, ChoosePredictor) {
 TEST(GBTree, JsonIO) {
   size_t constexpr kRows = 16, kCols = 16;
 
-  LearnerModelParam mparam;
-  mparam.num_feature = kCols;
-  mparam.num_output_group = 1;
-  mparam.base_score.Resize(1, 0.5);
-
-  GenericParameter gparam;
-  gparam.Init(Args{});
+  Context ctx;
+  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> gbm {
-    CreateTrainedGBM("gbtree", Args{}, kRows, kCols, &mparam, &gparam) };
+    CreateTrainedGBM("gbtree", Args{}, kRows, kCols, &mparam, &ctx) };
 
   Json model {Object()};
   model["model"] = Object();
@@ -215,16 +202,11 @@ TEST(GBTree, JsonIO) {
 TEST(Dart, JsonIO) {
   size_t constexpr kRows = 16, kCols = 16;
 
-  LearnerModelParam mparam;
-  mparam.num_feature = kCols;
-  mparam.base_score.Resize(1, 0.5);
-  mparam.num_output_group = 1;
+  Context ctx;
+  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
 
-  GenericParameter gparam;
-  gparam.Init(Args{});
-
-  std::unique_ptr<GradientBooster> gbm {
-    CreateTrainedGBM("dart", Args{}, kRows, kCols, &mparam, &gparam) };
+  std::unique_ptr<GradientBooster> gbm{
+      CreateTrainedGBM("dart", Args{}, kRows, kCols, &mparam, &ctx)};
 
   Json model {Object()};
   model["model"] = Object();

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -21,7 +21,7 @@ TEST(GBTree, SelectTreeMethod) {
   GenericParameter generic_param;
   generic_param.UpdateAllowUnknown(Args{});
   LearnerModelParam mparam;
-  mparam.base_score = 0.5;
+  mparam.base_score.Resize(1, 0.5);
   mparam.num_feature = kCols;
   mparam.num_output_group = 1;
 
@@ -58,7 +58,7 @@ TEST(GBTree, PredictionCache) {
   GenericParameter generic_param;
   generic_param.UpdateAllowUnknown(Args{});
   LearnerModelParam mparam;
-  mparam.base_score = 0.5;
+  mparam.base_score.Resize(1, 0.5);
   mparam.num_feature = kCols;
   mparam.num_output_group = 1;
 
@@ -179,7 +179,7 @@ TEST(GBTree, JsonIO) {
   LearnerModelParam mparam;
   mparam.num_feature = kCols;
   mparam.num_output_group = 1;
-  mparam.base_score = 0.5;
+  mparam.base_score.Resize(1, 0.5);
 
   GenericParameter gparam;
   gparam.Init(Args{});
@@ -217,7 +217,7 @@ TEST(Dart, JsonIO) {
 
   LearnerModelParam mparam;
   mparam.num_feature = kCols;
-  mparam.base_score = 0.5;
+  mparam.base_score.Resize(1, 0.5);
   mparam.num_output_group = 1;
 
   GenericParameter gparam;

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -451,5 +451,14 @@ class RMMAllocator;
 using RMMAllocatorPtr = std::unique_ptr<RMMAllocator, void(*)(RMMAllocator*)>;
 RMMAllocatorPtr SetUpRMMResourceForCppTests(int argc, char** argv);
 
+/*
+ * \brief Make learner model param
+ */
+inline LearnerModelParam MakeMP(bst_feature_t n_features, float base_score, uint32_t n_groups) {
+  size_t shape[1]{1};
+  LearnerModelParam mparam(n_features, linalg::Tensor<float, 1>{{base_score}, shape}, n_groups);
+  return mparam;
+}
+
 }  // namespace xgboost
 #endif

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -454,9 +454,11 @@ RMMAllocatorPtr SetUpRMMResourceForCppTests(int argc, char** argv);
 /*
  * \brief Make learner model param
  */
-inline LearnerModelParam MakeMP(bst_feature_t n_features, float base_score, uint32_t n_groups) {
+inline LearnerModelParam MakeMP(bst_feature_t n_features, float base_score, uint32_t n_groups,
+                                int32_t device = Context::kCpuId) {
   size_t shape[1]{1};
-  LearnerModelParam mparam(n_features, linalg::Tensor<float, 1>{{base_score}, shape}, n_groups);
+  LearnerModelParam mparam(n_features, linalg::Tensor<float, 1>{{base_score}, shape, device},
+                           n_groups);
   return mparam;
 }
 

--- a/tests/cpp/linear/test_linear.cc
+++ b/tests/cpp/linear/test_linear.cc
@@ -18,10 +18,7 @@ TEST(Linear, Shotgun) {
   auto p_fmat = xgboost::RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
 
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  LearnerModelParam mparam;
-  mparam.num_feature = kCols;
-  mparam.num_output_group = 1;
-  mparam.base_score = 0.5;
+  LearnerModelParam mparam(kCols, {.5}, 1);
 
   {
     auto updater = std::unique_ptr<xgboost::LinearUpdater>(
@@ -54,10 +51,7 @@ TEST(Linear, coordinate) {
   auto p_fmat = xgboost::RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
 
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  LearnerModelParam mparam;
-  mparam.num_feature = kCols;
-  mparam.num_output_group = 1;
-  mparam.base_score = 0.5;
+  LearnerModelParam mparam(kCols, {.5}, 1);
 
   auto updater = std::unique_ptr<xgboost::LinearUpdater>(
       xgboost::LinearUpdater::Create("coord_descent", &lparam));

--- a/tests/cpp/linear/test_linear.cc
+++ b/tests/cpp/linear/test_linear.cc
@@ -18,7 +18,7 @@ TEST(Linear, Shotgun) {
   auto p_fmat = xgboost::RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
 
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  LearnerModelParam mparam(kCols, {.5}, 1);
+  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
 
   {
     auto updater = std::unique_ptr<xgboost::LinearUpdater>(
@@ -51,7 +51,7 @@ TEST(Linear, coordinate) {
   auto p_fmat = xgboost::RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
 
   auto lparam = xgboost::CreateEmptyGenericParam(GPUIDX);
-  LearnerModelParam mparam(kCols, {.5}, 1);
+  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
 
   auto updater = std::unique_ptr<xgboost::LinearUpdater>(
       xgboost::LinearUpdater::Create("coord_descent", &lparam));

--- a/tests/cpp/linear/test_linear.cu
+++ b/tests/cpp/linear/test_linear.cu
@@ -15,7 +15,7 @@ TEST(Linear, GPUCoordinate) {
   auto mat = xgboost::RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
   auto ctx = CreateEmptyGenericParam(GPUIDX);
 
-  LearnerModelParam mparam(kCols, {.5}, 1);
+  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
   auto updater = std::unique_ptr<xgboost::LinearUpdater>(
       xgboost::LinearUpdater::Create("gpu_coord_descent", &ctx));
   updater->Configure({{"eta", "1."}});

--- a/tests/cpp/linear/test_linear.cu
+++ b/tests/cpp/linear/test_linear.cu
@@ -13,15 +13,11 @@ TEST(Linear, GPUCoordinate) {
   size_t constexpr kCols = 10;
 
   auto mat = xgboost::RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
-  auto lparam = CreateEmptyGenericParam(GPUIDX);
+  auto ctx = CreateEmptyGenericParam(GPUIDX);
 
-  LearnerModelParam mparam;
-  mparam.num_feature = kCols;
-  mparam.num_output_group = 1;
-  mparam.base_score = 0.5;
-
+  LearnerModelParam mparam(kCols, {.5}, 1);
   auto updater = std::unique_ptr<xgboost::LinearUpdater>(
-      xgboost::LinearUpdater::Create("gpu_coord_descent", &lparam));
+      xgboost::LinearUpdater::Create("gpu_coord_descent", &ctx));
   updater->Configure({{"eta", "1."}});
   xgboost::HostDeviceVector<xgboost::GradientPair> gpair(
       mat->Info().num_row_, xgboost::GradientPair(-5, 1.0));

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -21,11 +21,11 @@ TEST(CpuPredictor, Basic) {
   size_t constexpr kRows = 5;
   size_t constexpr kCols = 5;
 
-  LearnerModelParam param{kCols, {0.0}, 1};
+  LearnerModelParam mparam{MakeMP(kCols, .0, 1)};
 
   GenericParameter ctx;
   ctx.UpdateAllowUnknown(Args{});
-  gbm::GBTreeModel model = CreateTestModel(&param, &ctx);
+  gbm::GBTreeModel model = CreateTestModel(&mparam, &ctx);
 
   auto dmat = RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
 
@@ -101,11 +101,11 @@ TEST(CpuPredictor, ExternalMemory) {
   std::unique_ptr<Predictor> cpu_predictor =
       std::unique_ptr<Predictor>(Predictor::Create("cpu_predictor", &lparam));
 
-  LearnerModelParam param(dmat->Info().num_col_, {0.0}, 1);
+  LearnerModelParam mparam{MakeMP(dmat->Info().num_col_, .0, 1)};
 
   GenericParameter ctx;
   ctx.UpdateAllowUnknown(Args{});
-  gbm::GBTreeModel model = CreateTestModel(&param, &ctx);
+  gbm::GBTreeModel model = CreateTestModel(&mparam, &ctx);
 
   // Test predict batch
   PredictionCacheEntry out_predictions;
@@ -195,7 +195,7 @@ TEST(CpuPredictor, InplacePredict) {
 
 void TestUpdatePredictionCache(bool use_subsampling) {
   size_t constexpr kRows = 64, kCols = 16, kClasses = 4;
-  LearnerModelParam mparam{kCols, {0.0}, kClasses};
+  LearnerModelParam mparam{MakeMP(kCols, .0, kClasses)};
   Context ctx;
 
   std::unique_ptr<gbm::GBTree> gbm;

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -21,10 +21,7 @@ TEST(CpuPredictor, Basic) {
   size_t constexpr kRows = 5;
   size_t constexpr kCols = 5;
 
-  LearnerModelParam param;
-  param.num_feature = kCols;
-  param.base_score = 0.0;
-  param.num_output_group = 1;
+  LearnerModelParam param{kCols, {0.0}, 1};
 
   GenericParameter ctx;
   ctx.UpdateAllowUnknown(Args{});
@@ -104,10 +101,7 @@ TEST(CpuPredictor, ExternalMemory) {
   std::unique_ptr<Predictor> cpu_predictor =
       std::unique_ptr<Predictor>(Predictor::Create("cpu_predictor", &lparam));
 
-  LearnerModelParam param;
-  param.base_score = 0;
-  param.num_feature = dmat->Info().num_col_;
-  param.num_output_group = 1;
+  LearnerModelParam param(dmat->Info().num_col_, {0.0}, 1);
 
   GenericParameter ctx;
   ctx.UpdateAllowUnknown(Args{});
@@ -201,16 +195,11 @@ TEST(CpuPredictor, InplacePredict) {
 
 void TestUpdatePredictionCache(bool use_subsampling) {
   size_t constexpr kRows = 64, kCols = 16, kClasses = 4;
-  LearnerModelParam mparam;
-  mparam.num_feature = kCols;
-  mparam.num_output_group = kClasses;
-  mparam.base_score = 0;
-
-  GenericParameter gparam;
-  gparam.Init(Args{});
+  LearnerModelParam mparam{kCols, {0.0}, kClasses};
+  Context ctx;
 
   std::unique_ptr<gbm::GBTree> gbm;
-  gbm.reset(static_cast<gbm::GBTree*>(GradientBooster::Create("gbtree", &gparam, &mparam)));
+  gbm.reset(static_cast<gbm::GBTree*>(GradientBooster::Create("gbtree", &ctx, &mparam)));
   std::map<std::string, std::string> cfg;
   cfg["tree_method"] = "hist";
   cfg["predictor"]   = "cpu_predictor";

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -34,8 +34,9 @@ TEST(GPUPredictor, Basic) {
     int n_row = i, n_col = i;
     auto dmat = RandomDataGenerator(n_row, n_col, 0).GenerateDMatrix();
 
-    LearnerModelParam mparam{MakeMP(n_col, .5, 1)};
-    GenericParameter ctx;
+    Context ctx;
+    ctx.gpu_id = 0;
+    LearnerModelParam mparam{MakeMP(n_col, .5, 1, ctx.gpu_id)};
     gbm::GBTreeModel model = CreateTestModel(&mparam, &ctx);
 
     // Test predict batch
@@ -89,9 +90,10 @@ TEST(GPUPredictor, ExternalMemoryTest) {
   gpu_predictor->Configure({});
 
   const int n_classes = 3;
-  LearnerModelParam mparam{MakeMP(5, .5, n_classes)};
-
   Context ctx;
+  ctx.gpu_id = 0;
+  LearnerModelParam mparam{MakeMP(5, .5, n_classes, ctx.gpu_id)};
+
   gbm::GBTreeModel model = CreateTestModel(&mparam, &ctx, n_classes);
   std::vector<std::unique_ptr<DMatrix>> dmats;
 
@@ -162,8 +164,9 @@ TEST(GpuPredictor, LesserFeatures) {
 TEST(GPUPredictor, ShapStump) {
   cudaSetDevice(0);
 
-  LearnerModelParam mparam{MakeMP(1, .5, 1)};
   Context ctx;
+  ctx.gpu_id = 0;
+  LearnerModelParam mparam{MakeMP(1, .5, 1, ctx.gpu_id)};
   gbm::GBTreeModel model(&mparam, &ctx);
 
   std::vector<std::unique_ptr<RegTree>> trees;
@@ -188,8 +191,9 @@ TEST(GPUPredictor, ShapStump) {
 }
 
 TEST(GPUPredictor, Shap) {
-  LearnerModelParam mparam{MakeMP(1, .5, 1)};
   Context ctx;
+  ctx.gpu_id = 0;
+  LearnerModelParam mparam{MakeMP(1, .5, 1, ctx.gpu_id)};
   gbm::GBTreeModel model(&mparam, &ctx);
 
   std::vector<std::unique_ptr<RegTree>> trees;

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -34,13 +34,8 @@ TEST(GPUPredictor, Basic) {
     int n_row = i, n_col = i;
     auto dmat = RandomDataGenerator(n_row, n_col, 0).GenerateDMatrix();
 
-    LearnerModelParam param;
-    param.num_feature = n_col;
-    param.num_output_group = 1;
-    param.base_score = 0.5;
-
+    LearnerModelParam param(n_col, {.5}, 1);
     GenericParameter ctx;
-    ctx.UpdateAllowUnknown(Args{});
     gbm::GBTreeModel model = CreateTestModel(&param, &ctx);
 
     // Test predict batch
@@ -93,14 +88,10 @@ TEST(GPUPredictor, ExternalMemoryTest) {
       std::unique_ptr<Predictor>(Predictor::Create("gpu_predictor", &lparam));
   gpu_predictor->Configure({});
 
-  LearnerModelParam param;
-  param.num_feature = 5;
   const int n_classes = 3;
-  param.num_output_group = n_classes;
-  param.base_score = 0.5;
+  LearnerModelParam param(5, {.5}, n_classes);
 
-  GenericParameter ctx;
-  ctx.UpdateAllowUnknown(Args{});
+  Context ctx;
   gbm::GBTreeModel model = CreateTestModel(&param, &ctx, n_classes);
   std::vector<std::unique_ptr<DMatrix>> dmats;
 
@@ -171,14 +162,8 @@ TEST(GpuPredictor, LesserFeatures) {
 TEST(GPUPredictor, ShapStump) {
   cudaSetDevice(0);
 
-  LearnerModelParam param;
-  param.num_feature = 1;
-  param.num_output_group = 1;
-  param.base_score = 0.5;
-
-  GenericParameter ctx;
-  ctx.UpdateAllowUnknown(Args{});
-
+  LearnerModelParam param(1, {.5}, 1);
+  Context ctx;
   gbm::GBTreeModel model(&param, &ctx);
 
   std::vector<std::unique_ptr<RegTree>> trees;
@@ -193,23 +178,18 @@ TEST(GPUPredictor, ShapStump) {
   auto dmat = RandomDataGenerator(3, 1, 0).GenerateDMatrix();
   gpu_predictor->PredictContribution(dmat.get(), &predictions, model);
   auto& phis = predictions.HostVector();
+  auto base_score = param.base_score.HostVector().front();
   EXPECT_EQ(phis[0], 0.0);
-  EXPECT_EQ(phis[1], param.base_score);
+  EXPECT_EQ(phis[1], base_score);
   EXPECT_EQ(phis[2], 0.0);
-  EXPECT_EQ(phis[3], param.base_score);
+  EXPECT_EQ(phis[3], base_score);
   EXPECT_EQ(phis[4], 0.0);
-  EXPECT_EQ(phis[5], param.base_score);
+  EXPECT_EQ(phis[5], base_score);
 }
 
 TEST(GPUPredictor, Shap) {
-  LearnerModelParam param;
-  param.num_feature = 1;
-  param.num_output_group = 1;
-  param.base_score = 0.5;
-
-  GenericParameter ctx;
-  ctx.UpdateAllowUnknown(Args{});
-
+  LearnerModelParam param(1, {.5}, 1);
+  Context ctx;
   gbm::GBTreeModel model(&param, &ctx);
 
   std::vector<std::unique_ptr<RegTree>> trees;
@@ -258,13 +238,8 @@ TEST(GPUPredictor, PredictLeafBasic) {
       std::unique_ptr<Predictor>(Predictor::Create("gpu_predictor", &lparam));
   gpu_predictor->Configure({});
 
-  LearnerModelParam param;
-  param.num_feature = kCols;
-  param.base_score = 0.0;
-  param.num_output_group = 1;
-
-  GenericParameter ctx;
-  ctx.UpdateAllowUnknown(Args{});
+  LearnerModelParam param(kCols, {.0}, 1);
+  Context ctx;
   gbm::GBTreeModel model = CreateTestModel(&param, &ctx);
 
   HostDeviceVector<float> leaf_out_predictions;

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -210,8 +210,7 @@ void TestCategoricalPrediction(std::string name) {
   size_t constexpr kCols = 10;
   PredictionCacheEntry out_predictions;
 
-  LearnerModelParam param(kCols, {.5}, 1);
-
+  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
   uint32_t split_ind = 3;
   bst_cat_t split_cat = 4;
   float left_weight = 1.3f;
@@ -219,7 +218,7 @@ void TestCategoricalPrediction(std::string name) {
 
   GenericParameter ctx;
   ctx.UpdateAllowUnknown(Args{});
-  gbm::GBTreeModel model(&param, &ctx);
+  gbm::GBTreeModel model(&mparam, &ctx);
   GBTreeModelForTest(&model, split_ind, split_cat, left_weight, right_weight);
 
   ctx.UpdateAllowUnknown(Args{{"gpu_id", "0"}});
@@ -234,7 +233,7 @@ void TestCategoricalPrediction(std::string name) {
 
   predictor->InitOutPredictions(m->Info(), &out_predictions.predictions, model);
   predictor->PredictBatch(m.get(), &out_predictions, model, 0);
-  auto score = param.base_score.HostVector().front();
+  auto score = mparam.BaseScore(Context::kCpuId)(0);
   ASSERT_EQ(out_predictions.predictions.Size(), 1ul);
   ASSERT_EQ(out_predictions.predictions.HostVector()[0],
             right_weight + score);  // go to right for matching cat
@@ -251,7 +250,7 @@ void TestCategoricalPredictLeaf(StringView name) {
   size_t constexpr kCols = 10;
   PredictionCacheEntry out_predictions;
 
-  LearnerModelParam param(kCols, {.5}, 1);
+  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
 
   uint32_t split_ind = 3;
   bst_cat_t split_cat = 4;
@@ -261,7 +260,7 @@ void TestCategoricalPredictLeaf(StringView name) {
   GenericParameter ctx;
   ctx.UpdateAllowUnknown(Args{});
 
-  gbm::GBTreeModel model(&param, &ctx);
+  gbm::GBTreeModel model(&mparam, &ctx);
   GBTreeModelForTest(&model, split_ind, split_cat, left_weight, right_weight);
 
   ctx.gpu_id = 0;

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -210,10 +210,7 @@ void TestCategoricalPrediction(std::string name) {
   size_t constexpr kCols = 10;
   PredictionCacheEntry out_predictions;
 
-  LearnerModelParam param;
-  param.num_feature = kCols;
-  param.num_output_group = 1;
-  param.base_score = 0.5;
+  LearnerModelParam param(kCols, {.5}, 1);
 
   uint32_t split_ind = 3;
   bst_cat_t split_cat = 4;
@@ -237,27 +234,24 @@ void TestCategoricalPrediction(std::string name) {
 
   predictor->InitOutPredictions(m->Info(), &out_predictions.predictions, model);
   predictor->PredictBatch(m.get(), &out_predictions, model, 0);
+  auto score = param.base_score.HostVector().front();
   ASSERT_EQ(out_predictions.predictions.Size(), 1ul);
   ASSERT_EQ(out_predictions.predictions.HostVector()[0],
-            right_weight + param.base_score);  // go to right for matching cat
+            right_weight + score);  // go to right for matching cat
 
   row[split_ind] = split_cat + 1;
   m = GetDMatrixFromData(row, 1, kCols);
   out_predictions.version = 0;
   predictor->InitOutPredictions(m->Info(), &out_predictions.predictions, model);
   predictor->PredictBatch(m.get(), &out_predictions, model, 0);
-  ASSERT_EQ(out_predictions.predictions.HostVector()[0],
-            left_weight + param.base_score);
+  ASSERT_EQ(out_predictions.predictions.HostVector()[0], left_weight + score);
 }
 
 void TestCategoricalPredictLeaf(StringView name) {
   size_t constexpr kCols = 10;
   PredictionCacheEntry out_predictions;
 
-  LearnerModelParam param;
-  param.num_feature = kCols;
-  param.num_output_group = 1;
-  param.base_score = 0.5;
+  LearnerModelParam param(kCols, {.5}, 1);
 
   uint32_t split_ind = 3;
   bst_cat_t split_cat = 4;

--- a/tests/cpp/predictor/test_predictor.h
+++ b/tests/cpp/predictor/test_predictor.h
@@ -12,7 +12,7 @@ void TestPredictionFromGradientIndex(std::string name, size_t rows, size_t cols,
                                      std::shared_ptr<DMatrix> p_hist) {
   constexpr size_t kClasses { 3 };
 
-  LearnerModelParam param(cols, {.5}, kClasses);
+  LearnerModelParam mparam{MakeMP(cols, .5, kClasses)};
   auto lparam = CreateEmptyGenericParam(0);
 
   std::unique_ptr<Predictor> predictor =
@@ -21,7 +21,7 @@ void TestPredictionFromGradientIndex(std::string name, size_t rows, size_t cols,
 
   GenericParameter ctx;
   ctx.UpdateAllowUnknown(Args{});
-  gbm::GBTreeModel model = CreateTestModel(&param, &ctx, kClasses);
+  gbm::GBTreeModel model = CreateTestModel(&mparam, &ctx, kClasses);
 
   {
     auto p_precise = RandomDataGenerator(rows, cols, 0).GenerateDMatrix();

--- a/tests/cpp/predictor/test_predictor.h
+++ b/tests/cpp/predictor/test_predictor.h
@@ -12,11 +12,7 @@ void TestPredictionFromGradientIndex(std::string name, size_t rows, size_t cols,
                                      std::shared_ptr<DMatrix> p_hist) {
   constexpr size_t kClasses { 3 };
 
-  LearnerModelParam param;
-  param.num_feature = cols;
-  param.num_output_group = kClasses;
-  param.base_score = 0.5;
-
+  LearnerModelParam param(cols, {.5}, kClasses);
   auto lparam = CreateEmptyGenericParam(0);
 
   std::unique_ptr<Predictor> predictor =

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -447,4 +447,17 @@ TEST(Learner, MultiTarget) {
     EXPECT_THROW({ learner->Configure(); }, dmlc::Error);
   }
 }
+
+TEST(Learner, BaseScore) {
+  size_t constexpr kRows{1024}, kCols{16};
+  auto m = RandomDataGenerator{kRows, kCols, 0}.GenerateDMatrix(true);
+  std::unique_ptr<Learner> learner{Learner::Create({m})};
+  learner->SetParam("objective", "reg:absoluteerror");
+  for (size_t i = 0; i < 4; ++i) {
+    learner->UpdateOneIter(i, m);
+  }
+  Json config{Object{}};
+  learner->SaveConfig(&config);
+  std::cout << config << std::endl;
+}
 }  // namespace xgboost

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -474,16 +474,23 @@ TEST(Learner, InitEstimation) {
         std::stof(get<String const>(config["learner"]["learner_model_param"]["base_score"]));
     // No base score is estimated yet.
     ASSERT_EQ(base_score, ObjFunction::DefaultBaseScore());
+  }
 
+  {
+    std::unique_ptr<Learner> learner{Learner::Create({Xy})};
+    learner->SetParam("objective", "reg:absoluteerror");
     learner->UpdateOneIter(0, Xy);
+
+    HostDeviceVector<float> predt;
     learner->Predict(Xy, false, &predt, 0, 0);
-    h_predt = predt.ConstHostSpan();
+    auto h_predt = predt.ConstHostSpan();
     for (auto v : h_predt) {
       ASSERT_NE(v, ObjFunction::DefaultBaseScore());
     }
 
+    Json config{Object{}};
     learner->SaveConfig(&config);
-    base_score =
+    auto base_score =
         std::stof(get<String const>(config["learner"]["learner_model_param"]["base_score"]));
     ASSERT_NE(base_score, ObjFunction::DefaultBaseScore());
 

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -3,8 +3,10 @@
  */
 #include <gtest/gtest.h>
 #include <xgboost/learner.h>
+#include <xgboost/objective.h>  // ObjFunction
 #include <xgboost/version_config.h>
 
+#include <string>  // std::stof, std::string
 #include <thread>
 #include <vector>
 
@@ -446,5 +448,41 @@ TEST(Learner, MultiTarget) {
     // unsupported objective.
     EXPECT_THROW({ learner->Configure(); }, dmlc::Error);
   }
+}
+
+/**
+ * Test the model initialization sequence is correctly performed.
+ */
+TEST(Learner, InitEstimation) {
+  size_t constexpr kCols = 10;
+  auto Xy = RandomDataGenerator{10, kCols, 0}.GenerateDMatrix(true);
+  std::unique_ptr<Learner> learner{Learner::Create({Xy})};
+  learner->SetParam("objective", "reg:absoluteerror");
+  learner->Configure();
+  HostDeviceVector<float> predt;
+  learner->Predict(Xy, false, &predt, 0, 0);
+
+  auto h_predt = predt.ConstHostSpan();
+  for (auto v : h_predt) {
+    ASSERT_EQ(v, ObjFunction::DefaultBaseScore());
+  }
+  Json config{Object{}};
+  learner->SaveConfig(&config);
+  auto base_score =
+      std::stof(get<String const>(config["learner"]["learner_model_param"]["base_score"]));
+  // No base score is estimated yet.
+  ASSERT_TRUE(std::isnan(base_score));
+
+  learner->UpdateOneIter(0, Xy);
+  learner->Predict(Xy, false, &predt, 0, 0);
+  h_predt = predt.ConstHostSpan();
+  for (auto v : h_predt) {
+    ASSERT_NE(v, ObjFunction::DefaultBaseScore());
+  }
+
+  learner->SaveConfig(&config);
+  base_score = std::stof(get<String const>(config["learner"]["learner_model_param"]["base_score"]));
+  ASSERT_NE(base_score, ObjFunction::DefaultBaseScore());
+  std::cout << base_score << std::endl;
 }
 }  // namespace xgboost

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -447,17 +447,4 @@ TEST(Learner, MultiTarget) {
     EXPECT_THROW({ learner->Configure(); }, dmlc::Error);
   }
 }
-
-TEST(Learner, BaseScore) {
-  size_t constexpr kRows{1024}, kCols{16};
-  auto m = RandomDataGenerator{kRows, kCols, 0}.GenerateDMatrix(true);
-  std::unique_ptr<Learner> learner{Learner::Create({m})};
-  learner->SetParam("objective", "reg:absoluteerror");
-  for (size_t i = 0; i < 4; ++i) {
-    learner->UpdateOneIter(i, m);
-  }
-  Json config{Object{}};
-  learner->SaveConfig(&config);
-  std::cout << config << std::endl;
-}
 }  // namespace xgboost

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -206,8 +206,7 @@ TEST(Learner, MultiThreadedPredict) {
   p_dmat->Info().labels.Reshape(kRows);
   CHECK_NE(p_dmat->Info().num_col_, 0);
 
-  std::shared_ptr<DMatrix> p_data{
-      RandomDataGenerator{kRows, kCols, 0}.GenerateDMatrix()};
+  std::shared_ptr<DMatrix> p_data{RandomDataGenerator{kRows, kCols, 0}.GenerateDMatrix()};
   CHECK_NE(p_data->Info().num_col_, 0);
 
   std::shared_ptr<Learner> learner{Learner::Create({p_dmat})};

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -447,6 +447,7 @@ TEST_F(L1SerializationTest, Hist) {
                            fmap_, p_dmat_);
 }
 
+#if defined(XGBOOST_USE_CUDA)
 TEST_F(L1SerializationTest, GpuHist) {
   TestLearnerSerialization({{"booster", "gbtree"},
                             {"objective", "reg:absoluteerror"},
@@ -455,6 +456,7 @@ TEST_F(L1SerializationTest, GpuHist) {
                             {"tree_method", "gpu_hist"}},
                            fmap_, p_dmat_);
 }
+#endif  //  defined(XGBOOST_USE_CUDA)
 
 class LogitSerializationTest : public SerializationTest {
  protected:

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -418,6 +418,43 @@ TEST_F(SerializationTest, GPUCoordDescent) {
 }
 #endif  // defined(XGBOOST_USE_CUDA)
 
+class L1SerializationTest : public SerializationTest {};
+
+TEST_F(L1SerializationTest, Exact) {
+  TestLearnerSerialization({{"booster", "gbtree"},
+                            {"objective", "reg:absoluteerror"},
+                            {"seed", "0"},
+                            {"max_depth", "2"},
+                            {"tree_method", "exact"}},
+                           fmap_, p_dmat_);
+}
+
+TEST_F(L1SerializationTest, Approx) {
+  TestLearnerSerialization({{"booster", "gbtree"},
+                            {"objective", "reg:absoluteerror"},
+                            {"seed", "0"},
+                            {"max_depth", "2"},
+                            {"tree_method", "approx"}},
+                           fmap_, p_dmat_);
+}
+
+TEST_F(L1SerializationTest, Hist) {
+  TestLearnerSerialization({{"booster", "gbtree"},
+                            {"objective", "reg:absoluteerror"},
+                            {"seed", "0"},
+                            {"max_depth", "2"},
+                            {"tree_method", "hist"}},
+                           fmap_, p_dmat_);
+}
+
+TEST_F(L1SerializationTest, GpuHist) {
+  TestLearnerSerialization({{"booster", "gbtree"},
+                            {"objective", "reg:absoluteerror"},
+                            {"seed", "0"},
+                            {"max_depth", "2"},
+                            {"tree_method", "gpu_hist"}},
+                           fmap_, p_dmat_);
+}
 
 class LogitSerializationTest : public SerializationTest {
  protected:

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -208,3 +208,8 @@ class TestGPUUpdaters:
         param = dataset.set_params(param)
         result = train_result(param, dataset.get_dmat(), 10)
         assert tm.non_increasing(result['train'][dataset.metric])
+
+    @pytest.mark.skipif(**tm.no_sklearn())
+    @pytest.mark.parametrize("weighted", [True, False])
+    def test_adaptive(self, weighted) -> None:
+        self.cputest.run_adaptive("gpu_hist", weighted)

--- a/tests/python/test_model_compatibility.py
+++ b/tests/python/test_model_compatibility.py
@@ -102,34 +102,38 @@ def run_scikit_model_check(name, path):
 
 @pytest.mark.skipif(**tm.no_sklearn())
 def test_model_compatibility():
-    '''Test model compatibility, can only be run on CI as others don't
+    """Test model compatibility, can only be run on CI as others don't
     have the credentials.
 
-    '''
+    """
     path = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(path, 'models')
+    path = os.path.join(path, "models")
 
-    zip_path, _ = urllib.request.urlretrieve('https://xgboost-ci-jenkins-artifacts.s3-us-west-2' +
-                                             '.amazonaws.com/xgboost_model_compatibility_test.zip')
-    with zipfile.ZipFile(zip_path, 'r') as z:
-        z.extractall(path)
+    if not os.path.exists(path):
+        zip_path, _ = urllib.request.urlretrieve(
+            "https://xgboost-ci-jenkins-artifacts.s3-us-west-2"
+            + ".amazonaws.com/xgboost_model_compatibility_test.zip"
+        )
+        with zipfile.ZipFile(zip_path, "r") as z:
+            z.extractall(path)
 
     models = [
-        os.path.join(root, f) for root, subdir, files in os.walk(path)
+        os.path.join(root, f)
+        for root, subdir, files in os.walk(path)
         for f in files
-        if f != 'version'
+        if f != "version"
     ]
     assert models
 
     for path in models:
         name = os.path.basename(path)
-        if name.startswith('xgboost-'):
+        if name.startswith("xgboost-"):
             booster = xgboost.Booster(model_file=path)
             run_booster_check(booster, name)
             # Do full serialization.
             booster = copy.copy(booster)
             run_booster_check(booster, name)
-        elif name.startswith('xgboost_scikit'):
+        elif name.startswith("xgboost_scikit"):
             run_scikit_model_check(name, path)
         else:
             assert False


### PR DESCRIPTION
https://github.com/dmlc/xgboost/issues/4321 .

This PR calculates the `base_score` from labels for l1 regression and saves it to the output model. Will follow up on other objectives as well.
- Configure model parameter for base_score.
- Add estimation function in objective.
- Change base_score to an array. At the moment, we use only 1 element, the change is to prepare for multi-class and multi-output once we can remove some legacy in the binary model.

Multi-target and multi-class are not yet supported due to the binary model parameter.