### PR TITLE
Remove the cub submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,9 +2,6 @@
 	path = dmlc-core
 	url = https://github.com/dmlc/dmlc-core
 	branch = main
-[submodule "cub"]
-	path = cub
-	url = https://github.com/NVlabs/cub
 [submodule "gputreeshap"]
 	path = gputreeshap
 	url = https://github.com/rapidsai/gputreeshap.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,6 @@ option(HIDE_CXX_SYMBOLS "Build shared library and hide all C++ symbols" OFF)
 option(USE_CUDA  "Build with GPU acceleration" OFF)
 option(USE_NCCL  "Build with NCCL to enable distributed GPU support." OFF)
 option(BUILD_WITH_SHARED_NCCL "Build with shared NCCL library." OFF)
-option(BUILD_WITH_CUDA_CUB "Build with cub in CUDA installation" OFF)
 set(GPU_COMPUTE_VER "" CACHE STRING
   "Semicolon separated list of compute versions to be built against, e.g. '35;61'")
 ## Copied From dmlc
@@ -115,9 +114,6 @@ endif (ENABLE_ALL_WARNINGS)
 if (BUILD_STATIC_LIB AND (R_LIB OR JVM_BINDINGS))
   message(SEND_ERROR "Cannot build a static library libxgboost.a when R or JVM packages are enabled.")
 endif (BUILD_STATIC_LIB AND (R_LIB OR JVM_BINDINGS))
-if (PLUGIN_RMM AND (NOT BUILD_WITH_CUDA_CUB))
-  message(SEND_ERROR "Cannot build with RMM using cub submodule.")
-endif (PLUGIN_RMM AND (NOT BUILD_WITH_CUDA_CUB))
 if (PLUGIN_FEDERATED)
   if (CMAKE_CROSSCOMPILING)
     message(SEND_ERROR "Cannot cross compile with federated learning support")
@@ -152,10 +148,6 @@ if (USE_CUDA)
   set(GEN_CODE "")
   format_gencode_flags("${GPU_COMPUTE_VER}" GEN_CODE)
   add_subdirectory(${PROJECT_SOURCE_DIR}/gputreeshap)
-
-  if ((${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 11.4) AND (NOT BUILD_WITH_CUDA_CUB))
-    set(BUILD_WITH_CUDA_CUB ON)
-  endif ()
 endif (USE_CUDA)
 
 if (FORCE_COLORED_OUTPUT AND (CMAKE_GENERATOR STREQUAL "Ninja") AND

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -165,13 +165,8 @@ function(xgboost_set_cuda_flags target)
     enable_nvtx(${target})
   endif (USE_NVTX)
 
-  if (NOT BUILD_WITH_CUDA_CUB)
-    target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_CUDA=1 -DTHRUST_IGNORE_CUB_VERSION_CHECK=1)
-    target_include_directories(${target} PRIVATE ${xgboost_SOURCE_DIR}/cub/ ${xgboost_SOURCE_DIR}/gputreeshap)
-  else ()
-    target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_CUDA=1)
-    target_include_directories(${target} PRIVATE ${xgboost_SOURCE_DIR}/gputreeshap)
-  endif (NOT BUILD_WITH_CUDA_CUB)
+  target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_CUDA=1)
+  target_include_directories(${target} PRIVATE ${xgboost_SOURCE_DIR}/gputreeshap)
 
   if (MSVC)
     target_compile_options(${target} PRIVATE

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -128,8 +128,7 @@ From the command line on Linux starting from the XGBoost directory:
 
   mkdir build
   cd build
-  # For CUDA toolkit >= 11.4, `BUILD_WITH_CUDA_CUB` is required.
-  cmake .. -DUSE_CUDA=ON -DBUILD_WITH_CUDA_CUB=ON
+  cmake .. -DUSE_CUDA=ON
   make -j4
 
 .. note:: Specifying compute capability

--- a/plugin/federated/README.md
+++ b/plugin/federated/README.md
@@ -15,7 +15,6 @@ mkdir build
 cd build
 cmake .. -GNinja \
  -DPLUGIN_FEDERATED=ON \
- -DBUILD_WITH_CUDA_CUB=ON \
  -DUSE_CUDA=ON\
  -DUSE_NCCL=ON
 ninja

--- a/tests/buildkite/build-cuda-with-rmm.sh
+++ b/tests/buildkite/build-cuda-with-rmm.sh
@@ -20,7 +20,7 @@ command_wrapper="tests/ci_build/ci_build.sh rmm docker --build-arg "`
 
 echo "--- Build libxgboost from the source"
 $command_wrapper tests/ci_build/build_via_cmake.sh --conda-env=gpu_test -DUSE_CUDA=ON \
-  -DUSE_NCCL=ON -DPLUGIN_RMM=ON -DBUILD_WITH_CUDA_CUB=ON ${arch_flag}
+  -DUSE_NCCL=ON -DPLUGIN_RMM=ON ${arch_flag}
 
 echo "-- Stash C++ test executable (testxgboost)"
 buildkite-agent artifact upload build/testxgboost


### PR DESCRIPTION
XGBoost now uses CTK-11.8 for binary packages, there's no need to maintain a cub submodule anymore.