### PR TITLE
Federated plugin for histogram.

### DIFF
--- a/plugin/federated/CMakeLists.txt
+++ b/plugin/federated/CMakeLists.txt
@@ -37,7 +37,8 @@ target_link_libraries(federated_client INTERFACE federated_proto)
 
 # Rabit engine for Federated Learning.
 target_sources(
-  objxgboost PRIVATE federated_tracker.cc federated_comm.cc federated_coll.cc federated_plugin.cc
+  objxgboost PRIVATE
+  federated_plugin.cc federated_hist.cc federated_tracker.cc federated_comm.cc federated_coll.cc
 )
 if(USE_CUDA)
   target_sources(objxgboost PRIVATE federated_comm.cu federated_coll.cu)

--- a/plugin/federated/federated_coll.cc
+++ b/plugin/federated/federated_coll.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, XGBoost contributors
+ * Copyright 2023-2024, XGBoost contributors
  */
 #include "federated_coll.h"
 
@@ -8,10 +8,14 @@
 
 #include <algorithm>  // for copy_n
 
-#include "../../src/collective/allgather.h"
-#include "../../src/common/common.h"    // for AssertGPUSupport
 #include "federated_comm.h"             // for FederatedComm
 #include "xgboost/collective/result.h"  // for Result
+
+#if !defined(XGBOOST_USE_CUDA)
+
+#include "../../src/common/common.h"  // for AssertGPUSupport
+
+#endif  // !defined(XGBOOST_USE_CUDA)
 
 namespace xgboost::collective {
 namespace {

--- a/plugin/federated/federated_hist.cc
+++ b/plugin/federated/federated_hist.cc
@@ -22,9 +22,6 @@ auto CopyBinsToDense(Context const *ctx, GHistIndexMatrix const &gidx) {
   });
   return bins;
 }
-
-constexpr double kFactor = sizeof(GradientPairPrecise) / sizeof(double);
-static_assert(kFactor == 2);
 }  // namespace
 
 template <bool any_missing>
@@ -32,10 +29,11 @@ void FederataedHistPolicy::DoBuildLocalHistograms(
     common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
     std::vector<bst_node_t> const &nodes_to_build,
     common::RowSetCollection const &row_set_collection, common::Span<GradientPair const> gpair_h,
-    bool force_read_by_column, common::ParallelGHistBuilder *buffer) {
+    bool force_read_by_column, common::ParallelGHistBuilder *p_buffer) {
   if (is_col_split_) {
-    // Call the interface to transmit gidx information to the secure worker for encrypted
-    // histogram computation
+    // Copy the gidx information to the secure worker for encrypted histogram
+    // computation. This is copied as we don't want the plugin to handle the bin
+    // compression, which is quite internal of XGBoost.
 
     // FIXME: this can be done during reset.
     if (!is_gidx_initialized_) {
@@ -45,8 +43,7 @@ void FederataedHistPolicy::DoBuildLocalHistograms(
       is_gidx_initialized_ = true;
     }
 
-    // Further use the row set collection info to
-    // get the encrypted histogram from the secure worker
+    // Share the row set collection without copy.
     std::vector<std::uint64_t const *> ptrs(nodes_to_build.size());
     std::vector<std::size_t> sizes(nodes_to_build.size());
     std::vector<bst_node_t> nodes(nodes_to_build.size());
@@ -59,7 +56,7 @@ void FederataedHistPolicy::DoBuildLocalHistograms(
     hist_data_ = this->plugin_->BuildEncryptedHistVert(ptrs, sizes, nodes);
   } else {
     BuildSampleHistograms<any_missing>(this->ctx_->Threads(), space, gidx, nodes_to_build,
-                                       row_set_collection, gpair_h, force_read_by_column, buffer);
+                                       row_set_collection, gpair_h, force_read_by_column, p_buffer);
   }
 }
 
@@ -74,14 +71,36 @@ template void FederataedHistPolicy::DoBuildLocalHistograms<false>(
     common::RowSetCollection const &row_set_collection, common::Span<GradientPair const> gpair_h,
     bool force_read_by_column, common::ParallelGHistBuilder *buffer);
 
-void FederataedHistPolicy::DoSyncHistogram(Context const *ctx, RegTree const *p_tree,
+namespace {
+// The label owner needs to gather the result from all workers.
+void GatherWorkerHist(common::Span<double> hist_aggr, std::int32_t n_workers,
+                      std::vector<bst_node_t> const &nodes_to_build, bst_bin_t n_total_bins,
+                      tree::BoundedHistCollection *p_hist) {
+  bst_idx_t worker_size = hist_aggr.size() / n_workers;
+  bst_node_t n_nodes = nodes_to_build.size();
+  auto &hist = *p_hist;
+  // for each worker
+  for (auto widx = 0; widx < n_workers; ++widx) {
+    auto worker_hist = hist_aggr.subspan(widx * worker_size, worker_size);
+    // for each node
+    for (bst_node_t nidx_in_set = 0; nidx_in_set < n_nodes; ++nidx_in_set) {
+      auto hist_size = n_total_bins * kHist2F64;  // Histogram size for one node.
+      auto hist_src = worker_hist.subspan(hist_size * nidx_in_set, hist_size);
+      auto hist_src_g = common::RestoreType<GradientPairPrecise>(hist_src);
+      auto hist_dst = hist[nodes_to_build[nidx_in_set]];
+      CHECK_EQ(hist_src_g.size(), hist_dst.size());
+      common::IncrementHist(hist_dst, hist_src_g, 0, hist_dst.size());
+    }
+  }
+}
+}  // namespace
+
+void FederataedHistPolicy::DoSyncHistogram(common::BlockedSpace2d const &space,
                                            std::vector<bst_node_t> const &nodes_to_build,
                                            std::vector<bst_node_t> const &nodes_to_trick,
-                                           common::ParallelGHistBuilder *buffer,
+                                           common::ParallelGHistBuilder *p_buffer,
                                            tree::BoundedHistCollection *p_hist) {
-  auto n_total_bins = buffer->TotalBins();
-  common::BlockedSpace2d space(
-      nodes_to_build.size(), [&](std::size_t) { return n_total_bins; }, 1024);
+  auto n_total_bins = p_buffer->TotalBins();
   CHECK(!nodes_to_build.empty());
 
   auto &hist = *p_hist;
@@ -93,18 +112,16 @@ void FederataedHistPolicy::DoSyncHistogram(Context const *ctx, RegTree const *p_
     HostDeviceVector<std::int8_t> hist_entries;
     std::vector<std::int64_t> recv_segments;
     collective::SafeColl(
-        collective::AllgatherV(ctx, linalg::MakeVec(hist_data_), &recv_segments, &hist_entries));
+        collective::AllgatherV(ctx_, linalg::MakeVec(hist_data_), &recv_segments, &hist_entries));
 
-    // Call interface here to post-process the messages
+    // Call the plugin here to get the resulting histogram. Histogram from all workers are
+    // gathered to the label owner.
     common::Span<double> hist_aggr =
         plugin_->SyncEncryptedHistVert(common::RestoreType<std::uint8_t>(hist_entries.HostSpan()));
 
     // Update histogram for the label owner
     if (collective::GetRank() == 0) {
-      // iterator of the beginning of the vector
-      bst_node_t n_nodes = nodes_to_build.size();
       std::int32_t n_workers = collective::GetWorldSize();
-      bst_idx_t worker_size = hist_aggr.size() / n_workers;
       CHECK_EQ(hist_aggr.size() % n_workers, 0);
       // Initialize histogram. For the normal case, this is done by the parallel hist
       // buffer. We should try to unify the code paths.
@@ -112,37 +129,24 @@ void FederataedHistPolicy::DoSyncHistogram(Context const *ctx, RegTree const *p_
         auto hist_dst = hist[nidx];
         std::fill_n(hist_dst.data(), hist_dst.size(), GradientPairPrecise{});
       }
-
-      // for each worker
-      for (auto widx = 0; widx < n_workers; ++widx) {
-        auto worker_hist = hist_aggr.subspan(widx * worker_size, worker_size);
-        // for each node
-        for (bst_node_t nidx_in_set = 0; nidx_in_set < n_nodes; ++nidx_in_set) {
-          auto hist_size = n_total_bins * kFactor;  // Histogram size for one node.
-          auto hist_src = worker_hist.subspan(hist_size * nidx_in_set, hist_size);
-          auto hist_src_g = common::RestoreType<GradientPairPrecise>(hist_src);
-          auto hist_dst = hist[nodes_to_build[nidx_in_set]];
-          CHECK_EQ(hist_src_g.size(), hist_dst.size());
-          common::IncrementHist(hist_dst, hist_src_g, 0, hist_dst.size());
-        }
-      }
+      GatherWorkerHist(hist_aggr, n_workers, nodes_to_build, n_total_bins, p_hist);
     }
   } else {
     common::ParallelFor2d(space, this->ctx_->Threads(), [&](std::size_t node, common::Range1d r) {
       // Merging histograms from each thread.
-      buffer->ReduceHist(node, r.begin(), r.end());
+      p_buffer->ReduceHist(node, r.begin(), r.end());
     });
-    // Secure mode, we need to call the plugin to perform encryption and decryption. Note
-    // that the actual aggregation is performed at server side
+    // Encrtyped mode, we need to call the plugin to perform encryption and decryption.
     auto first_nidx = nodes_to_build.front();
-    std::size_t n = n_total_bins * nodes_to_build.size() * kFactor;
+    std::size_t n = n_total_bins * nodes_to_build.size() * kHist2F64;
     auto src_hist = common::Span{reinterpret_cast<double const *>(hist[first_nidx].data()), n};
     auto hist_buf = plugin_->BuildEncryptedHistHori(src_hist);
 
     // allgather
     HostDeviceVector<std::int8_t> hist_entries;
     std::vector<std::int64_t> recv_segments;
-    auto rc = collective::AllgatherV(ctx, linalg::MakeVec(hist_buf), &recv_segments, &hist_entries);
+    auto rc =
+        collective::AllgatherV(ctx_, linalg::MakeVec(hist_buf), &recv_segments, &hist_entries);
     collective::SafeColl(rc);
 
     auto hist_aggr =
@@ -151,7 +155,5 @@ void FederataedHistPolicy::DoSyncHistogram(Context const *ctx, RegTree const *p_
     auto hist_dst = reinterpret_cast<double *>(hist[first_nidx].data());
     std::copy_n(hist_aggr.data(), hist_aggr.size(), hist_dst);
   }
-
-  SubtractHistParallel(ctx, space, p_tree, nodes_to_build, nodes_to_trick, buffer, p_hist);
 }
 }  // namespace xgboost::tree

--- a/plugin/federated/federated_hist.cc
+++ b/plugin/federated/federated_hist.cc
@@ -39,7 +39,7 @@ void FederataedHistPolicy::DoBuildLocalHistograms(
     std::vector<bst_node_t> nodes(nodes_to_build.size());
     for (std::size_t i = 0; i < nodes_to_build.size(); ++i) {
       auto nidx = nodes_to_build[i];
-      ptrs[i] = row_set_collection[nidx].begin;
+      ptrs[i] = row_set_collection[nidx].begin();
       sizes[i] = row_set_collection[nidx].Size();
       nodes[i] = nidx;
     }

--- a/plugin/federated/federated_hist.cc
+++ b/plugin/federated/federated_hist.cc
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2024, XGBoost contributors
+ */
+#include "federated_hist.h"
+
+#include "../../src/collective/allgather.h"         // for AllgatherV
+#include "../../src/collective/communicator-inl.h"  // for GetRank
+#include "../../src/tree/hist/histogram.h"  // for SubtractHistParallel, BuildSampleHistograms
+
+namespace xgboost::tree {
+template <bool any_missing>
+void FederataedHistPolicy::DoBuildLocalHistograms(
+    common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+    std::vector<bst_node_t> const &nodes_to_build,
+    common::RowSetCollection const &row_set_collection, common::Span<GradientPair const> gpair_h,
+    bool force_read_by_column, common::ParallelGHistBuilder *buffer) {
+  if (is_col_split_) {
+    // Call the interface to transmit gidx information to the secure worker for encrypted
+    // histogram computation
+    auto cuts = gidx.Cuts().Ptrs();
+    // fixme: this can be done during reset.
+    if (!is_aggr_context_initialized_) {
+      auto slots = std::vector<int>();
+      auto num_rows = gidx.Size();
+      for (std::size_t row = 0; row < num_rows; row++) {
+        for (std::size_t f = 0; f < cuts.size() - 1; f++) {
+          auto slot = gidx.GetGindex(row, f);
+          slots.push_back(slot);
+        }
+      }
+      plugin_->Reset(cuts, slots);
+      is_aggr_context_initialized_ = true;
+    }
+
+    // Further use the row set collection info to
+    // get the encrypted histogram from the secure worker
+    std::vector<std::uint64_t const *> ptrs(nodes_to_build.size());
+    std::vector<std::size_t> sizes(nodes_to_build.size());
+    std::vector<bst_node_t> nodes(nodes_to_build.size());
+    for (std::size_t i = 0; i < nodes_to_build.size(); ++i) {
+      auto nidx = nodes_to_build[i];
+      ptrs[i] = row_set_collection[nidx].begin;
+      sizes[i] = row_set_collection[nidx].Size();
+      nodes[i] = nidx;
+    }
+    hist_data_ = this->plugin_->BuildEncryptedHistVert(ptrs, sizes, nodes);
+  } else {
+    BuildSampleHistograms<any_missing>(this->n_threads_, space, gidx, nodes_to_build,
+                                       row_set_collection, gpair_h, force_read_by_column, buffer);
+  }
+}
+
+template void FederataedHistPolicy::DoBuildLocalHistograms<true>(
+    common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+    std::vector<bst_node_t> const &nodes_to_build,
+    common::RowSetCollection const &row_set_collection, common::Span<GradientPair const> gpair_h,
+    bool force_read_by_column, common::ParallelGHistBuilder *buffer);
+template void FederataedHistPolicy::DoBuildLocalHistograms<false>(
+    common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+    std::vector<bst_node_t> const &nodes_to_build,
+    common::RowSetCollection const &row_set_collection, common::Span<GradientPair const> gpair_h,
+    bool force_read_by_column, common::ParallelGHistBuilder *buffer);
+
+void FederataedHistPolicy::DoSyncHistogram(Context const *ctx, RegTree const *p_tree,
+                                           std::vector<bst_node_t> const &nodes_to_build,
+                                           std::vector<bst_node_t> const &nodes_to_trick,
+                                           common::ParallelGHistBuilder *buffer,
+                                           tree::BoundedHistCollection *p_hist) {
+  auto n_total_bins = buffer->TotalBins();
+  common::BlockedSpace2d space(
+      nodes_to_build.size(), [&](std::size_t) { return n_total_bins; }, 1024);
+  CHECK(!nodes_to_build.empty());
+
+  auto &hist = *p_hist;
+  if (is_col_split_) {
+    // Under secure vertical mode, we perform allgather to get the global histogram. Note
+    // that only the label owner (rank == 0) needs the global histogram
+
+    // Perform AllGather
+    HostDeviceVector<std::int8_t> hist_entries;
+    std::vector<std::int64_t> recv_segments;
+    collective::SafeColl(
+        collective::AllgatherV(ctx, linalg::MakeVec(hist_data_), &recv_segments, &hist_entries));
+
+    // Call interface here to post-process the messages
+    common::Span<double> hist_aggr =
+        plugin_->SyncEncryptedHistVert(common::RestoreType<std::uint8_t>(hist_entries.HostSpan()));
+
+    // Update histogram for label owner
+    if (collective::GetRank() == 0) {
+      // iterator of the beginning of the vector
+      bst_node_t n_nodes = nodes_to_build.size();
+      std::int32_t n_workers = collective::GetWorldSize();
+      bst_idx_t worker_size = hist_aggr.size() / n_workers;
+      CHECK_EQ(hist_aggr.size() % n_workers, 0);
+      // Initialize histogram. For the normal case, this is done by the parallel hist
+      // buffer. We should try to unify the code paths.
+      for (auto nidx : nodes_to_build) {
+        auto hist_dst = hist[nidx];
+        std::fill_n(hist_dst.data(), hist_dst.size(), GradientPairPrecise{});
+      }
+
+      // for each worker
+      for (auto widx = 0; widx < n_workers; ++widx) {
+        auto worker_hist = hist_aggr.subspan(widx * worker_size, worker_size);
+        // for each node
+        for (bst_node_t nidx_in_set = 0; nidx_in_set < n_nodes; ++nidx_in_set) {
+          auto hist_src = worker_hist.subspan(n_total_bins * 2 * nidx_in_set, n_total_bins * 2);
+          auto hist_src_g = common::RestoreType<GradientPairPrecise>(hist_src);
+          auto hist_dst = hist[nodes_to_build[nidx_in_set]];
+          CHECK_EQ(hist_src_g.size(), hist_dst.size());
+          common::IncrementHist(hist_dst, hist_src_g, 0, hist_dst.size());
+        }
+      }
+    }
+  } else {
+    common::ParallelFor2d(space, this->n_threads_, [&](std::size_t node, common::Range1d r) {
+      // Merging histograms from each thread.
+      buffer->ReduceHist(node, r.begin(), r.end());
+    });
+    // Secure mode, we need to call interface to perform encryption and decryption
+    // note that the actual aggregation will be performed at server side
+    auto first_nidx = nodes_to_build.front();
+    std::size_t n = n_total_bins * nodes_to_build.size() * 2;
+    auto hist_to_aggr = std::vector<double>();
+    for (std::size_t hist_idx = 0; hist_idx < n; hist_idx++) {
+      double hist_item = reinterpret_cast<double *>(hist[first_nidx].data())[hist_idx];
+      hist_to_aggr.push_back(hist_item);
+    }
+    // ProcessHistograms
+    auto hist_buf = plugin_->BuildEncryptedHistHori(hist_to_aggr);
+
+    // allgather
+    HostDeviceVector<std::int8_t> hist_entries;
+    std::vector<std::int64_t> recv_segments;
+    auto rc = collective::AllgatherV(ctx, linalg::MakeVec(hist_buf), &recv_segments, &hist_entries);
+    collective::SafeColl(rc);
+
+    auto hist_aggr =
+        plugin_->SyncEncryptedHistHori(common::RestoreType<std::uint8_t>(hist_entries.HostSpan()));
+    // Assign the aggregated histogram back to the local histogram
+    for (std::size_t hist_idx = 0; hist_idx < n; hist_idx++) {
+      reinterpret_cast<double *>(hist[first_nidx].data())[hist_idx] = hist_aggr[hist_idx];
+    }
+  }
+
+  SubtractHistParallel(ctx, space, p_tree, nodes_to_build, nodes_to_trick, buffer, p_hist);
+}
+}  // namespace xgboost::tree

--- a/plugin/federated/federated_hist.h
+++ b/plugin/federated/federated_hist.h
@@ -32,7 +32,7 @@ class FederataedHistPolicy {
   Context const* ctx_;
 
  public:
-  void Reset(Context const *ctx, bool is_distributed, bool is_col_split) {
+  void DoReset(Context const *ctx, bool is_distributed, bool is_col_split) {
     this->is_distributed_ = is_distributed;
     CHECK(is_distributed);
     this->ctx_ = ctx;
@@ -48,11 +48,11 @@ class FederataedHistPolicy {
                               std::vector<bst_node_t> const &nodes_to_build,
                               common::RowSetCollection const &row_set_collection,
                               common::Span<GradientPair const> gpair_h, bool force_read_by_column,
-                              common::ParallelGHistBuilder *buffer);
+                              common::ParallelGHistBuilder *p_buffer);
 
-  void DoSyncHistogram(Context const *ctx, RegTree const *p_tree,
+  void DoSyncHistogram(common::BlockedSpace2d const &space,
                        std::vector<bst_node_t> const &nodes_to_build,
                        std::vector<bst_node_t> const &nodes_to_trick,
-                       common::ParallelGHistBuilder *buffer, tree::BoundedHistCollection *p_hist);
+                       common::ParallelGHistBuilder *p_buffer, tree::BoundedHistCollection *p_hist);
 };
 }  // namespace xgboost::tree

--- a/plugin/federated/federated_hist.h
+++ b/plugin/federated/federated_hist.h
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2024, XGBoost contributors
+ */
+#pragma once
+#include <cstdint>  // for int32_t
+#include <vector>   // for vector
+
+#include "../../src/collective/comm_group.h"   // for GlobalCommGroup
+#include "../../src/common/hist_util.h"        // for ParallelGHistBuilder
+#include "../../src/common/row_set.h"          // for RowSetCollection
+#include "../../src/common/threading_utils.h"  // for BlockedSpace2d
+#include "../../src/data/gradient_index.h"     // for GHistIndexMatrix
+#include "../../src/tree/hist/hist_cache.h"    // for BoundedHistCollection
+#include "federated_comm.h"                    // for FederatedComm
+#include "xgboost/base.h"                      // for GradientPair
+#include "xgboost/context.h"                   // for Context
+#include "xgboost/span.h"                      // for Span
+#include "xgboost/tree_model.h"                // for RegTree
+
+namespace xgboost::tree {
+/**
+ * @brief Federated histogram build policy
+ */
+class FederataedHistPolicy {
+  // fixme: duplicated code
+  bool is_col_split_{false};
+  bool is_distributed_{false};
+  std::int32_t n_threads_{false};
+  decltype(std::declval<collective::FederatedComm>().EncryptionPlugin()) plugin_;
+  xgboost::common::Span<std::uint8_t> hist_data_;
+  // only initialize the aggregation context once
+  bool is_aggr_context_initialized_ = false;  // fixme
+
+ public:
+  void Reset(Context const *ctx, bool is_distributed, bool is_col_split) {
+    this->is_distributed_ = is_distributed;
+    CHECK(is_distributed);
+    this->n_threads_ = ctx->Threads();
+    this->is_col_split_ = is_col_split;
+    auto const &comm = collective::GlobalCommGroup()->Ctx(ctx, DeviceOrd::CPU());
+    auto const &fed = dynamic_cast<collective::FederatedComm const &>(comm);
+    plugin_ = fed.EncryptionPlugin();
+    CHECK(is_distributed_) << "Unreachable. Single node training can not be federated.";
+  }
+
+  template <bool any_missing>
+  void DoBuildLocalHistograms(common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+                              std::vector<bst_node_t> const &nodes_to_build,
+                              common::RowSetCollection const &row_set_collection,
+                              common::Span<GradientPair const> gpair_h, bool force_read_by_column,
+                              common::ParallelGHistBuilder *buffer);
+
+  void DoSyncHistogram(Context const *ctx, RegTree const *p_tree,
+                       std::vector<bst_node_t> const &nodes_to_build,
+                       std::vector<bst_node_t> const &nodes_to_trick,
+                       common::ParallelGHistBuilder *buffer, tree::BoundedHistCollection *p_hist);
+};
+}  // namespace xgboost::tree

--- a/plugin/federated/federated_hist.h
+++ b/plugin/federated/federated_hist.h
@@ -25,17 +25,17 @@ class FederataedHistPolicy {
   // fixme: duplicated code
   bool is_col_split_{false};
   bool is_distributed_{false};
-  std::int32_t n_threads_{false};
   decltype(std::declval<collective::FederatedComm>().EncryptionPlugin()) plugin_;
   xgboost::common::Span<std::uint8_t> hist_data_;
-  // only initialize the aggregation context once
-  bool is_aggr_context_initialized_ = false;  // fixme
+  // Only initialize the aggregation context once
+  bool is_gidx_initialized_{false};
+  Context const* ctx_;
 
  public:
   void Reset(Context const *ctx, bool is_distributed, bool is_col_split) {
     this->is_distributed_ = is_distributed;
     CHECK(is_distributed);
-    this->n_threads_ = ctx->Threads();
+    this->ctx_ = ctx;
     this->is_col_split_ = is_col_split;
     auto const &comm = collective::GlobalCommGroup()->Ctx(ctx, DeviceOrd::CPU());
     auto const &fed = dynamic_cast<collective::FederatedComm const &>(comm);

--- a/plugin/federated/federated_plugin.h
+++ b/plugin/federated/federated_plugin.h
@@ -12,6 +12,12 @@
  *   - Build histogram for vertical federated learning.
  *   - Build histogram for horizontal federated learning.
  *
+ * Since we don't require the plugin to have network capability, the synchronization is
+ * performed in XGBoost. As a result, the build procedure is divided into four steps,
+ * first we need to build a local histogram, then encrypt it with the plugin. Afterward,
+ * the control returns to XBGoost, which is responsible for synchronization. Lastly, the
+ * plugin will recieve the synchronization result and return the decrypted histogram.
+ *
  * See below function prototypes for details. All prototypes are for C functions that are
  * suitable for `dlopen`.
  */

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -7,8 +7,8 @@
 
 #include <algorithm>  // for min
 #include <atomic>     // for atomic
-#include <cinttypes>  // for uint32_t
 #include <cstddef>    // for size_t
+#include <cstdint>    // for uint32_t
 #include <memory>     // for make_unique
 #include <vector>
 

--- a/src/tree/hist/histogram.cc
+++ b/src/tree/hist/histogram.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 by XGBoost Contributors
+ * Copyright 2023-2024, XGBoost Contributors
  */
 #include "histogram.h"
 
@@ -10,7 +10,7 @@
 
 #include "../../common/transform_iterator.h"  // for MakeIndexTransformIter
 #include "expand_entry.h"                     // for MultiExpandEntry, CPUExpandEntry
-#include "xgboost/logging.h"                  // for CHECK_NE
+#include "xgboost/logging.h"                  // for CHECK_EQ
 #include "xgboost/span.h"                     // for Span
 #include "xgboost/tree_model.h"               // for RegTree
 

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -277,7 +277,7 @@ class DefaultHistPolicy {
       buffer->ReduceHist(node, r.begin(), r.end());
     });
 
-    // Sync the histogram if it's not column split
+    // Aggregate the histogram if it's not column split
     if (is_distributed_ && !is_col_split_) {
       // The cache is contiguous, we can perform allreduce for all nodes in one go.
       CHECK(!nodes_to_build.empty());

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -200,13 +200,12 @@ void BuildSampleHistograms(std::int32_t n_threads, common::BlockedSpace2d const 
   common::ParallelFor2d(space, n_threads, [&](bst_idx_t nid_in_set, common::Range1d r) {
     auto const tid = omp_get_thread_num();
     bst_node_t const nidx = nodes_to_build[nid_in_set];
-    auto elem = row_set_collection[nidx];
+    auto const &elem = row_set_collection[nidx];
     auto start_of_row_set = std::min(r.begin(), elem.Size());
     auto end_of_row_set = std::min(r.end(), elem.Size());
-    auto rid_set = common::RowSetCollection::Elem(elem.begin + start_of_row_set,
-                                                  elem.begin + end_of_row_set, nidx);
+    auto rid_set = common::Span{elem.begin() + start_of_row_set, elem.begin() + end_of_row_set};
     auto hist = buffer->GetInitializedHist(tid, nid_in_set);
-    if (rid_set.Size() != 0) {
+    if (!rid_set.empty()) {
       common::BuildHist<any_missing>(gpair_h, rid_set, gidx, hist, force_read_by_column);
     }
   });

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -29,6 +29,8 @@
 
 #if defined(XGBOOST_USE_FEDERATED)
 #include "../../../plugin/federated/federated_hist.h"  // for FederataedHistPolicy
+#else
+#include "../../common/error_msg.h"  // for NoFederated
 #endif
 
 namespace xgboost::tree {
@@ -437,15 +439,15 @@ class MultiHistogramBuilder {
   }
 
   void Reset(Context const *ctx, bst_bin_t total_bins, bst_target_t n_targets, BatchParam const &p,
-             bool is_distributed, bool is_col_split, bool is_secure,
+             bool is_distributed, bool is_col_split, bool is_encrypted,
              HistMakerTrainParam const *param) {
     ctx_ = ctx;
 #if defined(XGBOOST_USE_FEDERATED)
-    if (is_secure && !std::get_if<std::vector<FedHistogramBuilder>>(&target_builders_)) {
+    if (is_encrypted && !std::get_if<std::vector<FedHistogramBuilder>>(&target_builders_)) {
       target_builders_.emplace<std::vector<FedHistogramBuilder>>(n_targets);
     }
 #else
-    CHECK(!is_secure);
+    CHECK(!is_encrypted) << error::NoFederated();
 #endif
 
     std::visit(

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -46,7 +46,7 @@ void AssignNodes(RegTree const *p_tree, std::vector<MultiExpandEntry> const &val
 void AssignNodes(RegTree const *p_tree, std::vector<CPUExpandEntry> const &candidates,
                  common::Span<bst_node_t> nodes_to_build, common::Span<bst_node_t> nodes_to_sub);
 
-constexpr std::size_t SubHistGrain() { return 1024; };
+constexpr std::size_t SubHistGrain() { return 1024; }
 
 constexpr double kHist2F64 = sizeof(GradientPairPrecise) / sizeof(double);
 static_assert(kHist2F64 == 2);

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -4,11 +4,12 @@
 #ifndef XGBOOST_TREE_HIST_HISTOGRAM_H_
 #define XGBOOST_TREE_HIST_HISTOGRAM_H_
 
-#include <algorithm>   // for max
-#include <cstddef>     // for size_t
-#include <cstdint>     // for int32_t
-#include <utility>     // for move
-#include <vector>      // for vector
+#include <algorithm>  // for max
+#include <cstddef>    // for size_t
+#include <cstdint>    // for int32_t
+#include <utility>    // for move
+#include <variant>    // for variant
+#include <vector>     // for vector
 
 #include "../../collective/allreduce.h"    // for Allreduce
 #include "../../common/hist_util.h"        // for GHistRow, ParallelGHi...
@@ -26,6 +27,10 @@
 #include "xgboost/span.h"                  // for Span
 #include "xgboost/tree_model.h"            // for RegTree
 
+#if defined(XGBOOST_USE_FEDERATED)
+#include "../../../plugin/federated/federated_hist.h"  // for FederataedHistPolicy
+#endif
+
 namespace xgboost::tree {
 /**
  * @brief Decide which node as the build node for multi-target trees.
@@ -39,18 +44,29 @@ void AssignNodes(RegTree const *p_tree, std::vector<MultiExpandEntry> const &val
 void AssignNodes(RegTree const *p_tree, std::vector<CPUExpandEntry> const &candidates,
                  common::Span<bst_node_t> nodes_to_build, common::Span<bst_node_t> nodes_to_sub);
 
-class HistogramBuilder {
-  /*! \brief culmulative histogram of gradients. */
+/**
+ * @brief Policy class container for building histogram.
+ *
+ * This is an algorithm template, it requires the specific policy to fill in the
+ * `DoBuildLocalHistograms`, `DoSyncHistogram`, and the `Reset` methods. See the default
+ * implementation for an example.
+ */
+template <typename BuildPolicy>
+class HistogramPolicyContainer : public BuildPolicy {
+  // Culmulative histogram of gradients.
   BoundedHistCollection hist_;
+  // Histogram buffers for threads.
   common::ParallelGHistBuilder buffer_;
   BatchParam param_;
-  int32_t n_threads_{-1};
-  // Whether XGBoost is running in distributed environment.
-  bool is_distributed_{false};
-  bool is_col_split_{false};
-  bool is_secure_{false};
+  std::int32_t n_threads_{-1};
 
  public:
+  HistogramPolicyContainer() = default;
+  HistogramPolicyContainer(HistogramPolicyContainer const &) = delete;
+  HistogramPolicyContainer(HistogramPolicyContainer &&) = default;
+  HistogramPolicyContainer &operator=(HistogramPolicyContainer const &) = delete;
+  HistogramPolicyContainer &operator=(HistogramPolicyContainer &&) = default;
+
   /**
    * @brief Reset the builder, should be called before growing a new tree.
    *
@@ -59,35 +75,13 @@ class HistogramBuilder {
    *                         of using global rabit variable.
    */
   void Reset(Context const *ctx, bst_bin_t total_bins, BatchParam const &p, bool is_distributed,
-             bool is_col_split, bool is_secure, HistMakerTrainParam const *param) {
+             bool is_col_split, HistMakerTrainParam const *param) {
     n_threads_ = ctx->Threads();
     param_ = p;
     hist_.Reset(total_bins, param->max_cached_hist_node);
     buffer_.Init(total_bins);
-    is_distributed_ = is_distributed;
-    is_col_split_ = is_col_split;
-    is_secure_ = is_secure;
-  }
 
-  template <bool any_missing>
-  void BuildLocalHistograms(common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
-                            std::vector<bst_node_t> const &nodes_to_build,
-                            common::RowSetCollection const &row_set_collection,
-                            common::Span<GradientPair const> gpair_h, bool force_read_by_column) {
-    // Parallel processing by nodes and data in each node
-    common::ParallelFor2d(space, this->n_threads_, [&](size_t nid_in_set, common::Range1d r) {
-      const auto tid = static_cast<unsigned>(omp_get_thread_num());
-      bst_node_t const nidx = nodes_to_build[nid_in_set];
-      auto const& elem = row_set_collection[nidx];
-      auto start_of_row_set = std::min(r.begin(), elem.Size());
-      auto end_of_row_set = std::min(r.end(), elem.Size());
-      auto rid_set = common::Span<bst_idx_t const>{elem.begin() + start_of_row_set,
-                                                   elem.begin() + end_of_row_set};
-      auto hist = buffer_.GetInitializedHist(tid, nid_in_set);
-      if (rid_set.size() != 0) {
-        common::BuildHist<any_missing>(gpair_h, rid_set, gidx, hist, force_read_by_column);
-      }
-    });
+    BuildPolicy::Reset(ctx, is_distributed, is_col_split);
   }
 
   /**
@@ -163,65 +157,27 @@ class HistogramBuilder {
     }
 
     if (gidx.IsDense()) {
-      this->BuildLocalHistograms<false>(space, gidx, nodes_to_build, row_set_collection,
-                                        gpair.Values(), force_read_by_column);
+      this->template BuildLocalHistograms<false>(space, gidx, nodes_to_build, row_set_collection,
+                                                 gpair.Values(), force_read_by_column);
     } else {
-      this->BuildLocalHistograms<true>(space, gidx, nodes_to_build, row_set_collection,
-                                       gpair.Values(), force_read_by_column);
+      this->template BuildLocalHistograms<true>(space, gidx, nodes_to_build, row_set_collection,
+                                                gpair.Values(), force_read_by_column);
     }
   }
 
-void SyncHistogram(Context const *ctx, RegTree const *p_tree,
+  template <bool any_missing>
+  void BuildLocalHistograms(common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+                            std::vector<bst_node_t> const &nodes_to_build,
+                            common::RowSetCollection const &row_set_collection,
+                            common::Span<GradientPair const> gpair_h, bool force_read_by_column) {
+    BuildPolicy::template DoBuildLocalHistograms<any_missing>(
+        space, gidx, nodes_to_build, row_set_collection, gpair_h, force_read_by_column, &buffer_);
+  }
+
+  void SyncHistogram(Context const *ctx, RegTree const *p_tree,
                      std::vector<bst_node_t> const &nodes_to_build,
                      std::vector<bst_node_t> const &nodes_to_trick) {
-    auto n_total_bins = buffer_.TotalBins();
-
-    common::BlockedSpace2d space(
-        nodes_to_build.size(), [&](std::size_t) { return n_total_bins; }, 1024);
-    common::ParallelFor2d(space, this->n_threads_, [&](size_t node, common::Range1d r) {
-      // Merging histograms from each thread.
-      this->buffer_.ReduceHist(node, r.begin(), r.end());
-    });
-    if (is_distributed_ && !is_col_split_) {
-      // The cache is contiguous, we can perform allreduce for all nodes in one go.
-      CHECK(!nodes_to_build.empty());
-      auto first_nidx = nodes_to_build.front();
-      std::size_t n = n_total_bins * nodes_to_build.size() * 2;
-      auto rc = collective::Allreduce(
-          ctx, linalg::MakeVec(reinterpret_cast<double *>(this->hist_[first_nidx].data()), n),
-          collective::Op::kSum);
-      SafeColl(rc);
-    }
-
-    if (is_distributed_ && is_col_split_ && is_secure_) {
-      // Under secure vertical mode, we perform allgather for all nodes
-      CHECK(!nodes_to_build.empty());
-      // in theory the operation is AllGather, under current histogram setting of
-      // same length with 0s for empty slots,
-      // AllReduce is the most efficient way of achieving the global histogram
-      auto first_nidx = nodes_to_build.front();
-      std::size_t n = n_total_bins * nodes_to_build.size() * 2;
-      collective::SafeColl(collective::Allreduce(
-          ctx, linalg::MakeVec(reinterpret_cast<double *>(this->hist_[first_nidx].data()), n),
-          collective::Op::kSum));
-    }
-
-    common::BlockedSpace2d const &subspace =
-        nodes_to_trick.size() == nodes_to_build.size()
-            ? space
-            : common::BlockedSpace2d{nodes_to_trick.size(),
-                                     [&](std::size_t) { return n_total_bins; }, 1024};
-    common::ParallelFor2d(
-        subspace, this->n_threads_, [&](std::size_t nidx_in_set, common::Range1d r) {
-          auto subtraction_nidx = nodes_to_trick[nidx_in_set];
-          auto parent_id = p_tree->Parent(subtraction_nidx);
-          auto sibling_nidx = p_tree->IsLeftChild(subtraction_nidx) ? p_tree->RightChild(parent_id)
-                                                                    : p_tree->LeftChild(parent_id);
-          auto sibling_hist = this->hist_[sibling_nidx];
-          auto parent_hist = this->hist_[parent_id];
-          auto subtract_hist = this->hist_[subtraction_nidx];
-          common::SubtractionHist(subtract_hist, parent_hist, sibling_hist, r.begin(), r.end());
-        });
+    BuildPolicy::DoSyncHistogram(ctx, p_tree, nodes_to_build, nodes_to_trick, &buffer_, &hist_);
   }
 
  public:
@@ -230,6 +186,118 @@ void SyncHistogram(Context const *ctx, RegTree const *p_tree,
   [[nodiscard]] BoundedHistCollection &Histogram() { return hist_; }
   auto &Buffer() { return buffer_; }
 };
+
+
+// Build routine for sample-based split.
+template <bool any_missing>
+void BuildSampleHistograms(std::int32_t n_threads, common::BlockedSpace2d const &space,
+                           GHistIndexMatrix const &gidx,
+                           std::vector<bst_node_t> const &nodes_to_build,
+                           common::RowSetCollection const &row_set_collection,
+                           common::Span<GradientPair const> gpair_h, bool force_read_by_column,
+                           common::ParallelGHistBuilder *buffer) {
+  // Parallel processing by nodes and data in each node
+  common::ParallelFor2d(space, n_threads, [&](bst_idx_t nid_in_set, common::Range1d r) {
+    auto const tid = omp_get_thread_num();
+    bst_node_t const nidx = nodes_to_build[nid_in_set];
+    auto elem = row_set_collection[nidx];
+    auto start_of_row_set = std::min(r.begin(), elem.Size());
+    auto end_of_row_set = std::min(r.end(), elem.Size());
+    auto rid_set = common::RowSetCollection::Elem(elem.begin + start_of_row_set,
+                                                  elem.begin + end_of_row_set, nidx);
+    auto hist = buffer->GetInitializedHist(tid, nid_in_set);
+    if (rid_set.Size() != 0) {
+      common::BuildHist<any_missing>(gpair_h, rid_set, gidx, hist, force_read_by_column);
+    }
+  });
+}
+
+// Perform the subtraction trick
+inline void SubtractHistParallel(Context const *ctx, common::BlockedSpace2d const &space,
+                                 RegTree const *p_tree,
+                                 std::vector<bst_node_t> const &nodes_to_build,
+                                 std::vector<bst_node_t> const &nodes_to_trick,
+                                 common::ParallelGHistBuilder *buffer,
+                                 BoundedHistCollection *p_hist) {
+  auto n_total_bins = buffer->TotalBins();
+  auto &hist = *p_hist;
+  common::BlockedSpace2d const &subspace =
+      nodes_to_trick.size() == nodes_to_build.size()
+          ? space
+          : common::BlockedSpace2d{nodes_to_trick.size(), [&](std::size_t) { return n_total_bins; },
+                                   1024};
+  common::ParallelFor2d(subspace, ctx->Threads(), [&](std::size_t nidx_in_set, common::Range1d r) {
+    auto subtraction_nidx = nodes_to_trick[nidx_in_set];
+    auto parent_id = p_tree->Parent(subtraction_nidx);
+    auto sibling_nidx = p_tree->IsLeftChild(subtraction_nidx) ? p_tree->RightChild(parent_id)
+                                                              : p_tree->LeftChild(parent_id);
+    auto sibling_hist = hist[sibling_nidx];
+    auto parent_hist = hist[parent_id];
+    auto subtract_hist = hist[subtraction_nidx];
+    common::SubtractionHist(subtract_hist, parent_hist, sibling_hist, r.begin(), r.end());
+  });
+}
+
+/**
+ * @brief Histogram build policy for normal cases.
+ */
+class DefaultHistPolicy {
+  // Whether XGBoost is running in distributed environment.
+  bool is_distributed_{false};
+  bool is_col_split_{false};
+  std::int32_t n_threads_{-1};
+
+ public:
+  void Reset(Context const *ctx, bool is_distributed, bool is_col_split) {
+    this->is_distributed_ = is_distributed;
+    this->n_threads_ = ctx->Threads();
+    this->is_col_split_ = is_col_split;
+  }
+
+  template <bool any_missing>
+  void DoBuildLocalHistograms(common::BlockedSpace2d const &space, GHistIndexMatrix const &gidx,
+                              std::vector<bst_node_t> const &nodes_to_build,
+                              common::RowSetCollection const &row_set_collection,
+                              common::Span<GradientPair const> gpair_h, bool force_read_by_column,
+                              common::ParallelGHistBuilder *buffer) {
+    BuildSampleHistograms<any_missing>(this->n_threads_, space, gidx, nodes_to_build,
+                                       row_set_collection, gpair_h, force_read_by_column, buffer);
+  }
+
+  void DoSyncHistogram(Context const *ctx, RegTree const *p_tree,
+                       std::vector<bst_node_t> const &nodes_to_build,
+                       std::vector<bst_node_t> const &nodes_to_trick,
+                       common::ParallelGHistBuilder *buffer, BoundedHistCollection *p_hist) {
+    auto n_total_bins = buffer->TotalBins();
+    auto &hist = *p_hist;
+
+    auto space = common::BlockedSpace2d{nodes_to_build.size(),
+                                        [&](std::size_t) { return n_total_bins; }, 1024};
+    common::ParallelFor2d(space, ctx->Threads(), [&](size_t node, common::Range1d r) {
+      // Merging histograms from each thread.
+      buffer->ReduceHist(node, r.begin(), r.end());
+    });
+
+    // Sync the histogram if it's not column split
+    if (is_distributed_ && !is_col_split_) {
+      // The cache is contiguous, we can perform allreduce for all nodes in one go.
+      CHECK(!nodes_to_build.empty());
+      auto first_nidx = nodes_to_build.front();
+      std::size_t n = n_total_bins * nodes_to_build.size() * 2;
+      auto rc = collective::Allreduce(
+          ctx, linalg::MakeVec(reinterpret_cast<double *>(hist[first_nidx].data()), n),
+          collective::Op::kSum);
+      SafeColl(rc);
+    }
+
+    SubtractHistParallel(ctx, space, p_tree, nodes_to_build, nodes_to_trick, buffer, p_hist);
+  }
+};
+
+using HistogramBuilder = HistogramPolicyContainer<DefaultHistPolicy>;
+#if defined(XGBOOST_USE_FEDERATED)
+using FedHistogramBuilder = HistogramPolicyContainer<FederataedHistPolicy>;
+#endif  // defined(XGBOOST_USE_FEDERATED)
 
 // Construct a work space for building histogram.  Eventually we should move this
 // function into histogram builder once hist tree method supports external memory.
@@ -257,7 +325,12 @@ common::BlockedSpace2d ConstructHistSpace(Partitioner const &partitioners,
  * @brief Histogram builder that can handle multiple targets.
  */
 class MultiHistogramBuilder {
-  std::vector<HistogramBuilder> target_builders_;
+#if defined(XGBOOST_USE_FEDERATED)
+  std::variant<std::vector<HistogramBuilder>, std::vector<FedHistogramBuilder>> target_builders_;
+#else
+  std::variant<std::vector<HistogramBuilder>> target_builders_;
+#endif
+
   Context const *ctx_;
 
  public:
@@ -272,30 +345,35 @@ class MultiHistogramBuilder {
     auto n_targets = p_tree->NumTargets();
     CHECK_EQ(gpair.Shape(1), n_targets);
     CHECK_EQ(p_fmat->Info().num_row_, gpair.Shape(0));
-    CHECK_EQ(target_builders_.size(), n_targets);
-    std::vector<bst_node_t> nodes{best.nid};
-    std::vector<bst_node_t> dummy_sub;
 
-    auto space = ConstructHistSpace(partitioners, nodes);
-    for (bst_target_t t{0}; t < n_targets; ++t) {
-      this->target_builders_[t].AddHistRows(p_tree, &nodes, &dummy_sub, false);
-    }
-    CHECK(dummy_sub.empty());
+    std::visit(
+        [&](auto &&target_builders) {
+          CHECK_EQ(target_builders.size(), n_targets);
+          std::vector<bst_node_t> nodes{best.nid};
+          std::vector<bst_node_t> dummy_sub;
 
-    std::size_t page_idx{0};
-    for (auto const &gidx : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, param)) {
-      for (bst_target_t t{0}; t < n_targets; ++t) {
-        auto t_gpair = gpair.Slice(linalg::All(), t);
-        this->target_builders_[t].BuildHist(page_idx, space, gidx,
-                                            partitioners[page_idx].Partitions(), nodes, t_gpair,
-                                            force_read_by_column);
-      }
-      ++page_idx;
-    }
+          auto space = ConstructHistSpace(partitioners, nodes);
+          for (bst_target_t t{0}; t < n_targets; ++t) {
+            target_builders[t].AddHistRows(p_tree, &nodes, &dummy_sub, false);
+          }
+          CHECK(dummy_sub.empty());
 
-    for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
-      this->target_builders_[t].SyncHistogram(ctx_, p_tree, nodes, dummy_sub);
-    }
+          std::size_t page_idx{0};
+          for (auto const &gidx : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, param)) {
+            for (bst_target_t t{0}; t < n_targets; ++t) {
+              auto t_gpair = gpair.Slice(linalg::All(), t);
+              target_builders[t].BuildHist(page_idx, space, gidx,
+                                           partitioners[page_idx].Partitions(), nodes, t_gpair,
+                                           force_read_by_column);
+            }
+            ++page_idx;
+          }
+
+          for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
+            target_builders[t].SyncHistogram(ctx_, p_tree, nodes, dummy_sub);
+          }
+        },
+        target_builders_);
   }
   /**
    * @brief Build histogram for left and right child of valid candidates
@@ -310,49 +388,76 @@ class MultiHistogramBuilder {
     std::vector<bst_node_t> nodes_to_sub(valid_candidates.size());
     AssignNodes(p_tree, valid_candidates, nodes_to_build, nodes_to_sub);
 
-    // use the first builder for getting number of valid nodes.
-    target_builders_.front().AddHistRows(p_tree, &nodes_to_build, &nodes_to_sub, true);
-    CHECK_GE(nodes_to_build.size(), nodes_to_sub.size());
-    CHECK_EQ(nodes_to_sub.size() + nodes_to_build.size(), valid_candidates.size() * 2);
+    std::visit(
+        [&](auto &&target_builders) {
+          // Use the first builder for getting the number of valid nodes.
+          target_builders.front().AddHistRows(p_tree, &nodes_to_build, &nodes_to_sub, true);
+          CHECK_GE(nodes_to_build.size(), nodes_to_sub.size());
+          CHECK_EQ(nodes_to_sub.size() + nodes_to_build.size(), valid_candidates.size() * 2);
 
-    // allocate storage for the rest of the builders
-    for (bst_target_t t = 1; t < target_builders_.size(); ++t) {
-      target_builders_[t].AddHistRows(p_tree, &nodes_to_build, &nodes_to_sub, false);
-    }
+          // allocate storage for the rest of the builders
+          for (bst_target_t t = 1; t < target_builders.size(); ++t) {
+            target_builders[t].AddHistRows(p_tree, &nodes_to_build, &nodes_to_sub, false);
+          }
 
-    auto space = ConstructHistSpace(partitioners, nodes_to_build);
-    std::size_t page_idx{0};
-    for (auto const &page : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, param)) {
-      CHECK_EQ(gpair.Shape(1), p_tree->NumTargets());
-      for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
-        auto t_gpair = gpair.Slice(linalg::All(), t);
-        CHECK_EQ(t_gpair.Shape(0), p_fmat->Info().num_row_);
-        this->target_builders_[t].BuildHist(page_idx, space, page,
-                                            partitioners[page_idx].Partitions(), nodes_to_build,
-                                            t_gpair, force_read_by_column);
-      }
-      page_idx++;
-    }
+          auto space = ConstructHistSpace(partitioners, nodes_to_build);
+          std::size_t page_idx{0};
+          // Build one histogram per target per page.
+          for (auto const &page : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, param)) {
+            CHECK_EQ(gpair.Shape(1), p_tree->NumTargets());
+            for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
+              auto t_gpair = gpair.Slice(linalg::All(), t);
+              CHECK_EQ(t_gpair.Shape(0), p_fmat->Info().num_row_);
+              target_builders[t].BuildHist(page_idx, space, page,
+                                           partitioners[page_idx].Partitions(), nodes_to_build,
+                                           t_gpair, force_read_by_column);
+            }
+            page_idx++;
+          }
 
-    for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
-      this->target_builders_[t].SyncHistogram(ctx, p_tree, nodes_to_build, nodes_to_sub);
-    }
+          for (bst_target_t t = 0; t < p_tree->NumTargets(); ++t) {
+            target_builders[t].SyncHistogram(ctx, p_tree, nodes_to_build, nodes_to_sub);
+          }
+        },
+        target_builders_);
   }
 
-  [[nodiscard]] auto const &Histogram(bst_target_t t) const {
-    return target_builders_[t].Histogram();
+  [[nodiscard]] decltype(auto) Histogram(bst_target_t t) const {
+    return std::visit(
+        [t](auto const &target_builders) -> decltype(auto) {
+          return target_builders[t].Histogram();
+        },
+        target_builders_);
   }
-  [[nodiscard]] auto &Histogram(bst_target_t t) { return target_builders_[t].Histogram(); }
+  [[nodiscard]] decltype(auto) Histogram(bst_target_t t) {
+    return std::visit(
+        [t](auto const &target_builders) -> decltype(auto) {
+          return target_builders[t].Histogram();
+        },
+        target_builders_);
+  }
 
   void Reset(Context const *ctx, bst_bin_t total_bins, bst_target_t n_targets, BatchParam const &p,
              bool is_distributed, bool is_col_split, bool is_secure,
              HistMakerTrainParam const *param) {
     ctx_ = ctx;
-    target_builders_.resize(n_targets);
-    CHECK_GE(n_targets, 1);
-    for (auto &v : target_builders_) {
-      v.Reset(ctx, total_bins, p, is_distributed, is_col_split, is_secure, param);
+#if defined(XGBOOST_USE_FEDERATED)
+    if (is_secure && !std::get_if<std::vector<FedHistogramBuilder>>(&target_builders_)) {
+      target_builders_.emplace<std::vector<FedHistogramBuilder>>(n_targets);
     }
+#else
+    CHECK(!is_secure);
+#endif
+
+    std::visit(
+        [&](auto &&target_builders) {
+          target_builders.resize(n_targets);
+          CHECK_GE(n_targets, 1);
+          for (auto &v : target_builders) {
+            v.Reset(ctx, total_bins, p, is_distributed, is_col_split, param);
+          }
+        },
+        this->target_builders_);
   }
 };
 }  // namespace xgboost::tree

--- a/src/tree/updater_gpu_common.cuh
+++ b/src/tree/updater_gpu_common.cuh
@@ -1,18 +1,13 @@
-/*!
- * Copyright 2017-2019 XGBoost contributors
+/**
+ * Copyright 2017-2024, XGBoost contributors
  */
 #pragma once
-#include <thrust/random.h>
-#include <cstdio>
-#include <cub/cub.cuh>
-#include <stdexcept>
-#include <string>
-#include <vector>
-#include "../common/categorical.h"
-#include "../common/device_helpers.cuh"
-#include "../common/random.h"
+#include <limits>   // for numeric_limits
+#include <ostream>  // for ostream
+
 #include "gpu_hist/histogram.cuh"
 #include "param.h"
+#include "xgboost/base.h"
 
 namespace xgboost::tree {
 struct GPUTrainingParam {
@@ -54,8 +49,8 @@ enum DefaultDirection {
 };
 
 struct DeviceSplitCandidate {
-  float loss_chg {-FLT_MAX};
-  DefaultDirection dir {kLeftDir};
+  float loss_chg{-std::numeric_limits<float>::max()};
+  DefaultDirection dir{kLeftDir};
   int findex {-1};
   float fvalue {0};
   // categorical split, either it's the split category for OHE or the threshold for partition-based

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -19,6 +19,7 @@
 #include "../common/cuda_context.cuh"  // CUDAContext
 #include "../common/device_helpers.cuh"
 #include "../common/hist_util.h"
+#include "../common/random.h"  // for ColumnSampler, GlobalRandom
 #include "../common/timer.h"
 #include "../data/ellpack_page.cuh"
 #include "../data/ellpack_page.h"

--- a/tests/cpp/objective/test_objective.cc
+++ b/tests/cpp/objective/test_objective.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2023 by XGBoost contributors
+ * Copyright 2016-2024, XGBoost contributors
  */
 #include <gtest/gtest.h>
 #include <xgboost/context.h>
@@ -99,6 +99,6 @@ TEST_P(TestDefaultObjConfig, Objective) {
 INSTANTIATE_TEST_SUITE_P(Objective, TestDefaultObjConfig,
                          ::testing::ValuesIn(MakeObjNamesForTest()),
                          [](const ::testing::TestParamInfo<TestDefaultObjConfig::ParamType>& info) {
-                           return ObjTestNameGenerator(info);
+                           return ObjTestNameGenerator(info.param);
                          });
 } // namespace xgboost

--- a/tests/cpp/objective_helpers.h
+++ b/tests/cpp/objective_helpers.h
@@ -21,9 +21,7 @@ inline auto MakeObjNamesForTest() {
   return names;
 }
 
-template <typename ParamType>
-inline std::string ObjTestNameGenerator(const ::testing::TestParamInfo<ParamType>& info) {
-  auto name = std::string{info.param};
+inline std::string ObjTestNameGenerator(std::string name) {
   // Name must be a valid c++ symbol
   auto it = std::find(name.cbegin(), name.cend(), ':');
   if (it != name.cend()) {

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -723,7 +723,7 @@ TEST_P(TestColumnSplit, Objective) {
 INSTANTIATE_TEST_SUITE_P(ColumnSplitObjective, TestColumnSplit,
                          ::testing::ValuesIn(MakeObjNamesForTest()),
                          [](const ::testing::TestParamInfo<TestColumnSplit::ParamType>& info) {
-                           return ObjTestNameGenerator(info);
+                           return ObjTestNameGenerator(info.param);
                          });
 
 namespace {

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -411,6 +411,7 @@ TEST(CPUHistogram, Categorical) {
     TestHistogramCategorical(n_categories, true);
   }
 }
+
 namespace {
 void TestHistogramExternalMemory(Context const *ctx, BatchParam batch_param, bool is_approx,
                                  bool force_read_by_column) {

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2023 by Contributors
+ * Copyright 2018-2024, XGBoost Contributors
  */
 #include <gtest/gtest.h>
 #include <xgboost/base.h>                // for bst_node_t, bst_bin_t, Gradient...
@@ -68,8 +68,8 @@ void TestAddHistRows(bool is_distributed) {
 
   HistMakerTrainParam hist_param;
   HistogramBuilder histogram_builder;
-  histogram_builder.Reset(&ctx, gmat.cut.TotalBins(), {kMaxBins, 0.5}, is_distributed,
-                          false, false, &hist_param);
+  histogram_builder.Reset(&ctx, gmat.cut.TotalBins(), {kMaxBins, 0.5}, is_distributed, false,
+                          &hist_param);
   histogram_builder.AddHistRows(&tree, &nodes_to_build, &nodes_to_sub, false);
 
   for (bst_node_t const &nidx : nodes_to_build) {
@@ -102,7 +102,7 @@ void TestSyncHist(bool is_distributed) {
   HistogramBuilder histogram;
   uint32_t total_bins = gmat.cut.Ptrs().back();
   HistMakerTrainParam hist_param;
-  histogram.Reset(&ctx, total_bins, {kMaxBins, 0.5}, is_distributed, false, false, &hist_param);
+  histogram.Reset(&ctx, total_bins, {kMaxBins, 0.5}, is_distributed, false, &hist_param);
 
   common::RowSetCollection row_set_collection;
   {
@@ -222,13 +222,12 @@ TEST(CPUHistogram, SyncHist) {
   TestSyncHist(false);
 }
 
-void TestBuildHistogram(bool is_distributed, bool force_read_by_column, bool is_col_split, bool is_secure) {
-  size_t constexpr kNRows = 8, kNCols = 16;
-  int32_t constexpr kMaxBins = 4;
+void TestBuildHistogram(bool is_distributed, bool force_read_by_column, bool is_col_split) {
+  bst_idx_t constexpr kNRows = 8, kNCols = 16;
+  bst_bin_t constexpr kMaxBins = 4;
   Context ctx;
-  auto p_fmat =
-      RandomDataGenerator(kNRows, kNCols, 0.8).Seed(3).GenerateDMatrix();
-  if (is_col_split && !is_secure) {
+  auto p_fmat = RandomDataGenerator(kNRows, kNCols, 0.8).Seed(3).GenerateDMatrix();
+  if (is_col_split) {
     p_fmat = std::shared_ptr<DMatrix>{
         p_fmat->SliceCol(collective::GetWorldSize(), collective::GetRank())};
   }
@@ -236,7 +235,6 @@ void TestBuildHistogram(bool is_distributed, bool force_read_by_column, bool is_
       *(p_fmat->GetBatches<GHistIndexMatrix>(&ctx, BatchParam{kMaxBins, 0.5}).begin());
   uint32_t total_bins = gmat.cut.Ptrs().back();
 
-  static double constexpr kEps = 1e-6;
   std::vector<GradientPair> gpair = {
       {0.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f}, {0.27f, 0.28f},
       {0.27f, 0.29f}, {0.37f, 0.39f}, {0.47f, 0.49f}, {0.57f, 0.59f}};
@@ -244,7 +242,7 @@ void TestBuildHistogram(bool is_distributed, bool force_read_by_column, bool is_
   bst_node_t nid = 0;
   HistogramBuilder histogram;
   HistMakerTrainParam hist_param;
-  histogram.Reset(&ctx, total_bins, {kMaxBins, 0.5}, is_distributed, is_col_split, is_secure, &hist_param);
+  histogram.Reset(&ctx, total_bins, {kMaxBins, 0.5}, is_distributed, is_col_split, &hist_param);
 
   RegTree tree;
 
@@ -288,42 +286,35 @@ void TestBuildHistogram(bool is_distributed, bool force_read_by_column, bool is_
     GradientPairPrecise sol = histogram_expected[i];
     double grad = sol.GetGrad();
     double hess = sol.GetHess();
-    if (is_distributed && (!is_col_split || (is_secure && is_col_split))) {
+    if (is_distributed && !is_col_split) {
       // the solution also needs to be allreduce
       collective::SafeColl(
           collective::Allreduce(&ctx, linalg::MakeVec(&grad, 1), collective::Op::kSum));
       collective::SafeColl(
           collective::Allreduce(&ctx, linalg::MakeVec(&hess, 1), collective::Op::kSum));
     }
-    ASSERT_NEAR(grad, histogram.Histogram()[nid][i].GetGrad(), kEps);
-    ASSERT_NEAR(hess, histogram.Histogram()[nid][i].GetHess(), kEps);
+    ASSERT_NEAR(grad, histogram.Histogram()[nid][i].GetGrad(), kRtEps);
+    ASSERT_NEAR(hess, histogram.Histogram()[nid][i].GetHess(), kRtEps);
   }
 }
 
 TEST(CPUHistogram, BuildHist) {
-  TestBuildHistogram(true, false, false, false);
-  TestBuildHistogram(false, false, false, false);
-  TestBuildHistogram(true, true, false, false);
-  TestBuildHistogram(false, true, false, false);
+  TestBuildHistogram(true, false, false);
+  TestBuildHistogram(false, false, false);
+  TestBuildHistogram(true, true, false);
+  TestBuildHistogram(false, true, false);
 }
 
 TEST(CPUHistogram, BuildHistDist) {
   auto constexpr kWorkers = 4;
-  collective::TestDistributedGlobal(kWorkers,
-                                    [] { TestBuildHistogram(true, false, false, false); });
-  collective::TestDistributedGlobal(kWorkers, [] { TestBuildHistogram(true, true, false, false); });
+  collective::TestDistributedGlobal(kWorkers, [] { TestBuildHistogram(true, false, false); });
+  collective::TestDistributedGlobal(kWorkers, [] { TestBuildHistogram(true, true, false); });
 }
 
 TEST(CPUHistogram, BuildHistDistColSplit) {
   auto constexpr kWorkers = 4;
-  collective::TestDistributedGlobal(kWorkers, [] { TestBuildHistogram(true, false, true, false); });
-  collective::TestDistributedGlobal(kWorkers, [] { TestBuildHistogram(true, true, true, false); });
-}
-
-TEST(CPUHistogram, BuildHistDistColSplitSecure) {
-  auto constexpr kWorkers = 4;
-  collective::TestDistributedGlobal(kWorkers, [] { TestBuildHistogram(true, true, true, true); });
-  collective::TestDistributedGlobal(kWorkers, [] { TestBuildHistogram(true, false, true, true); });
+  collective::TestDistributedGlobal(kWorkers, [] { TestBuildHistogram(true, false, true); });
+  collective::TestDistributedGlobal(kWorkers, [] { TestBuildHistogram(true, true, true); });
 }
 
 namespace {
@@ -382,7 +373,7 @@ void TestHistogramCategorical(size_t n_categories, bool force_read_by_column) {
   HistogramBuilder cat_hist;
   for (auto const &gidx : cat_m->GetBatches<GHistIndexMatrix>(&ctx, {kBins, 0.5})) {
     auto total_bins = gidx.cut.TotalBins();
-    cat_hist.Reset(&ctx, total_bins, {kBins, 0.5}, false, false, false, &hist_param);
+    cat_hist.Reset(&ctx, total_bins, {kBins, 0.5}, false, false, &hist_param);
     cat_hist.AddHistRows(&tree, &nodes_to_build, &dummy_sub, false);
     cat_hist.BuildHist(0, space, gidx, row_set_collection, nodes_to_build,
                        linalg::MakeTensorView(&ctx, gpair.ConstHostSpan(), gpair.Size()),
@@ -398,7 +389,7 @@ void TestHistogramCategorical(size_t n_categories, bool force_read_by_column) {
   HistogramBuilder onehot_hist;
   for (auto const &gidx : encode_m->GetBatches<GHistIndexMatrix>(&ctx, {kBins, 0.5})) {
     auto total_bins = gidx.cut.TotalBins();
-    onehot_hist.Reset(&ctx, total_bins, {kBins, 0.5}, false, false, false, &hist_param);
+    onehot_hist.Reset(&ctx, total_bins, {kBins, 0.5}, false, false, &hist_param);
     onehot_hist.AddHistRows(&tree, &nodes_to_build, &dummy_sub, false);
     onehot_hist.BuildHist(0, space, gidx, row_set_collection, nodes_to_build,
                           linalg::MakeTensorView(&ctx, gpair.ConstHostSpan(), gpair.Size()),
@@ -464,7 +455,7 @@ void TestHistogramExternalMemory(Context const *ctx, BatchParam batch_param, boo
     }
     ASSERT_EQ(n_samples, m->Info().num_row_);
 
-    multi_build.Reset(ctx, total_bins, batch_param, false, false, false, &hist_param);
+    multi_build.Reset(ctx, total_bins, batch_param, false, false, &hist_param);
     multi_build.AddHistRows(&tree, &nodes, &dummy_sub, false);
     std::size_t page_idx{0};
     for (auto const &page : m->GetBatches<GHistIndexMatrix>(ctx, batch_param)) {
@@ -487,7 +478,7 @@ void TestHistogramExternalMemory(Context const *ctx, BatchParam batch_param, boo
     common::RowSetCollection row_set_collection;
     InitRowPartitionForTest(&row_set_collection, n_samples);
 
-    single_build.Reset(ctx, total_bins, batch_param, false, false, false, &hist_param);
+    single_build.Reset(ctx, total_bins, batch_param, false, false, &hist_param);
     SparsePage concat;
     std::vector<float> hess(m->Info().num_row_, 1.0f);
     for (auto const &page : m->GetBatches<SparsePage>()) {


### PR DESCRIPTION
Rebased version https://github.com/dmlc/xgboost/pull/10410 . After all the extracted PRs, this PR:
- Split up the histogram builder into policies, one for normal build, and another for encrypted build.
- Each policy is responsible for both sample split and column split.
- Federated learning without encryption is handled by the normal build.