### PR TITLE
[ci] remove unused imports in tests

### DIFF
--- a/tests/python/test_ranking.py
+++ b/tests/python/test_ranking.py
@@ -1,8 +1,6 @@
 import itertools
 import os
 import shutil
-import urllib.request
-import zipfile
 
 import numpy as np
 from scipy.sparse import csr_matrix

--- a/tests/python/test_with_pandas.py
+++ b/tests/python/test_with_pandas.py
@@ -1,6 +1,3 @@
-import os
-import tempfile
-
 import numpy as np
 import pytest
 from test_dmatrix import set_base_margin_info


### PR DESCRIPTION
I ran `flake8` over the code in `tests/`, which revealed a few unused imports.

```text
tests/python/test_ranking.py:4:1: F401 'urllib.request' imported but unused
tests/python/test_ranking.py:5:1: F401 'zipfile' imported but unused
tests/python/test_with_pandas.py:1:1: F401 'os' imported but unused
tests/python/test_with_pandas.py:2:1: F401 'tempfile' imported but unused
```

This PR proposes removing them.