### PR TITLE
[R] Differentiate dev version with release version.

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: xgboost
 Type: Package
 Title: Extreme Gradient Boosting
-Version: 2.1.0.1
-Date: 2023-08-17
+Version: 2.1.0.0
+Date: 2023-08-19
 Authors@R: c(
   person("Tianqi", "Chen", role = c("aut"),
          email = "tianqi.tchen@gmail.com"),

--- a/tests/ci_build/change_version.py
+++ b/tests/ci_build/change_version.py
@@ -61,8 +61,11 @@ def pypkg(
 
 
 @cd(R_PACKAGE)
-def rpkg(major: int, minor: int, patch: int) -> None:
-    version = f"{major}.{minor}.{patch}.1"
+def rpkg(major: int, minor: int, patch: int, is_dev: bool) -> None:
+    if is_dev:
+        version = f"{major}.{minor}.{patch}.0"
+    else:
+        version = f"{major}.{minor}.{patch}.1"
     # Version: 2.0.0.1
     desc_path = "DESCRIPTION"
     with open(desc_path, "r") as fd:
@@ -119,8 +122,8 @@ def main(args: argparse.Namespace) -> None:
     minor = args.minor
     patch = args.patch
     rc = args.rc
-    is_rc = args.is_rc == 1
-    is_dev = args.is_dev == 1
+    is_rc = args.is_rc
+    is_dev = args.is_dev
     if is_rc and is_dev:
         raise ValueError("It cannot be both a rc and a dev branch.")
     if is_rc:
@@ -130,7 +133,7 @@ def main(args: argparse.Namespace) -> None:
 
     cmake(major, minor, patch)
     pypkg(major, minor, patch, rc, is_rc, is_dev)
-    rpkg(major, minor, patch)
+    rpkg(major, minor, patch, is_dev=is_dev)
     jvmpkgs(major, minor, patch, rc, is_rc, is_dev)
 
     print(
@@ -149,8 +152,8 @@ if __name__ == "__main__":
     parser.add_argument("--minor", type=int)
     parser.add_argument("--patch", type=int)
     parser.add_argument("--rc", type=int, default=0)
-    parser.add_argument("--is-rc", type=int, choices=[0, 1])
-    parser.add_argument("--is-dev", type=int, choices=[0, 1])
+    parser.add_argument("--is-rc", action="store_true")
+    parser.add_argument("--is-dev", action="store_true")
     args = parser.parse_args()
     try:
         main(args)


### PR DESCRIPTION
Use 2.1.0.0 as the development version, we will change it to 2.1.0.1 during the release.

Adress comment https://github.com/dmlc/xgboost/issues/9497#issuecomment-1682655854 by @terrytangyuan