### PR TITLE
Increase timeout in C++ tests from 1 to 5 seconds.

### DIFF
--- a/tests/cpp/collective/test_worker.h
+++ b/tests/cpp/collective/test_worker.h
@@ -151,13 +151,13 @@ template <typename WorkerFn>
 void TestDistributedGlobal(std::int32_t n_workers, WorkerFn worker_fn, bool need_finalize = true,
                            std::chrono::seconds test_timeout = std::chrono::seconds{30}) {
   system::SocketStartup();
-  std::chrono::seconds timeout{1};
+  std::chrono::seconds poll_timeout{5};
 
   std::string host;
   auto rc = GetHostAddress(&host);
   SafeColl(rc);
 
-  RabitTracker tracker{MakeTrackerConfig(host, n_workers, timeout)};
+  RabitTracker tracker{MakeTrackerConfig(host, n_workers, poll_timeout)};
   auto fut = tracker.Run();
 
   std::vector<std::thread> workers;
@@ -166,7 +166,7 @@ void TestDistributedGlobal(std::int32_t n_workers, WorkerFn worker_fn, bool need
   for (std::int32_t i = 0; i < n_workers; ++i) {
     workers.emplace_back([=] {
       auto fut = std::async(std::launch::async, [=] {
-        auto config = MakeDistributedTestConfig(host, port, timeout, i);
+        auto config = MakeDistributedTestConfig(host, port, poll_timeout, i);
         Init(config);
         worker_fn();
         if (need_finalize) {

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -283,22 +283,22 @@ void TestColSplitQuantile(size_t rows, size_t cols) {
 }
 }  // anonymous namespace
 
-TEST(Quantile, ColSplitBasic) {
+TEST(Quantile, ColumnSplitBasic) {
   constexpr size_t kRows = 10, kCols = 10;
   TestColSplitQuantile<false>(kRows, kCols);
 }
 
-TEST(Quantile, ColSplit) {
+TEST(Quantile, ColumnSplit) {
   constexpr size_t kRows = 4000, kCols = 200;
   TestColSplitQuantile<false>(kRows, kCols);
 }
 
-TEST(Quantile, ColSplitSortedBasic) {
+TEST(Quantile, ColumnSplitSortedBasic) {
   constexpr size_t kRows = 10, kCols = 10;
   TestColSplitQuantile<true>(kRows, kCols);
 }
 
-TEST(Quantile, ColSplitSorted) {
+TEST(Quantile, ColumnSplitSorted) {
   constexpr size_t kRows = 4000, kCols = 200;
   TestColSplitQuantile<true>(kRows, kCols);
 }

--- a/tests/cpp/tree/test_approx.cc
+++ b/tests/cpp/tree/test_approx.cc
@@ -181,7 +181,7 @@ void TestColumnSplitPartitioner(size_t n_samples, size_t base_rowid, std::shared
 }
 }  // anonymous namespace
 
-TEST(Approx, PartitionerColSplit) {
+TEST(Approx, PartitionerColumnSplit) {
   size_t n_samples = 1024, n_features = 16, base_rowid = 0;
   auto const Xy = RandomDataGenerator{n_samples, n_features, 0}.GenerateDMatrix(true);
   auto hess = GenerateHess(n_samples);
@@ -211,7 +211,7 @@ TEST(Approx, PartitionerColSplit) {
 }
 
 namespace {
-class TestApproxColSplit : public ::testing::TestWithParam<std::tuple<bool, float>> {
+class TestApproxColumnSplit : public ::testing::TestWithParam<std::tuple<bool, float>> {
  public:
   void Run() {
     auto [categorical, sparsity] = GetParam();
@@ -220,9 +220,9 @@ class TestApproxColSplit : public ::testing::TestWithParam<std::tuple<bool, floa
 };
 }  // namespace
 
-TEST_P(TestApproxColSplit, Basic) { this->Run(); }
+TEST_P(TestApproxColumnSplit, Basic) { this->Run(); }
 
-INSTANTIATE_TEST_SUITE_P(ColumnSplit, TestApproxColSplit, ::testing::ValuesIn([]() {
+INSTANTIATE_TEST_SUITE_P(ColumnSplit, TestApproxColumnSplit, ::testing::ValuesIn([]() {
                            std::vector<std::tuple<bool, float>> params;
                            for (auto categorical : {true, false}) {
                              for (auto sparsity : {0.0f, 0.6f}) {

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -203,12 +203,12 @@ void TestColumnSplitPartitioner(bst_target_t n_targets) {
 }
 }  // anonymous namespace
 
-TEST(QuantileHist, PartitionerColSplit) { TestColumnSplitPartitioner<CPUExpandEntry>(1); }
+TEST(QuantileHist, PartitionerColumnSplit) { TestColumnSplitPartitioner<CPUExpandEntry>(1); }
 
-TEST(QuantileHist, MultiPartitionerColSplit) { TestColumnSplitPartitioner<MultiExpandEntry>(3); }
+TEST(QuantileHist, MultiPartitionerColumnSplit) { TestColumnSplitPartitioner<MultiExpandEntry>(3); }
 
 namespace {
-class TestHistColSplit : public ::testing::TestWithParam<std::tuple<bst_target_t, bool, float>> {
+class TestHistColumnSplit : public ::testing::TestWithParam<std::tuple<bst_target_t, bool, float>> {
  public:
   void Run() {
     auto [n_targets, categorical, sparsity] = GetParam();
@@ -217,9 +217,9 @@ class TestHistColSplit : public ::testing::TestWithParam<std::tuple<bst_target_t
 };
 }  // anonymous namespace
 
-TEST_P(TestHistColSplit, Basic) { this->Run(); }
+TEST_P(TestHistColumnSplit, Basic) { this->Run(); }
 
-INSTANTIATE_TEST_SUITE_P(ColumnSplit, TestHistColSplit, ::testing::ValuesIn([]() {
+INSTANTIATE_TEST_SUITE_P(ColumnSplit, TestHistColumnSplit, ::testing::ValuesIn([]() {
                            std::vector<std::tuple<bst_target_t, bool, float>> params;
                            for (auto categorical : {true, false}) {
                              for (auto sparsity : {0.0f, 0.6f}) {


### PR DESCRIPTION
To avoid CI failures on FreeBSD.

- Increase timeout from 1 second to 5 seconds for the poll and recv.
- Use the name "ColumnSplit" uniformly across all tests for easier filtering.


Related https://github.com/dmlc/xgboost/issues/10704 .