### PR TITLE
Avoid blank lines with federated training

### DIFF
--- a/python-package/xgboost/collective.py
+++ b/python-package/xgboost/collective.py
@@ -114,7 +114,7 @@ def communicator_print(msg: Any) -> None:
         msg = str(msg)
     is_dist = _LIB.XGCommunicatorIsDistributed()
     if is_dist != 0:
-        _check_call(_LIB.XGCommunicatorPrint(c_str(msg)))
+        _check_call(_LIB.XGCommunicatorPrint(c_str(msg.strip())))
     else:
         print(msg.strip(), flush=True)
 


### PR DESCRIPTION
Right now we use `LOG(CONSOLE) << msg` to print messages during federated training. But the evaluation callback already puts a newline in the message, resulting in blank lines being printed.

@trivialfis 