### PR TITLE
[CI] [jvm-packages] Build libxgboost4j.dylib on M1 MacOS with OpenMP support

### DIFF
--- a/tests/buildkite/test-macos-m1-clang11.sh
+++ b/tests/buildkite/test-macos-m1-clang11.sh
@@ -18,10 +18,11 @@ set -x
 mkdir build
 pushd build
 export JAVA_HOME=$(/usr/libexec/java_home)
-cmake .. -GNinja -DJVM_BINDINGS=ON -DUSE_OPENMP=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
+cmake .. -GNinja -DJVM_BINDINGS=ON -DUSE_OPENMP=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
 ninja -v
 popd
 rm -rf build
+otool -L lib/libxgboost.dylib
 set +x
 
 echo "--- Upload Python wheel"


### PR DESCRIPTION
Currently, the CI pipeline builds `libxgboost4j.dylib` (M1, arm64) with OpenMP turned off.
We should enable it for M1 as well.