### PR TITLE
Load configuration before loading model.

### DIFF
--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -405,9 +405,7 @@ void GBTree::SaveConfig(Json* p_out) const {
   // e.g. updating a model, then saving and loading it would result in an empty
   // model
   out["gbtree_train_param"]["process_type"] = String("default");
-  // Duplicated from SaveModel so that user can get `num_parallel_tree` without parsing
-  // the model. We might remove this once we can deprecate `best_ntree_limit` so that the
-  // language binding doesn't need to know about the forest size.
+  // We save it for parameter validation. It's not loaded in `LoadConfig`.
   out["gbtree_model_param"] = ToJson(model_.param);
 
   out["updater"] = Array{};

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1170,8 +1170,8 @@ class LearnerIO : public LearnerConfiguration {
         // We should migrate to use `xgb.load.raw` instead.
         this->LoadModel(memory_snapshot);
       } else {
-        this->LoadModel(memory_snapshot["Model"]);
         this->LoadConfig(memory_snapshot["Config"]);
+        this->LoadModel(memory_snapshot["Model"]);
       }
     } else {
       std::string header;


### PR DESCRIPTION
Initialize the context before loading the model. Partly addresses https://github.com/dmlc/xgboost/issues/9497#issuecomment-1728436631 .