### PR TITLE
[R] Handle UTF-8 paths on Windows

### DIFF
--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -12,7 +12,7 @@ xgb.Booster.handle <- function(params = list(), cachelist = list(),
       ## A filename
       handle <- .Call(XGBoosterCreate_R, cachelist)
       modelfile <- path.expand(modelfile)
-      .Call(XGBoosterLoadModel_R, handle, modelfile[1])
+      .Call(XGBoosterLoadModel_R, handle, enc2utf8(modelfile[1]))
       class(handle) <- "xgb.Booster.handle"
       if (length(params) > 0) {
         xgb.parameters(handle) <- params

--- a/R-package/R/xgb.save.R
+++ b/R-package/R/xgb.save.R
@@ -43,6 +43,6 @@ xgb.save <- function(model, fname) {
   }
   model <- xgb.Booster.complete(model, saveraw = FALSE)
   fname <- path.expand(fname)
-  .Call(XGBoosterSaveModel_R, model$handle, fname[1])
+  .Call(XGBoosterSaveModel_R, model$handle, enc2utf8(fname[1]))
   return(TRUE)
 }

--- a/R-package/tests/testthat/test_unicode.R
+++ b/R-package/tests/testthat/test_unicode.R
@@ -1,0 +1,21 @@
+context("Test Unicode handling")
+
+data(agaricus.train, package = 'xgboost')
+data(agaricus.test, package = 'xgboost')
+train <- agaricus.train
+test <- agaricus.test
+set.seed(1994)
+
+test_that("Can save and load models with Unicode paths", {
+  nrounds <- 2
+  bst <- xgboost(data = train$data, label = train$label, max_depth = 2,
+                 eta = 1, nthread = 2, nrounds = nrounds, objective = "binary:logistic",
+                 eval_metric = "error")
+  tmpdir <- tempdir()
+  lapply(c("모델.json", "がうる・ぐら.json", "类继承.ubj"), function(x) {
+    path <- file.path(tmpdir, x)
+    xgb.save(bst, path)
+    bst2 <- xgb.load(path)
+    expect_equal(predict(bst, test$data), predict(bst2, test$data))
+  })
+})


### PR DESCRIPTION
* Use the built-in method `enc2utf8` to ensure that UTF-8 strings are passed to `XGBoosterLoadModel` and `XGBoosterSaveModel`.
* Add a unit test for R

Follow-up for #9443