### PR TITLE
[dask] Workaround the tokenizer by changing the scatter function.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -3144,9 +3144,3 @@ class Booster:
                 UserWarning,
             )
         return nph_stacked
-
-    def __dask_tokenize__(self) -> uuid.UUID:
-        # TODO: Implement proper tokenization to avoid unnecessary re-computation in
-        # Dask. However, default tokenzation causes problems after
-        # https://github.com/dask/dask/pull/10883
-        return uuid.uuid4()

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -7,7 +7,6 @@ import json
 import os
 import re
 import sys
-import uuid
 import warnings
 import weakref
 from abc import ABC, abstractmethod

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -1238,9 +1238,9 @@ async def _get_model_future(
     client: "distributed.Client", model: Union[Booster, Dict, "distributed.Future"]
 ) -> "distributed.Future":
     if isinstance(model, Booster):
-        booster = await client.scatter(model, broadcast=True)
+        booster = await client.scatter(model, broadcast=True, hash=False)
     elif isinstance(model, dict):
-        booster = await client.scatter(model["booster"], broadcast=True)
+        booster = await client.scatter(model["booster"], broadcast=True, hash=False)
     elif isinstance(model, distributed.Future):
         booster = model
         t = booster.type

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -1237,6 +1237,8 @@ def _infer_predict_output(
 async def _get_model_future(
     client: "distributed.Client", model: Union[Booster, Dict, "distributed.Future"]
 ) -> "distributed.Future":
+    # See https://github.com/dask/dask/issues/11179#issuecomment-2168094529 for
+    # the use of hash.
     if isinstance(model, Booster):
         booster = await client.scatter(model, broadcast=True, hash=False)
     elif isinstance(model, dict):


### PR DESCRIPTION
See https://github.com/dask/dask/issues/11179 and https://github.com/dmlc/xgboost/pull/10398/files#r1639860991

Moving the dask specific workaround into the dask module instead of changing the core booster.