### PR TITLE
Update PyPi wheel size limit.

### DIFF
--- a/tests/ci_build/rename_whl.py
+++ b/tests/ci_build/rename_whl.py
@@ -42,4 +42,4 @@ with cd(dirname):
 
     filesize = os.path.getsize(new_name) / 1024 / 1024  # MB
     msg = f"Limit of wheel size set by PyPI is exceeded. {new_name}: {filesize}"
-    assert filesize <= 200, msg
+    assert filesize <= 300, msg


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/8135 .

Thanks to the upgrade from the PyPI maintainer, the limit for XGBoost is now 300MB. But we still need to think of a more future-proofed way to reduce the overall binary size.