### PR TITLE
Cleanup GPU Hist tests.

### DIFF
--- a/include/xgboost/task.h
+++ b/include/xgboost/task.h
@@ -1,12 +1,12 @@
-/*!
- * Copyright 2021-2022 by XGBoost Contributors
+/**
+ * Copyright 2021-2024, XGBoost Contributors
  */
 #ifndef XGBOOST_TASK_H_
 #define XGBOOST_TASK_H_
 
 #include <xgboost/base.h>
 
-#include <cinttypes>
+#include <cstdint>  // for uint8_t
 
 namespace xgboost {
 /*!
@@ -23,7 +23,7 @@ namespace xgboost {
  */
 struct ObjInfo {
   // What kind of problem are we trying to solve
-  enum Task : uint8_t {
+  enum Task : std::uint8_t {
     kRegression = 0,
     kBinary = 1,
     kClassification = 2,

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -45,9 +45,7 @@
 #include "xgboost/tree_model.h"
 
 namespace xgboost::tree {
-#if !defined(GTEST_TEST)
 DMLC_REGISTRY_FILE_TAG(updater_gpu_hist);
-#endif  // !defined(GTEST_TEST)
 
 // Manage memory for a single GPU
 struct GPUHistMakerDevice {
@@ -831,13 +829,11 @@ class GPUHistMaker : public TreeUpdater {
   std::shared_ptr<common::ColumnSampler> column_sampler_;
 };
 
-#if !defined(GTEST_TEST)
 XGBOOST_REGISTER_TREE_UPDATER(GPUHistMaker, "grow_gpu_hist")
     .describe("Grow tree with GPU.")
     .set_body([](Context const* ctx, ObjInfo const* task) {
       return new GPUHistMaker(ctx, task);
     });
-#endif  // !defined(GTEST_TEST)
 
 class GPUGlobalApproxMaker : public TreeUpdater {
  public:
@@ -960,11 +956,9 @@ class GPUGlobalApproxMaker : public TreeUpdater {
   common::Monitor monitor_;
 };
 
-#if !defined(GTEST_TEST)
 XGBOOST_REGISTER_TREE_UPDATER(GPUApproxMaker, "grow_gpu_approx")
     .describe("Grow tree with GPU.")
     .set_body([](Context const* ctx, ObjInfo const* task) {
       return new GPUGlobalApproxMaker(ctx, task);
     });
-#endif  // !defined(GTEST_TEST)
 }  // namespace xgboost::tree

--- a/tests/cpp/tree/gpu_hist/test_gradient_based_sampler.cu
+++ b/tests/cpp/tree/gpu_hist/test_gradient_based_sampler.cu
@@ -10,9 +10,7 @@
 #include "../../filesystem.h"            // dmlc::TemporaryDirectory
 #include "../../helpers.h"
 
-namespace xgboost {
-namespace tree {
-
+namespace xgboost::tree {
 void VerifySampling(size_t page_size,
                     float subsample,
                     int sampling_method,
@@ -151,6 +149,4 @@ TEST(GradientBasedSampler, GradientBasedSamplingExternalMemory) {
   constexpr bool kFixedSizeSampling = false;
   VerifySampling(kPageSize, kSubsample, kSamplingMethod, kFixedSizeSampling);
 }
-
-};  // namespace tree
-};  // namespace xgboost
+};  // namespace xgboost::tree

--- a/tests/cpp/tree/gpu_hist/test_histogram.cu
+++ b/tests/cpp/tree/gpu_hist/test_histogram.cu
@@ -70,7 +70,6 @@ std::vector<GradientPairPrecise> GetHostHistGpair() {
   return hist_gpair;
 }
 
-template <typename GradientSumT>
 void TestBuildHist(bool use_shared_memory_histograms) {
   int const kNRows = 16, kNCols = 8;
   Context ctx{MakeCUDACtx(0)};
@@ -126,11 +125,11 @@ void TestBuildHist(bool use_shared_memory_histograms) {
 }
 
 TEST(Histogram, BuildHistGlobalMem) {
-  TestBuildHist<GradientPairPrecise>(false);
+  TestBuildHist(false);
 }
 
 TEST(Histogram, BuildHistSharedMem) {
-  TestBuildHist<GradientPairPrecise>(true);
+  TestBuildHist(true);
 }
 
 void TestDeterministicHistogram(bool is_dense, int shm_size, bool force_global) {

--- a/tests/cpp/tree/gpu_hist/test_histogram.cu
+++ b/tests/cpp/tree/gpu_hist/test_histogram.cu
@@ -12,6 +12,7 @@
 #include "../../../../src/tree/param.h"                       // for TrainParam
 #include "../../categorical_helpers.h"                        // for OneHotEncodeFeature
 #include "../../helpers.h"
+#include "../../histogram_helpers.h"  // for BuildEllpackPage
 
 namespace xgboost::tree {
 TEST(Histogram, DeviceHistogramStorage) {
@@ -52,6 +53,84 @@ TEST(Histogram, DeviceHistogramStorage) {
 
   // Add same node again - should fail
   EXPECT_ANY_THROW(histogram.AllocateHistograms(&ctx, {kNNodes + 1}););
+}
+
+std::vector<GradientPairPrecise> GetHostHistGpair() {
+  // 24 bins, 3 bins for each feature (column).
+  std::vector<GradientPairPrecise> hist_gpair = {
+    {0.8314f, 0.7147f}, {1.7989f, 3.7312f}, {3.3846f, 3.4598f},
+    {2.9277f, 3.5886f}, {1.8429f, 2.4152f}, {1.2443f, 1.9019f},
+    {1.6380f, 2.9174f}, {1.5657f, 2.5107f}, {2.8111f, 2.4776f},
+    {2.1322f, 3.0651f}, {3.2927f, 3.8540f}, {0.5899f, 0.9866f},
+    {1.5185f, 1.6263f}, {2.0686f, 3.1844f}, {2.4278f, 3.0950f},
+    {1.5105f, 2.1403f}, {2.6922f, 4.2217f}, {1.8122f, 1.5437f},
+    {0.0000f, 0.0000f}, {4.3245f, 5.7955f}, {1.6903f, 2.1103f},
+    {2.4012f, 4.4754f}, {3.6136f, 3.4303f}, {0.0000f, 0.0000f}
+  };
+  return hist_gpair;
+}
+
+template <typename GradientSumT>
+void TestBuildHist(bool use_shared_memory_histograms) {
+  int const kNRows = 16, kNCols = 8;
+  Context ctx{MakeCUDACtx(0)};
+
+  TrainParam param;
+  Args args{
+      {"max_depth", "6"},
+      {"max_leaves", "0"},
+  };
+  param.Init(args);
+
+  auto page = BuildEllpackPage(&ctx, kNRows, kNCols);
+  BatchParam batch_param{};
+
+  xgboost::SimpleLCG gen;
+  xgboost::SimpleRealUniformDistribution<bst_float> dist(0.0f, 1.0f);
+  HostDeviceVector<GradientPair> gpair(kNRows);
+  for (auto& gp : gpair.HostVector()) {
+    float grad = dist(&gen);
+    float hess = dist(&gen);
+    gp = GradientPair{grad, hess};
+  }
+  gpair.SetDevice(ctx.Device());
+
+  auto row_partitioner = std::make_unique<RowPartitioner>();
+  row_partitioner->Reset(&ctx, kNRows, 0);
+
+  auto quantiser = std::make_unique<GradientQuantiser>(&ctx, gpair.ConstDeviceSpan(), MetaInfo());
+  auto shm_size = use_shared_memory_histograms ? dh::MaxSharedMemoryOptin(ctx.Ordinal()) : 0;
+  FeatureGroups feature_groups(page->Cuts(), page->is_dense, shm_size, sizeof(GradientPairInt64));
+
+  DeviceHistogramStorage hist;
+  hist.Init(ctx.Device(), page->Cuts().TotalBins());
+  hist.AllocateHistograms(&ctx, {0});
+
+  DeviceHistogramBuilder builder;
+  builder.Reset(&ctx, feature_groups.DeviceAccessor(ctx.Device()), !use_shared_memory_histograms);
+  builder.BuildHistogram(ctx.CUDACtx(), page->GetDeviceAccessor(ctx.Device()),
+                         feature_groups.DeviceAccessor(ctx.Device()), gpair.DeviceSpan(),
+                         row_partitioner->GetRows(0), hist.GetNodeHistogram(0), *quantiser);
+
+  auto node_histogram = hist.GetNodeHistogram(0);
+
+  std::vector<GradientPairInt64> h_result(node_histogram.size());
+  dh::CopyDeviceSpanToVector(&h_result, node_histogram);
+
+  std::vector<GradientPairPrecise> solution = GetHostHistGpair();
+  for (size_t i = 0; i < h_result.size(); ++i) {
+    auto result = quantiser->ToFloatingPoint(h_result[i]);
+    ASSERT_NEAR(result.GetGrad(), solution[i].GetGrad(), 0.01f);
+    ASSERT_NEAR(result.GetHess(), solution[i].GetHess(), 0.01f);
+  }
+}
+
+TEST(Histogram, BuildHistGlobalMem) {
+  TestBuildHist<GradientPairPrecise>(false);
+}
+
+TEST(Histogram, BuildHistSharedMem) {
+  TestBuildHist<GradientPairPrecise>(true);
 }
 
 void TestDeterministicHistogram(bool is_dense, int shm_size, bool force_global) {


### PR DESCRIPTION
- Remove GPU Hist gradient sampling test. The same properties are tested in the gradient sampler test suite.
- Move basic histogram tests into the histogram test suite.
- Remove the header inclusion of the `updater_gpu_hist.cu` in tests.

Follow up of #10608