### PR TITLE
Partial fix for CTK 12.5

### DIFF
--- a/src/tree/updater_gpu_common.cuh
+++ b/src/tree/updater_gpu_common.cuh
@@ -1,18 +1,13 @@
-/*!
- * Copyright 2017-2019 XGBoost contributors
+/**
+ * Copyright 2017-2024, XGBoost contributors
  */
 #pragma once
-#include <thrust/random.h>
-#include <cstdio>
-#include <cub/cub.cuh>
-#include <stdexcept>
-#include <string>
-#include <vector>
-#include "../common/categorical.h"
-#include "../common/device_helpers.cuh"
-#include "../common/random.h"
+#include <limits>   // for numeric_limits
+#include <ostream>  // for ostream
+
 #include "gpu_hist/histogram.cuh"
 #include "param.h"
+#include "xgboost/base.h"
 
 namespace xgboost::tree {
 struct GPUTrainingParam {
@@ -54,8 +49,8 @@ enum DefaultDirection {
 };
 
 struct DeviceSplitCandidate {
-  float loss_chg {-FLT_MAX};
-  DefaultDirection dir {kLeftDir};
+  float loss_chg{-std::numeric_limits<float>::max()};
+  DefaultDirection dir{kLeftDir};
   int findex {-1};
   float fvalue {0};
   // categorical split, either it's the split category for OHE or the threshold for partition-based

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -19,6 +19,7 @@
 #include "../common/cuda_context.cuh"  // CUDAContext
 #include "../common/device_helpers.cuh"
 #include "../common/hist_util.h"
+#include "../common/random.h"  // for ColumnSampler, GlobalRandom
 #include "../common/timer.h"
 #include "../data/ellpack_page.cuh"
 #include "../data/ellpack_page.h"


### PR DESCRIPTION
This PR fixes the following error:
```
/home/nvidia/jiamingy/xgboost_dev/xgboost/src/tree/gpu_hist/../updater_gpu_common.cuh(57): error: identifier "FLT_MAX" is undefined
    float loss_chg {-FLT_MAX};
                     ^

1 error detected in the compilation of "/home/nvidia/jiamingy/xgboost_dev/xgboost/src/tree/updater_gpu_hist.cu".
```

We still need the latest CCCL due to https://github.com/dmlc/xgboost/issues/10555 .