### PR TITLE
[CI] add script to generate meta info and upload to s3

### DIFF
--- a/tests/buildkite/build-cuda.sh
+++ b/tests/buildkite/build-cuda.sh
@@ -54,6 +54,12 @@ if [[ ($is_pull_request == 0) && ($is_release_branch == 1) ]]
 then
   aws s3 cp python-package/dist/*.whl s3://xgboost-nightly-builds/${BRANCH_NAME}/ \
     --acl public-read --no-progress
+
+  # Generate the meta info which includes xgboost version and the commit info
+  whl_name=`basename $(ls python-package/dist/*.whl | head -n 1)`
+  tests/ci_build/generate_meta.sh $whl_name python-package/dist/meta.xml
+  aws s3 cp python-package/dist/meta.xml s3://xgboost-nightly-builds/${BRANCH_NAME}/ \
+    --acl public-read --no-progress
 fi
 echo "-- Stash C++ test executable (testxgboost)"
 buildkite-agent artifact upload build/testxgboost

--- a/tests/ci_build/generate_meta.sh
+++ b/tests/ci_build/generate_meta.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+whl_name=$1
+dest_file=$2
+
+ver_commit=`echo $1 | awk -F- '{print $2}'`
+ver=`echo $ver_commit | awk -F+ '{print $1}'`
+commit_id=`echo $ver_commit | awk -F+ '{print $2}'`
+
+cat << EOF > $dest_file
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <version>${ver}</version>
+  <commit>${commit_id}</commit>
+</root>
+EOF
+


### PR DESCRIPTION
I would like to add a meta file to describe the latest xgboost nightly build info including xgboost version and commit id, and then upload it to s3, the file looks like that,

meta.xml

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<root>
  <version>2.1.0.dev0</version>
  <commit>ee2afb3256ce2f333c0da56408dfc7360bbf8b7a</commit>
</root>

```

Hi @hcho3 Could you help review it.