### PR TITLE
Various CI savings

### DIFF
--- a/tests/buildkite/enforce_daily_budget.py
+++ b/tests/buildkite/enforce_daily_budget.py
@@ -1,0 +1,26 @@
+import boto3
+import json
+
+lambda_client = boto3.client('lambda', region_name='us-west-2')
+
+# Source code for the Lambda function is available at https://github.com/hcho3/xgboost-devops
+r = lambda_client.invoke(
+    FunctionName='XGBoostCICostWatcher',
+    InvocationType='RequestResponse',
+    Payload='{}'.encode('utf-8')
+)
+
+payload = r['Payload'].read().decode('utf-8')
+if 'FunctionError' in r:
+    msg = 'Error when invoking the Lambda function. Stack trace:\n'
+    error = json.loads(payload)
+    msg += f"    {error['errorType']}: {error['errorMessage']}\n"
+    for trace in error['stackTrace']:
+        for line in trace.split('\n'):
+            msg += f'    {line}\n'
+    raise RuntimeError(msg)
+response = json.loads(payload)
+if response['approved']:
+    print(f"Testing approved. Reason: {response['reason']}")
+else:
+    raise RuntimeError(f"Testing rejected. Reason: {response['reason']}")

--- a/tests/buildkite/enforce_daily_budget.py
+++ b/tests/buildkite/enforce_daily_budget.py
@@ -1,26 +1,14 @@
-import boto3
 import json
+import argparse
 
-lambda_client = boto3.client('lambda', region_name='us-west-2')
-
-# Source code for the Lambda function is available at https://github.com/hcho3/xgboost-devops
-r = lambda_client.invoke(
-    FunctionName='XGBoostCICostWatcher',
-    InvocationType='RequestResponse',
-    Payload='{}'.encode('utf-8')
-)
-
-payload = r['Payload'].read().decode('utf-8')
-if 'FunctionError' in r:
-    msg = 'Error when invoking the Lambda function. Stack trace:\n'
-    error = json.loads(payload)
-    msg += f"    {error['errorType']}: {error['errorMessage']}\n"
-    for trace in error['stackTrace']:
-        for line in trace.split('\n'):
-            msg += f'    {line}\n'
-    raise RuntimeError(msg)
-response = json.loads(payload)
-if response['approved']:
-    print(f"Testing approved. Reason: {response['reason']}")
-else:
-    raise RuntimeError(f"Testing rejected. Reason: {response['reason']}")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--response", type=str, required=True)
+    args = parser.parse_args()
+    with open(args.response, "r") as f:
+        payload = f.read()
+    response = json.loads(payload)
+    if response["approved"]:
+        print(f"Testing approved. Reason: {response['reason']}")
+    else:
+        raise RuntimeError(f"Testing rejected. Reason: {response['reason']}")

--- a/tests/buildkite/enforce_daily_budget.sh
+++ b/tests/buildkite/enforce_daily_budget.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "--- Enforce daily budget"
+
+source tests/buildkite/conftest.sh
+
+if [[ $is_release_branch == 1 ]]
+then
+  echo "Automatically approving all test jobs for release branches"
+else
+  python3 tests/buildkite/enforce_daily_budget.py
+fi

--- a/tests/buildkite/enforce_daily_budget.sh
+++ b/tests/buildkite/enforce_daily_budget.sh
@@ -10,5 +10,6 @@ if [[ $is_release_branch == 1 ]]
 then
   echo "Automatically approving all test jobs for release branches"
 else
-  python3 tests/buildkite/enforce_daily_budget.py
+  aws lambda invoke --function-name XGBoostCICostWatcher --invocation-type RequestResponse --region us-west-2 response.json
+  python3 tests/buildkite/enforce_daily_budget.py --response response.json
 fi

--- a/tests/buildkite/infrastructure/aws-stack-creator/metadata.py
+++ b/tests/buildkite/infrastructure/aws-stack-creator/metadata.py
@@ -9,6 +9,9 @@ AMI_ID = {
     "windows-gpu": {
         "us-west-2": "ami-0a1a2ea551a07ad5f",
     },
+    "windows-cpu": {
+        "us-west-2": "ami-0a1a2ea551a07ad5f",
+    },
     # Managed by BuildKite
     "linux-amd64-cpu": {
         "us-west-2": "ami-075d4c25d5f0c17c1",
@@ -37,7 +40,7 @@ STACK_PARAMS = {
         "InstanceType": "g4dn.12xlarge",
         "AgentsPerInstance": "1",
         "MinSize": "0",
-        "MaxSize": "4",
+        "MaxSize": "1",
         "OnDemandPercentage": "100",
         "ScaleOutFactor": "1.0",
         "ScaleInIdlePeriod": "60",  # in seconds
@@ -50,7 +53,17 @@ STACK_PARAMS = {
         "MaxSize": "2",
         "OnDemandPercentage": "100",
         "ScaleOutFactor": "1.0",
-        "ScaleInIdlePeriod": "600",  # in seconds
+        "ScaleInIdlePeriod": "60",  # in seconds
+    },
+    "windows-cpu": {
+        "InstanceOperatingSystem": "windows",
+        "InstanceType": "c5a.2xlarge",
+        "AgentsPerInstance": "1",
+        "MinSize": "0",
+        "MaxSize": "2",
+        "OnDemandPercentage": "100",
+        "ScaleOutFactor": "1.0",
+        "ScaleInIdlePeriod": "60",  # in seconds
     },
     "linux-amd64-cpu": {
         "InstanceOperatingSystem": "linux",

--- a/tests/buildkite/infrastructure/aws-stack-creator/metadata.py
+++ b/tests/buildkite/infrastructure/aws-stack-creator/metadata.py
@@ -105,7 +105,7 @@ COMMON_STACK_PARAMS = {
     "EnableCostAllocationTags": "true",
     "CostAllocationTagName": "CreatedBy",
     "ECRAccessPolicy": "full",
-    "ManagedPolicyARN": "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+    "ManagedPolicyARN": "arn:aws:iam::aws:policy/AmazonS3FullAccess,arn:aws:iam::aws:policy/service-role/AWSLambdaRole",
     "EnableSecretsPlugin": "false",
     "EnableECRPlugin": "false",
     "EnableDockerLoginPlugin": "false",

--- a/tests/buildkite/pipeline-mgpu.yml
+++ b/tests/buildkite/pipeline-mgpu.yml
@@ -5,6 +5,11 @@ env:
     # Skip uploading artifacts to S3 bucket
     # Also, don't build all CUDA archs; just build sm_75
 steps:
+  - label: ":moneybag: Enforce daily budget"
+    command: "tests/buildkite/enforce_daily_budget.sh"
+    key: enforce-daily-budget
+    agents:
+      queue: pipeline-loader
   - block: ":rocket: Run this test job"
     if: build.pull_request.repository.fork == true
   #### -------- BUILD --------

--- a/tests/buildkite/pipeline-win64.yml
+++ b/tests/buildkite/pipeline-win64.yml
@@ -11,12 +11,12 @@ steps:
     command: "tests/buildkite/build-win64-gpu.ps1"
     key: build-win64-gpu
     agents:
-      queue: windows-gpu
+      queue: windows-cpu
   - label: ":windows: Build XGBoost R package for Windows with CUDA"
     command: "tests/buildkite/build-rpkg-win64-gpu.ps1"
     key: build-rpkg-win64-gpu
     agents:
-      queue: windows-gpu
+      queue: windows-cpu
 
   - wait
 

--- a/tests/buildkite/pipeline-win64.yml
+++ b/tests/buildkite/pipeline-win64.yml
@@ -1,4 +1,9 @@
 steps:
+  - label: ":moneybag: Enforce daily budget"
+    command: "tests/buildkite/enforce_daily_budget.sh"
+    key: enforce-daily-budget
+    agents:
+      queue: pipeline-loader
   - block: ":rocket: Run this test job"
     if: build.pull_request.repository.fork == true
   #### -------- BUILD --------

--- a/tests/buildkite/pipeline.yml
+++ b/tests/buildkite/pipeline.yml
@@ -2,6 +2,11 @@ env:
   DOCKER_CACHE_ECR_ID: "492475357299"
   DOCKER_CACHE_ECR_REGION: "us-west-2"
 steps:
+  - label: ":moneybag: Enforce daily budget"
+    command: "tests/buildkite/enforce_daily_budget.sh"
+    key: enforce-daily-budget
+    agents:
+      queue: pipeline-loader
   - block: ":rocket: Run this test job"
     if: build.pull_request.repository.fork == true
   #### -------- BUILD --------


### PR DESCRIPTION
* Reduce cost of (some) Windows tests by using a CPU-only worker
* Don't store too many old Docker containers; delete them after 30 days
* Add back the daily cost check to ensure that we don't run too many test jobs
* Reduce timeout to 60 s for Windows workers (workers that are idle for 1 min will be terminated)
* Set max number of workers to 1 for multi-GPU