### PR TITLE
[R] discourage use of regex for fixed string comparisons

### DIFF
--- a/R-package/R/callbacks.R
+++ b/R-package/R/callbacks.R
@@ -114,7 +114,7 @@ cb.evaluation.log <- function() {
     if (is.null(mnames) || any(mnames == ""))
       stop("bst_evaluation must have non-empty names")
 
-    mnames <<- gsub('-', '_', names(env$bst_evaluation))
+    mnames <<- gsub('-', '_', names(env$bst_evaluation), fixed = TRUE)
     if (!is.null(env$bst_evaluation_err))
       mnames <<- c(paste0(mnames, '_mean'), paste0(mnames, '_std'))
   }
@@ -185,7 +185,7 @@ cb.reset.parameters <- function(new_params) {
 
   if (typeof(new_params) != "list")
     stop("'new_params' must be a list")
-  pnames <- gsub("\\.", "_", names(new_params))
+  pnames <- gsub(".", "_", names(new_params), fixed = TRUE)
   nrounds <- NULL
 
   # run some checks in the beginning
@@ -300,9 +300,9 @@ cb.early.stop <- function(stopping_rounds, maximize = FALSE,
     if (length(env$bst_evaluation) == 0)
       stop("For early stopping, watchlist must have at least one element")
 
-    eval_names <- gsub('-', '_', names(env$bst_evaluation))
+    eval_names <- gsub('-', '_', names(env$bst_evaluation), fixed = TRUE)
     if (!is.null(metric_name)) {
-      metric_idx <<- which(gsub('-', '_', metric_name) == eval_names)
+      metric_idx <<- which(gsub('-', '_', metric_name, fixed = TRUE) == eval_names)
       if (length(metric_idx) == 0)
         stop("'metric_name' for early stopping is not one of the following:\n",
              paste(eval_names, collapse = ' '), '\n')

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -38,11 +38,11 @@ check.booster.params <- function(params, ...) {
     stop("params must be a list")
 
   # in R interface, allow for '.' instead of '_' in parameter names
-  names(params) <- gsub("\\.", "_", names(params))
+  names(params) <- gsub(".", "_", names(params), fixed = TRUE)
 
   # merge parameters from the params and the dots-expansion
   dot_params <- list(...)
-  names(dot_params) <- gsub("\\.", "_", names(dot_params))
+  names(dot_params) <- gsub(".", "_", names(dot_params), fixed = TRUE)
   if (length(intersect(names(params),
                        names(dot_params))) > 0)
     stop("Same parameters in 'params' and in the call are not allowed. Please check your 'params' list.")

--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -672,7 +672,7 @@ xgb.config <- function(object) {
   if (is.null(names(p)) || any(nchar(names(p)) == 0)) {
     stop("parameter names cannot be empty strings")
   }
-  names(p) <- gsub("\\.", "_", names(p))
+  names(p) <- gsub(".", "_", names(p), fixed = TRUE)
   p <- lapply(p, function(x) as.character(x)[1])
   handle <- xgb.get.handle(object)
   for (i in seq_along(p)) {

--- a/R-package/inst/make-r-def.R
+++ b/R-package/inst/make-r-def.R
@@ -79,9 +79,9 @@ end_of_table <- empty_lines[empty_lines > start_index][1L]
 
 # Read the contents of the table
 exported_symbols <- objdump_results[(start_index + 1L):end_of_table]
-exported_symbols <- gsub("\t", "", exported_symbols)
+exported_symbols <- gsub("\t", "", exported_symbols, fixed = TRUE)
 exported_symbols <- gsub(".*\\] ", "", exported_symbols)
-exported_symbols <- gsub(" ", "", exported_symbols)
+exported_symbols <- gsub(" ", "", exported_symbols, fixed = TRUE)
 
 # Write R.def file
 writeLines(

--- a/R-package/tests/testthat/test_helpers.R
+++ b/R-package/tests/testthat/test_helpers.R
@@ -63,7 +63,7 @@ test_that("xgb.dump works", {
   dmp <- xgb.dump(bst.Tree, dump_format = "json")
   expect_length(dmp, 1)
   if (!flag_32bit)
-    expect_length(grep('nodeid', strsplit(dmp, '\n')[[1]]), 188)
+    expect_length(grep('nodeid', strsplit(dmp, '\n', fixed = TRUE)[[1]], fixed = TRUE), 188)
 })
 
 test_that("xgb.dump works for gblinear", {
@@ -80,7 +80,7 @@ test_that("xgb.dump works for gblinear", {
   # JSON format
   dmp <- xgb.dump(bst.GLM.sp, dump_format = "json")
   expect_length(dmp, 1)
-  expect_length(grep('\\d', strsplit(dmp, '\n')[[1]]), 11)
+  expect_length(grep('\\d', strsplit(dmp, '\n', fixed = TRUE)[[1]]), 11)
 })
 
 test_that("predict leafs works", {
@@ -231,9 +231,9 @@ test_that("xgb-attribute functionality", {
   expect_null(xgb.attributes(bst))
 })
 
-if (grepl('Windows', Sys.info()[['sysname']]) ||
-    grepl('Linux', Sys.info()[['sysname']]) ||
-    grepl('Darwin', Sys.info()[['sysname']])) {
+if (grepl('Windows', Sys.info()[['sysname']], fixed = TRUE) ||
+    grepl('Linux', Sys.info()[['sysname']], fixed = TRUE) ||
+    grepl('Darwin', Sys.info()[['sysname']], fixed = TRUE)) {
     test_that("xgb-attribute numeric precision", {
       .skip_if_vcd_not_available()
       # check that lossless conversion works with 17 digits
@@ -293,9 +293,9 @@ test_that("xgb.model.dt.tree works with and without feature names", {
 
   # using integer node ID instead of character
   dt.tree.int <- xgb.model.dt.tree(model = bst.Tree, use_int_id = TRUE)
-  expect_equal(as.integer(data.table::tstrsplit(dt.tree$Yes, '-')[[2]]), dt.tree.int$Yes)
-  expect_equal(as.integer(data.table::tstrsplit(dt.tree$No, '-')[[2]]), dt.tree.int$No)
-  expect_equal(as.integer(data.table::tstrsplit(dt.tree$Missing, '-')[[2]]), dt.tree.int$Missing)
+  expect_equal(as.integer(data.table::tstrsplit(dt.tree$Yes, '-', fixed = TRUE)[[2]]), dt.tree.int$Yes)
+  expect_equal(as.integer(data.table::tstrsplit(dt.tree$No, '-', fixed = TRUE)[[2]]), dt.tree.int$No)
+  expect_equal(as.integer(data.table::tstrsplit(dt.tree$Missing, '-', fixed = TRUE)[[2]]), dt.tree.int$Missing)
 })
 
 test_that("xgb.model.dt.tree throws error for gblinear", {

--- a/demo/kaggle-otto/otto_train_pred.R
+++ b/demo/kaggle-otto/otto_train_pred.R
@@ -7,7 +7,7 @@ train <- train[, -1]
 test <- test[, -1]
 
 y <- train[, ncol(train)]
-y <- gsub('Class_', '', y)
+y <- gsub('Class_', '', y, fixed = TRUE)
 y <- as.integer(y) - 1  # xgboost take features in [0,numOfClass)
 
 x <- rbind(train[, -ncol(train)], test)

--- a/demo/kaggle-otto/understandingXGBoostModel.Rmd
+++ b/demo/kaggle-otto/understandingXGBoostModel.Rmd
@@ -87,7 +87,7 @@ For that purpose, we will:
 ```{r classToIntegers}
 # Convert from classes to numbers
 y <- train[, nameLastCol, with = FALSE][[1]] %>%
-    gsub('Class_', '', .) %>%
+    gsub('Class_', '', ., fixed = TRUE) %>%
     as.integer %>%
     subtract(., 1)
 

--- a/tests/ci_build/lint_r.R
+++ b/tests/ci_build/lint_r.R
@@ -23,6 +23,7 @@ my_linters <- list(
   brace_linter = lintr::brace_linter(),
   commas_linter = lintr::commas_linter(),
   equals_na = lintr::equals_na_linter(),
+  fixed_regex = lintr::fixed_regex_linter(),
   infix_spaces_linter = lintr::infix_spaces_linter(),
   line_length_linter = lintr::line_length_linter(length = 150L),
   no_tab_linter = lintr::no_tab_linter(),


### PR DESCRIPTION
This PR proposes two changes for the R package

* using fixed string matching instead of regular expressions in string comparisons
* enforcing that practice with `lintr::fixed_regex_linter`

<details><summary>all lintr warnings addressed in this PR (click me)</summary>

```text
[[1]]
demo/kaggle-otto/otto_train_pred.R:10:11: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "Class_" with fixed = TRUE.
y <- gsub('Class_', '', y)
          ^~~~~~~~

[[2]]
demo/kaggle-otto/understandingXGBoostModel.Rmd:90:10: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "Class_" with fixed = TRUE.
    gsub('Class_', '', .) %>%
         ^~~~~~~~

[[3]]
R-package/inst/make-r-def.R:82:26: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "\t" with fixed = TRUE.
exported_symbols <- gsub("\t", "", exported_symbols)
                         ^~~~

[[4]]
R-package/inst/make-r-def.R:84:26: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use " " with fixed = TRUE.
exported_symbols <- gsub(" ", "", exported_symbols)
                         ^~~

[[5]]
R-package/R/callbacks.R:117:21: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "-" with fixed = TRUE.
    mnames <<- gsub('-', '_', names(env$bst_evaluation))
                    ^~~

[[6]]
R-package/R/callbacks.R:188:18: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "." with fixed = TRUE.
  pnames <- gsub("\\.", "_", names(new_params))
                 ^~~~~

[[7]]
R-package/R/callbacks.R:303:24: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "-" with fixed = TRUE.
    eval_names <- gsub('-', '_', names(env$bst_evaluation))
                       ^~~

[[8]]
R-package/R/callbacks.R:305:33: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "-" with fixed = TRUE.
      metric_idx <<- which(gsub('-', '_', metric_name) == eval_names)
                                ^~~

[[9]]
R-package/R/utils.R:41:25: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "." with fixed = TRUE.
  names(params) <- gsub("\\.", "_", names(params))
                        ^~~~~

[[10]]
R-package/R/utils.R:45:29: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "." with fixed = TRUE.
  names(dot_params) <- gsub("\\.", "_", names(dot_params))
                            ^~~~~

[[11]]
R-package/R/xgb.Booster.R:675:20: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "." with fixed = TRUE.
  names(p) <- gsub("\\.", "_", names(p))
                   ^~~~~

[[12]]
R-package/tests/testthat/test_helpers.R:66:24: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "nodeid" with fixed = TRUE.
    expect_length(grep('nodeid', strsplit(dmp, '\n')[[1]]), 188)
                       ^~~~~~~~

[[13]]
R-package/tests/testthat/test_helpers.R:66:48: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "\n" with fixed = TRUE.
    expect_length(grep('nodeid', strsplit(dmp, '\n')[[1]]), 188)
                                               ^~~~

[[14]]
R-package/tests/testthat/test_helpers.R:83:43: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "\n" with fixed = TRUE.
  expect_length(grep('\\d', strsplit(dmp, '\n')[[1]]), 11)
                                          ^~~~

[[15]]
R-package/tests/testthat/test_helpers.R:234:11: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "Windows" with fixed = TRUE.
if (grepl('Windows', Sys.info()[['sysname']]) ||
          ^~~~~~~~~

[[16]]
R-package/tests/testthat/test_helpers.R:235:11: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "Linux" with fixed = TRUE.
    grepl('Linux', Sys.info()[['sysname']]) ||
          ^~~~~~~

[[17]]
R-package/tests/testthat/test_helpers.R:236:11: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "Darwin" with fixed = TRUE.
    grepl('Darwin', Sys.info()[['sysname']])) {
          ^~~~~~~~

[[18]]
R-package/tests/testthat/test_helpers.R:296:62: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "-" with fixed = TRUE.
  expect_equal(as.integer(data.table::tstrsplit(dt.tree$Yes, '-')[[2]]), dt.tree.int$Yes)
                                                             ^~~

[[19]]
R-package/tests/testthat/test_helpers.R:297:61: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "-" with fixed = TRUE.
  expect_equal(as.integer(data.table::tstrsplit(dt.tree$No, '-')[[2]]), dt.tree.int$No)
                                                            ^~~

[[20]]
R-package/tests/testthat/test_helpers.R:298:66: warning: [fixed_regex] This regular expression is static, i.e., its matches can be expressed as a fixed substring expression, which is faster to compute. Here, you can use "-" with fixed = TRUE.
  expect_equal(as.integer(data.table::tstrsplit(dt.tree$Missing, '-')[[2]]), dt.tree.int$Missing)
                                                                 ^~~
```

</details>

Searching for a fixed string in `gsub()`, `grepl()`, etc. is faster than evaluating regular expressions, so this change should make the library and tests a tiny bit faster.

### How I tested this

```shell
# lint
Rscript ./tests/ci_build/lint_r.R $(pwd)

# run unit tests
cd ./R-package
R CMD INSTALL --with-keep.source .
cd ./tests
Rscript testthat.R
```

### Notes for Reviewers

We're about to adopt the same change over in LightGBM (https://github.com/microsoft/LightGBM/pull/5685).

Thanks for your time and consideration.

And thanks to @MichaelChirico and @AshesITR for the work on `fixed_regex_linter`!