### PR TITLE
musl libc support

### DIFF
--- a/include/xgboost/collective/poll_utils.h
+++ b/include/xgboost/collective/poll_utils.h
@@ -35,13 +35,7 @@
 
 #if !defined(_WIN32)
 
-#define _GNU_SOURCE
-#include <features.h>
-#ifndef __USE_GNU
-    #define __MUSL__
-#endif
-#undef _GNU_SOURCE
-
+#include "xgboost/unixdefs.h"
 #ifdef __MUSL__
 #include <poll.h>
 #else

--- a/include/xgboost/collective/poll_utils.h
+++ b/include/xgboost/collective/poll_utils.h
@@ -35,7 +35,18 @@
 
 #if !defined(_WIN32)
 
+#define _GNU_SOURCE
+#include <features.h>
+#ifndef __USE_GNU
+    #define __MUSL__
+#endif
+#undef _GNU_SOURCE
+
+#ifdef __MUSL__
+#include <poll.h>
+#else
 #include <sys/poll.h>
+#endif
 
 using SOCKET = int;
 using sock_size_t = size_t;  // NOLINT

--- a/include/xgboost/unixdefs.h
+++ b/include/xgboost/unixdefs.h
@@ -1,0 +1,14 @@
+#if defined(UNIXDEFS_H) && !defined(_MSC_VER) && \
+    !defined(__MINGW32__) && !defined(__CYGWIN__) && \
+    !defined(_WIN32) && !defined(__WINDOWS__) && \
+    !defined(__MUSL__)
+#define UNIXDEFS_H
+
+#define _GNU_SOURCE
+#include <features.h>
+#ifndef __USE_GNU
+    #define __MUSL__
+#endif
+#undef _GNU_SOURCE
+
+#endif

--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -7,13 +7,7 @@
 #include <sys/mman.h>  // for mmap, mmap64, munmap, madvise
 #include <unistd.h>    // for close, getpagesize
 
-#define _GNU_SOURCE
-#include <features.h>
-#ifndef __USE_GNU
-    #define __MUSL__ 
-#endif
-#undef _GNU_SOURCE
-
+#include "xgboost/unixdefs.h"
 #ifdef __MUSL__
 #define mmap64 mmap
 #endif

--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -7,6 +7,17 @@
 #include <sys/mman.h>  // for mmap, mmap64, munmap, madvise
 #include <unistd.h>    // for close, getpagesize
 
+#define _GNU_SOURCE
+#include <features.h>
+#ifndef __USE_GNU
+    #define __MUSL__ 
+#endif
+#undef _GNU_SOURCE
+
+#ifdef __MUSL__
+#define mmap64 mmap
+#endif
+
 #else
 
 #include <xgboost/windefs.h>


### PR DESCRIPTION
Warnings are bad! - Found one in your library deep within another:
```
#17 120.2   In file included from /tmp/wd/postgresml/pgml-extension/target/debug/build/xgboost-sys-a1e545b7b843ddb4/out/xgboost/rabit/include/rabit/internal/socket.h:38,
#17 120.2                    from /tmp/wd/postgresml/pgml-extension/target/debug/build/xgboost-sys-a1e545b7b843ddb4/out/xgboost/src/collective/loop.cc:15:
#17 120.2   /usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
#17 120.2       1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
#17 120.2         |  ^~~~~~~
#17 120.2   In file included from /tmp/wd/postgresml/pgml-extension/target/debug/build/xgboost-sys-a1e545b7b843ddb4/out/xgboost/rabit/include/rabit/internal/socket.h:38,
#17 120.2                    from /tmp/wd/postgresml/pgml-extension/target/debug/build/xgboost-sys-a1e545b7b843ddb4/out/xgboost/src/collective/socket.cc:14:
#17 120.2   /usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
#17 120.2       1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
#17 120.2         |  ^~~~~~~
#17 120.2   In file included from /tmp/wd/postgresml/pgml-extension/target/debug/build/xgboost-sys-a1e545b7b843ddb4/out/xgboost/rabit/include/rabit/internal/socket.h:38,
#17 120.2                    from /tmp/wd/postgresml/pgml-extension/target/debug/build/xgboost-sys-a1e545b7b843ddb4/out/xgboost/src/collective/tracker.cc:4:
#17 120.2   /usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
#17 120.2       1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
#17 120.2         |  ^~~~~~~
```

EDIT0: Another one, resolved it same way they did https://github.com/gperftools/gperftools/issues/693' ; a simple `#define mmap64 mmap`

EDIT1: To replicate, here's a `Dockerfile`:
```dockerfile
FROM alpine
RUN apk add --no-cache cmake gcc g++ make musl-dev
WORKDIR /src/xgboost
COPY . .
RUN cmake -S . -B build && \
    cmake --build build
```