### PR TITLE
[pyspark] Fix xgboost spark estimator dataset repartition issues

### DIFF
--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -20,7 +20,7 @@ from pyspark.ml.param.shared import (
     HasWeightCol,
 )
 from pyspark.ml.util import MLReadable, MLWritable
-from pyspark.sql.functions import col, countDistinct, pandas_udf, struct, rand
+from pyspark.sql.functions import col, countDistinct, pandas_udf, rand, struct
 from pyspark.sql.types import (
     ArrayType,
     DoubleType,
@@ -168,7 +168,7 @@ class _SparkXGBParams(
         Params._dummy(),
         "repartition_random_shuffle",
         "A boolean variable. Set repartition_random_shuffle=true if you want to random shuffle "
-        "dataset when repartitioning is required. By default is True."
+        "dataset when repartitioning is required. By default is True.",
     )
     feature_names = Param(
         Params._dummy(), "feature_names", "A list of str to specify feature names."

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -541,9 +541,6 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
         query_plan = dataset._sc._jvm.PythonSQLUtils.explainString(
             dataset._jdf.queryExecution(), "extended"
         )
-        get_logger(self.__class__.__name__).warning(
-            f"debug-repartition: \n{query_plan}\n"
-        )
         start = query_plan.index("== Optimized Logical Plan ==")
         start += len("== Optimized Logical Plan ==") + 1
         num_workers = self.getOrDefault(self.num_workers)

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -543,6 +543,9 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
         query_plan = dataset._sc._jvm.PythonSQLUtils.explainString(
             dataset._jdf.queryExecution(), "extended"
         )
+        get_logger(self.__class__.__name__).warning(
+            f"debug-repartition: \n{query_plan}\n"
+        )
         start = query_plan.index("== Optimized Logical Plan ==")
         start += len("== Optimized Logical Plan ==") + 1
         num_workers = self.getOrDefault(self.num_workers)
@@ -683,11 +686,23 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
                 num_workers,
             )
 
+        def log_partition_rows(df, msg):
+
+            def count_partition_rows(iter):
+                yield len(list(iter))
+
+            result = df.rdd.mapPartitions(count_partition_rows).collect()
+            get_logger(self.__class__.__name__).warning(
+                f"debug-repartition: {msg}: {str(list(result))}\n"
+            )
+
+        log_partition_rows(dataset, "before-repartition")
         if self._repartition_needed(dataset):
             # Repartition on `monotonically_increasing_id` column to avoid repartition
             # result unbalance. Directly using `.repartition(N)` might result in some
             # empty partitions.
             dataset = dataset.repartition(num_workers, monotonically_increasing_id())
+            log_partition_rows(dataset, "after-repartition")
         train_params = self._get_distributed_train_params(dataset)
         booster_params, train_call_kwargs_params = self._get_xgb_train_call_args(
             train_params

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -684,16 +684,6 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
                 num_workers,
             )
 
-        def log_partition_rows(df, msg):
-            def count_partition_rows(iter):
-                yield len(list(iter))
-
-            result = df.rdd.mapPartitions(count_partition_rows).collect()
-            get_logger(self.__class__.__name__).warning(
-                f"debug-repartition: {msg}: {str(list(result))}\n"
-            )
-
-        log_partition_rows(dataset, "before-repartition")
         if self._repartition_needed(dataset) or (
             self.isDefined(self.validationIndicatorCol)
             and self.getOrDefault(self.validationIndicatorCol)
@@ -706,7 +696,7 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
             # result unbalance. Directly using `.repartition(N)` might result in some
             # empty partitions.
             dataset = dataset.repartition(num_workers, rand(1))
-            log_partition_rows(dataset, "after-repartition")
+
         train_params = self._get_distributed_train_params(dataset)
         booster_params, train_call_kwargs_params = self._get_xgb_train_call_args(
             train_params


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

Fix xgboost spark estimator dataset repartition issues

1. Fix issue of repartition generating empty partitions, via repartition on `rand(1)` column.
2. For num_worker=1, if setting force_repartition=True, does not raise error but still repartition to 1 partition.
3. When `validationIndicatorCol` set, always trigger repartition.

Closes https://github.com/dmlc/xgboost/issues/8221