### PR TITLE
[CI] remove unused import in python tests

### DIFF
--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -3,7 +3,6 @@ change without notice.
 
 """
 # pylint: disable=invalid-name,missing-function-docstring,import-error
-import copy
 import gc
 import importlib.util
 import multiprocessing


### PR DESCRIPTION
👋 I'm interested in spending some time helping out on `xgboost`, so I started looking around tonight.

I ran `flake8` over the Python package tonight, and found what looks like an unused import.

```shell
flake8 \
    --ignore=E501,W503 \
    python-package/xgboost
```

```text
python-package/xgboost/testing/__init__.py:6:1: F401 'copy' imported but unused
```

This PR proposes removing it.

### How I tested this

<details><summary>locally on my mac (click for details)</summary>

Basically copied what I saw in https://github.com/dmlc/xgboost/blob/0db903b4714ea2eb5cca8c61c4eb108874c3ec2e/.github/workflows/python_tests.yml#L157.

Created and activated a `conda` environment.

```shell
mamba env create \
    --name xgboost-dev \
        pythoon=3.10 \
        pandas \
        numpy \
        scipy \
        dask \
        distributed \
        hypothesis \
        pytest \
        pytest-cov \
        matplotlib

source activate xgboost-dev
```

Then compiled, built the Python package, installed it, and ran the Python tests.

```shell
brew install ninja
mkdir build
cd build
cmake \
    -GNinja \
    -DGOOGLE_TEST=ON \
    -DUSE_DMLC_GTEST=ON \
    -DCMAKE_PREFIX_PATH=$CONDA_PREFIX \
    ..

ninja -j2

cd ../python-package
python setup.py install

cd ../
pytest tests/python
```

This resulted in 3 test failures which I'm guessing are not related to the change in this PR.

```text
FAILED tests/python/test_linear.py::TestLinear::test_coordinate - hypothesis.errors.FailedHealthCheck: Examples routinely exceeded the max allowable size...
FAILED tests/python/test_tracker.py::test_rabit_ops - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
FAILED tests/python/test_tracker.py::test_rank_assignment - socket.gaierror: [Errno 8] nodename nor servname provided, or not known
```

</details>

### Notes for Reviewers

Thanks very much for your time and consideration.