### PR TITLE
XGBRanker documentation: missing default objective

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -1785,6 +1785,10 @@ class XGBRFRegressor(XGBRegressor):
     end_note="""
         .. note::
 
+            The default objectivefor XGBRanker is "rank:pairwise"
+
+        .. note::
+
             A custom objective function is currently not supported by XGBRanker.
             Likewise, a custom metric function is not supported either.
 


### PR DESCRIPTION
I couldn't find in the documentation what the default objective for `XGBRanker` was, so I checked the source code and found that it is `rank:pairwise`. I would suggest to mention that in the documentation, it would be very helpful.