### PR TITLE
Drop use of deleted virtual function to support older MacOS

### DIFF
--- a/include/xgboost/json.h
+++ b/include/xgboost/json.h
@@ -58,6 +58,9 @@ class Value {
   virtual Json& operator[](int ind);
 
   virtual bool operator==(Value const& rhs) const = 0;
+#if !defined(__APPLE__)
+  virtual Value& operator=(Value const& rhs) = delete;
+#endif  // !defined(__APPLE__)
 
   std::string TypeStr() const;
 

--- a/include/xgboost/json.h
+++ b/include/xgboost/json.h
@@ -58,7 +58,6 @@ class Value {
   virtual Json& operator[](int ind);
 
   virtual bool operator==(Value const& rhs) const = 0;
-  virtual Value& operator=(Value const& rhs) = delete;
 
   std::string TypeStr() const;
 


### PR DESCRIPTION
Deleted virtual functions are not supported in earlier versions of MacOS (<10.15). See https://github.com/JuliaPackaging/Yggdrasil/pull/5430.