### PR TITLE
Support cpu quantile sketch with column-wise data split

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -627,11 +627,11 @@ class DMatrix {
   /**
    * \brief Slice a DMatrix by columns.
    *
-   * @param start The position of the first column
-   * @param size The number of columns in the slice
+   * @param num_slices Total number of slices
+   * @param slice_id Index of the current slice
    * @return DMatrix containing the slice of columns
    */
-  virtual DMatrix *SliceCol(std::size_t start, std::size_t size) = 0;
+  virtual DMatrix *SliceCol(int num_slices, int slice_id) = 0;
 
  protected:
   virtual BatchSet<SparsePage> GetRowBatches() = 0;

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -45,14 +45,16 @@ HistogramCuts SketchOnDMatrix(DMatrix *m, int32_t max_bins, int32_t n_threads, b
 
   if (!use_sorted) {
     HostSketchContainer container(max_bins, m->Info().feature_types.ConstHostSpan(), reduced,
-                                  HostSketchContainer::UseGroup(info), n_threads);
+                                  HostSketchContainer::UseGroup(info),
+                                  m->Info().data_split_mode == DataSplitMode::kCol, n_threads);
     for (auto const& page : m->GetBatches<SparsePage>()) {
       container.PushRowPage(page, info, hessian);
     }
     container.MakeCuts(&out);
   } else {
     SortedSketchContainer container{max_bins, m->Info().feature_types.ConstHostSpan(), reduced,
-                                    HostSketchContainer::UseGroup(info), n_threads};
+                                    HostSketchContainer::UseGroup(info),
+                                    m->Info().data_split_mode == DataSplitMode::kCol, n_threads};
     for (auto const& page : m->GetBatches<SortedCSCPage>()) {
       container.PushColPage(page, info, hessian);
     }

--- a/src/common/quantile.cc
+++ b/src/common/quantile.cc
@@ -298,8 +298,10 @@ void SketchContainerImpl<WQSketch>::AllReduce(
 
   // Prune the intermediate num cuts for synchronization.
   std::vector<bst_row_t> global_column_size(columns_size_);
-  collective::Allreduce<collective::Operation::kSum>(global_column_size.data(),
-                                                     global_column_size.size());
+  if (!col_split_) {
+    collective::Allreduce<collective::Operation::kSum>(global_column_size.data(),
+                                                       global_column_size.size());
+  }
 
   ParallelFor(sketches_.size(), n_threads_, [&](size_t i) {
     int32_t intermediate_num_cuts = static_cast<int32_t>(

--- a/src/common/quantile.cc
+++ b/src/common/quantile.cc
@@ -396,7 +396,7 @@ void SketchContainerImpl<WQSketch>::MakeCuts(HistogramCuts* cuts) {
   cuts->min_vals_.HostVector().resize(sketches_.size(), 0.0f);
   std::vector<typename WQSketch::SummaryContainer> final_summaries(reduced.size());
 
-  ParallelFor(reduced.size(), n_threads_, [&](size_t fidx) {
+  ParallelFor(reduced.size(), n_threads_, Sched::Guided(), [&](size_t fidx) {
     if (IsCat(feature_types_, fidx)) {
       return;
     }

--- a/src/common/quantile.cc
+++ b/src/common/quantile.cc
@@ -396,7 +396,7 @@ void SketchContainerImpl<WQSketch>::MakeCuts(HistogramCuts* cuts) {
   cuts->min_vals_.HostVector().resize(sketches_.size(), 0.0f);
   std::vector<typename WQSketch::SummaryContainer> final_summaries(reduced.size());
 
-  ParallelFor(reduced.size(), n_threads_, Sched::Guided(), [&](size_t fidx) {
+  ParallelFor(reduced.size(), n_threads_, Sched::Auto(), [&](size_t fidx) {
     if (IsCat(feature_types_, fidx)) {
       return;
     }

--- a/src/common/quantile.cc
+++ b/src/common/quantile.cc
@@ -396,7 +396,7 @@ void SketchContainerImpl<WQSketch>::MakeCuts(HistogramCuts* cuts) {
   cuts->min_vals_.HostVector().resize(sketches_.size(), 0.0f);
   std::vector<typename WQSketch::SummaryContainer> final_summaries(reduced.size());
 
-  ParallelFor(reduced.size(), n_threads_, Sched::Auto(), [&](size_t fidx) {
+  ParallelFor(reduced.size(), n_threads_, [&](size_t fidx) {
     if (IsCat(feature_types_, fidx)) {
       return;
     }

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -802,9 +802,9 @@ class SketchContainerImpl {
   std::vector<bst_row_t> columns_size_;
   int32_t max_bins_;
   bool use_group_ind_{false};
+  bool col_split_;
   int32_t n_threads_;
   bool has_categorical_{false};
-  bool col_split_{false};
   Monitor monitor_;
 
  public:

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -804,6 +804,7 @@ class SketchContainerImpl {
   bool use_group_ind_{false};
   int32_t n_threads_;
   bool has_categorical_{false};
+  bool col_split_{false};
   Monitor monitor_;
 
  public:
@@ -814,7 +815,7 @@ class SketchContainerImpl {
    * \param use_group whether is assigned to group to data instance.
    */
   SketchContainerImpl(std::vector<bst_row_t> columns_size, int32_t max_bins,
-                      common::Span<FeatureType const> feature_types, bool use_group,
+                      common::Span<FeatureType const> feature_types, bool use_group, bool col_split,
                       int32_t n_threads);
 
   static bool UseGroup(MetaInfo const &info) {
@@ -904,7 +905,8 @@ class HostSketchContainer : public SketchContainerImpl<WQuantileSketch<float, fl
 
  public:
   HostSketchContainer(int32_t max_bins, common::Span<FeatureType const> ft,
-                      std::vector<size_t> columns_size, bool use_group, int32_t n_threads);
+                      std::vector<size_t> columns_size, bool use_group, bool col_split,
+                      int32_t n_threads);
 
   template <typename Batch>
   void PushAdapterBatch(Batch const &batch, size_t base_rowid, MetaInfo const &info, float missing);
@@ -1000,9 +1002,9 @@ class SortedSketchContainer : public SketchContainerImpl<WXQuantileSketch<float,
 
  public:
   explicit SortedSketchContainer(int32_t max_bins, common::Span<FeatureType const> ft,
-                                 std::vector<size_t> columns_size, bool use_group,
+                                 std::vector<size_t> columns_size, bool use_group, bool col_split,
                                  int32_t n_threads)
-      : SketchContainerImpl{columns_size, max_bins, ft, use_group, n_threads} {
+      : SketchContainerImpl{columns_size, max_bins, ft, use_group, col_split, n_threads} {
     monitor_.Init(__func__);
     sketches_.resize(columns_size.size());
     size_t i = 0;

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -897,6 +897,10 @@ class SketchContainerImpl {
   void PushRowPage(SparsePage const &page, MetaInfo const &info, Span<float const> hessian = {});
 
   void MakeCuts(HistogramCuts* cuts);
+
+ private:
+  // Merge all categories from other workers.
+  void AllreduceCategories();
 };
 
 class HostSketchContainer : public SketchContainerImpl<WQuantileSketch<float, float>> {

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -897,10 +897,7 @@ DMatrix* DMatrix::Load(const std::string& uri, bool silent, DataSplitMode data_s
     if (!cache_file.empty()) {
       LOG(FATAL) << "Column-wise data split is not support for external memory.";
     }
-    auto slice_cols = (dmat->Info().num_col_ + 1) / npart;
-    auto slice_start = slice_cols * partid;
-    auto size = std::min(slice_cols, dmat->Info().num_col_ - slice_start);
-    auto* sliced = dmat->SliceCol(slice_start, size);
+    auto* sliced = dmat->SliceCol(npart, partid);
     delete dmat;
     return sliced;
   } else {

--- a/src/data/iterative_dmatrix.cc
+++ b/src/data/iterative_dmatrix.cc
@@ -172,9 +172,9 @@ void IterativeDMatrix::InitFromCPU(DataIterHandle iter_handle, float missing,
     size_t i = 0;
     while (iter.Next()) {
       if (!p_sketch) {
-        p_sketch.reset(new common::HostSketchContainer{batch_param_.max_bin,
-                                                       proxy->Info().feature_types.ConstHostSpan(),
-                                                       column_sizes, false, ctx_.Threads()});
+        p_sketch.reset(new common::HostSketchContainer{
+            batch_param_.max_bin, proxy->Info().feature_types.ConstHostSpan(), column_sizes, false,
+            proxy->Info().data_split_mode == DataSplitMode::kCol, ctx_.Threads()});
       }
       HostAdapterDispatch(proxy, [&](auto const& batch) {
         proxy->Info().num_nonzero_ = batch_nnz[i];

--- a/src/data/iterative_dmatrix.h
+++ b/src/data/iterative_dmatrix.h
@@ -86,7 +86,7 @@ class IterativeDMatrix : public DMatrix {
     LOG(FATAL) << "Slicing DMatrix is not supported for Quantile DMatrix.";
     return nullptr;
   }
-  DMatrix *SliceCol(std::size_t, std::size_t) override {
+  DMatrix *SliceCol(int num_slices, int slice_id) override {
     LOG(FATAL) << "Slicing DMatrix columns is not supported for Quantile DMatrix.";
     return nullptr;
   }

--- a/src/data/proxy_dmatrix.h
+++ b/src/data/proxy_dmatrix.h
@@ -87,7 +87,7 @@ class DMatrixProxy : public DMatrix {
     LOG(FATAL) << "Slicing DMatrix is not supported for Proxy DMatrix.";
     return nullptr;
   }
-  DMatrix* SliceCol(std::size_t, std::size_t) override {
+  DMatrix* SliceCol(int num_slices, int slice_id) override {
     LOG(FATAL) << "Slicing DMatrix columns is not supported for Proxy DMatrix.";
     return nullptr;
   }

--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -35,7 +35,7 @@ class SimpleDMatrix : public DMatrix {
 
   bool SingleColBlock() const override { return true; }
   DMatrix* Slice(common::Span<int32_t const> ridxs) override;
-  DMatrix* SliceCol(std::size_t start, std::size_t size) override;
+  DMatrix* SliceCol(int num_slices, int slice_id) override;
 
   /*! \brief magic number used to identify SimpleDMatrix binary files */
   static const int kMagic = 0xffffab01;

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -107,7 +107,7 @@ class SparsePageDMatrix : public DMatrix {
     LOG(FATAL) << "Slicing DMatrix is not supported for external memory.";
     return nullptr;
   }
-  DMatrix *SliceCol(std::size_t, std::size_t) override {
+  DMatrix *SliceCol(int num_slices, int slice_id) override {
     LOG(FATAL) << "Slicing DMatrix columns is not supported for external memory.";
     return nullptr;
   }

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -148,17 +148,17 @@ void DoTestDistributedQuantile(size_t rows, size_t cols) {
 
   EXPECT_EQ(sptrs.size(), dptrs.size());
   for (size_t i = 0; i < sptrs.size(); ++i) {
-    EXPECT_EQ(sptrs[i], dptrs[i]) << i;
+    EXPECT_EQ(sptrs[i], dptrs[i]) << "rank: " << rank << ", i: " << i;
   }
 
   EXPECT_EQ(svals.size(), dvals.size());
   for (size_t i = 0; i < svals.size(); ++i) {
-    EXPECT_NEAR(svals[i], dvals[i], 2e-2f) << i;
+    EXPECT_NEAR(svals[i], dvals[i], 2e-2f) << "rank: " << rank << ", i: " << i;
   }
 
   EXPECT_EQ(smins.size(), dmins.size());
   for (size_t i = 0; i < smins.size(); ++i) {
-    EXPECT_FLOAT_EQ(smins[i], dmins[i]) << i;
+    EXPECT_FLOAT_EQ(smins[i], dmins[i]) << "rank: " << rank << ", i: " << i;
   }
 }
 

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -146,19 +146,19 @@ void DoTestDistributedQuantile(size_t rows, size_t cols) {
   auto const& smins = single_node_cuts.MinValues();
   auto const& dmins = distributed_cuts.MinValues();
 
-  ASSERT_EQ(sptrs.size(), dptrs.size());
+  EXPECT_EQ(sptrs.size(), dptrs.size());
   for (size_t i = 0; i < sptrs.size(); ++i) {
-    ASSERT_EQ(sptrs[i], dptrs[i]) << i;
+    EXPECT_EQ(sptrs[i], dptrs[i]) << i;
   }
 
-  ASSERT_EQ(svals.size(), dvals.size());
+  EXPECT_EQ(svals.size(), dvals.size());
   for (size_t i = 0; i < svals.size(); ++i) {
-    ASSERT_NEAR(svals[i], dvals[i], 2e-2f);
+    EXPECT_NEAR(svals[i], dvals[i], 2e-2f) << i;
   }
 
-  ASSERT_EQ(smins.size(), dmins.size());
+  EXPECT_EQ(smins.size(), dmins.size());
   for (size_t i = 0; i < smins.size(); ++i) {
-    ASSERT_FLOAT_EQ(smins[i], dmins[i]);
+    EXPECT_FLOAT_EQ(smins[i], dmins[i]) << i;
   }
 }
 
@@ -262,17 +262,17 @@ void TestSameOnAllWorkers() {
         for (int32_t i = 0; i < world; i++) {
           for (size_t j = 0; j < value_size; ++j) {
             size_t idx = i * value_size + j;
-            ASSERT_NEAR(cuts.Values().at(j), cut_values.at(idx), kRtEps);
+            EXPECT_NEAR(cuts.Values().at(j), cut_values.at(idx), kRtEps);
           }
 
           for (size_t j = 0; j < ptr_size; ++j) {
             size_t idx = i * ptr_size + j;
-            ASSERT_EQ(cuts.Ptrs().at(j), cut_ptrs.at(idx));
+            EXPECT_EQ(cuts.Ptrs().at(j), cut_ptrs.at(idx));
           }
 
           for (size_t j = 0; j < min_value_size; ++j) {
             size_t idx = i * min_value_size + j;
-            ASSERT_EQ(cuts.MinValues().at(j), cut_min_values.at(idx));
+            EXPECT_EQ(cuts.MinValues().at(j), cut_min_values.at(idx));
           }
         }
       });

--- a/tests/cpp/common/test_quantile.h
+++ b/tests/cpp/common/test_quantile.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "../helpers.h"
-#include "../../src/collective/communicator-inl.h"
 
 namespace xgboost {
 namespace common {

--- a/tests/cpp/data/test_simple_dmatrix.cc
+++ b/tests/cpp/data/test_simple_dmatrix.cc
@@ -338,10 +338,10 @@ TEST(SimpleDMatrix, SliceCol) {
   auto& margin = p_m->Info().base_margin_;
   margin = decltype(p_m->Info().base_margin_){{kRows, kClasses}, Context::kCpuId};
 
-  size_t constexpr kSlicCols {4};
-  for (auto slice = 0; slice < 2; slice++) {
-    auto const slice_start = slice * kSlicCols;
-    std::unique_ptr<DMatrix> out { p_m->SliceCol(slice_start, kSlicCols) };
+  auto constexpr kSlices {2};
+  auto constexpr kSliceSize {4};
+  for (auto slice = 0; slice < kSlices; slice++) {
+    std::unique_ptr<DMatrix> out { p_m->SliceCol(kSlices, slice) };
     ASSERT_EQ(out->Info().labels.Size(), kRows);
     ASSERT_EQ(out->Info().labels_lower_bound_.Size(), kRows);
     ASSERT_EQ(out->Info().labels_upper_bound_.Size(), kRows);
@@ -355,7 +355,8 @@ TEST(SimpleDMatrix, SliceCol) {
           auto out_inst = out_page[i];
           auto in_inst = in_page[i];
           ASSERT_EQ(out_inst.size() * 2, in_inst.size()) << i;
-          for (size_t j = 0; j < kSlicCols; ++j) {
+          for (size_t j = 0; j < kSliceSize; ++j) {
+            auto const slice_start = kSliceSize * slice;
             ASSERT_EQ(in_inst[slice_start + j].fvalue, out_inst[j].fvalue);
             ASSERT_EQ(in_inst[slice_start + j].index, out_inst[j].index);
           }
@@ -377,7 +378,7 @@ TEST(SimpleDMatrix, SliceCol) {
 
     ASSERT_EQ(out->Info().num_col_, out->Info().num_col_);
     ASSERT_EQ(out->Info().num_row_, kRows);
-    ASSERT_EQ(out->Info().num_nonzero_, kRows * kSlicCols);  // dense
+    ASSERT_EQ(out->Info().num_nonzero_, kRows * kSliceSize);  // dense
     ASSERT_EQ(out->Info().data_split_mode, DataSplitMode::kCol);
   }
 }

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -97,7 +97,6 @@ void TestColumnSplitPredictBatch() {
   auto dmat = RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
   auto const world_size = collective::GetWorldSize();
   auto const rank = collective::GetRank();
-  auto const kSliceSize = (kCols + 1) / world_size;
 
   auto lparam = CreateEmptyGenericParam(GPUIDX);
   std::unique_ptr<Predictor> cpu_predictor =
@@ -112,7 +111,7 @@ void TestColumnSplitPredictBatch() {
   // Test predict batch
   PredictionCacheEntry out_predictions;
   cpu_predictor->InitOutPredictions(dmat->Info(), &out_predictions.predictions, model);
-  auto sliced = std::unique_ptr<DMatrix>{dmat->SliceCol(rank * kSliceSize, kSliceSize)};
+  auto sliced = std::unique_ptr<DMatrix>{dmat->SliceCol(world_size, rank)};
   cpu_predictor->PredictBatch(sliced.get(), &out_predictions, model, 0);
 
   std::vector<float>& out_predictions_h = out_predictions.predictions.HostVector();


### PR DESCRIPTION
When doing quantile sketch with column-wise split data, we only need to sketch columns available locally, there is no need to synchronize the cuts across all the workers. Later on when we evaluate the splits, we also only need to evaluate on locally available columns, and then synchronize across the workers to find the global best split.

This PR also changes the `DMatrix::SliceCol` method slightly since we always split the columns into n (roughly) equal parts, so that we don't have to repeat the slice index calculation everywhere.