### PR TITLE
[R] fix OpenMP detection on macOS

### DIFF
--- a/R-package/configure
+++ b/R-package/configure
@@ -2101,8 +2101,6 @@ CXX14STD=`"${R_HOME}/bin/R" CMD config CXX14STD`
 CXX="${CXX14} ${CXX14STD}"
 CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
 
-CC=`"${R_HOME}/bin/R" CMD config CC`
-CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
@@ -2857,7 +2855,7 @@ main (void)
   return 0;
 }
 _ACEOF
-  ${CC} -o conftest conftest.c ${CPPFLAGS} ${LDFLAGS} ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+  ${CXX} -o conftest conftest.cpp ${CPPFLAGS} ${LDFLAGS} ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${ac_pkg_openmp}" >&5
 printf "%s\n" "${ac_pkg_openmp}" >&6; }
   if test "${ac_pkg_openmp}" = no; then

--- a/R-package/configure
+++ b/R-package/configure
@@ -2101,6 +2101,8 @@ CXX14STD=`"${R_HOME}/bin/R" CMD config CXX14STD`
 CXX="${CXX14} ${CXX14STD}"
 CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
 
+CC=`"${R_HOME}/bin/R" CMD config CC`
+CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -15,6 +15,8 @@ CXX14STD=`"${R_HOME}/bin/R" CMD config CXX14STD`
 CXX="${CXX14} ${CXX14STD}"
 CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
 
+CC=`"${R_HOME}/bin/R" CMD config CC`
+CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -15,8 +15,6 @@ CXX14STD=`"${R_HOME}/bin/R" CMD config CXX14STD`
 CXX="${CXX14} ${CXX14STD}"
 CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
 
-CC=`"${R_HOME}/bin/R" CMD config CC`
-CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
@@ -55,7 +53,7 @@ then
   ac_pkg_openmp=no
   AC_MSG_CHECKING([whether OpenMP will work in a package])
   AC_LANG_CONFTEST([AC_LANG_PROGRAM([[#include <omp.h>]], [[ return (omp_get_max_threads() <= 1); ]])])
-  ${CC} -o conftest conftest.c ${CPPFLAGS} ${LDFLAGS} ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
+  ${CXX} -o conftest conftest.cpp ${CPPFLAGS} ${LDFLAGS} ${OPENMP_LIB} ${OPENMP_CXXFLAGS} 2>/dev/null && ./conftest && ac_pkg_openmp=yes
   AC_MSG_RESULT([${ac_pkg_openmp}])
   if test "${ac_pkg_openmp}" = no; then
     OPENMP_CXXFLAGS=''


### PR DESCRIPTION
Detection of OpenMP on macOS in the R package's `configure` script is currently not working.

This PR proposes switching from a C compiler to a C++ compiler in `R-package/configure` to fix that.

### Why using a C compiler breaks this check

This code in `configure.ac`...

https://github.com/dmlc/xgboost/blob/e7d612d22ca7bf82ada8f581a40253e3cf7230b4/R-package/configure.ac#L23

https://github.com/dmlc/xgboost/blob/e7d612d22ca7bf82ada8f581a40253e3cf7230b4/R-package/configure.ac#L57

... results in `autoconf` generating a file `conftest.cpp`

https://github.com/dmlc/xgboost/blob/e7d612d22ca7bf82ada8f581a40253e3cf7230b4/R-package/configure#L2745

https://github.com/dmlc/xgboost/blob/e7d612d22ca7bf82ada8f581a40253e3cf7230b4/R-package/configure#L2849

... but then XGBoost's `configure` file is looking instead for a file named `conftest.c`

https://github.com/dmlc/xgboost/blob/e7d612d22ca7bf82ada8f581a40253e3cf7230b4/R-package/configure.ac#L58

### How I tested this

On my mac tonight (macOS 12.2.1, R 4.2.2, compiling with `clang++` 13.0.0), I ran the following on `master`

```shell
cd R-package
R CMD INSTALL .
```

And saw the following in logs

```text
checking whether OpenMP will work in a package... no
*****************************************************************************************
         OpenMP is unavailable on this Mac OSX system. Training speed may be suboptimal.
         To use all CPU cores for training jobs, you should install OpenMP by running

             brew install libomp
*****************************************************************************************
```

@trivialfis noted the same thing on recent R Hub checks, https://github.com/dmlc/xgboost/pull/8669#issuecomment-1381000453

Repeating that on this branch, the R package compiles, links to OpenMP, and its unit tests succeed.

```shell
cd tests
Rscript testthat.R
```

### Notes for Reviewers

Sorry for not noticing this while reviewing #8669. It wasn't until today that I had time to look closely and test.

In LightGBM, we try to catch issues like this by `grep`-ing the build logs: https://github.com/microsoft/LightGBM/blob/5df7d516f3e64e8431aecfea892a850afeb787bb/.ci/test_r_package.sh#L250-L267. I'm not proposing that here, but you might want to consider it in the future.

Thanks for your time and consideration.