### PR TITLE
SYCL. Fix sampling for devices without fp64 support

### DIFF
--- a/plugin/sycl/tree/hist_updater.h
+++ b/plugin/sycl/tree/hist_updater.h
@@ -67,6 +67,7 @@ class HistUpdater {
     if (param.max_depth > 0) {
       snode_device_.Resize(&qu, 1u << (param.max_depth + 1));
     }
+    has_fp64_support_ = qu_.get_device().has(::sycl::aspect::fp64);
     const auto sub_group_sizes =
       qu_.get_device().get_info<::sycl::info::device::sub_group_sizes>();
     sub_group_size_ = sub_group_sizes.back();
@@ -183,6 +184,7 @@ class HistUpdater {
 
   //  --data fields--
   const Context* ctx_;
+  bool has_fp64_support_;
   size_t sub_group_size_;
 
   // the internal row sets


### PR DESCRIPTION
Currently sampling for `sycl`-devices uses `oneDPL `library for generation of bernoulli distribution. Unfortunately, `oneDPL `implicitly uses `fp64 `for bernoulli, that makes impossible to launch fitting on `sycl `devices without `fp64 `support.
This PR fix this issue by adding specialized code for such cases.