### PR TITLE
Optimization/buildhist/hist util

### DIFF
--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -192,11 +192,14 @@ void BuildHistKernel(const std::vector<GradientPair> &gpair,
     }
     const BinIdxType *gr_index_local = gradient_index + icol_start;
 
+    // The trick with pgh_t helps the compiler to use more effective processor instructions.
+    const float pgh_t[] = {pgh[idx_gh], pgh[idx_gh + 1]};
     for (size_t j = 0; j < row_size; ++j) {
       const uint32_t idx_bin = two * (static_cast<uint32_t>(gr_index_local[j]) +
                                       (any_missing ? 0 : offsets[j]));
-      hist_data[idx_bin] += pgh[idx_gh];
-      hist_data[idx_bin + 1] += pgh[idx_gh + 1];
+      auto hist_local = hist_data + idx_bin;
+      *(hist_local)     += pgh_t[0];
+      *(hist_local + 1) += pgh_t[1];
     }
   }
 }

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -192,7 +192,7 @@ void BuildHistKernel(const std::vector<GradientPair> &gpair,
     }
     const BinIdxType *gr_index_local = gradient_index + icol_start;
 
-    // The trick with pgh_t helps the compiler to use more effective processor instructions.
+    // The trick with pgh_t buffer helps the compiler to generate faster binary.
     const float pgh_t[] = {pgh[idx_gh], pgh[idx_gh + 1]};
     for (size_t j = 0; j < row_size; ++j) {
       const uint32_t idx_bin = two * (static_cast<uint32_t>(gr_index_local[j]) +


### PR DESCRIPTION
Hi,
this small PR provides performance improvement for BuildHistKernel by helping the compiler to generate faster binary. For performance measurements I booked the c6i.12xlarge (24 cores, hyperthreading is off) instance on on Amazon Web Services and used the benchmarks from [here](https://github.com/IntelPython/scikit-learn_bench).

Each dataset was executed five times. The average run time is calculated by the formula
average = (run1 + run2 + run3 + run4 + run5 - min - max) / 3. I.e. the fastest and the slowest runs are cuted off, then other three are averaged. The summary of measurements are in the following table:
(Note that speed up value of the mlsr dataset is not a representative, due to runtime speed of this dataset is very unstable).

|  Dataset name       | master run1    | master run2    | master run3    | master run4    | master run5    | master average  | this PR run1    | this PR run2   | this PR run3    | this PR run4    | this PR run5    | this PR average   | speedup |
| --------------------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | -------- | ------- |
| abalone               | 4.10E-01 | 4.03E-01 | 4.11E-01 | 3.99E-01 | 4.05E-01 | **4.06E-01** | 4.02E-01 | 4.01E-01 | 3.94E-01 | 3.97E-01 | 3.96E-01 | **3.98E-01** | **1.02**    |
| airline-ohe           | 4.09E+01 | 4.20E+01 | 4.00E+01 | 3.99E+01 | 4.20E+01 | **4.10E+0**1 | 3.37E+01 | 3.37E+01 | 3.37E+01 | 3.27E+01 | 3.39E+01 | **3.37E+01** | **1.22**    |
| higgs1m               | 1.04E+01 | 1.04E+01 | 1.04E+01 | 1.04E+01 | 1.04E+01 | **1.04E+01** | 9.26E+00 | 9.27E+00 | 9.27E+00 | 9.32E+00 | 9.23E+00 | **9.27E+00** | **1.12**    |
| letters               | 1.04E+01 | 1.04E+01 | 1.04E+01 | 1.02E+01 | 1.02E+01 | **1.03E+01** | 1.01E+01 | 1.00E+01 | 1.00E+01 | 1.00E+01 | 1.00E+01 | **1.00E+01** | **1.03**    |
| mlsr                  | 9.64E+01 | 9.50E+01 | 6.80E+01 | 6.79E+01 | 6.83E+01 | **7.71E+01** | 5.94E+01 | 5.31E+01 | 5.36E+01 | 5.62E+01 | 9.19E+01 | **5.64E+01** | **1.37**    |
| mortgage1Q            | 1.15E+01 | 1.15E+01 | 1.16E+01 | 1.15E+01 | 1.15E+01 | **1.15E+01** | 1.04E+01 | 1.04E+01 | 1.16E+01 | 1.04E+01 | 1.04E+01 | **1.04E+01** | **1.11**    |
| plasticc              | 4.83E-01 | 4.86E-01 | 4.85E-01 | 4.91E-01 | 4.83E-01 | **4.85E-01** | 4.69E-01 | 4.72E-01 | 4.74E-01 | 4.73E-01 | 4.77E-01 | **4.73E-01** | **1.02**    |
| santander             | 1.29E+02 | 1.29E+02 | 1.30E+02 | 1.29E+02 | 1.29E+02 | **1.29E+02** | 1.02E+02 | 1.03E+02 | 1.02E+02 | 1.03E+02 | 1.02E+02 | **1.02E+02** | **1.26**    |
| airline               | 1.22E+02 | 1.22E+02 | 1.21E+02 | 1.21E+02 | 1.21E+02 | **1.21E+02** | 1.17E+02 | 1.17E+02 | 1.17E+02 | 1.20E+02 | 1.17E+02 | **1.17E+02** | **1.04**    |
| bosch                 | 7.57E+00 | 7.59E+00 | 7.57E+00 | 7.59E+00 | 7.58E+00 | **7.58E+00** | 7.23E+00 | 7.23E+00 | 7.20E+00 | 7.18E+00 | 7.17E+00 | **7.20E+00** | **1.05**    |
| covtype               | 5.69E+00 | 5.77E+00 | 5.81E+00 | 5.86E+00 | 6.69E+00 | **5.81E+00** | 4.56E+00 | 3.79E+00 | 3.96E+00 | 4.06E+00 | 3.26E+00 | **3.94E+00** | **1.48**    |
| epsion                | 2.13E+02 | 2.14E+02 | 2.12E+02 | 2.11E+02 | 2.10E+02 | **2.12E+02** | 1.83E+02 | 1.86E+02 | 1.84E+02 | 1.87E+02 | 1.86E+02 | **1.85E+02** | **1.14**    |
| fraud                 | 2.79E-01 | 2.92E-01 | 2.88E-01 | 2.79E-01 | 2.77E-01 | **2.82E-01** | 2.58E-01 | 2.59E-01 | 2.60E-01 | 2.58E-01 | 2.58E-01 | **2.58E-01** | **1.09**   |
| higgs                 | 1.46E+01 | 1.45E+01 | 1.45E+01 | 1.45E+01 | 1.45E+01 | **1.45E+01** | 1.37E+01 | 1.38E+01 | 1.41E+01 | 1.37E+01 | 1.37E+01 | **1.37E+01** | **1.06**    |
| year\_prediction\_msd | 1.45E+00 | 1.45E+00 | 1.45E+00 | 1.45E+00 | 1.45E+00 | **1.45E+00** | 1.26E+00 | 1.26E+00 | 1.26E+00 | 1.27E+00 | 1.26E+00 | **1.26E+00** | **1.15**    |
| geomean               |          |          |          |          |          |          |          |          |          |          |          |          | **1.14**    |