### PR TITLE
Support all pandas nullable integer types.

### DIFF
--- a/python-package/xgboost/_typing.py
+++ b/python-package/xgboost/_typing.py
@@ -32,6 +32,7 @@ PathLike = Union[str, os.PathLike]
 CupyT = ArrayLike  # maybe need a stub for cupy arrays
 NumpyOrCupy = Any
 NumpyDType = Union[str, Type[np.number]]
+PandasDType = Any  # real type is pandas.core.dtypes.base.ExtensionDtype
 
 FloatCompatible = Union[float, np.float32, np.float64]
 

--- a/python-package/xgboost/_typing.py
+++ b/python-package/xgboost/_typing.py
@@ -32,7 +32,6 @@ PathLike = Union[str, os.PathLike]
 CupyT = ArrayLike  # maybe need a stub for cupy arrays
 NumpyOrCupy = Any
 NumpyDType = Union[str, Type[np.number]]
-PandasDType = Any  # real type is pandas.core.dtypes.base.ExtensionDtype
 
 FloatCompatible = Union[float, np.float32, np.float64]
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1068,7 +1068,11 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return ret.value
 
     def num_nonmissing(self) -> int:
-        """Get the number of non-missing values in the DMatrix."""
+        """Get the number of non-missing values in the DMatrix.
+
+            .. versionadded:: 1.7.0
+
+        """
         ret = c_bst_ulong()
         _check_call(_LIB.XGDMatrixNumNonMissing(self.handle, ctypes.byref(ret)))
         return ret.value

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -16,7 +16,6 @@ from ._typing import (
     FeatureTypes,
     FloatCompatible,
     NumpyDType,
-    PandasDType,
     c_bst_ulong,
 )
 from .compat import DataFrame, lazy_isinstance

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -34,7 +34,8 @@ from .core import (
 )
 
 DispatchedDataBackendReturnType = Tuple[
-    ctypes.c_void_p, Optional[FeatureNames], Optional[FeatureTypes]]
+    ctypes.c_void_p, Optional[FeatureNames], Optional[FeatureTypes]
+]
 
 CAT_T = "c"
 
@@ -217,22 +218,27 @@ def _is_modin_df(data: DataType) -> bool:
 
 
 _pandas_dtype_mapper = {
-    'int8': 'int',
-    'int16': 'int',
-    'int32': 'int',
-    'int64': 'int',
-    'uint8': 'int',
-    'uint16': 'int',
-    'uint32': 'int',
-    'uint64': 'int',
-    'float16': 'float',
-    'float32': 'float',
-    'float64': 'float',
-    'bool': 'i',
+    "int8": "int",
+    "int16": "int",
+    "int32": "int",
+    "int64": "int",
+    "uint8": "int",
+    "uint16": "int",
+    "uint32": "int",
+    "uint64": "int",
+    "float16": "float",
+    "float32": "float",
+    "float64": "float",
+    "bool": "i",
     # nullable types
+    "Int8": "int",
     "Int16": "int",
     "Int32": "int",
     "Int64": "int",
+    "UInt8": "i",
+    "UInt16": "i",
+    "UInt32": "i",
+    "UInt64": "i",
     "Float32": "float",
     "Float64": "float",
     "boolean": "i",
@@ -295,25 +301,8 @@ def _pandas_feature_info(
     return feature_names, feature_types
 
 
-def is_nullable_dtype(dtype: PandasDType) -> bool:
-    """Wether dtype is a pandas nullable type."""
-    from pandas.api.types import (
-        is_bool_dtype,
-        is_categorical_dtype,
-        is_float_dtype,
-        is_integer_dtype,
-    )
-
-    # dtype: pd.core.arrays.numeric.NumericDtype
-    nullable_alias = {"Int16", "Int32", "Int64", "Float32", "Float64", "category"}
-    is_int = is_integer_dtype(dtype) and dtype.name in nullable_alias
-    # np.bool has alias `bool`, while pd.BooleanDtype has `bzoolean`.
-    is_bool = is_bool_dtype(dtype) and dtype.name == "boolean"
-    is_float = is_float_dtype(dtype) and dtype.name in nullable_alias
-    return is_int or is_bool or is_float or is_categorical_dtype(dtype)
-
-
-def _pandas_cat_null(data: DataFrame) -> DataFrame:
+def pandas_cat_null(data: DataFrame) -> DataFrame:
+    """Handle categorical dtype and nullable extension types from pandas."""
     from pandas.api.types import is_categorical_dtype
 
     # handle category codes and nullable.
@@ -322,10 +311,7 @@ def _pandas_cat_null(data: DataFrame) -> DataFrame:
         for col, dtype in zip(data.columns, data.dtypes)
         if is_categorical_dtype(dtype)
     ]
-    nul_columns = [
-        col for col, dtype in zip(data.columns, data.dtypes) if is_nullable_dtype(dtype)
-    ]
-    if cat_columns or nul_columns:
+    if cat_columns:
         # Avoid transformation due to: PerformanceWarning: DataFrame is highly
         # fragmented
         transformed = data.copy()
@@ -333,16 +319,21 @@ def _pandas_cat_null(data: DataFrame) -> DataFrame:
         transformed = data
 
     if cat_columns:
-        # DF doesn't have the cat attribute, so we use apply here
+        # DF doesn't have the cat attribute, as a result, we use apply here
         transformed[cat_columns] = (
             transformed[cat_columns]
             .apply(lambda x: x.cat.codes)
             .astype(np.float32)
             .replace(-1.0, np.NaN)
         )
-    if nul_columns:
-        transformed[nul_columns] = transformed[nul_columns].astype(np.float32)
 
+    # Convert all types including nullable extension types to float32
+
+    # TODO(jiamingy): Investigate the possibility of using dataframe protocol or arrow
+    # IPC format for pandas so that we can apply the data transformation inside XGBoost
+    # for better memory efficiency.
+
+    transformed = transformed.astype(np.float32)
     return transformed
 
 
@@ -357,9 +348,8 @@ def _transform_pandas_df(
     from pandas.api.types import is_categorical_dtype, is_sparse
 
     if not all(
-        dtype.name in _pandas_dtype_mapper
+        (dtype.name in _pandas_dtype_mapper)
         or is_sparse(dtype)
-        or (is_nullable_dtype(dtype) and not is_categorical_dtype(dtype))
         or (is_categorical_dtype(dtype) and enable_categorical)
         for dtype in data.dtypes
     ):
@@ -369,7 +359,7 @@ def _transform_pandas_df(
         data, meta, feature_names, feature_types, enable_categorical
     )
 
-    transformed = _pandas_cat_null(data)
+    transformed = pandas_cat_null(data)
 
     if meta and len(data.columns) > 1 and meta not in _matrix_meta:
         raise ValueError(f"DataFrame for {meta} cannot have multiple columns")
@@ -404,14 +394,12 @@ def _is_pandas_series(data: DataType) -> bool:
 
 
 def _meta_from_pandas_series(
-    data: DataType,
-    name: str,
-    dtype: Optional[NumpyDType],
-    handle: ctypes.c_void_p
+    data: DataType, name: str, dtype: Optional[NumpyDType], handle: ctypes.c_void_p
 ) -> None:
     """Help transform pandas series for meta data like labels"""
-    data = data.values.astype('float')
+    data = data.values.astype("float")
     from pandas.api.types import is_sparse
+
     if is_sparse(data):
         data = data.to_dense()  # type: ignore
     assert len(data.shape) == 1 or data.shape[1] == 0 or data.shape[1] == 1

--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -768,6 +768,19 @@ def non_increasing(L: Sequence[float], tolerance: float = 1e-4) -> bool:
     return all((y - x) < tolerance for x, y in zip(L, L[1:]))
 
 
+def predictor_equal(lhs: xgb.DMatrix, rhs: xgb.DMatrix) -> bool:
+    """Assert whether two DMatrices contain the same predictors."""
+    lcsr = lhs.get_data()
+    rcsr = rhs.get_data()
+    return all(
+        (
+            np.array_equal(lcsr.data, rcsr.data),
+            np.array_equal(lcsr.indices, rcsr.indices),
+            np.array_equal(lcsr.indptr, rcsr.indptr),
+        )
+    )
+
+
 def eval_error_metric(predt: np.ndarray, dtrain: xgb.DMatrix) -> Tuple[str, np.float64]:
     """Evaluation metric for xgb.train"""
     label = dtrain.get_label()

--- a/python-package/xgboost/testing/data.py
+++ b/python-package/xgboost/testing/data.py
@@ -7,7 +7,7 @@ import numpy as np
 def np_dtypes(
     n_samples: int, n_features: int
 ) -> Generator[Tuple[np.ndarray, np.ndarray], None, None]:
-    """Generate all supported dtypes from numpy."""
+    """Enumerate all supported dtypes from numpy."""
     import pandas as pd
 
     rng = np.random.RandomState(1994)
@@ -60,3 +60,71 @@ def np_dtypes(
         df_orig = pd.DataFrame(orig)
         df = pd.DataFrame(X)
         yield df_orig, df
+
+
+def pd_dtypes() -> Generator:
+    """Enumerate all supported pandas extension types."""
+    import pandas as pd
+
+    # Integer
+    dtypes = [
+        pd.UInt8Dtype(),
+        pd.UInt16Dtype(),
+        pd.UInt32Dtype(),
+        pd.UInt64Dtype(),
+        pd.Int8Dtype(),
+        pd.Int16Dtype(),
+        pd.Int32Dtype(),
+        pd.Int64Dtype(),
+    ]
+
+    Null = np.nan
+    orig = pd.DataFrame(
+        {"f0": [1, 2, Null, 3], "f1": [4, 3, Null, 1]}, dtype=np.float32
+    )
+    for Null in (np.nan, None, pd.NA):
+        for dtype in dtypes:
+            df = pd.DataFrame(
+                {"f0": [1, 2, Null, 3], "f1": [4, 3, Null, 1]}, dtype=dtype
+            )
+            break
+            yield orig, df
+
+    # Float
+    Null = np.nan
+    dtypes = [pd.Float32Dtype(), pd.Float64Dtype()]
+    orig = pd.DataFrame(
+        {"f0": [1.0, 2.0, Null, 3.0], "f1": [3.0, 2.0, Null, 1.0]}, dtype=np.float32
+    )
+    for Null in (np.nan, None, pd.NA):
+        for dtype in dtypes:
+            df = pd.DataFrame(
+                {"f0": [1.0, 2.0, Null, 3.0], "f1": [3.0, 2.0, Null, 1.0]}, dtype=dtype
+            )
+            break
+            yield orig, df
+
+    # Categorical
+    orig = orig.astype("category")
+    for Null in (np.nan, None, pd.NA):
+        df = pd.DataFrame(
+            {"f0": [1.0, 2.0, Null, 3.0], "f1": [3.0, 2.0, Null, 1.0]},
+            dtype=pd.CategoricalDtype(),
+        )
+        break
+        yield orig, df
+
+    # Boolean
+    Null = None
+    data = {"f0": [True, False, Null, True], "f1": [False, True, Null, True]}
+
+    orig = pd.DataFrame(data, dtype=np.bool_)
+    df = pd.DataFrame(data, dtype=pd.BooleanDtype())
+    yield orig, df
+
+    Null = pd.NA
+    data = {"f0": [True, False, Null, True], "f1": [False, True, Null, True]}
+    # pd.NA is not convertible to bool.
+    orig = pd.DataFrame(data, dtype=pd.BooleanDtype())
+    df = pd.DataFrame(data, dtype=pd.BooleanDtype())
+    yield orig, df

--- a/python-package/xgboost/testing/data.py
+++ b/python-package/xgboost/testing/data.py
@@ -112,16 +112,9 @@ def pd_dtypes() -> Generator:
         yield orig, df
 
     # Boolean
-    Null = None
-    data0 = {"f0": [True, False, Null, True], "f1": [False, True, Null, True]}
-
-    orig = pd.DataFrame(data0, dtype=np.bool_)
-    df = pd.DataFrame(data0, dtype=pd.BooleanDtype())
-    yield orig, df
-
-    Null = pd.NA
-    data1 = {"f0": [True, False, Null, True], "f1": [False, True, Null, True]}
-    # pd.NA is not convertible to bool.
-    orig = pd.DataFrame(data1, dtype=pd.BooleanDtype())
-    df = pd.DataFrame(data1, dtype=pd.BooleanDtype())
-    yield orig, df
+    for Null in [None, pd.NA]:
+        data = {"f0": [True, False, Null, True], "f1": [False, True, Null, True]}
+        # pd.NA is not convertible to bool.
+        orig = pd.DataFrame(data, dtype=np.bool_ if Null is None else pd.BooleanDtype())
+        df = pd.DataFrame(data, dtype=pd.BooleanDtype())
+        yield orig, df

--- a/python-package/xgboost/testing/data.py
+++ b/python-package/xgboost/testing/data.py
@@ -1,5 +1,5 @@
 """Utilities for data generation."""
-from typing import Generator, Tuple
+from typing import Any, Generator, Tuple, Union
 
 import numpy as np
 
@@ -78,7 +78,7 @@ def pd_dtypes() -> Generator:
         pd.Int64Dtype(),
     ]
 
-    Null = np.nan
+    Null: Union[float, None, Any] = np.nan
     orig = pd.DataFrame(
         {"f0": [1, 2, Null, 3], "f1": [4, 3, Null, 1]}, dtype=np.float32
     )
@@ -113,15 +113,15 @@ def pd_dtypes() -> Generator:
 
     # Boolean
     Null = None
-    data = {"f0": [True, False, Null, True], "f1": [False, True, Null, True]}
+    data0 = {"f0": [True, False, Null, True], "f1": [False, True, Null, True]}
 
-    orig = pd.DataFrame(data, dtype=np.bool_)
-    df = pd.DataFrame(data, dtype=pd.BooleanDtype())
+    orig = pd.DataFrame(data0, dtype=np.bool_)
+    df = pd.DataFrame(data0, dtype=pd.BooleanDtype())
     yield orig, df
 
     Null = pd.NA
-    data = {"f0": [True, False, Null, True], "f1": [False, True, Null, True]}
+    data1 = {"f0": [True, False, Null, True], "f1": [False, True, Null, True]}
     # pd.NA is not convertible to bool.
-    orig = pd.DataFrame(data, dtype=pd.BooleanDtype())
-    df = pd.DataFrame(data, dtype=pd.BooleanDtype())
+    orig = pd.DataFrame(data1, dtype=pd.BooleanDtype())
+    df = pd.DataFrame(data1, dtype=pd.BooleanDtype())
     yield orig, df

--- a/python-package/xgboost/testing/data.py
+++ b/python-package/xgboost/testing/data.py
@@ -87,7 +87,6 @@ def pd_dtypes() -> Generator:
             df = pd.DataFrame(
                 {"f0": [1, 2, Null, 3], "f1": [4, 3, Null, 1]}, dtype=dtype
             )
-            break
             yield orig, df
 
     # Float
@@ -101,7 +100,6 @@ def pd_dtypes() -> Generator:
             df = pd.DataFrame(
                 {"f0": [1.0, 2.0, Null, 3.0], "f1": [3.0, 2.0, Null, 1.0]}, dtype=dtype
             )
-            break
             yield orig, df
 
     # Categorical
@@ -111,7 +109,6 @@ def pd_dtypes() -> Generator:
             {"f0": [1.0, 2.0, Null, 3.0], "f1": [3.0, 2.0, Null, 1.0]},
             dtype=pd.CategoricalDtype(),
         )
-        break
         yield orig, df
 
     # Boolean

--- a/tests/python/test_dmatrix.py
+++ b/tests/python/test_dmatrix.py
@@ -461,8 +461,4 @@ class TestDMatrix:
         for orig, x in np_dtypes(n_samples, n_features):
             m0 = xgb.DMatrix(orig)
             m1 = xgb.DMatrix(x)
-            csr0 = m0.get_data()
-            csr1 = m1.get_data()
-            np.testing.assert_allclose(csr0.data, csr1.data)
-            np.testing.assert_allclose(csr0.indptr, csr1.indptr)
-            np.testing.assert_allclose(csr0.indices, csr1.indices)
+            assert tm.predictor_equal(m0, m1)

--- a/tests/python/test_quantile_dmatrix.py
+++ b/tests/python/test_quantile_dmatrix.py
@@ -10,6 +10,7 @@ from xgboost.testing import (
     make_batches_sparse,
     make_categorical,
     make_sparse_regression,
+    predictor_equal,
 )
 from xgboost.testing.data import np_dtypes
 
@@ -246,11 +247,7 @@ class TestQuantileDMatrix:
         for orig, x in np_dtypes(n_samples, n_features):
             m0 = xgb.QuantileDMatrix(orig)
             m1 = xgb.QuantileDMatrix(x)
-            csr0 = m0.get_data()
-            csr1 = m1.get_data()
-            np.testing.assert_allclose(csr0.data, csr1.data)
-            np.testing.assert_allclose(csr0.indptr, csr1.indptr)
-            np.testing.assert_allclose(csr0.indices, csr1.indices)
+            assert predictor_equal(m0, m1)
 
         # unsupported types
         for dtype in [

--- a/tests/python/test_with_pandas.py
+++ b/tests/python/test_with_pandas.py
@@ -4,10 +4,10 @@ import tempfile
 import numpy as np
 import pytest
 from test_dmatrix import set_base_margin_info
+from xgboost.testing.data import pd_dtypes
 
 import xgboost as xgb
 from xgboost import testing as tm
-from xgboost.testing.data import pd_dtypes
 
 try:
     import pandas as pd

--- a/tests/python/test_with_pandas.py
+++ b/tests/python/test_with_pandas.py
@@ -7,6 +7,7 @@ from test_dmatrix import set_base_margin_info
 
 import xgboost as xgb
 from xgboost import testing as tm
+from xgboost.testing.data import pd_dtypes
 
 try:
     import pandas as pd
@@ -298,86 +299,21 @@ class TestPandas:
         assert 'error' in cv.columns[0]
 
     def test_nullable_type(self) -> None:
-        y = np.random.default_rng(0).random(4)
+        from pandas.api.types import is_categorical
 
-        def to_bytes(Xy: xgb.DMatrix) -> bytes:
-            with tempfile.TemporaryDirectory() as tmpdir:
-                path = os.path.join(tmpdir, "Xy.dmatrix")
-                Xy.save_binary(path)
-                with open(path, "rb") as fd:
-                    result = fd.read()
-            return result
+        for DMatrixT in (xgb.DMatrix, xgb.QuantileDMatrix):
+            for orig, df in pd_dtypes():
+                enable_categorical = any(is_categorical for dtype in df.dtypes)
 
-        def test_int(dtype, Null) -> bytes:
-            arr = pd.DataFrame(
-                {"f0": [1, 2, Null, 3], "f1": [4, 3, Null, 1]}, dtype=dtype
-            )
-            Xy = xgb.DMatrix(arr, y)
-            Xy.feature_types = None
+                m_orig = DMatrixT(orig, enable_categorical=enable_categorical)
+                # extension types
+                m_etype = DMatrixT(df, enable_categorical=enable_categorical)
+                # different from pd.BooleanDtype(), None is converted to False with bool
+                if any(dtype == "bool" for dtype in orig.dtypes):
+                    assert not tm.predictor_equal(m_orig, m_etype)
+                else:
+                    assert tm.predictor_equal(m_orig, m_etype)
 
-            f0 = arr["f0"]
-            with pytest.raises(ValueError, match="Label contains NaN"):
-                xgb.DMatrix(arr, f0)
-            return to_bytes(Xy)
-
-        b0 = test_int(np.float32, np.nan)
-
-        for dtype in (
-            pd.UInt8Dtype(),
-            pd.UInt16Dtype(),
-            pd.UInt32Dtype(),
-            pd.UInt64Dtype(),
-            pd.Int8Dtype(),
-            pd.Int16Dtype(),
-            pd.Int32Dtype(),
-            pd.Int64Dtype(),
-        ):
-            b1 = test_int(dtype, None)
-            assert b0 == b1
-            b1 = test_int(dtype, pd.NA)
-            assert b0 == b1
-
-        def test_bool(dtype) -> bytes:
-            arr = pd.DataFrame(
-                {"f0": [True, False, None, True], "f1": [False, True, None, True]},
-                dtype=dtype,
-            )
-            Xy = xgb.DMatrix(arr, y)
-            Xy.feature_types = None
-            return to_bytes(Xy)
-
-        b0 = test_bool(pd.BooleanDtype())
-        b1 = test_bool(bool)
-        assert b0 != b1  # None is converted to False with np.bool
-
-        data = {"f0": [1.0, 2.0, None, 3.0], "f1": [3.0, 2.0, None, 1.0]}
-
-        arr = np.array([data["f0"], data["f1"]]).T
-        Xy = xgb.DMatrix(arr, y)
-        Xy.feature_types = None
-        Xy.feature_names = None
-        from_np = to_bytes(Xy)
-
-        def test_float(dtype) -> bytes:
-            arr = pd.DataFrame(data, dtype=dtype)
-            Xy = xgb.DMatrix(arr, y)
-            Xy.feature_types = None
-            Xy.feature_names = None
-            return to_bytes(Xy)
-
-        b0 = test_float(pd.Float64Dtype())
-        b1 = test_float(float)
-        assert b0 == b1  # both are converted to NaN
-        assert b0 == from_np
-
-        def test_cat(dtype) -> bytes:
-            arr = pd.DataFrame(data, dtype=dtype)
-            if dtype is None:
-                arr = arr.astype("category")
-            Xy = xgb.DMatrix(arr, y, enable_categorical=True)
-            Xy.feature_types = None
-            return to_bytes(Xy)
-
-        b0 = test_cat(pd.CategoricalDtype())
-        b1 = test_cat(None)
-        assert b0 == b1
+                f0 = df["f0"]
+                with pytest.raises(ValueError, match="Label contains NaN"):
+                    xgb.DMatrix(df, f0, enable_categorical=enable_categorical)


### PR DESCRIPTION
- Enumerate all pandas extension types.
- Tests for `None`, `nan`, and `pd.NA`

Close https://github.com/dmlc/xgboost/issues/8466 .