### PR TITLE
add HTML files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,8 @@ __MACOSX/
 model*.json
 
 # R tests
+*.htm
+*.html
 *.libsvm
 *.rds
 Rplots.pdf


### PR DESCRIPTION
Proposes ignoring HTML files (`.htm` and `.html`) via .gitignore. This project doesn't have any checked in currently...

```shell
git ls-files *.htm
git ls-files *.html
```

... and I believe that's intentional.

### Notes for Reviewers

I'm proposing this because I've been using the following to generate a test coverage report for the R package:

```shell
cd R-package/
Rscript -e "install.packages(c('covr', 'DT'), repos = 'https://cran.r-project.org')"
Rscript -e " \
    coverage <- covr::package_coverage(type = 'tests', quiet = FALSE);
    print(coverage);
    covr::report(coverage, file = file.path(getwd(), 'coverage.html'), browse = TRUE);
    "
```

That generates a file, `R-package/coverage.html`, which is not currently ignored by any `.gitignore` rules. Ignoring all `.html` files would prevent such files from being accidentally checked into source control here... both from this specific use case, and in other local development that involves rendering HTML files.