### PR TITLE
[Don't merge] Root cause for slowdown in CPU tests

### DIFF
--- a/tests/buildkite/build-cuda.sh
+++ b/tests/buildkite/build-cuda.sh
@@ -20,8 +20,8 @@ command_wrapper="tests/ci_build/ci_build.sh gpu_build_centos7 docker --build-arg
 
 echo "--- Build libxgboost from the source"
 $command_wrapper tests/ci_build/prune_libnccl.sh
-$command_wrapper tests/ci_build/build_via_cmake.sh -DCMAKE_PREFIX_PATH=/opt/grpc \
-  -DUSE_CUDA=ON -DUSE_NCCL=ON -DUSE_OPENMP=ON -DHIDE_CXX_SYMBOLS=ON -DPLUGIN_FEDERATED=ON \
+$command_wrapper tests/ci_build/build_via_cmake.sh \
+  -DUSE_CUDA=ON -DUSE_NCCL=ON -DUSE_OPENMP=ON -DHIDE_CXX_SYMBOLS=ON \
   -DUSE_NCCL_LIB_PATH=ON -DNCCL_INCLUDE_DIR=/usr/include \
   -DNCCL_LIBRARY=/workspace/libnccl_static.a ${arch_flag}
 echo "--- Build binary wheel"


### PR DESCRIPTION
See #8334. It appears that building the Python wheel with federated learning support leads to massively longer run-time for some CPU tests. I've verified it on my machine.

Submitting this PR to measure the difference in performance.