### PR TITLE
[pyspark] clear temp storage to release GPU memory before each iteration

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -632,8 +632,12 @@ class DataIter(ABC):  # pylint: disable=too-many-instance-attributes
             )
             self._data_ref = ref
 
+        def _next() -> int:
+            self.clear()
+            return self.next(input_data)
+
         # pylint: disable=not-callable
-        return self._handle_exception(lambda: self.next(input_data), 0)
+        return self._handle_exception(_next, 0)
 
     @abstractmethod
     def reset(self) -> None:
@@ -657,6 +661,10 @@ class DataIter(ABC):  # pylint: disable=too-many-instance-attributes
 
         """
         raise NotImplementedError()
+
+    def clear(self) -> None:
+        """Clear function to be called before each iteration."""
+        pass  # pylint: disable=unnecessary-pass
 
 
 # Notice for `require_keyword_args`

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -111,6 +111,11 @@ class PartIter(DataIter):
     def reset(self) -> None:
         self._iter = 0
 
+    def clear(self) -> None:
+        """Clear _temporary_data to release all cached data in the GPU
+        to decrease the peak memory"""
+        self._temporary_data = None
+
 
 def _read_csr_matrix_from_unwrapped_spark_vec(part: pd.DataFrame) -> csr_matrix:
     # variables for constructing csr_matrix


### PR DESCRIPTION
When setting the current data batch (already copied to GPU from CPU) to the DMatrixProxy, it still holds the previous data batch during building QDM, which will increase the peak GPU  memory usage. So this PR tried to clear the temporary storage before each iteration.

I tested it on my local standalone cluster with 1 worker node with 12G GPU memory, XGBoost can train (4800000, 750)  with this PR, while XGBoost can train only (4300000, 750) without this PR.

