### PR TITLE
[CI] Block CI from running for dependabot PRs

### DIFF
--- a/tests/buildkite/pipeline-mgpu.yml
+++ b/tests/buildkite/pipeline-mgpu.yml
@@ -12,7 +12,7 @@ steps:
       queue: pipeline-loader
   - wait
   - block: ":rocket: Run this test job"
-    if: build.pull_request.id != null
+    if: build.pull_request.id != null || build.branch =~ /^dependabot\//
   #### -------- CONTAINER BUILD --------
   - label: ":docker: Build containers"
     commands:

--- a/tests/buildkite/pipeline-win64.yml
+++ b/tests/buildkite/pipeline-win64.yml
@@ -6,7 +6,7 @@ steps:
       queue: pipeline-loader
   - wait
   - block: ":rocket: Run this test job"
-    if: build.pull_request.id != null
+    if: build.pull_request.id != null || build.branch =~ /^dependabot\//
   #### -------- BUILD --------
   - label: ":windows: Build XGBoost for Windows with CUDA"
     command: "tests/buildkite/build-win64-gpu.ps1"

--- a/tests/buildkite/pipeline.yml
+++ b/tests/buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
       queue: pipeline-loader
   - wait
   - block: ":rocket: Run this test job"
-    if: build.pull_request.id != null
+    if: build.pull_request.id != null || build.branch =~ /^dependabot\//
   #### -------- CONTAINER BUILD --------
   - label: ":docker: Build containers"
     commands:


### PR DESCRIPTION
Fix #9034 by additionally filtering the branch name, to ensure that PRs submitted by dependabots don't consume the CI resources.

Tested in #9393