### PR TITLE
[breaking] Remove support for single string feature info.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1234,11 +1234,10 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @property
     def feature_names(self) -> Optional[FeatureNames]:
-        """Get feature names (column labels).
+        """Labels for features (column labels).
 
-        Returns
-        -------
-        feature_names : list or None
+        Setting it to ``None`` resets existing feature names.
+
         """
         length = c_bst_ulong()
         sarr = ctypes.POINTER(ctypes.c_char_p)()
@@ -1257,13 +1256,6 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @feature_names.setter
     def feature_names(self, feature_names: Optional[FeatureNames]) -> None:
-        """Set feature names (column labels).
-
-        Parameters
-        ----------
-        feature_names :
-            Labels for features. None will reset existing feature names.
-        """
         if feature_names is None:
             _check_call(
                 _LIB.XGDMatrixSetStrFeatureInfo(
@@ -1312,11 +1304,13 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @property
     def feature_types(self) -> Optional[FeatureTypes]:
-        """Get feature types (column types).
+        """Type of features (column types).
 
-        Returns
-        -------
-        feature_types : list or None
+        This is for displaying the results and categorical data support. See
+        :py:class:`DMatrix` for details.
+
+        Setting it to ``None`` resets existing feature types.
+
         """
         length = c_bst_ulong()
         sarr = ctypes.POINTER(ctypes.c_char_p)()
@@ -1335,17 +1329,6 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @feature_types.setter
     def feature_types(self, feature_types: Optional[FeatureTypes]) -> None:
-        """Set feature types (column types).
-
-        This is for displaying the results and categorical data support. See
-        :py:class:`DMatrix` for details.
-
-        Parameters
-        ----------
-        feature_types :
-            Labels for features. None will reset existing feature names
-
-        """
         if feature_types is None:
             # Reset
             _check_call(

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1285,7 +1285,7 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             )
             duplicates = [name for name, cnt in zip(values, counts) if cnt > 1]
             raise ValueError(
-                "feature_names must be unique. Duplicates found: {}".format(duplicates)
+                f"feature_names must be unique. Duplicates found: {duplicates}"
             )
 
         # prohibit the use symbols that may affect parsing. e.g. []<

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -678,3 +678,6 @@ class TestModels:
 
             assert booster.feature_names == Xy.feature_names
             assert booster.feature_types == Xy.feature_types
+
+        with pytest.raises(ValueError, match=r"Duplicates found: \['bar'\]"):
+            Xy.feature_names = ["bar"] * (cols - 2) + ["a", "b"]

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -678,6 +678,3 @@ class TestModels:
 
             assert booster.feature_names == Xy.feature_names
             assert booster.feature_types == Xy.feature_types
-
-        with pytest.raises(ValueError, match=r"Duplicates found: \['bar'\]"):
-            Xy.feature_names = ["bar"] * (cols - 2) + ["a", "b"]

--- a/tests/python/test_dmatrix.py
+++ b/tests/python/test_dmatrix.py
@@ -219,8 +219,8 @@ class TestDMatrix:
         assert dm.slice([0, 1]).num_col() == dm.num_col()
         assert dm.slice([0, 1]).feature_names == dm.feature_names
 
-        dm.feature_types = 'q'
-        assert dm.feature_types == list('qqqqq')
+        with pytest.raises(ValueError, match=r"Duplicates found: \['bar'\]"):
+            dm.feature_names = ["bar"] * (data.shape[1] - 2) + ["a", "b"]
 
         dm.feature_types = list('qiqiq')
         assert dm.feature_types == list('qiqiq')
@@ -230,6 +230,7 @@ class TestDMatrix:
 
         # reset
         dm.feature_names = None
+        dm.feature_types = None
         assert dm.feature_names is None
         assert dm.feature_types is None
 


### PR DESCRIPTION
- Input must be a sequence of strings.
- Improve validation error message.
- Don't reset feature type along with feature name.

Close https://github.com/dmlc/xgboost/issues/9322 .