### PR TITLE
Raise if expected workers are not alive in `xgboost.dask.train`

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -905,8 +905,9 @@ def _filter_empty(
     raise ValueError("None of the workers can provide a valid result.")
 
 
-def _check_workers_are_alive(workers: List[str], client: "distributed.Client") -> None:
-    current_workers = client.scheduler_info()["workers"].keys()
+async def _check_workers_are_alive(workers: List[str], client: "distributed.Client") -> None:
+    info = await self.scheduler.identity()
+    current_workers = info["workers"].keys()
     missing_workers = set(workers) - current_workers
     if missing_workers:
         raise RuntimeError(f"Missing required workers: {missing_workers}")

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -906,7 +906,7 @@ def _filter_empty(
 
 
 async def _check_workers_are_alive(workers: List[str], client: "distributed.Client") -> None:
-    info = await self.scheduler.identity()
+    info = await client.scheduler.identity()
     current_workers = info["workers"].keys()
     missing_workers = set(workers) - current_workers
     if missing_workers:

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -905,7 +905,9 @@ def _filter_empty(
     raise ValueError("None of the workers can provide a valid result.")
 
 
-async def _check_workers_are_alive(workers: List[str], client: "distributed.Client") -> None:
+async def _check_workers_are_alive(
+    workers: List[str], client: "distributed.Client"
+) -> None:
     info = await client.scheduler.identity()
     current_workers = info["workers"].keys()
     missing_workers = set(workers) - current_workers

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -905,8 +905,7 @@ def _filter_empty(
     raise ValueError("None of the workers can provide a valid result.")
 
 def _check_workers_are_alive(workers: List[str], client: "distributed.Client"):
-    info = client.scheduler_info()
-    current_workers = info["workers"].keys()
+    current_workers = client.scheduler_info()["workers"].keys()
     missing_workers = set(workers) - current_workers
     if missing_workers:
         raise RuntimeError(f"Missing required workers: {missing_workers}")

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -930,7 +930,7 @@ async def _train_async(
     custom_metric: Optional[Metric],
 ) -> Optional[TrainReturnT]:
     workers = _get_workers_from_data(dtrain, evals)
-    _check_workers_are_alive(workers, client)
+    await _check_workers_are_alive(workers, client)
     _rabit_args = await _get_rabit_args(len(workers), dconfig, client)
     _check_distributed_params(params)
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -905,7 +905,7 @@ def _filter_empty(
     raise ValueError("None of the workers can provide a valid result.")
 
 
-def _check_workers_are_alive(workers: List[str], client: "distributed.Client"):
+def _check_workers_are_alive(workers: List[str], client: "distributed.Client") -> None:
     current_workers = client.scheduler_info()["workers"].keys()
     missing_workers = set(workers) - current_workers
     if missing_workers:

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -850,8 +850,6 @@ async def _get_rabit_args(
     except Exception:  # pylint: disable=broad-except
         sched_addr = None
 
-    # make sure all workers are online so that we can obtain reliable scheduler_info
-    await client.wait_for_workers(n_workers)  # type: ignore
     env = await client.run_on_scheduler(
         _start_tracker, n_workers, sched_addr, user_addr
     )
@@ -906,6 +904,12 @@ def _filter_empty(
 
     raise ValueError("None of the workers can provide a valid result.")
 
+def _check_workers_are_alive(workers: List[str], client: "distributed.Client"):
+    info = client.scheduler_info()
+    current_workers = info["workers"].keys()
+    missing_workers = set(workers) - current_workers
+    if missing_workers:
+        raise RuntimeError(f"Missing required workers: {missing_workers}")
 
 async def _train_async(
     client: "distributed.Client",
@@ -924,6 +928,7 @@ async def _train_async(
     custom_metric: Optional[Metric],
 ) -> Optional[TrainReturnT]:
     workers = _get_workers_from_data(dtrain, evals)
+    _check_workers_are_alive(workers, client)
     _rabit_args = await _get_rabit_args(len(workers), dconfig, client)
     _check_distributed_params(params)
 

--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -904,11 +904,13 @@ def _filter_empty(
 
     raise ValueError("None of the workers can provide a valid result.")
 
+
 def _check_workers_are_alive(workers: List[str], client: "distributed.Client"):
     current_workers = client.scheduler_info()["workers"].keys()
     missing_workers = set(workers) - current_workers
     if missing_workers:
         raise RuntimeError(f"Missing required workers: {missing_workers}")
+
 
 async def _train_async(
     client: "distributed.Client",

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -37,7 +37,7 @@ import dask
 import dask.array as da
 import dask.dataframe as dd
 from distributed import Client, LocalCluster, Nanny, Worker
-from distributed.utils_test import gen_cluster, async_poll_for
+from distributed.utils_test import async_poll_for, gen_cluster
 from toolz import sliding_window  # dependency of dask
 
 from xgboost.dask import DaskDMatrix

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -2231,8 +2231,8 @@ class TestDaskCallbacks:
 @gen_cluster(client=True, clean_kwargs={"processes": False, "threads": False}, allow_unclosed=True)
 async def test_worker_left(c, s, a, b):
     async with Worker(s.address):
-        dx = da.random.random((100, 10)).rechunk(chunks=(10, None))
-        dy = da.random.random((100,)).rechunk(chunks=(10,))
+        dx = da.random.random((1000, 10)).rechunk(chunks=(10, None))
+        dy = da.random.random((1000,)).rechunk(chunks=(10,))
         d_train = await xgb.dask.DaskDMatrix(
             c, dx, dy,
         )
@@ -2248,8 +2248,8 @@ async def test_worker_left(c, s, a, b):
 
 @gen_cluster(client=True, Worker=Nanny, clean_kwargs={"processes": False, "threads": False}, allow_unclosed=True)
 async def test_worker_restarted(c, s, a, b):
-    dx = da.random.random((100, 10)).rechunk(chunks=(10, None))
-    dy = da.random.random((100,)).rechunk(chunks=(10,))
+    dx = da.random.random((1000, 10)).rechunk(chunks=(10, None))
+    dy = da.random.random((1000,)).rechunk(chunks=(10,))
     d_train = await xgb.dask.DaskDMatrix(
         c, dx, dy,
     )

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -36,7 +36,8 @@ pytestmark = [tm.timeout(60), pytest.mark.skipif(**tm.no_dask())]
 import dask
 import dask.array as da
 import dask.dataframe as dd
-from distributed import Client, LocalCluster
+from distributed import Client, LocalCluster, Nanny, Worker
+from distributed.utils_test import gen_cluster, async_poll_for
 from toolz import sliding_window  # dependency of dask
 
 from xgboost.dask import DaskDMatrix
@@ -2225,3 +2226,38 @@ class TestDaskCallbacks:
             )
             for i in range(1, 10):
                 assert os.path.exists(os.path.join(tmpdir, "model_" + str(i) + ".json"))
+
+
+@gen_cluster(client=True)
+async def test_worker_left(c, s, a, b):
+    async with Worker(s.address):
+        dx = da.random.random((100, 10)).rechunk(chunks=(10, None))
+        dy = da.random.random((100,)).rechunk(chunks=(10,))
+        d_train = await xgb.dask.DaskDMatrix(
+            c, dx, dy,
+        )
+    await async_poll_for(lambda: len(s.workers) == 2, timeout=5)
+    with pytest.raises(RuntimeError, match="Missing"):
+        await xgb.dask.train( 
+            c,
+            {},
+            d_train,
+            evals=[(d_train, "train")],
+        )
+
+
+@gen_cluster(client=True, Worker=Nanny)
+async def test_worker_restarted(c, s, a, b):
+    dx = da.random.random((100, 10)).rechunk(chunks=(10, None))
+    dy = da.random.random((100,)).rechunk(chunks=(10,))
+    d_train = await xgb.dask.DaskDMatrix(
+        c, dx, dy,
+    )
+    await c.restart_workers([a.worker_address])
+    with pytest.raises(RuntimeError, match="Missing"):
+        await xgb.dask.train( 
+            c,
+            {},
+            d_train,
+            evals=[(d_train, "train")],
+        )

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -2228,7 +2228,7 @@ class TestDaskCallbacks:
                 assert os.path.exists(os.path.join(tmpdir, "model_" + str(i) + ".json"))
 
 
-@gen_cluster(client=True)
+@gen_cluster(client=True, clean_kwargs={"processes": False, "threads": False}, allow_unclosed=True)
 async def test_worker_left(c, s, a, b):
     async with Worker(s.address):
         dx = da.random.random((100, 10)).rechunk(chunks=(10, None))
@@ -2246,7 +2246,7 @@ async def test_worker_left(c, s, a, b):
         )
 
 
-@gen_cluster(client=True, Worker=Nanny)
+@gen_cluster(client=True, Worker=Nanny, clean_kwargs={"processes": False, "threads": False}, allow_unclosed=True)
 async def test_worker_restarted(c, s, a, b):
     dx = da.random.random((100, 10)).rechunk(chunks=(10, None))
     dy = da.random.random((100,)).rechunk(chunks=(10,))


### PR DESCRIPTION
* Closes #9419
* Closes #9420

This PR checks whether the workers expected to hold the data from `DaskDMatrix` are still alive so that training jobs can then be scheduled on those workers. This avoids several deadlock scenarios.

Note that this PR does not make `xgboost.dask.train` resilient against an expected worker leaving _after_ the check.