### PR TITLE
[pyspark] Allow to avoid repartition 

### DIFF
--- a/doc/tutorials/spark_estimator.rst
+++ b/doc/tutorials/spark_estimator.rst
@@ -267,7 +267,7 @@ An example submit command is shown below with additional spark configurations an
     --conf spark.task.cpus=1 \
     --conf spark.executor.resource.gpu.amount=1 \
     --conf spark.task.resource.gpu.amount=0.08 \
-    --packages com.nvidia:rapids-4-spark_2.12:23.04.0 \
+    --packages com.nvidia:rapids-4-spark_2.12:24.04.1 \
     --conf spark.plugins=com.nvidia.spark.SQLPlugin \
     --conf spark.sql.execution.arrow.maxRecordsPerBatch=1000000 \
     --archives xgboost_env.tar.gz#environment \
@@ -276,3 +276,11 @@ An example submit command is shown below with additional spark configurations an
 When rapids plugin is enabled, both of the JVM rapids plugin and the cuDF Python package
 are required. More configuration options can be found in the RAPIDS link above along with
 details on the plugin.
+
+Advanced Usage
+==============
+
+XGBoost needs to repartition to the num_workers to ensure there will be num_workers training
+tasks running at the same time, but repartition is a costly operation. To avoid repartition,
+users can set ``spark.sql.files.maxPartitionNum`` and ``spark.sql.files.minPartitionNum``
+to num_workers.

--- a/doc/tutorials/spark_estimator.rst
+++ b/doc/tutorials/spark_estimator.rst
@@ -280,7 +280,15 @@ details on the plugin.
 Advanced Usage
 ==============
 
-XGBoost needs to repartition to the num_workers to ensure there will be num_workers training
-tasks running at the same time, but repartition is a costly operation. To avoid repartition,
-users can set ``spark.sql.files.maxPartitionNum`` and ``spark.sql.files.minPartitionNum``
-to num_workers.
+XGBoost needs to repartition the input dataset to the num_workers to ensure there will be
+num_workers training tasks running at the same time. However, repartition is a costly operation.
+
+To avoid the need for repartitioning, users can set the Spark configuration parameters
+``spark.sql.files.maxPartitionNum`` and ``spark.sql.files.minPartitionNum`` to num_workers.
+This tells Spark to automatically partition the dataset into the desired number of partitions.
+
+However, if the input dataset is skewed (i.e. the data is not evenly distributed), setting
+the partition number to num_workers may not be sufficient. In this case, users can set
+the ``force_repartition=true`` option to explicitly force XGBoost to repartition the dataset,
+even if the partition number is already equal to num_workers. This ensures the data is evenly
+distributed across the workers.

--- a/doc/tutorials/spark_estimator.rst
+++ b/doc/tutorials/spark_estimator.rst
@@ -283,12 +283,14 @@ Advanced Usage
 XGBoost needs to repartition the input dataset to the num_workers to ensure there will be
 num_workers training tasks running at the same time. However, repartition is a costly operation.
 
-To avoid the need for repartitioning, users can set the Spark configuration parameters
-``spark.sql.files.maxPartitionNum`` and ``spark.sql.files.minPartitionNum`` to num_workers.
-This tells Spark to automatically partition the dataset into the desired number of partitions.
+If there is a scenario where reading the data from source and directly fitting it to XGBoost
+without introducing the shuffle stage, users can avoid the need for repartitioning by setting
+the Spark configuration parameters ``spark.sql.files.maxPartitionNum`` and
+``spark.sql.files.minPartitionNum`` to num_workers. This tells Spark to automatically partition
+the dataset into the desired number of partitions.
 
 However, if the input dataset is skewed (i.e. the data is not evenly distributed), setting
-the partition number to num_workers may not be sufficient. In this case, users can set
+the partition number to num_workers may not be efficient. In this case, users can set
 the ``force_repartition=true`` option to explicitly force XGBoost to repartition the dataset,
 even if the partition number is already equal to num_workers. This ensures the data is evenly
 distributed across the workers.

--- a/tests/test_distributed/test_with_spark/test_spark_local_cluster.py
+++ b/tests/test_distributed/test_with_spark/test_spark_local_cluster.py
@@ -474,7 +474,7 @@ class XgboostLocalClusterTestCase(SparkLocalClusterTestCase):
 
         classifier = SparkXGBClassifier(num_workers=self.n_workers)
         basic = self.cls_df_train_distributed
-        self.assertTrue(classifier._repartition_needed(basic))
+        self.assertTrue(not classifier._repartition_needed(basic))
         bad_repartitioned = basic.repartition(self.n_workers + 1)
         self.assertTrue(classifier._repartition_needed(bad_repartitioned))
         good_repartitioned = basic.repartition(self.n_workers)


### PR DESCRIPTION
The current xgboost pyspark will not repartition the dataset only when the last operator of input dataset is repartition and the repartitioned number is equal to num_workers. Overall, this looks good. But we should also keep in mind that repartition is really expensive especially for the GPU  case, the repartition probably dominates the most of training time.  

There is a real xgboost case that reading from file directly using spark and then fit the data into xgboost estimator.  So for this kind of case, we can make the partition number equal to num_workers by playing with some spark configurations, and the data partitions should have been well balanced by spark. So I think, it's safe for xgboost to skip the repartition internally  which can really improve the whole xgboost end to end time.

And on the other hand, xgboost already supports the force_repartition, so if user really would like to enable the repartition, they can set force_repartition to true.