### PR TITLE
[WIP] Use `config_context` for device configuration.

### DIFF
--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -28,7 +28,7 @@ class Json;
 class FeatureMap;
 class ObjFunction;
 
-struct GenericParameter;
+struct Context;
 struct LearnerModelParam;
 struct PredictionCacheEntry;
 class PredictionContainer;
@@ -38,8 +38,8 @@ class PredictionContainer;
  */
 class GradientBooster : public Model, public Configurable {
  protected:
-  GenericParameter const* ctx_;
-  explicit GradientBooster(GenericParameter const* ctx) : ctx_{ctx} {}
+  Context const* ctx_;
+  explicit GradientBooster(Context const* ctx) : ctx_{ctx} {}
 
  public:
   /*! \brief virtual destructor */
@@ -177,21 +177,16 @@ class GradientBooster : public Model, public Configurable {
                             common::Span<int32_t const> trees,
                             std::vector<bst_feature_t>* features,
                             std::vector<float>* scores) const = 0;
-  /*!
-   * \brief Whether the current booster uses GPU.
-   */
-  virtual bool UseGPU() const = 0;
+
   /*!
    * \brief create a gradient booster from given name
    * \param name name of gradient booster
-   * \param generic_param Pointer to runtime parameters
+   * \param ctx Pointer to runtime parameters
    * \param learner_model_param pointer to global model parameters
    * \return The created booster.
    */
-  static GradientBooster* Create(
-      const std::string& name,
-      GenericParameter const* generic_param,
-      LearnerModelParam const* learner_model_param);
+  static GradientBooster* Create(const std::string& name, Context const* ctx,
+                                 LearnerModelParam const* learner_model_param);
 };
 
 /*!
@@ -201,7 +196,7 @@ struct GradientBoosterReg
     : public dmlc::FunctionRegEntryBase<
           GradientBoosterReg,
           std::function<GradientBooster*(LearnerModelParam const* learner_model_param,
-                                         GenericParameter const* ctx)> > {};
+                                         Context const* ctx)> > {};
 
 /*!
  * \brief Macro to register gradient booster.

--- a/include/xgboost/generic_parameters.h
+++ b/include/xgboost/generic_parameters.h
@@ -12,7 +12,7 @@
 
 namespace xgboost {
 
-struct GenericParameter : public XGBoostParameter<GenericParameter> {
+struct Context : public XGBoostParameter<Context> {
  private:
   // cached value for CFS CPU limit. (used in containerized env)
   int32_t cfs_cpu_count_;  // NOLINT
@@ -23,7 +23,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
   static int64_t constexpr kDefaultSeed = 0;
 
  public:
-  GenericParameter();
+  Context() noexcept(false);
 
   // stored random seed
   int64_t seed { kDefaultSeed };
@@ -40,19 +40,18 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
 
   /*!
    * \brief Configure the parameter `gpu_id'.
-   *
-   * \param require_gpu  Whether GPU is explicitly required from user.
    */
-  void ConfigureGpuId(bool require_gpu);
+  void ConfigureGpuId();
   /*!
    * Return automatically chosen threads.
    */
   int32_t Threads() const;
 
   bool IsCPU() const { return gpu_id == kCpuId; }
+  bool IsCUDA() const { return !IsCPU(); }
 
   // declare parameters
-  DMLC_DECLARE_PARAMETER(GenericParameter) {
+  DMLC_DECLARE_PARAMETER(Context) {
     DMLC_DECLARE_FIELD(seed).set_default(kDefaultSeed).describe(
         "Random number seed during training.");
     DMLC_DECLARE_ALIAS(seed, random_state);
@@ -62,11 +61,6 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
     DMLC_DECLARE_FIELD(nthread).set_default(0).describe(
         "Number of threads to use.");
     DMLC_DECLARE_ALIAS(nthread, n_jobs);
-
-    DMLC_DECLARE_FIELD(gpu_id)
-        .set_default(-1)
-        .set_lower_bound(-1)
-        .describe("The primary GPU device ordinal.");
     DMLC_DECLARE_FIELD(fail_on_invalid_gpu_id)
         .set_default(false)
         .describe("Fail with error when gpu_id is invalid.");
@@ -76,7 +70,7 @@ struct GenericParameter : public XGBoostParameter<GenericParameter> {
   }
 };
 
-using Context = GenericParameter;
+using GenericParameter = Context;
 }  // namespace xgboost
 
 #endif  // XGBOOST_GENERIC_PARAMETERS_H_

--- a/include/xgboost/global_config.h
+++ b/include/xgboost/global_config.h
@@ -7,9 +7,11 @@
 #ifndef XGBOOST_GLOBAL_CONFIG_H_
 #define XGBOOST_GLOBAL_CONFIG_H_
 
+#include <dmlc/thread_local.h>
 #include <xgboost/parameter.h>
-#include <vector>
+
 #include <string>
+#include <vector>
 
 namespace xgboost {
 class Json;
@@ -17,6 +19,7 @@ class Json;
 struct GlobalConfiguration : public XGBoostParameter<GlobalConfiguration> {
   int verbosity { 1 };
   bool use_rmm { false };
+  std::string device{"CPU"};
   DMLC_DECLARE_PARAMETER(GlobalConfiguration) {
     DMLC_DECLARE_FIELD(verbosity)
         .set_range(0, 3)
@@ -25,6 +28,9 @@ struct GlobalConfiguration : public XGBoostParameter<GlobalConfiguration> {
     DMLC_DECLARE_FIELD(use_rmm)
         .set_default(false)
         .describe("Whether to use RAPIDS Memory Manager to allocate GPU memory in XGBoost");
+    DMLC_DECLARE_FIELD(device)
+        .set_default("CPU")
+        .describe("Device to run on. Can be CPU or CUDA:<ordinal>.");
   }
 };
 

--- a/include/xgboost/global_config.h
+++ b/include/xgboost/global_config.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020 by Contributors
+ * Copyright 2020-2022 by Contributors
  * \file global_config.h
  * \brief Global configuration for XGBoost
  * \author Hyunsu Cho
@@ -7,6 +7,7 @@
 #ifndef XGBOOST_GLOBAL_CONFIG_H_
 #define XGBOOST_GLOBAL_CONFIG_H_
 
+#include <dmlc/optional.h>
 #include <dmlc/thread_local.h>
 #include <xgboost/parameter.h>
 
@@ -17,19 +18,19 @@ namespace xgboost {
 class Json;
 
 struct GlobalConfiguration : public XGBoostParameter<GlobalConfiguration> {
-  int verbosity { 1 };
-  bool use_rmm { false };
-  std::string device{"CPU"};
+  int verbosity{1};
+  bool use_rmm{false};
+  dmlc::optional<std::string> device{dmlc::nullopt};
+
   DMLC_DECLARE_PARAMETER(GlobalConfiguration) {
     DMLC_DECLARE_FIELD(verbosity)
         .set_range(0, 3)
         .set_default(1)  // shows only warning
         .describe("Flag to print out detailed breakdown of runtime.");
-    DMLC_DECLARE_FIELD(use_rmm)
-        .set_default(false)
-        .describe("Whether to use RAPIDS Memory Manager to allocate GPU memory in XGBoost");
+    DMLC_DECLARE_FIELD(use_rmm).set_default(false).describe(
+        "Whether to use RAPIDS Memory Manager to allocate GPU memory in XGBoost");
     DMLC_DECLARE_FIELD(device)
-        .set_default("CPU")
+        .set_default(dmlc::nullopt)
         .describe("Device to run on. Can be CPU or CUDA:<ordinal>.");
   }
 };

--- a/include/xgboost/global_config.h
+++ b/include/xgboost/global_config.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020-2022 by Contributors
+ * Copyright 2020 by Contributors
  * \file global_config.h
  * \brief Global configuration for XGBoost
  * \author Hyunsu Cho
@@ -7,7 +7,6 @@
 #ifndef XGBOOST_GLOBAL_CONFIG_H_
 #define XGBOOST_GLOBAL_CONFIG_H_
 
-#include <dmlc/optional.h>
 #include <dmlc/thread_local.h>
 #include <xgboost/parameter.h>
 
@@ -18,19 +17,19 @@ namespace xgboost {
 class Json;
 
 struct GlobalConfiguration : public XGBoostParameter<GlobalConfiguration> {
-  int verbosity{1};
-  bool use_rmm{false};
-  dmlc::optional<std::string> device{dmlc::nullopt};
-
+  int verbosity { 1 };
+  bool use_rmm { false };
+  std::string device{"CPU"};
   DMLC_DECLARE_PARAMETER(GlobalConfiguration) {
     DMLC_DECLARE_FIELD(verbosity)
         .set_range(0, 3)
         .set_default(1)  // shows only warning
         .describe("Flag to print out detailed breakdown of runtime.");
-    DMLC_DECLARE_FIELD(use_rmm).set_default(false).describe(
-        "Whether to use RAPIDS Memory Manager to allocate GPU memory in XGBoost");
+    DMLC_DECLARE_FIELD(use_rmm)
+        .set_default(false)
+        .describe("Whether to use RAPIDS Memory Manager to allocate GPU memory in XGBoost");
     DMLC_DECLARE_FIELD(device)
-        .set_default(dmlc::nullopt)
+        .set_default("CPU")
         .describe("Device to run on. Can be CPU or CUDA:<ordinal>.");
   }
 };

--- a/python-package/xgboost/testing.py
+++ b/python-package/xgboost/testing.py
@@ -1,0 +1,16 @@
+from functools import wraps
+from typing import Any, Callable
+
+from ._typing import _T
+from .config import config_context
+
+
+def with_cuda_test(fn: Callable[..., _T]) -> Callable[..., _T]:
+    """Annotate a test to use CUDA."""
+
+    @wraps(fn)
+    def inner_fn(*args: Any, **kwargs: Any) -> _T:
+        with config_context(device="CUDA:0"):
+            return fn(*args, **kwargs)
+
+    return inner_fn

--- a/src/context.cc
+++ b/src/context.cc
@@ -1,0 +1,88 @@
+#include <cctype>  // std::tolower
+#include <string>
+
+#include "common/common.h"
+#include "common/threading_utils.h"
+#include "xgboost/generic_parameters.h"
+#include "xgboost/global_config.h"
+#include "xgboost/string_view.h"
+
+namespace xgboost {
+int32_t constexpr Context::kCpuId;
+int64_t constexpr Context::kDefaultSeed;
+
+Context::Context() noexcept(false) : cfs_cpu_count_{common::GetCfsCPUCount()} {
+  StringView msg{R"(Invalid argument for `device`. Expected to be one of the following:
+- CPU
+- CUDA
+- CUDA:<device ordinal>
+)"};
+  auto original = GlobalConfigThreadLocalStore::Get()->device;
+  std::string device = original;
+  std::transform(device.cbegin(), device.cend(), device.begin(),
+                 [](auto c) { return std::tolower(c); });
+  auto split_it = std::find(device.cbegin(), device.cend(), ':');
+  gpu_id = -2;  // mark it invalid for check.
+  if (split_it == device.cend()) {
+    // no ordinal.
+    if (device == "cpu") {
+      gpu_id = kCpuId;
+    } else if (device == "cuda") {
+      gpu_id = 0;  // use 0 as default;
+    } else {
+      LOG(FATAL) << msg << "Got: " << original;
+    }
+  } else {
+    // must be CUDA when ordinal is specifed.
+    auto splited = common::Split(device, ':');
+    CHECK_EQ(splited.size(), 2) << msg;
+    device = splited[0];
+    CHECK_EQ(device, "cuda") << msg << "Got: " << original;
+
+    // boost::lexical_cast should be used instead, but for now some basic checks will do
+    auto ordinal = splited[1];
+    CHECK_GE(ordinal.size(), 1) << msg << "Got: " << original;
+    CHECK(std::isdigit(ordinal.front())) << msg << "Got: " << original;
+    try {
+      gpu_id = std::stoi(splited[1]);
+    } catch (std::exception const& e) {
+      LOG(FATAL) << msg << "Got: " << original;
+    }
+  }
+  CHECK_GE(gpu_id, kCpuId) << msg;
+}
+
+void Context::ConfigureGpuId() {
+#if defined(XGBOOST_USE_CUDA)
+  // 3. When booster is loaded from a memory image (Python pickle or R
+  // raw model), number of available GPUs could be different.  Wrap around it.
+  int32_t n_gpus = common::AllVisibleGPUs();
+  if (n_gpus == 0) {
+    if (gpu_id != kCpuId) {
+      LOG(WARNING) << "No visible GPU is found, setting `gpu_id` to -1";
+    }
+    this->UpdateAllowUnknown(Args{{"gpu_id", std::to_string(kCpuId)}});
+  } else if (fail_on_invalid_gpu_id) {
+    CHECK(gpu_id == kCpuId || gpu_id < n_gpus)
+        << "Only " << n_gpus << " GPUs are visible, gpu_id " << gpu_id << " is invalid.";
+  } else if (gpu_id != kCpuId && gpu_id >= n_gpus) {
+    LOG(WARNING) << "Only " << n_gpus << " GPUs are visible, setting `gpu_id` to "
+                 << gpu_id % n_gpus;
+    this->UpdateAllowUnknown(Args{{"gpu_id", std::to_string(gpu_id % n_gpus)}});
+  }
+#else
+  // Just set it to CPU, don't think about it.
+  this->UpdateAllowUnknown(Args{{"gpu_id", std::to_string(kCpuId)}});
+#endif  // defined(XGBOOST_USE_CUDA)
+}
+
+int32_t Context::Threads() const {
+  auto n_threads = common::OmpGetNumThreads(nthread);
+  if (cfs_cpu_count_ > 0) {
+    n_threads = std::min(n_threads, cfs_cpu_count_);
+  }
+  return n_threads;
+}
+
+DMLC_REGISTER_PARAMETER(Context);
+}  // namespace xgboost

--- a/src/context.cc
+++ b/src/context.cc
@@ -1,3 +1,6 @@
+/**
+ * \brief Configuration for creating context.
+ */
 #include <cctype>  // std::tolower
 #include <string>
 
@@ -18,7 +21,10 @@ Context::Context() noexcept(false) : cfs_cpu_count_{common::GetCfsCPUCount()} {
 - CUDA:<device ordinal>
 )"};
   auto original = GlobalConfigThreadLocalStore::Get()->device;
-  std::string device = original;
+  std::string device{"CPU"};
+  if (original.has_value()) {
+    device = original.value();
+  }
   std::transform(device.cbegin(), device.cend(), device.begin(),
                  [](auto c) { return std::tolower(c); });
   auto split_it = std::find(device.cbegin(), device.cend(), ':');

--- a/src/context.cc
+++ b/src/context.cc
@@ -1,6 +1,3 @@
-/**
- * \brief Configuration for creating context.
- */
 #include <cctype>  // std::tolower
 #include <string>
 
@@ -21,10 +18,7 @@ Context::Context() noexcept(false) : cfs_cpu_count_{common::GetCfsCPUCount()} {
 - CUDA:<device ordinal>
 )"};
   auto original = GlobalConfigThreadLocalStore::Get()->device;
-  std::string device{"CPU"};
-  if (original.has_value()) {
-    device = original.value();
-  }
+  std::string device = original;
   std::transform(device.cbegin(), device.cend(), device.begin(),
                  [](auto c) { return std::tolower(c); });
   auto split_it = std::find(device.cbegin(), device.cend(), ':');

--- a/src/data/array_interface.h
+++ b/src/data/array_interface.h
@@ -345,8 +345,8 @@ struct ToDType<int64_t> {
 };
 
 #if !defined(XGBOOST_USE_CUDA)
-inline void ArrayInterfaceHandler::SyncCudaStream(int64_t stream) { common::AssertGPUSupport(); }
-inline bool ArrayInterfaceHandler::IsCudaPtr(void const *ptr) { return false; }
+inline void ArrayInterfaceHandler::SyncCudaStream(int64_t) { common::AssertGPUSupport(); }
+inline bool ArrayInterfaceHandler::IsCudaPtr(void const *) { return false; }
 #endif  // !defined(XGBOOST_USE_CUDA)
 
 /**

--- a/src/data/iterative_dmatrix.h
+++ b/src/data/iterative_dmatrix.h
@@ -121,15 +121,14 @@ void GetCutsFromRef(std::shared_ptr<DMatrix> ref_, bst_feature_t n_features, Bat
 void GetCutsFromEllpack(EllpackPage const &page, common::HistogramCuts *cuts);
 
 #if !defined(XGBOOST_USE_CUDA)
-inline void IterativeDMatrix::InitFromCUDA(DataIterHandle iter, float missing,
-                                           std::shared_ptr<DMatrix> ref) {
+inline void IterativeDMatrix::InitFromCUDA(DataIterHandle, float, std::shared_ptr<DMatrix>) {
   // silent the warning about unused variables.
   (void)(proxy_);
   (void)(reset_);
   (void)(next_);
   common::AssertGPUSupport();
 }
-inline BatchSet<EllpackPage> IterativeDMatrix::GetEllpackBatches(const BatchParam &param) {
+inline BatchSet<EllpackPage> IterativeDMatrix::GetEllpackBatches(const BatchParam &) {
   common::AssertGPUSupport();
   auto begin_iter = BatchIterator<EllpackPage>(new SimpleBatchIteratorImpl<EllpackPage>(ellpack_));
   return BatchSet<EllpackPage>(BatchIterator<EllpackPage>(begin_iter));

--- a/src/data/proxy_dmatrix.cc
+++ b/src/data/proxy_dmatrix.cc
@@ -7,6 +7,21 @@
 
 namespace xgboost {
 namespace data {
+void DMatrixProxy::SetCUDAArray(char const *c_interface) {
+  common::AssertGPUSupport();
+#if defined(XGBOOST_USE_CUDA)
+  StringView interface_str{c_interface};
+  Json json_array_interface = Json::Load(interface_str);
+  if (IsA<Array>(json_array_interface)) {
+    this->FromCudaColumnar(interface_str);
+  } else {
+    this->FromCudaArray(interface_str);
+  }
+#else
+  (void*)c_interface;
+#endif  // defined(XGBOOST_USE_CUDA)
+}
+
 void DMatrixProxy::SetArrayData(char const *c_interface) {
   std::shared_ptr<ArrayAdapter> adapter{new ArrayAdapter(StringView{c_interface})};
   this->batch_ = adapter;

--- a/src/data/proxy_dmatrix.h
+++ b/src/data/proxy_dmatrix.h
@@ -55,23 +55,10 @@ class DMatrixProxy : public DMatrix {
  public:
   int DeviceIdx() const { return ctx_.gpu_id; }
 
-  void SetCUDAArray(char const* c_interface) {
-    common::AssertGPUSupport();
-#if defined(XGBOOST_USE_CUDA)
-    StringView interface_str{c_interface};
-    Json json_array_interface = Json::Load(interface_str);
-    if (IsA<Array>(json_array_interface)) {
-      this->FromCudaColumnar(interface_str);
-    } else {
-      this->FromCudaArray(interface_str);
-    }
-#endif  // defined(XGBOOST_USE_CUDA)
-  }
-
+  void SetCUDAArray(char const* c_interface);
   void SetArrayData(char const* c_interface);
-  void SetCSRData(char const *c_indptr, char const *c_indices,
-                  char const *c_values, bst_feature_t n_features,
-                  bool on_host);
+  void SetCSRData(char const* c_indptr, char const* c_indices, char const* c_values,
+                  bst_feature_t n_features, bool on_host);
 
   MetaInfo& Info() override { return info_; }
   MetaInfo const& Info() const override { return info_; }

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -17,7 +17,7 @@ const MetaInfo &SparsePageDMatrix::Info() const { return info_; }
 
 namespace detail {
 // Use device dispatch
-size_t NSamplesDevice(DMatrixProxy *proxy)
+size_t NSamplesDevice(DMatrixProxy *)
 #if defined(XGBOOST_USE_CUDA)
 ;  // NOLINT
 #else
@@ -26,7 +26,7 @@ size_t NSamplesDevice(DMatrixProxy *proxy)
   return 0;
 }
 #endif
-size_t NFeaturesDevice(DMatrixProxy *proxy)
+size_t NFeaturesDevice(DMatrixProxy *)
 #if defined(XGBOOST_USE_CUDA)
 ;  // NOLINT
 #else

--- a/src/data/sparse_page_source.h
+++ b/src/data/sparse_page_source.h
@@ -210,9 +210,7 @@ class SparsePageSourceImpl : public BatchIteratorImpl<S> {
 #if defined(XGBOOST_USE_CUDA)
 void DevicePush(DMatrixProxy* proxy, float missing, SparsePage* page);
 #else
-inline void DevicePush(DMatrixProxy* proxy, float missing, SparsePage* page) {
-  common::AssertGPUSupport();
-}
+inline void DevicePush(DMatrixProxy*, float, SparsePage*) { common::AssertGPUSupport(); }
 #endif
 
 class SparsePageSource : public SparsePageSourceImpl<SparsePage> {

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -254,14 +254,6 @@ class GBLinear : public GradientBooster {
     }
   }
 
-  bool UseGPU() const override {
-    if (param_.updater == "gpu_coord_descent") {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
  protected:
   void PredictBatchInternal(DMatrix *p_fmat,
                             std::vector<bst_float> *out_preds) {

--- a/src/gbm/gbm.cc
+++ b/src/gbm/gbm.cc
@@ -17,7 +17,7 @@ DMLC_REGISTRY_ENABLE(::xgboost::GradientBoosterReg);
 }  // namespace dmlc
 
 namespace xgboost {
-GradientBooster* GradientBooster::Create(const std::string& name, GenericParameter const* ctx,
+GradientBooster* GradientBooster::Create(const std::string& name, Context const* ctx,
                                          LearnerModelParam const* learner_model_param) {
   auto *e = ::dmlc::Registry< ::xgboost::GradientBoosterReg>::Get()->Find(name);
   if (e == nullptr) {

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -248,11 +248,10 @@ void GBTree::DoBoost(DMatrix* p_fmat, HostDeviceVector<GradientPair>* in_gpair,
   // Weird case that tree method is cpu-based but gpu_id is set.  Ideally we should let
   // `gpu_id` be the single source of determining what algorithms to run, but that will
   // break a lots of existing code.
-  auto device = tparam_.tree_method != TreeMethod::kGPUHist ? Context::kCpuId : ctx_->gpu_id;
   auto out = linalg::TensorView<float, 2>{
-      device == Context::kCpuId ? predt->predictions.HostSpan() : predt->predictions.DeviceSpan(),
+      ctx_->IsCPU() ? predt->predictions.HostSpan() : predt->predictions.DeviceSpan(),
       {static_cast<size_t>(p_fmat->Info().num_row_), static_cast<size_t>(ngroup)},
-      device};
+      ctx_->gpu_id};
   CHECK_NE(ngroup, 0);
 
   if (!p_fmat->SingleColBlock() && obj->Task().UpdateTreeLeaf()) {

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -170,9 +170,15 @@ void GBTree::ConfigureUpdaters() {
       break;
     case TreeMethod::kApprox:
       tparam_.updater_seq = "grow_histmaker";
+      if (ctx_->IsCUDA()) {
+        LOG(FATAL) << "Approx tree method is not supported on GPU.";
+      }
       break;
     case TreeMethod::kExact:
       tparam_.updater_seq = "grow_colmaker,prune";
+      if (ctx_->IsCUDA()) {
+        LOG(FATAL) << "Exact tree method is not supported on GPU.";
+      }
       break;
     case TreeMethod::kHist:
       LOG(INFO) << "Tree method is selected to be 'hist'.";

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -211,12 +211,6 @@ class GBTree : public GradientBooster {
   void DoBoost(DMatrix* p_fmat, HostDeviceVector<GradientPair>* in_gpair,
                PredictionCacheEntry* predt, ObjFunction const* obj) override;
 
-  bool UseGPU() const override {
-    return
-        tparam_.predictor == PredictorType::kGPUPredictor ||
-        tparam_.tree_method == TreeMethod::kGPUHist;
-  }
-
   GBTreeTrainParam const& GetTrainParam() const {
     return tparam_;
   }
@@ -413,8 +407,7 @@ class GBTree : public GradientBooster {
                      int bst_group,
                      std::vector<std::unique_ptr<RegTree> >* ret);
 
-  std::unique_ptr<Predictor> const& GetPredictor(HostDeviceVector<float> const* out_pred = nullptr,
-                                                 DMatrix* f_dmat = nullptr) const;
+  std::unique_ptr<Predictor> const& GetPredictor(DMatrix* f_dmat = nullptr) const;
 
   // commit new trees all at once
   virtual void CommitModel(std::vector<std::vector<std::unique_ptr<RegTree>>>&& new_trees);

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -218,53 +218,6 @@ struct LearnerTrainParam : public XGBoostParameter<LearnerTrainParam> {
 
 DMLC_REGISTER_PARAMETER(LearnerModelParamLegacy);
 DMLC_REGISTER_PARAMETER(LearnerTrainParam);
-DMLC_REGISTER_PARAMETER(GenericParameter);
-
-int constexpr GenericParameter::kCpuId;
-int64_t constexpr GenericParameter::kDefaultSeed;
-
-GenericParameter::GenericParameter() : cfs_cpu_count_{common::GetCfsCPUCount()} {}
-
-void GenericParameter::ConfigureGpuId(bool require_gpu) {
-#if defined(XGBOOST_USE_CUDA)
-  if (gpu_id == kCpuId) {  // 0. User didn't specify the `gpu_id'
-    if (require_gpu) {     // 1. `tree_method' or `predictor' or both are using
-                           // GPU.
-      // 2. Use device 0 as default.
-      this->UpdateAllowUnknown(Args{{"gpu_id", "0"}});
-    }
-  }
-
-  // 3. When booster is loaded from a memory image (Python pickle or R
-  // raw model), number of available GPUs could be different.  Wrap around it.
-  int32_t n_gpus = common::AllVisibleGPUs();
-  if (n_gpus == 0) {
-    if (gpu_id != kCpuId) {
-      LOG(WARNING) << "No visible GPU is found, setting `gpu_id` to -1";
-    }
-    this->UpdateAllowUnknown(Args{{"gpu_id", std::to_string(kCpuId)}});
-  } else if (fail_on_invalid_gpu_id) {
-    CHECK(gpu_id == kCpuId || gpu_id < n_gpus)
-      << "Only " << n_gpus << " GPUs are visible, gpu_id "
-      << gpu_id << " is invalid.";
-  } else if (gpu_id != kCpuId && gpu_id >= n_gpus) {
-    LOG(WARNING) << "Only " << n_gpus
-                 << " GPUs are visible, setting `gpu_id` to " << gpu_id % n_gpus;
-    this->UpdateAllowUnknown(Args{{"gpu_id", std::to_string(gpu_id % n_gpus)}});
-  }
-#else
-  // Just set it to CPU, don't think about it.
-  this->UpdateAllowUnknown(Args{{"gpu_id", std::to_string(kCpuId)}});
-#endif  // defined(XGBOOST_USE_CUDA)
-}
-
-int32_t GenericParameter::Threads() const {
-  auto n_threads = common::OmpGetNumThreads(nthread);
-  if (cfs_cpu_count_ > 0) {
-    n_threads = std::min(n_threads, cfs_cpu_count_);
-  }
-  return n_threads;
-}
 
 using LearnerAPIThreadLocalStore =
     dmlc::ThreadLocalStore<std::map<Learner const *, XGBAPIThreadLocalEntry>>;
@@ -384,7 +337,7 @@ class LearnerConfiguration : public Learner {
     }
 
     this->ConfigureGBM(old_tparam, args);
-    generic_parameters_.ConfigureGpuId(this->gbm_->UseGPU());
+    generic_parameters_.ConfigureGpuId();
     this->ConfigureMetrics(args);
 
     this->need_configuration_ = false;
@@ -449,7 +402,7 @@ class LearnerConfiguration : public Learner {
 
     FromJson(learner_parameters.at("generic_param"), &generic_parameters_);
     // make sure the GPU ID is valid in new environment before start running configure.
-    generic_parameters_.ConfigureGpuId(false);
+    generic_parameters_.ConfigureGpuId();
 
     this->need_configuration_ = true;
   }

--- a/tests/python-gpu/test_gpu_config.py
+++ b/tests/python-gpu/test_gpu_config.py
@@ -1,0 +1,8 @@
+import xgboost as xgb
+
+
+def test_config():
+    with xgb.config_context(device="CPU"):
+        assert xgb.get_config()["device"] == "CPU"
+        with xgb.config_context(device="CUDA"):
+            assert xgb.get_config()["device"] == "CUDA"

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -1,28 +1,34 @@
-import numpy as np
-import sys
 import gc
+import sys
+
+import numpy as np
 import pytest
+from hypothesis import assume, given, note, settings, strategies
+from xgboost.testing import with_cuda_test
+
 import xgboost as xgb
-from hypothesis import given, strategies, assume, settings, note
 
 sys.path.append("tests/python")
-import testing as tm
 import test_updaters as test_up
+import testing as tm
 
-
-parameter_strategy = strategies.fixed_dictionaries({
-    'max_depth': strategies.integers(0, 11),
-    'max_leaves': strategies.integers(0, 256),
-    'max_bin': strategies.integers(2, 1024),
-    'grow_policy': strategies.sampled_from(['lossguide', 'depthwise']),
-    'min_child_weight': strategies.floats(0.5, 2.0),
-    'seed': strategies.integers(0, 10),
-    # We cannot enable subsampling as the training loss can increase
-    # 'subsample': strategies.floats(0.5, 1.0),
-    'colsample_bytree': strategies.floats(0.5, 1.0),
-    'colsample_bylevel': strategies.floats(0.5, 1.0),
-}).filter(lambda x: (x['max_depth'] > 0 or x['max_leaves'] > 0) and (
-    x['max_depth'] > 0 or x['grow_policy'] == 'lossguide'))
+parameter_strategy = strategies.fixed_dictionaries(
+    {
+        "max_depth": strategies.integers(0, 11),
+        "max_leaves": strategies.integers(0, 256),
+        "max_bin": strategies.integers(2, 1024),
+        "grow_policy": strategies.sampled_from(["lossguide", "depthwise"]),
+        "min_child_weight": strategies.floats(0.5, 2.0),
+        "seed": strategies.integers(0, 10),
+        # We cannot enable subsampling as the training loss can increase
+        # 'subsample': strategies.floats(0.5, 1.0),
+        "colsample_bytree": strategies.floats(0.5, 1.0),
+        "colsample_bylevel": strategies.floats(0.5, 1.0),
+    }
+).filter(
+    lambda x: (x["max_depth"] > 0 or x["max_leaves"] > 0)
+    and (x["max_depth"] > 0 or x["grow_policy"] == "lossguide")
+)
 
 
 def train_result(param, dmat: xgb.DMatrix, num_rounds: int) -> dict:
@@ -46,8 +52,9 @@ class TestGPUUpdaters:
 
     @given(parameter_strategy, strategies.integers(1, 20), tm.dataset_strategy)
     @settings(deadline=None, print_blob=True)
+    @with_cuda_test
     def test_gpu_hist(self, param, num_rounds, dataset):
-        param["tree_method"] = "gpu_hist"
+        param["tree_method"] = "hist"
         param = dataset.set_params(param)
         result = train_result(param, dataset.get_dmat(), num_rounds)
         note(result)
@@ -59,79 +66,89 @@ class TestGPUUpdaters:
         param = {"tree_method": "hist", "max_bin": 64}
         hist_result = train_result(param, dataset.get_dmat(), 16)
         note(hist_result)
-        assert tm.non_increasing(hist_result['train'][dataset.metric])
+        assert tm.non_increasing(hist_result["train"][dataset.metric])
 
-        param = {"tree_method": "gpu_hist", "max_bin": 64}
-        gpu_hist_result = train_result(param, dataset.get_dmat(), 16)
+        with xgb.config_context(device="CUDA:0"):
+            gpu_hist_result = train_result(param, dataset.get_dmat(), 16)
         note(gpu_hist_result)
-        assert tm.non_increasing(gpu_hist_result['train'][dataset.metric])
+        assert tm.non_increasing(gpu_hist_result["train"][dataset.metric])
 
         np.testing.assert_allclose(
             hist_result["train"]["rmse"], gpu_hist_result["train"]["rmse"], rtol=1e-2
         )
 
-    @given(strategies.integers(10, 400), strategies.integers(3, 8),
-           strategies.integers(1, 2), strategies.integers(4, 7))
+    @given(
+        strategies.integers(10, 400),
+        strategies.integers(3, 8),
+        strategies.integers(1, 2),
+        strategies.integers(4, 7),
+    )
     @settings(deadline=None, print_blob=True)
     @pytest.mark.skipif(**tm.no_pandas())
+    @with_cuda_test
     def test_categorical_ohe(self, rows, cols, rounds, cats):
-        self.cputest.run_categorical_ohe(rows, cols, rounds, cats, "gpu_hist")
+        self.cputest.run_categorical_ohe(rows, cols, rounds, cats, "hist")
 
     @given(
         strategies.integers(10, 400),
         strategies.integers(3, 8),
-        strategies.integers(4, 7)
+        strategies.integers(4, 7),
     )
     @settings(deadline=None, print_blob=True)
     @pytest.mark.skipif(**tm.no_pandas())
+    @with_cuda_test
     def test_categorical_missing(self, rows, cols, cats):
-        self.cputest.run_categorical_missing(rows, cols, cats, "gpu_hist")
+        self.cputest.run_categorical_missing(rows, cols, cats, "hist")
 
     @pytest.mark.skipif(**tm.no_pandas())
+    @with_cuda_test
     def test_max_cat(self) -> None:
-        self.cputest.run_max_cat("gpu_hist")
+        self.cputest.run_max_cat("hist")
 
+    @with_cuda_test
     def test_categorical_32_cat(self):
-        '''32 hits the bound of integer bitset, so special test'''
+        """32 hits the bound of integer bitset, so special test"""
         rows = 1000
         cols = 10
         cats = 32
         rounds = 4
-        self.cputest.run_categorical_ohe(rows, cols, rounds, cats, "gpu_hist")
+        self.cputest.run_categorical_ohe(rows, cols, rounds, cats, "hist")
 
     @pytest.mark.skipif(**tm.no_cupy())
+    @with_cuda_test
     def test_invalid_category(self):
-        self.cputest.run_invalid_category("gpu_hist")
+        self.cputest.run_invalid_category("hist")
 
     @pytest.mark.skipif(**tm.no_cupy())
-    @given(parameter_strategy, strategies.integers(1, 20),
-           tm.dataset_strategy)
+    @given(parameter_strategy, strategies.integers(1, 20), tm.dataset_strategy)
     @settings(deadline=None, print_blob=True)
+    @with_cuda_test
     def test_gpu_hist_device_dmatrix(self, param, num_rounds, dataset):
         # We cannot handle empty dataset yet
         assume(len(dataset.y) > 0)
-        param['tree_method'] = 'gpu_hist'
+        param["tree_method"] = "hist"
         param = dataset.set_params(param)
         result = train_result(param, dataset.get_device_dmat(), num_rounds)
         note(result)
-        assert tm.non_increasing(result['train'][dataset.metric], tolerance=1e-3)
+        assert tm.non_increasing(result["train"][dataset.metric], tolerance=1e-3)
 
-    @given(parameter_strategy, strategies.integers(1, 20),
-           tm.dataset_strategy)
+    @given(parameter_strategy, strategies.integers(1, 20), tm.dataset_strategy)
     @settings(deadline=None, print_blob=True)
+    @with_cuda_test
     def test_external_memory(self, param, num_rounds, dataset):
         if dataset.name.endswith("-l1"):
             return
         # We cannot handle empty dataset yet
         assume(len(dataset.y) > 0)
-        param['tree_method'] = 'gpu_hist'
+        param["tree_method"] = "hist"
         param = dataset.set_params(param)
         m = dataset.get_external_dmat()
         external_result = train_result(param, m, num_rounds)
         del m
         gc.collect()
-        assert tm.non_increasing(external_result['train'][dataset.metric])
+        assert tm.non_increasing(external_result["train"][dataset.metric])
 
+    @with_cuda_test
     def test_empty_dmatrix_prediction(self):
         # FIXME(trivialfis): This should be done with all updaters
         kRows = 0
@@ -142,13 +159,13 @@ class TestGPUUpdaters:
 
         dtrain = xgb.DMatrix(X, y)
 
-        bst = xgb.train({'verbosity': 2,
-                         'tree_method': 'gpu_hist',
-                         'gpu_id': 0},
-                        dtrain,
-                        verbose_eval=True,
-                        num_boost_round=6,
-                        evals=[(dtrain, 'Train')])
+        bst = xgb.train(
+            {"verbosity": 2, "tree_method": "hist"},
+            dtrain,
+            verbose_eval=True,
+            num_boost_round=6,
+            evals=[(dtrain, "Train")],
+        )
 
         kRows = 100
         X = np.random.randn(kRows, kCols)
@@ -161,7 +178,8 @@ class TestGPUUpdaters:
     @given(tm.dataset_strategy, strategies.integers(0, 10))
     @settings(deadline=None, max_examples=10, print_blob=True)
     def test_specified_gpu_id_gpu_update(self, dataset, gpu_id):
-        param = {'tree_method': 'gpu_hist', 'gpu_id': gpu_id}
-        param = dataset.set_params(param)
-        result = train_result(param, dataset.get_dmat(), 10)
-        assert tm.non_increasing(result['train'][dataset.metric])
+        with xgb.config_context(device=f"CUDA:{gpu_id}"):
+            param = {"tree_method": "hist"}
+            param = dataset.set_params(param)
+            result = train_result(param, dataset.get_dmat(), 10)
+            assert tm.non_increasing(result["train"][dataset.metric])

--- a/tests/python/test_updaters.py
+++ b/tests/python/test_updaters.py
@@ -1,11 +1,13 @@
 from random import choice
 from string import ascii_lowercase
-from typing import Dict, Any
-import testing as tm
-import pytest
-import xgboost as xgb
+from typing import Any, Dict
+
 import numpy as np
-from hypothesis import given, strategies, settings, note
+import pytest
+import testing as tm
+from hypothesis import given, note, settings, strategies
+
+import xgboost as xgb
 
 exact_parameter_strategy = strategies.fixed_dictionaries({
     'nthread': strategies.integers(1, 4),
@@ -272,8 +274,7 @@ class TestTreeMethod:
         by_etl_results = {}
         by_builtin_results = {}
 
-        predictor = "gpu_predictor" if tree_method == "gpu_hist" else None
-        parameters = {"tree_method": tree_method, "predictor": predictor}
+        parameters = {"tree_method": tree_method}
         # Use one-hot exclusively
         parameters["max_cat_to_onehot"] = self.USE_ONEHOT
 


### PR DESCRIPTION
This is an early working-in-progress PR for using global configuration for device.  There are still plenty of things I need to do, the PR is for the CI so that I can get a better picture on how many changes I need to make.

Related issue: https://github.com/dmlc/xgboost/issues/7308

For sklearn, we will support both the `config_context` and constructor parameter `device` (replacing the `gpu_id` training parameter) for easier hyper-parameter search.

``` python
xgb.XGBRegressor(device="CUDA:0", tree_method="hist") # ok, easy for parameter search with sklearn
xgb.XGBRegressor(device="CPU", tree_method="approx") # CUDA + approx will throw an error

with xgb.config_context(device="CUDA:0"):
    xgb.XGBRegressor(tree_method="hist") # ok, easier for setting global configuration.
```