### PR TITLE
[CI] remove unused cpp test helper function

### DIFF
--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -38,12 +38,6 @@ bool FileExists(const std::string& filename) {
   return stat(filename.c_str(), &st) == 0;
 }
 
-int64_t GetFileSize(const std::string& filename) {
-  struct stat st;
-  stat(filename.c_str(), &st);
-  return st.st_size;
-}
-
 void CreateSimpleTestData(const std::string& filename) {
   CreateBigTestData(filename, 6);
 }

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -50,8 +50,6 @@ Float RelError(Float l, Float r) {
 
 bool FileExists(const std::string& filename);
 
-int64_t GetFileSize(const std::string& filename);
-
 void CreateSimpleTestData(const std::string& filename);
 
 // Create a libsvm format file with 3 entries per-row. `zero_based` specifies whether it's


### PR DESCRIPTION
Looking through the project's C++ tests, I found a function that I think is no longer used.

This PR proposes removing `GetFileSize()`.

### How I tested this

Saw that the function isn't used anywhere by running the following from the root of the repo.

```shell
git grep GetFileSize
```

Ran the cpp tests on my Mac, with the following code adapted from the project's CI ([.github/worfklows/main.yml](https://github.com/dmlc/xgboost/blob/77b069c25d47c47ceebbaf6235d1b2d996174944/.github/workflows/main.yml#L15))

```shell
rm -rf ./build ./lib
mkdir build
cd build
cmake \
    -DGOOGLE_TEST=ON \
    -DUSE_OPENMP=ON \
    -DUSE_DMLC_GTEST=ON \
    -DPLUGIN_DENSE_PARSER=ON \
    -GNinja \
    ..
ninja -v
cd build
./testxgboost
ctest -R TestXGBoostCLI
```

### Notes for Reviewers

Thanks for your time and consideration.