### PR TITLE
Send null values down both branches

### DIFF
--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -207,13 +207,10 @@ class HistEvaluator {
   // Enumerate/Scan the split values of specific feature
   // Returns the sum of gradients corresponding to the data points that contains
   // a non-missing value for the particular feature fid.
-  template <int d_step>
   GradStats EnumerateSplit(common::HistogramCuts const &cut, const common::GHistRow &hist,
                            bst_feature_t fidx, bst_node_t nidx,
                            TreeEvaluator::SplitEvaluator<TrainParam> const &evaluator,
                            SplitEntry *p_best) const {
-    static_assert(d_step == +1 || d_step == -1, "Invalid step.");
-
     // aliases
     const std::vector<uint32_t> &cut_ptr = cut.Ptrs();
     const std::vector<bst_float> &cut_val = cut.Values();
@@ -233,16 +230,11 @@ class HistEvaluator {
     const auto imin = static_cast<bst_bin_t>(cut_ptr[fidx]);
     // ibegin, iend: smallest/largest cut points for feature fid use int to allow for
     // value -1
-    bst_bin_t ibegin, iend;
-    if (d_step > 0) {
-      ibegin = static_cast<bst_bin_t>(cut_ptr[fidx]);
-      iend = static_cast<bst_bin_t>(cut_ptr.at(fidx + 1));
-    } else {
-      ibegin = static_cast<bst_bin_t>(cut_ptr[fidx + 1]) - 1;
-      iend = static_cast<bst_bin_t>(cut_ptr[fidx]) - 1;
-    }
+    bst_bin_t ibegin, iend, i;
+    ibegin = static_cast<bst_bin_t>(cut_ptr[fidx]);
+    iend = static_cast<bst_bin_t>(cut_ptr.at(fidx + 1));
 
-    for (bst_bin_t i = ibegin; i != iend; i += d_step) {
+    for (bst_bin_t i = ibegin; i != iend; i += 1) {
       // start working
       // try to find a split
       left_sum.Add(hist[i].GetGrad(), hist[i].GetHess());
@@ -250,30 +242,52 @@ class HistEvaluator {
       if (IsValid(left_sum, right_sum)) {
         bst_float loss_chg;
         bst_float split_pt;
-        if (d_step > 0) {
-          // forward enumeration: split at right bound of each bin
-          loss_chg =
-              static_cast<float>(evaluator.CalcSplitGain(param_, nidx, fidx, GradStats{left_sum},
-                                                         GradStats{right_sum}) -
-                                 parent.root_gain);
-          split_pt = cut_val[i];  // not used for partition based
-          best.Update(loss_chg, fidx, split_pt, d_step == -1, false, left_sum, right_sum);
-        } else {
-          // backward enumeration: split at left bound of each bin
-          loss_chg =
-              static_cast<float>(evaluator.CalcSplitGain(param_, nidx, fidx, GradStats{right_sum},
-                                                         GradStats{left_sum}) -
-                                 parent.root_gain);
-          if (i == imin) {
-            split_pt = cut.MinValues()[fidx];
-          } else {
-            split_pt = cut_val[i - 1];
-          }
-          best.Update(loss_chg, fidx, split_pt, d_step == -1, false, right_sum, left_sum);
-        }
+        // forward enumeration: split at right bound of each bin
+        loss_chg =
+            static_cast<float>(evaluator.CalcSplitGain(param_, nidx, fidx, GradStats{left_sum},
+                                                       GradStats{right_sum}) -
+                               parent.root_gain);
+        split_pt = cut_val[i];  // not used for partition based
+        best.Update(loss_chg, fidx, split_pt, false, false, left_sum, right_sum);
       }
     }
 
+    if (left_sum.GetGrad() == parent.stats.GetGrad() && left_sum.GetHess() == parent.stats.GetHess()) {
+      p_best->Update(best);
+      return left_sum;
+    }
+
+    const float inc = (float) (iend - ibegin);
+    const GradStats::GradType dnull_grad = param_.new_null_handler ? right_sum.GetGrad() / inc : 0;
+    const GradStats::GradType dnull_hess = param_.new_null_handler ? right_sum.GetHess() / inc : 0;
+    if (param_.new_null_handler) {
+      p_best->Update(best);
+    }
+
+    // reset to 0
+    right_sum.SetSubstract(left_sum, left_sum);
+    left_sum.SetSubstract(left_sum, left_sum);
+    for (i = iend - 1; i >= ibegin; i -= 1) {
+      // start working
+      // try to find a split
+      left_sum.Add(hist[i].GetGrad() + dnull_grad, hist[i].GetHess() + dnull_hess);
+      right_sum.SetSubstract(parent.stats, left_sum);
+      if (IsValid(left_sum, right_sum)) {
+        bst_float loss_chg;
+        bst_float split_pt;
+        // backward enumeration: split at left bound of each bin
+        loss_chg =
+            static_cast<float>(evaluator.CalcSplitGain(param_, nidx, fidx, GradStats{right_sum},
+                                                       GradStats{left_sum}) -
+                               parent.root_gain);
+        if (i == imin) {
+          split_pt = cut.MinValues()[fidx];
+        } else {
+          split_pt = cut_val[i - 1];
+        }
+        best.Update(loss_chg, fidx, split_pt, true, false, right_sum, left_sum);
+      }
+    }
     p_best->Update(best);
     return left_sum;
   }
@@ -338,10 +352,7 @@ class HistEvaluator {
             EnumeratePart<-1>(cut, sorted_idx, histogram, fidx, nidx, evaluator, best);
           }
         } else {
-          auto grad_stats = EnumerateSplit<+1>(cut, histogram, fidx, nidx, evaluator, best);
-          if (SplitContainsMissingValues(grad_stats, snode_[nidx])) {
-            EnumerateSplit<-1>(cut, histogram, fidx, nidx, evaluator, best);
-          }
+          auto grad_stats = EnumerateSplit(cut, histogram, fidx, nidx, evaluator, best);
         }
       }
     });

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -81,6 +81,8 @@ struct TrainParam : public XGBoostParameter<TrainParam> {
   static constexpr double DftSparseThreshold() { return 0.2; }
 
   double sparse_threshold{DftSparseThreshold()};
+  // Whether null values should be sent down both branches
+  bool new_null_handler;
 
   // declare the parameters
   DMLC_DECLARE_PARAMETER(TrainParam) {
@@ -188,6 +190,10 @@ struct TrainParam : public XGBoostParameter<TrainParam> {
         .set_range(0, 1.0)
         .set_default(DftSparseThreshold())
         .describe("percentage threshold for treating a feature as sparse");
+
+    DMLC_DECLARE_FIELD(new_null_handler)
+        .set_default(false)
+        .describe("Whether to send null values down both branches.");
 
     // add alias of parameters
     DMLC_DECLARE_ALIAS(reg_lambda, lambda);


### PR DESCRIPTION
# WIP

Potential means of handling missing data that avoids overfitting. See feature-request #8249 and [this link](http://mlwiki.org/index.php/Decision_Tree_(Data_Mining)#Handling_Missing_Values) for the basic concept. 

I added a new boolean into the training parameters (better names are, of course, welcome) and took a crack at refactoring evaluate_splits.h to incorporate the algorithm when searching for splits with continuous features. The idea is instead of simply doing a backward sweep when there is a discrepancy between `left_sum` and the total gradient and hessian, do a backward sweep while adding `1/(iend-ibegin)` times that discrepancy to the `left_sum` for each iteration in the sweep. This way, the residual gradients and Hessians from null values are added to `left_sum` incrementally throughout the sweep.

If how the code was refactored seems acceptable, I can repeat the pattern on methods that handle categorical and one hot encoded feature, then move on to inference and testing. 

@trivialfis 