### PR TITLE
fix inconsistent doc and minor typo for external memory

### DIFF
--- a/doc/tutorials/external_memory.rst
+++ b/doc/tutorials/external_memory.rst
@@ -63,7 +63,7 @@ constructor.
   booster = xgboost.train({"tree_method": "approx"}, Xy)
 
 
-The above snippet is a simplifed version of ``demo/guide-python/external_memory.py``.  For
+The above snippet is a simplified version of ``demo/guide-python/external_memory.py``.  For
 an example in C, please see ``demo/c-api/external-memory/``.
 
 ****************

--- a/doc/tutorials/external_memory.rst
+++ b/doc/tutorials/external_memory.rst
@@ -46,7 +46,7 @@ constructor.
       # input_data is a function passed in by XGBoost who has the exact same signature of
       # ``DMatrix``
       X, y = load_svmlight_file(self._file_paths[self._it])
-      input_data(X, y)
+      input_data(data=X, label=y)
       self._it += 1
       # Return 1 to let XGBoost know we haven't seen all the files yet.
       return 1


### PR DESCRIPTION
Current [doc](https://xgboost.readthedocs.io/en/stable/tutorials/external_memory.html) is using `input_data` without **keyword arguments**.
https://github.com/dmlc/xgboost/blob/199c421d60d375eda169cd1715f5beba95b5b86d/doc/tutorials/external_memory.rst#L49
As shown below, it mentioned it's simplified version of `demo/guide-python/external_memory.py`
https://github.com/dmlc/xgboost/blob/199c421d60d375eda169cd1715f5beba95b5b86d/doc/tutorials/external_memory.rst#L66
but it's actually different from the file mentioned as follows:
https://github.com/dmlc/xgboost/blob/199c421d60d375eda169cd1715f5beba95b5b86d/demo/guide-python/external_memory.py#L67

I've found errors may occur like the one in #8202 if following the current doc. Not sure if it's better to update the doc to make it consistent with the `demo/guide-python/external_memory.py` to avoid any possible error for the users.