### PR TITLE
Avoid redefining `_CRT_SECURE_NO_WARNINGS`, `_CRT_SECURE_NO_DEPRECATE`

### DIFF
--- a/src/cli_main.cc
+++ b/src/cli_main.cc
@@ -4,9 +4,6 @@
  * \brief The command line interface program of xgboost.
  *  This file is not included in dynamic library.
  */
-#define _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_DEPRECATE
-
 #if !defined(NOMINMAX) && defined(_WIN32)
 #define NOMINMAX
 #endif  // !defined(NOMINMAX)


### PR DESCRIPTION
Building XGBoost with MSVC emits:

```
src\cli_main.cc(7): warning C4005: '_CRT_SECURE_NO_WARNINGS': macro redefinition
src\cli_main.cc(7): note: '_CRT_SECURE_NO_WARNINGS' previously declared on the command line
src\cli_main.cc(8): warning C4005: '_CRT_SECURE_NO_DEPRECATE': macro redefinition
src\cli_main.cc(8): note: '_CRT_SECURE_NO_DEPRECATE' previously declared on the command line
```

These macros are indeed defined on the command line by:

https://github.com/dmlc/xgboost/blob/603f8ce2fa71eecedadd837316dcac95ab7f4ff7/cmake/Utils.cmake#L223-L229

Removing the definitions in `cli_main.cc` avoids the redefinition warnings, without emitting any Secure CRT warnings.