### PR TITLE
Rearranged maven profiles so that scala-2.13 artifacts are published without gpu-related libraries

### DIFF
--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -301,14 +301,6 @@
                     <url>https://s3.amazonaws.com/xgboost-maven-repo/release</url>
                 </repository>
             </repositories>
-            <modules>
-                <module>xgboost4j</module>
-                <module>xgboost4j-example</module>
-                <module>xgboost4j-spark</module>
-                <module>xgboost4j-flink</module>
-                <module>xgboost4j-gpu</module>
-                <module>xgboost4j-spark-gpu</module>
-            </modules>
             <build>
                 <plugins>
                     <plugin>

--- a/tests/ci_build/deploy_jvm_packages.sh
+++ b/tests/ci_build/deploy_jvm_packages.sh
@@ -18,8 +18,17 @@ rm -rf $(find . -name target)
 rm -rf ../build/
 
 # Re-build package without Mock Rabit
+# Maven profiles:
+# `default`           includes modules: xgboost4j, xgboost4j-spark, xgboost4j-flink, xgboost4j-example
+# `gpu`               includes modules: xgboost4j-gpu, xgboost4j-spark-gpu, sets `use.cuda = ON`
+# `scala-2.13`        sets the scala binary version to the 2.13
+# `release-to-s3`     sets maven deployment targets
+
 # Deploy to S3 bucket xgboost-maven-repo
-mvn --no-transfer-progress package deploy -Duse.cuda=ON -P release-to-s3 -Dspark.version=${spark_version} -DskipTests
+mvn --no-transfer-progress package deploy -P default,gpu,release-to-s3 -Dspark.version=${spark_version} -DskipTests
+# Deploy scala 2.13 to S3 bucket xgboost-maven-repo
+mvn --no-transfer-progress package deploy -P release-to-s3,default,scala-2.13 -Dspark.version=${spark_version} -DskipTests
+
 
 set +x
 set +e


### PR DESCRIPTION
I've noticed that the 2.13 is missing in the S3 snapshot folder.
