### PR TITLE
[R] Minor improvements for evaluation printing

### DIFF
--- a/R-package/R/callbacks.R
+++ b/R-package/R/callbacks.R
@@ -766,7 +766,7 @@ xgb.gblinear.history <- function(model, class_index = NULL) {
   enames <- names(eval_res)
   if (is.null(enames))
     stop('evaluation results must have names')
-  iter <- sprintf('[round: %d]\t', iter)
+  iter <- sprintf('[%d]\t', iter)
   if (!is.null(eval_err)) {
     if (length(eval_res) != length(eval_err))
       stop('eval_res & eval_err lengths mismatch')

--- a/R-package/R/callbacks.R
+++ b/R-package/R/callbacks.R
@@ -766,11 +766,12 @@ xgb.gblinear.history <- function(model, class_index = NULL) {
   enames <- names(eval_res)
   if (is.null(enames))
     stop('evaluation results must have names')
-  iter <- sprintf('[%d]\t', iter)
+  iter <- sprintf('[round: %d]\t', iter)
   if (!is.null(eval_err)) {
     if (length(eval_res) != length(eval_err))
       stop('eval_res & eval_err lengths mismatch')
-    res <- paste0(sprintf("%s:%f+%f", enames, eval_res, eval_err), collapse = '\t')
+    # Note: UTF-8 code for plus/minus sign is U+00B1
+    res <- paste0(sprintf("%s:%f\U00B1%f", enames, eval_res, eval_err), collapse = '\t')
   } else {
     res <- paste0(sprintf("%s:%f", enames, eval_res), collapse = '\t')
   }

--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -244,8 +244,9 @@ xgb.cv <- function(params = list(), data, nrounds, nfold, label = NULL, missing 
       )
     })
     msg <- simplify2array(msg)
-    bst_evaluation <- rowMeans(msg)
-    bst_evaluation_err <- sqrt(rowMeans(msg^2) - bst_evaluation^2) # nolint
+    # Note: these variables might look unused here, but they are used in the callbacks
+    bst_evaluation <- rowMeans(msg) # nolint
+    bst_evaluation_err <- apply(msg, 1, sd) # nolint
 
     for (f in cb$post_iter) f()
 

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -361,7 +361,7 @@ test_that("xgb.cv works", {
   expect_is(cv, "xgb.cv.synchronous")
   expect_false(is.null(cv$evaluation_log))
   expect_lt(cv$evaluation_log[, min(test_error_mean)], 0.03)
-  expect_lt(cv$evaluation_log[, min(test_error_std)], 0.008)
+  expect_lt(cv$evaluation_log[, min(test_error_std)], 0.0085)
   expect_equal(cv$niter, 2)
   expect_false(is.null(cv$folds) && is.list(cv$folds))
   expect_length(cv$folds, 5)

--- a/R-package/tests/testthat/test_callbacks.R
+++ b/R-package/tests/testthat/test_callbacks.R
@@ -44,20 +44,20 @@ test_that("cb.print.evaluation works as expected", {
 
   iteration <- 1
   expect_silent(f0())
-  expect_output(f1(), "\\[round: 1\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
-  expect_output(f5(), "\\[round: 1\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
+  expect_output(f1(), "\\[1\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
+  expect_output(f5(), "\\[1\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
   expect_null(f1())
 
   iteration <- 2
-  expect_output(f1(), "\\[round: 2\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
+  expect_output(f1(), "\\[2\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
   expect_silent(f5())
 
   iteration <- 7
-  expect_output(f1(), "\\[round: 7\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
-  expect_output(f5(), "\\[round: 7\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
+  expect_output(f1(), "\\[7\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
+  expect_output(f5(), "\\[7\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
 
   bst_evaluation_err  <- c('train-auc' = 0.1, 'test-auc' = 0.2)
-  expect_output(f1(), "\\[round: 7\\]\ttrain-auc:0.900000±0.100000\ttest-auc:0.800000±0.200000")
+  expect_output(f1(), "\\[7\\]\ttrain-auc:0.900000±0.100000\ttest-auc:0.800000±0.200000")
 })
 
 test_that("cb.evaluation.log works as expected", {

--- a/R-package/tests/testthat/test_callbacks.R
+++ b/R-package/tests/testthat/test_callbacks.R
@@ -57,7 +57,7 @@ test_that("cb.print.evaluation works as expected", {
   expect_output(f5(), "\\[round: 7\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
 
   bst_evaluation_err  <- c('train-auc' = 0.1, 'test-auc' = 0.2)
-  expect_output(f1(), "\\[round: 7\\]\ttrain-auc:0.900000\\±0.100000\ttest-auc:0.800000\\±0.200000")
+  expect_output(f1(), "\\[round: 7\\]\ttrain-auc:0.900000±0.100000\ttest-auc:0.800000±0.200000")
 })
 
 test_that("cb.evaluation.log works as expected", {

--- a/R-package/tests/testthat/test_callbacks.R
+++ b/R-package/tests/testthat/test_callbacks.R
@@ -44,20 +44,20 @@ test_that("cb.print.evaluation works as expected", {
 
   iteration <- 1
   expect_silent(f0())
-  expect_output(f1(), "\\[1\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
-  expect_output(f5(), "\\[1\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
+  expect_output(f1(), "\\[round: 1\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
+  expect_output(f5(), "\\[round: 1\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
   expect_null(f1())
 
   iteration <- 2
-  expect_output(f1(), "\\[2\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
+  expect_output(f1(), "\\[round: 2\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
   expect_silent(f5())
 
   iteration <- 7
-  expect_output(f1(), "\\[7\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
-  expect_output(f5(), "\\[7\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
+  expect_output(f1(), "\\[round: 7\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
+  expect_output(f5(), "\\[round: 7\\]\ttrain-auc:0.900000\ttest-auc:0.800000")
 
   bst_evaluation_err  <- c('train-auc' = 0.1, 'test-auc' = 0.2)
-  expect_output(f1(), "\\[7\\]\ttrain-auc:0.900000\\+0.100000\ttest-auc:0.800000\\+0.200000")
+  expect_output(f1(), "\\[round: 7\\]\ttrain-auc:0.900000\\±0.100000\ttest-auc:0.800000\\±0.200000")
 })
 
 test_that("cb.evaluation.log works as expected", {


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

This PR makes some small changes in the evaluation metrics printing:
* It uses a plus-minus sign for the standard deviation instead of '+', since that's what the standard deviation is meant to represent.
* It prints 'round' before the boosting round number in order to make these prints visually different from R's `print`.
* It uses R's `sd` function to calculate standard deviations, which correctly applies a bias correction for sampling bias and uses more numerically robust techniques than the current difference of squares.