### PR TITLE
Fix integer overflow.

### DIFF
--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -24,7 +24,7 @@ struct EllpackDeviceAccessor {
   /*! \brief Whether or not if the matrix is dense. */
   bool is_dense;
   /*! \brief Row length for ELLPACK, equal to number of features. */
-  size_t row_stride;
+  bst_idx_t row_stride;
   bst_idx_t base_rowid{0};
   bst_idx_t n_rows{0};
   common::CompressedIterator<std::uint32_t> gidx_iter;
@@ -118,7 +118,7 @@ struct EllpackDeviceAccessor {
    * not found). */
   [[nodiscard]] XGBOOST_DEVICE size_t NumSymbols() const { return gidx_fvalue_map.size() + 1; }
 
-  [[nodiscard]] XGBOOST_DEVICE size_t NullValue() const { return gidx_fvalue_map.size(); }
+  [[nodiscard]] XGBOOST_DEVICE size_t NullValue() const { return this->NumBins(); }
 
   [[nodiscard]] XGBOOST_DEVICE size_t NumBins() const { return gidx_fvalue_map.size(); }
 

--- a/src/tree/gpu_hist/feature_groups.cu
+++ b/src/tree/gpu_hist/feature_groups.cu
@@ -31,11 +31,12 @@ FeatureGroups::FeatureGroups(const common::HistogramCuts& cuts, bool is_dense,
 
   for (size_t i = 2; i < cut_ptrs.size(); ++i) {
     int last_start = bin_segments_h.back();
+    // Push a new group whenever the size of required bin storage is greater than the
+    // shared memory size.
     if (cut_ptrs[i] - last_start > max_shmem_bins) {
       feature_segments_h.push_back(i - 1);
       bin_segments_h.push_back(cut_ptrs[i - 1]);
-      max_group_bins = std::max(max_group_bins,
-                                bin_segments_h.back() - last_start);
+      max_group_bins = std::max(max_group_bins, bin_segments_h.back() - last_start);
     }
   }
   feature_segments_h.push_back(cut_ptrs.size() - 1);


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/10613 .

This was introduced by #10549 by accident. Before that PR, the index was directly passed into the iterator, which accepts a `size_t` as the indexing argument.  #10549 created an intermediate variable, which has the same type as the row index (std::uint32_t), resulting in a smaller type.

The PR also does some small cleanups.