### PR TITLE
[R] Safer assignment during deprecation checks

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -562,7 +562,7 @@ check.deprecation <- function(..., env = parent.frame()) {
     }
     .Deprecated(new_par, old = old_par, package = 'xgboost')
     if (new_par != 'NULL') {
-      eval(parse(text = paste(new_par, '<-', pars[[pars_par]])), envir = env)
+      assign(new_par, pars[[pars_par]], envir = env)
     }
   }
 }

--- a/R-package/tests/testthat/test_helpers.R
+++ b/R-package/tests/testthat/test_helpers.R
@@ -487,7 +487,7 @@ test_that("check.deprecation works", {
     res <- ttt(a = 1, dumm = 22, z = 3)
   , "\'dumm\' was partially matched to \'dummy\'")
   expect_equal(res, list(a = 1, DUMMY = 22))
-  
+
   # More complex object to be assigned
   dm <- xgb.DMatrix(cbind(x1 = 1:2, x2 = 2:3), label = 2:3)
   expect_warning(

--- a/R-package/tests/testthat/test_helpers.R
+++ b/R-package/tests/testthat/test_helpers.R
@@ -487,6 +487,15 @@ test_that("check.deprecation works", {
     res <- ttt(a = 1, dumm = 22, z = 3)
   , "\'dumm\' was partially matched to \'dummy\'")
   expect_equal(res, list(a = 1, DUMMY = 22))
+  
+  # More complex object to be assigned
+  dm <- xgb.DMatrix(cbind(x1 = 1:2, x2 = 2:3), label = 2:3)
+  expect_warning(
+    xgb.train(
+      data = dm, watchlist = list(valid = dm), nrounds = 2, nthread = 2, verbose = 0
+    ),
+    "watchlist"
+  )
 })
 
 test_that('convert.labels works', {


### PR DESCRIPTION
Fixes https://github.com/dmlc/xgboost/issues/10726 by using a more stable assignment of deprecated parameters to the paramter list.