### PR TITLE
[pyspark] disable repartition_random_shuffle by default

### DIFF
--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -88,6 +88,7 @@ _pyspark_specific_params = [
     "features_cols",
     "enable_sparse_data_optim",
     "qid_col",
+    "repartition_random_shuffle",
 ]
 
 _non_booster_params = ["missing", "n_estimators", "feature_types", "feature_weights"]
@@ -477,7 +478,7 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
             num_workers=1,
             use_gpu=False,
             force_repartition=False,
-            repartition_random_shuffle=True,
+            repartition_random_shuffle=False,
             feature_names=None,
             feature_types=None,
             arbitrary_params_dict={},

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -9,6 +9,8 @@ from xgboost.compat import concat
 
 from xgboost import DataIter, DeviceQuantileDMatrix, DMatrix
 
+from .utils import get_logger
+
 
 def stack_series(series: pd.Series) -> np.ndarray:
     """Stack a series of arrays."""
@@ -246,6 +248,11 @@ def create_dmatrix_from_partitions(  # pylint: disable=too-many-arguments
         else:
             append_fn = append_m
         cache_partitions(iterator, append_fn)
+        if len(train_data) == 0:
+            get_logger("XGBoostPySpark").warning(
+                "Detected an empty partition in the training data. "
+                "Consider to enable repartition_random_shuffle"
+            )
         dtrain = make(train_data, kwargs)
     else:
         cache_partitions(iterator, append_dqm)

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -9,7 +9,7 @@ from xgboost.compat import concat
 
 from xgboost import DataIter, DeviceQuantileDMatrix, DMatrix
 
-from .utils import get_logger
+from .utils import get_logger  # type: ignore
 
 
 def stack_series(series: pd.Series) -> np.ndarray:


### PR DESCRIPTION
This PR resolved the issue1 xgboost detected this parameter is not used in native.

``` console
Parameters: { "repartition_random_shuffle" } are not used.
```

and this PR disabled repartition_random_shuffle by default and will give some prompt when detecting an empty partition.  The severe data skew mentioned in https://github.com/dmlc/xgboost/issues/8221  is really kind of rare case, so I don't think we need to change the default repartition behavior to hash partitioning from round robin partitioning. Besides, the hash partitioning will introduce an extra "project" physical plan, see

- repartition_random_shuffle=False
``` console
== Physical Plan ==
Exchange RoundRobinPartitioning(1), REPARTITION_WITH_NUM, [id=#94]
+- *(1) Project [cast(class#4 as float) AS label#20, cast(sepal_length#0 as float) AS sepal_length#10, cast(sepal_width#1 as float) AS sepal_width#11, cast(petal_length#2 as float) AS petal_length#12, cast(petal_width#3 as float) AS petal_width#13]
   +- *(1) ColumnarToRow
      +- FileScan parquet [sepal_length#0,sepal_width#1,petal_length#2,petal_width#3,class#4] Batched: true, DataFilters: [], Format: Parquet, Location: xxx
```

- repartition_random_shuffle=True

``` console
== Physical Plan ==
*(2) Project [label#20, sepal_length#10, sepal_width#11, petal_length#12, petal_width#13]
+- Exchange hashpartitioning(_nondeterministic#26, 1), REPARTITION_WITH_NUM, [id=#92]
   +- *(1) Project [cast(class#4 as float) AS label#20, cast(sepal_length#0 as float) AS sepal_length#10, cast(sepal_width#1 as float) AS sepal_width#11, cast(petal_length#2 as float) AS petal_length#12, cast(petal_width#3 as float) AS petal_width#13, rand(1) AS _nondeterministic#26]
      +- *(1) ColumnarToRow
         +- FileScan parquet [sepal_length#0,sepal_width#1,petal_length#2,petal_width#3,class#4] Batched: true, DataFilters: [], Format: Parquet, Location: xxx