### PR TITLE
fix: calling member function without object when build from source

### DIFF
--- a/src/tree/updater_histmaker.cc
+++ b/src/tree/updater_histmaker.cc
@@ -215,7 +215,7 @@ class HistMaker: public BaseMaker {
           continue;
         }
 
-        EnumerateSplit(this->wspace_.hset[0][i + wid * (num_feature + 1)], node_sum, feature_set[i],
+        this->EnumerateSplit(this->wspace_.hset[0][i + wid * (num_feature + 1)], node_sum, feature_set[i],
                        &best, &left_sum[wid]);
       }
     });


### PR DESCRIPTION
resolve error when building from source:
[ 77%] Building CXX object src/CMakeFiles/objxgboost.dir/tree/tree_model.cc.o
[ 78%] Building CXX object src/CMakeFiles/objxgboost.dir/tree/tree_updater.cc.o
[ 79%] Building CXX object src/CMakeFiles/objxgboost.dir/tree/updater_approx.cc.o
[ 80%] Building CXX object src/CMakeFiles/objxgboost.dir/tree/updater_colmaker.cc.o
[ 81%] Building CXX object src/CMakeFiles/objxgboost.dir/tree/updater_histmaker.cc.o
[ 83%] Building CXX object src/CMakeFiles/objxgboost.dir/tree/updater_prune.cc.o
[ 84%] Building CXX object src/CMakeFiles/objxgboost.dir/tree/updater_quantile_hist.cc.o
[ 85%] Building CXX object src/CMakeFiles/objxgboost.dir/tree/updater_refresh.cc.o
[ 86%] Building CXX object src/CMakeFiles/objxgboost.dir/tree/updater_sync.cc.o
/root/xgboost/xgboost/src/tree/updater_histmaker.cc: In instantiation of ‘xgboost::tree::HistMaker::FindSplit(const std::vector<unsigned int>&, xgboost::RegTree*)::<lambda(auto:8)> [with auto:8 = long unsigned int]’:
/root/xgboost/xgboost/dmlc-core/include/dmlc/././common.h:67:8:   required from ‘void dmlc::OMPException::Run(Function, Parameters ...) [with Function = xgboost::tree::HistMaker::FindSplit(const std::vector<unsigned int>&, xgboost::RegTree*)::<lambda(auto:8)>; Parameters = {long unsigned int}]’
/root/xgboost/xgboost/src/tree/./../common/threading_utils.h:185:7:   required from ‘void xgboost::common::ParallelFor(Index, int32_t, xgboost::common::Sched, Func) [with Index = long unsigned int; Func = xgboost::tree::HistMaker::FindSplit(const std::vector<unsigned int>&, xgboost::RegTree*)::<lambda(auto:8)>; int32_t = int]’
/root/xgboost/xgboost/src/tree/updater_histmaker.cc:221:6:   required from here
/root/xgboost/xgboost/src/tree/updater_histmaker.cc:218:9: 错误：没有对象无法调用成员函数‘void xgboost::tree::HistMaker::EnumerateSplit(const xgboost::tree::HistMaker::HistUnit&, const xgboost::tree::GradStats&, xgboost::bst_uint, xgboost::tree::SplitEntry*, xgboost::tree::GradStats*) const’
         EnumerateSplit(this->wspace_.hset[0][i + wid * (num_feature + 1)], node_sum, feature_set[i],
         ^~~~~~~~~~~~~~
[ 87%] Building CXX object src/CMakeFiles/objxgboost.dir/__/rabit/src/allreduce_base.cc.o
gmake[2]: *** [src/CMakeFiles/objxgboost.dir/tree/updater_histmaker.cc.o] 错误 1
gmake[2]: *** 正在等待未完成的任务....
gmake[1]: *** [src/CMakeFiles/objxgboost.dir/all] 错误 2
gmake: *** [all] 错误 2
Traceback (most recent call last):
  File "create_jni.py", line 122, in <module>
building Java wrapper
cd ..
mkdir -p build
