### PR TITLE
Change training stage from ResultStage to ShuffleMapStage

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala
@@ -422,7 +422,10 @@ object XGBoost extends Serializable {
 
         }}
 
-        val (booster, metrics) = boostersAndMetrics.collect()(0)
+        // The repartition step is to make training stage as ShuffleMapStage, so that when one
+        // of the training task fails the training stage can retry. ResultStage won't retry when
+        // it fails.
+        val (booster, metrics) = boostersAndMetrics.repartition(1).collect()(0)
         val trackerReturnVal = tracker.waitFor(0L)
         logger.info(s"Rabit returns with exit code $trackerReturnVal")
         if (trackerReturnVal != 0) {


### PR DESCRIPTION
The training step runs in barrier model and is ResultStage, which means when one of the training task failed the training stage failed, and the whole application failed becuase no retry for ResultStage. 
When there are many training tasks, it's easy that one task will fail due to cluster node issue, so the application may has a high failure rate. 
In this PR, we add a repartition step to make the training stage as ShuffleMapStage, so that when the training stage failed, the stage can retry and the whole spark application won't fail. 