### PR TITLE
[coll] Increase timeout for allgather test.

### DIFF
--- a/tests/cpp/collective/test_allgather.cc
+++ b/tests/cpp/collective/test_allgather.cc
@@ -45,9 +45,9 @@ class Worker : public WorkerForTest {
       // test for limited socket buffer
       this->LimitSockBuf(4096);
 
-      std::size_t n = 8192;  // n_bytes = 8192 * sizeof(int)
+      std::size_t n = 8192 * 8;  // n_bytes = 8192 * sizeof(int)
       std::vector<std::int32_t> data(comm_.World() * n, 0);
-      auto s_data = common::Span{data.data(), data.size()};
+      auto s_data = common::Span<std::int32_t>{data};
       auto seg = s_data.subspan(comm_.Rank() * n, n);
       std::iota(seg.begin(), seg.end(), comm_.Rank());
 

--- a/tests/cpp/collective/test_allgather.cc
+++ b/tests/cpp/collective/test_allgather.cc
@@ -45,7 +45,7 @@ class Worker : public WorkerForTest {
       // test for limited socket buffer
       this->LimitSockBuf(4096);
 
-      std::size_t n = 8192 * 8;  // n_bytes = 8192 * sizeof(int)
+      std::size_t n = 8192;  // n_bytes = 8192 * sizeof(int)
       std::vector<std::int32_t> data(comm_.World() * n, 0);
       auto s_data = common::Span<std::int32_t>{data};
       auto seg = s_data.subspan(comm_.Rank() * n, n);

--- a/tests/cpp/collective/test_worker.h
+++ b/tests/cpp/collective/test_worker.h
@@ -92,7 +92,7 @@ class TrackerTest : public SocketTest {
 
 template <typename WorkerFn>
 void TestDistributed(std::int32_t n_workers, WorkerFn worker_fn) {
-  std::chrono::seconds timeout{1};
+  std::chrono::seconds timeout{2};
 
   std::string host;
   auto rc = GetHostAddress(&host);

--- a/tests/cpp/collective/test_worker.h
+++ b/tests/cpp/collective/test_worker.h
@@ -97,6 +97,7 @@ void TestDistributed(std::int32_t n_workers, WorkerFn worker_fn) {
   std::string host;
   auto rc = GetHostAddress(&host);
   ASSERT_TRUE(rc.OK()) << rc.Report();
+  LOG(INFO) << "Using " << n_workers << " workers for test.";
   RabitTracker tracker{StringView{host}, n_workers, 0, timeout};
   auto fut = tracker.Run();
 


### PR DESCRIPTION
https://buildkite.com/xgboost/xgboost-ci/builds/3904#018baca3-2d1c-44f8-b22d-f8d724d46f32

I can reproduce the error by increasing the size of the input data, but couldn't reproduce the hang, from the log it looks like the tracker is refusing the shutdown. I will work on canceling the tracker in the future.