### PR TITLE
Update eval_metric validation to support list of strings

### DIFF
--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -314,6 +314,7 @@ class _SparkXGBParams(
                 raise ValueError("Only string type 'objective' param is allowed.")
 
         if self.getOrDefault(self.eval_metric) is not None:
+            if not (
                 isinstance(self.getOrDefault(self.eval_metric), str)
                 or (isinstance(self.getOrDefault(self.eval_metric), List)
                     and all(isinstance(metric, str) for metric in self.getOrDefault(self.eval_metric)))

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -316,10 +316,17 @@ class _SparkXGBParams(
         if self.getOrDefault(self.eval_metric) is not None:
             if not (
                 isinstance(self.getOrDefault(self.eval_metric), str)
-                or (isinstance(self.getOrDefault(self.eval_metric), List)
-                    and all(isinstance(metric, str) for metric in self.getOrDefault(self.eval_metric)))
+                or (
+                    isinstance(self.getOrDefault(self.eval_metric), List)
+                    and all(
+                        isinstance(metric, str)
+                        for metric in self.getOrDefault(self.eval_metric)
+                    )
+                )
             ):
-                raise ValueError("Only string type or list of string type 'eval_metric' param is allowed.")
+                raise ValueError(
+                    "Only string type or list of string type 'eval_metric' param is allowed."
+                )
 
         if self.getOrDefault(self.early_stopping_rounds) is not None:
             if not (
@@ -601,7 +608,7 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
         start += len("== Optimized Logical Plan ==") + 1
         num_workers = self.getOrDefault(self.num_workers)
         if (
-            query_plan[start: start + len("Repartition")] == "Repartition"
+            query_plan[start : start + len("Repartition")] == "Repartition"
             and num_workers == num_partitions
         ):
             return True

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -313,10 +313,6 @@ class _SparkXGBParams(
             if not isinstance(self.getOrDefault(self.objective), str):
                 raise ValueError("Only string type 'objective' param is allowed.")
 
-        if self.getOrDefault(self.eval_metric) is not None:
-            if not isinstance(self.getOrDefault(self.eval_metric), str):
-                raise ValueError("Only string type 'eval_metric' param is allowed.")
-
         if self.getOrDefault(self.early_stopping_rounds) is not None:
             if not (
                 self.isDefined(self.validationIndicatorCol)

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -313,6 +313,13 @@ class _SparkXGBParams(
             if not isinstance(self.getOrDefault(self.objective), str):
                 raise ValueError("Only string type 'objective' param is allowed.")
 
+        if self.getOrDefault(self.eval_metric) is not None:
+                isinstance(self.getOrDefault(self.eval_metric), str)
+                or (isinstance(self.getOrDefault(self.eval_metric), List)
+                    and all(isinstance(metric, str) for metric in self.getOrDefault(self.eval_metric)))
+            ):
+                raise ValueError("Only string type or list of string type 'eval_metric' param is allowed.")
+
         if self.getOrDefault(self.early_stopping_rounds) is not None:
             if not (
                 self.isDefined(self.validationIndicatorCol)
@@ -593,7 +600,7 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
         start += len("== Optimized Logical Plan ==") + 1
         num_workers = self.getOrDefault(self.num_workers)
         if (
-            query_plan[start : start + len("Repartition")] == "Repartition"
+            query_plan[start: start + len("Repartition")] == "Repartition"
             and num_workers == num_partitions
         ):
             return True

--- a/tests/test_distributed/test_with_spark/test_spark_local.py
+++ b/tests/test_distributed/test_with_spark/test_spark_local.py
@@ -730,6 +730,16 @@ class TestPySparkLocal:
         train_params = py_cls._get_distributed_train_params(clf_data.cls_df_train)
         assert train_params["tree_method"] == "gpu_hist"
 
+    def test_classifier_with_list_eval_metric(self, clf_data: ClfData) -> None:
+        classifier = SparkXGBClassifier(eval_metric=["auc", "rmse"])
+        model = classifier.fit(clf_data.cls_df_train)
+        model.transform(clf_data.cls_df_test).collect()
+
+    def test_classifier_with_string_eval_metric(self, clf_data: ClfData) -> None:
+        classifier = SparkXGBClassifier(eval_metric="auc")
+        model = classifier.fit(clf_data.cls_df_train)
+        model.transform(clf_data.cls_df_test).collect()
+
 
 class XgboostLocalTest(SparkTestCase):
     def setUp(self):


### PR DESCRIPTION
Hey guys, I find that SparkXGB estimators do not support multiple evaluation metric because of param validation. 

In this PR, I deleted the param validation for eval_metrics.