### PR TITLE
[R] More clear function signatures for S3 methods

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -420,7 +420,6 @@ getinfo.xgb.DMatrix <- function(object, name) {
 #' @param object Object of class "xgb.DMatrix"
 #' @param name the name of the field to get
 #' @param info the specific field of information to set
-#' @param ... Not used.
 #'
 #' @details
 #' See the documentation for \link{xgb.DMatrix} for possible fields that can be set

--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -340,7 +340,6 @@ dimnames.xgb.DMatrix <- function(x) {
 #' Get information of an xgb.DMatrix object
 #' @param object Object of class \code{xgb.DMatrix}
 #' @param name the name of the information field to get (see details)
-#' @param ... other parameters
 #'
 #' @details
 #' The \code{name} field can be one of the following:
@@ -372,11 +371,11 @@ dimnames.xgb.DMatrix <- function(x) {
 #' stopifnot(all(labels2 == 1-labels))
 #' @rdname getinfo
 #' @export
-getinfo <- function(object, ...) UseMethod("getinfo")
+getinfo <- function(object, name) UseMethod("getinfo")
 
 #' @rdname getinfo
 #' @export
-getinfo.xgb.DMatrix <- function(object, name, ...) {
+getinfo.xgb.DMatrix <- function(object, name) {
   allowed_int_fields <- 'group'
   allowed_float_fields <- c(
     'label', 'weight', 'base_margin',
@@ -445,17 +444,17 @@ getinfo.xgb.DMatrix <- function(object, name, ...) {
 #' stopifnot(all.equal(labels2, 1-labels))
 #' @rdname setinfo
 #' @export
-setinfo <- function(object, ...) UseMethod("setinfo")
+setinfo <- function(object, name, info) UseMethod("setinfo")
 
 #' @rdname setinfo
 #' @export
-setinfo.xgb.DMatrix <- function(object, name, info, ...) {
-  .internal.setinfo.xgb.DMatrix(object, name, info, ...)
+setinfo.xgb.DMatrix <- function(object, name, info) {
+  .internal.setinfo.xgb.DMatrix(object, name, info)
   attr(object, "fields")[[name]] <- TRUE
   return(TRUE)
 }
 
-.internal.setinfo.xgb.DMatrix <- function(object, name, info, ...) {
+.internal.setinfo.xgb.DMatrix <- function(object, name, info) {
   if (name == "label") {
     if (NROW(info) != nrow(object))
       stop("The length of labels must equal to the number of rows in the input data")
@@ -538,7 +537,6 @@ setinfo.xgb.DMatrix <- function(object, name, info, ...) {
 #' @param object Object of class "xgb.DMatrix"
 #' @param idxset a integer vector of indices of rows needed
 #' @param colset currently not used (columns subsetting is not available)
-#' @param ... other parameters (currently not used)
 #'
 #' @examples
 #' data(agaricus.train, package='xgboost')
@@ -552,11 +550,11 @@ setinfo.xgb.DMatrix <- function(object, name, info, ...) {
 #'
 #' @rdname slice.xgb.DMatrix
 #' @export
-slice <- function(object, ...) UseMethod("slice")
+slice <- function(object, idxset) UseMethod("slice")
 
 #' @rdname slice.xgb.DMatrix
 #' @export
-slice.xgb.DMatrix <- function(object, idxset, ...) {
+slice.xgb.DMatrix <- function(object, idxset) {
   if (!inherits(object, "xgb.DMatrix")) {
     stop("object must be xgb.DMatrix")
   }

--- a/R-package/man/getinfo.Rd
+++ b/R-package/man/getinfo.Rd
@@ -5,14 +5,12 @@
 \alias{getinfo.xgb.DMatrix}
 \title{Get information of an xgb.DMatrix object}
 \usage{
-getinfo(object, ...)
+getinfo(object, name)
 
-\method{getinfo}{xgb.DMatrix}(object, name, ...)
+\method{getinfo}{xgb.DMatrix}(object, name)
 }
 \arguments{
 \item{object}{Object of class \code{xgb.DMatrix}}
-
-\item{...}{other parameters}
 
 \item{name}{the name of the information field to get (see details)}
 }

--- a/R-package/man/setinfo.Rd
+++ b/R-package/man/setinfo.Rd
@@ -5,18 +5,18 @@
 \alias{setinfo.xgb.DMatrix}
 \title{Set information of an xgb.DMatrix object}
 \usage{
-setinfo(object, ...)
+setinfo(object, name, info)
 
-\method{setinfo}{xgb.DMatrix}(object, name, info, ...)
+\method{setinfo}{xgb.DMatrix}(object, name, info)
 }
 \arguments{
 \item{object}{Object of class "xgb.DMatrix"}
 
-\item{...}{Not used.}
-
 \item{name}{the name of the field to get}
 
 \item{info}{the specific field of information to set}
+
+\item{...}{Not used.}
 }
 \description{
 Set information of an xgb.DMatrix object

--- a/R-package/man/setinfo.Rd
+++ b/R-package/man/setinfo.Rd
@@ -15,8 +15,6 @@ setinfo(object, name, info)
 \item{name}{the name of the field to get}
 
 \item{info}{the specific field of information to set}
-
-\item{...}{Not used.}
 }
 \description{
 Set information of an xgb.DMatrix object

--- a/R-package/man/slice.xgb.DMatrix.Rd
+++ b/R-package/man/slice.xgb.DMatrix.Rd
@@ -7,16 +7,14 @@
 \title{Get a new DMatrix containing the specified rows of
 original xgb.DMatrix object}
 \usage{
-slice(object, ...)
+slice(object, idxset)
 
-\method{slice}{xgb.DMatrix}(object, idxset, ...)
+\method{slice}{xgb.DMatrix}(object, idxset)
 
 \method{[}{xgb.DMatrix}(object, idxset, colset = NULL)
 }
 \arguments{
 \item{object}{Object of class "xgb.DMatrix"}
-
-\item{...}{other parameters (currently not used)}
 
 \item{idxset}{a integer vector of indices of rows needed}
 


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

There are generic methods defined for DMatrix and Booster classes. These methods have generic signatures with `...` which aren't used. This PR modifies them to have stricter signatures according to what they use.