### PR TITLE
Use bst_ulong instead of size_t for CSR conversion

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2307,7 +2307,7 @@ class Booster:
                     _array_interface(csr.indptr),
                     _array_interface(csr.indices),
                     _array_interface(csr.data),
-                    ctypes.c_size_t(csr.shape[1]),
+                    c_bst_ulong(csr.shape[1]),
                     from_pystr_to_cstr(json.dumps(args)),
                     p_handle,
                     ctypes.byref(shape),

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -103,7 +103,7 @@ def _from_scipy_csr(
             _array_interface(data.indptr),
             _array_interface(data.indices),
             _array_interface(data.data),
-            ctypes.c_size_t(data.shape[1]),
+            c_bst_ulong(data.shape[1]),
             config,
             ctypes.byref(handle),
         )


### PR DESCRIPTION
Some platform, e.g., WebAssembly, has strict typing checking. The mismatch will cause crash.

And they should be `size_t` to be consistent with https://github.com/dmlc/xgboost/blob/master/src/c_api/c_api.cc#L392 and https://github.com/dmlc/xgboost/blob/master/src/data/proxy_dmatrix.cc#L19