### PR TITLE
[R] ignore auto-generated config.h, ensure tests run without 'vcd'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ metastore_db
 
 # files from R-package source install
 **/config.status
+R-package/config.h
 R-package/src/Makevars
 *.lib
 

--- a/R-package/tests/testthat/test_helpers.R
+++ b/R-package/tests/testthat/test_helpers.R
@@ -36,6 +36,10 @@ if (isTRUE(VCD_AVAILABLE)) {
                          base_score = 0.5)
 
     feature.names <- colnames(sparse_matrix)
+
+    # without feature names
+    bst.Tree.unnamed <- xgb.copy.Booster(bst.Tree)
+    setinfo(bst.Tree.unnamed, "feature_name", NULL)
 }
 
 # multiclass
@@ -48,10 +52,6 @@ mbst.Tree <- xgb.train(data = xgb.DMatrix(as.matrix(iris[, -5]), label = mlabel)
 mbst.GLM <- xgb.train(data = xgb.DMatrix(as.matrix(iris[, -5]), label = mlabel), verbose = 0,
                       booster = "gblinear", eta = 0.1, nthread = 1, nrounds = nrounds,
                       objective = "multi:softprob", num_class = nclass, base_score = 0)
-
-# without feature names
-bst.Tree.unnamed <- xgb.copy.Booster(bst.Tree)
-setinfo(bst.Tree.unnamed, "feature_name", NULL)
 
 test_that("xgb.dump works", {
   .skip_if_vcd_not_available()


### PR DESCRIPTION
I've been working on the R package today, and was doing this locally:

```shell
# install
cd R-package/
R CMD INSTALL .

# test
cd tests
Rscript testthat.R
```

This proposes 2 changes to reduce the friction in that type of local development:

* adds `R-package/config.h` to `.gitignore`
  - this is auto-generated based on a `config.h.in` file, since #10642
* ensures tests can run successfully even when `{vcd}` is not installed

Running the tests without `{vcd}` installed today fails like this:

```text
── Failed tests ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Error (test_helpers.R:53:1): (code run outside of `test_that()`)
Error in `eval(code, test_env)`: object 'bst.Tree' not found
Backtrace:
    ▆
 1. └─xgboost::xgb.copy.Booster(bst.Tree) at test_helpers.R:53:1
```

Thanks for your time and consideration.

Promise I'm done putting up little R PRs for today 😅 