### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/tests/benchmark/benchmark_linear.py
+++ b/tests/benchmark/benchmark_linear.py
@@ -43,7 +43,7 @@ def run_benchmark(args):
         dtrain.save_binary('dtrain.dm')
 
     param = {'objective': 'binary:logistic','booster':'gblinear'}
-    if args.params is not '':
+    if args.params != '':
         param.update(ast.literal_eval(args.params))
 
     param['updater'] = args.updater


### PR DESCRIPTION
See PEP8.  Identity is different than equality in Python.