### PR TITLE
Choose predictor only when it's training.

### DIFF
--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -260,8 +260,8 @@ class GBTree : public GradientBooster {
       }
       LOG(FATAL) << msg;
     } else {
-      bool success = this->GetPredictor()->InplacePredict(p_m, model_, missing, out_preds,
-                                                          tree_begin, tree_end);
+      bool success = this->GetPredictor(nullptr, nullptr, false)
+                         ->InplacePredict(p_m, model_, missing, out_preds, tree_begin, tree_end);
       CHECK(success) << msg << std::endl
                      << "Current Predictor: "
                      << (tparam_.predictor == PredictorType::kCPUPredictor
@@ -349,7 +349,7 @@ class GBTree : public GradientBooster {
     auto [tree_begin, tree_end] = detail::LayerToTree(model_, layer_begin, layer_end);
     CHECK_EQ(tree_begin, 0) << "Predict leaf supports only iteration end: (0, "
                                "n_iteration), use model slicing instead.";
-    this->GetPredictor()->PredictLeaf(p_fmat, out_preds, model_, tree_end);
+    this->GetPredictor(nullptr, nullptr, false)->PredictLeaf(p_fmat, out_preds, model_, tree_end);
   }
 
   void PredictContribution(DMatrix* p_fmat,
@@ -361,7 +361,7 @@ class GBTree : public GradientBooster {
     CHECK_EQ(tree_begin, 0)
         << "Predict contribution supports only iteration end: (0, "
            "n_iteration), using model slicing instead.";
-    this->GetPredictor()->PredictContribution(
+    this->GetPredictor(nullptr, nullptr, false)->PredictContribution(
         p_fmat, out_contribs, model_, tree_end, nullptr, approximate);
   }
 
@@ -373,8 +373,9 @@ class GBTree : public GradientBooster {
     CHECK_EQ(tree_begin, 0)
         << "Predict interaction contribution supports only iteration end: (0, "
            "n_iteration), using model slicing instead.";
-    this->GetPredictor()->PredictInteractionContributions(
-        p_fmat, out_contribs, model_, tree_end, nullptr, approximate);
+    this->GetPredictor(nullptr, nullptr, false)
+        ->PredictInteractionContributions(p_fmat, out_contribs, model_, tree_end, nullptr,
+                                          approximate);
   }
 
   [[nodiscard]] std::vector<std::string> DumpModel(const FeatureMap& fmap, bool with_stats,
@@ -390,8 +391,8 @@ class GBTree : public GradientBooster {
                      std::vector<HostDeviceVector<bst_node_t>>* out_position,
                      std::vector<std::unique_ptr<RegTree>>* ret);
 
-  std::unique_ptr<Predictor> const& GetPredictor(HostDeviceVector<float> const* out_pred = nullptr,
-                                                 DMatrix* f_dmat = nullptr) const;
+  std::unique_ptr<Predictor> const& GetPredictor(HostDeviceVector<float> const* out_pred,
+                                                 DMatrix* f_dmat, bool is_training) const;
 
   // commit new trees all at once
   virtual void CommitModel(TreesOneIter&& new_trees);


### PR DESCRIPTION
We will remove the parameter `predictor`. After the removal, the predictor will be dispatched based on the device context. However, we keep the heuristic for choosing the CPU predictor for the first prediction round during training due to memory pressure.