### PR TITLE
Flexible find protobuf.

### DIFF
--- a/plugin/federated/CMakeLists.txt
+++ b/plugin/federated/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT Protobuf_FOUND)
 endif()
 if(NOT Protobuf_FOUND)
   # let CMake emit error
-  find_package(Protobuf CONFIG)
+  find_package(Protobuf CONFIG REQUIRED)
 endif()
 
 find_package(gRPC CONFIG REQUIRED)

--- a/plugin/federated/CMakeLists.txt
+++ b/plugin/federated/CMakeLists.txt
@@ -1,7 +1,16 @@
 # gRPC needs to be installed first. See README.md.
 set(protobuf_MODULE_COMPATIBLE TRUE)
 set(protobuf_BUILD_SHARED_LIBS TRUE)
-find_package(Protobuf CONFIG REQUIRED)
+
+find_package(Protobuf CONFIG)
+if(NOT Protobuf_FOUND)
+  find_package(Protobuf)
+endif()
+if(NOT Protobuf_FOUND)
+  # let CMake emit error
+  find_package(Protobuf CONFIG)
+endif()
+
 find_package(gRPC CONFIG REQUIRED)
 message(STATUS "Found gRPC: ${gRPC_CONFIG}")
 


### PR DESCRIPTION
- Allow using non-config based find package.


I use the protobuf from conda-forge for development, which doesn't have the cmake config file.