### PR TITLE
Add `Library\mingw-w64` to Windows search path

### DIFF
--- a/python-package/packager/nativelib.py
+++ b/python-package/packager/nativelib.py
@@ -138,6 +138,9 @@ def locate_or_build_libxgboost(
             sys_prefix / "Library",
             sys_prefix / "Library" / "bin",
             sys_prefix / "Library" / "lib",
+            sys_prefix / "Library" / "mingw-w64",
+            sys_prefix / "Library" / "mingw-w64" / "bin",
+            sys_prefix / "Library" / "mingw-w64" / "lib",
         ]
         sys_prefix_candidates = [
             p.expanduser().resolve() for p in sys_prefix_candidates

--- a/python-package/xgboost/libpath.py
+++ b/python-package/xgboost/libpath.py
@@ -38,6 +38,9 @@ def find_lib_path() -> List[str]:
                 os.path.join(sys.base_prefix, "Library"),
                 os.path.join(sys.base_prefix, "Library", "bin"),
                 os.path.join(sys.base_prefix, "Library", "lib"),
+                os.path.join(sys.base_prefix, "Library", "mingw-w64"),
+                os.path.join(sys.base_prefix, "Library", "mingw-w64", "bin"),
+                os.path.join(sys.base_prefix, "Library", "mingw-w64", "lib"),
             ]
         )
         dll_path = [os.path.join(p, "xgboost.dll") for p in dll_path]


### PR DESCRIPTION
Fixes https://github.com/dmlc/xgboost/issues/5386
Fixes https://github.com/conda-forge/xgboost-feedstock/issues/51

When searching for `libxgboost` on Windows, this adds `Library\mingw-w64` to the search path after other paths

This currently is done as [a patch in conda-forge]( https://github.com/conda-forge/xgboost-feedstock/blob/44f54392837b13980c3a0d68d7b03c78b041b3c6/recipe/patches/0003-Use-mingw-w64-path.patch#L11-L35 ). Given this is just checking one more location (and after checking the usual ones), though it made sense to go ahead and upstream this one