### PR TITLE
Fix deprecated CUB calls in CUDA 12.0

### DIFF
--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -238,13 +238,25 @@ void CopyDataToEllpack(const AdapterBatchT &batch,
   using DispatchScan =
       cub::DispatchScan<decltype(key_value_index_iter), decltype(out),
                         TupleScanOp<Tuple>, cub::NullType, int64_t>;
+#if THRUST_MAJOR_VERSION >= 2
+  DispatchScan::Dispatch(nullptr, temp_storage_bytes, key_value_index_iter, out,
+                         TupleScanOp<Tuple>(), cub::NullType(), batch.Size(),
+                         nullptr);
+#else
   DispatchScan::Dispatch(nullptr, temp_storage_bytes, key_value_index_iter, out,
                          TupleScanOp<Tuple>(), cub::NullType(), batch.Size(),
                          nullptr, false);
+#endif
   dh::TemporaryArray<char> temp_storage(temp_storage_bytes);
+#if THRUST_MAJOR_VERSION >= 2
+  DispatchScan::Dispatch(temp_storage.data().get(), temp_storage_bytes,
+                         key_value_index_iter, out, TupleScanOp<Tuple>(),
+                         cub::NullType(), batch.Size(), nullptr);
+#else
   DispatchScan::Dispatch(temp_storage.data().get(), temp_storage_bytes,
                          key_value_index_iter, out, TupleScanOp<Tuple>(),
                          cub::NullType(), batch.Size(), nullptr, false);
+#endif
 }
 
 void WriteNullValues(EllpackPageImpl* dst, int device_idx,


### PR DESCRIPTION
The CUB version included in CUDA 12.0 deprecated the `debug_synchronous` parameter, causing compiler warnings like this:
```console
/home/rongou/src/xgboost/tests/cpp/common/../../../src/common/device_helpers.cuh: In instantiation of ‘void dh::InclusiveScan(InputIteratorT, OutputIteratorT, ScanOpT, OffsetT) [with InputIteratorT = long unsigned int*; OutputIteratorT = long unsigned int*; ScanOpT = cub::Sum; OffsetT = long unsigned int]’:
/home/rongou/src/xgboost/tests/cpp/common/../../../src/common/device_helpers.cuh:1205:14:   required from ‘void dh::InclusiveSum(InputIteratorT, OutputIteratorT, OffsetT) [with InputIteratorT = long unsigned int*; OutputIteratorT = long unsigned int*; OffsetT = long unsigned int]’
/home/rongou/src/xgboost/tests/cpp/common/../../../src/common/ranking_utils.cuh:56:17:   required from ‘size_t xgboost::common::SegmentedTrapezoidThreads(Span<T, 18446744073709551615>, Span<long unsigned int, 18446744073709551615>, size_t) [with U = long unsigned int; size_t = long unsigned int]’
/home/rongou/src/xgboost/tests/cpp/common/test_ranking_utils.cu:18:41:   required from here
/home/rongou/src/xgboost/tests/cpp/common/../../../src/common/device_helpers.cuh:1175:122: warning: ‘static cudaError_t cub::DispatchScan<InputIteratorT, OutputIteratorT, ScanOpT, InitValueT, OffsetT, AccumT, SelectedPolicy>::Dispatch(void*, size_t&, InputIteratorT, OutputIteratorT, ScanOpT, InitValueT, OffsetT, cudaStream_t, bool) [with InputIteratorT = long unsigned int*; OutputIteratorT = long unsigned int*; ScanOpT = cub::Sum; InitValueT = cub::NullType; OffsetT = long unsigned int; AccumT = long unsigned int; SelectedPolicy = cub::DeviceScanPolicy<long unsigned int>; cudaError_t = cudaError; size_t = long unsigned int; cudaStream_t = CUstream_st*]’ is deprecated: CUB no longer accepts `debug_synchronous` parameter. Define CUB_DEBUG_SYNC instead, or silence this message with CUB_IGNORE_DEPRECATED_API. [-Wdeprecated-declarations]
 1175 |   safe_cuda((
      |                                                                                                                          ^                                                                                 
/usr/local/cuda/bin/../targets/x86_64-linux/include/cub/device/dispatch/dispatch_scan.cuh:672:1: note: declared here
  672 |   Dispatch(void *d_temp_storage,
      | ^ ~~~~~~
```