### PR TITLE
compat.py: Ensure Python is >= v3.8

### DIFF
--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from ._typing import _T
 
-assert sys.version_info[0] == 3, "Python 2 is no longer supported."
+assert sys.version_info >= (3, 8), "Python < v3.8 is no longer supported."
 
 
 def py_str(x: bytes) -> str:


### PR DESCRIPTION
https://pypi.org/project/flake8-2020 says...
```
./python-package/xgboost/compat.py:13:8: YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`
assert sys.version_info[0] == 3, "Python 2 is no longer supported."
       ^
```