### PR TITLE
[fed] Replace secure split with query in coll.

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -39,7 +39,7 @@ enum class DataType : uint8_t {
 
 enum class FeatureType : uint8_t { kNumerical = 0, kCategorical = 1 };
 
-enum class DataSplitMode : int { kRow = 0, kCol = 1, kColSecure = 2 };
+enum class DataSplitMode : int { kRow = 0, kCol = 1 };
 
 /*!
  * \brief Meta information about dataset, always sit in memory.
@@ -174,17 +174,11 @@ class MetaInfo {
    */
   void SynchronizeNumberOfColumns(Context const* ctx);
 
-  /*! \brief Whether the data is split row-wise. */
-  bool IsRowSplit() const {
-    return data_split_mode == DataSplitMode::kRow;
-  }
+  /** @brief Whether the data is split row-wise. */
+  [[nodiscard]] bool IsRowSplit() const { return data_split_mode == DataSplitMode::kRow; }
 
   /** @brief Whether the data is split column-wise. */
-  bool IsColumnSplit() const { return (data_split_mode == DataSplitMode::kCol)
-  || (data_split_mode == DataSplitMode::kColSecure); }
-
-  /** @brief Whether the data is split column-wise with secure computation. */
-  bool IsSecure() const { return data_split_mode == DataSplitMode::kColSecure; }
+  [[nodiscard]] bool IsColumnSplit() const { return !this->IsRowSplit(); }
 
   /** @brief Whether this is a learning to rank data. */
   bool IsRanking() const { return !group_ptr_.empty(); }

--- a/plugin/federated/federated_comm.h
+++ b/plugin/federated/federated_comm.h
@@ -11,12 +11,15 @@
 #include <memory>   // for shared_ptr
 #include <string>   // for string
 
-#include "../../src/collective/comm.h"    // for HostComm
+#include "../../src/collective/comm.h"  // for HostComm
+#include "federated_plugin.h"           // for FederatedPlugin
 #include "xgboost/json.h"
 
 namespace xgboost::collective {
 class FederatedComm : public HostComm {
   std::shared_ptr<federated::Federated::Stub> stub_;
+  // Plugin for encryption
+  std::shared_ptr<FederatedPluginBase> plugin_{nullptr};
 
   void Init(std::string const& host, std::int32_t port, std::int32_t world, std::int32_t rank,
             std::string const& server_cert, std::string const& client_key,
@@ -62,6 +65,7 @@ class FederatedComm : public HostComm {
     return Success();
   }
   [[nodiscard]] bool IsFederated() const override { return true; }
+  [[nodiscard]] bool IsEncrypted() const override { return static_cast<bool>(plugin_); }
   [[nodiscard]] federated::Federated::Stub* Handle() const { return stub_.get(); }
 
   [[nodiscard]] Comm* MakeCUDAVar(Context const* ctx, std::shared_ptr<Coll> pimpl) const override;
@@ -73,5 +77,7 @@ class FederatedComm : public HostComm {
     *out = "rank:" + std::to_string(rank);
     return Success();
   };
+
+  auto EncryptionPlugin() const { return plugin_; }
 };
 }  // namespace xgboost::collective

--- a/src/collective/comm.cu
+++ b/src/collective/comm.cu
@@ -11,7 +11,6 @@
 #include <vector>     // for vector
 
 #include "../common/cuda_context.cuh"    // for CUDAContext
-#include "../common/device_helpers.cuh"  // for DefaultStream
 #include "../common/type.h"              // for EraseType
 #include "comm.cuh"                      // for NCCLComm
 #include "comm.h"                        // for Comm

--- a/src/collective/comm.h
+++ b/src/collective/comm.h
@@ -102,6 +102,7 @@ class Comm : public std::enable_shared_from_this<Comm> {
     return channels_.at(rank);
   }
   [[nodiscard]] virtual bool IsFederated() const = 0;
+  [[nodiscard]] virtual bool IsEncrypted() const { return false; }
   [[nodiscard]] virtual Result LogTracker(std::string msg) const = 0;
 
   [[nodiscard]] virtual Result SignalError(Result const&) { return Success(); }

--- a/src/collective/comm_group.cc
+++ b/src/collective/comm_group.cc
@@ -128,14 +128,18 @@ void Init(Json const& config) { GlobalCommGroupInit(config); }
 
 void Finalize() { GlobalCommGroupFinalize(); }
 
-std::int32_t GetRank() noexcept { return GlobalCommGroup()->Rank(); }
+[[nodiscard]] std::int32_t GetRank() noexcept { return GlobalCommGroup()->Rank(); }
 
-std::int32_t GetWorldSize() noexcept { return GlobalCommGroup()->World(); }
+[[nodiscard]] std::int32_t GetWorldSize() noexcept { return GlobalCommGroup()->World(); }
 
-bool IsDistributed() noexcept { return GlobalCommGroup()->IsDistributed(); }
+[[nodiscard]] bool IsDistributed() noexcept { return GlobalCommGroup()->IsDistributed(); }
 
-[[nodiscard]] bool IsFederated() {
+[[nodiscard]] bool IsFederated() noexcept {
   return GlobalCommGroup()->Ctx(nullptr, DeviceOrd::CPU()).IsFederated();
+}
+
+[[nodiscard]] bool IsEncrypted() noexcept {
+  return IsFederated() && GlobalCommGroup()->Ctx(nullptr, DeviceOrd::CPU()).IsEncrypted();
 }
 
 void Print(std::string const& message) {

--- a/src/collective/comm_group.h
+++ b/src/collective/comm_group.h
@@ -17,7 +17,7 @@ namespace xgboost::collective {
  */
 class CommGroup {
   std::shared_ptr<HostComm> comm_;
-  mutable std::shared_ptr<Comm> gpu_comm_;
+  mutable std::shared_ptr<Comm> gpu_comm_;  // lazy initialization
 
   std::shared_ptr<Coll> backend_;
   mutable std::shared_ptr<Coll> gpu_coll_;  // lazy initialization

--- a/src/collective/communicator-inl.h
+++ b/src/collective/communicator-inl.h
@@ -48,6 +48,11 @@ void Finalize();
 [[nodiscard]] bool IsFederated();
 
 /**
+ * @brief Get if the communicator has an encryption plugin.
+ */
+[[nodiscard]] bool IsEncrypted();
+
+/**
  * @brief Print the message to the communicator.
  *
  * This function can be used to communicate the information of the progress to the user who monitors

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -803,9 +803,7 @@ void MetaInfo::Validate(DeviceOrd device) const {
 void MetaInfo::SetInfoFromCUDA(Context const&, StringView, Json) { common::AssertGPUSupport(); }
 #endif  // !defined(XGBOOST_USE_CUDA)
 
-bool MetaInfo::IsVerticalFederated() const {
-  return collective::IsFederated() && IsColumnSplit();
-}
+bool MetaInfo::IsVerticalFederated() const { return collective::IsFederated() && IsColumnSplit(); }
 
 bool MetaInfo::ShouldHaveLabels() const {
   return !IsVerticalFederated() || collective::GetRank() == 0;

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -291,6 +291,7 @@ class HistEvaluator {
       ibegin = static_cast<bst_bin_t>(cut_ptr[fidx + 1]) - 1;
       iend = static_cast<bst_bin_t>(cut_ptr[fidx]) - 1;
     }
+    bool enc_vertical = is_secure_ && is_col_split_;
 
     for (bst_bin_t i = ibegin; i != iend; i += d_step) {
       // start working
@@ -305,7 +306,7 @@ class HistEvaluator {
           loss_chg =
               static_cast<float>(evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{left_sum},
                                                          GradStats{right_sum}) - parent.root_gain);
-          if (!is_secure_) {
+          if (!enc_vertical) {
             split_pt = cut_val[i];  // not used for partition based
             best.Update(loss_chg, fidx, split_pt, d_step == -1, false, left_sum, right_sum);
           } else {
@@ -318,7 +319,7 @@ class HistEvaluator {
           loss_chg =
               static_cast<float>(evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{right_sum},
                                                          GradStats{left_sum}) - parent.root_gain);
-          if (!is_secure_) {
+          if (!enc_vertical) {
             if (i == imin) {
               split_pt = cut.MinValues()[fidx];
             } else {
@@ -369,9 +370,11 @@ class HistEvaluator {
     // Under secure vertical setting, only the active party is able to evaluate the split
     // based on global histogram. Other parties will receive the final best split information
     // Hence the below computation is not performed by the passive parties
-    if ((!is_secure_) || (collective::GetRank() == 0)) {
+    bool is_passive_party = is_col_split_ && is_secure_ && collective::GetRank() != 0;
+    bool is_active_party = !is_passive_party;
+    if (is_active_party) {
       // Evaluate the splits for each feature
-      common::ParallelFor2d(space, n_threads, [&](size_t nidx_in_set, common::Range1d r) {
+      common::ParallelFor2d(space, n_threads, [&](std::size_t nidx_in_set, common::Range1d r) {
         auto tidx = omp_get_thread_num();
         auto entry = &tloc_candidates[n_threads * nidx_in_set + tidx];
         auto best = &entry->split;
@@ -410,7 +413,7 @@ class HistEvaluator {
         }
       });
 
-      for (unsigned nidx_in_set = 0; nidx_in_set < entries.size(); ++nidx_in_set) {
+      for (std::size_t nidx_in_set = 0; nidx_in_set < entries.size(); ++nidx_in_set) {
         for (auto tidx = 0; tidx < n_threads; ++tidx) {
           entries[nidx_in_set].split.Update(tloc_candidates[n_threads * nidx_in_set + tidx].split);
         }
@@ -513,7 +516,7 @@ class HistEvaluator {
         column_sampler_{std::move(sampler)},
         tree_evaluator_{*param, static_cast<bst_feature_t>(info.num_col_), DeviceOrd::CPU()},
         is_col_split_{info.IsColumnSplit()},
-        is_secure_{info.IsSecure()}{
+        is_secure_{collective::IsEncrypted()} {
     interaction_constraints_.Configure(*param, info.num_col_);
     column_sampler_->Init(ctx, info.num_col_, info.feature_weights.HostVector(),
                           param_->colsample_bynode, param_->colsample_bylevel,
@@ -744,7 +747,7 @@ class HistMultiEvaluator {
         column_sampler_{std::move(sampler)},
         ctx_{ctx},
         is_col_split_{info.IsColumnSplit()},
-        is_secure_{info.IsSecure()} {
+        is_secure_{collective::IsEncrypted()} {
     interaction_constraints_.Configure(*param, info.num_col_);
     column_sampler_->Init(ctx, info.num_col_, info.feature_weights.HostVector(),
                           param_->colsample_bynode, param_->colsample_bylevel,

--- a/src/tree/updater_approx.cc
+++ b/src/tree/updater_approx.cc
@@ -93,7 +93,7 @@ class GlobalApproxBuilder {
 
     histogram_builder_.Reset(ctx_, n_total_bins, p_tree->NumTargets(), BatchSpec(*param_, hess),
                              collective::IsDistributed(), p_fmat->Info().IsColumnSplit(),
-                             p_fmat->Info().IsSecure(), hist_param_);
+                             collective::IsEncrypted(), hist_param_);
     monitor_->Stop(__func__);
   }
 

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -165,7 +165,7 @@ class MultiTargetHistBuilder {
     histogram_builder_ = std::make_unique<MultiHistogramBuilder>();
     histogram_builder_->Reset(ctx_, n_total_bins, n_targets, HistBatch(param_),
                               collective::IsDistributed(), p_fmat->Info().IsColumnSplit(),
-                              p_fmat->Info().IsSecure(), hist_param_);
+                              collective::IsEncrypted(), hist_param_);
 
     evaluator_ = std::make_unique<HistMultiEvaluator>(ctx_, p_fmat->Info(), param_, col_sampler_);
     p_last_tree_ = p_tree;
@@ -355,7 +355,7 @@ class HistUpdater {
                                 fmat->Info().IsColumnSplit());
     }
     histogram_builder_->Reset(ctx_, n_total_bins, 1, HistBatch(param_), collective::IsDistributed(),
-                              fmat->Info().IsColumnSplit(), fmat->Info().IsSecure(), hist_param_);
+                              fmat->Info().IsColumnSplit(), collective::IsEncrypted(), hist_param_);
     evaluator_ = std::make_unique<HistEvaluator>(ctx_, this->param_, fmat->Info(), col_sampler_);
     p_last_tree_ = p_tree;
     monitor_->Stop(__func__);

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -12,6 +12,10 @@
 #include "../../../src/data/adapter.h"
 #include "../../../src/data/simple_dmatrix.h"  // for SimpleDMatrix
 #include "../collective/test_worker.h"         // for TestDistributedGlobal
+
+#if defined(XGBOOST_USE_FEDERATED)
+#include "../plugin/federated/test_worker.h"  // for TestEncryptedGlobal
+#endif  // defined(XGBOOST_USE_FEDERATED)
 #include "xgboost/context.h"
 
 namespace xgboost::common {
@@ -310,6 +314,7 @@ void DoTestColSplitQuantileSecure() {
   Context ctx;
   auto const world = collective::GetWorldSize();
   auto const rank = collective::GetRank();
+  ASSERT_TRUE(collective::IsEncrypted());
   size_t cols = 2;
   size_t rows = 3;
 
@@ -336,7 +341,7 @@ void DoTestColSplitQuantileSecure() {
 
   auto const n_bins = 64;
 
-  m->Info().data_split_mode = DataSplitMode::kColSecure;
+  m->Info().data_split_mode = DataSplitMode::kCol;
   // Generate cuts for distributed environment.
   HistogramCuts distributed_cuts;
   {
@@ -392,7 +397,7 @@ void DoTestColSplitQuantileSecure() {
 template <bool use_column>
 void TestColSplitQuantileSecure() {
   auto constexpr kWorkers = 2;
-  collective::TestFederatedGlobal(kWorkers, [] { DoTestColSplitQuantileSecure<use_column>(); });
+  collective::TestEncryptedGlobal(kWorkers, [&] { DoTestColSplitQuantileSecure<use_column>(); });
 }
 #endif  // defined(XGBOOST_USE_FEDERATED)
 }  // anonymous namespace

--- a/tests/cpp/plugin/federated/test_worker.h
+++ b/tests/cpp/plugin/federated/test_worker.h
@@ -83,4 +83,16 @@ void TestFederatedGlobal(std::int32_t n_workers, WorkerFn&& fn) {
     collective::Finalize();
   });
 }
+
+template <typename WorkerFn>
+void TestEncryptedGlobal(std::int32_t n_workers, WorkerFn&& fn) {
+  TestFederatedImpl(n_workers, [&](std::int32_t port, std::int32_t i) {
+    auto config = FederatedTestConfig(n_workers, port, i);
+    config["federated_plugin"] = Object{};
+    config["federated_plugin"]["name"] = String{"mock"};
+    collective::Init(config);
+    fn();
+    collective::Finalize();
+  });
+}
 }  // namespace xgboost::collective

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -307,7 +307,7 @@ void DoTestEvaluateSplitsSecure(bool force_read_by_column) {
 
   auto dmat = RandomDataGenerator(kRows, kCols, 0).Seed(3).GenerateDMatrix();
   auto m = dmat->SliceCol(world, rank);
-  m->Info().data_split_mode = DataSplitMode::kColSecure;
+  m->Info().data_split_mode = DataSplitMode::kCol;
 
   auto evaluator = HistEvaluator{&ctx, &param, m->Info(), sampler};
   BoundedHistCollection hist;

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -565,7 +565,7 @@ class OverflowTest : public ::testing::TestWithParam<std::tuple<bool, bool>> {
     CHECK_EQ(Xy->Info().IsColumnSplit(), is_col_split);
 
     hist_builder.Reset(&ctx, n_total_bins, tree.NumTargets(), batch, is_distributed,
-                       Xy->Info().IsColumnSplit(), Xy->Info().IsSecure(), &hist_param);
+                       Xy->Info().IsColumnSplit(), collective::IsEncrypted(), &hist_param);
 
     std::vector<CommonRowPartitioner> partitioners;
     partitioners.emplace_back(&ctx, Xy->Info().num_row_, /*base_rowid=*/0,


### PR DESCRIPTION
Extracted from https://github.com/dmlc/xgboost/pull/10534 . This PR removes the secure col split and prefers querying whether a plugin is available.

We will be targeting the feature branch for now. The merge into the master branch will start once the feature branch is complete.