### PR TITLE
Disable shap package related tests on the 1.7 branch.

### DIFF
--- a/tests/ci_build/conda_env/aarch64_test.yml
+++ b/tests/ci_build/conda_env/aarch64_test.yml
@@ -31,6 +31,5 @@ dependencies:
 - pyspark
 - cloudpickle
 - pip:
-  - shap
   - awscli
   - auditwheel

--- a/tests/ci_build/conda_env/cpu_test.yml
+++ b/tests/ci_build/conda_env/cpu_test.yml
@@ -34,7 +34,6 @@ dependencies:
 - pyarrow
 - protobuf
 - cloudpickle
-- shap
 - modin
 # TODO: Replace it with pyspark>=3.4 once 3.4 released.
 # - https://ml-team-public-read.s3.us-west-2.amazonaws.com/pyspark-3.4.0.dev0.tar.gz


### PR DESCRIPTION
Due to error: https://buildkite.com/xgboost/xgboost-ci/builds/2712#0188a1cf-1666-4259-9bc4-e25b206ff73d .

The test is disabled on the master branch due to the removal of `ntree_limit`. I will find time to work on SHAP integration after major tasks for 2.0 are completed.