### PR TITLE
Copy data from Ellpack to GHist.

### DIFF
--- a/src/common/algorithm.cuh
+++ b/src/common/algorithm.cuh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <thrust/binary_search.h>     // thrust::upper_bound
+#include <thrust/execution_policy.h>  // thrust::seq
+
+#include "xgboost/base.h"
+#include "xgboost/span.h"
+
+namespace xgboost {
+namespace common {
+namespace cuda {
+template <typename It>
+size_t XGBOOST_DEVICE SegmentId(It first, It last, size_t idx) {
+  size_t segment_id = thrust::upper_bound(thrust::seq, first, last, idx) - 1 - first;
+  return segment_id;
+}
+
+template <typename T>
+size_t XGBOOST_DEVICE SegmentId(Span<T> segments_ptr, size_t idx) {
+  return SegmentId(segments_ptr.cbegin(), segments_ptr.cend(), idx);
+}
+}  // namespace cuda
+}  // namespace common
+}  // namespace xgboost

--- a/src/common/algorithm.cuh
+++ b/src/common/algorithm.cuh
@@ -1,3 +1,6 @@
+/*!
+ * Copyright 2022 by XGBoost Contributors
+ */
 #pragma once
 
 #include <thrust/binary_search.h>     // thrust::upper_bound

--- a/src/common/algorithm.h
+++ b/src/common/algorithm.h
@@ -1,3 +1,6 @@
+/*!
+ * Copyright 2022 by XGBoost Contributors
+ */
 #pragma once
 #include <algorithm>  // std::upper_bound
 #include <cinttypes>  // std::size_t

--- a/src/common/algorithm.h
+++ b/src/common/algorithm.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <algorithm>  // std::upper_bound
+#include <cinttypes>  // std::size_t
+
+namespace xgboost {
+namespace common {
+template <typename It, typename Idx>
+auto SegmentId(It first, It last, Idx idx) {
+  std::size_t segment_id = std::upper_bound(first, last, idx) - 1 - first;
+  return segment_id;
+}
+}  // namespace common
+}  // namespace xgboost

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -266,7 +266,7 @@ class ColumnMatrix {
     DispatchBinType(bins_type_size_, [&](auto t) {
       using ColumnBinT = decltype(t);
       ColumnBinT* local_index = reinterpret_cast<ColumnBinT*>(index_.data());
-      size_t const batch_size = gmat.Size();
+      size_t const batch_size = batch.Size();
       size_t k{0};
       for (size_t rid = 0; rid < batch_size; ++rid) {
         auto line = batch.GetLine(rid);

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -150,7 +150,6 @@ class ColumnMatrix {
     // pre-fill index_ for dense columns
     auto n_features = gmat.Features();
     if (!any_missing_) {
-      missing_flags_.resize(feature_offsets_[n_features], false);
       // row index is compressed, we need to dispatch it.
       DispatchBinType(gmat.index.GetBinTypeSize(), [&, size = batch.Size(), n_features = n_features,
                                                     n_threads = n_threads](auto t) {
@@ -210,6 +209,7 @@ class ColumnMatrix {
   template <typename RowBinIdxT>
   void SetIndexNoMissing(bst_row_t base_rowid, RowBinIdxT const* row_index, const size_t n_samples,
                          const size_t n_features, int32_t n_threads) {
+    missing_flags_.resize(feature_offsets_[n_features], false);
     DispatchBinType(bins_type_size_, [&](auto t) {
       using ColumnBinT = decltype(t);
       auto column_index = Span<ColumnBinT>{reinterpret_cast<ColumnBinT*>(index_.data()),

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -35,6 +35,7 @@
 #include "xgboost/global_config.h"
 
 #include "common.h"
+#include "algorithm.cuh"
 
 #ifdef XGBOOST_USE_NCCL
 #include "nccl.h"
@@ -1556,17 +1557,7 @@ XGBOOST_DEVICE thrust::transform_iterator<FuncT, IterT, ReturnT> MakeTransformIt
   return thrust::transform_iterator<FuncT, IterT, ReturnT>(iter, func);
 }
 
-template <typename It>
-size_t XGBOOST_DEVICE SegmentId(It first, It last, size_t idx) {
-  size_t segment_id = thrust::upper_bound(thrust::seq, first, last, idx) -
-                      1 - first;
-  return segment_id;
-}
-
-template <typename T>
-size_t XGBOOST_DEVICE SegmentId(xgboost::common::Span<T> segments_ptr, size_t idx) {
-  return SegmentId(segments_ptr.cbegin(), segments_ptr.cend(), idx);
-}
+using xgboost::common::cuda::SegmentId;  // import it for compatibility
 
 namespace detail {
 template <typename Key, typename KeyOutIt>

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -131,18 +131,22 @@ class HistogramCuts {
   /**
    * \brief Search the bin index for categorical feature.
    */
-  bst_bin_t SearchCatBin(float value, bst_feature_t fidx) const {
-    auto const &ptrs = this->Ptrs();
-    auto const &vals = this->Values();
+  bst_bin_t SearchCatBin(float value, bst_feature_t fidx, std::vector<uint32_t> const& ptrs,
+                         std::vector<float> const& vals) const {
     auto end = ptrs.at(fidx + 1) + vals.cbegin();
     auto beg = ptrs[fidx] + vals.cbegin();
     // Truncates the value in case it's not perfectly rounded.
-    auto v  = static_cast<float>(common::AsCat(value));
+    auto v = static_cast<float>(common::AsCat(value));
     auto bin_idx = std::lower_bound(beg, end, v) - vals.cbegin();
     if (bin_idx == ptrs.at(fidx + 1)) {
       bin_idx -= 1;
     }
     return bin_idx;
+  }
+  bst_bin_t SearchCatBin(float value, bst_feature_t fidx) const {
+    auto const& ptrs = this->Ptrs();
+    auto const& vals = this->Values();
+    return this->SearchCatBin(value, fidx, ptrs, vals);
   }
   bst_bin_t SearchCatBin(Entry const& e) const { return SearchCatBin(e.fvalue, e.index); }
 

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -22,6 +22,7 @@
 #include "row_set.h"
 #include "threading_utils.h"
 #include "timer.h"
+#include "algorithm.h"  // SegmentId
 
 namespace xgboost {
 class GHistIndexMatrix;
@@ -144,6 +145,18 @@ class HistogramCuts {
     return bin_idx;
   }
   bst_bin_t SearchCatBin(Entry const& e) const { return SearchCatBin(e.fvalue, e.index); }
+
+  static bst_feature_t SearchFeature(std::vector<uint32_t> const& ptrs, bst_bin_t bin_idx) {
+    auto fidx = SegmentId(ptrs.cbegin(), ptrs.cend(), bin_idx);
+    return fidx;
+  }
+  /**
+   * \brief Search the feature index with histogram bin index.
+   */
+  bst_feature_t SearchFeature(bst_bin_t bin_idx) {
+    auto const& ptrs = this->Ptrs();  // might race due to pulling data to host.
+    return SearchFeature(ptrs, bin_idx);
+  }
 };
 
 /**

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -547,4 +547,15 @@ EllpackDeviceAccessor EllpackPageImpl::GetDeviceAccessor(
                                                NumSymbols()),
           feature_types};
 }
+EllpackDeviceAccessor EllpackPageImpl::GetHostAccessor(
+    common::Span<FeatureType const> feature_types) const {
+  return {Context::kCpuId,
+          cuts_,
+          is_dense,
+          row_stride,
+          base_rowid,
+          n_rows,
+          common::CompressedIterator<uint32_t>(gidx_buffer.ConstHostPointer(), NumSymbols()),
+          feature_types};
+}
 }  // namespace xgboost

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -43,12 +43,18 @@ struct EllpackDeviceAccessor {
         base_rowid(base_rowid),
         n_rows(n_rows) ,gidx_iter(gidx_iter),
         feature_types{feature_types} {
-    cuts.cut_values_.SetDevice(device);
-    cuts.cut_ptrs_.SetDevice(device);
-    cuts.min_vals_.SetDevice(device);
-    gidx_fvalue_map = cuts.cut_values_.ConstDeviceSpan();
-    feature_segments = cuts.cut_ptrs_.ConstDeviceSpan();
-    min_fvalue = cuts.min_vals_.ConstDeviceSpan();
+    if (device == Context::kCpuId) {
+      gidx_fvalue_map = cuts.cut_values_.ConstHostSpan();
+      feature_segments = cuts.cut_ptrs_.ConstHostSpan();
+      min_fvalue = cuts.min_vals_.ConstHostSpan();
+    } else {
+      cuts.cut_values_.SetDevice(device);
+      cuts.cut_ptrs_.SetDevice(device);
+      cuts.min_vals_.SetDevice(device);
+      gidx_fvalue_map = cuts.cut_values_.ConstDeviceSpan();
+      feature_segments = cuts.cut_ptrs_.ConstDeviceSpan();
+      min_fvalue = cuts.min_vals_.ConstDeviceSpan();
+    }
   }
   // Get a matrix element, uses binary search for look up Return NaN if missing
   // Given a row index and a feature index, returns the corresponding cut value
@@ -202,6 +208,7 @@ class EllpackPageImpl {
   EllpackDeviceAccessor
   GetDeviceAccessor(int device,
                     common::Span<FeatureType const> feature_types = {}) const;
+  EllpackDeviceAccessor GetHostAccessor(common::Span<FeatureType const> feature_types = {}) const;
 
  private:
   /*!

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -66,6 +66,13 @@ GHistIndexMatrix::GHistIndexMatrix(MetaInfo const &info, common::HistogramCuts &
       max_num_bins(max_bin_per_feat),
       isDense_{info.num_col_ * info.num_row_ == info.num_nonzero_} {}
 
+#if !defined(XGBOOST_USE_CUDA)
+GHistIndexMatrix::GHistIndexMatrix(Context const *, MetaInfo const &, EllpackPage const &,
+                                   BatchParam const &) {
+  common::AssertGPUSupport();
+}
+#endif  // defined(XGBOOST_USE_CUDA)
+
 GHistIndexMatrix::~GHistIndexMatrix() = default;
 
 void GHistIndexMatrix::PushBatch(SparsePage const &batch, common::Span<FeatureType const> ft,

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -66,7 +66,6 @@ GHistIndexMatrix::GHistIndexMatrix(MetaInfo const &info, common::HistogramCuts &
       max_num_bins(max_bin_per_feat),
       isDense_{info.num_col_ * info.num_row_ == info.num_nonzero_} {}
 
-
 GHistIndexMatrix::~GHistIndexMatrix() = default;
 
 void GHistIndexMatrix::PushBatch(SparsePage const &batch, common::Span<FeatureType const> ft,

--- a/src/data/gradient_index.cu
+++ b/src/data/gradient_index.cu
@@ -1,3 +1,6 @@
+/*!
+ * Copyright 2022 by XGBoost Contributors
+ */
 #include <memory>  // std::unique_ptr
 
 #include "../common/column_matrix.h"

--- a/src/data/gradient_index.cu
+++ b/src/data/gradient_index.cu
@@ -10,9 +10,11 @@ namespace xgboost {
 void CopyEllpackToGHist(Context const* ctx, MetaInfo const& info, EllpackPageImpl const& page,
                         GHistIndexMatrix* p_out) {
   CHECK_EQ(info.num_row_, page.Size());
-  auto cuts = page.Cuts();
   GHistIndexMatrix& out = *p_out;
   out.cut = page.Cuts();
+  out.cut.Ptrs();
+  out.cut.Values();
+  out.cut.MinValues();
 
   out.ResizeIndex(info.num_nonzero_, page.is_dense);
   if (page.is_dense) {
@@ -84,8 +86,12 @@ void CopyEllpackToGHist(Context const* ctx, MetaInfo const& info, EllpackPageImp
       hit_count_tloc[tid * n_bins_total + idx] = 0;  // reset for next batch
     }
   });
+
   CHECK_EQ(out.Features(), info.num_col_);
   CHECK_EQ(out.Size(), info.num_row_);
+  CHECK(out.cut.cut_ptrs_.HostCanRead());
+  CHECK(out.cut.cut_values_.HostCanRead());
+  CHECK(out.cut.min_vals_.HostCanRead());
 }
 
 GHistIndexMatrix::GHistIndexMatrix(Context const* ctx, MetaInfo const& info,

--- a/src/data/gradient_index.cu
+++ b/src/data/gradient_index.cu
@@ -1,0 +1,90 @@
+#include <memory>  // std::unique_ptr
+
+#include "../common/column_matrix.h"
+#include "../common/hist_util.h"
+#include "ellpack_page.cuh"
+#include "gradient_index.h"
+#include "xgboost/data.h"
+
+namespace xgboost {
+void CopyEllpackToGHist(Context const* ctx, MetaInfo const& info, EllpackPageImpl const& page,
+                        size_t nnz, GHistIndexMatrix* p_out) {
+  CHECK_EQ(info.num_row_, page.Size());
+  auto cuts = page.Cuts();
+  GHistIndexMatrix& out = *p_out;
+  out.cut = page.Cuts();
+
+  out.ResizeIndex(info.num_nonzero_, page.is_dense);
+  if (page.is_dense) {
+    out.index.SetBinOffset(page.Cuts().Ptrs());
+  }
+
+  auto n_threads = ctx->Threads();
+  auto const& h_gidx_buffer = page.gidx_buffer.ConstHostVector();
+  common::CompressedIterator<bst_bin_t> data_buf{h_gidx_buffer.data(), page.NumSymbols()};
+  if (page.is_dense) {
+    uint32_t const* offsets = out.index.Offset();
+    out.row_ptr.resize(page.Size() + 1);
+    out.row_ptr.front() = 0;
+    for (size_t i = 1; i < out.row_ptr.size(); ++i) {
+      out.row_ptr[i] = out.row_ptr[i - 1] + page.row_stride;
+    }
+    auto n_bins_total = page.Cuts().TotalBins();
+    std::vector<size_t> hit_count_tloc(ctx->Threads() * n_bins_total, 0);
+    common::DispatchBinType(out.index.GetBinTypeSize(), [&](auto dtype) {
+      using T = decltype(dtype);
+      auto get_offset = [&](auto bin_idx, auto fidx) {
+        return static_cast<T>(bin_idx - offsets[fidx]);
+      };
+      common::Span<T> index_data_span = {out.index.data<T>(), out.index.Size()};
+      common::ParallelFor(page.Size(), n_threads, [&](auto i) {
+        auto tid = omp_get_thread_num();
+        size_t ibegin = page.row_stride * i;
+        for (size_t j = 0; j < page.row_stride; ++j) {
+          auto bin_idx = data_buf[ibegin + j];
+          index_data_span[ibegin + j] = get_offset(bin_idx, j);
+          ++hit_count_tloc[tid * n_bins_total + bin_idx];
+        }
+      });
+    });
+
+    out.hit_count.resize(n_bins_total, 0);
+    common::ParallelFor(n_bins_total, ctx->Threads(), [&](auto idx) {
+      for (int32_t tid = 0; tid < n_threads; ++tid) {
+        out.hit_count[idx] += hit_count_tloc[tid * n_bins_total + idx];
+        hit_count_tloc[tid * n_bins_total + idx] = 0;  // reset for next batch
+      }
+    });
+
+    {
+
+    }
+  } else {
+    LOG(FATAL) << "Not implemented";
+  }
+  CHECK_EQ(out.Features(), info.num_col_);
+  CHECK_EQ(out.Size(), info.num_row_);
+}
+
+GHistIndexMatrix::GHistIndexMatrix(Context const* ctx, MetaInfo const& info,
+                                   EllpackPage const& in_page, BatchParam const& p) {
+  auto page = in_page.Impl();
+
+  CopyEllpackToGHist(ctx, info, *page, info.num_nonzero_, this);
+
+  this->columns_ = std::make_unique<common::ColumnMatrix>(*this, p.sparse_thresh);
+  auto n_features = info.num_col_;
+
+  if (page->is_dense) {
+    // row index is compressed, we need to dispatch it.
+    common::DispatchBinType(index.GetBinTypeSize(),
+                            [&, size = page->Size(), n_features = n_features](auto t) {
+                              using RowBinIdxT = decltype(t);
+                              columns_->SetIndexNoMissing(base_rowid, index.data<RowBinIdxT>(),
+                                                          size, n_features, ctx->Threads());
+                            });
+  } else {
+    LOG(FATAL) << "Not implemented";
+  }
+}
+}  // namespace xgboost

--- a/src/data/gradient_index.cu
+++ b/src/data/gradient_index.cu
@@ -38,7 +38,7 @@ void SetIndexData(Context const* ctx, EllpackPageImpl const* page,
       ++hit_count_tloc[tid * n_bins_total + bin_idx];
     }
   });
-};
+}
 
 void GetRowPtrFromEllpack(Context const* ctx, EllpackPageImpl const* page,
                           std::vector<size_t>* p_out) {

--- a/src/data/gradient_index.cu
+++ b/src/data/gradient_index.cu
@@ -1,12 +1,66 @@
 #include <memory>  // std::unique_ptr
 
 #include "../common/column_matrix.h"
-#include "../common/hist_util.h"
+#include "../common/hist_util.h"  // Index
 #include "ellpack_page.cuh"
 #include "gradient_index.h"
 #include "xgboost/data.h"
 
 namespace xgboost {
+// Similar to GHistIndexMatrix::SetIndexData, but without the need for adaptor or bin
+// searching. Is there a way to unify the code?
+template <typename BinT, typename CompressOffset>
+void SetIndexData(Context const* ctx, EllpackPageImpl const* page,
+                  std::vector<size_t>* p_hit_count_tloc, CompressOffset&& get_offset,
+                  GHistIndexMatrix* out) {
+  auto accessor = page->GetHostAccessor();
+  auto const kNull = static_cast<bst_bin_t>(accessor.NullValue());
+
+  common::Span<BinT> index_data_span = {out->index.data<BinT>(), out->index.Size()};
+  auto n_bins_total = page->Cuts().TotalBins();
+
+  auto& hit_count_tloc = *p_hit_count_tloc;
+  hit_count_tloc.clear();
+  hit_count_tloc.resize(ctx->Threads() * n_bins_total, 0);
+
+  common::ParallelFor(page->Size(), ctx->Threads(), [&](auto i) {
+    auto tid = omp_get_thread_num();
+    size_t in_rbegin = page->row_stride * i;
+    size_t out_rbegin = out->row_ptr[i];
+    auto r_size = out->row_ptr[i + 1] - out->row_ptr[i];
+    for (size_t j = 0; j < r_size; ++j) {
+      auto bin_idx = accessor.gidx_iter[in_rbegin + j];
+      assert(bin_idx != kNull);
+      index_data_span[out_rbegin + j] = get_offset(bin_idx, j);
+      ++hit_count_tloc[tid * n_bins_total + bin_idx];
+    }
+  });
+};
+
+void GetRowPtrFromEllpack(Context const* ctx, EllpackPageImpl const* page,
+                          std::vector<size_t>* p_out) {
+  auto& row_ptr = *p_out;
+  row_ptr.resize(page->Size() + 1, 0);
+  if (page->is_dense) {
+    std::fill(row_ptr.begin() + 1, row_ptr.end(), page->row_stride);
+  } else {
+    auto accessor = page->GetHostAccessor();
+    auto const kNull = static_cast<bst_bin_t>(accessor.NullValue());
+
+    std::vector<size_t> row_size(page->Size() + 1, 0);
+    common::ParallelFor(page->Size(), ctx->Threads(), [&](auto i) {
+      size_t ibegin = page->row_stride * i;
+      for (size_t j = 0; j < page->row_stride; ++j) {
+        auto bin_idx = accessor.gidx_iter[ibegin + j];
+        if (bin_idx != kNull) {
+          row_size[i + 1]++;
+        }
+      }
+    });
+  }
+  std::partial_sum(row_ptr.begin(), row_ptr.end(), row_ptr.begin());
+}
+
 GHistIndexMatrix::GHistIndexMatrix(Context const* ctx, MetaInfo const& info,
                                    EllpackPage const& in_page, BatchParam const& p)
     : max_num_bins{p.max_bin} {
@@ -26,69 +80,23 @@ GHistIndexMatrix::GHistIndexMatrix(Context const* ctx, MetaInfo const& info,
     this->index.SetBinOffset(page->Cuts().Ptrs());
   }
 
-  auto n_threads = ctx->Threads();
-  auto const& h_gidx_buffer = page->gidx_buffer.ConstHostVector();
   auto n_bins_total = page->Cuts().TotalBins();
-  std::vector<size_t> hit_count_tloc(ctx->Threads() * n_bins_total, 0);
-
-  common::CompressedIterator<bst_bin_t> data_buf{h_gidx_buffer.data(), page->NumSymbols()};
+  GetRowPtrFromEllpack(ctx, page, &this->row_ptr);
   if (page->is_dense) {
-    uint32_t const* offsets = this->index.Offset();
-    this->row_ptr.resize(page->Size() + 1);
-    this->row_ptr.front() = 0;
-    for (size_t i = 1; i < this->row_ptr.size(); ++i) {
-      this->row_ptr[i] = this->row_ptr[i - 1] + page->row_stride;
-    }
     common::DispatchBinType(this->index.GetBinTypeSize(), [&](auto dtype) {
       using T = decltype(dtype);
-      auto get_offset = [&](auto bin_idx, auto fidx) {
-        return static_cast<T>(bin_idx - offsets[fidx]);
-      };
-      common::Span<T> index_data_span = {this->index.data<T>(), this->index.Size()};
-
-      common::ParallelFor(page->Size(), n_threads, [&](auto i) {
-        auto tid = omp_get_thread_num();
-        size_t ibegin = page->row_stride * i;
-        for (size_t j = 0; j < page->row_stride; ++j) {
-          auto bin_idx = data_buf[ibegin + j];
-          index_data_span[ibegin + j] = get_offset(bin_idx, j);
-          ++hit_count_tloc[tid * n_bins_total + bin_idx];
-        }
-      });
+      ::xgboost::SetIndexData<T>(ctx, page, &hit_count_tloc_, index.MakeCompressor<T>(), this);
     });
   } else {
-    std::vector<size_t> row_size(page->Size() + 1, 0);
-    auto const kNull = static_cast<bst_bin_t>(page->GetDeviceAccessor(ctx->gpu_id).NullValue());
-    common::ParallelFor(page->Size(), ctx->Threads(), [&](auto i) {
-      size_t ibegin = page->row_stride * i;
-      for (size_t j = 0; j < page->row_stride; ++j) {
-        auto bin_idx = data_buf[ibegin + j];
-        if (bin_idx != kNull) {
-          row_size[i + 1]++;
-        }
-      }
-    });
-    std::partial_sum(row_size.begin(), row_size.end(), row_size.begin());
-    this->row_ptr = std::move(row_size);
-
-    common::Span<uint32_t> index_data_span = {this->index.data<uint32_t>(), this->index.Size()};
-    common::ParallelFor(page->Size(), n_threads, [&](auto i) {
-      auto tid = omp_get_thread_num();
-      size_t in_rbegin = page->row_stride * i;
-      size_t out_rbegin = this->row_ptr[i];
-      auto r_size = this->row_ptr[i + 1] - this->row_ptr[i];
-      for (size_t j = 0; j < r_size; ++j) {
-        auto bin_idx = data_buf[in_rbegin + j];
-        assert(bin_idx != kNull);
-        index_data_span[out_rbegin + j] = bin_idx;
-        ++hit_count_tloc[tid * n_bins_total + bin_idx];
-      }
-    });
+    // no compression
+    ::xgboost::SetIndexData<uint32_t>(
+        ctx, page, &hit_count_tloc_, [&](auto bin_idx, auto fidx) { return bin_idx; }, this);
   }
 
   this->hit_count.resize(n_bins_total, 0);
-  this->GatherHitCount(n_threads, n_bins_total);
+  this->GatherHitCount(ctx->Threads(), n_bins_total);
 
+  // sanity checks
   CHECK_EQ(this->Features(), info.num_col_);
   CHECK_EQ(this->Size(), info.num_row_);
   CHECK(this->cut.cut_ptrs_.HostCanRead());

--- a/src/data/gradient_index.cu
+++ b/src/data/gradient_index.cu
@@ -7,43 +7,48 @@
 #include "xgboost/data.h"
 
 namespace xgboost {
-void CopyEllpackToGHist(Context const* ctx, MetaInfo const& info, EllpackPageImpl const& page,
-                        GHistIndexMatrix* p_out) {
-  CHECK_EQ(info.num_row_, page.Size());
-  GHistIndexMatrix& out = *p_out;
-  out.cut = page.Cuts();
-  out.cut.Ptrs();
-  out.cut.Values();
-  out.cut.MinValues();
+GHistIndexMatrix::GHistIndexMatrix(Context const* ctx, MetaInfo const& info,
+                                   EllpackPage const& in_page, BatchParam const& p)
+    : max_num_bins{p.max_bin} {
+  auto page = in_page.Impl();
+  isDense_ = page->is_dense;
 
-  out.ResizeIndex(info.num_nonzero_, page.is_dense);
-  if (page.is_dense) {
-    out.index.SetBinOffset(page.Cuts().Ptrs());
+  CHECK_EQ(info.num_row_, in_page.Size());
+
+  this->cut = page->Cuts();
+
+  this->cut.Ptrs();
+  this->cut.Values();
+  this->cut.MinValues();
+
+  this->ResizeIndex(info.num_nonzero_, page->is_dense);
+  if (page->is_dense) {
+    this->index.SetBinOffset(page->Cuts().Ptrs());
   }
 
   auto n_threads = ctx->Threads();
-  auto const& h_gidx_buffer = page.gidx_buffer.ConstHostVector();
-  auto n_bins_total = page.Cuts().TotalBins();
+  auto const& h_gidx_buffer = page->gidx_buffer.ConstHostVector();
+  auto n_bins_total = page->Cuts().TotalBins();
   std::vector<size_t> hit_count_tloc(ctx->Threads() * n_bins_total, 0);
 
-  common::CompressedIterator<bst_bin_t> data_buf{h_gidx_buffer.data(), page.NumSymbols()};
-  if (page.is_dense) {
-    uint32_t const* offsets = out.index.Offset();
-    out.row_ptr.resize(page.Size() + 1);
-    out.row_ptr.front() = 0;
-    for (size_t i = 1; i < out.row_ptr.size(); ++i) {
-      out.row_ptr[i] = out.row_ptr[i - 1] + page.row_stride;
+  common::CompressedIterator<bst_bin_t> data_buf{h_gidx_buffer.data(), page->NumSymbols()};
+  if (page->is_dense) {
+    uint32_t const* offsets = this->index.Offset();
+    this->row_ptr.resize(page->Size() + 1);
+    this->row_ptr.front() = 0;
+    for (size_t i = 1; i < this->row_ptr.size(); ++i) {
+      this->row_ptr[i] = this->row_ptr[i - 1] + page->row_stride;
     }
-    common::DispatchBinType(out.index.GetBinTypeSize(), [&](auto dtype) {
+    common::DispatchBinType(this->index.GetBinTypeSize(), [&](auto dtype) {
       using T = decltype(dtype);
       auto get_offset = [&](auto bin_idx, auto fidx) {
         return static_cast<T>(bin_idx - offsets[fidx]);
       };
-      common::Span<T> index_data_span = {out.index.data<T>(), out.index.Size()};
-      common::ParallelFor(page.Size(), n_threads, [&](auto i) {
+      common::Span<T> index_data_span = {this->index.data<T>(), this->index.Size()};
+      common::ParallelFor(page->Size(), n_threads, [&](auto i) {
         auto tid = omp_get_thread_num();
-        size_t ibegin = page.row_stride * i;
-        for (size_t j = 0; j < page.row_stride; ++j) {
+        size_t ibegin = page->row_stride * i;
+        for (size_t j = 0; j < page->row_stride; ++j) {
           auto bin_idx = data_buf[ibegin + j];
           index_data_span[ibegin + j] = get_offset(bin_idx, j);
           ++hit_count_tloc[tid * n_bins_total + bin_idx];
@@ -51,11 +56,11 @@ void CopyEllpackToGHist(Context const* ctx, MetaInfo const& info, EllpackPageImp
       });
     });
   } else {
-    std::vector<size_t> row_size(page.Size() + 1, 0);
-    auto const kNull = static_cast<bst_bin_t>(page.GetDeviceAccessor(ctx->gpu_id).NullValue());
-    common::ParallelFor(page.Size(), ctx->Threads(), [&](auto i) {
-      size_t ibegin = page.row_stride * i;
-      for (size_t j = 0; j < page.row_stride; ++j) {
+    std::vector<size_t> row_size(page->Size() + 1, 0);
+    auto const kNull = static_cast<bst_bin_t>(page->GetDeviceAccessor(ctx->gpu_id).NullValue());
+    common::ParallelFor(page->Size(), ctx->Threads(), [&](auto i) {
+      size_t ibegin = page->row_stride * i;
+      for (size_t j = 0; j < page->row_stride; ++j) {
         auto bin_idx = data_buf[ibegin + j];
         if (bin_idx != kNull) {
           row_size[i + 1]++;
@@ -63,13 +68,13 @@ void CopyEllpackToGHist(Context const* ctx, MetaInfo const& info, EllpackPageImp
       }
     });
     std::partial_sum(row_size.begin(), row_size.end(), row_size.begin());
-    out.row_ptr = std::move(row_size);
-    common::Span<uint32_t> index_data_span = {out.index.data<uint32_t>(), out.index.Size()};
-    common::ParallelFor(page.Size(), n_threads, [&](auto i) {
+    this->row_ptr = std::move(row_size);
+    common::Span<uint32_t> index_data_span = {this->index.data<uint32_t>(), this->index.Size()};
+    common::ParallelFor(page->Size(), n_threads, [&](auto i) {
       auto tid = omp_get_thread_num();
-      size_t in_rbegin = page.row_stride * i;
-      size_t out_rbegin = out.row_ptr[i];
-      auto r_size = out.row_ptr[i + 1] - out.row_ptr[i];
+      size_t in_rbegin = page->row_stride * i;
+      size_t out_rbegin = this->row_ptr[i];
+      auto r_size = this->row_ptr[i + 1] - this->row_ptr[i];
       for (size_t j = 0; j < r_size; ++j) {
         auto bin_idx = data_buf[in_rbegin + j];
         assert(bin_idx != kNull);
@@ -79,28 +84,19 @@ void CopyEllpackToGHist(Context const* ctx, MetaInfo const& info, EllpackPageImp
     });
   }
 
-  out.hit_count.resize(n_bins_total, 0);
+  this->hit_count.resize(n_bins_total, 0);
   common::ParallelFor(n_bins_total, ctx->Threads(), [&](auto idx) {
     for (int32_t tid = 0; tid < n_threads; ++tid) {
-      out.hit_count[idx] += hit_count_tloc[tid * n_bins_total + idx];
+      this->hit_count[idx] += hit_count_tloc[tid * n_bins_total + idx];
       hit_count_tloc[tid * n_bins_total + idx] = 0;  // reset for next batch
     }
   });
 
-  CHECK_EQ(out.Features(), info.num_col_);
-  CHECK_EQ(out.Size(), info.num_row_);
-  CHECK(out.cut.cut_ptrs_.HostCanRead());
-  CHECK(out.cut.cut_values_.HostCanRead());
-  CHECK(out.cut.min_vals_.HostCanRead());
-}
-
-GHistIndexMatrix::GHistIndexMatrix(Context const* ctx, MetaInfo const& info,
-                                   EllpackPage const& in_page, BatchParam const& p)
-    : max_num_bins{p.max_bin} {
-  auto page = in_page.Impl();
-  isDense_ = page->is_dense;
-
-  CopyEllpackToGHist(ctx, info, *page, this);
+  CHECK_EQ(this->Features(), info.num_col_);
+  CHECK_EQ(this->Size(), info.num_row_);
+  CHECK(this->cut.cut_ptrs_.HostCanRead());
+  CHECK(this->cut.cut_values_.HostCanRead());
+  CHECK(this->cut.min_vals_.HostCanRead());
 
   this->columns_ = std::make_unique<common::ColumnMatrix>(*this, p.sparse_thresh);
   this->columns_->PushBatch(ctx->Threads(), *this);

--- a/src/data/gradient_index.cu
+++ b/src/data/gradient_index.cu
@@ -50,13 +50,12 @@ void GetRowPtrFromEllpack(Context const* ctx, EllpackPageImpl const* page,
     auto accessor = page->GetHostAccessor();
     auto const kNull = static_cast<bst_bin_t>(accessor.NullValue());
 
-    std::vector<size_t> row_size(page->Size() + 1, 0);
     common::ParallelFor(page->Size(), ctx->Threads(), [&](auto i) {
       size_t ibegin = page->row_stride * i;
       for (size_t j = 0; j < page->row_stride; ++j) {
-        auto bin_idx = accessor.gidx_iter[ibegin + j];
+        bst_bin_t bin_idx = accessor.gidx_iter[ibegin + j];
         if (bin_idx != kNull) {
-          row_size[i + 1]++;
+          row_ptr[i + 1]++;
         }
       }
     });
@@ -93,7 +92,7 @@ GHistIndexMatrix::GHistIndexMatrix(Context const* ctx, MetaInfo const& info,
   } else {
     // no compression
     ::xgboost::SetIndexData<uint32_t>(
-        ctx, page, &hit_count_tloc_, [&](auto bin_idx, auto fidx) { return bin_idx; }, this);
+        ctx, page, &hit_count_tloc_, [&](auto bin_idx, auto) { return bin_idx; }, this);
   }
 
   this->hit_count.resize(n_bins_total, 0);

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -150,6 +150,13 @@ class GHistIndexMatrix {
    */
   GHistIndexMatrix(MetaInfo const& info, common::HistogramCuts&& cuts, bst_bin_t max_bin_per_feat);
   /**
+   * \brief Constructor fro Iterative DMatrix where we might copy an existing ellpack page
+   *        to host gradient index.
+   */
+  GHistIndexMatrix(Context const* ctx, MetaInfo const& info, EllpackPage const& page,
+                   BatchParam const& p);
+
+  /**
    * \brief Constructor for external memory.
    */
   GHistIndexMatrix(SparsePage const& page, common::Span<FeatureType const> ft,

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -69,7 +69,7 @@ class GHistIndexMatrix {
         if (is_valid(elem)) {
           bst_bin_t bin_idx{-1};
           if (common::IsCat(ft, elem.column_idx)) {
-            bin_idx = cut.SearchCatBin(elem.value, elem.column_idx);
+            bin_idx = cut.SearchCatBin(elem.value, elem.column_idx, ptrs, values);
           } else {
             bin_idx = cut.SearchBin(elem.value, elem.column_idx, ptrs, values);
           }

--- a/src/data/iterative_dmatrix.cc
+++ b/src/data/iterative_dmatrix.cc
@@ -206,14 +206,10 @@ void IterativeDMatrix::InitFromCPU(DataIterHandle iter_handle, float missing,
 BatchSet<GHistIndexMatrix> IterativeDMatrix::GetGradientIndex(BatchParam const& param) {
   CheckParam(param);
   if (!ghist_) {
+    CHECK(ellpack_);
     ghist_ = std::make_shared<GHistIndexMatrix>(&ctx_, Info(), *ellpack_, param);
   }
-  CHECK(ghist_) << R"(`QuantileDMatrix` is not initialized with CPU data but used for CPU training.
-Possible solutions:
-- Use `DMatrix` instead.
-- Use CPU input for `QuantileDMatrix`.
-- Run training on GPU.
-)";
+
   auto begin_iter =
       BatchIterator<GHistIndexMatrix>(new SimpleBatchIteratorImpl<GHistIndexMatrix>(ghist_));
   return BatchSet<GHistIndexMatrix>(begin_iter);

--- a/src/data/iterative_dmatrix.cc
+++ b/src/data/iterative_dmatrix.cc
@@ -205,6 +205,9 @@ void IterativeDMatrix::InitFromCPU(DataIterHandle iter_handle, float missing,
 
 BatchSet<GHistIndexMatrix> IterativeDMatrix::GetGradientIndex(BatchParam const& param) {
   CheckParam(param);
+  if (!ghist_) {
+    ghist_ = std::make_shared<GHistIndexMatrix>(&ctx_, Info(), *ellpack_, param);
+  }
   CHECK(ghist_) << R"(`QuantileDMatrix` is not initialized with CPU data but used for CPU training.
 Possible solutions:
 - Use `DMatrix` instead.

--- a/src/data/iterative_dmatrix.h
+++ b/src/data/iterative_dmatrix.h
@@ -29,20 +29,17 @@ namespace data {
  * `QuantileDMatrix` is an intermediate storage for quantilization results including
  * quantile cuts and histogram index. Quantilization is designed to be performed on stream
  * of data (or batches of it). As a result, the `QuantileDMatrix` is also designed to work
- * with batches of data. During initializaion, it will walk through the data multiple
- * times iteratively in order to perform quantilization. This design can help us reduce
- * memory usage significantly by avoiding data concatenation along with removing the CSR
- * matrix `SparsePage`. However, it has its limitation (can be fixed if needed):
+ * with batches of data. During initializaion, it walks through the data multiple times
+ * iteratively in order to perform quantilization. This design helps us reduce memory
+ * usage significantly by avoiding data concatenation along with removing the CSR matrix
+ * `SparsePage`. However, it has its limitation (can be fixed if needed):
  *
  * - It's only supported by hist tree method (both CPU and GPU) since approx requires a
  *   re-calculation of quantiles for each iteration. We can fix this by retaining a
  *   reference to the callback if there are feature requests.
  *
  * - The CPU format and the GPU format are different, the former uses a CSR + CSC for
- *   histogram index while the latter uses only Ellpack. This results into a design that
- *   we can obtain the GPU format from CPU but the other way around is not yet
- *   supported. We can search the bin value from ellpack to recover the feature index when
- *   we support copying data from GPU to CPU.
+ *   histogram index while the latter uses only Ellpack.
  */
 class IterativeDMatrix : public DMatrix {
   MetaInfo info_;

--- a/tests/cpp/data/test_gradient_index.cc
+++ b/tests/cpp/data/test_gradient_index.cc
@@ -139,8 +139,12 @@ class GHistIndexMatrixTest : public testing::TestWithParam<std::tuple<float, flo
       auto const &gidx_from_ellpack = from_ellpack->index;
 
       for (size_t i = 0; i < gidx_from_sparse.Size(); ++i) {
-        EXPECT_EQ(gidx_from_sparse[i], gidx_from_ellpack[i]);
+        ASSERT_EQ(gidx_from_sparse[i], gidx_from_ellpack[i]);
       }
+
+      auto const& columns_from_sparse = from_sparse_page.Transpose();
+      auto const& columns_from_ellpack = from_ellpack->Transpose();
+      ASSERT_EQ(columns_from_sparse.AnyMissing(), columns_from_ellpack.AnyMissing());
     }
   }
 };
@@ -160,6 +164,7 @@ INSTANTIATE_TEST_SUITE_P(GHistIndexMatrix, GHistIndexMatrixTest,
                                          std::make_tuple(1.f, .2),    // no missing
                                          std::make_tuple(.5f, .6),    // sparse columns
                                          std::make_tuple(.6f, .4)));  // dense columns
-#endif
+
+#endif  // defined(XGBOOST_USE_CUDA)
 }  // namespace data
 }  // namespace xgboost

--- a/tests/cpp/data/test_gradient_index.cc
+++ b/tests/cpp/data/test_gradient_index.cc
@@ -107,5 +107,59 @@ TEST(GradientIndex, PushBatch) {
   test(0.5f);
   test(0.9f);
 }
+
+#if defined(XGBOOST_USE_CUDA)
+
+namespace {
+class GHistIndexMatrixTest : public testing::TestWithParam<std::tuple<float, float>> {
+ protected:
+  void Run(float density, double threshold) {
+    // Only testing with small sample size as the cuts might be different between host and
+    // device.
+    size_t n_samples{128}, n_features{13};
+    Context ctx;
+    ctx.gpu_id = 0;
+    auto Xy = RandomDataGenerator{n_samples, n_features, 1 - density}.GenerateDMatrix(true);
+    std::unique_ptr<GHistIndexMatrix> from_ellpack;
+    ASSERT_TRUE(Xy->SingleColBlock());
+    bst_bin_t constexpr kBins{17};
+    auto p = BatchParam{kBins, threshold};
+    for (auto const &page : Xy->GetBatches<EllpackPage>(BatchParam{0, kBins})) {
+      from_ellpack.reset(new GHistIndexMatrix{&ctx, Xy->Info(), page, p});
+    }
+
+    for (auto const &from_sparse_page : Xy->GetBatches<GHistIndexMatrix>(p)) {
+      ASSERT_EQ(from_sparse_page.IsDense(), from_ellpack->IsDense());
+      ASSERT_EQ(from_sparse_page.base_rowid, 0);
+      ASSERT_EQ(from_sparse_page.base_rowid, from_ellpack->base_rowid);
+      ASSERT_EQ(from_sparse_page.Size(), from_ellpack->Size());
+      ASSERT_EQ(from_sparse_page.index.Size(), from_ellpack->index.Size());
+
+      auto const &gidx_from_sparse = from_sparse_page.index;
+      auto const &gidx_from_ellpack = from_ellpack->index;
+
+      for (size_t i = 0; i < gidx_from_sparse.Size(); ++i) {
+        EXPECT_EQ(gidx_from_sparse[i], gidx_from_ellpack[i]);
+      }
+    }
+  }
+};
+}  // anonymous namespace
+
+TEST_P(GHistIndexMatrixTest, FromEllpack) {
+  float sparsity;
+  double thresh;
+  std::tie(sparsity, thresh) = GetParam();
+  this->Run(sparsity, thresh);
+}
+
+INSTANTIATE_TEST_SUITE_P(GHistIndexMatrix, GHistIndexMatrixTest,
+                         testing::Values(std::make_tuple(1.f, .0),    // no missing
+                                         std::make_tuple(.2f, .8),    // sparse columns
+                                         std::make_tuple(.8f, .2),    // dense columns
+                                         std::make_tuple(1.f, .2),    // no missing
+                                         std::make_tuple(.5f, .6),    // sparse columns
+                                         std::make_tuple(.6f, .4)));  // dense columns
+#endif
 }  // namespace data
 }  // namespace xgboost


### PR DESCRIPTION
This allows XGBoost to train with `hist` tree method on CPU with GPU-initialized `QuantileDMatrix`.

Related: https://github.com/dmlc/xgboost/issues/7890 .