### PR TITLE
[backport] Require Pandas 1.2+ (#10476)

### DIFF
--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -38,7 +38,7 @@ documentation = "https://xgboost.readthedocs.io/en/stable/"
 repository = "https://github.com/dmlc/xgboost"
 
 [project.optional-dependencies]
-pandas = ["pandas"]
+pandas = ["pandas>=1.2"]
 scikit-learn = ["scikit-learn"]
 dask = ["dask", "pandas", "distributed"]
 datatable = ["datatable"]


### PR DESCRIPTION
This should be part of the 2.1.1 patch release.