### PR TITLE
[CI] Don't run CI automatically for dependabot

### DIFF
--- a/tests/buildkite/pipeline-mgpu.yml
+++ b/tests/buildkite/pipeline-mgpu.yml
@@ -12,7 +12,7 @@ steps:
       queue: pipeline-loader
   - wait
   - block: ":rocket: Run this test job"
-    if: build.pull_request.repository.fork == true
+    if: build.pull_request.id != null
   #### -------- CONTAINER BUILD --------
   - label: ":docker: Build containers"
     commands:

--- a/tests/buildkite/pipeline-win64.yml
+++ b/tests/buildkite/pipeline-win64.yml
@@ -6,7 +6,7 @@ steps:
       queue: pipeline-loader
   - wait
   - block: ":rocket: Run this test job"
-    if: build.pull_request.repository.fork == true
+    if: build.pull_request.id != null
   #### -------- BUILD --------
   - label: ":windows: Build XGBoost for Windows with CUDA"
     command: "tests/buildkite/build-win64-gpu.ps1"

--- a/tests/buildkite/pipeline.yml
+++ b/tests/buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
       queue: pipeline-loader
   - wait
   - block: ":rocket: Run this test job"
-    if: build.pull_request.repository.fork == true
+    if: build.pull_request.id != null
   #### -------- CONTAINER BUILD --------
   - label: ":docker: Build containers"
     commands:


### PR DESCRIPTION
Closes #9012

* For dependabot PRs, build.pull_request.repository.fork is false, since dependabot creates a new branch in the XGBoost repo itself
* Use build.pull_request.id instead, which will be non-null for all pull requests