### PR TITLE
Use `realloc` for histogram cache and expose the cache limit.

### DIFF
--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -226,6 +226,15 @@ Parameters for Tree Booster
     - ``one_output_per_tree``: One model for each target.
     - ``multi_output_tree``:  Use multi-target trees.
 
+* ``max_cached_hist_node``, [default = 65536]
+
+  Maximum number of cached nodes for CPU histogram.
+
+  .. versionadded:: 2.0.0
+
+  - For most of the cases this parameter should not be set except for growing deep trees
+    on CPU.
+
 .. _cat-param:
 
 Parameters for Categorical Feature

--- a/python-package/xgboost/testing/params.py
+++ b/python-package/xgboost/testing/params.py
@@ -42,7 +42,7 @@ hist_parameter_strategy = strategies.fixed_dictionaries(
 )
 
 hist_cache_strategy = strategies.fixed_dictionaries(
-    {"internal_max_cached_hist_node": strategies.sampled_from([1, 4, 1024, 2**31])}
+    {"max_cached_hist_node": strategies.sampled_from([1, 4, 1024, 2**31])}
 )
 
 hist_multi_parameter_strategy = strategies.fixed_dictionaries(

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -63,7 +63,7 @@ class HistogramBuilder {
              bool is_col_split, HistMakerTrainParam const *param) {
     n_threads_ = ctx->Threads();
     param_ = p;
-    hist_.Reset(total_bins, param->internal_max_cached_hist_node);
+    hist_.Reset(total_bins, param->max_cached_hist_node);
     buffer_.Init(total_bins);
     is_distributed_ = is_distributed;
     is_col_split_ = is_col_split;

--- a/src/tree/hist/param.h
+++ b/src/tree/hist/param.h
@@ -13,7 +13,7 @@ struct HistMakerTrainParam : public XGBoostParameter<HistMakerTrainParam> {
   constexpr static std::size_t DefaultNodes() { return static_cast<std::size_t>(1) << 16; }
 
   bool debug_synchronize{false};
-  std::size_t internal_max_cached_hist_node{DefaultNodes()};
+  std::size_t max_cached_hist_node{DefaultNodes()};
 
   void CheckTreesSynchronized(RegTree const* local_tree) const;
 
@@ -22,7 +22,7 @@ struct HistMakerTrainParam : public XGBoostParameter<HistMakerTrainParam> {
     DMLC_DECLARE_FIELD(debug_synchronize)
         .set_default(false)
         .describe("Check if all distributed tree are identical after tree construction.");
-    DMLC_DECLARE_FIELD(internal_max_cached_hist_node)
+    DMLC_DECLARE_FIELD(max_cached_hist_node)
         .set_default(DefaultNodes())
         .set_lower_bound(1)
         .describe("Maximum number of nodes in CPU histogram cache. Only for internal usage.");

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -866,6 +866,9 @@ class GPUGlobalApproxMaker : public TreeUpdater {
     // Used in test to count how many configurations are performed
     LOG(DEBUG) << "[GPU Approx]: Configure";
     hist_maker_param_.UpdateAllowUnknown(args);
+    if (hist_maker_param_.max_cached_hist_node != HistMakerTrainParam::DefaultNodes()) {
+      LOG(WARNING) << "The `max_cached_hist_node` is ignored in GPU.";
+    }
     dh::CheckComputeCapability();
     initialised_ = false;
 

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -51,7 +51,7 @@ void TestEvaluateSplits(bool force_read_by_column) {
   row_set_collection.Init();
 
   HistMakerTrainParam hist_param;
-  hist.Reset(gmat.cut.Ptrs().back(), hist_param.internal_max_cached_hist_node);
+  hist.Reset(gmat.cut.Ptrs().back(), hist_param.max_cached_hist_node);
   hist.AllocateHistograms({0});
   common::BuildHist<false>(row_gpairs, row_set_collection[0], gmat, hist[0], force_read_by_column);
 
@@ -118,7 +118,7 @@ TEST(HistMultiEvaluator, Evaluate) {
   linalg::Vector<GradientPairPrecise> root_sum({2}, Context::kCpuId);
   for (bst_target_t t{0}; t < n_targets; ++t) {
     auto &hist = histogram[t];
-    hist.Reset(n_bins * n_features, hist_param.internal_max_cached_hist_node);
+    hist.Reset(n_bins * n_features, hist_param.max_cached_hist_node);
     hist.AllocateHistograms({0});
     auto node_hist = hist[0];
     node_hist[0] = {-0.5, 0.5};
@@ -235,7 +235,7 @@ auto CompareOneHotAndPartition(bool onehot) {
     entries.front().nid = 0;
     entries.front().depth = 0;
 
-    hist.Reset(gmat.cut.TotalBins(), hist_param.internal_max_cached_hist_node);
+    hist.Reset(gmat.cut.TotalBins(), hist_param.max_cached_hist_node);
     hist.AllocateHistograms({0});
     auto node_hist = hist[0];
 
@@ -265,7 +265,7 @@ TEST(HistEvaluator, Categorical) {
 TEST_F(TestCategoricalSplitWithMissing, HistEvaluator) {
   BoundedHistCollection hist;
   HistMakerTrainParam hist_param;
-  hist.Reset(cuts_.TotalBins(), hist_param.internal_max_cached_hist_node);
+  hist.Reset(cuts_.TotalBins(), hist_param.max_cached_hist_node);
   hist.AllocateHistograms({0});
   auto node_hist = hist[0];
   ASSERT_EQ(node_hist.size(), feature_histogram_.size());

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -516,7 +516,7 @@ class OverflowTest : public ::testing::TestWithParam<std::tuple<bool, bool>> {
     Context ctx;
     HistMakerTrainParam hist_param;
     if (limit) {
-      hist_param.Init(Args{{"internal_max_cached_hist_node", "1"}});
+      hist_param.Init(Args{{"max_cached_hist_node", "1"}});
     }
 
     std::shared_ptr<DMatrix> Xy =

--- a/tests/cpp/tree/test_evaluate_splits.h
+++ b/tests/cpp/tree/test_evaluate_splits.h
@@ -59,7 +59,7 @@ class TestPartitionBasedSplit : public ::testing::Test {
     cuts_.min_vals_.Resize(1);
 
     HistMakerTrainParam hist_param;
-    hist_.Reset(cuts_.TotalBins(), hist_param.internal_max_cached_hist_node);
+    hist_.Reset(cuts_.TotalBins(), hist_param.max_cached_hist_node);
     hist_.AllocateHistograms({0});
     auto node_hist = hist_[0];
 


### PR DESCRIPTION
Following are plots with 4 local workers from `LocalCluster`. The initial spike in the plot is not accurate. Please note that memory usage with `LocalCluster` does not represent real world usage. The histogram cache is built for each worker.

The memory spike observed in https://github.com/dmlc/xgboost/issues/9452 is caused by `std::vector::resize`. I'm not sure which one is actually better for a longer term.

The memory usage can not be directly compared to 1.7.x as we have a new estimation method for intercept. To disable it, set the `base_score` to `0.5` (default in 1.7).

I have exposed the limit as a parameter to the user interface so that there's at least an option when things get dire.

Close https://github.com/dmlc/xgboost/issues/9452 .

- Default configuration of max cache:

![figure-16](https://github.com/dmlc/xgboost/assets/16746409/4e1b8b8e-481e-4429-9d26-dea659b74db4)

- Cache size limited to 4096:

![figure-12](https://github.com/dmlc/xgboost/assets/16746409/2b930e14-936e-4ddf-9a5d-fe11d15991c3)
