### PR TITLE
Make NCCL an optional dependency.

### DIFF
--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -30,8 +30,10 @@ classifiers = [
 dependencies = [
     "numpy",
     "scipy",
-    "nvidia-nccl-cu12 ; platform_system == 'Linux' and platform_machine != 'aarch64'"
 ]
+
+[project.optional-dependencies]
+gpu = ["nvidia-nccl-cu12"]
 
 [project.urls]
 documentation = "https://xgboost.readthedocs.io/en/stable/"


### PR DESCRIPTION
This commit makes NCCL an optional dependency for the Python package, which is only installed with the GPU tag.