### PR TITLE
Add getData function for DMatrix

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -396,6 +396,39 @@ public class DMatrix {
   }
 
   /**
+   * Get feature data as BigDenseMatrix
+   * @return feature Matrix
+   * @throws XGBoostError
+   */
+  public BigDenseMatrix getData() throws XGBoostError {
+    int rowNum = (int) rowNum();
+    int colNum = (int) colNum();
+    int nonMissingNum = (int) nonMissingNum();
+
+    long[] rowOffset = new long[rowNum + 1];
+    int[] featureIndex = new int[nonMissingNum];
+    float[] featureValue = new float[nonMissingNum];
+
+    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixGetDataAsCSR(handle, "{}",
+        rowOffset, featureIndex, featureValue));
+
+    BigDenseMatrix denseMatrix = new BigDenseMatrix(rowNum, colNum);
+
+    for (int row = 0; row < rowNum; row++) {
+      for(int col = 0; col < colNum; col++) {
+        denseMatrix.set(row, col, 0.0f);
+      }
+      int rowStart = (int)rowOffset[row];
+      int rowEnd = (int)rowOffset[row + 1];
+      for(int idx = rowStart; idx < rowEnd; idx ++) {
+        denseMatrix.set(row, featureIndex[idx], featureValue[idx]);
+      }
+    }
+
+    return denseMatrix;
+  }
+
+  /**
    * Slice the DMatrix and return a new DMatrix that only contains `rowIndex`.
    *
    * @param rowIndex row index
@@ -420,6 +453,17 @@ public class DMatrix {
     long[] rowNum = new long[1];
     XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixNumRow(handle, rowNum));
     return rowNum[0];
+  }
+
+  /**
+   * Get the col number of DMatrix
+   * @return number of columns
+   * @throws XGBoostError native error
+   */
+  public long colNum() throws XGBoostError {
+    long[] colNum = new long[1];
+    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixNumCol(handle, colNum));
+    return colNum[0];
   }
 
   /**

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -100,6 +100,9 @@ class XGBoostJNI {
                                                             long[] outLength, String[][] outValues);
 
   public final static native int XGDMatrixNumRow(long handle, long[] row);
+
+  public final static native int XGDMatrixNumCol(long handle, long[] col);
+
   public final static native int XGDMatrixNumNonMissing(long handle, long[] nonMissings);
 
   public final static native int XGBoosterCreate(long[] handles, long[] out);
@@ -168,4 +171,6 @@ class XGBoostJNI {
 
   public final static native int XGBoosterGetStrFeatureInfo(long handle, String field, String[] out);
 
+  public final static native int XGDMatrixGetDataAsCSR(long handle, String config, long[] rowOffset,
+    int[] featureIndex, float[] featureValue);
 }

--- a/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
+++ b/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala
@@ -19,6 +19,7 @@ package ml.dmlc.xgboost4j.scala
 import _root_.scala.collection.JavaConverters._
 
 import ml.dmlc.xgboost4j.LabeledPoint
+import ml.dmlc.xgboost4j.java.util.BigDenseMatrix
 import ml.dmlc.xgboost4j.java.{Column, ColumnBatch, DataBatch, XGBoostError, DMatrix => JDMatrix}
 
 class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
@@ -284,6 +285,16 @@ class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
   }
 
   /**
+   * get raw data from DMatrix as BigDenseMatrix
+   * @throws ml.dmlc.xgboost4j.java.XGBoostError
+   * @return
+   */
+  @throws(classOf[XGBoostError])
+  def getData: BigDenseMatrix = {
+    jDMatrix.getData
+  }
+
+  /**
    * Slice the DMatrix and return a new DMatrix that only contains `rowIndex`.
    *
    * @param rowIndex row index
@@ -302,6 +313,17 @@ class DMatrix private[scala](private[scala] val jDMatrix: JDMatrix) {
   @throws(classOf[XGBoostError])
   def rowNum: Long = {
     jDMatrix.rowNum
+  }
+
+  /**
+   * get the col number of DMatrix
+   *
+   * @throws ml.dmlc.xgboost4j.java.XGBoostError
+   * @return
+   */
+  @throws(classOf[XGBoostError])
+  def colNum: Long = {
+    jDMatrix.colNum
   }
 
   /**

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -497,6 +497,21 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixNumRow
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGDMatrixNumCol
+ * Signature: (J[J)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixNumCol(
+    JNIEnv *jenv, jclass jcls, jlong jhandle, jlongArray jout) {
+  DMatrixHandle handle = (DMatrixHandle)jhandle;
+  bst_ulong result[1];
+  int ret = (jint)XGDMatrixNumCol(handle, result);
+  JVM_CHECK_CALL(ret);
+  jenv->SetLongArrayRegion(jout, 0, 1, (const jlong *)result);
+  return ret;
+}
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGDMatrixNumNonMissing
  * Signature: (J[J)I
  */
@@ -1211,5 +1226,32 @@ Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetStrFeatureInfo(
     jenv->SetObjectArrayElement(jout, i, jfeature);
   }
 
+  return ret;
+}
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGDMatrixGetDataAsCSR
+ * Signature: (Ljava/lang/String;[J[I[F)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetDataAsCSR
+  (JNIEnv *jenv, jclass jclz, jlong jhandle, jstring jconfig, jlongArray jrowOffset,
+      jintArray jfeatureIndex, jfloatArray jfeatureValue) {
+  DMatrixHandle handle = (DMatrixHandle) jhandle;
+  const char *config = jenv->GetStringUTFChars(jconfig, 0);
+
+  const int offsetNum = jenv->GetArrayLength(jrowOffset);
+  const int nonMissingNum = jenv->GetArrayLength(jfeatureIndex);
+  bst_ulong *rowOffset = new bst_ulong[offsetNum];
+  unsigned int *featureIndex = new unsigned int[nonMissingNum];
+  float *featureValue = new float[nonMissingNum];
+
+  int ret = XGDMatrixGetDataAsCSR(handle, config, rowOffset, featureIndex, featureValue);
+
+  jenv->SetLongArrayRegion(jrowOffset, 0, offsetNum, (const jlong *)rowOffset);
+  jenv->SetIntArrayRegion(jfeatureIndex, 0, nonMissingNum, (const jint *)featureIndex);
+  jenv->SetFloatArrayRegion(jfeatureValue, 0, nonMissingNum, (const jfloat *)featureValue);
+
+  JVM_CHECK_CALL(ret);
   return ret;
 }

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.h
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.h
@@ -145,6 +145,14 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixNumRow
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGDMatrixNumCol
+ * Signature: (J[J)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixNumCol
+  (JNIEnv *, jclass, jlong, jlongArray);
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGDMatrixNumNonMissing
  * Signature: (J[J)I
  */
@@ -400,6 +408,14 @@ Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetStrFeatureInfo
 JNIEXPORT jint JNICALL
 Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetStrFeatureInfo
   (JNIEnv *, jclass, jlong, jstring, jobjectArray);
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGDMatrixGetDataAsCSR
+ * Signature: (Ljava/lang/String;[J[I[F)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetDataAsCSR
+  (JNIEnv *, jclass, jlong, jstring, jlongArray, jintArray, jfloatArray);
 
 #ifdef __cplusplus
 }

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/DMatrixTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/DMatrixTest.java
@@ -428,4 +428,39 @@ public class DMatrixTest {
     String[] retFeatureTypes = dmat.getFeatureTypes();
     assertArrayEquals(featureTypes, retFeatureTypes);
   }
+
+  @Test
+  public void testGetDataMatrixForCSR() throws XGBoostError {
+    //create Matrix from csr format sparse Matrix and labels
+    /**
+     * sparse matrix
+     * 1 0 2 3 0
+     * 4 0 2 3 5
+     * 3 1 2 5 0
+     */
+    float[] data = new float[]{1, 2, 3, 4, 2, 3, 5, 3, 1, 2, 5};
+    int[] colIndex = new int[]{0, 2, 3, 0, 2, 3, 4, 0, 1, 2, 3};
+    long[] rowHeaders = new long[]{0, 3, 7, 11};
+    DMatrix dmat1 = new DMatrix(rowHeaders, colIndex, data, DMatrix.SparseType.CSR, 5);
+    BigDenseMatrix denseMatrix = dmat1.getData();
+
+    TestCase.assertTrue(denseMatrix.get(0, 0) == 1.0f);
+    TestCase.assertTrue(denseMatrix.get(0, 1) == 0.0f);
+    TestCase.assertTrue(denseMatrix.get(0, 2) == 2.0f);
+    TestCase.assertTrue(denseMatrix.get(0, 3) == 3.0f);
+    TestCase.assertTrue(denseMatrix.get(0, 4) == 0.0f);
+
+    TestCase.assertTrue(denseMatrix.get(1, 0) == 4.0f);
+    TestCase.assertTrue(denseMatrix.get(1, 1) == 0.0f);
+    TestCase.assertTrue(denseMatrix.get(1, 2) == 2.0f);
+    TestCase.assertTrue(denseMatrix.get(1, 3) == 3.0f);
+    TestCase.assertTrue(denseMatrix.get(1, 4) == 5.0f);
+
+    TestCase.assertTrue(denseMatrix.get(2, 0) == 3.0f);
+    TestCase.assertTrue(denseMatrix.get(2, 1) == 1.0f);
+    TestCase.assertTrue(denseMatrix.get(2, 2) == 2.0f);
+    TestCase.assertTrue(denseMatrix.get(2, 3) == 5.0f);
+    TestCase.assertTrue(denseMatrix.get(2, 4) == 0.0f);
+
+  }
 }

--- a/jvm-packages/xgboost4j/src/test/scala/ml/dmlc/xgboost4j/scala/DMatrixSuite.scala
+++ b/jvm-packages/xgboost4j/src/test/scala/ml/dmlc/xgboost4j/scala/DMatrixSuite.scala
@@ -16,10 +16,10 @@
 
 package ml.dmlc.xgboost4j.scala
 
+import ml.dmlc.xgboost4j.java.DMatrix.SparseType
+
 import java.util.Arrays
-
 import scala.util.Random
-
 import org.scalatest.funsuite.AnyFunSuite
 import ml.dmlc.xgboost4j.java.{DMatrix => JDMatrix}
 
@@ -173,4 +173,28 @@ class DMatrixSuite extends AnyFunSuite {
     assert(dmat0.rowNum === 10)
     assert(dmat0.getLabel.length === 10)
   }
+
+  test("create get data from DMatrix as BigDenseMatrix") {
+    // create Matrix from csr format sparse Matrix and labels
+    /**
+     * sparse matrix
+     * 1 0 2 3 0
+     * 4 0 2 3 5
+     * 3 1 2 5 0
+     */
+    val data = Array[Float](1, 2, 3, 4, 2, 3, 5, 3, 1, 2, 5)
+    val colIndex = Array[Int](0, 2, 3, 0, 2, 3, 4, 0, 1, 2, 3)
+    val rowHeaders = Array[Long](0, 3, 7, 11)
+    val dmatrix = new DMatrix(rowHeaders, colIndex, data, SparseType.CSR, 5)
+
+    val denseMatrix = dmatrix.getData
+
+    assert(denseMatrix.get(0, 0) == 1.0f)
+    assert(denseMatrix.get(0, 3) == 3.0f)
+    assert(denseMatrix.get(1, 2) == 2.0f)
+    assert(denseMatrix.get(2, 3) == 5.0f)
+    assert(denseMatrix.get(2, 4) == 0.0f)
+
+  }
+
 }


### PR DESCRIPTION
The python API has a [get_data](https://github.com/dmlc/xgboost/blob/3632242e0b680592a0bbae7b086c42e52741cfaa/python-package/xgboost/core.py#L1087) function, add a similar api for jvm-package too.