### PR TITLE
fixes #9972 FieldEntry ctor specialisation syntax error

### DIFF
--- a/include/xgboost/parameter.h
+++ b/include/xgboost/parameter.h
@@ -53,7 +53,7 @@ namespace parameter {  \
 template <>  \
 class FieldEntry<EnumClass> : public FieldEntry<int> {  \
  public:  \
-  FieldEntry<EnumClass>() {  \
+  FieldEntry() {  \
     static_assert(  \
       std::is_same<int, typename std::underlying_type<EnumClass>::type>::value,  \
       "enum class must be backed by int");  \


### PR DESCRIPTION
fixes #9972 FieldEntry ctor specialisation syntax error in macro DECLARE_FIELD_ENUM_CLASS