### PR TITLE
[jvm-package] separate spark.version for cpu and gpu

### DIFF
--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -35,6 +35,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <flink.version>1.17.0</flink.version>
         <spark.version>3.4.0</spark.version>
+        <spark.version.gpu>3.3.2</spark.version.gpu>
         <scala.version>2.12.17</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <hadoop.version>3.3.5</hadoop.version>

--- a/jvm-packages/xgboost4j-spark-gpu/pom.xml
+++ b/jvm-packages/xgboost4j-spark-gpu/pom.xml
@@ -29,19 +29,19 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
+            <version>${spark.version.gpu}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
+            <version>${spark.version.gpu}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
+            <version>${spark.version.gpu}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
spark-rapids may not always support the latest spark version, so this PR adds an extra spark.version.gpu property to specify spark version for xgboost4j-spark-gpu.