### PR TITLE
[R] Keep row names in predictions

### DIFF
--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -354,6 +354,11 @@ predict.xgb.Booster <- function(object, newdata, missing = NA, outputmargin = FA
       " Should be passed as argument to 'xgb.DMatrix' constructor."
     )
   }
+  if (is_dmatrix) {
+    rnames <- NULL
+  } else {
+    rnames <- row.names(newdata)
+  }
 
   use_as_df <- FALSE
   use_as_dense_matrix <- FALSE
@@ -499,6 +504,19 @@ predict.xgb.Booster <- function(object, newdata, missing = NA, outputmargin = FA
     dim_names[[1L]] <- cnames
     if (predinteraction) dim_names[[2L]] <- cnames
     .Call(XGSetArrayDimNamesInplace_R, arr, dim_names)
+  }
+
+  if (NROW(rnames)) {
+    if (is.null(dim(arr))) {
+      .Call(XGSetVectorNamesInplace_R, arr, rnames)
+    } else {
+      dim_names <- dimnames(arr)
+      if (is.null(dim_names)) {
+        dim_names <- vector(mode = "list", length = length(dim(arr)))
+      }
+      dim_names[[length(dim_names)]] <- rnames
+      .Call(XGSetArrayDimNamesInplace_R, arr, dim_names)
+    }
   }
 
   if (!avoid_transpose && is.array(arr)) {

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -46,6 +46,7 @@ extern SEXP XGBoosterSetParam_R(SEXP, SEXP, SEXP);
 extern SEXP XGBoosterUpdateOneIter_R(SEXP, SEXP, SEXP);
 extern SEXP XGCheckNullPtr_R(SEXP);
 extern SEXP XGSetArrayDimNamesInplace_R(SEXP, SEXP);
+extern SEXP XGSetVectorNamesInplace_R(SEXP, SEXP);
 extern SEXP XGDMatrixCreateFromCSC_R(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP XGDMatrixCreateFromCSR_R(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP XGDMatrixCreateFromURI_R(SEXP, SEXP, SEXP);
@@ -108,6 +109,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"XGBoosterUpdateOneIter_R",    (DL_FUNC) &XGBoosterUpdateOneIter_R,    3},
   {"XGCheckNullPtr_R",            (DL_FUNC) &XGCheckNullPtr_R,            1},
   {"XGSetArrayDimNamesInplace_R", (DL_FUNC) &XGSetArrayDimNamesInplace_R, 2},
+  {"XGSetVectorNamesInplace_R",   (DL_FUNC) &XGSetVectorNamesInplace_R,   2},
   {"XGDMatrixCreateFromCSC_R",    (DL_FUNC) &XGDMatrixCreateFromCSC_R,    6},
   {"XGDMatrixCreateFromCSR_R",    (DL_FUNC) &XGDMatrixCreateFromCSR_R,    6},
   {"XGDMatrixCreateFromURI_R",    (DL_FUNC) &XGDMatrixCreateFromURI_R,    3},

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -335,6 +335,11 @@ XGB_DLL SEXP XGSetArrayDimNamesInplace_R(SEXP arr, SEXP dim_names) {
   return R_NilValue;
 }
 
+XGB_DLL SEXP XGSetVectorNamesInplace_R(SEXP arr, SEXP names) {
+  Rf_setAttrib(arr, R_NamesSymbol, names);
+  return R_NilValue;
+}
+
 namespace {
 void _DMatrixFinalizer(SEXP ext) {
   R_API_BEGIN();

--- a/R-package/src/xgboost_R.h
+++ b/R-package/src/xgboost_R.h
@@ -35,6 +35,14 @@ XGB_DLL SEXP XGCheckNullPtr_R(SEXP handle);
 XGB_DLL SEXP XGSetArrayDimNamesInplace_R(SEXP arr, SEXP dim_names);
 
 /*!
+ * \brief set the names of a vector in-place
+ * \param arr
+ * \param names names for the dimensions to set
+ * \return NULL value
+ */
+XGB_DLL SEXP XGSetVectorNamesInplace_R(SEXP arr, SEXP names);
+
+/*!
  * \brief Set global configuration
  * \param json_str a JSON string representing the list of key-value pairs
  * \return R_NilValue

--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -493,6 +493,7 @@ test_that("xgb.DMatrix: ExternalDMatrix produces the same results as regular DMa
     nrounds = 5
   )
   pred <- predict(model, x)
+  pred <- unname(pred)
 
   iterator_env <- as.environment(
     list(
@@ -538,7 +539,7 @@ test_that("xgb.DMatrix: ExternalDMatrix produces the same results as regular DMa
   )
 
   pred_model1_edm <- predict(model, edm)
-  pred_model2_mat <- predict(model_ext, x)
+  pred_model2_mat <- predict(model_ext, x) |> unname()
   pred_model2_edm <- predict(model_ext, edm)
 
   expect_equal(pred_model1_edm, pred)
@@ -567,6 +568,7 @@ test_that("xgb.DMatrix: External QDM produces same results as regular QDM", {
     nrounds = 5
   )
   pred <- predict(model, x)
+  pred <- unname(pred)
 
   iterator_env <- as.environment(
     list(
@@ -616,7 +618,7 @@ test_that("xgb.DMatrix: External QDM produces same results as regular QDM", {
   )
 
   pred_model1_qdm <- predict(model, qdm)
-  pred_model2_mat <- predict(model_ext, x)
+  pred_model2_mat <- predict(model_ext, x) |> unname()
   pred_model2_qdm <- predict(model_ext, qdm)
 
   expect_equal(pred_model1_qdm, pred)


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

This MR modified the logic of `predict` to keep row names in the output if the input had them.