### PR TITLE
Fixes #9332. xgboost4j-gpu_2.12-2.0.0: added libxgboost4j.so back.

### DIFF
--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -91,6 +91,9 @@
                     <value>ON</value>
                 </property>
             </activation>
+            <properties>
+               <use.cuda>ON</use.cuda>
+            </properties>
             <modules>
                 <module>xgboost4j-gpu</module>
                 <module>xgboost4j-spark-gpu</module>


### PR DESCRIPTION
Fixes #9332 