### PR TITLE
Add data format when converting DMatrix data in dart demo code

### DIFF
--- a/doc/tutorials/dart.rst
+++ b/doc/tutorials/dart.rst
@@ -96,8 +96,8 @@ Sample Script
 
   import xgboost as xgb
   # read in data
-  dtrain = xgb.DMatrix('demo/data/agaricus.txt.train')
-  dtest = xgb.DMatrix('demo/data/agaricus.txt.test')
+  dtrain = xgb.DMatrix('demo/data/agaricus.txt.train?format=libsvm')
+  dtest = xgb.DMatrix('demo/data/agaricus.txt.test?format=libsvm')
   # specify parameters via map
   param = {'booster': 'dart',
            'max_depth': 5, 'learning_rate': 0.1,


### PR DESCRIPTION
My version is 2.0.3, and I encountered an error while following the tutorial,  the error info is 
```
XGBoostError: [15:08:32] /workspace/src/data/file_iterator.cc:24: Check failed: name_args.size() == 2 (1 vs. 2) : URI parameter `format` is required for loading text data: filename?format=csv
```

after consulting relevant materials and adding data format libsvm, the program did not report any errors.