### PR TITLE
Update prediction.rst

### DIFF
--- a/doc/prediction.rst
+++ b/doc/prediction.rst
@@ -35,14 +35,14 @@ After 1.4 release, we added a new parameter called ``strict_shape``, one can set
   has equivalent output shape of ``multi:softprob`` due to dropped transformation.  If
   strict shape is set to False then output can have 1 or 2 dim depending on used model.
 
-- When using ``preds_contribs`` with ``strict_shape`` set to ``True``:
+- When using ``pred_contribs`` with ``strict_shape`` set to ``True``:
 
   Output is a 3-dim array, with ``(rows, groups, columns + 1)`` as shape.  Whether
   ``approx_contribs`` is used does not change the output shape. If the strict shape
   parameter is not set, it can be a 2 or 3 dimension array depending on whether
   multi-class model is being used.
 
-- When using ``preds_interactions`` with ``strict_shape`` set to ``True``:
+- When using ``pred_interactions`` with ``strict_shape`` set to ``True``:
 
   Output is a 4-dim array, with ``(rows, groups, columns + 1, columns + 1)`` as shape.
   Like the predict contribution case, whether ``approx_contribs`` is used does not change


### PR DESCRIPTION
Typo for `pred_contribs` and `pred_interactions`

See method [here](https://github.com/dmlc/xgboost/blob/3a9996173e5209dff0e71ea8b2e85c954339ab59/python-package/xgboost/core.py#L2142) for confirmation of param names

``` 
def predict(
        self,
        data: DMatrix,
        output_margin: bool = False,
        pred_leaf: bool = False,
        pred_contribs: bool = False,
        approx_contribs: bool = False,
        pred_interactions: bool = False,
        validate_features: bool = True,
        training: bool = False,
        iteration_range: Tuple[int, int] = (0, 0),
        strict_shape: bool = False,
    ) -> np.ndarray:
 ````