### PR TITLE
[doc] Fix the default value for `lambdarank_pair_method`.

### DIFF
--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -502,6 +502,8 @@ These are parameters specific to learning to rank task. See :doc:`Learning to Ra
 
 * ``lambdarank_normalization`` [default = ``true``]
 
+  .. versionadded:: 2.1.0
+
   Whether to normalize the leaf value by lambda gradient. This can sometimes stagnate the training progress.
 
 *  ``lambdarank_unbiased`` [default = ``false``]

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -489,7 +489,7 @@ Parameters for learning to rank (``rank:ndcg``, ``rank:map``, ``rank:pairwise``)
 
 These are parameters specific to learning to rank task. See :doc:`Learning to Rank </tutorials/learning_to_rank>` for an in-depth explanation.
 
-* ``lambdarank_pair_method`` [default = ``mean``]
+* ``lambdarank_pair_method`` [default = ``topk``]
 
   How to construct pairs for pair-wise learning.
 


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/10097 .