### PR TITLE
[EM] Add GPU version of the external memory QDM.

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -641,7 +641,7 @@ class DMatrix {
             typename XGDMatrixCallbackNext>
   static DMatrix* Create(DataIterHandle iter, DMatrixHandle proxy, std::shared_ptr<DMatrix> ref,
                          DataIterResetCallback* reset, XGDMatrixCallbackNext* next, float missing,
-                         std::int32_t nthread, bst_bin_t max_bin, std::string cache);
+                         std::int32_t nthread, bst_bin_t max_bin, std::string cache, bool on_host);
 
   virtual DMatrix *Slice(common::Span<int32_t const> ridxs) = 0;
 

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -116,6 +116,13 @@ inline int32_t CurrentDevice() {
   return device;
 }
 
+// Helper function to get a device from a potentially CPU context.
+inline auto GetDevice(xgboost::Context const *ctx) {
+  auto d = (ctx->IsCUDA()) ? ctx->Device() : xgboost::DeviceOrd::CUDA(dh::CurrentDevice());
+  CHECK(!d.IsCPU());
+  return d;
+}
+
 inline size_t TotalMemory(int device_idx) {
   size_t device_free = 0;
   size_t device_total = 0;

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -914,9 +914,9 @@ template <typename DataIterHandle, typename DMatrixHandle, typename DataIterRese
           typename XGDMatrixCallbackNext>
 DMatrix* DMatrix::Create(DataIterHandle iter, DMatrixHandle proxy, std::shared_ptr<DMatrix> ref,
                          DataIterResetCallback* reset, XGDMatrixCallbackNext* next, float missing,
-                         std::int32_t nthread, bst_bin_t max_bin, std::string cache) {
+                         std::int32_t nthread, bst_bin_t max_bin, std::string cache, bool on_host) {
   return new data::ExtMemQuantileDMatrix{
-      iter, proxy, ref, reset, next, missing, nthread, std::move(cache), max_bin};
+      iter, proxy, ref, reset, next, missing, nthread, std::move(cache), max_bin, on_host};
 }
 
 template DMatrix* DMatrix::Create<DataIterHandle, DMatrixHandle, DataIterResetCallback,
@@ -935,7 +935,7 @@ template DMatrix* DMatrix::Create<DataIterHandle, DMatrixHandle, DataIterResetCa
 template DMatrix*
 DMatrix::Create<DataIterHandle, DMatrixHandle, DataIterResetCallback, XGDMatrixCallbackNext>(
     DataIterHandle, DMatrixHandle, std::shared_ptr<DMatrix>, DataIterResetCallback*,
-    XGDMatrixCallbackNext*, float, std::int32_t, bst_bin_t, std::string);
+    XGDMatrixCallbackNext*, float, std::int32_t, bst_bin_t, std::string, bool);
 
 template <typename AdapterT>
 DMatrix* DMatrix::Create(AdapterT* adapter, float missing, int nthread, const std::string&,

--- a/src/data/ellpack_page.cc
+++ b/src/data/ellpack_page.cc
@@ -47,6 +47,18 @@ bst_idx_t EllpackPage::Size() const {
                 "EllpackPage is required";
   return impl_->Cuts();
 }
+
+[[nodiscard]] bst_idx_t EllpackPage::BaseRowId() const {
+  LOG(FATAL) << "Internal Error: XGBoost is not compiled with CUDA but "
+                "EllpackPage is required";
+  return 0;
+}
+
+[[nodiscard]] bool EllpackPage::IsDense() const {
+  LOG(FATAL) << "Internal Error: XGBoost is not compiled with CUDA but "
+                "EllpackPage is required";
+  return false;
+}
 }  // namespace xgboost
 
 #endif  // XGBOOST_USE_CUDA

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -39,6 +39,9 @@ void EllpackPage::SetBaseRowId(std::size_t row_id) { impl_->SetBaseRowId(row_id)
   return impl_->Cuts();
 }
 
+[[nodiscard]] bst_idx_t EllpackPage::BaseRowId() const { return this->Impl()->base_rowid; }
+[[nodiscard]] bool EllpackPage::IsDense() const { return this->Impl()->IsDense(); }
+
 // Bin each input data entry, store the bin indices in compressed form.
 __global__ void CompressBinEllpackKernel(
     common::CompressedBufferWriter wr,

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -397,7 +397,7 @@ struct CopyPage {
 size_t EllpackPageImpl::Copy(Context const* ctx, EllpackPageImpl const* page, bst_idx_t offset) {
   monitor_.Start(__func__);
   bst_idx_t num_elements = page->n_rows * page->row_stride;
-  CHECK_EQ(row_stride, page->row_stride);
+  CHECK_EQ(this->row_stride, page->row_stride);
   CHECK_EQ(NumSymbols(), page->NumSymbols());
   CHECK_GE(n_rows * row_stride, offset + num_elements);
   if (page == this) {

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -203,6 +203,7 @@ class EllpackPageImpl {
   [[nodiscard]] std::shared_ptr<common::HistogramCuts const> CutsShared() const { return cuts_; }
   void SetCuts(std::shared_ptr<common::HistogramCuts const> cuts) { cuts_ = cuts; }
 
+  [[nodiscard]] bool IsDense() const { return is_dense; }
   /** @return Estimation of memory cost of this page. */
   static size_t MemCostBytes(size_t num_rows, size_t row_stride, const common::HistogramCuts&cuts) ;
 

--- a/src/data/ellpack_page.h
+++ b/src/data/ellpack_page.h
@@ -42,6 +42,7 @@ class EllpackPage {
 
   /*! \return Number of instances in the page. */
   [[nodiscard]] bst_idx_t Size() const;
+  [[nodiscard]] bool IsDense() const;
 
   /*! \brief Set the base row id for this page. */
   void SetBaseRowId(std::size_t row_id);
@@ -50,6 +51,7 @@ class EllpackPage {
   EllpackPageImpl* Impl() { return impl_.get(); }
 
   [[nodiscard]] common::HistogramCuts const& Cuts() const;
+  [[nodiscard]] bst_idx_t BaseRowId() const;
 
  private:
   std::unique_ptr<EllpackPageImpl> impl_;

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -8,6 +8,7 @@
 #include <cstdint>  // for int32_t
 #include <memory>   // for shared_ptr
 #include <utility>  // for move
+#include <vector>   // for vector
 
 #include "../common/cuda_rt_utils.h"  // for SupportsPageableMem
 #include "../common/hist_util.h"      // for HistogramCuts

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -169,12 +169,62 @@ using EllpackPageHostSource =
 using EllpackPageSource =
     EllpackPageSourceImpl<EllpackMmapStreamPolicy<EllpackPage, EllpackFormatPolicy>>;
 
+template <typename FormatCreatePolicy>
+class ExtEllpackPageSourceImpl : public ExtQantileSourceMixin<EllpackPage, FormatCreatePolicy> {
+  using Super = ExtQantileSourceMixin<EllpackPage, FormatCreatePolicy>;
+
+  Context const* ctx_;
+  BatchParam p_;
+  DMatrixProxy* proxy_;
+  MetaInfo* info_;
+  ExternalDataInfo ext_info_;
+
+  std::vector<bst_idx_t> base_rows_;
+
+ public:
+  ExtEllpackPageSourceImpl(
+      Context const* ctx, float missing, MetaInfo* info, ExternalDataInfo ext_info,
+      std::shared_ptr<Cache> cache, BatchParam param, std::shared_ptr<common::HistogramCuts> cuts,
+      std::shared_ptr<DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>> source,
+      DMatrixProxy* proxy, std::vector<bst_idx_t> base_rows)
+      : Super{missing,
+              ctx->Threads(),
+              static_cast<bst_feature_t>(info->num_col_),
+              ext_info.n_batches,
+              source,
+              cache},
+        ctx_{ctx},
+        p_{std::move(param)},
+        proxy_{proxy},
+        info_{info},
+        ext_info_{std::move(ext_info)},
+        base_rows_{std::move(base_rows)} {
+    this->SetCuts(std::move(cuts), ctx->Device());
+    this->Fetch();
+  }
+
+  void Fetch() final;
+};
+
+// Cache to host
+using ExtEllpackPageHostSource =
+    ExtEllpackPageSourceImpl<EllpackCacheStreamPolicy<EllpackPage, EllpackFormatPolicy>>;
+
+// Cache to disk
+using ExtEllpackPageSource =
+    ExtEllpackPageSourceImpl<EllpackMmapStreamPolicy<EllpackPage, EllpackFormatPolicy>>;
+
 #if !defined(XGBOOST_USE_CUDA)
 template <typename F>
 inline void EllpackPageSourceImpl<F>::Fetch() {
   // silent the warning about unused variables.
   (void)(row_stride_);
   (void)(is_dense_);
+  common::AssertGPUSupport();
+}
+
+template <typename F>
+inline void ExtEllpackPageSourceImpl<F>::Fetch() {
   common::AssertGPUSupport();
 }
 #endif  // !defined(XGBOOST_USE_CUDA)

--- a/src/data/extmem_quantile_dmatrix.cc
+++ b/src/data/extmem_quantile_dmatrix.cc
@@ -72,7 +72,7 @@ void ExtMemQuantileDMatrix::InitFromCPU(
   common::HistogramCuts cuts;
   ExternalDataInfo ext_info;
   cpu_impl::GetDataShape(ctx, proxy, *iter, missing, &ext_info);
-  ext_info.SetInfo(ctx, &this->Info());
+  ext_info.SetInfo(ctx, &this->info_);
 
   /**
    * Generate quantiles

--- a/src/data/extmem_quantile_dmatrix.cc
+++ b/src/data/extmem_quantile_dmatrix.cc
@@ -143,7 +143,7 @@ BatchSet<EllpackPage> ExtMemQuantileDMatrix::GetEllpackBatches(Context const *,
   return batch_set;
 }
 
-BatchSet<EllpackPage> ExtMemQuantileDMatrix::GetEllpackPageImpl(Context const *) {
+BatchSet<EllpackPage> ExtMemQuantileDMatrix::GetEllpackPageImpl() {
   common::AssertGPUSupport();
   auto batch_set =
       std::visit([this](auto &&ptr) { return BatchSet{BatchIterator<EllpackPage>{ptr}}; },

--- a/src/data/extmem_quantile_dmatrix.cc
+++ b/src/data/extmem_quantile_dmatrix.cc
@@ -24,8 +24,8 @@ ExtMemQuantileDMatrix::ExtMemQuantileDMatrix(DataIterHandle iter_handle, DMatrix
                                              DataIterResetCallback *reset,
                                              XGDMatrixCallbackNext *next, float missing,
                                              std::int32_t n_threads, std::string cache,
-                                             bst_bin_t max_bin)
-    : cache_prefix_{std::move(cache)} {
+                                             bst_bin_t max_bin, bool on_host)
+    : cache_prefix_{std::move(cache)}, on_host_{on_host} {
   auto iter = std::make_shared<DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>>(
       iter_handle, reset, next);
   iter->Reset();

--- a/src/data/extmem_quantile_dmatrix.cu
+++ b/src/data/extmem_quantile_dmatrix.cu
@@ -4,21 +4,82 @@
 #include <memory>   // for shared_ptr
 #include <variant>  // for visit
 
+#include "batch_utils.h"     // for CheckParam, RegenGHist
+#include "ellpack_page.cuh"  // for EllpackPage
 #include "extmem_quantile_dmatrix.h"
+#include "proxy_dmatrix.h"    // for DataIterProxy
+#include "xgboost/context.h"  // for Context
+#include "xgboost/data.h"     // for BatchParam
 
 namespace xgboost::data {
 void ExtMemQuantileDMatrix::InitFromCUDA(
-    Context const *, std::shared_ptr<DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>>,
-    DMatrixHandle, BatchParam const &, float, std::shared_ptr<DMatrix>) {
-  LOG(FATAL) << "Not implemented.";
+    Context const *ctx,
+    std::shared_ptr<DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>> iter,
+    DMatrixHandle proxy_handle, BatchParam const &p, float missing, std::shared_ptr<DMatrix> ref) {
+  // A handle passed to external iterator.
+  auto proxy = MakeProxy(proxy_handle);
+  CHECK(proxy);
+
+  /**
+   * Generate quantiles
+   */
+  auto cuts = std::make_shared<common::HistogramCuts>();
+  ExternalDataInfo ext_info;
+  cuda_impl::MakeSketches(ctx, iter.get(), proxy, ref, p, missing, cuts, this->Info(), &ext_info);
+  ext_info.SetInfo(ctx, &this->Info());
+
+  /**
+   * Generate gradient index
+   */
+  auto id = MakeCache(this, ".ellpack.page", false, cache_prefix_, &cache_info_);
+  bool on_host_ = false;  // fixme
+  if (on_host_ && std::get_if<EllpackHostPtr>(&ellpack_page_source_) == nullptr) {
+    ellpack_page_source_.emplace<EllpackHostPtr>(nullptr);
+  }
+  std::visit(
+      [&](auto &&ptr) {
+        using SourceT = typename std::remove_reference_t<decltype(ptr)>::element_type;
+        ptr = std::make_shared<SourceT>(ctx, missing, &this->Info(), ext_info, cache_info_.at(id),
+                                        p, cuts, iter, proxy, ext_info.base_rows);
+      },
+      ellpack_page_source_);
+
+  /**
+   * Force initialize the cache and do some sanity checks along the way
+   */
+  bst_idx_t batch_cnt = 0, k = 0;
+  bst_idx_t n_total_samples = 0;
+  for (auto const &page : this->GetEllpackPageImpl()) {
+    n_total_samples += page.Size();
+    CHECK_EQ(page.Impl()->base_rowid, ext_info.base_rows[k]);
+    CHECK_EQ(page.Impl()->row_stride, ext_info.row_stride);
+    ++k, ++batch_cnt;
+  }
+  CHECK_EQ(batch_cnt, ext_info.n_batches);
+  CHECK_EQ(n_total_samples, ext_info.accumulated_rows);
 }
 
-BatchSet<EllpackPage> ExtMemQuantileDMatrix::GetEllpackBatches(Context const *,
-                                                               const BatchParam &) {
-  LOG(FATAL) << "Not implemented.";
+[[nodiscard]] BatchSet<EllpackPage> ExtMemQuantileDMatrix::GetEllpackPageImpl() {
   auto batch_set =
       std::visit([this](auto &&ptr) { return BatchSet{BatchIterator<EllpackPage>{ptr}}; },
                  this->ellpack_page_source_);
   return batch_set;
+}
+
+BatchSet<EllpackPage> ExtMemQuantileDMatrix::GetEllpackBatches(Context const *,
+                                                               const BatchParam &param) {
+  if (param.Initialized()) {
+    detail::CheckParam(this->batch_, param);
+    CHECK(!detail::RegenGHist(param, batch_)) << error::InconsistentMaxBin();
+  }
+
+  std::visit(
+      [this](auto &&ptr) {
+        CHECK(ptr);
+        ptr->Reset();
+      },
+      this->ellpack_page_source_);
+
+  return this->GetEllpackPageImpl();
 }
 }  // namespace xgboost::data

--- a/src/data/extmem_quantile_dmatrix.cu
+++ b/src/data/extmem_quantile_dmatrix.cu
@@ -32,7 +32,6 @@ void ExtMemQuantileDMatrix::InitFromCUDA(
    * Generate gradient index
    */
   auto id = MakeCache(this, ".ellpack.page", false, cache_prefix_, &cache_info_);
-  bool on_host_ = false;  // fixme
   if (on_host_ && std::get_if<EllpackHostPtr>(&ellpack_page_source_) == nullptr) {
     ellpack_page_source_.emplace<EllpackHostPtr>(nullptr);
   }

--- a/src/data/extmem_quantile_dmatrix.cu
+++ b/src/data/extmem_quantile_dmatrix.cu
@@ -26,7 +26,7 @@ void ExtMemQuantileDMatrix::InitFromCUDA(
   auto cuts = std::make_shared<common::HistogramCuts>();
   ExternalDataInfo ext_info;
   cuda_impl::MakeSketches(ctx, iter.get(), proxy, ref, p, missing, cuts, this->Info(), &ext_info);
-  ext_info.SetInfo(ctx, &this->Info());
+  ext_info.SetInfo(ctx, &this->info_);
 
   /**
    * Generate gradient index

--- a/src/data/extmem_quantile_dmatrix.h
+++ b/src/data/extmem_quantile_dmatrix.h
@@ -45,9 +45,10 @@ class ExtMemQuantileDMatrix : public QuantileDMatrix {
       std::shared_ptr<DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>> iter,
       DMatrixHandle proxy_handle, BatchParam const &p, float missing, std::shared_ptr<DMatrix> ref);
 
-  BatchSet<GHistIndexMatrix> GetGradientIndexImpl();
+  [[nodiscard]] BatchSet<GHistIndexMatrix> GetGradientIndexImpl();
   BatchSet<GHistIndexMatrix> GetGradientIndex(Context const *ctx, BatchParam const &param) override;
 
+  [[nodiscard]] BatchSet<EllpackPage> GetEllpackPageImpl();
   BatchSet<EllpackPage> GetEllpackBatches(Context const *ctx, const BatchParam &param) override;
 
   [[nodiscard]] bool EllpackExists() const override {
@@ -62,8 +63,8 @@ class ExtMemQuantileDMatrix : public QuantileDMatrix {
   std::string cache_prefix_;
   BatchParam batch_;
 
-  using EllpackDiskPtr = std::shared_ptr<EllpackPageSource>;
-  using EllpackHostPtr = std::shared_ptr<EllpackPageHostSource>;
+  using EllpackDiskPtr = std::shared_ptr<ExtEllpackPageSource>;
+  using EllpackHostPtr = std::shared_ptr<ExtEllpackPageHostSource>;
   std::variant<EllpackDiskPtr, EllpackHostPtr> ellpack_page_source_;
   std::shared_ptr<ExtGradientIndexPageSource> ghist_index_source_;
 };

--- a/src/data/extmem_quantile_dmatrix.h
+++ b/src/data/extmem_quantile_dmatrix.h
@@ -30,7 +30,7 @@ class ExtMemQuantileDMatrix : public QuantileDMatrix {
   ExtMemQuantileDMatrix(DataIterHandle iter_handle, DMatrixHandle proxy,
                         std::shared_ptr<DMatrix> ref, DataIterResetCallback *reset,
                         XGDMatrixCallbackNext *next, float missing, std::int32_t n_threads,
-                        std::string cache, bst_bin_t max_bin);
+                        std::string cache, bst_bin_t max_bin, bool on_host);
   ~ExtMemQuantileDMatrix() override;
 
   [[nodiscard]] bool SingleColBlock() const override { return false; }
@@ -61,6 +61,7 @@ class ExtMemQuantileDMatrix : public QuantileDMatrix {
 
   std::map<std::string, std::shared_ptr<Cache>> cache_info_;
   std::string cache_prefix_;
+  bool on_host_;
   BatchParam batch_;
 
   using EllpackDiskPtr = std::shared_ptr<ExtEllpackPageSource>;

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -242,6 +242,7 @@ class GHistIndexMatrix {
 
   [[nodiscard]] bool IsDense() const { return isDense_; }
   void SetDense(bool is_dense) { isDense_ = is_dense; }
+  [[nodiscard]] bst_idx_t BaseRowId() const { return base_rowid; }
   /**
    * @brief Get the local row index.
    */

--- a/src/data/iterative_dmatrix.cc
+++ b/src/data/iterative_dmatrix.cc
@@ -63,7 +63,7 @@ void IterativeDMatrix::InitFromCPU(Context const* ctx, BatchParam const& p,
   common::HistogramCuts cuts;
   ExternalDataInfo ext_info;
   cpu_impl::GetDataShape(ctx, proxy, iter, missing, &ext_info);
-  ext_info.SetInfo(ctx, &this->Info());
+  ext_info.SetInfo(ctx, &this->info_);
 
   /**
    * Generate quantiles

--- a/src/data/iterative_dmatrix.cc
+++ b/src/data/iterative_dmatrix.cc
@@ -63,13 +63,7 @@ void IterativeDMatrix::InitFromCPU(Context const* ctx, BatchParam const& p,
   common::HistogramCuts cuts;
   ExternalDataInfo ext_info;
   cpu_impl::GetDataShape(ctx, proxy, iter, missing, &ext_info);
-
-  // From here on Info() has the correct data shape
-  this->Info().num_row_ = ext_info.accumulated_rows;
-  this->Info().num_col_ = ext_info.n_features;
-  this->Info().num_nonzero_ = ext_info.nnz;
-  this->Info().SynchronizeNumberOfColumns(ctx);
-  ext_info.Validate();
+  ext_info.SetInfo(ctx, &this->Info());
 
   /**
    * Generate quantiles

--- a/src/data/iterative_dmatrix.cu
+++ b/src/data/iterative_dmatrix.cu
@@ -43,7 +43,7 @@ void IterativeDMatrix::InitFromCUDA(Context const* ctx, BatchParam const& p,
   auto cuts = std::make_shared<common::HistogramCuts>();
   ExternalDataInfo ext_info;
   cuda_impl::MakeSketches(ctx, &iter, proxy, ref, p, missing, cuts, this->Info(), &ext_info);
-  ext_info.SetInfo(ctx, &this->Info());
+  ext_info.SetInfo(ctx, &this->info_);
 
   auto init_page = [this, &cuts, &ext_info]() {
     if (!ellpack_) {

--- a/src/data/iterative_dmatrix.cu
+++ b/src/data/iterative_dmatrix.cu
@@ -1,20 +1,15 @@
 /**
  * Copyright 2020-2024, XGBoost contributors
  */
-#include <algorithm>  // for max
 #include <memory>     // for shared_ptr
 #include <utility>    // for move
-#include <vector>     // for vector
 
-#include "../collective/allreduce.h"
-#include "../common/cuda_rt_utils.h"  // for AllVisibleGPUs
-#include "../common/hist_util.cuh"
 #include "batch_utils.h"  // for RegenGHist, CheckParam
 #include "device_adapter.cuh"
 #include "ellpack_page.cuh"
 #include "iterative_dmatrix.h"
 #include "proxy_dmatrix.cuh"
-#include "proxy_dmatrix.h"
+#include "proxy_dmatrix.h"  // for BatchSamples, BatchColumns
 #include "simple_batch_iterator.h"
 
 namespace xgboost::data {
@@ -31,103 +26,32 @@ void IterativeDMatrix::InitFromCUDA(Context const* ctx, BatchParam const& p,
 
   dh::XGBCachingDeviceAllocator<char> alloc;
 
-  auto num_rows = [&]() {
-    return cuda_impl::Dispatch(proxy, [](auto const& value) { return value.NumRows(); });
-  };
-  auto num_cols = [&]() {
-    return cuda_impl::Dispatch(proxy, [](auto const& value) { return value.NumCols(); });
-  };
-
-  size_t row_stride = 0;
-  size_t nnz = 0;
   // Sketch for all batches.
-  std::vector<common::SketchContainer> sketch_containers;
-  size_t batches = 0;
-  size_t accumulated_rows = 0;
-  bst_feature_t cols = 0;
 
-  int32_t current_device;
-  dh::safe_cuda(cudaGetDevice(&current_device));
+  std::int32_t current_device{dh::CurrentDevice()};
   auto get_ctx = [&]() {
     Context d_ctx = (ctx->IsCUDA()) ? *ctx : Context{}.MakeCUDA(current_device);
     CHECK(!d_ctx.IsCPU());
     return d_ctx;
   };
-  auto get_device = [&]() {
-    auto d = (ctx->IsCUDA()) ? ctx->Device() : DeviceOrd::CUDA(current_device);
-    CHECK(!d.IsCPU());
-    return d;
-  };
+
   fmat_ctx_ = get_ctx();
 
   /**
    * Generate quantiles
    */
   auto cuts = std::make_shared<common::HistogramCuts>();
-  do {
-    // We use do while here as the first batch is fetched in ctor
-    CHECK_LT(ctx->Ordinal(), common::AllVisibleGPUs());
-    dh::safe_cuda(cudaSetDevice(get_device().ordinal));
-    if (cols == 0) {
-      cols = num_cols();
-      auto rc = collective::Allreduce(ctx, linalg::MakeVec(&cols, 1), collective::Op::kMax);
-      SafeColl(rc);
-      this->info_.num_col_ = cols;
-    } else {
-      CHECK_EQ(cols, num_cols()) << "Inconsistent number of columns.";
-    }
-    if (!ref) {
-      sketch_containers.emplace_back(proxy->Info().feature_types, p.max_bin, cols, num_rows(),
-                                     get_device());
-      auto* p_sketch = &sketch_containers.back();
-      proxy->Info().weights_.SetDevice(get_device());
-      cuda_impl::Dispatch(proxy, [&](auto const& value) {
-        common::AdapterDeviceSketch(value, p.max_bin, proxy->Info(), missing, p_sketch);
-      });
-    }
-    auto batch_rows = num_rows();
-    accumulated_rows += batch_rows;
-    dh::device_vector<size_t> row_counts(batch_rows + 1, 0);
-    common::Span<size_t> row_counts_span(row_counts.data().get(), row_counts.size());
-    row_stride = std::max(row_stride, cuda_impl::Dispatch(proxy, [=](auto const& value) {
-                            return GetRowCounts(value, row_counts_span, get_device(), missing);
-                          }));
-    nnz += thrust::reduce(thrust::cuda::par(alloc), row_counts.begin(), row_counts.end());
-    batches++;
-  } while (iter.Next());
-  iter.Reset();
+  ExternalDataInfo ext_info;
+  cuda_impl::MakeSketches(ctx, &iter, proxy, ref, p, missing, cuts, this->Info(), &ext_info);
+  ext_info.SetInfo(ctx, &this->Info());
 
-  auto n_features = cols;
-  CHECK_GE(n_features, 1) << "Data must has at least 1 column.";
-
-  dh::safe_cuda(cudaSetDevice(get_device().ordinal));
-  if (!ref) {
-    HostDeviceVector<FeatureType> ft;
-    common::SketchContainer final_sketch(
-        sketch_containers.empty() ? ft : sketch_containers.front().FeatureTypes(), p.max_bin, cols,
-        accumulated_rows, get_device());
-    for (auto const& sketch : sketch_containers) {
-      final_sketch.Merge(sketch.ColumnsPtr(), sketch.Data());
-      final_sketch.FixError();
-    }
-    sketch_containers.clear();
-    sketch_containers.shrink_to_fit();
-
-    final_sketch.MakeCuts(ctx, cuts.get(), this->info_.IsColumnSplit());
-  } else {
-    GetCutsFromRef(ctx, ref, Info().num_col_, p, cuts.get());
-  }
-
-  this->info_.num_row_ = accumulated_rows;
-  this->info_.num_nonzero_ = nnz;
-
-  auto init_page = [this, &cuts, row_stride, accumulated_rows, get_device]() {
+  auto init_page = [this, &cuts, &ext_info]() {
     if (!ellpack_) {
       // Should be put inside the while loop to protect against empty batch.  In
       // that case device id is invalid.
       ellpack_.reset(new EllpackPage);
-      *(ellpack_->Impl()) =
-          EllpackPageImpl(&fmat_ctx_, cuts, this->IsDense(), row_stride, accumulated_rows);
+      *(ellpack_->Impl()) = EllpackPageImpl(&fmat_ctx_, cuts, this->IsDense(), ext_info.row_stride,
+                                            ext_info.accumulated_rows);
     }
   };
 
@@ -139,43 +63,42 @@ void IterativeDMatrix::InitFromCUDA(Context const* ctx, BatchParam const& p,
   size_t n_batches_for_verification = 0;
   while (iter.Next()) {
     init_page();
-    dh::safe_cuda(cudaSetDevice(get_device().ordinal));
-    auto rows = num_rows();
+    dh::safe_cuda(cudaSetDevice(dh::GetDevice(ctx).ordinal));
+    auto rows = BatchSamples(proxy);
     dh::device_vector<size_t> row_counts(rows + 1, 0);
     common::Span<size_t> row_counts_span(row_counts.data().get(), row_counts.size());
     cuda_impl::Dispatch(proxy, [=](auto const& value) {
-      return GetRowCounts(value, row_counts_span, get_device(), missing);
+      return GetRowCounts(value, row_counts_span, dh::GetDevice(ctx), missing);
     });
     auto is_dense = this->IsDense();
 
-    proxy->Info().feature_types.SetDevice(get_device());
+    proxy->Info().feature_types.SetDevice(dh::GetDevice(ctx));
     auto d_feature_types = proxy->Info().feature_types.ConstDeviceSpan();
     auto new_impl = cuda_impl::Dispatch(proxy, [&](auto const& value) {
       return EllpackPageImpl(&fmat_ctx_, value, missing, is_dense, row_counts_span, d_feature_types,
-                             row_stride, rows, cuts);
+                             ext_info.row_stride, rows, cuts);
     });
     std::size_t num_elements = ellpack_->Impl()->Copy(&fmat_ctx_, &new_impl, offset);
     offset += num_elements;
 
-    proxy->Info().num_row_ = num_rows();
-    proxy->Info().num_col_ = cols;
-    if (batches != 1) {
+    proxy->Info().num_row_ = BatchSamples(proxy);
+    proxy->Info().num_col_ = ext_info.n_features;
+    if (ext_info.n_batches != 1) {
       this->info_.Extend(std::move(proxy->Info()), false, true);
     }
     n_batches_for_verification++;
   }
-  CHECK_EQ(batches, n_batches_for_verification)
+  CHECK_EQ(ext_info.n_batches, n_batches_for_verification)
       << "Different number of batches returned between 2 iterations";
 
-  if (batches == 1) {
+  if (ext_info.n_batches == 1) {
     this->info_ = std::move(proxy->Info());
-    this->info_.num_nonzero_ = nnz;
+    this->info_.num_nonzero_ = ext_info.nnz;
     CHECK_EQ(proxy->Info().labels.Size(), 0);
   }
 
   iter.Reset();
   // Synchronise worker columns
-  info_.SynchronizeNumberOfColumns(ctx);
 }
 
 BatchSet<EllpackPage> IterativeDMatrix::GetEllpackBatches(Context const* ctx,

--- a/src/data/quantile_dmatrix.cu
+++ b/src/data/quantile_dmatrix.cu
@@ -1,10 +1,93 @@
 /**
- * Copyright 2024, XGBoost Contributors
+ * Copyright 2020-2024, XGBoost Contributors
  */
-#include "ellpack_page.cuh"
+#include <algorithm>  // for max
+#include <numeric>    // for partial_sum
+#include <vector>     // for vector
+
+#include "../collective/allreduce.h"    // for Allreduce
+#include "../common/cuda_rt_utils.h"    // for AllVisibleGPUs
+#include "../common/device_vector.cuh"  // for XGBCachingDeviceAllocator
+#include "../common/hist_util.cuh"      // for AdapterDeviceSketch
+#include "../common/quantile.cuh"       // for SketchContainer
+#include "ellpack_page.cuh"             // for EllpackPage
+#include "proxy_dmatrix.cuh"            // for Dispatch
+#include "proxy_dmatrix.h"              // for DataIterProxy
+#include "quantile_dmatrix.h"           // for GetCutsFromRef
 
 namespace xgboost::data {
 void GetCutsFromEllpack(EllpackPage const& page, common::HistogramCuts* cuts) {
   *cuts = page.Impl()->Cuts();
 }
+
+namespace cuda_impl {
+void MakeSketches(Context const* ctx,
+                  DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>* iter,
+                  DMatrixProxy* proxy, std::shared_ptr<DMatrix> ref, BatchParam const& p,
+                  float missing, std::shared_ptr<common::HistogramCuts> cuts, MetaInfo const& info,
+                  ExternalDataInfo* p_ext_info) {
+  dh::XGBCachingDeviceAllocator<char> alloc;
+  std::vector<common::SketchContainer> sketch_containers;
+  auto& ext_info = *p_ext_info;
+
+  do {
+    // We use do while here as the first batch is fetched in ctor
+    CHECK_LT(ctx->Ordinal(), common::AllVisibleGPUs());
+    dh::safe_cuda(cudaSetDevice(dh::GetDevice(ctx).ordinal));
+    if (ext_info.n_features == 0) {
+      ext_info.n_features = data::BatchColumns(proxy);
+      auto rc = collective::Allreduce(ctx, linalg::MakeVec(&ext_info.n_features, 1),
+                                      collective::Op::kMax);
+      SafeColl(rc);
+    } else {
+      CHECK_EQ(ext_info.n_features, ::xgboost::data::BatchColumns(proxy))
+          << "Inconsistent number of columns.";
+    }
+    if (!ref) {
+      sketch_containers.emplace_back(proxy->Info().feature_types, p.max_bin, ext_info.n_features,
+                                     data::BatchSamples(proxy), dh::GetDevice(ctx));
+      auto* p_sketch = &sketch_containers.back();
+      proxy->Info().weights_.SetDevice(dh::GetDevice(ctx));
+      cuda_impl::Dispatch(proxy, [&](auto const& value) {
+        common::AdapterDeviceSketch(value, p.max_bin, proxy->Info(), missing, p_sketch);
+      });
+    }
+    auto batch_rows = data::BatchSamples(proxy);
+    ext_info.accumulated_rows += batch_rows;
+    dh::device_vector<size_t> row_counts(batch_rows + 1, 0);
+    common::Span<size_t> row_counts_span(row_counts.data().get(), row_counts.size());
+    ext_info.row_stride =
+        std::max(ext_info.row_stride, cuda_impl::Dispatch(proxy, [=](auto const& value) {
+                   return GetRowCounts(value, row_counts_span, dh::GetDevice(ctx), missing);
+                 }));
+    ext_info.nnz += thrust::reduce(thrust::cuda::par(alloc), row_counts.begin(), row_counts.end());
+    ext_info.n_batches++;
+    ext_info.base_rows.push_back(batch_rows);
+  } while (iter->Next());
+  iter->Reset();
+
+  CHECK_GE(ext_info.n_features, 1) << "Data must has at least 1 column.";
+  std::partial_sum(ext_info.base_rows.cbegin(), ext_info.base_rows.cend(),
+                   ext_info.base_rows.begin());
+
+  // Get reference
+  dh::safe_cuda(cudaSetDevice(dh::GetDevice(ctx).ordinal));
+  if (!ref) {
+    HostDeviceVector<FeatureType> ft;
+    common::SketchContainer final_sketch(
+        sketch_containers.empty() ? ft : sketch_containers.front().FeatureTypes(), p.max_bin,
+        ext_info.n_features, ext_info.accumulated_rows, dh::GetDevice(ctx));
+    for (auto const& sketch : sketch_containers) {
+      final_sketch.Merge(sketch.ColumnsPtr(), sketch.Data());
+      final_sketch.FixError();
+    }
+    sketch_containers.clear();
+    sketch_containers.shrink_to_fit();
+
+    final_sketch.MakeCuts(ctx, cuts.get(), info.IsColumnSplit());
+  } else {
+    GetCutsFromRef(ctx, ref, ext_info.n_features, p, cuts.get());
+  }
+}
+}  // namespace cuda_impl
 }  // namespace xgboost::data

--- a/src/data/quantile_dmatrix.h
+++ b/src/data/quantile_dmatrix.h
@@ -104,4 +104,12 @@ void MakeSketches(Context const *ctx,
                   common::HistogramCuts *cuts, BatchParam const &p, MetaInfo const &info,
                   ExternalDataInfo const &ext_info, std::vector<FeatureType> *p_h_ft);
 }  // namespace cpu_impl
+
+namespace cuda_impl {
+void MakeSketches(Context const *ctx,
+                  DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext> *iter,
+                  DMatrixProxy *proxy, std::shared_ptr<DMatrix> ref, BatchParam const &p,
+                  float missing, std::shared_ptr<common::HistogramCuts> cuts, MetaInfo const &info,
+                  ExternalDataInfo *p_ext_info);
+}  // namespace cuda_impl
 }  // namespace xgboost::data

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -38,30 +38,23 @@ SparsePageDMatrix::SparsePageDMatrix(DataIterHandle iter_handle, DMatrixHandle p
   auto iter = DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>{
       iter_, reset_, next_};
 
-  std::uint32_t n_batches = 0;
-  bst_feature_t n_features = 0;
-  bst_idx_t n_samples = 0;
-  bst_idx_t nnz = 0;
+  ExternalDataInfo ext_info;
 
   // The proxy is iterated together with the sparse page source so we can obtain all
   // information in 1 pass.
   for (auto const &page : this->GetRowBatchesImpl(&ctx)) {
     this->info_.Extend(std::move(proxy->Info()), false, false);
-    n_features = std::max(n_features, BatchColumns(proxy));
-    n_samples += BatchSamples(proxy);
-    nnz += page.data.Size();
-    n_batches++;
+    ext_info.n_features =
+        std::max(static_cast<bst_feature_t>(ext_info.n_features), BatchColumns(proxy));
+    ext_info.accumulated_rows += BatchSamples(proxy);
+    ext_info.nnz += page.data.Size();
+    ext_info.n_batches++;
   }
 
   iter.Reset();
 
-  this->n_batches_ = n_batches;
-  this->info_.num_row_ = n_samples;
-  this->info_.num_col_ = n_features;
-  this->info_.num_nonzero_ = nnz;
-
-  info_.SynchronizeNumberOfColumns(&ctx);
-  CHECK_NE(info_.num_col_, 0);
+  this->n_batches_ = ext_info.n_batches;
+  ext_info.SetInfo(&ctx, &this->Info());
 
   fmat_ctx_ = ctx;
 }

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -54,7 +54,7 @@ SparsePageDMatrix::SparsePageDMatrix(DataIterHandle iter_handle, DMatrixHandle p
   iter.Reset();
 
   this->n_batches_ = ext_info.n_batches;
-  ext_info.SetInfo(&ctx, &this->Info());
+  ext_info.SetInfo(&ctx, &this->info_);
 
   fmat_ctx_ = ctx;
 }

--- a/tests/cpp/data/test_extmem_quantile_dmatrix.cc
+++ b/tests/cpp/data/test_extmem_quantile_dmatrix.cc
@@ -1,6 +1,8 @@
 /**
  * Copyright 2024, XGBoost Contributors
  */
+#include "test_extmem_quantile_dmatrix.h"  // for TestExtMemQdmBasic
+
 #include <gtest/gtest.h>
 #include <xgboost/data.h>  // for BatchParam
 
@@ -9,76 +11,30 @@
 #include "../../../src/common/column_matrix.h"  // for ColumnMatrix
 #include "../../../src/data/gradient_index.h"   // for GHistIndexMatrix
 #include "../../../src/tree/param.h"            // for TrainParam
-#include "../helpers.h"                         // for RandomDataGenerator
 
 namespace xgboost::data {
 namespace {
 class ExtMemQuantileDMatrixCpu : public ::testing::TestWithParam<float> {
  public:
   void Run(float sparsity) {
-    bst_idx_t n_samples = 256, n_features = 16, n_batches = 4;
-    bst_bin_t max_bin = 64;
-    bst_target_t n_targets = 3;
-    auto p_fmat = RandomDataGenerator{n_samples, n_features, sparsity}
-                      .Bins(max_bin)
-                      .Batches(n_batches)
-                      .Targets(n_targets)
-                      .GenerateExtMemQuantileDMatrix("temp", true);
-    ASSERT_FALSE(p_fmat->SingleColBlock());
-
-    BatchParam p{max_bin, tree::TrainParam::DftSparseThreshold()};
-    Context ctx;
-
-    // Loop over the batches and count the number of pages
-    bst_idx_t batch_cnt = 0;
-    bst_idx_t base_cnt = 0;
-    bst_idx_t row_cnt = 0;
-    for (auto const& page : p_fmat->GetBatches<GHistIndexMatrix>(&ctx, p)) {
-      ASSERT_EQ(page.base_rowid, base_cnt);
-      ++batch_cnt;
-      base_cnt += n_samples / n_batches;
-      row_cnt += page.Size();
-      ASSERT_EQ((sparsity == 0.0f), page.IsDense());
-    }
-    ASSERT_EQ(n_batches, batch_cnt);
-    ASSERT_EQ(p_fmat->Info().num_row_, n_samples);
-    EXPECT_EQ(p_fmat->Info().num_row_, row_cnt);
-    ASSERT_EQ(p_fmat->Info().num_col_, n_features);
-    if (sparsity == 0.0f) {
-      ASSERT_EQ(p_fmat->Info().num_nonzero_, n_samples * n_features);
-    } else {
-      ASSERT_LT(p_fmat->Info().num_nonzero_, n_samples * n_features);
-      ASSERT_GT(p_fmat->Info().num_nonzero_, 0);
-    }
-    ASSERT_EQ(p_fmat->Info().labels.Shape(0), n_samples);
-    ASSERT_EQ(p_fmat->Info().labels.Shape(1), n_targets);
-
-    // Compare against the sparse page DMatrix
-    auto p_sparse = RandomDataGenerator{n_samples, n_features, sparsity}
-                        .Bins(max_bin)
-                        .Batches(n_batches)
-                        .Targets(n_targets)
-                        .GenerateSparsePageDMatrix("temp", true);
-    auto it = p_fmat->GetBatches<GHistIndexMatrix>(&ctx, p).begin();
-    for (auto const& page : p_sparse->GetBatches<GHistIndexMatrix>(&ctx, p)) {
-      auto orig = it.Page();
+    auto equal = [](Context const*, GHistIndexMatrix const& orig, GHistIndexMatrix const& sparse) {
       // Check the CSR matrix
-      auto orig_cuts = it.Page()->Cuts();
-      auto sparse_cuts = page.Cuts();
+      auto orig_cuts = orig.Cuts();
+      auto sparse_cuts = sparse.Cuts();
       ASSERT_EQ(orig_cuts.Values(), sparse_cuts.Values());
       ASSERT_EQ(orig_cuts.MinValues(), sparse_cuts.MinValues());
       ASSERT_EQ(orig_cuts.Ptrs(), sparse_cuts.Ptrs());
 
-      auto orig_ptr = orig->data.data();
-      auto sparse_ptr = page.data.data();
-      ASSERT_EQ(orig->data.size(), page.data.size());
+      auto orig_ptr = orig.data.data();
+      auto sparse_ptr = sparse.data.data();
+      ASSERT_EQ(orig.data.size(), sparse.data.size());
 
-      auto equal = std::equal(orig_ptr, orig_ptr + orig->data.size(), sparse_ptr);
+      auto equal = std::equal(orig_ptr, orig_ptr + orig.data.size(), sparse_ptr);
       ASSERT_TRUE(equal);
 
       // Check the column matrix
-      common::ColumnMatrix const& orig_columns = orig->Transpose();
-      common::ColumnMatrix const& sparse_columns = page.Transpose();
+      common::ColumnMatrix const& orig_columns = orig.Transpose();
+      common::ColumnMatrix const& sparse_columns = sparse.Transpose();
 
       std::string str_orig, str_sparse;
       common::AlignedMemWriteStream fo_orig{&str_orig}, fo_sparse{&str_sparse};
@@ -86,18 +42,10 @@ class ExtMemQuantileDMatrixCpu : public ::testing::TestWithParam<float> {
       auto n_bytes_sparse = sparse_columns.Write(&fo_sparse);
       ASSERT_EQ(n_bytes_orig, n_bytes_sparse);
       ASSERT_EQ(str_orig, str_sparse);
+    };
 
-      ++it;
-    }
-
-    // Check meta info
-    auto h_y_sparse = p_sparse->Info().labels.HostView();
-    auto h_y = p_fmat->Info().labels.HostView();
-    for (std::size_t i = 0, m = h_y_sparse.Shape(0); i < m; ++i) {
-      for (std::size_t j = 0, n = h_y_sparse.Shape(1); j < n; ++j) {
-        ASSERT_EQ(h_y(i, j), h_y_sparse(i, j));
-      }
-    }
+    Context ctx;
+    TestExtMemQdmBasic<GHistIndexMatrix>(&ctx, sparsity, equal);
   }
 };
 }  // anonymous namespace

--- a/tests/cpp/data/test_extmem_quantile_dmatrix.cc
+++ b/tests/cpp/data/test_extmem_quantile_dmatrix.cc
@@ -45,7 +45,7 @@ class ExtMemQuantileDMatrixCpu : public ::testing::TestWithParam<float> {
     };
 
     Context ctx;
-    TestExtMemQdmBasic<GHistIndexMatrix>(&ctx, sparsity, equal);
+    TestExtMemQdmBasic<GHistIndexMatrix>(&ctx, false, sparsity, equal);
   }
 };
 }  // anonymous namespace

--- a/tests/cpp/data/test_extmem_quantile_dmatrix.cu
+++ b/tests/cpp/data/test_extmem_quantile_dmatrix.cu
@@ -31,7 +31,8 @@ class ExtMemQuantileDMatrixGpu : public ::testing::TestWithParam<float> {
     };
 
     auto ctx = MakeCUDACtx(0);
-    TestExtMemQdmBasic<EllpackPage>(&ctx, sparsity, equal);
+    TestExtMemQdmBasic<EllpackPage>(&ctx, true, sparsity, equal);
+    TestExtMemQdmBasic<EllpackPage>(&ctx, false, sparsity, equal);
   }
 };
 

--- a/tests/cpp/data/test_extmem_quantile_dmatrix.cu
+++ b/tests/cpp/data/test_extmem_quantile_dmatrix.cu
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2024, XGBoost Contributors
+ */
+#include <gtest/gtest.h>
+#include <xgboost/data.h>  // for BatchParam
+
+#include "../helpers.h"  // for RandomDataGenerator
+
+namespace xgboost::data {
+class ExtMemQuantileDMatrixGpu : public ::testing::TestWithParam<float> {
+ public:
+  void Run(float sparsity) {
+    bst_idx_t n_samples = 256, n_features = 16, n_batches = 4;
+    bst_bin_t max_bin = 64;
+    bst_target_t n_targets = 3;
+    auto ctx = MakeCUDACtx(0);
+    auto p_fmat = RandomDataGenerator{n_samples, n_features, sparsity}
+                      .Bins(max_bin)
+                      .Batches(n_batches)
+                      .Targets(n_targets)
+                      .Device(ctx.Device())
+                      .GenerateExtMemQuantileDMatrix("temp", true);
+  }
+};
+
+TEST_P(ExtMemQuantileDMatrixGpu, Basic) { this->Run(this->GetParam()); }
+
+INSTANTIATE_TEST_SUITE_P(ExtMemQuantileDMatrix, ExtMemQuantileDMatrixGpu, ::testing::ValuesIn([] {
+                           std::vector<float> sparsities{0.0f, 0.2f, 0.4f, 0.8f};
+                           return sparsities;
+                         }()));
+}  // namespace xgboost::data

--- a/tests/cpp/data/test_extmem_quantile_dmatrix.h
+++ b/tests/cpp/data/test_extmem_quantile_dmatrix.h
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2024, XGBoost Contributors
+ */
+#include <xgboost/base.h>
+#include <xgboost/context.h>
+
+#include "../../../src/tree/param.h"  // for TrainParam
+#include "../helpers.h"               // for RandomDataGenerator
+
+namespace xgboost::data {
+template <typename Page, typename Equal>
+void TestExtMemQdmBasic(Context const* ctx, float sparsity, Equal&& check_equal) {
+  bst_idx_t n_samples = 256, n_features = 16, n_batches = 4;
+  bst_bin_t max_bin = 64;
+  bst_target_t n_targets = 3;
+  BatchParam p{max_bin, tree::TrainParam::DftSparseThreshold()};
+
+  auto p_fmat = RandomDataGenerator{n_samples, n_features, sparsity}
+                    .Bins(max_bin)
+                    .Batches(n_batches)
+                    .Targets(n_targets)
+                    .Device(ctx->Device())
+                    .GenerateExtMemQuantileDMatrix("temp", true);
+  ASSERT_FALSE(p_fmat->SingleColBlock());
+
+  // Loop over the batches and count the number of pages
+  bst_idx_t batch_cnt = 0, base_cnt = 0, row_cnt = 0;
+  for (auto const& page : p_fmat->GetBatches<Page>(ctx, p)) {
+    ASSERT_EQ(page.BaseRowId(), base_cnt);
+    ++batch_cnt;
+    base_cnt += n_samples / n_batches;
+    row_cnt += page.Size();
+    ASSERT_EQ((sparsity == 0.0f), page.IsDense());
+  }
+  ASSERT_EQ(n_batches, batch_cnt);
+  ASSERT_EQ(p_fmat->Info().num_row_, n_samples);
+  EXPECT_EQ(p_fmat->Info().num_row_, row_cnt);
+  ASSERT_EQ(p_fmat->Info().num_col_, n_features);
+  if (sparsity == 0.0f) {
+    ASSERT_EQ(p_fmat->Info().num_nonzero_, n_samples * n_features);
+  } else {
+    ASSERT_LT(p_fmat->Info().num_nonzero_, n_samples * n_features);
+    ASSERT_GT(p_fmat->Info().num_nonzero_, 0);
+  }
+  ASSERT_EQ(p_fmat->Info().labels.Shape(0), n_samples);
+  ASSERT_EQ(p_fmat->Info().labels.Shape(1), n_targets);
+
+  // Compare against the sparse page DMatrix
+  auto p_sparse = RandomDataGenerator{n_samples, n_features, sparsity}
+                      .Bins(max_bin)
+                      .Batches(n_batches)
+                      .Targets(n_targets)
+                      .GenerateSparsePageDMatrix("temp", true);
+  auto it = p_fmat->GetBatches<Page>(ctx, p).begin();
+  for (auto const& page : p_sparse->GetBatches<Page>(ctx, p)) {
+    auto orig = it.Page();
+    check_equal(ctx, *orig, page);
+    ++it;
+  }
+
+  // Check meta info
+  auto h_y_sparse = p_sparse->Info().labels.HostView();
+  auto h_y = p_fmat->Info().labels.HostView();
+  for (std::size_t i = 0, m = h_y_sparse.Shape(0); i < m; ++i) {
+    for (std::size_t j = 0, n = h_y_sparse.Shape(1); j < n; ++j) {
+      ASSERT_EQ(h_y(i, j), h_y_sparse(i, j));
+    }
+  }
+}
+}  // namespace xgboost::data

--- a/tests/cpp/data/test_extmem_quantile_dmatrix.h
+++ b/tests/cpp/data/test_extmem_quantile_dmatrix.h
@@ -9,7 +9,7 @@
 
 namespace xgboost::data {
 template <typename Page, typename Equal>
-void TestExtMemQdmBasic(Context const* ctx, float sparsity, Equal&& check_equal) {
+void TestExtMemQdmBasic(Context const* ctx, bool on_host, float sparsity, Equal&& check_equal) {
   bst_idx_t n_samples = 256, n_features = 16, n_batches = 4;
   bst_bin_t max_bin = 64;
   bst_target_t n_targets = 3;
@@ -20,6 +20,7 @@ void TestExtMemQdmBasic(Context const* ctx, float sparsity, Equal&& check_equal)
                     .Batches(n_batches)
                     .Targets(n_targets)
                     .Device(ctx->Device())
+                    .OnHost(on_host)
                     .GenerateExtMemQuantileDMatrix("temp", true);
   ASSERT_FALSE(p_fmat->SingleColBlock());
 
@@ -50,6 +51,8 @@ void TestExtMemQdmBasic(Context const* ctx, float sparsity, Equal&& check_equal)
                       .Bins(max_bin)
                       .Batches(n_batches)
                       .Targets(n_targets)
+                      .Device(ctx->Device())
+                      .OnHost(on_host)
                       .GenerateSparsePageDMatrix("temp", true);
   auto it = p_fmat->GetBatches<Page>(ctx, p).begin();
   for (auto const& page : p_sparse->GetBatches<Page>(ctx, p)) {

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -487,7 +487,8 @@ void RandomDataGenerator::GenerateCSR(
       DMatrix::Create(static_cast<DataIterHandle>(iter.get()), iter->Proxy(), nullptr, Reset, Next,
                       std::numeric_limits<float>::quiet_NaN(), 0, this->bins_, prefix)};
 
-  auto page_path = data::MakeId(prefix, p_fmat.get()) + ".gradient_index.page";
+  auto page_path = data::MakeId(prefix, p_fmat.get());
+  page_path += device_.IsCPU() ? ".gradient_index.page" : ".ellpack.page";
   EXPECT_TRUE(FileExists(page_path)) << page_path;
 
   if (with_label) {

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -483,13 +483,15 @@ void RandomDataGenerator::GenerateCSR(
   }
   CHECK(iter);
 
-  std::shared_ptr<DMatrix> p_fmat{
-      DMatrix::Create(static_cast<DataIterHandle>(iter.get()), iter->Proxy(), nullptr, Reset, Next,
-                      std::numeric_limits<float>::quiet_NaN(), 0, this->bins_, prefix)};
+  std::shared_ptr<DMatrix> p_fmat{DMatrix::Create(
+      static_cast<DataIterHandle>(iter.get()), iter->Proxy(), nullptr, Reset, Next,
+      std::numeric_limits<float>::quiet_NaN(), 0, this->bins_, prefix, this->on_host_)};
 
   auto page_path = data::MakeId(prefix, p_fmat.get());
   page_path += device_.IsCPU() ? ".gradient_index.page" : ".ellpack.page";
-  EXPECT_TRUE(FileExists(page_path)) << page_path;
+  if (!this->on_host_) {
+    EXPECT_TRUE(FileExists(page_path)) << page_path;
+  }
 
   if (with_label) {
     RandomDataGenerator{static_cast<bst_idx_t>(p_fmat->Info().num_row_), this->n_targets_, 0.0f}


### PR DESCRIPTION
The second part of https://github.com/dmlc/xgboost/pull/10682 .

This PR adds basic GPU support for the  external memory QDM, some features still need to be worked on:

TO-DO:
- Interpolation between CPU and GPU.
- Exporting data to CSR.
- Expose the features to the interface.

In addition, we will change the GPU updater to support batch-based training in the coming PRs. I haven't decided whether we should support the page concatenation in the future. It will depend on the difficulty of supporting two batch-based training paradigms.