### PR TITLE
[R] Enable multi-dimensional `base_margin`

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -16,6 +16,8 @@
 #' only care about the relative ordering of data points within each group,
 #' so it doesn't make sense to assign weights to individual data points.
 #' @param base_margin Base margin used for boosting from existing model.
+#'
+#'        In the case of multi-output models, one can also pass multi-dimensional base_margin.
 #' @param missing a float value to represents missing values in data (used only when input is a dense matrix).
 #'        It is useful when a 0 or some other extreme value represents missing values in data.
 #' @param silent whether to suppress printing an informational message after loading from a file.
@@ -439,9 +441,7 @@ setinfo.xgb.DMatrix <- function(object, name, info, ...) {
     return(TRUE)
   }
   if (name == "base_margin") {
-    # if (length(info)!=nrow(object))
-    #   stop("The length of base margin must equal to the number of rows in the input data")
-    .Call(XGDMatrixSetInfo_R, object, name, as.numeric(info))
+    .Call(XGDMatrixSetInfo_R, object, name, info)
     return(TRUE)
   }
   if (name == "group") {

--- a/R-package/man/xgb.DMatrix.Rd
+++ b/R-package/man/xgb.DMatrix.Rd
@@ -36,7 +36,9 @@ is assigned to each group (not each data point). This is because we
 only care about the relative ordering of data points within each group,
 so it doesn't make sense to assign weights to individual data points.}
 
-\item{base_margin}{Base margin used for boosting from existing model.}
+\item{base_margin}{Base margin used for boosting from existing model.
+
+       In the case of multi-output models, one can also pass multi-dimensional base_margin.}
 
 \item{missing}{a float value to represents missing values in data (used only when input is a dense matrix).
 It is useful when a 0 or some other extreme value represents missing values in data.}


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810
As a follow up from https://github.com/dmlc/xgboost/pull/9882

This PR enables multi-dimensional `base_margin` in the R interface. Alongside, it adds a small mention about it in the docs, also for python.