### PR TITLE
[R] prefer startsWith() to substr() or regular expressions

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -104,7 +104,7 @@ check.booster.params <- function(params, ...) {
 
   # for multiclass, expect num_class to be set
   if (typeof(params[['objective']]) == "character" &&
-      substr(NVL(params[['objective']], 'x'), 1, 6) == 'multi:' &&
+      startsWith(NVL(params[['objective']], 'x'), 'multi:') &&
       as.numeric(NVL(params[['num_class']], 0)) < 2) {
         stop("'num_class' > 1 parameter must be set for multiclass classification")
   }

--- a/R-package/R/xgb.model.dt.tree.R
+++ b/R-package/R/xgb.model.dt.tree.R
@@ -109,7 +109,7 @@ xgb.model.dt.tree <- function(model = NULL, text = NULL,
   } else {
     trees <- trees[trees >= 0 & trees <= max(td$Tree)]
   }
-  td <- td[Tree %in% trees & !grepl('^booster', t)]
+  td <- td[Tree %in% trees & !is.na(t) & !startsWith(t, 'booster')]
 
   td[, Node := as.integer(sub("^([0-9]+):.*", "\\1", t))]
   if (!use_int_id) td[, ID := add.tree.id(Node, Tree)]

--- a/tests/ci_build/lint_r.R
+++ b/tests/ci_build/lint_r.R
@@ -43,6 +43,7 @@ my_linters <- list(
   spaces_inside_linter = lintr::spaces_inside_linter(),
   spaces_left_parentheses_linter = lintr::spaces_left_parentheses_linter(),
   sprintf = lintr::sprintf_linter(),
+  string_boundary = lintr::string_boundary_linter(),
   trailing_blank_lines_linter = lintr::trailing_blank_lines_linter(),
   trailing_whitespace_linter = lintr::trailing_whitespace_linter(),
   true_false = lintr::T_and_F_symbol_linter(),


### PR DESCRIPTION
Base R has a function `startsWith()`, which behaves similarly to the Python string method `.startswith()` (but vectorized 😁).

This can be faster than other methods for checking the start of a string, like using `substr(x) == "pattern"` or `grep()` or `grepl()`. For what it's worth, I also think it's a little easier to read.

This proposes adding a `{lintr}` linter that suggests doing that, and fixing two such cases in `{xgboost}`. Specifically these:

```text
xgboost/R-package/R/utils.R:107:7: warning: [string_boundary] Use startsWith() to detect an initial substring. Doing so is more readable and more efficient.
      substr(NVL(params[['objective']], 'x'), 1, 6) == 'multi:' &&
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[[2]]
xgboost/R-package/R/xgb.model.dt.tree.R:112:37: warning: [string_boundary] Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring, or, if missingness is not a concern, just startsWith. Doing so is more readable and more efficient.
  td <- td[Tree %in% trees & !grepl('^booster', t)]
                                    ^~~~~~~~~~
```

Thanks for your time and consideration.