### PR TITLE
Fix building XGBoost with libomp 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,10 @@ if (USE_OPENMP)
     # Require CMake 3.16+ on Mac OSX, as previous versions of CMake had trouble locating
     # OpenMP on Mac. See https://github.com/dmlc/xgboost/pull/5146#issuecomment-568312706
     cmake_minimum_required(VERSION 3.16)
+    set(OpenMP_CXX_FLAGS
+      "-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include")
+    set(OpenMP_CXX_LIB_NAMES omp)
+    set(OpenMP_omp_LIBRARY /opt/homebrew/opt/libomp/lib/libomp.dylib)
   endif (APPLE)
   find_package(OpenMP REQUIRED)
 endif (USE_OPENMP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,12 +171,21 @@ if (USE_OPENMP)
     # Require CMake 3.16+ on Mac OSX, as previous versions of CMake had trouble locating
     # OpenMP on Mac. See https://github.com/dmlc/xgboost/pull/5146#issuecomment-568312706
     cmake_minimum_required(VERSION 3.16)
-    set(OpenMP_CXX_FLAGS
-      "-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include")
-    set(OpenMP_CXX_LIB_NAMES omp)
-    set(OpenMP_omp_LIBRARY /opt/homebrew/opt/libomp/lib/libomp.dylib)
-  endif (APPLE)
-  find_package(OpenMP REQUIRED)
+    find_package(OpenMP)
+    if (NOT OpenMP_FOUND)
+      # Try again with extra path info; required for libomp 15+ from Homebrew
+      set(OpenMP_C_FLAGS
+        "-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include")
+      set(OpenMP_CXX_FLAGS
+        "-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include")
+      set(OpenMP_C_LIB_NAMES omp)
+      set(OpenMP_CXX_LIB_NAMES omp)
+      set(OpenMP_omp_LIBRARY /opt/homebrew/opt/libomp/lib/libomp.dylib)
+      find_package(OpenMP REQUIRED)
+    endif ()
+  else ()
+    find_package(OpenMP REQUIRED)
+  endif ()
 endif (USE_OPENMP)
 #Add for IBM i
 if (${CMAKE_SYSTEM_NAME} MATCHES "OS400")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,13 +174,16 @@ if (USE_OPENMP)
     find_package(OpenMP)
     if (NOT OpenMP_FOUND)
       # Try again with extra path info; required for libomp 15+ from Homebrew
+      execute_process(COMMAND brew --prefix libomp
+                      OUTPUT_VARIABLE HOMEBREW_LIBOMP_PREFIX
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
       set(OpenMP_C_FLAGS
-        "-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include")
+        "-Xpreprocessor -fopenmp -I${HOMEBREW_LIBOMP_PREFIX}/include")
       set(OpenMP_CXX_FLAGS
-        "-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include")
+        "-Xpreprocessor -fopenmp -I${HOMEBREW_LIBOMP_PREFIX}/include")
       set(OpenMP_C_LIB_NAMES omp)
       set(OpenMP_CXX_LIB_NAMES omp)
-      set(OpenMP_omp_LIBRARY /opt/homebrew/opt/libomp/lib/libomp.dylib)
+      set(OpenMP_omp_LIBRARY ${HOMEBREW_LIBOMP_PREFIX}/lib/libomp.dylib)
       find_package(OpenMP REQUIRED)
     endif ()
   else ()

--- a/R-package/configure
+++ b/R-package/configure
@@ -2710,6 +2710,7 @@ fi
 if test `uname -s` = "Darwin"
 then
   if command -v brew &> /dev/null
+  then
     HOMEBREW_LIBOMP_PREFIX=`brew --prefix libomp`
   else
     # Homebrew not found

--- a/R-package/configure
+++ b/R-package/configure
@@ -2710,7 +2710,7 @@ fi
 if test `uname -s` = "Darwin"
 then
   OPENMP_CXXFLAGS='-Xclang -fopenmp'
-  OPENMP_LIB='-lomp'
+  OPENMP_LIB='-I/opt/homebrew/opt/libomp/include -lomp -L/opt/homebrew/opt/libomp/lib'
   ac_pkg_openmp=no
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenMP will work in a package" >&5
 $as_echo_n "checking whether OpenMP will work in a package... " >&6; }

--- a/R-package/configure
+++ b/R-package/configure
@@ -2709,8 +2709,9 @@ fi
 
 if test `uname -s` = "Darwin"
 then
-  OPENMP_CXXFLAGS='-Xclang -fopenmp'
-  OPENMP_LIB='-I/opt/homebrew/opt/libomp/include -lomp -L/opt/homebrew/opt/libomp/lib'
+  HOMEBREW_LIBOMP_PREFIX=`brew --prefix libomp`
+  OPENMP_CXXFLAGS="-Xpreprocessor -fopenmp -I${HOMEBREW_LIBOMP_PREFIX}/include"
+  OPENMP_LIB="-lomp -L${HOMEBREW_LIBOMP_PREFIX}/lib"
   ac_pkg_openmp=no
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether OpenMP will work in a package" >&5
 $as_echo_n "checking whether OpenMP will work in a package... " >&6; }

--- a/R-package/configure
+++ b/R-package/configure
@@ -2709,7 +2709,12 @@ fi
 
 if test `uname -s` = "Darwin"
 then
-  HOMEBREW_LIBOMP_PREFIX=`brew --prefix libomp`
+  if command -v brew &> /dev/null
+    HOMEBREW_LIBOMP_PREFIX=`brew --prefix libomp`
+  else
+    # Homebrew not found
+    HOMEBREW_LIBOMP_PREFIX=''
+  fi
   OPENMP_CXXFLAGS="-Xpreprocessor -fopenmp -I${HOMEBREW_LIBOMP_PREFIX}/include"
   OPENMP_LIB="-lomp -L${HOMEBREW_LIBOMP_PREFIX}/lib"
   ac_pkg_openmp=no

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -29,7 +29,7 @@ fi
 if test `uname -s` = "Darwin"
 then
   OPENMP_CXXFLAGS='-Xclang -fopenmp'
-  OPENMP_LIB='-lomp'
+  OPENMP_LIB='-I/opt/homebrew/opt/libomp/include -lomp -L/opt/homebrew/opt/libomp/lib'
   ac_pkg_openmp=no
   AC_MSG_CHECKING([whether OpenMP will work in a package])
   AC_LANG_CONFTEST([AC_LANG_PROGRAM([[#include <omp.h>]], [[ return (omp_get_max_threads() <= 1); ]])])

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -28,7 +28,12 @@ fi
 
 if test `uname -s` = "Darwin"
 then
-  HOMEBREW_LIBOMP_PREFIX=`brew --prefix libomp`
+  if command -v brew &> /dev/null
+    HOMEBREW_LIBOMP_PREFIX=`brew --prefix libomp`
+  else
+    # Homebrew not found
+    HOMEBREW_LIBOMP_PREFIX=''
+  fi
   OPENMP_CXXFLAGS="-Xpreprocessor -fopenmp -I${HOMEBREW_LIBOMP_PREFIX}/include"
   OPENMP_LIB="-lomp -L${HOMEBREW_LIBOMP_PREFIX}/lib"
   ac_pkg_openmp=no

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -28,8 +28,9 @@ fi
 
 if test `uname -s` = "Darwin"
 then
-  OPENMP_CXXFLAGS='-Xclang -fopenmp'
-  OPENMP_LIB='-I/opt/homebrew/opt/libomp/include -lomp -L/opt/homebrew/opt/libomp/lib'
+  HOMEBREW_LIBOMP_PREFIX=`brew --prefix libomp`
+  OPENMP_CXXFLAGS="-Xpreprocessor -fopenmp -I${HOMEBREW_LIBOMP_PREFIX}/include"
+  OPENMP_LIB="-lomp -L${HOMEBREW_LIBOMP_PREFIX}/lib"
   ac_pkg_openmp=no
   AC_MSG_CHECKING([whether OpenMP will work in a package])
   AC_LANG_CONFTEST([AC_LANG_PROGRAM([[#include <omp.h>]], [[ return (omp_get_max_threads() <= 1); ]])])

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -29,6 +29,7 @@ fi
 if test `uname -s` = "Darwin"
 then
   if command -v brew &> /dev/null
+  then
     HOMEBREW_LIBOMP_PREFIX=`brew --prefix libomp`
   else
     # Homebrew not found


### PR DESCRIPTION
The Homebrew package for libomp 15 is [now keg-only](https://github.com/Homebrew/homebrew-core/issues/112107#issuecomment-1278042927), meaning that we now need to specify extra build flags.
```
==> Caveats
libomp is keg-only, which means it was not symlinked into /opt/homebrew,
because it can override GCC headers and result in broken builds.

For compilers to find libomp you may need to set:
  export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"
  export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"
```
This PR attempts to fix building XGBoost with libomp 15.

This should be also back-ported to the R package.