### PR TITLE
[R] Destruct `dmlc::Error` objects before long jumps

### DIFF
--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -161,15 +161,13 @@ object, need to be destructed before triggering the R error.
 In order to preserve the error message, it gets copied to a temporary
 buffer, and the R error section is reached through a 'goto' statement
 that bypasses usual function control flow. */
-char cpp_ex_msg[256];
+char cpp_ex_msg[512];
 /*!
  * \brief macro to annotate end of api
  */
 #define R_API_END()                             \
-  } catch(dmlc::Error& e) {                     \
-    Rf_error("%s", e.what());                   \
   } catch(std::exception &e) {                  \
-    std::strncpy(cpp_ex_msg, e.what(), 256);    \
+    std::strncpy(cpp_ex_msg, e.what(), 512);    \
     goto throw_cpp_ex_as_R_err;                 \
   }                                             \
   if (false) {                                  \


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810
As a follow-up from https://github.com/dmlc/xgboost/pull/9903

I just noticed that the custom exception class `dmlc::Error` is subcblassed from `std::runtime_error`, which is in turn subclassed from `std::exception`:
https://github.com/dmlc/dmlc-core/blob/ea21135fbb141ae103fb5fc960289b5601b468f2/include/dmlc/logging.h#L34 

Since these objects hold dynamically-allocated memory for the error message, they need to be destructed before doing a long jump, which is how R handles errors.

Currently, I think this type of error can only be thrown by the few lines in the R interface which explicitly call `LOG()`, as otherwise the xgboost C functions signal errors by return codes; and in many cases the conditions leading to these `LOG()` calls would have been checked beforehand in R code, so I'm not sure if it's even possible to end up in that `catch` clause, but this should prevent any potential leaks if that happens.

**********************

By the way, it would be quite helpful to set up an optional CI job running the R tests and examples with either ASAN or valgrind, as then these types of leaks could be detected more easily.