### PR TITLE
[R] [CI] add more linting checks

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -328,7 +328,6 @@ setinfo.xgb.DMatrix <- function(object, name, info, ...) {
     return(TRUE)
   }
   stop("setinfo: unknown info name ", name)
-  return(FALSE)
 }
 
 
@@ -418,7 +417,7 @@ print.xgb.DMatrix <- function(x, verbose = FALSE, ...) {
   cat(infos)
   cnames <- colnames(x)
   cat('  colnames:')
-  if (verbose & !is.null(cnames)) {
+  if (verbose && !is.null(cnames)) {
     cat("\n'")
     cat(cnames, sep = "','")
     cat("'")

--- a/R-package/R/xgb.plot.shap.R
+++ b/R-package/R/xgb.plot.shap.R
@@ -143,7 +143,7 @@ xgb.plot.shap <- function(data, shap_contrib = NULL, features = NULL, top_n = 1,
       y <- shap_contrib[, f][ord]
       x_lim <- range(x, na.rm = TRUE)
       y_lim <- range(y, na.rm = TRUE)
-      do_na <- plot_NA && any(is.na(x))
+      do_na <- plot_NA && anyNA(x)
       if (do_na) {
         x_range <- diff(x_lim)
         loc_na <- min(x, na.rm = TRUE) + x_range * pos_NA
@@ -272,7 +272,7 @@ xgb.shap.data <- function(data, shap_contrib = NULL, features = NULL, top_n = 1,
       imp <- xgb.importance(model = model, trees = trees, feature_names = colnames(data))
     }
     top_n <- top_n[1]
-    if (top_n < 1 | top_n > 100) stop("top_n: must be an integer within [1, 100]")
+    if (top_n < 1 || top_n > 100) stop("top_n: must be an integer within [1, 100]")
     features <- imp$Feature[seq_len(min(top_n, NROW(imp)))]
   }
   if (is.character(features)) {

--- a/tests/ci_build/lint_r.R
+++ b/tests/ci_build/lint_r.R
@@ -17,6 +17,8 @@ FILES_TO_LINT <- list.files(
 
 my_linters <- list(
   absolute_path_linter = lintr::absolute_path_linter(),
+  any_duplicated = lintr::any_duplicated_linter(),
+  any_is_na = lintr::any_is_na_linter(),
   assignment_linter = lintr::assignment_linter(),
   brace_linter = lintr::brace_linter(),
   commas_linter = lintr::commas_linter(),
@@ -30,10 +32,13 @@ my_linters <- list(
   seq = lintr::seq_linter(),
   spaces_inside_linter = lintr::spaces_inside_linter(),
   spaces_left_parentheses_linter = lintr::spaces_left_parentheses_linter(),
+  sprintf = lintr::sprintf_linter(),
   trailing_blank_lines_linter = lintr::trailing_blank_lines_linter(),
   trailing_whitespace_linter = lintr::trailing_whitespace_linter(),
   true_false = lintr::T_and_F_symbol_linter(),
-  unneeded_concatenation = lintr::unneeded_concatenation_linter()
+  unneeded_concatenation = lintr::unneeded_concatenation_linter(),
+  unreachable_code = lintr::unreachable_code_linter(),
+  vector_logic = lintr::vector_logic_linter()
 )
 
 noquote(paste0(length(FILES_TO_LINT), " R files need linting"))


### PR DESCRIPTION
Proposes adding the following additional linting checks on R code in the project:

* `any_duplicated_linter()`
    - *encourages the use of `anyDuplicated(x)` over `any(duplicated(x))`*
    - *this built-in is faster in most cases, because it doesn't need to compute all duplicates*
* `any_is_na_linter()`
    - *encourages the use of `anyNA(x)` over `is.na(x)`*
    - *this built-in is faster in most cases, because it doesn't need to compute whether or not every value in `x` is `NA`*
* `sprintf_linter()`
    - *detects mistakes in string formatting with `sprintf()`*
* `unreachable_code_linter()`
    - *detects code that will never be executed, e.g. after an unconditional `stop()` or `return()`*
* `vector_logic_linter()`
    - *warns against the common mistake of using vectorized logical operators like `|` and `&&` (which return a vector of results) when a single logical is expected*

Other changes in this PR are to address the following errors raised by these linters.

> warning: [unreachable_code] Code and comments coming after a top-level return() or stop() should be removed.
>
> warning: [vector_logic] Conditional expressions require scalar logical operators (&& and ||)
>
> warning: [any_is_na] anyNA(x) is better than any(is.na(x))

### How I tested this

```shell
Rscript ./tests/ci_build/lint_r.R $(pwd)

R CMD INSTALL R-package/
cd R-package/tests
Rscript testthat.R
```

### Notes for Reviewers

I chose this set of additional linters because they address efficiency and correctness, so they provide some user-facing benefit.

I might propose adding more in the future ([we use many more in LightGBM](https://github.com/microsoft/LightGBM/blob/08f0853db2cf609bad43d5df5a4d92c3fe2d7caf/.ci/lint_r_code.R#L31)), but don't want to draw away too much of maintainers' attention here.

Thanks for your time and consideration!