### PR TITLE
make DMatrix subclassable that supports slice mehod

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1295,7 +1295,7 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 ctypes.c_int(1 if allow_groups else 0),
             )
         )
-        return DMatrix(handle)
+        return self.__class__(handle)
 
     @property
     def feature_names(self) -> Optional[FeatureNames]:


### PR DESCRIPTION
Currently, subclass of `DMatrix` could not slice normally. `slice` method on subclass will return a `DMatrix` instance not the subclass instance.