### PR TITLE
Implement iterative DMatrix for CPU.

### DIFF
--- a/amalgamation/xgboost-all0.cc
+++ b/amalgamation/xgboost-all0.cc
@@ -43,6 +43,7 @@
 #include "../src/data/gradient_index_format.cc"
 #include "../src/data/sparse_page_dmatrix.cc"
 #include "../src/data/proxy_dmatrix.cc"
+#include "../src/data/iterative_dmatrix.cc"
 
 // prediction
 #include "../src/predictor/predictor.cc"

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -559,6 +559,7 @@ class DMatrix {
    *
    * \param iter    External data iterator
    * \param proxy   A hanlde to ProxyDMatrix
+   * \param ref     Reference Quantile DMatrix.
    * \param reset   Callback for reset
    * \param next    Callback for next
    * \param missing Value that should be treated as missing.
@@ -567,13 +568,11 @@ class DMatrix {
    *
    * \return A created quantile based DMatrix.
    */
-  template <typename DataIterHandle, typename DMatrixHandle,
-            typename DataIterResetCallback, typename XGDMatrixCallbackNext>
-  static DMatrix *Create(DataIterHandle iter, DMatrixHandle proxy,
-                         DataIterResetCallback *reset,
-                         XGDMatrixCallbackNext *next, float missing,
-                         int nthread,
-                         int max_bin);
+  template <typename DataIterHandle, typename DMatrixHandle, typename DataIterResetCallback,
+            typename XGDMatrixCallbackNext>
+  static DMatrix* Create(DataIterHandle iter, DMatrixHandle proxy, std::shared_ptr<DMatrix> ref,
+                         DataIterResetCallback* reset, XGDMatrixCallbackNext* next, float missing,
+                         int nthread, bst_bin_t max_bin);
 
   /**
    * \brief Create an external memory DMatrix with callbacks.
@@ -613,6 +612,7 @@ class DMatrix {
   virtual BatchSet<GHistIndexMatrix> GetGradientIndex(const BatchParam& param) = 0;
 
   virtual bool EllpackExists() const = 0;
+  virtual bool GHistIndexExists() const = 0;
   virtual bool SparsePageExists() const = 0;
 };
 
@@ -621,9 +621,14 @@ inline BatchSet<SparsePage> DMatrix::GetBatches() {
   return GetRowBatches();
 }
 
-template<>
+template <>
 inline bool DMatrix::PageExists<EllpackPage>() const {
   return this->EllpackExists();
+}
+
+template <>
+inline bool DMatrix::PageExists<GHistIndexMatrix>() const {
+  return this->GHistIndexExists();
 }
 
 template<>

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -275,13 +275,14 @@ XGB_DLL int XGDMatrixCreateFromCallback(DataIterHandle iter, DMatrixHandle proxy
   API_END();
 }
 
-XGB_DLL int XGDeviceQuantileDMatrixCreateFromCallback(
-    DataIterHandle iter, DMatrixHandle proxy, DataIterResetCallback *reset,
-    XGDMatrixCallbackNext *next, float missing, int nthread,
-    int max_bin, DMatrixHandle *out) {
+XGB_DLL int XGDeviceQuantileDMatrixCreateFromCallback(DataIterHandle iter, DMatrixHandle proxy,
+                                                      DataIterResetCallback *reset,
+                                                      XGDMatrixCallbackNext *next, float missing,
+                                                      int nthread, int max_bin,
+                                                      DMatrixHandle *out) {
   API_BEGIN();
   *out = new std::shared_ptr<xgboost::DMatrix>{
-    xgboost::DMatrix::Create(iter, proxy, reset, next, missing, nthread, max_bin)};
+      xgboost::DMatrix::Create(iter, proxy, nullptr, reset, next, missing, nthread, max_bin)};
   API_END();
 }
 

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -931,15 +931,13 @@ DMatrix* DMatrix::Load(const std::string& uri,
   }
   return dmat;
 }
-template <typename DataIterHandle, typename DMatrixHandle,
-          typename DataIterResetCallback, typename XGDMatrixCallbackNext>
-DMatrix *DMatrix::Create(DataIterHandle iter, DMatrixHandle proxy,
-                         DataIterResetCallback *reset,
-                         XGDMatrixCallbackNext *next, float missing,
-                         int nthread,
-                         int max_bin) {
-  return new data::IterativeDMatrix(iter, proxy, reset, next, missing,
-                                          nthread, max_bin);
+
+template <typename DataIterHandle, typename DMatrixHandle, typename DataIterResetCallback,
+          typename XGDMatrixCallbackNext>
+DMatrix* DMatrix::Create(DataIterHandle iter, DMatrixHandle proxy, std::shared_ptr<DMatrix> ref,
+                         DataIterResetCallback* reset, XGDMatrixCallbackNext* next, float missing,
+                         int nthread, bst_bin_t max_bin) {
+  return new data::IterativeDMatrix(iter, proxy, ref, reset, next, missing, nthread, max_bin);
 }
 
 template <typename DataIterHandle, typename DMatrixHandle,
@@ -953,11 +951,12 @@ DMatrix *DMatrix::Create(DataIterHandle iter, DMatrixHandle proxy,
                                      cache);
 }
 
-template DMatrix *DMatrix::Create<DataIterHandle, DMatrixHandle,
-                                  DataIterResetCallback, XGDMatrixCallbackNext>(
-    DataIterHandle iter, DMatrixHandle proxy, DataIterResetCallback *reset,
-    XGDMatrixCallbackNext *next, float missing, int nthread,
-    int max_bin);
+template DMatrix* DMatrix::Create<DataIterHandle, DMatrixHandle, DataIterResetCallback,
+                                  XGDMatrixCallbackNext>(DataIterHandle iter, DMatrixHandle proxy,
+                                                         std::shared_ptr<DMatrix> ref,
+                                                         DataIterResetCallback* reset,
+                                                         XGDMatrixCallbackNext* next, float missing,
+                                                         int nthread, int max_bin);
 
 template DMatrix *DMatrix::Create<DataIterHandle, DMatrixHandle,
                                   DataIterResetCallback, XGDMatrixCallbackNext>(

--- a/src/data/iterative_dmatrix.cc
+++ b/src/data/iterative_dmatrix.cc
@@ -1,0 +1,214 @@
+/*!
+ * Copyright 2022 XGBoost contributors
+ */
+#include "iterative_dmatrix.h"
+
+#include <rabit/rabit.h>
+
+#include "../common/column_matrix.h"
+#include "../common/hist_util.h"
+#include "gradient_index.h"
+#include "proxy_dmatrix.h"
+#include "simple_batch_iterator.h"
+
+namespace xgboost {
+namespace data {
+
+void GetCutsFromRef(std::shared_ptr<DMatrix> ref_, bst_feature_t n_features, BatchParam p,
+                    common::HistogramCuts* p_cuts) {
+  CHECK(ref_);
+  CHECK(p_cuts);
+  auto csr = [&]() {
+    for (auto const& page : ref_->GetBatches<GHistIndexMatrix>(p)) {
+      *p_cuts = page.cut;
+      break;
+    }
+  };
+  auto ellpack = [&]() {
+    for (auto const& page : ref_->GetBatches<EllpackPage>(p)) {
+      GetCutsFromEllpack(page, p_cuts);
+      break;
+    }
+  };
+
+  if (ref_->PageExists<GHistIndexMatrix>()) {
+    csr();
+  } else if (ref_->PageExists<EllpackPage>()) {
+    ellpack();
+  } else {
+    if (p.gpu_id == Context::kCpuId) {
+      csr();
+    } else {
+      ellpack();
+    }
+  }
+  CHECK_EQ(ref_->Info().num_col_, n_features)
+      << "Invalid ref DMatrix, different number of features.";
+}
+
+void IterativeDMatrix::InitFromCPU(DataIterHandle iter_handle, float missing,
+                                   std::shared_ptr<DMatrix> ref) {
+  DMatrixProxy* proxy = MakeProxy(proxy_);
+  CHECK(proxy);
+
+  // The external iterator
+  auto iter =
+      DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>{iter_handle, reset_, next_};
+  common::HistogramCuts cuts;
+
+  auto num_rows = [&]() {
+    return HostAdapterDispatch(proxy, [](auto const& value) { return value.Size(); });
+  };
+  auto num_cols = [&]() {
+    return HostAdapterDispatch(proxy, [](auto const& value) { return value.NumCols(); });
+  };
+
+  std::vector<size_t> column_sizes;
+  auto const is_valid = data::IsValidFunctor{missing};
+  auto nnz_cnt = [&]() {
+    return HostAdapterDispatch(proxy, [&](auto const& value) {
+      size_t n_threads = ctx_.Threads();
+      size_t n_features = column_sizes.size();
+      linalg::Tensor<size_t, 2> column_sizes_tloc({n_threads, n_features}, Context::kCpuId);
+      auto view = column_sizes_tloc.HostView();
+      common::ParallelFor(value.Size(), n_threads, common::Sched::Static(256), [&](auto i) {
+        auto const& line = value.GetLine(i);
+        for (size_t j = 0; j < line.Size(); ++j) {
+          data::COOTuple const& elem = line.GetElement(j);
+          if (is_valid(elem)) {
+            view(omp_get_thread_num(), elem.column_idx)++;
+          }
+        }
+      });
+      auto ptr = column_sizes_tloc.Data()->HostPointer();
+      auto result = std::accumulate(ptr, ptr + column_sizes_tloc.Size(), static_cast<size_t>(0));
+      for (size_t tidx = 0; tidx < n_threads; ++tidx) {
+        for (size_t fidx = 0; fidx < n_features; ++fidx) {
+          column_sizes[fidx] += view(tidx, fidx);
+        }
+      }
+      return result;
+    });
+  };
+
+  size_t n_features = 0;
+  size_t n_batches = 0;
+  size_t accumulated_rows{0};
+  size_t nnz{0};
+
+  /**
+   * CPU impl needs an additional loop for accumulating the column size.
+   */
+  std::unique_ptr<common::HostSketchContainer> p_sketch;
+  std::vector<size_t> batch_nnz;
+  do {
+    // We use do while here as the first batch is fetched in ctor
+    if (n_features == 0) {
+      n_features = num_cols();
+      rabit::Allreduce<rabit::op::Max>(&n_features, 1);
+      column_sizes.resize(n_features);
+      info_.num_col_ = n_features;
+    } else {
+      CHECK_EQ(n_features, num_cols()) << "Inconsistent number of columns.";
+    }
+
+    size_t batch_size = num_rows();
+    batch_nnz.push_back(nnz_cnt());
+    nnz += batch_nnz.back();
+    accumulated_rows += batch_size;
+    n_batches++;
+  } while (iter.Next());
+  iter.Reset();
+
+  // From here on Info() has the correct data shape
+  Info().num_row_ = accumulated_rows;
+  Info().num_nonzero_ = nnz;
+  rabit::Allreduce<rabit::op::Max>(&info_.num_col_, 1);
+  CHECK(std::none_of(column_sizes.cbegin(), column_sizes.cend(), [&](auto f) {
+    return f > accumulated_rows;
+  })) << "Something went wrong during iteration.";
+
+  /**
+   * Generate quantiles
+   */
+  accumulated_rows = 0;
+  if (ref) {
+    GetCutsFromRef(ref, Info().num_col_, batch_param_, &cuts);
+  } else {
+    size_t i = 0;
+    while (iter.Next()) {
+      if (!p_sketch) {
+        p_sketch.reset(new common::HostSketchContainer{batch_param_.max_bin,
+                                                       proxy->Info().feature_types.ConstHostSpan(),
+                                                       column_sizes, false, ctx_.Threads()});
+      }
+      HostAdapterDispatch(proxy, [&](auto const& batch) {
+        proxy->Info().num_nonzero_ = batch_nnz[i];
+        // We don't need base row idx here as Info is from proxy and the number of rows in
+        // it is consistent with data batch.
+        p_sketch->PushAdapterBatch(batch, 0, proxy->Info(), missing);
+      });
+      accumulated_rows += num_rows();
+      ++i;
+    }
+    iter.Reset();
+    CHECK_EQ(accumulated_rows, Info().num_row_);
+
+    CHECK(p_sketch);
+    p_sketch->MakeCuts(&cuts);
+  }
+
+  /**
+   * Generate gradient index.
+   */
+  this->ghist_ = std::make_unique<GHistIndexMatrix>(Info(), std::move(cuts), batch_param_.max_bin);
+  size_t rbegin = 0;
+  size_t prev_sum = 0;
+  size_t i = 0;
+  while (iter.Next()) {
+    HostAdapterDispatch(proxy, [&](auto const& batch) {
+      proxy->Info().num_nonzero_ = batch_nnz[i];
+      this->ghist_->PushAdapterBatch(&ctx_, rbegin, prev_sum, batch, missing,
+                                     proxy->Info().feature_types.ConstHostSpan(),
+                                     batch_param_.sparse_thresh, Info().num_row_);
+    });
+    if (n_batches != 1) {
+      this->info_.Extend(std::move(proxy->Info()), false, true);
+    }
+    size_t batch_size = num_rows();
+    prev_sum = this->ghist_->row_ptr[rbegin + batch_size];
+    rbegin += batch_size;
+    ++i;
+  }
+  iter.Reset();
+  CHECK_EQ(rbegin, Info().num_row_);
+
+  /**
+   * Generate column matrix
+   */
+  accumulated_rows = 0;
+  while (iter.Next()) {
+    HostAdapterDispatch(proxy, [&](auto const& batch) {
+      this->ghist_->PushAdapterBatchColumns(&ctx_, batch, missing, accumulated_rows);
+    });
+    accumulated_rows += num_rows();
+  }
+  iter.Reset();
+  CHECK_EQ(accumulated_rows, Info().num_row_);
+
+  if (n_batches == 1) {
+    this->info_ = std::move(proxy->Info());
+    this->info_.num_nonzero_ = nnz;
+    CHECK_EQ(proxy->Info().labels.Size(), 0);
+  }
+}
+
+BatchSet<GHistIndexMatrix> IterativeDMatrix::GetGradientIndex(BatchParam const& param) {
+  CheckParam(param);
+  CHECK(ghist_) << "Not initialized with CPU data";
+  auto begin_iter =
+      BatchIterator<GHistIndexMatrix>(new SimpleBatchIteratorImpl<GHistIndexMatrix>(ghist_));
+  return BatchSet<GHistIndexMatrix>(begin_iter);
+}
+}  // namespace data
+}  // namespace xgboost

--- a/src/data/iterative_dmatrix.h
+++ b/src/data/iterative_dmatrix.h
@@ -5,45 +5,87 @@
 #ifndef XGBOOST_DATA_ITERATIVE_DMATRIX_H_
 #define XGBOOST_DATA_ITERATIVE_DMATRIX_H_
 
-#include <vector>
+#include <memory>
 #include <string>
 #include <utility>
-#include <memory>
+#include <vector>
 
-#include "xgboost/base.h"
-#include "xgboost/data.h"
-#include "xgboost/c_api.h"
 #include "proxy_dmatrix.h"
 #include "simple_batch_iterator.h"
+#include "xgboost/base.h"
+#include "xgboost/c_api.h"
+#include "xgboost/data.h"
 
 namespace xgboost {
+namespace common {
+class HistogramCuts;
+}
+
 namespace data {
 
 class IterativeDMatrix : public DMatrix {
   MetaInfo info_;
   Context ctx_;
   BatchParam batch_param_;
-  std::shared_ptr<EllpackPage> page_;
+  std::shared_ptr<EllpackPage> ellpack_;
+  std::shared_ptr<GHistIndexMatrix> ghist_;
 
   DMatrixHandle proxy_;
   DataIterResetCallback *reset_;
   XGDMatrixCallbackNext *next_;
 
- public:
-  void InitFromCUDA(DataIterHandle iter, float missing);
+  void CheckParam(BatchParam const &param) {
+    // FIXME(Jiamingy): https://github.com/dmlc/xgboost/issues/7976
+    if (param.max_bin != batch_param_.max_bin && param.max_bin != 0) {
+      LOG(WARNING) << "Inconsistent max_bin between Quantile DMatrix and Booster:" << param.max_bin
+                   << " vs. " << batch_param_.max_bin;
+    }
+    CHECK(!param.regen) << "Only `hist` and `gpu_hist` tree method can use `QuantileDMatrix`.";
+  }
+
+  template <typename Page>
+  static auto InvalidTreeMethod() {
+    LOG(FATAL) << "Only `hist` and `gpu_hist` tree method can use `QuantileDMatrix`.";
+    return BatchSet<Page>(BatchIterator<Page>(nullptr));
+  }
 
  public:
-  explicit IterativeDMatrix(DataIterHandle iter, DMatrixHandle proxy, DataIterResetCallback *reset,
-                            XGDMatrixCallbackNext *next, float missing, int nthread, int max_bin)
+  void InitFromCUDA(DataIterHandle iter, float missing, std::shared_ptr<DMatrix> ref);
+  void InitFromCPU(DataIterHandle iter_handle, float missing, std::shared_ptr<DMatrix> ref);
+
+ public:
+  explicit IterativeDMatrix(DataIterHandle iter_handle, DMatrixHandle proxy,
+                            std::shared_ptr<DMatrix> ref, DataIterResetCallback *reset,
+                            XGDMatrixCallbackNext *next, float missing, int nthread,
+                            bst_bin_t max_bin)
       : proxy_{proxy}, reset_{reset}, next_{next} {
-    batch_param_ = BatchParam{MakeProxy(proxy_)->DeviceIdx(), max_bin};
+    // fetch the first batch
+    auto iter =
+        DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>{iter_handle, reset_, next_};
+    iter.Reset();
+    bool valid = iter.Next();
+    CHECK(valid) << "Iterative DMatrix must have at least 1 batch.";
+
+    auto d = MakeProxy(proxy_)->DeviceIdx();
+    if (batch_param_.gpu_id != Context::kCpuId) {
+      CHECK_EQ(d, batch_param_.gpu_id) << "All batch should be on the same device.";
+    }
+    batch_param_ = BatchParam{d, max_bin};
+    batch_param_.sparse_thresh = 0.2;  // default from TrainParam
+
     ctx_.UpdateAllowUnknown(Args{{"nthread", std::to_string(nthread)}});
-    this->InitFromCUDA(iter, missing);
+    if (d == Context::kCpuId) {
+      this->InitFromCPU(iter_handle, missing, ref);
+    } else {
+      this->InitFromCUDA(iter_handle, missing, ref);
+    }
   }
   ~IterativeDMatrix() override = default;
 
-  bool EllpackExists() const override { return true; }
+  bool EllpackExists() const override { return static_cast<bool>(ellpack_); }
+  bool GHistIndexExists() const override { return static_cast<bool>(ghist_); }
   bool SparsePageExists() const override { return false; }
+
   DMatrix *Slice(common::Span<int32_t const>) override {
     LOG(FATAL) << "Slicing DMatrix is not supported for Quantile DMatrix.";
     return nullptr;
@@ -52,20 +94,13 @@ class IterativeDMatrix : public DMatrix {
     LOG(FATAL) << "Not implemented.";
     return BatchSet<SparsePage>(BatchIterator<SparsePage>(nullptr));
   }
-  BatchSet<CSCPage> GetColumnBatches() override {
-    LOG(FATAL) << "Not implemented.";
-    return BatchSet<CSCPage>(BatchIterator<CSCPage>(nullptr));
-  }
+  BatchSet<CSCPage> GetColumnBatches() override { return InvalidTreeMethod<CSCPage>(); }
   BatchSet<SortedCSCPage> GetSortedColumnBatches() override {
-    LOG(FATAL) << "Not implemented.";
-    return BatchSet<SortedCSCPage>(BatchIterator<SortedCSCPage>(nullptr));
+    return InvalidTreeMethod<SortedCSCPage>();
   }
-  BatchSet<GHistIndexMatrix> GetGradientIndex(const BatchParam&) override {
-    LOG(FATAL) << "Not implemented.";
-    return BatchSet<GHistIndexMatrix>(BatchIterator<GHistIndexMatrix>(nullptr));
-  }
+  BatchSet<GHistIndexMatrix> GetGradientIndex(BatchParam const &param) override;
 
-  BatchSet<EllpackPage> GetEllpackBatches(const BatchParam& param) override;
+  BatchSet<EllpackPage> GetEllpackBatches(const BatchParam &param) override;
 
   bool SingleColBlock() const override { return true; }
 
@@ -75,19 +110,33 @@ class IterativeDMatrix : public DMatrix {
   Context const *Ctx() const override { return &ctx_; }
 };
 
+/**
+ * \brief Get quantile cuts from reference Quantile DMatrix.
+ */
+void GetCutsFromRef(std::shared_ptr<DMatrix> ref_, bst_feature_t n_features, BatchParam p,
+                    common::HistogramCuts *p_cuts);
+/**
+ * \brief Get quantile cuts from ellpack page.
+ */
+void GetCutsFromEllpack(EllpackPage const &page, common::HistogramCuts *cuts);
+
 #if !defined(XGBOOST_USE_CUDA)
-inline void IterativeDMatrix::InitFromCUDA(DataIterHandle iter, float missing) {
+inline void IterativeDMatrix::InitFromCUDA(DataIterHandle iter, float missing,
+                                           std::shared_ptr<DMatrix> ref) {
   // silent the warning about unused variables.
   (void)(proxy_);
   (void)(reset_);
   (void)(next_);
   common::AssertGPUSupport();
 }
-inline BatchSet<EllpackPage> IterativeDMatrix::GetEllpackBatches(const BatchParam& param) {
+inline BatchSet<EllpackPage> IterativeDMatrix::GetEllpackBatches(const BatchParam &param) {
   common::AssertGPUSupport();
-  auto begin_iter =
-      BatchIterator<EllpackPage>(new SimpleBatchIteratorImpl<EllpackPage>(page_));
+  auto begin_iter = BatchIterator<EllpackPage>(new SimpleBatchIteratorImpl<EllpackPage>(ellpack_));
   return BatchSet<EllpackPage>(BatchIterator<EllpackPage>(begin_iter));
+}
+
+inline void GetCutsFromEllpack(EllpackPage const &, common::HistogramCuts *) {
+  common::AssertGPUSupport();
 }
 #endif  // !defined(XGBOOST_USE_CUDA)
 }  // namespace data

--- a/src/data/proxy_dmatrix.cc
+++ b/src/data/proxy_dmatrix.cc
@@ -8,22 +8,22 @@
 namespace xgboost {
 namespace data {
 void DMatrixProxy::SetArrayData(char const *c_interface) {
-  std::shared_ptr<ArrayAdapter> adapter{
-      new ArrayAdapter(StringView{c_interface})};
+  std::shared_ptr<ArrayAdapter> adapter{new ArrayAdapter(StringView{c_interface})};
   this->batch_ = adapter;
   this->Info().num_col_ = adapter->NumColumns();
   this->Info().num_row_ = adapter->NumRows();
+  this->ctx_.gpu_id = Context::kCpuId;
 }
 
 void DMatrixProxy::SetCSRData(char const *c_indptr, char const *c_indices,
                               char const *c_values, bst_feature_t n_features, bool on_host) {
   CHECK(on_host) << "Not implemented on device.";
-  std::shared_ptr<CSRArrayAdapter> adapter{
-      new CSRArrayAdapter(StringView{c_indptr}, StringView{c_indices},
-                          StringView{c_values}, n_features)};
+  std::shared_ptr<CSRArrayAdapter> adapter{new CSRArrayAdapter(
+      StringView{c_indptr}, StringView{c_indices}, StringView{c_values}, n_features)};
   this->batch_ = adapter;
   this->Info().num_col_ = adapter->NumColumns();
   this->Info().num_row_ = adapter->NumRows();
+  this->ctx_.gpu_id = Context::kCpuId;
 }
 }  // namespace data
 }  // namespace xgboost

--- a/src/data/proxy_dmatrix.cu
+++ b/src/data/proxy_dmatrix.cu
@@ -16,6 +16,7 @@ void DMatrixProxy::FromCudaColumnar(StringView interface_str) {
   this->Info().num_row_ = adapter->NumRows();
   if (ctx_.gpu_id < 0) {
     CHECK_EQ(this->Info().num_row_, 0);
+    ctx_.gpu_id = dh::CurrentDevice();
   }
 }
 
@@ -27,6 +28,7 @@ void DMatrixProxy::FromCudaArray(StringView interface_str) {
   this->Info().num_row_ = adapter->NumRows();
   if (ctx_.gpu_id < 0) {
     CHECK_EQ(this->Info().num_row_, 0);
+    ctx_.gpu_id = dh::CurrentDevice();
   }
 }
 }  // namespace data

--- a/src/data/proxy_dmatrix.h
+++ b/src/data/proxy_dmatrix.h
@@ -65,9 +65,6 @@ class DMatrixProxy : public DMatrix {
     } else {
       this->FromCudaArray(interface_str);
     }
-    if (this->info_.num_row_ == 0) {
-      this->ctx_.gpu_id = Context::kCpuId;
-    }
 #endif  // defined(XGBOOST_USE_CUDA)
   }
 
@@ -80,9 +77,11 @@ class DMatrixProxy : public DMatrix {
   MetaInfo const& Info() const override { return info_; }
   Context const* Ctx() const override { return &ctx_; }
 
-  bool SingleColBlock() const override { return true; }
-  bool EllpackExists() const override { return true; }
+  bool SingleColBlock() const override { return false; }
+  bool EllpackExists() const override { return false; }
+  bool GHistIndexExists() const override { return false; }
   bool SparsePageExists() const override { return false; }
+
   DMatrix* Slice(common::Span<int32_t const> /*ridxs*/) override {
     LOG(FATAL) << "Slicing DMatrix is not supported for Proxy DMatrix.";
     return nullptr;

--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -55,12 +55,9 @@ class SimpleDMatrix : public DMatrix {
   std::shared_ptr<GHistIndexMatrix> gradient_index_{nullptr};
   BatchParam batch_param_;
 
-  bool EllpackExists() const override {
-    return static_cast<bool>(ellpack_page_);
-  }
-  bool SparsePageExists() const override {
-    return true;
-  }
+  bool EllpackExists() const override { return static_cast<bool>(ellpack_page_); }
+  bool GHistIndexExists() const override { return static_cast<bool>(gradient_index_); }
+  bool SparsePageExists() const override { return true; }
 
  private:
   Context ctx_;

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -120,15 +120,11 @@ class SparsePageDMatrix : public DMatrix {
   std::shared_ptr<EllpackPageSource> ellpack_page_source_;
   std::shared_ptr<CSCPageSource> column_source_;
   std::shared_ptr<SortedCSCPageSource> sorted_column_source_;
-  std::shared_ptr<GHistIndexMatrix> ghist_index_page_;  // hist
   std::shared_ptr<GradientIndexPageSource> ghist_index_source_;
 
-  bool EllpackExists() const override {
-    return static_cast<bool>(ellpack_page_source_);
-  }
-  bool SparsePageExists() const override {
-    return static_cast<bool>(sparse_page_source_);
-  }
+  bool EllpackExists() const override { return static_cast<bool>(ellpack_page_source_); }
+  bool GHistIndexExists() const override { return static_cast<bool>(ghist_index_source_); }
+  bool SparsePageExists() const override { return static_cast<bool>(sparse_page_source_); }
 };
 
 inline std::string MakeId(std::string prefix, SparsePageDMatrix *ptr) {

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -149,10 +149,10 @@ struct SparsePageLoader {
 
 struct EllpackLoader {
   EllpackDeviceAccessor const& matrix;
-  XGBOOST_DEVICE EllpackLoader(EllpackDeviceAccessor const& m, bool,
-                               bst_feature_t, bst_row_t, size_t, float)
+  XGBOOST_DEVICE EllpackLoader(EllpackDeviceAccessor const& m, bool, bst_feature_t, bst_row_t,
+                               size_t, float)
       : matrix{m} {}
-  __device__ __forceinline__ float GetElement(size_t  ridx, size_t  fidx) const {
+  __device__ __forceinline__ float GetElement(size_t ridx, size_t fidx) const {
     auto gidx = matrix.GetBinIndex(ridx, fidx);
     if (gidx == -1) {
       return nan("");

--- a/tests/cpp/data/test_iterative_dmatrix.cc
+++ b/tests/cpp/data/test_iterative_dmatrix.cc
@@ -1,0 +1,36 @@
+/*!
+ * Copyright 2022 XGBoost contributors
+ */
+#include "test_iterative_dmatrix.h"
+
+#include <gtest/gtest.h>
+
+#include "../../../src/data/gradient_index.h"
+#include "../../../src/data/iterative_dmatrix.h"
+#include "../helpers.h"
+
+namespace xgboost {
+namespace data {
+TEST(IterativeDMatrix, Ref) {
+  TestRefDMatrix<GHistIndexMatrix, NumpyArrayIterForTest>(
+      [&](GHistIndexMatrix const& page) { return page.cut; });
+}
+
+TEST(IterativeDMatrix, IsDense) {
+  int n_bins = 16;
+  auto test = [n_bins](float sparsity) {
+    NumpyArrayIterForTest iter(sparsity);
+    IterativeDMatrix m(&iter, iter.Proxy(), nullptr, Reset, Next,
+                       std::numeric_limits<float>::quiet_NaN(), 0, n_bins);
+    if (sparsity == 0.0) {
+      ASSERT_TRUE(m.IsDense());
+    } else {
+      ASSERT_FALSE(m.IsDense());
+    }
+  };
+  test(0.0);
+  test(0.1);
+  test(1.0);
+}
+}  // namespace data
+}  // namespace xgboost

--- a/tests/cpp/data/test_iterative_dmatrix.h
+++ b/tests/cpp/data/test_iterative_dmatrix.h
@@ -1,0 +1,59 @@
+/*!
+ * Copyright 2022 XGBoost contributors
+ */
+#pragma once
+#include <memory>  // std::make_shared
+
+#include "../../../src/data/iterative_dmatrix.h"
+#include "../helpers.h"
+
+namespace xgboost {
+namespace data {
+template <typename Page, typename Iter, typename Cuts>
+void TestRefDMatrix(Cuts&& get_cuts) {
+  int n_bins = 256;
+  Iter iter(0.3, 2048);
+  auto m = std::make_shared<IterativeDMatrix>(&iter, iter.Proxy(), nullptr, Reset, Next,
+                                              std::numeric_limits<float>::quiet_NaN(), 0, n_bins);
+
+  Iter iter_1(0.8, 32, Iter::Cols(), 13);
+  auto m_1 = std::make_shared<IterativeDMatrix>(&iter_1, iter_1.Proxy(), m, Reset, Next,
+                                                std::numeric_limits<float>::quiet_NaN(), 0, n_bins);
+
+  for (auto const& page_0 : m->template GetBatches<Page>({})) {
+    for (auto const& page_1 : m_1->template GetBatches<Page>({})) {
+      auto const& cuts_0 = get_cuts(page_0);
+      auto const& cuts_1 = get_cuts(page_1);
+      ASSERT_EQ(cuts_0.Values(), cuts_1.Values());
+      ASSERT_EQ(cuts_0.Ptrs(), cuts_1.Ptrs());
+      ASSERT_EQ(cuts_0.MinValues(), cuts_1.MinValues());
+    }
+  }
+
+  m_1 = std::make_shared<IterativeDMatrix>(&iter_1, iter_1.Proxy(), nullptr, Reset, Next,
+                                           std::numeric_limits<float>::quiet_NaN(), 0, n_bins);
+  for (auto const& page_0 : m->template GetBatches<Page>({})) {
+    for (auto const& page_1 : m_1->template GetBatches<Page>({})) {
+      auto const& cuts_0 = get_cuts(page_0);
+      auto const& cuts_1 = get_cuts(page_1);
+      ASSERT_NE(cuts_0.Values(), cuts_1.Values());
+      ASSERT_NE(cuts_0.Ptrs(), cuts_1.Ptrs());
+    }
+  }
+
+  // Use DMatrix as ref
+  auto dm = RandomDataGenerator(2048, Iter::Cols(), 0.5).GenerateDMatrix(true);
+  auto dqm = std::make_shared<IterativeDMatrix>(&iter_1, iter_1.Proxy(), dm, Reset, Next,
+                                                std::numeric_limits<float>::quiet_NaN(), 0, n_bins);
+  for (auto const& page_0 : dm->template GetBatches<Page>({})) {
+    for (auto const& page_1 : dqm->template GetBatches<Page>({})) {
+      auto const& cuts_0 = get_cuts(page_0);
+      auto const& cuts_1 = get_cuts(page_1);
+      ASSERT_EQ(cuts_0.Values(), cuts_1.Values());
+      ASSERT_EQ(cuts_0.Ptrs(), cuts_1.Ptrs());
+      ASSERT_EQ(cuts_0.MinValues(), cuts_1.MinValues());
+    }
+  }
+}
+}  // namespace data
+}  // namespace xgboost

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -384,7 +384,7 @@ RandomDataGenerator::GenerateDMatrix(bool with_label, bool float_label,
 std::shared_ptr<DMatrix> RandomDataGenerator::GenerateQuantileDMatrix() {
   NumpyArrayIterForTest iter{this->sparsity_, this->rows_, this->cols_, 1};
   auto m = std::make_shared<data::IterativeDMatrix>(
-      &iter, iter.Proxy(), Reset, Next, std::numeric_limits<float>::quiet_NaN(), 0, bins_);
+      &iter, iter.Proxy(), nullptr, Reset, Next, std::numeric_limits<float>::quiet_NaN(), 0, bins_);
   return m;
 }
 
@@ -569,7 +569,7 @@ std::unique_ptr<GradientBooster> CreateTrainedGBM(
   auto& h_gpair = gpair.HostVector();
   h_gpair.resize(kRows);
   for (size_t i = 0; i < kRows; ++i) {
-    h_gpair[i] = {static_cast<float>(i), 1};
+    h_gpair[i] = GradientPair{static_cast<float>(i), 1};
   }
 
   PredictionCacheEntry predts;

--- a/tests/cpp/helpers.cu
+++ b/tests/cpp/helpers.cu
@@ -27,7 +27,7 @@ int CudaArrayIterForTest::Next() {
 std::shared_ptr<DMatrix> RandomDataGenerator::GenerateDeviceDMatrix() {
   CudaArrayIterForTest iter{this->sparsity_, this->rows_, this->cols_, 1};
   auto m = std::make_shared<data::IterativeDMatrix>(
-      &iter, iter.Proxy(), Reset, Next, std::numeric_limits<float>::quiet_NaN(), 0, bins_);
+      &iter, iter.Proxy(), nullptr, Reset, Next, std::numeric_limits<float>::quiet_NaN(), 0, bins_);
   return m;
 }
 }  // namespace xgboost

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -245,6 +245,17 @@ void TestUpdatePredictionCache(bool use_subsampling) {
   }
 }
 
+TEST(CPUPredictor, GHistIndex) {
+  size_t constexpr kRows{128}, kCols{16}, kBins{64};
+  auto p_hist = RandomDataGenerator{kRows, kCols, 0.0}.Bins(kBins).GenerateQuantileDMatrix();
+  HostDeviceVector<float> storage(kRows * kCols);
+  auto columnar = RandomDataGenerator{kRows, kCols, 0.0}.GenerateArrayInterface(&storage);
+  auto adapter = data::ArrayAdapter(columnar.c_str());
+  std::shared_ptr<DMatrix> p_full{
+      DMatrix::Create(&adapter, std::numeric_limits<float>::quiet_NaN(), 1)};
+  TestTrainingPrediction(kRows, kBins, "hist", p_full, p_hist);
+}
+
 TEST(CPUPredictor, CategoricalPrediction) {
   TestCategoricalPrediction("cpu_predictor");
 }


### PR DESCRIPTION
Extracted from https://github.com/dmlc/xgboost/pull/8050 .

- Implement IterativeDMatrix for CPU.
- Add reference DMatrix (usually the training DMatrix), which allows evaluation DMatrix to reuse the quantile cuts.