### PR TITLE
Fix aft_loss_distribution documentation

### DIFF
--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -372,7 +372,6 @@ Specify the learning task and the corresponding learning objective. The objectiv
     Note that predictions are returned on the hazard ratio scale (i.e., as HR = exp(marginal_prediction) in the proportional hazard function ``h(t) = h0(t) * HR``).
   - ``survival:aft``: Accelerated failure time model for censored survival time data.
     See :doc:`/tutorials/aft_survival_analysis` for details.
-  - ``aft_loss_distribution``: Probability Density Function used by ``survival:aft`` objective and ``aft-nloglik`` metric.
   - ``multi:softmax``: set XGBoost to do multiclass classification using the softmax objective, you also need to set num_class(number of classes)
   - ``multi:softprob``: same as softmax, but output a vector of ``ndata * nclass``, which can be further reshaped to ``ndata * nclass`` matrix. The result contains predicted probability of each data point belonging to each class.
   - ``rank:pairwise``: Use LambdaMART to perform pairwise ranking where the pairwise loss is minimized
@@ -467,6 +466,11 @@ Parameter for using Quantile Loss (``reg:quantileerror``)
 =========================================================
 
 * ``quantile_alpha``: A scala or a list of targeted quantiles.
+
+Parameter for using AFT Survival Loss (``survival:aft``) and Negative Log Likelihood of AFT metric (``aft-nloglik``)
+====================================================================================================================
+
+* ``aft_loss_distribution``: Probability Density Function, ``normal``, ``logistic``, or ``extreme``.
 
 ***********************
 Command Line Parameters


### PR DESCRIPTION
Turns out `aft_loss_distribution` is not really a loss, but a parameter to the `survival:aft` loss. 