### PR TITLE
Fix dask.py lint error

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1684,7 +1684,7 @@ class DaskScikitLearnBase(XGBModel):
 
     def __getstate__(self) -> Dict:
         this = self.__dict__.copy()
-        if "_client" in this.keys():
+        if "_client" in this:
             del this["_client"]
         return this
 


### PR DESCRIPTION
CI is complaining about pylint error:
```
 /home/runner/work/xgboost/xgboost/python-package/xgboost/dask.py:1687: convention (C0201, consider-iterating-dictionary, DaskScikitLearnBase.__getstate__) Consider iterating the dictionary directly instead of calling .keys()
```
@trivialfis 