### PR TITLE
[R] resolve line_length_linter warnings

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -64,6 +64,6 @@ Imports:
     methods,
     data.table (>= 1.9.6),
     jsonlite (>= 1.0),
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Encoding: UTF-8
 SystemRequirements: GNU make, C++14

--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -75,9 +75,11 @@
 #' @details
 #' The original sample is randomly partitioned into \code{nfold} equal size subsamples.
 #'
-#' Of the \code{nfold} subsamples, a single subsample is retained as the validation data for testing the model, and the remaining \code{nfold - 1} subsamples are used as training data.
+#' Of the \code{nfold} subsamples, a single subsample is retained as the validation data for testing the model,
+#' and the remaining \code{nfold - 1} subsamples are used as training data.
 #'
-#' The cross-validation process is then repeated \code{nrounds} times, with each of the \code{nfold} subsamples used exactly once as the validation data.
+#' The cross-validation process is then repeated \code{nrounds} times, with each of the
+#' \code{nfold} subsamples used exactly once as the validation data.
 #'
 #' All observations are used for both training and validation.
 #'

--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -21,9 +21,10 @@
 #'   \item{ \code{eta} control the learning rate: scale the contribution of each tree by a factor of \code{0 < eta < 1}
 #'          when it is added to the current approximation.
 #'          Used to prevent overfitting by making the boosting process more conservative.
-#'          Lower value for \code{eta} implies larger value for \code{nrounds}: low \code{eta} value means model more robust to overfitting but slower to compute.
-#'          Default: 0.3}
-#'   \item \code{gamma} minimum loss reduction required to make a further partition on a leaf node of the tree. the larger, the more conservative the algorithm will be.
+#'          Lower value for \code{eta} implies larger value for \code{nrounds}: low \code{eta} value means model
+#'          more robust to overfitting but slower to compute. Default: 0.3}
+#'   \item{ \code{gamma} minimum loss reduction required to make a further partition on a leaf node of the tree.
+#'          the larger, the more conservative the algorithm will be.}
 #'   \item \code{max_depth} maximum depth of a tree. Default: 6
 #'   \item{\code{min_child_weight} minimum sum of instance weight (hessian) needed in a child.
 #'         If the tree partition step results in a leaf node with the sum of instance weight less than min_child_weight,
@@ -78,8 +79,8 @@
 #'     \item{ \code{survival:cox}: Cox regression for right censored survival time data (negative values are considered right censored).
 #'            Note that predictions are returned on the hazard ratio scale (i.e., as HR = exp(marginal_prediction) in the proportional
 #'            hazard function \code{h(t) = h0(t) * HR)}.}
-#'     \item{ \code{survival:aft}: Accelerated failure time model for censored survival time data.
-#'            See \href{https://xgboost.readthedocs.io/en/latest/tutorials/aft_survival_analysis.html}{Survival Analysis with Accelerated Failure Time}
+#'     \item{ \code{survival:aft}: Accelerated failure time model for censored survival time data. See
+#'            \href{https://xgboost.readthedocs.io/en/latest/tutorials/aft_survival_analysis.html}{Survival Analysis with Accelerated Failure Time}
 #'            for details.}
 #'     \item \code{aft_loss_distribution}: Probability Density Function used by \code{survival:aft} and \code{aft-nloglik} metric.
 #'     \item{ \code{multi:softmax} set xgboost to do multiclass classification using the softmax objective.
@@ -105,7 +106,8 @@
 #'   \item \code{base_score} the initial prediction score of all instances, global bias. Default: 0.5
 #'   \item{ \code{eval_metric} evaluation metrics for validation data.
 #'          Users can pass a self-defined function to it.
-#'          Default: metric will be assigned according to objective(rmse for regression, and error for classification, mean average precision for ranking).
+#'          Default: metric will be assigned according to objective
+#'          (rmse for regression, and error for classification, mean average precision for ranking).
 #'          List is provided in detail section.}
 #' }
 #'
@@ -183,7 +185,8 @@
 #'      \item \code{merror} Multiclass classification error rate. It is calculated as \code{(# wrong cases) / (# all cases)}.
 #'      \item \code{mae} Mean absolute error
 #'      \item \code{mape} Mean absolute percentage error
-#'      \item \code{auc} Area under the curve. \url{https://en.wikipedia.org/wiki/Receiver_operating_characteristic#'Area_under_curve} for ranking evaluation.
+#'      \item{ \code{auc} Area under the curve.
+#'             \url{https://en.wikipedia.org/wiki/Receiver_operating_characteristic#'Area_under_curve} for ranking evaluation.}
 #'      \item \code{aucpr} Area under the PR curve. \url{https://en.wikipedia.org/wiki/Precision_and_recall} for ranking evaluation.
 #'      \item \code{ndcg} Normalized Discounted Cumulative Gain (for ranking task). \url{https://en.wikipedia.org/wiki/NDCG}
 #'   }

--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -18,17 +18,34 @@
 #' 2.1. Parameters for Tree Booster
 #'
 #' \itemize{
-#'   \item \code{eta} control the learning rate: scale the contribution of each tree by a factor of \code{0 < eta < 1} when it is added to the current approximation. Used to prevent overfitting by making the boosting process more conservative. Lower value for \code{eta} implies larger value for \code{nrounds}: low \code{eta} value means model more robust to overfitting but slower to compute. Default: 0.3
+#'   \item{ \code{eta} control the learning rate: scale the contribution of each tree by a factor of \code{0 < eta < 1}
+#'          when it is added to the current approximation.
+#'          Used to prevent overfitting by making the boosting process more conservative.
+#'          Lower value for \code{eta} implies larger value for \code{nrounds}: low \code{eta} value means model more robust to overfitting but slower to compute.
+#'          Default: 0.3}
 #'   \item \code{gamma} minimum loss reduction required to make a further partition on a leaf node of the tree. the larger, the more conservative the algorithm will be.
 #'   \item \code{max_depth} maximum depth of a tree. Default: 6
-#'   \item \code{min_child_weight} minimum sum of instance weight (hessian) needed in a child. If the tree partition step results in a leaf node with the sum of instance weight less than min_child_weight, then the building process will give up further partitioning. In linear regression mode, this simply corresponds to minimum number of instances needed to be in each node. The larger, the more conservative the algorithm will be. Default: 1
-#'   \item \code{subsample} subsample ratio of the training instance. Setting it to 0.5 means that xgboost randomly collected half of the data instances to grow trees and this will prevent overfitting. It makes computation shorter (because less data to analyse). It is advised to use this parameter with \code{eta} and increase \code{nrounds}. Default: 1
+#'   \item{\code{min_child_weight} minimum sum of instance weight (hessian) needed in a child.
+#'         If the tree partition step results in a leaf node with the sum of instance weight less than min_child_weight,
+#'         then the building process will give up further partitioning.
+#'         In linear regression mode, this simply corresponds to minimum number of instances needed to be in each node.
+#'         The larger, the more conservative the algorithm will be. Default: 1}
+#'   \item{ \code{subsample} subsample ratio of the training instance.
+#'         Setting it to 0.5 means that xgboost randomly collected half of the data instances to grow trees
+#'         and this will prevent overfitting. It makes computation shorter (because less data to analyse).
+#'         It is advised to use this parameter with \code{eta} and increase \code{nrounds}. Default: 1}
 #'   \item \code{colsample_bytree} subsample ratio of columns when constructing each tree. Default: 1
 #'   \item \code{lambda} L2 regularization term on weights. Default: 1
 #'   \item \code{alpha} L1 regularization term on weights. (there is no L1 reg on bias because it is not important). Default: 0
-#'   \item \code{num_parallel_tree} Experimental parameter. number of trees to grow per round. Useful to test Random Forest through XGBoost (set \code{colsample_bytree < 1}, \code{subsample  < 1}  and \code{round = 1}) accordingly. Default: 1
+#'   \item{ \code{num_parallel_tree} Experimental parameter. number of trees to grow per round.
+#'          Useful to test Random Forest through XGBoost
+#'          (set \code{colsample_bytree < 1}, \code{subsample  < 1}  and \code{round = 1}) accordingly.
+#'          Default: 1}
 #'   \item \code{monotone_constraints} A numerical vector consists of \code{1}, \code{0} and \code{-1} with its length equals to the number of features in the training data. \code{1} is increasing, \code{-1} is decreasing and \code{0} is no constraint.
-#'   \item \code{interaction_constraints} A list of vectors specifying feature indices of permitted interactions. Each item of the list represents one permitted interaction where specified features are allowed to interact with each other. Feature index values should start from \code{0} (\code{0} references the first column).  Leave argument unspecified for no interaction constraints.
+#'   \item{ \code{interaction_constraints} A list of vectors specifying feature indices of permitted interactions.
+#'        Each item of the list represents one permitted interaction where specified features are allowed to interact with each other.
+#'        Feature index values should start from \code{0} (\code{0} references the first column).
+#'        Leave argument unspecified for no interaction constraints.}
 #' }
 #'
 #' 2.2. Parameters for Linear Booster

--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -41,7 +41,9 @@
 #'          Useful to test Random Forest through XGBoost
 #'          (set \code{colsample_bytree < 1}, \code{subsample  < 1}  and \code{round = 1}) accordingly.
 #'          Default: 1}
-#'   \item \code{monotone_constraints} A numerical vector consists of \code{1}, \code{0} and \code{-1} with its length equals to the number of features in the training data. \code{1} is increasing, \code{-1} is decreasing and \code{0} is no constraint.
+#'   \item{ \code{monotone_constraints} A numerical vector consists of \code{1}, \code{0} and \code{-1} with its length
+#'          equals to the number of features in the training data.
+#'          \code{1} is increasing, \code{-1} is decreasing and \code{0} is no constraint.}
 #'   \item{ \code{interaction_constraints} A list of vectors specifying feature indices of permitted interactions.
 #'        Each item of the list represents one permitted interaction where specified features are allowed to interact with each other.
 #'        Feature index values should start from \code{0} (\code{0} references the first column).
@@ -59,29 +61,52 @@
 #' 3. Task Parameters
 #'
 #' \itemize{
-#' \item \code{objective} specify the learning task and the corresponding learning objective, users can pass a self-defined function to it. The default objective options are below:
+#' \item{ \code{objective} specify the learning task and the corresponding learning objective, users can pass a self-defined function to it.
+#'        The default objective options are below:
 #'   \itemize{
 #'     \item \code{reg:squarederror} Regression with squared loss (Default).
-#'     \item \code{reg:squaredlogerror}: regression with squared log loss \eqn{1/2 * (log(pred + 1) - log(label + 1))^2}. All inputs are required to be greater than -1. Also, see metric rmsle for possible issue with this objective.
+#'     \item{ \code{reg:squaredlogerror}: regression with squared log loss \eqn{1/2 * (log(pred + 1) - log(label + 1))^2}.
+#'            All inputs are required to be greater than -1.
+#'            Also, see metric rmsle for possible issue with this objective.}
 #'     \item \code{reg:logistic} logistic regression.
 #'     \item \code{reg:pseudohubererror}: regression with Pseudo Huber loss, a twice differentiable alternative to absolute loss.
 #'     \item \code{binary:logistic} logistic regression for binary classification. Output probability.
 #'     \item \code{binary:logitraw} logistic regression for binary classification, output score before logistic transformation.
 #'     \item \code{binary:hinge}: hinge loss for binary classification. This makes predictions of 0 or 1, rather than producing probabilities.
-#'     \item \code{count:poisson}: Poisson regression for count data, output mean of Poisson distribution. \code{max_delta_step} is set to 0.7 by default in poisson regression (used to safeguard optimization).
-#'     \item \code{survival:cox}: Cox regression for right censored survival time data (negative values are considered right censored). Note that predictions are returned on the hazard ratio scale (i.e., as HR = exp(marginal_prediction) in the proportional hazard function \code{h(t) = h0(t) * HR)}.
-#'     \item \code{survival:aft}: Accelerated failure time model for censored survival time data. See \href{https://xgboost.readthedocs.io/en/latest/tutorials/aft_survival_analysis.html}{Survival Analysis with Accelerated Failure Time} for details.
+#'     \item{ \code{count:poisson}: Poisson regression for count data, output mean of Poisson distribution.
+#'            \code{max_delta_step} is set to 0.7 by default in poisson regression (used to safeguard optimization).}
+#'     \item{ \code{survival:cox}: Cox regression for right censored survival time data (negative values are considered right censored).
+#'            Note that predictions are returned on the hazard ratio scale (i.e., as HR = exp(marginal_prediction) in the proportional
+#'            hazard function \code{h(t) = h0(t) * HR)}.}
+#'     \item{ \code{survival:aft}: Accelerated failure time model for censored survival time data.
+#'            See \href{https://xgboost.readthedocs.io/en/latest/tutorials/aft_survival_analysis.html}{Survival Analysis with Accelerated Failure Time}
+#'            for details.}
 #'     \item \code{aft_loss_distribution}: Probability Density Function used by \code{survival:aft} and \code{aft-nloglik} metric.
-#'     \item \code{multi:softmax} set xgboost to do multiclass classification using the softmax objective. Class is represented by a number and should be from 0 to \code{num_class - 1}.
-#'     \item \code{multi:softprob} same as softmax, but prediction outputs a vector of ndata * nclass elements, which can be further reshaped to ndata, nclass matrix. The result contains predicted probabilities of each data point belonging to each class.
+#'     \item{ \code{multi:softmax} set xgboost to do multiclass classification using the softmax objective.
+#'            Class is represented by a number and should be from 0 to \code{num_class - 1}.}
+#'     \item{ \code{multi:softprob} same as softmax, but prediction outputs a vector of ndata * nclass elements, which can be
+#'            further reshaped to ndata, nclass matrix. The result contains predicted probabilities of each data point belonging
+#'            to each class.}
 #'     \item \code{rank:pairwise} set xgboost to do ranking task by minimizing the pairwise loss.
-#'     \item \code{rank:ndcg}: Use LambdaMART to perform list-wise ranking where \href{https://en.wikipedia.org/wiki/Discounted_cumulative_gain}{Normalized Discounted Cumulative Gain (NDCG)} is maximized.
-#'     \item \code{rank:map}: Use LambdaMART to perform list-wise ranking where \href{https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Mean_average_precision}{Mean Average Precision (MAP)} is maximized.
-#'     \item \code{reg:gamma}: gamma regression with log-link. Output is a mean of gamma distribution. It might be useful, e.g., for modeling insurance claims severity, or for any outcome that might be \href{https://en.wikipedia.org/wiki/Gamma_distribution#Applications}{gamma-distributed}.
-#'     \item \code{reg:tweedie}: Tweedie regression with log-link. It might be useful, e.g., for modeling total loss in insurance, or for any outcome that might be \href{https://en.wikipedia.org/wiki/Tweedie_distribution#Applications}{Tweedie-distributed}.
+#'     \item{ \code{rank:ndcg}: Use LambdaMART to perform list-wise ranking where
+#'            \href{https://en.wikipedia.org/wiki/Discounted_cumulative_gain}{Normalized Discounted Cumulative Gain (NDCG)} is maximized.}
+#'     \item{ \code{rank:map}: Use LambdaMART to perform list-wise ranking where
+#'            \href{https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Mean_average_precision}{Mean Average Precision (MAP)}
+#'            is maximized.}
+#'     \item{ \code{reg:gamma}: gamma regression with log-link.
+#'            Output is a mean of gamma distribution.
+#'            It might be useful, e.g., for modeling insurance claims severity, or for any outcome that might be
+#'            \href{https://en.wikipedia.org/wiki/Gamma_distribution#Applications}{gamma-distributed}.}
+#'     \item{ \code{reg:tweedie}: Tweedie regression with log-link.
+#'            It might be useful, e.g., for modeling total loss in insurance, or for any outcome that might be
+#'            \href{https://en.wikipedia.org/wiki/Tweedie_distribution#Applications}{Tweedie-distributed}.}
 #'   }
+#'  }
 #'   \item \code{base_score} the initial prediction score of all instances, global bias. Default: 0.5
-#'   \item \code{eval_metric} evaluation metrics for validation data. Users can pass a self-defined function to it. Default: metric will be assigned according to objective(rmse for regression, and error for classification, mean average precision for ranking). List is provided in detail section.
+#'   \item{ \code{eval_metric} evaluation metrics for validation data.
+#'          Users can pass a self-defined function to it.
+#'          Default: metric will be assigned according to objective(rmse for regression, and error for classification, mean average precision for ranking).
+#'          List is provided in detail section.}
 #' }
 #'
 #' @param data training dataset. \code{xgb.train} accepts only an \code{xgb.DMatrix} as the input.

--- a/R-package/demo/caret_wrapper.R
+++ b/R-package/demo/caret_wrapper.R
@@ -1,3 +1,4 @@
+# nolint start
 # install development version of caret library that contains xgboost models
 devtools::install_github("topepo/caret/pkg/caret")
 require(caret)
@@ -33,3 +34,5 @@ model <- train(factor(Improved)~., data = df, method = "xgbTree", trControl = fi
 
 # See model results
 print(model)
+
+# nolint end

--- a/R-package/demo/caret_wrapper.R
+++ b/R-package/demo/caret_wrapper.R
@@ -1,4 +1,3 @@
-# nolint start
 # install development version of caret library that contains xgboost models
 devtools::install_github("topepo/caret/pkg/caret")
 require(caret)
@@ -9,14 +8,23 @@ require(e1071)
 
 # Load Arthritis dataset in memory.
 data(Arthritis)
-# Create a copy of the dataset with data.table package (data.table is 100% compliant with R dataframe but its syntax is a lot more consistent and its performance are really good).
+# Create a copy of the dataset with data.table package
+# (data.table is 100% compliant with R dataframe but its syntax is a lot more consistent
+# and its performance are really good).
 df <- data.table(Arthritis, keep.rownames = FALSE)
 
-# Let's add some new categorical features to see if it helps. Of course these feature are highly correlated to the Age feature. Usually it's not a good thing in ML, but Tree algorithms (including boosted trees) are able to select the best features, even in case of highly correlated features.
-# For the first feature we create groups of age by rounding the real age. Note that we transform it to factor (categorical data) so the algorithm treat them as independant values.
+# Let's add some new categorical features to see if it helps.
+# Of course these feature are highly correlated to the Age feature.
+# Usually it's not a good thing in ML, but Tree algorithms (including boosted trees) are able to select the best features,
+# even in case of highly correlated features.
+# For the first feature we create groups of age by rounding the real age.
+# Note that we transform it to factor (categorical data) so the algorithm treat them as independant values.
 df[, AgeDiscret := as.factor(round(Age / 10, 0))]
 
-# Here is an even stronger simplification of the real age with an arbitrary split at 30 years old. I choose this value based on nothing. We will see later if simplifying the information based on arbitrary values is a good strategy (I am sure you already have an idea of how well it will work!).
+# Here is an even stronger simplification of the real age with an arbitrary split at 30 years old.
+# I choose this value based on nothing.
+# We will see later if simplifying the information based on arbitrary values is a good strategy
+# (I am sure you already have an idea of how well it will work!).
 df[, AgeCat := as.factor(ifelse(Age > 30, "Old", "Young"))]
 
 # We remove ID as there is nothing to learn from this feature (it will just add some noise as the dataset is small).
@@ -29,10 +37,9 @@ fitControl <- trainControl(method = "repeatedcv", number = 10, repeats = 2, sear
 # train a xgbTree model using caret::train
 model <- train(factor(Improved)~., data = df, method = "xgbTree", trControl = fitControl)
 
-# Instead of tree for our boosters, you can also fit a linear regression or logistic regression model using xgbLinear
+# Instead of tree for our boosters, you can also fit a linear regression or logistic regression model
+# using xgbLinear
 # model <- train(factor(Improved)~., data = df, method = "xgbLinear", trControl = fitControl)
 
 # See model results
 print(model)
-
-# nolint end

--- a/R-package/demo/create_sparse_matrix.R
+++ b/R-package/demo/create_sparse_matrix.R
@@ -1,5 +1,3 @@
-# nolint start
-
 require(xgboost)
 require(Matrix)
 require(data.table)
@@ -9,34 +7,47 @@ if (!require(vcd)) {
 }
 # According to its documentation, XGBoost works only on numbers.
 # Sometimes the dataset we have to work on have categorical data.
-# A categorical variable is one which have a fixed number of values. By example, if for each observation a variable called "Colour" can have only "red", "blue" or "green" as value, it is a categorical variable.
+# A categorical variable is one which have a fixed number of values.
+# By example, if for each observation a variable called "Colour" can have only
+# "red", "blue" or "green" as value, it is a categorical variable.
 #
 # In R, categorical variable is called Factor.
 # Type ?factor in console for more information.
 #
-# In this demo we will see how to transform a dense dataframe with categorical variables to a sparse matrix before analyzing it in XGBoost.
+# In this demo we will see how to transform a dense dataframe with categorical variables to a sparse matrix
+# before analyzing it in XGBoost.
 # The method we are going to see is usually called "one hot encoding".
 
 #load Arthritis dataset in memory.
 data(Arthritis)
 
-# create a copy of the dataset with data.table package (data.table is 100% compliant with R dataframe but its syntax is a lot more consistent and its performance are really good).
+# create a copy of the dataset with data.table package
+# (data.table is 100% compliant with R dataframe but its syntax is a lot more consistent
+# and its performance are really good).
 df <- data.table(Arthritis, keep.rownames = FALSE)
 
 # Let's have a look to the data.table
 cat("Print the dataset\n")
 print(df)
 
-# 2 columns have factor type, one has ordinal type (ordinal variable is a categorical variable with values which can be ordered, here: None > Some > Marked).
+# 2 columns have factor type, one has ordinal type
+# (ordinal variable is a categorical variable with values which can be ordered, here: None > Some > Marked).
 cat("Structure of the dataset\n")
 str(df)
 
-# Let's add some new categorical features to see if it helps. Of course these feature are highly correlated to the Age feature. Usually it's not a good thing in ML, but Tree algorithms (including boosted trees) are able to select the best features, even in case of highly correlated features.
+# Let's add some new categorical features to see if it helps.
+# Of course these feature are highly correlated to the Age feature.
+# Usually it's not a good thing in ML, but Tree algorithms (including boosted trees) are able to select the best features,
+# even in case of highly correlated features.
 
-# For the first feature we create groups of age by rounding the real age. Note that we transform it to factor (categorical data) so the algorithm treat them as independent values.
+# For the first feature we create groups of age by rounding the real age.
+# Note that we transform it to factor (categorical data) so the algorithm treat them as independent values.
 df[, AgeDiscret := as.factor(round(Age / 10, 0))]
 
-# Here is an even stronger simplification of the real age with an arbitrary split at 30 years old. I choose this value based on nothing. We will see later if simplifying the information based on arbitrary values is a good strategy (I am sure you already have an idea of how well it will work!).
+# Here is an even stronger simplification of the real age with an arbitrary split at 30 years old.
+# I choose this value based on nothing.
+# We will see later if simplifying the information based on arbitrary values is a good strategy
+# (I am sure you already have an idea of how well it will work!).
 df[, AgeCat := as.factor(ifelse(Age > 30, "Old", "Young"))]
 
 # We remove ID as there is nothing to learn from this feature (it will just add some noise as the dataset is small).
@@ -50,7 +61,10 @@ print(levels(df[, Treatment]))
 # This method is also called one hot encoding.
 # The purpose is to transform each value of each categorical feature in one binary feature.
 #
-# Let's take, the column Treatment will be replaced by two columns, Placebo, and Treated. Each of them will be binary. For example an observation which had the value Placebo in column Treatment before the transformation will have, after the transformation, the value 1 in the new column Placebo and the value 0 in the new column  Treated.
+# Let's take, the column Treatment will be replaced by two columns, Placebo, and Treated.
+# Each of them will be binary.
+# For example an observation which had the value Placebo in column Treatment before the transformation will have, after the transformation,
+# the value 1 in the new column Placebo and the value 0 in the new column  Treated.
 #
 # Formulae Improved~.-1 used below means transform all categorical features but column Improved to binary values.
 # Column Improved is excluded because it will be our output column, the one we want to predict.
@@ -72,7 +86,10 @@ bst <- xgboost(data = sparse_matrix, label = output_vector, max_depth = 9,
 
 importance <- xgb.importance(feature_names = colnames(sparse_matrix), model = bst)
 print(importance)
-# According to the matrix below, the most important feature in this dataset to predict if the treatment will work is the Age. The second most important feature is having received a placebo or not. The sex is third. Then we see our generated features (AgeDiscret). We can see that their contribution is very low (Gain column).
+# According to the matrix below, the most important feature in this dataset to predict if the treatment will work is the Age.
+# The second most important feature is having received a placebo or not.
+# The sex is third.
+# Then we see our generated features (AgeDiscret). We can see that their contribution is very low (Gain column).
 
 # Does these result make sense?
 # Let's check some Chi2 between each of these features and the outcome.
@@ -84,10 +101,17 @@ print(chisq.test(df$AgeDiscret, df$Y))
 # Our first simplification of Age gives a Pearson correlation of 8.
 
 print(chisq.test(df$AgeCat, df$Y))
-# The perfectly random split I did between young and old at 30 years old have a low correlation of 2. It's a result we may expect as may be in my mind > 30 years is being old (I am 32 and starting feeling old, this may explain that), but  for the illness we are studying, the age to be vulnerable is not the same. Don't let your "gut" lower the quality of your model. In "data science", there is science :-)
+# The perfectly random split I did between young and old at 30 years old have a low correlation of 2.
+# It's a result we may expect as may be in my mind > 30 years is being old (I am 32 and starting feeling old, this may explain that),
+# but for the illness we are studying, the age to be vulnerable is not the same.
+# Don't let your "gut" lower the quality of your model. In "data science", there is science :-)
 
-# As you can see, in general destroying information by simplifying it won't improve your model. Chi2 just demonstrates that. But in more complex cases, creating a new feature based on existing one which makes link with the outcome more obvious may help the algorithm and improve the model. The case studied here is not enough complex to show that. Check Kaggle forum for some challenging datasets.
+# As you can see, in general destroying information by simplifying it won't improve your model.
+# Chi2 just demonstrates that.
+# But in more complex cases, creating a new feature based on existing one which makes link with the outcome
+# more obvious may help the algorithm and improve the model.
+# The case studied here is not enough complex to show that. Check Kaggle forum for some challenging datasets.
 # However it's almost always worse when you add some arbitrary rules.
-# Moreover, you can notice that even if we have added some not useful new features highly correlated with other features, the boosting tree algorithm have been able to choose the best one, which in this case is the Age. Linear model may not be that strong in these scenario.
-
-# nolint end
+# Moreover, you can notice that even if we have added some not useful new features highly correlated with
+# other features, the boosting tree algorithm have been able to choose the best one, which in this case is the Age.
+# Linear model may not be that strong in these scenario.

--- a/R-package/demo/create_sparse_matrix.R
+++ b/R-package/demo/create_sparse_matrix.R
@@ -1,3 +1,5 @@
+# nolint start
+
 require(xgboost)
 require(Matrix)
 require(data.table)
@@ -87,3 +89,5 @@ print(chisq.test(df$AgeCat, df$Y))
 # As you can see, in general destroying information by simplifying it won't improve your model. Chi2 just demonstrates that. But in more complex cases, creating a new feature based on existing one which makes link with the outcome more obvious may help the algorithm and improve the model. The case studied here is not enough complex to show that. Check Kaggle forum for some challenging datasets.
 # However it's almost always worse when you add some arbitrary rules.
 # Moreover, you can notice that even if we have added some not useful new features highly correlated with other features, the boosting tree algorithm have been able to choose the best one, which in this case is the Age. Linear model may not be that strong in these scenario.
+
+# nolint end

--- a/R-package/man/xgb.cv.Rd
+++ b/R-package/man/xgb.cv.Rd
@@ -148,9 +148,11 @@ The cross validation function of xgboost
 \details{
 The original sample is randomly partitioned into \code{nfold} equal size subsamples.
 
-Of the \code{nfold} subsamples, a single subsample is retained as the validation data for testing the model, and the remaining \code{nfold - 1} subsamples are used as training data.
+Of the \code{nfold} subsamples, a single subsample is retained as the validation data for testing the model,
+and the remaining \code{nfold - 1} subsamples are used as training data.
 
-The cross-validation process is then repeated \code{nrounds} times, with each of the \code{nfold} subsamples used exactly once as the validation data.
+The cross-validation process is then repeated \code{nrounds} times, with each of the
+\code{nfold} subsamples used exactly once as the validation data.
 
 All observations are used for both training and validation.
 

--- a/R-package/man/xgb.train.Rd
+++ b/R-package/man/xgb.train.Rd
@@ -60,9 +60,10 @@ xgboost(
   \item{ \code{eta} control the learning rate: scale the contribution of each tree by a factor of \code{0 < eta < 1}
          when it is added to the current approximation.
          Used to prevent overfitting by making the boosting process more conservative.
-         Lower value for \code{eta} implies larger value for \code{nrounds}: low \code{eta} value means model more robust to overfitting but slower to compute.
-         Default: 0.3}
-  \item \code{gamma} minimum loss reduction required to make a further partition on a leaf node of the tree. the larger, the more conservative the algorithm will be.
+         Lower value for \code{eta} implies larger value for \code{nrounds}: low \code{eta} value means model
+         more robust to overfitting but slower to compute. Default: 0.3}
+  \item{ \code{gamma} minimum loss reduction required to make a further partition on a leaf node of the tree.
+         the larger, the more conservative the algorithm will be.}
   \item \code{max_depth} maximum depth of a tree. Default: 6
   \item{\code{min_child_weight} minimum sum of instance weight (hessian) needed in a child.
         If the tree partition step results in a leaf node with the sum of instance weight less than min_child_weight,
@@ -117,8 +118,8 @@ xgboost(
     \item{ \code{survival:cox}: Cox regression for right censored survival time data (negative values are considered right censored).
            Note that predictions are returned on the hazard ratio scale (i.e., as HR = exp(marginal_prediction) in the proportional
            hazard function \code{h(t) = h0(t) * HR)}.}
-    \item{ \code{survival:aft}: Accelerated failure time model for censored survival time data.
-           See \href{https://xgboost.readthedocs.io/en/latest/tutorials/aft_survival_analysis.html}{Survival Analysis with Accelerated Failure Time}
+    \item{ \code{survival:aft}: Accelerated failure time model for censored survival time data. See
+           \href{https://xgboost.readthedocs.io/en/latest/tutorials/aft_survival_analysis.html}{Survival Analysis with Accelerated Failure Time}
            for details.}
     \item \code{aft_loss_distribution}: Probability Density Function used by \code{survival:aft} and \code{aft-nloglik} metric.
     \item{ \code{multi:softmax} set xgboost to do multiclass classification using the softmax objective.
@@ -144,7 +145,8 @@ xgboost(
   \item \code{base_score} the initial prediction score of all instances, global bias. Default: 0.5
   \item{ \code{eval_metric} evaluation metrics for validation data.
          Users can pass a self-defined function to it.
-         Default: metric will be assigned according to objective(rmse for regression, and error for classification, mean average precision for ranking).
+         Default: metric will be assigned according to objective
+         (rmse for regression, and error for classification, mean average precision for ranking).
          List is provided in detail section.}
 }}
 
@@ -265,7 +267,8 @@ The following is the list of built-in metrics for which XGBoost provides optimiz
      \item \code{merror} Multiclass classification error rate. It is calculated as \code{(# wrong cases) / (# all cases)}.
      \item \code{mae} Mean absolute error
      \item \code{mape} Mean absolute percentage error
-     \item \code{auc} Area under the curve. \url{https://en.wikipedia.org/wiki/Receiver_operating_characteristic#'Area_under_curve} for ranking evaluation.
+     \item{ \code{auc} Area under the curve.
+            \url{https://en.wikipedia.org/wiki/Receiver_operating_characteristic#'Area_under_curve} for ranking evaluation.}
      \item \code{aucpr} Area under the PR curve. \url{https://en.wikipedia.org/wiki/Precision_and_recall} for ranking evaluation.
      \item \code{ndcg} Normalized Discounted Cumulative Gain (for ranking task). \url{https://en.wikipedia.org/wiki/NDCG}
   }

--- a/R-package/man/xgb.train.Rd
+++ b/R-package/man/xgb.train.Rd
@@ -57,17 +57,34 @@ xgboost(
 2.1. Parameters for Tree Booster
 
 \itemize{
-  \item \code{eta} control the learning rate: scale the contribution of each tree by a factor of \code{0 < eta < 1} when it is added to the current approximation. Used to prevent overfitting by making the boosting process more conservative. Lower value for \code{eta} implies larger value for \code{nrounds}: low \code{eta} value means model more robust to overfitting but slower to compute. Default: 0.3
+  \item{ \code{eta} control the learning rate: scale the contribution of each tree by a factor of \code{0 < eta < 1}
+         when it is added to the current approximation.
+         Used to prevent overfitting by making the boosting process more conservative.
+         Lower value for \code{eta} implies larger value for \code{nrounds}: low \code{eta} value means model more robust to overfitting but slower to compute.
+         Default: 0.3}
   \item \code{gamma} minimum loss reduction required to make a further partition on a leaf node of the tree. the larger, the more conservative the algorithm will be.
   \item \code{max_depth} maximum depth of a tree. Default: 6
-  \item \code{min_child_weight} minimum sum of instance weight (hessian) needed in a child. If the tree partition step results in a leaf node with the sum of instance weight less than min_child_weight, then the building process will give up further partitioning. In linear regression mode, this simply corresponds to minimum number of instances needed to be in each node. The larger, the more conservative the algorithm will be. Default: 1
-  \item \code{subsample} subsample ratio of the training instance. Setting it to 0.5 means that xgboost randomly collected half of the data instances to grow trees and this will prevent overfitting. It makes computation shorter (because less data to analyse). It is advised to use this parameter with \code{eta} and increase \code{nrounds}. Default: 1
+  \item{\code{min_child_weight} minimum sum of instance weight (hessian) needed in a child.
+        If the tree partition step results in a leaf node with the sum of instance weight less than min_child_weight,
+        then the building process will give up further partitioning.
+        In linear regression mode, this simply corresponds to minimum number of instances needed to be in each node.
+        The larger, the more conservative the algorithm will be. Default: 1}
+  \item{ \code{subsample} subsample ratio of the training instance.
+        Setting it to 0.5 means that xgboost randomly collected half of the data instances to grow trees
+        and this will prevent overfitting. It makes computation shorter (because less data to analyse).
+        It is advised to use this parameter with \code{eta} and increase \code{nrounds}. Default: 1}
   \item \code{colsample_bytree} subsample ratio of columns when constructing each tree. Default: 1
   \item \code{lambda} L2 regularization term on weights. Default: 1
   \item \code{alpha} L1 regularization term on weights. (there is no L1 reg on bias because it is not important). Default: 0
-  \item \code{num_parallel_tree} Experimental parameter. number of trees to grow per round. Useful to test Random Forest through XGBoost (set \code{colsample_bytree < 1}, \code{subsample  < 1}  and \code{round = 1}) accordingly. Default: 1
+  \item{ \code{num_parallel_tree} Experimental parameter. number of trees to grow per round.
+         Useful to test Random Forest through XGBoost
+         (set \code{colsample_bytree < 1}, \code{subsample  < 1}  and \code{round = 1}) accordingly.
+         Default: 1}
   \item \code{monotone_constraints} A numerical vector consists of \code{1}, \code{0} and \code{-1} with its length equals to the number of features in the training data. \code{1} is increasing, \code{-1} is decreasing and \code{0} is no constraint.
-  \item \code{interaction_constraints} A list of vectors specifying feature indices of permitted interactions. Each item of the list represents one permitted interaction where specified features are allowed to interact with each other. Feature index values should start from \code{0} (\code{0} references the first column).  Leave argument unspecified for no interaction constraints.
+  \item{ \code{interaction_constraints} A list of vectors specifying feature indices of permitted interactions.
+       Each item of the list represents one permitted interaction where specified features are allowed to interact with each other.
+       Feature index values should start from \code{0} (\code{0} references the first column).
+       Leave argument unspecified for no interaction constraints.}
 }
 
 2.2. Parameters for Linear Booster

--- a/R-package/man/xgb.train.Rd
+++ b/R-package/man/xgb.train.Rd
@@ -80,7 +80,9 @@ xgboost(
          Useful to test Random Forest through XGBoost
          (set \code{colsample_bytree < 1}, \code{subsample  < 1}  and \code{round = 1}) accordingly.
          Default: 1}
-  \item \code{monotone_constraints} A numerical vector consists of \code{1}, \code{0} and \code{-1} with its length equals to the number of features in the training data. \code{1} is increasing, \code{-1} is decreasing and \code{0} is no constraint.
+  \item{ \code{monotone_constraints} A numerical vector consists of \code{1}, \code{0} and \code{-1} with its length
+         equals to the number of features in the training data.
+         \code{1} is increasing, \code{-1} is decreasing and \code{0} is no constraint.}
   \item{ \code{interaction_constraints} A list of vectors specifying feature indices of permitted interactions.
        Each item of the list represents one permitted interaction where specified features are allowed to interact with each other.
        Feature index values should start from \code{0} (\code{0} references the first column).
@@ -98,29 +100,52 @@ xgboost(
 3. Task Parameters
 
 \itemize{
-\item \code{objective} specify the learning task and the corresponding learning objective, users can pass a self-defined function to it. The default objective options are below:
+\item{ \code{objective} specify the learning task and the corresponding learning objective, users can pass a self-defined function to it.
+       The default objective options are below:
   \itemize{
     \item \code{reg:squarederror} Regression with squared loss (Default).
-    \item \code{reg:squaredlogerror}: regression with squared log loss \eqn{1/2 * (log(pred + 1) - log(label + 1))^2}. All inputs are required to be greater than -1. Also, see metric rmsle for possible issue with this objective.
+    \item{ \code{reg:squaredlogerror}: regression with squared log loss \eqn{1/2 * (log(pred + 1) - log(label + 1))^2}.
+           All inputs are required to be greater than -1.
+           Also, see metric rmsle for possible issue with this objective.}
     \item \code{reg:logistic} logistic regression.
     \item \code{reg:pseudohubererror}: regression with Pseudo Huber loss, a twice differentiable alternative to absolute loss.
     \item \code{binary:logistic} logistic regression for binary classification. Output probability.
     \item \code{binary:logitraw} logistic regression for binary classification, output score before logistic transformation.
     \item \code{binary:hinge}: hinge loss for binary classification. This makes predictions of 0 or 1, rather than producing probabilities.
-    \item \code{count:poisson}: Poisson regression for count data, output mean of Poisson distribution. \code{max_delta_step} is set to 0.7 by default in poisson regression (used to safeguard optimization).
-    \item \code{survival:cox}: Cox regression for right censored survival time data (negative values are considered right censored). Note that predictions are returned on the hazard ratio scale (i.e., as HR = exp(marginal_prediction) in the proportional hazard function \code{h(t) = h0(t) * HR)}.
-    \item \code{survival:aft}: Accelerated failure time model for censored survival time data. See \href{https://xgboost.readthedocs.io/en/latest/tutorials/aft_survival_analysis.html}{Survival Analysis with Accelerated Failure Time} for details.
+    \item{ \code{count:poisson}: Poisson regression for count data, output mean of Poisson distribution.
+           \code{max_delta_step} is set to 0.7 by default in poisson regression (used to safeguard optimization).}
+    \item{ \code{survival:cox}: Cox regression for right censored survival time data (negative values are considered right censored).
+           Note that predictions are returned on the hazard ratio scale (i.e., as HR = exp(marginal_prediction) in the proportional
+           hazard function \code{h(t) = h0(t) * HR)}.}
+    \item{ \code{survival:aft}: Accelerated failure time model for censored survival time data.
+           See \href{https://xgboost.readthedocs.io/en/latest/tutorials/aft_survival_analysis.html}{Survival Analysis with Accelerated Failure Time}
+           for details.}
     \item \code{aft_loss_distribution}: Probability Density Function used by \code{survival:aft} and \code{aft-nloglik} metric.
-    \item \code{multi:softmax} set xgboost to do multiclass classification using the softmax objective. Class is represented by a number and should be from 0 to \code{num_class - 1}.
-    \item \code{multi:softprob} same as softmax, but prediction outputs a vector of ndata * nclass elements, which can be further reshaped to ndata, nclass matrix. The result contains predicted probabilities of each data point belonging to each class.
+    \item{ \code{multi:softmax} set xgboost to do multiclass classification using the softmax objective.
+           Class is represented by a number and should be from 0 to \code{num_class - 1}.}
+    \item{ \code{multi:softprob} same as softmax, but prediction outputs a vector of ndata * nclass elements, which can be
+           further reshaped to ndata, nclass matrix. The result contains predicted probabilities of each data point belonging
+           to each class.}
     \item \code{rank:pairwise} set xgboost to do ranking task by minimizing the pairwise loss.
-    \item \code{rank:ndcg}: Use LambdaMART to perform list-wise ranking where \href{https://en.wikipedia.org/wiki/Discounted_cumulative_gain}{Normalized Discounted Cumulative Gain (NDCG)} is maximized.
-    \item \code{rank:map}: Use LambdaMART to perform list-wise ranking where \href{https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Mean_average_precision}{Mean Average Precision (MAP)} is maximized.
-    \item \code{reg:gamma}: gamma regression with log-link. Output is a mean of gamma distribution. It might be useful, e.g., for modeling insurance claims severity, or for any outcome that might be \href{https://en.wikipedia.org/wiki/Gamma_distribution#Applications}{gamma-distributed}.
-    \item \code{reg:tweedie}: Tweedie regression with log-link. It might be useful, e.g., for modeling total loss in insurance, or for any outcome that might be \href{https://en.wikipedia.org/wiki/Tweedie_distribution#Applications}{Tweedie-distributed}.
+    \item{ \code{rank:ndcg}: Use LambdaMART to perform list-wise ranking where
+           \href{https://en.wikipedia.org/wiki/Discounted_cumulative_gain}{Normalized Discounted Cumulative Gain (NDCG)} is maximized.}
+    \item{ \code{rank:map}: Use LambdaMART to perform list-wise ranking where
+           \href{https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Mean_average_precision}{Mean Average Precision (MAP)}
+           is maximized.}
+    \item{ \code{reg:gamma}: gamma regression with log-link.
+           Output is a mean of gamma distribution.
+           It might be useful, e.g., for modeling insurance claims severity, or for any outcome that might be
+           \href{https://en.wikipedia.org/wiki/Gamma_distribution#Applications}{gamma-distributed}.}
+    \item{ \code{reg:tweedie}: Tweedie regression with log-link.
+           It might be useful, e.g., for modeling total loss in insurance, or for any outcome that might be
+           \href{https://en.wikipedia.org/wiki/Tweedie_distribution#Applications}{Tweedie-distributed}.}
   }
+ }
   \item \code{base_score} the initial prediction score of all instances, global bias. Default: 0.5
-  \item \code{eval_metric} evaluation metrics for validation data. Users can pass a self-defined function to it. Default: metric will be assigned according to objective(rmse for regression, and error for classification, mean average precision for ranking). List is provided in detail section.
+  \item{ \code{eval_metric} evaluation metrics for validation data.
+         Users can pass a self-defined function to it.
+         Default: metric will be assigned according to objective(rmse for regression, and error for classification, mean average precision for ranking).
+         List is provided in detail section.}
 }}
 
 \item{data}{training dataset. \code{xgb.train} accepts only an \code{xgb.DMatrix} as the input.

--- a/R-package/vignettes/discoverYourData.Rmd
+++ b/R-package/vignettes/discoverYourData.Rmd
@@ -327,10 +327,25 @@ train <- agaricus.train
 test <- agaricus.test
 
 #Random Forest - 1000 trees
-bst <- xgboost(data = train$data, label = train$label, max_depth = 4, num_parallel_tree = 1000, subsample = 0.5, colsample_bytree =0.5, nrounds = 1, objective = "binary:logistic")
+bst <- xgboost(
+    data = train$data
+    , label = train$label
+    , max_depth = 4
+    , num_parallel_tree = 1000
+    , subsample = 0.5
+    , colsample_bytree = 0.5
+    , nrounds = 1
+    , objective = "binary:logistic"
+)
 
 #Boosting - 3 rounds
-bst <- xgboost(data = train$data, label = train$label, max_depth = 4, nrounds = 3, objective = "binary:logistic")
+bst <- xgboost(
+    data = train$data
+    , label = train$label
+    , max_depth = 4
+    , nrounds = 3
+    , objective = "binary:logistic"
+)
 ```
 
 > Note that the parameter `round` is set to `1`.

--- a/R-package/vignettes/xgboostPresentation.Rmd
+++ b/R-package/vignettes/xgboostPresentation.Rmd
@@ -354,7 +354,17 @@ If with your own dataset you have not such results, you should think about how y
 For a better understanding of the learning progression, you may want to have some specific metric or even use multiple evaluation metrics.
 
 ```{r watchlist2, message=F, warning=F}
-bst <- xgb.train(data=dtrain, max_depth=2, eta=1, nthread = 2, nrounds=2, watchlist=watchlist, eval_metric = "error", eval_metric = "logloss", objective = "binary:logistic")
+bst <- xgb.train(
+    data = dtrain
+    , max_depth = 2
+    , eta = 1
+    , nthread = 2
+    , nrounds = 2
+    , watchlist = watchlist
+    , eval_metric = "error"
+    , eval_metric = "logloss"
+    , objective = "binary:logistic"
+)
 ```
 
 > `eval_metric` allows us to monitor two new metrics for each round, `logloss` and `error`.

--- a/R-package/vignettes/xgboostPresentation.Rmd
+++ b/R-package/vignettes/xgboostPresentation.Rmd
@@ -152,7 +152,15 @@ We will train decision tree model using the following parameters:
 * `nrounds = 2`: there will be two passes on the data, the second one will enhance the model by further reducing the difference between ground truth and prediction.
 
 ```{r trainingSparse, message=F, warning=F}
-bstSparse <- xgboost(data = train$data, label = train$label, max_depth = 2, eta = 1, nthread = 2, nrounds = 2, objective = "binary:logistic")
+bstSparse <- xgboost(
+    data = train$data
+    , label = train$label
+    , max_depth = 2
+    , eta = 1
+    , nthread = 2
+    , nrounds = 2
+    , objective = "binary:logistic"
+)
 ```
 
 > More complex the relationship between your features and your `label` is, more passes you need.
@@ -164,7 +172,15 @@ bstSparse <- xgboost(data = train$data, label = train$label, max_depth = 2, eta 
 Alternatively, you can put your dataset in a *dense* matrix, i.e. a basic **R** matrix.
 
 ```{r trainingDense, message=F, warning=F}
-bstDense <- xgboost(data = as.matrix(train$data), label = train$label, max_depth = 2, eta = 1, nthread = 2, nrounds = 2, objective = "binary:logistic")
+bstDense <- xgboost(
+    data = as.matrix(train$data)
+    , label = train$label
+    , max_depth = 2
+    , eta = 1
+    , nthread = 2
+    , nrounds = 2
+    , objective = "binary:logistic"
+)
 ```
 
 ##### xgb.DMatrix
@@ -173,7 +189,14 @@ bstDense <- xgboost(data = as.matrix(train$data), label = train$label, max_depth
 
 ```{r trainingDmatrix, message=F, warning=F}
 dtrain <- xgb.DMatrix(data = train$data, label = train$label)
-bstDMatrix <- xgboost(data = dtrain, max_depth = 2, eta = 1, nthread = 2, nrounds = 2, objective = "binary:logistic")
+bstDMatrix <- xgboost(
+    data = dtrain
+    , max_depth = 2
+    , eta = 1
+    , nthread = 2
+    , nrounds = 2
+    , objective = "binary:logistic"
+)
 ```
 
 ##### Verbose option
@@ -184,17 +207,41 @@ One of the simplest way to see the training progress is to set the `verbose` opt
 
 ```{r trainingVerbose0, message=T, warning=F}
 # verbose = 0, no message
-bst <- xgboost(data = dtrain, max_depth = 2, eta = 1, nthread = 2, nrounds = 2, objective = "binary:logistic", verbose = 0)
+bst <- xgboost(
+    data = dtrain
+    , max_depth = 2
+    , eta = 1
+    , nthread = 2
+    , nrounds = 2
+    , objective = "binary:logistic"
+    , verbose = 0
+)
 ```
 
 ```{r trainingVerbose1, message=T, warning=F}
 # verbose = 1, print evaluation metric
-bst <- xgboost(data = dtrain, max_depth = 2, eta = 1, nthread = 2, nrounds = 2, objective = "binary:logistic", verbose = 1)
+bst <- xgboost(
+    data = dtrain
+    , max_depth = 2
+    , eta = 1
+    , nthread = 2
+    , nrounds = 2
+    , objective = "binary:logistic"
+    , verbose = 1
+)
 ```
 
 ```{r trainingVerbose2, message=T, warning=F}
 # verbose = 2, also print information about tree
-bst <- xgboost(data = dtrain, max_depth = 2, eta = 1, nthread = 2, nrounds = 2, objective = "binary:logistic", verbose = 2)
+bst <- xgboost(
+    data = dtrain
+    , max_depth = 2
+    , eta = 1
+    , nthread = 2
+    , nrounds = 2
+    , objective = "binary:logistic"
+    , verbose = 2
+)
 ```
 
 ## Basic prediction using XGBoost
@@ -287,7 +334,15 @@ For the purpose of this example, we use `watchlist` parameter. It is a list of `
 ```{r watchlist, message=F, warning=F}
 watchlist <- list(train=dtrain, test=dtest)
 
-bst <- xgb.train(data=dtrain, max_depth=2, eta=1, nthread = 2, nrounds=2, watchlist=watchlist, objective = "binary:logistic")
+bst <- xgb.train(
+    data = dtrain
+    , max_depth = 2
+    , eta = 1
+    , nthread = 2
+    , nrounds = 2
+    , watchlist = watchlist
+    , objective = "binary:logistic"
+)
 ```
 
 **XGBoost** has computed at each round the same average error metric than seen above (we set `nrounds` to 2, that is why we have two lines). Obviously, the `train-error` number is related to the training dataset (the one the algorithm learns from) and the `test-error` number to the test dataset.
@@ -310,7 +365,17 @@ bst <- xgb.train(data=dtrain, max_depth=2, eta=1, nthread = 2, nrounds=2, watchl
 Until now, all the learnings we have performed were based on boosting trees. **XGBoost** implements a second algorithm, based on linear boosting. The only difference with previous command is `booster = "gblinear"` parameter (and removing `eta` parameter).
 
 ```{r linearBoosting, message=F, warning=F}
-bst <- xgb.train(data=dtrain, booster = "gblinear", max_depth=2, nthread = 2, nrounds=2, watchlist=watchlist, eval_metric = "error", eval_metric = "logloss", objective = "binary:logistic")
+bst <- xgb.train(
+    data = dtrain
+    , booster = "gblinear"
+    , max_depth = 2
+    , nthread = 2
+    , nrounds = 2
+    , watchlist = watchlist
+    , eval_metric = "error"
+    , eval_metric = "logloss"
+    , objective = "binary:logistic"
+)
 ```
 
 In this specific case, *linear boosting* gets slightly better performance metrics than decision trees based algorithm.
@@ -328,7 +393,15 @@ Like saving models, `xgb.DMatrix` object (which groups both dataset and outcome)
 xgb.DMatrix.save(dtrain, "dtrain.buffer")
 # to load it in, simply call xgb.DMatrix
 dtrain2 <- xgb.DMatrix("dtrain.buffer")
-bst <- xgb.train(data=dtrain2, max_depth=2, eta=1, nthread = 2, nrounds=2, watchlist=watchlist, objective = "binary:logistic")
+bst <- xgb.train(
+    data = dtrain2
+    , max_depth = 2
+    , eta = 1
+    , nthread = 2
+    , nrounds = 2
+    , watchlist = watchlist
+    , objective = "binary:logistic"
+)
 ```
 
 ```{r DMatrixDel, include=FALSE}

--- a/tests/ci_build/lint_r.R
+++ b/tests/ci_build/lint_r.R
@@ -22,7 +22,7 @@ my_linters <- list(
   # commas_linter = lintr::commas_linter(),
   # equals_na = lintr::equals_na_linter(),
   # infix_spaces_linter = lintr::infix_spaces_linter(),
-  line_length_linter = lintr::line_length_linter(length = 175L)
+  line_length_linter = lintr::line_length_linter(length = 150L)
   # no_tab_linter = lintr::no_tab_linter(),
   # object_usage_linter = lintr::object_usage_linter(),
   # object_length_linter = lintr::object_length_linter(),

--- a/tests/ci_build/lint_r.R
+++ b/tests/ci_build/lint_r.R
@@ -16,24 +16,24 @@ FILES_TO_LINT <- list.files(
 )
 
 my_linters <- list(
-  # absolute_path_linter = lintr::absolute_path_linter(),
-  # assignment_linter = lintr::assignment_linter(),
-  # brace_linter = lintr::brace_linter(),
-  # commas_linter = lintr::commas_linter(),
-  # equals_na = lintr::equals_na_linter(),
-  # infix_spaces_linter = lintr::infix_spaces_linter(),
-  line_length_linter = lintr::line_length_linter(length = 150L)
-  # no_tab_linter = lintr::no_tab_linter(),
-  # object_usage_linter = lintr::object_usage_linter(),
-  # object_length_linter = lintr::object_length_linter(),
-  # semicolon = lintr::semicolon_linter(),
-  # seq = lintr::seq_linter(),
-  # spaces_inside_linter = lintr::spaces_inside_linter(),
-  # spaces_left_parentheses_linter = lintr::spaces_left_parentheses_linter(),
-  # trailing_blank_lines_linter = lintr::trailing_blank_lines_linter(),
-  # trailing_whitespace_linter = lintr::trailing_whitespace_linter(),
-  # true_false = lintr::T_and_F_symbol_linter(),
-  # unneeded_concatenation = lintr::unneeded_concatenation_linter()
+  absolute_path_linter = lintr::absolute_path_linter(),
+  assignment_linter = lintr::assignment_linter(),
+  brace_linter = lintr::brace_linter(),
+  commas_linter = lintr::commas_linter(),
+  equals_na = lintr::equals_na_linter(),
+  infix_spaces_linter = lintr::infix_spaces_linter(),
+  line_length_linter = lintr::line_length_linter(length = 150L),
+  no_tab_linter = lintr::no_tab_linter(),
+  object_usage_linter = lintr::object_usage_linter(),
+  object_length_linter = lintr::object_length_linter(),
+  semicolon = lintr::semicolon_linter(),
+  seq = lintr::seq_linter(),
+  spaces_inside_linter = lintr::spaces_inside_linter(),
+  spaces_left_parentheses_linter = lintr::spaces_left_parentheses_linter(),
+  trailing_blank_lines_linter = lintr::trailing_blank_lines_linter(),
+  trailing_whitespace_linter = lintr::trailing_whitespace_linter(),
+  true_false = lintr::T_and_F_symbol_linter(),
+  unneeded_concatenation = lintr::unneeded_concatenation_linter()
 )
 
 noquote(paste0(length(FILES_TO_LINT), " R files need linting"))

--- a/tests/ci_build/lint_r.R
+++ b/tests/ci_build/lint_r.R
@@ -16,24 +16,24 @@ FILES_TO_LINT <- list.files(
 )
 
 my_linters <- list(
-  absolute_path_linter = lintr::absolute_path_linter(),
-  assignment_linter = lintr::assignment_linter(),
-  brace_linter = lintr::brace_linter(),
-  commas_linter = lintr::commas_linter(),
-  equals_na = lintr::equals_na_linter(),
-  infix_spaces_linter = lintr::infix_spaces_linter(),
-  line_length_linter = lintr::line_length_linter(),
-  no_tab_linter = lintr::no_tab_linter(),
-  object_usage_linter = lintr::object_usage_linter(),
-  object_length_linter = lintr::object_length_linter(),
-  semicolon = lintr::semicolon_linter(),
-  seq = lintr::seq_linter(),
-  spaces_inside_linter = lintr::spaces_inside_linter(),
-  spaces_left_parentheses_linter = lintr::spaces_left_parentheses_linter(),
-  trailing_blank_lines_linter = lintr::trailing_blank_lines_linter(),
-  trailing_whitespace_linter = lintr::trailing_whitespace_linter(),
-  true_false = lintr::T_and_F_symbol_linter(),
-  unneeded_concatenation = lintr::unneeded_concatenation_linter()
+  # absolute_path_linter = lintr::absolute_path_linter(),
+  # assignment_linter = lintr::assignment_linter(),
+  # brace_linter = lintr::brace_linter(),
+  # commas_linter = lintr::commas_linter(),
+  # equals_na = lintr::equals_na_linter(),
+  # infix_spaces_linter = lintr::infix_spaces_linter(),
+  line_length_linter = lintr::line_length_linter(length = 175L)
+  # no_tab_linter = lintr::no_tab_linter(),
+  # object_usage_linter = lintr::object_usage_linter(),
+  # object_length_linter = lintr::object_length_linter(),
+  # semicolon = lintr::semicolon_linter(),
+  # seq = lintr::seq_linter(),
+  # spaces_inside_linter = lintr::spaces_inside_linter(),
+  # spaces_left_parentheses_linter = lintr::spaces_left_parentheses_linter(),
+  # trailing_blank_lines_linter = lintr::trailing_blank_lines_linter(),
+  # trailing_whitespace_linter = lintr::trailing_whitespace_linter(),
+  # true_false = lintr::T_and_F_symbol_linter(),
+  # unneeded_concatenation = lintr::unneeded_concatenation_linter()
 )
 
 noquote(paste0(length(FILES_TO_LINT), " R files need linting"))


### PR DESCRIPTION
Contributes to #8012 .

This fixes warnings about long lines in the project's R code. It fixes 1013 of the 1285 warnings `{lintr}` is currently raising ([link to recent CI build I got that value from](https://github.com/dmlc/xgboost/actions/runs/3635197925/jobs/6134073268)).

I chose an arbitrary value (150 characters) that could be achieved without needing to touch too many lines. I'm proposing that this be accepted to at least prevent any longer lines from making it into the project's R code.

Reducing this ceiling to, say, 125 or 100 characters would involve touching a LOT more of the project's R code, and I think that should be done by maintainers if you want to enforce a stricter limit.

### How I tested this

Ran the following to re-generate the docs and double-check that adding `{}` and changing indentation in roxygen comments wouldn't actually change their formatting.

```shell
cd R-package
R CMD INSTALL --with-keep.source .
Rscript -e "roxygen2::royxgenize(load = 'installed')"
Rscript -e "?xgboost::xgb.train"
```
