### PR TITLE
[R] update `predict` docs (fixes #8869)

### DIFF
--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -214,6 +214,10 @@ xgb.Booster.complete <- function(object, saveraw = TRUE) {
 #' Since it quadratically depends on the number of features, it is recommended to perform selection
 #' of the most important features first. See below about the format of the returned results.
 #'
+#' The \code{predict()} method uses as many threads as defined in \code{xgb.Booster} object (all by default).
+#' If you want to change their number, then assign a new number to \code{nthread} using \code{\link{xgb.parameters<-}}.
+#' Note also that converting a matrix to \code{\link{xgb.DMatrix}} uses multiple threads too.
+#'
 #' @return
 #' The return type is different depending whether \code{strict_shape} is set to \code{TRUE}.  By default,
 #' for regression or binary classification, it returns a vector of length \code{nrows(newdata)}.

--- a/R-package/man/predict.xgb.Booster.Rd
+++ b/R-package/man/predict.xgb.Booster.Rd
@@ -122,6 +122,10 @@ With \code{predinteraction = TRUE}, SHAP values of contributions of interaction 
 are computed. Note that this operation might be rather expensive in terms of compute and memory.
 Since it quadratically depends on the number of features, it is recommended to perform selection
 of the most important features first. See below about the format of the returned results.
+
+The \code{predict()} method uses as many threads as defined in \code{xgb.Booster} object (all by default).
+If you want to change their number, then assign a new number to \code{nthread} using \code{\link{xgb.parameters<-}}.
+Note also that converting a matrix to \code{\link{xgb.DMatrix}} uses multiple threads too.
 }
 \examples{
 ## binary classification:


### PR DESCRIPTION
I wanted to rebuild Rd documentation in RStudio, but I got this error:

```
xgboost_R.cc:4:10: fatal error: dmlc/common.h: No such file or directory
    4 | #include <dmlc/common.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
```

But in general this PR should work.