### PR TITLE
Add useful links to pyproject.toml

### DIFF
--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
     "scipy"
 ]
 
+[project.urls]
+documentation = "https://xgboost.readthedocs.io/en/stable/"
+repository = "https://github.com/dmlc/xgboost"
+
 [project.optional-dependencies]
 pandas = ["pandas"]
 scikit-learn = ["scikit-learn"]


### PR DESCRIPTION
The old `setup.py` script had link to the GitHub repository:
https://github.com/dmlc/xgboost/blob/21d95f3d8f23873a76f8afaad0fee5fa3e00eafe/python-package/setup.py#L374

It gets rendered on the PyPI page:
![Screenshot 2023-05-02 104248](https://user-images.githubusercontent.com/2532981/235743451-446dfb91-711c-480c-8563-a9954f12a2e1.png)

The new `pyproject.toml` should also have a similar link. What's different is that we can add multiple URLs, such as one for ReadTheDocs.