### PR TITLE
ignore UBJSON files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ target
 *.gcov
 *.gcda
 *.gcno
+*.ubj
 build_tests
 /tests/cpp/xgboost_test
 


### PR DESCRIPTION
Proposes gitignore-ing `.ubj` files.

There are none currently in source control:

```shell
git ls-files | grep ubj
```

And a file `test.ubj` is created by running the C++ tests.

```shell
cmake -B build -S . -GNinja -DGOOGLE_TEST=ON -DUSE_DMLC_GTEST=O
cmake --build build -j4
./build/testxgboost
```

Thanks for your time and consideration.