### PR TITLE
[backport] Properly await async method client.wait_for_workers (#8558)

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -853,7 +853,7 @@ async def _get_rabit_args(
         sched_addr = None
 
     # make sure all workers are online so that we can obtain reliable scheduler_info
-    client.wait_for_workers(n_workers)
+    await client.wait_for_workers(n_workers)  # type: ignore
     env = await client.run_on_scheduler(
         _start_tracker, n_workers, sched_addr, user_addr
     )


### PR DESCRIPTION
* Properly await async method client.wait_for_workers

* ignore mypy error.

Co-authored-by: jiamingy <jm.yuan@outlook.com>