### PR TITLE
[EM] Return a full DMatrix instead of a Ellpack from the GPU sampler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ java/xgboost4j-demo/data/
 java/xgboost4j-demo/tmp/
 java/xgboost4j-demo/model/
 nb-configuration*
+
 # Eclipse
 .project
 .cproject
@@ -154,3 +155,6 @@ model*.json
 *.rds
 Rplots.pdf
 *.zip
+
+# nsys
+*.nsys-rep

--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -110,8 +110,15 @@ class MetaInfo {
    * @brief Validate all metainfo.
    */
   void Validate(DeviceOrd device) const;
-
-  MetaInfo Slice(common::Span<int32_t const> ridxs) const;
+  /**
+   * @brief Slice the meta info.
+   *
+   * The device of ridxs is specified by the ctx object.
+   *
+   * @param ridxs Index of selected rows.
+   * @param nnz   The number of non-missing values.
+   */
+  MetaInfo Slice(Context const* ctx, common::Span<bst_idx_t const> ridxs, bst_idx_t nnz) const;
 
   MetaInfo Copy() const;
   /**

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -508,6 +508,11 @@ xgboost::common::Span<T> ToSpan(DeviceUVector<T> &vec) {
   return {vec.data(), vec.size()};
 }
 
+template <typename T>
+xgboost::common::Span<std::add_const_t<T>> ToSpan(DeviceUVector<T> const &vec) {
+  return {vec.data(), vec.size()};
+}
+
 // thrust begin, similiar to std::begin
 template <typename T>
 thrust::device_ptr<T> tbegin(xgboost::HostDeviceVector<T>& vector) {  // NOLINT

--- a/src/common/linalg_op.cuh
+++ b/src/common/linalg_op.cuh
@@ -76,7 +76,7 @@ struct IterOp {
 // returns a thrust iterator for a tensor view.
 template <typename T, std::int32_t kDim>
 auto tcbegin(TensorView<T, kDim> v) {  // NOLINT
-  return dh::MakeTransformIterator<T>(
+  return thrust::make_transform_iterator(
       thrust::make_counting_iterator(0ul),
       detail::IterOp<std::add_const_t<std::remove_const_t<T>>, kDim>{v});
 }
@@ -84,6 +84,17 @@ auto tcbegin(TensorView<T, kDim> v) {  // NOLINT
 template <typename T, std::int32_t kDim>
 auto tcend(TensorView<T, kDim> v) {  // NOLINT
   return tcbegin(v) + v.Size();
+}
+
+template <typename T, std::int32_t kDim>
+auto tbegin(TensorView<T, kDim> v) {  // NOLINT
+  return thrust::make_transform_iterator(thrust::make_counting_iterator(0ul),
+                                         detail::IterOp<std::remove_const_t<T>, kDim>{v});
+}
+
+template <typename T, std::int32_t kDim>
+auto tend(TensorView<T, kDim> v) {  // NOLINT
+  return tbegin(v) + v.Size();
 }
 }  // namespace xgboost::linalg
 #endif  // XGBOOST_COMMON_LINALG_OP_CUH_

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -351,8 +351,10 @@ void MetaInfo::LoadBinary(dmlc::Stream *fi) {
   this->has_categorical_ = LoadFeatureType(feature_type_names, &feature_types.HostVector());
 }
 
+namespace {
 template <typename T>
-std::vector<T> Gather(const std::vector<T> &in, common::Span<int const> ridxs, size_t stride = 1) {
+std::vector<T> Gather(const std::vector<T>& in, common::Span<bst_idx_t const> ridxs,
+                      size_t stride = 1) {
   if (in.empty()) {
     return {};
   }
@@ -361,16 +363,57 @@ std::vector<T> Gather(const std::vector<T> &in, common::Span<int const> ridxs, s
   for (auto i = 0ull; i < size; i++) {
     auto ridx = ridxs[i];
     for (size_t j = 0; j < stride; ++j) {
-      out[i * stride +j] = in[ridx * stride + j];
+      out[i * stride + j] = in[ridx * stride + j];
     }
   }
   return out;
 }
+}  // namespace
 
-MetaInfo MetaInfo::Slice(common::Span<int32_t const> ridxs) const {
+namespace cuda_impl {
+void SliceMetaInfo(Context const* ctx, MetaInfo const& info, common::Span<bst_idx_t const> ridx,
+                   MetaInfo* p_out);
+#if !defined(XGBOOST_USE_CUDA)
+void SliceMetaInfo(Context const*, MetaInfo const&, common::Span<bst_idx_t const>, MetaInfo*) {
+  common::AssertGPUSupport();
+}
+#endif
+}  // namespace cuda_impl
+
+MetaInfo MetaInfo::Slice(Context const* ctx, common::Span<bst_idx_t const> ridxs,
+                         bst_idx_t nnz) const {
+  /**
+   * Shape
+   */
   MetaInfo out;
   out.num_row_ = ridxs.size();
   out.num_col_ = this->num_col_;
+  out.num_nonzero_ = nnz;
+
+  /**
+   * Feature Info
+   */
+
+  out.feature_weights.SetDevice(ctx->Device());
+  out.feature_weights.Resize(this->feature_weights.Size());
+  out.feature_weights.Copy(this->feature_weights);
+
+  out.feature_names = this->feature_names;
+
+  out.feature_types.SetDevice(ctx->Device());
+  out.feature_types.Resize(this->feature_types.Size());
+  out.feature_types.Copy(this->feature_types);
+
+  out.feature_type_names = this->feature_type_names;
+
+  /**
+   * Sample Info
+   */
+  if (ctx->IsCUDA()) {
+    cuda_impl::SliceMetaInfo(ctx, *this, ridxs, &out);
+    return out;
+  }
+
   // Groups is maintained by a higher level Python function.  We should aim at deprecating
   // the slice function.
   if (this->labels.Size() != this->num_row_) {
@@ -386,13 +429,11 @@ MetaInfo MetaInfo::Slice(common::Span<int32_t const> ridxs) const {
     });
   }
 
-  out.labels_upper_bound_.HostVector() =
-      Gather(this->labels_upper_bound_.HostVector(), ridxs);
-  out.labels_lower_bound_.HostVector() =
-      Gather(this->labels_lower_bound_.HostVector(), ridxs);
+  out.labels_upper_bound_.HostVector() = Gather(this->labels_upper_bound_.HostVector(), ridxs);
+  out.labels_lower_bound_.HostVector() = Gather(this->labels_lower_bound_.HostVector(), ridxs);
   // weights
   if (this->weights_.Size() + 1 == this->group_ptr_.size()) {
-    auto& h_weights =  out.weights_.HostVector();
+    auto& h_weights = out.weights_.HostVector();
     // Assuming all groups are available.
     out.weights_.HostVector() = h_weights;
   } else {
@@ -413,14 +454,6 @@ MetaInfo MetaInfo::Slice(common::Span<int32_t const> ridxs) const {
       shape[1] = 1;
     });
   }
-
-  out.feature_weights.Resize(this->feature_weights.Size());
-  out.feature_weights.Copy(this->feature_weights);
-
-  out.feature_names = this->feature_names;
-  out.feature_types.Resize(this->feature_types.Size());
-  out.feature_types.Copy(this->feature_types);
-  out.feature_type_names = this->feature_type_names;
 
   return out;
 }

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -393,7 +393,6 @@ MetaInfo MetaInfo::Slice(Context const* ctx, common::Span<bst_idx_t const> ridxs
   /**
    * Feature Info
    */
-
   out.feature_weights.SetDevice(ctx->Device());
   out.feature_weights.Resize(this->feature_weights.Size());
   out.feature_weights.Copy(this->feature_weights);

--- a/src/data/data.cu
+++ b/src/data/data.cu
@@ -4,6 +4,8 @@
  * \file data.cu
  * \brief Handles setting metainfo from array interface.
  */
+#include <thrust/gather.h>  // for gather
+
 #include "../common/cuda_context.cuh"
 #include "../common/device_helpers.cuh"
 #include "../common/linalg_op.cuh"
@@ -168,6 +170,62 @@ void MetaInfo::SetInfoFromCUDA(Context const& ctx, StringView key, Json array) {
     LOG(FATAL) << "Unknown key for MetaInfo: " << key;
   }
 }
+
+namespace {
+void Gather(Context const* ctx, linalg::MatrixView<float const> in,
+            common::Span<bst_idx_t const> ridx, linalg::Matrix<float>* p_out) {
+  if (in.Empty()) {
+    return;
+  }
+  auto& out = *p_out;
+  out.Reshape(ridx.size(), in.Shape(1));
+  auto d_out = out.View(ctx->Device());
+
+  auto cuctx = ctx->CUDACtx();
+  auto map_it = thrust::make_transform_iterator(thrust::make_counting_iterator(0ull),
+                                                [=] XGBOOST_DEVICE(bst_idx_t i) {
+                                                  auto [r, c] = linalg::UnravelIndex(i, in.Shape());
+                                                  return (ridx[r] * in.Shape(1)) + c;
+                                                });
+  CHECK_NE(in.Shape(1), 0);
+  thrust::gather(cuctx->TP(), map_it, map_it + (ridx.size() * in.Shape(1)), linalg::tcbegin(in),
+                 linalg::tbegin(d_out));
+}
+
+template <typename T>
+void Gather(Context const* ctx, HostDeviceVector<T> const& in, common::Span<bst_idx_t const> ridx,
+            HostDeviceVector<T>* p_out) {
+  if (in.Empty()) {
+    return;
+  }
+  in.SetDevice(ctx->Device());
+
+  auto& out = *p_out;
+  out.SetDevice(ctx->Device());
+  out.Resize(ridx.size());
+  auto d_out = out.DeviceSpan();
+
+  auto cuctx = ctx->CUDACtx();
+  auto d_in = in.ConstDeviceSpan();
+  thrust::gather(cuctx->TP(), dh::tcbegin(ridx), dh::tcend(ridx), dh::tcbegin(d_in),
+                 dh::tbegin(d_out));
+}
+}  // anonymous namespace
+
+namespace cuda_impl {
+void SliceMetaInfo(Context const* ctx, MetaInfo const& info, common::Span<bst_idx_t const> ridx,
+                   MetaInfo* p_out) {
+  auto& out = *p_out;
+
+  Gather(ctx, info.labels.View(ctx->Device()), ridx, &p_out->labels);
+  Gather(ctx, info.base_margin_.View(ctx->Device()), ridx, &p_out->base_margin_);
+
+  Gather(ctx, info.labels_lower_bound_, ridx, &out.labels_lower_bound_);
+  Gather(ctx, info.labels_upper_bound_, ridx, &out.labels_upper_bound_);
+
+  Gather(ctx, info.weights_, ridx, &out.weights_);
+}
+}  // namespace cuda_impl
 
 template <typename AdapterT>
 DMatrix* DMatrix::Create(AdapterT* adapter, float missing, int nthread,

--- a/src/data/data.cu
+++ b/src/data/data.cu
@@ -188,7 +188,7 @@ void Gather(Context const* ctx, linalg::MatrixView<float const> in,
                                                   return (ridx[r] * in.Shape(1)) + c;
                                                 });
   CHECK_NE(in.Shape(1), 0);
-  thrust::gather(cuctx->TP(), map_it, map_it + (ridx.size() * in.Shape(1)), linalg::tcbegin(in),
+  thrust::gather(cuctx->TP(), map_it, map_it + out.Size(), linalg::tcbegin(in),
                  linalg::tbegin(d_out));
 }
 

--- a/src/data/data.cu
+++ b/src/data/data.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2022 by XGBoost Contributors
+ * Copyright 2019-2024, XGBoost Contributors
  *
  * \file data.cu
  * \brief Handles setting metainfo from array interface.

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -236,6 +236,11 @@ class EllpackPageImpl {
   [[nodiscard]] EllpackDeviceAccessor GetHostAccessor(
       Context const* ctx, std::vector<common::CompressedByteT>* h_gidx_buffer,
       common::Span<FeatureType const> feature_types = {}) const;
+  /**
+   * @brief Calculate the number of non-missing values.
+   */
+  [[nodiscard]] bst_idx_t NumNonMissing(Context const* ctx,
+                                        common::Span<FeatureType const> feature_types) const;
 
  private:
   /**

--- a/src/data/iterative_dmatrix.cu
+++ b/src/data/iterative_dmatrix.cu
@@ -101,6 +101,17 @@ void IterativeDMatrix::InitFromCUDA(Context const* ctx, BatchParam const& p,
   // Synchronise worker columns
 }
 
+IterativeDMatrix::IterativeDMatrix(std::shared_ptr<EllpackPage> ellpack, MetaInfo const& info,
+                                   BatchParam batch) {
+  this->ellpack_ = ellpack;
+  CHECK_EQ(this->Info().num_row_, 0);
+  CHECK_EQ(this->Info().num_col_, 0);
+  this->Info().Extend(info, true, true);
+  this->Info().num_nonzero_ = info.num_nonzero_;
+  CHECK_EQ(this->Info().num_row_, info.num_row_);
+  this->batch_ = batch;
+}
+
 BatchSet<EllpackPage> IterativeDMatrix::GetEllpackBatches(Context const* ctx,
                                                           BatchParam const& param) {
   if (param.Initialized()) {

--- a/src/data/iterative_dmatrix.h
+++ b/src/data/iterative_dmatrix.h
@@ -48,6 +48,11 @@ class IterativeDMatrix : public QuantileDMatrix {
                             std::shared_ptr<DMatrix> ref, DataIterResetCallback *reset,
                             XGDMatrixCallbackNext *next, float missing, int nthread,
                             bst_bin_t max_bin);
+  /**
+   * @param Directly construct a QDM from an existing one.
+   */
+  IterativeDMatrix(std::shared_ptr<EllpackPage> ellpack, MetaInfo const &info, BatchParam batch);
+
   ~IterativeDMatrix() override = default;
 
   bool EllpackExists() const override { return static_cast<bool>(ellpack_); }

--- a/src/tree/gpu_hist/gradient_based_sampler.cu
+++ b/src/tree/gpu_hist/gradient_based_sampler.cu
@@ -14,12 +14,12 @@
 
 #include "../../common/cuda_context.cuh"  // for CUDAContext
 #include "../../common/random.h"
+#include "../../data/ellpack_page.cuh"     // for EllpackPageImpl
+#include "../../data/iterative_dmatrix.h"  // for IterativeDMatrix
 #include "../param.h"
 #include "gradient_based_sampler.cuh"
 
-namespace xgboost {
-namespace tree {
-
+namespace xgboost::tree {
 /*! \brief A functor that returns random weights. */
 class RandomWeight : public thrust::unary_function<size_t, float> {
  public:
@@ -58,12 +58,14 @@ struct IsNonZero : public thrust::unary_function<GradientPair, bool> {
 };
 
 /*! \brief A functor that clears the row indexes with empty gradient. */
-struct ClearEmptyRows : public thrust::binary_function<GradientPair, size_t, size_t> {
+struct ClearEmptyRows : public thrust::binary_function<GradientPair, bst_idx_t, bst_idx_t> {
+  static constexpr bst_idx_t InvalidRow() { return std::numeric_limits<std::size_t>::max(); }
+
   XGBOOST_DEVICE size_t operator()(const GradientPair& gpair, size_t row_index) const {
     if (gpair.GetGrad() != 0 || gpair.GetHess() != 0) {
       return row_index;
     } else {
-      return std::numeric_limits<std::size_t>::max();
+      return InvalidRow();
     }
   }
 };
@@ -148,10 +150,9 @@ class PoissonSampling : public thrust::binary_function<GradientPair, size_t, Gra
 
 NoSampling::NoSampling(BatchParam batch_param) : batch_param_(std::move(batch_param)) {}
 
-GradientBasedSample NoSampling::Sample(Context const* ctx, common::Span<GradientPair> gpair,
+GradientBasedSample NoSampling::Sample(Context const*, common::Span<GradientPair> gpair,
                                        DMatrix* dmat) {
-  auto page = (*dmat->GetBatches<EllpackPage>(ctx, batch_param_).begin()).Impl();
-  return {dmat->Info().num_row_, page, gpair};
+  return {dmat->Info().num_row_, dmat, gpair};
 }
 
 ExternalMemoryNoSampling::ExternalMemoryNoSampling(BatchParam batch_param)
@@ -159,37 +160,39 @@ ExternalMemoryNoSampling::ExternalMemoryNoSampling(BatchParam batch_param)
 
 GradientBasedSample ExternalMemoryNoSampling::Sample(Context const* ctx,
                                                      common::Span<GradientPair> gpair,
-                                                     DMatrix* dmat) {
+                                                     DMatrix* p_fmat) {
+  std::shared_ptr<EllpackPage> new_page;
   if (!page_concatenated_) {
     // Concatenate all the external memory ELLPACK pages into a single in-memory page.
-    page_.reset(nullptr);
     bst_idx_t offset = 0;
-    for (auto& batch : dmat->GetBatches<EllpackPage>(ctx, batch_param_)) {
+    for (auto& batch : p_fmat->GetBatches<EllpackPage>(ctx, batch_param_)) {
       auto page = batch.Impl();
-      if (!page_) {
-        page_ = std::make_unique<EllpackPageImpl>(ctx, page->CutsShared(), page->is_dense,
-                                                  page->row_stride, dmat->Info().num_row_);
+      if (!new_page) {
+        new_page = std::make_shared<EllpackPage>();
+        *new_page->Impl() = EllpackPageImpl(ctx, page->CutsShared(), page->is_dense,
+                                            page->row_stride, p_fmat->Info().num_row_);
       }
-      bst_idx_t num_elements = page_->Copy(ctx, page, offset);
+      bst_idx_t num_elements = new_page->Impl()->Copy(ctx, page, offset);
       offset += num_elements;
     }
     page_concatenated_ = true;
+    this->p_fmat_new_ =
+        std::make_unique<data::IterativeDMatrix>(new_page, p_fmat->Info(), batch_param_);
   }
-  return {dmat->Info().num_row_, page_.get(), gpair};
+  return {p_fmat->Info().num_row_, this->p_fmat_new_.get(), gpair};
 }
 
 UniformSampling::UniformSampling(BatchParam batch_param, float subsample)
-    : batch_param_{std::move(batch_param)}, subsample_(subsample) {}
+    : batch_param_{std::move(batch_param)}, subsample_{subsample} {}
 
 GradientBasedSample UniformSampling::Sample(Context const* ctx, common::Span<GradientPair> gpair,
-                                            DMatrix* dmat) {
+                                            DMatrix* p_fmat) {
   // Set gradient pair to 0 with p = 1 - subsample
   auto cuctx = ctx->CUDACtx();
   thrust::replace_if(cuctx->CTP(), dh::tbegin(gpair), dh::tend(gpair),
                      thrust::counting_iterator<std::size_t>(0),
                      BernoulliTrial(common::GlobalRandom()(), subsample_), GradientPair());
-  auto page = (*dmat->GetBatches<EllpackPage>(ctx, batch_param_).begin()).Impl();
-  return {dmat->Info().num_row_, page, gpair};
+  return {p_fmat->Info().num_row_, p_fmat, gpair};
 }
 
 ExternalMemoryUniformSampling::ExternalMemoryUniformSampling(size_t n_rows,
@@ -203,13 +206,17 @@ GradientBasedSample ExternalMemoryUniformSampling::Sample(Context const* ctx,
                                                           common::Span<GradientPair> gpair,
                                                           DMatrix* dmat) {
   auto cuctx = ctx->CUDACtx();
+
+  std::shared_ptr<EllpackPage> new_page = std::make_shared<EllpackPage>();
+  auto page = new_page->Impl();
+
   // Set gradient pair to 0 with p = 1 - subsample
   thrust::replace_if(cuctx->CTP(), dh::tbegin(gpair), dh::tend(gpair),
                      thrust::counting_iterator<std::size_t>(0),
                      BernoulliTrial(common::GlobalRandom()(), subsample_), GradientPair{});
 
   // Count the sampled rows.
-  size_t sample_rows =
+  bst_idx_t sample_rows =
       thrust::count_if(cuctx->CTP(), dh::tbegin(gpair), dh::tend(gpair), IsNonZero{});
 
   // Compact gradient pairs.
@@ -227,17 +234,25 @@ GradientBasedSample ExternalMemoryUniformSampling::Sample(Context const* ctx,
   auto batch_iterator = dmat->GetBatches<EllpackPage>(ctx, batch_param_);
   auto first_page = (*batch_iterator.begin()).Impl();
   // Create a new ELLPACK page with empty rows.
-  page_.reset();  // Release the device memory first before reallocating
-  page_.reset(new EllpackPageImpl(ctx, first_page->CutsShared(), first_page->is_dense,
-                                  first_page->row_stride, sample_rows));
+  *page = EllpackPageImpl{ctx, first_page->CutsShared(), first_page->is_dense,
+                          first_page->row_stride, sample_rows};
 
   // Compact the ELLPACK pages into the single sample page.
-  thrust::fill(cuctx->CTP(), page_->gidx_buffer.begin(), page_->gidx_buffer.end(), 0);
+  thrust::fill(cuctx->CTP(), page->gidx_buffer.begin(), page->gidx_buffer.end(), 0);
   for (auto& batch : batch_iterator) {
-    page_->Compact(ctx, batch.Impl(), dh::ToSpan(sample_row_index_));
+    page->Compact(ctx, batch.Impl(), dh::ToSpan(sample_row_index_));
   }
-
-  return {sample_rows, page_.get(), dh::ToSpan(gpair_)};
+  // Select the metainfo
+  dmat->Info().feature_types.SetDevice(ctx->Device());
+  auto nnz = page->NumNonMissing(ctx, dmat->Info().feature_types.ConstDeviceSpan());
+  compact_row_index_.resize(sample_rows);
+  thrust::copy_if(
+      cuctx->TP(), sample_row_index_.cbegin(), sample_row_index_.cend(), compact_row_index_.begin(),
+      [] XGBOOST_DEVICE(std::size_t idx) { return idx != ClearEmptyRows::InvalidRow(); });
+  // Create the new DMatrix
+  this->p_fmat_new_ = std::make_unique<data::IterativeDMatrix>(
+      new_page, dmat->Info().Slice(ctx, dh::ToSpan(compact_row_index_), nnz), batch_param_);
+  return {sample_rows, this->p_fmat_new_.get(), dh::ToSpan(gpair_)};
 }
 
 GradientBasedSampling::GradientBasedSampling(std::size_t n_rows, BatchParam batch_param,
@@ -254,14 +269,12 @@ GradientBasedSample GradientBasedSampling::Sample(Context const* ctx,
   size_t threshold_index = GradientBasedSampler::CalculateThresholdIndex(
       ctx, gpair, dh::ToSpan(threshold_), dh::ToSpan(grad_sum_), n_rows * subsample_);
 
-  auto page = (*dmat->GetBatches<EllpackPage>(ctx, batch_param_).begin()).Impl();
-
   // Perform Poisson sampling in place.
   thrust::transform(cuctx->CTP(), dh::tbegin(gpair), dh::tend(gpair),
                     thrust::counting_iterator<size_t>(0), dh::tbegin(gpair),
                     PoissonSampling(dh::ToSpan(threshold_), threshold_index,
                                     RandomWeight(common::GlobalRandom()())));
-  return {n_rows, page, gpair};
+  return {n_rows, dmat, gpair};
 }
 
 ExternalMemoryGradientBasedSampling::ExternalMemoryGradientBasedSampling(size_t n_rows,
@@ -277,6 +290,8 @@ GradientBasedSample ExternalMemoryGradientBasedSampling::Sample(Context const* c
                                                                 common::Span<GradientPair> gpair,
                                                                 DMatrix* dmat) {
   auto cuctx = ctx->CUDACtx();
+  std::shared_ptr<EllpackPage> new_page = std::make_shared<EllpackPage>();
+  auto page = new_page->Impl();
   bst_idx_t n_rows = dmat->Info().num_row_;
   size_t threshold_index = GradientBasedSampler::CalculateThresholdIndex(
       ctx, gpair, dh::ToSpan(threshold_), dh::ToSpan(grad_sum_), n_rows * subsample_);
@@ -293,24 +308,33 @@ GradientBasedSample ExternalMemoryGradientBasedSampling::Sample(Context const* c
   thrust::copy_if(cuctx->CTP(), dh::tbegin(gpair), dh::tend(gpair), gpair_.begin(), IsNonZero());
   // Index the sample rows.
   thrust::transform(cuctx->CTP(), dh::tbegin(gpair), dh::tend(gpair), sample_row_index_.begin(),
-                    IsNonZero());
+                    IsNonZero{});
   thrust::exclusive_scan(cuctx->CTP(), sample_row_index_.begin(), sample_row_index_.end(),
                          sample_row_index_.begin());
   thrust::transform(cuctx->CTP(), dh::tbegin(gpair), dh::tend(gpair), sample_row_index_.begin(),
-                    sample_row_index_.begin(), ClearEmptyRows());
+                    sample_row_index_.begin(), ClearEmptyRows{});
   auto batch_iterator = dmat->GetBatches<EllpackPage>(ctx, batch_param_);
   auto first_page = (*batch_iterator.begin()).Impl();
   // Create a new ELLPACK page with empty rows.
-  page_.reset();  // Release the device memory first before reallocating
-  page_.reset(new EllpackPageImpl{ctx, first_page->CutsShared(), dmat->IsDense(),
-                                  first_page->row_stride, sample_rows});
-  // Compact the ELLPACK pages into the single sample page.
-  thrust::fill(cuctx->CTP(), page_->gidx_buffer.begin(), page_->gidx_buffer.end(), 0);
-  for (auto& batch : batch_iterator) {
-    page_->Compact(ctx, batch.Impl(), dh::ToSpan(sample_row_index_));
-  }
 
-  return {sample_rows, page_.get(), dh::ToSpan(gpair_)};
+  *page = EllpackPageImpl{ctx, first_page->CutsShared(), dmat->IsDense(), first_page->row_stride,
+                          sample_rows};
+  // Compact the ELLPACK pages into the single sample page.
+  thrust::fill(cuctx->CTP(), page->gidx_buffer.begin(), page->gidx_buffer.end(), 0);
+  for (auto& batch : batch_iterator) {
+    page->Compact(ctx, batch.Impl(), dh::ToSpan(sample_row_index_));
+  }
+  // Select the metainfo
+  dmat->Info().feature_types.SetDevice(ctx->Device());
+  auto nnz = page->NumNonMissing(ctx, dmat->Info().feature_types.ConstDeviceSpan());
+  compact_row_index_.resize(sample_rows);
+  thrust::copy_if(
+      cuctx->TP(), sample_row_index_.cbegin(), sample_row_index_.cend(), compact_row_index_.begin(),
+      [] XGBOOST_DEVICE(std::size_t idx) { return idx != ClearEmptyRows::InvalidRow(); });
+  // Create the new DMatrix
+  this->p_fmat_new_ = std::make_unique<data::IterativeDMatrix>(
+      new_page, dmat->Info().Slice(ctx, dh::ToSpan(compact_row_index_), nnz), batch_param_);
+  return {sample_rows, this->p_fmat_new_.get(), dh::ToSpan(gpair_)};
 }
 
 GradientBasedSampler::GradientBasedSampler(Context const* /*ctx*/, size_t n_rows,
@@ -378,5 +402,4 @@ size_t GradientBasedSampler::CalculateThresholdIndex(Context const* ctx,
       thrust::min_element(cuctx->CTP(), dh::tbegin(grad_sum), dh::tend(grad_sum));
   return thrust::distance(dh::tbegin(grad_sum), min) + 1;
 }
-};  // namespace tree
-};  // namespace xgboost
+};  // namespace xgboost::tree

--- a/src/tree/gpu_hist/gradient_based_sampler.cuh
+++ b/src/tree/gpu_hist/gradient_based_sampler.cuh
@@ -5,7 +5,7 @@
 #include <cstddef>  // for size_t
 
 #include "../../common/device_vector.cuh"  // for device_vector, caching_device_vector
-#include "../../data/ellpack_page.cuh"     // for EllpackPageImpl
+#include "../../common/timer.h"            // for Monitor
 #include "xgboost/base.h"                  // for GradientPair
 #include "xgboost/data.h"                  // for BatchParam
 #include "xgboost/span.h"                  // for Span
@@ -13,11 +13,11 @@
 namespace xgboost::tree {
 struct GradientBasedSample {
   /*!\brief Number of sampled rows. */
-  std::size_t sample_rows;
+  bst_idx_t sample_rows;
   /*!\brief Sampled rows in ELLPACK format. */
-  EllpackPageImpl const* page;
+  DMatrix* p_fmat;
   /*!\brief Gradient pairs for the sampled rows. */
-  common::Span<GradientPair> gpair;
+  common::Span<GradientPair const> gpair;
 };
 
 class SamplingStrategy {
@@ -48,7 +48,7 @@ class ExternalMemoryNoSampling : public SamplingStrategy {
 
  private:
   BatchParam batch_param_;
-  std::unique_ptr<EllpackPageImpl> page_{nullptr};
+  std::unique_ptr<DMatrix> p_fmat_new_{nullptr};
   bool page_concatenated_{false};
 };
 
@@ -74,9 +74,10 @@ class ExternalMemoryUniformSampling : public SamplingStrategy {
  private:
   BatchParam batch_param_;
   float subsample_;
-  std::unique_ptr<EllpackPageImpl> page_;
+  std::unique_ptr<DMatrix> p_fmat_new_{nullptr};
   dh::device_vector<GradientPair> gpair_{};
-  dh::caching_device_vector<size_t> sample_row_index_;
+  dh::caching_device_vector<bst_idx_t> sample_row_index_;
+  dh::device_vector<bst_idx_t> compact_row_index_;
 };
 
 /*! \brief Gradient-based sampling in in-memory mode.. */
@@ -105,9 +106,10 @@ class ExternalMemoryGradientBasedSampling : public SamplingStrategy {
   float subsample_;
   dh::device_vector<float> threshold_;
   dh::device_vector<float> grad_sum_;
-  std::unique_ptr<EllpackPageImpl> page_;
+  std::unique_ptr<DMatrix> p_fmat_new_{nullptr};
   dh::device_vector<GradientPair> gpair_;
-  dh::device_vector<size_t> sample_row_index_;
+  dh::device_vector<bst_idx_t> sample_row_index_;
+  dh::device_vector<bst_idx_t> compact_row_index_;
 };
 
 /*! \brief Draw a sample of rows from a DMatrix.

--- a/src/tree/updater_gpu_common.cuh
+++ b/src/tree/updater_gpu_common.cuh
@@ -119,9 +119,9 @@ struct DeviceSplitCandidate {
 };
 
 namespace cuda_impl {
-inline BatchParam HistBatch(TrainParam const& param, bool prefetch_copy = true) {
+inline BatchParam HistBatch(TrainParam const& param) {
   auto p = BatchParam{param.max_bin, TrainParam::DftSparseThreshold()};
-  p.prefetch_copy = prefetch_copy;
+  p.prefetch_copy = true;
   p.n_prefetch_batches = 1;
   return p;
 }
@@ -133,6 +133,14 @@ inline BatchParam HistBatch(bst_bin_t max_bin) {
 inline BatchParam ApproxBatch(TrainParam const& p, common::Span<float const> hess,
                               ObjInfo const& task) {
   return BatchParam{p.max_bin, hess, !task.const_hess};
+}
+
+// Empty parameter to prevent regen, only used to control external memory prefetching.
+inline BatchParam StaticBatch(bool prefetch_copy) {
+  BatchParam p;
+  p.prefetch_copy = prefetch_copy;
+  p.n_prefetch_batches = 1;
+  return p;
 }
 }  // namespace cuda_impl
 

--- a/tests/cpp/data/test_ellpack_page.cu
+++ b/tests/cpp/data/test_ellpack_page.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023, XGBoost contributors
+ * Copyright 2019-2024, XGBoost contributors
  */
 #include <xgboost/base.h>
 
@@ -15,7 +15,6 @@
 #include "gtest/gtest.h"
 
 namespace xgboost {
-
 TEST(EllpackPage, EmptyDMatrix) {
   constexpr int kNRows = 0, kNCols = 0, kMaxBin = 256;
   constexpr float kSparsity = 0;
@@ -242,7 +241,7 @@ TEST(EllpackPage, Compact) {
 namespace {
 class EllpackPageTest : public testing::TestWithParam<float> {
  protected:
-  void Run(float sparsity) {
+  void TestFromGHistIndex(float sparsity) const {
     // Only testing with small sample size as the cuts might be different between host and
     // device.
     size_t n_samples{128}, n_features{13};
@@ -273,9 +272,25 @@ class EllpackPageTest : public testing::TestWithParam<float> {
       }
     }
   }
+
+  void TestNumNonMissing(float sparsity) const {
+    size_t n_samples{1024}, n_features{13};
+    auto ctx = MakeCUDACtx(0);
+    auto p_fmat = RandomDataGenerator{n_samples, n_features, sparsity}.GenerateDMatrix(true);
+    auto nnz = p_fmat->Info().num_nonzero_;
+    for (auto const& page : p_fmat->GetBatches<EllpackPage>(
+             &ctx, BatchParam{17, tree::TrainParam::DftSparseThreshold()})) {
+      auto ellpack_nnz =
+          page.Impl()->NumNonMissing(&ctx, p_fmat->Info().feature_types.ConstDeviceSpan());
+      ASSERT_EQ(nnz, ellpack_nnz);
+    }
+  }
 };
 }  // namespace
 
-TEST_P(EllpackPageTest, FromGHistIndex) { this->Run(GetParam()); }
+TEST_P(EllpackPageTest, FromGHistIndex) { this->TestFromGHistIndex(GetParam()); }
+
+TEST_P(EllpackPageTest, NumNonMissing) { this->TestNumNonMissing(this->GetParam()); }
+
 INSTANTIATE_TEST_SUITE_P(EllpackPage, EllpackPageTest, testing::Values(.0f, .2f, .4f, .8f));
 }  // namespace xgboost

--- a/tests/cpp/data/test_metainfo.h
+++ b/tests/cpp/data/test_metainfo.h
@@ -1,5 +1,5 @@
-/*!
- * Copyright 2021 by XGBoost Contributors
+/**
+ * Copyright 2021-2024, XGBoost Contributors
  */
 #ifndef XGBOOST_TESTS_CPP_DATA_TEST_METAINFO_H_
 #define XGBOOST_TESTS_CPP_DATA_TEST_METAINFO_H_
@@ -11,7 +11,6 @@
 #include <numeric>
 
 #include "../../../src/common/linalg_op.h"
-#include "../../../src/data/array_interface.h"
 
 namespace xgboost {
 inline void TestMetaInfoStridedData(DeviceOrd device) {

--- a/tests/cpp/tree/gpu_hist/test_gradient_based_sampler.cu
+++ b/tests/cpp/tree/gpu_hist/test_gradient_based_sampler.cu
@@ -39,11 +39,11 @@ void VerifySampling(size_t page_size, float subsample, int sampling_method,
 
   if (fixed_size_sampling) {
     EXPECT_EQ(sample.sample_rows, kRows);
-    EXPECT_EQ(sample.page->n_rows, kRows);
+    EXPECT_EQ(sample.p_fmat->Info().num_row_, kRows);
     EXPECT_EQ(sample.gpair.size(), kRows);
   } else {
     EXPECT_NEAR(sample.sample_rows, sample_rows, kRows * 0.03);
-    EXPECT_NEAR(sample.page->n_rows, sample_rows, kRows * 0.03f);
+    EXPECT_NEAR(sample.p_fmat->Info().num_row_, sample_rows, kRows * 0.03f);
     EXPECT_NEAR(sample.gpair.size(), sample_rows, kRows * 0.03f);
   }
 
@@ -88,25 +88,28 @@ TEST(GradientBasedSampler, NoSamplingExternalMemory) {
 
   GradientBasedSampler sampler(&ctx, kRows, param, kSubsample, TrainParam::kUniform, true);
   auto sample = sampler.Sample(&ctx, gpair.DeviceSpan(), dmat.get());
-  auto sampled_page = sample.page;
+  auto p_fmat = sample.p_fmat;
   EXPECT_EQ(sample.sample_rows, kRows);
   EXPECT_EQ(sample.gpair.size(), gpair.Size());
   EXPECT_EQ(sample.gpair.data(), gpair.DevicePointer());
-  EXPECT_EQ(sampled_page->n_rows, kRows);
+  EXPECT_EQ(p_fmat->Info().num_row_, kRows);
 
-  std::vector<common::CompressedByteT> h_gidx_buffer;
-  auto h_accessor = sampled_page->GetHostAccessor(&ctx, &h_gidx_buffer);
+  ASSERT_EQ(p_fmat->NumBatches(), 1);
+  for (auto const& sampled_page : p_fmat->GetBatches<EllpackPage>(&ctx, param)) {
+    std::vector<common::CompressedByteT> h_gidx_buffer;
+    auto h_accessor = sampled_page.Impl()->GetHostAccessor(&ctx, &h_gidx_buffer);
 
-  std::size_t offset = 0;
-  for (auto& batch : dmat->GetBatches<EllpackPage>(&ctx, param)) {
-    auto page = batch.Impl();
-    std::vector<common::CompressedByteT> h_page_gidx_buffer;
-    auto page_accessor = page->GetHostAccessor(&ctx, &h_page_gidx_buffer);
-    size_t num_elements = page->n_rows * page->row_stride;
-    for (size_t i = 0; i < num_elements; i++) {
-      EXPECT_EQ(h_accessor.gidx_iter[i + offset], page_accessor.gidx_iter[i]);
+    std::size_t offset = 0;
+    for (auto& batch : dmat->GetBatches<EllpackPage>(&ctx, param)) {
+      auto page = batch.Impl();
+      std::vector<common::CompressedByteT> h_page_gidx_buffer;
+      auto page_accessor = page->GetHostAccessor(&ctx, &h_page_gidx_buffer);
+      size_t num_elements = page->n_rows * page->row_stride;
+      for (size_t i = 0; i < num_elements; i++) {
+        EXPECT_EQ(h_accessor.gidx_iter[i + offset], page_accessor.gidx_iter[i]);
+      }
+      offset += num_elements;
     }
-    offset += num_elements;
   }
 }
 


### PR DESCRIPTION
- Slice meta info using GPU.
- Work with `DMatrix` intead of `Ellpack` in the hist updater.
This way we can support page concatenation and batch training at the same time.

todos:
- [x] Test `NumNonMissing`.