### PR TITLE
Fix PseudoHuberLoss::LoadConfig()

### DIFF
--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -175,12 +175,14 @@ class PseudoErrorLoss : public MetricNoCache {
   const char* Name() const override { return "mphe"; }
   void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
   void LoadConfig(Json const& in) override {
-    auto const& obj = get<Object const>(in);
-    auto it = obj.find("pseudo_huber_param");
-    if (it != obj.cend()) {
-      FromJson(it->second, &param_);
-      auto const& name = get<String const>(in["name"]);
-      CHECK_EQ(name, this->Name());
+    if (IsA<Object const>(in)) {
+      auto const& obj = get<Object const>(in);
+      auto it = obj.find("pseudo_huber_param");
+      if (it != obj.cend()) {
+        FromJson(it->second, &param_);
+        auto const& name = get<String const>(in["name"]);
+        CHECK_EQ(name, this->Name());
+      }
     }
   }
   void SaveConfig(Json* p_out) const override {

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -174,7 +174,15 @@ class PseudoErrorLoss : public MetricNoCache {
  public:
   const char* Name() const override { return "mphe"; }
   void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
-  void LoadConfig(Json const& in) override { FromJson(in["pseudo_huber_param"], &param_); }
+  void LoadConfig(Json const& in) override {
+    auto const& obj = get<Object const>(in);
+    auto it = obj.find("pseudo_huber_param");
+    if (it != obj.cend()) {
+      FromJson(in->second, &param_);
+      auto const& name = get<String const>(in["name"]);
+      CHECK_EQ(name, this->Name());
+    }
+  }
   void SaveConfig(Json* p_out) const override {
     auto& out = *p_out;
     out["name"] = String(this->Name());

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -178,7 +178,7 @@ class PseudoErrorLoss : public MetricNoCache {
     auto const& obj = get<Object const>(in);
     auto it = obj.find("pseudo_huber_param");
     if (it != obj.cend()) {
-      FromJson(in->second, &param_);
+      FromJson(it->second, &param_);
       auto const& name = get<String const>(in["name"]);
       CHECK_EQ(name, this->Name());
     }


### PR DESCRIPTION
This pull request fixes the serialization of PseudoHuberLoss.

Update. The bug also appears when using the JSON serializer.

Minimal reproducer:
```python
import os
from tempfile import TemporaryDirectory

import xgboost as xgb
from sklearn.datasets import load_diabetes

X, y = load_diabetes(return_X_y=True)
dtrain = xgb.DMatrix(X, label=y)
param = {
    "max_depth": 8,
    "eta": 1,
    "verbosity": 0,
    "objective": "reg:pseudohubererror",
}
xgb_model = xgb.train(
    param,
    dtrain,
    num_boost_round=10,
    evals=[(dtrain, "train")],
)
with TemporaryDirectory() as tmpdir:
    model_name = "model.json"
    #  model_name = "model.model"
    model_path = os.path.join(tmpdir, model_name)
    xgb_model.save_model(model_path)
```

Error message
```
xgboost.core.XGBoostError: [13:04:11] xgboost/src/common/json.cc:166: Object of type Null can not be indexed by string.
Stack trace:
  [bt] (0) xgboost/lib/libxgboost.so(dmlc::LogMessageFatal::~LogMessageFatal()+0x59) [0x7f385dc32bbd]
  [bt] (1) xgboost/lib/libxgboost.so(xgboost::Value::operator[](std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)+0xa3) [0x7f385dd420c1]
  [bt] (2) xgboost/lib/libxgboost.so(xgboost::Json::operator[](std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const+0x36) [0x7f385dc34736]
  [bt] (3) xgboost/lib/libxgboost.so(xgboost::metric::PseudoErrorLoss::LoadConfig(xgboost::Json const&)+0x62) [0x7f385dfbac9c]
  [bt] (4) xgboost/lib/libxgboost.so(xgboost::LearnerImpl::EvalOneIter(int, std::vector<std::shared_ptr<xgboost::DMatrix>, std::allocator<std::shared_ptr<xgboost::DMatrix> > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&)+0x29b) [0x7f385df6e299]
  [bt] (5) xgboost/lib/libxgboost.so(XGBoosterEvalOneIter+0x24c) [0x7f385dc0fe0e]
```