### PR TITLE
[R] Move all DMatrix fields to function arguments

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -287,7 +287,7 @@ getinfo <- function(object, ...) UseMethod("getinfo")
 #' @rdname getinfo
 #' @export
 getinfo.xgb.DMatrix <- function(object, name, ...) {
-  allowed_int_fields <- c('group')
+  allowed_int_fields <- 'group'
   allowed_float_fields <- c(
     'label', 'weight', 'base_margin',
     'label_lower_bound', 'label_upper_bound'

--- a/R-package/man/getinfo.Rd
+++ b/R-package/man/getinfo.Rd
@@ -23,14 +23,20 @@ Get information of an xgb.DMatrix object
 The \code{name} field can be one of the following:
 
 \itemize{
-    \item \code{label}: label XGBoost learn from ;
-    \item \code{weight}: to do a weight rescale ;
-    \item \code{base_margin}: base margin is the base prediction XGBoost will boost from ;
-    \item \code{nrow}: number of rows of the \code{xgb.DMatrix}.
-
+    \item \code{label}
+    \item \code{weight}
+    \item \code{base_margin}
+    \item \code{label_lower_bound}
+    \item \code{label_upper_bound}
+    \item \code{group}
+    \item \code{feature_type}
+    \item \code{feature_name}
+    \item \code{nrow}
 }
+See the documentation for \link{xgb.DMatrix} for more information about these fields.
 
-\code{group} can be setup by \code{setinfo} but can't be retrieved by \code{getinfo}.
+Note that, while 'qid' cannot be retrieved, it's possible to get the equivalent 'group'
+for a DMatrix that had 'qid' assigned.
 }
 \examples{
 data(agaricus.train, package='xgboost')

--- a/R-package/man/setinfo.Rd
+++ b/R-package/man/setinfo.Rd
@@ -22,13 +22,15 @@ setinfo(object, ...)
 Set information of an xgb.DMatrix object
 }
 \details{
-The \code{name} field can be one of the following:
+See the documentation for \link{xgb.DMatrix} for possible fields that can be set
+(which correspond to arguments in that function).
 
-\itemize{
-    \item \code{label}: label XGBoost learn from ;
-    \item \code{weight}: to do a weight rescale ;
-    \item \code{base_margin}: base margin is the base prediction XGBoost will boost from ;
-    \item \code{group}: number of rows in each group (to use with \code{rank:pairwise} objective).
+Note that the following fields are allowed in the construction of an \code{xgb.DMatrix}
+but \bold{aren't} allowed here:\itemize{
+\item data
+\item missing
+\item silent
+\item nthread
 }
 }
 \examples{

--- a/R-package/man/xgb.DMatrix.Rd
+++ b/R-package/man/xgb.DMatrix.Rd
@@ -6,11 +6,18 @@
 \usage{
 xgb.DMatrix(
   data,
-  info = list(),
+  label = NULL,
+  weight = NULL,
+  base_margin = NULL,
   missing = NA,
   silent = FALSE,
+  feature_names = colnames(data),
   nthread = NULL,
-  ...
+  group = NULL,
+  qid = NULL,
+  label_lower_bound = NULL,
+  label_upper_bound = NULL,
+  feature_weights = NULL
 )
 }
 \arguments{
@@ -19,17 +26,35 @@ a \code{dgRMatrix} object,
 a \code{dsparseVector} object (only when making predictions from a fitted model, will be
 interpreted as a row vector), or a character string representing a filename.}
 
-\item{info}{a named list of additional information to store in the \code{xgb.DMatrix} object.
-See \code{\link{setinfo}} for the specific allowed kinds of}
+\item{label}{Label of the training data.}
+
+\item{weight}{Weight for each instance.
+
+Note that, for ranking task, weights are per-group.  In ranking task, one weight
+is assigned to each group (not each data point). This is because we
+only care about the relative ordering of data points within each group,
+so it doesn't make sense to assign weights to individual data points.}
+
+\item{base_margin}{Base margin used for boosting from existing model.}
 
 \item{missing}{a float value to represents missing values in data (used only when input is a dense matrix).
 It is useful when a 0 or some other extreme value represents missing values in data.}
 
 \item{silent}{whether to suppress printing an informational message after loading from a file.}
 
+\item{feature_names}{Set names for features.}
+
 \item{nthread}{Number of threads used for creating DMatrix.}
 
-\item{...}{the \code{info} data could be passed directly as parameters, without creating an \code{info} list.}
+\item{group}{Group size for all ranking group.}
+
+\item{qid}{Query ID for data samples, used for ranking.}
+
+\item{label_lower_bound}{Lower bound for survival training.}
+
+\item{label_upper_bound}{Upper bound for survival training.}
+
+\item{feature_weights}{Set feature weights for column sampling.}
 }
 \description{
 Construct xgb.DMatrix object from either a dense matrix, a sparse matrix, or a local file.

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -39,7 +39,8 @@ extern SEXP XGDMatrixCreateFromCSC_R(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP XGDMatrixCreateFromCSR_R(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP XGDMatrixCreateFromFile_R(SEXP, SEXP);
 extern SEXP XGDMatrixCreateFromMat_R(SEXP, SEXP, SEXP);
-extern SEXP XGDMatrixGetInfo_R(SEXP, SEXP);
+extern SEXP XGDMatrixGetFloatInfo_R(SEXP, SEXP);
+extern SEXP XGDMatrixGetUIntInfo_R(SEXP, SEXP);
 extern SEXP XGDMatrixGetStrFeatureInfo_R(SEXP, SEXP);
 extern SEXP XGDMatrixNumCol_R(SEXP);
 extern SEXP XGDMatrixNumRow_R(SEXP);
@@ -76,7 +77,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"XGDMatrixCreateFromCSR_R",    (DL_FUNC) &XGDMatrixCreateFromCSR_R,    6},
   {"XGDMatrixCreateFromFile_R",   (DL_FUNC) &XGDMatrixCreateFromFile_R,   2},
   {"XGDMatrixCreateFromMat_R",    (DL_FUNC) &XGDMatrixCreateFromMat_R,    3},
-  {"XGDMatrixGetInfo_R",          (DL_FUNC) &XGDMatrixGetInfo_R,          2},
+  {"XGDMatrixGetFloatInfo_R",     (DL_FUNC) &XGDMatrixGetFloatInfo_R,     2},
+  {"XGDMatrixGetUIntInfo_R",      (DL_FUNC) &XGDMatrixGetUIntInfo_R,      2},
   {"XGDMatrixGetStrFeatureInfo_R", (DL_FUNC) &XGDMatrixGetStrFeatureInfo_R, 2},
   {"XGDMatrixNumCol_R",           (DL_FUNC) &XGDMatrixNumCol_R,           1},
   {"XGDMatrixNumRow_R",           (DL_FUNC) &XGDMatrixNumRow_R,           1},

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -8,6 +8,7 @@
 #include <xgboost/data.h>
 #include <xgboost/logging.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -412,17 +413,27 @@ XGB_DLL SEXP XGDMatrixGetStrFeatureInfo_R(SEXP handle, SEXP field) {
   return ret;
 }
 
-XGB_DLL SEXP XGDMatrixGetInfo_R(SEXP handle, SEXP field) {
+XGB_DLL SEXP XGDMatrixGetFloatInfo_R(SEXP handle, SEXP field) {
   SEXP ret;
   R_API_BEGIN();
   bst_ulong olen;
   const float *res;
   CHECK_CALL(XGDMatrixGetFloatInfo(R_ExternalPtrAddr(handle), CHAR(asChar(field)), &olen, &res));
   ret = PROTECT(allocVector(REALSXP, olen));
-  double *ret_ = REAL(ret);
-  for (size_t i = 0; i < olen; ++i) {
-    ret_[i] = res[i];
-  }
+  std::copy(res, res + olen, REAL(ret));
+  R_API_END();
+  UNPROTECT(1);
+  return ret;
+}
+
+XGB_DLL SEXP XGDMatrixGetUIntInfo_R(SEXP handle, SEXP field) {
+  SEXP ret;
+  R_API_BEGIN();
+  bst_ulong olen;
+  const unsigned *res;
+  CHECK_CALL(XGDMatrixGetUIntInfo(R_ExternalPtrAddr(handle), CHAR(asChar(field)), &olen, &res));
+  ret = PROTECT(allocVector(INTSXP, olen));
+  std::copy(res, res + olen, INTEGER(ret));
   R_API_END();
   UNPROTECT(1);
   return ret;

--- a/R-package/src/xgboost_R.h
+++ b/R-package/src/xgboost_R.h
@@ -106,12 +106,20 @@ XGB_DLL SEXP XGDMatrixSaveBinary_R(SEXP handle, SEXP fname, SEXP silent);
 XGB_DLL SEXP XGDMatrixSetInfo_R(SEXP handle, SEXP field, SEXP array);
 
 /*!
- * \brief get info vector from matrix
+ * \brief get info vector (float type) from matrix
  * \param handle a instance of data matrix
  * \param field field name
  * \return info vector
  */
-XGB_DLL SEXP XGDMatrixGetInfo_R(SEXP handle, SEXP field);
+XGB_DLL SEXP XGDMatrixGetFloatInfo_R(SEXP handle, SEXP field);
+
+/*!
+ * \brief get info vector (uint type) from matrix
+ * \param handle a instance of data matrix
+ * \param field field name
+ * \return info vector
+ */
+XGB_DLL SEXP XGDMatrixGetUIntInfo_R(SEXP handle, SEXP field);
 
 /*!
  * \brief return number of rows

--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -305,3 +305,20 @@ test_that("xgb.DMatrix: error on three-dimensional array", {
   dim(y) <- c(50, 4, 2)
   expect_error(xgb.DMatrix(data = x, label = y))
 })
+
+test_that("xgb.DMatrix: can get group for both 'qid' and 'group' constructors", {
+  set.seed(123)
+  x <- matrix(rnorm(1000), nrow = 100)
+  group <- c(20, 20, 60)
+  qid <- c(rep(1, 20), rep(2, 20), rep(3, 60))
+
+  gr_mat <- xgb.DMatrix(x, group = group)
+  qid_mat <- xgb.DMatrix(x, qid = qid)
+
+  info_gr <- getinfo(gr_mat, "group")
+  info_qid <- getinfo(qid_mat, "group")
+  expect_equal(info_gr, info_qid)
+
+  expected_gr <- c(0, 20, 40, 100)
+  expect_equal(info_gr, expected_gr)
+})

--- a/R-package/tests/testthat/test_interaction_constraints.R
+++ b/R-package/tests/testthat/test_interaction_constraints.R
@@ -47,7 +47,7 @@ test_that("interaction constraints scientific representation", {
   d <- matrix(rexp(rows, rate = .1), nrow = rows, ncol = cols)
   y <- rnorm(rows)
 
-  dtrain <- xgb.DMatrix(data = d, info = list(label = y), nthread = n_threads)
+  dtrain <- xgb.DMatrix(data = d, label = y, nthread = n_threads)
   inc <- list(c(seq.int(from = 0, to = cols, by = 1)))
 
   with_inc <- xgb.train(


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

This PR switches the DMatrix constructor to have all the possible inputs that it accepts as parameters in the function, like the python class for DMatrix does. The docs were all copied from the python DMatrix class.

I've purposefully left out all the parameters related to categorical features as that's still a work in progress from what I understand.