### PR TITLE
Core.py removing 'type: ignore' hints

### DIFF
--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -395,7 +395,7 @@ class EarlyStopping(TrainingCallback):
             self.stopping_history[name][metric] = cast(_ScoreList, [score])
             self.best_scores[name] = {}
             self.best_scores[name][metric] = [score]
-            model.set_attr(best_score=str(score), best_iteration=int(epoch))
+            model.set_attr(best_score=str(score), best_iteration=str(epoch))
         elif not improve_op(score, self.best_scores[name][metric][-1]):
             # Not improved
             self.stopping_history[name][metric].append(score)  # type: ignore

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -395,7 +395,7 @@ class EarlyStopping(TrainingCallback):
             self.stopping_history[name][metric] = cast(_ScoreList, [score])
             self.best_scores[name] = {}
             self.best_scores[name][metric] = [score]
-            model.set_attr(best_score=str(score), best_iteration=str(epoch))
+            model.set_attr(best_score=str(score), best_iteration=int(epoch))
         elif not improve_op(score, self.best_scores[name][metric][-1]):
             # Not improved
             self.stopping_history[name][metric].append(score)  # type: ignore

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -317,7 +317,7 @@ def _cuda_array_interface(data: DataType) -> bytes:
 def ctypes2numpy(cptr: CNumericPtr, length: int, dtype: Type[np.number]) -> np.ndarray:
     """Convert a ctypes pointer array to a numpy array."""
     ctype: Type[CNumeric] = _numpy2ctypes_type(dtype)
-    if not isinstance(cptr, ctypes.POINTER(ctype)):  # type: ignore
+    if not isinstance(cptr, ctypes.POINTER(ctype)):
         raise RuntimeError(f"expected {ctype} pointer")
     res = np.zeros(length, dtype=dtype)
     if not ctypes.memmove(res.ctypes.data, cptr, length * res.strides[0]):
@@ -2458,9 +2458,9 @@ class Booster:
             raise TypeError("Unknown file type: ", fname)
 
         if self.attr("best_iteration") is not None:
-            self.best_iteration = int(self.attr("best_iteration"))  # type: ignore
+            self.best_iteration = int(cast(int,self.attr("best_iteration")))
         if self.attr("best_score") is not None:
-            self.best_score = float(self.attr("best_score"))  # type: ignore
+            self.best_score = float(cast(float,self.attr("best_score")))
 
     def num_boosted_rounds(self) -> int:
         """Get number of boosted rounds.  For gblinear this is reset to 0 after

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -82,12 +82,10 @@ def from_pystr_to_cstr(data: Union[str, List[str]]) -> Union[bytes, ctypes.Array
     if isinstance(data, str):
         return bytes(data, "utf-8")
     if isinstance(data, list):
-        pointers: ctypes.Array[ctypes.c_char_p] = (ctypes.c_char_p * len(data))()
-        data_as_bytes = [bytes(d, "utf-8") for d in data]
-        pointers[:] = data_as_bytes  # type: ignore
+        data_as_bytes: List[bytes] = [bytes(d, "utf-8") for d in data]
+        pointers: ctypes.Array[ctypes.c_char_p] = (ctypes.c_char_p * len(data_as_bytes))(*data_as_bytes)
         return pointers
     raise TypeError()
-
 
 def from_cstr_to_pystr(data: CStrPptr, length: c_bst_ulong) -> List[str]:
     """Revert C pointer to Python str

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -83,9 +83,12 @@ def from_pystr_to_cstr(data: Union[str, List[str]]) -> Union[bytes, ctypes.Array
         return bytes(data, "utf-8")
     if isinstance(data, list):
         data_as_bytes: List[bytes] = [bytes(d, "utf-8") for d in data]
-        pointers: ctypes.Array[ctypes.c_char_p] = (ctypes.c_char_p * len(data_as_bytes))(*data_as_bytes)
+        pointers: ctypes.Array[ctypes.c_char_p] = (
+            ctypes.c_char_p * len(data_as_bytes)
+        )(*data_as_bytes)
         return pointers
     raise TypeError()
+
 
 def from_cstr_to_pystr(data: CStrPptr, length: c_bst_ulong) -> List[str]:
     """Revert C pointer to Python str
@@ -2458,9 +2461,9 @@ class Booster:
             raise TypeError("Unknown file type: ", fname)
 
         if self.attr("best_iteration") is not None:
-            self.best_iteration = int(cast(int,self.attr("best_iteration")))
+            self.best_iteration = int(cast(int, self.attr("best_iteration")))
         if self.attr("best_score") is not None:
-            self.best_score = float(cast(float,self.attr("best_score")))
+            self.best_score = float(cast(float, self.attr("best_score")))
 
     def num_boosted_rounds(self) -> int:
         """Get number of boosted rounds.  For gblinear this is reset to 0 after


### PR DESCRIPTION
As part of [this issue](https://github.com/dmlc/xgboost/issues/6496#issuecomment-1558022930), we want to remove some of the `type: ignore` hints to make the code more rigorous. This PR will aim to remove all the `type: ignore` hints in core.py