### PR TITLE
[R] Catch C++ exceptions

### DIFF
--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -138,7 +138,6 @@ SEXP SafeMkChar(const char *c_str, SEXP continuation_token) {
 }
 }  // namespace
 
-char cpp_ex_msg[256];
 struct RRNGStateController {
   RRNGStateController() {
     GetRNGstate();
@@ -155,6 +154,14 @@ struct RRNGStateController {
 #define R_API_BEGIN()                           \
   try {                                         \
     RRNGStateController rng_controller{};
+
+/* Note: an R error triggers a long jump, hence all C++ objects that
+allocated memory through non-R allocators, including the exception
+object, need to be destructed before triggering the R error.
+In order to preserve the error message, it gets copied to a temporary
+buffer, and the R error section is reached through a 'goto' statement
+that bypasses usual function control flow. */
+char cpp_ex_msg[256];
 /*!
  * \brief macro to annotate end of api
  */


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

This PR adds a catch clause for C++ exceptions in the R interface.

Currently, the code involves constructing objects such as `std::vector`, which can potentially throw exceptions like `std::bad_alloc`. At the moment, those exceptions would not be catched anywhere, and since the functions have C linkage, this means that such exceptions could potentially result in memory corruption and similar from the user side when triggered.

Note that producing an R error involves a C long jump, so any C++ objects that deal with memory outside of the function stack, including the exception object, need to be destructed before throwing the error.

There's one thing I wasn't quite sure about though: there's a built-in error class `dmlc::Error` which can contain error messages. Right now, those are passed to the R error function by accessing `.what()`, but I am not sure if the memory for that exception also needs to be freed with a similar workaround as the one introduced here for standard C++ exceptions.