### PR TITLE
[R] [CI] enforce lintr::function_left_parentheses_linter check

### DIFF
--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -21,13 +21,13 @@ xgb.Booster.handle <- function(params, cachelist, modelfile, handle) {
       ## A memory buffer
       bst <- xgb.unserialize(modelfile, handle)
       xgb.parameters(bst) <- params
-      return (bst)
+      return(bst)
     } else if (inherits(modelfile, "xgb.Booster")) {
       ## A booster object
       bst <- xgb.Booster.complete(modelfile, saveraw = TRUE)
       bst <- xgb.unserialize(bst$raw)
       xgb.parameters(bst) <- params
-      return (bst)
+      return(bst)
     } else {
       stop("modelfile must be either character filename, or raw booster dump, or xgb.Booster object")
     }
@@ -382,7 +382,7 @@ predict.xgb.Booster <- function(object, newdata, missing = NA, outputmargin = FA
       cval[0] <- val
       return(cval)
     }
-    return (val)
+    return(val)
   }
 
   ## We set strict_shape to TRUE then drop the dimensions conditionally

--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -117,7 +117,7 @@ xgb.get.DMatrix <- function(data, label, missing, weight, nthread) {
       stop("xgboost: invalid input data")
     }
   }
-  return (dtrain)
+  return(dtrain)
 }
 
 

--- a/R-package/R/xgb.load.raw.R
+++ b/R-package/R/xgb.load.raw.R
@@ -18,6 +18,6 @@ xgb.load.raw <- function(buffer, as_booster = FALSE) {
     booster <- xgb.Booster.complete(booster, saveraw = TRUE)
     return(booster)
   } else {
-    return (handle)
+    return(handle)
   }
 }

--- a/R-package/R/xgb.unserialize.R
+++ b/R-package/R/xgb.unserialize.R
@@ -37,5 +37,5 @@ xgb.unserialize <- function(buffer, handle = NULL) {
       }
     })
   class(handle) <- "xgb.Booster.handle"
-  return (handle)
+  return(handle)
 }

--- a/R-package/R/xgboost.R
+++ b/R-package/R/xgboost.R
@@ -24,7 +24,7 @@ xgboost <- function(data = NULL, label = NULL, missing = NA, weight = NULL,
                    early_stopping_rounds = early_stopping_rounds, maximize = maximize,
                    save_period = save_period, save_name = save_name,
                    xgb_model = xgb_model, callbacks = callbacks, ...)
-  return (bst)
+  return(bst)
 }
 
 #' Training part from Mushroom Data Set

--- a/R-package/demo/cross_validation.R
+++ b/R-package/demo/cross_validation.R
@@ -25,7 +25,7 @@ xgb.cv(param, dtrain, nrounds, nfold = 5,
 # you can also do cross validation with customized loss function
 # See custom_objective.R
 ##
-print ('running cross validation, with customized loss function')
+print('running cross validation, with customized loss function')
 
 logregobj <- function(preds, dtrain) {
   labels <- getinfo(dtrain, "label")

--- a/R-package/demo/custom_objective.R
+++ b/R-package/demo/custom_objective.R
@@ -35,7 +35,7 @@ evalerror <- function(preds, dtrain) {
 
 param <- list(max_depth = 2, eta = 1, nthread  =  2, verbosity = 0,
               objective = logregobj, eval_metric = evalerror)
-print ('start training with user customized objective')
+print('start training with user customized objective')
 # training with customized objective, we can also do step by step training
 # simply look at xgboost.py's implementation of train
 bst <- xgb.train(param, dtrain, num_round, watchlist)
@@ -59,7 +59,7 @@ logregobjattr <- function(preds, dtrain) {
 }
 param <- list(max_depth = 2, eta = 1, nthread  =  2, verbosity = 0,
               objective = logregobjattr, eval_metric = evalerror)
-print ('start training with user customized objective, with additional attributes in DMatrix')
+print('start training with user customized objective, with additional attributes in DMatrix')
 # training with customized objective, we can also do step by step training
 # simply look at xgboost.py's implementation of train
 bst <- xgb.train(param, dtrain, num_round, watchlist)

--- a/R-package/demo/early_stopping.R
+++ b/R-package/demo/early_stopping.R
@@ -30,7 +30,7 @@ evalerror <- function(preds, dtrain) {
   err <- as.numeric(sum(labels != (preds > 0))) / length(labels)
   return(list(metric = "error", value = err))
 }
-print ('start training with early Stopping setting')
+print('start training with early Stopping setting')
 
 bst <- xgb.train(param, dtrain, num_round, watchlist,
                  objective = logregobj, eval_metric = evalerror, maximize = FALSE,

--- a/R-package/tests/helper_scripts/generate_models.R
+++ b/R-package/tests/helper_scripts/generate_models.R
@@ -19,15 +19,15 @@ w <- runif(metadata$kRows)
 version <- packageVersion('xgboost')
 target_dir <- 'models'
 
-save_booster <- function (booster, model_name) {
-  booster_bin <- function (model_name) {
-    return (file.path(target_dir, paste('xgboost-', version, '.', model_name, '.bin', sep = '')))
+save_booster <- function(booster, model_name) {
+  booster_bin <- function(model_name) {
+    return(file.path(target_dir, paste('xgboost-', version, '.', model_name, '.bin', sep = '')))
   }
-  booster_json <- function (model_name) {
-    return (file.path(target_dir, paste('xgboost-', version, '.', model_name, '.json', sep = '')))
+  booster_json <- function(model_name) {
+    return(file.path(target_dir, paste('xgboost-', version, '.', model_name, '.json', sep = '')))
   }
-  booster_rds <- function (model_name) {
-    return (file.path(target_dir, paste('xgboost-', version, '.', model_name, '.rds', sep = '')))
+  booster_rds <- function(model_name) {
+    return(file.path(target_dir, paste('xgboost-', version, '.', model_name, '.rds', sep = '')))
   }
   xgb.save(booster, booster_bin(model_name))
   saveRDS(booster, booster_rds(model_name))
@@ -36,7 +36,7 @@ save_booster <- function (booster, model_name) {
   }
 }
 
-generate_regression_model <- function () {
+generate_regression_model <- function() {
   print('Regression')
   y <- rnorm(metadata$kRows)
 
@@ -47,7 +47,7 @@ generate_regression_model <- function () {
   save_booster(booster, 'reg')
 }
 
-generate_logistic_model <- function () {
+generate_logistic_model <- function() {
   print('Binary classification with logistic loss')
   y <- sample(0:1, size = metadata$kRows, replace = TRUE)
   stopifnot(max(y) == 1, min(y) == 0)
@@ -64,7 +64,7 @@ generate_logistic_model <- function () {
   }
 }
 
-generate_classification_model <- function () {
+generate_classification_model <- function() {
   print('Multi-class classification')
   y <- sample(0:(metadata$kClasses - 1), size = metadata$kRows, replace = TRUE)
   stopifnot(max(y) == metadata$kClasses - 1, min(y) == 0)
@@ -77,7 +77,7 @@ generate_classification_model <- function () {
   save_booster(booster, 'cls')
 }
 
-generate_ranking_model <- function () {
+generate_ranking_model <- function() {
   print('Learning to rank')
   y <- sample(0:4, size = metadata$kRows, replace = TRUE)
   stopifnot(max(y) == 4, min(y) == 0)

--- a/R-package/tests/testthat/test_model_compatibility.R
+++ b/R-package/tests/testthat/test_model_compatibility.R
@@ -9,20 +9,20 @@ metadata <- list(
   kClasses = 3
 )
 
-run_model_param_check <- function (config) {
+run_model_param_check <- function(config) {
   testthat::expect_equal(config$learner$learner_model_param$num_feature, '4')
   testthat::expect_equal(config$learner$learner_train_param$booster, 'gbtree')
 }
 
-get_num_tree <- function (booster) {
+get_num_tree <- function(booster) {
   dump <- xgb.dump(booster)
   m <- regexec('booster\\[[0-9]+\\]', dump, perl = TRUE)
   m <- regmatches(dump, m)
   num_tree <- Reduce('+', lapply(m, length))
-  return (num_tree)
+  return(num_tree)
 }
 
-run_booster_check <- function (booster, name) {
+run_booster_check <- function(booster, name) {
   # If given a handle, we need to call xgb.Booster.complete() prior to using xgb.config().
   if (inherits(booster, "xgb.Booster") && xgboost:::is.null.handle(booster$handle)) {
     booster <- xgb.Booster.complete(booster)
@@ -68,7 +68,7 @@ test_that("Models from previous versions of XGBoost can be loaded", {
 
   pred_data <- xgb.DMatrix(matrix(c(0, 0, 0, 0), nrow = 1, ncol = 4), nthread = 2)
 
-  lapply(list.files(model_dir), function (x) {
+  lapply(list.files(model_dir), function(x) {
     model_file <- file.path(model_dir, x)
     m <- regexec("xgboost-([0-9\\.]+)\\.([a-z]+)\\.[a-z]+", model_file, perl = TRUE)
     m <- regmatches(model_file, m)[[1]]

--- a/R-package/tests/testthat/test_ranking.R
+++ b/R-package/tests/testthat/test_ranking.R
@@ -47,7 +47,7 @@ test_that('Test ranking with weighted data', {
     pred <- predict(bst, newdata = dtrain, ntreelimit = i)
     # is_sorted[i]: is i-th group correctly sorted by the ranking predictor?
     is_sorted <- lapply(seq(1, 20, by = 5),
-      function (k) {
+      function(k) {
         ind <- order(-pred[k:(k + 4)])
         z <- y[ind + (k - 1)]
         all(diff(z) <= 0)  # Check if z is monotone decreasing

--- a/demo/kaggle-higgs/higgs-train.R
+++ b/demo/kaggle-higgs/higgs-train.R
@@ -24,8 +24,8 @@ param <- list("objective" = "binary:logitraw",
               "nthread" = 16)
 watchlist <- list("train" = xgmat)
 nrounds <- 120
-print ("loading data end, start to boost trees")
+print("loading data end, start to boost trees")
 bst <- xgb.train(param, xgmat, nrounds, watchlist)
 # save out model
 xgb.save(bst, "higgs.model")
-print ('finish training')
+print('finish training')

--- a/demo/kaggle-higgs/speedtest.R
+++ b/demo/kaggle-higgs/speedtest.R
@@ -39,11 +39,11 @@ for (i in seq_along(threads)){
                   "nthread" = thread)
     watchlist <- list("train" = xgmat)
     nrounds <- 120
-    print ("loading data end, start to boost trees")
+    print("loading data end, start to boost trees")
     bst <- xgb.train(param, xgmat, nrounds, watchlist)
     # save out model
     xgb.save(bst, "higgs.model")
-    print ('finish training')
+    print('finish training')
   })
 }
 

--- a/tests/ci_build/lint_r.R
+++ b/tests/ci_build/lint_r.R
@@ -28,6 +28,7 @@ my_linters <- list(
   equals_na = lintr::equals_na_linter(),
   fixed_regex = lintr::fixed_regex_linter(),
   for_loop_index = lintr::for_loop_index_linter(),
+  function_left_parentheses = lintr::function_left_parentheses_linter(),
   function_return = lintr::function_return_linter(),
   infix_spaces_linter = lintr::infix_spaces_linter(),
   is_numeric = lintr::is_numeric_linter(),


### PR DESCRIPTION
Proposes further standardizing the formatting of the project's R code, by enforcing `lintr::function_left_parentheses_linter`.

Addresses the following errors raised by that linter:

<details><summary>list of errors (click me)</summary>

```text
demo/kaggle-higgs/higgs-train.R:27:6: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
print ("loading data end, start to boost trees")
     ^

[[2]]
demo/kaggle-higgs/higgs-train.R:31:6: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
print ('finish training')
     ^

[[3]]
demo/kaggle-higgs/speedtest.R:42:10: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
    print ("loading data end, start to boost trees")
         ^

[[4]]
demo/kaggle-higgs/speedtest.R:46:10: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
    print ('finish training')
         ^

[[5]]
R-package/demo/cross_validation.R:28:6: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
print ('running cross validation, with customized loss function')
     ^

[[6]]
R-package/demo/custom_objective.R:38:6: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
print ('start training with user customized objective')
     ^

[[7]]
R-package/demo/custom_objective.R:62:6: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
print ('start training with user customized objective, with additional attributes in DMatrix')
     ^

[[8]]
R-package/demo/early_stopping.R:33:6: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
print ('start training with early Stopping setting')
     ^

[[9]]
R-package/R/xgb.Booster.R:24:13: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
      return (bst)
            ^

[[10]]
R-package/R/xgb.Booster.R:30:13: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
      return (bst)
            ^

[[11]]
R-package/R/xgb.Booster.R:385:11: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
    return (val)
          ^

[[12]]
R-package/R/xgb.DMatrix.R:120:9: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
  return (dtrain)
        ^

[[13]]
R-package/R/xgb.load.raw.R:21:11: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
    return (handle)
          ^

[[14]]
R-package/R/xgb.unserialize.R:40:9: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
  return (handle)
        ^

[[15]]
R-package/R/xgboost.R:27:9: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
  return (bst)
        ^

[[16]]
R-package/tests/helper_scripts/generate_models.R:22:25: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
save_booster <- function (booster, model_name) {
                        ^

[[17]]
R-package/tests/helper_scripts/generate_models.R:23:26: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
  booster_bin <- function (model_name) {
                         ^

[[18]]
R-package/tests/helper_scripts/generate_models.R:24:11: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
    return (file.path(target_dir, paste('xgboost-', version, '.', model_name, '.bin', sep = '')))
          ^

[[19]]
R-package/tests/helper_scripts/generate_models.R:26:27: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
  booster_json <- function (model_name) {
                          ^

[[20]]
R-package/tests/helper_scripts/generate_models.R:27:11: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
    return (file.path(target_dir, paste('xgboost-', version, '.', model_name, '.json', sep = '')))
          ^

[[21]]
R-package/tests/helper_scripts/generate_models.R:29:26: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
  booster_rds <- function (model_name) {
                         ^

[[22]]
R-package/tests/helper_scripts/generate_models.R:30:11: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
    return (file.path(target_dir, paste('xgboost-', version, '.', model_name, '.rds', sep = '')))
          ^

[[23]]
R-package/tests/helper_scripts/generate_models.R:39:38: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
generate_regression_model <- function () {
                                     ^

[[24]]
R-package/tests/helper_scripts/generate_models.R:50:36: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
generate_logistic_model <- function () {
                                   ^

[[25]]
R-package/tests/helper_scripts/generate_models.R:67:42: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
generate_classification_model <- function () {
                                         ^

[[26]]
R-package/tests/helper_scripts/generate_models.R:80:35: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
generate_ranking_model <- function () {
                                  ^

[[27]]
R-package/tests/testthat/test_model_compatibility.R:12:34: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
run_model_param_check <- function (config) {
                                 ^

[[28]]
R-package/tests/testthat/test_model_compatibility.R:17:25: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
get_num_tree <- function (booster) {
                        ^

[[29]]
R-package/tests/testthat/test_model_compatibility.R:22:9: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function call.
  return (num_tree)
        ^

[[30]]
R-package/tests/testthat/test_model_compatibility.R:25:30: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
run_booster_check <- function (booster, name) {
                             ^

[[31]]
R-package/tests/testthat/test_model_compatibility.R:71:41: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
  lapply(list.files(model_dir), function (x) {
                                        ^

[[32]]
R-package/tests/testthat/test_ranking.R:50:15: style: [function_left_parentheses_linter] Remove spaces before the left parenthesis in a function definition.
      function (k) {
```

</details>