### PR TITLE
[R] Avoid in-place modifications to inputs when plotting importances

### DIFF
--- a/R-package/R/xgb.plot.importance.R
+++ b/R-package/R/xgb.plot.importance.R
@@ -87,7 +87,13 @@ xgb.plot.importance <- function(importance_matrix = NULL, top_n = NULL, measure 
   }
 
   # also aggregate, just in case when the values were not yet summed up by feature
-  importance_matrix <- importance_matrix[, Importance := sum(get(measure)), by = Feature]
+  importance_matrix <- importance_matrix[
+    , lapply(.SD, sum)
+    , .SDcols = setdiff(names(importance_matrix), "Feature")
+    , by = Feature
+  ][
+    , Importance := get(measure)
+  ]
 
   # make sure it's ordered
   importance_matrix <- importance_matrix[order(-abs(Importance))]

--- a/R-package/tests/testthat/test_helpers.R
+++ b/R-package/tests/testthat/test_helpers.R
@@ -382,6 +382,9 @@ test_that("xgb.importance works with GLM model", {
   expect_equal(colnames(imp2plot), c("Feature", "Weight", "Importance"))
   xgb.ggplot.importance(importance.GLM)
 
+  # check that the input is not modified in-place
+  expect_false("Importance" %in% names(importance.GLM))
+
   # for multiclass
   imp.GLM <- xgb.importance(model = mbst.GLM)
   expect_equal(dim(imp.GLM), c(12, 3))
@@ -398,6 +401,16 @@ test_that("xgb.model.dt.tree and xgb.importance work with a single split model",
   expect_error(imp <- xgb.importance(model = bst1), regexp = NA) # no error
   expect_equal(nrow(imp), 1)
   expect_equal(imp$Gain, 1)
+})
+
+test_that("xgb.plot.importance de-duplicates features", {
+  importances <- data.table(
+    Feature = c("col1", "col2", "col2"),
+    Gain = c(0.4, 0.3, 0.3)
+  )
+  imp2plot <- xgb.plot.importance(importances)
+  expect_equal(nrow(imp2plot), 2L)
+  expect_equal(imp2plot$Feature, c("col2", "col1"))
 })
 
 test_that("xgb.plot.tree works with and without feature names", {


### PR DESCRIPTION
This PR addresses two issues:
* Calling `xgb.plot.importance` performs in-place modifications to the input it receives, by adding a new column `Importance`.
* It currently states that it will
> aggregate, just in case when the values were not yet summed up by feature

but this is not the case: while it aggregates, if there is a duplicated entry (Feature), the output will still have it more than once, only with the importances summed, and the plot will have two bars for the same feature.

I'm not entirely sure if this is the most correct behavior though - perhaps a better thing to do would be to not atempt to aggregate when there are duplicated features, and just plot them like they are in the input.

The first behavior (modifying the input it receives in-place) is quite bothersome however.