### PR TITLE
[jvm-packages] update rapids dep to 23.12.1

### DIFF
--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -43,9 +43,9 @@
         <maven.wagon.http.retryHandler.count>5</maven.wagon.http.retryHandler.count>
         <log.capi.invocation>OFF</log.capi.invocation>
         <use.cuda>OFF</use.cuda>
-        <cudf.version>23.10.0</cudf.version>
-        <spark.rapids.version>23.10.0</spark.rapids.version>
-        <cudf.classifier>cuda11</cudf.classifier>
+        <cudf.version>23.12.1</cudf.version>
+        <spark.rapids.version>23.12.1</spark.rapids.version>
+        <cudf.classifier>cuda12</cudf.classifier>
         <scalatest.version>3.2.17</scalatest.version>
         <scala-collection-compat.version>2.11.0</scala-collection-compat.version>
       </properties>


### PR DESCRIPTION
To fix https://github.com/dmlc/xgboost/issues/9760. With this PR, XGBoost GPU can support scala 2.13


Close https://github.com/dmlc/xgboost/pull/9945
Close https://github.com/dmlc/xgboost/pull/9873
Close https://github.com/dmlc/xgboost/pull/9872