### PR TITLE
[CI] Put Multi-GPU test suites in separate pipeline

### DIFF
--- a/tests/buildkite/conftest.sh
+++ b/tests/buildkite/conftest.sh
@@ -12,9 +12,14 @@ else
   export BRANCH_NAME=$BUILDKITE_BRANCH
 fi
 
-if [[ $BUILDKITE_BRANCH == "master" || $BUILDKITE_BRANCH == "release_"* ]]
+if [[ -z $DISABLE_RELEASE ]]
 then
-  is_release_branch=1
+  if [[ $BUILDKITE_BRANCH == "master" || $BUILDKITE_BRANCH == "release_"* ]]
+  then
+    is_release_branch=1
+  else
+    is_release_branch=0
+  fi
 else
   is_release_branch=0
 fi

--- a/tests/buildkite/conftest.sh
+++ b/tests/buildkite/conftest.sh
@@ -12,7 +12,7 @@ else
   export BRANCH_NAME=$BUILDKITE_BRANCH
 fi
 
-if [[ -z $DISABLE_RELEASE ]]
+if [[ -z ${DISABLE_RELEASE:-} ]]
 then
   if [[ $BUILDKITE_BRANCH == "master" || $BUILDKITE_BRANCH == "release_"* ]]
   then

--- a/tests/buildkite/pipeline-mgpu.yml
+++ b/tests/buildkite/pipeline-mgpu.yml
@@ -1,0 +1,29 @@
+env:
+  DOCKER_CACHE_ECR_ID: "492475357299"
+  DOCKER_CACHE_ECR_REGION: "us-west-2"
+  DISABLE_RELEASE: "1"
+    # Skip uploading artifacts to S3 bucket
+    # Also, don't build all CUDA archs; just build sm_75
+steps:
+  - block: ":rocket: Run this test job"
+    if: build.pull_request.repository.fork == true
+  #### -------- BUILD --------
+  - label: ":console: Build CUDA"
+    command: "tests/buildkite/build-cuda.sh"
+    key: build-cuda
+    agents:
+      queue: linux-amd64-cpu
+  - label: ":console: Build JVM packages with CUDA"
+    command: "tests/buildkite/build-jvm-packages-gpu.sh"
+    key: build-jvm-packages-gpu
+    agents:
+      queue: linux-amd64-mgpu
+
+  - wait
+
+  #### -------- TEST --------
+  - label: ":console: Test Python package, 4 GPUs"
+    command: "tests/buildkite/test-python-gpu.sh mgpu"
+    key: test-python-mgpu
+    agents:
+      queue: linux-amd64-mgpu

--- a/tests/buildkite/pipeline.yml
+++ b/tests/buildkite/pipeline.yml
@@ -40,11 +40,6 @@ steps:
     key: build-jvm-packages
     agents:
       queue: linux-amd64-cpu
-  - label: ":console: Build JVM packages with CUDA"
-    command: "tests/buildkite/build-jvm-packages-gpu.sh"
-    key: build-jvm-packages-gpu
-    agents:
-      queue: linux-amd64-mgpu
   - label: ":console: Build JVM package doc"
     command: "tests/buildkite/build-jvm-doc.sh"
     key: build-jvm-doc
@@ -69,11 +64,6 @@ steps:
     key: test-python-gpu
     agents:
       queue: linux-amd64-gpu
-  - label: ":console: Test Python package, 4 GPUs"
-    command: "tests/buildkite/test-python-gpu.sh mgpu"
-    key: test-python-mgpu
-    agents:
-      queue: linux-amd64-mgpu
   - label: ":console: Run Google Tests, 4 GPUs"
     command: "tests/buildkite/test-cpp-gpu.sh"
     key: test-cpp-gpu


### PR DESCRIPTION
The multi-GPU tests comprise 38% of the CI cost. In an effort to reduce the cost of CI pipelines, we will require an explicit approval from the XGBoost administrators to run multi-GPU tests.

* Move multi-GPU tests in a separate CI pipeline
* Require explicit approval for the multi-GPU pipeline 

For this PR, please skip the pipeline `buildkite/xgboost-ci-windows`.

<details>
  <summary>Show the detailed breakdown of the cost of a single CI test job</summary>

Pipeline | Stage | Queue | Time (min) | Time (hr) | Total Cost | Percent
-- | -- | -- | -- | -- | -- | --
Linux | run-clang-tidy | linux-amd64-cpu | 9 | 0.150 | $ 0.092 | 2.1%
Linux | build-cpu | linux-amd64-cpu | 8 | 0.133 | $ 0.082 | 1.9%
Linux | build-cpu-arm64 | linux-arm64-cpu | 4 | 0.067 | $ 0.036 | 0.8%
Linux | build-cuda | linux-amd64-cpu | 13 | 0.217 | $ 0.133 | 3.1%
Linux | build-cuda-with-rmm | linux-amd64-cpu | 21 | 0.350 | $ 0.216 | 5.0%
Linux | build-gpu-rpkg | linux-amd64-cpu | 9 | 0.150 | $ 0.092 | 2.1%
Linux | build-jvm-packages | linux-amd64-cpu | 7 | 0.117 | $ 0.072 | 1.7%
**Linux** | **build-jvm-packages-gpu** | **linux-amd64-mgpu** | 10 | 0.167 | **$ 0.652** | **15.0%**
Linux | build-jvm-doc | linux-amd64-cpu | 4 | 0.067 | $ 0.041 | 0.9%
Linux | test-python-cpu | linux-amd64-cpu | 28 | 0.467 | $ 0.287 | 6.6%
Linux | test-python-cpu-arm64 | linux-arm64-cpu | 3 | 0.050 | $ 0.027 | 0.6%
Linux | test-python-gpu | linux-amd64-gpu | 14 | 0.233 | $ 0.123 | 2.8%
**Linux** | **test-python-mgpu** | **linux-amd64-mgpu** | 15 | 0.250 | **$ 0.978** | **22.6%**
Linux | test-cpp-gpu | linux-amd64-gpu | 15 | 0.250 | $ 0.132 | 3.0%
Linux | test-integration-jvm-packages | linux-amd64-cpu | 3 | 0.050 | $ 0.031 | 0.7%
Linux | deploy-jvm-packages | linux-amd64-cpu | 14 | 0.233 | $ 0.144 | 3.3%
Windows | build-win64-gpu | windows-gpu | 25 | 0.417 | $ 0.467 | 10.8%
Windows | build-rpkg-win64-gpu | windows-gpu | 17 | 0.283 | $ 0.317 | 7.3%
Windows | test-win64-gpu | windows-gpu | 22 | 0.367 | $ 0.411 | 9.5%
**TOTAL**  |   |   |   |   | **$ 4.333** | **100.0%**

Queue | EC2 instance type | Unit Cost per hour
-- | -- | --
linux-amd64-cpu | c5a.4xlarge, Linux, us-west-2 | $ 0.616
linux-arm64-cpu | c6g.4xlarge, Linux, us-west-2 | $ 0.544
linux-amd64-gpu | g4dn.xlarge, Linux, us-west-2 | $ 0.526
linux-amd64-mgpu | g4dn.12xlarge, Linux, us-west-2 | $ 3.912
windows-gpu | g4dn.2xlarge, Windows, us-west-2 | $ 1.120

</details>