### PR TITLE
[EM] Prevent init with CUDA malloc resource.

### DIFF
--- a/src/common/cuda_rt_utils.h
+++ b/src/common/cuda_rt_utils.h
@@ -3,6 +3,11 @@
  */
 #pragma once
 #include <cstdint>  // for int32_t
+
+#if defined(XGBOOST_USE_NVTX)
+#include <nvtx3/nvtx3.hpp>
+#endif  // defined(XGBOOST_USE_NVTX)
+
 namespace xgboost::common {
 std::int32_t AllVisibleGPUs();
 
@@ -18,4 +23,36 @@ bool SupportsAts();
 void CheckComputeCapability();
 
 void SetDevice(std::int32_t device);
+
+struct NvtxDomain {
+  static constexpr char const *name{"libxgboost"};  // NOLINT
+};
+
+#if defined(XGBOOST_USE_NVTX)
+using ScopedRange = ::nvtx3::scoped_range_in<NvtxDomain>;
+using NvtxEventAttr = ::nvtx3::event_attributes;
+using NvtxRgb = nvtx3::rgb;
+#else
+class ScopedRange {
+ public:
+  template <typename... Args>
+  explicit ScopedRange(Args &&...) {}
+};
+class NvtxEventAttr {
+ public:
+  template <typename... Args>
+  explicit NvtxEventAttr(Args &&...) {}
+};
+class NvtxRgb {
+ public:
+  template <typename... Args>
+  explicit NvtxRgb(Args &&...) {}
+};
+#endif  // defined(XGBOOST_USE_NVTX)
 }  // namespace xgboost::common
+
+#if defined(XGBOOST_USE_NVTX)
+#define xgboost_NVTX_FN_RANGE() NVTX3_FUNC_RANGE_IN(::xgboost::common::NvtxDomain)
+#else
+#define xgboost_FUNC_RANGE()
+#endif  // defined(XGBOOST_USE_NVTX)

--- a/src/common/cuda_rt_utils.h
+++ b/src/common/cuda_rt_utils.h
@@ -54,5 +54,5 @@ class NvtxRgb {
 #if defined(XGBOOST_USE_NVTX)
 #define xgboost_NVTX_FN_RANGE() NVTX3_FUNC_RANGE_IN(::xgboost::common::NvtxDomain)
 #else
-#define xgboost_FUNC_RANGE()
+#define xgboost_NVTX_FN_RANGE()
 #endif  // defined(XGBOOST_USE_NVTX)

--- a/src/common/cuda_rt_utils.h
+++ b/src/common/cuda_rt_utils.h
@@ -29,14 +29,14 @@ struct NvtxDomain {
 };
 
 #if defined(XGBOOST_USE_NVTX)
-using ScopedRange = ::nvtx3::scoped_range_in<NvtxDomain>;
+using NvtxScopedRange = ::nvtx3::scoped_range_in<NvtxDomain>;
 using NvtxEventAttr = ::nvtx3::event_attributes;
-using NvtxRgb = nvtx3::rgb;
+using NvtxRgb = ::nvtx3::rgb;
 #else
-class ScopedRange {
+class NvtxScopedRange {
  public:
   template <typename... Args>
-  explicit ScopedRange(Args &&...) {}
+  explicit NvtxScopedRange(Args &&...) {}
 };
 class NvtxEventAttr {
  public:

--- a/src/common/ref_resource_view.cuh
+++ b/src/common/ref_resource_view.cuh
@@ -17,9 +17,16 @@ namespace xgboost::common {
  */
 template <typename T>
 [[nodiscard]] RefResourceView<T> MakeFixedVecWithCudaMalloc(Context const* ctx,
-                                                            std::size_t n_elements, T const& init) {
+                                                            std::size_t n_elements) {
   auto resource = std::make_shared<common::CudaMallocResource>(n_elements * sizeof(T));
   auto ref = RefResourceView{resource->DataAs<T>(), n_elements, resource};
+  return ref;
+}
+
+template <typename T>
+[[nodiscard]] RefResourceView<T> MakeFixedVecWithCudaMalloc(Context const* ctx,
+                                                            std::size_t n_elements, T const& init) {
+  auto ref = MakeFixedVecWithCudaMalloc<T>(ctx, n_elements);
   thrust::fill_n(ctx->CUDACtx()->CTP(), ref.data(), ref.size(), init);
   return ref;
 }

--- a/src/common/ref_resource_view.cuh
+++ b/src/common/ref_resource_view.cuh
@@ -16,7 +16,7 @@ namespace xgboost::common {
  * @brief Make a fixed size `RefResourceView` with cudaMalloc resource.
  */
 template <typename T>
-[[nodiscard]] RefResourceView<T> MakeFixedVecWithCudaMalloc(Context const* ctx,
+[[nodiscard]] RefResourceView<T> MakeFixedVecWithCudaMalloc(Context const*,
                                                             std::size_t n_elements) {
   auto resource = std::make_shared<common::CudaMallocResource>(n_elements * sizeof(T));
   auto ref = RefResourceView{resource->DataAs<T>(), n_elements, resource};

--- a/src/common/resource.cuh
+++ b/src/common/resource.cuh
@@ -26,9 +26,7 @@ class CudaMallocResource : public ResourceHandler {
 
   void* Data() override { return storage_.data(); }
   [[nodiscard]] std::size_t Size() const override { return storage_.size(); }
-  void Resize(std::size_t n_bytes, std::byte init = std::byte{0}) {
-    this->storage_.resize(n_bytes, init);
-  }
+  void Resize(std::size_t n_bytes) { this->storage_.resize(n_bytes); }
 };
 
 class CudaMmapResource : public ResourceHandler {

--- a/src/common/resource.cuh
+++ b/src/common/resource.cuh
@@ -24,7 +24,7 @@ class CudaMallocResource : public ResourceHandler {
   }
   ~CudaMallocResource() noexcept(true) override { this->Clear(); }
 
-  void* Data() override { return storage_.data(); }
+  [[nodiscard]] void* Data() override { return storage_.data(); }
   [[nodiscard]] std::size_t Size() const override { return storage_.size(); }
   void Resize(std::size_t n_bytes) { this->storage_.resize(n_bytes); }
 };

--- a/src/common/timer.cc
+++ b/src/common/timer.cc
@@ -6,9 +6,10 @@
 #include <utility>
 
 #include "../collective/communicator-inl.h"
+#include "cuda_rt_utils.h"
 
 #if defined(XGBOOST_USE_NVTX)
-#include <nvtx3/nvToolsExt.h>
+#include <nvtx3/nvtx3.hpp>
 #endif  // defined(XGBOOST_USE_NVTX)
 
 namespace xgboost::common {
@@ -16,10 +17,9 @@ void Monitor::Start(std::string const &name) {
   if (ConsoleLogger::ShouldLog(ConsoleLogger::LV::kDebug)) {
     auto &stats = statistics_map_[name];
     stats.timer.Start();
-#if defined(XGBOOST_USE_NVTX)
-    std::string nvtx_name = "xgboost::" + label_ + "::" + name;
-    stats.nvtx_id = nvtxRangeStartA(nvtx_name.c_str());
-#endif  // defined(XGBOOST_USE_NVTX)
+
+    auto range_handle = nvtx3::start_range_in<common::NvtxDomain>(name);
+    stats.nvtx_id = range_handle.get_value();
   }
 }
 
@@ -28,35 +28,32 @@ void Monitor::Stop(const std::string &name) {
     auto &stats = statistics_map_[name];
     stats.timer.Stop();
     stats.count++;
-#if defined(XGBOOST_USE_NVTX)
-    nvtxRangeEnd(stats.nvtx_id);
-#endif  // defined(XGBOOST_USE_NVTX)
+
+    nvtx3::end_range_in<common::NvtxDomain>(nvtx3::range_handle{stats.nvtx_id});
   }
 }
 
-void Monitor::PrintStatistics(StatMap const& statistics) const {
+void Monitor::PrintStatistics(StatMap const &statistics) const {
   for (auto &kv : statistics) {
     if (kv.second.first == 0) {
-      LOG(WARNING) <<
-          "Timer for " << kv.first << " did not get stopped properly.";
+      LOG(WARNING) << "Timer for " << kv.first << " did not get stopped properly.";
       continue;
     }
-    LOG(CONSOLE) << kv.first << ": " << static_cast<double>(kv.second.second) / 1e+6
-                 << "s, " << kv.second.first << " calls @ "
-                 << kv.second.second
-                 << "us" << std::endl;
+    LOG(CONSOLE) << kv.first << ": " << static_cast<double>(kv.second.second) / 1e+6 << "s, "
+                 << kv.second.first << " calls @ " << kv.second.second << "us" << std::endl;
   }
 }
 
 void Monitor::Print() const {
-  if (!ConsoleLogger::ShouldLog(ConsoleLogger::LV::kDebug)) { return; }
+  if (!ConsoleLogger::ShouldLog(ConsoleLogger::LV::kDebug)) {
+    return;
+  }
   auto rank = collective::GetRank();
   StatMap stat_map;
   for (auto const &kv : statistics_map_) {
     stat_map[kv.first] = std::make_pair(
-        kv.second.count, std::chrono::duration_cast<std::chrono::microseconds>(
-                             kv.second.timer.elapsed)
-                             .count());
+        kv.second.count,
+        std::chrono::duration_cast<std::chrono::microseconds>(kv.second.timer.elapsed).count());
   }
   if (stat_map.empty()) {
     return;

--- a/src/common/timer.cc
+++ b/src/common/timer.cc
@@ -17,9 +17,10 @@ void Monitor::Start(std::string const &name) {
   if (ConsoleLogger::ShouldLog(ConsoleLogger::LV::kDebug)) {
     auto &stats = statistics_map_[name];
     stats.timer.Start();
-
+#if defined(XGBOOST_USE_NVTX)
     auto range_handle = nvtx3::start_range_in<common::NvtxDomain>(name);
     stats.nvtx_id = range_handle.get_value();
+#endif  // defined(XGBOOST_USE_NVTX)
   }
 }
 
@@ -28,8 +29,9 @@ void Monitor::Stop(const std::string &name) {
     auto &stats = statistics_map_[name];
     stats.timer.Stop();
     stats.count++;
-
+#if defined(XGBOOST_USE_NVTX)
     nvtx3::end_range_in<common::NvtxDomain>(nvtx3::range_handle{stats.nvtx_id});
+#endif  // defined(XGBOOST_USE_NVTX)
   }
 }
 

--- a/src/common/timer.cc
+++ b/src/common/timer.cc
@@ -18,7 +18,7 @@ void Monitor::Start(std::string const &name) {
     auto &stats = statistics_map_[name];
     stats.timer.Start();
 #if defined(XGBOOST_USE_NVTX)
-    auto range_handle = nvtx3::start_range_in<common::NvtxDomain>(name);
+    auto range_handle = nvtx3::start_range_in<common::NvtxDomain>(label_ + "::" + name);
     stats.nvtx_id = range_handle.get_value();
 #endif  // defined(XGBOOST_USE_NVTX)
   }

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -404,7 +404,7 @@ size_t EllpackPageImpl::Copy(Context const* ctx, EllpackPageImpl const* page, bs
     LOG(FATAL) << "Concatenating the same Ellpack.";
     return this->n_rows * this->row_stride;
   }
-  dh::LaunchN(num_elements, CopyPage{this, page, offset});
+  dh::LaunchN(num_elements, ctx->CUDACtx()->Stream(), CopyPage{this, page, offset});
   monitor_.Stop(__func__);
   return num_elements;
 }

--- a/src/data/ellpack_page_raw_format.cu
+++ b/src/data/ellpack_page_raw_format.cu
@@ -113,20 +113,17 @@ template <typename T>
 
 [[nodiscard]] std::size_t EllpackPageRawFormat::Write(const EllpackPage& page,
                                                       EllpackHostCacheStream* fo) const {
-  auto nvtxid = nvtxRangeStartA(__func__);
   bst_idx_t bytes{0};
   auto* impl = page.Impl();
 
   // Write vector
   auto write_vec = [&] {
-    auto wv_nvtx = nvtxRangeStartA("write_vec");
     bst_idx_t n = impl->gidx_buffer.size();
     bytes += fo->Write(n);
 
     if (!impl->gidx_buffer.empty()) {
       bytes += fo->Write(impl->gidx_buffer.data(), impl->gidx_buffer.size_bytes());
     }
-    nvtxRangeEnd(wv_nvtx);
   };
 
   write_vec();

--- a/src/data/ellpack_page_raw_format.cu
+++ b/src/data/ellpack_page_raw_format.cu
@@ -99,7 +99,7 @@ template <typename T>
   // Read vector
   Context ctx = Context{}.MakeCUDA(common::CurrentDevice());
   auto read_vec = [&] {
-    common::ScopedRange range{common::NvtxEventAttr{"read-vec", common::NvtxRgb{127, 255, 0}}};
+    common::NvtxScopedRange range{common::NvtxEventAttr{"read-vec", common::NvtxRgb{127, 255, 0}}};
     bst_idx_t n{0};
     RET_IF_NOT(fi->Read(&n));
     if (n == 0) {
@@ -129,7 +129,7 @@ template <typename T>
 
   // Write vector
   auto write_vec = [&] {
-    common::ScopedRange range{common::NvtxEventAttr{"write-vec", common::NvtxRgb{127, 255, 0}}};
+    common::NvtxScopedRange range{common::NvtxEventAttr{"write-vec", common::NvtxRgb{127, 255, 0}}};
     bst_idx_t n = impl->gidx_buffer.size();
     bytes += fo->Write(n);
 

--- a/tests/ci_build/conda_env/macos_cpu_test.yml
+++ b/tests/ci_build/conda_env/macos_cpu_test.yml
@@ -37,4 +37,5 @@ dependencies:
 - pyspark>=3.4.0
 - cloudpickle
 - pip:
+  - setuptools
   - sphinx_rtd_theme


### PR DESCRIPTION
- Make `thrust::fill_n` optional.
- Add NVTX utilities for improved profiling.