### PR TITLE
[jvm-packages] Configure dependabot properly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,60 +10,84 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      # Pin Scala version
+      # Pin Scala version to 2.12.x
       - dependency-name: "org.scala-lang:scala-compiler"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-reflect"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-library"
+        versions: [">= 2.13.0"]
   - package-ecosystem: "maven"
     directory: "/jvm-packages/xgboost4j"
     schedule:
       interval: "daily"
     ignore:
-      # Pin Scala version
+      # Pin Scala version to 2.12.x
       - dependency-name: "org.scala-lang:scala-compiler"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-reflect"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-library"
+        versions: [">= 2.13.0"]
   - package-ecosystem: "maven"
     directory: "/jvm-packages/xgboost4j-gpu"
     schedule:
       interval: "daily"
     ignore:
-      # Pin Scala version
+      # Pin Scala version to 2.12.x
       - dependency-name: "org.scala-lang:scala-compiler"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-reflect"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-library"
+        versions: [">= 2.13.0"]
   - package-ecosystem: "maven"
     directory: "/jvm-packages/xgboost4j-example"
     schedule:
       interval: "daily"
     ignore:
-      # Pin Scala version
+      # Pin Scala version to 2.12.x
       - dependency-name: "org.scala-lang:scala-compiler"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-reflect"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-library"
+        versions: [">= 2.13.0"]
   - package-ecosystem: "maven"
     directory: "/jvm-packages/xgboost4j-spark"
     schedule:
       interval: "daily"
     ignore:
-      # Pin Scala version
+      # Pin Scala version to 2.12.x
       - dependency-name: "org.scala-lang:scala-compiler"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-reflect"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-library"
-      # Pin Spark version
+        versions: [">= 2.13.0"]
+      # Pin Spark version to 3.0.x
       - dependency-name: "org.apache.spark:spark-core_2.12"
+        versions: [">= 3.1.0"]
       - dependency-name: "org.apache.spark:spark-sql_2.12"
+        versions: [">= 3.1.0"]
       - dependency-name: "org.apache.spark:spark-mllib_2.12"
+        versions: [">= 3.1.0"]
   - package-ecosystem: "maven"
     directory: "/jvm-packages/xgboost4j-spark-gpu"
     schedule:
       interval: "daily"
     ignore:
-      # Pin Scala version
+      # Pin Scala version to 2.12.x
       - dependency-name: "org.scala-lang:scala-compiler"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-reflect"
+        versions: [">= 2.13.0"]
       - dependency-name: "org.scala-lang:scala-library"
-      # Pin Spark version
+        versions: [">= 2.13.0"]
+      # Pin Spark version to 3.0.x
       - dependency-name: "org.apache.spark:spark-core_2.12"
+        versions: [">= 3.1.0"]
       - dependency-name: "org.apache.spark:spark-sql_2.12"
+        versions: [">= 3.1.0"]
       - dependency-name: "org.apache.spark:spark-mllib_2.12"
+        versions: [">= 3.1.0"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,65 @@
 
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/jvm-packages" # Location of package manifests
+  - package-ecosystem: "maven"
+    directory: "/jvm-packages"
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "spark-core_2.12"
-      - dependency-name: "spark-sql_2.12"
-      - dependency-name: "spark-mllib_2.12"
-      - dependency-name: "scala-compiler"
+      # Pin Scala version
+      - dependency-name: "org.scala-lang:scala-compiler"
+      - dependency-name: "org.scala-lang:scala-reflect"
+      - dependency-name: "org.scala-lang:scala-library"
+  - package-ecosystem: "maven"
+    directory: "/jvm-packages/xgboost4j"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Pin Scala version
+      - dependency-name: "org.scala-lang:scala-compiler"
+      - dependency-name: "org.scala-lang:scala-reflect"
+      - dependency-name: "org.scala-lang:scala-library"
+  - package-ecosystem: "maven"
+    directory: "/jvm-packages/xgboost4j-gpu"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Pin Scala version
+      - dependency-name: "org.scala-lang:scala-compiler"
+      - dependency-name: "org.scala-lang:scala-reflect"
+      - dependency-name: "org.scala-lang:scala-library"
+  - package-ecosystem: "maven"
+    directory: "/jvm-packages/xgboost4j-example"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Pin Scala version
+      - dependency-name: "org.scala-lang:scala-compiler"
+      - dependency-name: "org.scala-lang:scala-reflect"
+      - dependency-name: "org.scala-lang:scala-library"
+  - package-ecosystem: "maven"
+    directory: "/jvm-packages/xgboost4j-spark"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Pin Scala version
+      - dependency-name: "org.scala-lang:scala-compiler"
+      - dependency-name: "org.scala-lang:scala-reflect"
+      - dependency-name: "org.scala-lang:scala-library"
+      # Pin Spark version
+      - dependency-name: "org.apache.spark:spark-core_2.12"
+      - dependency-name: "org.apache.spark:spark-sql_2.12"
+      - dependency-name: "org.apache.spark:spark-mllib_2.12"
+  - package-ecosystem: "maven"
+    directory: "/jvm-packages/xgboost4j-spark-gpu"
+    schedule:
+      interval: "daily"
+    ignore:
+      # Pin Scala version
+      - dependency-name: "org.scala-lang:scala-compiler"
+      - dependency-name: "org.scala-lang:scala-reflect"
+      - dependency-name: "org.scala-lang:scala-library"
+      # Pin Spark version
+      - dependency-name: "org.apache.spark:spark-core_2.12"
+      - dependency-name: "org.apache.spark:spark-sql_2.12"
+      - dependency-name: "org.apache.spark:spark-mllib_2.12"


### PR DESCRIPTION
Following up with #8501

* Specify the group ID in dependency specification.
* Update all `pom.xml` files.
* Pin Spark and Scala to 3.0 and 2.12, respectively. Allow automatic updates for patch releases.

cc @trivialfis @wbo4958 @WeichenXu123 We are setting up a bot to automatically file pull requests to update dependencies of the JVM packages.