### PR TITLE
[doc] Variable 'label' is not defined in the pyspark application example #9301

### DIFF
--- a/doc/tutorials/spark_estimator.rst
+++ b/doc/tutorials/spark_estimator.rst
@@ -146,7 +146,7 @@ using a list of feature names and the additional parameter ``use_gpu``:
   label_name = "class"
 
   # get a list with feature column names
-  feature_names = [x.name for x in train_df.schema if x.name != label]
+  feature_names = [x.name for x in train_df.schema if x.name != label_name]
 
   # create a xgboost pyspark regressor estimator and set use_gpu=True
   regressor = SparkXGBRegressor(


### PR DESCRIPTION
Hi, I found an undefined variable in the pyspark estimator application example. The variable 'label' was used instead of the variable 'label_name' to generate the feture list.
![xgboost_doc](https://github.com/dmlc/xgboost/assets/60243072/a21e0f31-38bf-44b3-a4d7-60ec19242da7)
