### PR TITLE
Simplify Python getting started example

### DIFF
--- a/doc/get_started.rst
+++ b/doc/get_started.rst
@@ -19,16 +19,18 @@ Python
 
 .. code-block:: python
 
-  import xgboost as xgb
-  # read in data
-  dtrain = xgb.DMatrix('demo/data/agaricus.txt.train')
-  dtest = xgb.DMatrix('demo/data/agaricus.txt.test')
-  # specify parameters via map
-  param = {'max_depth':2, 'eta':1, 'objective':'binary:logistic' }
-  num_round = 2
-  bst = xgb.train(param, dtrain, num_round)
-  # make prediction
-  preds = bst.predict(dtest)
+  from xgboost import XGBClassifier
+  # read data
+  from sklearn.datasets import load_iris
+  from sklearn.model_selection import train_test_split
+  data = load_iris()
+  X_train, X_test, y_train, y_test = train_test_split(data['data'], data['target'], test_size=.2)
+  # create model instance
+  bst = XGBClassifier(n_estimators=2, max_depth=2, learning_rate=1, objective='binary:logistic')
+  # fit model
+  bst.fit(X_train, y_train)
+  # make predictions
+  preds = bst.predict(X_test)
 
 ***
 R


### PR DESCRIPTION
This PR aims to resolve issue #8146. 

#### Current behavior: 

The current Python [getting started example](https://xgboost.readthedocs.io/en/stable/get_started.html) requires the user to manually set the local file path to the Agaricus data set in libsvm format before being able to run the example code. 

#### New behavior: 

This PR leverages `sklearn` to load the data set. Hence, as long as the user has `sklearn` installed, after a `pip install xgboost`, the user should be able to run the getting started example as is (reducing friction, especially for new users). 

#### Additional Details:

- The well-known Iris data set is used, since the Agaricus data set is not available in `sklearn.datasets`. 
- The `xgboost.XGBClassifier` class is used here rather than the `xgboost.fit` function to train the model as the latter would require an extra step of converting form `numpy` arrays to `xgboost.DMatrix`. 