### PR TITLE
[R] Add note about DMatrix being non-serializable

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -16,6 +16,12 @@
 #' @param nthread Number of threads used for creating DMatrix.
 #' @param ... the \code{info} data could be passed directly as parameters, without creating an \code{info} list.
 #'
+#' @details
+#' Note that DMatrix objects are not serializable through R functions such as \code{saveRDS} or \code{save}.
+#' If a DMatrix gets serialized and then de-serialized (for example, when saving data in an R session or caching
+#' chunks in an Rmd file), the resulting object will not be usable anymore and will need to be reconstructed
+#' from the original source of data.
+#'
 #' @examples
 #' data(agaricus.train, package='xgboost')
 #' ## Keep the number of threads to 1 for examples

--- a/R-package/man/xgb.DMatrix.Rd
+++ b/R-package/man/xgb.DMatrix.Rd
@@ -36,6 +36,12 @@ Construct xgb.DMatrix object from either a dense matrix, a sparse matrix, or a l
 Supported input file formats are either a LIBSVM text file or a binary file that was created previously by
 \code{\link{xgb.DMatrix.save}}).
 }
+\details{
+Note that DMatrix objects are not serializable through R functions such as \code{saveRDS} or \code{save}.
+If a DMatrix gets serialized and then de-serialized (for example, when saving data in an R session or caching
+chunks in an Rmd file), the resulting object will not be usable anymore and will need to be reconstructed
+from the original source of data.
+}
 \examples{
 data(agaricus.train, package='xgboost')
 ## Keep the number of threads to 1 for examples


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

Per comment: https://github.com/dmlc/xgboost/issues/9734#issuecomment-1839914385

This PR adds a note in the DMatrix R documentation about the objects not being serializable.