### PR TITLE
Add timeout for distributed tests.

### DIFF
--- a/src/collective/coll.cu
+++ b/src/collective/coll.cu
@@ -191,7 +191,7 @@ Result BroadcastAllgatherV(NCCLComm const* comm, common::Span<std::int8_t const>
     for (std::int32_t r = 0; r < comm->World(); ++r) {
       auto as_bytes = sizes[r];
       auto rc = stub->Broadcast(data.data(), recv.subspan(offset, as_bytes).data(), as_bytes,
-                                ncclInt8, r, comm->Handle(), dh::DefaultStream());
+                                ncclInt8, r, comm->Handle(), comm->Stream());
       if (!rc.OK()) {
         return rc;
       }


### PR DESCRIPTION
I don't have a fix for https://github.com/dmlc/xgboost/issues/10312 yet, the deadlock is inside CUDA runtime. This PR only helps prevent a CI stall.