### PR TITLE
[Python] Accept numpy generators as `random_state`

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -248,7 +248,7 @@ __model_doc = f"""
         Balancing of positive and negative weights.
     base_score : Optional[float]
         The initial prediction score of all instances, global bias.
-    random_state : Optional[Union[numpy.random.RandomState, int]]
+    random_state : Optional[Union[numpy.random.RandomState, numpy.random.Generator, int]]
         Random number seed.
 
         .. note::
@@ -651,7 +651,7 @@ class XGBModel(XGBModelBase):
         reg_lambda: Optional[float] = None,
         scale_pos_weight: Optional[float] = None,
         base_score: Optional[float] = None,
-        random_state: Optional[Union[np.random.RandomState, int]] = None,
+        random_state: Optional[Union[np.random.RandomState, np.random.Generator, int]] = None,
         missing: float = np.nan,
         num_parallel_tree: Optional[int] = None,
         monotone_constraints: Optional[Union[Dict[str, int], str]] = None,
@@ -787,6 +787,10 @@ class XGBModel(XGBModelBase):
             params.update(self.kwargs)
         if isinstance(params["random_state"], np.random.RandomState):
             params["random_state"] = params["random_state"].randint(
+                np.iinfo(np.int32).max
+            )
+        elif isinstance(params["random_state"], np.random.Generator):
+            params["random_state"] = params["random_state"].integers(
                 np.iinfo(np.int32).max
             )
 

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -792,8 +792,8 @@ class XGBModel(XGBModelBase):
                 np.iinfo(np.int32).max
             )
         elif isinstance(params["random_state"], np.random.Generator):
-            params["random_state"] = params["random_state"].integers(
-                np.iinfo(np.int32).max
+            params["random_state"] = int(
+                params["random_state"].integers(np.iinfo(np.int32).max)
             )
 
         return params

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -651,7 +651,9 @@ class XGBModel(XGBModelBase):
         reg_lambda: Optional[float] = None,
         scale_pos_weight: Optional[float] = None,
         base_score: Optional[float] = None,
-        random_state: Optional[Union[np.random.RandomState, np.random.Generator, int]] = None,
+        random_state: Optional[
+            Union[np.random.RandomState, np.random.Generator, int]
+        ] = None,
         missing: float = np.nan,
         num_parallel_tree: Optional[int] = None,
         monotone_constraints: Optional[Union[Dict[str, int], str]] = None,

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -702,6 +702,10 @@ def test_sklearn_random_state():
     clf = xgb.XGBClassifier(random_state=random_state)
     assert isinstance(clf.get_xgb_params()['random_state'], int)
 
+    random_state = np.random.default_rng(seed=404)
+    clf = xgb.XGBClassifier(random_state=random_state)
+    assert isinstance(clf.get_xgb_params()['random_state'], int)
+
 
 def test_sklearn_n_jobs():
     clf = xgb.XGBClassifier(n_jobs=1)


### PR DESCRIPTION
This PR modifies the scikit-learn interface to accept numpy generators as possible inputs for `random_state`. Generators are now the recommended mechanism for drawing random numbers in numpy, while the previous `RandomState` is deprecated. Lots of other software like SciPy have moved towards the new `Generator` class and allow passing a `random_state` as either `int`/`RandomState`/`Generator` ([example](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.random.html)).