### PR TITLE
[WIP] Federated learning plugin.

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -39,7 +39,7 @@ enum class DataType : uint8_t {
 
 enum class FeatureType : uint8_t { kNumerical = 0, kCategorical = 1 };
 
-enum class DataSplitMode : int { kRow = 0, kCol = 1, kColSecure = 2 };
+enum class DataSplitMode : int { kRow = 0, kCol = 1, kColSecure = 2, kRowSecure = 3 };
 
 /*!
  * \brief Meta information about dataset, always sit in memory.
@@ -171,17 +171,19 @@ class MetaInfo {
    */
   void SynchronizeNumberOfColumns(Context const* ctx);
 
-  /*! \brief Whether the data is split row-wise. */
-  bool IsRowSplit() const {
-    return data_split_mode == DataSplitMode::kRow;
+  /** @brief Whether the data is split row-wise. */
+  [[nodiscard]] bool IsRowSplit() const {
+    return data_split_mode == DataSplitMode::kRow || data_split_mode == DataSplitMode::kRowSecure;
   }
 
   /** @brief Whether the data is split column-wise. */
-  bool IsColumnSplit() const { return (data_split_mode == DataSplitMode::kCol)
-  || (data_split_mode == DataSplitMode::kColSecure); }
+  [[nodiscard]] bool IsColumnSplit() const { return !this->IsRowSplit(); }
 
-  /** @brief Whether the data is split column-wise with secure computation. */
-  bool IsSecure() const { return data_split_mode == DataSplitMode::kColSecure; }
+  /** @brief Whether the data is split with secure computation. */
+  [[nodiscard]] bool IsSecure() const {
+    return data_split_mode == DataSplitMode::kColSecure ||
+           data_split_mode == DataSplitMode::kRowSecure;
+  }
 
   /** @brief Whether this is a learning to rank data. */
   bool IsRanking() const { return !group_ptr_.empty(); }

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -39,7 +39,7 @@ enum class DataType : uint8_t {
 
 enum class FeatureType : uint8_t { kNumerical = 0, kCategorical = 1 };
 
-enum class DataSplitMode : int { kRow = 0, kCol = 1, kColSecure = 2, kRowSecure = 3 };
+enum class DataSplitMode : int { kRow = 0, kCol = 1 };
 
 /*!
  * \brief Meta information about dataset, always sit in memory.
@@ -172,18 +172,10 @@ class MetaInfo {
   void SynchronizeNumberOfColumns(Context const* ctx);
 
   /** @brief Whether the data is split row-wise. */
-  [[nodiscard]] bool IsRowSplit() const {
-    return data_split_mode == DataSplitMode::kRow || data_split_mode == DataSplitMode::kRowSecure;
-  }
+  [[nodiscard]] bool IsRowSplit() const { return data_split_mode == DataSplitMode::kRow; }
 
   /** @brief Whether the data is split column-wise. */
   [[nodiscard]] bool IsColumnSplit() const { return !this->IsRowSplit(); }
-
-  /** @brief Whether the data is split with secure computation. */
-  [[nodiscard]] bool IsSecure() const {
-    return data_split_mode == DataSplitMode::kColSecure ||
-           data_split_mode == DataSplitMode::kRowSecure;
-  }
 
   /** @brief Whether this is a learning to rank data. */
   bool IsRanking() const { return !group_ptr_.empty(); }

--- a/include/xgboost/linalg.h
+++ b/include/xgboost/linalg.h
@@ -663,6 +663,11 @@ auto MakeVec(T *ptr, size_t s, DeviceOrd device = DeviceOrd::CPU()) {
 }
 
 template <typename T>
+auto MakeVec(common::Span<T> data, DeviceOrd device = DeviceOrd::CPU()) {
+  return linalg::TensorView<T, 1>{data, {data.size()}, device};
+}
+
+template <typename T>
 auto MakeVec(HostDeviceVector<T> *data) {
   return MakeVec(data->Device().IsCPU() ? data->HostPointer() : data->DevicePointer(), data->Size(),
                  data->Device());

--- a/plugin/example/custom_obj.cc
+++ b/plugin/example/custom_obj.cc
@@ -69,7 +69,7 @@ class MyLogistic : public ObjFunction {
 
   void SaveConfig(Json* p_out) const override {
     auto& out = *p_out;
-    out["name"] = String("my_logistic");
+    out["name"] = String("mylogistic");
     out["my_logistic_param"] = ToJson(param_);
   }
 

--- a/plugin/federated/CMakeLists.txt
+++ b/plugin/federated/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(federated_client INTERFACE federated_proto)
 # Rabit engine for Federated Learning.
 target_sources(
   objxgboost PRIVATE
-  federated_plugin.cc federated_tracker.cc federated_comm.cc federated_coll.cc
+  federated_plugin.cc federated_hist.cc federated_tracker.cc federated_comm.cc federated_coll.cc
 )
 if(USE_CUDA)
   target_sources(objxgboost PRIVATE federated_comm.cu federated_coll.cu)

--- a/plugin/federated/CMakeLists.txt
+++ b/plugin/federated/CMakeLists.txt
@@ -37,7 +37,8 @@ target_link_libraries(federated_client INTERFACE federated_proto)
 
 # Rabit engine for Federated Learning.
 target_sources(
-  objxgboost PRIVATE federated_tracker.cc federated_comm.cc federated_coll.cc
+  objxgboost PRIVATE
+  federated_plugin.cc federated_tracker.cc federated_comm.cc federated_coll.cc
 )
 if(USE_CUDA)
   target_sources(objxgboost PRIVATE federated_comm.cu federated_coll.cu)

--- a/plugin/federated/federated_coll.cc
+++ b/plugin/federated/federated_coll.cc
@@ -148,15 +148,7 @@ Coll *FederatedColl::MakeCUDAVar() {
     return GetGRPCResult("AllgatherV", status);
   }
   std::string const &r = reply.receive_buffer();
-  // if (r.size() != recv.size()) {
-  //   std::stringstream ss;
-  //   ss << "[xgboosg]: r:" << r.size() << ", recv:" << recv.size() << std::endl;
-  //   for (auto v : r) {
-  //     ss << int(v) << ", ";
-  //   }
-  //   std::cout << ss.str() << std::endl;
-  // }
-  // CHECK_EQ(r.size(), recv.size());
+  CHECK_EQ(r.size(), recv.size());
   std::copy_n(r.cbegin(), r.size(), recv.begin());
   return Success();
 }

--- a/plugin/federated/federated_coll.cc
+++ b/plugin/federated/federated_coll.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, XGBoost contributors
+ * Copyright 2023-2024, XGBoost contributors
  */
 #include "federated_coll.h"
 
@@ -8,10 +8,14 @@
 
 #include <algorithm>  // for copy_n
 
-#include "../../src/collective/allgather.h"
-#include "../../src/common/common.h"    // for AssertGPUSupport
 #include "federated_comm.h"             // for FederatedComm
 #include "xgboost/collective/result.h"  // for Result
+
+#if !defined(XGBOOST_USE_CUDA)
+
+#include "../../src/common/common.h"  // for AssertGPUSupport
+
+#endif  // !defined(XGBOOST_USE_CUDA)
 
 namespace xgboost::collective {
 namespace {
@@ -144,7 +148,15 @@ Coll *FederatedColl::MakeCUDAVar() {
     return GetGRPCResult("AllgatherV", status);
   }
   std::string const &r = reply.receive_buffer();
-  CHECK_EQ(r.size(), recv.size());
+  // if (r.size() != recv.size()) {
+  //   std::stringstream ss;
+  //   ss << "[xgboosg]: r:" << r.size() << ", recv:" << recv.size() << std::endl;
+  //   for (auto v : r) {
+  //     ss << int(v) << ", ";
+  //   }
+  //   std::cout << ss.str() << std::endl;
+  // }
+  // CHECK_EQ(r.size(), recv.size());
   std::copy_n(r.cbegin(), r.size(), recv.begin());
   return Success();
 }

--- a/plugin/federated/federated_comm.cc
+++ b/plugin/federated/federated_comm.cc
@@ -128,11 +128,7 @@ FederatedComm::FederatedComm(std::int32_t retry, std::chrono::seconds timeout, s
   /**
    * Hist encryption plugin.
    */
-  auto plugin = OptionalArg<Object>(config, "federated_plugin", Object::Map{});
-  if (!plugin.empty()) {
-    auto path = get<String>(plugin["path"]);
-    this->plugin_ = std::make_shared<FederatedPlugin>(path.c_str(), config["federated_plugin"]);
-  }
+  this->plugin_.reset(CreateFederatedPlugin(config));
 
   this->Init(parsed[0], std::stoi(parsed[1]), world_size, rank, server_cert, client_key,
              client_cert);

--- a/plugin/federated/federated_comm.h
+++ b/plugin/federated/federated_comm.h
@@ -19,7 +19,7 @@ namespace xgboost::collective {
 class FederatedComm : public HostComm {
   std::shared_ptr<federated::Federated::Stub> stub_;
   // Plugin for encryption
-  std::shared_ptr<FederatedPlugin> plugin_{nullptr};
+  std::shared_ptr<FederatedPluginBase> plugin_{nullptr};
 
   void Init(std::string const& host, std::int32_t port, std::int32_t world, std::int32_t rank,
             std::string const& server_cert, std::string const& client_key,

--- a/plugin/federated/federated_comm.h
+++ b/plugin/federated/federated_comm.h
@@ -6,16 +6,20 @@
 #include <federated.grpc.pb.h>
 #include <federated.pb.h>
 
+#include <chrono>   // for seconds
 #include <cstdint>  // for int32_t
-#include <memory>   // for unique_ptr
+#include <memory>   // for shared_ptr
 #include <string>   // for string
 
-#include "../../src/collective/comm.h"    // for HostComm
+#include "../../src/collective/comm.h"  // for HostComm
+#include "federated_plugin.h"           // for FederatedPlugin
 #include "xgboost/json.h"
 
 namespace xgboost::collective {
 class FederatedComm : public HostComm {
   std::shared_ptr<federated::Federated::Stub> stub_;
+  // Plugin for encryption
+  std::shared_ptr<FederatedPlugin> plugin_{nullptr};
 
   void Init(std::string const& host, std::int32_t port, std::int32_t world, std::int32_t rank,
             std::string const& server_cert, std::string const& client_key,
@@ -46,10 +50,6 @@ class FederatedComm : public HostComm {
    */
   explicit FederatedComm(std::int32_t retry, std::chrono::seconds timeout, std::string task_id,
                          Json const& config);
-  explicit FederatedComm(std::string const& host, std::int32_t port, std::int32_t world,
-                         std::int32_t rank) {
-    this->Init(host, port, world, rank, {}, {}, {});
-  }
   [[nodiscard]] Result Shutdown() final {
     this->ResetState();
     return Success();
@@ -76,5 +76,7 @@ class FederatedComm : public HostComm {
     *out = "rank:" + std::to_string(rank);
     return Success();
   };
+
+  auto EncryptionPlugin() const { return plugin_; }
 };
 }  // namespace xgboost::collective

--- a/plugin/federated/federated_comm.h
+++ b/plugin/federated/federated_comm.h
@@ -8,7 +8,7 @@
 
 #include <chrono>   // for seconds
 #include <cstdint>  // for int32_t
-#include <memory>   // for shared_ptr, dynamic_pointer_cast
+#include <memory>   // for shared_ptr
 #include <string>   // for string
 
 #include "../../src/collective/comm.h"  // for HostComm
@@ -65,10 +65,7 @@ class FederatedComm : public HostComm {
     return Success();
   }
   [[nodiscard]] bool IsFederated() const override { return true; }
-  [[nodiscard]] bool IsEncrypted() const override {
-    auto mock_ptr = std::dynamic_pointer_cast<FederatedPluginMock>(plugin_);
-    return !mock_ptr;
-  }
+  [[nodiscard]] bool IsEncrypted() const override { return static_cast<bool>(plugin_); }
   [[nodiscard]] federated::Federated::Stub* Handle() const { return stub_.get(); }
 
   [[nodiscard]] Comm* MakeCUDAVar(Context const* ctx, std::shared_ptr<Coll> pimpl) const override;

--- a/plugin/federated/federated_comm.h
+++ b/plugin/federated/federated_comm.h
@@ -8,7 +8,7 @@
 
 #include <chrono>   // for seconds
 #include <cstdint>  // for int32_t
-#include <memory>   // for shared_ptr
+#include <memory>   // for shared_ptr, dynamic_pointer_cast
 #include <string>   // for string
 
 #include "../../src/collective/comm.h"  // for HostComm
@@ -65,6 +65,10 @@ class FederatedComm : public HostComm {
     return Success();
   }
   [[nodiscard]] bool IsFederated() const override { return true; }
+  [[nodiscard]] bool IsEncrypted() const override {
+    auto mock_ptr = std::dynamic_pointer_cast<FederatedPluginMock>(plugin_);
+    return !mock_ptr;
+  }
   [[nodiscard]] federated::Federated::Stub* Handle() const { return stub_.get(); }
 
   [[nodiscard]] Comm* MakeCUDAVar(Context const* ctx, std::shared_ptr<Coll> pimpl) const override;

--- a/plugin/federated/federated_hist.cc
+++ b/plugin/federated/federated_hist.cc
@@ -93,6 +93,13 @@ void FederataedHistPolicy::DoSyncHistogram(Context const *ctx, RegTree const *p_
       std::int32_t n_workers = collective::GetWorldSize();
       bst_idx_t worker_size = hist_aggr.size() / n_workers;
       CHECK_EQ(hist_aggr.size() % n_workers, 0);
+      // Initialize histogram. For the normal case, this is done by the parallel hist
+      // buffer. We should try to unify the code paths.
+      for (auto nidx : nodes_to_build) {
+        auto hist_dst = hist[nidx];
+        std::fill_n(hist_dst.data(), hist_dst.size(), GradientPairPrecise{});
+      }
+
       // for each worker
       for (auto widx = 0; widx < n_workers; ++widx) {
         auto worker_hist = hist_aggr.subspan(widx * worker_size, worker_size);

--- a/plugin/federated/federated_hist.cc
+++ b/plugin/federated/federated_hist.cc
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2024, XGBoost contributors
+ */
+#include "federated_hist.h"
+
+#include "../../src/collective/allgather.h"         // for AllgatherV
+#include "../../src/collective/communicator-inl.h"  // for GetRank
+#include "../../src/tree/hist/histogram.h"
+
+namespace xgboost::tree {
+template <bool any_missing>
+void FederataedHistPolicy::DoBuildLocalHistograms(
+    common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+    std::vector<bst_node_t> const &nodes_to_build,
+    common::RowSetCollection const &row_set_collection, common::Span<GradientPair const> gpair_h,
+    bool force_read_by_column, common::ParallelGHistBuilder *buffer) {
+  if (is_col_split_) {
+    // Call the interface to transmit gidx information to the secure worker for encrypted
+    // histogram computation
+    auto cuts = gidx.Cuts().Ptrs();
+    // fixme: this can be done during reset.
+    if (!is_aggr_context_initialized_) {
+      auto slots = std::vector<int>();
+      auto num_rows = gidx.Size();
+      for (std::size_t row = 0; row < num_rows; row++) {
+        for (std::size_t f = 0; f < cuts.size() - 1; f++) {
+          auto slot = gidx.GetGindex(row, f);
+          slots.push_back(slot);
+        }
+      }
+      plugin_->Reset(cuts, slots);
+      is_aggr_context_initialized_ = true;
+    }
+
+    // Further use the row set collection info to
+    // get the encrypted histogram from the secure worker
+    std::vector<std::uint64_t const *> ptrs(nodes_to_build.size());
+    std::vector<std::size_t> sizes(nodes_to_build.size());
+    std::vector<bst_node_t> nodes(nodes_to_build.size());
+    for (std::size_t i = 0; i < nodes_to_build.size(); ++i) {
+      auto nidx = nodes_to_build[i];
+      ptrs[i] = row_set_collection[nidx].begin;
+      sizes[i] = row_set_collection[nidx].Size();
+      nodes[i] = nidx;
+    }
+    hist_data_ = this->plugin_->BuildEncryptedHistVert(ptrs, sizes, nodes);
+  } else {
+    BuildSampleHistograms<any_missing>(this->n_threads_, space, gidx, nodes_to_build,
+                                       row_set_collection, gpair_h, force_read_by_column, buffer);
+  }
+}
+
+template void FederataedHistPolicy::DoBuildLocalHistograms<true>(
+    common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+    std::vector<bst_node_t> const &nodes_to_build,
+    common::RowSetCollection const &row_set_collection, common::Span<GradientPair const> gpair_h,
+    bool force_read_by_column, common::ParallelGHistBuilder *buffer);
+template void FederataedHistPolicy::DoBuildLocalHistograms<false>(
+    common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+    std::vector<bst_node_t> const &nodes_to_build,
+    common::RowSetCollection const &row_set_collection, common::Span<GradientPair const> gpair_h,
+    bool force_read_by_column, common::ParallelGHistBuilder *buffer);
+
+void FederataedHistPolicy::DoSyncHistogram(Context const *ctx, RegTree const *p_tree,
+                                           std::vector<bst_node_t> const &nodes_to_build,
+                                           std::vector<bst_node_t> const &nodes_to_trick,
+                                           common::ParallelGHistBuilder *buffer,
+                                           tree::BoundedHistCollection *p_hist) {
+  auto n_total_bins = buffer->TotalBins();
+  common::BlockedSpace2d space(
+      nodes_to_build.size(), [&](std::size_t) { return n_total_bins; }, 1024);
+  CHECK(!nodes_to_build.empty());
+
+  auto &hist = *p_hist;
+  if (is_col_split_) {
+    // Under secure vertical mode, we perform allgather to get the global histogram. Note
+    // that only the label owner (rank == 0) needs the global histogram
+    auto first_nidx = nodes_to_build.front();
+    // *2 because we have a pair of g and h for each histogram item
+    std::size_t n = n_total_bins * nodes_to_build.size() * 2;
+
+    // Perform AllGather
+    HostDeviceVector<std::int8_t> hist_entries;
+    std::vector<std::int64_t> recv_segments;
+    collective::SafeColl(
+        collective::AllgatherV(ctx, linalg::MakeVec(hist_data_), &recv_segments, &hist_entries));
+
+    // Call interface here to post-process the messages
+    auto hist_aggr =
+        plugin_->SyncEncryptedHistVert(common::RestoreType<std::uint8_t>(hist_entries.HostSpan()));
+
+    // Update histogram for label owner
+    if (collective::GetRank() == 0) {
+      // iterator of the beginning of the vector
+      auto it = reinterpret_cast<double *>(hist[first_nidx].data());
+      // iterate through the hist vector of the label owner
+      for (std::size_t i = 0; i < n; i++) {
+        // get the sum of the entries from all ranks
+        double hist_sum = 0.0;
+        for (std::size_t rank_idx = 0; rank_idx < hist_aggr.size() / n; rank_idx++) {
+          int flat_idx = rank_idx * n + i;
+          hist_sum += hist_aggr[flat_idx];
+        }
+        // update rank 0's record with the global histogram
+        *it = hist_sum;
+        it++;
+      }
+    }
+  } else {
+    common::ParallelFor2d(space, this->n_threads_, [&](std::size_t node, common::Range1d r) {
+      // Merging histograms from each thread.
+      buffer->ReduceHist(node, r.begin(), r.end());
+    });
+    // Secure mode, we need to call interface to perform encryption and decryption
+    // note that the actual aggregation will be performed at server side
+    auto first_nidx = nodes_to_build.front();
+    std::size_t n = n_total_bins * nodes_to_build.size() * 2;
+    auto hist_to_aggr = std::vector<double>();
+    for (std::size_t hist_idx = 0; hist_idx < n; hist_idx++) {
+      double hist_item = reinterpret_cast<double *>(hist[first_nidx].data())[hist_idx];
+      hist_to_aggr.push_back(hist_item);
+    }
+    // ProcessHistograms
+    auto hist_buf = plugin_->BuildEncryptedHistHori(hist_to_aggr);
+
+    // allgather
+    HostDeviceVector<std::int8_t> hist_entries;
+    std::vector<std::int64_t> recv_segments;
+    auto rc = collective::AllgatherV(ctx, linalg::MakeVec(hist_buf), &recv_segments, &hist_entries);
+    collective::SafeColl(rc);
+
+    auto hist_aggr =
+        plugin_->SyncEncryptedHistHori(common::RestoreType<std::uint8_t>(hist_entries.HostSpan()));
+    // Assign the aggregated histogram back to the local histogram
+    for (std::size_t hist_idx = 0; hist_idx < n; hist_idx++) {
+      reinterpret_cast<double *>(hist[first_nidx].data())[hist_idx] = hist_aggr[hist_idx];
+    }
+  }
+
+  SubtractHistParallel(ctx, space, p_tree, nodes_to_build, nodes_to_trick, buffer, p_hist);
+}
+}  // namespace xgboost::tree

--- a/plugin/federated/federated_hist.h
+++ b/plugin/federated/federated_hist.h
@@ -35,11 +35,11 @@ class FederataedHistPolicy {
   bool is_aggr_context_initialized_ = false;  // fixme
 
  public:
-  void Reset(Context const *ctx, bool is_distributed, DMatrix const *p_fmat) {
+  void Reset(Context const *ctx, bool is_distributed, bool is_col_split) {
     this->is_distributed_ = is_distributed;
     CHECK(is_distributed);
     this->n_threads_ = ctx->Threads();
-    this->is_col_split_ = p_fmat->Info().IsColumnSplit();
+    this->is_col_split_ = is_col_split;
     auto const &comm = collective::GlobalCommGroup()->Ctx(ctx, DeviceOrd::CPU());
     auto const &fed = dynamic_cast<collective::FederatedComm const &>(comm);
     plugin_ = fed.EncryptionPlugin();

--- a/plugin/federated/federated_hist.h
+++ b/plugin/federated/federated_hist.h
@@ -2,23 +2,20 @@
  * Copyright 2024, XGBoost contributors
  */
 #pragma once
-#include <cstddef>  // for size_t
 #include <cstdint>  // for int32_t
-#include <vector>   // for vector-
+#include <vector>   // for vector
 
-#include "../../src/collective/allgather.h"         // for AllgatherV
-#include "../../src/collective/comm_group.h"        // for GlobalCommGroup
-#include "../../src/collective/communicator-inl.h"  // for GetRank
-#include "../../src/common/hist_util.h"             // for ParallelGHistBuilder, SubtractionHist
-#include "../../src/common/row_set.h"               // for RowSetCollection
-#include "../../src/common/threading_utils.h"       // for ParallelFor2d, Range1d, BlockedSpace2d
-#include "../../src/data/gradient_index.h"          // for GHistIndexMatrix
-#include "../../src/tree/hist/hist_cache.h"         // for BoundedHistCollection
-#include "federated_comm.h"                         // for FederatedComm
-#include "xgboost/base.h"                           // for GradientPair
-#include "xgboost/context.h"                        // for Context
-#include "xgboost/span.h"                           // for Span
-#include "xgboost/tree_model.h"                     // for RegTree
+#include "../../src/collective/comm_group.h"   // for GlobalCommGroup
+#include "../../src/common/hist_util.h"        // for ParallelGHistBuilder
+#include "../../src/common/row_set.h"          // for RowSetCollection
+#include "../../src/common/threading_utils.h"  // for BlockedSpace2d
+#include "../../src/data/gradient_index.h"     // for GHistIndexMatrix
+#include "../../src/tree/hist/hist_cache.h"    // for BoundedHistCollection
+#include "federated_comm.h"                    // for FederatedComm
+#include "xgboost/base.h"                      // for GradientPair
+#include "xgboost/context.h"                   // for Context
+#include "xgboost/span.h"                      // for Span
+#include "xgboost/tree_model.h"                // for RegTree
 
 namespace xgboost::tree {
 /**
@@ -51,137 +48,11 @@ class FederataedHistPolicy {
                               std::vector<bst_node_t> const &nodes_to_build,
                               common::RowSetCollection const &row_set_collection,
                               common::Span<GradientPair const> gpair_h, bool force_read_by_column,
-                              common::ParallelGHistBuilder *buffer) {
-    if (is_col_split_) {
-      // Call the interface to transmit gidx information to the secure worker for encrypted
-      // histogram computation
-      auto cuts = gidx.Cuts().Ptrs();
-      // fixme: this can be done during reset.
-      if (!is_aggr_context_initialized_) {
-        auto slots = std::vector<int>();
-        auto num_rows = gidx.Size();
-        for (std::size_t row = 0; row < num_rows; row++) {
-          for (std::size_t f = 0; f < cuts.size() - 1; f++) {
-            auto slot = gidx.GetGindex(row, f);
-            slots.push_back(slot);
-          }
-        }
-        plugin_->Reset(cuts, slots);
-        is_aggr_context_initialized_ = true;
-      }
-
-      // Further use the row set collection info to
-      // get the encrypted histogram from the secure worker
-      std::vector<std::uint64_t const *> ptrs(nodes_to_build.size());
-      std::vector<std::size_t> sizes(nodes_to_build.size());
-      std::vector<bst_node_t> nodes(nodes_to_build.size());
-      for (std::size_t i = 0; i < nodes_to_build.size(); ++i) {
-        auto nidx = nodes_to_build[i];
-        ptrs[i] = row_set_collection[nidx].begin;
-        sizes[i] = row_set_collection[nidx].Size();
-        nodes[i] = nidx;
-      }
-      hist_data_ = this->plugin_->BuildEncryptedHistVert(ptrs, sizes, nodes);
-    } else {
-      common::BuildSampleHistograms<any_missing>(this->n_threads_, space, gidx, nodes_to_build,
-                                                 row_set_collection, gpair_h, force_read_by_column,
-                                                 buffer);
-    }
-  }
+                              common::ParallelGHistBuilder *buffer);
 
   void DoSyncHistogram(Context const *ctx, RegTree const *p_tree,
                        std::vector<bst_node_t> const &nodes_to_build,
                        std::vector<bst_node_t> const &nodes_to_trick,
-                       common::ParallelGHistBuilder *buffer, tree::BoundedHistCollection *p_hist) {
-    auto n_total_bins = buffer->TotalBins();
-    common::BlockedSpace2d space(
-        nodes_to_build.size(), [&](std::size_t) { return n_total_bins; }, 1024);
-
-    auto &hist = *p_hist;
-    if (is_col_split_) {
-      // Under secure vertical mode, we perform allgather to get the global histogram.
-      // note that only Label Owner needs the global histogram
-      CHECK(!nodes_to_build.empty());
-      // Front item of nodes_to_build
-      auto first_nidx = nodes_to_build.front();
-      // *2 because we have a pair of g and h for each histogram item
-      std::size_t n = n_total_bins * nodes_to_build.size() * 2;
-
-      // Perform AllGather
-      HostDeviceVector<std::int8_t> hist_entries;
-      std::vector<std::int64_t> recv_segments;
-      collective::SafeColl(
-          collective::AllgatherV(ctx, linalg::MakeVec(hist_data_), &recv_segments, &hist_entries));
-
-      // Call interface here to post-process the messages
-      auto hist_aggr = plugin_->SyncEncryptedHistVert(
-          common::RestoreType<std::uint8_t>(hist_entries.HostSpan()));
-
-      // Update histogram for label owner
-      if (collective::GetRank() == 0) {
-        // iterator of the beginning of the vector
-        auto it = reinterpret_cast<double *>(hist[first_nidx].data());
-        // iterate through the hist vector of the label owner
-        for (std::size_t i = 0; i < n; i++) {
-          // get the sum of the entries from all ranks
-          double hist_sum = 0.0;
-          for (std::size_t rank_idx = 0; rank_idx < hist_aggr.size() / n; rank_idx++) {
-            int flat_idx = rank_idx * n + i;
-            hist_sum += hist_aggr[flat_idx];
-          }
-          // update rank 0's record with the global histogram
-          *it = hist_sum;
-          it++;
-        }
-      }
-    } else {
-      common::ParallelFor2d(space, this->n_threads_, [&](std::size_t node, common::Range1d r) {
-        // Merging histograms from each thread.
-        buffer->ReduceHist(node, r.begin(), r.end());
-      });
-      // Secure mode, we need to call interface to perform encryption and decryption
-      // note that the actual aggregation will be performed at server side
-      auto first_nidx = nodes_to_build.front();
-      std::size_t n = n_total_bins * nodes_to_build.size() * 2;
-      auto hist_to_aggr = std::vector<double>();
-      for (std::size_t hist_idx = 0; hist_idx < n; hist_idx++) {
-        double hist_item = reinterpret_cast<double *>(hist[first_nidx].data())[hist_idx];
-        hist_to_aggr.push_back(hist_item);
-      }
-      // ProcessHistograms
-      auto hist_buf = plugin_->BuildEncryptedHistHori(hist_to_aggr);
-
-      // allgather
-      HostDeviceVector<std::int8_t> hist_entries;
-      std::vector<std::int64_t> recv_segments;
-      auto rc =
-          collective::AllgatherV(ctx, linalg::MakeVec(hist_buf), &recv_segments, &hist_entries);
-      collective::SafeColl(rc);
-
-      auto hist_aggr = plugin_->SyncEncryptedHistHori(
-          common::RestoreType<std::uint8_t>(hist_entries.HostSpan()));
-      // Assign the aggregated histogram back to the local histogram
-      for (std::size_t hist_idx = 0; hist_idx < n; hist_idx++) {
-        reinterpret_cast<double *>(hist[first_nidx].data())[hist_idx] = hist_aggr[hist_idx];
-      }
-    }
-
-    common::BlockedSpace2d const &subspace =
-        nodes_to_trick.size() == nodes_to_build.size()
-            ? space
-            : common::BlockedSpace2d{nodes_to_trick.size(),
-                                     [&](std::size_t) { return n_total_bins; }, 1024};
-    common::ParallelFor2d(
-        subspace, this->n_threads_, [&](std::size_t nidx_in_set, common::Range1d r) {
-          auto subtraction_nidx = nodes_to_trick[nidx_in_set];
-          auto parent_id = p_tree->Parent(subtraction_nidx);
-          auto sibling_nidx = p_tree->IsLeftChild(subtraction_nidx) ? p_tree->RightChild(parent_id)
-                                                                    : p_tree->LeftChild(parent_id);
-          auto sibling_hist = hist[sibling_nidx];
-          auto parent_hist = hist[parent_id];
-          auto subtract_hist = hist[subtraction_nidx];
-          common::SubtractionHist(subtract_hist, parent_hist, sibling_hist, r.begin(), r.end());
-        });
-  }
+                       common::ParallelGHistBuilder *buffer, tree::BoundedHistCollection *p_hist);
 };
 }  // namespace xgboost::tree

--- a/plugin/federated/federated_hist.h
+++ b/plugin/federated/federated_hist.h
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2024, XGBoost contributors
+ */
+#pragma once
+#include <cstddef>  // for size_t
+#include <cstdint>  // for int32_t
+#include <vector>   // for vector-
+
+#include "../../src/collective/allgather.h"         // for AllgatherV
+#include "../../src/collective/comm_group.h"        // for GlobalCommGroup
+#include "../../src/collective/communicator-inl.h"  // for GetRank
+#include "../../src/common/hist_util.h"             // for ParallelGHistBuilder, SubtractionHist
+#include "../../src/common/row_set.h"               // for RowSetCollection
+#include "../../src/common/threading_utils.h"       // for ParallelFor2d, Range1d, BlockedSpace2d
+#include "../../src/data/gradient_index.h"          // for GHistIndexMatrix
+#include "../../src/tree/hist/hist_cache.h"         // for BoundedHistCollection
+#include "federated_comm.h"                         // for FederatedComm
+#include "xgboost/base.h"                           // for GradientPair
+#include "xgboost/context.h"                        // for Context
+#include "xgboost/span.h"                           // for Span
+#include "xgboost/tree_model.h"                     // for RegTree
+
+namespace xgboost::tree {
+/**
+ * @brief Federated histogram build policy
+ */
+class FederataedHistPolicy {
+  // fixme: duplicated code
+  bool is_col_split_{false};
+  bool is_distributed_{false};
+  std::int32_t n_threads_{false};
+  decltype(std::declval<collective::FederatedComm>().EncryptionPlugin()) plugin_;
+  xgboost::common::Span<std::uint8_t> hist_data_;
+  // only initialize the aggregation context once
+  bool is_aggr_context_initialized_ = false;  // fixme
+
+ public:
+  void Reset(Context const *ctx, bool is_distributed, DMatrix const *p_fmat) {
+    this->is_distributed_ = is_distributed;
+    CHECK(is_distributed);
+    this->n_threads_ = ctx->Threads();
+    this->is_col_split_ = p_fmat->Info().IsColumnSplit();
+    auto const &comm = collective::GlobalCommGroup()->Ctx(ctx, DeviceOrd::CPU());
+    auto const &fed = dynamic_cast<collective::FederatedComm const &>(comm);
+    plugin_ = fed.EncryptionPlugin();
+    CHECK(is_distributed_) << "Unreachable. Single node training can not be federated.";
+  }
+
+  template <bool any_missing>
+  void DoBuildLocalHistograms(common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+                              std::vector<bst_node_t> const &nodes_to_build,
+                              common::RowSetCollection const &row_set_collection,
+                              common::Span<GradientPair const> gpair_h, bool force_read_by_column,
+                              common::ParallelGHistBuilder *buffer) {
+    if (is_col_split_) {
+      // Call the interface to transmit gidx information to the secure worker for encrypted
+      // histogram computation
+      auto cuts = gidx.Cuts().Ptrs();
+      // fixme: this can be done during reset.
+      if (!is_aggr_context_initialized_) {
+        auto slots = std::vector<int>();
+        auto num_rows = gidx.Size();
+        for (std::size_t row = 0; row < num_rows; row++) {
+          for (std::size_t f = 0; f < cuts.size() - 1; f++) {
+            auto slot = gidx.GetGindex(row, f);
+            slots.push_back(slot);
+          }
+        }
+        plugin_->Reset(cuts, slots);
+        is_aggr_context_initialized_ = true;
+      }
+
+      // Further use the row set collection info to
+      // get the encrypted histogram from the secure worker
+      std::vector<std::uint64_t const *> ptrs(nodes_to_build.size());
+      std::vector<std::size_t> sizes(nodes_to_build.size());
+      std::vector<bst_node_t> nodes(nodes_to_build.size());
+      for (std::size_t i = 0; i < nodes_to_build.size(); ++i) {
+        auto nidx = nodes_to_build[i];
+        ptrs[i] = row_set_collection[nidx].begin;
+        sizes[i] = row_set_collection[nidx].Size();
+        nodes[i] = nidx;
+      }
+      hist_data_ = this->plugin_->BuildEncryptedHistVert(ptrs, sizes, nodes);
+    } else {
+      common::BuildSampleHistograms<any_missing>(this->n_threads_, space, gidx, nodes_to_build,
+                                                 row_set_collection, gpair_h, force_read_by_column,
+                                                 buffer);
+    }
+  }
+
+  void DoSyncHistogram(Context const *ctx, RegTree const *p_tree,
+                       std::vector<bst_node_t> const &nodes_to_build,
+                       std::vector<bst_node_t> const &nodes_to_trick,
+                       common::ParallelGHistBuilder *buffer, tree::BoundedHistCollection *p_hist) {
+    auto n_total_bins = buffer->TotalBins();
+    common::BlockedSpace2d space(
+        nodes_to_build.size(), [&](std::size_t) { return n_total_bins; }, 1024);
+
+    auto &hist = *p_hist;
+    if (is_col_split_) {
+      // Under secure vertical mode, we perform allgather to get the global histogram.
+      // note that only Label Owner needs the global histogram
+      CHECK(!nodes_to_build.empty());
+      // Front item of nodes_to_build
+      auto first_nidx = nodes_to_build.front();
+      // *2 because we have a pair of g and h for each histogram item
+      std::size_t n = n_total_bins * nodes_to_build.size() * 2;
+
+      // Perform AllGather
+      HostDeviceVector<std::int8_t> hist_entries;
+      std::vector<std::int64_t> recv_segments;
+      collective::SafeColl(
+          collective::AllgatherV(ctx, linalg::MakeVec(hist_data_), &recv_segments, &hist_entries));
+
+      // Call interface here to post-process the messages
+      auto hist_aggr = plugin_->SyncEncryptedHistVert(
+          common::RestoreType<std::uint8_t>(hist_entries.HostSpan()));
+
+      // Update histogram for label owner
+      if (collective::GetRank() == 0) {
+        // iterator of the beginning of the vector
+        auto it = reinterpret_cast<double *>(hist[first_nidx].data());
+        // iterate through the hist vector of the label owner
+        for (std::size_t i = 0; i < n; i++) {
+          // get the sum of the entries from all ranks
+          double hist_sum = 0.0;
+          for (std::size_t rank_idx = 0; rank_idx < hist_aggr.size() / n; rank_idx++) {
+            int flat_idx = rank_idx * n + i;
+            hist_sum += hist_aggr[flat_idx];
+          }
+          // update rank 0's record with the global histogram
+          *it = hist_sum;
+          it++;
+        }
+      }
+    } else {
+      common::ParallelFor2d(space, this->n_threads_, [&](std::size_t node, common::Range1d r) {
+        // Merging histograms from each thread.
+        buffer->ReduceHist(node, r.begin(), r.end());
+      });
+      // Secure mode, we need to call interface to perform encryption and decryption
+      // note that the actual aggregation will be performed at server side
+      auto first_nidx = nodes_to_build.front();
+      std::size_t n = n_total_bins * nodes_to_build.size() * 2;
+      auto hist_to_aggr = std::vector<double>();
+      for (std::size_t hist_idx = 0; hist_idx < n; hist_idx++) {
+        double hist_item = reinterpret_cast<double *>(hist[first_nidx].data())[hist_idx];
+        hist_to_aggr.push_back(hist_item);
+      }
+      // ProcessHistograms
+      auto hist_buf = plugin_->BuildEncryptedHistHori(hist_to_aggr);
+
+      // allgather
+      HostDeviceVector<std::int8_t> hist_entries;
+      std::vector<std::int64_t> recv_segments;
+      auto rc =
+          collective::AllgatherV(ctx, linalg::MakeVec(hist_buf), &recv_segments, &hist_entries);
+      collective::SafeColl(rc);
+
+      auto hist_aggr = plugin_->SyncEncryptedHistHori(
+          common::RestoreType<std::uint8_t>(hist_entries.HostSpan()));
+      // Assign the aggregated histogram back to the local histogram
+      for (std::size_t hist_idx = 0; hist_idx < n; hist_idx++) {
+        reinterpret_cast<double *>(hist[first_nidx].data())[hist_idx] = hist_aggr[hist_idx];
+      }
+    }
+
+    common::BlockedSpace2d const &subspace =
+        nodes_to_trick.size() == nodes_to_build.size()
+            ? space
+            : common::BlockedSpace2d{nodes_to_trick.size(),
+                                     [&](std::size_t) { return n_total_bins; }, 1024};
+    common::ParallelFor2d(
+        subspace, this->n_threads_, [&](std::size_t nidx_in_set, common::Range1d r) {
+          auto subtraction_nidx = nodes_to_trick[nidx_in_set];
+          auto parent_id = p_tree->Parent(subtraction_nidx);
+          auto sibling_nidx = p_tree->IsLeftChild(subtraction_nidx) ? p_tree->RightChild(parent_id)
+                                                                    : p_tree->LeftChild(parent_id);
+          auto sibling_hist = hist[sibling_nidx];
+          auto parent_hist = hist[parent_id];
+          auto subtract_hist = hist[subtraction_nidx];
+          common::SubtractionHist(subtract_hist, parent_hist, sibling_hist, r.begin(), r.end());
+        });
+  }
+};
+}  // namespace xgboost::tree

--- a/plugin/federated/federated_plugin.cc
+++ b/plugin/federated/federated_plugin.cc
@@ -9,7 +9,6 @@
 #include <cstdint>  // for uint8_t, uint64_t
 #include <sstream>  // for stringstream
 
-#include "../../src/collective/communicator-inl.h"
 #include "../../src/common/json_utils.h"  // for OptionalArg
 #include "../../src/common/type.h"        // for RestoreType
 #include "xgboost/base.h"                 // for bst_bin_t, bst_feature_t
@@ -52,6 +51,7 @@ void FederatedPluginMock::Reset(common::Span<std::uint32_t const> cutptrs,
     auto n_samples_in_node = sizes[i];
     auto samples = common::Span{rowptrs[i], n_samples_in_node};
     auto hist = hist_buffer.subspan(i * hist_size, hist_size);
+    // We should port this to a better implementation that uses parallel build.
     for (auto ridx : samples) {
       for (bst_feature_t f = 0; f < n_features; ++f) {
         auto bin = gidx(ridx, f);

--- a/plugin/federated/federated_plugin.cc
+++ b/plugin/federated/federated_plugin.cc
@@ -172,9 +172,13 @@ FederatedPlugin::~FederatedPlugin() = default;
 [[nodiscard]] FederatedPluginBase* CreateFederatedPlugin(Json config) {
   auto plugin = OptionalArg<Object>(config, "federated_plugin", Object::Map{});
   if (!plugin.empty()) {
+    auto name_it = plugin.find("name");
+    if (name_it != plugin.cend() && get<String const>(name_it->second) == "mock") {
+      return new FederatedPluginMock{};
+    }
     auto path = get<String>(plugin["path"]);
     return new FederatedPlugin{path, config};
   }
-  return new FederatedPluginMock{};
+  return nullptr;
 }
 }  // namespace xgboost::collective

--- a/plugin/federated/federated_plugin.cc
+++ b/plugin/federated/federated_plugin.cc
@@ -9,13 +9,13 @@
 #include <cstdint>  // for uint8_t, uint64_t
 #include <sstream>  // for stringstream
 
-#include "xgboost/base.h"         // for bst_bin_t, bst_feature_t
-#include "xgboost/json.h"         // for Json
-#include "xgboost/linalg.h"       // for MakeTensorView
-#include "xgboost/logging.h"      // for CHECK_EQ
-#include "xgboost/span.h"         // for Span
-#include "xgboost/string_view.h"  // for StringView
 #include "../../src/common/json_utils.h"  // for OptionalArg
+#include "xgboost/base.h"                 // for bst_bin_t, bst_feature_t
+#include "xgboost/json.h"                 // for Json
+#include "xgboost/linalg.h"               // for MakeTensorView
+#include "xgboost/logging.h"              // for CHECK_EQ
+#include "xgboost/span.h"                 // for Span
+#include "xgboost/string_view.h"          // for StringView
 
 namespace xgboost::collective {
 void FederatedPluginMock::Reset(common::Span<std::uint32_t const> cutptrs,
@@ -68,7 +68,7 @@ void FederatedPluginMock::Reset(common::Span<std::uint32_t const> cutptrs,
   return {hist_plain_};
 }
 
-template <typename T>  // fixme, duplicated code
+template <typename T>
 auto SafeLoad(federated::FederatedPluginHandle handle, StringView name) {
   std::stringstream errs;
   auto ptr = reinterpret_cast<T>(dlsym(handle, name.c_str()));

--- a/plugin/federated/federated_plugin.cc
+++ b/plugin/federated/federated_plugin.cc
@@ -5,14 +5,71 @@
 
 #include <dlfcn.h>  // for dlclose, dlsym, dlopen
 
-#include "xgboost/json.h"  // for Json
-#include "xgboost/logging.h"
+#include <cstddef>  // for size_t
+#include <cstdint>  // for uint8_t, uint64_t
+#include <sstream>  // for stringstream
 
-typedef void* FederatedPluginHandle;  // NOLINT
+#include "xgboost/base.h"         // for bst_bin_t, bst_feature_t
+#include "xgboost/json.h"         // for Json
+#include "xgboost/linalg.h"       // for MakeTensorView
+#include "xgboost/logging.h"      // for CHECK_EQ
+#include "xgboost/span.h"         // for Span
+#include "xgboost/string_view.h"  // for StringView
+#include "../../src/common/json_utils.h"  // for OptionalArg
 
 namespace xgboost::collective {
+void FederatedPluginMock::Reset(common::Span<std::uint32_t const> cutptrs,
+                                common::Span<std::int32_t const> bin_idx) {
+  this->cuts_.resize(cutptrs.size());
+  std::copy_n(cutptrs.data(), cutptrs.size(), this->cuts_.data());
+  this->gidx_.resize(bin_idx.size());
+  std::copy_n(bin_idx.data(), bin_idx.size(), this->gidx_.data());
+}
+
+[[nodiscard]] common::Span<std::uint8_t> FederatedPluginMock::BuildEncryptedHistVert(
+    common::Span<std::uint64_t const*> rowptrs, common::Span<std::size_t const> sizes,
+    common::Span<bst_node_t const> nids) {
+  bst_bin_t total_bin_size = cuts_.back();
+  bst_feature_t n_features = cuts_.size() - 1;
+  bst_idx_t n_total_samples = gidx_.size() / n_features;
+  CHECK_EQ(gidx_.size() % n_features, 0);
+  bst_bin_t hist_size = total_bin_size * 2;
+  hist_plain_.resize(hist_size);
+  CHECK_EQ(rowptrs.size(), sizes.size());
+  CHECK_EQ(nids.size(), sizes.size());
+  CHECK_EQ(n_total_samples * 2, grad_.size());
+
+  Context ctx;
+  auto gidx = linalg::MakeTensorView(&ctx, common::Span{gidx_.data(), gidx_.size()},
+                                     n_total_samples, n_features);
+  for (std::size_t i = 0; i < sizes.size(); ++i) {
+    auto n_samples = sizes[i];
+    auto samples = common::Span{rowptrs[i], n_samples};
+    for (auto ridx : samples) {
+      for (bst_feature_t f = 0; f < n_features; ++f) {
+        auto bin = gidx(ridx, f);
+        if (bin < 0) {
+          continue;
+        }
+        auto g = grad_[ridx * 2];
+        auto h = grad_[ridx * 2 + 1];
+        hist_plain_[bin * 2] += g;
+        hist_plain_[bin * 2 + 1] += h;
+      }
+    }
+  }
+
+  return {reinterpret_cast<std::uint8_t*>(hist_plain_.data()),
+          common::Span<double>{hist_plain_}.size_bytes()};
+}
+
+[[nodiscard]] common::Span<double> FederatedPluginMock::SyncEncryptedHistVert(
+    common::Span<std::uint8_t>) {
+  return {hist_plain_};
+}
+
 template <typename T>  // fixme, duplicated code
-auto SafeLoad(FederatedPluginHandle handle, StringView name) {
+auto SafeLoad(federated::FederatedPluginHandle handle, StringView name) {
   std::stringstream errs;
   auto ptr = reinterpret_cast<T>(dlsym(handle, name.c_str()));
   if (!ptr) {
@@ -22,9 +79,9 @@ auto SafeLoad(FederatedPluginHandle handle, StringView name) {
   return ptr;
 }
 
-FederatedPlugin::FederatedPlugin(std::string_view path, Json config)
+FederatedPlugin::FederatedPlugin(StringView path, Json config)
     : plugin_{[&] {
-                auto handle = dlopen(path.data(), RTLD_LAZY | RTLD_GLOBAL);
+                auto handle = dlopen(path.c_str(), RTLD_LAZY | RTLD_GLOBAL);
                 CHECK(handle) << "Failed to load federated plugin `" << path << "`:" << dlerror();
                 return handle;
               }(),
@@ -75,7 +132,7 @@ FederatedPlugin::FederatedPlugin(std::string_view path, Json config)
 
         return handle;
       }(),
-      [this](FederatedPluginHandle handle) {
+      [this](federated::FederatedPluginHandle handle) {
         int rc = this->PluginClose_(handle);
         if (rc != 0) {
           LOG(WARNING) << "Failed to close plugin";
@@ -101,4 +158,13 @@ FederatedPlugin::FederatedPlugin(std::string_view path, Json config)
 }
 
 FederatedPlugin::~FederatedPlugin() = default;
+
+[[nodiscard]] FederatedPluginBase* CreateFederatedPlugin(Json config) {
+  auto plugin = OptionalArg<Object>(config, "federated_plugin", Object::Map{});
+  if (!plugin.empty()) {
+    auto path = get<String>(plugin["path"]);
+    return new FederatedPlugin{path, config};
+  }
+  return new FederatedPluginMock{};
+}
 }  // namespace xgboost::collective

--- a/plugin/federated/federated_plugin.cc
+++ b/plugin/federated/federated_plugin.cc
@@ -38,6 +38,7 @@ void FederatedPluginMock::Reset(common::Span<std::uint32_t const> cutptrs,
   bst_bin_t hist_size = total_bin_size * 2;
   hist_plain_.resize(hist_size * sizes.size());
   auto hist_buffer = common::Span<double>{hist_plain_};
+  std::fill_n(hist_buffer.data(), hist_buffer.size(), 0.0);
 
   CHECK_EQ(rowptrs.size(), sizes.size());
   CHECK_EQ(nids.size(), sizes.size());

--- a/plugin/federated/federated_plugin.cc
+++ b/plugin/federated/federated_plugin.cc
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2024, XGBoost Contributors
+ */
+#include "federated_plugin.h"
+
+#include <dlfcn.h>  // for dlclose, dlsym, dlopen
+
+#include "xgboost/json.h"  // for Json
+#include "xgboost/logging.h"
+
+typedef void* FederatedPluginHandle;  // NOLINT
+
+namespace xgboost::collective {
+template <typename T>  // fixme, duplicated code
+auto SafeLoad(FederatedPluginHandle handle, StringView name) {
+  std::stringstream errs;
+  auto ptr = reinterpret_cast<T>(dlsym(handle, name.c_str()));
+  if (!ptr) {
+    errs << "Failed to load symbol `" << name << "`. Error:\n  " << dlerror();
+    LOG(FATAL) << errs.str();
+  }
+  return ptr;
+}
+
+FederatedPlugin::FederatedPlugin(std::string_view path, Json config)
+    : plugin_{[&] {
+                auto handle = dlopen(path.data(), RTLD_LAZY | RTLD_GLOBAL);
+                CHECK(handle) << "Failed to load federated plugin `" << path << "`:" << dlerror();
+                return handle;
+              }(),
+              [](void* handle) {
+                if (handle) {
+                  auto rc = dlclose(handle);
+                  if (rc != 0) {
+                    LOG(WARNING) << "Failed to close federated plugin handle:" << dlerror();
+                  }
+                }
+              }} {
+  plugin_handle_ = decltype(plugin_handle_)(
+      [&] {
+        // Initialize the parameters
+        auto const& obj = get<Object>(config);
+        std::vector<std::string> kwargs;
+        for (auto const& kv : obj) {
+          std::string value;
+          if (IsA<Integer>(kv.second)) {
+            value = std::to_string(get<Integer const>(kv.second));
+          } else if (IsA<Number>(kv.second)) {
+            value = std::to_string(get<Number const>(kv.second));
+          } else if (IsA<Boolean>(kv.second)) {
+            value = std::to_string(get<Boolean const>(kv.second));
+          } else if (IsA<String>(kv.second)) {
+            value = get<String const>(kv.second);
+          } else {
+            LOG(FATAL) << "Invalid type of federated plugin parameter:"
+                       << kv.second.GetValue().TypeStr();
+          }
+          if (kv.first == "path") {
+            continue;
+          }
+          kwargs.emplace_back(kv.first + "=" + value);
+        }
+        std::vector<char const*> ckwargs(kwargs.size());
+        std::transform(kwargs.cbegin(), kwargs.cend(), ckwargs.begin(),
+                       [](auto const& str) { return str.c_str(); });
+
+        // Plugin itself
+        PluginCreate_ = SafeLoad<decltype(PluginCreate_)>(plugin_.get(), "FederatedPluginCreate");
+        PluginClose_ = SafeLoad<decltype(PluginClose_)>(plugin_.get(), "FederatedPluginClose");
+        ErrorMsg_ = SafeLoad<decltype(ErrorMsg_)>(plugin_.get(), "FederatedPluginErrorMsg");
+
+        auto handle =
+            this->PluginCreate_(static_cast<std::int32_t>(ckwargs.size()), ckwargs.data());
+        CHECK(handle) << "Failed to create federated plugin";
+
+        return handle;
+      }(),
+      [this](FederatedPluginHandle handle) {
+        int rc = this->PluginClose_(handle);
+        if (rc != 0) {
+          LOG(WARNING) << "Failed to close plugin";
+        }
+      });
+  // gradient
+  CHECK(plugin_handle_);
+  Encrypt_ = SafeLoad<decltype(Encrypt_)>(plugin_.get(), "FederatedPluginEncryptGPairs");
+  SyncEncrypt_ =
+      SafeLoad<decltype(SyncEncrypt_)>(plugin_.get(), "FederatedPluginSyncEncryptedGPairs");
+  // Vertical
+  ResetHistCtxVert_ =
+      SafeLoad<decltype(ResetHistCtxVert_)>(plugin_.get(), "FederatedPluginResetHistContextVert");
+  BuildEncryptedHistVert_ = SafeLoad<decltype(BuildEncryptedHistVert_)>(
+      plugin_.get(), "FederatedPluginBuildEncryptedHistVert");
+  SyncEncryptedHistVert_ = SafeLoad<decltype(SyncEncryptedHistVert_)>(
+      plugin_.get(), "FederatedPluginSyncEnrcyptedHistVert");
+  // Horizontal
+  BuildEncryptedHistHori_ = SafeLoad<decltype(BuildEncryptedHistHori_)>(
+      plugin_.get(), "FederatedPluginBuildEncryptedHistHori");
+  SyncEncryptedHistHori_ = SafeLoad<decltype(SyncEncryptedHistHori_)>(
+      plugin_.get(), "FederatedPluginSyncEnrcyptedHistHori");
+}
+
+FederatedPlugin::~FederatedPlugin() = default;
+}  // namespace xgboost::collective

--- a/plugin/federated/federated_plugin.h
+++ b/plugin/federated/federated_plugin.h
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2024, XGBoost contributors
+ */
+#pragma once
+
+#include <functional>   // for function
+#include <memory>       // for unique_ptr
+#include <string_view>  // for string_view
+
+#include "xgboost/json.h"  // for Json
+#include "xgboost/span.h"  // for Span
+
+typedef void *FederatedPluginHandle;  // NOLINT
+
+namespace xgboost::collective {
+namespace federated {
+// API exposed by the plugin
+using CreateFn = FederatedPluginHandle(int, char const **);
+using CloseFn = int(FederatedPluginHandle);
+using ErrorFn = char const *();
+// Gradient
+using EncryptFn = int(FederatedPluginHandle handle, float const *in_gpair, size_t n_in,
+                      uint8_t **out_gpair, size_t *n_out);
+using SyncEncryptFn = int(FederatedPluginHandle handle, uint8_t const *in_gpair, size_t n_bytes,
+                          uint8_t const **out_gpair, size_t *n_out);
+// Vert Histogram
+using ResetHistCtxVertFn = int(FederatedPluginHandle handle, std::uint32_t const *cutptrs,
+                               std::size_t cutptr_len, std::int32_t const *bin_idx,
+                               std::size_t n_idx);
+using BuildHistVertFn = int(FederatedPluginHandle handle, uint64_t const **ridx,
+                            size_t const *sizes, int32_t const *nidx, size_t len,
+                            uint8_t **out_hist, size_t *out_len);
+using SyncHistVertFn = int(FederatedPluginHandle handle, uint8_t *buf, size_t len, double **out,
+                           size_t *out_len);
+// Hori Histogram
+using BuildHistHoriFn = int(FederatedPluginHandle handle, double const *in_histogram, size_t len,
+                            uint8_t **out_hist, size_t *out_len);
+using SyncHistHoriFn = int(FederatedPluginHandle handle, std::uint8_t const *buffer,
+                           std::size_t len, double **out_hist, std::size_t *out_len);
+}  // namespace federated
+
+/**
+ * @brief Bridge for plugins that handle encryption.
+ */
+class FederatedPlugin {
+  // Federated plugin shared object, for dlopen.
+  std::unique_ptr<void, std::function<void(void *)>> plugin_;
+
+  federated::CreateFn *PluginCreate_{nullptr};
+  federated::CloseFn *PluginClose_{nullptr};
+  federated::ErrorFn *ErrorMsg_{nullptr};
+  // Gradient
+  federated::EncryptFn *Encrypt_{nullptr};
+  federated::SyncEncryptFn *SyncEncrypt_{nullptr};
+  // Vert Histogram
+  federated::ResetHistCtxVertFn *ResetHistCtxVert_{nullptr};
+  federated::BuildHistVertFn *BuildEncryptedHistVert_{nullptr};
+  federated::SyncHistVertFn *SyncEncryptedHistVert_{nullptr};
+  // Hori Histogram
+  federated::BuildHistHoriFn *BuildEncryptedHistHori_{nullptr};
+  federated::SyncHistHoriFn *SyncEncryptedHistHori_;
+
+  // Object handle of the plugin.
+  std::unique_ptr<void, std::function<void(void *)>> plugin_handle_;
+
+  void CheckRC(std::int32_t rc, std::string_view msg) {
+    if (rc != 0) {
+      auto err_msg = ErrorMsg_();
+      LOG(FATAL) << msg << ":" << err_msg;
+    }
+  }
+
+ public:
+  explicit FederatedPlugin(std::string_view path, Json config);
+  ~FederatedPlugin();
+  // Gradient
+  [[nodiscard]] virtual common::Span<std::uint8_t> EncryptGradient(common::Span<float const> data) {
+    std::uint8_t *ptr{nullptr};
+    std::size_t n{0};
+    auto rc = Encrypt_(this->plugin_handle_.get(), data.data(), data.size(), &ptr, &n);
+    CheckRC(rc, "Failed to encrypt gradient");
+    return {ptr, n};
+  }
+  virtual void SyncEncryptedGradient(common::Span<std::uint8_t const> data) {
+    uint8_t const *out;
+    std::size_t n{0};
+    auto rc = SyncEncrypt_(this->plugin_handle_.get(), data.data(), data.size(), &out, &n);
+    CheckRC(rc, "Failed to sync encrypt gradient");
+  }
+
+  // Vertical histogram
+  virtual void Reset(common::Span<std::uint32_t const> cutptrs,
+                     common::Span<std::int32_t const> bin_idx) {
+    auto rc = ResetHistCtxVert_(this->plugin_handle_.get(), cutptrs.data(), cutptrs.size(),
+                                bin_idx.data(), bin_idx.size());
+    CheckRC(rc, "Failed to set the data context for federated learning");
+  }
+  [[nodiscard]] virtual common::Span<std::uint8_t> BuildEncryptedHistVert(
+      common::Span<std::uint64_t const *> rowptrs, common::Span<std::size_t const> sizes,
+      common::Span<bst_node_t const> nids) {
+    std::uint8_t *ptr{nullptr};
+    std::size_t n{0};
+    auto rc = BuildEncryptedHistVert_(this->plugin_handle_.get(), rowptrs.data(), sizes.data(),
+                                      nids.data(), nids.size(), &ptr, &n);
+    CheckRC(rc, "Failed to build the encrypted hist");
+    return {ptr, n};
+  }
+  [[nodiscard]] virtual common::Span<double> SyncEncryptedHistVert(
+      common::Span<std::uint8_t> hist) {
+    double *ptr{nullptr};
+    std::size_t n{0};
+    auto rc =
+        SyncEncryptedHistVert_(this->plugin_handle_.get(), hist.data(), hist.size(), &ptr, &n);
+    CheckRC(rc, "Failed to sync the encrypted hist");
+    return {ptr, n};
+  }
+
+  // Horizontal histogram
+  [[nodiscard]] virtual common::Span<std::uint8_t> BuildEncryptedHistHori(
+      common::Span<double const> hist) {
+    std::uint8_t *ptr{nullptr};
+    std::size_t n{0};
+    auto rc =
+        BuildEncryptedHistHori_(this->plugin_handle_.get(), hist.data(), hist.size(), &ptr, &n);
+    CheckRC(rc, "Failed to build the encrypted hist");
+    return {ptr, n};
+  }
+  [[nodiscard]] virtual common::Span<double> SyncEncryptedHistHori(
+      common::Span<std::uint8_t const> hist) {
+    double *ptr{nullptr};
+    std::size_t n{0};
+    auto rc =
+        SyncEncryptedHistHori_(this->plugin_handle_.get(), hist.data(), hist.size(), &ptr, &n);
+    CheckRC(rc, "Failed to sync the encrypted hist");
+    return {ptr, n};
+  }
+};
+
+class FederatedPluginMock : public FederatedPlugin {
+ public:
+};
+}  // namespace xgboost::collective

--- a/plugin/federated/federated_plugin.h
+++ b/plugin/federated/federated_plugin.h
@@ -1,48 +1,156 @@
 /**
  * Copyright 2024, XGBoost contributors
+ *
+ * @brief This file defines the interface required for a federated plugin to implement.
+
+ * For federated learning, operations for the gradient and gradient histogram are
+ * performed in the encrypted space, and the encryption is provided by a third-party
+ * plugin. The interface is split into four sections:
+ *
+ *   - Library handle.
+ *   - Gradient encryption.
+ *   - Build histogram for vertical federated learning.
+ *   - Build histogram for horizontal federated learning.
+ *
+ * See below function prototypes for details. All prototypes are for C functions that are
+ * suitable for `dlopen`.
  */
 #pragma once
 
-#include <functional>   // for function
-#include <memory>       // for unique_ptr
-#include <string_view>  // for string_view
+#include <algorithm>   // for copy_n
+#include <cstdint>     // for uint8_t
+#include <functional>  // for function
+#include <memory>      // for unique_ptr
+#include <vector>      // for vector
 
-#include "xgboost/json.h"  // for Json
-#include "xgboost/span.h"  // for Span
-
-typedef void *FederatedPluginHandle;  // NOLINT
+#include "xgboost/json.h"         // for Json
+#include "xgboost/span.h"         // for Span
+#include "xgboost/string_view.h"  // for StringView
 
 namespace xgboost::collective {
 namespace federated {
-// API exposed by the plugin
+/**
+ * @brief Functions for the plugin handle. Plugin can use an opaque handle for defining
+ *        private data structures.
+ */
+typedef void *FederatedPluginHandle;  // NOLINT
+
 using CreateFn = FederatedPluginHandle(int, char const **);
 using CloseFn = int(FederatedPluginHandle);
 using ErrorFn = char const *();
-// Gradient
+/**
+ * @brief Gradient functions, used to provide encryption for gradients.
+ */
 using EncryptFn = int(FederatedPluginHandle handle, float const *in_gpair, size_t n_in,
                       uint8_t **out_gpair, size_t *n_out);
 using SyncEncryptFn = int(FederatedPluginHandle handle, uint8_t const *in_gpair, size_t n_bytes,
-                          uint8_t const **out_gpair, size_t *n_out);
-// Vert Histogram
-using ResetHistCtxVertFn = int(FederatedPluginHandle handle, std::uint32_t const *cutptrs,
-                               std::size_t cutptr_len, std::int32_t const *bin_idx,
-                               std::size_t n_idx);
+                          uint8_t **out_gpair, size_t *n_out);
+/**
+ * @brief Vertical federated learning histogram functions.
+ */
+using ResetHistCtxVertFn = int(FederatedPluginHandle handle, uint32_t const *cutptrs,
+                               size_t cutptr_len, int32_t const *bin_idx, size_t n_idx);
 using BuildHistVertFn = int(FederatedPluginHandle handle, uint64_t const **ridx,
                             size_t const *sizes, int32_t const *nidx, size_t len,
                             uint8_t **out_hist, size_t *out_len);
 using SyncHistVertFn = int(FederatedPluginHandle handle, uint8_t *buf, size_t len, double **out,
                            size_t *out_len);
-// Hori Histogram
+/**
+ * @brief Horizontal federated learning histogram functions.
+ */
 using BuildHistHoriFn = int(FederatedPluginHandle handle, double const *in_histogram, size_t len,
                             uint8_t **out_hist, size_t *out_len);
-using SyncHistHoriFn = int(FederatedPluginHandle handle, std::uint8_t const *buffer,
-                           std::size_t len, double **out_hist, std::size_t *out_len);
+using SyncHistHoriFn = int(FederatedPluginHandle handle, uint8_t const *buffer, size_t len,
+                           double **out_hist, size_t *out_len);
 }  // namespace federated
+
+// Base class for federated learning plugin.
+class FederatedPluginBase {
+  std::vector<std::uint8_t> grad_;
+  std::vector<std::uint8_t> hist_enc_;
+  std::vector<double> hist_plain_;
+
+ public:
+  [[nodiscard]] virtual common::Span<std::uint8_t> EncryptGradient(
+      common::Span<float const> data) = 0;
+  virtual void SyncEncryptedGradient(common::Span<std::uint8_t const>) = 0;
+
+  // Vertical histogram
+  virtual void Reset(common::Span<std::uint32_t const>, common::Span<std::int32_t const>) {}
+
+  [[nodiscard]] virtual common::Span<std::uint8_t> BuildEncryptedHistVert(
+      common::Span<std::uint64_t const *> rowptrs, common::Span<std::size_t const> sizes,
+      common::Span<bst_node_t const> nids) = 0;
+
+  [[nodiscard]] virtual common::Span<double> SyncEncryptedHistVert(
+      common::Span<std::uint8_t> hist) = 0;
+
+  // Horizontal histogram
+  [[nodiscard]] virtual common::Span<std::uint8_t> BuildEncryptedHistHori(
+      common::Span<double const> hist) = 0;
+  [[nodiscard]] virtual common::Span<double> SyncEncryptedHistHori(
+      common::Span<std::uint8_t const> hist) = 0;
+};
+
+// Only used for testing, this class is an no-op implementation.
+class FederatedPluginMock : public FederatedPluginBase {
+  std::vector<std::uint8_t> grad_;
+
+  std::vector<std::uint8_t> hist_enc_;  // represents the encrypted histogram
+  std::vector<double> hist_plain_;      // represents the plain text histogram
+
+  std::vector<std::uint32_t> cuts_;  // HistogramCuts::Ptrs()
+  std::vector<bst_bin_t> gidx_;      // GHistIndexMatrix
+
+ public:
+  ~FederatedPluginMock() = default;
+
+  [[nodiscard]] common::Span<std::uint8_t> EncryptGradient(
+      common::Span<float const> data) override {
+    grad_.resize(data.size_bytes());
+    auto casted =
+        common::Span{reinterpret_cast<std::uint8_t const *>(data.data()), data.size_bytes()};
+    std::copy_n(casted.data(), casted.size(), grad_.data());
+    return grad_;
+  }
+  void SyncEncryptedGradient(common::Span<std::uint8_t const> data) override {
+    auto casted =
+        common::Span{reinterpret_cast<float const *>(data.data()), data.size() / sizeof(float)};
+    grad_.resize(casted.size());
+    std::copy_n(casted.data(), casted.size(), grad_.data());
+  }
+
+  // Vertical histogram
+  void Reset(common::Span<std::uint32_t const>, common::Span<std::int32_t const>) override;
+
+  [[nodiscard]] common::Span<std::uint8_t> BuildEncryptedHistVert(
+      common::Span<std::uint64_t const *> rowptrs, common::Span<std::size_t const> sizes,
+      common::Span<bst_node_t const> nids) override;
+
+  [[nodiscard]] common::Span<double> SyncEncryptedHistVert(
+      common::Span<std::uint8_t> hist) override;
+
+  // Horizontal histogram
+  [[nodiscard]] common::Span<std::uint8_t> BuildEncryptedHistHori(
+      common::Span<double const> hist) override {
+    hist_enc_.resize(hist.size_bytes());
+    std::copy_n(reinterpret_cast<std::uint8_t const *>(hist.data()), hist.size_bytes(),
+                hist_enc_.data());
+    return hist_enc_;
+  }
+  [[nodiscard]] common::Span<double> SyncEncryptedHistHori(
+      common::Span<std::uint8_t const> hist) override {
+    std::size_t n = hist.size_bytes() / sizeof(double);
+    hist_plain_.resize(n);
+    std::copy_n(reinterpret_cast<double const *>(hist.data()), n, hist_plain_.data());
+    return hist_plain_;
+  }
+};
 
 /**
  * @brief Bridge for plugins that handle encryption.
  */
-class FederatedPlugin {
+class FederatedPlugin : public FederatedPluginBase {
   // Federated plugin shared object, for dlopen.
   std::unique_ptr<void, std::function<void(void *)>> plugin_;
 
@@ -71,33 +179,34 @@ class FederatedPlugin {
   }
 
  public:
-  explicit FederatedPlugin(std::string_view path, Json config);
+  explicit FederatedPlugin(StringView path, Json config);
   ~FederatedPlugin();
   // Gradient
-  [[nodiscard]] virtual common::Span<std::uint8_t> EncryptGradient(common::Span<float const> data) {
+  [[nodiscard]] common::Span<std::uint8_t> EncryptGradient(
+      common::Span<float const> data) override {
     std::uint8_t *ptr{nullptr};
     std::size_t n{0};
     auto rc = Encrypt_(this->plugin_handle_.get(), data.data(), data.size(), &ptr, &n);
     CheckRC(rc, "Failed to encrypt gradient");
     return {ptr, n};
   }
-  virtual void SyncEncryptedGradient(common::Span<std::uint8_t const> data) {
-    uint8_t const *out;
+  void SyncEncryptedGradient(common::Span<std::uint8_t const> data) override {
+    uint8_t *out;
     std::size_t n{0};
     auto rc = SyncEncrypt_(this->plugin_handle_.get(), data.data(), data.size(), &out, &n);
     CheckRC(rc, "Failed to sync encrypt gradient");
   }
 
   // Vertical histogram
-  virtual void Reset(common::Span<std::uint32_t const> cutptrs,
-                     common::Span<std::int32_t const> bin_idx) {
+  void Reset(common::Span<std::uint32_t const> cutptrs,
+             common::Span<std::int32_t const> bin_idx) override {
     auto rc = ResetHistCtxVert_(this->plugin_handle_.get(), cutptrs.data(), cutptrs.size(),
                                 bin_idx.data(), bin_idx.size());
     CheckRC(rc, "Failed to set the data context for federated learning");
   }
-  [[nodiscard]] virtual common::Span<std::uint8_t> BuildEncryptedHistVert(
+  [[nodiscard]] common::Span<std::uint8_t> BuildEncryptedHistVert(
       common::Span<std::uint64_t const *> rowptrs, common::Span<std::size_t const> sizes,
-      common::Span<bst_node_t const> nids) {
+      common::Span<bst_node_t const> nids) override {
     std::uint8_t *ptr{nullptr};
     std::size_t n{0};
     auto rc = BuildEncryptedHistVert_(this->plugin_handle_.get(), rowptrs.data(), sizes.data(),
@@ -105,8 +214,8 @@ class FederatedPlugin {
     CheckRC(rc, "Failed to build the encrypted hist");
     return {ptr, n};
   }
-  [[nodiscard]] virtual common::Span<double> SyncEncryptedHistVert(
-      common::Span<std::uint8_t> hist) {
+  [[nodiscard]] common::Span<double> SyncEncryptedHistVert(
+      common::Span<std::uint8_t> hist) override {
     double *ptr{nullptr};
     std::size_t n{0};
     auto rc =
@@ -116,8 +225,8 @@ class FederatedPlugin {
   }
 
   // Horizontal histogram
-  [[nodiscard]] virtual common::Span<std::uint8_t> BuildEncryptedHistHori(
-      common::Span<double const> hist) {
+  [[nodiscard]] common::Span<std::uint8_t> BuildEncryptedHistHori(
+      common::Span<double const> hist) override {
     std::uint8_t *ptr{nullptr};
     std::size_t n{0};
     auto rc =
@@ -125,8 +234,8 @@ class FederatedPlugin {
     CheckRC(rc, "Failed to build the encrypted hist");
     return {ptr, n};
   }
-  [[nodiscard]] virtual common::Span<double> SyncEncryptedHistHori(
-      common::Span<std::uint8_t const> hist) {
+  [[nodiscard]] common::Span<double> SyncEncryptedHistHori(
+      common::Span<std::uint8_t const> hist) override {
     double *ptr{nullptr};
     std::size_t n{0};
     auto rc =
@@ -136,7 +245,5 @@ class FederatedPlugin {
   }
 };
 
-class FederatedPluginMock : public FederatedPlugin {
- public:
-};
+[[nodiscard]] FederatedPluginBase *CreateFederatedPlugin(Json config);
 }  // namespace xgboost::collective

--- a/plugin/federated/federated_plugin.h
+++ b/plugin/federated/federated_plugin.h
@@ -206,10 +206,8 @@ class FederatedPluginMock : public FederatedPluginBase {
     return grad_;
   }
   void SyncEncryptedGradient(common::Span<std::uint8_t const> data) override {
-    auto casted =
-        common::Span{reinterpret_cast<float const *>(data.data()), data.size() / sizeof(float)};
-    grad_.resize(casted.size());
-    std::copy_n(casted.data(), casted.size(), grad_.data());
+    grad_.resize(data.size_bytes());
+    std::copy_n(data.data(), data.size(), grad_.data());
   }
 
   // Vertical histogram

--- a/python-package/xgboost/federated.py
+++ b/python-package/xgboost/federated.py
@@ -65,9 +65,19 @@ def run_federated_server(  # pylint: disable=too-many-arguments
     server_key_path: Optional[str] = None,
     server_cert_path: Optional[str] = None,
     client_cert_path: Optional[str] = None,
+    blocking: bool = True,
     timeout: int = 300,
-) -> Dict[str, Any]:
-    """See :py:class:`~xgboost.federated.FederatedTracker` for more info."""
+) -> Dict[str, Any] | None:
+    """See :py:class:`~xgboost.federated.FederatedTracker` for more info.
+
+    Parameters
+    ----------
+    blocking :
+        Block the server until the training is finished. If set to False, the function
+        launches an additional thread and returns the worker arguments. The default is
+        True and a higher level framework is responsible for setting worker parameters.
+
+    """
     args: Dict[str, Any] = {"n_workers": n_workers}
     secure = all(
         path is not None
@@ -77,6 +87,10 @@ def run_federated_server(  # pylint: disable=too-many-arguments
         n_workers=n_workers, port=port, secure=secure, timeout=timeout
     )
     tracker.start()
+
+    if blocking:
+        tracker.wait_for()
+        return None
 
     thread = Thread(target=tracker.wait_for)
     thread.daemon = True

--- a/python-package/xgboost/federated.py
+++ b/python-package/xgboost/federated.py
@@ -67,7 +67,7 @@ def run_federated_server(  # pylint: disable=too-many-arguments
     client_cert_path: Optional[str] = None,
     blocking: bool = True,
     timeout: int = 300,
-) -> Dict[str, Any] | None:
+) -> Optional[Dict[str, Any]]:
     """See :py:class:`~xgboost.federated.FederatedTracker` for more info.
 
     Parameters

--- a/src/collective/aggregator.h
+++ b/src/collective/aggregator.h
@@ -98,7 +98,7 @@ void ApplyWithLabels(Context const* ctx, MetaInfo const& info, void* buffer, std
 template <typename T, typename Fn>
 void ApplyWithLabels(Context const* ctx, MetaInfo const& info, HostDeviceVector<T>* result,
                      Fn&& fn) {
-  if (info.IsColumnSplit()) {
+  if (info.IsVerticalFederated()) {
     // We assume labels are only available on worker 0, so the calculation is done there
     // and result is broadcasted to other workers.
     auto rc = detail::TryApplyWithLabels(ctx, std::forward<Fn>(fn));

--- a/src/collective/aggregator.h
+++ b/src/collective/aggregator.h
@@ -9,7 +9,6 @@
 #include <limits>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "allreduce.h"
 #include "broadcast.h"
@@ -17,9 +16,13 @@
 #include "communicator-inl.h"
 #include "xgboost/collective/result.h"  // for Result
 #include "xgboost/data.h"               // for MetaINfo
+#if defined(XGBOOST_USE_FEDERATED)
+#include "../../plugin/federated/federated_comm.h"
+#endif  // defined(XGBOOST_USE_FEDERATED)
 
 namespace xgboost::collective {
 namespace detail {
+// Apply function fn, and handle potential errors.
 template <typename Fn>
 [[nodiscard]] Result TryApplyWithLabels(Context const* ctx, Fn&& fn) {
   std::string msg;
@@ -30,10 +33,10 @@ template <typename Fn>
       msg = e.what();
     }
   }
+  // Error handling
   std::size_t msg_size{msg.size()};
   auto rc = Success() << [&] {
-    auto rc = collective::Broadcast(ctx, linalg::MakeVec(&msg_size, 1), 0);
-    return rc;
+    return collective::Broadcast(ctx, linalg::MakeVec(&msg_size, 1), 0);
   } << [&] {
     if (msg_size > 0) {
       msg.resize(msg_size);
@@ -95,11 +98,11 @@ void ApplyWithLabels(Context const* ctx, MetaInfo const& info, void* buffer, std
 template <typename T, typename Fn>
 void ApplyWithLabels(Context const* ctx, MetaInfo const& info, HostDeviceVector<T>* result,
                      Fn&& fn) {
-  if (info.IsVerticalFederated()) {
-    // We assume labels are only available on worker 0, so the calculation is done there and result
-    // broadcast to other workers.
-    auto rc = detail::TryApplyWithLabels(ctx, fn);
-
+  if (info.IsColumnSplit()) {
+    // We assume labels are only available on worker 0, so the calculation is done there
+    // and result is broadcasted to other workers.
+    auto rc = detail::TryApplyWithLabels(ctx, std::forward<Fn>(fn));
+    // Broadcast the result
     std::size_t size{result->Size()};
     rc = std::move(rc) << [&] {
       return collective::Broadcast(ctx, linalg::MakeVec(&size, 1), 0);
@@ -109,7 +112,7 @@ void ApplyWithLabels(Context const* ctx, MetaInfo const& info, HostDeviceVector<
     };
     SafeColl(rc);
   } else {
-    std::forward<Fn>(fn)();
+    fn();
   }
 }
 

--- a/src/collective/comm.cu
+++ b/src/collective/comm.cu
@@ -11,7 +11,6 @@
 #include <vector>     // for vector
 
 #include "../common/cuda_context.cuh"    // for CUDAContext
-#include "../common/device_helpers.cuh"  // for DefaultStream
 #include "../common/type.h"              // for EraseType
 #include "comm.cuh"                      // for NCCLComm
 #include "comm.h"                        // for Comm

--- a/src/collective/comm.h
+++ b/src/collective/comm.h
@@ -102,6 +102,7 @@ class Comm : public std::enable_shared_from_this<Comm> {
     return channels_.at(rank);
   }
   [[nodiscard]] virtual bool IsFederated() const = 0;
+  [[nodiscard]] virtual bool IsEncrypted() const { return false; }
   [[nodiscard]] virtual Result LogTracker(std::string msg) const = 0;
 
   [[nodiscard]] virtual Result SignalError(Result const&) { return Success(); }

--- a/src/collective/comm_group.cc
+++ b/src/collective/comm_group.cc
@@ -128,14 +128,18 @@ void Init(Json const& config) { GlobalCommGroupInit(config); }
 
 void Finalize() { GlobalCommGroupFinalize(); }
 
-std::int32_t GetRank() noexcept { return GlobalCommGroup()->Rank(); }
+[[nodiscard]] std::int32_t GetRank() noexcept { return GlobalCommGroup()->Rank(); }
 
-std::int32_t GetWorldSize() noexcept { return GlobalCommGroup()->World(); }
+[[nodiscard]] std::int32_t GetWorldSize() noexcept { return GlobalCommGroup()->World(); }
 
-bool IsDistributed() noexcept { return GlobalCommGroup()->IsDistributed(); }
+[[nodiscard]] bool IsDistributed() noexcept { return GlobalCommGroup()->IsDistributed(); }
 
-[[nodiscard]] bool IsFederated() {
+[[nodiscard]] bool IsFederated() noexcept {
   return GlobalCommGroup()->Ctx(nullptr, DeviceOrd::CPU()).IsFederated();
+}
+
+[[nodiscard]] bool IsEncrypted() noexcept {
+  return IsFederated() && GlobalCommGroup()->Ctx(nullptr, DeviceOrd::CPU()).IsEncrypted();
 }
 
 void Print(std::string const& message) {

--- a/src/collective/comm_group.h
+++ b/src/collective/comm_group.h
@@ -17,7 +17,7 @@ namespace xgboost::collective {
  */
 class CommGroup {
   std::shared_ptr<HostComm> comm_;
-  mutable std::shared_ptr<Comm> gpu_comm_;
+  mutable std::shared_ptr<Comm> gpu_comm_;  // lazy initialization
 
   std::shared_ptr<Coll> backend_;
   mutable std::shared_ptr<Coll> gpu_coll_;  // lazy initialization

--- a/src/collective/communicator-inl.h
+++ b/src/collective/communicator-inl.h
@@ -45,9 +45,12 @@ void Finalize();
  *
  * @return True if the communicator is federated.
  */
-[[nodiscard]] bool IsFederated() noexcept;
+[[nodiscard]] bool IsFederated();
 
-[[nodiscard]] bool IsEncrypted() noexcept;
+/**
+ * @brief Get if the communicator has an encryption plugin.
+ */
+[[nodiscard]] bool IsEncrypted();
 
 /**
  * @brief Print the message to the communicator.

--- a/src/collective/communicator-inl.h
+++ b/src/collective/communicator-inl.h
@@ -45,7 +45,9 @@ void Finalize();
  *
  * @return True if the communicator is federated.
  */
-[[nodiscard]] bool IsFederated();
+[[nodiscard]] bool IsFederated() noexcept;
+
+[[nodiscard]] bool IsEncrypted() noexcept;
 
 /**
  * @brief Print the message to the communicator.

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -626,30 +626,6 @@ class ParallelGHistBuilder {
 template <bool any_missing>
 void BuildHist(Span<GradientPair const> gpair, const RowSetCollection::Elem row_indices,
                const GHistIndexMatrix& gmat, GHistRow hist, bool force_read_by_column = false);
-
-// Build routine for sample-based split.
-template <bool any_missing>
-void BuildSampleHistograms(std::int32_t n_threads, common::BlockedSpace2d const& space,
-                           GHistIndexMatrix const& gidx,
-                           std::vector<bst_node_t> const& nodes_to_build,
-                           common::RowSetCollection const& row_set_collection,
-                           common::Span<GradientPair const> gpair_h, bool force_read_by_column,
-                           common::ParallelGHistBuilder* buffer) {
-  // Parallel processing by nodes and data in each node
-  common::ParallelFor2d(space, n_threads, [&](bst_idx_t nid_in_set, common::Range1d r) {
-    auto const tid = omp_get_thread_num();
-    bst_node_t const nidx = nodes_to_build[nid_in_set];
-    auto elem = row_set_collection[nidx];
-    auto start_of_row_set = std::min(r.begin(), elem.Size());
-    auto end_of_row_set = std::min(r.end(), elem.Size());
-    auto rid_set = common::RowSetCollection::Elem(elem.begin + start_of_row_set,
-                                                  elem.begin + end_of_row_set, nidx);
-    auto hist = buffer->GetInitializedHist(tid, nid_in_set);
-    if (rid_set.Size() != 0) {
-      common::BuildHist<any_missing>(gpair_h, rid_set, gidx, hist, force_read_by_column);
-    }
-  });
-}
 }  // namespace common
 }  // namespace xgboost
 #endif  // XGBOOST_COMMON_HIST_UTIL_H_

--- a/src/common/quantile.cc
+++ b/src/common/quantile.cc
@@ -448,7 +448,7 @@ void SketchContainerImpl<WQSketch>::MakeCuts(Context const *ctx, MetaInfo const 
     std::int32_t max_num_bins = std::min(num_cuts[fid], max_bins_);
     // If vertical and secure mode, we need to sync the max_num_bins aross workers
     // to create the same global number of cut point bins for easier future processing
-    if (info.IsVerticalFederated() && info.IsSecure()) {
+    if (info.IsVerticalFederated() && collective::IsFederated()) {
       collective::SafeColl(collective::Allreduce(ctx, &max_num_bins, collective::Op::kMax));
     }
     typename WQSketch::SummaryContainer const &a = final_summaries[fid];
@@ -456,7 +456,7 @@ void SketchContainerImpl<WQSketch>::MakeCuts(Context const *ctx, MetaInfo const 
       max_cat = std::max(max_cat, AddCategories(categories_.at(fid), p_cuts));
     } else {
       // use special AddCutPoint scheme for secure vertical federated learning
-      bool is_nan = AddCutPoint<WQSketch>(ctx, a, max_num_bins, p_cuts, info.IsSecure());
+      bool is_nan = AddCutPoint<WQSketch>(ctx, a, max_num_bins, p_cuts, collective::IsFederated());
       // push a value that is greater than anything if the feature is not empty
       // i.e. if the last value is not NaN
       if (!is_nan) {

--- a/src/common/quantile.cc
+++ b/src/common/quantile.cc
@@ -388,7 +388,7 @@ bool AddCutPoint(Context const *ctx, typename SketchType::SummaryContainer const
   } else {
     // we use the min_value as the first (0th) element, hence starting from 1.
     for (size_t i = 1; i < required_cuts; ++i) {
-      bst_float cpt = summary.data[i].value;
+      auto cpt = summary.data[i].value;
       if (i == 1 || cpt > cut_values.back()) {
         cut_values.push_back(cpt);
       }
@@ -461,13 +461,13 @@ void SketchContainerImpl<WQSketch>::MakeCuts(Context const *ctx, MetaInfo const 
       // i.e. if the last value is not NaN
       if (!is_nan) {
         const bst_float cpt =
-              (a.size > 0) ? a.data[a.size - 1].value : p_cuts->min_vals_.HostVector()[fid];
+            (a.size > 0) ? a.data[a.size - 1].value : p_cuts->min_vals_.HostVector()[fid];
         // this must be bigger than last value in a scale
         const bst_float last = cpt + (fabs(cpt) + 1e-5f);
         p_cuts->cut_values_.HostVector().push_back(last);
       } else {
-          // if the feature is empty, push a NaN value
-          p_cuts->cut_values_.HostVector().push_back(std::numeric_limits<double>::quiet_NaN());
+        // if the feature is empty, push a NaN value
+        p_cuts->cut_values_.HostVector().push_back(std::numeric_limits<double>::quiet_NaN());
       }
     }
     // Ensure that every feature gets at least one quantile point

--- a/src/common/quantile.cc
+++ b/src/common/quantile.cc
@@ -448,7 +448,7 @@ void SketchContainerImpl<WQSketch>::MakeCuts(Context const *ctx, MetaInfo const 
     std::int32_t max_num_bins = std::min(num_cuts[fid], max_bins_);
     // If vertical and secure mode, we need to sync the max_num_bins aross workers
     // to create the same global number of cut point bins for easier future processing
-    if (info.IsVerticalFederated() && collective::IsFederated()) {
+    if (info.IsVerticalFederated()) {
       collective::SafeColl(collective::Allreduce(ctx, &max_num_bins, collective::Op::kMax));
     }
     typename WQSketch::SummaryContainer const &a = final_summaries[fid];

--- a/src/common/row_set.h
+++ b/src/common/row_set.h
@@ -1,5 +1,5 @@
-/*!
- * Copyright 2017-2022 by Contributors
+/**
+ * Copyright 2017-2024, XGBoost Contributors
  * \file row_set.h
  * \brief Quick Utility to compute subset of rows
  * \author Philip Cho, Tianqi Chen
@@ -7,15 +7,17 @@
 #ifndef XGBOOST_COMMON_ROW_SET_H_
 #define XGBOOST_COMMON_ROW_SET_H_
 
-#include <xgboost/data.h>
-#include <algorithm>
-#include <vector>
-#include <utility>
-#include <memory>
+#include <cstddef>   // for size_t
+#include <iterator>  // for distance
+#include <vector>    // for vector
 
-namespace xgboost {
-namespace common {
-/*! \brief collection of rowset */
+#include "xgboost/base.h"     // for bst_node_t
+#include "xgboost/logging.h"  // for CHECK
+
+namespace xgboost::common {
+/**
+ * @brief Collection of rows for each tree node.
+ */
 class RowSetCollection {
  public:
   RowSetCollection() = default;
@@ -24,84 +26,78 @@ class RowSetCollection {
   RowSetCollection& operator=(RowSetCollection const&) = delete;
   RowSetCollection& operator=(RowSetCollection&&) = default;
 
-  /*! \brief data structure to store an instance set, a subset of
-   *  rows (instances) associated with a particular node in a decision
-   *  tree. */
+  /**
+   * @brief data structure to store an instance set, a subset of rows (instances)
+   *        associated with a particular node in a decision tree.
+   */
   struct Elem {
-    const size_t* begin{nullptr};
-    const size_t* end{nullptr};
+    std::size_t const* begin{nullptr};
+    std::size_t const* end{nullptr};
     bst_node_t node_id{-1};
-      // id of node associated with this instance set; -1 means uninitialized
-    Elem()
-         = default;
-    Elem(const size_t* begin,
-         const size_t* end,
-         bst_node_t node_id = -1)
+    // id of node associated with this instance set; -1 means uninitialized
+    Elem() = default;
+    Elem(std::size_t const* begin, std::size_t const* end, bst_node_t node_id = -1)
         : begin(begin), end(end), node_id(node_id) {}
 
-    inline size_t Size() const {
-      return end - begin;
-    }
+    std::size_t Size() const { return end - begin; }
   };
 
-  std::vector<Elem>::const_iterator begin() const {  // NOLINT
-    return elem_of_each_node_.begin();
+  [[nodiscard]] std::vector<Elem>::const_iterator begin() const {  // NOLINT
+    return elem_of_each_node_.cbegin();
+  }
+  [[nodiscard]] std::vector<Elem>::const_iterator end() const {  // NOLINT
+    return elem_of_each_node_.cend();
   }
 
-  std::vector<Elem>::const_iterator end() const {  // NOLINT
-    return elem_of_each_node_.end();
-  }
+  [[nodiscard]] std::size_t Size() const { return std::distance(begin(), end()); }
 
-  size_t Size() const { return std::distance(begin(), end()); }
-
-  /*! \brief return corresponding element set given the node_id */
-  inline const Elem& operator[](unsigned node_id) const {
-    const Elem& e = elem_of_each_node_[node_id];
+  /** @brief return corresponding element set given the node_id */
+  [[nodiscard]] Elem const& operator[](bst_node_t node_id) const {
+    Elem const& e = elem_of_each_node_[node_id];
     return e;
   }
-
-  /*! \brief return corresponding element set given the node_id */
-  inline Elem& operator[](unsigned node_id) {
+  /** @brief return corresponding element set given the node_id */
+  [[nodiscard]] Elem& operator[](bst_node_t node_id) {
     Elem& e = elem_of_each_node_[node_id];
     return e;
   }
 
   // clear up things
-  inline void Clear() {
+  void Clear() {
     elem_of_each_node_.clear();
   }
   // initialize node id 0->everything
-  inline void Init() {
-    CHECK_EQ(elem_of_each_node_.size(), 0U);
+  void Init() {
+    CHECK(elem_of_each_node_.empty());
 
     if (row_indices_.empty()) {  // edge case: empty instance set
-      constexpr size_t* kBegin = nullptr;
-      constexpr size_t* kEnd = nullptr;
+      constexpr std::size_t* kBegin = nullptr;
+      constexpr std::size_t* kEnd = nullptr;
       static_assert(kEnd - kBegin == 0);
       elem_of_each_node_.emplace_back(kBegin, kEnd, 0);
       return;
     }
 
-    const size_t* begin = dmlc::BeginPtr(row_indices_);
-    const size_t* end = dmlc::BeginPtr(row_indices_) + row_indices_.size();
+    const std::size_t* begin = dmlc::BeginPtr(row_indices_);
+    const std::size_t* end = dmlc::BeginPtr(row_indices_) + row_indices_.size();
     elem_of_each_node_.emplace_back(begin, end, 0);
   }
 
-  std::vector<size_t>* Data() { return &row_indices_; }
-  std::vector<size_t> const* Data() const { return &row_indices_; }
+  [[nodiscard]] std::vector<std::size_t>* Data() { return &row_indices_; }
+  [[nodiscard]] std::vector<std::size_t> const* Data() const { return &row_indices_; }
 
   // split rowset into two
-  inline void AddSplit(unsigned node_id, unsigned left_node_id, unsigned right_node_id,
-                       size_t n_left, size_t n_right) {
+  void AddSplit(bst_node_t node_id, bst_node_t left_node_id, bst_node_t right_node_id,
+                bst_idx_t n_left, bst_idx_t n_right) {
     const Elem e = elem_of_each_node_[node_id];
 
-    size_t* all_begin{nullptr};
-    size_t* begin{nullptr};
+    std::size_t* all_begin{nullptr};
+    std::size_t* begin{nullptr};
     if (e.begin == nullptr) {
       CHECK_EQ(n_left, 0);
       CHECK_EQ(n_right, 0);
     } else {
-      all_begin = dmlc::BeginPtr(row_indices_);
+      all_begin = row_indices_.data();
       begin = all_begin + (e.begin - all_begin);
     }
 
@@ -109,25 +105,24 @@ class RowSetCollection {
     CHECK_LE(begin + n_left, e.end);
     CHECK_EQ(begin + n_left + n_right, e.end);
 
-    if (left_node_id >= elem_of_each_node_.size()) {
-      elem_of_each_node_.resize(left_node_id + 1, Elem(nullptr, nullptr, -1));
+    if (left_node_id >= static_cast<bst_node_t>(elem_of_each_node_.size())) {
+      elem_of_each_node_.resize(left_node_id + 1, Elem{nullptr, nullptr, -1});
     }
-    if (right_node_id >= elem_of_each_node_.size()) {
-      elem_of_each_node_.resize(right_node_id + 1, Elem(nullptr, nullptr, -1));
+    if (right_node_id >= static_cast<bst_node_t>(elem_of_each_node_.size())) {
+      elem_of_each_node_.resize(right_node_id + 1, Elem{nullptr, nullptr, -1});
     }
 
-    elem_of_each_node_[left_node_id] = Elem(begin, begin + n_left, left_node_id);
-    elem_of_each_node_[right_node_id] = Elem(begin + n_left, e.end, right_node_id);
-    elem_of_each_node_[node_id] = Elem(nullptr, nullptr, -1);
+    elem_of_each_node_[left_node_id] = Elem{begin, begin + n_left, left_node_id};
+    elem_of_each_node_[right_node_id] = Elem{begin + n_left, e.end, right_node_id};
+    elem_of_each_node_[node_id] = Elem{nullptr, nullptr, -1};
   }
 
  private:
   // stores the row indexes in the set
-  std::vector<size_t> row_indices_;
+  std::vector<std::size_t> row_indices_;
   // vector: node_id -> elements
   std::vector<Elem> elem_of_each_node_;
 };
-}  // namespace common
-}  // namespace xgboost
+}  // namespace xgboost::common
 
 #endif  // XGBOOST_COMMON_ROW_SET_H_

--- a/src/common/threadpool.h
+++ b/src/common/threadpool.h
@@ -34,12 +34,10 @@ class ThreadPool {
           cv_.wait(lock, [this] { return !this->tasks_.empty() || stop_; });
 
           if (this->stop_) {
-            if (!tasks_.empty()) {
-              while (!tasks_.empty()) {
-                auto fn = tasks_.front();
-                tasks_.pop();
-                fn();
-              }
+            while (!tasks_.empty()) {
+              auto fn = tasks_.front();
+              tasks_.pop();
+              fn();
             }
             return;
           }

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -803,9 +803,7 @@ void MetaInfo::Validate(DeviceOrd device) const {
 void MetaInfo::SetInfoFromCUDA(Context const&, StringView, Json) { common::AssertGPUSupport(); }
 #endif  // !defined(XGBOOST_USE_CUDA)
 
-bool MetaInfo::IsVerticalFederated() const {
-  return collective::IsFederated() && IsColumnSplit();
-}
+bool MetaInfo::IsVerticalFederated() const { return collective::IsFederated() && IsColumnSplit(); }
 
 bool MetaInfo::ShouldHaveLabels() const {
   return !IsVerticalFederated() || collective::GetRank() == 0;

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -7,8 +7,8 @@
 
 #include <algorithm>  // for min
 #include <atomic>     // for atomic
-#include <cinttypes>  // for uint32_t
 #include <cstddef>    // for size_t
+#include <cstdint>    // for uint32_t
 #include <memory>     // for make_unique
 #include <vector>
 

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1470,7 +1470,7 @@ class LearnerImpl : public LearnerIO {
                    std::int32_t iter, linalg::Matrix<GradientPair>* out_gpair) {
     monitor_.Start(__func__);
     out_gpair->Reshape(info.num_row_, this->learner_model_param_.OutputLength());
-    if (info.IsVerticalFederated()) {
+    if (info.IsVerticalFederated() && collective::IsEncrypted()) {
 #if defined(XGBOOST_USE_FEDERATED)
       // Need to encrypt the gradient before broadcasting.
       common::Span<std::uint8_t> encrypted;

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -23,13 +23,11 @@
 #include <limits>                         // for numeric_limits
 #include <memory>                         // for allocator, unique_ptr, shared_ptr, operator==
 #include <mutex>                          // for mutex, lock_guard
-#include <set>                            // for set
 #include <sstream>                        // for operator<<, basic_ostream, basic_ostream::opera...
 #include <stack>                          // for stack
 #include <string>                         // for basic_string, char_traits, operator<, string
 #include <system_error>                   // for errc
 #include <tuple>                          // for get
-#include <unordered_map>                  // for operator!=, unordered_map
 #include <utility>                        // for pair, as_const, move, swap
 #include <vector>                         // for vector
 
@@ -1283,9 +1281,7 @@ class LearnerImpl : public LearnerIO {
     TrainingObserver::Instance().Observe(predt.predictions, "Predictions");
     monitor_.Stop("PredictRaw");
 
-    monitor_.Start("GetGradient");
-    GetGradient(predt.predictions, train->Info(), iter, &gpair_);
-    monitor_.Stop("GetGradient");
+    this->GetGradient(predt.predictions, train->Info(), iter, &gpair_);
     TrainingObserver::Instance().Observe(*gpair_.Data(), "Gradients");
 
     gbm_->DoBoost(train.get(), &gpair_, &predt, obj_.get());
@@ -1472,9 +1468,49 @@ class LearnerImpl : public LearnerIO {
  private:
   void GetGradient(HostDeviceVector<bst_float> const& preds, MetaInfo const& info,
                    std::int32_t iter, linalg::Matrix<GradientPair>* out_gpair) {
+    monitor_.Start(__func__);
     out_gpair->Reshape(info.num_row_, this->learner_model_param_.OutputLength());
-    collective::ApplyWithLabels(&ctx_, info, out_gpair->Data(),
-                                [&] { obj_->GetGradient(preds, info, iter, out_gpair); });
+    if (info.IsVerticalFederated()) {
+      // Need to encrypt the gradient before broadcasting.
+      common::Span<std::uint8_t> encrypted;
+      auto const& comm = collective::GlobalCommGroup()->Ctx(&ctx_, ctx_.Device());
+      auto const& fed = dynamic_cast<collective::FederatedComm const&>(comm);
+      if (collective::GetRank() == 0) {
+        // Obtain the gradient
+        obj_->GetGradient(preds, info, iter, out_gpair);
+        auto values = out_gpair->HostView().Values();
+        // Encrypt the gradient
+        static_assert(sizeof(GradientPair) == sizeof(float) * 2);
+        auto casted = reinterpret_cast<float const*>(values.data());
+        auto data = common::Span{casted, values.size() * 2};
+
+        encrypted = fed.EncryptionPlugin()->EncryptGradient(data);
+      }
+      // Broadcast the gradient
+      std::uint64_t n_bytes = encrypted.size();
+      HostDeviceVector<std::uint8_t> grad;
+      auto rc = collective::Success() << [&] {
+        return collective::Broadcast(&ctx_, linalg::MakeVec(&n_bytes, 1), 0);
+      } << [&] {
+        if (collective::GetRank() != 0) {
+          grad.Resize(n_bytes);
+          encrypted = grad.HostSpan();
+        }
+        return collective::Broadcast(&ctx_, linalg::MakeVec(encrypted), 0);
+      };
+      collective::SafeColl(rc);
+      auto sig = encrypted.subspan(0, 8);
+      std::stringstream ss;
+      for (auto v : sig) {
+        ss << static_cast<char>(v);
+      }
+      // Pass the gradient to the plugin
+      fed.EncryptionPlugin()->SyncEncryptedGradient(encrypted);
+    } else {
+      collective::ApplyWithLabels(&ctx_, info, out_gpair->Data(),
+                                  [&]() { obj_->GetGradient(preds, info, iter, out_gpair); });
+    }
+    monitor_.Stop(__func__);
   }
 
   /*! \brief random number transformation seed. */

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -291,7 +291,7 @@ class HistEvaluator {
       ibegin = static_cast<bst_bin_t>(cut_ptr[fidx + 1]) - 1;
       iend = static_cast<bst_bin_t>(cut_ptr[fidx]) - 1;
     }
-    bool fed_vertical = is_secure_ && is_col_split_;
+    bool enc_vertical = is_secure_ && is_col_split_;
 
     for (bst_bin_t i = ibegin; i != iend; i += d_step) {
       // start working
@@ -306,7 +306,7 @@ class HistEvaluator {
           loss_chg =
               static_cast<float>(evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{left_sum},
                                                          GradStats{right_sum}) - parent.root_gain);
-          if (!fed_vertical) {
+          if (!enc_vertical) {
             split_pt = cut_val[i];  // not used for partition based
             best.Update(loss_chg, fidx, split_pt, d_step == -1, false, left_sum, right_sum);
           } else {
@@ -319,7 +319,7 @@ class HistEvaluator {
           loss_chg =
               static_cast<float>(evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{right_sum},
                                                          GradStats{left_sum}) - parent.root_gain);
-          if (!fed_vertical) {
+          if (!enc_vertical) {
             if (i == imin) {
               split_pt = cut.MinValues()[fidx];
             } else {
@@ -516,7 +516,7 @@ class HistEvaluator {
         column_sampler_{std::move(sampler)},
         tree_evaluator_{*param, static_cast<bst_feature_t>(info.num_col_), DeviceOrd::CPU()},
         is_col_split_{info.IsColumnSplit()},
-        is_secure_{collective::IsFederated()} {
+        is_secure_{collective::IsEncrypted()} {
     interaction_constraints_.Configure(*param, info.num_col_);
     column_sampler_->Init(ctx, info.num_col_, info.feature_weights.HostVector(),
                           param_->colsample_bynode, param_->colsample_bylevel,
@@ -747,7 +747,7 @@ class HistMultiEvaluator {
         column_sampler_{std::move(sampler)},
         ctx_{ctx},
         is_col_split_{info.IsColumnSplit()},
-        is_secure_{collective::IsFederated()} {
+        is_secure_{collective::IsEncrypted()} {
     interaction_constraints_.Configure(*param, info.num_col_);
     column_sampler_->Init(ctx, info.num_col_, info.feature_weights.HostVector(),
                           param_->colsample_bynode, param_->colsample_bylevel,

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -516,7 +516,7 @@ class HistEvaluator {
         column_sampler_{std::move(sampler)},
         tree_evaluator_{*param, static_cast<bst_feature_t>(info.num_col_), DeviceOrd::CPU()},
         is_col_split_{info.IsColumnSplit()},
-        is_secure_{info.IsSecure()}{
+        is_secure_{collective::IsFederated()} {
     interaction_constraints_.Configure(*param, info.num_col_);
     column_sampler_->Init(ctx, info.num_col_, info.feature_weights.HostVector(),
                           param_->colsample_bynode, param_->colsample_bylevel,
@@ -747,7 +747,7 @@ class HistMultiEvaluator {
         column_sampler_{std::move(sampler)},
         ctx_{ctx},
         is_col_split_{info.IsColumnSplit()},
-        is_secure_{info.IsSecure()} {
+        is_secure_{collective::IsFederated()} {
     interaction_constraints_.Configure(*param, info.num_col_);
     column_sampler_->Init(ctx, info.num_col_, info.feature_weights.HostVector(),
                           param_->colsample_bynode, param_->colsample_bylevel,

--- a/src/tree/hist/histogram.cc
+++ b/src/tree/hist/histogram.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 by XGBoost Contributors
+ * Copyright 2023-2024, XGBoost Contributors
  */
 #include "histogram.h"
 
@@ -10,7 +10,7 @@
 
 #include "../../common/transform_iterator.h"  // for MakeIndexTransformIter
 #include "expand_entry.h"                     // for MultiExpandEntry, CPUExpandEntry
-#include "xgboost/logging.h"                  // for CHECK_NE
+#include "xgboost/logging.h"                  // for CHECK_EQ
 #include "xgboost/span.h"                     // for Span
 #include "xgboost/tree_model.h"               // for RegTree
 

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -271,8 +271,8 @@ class DefaultHistPolicy {
     auto n_total_bins = buffer->TotalBins();
     auto &hist = *p_hist;
 
-    common::BlockedSpace2d space(
-        nodes_to_build.size(), [&](std::size_t) { return n_total_bins; }, 1024);
+    auto space = common::BlockedSpace2d{nodes_to_build.size(),
+                                        [&](std::size_t) { return n_total_bins; }, 1024};
     common::ParallelFor2d(space, ctx->Threads(), [&](size_t node, common::Range1d r) {
       // Merging histograms from each thread.
       buffer->ReduceHist(node, r.begin(), r.end());

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -197,7 +197,6 @@ class DefaultHistPolicy {
   std::int32_t n_threads_{-1};
 
  public:
- public:
   void Reset(Context const *ctx, bool is_distributed, bool is_col_split) {
     this->is_distributed_ = is_distributed;
     this->n_threads_ = ctx->Threads();

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -4,11 +4,12 @@
 #ifndef XGBOOST_TREE_HIST_HISTOGRAM_H_
 #define XGBOOST_TREE_HIST_HISTOGRAM_H_
 
-#include <algorithm>   // for max
-#include <cstddef>     // for size_t
-#include <cstdint>     // for int32_t
-#include <utility>     // for move
-#include <vector>      // for vector
+#include <algorithm>  // for max
+#include <cstddef>    // for size_t
+#include <cstdint>    // for int32_t
+#include <utility>    // for move
+#include <variant>    // for variant
+#include <vector>     // for vector
 
 #include "../../collective/allreduce.h"    // for Allreduce
 #include "../../common/hist_util.h"        // for GHistRow, ParallelGHi...
@@ -26,6 +27,10 @@
 #include "xgboost/span.h"                  // for Span
 #include "xgboost/tree_model.h"            // for RegTree
 
+#if defined(XGBOOST_USE_FEDERATED)
+#include "../../../plugin/federated/federated_hist.h"  // for FederataedHistPolicy
+#endif
+
 namespace xgboost::tree {
 /**
  * @brief Decide which node as the build node for multi-target trees.
@@ -39,18 +44,29 @@ void AssignNodes(RegTree const *p_tree, std::vector<MultiExpandEntry> const &val
 void AssignNodes(RegTree const *p_tree, std::vector<CPUExpandEntry> const &candidates,
                  common::Span<bst_node_t> nodes_to_build, common::Span<bst_node_t> nodes_to_sub);
 
-class HistogramBuilder {
-  /*! \brief culmulative histogram of gradients. */
+/**
+ * @brief Policy class container for building histogram.
+ *
+ * This is an algorithm template, it requires the specific policy to fill in the
+ * `DoBuildLocalHistograms`, `DoSyncHistogram`, and the `Reset` methods. See the default
+ * implementation for an example.
+ */
+template <typename BuildPolicy>
+class HistogramPolicyContainer : public BuildPolicy {
+  // Culmulative histogram of gradients.
   BoundedHistCollection hist_;
+  // Histogram buffers for threads.
   common::ParallelGHistBuilder buffer_;
   BatchParam param_;
-  int32_t n_threads_{-1};
-  // Whether XGBoost is running in distributed environment.
-  bool is_distributed_{false};
-  bool is_col_split_{false};
-  bool is_secure_{false};
+  std::int32_t n_threads_{-1};
 
  public:
+  HistogramPolicyContainer() = default;
+  HistogramPolicyContainer(HistogramPolicyContainer const &) = delete;
+  HistogramPolicyContainer(HistogramPolicyContainer &&) = default;
+  HistogramPolicyContainer &operator=(HistogramPolicyContainer const &) = delete;
+  HistogramPolicyContainer &operator=(HistogramPolicyContainer &&) = default;
+
   /**
    * @brief Reset the builder, should be called before growing a new tree.
    *
@@ -59,35 +75,13 @@ class HistogramBuilder {
    *                         of using global rabit variable.
    */
   void Reset(Context const *ctx, bst_bin_t total_bins, BatchParam const &p, bool is_distributed,
-             bool is_col_split, bool is_secure, HistMakerTrainParam const *param) {
+             DMatrix const *p_fmat, HistMakerTrainParam const *param) {
     n_threads_ = ctx->Threads();
     param_ = p;
     hist_.Reset(total_bins, param->max_cached_hist_node);
     buffer_.Init(total_bins);
-    is_distributed_ = is_distributed;
-    is_col_split_ = is_col_split;
-    is_secure_ = is_secure;
-  }
 
-  template <bool any_missing>
-  void BuildLocalHistograms(common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
-                            std::vector<bst_node_t> const &nodes_to_build,
-                            common::RowSetCollection const &row_set_collection,
-                            common::Span<GradientPair const> gpair_h, bool force_read_by_column) {
-    // Parallel processing by nodes and data in each node
-    common::ParallelFor2d(space, this->n_threads_, [&](size_t nid_in_set, common::Range1d r) {
-      const auto tid = static_cast<unsigned>(omp_get_thread_num());
-      bst_node_t const nidx = nodes_to_build[nid_in_set];
-      auto elem = row_set_collection[nidx];
-      auto start_of_row_set = std::min(r.begin(), elem.Size());
-      auto end_of_row_set = std::min(r.end(), elem.Size());
-      auto rid_set = common::RowSetCollection::Elem(elem.begin + start_of_row_set,
-                                                    elem.begin + end_of_row_set, nidx);
-      auto hist = buffer_.GetInitializedHist(tid, nid_in_set);
-      if (rid_set.Size() != 0) {
-        common::BuildHist<any_missing>(gpair_h, rid_set, gidx, hist, force_read_by_column);
-      }
-    });
+    BuildPolicy::Reset(ctx, is_distributed, p_fmat);
   }
 
   /**
@@ -163,65 +157,27 @@ class HistogramBuilder {
     }
 
     if (gidx.IsDense()) {
-      this->BuildLocalHistograms<false>(space, gidx, nodes_to_build, row_set_collection,
-                                        gpair.Values(), force_read_by_column);
+      this->template BuildLocalHistograms<false>(space, gidx, nodes_to_build, row_set_collection,
+                                                 gpair.Values(), force_read_by_column);
     } else {
-      this->BuildLocalHistograms<true>(space, gidx, nodes_to_build, row_set_collection,
-                                       gpair.Values(), force_read_by_column);
+      this->template BuildLocalHistograms<true>(space, gidx, nodes_to_build, row_set_collection,
+                                                gpair.Values(), force_read_by_column);
     }
+  }
+
+  template <bool any_missing>
+  void BuildLocalHistograms(common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+                            std::vector<bst_node_t> const &nodes_to_build,
+                            common::RowSetCollection const &row_set_collection,
+                            common::Span<GradientPair const> gpair_h, bool force_read_by_column) {
+    BuildPolicy::template DoBuildLocalHistograms<any_missing>(
+        space, gidx, nodes_to_build, row_set_collection, gpair_h, force_read_by_column, &buffer_);
   }
 
   void SyncHistogram(Context const *ctx, RegTree const *p_tree,
                      std::vector<bst_node_t> const &nodes_to_build,
                      std::vector<bst_node_t> const &nodes_to_trick) {
-    auto n_total_bins = buffer_.TotalBins();
-
-    common::BlockedSpace2d space(
-        nodes_to_build.size(), [&](std::size_t) { return n_total_bins; }, 1024);
-    common::ParallelFor2d(space, this->n_threads_, [&](size_t node, common::Range1d r) {
-      // Merging histograms from each thread.
-      this->buffer_.ReduceHist(node, r.begin(), r.end());
-    });
-    if (is_distributed_ && !is_col_split_) {
-      // The cache is contiguous, we can perform allreduce for all nodes in one go.
-      CHECK(!nodes_to_build.empty());
-      auto first_nidx = nodes_to_build.front();
-      std::size_t n = n_total_bins * nodes_to_build.size() * 2;
-      auto rc = collective::Allreduce(
-          ctx, linalg::MakeVec(reinterpret_cast<double *>(this->hist_[first_nidx].data()), n),
-          collective::Op::kSum);
-      SafeColl(rc);
-    }
-
-    if (is_distributed_ && is_col_split_ && is_secure_) {
-      // Under secure vertical mode, we perform allgather for all nodes
-      CHECK(!nodes_to_build.empty());
-      // in theory the operation is AllGather, under current histogram setting of
-      // same length with 0s for empty slots,
-      // AllReduce is the most efficient way of achieving the global histogram
-      auto first_nidx = nodes_to_build.front();
-      std::size_t n = n_total_bins * nodes_to_build.size() * 2;
-      collective::SafeColl(collective::Allreduce(
-          ctx, linalg::MakeVec(reinterpret_cast<double *>(this->hist_[first_nidx].data()), n),
-          collective::Op::kSum));
-    }
-
-    common::BlockedSpace2d const &subspace =
-        nodes_to_trick.size() == nodes_to_build.size()
-            ? space
-            : common::BlockedSpace2d{nodes_to_trick.size(),
-                                     [&](std::size_t) { return n_total_bins; }, 1024};
-    common::ParallelFor2d(
-        subspace, this->n_threads_, [&](std::size_t nidx_in_set, common::Range1d r) {
-          auto subtraction_nidx = nodes_to_trick[nidx_in_set];
-          auto parent_id = p_tree->Parent(subtraction_nidx);
-          auto sibling_nidx = p_tree->IsLeftChild(subtraction_nidx) ? p_tree->RightChild(parent_id)
-                                                                    : p_tree->LeftChild(parent_id);
-          auto sibling_hist = this->hist_[sibling_nidx];
-          auto parent_hist = this->hist_[parent_id];
-          auto subtract_hist = this->hist_[subtraction_nidx];
-          common::SubtractionHist(subtract_hist, parent_hist, sibling_hist, r.begin(), r.end());
-        });
+    BuildPolicy::DoSyncHistogram(ctx, p_tree, nodes_to_build, nodes_to_trick, &buffer_, &hist_);
   }
 
  public:
@@ -230,6 +186,80 @@ class HistogramBuilder {
   [[nodiscard]] BoundedHistCollection &Histogram() { return hist_; }
   auto &Buffer() { return buffer_; }
 };
+
+/**
+ * @brief Histogram build policy for normal cases.
+ */
+class DefaultHistPolicy {
+  // Whether XGBoost is running in distributed environment.
+  bool is_distributed_{false};
+  bool is_col_split_{false};
+  std::int32_t n_threads_{-1};
+
+ public:
+ public:
+  void Reset(Context const *ctx, bool is_distributed, DMatrix const *p_fmat) {
+    this->is_distributed_ = is_distributed;
+    this->n_threads_ = ctx->Threads();
+    this->is_col_split_ = p_fmat->Info().IsColumnSplit();
+  }
+
+  template <bool any_missing>
+  void DoBuildLocalHistograms(common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+                              std::vector<bst_node_t> const &nodes_to_build,
+                              common::RowSetCollection const &row_set_collection,
+                              common::Span<GradientPair const> gpair_h, bool force_read_by_column,
+                              common::ParallelGHistBuilder *buffer) {
+    common::BuildSampleHistograms<any_missing>(this->n_threads_, space, gidx, nodes_to_build,
+                                               row_set_collection, gpair_h, force_read_by_column,
+                                               buffer);
+  }
+
+  void DoSyncHistogram(Context const *ctx, RegTree const *p_tree,
+                       std::vector<bst_node_t> const &nodes_to_build,
+                       std::vector<bst_node_t> const &nodes_to_trick,
+                       common::ParallelGHistBuilder *buffer, BoundedHistCollection *p_hist) {
+    auto n_total_bins = buffer->TotalBins();
+    auto &hist = *p_hist;
+    common::BlockedSpace2d space(
+        nodes_to_build.size(), [&](std::size_t) { return n_total_bins; }, 1024);
+    common::ParallelFor2d(space, ctx->Threads(), [&](size_t node, common::Range1d r) {
+      // Merging histograms from each thread.
+      buffer->ReduceHist(node, r.begin(), r.end());
+    });
+    // Sync the histogram if it's not column split
+    if (is_distributed_ && !is_col_split_) {
+      // The cache is contiguous, we can perform allreduce for all nodes in one go.
+      CHECK(!nodes_to_build.empty());
+      auto first_nidx = nodes_to_build.front();
+      std::size_t n = n_total_bins * nodes_to_build.size() * 2;
+      auto rc = collective::Allreduce(
+          ctx, linalg::MakeVec(reinterpret_cast<double *>(hist[first_nidx].data()), n),
+          collective::Op::kSum);
+      SafeColl(rc);
+    }
+
+    common::BlockedSpace2d const &subspace =
+        nodes_to_trick.size() == nodes_to_build.size()
+            ? space
+            : common::BlockedSpace2d{nodes_to_trick.size(),
+                                     [&](std::size_t) { return n_total_bins; }, 1024};
+    common::ParallelFor2d(
+        subspace, ctx->Threads(), [&](std::size_t nidx_in_set, common::Range1d r) {
+          auto subtraction_nidx = nodes_to_trick[nidx_in_set];
+          auto parent_id = p_tree->Parent(subtraction_nidx);
+          auto sibling_nidx = p_tree->IsLeftChild(subtraction_nidx) ? p_tree->RightChild(parent_id)
+                                                                    : p_tree->LeftChild(parent_id);
+          auto sibling_hist = hist[sibling_nidx];
+          auto parent_hist = hist[parent_id];
+          auto subtract_hist = hist[subtraction_nidx];
+          common::SubtractionHist(subtract_hist, parent_hist, sibling_hist, r.begin(), r.end());
+        });
+  }
+};
+
+using HistogramBuilder = HistogramPolicyContainer<DefaultHistPolicy>;
+using FedHistogramBuilder = HistogramPolicyContainer<FederataedHistPolicy>;
 
 // Construct a work space for building histogram.  Eventually we should move this
 // function into histogram builder once hist tree method supports external memory.
@@ -257,7 +287,7 @@ common::BlockedSpace2d ConstructHistSpace(Partitioner const &partitioners,
  * @brief Histogram builder that can handle multiple targets.
  */
 class MultiHistogramBuilder {
-  std::vector<HistogramBuilder> target_builders_;
+  std::variant<std::vector<HistogramBuilder>, std::vector<FedHistogramBuilder>> target_builders_;
   Context const *ctx_;
 
  public:
@@ -272,30 +302,35 @@ class MultiHistogramBuilder {
     auto n_targets = p_tree->NumTargets();
     CHECK_EQ(gpair.Shape(1), n_targets);
     CHECK_EQ(p_fmat->Info().num_row_, gpair.Shape(0));
-    CHECK_EQ(target_builders_.size(), n_targets);
-    std::vector<bst_node_t> nodes{best.nid};
-    std::vector<bst_node_t> dummy_sub;
 
-    auto space = ConstructHistSpace(partitioners, nodes);
-    for (bst_target_t t{0}; t < n_targets; ++t) {
-      this->target_builders_[t].AddHistRows(p_tree, &nodes, &dummy_sub, false);
-    }
-    CHECK(dummy_sub.empty());
+    std::visit(
+        [&](auto &target_builders) {
+          CHECK_EQ(target_builders.size(), n_targets);
+          std::vector<bst_node_t> nodes{best.nid};
+          std::vector<bst_node_t> dummy_sub;
 
-    std::size_t page_idx{0};
-    for (auto const &gidx : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, param)) {
-      for (bst_target_t t{0}; t < n_targets; ++t) {
-        auto t_gpair = gpair.Slice(linalg::All(), t);
-        this->target_builders_[t].BuildHist(page_idx, space, gidx,
-                                            partitioners[page_idx].Partitions(), nodes, t_gpair,
-                                            force_read_by_column);
-      }
-      ++page_idx;
-    }
+          auto space = ConstructHistSpace(partitioners, nodes);
+          for (bst_target_t t{0}; t < n_targets; ++t) {
+            target_builders[t].AddHistRows(p_tree, &nodes, &dummy_sub, false);
+          }
+          CHECK(dummy_sub.empty());
 
-    for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
-      this->target_builders_[t].SyncHistogram(ctx_, p_tree, nodes, dummy_sub);
-    }
+          std::size_t page_idx{0};
+          for (auto const &gidx : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, param)) {
+            for (bst_target_t t{0}; t < n_targets; ++t) {
+              auto t_gpair = gpair.Slice(linalg::All(), t);
+              target_builders[t].BuildHist(page_idx, space, gidx,
+                                           partitioners[page_idx].Partitions(), nodes, t_gpair,
+                                           force_read_by_column);
+            }
+            ++page_idx;
+          }
+
+          for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
+            target_builders[t].SyncHistogram(ctx_, p_tree, nodes, dummy_sub);
+          }
+        },
+        target_builders_);
   }
   /**
    * @brief Build histogram for left and right child of valid candidates
@@ -310,49 +345,72 @@ class MultiHistogramBuilder {
     std::vector<bst_node_t> nodes_to_sub(valid_candidates.size());
     AssignNodes(p_tree, valid_candidates, nodes_to_build, nodes_to_sub);
 
-    // use the first builder for getting number of valid nodes.
-    target_builders_.front().AddHistRows(p_tree, &nodes_to_build, &nodes_to_sub, true);
-    CHECK_GE(nodes_to_build.size(), nodes_to_sub.size());
-    CHECK_EQ(nodes_to_sub.size() + nodes_to_build.size(), valid_candidates.size() * 2);
+    std::visit(
+        [&](auto &target_builders) {
+          // Use the first builder for getting the number of valid nodes.
+          target_builders.front().AddHistRows(p_tree, &nodes_to_build, &nodes_to_sub, true);
+          CHECK_GE(nodes_to_build.size(), nodes_to_sub.size());
+          CHECK_EQ(nodes_to_sub.size() + nodes_to_build.size(), valid_candidates.size() * 2);
 
-    // allocate storage for the rest of the builders
-    for (bst_target_t t = 1; t < target_builders_.size(); ++t) {
-      target_builders_[t].AddHistRows(p_tree, &nodes_to_build, &nodes_to_sub, false);
-    }
+          // allocate storage for the rest of the builders
+          for (bst_target_t t = 1; t < target_builders.size(); ++t) {
+            target_builders[t].AddHistRows(p_tree, &nodes_to_build, &nodes_to_sub, false);
+          }
 
-    auto space = ConstructHistSpace(partitioners, nodes_to_build);
-    std::size_t page_idx{0};
-    for (auto const &page : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, param)) {
-      CHECK_EQ(gpair.Shape(1), p_tree->NumTargets());
-      for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
-        auto t_gpair = gpair.Slice(linalg::All(), t);
-        CHECK_EQ(t_gpair.Shape(0), p_fmat->Info().num_row_);
-        this->target_builders_[t].BuildHist(page_idx, space, page,
-                                            partitioners[page_idx].Partitions(), nodes_to_build,
-                                            t_gpair, force_read_by_column);
-      }
-      page_idx++;
-    }
+          auto space = ConstructHistSpace(partitioners, nodes_to_build);
+          std::size_t page_idx{0};
+          // Build one histogram per target per page.
+          for (auto const &page : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, param)) {
+            CHECK_EQ(gpair.Shape(1), p_tree->NumTargets());
+            for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
+              auto t_gpair = gpair.Slice(linalg::All(), t);
+              CHECK_EQ(t_gpair.Shape(0), p_fmat->Info().num_row_);
+              target_builders[t].BuildHist(page_idx, space, page,
+                                           partitioners[page_idx].Partitions(), nodes_to_build,
+                                           t_gpair, force_read_by_column);
+            }
+            page_idx++;
+          }
 
-    for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
-      this->target_builders_[t].SyncHistogram(ctx, p_tree, nodes_to_build, nodes_to_sub);
-    }
+          for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
+            target_builders[t].SyncHistogram(ctx, p_tree, nodes_to_build, nodes_to_sub);
+          }
+        },
+        target_builders_);
   }
 
-  [[nodiscard]] auto const &Histogram(bst_target_t t) const {
-    return target_builders_[t].Histogram();
+  [[nodiscard]] decltype(auto) Histogram(bst_target_t t) const {
+    return std::visit(
+        [t](auto const &target_builders) -> decltype(auto) {
+          return target_builders[t].Histogram();
+        },
+        target_builders_);
   }
-  [[nodiscard]] auto &Histogram(bst_target_t t) { return target_builders_[t].Histogram(); }
+  [[nodiscard]] decltype(auto) Histogram(bst_target_t t) {
+    return std::visit(
+        [t](auto const &target_builders) -> decltype(auto) {
+          return target_builders[t].Histogram();
+        },
+        target_builders_);
+  }
 
   void Reset(Context const *ctx, bst_bin_t total_bins, bst_target_t n_targets, BatchParam const &p,
-             bool is_distributed, bool is_col_split, bool is_secure,
-             HistMakerTrainParam const *param) {
+             bool is_distributed, DMatrix const *p_fmat, HistMakerTrainParam const *param) {
     ctx_ = ctx;
-    target_builders_.resize(n_targets);
-    CHECK_GE(n_targets, 1);
-    for (auto &v : target_builders_) {
-      v.Reset(ctx, total_bins, p, is_distributed, is_col_split, is_secure, param);
+    if (p_fmat->Info().IsSecure() &&
+        !std::get_if<std::vector<FedHistogramBuilder>>(&target_builders_)) {
+      target_builders_.emplace<std::vector<FedHistogramBuilder>>(n_targets);
     }
+
+    std::visit(
+        [&](auto &&target_builders) {
+          target_builders.resize(n_targets);
+          CHECK_GE(n_targets, 1);
+          for (auto &v : target_builders) {
+            v.Reset(ctx, total_bins, p, is_distributed, p_fmat, param);
+          }
+        },
+        this->target_builders_);
   }
 };
 }  // namespace xgboost::tree

--- a/src/tree/updater_approx.cc
+++ b/src/tree/updater_approx.cc
@@ -93,7 +93,7 @@ class GloablApproxBuilder {
 
     histogram_builder_.Reset(ctx_, n_total_bins, p_tree->NumTargets(), BatchSpec(*param_, hess),
                              collective::IsDistributed(), p_fmat->Info().IsColumnSplit(),
-                             collective::IsFederated(), hist_param_);
+                             collective::IsEncrypted(), hist_param_);
     monitor_->Stop(__func__);
   }
 

--- a/src/tree/updater_approx.cc
+++ b/src/tree/updater_approx.cc
@@ -92,8 +92,7 @@ class GloablApproxBuilder {
     }
 
     histogram_builder_.Reset(ctx_, n_total_bins, p_tree->NumTargets(), BatchSpec(*param_, hess),
-                             collective::IsDistributed(), p_fmat->Info().IsColumnSplit(),
-                             p_fmat->Info().IsSecure(), hist_param_);
+                             collective::IsDistributed(), p_fmat, hist_param_);
     monitor_->Stop(__func__);
   }
 

--- a/src/tree/updater_approx.cc
+++ b/src/tree/updater_approx.cc
@@ -92,7 +92,8 @@ class GloablApproxBuilder {
     }
 
     histogram_builder_.Reset(ctx_, n_total_bins, p_tree->NumTargets(), BatchSpec(*param_, hess),
-                             collective::IsDistributed(), p_fmat, hist_param_);
+                             collective::IsDistributed(), p_fmat->Info().IsColumnSplit(),
+                             collective::IsFederated(), hist_param_);
     monitor_->Stop(__func__);
   }
 

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -355,8 +355,7 @@ class HistUpdater {
                                 fmat->Info().IsColumnSplit());
     }
     histogram_builder_->Reset(ctx_, n_total_bins, 1, HistBatch(param_), collective::IsDistributed(),
-                              fmat->Info().IsColumnSplit(), collective::IsDistributed(),
-                              hist_param_);
+                              fmat->Info().IsColumnSplit(), collective::IsFederated(), hist_param_);
     evaluator_ = std::make_unique<HistEvaluator>(ctx_, this->param_, fmat->Info(), col_sampler_);
     p_last_tree_ = p_tree;
     monitor_->Stop(__func__);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -165,7 +165,7 @@ class MultiTargetHistBuilder {
     histogram_builder_ = std::make_unique<MultiHistogramBuilder>();
     histogram_builder_->Reset(ctx_, n_total_bins, n_targets, HistBatch(param_),
                               collective::IsDistributed(), p_fmat->Info().IsColumnSplit(),
-                              collective::IsFederated(), hist_param_);
+                              collective::IsEncrypted(), hist_param_);
 
     evaluator_ = std::make_unique<HistMultiEvaluator>(ctx_, p_fmat->Info(), param_, col_sampler_);
     p_last_tree_ = p_tree;
@@ -355,7 +355,7 @@ class HistUpdater {
                                 fmat->Info().IsColumnSplit());
     }
     histogram_builder_->Reset(ctx_, n_total_bins, 1, HistBatch(param_), collective::IsDistributed(),
-                              fmat->Info().IsColumnSplit(), collective::IsFederated(), hist_param_);
+                              fmat->Info().IsColumnSplit(), collective::IsEncrypted(), hist_param_);
     evaluator_ = std::make_unique<HistEvaluator>(ctx_, this->param_, fmat->Info(), col_sampler_);
     p_last_tree_ = p_tree;
     monitor_->Stop(__func__);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -7,7 +7,6 @@
 #include <algorithm>  // for max, copy, transform
 #include <cstddef>    // for size_t
 #include <cstdint>    // for uint32_t, int32_t
-#include <exception>  // for exception
 #include <memory>     // for allocator, unique_ptr, make_unique, shared_ptr
 #include <ostream>    // for operator<<, basic_ostream, char_traits
 #include <utility>    // for move
@@ -20,7 +19,6 @@
 #include "../common/random.h"                // for ColumnSampler
 #include "../common/threading_utils.h"       // for ParallelFor
 #include "../common/timer.h"                 // for Monitor
-#include "../common/transform_iterator.h"    // for IndexTransformIter
 #include "../data/gradient_index.h"          // for GHistIndexMatrix
 #include "common_row_partitioner.h"          // for CommonRowPartitioner
 #include "dmlc/registry.h"                   // for DMLC_REGISTRY_FILE_TAG
@@ -166,8 +164,7 @@ class MultiTargetHistBuilder {
     bst_target_t n_targets = p_tree->NumTargets();
     histogram_builder_ = std::make_unique<MultiHistogramBuilder>();
     histogram_builder_->Reset(ctx_, n_total_bins, n_targets, HistBatch(param_),
-                              collective::IsDistributed(), p_fmat->Info().IsColumnSplit(),
-                              p_fmat->Info().IsSecure(), hist_param_);
+                              collective::IsDistributed(), p_fmat, hist_param_);
 
     evaluator_ = std::make_unique<HistMultiEvaluator>(ctx_, p_fmat->Info(), param_, col_sampler_);
     p_last_tree_ = p_tree;
@@ -357,7 +354,7 @@ class HistUpdater {
                                 fmat->Info().IsColumnSplit());
     }
     histogram_builder_->Reset(ctx_, n_total_bins, 1, HistBatch(param_), collective::IsDistributed(),
-                              fmat->Info().IsColumnSplit(), fmat->Info().IsSecure(), hist_param_);
+                              fmat, hist_param_);
     evaluator_ = std::make_unique<HistEvaluator>(ctx_, this->param_, fmat->Info(), col_sampler_);
     p_last_tree_ = p_tree;
     monitor_->Stop(__func__);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -164,7 +164,8 @@ class MultiTargetHistBuilder {
     bst_target_t n_targets = p_tree->NumTargets();
     histogram_builder_ = std::make_unique<MultiHistogramBuilder>();
     histogram_builder_->Reset(ctx_, n_total_bins, n_targets, HistBatch(param_),
-                              collective::IsDistributed(), p_fmat, hist_param_);
+                              collective::IsDistributed(), p_fmat->Info().IsColumnSplit(),
+                              collective::IsFederated(), hist_param_);
 
     evaluator_ = std::make_unique<HistMultiEvaluator>(ctx_, p_fmat->Info(), param_, col_sampler_);
     p_last_tree_ = p_tree;
@@ -354,7 +355,8 @@ class HistUpdater {
                                 fmat->Info().IsColumnSplit());
     }
     histogram_builder_->Reset(ctx_, n_total_bins, 1, HistBatch(param_), collective::IsDistributed(),
-                              fmat, hist_param_);
+                              fmat->Info().IsColumnSplit(), collective::IsDistributed(),
+                              hist_param_);
     evaluator_ = std::make_unique<HistEvaluator>(ctx_, this->param_, fmat->Info(), col_sampler_);
     p_last_tree_ = p_tree;
     monitor_->Stop(__func__);

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -340,7 +340,7 @@ void DoTestColSplitQuantileSecure() {
 
   auto const n_bins = 64;
 
-  m->Info().data_split_mode = DataSplitMode::kColSecure;
+  m->Info().data_split_mode = DataSplitMode::kCol;
   // Generate cuts for distributed environment.
   HistogramCuts distributed_cuts;
   {

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -13,7 +13,7 @@
 #include "../../../src/data/simple_dmatrix.h"  // SimpleDMatrix
 #include "../collective/test_worker.h"         // for TestDistributedGlobal
 #if defined(XGBOOST_USE_FEDERATED)
-#include "../plugin/federated/test_worker.h"
+#include "../plugin/federated/test_worker.h"  // for TestEncryptedGlobal
 #endif  // defined(XGBOOST_USE_FEDERATED)
 #include "xgboost/context.h"
 
@@ -314,6 +314,7 @@ void DoTestColSplitQuantileSecure() {
   Context ctx;
   auto const world = collective::GetWorldSize();
   auto const rank = collective::GetRank();
+  ASSERT_TRUE(collective::IsEncrypted());
   size_t cols = 2;
   size_t rows = 3;
 
@@ -395,7 +396,7 @@ void DoTestColSplitQuantileSecure() {
 template <bool use_column>
 void TestColSplitQuantileSecure() {
   auto constexpr kWorkers = 2;
-  collective::TestFederatedGlobal(kWorkers, [&] { DoTestColSplitQuantileSecure<use_column>(); });
+  collective::TestEncryptedGlobal(kWorkers, [&] { DoTestColSplitQuantileSecure<use_column>(); });
 }
 }  // anonymous namespace
 

--- a/tests/cpp/objective/test_objective.cc
+++ b/tests/cpp/objective/test_objective.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2023 by XGBoost contributors
+ * Copyright 2016-2024, XGBoost contributors
  */
 #include <gtest/gtest.h>
 #include <xgboost/context.h>
@@ -99,6 +99,6 @@ TEST_P(TestDefaultObjConfig, Objective) {
 INSTANTIATE_TEST_SUITE_P(Objective, TestDefaultObjConfig,
                          ::testing::ValuesIn(MakeObjNamesForTest()),
                          [](const ::testing::TestParamInfo<TestDefaultObjConfig::ParamType>& info) {
-                           return ObjTestNameGenerator(info);
+                           return ObjTestNameGenerator(info.param);
                          });
 } // namespace xgboost

--- a/tests/cpp/objective_helpers.h
+++ b/tests/cpp/objective_helpers.h
@@ -21,9 +21,7 @@ inline auto MakeObjNamesForTest() {
   return names;
 }
 
-template <typename ParamType>
-inline std::string ObjTestNameGenerator(const ::testing::TestParamInfo<ParamType>& info) {
-  auto name = std::string{info.param};
+inline std::string ObjTestNameGenerator(std::string name) {
   // Name must be a valid c++ symbol
   auto it = std::find(name.cbegin(), name.cend(), ':');
   if (it != name.cend()) {

--- a/tests/cpp/plugin/federated/test_federated_comm.cc
+++ b/tests/cpp/plugin/federated/test_federated_comm.cc
@@ -16,21 +16,35 @@
 namespace xgboost::collective {
 namespace {
 class FederatedCommTest : public SocketTest {};
+auto MakeConfig(std::string host, std::int32_t port, std::int32_t world, std::int32_t rank) {
+  Json config{Object{}};
+  config["federated_server_address"] = host + ":" + std::to_string(port);
+  config["federated_world_size"] = Integer{world};
+  config["federated_rank"] = Integer{rank};
+  return config;
+}
 }  // namespace
 
 TEST_F(FederatedCommTest, ThrowOnWorldSizeTooSmall) {
-  auto construct = [] { FederatedComm comm{"localhost", 0, 0, 0}; };
+  auto config = MakeConfig("localhost", 0, 0, 0);
+  auto construct = [config] {
+    FederatedComm comm{DefaultRetry(), std::chrono::seconds{DefaultTimeoutSec()}, "", config};
+  };
   ASSERT_THAT(construct, GMockThrow("Invalid world size"));
 }
 
 TEST_F(FederatedCommTest, ThrowOnRankTooSmall) {
-  auto construct = [] { FederatedComm comm{"localhost", 0, 1, -1}; };
+  auto config = MakeConfig("localhost", 0, 1, -1);
+  auto construct = [config] {
+    FederatedComm comm{DefaultRetry(), std::chrono::seconds{DefaultTimeoutSec()}, "", config};
+  };
   ASSERT_THAT(construct, GMockThrow("Invalid worker rank."));
 }
 
 TEST_F(FederatedCommTest, ThrowOnRankTooBig) {
-  auto construct = [] {
-    FederatedComm comm{"localhost", 0, 1, 1};
+  auto config = MakeConfig("localhost", 0, 1, 1);
+  auto construct = [config] {
+    FederatedComm comm{DefaultRetry(), std::chrono::seconds{DefaultTimeoutSec()}, "", config};
   };
   ASSERT_THAT(construct, GMockThrow("Invalid worker rank."));
 }
@@ -68,7 +82,8 @@ TEST_F(FederatedCommTest, GetWorldSizeAndRank) {
 }
 
 TEST_F(FederatedCommTest, IsDistributed) {
-  FederatedComm comm{"localhost", 0, 2, 1};
+  FederatedComm comm{DefaultRetry(), std::chrono::seconds{DefaultTimeoutSec()}, "",
+                     MakeConfig("localhost", 0, 2, 1)};
   EXPECT_TRUE(comm.IsDistributed());
 }
 

--- a/tests/cpp/plugin/federated/test_worker.h
+++ b/tests/cpp/plugin/federated/test_worker.h
@@ -83,4 +83,16 @@ void TestFederatedGlobal(std::int32_t n_workers, WorkerFn&& fn) {
     collective::Finalize();
   });
 }
+
+template <typename WorkerFn>
+void TestEncryptedGlobal(std::int32_t n_workers, WorkerFn&& fn) {
+  TestFederatedImpl(n_workers, [&](std::int32_t port, std::int32_t i) {
+    auto config = FederatedTestConfig(n_workers, port, i);
+    config["federated_plugin"] = Object{};
+    config["federated_plugin"]["name"] = String{"mock"};
+    collective::Init(config);
+    fn();
+    collective::Finalize();
+  });
+}
 }  // namespace xgboost::collective

--- a/tests/cpp/plugin/test_federated_learner.cc
+++ b/tests/cpp/plugin/test_federated_learner.cc
@@ -51,21 +51,8 @@ void VerifyObjective(std::size_t rows, std::size_t cols, float expected_base_sco
 
   auto model = MakeModel(tree_method, device, objective, sliced);
   auto base_score = GetBaseScore(model);
-
-  std::unique_ptr<Learner> expected{Learner::Create({})};
-  expected->LoadModel(expected_model);
-
-  std::unique_ptr<Learner> got{Learner::Create({})};
-  got->LoadModel(model);
-
-  if (rank == 0) {
-    ASSERT_EQ(base_score, expected_base_score) << " rank " << rank;
-    HostDeviceVector<float> expected_predt;
-    expected->Predict(dmat, false, &expected_predt, 0, 0);
-    HostDeviceVector<float> got_predt;
-    expected->Predict(dmat, false, &got_predt, 0, 0);
-    ASSERT_EQ(expected_predt.HostVector(), got_predt.HostVector());
-  }
+  ASSERT_EQ(base_score, expected_base_score) << " rank " << rank;
+  ASSERT_EQ(model, expected_model) << " rank " << rank;
 }
 }  // namespace
 
@@ -74,19 +61,6 @@ class VerticalFederatedLearnerTest : public ::testing::TestWithParam<std::string
 
  protected:
   void Run(std::string tree_method, std::string device, std::string objective) {
-    // Following objectives are not yet supported.
-    if (objective.find("multi:") != std::string::npos) {
-      GTEST_SKIP();
-      return;
-    }
-    if (objective.find("quantile") != std::string::npos) {
-      GTEST_SKIP();
-      return;
-    }
-    if (objective.find("absoluteerror") != std::string::npos) {
-      GTEST_SKIP();
-    }
-
     static auto constexpr kRows{16};
     static auto constexpr kCols{16};
 
@@ -132,15 +106,11 @@ TEST_P(VerticalFederatedLearnerTest, Hist) {
 #if defined(XGBOOST_USE_CUDA)
 TEST_P(VerticalFederatedLearnerTest, GPUApprox) {
   std::string objective = GetParam();
-  // Not yet supported by the plugin system
-  GTEST_SKIP();
   this->Run("approx", DeviceSym::CUDA(), objective);
 }
 
 TEST_P(VerticalFederatedLearnerTest, GPUHist) {
   std::string objective = GetParam();
-  // Not yet supported by the plugin system
-  GTEST_SKIP();
   this->Run("hist", DeviceSym::CUDA(), objective);
 }
 #endif  // defined(XGBOOST_USE_CUDA)

--- a/tests/cpp/plugin/test_federated_learner.cc
+++ b/tests/cpp/plugin/test_federated_learner.cc
@@ -14,6 +14,7 @@
 #include "../helpers.h"
 #include "../objective_helpers.h"  // for MakeObjNamesForTest, ObjTestNameGenerator
 #include "federated/test_worker.h"
+#include "../collective/test_worker.h"
 
 namespace xgboost {
 namespace {
@@ -39,7 +40,7 @@ auto MakeModel(std::string tree_method, std::string device, std::string objectiv
 }
 
 void VerifyObjective(std::size_t rows, std::size_t cols, float expected_base_score,
-                     Json expected_model, std::string const &tree_method, std::string device,
+                     Json const &expected_model, std::string const &tree_method, std::string device,
                      std::string const &objective) {
   auto rank = collective::GetRank();
   std::shared_ptr<DMatrix> dmat{RandomDataGenerator{rows, cols, 0}.GenerateDMatrix(rank == 0)};
@@ -94,23 +95,23 @@ class VerticalFederatedLearnerTest : public ::testing::TestWithParam<std::string
 
 TEST_P(VerticalFederatedLearnerTest, Approx) {
   std::string objective = GetParam();
-  this->Run("approx", "cpu", objective);
+  this->Run("approx", DeviceSym::CPU(), objective);
 }
 
 TEST_P(VerticalFederatedLearnerTest, Hist) {
   std::string objective = GetParam();
-  this->Run("hist", "cpu", objective);
+  this->Run("hist", DeviceSym::CPU(), objective);
 }
 
 #if defined(XGBOOST_USE_CUDA)
 TEST_P(VerticalFederatedLearnerTest, GPUApprox) {
   std::string objective = GetParam();
-  this->Run("approx", "cuda:0", objective);
+  this->Run("approx", DeviceSym::CUDA(), objective);
 }
 
 TEST_P(VerticalFederatedLearnerTest, GPUHist) {
   std::string objective = GetParam();
-  this->Run("hist", "cuda:0", objective);
+  this->Run("hist", DeviceSym::CUDA(), objective);
 }
 #endif  // defined(XGBOOST_USE_CUDA)
 

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -756,9 +756,6 @@ void TestColumnSplitWithArgs(std::string const& tree_method, bool use_gpu, Args 
   auto model = GetModelWithArgs(p_fmat, tree_method, device, args);
 
   auto world_size{3};
-  if (federated && use_gpu) {
-    GTEST_SKIP();
-  }
   if (use_gpu) {
     world_size = common::AllVisibleGPUs();
     // Simulate MPU on a single GPU. Federated doesn't use nccl, can run multiple
@@ -791,26 +788,17 @@ class ColumnSplitTrainingTest
  public:
   static void TestColumnSplitColumnSampler(std::string const& tree_method, bool use_gpu,
                                            bool federated) {
-    if (federated) {
-      GTEST_SKIP();
-    }
     Args args{
         {"colsample_bytree", "0.5"}, {"colsample_bylevel", "0.6"}, {"colsample_bynode", "0.7"}};
     TestColumnSplitWithArgs(tree_method, use_gpu, args, federated);
   }
   static void TestColumnSplitInteractionConstraints(std::string const& tree_method, bool use_gpu,
                                                     bool federated) {
-    if (federated) {
-      GTEST_SKIP();
-    }
     Args args{{"interaction_constraints", "[[0, 5, 7], [2, 8, 9], [1, 3, 6]]"}};
     TestColumnSplitWithArgs(tree_method, use_gpu, args, federated);
   }
   static void TestColumnSplitMonotoneConstraints(std::string const& tree_method, bool use_gpu,
                                                  bool federated) {
-    if (federated) {
-      GTEST_SKIP();
-    }
     Args args{{"monotone_constraints", "(1,-1,0,1,1,-1,-1,0,0,1)"}};
     TestColumnSplitWithArgs(tree_method, use_gpu, args, federated);
   }

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -756,6 +756,9 @@ void TestColumnSplitWithArgs(std::string const& tree_method, bool use_gpu, Args 
   auto model = GetModelWithArgs(p_fmat, tree_method, device, args);
 
   auto world_size{3};
+  if (federated && use_gpu) {
+    GTEST_SKIP();
+  }
   if (use_gpu) {
     world_size = common::AllVisibleGPUs();
     // Simulate MPU on a single GPU. Federated doesn't use nccl, can run multiple
@@ -788,17 +791,28 @@ class ColumnSplitTrainingTest
  public:
   static void TestColumnSplitColumnSampler(std::string const& tree_method, bool use_gpu,
                                            bool federated) {
+    if (federated) {
+      GTEST_SKIP();
+    }
+    std::cout << "tree_method:" << tree_method << " gpu:" << use_gpu << " federated:" << federated
+              << std::endl;
     Args args{
         {"colsample_bytree", "0.5"}, {"colsample_bylevel", "0.6"}, {"colsample_bynode", "0.7"}};
     TestColumnSplitWithArgs(tree_method, use_gpu, args, federated);
   }
   static void TestColumnSplitInteractionConstraints(std::string const& tree_method, bool use_gpu,
                                                     bool federated) {
+    if (federated) {
+      GTEST_SKIP();
+    }
     Args args{{"interaction_constraints", "[[0, 5, 7], [2, 8, 9], [1, 3, 6]]"}};
     TestColumnSplitWithArgs(tree_method, use_gpu, args, federated);
   }
   static void TestColumnSplitMonotoneConstraints(std::string const& tree_method, bool use_gpu,
                                                  bool federated) {
+    if (federated) {
+      GTEST_SKIP();
+    }
     Args args{{"monotone_constraints", "(1,-1,0,1,1,-1,-1,0,0,1)"}};
     TestColumnSplitWithArgs(tree_method, use_gpu, args, federated);
   }

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -794,8 +794,6 @@ class ColumnSplitTrainingTest
     if (federated) {
       GTEST_SKIP();
     }
-    std::cout << "tree_method:" << tree_method << " gpu:" << use_gpu << " federated:" << federated
-              << std::endl;
     Args args{
         {"colsample_bytree", "0.5"}, {"colsample_bylevel", "0.6"}, {"colsample_bynode", "0.7"}};
     TestColumnSplitWithArgs(tree_method, use_gpu, args, federated);

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -717,7 +717,7 @@ TEST_P(TestColumnSplit, Objective) {
 INSTANTIATE_TEST_SUITE_P(ColumnSplitObjective, TestColumnSplit,
                          ::testing::ValuesIn(MakeObjNamesForTest()),
                          [](const ::testing::TestParamInfo<TestColumnSplit::ParamType>& info) {
-                           return ObjTestNameGenerator(info);
+                           return ObjTestNameGenerator(info.param);
                          });
 
 namespace {

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -307,7 +307,7 @@ void DoTestEvaluateSplitsSecure(bool force_read_by_column) {
 
   auto dmat = RandomDataGenerator(kRows, kCols, 0).Seed(3).GenerateDMatrix();
   auto m = dmat->SliceCol(world, rank);
-  m->Info().data_split_mode = DataSplitMode::kColSecure;
+  m->Info().data_split_mode = DataSplitMode::kCol;
 
   auto evaluator = HistEvaluator{&ctx, &param, m->Info(), sampler};
   BoundedHistCollection hist;

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -68,7 +68,7 @@ void TestAddHistRows(bool is_distributed) {
 
   HistMakerTrainParam hist_param;
   HistogramBuilder histogram_builder;
-  histogram_builder.Reset(&ctx, gmat.cut.TotalBins(), {kMaxBins, 0.5}, is_distributed, p_fmat.get(),
+  histogram_builder.Reset(&ctx, gmat.cut.TotalBins(), {kMaxBins, 0.5}, is_distributed, false,
                           &hist_param);
   histogram_builder.AddHistRows(&tree, &nodes_to_build, &nodes_to_sub, false);
 
@@ -102,7 +102,7 @@ void TestSyncHist(bool is_distributed) {
   HistogramBuilder histogram;
   uint32_t total_bins = gmat.cut.Ptrs().back();
   HistMakerTrainParam hist_param;
-  histogram.Reset(&ctx, total_bins, {kMaxBins, 0.5}, is_distributed, p_fmat.get(), &hist_param);
+  histogram.Reset(&ctx, total_bins, {kMaxBins, 0.5}, is_distributed, false, &hist_param);
 
   common::RowSetCollection row_set_collection;
   {
@@ -244,9 +244,7 @@ void TestBuildHistogram(bool is_distributed, bool force_read_by_column, bool is_
   bst_node_t nid = 0;
   HistogramBuilder histogram;
   HistMakerTrainParam hist_param;
-  // fixme: is_secure
-  CHECK_EQ(p_fmat->Info().IsColumnSplit(), is_col_split);
-  histogram.Reset(&ctx, total_bins, {kMaxBins, 0.5}, is_distributed, p_fmat.get(), &hist_param);
+  histogram.Reset(&ctx, total_bins, {kMaxBins, 0.5}, is_distributed, is_col_split, &hist_param);
 
   RegTree tree;
 
@@ -384,7 +382,7 @@ void TestHistogramCategorical(size_t n_categories, bool force_read_by_column) {
   HistogramBuilder cat_hist;
   for (auto const &gidx : cat_m->GetBatches<GHistIndexMatrix>(&ctx, {kBins, 0.5})) {
     auto total_bins = gidx.cut.TotalBins();
-    cat_hist.Reset(&ctx, total_bins, {kBins, 0.5}, false, cat_m.get(), &hist_param);
+    cat_hist.Reset(&ctx, total_bins, {kBins, 0.5}, false, false, &hist_param);
     cat_hist.AddHistRows(&tree, &nodes_to_build, &dummy_sub, false);
     cat_hist.BuildHist(0, space, gidx, row_set_collection, nodes_to_build,
                        linalg::MakeTensorView(&ctx, gpair.ConstHostSpan(), gpair.Size()),
@@ -400,7 +398,7 @@ void TestHistogramCategorical(size_t n_categories, bool force_read_by_column) {
   HistogramBuilder onehot_hist;
   for (auto const &gidx : encode_m->GetBatches<GHistIndexMatrix>(&ctx, {kBins, 0.5})) {
     auto total_bins = gidx.cut.TotalBins();
-    onehot_hist.Reset(&ctx, total_bins, {kBins, 0.5}, false, encode_m.get(), &hist_param);
+    onehot_hist.Reset(&ctx, total_bins, {kBins, 0.5}, false, false, &hist_param);
     onehot_hist.AddHistRows(&tree, &nodes_to_build, &dummy_sub, false);
     onehot_hist.BuildHist(0, space, gidx, row_set_collection, nodes_to_build,
                           linalg::MakeTensorView(&ctx, gpair.ConstHostSpan(), gpair.Size()),
@@ -466,7 +464,7 @@ void TestHistogramExternalMemory(Context const *ctx, BatchParam batch_param, boo
     }
     ASSERT_EQ(n_samples, m->Info().num_row_);
 
-    multi_build.Reset(ctx, total_bins, batch_param, false, m.get(), &hist_param);
+    multi_build.Reset(ctx, total_bins, batch_param, false, false, &hist_param);
     multi_build.AddHistRows(&tree, &nodes, &dummy_sub, false);
     std::size_t page_idx{0};
     for (auto const &page : m->GetBatches<GHistIndexMatrix>(ctx, batch_param)) {
@@ -489,7 +487,7 @@ void TestHistogramExternalMemory(Context const *ctx, BatchParam batch_param, boo
     common::RowSetCollection row_set_collection;
     InitRowPartitionForTest(&row_set_collection, n_samples);
 
-    single_build.Reset(ctx, total_bins, batch_param, false, m.get(), &hist_param);
+    single_build.Reset(ctx, total_bins, batch_param, false, false, &hist_param);
     SparsePage concat;
     std::vector<float> hess(m->Info().num_row_, 1.0f);
     for (auto const &page : m->GetBatches<SparsePage>()) {
@@ -565,8 +563,8 @@ class OverflowTest : public ::testing::TestWithParam<std::tuple<bool, bool>> {
     MultiHistogramBuilder hist_builder;
     CHECK_EQ(Xy->Info().IsColumnSplit(), is_col_split);
 
-    hist_builder.Reset(&ctx, n_total_bins, tree.NumTargets(), batch, is_distributed, Xy.get(),
-                       &hist_param);
+    hist_builder.Reset(&ctx, n_total_bins, tree.NumTargets(), batch, is_distributed,
+                       Xy->Info().IsColumnSplit(), false, &hist_param);
 
     std::vector<CommonRowPartitioner> partitioners;
     partitioners.emplace_back(&ctx, Xy->Info().num_row_, /*base_rowid=*/0,

--- a/tests/python/test_collective.py
+++ b/tests/python/test_collective.py
@@ -63,7 +63,7 @@ def test_federated_communicator():
     world_size = 2
     tracker = multiprocessing.Process(
         target=federated.run_federated_server,
-        kwargs={"port": port, "n_workers": world_size},
+        kwargs={"port": port, "n_workers": world_size, "blocking": False},
     )
     tracker.start()
     if not tracker.is_alive():


### PR DESCRIPTION
The underlying logic is the same as https://github.com/dmlc/xgboost/pull/10231 , with a couple of changes in the interface. This PR is still extremely early, opening it for collabration and discussion. The code is not ready for merge.

At the moment, vertical learning is blocked by a IPC issue in nvflare where the message size can change for the allgather V call. I haven't tested horizontal yet.

# Difference

## A C interface
The original PR proposes a C++ interface. This appears to be convenient but has some drawbacks:
- Cross DLL problem. C++ is not good at defining DLLs, it's extremely difficult to make good loadable DLL. For instance, memory allocated by the plugin should never be freed by the host. The `malloc` and `free` calls (along with `new` and `delete`) should come from the same version of `libc` and C++ runtime, along with the C++ compiler. XGBoost is distributed in binary format in PyPI, which makes this requirement difficult to fulfill. This rule applies to CUDA memory as well.
- In addition, exceptions should rarely escape DLL, meaning C++ exceptions in the plugin should never reach XGBoost. One can look up the cross DLL problem online for more info. Using a C interface is the simplest solution to these errors.
- Remove circular dependency.
- The life time of the plugin is now tied into the communicator instead of a new global variable.

## Split up the histogram implementation
- The original PR packs the federated learning into the existing histogram builder. I split it into the plugin directory as a policy class. The policy class will be a playground for people who are working on it without affecting the main XGBoost logic. Also, change will have less resistance from reviewers.

## Remove secure data split
- The `collective::IsFederated()` will be the only source of information about whether training is performed in an encrypted space. If we don't remove the secure split in data, we will have 8 different states: `row-split/col-split x secure/insecure x federated/normal`, which is difficult to maintain.

## Rebased to the new collective implementation
This PR uses the latest GRPC backend.

# Interface
The plugin interface I have at the moment has two major steps for both horizontal and vertical:
- Build
Takes in raw data (vertical) or histogram (horizontal), and returns an encrypted/encoded histogram.
- Sync
Takes an encrypted histogram, and returns a decrypted one.

The plugin itself owns all the buffers, and is freed after the plugin is closed. In addition, minimal data copying is required from the interface's perspective. For instance, we can directly reuse the row partition as input for the plugin. Lastly, since the histogram procedure is split into a policy class, feel free to modify the plugin interface in the future as you see fit.