### PR TITLE
Remove public access to tree model param.

### DIFF
--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -360,8 +360,8 @@ void GBTree::BoostNewTrees(HostDeviceVector<GradientPair>* gpair, DMatrix* p_fma
           << "Set `process_type` to `update` if you want to update existing "
              "trees.";
       // create new tree
-      std::unique_ptr<RegTree> ptr(new RegTree());
-      ptr->param.UpdateAllowUnknown(this->cfg_);
+      std::unique_ptr<RegTree> ptr(new RegTree{this->model_.learner_model_param->LeafLength(),
+                                               this->model_.learner_model_param->num_feature});
       new_trees.push_back(ptr.get());
       ret->push_back(std::move(ptr));
     } else if (tparam_.process_type == TreeProcessType::kUpdate) {

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -775,8 +775,6 @@ class LearnerConfiguration : public Learner {
     }
     CHECK_NE(mparam_.num_feature, 0)
         << "0 feature is supplied.  Are you using raw Booster interface?";
-    // Remove these once binary IO is gone.
-    cfg_["num_feature"] = common::ToString(mparam_.num_feature);
   }
 
   void ConfigureGBM(LearnerTrainParam const& old, Args const& args) {

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -275,7 +275,7 @@ float FillNodeMeanValues(RegTree const *tree, bst_node_t nidx, std::vector<float
 }
 
 void FillNodeMeanValues(RegTree const* tree, std::vector<float>* mean_values) {
-  size_t num_nodes = tree->param.num_nodes;
+  size_t num_nodes = tree->NumNodes();
   if (mean_values->size() == num_nodes) {
     return;
   }

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -190,7 +190,7 @@ class ColMaker: public TreeUpdater {
         (*p_tree)[nid].SetLeaf(snode_[nid].weight * param_.learning_rate);
       }
       // remember auxiliary statistics in the tree node
-      for (int nid = 0; nid < p_tree->param.num_nodes; ++nid) {
+      for (int nid = 0; nid < p_tree->NumNodes(); ++nid) {
         p_tree->Stat(nid).loss_chg = snode_[nid].best.loss_chg;
         p_tree->Stat(nid).base_weight = snode_[nid].weight;
         p_tree->Stat(nid).sum_hess = static_cast<float>(snode_[nid].stats.sum_hess);
@@ -255,9 +255,9 @@ class ColMaker: public TreeUpdater {
       {
         // setup statistics space for each tree node
         for (auto& i : stemp_) {
-          i.resize(tree.param.num_nodes, ThreadEntry());
+          i.resize(tree.NumNodes(), ThreadEntry());
         }
-        snode_.resize(tree.param.num_nodes, NodeEntry());
+        snode_.resize(tree.NumNodes(), NodeEntry());
       }
       const MetaInfo& info = fmat.Info();
       // setup position

--- a/src/tree/updater_prune.cc
+++ b/src/tree/updater_prune.cc
@@ -72,7 +72,7 @@ class TreePruner : public TreeUpdater {
   void DoPrune(TrainParam const* param, RegTree* p_tree) {
     auto& tree = *p_tree;
     bst_node_t npruned = 0;
-    for (int nid = 0; nid < tree.param.num_nodes; ++nid) {
+    for (int nid = 0; nid < tree.NumNodes(); ++nid) {
       if (tree[nid].IsLeaf() && !tree[nid].IsDeleted()) {
         npruned = this->TryPruneLeaf(param, p_tree, nid, tree.GetDepth(nid), npruned);
       }

--- a/src/tree/updater_refresh.cc
+++ b/src/tree/updater_refresh.cc
@@ -50,11 +50,11 @@ class TreeRefresher : public TreeUpdater {
         int tid = omp_get_thread_num();
         int num_nodes = 0;
         for (auto tree : trees) {
-          num_nodes += tree->param.num_nodes;
+          num_nodes += tree->NumNodes();
         }
         stemp[tid].resize(num_nodes, GradStats());
         std::fill(stemp[tid].begin(), stemp[tid].end(), GradStats());
-        fvec_temp[tid].Init(trees[0]->param.num_feature);
+        fvec_temp[tid].Init(trees[0]->NumFeatures());
       });
     }
     exc.Rethrow();
@@ -77,7 +77,7 @@ class TreeRefresher : public TreeUpdater {
           for (auto tree : trees) {
             AddStats(*tree, feats, gpair_h, info, ridx,
                      dmlc::BeginPtr(stemp[tid]) + offset);
-            offset += tree->param.num_nodes;
+            offset += tree->NumNodes();
           }
           feats.Drop(inst);
         });
@@ -96,7 +96,7 @@ class TreeRefresher : public TreeUpdater {
     int offset = 0;
     for (auto tree : trees) {
       this->Refresh(param, dmlc::BeginPtr(stemp[0]) + offset, 0, tree);
-      offset += tree->param.num_nodes;
+      offset += tree->NumNodes();
     }
   }
 

--- a/tests/cpp/tree/test_histmaker.cc
+++ b/tests/cpp/tree/test_histmaker.cc
@@ -40,8 +40,7 @@ TEST(GrowHistMaker, InteractionConstraint)
   ObjInfo task{ObjInfo::kRegression};
   {
     // With constraints
-    RegTree tree;
-    tree.param.num_feature = kCols;
+    RegTree tree{1, kCols};
 
     std::unique_ptr<TreeUpdater> updater{TreeUpdater::Create("grow_histmaker", &ctx, &task)};
     TrainParam param;
@@ -58,8 +57,7 @@ TEST(GrowHistMaker, InteractionConstraint)
   }
   {
     // Without constraints
-    RegTree tree;
-    tree.param.num_feature = kCols;
+    RegTree tree{1u, kCols};
 
     std::unique_ptr<TreeUpdater> updater{TreeUpdater::Create("grow_histmaker", &ctx, &task)};
     std::vector<HostDeviceVector<bst_node_t>> position(1);
@@ -76,7 +74,7 @@ TEST(GrowHistMaker, InteractionConstraint)
 }
 
 namespace {
-void TestColumnSplit(int32_t rows, int32_t cols, RegTree const& expected_tree) {
+void TestColumnSplit(int32_t rows, bst_feature_t cols, RegTree const& expected_tree) {
   auto p_dmat = GenerateDMatrix(rows, cols);
   auto p_gradients = GenerateGradients(rows);
   Context ctx;
@@ -87,8 +85,7 @@ void TestColumnSplit(int32_t rows, int32_t cols, RegTree const& expected_tree) {
   std::unique_ptr<DMatrix> sliced{
       p_dmat->SliceCol(collective::GetWorldSize(), collective::GetRank())};
 
-  RegTree tree;
-  tree.param.num_feature = cols;
+  RegTree tree{1u, cols};
   TrainParam param;
   param.Init(Args{});
   updater->Update(&param, p_gradients.get(), sliced.get(), position, {&tree});
@@ -107,8 +104,7 @@ TEST(GrowHistMaker, ColumnSplit) {
   auto constexpr kRows = 32;
   auto constexpr kCols = 16;
 
-  RegTree expected_tree;
-  expected_tree.param.num_feature = kCols;
+  RegTree expected_tree{1u, kCols};
   ObjInfo task{ObjInfo::kRegression};
   {
     auto p_dmat = GenerateDMatrix(kRows, kCols);

--- a/tests/cpp/tree/test_multi_target_tree_model.cc
+++ b/tests/cpp/tree/test_multi_target_tree_model.cc
@@ -17,8 +17,8 @@ TEST(MultiTargetTree, JsonIO) {
   linalg::Vector<float> right_weight{{3.0f, 4.0f, 5.0f}, {3ul}, Context::kCpuId};
   tree.ExpandNode(RegTree::kRoot, /*split_idx=*/1, 0.5f, true, base_weight.HostView(),
                   left_weight.HostView(), right_weight.HostView());
-  ASSERT_EQ(tree.param.num_nodes, 3);
-  ASSERT_EQ(tree.param.size_leaf_vector, 3);
+  ASSERT_EQ(tree.NumNodes(), 3);
+  ASSERT_EQ(tree.NumTargets(), 3);
   ASSERT_EQ(tree.GetMultiTargetTree()->Size(), 3);
   ASSERT_EQ(tree.Size(), 3);
 
@@ -26,20 +26,19 @@ TEST(MultiTargetTree, JsonIO) {
   tree.SaveModel(&jtree);
 
   auto check_jtree = [](Json jtree, RegTree const& tree) {
-    ASSERT_EQ(get<String const>(jtree["tree_param"]["num_nodes"]),
-              std::to_string(tree.param.num_nodes));
+    ASSERT_EQ(get<String const>(jtree["tree_param"]["num_nodes"]), std::to_string(tree.NumNodes()));
     ASSERT_EQ(get<F32Array const>(jtree["base_weights"]).size(),
-              tree.param.num_nodes * tree.param.size_leaf_vector);
-    ASSERT_EQ(get<I32Array const>(jtree["parents"]).size(), tree.param.num_nodes);
-    ASSERT_EQ(get<I32Array const>(jtree["left_children"]).size(), tree.param.num_nodes);
-    ASSERT_EQ(get<I32Array const>(jtree["right_children"]).size(), tree.param.num_nodes);
+              tree.NumNodes() * tree.NumTargets());
+    ASSERT_EQ(get<I32Array const>(jtree["parents"]).size(), tree.NumNodes());
+    ASSERT_EQ(get<I32Array const>(jtree["left_children"]).size(), tree.NumNodes());
+    ASSERT_EQ(get<I32Array const>(jtree["right_children"]).size(), tree.NumNodes());
   };
   check_jtree(jtree, tree);
 
   RegTree loaded;
   loaded.LoadModel(jtree);
   ASSERT_TRUE(loaded.IsMultiTarget());
-  ASSERT_EQ(loaded.param.num_nodes, 3);
+  ASSERT_EQ(loaded.NumNodes(), 3);
 
   Json jtree1{Object{}};
   loaded.SaveModel(&jtree1);

--- a/tests/cpp/tree/test_prune.cc
+++ b/tests/cpp/tree/test_prune.cc
@@ -32,8 +32,7 @@ TEST(Updater, Prune) {
   auto ctx = CreateEmptyGenericParam(GPUIDX);
 
   // prepare tree
-  RegTree tree = RegTree();
-  tree.param.UpdateAllowUnknown(cfg);
+  RegTree tree = RegTree{1u, kCols};
   std::vector<RegTree*> trees {&tree};
   // prepare pruner
   TrainParam param;

--- a/tests/cpp/tree/test_refresh.cc
+++ b/tests/cpp/tree/test_refresh.cc
@@ -28,9 +28,8 @@ TEST(Updater, Refresh) {
       {"num_feature", std::to_string(kCols)},
       {"reg_lambda", "1"}};
 
-  RegTree tree = RegTree();
+  RegTree tree = RegTree{1u, kCols};
   auto ctx = CreateEmptyGenericParam(GPUIDX);
-  tree.param.UpdateAllowUnknown(cfg);
   std::vector<RegTree*> trees{&tree};
 
   ObjInfo task{ObjInfo::kRegression};

--- a/tests/cpp/tree/test_tree_model.cc
+++ b/tests/cpp/tree/test_tree_model.cc
@@ -11,9 +11,8 @@
 namespace xgboost {
 TEST(Tree, ModelShape) {
   bst_feature_t n_features = std::numeric_limits<uint32_t>::max();
-  RegTree tree;
-  tree.param.UpdateAllowUnknown(Args{{"num_feature", std::to_string(n_features)}});
-  ASSERT_EQ(tree.param.num_feature, n_features);
+  RegTree tree{1u, n_features};
+  ASSERT_EQ(tree.NumFeatures(), n_features);
 
   dmlc::TemporaryDirectory tempdir;
   const std::string tmp_file = tempdir.path + "/tree.model";
@@ -27,7 +26,7 @@ TEST(Tree, ModelShape) {
     RegTree new_tree;
     std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(tmp_file.c_str(), "r"));
     new_tree.Load(fi.get());
-    ASSERT_EQ(new_tree.param.num_feature, n_features);
+    ASSERT_EQ(new_tree.NumFeatures(), n_features);
   }
   {
     // json
@@ -39,7 +38,7 @@ TEST(Tree, ModelShape) {
 
     auto j_loaded = Json::Load(StringView{dumped.data(), dumped.size()});
     new_tree.LoadModel(j_loaded);
-    ASSERT_EQ(new_tree.param.num_feature, n_features);
+    ASSERT_EQ(new_tree.NumFeatures(), n_features);
   }
   {
     // ubjson
@@ -51,7 +50,7 @@ TEST(Tree, ModelShape) {
 
     auto j_loaded = Json::Load(StringView{dumped.data(), dumped.size()}, std::ios::binary);
     new_tree.LoadModel(j_loaded);
-    ASSERT_EQ(new_tree.param.num_feature, n_features);
+    ASSERT_EQ(new_tree.NumFeatures(), n_features);
   }
 }
 
@@ -488,8 +487,7 @@ TEST(Tree, JsonIO) {
 
   RegTree loaded_tree;
   loaded_tree.LoadModel(j_tree);
-  ASSERT_EQ(loaded_tree.param.num_nodes, 3);
-
+  ASSERT_EQ(loaded_tree.NumNodes(), 3);
   ASSERT_TRUE(loaded_tree == tree);
 
   auto left = tree[0].LeftChild();

--- a/tests/cpp/tree/test_tree_stat.cc
+++ b/tests/cpp/tree/test_tree_stat.cc
@@ -37,8 +37,7 @@ class UpdaterTreeStatTest : public ::testing::Test {
                                            : CreateEmptyGenericParam(Context::kCpuId));
     auto up = std::unique_ptr<TreeUpdater>{TreeUpdater::Create(updater, &ctx, &task)};
     up->Configure(Args{});
-    RegTree tree;
-    tree.param.num_feature = kCols;
+    RegTree tree{1u, kCols};
     std::vector<HostDeviceVector<bst_node_t>> position(1);
     up->Update(&param, &gpairs_, p_dmat_.get(), position, {&tree});
 
@@ -95,16 +94,14 @@ class UpdaterEtaTest : public ::testing::Test {
     param1.Init(Args{{"eta", "1.0"}});
 
     for (size_t iter = 0; iter < 4; ++iter) {
-      RegTree tree_0;
+      RegTree tree_0{1u, kCols};
       {
-        tree_0.param.num_feature = kCols;
         std::vector<HostDeviceVector<bst_node_t>> position(1);
         up_0->Update(&param0, &gpairs_, p_dmat_.get(), position, {&tree_0});
       }
 
-      RegTree tree_1;
+      RegTree tree_1{1u, kCols};
       {
-        tree_1.param.num_feature = kCols;
         std::vector<HostDeviceVector<bst_node_t>> position(1);
         up_1->Update(&param1, &gpairs_, p_dmat_.get(), position, {&tree_1});
       }


### PR DESCRIPTION
* Make tree model param a private member.
* Number of features and targets are immutable after construction.

This is to reduce the number of places where we can run configuration.