### PR TITLE
[pyspark] Make Xgboost estimator support using sparse matrix as optimization

### DIFF
--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -38,10 +38,10 @@ import xgboost
 from xgboost import XGBClassifier, XGBRegressor
 
 from .data import (
+    _read_csr_matrix_from_unwrapped_spark_vec,
     alias,
     create_dmatrix_from_partitions,
     stack_series,
-    _read_csr_matrix_from_unwrapped_spark_vec,
 )
 from .model import (
     SparkXGBModelReader,
@@ -52,8 +52,8 @@ from .model import (
 from .params import (
     HasArbitraryParamsDict,
     HasBaseMarginCol,
-    HasFeaturesCols,
     HasEnableSparseDataOptim,
+    HasFeaturesCols,
 )
 from .utils import (
     RabitContext,

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -39,7 +39,8 @@ from xgboost import XGBClassifier, XGBRegressor
 
 from .data import (
     alias,
-    create_dmatrix_from_partitions, stack_series,
+    create_dmatrix_from_partitions,
+    stack_series,
     _read_csr_matrix_from_unwrapped_spark_vec,
 )
 from .model import (
@@ -49,7 +50,10 @@ from .model import (
     SparkXGBWriter,
 )
 from .params import (
-    HasArbitraryParamsDict, HasBaseMarginCol, HasFeaturesCols, HasEnableSparseDataOptim
+    HasArbitraryParamsDict,
+    HasBaseMarginCol,
+    HasFeaturesCols,
+    HasEnableSparseDataOptim,
 )
 from .utils import (
     RabitContext,
@@ -394,12 +398,14 @@ def _validate_and_convert_feature_col_as_array_col(dataset, features_col_name):
 def _get_unwrap_udt_fn():
     try:
         from pyspark.sql.functions import unwrap_udt
+
         return unwrap_udt
     except ImportError:
         pass
 
     try:
         from pyspark.databricks.sql.functions import unwrap_udt
+
         return unwrap_udt
     except ImportError:
         raise RuntimeError(
@@ -429,8 +435,9 @@ def _get_unwrapped_vec_cols(feature_col):
         features_unwrapped_vec_col.indices.alias("featureVectorIndices"),
         # Note: the value field is double array type, cast it to float32 array type
         # for speedup following repartitioning.
-        features_unwrapped_vec_col.values.cast(ArrayType(FloatType())) \
-            .alias("featureVectorValues"),
+        features_unwrapped_vec_col.values.cast(ArrayType(FloatType())).alias(
+            "featureVectorValues"
+        ),
     ]
 
 
@@ -709,7 +716,10 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
             evals_result = {}
             with RabitContext(_rabit_args, context):
                 dtrain, dvalid = create_dmatrix_from_partitions(
-                    pandas_df_iter, features_cols_names, gpu_id, dmatrix_kwargs,
+                    pandas_df_iter,
+                    features_cols_names,
+                    gpu_id,
+                    dmatrix_kwargs,
                     enable_sparse_data_optim=enable_sparse_data_optim,
                 )
                 if dvalid is not None:
@@ -817,7 +827,9 @@ class _SparkXGBModel(Model, _SparkXGBParams, MLReadable, MLWritable):
         """
         if self.getOrDefault(self.enable_sparse_data_optim):
             feature_col_names = None
-            features_col = _get_unwrapped_vec_cols(col(self.getOrDefault(self.featuresCol)))
+            features_col = _get_unwrapped_vec_cols(
+                col(self.getOrDefault(self.featuresCol))
+            )
             return features_col, feature_col_names
 
         feature_col_names = self.getOrDefault(self.features_cols)

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -1,7 +1,7 @@
 # type: ignore
 """Xgboost pyspark integration submodule for core code."""
 # pylint: disable=fixme, too-many-ancestors, protected-access, no-member, invalid-name
-# pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods, too-many-lines
 from typing import Iterator, Optional, Tuple
 
 import numpy as np
@@ -249,6 +249,7 @@ class _SparkXGBParams(
         return predict_params
 
     def _validate_params(self):
+        # pylint: disable=too-many-branches
         init_model = self.getOrDefault(self.xgb_model)
         if init_model is not None and not isinstance(init_model, Booster):
             raise ValueError(
@@ -407,11 +408,11 @@ def _get_unwrap_udt_fn():
         from pyspark.databricks.sql.functions import unwrap_udt
 
         return unwrap_udt
-    except ImportError:
+    except ImportError as exc:
         raise RuntimeError(
             "Cannot import pyspark `unwrap_udt` function. Please install pyspark>=3.4 "
             "or run on Databricks Runtime."
-        )
+        ) from exc
 
 
 def _get_unwrapped_vec_cols(feature_col):
@@ -931,6 +932,7 @@ class SparkXGBClassifierModel(_SparkXGBModel, HasProbabilityCol, HasRawPredictio
         return XGBClassifier
 
     def _transform(self, dataset):
+        # pylint: disable=too-many-locals
         # Save xgb_sklearn_model and predict_params to be local variable
         # to avoid the `self` object to be pickled to remote.
         xgb_sklearn_model = self._xgb_sklearn_model

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -81,6 +81,7 @@ _pyspark_specific_params = [
     "use_gpu",
     "feature_names",
     "features_cols",
+    "enable_sparse_data_optim",
 ]
 
 _non_booster_params = ["missing", "n_estimators", "feature_types", "feature_weights"]

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -427,9 +427,10 @@ def _get_unwrapped_vec_cols(feature_col):
         features_unwrapped_vec_col.type.alias("featureVectorType"),
         features_unwrapped_vec_col.size.alias("featureVectorSize"),
         features_unwrapped_vec_col.indices.alias("featureVectorIndices"),
-        # Note: the value field is double type, cast it to float32 type
+        # Note: the value field is double array type, cast it to float32 array type
         # for speedup following repartitioning.
-        features_unwrapped_vec_col.values.cast(FloatType()).alias("featureVectorValues"),
+        features_unwrapped_vec_col.values.cast(ArrayType(FloatType())) \
+            .alias("featureVectorValues"),
     ]
 
 

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -235,8 +235,6 @@ def create_dmatrix_from_partitions(
         label = concat_or_none(values.get(alias.label, None))
         weight = concat_or_none(values.get(alias.weight, None))
         margin = concat_or_none(values.get(alias.margin, None))
-        if enable_sparse_data_optim:
-            assert kwargs["missing"] == 0.0
 
         return DMatrix(
             data=data, label=label, weight=weight, base_margin=margin, **kwargs

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -163,7 +163,7 @@ def create_dmatrix_from_partitions(
         Metainfo for DMatrix.
 
     """
-
+    # pylint: disable=too-many-locals, too-many-statements
     train_data: Dict[str, List[np.ndarray]] = defaultdict(list)
     valid_data: Dict[str, List[np.ndarray]] = defaultdict(list)
 

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -4,10 +4,10 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tupl
 
 import numpy as np
 import pandas as pd
+from scipy.sparse import csr_matrix
 from xgboost.compat import concat
 
 from xgboost import DataIter, DeviceQuantileDMatrix, DMatrix
-from scipy.sparse import csr_matrix
 
 
 def stack_series(series: pd.Series) -> np.ndarray:

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -7,6 +7,7 @@ import pandas as pd
 from xgboost.compat import concat
 
 from xgboost import DataIter, DeviceQuantileDMatrix, DMatrix
+from scipy.sparse import csr_matrix
 
 
 def stack_series(series: pd.Series) -> np.ndarray:
@@ -101,9 +102,7 @@ class PartIter(DataIter):
         self._iter = 0
 
 
-def _read_csr_matrix_from_unwrapped_spark_vec(part: pd.DataFrame):
-    from scipy.sparse import csr_matrix
-
+def _read_csr_matrix_from_unwrapped_spark_vec(part: pd.DataFrame) -> csr_matrix:
     # variables for constructing csr_matrix
     csr_indices_list, csr_indptr_list, csr_values_list = [], [0], []
 
@@ -113,7 +112,7 @@ def _read_csr_matrix_from_unwrapped_spark_vec(part: pd.DataFrame):
         part.featureVectorType,
         part.featureVectorSize,
         part.featureVectorIndices,
-        part.featureVectorValues
+        part.featureVectorValues,
     ):
         if vec_type == 0:
             # sparse vector
@@ -142,8 +141,7 @@ def _read_csr_matrix_from_unwrapped_spark_vec(part: pd.DataFrame):
     csr_values_arr = np.concatenate(csr_values_list)
 
     return csr_matrix(
-        (csr_values_arr, csr_indices_arr, csr_indptr_arr),
-        shape=(len(part), n_features)
+        (csr_values_arr, csr_indices_arr, csr_indptr_arr), shape=(len(part), n_features)
     )
 
 

--- a/python-package/xgboost/spark/params.py
+++ b/python-package/xgboost/spark/params.py
@@ -50,3 +50,25 @@ class HasFeaturesCols(Params):
     def __init__(self):
         super().__init__()
         self._setDefault(features_cols=[])
+
+
+class HasEnableSparseDataOptim(Params):
+
+    """
+    This is a Params based class that is extended by _SparkXGBParams
+    and holds the variable to store the boolean config of enabling sparse data optimization.
+    """
+
+    enable_sparse_data_optim = Param(
+        Params._dummy(),
+        "enable_sparse_data_optim",
+        "This stores the boolean config of enabling sparse data optimization, if enabled, "
+        "Xgboost DMatrix object will be constructed from sparse matrix instead of "
+        "dense matrix. This config is disabled by default. If most of examples in your "
+        "training dataset contains sparse features, we suggest to enable this config.",
+        typeConverter=TypeConverters.toBoolean,
+    )
+
+    def __init__(self):
+        super().__init__()
+        self._setDefault(enable_sparse_data_optim=False)

--- a/tests/ci_build/conda_env/cpu_test.yml
+++ b/tests/ci_build/conda_env/cpu_test.yml
@@ -32,7 +32,8 @@ dependencies:
 - cffi
 - pyarrow
 - protobuf
-- pyspark>=3.3.0
+# replace it with pyspark>=3.4 once 3.4 released.
+- https://ml-team-public-read.s3.us-west-2.amazonaws.com/pyspark-3.4.0.dev0.tar.gz
 - cloudpickle
 - shap
 - modin

--- a/tests/ci_build/conda_env/cpu_test.yml
+++ b/tests/ci_build/conda_env/cpu_test.yml
@@ -32,10 +32,10 @@ dependencies:
 - cffi
 - pyarrow
 - protobuf
-# replace it with pyspark>=3.4 once 3.4 released.
-- https://ml-team-public-read.s3.us-west-2.amazonaws.com/pyspark-3.4.0.dev0.tar.gz
 - cloudpickle
 - shap
 - modin
 - pip:
   - datatable
+  # TODO: Replace it with pyspark>=3.4 once 3.4 released.
+  - https://ml-team-public-read.s3.us-west-2.amazonaws.com/pyspark-3.4.0.dev0.tar.gz

--- a/tests/python/test_spark/test_data.py
+++ b/tests/python/test_spark/test_data.py
@@ -105,7 +105,7 @@ def test_dmatrix_ctor() -> None:
     run_dmatrix_ctor(False)
 
 
-def test_read_csr_matrix_from_unwrapped_spark_vec():
+def test_read_csr_matrix_from_unwrapped_spark_vec() -> None:
     from scipy.sparse import csr_matrix
     pd1 = pd.DataFrame({
         "featureVectorType": [0, 1, 1, 0],

--- a/tests/python/test_spark/test_data.py
+++ b/tests/python/test_spark/test_data.py
@@ -68,7 +68,7 @@ def run_dmatrix_ctor(is_dqm: bool) -> None:
         train_Xy, valid_Xy = create_dmatrix_from_partitions(iter(dfs), cols, 0, kwargs, False)
     else:
         train_Xy, valid_Xy = create_dmatrix_from_partitions(
-            iter(dfs), None, None, kwargs, True
+            iter(dfs), None, None, kwargs, False
         )
 
     assert valid_Xy is not None

--- a/tests/python/test_spark/test_data.py
+++ b/tests/python/test_spark/test_data.py
@@ -12,8 +12,10 @@ if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
     pytest.skip("Skipping PySpark tests on Windows", allow_module_level=True)
 
 from xgboost.spark.data import (
-    alias, create_dmatrix_from_partitions, stack_series,
     _read_csr_matrix_from_unwrapped_spark_vec,
+    alias,
+    create_dmatrix_from_partitions,
+    stack_series,
 )
 
 
@@ -65,7 +67,9 @@ def run_dmatrix_ctor(is_dqm: bool) -> None:
     kwargs = {"feature_types": feature_types}
     if is_dqm:
         cols = [f"feat-{i}" for i in range(n_features)]
-        train_Xy, valid_Xy = create_dmatrix_from_partitions(iter(dfs), cols, 0, kwargs, False)
+        train_Xy, valid_Xy = create_dmatrix_from_partitions(
+            iter(dfs), cols, 0, kwargs, False
+        )
     else:
         train_Xy, valid_Xy = create_dmatrix_from_partitions(
             iter(dfs), None, None, kwargs, False
@@ -107,26 +111,31 @@ def test_dmatrix_ctor() -> None:
 
 def test_read_csr_matrix_from_unwrapped_spark_vec() -> None:
     from scipy.sparse import csr_matrix
-    pd1 = pd.DataFrame({
-        "featureVectorType": [0, 1, 1, 0],
-        "featureVectorSize": [3, None, None, 3],
-        "featureVectorIndices": [
-            np.array([0, 2], dtype=np.int32),
-            None,
-            None,
-            np.array([1, 2], dtype=np.int32)
-        ],
-        "featureVectorValues": [
-            np.array([3.0, 0.0], dtype=np.float64),
-            np.array([13.0, 14.0, 0.0], dtype=np.float64),
-            np.array([0.0, 24.0, 25.0], dtype=np.float64),
-            np.array([0.0, 35.0], dtype=np.float64)
-        ],
-    })
+
+    pd1 = pd.DataFrame(
+        {
+            "featureVectorType": [0, 1, 1, 0],
+            "featureVectorSize": [3, None, None, 3],
+            "featureVectorIndices": [
+                np.array([0, 2], dtype=np.int32),
+                None,
+                None,
+                np.array([1, 2], dtype=np.int32),
+            ],
+            "featureVectorValues": [
+                np.array([3.0, 0.0], dtype=np.float64),
+                np.array([13.0, 14.0, 0.0], dtype=np.float64),
+                np.array([0.0, 24.0, 25.0], dtype=np.float64),
+                np.array([0.0, 35.0], dtype=np.float64),
+            ],
+        }
+    )
     sm = _read_csr_matrix_from_unwrapped_spark_vec(pd1)
     assert isinstance(sm, csr_matrix)
 
-    np.testing.assert_array_equal(sm.data, [3., 0., 13., 14., 0., 0., 24., 25., 0., 35.])
+    np.testing.assert_array_equal(
+        sm.data, [3.0, 0.0, 13.0, 14.0, 0.0, 0.0, 24.0, 25.0, 0.0, 35.0]
+    )
     np.testing.assert_array_equal(sm.indptr, [0, 2, 5, 8, 10])
     np.testing.assert_array_equal(sm.indices, [0, 2, 0, 1, 2, 0, 1, 2, 1, 2])
     assert sm.shape == (4, 3)

--- a/tests/python/test_spark/test_data.py
+++ b/tests/python/test_spark/test_data.py
@@ -5,14 +5,16 @@ import numpy as np
 import pandas as pd
 import pytest
 import testing as tm
-from unittest import mock
 
 if tm.no_spark()["condition"]:
     pytest.skip(msg=tm.no_spark()["reason"], allow_module_level=True)
 if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
     pytest.skip("Skipping PySpark tests on Windows", allow_module_level=True)
 
-from xgboost.spark.data import alias, create_dmatrix_from_partitions, stack_series
+from xgboost.spark.data import (
+    alias, create_dmatrix_from_partitions, stack_series,
+    _read_csr_matrix_from_unwrapped_spark_vec,
+)
 
 
 def test_stack() -> None:
@@ -103,26 +105,28 @@ def test_dmatrix_ctor() -> None:
     run_dmatrix_ctor(False)
 
 
-def test_dmatrix_ctor_with_sparse_optim():
+def test_read_csr_matrix_from_unwrapped_spark_vec():
     from scipy.sparse import csr_matrix
     pd1 = pd.DataFrame({
-        "featureVectorType": [0, 1],
-        "featureVectorSize": [3, None],
-        "featureVectorIndices": [np.array([0, 2], dtype=np.int32), None],
-        "featureVectorValues": [np.array([3.0, 0.0], dtype=np.float64), np.array([13.0, 14.0, 0.0], dtype=np.float64)],
+        "featureVectorType": [0, 1, 1, 0],
+        "featureVectorSize": [3, None, None, 3],
+        "featureVectorIndices": [
+            np.array([0, 2], dtype=np.int32),
+            None,
+            None,
+            np.array([1, 2], dtype=np.int32)
+        ],
+        "featureVectorValues": [
+            np.array([3.0, 0.0], dtype=np.float64),
+            np.array([13.0, 14.0, 0.0], dtype=np.float64),
+            np.array([0.0, 24.0, 25.0], dtype=np.float64),
+            np.array([0.0, 35.0], dtype=np.float64)
+        ],
     })
-    pd2 = pd.DataFrame({
-        "featureVectorType": [1, 0],
-        "featureVectorSize": [None, 3],
-        "featureVectorIndices": [None, np.array([1, 2], dtype=np.int32)],
-        "featureVectorValues": [np.array([0.0, 24.0, 25.0], dtype=np.float64), np.array([0.0, 35.0], dtype=np.float64)],
-    })
-
-    with mock.patch("xgboost.core.DMatrix.__init__", return_value=None) as mock_dmatrix_ctor:
-        create_dmatrix_from_partitions([pd1, pd2], None, None, {}, True)
-    sm = mock_dmatrix_ctor.call_args_list[0][1]["data"]
+    sm = _read_csr_matrix_from_unwrapped_spark_vec(pd1)
     assert isinstance(sm, csr_matrix)
-    np.testing.assert_array_equal(sm.data, [3, 13, 14, 24, 25, 35])
-    np.testing.assert_array_equal(sm.indptr, [0, 1, 3, 5, 6])
-    np.testing.assert_array_equal(sm.indices, [0, 0, 1, 1, 2, 2])
+
+    np.testing.assert_array_equal(sm.data, [3., 0., 13., 14., 0., 0., 24., 25., 0., 35.])
+    np.testing.assert_array_equal(sm.indptr, [0, 2, 5, 8, 10])
+    np.testing.assert_array_equal(sm.indices, [0, 2, 0, 1, 2, 0, 1, 2, 1, 2])
     assert sm.shape == (4, 3)

--- a/tests/python/test_spark/test_data.py
+++ b/tests/python/test_spark/test_data.py
@@ -9,8 +9,8 @@ from unittest import mock
 
 if tm.no_spark()["condition"]:
     pytest.skip(msg=tm.no_spark()["reason"], allow_module_level=True)
-#if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
-#    pytest.skip("Skipping PySpark tests on Windows", allow_module_level=True)
+if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
+    pytest.skip("Skipping PySpark tests on Windows", allow_module_level=True)
 
 from xgboost.spark.data import alias, create_dmatrix_from_partitions, stack_series
 

--- a/tests/python/test_spark/test_spark_local.py
+++ b/tests/python/test_spark/test_spark_local.py
@@ -381,6 +381,24 @@ class XgboostLocalTest(SparkTestCase):
             ],
         )
 
+        self.reg_df_sparse_train = self.session.createDataFrame(
+            [
+                (Vectors.dense(1.0, 0.0, 3.0, 0.0, 0.0), 0),
+                (Vectors.sparse(5, {1: 1.0, 3: 5.5}), 1),
+                (Vectors.sparse(5, {4: -3.0}), 2),
+            ] * 10,
+            ["features", "label"],
+        )
+
+        self.cls_df_sparse_train = self.session.createDataFrame(
+            [
+                (Vectors.dense(1.0, 0.0, 3.0, 0.0, 0.0), 0),
+                (Vectors.sparse(5, {1: 1.0, 3: 5.5}), 1),
+                (Vectors.sparse(5, {4: -3.0}), 0),
+            ] * 10,
+            ["features", "label"]
+        )
+
     def get_local_tmp_dir(self):
         return self.tempdir + str(uuid.uuid4())
 
@@ -975,9 +993,30 @@ class XgboostLocalTest(SparkTestCase):
 
     def test_regressor_with_sparse_optim(self):
         regressor = SparkXGBRegressor(missing=0.0)
-        model = regressor.fit(self.reg_df_train)
-        pred_result = model.transform(self.reg_df_test).collect()
-        for row in pred_result:
+        model = regressor.fit(self.reg_df_sparse_train)
+        pred_result = model.transform(self.reg_df_sparse_train).collect()
+
+        # enable sparse optimiaztion
+        regressor2 = SparkXGBRegressor(missing=0.0, enable_sparse_data_optim=True)
+        model2 = regressor2.fit(self.reg_df_sparse_train)
+        pred_result2 = model2.transform(self.reg_df_sparse_train).collect()
+
+        for row1, row2 in zip(pred_result, pred_result2):
             self.assertTrue(
-                np.isclose(row.prediction, row.expected_prediction, atol=1e-3)
+                np.isclose(row1.prediction, row2.prediction, atol=1e-3)
+            )
+
+    def test_classifier_with_sparse_optim(self):
+        cls = SparkXGBClassifier(missing=0.0)
+        model = cls.fit(self.cls_df_sparse_train)
+        pred_result = model.transform(self.cls_df_sparse_train).collect()
+
+        # enable sparse optimiaztion
+        cls2 = SparkXGBClassifier(missing=0.0, enable_sparse_data_optim=True)
+        model2 = cls2.fit(self.cls_df_sparse_train)
+        pred_result2 = model2.transform(self.cls_df_sparse_train).collect()
+
+        for row1, row2 in zip(pred_result, pred_result2):
+            self.assertTrue(
+                np.allclose(row1.probability, row2.probability, rtol=1e-3)
             )

--- a/tests/python/test_spark/test_spark_local.py
+++ b/tests/python/test_spark/test_spark_local.py
@@ -1,11 +1,10 @@
-import sys
 import logging
 import random
+import sys
 import uuid
 
 import numpy as np
 import pytest
-
 import testing as tm
 
 if tm.no_spark()["condition"]:
@@ -13,25 +12,26 @@ if tm.no_spark()["condition"]:
 if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
     pytest.skip("Skipping PySpark tests on Windows", allow_module_level=True)
 
-from pyspark.ml.functions import vector_to_array
-from pyspark.sql import functions as spark_sql_func
 from pyspark.ml import Pipeline, PipelineModel
 from pyspark.ml.evaluation import (
     BinaryClassificationEvaluator,
     MulticlassClassificationEvaluator,
 )
+from pyspark.ml.functions import vector_to_array
 from pyspark.ml.linalg import Vectors
 from pyspark.ml.tuning import CrossValidator, ParamGridBuilder
-
+from pyspark.sql import functions as spark_sql_func
 from xgboost.spark import (
     SparkXGBClassifier,
     SparkXGBClassifierModel,
     SparkXGBRegressor,
     SparkXGBRegressorModel,
 )
-from .utils import SparkTestCase
-from xgboost import XGBClassifier, XGBRegressor
 from xgboost.spark.core import _non_booster_params
+
+from xgboost import XGBClassifier, XGBRegressor
+
+from .utils import SparkTestCase
 
 logging.getLogger("py4j").setLevel(logging.INFO)
 
@@ -386,7 +386,8 @@ class XgboostLocalTest(SparkTestCase):
                 (Vectors.dense(1.0, 0.0, 3.0, 0.0, 0.0), 0),
                 (Vectors.sparse(5, {1: 1.0, 3: 5.5}), 1),
                 (Vectors.sparse(5, {4: -3.0}), 2),
-            ] * 10,
+            ]
+            * 10,
             ["features", "label"],
         )
 
@@ -395,8 +396,9 @@ class XgboostLocalTest(SparkTestCase):
                 (Vectors.dense(1.0, 0.0, 3.0, 0.0, 0.0), 0),
                 (Vectors.sparse(5, {1: 1.0, 3: 5.5}), 1),
                 (Vectors.sparse(5, {4: -3.0}), 0),
-            ] * 10,
-            ["features", "label"]
+            ]
+            * 10,
+            ["features", "label"],
         )
 
     def get_local_tmp_dir(self):
@@ -1005,9 +1007,7 @@ class XgboostLocalTest(SparkTestCase):
         pred_result2 = model2.transform(self.reg_df_sparse_train).collect()
 
         for row1, row2 in zip(pred_result, pred_result2):
-            self.assertTrue(
-                np.isclose(row1.prediction, row2.prediction, atol=1e-3)
-            )
+            self.assertTrue(np.isclose(row1.prediction, row2.prediction, atol=1e-3))
 
     def test_classifier_with_sparse_optim(self):
         cls = SparkXGBClassifier(missing=0.0)
@@ -1023,6 +1023,4 @@ class XgboostLocalTest(SparkTestCase):
         pred_result2 = model2.transform(self.cls_df_sparse_train).collect()
 
         for row1, row2 in zip(pred_result, pred_result2):
-            self.assertTrue(
-                np.allclose(row1.probability, row2.probability, rtol=1e-3)
-            )
+            self.assertTrue(np.allclose(row1.probability, row2.probability, rtol=1e-3))

--- a/tests/python/test_spark/test_spark_local.py
+++ b/tests/python/test_spark/test_spark_local.py
@@ -994,11 +994,14 @@ class XgboostLocalTest(SparkTestCase):
     def test_regressor_with_sparse_optim(self):
         regressor = SparkXGBRegressor(missing=0.0)
         model = regressor.fit(self.reg_df_sparse_train)
+        assert model._xgb_sklearn_model.missing == 0.0
         pred_result = model.transform(self.reg_df_sparse_train).collect()
 
         # enable sparse optimiaztion
         regressor2 = SparkXGBRegressor(missing=0.0, enable_sparse_data_optim=True)
         model2 = regressor2.fit(self.reg_df_sparse_train)
+        assert model2.getOrDefault(model2.enable_sparse_data_optim)
+        assert model2._xgb_sklearn_model.missing == 0.0
         pred_result2 = model2.transform(self.reg_df_sparse_train).collect()
 
         for row1, row2 in zip(pred_result, pred_result2):
@@ -1009,11 +1012,14 @@ class XgboostLocalTest(SparkTestCase):
     def test_classifier_with_sparse_optim(self):
         cls = SparkXGBClassifier(missing=0.0)
         model = cls.fit(self.cls_df_sparse_train)
+        assert model._xgb_sklearn_model.missing == 0.0
         pred_result = model.transform(self.cls_df_sparse_train).collect()
 
         # enable sparse optimiaztion
         cls2 = SparkXGBClassifier(missing=0.0, enable_sparse_data_optim=True)
         model2 = cls2.fit(self.cls_df_sparse_train)
+        assert model2.getOrDefault(model2.enable_sparse_data_optim)
+        assert model2._xgb_sklearn_model.missing == 0.0
         pred_result2 = model2.transform(self.cls_df_sparse_train).collect()
 
         for row1, row2 in zip(pred_result, pred_result2):

--- a/tests/python/test_spark/test_spark_local.py
+++ b/tests/python/test_spark/test_spark_local.py
@@ -972,3 +972,12 @@ class XgboostLocalTest(SparkTestCase):
         )
         model = classifier.fit(self.cls_df_train)
         model.transform(self.cls_df_test).collect()
+
+    def test_regressor_with_sparse_optim(self):
+        regressor = SparkXGBRegressor(missing=0.0)
+        model = regressor.fit(self.reg_df_train)
+        pred_result = model.transform(self.reg_df_test).collect()
+        for row in pred_result:
+            self.assertTrue(
+                np.isclose(row.prediction, row.expected_prediction, atol=1e-3)
+            )

--- a/tests/python/test_spark/test_spark_local_cluster.py
+++ b/tests/python/test_spark/test_spark_local_cluster.py
@@ -1,11 +1,11 @@
-import sys
-import random
 import json
-import uuid
 import os
+import random
+import sys
+import uuid
 
-import pytest
 import numpy as np
+import pytest
 import testing as tm
 
 if tm.no_spark()["condition"]:
@@ -13,10 +13,11 @@ if tm.no_spark()["condition"]:
 if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
     pytest.skip("Skipping PySpark tests on Windows", allow_module_level=True)
 
-from .utils import SparkLocalClusterTestCase
+from pyspark.ml.linalg import Vectors
 from xgboost.spark import SparkXGBClassifier, SparkXGBRegressor
 from xgboost.spark.utils import _get_max_num_concurrent_tasks
-from pyspark.ml.linalg import Vectors
+
+from .utils import SparkLocalClusterTestCase
 
 
 class XgboostLocalClusterTestCase(SparkLocalClusterTestCase):

--- a/tests/python/test_spark/utils.py
+++ b/tests/python/test_spark/utils.py
@@ -3,22 +3,18 @@ import logging
 import shutil
 import sys
 import tempfile
-
 import unittest
+
 import pytest
-
-from six import StringIO
-
 import testing as tm
+from six import StringIO
 
 if tm.no_spark()["condition"]:
     pytest.skip(msg=tm.no_spark()["reason"], allow_module_level=True)
 if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
     pytest.skip("Skipping PySpark tests on Windows", allow_module_level=True)
 
-from pyspark.sql import SQLContext
-from pyspark.sql import SparkSession
-
+from pyspark.sql import SparkSession, SQLContext
 from xgboost.spark.utils import _get_default_params_from_func
 
 


### PR DESCRIPTION
Closes https://github.com/dmlc/xgboost/issues/8108

Make Xgboost estimator support using sparse matrix as optimization.