### PR TITLE
Sync stream in ellpack format.

### DIFF
--- a/src/data/ellpack_page_raw_format.cu
+++ b/src/data/ellpack_page_raw_format.cu
@@ -36,6 +36,7 @@ class EllpackPageRawFormat : public SparsePageFormat<EllpackPage> {
     if (!fi->Read(&impl->base_rowid)) {
       return false;
     }
+    dh::DefaultStream().Sync();
     return true;
   }
 


### PR DESCRIPTION
Since we are reusing the threads in https://github.com/dmlc/xgboost/pull/10288 , and the default CUDA stream is thread stream, it's safer for us to synchronize it after reading.