### PR TITLE
[R] avoid leaving test files behind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,9 @@ demo/**/*.txt
 .hypothesis
 __MACOSX/
 model*.json
+
+# R tests
+*.libsvm
+*.rds
+Rplots.pdf
+*.zip

--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -70,7 +70,7 @@ test_that("xgb.DMatrix: saving, loading", {
 
   # from a libsvm text file
   tmp <- c("0 1:1 2:1", "1 3:1", "0 1:1")
-  tmp_file <- 'tmp.libsvm'
+  tmp_file <- tempfile(fileext = ".libsvm")
   writeLines(tmp, tmp_file)
   dtest4 <- xgb.DMatrix(tmp_file, silent = TRUE)
   expect_equal(dim(dtest4), c(3, 4))

--- a/R-package/tests/testthat/test_model_compatibility.R
+++ b/R-package/tests/testthat/test_model_compatibility.R
@@ -59,11 +59,12 @@ test_that("Models from previous versions of XGBoost can be loaded", {
   bucket <- 'xgboost-ci-jenkins-artifacts'
   region <- 'us-west-2'
   file_name <- 'xgboost_r_model_compatibility_test.zip'
-  zipfile <- file.path(getwd(), file_name)
-  model_dir <- file.path(getwd(), 'models')
+  zipfile <- tempfile(fileext = ".zip")
+  extract_dir <- tempdir()
   download.file(paste('https://', bucket, '.s3-', region, '.amazonaws.com/', file_name, sep = ''),
                 destfile = zipfile, mode = 'wb', quiet = TRUE)
-  unzip(zipfile, overwrite = TRUE)
+  unzip(zipfile, exdir = extract_dir, overwrite = TRUE)
+  model_dir <- file.path(extract_dir, 'models')
 
   pred_data <- xgb.DMatrix(matrix(c(0, 0, 0, 0), nrow = 1, ncol = 4))
 


### PR DESCRIPTION
Working on the R package here recently, I've found that running the tests locally...

```shell
cd R-package
R CMD INSTALL .
cd tests
Rscript testthat.R
```

... leaves a few files behind

```shell
git status
```

```text
R-package/tests/testthat/Rplots.pdf
R-package/tests/testthat/models/
R-package/tests/testthat/tmp.libsvm
R-package/tests/testthat/xgboost_r_model_compatibility_test.zip
```

This PR proposes two changes to address that:

* using `tempfile()` and `tempdir()` for files generated by the tests, so R will automatically clean them up on process exit
* adding `.gitignore` rules matching those files, since I think they generally are undesirable in the project (e.g., there are 0 `.libsvm` files in source control here

### How I tested this

```shell
Rscript ./tests/ci_build/lint_r.R $(pwd)/R-package

cd R-package
R CMD INSTALL .
cd tests
Rscript testthat.R
```