### PR TITLE
Remove support for deprecated format in Python.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2650,7 +2650,7 @@ class Booster:
         Parameters
         ----------
         raw_format :
-            Format of output buffer. Can be `json`, `ubj` or `deprecated`.
+            Format of output buffer. Can be `json` or `ubj`.
 
         Returns
         -------


### PR DESCRIPTION
We will do the removal interface by interface.

In 2.2, we will keep the C++ code for testing.

https://github.com/dmlc/xgboost/issues/7547