### PR TITLE
[doc] [R] clarify lintr docs

### DIFF
--- a/doc/contrib/coding_guide.rst
+++ b/doc/contrib/coding_guide.rst
@@ -134,6 +134,7 @@ To run checks for R:
 .. code-block:: bash
 
   cd /path/to/xgboost/
+  R CMD INSTALL R-package/
   Rscript tests/ci_build/lint_r.R $(pwd)
 
 To run checks for cpplint locally:


### PR DESCRIPTION
Fixes #10455

Clarifies how to run the R linting checks. That is already documented at https://xgboost.readthedocs.io/en/stable/contrib/coding_guide.html#running-formatting-checks-locally, but this clarifies that the library must be installed for the linter to pass.

Without the library installed ...

```shell
Rscript -e "remove.packages('xgboost')"
Rscript tests/ci_build/lint_r.R $(pwd)
```

yields 500+ instances of this error (for different files and lines):

```text
xgboost/R-package/tests/testthat/test_model_compatibility.R:18:11: warning: [object_usage_linter] no visible global function definition for 'xgb.dump'
  dump <- xgb.dump(booster)
          ^~~~~~~~
```