### PR TITLE
[coll] Improve column split tests with named threads.

### DIFF
--- a/include/xgboost/windefs.h
+++ b/include/xgboost/windefs.h
@@ -30,4 +30,4 @@
 
 #endif  // xgboost_IS_MINGW
 
-#endif  // defined(xgboost_IS_WIN)
+#endif  // !defined(xgboost_IS_WIN)

--- a/src/collective/loop.cc
+++ b/src/collective/loop.cc
@@ -271,5 +271,11 @@ Loop::Loop(std::chrono::seconds timeout) : timeout_{timeout} {
   worker_ = std::thread{[this] {
     this->Process();
   }};
+#if defined(__linux__)
+  auto ret = pthread_setname_np(worker_.native_handle(), "loop-worker");
+  if (ret != 0) {
+    LOG(WARNING) << "Failed to name thread:" << ret;
+  }
+#endif
 }
 }  // namespace xgboost::collective

--- a/src/collective/loop.cc
+++ b/src/collective/loop.cc
@@ -14,6 +14,7 @@
 #include <thread>     // for thread
 #include <utility>    // for move
 
+#include "../common/threading_utils.h"      // for NameThread
 #include "xgboost/collective/poll_utils.h"  // for PollHelper
 #include "xgboost/collective/result.h"      // for Fail, Success
 #include "xgboost/collective/socket.h"      // for FailWithCode
@@ -271,11 +272,6 @@ Loop::Loop(std::chrono::seconds timeout) : timeout_{timeout} {
   worker_ = std::thread{[this] {
     this->Process();
   }};
-#if defined(__linux__)
-  auto ret = pthread_setname_np(worker_.native_handle(), "loop-worker");
-  if (ret != 0) {
-    LOG(WARNING) << "Failed to name thread:" << ret;
-  }
-#endif
+  common::NameThread(&worker_, "lw");
 }
 }  // namespace xgboost::collective

--- a/src/collective/tracker.cc
+++ b/src/collective/tracker.cc
@@ -23,6 +23,7 @@
 #include <utility>    // for move, forward
 
 #include "../common/json_utils.h"
+#include "../common/threading_utils.h"  // for NameThread
 #include "comm.h"
 #include "protocol.h"  // for kMagic, PeerInfo
 #include "tracker.h"
@@ -143,6 +144,8 @@ Result RabitTracker::Bootstrap(std::vector<WorkerProxy>* p_workers) {
       Json::Dump(jnext, &str);
       worker.Send(StringView{str});
     });
+    std::string name = "tkbs_t-" + std::to_string(r);
+    common::NameThread(&bootstrap_threads.back(), name.c_str());
   }
 
   for (auto& t : bootstrap_threads) {

--- a/src/common/threading_utils.cc
+++ b/src/common/threading_utils.cc
@@ -11,9 +11,7 @@
 
 #include "common.h"           // for DivRoundUp
 
-#if defined(xgboost_IS_WIN)
-#include <processthreadsapi.h>
-#else
+#if defined(__linux__)
 #include <pthread.h>
 #endif
 

--- a/src/common/threading_utils.cc
+++ b/src/common/threading_utils.cc
@@ -10,7 +10,6 @@
 #include <string>      // for string
 
 #include "common.h"           // for DivRoundUp
-#include "xgboost/windefs.h"  // for xgboost_IS_WIN
 
 #if defined(xgboost_IS_WIN)
 #include <processthreadsapi.h>
@@ -122,13 +121,8 @@ std::int32_t OmpGetNumThreads(std::int32_t n_threads) {
 }
 
 void NameThread(std::thread* t, StringView name) {
+#if defined(__linux__)
   auto handle = t->native_handle();
-#if defined(xgboost_IS_WIN)
-  HRESULT ret = SetThreadDescription(handle, name.c_str());
-  if (FAILED(ret)) {
-    LOG(WARNING) << "Failed to name thread:" << ret;
-  }
-#else
   char old[16];
   auto ret = pthread_getname_np(handle, old, 16);
   if (ret != 0) {
@@ -142,6 +136,9 @@ void NameThread(std::thread* t, StringView name) {
   if (ret != 0) {
     LOG(WARNING) << "Failed to name thread:" << ret << " :" << new_name;
   }
+#else
+  (void)name;
+  (void)t;
 #endif
 }
 }  // namespace xgboost::common

--- a/src/common/threading_utils.cc
+++ b/src/common/threading_utils.cc
@@ -129,9 +129,18 @@ void NameThread(std::thread* t, StringView name) {
     LOG(WARNING) << "Failed to name thread:" << ret;
   }
 #else
-  auto ret = pthread_setname_np(handle, name.c_str());
+  char old[16];
+  auto ret = pthread_getname_np(handle, old, 16);
   if (ret != 0) {
-    LOG(WARNING) << "Failed to name thread:" << ret;
+    LOG(WARNING) << "Failed to get the name from thread";
+  }
+  auto new_name = std::string{old} + ">" + name.c_str();
+  if (new_name.size() > 15) {
+    new_name = new_name.substr(new_name.size() - 15);
+  }
+  ret = pthread_setname_np(handle, new_name.c_str());
+  if (ret != 0) {
+    LOG(WARNING) << "Failed to name thread:" << ret << " :" << new_name;
   }
 #endif
 }

--- a/src/common/threading_utils.cc
+++ b/src/common/threading_utils.cc
@@ -126,7 +126,7 @@ void NameThread(std::thread* t, StringView name) {
   if (ret != 0) {
     LOG(WARNING) << "Failed to get the name from thread";
   }
-  auto new_name = std::string{old} + ">" + name.c_str();
+  auto new_name = std::string{old} + ">" + name.c_str();  // NOLINT
   if (new_name.size() > 15) {
     new_name = new_name.substr(new_name.size() - 15);
   }

--- a/src/common/threading_utils.h
+++ b/src/common/threading_utils.h
@@ -311,7 +311,7 @@ class MemStackAllocator {
 std::int32_t constexpr DefaultMaxThreads() { return 128; }
 
 /**
- * @brief Give the thread a name.
+ * @brief Give the thread a name. Supports only pthread on linux.
  */
 void NameThread(std::thread* t, StringView name);
 }  // namespace xgboost::common

--- a/src/common/threading_utils.h
+++ b/src/common/threading_utils.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023 by XGBoost Contributors
+ * Copyright 2019-2024, XGBoost Contributors
  */
 #ifndef XGBOOST_COMMON_THREADING_UTILS_H_
 #define XGBOOST_COMMON_THREADING_UTILS_H_
@@ -11,12 +11,13 @@
 #include <cstddef>      // for size_t
 #include <cstdint>      // for int32_t
 #include <cstdlib>      // for malloc, free
-#include <functional>   // for function
 #include <new>          // for bad_alloc
+#include <thread>       // for thread
 #include <type_traits>  // for is_signed, conditional_t, is_integral_v, invoke_result_t
 #include <vector>       // for vector
 
 #include "xgboost/logging.h"
+#include "xgboost/string_view.h"  // for StringView
 
 #if !defined(_OPENMP)
 extern "C" {
@@ -308,6 +309,11 @@ class MemStackAllocator {
  * \brief Constant that can be used for initializing static thread local memory.
  */
 std::int32_t constexpr DefaultMaxThreads() { return 128; }
+
+/**
+ * @brief Give the thread a name.
+ */
+void NameThread(std::thread* t, StringView name);
 }  // namespace xgboost::common
 
 #endif  // XGBOOST_COMMON_THREADING_UTILS_H_

--- a/src/common/threadpool.h
+++ b/src/common/threadpool.h
@@ -9,13 +9,14 @@
 #include <memory>              // for make_shared
 #include <mutex>               // for mutex, unique_lock
 #include <queue>               // for queue
+#include <string>              // for string
 #include <thread>              // for thread
 #include <type_traits>         // for invoke_result_t
 #include <utility>             // for move
 #include <vector>              // for vector
 
-#include "xgboost/string_view.h"  // for StringView
 #include "threading_utils.h"      // for NameThread
+#include "xgboost/string_view.h"  // for StringView
 
 namespace xgboost::common {
 /**
@@ -59,7 +60,7 @@ class ThreadPool {
           fn();
         }
       });
-      std::string name_i = name.c_str() + std::string{"-"} + std::to_string(i);
+      std::string name_i = name.c_str() + std::string{"-"} + std::to_string(i);  // NOLINT
       NameThread(&pool_.back(), name_i);
     }
   }

--- a/src/data/sparse_page_source.h
+++ b/src/data/sparse_page_source.h
@@ -336,7 +336,7 @@ class SparsePageSourceImpl : public BatchIteratorImpl<S>, public FormatStreamPol
  public:
   SparsePageSourceImpl(float missing, int nthreads, bst_feature_t n_features, bst_idx_t n_batches,
                        std::shared_ptr<Cache> cache)
-      : workers_{std::max(2, std::min(nthreads, 16)), InitNewThread{}},
+      : workers_{StringView{"ext-mem"}, std::max(2, std::min(nthreads, 16)), InitNewThread{}},
         missing_{missing},
         nthreads_{nthreads},
         n_features_{n_features},

--- a/tests/cpp/collective/test_worker.h
+++ b/tests/cpp/collective/test_worker.h
@@ -178,7 +178,7 @@ void TestDistributedGlobal(std::int32_t n_workers, WorkerFn worker_fn, bool need
       fut.get();
     });
 
-    std::string name = "test-worker-" + std::to_string(i);
+    std::string name = "tw-" + std::to_string(i);
     common::NameThread(&workers.back(), name.c_str());
   }
 

--- a/tests/cpp/collective/test_worker.h
+++ b/tests/cpp/collective/test_worker.h
@@ -199,7 +199,7 @@ class BaseMGPUTest : public ::testing::Test {
    *                          available.
    */
   template <typename Fn>
-  auto DoTest(Fn&& fn, bool is_federated, bool emulate_if_single = false) const {
+  auto DoTest(Fn&& fn, bool is_federated, [[maybe_unused]] bool emulate_if_single = false) const {
     auto n_gpus = common::AllVisibleGPUs();
     if (is_federated) {
 #if defined(XGBOOST_USE_FEDERATED)

--- a/tests/cpp/collective/test_worker.h
+++ b/tests/cpp/collective/test_worker.h
@@ -12,10 +12,11 @@
 #include <utility>  // for move
 #include <vector>   // for vector
 
-#include "../../../src/collective/comm.h"
+#include "../../../src/collective/comm.h"              // for RabitComm
 #include "../../../src/collective/communicator-inl.h"  // for Init, Finalize
 #include "../../../src/collective/tracker.h"           // for GetHostAddress
 #include "../../../src/common/cuda_rt_utils.h"         // for AllVisibleGPUs
+#include "../../../src/common/threading_utils.h"       // for NameThread
 #include "../helpers.h"                                // for FileExists
 
 #if defined(XGBOOST_USE_FEDERATED)
@@ -176,6 +177,9 @@ void TestDistributedGlobal(std::int32_t n_workers, WorkerFn worker_fn, bool need
       CHECK(status == std::future_status::ready) << "Test timeout";
       fut.get();
     });
+
+    std::string name = "test-worker-" + std::to_string(i);
+    common::NameThread(&workers.back(), name.c_str());
   }
 
   for (auto& t : workers) {

--- a/tests/cpp/common/test_threadpool.cc
+++ b/tests/cpp/common/test_threadpool.cc
@@ -21,7 +21,7 @@ TEST(ThreadPool, Basic) {
   // 4 is an invalid value, it's only possible to set it by bypassing the parameter
   // validation.
   ASSERT_NE(orig, GlobalConfigThreadLocalStore::Get()->verbosity);
-  ThreadPool pool{n_threads, [config = *GlobalConfigThreadLocalStore::Get()] {
+  ThreadPool pool{StringView{"test"}, n_threads, [config = *GlobalConfigThreadLocalStore::Get()] {
                     *GlobalConfigThreadLocalStore::Get() = config;
                   }};
   GlobalConfigThreadLocalStore::Get()->verbosity = orig;  // restore

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -781,7 +781,8 @@ void TestColumnSplitWithArgs(std::string const& tree_method, bool use_gpu, Args 
     }
 #endif  //  defined(XGBOOST_USE_NCCL)
     collective::TestDistributedGlobal(
-        world_size, [&] { VerifyColumnSplitWithArgs(tree_method, use_gpu, args, model); });
+        world_size, [&] { VerifyColumnSplitWithArgs(tree_method, use_gpu, args, model); }, true,
+        std::chrono::seconds{3000});
   }
 }
 

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -781,8 +781,7 @@ void TestColumnSplitWithArgs(std::string const& tree_method, bool use_gpu, Args 
     }
 #endif  //  defined(XGBOOST_USE_NCCL)
     collective::TestDistributedGlobal(
-        world_size, [&] { VerifyColumnSplitWithArgs(tree_method, use_gpu, args, model); }, true,
-        std::chrono::seconds{3000});
+        world_size, [&] { VerifyColumnSplitWithArgs(tree_method, use_gpu, args, model); });
   }
 }
 


### PR DESCRIPTION
- Name some of the threads for easier debugging.
- Use the `MGPU` prefix for running tests on the CI.

Tried to debug https://github.com/dmlc/xgboost/issues/10312 , the hang comes from inside CTK host malloc, I don't have a fix yet. Upstreaming some of the enhancements.