### PR TITLE
Add python api to slice columns in DMatrix

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -579,6 +579,18 @@ XGB_DLL int XGDMatrixSliceDMatrixEx(DMatrixHandle handle,
                                     DMatrixHandle *out,
                                     int allow_groups);
 /*!
+ * \brief create a new dmatrix from sliced columns of existing matrix
+ * \param handle instance of data matrix to be sliced
+ * \param num_slices Total number of slices
+ * \param slice_id Index of the current slice
+ * \param out a sliced new matrix
+ * \return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixSliceColumns(DMatrixHandle handle,
+                                  bst_ulong num_slices,
+                                  bst_ulong slice_id,
+                                  DMatrixHandle *out);
+/*!
  * \brief free space in data matrix
  * \return 0 when success, -1 when failure happens
  */

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -642,7 +642,7 @@ class DMatrix {
    * @param slice_id Index of the current slice
    * @return DMatrix containing the slice of columns
    */
-  virtual DMatrix *SliceCol(int num_slices, int slice_id) = 0;
+  virtual DMatrix *SliceCol(bst_ulong num_slices, bst_ulong slice_id) = 0;
 
  protected:
   virtual BatchSet<SparsePage> GetRowBatches() = 0;

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1264,6 +1264,35 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         )
         return res
 
+    def slice_columns(self, num_slices: int, slice_id: int) -> "DMatrix":
+        """Slice the DMatrix by column and return a new DMatrix that only contains the desired columns.
+
+        Parameters
+        ----------
+        num_slices
+            Total number of slices.
+        slice_id
+            Desired slice index.
+
+        Returns
+        -------
+        res
+            A new DMatrix containing only sliced columns.
+        """
+        assert num_slices >= 0
+        assert 0 <= slice_id < num_slices
+        res = DMatrix(None)
+        res.handle = ctypes.c_void_p()
+        _check_call(
+            _LIB.XGDMatrixSliceColumns(
+                self.handle,
+                c_bst_ulong(num_slices),
+                c_bst_ulong(slice_id),
+                ctypes.byref(res.handle),
+            )
+        )
+        return res
+
     @property
     def feature_names(self) -> Optional[FeatureNames]:
         """Labels for features (column labels).

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -559,6 +559,18 @@ XGB_DLL int XGDMatrixSliceDMatrixEx(DMatrixHandle handle,
   API_END();
 }
 
+XGB_DLL int XGDMatrixSliceColumns(DMatrixHandle handle,
+                                  xgboost::bst_ulong num_slices,
+                                  xgboost::bst_ulong slice_id,
+                                  DMatrixHandle *out) {
+  API_BEGIN();
+  CHECK_HANDLE();
+  DMatrix* dmat = static_cast<std::shared_ptr<DMatrix>*>(handle)->get();
+  *out = new std::shared_ptr<DMatrix>(
+      dmat->SliceCol(num_slices, slice_id));
+  API_END();
+}
+
 XGB_DLL int XGDMatrixFree(DMatrixHandle handle) {
   API_BEGIN();
   CHECK_HANDLE();

--- a/src/data/iterative_dmatrix.h
+++ b/src/data/iterative_dmatrix.h
@@ -88,7 +88,7 @@ class IterativeDMatrix : public DMatrix {
     LOG(FATAL) << "Slicing DMatrix is not supported for Quantile DMatrix.";
     return nullptr;
   }
-  DMatrix *SliceCol(int, int) override {
+  DMatrix *SliceCol(bst_ulong, bst_ulong) override {
     LOG(FATAL) << "Slicing DMatrix columns is not supported for Quantile DMatrix.";
     return nullptr;
   }

--- a/src/data/proxy_dmatrix.h
+++ b/src/data/proxy_dmatrix.h
@@ -85,7 +85,7 @@ class DMatrixProxy : public DMatrix {
     LOG(FATAL) << "Slicing DMatrix is not supported for Proxy DMatrix.";
     return nullptr;
   }
-  DMatrix* SliceCol(int, int) override {
+  DMatrix* SliceCol(bst_ulong, bst_ulong) override {
     LOG(FATAL) << "Slicing DMatrix columns is not supported for Proxy DMatrix.";
     return nullptr;
   }

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -48,7 +48,7 @@ DMatrix* SimpleDMatrix::Slice(common::Span<int32_t const> ridxs) {
   return out;
 }
 
-DMatrix* SimpleDMatrix::SliceCol(int num_slices, int slice_id) {
+DMatrix* SimpleDMatrix::SliceCol(bst_ulong num_slices, bst_ulong slice_id) {
   auto out = new SimpleDMatrix;
   SparsePage& out_page = *out->sparse_page_;
   auto const slice_size = info_.num_col_ / num_slices;

--- a/src/data/simple_dmatrix.h
+++ b/src/data/simple_dmatrix.h
@@ -35,7 +35,7 @@ class SimpleDMatrix : public DMatrix {
 
   bool SingleColBlock() const override { return true; }
   DMatrix* Slice(common::Span<int32_t const> ridxs) override;
-  DMatrix* SliceCol(int num_slices, int slice_id) override;
+  DMatrix* SliceCol(bst_ulong num_slices, bst_ulong slice_id) override;
 
   /*! \brief magic number used to identify SimpleDMatrix binary files */
   static const int kMagic = 0xffffab01;

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -102,7 +102,7 @@ class SparsePageDMatrix : public DMatrix {
     LOG(FATAL) << "Slicing DMatrix is not supported for external memory.";
     return nullptr;
   }
-  DMatrix *SliceCol(int, int) override {
+  DMatrix *SliceCol(bst_ulong, bst_ulong) override {
     LOG(FATAL) << "Slicing DMatrix columns is not supported for external memory.";
     return nullptr;
   }


### PR DESCRIPTION
Expose the C++ `DMatrix.SliceCol()` method in Python, mostly for testing purposes.