### PR TITLE
[WIP] Add decision path dump feature

### DIFF
--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -99,7 +99,7 @@ class GradientBooster : public Model, public Configurable {
    * \param end      End of booster layer. 0 means do not limit trees.
    */
   virtual void PredictBatch(DMatrix* dmat, PredictionCacheEntry* out_preds, bool training,
-                            bst_layer_t begin, bst_layer_t end) = 0;
+                            std::vector<std::vector<bst_node_t>> *decision_path, bst_layer_t begin, bst_layer_t end) = 0;
 
   /**
    * \brief Inplace prediction.
@@ -172,6 +172,10 @@ class GradientBooster : public Model, public Configurable {
   virtual std::vector<std::string> DumpModel(const FeatureMap& fmap,
                                              bool with_stats,
                                              std::string format) const = 0;
+
+  virtual std::vector<std::string> DumpDecisionPath(const FeatureMap& fmap,
+                                                    bool with_stats,
+                                                    const std::vector<std::vector<int32_t>> &decision_paths) const = 0;
 
   virtual void FeatureScore(std::string const& importance_type,
                             common::Span<int32_t const> trees,

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -26,6 +26,7 @@ namespace xgboost {
 class Json;
 class FeatureMap;
 class ObjFunction;
+class TreeSetDecisionPath;
 
 struct Context;
 struct LearnerModelParam;
@@ -99,7 +100,7 @@ class GradientBooster : public Model, public Configurable {
    * \param end      End of booster layer. 0 means do not limit trees.
    */
   virtual void PredictBatch(DMatrix* dmat, PredictionCacheEntry* out_preds, bool training,
-                            std::vector<std::vector<bst_node_t>> *decision_path, bst_layer_t begin, bst_layer_t end) = 0;
+                            std::vector<TreeSetDecisionPath>* decision_path, bst_layer_t begin, bst_layer_t end) = 0;
 
   /**
    * \brief Inplace prediction.
@@ -175,7 +176,9 @@ class GradientBooster : public Model, public Configurable {
 
   virtual std::vector<std::string> DumpDecisionPath(const FeatureMap& fmap,
                                                     bool with_stats,
-                                                    const std::vector<std::vector<int32_t>> &decision_paths) const = 0;
+      const std::vector<TreeSetDecisionPath>& decision_paths) const = 0;
+
+  virtual uint64_t GetTreeCount() const = 0;
 
   virtual void FeatureScore(std::string const& importance_type,
                             common::Span<int32_t const> trees,

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -119,7 +119,8 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
                        bool pred_leaf = false,
                        bool pred_contribs = false,
                        bool approx_contribs = false,
-                       bool pred_interactions = false) = 0;
+                       bool pred_interactions = false,
+                       std::vector<std::vector<int32_t>> *decision_path = nullptr) = 0;
 
   /*!
    * \brief Inplace prediction.
@@ -251,6 +252,8 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
   virtual std::vector<std::string> DumpModel(const FeatureMap& fmap,
                                              bool with_stats,
                                              std::string format) = 0;
+
+  virtual std::vector<std::string> DumpDecisionPath(const FeatureMap& fmap, bool with_stats, const std::vector<std::vector<int32_t>> &decision_path) = 0;
 
   virtual XGBAPIThreadLocalEntry& GetThreadLocal() const = 0;
   /*!

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -35,6 +35,7 @@ class Json;
 struct XGBAPIThreadLocalEntry;
 template <typename T>
 class HostDeviceVector;
+class TreeSetDecisionPath;
 
 enum class PredictionType : std::uint8_t {  // NOLINT
   kValue = 0,
@@ -120,7 +121,7 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
                        bool pred_contribs = false,
                        bool approx_contribs = false,
                        bool pred_interactions = false,
-                       std::vector<std::vector<int32_t>> *decision_path = nullptr) = 0;
+                       std::vector<TreeSetDecisionPath> *decision_path = nullptr) = 0;
 
   /*!
    * \brief Inplace prediction.
@@ -242,6 +243,9 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    */
   virtual Learner* Slice(bst_layer_t begin, bst_layer_t end, bst_layer_t step,
                          bool* out_of_bound) = 0;
+
+  virtual uint64_t GetTreeCount() const = 0;
+
   /*!
    * \brief dump the model in the requested format
    * \param fmap feature map that may help give interpretations of feature
@@ -253,7 +257,8 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
                                              bool with_stats,
                                              std::string format) = 0;
 
-  virtual std::vector<std::string> DumpDecisionPath(const FeatureMap& fmap, bool with_stats, const std::vector<std::vector<int32_t>> &decision_path) = 0;
+  virtual std::vector<std::string> DumpDecisionPath(const FeatureMap& fmap, bool with_stats,
+      const std::vector<TreeSetDecisionPath>& decision_path) = 0;
 
   virtual XGBAPIThreadLocalEntry& GetThreadLocal() const = 0;
   /*!

--- a/include/xgboost/multi_target_tree_model.h
+++ b/include/xgboost/multi_target_tree_model.h
@@ -89,6 +89,10 @@ class MultiTargetTree : public Model {
     return this->NodeWeight(nidx);
   }
 
+  [[nodiscard]] linalg::VectorView<float const> NodeValue(bst_node_t nidx) const {
+    return this->NodeWeight(nidx);
+  }
+
   void LoadModel(Json const& in) override;
   void SaveModel(Json* out) const override;
 };

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -109,7 +109,7 @@ class Predictor {
    * \param           tree_end    The tree end index.
    */
   virtual void PredictBatch(DMatrix* dmat, PredictionCacheEntry* out_preds,
-                            const gbm::GBTreeModel& model, uint32_t tree_begin,
+                            const gbm::GBTreeModel& model, std::vector<std::vector<bst_node_t>> *path_list, uint32_t tree_begin,
                             uint32_t tree_end = 0) const = 0;
 
   /**
@@ -126,7 +126,7 @@ class Predictor {
    * \return True if the data can be handled by current predictor, false otherwise.
    */
   virtual bool InplacePredict(std::shared_ptr<DMatrix> p_fmat, const gbm::GBTreeModel& model,
-                              float missing, PredictionCacheEntry* out_preds,
+                              float missing, PredictionCacheEntry* out_preds, std::vector<std::vector<bst_node_t>> *path_list,
                               uint32_t tree_begin = 0, uint32_t tree_end = 0) const = 0;
   /**
    * \brief online prediction function, predict score for one instance at a time
@@ -142,7 +142,7 @@ class Predictor {
 
   virtual void PredictInstance(const SparsePage::Inst& inst,
                                std::vector<bst_float>* out_preds,
-                               const gbm::GBTreeModel& model,
+                               const gbm::GBTreeModel& model, std::vector<std::vector<bst_node_t>> *path_list,
                                unsigned tree_end = 0) const = 0;
 
   /**
@@ -156,7 +156,7 @@ class Predictor {
    */
 
   virtual void PredictLeaf(DMatrix* dmat, HostDeviceVector<bst_float>* out_preds,
-                           const gbm::GBTreeModel& model,
+                           const gbm::GBTreeModel& model, std::vector<std::vector<bst_node_t>> *path_list,
                            unsigned tree_end = 0) const = 0;
 
   /**

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -26,6 +26,7 @@ struct GBTreeModel;
 }  // namespace xgboost
 
 namespace xgboost {
+class TreeSetDecisionPath;
 /**
  * \brief Contains pointer to input matrix and associated cached predictions.
  */
@@ -109,7 +110,8 @@ class Predictor {
    * \param           tree_end    The tree end index.
    */
   virtual void PredictBatch(DMatrix* dmat, PredictionCacheEntry* out_preds,
-                            const gbm::GBTreeModel& model, std::vector<std::vector<bst_node_t>> *path_list, uint32_t tree_begin,
+                            const gbm::GBTreeModel& model,
+                            std::vector<TreeSetDecisionPath>* path_list, uint32_t tree_begin,
                             uint32_t tree_end = 0) const = 0;
 
   /**
@@ -126,7 +128,7 @@ class Predictor {
    * \return True if the data can be handled by current predictor, false otherwise.
    */
   virtual bool InplacePredict(std::shared_ptr<DMatrix> p_fmat, const gbm::GBTreeModel& model,
-                              float missing, PredictionCacheEntry* out_preds, std::vector<std::vector<bst_node_t>> *path_list,
+                              float missing, PredictionCacheEntry* out_preds, std::vector<TreeSetDecisionPath> *path_list,
                               uint32_t tree_begin = 0, uint32_t tree_end = 0) const = 0;
   /**
    * \brief online prediction function, predict score for one instance at a time

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -839,5 +839,29 @@ inline bool RegTree::FVec::HasMissing() const {
 inline StringView MTNotImplemented() {
   return " support for multi-target tree is not yet implemented.";
 }
+
+class TreeSetDecisionPath {
+public:
+  TreeSetDecisionPath(uint32_t tree_count)
+    : tree2path_(tree_count) {}
+
+  const std::vector<bst_node_t> &get_decision_path(uint32_t tree_id) const {
+    return tree2path_.at(tree_id);
+  }
+
+  void set_decision_path(uint32_t tree_id, std::vector<bst_node_t> &&new_path) {
+    tree2path_.at(tree_id) = std::forward<std::vector<bst_node_t>>(new_path);
+  }
+
+  uint32_t num_trees() const {
+    return tree2path_.size();
+  }
+
+private:
+  std::vector<std::vector<bst_node_t>> tree2path_;
+};
+
+void PrintDecisionPath(FILE *os, const std::vector<std::string> &decision_paths_dumped);
+
 }  // namespace xgboost
 #endif  // XGBOOST_TREE_MODEL_H_

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -618,6 +618,11 @@ class RegTree : public Model {
    */
   [[nodiscard]] std::string DumpModel(const FeatureMap& fmap, bool with_stats,
                                       std::string format) const;
+
+  [[nodiscard]] std::string DumpDecisionPath(const FeatureMap& fmap,
+                            bool with_stats,
+                            const std::vector<int32_t> &decision_path) const ;
+
   /*!
    * \brief Get split type for a node.
    * \param nidx Index of node.

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2055,6 +2055,8 @@ class Booster:
         training: bool = False,
         iteration_range: Tuple[int, int] = (0, 0),
         strict_shape: bool = False,
+        print_decision_path: bool = False,
+        fmap: str = "",
     ) -> np.ndarray:
         """Predict with data.  The full model will be used unless `iteration_range` is specified,
         meaning user have to either slice the model or use the ``best_iteration``
@@ -2145,6 +2147,8 @@ class Booster:
             "iteration_begin": iteration_range[0],
             "iteration_end": iteration_range[1],
             "strict_shape": strict_shape,
+            "print_decision_path": print_decision_path,
+            "fmap": fmap,
         }
 
         def assign_type(t: int) -> None:

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -148,7 +148,7 @@ class GBLinear : public GradientBooster {
   }
 
   void PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* predts, bool /*training*/,
-                    std::vector<std::vector<bst_node_t>> *, bst_layer_t layer_begin, bst_layer_t) override {
+                    std::vector<TreeSetDecisionPath>*, bst_layer_t layer_begin, bst_layer_t) override {
     monitor_.Start("PredictBatch");
     LinearCheckLayer(layer_begin);
     auto* out_preds = &predts->predictions;
@@ -232,8 +232,12 @@ class GBLinear : public GradientBooster {
 
   std::vector<std::string> DumpDecisionPath(const FeatureMap& fmap,
                                             bool with_stats,
-                                            const std::vector<std::vector<int32_t>> &decision_paths) const override {
+      const std::vector<TreeSetDecisionPath>& decision_paths) const override {
     throw "Not implemented";
+  }
+
+  uint64_t GetTreeCount() const override {
+    return 0;
   }
 
   void FeatureScore(std::string const &importance_type,

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -148,7 +148,7 @@ class GBLinear : public GradientBooster {
   }
 
   void PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* predts, bool /*training*/,
-                    bst_layer_t layer_begin, bst_layer_t) override {
+                    std::vector<std::vector<bst_node_t>> *, bst_layer_t layer_begin, bst_layer_t) override {
     monitor_.Start("PredictBatch");
     LinearCheckLayer(layer_begin);
     auto* out_preds = &predts->predictions;
@@ -228,6 +228,12 @@ class GBLinear : public GradientBooster {
                                      bool with_stats,
                                      std::string format) const override {
     return model_.DumpModel(fmap, with_stats, format);
+  }
+
+  std::vector<std::string> DumpDecisionPath(const FeatureMap& fmap,
+                                            bool with_stats,
+                                            const std::vector<std::vector<int32_t>> &decision_paths) const override {
+    throw "Not implemented";
   }
 
   void FeatureScore(std::string const &importance_type,

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -568,7 +568,7 @@ void GBTree::Slice(bst_layer_t begin, bst_layer_t end, bst_layer_t step, Gradien
 }
 
 void GBTree::PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* out_preds, bool,
-                          bst_layer_t layer_begin, bst_layer_t layer_end) {
+                          std::vector<std::vector<bst_node_t>> *decision_paths, bst_layer_t layer_begin, bst_layer_t layer_end) {
   CHECK(configured_);
   if (layer_end == 0) {
     layer_end = this->BoostedRounds();
@@ -598,7 +598,19 @@ void GBTree::PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* out_preds, bool
   auto [tree_begin, tree_end] = detail::LayerToTree(model_, layer_begin, layer_end);
   CHECK_LE(tree_end, model_.trees.size()) << "Invalid number of trees.";
   if (tree_end > tree_begin) {
-    predictor->PredictBatch(p_fmat, out_preds, model_, tree_begin, tree_end);
+    if (decision_paths != nullptr) {
+      decision_paths->resize(tree_end);
+    }
+    predictor->PredictBatch(p_fmat, out_preds, model_, decision_paths, tree_begin, tree_end);
+//    if (decision_paths != nullptr) {
+//      fprintf(stderr, "dumping decision paths...\n");
+//      for (uint32_t tree_id = 0; tree_id < decision_paths->size(); ++tree_id) {
+//        fprintf(stderr, "\ttree %u\n", tree_id);
+//        for (int nid : decision_paths->at(tree_id)) {
+//          fprintf(stderr, "\t\tnid %u\n", nid);
+//        }
+//      }
+//    }
   }
   if (reset) {
     out_preds->version = 0;
@@ -823,7 +835,7 @@ class Dart : public GBTree {
       auto version = i / layer_trees();
       p_out_preds->version = version;
       predts.predictions.Fill(0);
-      predictor->PredictBatch(p_fmat, &predts, model_, i, i + 1);
+      predictor->PredictBatch(p_fmat, &predts, model_, nullptr, i, i + 1);
 
       // Multiple the weight to output prediction.
       auto w = this->weight_drop_.at(i);
@@ -848,7 +860,7 @@ class Dart : public GBTree {
   }
 
   void PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* p_out_preds, bool training,
-                    bst_layer_t layer_begin, bst_layer_t layer_end) override {
+                    std::vector<std::vector<bst_node_t>> *decision_paths, bst_layer_t layer_begin, bst_layer_t layer_end) override {
     DropTrees(training);
     this->PredictBatchImpl(p_fmat, p_out_preds, training, layer_begin, layer_end);
   }
@@ -881,7 +893,7 @@ class Dart : public GBTree {
         // Try both predictor implementations
         bool success = false;
         for (auto const& p : predictors) {
-          if (p && p->InplacePredict(p_fmat, model_, missing, &predts, i, i + 1)) {
+          if (p && p->InplacePredict(p_fmat, model_, missing, &predts, nullptr, i, i + 1)) {
             success = true;
             predictor = p;
             break;
@@ -890,7 +902,7 @@ class Dart : public GBTree {
         CHECK(success) << msg;
       } else {
         predictor = this->GetPredictor().get();
-        bool success = predictor->InplacePredict(p_fmat, model_, missing, &predts, i, i + 1);
+        bool success = predictor->InplacePredict(p_fmat, model_, missing, &predts, nullptr, i, i + 1);
         CHECK(success) << msg << std::endl
                        << "Current Predictor: "
                        << (tparam_.predictor == PredictorType::kCPUPredictor ? "cpu_predictor"
@@ -935,7 +947,7 @@ class Dart : public GBTree {
     auto &predictor = this->GetPredictor();
     uint32_t _, tree_end;
     std::tie(_, tree_end) = detail::LayerToTree(model_, layer_begin, layer_end);
-    predictor->PredictInstance(inst, out_preds, model_, tree_end);
+    predictor->PredictInstance(inst, out_preds, model_, nullptr, tree_end);
   }
 
   void PredictContribution(DMatrix* p_fmat,

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -568,7 +568,7 @@ void GBTree::Slice(bst_layer_t begin, bst_layer_t end, bst_layer_t step, Gradien
 }
 
 void GBTree::PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* out_preds, bool,
-                          std::vector<std::vector<bst_node_t>> *decision_paths, bst_layer_t layer_begin, bst_layer_t layer_end) {
+                          std::vector<TreeSetDecisionPath>* decision_paths, bst_layer_t layer_begin, bst_layer_t layer_end) {
   CHECK(configured_);
   if (layer_end == 0) {
     layer_end = this->BoostedRounds();
@@ -598,19 +598,7 @@ void GBTree::PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* out_preds, bool
   auto [tree_begin, tree_end] = detail::LayerToTree(model_, layer_begin, layer_end);
   CHECK_LE(tree_end, model_.trees.size()) << "Invalid number of trees.";
   if (tree_end > tree_begin) {
-    if (decision_paths != nullptr) {
-      decision_paths->resize(tree_end);
-    }
     predictor->PredictBatch(p_fmat, out_preds, model_, decision_paths, tree_begin, tree_end);
-//    if (decision_paths != nullptr) {
-//      fprintf(stderr, "dumping decision paths...\n");
-//      for (uint32_t tree_id = 0; tree_id < decision_paths->size(); ++tree_id) {
-//        fprintf(stderr, "\ttree %u\n", tree_id);
-//        for (int nid : decision_paths->at(tree_id)) {
-//          fprintf(stderr, "\t\tnid %u\n", nid);
-//        }
-//      }
-//    }
   }
   if (reset) {
     out_preds->version = 0;
@@ -860,7 +848,7 @@ class Dart : public GBTree {
   }
 
   void PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* p_out_preds, bool training,
-                    std::vector<std::vector<bst_node_t>> *decision_paths, bst_layer_t layer_begin, bst_layer_t layer_end) override {
+                    std::vector<TreeSetDecisionPath>* decision_paths, bst_layer_t layer_begin, bst_layer_t layer_end) override {
     DropTrees(training);
     this->PredictBatchImpl(p_fmat, p_out_preds, training, layer_begin, layer_end);
   }

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -247,7 +247,7 @@ class GBTree : public GradientBooster {
   }
 
   void PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* out_preds, bool training,
-                    bst_layer_t layer_begin, bst_layer_t layer_end) override;
+                    std::vector<std::vector<bst_node_t>> *decision_paths, bst_layer_t layer_begin, bst_layer_t layer_end) override;
 
   void InplacePredict(std::shared_ptr<DMatrix> p_m, float missing, PredictionCacheEntry* out_preds,
                       bst_layer_t layer_begin, bst_layer_t layer_end) const override {
@@ -264,14 +264,14 @@ class GBTree : public GradientBooster {
     if (tparam_.predictor == PredictorType::kAuto) {
       // Try both predictor implementations
       for (auto const &p : predictors) {
-        if (p && p->InplacePredict(p_m, model_, missing, out_preds, tree_begin, tree_end)) {
+        if (p && p->InplacePredict(p_m, model_, missing, out_preds, nullptr, tree_begin, tree_end)) {
           return;
         }
       }
       LOG(FATAL) << msg;
     } else {
       bool success = this->GetPredictor()->InplacePredict(p_m, model_, missing, out_preds,
-                                                          tree_begin, tree_end);
+                                                          nullptr, tree_begin, tree_end);
       CHECK(success) << msg << std::endl
                      << "Current Predictor: "
                      << (tparam_.predictor == PredictorType::kCPUPredictor
@@ -350,7 +350,7 @@ class GBTree : public GradientBooster {
     CHECK(configured_);
     std::uint32_t _, tree_end;
     std::tie(_, tree_end) = detail::LayerToTree(model_, layer_begin, layer_end);
-    cpu_predictor_->PredictInstance(inst, out_preds, model_, tree_end);
+    cpu_predictor_->PredictInstance(inst, out_preds, model_, nullptr, tree_end);
   }
 
   void PredictLeaf(DMatrix* p_fmat,
@@ -359,7 +359,7 @@ class GBTree : public GradientBooster {
     auto [tree_begin, tree_end] = detail::LayerToTree(model_, layer_begin, layer_end);
     CHECK_EQ(tree_begin, 0) << "Predict leaf supports only iteration end: (0, "
                                "n_iteration), use model slicing instead.";
-    this->GetPredictor()->PredictLeaf(p_fmat, out_preds, model_, tree_end);
+    this->GetPredictor()->PredictLeaf(p_fmat, out_preds, model_, nullptr, tree_end);
   }
 
   void PredictContribution(DMatrix* p_fmat,
@@ -390,6 +390,12 @@ class GBTree : public GradientBooster {
   [[nodiscard]] std::vector<std::string> DumpModel(const FeatureMap& fmap, bool with_stats,
                                                    std::string format) const override {
     return model_.DumpModel(fmap, with_stats, this->ctx_->Threads(), format);
+  }
+
+  std::vector<std::string> DumpDecisionPath(const FeatureMap& fmap,
+                                            bool with_stats,
+                                            const std::vector<std::vector<int32_t>> &decision_paths) const override {
+    return model_.DumpDecisionPath(fmap, with_stats, decision_paths);
   }
 
  protected:

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -247,7 +247,7 @@ class GBTree : public GradientBooster {
   }
 
   void PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* out_preds, bool training,
-                    std::vector<std::vector<bst_node_t>> *decision_paths, bst_layer_t layer_begin, bst_layer_t layer_end) override;
+                    std::vector<TreeSetDecisionPath>* decision_paths, bst_layer_t layer_begin, bst_layer_t layer_end) override;
 
   void InplacePredict(std::shared_ptr<DMatrix> p_m, float missing, PredictionCacheEntry* out_preds,
                       bst_layer_t layer_begin, bst_layer_t layer_end) const override {
@@ -394,8 +394,12 @@ class GBTree : public GradientBooster {
 
   std::vector<std::string> DumpDecisionPath(const FeatureMap& fmap,
                                             bool with_stats,
-                                            const std::vector<std::vector<int32_t>> &decision_paths) const override {
+      const std::vector<TreeSetDecisionPath>& decision_paths) const override {
     return model_.DumpDecisionPath(fmap, with_stats, decision_paths);
+  }
+
+  uint64_t GetTreeCount() const override {
+    return model_.GetTreeCount();
   }
 
  protected:

--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -119,6 +119,18 @@ struct GBTreeModel : public Model {
                         [&](size_t i) { dump[i] = trees[i]->DumpModel(fmap, with_stats, format); });
     return dump;
   }
+
+  [[nodiscard]] std::vector<std::string> DumpDecisionPath(const FeatureMap& fmap,
+                                 bool with_stats,
+                                 const std::vector<std::vector<int32_t>> &decision_path) const {
+    std::vector<std::string> dump;
+    dump.resize(trees.size());
+    for (uint32_t i = 0; i < trees.size(); ++i) {
+      dump[i] = trees[i]->DumpDecisionPath(fmap, with_stats, decision_path[i]);
+    }
+    return dump;
+  }
+
   /**
    * \brief Add trees to the model.
    *

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1236,6 +1236,11 @@ class LearnerImpl : public LearnerIO {
     return gbm_->DumpModel(fmap, with_stats, format);
   }
 
+  std::vector<std::string> DumpDecisionPath(const FeatureMap& fmap, bool with_stats,
+                                            const std::vector<std::vector<int32_t>> &decision_paths) override {
+    return gbm_->DumpDecisionPath(fmap, with_stats, decision_paths);
+  }
+
   Learner* Slice(bst_layer_t begin, bst_layer_t end, bst_layer_t step,
                  bool* out_of_bound) override {
     this->Configure();
@@ -1289,7 +1294,7 @@ class LearnerImpl : public LearnerIO {
     auto& predt = prediction_container_.Cache(train, ctx_.gpu_id);
 
     monitor_.Start("PredictRaw");
-    this->PredictRaw(train.get(), &predt, true, 0, 0);
+    this->PredictRaw(train.get(), &predt, true, nullptr, 0, 0);
     TrainingObserver::Instance().Observe(predt.predictions, "Predictions");
     monitor_.Stop("PredictRaw");
 
@@ -1339,7 +1344,7 @@ class LearnerImpl : public LearnerIO {
       std::shared_ptr<DMatrix> m = data_sets[i];
       auto &predt = prediction_container_.Cache(m, ctx_.gpu_id);
       this->ValidateDMatrix(m.get(), false);
-      this->PredictRaw(m.get(), &predt, false, 0, 0);
+      this->PredictRaw(m.get(), &predt, false, nullptr, 0, 0);
 
       auto &out = output_predictions_.Cache(m, ctx_.gpu_id).predictions;
       out.Resize(predt.predictions.Size());
@@ -1359,7 +1364,8 @@ class LearnerImpl : public LearnerIO {
                HostDeviceVector<bst_float> *out_preds, unsigned layer_begin,
                unsigned layer_end, bool training,
                bool pred_leaf, bool pred_contribs, bool approx_contribs,
-               bool pred_interactions) override {
+               bool pred_interactions,
+               std::vector<std::vector<int32_t>> *decision_paths) override {
     int multiple_predictions = static_cast<int>(pred_leaf) +
                                static_cast<int>(pred_interactions) +
                                static_cast<int>(pred_contribs);
@@ -1379,7 +1385,11 @@ class LearnerImpl : public LearnerIO {
       gbm_->PredictLeaf(data.get(), out_preds, layer_begin, layer_end);
     } else {
       auto& prediction = prediction_container_.Cache(data, ctx_.gpu_id);
-      this->PredictRaw(data.get(), &prediction, training, layer_begin, layer_end);
+      if (decision_paths != nullptr) {
+        this->PredictRaw(data.get(), &prediction, training, decision_paths, layer_begin, layer_end);
+      } else {
+        this->PredictRaw(data.get(), &prediction, training, nullptr, layer_begin, layer_end);
+      }
       // Copy the prediction cache to output prediction. out_preds comes from C API
       out_preds->SetDevice(ctx_.gpu_id);
       out_preds->Resize(prediction.predictions.Size());
@@ -1446,11 +1456,11 @@ class LearnerImpl : public LearnerIO {
    * \param training allow dropout when the DART booster is being used
    */
   void PredictRaw(DMatrix *data, PredictionCacheEntry *out_preds, bool training,
-                  unsigned layer_begin, unsigned layer_end) const {
+                  std::vector<std::vector<bst_node_t>> *decision_paths, unsigned layer_begin, unsigned layer_end) const {
     CHECK(gbm_ != nullptr) << "Predict must happen after Load or configuration";
     this->CheckModelInitialized();
     this->ValidateDMatrix(data, false);
-    gbm_->PredictBatch(data, out_preds, training, layer_begin, layer_end);
+    gbm_->PredictBatch(data, out_preds, training, decision_paths, layer_begin, layer_end);
   }
 
   void ValidateDMatrix(DMatrix* p_fmat, bool is_training) const {

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -55,6 +55,21 @@ bst_node_t GetLeafIndex(RegTree const &tree, const RegTree::FVec &feat,
   return nidx;
 }
 
+template <bool has_missing, bool has_categorical>
+std::vector<bst_node_t> GetLeafIndexVerbose(RegTree const &tree, const RegTree::FVec &feat,
+                        RegTree::CategoricalSplitMatrix const &cats) {
+  bst_node_t nidx{0};
+  std::vector<bst_node_t> nid_list;
+  while (!tree[nidx].IsLeaf()) {
+    bst_feature_t split_index = tree[nidx].SplitIndex();
+    auto fvalue = feat.GetFvalue(split_index);
+    nid_list.push_back(nidx);
+    nidx = GetNextNode<has_missing, has_categorical>(
+        tree[nidx], nidx, fvalue, has_missing && feat.IsMissing(split_index), cats);
+  }
+  return nid_list;
+}
+
 bst_float PredValue(const SparsePage::Inst &inst,
                     const std::vector<std::unique_ptr<RegTree>> &trees,
                     const std::vector<int> &tree_info, std::int32_t bst_group,
@@ -87,6 +102,14 @@ bst_float PredValueByOneTree(const RegTree::FVec &p_feats, RegTree const &tree,
                               : GetLeafIndex<false, has_categorical>(tree, p_feats, cats);
   return tree[leaf].LeafValue();
 }
+
+template <bool has_categorical>
+std::vector<bst_node_t> PredValueByOneTreeVerbose(const RegTree::FVec &p_feats, RegTree const &tree,
+                             RegTree::CategoricalSplitMatrix const &cats) {
+  return p_feats.HasMissing()
+                              ? GetLeafIndexVerbose<true, has_categorical>(tree, p_feats, cats)
+                              : GetLeafIndexVerbose<false, has_categorical>(tree, p_feats, cats);
+}
 }  // namespace scalar
 
 namespace multi {
@@ -103,6 +126,21 @@ bst_node_t GetLeafIndex(MultiTargetTree const &tree, const RegTree::FVec &feat,
   return nidx;
 }
 
+template <bool has_missing, bool has_categorical>
+std::vector<bst_node_t> GetLeafIndexPath(MultiTargetTree const &tree, const RegTree::FVec &feat,
+                        RegTree::CategoricalSplitMatrix const &cats) {
+  bst_node_t nidx{0};
+  std::vector<bst_node_t> nid_list;
+  while (!tree.IsLeaf(nidx)) {
+    unsigned split_index = tree.SplitIndex(nidx);
+    auto fvalue = feat.GetFvalue(split_index);
+    nidx = GetNextNodeMulti<has_missing, has_categorical>(
+        tree, nidx, fvalue, has_missing && feat.IsMissing(split_index), cats);
+    nid_list.push_back(nidx);
+  }
+  return std::move(nid_list);
+}
+
 template <bool has_categorical>
 void PredValueByOneTree(RegTree::FVec const &p_feats, MultiTargetTree const &tree,
                         RegTree::CategoricalSplitMatrix const &cats,
@@ -116,47 +154,93 @@ void PredValueByOneTree(RegTree::FVec const &p_feats, MultiTargetTree const &tre
     out_predt(i) += leaf_value(i);
   }
 }
+
+template <bool has_categorical>
+std::vector<bst_node_t> PredValueByOneTreeVerbose(RegTree::FVec const &p_feats, MultiTargetTree const &tree,
+                        RegTree::CategoricalSplitMatrix const &cats,
+                        linalg::VectorView<float> out_predt) {
+  //  bst_node_t const leaf = p_feats.HasMissing()
+  //                              ? GetLeafIndex<true, has_categorical>(tree, p_feats, cats)
+  //                              : GetLeafIndex<false, has_categorical>(tree, p_feats, cats);
+  auto path_to_leaf = p_feats.HasMissing()
+                          ? GetLeafIndexPath<true, has_categorical>(tree, p_feats, cats)
+                          : GetLeafIndexPath<false, has_categorical>(tree, p_feats, cats);
+  bst_node_t const leaf = path_to_leaf.back();
+  auto leaf_value = tree.LeafValue(leaf);
+  assert(out_predt.Shape(0) == leaf_value.Shape(0) && "shape mismatch.");
+  for (size_t i = 0; i < leaf_value.Size(); ++i) {
+    out_predt(i) += leaf_value(i);
+  }
+  return path_to_leaf;
+}
 }  // namespace multi
 
 namespace {
-void PredictByAllTrees(gbm::GBTreeModel const &model, std::uint32_t const tree_begin,
+template <bool verbose>
+std::map<uint32_t, std::vector<bst_node_t>> PredictByAllTrees(gbm::GBTreeModel const &model, std::uint32_t const tree_begin,
                        std::uint32_t const tree_end, std::size_t const predict_offset,
                        std::vector<RegTree::FVec> const &thread_temp, std::size_t const offset,
                        std::size_t const block_size, linalg::MatrixView<float> out_predt) {
+  std::map<uint32_t, std::vector<bst_node_t>> tree2path;
   for (std::uint32_t tree_id = tree_begin; tree_id < tree_end; ++tree_id) {
     auto const &tree = *model.trees.at(tree_id);
     auto const &cats = tree.GetCategoriesMatrix();
     bool has_categorical = tree.HasCategoricalSplit();
+    std::vector<bst_node_t> node_path;
 
     if (tree.IsMultiTarget()) {
       if (has_categorical) {
         for (std::size_t i = 0; i < block_size; ++i) {
           auto t_predts = out_predt.Slice(predict_offset + i, linalg::All());
-          multi::PredValueByOneTree<true>(thread_temp[offset + i], *tree.GetMultiTargetTree(), cats,
-                                          t_predts);
+          if (verbose) {
+            node_path = multi::PredValueByOneTreeVerbose<true>(thread_temp[offset + i], *tree.GetMultiTargetTree(), cats,
+                                                               t_predts);
+          } else {
+            multi::PredValueByOneTree<true>(thread_temp[offset + i], *tree.GetMultiTargetTree(), cats,
+                                                   t_predts);
+          }
         }
       } else {
         for (std::size_t i = 0; i < block_size; ++i) {
           auto t_predts = out_predt.Slice(predict_offset + i, linalg::All());
-          multi::PredValueByOneTree<false>(thread_temp[offset + i], *tree.GetMultiTargetTree(),
-                                           cats, t_predts);
+          if (verbose) {
+            node_path = multi::PredValueByOneTreeVerbose<false>(thread_temp[offset + i], *tree.GetMultiTargetTree(),
+                                                                cats, t_predts);
+          } else {
+            multi::PredValueByOneTree<false>(thread_temp[offset + i], *tree.GetMultiTargetTree(),
+                                                    cats, t_predts);
+          }
         }
       }
     } else {
       auto const gid = model.tree_info[tree_id];
       if (has_categorical) {
         for (std::size_t i = 0; i < block_size; ++i) {
-          out_predt(predict_offset + i, gid) +=
-              scalar::PredValueByOneTree<true>(thread_temp[offset + i], tree, cats);
+          if (verbose) {
+            node_path = scalar::PredValueByOneTreeVerbose<true>(thread_temp[offset + i], tree, cats);
+            out_predt(predict_offset + i, gid) += tree[node_path.back()].LeafValue();
+          } else {
+            out_predt(predict_offset + i, gid) +=
+                scalar::PredValueByOneTree<true>(thread_temp[offset + i], tree, cats);
+          }
         }
       } else {
         for (std::size_t i = 0; i < block_size; ++i) {
-          out_predt(predict_offset + i, gid) +=
-              scalar::PredValueByOneTree<true>(thread_temp[offset + i], tree, cats);
+          if (verbose) {
+            node_path = scalar::PredValueByOneTreeVerbose<true>(thread_temp[offset + i], tree, cats);
+            out_predt(predict_offset + i, gid) += tree[node_path.back()].LeafValue();
+          } else {
+            out_predt(predict_offset + i, gid) +=
+                scalar::PredValueByOneTree<true>(thread_temp[offset + i], tree, cats);
+          }
         }
       }
     }
+    if (verbose) {
+      tree2path.insert(std::make_pair(tree_id, node_path));
+    }
   }
+  return tree2path;
 }
 
 template <typename DataView>
@@ -285,8 +369,8 @@ class AdapterView {
   bst_row_t const static base_rowid = 0;  // NOLINT
 };
 
-template <typename DataView, size_t block_of_rows_size>
-void PredictBatchByBlockOfRowsKernel(DataView batch, gbm::GBTreeModel const &model,
+template <typename DataView, size_t block_of_rows_size, bool verbose>
+std::map<uint32_t, std::vector<bst_node_t>> PredictBatchByBlockOfRowsKernel(DataView batch, gbm::GBTreeModel const &model,
                                      std::uint32_t tree_begin, std::uint32_t tree_end,
                                      std::vector<RegTree::FVec> *p_thread_temp, int32_t n_threads,
                                      linalg::TensorView<float, 2> out_predt) {
@@ -296,6 +380,10 @@ void PredictBatchByBlockOfRowsKernel(DataView batch, gbm::GBTreeModel const &mod
   const auto nsize = static_cast<bst_omp_uint>(batch.Size());
   const int num_feature = model.learner_model_param->num_feature;
   omp_ulong n_blocks = common::DivRoundUp(nsize, block_of_rows_size);
+  // verbose decision path information
+  std::map<uint32_t, std::vector<bst_node_t>> tree2path_globl;
+  omp_lock_t globl_lock;
+  omp_init_lock(&globl_lock);
 
   common::ParallelFor(n_blocks, n_threads, [&](bst_omp_uint block_id) {
     const size_t batch_offset = block_id * block_of_rows_size;
@@ -304,10 +392,19 @@ void PredictBatchByBlockOfRowsKernel(DataView batch, gbm::GBTreeModel const &mod
 
     FVecFill(block_size, batch_offset, num_feature, &batch, fvec_offset, p_thread_temp);
     // process block of rows through all trees to keep cache locality
-    PredictByAllTrees(model, tree_begin, tree_end, batch_offset + batch.base_rowid, thread_temp,
-                      fvec_offset, block_size, out_predt);
+    if (verbose) {
+      auto tree2path = PredictByAllTrees<true>(model, tree_begin, tree_end, batch_offset + batch.base_rowid, thread_temp,
+                        fvec_offset, block_size, out_predt);
+      omp_set_lock(&globl_lock);
+      tree2path_globl.insert(tree2path.begin(), tree2path.end());
+      omp_unset_lock(&globl_lock);
+    } else {
+      PredictByAllTrees<false>(model, tree_begin, tree_end, batch_offset + batch.base_rowid, thread_temp,
+                        fvec_offset, block_size, out_predt);
+    }
     FVecDrop(block_size, fvec_offset, p_thread_temp);
   });
+  return tree2path_globl;
 }
 
 float FillNodeMeanValues(RegTree const *tree, bst_node_t nidx, std::vector<float> *mean_values) {
@@ -608,12 +705,13 @@ class ColumnSplitHelper {
 
 class CPUPredictor : public Predictor {
  protected:
-  void PredictDMatrix(DMatrix *p_fmat, std::vector<bst_float> *out_preds,
+  template <bool verbose>
+  std::map<uint32_t, std::vector<bst_node_t>> PredictDMatrix(DMatrix *p_fmat, std::vector<bst_float> *out_preds,
                       gbm::GBTreeModel const &model, int32_t tree_begin, int32_t tree_end) const {
     if (p_fmat->Info().IsColumnSplit()) {
       ColumnSplitHelper helper(this->ctx_->Threads(), model, tree_begin, tree_end);
       helper.PredictDMatrix(p_fmat, out_preds);
-      return;
+      return std::map<uint32_t, std::vector<bst_node_t>> {};
     }
 
     auto const n_threads = this->ctx_->Threads();
@@ -631,48 +729,61 @@ class CPUPredictor : public Predictor {
     CHECK_EQ(out_preds->size(), n_samples * n_groups);
     linalg::TensorView<float, 2> out_predt{*out_preds, {n_samples, n_groups}, ctx_->gpu_id};
 
+    std::map<uint32_t, std::vector<bst_node_t>> tree2path_globl;
     if (!p_fmat->PageExists<SparsePage>()) {
       std::vector<Entry> workspace(p_fmat->Info().num_col_ * kUnroll * n_threads);
       auto ft = p_fmat->Info().feature_types.ConstHostVector();
       for (auto const &batch : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, {})) {
         if (blocked) {
-          PredictBatchByBlockOfRowsKernel<GHistIndexMatrixView, kBlockOfRowsSize>(
+          auto tree2path = PredictBatchByBlockOfRowsKernel<GHistIndexMatrixView, kBlockOfRowsSize, verbose>(
               GHistIndexMatrixView{batch, p_fmat->Info().num_col_, ft, workspace, n_threads}, model,
               tree_begin, tree_end, &feat_vecs, n_threads, out_predt);
+          tree2path_globl.insert(tree2path.begin(), tree2path.end());
         } else {
-          PredictBatchByBlockOfRowsKernel<GHistIndexMatrixView, 1>(
+          auto tree2path = PredictBatchByBlockOfRowsKernel<GHistIndexMatrixView, 1, verbose>(
               GHistIndexMatrixView{batch, p_fmat->Info().num_col_, ft, workspace, n_threads}, model,
               tree_begin, tree_end, &feat_vecs, n_threads, out_predt);
+          tree2path_globl.insert(tree2path.begin(), tree2path.end());
         }
       }
     } else {
       for (auto const &batch : p_fmat->GetBatches<SparsePage>()) {
         if (blocked) {
-          PredictBatchByBlockOfRowsKernel<SparsePageView, kBlockOfRowsSize>(
+          auto tree2path = PredictBatchByBlockOfRowsKernel<SparsePageView, kBlockOfRowsSize, verbose>(
               SparsePageView{&batch}, model, tree_begin, tree_end, &feat_vecs, n_threads,
               out_predt);
-
+          tree2path_globl.insert(tree2path.begin(), tree2path.end());
         } else {
-          PredictBatchByBlockOfRowsKernel<SparsePageView, 1>(SparsePageView{&batch}, model,
+          auto tree2path = PredictBatchByBlockOfRowsKernel<SparsePageView, 1, verbose>(SparsePageView{&batch}, model,
                                                              tree_begin, tree_end, &feat_vecs,
                                                              n_threads, out_predt);
+          tree2path_globl.insert(tree2path.begin(), tree2path.end());
         }
       }
     }
+    return tree2path_globl;
   }
 
  public:
   explicit CPUPredictor(Context const *ctx) : Predictor::Predictor{ctx} {}
 
   void PredictBatch(DMatrix *dmat, PredictionCacheEntry *predts, const gbm::GBTreeModel &model,
-                    uint32_t tree_begin, uint32_t tree_end = 0) const override {
+                    std::vector<std::vector<bst_node_t>> *path_list, uint32_t tree_begin, uint32_t tree_end = 0) const override {
     auto *out_preds = &predts->predictions;
     // This is actually already handled in gbm, but large amount of tests rely on the
     // behaviour.
     if (tree_end == 0) {
       tree_end = model.trees.size();
     }
-    this->PredictDMatrix(dmat, &out_preds->HostVector(), model, tree_begin, tree_end);
+    std::map<uint32_t, std::vector<bst_node_t>> tree2path;
+    if (path_list != nullptr) {
+      tree2path = this->PredictDMatrix<true>(dmat, &out_preds->HostVector(), model, tree_begin, tree_end);
+      for (auto &pair : tree2path) {
+        path_list->at(pair.first) = pair.second;
+      }
+    } else {
+      this->PredictDMatrix<false>(dmat, &out_preds->HostVector(), model, tree_begin, tree_end);
+    }
   }
 
   template <typename Adapter, size_t kBlockSize>
@@ -699,13 +810,13 @@ class CPUPredictor : public Predictor {
     InitThreadTemp(n_threads * kBlockSize, &thread_temp);
     std::size_t n_groups = model.learner_model_param->OutputLength();
     linalg::TensorView<float, 2> out_predt{predictions, {m->NumRows(), n_groups}, Context::kCpuId};
-    PredictBatchByBlockOfRowsKernel<AdapterView<Adapter>, kBlockSize>(
+    PredictBatchByBlockOfRowsKernel<AdapterView<Adapter>, kBlockSize, false>(
         AdapterView<Adapter>(m.get(), missing, common::Span<Entry>{workspace}, n_threads), model,
         tree_begin, tree_end, &thread_temp, n_threads, out_predt);
   }
 
   bool InplacePredict(std::shared_ptr<DMatrix> p_m, const gbm::GBTreeModel &model, float missing,
-                      PredictionCacheEntry *out_preds, uint32_t tree_begin,
+                      PredictionCacheEntry *out_preds, std::vector<std::vector<bst_node_t>> *path_list, uint32_t tree_begin,
                       unsigned tree_end) const override {
     auto proxy = dynamic_cast<data::DMatrixProxy *>(p_m.get());
     CHECK(proxy)<< "Inplace predict accepts only DMatrixProxy as input.";
@@ -730,7 +841,7 @@ class CPUPredictor : public Predictor {
 
   void PredictInstance(const SparsePage::Inst& inst,
                        std::vector<bst_float>* out_preds,
-                       const gbm::GBTreeModel& model, unsigned ntree_limit) const override {
+                       const gbm::GBTreeModel& model, std::vector<std::vector<bst_node_t>> *path_list, unsigned ntree_limit) const override {
     CHECK(!model.learner_model_param->IsVectorLeaf()) << "predict instance" << MTNotImplemented();
     std::vector<RegTree::FVec> feat_vecs;
     feat_vecs.resize(1, RegTree::FVec());
@@ -750,7 +861,7 @@ class CPUPredictor : public Predictor {
   }
 
   void PredictLeaf(DMatrix *p_fmat, HostDeviceVector<bst_float> *out_preds,
-                   const gbm::GBTreeModel &model, unsigned ntree_limit) const override {
+                   const gbm::GBTreeModel &model, std::vector<std::vector<bst_node_t>> *path_list, unsigned ntree_limit) const override {
     auto const n_threads = this->ctx_->Threads();
     std::vector<RegTree::FVec> feat_vecs;
     const int num_feature = model.learner_model_param->num_feature;

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -515,7 +515,7 @@ class JsonGenerator : public TreeGenerator {
   }
 
   void BuildPath(RegTree const &tree, const std::vector<int32_t> &path) override {
-    static std::string const pathEntryTemplate = "{{properties} {stat}},\n";
+    static std::string const pathEntryTemplate = "{{properties} {stat}}";
     std::string result;
     for (uint32_t i = 0; i < path.size(); ++i) {
       int32_t nid = path.at(i);
@@ -527,10 +527,22 @@ class JsonGenerator : public TreeGenerator {
               {"{stat}", with_stats_ ? this->NodeStat(tree, nid) : ""},
           }
       );
+      if (i < path.size() - 1) {
+        result += std::string(",");
+      }
+      result += std::string("\n");
     }
     ss_ << result;
   }
 };
+
+void PrintDecisionPath(FILE *os, const std::vector<std::string> &decision_paths_dumped) {
+  fprintf(os, "[");
+  for (uint32_t tree_id = 0; tree_id < decision_paths_dumped.size(); ++tree_id) {
+    fprintf(stderr, "%s,\n", decision_paths_dumped.at(tree_id).c_str());
+  }
+  fprintf(os, "]");
+}
 
 XGBOOST_REGISTER_TREE_IO(JsonGenerator, "json")
     .describe("Dump json representation of tree")

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -111,12 +111,14 @@ TEST(GBTree, DecisionPath) {
   for (uint32_t feat_i = 0; feat_i < kCols; ++feat_i) {
     feature_map.PushBack(feat_i, (std::string("feat_slot_") + std::to_string(feat_i)).c_str(), "float");
   }
-  std::vector<std::vector<bst_node_t>> decision_paths;
-  gbtree.PredictBatch(p_m.get(), &out_predictions, false, &decision_paths, 0, 1);
-  auto decision_paths_dumped = gbtree.DumpDecisionPath(feature_map, true, decision_paths);
-  for (uint32_t tree_id = 0; tree_id < decision_paths_dumped.size(); ++tree_id) {
-    fprintf(stderr, "tree_id: %u\n\t%s\n", tree_id, decision_paths_dumped.at(tree_id).c_str());
+  std::vector<TreeSetDecisionPath> row2paths;
+  row2paths.reserve(p_m->Info().num_row_);
+  for (uint32_t row_id = 0; row_id < p_m->Info().num_row_; ++row_id) {
+    row2paths.emplace_back(TreeSetDecisionPath{static_cast<uint32_t>(gbtree.GetTreeCount())});
   }
+  gbtree.PredictBatch(p_m.get(), &out_predictions, false, &row2paths, 0, 1);
+  auto decision_paths_dumped = gbtree.DumpDecisionPath(feature_map, true, row2paths);
+  PrintDecisionPath(stderr, decision_paths_dumped);
   ASSERT_EQ(1, out_predictions.version);
   std::vector<float> first_iter = out_predictions.predictions.HostVector();
 }

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -36,7 +36,7 @@ TEST(CpuPredictor, Basic) {
   // Test predict batch
   PredictionCacheEntry out_predictions;
   cpu_predictor->InitOutPredictions(dmat->Info(), &out_predictions.predictions, model);
-  cpu_predictor->PredictBatch(dmat.get(), &out_predictions, model, 0);
+  cpu_predictor->PredictBatch(dmat.get(), &out_predictions, model, nullptr, 0);
 
   std::vector<float>& out_predictions_h = out_predictions.predictions.HostVector();
   for (size_t i = 0; i < out_predictions.predictions.Size(); i++) {
@@ -48,13 +48,13 @@ TEST(CpuPredictor, Basic) {
   auto page = batch.GetView();
   for (size_t i = 0; i < batch.Size(); i++) {
     std::vector<float> instance_out_predictions;
-    cpu_predictor->PredictInstance(page[i], &instance_out_predictions, model);
+    cpu_predictor->PredictInstance(page[i], &instance_out_predictions, model, nullptr);
     ASSERT_EQ(instance_out_predictions[0], 1.5);
   }
 
   // Test predict leaf
   HostDeviceVector<float> leaf_out_predictions;
-  cpu_predictor->PredictLeaf(dmat.get(), &leaf_out_predictions, model);
+  cpu_predictor->PredictLeaf(dmat.get(), &leaf_out_predictions, model, nullptr);
   auto const& h_leaf_out_predictions = leaf_out_predictions.ConstHostVector();
   for (auto v : h_leaf_out_predictions) {
     ASSERT_EQ(v, 0);
@@ -112,7 +112,7 @@ void TestColumnSplitPredictBatch() {
   PredictionCacheEntry out_predictions;
   cpu_predictor->InitOutPredictions(dmat->Info(), &out_predictions.predictions, model);
   auto sliced = std::unique_ptr<DMatrix>{dmat->SliceCol(world_size, rank)};
-  cpu_predictor->PredictBatch(sliced.get(), &out_predictions, model, 0);
+  cpu_predictor->PredictBatch(sliced.get(), &out_predictions, model, nullptr, 0);
 
   std::vector<float>& out_predictions_h = out_predictions.predictions.HostVector();
   for (size_t i = 0; i < out_predictions.predictions.Size(); i++) {
@@ -149,7 +149,7 @@ TEST(CpuPredictor, ExternalMemory) {
   // Test predict batch
   PredictionCacheEntry out_predictions;
   cpu_predictor->InitOutPredictions(dmat->Info(), &out_predictions.predictions, model);
-  cpu_predictor->PredictBatch(dmat.get(), &out_predictions, model, 0);
+  cpu_predictor->PredictBatch(dmat.get(), &out_predictions, model, nullptr, 0);
   std::vector<float> &out_predictions_h = out_predictions.predictions.HostVector();
   ASSERT_EQ(out_predictions.predictions.Size(), dmat->Info().num_row_);
   for (const auto& v : out_predictions_h) {
@@ -158,7 +158,7 @@ TEST(CpuPredictor, ExternalMemory) {
 
   // Test predict leaf
   HostDeviceVector<float> leaf_out_predictions;
-  cpu_predictor->PredictLeaf(dmat.get(), &leaf_out_predictions, model);
+  cpu_predictor->PredictLeaf(dmat.get(), &leaf_out_predictions, model, nullptr);
   auto const& h_leaf_out_predictions = leaf_out_predictions.ConstHostVector();
   ASSERT_EQ(h_leaf_out_predictions.size(), dmat->Info().num_row_);
   for (const auto& v : h_leaf_out_predictions) {
@@ -264,7 +264,7 @@ void TestUpdatePredictionCache(bool use_subsampling) {
 
   PredictionCacheEntry out_predictions;
   // perform fair prediction on the same input data, should be equal to cached result
-  gbm->PredictBatch(dmat.get(), &out_predictions, false, 0, 0);
+  gbm->PredictBatch(dmat.get(), &out_predictions, false, nullptr, 0, 0);
 
   std::vector<float> &out_predictions_h = out_predictions.predictions.HostVector();
   std::vector<float> &predtion_cache_from_train = predtion_cache.predictions.HostVector();

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -238,7 +238,7 @@ void TestCategoricalPrediction(std::string name) {
   m->Info().feature_types.HostVector() = types;
 
   predictor->InitOutPredictions(m->Info(), &out_predictions.predictions, model);
-  predictor->PredictBatch(m.get(), &out_predictions, model, 0);
+  predictor->PredictBatch(m.get(), &out_predictions, model, nullptr, 0);
   auto score = mparam.BaseScore(Context::kCpuId)(0);
   ASSERT_EQ(out_predictions.predictions.Size(), 1ul);
   ASSERT_EQ(out_predictions.predictions.HostVector()[0],
@@ -248,7 +248,7 @@ void TestCategoricalPrediction(std::string name) {
   m = GetDMatrixFromData(row, 1, kCols);
   out_predictions.version = 0;
   predictor->InitOutPredictions(m->Info(), &out_predictions.predictions, model);
-  predictor->PredictBatch(m.get(), &out_predictions, model, 0);
+  predictor->PredictBatch(m.get(), &out_predictions, model, nullptr, 0);
   ASSERT_EQ(out_predictions.predictions.HostVector()[0], left_weight + score);
 }
 
@@ -276,7 +276,7 @@ void TestCategoricalPredictLeaf(StringView name) {
   row[split_ind] = split_cat;
   auto m = GetDMatrixFromData(row, 1, kCols);
 
-  predictor->PredictLeaf(m.get(), &out_predictions.predictions, model);
+  predictor->PredictLeaf(m.get(), &out_predictions.predictions, model, nullptr);
   CHECK_EQ(out_predictions.predictions.Size(), 1);
   // go to left if it doesn't match the category, otherwise right.
   ASSERT_EQ(out_predictions.predictions.HostVector()[0], 2);
@@ -285,7 +285,7 @@ void TestCategoricalPredictLeaf(StringView name) {
   m = GetDMatrixFromData(row, 1, kCols);
   out_predictions.version = 0;
   predictor->InitOutPredictions(m->Info(), &out_predictions.predictions, model);
-  predictor->PredictLeaf(m.get(), &out_predictions.predictions, model);
+  predictor->PredictLeaf(m.get(), &out_predictions.predictions, model, nullptr);
   ASSERT_EQ(out_predictions.predictions.HostVector()[0], 1);
 }
 

--- a/tests/cpp/predictor/test_predictor.h
+++ b/tests/cpp/predictor/test_predictor.h
@@ -52,11 +52,11 @@ void TestPredictionFromGradientIndex(std::string name, size_t rows, size_t cols,
 
     PredictionCacheEntry approx_out_predictions;
     predictor->InitOutPredictions(p_hist->Info(), &approx_out_predictions.predictions, model);
-    predictor->PredictBatch(p_hist.get(), &approx_out_predictions, model, 0);
+    predictor->PredictBatch(p_hist.get(), &approx_out_predictions, model, nullptr, 0);
 
     PredictionCacheEntry precise_out_predictions;
     predictor->InitOutPredictions(p_precise->Info(), &precise_out_predictions.predictions, model);
-    predictor->PredictBatch(p_precise.get(), &precise_out_predictions, model, 0);
+    predictor->PredictBatch(p_precise.get(), &precise_out_predictions, model, nullptr, 0);
 
     for (size_t i = 0; i < rows; ++i) {
       CHECK_EQ(approx_out_predictions.predictions.HostVector()[i],
@@ -71,7 +71,7 @@ void TestPredictionFromGradientIndex(std::string name, size_t rows, size_t cols,
     auto p_dmat = RandomDataGenerator(rows, cols, 0).GenerateDMatrix();
     PredictionCacheEntry precise_out_predictions;
     predictor->InitOutPredictions(p_dmat->Info(), &precise_out_predictions.predictions, model);
-    predictor->PredictBatch(p_dmat.get(), &precise_out_predictions, model, 0);
+    predictor->PredictBatch(p_dmat.get(), &precise_out_predictions, model, nullptr, 0);
     CHECK(!p_dmat->PageExists<Page>());
   }
 }


### PR DESCRIPTION
This patch follows this issue https://github.com/dmlc/xgboost/issues/9128. I have already implemented a prototype for dumping decision paths in tree models. `XGBoosterPredictFromDMatrix` calls this new version of `predict` and works as expected when called from Python.

A dumped decision path looks like the following:
```json
[{"row_index": 0, "decision_path": [
{ "nodeid": 0, "depth": 0, "split": "feat_slot_8", "split_condition": 0.18880336, "yes": 1, "no": 2, "missing": 2 , "gain": 3.37755585, "cover": 46.0216866},
{ "nodeid": 2, "depth": 1, "split": "feat_slot_1", "split_condition": 0.0665793717, "yes": 5, "no": 6, "missing": 6 , "gain": 1.01384354, "cover": 34.8793144},
{ "nodeid": 5, "depth": 2, "split": "feat_slot_5", "split_condition": 0.137061194, "yes": 11, "no": 12, "missing": 12 , "gain": 0.0831073523, "cover": 2.51199985}
]},
{"row_index": 1, "decision_path": [
{ "nodeid": 0, "depth": 0, "split": "feat_slot_8", "split_condition": 0.18880336, "yes": 1, "no": 2, "missing": 2 , "gain": 3.37755585, "cover": 46.0216866},
{ "nodeid": 2, "depth": 1, "split": "feat_slot_1", "split_condition": 0.0665793717, "yes": 5, "no": 6, "missing": 6 , "gain": 1.01384354, "cover": 34.8793144},
{ "nodeid": 6, "depth": 2, "split": "feat_slot_7", "split_condition": 0.579003334, "yes": 13, "no": 14, "missing": 14 , "gain": 1.50590134, "cover": 32.3673134},
{ "nodeid": 13, "depth": 3, "split": "feat_slot_8", "split_condition": 0.632688642, "yes": 15, "no": 16, "missing": 16 , "gain": 0.154432297, "cover": 25.213913},
{ "nodeid": 15, "depth": 4, "split": "feat_slot_7", "split_condition": 0.119174264, "yes": 19, "no": 20, "missing": 20 , "gain": 0.0240440369, "cover": 16.2166805}
]},
{"row_index": 2, "decision_path": [
{ "nodeid": 0, "depth": 0, "split": "feat_slot_8", "split_condition": 0.18880336, "yes": 1, "no": 2, "missing": 2 , "gain": 3.37755585, "cover": 46.0216866},
{ "nodeid": 2, "depth": 1, "split": "feat_slot_1", "split_condition": 0.0665793717, "yes": 5, "no": 6, "missing": 6 , "gain": 1.01384354, "cover": 34.8793144},
{ "nodeid": 6, "depth": 2, "split": "feat_slot_7", "split_condition": 0.579003334, "yes": 13, "no": 14, "missing": 14 , "gain": 1.50590134, "cover": 32.3673134},
{ "nodeid": 13, "depth": 3, "split": "feat_slot_8", "split_condition": 0.632688642, "yes": 15, "no": 16, "missing": 16 , "gain": 0.154432297, "cover": 25.213913},
{ "nodeid": 15, "depth": 4, "split": "feat_slot_7", "split_condition": 0.119174264, "yes": 19, "no": 20, "missing": 20 , "gain": 0.0240440369, "cover": 16.2166805}
]},
{"row_index": 3, "decision_path": [
{ "nodeid": 0, "depth": 0, "split": "feat_slot_8", "split_condition": 0.18880336, "yes": 1, "no": 2, "missing": 2 , "gain": 3.37755585, "cover": 46.0216866},
{ "nodeid": 2, "depth": 1, "split": "feat_slot_1", "split_condition": 0.0665793717, "yes": 5, "no": 6, "missing": 6 , "gain": 1.01384354, "cover": 34.8793144},
{ "nodeid": 6, "depth": 2, "split": "feat_slot_7", "split_condition": 0.579003334, "yes": 13, "no": 14, "missing": 14 , "gain": 1.50590134, "cover": 32.3673134},
{ "nodeid": 13, "depth": 3, "split": "feat_slot_8", "split_condition": 0.632688642, "yes": 15, "no": 16, "missing": 16 , "gain": 0.154432297, "cover": 25.213913},
{ "nodeid": 16, "depth": 4, "split": "feat_slot_6", "split_condition": 0.774850428, "yes": 21, "no": 22, "missing": 22 , "gain": 0.0456981659, "cover": 8.99723244}
]},...
```

Some future work direction:
- Fix format issues & add doc comments.
- Add path dumping in other formats (text, graphviz)
- Add api support in other programming languages