### PR TITLE
Fix IsBinaryRel() check

### DIFF
--- a/src/common/ranking_utils.h
+++ b/src/common/ranking_utils.h
@@ -362,7 +362,7 @@ template <typename AllOf>
 bool IsBinaryRel(linalg::VectorView<float const> label, AllOf all_of) {
   auto s_label = label.Values();
   return all_of(s_label.data(), s_label.data() + s_label.size(), [] XGBOOST_DEVICE(float y) {
-    return std::abs(y - 1.0f) < kRtEps || std::abs(y - 0.0f) < kRtEps;
+    return ((y - 1.0f) < kRtEps) && ((y - 0.0f) > -kRtEps);
   });
 }
 /**
@@ -373,7 +373,6 @@ bool IsBinaryRel(linalg::VectorView<float const> label, AllOf all_of) {
  */
 template <typename AllOf>
 void CheckMapLabels(linalg::VectorView<float const> label, AllOf all_of) {
-  auto s_label = label.Values();
   auto is_binary = IsBinaryRel(label, all_of);
   CHECK(is_binary) << "MAP can only be used with binary labels.";
 }


### PR DESCRIPTION
This small PR fixes wrong binary checks for labels.


* The behaviour ~~bug~~ was introduced by https://github.com/dmlc/xgboost/pull/8931
* The checks ~~should be~~ now are in range ```1.0+eps > label > 0.0-eps```, with ```eps = 1e-6```

----

The errors was cought on TVM autotune process:
```
File "/usr/lib64/python3.11/site-packages/tvm/autotvm/tuner/xgboost_cost_model.py"
, line 538, in after_iteration
    bst_eval = model.eval_set(self.evals, epoch, feval)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/lib64/python3.11/site-packages/xgboost/core.py", line 1995, in eval_set
    _check_call(
File "/usr/lib64/python3.11/site-packages/xgboost/core.py", line 270, in _check_call
    raise XGBoostError(py_str(_LIB.XGBGetLastError()))
xgboost.core.XGBoostError: [15:59:59] /builddir/build/BUILD/xgboost/src/common/ranking_utils.h:378: 
Check failed: is_binary: MAP can only be used with binary labels.
```

---

Thank you,
~Cristian.

Cc: @trivialfis , @RAMitchell , please help with the review.