### PR TITLE
Keep GitHub Actions up to date with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,7 @@ updates:
     directory: "/jvm-packages/xgboost4j-spark-gpu"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Fixes software supply chain safety warnings like at the bottom right of
https://github.com/dmlc/xgboost/actions/runs/9048469681

* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the dependabot.yml file - package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)