### PR TITLE
[doc] Reference `enable_categorical` doc in sklearn.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -824,9 +824,10 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
             Experimental support of specializing for categorical features.
 
-            If passing 'True' and 'data' is a data frame (from supported libraries
-            such as Pandas or Modin), columns of categorical types will automatically
-            be set to be of categorical type (feature_type='c') in the resulting DMatrix.
+            If passing 'True' and 'data' is a data frame (from supported libraries such
+            as Pandas, Modin or cuDF), columns of categorical types will automatically
+            be set to be of categorical type (feature_type='c') in the resulting
+            DMatrix.
 
             If passing 'False' and 'data' is a data frame with categorical columns,
             it will result in an error being thrown.

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -276,13 +276,7 @@ __model_doc = f"""
 
     enable_categorical : bool
 
-        .. versionadded:: 1.5.0
-
-        .. note:: This parameter is experimental
-
-        Experimental support for categorical data.  When enabled, cudf/pandas.DataFrame
-        should be used to specify categorical data type.  Also, JSON/UBJSON
-        serialization format is required.
+        See the same parameter of :py:class:`DMatrix` for details.
 
     feature_types : Optional[FeatureTypes]
 


### PR DESCRIPTION
Followup on https://github.com/dmlc/xgboost/pull/9877 .