### PR TITLE
[R] add tests on print.xgb.DMatrix()

### DIFF
--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -162,3 +162,46 @@ test_that("xgb.DMatrix: nrow is correct for a very sparse matrix", {
   dtest <- xgb.DMatrix(x)
   expect_equal(dim(dtest), dim(x))
 })
+
+test_that("xgb.DMatrix: print", {
+    data(agaricus.train, package = 'xgboost')
+
+    # core DMatrix with just data and labels
+    dtrain <- xgb.DMatrix(
+        data = agaricus.train$data
+        , label = agaricus.train$label
+    )
+    txt <- capture.output({print(dtrain)})
+    expect_equal(txt, "xgb.DMatrix  dim: 6513 x 126  info: label  colnames: yes")
+
+    # verbose=TRUE prints feature names
+    txt <- capture.output({print(dtrain, verbose = TRUE)})
+    expect_equal(txt[[1L]], "xgb.DMatrix  dim: 6513 x 126  info: label  colnames:")
+    expect_equal(txt[[2L]], sprintf("'%s'", paste(colnames(dtrain), collapse = "','")))
+
+    # DMatrix with weights and base_margin
+    dtrain <- xgb.DMatrix(
+        data = agaricus.train$data
+        , label = agaricus.train$label
+        , weight = seq_along(agaricus.train$label)
+        , base_margin = agaricus.train$label
+    )
+    txt <- capture.output({print(dtrain)})
+    expect_equal(txt, "xgb.DMatrix  dim: 6513 x 126  info: label weight base_margin  colnames: yes")
+
+    # DMatrix with just features
+    dtrain <- xgb.DMatrix(
+        data = agaricus.train$data
+    )
+    txt <- capture.output({print(dtrain)})
+    expect_equal(txt, "xgb.DMatrix  dim: 6513 x 126  info: NA  colnames: yes")
+
+    # DMatrix with no column names
+    data_no_colnames <- agaricus.train$data
+    colnames(data_no_colnames) <- NULL
+    dtrain <- xgb.DMatrix(
+        data = data_no_colnames
+    )
+    txt <- capture.output({print(dtrain)})
+    expect_equal(txt, "xgb.DMatrix  dim: 6513 x 126  info: NA  colnames: no")
+})

--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -171,11 +171,15 @@ test_that("xgb.DMatrix: print", {
         data = agaricus.train$data
         , label = agaricus.train$label
     )
-    txt <- capture.output({print(dtrain)})
+    txt <- capture.output({
+        print(dtrain)
+    })
     expect_equal(txt, "xgb.DMatrix  dim: 6513 x 126  info: label  colnames: yes")
 
     # verbose=TRUE prints feature names
-    txt <- capture.output({print(dtrain, verbose = TRUE)})
+    txt <- capture.output({
+        print(dtrain, verbose = TRUE)
+    })
     expect_equal(txt[[1L]], "xgb.DMatrix  dim: 6513 x 126  info: label  colnames:")
     expect_equal(txt[[2L]], sprintf("'%s'", paste(colnames(dtrain), collapse = "','")))
 
@@ -186,14 +190,18 @@ test_that("xgb.DMatrix: print", {
         , weight = seq_along(agaricus.train$label)
         , base_margin = agaricus.train$label
     )
-    txt <- capture.output({print(dtrain)})
+    txt <- capture.output({
+        print(dtrain)
+    })
     expect_equal(txt, "xgb.DMatrix  dim: 6513 x 126  info: label weight base_margin  colnames: yes")
 
     # DMatrix with just features
     dtrain <- xgb.DMatrix(
         data = agaricus.train$data
     )
-    txt <- capture.output({print(dtrain)})
+    txt <- capture.output({
+        print(dtrain)
+    })
     expect_equal(txt, "xgb.DMatrix  dim: 6513 x 126  info: NA  colnames: yes")
 
     # DMatrix with no column names
@@ -202,6 +210,8 @@ test_that("xgb.DMatrix: print", {
     dtrain <- xgb.DMatrix(
         data = data_no_colnames
     )
-    txt <- capture.output({print(dtrain)})
+    txt <- capture.output({
+        print(dtrain)
+    })
     expect_equal(txt, "xgb.DMatrix  dim: 6513 x 126  info: NA  colnames: no")
 })


### PR DESCRIPTION
I noticed that `print.xgb.DMatrix()` in the R package is not currently covered by any unit tests.

<details><summary>how I found that (click me)</summary>

```shell
cd R-package
Rscript -e " \
    coverage <- covr::package_coverage(type = 'tests', quiet = FALSE);
    print(coverage);
    covr::report(coverage, file = file.path(getwd(), 'coverage.html'), browse = TRUE);
    "
```

</details>

This PR proposes adding tests on that function.

## Notes for Reviewers

Each of the combinations in the test added here covers one set of `if-else` conditions through that function. As of this PR, they're all covered by at least one test case.