### PR TITLE
Fix warnings in tests.

### DIFF
--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -37,6 +37,7 @@ from scipy import sparse
 import xgboost as xgb
 from xgboost import RabitTracker
 from xgboost.core import ArrayLike
+from xgboost.data import is_pd_cat_dtype
 from xgboost.sklearn import SklObjective
 from xgboost.testing.data import (
     get_california_housing,
@@ -403,7 +404,6 @@ def make_categorical(
     X, y
     """
     import pandas as pd
-    from pandas.api.types import is_categorical_dtype
 
     rng = np.random.RandomState(1994)
 
@@ -431,8 +431,8 @@ def make_categorical(
                 low=0, high=n_samples - 1, size=int(n_samples * sparsity)
             )
             df.iloc[index, i] = np.nan
-            if is_categorical_dtype(df.dtypes[i]):
-                assert n_categories == np.unique(df.dtypes[i].categories).size
+            if is_pd_cat_dtype(df.dtypes.iloc[i]):
+                assert n_categories == np.unique(df.dtypes.iloc[i].categories).size
 
     if onehot:
         df = pd.get_dummies(df)

--- a/python-package/xgboost/testing/updater.py
+++ b/python-package/xgboost/testing/updater.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import xgboost as xgb
 import xgboost.testing as tm
+from xgboost.data import is_pd_cat_dtype
 
 
 def get_basescore(model: xgb.XGBModel) -> float:
@@ -166,8 +167,6 @@ def check_cut(
     n_entries: int, indptr: np.ndarray, data: np.ndarray, dtypes: Any
 ) -> None:
     """Check the cut values."""
-    from pandas.api.types import is_categorical_dtype
-
     assert data.shape[0] == indptr[-1]
     assert data.shape[0] == n_entries
 
@@ -177,14 +176,12 @@ def check_cut(
         end = int(indptr[i])
         for j in range(beg + 1, end):
             assert data[j] > data[j - 1]
-            if is_categorical_dtype(dtypes[i - 1]):
+            if is_pd_cat_dtype(dtypes.iloc[i - 1]):
                 assert data[j] == data[j - 1] + 1
 
 
 def check_get_quantile_cut_device(tree_method: str, use_cupy: bool) -> None:
     """Check with optional cupy."""
-    from pandas.api.types import is_categorical_dtype
-
     n_samples = 1024
     n_features = 14
     max_bin = 16
@@ -237,7 +234,7 @@ def check_get_quantile_cut_device(tree_method: str, use_cupy: bool) -> None:
     X, y = tm.make_categorical(
         n_samples, n_features, n_categories, False, sparsity=0.8, cat_ratio=0.5
     )
-    n_cat_features = len([0 for dtype in X.dtypes if is_categorical_dtype(dtype)])
+    n_cat_features = len([0 for dtype in X.dtypes if is_pd_cat_dtype(dtype)])
     n_num_features = n_features - n_cat_features
     n_entries = n_categories * n_cat_features + (max_bin + 1) * n_num_features
     # - qdm

--- a/python-package/xgboost/testing/updater.py
+++ b/python-package/xgboost/testing/updater.py
@@ -182,10 +182,12 @@ def check_cut(
 
 def check_get_quantile_cut_device(tree_method: str, use_cupy: bool) -> None:
     """Check with optional cupy."""
+    import pandas as pd
+
     n_samples = 1024
     n_features = 14
     max_bin = 16
-    dtypes = [np.float32] * n_features
+    dtypes = pd.Series([np.float32] * n_features)
 
     # numerical
     X, y, w = tm.make_regression(n_samples, n_features, use_cupy=use_cupy)

--- a/tests/test_distributed/test_with_dask/test_external_memory.py
+++ b/tests/test_distributed/test_with_dask/test_external_memory.py
@@ -54,7 +54,7 @@ def run_external_memory(worker_id: int, n_workers: int, comm_args: dict) -> None
     X = concat(lx)
     yconcat = concat(ly)
     wconcat = concat(lw)
-    Xy = xgb.DMatrix(X, yconcat, wconcat, nthread=n_threads)
+    Xy = xgb.DMatrix(X, yconcat, weight=wconcat, nthread=n_threads)
 
     results_local: xgb.callback.TrainingCallback.EvalsLog = {}
     booster = xgb.train(

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -434,7 +434,7 @@ def run_boost_from_prediction_multi_class(
         device=device,
     )
     X, y, _ = deterministic_repartition(client, X, y, None, divisions)
-    model_0.fit(X=X, y=y)
+    model_0.fit(X=X, y=y, eval_set=[(X, y)])
     margin = xgb.dask.inplace_predict(
         client, model_0.get_booster(), X, predict_type="margin"
     )
@@ -448,7 +448,7 @@ def run_boost_from_prediction_multi_class(
         device=device,
     )
     X, y, margin = deterministic_repartition(client, X, y, margin, divisions)
-    model_1.fit(X=X, y=y, base_margin=margin)
+    model_1.fit(X=X, y=y, base_margin=margin, eval_set=[(X, y)], base_margin_eval_set=[margin])
     predictions_1 = xgb.dask.predict(
         client,
         model_1.get_booster(),
@@ -464,7 +464,7 @@ def run_boost_from_prediction_multi_class(
         device=device,
     )
     X, y, _ = deterministic_repartition(client, X, y, None, divisions)
-    model_2.fit(X=X, y=y)
+    model_2.fit(X=X, y=y, eval_set=[(X, y)])
     predictions_2 = xgb.dask.inplace_predict(
         client, model_2.get_booster(), X, predict_type="margin"
     )
@@ -498,7 +498,7 @@ def run_boost_from_prediction(
         device=device,
     )
     X, y, _ = deterministic_repartition(client, X, y, None, divisions)
-    model_0.fit(X=X, y=y)
+    model_0.fit(X=X, y=y, eval_set=[(X, y)])
     margin: dd.Series = model_0.predict(X, output_margin=True)
 
     model_1 = xgb.dask.DaskXGBClassifier(
@@ -509,7 +509,7 @@ def run_boost_from_prediction(
         device=device,
     )
     X, y, margin = deterministic_repartition(client, X, y, margin, divisions)
-    model_1.fit(X=X, y=y, base_margin=margin)
+    model_1.fit(X=X, y=y, base_margin=margin, eval_set=[(X, y)], base_margin_eval_set=[margin])
     X, y, margin = deterministic_repartition(client, X, y, margin, divisions)
     predictions_1: dd.Series = model_1.predict(X, base_margin=margin)
 
@@ -521,7 +521,7 @@ def run_boost_from_prediction(
         device=device,
     )
     X, y, _ = deterministic_repartition(client, X, y, None, divisions)
-    model_2.fit(X=X, y=y)
+    model_2.fit(X=X, y=y, eval_set=[(X, y)])
     predictions_2: dd.Series = model_2.predict(X)
 
     predt_1 = predictions_1.compute()

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -155,6 +155,10 @@ def deterministic_repartition(
     m: Margin,
     divisions,
 ) -> Tuple[dd.DataFrame, dd.Series, Margin]:
+    """Try to partition the dataframes according to divisions, this doesn't guarantee
+    the reproducibiliy.
+
+    """
     X, y, margin = (
         dd.repartition(X, divisions=divisions, force=True),
         dd.repartition(y, divisions=divisions, force=True),
@@ -494,7 +498,7 @@ def run_boost_from_prediction(
 
     model_0 = xgb.dask.DaskXGBClassifier(
         learning_rate=0.3,
-        n_estimators=4,
+        n_estimators=3,
         tree_method=tree_method,
         max_bin=512,
         device=device,
@@ -505,7 +509,7 @@ def run_boost_from_prediction(
 
     model_1 = xgb.dask.DaskXGBClassifier(
         learning_rate=0.3,
-        n_estimators=4,
+        n_estimators=3,
         tree_method=tree_method,
         max_bin=512,
         device=device,
@@ -519,7 +523,7 @@ def run_boost_from_prediction(
 
     model_2 = xgb.dask.DaskXGBClassifier(
         learning_rate=0.3,
-        n_estimators=8,
+        n_estimators=6,
         tree_method=tree_method,
         max_bin=512,
         device=device,


### PR DESCRIPTION
- Fix warnings.
```
FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
```
```
FutureWarning: Pass `weight` as keyword args.
```
```
DeprecationWarning: is_categorical_dtype is deprecated and will be removed in a future version. Use isinstance(dtype, pd.CategoricalDtype) instead
```
- Try to reduce the flakiness of the dask test.