### PR TITLE
[CI] use key=value form for Dockerfile ENV statements

### DIFF
--- a/tests/ci_build/Dockerfile.aarch64
+++ b/tests/ci_build/Dockerfile.aarch64
@@ -16,7 +16,7 @@ ENV PATH=/opt/miniforge/bin:$PATH
 ENV CC=/opt/rh/gcc-toolset-10/root/usr/bin/gcc
 ENV CXX=/opt/rh/gcc-toolset-10/root/usr/bin/c++
 ENV CPP=/opt/rh/gcc-toolset-10/root/usr/bin/cpp
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 
 # Create new Conda environment
 COPY conda_env/aarch64_test.yml /scripts/

--- a/tests/ci_build/Dockerfile.clang_tidy
+++ b/tests/ci_build/Dockerfile.clang_tidy
@@ -3,7 +3,7 @@ FROM nvidia/cuda:$CUDA_VERSION_ARG-devel-ubuntu22.04
 ARG CUDA_VERSION_ARG
 
 # Environment
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install all basic requirements
 RUN \
@@ -26,7 +26,7 @@ RUN \
 RUN \
     pip3 install pyyaml
 
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.cpu
+++ b/tests/ci_build/Dockerfile.cpu
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # Environment
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-c"]   # Use Bash as shell
 
 # Install all basic requirements
@@ -20,8 +20,8 @@ ENV CC=gcc-10
 ENV CXX=g++-10
 ENV CPP=cpp-10
 
-ENV GOSU_VERSION 1.10
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+ENV GOSU_VERSION=1.10
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 # Install gRPC
 RUN git clone -b v1.49.1 https://github.com/grpc/grpc.git \

--- a/tests/ci_build/Dockerfile.gpu
+++ b/tests/ci_build/Dockerfile.gpu
@@ -5,7 +5,7 @@ ARG RAPIDS_VERSION_ARG
 ARG NCCL_VERSION_ARG
 
 # Environment
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-c"]   # Use Bash as shell
 
 # Install all basic requirements
@@ -33,8 +33,8 @@ RUN \
     mamba clean --all --yes && \
     conda run --no-capture-output -n gpu_test pip install buildkite-test-collector
 
-ENV GOSU_VERSION 1.10
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+ENV GOSU_VERSION=1.10
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.gpu_build_r_rockylinux8
+++ b/tests/ci_build/Dockerfile.gpu_build_r_rockylinux8
@@ -42,7 +42,7 @@ run \
     wget -nv -nc https://cmake.org/files/v3.29/cmake-3.29.5-linux-x86_64.sh --no-check-certificate && \
     bash cmake-3.29.5-linux-x86_64.sh --skip-license --prefix=/usr
 
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.gpu_build_rockylinux8
+++ b/tests/ci_build/Dockerfile.gpu_build_rockylinux8
@@ -34,7 +34,7 @@ ENV CXX=/opt/rh/gcc-toolset-10/root/usr/bin/c++
 ENV CPP=/opt/rh/gcc-toolset-10/root/usr/bin/cpp
 ENV CUDAHOSTCXX=/opt/rh/gcc-toolset-10/root/usr/bin/c++
 
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 
 # Install RMM (Patch out -Werror)
 RUN git clone -b v${RAPIDS_VERSION_ARG}.00 https://github.com/rapidsai/rmm.git --recurse-submodules --depth 1 && \

--- a/tests/ci_build/Dockerfile.gpu_dev_ver
+++ b/tests/ci_build/Dockerfile.gpu_dev_ver
@@ -8,7 +8,7 @@ ARG RAPIDS_VERSION_ARG
 ARG NCCL_VERSION_ARG
 
 # Environment
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-c"]   # Use Bash as shell
 
 # Install all basic requirements
@@ -36,8 +36,8 @@ RUN \
     mamba clean --all --yes && \
     conda run --no-capture-output -n gpu_test pip install buildkite-test-collector
 
-ENV GOSU_VERSION 1.10
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+ENV GOSU_VERSION=1.10
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.i386
+++ b/tests/ci_build/Dockerfile.i386
@@ -1,6 +1,6 @@
 FROM i386/debian:sid
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-c"]
 
 RUN \

--- a/tests/ci_build/Dockerfile.jvm
+++ b/tests/ci_build/Dockerfile.jvm
@@ -27,7 +27,7 @@ ENV CPP=/opt/rh/gcc-toolset-10/root/usr/bin/cpp
 # Install Python packages
 RUN pip install numpy pytest scipy scikit-learn wheel kubernetes awscli
 
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.jvm_cross
+++ b/tests/ci_build/Dockerfile.jvm_cross
@@ -3,7 +3,7 @@ ARG JDK_VERSION=8
 ARG SPARK_VERSION=3.5.1
 
 # Environment
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install all basic requirements
 RUN \
@@ -34,7 +34,7 @@ ENV PATH=/opt/miniforge/bin:/opt/spark/bin:/opt/maven/bin:$PATH
 # Install Python packages
 RUN pip install numpy scipy pandas scikit-learn
 
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.jvm_gpu_build
+++ b/tests/ci_build/Dockerfile.jvm_gpu_build
@@ -38,7 +38,7 @@ ENV CPP=/opt/rh/gcc-toolset-10/root/usr/bin/cpp
 # Install Python packages
 RUN pip install numpy pytest scipy scikit-learn wheel kubernetes awscli
 
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \

--- a/tests/ci_build/Dockerfile.jvm_manylinux2014_aarch64
+++ b/tests/ci_build/Dockerfile.jvm_manylinux2014_aarch64
@@ -3,7 +3,7 @@ FROM quay.io/pypa/manylinux2014_aarch64
 RUN yum update -y && yum install -y java-1.8.0-openjdk-devel
 
 # Install lightweight sudo (not bound to TTY)
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 RUN set -ex; \
     curl -o /usr/local/bin/gosu -L "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-arm64" && \
     chmod +x /usr/local/bin/gosu && \

--- a/tests/ci_build/Dockerfile.jvm_manylinux2014_x86_64
+++ b/tests/ci_build/Dockerfile.jvm_manylinux2014_x86_64
@@ -3,7 +3,7 @@ FROM quay.io/pypa/manylinux2014_x86_64
 RUN yum update -y && yum install -y java-1.8.0-openjdk-devel ninja-build
 
 # Install lightweight sudo (not bound to TTY)
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 RUN set -ex; \
     curl -o /usr/local/bin/gosu -L "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" && \
     chmod +x /usr/local/bin/gosu && \

--- a/tests/ci_build/Dockerfile.manylinux2014_aarch64
+++ b/tests/ci_build/Dockerfile.manylinux2014_aarch64
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_aarch64
 
 # Install lightweight sudo (not bound to TTY)
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 RUN set -ex; \
     curl -o /usr/local/bin/gosu -L "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-arm64" && \
     chmod +x /usr/local/bin/gosu && \

--- a/tests/ci_build/Dockerfile.manylinux2014_x86_64
+++ b/tests/ci_build/Dockerfile.manylinux2014_x86_64
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux2014_x86_64
 
 # Install lightweight sudo (not bound to TTY)
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 RUN set -ex; \
     curl -o /usr/local/bin/gosu -L "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" && \
     chmod +x /usr/local/bin/gosu && \

--- a/tests/ci_build/Dockerfile.manylinux_2_28_x86_64
+++ b/tests/ci_build/Dockerfile.manylinux_2_28_x86_64
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
 # Install lightweight sudo (not bound to TTY)
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION=1.10
 RUN set -ex; \
     curl -o /usr/local/bin/gosu -L "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" && \
     chmod +x /usr/local/bin/gosu && \


### PR DESCRIPTION
Was looking at recent PRs, and noticed a warning in #10654.

> Legacy key/value format with whitespace separator should not be used
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/

Per those Docker docs, it seems that syntax found in some of this project's Dockerfiles is considered deprecated and may be removed in a future Docker release.

```dockerfile
# deprecated
ENV VER 10

# preferred syntax
ENV VER=10
```

This proposes fixing those here. I found them like this:

```shell
git grep 'ARG .* .*'
git grep 'ENV .* .*'
```