### PR TITLE
Support dataframe data format in native XGBoost.

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -19,7 +19,8 @@
 #' @param missing a float value to represents missing values in data (used only when input is a dense matrix).
 #'        It is useful when a 0 or some other extreme value represents missing values in data.
 #' @param silent whether to suppress printing an informational message after loading from a file.
-#' @param feature_names Set names for features.
+#' @param feature_names Set names for features. Overrides column names in data
+#'        frame and matrix.
 #' @param nthread Number of threads used for creating DMatrix.
 #' @param group Group size for all ranking group.
 #' @param qid Query ID for data samples, used for ranking.
@@ -32,6 +33,8 @@
 #' If a DMatrix gets serialized and then de-serialized (for example, when saving data in an R session or caching
 #' chunks in an Rmd file), the resulting object will not be usable anymore and will need to be reconstructed
 #' from the original source of data.
+#' @param enable_categorical Experimental support of specializing for
+#'        categorical features. JSON/UBJSON serialization format is required.
 #'
 #' @examples
 #' data(agaricus.train, package='xgboost')
@@ -58,19 +61,28 @@ xgb.DMatrix <- function(
   qid = NULL,
   label_lower_bound = NULL,
   label_upper_bound = NULL,
-  feature_weights = NULL
+  feature_weights = NULL,
+  enable_categorical = FALSE
 ) {
   if (!is.null(group) && !is.null(qid)) {
     stop("Either one of 'group' or 'qid' should be NULL")
   }
+  cnames <- NULL
+  ctypes <- NULL
   if (typeof(data) == "character") {
-    if (length(data) > 1)
-      stop("'data' has class 'character' and length ", length(data),
-           ".\n  'data' accepts either a numeric matrix or a single filename.")
+    if (length(data) > 1) {
+      stop(
+        "'data' has class 'character' and length ", length(data),
+        ".\n  'data' accepts either a numeric matrix or a single filename."
+      )
+    }
     data <- path.expand(data)
     handle <- .Call(XGDMatrixCreateFromFile_R, data, as.integer(silent))
   } else if (is.matrix(data)) {
-    handle <- .Call(XGDMatrixCreateFromMat_R, data, missing, as.integer(NVL(nthread, -1)))
+    handle <- .Call(
+      XGDMatrixCreateFromMat_R, data, missing, as.integer(NVL(nthread, -1))
+    )
+    cnames <- colnames(data)
   } else if (inherits(data, "dgCMatrix")) {
     handle <- .Call(
       XGDMatrixCreateFromCSC_R,
@@ -103,6 +115,40 @@ xgb.DMatrix <- function(
       missing,
       as.integer(NVL(nthread, -1))
     )
+  } else if (is.data.frame(data)) {
+    ctypes <- sapply(data, function(x) {
+      if (is.factor(x)) {
+        if (!enable_categorical) {
+          stop(
+            "When factor type is used, the parameter `enable_categorical`",
+            " must be set to TRUE."
+          )
+        }
+        "c"
+      } else if (is.integer(x)) {
+        "int"
+      } else if (is.logical(x)) {
+        "i"
+      } else {
+        if (!is.numeric(x)) {
+          stop("Invalid type in dataframe.")
+        }
+        "float"
+      }
+    })
+    ## as.data.frame somehow converts integer/logical into real.
+    data <- as.data.frame(sapply(data, function(x) {
+      if (is.factor(x)) {
+        ## XGBoost uses 0-based indexing.
+        as.numeric(x) - 1
+      } else {
+        x
+      }
+    }))
+    handle <- .Call(
+      XGDMatrixCreateFromDF_R, data, missing, as.integer(NVL(nthread, -1))
+    )
+    cnames <- colnames(data)
   } else {
     stop("xgb.DMatrix does not support construction from ", typeof(data))
   }
@@ -119,7 +165,11 @@ xgb.DMatrix <- function(
   if (!is.null(base_margin)) {
     setinfo(dmat, "base_margin", base_margin)
   }
+  if (!is.null(cnames)) {
+    setinfo(dmat, "feature_name", cnames)
+  }
   if (!is.null(feature_names)) {
+    ## override cnames
     setinfo(dmat, "feature_name", feature_names)
   }
   if (!is.null(group)) {
@@ -136,6 +186,9 @@ xgb.DMatrix <- function(
   }
   if (!is.null(feature_weights)) {
     setinfo(dmat, "feature_weights", feature_weights)
+  }
+  if (!is.null(ctypes)) {
+    setinfo(dmat, "feature_type", ctypes)
   }
 
   return(dmat)

--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -67,7 +67,6 @@ xgb.DMatrix <- function(
   if (!is.null(group) && !is.null(qid)) {
     stop("Either one of 'group' or 'qid' should be NULL")
   }
-  cnames <- NULL
   ctypes <- NULL
   if (typeof(data) == "character") {
     if (length(data) > 1) {
@@ -82,7 +81,6 @@ xgb.DMatrix <- function(
     handle <- .Call(
       XGDMatrixCreateFromMat_R, data, missing, as.integer(NVL(nthread, -1))
     )
-    cnames <- colnames(data)
   } else if (inherits(data, "dgCMatrix")) {
     handle <- .Call(
       XGDMatrixCreateFromCSC_R,
@@ -148,7 +146,6 @@ xgb.DMatrix <- function(
     handle <- .Call(
       XGDMatrixCreateFromDF_R, data, missing, as.integer(NVL(nthread, -1))
     )
-    cnames <- colnames(data)
   } else {
     stop("xgb.DMatrix does not support construction from ", typeof(data))
   }
@@ -165,11 +162,7 @@ xgb.DMatrix <- function(
   if (!is.null(base_margin)) {
     setinfo(dmat, "base_margin", base_margin)
   }
-  if (!is.null(cnames)) {
-    setinfo(dmat, "feature_name", cnames)
-  }
   if (!is.null(feature_names)) {
-    ## override cnames
     setinfo(dmat, "feature_name", feature_names)
   }
   if (!is.null(group)) {

--- a/R-package/man/xgb.DMatrix.Rd
+++ b/R-package/man/xgb.DMatrix.Rd
@@ -17,7 +17,8 @@ xgb.DMatrix(
   qid = NULL,
   label_lower_bound = NULL,
   label_upper_bound = NULL,
-  feature_weights = NULL
+  feature_weights = NULL,
+  enable_categorical = FALSE
 )
 }
 \arguments{
@@ -42,7 +43,8 @@ It is useful when a 0 or some other extreme value represents missing values in d
 
 \item{silent}{whether to suppress printing an informational message after loading from a file.}
 
-\item{feature_names}{Set names for features.}
+\item{feature_names}{Set names for features. Overrides column names in data
+frame and matrix.}
 
 \item{nthread}{Number of threads used for creating DMatrix.}
 
@@ -55,6 +57,9 @@ It is useful when a 0 or some other extreme value represents missing values in d
 \item{label_upper_bound}{Upper bound for survival training.}
 
 \item{feature_weights}{Set feature weights for column sampling.}
+
+\item{enable_categorical}{Experimental support of specializing for
+categorical features. JSON/UBJSON serialization format is required.}
 }
 \description{
 Construct xgb.DMatrix object from either a dense matrix, a sparse matrix, or a local file.

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -41,6 +41,7 @@ extern SEXP XGDMatrixCreateFromFile_R(SEXP, SEXP);
 extern SEXP XGDMatrixCreateFromMat_R(SEXP, SEXP, SEXP);
 extern SEXP XGDMatrixGetFloatInfo_R(SEXP, SEXP);
 extern SEXP XGDMatrixGetUIntInfo_R(SEXP, SEXP);
+extern SEXP XGDMatrixCreateFromDF_R(SEXP, SEXP, SEXP);
 extern SEXP XGDMatrixGetStrFeatureInfo_R(SEXP, SEXP);
 extern SEXP XGDMatrixNumCol_R(SEXP);
 extern SEXP XGDMatrixNumRow_R(SEXP);
@@ -79,6 +80,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"XGDMatrixCreateFromMat_R",    (DL_FUNC) &XGDMatrixCreateFromMat_R,    3},
   {"XGDMatrixGetFloatInfo_R",     (DL_FUNC) &XGDMatrixGetFloatInfo_R,     2},
   {"XGDMatrixGetUIntInfo_R",      (DL_FUNC) &XGDMatrixGetUIntInfo_R,      2},
+  {"XGDMatrixCreateFromDF_R",     (DL_FUNC) &XGDMatrixCreateFromDF_R,     3},
   {"XGDMatrixGetStrFeatureInfo_R", (DL_FUNC) &XGDMatrixGetStrFeatureInfo_R, 2},
   {"XGDMatrixNumCol_R",           (DL_FUNC) &XGDMatrixNumCol_R,           1},
   {"XGDMatrixNumRow_R",           (DL_FUNC) &XGDMatrixNumRow_R,           1},

--- a/R-package/src/xgboost_R.h
+++ b/R-package/src/xgboost_R.h
@@ -53,6 +53,16 @@ XGB_DLL SEXP XGDMatrixCreateFromFile_R(SEXP fname, SEXP silent);
 XGB_DLL SEXP XGDMatrixCreateFromMat_R(SEXP mat,
                                       SEXP missing,
                                       SEXP n_threads);
+
+/**
+ * @brief Create matrix content from a data frame.
+ * @param data R data.frame object
+ * @param missing which value to represent missing value
+ * @param n_threads Number of threads used to construct DMatrix from dense matrix.
+ * @return created dmatrix
+ */
+XGB_DLL SEXP XGDMatrixCreateFromDF_R(SEXP df, SEXP missing, SEXP n_threads);
+
 /*!
  * \brief create a matrix content from CSC format
  * \param indptr pointer to column headers

--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -322,3 +322,30 @@ test_that("xgb.DMatrix: can get group for both 'qid' and 'group' constructors", 
   expected_gr <- c(0, 20, 40, 100)
   expect_equal(info_gr, expected_gr)
 })
+
+test_that("xgb.DMatrix: data.frame", {
+  df <- data.frame(
+    a = (1:4) / 10,
+    num = c(1, NA, 3, 4),
+    as.int = as.integer(c(1, 2, 3, 4)),
+    lo = c(TRUE, FALSE, NA, TRUE),
+    str.fac = c("a", "b", "d", "c"),
+    as.fac = as.factor(c(3, 5, 8, 11)),
+    stringsAsFactors = TRUE
+  )
+
+  m <- xgb.DMatrix(df, enable_categorical = TRUE)
+  expect_equal(colnames(m), colnames(df))
+  expect_equal(
+    getinfo(m, "feature_type"), c("float", "float", "int", "i", "c", "c")
+  )
+  expect_error(xgb.DMatrix(df))
+
+  df <- data.frame(
+    missing = c("a", "b", "d", NA),
+    valid = c("a", "b", "d", "c"),
+    stringsAsFactors = TRUE
+  )
+  m <- xgb.DMatrix(df, enable_categorical = TRUE)
+  expect_equal(getinfo(m, "feature_type"), c("c", "c"))
+})

--- a/demo/guide-python/cat_in_the_dat.py
+++ b/demo/guide-python/cat_in_the_dat.py
@@ -78,6 +78,10 @@ def categorical_model(X: pd.DataFrame, y: pd.Series, output_dir: str) -> None:
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, random_state=1994, test_size=0.2
     )
+    # Be aware that the encoding for X_train and X_test are the same here. In practice,
+    # we should try to use an encoder like (sklearn OrdinalEncoder) to obtain the
+    # categorical values.
+
     # Specify `enable_categorical` to True.
     clf = xgb.XGBClassifier(
         **params,

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -159,6 +159,16 @@ XGB_DLL int XGDMatrixCreateFromURI(char const *config, DMatrixHandle *out);
 XGB_DLL int XGDMatrixCreateFromCSREx(const size_t *indptr, const unsigned *indices,
                                      const float *data, size_t nindptr, size_t nelem,
                                      size_t num_col, DMatrixHandle *out);
+/**
+ * @brief Create a DMatrix from columnar data. (table)
+ *
+ * @param data   See @ref XGBoosterPredictFromColumnar for details.
+ * @param config See @ref XGDMatrixCreateFromDense for details.
+ * @param out    The created dmatrix.
+ *
+ * @return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGDMatrixCreateFromColumnar(char const *data, char const *config, DMatrixHandle *out);
 
 /**
  * @example c-api-demo.c
@@ -513,6 +523,16 @@ XGB_DLL int XGDeviceQuantileDMatrixCreateFromCallback(DataIterHandle iter, DMatr
 XGB_DLL int
 XGProxyDMatrixSetDataCudaArrayInterface(DMatrixHandle handle,
                                         const char *c_interface_str);
+
+/**
+ * @brief Set columnar (table) data on a DMatrix proxy.
+ *
+ * @param handle          A DMatrix proxy created by @ref XGProxyDMatrixCreate
+ * @param c_interface_str See @ref XGBoosterPredictFromColumnar for details.
+ *
+ * @return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGProxyDMatrixSetDataCudaColumnar(DMatrixHandle handle, char const *c_interface_str);
 
 /*!
  * \brief Set data on a DMatrix proxy.
@@ -1112,6 +1132,31 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle, char const *values, 
 /**
  * @example inference.c
  */
+
+/**
+ * @brief Inplace prediction from CPU columnar data. (Table)
+ *
+ * @note If the booster is configured to run on a CUDA device, XGBoost falls back to run
+ *       prediction with DMatrix with a performance warning.
+ *
+ * @param handle        Booster handle.
+ * @param values        An JSON array of __array_interface__ for each column.
+ * @param config        See @ref XGBoosterPredictFromDMatrix for more info.
+ *   Additional fields for inplace prediction are:
+ *     - "missing": float
+ * @param m             An optional (NULL if not available) proxy DMatrix instance
+ *                      storing meta info.
+ *
+ * @param out_shape     See @ref XGBoosterPredictFromDMatrix for more info.
+ * @param out_dim       See @ref XGBoosterPredictFromDMatrix for more info.
+ * @param out_result    See @ref XGBoosterPredictFromDMatrix for more info.
+ *
+ * @return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterPredictFromColumnar(BoosterHandle handle, char const *array_interface,
+                                         char const *c_json_config, DMatrixHandle m,
+                                         bst_ulong const **out_shape, bst_ulong *out_dim,
+                                         const float **out_result);
 
 /**
  * \brief Inplace prediction from CPU CSR matrix.

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -361,49 +361,57 @@ XGB_DLL int XGProxyDMatrixCreate(DMatrixHandle *out) {
   API_END();
 }
 
-XGB_DLL int
-XGProxyDMatrixSetDataCudaArrayInterface(DMatrixHandle handle,
-                                        char const *c_interface_str) {
+XGB_DLL int XGProxyDMatrixSetDataCudaArrayInterface(DMatrixHandle handle,
+                                                    char const *c_interface_str) {
   API_BEGIN();
   CHECK_HANDLE();
   xgboost_CHECK_C_ARG_PTR(c_interface_str);
   auto p_m = static_cast<std::shared_ptr<xgboost::DMatrix> *>(handle);
   CHECK(p_m);
-  auto m =   static_cast<xgboost::data::DMatrixProxy*>(p_m->get());
+  auto m = static_cast<xgboost::data::DMatrixProxy *>(p_m->get());
   CHECK(m) << "Current DMatrix type does not support set data.";
   m->SetCUDAArray(c_interface_str);
   API_END();
 }
 
-XGB_DLL int XGProxyDMatrixSetDataCudaColumnar(DMatrixHandle handle,
-                                              char const *c_interface_str) {
+XGB_DLL int XGProxyDMatrixSetDataCudaColumnar(DMatrixHandle handle, char const *c_interface_str) {
   API_BEGIN();
   CHECK_HANDLE();
   xgboost_CHECK_C_ARG_PTR(c_interface_str);
   auto p_m = static_cast<std::shared_ptr<xgboost::DMatrix> *>(handle);
   CHECK(p_m);
-  auto m =   static_cast<xgboost::data::DMatrixProxy*>(p_m->get());
+  auto m = static_cast<xgboost::data::DMatrixProxy *>(p_m->get());
   CHECK(m) << "Current DMatrix type does not support set data.";
   m->SetCUDAArray(c_interface_str);
   API_END();
 }
 
-XGB_DLL int XGProxyDMatrixSetDataDense(DMatrixHandle handle,
-                                       char const *c_interface_str) {
+XGB_DLL int XGProxyDMatrixSetDataColumnar(DMatrixHandle handle, char const *c_interface_str) {
   API_BEGIN();
   CHECK_HANDLE();
   xgboost_CHECK_C_ARG_PTR(c_interface_str);
   auto p_m = static_cast<std::shared_ptr<xgboost::DMatrix> *>(handle);
   CHECK(p_m);
-  auto m =   static_cast<xgboost::data::DMatrixProxy*>(p_m->get());
+  auto m = static_cast<xgboost::data::DMatrixProxy *>(p_m->get());
+  CHECK(m) << "Current DMatrix type does not support set data.";
+  m->SetColumnarData(c_interface_str);
+  API_END();
+}
+
+XGB_DLL int XGProxyDMatrixSetDataDense(DMatrixHandle handle, char const *c_interface_str) {
+  API_BEGIN();
+  CHECK_HANDLE();
+  xgboost_CHECK_C_ARG_PTR(c_interface_str);
+  auto p_m = static_cast<std::shared_ptr<xgboost::DMatrix> *>(handle);
+  CHECK(p_m);
+  auto m = static_cast<xgboost::data::DMatrixProxy *>(p_m->get());
   CHECK(m) << "Current DMatrix type does not support set data.";
   m->SetArrayData(c_interface_str);
   API_END();
 }
 
-XGB_DLL int XGProxyDMatrixSetDataCSR(DMatrixHandle handle, char const *indptr,
-                                     char const *indices, char const *data,
-                                     xgboost::bst_ulong ncol) {
+XGB_DLL int XGProxyDMatrixSetDataCSR(DMatrixHandle handle, char const *indptr, char const *indices,
+                                     char const *data, xgboost::bst_ulong ncol) {
   API_BEGIN();
   CHECK_HANDLE();
   xgboost_CHECK_C_ARG_PTR(indptr);
@@ -411,7 +419,7 @@ XGB_DLL int XGProxyDMatrixSetDataCSR(DMatrixHandle handle, char const *indptr,
   xgboost_CHECK_C_ARG_PTR(data);
   auto p_m = static_cast<std::shared_ptr<xgboost::DMatrix> *>(handle);
   CHECK(p_m);
-  auto m =   static_cast<xgboost::data::DMatrixProxy*>(p_m->get());
+  auto m = static_cast<xgboost::data::DMatrixProxy *>(p_m->get());
   CHECK(m) << "Current DMatrix type does not support set data.";
   m->SetCSRData(indptr, indices, data, ncol, true);
   API_END();
@@ -426,6 +434,25 @@ XGB_DLL int XGDMatrixCreateFromCSREx(const size_t *indptr, const unsigned *indic
   LOG(WARNING) << error::DeprecatedFunc(__func__, "2.0.0", "XGDMatrixCreateFromCSR");
   data::CSRAdapter adapter(indptr, indices, data, nindptr - 1, nelem, num_col);
   *out = new std::shared_ptr<DMatrix>(DMatrix::Create(&adapter, std::nan(""), 1));
+  API_END();
+}
+
+XGB_DLL int XGDMatrixCreateFromColumnar(char const *data, char const *c_json_config,
+                                        DMatrixHandle *out) {
+  API_BEGIN();
+  xgboost_CHECK_C_ARG_PTR(c_json_config);
+  xgboost_CHECK_C_ARG_PTR(data);
+
+  auto config = Json::Load(c_json_config);
+  float missing = GetMissing(config);
+  auto n_threads = OptionalArg<Integer, std::int64_t>(config, "nthread", 0);
+  auto data_split_mode =
+      static_cast<DataSplitMode>(OptionalArg<Integer, int64_t>(config, "data_split_mode", 0));
+
+  data::ColumnarAdapter adapter{data};
+  *out = new std::shared_ptr<DMatrix>(
+      DMatrix::Create(&adapter, missing, n_threads, "", data_split_mode));
+
   API_END();
 }
 
@@ -1191,6 +1218,27 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle, char const *array_in
   CHECK(proxy) << "Invalid input type for inplace predict.";
   xgboost_CHECK_C_ARG_PTR(array_interface);
   proxy->SetArrayData(array_interface);
+  auto *learner = static_cast<xgboost::Learner *>(handle);
+  InplacePredictImpl(p_m, c_json_config, learner, out_shape, out_dim, out_result);
+  API_END();
+}
+
+XGB_DLL int XGBoosterPredictFromColumnar(BoosterHandle handle, char const *array_interface,
+                                         char const *c_json_config, DMatrixHandle m,
+                                         xgboost::bst_ulong const **out_shape,
+                                         xgboost::bst_ulong *out_dim, const float **out_result) {
+  API_BEGIN();
+  CHECK_HANDLE();
+  std::shared_ptr<DMatrix> p_m{nullptr};
+  if (!m) {
+    p_m.reset(new data::DMatrixProxy);
+  } else {
+    p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);
+  }
+  auto proxy = dynamic_cast<data::DMatrixProxy *>(p_m.get());
+  CHECK(proxy) << "Invalid input type for inplace predict.";
+  xgboost_CHECK_C_ARG_PTR(array_interface);
+  proxy->SetColumnarData(array_interface);
   auto *learner = static_cast<xgboost::Learner *>(handle);
   InplacePredictImpl(p_m, c_json_config, learner, out_shape, out_dim, out_result);
   API_END();

--- a/src/common/quantile.cc
+++ b/src/common/quantile.cc
@@ -97,6 +97,7 @@ void HostSketchContainer::PushAdapterBatch(Batch const &batch, size_t base_rowid
   // the nnz from info is not reliable as sketching might be the first place to go through
   // the data.
   auto is_dense = info.num_nonzero_ == info.num_col_ * info.num_row_;
+  CHECK(!this->columns_size_.empty());
   this->PushRowPageImpl(batch, base_rowid, weights, info.num_nonzero_, info.num_col_, is_dense,
                         is_valid);
 }
@@ -110,6 +111,7 @@ INSTANTIATE(CSRArrayAdapterBatch)
 INSTANTIATE(CSCAdapterBatch)
 INSTANTIATE(DataTableAdapterBatch)
 INSTANTIATE(SparsePageAdapterBatch)
+INSTANTIATE(ColumnarAdapterBatch)
 
 namespace {
 /**

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -947,38 +947,24 @@ DMatrix* DMatrix::Create(AdapterT* adapter, float missing, int nthread, const st
   return new data::SimpleDMatrix(adapter, missing, nthread, data_split_mode);
 }
 
-template DMatrix* DMatrix::Create<data::DenseAdapter>(data::DenseAdapter* adapter, float missing,
-                                                      std::int32_t nthread,
-                                                      const std::string& cache_prefix,
-                                                      DataSplitMode data_split_mode);
-template DMatrix* DMatrix::Create<data::ArrayAdapter>(data::ArrayAdapter* adapter, float missing,
-                                                      std::int32_t nthread,
-                                                      const std::string& cache_prefix,
-                                                      DataSplitMode data_split_mode);
-template DMatrix* DMatrix::Create<data::CSRAdapter>(data::CSRAdapter* adapter, float missing,
-                                                    std::int32_t nthread,
-                                                    const std::string& cache_prefix,
-                                                    DataSplitMode data_split_mode);
-template DMatrix* DMatrix::Create<data::CSCAdapter>(data::CSCAdapter* adapter, float missing,
-                                                    std::int32_t nthread,
-                                                    const std::string& cache_prefix,
-                                                    DataSplitMode data_split_mode);
-template DMatrix* DMatrix::Create<data::DataTableAdapter>(data::DataTableAdapter* adapter,
-                                                          float missing, std::int32_t nthread,
-                                                          const std::string& cache_prefix,
-                                                          DataSplitMode data_split_mode);
-template DMatrix* DMatrix::Create<data::FileAdapter>(data::FileAdapter* adapter, float missing,
-                                                     std::int32_t nthread,
-                                                     const std::string& cache_prefix,
-                                                     DataSplitMode data_split_mode);
-template DMatrix* DMatrix::Create<data::CSRArrayAdapter>(data::CSRArrayAdapter* adapter,
-                                                         float missing, std::int32_t nthread,
-                                                         const std::string& cache_prefix,
-                                                         DataSplitMode data_split_mode);
-template DMatrix* DMatrix::Create<data::CSCArrayAdapter>(data::CSCArrayAdapter* adapter,
-                                                         float missing, std::int32_t nthread,
-                                                         const std::string& cache_prefix,
-                                                         DataSplitMode data_split_mode);
+// Instantiate the factory function for various adapters
+#define INSTANTIATION_CREATE(_AdapterT)                               \
+  template DMatrix* DMatrix::Create<data::_AdapterT>(                 \
+      data::_AdapterT * adapter, float missing, std::int32_t nthread, \
+      const std::string& cache_prefix, DataSplitMode data_split_mode);
+
+INSTANTIATION_CREATE(DenseAdapter)
+INSTANTIATION_CREATE(ArrayAdapter)
+INSTANTIATION_CREATE(CSRAdapter)
+INSTANTIATION_CREATE(CSCAdapter)
+INSTANTIATION_CREATE(DataTableAdapter)
+INSTANTIATION_CREATE(FileAdapter)
+INSTANTIATION_CREATE(CSRArrayAdapter)
+INSTANTIATION_CREATE(CSCArrayAdapter)
+INSTANTIATION_CREATE(ColumnarAdapter)
+
+#undef INSTANTIATION_CREATE
+
 template DMatrix* DMatrix::Create(
     data::IteratorAdapter<DataIterHandle, XGBCallbackDataIterNext, XGBoostBatchCSR>* adapter,
     float missing, int nthread, const std::string& cache_prefix, DataSplitMode data_split_mode);
@@ -1156,7 +1142,6 @@ uint64_t SparsePage::Push(const AdapterBatchT& batch, float missing, int nthread
   builder.InitStorage();
 
   // Second pass over batch, placing elements in correct position
-
   auto is_valid = data::IsValidFunctor{missing};
 #pragma omp parallel num_threads(nthread)
   {
@@ -1253,9 +1238,10 @@ template uint64_t SparsePage::Push(const data::CSCAdapterBatch& batch, float mis
 template uint64_t SparsePage::Push(const data::DataTableAdapterBatch& batch, float missing,
                                    int nthread);
 template uint64_t SparsePage::Push(const data::FileAdapterBatch& batch, float missing, int nthread);
+template uint64_t SparsePage::Push(const data::ColumnarAdapterBatch& batch, float missing,
+                                   std::int32_t nthread);
 
 namespace data {
-
 // List of files that will be force linked in static links.
 DMLC_REGISTRY_LINK_TAG(sparse_page_raw_format);
 DMLC_REGISTRY_LINK_TAG(gradient_index_format);

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -120,7 +120,7 @@ void GHistIndexMatrix::PushAdapterBatchColumns(Context const *ctx, Batch const &
 INSTANTIATION_PUSH(data::CSRArrayAdapterBatch)
 INSTANTIATION_PUSH(data::ArrayAdapterBatch)
 INSTANTIATION_PUSH(data::SparsePageAdapterBatch)
-
+INSTANTIATION_PUSH(data::ColumnarAdapterBatch)
 #undef INSTANTIATION_PUSH
 
 void GHistIndexMatrix::ResizeIndex(const size_t n_index, const bool isDense) {

--- a/src/data/proxy_dmatrix.cc
+++ b/src/data/proxy_dmatrix.cc
@@ -5,7 +5,22 @@
 
 #include "proxy_dmatrix.h"
 
+#include <memory>  // for shared_ptr
+
+#include "xgboost/context.h"  // for Context
+#include "xgboost/data.h"     // for DMatrix
+#include "xgboost/logging.h"
+#include "xgboost/string_view.h"  // for StringView
+
 namespace xgboost::data {
+void DMatrixProxy::SetColumnarData(StringView interface_str) {
+  std::shared_ptr<ColumnarAdapter> adapter{new ColumnarAdapter{interface_str}};
+  this->batch_ = adapter;
+  this->Info().num_col_ = adapter->NumColumns();
+  this->Info().num_row_ = adapter->NumRows();
+  this->ctx_.Init(Args{{"device", "cpu"}});
+}
+
 void DMatrixProxy::SetArrayData(StringView interface_str) {
   std::shared_ptr<ArrayAdapter> adapter{new ArrayAdapter{interface_str}};
   this->batch_ = adapter;

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014~2023 by XGBoost Contributors
+ * Copyright 2014~2023, XGBoost Contributors
  * \file simple_dmatrix.cc
  * \brief the input data structure for gradient boosting
  * \author Tianqi Chen
@@ -355,6 +355,8 @@ template SimpleDMatrix::SimpleDMatrix(CSCAdapter* adapter, float missing, int nt
 template SimpleDMatrix::SimpleDMatrix(DataTableAdapter* adapter, float missing, int nthread,
                                       DataSplitMode data_split_mode);
 template SimpleDMatrix::SimpleDMatrix(FileAdapter* adapter, float missing, int nthread,
+                                      DataSplitMode data_split_mode);
+template SimpleDMatrix::SimpleDMatrix(ColumnarAdapter* adapter, float missing, int nthread,
                                       DataSplitMode data_split_mode);
 template SimpleDMatrix::SimpleDMatrix(
     IteratorAdapter<DataIterHandle, XGBCallbackDataIterNext, XGBoostBatchCSR>* adapter,

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -761,6 +761,9 @@ class CPUPredictor : public Predictor {
     } else if (x.type() == typeid(std::shared_ptr<data::CSRArrayAdapter>)) {
       this->DispatchedInplacePredict<data::CSRArrayAdapter, 1>(x, p_m, model, missing, out_preds,
                                                                tree_begin, tree_end);
+    } else if (x.type() == typeid(std::shared_ptr<data::ColumnarAdapter>)) {
+      this->DispatchedInplacePredict<data::ColumnarAdapter, kBlockOfRowsSize>(
+          x, p_m, model, missing, out_preds, tree_begin, tree_end);
     } else {
       return false;
     }

--- a/tests/python/test_with_pandas.py
+++ b/tests/python/test_with_pandas.py
@@ -105,8 +105,8 @@ class TestPandas:
         result, _, _ = xgb.data._transform_pandas_df(dummies, enable_categorical=False)
         exp = np.array(
             [[1.0, 1.0, 0.0, 0.0], [2.0, 0.0, 1.0, 0.0], [3.0, 0.0, 0.0, 1.0]]
-        )
-        np.testing.assert_array_equal(result, exp)
+        ).T
+        np.testing.assert_array_equal(result.columns, exp)
         dm = xgb.DMatrix(dummies, data_split_mode=data_split_mode)
         assert dm.num_row() == 3
         if data_split_mode == DataSplitMode.ROW:
@@ -202,6 +202,20 @@ class TestPandas:
         else:
             assert dm.num_col() == 1 * world_size
 
+    @pytest.mark.skipif(**tm.no_sklearn())
+    def test_multi_target(self) -> None:
+        from sklearn.datasets import make_regression
+
+        X, y = make_regression(n_samples=1024, n_features=4, n_targets=3)
+        ydf = pd.DataFrame({i: y[:, i] for i in range(y.shape[1])})
+
+        Xy = xgb.DMatrix(X, ydf)
+        assert Xy.num_row() == y.shape[0]
+        assert Xy.get_label().size == y.shape[0] * y.shape[1]
+        Xy = xgb.QuantileDMatrix(X, ydf)
+        assert Xy.num_row() == y.shape[0]
+        assert Xy.get_label().size == y.shape[0] * y.shape[1]
+
     def test_slice(self):
         rng = np.random.RandomState(1994)
         rows = 100
@@ -233,13 +247,14 @@ class TestPandas:
             X, enable_categorical=True
         )
 
-        assert transformed[:, 0].min() == 0
+        assert transformed.columns[0].min() == 0
 
         # test missing value
         X = pd.DataFrame({"f0": ["a", "b", np.NaN]})
         X["f0"] = X["f0"].astype("category")
         arr, _, _ = xgb.data._transform_pandas_df(X, enable_categorical=True)
-        assert not np.any(arr == -1.0)
+        for c in arr.columns:
+            assert not np.any(c == -1.0)
 
         X = X["f0"]
         y = y[: X.shape[0]]
@@ -273,24 +288,25 @@ class TestPandas:
         predt_dense = booster.predict(xgb.DMatrix(X.sparse.to_dense()))
         np.testing.assert_allclose(predt_sparse, predt_dense)
 
-    def test_pandas_label(self, data_split_mode=DataSplitMode.ROW):
+    def test_pandas_label(
+        self, data_split_mode: DataSplitMode = DataSplitMode.ROW
+    ) -> None:
         world_size = xgb.collective.get_world_size()
         # label must be a single column
         df = pd.DataFrame({"A": ["X", "Y", "Z"], "B": [1, 2, 3]})
         with pytest.raises(ValueError):
-            xgb.data._transform_pandas_df(df, False, None, None, "label", "float")
+            xgb.data._transform_pandas_df(df, False, None, None, "label")
 
         # label must be supported dtype
         df = pd.DataFrame({"A": np.array(["a", "b", "c"], dtype=object)})
         with pytest.raises(ValueError):
-            xgb.data._transform_pandas_df(df, False, None, None, "label", "float")
+            xgb.data._transform_pandas_df(df, False, None, None, "label")
 
         df = pd.DataFrame({"A": np.array([1, 2, 3], dtype=int)})
-        result, _, _ = xgb.data._transform_pandas_df(
-            df, False, None, None, "label", "float"
-        )
+        result, _, _ = xgb.data._transform_pandas_df(df, False, None, None, "label")
         np.testing.assert_array_equal(
-            result, np.array([[1.0], [2.0], [3.0]], dtype=float)
+            np.stack(result.columns, axis=1),
+            np.array([[1.0], [2.0], [3.0]], dtype=float),
         )
         dm = xgb.DMatrix(
             np.random.randn(3, 2), label=df, data_split_mode=data_split_mode
@@ -506,6 +522,35 @@ class TestPandas:
             if y is not None:
                 np.testing.assert_allclose(m_orig.get_label(), m_etype.get_label())
                 np.testing.assert_allclose(m_etype.get_label(), y.values)
+
+    @pytest.mark.parametrize("DMatrixT", [xgb.DMatrix, xgb.QuantileDMatrix])
+    def test_mixed_type(self, DMatrixT: Type[xgb.DMatrix]) -> None:
+        f0 = np.arange(0, 4)
+        f1 = pd.Series(f0, dtype="int64[pyarrow]")
+        f2l = list(f0)
+        f2l[0] = pd.NA
+        f2 = pd.Series(f2l, dtype=pd.Int64Dtype())
+
+        df = pd.DataFrame({"f0": f0})
+        df["f2"] = f2
+
+        m = DMatrixT(df)
+        assert m.num_col() == df.shape[1]
+
+        df["f1"] = f1
+        m = DMatrixT(df)
+        assert m.num_col() == df.shape[1]
+        assert m.num_row() == df.shape[0]
+        assert m.num_nonmissing() == df.size - 1
+        assert m.feature_names == list(map(str, df.columns))
+        assert m.feature_types == ["int"] * df.shape[1]
+
+        y = f0
+        m.set_info(label=y)
+        booster = xgb.train({}, m)
+        p0 = booster.inplace_predict(df)
+        p1 = booster.predict(m)
+        np.testing.assert_allclose(p0, p1)
 
     @pytest.mark.skipif(tm.is_windows(), reason="Rabit does not run on windows")
     def test_pandas_column_split(self):


### PR DESCRIPTION
- Implement a columnar adapter.
- Refactor Python pandas handling code to avoid converting into a single numpy array.
- Add support in R for transforming columns.

This is not yet as efficient as we would like since we can't handle missing value indicators for each column. I will leave that as a future to-do instead.

Categorical data should work with R factor now, minus the uncertainty about how we should suggest people to use a consistent encoder.

related: https://github.com/dmlc/xgboost/issues/9810 .