### PR TITLE
[R] remove unused headers

### DIFF
--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -5,7 +5,6 @@
  * and edited to conform to xgboost C linter requirements. For details, see
  * https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Registering-native-routines
  */
-#include <R.h>
 #include <Rinternals.h>
 #include <stdlib.h>
 #include <R_ext/Rdynload.h>

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -20,7 +20,6 @@
 #include "../../src/common/threading_utils.h"
 
 #include "./xgboost_R.h"  // Must follow other includes.
-#include "Rinternals.h"
 
 /*!
  * \brief macro to annotate begin of api


### PR DESCRIPTION
Proposes removing some unnecessary headers in the R package's R-to-C/C++ interface.

These unnecessarily introduce a risk of name collisions and other types of compilation errors, and make it a bit more difficult to understand what the R package is relying on from R itself.

### Notes for Reviewers

For background on how routine registration works in R packages (e.g. how the `R-package/src/init.c` works), see https://cran.r-project.org/doc/manuals/R-exts.html#Registering-native-routines.

For a summary of what's in `<R.h>` and `<Rinternals.h>` from R, see https://cran.r-project.org/doc/manuals/R-exts.html#Organization-of-header-files.