### PR TITLE
[CI] fix git errors related to directory ownership

### DIFF
--- a/.github/workflows/r_tests.yml
+++ b/.github/workflows/r_tests.yml
@@ -104,6 +104,10 @@ jobs:
         # No need to add pandoc, the container has it figured out.
         apt update && apt install libcurl4-openssl-dev libssl-dev libssh2-1-dev libgit2-dev libglpk-dev libxml2-dev libharfbuzz-dev libfribidi-dev git -y
 
+    - name: Trust git cloning project sources
+      run: |
+        git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
     - uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
       with:
         submodules: 'true'


### PR DESCRIPTION
The `Test R package on Debian` CI job is currently failing on `master` ([build link](https://github.com/dmlc/xgboost/actions/runs/3799876978/jobs/6462812830)) and on #8627 ([build link](https://github.com/dmlc/xgboost/actions/runs/3791482121/jobs/6462769234)) with the following error at the step where the repo is `git clone`'d.

> ValueError: ('Failed to check git repository status.', CompletedProcess(args=['git', 'clean', '-xdf', '--dry-run'], returncode=128, stdout=b'', stderr=b"fatal: detected dubious ownership in repository at '/__w/xgboost/xgboost'\nTo add an exception for this directory, call:\n\n\tgit config --global --add safe.directory /__w/xgboost/xgboost\n"))

I suspect this means that that job started getting a newer version of `git` recently, which contains a patch for the CVE described at https://github.blog/2022-04-12-git-security-vulnerability-announced/.

This PR proposes a patch that I think will address it. We've been using something similar over in LightGBM for the last 8 months (https://github.com/microsoft/LightGBM/pull/5152) without issue.