### PR TITLE
Correct name of function for setting data frames in proxy dmatrix

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -532,7 +532,7 @@ XGProxyDMatrixSetDataCudaArrayInterface(DMatrixHandle handle,
  *
  * @return 0 when success, -1 when failure happens
  */
-XGB_DLL int XGProxyDMatrixSetDataCudaColumnar(DMatrixHandle handle, char const *c_interface_str);
+XGB_DLL int XGProxyDMatrixSetDataColumnar(DMatrixHandle handle, char const *c_interface_str);
 
 /*!
  * \brief Set data on a DMatrix proxy.


### PR DESCRIPTION
In a previous PR: https://github.com/dmlc/xgboost/pull/9828

A C function `XGProxyDMatrixSetDataColumnar` was introduced, but what was added to the public C header was instead `XGProxyDMatrixSetDataCudaColumnar`, which overlaps with a previous function name.

This PR renames it to match with the function which was introduced in the PR.