### PR TITLE
Support `Series` and Python primitives in `inplace_predict` and QDM

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2237,17 +2237,15 @@ class Booster:
         preds = ctypes.POINTER(ctypes.c_float)()
 
         # once caching is supported, we can pass id(data) as cache id.
-        args = {
-            "type": 0,
-            "training": False,
-            "iteration_begin": iteration_range[0],
-            "iteration_end": iteration_range[1],
-            "missing": missing,
-            "strict_shape": strict_shape,
-            "cache_id": 0,
-        }
-        if predict_type == "margin":
-            args["type"] = 1
+        args = make_jcargs(
+            type=1 if predict_type == "margin" else 0,
+            training=False,
+            iteration_begin=iteration_range[0],
+            iteration_end=iteration_range[1],
+            missing=missing,
+            strict_shape=strict_shape,
+            cache_id=0,
+        )
         shape = ctypes.POINTER(c_bst_ulong)()
         dims = c_bst_ulong()
 
@@ -2302,7 +2300,7 @@ class Booster:
                 _LIB.XGBoosterPredictFromDense(
                     self.handle,
                     _array_interface(data),
-                    from_pystr_to_cstr(json.dumps(args)),
+                    args,
                     p_handle,
                     ctypes.byref(shape),
                     ctypes.byref(dims),
@@ -2319,7 +2317,7 @@ class Booster:
                     _array_interface(csr.indices),
                     _array_interface(csr.data),
                     c_bst_ulong(csr.shape[1]),
-                    from_pystr_to_cstr(json.dumps(args)),
+                    args,
                     p_handle,
                     ctypes.byref(shape),
                     ctypes.byref(dims),
@@ -2336,7 +2334,7 @@ class Booster:
                 _LIB.XGBoosterPredictFromCudaArray(
                     self.handle,
                     interface_str,
-                    from_pystr_to_cstr(json.dumps(args)),
+                    args,
                     p_handle,
                     ctypes.byref(shape),
                     ctypes.byref(dims),
@@ -2357,7 +2355,7 @@ class Booster:
                 _LIB.XGBoosterPredictFromCudaColumnar(
                     self.handle,
                     interfaces_str,
-                    from_pystr_to_cstr(json.dumps(args)),
+                    args,
                     p_handle,
                     ctypes.byref(shape),
                     ctypes.byref(dims),

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2260,6 +2260,25 @@ class Booster:
             proxy = None
             p_handle = ctypes.c_void_p()
         assert proxy is None or isinstance(proxy, _ProxyDMatrix)
+
+        from .data import (
+            _array_interface,
+            _is_cudf_df,
+            _is_cupy_array,
+            _is_list,
+            _is_pandas_df,
+            _is_tuple,
+            _transform_pandas_df,
+        )
+
+        enable_categorical = _has_categorical(self, data)
+        if _is_pandas_df(data):
+            data, fns, _ = _transform_pandas_df(data, enable_categorical)
+            if validate_features:
+                self._validate_features(fns)
+        if _is_list(data) or _is_tuple(data):
+            data = np.array(data)
+
         if validate_features:
             if not hasattr(data, "shape"):
                 raise TypeError(
@@ -2270,20 +2289,6 @@ class Booster:
                     f"Feature shape mismatch, expected: {self.num_features()}, "
                     f"got {data.shape[1]}"
                 )
-
-        from .data import (
-            _array_interface,
-            _is_cudf_df,
-            _is_cupy_array,
-            _is_pandas_df,
-            _transform_pandas_df,
-        )
-
-        enable_categorical = _has_categorical(self, data)
-        if _is_pandas_df(data):
-            data, fns, _ = _transform_pandas_df(data, enable_categorical)
-            if validate_features:
-                self._validate_features(fns)
 
         if isinstance(data, np.ndarray):
             from .data import _ensure_np_dtype

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2253,17 +2253,6 @@ class Booster:
             _transform_pandas_df,
         )
 
-        if validate_features:
-            if not hasattr(data, "shape"):
-                raise TypeError(
-                    "`shape` attribute is required when `validate_features` is True."
-                )
-            if len(data.shape) != 1 and self.num_features() != data.shape[1]:
-                raise ValueError(
-                    f"Feature shape mismatch, expected: {self.num_features()}, "
-                    f"got {data.shape[1]}"
-                )
-
         enable_categorical = True
         if _is_pandas_series(data):
             import pandas as pd
@@ -2274,6 +2263,17 @@ class Booster:
                 self._validate_features(fns)
         if _is_list(data) or _is_tuple(data):
             data = np.array(data)
+
+        if validate_features:
+            if not hasattr(data, "shape"):
+                raise TypeError(
+                    "`shape` attribute is required when `validate_features` is True."
+                )
+            if len(data.shape) != 1 and self.num_features() != data.shape[1]:
+                raise ValueError(
+                    f"Feature shape mismatch, expected: {self.num_features()}, "
+                    f"got {data.shape[1]}"
+                )
 
         if isinstance(data, np.ndarray):
             from .data import _ensure_np_dtype

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2267,11 +2267,15 @@ class Booster:
             _is_cupy_array,
             _is_list,
             _is_pandas_df,
+            _is_pandas_series,
             _is_tuple,
             _transform_pandas_df,
         )
 
         enable_categorical = _has_categorical(self, data)
+        if _is_pandas_series(data):
+            import pandas as pd
+            data = pd.DataFrame(data)
         if _is_pandas_df(data):
             data, fns, _ = _transform_pandas_df(data, enable_categorical)
             if validate_features:

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -958,12 +958,12 @@ def dispatch_data_backend(
         return _from_list(data, missing, threads, feature_names, feature_types)
     if _is_tuple(data):
         return _from_tuple(data, missing, threads, feature_names, feature_types)
-    if _is_pandas_df(data):
-        return _from_pandas_df(data, enable_categorical, missing, threads,
-                               feature_names, feature_types)
     if _is_pandas_series(data):
-        return _from_pandas_series(
-            data, missing, threads, enable_categorical, feature_names, feature_types
+        import pandas as pd
+        data = pd.DataFrame(data)
+    if _is_pandas_df(data):
+        return _from_pandas_df(
+            data, enable_categorical, missing, threads, feature_names, feature_types
         )
     if _is_cudf_df(data) or _is_cudf_ser(data):
         return _from_cudf_df(
@@ -1205,6 +1205,9 @@ def _proxy_transform(
         return data, None, feature_names, feature_types
     if _is_scipy_csr(data):
         return data, None, feature_names, feature_types
+    if _is_pandas_series(data):
+        import pandas as pd
+        data = pd.DataFrame(data)
     if _is_pandas_df(data):
         arr, feature_names, feature_types = _transform_pandas_df(
             data, enable_categorical, feature_names, feature_types

--- a/python-package/xgboost/testing/data.py
+++ b/python-package/xgboost/testing/data.py
@@ -40,6 +40,7 @@ def np_dtypes(
     for dtype in dtypes:
         X = np.array(orig, dtype=dtype)
         yield orig, X
+        yield orig.tolist(), X.tolist()
 
     for dtype in dtypes:
         X = np.array(orig, dtype=dtype)

--- a/python-package/xgboost/testing/data.py
+++ b/python-package/xgboost/testing/data.py
@@ -101,6 +101,11 @@ def pd_dtypes() -> Generator:
                 {"f0": [1.0, 2.0, Null, 3.0], "f1": [3.0, 2.0, Null, 1.0]}, dtype=dtype
             )
             yield orig, df
+            ser_orig = orig["f0"]
+            ser = df["f0"]
+            assert isinstance(ser, pd.Series)
+            assert isinstance(ser_orig, pd.Series)
+            yield ser_orig, ser
 
     # Categorical
     orig = orig.astype("category")

--- a/tests/python/test_predict.py
+++ b/tests/python/test_predict.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from scipy import sparse
-from xgboost.testing.data import np_dtypes
+from xgboost.testing.data import np_dtypes, pd_dtypes
 from xgboost.testing.shared import validate_leaf_output
 
 import xgboost as xgb
@@ -231,6 +231,7 @@ class TestInplacePredict:
         from_dmatrix = booster.predict(dtrain)
         np.testing.assert_allclose(from_dmatrix, from_inplace)
 
+    @pytest.mark.skipif(**tm.no_pandas())
     def test_dtypes(self) -> None:
         for orig, x in np_dtypes(self.rows, self.cols):
             predt_orig = self.booster.inplace_predict(orig)
@@ -246,3 +247,18 @@ class TestInplacePredict:
             X: np.ndarray = np.array(orig, dtype=dtype)
             with pytest.raises(ValueError):
                 self.booster.inplace_predict(X)
+
+    @pytest.mark.skipif(**tm.no_pandas())
+    def test_pd_dtypes(self) -> None:
+        from pandas.api.types import is_bool_dtype
+        for orig, x in pd_dtypes():
+            dtypes = orig.dtypes if isinstance(orig, pd.DataFrame) else [orig.dtypes]
+            if isinstance(orig, pd.DataFrame) and is_bool_dtype(dtypes[0]):
+                continue
+            print(orig.dtypes)
+            y = np.arange(x.shape[0])
+            Xy = xgb.DMatrix(orig, y, enable_categorical=True)
+            booster = xgb.train({"tree_method": "hist"}, Xy, num_boost_round=1)
+            predt_orig = booster.inplace_predict(orig)
+            predt = booster.inplace_predict(x)
+            np.testing.assert_allclose(predt, predt_orig)

--- a/tests/python/test_predict.py
+++ b/tests/python/test_predict.py
@@ -255,7 +255,6 @@ class TestInplacePredict:
             dtypes = orig.dtypes if isinstance(orig, pd.DataFrame) else [orig.dtypes]
             if isinstance(orig, pd.DataFrame) and is_bool_dtype(dtypes[0]):
                 continue
-            print(orig.dtypes)
             y = np.arange(x.shape[0])
             Xy = xgb.DMatrix(orig, y, enable_categorical=True)
             booster = xgb.train({"tree_method": "hist"}, Xy, num_boost_round=1)


### PR DESCRIPTION
- Support `pd.Series` in inplace predict.
- Support list and tuple in inplace predict.
- Support `pd.Series` in QDM.