### PR TITLE
Tweak R-package endian message for clarity

### DIFF
--- a/R-package/configure
+++ b/R-package/configure
@@ -3127,12 +3127,12 @@ fi
 printf "%s\n" "$ac_cv_c_bigendian" >&6; }
  case $ac_cv_c_bigendian in #(
    yes)
-     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: big endian" >&5
-printf "%s\n" "big endian" >&6; }
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: using big endian" >&5
+printf "%s\n" "using big endian" >&6; }
      ENDIAN_FLAG="-DDMLC_CMAKE_LITTLE_ENDIAN=0";; #(
    no)
-     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: little endian" >&5
-printf "%s\n" "little endian" >&6; }
+     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: using little endian" >&5
+printf "%s\n" "using little endian" >&6; }
      ENDIAN_FLAG="-DDMLC_CMAKE_LITTLE_ENDIAN=1" ;; #(
    universal)
 

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -33,9 +33,9 @@ AS_IF([test -z "${USE_LITTLE_ENDIAN+x}"], [
   AC_MSG_NOTICE([Checking system endianness as USE_LITTLE_ENDIAN is unset])
   AC_MSG_CHECKING([system endianness])
   AC_C_BIGENDIAN(
-    [AC_MSG_RESULT([big endian])
+    [AC_MSG_RESULT([using big endian])
      ENDIAN_FLAG="-DDMLC_CMAKE_LITTLE_ENDIAN=0"],
-    [AC_MSG_RESULT([little endian])
+    [AC_MSG_RESULT([using little endian])
      ENDIAN_FLAG="-DDMLC_CMAKE_LITTLE_ENDIAN=1"],
     [AC_MSG_RESULT([unknown])
      AC_MSG_ERROR([Could not determine endianness. Please set USE_LITTLE_ENDIAN])]


### PR DESCRIPTION
Add `using` before the endian type selected by `autoconf` to make it clearer what the endian selection means