### PR TITLE
Enable Installation of Python Package with System lib in a Virtual Environment

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -275,7 +275,7 @@ jobs:
 
       - name: Install ninja
         run: |
-          apt-get update && apt-get install -y ninja-build
+          sudo apt-get update && sudo apt-get install -y ninja-build
 
       - name: Build XGBoost on Ubuntu
         run: |

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -108,6 +108,37 @@ jobs:
         cd ..
         python -c 'import xgboost'
 
+  python-system-installation-test-on-Linux:
+    runs-on: ${{ matrix.os }}
+    name: Test installing XGBoost Python with System Installation on Linux
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.8"]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    - name: Install Ubuntu system dependencies
+      run: |
+        sudo apt-get install -y --no-install-recommends ninja-build
+    - name: Build and install XGBoost
+      shell: bash -l {0}
+      run: |
+        mkdir build
+        cd build
+        cmake ..
+        make -j$(nproc)
+        cd ..
+        cp lib/* $(python  -c 'import sys; print(sys.base_prefix)')/lib
+        pip install virtualenv
+        virtualenv venv
+        export VIRTUAL_ENV="$(pwd)/venv"
+        export PATH="$VIRTUAL_ENV/bin:$PATH"
+        cd python-package
+        pip install . --config-settings use_system_libxgboost=True
+        python -c 'import xgboost'
+
   python-tests-on-macos:
     name: Test XGBoost Python package on ${{ matrix.config.os }}
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -108,37 +108,6 @@ jobs:
         cd ..
         python -c 'import xgboost'
 
-  python-system-installation-test-on-Linux:
-    runs-on: ${{ matrix.os }}
-    name: Test installing XGBoost Python with System Installation on Linux
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.8"]
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: 'true'
-    - name: Install Ubuntu system dependencies
-      run: |
-        sudo apt-get install -y --no-install-recommends ninja-build
-    - name: Build and install XGBoost
-      shell: bash -l {0}
-      run: |
-        mkdir build
-        cd build
-        cmake ..
-        make -j$(nproc)
-        cd ..
-        cp lib/* $(python  -c 'import sys; print(sys.base_prefix)')/lib
-        pip install virtualenv
-        virtualenv venv
-        export VIRTUAL_ENV="$(pwd)/venv"
-        export PATH="$VIRTUAL_ENV/bin:$PATH"
-        cd python-package
-        pip install . --config-settings use_system_libxgboost=True
-        python -c 'import xgboost'
-
   python-tests-on-macos:
     name: Test XGBoost Python package on ${{ matrix.config.os }}
     runs-on: ${{ matrix.config.os }}
@@ -286,3 +255,44 @@ jobs:
       shell: bash -l {0}
       run: |
         pytest -s -v -rxXs --durations=0 ./tests/test_distributed/test_with_spark
+
+  python-system-installation-on-ubuntu:
+    name: Test XGBoost Python package System Installation on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Install ninja
+        run: |
+          apt-get update && apt-get install -y ninja-build
+
+      - name: Build XGBoost on Ubuntu
+        run: |
+          mkdir build
+          cd build
+          cmake .. -GNinja
+          ninja
+
+      - name: Copy lib to system lib
+        run: |
+          cp lib/* "$(python -c 'import sys; print(sys.base_prefix)')/lib"
+
+      - name: Install XGBoost in Virtual Environment
+        run: |
+          cd python-package
+          pip install virtualenv
+          virtualenv venv
+          source venv/bin/activate && \
+            pip install -v . --config-settings use_system_libxgboost=True && \
+            python -c 'import xgboost'

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -259,7 +259,7 @@ There are several ways to build and install the package from source:
 
     import sys
     import pathlib
-    libpath = pathlib.Path(sys.prefix).joinpath("lib", "libxgboost.so")
+    libpath = pathlib.Path(sys.base_prefix).joinpath("lib", "libxgboost.so")
     assert libpath.exists()
 
   Then pass ``use_system_libxgboost=True`` option to ``pip install``:

--- a/python-package/packager/nativelib.py
+++ b/python-package/packager/nativelib.py
@@ -132,8 +132,8 @@ def locate_or_build_libxgboost(
 
     if build_config.use_system_libxgboost:
         # Find libxgboost from system prefix
-        sys_prefix = pathlib.Path(sys.prefix).absolute().resolve()
-        libxgboost_sys = sys_prefix / "lib" / _lib_name()
+        sys_base_prefix = pathlib.Path(sys.base_prefix).absolute().resolve()
+        libxgboost_sys = sys_base_prefix / "lib" / _lib_name()
         if not libxgboost_sys.exists():
             raise RuntimeError(
                 f"use_system_libxgboost was specified but {_lib_name()} is "

--- a/python-package/xgboost/libpath.py
+++ b/python-package/xgboost/libpath.py
@@ -27,7 +27,7 @@ def find_lib_path() -> List[str]:
         os.path.join(curr_path, os.path.pardir, os.path.pardir, "lib"),
         # use libxgboost from a system prefix, if available.  This should be the last
         # option.
-        os.path.join(sys.base_prefix, 'lib'),
+        os.path.join(sys.base_prefix, "lib"),
     ]
 
     if sys.platform == "win32":
@@ -62,8 +62,8 @@ def find_lib_path() -> List[str]:
             + ("\n- ".join(dll_path))
             + "\nXGBoost Python package path: "
             + curr_path
-            + "\nsys.prefix: "
-            + sys.prefix
+            + "\nsys.base_prefix: "
+            + sys.base_prefix
             + "\nSee: "
             + link
             + " for installing XGBoost."

--- a/python-package/xgboost/libpath.py
+++ b/python-package/xgboost/libpath.py
@@ -27,7 +27,7 @@ def find_lib_path() -> List[str]:
         os.path.join(curr_path, os.path.pardir, os.path.pardir, "lib"),
         # use libxgboost from a system prefix, if available.  This should be the last
         # option.
-        os.path.join(sys.prefix, "lib"),
+        os.path.join(sys.base_prefix, 'lib'),
     ]
 
     if sys.platform == "win32":


### PR DESCRIPTION
## Goal

Enable Installation of Python Package with System lib in a Virtual Environment

## Details

- Replaces `sys.prefix` with `sys.base_prefix`
  - these are different when inside a virtual environment. Using  `sys.base_prefix` instead of `sys.prefix` enables installation of package in a virtual environment when the xgboost is already installed on the system

> **sys.base_prefix**
> Set during Python startup, before site.py is run, to the same value as `prefix`. If not running in a virtual environment, the values will stay the same; if site.py finds that a virtual environment is in use, the values of `prefix` and `exec_prefix` will be changed to point to the virtual environment, whereas `base_prefix` and `base_exec_prefix` will remain pointing to the base Python installation (the one which the virtual environment was created from).

## Motivation

Setting up tests to run inside a virtual environment in an image that has xgboost pre-installed as a system lib. (e.g. `nvcr.io/nvidia/tensorflow:23.06-tf2-py3`). When in a virtual environment, the `sys.prefix` changes to point to the `lib` directory inside the virtualenvironment instead of the system lib path. 
- Installing xgboost with the `use_system_libxgboost=True` in a virtual environment
- Using a `tox` virtual environment with `sitepackages=true` to pickup an xgboost installation present on the system already 