### PR TITLE
[R] Very small performance tweaks

### DIFF
--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -311,7 +311,9 @@ XGB_DLL SEXP XGDMatrixSliceDMatrix_R(SEXP handle, SEXP idxset) {
   int res_code;
   {
     std::vector<int> idxvec(len);
+    #ifndef _MSC_VER
     #pragma omp simd
+    #endif
     for (R_xlen_t i = 0; i < len; ++i) {
       idxvec[i] = idxset_[i] - 1;
     }

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -160,13 +160,6 @@ SEXP SafeMkChar(const char *c_str, SEXP continuation_token) {
 
 using dmlc::BeginPtr;
 
-xgboost::Context const *DMatrixCtx(DMatrixHandle handle) {
-  CHECK_HANDLE();
-  auto p_m = static_cast<std::shared_ptr<xgboost::DMatrix> *>(handle);
-  CHECK(p_m);
-  return p_m->get()->Ctx();
-}
-
 XGB_DLL SEXP XGCheckNullPtr_R(SEXP handle) {
   return ScalarLogical(R_ExternalPtrAddr(handle) == NULL);
 }
@@ -318,6 +311,7 @@ XGB_DLL SEXP XGDMatrixSliceDMatrix_R(SEXP handle, SEXP idxset) {
   int res_code;
   {
     std::vector<int> idxvec(len);
+    #pragma omp simd
     for (R_xlen_t i = 0; i < len; ++i) {
       idxvec[i] = idxset_[i] - 1;
     }
@@ -375,6 +369,7 @@ XGB_DLL SEXP XGDMatrixSetStrFeatureInfo_R(SEXP handle, SEXP field, SEXP array) {
   int res_code;
   {
     std::vector<std::string> str_info;
+    str_info.reserve(len);
     for (size_t i = 0; i < len; ++i) {
       str_info.emplace_back(CHAR(VECTOR_ELT(str_info_holder, i)));
     }
@@ -457,9 +452,9 @@ XGB_DLL SEXP XGBoosterCreate_R(SEXP dmats) {
 
   int res_code;
   {
-    std::vector<void*> dvec;
+    std::vector<void*> dvec(len);
     for (R_xlen_t i = 0; i < len; ++i) {
-      dvec.push_back(R_ExternalPtrAddr(VECTOR_ELT(dmats, i)));
+      dvec[i] = R_ExternalPtrAddr(VECTOR_ELT(dmats, i));
     }
     res_code = XGBoosterCreate(BeginPtr(dvec), dvec.size(), &handle);
   }
@@ -478,9 +473,9 @@ XGB_DLL SEXP XGBoosterCreateInEmptyObj_R(SEXP dmats, SEXP R_handle) {
 
   int res_code;
   {
-    std::vector<void*> dvec;
+    std::vector<void*> dvec(len);
     for (R_xlen_t i = 0; i < len; ++i) {
-      dvec.push_back(R_ExternalPtrAddr(VECTOR_ELT(dmats, i)));
+      dvec[i] = R_ExternalPtrAddr(VECTOR_ELT(dmats, i));
     }
     res_code = XGBoosterCreate(BeginPtr(dvec), dvec.size(), &handle);
   }
@@ -552,15 +547,16 @@ XGB_DLL SEXP XGBoosterEvalOneIter_R(SEXP handle, SEXP iter, SEXP dmats, SEXP evn
 
   int res_code;
   {
-    std::vector<void*> vec_dmats;
+    std::vector<void*> vec_dmats(len);
     std::vector<std::string> vec_names;
-    std::vector<const char*> vec_sptr;
+    vec_names.reserve(len);
+    std::vector<const char*> vec_sptr(len);
     for (R_xlen_t i = 0; i < len; ++i) {
-      vec_dmats.push_back(R_ExternalPtrAddr(VECTOR_ELT(dmats, i)));
+      vec_dmats[i] = R_ExternalPtrAddr(VECTOR_ELT(dmats, i));
       vec_names.emplace_back(CHAR(VECTOR_ELT(evnames_lst, i)));
     }
     for (R_xlen_t i = 0; i < len; ++i) {
-      vec_sptr.push_back(vec_names[i].c_str());
+      vec_sptr[i] = vec_names[i].c_str();
     }
     res_code = XGBoosterEvalOneIter(R_ExternalPtrAddr(handle),
                                     asInteger(iter),
@@ -598,11 +594,7 @@ XGB_DLL SEXP XGBoosterPredictFromDMatrix_R(SEXP handle, SEXP dmat, SEXP json_con
     len *= out_shape[i];
   }
   r_out_result = PROTECT(allocVector(REALSXP, len));
-  auto ctx = xgboost::detail::BoosterCtx(R_ExternalPtrAddr(handle));
-  double *r_out_result_ = REAL(r_out_result);
-  xgboost::common::ParallelFor(len, ctx->Threads(), [&](xgboost::omp_ulong i) {
-    r_out_result_[i] = out_result[i];
-  });
+  std::copy(out_result, out_result + len, REAL(r_out_result));
 
   SET_VECTOR_ELT(r_out, 0, r_out_shape);
   SET_VECTOR_ELT(r_out, 1, r_out_result);
@@ -831,11 +823,7 @@ XGB_DLL SEXP XGBoosterFeatureScore_R(SEXP handle, SEXP json_config) {
   }
 
   out_scores_sexp = PROTECT(allocVector(REALSXP, len));
-  auto ctx = xgboost::detail::BoosterCtx(R_ExternalPtrAddr(handle));
-  double *out_scores_sexp_ = REAL(out_scores_sexp);
-  xgboost::common::ParallelFor(len, ctx->Threads(), [&](xgboost::omp_ulong i) {
-    out_scores_sexp_[i] = out_scores[i];
-  });
+  std::copy(out_scores, out_scores + len, REAL(out_scores_sexp));
 
   SET_VECTOR_ELT(r_out, 0, out_features_sexp);
   SET_VECTOR_ELT(r_out, 1, out_shape_sexp);


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

This PR makes some very small performance tweaks to the R interface:
* Pre-allocating or reserving vectors instead of allocating them dynamically.
* Avoiding parallelization when not beneficial.
* Removing unused code for `DMatrixCtx`.