### PR TITLE
Fix multi-threaded gtests

### DIFF
--- a/src/collective/in_memory_handler.cc
+++ b/src/collective/in_memory_handler.cc
@@ -222,15 +222,15 @@ void InMemoryHandler::Handle(char const* input, std::size_t bytes, std::string* 
 
   std::unique_lock<std::mutex> lock(mutex_);
 
-  LOG(INFO) << functor.name << " rank " << rank << ": waiting for current sequence number";
+  LOG(DEBUG) << functor.name << " rank " << rank << ": waiting for current sequence number";
   cv_.wait(lock, [this, sequence_number] { return sequence_number_ == sequence_number; });
 
-  LOG(INFO) << functor.name << " rank " << rank << ": handling request";
+  LOG(DEBUG) << functor.name << " rank " << rank << ": handling request";
   functor(input, bytes, &buffer_);
   received_++;
 
   if (received_ == world_size_) {
-    LOG(INFO) << functor.name << " rank " << rank << ": all requests received";
+    LOG(DEBUG) << functor.name << " rank " << rank << ": all requests received";
     output->assign(buffer_);
     sent_++;
     lock.unlock();
@@ -238,15 +238,15 @@ void InMemoryHandler::Handle(char const* input, std::size_t bytes, std::string* 
     return;
   }
 
-  LOG(INFO) << functor.name << " rank " << rank << ": waiting for all clients";
+  LOG(DEBUG) << functor.name << " rank " << rank << ": waiting for all clients";
   cv_.wait(lock, [this] { return received_ == world_size_; });
 
-  LOG(INFO) << functor.name << " rank " << rank << ": sending reply";
+  LOG(DEBUG) << functor.name << " rank " << rank << ": sending reply";
   output->assign(buffer_);
   sent_++;
 
   if (sent_ == world_size_) {
-    LOG(INFO) << functor.name << " rank " << rank << ": all replies sent";
+    LOG(DEBUG) << functor.name << " rank " << rank << ": all replies sent";
     sent_ = 0;
     received_ = 0;
     buffer_.clear();

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -166,7 +166,7 @@ BatchSet<GHistIndexMatrix> SimpleDMatrix::GetGradientIndex(Context const* ctx,
   }
   if (!gradient_index_ || detail::RegenGHist(batch_param_, param)) {
     // GIDX page doesn't exist, generate it
-    LOG(INFO) << "Generating new Gradient Index.";
+    LOG(DEBUG) << "Generating new Gradient Index.";
     // These places can ask for a CSR gidx:
     // - CPU Hist: the ctx must be on CPU.
     // - IterativeDMatrix::InitFromCPU: The ctx must be on CPU.

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -497,22 +497,17 @@ inline std::int32_t AllThreadsForTest() { return Context{}.Threads(); }
 
 template <typename Function, typename... Args>
 void RunWithInMemoryCommunicator(int32_t world_size, Function&& function, Args&&... args) {
-  std::vector<std::thread> threads;
-  for (auto rank = 0; rank < world_size; rank++) {
-    threads.emplace_back([&, rank]() {
-      Json config{JsonObject()};
-      config["xgboost_communicator"] = String("in-memory");
-      config["in_memory_world_size"] = world_size;
-      config["in_memory_rank"] = rank;
-      xgboost::collective::Init(config);
+#pragma omp parallel num_threads(world_size)
+  {
+    Json config{JsonObject()};
+    config["xgboost_communicator"] = String("in-memory");
+    config["in_memory_world_size"] = world_size;
+    config["in_memory_rank"] = omp_get_thread_num();
+    xgboost::collective::Init(config);
 
-      std::forward<Function>(function)(std::forward<Args>(args)...);
+    std::forward<Function>(function)(std::forward<Args>(args)...);
 
-      xgboost::collective::Finalize();
-    });
-  }
-  for (auto& thread : threads) {
-    thread.join();
+    xgboost::collective::Finalize();
   }
 }
 

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -497,18 +497,32 @@ inline std::int32_t AllThreadsForTest() { return Context{}.Threads(); }
 
 template <typename Function, typename... Args>
 void RunWithInMemoryCommunicator(int32_t world_size, Function&& function, Args&&... args) {
-#pragma omp parallel num_threads(world_size)
-  {
+  auto run = [&](auto rank) {
     Json config{JsonObject()};
     config["xgboost_communicator"] = String("in-memory");
     config["in_memory_world_size"] = world_size;
-    config["in_memory_rank"] = omp_get_thread_num();
+    config["in_memory_rank"] = rank;
     xgboost::collective::Init(config);
 
     std::forward<Function>(function)(std::forward<Args>(args)...);
 
     xgboost::collective::Finalize();
+  };
+#if defined(_OPENMP)
+#pragma omp parallel num_threads(world_size)
+  {
+    auto rank = omp_get_thread_num();
+    run(rank);
   }
+#else
+  std::vector<std::thread> threads;
+  for (auto rank = 0; rank < world_size; rank++) {
+    threads.emplace_back(run, rank);
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+#endif
 }
 
 class DeclareUnifiedDistributedTest(MetricTest) : public ::testing::Test {

--- a/tests/cpp/plugin/helpers.h
+++ b/tests/cpp/plugin/helpers.h
@@ -3,6 +3,7 @@
  */
 #pragma once
 
+#include <dmlc/omp.h>
 #include <grpcpp/server_builder.h>
 #include <gtest/gtest.h>
 #include <xgboost/json.h>
@@ -61,23 +62,18 @@ class BaseFederatedTest : public ::testing::Test {
 template <typename Function, typename... Args>
 void RunWithFederatedCommunicator(int32_t world_size, std::string const& server_address,
                                   Function&& function, Args&&... args) {
-  std::vector<std::thread> threads;
-  for (auto rank = 0; rank < world_size; rank++) {
-    threads.emplace_back([&, rank]() {
-      Json config{JsonObject()};
-      config["xgboost_communicator"] = String("federated");
-      config["federated_server_address"] = String(server_address);
-      config["federated_world_size"] = world_size;
-      config["federated_rank"] = rank;
-      xgboost::collective::Init(config);
+#pragma omp parallel num_threads(world_size)
+  {
+    Json config{JsonObject()};
+    config["xgboost_communicator"] = String("federated");
+    config["federated_server_address"] = String(server_address);
+    config["federated_world_size"] = world_size;
+    config["federated_rank"] = omp_get_thread_num();
+    xgboost::collective::Init(config);
 
-      std::forward<Function>(function)(std::forward<Args>(args)...);
+    std::forward<Function>(function)(std::forward<Args>(args)...);
 
-      xgboost::collective::Finalize();
-    });
-  }
-  for (auto& thread : threads) {
-    thread.join();
+    xgboost::collective::Finalize();
   }
 }
 

--- a/tests/cpp/tree/test_histmaker.cc
+++ b/tests/cpp/tree/test_histmaker.cc
@@ -90,13 +90,16 @@ void TestColumnSplit(int32_t rows, bst_feature_t cols, RegTree const& expected_t
   param.Init(Args{});
   updater->Update(&param, p_gradients.get(), sliced.get(), position, {&tree});
 
-  EXPECT_EQ(tree.NumExtraNodes(), 10);
-  EXPECT_EQ(tree[0].SplitIndex(), 1);
+  ASSERT_EQ(tree.NumExtraNodes(), 10);
+  ASSERT_EQ(tree[0].SplitIndex(), 1);
 
-  EXPECT_NE(tree[tree[0].LeftChild()].SplitIndex(), 0);
-  EXPECT_NE(tree[tree[0].RightChild()].SplitIndex(), 0);
+  ASSERT_NE(tree[tree[0].LeftChild()].SplitIndex(), 0);
+  ASSERT_NE(tree[tree[0].RightChild()].SplitIndex(), 0);
 
-  EXPECT_EQ(tree, expected_tree);
+  FeatureMap fmap;
+  auto json = tree.DumpModel(fmap, false, "json");
+  auto expected_json = expected_tree.DumpModel(fmap, false, "json");
+  ASSERT_EQ(json, expected_json);
 }
 }  // anonymous namespace
 


### PR DESCRIPTION
Turns out OpenMP doesn't play nice with C++ `std::thread`s, causing occasional test failures.

Fixes #9146