### PR TITLE
feat(py, plot_importance): + values_format as arg

### DIFF
--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -30,6 +30,7 @@ def plot_importance(
     max_num_features: Optional[int] = None,
     grid: bool = True,
     show_values: bool = True,
+    values_format: str = "{v}",
     **kwargs: Any
 ) -> Axes:
     """Plot importance based on fitted trees.
@@ -66,6 +67,10 @@ def plot_importance(
         The name of feature map file.
     show_values : bool, default True
         Show values on plot. To disable, pass False.
+    values_format : str, default "{v}"
+        Format string for values. "v" will be replaced by the value of the feature importance.
+        e.g. Pass "{v:.2f}" in order to limit the number of digits after the decimal point
+        to two, for each value printed on the graph.
     kwargs :
         Other keywords passed to ax.barh()
 
@@ -109,7 +114,7 @@ def plot_importance(
 
     if show_values is True:
         for x, y in zip(values, ylocs):
-            ax.text(x + 1, y, x, va='center')
+            ax.text(x + 1, y, values_format.format(v=x), va='center')
 
     ax.set_yticks(ylocs)
     ax.set_yticklabels(labels)


### PR DESCRIPTION
Adds the ability to format the value printed near the bars on the `plot_importance` plot, directly from function arguments.

`plot_importance` is a very convenient graph, but the values it prints are too noisy, being full precision.  
This forces you to have to construct your own clean plot yourself from scratch.  
With this improvement you can continue to use `plot_importance` and have more control over the values printed on the bars.