### PR TITLE
Skip optional synchronization in thrust.

### DIFF
--- a/src/common/cuda_context.cuh
+++ b/src/common/cuda_context.cuh
@@ -17,11 +17,23 @@ struct CUDAContext {
   /**
    * \brief Caching thrust policy.
    */
-  auto CTP() const { return thrust::cuda::par_nosync(caching_alloc_).on(dh::DefaultStream()); }
+  auto CTP() const {
+#if THRUST_MAJOR_VERSION >= 2
+    return thrust::cuda::par_nosync(caching_alloc_).on(dh::DefaultStream());
+#else
+    return thrust::cuda::par(caching_alloc_).on(dh::DefaultStream());
+#endif  // THRUST_MAJOR_VERSION >= 2
+  }
   /**
    * \brief Thrust policy without caching allocator.
    */
-  auto TP() const { return thrust::cuda::par_nosync(alloc_).on(dh::DefaultStream()); }
+  auto TP() const {
+#if THRUST_MAJOR_VERSION >= 2
+    return thrust::cuda::par_nosync(alloc_).on(dh::DefaultStream());
+#else
+    return thrust::cuda::par(alloc_).on(dh::DefaultStream());
+#endif  // THRUST_MAJOR_VERSION >= 2
+  }
   auto Stream() const { return dh::DefaultStream(); }
 };
 }  // namespace xgboost


### PR DESCRIPTION
- Use `par_nosync` from thrust 2.0 (bundled in CTK 12.0).