### PR TITLE
remove unused variables in JSON-parsing code

### DIFF
--- a/src/common/json.cc
+++ b/src/common/json.cc
@@ -437,7 +437,6 @@ void ParseStr(std::string const& str) {
 
 Json JsonReader::ParseString() {
   char ch { GetConsecutiveChar('\"') };  // NOLINT
-  std::ostringstream output;
   std::string str;
   while (true) {
     ch = GetNextChar();
@@ -656,7 +655,6 @@ Json JsonReader::ParseBoolean() {
   char ch = GetNextNonSpaceChar();
   std::string const t_value = u8"true";
   std::string const f_value = u8"false";
-  std::string buffer;
 
   if (ch == 't') {
     GetConsecutiveChar('r');


### PR DESCRIPTION
Proposes removing two unused variables in `src/common/json.cc`. Hopefully this will cut a bit of processing time and a some unnecessary allocations out of JSON-reading operations.

### Notes for Reviewers

I found these by running `cppcheck` over the project's source code.

```shell
cppcheck \
    --force \
    --enable=all \
    --std=c++14 \
    -I include/ \
    -UDEBUG \
    src/ \
> cppcheck.txt 2>&1

cat cppcheck.txt | grep 'unusedVar'
```

These are the only two such warnings `cppcheck` found.

> src/common/json.cc:440:22: style: Unused variable: output [unusedVariable]
src/common/json.cc:659:15: style: Unused variable: buffer [unusedVariable]