### PR TITLE
[R] remove XGBoosterPredict_R (fixes #8687)

### DIFF
--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -30,7 +30,6 @@ extern SEXP XGBoosterSaveJsonConfig_R(SEXP handle);
 extern SEXP XGBoosterLoadJsonConfig_R(SEXP handle, SEXP value);
 extern SEXP XGBoosterSerializeToBuffer_R(SEXP handle);
 extern SEXP XGBoosterUnserializeFromBuffer_R(SEXP handle, SEXP raw);
-extern SEXP XGBoosterPredict_R(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP XGBoosterPredictFromDMatrix_R(SEXP, SEXP, SEXP);
 extern SEXP XGBoosterSaveModel_R(SEXP, SEXP);
 extern SEXP XGBoosterSetAttr_R(SEXP, SEXP, SEXP);
@@ -68,7 +67,6 @@ static const R_CallMethodDef CallEntries[] = {
   {"XGBoosterLoadJsonConfig_R",   (DL_FUNC) &XGBoosterLoadJsonConfig_R,   2},
   {"XGBoosterSerializeToBuffer_R",     (DL_FUNC) &XGBoosterSerializeToBuffer_R,     1},
   {"XGBoosterUnserializeFromBuffer_R", (DL_FUNC) &XGBoosterUnserializeFromBuffer_R, 2},
-  {"XGBoosterPredict_R",          (DL_FUNC) &XGBoosterPredict_R,          5},
   {"XGBoosterPredictFromDMatrix_R", (DL_FUNC) &XGBoosterPredictFromDMatrix_R, 3},
   {"XGBoosterSaveModel_R",        (DL_FUNC) &XGBoosterSaveModel_R,        2},
   {"XGBoosterSetAttr_R",          (DL_FUNC) &XGBoosterSetAttr_R,          3},

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -458,27 +458,6 @@ XGB_DLL SEXP XGBoosterEvalOneIter_R(SEXP handle, SEXP iter, SEXP dmats, SEXP evn
   return mkString(ret);
 }
 
-XGB_DLL SEXP XGBoosterPredict_R(SEXP handle, SEXP dmat, SEXP option_mask,
-                                SEXP ntree_limit, SEXP training) {
-  SEXP ret;
-  R_API_BEGIN();
-  bst_ulong olen;
-  const float *res;
-  CHECK_CALL(XGBoosterPredict(R_ExternalPtrAddr(handle),
-                              R_ExternalPtrAddr(dmat),
-                              asInteger(option_mask),
-                              asInteger(ntree_limit),
-                              asInteger(training),
-                              &olen, &res));
-  ret = PROTECT(allocVector(REALSXP, olen));
-  for (size_t i = 0; i < olen; ++i) {
-    REAL(ret)[i] = res[i];
-  }
-  R_API_END();
-  UNPROTECT(1);
-  return ret;
-}
-
 XGB_DLL SEXP XGBoosterPredictFromDMatrix_R(SEXP handle, SEXP dmat, SEXP json_config)  {
   SEXP r_out_shape;
   SEXP r_out_result;

--- a/R-package/src/xgboost_R.h
+++ b/R-package/src/xgboost_R.h
@@ -177,17 +177,6 @@ XGB_DLL SEXP XGBoosterBoostOneIter_R(SEXP handle, SEXP dtrain, SEXP grad, SEXP h
 XGB_DLL SEXP XGBoosterEvalOneIter_R(SEXP handle, SEXP iter, SEXP dmats, SEXP evnames);
 
 /*!
- * \brief (Deprecated) make prediction based on dmat
- * \param handle handle
- * \param dmat data matrix
- * \param option_mask output_margin:1 predict_leaf:2
- * \param ntree_limit limit number of trees used in prediction
- * \param training Whether the prediction value is used for training.
- */
-XGB_DLL SEXP XGBoosterPredict_R(SEXP handle, SEXP dmat, SEXP option_mask,
-                                SEXP ntree_limit, SEXP training);
-
-/*!
  * \brief Run prediction on DMatrix, replacing `XGBoosterPredict_R`
  * \param handle handle
  * \param dmat data matrix


### PR DESCRIPTION
Fixes #8687.

Proposes removing `XGBoosterPredict_R()`, which is no longer used in the R package. See the linked issue for more details.