### PR TITLE
[R] Enable vector-valued parameters

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -93,6 +93,14 @@ check.booster.params <- function(params, ...) {
     interaction_constraints <- sapply(params[['interaction_constraints']], function(x) paste0('[', paste(x, collapse = ','), ']'))
     params[['interaction_constraints']] <- paste0('[', paste(interaction_constraints, collapse = ','), ']')
   }
+
+  # for evaluation metrics, should generate multiple entries per metric
+  if (NROW(params[['eval_metric']]) > 1) {
+    eval_metrics <- as.list(params[["eval_metric"]])
+    names(eval_metrics) <- rep("eval_metric", length(eval_metrics))
+    params_without_ev_metrics <- within(params, rm(eval_metric))
+    params <- c(params_without_ev_metrics, eval_metrics)
+  }
   return(params)
 }
 

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -98,7 +98,7 @@ check.booster.params <- function(params, ...) {
   if (NROW(params[['eval_metric']]) > 1) {
     eval_metrics <- as.list(params[["eval_metric"]])
     names(eval_metrics) <- rep("eval_metric", length(eval_metrics))
-    params_without_ev_metrics <- within(params, rm(eval_metric))
+    params_without_ev_metrics <- within(params, rm("eval_metric"))
     params <- c(params_without_ev_metrics, eval_metrics)
   }
   return(params)

--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -697,7 +697,13 @@ xgb.config <- function(object) {
     stop("parameter names cannot be empty strings")
   }
   names(p) <- gsub(".", "_", names(p), fixed = TRUE)
-  p <- lapply(p, function(x) as.character(x)[1])
+  p <- lapply(p, function (x) {
+    if (is.vector(x) && length(x) == 1) {
+      return(as.character(x)[1])
+    } else {
+      return(jsonlite::toJSON(x, auto_unbox = TRUE))
+    }
+  })
   handle <- xgb.get.handle(object)
   for (i in seq_along(p)) {
     .Call(XGBoosterSetParam_R, handle, names(p[i]), p[[i]])

--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -697,7 +697,7 @@ xgb.config <- function(object) {
     stop("parameter names cannot be empty strings")
   }
   names(p) <- gsub(".", "_", names(p), fixed = TRUE)
-  p <- lapply(p, function (x) {
+  p <- lapply(p, function(x) {
     if (is.vector(x) && length(x) == 1) {
       return(as.character(x)[1])
     } else {


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

This PR adds support for passing parameters that might consist of a vector of values instead of a single value, thereby enabling support for multi-quantile regression.

I see in the python interface that parameter `eval_metric` behaves quite differently as it requires passing entries by triggering multiple calls to `XGBoosterSetParam` but with the same parameter name, instead of passing a json list as a single parameter, so that's the approach I am following here.