### PR TITLE
[jvm-packages] handle null to avoid potential NullPointerException

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/TrackerProperties.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/TrackerProperties.java
@@ -22,10 +22,12 @@ public class TrackerProperties {
     InputStream inputStream = null;
 
     try {
-      URL propertiesFileURL =
-          Thread.currentThread().getContextClassLoader().getResource(PROPERTIES_FILENAME);
-      if (propertiesFileURL != null){
-        inputStream = propertiesFileURL.openStream();
+      ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+      if (classLoader != null) {
+        URL propertiesFileURL = classLoader.getResource(PROPERTIES_FILENAME);
+        if (propertiesFileURL != null) {
+          inputStream = propertiesFileURL.openStream();
+        }
       }
     } catch (IOException e) {
       logger.warn("Could not load " + PROPERTIES_FILENAME + " file. ", e);


### PR DESCRIPTION
This PR add null checks for `jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/TrackerProperties.java`.

It retrieves the current thread's class loader using `Thread.currentThread().getContextClassLoader()` and verifies if it is not null.