### PR TITLE
Update custom_metric_obj.rst

### DIFF
--- a/doc/tutorials/custom_metric_obj.rst
+++ b/doc/tutorials/custom_metric_obj.rst
@@ -292,6 +292,7 @@ access ``DMatrix``:
 
     def softprob_obj(labels: np.ndarray, predt: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         rows = labels.shape[0]
+        classes = labels.shape[1] if labels.ndim > 1 else 1
         grad = np.zeros((rows, classes), dtype=float)
         hess = np.zeros((rows, classes), dtype=float)
         eps = 1e-6

--- a/doc/tutorials/custom_metric_obj.rst
+++ b/doc/tutorials/custom_metric_obj.rst
@@ -292,7 +292,7 @@ access ``DMatrix``:
 
     def softprob_obj(labels: np.ndarray, predt: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         rows = labels.shape[0]
-        classes = labels.shape[1] if labels.ndim > 1 else 1
+        classes = predt.shape[1]
         grad = np.zeros((rows, classes), dtype=float)
         hess = np.zeros((rows, classes), dtype=float)
         eps = 1e-6


### PR DESCRIPTION
For the codeblock given in line 291, in the softprob_obj method definition, the variable 'classes' is not defined. It seems it should be defined as given in the changes.