### PR TITLE
[R] [CI] use lintr 3.1.0

### DIFF
--- a/R-package/R/xgb.model.dt.tree.R
+++ b/R-package/R/xgb.model.dt.tree.R
@@ -86,8 +86,7 @@ xgb.model.dt.tree <- function(feature_names = NULL, model = NULL, text = NULL,
     text <- xgb.dump(model = model, with_stats = TRUE)
   }
 
-  if (length(text) < 2 ||
-      sum(grepl('leaf=(\\d+)', text)) < 1) {
+  if (length(text) < 2 || !any(grepl('leaf=(\\d+)', text))) {
     stop("Non-tree model detected! This function can only be used with tree models.")
   }
 

--- a/R-package/R/xgb.plot.deepness.R
+++ b/R-package/R/xgb.plot.deepness.R
@@ -136,7 +136,7 @@ get.leaf.depth <- function(dt_tree) {
     # list of paths to each leaf in a tree
     paths <- lapply(paths_tmp$vpath, names)
     # combine into a resulting path lengths table for a tree
-    data.table(Depth = sapply(paths, length), ID = To[Leaf == TRUE])
+    data.table(Depth = lengths(paths), ID = To[Leaf == TRUE])
   }, by = Tree]
 }
 

--- a/R-package/demo/interaction_constraints.R
+++ b/R-package/demo/interaction_constraints.R
@@ -44,7 +44,7 @@ treeInteractions <- function(input_tree, input_max_depth) {
 
   # Remove non-interactions (same variable)
   interaction_list <- lapply(interaction_list, unique)  # remove same variables
-  interaction_length <- sapply(interaction_list, length)
+  interaction_length <- lengths(interaction_list)
   interaction_list <- interaction_list[interaction_length > 1]
   interaction_list <- unique(lapply(interaction_list, sort))
   return(interaction_list)

--- a/R-package/tests/testthat/test_helpers.R
+++ b/R-package/tests/testthat/test_helpers.R
@@ -189,7 +189,7 @@ test_that("SHAPs sum to predictions, with or without DART", {
     tol <- 1e-5
 
     expect_equal(rowSums(shap), pred, tol = tol)
-    expect_equal(apply(shapi, 1, sum), pred, tol = tol)
+    expect_equal(rowSums(shapi), pred, tol = tol)
     for (i in seq_len(nrow(d)))
       for (f in list(rowSums, colSums))
         expect_equal(f(shapi[i, , ]), shap[i, ], tol = tol)

--- a/tests/ci_build/lint_r.R
+++ b/tests/ci_build/lint_r.R
@@ -20,15 +20,23 @@ my_linters <- list(
   any_duplicated = lintr::any_duplicated_linter(),
   any_is_na = lintr::any_is_na_linter(),
   assignment_linter = lintr::assignment_linter(),
+  boolean_arithmetic = lintr::boolean_arithmetic_linter(),
   brace_linter = lintr::brace_linter(),
+  class_equals = lintr::class_equals_linter(),
   commas_linter = lintr::commas_linter(),
+  empty_assignment = lintr::empty_assignment_linter(),
   equals_na = lintr::equals_na_linter(),
   fixed_regex = lintr::fixed_regex_linter(),
+  for_loop_index = lintr::for_loop_index_linter(),
+  function_return = lintr::function_return_linter(),
   infix_spaces_linter = lintr::infix_spaces_linter(),
+  is_numeric = lintr::is_numeric_linter(),
   line_length_linter = lintr::line_length_linter(length = 150L),
-  no_tab_linter = lintr::no_tab_linter(),
+  lengths = lintr::lengths_linter(),
+  matrix = lintr::matrix_apply_linter(),
   object_usage_linter = lintr::object_usage_linter(),
   object_length_linter = lintr::object_length_linter(),
+  routine_registration = lintr::routine_registration_linter(),
   semicolon = lintr::semicolon_linter(),
   seq = lintr::seq_linter(),
   spaces_inside_linter = lintr::spaces_inside_linter(),
@@ -37,9 +45,10 @@ my_linters <- list(
   trailing_blank_lines_linter = lintr::trailing_blank_lines_linter(),
   trailing_whitespace_linter = lintr::trailing_whitespace_linter(),
   true_false = lintr::T_and_F_symbol_linter(),
-  unneeded_concatenation = lintr::unneeded_concatenation_linter(),
+  unnecessary_concatenation = lintr::unnecessary_concatenation_linter(),
   unreachable_code = lintr::unreachable_code_linter(),
-  vector_logic = lintr::vector_logic_linter()
+  vector_logic = lintr::vector_logic_linter(),
+  whitespace = lintr::whitespace_linter()
 )
 
 noquote(paste0(length(FILES_TO_LINT), " R files need linting"))


### PR DESCRIPTION
`{lintr}` 3.1.0 came out a few weeks ago: https://github.com/r-lib/lintr/releases/tag/v3.1.0

It includes a few new linters, a bunch of bugfixes, and some new deprecation warnings. `{xgboost}` has already been using it, since this instalation is unpinned:

https://github.com/dmlc/xgboost/blob/a57371ef7c58acefe4bc794a23089a90734cc1a1/R-package/tests/helper_scripts/install_deps.R#L19

This PR proposes some changes to the R linting to better take advantage of that new version.

Fixes these warnings

```text
1: Linter no_tab_linter was deprecated in lintr version 3.1.0. Use whitespace_linter instead.
2: Linter unneeded_concatenation_linter was deprecated in lintr version 3.1.0. Use unnecessary_concatenation_linter instead.
```

And these errors

```text
[[1]]
R-package/demo/interaction_constraints.R:47:25: warning: [lengths] Use lengths() to find the length of each element in a list.
  interaction_length <- sapply(interaction_list, length)
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[[2]]
R-package/R/xgb.model.dt.tree.R:90:7: warning: [boolean_arithmetic] Use any() to express logical aggregations. For example, replace length(which(x == y)) == 0 with !any(x == y).
      sum(grepl('leaf=(\\d+)', text)) < 1) {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[[3]]
R-package/R/xgb.plot.deepness.R:139:24: warning: [lengths] Use lengths() to find the length of each element in a list.
    data.table(Depth = sapply(paths, length), ID = To[Leaf == TRUE])
                       ^~~~~~~~~~~~~~~~~~~~~

[[4]]
R-package/tests/testthat/test_helpers.R:192:18: warning: [matrix] Use rowSums(shapi) rather than apply(shapi, 1, sum)
    expect_equal(apply(shapi, 1, sum), pred, tol = tol)
                 ^~~~~~~~~~~~~~~~~~~~
```

### Notes for Reviewers

We made similar changes a few weeks ago in LightGBM and it's been working well so far: https://github.com/microsoft/LightGBM/pull/5997

Thanks for your time and consideration!