### PR TITLE
[jvm-packages] [pyspark] Make cuDF optional in PySpark package

### DIFF
--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -43,6 +43,11 @@ except ImportError:
     pandas_concat = None
     PANDAS_INSTALLED = False
 
+
+# cuDF
+CUDF_INSTALLED = importlib.util.find_spec("cudf") is not None
+
+
 # sklearn
 try:
     from sklearn.base import BaseEstimator as XGBModelBase

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tupl
 import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
-from xgboost.compat import concat
+from xgboost.compat import CUDF_INSTALLED, concat
 
 from xgboost import DataIter, DMatrix, QuantileDMatrix
 
@@ -81,7 +81,7 @@ class PartIter(DataIter):
         if not data:
             return None
 
-        if self._device_id is not None:
+        if self._device_id is not None and CUDF_INSTALLED:
             import cudf  # pylint: disable=import-error
             import cupy as cp  # pylint: disable=import-error
 


### PR DESCRIPTION
Closes #8467

Not using cuDF may have adverse performance implication, but at least it's better not to crash due to missing `cudf`.