### PR TITLE
[WIP] Fix GPU categorical bug.

### DIFF
--- a/src/common/categorical.h
+++ b/src/common/categorical.h
@@ -49,8 +49,6 @@ inline XGBOOST_DEVICE bool InvalidCat(float cat) {
 }
 
 /* \brief Whether should it traverse to left branch of a tree.
- *
- *  For one hot split, go to left if it's NOT the matching category.
  */
 template <bool validate = true>
 inline XGBOOST_DEVICE bool Decision(common::Span<uint32_t const> cats, float cat, bool dft_left) {
@@ -63,9 +61,9 @@ inline XGBOOST_DEVICE bool Decision(common::Span<uint32_t const> cats, float cat
 
   auto pos = KCatBitField::ToBitPos(cat);
   if (pos.int_pos >= cats.size()) {
-    return true;
+    return false;
   }
-  return !s_cats.Check(AsCat(cat));
+  return s_cats.Check(AsCat(cat));
 }
 
 inline void InvalidCategory() {

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -255,8 +255,7 @@ class TextGenerator : public TreeGenerator {
 
   std::string Indicator(RegTree const& tree, int32_t nid, uint32_t) const override {
     static std::string const kIndicatorTemplate = "{nid}:[{fname}] yes={yes},no={no}";
-    int32_t nyes = tree[nid].DefaultLeft() ?
-                   tree[nid].RightChild() : tree[nid].LeftChild();
+    int32_t nyes = tree[nid].LeftChild();
     auto split_index = tree[nid].SplitIndex();
     std::string result = SuperT::Match(
         kIndicatorTemplate,
@@ -315,7 +314,7 @@ class TextGenerator : public TreeGenerator {
     auto cats = GetSplitCategories(tree, nid);
     std::string cats_str = PrintCatsAsSet(cats);
     static std::string const kNodeTemplate =
-        "{tabs}{nid}:[{fname}:{cond}] yes={right},no={left},missing={missing}";
+        "{tabs}{nid}:[{fname}:{cond}] yes={left},no={right},missing={missing}";
     std::string const result =
         SplitNodeImpl(tree, nid, kNodeTemplate, cats_str, depth);
     return result;
@@ -621,12 +620,7 @@ class GraphvizGenerator : public TreeGenerator {
         "    {nid} -> {child} [label=\"{branch}\" color=\"{color}\"]\n";
     // Is this the default child for missing value?
     bool is_missing = tree[nid].DefaultChild() == child;
-    std::string branch;
-    if (is_categorical) {
-      branch = std::string{left ? "no" : "yes"} + std::string{is_missing ? ", missing" : ""};
-    } else {
-      branch = std::string{left ? "yes" : "no"} + std::string{is_missing ? ", missing" : ""};
-    }
+    std::string branch = std::string{left ? "yes" : "no"} + std::string{is_missing ? ", missing" : ""};
     std::string buffer =
         SuperT::Match(kEdgeTemplate,
                 {{"{nid}", std::to_string(nid)},

--- a/tests/cpp/tree/gpu_hist/test_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_evaluate_splits.cu
@@ -83,6 +83,244 @@ TEST(GpuHist, EvaluateCategoricalSplit) {
   TestEvaluateSingleSplit(true);
 }
 
+TEST(GpuHist, PartitionBasic) {
+  TrainParam tparam = ZeroParam();
+  tparam.max_cat_to_onehot = 0;
+  GPUTrainingParam param{tparam};
+
+  common::HistogramCuts cuts;
+  cuts.cut_values_.HostVector() = std::vector<float>{0.0, 1.0, 2.0};
+  cuts.cut_ptrs_.HostVector() = std::vector<uint32_t>{0, 3};
+  cuts.min_vals_.HostVector() =  std::vector<float>{0.0};
+  cuts.cut_ptrs_.SetDevice(0);
+  cuts.cut_values_.SetDevice(0);
+  cuts.min_vals_.SetDevice(0);
+  thrust::device_vector<bst_feature_t> feature_set =
+      std::vector<bst_feature_t>{0};
+
+  thrust::device_vector<int> monotonic_constraints(feature_set.size(), 0);
+  dh::device_vector<FeatureType> feature_types(feature_set.size(), FeatureType::kCategorical);
+  common::Span<FeatureType> d_feature_types;
+  auto max_cat =
+      *std::max_element(cuts.cut_values_.HostVector().begin(), cuts.cut_values_.HostVector().end());
+  cuts.SetCategorical(true, max_cat);
+  d_feature_types = dh::ToSpan(feature_types);
+
+  EvaluateSplitSharedInputs shared_inputs{
+      param,
+      d_feature_types,
+      cuts.cut_ptrs_.ConstDeviceSpan(),
+      cuts.cut_values_.ConstDeviceSpan(),
+      cuts.min_vals_.ConstDeviceSpan(),
+  };
+
+  GPUHistEvaluator evaluator{
+      tparam, static_cast<bst_feature_t>(feature_set.size()), 0};
+  evaluator.Reset(cuts, dh::ToSpan(feature_types), feature_set.size(), tparam, 0);
+
+  {
+    // -1.0s go left
+    // -3.0s go right
+    GradientPairPrecise parent_sum(-5.0, 3.0);
+    thrust::device_vector<GradientPairPrecise> feature_histogram =
+        std::vector<GradientPairPrecise>{{-1.0, 1.0}, {-1.0, 1.0}, {-3.0, 1.0}};
+    EvaluateSplitInputs input{0, 0, parent_sum, dh::ToSpan(feature_set),
+                              dh::ToSpan(feature_histogram)};
+    DeviceSplitCandidate result = evaluator.EvaluateSingleSplit(input, shared_inputs).split;
+    auto cats = std::bitset<32>(evaluator.GetHostNodeCats(input.nidx)[0]);
+    EXPECT_EQ(cats, std::bitset<32>("11000000000000000000000000000000"));
+    EXPECT_FLOAT_EQ(result.left_sum.GetGrad() + result.right_sum.GetGrad(), parent_sum.GetGrad());
+    EXPECT_FLOAT_EQ(result.left_sum.GetHess() + result.right_sum.GetHess(), parent_sum.GetHess());
+  }
+
+  {
+    // -1.0s go left
+    // -3.0s go right
+    GradientPairPrecise parent_sum(-7.0, 3.0);
+    thrust::device_vector<GradientPairPrecise> feature_histogram =
+        std::vector<GradientPairPrecise>{{-1.0, 1.0}, {-3.0, 1.0}, {-3.0, 1.0}};
+    EvaluateSplitInputs input{1, 0, parent_sum, dh::ToSpan(feature_set),
+                              dh::ToSpan(feature_histogram)};
+    DeviceSplitCandidate result = evaluator.EvaluateSingleSplit(input, shared_inputs).split;
+    auto cats = std::bitset<32>(evaluator.GetHostNodeCats(input.nidx)[0]);
+    EXPECT_EQ(cats, std::bitset<32>("10000000000000000000000000000000"));
+    EXPECT_FLOAT_EQ(result.left_sum.GetGrad() + result.right_sum.GetGrad(), parent_sum.GetGrad());
+    EXPECT_FLOAT_EQ(result.left_sum.GetHess() + result.right_sum.GetHess(), parent_sum.GetHess());
+  }
+  {
+    // All -1.0, gain from splitting should be 0.0
+    GradientPairPrecise parent_sum(-3.0, 3.0);
+    thrust::device_vector<GradientPairPrecise> feature_histogram =
+        std::vector<GradientPairPrecise>{{-1.0, 1.0}, {-1.0, 1.0}, {-1.0, 1.0}};
+    EvaluateSplitInputs input{2, 0, parent_sum, dh::ToSpan(feature_set),
+                              dh::ToSpan(feature_histogram)};
+    DeviceSplitCandidate result = evaluator.EvaluateSingleSplit(input, shared_inputs).split;
+    EXPECT_FLOAT_EQ(result.loss_chg, 0.0f);
+    EXPECT_FLOAT_EQ(result.left_sum.GetGrad() + result.right_sum.GetGrad(), parent_sum.GetGrad());
+    EXPECT_FLOAT_EQ(result.left_sum.GetHess() + result.right_sum.GetHess(), parent_sum.GetHess());
+  }
+  // With 3.0/3.0 missing values
+  // All categories go left
+  // missing values go right
+  {
+    GradientPairPrecise parent_sum(0.0, 6.0);
+    thrust::device_vector<GradientPairPrecise> feature_histogram =
+        std::vector<GradientPairPrecise>{{-1.0, 1.0}, {-1.0, 1.0}, {-1.0, 1.0}};
+    EvaluateSplitInputs input{3, 0, parent_sum, dh::ToSpan(feature_set),
+                              dh::ToSpan(feature_histogram)};
+    DeviceSplitCandidate result = evaluator.EvaluateSingleSplit(input, shared_inputs).split;
+    auto cats = std::bitset<32>(evaluator.GetHostNodeCats(input.nidx)[0]);
+    EXPECT_EQ(cats, std::bitset<32>("11100000000000000000000000000000"));
+    EXPECT_EQ(result.dir, kRightDir);
+    EXPECT_FLOAT_EQ(result.left_sum.GetGrad() + result.right_sum.GetGrad(), parent_sum.GetGrad());
+    EXPECT_FLOAT_EQ(result.left_sum.GetHess() + result.right_sum.GetHess(), parent_sum.GetHess());
+  }
+  {
+    // -1.0s go left
+    // -3.0s go right
+    GradientPairPrecise parent_sum(-5.0, 3.0);
+    thrust::device_vector<GradientPairPrecise> feature_histogram =
+        std::vector<GradientPairPrecise>{{-1.0, 1.0}, {-3.0, 1.0}, {-1.0, 1.0}};
+    EvaluateSplitInputs input{4, 0, parent_sum, dh::ToSpan(feature_set),
+                              dh::ToSpan(feature_histogram)};
+    DeviceSplitCandidate result = evaluator.EvaluateSingleSplit(input, shared_inputs).split;
+    auto cats = std::bitset<32>(evaluator.GetHostNodeCats(input.nidx)[0]);
+    EXPECT_EQ(cats, std::bitset<32>("10100000000000000000000000000000"));
+    EXPECT_FLOAT_EQ(result.left_sum.GetGrad() + result.right_sum.GetGrad(), parent_sum.GetGrad());
+    EXPECT_FLOAT_EQ(result.left_sum.GetHess() + result.right_sum.GetHess(), parent_sum.GetHess());
+  }
+  {
+    // -1.0s go left
+    // -3.0s go right
+    GradientPairPrecise parent_sum(-5.0, 3.0);
+    thrust::device_vector<GradientPairPrecise> feature_histogram =
+        std::vector<GradientPairPrecise>{{-3.0, 1.0}, {-1.0, 1.0}, {-3.0, 1.0}};
+    EvaluateSplitInputs input{5, 0, parent_sum, dh::ToSpan(feature_set),
+                              dh::ToSpan(feature_histogram)};
+    DeviceSplitCandidate result = evaluator.EvaluateSingleSplit(input, shared_inputs).split;
+    auto cats = std::bitset<32>(evaluator.GetHostNodeCats(input.nidx)[0]);
+    EXPECT_EQ(cats, std::bitset<32>("01000000000000000000000000000000"));
+    EXPECT_FLOAT_EQ(result.left_sum.GetGrad() + result.right_sum.GetGrad(), parent_sum.GetGrad());
+    EXPECT_FLOAT_EQ(result.left_sum.GetHess() + result.right_sum.GetHess(), parent_sum.GetHess());
+  }
+}
+
+TEST(GpuHist, PartitionTwoFeatures) {
+  TrainParam tparam = ZeroParam();
+  tparam.max_cat_to_onehot = 0;
+  GPUTrainingParam param{tparam};
+
+  common::HistogramCuts cuts;
+  cuts.cut_values_.HostVector() = std::vector<float>{0.0, 1.0, 2.0, 0.0, 1.0, 2.0};
+  cuts.cut_ptrs_.HostVector() = std::vector<uint32_t>{0, 3, 6};
+  cuts.min_vals_.HostVector() =  std::vector<float>{0.0, 0.0};
+  cuts.cut_ptrs_.SetDevice(0);
+  cuts.cut_values_.SetDevice(0);
+  cuts.min_vals_.SetDevice(0);
+  thrust::device_vector<bst_feature_t> feature_set =
+      std::vector<bst_feature_t>{0, 1};
+
+  thrust::device_vector<int> monotonic_constraints(feature_set.size(), 0);
+  dh::device_vector<FeatureType> feature_types(feature_set.size(), FeatureType::kCategorical);
+  common::Span<FeatureType> d_feature_types(dh::ToSpan(feature_types));
+  auto max_cat =
+      *std::max_element(cuts.cut_values_.HostVector().begin(), cuts.cut_values_.HostVector().end());
+  cuts.SetCategorical(true, max_cat);
+
+  EvaluateSplitSharedInputs shared_inputs{
+      param,
+      d_feature_types,
+      cuts.cut_ptrs_.ConstDeviceSpan(),
+      cuts.cut_values_.ConstDeviceSpan(),
+      cuts.min_vals_.ConstDeviceSpan(),
+  };
+
+  GPUHistEvaluator evaluator{
+      tparam, static_cast<bst_feature_t>(feature_set.size()), 0};
+  evaluator.Reset(cuts, dh::ToSpan(feature_types), feature_set.size(), tparam, 0);
+
+  {
+    GradientPairPrecise parent_sum(-6.0, 3.0);
+    thrust::device_vector<GradientPairPrecise> feature_histogram =
+        std::vector<GradientPairPrecise>{{-2.0, 1.0}, {-2.0, 1.0}, {-2.0, 1.0},{-1.0, 1.0}, {-1.0, 1.0}, {-4.0, 1.0}};
+    EvaluateSplitInputs input{0, 0, parent_sum, dh::ToSpan(feature_set),
+                              dh::ToSpan(feature_histogram)};
+    DeviceSplitCandidate result = evaluator.EvaluateSingleSplit(input, shared_inputs).split;
+    auto cats = std::bitset<32>(evaluator.GetHostNodeCats(input.nidx)[0]);
+    EXPECT_EQ(result.findex, 1);
+    EXPECT_EQ(cats, std::bitset<32>("11000000000000000000000000000000"));
+    EXPECT_FLOAT_EQ(result.left_sum.GetGrad() + result.right_sum.GetGrad(), parent_sum.GetGrad());
+    EXPECT_FLOAT_EQ(result.left_sum.GetHess() + result.right_sum.GetHess(), parent_sum.GetHess());
+  }
+
+  {
+    GradientPairPrecise parent_sum(-6.0, 3.0);
+    thrust::device_vector<GradientPairPrecise> feature_histogram =
+        std::vector<GradientPairPrecise>{{-2.0, 1.0}, {-2.0, 1.0}, {-2.0, 1.0},{-1.0, 1.0}, {-2.5, 1.0}, {-2.5, 1.0}};
+    EvaluateSplitInputs input{1, 0, parent_sum, dh::ToSpan(feature_set),
+                              dh::ToSpan(feature_histogram)};
+    DeviceSplitCandidate result = evaluator.EvaluateSingleSplit(input, shared_inputs).split;
+    auto cats = std::bitset<32>(evaluator.GetHostNodeCats(input.nidx)[0]);
+    EXPECT_EQ(result.findex, 1);
+    EXPECT_EQ(cats, std::bitset<32>("10000000000000000000000000000000"));
+    EXPECT_FLOAT_EQ(result.left_sum.GetGrad() + result.right_sum.GetGrad(), parent_sum.GetGrad());
+    EXPECT_FLOAT_EQ(result.left_sum.GetHess() + result.right_sum.GetHess(), parent_sum.GetHess());
+  }
+}
+
+TEST(GpuHist, PartitionTwoNodes) {
+  TrainParam tparam = ZeroParam();
+  tparam.max_cat_to_onehot = 0;
+  GPUTrainingParam param{tparam};
+
+  common::HistogramCuts cuts;
+  cuts.cut_values_.HostVector() = std::vector<float>{0.0, 1.0, 2.0};
+  cuts.cut_ptrs_.HostVector() = std::vector<uint32_t>{0, 3};
+  cuts.min_vals_.HostVector() =  std::vector<float>{0.0};
+  cuts.cut_ptrs_.SetDevice(0);
+  cuts.cut_values_.SetDevice(0);
+  cuts.min_vals_.SetDevice(0);
+  thrust::device_vector<bst_feature_t> feature_set =
+      std::vector<bst_feature_t>{0};
+
+  thrust::device_vector<int> monotonic_constraints(feature_set.size(), 0);
+  dh::device_vector<FeatureType> feature_types(feature_set.size(), FeatureType::kCategorical);
+  common::Span<FeatureType> d_feature_types(dh::ToSpan(feature_types));
+  auto max_cat =
+      *std::max_element(cuts.cut_values_.HostVector().begin(), cuts.cut_values_.HostVector().end());
+  cuts.SetCategorical(true, max_cat);
+
+  EvaluateSplitSharedInputs shared_inputs{
+      param,
+      d_feature_types,
+      cuts.cut_ptrs_.ConstDeviceSpan(),
+      cuts.cut_values_.ConstDeviceSpan(),
+      cuts.min_vals_.ConstDeviceSpan(),
+  };
+
+  GPUHistEvaluator evaluator{
+      tparam, static_cast<bst_feature_t>(feature_set.size()), 0};
+  evaluator.Reset(cuts, dh::ToSpan(feature_types), feature_set.size(), tparam, 0);
+
+  {
+    GradientPairPrecise parent_sum(-6.0, 3.0);
+    thrust::device_vector<GradientPairPrecise> feature_histogram_a =
+        std::vector<GradientPairPrecise>{{-1.0, 1.0}, {-2.5, 1.0}, {-2.5, 1.0},{-1.0, 1.0}, {-1.0, 1.0}, {-4.0, 1.0}};
+        thrust::device_vector<EvaluateSplitInputs> inputs(2);
+    inputs[0]= EvaluateSplitInputs{0, 0, parent_sum, dh::ToSpan(feature_set),
+                              dh::ToSpan(feature_histogram_a)};
+    thrust::device_vector<GradientPairPrecise> feature_histogram_b =
+        std::vector<GradientPairPrecise>{{-1.0, 1.0}, {-1.0, 1.0}, {-4.0, 1.0}};
+    inputs[1]= EvaluateSplitInputs{1, 0, parent_sum, dh::ToSpan(feature_set),
+                              dh::ToSpan(feature_histogram_b)};
+                              thrust::device_vector<GPUExpandEntry> results(2);
+    evaluator.EvaluateSplits({0,1},1,dh::ToSpan(inputs), shared_inputs,dh::ToSpan(results));
+    GPUExpandEntry result_a = results[0];
+    GPUExpandEntry result_b = results[1];
+    EXPECT_EQ(std::bitset<32>(evaluator.GetHostNodeCats(0)[0]), std::bitset<32>("10000000000000000000000000000000"));
+    EXPECT_EQ(std::bitset<32>(evaluator.GetHostNodeCats(1)[0]), std::bitset<32>("11000000000000000000000000000000"));
+  }
+}
 TEST(GpuHist, EvaluateSingleSplitMissing) {
   GradientPairPrecise parent_sum(1.0, 1.5);
   TrainParam tparam = ZeroParam();


### PR DESCRIPTION
This fixes an off by one error in GPU partition based split calculation and changes the direction of the categorical split condition. The off by one error resulted in one category consistently being put on the wrong side, so training loss can diverge significantly. 

Before, a training instance that belongs to the set of a categorical split would take the right branch, now it takes the left branch. For me this feels like a simplification, as matching the split condition always goes left, and also avoids complication in split evaluation with the direction of scan and missing value direction.

I have not adjusted the CPU code yet, so CPU tests should fail, but this should be relatively simple.