### PR TITLE
[R] Update docs for `...` in `predict`

### DIFF
--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -194,7 +194,7 @@ xgb.Booster.complete <- function(object, saveraw = TRUE) {
 #' @param strict_shape  Default is \code{FALSE}. When it's set to \code{TRUE}, output
 #'        type and shape of prediction are invariant to model type.
 #'
-#' @param ... Parameters passed to \code{predict.xgb.Booster}
+#' @param ... Not used.
 #'
 #' @details
 #'

--- a/R-package/man/predict.xgb.Booster.Rd
+++ b/R-package/man/predict.xgb.Booster.Rd
@@ -66,7 +66,7 @@ to \code{c(1, 1)} XGBoost will use all trees.}
 \item{strict_shape}{Default is \code{FALSE}. When it's set to \code{TRUE}, output
 type and shape of prediction are invariant to model type.}
 
-\item{...}{Parameters passed to \code{predict.xgb.Booster}}
+\item{...}{Not used.}
 }
 \value{
 The return type is different depending whether \code{strict_shape} is set to \code{TRUE}.  By default,


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

R method `predict` has a three-dots argument (`...`) which needs to be in the function signature of derived predict methods, such as xgboost's.

Currently, the docs for this parameter say:
> Parameters passed to \code{predict.xgb.Booster}

But the parameters aren't actually used anywhere in the function.