### PR TITLE
xrange() was removed in Python 3 in favor or range()

### DIFF
--- a/rabit/guide/lazy_allreduce.py
+++ b/rabit/guide/lazy_allreduce.py
@@ -20,7 +20,7 @@ a = np.zeros(n)
 def prepare(a):
     print('@node[%d] run prepare function' % rank)
     # must take in reference and modify the reference
-    for i in xrange(n):
+    for i in range(n):
         a[i] = rank + i
 
 print('@node[%d] before-allreduce: a=%s' % (rank, str(a)))


### PR DESCRIPTION
https://portingguide.readthedocs.io/en/latest/iterators.html#new-behavior-of-range