### PR TITLE
Fix `IndexTransformIter` to be compatible with C++23

### DIFF
--- a/src/common/transform_iterator.h
+++ b/src/common/transform_iterator.h
@@ -26,9 +26,9 @@ class IndexTransformIter {
 
  public:
   using iterator_category = std::random_access_iterator_tag;  // NOLINT
-  using value_type = std::result_of_t<Fn(std::size_t)>;       // NOLINT
+  using reference = std::result_of_t<Fn(std::size_t)>;        // NOLINT
+  using value_type = std::remove_cv_t<std::remove_reference_t<reference>>; // NOLINT
   using difference_type = detail::ptrdiff_t;                  // NOLINT
-  using reference = std::add_lvalue_reference_t<value_type>;  // NOLINT
   using pointer = std::add_pointer_t<value_type>;             // NOLINT
 
  public:
@@ -43,8 +43,8 @@ class IndexTransformIter {
     return *this;
   }
 
-  value_type operator*() const { return fn_(iter_); }
-  value_type operator[](std::size_t i) const {
+  reference operator*() const { return fn_(iter_); }
+  reference operator[](std::size_t i) const {
     auto iter = *this + i;
     return *iter;
   }


### PR DESCRIPTION
Fixes #9127.

In the STL's conventions, an iterator's `value_type` should always be "plain" - no cv-qualifiers and no references. Although this convention dates back to C++98, code could sometimes violate it and still compile, depending on the exact operations used by any instantiated templates. However, now that C++ has evolved to perform concept checking, stricter enforcement is happening within STL algorithms. XGBoost fails to compile with MSVC's `/std:c++latest` mode because its iterator `IndexTransformIter` has a `value_type` that doesn't follow the proper conventions.

This PR is my attempted fix, which appears to resolve the compilation issues, and "seems reasonable" to me - it changes the `value_type` to be plain by using `remove_cvref_t` (but written in the older style to avoid depending on the C++20 convenience type trait), while `reference` is the type that's being returned by the `Fn` invocation.

Note that the actual return types of `operator*` and `operator[]` are being preserved (they continue to return the `result_of_t`), it's just the mentioned typedef that's changing.

Because I work on the C++ Standard Library all day and haven't actually used XGBoost or run its tests, this PR could have subtle implications elsewhere. I hope that it's correct or at least a good start.