### PR TITLE
Partial fixups for federated tests

### DIFF
--- a/plugin/federated/README.md
+++ b/plugin/federated/README.md
@@ -10,7 +10,7 @@ Test Federated XGBoost
 ----------------------
 ```shell
 # Under xgboost source tree.
-cd tests/distributed/test_federated
+cd tests/test_distributed/test_federated
 # This tests both CPU training (`hist`) and GPU training (`gpu_hist`).
 ./runtests-federated.sh
 ```

--- a/python-package/xgboost/federated.py
+++ b/python-package/xgboost/federated.py
@@ -69,14 +69,22 @@ def run_federated_server(  # pylint: disable=too-many-arguments
 ) -> Dict[str, Any]:
     """See :py:class:`~xgboost.federated.FederatedTracker` for more info."""
     args: Dict[str, Any] = {"n_workers": n_workers}
+    args['port'] = port
+    args['timeout'] = timeout
+
     secure = all(
         path is not None
         for path in [server_key_path, server_cert_path, client_cert_path]
     )
-    tracker = FederatedTracker(
-        n_workers=n_workers, port=port, secure=secure, timeout=timeout
-    )
+    args['secure'] = secure
+    if secure:
+        args['server_key_path'] = server_key_path
+        args['server_cert_path'] = server_cert_path
+        args['client_cert_path'] = client_cert_path
+
+    tracker = FederatedTracker(**args)
     tracker.start()
+    print('args', tracker.worker_args())
 
     thread = Thread(target=tracker.wait_for)
     thread.daemon = True

--- a/python-package/xgboost/federated.py
+++ b/python-package/xgboost/federated.py
@@ -60,8 +60,8 @@ class FederatedTracker(RabitTracker):
 
 
 def run_federated_server(  # pylint: disable=too-many-arguments
-    n_workers: int,
     port: int,
+    n_workers: int,
     server_key_path: Optional[str] = None,
     server_cert_path: Optional[str] = None,
     client_cert_path: Optional[str] = None,
@@ -84,7 +84,6 @@ def run_federated_server(  # pylint: disable=too-many-arguments
 
     tracker = FederatedTracker(**args)
     tracker.start()
-    print('args', tracker.worker_args())
 
     thread = Thread(target=tracker.wait_for)
     thread.daemon = True


### PR DESCRIPTION
When I tried to run federated learning tests following the directions in https://github.com/dmlc/xgboost/blob/master/plugin/federated/README.md, I ran into several problems.

1. The path to the tests is wrong in the README; that's fixed in this PR.
2. All calls to `run_federated_server` swap the order of the first two arguments. I decided to change the order of the parameters rather than change each call to the function. 
3. `run_federated_server` doesn't supply the key/certificate paths when creating a `FederatedTracker`.

Note that I still cannot get the tests to work even with these changes; now they fail without a helpful error:
```
[21:45:11] Insecure federated server listening on 0.0.0.0:9091, world size 2
Traceback (most recent call last):
  File "/home/ubuntu/xgboost/tests/test_distributed/test_federated/test_federated.py", line 84, in <module>
    run_federated(with_ssl=False, with_gpu=False)
  File "/home/ubuntu/xgboost/tests/test_distributed/test_federated/test_federated.py", line 69, in run_federated
    raise Exception("Error starting Federated Learning server")
Exception: Error starting Federated Learning server
```