### PR TITLE
[jvm-packages] Honor skip.native.build option in xgboost4j-gpu

### DIFF
--- a/jvm-packages/xgboost4j-gpu/pom.xml
+++ b/jvm-packages/xgboost4j-gpu/pom.xml
@@ -106,6 +106,7 @@
                                 <argument>${use.cuda}</argument>
                             </arguments>
                             <workingDirectory>${user.dir}</workingDirectory>
+                            <skip>${skip.native.build}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
The `skip.native.build` option should be honored in both `xgboost4j` and `xgboost4j-gpu` modules.