### PR TITLE
Unify the hist tree method for different devices.

### DIFF
--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -82,6 +82,7 @@ OBJECTS= \
     $(PKGROOT)/src/common/charconv.o \
     $(PKGROOT)/src/common/column_matrix.o \
     $(PKGROOT)/src/common/common.o \
+    $(PKGROOT)/src/common/error_msg.o \
     $(PKGROOT)/src/common/hist_util.o \
     $(PKGROOT)/src/common/host_device_vector.o \
     $(PKGROOT)/src/common/io.o \

--- a/R-package/src/Makevars.win
+++ b/R-package/src/Makevars.win
@@ -82,6 +82,7 @@ OBJECTS= \
     $(PKGROOT)/src/common/charconv.o \
     $(PKGROOT)/src/common/column_matrix.o \
     $(PKGROOT)/src/common/common.o \
+    $(PKGROOT)/src/common/error_msg.o \
     $(PKGROOT)/src/common/hist_util.o \
     $(PKGROOT)/src/common/host_device_vector.o \
     $(PKGROOT)/src/common/io.o \

--- a/src/common/error_msg.cc
+++ b/src/common/error_msg.cc
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2023 by XGBoost contributors
+ */
+#include "error_msg.h"
+
+#include "xgboost/logging.h"
+
+namespace xgboost::error {
+void WarnDeprecatedGPUHist() {
+  bool static thread_local logged{false};
+  if (logged) {
+    return;
+  }
+  auto msg =
+      "The tree method `gpu_hist` is deprecated since 2.0.0. To use GPU training, set the `device` "
+      R"(parameter to CUDA instead.
+
+    E.g. tree_method = "hist", device = "CUDA"
+
+)";
+  LOG(WARNING) << msg;
+  logged = true;
+}
+
+void WarnManualUpdater() {
+  bool static thread_local logged{false};
+  if (logged) {
+    return;
+  }
+  LOG(WARNING)
+      << "You have manually specified the `updater` parameter. The `tree_method` parameter "
+         "will be ignored. Incorrect sequence of updaters will produce undefined "
+         "behavior. For common uses, we recommend using `tree_method` parameter instead.";
+  logged = true;
+}
+}  // namespace xgboost::error

--- a/src/common/error_msg.h
+++ b/src/common/error_msg.h
@@ -89,5 +89,17 @@ inline void WarnDeprecatedGPUHist() {
   LOG(WARNING) << msg;
   logged = true;
 }
+
+inline void WarnManualUpdater() {
+  bool static thread_local logged{false};
+  if (logged) {
+    return;
+  }
+  LOG(WARNING)
+      << "You have manually specified the `updater` parameter. The `tree_method` parameter "
+         "will be ignored. Incorrect sequence of updaters will produce undefined "
+         "behavior. For common uses, we recommend using `tree_method` parameter instead.";
+  logged = true;
+}
 }  // namespace xgboost::error
 #endif  // XGBOOST_COMMON_ERROR_MSG_H_

--- a/src/common/error_msg.h
+++ b/src/common/error_msg.h
@@ -75,8 +75,18 @@ inline void WarnOldSerialization() {
   if (logged) {
     return;
   }
-
   LOG(WARNING) << OldSerialization();
+  logged = true;
+}
+
+inline void WarnDeprecatedGPUHist() {
+  bool static thread_local logged{false};
+  if (logged) {
+    return;
+  }
+  auto msg =
+      R"(The tree method `gpu_hist` is deprecated since 2.0.0. To use GPU training, set the `device` parameter to CUDA.)";
+  LOG(WARNING) << msg;
   logged = true;
 }
 }  // namespace xgboost::error

--- a/src/common/error_msg.h
+++ b/src/common/error_msg.h
@@ -79,27 +79,8 @@ inline void WarnOldSerialization() {
   logged = true;
 }
 
-inline void WarnDeprecatedGPUHist() {
-  bool static thread_local logged{false};
-  if (logged) {
-    return;
-  }
-  auto msg =
-      R"(The tree method `gpu_hist` is deprecated since 2.0.0. To use GPU training, set the `device` parameter to CUDA.)";
-  LOG(WARNING) << msg;
-  logged = true;
-}
+void WarnDeprecatedGPUHist();
 
-inline void WarnManualUpdater() {
-  bool static thread_local logged{false};
-  if (logged) {
-    return;
-  }
-  LOG(WARNING)
-      << "You have manually specified the `updater` parameter. The `tree_method` parameter "
-         "will be ignored. Incorrect sequence of updaters will produce undefined "
-         "behavior. For common uses, we recommend using `tree_method` parameter instead.";
-  logged = true;
-}
+void WarnManualUpdater();
 }  // namespace xgboost::error
 #endif  // XGBOOST_COMMON_ERROR_MSG_H_

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -68,6 +68,9 @@ std::string MapTreeMethodToUpdaters(Context const* ctx_, TreeMethod tree_method)
       auto tm = static_cast<std::underlying_type_t<TreeMethod>>(tree_method);
       LOG(FATAL) << "Unknown tree_method: `" << tm << "`.";
   }
+
+  LOG(FATAL) << "unreachable";
+  return "";
 }
 }  // namespace
 

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -172,20 +172,17 @@ class GBTree : public GradientBooster {
   explicit GBTree(LearnerModelParam const* booster_config, Context const* ctx)
       : GradientBooster{ctx}, model_(booster_config, ctx_) {}
 
-  void Configure(const Args& cfg) override;
-  /*! \brief Map `tree_method` parameter to `updater` parameter */
-  void ConfigureUpdaters();
-
+  void Configure(Args const& cfg) override;
   /**
-   * \brief Optionally update the leaf value.
+   * @brief Optionally update the leaf value.
    */
   void UpdateTreeLeaf(DMatrix const* p_fmat, HostDeviceVector<float> const& predictions,
-                      ObjFunction const* obj,
-                      std::int32_t group_idx,
+                      ObjFunction const* obj, std::int32_t group_idx,
                       std::vector<HostDeviceVector<bst_node_t>> const& node_position,
                       std::vector<std::unique_ptr<RegTree>>* p_trees);
-
-  /*! \brief Carry out one iteration of boosting */
+  /**
+   * @brief Carry out one iteration of boosting.
+   */
   void DoBoost(DMatrix* p_fmat, HostDeviceVector<GradientPair>* in_gpair,
                PredictionCacheEntry* predt, ObjFunction const* obj) override;
 

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -59,9 +59,7 @@ struct GBTreeTrainParam : public XGBoostParameter<GBTreeTrainParam> {
   TreeMethod tree_method;
   // declare parameters
   DMLC_DECLARE_PARAMETER(GBTreeTrainParam) {
-    DMLC_DECLARE_FIELD(updater_seq)
-        .set_default("grow_colmaker,prune")
-        .describe("Tree updater sequence.");
+    DMLC_DECLARE_FIELD(updater_seq).describe("Tree updater sequence.").set_default("");
     DMLC_DECLARE_FIELD(process_type)
         .set_default(TreeProcessType::kDefault)
         .add_enum("default", TreeProcessType::kDefault)
@@ -170,7 +168,9 @@ bool SliceTrees(bst_layer_t begin, bst_layer_t end, bst_layer_t step, GBTreeMode
 class GBTree : public GradientBooster {
  public:
   explicit GBTree(LearnerModelParam const* booster_config, Context const* ctx)
-      : GradientBooster{ctx}, model_(booster_config, ctx_) {}
+      : GradientBooster{ctx}, model_(booster_config, ctx_) {
+    monitor_.Init(__func__);
+  }
 
   void Configure(Args const& cfg) override;
   /**

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -286,7 +286,6 @@ class GBTree : public GradientBooster {
 
   void PredictInstance(const SparsePage::Inst& inst, std::vector<bst_float>* out_preds,
                        uint32_t layer_begin, uint32_t layer_end) override {
-    CHECK(configured_);
     std::uint32_t _, tree_end;
     std::tie(_, tree_end) = detail::LayerToTree(model_, layer_begin, layer_end);
     cpu_predictor_->PredictInstance(inst, out_preds, model_, tree_end);
@@ -304,7 +303,6 @@ class GBTree : public GradientBooster {
   void PredictContribution(DMatrix* p_fmat, HostDeviceVector<float>* out_contribs,
                            bst_layer_t layer_begin, bst_layer_t layer_end,
                            bool approximate) override {
-    CHECK(configured_);
     auto [tree_begin, tree_end] = detail::LayerToTree(model_, layer_begin, layer_end);
     CHECK_EQ(tree_begin, 0) << "Predict contribution supports only iteration end: (0, "
                                "n_iteration), using model slicing instead.";
@@ -315,7 +313,6 @@ class GBTree : public GradientBooster {
   void PredictInteractionContributions(DMatrix* p_fmat, HostDeviceVector<float>* out_contribs,
                                        bst_layer_t layer_begin, bst_layer_t layer_end,
                                        bool approximate) override {
-    CHECK(configured_);
     auto [tree_begin, tree_end] = detail::LayerToTree(model_, layer_begin, layer_end);
     CHECK_EQ(tree_begin, 0) << "Predict interaction contribution supports only iteration end: (0, "
                                "n_iteration), using model slicing instead.";
@@ -329,9 +326,6 @@ class GBTree : public GradientBooster {
   }
 
  protected:
-  // initialize updater before using them
-  void InitUpdater(Args const& cfg);
-
   void BoostNewTrees(HostDeviceVector<GradientPair>* gpair, DMatrix* p_fmat, int bst_group,
                      std::vector<HostDeviceVector<bst_node_t>>* out_position,
                      std::vector<std::unique_ptr<RegTree>>* ret);
@@ -349,10 +343,7 @@ class GBTree : public GradientBooster {
   GBTreeTrainParam tparam_;
   // Tree training parameter
   tree::TrainParam tree_param_;
-  // ----training fields----
-  bool showed_updater_warning_ {false};
   bool specified_updater_   {false};
-  bool configured_ {false};
   // the updaters that can be applied to each of tree
   std::vector<std::unique_ptr<TreeUpdater>> updaters_;
   // Predictors

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -218,8 +218,8 @@ TEST(GBTree, ChooseTreeMethod) {
   // | CUDA:0 | GPU     | GPU (w)  | Err   | GPU | # not yet tested
   // | CPU    | CPU     | Err      | CPU   | CPU | # not yet tested
   // |--------+---------+----------+-------+-----|
-  // | -1     | CPU     | Err      | CPU   | CPU |
-  // | 0      | GPU (w) | GPU (w)  | Err   | GPU |
+  // | -1     | CPU     | GPU (w)  | CPU   | CPU |
+  // | 0      | GPU     | GPU (w)  | Err   | GPU |
   // | NA     | CPU     | GPU (w)  | CPU   | CPU |
   //
   // - (w): warning
@@ -228,6 +228,10 @@ TEST(GBTree, ChooseTreeMethod) {
   // - Err: Not feasible.
   // - NA:  Parameter is not specified.
 
+  // When GPU hist is specified with a CPU context, we should emit error. However, it's
+  // quite difficult to detect whether the CPU context is being used as default or as
+  // specified by the user. We choose not to raise an error and continue on GPU.
+
   std::map<std::pair<std::optional<std::string>, std::optional<std::string>>, std::string>
       expectation{
           // hist
@@ -235,7 +239,7 @@ TEST(GBTree, ChooseTreeMethod) {
           {{"hist", "0"}, "grow_gpu_hist"},
           {{"hist", std::nullopt}, "grow_quantile_histmaker"},
           // gpu_hist
-          // {{"gpu_hist", "-1"}, "err"},
+          {{"gpu_hist", "-1"}, "grow_gpu_hist"},
           {{"gpu_hist", "0"}, "grow_gpu_hist"},
           {{"gpu_hist", std::nullopt}, "grow_gpu_hist"},
           // exact

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -228,9 +228,9 @@ TEST(GBTree, ChooseTreeMethod) {
   // - Err: Not feasible.
   // - NA:  Parameter is not specified.
 
-  // When GPU hist is specified with a CPU context, we should emit error. However, it's
-  // quite difficult to detect whether the CPU context is being used as default or as
-  // specified by the user. We choose not to raise an error and continue on GPU.
+  // When GPU hist is specified with a CPU context, we should emit an error. However, it's
+  // quite difficult to detect whether the CPU context is being used because it's the
+  // default or because it's specified by the user.
 
   std::map<std::pair<std::optional<std::string>, std::optional<std::string>>, std::string>
       expectation{

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -239,9 +239,9 @@ TEST(GBTree, ChooseTreeMethod) {
           {{"gpu_hist", "0"}, "grow_gpu_hist"},
           {{"gpu_hist", std::nullopt}, "grow_gpu_hist"},
           // exact
-          {{"exact", "-1"}, "grow_colmaker"},
+          {{"exact", "-1"}, "grow_colmaker,prune"},
           {{"exact", "0"}, "err"},
-          {{"exact", std::nullopt}, "grow_colmaker"},
+          {{"exact", std::nullopt}, "grow_colmaker,prune"},
           // NA
           {{std::nullopt, "-1"}, "grow_quantile_histmaker"},
           {{std::nullopt, "0"}, "grow_gpu_hist"},  // default to hist
@@ -259,9 +259,11 @@ TEST(GBTree, ChooseTreeMethod) {
         continue;
       }
       auto up = fn(device, tm);
-      auto map = get<Array const>(up);
-      for (auto const& got : map) {
-        ASSERT_EQ(get<String const>(got["name"]), kv.second)
+      auto ups = get<Array const>(up);
+      auto exp_names = common::Split(kv.second, ',');
+      ASSERT_EQ(exp_names.size(), ups.size());
+      for (std::size_t i = 0; i < exp_names.size(); ++i) {
+        ASSERT_EQ(get<String const>(ups[i]["name"]), exp_names[i])
             << " device:" << device.value_or("NA") << " tm:" << tm.value_or("NA");
       }
     }

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -4,11 +4,13 @@
 #include <gtest/gtest.h>
 #include <xgboost/context.h>
 #include <xgboost/host_device_vector.h>  // for HostDeviceVector
+#include <xgboost/json.h>                // for Json, Object
 #include <xgboost/learner.h>             // for Learner
 
-#include <limits>  // for numeric_limits
-#include <memory>  // for shared_ptr
-#include <string>  // for string
+#include <limits>    // for numeric_limits
+#include <memory>    // for shared_ptr
+#include <optional>  // for optional
+#include <string>    // for string
 
 #include "../../../src/data/proxy_dmatrix.h"  // for DMatrixProxy
 #include "../../../src/gbm/gbtree.h"
@@ -164,6 +166,115 @@ TEST(GBTree, ChoosePredictor) {
   }
   // data is not pulled back into host
   ASSERT_FALSE(data.HostCanWrite());
+}
+
+TEST(GBTree, ChooseTreeMethod) {
+  bst_row_t n_samples{128};
+  bst_feature_t n_features{64};
+  auto Xy = RandomDataGenerator{n_samples, n_features, 0.5f}.GenerateDMatrix(true);
+
+  auto with_update = [&](std::optional<std::string> device,
+                         std::optional<std::string> tree_method) {
+    auto learner = std::unique_ptr<Learner>(Learner::Create({Xy}));
+    if (tree_method.has_value()) {
+      learner->SetParam("tree_method", tree_method.value());
+    }
+    if (device.has_value()) {
+      learner->SetParam("gpu_id", device.value());
+    }
+    learner->Configure();
+    for (std::int32_t i = 0; i < 3; ++i) {
+      learner->UpdateOneIter(0, Xy);
+    }
+    Json config{Object{}};
+    learner->SaveConfig(&config);
+    auto updater = config["learner"]["gradient_booster"]["updater"];
+    CHECK(!IsA<Null>(updater));
+    return updater;
+  };
+
+  auto with_boost = [&](std::optional<std::string> device, std::optional<std::string> tree_method) {
+    auto learner = std::unique_ptr<Learner>(Learner::Create({Xy}));
+    if (tree_method.has_value()) {
+      learner->SetParam("tree_method", tree_method.value());
+    }
+    if (device.has_value()) {
+      learner->SetParam("gpu_id", device.value());
+    }
+    learner->Configure();
+    for (std::int32_t i = 0; i < 3; ++i) {
+      HostDeviceVector<GradientPair> gpair{GenerateRandomGradients(Xy->Info().num_row_)};
+      learner->BoostOneIter(0, Xy, &gpair);
+    }
+
+    Json config{Object{}};
+    learner->SaveConfig(&config);
+    auto updater = config["learner"]["gradient_booster"]["updater"];
+    return updater;
+  };
+
+  // |        | hist    | gpu_hist | exact | NA  |
+  // |--------+---------+----------+-------+-----|
+  // | CUDA:0 | GPU     | GPU (w)  | Err   | GPU | # not yet tested
+  // | CPU    | CPU     | Err      | CPU   | CPU | # not yet tested
+  // |--------+---------+----------+-------+-----|
+  // | -1     | CPU     | Err      | CPU   | CPU |
+  // | 0      | GPU (w) | GPU (w)  | Err   | GPU |
+  // | NA     | CPU     | GPU (w)  | CPU   | CPU |
+  //
+  // - (w): warning
+  // - CPU: Run on CPU.
+  // - GPU: Run on CUDA.
+  // - Err: Not feasible.
+  // - NA:  Parameter is not specified.
+
+  std::map<std::pair<std::optional<std::string>, std::optional<std::string>>, std::string>
+      expectation{
+          // hist
+          {{"hist", "-1"}, "grow_quantile_histmaker"},
+          {{"hist", "0"}, "grow_gpu_hist"},
+          {{"hist", std::nullopt}, "grow_quantile_histmaker"},
+          // gpu_hist
+          // {{"gpu_hist", "-1"}, "err"},
+          {{"gpu_hist", "0"}, "grow_gpu_hist"},
+          {{"gpu_hist", std::nullopt}, "grow_gpu_hist"},
+          // exact
+          {{"exact", "-1"}, "grow_colmaker"},
+          {{"exact", "0"}, "err"},
+          {{"exact", std::nullopt}, "grow_colmaker"},
+          // NA
+          {{std::nullopt, "-1"}, "grow_quantile_histmaker"},
+          {{std::nullopt, "0"}, "grow_gpu_hist"},  // default to hist
+          {{std::nullopt, std::nullopt}, "grow_quantile_histmaker"},
+      };
+
+  auto check_updater = [&](std::string name, Json updater) {
+    auto map = get<Object const>(updater);
+    ASSERT_NE(map.find(name), map.cend());
+  };
+
+  auto run_test = [&](auto fn) {
+    for (auto const& kv : expectation) {
+      auto device = kv.first.second;
+      auto tm = kv.first.first;
+
+      if (kv.second == "err") {
+        ASSERT_THROW({ fn(device, tm); }, dmlc::Error)
+            << " device:" << device.value_or("NA") << " tm:" << tm.value_or("NA");
+        continue;
+      }
+      auto up = fn(device, tm);
+      check_updater(kv.second, up);
+      // auto map = get<Object const>(up);
+      // for (auto const& got : map) {
+      //   ASSERT_EQ(got.first, kv.second)
+      //       << " device:" << device.value_or("NA") << " tm:" << tm.value_or("NA");
+      // }
+    }
+  };
+
+  run_test(with_update);
+  run_test(with_boost);
 }
 #endif  // XGBOOST_USE_CUDA
 

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -248,11 +248,6 @@ TEST(GBTree, ChooseTreeMethod) {
           {{std::nullopt, std::nullopt}, "grow_quantile_histmaker"},
       };
 
-  auto check_updater = [&](std::string name, Json updater) {
-    auto map = get<Object const>(updater);
-    ASSERT_NE(map.find(name), map.cend());
-  };
-
   auto run_test = [&](auto fn) {
     for (auto const& kv : expectation) {
       auto device = kv.first.second;
@@ -264,12 +259,11 @@ TEST(GBTree, ChooseTreeMethod) {
         continue;
       }
       auto up = fn(device, tm);
-      check_updater(kv.second, up);
-      // auto map = get<Object const>(up);
-      // for (auto const& got : map) {
-      //   ASSERT_EQ(got.first, kv.second)
-      //       << " device:" << device.value_or("NA") << " tm:" << tm.value_or("NA");
-      // }
+      auto map = get<Array const>(up);
+      for (auto const& got : map) {
+        ASSERT_EQ(get<String const>(got["name"]), kv.second)
+            << " device:" << device.value_or("NA") << " tm:" << tm.value_or("NA");
+      }
     }
   };
 

--- a/tests/python/test_training_continuation.py
+++ b/tests/python/test_training_continuation.py
@@ -57,12 +57,12 @@ class TestTrainingContinuation:
 
         gbdt_02 = xgb.train(xgb_params_01, dtrain_2class,
                             num_boost_round=0)
-        gbdt_02.save_model('xgb_tc.model')
+        gbdt_02.save_model('xgb_tc.json')
 
         gbdt_02a = xgb.train(xgb_params_01, dtrain_2class,
                              num_boost_round=10, xgb_model=gbdt_02)
         gbdt_02b = xgb.train(xgb_params_01, dtrain_2class,
-                             num_boost_round=10, xgb_model="xgb_tc.model")
+                             num_boost_round=10, xgb_model="xgb_tc.json")
         ntrees_02a = len(gbdt_02a.get_dump())
         ntrees_02b = len(gbdt_02b.get_dump())
         assert ntrees_02a == 10
@@ -78,18 +78,18 @@ class TestTrainingContinuation:
 
         gbdt_03 = xgb.train(xgb_params_01, dtrain_2class,
                             num_boost_round=3)
-        gbdt_03.save_model('xgb_tc.model')
+        gbdt_03.save_model('xgb_tc.json')
 
         gbdt_03a = xgb.train(xgb_params_01, dtrain_2class,
                              num_boost_round=7, xgb_model=gbdt_03)
         gbdt_03b = xgb.train(xgb_params_01, dtrain_2class,
-                             num_boost_round=7, xgb_model="xgb_tc.model")
+                             num_boost_round=7, xgb_model="xgb_tc.json")
         ntrees_03a = len(gbdt_03a.get_dump())
         ntrees_03b = len(gbdt_03b.get_dump())
         assert ntrees_03a == 10
         assert ntrees_03b == 10
 
-        os.remove('xgb_tc.model')
+        os.remove('xgb_tc.json')
 
         res1 = mean_squared_error(y_2class, gbdt_03a.predict(dtrain_2class))
         res2 = mean_squared_error(y_2class, gbdt_03b.predict(dtrain_2class))


### PR DESCRIPTION
- Dispatch the tree method based on the current context.
- Deprecate the use of `gpu_hist`.