### PR TITLE
[CI] Use Python 3.10 to build docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ submodules:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
   apt_packages:
     - graphviz
     - cmake


### PR DESCRIPTION
Latest Sphinx dropped support for Python 3.8 (https://github.com/sphinx-doc/sphinx/pull/11511).