### PR TITLE
[CI] Run two pipeline loaders for responsiveness

### DIFF
--- a/tests/buildkite/infrastructure/aws-stack-creator/metadata.py
+++ b/tests/buildkite/infrastructure/aws-stack-creator/metadata.py
@@ -80,8 +80,8 @@ STACK_PARAMS = {
         "InstanceOperatingSystem": "linux",
         "InstanceType": "t3a.micro",
         "AgentsPerInstance": "1",
-        "MinSize": "1",
-        "MaxSize": "1",
+        "MinSize": "2",
+        "MaxSize": "2",
         "OnDemandPercentage": "100",
         "ScaleOutFactor": "1.0",
         "ScaleInIdlePeriod": "60",  # in seconds


### PR DESCRIPTION
Currently, only one worker listens to CI job requests. This leads to delays when many pull requests are being run at the same time.

Fix: Have two workers listen to CI job requests. The cost won't increase, as I am using spare capacity in EC2 Reserved Instances.