### PR TITLE
[ci] reduce pyspark test time

### DIFF
--- a/tests/test_distributed/test_with_spark/test_spark_local.py
+++ b/tests/test_distributed/test_with_spark/test_spark_local.py
@@ -697,13 +697,14 @@ class XgboostLocalTest(SparkTestCase):
         self.assert_model_compatible(model.stages[0], tmp_dir)
 
     def test_classifier_with_cross_validator(self):
-        xgb_classifer = SparkXGBClassifier()
+        xgb_classifer = SparkXGBClassifier(n_estimators=1)
         paramMaps = ParamGridBuilder().addGrid(xgb_classifer.max_depth, [1, 2]).build()
         cvBin = CrossValidator(
             estimator=xgb_classifer,
             estimatorParamMaps=paramMaps,
             evaluator=BinaryClassificationEvaluator(),
             seed=1,
+            parallelism=4,
             numFolds=2,
         )
         cvBinModel = cvBin.fit(self.cls_df_train_large)


### PR DESCRIPTION
Without this PR, It takes 70s to finish test_classifier_with_cross_validator 
`70.03s call     python/test_spark/test_spark_local.py::XgboostLocalTest::test_classifier_with_cross_validator`
With this PR, it only takes 17s to be finished `17.43s call     python/test_spark/test_spark_local.py::XgboostLocalTest::test_classifier_with_cross_validator`

I also tried enabling pytest with parallelly running by pytest-xdist and it worked well with pyspark tests, and the time can be reduced from `4m49.335s` to `2m19.574s`.

I don't know if we need to enable pytest-xdist for python tests?

BTW, I also found some tests may have overlaps, like `test_classifier_distributed_weight_eval` and `test_regressor_distributed_weight_eval`, seems we don't need to test all kinds of estimators @WeichenXu123, please correct me.
 
