### PR TITLE
[jvm-packages] Reduce log verbosity for GPU tests.

### DIFF
--- a/jvm-packages/xgboost4j-spark-gpu/src/test/scala/ml/dmlc/xgboost4j/scala/rapids/spark/GpuTestSuite.scala
+++ b/jvm-packages/xgboost4j-spark-gpu/src/test/scala/ml/dmlc/xgboost4j/scala/rapids/spark/GpuTestSuite.scala
@@ -282,7 +282,7 @@ object SparkSessionHolder extends Logging {
     logDebug(s"SETTING  CONF: ${conf.getAll.toMap}")
     setAllConfs(conf.getAll)
     logDebug(s"RUN WITH CONF: ${spark.conf.getAll}\n")
+    spark.sparkContext.setLogLevel("WARN")
     f(spark)
   }
-
 }


### PR DESCRIPTION
Most of the info log are not useful for XGBoost tests.