### PR TITLE
[R] Fix xgb.cv() for AFT models

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -239,6 +239,12 @@ convert.labels <- function(labels, objective_name) {
 
 # Generates random (stratified if needed) CV folds
 generate.cv.folds <- function(nfold, nrows, stratified, label, params) {
+  
+  # cannot stratify if label is NULL
+  if (isTRUE(stratified) && is.null(label)) {
+    warning("Will use unstratified splitting (no labels provided)")
+    stratified <- FALSE
+  }
 
   # cannot do it for rank
   objective <- params$objective

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -239,7 +239,7 @@ convert.labels <- function(labels, objective_name) {
 
 # Generates random (stratified if needed) CV folds
 generate.cv.folds <- function(nfold, nrows, stratified, label, params) {
-  
+
   # cannot stratify if label is NULL
   if (isTRUE(stratified) && is.null(label)) {
     warning("Will use unstratified splitting (no labels provided)")

--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -134,13 +134,13 @@ xgb.cv <- function(params = list(), data, nrounds, nfold, label = NULL, missing 
 
   check.custom.obj()
   check.custom.eval()
-  
+
   # AFT uses 'label_lower/upper_bound' instead of 'label'
   if (is.character(params$objective) && params$objective == 'survival:aft') {
     if (!inherits(data, 'xgb.DMatrix')) {
       stop("Objective 'survival:aft' requires the data to be an 'xgb.DMatrix'.")
     }
-    if (is.null(getinfo(data, name = 'label_lower_bound')) || 
+    if (is.null(getinfo(data, name = 'label_lower_bound')) ||
         is.null(getinfo(data, name = 'label_upper_bound'))) {
       stop("Objective 'survival:aft' requires 'label_lower_bound' and 'label_upper_bound.")
     }

--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -134,17 +134,29 @@ xgb.cv <- function(params = list(), data, nrounds, nfold, label = NULL, missing 
 
   check.custom.obj()
   check.custom.eval()
-
-  # Check the labels
-  if ((inherits(data, 'xgb.DMatrix') && is.null(getinfo(data, 'label'))) ||
-      (!inherits(data, 'xgb.DMatrix') && is.null(label))) {
-    stop("Labels must be provided for CV either through xgb.DMatrix, or through 'label=' when 'data' is matrix")
-  } else if (inherits(data, 'xgb.DMatrix')) {
-    if (!is.null(label))
-      warning("xgb.cv: label will be ignored, since data is of type xgb.DMatrix")
-    cv_label <- getinfo(data, 'label')
+  
+  # AFT uses 'label_lower/upper_bound' instead of 'label'
+  if (is.character(params$objective) && params$objective == 'survival:aft') {
+    if (!inherits(data, 'xgb.DMatrix')) {
+      stop("Objective 'survival:aft' requires the data to be an 'xgb.DMatrix'.")
+    }
+    if (is.null(getinfo(data, name = 'label_lower_bound')) || 
+        is.null(getinfo(data, name = 'label_upper_bound'))) {
+      stop("Objective 'survival:aft' requires 'label_lower_bound' and 'label_upper_bound.")
+    }
+    cv_label <- NULL
   } else {
-    cv_label <- label
+    # Check the labels
+    if ((inherits(data, 'xgb.DMatrix') && is.null(getinfo(data, 'label'))) ||
+        (!inherits(data, 'xgb.DMatrix') && is.null(label))) {
+      stop("Labels must be provided for CV either through xgb.DMatrix, or through 'label=' when 'data' is matrix")
+    } else if (inherits(data, 'xgb.DMatrix')) {
+      if (!is.null(label))
+        warning("xgb.cv: label will be ignored, since data is of type xgb.DMatrix")
+      cv_label <- getinfo(data, 'label')
+    } else {
+      cv_label <- label
+    }
   }
 
   # CV folds

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -391,29 +391,29 @@ test_that("xgb.cv works with stratified folds", {
 test_that("xgb.cv works for AFT", {
   X <- matrix(c(1, -1, -1, 1, 0, 1, 1, 0), nrow = 4, byrow = TRUE)  # 4x2 matrix
   dtrain <- xgb.DMatrix(X, nthread = n_threads)
-  
+
   setinfo(dtrain, 'label_lower_bound', c(2, 3, 0, 4))
   setinfo(dtrain, 'label_upper_bound', c(2, Inf, 4, 5))
-  
+
   params <- list(objective = 'survival:aft', learning_rate = 0.2, max_depth = 2L)
-  
+
   # data must be xgb.DMatrix in aft case
   expect_error(
     xgb.cv(
-      params = params, 
-      data = X, 
-      nround = 5L, 
-      nfold = 4L, 
+      params = params,
+      data = X,
+      nround = 5L,
+      nfold = 4L,
       nthread = n_threads,
       label = c(2, 3, 0, 4)
     )
   )
-  
+
   # automatic stratified splitting is turned off
   expect_warning(
     xgb.cv(params = params, data = dtrain, nround = 5L, nfold = 4L, nthread = n_threads)
   )
-  
+
   # this works without any issue
   expect_no_warning(
     xgb.cv(params = params, data = dtrain, nround = 5L, nfold = 4L, stratified = FALSE)


### PR DESCRIPTION
This PR fixes https://github.com/dmlc/xgboost/issues/7118

In order to keep the `xgb.cv()` API as it is:

- `data` must be an `xgb.DMatrix` object
- which contains the two infos 'label_lower_bound' and 'label_upper_bound'.

Automatic stratified splitting is deactivated with a warning. @david-cortes this is something we need to keep in mind for multioutput regressions as well.