### PR TITLE
[CI] Update GitHub Actions to use macos-11

### DIFF
--- a/.github/workflows/jvm_tests.yml
+++ b/.github/workflows/jvm_tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-10.15]
+        os: [windows-latest, ubuntu-latest, macos-11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15]
+        os: [macos-11]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,11 +80,9 @@ jobs:
         sudo apt-get install -y --no-install-recommends ninja-build
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        auto-update-conda: true
         python-version: ${{ matrix.python-version }}
-        mamba-version: "*"
-        channels: conda-forge
-        channel-priority: true
+        miniforge-variant: Mambaforge
+        use-mamba: true
         activate-environment: test
     - name: Display Conda env
       shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,9 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+        channels: conda-forge
+        channel-priority: true
         activate-environment: test
     - name: Display Conda env
       shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,9 +80,8 @@ jobs:
         sudo apt-get install -y --no-install-recommends ninja-build
     - uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-update-conda: true
         python-version: ${{ matrix.python-version }}
-        miniforge-variant: Mambaforge
-        use-mamba: true
         activate-environment: test
     - name: Display Conda env
       shell: bash -l {0}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -135,6 +135,8 @@ jobs:
       matrix:
         config:
           - {os: macos-11, python-version "3.8" }
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 11.0
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -175,7 +175,7 @@ jobs:
         cd python-package
         python --version
         python setup.py bdist_wheel --universal
-        python ../tests/ci_build/rename_whl.py ./dist/*.whl $GITHUB_SHA $wheel_tag
+        python ../tests/ci_build/rename_whl.py ./dist/*.whl ${{ github.sha }} $wheel_tag
         pip install ./dist/*.whl
 
     - name: Test Python package

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -19,9 +19,8 @@ jobs:
         submodules: 'true'
     - uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-update-conda: true
         python-version: ${{ matrix.python-version }}
-        miniforge-variant: Mambaforge
-        use-mamba: true
         activate-environment: python_lint
         environment-file: tests/ci_build/conda_env/python_lint.yml
     - name: Display Conda env
@@ -63,9 +62,8 @@ jobs:
         sudo apt-get install -y --no-install-recommends ninja-build
     - uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-update-conda: true
         python-version: ${{ matrix.python-version }}
-        miniforge-variant: Mambaforge
-        use-mamba: true
         activate-environment: test
     - name: Display Conda env
       shell: bash -l {0}
@@ -97,9 +95,8 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-update-conda: true
         python-version: ${{ matrix.config.python-version }}
-        miniforge-variant: Mambaforge
-        use-mamba: true
         activate-environment: win64_env
         environment-file: tests/ci_build/conda_env/win64_cpu_test.yml
 
@@ -138,8 +135,6 @@ jobs:
       matrix:
         config:
           - {os: macos-11, python-version "3.8" }
-    env:
-      wheel_tag: macosx_11_0_x86_64
 
     steps:
     - uses: actions/checkout@v2
@@ -148,9 +143,8 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-update-conda: true
         python-version: ${{ matrix.config.python-version }}
-        miniforge-variant: Mambaforge
-        use-mamba: true
         activate-environment: macos_test
         environment-file: tests/ci_build/conda_env/macos_cpu_test.yml
 

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -21,6 +21,9 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+        channels: conda-forge
+        channel-priority: true
         activate-environment: python_lint
         environment-file: tests/ci_build/conda_env/python_lint.yml
     - name: Display Conda env

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -46,14 +46,14 @@ jobs:
     name: Test installing XGBoost Python source package on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-11, windows-latest]
         python-version: ["3.8"]
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
     - name: Install osx system dependencies
-      if: matrix.os == 'macos-10.15'
+      if: matrix.os == 'macos-11'
       run: |
         brew install ninja libomp
     - name: Install Ubuntu system dependencies
@@ -134,7 +134,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - {os: macos-10.15, python-version "3.8" }
+          - {os: macos-11, python-version "3.8" }
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -63,8 +63,9 @@ jobs:
         sudo apt-get install -y --no-install-recommends ninja-build
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        auto-update-conda: true
         python-version: ${{ matrix.python-version }}
+        miniforge-variant: Mambaforge
+        use-mamba: true
         activate-environment: test
     - name: Display Conda env
       shell: bash -l {0}
@@ -96,8 +97,9 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        auto-update-conda: true
         python-version: ${{ matrix.config.python-version }}
+        miniforge-variant: Mambaforge
+        use-mamba: true
         activate-environment: win64_env
         environment-file: tests/ci_build/conda_env/win64_cpu_test.yml
 
@@ -146,8 +148,9 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        auto-update-conda: true
         python-version: ${{ matrix.config.python-version }}
+        miniforge-variant: Mambaforge
+        use-mamba: true
         activate-environment: macos_test
         environment-file: tests/ci_build/conda_env/macos_cpu_test.yml
 

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -136,7 +136,7 @@ jobs:
         config:
           - {os: macos-11, python-version "3.8" }
     env:
-      MACOSX_DEPLOYMENT_TARGET: 11.0
+      wheel_tag: macosx_11_0_x86_64
 
     steps:
     - uses: actions/checkout@v2
@@ -175,6 +175,7 @@ jobs:
         cd python-package
         python --version
         python setup.py bdist_wheel --universal
+        python ../tests/ci_build/rename_whl.py ./dist/*.whl $GITHUB_SHA $wheel_tag
         pip install ./dist/*.whl
 
     - name: Test Python package

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -19,11 +19,9 @@ jobs:
         submodules: 'true'
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        auto-update-conda: true
         python-version: ${{ matrix.python-version }}
-        mamba-version: "*"
-        channels: conda-forge
-        channel-priority: true
+        miniforge-variant: Mambaforge
+        use-mamba: true
         activate-environment: python_lint
         environment-file: tests/ci_build/conda_env/python_lint.yml
     - name: Display Conda env

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -178,9 +178,7 @@ jobs:
       run: |
         cd python-package
         python --version
-        python setup.py bdist_wheel --universal
-        python ../tests/ci_build/rename_whl.py ./dist/*.whl ${{ github.sha }} $wheel_tag
-        pip install ./dist/*.whl
+        python setup.py install
 
     - name: Test Python package
       shell: bash -l {0}


### PR DESCRIPTION
MacOS 10.15 worker has been deprecated and is scheduled to be removed in the near future. See https://github.com/actions/runner-images/issues/5583

~Also, use Mamba to speed up Python env setup.~

Note: no need to trigger BuildKite jobs for this PR.