### PR TITLE
[R] remove commented-out code

### DIFF
--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -135,9 +135,6 @@ xgb.cv <- function(params = list(), data, nrounds, nfold, label = NULL, missing 
   check.custom.obj()
   check.custom.eval()
 
-  #if (is.null(params[['eval_metric']]) && is.null(feval))
-  #  stop("Either 'eval_metric' or 'feval' must be provided for CV")
-
   # Check the labels
   if ((inherits(data, 'xgb.DMatrix') && is.null(getinfo(data, 'label'))) ||
       (!inherits(data, 'xgb.DMatrix') && is.null(label))) {
@@ -160,10 +157,6 @@ xgb.cv <- function(params = list(), data, nrounds, nfold, label = NULL, missing 
       stop("'nfold' must be > 1")
     folds <- generate.cv.folds(nfold, nrow(data), stratified, cv_label, params)
   }
-
-  # Potential TODO: sequential CV
-  #if (strategy == 'sequential')
-  #  stop('Sequential CV strategy is not yet implemented')
 
   # verbosity & evaluation printing callback:
   params <- c(params, list(silent = 1))


### PR DESCRIPTION
Proposes removing a bit of commented-out code that has been in the R package for the last 7 years, since #1264.

https://github.com/dmlc/xgboost/blame/19b59938b7bf5bcc29b200268a5dd44e470b0705/R-package/R/xgb.cv.R#L138-L139

https://github.com/dmlc/xgboost/blame/19b59938b7bf5bcc29b200268a5dd44e470b0705/R-package/R/xgb.cv.R#L164-L166

Just to reduce the risk of false positives from code search and make it slightly easier to read the code.

Thanks for your time and consideration.