### PR TITLE
[R] Gracefully handle deprecated parameters

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -86,7 +86,7 @@ check.booster.params <- function(params, deprecated_params, ...) {
   if (length(intersect(names(params),
                        names(dot_params))) > 0)
     stop("Same parameters in 'params' and in the call are not allowed. Please check your 'params' list.")
-  dot_params <- within(dot_params, rm(list=deprecated_params))  # Exclude deprecated params
+  dot_params <- within(dot_params, rm(list = deprecated_params))  # Exclude deprecated params
   params <- c(params, dot_params)
 
   # providing a parameter multiple times makes sense only for 'eval_metric'

--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -145,13 +145,13 @@ xgb.cv <- function(params = list(), data, nrounds, nfold,
                    verbose = TRUE, print_every_n = 1L,
                    early_stopping_rounds = NULL, maximize = NULL, callbacks = list(), ...) {
 
-  check.deprecation(...)
+  deprecated_params <- check.deprecation(...)
   stopifnot(inherits(data, "xgb.DMatrix"))
   if (inherits(data, "xgb.DMatrix") && .Call(XGCheckNullPtr_R, data)) {
     stop("'data' is an invalid 'xgb.DMatrix' object. Must be constructed again.")
   }
 
-  params <- check.booster.params(params, ...)
+  params <- check.booster.params(params, deprecated_params, ...)
   # TODO: should we deprecate the redundant 'metrics' parameter?
   for (m in metrics)
     params <- c(params, list("eval_metric" = m))

--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -346,9 +346,9 @@ xgb.train <- function(params = list(), data, nrounds, evals = list(),
                       save_period = NULL, save_name = "xgboost.model",
                       xgb_model = NULL, callbacks = list(), ...) {
 
-  check.deprecation(...)
+  deprecated_params <- check.deprecation(...)
 
-  params <- check.booster.params(params, ...)
+  params <- check.booster.params(params, deprecated_params, ...)
 
   check.custom.obj()
   check.custom.eval()


### PR DESCRIPTION
Reproducer:
```R
require(xgboost)
data(agaricus.train, package='xgboost')
data(agaricus.test, package='xgboost')
train <- agaricus.train
test <- agaricus.test
dtrain <- xgb.DMatrix(data = train$data, label=train$label)
dtest <- xgb.DMatrix(data = test$data, label=test$label)
watchlist <- list(train=dtrain, test=dtest)
bst <- xgb.train(data=dtrain, max_depth=2, eta=1, nthread = 2, nrounds=2,
                 watchlist=watchlist, objective = "binary:logistic")
```

The current `master` version fails with cryptic error
```
Loading required package: xgboost
Error in parse(text = paste(new_par, "<-", pars[[pars_par]])) :
  <text>:1:10: unexpected '<'
1: evals <- <
             ^
Calls: xgb.train -> check.deprecation -> eval -> parse
In addition: Warning message:
In check.deprecation(...) : 'watchlist' is deprecated.
Use 'evals' instead.
See help("Deprecated") and help("xgboost-deprecated").
4: parse(text = paste(new_par, "<-", pars[[pars_par]]))
3: eval(parse(text = paste(new_par, "<-", pars[[pars_par]])), envir = env)
2: check.deprecation(...)
1: xgb.train(data = dtrain, max_depth = 2, eta = 1, nthread = 2,
       nrounds = 2, watchlist = watchlist, objective = "binary:logistic")
```
The error occurs because the use of `eval(parse(...))` does not correctly handle data frame values.
This pull request replaces the expression with `assign(...)`.

Also: Explicitly filter out deprecated parameters from the dot params. In the reproducer script, not filtering out `watchlist` leads to error `Error: No method asJSON S3 class: xgb.DMatrix` because `watchlist` was still part of the `params` list and R tried to serialize the `params` list as JSON.

After the fix, the reproducer script successfully runs, with only a warning:
```
Loading required package: xgboost
[1]     train-logloss:0.233156  test-logloss:0.226460
[2]     train-logloss:0.136542  test-logloss:0.137763
Warning message:
In check.deprecation(...) : 'watchlist' is deprecated.
Use 'evals' instead.
See help("Deprecated") and help("xgboost-deprecated").
```