### PR TITLE
SYCL. Add splits application

### DIFF
--- a/plugin/sycl/tree/hist_updater.h
+++ b/plugin/sycl/tree/hist_updater.h
@@ -101,6 +101,12 @@ class HistUpdater {
       typename TreeEvaluator<GradientSumT>::SplitEvaluator const &evaluator,
       float min_child_weight);
 
+  void ApplySplit(std::vector<ExpandEntry> nodes,
+                      const common::GHistIndexMatrix& gmat,
+                      RegTree* p_tree);
+
+  void AddSplitsToRowSet(const std::vector<ExpandEntry>& nodes, RegTree* p_tree);
+
   void InitData(const common::GHistIndexMatrix& gmat,
                 const USMVector<GradientPair, MemoryType::on_device> &gpair,
                 const DMatrix& fmat,
@@ -178,6 +184,8 @@ class HistUpdater {
   uint32_t fid_least_bins_;
 
   uint64_t seed_ = 0;
+
+  common::PartitionBuilder partition_builder_;
 
   // key is the node id which should be calculated by Subtraction Trick, value is the node which
   // provides the evidence for substracts

--- a/src/tree/common_row_partitioner.h
+++ b/src/tree/common_row_partitioner.h
@@ -144,9 +144,10 @@ class CommonRowPartitioner {
     }
   }
 
-  template <typename ExpandEntry>
-  void FindSplitConditions(const std::vector<ExpandEntry>& nodes, const RegTree& tree,
-                           const GHistIndexMatrix& gmat, std::vector<bst_bin_t>* split_conditions) {
+  /* Making GHistIndexMatrix_t a templete parameter allows reuse this function for sycl-plugin */
+  template <typename ExpandEntry, typename GHistIndexMatrix_t>
+  static void FindSplitConditions(const std::vector<ExpandEntry>& nodes, const RegTree& tree,
+                        const GHistIndexMatrix_t& gmat, std::vector<int32_t>* split_conditions) {
     auto const& ptrs = gmat.cut.Ptrs();
     auto const& vals = gmat.cut.Values();
 


### PR DESCRIPTION
Hi,
I continue adding of sycl support (https://github.com/dmlc/xgboost/pull/10605, https://github.com/dmlc/xgboost/pull/10269, etc).
By this PR I add the next part of the training-related code for the sycl devices. Here I add functional for application of splits and the related tests.
This PR itself doesn't add any new functional, but I plan to combine all related parts one by one to a launchable sycl-training.