### PR TITLE
Define default ctors for gpair.

### DIFF
--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -1,18 +1,19 @@
-/*!
- * Copyright (c) 2015 by Contributors
+/**
+ * Copyright 2015-2023 by XGBoost Contributors
  * \file base.h
- * \brief defines configuration macros of xgboost.
+ * \brief Defines configuration macros and basic types for xgboost.
  */
 #ifndef XGBOOST_BASE_H_
 #define XGBOOST_BASE_H_
 
 #include <dmlc/base.h>
 #include <dmlc/omp.h>
+
 #include <cmath>
 #include <iostream>
-#include <vector>
 #include <string>
 #include <utility>
+#include <vector>
 
 /*!
  * \brief string flag for R library, to leave hooks when needed.
@@ -164,7 +165,10 @@ class GradientPairInternal {
   }
 
   // Copy constructor if of same value type, marked as default to be trivially_copyable
-  GradientPairInternal(const GradientPairInternal<T> &g) = default;
+  GradientPairInternal(GradientPairInternal const &g) = default;
+  GradientPairInternal(GradientPairInternal &&g) = default;
+  GradientPairInternal &operator=(GradientPairInternal const &that) = default;
+  GradientPairInternal &operator=(GradientPairInternal &&that) = default;
 
   // Copy constructor if different value type - use getters and setters to
   // perform conversion

--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -1,5 +1,5 @@
-/*!
- * Copyright 2018-2019 by Contributors
+/**
+ * Copyright 2018-2023 by XGBoost Contributors
  * \author Rory Mitchell
  */
 
@@ -202,8 +202,7 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     auto f = [=] __device__(size_t idx) {
       auto entry = d_col[idx];
       auto g = d_gpair[entry.index * num_group + group_idx];
-      return GradientPair(g.GetGrad() * entry.fvalue,
-                          g.GetHess() * entry.fvalue * entry.fvalue);
+      return GradientPair{g.GetGrad() * entry.fvalue, g.GetHess() * entry.fvalue * entry.fvalue};
     };  // NOLINT
     thrust::transform_iterator<decltype(f), decltype(counting), GradientPair>
         multiply_iterator(counting, f);


### PR DESCRIPTION
Fix clang warning:
```
Definition of implicit copy assignment operator for 'GradientPairInternal<float>' is deprecated because it has a user-declared copy constructor
```