### PR TITLE
Quick fix for clang-tidy error.

### DIFF
--- a/src/tree/common_row_partitioner.h
+++ b/src/tree/common_row_partitioner.h
@@ -145,9 +145,10 @@ class CommonRowPartitioner {
   }
 
   /* Making GHistIndexMatrix_t a templete parameter allows reuse this function for sycl-plugin */
-  template <typename ExpandEntry, typename GHistIndexMatrix_t>
+  template <typename ExpandEntry, typename GHistIndexMatrixT>
   static void FindSplitConditions(const std::vector<ExpandEntry>& nodes, const RegTree& tree,
-                        const GHistIndexMatrix_t& gmat, std::vector<int32_t>* split_conditions) {
+                                  GHistIndexMatrixT const& gmat,
+                                  std::vector<int32_t>* split_conditions) {
     auto const& ptrs = gmat.cut.Ptrs();
     auto const& vals = gmat.cut.Values();
 


### PR DESCRIPTION
https://buildkite.com/xgboost/xgboost-ci/builds/6230#0190edee-a00d-4bbf-a891-639a084353dc