### PR TITLE
Fix `_defined` typo

### DIFF
--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -150,7 +150,7 @@ inline LINALG_HD int Popc(uint64_t v) {
   return __popcll(v);
 #elif defined(__GNUC__) || defined(__clang__)
   return __builtin_popcountll(v);
-#elif defined(_MSC_VER) && _defined(_M_X64)
+#elif defined(_MSC_VER) && defined(_M_X64)
   return __popcnt64(v);
 #else
   return NativePopc(v);


### PR DESCRIPTION
Attempting to build XGBoost with MSVC fails catastrophically because there's a preprocessor line saying `_defined` which is malformed. This is the only occurrence in the whole codebase and it appears to be a simple typo.

After fixing this, compilation appears to succeed (with compiler warnings).