### PR TITLE
[doc] document how to install the GPU variant in environments without CUDA

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -107,6 +107,13 @@ Conda should be able to detect the existence of a GPU on your machine and instal
    # Use NVIDIA GPU
    conda install -c conda-forge py-xgboost-gpu
 
+To force the installation of the GPU variant on a machine that does not have an NVIDIA GPU, use environment variable ``CONDA_OVERRIDE_CUDA``,
+as described in `"Managing Virtual Packages" in the conda docs <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html>`_.
+
+.. code-block:: bash
+
+  export CONDA_OVERRIDE_CUDA="12.5"
+  conda install -c conda-forge py-xgboost-gpu
 
 Visit the `Miniconda website <https://docs.conda.io/en/latest/miniconda.html>`_ to obtain Conda.
 


### PR DESCRIPTION
Fixes #10715

Adds a note to the installation docs about how to force `conda` to install `py-xgboost-gpu` on a system without an NVIDIA GPU.

## Notes for Reviewers

### How I tested this

In Docker, on an M2 mac (no CUDA, no NVIDIA GPU)

```shell
docker run \
    --rm \
    -it ghcr.io/dask/dask \
    bash
```

Tried first without setting that variable.

```shell
conda install --dry-run \
    -c conda-forge \
    'py-xgboost-gpu>=2.0'
```

After 20+ minutes, conda was still trying to solve...I strongly suspect it would have eventually failed,
with the error seen in #10715.

Added the environment variable and tried again.

```shell
CONDA_OVERRIDE_CUDA="12.5" \
conda install --dry-run \
    -c conda-forge \
    py-xgboost-gpu
```

That succeeded in a few seconds.

```text
The following NEW packages will be INSTALLED:

  _py-xgboost-mutex  conda-forge/linux-64::_py-xgboost-mutex-2.0-gpu_0 
  cuda-version       conda-forge/noarch::cuda-version-12.6-h7480c83_3 
  ...
  libxgboost         conda-forge/linux-64::libxgboost-2.1.1-cuda120_h9dfd3e9_1 
  nccl               conda-forge/linux-64::nccl-2.22.3.1-hbc370b7_1 
  py-xgboost         conda-forge/noarch::py-xgboost-2.1.1-cuda120_pyhc555c4d_1 
  py-xgboost-gpu     conda-forge/noarch::py-xgboost-gpu-2.1.1-pyhc629091_1 
  ...
```
