### PR TITLE
[CI] Set up CI for Mac M1

### DIFF
--- a/src/collective/comm.cc
+++ b/src/collective/comm.cc
@@ -23,7 +23,7 @@ Comm::Comm(std::string const& host, std::int32_t port, std::chrono::seconds time
       retry_{retry},
       tracker_{host, port, -1},
       task_id_{std::move(task_id)},
-      loop_{std::make_shared<Loop>(timeout)} {}
+      loop_{std::shared_ptr<Loop>{new Loop{timeout}}} {}
 
 Result ConnectTrackerImpl(proto::PeerInfo info, std::chrono::seconds timeout, std::int32_t retry,
                           std::string const& task_id, TCPSocket* out, std::int32_t rank,

--- a/tests/buildkite/pipeline-mac-m1.yml
+++ b/tests/buildkite/pipeline-mac-m1.yml
@@ -1,0 +1,8 @@
+steps:
+  - block: ":rocket: Run this test job"
+    if: build.pull_request.id != null || build.branch =~ /^dependabot\//
+  - label: ":macos: Build and Test XGBoost for MacOS M1 with Clang 11"
+    command: "tests/buildkite/test-macos-m1-clang11.sh"
+    key: mac-m1-appleclang11
+    agents:
+      queue: mac-mini-m1

--- a/tests/buildkite/test-macos-m1-clang11.sh
+++ b/tests/buildkite/test-macos-m1-clang11.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "--- Build and Test XGBoost with MacOS M1, Clang 11"
+
+source tests/buildkite/conftest.sh
+
+# Ensure that XGBoost can be built with Clang 11
+LLVM11_PATH=$(brew --prefix llvm\@11)
+mkdir build
+pushd build
+cmake .. -GNinja -DCMAKE_C_COMPILER=$LLVM11_PATH/bin/clang \
+  -DCMAKE_CXX_COMPILER=LLVM11_PATH/bin/clang++ -DGOOGLE_TEST=ON \
+  -DUSE_DMLC_GTEST=ON
+ninja -v
+
+# Create new Conda env
+conda_env=xgboost_dev_$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
+mamba env create -n ${conda_env} --file=tests/ci_build/conda_env/macos_cpu_test.yml

--- a/tests/buildkite/test-macos-m1-clang11.sh
+++ b/tests/buildkite/test-macos-m1-clang11.sh
@@ -2,15 +2,17 @@
 
 set -euo pipefail
 
-echo "--- Build and Test XGBoost with MacOS M1, Clang 11"
-
 source tests/buildkite/conftest.sh
 
 # Display system info
+echo "--- Display system information"
 set -x
 system_profiler SPSoftwareDataType
+sysctl -n machdep.cpu.brand_string
+uname -m
 
 # Ensure that XGBoost can be built with Clang 11
+echo "--- Build and Test XGBoost with MacOS M1, Clang 11"
 LLVM11_PATH=$(brew --prefix llvm\@11)
 mkdir build
 pushd build

--- a/tests/buildkite/test-macos-m1-clang11.sh
+++ b/tests/buildkite/test-macos-m1-clang11.sh
@@ -16,9 +16,9 @@ set +x
 . $HOME/mambaforge/etc/profile.d/conda.sh
 . $HOME/mambaforge/etc/profile.d/mamba.sh
 conda_env=xgboost_dev_$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
-mamba create -n ${conda_env} python=3.8
+mamba create -y -n ${conda_env} python=3.8
 conda activate ${conda_env}
-mamba env update -n ${conda_env} --file tests/ci_build/conda_env/macos_cpu_test.yml
+mamba env update -y -n ${conda_env} --file tests/ci_build/conda_env/macos_cpu_test.yml
 
 # Ensure that XGBoost can be built with Clang 11
 echo "--- Build and Test XGBoost with MacOS M1, Clang 11"

--- a/tests/buildkite/test-macos-m1-clang11.sh
+++ b/tests/buildkite/test-macos-m1-clang11.sh
@@ -10,10 +10,12 @@ set -x
 system_profiler SPSoftwareDataType
 sysctl -n machdep.cpu.brand_string
 uname -m
+set +x
 
 # Create new Conda env
 . $HOME/mambaforge/etc/profile.d/conda.sh
 . $HOME/mambaforge/etc/profile.d/mamba.sh
+set -x
 conda_env=xgboost_dev_$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
 conda activate
 mamba env create -n ${conda_env} --file=tests/ci_build/conda_env/macos_cpu_test.yml

--- a/tests/buildkite/test-macos-m1-clang11.sh
+++ b/tests/buildkite/test-macos-m1-clang11.sh
@@ -8,10 +8,11 @@ source tests/buildkite/conftest.sh
 
 # Ensure that XGBoost can be built with Clang 11
 LLVM11_PATH=$(brew --prefix llvm\@11)
+set -x
 mkdir build
 pushd build
-cmake .. -GNinja -DCMAKE_C_COMPILER=$LLVM11_PATH/bin/clang \
-  -DCMAKE_CXX_COMPILER=LLVM11_PATH/bin/clang++ -DGOOGLE_TEST=ON \
+cmake .. -GNinja -DCMAKE_C_COMPILER=${LLVM11_PATH}/bin/clang \
+  -DCMAKE_CXX_COMPILER=${LLVM11_PATH}/bin/clang++ -DGOOGLE_TEST=ON \
   -DUSE_DMLC_GTEST=ON
 ninja -v
 

--- a/tests/buildkite/test-macos-m1-clang11.sh
+++ b/tests/buildkite/test-macos-m1-clang11.sh
@@ -12,6 +12,8 @@ sysctl -n machdep.cpu.brand_string
 uname -m
 
 # Create new Conda env
+. $HOME/mambaforge/etc/profile.d/conda.sh
+. $HOME/mambaforge/etc/profile.d/mamba.sh
 conda_env=xgboost_dev_$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
 conda activate
 mamba env create -n ${conda_env} --file=tests/ci_build/conda_env/macos_cpu_test.yml

--- a/tests/buildkite/test-macos-m1-clang11.sh
+++ b/tests/buildkite/test-macos-m1-clang11.sh
@@ -15,13 +15,14 @@ set +x
 # Create new Conda env
 . $HOME/mambaforge/etc/profile.d/conda.sh
 . $HOME/mambaforge/etc/profile.d/mamba.sh
-set -x
 conda_env=xgboost_dev_$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
-conda activate
-mamba env create -n ${conda_env} --file=tests/ci_build/conda_env/macos_cpu_test.yml
+mamba create -n ${conda_env} python=3.8
+conda activate ${conda_env}
+mamba env update -n ${conda_env} --file tests/ci_build/conda_env/macos_cpu_test.yml
 
 # Ensure that XGBoost can be built with Clang 11
 echo "--- Build and Test XGBoost with MacOS M1, Clang 11"
+set -x
 LLVM11_PATH=$(brew --prefix llvm\@11)
 mkdir build
 pushd build

--- a/tests/buildkite/test-macos-m1-clang11.sh
+++ b/tests/buildkite/test-macos-m1-clang11.sh
@@ -6,9 +6,12 @@ echo "--- Build and Test XGBoost with MacOS M1, Clang 11"
 
 source tests/buildkite/conftest.sh
 
+# Display system info
+set -x
+system_profiler SPSoftwareDataType
+
 # Ensure that XGBoost can be built with Clang 11
 LLVM11_PATH=$(brew --prefix llvm\@11)
-set -x
 mkdir build
 pushd build
 cmake .. -GNinja -DCMAKE_C_COMPILER=${LLVM11_PATH}/bin/clang \

--- a/tests/buildkite/test-macos-m1-clang11.sh
+++ b/tests/buildkite/test-macos-m1-clang11.sh
@@ -13,12 +13,13 @@ uname -m
 set +x
 
 # Create new Conda env
+echo "--- Set up Conda env"
 . $HOME/mambaforge/etc/profile.d/conda.sh
 . $HOME/mambaforge/etc/profile.d/mamba.sh
 conda_env=xgboost_dev_$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
 mamba create -y -n ${conda_env} python=3.8
 conda activate ${conda_env}
-mamba env update -y -n ${conda_env} --file tests/ci_build/conda_env/macos_cpu_test.yml
+mamba env update -n ${conda_env} --file tests/ci_build/conda_env/macos_cpu_test.yml
 
 # Ensure that XGBoost can be built with Clang 11
 echo "--- Build and Test XGBoost with MacOS M1, Clang 11"

--- a/tests/buildkite/test-macos-m1-clang11.sh
+++ b/tests/buildkite/test-macos-m1-clang11.sh
@@ -11,6 +11,11 @@ system_profiler SPSoftwareDataType
 sysctl -n machdep.cpu.brand_string
 uname -m
 
+# Create new Conda env
+conda_env=xgboost_dev_$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
+conda activate
+mamba env create -n ${conda_env} --file=tests/ci_build/conda_env/macos_cpu_test.yml
+
 # Ensure that XGBoost can be built with Clang 11
 echo "--- Build and Test XGBoost with MacOS M1, Clang 11"
 LLVM11_PATH=$(brew --prefix llvm\@11)
@@ -20,7 +25,3 @@ cmake .. -GNinja -DCMAKE_C_COMPILER=${LLVM11_PATH}/bin/clang \
   -DCMAKE_CXX_COMPILER=${LLVM11_PATH}/bin/clang++ -DGOOGLE_TEST=ON \
   -DUSE_DMLC_GTEST=ON
 ninja -v
-
-# Create new Conda env
-conda_env=xgboost_dev_$(uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-')
-mamba env create -n ${conda_env} --file=tests/ci_build/conda_env/macos_cpu_test.yml

--- a/tests/ci_build/conda_env/macos_cpu_test.yml
+++ b/tests/ci_build/conda_env/macos_cpu_test.yml
@@ -38,5 +38,4 @@ dependencies:
 - cloudpickle
 - pip:
   - sphinx_rtd_theme
-  - datatable
   - py-ubjson

--- a/tests/ci_build/conda_env/macos_cpu_test.yml
+++ b/tests/ci_build/conda_env/macos_cpu_test.yml
@@ -32,7 +32,6 @@ dependencies:
 - jsonschema
 - boto3
 - awscli
-- py-ubjson
 - cffi
 - pyarrow
 - pyspark>=3.4.0
@@ -40,3 +39,4 @@ dependencies:
 - pip:
   - sphinx_rtd_theme
   - datatable
+  - py-ubjson

--- a/tests/cpp/collective/test_allreduce.cc
+++ b/tests/cpp/collective/test_allreduce.cc
@@ -53,7 +53,7 @@ class AllreduceWorker : public WorkerForTest {
     Context ctx;
     std::vector<std::uint32_t> data(comm_.World(), 0);
     data[comm_.Rank()] = ~std::uint32_t{0};
-    auto pcoll = std::make_shared<Coll>();
+    auto pcoll = std::shared_ptr<Coll>{new Coll{}};
     auto rc = pcoll->Allreduce(&ctx, comm_, EraseType(common::Span{data.data(), data.size()}),
                                ArrayInterfaceHandler::kU4, Op::kBitwiseOR);
     ASSERT_TRUE(rc.OK()) << rc.Report();

--- a/tests/cpp/collective/test_loop.cc
+++ b/tests/cpp/collective/test_loop.cc
@@ -41,7 +41,7 @@ class LoopTest : public ::testing::Test {
     rc = pair_.first.NonBlocking(true);
     ASSERT_TRUE(rc.OK());
 
-    loop_ = std::make_shared<Loop>(timeout);
+    loop_ = std::shared_ptr<Loop>{new Loop{timeout}};
   }
 
   void TearDown() override {


### PR DESCRIPTION
For now, ensure that XGBoost can be built with Clang 11 on Mac M1. This particular combination has given us trouble before (https://github.com/dmlc/xgboost/pull/9684).