### PR TITLE
add files from python tests to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,9 @@ credentials.csv
 .metals
 .bloop
 
-# hypothesis python tests
+# python tests
+demo/**/*.txt
+*.dmatrix
 .hypothesis
+__MACOSX/
+model*.json


### PR DESCRIPTION
Working on #8409, I ran the Python unit tests locally on my Mac tonight.

<details><summary>how I did that (click me)</summary>

Created a conda environment.

```shell
mamba env create \
    --name xgboost-dev \
        pythoon=3.10 \
        pandas \
        numpy \
        scipy \
        dask \
        distributed \
        hypothesis \
        pytest \
        pytest-cov \
        matplotlib

source activate xgboost-dev
```

Built the library and ran the tests.

```shell
brew install ninja
mkdir build
cd build
cmake \
    -GNinja \
    -DGOOGLE_TEST=ON \
    -DUSE_DMLC_GTEST=ON \
    -DCMAKE_PREFIX_PATH=$CONDA_PREFIX \
    ..

ninja -j2

cd ../python-package
python setup.py install

cd ../
pytest tests/python
```

</details>

After doing that, I saw a few untracked files that look like they were generated by the tests, and probably shouldn't be checked into source control.

```shell
git status
```

```text
demo/CLI/regression/featmap.txt
demo/CLI/regression/machine.txt
demo/rank/__MACOSX/
dtest.dmatrix
model-0.json
model-1.json
```

This PR proposes adding `.gitignore` rules to prevent them from being checked in.

Thanks very much for your time and consideration.