### PR TITLE
[dask] Reduce the flakiness of tests.

### DIFF
--- a/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
+++ b/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
@@ -221,16 +221,12 @@ class TestDistributedGPU:
         X_, y_ = load_breast_cancer(return_X_y=True)
         X = dd.from_array(X_, chunksize=100).to_backend("cudf")
         y = dd.from_array(y_, chunksize=100).to_backend("cudf")
-        divisions = copy(X.divisions)
-        run_boost_from_prediction(X, y, "hist", "cuda", local_cuda_client, divisions)
+        run_boost_from_prediction(X, y, "hist", "cuda", local_cuda_client)
 
         X_, y_ = load_iris(return_X_y=True)
         X = dd.from_array(X_, chunksize=50).to_backend("cudf")
         y = dd.from_array(y_, chunksize=50).to_backend("cudf")
-        divisions = copy(X.divisions)
-        run_boost_from_prediction_multi_class(
-            X, y, "hist", "cuda", local_cuda_client, divisions
-        )
+        run_boost_from_prediction_multi_class(X, y, "hist", "cuda", local_cuda_client)
 
     def test_init_estimation(self, local_cuda_client: Client) -> None:
         check_init_estimation("hist", "cuda", local_cuda_client)

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -160,9 +160,9 @@ def deterministic_repartition(
 
     """
     X, y, margin = (
-        dd.repartition(X, divisions=divisions, force=True),
-        dd.repartition(y, divisions=divisions, force=True),
-        dd.repartition(m, divisions=divisions, force=True) if m is not None else None,
+        dd.repartition(X, divisions=divisions),
+        dd.repartition(y, divisions=divisions),
+        dd.repartition(m, divisions=divisions) if m is not None else None,
     )
     if margin is not None:
         X, y, margin = client.persist([X, y, margin])

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -49,7 +49,7 @@ pytestmark = [tm.timeout(60), pytest.mark.skipif(**tm.no_dask())]
 import dask
 import dask.array as da
 import dask.dataframe as dd
-from distributed import Client, LocalCluster, Nanny, Worker
+from distributed import Client, LocalCluster, Nanny, Worker, wait
 from distributed.utils_test import async_poll_for, gen_cluster
 from toolz import sliding_window  # dependency of dask
 
@@ -164,6 +164,12 @@ def deterministic_repartition(
         dd.repartition(y, divisions=divisions, force=True),
         dd.repartition(m, divisions=divisions, force=True) if m is not None else None,
     )
+    if margin is not None:
+        X, y, margin = client.persist([X, y, margin])
+        wait([X, y, m])
+    else:
+        X, y = client.persist([X, y])
+        wait([X, y])
     return X, y, margin
 
 

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -533,10 +533,10 @@ def test_boost_from_prediction(tree_method: str) -> None:
 
     n_threads = os.cpu_count()
     assert n_threads is not None
-    # Test test has strict requirements on reproducibiliy but Dask can move partitions
-    # between workers and change partition sizes during the test. There's no good way to
-    # control the partitioning logic. As a result, only a single worker is used for this
-    # test.
+    # This test has strict requirements on reproducibiliy. However, Dask is freed to
+    # move partitions between workers and change partition sizes during the
+    # test. There's no good way to control the partitioning logic. As a result, only a
+    # single worker is used.
     n_workers = 1
 
     with LocalCluster(

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -533,10 +533,10 @@ def test_boost_from_prediction(tree_method: str) -> None:
 
     n_threads = os.cpu_count()
     assert n_threads is not None
-    # This test has strict requirements on reproducibiliy. However, Dask is freed to
-    # move partitions between workers and change partition sizes during the
-    # test. There's no good way to control the partitioning logic. As a result, only a
-    # single worker is used.
+    # This test has strict reproducibility requirements. However, Dask is freed to move
+    # partitions between workers and modify the partitions' size during the test. Given
+    # the lack of control over the partitioning logic, here we use a single worker as a
+    # workaround.
     n_workers = 1
 
     with LocalCluster(

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -406,7 +406,6 @@ def run_boost_from_prediction_multi_class(
     tree_method: str,
     device: str,
     client: "Client",
-    divisions: List[int],
 ) -> None:
     model_0 = xgb.dask.DaskXGBClassifier(
         learning_rate=0.3,
@@ -467,7 +466,6 @@ def run_boost_from_prediction(
     tree_method: str,
     device: str,
     client: "Client",
-    divisions: List[int],
 ) -> None:
     X, y = client.persist([X, y])
 
@@ -545,15 +543,11 @@ def test_boost_from_prediction(tree_method: str) -> None:
         with Client(cluster) as client:
             X_, y_ = load_breast_cancer(return_X_y=True)
             X, y = dd.from_array(X_, chunksize=200), dd.from_array(y_, chunksize=200)
-            divisions = copy(X.divisions)
-            run_boost_from_prediction(X, y, tree_method, "cpu", client, divisions)
+            run_boost_from_prediction(X, y, tree_method, "cpu", client)
 
             X_, y_ = load_digits(return_X_y=True)
             X, y = dd.from_array(X_, chunksize=100), dd.from_array(y_, chunksize=100)
-            divisions = copy(X.divisions)
-            run_boost_from_prediction_multi_class(
-                X, y, tree_method, "cpu", client, divisions
-            )
+            run_boost_from_prediction_multi_class(X, y, tree_method, "cpu", client)
 
 
 def test_inplace_predict(client: "Client") -> None:
@@ -1556,7 +1550,6 @@ class TestWithDask:
     def test_empty_quantile_dmatrix(self, client: Client) -> None:
         X, y = make_categorical(client, 2, 30, 13)
         X_valid, y_valid = make_categorical(client, 10000, 30, 13)
-        divisions = copy(X_valid.divisions)
 
         Xy = xgb.dask.DaskQuantileDMatrix(client, X, y, enable_categorical=True)
         Xy_valid = xgb.dask.DaskQuantileDMatrix(


### PR DESCRIPTION
- Use a dedicated cluster with a single worker.