### PR TITLE
[dask] Filter models on worker.

### DIFF
--- a/python-package/xgboost/dask.py
+++ b/python-package/xgboost/dask.py
@@ -536,7 +536,7 @@ async def map_worker_partitions(
         )
         futures.append(fut)
 
-    def first_valid(results: Iterable[TrainReturnT]) -> Optional[TrainReturnT]:
+    def first_valid(results: Iterable[Optional[_MapRetT]]) -> Optional[_MapRetT]:
         for v in results:
             if v is not None:
                 return v


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/7913

- Uses dask bag to perform tree reduction to filter out empty boosters.

Partially revert https://github.com/dmlc/xgboost/pull/8993