### PR TITLE
[R] Fix incorrect division of classification/ranking objectives

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -27,8 +27,7 @@ NVL <- function(x, val) {
 }
 
 .RANKING_OBJECTIVES <- function() {
-  return(c('binary:logistic', 'binary:logitraw', 'binary:hinge', 'multi:softmax',
-           'multi:softprob'))
+  return(c('rank:pairwise', 'rank:ndcg', 'rank:map'))
 }
 
 


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

In previous PR: https://github.com/dmlc/xgboost/pull/10031

There was a workaround introduced to determine when to default to stratification for `xgb.cv` which involved checking which classification objectives were for ranking and which weren't.

Unfortunately the categorization was done incorrectly. This PR fixes it.