### PR TITLE
Remove note about multi-quantile being python-only

### DIFF
--- a/demo/guide-python/quantile_regression.py
+++ b/demo/guide-python/quantile_regression.py
@@ -9,7 +9,8 @@ https://scikit-learn.org/stable/auto_examples/ensemble/plot_gradient_boosting_qu
 
 .. note::
 
-    Quantile crossing can happen due to limitation in the algorithm.
+    The feature is only supported using the Python, R, and C packages. In addition, quantile
+    crossing can happen due to limitation in the algorithm.
 
 """
 import argparse

--- a/demo/guide-python/quantile_regression.py
+++ b/demo/guide-python/quantile_regression.py
@@ -9,8 +9,7 @@ https://scikit-learn.org/stable/auto_examples/ensemble/plot_gradient_boosting_qu
 
 .. note::
 
-    The feature is only supported using the Python package. In addition, quantile
-    crossing can happen due to limitation in the algorithm.
+    Quantile crossing can happen due to limitation in the algorithm.
 
 """
 import argparse


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

After PR https://github.com/dmlc/xgboost/pull/9849 , multi-quantile regression is now supported in the R interface.

Hence, this PR removes the disclaimer that it is only available in the python interface, as that's no longer the case.