### PR TITLE
[R] remove default values in internal utility functions

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -140,7 +140,7 @@ check.custom.eval <- function(env = parent.frame()) {
 
 
 # Update a booster handle for an iteration with dtrain data
-xgb.iter.update <- function(booster_handle, dtrain, iter, obj = NULL) {
+xgb.iter.update <- function(booster_handle, dtrain, iter, obj) {
   if (!identical(class(booster_handle), "xgb.Booster.handle")) {
     stop("booster_handle must be of xgb.Booster.handle class")
   }
@@ -163,7 +163,7 @@ xgb.iter.update <- function(booster_handle, dtrain, iter, obj = NULL) {
 # Evaluate one iteration.
 # Returns a named vector of evaluation metrics
 # with the names in a 'datasetname-metricname' format.
-xgb.iter.eval <- function(booster_handle, watchlist, iter, feval = NULL) {
+xgb.iter.eval <- function(booster_handle, watchlist, iter, feval) {
   if (!identical(class(booster_handle), "xgb.Booster.handle"))
     stop("class of booster_handle must be xgb.Booster.handle")
 
@@ -234,7 +234,7 @@ generate.cv.folds <- function(nfold, nrows, stratified, label, params) {
         y <- factor(y)
       }
     }
-    folds <- xgb.createFolds(y, nfold)
+    folds <- xgb.createFolds(y = y, k = nfold)
   } else {
     # make simple non-stratified folds
     kstep <- length(rnd_idx) %/% nfold
@@ -251,7 +251,7 @@ generate.cv.folds <- function(nfold, nrows, stratified, label, params) {
 # Creates CV folds stratified by the values of y.
 # It was borrowed from caret::createFolds and simplified
 # by always returning an unnamed list of fold indices.
-xgb.createFolds <- function(y, k = 10) {
+xgb.createFolds <- function(y, k) {
   if (is.numeric(y)) {
     ## Group the numeric data based on their magnitudes
     ## and sample within those groups.

--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -223,8 +223,18 @@ xgb.cv <- function(params = list(), data, nrounds, nfold, label = NULL, missing 
     for (f in cb$pre_iter) f()
 
     msg <- lapply(bst_folds, function(fd) {
-      xgb.iter.update(fd$bst, fd$dtrain, iteration - 1, obj)
-      xgb.iter.eval(fd$bst, fd$watchlist, iteration - 1, feval)
+      xgb.iter.update(
+        booster_handle = fd$bst,
+        dtrain = fd$dtrain,
+        iter = iteration - 1,
+        obj = obj
+      )
+      xgb.iter.eval(
+        booster_handle = fd$bst,
+        watchlist = fd$watchlist,
+        iter = iteration - 1,
+        feval = feval
+      )
     })
     msg <- simplify2array(msg)
     bst_evaluation <- rowMeans(msg)

--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -390,10 +390,21 @@ xgb.train <- function(params = list(), data, nrounds, watchlist = list(),
 
     for (f in cb$pre_iter) f()
 
-    xgb.iter.update(bst$handle, dtrain, iteration - 1, obj)
+    xgb.iter.update(
+        booster_handle = bst$handle,
+        dtrain = dtrain,
+        iter = iteration - 1,
+        obj = obj
+    )
 
-    if (length(watchlist) > 0)
-      bst_evaluation <- xgb.iter.eval(bst$handle, watchlist, iteration - 1, feval)  # nolint: object_usage_linter
+    if (length(watchlist) > 0) {
+      bst_evaluation <- xgb.iter.eval(  # nolint: object_usage_linter
+        booster_handle = bst$handle,
+        watchlist = watchlist,
+        iter = iteration - 1,
+        feval = feval
+      )
+    }
 
     xgb.attr(bst$handle, 'niter') <- iteration - 1
 


### PR DESCRIPTION
Some of the internal-only functions in `R-package/R/utilities.R` have default values for some arguments.

This PR proposes removing those defaults, to force any calling code to specify values for all arguments. It also proposes switching the calls to those functions to using keyword arguments.

Taken together, I think these changes make bugs of the form "forgot to pass through configuration" and "passed through arguments in the wrong order" slightly less likely, and make it a bit easier to read through and understand the code.

Thanks for your time and consideration.