### PR TITLE
Only passing federated-plugin parameter to plugins

### DIFF
--- a/plugin/federated/federated_plugin.cc
+++ b/plugin/federated/federated_plugin.cc
@@ -125,7 +125,7 @@ FederatedPlugin::FederatedPlugin(StringView path, Json config)
   plugin_handle_ = decltype(plugin_handle_)(
       [&] {
         // Initialize the parameters
-        auto const& obj = get<Object>(config);
+        auto const& obj = OptionalArg<Object>(config, "federated_plugin", Object::Map{});
         std::vector<std::string> kwargs;
         for (auto const& kv : obj) {
           std::string value;


### PR DESCRIPTION
Only passing 'federated-plugin' parameter to encryption plugin so it doesn't have to handle nested maps.