### PR TITLE
[spark] Add validation for param 'early_stopping_rounds' and 'validation_indicator_col'

### DIFF
--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -295,7 +295,7 @@ class _SparkXGBParams(
             if not isinstance(self.getOrDefault(self.eval_metric), str):
                 raise ValueError("Only string type 'eval_metric' param is allowed.")
 
-        if self.isDefined(self.early_stopping_rounds):
+        if self.getOrDefault(self.early_stopping_rounds) is not None:
             if not (
                 self.isDefined(self.validationIndicatorCol) and self.getOrDefault(self.validationIndicatorCol)
             ):

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -295,6 +295,15 @@ class _SparkXGBParams(
             if not isinstance(self.getOrDefault(self.eval_metric), str):
                 raise ValueError("Only string type 'eval_metric' param is allowed.")
 
+        if self.isDefined(self.early_stopping_rounds):
+            if not (
+                self.isDefined(self.validationIndicatorCol) and self.getOrDefault(self.validationIndicatorCol)
+            ):
+                raise ValueError(
+                    "If 'early_stopping_rounds' param is set, you need to set "
+                    "'validation_indicator_col' param as well."
+                )
+
         if self.getOrDefault(self.enable_sparse_data_optim):
             if self.getOrDefault(self.missing) != 0.0:
                 # If DMatrix is constructed from csr / csc matrix, then inactive elements

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -297,7 +297,8 @@ class _SparkXGBParams(
 
         if self.getOrDefault(self.early_stopping_rounds) is not None:
             if not (
-                self.isDefined(self.validationIndicatorCol) and self.getOrDefault(self.validationIndicatorCol)
+                self.isDefined(self.validationIndicatorCol)
+                and self.getOrDefault(self.validationIndicatorCol)
             ):
                 raise ValueError(
                     "If 'early_stopping_rounds' param is set, you need to set "

--- a/tests/python/test_spark/test_spark_local.py
+++ b/tests/python/test_spark/test_spark_local.py
@@ -1147,6 +1147,8 @@ class XgboostLocalTest(SparkTestCase):
         classifier.fit(data_trans)
 
     def test_early_stop_param_validation(self):
-        classifier = SparkXGBClassifier(early_stopping_rounds=1)
+        classifier = SparkXGBClassifier(
+            early_stopping_rounds=1, validation_indicator_col="isVal"
+        )
         with pytest.raises(ValueError):
             classifier.fit(self.cls_df_train)

--- a/tests/python/test_spark/test_spark_local.py
+++ b/tests/python/test_spark/test_spark_local.py
@@ -1145,3 +1145,8 @@ class XgboostLocalTest(SparkTestCase):
             num_workers=4,
         )
         classifier.fit(data_trans)
+
+    def test_early_stop_param_validation(self):
+        classifier = SparkXGBClassifier(early_stopping_rounds=1)
+        with pytest.raises(ValueError):
+            classifier.fit(self.cls_df_train)

--- a/tests/python/test_spark/test_spark_local.py
+++ b/tests/python/test_spark/test_spark_local.py
@@ -1147,8 +1147,6 @@ class XgboostLocalTest(SparkTestCase):
         classifier.fit(data_trans)
 
     def test_early_stop_param_validation(self):
-        classifier = SparkXGBClassifier(
-            early_stopping_rounds=1, validation_indicator_col="isVal"
-        )
-        with pytest.raises(ValueError):
+        classifier = SparkXGBClassifier(early_stopping_rounds=1)
+        with pytest.raises(ValueError, match="early_stopping_rounds"):
             classifier.fit(self.cls_df_train)


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

Add validation for param 'early_stopping_rounds' and 'validation_indicator_col'