### PR TITLE
Accept only keyword arguments in data iterator.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -582,8 +582,8 @@ class DataIter(ABC):  # pylint: disable=too-many-instance-attributes
 
         @require_keyword_args(True)
         def input_data(
-            data: Any,
             *,
+            data: Any,
             feature_names: Optional[FeatureNames] = None,
             feature_types: Optional[FeatureTypes] = None,
             **kwargs: Any,
@@ -684,6 +684,9 @@ def require_keyword_args(
         @wraps(func)
         def inner_f(*args: Any, **kwargs: Any) -> _T:
             extra_args = len(args) - len(all_args)
+            if not all_args and extra_args > 0:  # keyword argument only
+                raise TypeError("Keyword argument is required.")
+
             if extra_args > 0:
                 # ignore first 'self' argument for instance methods
                 args_msg = [

--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -212,7 +212,7 @@ class IteratorForTest(xgb.core.DataIter):
         if self.it == len(self.X):
             return 0
 
-        with pytest.raises(TypeError, match="keyword args"):
+        with pytest.raises(TypeError, match="Keyword argument"):
             input_data(self.X[self.it], self.y[self.it], None)
 
         # Use copy to make sure the iterator doesn't hold a reference to the data.


### PR DESCRIPTION
Fix https://github.com/dmlc/xgboost/issues/9418