### PR TITLE
Disable gcc parallel extension if openmp is not available.

### DIFF
--- a/src/common/algorithm.h
+++ b/src/common/algorithm.h
@@ -13,7 +13,8 @@
 #include "xgboost/context.h"  // Context
 
 // clang with libstdc++ works as well
-#if defined(__GNUC__) && (__GNUC__ >= 4) && !defined(__sun) && !defined(sun) && !defined(__APPLE__)
+#if defined(__GNUC__) && (__GNUC__ >= 4) && !defined(__sun) && !defined(sun) && \
+    !defined(__APPLE__) && __has_include(<omp.h>)
 #define GCC_HAS_PARALLEL 1
 #endif  // GLIC_VERSION
 


### PR DESCRIPTION
`<parallel/algorithm>` internally includes the <omp.h> header, which leads to an error when openmp is not available.