### PR TITLE
expand_entry remove redundant methods

### DIFF
--- a/src/tree/gpu_hist/expand_entry.cuh
+++ b/src/tree/gpu_hist/expand_entry.cuh
@@ -42,12 +42,6 @@ struct GPUExpandEntry {
     return true;
   }
 
-  static bool ChildIsValid(const TrainParam& param, int depth, int num_leaves) {
-    if (param.max_depth > 0 && depth >= param.max_depth) return false;
-    if (param.max_leaves > 0 && num_leaves >= param.max_leaves) return false;
-    return true;
-  }
-
   bst_float GetLossChange() const {
     return split.loss_chg;
   }

--- a/src/tree/hist/expand_entry.h
+++ b/src/tree/hist/expand_entry.h
@@ -26,12 +26,6 @@ struct ExpandEntryImpl {
   }
   [[nodiscard]] bst_node_t GetNodeId() const { return nid; }
 
-  static bool ChildIsValid(TrainParam const& param, bst_node_t depth, bst_node_t num_leaves) {
-    if (param.max_depth > 0 && depth >= param.max_depth) return false;
-    if (param.max_leaves > 0 && num_leaves >= param.max_leaves) return false;
-    return true;
-  }
-
   [[nodiscard]] bool IsValid(TrainParam const& param, bst_node_t num_leaves) const {
     return static_cast<Impl const*>(this)->IsValidImpl(param, num_leaves);
   }


### PR DESCRIPTION
This function does not seem to be used in the code.