### PR TITLE
Convert ``DaskXGBClassifier.classes_`` to an array

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -73,7 +73,7 @@ from .core import (
     _deprecate_positional_args,
     _expect,
 )
-from .data import _is_cudf_df, _is_cupy_array
+from .data import _is_cudf_ser, _is_cupy_array
 from .sklearn import (
     XGBClassifier,
     XGBClassifierBase,
@@ -1899,7 +1899,7 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierMixIn, XGBClassifierBa
             self.classes_ = await self.client.compute(da.unique(y))
         else:
             self.classes_ = await self.client.compute(y.drop_duplicates())
-        if _is_cudf_df(self.classes_):
+        if _is_cudf_ser(self.classes_):
             self.classes_ = self.classes_.to_cupy()
         if _is_cupy_array(self.classes_):
             self.classes_ = self.classes_.get()

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -73,6 +73,7 @@ from .core import (
     _deprecate_positional_args,
     _expect,
 )
+from .data import _is_cudf_df, _is_cupy_array
 from .sklearn import (
     XGBClassifier,
     XGBClassifierBase,
@@ -1898,11 +1899,9 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierMixIn, XGBClassifierBa
             self.classes_ = await self.client.compute(da.unique(y))
         else:
             self.classes_ = await self.client.compute(y.drop_duplicates())
-        if hasattr(self.classes_, "to_cupy"):
-            # cuDF dataframe
+        if _is_cudf_df(self.classes_):
             self.classes_ = self.classes_.to_cupy()
-        if hasattr(self.classes_, "get"):
-            # cupy array
+        if _is_cupy_array(self.classes_):
             self.classes_ = self.classes_.get()
         self.classes_ = numpy.array(self.classes_)
         self.n_classes_ = len(self.classes_)

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1894,10 +1894,16 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierMixIn, XGBClassifierBa
         )
 
         # pylint: disable=attribute-defined-outside-init
-        if isinstance(y, (da.Array)):
+        if isinstance(y, da.Array):
             self.classes_ = await self.client.compute(da.unique(y))
         else:
             self.classes_ = await self.client.compute(y.drop_duplicates())
+        if hasattr(self.classes_, "to_cupy"):
+            # cuDF dataframe
+            self.classes_ = self.classes_.to_cupy()
+        if hasattr(self.classes_, "get"):
+            # cupy array
+            self.classes_ = self.classes_.get()
         self.classes_ = numpy.array(self.classes_)
         self.n_classes_ = len(self.classes_)
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -1898,6 +1898,7 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierMixIn, XGBClassifierBa
             self.classes_ = await self.client.compute(da.unique(y))
         else:
             self.classes_ = await self.client.compute(y.drop_duplicates())
+        self.classes_ = numpy.array(self.classes_)
         self.n_classes_ = len(self.classes_)
 
         if self.n_classes_ > 2:


### PR DESCRIPTION
This PR fixes #8451 and adds a test to check that `classes_` is an array of the expected labels regardless of whether input is a dask array or dataframe.