### PR TITLE
Allow building with CCCL that's newer than CTK

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -104,7 +104,9 @@ function(xgboost_set_cuda_flags target)
     target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_NVTX=1)
   endif()
 
-  target_link_libraries(${target} PRIVATE CCCL::CCCL)
+  target_link_libraries(${target}
+    INTERFACE CCCL::CCCL
+    PUBLIC CUDA::cudart_static)
   target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_CUDA=1)
   target_include_directories(
     ${target} PRIVATE
@@ -235,7 +237,6 @@ macro(xgboost_target_link_libraries target)
 
   if(USE_CUDA)
     xgboost_set_cuda_flags(${target})
-    target_link_libraries(${target} PUBLIC CUDA::cudart_static)
   endif()
 
   if(PLUGIN_RMM)

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -104,6 +104,8 @@ function(xgboost_set_cuda_flags target)
     target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_NVTX=1)
   endif()
 
+  # Use CCCL we find before CUDA Toolkit to make sure we get newer headers as intended
+  # The CUDA Toolkit includes its own copy of CCCL that often lags the latest releases (and would be picked up otherwise)
   target_link_libraries(${target}
     PRIVATE CCCL::CCCL CUDA::cudart_static)
   target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_CUDA=1)

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -105,8 +105,7 @@ function(xgboost_set_cuda_flags target)
   endif()
 
   target_link_libraries(${target}
-    INTERFACE CCCL::CCCL
-    PUBLIC CUDA::cudart_static)
+    PRIVATE CCCL::CCCL CUDA::cudart_static)
   target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_CUDA=1)
   target_include_directories(
     ${target} PRIVATE

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -105,9 +105,19 @@ function(xgboost_set_cuda_flags target)
   endif()
 
   # Use CCCL we find before CUDA Toolkit to make sure we get newer headers as intended
-  # The CUDA Toolkit includes its own copy of CCCL that often lags the latest releases (and would be picked up otherwise)
-  target_link_libraries(${target}
-    PRIVATE CCCL::CCCL CUDA::cudart_static)
+  # The CUDA Toolkit includes its own copy of CCCL that often lags the latest releases
+  # (and would be picked up otherwise)
+  if(BUILD_STATIC_LIB)
+    # If the downstream user is statically linking with libxgboost, it needs to
+    # explicitly link with CCCL and CUDA runtime.
+    target_link_libraries(${target}
+      PUBLIC CCCL::CCCL CUDA::cudart_static)
+  else()
+    # If the downstream user is dynamically linking with libxgboost, it does not
+    # need to link with CCCL and CUDA runtime.
+    target_link_libraries(${target}
+      PRIVATE CCCL::CCCL CUDA::cudart_static)
+  endif()
   target_compile_definitions(${target} PRIVATE -DXGBOOST_USE_CUDA=1)
   target_include_directories(
     ${target} PRIVATE

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -71,14 +71,6 @@ struct WQSummary {
          << "value: " << e.value;
       return os;
     }
-
-    XGBOOST_DEVICE inline bool operator==(Entry const& rhs) const {
-      return (rmin == rhs.rmin) && (rmax == rhs.rmax)
-             && (wmin == rhs.wmin) && (value == rhs.value);
-    }
-    XGBOOST_DEVICE inline bool operator!=(Entry const& rhs) const {
-      return !operator==(rhs);
-    }
   };
   /*! \brief input data queue before entering the summary */
   struct Queue {

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -71,6 +71,14 @@ struct WQSummary {
          << "value: " << e.value;
       return os;
     }
+
+    XGBOOST_DEVICE inline bool operator==(Entry const& rhs) const {
+      return (rmin == rhs.rmin) && (rmax == rhs.rmax)
+             && (wmin == rhs.wmin) && (value == rhs.value);
+    }
+    XGBOOST_DEVICE inline bool operator!=(Entry const& rhs) const {
+      return !operator==(rhs);
+    }
   };
   /*! \brief input data queue before entering the summary */
   struct Queue {


### PR DESCRIPTION
Follow-up to #10624

* When using an external CCCL (e.g. Conda), ensure that the Thrust/CUB headers from the external CCCL are chosen instead of the ones from the CTK. This way, we can build XGBoost with CCCL that's newer than the CTK.
  - The include paths need to be correctly ordered.
     (Bad) `-I/usr/local/cuda/targets/x86_64-linux/include -I$CONDA_PREFIX/include`
     (Good) `-I$CONDA_PREFIX/include -I/usr/local/cuda/targets/x86_64-linux/include`

With this PR, we can build XGBoost with CCCL 2.5.0 + CTK 11.8.