### PR TITLE
add port in trackerConf for spark mode

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -55,7 +55,7 @@ import org.apache.spark.sql.SparkSession
  *                   which is only used for python implementation.
  */
 case class TrackerConf(workerConnectionTimeout: Long, trackerImpl: String,
-  hostIp: String = "", pythonExec: String = "")
+  hostIp: String = "", pythonExec: String = "", port: Option[Int] = None)
 
 object TrackerConf {
   def apply(): TrackerConf = TrackerConf(0L, "python")
@@ -350,8 +350,9 @@ object XGBoost extends Serializable {
   /** visiable for testing */
   private[scala] def getTracker(nWorkers: Int, trackerConf: TrackerConf): IRabitTracker = {
     val tracker: IRabitTracker = trackerConf.trackerImpl match {
-      case "scala" => new RabitTracker(nWorkers)
-      case "python" => new PyRabitTracker(nWorkers, trackerConf.hostIp, trackerConf.pythonExec)
+      case "scala" => new RabitTracker(nWorkers, trackerConf.port)
+      case "python" => new PyRabitTracker(nWorkers, trackerConf.hostIp,
+       trackerConf.port.getOrElse(0), trackerConf.pythonExec)
       case _ => new PyRabitTracker(nWorkers)
     }
     tracker

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/RabitTracker.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/RabitTracker.java
@@ -31,6 +31,7 @@ public class RabitTracker implements IRabitTracker {
   // number of workers to be submitted.
   private int numWorkers;
   private String hostIp = "";
+  private int hostPort = 0;
   private String pythonExec = "";
   private AtomicReference<Process> trackerProcess = new AtomicReference<Process>();
 
@@ -98,6 +99,14 @@ public class RabitTracker implements IRabitTracker {
     this.pythonExec = pythonExec;
   }
 
+  public RabitTracker(int numWorkers, String hostIp, int hostPort,
+                      String pythonExec) throws XGBoostError {
+    this(numWorkers);
+    this.hostIp = hostIp;
+    this.hostPort = hostPort;
+    this.pythonExec = pythonExec;
+  }
+
   public void uncaughtException(Thread t, Throwable e) {
     logger.error("Uncaught exception thrown by worker:", e);
     try {
@@ -159,6 +168,9 @@ public class RabitTracker implements IRabitTracker {
     } else if (hostIp != null & !hostIp.isEmpty()) {
       logger.debug("Using the parametr host-ip: " + hostIp);
       sb.append(" --host-ip=" + hostIp + " ");
+    }
+    if(hostPort != 0){
+      sb.append(" --port=" + hostPort + " ");
     }
     return sb.toString();
   }

--- a/python-package/xgboost/tracker.py
+++ b/python-package/xgboost/tracker.py
@@ -444,7 +444,8 @@ def start_rabit_tracker(args: argparse.Namespace) -> None:
     """
     envs = {"DMLC_NUM_WORKER": args.num_workers, "DMLC_NUM_SERVER": args.num_servers}
     rabit = RabitTracker(
-        host_ip=get_host_ip(args.host_ip), n_workers=args.num_workers, use_logger=True
+        host_ip=get_host_ip(args.host_ip), port=args.port, n_workers=args.num_workers,
+        use_logger=True
     )
     envs.update(rabit.worker_envs())
     rabit.start(args.num_workers)
@@ -469,6 +470,8 @@ def main() -> None:
     parser.add_argument('--host-ip', default=None, type=str,
                         help=('Host IP addressed, this is only needed ' +
                               'if the host IP cannot be automatically guessed.'))
+    parser.add_argument('--port', default=0, type=int,
+                        help='Host port of the tracker, default 0 for ramdom.')
     parser.add_argument('--log-level', default='INFO', type=str,
                         choices=['INFO', 'DEBUG'],
                         help='Logging level of the logger.')


### PR DESCRIPTION
allow customize pyTracker / sparkTracker port binding for spark mode.in some case , user need give a fixed port number. 
for example run SparkDriver pod with istio sidecar. add annotation
`traffic.sidecar.istio.io/excludeInboundPorts: {portNumber}`