### PR TITLE
[jvm-packages] Don't cast to float if it's already float

### DIFF
--- a/jvm-packages/xgboost4j-spark-gpu/src/main/scala/ml/dmlc/xgboost4j/scala/rapids/spark/GpuUtils.scala
+++ b/jvm-packages/xgboost4j-spark-gpu/src/main/scala/ml/dmlc/xgboost4j/scala/rapids/spark/GpuUtils.scala
@@ -89,9 +89,13 @@ private[spark] object GpuUtils {
     val featureNameSet = featureNames.distinct
     validateSchema(dataset.schema, featureNameSet, labelName, weightName, marginName, fitting)
 
-    val castToFloat = (ds: Dataset[_], colName: String) => {
-      val colMeta = ds.schema(colName).metadata
-      ds.withColumn(colName, col(colName).as(colName, colMeta).cast(FloatType))
+    val castToFloat = (df: DataFrame, colName: String) => {
+      if (df.schema(colName).dataType.isInstanceOf[FloatType]) {
+        df
+      } else {
+        val colMeta = df.schema(colName).metadata
+        df.withColumn(colName, col(colName).as(colName, colMeta).cast(FloatType))
+      }
     }
     val colNames = if (fitting) {
       var names = featureNameSet :+ labelName


### PR DESCRIPTION
`cast to float` is quite slow when the number of feature columns is a little bit larger like 750, the `castToFloat` will take about **540s** to finish on the driver side. 

The original code will force to cast all the feature columns to the float even if some of them are already floats. So this PR just cast not-float features to float to avoid un-necessary casting. With this PR, if the 750 features are all floats, it can eliminate the 540s.

But if the features are not float, xgboost still need to cast them to floats, which is really bad. So I will create a follow up to make XGBoost4j GPU to support the numerical types.

