### PR TITLE
Fix typo & format in C API documentation

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -1265,13 +1265,11 @@ XGB_DLL int XGBoosterLoadModelFromBuffer(BoosterHandle handle,
  * \param handle handle
  * \param config JSON encoded string storing parameters for the function.  Following
  *               keys are expected in the JSON document:
- *
- *     "format": str
- *       - json: Output booster will be encoded as JSON.
- *       - ubj:  Output booster will be encoded as Univeral binary JSON.
- *       - deprecated: Output booster will be encoded as old custom binary format.  Do not use
- *         this format except for compatibility reasons.
- *
+ *               - "format": str
+ *                 - json: Output booster will be encoded as JSON.
+ *                 - ubj:  Output booster will be encoded as Universal binary JSON.
+ *                 - deprecated: Output booster will be encoded as old custom binary format.  Do not use
+ *                   this format except for compatibility reasons.
  * \param out_len  The argument to hold the output length
  * \param out_dptr The argument to hold the output data pointer
  *


### PR DESCRIPTION
Fix typo : `Univeral` -> `Universal`

Also, the format of the Doxygen was wrong : the list `format` is supposed to be displayed within the `config` argument, but in the documentation, it's displayed outside : 

![Screenshot 2024-05-30 at 10 51 31 PM](https://github.com/dmlc/xgboost/assets/43774355/53043699-716c-4020-b3ff-1e1cbac85b38)

---

Disclaimer : I couldn't build the docs locally, I couldn't test my changes.