### PR TITLE
Support bitwise allreduce operations in the communicator

### DIFF
--- a/plugin/federated/federated.proto
+++ b/plugin/federated/federated.proto
@@ -25,6 +25,9 @@ enum ReduceOperation {
   MAX = 0;
   MIN = 1;
   SUM = 2;
+  BITWISE_AND = 3;
+  BITWISE_OR = 4;
+  BITWISE_XOR = 5;
 }
 
 message AllreduceRequest {

--- a/python-package/xgboost/collective.py
+++ b/python-package/xgboost/collective.py
@@ -191,6 +191,9 @@ class Op(IntEnum):
     MAX = 0
     MIN = 1
     SUM = 2
+    BITWISE_AND = 3
+    BITWISE_OR = 4
+    BITWISE_XOR = 5
 
 
 def allreduce(  # pylint:disable=invalid-name

--- a/rabit/include/rabit/internal/engine.h
+++ b/rabit/include/rabit/internal/engine.h
@@ -133,7 +133,9 @@ enum OpType {
   kMax = 0,
   kMin = 1,
   kSum = 2,
-  kBitwiseOR = 3
+  kBitwiseAND = 3,
+  kBitwiseOR = 4,
+  kBitwiseXOR = 5,
 };
 /*!\brief enum of supported data types */
 enum DataType {

--- a/rabit/include/rabit/internal/rabit-inl.h
+++ b/rabit/include/rabit/internal/rabit-inl.h
@@ -85,11 +85,25 @@ struct Sum {
     dst += src;
   }
 };
+struct BitAND {
+  static const engine::mpi::OpType kType = engine::mpi::kBitwiseAND;
+  template<typename DType>
+  inline static void Reduce(DType &dst, const DType &src) { // NOLINT(*)
+    dst &= src;
+  }
+};
 struct BitOR {
   static const engine::mpi::OpType kType = engine::mpi::kBitwiseOR;
   template<typename DType>
   inline static void Reduce(DType &dst, const DType &src) { // NOLINT(*)
     dst |= src;
+  }
+};
+struct BitXOR {
+  static const engine::mpi::OpType kType = engine::mpi::kBitwiseXOR;
+  template<typename DType>
+  inline static void Reduce(DType &dst, const DType &src) { // NOLINT(*)
+    dst ^= src;
   }
 };
 template <typename OP, typename DType>

--- a/rabit/include/rabit/rabit.h
+++ b/rabit/include/rabit/rabit.h
@@ -51,10 +51,20 @@ struct Min;
  */
 struct Sum;
 /*!
+ * \class rabit::op::BitAND
+ * \brief bitwise AND reduction operator
+ */
+struct BitAND;
+/*!
  * \class rabit::op::BitOR
  * \brief bitwise OR reduction operator
  */
 struct BitOR;
+/*!
+ * \class rabit::op::BitXOR
+ * \brief bitwise XOR reduction operator
+ */
+struct BitXOR;
 }  // namespace op
 /*!
  * \brief initializes rabit, call this once at the beginning of your program

--- a/rabit/src/rabit_c_api.cc
+++ b/rabit/src/rabit_c_api.cc
@@ -24,13 +24,35 @@ struct FHelper {
 };
 
 template<typename DType>
+struct FHelper<op::BitAND, DType> {
+  static void
+  Allreduce(DType *,
+            size_t ,
+            void (*)(void *arg),
+            void *) {
+    utils::Error("DataType does not support bitwise AND operation");
+  }
+};
+
+template<typename DType>
 struct FHelper<op::BitOR, DType> {
   static void
   Allreduce(DType *,
             size_t ,
             void (*)(void *arg),
             void *) {
-    utils::Error("DataType does not support bitwise or operation");
+    utils::Error("DataType does not support bitwise OR operation");
+  }
+};
+
+template<typename DType>
+struct FHelper<op::BitXOR, DType> {
+  static void
+  Allreduce(DType *,
+            size_t ,
+            void (*)(void *arg),
+            void *) {
+    utils::Error("DataType does not support bitwise XOR operation");
   }
 };
 
@@ -111,8 +133,20 @@ void Allreduce(void *sendrecvbuf,
            count, enum_dtype,
            prepare_fun, prepare_arg);
       return;
+    case kBitwiseAND:
+      Allreduce<op::BitAND>
+          (sendrecvbuf,
+           count, enum_dtype,
+           prepare_fun, prepare_arg);
+      return;
     case kBitwiseOR:
       Allreduce<op::BitOR>
+          (sendrecvbuf,
+           count, enum_dtype,
+           prepare_fun, prepare_arg);
+      return;
+    case kBitwiseXOR:
+      Allreduce<op::BitXOR>
           (sendrecvbuf,
            count, enum_dtype,
            prepare_fun, prepare_arg);

--- a/src/collective/communicator.h
+++ b/src/collective/communicator.h
@@ -58,7 +58,14 @@ inline std::size_t GetTypeSize(DataType data_type) {
 }
 
 /** @brief Defines the reduction operation. */
-enum class Operation { kMax = 0, kMin = 1, kSum = 2 };
+enum class Operation {
+  kMax = 0,
+  kMin = 1,
+  kSum = 2,
+  kBitwiseAND = 3,
+  kBitwiseOR = 4,
+  kBitwiseXOR = 5
+};
 
 class DeviceCommunicator;
 

--- a/tests/cpp/collective/test_in_memory_communicator.cc
+++ b/tests/cpp/collective/test_in_memory_communicator.cc
@@ -58,7 +58,7 @@ class InMemoryCommunicatorTest : public ::testing::Test {
     InMemoryCommunicator comm{kWorldSize, rank};
     std::bitset<2> original(rank);
     auto buffer = original.to_ulong();
-    comm.AllReduce(&buffer, sizeof(buffer), DataType::kUInt32, Operation::kBitwiseAND);
+    comm.AllReduce(&buffer, 1, DataType::kUInt32, Operation::kBitwiseAND);
     EXPECT_EQ(buffer, 0UL);
   }
 
@@ -66,7 +66,7 @@ class InMemoryCommunicatorTest : public ::testing::Test {
     InMemoryCommunicator comm{kWorldSize, rank};
     std::bitset<2> original(rank);
     auto buffer = original.to_ulong();
-    comm.AllReduce(&buffer, sizeof(buffer), DataType::kUInt32, Operation::kBitwiseOR);
+    comm.AllReduce(&buffer, 1, DataType::kUInt32, Operation::kBitwiseOR);
     std::bitset<2> actual(buffer);
     std::bitset<2> expected{0b11};
     EXPECT_EQ(actual, expected);
@@ -76,7 +76,7 @@ class InMemoryCommunicatorTest : public ::testing::Test {
     InMemoryCommunicator comm{kWorldSize, rank};
     std::bitset<3> original(rank * 2);
     auto buffer = original.to_ulong();
-    comm.AllReduce(&buffer, sizeof(buffer), DataType::kUInt32, Operation::kBitwiseXOR);
+    comm.AllReduce(&buffer, 1, DataType::kUInt32, Operation::kBitwiseXOR);
     std::bitset<3> actual(buffer);
     std::bitset<3> expected{0b110};
     EXPECT_EQ(actual, expected);

--- a/tests/cpp/collective/test_in_memory_communicator.cc
+++ b/tests/cpp/collective/test_in_memory_communicator.cc
@@ -4,6 +4,7 @@
 #include <dmlc/parameter.h>
 #include <gtest/gtest.h>
 
+#include <bitset>
 #include <thread>
 
 #include "../../../src/collective/in_memory_communicator.h"
@@ -13,7 +14,37 @@ namespace collective {
 
 class InMemoryCommunicatorTest : public ::testing::Test {
  public:
-  static void VerifyAllreduce(int rank) {
+  static void Verify(void (*function)(int)) {
+    std::vector<std::thread> threads;
+    for (auto rank = 0; rank < kWorldSize; rank++) {
+      threads.emplace_back(function, rank);
+    }
+    for (auto &thread : threads) {
+      thread.join();
+    }
+  }
+
+  static void AllreduceMax(int rank) {
+    InMemoryCommunicator comm{kWorldSize, rank};
+    int buffer[] = {1 + rank, 2 + rank, 3 + rank, 4 + rank, 5 + rank};
+    comm.AllReduce(buffer, sizeof(buffer) / sizeof(buffer[0]), DataType::kInt32, Operation::kMax);
+    int expected[] = {3, 4, 5, 6, 7};
+    for (auto i = 0; i < 5; i++) {
+      EXPECT_EQ(buffer[i], expected[i]);
+    }
+  }
+
+  static void AllreduceMin(int rank) {
+    InMemoryCommunicator comm{kWorldSize, rank};
+    int buffer[] = {1 + rank, 2 + rank, 3 + rank, 4 + rank, 5 + rank};
+    comm.AllReduce(buffer, sizeof(buffer) / sizeof(buffer[0]), DataType::kInt32, Operation::kMin);
+    int expected[] = {1, 2, 3, 4, 5};
+    for (auto i = 0; i < 5; i++) {
+      EXPECT_EQ(buffer[i], expected[i]);
+    }
+  }
+
+  static void AllreduceSum(int rank) {
     InMemoryCommunicator comm{kWorldSize, rank};
     int buffer[] = {1, 2, 3, 4, 5};
     comm.AllReduce(buffer, sizeof(buffer) / sizeof(buffer[0]), DataType::kInt32, Operation::kSum);
@@ -23,7 +54,35 @@ class InMemoryCommunicatorTest : public ::testing::Test {
     }
   }
 
-  static void VerifyBroadcast(int rank) {
+  static void AllreduceBitwiseAND(int rank) {
+    InMemoryCommunicator comm{kWorldSize, rank};
+    std::bitset<2> original(rank);
+    auto buffer = original.to_ulong();
+    comm.AllReduce(&buffer, sizeof(buffer), DataType::kUInt32, Operation::kBitwiseAND);
+    EXPECT_EQ(buffer, 0UL);
+  }
+
+  static void AllreduceBitwiseOR(int rank) {
+    InMemoryCommunicator comm{kWorldSize, rank};
+    std::bitset<2> original(rank);
+    auto buffer = original.to_ulong();
+    comm.AllReduce(&buffer, sizeof(buffer), DataType::kUInt32, Operation::kBitwiseOR);
+    std::bitset<2> actual(buffer);
+    std::bitset<2> expected{0b11};
+    EXPECT_EQ(actual, expected);
+  }
+
+  static void AllreduceBitwiseXOR(int rank) {
+    InMemoryCommunicator comm{kWorldSize, rank};
+    std::bitset<3> original(rank * 2);
+    auto buffer = original.to_ulong();
+    comm.AllReduce(&buffer, sizeof(buffer), DataType::kUInt32, Operation::kBitwiseXOR);
+    std::bitset<3> actual(buffer);
+    std::bitset<3> expected{0b110};
+    EXPECT_EQ(actual, expected);
+  }
+
+  static void Broadcast(int rank) {
     InMemoryCommunicator comm{kWorldSize, rank};
     if (rank == 0) {
       std::string buffer{"hello"};
@@ -88,25 +147,19 @@ TEST(InMemoryCommunicatorSimpleTest, IsDistributed) {
   EXPECT_TRUE(comm.IsDistributed());
 }
 
-TEST_F(InMemoryCommunicatorTest, Allreduce) {
-  std::vector<std::thread> threads;
-  for (auto rank = 0; rank < kWorldSize; rank++) {
-    threads.emplace_back(std::thread(&InMemoryCommunicatorTest::VerifyAllreduce, rank));
-  }
-  for (auto &thread : threads) {
-    thread.join();
-  }
-}
+TEST_F(InMemoryCommunicatorTest, AllreduceMax) { Verify(&AllreduceMax); }
 
-TEST_F(InMemoryCommunicatorTest, Broadcast) {
-  std::vector<std::thread> threads;
-  for (auto rank = 0; rank < kWorldSize; rank++) {
-    threads.emplace_back(std::thread(&InMemoryCommunicatorTest::VerifyBroadcast, rank));
-  }
-  for (auto &thread : threads) {
-    thread.join();
-  }
-}
+TEST_F(InMemoryCommunicatorTest, AllreduceMin) { Verify(&AllreduceMin); }
+
+TEST_F(InMemoryCommunicatorTest, AllreduceSum) { Verify(&AllreduceSum); }
+
+TEST_F(InMemoryCommunicatorTest, AllreduceBitwiseAND) { Verify(&AllreduceBitwiseAND); }
+
+TEST_F(InMemoryCommunicatorTest, AllreduceBitwiseOR) { Verify(&AllreduceBitwiseOR); }
+
+TEST_F(InMemoryCommunicatorTest, AllreduceBitwiseXOR) { Verify(&AllreduceBitwiseXOR); }
+
+TEST_F(InMemoryCommunicatorTest, Broadcast) { Verify(&Broadcast); }
 
 }  // namespace collective
 }  // namespace xgboost


### PR DESCRIPTION
We likely need bitwise allreduce operations for feature parallel training.

Part of #8424 