### PR TITLE
Fixes compilation errors on MSVC x86 targets

### DIFF
--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -151,7 +151,7 @@ inline LINALG_HD int Popc(uint64_t v) {
   return __popcll(v);
 #elif defined(__GNUC__) || defined(__clang__)
   return __builtin_popcountll(v);
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && _defined(_M_X64)
   return __popcnt64(v);
 #else
   return NativePopc(v);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -455,7 +455,7 @@ XGB_DLL int XGDMatrixCreateFromCSC(char const *indptr, char const *indices, char
   xgboost_CHECK_C_ARG_PTR(indptr);
   xgboost_CHECK_C_ARG_PTR(indices);
   xgboost_CHECK_C_ARG_PTR(data);
-  data::CSCArrayAdapter adapter{StringView{indptr}, StringView{indices}, StringView{data}, nrow};
+  data::CSCArrayAdapter adapter{StringView{indptr}, StringView{indices}, StringView{data}, (std::size_t)nrow};
   xgboost_CHECK_C_ARG_PTR(c_json_config);
   auto config = Json::Load(StringView{c_json_config});
   float missing = GetMissing(config);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -455,7 +455,8 @@ XGB_DLL int XGDMatrixCreateFromCSC(char const *indptr, char const *indices, char
   xgboost_CHECK_C_ARG_PTR(indptr);
   xgboost_CHECK_C_ARG_PTR(indices);
   xgboost_CHECK_C_ARG_PTR(data);
-  data::CSCArrayAdapter adapter{StringView{indptr}, StringView{indices}, StringView{data}, (std::size_t)nrow};
+  data::CSCArrayAdapter adapter{StringView{indptr}, StringView{indices}, StringView{data},
+                                static_cast<std::size_t>(nrow)};
   xgboost_CHECK_C_ARG_PTR(c_json_config);
   auto config = Json::Load(StringView{c_json_config});
   float missing = GetMissing(config);

--- a/src/objective/quantile_obj.cu
+++ b/src/objective/quantile_obj.cu
@@ -81,7 +81,8 @@ class QuantileRegression : public ObjFunction {
     linalg::ElementWiseKernel(
         ctx_, gpair, [=] XGBOOST_DEVICE(std::size_t i, GradientPair const&) mutable {
           auto idx = linalg::UnravelIndex(static_cast<std::size_t>(i),
-                                          {static_cast<std::size_t>(n_samples), static_cast<std::size_t>(alpha.size()),
+                                          {static_cast<std::size_t>(n_samples),
+                                           static_cast<std::size_t>(alpha.size()),
                                            static_cast<std::size_t>(n_targets / alpha.size())});
 
           // std::tie is not available for cuda kernel.

--- a/src/objective/quantile_obj.cu
+++ b/src/objective/quantile_obj.cu
@@ -80,9 +80,9 @@ class QuantileRegression : public ObjFunction {
 
     linalg::ElementWiseKernel(
         ctx_, gpair, [=] XGBOOST_DEVICE(std::size_t i, GradientPair const&) mutable {
-          auto idx = linalg::UnravelIndex(
-              (std::size_t)i, {(std::size_t)n_samples, static_cast<SizeT>((std::size_t)alpha.size()),
-                               (std::size_t)(n_targets / alpha.size())});
+          auto idx = linalg::UnravelIndex(static_cast<std::size_t>(i),
+                                          {static_cast<std::size_t>(n_samples), static_cast<std::size_t>(alpha.size()),
+                                           static_cast<std::size_t>(n_targets / alpha.size())});
 
           // std::tie is not available for cuda kernel.
           std::size_t sample_id = std::get<0>(idx);

--- a/src/objective/quantile_obj.cu
+++ b/src/objective/quantile_obj.cu
@@ -81,7 +81,9 @@ class QuantileRegression : public ObjFunction {
     linalg::ElementWiseKernel(
         ctx_, gpair, [=] XGBOOST_DEVICE(std::size_t i, GradientPair const&) mutable {
           auto idx = linalg::UnravelIndex(
-              i, {n_samples, static_cast<SizeT>(alpha.size()), n_targets / alpha.size()});
+              (std::size_t)i, {(std::size_t)n_samples, static_cast<SizeT>((std::size_t)alpha.size()),
+                               (std::size_t)(n_targets / alpha.size())});
+
           // std::tie is not available for cuda kernel.
           std::size_t sample_id = std::get<0>(idx);
           std::size_t quantile_id = std::get<1>(idx);

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -164,7 +164,7 @@ struct GHistIndexMatrixView {
   SparsePage::Inst operator[](size_t r) {
     auto t = omp_get_thread_num();
     auto const beg = (n_features_ * kUnroll * t) + (current_unroll_[t] * n_features_);
-    size_t non_missing{beg};
+    size_t non_missing{(std::size_t)beg};
 
     for (bst_feature_t c = 0; c < n_features_; ++c) {
       float f = page_.GetFvalue(r, c, common::IsCat(ft_, c));
@@ -477,7 +477,7 @@ class ColumnSplitHelper {
     // auto block_id has the same type as `n_blocks`.
     common::ParallelFor(n_blocks, n_threads_, [&](auto block_id) {
       auto const batch_offset = block_id * block_of_rows_size;
-      auto const block_size = std::min(nsize - batch_offset, block_of_rows_size);
+      auto const block_size = std::min((std::size_t)(nsize - batch_offset), (std::size_t)block_of_rows_size);
       auto const fvec_offset = omp_get_thread_num() * block_of_rows_size;
 
       FVecFill(block_size, batch_offset, num_feature, &batch, fvec_offset, &feat_vecs_);
@@ -490,7 +490,7 @@ class ColumnSplitHelper {
     // auto block_id has the same type as `n_blocks`.
     common::ParallelFor(n_blocks, n_threads_, [&](auto block_id) {
       auto const batch_offset = block_id * block_of_rows_size;
-      auto const block_size = std::min(nsize - batch_offset, block_of_rows_size);
+      auto const block_size = std::min((std::size_t)(nsize - batch_offset), (std::size_t)block_of_rows_size);
       PredictAllTrees(out_preds, batch_offset, batch_offset + batch.base_rowid, num_group,
                       block_size);
     });

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -164,7 +164,7 @@ struct GHistIndexMatrixView {
   SparsePage::Inst operator[](size_t r) {
     auto t = omp_get_thread_num();
     auto const beg = (n_features_ * kUnroll * t) + (current_unroll_[t] * n_features_);
-    size_t non_missing{(std::size_t)beg};
+    size_t non_missing{static_cast<std::size_t>(beg)};
 
     for (bst_feature_t c = 0; c < n_features_; ++c) {
       float f = page_.GetFvalue(r, c, common::IsCat(ft_, c));
@@ -477,7 +477,8 @@ class ColumnSplitHelper {
     // auto block_id has the same type as `n_blocks`.
     common::ParallelFor(n_blocks, n_threads_, [&](auto block_id) {
       auto const batch_offset = block_id * block_of_rows_size;
-      auto const block_size = std::min((std::size_t)(nsize - batch_offset), (std::size_t)block_of_rows_size);
+      auto const block_size = std::min(static_cast<std::size_t>(nsize - batch_offset),
+                                       static_cast<std::size_t>(block_of_rows_size));
       auto const fvec_offset = omp_get_thread_num() * block_of_rows_size;
 
       FVecFill(block_size, batch_offset, num_feature, &batch, fvec_offset, &feat_vecs_);
@@ -490,7 +491,8 @@ class ColumnSplitHelper {
     // auto block_id has the same type as `n_blocks`.
     common::ParallelFor(n_blocks, n_threads_, [&](auto block_id) {
       auto const batch_offset = block_id * block_of_rows_size;
-      auto const block_size = std::min((std::size_t)(nsize - batch_offset), (std::size_t)block_of_rows_size);
+      auto const block_size = std::min(static_cast<std::size_t>(nsize - batch_offset),
+                                       static_cast<std::size_t>(block_of_rows_size));
       PredictAllTrees(out_preds, batch_offset, batch_offset + batch.base_rowid, num_group,
                       block_size);
     });


### PR DESCRIPTION
This PR aims to fix compilation issues found when targeting 32-bit on MSVC.

`__popcnt64` is not available on x86 and, for the rest of the fixes, MSVC does not like narrowing without explicit conversion.