### PR TITLE
[R] Use array interface for dense DMatrix creation

### DIFF
--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -74,14 +74,8 @@ namespace {
       jconfig["missing"] = R_NaInt;
     }
   } else {
-    const double missing_as_double = Rf_asReal(missing);
     // missing specified
-    if (std::isinf(missing_as_double)) {
-      jconfig["missing"] = (missing_as_double < 0) ? -std::numeric_limits<float>::infinity()
-                                                   : std::numeric_limits<float>::infinity();
-    } else {
-      jconfig["missing"] = Rf_asReal(missing);
-    }
+    jconfig["missing"] = Rf_asReal(missing);
   }
 
   jconfig["nthread"] = Rf_asInteger(n_threads);

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -15,9 +15,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#ifdef __cpp_lib_endian
-# include <bit>
-#endif
 
 #include "../../src/c_api/c_api_error.h"
 #include "../../src/c_api/c_api_utils.h"  // MakeSparseFromPtr
@@ -42,8 +39,7 @@ namespace {
         linalg::Order::kF  // R uses column-major
     };
     CHECK(m.FContiguous());
-    auto array_str = linalg::ArrayInterfaceStr(m);
-    return array_str;
+    return linalg::ArrayInterfaceStr(m);
   };
 
   const SEXPTYPE arr_type = TYPEOF(R_mat);

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -25,8 +25,7 @@
 
 #include "./xgboost_R.h"  // Must follow other includes.
 
-static bool get_is_little_endian()
-{
+static bool get_is_little_endian() {
 #ifdef __cpp_lib_endian
   return std::endian::native == std::endian::little;
 #else
@@ -39,8 +38,7 @@ const bool is_little_endian = get_is_little_endian();
 
 #define ARR_MAX_JSON_LENGTH 256
 
-const void* get_R_pointer(SEXP &R_arr)
-{
+const void* get_R_pointer(SEXP R_arr) {
   const SEXPTYPE arr_type = TYPEOF(R_arr);
   switch (arr_type) {
     case REALSXP: return static_cast<const void*>(REAL(R_arr));
@@ -50,8 +48,7 @@ const void* get_R_pointer(SEXP &R_arr)
   }
 }
 
-static void make_numpy_array_interface_from_R_mat(char *out_json, SEXP &R_mat)
-{
+static void make_numpy_array_interface_from_R_mat(char *out_json, SEXP R_mat) {
   SEXP mat_dims = Rf_getAttrib(R_mat, R_DimSymbol);
   const int *ptr_mat_dims = INTEGER(mat_dims);
   const bool is_double = TYPEOF(R_mat) == REALSXP;
@@ -62,15 +59,16 @@ static void make_numpy_array_interface_from_R_mat(char *out_json, SEXP &R_mat)
   std::snprintf(
     out_json,
     ARR_MAX_JSON_LENGTH,
-    "{\"data\": [%" PRIuPTR ", true], \"shape\": [%d,%d], \"strides\": [%d,%" PRIu64 "], \"typestr\": \"%s%s%d\", \"version\":3}",
+    "{\"data\": [%" PRIuPTR ", true], \"shape\": [%d,%d], \"strides\": [%d,%" PRIu64
+    "], \"typestr\": \"%s%s%d\", \"version\":3}",
     ptr_as_number, ptr_mat_dims[0], ptr_mat_dims[1],
     static_cast<int>(size_of_type), stride,
-    is_little_endian? "<" : ">", is_double? "f" : "i", static_cast<int>(size_of_type)
-  );
+    is_little_endian? "<" : ">", is_double? "f" : "i", static_cast<int>(size_of_type));
 }
 
-static void make_json_config_for_array(char *out_json, SEXP missing, SEXP n_threads, SEXPTYPE arr_type)
-{
+static void make_json_config_for_array(
+  char *out_json, SEXP missing, SEXP n_threads, SEXPTYPE arr_type
+) {
   char missing_str[128];
   const SEXPTYPE missing_type = TYPEOF(missing);
   if (Rf_isNull(missing) ||
@@ -80,14 +78,15 @@ static void make_json_config_for_array(char *out_json, SEXP missing, SEXP n_thre
     if (arr_type == REALSXP) {
       std::strncpy(missing_str, "NaN", 128);
     } else {
-      std::snprintf(missing_str, 128, "%d", R_NaInt);
+      std::snprintf(missing_str, sizeof(missing_str), "%d", R_NaInt);
     }
   } else {
     const double missing_as_double = Rf_asReal(missing);
     if (std::isinf(missing_as_double)) {
-      std::snprintf(missing_str, 128, "%sInfinity", (missing_as_double < 0)? "-" : "");
+      std::snprintf(
+        missing_str, sizeof(missing_str), "%sInfinity", (missing_as_double < 0)? "-" : "");
     } else {
-      std::snprintf(missing_str, 128, "%f", Rf_asReal(missing));
+      std::snprintf(missing_str, sizeof(missing_str), "%f", Rf_asReal(missing));
     }
   }
 
@@ -95,8 +94,7 @@ static void make_json_config_for_array(char *out_json, SEXP missing, SEXP n_thre
     out_json,
     ARR_MAX_JSON_LENGTH,
     "{\"missing\": %s, \"nthread\": %d}",
-    missing_str, Rf_asInteger(n_threads)
-  );
+    missing_str, Rf_asInteger(n_threads));
 }
 
 /*!

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -52,7 +52,7 @@ namespace {
       return make_matrix(LOGICAL(R_mat));
     default:
       LOG(FATAL) << "Array or matrix has unsupported type.";
-  };
+  }
 
   LOG(FATAL) << "Not reachable";
   return "";

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -33,7 +33,8 @@ namespace {
     using T = std::remove_pointer_t<decltype(ptr)>;
 
     auto m = linalg::MatrixView<T>{
-        common::Span{ptr, static_cast<std::size_t>(ptr_mat_dims[0] * ptr_mat_dims[1])},
+        common::Span{ptr,
+          static_cast<std::size_t>(ptr_mat_dims[0]) * static_cast<std::size_t>(ptr_mat_dims[1])},
         {ptr_mat_dims[0], ptr_mat_dims[1]},  // Shape
         DeviceOrd::CPU(),
         linalg::Order::kF  // R uses column-major

--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -267,7 +267,7 @@ test_that("xgb.DMatrix: print", {
 })
 
 test_that("xgb.DMatrix: Inf as missing", {
-  x_inf <- matrix(as.numeric(1:10), nrow=5)
+  x_inf <- matrix(as.numeric(1:10), nrow = 5)
   x_inf[2, 1] <- Inf
 
   x_nan <- x_inf

--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -265,3 +265,35 @@ test_that("xgb.DMatrix: print", {
     })
     expect_equal(txt, "xgb.DMatrix  dim: 6513 x 126  info: NA  colnames: no")
 })
+
+test_that("xgb.DMatrix: Inf as missing", {
+  x_inf <- matrix(as.numeric(1:10), nrow=5)
+  x_inf[2, 1] <- Inf
+
+  x_nan <- x_inf
+  x_nan[2, 1] <- NA_real_
+
+  m_inf <- xgb.DMatrix(x_inf, nthread = n_threads, missing = Inf)
+  xgb.DMatrix.save(m_inf, "inf.dmatrix")
+
+  m_nan <- xgb.DMatrix(x_nan, nthread = n_threads, missing = NA_real_)
+  xgb.DMatrix.save(m_nan, "nan.dmatrix")
+
+  infconn <- file("inf.dmatrix", "rb")
+  nanconn <- file("nan.dmatrix", "rb")
+
+  expect_equal(file.size("inf.dmatrix"), file.size("nan.dmatrix"))
+
+  bytes <- file.size("inf.dmatrix")
+  infdmatrix <- readBin(infconn, "raw", n = bytes)
+  nandmatrix <- readBin(nanconn, "raw", n = bytes)
+
+  expect_equal(length(infdmatrix), length(nandmatrix))
+  expect_equal(infdmatrix, nandmatrix)
+
+  close(infconn)
+  close(nanconn)
+
+  file.remove("inf.dmatrix")
+  file.remove("nan.dmatrix")
+})


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

This PR switches the underlying C function for DMatrix creation from dense R matrices to the `XGDMatrixCreateFromDense` function used in the python interface.

Along the way, it also fixes a potential memory leak in case of failures, in which a failure to allocate an R externalptr would lead to a longjump without freeing the allocated C++ object from its pointer.

I see there was already some mechanism to create the kind of array JSON that numpy uses in the DMatrix creators from sparse matrices, but couldn't find any equivalent for dense matrices. There also seems to be a dedicated module to create JSONs, but they look simple enough for `snprintf`.

The JSON parser for the config by the way seems to have issues with `nan` and `inf`, so this PR makes a conversion to `NaN` and `Infinity` which seem to be accepted.