### PR TITLE
Do not return internal value for `get_params`.

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -725,7 +725,7 @@ class XGBModel(XGBModelBase):
                         stack.append(v)
 
             for k, v in internal.items():
-                if k in params and params[k] is None:
+                if k not in params:
                     params[k] = parse_parameter(v)
         except ValueError:
             pass


### PR DESCRIPTION
Users will have to reach the booster object for internally configured values using `clf.get_booster().save_config()`. The `get_params` method will only return what's set in the estimator interface.


Close https://github.com/dmlc/xgboost/issues/8596 .