### PR TITLE
[R] Throw error on arrays with more than 2 dimensions

### DIFF
--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -50,6 +50,9 @@ SEXP SafeMkChar(const char *c_str, SEXP continuation_token) {
 
 [[nodiscard]] std::string MakeArrayInterfaceFromRMat(SEXP R_mat) {
   SEXP mat_dims = Rf_getAttrib(R_mat, R_DimSymbol);
+  if (Rf_xlength(mat_dims) > 2) {
+    LOG(FATAL) << "Passed input array with more than two dimensions, which is not supported.";
+  }
   const int *ptr_mat_dims = INTEGER(mat_dims);
 
   // Lambda for type dispatch.

--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -297,3 +297,11 @@ test_that("xgb.DMatrix: Inf as missing", {
   file.remove("inf.dmatrix")
   file.remove("nan.dmatrix")
 })
+
+test_that("xgb.DMatrix: error on three-dimensional array", {
+  set.seed(123)
+  x <- matrix(rnorm(500), nrow = 50)
+  y <- rnorm(400)
+  dim(y) <- c(50, 4, 2)
+  expect_error(xgb.DMatrix(data = x, label = y))
+})


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

Per comment: https://github.com/dmlc/xgboost/issues/9734#issuecomment-1839914385

This PR adds an error check when the user supplies an array with more than 2 dimensions under some input that would otherwise accept a two-dimensional array.