### PR TITLE
[jvm-packagaes] Freeze spark to 3.4.1 for now.

### DIFF
--- a/jvm-packages/pom.xml
+++ b/jvm-packages/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <flink.version>1.19.0</flink.version>
         <junit.version>4.13.2</junit.version>
-        <spark.version>3.5.1</spark.version>
+        <spark.version>3.4.1</spark.version>
         <spark.version.gpu>3.4.1</spark.version.gpu>
         <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>


### PR DESCRIPTION
The newer spark version for CPU conflicts with the more conservative version used by rapids.

We need JSON support for JVM packages for passing various XGBoost parameters in https://github.com/dmlc/xgboost/pull/10112  . However, different spark versions require different jackson versions. This creates conflicts between packages.