### PR TITLE
Update release script for the JVM packages

### DIFF
--- a/dev/prepare_jvm_release.py
+++ b/dev/prepare_jvm_release.py
@@ -55,11 +55,6 @@ def run(command, **kwargs):
     subprocess.check_call(command, shell=True, **kwargs)
 
 
-def get_current_git_tag():
-    out = subprocess.check_output(["git", "tag", "--points-at", "HEAD"])
-    return out.decode().split("\n")[0]
-
-
 def get_current_commit_hash():
     out = subprocess.check_output(["git", "rev-parse", "HEAD"])
     return out.decode().split("\n")[0]
@@ -88,23 +83,11 @@ def main():
     )
     args = parser.parse_args()
     version = args.release_version
-    expected_git_tag = "v" + version
-    current_git_tag = get_current_git_tag()
-    if current_git_tag != expected_git_tag:
-        if not current_git_tag:
-            raise ValueError(
-                f"Expected git tag {expected_git_tag} but current HEAD has no tag. "
-                f"Run: git checkout {expected_git_tag}"
-            )
-        raise ValueError(
-            f"Expected git tag {expected_git_tag} but current HEAD is at tag "
-            f"{current_git_tag}. Run: git checkout {expected_git_tag}"
-        )
 
     commit_hash = get_current_commit_hash()
     git_branch = get_current_git_branch()
     print(
-        f"Using commit {commit_hash} of branch {git_branch}, git tag {current_git_tag}"
+        f"Using commit {commit_hash} of branch {git_branch}"
     )
 
     with cd("jvm-packages/"):


### PR DESCRIPTION
* Don't require the existence of a git tag