### PR TITLE
In PySpark Estimator example use the model with validation_indicator

### DIFF
--- a/demo/guide-python/spark_estimator_examples.py
+++ b/demo/guide-python/spark_estimator_examples.py
@@ -75,7 +75,7 @@ iris_train_spark_df2 = iris_train_spark_df.withColumn(
 
 # train xgboost classifier model with validation dataset
 xgb_classifier2 = SparkXGBClassifier(max_depth=5, validation_indicator_col="validationIndicatorCol")
-xgb_classifier_model2 = xgb_classifier.fit(iris_train_spark_df2)
+xgb_classifier_model2 = xgb_classifier2.fit(iris_train_spark_df2)
 transformed_iris_test_spark_df2 = xgb_classifier_model2.transform(iris_test_spark_df)
 print(f"classifier2 f1={classifier_evaluator.evaluate(transformed_iris_test_spark_df2)}")
 

--- a/demo/guide-python/spark_estimator_examples.py
+++ b/demo/guide-python/spark_estimator_examples.py
@@ -48,7 +48,7 @@ diabetes_train_spark_df2 = diabetes_train_spark_df.withColumn(
 
 # train xgboost regressor model with validation dataset
 xgb_regressor2 = SparkXGBRegressor(max_depth=5, validation_indicator_col="validationIndicatorCol")
-xgb_regressor_model2 = xgb_regressor.fit(diabetes_train_spark_df2)
+xgb_regressor_model2 = xgb_regressor2.fit(diabetes_train_spark_df2)
 transformed_diabetes_test_spark_df2 = xgb_regressor_model2.transform(diabetes_test_spark_df)
 print(f"regressor2 rmse={regressor_evaluator.evaluate(transformed_diabetes_test_spark_df2)}")
 


### PR DESCRIPTION
The example was not using `xgb_regressor2` or `xgb_classifier2` which actually has `validation_indicator_col` property defined.