### PR TITLE
Use sys.base_prefix instead of sys.prefix

### DIFF
--- a/python-package/packager/nativelib.py
+++ b/python-package/packager/nativelib.py
@@ -132,7 +132,7 @@ def locate_or_build_libxgboost(
 
     if build_config.use_system_libxgboost:
         # Find libxgboost from system prefix
-        sys_prefix = pathlib.Path(sys.prefix)
+        sys_prefix = pathlib.Path(sys.base_prefix)
         sys_prefix_candidates = [
             sys_prefix / "lib",
             # Paths possibly used on Windows

--- a/python-package/xgboost/libpath.py
+++ b/python-package/xgboost/libpath.py
@@ -34,10 +34,10 @@ def find_lib_path() -> List[str]:
         # On Windows, Conda may install libs in different paths
         dll_path.extend(
             [
-                os.path.join(sys.prefix, "bin"),
-                os.path.join(sys.prefix, "Library"),
-                os.path.join(sys.prefix, "Library", "bin"),
-                os.path.join(sys.prefix, "Library", "lib"),
+                os.path.join(sys.base_prefix, "bin"),
+                os.path.join(sys.base_prefix, "Library"),
+                os.path.join(sys.base_prefix, "Library", "bin"),
+                os.path.join(sys.base_prefix, "Library", "lib"),
             ]
         )
         dll_path = [os.path.join(p, "xgboost.dll") for p in dll_path]


### PR DESCRIPTION
Follow-up to #9687. 

#9687 should have used `sys.base_prefix` instead of `sys.prefix`, as in #9349. This is the cause of a CI failure: https://github.com/dmlc/xgboost/actions/runs/6622306062/job/17988733477