### PR TITLE
POSIX compliant `poll.h` and `mmap` over `sys/poll.h` and `mmap64`

### DIFF
--- a/include/xgboost/collective/poll_utils.h
+++ b/include/xgboost/collective/poll_utils.h
@@ -35,7 +35,7 @@
 
 #if !defined(_WIN32)
 
-#include <sys/poll.h>
+#include <poll.h>
 
 using SOCKET = int;
 using sock_size_t = size_t;  // NOLINT

--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -4,7 +4,7 @@
 #if defined(__unix__) || defined(__APPLE__)
 
 #include <fcntl.h>     // for open, O_RDONLY
-#include <sys/mman.h>  // for mmap, mmap64, munmap, madvise
+#include <sys/mman.h>  // for mmap, munmap, madvise
 #include <unistd.h>    // for close, getpagesize
 
 #else
@@ -202,7 +202,7 @@ MMAPFile* detail::OpenMmap(std::string path, std::size_t offset, std::size_t len
 
 #if defined(__linux__) || defined(__GLIBC__)
   int prot{PROT_READ};
-  ptr = reinterpret_cast<std::byte*>(mmap64(nullptr, view_size, prot, MAP_PRIVATE, fd, view_start));
+  ptr = reinterpret_cast<std::byte*>(mmap(nullptr, view_size, prot, MAP_PRIVATE, fd, view_start));
   CHECK_NE(ptr, MAP_FAILED) << "Failed to map: " << path << ". " << SystemErrorMsg();
   auto handle = new MMAPFile{fd, ptr, view_size, offset - view_start, std::move(path)};
 #elif defined(xgboost_IS_WIN)


### PR DESCRIPTION
Closes #10737 

Basic build testing confirms this works with both musl and glibc:
```dockerfile
FROM alpine
RUN apk add --no-cache cmake gcc g++ make musl-dev
WORKDIR /src/xgboost
COPY . .
RUN cmake -S . -B build && \
    cmake --build build
```

```dockerfile
FROM debian:bookworm-slim
RUN apt-get update -qq && \
    apt-get install -y cmake gcc g++ make libstdc++6 && \
    rm -rf /var/lib/apt/lists/*
WORKDIR /src/xgboost
COPY . .
RUN cmake -S . -B build && \
    cmake --build build
```