### PR TITLE
[CI] Use conda-forge channel in Conda

### DIFF
--- a/tests/ci_build/conda_env/cpp_test.yml
+++ b/tests/ci_build/conda_env/cpp_test.yml
@@ -1,7 +1,6 @@
 # conda environment for CPP test on Linux distributions
 name: cpp_test
 channels:
-- defaults
 - conda-forge
 dependencies:
 - cmake

--- a/tests/ci_build/conda_env/cpu_test.yml
+++ b/tests/ci_build/conda_env/cpu_test.yml
@@ -1,6 +1,5 @@
 name: cpu_test
 channels:
-- defaults
 - conda-forge
 dependencies:
 - python=3.8

--- a/tests/ci_build/conda_env/sdist_test.yml
+++ b/tests/ci_build/conda_env/sdist_test.yml
@@ -1,7 +1,6 @@
 # conda environment for source distribution test.
 name: sdist_test
 channels:
-- defaults
 - conda-forge
 dependencies:
 - python=3.8


### PR DESCRIPTION
In https://buildkite.com/xgboost/xgboost-ci/builds/983#018500ac-b266-4bdb-bf84-440fc7615ee2, the scikit-learn version of 1.1.3 was pulled from the `defaults` channel. We should use conda-forge channel always for consistency.