### PR TITLE
[pyspark] fix a minor typing bug

### DIFF
--- a/python-package/xgboost/spark/params.py
+++ b/python-package/xgboost/spark/params.py
@@ -1,4 +1,6 @@
 """Xgboost pyspark integration submodule for params."""
+from typing import Dict
+
 # pylint: disable=too-few-public-methods
 from pyspark.ml.param import TypeConverters
 from pyspark.ml.param.shared import Param, Params
@@ -11,7 +13,7 @@ class HasArbitraryParamsDict(Params):
     input.
     """
 
-    arbitrary_params_dict: Param[dict] = Param(
+    arbitrary_params_dict: "Param[Dict]" = Param(
         Params._dummy(),
         "arbitrary_params_dict",
         "arbitrary_params_dict This parameter holds all of the additional parameters which are "


### PR DESCRIPTION
`from xgboost.spark import SparkXGBClassifier` will throw exception when running on older pyspark (3.2.1) with the error msg

``` python
---> 16     arbitrary_params_dict: Param[Dict] = Param(
     17         Params._dummy(),
     18         "arbitrary_params_dict",
     19         "arbitrary_params_dict This parameter holds all of the additional parameters which are "
     20         "not exposed as the the XGBoost Spark estimator params but can be recognized by "
     21         "underlying XGBoost library. It is stored as a dictionary.",
     22     )

TypeError: 'type' object is not subscriptable
```

Change the typing to "Param[Dict]"