### PR TITLE
[pyspark] Don't stack for non feature columns

### DIFF
--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -219,7 +219,9 @@ def create_dmatrix_from_partitions(  # pylint: disable=too-many-arguments
                 array: Optional[np.ndarray] = part[feature_cols]
             elif part[name].shape[0] > 0:
                 array = part[name]
-                array = stack_series(array)
+                if name == alias.data:
+                    # For the array/vector typed case.
+                    array = stack_series(array)
             else:
                 array = None
 


### PR DESCRIPTION
To close https://github.com/dmlc/xgboost/issues/9016. I did some benchmark tests, this PR can bring ~1x speed up. Please see the details https://github.com/dmlc/xgboost/issues/9016#issuecomment-1521451690
