### PR TITLE
[R] Use R's error stream for printing warnings

### DIFF
--- a/R-package/src/xgboost_custom.cc
+++ b/R-package/src/xgboost_custom.cc
@@ -17,7 +17,11 @@ namespace xgboost {
 ConsoleLogger::~ConsoleLogger() {
   if (cur_verbosity_ == LogVerbosity::kIgnore ||
       cur_verbosity_ <= GlobalVerbosity()) {
-    dmlc::CustomLogMessage::Log(log_stream_.str());
+    if (cur_verbosity_ == LogVerbosity::kWarning) {
+      REprintf("%s\n", log_stream_.str().c_str());
+    } else {
+      dmlc::CustomLogMessage::Log(log_stream_.str());
+    }
   }
 }
 TrackerLogger::~TrackerLogger() {

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -83,7 +83,8 @@ test_that("parameter validation works", {
       bar = "foo"
     )
     output <- capture.output(
-      xgb.train(params = params, data = dtrain, nrounds = nrounds)
+      xgb.train(params = params, data = dtrain, nrounds = nrounds),
+      type = "message"
     )
     print(output)
   }


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

Currenly, warnings that are thrown from the C++ side are printed as regular R standard output messages, which doesn't convey the idea of being warnings.

This PR switches modifies them to be printed using `REprintf` (R's `stderr` analog), so that they would look like regular R warnings.