### PR TITLE
[R] Update docs about fitting from CSR

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -5,7 +5,7 @@
 #' \code{\link{xgb.DMatrix.save}}).
 #'
 #' @param data a \code{matrix} object (either numeric or integer), a \code{dgCMatrix} object,
-#'        a \code{dgRMatrix} object (only when making predictions from a fitted model),
+#'        a \code{dgRMatrix} object,
 #'        a \code{dsparseVector} object (only when making predictions from a fitted model, will be
 #'        interpreted as a row vector), or a character string representing a filename.
 #' @param info a named list of additional information to store in the \code{xgb.DMatrix} object.

--- a/R-package/man/xgb.DMatrix.Rd
+++ b/R-package/man/xgb.DMatrix.Rd
@@ -15,7 +15,7 @@ xgb.DMatrix(
 }
 \arguments{
 \item{data}{a \code{matrix} object (either numeric or integer), a \code{dgCMatrix} object,
-a \code{dgRMatrix} object (only when making predictions from a fitted model),
+a \code{dgRMatrix} object,
 a \code{dsparseVector} object (only when making predictions from a fitted model, will be
 interpreted as a row vector), or a character string representing a filename.}
 


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

The docs had a note about not supporting DMatrix objects created from CSR when fitting models. The problem has been solved by now so the note is not applicable anymore.