### PR TITLE
Fix feature types param

### DIFF
--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -147,7 +147,7 @@ _unsupported_predict_params = {
 _unsupported_params_hint_message = {
     "enable_categorical":
         "`xgboost.spark` estimators do not have 'enable_categorical' param, but you can "
-        "set `feature_types` params and mark categorical feature with 'c' string. "
+        "set `feature_types` param and mark categorical features with 'c' string. "
 }
 
 # Global prediction names

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -143,6 +143,13 @@ _unsupported_predict_params = {
     "base_margin",  # Use pyspark base_margin_col param instead.
 }
 
+# TODO: supply hint message for all other unsupported params.
+_unsupported_params_hint_message = {
+    "enable_categorical":
+        "`xgboost.spark` estimators do not have 'enable_categorical' param, but you can "
+        "set `feature_types` params and mark categorical feature with 'c' string. "
+}
+
 # Global prediction names
 Pred = namedtuple(
     "Pred", ("prediction", "raw_prediction", "probability", "pred_contrib")
@@ -540,7 +547,10 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
                     or k in _unsupported_predict_params
                     or k in _unsupported_train_params
                 ):
-                    raise ValueError(f"Unsupported param '{k}'.")
+                    err_msg = _unsupported_params_hint_message.get(
+                        k, f"Unsupported param '{k}'."
+                    )
+                    raise ValueError(err_msg)
                 _extra_params[k] = v
         _existing_extra_params = self.getOrDefault(self.arbitrary_params_dict)
         self._set(arbitrary_params_dict={**_existing_extra_params, **_extra_params})

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -145,9 +145,8 @@ _unsupported_predict_params = {
 
 # TODO: supply hint message for all other unsupported params.
 _unsupported_params_hint_message = {
-    "enable_categorical":
-        "`xgboost.spark` estimators do not have 'enable_categorical' param, but you can "
-        "set `feature_types` param and mark categorical features with 'c' string. "
+    "enable_categorical": "`xgboost.spark` estimators do not have 'enable_categorical' param, "
+    "but you can set `feature_types` param and mark categorical features with 'c' string."
 }
 
 # Global prediction names

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -780,6 +780,8 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
             "feature_weights": self.getOrDefault(self.feature_weights),
             "missing": float(self.getOrDefault(self.missing)),
         }
+        if dmatrix_kwargs["feature_types"] is not None:
+            dmatrix_kwargs["enable_categorical"] = True
         booster_params["nthread"] = cpu_per_task
 
         # Remove the parameters whose value is None


### PR DESCRIPTION
Fix feature types param:
If user provides feature_types param, we should set 'enable_categorical' param as `True` when constructing `DMatrix`.

closes https://github.com/dmlc/xgboost/issues/8766
