### PR TITLE
[coll] Increase timeout limit.

### DIFF
--- a/src/collective/comm.h
+++ b/src/collective/comm.h
@@ -20,7 +20,7 @@
 
 namespace xgboost::collective {
 
-inline constexpr std::int64_t DefaultTimeoutSec() { return 300; }  // 5min
+inline constexpr std::int64_t DefaultTimeoutSec() { return 60 * 30; }  // 30min
 inline constexpr std::int32_t DefaultRetry() { return 3; }
 
 // indexing into the ring


### PR DESCRIPTION
One of the pyspark workflows ran into troubles due to timeout. One of the workers started constructing QDM while another one took more than 5 minutes after the first one to get started. The time was spent on the `cache_partitions` function. Not much can be done in XGBoost since it's simply fetching partitions from pyspark.

This PR increases the timeout to 30 minutes from 5 minutes. Please note that, the timeout is caused by the difference between workers, which should be minimal for normal workflows.