### PR TITLE
[pyspark] Add launch_tracker_on_driver to decide where the tracker will be launched

### DIFF
--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -86,6 +86,7 @@ from .utils import (
     CommunicatorContext,
     _get_default_params_from_func,
     _get_gpu_id,
+    _get_host_ip,
     _get_max_num_concurrent_tasks,
     _get_rabit_args,
     _get_spark_session,
@@ -121,6 +122,7 @@ _pyspark_specific_params = [
     "repartition_random_shuffle",
     "pred_contrib_col",
     "use_gpu",
+    "tracker_on_driver",
 ]
 
 _non_booster_params = ["missing", "n_estimators", "feature_types", "feature_weights"]
@@ -245,6 +247,13 @@ class _SparkXGBParams(
         "feature_names",
         "A list of str to specify feature names.",
         TypeConverters.toList,
+    )
+    tracker_on_driver = Param(
+        Params._dummy(),
+        "tracker_on_driver",
+        "A boolean variable. Set tracker_on_driver to true if you want the tracker to be launched "
+        "on the driver side; otherwise, it will be launched on the executor side.",
+        TypeConverters.toBoolean,
     )
 
     def set_device(self, value: str) -> "_SparkXGBParams":
@@ -617,6 +626,7 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
             feature_names=None,
             feature_types=None,
             arbitrary_params_dict={},
+            tracker_on_driver=True,
         )
 
         self.logger = get_logger(self.__class__.__name__)
@@ -1014,6 +1024,16 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
 
         num_workers = self.getOrDefault(self.num_workers)
 
+        run_tracker_on_driver = self.getOrDefault(self.tracker_on_driver)
+
+        rabit_args = {}
+        if run_tracker_on_driver:
+            driver_host = (
+                _get_spark_session().sparkContext.getConf().get("spark.driver.host")
+            )
+            assert driver_host is not None
+            rabit_args = _get_rabit_args(driver_host, num_workers)
+
         log_level = get_logger_level(_LOG_TAG)
 
         def _train_booster(
@@ -1053,21 +1073,25 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
             if use_qdm and (booster_params.get("max_bin", None) is not None):
                 dmatrix_kwargs["max_bin"] = booster_params["max_bin"]
 
-            _rabit_args = {}
+            _rabit_args = rabit_args
             if context.partitionId() == 0:
-                _rabit_args = _get_rabit_args(context, num_workers)
+                if not run_tracker_on_driver:
+                    _rabit_args = _get_rabit_args(_get_host_ip(context), num_workers)
                 get_logger(_LOG_TAG, log_level).info(msg)
 
-            worker_message = {
-                "rabit_msg": _rabit_args,
+            worker_message: Dict[str, Any] = {
                 "use_qdm": use_qdm,
             }
+
+            if not run_tracker_on_driver:
+                worker_message["rabit_msg"] = _rabit_args
 
             messages = context.allGather(message=json.dumps(worker_message))
             if len(set(json.loads(x)["use_qdm"] for x in messages)) != 1:
                 raise RuntimeError("The workers' cudf environments are in-consistent ")
 
-            _rabit_args = json.loads(messages[0])["rabit_msg"]
+            if not run_tracker_on_driver:
+                _rabit_args = json.loads(messages[0])["rabit_msg"]
 
             evals_result: Dict[str, Any] = {}
             with CommunicatorContext(context, **_rabit_args):

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -1027,6 +1027,7 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
         launch_tracker_on_driver = self.getOrDefault(self.launch_tracker_on_driver)
         rabit_args = {}
         if launch_tracker_on_driver:
+            tracker_host: Optional[str] = None
             if self.isDefined(self.tracker_host):
                 tracker_host = self.getOrDefault(self.tracker_host)
             else:

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -1064,7 +1064,7 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
 
         num_workers = self.getOrDefault(self.num_workers)
 
-        launch_tracker_on_driver, rabit_args = self._get_tracker_args_on_driver()
+        launch_tracker_on_driver, rabit_args = self._get_tracker_args()
 
         log_level = get_logger_level(_LOG_TAG)
 

--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -1043,8 +1043,10 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
             rabit_args.update(_get_rabit_args(tracker_host, num_workers, tracker_port))
         else:
             if self.isDefined(self.tracker_host) or self.isDefined(self.tracker_port):
-                raise ValueError("You must enable launch_tracker_on_driver to use "
-                                 "tracker_host and tracker_port")
+                raise ValueError(
+                    "You must enable launch_tracker_on_driver to use "
+                    "tracker_host and tracker_port"
+                )
         return launch_tracker_on_driver, rabit_args
 
     def _fit(self, dataset: DataFrame) -> "_SparkXGBModel":

--- a/python-package/xgboost/spark/estimator.py
+++ b/python-package/xgboost/spark/estimator.py
@@ -161,6 +161,9 @@ class SparkXGBRegressor(_SparkXGBEstimator):
         Boolean value to specify if enabling sparse data optimization, if True,
         Xgboost DMatrix object will be constructed from sparse matrix instead of
         dense matrix.
+    tracker_on_driver:
+        Boolean value to indicate whether the tracker should be launched on the driver side or
+        the executor side.
 
     kwargs:
         A dictionary of xgboost parameters, please refer to
@@ -215,6 +218,7 @@ class SparkXGBRegressor(_SparkXGBEstimator):
         force_repartition: bool = False,
         repartition_random_shuffle: bool = False,
         enable_sparse_data_optim: bool = False,
+        tracker_on_driver: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -341,6 +345,9 @@ class SparkXGBClassifier(_SparkXGBEstimator, HasProbabilityCol, HasRawPrediction
         Boolean value to specify if enabling sparse data optimization, if True,
         Xgboost DMatrix object will be constructed from sparse matrix instead of
         dense matrix.
+    tracker_on_driver:
+        Boolean value to indicate whether the tracker should be launched on the driver side or
+        the executor side.
 
     kwargs:
         A dictionary of xgboost parameters, please refer to
@@ -395,6 +402,7 @@ class SparkXGBClassifier(_SparkXGBEstimator, HasProbabilityCol, HasRawPrediction
         force_repartition: bool = False,
         repartition_random_shuffle: bool = False,
         enable_sparse_data_optim: bool = False,
+        tracker_on_driver: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -524,6 +532,9 @@ class SparkXGBRanker(_SparkXGBEstimator):
         Boolean value to specify if enabling sparse data optimization, if True,
         Xgboost DMatrix object will be constructed from sparse matrix instead of
         dense matrix.
+    tracker_on_driver:
+        Boolean value to indicate whether the tracker should be launched on the driver side or
+        the executor side.
 
     kwargs:
         A dictionary of xgboost parameters, please refer to
@@ -584,6 +595,7 @@ class SparkXGBRanker(_SparkXGBEstimator):
         force_repartition: bool = False,
         repartition_random_shuffle: bool = False,
         enable_sparse_data_optim: bool = False,
+        tracker_on_driver: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__()

--- a/python-package/xgboost/spark/estimator.py
+++ b/python-package/xgboost/spark/estimator.py
@@ -161,7 +161,7 @@ class SparkXGBRegressor(_SparkXGBEstimator):
         Boolean value to specify if enabling sparse data optimization, if True,
         Xgboost DMatrix object will be constructed from sparse matrix instead of
         dense matrix.
-    tracker_on_driver:
+    launch_tracker_on_driver:
         Boolean value to indicate whether the tracker should be launched on the driver side or
         the executor side.
 
@@ -218,7 +218,7 @@ class SparkXGBRegressor(_SparkXGBEstimator):
         force_repartition: bool = False,
         repartition_random_shuffle: bool = False,
         enable_sparse_data_optim: bool = False,
-        tracker_on_driver: bool = True,
+        launch_tracker_on_driver: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -345,7 +345,7 @@ class SparkXGBClassifier(_SparkXGBEstimator, HasProbabilityCol, HasRawPrediction
         Boolean value to specify if enabling sparse data optimization, if True,
         Xgboost DMatrix object will be constructed from sparse matrix instead of
         dense matrix.
-    tracker_on_driver:
+    launch_tracker_on_driver:
         Boolean value to indicate whether the tracker should be launched on the driver side or
         the executor side.
 
@@ -402,7 +402,7 @@ class SparkXGBClassifier(_SparkXGBEstimator, HasProbabilityCol, HasRawPrediction
         force_repartition: bool = False,
         repartition_random_shuffle: bool = False,
         enable_sparse_data_optim: bool = False,
-        tracker_on_driver: bool = True,
+        launch_tracker_on_driver: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -532,7 +532,7 @@ class SparkXGBRanker(_SparkXGBEstimator):
         Boolean value to specify if enabling sparse data optimization, if True,
         Xgboost DMatrix object will be constructed from sparse matrix instead of
         dense matrix.
-    tracker_on_driver:
+    launch_tracker_on_driver:
         Boolean value to indicate whether the tracker should be launched on the driver side or
         the executor side.
 
@@ -595,7 +595,7 @@ class SparkXGBRanker(_SparkXGBEstimator):
         force_repartition: bool = False,
         repartition_random_shuffle: bool = False,
         enable_sparse_data_optim: bool = False,
-        tracker_on_driver: bool = True,
+        launch_tracker_on_driver: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__()

--- a/python-package/xgboost/spark/utils.py
+++ b/python-package/xgboost/spark/utils.py
@@ -51,10 +51,9 @@ class CommunicatorContext(CCtx):  # pylint: disable=too-few-public-methods
         super().__init__(**args)
 
 
-def _start_tracker(context: BarrierTaskContext, n_workers: int) -> Dict[str, Any]:
+def _start_tracker(host: str, n_workers: int) -> Dict[str, Any]:
     """Start Rabit tracker with n_workers"""
     args: Dict[str, Any] = {"n_workers": n_workers}
-    host = _get_host_ip(context)
     tracker = RabitTracker(n_workers=n_workers, host_ip=host, sortby="task")
     tracker.start()
     thread = Thread(target=tracker.wait_for)
@@ -64,9 +63,9 @@ def _start_tracker(context: BarrierTaskContext, n_workers: int) -> Dict[str, Any
     return args
 
 
-def _get_rabit_args(context: BarrierTaskContext, n_workers: int) -> Dict[str, Any]:
+def _get_rabit_args(host: str, n_workers: int) -> Dict[str, Any]:
     """Get rabit context arguments to send to each worker."""
-    env = _start_tracker(context, n_workers)
+    env = _start_tracker(host, n_workers)
     return env
 
 

--- a/python-package/xgboost/spark/utils.py
+++ b/python-package/xgboost/spark/utils.py
@@ -51,10 +51,10 @@ class CommunicatorContext(CCtx):  # pylint: disable=too-few-public-methods
         super().__init__(**args)
 
 
-def _start_tracker(host: str, n_workers: int) -> Dict[str, Any]:
+def _start_tracker(host: str, n_workers: int, port: int = 0) -> Dict[str, Any]:
     """Start Rabit tracker with n_workers"""
     args: Dict[str, Any] = {"n_workers": n_workers}
-    tracker = RabitTracker(n_workers=n_workers, host_ip=host, sortby="task")
+    tracker = RabitTracker(n_workers=n_workers, host_ip=host, sortby="task", port=port)
     tracker.start()
     thread = Thread(target=tracker.wait_for)
     thread.daemon = True
@@ -63,9 +63,9 @@ def _start_tracker(host: str, n_workers: int) -> Dict[str, Any]:
     return args
 
 
-def _get_rabit_args(host: str, n_workers: int) -> Dict[str, Any]:
+def _get_rabit_args(host: str, n_workers: int, port: int = 0) -> Dict[str, Any]:
     """Get rabit context arguments to send to each worker."""
-    env = _start_tracker(host, n_workers)
+    env = _start_tracker(host, n_workers, port)
     return env
 
 

--- a/tests/test_distributed/test_with_spark/test_spark_local.py
+++ b/tests/test_distributed/test_with_spark/test_spark_local.py
@@ -1631,18 +1631,28 @@ class XgboostLocalTest(SparkTestCase):
             SparkXGBClassifier(evals_result={})
 
     def test_tracker(self):
-        classifier = SparkXGBClassifier(launch_tracker_on_driver=True, tracker_host="192.168.1.32", tracker_port=59981)
+        classifier = SparkXGBClassifier(
+            launch_tracker_on_driver=True,
+            tracker_host="192.168.1.32",
+            tracker_port=59981,
+        )
         with pytest.raises(Exception, match="Failed to bind socket"):
             classifier._get_tracker_args()
 
-        classifier = SparkXGBClassifier(launch_tracker_on_driver=False, tracker_host="127.0.0.1", tracker_port=58892)
-        with pytest.raises(ValueError, match="You must enable launch_tracker_on_driver"):
+        classifier = SparkXGBClassifier(
+            launch_tracker_on_driver=False, tracker_host="127.0.0.1", tracker_port=58892
+        )
+        with pytest.raises(
+            ValueError, match="You must enable launch_tracker_on_driver"
+        ):
             classifier._get_tracker_args()
 
-        classifier = SparkXGBClassifier(launch_tracker_on_driver=True,
-                                        tracker_host="127.0.0.1",
-                                        tracker_port=58892,
-                                        num_workers=2)
+        classifier = SparkXGBClassifier(
+            launch_tracker_on_driver=True,
+            tracker_host="127.0.0.1",
+            tracker_port=58892,
+            num_workers=2,
+        )
         launch_tracker_on_driver, rabit_envs = classifier._get_tracker_args()
         assert launch_tracker_on_driver == True
         assert rabit_envs["n_workers"] == 2

--- a/tests/test_distributed/test_with_spark/test_spark_local.py
+++ b/tests/test_distributed/test_with_spark/test_spark_local.py
@@ -1630,6 +1630,24 @@ class XgboostLocalTest(SparkTestCase):
         with pytest.raises(ValueError, match="evals_result"):
             SparkXGBClassifier(evals_result={})
 
+    def test_tracker(self):
+        classifier = SparkXGBClassifier(launch_tracker_on_driver=True, tracker_host="192.168.1.32", tracker_port=59981)
+        with pytest.raises(Exception, match="Failed to bind socket"):
+            classifier._get_tracker_args()
+
+        classifier = SparkXGBClassifier(launch_tracker_on_driver=False, tracker_host="127.0.0.1", tracker_port=58892)
+        with pytest.raises(ValueError, match="You must enable launch_tracker_on_driver"):
+            classifier._get_tracker_args()
+
+        classifier = SparkXGBClassifier(launch_tracker_on_driver=True,
+                                        tracker_host="127.0.0.1",
+                                        tracker_port=58892,
+                                        num_workers=2)
+        launch_tracker_on_driver, rabit_envs = classifier._get_tracker_args()
+        assert launch_tracker_on_driver == True
+        assert rabit_envs["n_workers"] == 2
+        assert rabit_envs["dmlc_tracker_uri"] == "127.0.0.1"
+
 
 LTRData = namedtuple("LTRData", ("df_train", "df_test", "df_train_1"))
 


### PR DESCRIPTION
This PR adds 3 parameters for setting tracker,

- launch_tracker_on_driver: will start the tracker on the driver side
- tracker_host: specify the tracker host
- tracker_port: specify the port tracker will listen up.

tracker_host and tracker_port needs launch_tracker_on_driver to be enabled.

Below is the test case.

``` bash
df_train = spark.createDataFrame(
    [
        (Vectors.dense(1.0, 2.0, 3.0), 0, False, 1.0),
        (Vectors.sparse(3, {1: 1.0, 2: 5.5}), 1, False, 2.0),
        (Vectors.dense(4.0, 5.0, 6.0), 0, True, 1.0),
        (Vectors.sparse(3, {1: 6.0, 2: 7.5}), 1, True, 2.0),
    ]
    * 100,
    ["features", "label", "isVal", "weight"],
)

from xgboost.spark import SparkXGBRegressor

callbacks = EvaluationMonitor()
xgb_regressor = SparkXGBRegressor(
    num_workers=5,
    callbacks=[callbacks],
    validation_indicator_col="isVal",
    launch_tracker_on_driver=True,
    tracker_host="192.168.1.32",
    tracker_port=0,
)
xgb_reg_model = xgb_regressor.fit(df_train)
```
With the above test code, The below log will be printed on the driver. Or else, they will be printed on the executor side.

``` bash
[0]	training-rmse:0.35149	validation-rmse:0.35149
[0]	training-rmse:0.35149	validation-rmse:0.35149
[1]	training-rmse:0.24708	validation-rmse:0.24708
[1]	training-rmse:0.24708	validation-rmse:0.24708
[2]	training-rmse:0.17369	validation-rmse:0.17369
[2]	training-rmse:0.17369	validation-rmse:0.17369
[3]	training-rmse:0.12210	validation-rmse:0.12210
[3]	training-rmse:0.12210	validation-rmse:0.12210
[4]	training-rmse:0.08583	validation-rmse:0.08583
[4]	training-rmse:0.08583	validation-rmse:0.08583
[5]	training-rmse:0.06034	validation-rmse:0.06034
[5]	training-rmse:0.06034	validation-rmse:0.06034
[6]	training-rmse:0.04242	validation-rmse:0.04242
...
```


