### PR TITLE
[jvm-packages] Remove hard dependency on libjvm

### DIFF
--- a/jvm-packages/CMakeLists.txt
+++ b/jvm-packages/CMakeLists.txt
@@ -25,4 +25,3 @@ target_include_directories(xgboost4j
   ${PROJECT_SOURCE_DIR}/rabit/include)
 
 set_output_directory(xgboost4j ${PROJECT_SOURCE_DIR}/lib)
-target_link_libraries(xgboost4j PRIVATE ${JAVA_JVM_LIBRARY})


### PR DESCRIPTION
Closes #9697

Follow the footstep of https://github.com/microsoft/onnxruntime/pull/2873 to remove the hard link dependency on libjvm. The JVM process will load the correct sets of libraries prior to loading libxgboost4j, so we don't need to explicitly link Java libraries again.

With this fix, XGBoost4J will no longer be tightly coupled with any particular JDK.

Before:
```
$ otool -L libxgboost4j.dylib
libxgboost4j.dylib:
        @rpath/libxgboost4j.dylib (compatibility version 0.0.0, current version 0.0.0)
        /opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home/lib/server/libjvm.dylib (compatibility version 1.0.0, current version 1.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
```

After:
```
$ otool -L libxgboost4j.dylib
libxgboost4j.dylib:
        @rpath/libxgboost4j.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
```