### PR TITLE
[coll] Keep the tracker alive during initialization error.

### DIFF
--- a/src/collective/tracker.cc
+++ b/src/collective/tracker.cc
@@ -286,7 +286,8 @@ Result RabitTracker::Bootstrap(std::vector<WorkerProxy>* p_workers) {
 
       auto worker = WorkerProxy{n_workers_, std::move(sock), std::move(addr)};
       if (!worker.Status().OK()) {
-        return Fail("Failed to initialize worker proxy.", std::move(worker.Status()));
+        LOG(WARNING) << "Failed to initialize worker proxy." << worker.Status().Report();
+        continue;
       }
       switch (worker.Command()) {
         case proto::CMD::kStart: {


### PR DESCRIPTION
This prevents the tracker from throwing additional errors, which breaks the assumption in the jvm package that errors are expected to be thrown in the executor.