### PR TITLE
Add missing xgboost::common::WQSummary::Entry::operator==

### DIFF
--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -15,6 +15,9 @@
 #include <cstring>
 #include <iostream>
 #include <set>
+#if __cplusplus < 202002L
+#include <tuple>              // WQSummary::Entry::operator==
+#endif
 #include <vector>
 
 #include "categorical.h"
@@ -71,6 +74,14 @@ struct WQSummary {
          << "value: " << e.value;
       return os;
     }
+
+    #if __cplusplus < 202002L
+    // Default comparison operators aren't present until C++20
+    inline bool operator==(const Entry &rhs) const {
+      return std::tie(rmin, rmax, wmin, value) ==
+             std::tie(rhs.rmin, rhs.rmax, rhs.wmin, rhs.value);
+    }
+    #endif
   };
   /*! \brief input data queue before entering the summary */
   struct Queue {


### PR DESCRIPTION
Thrust fails to compile with specific combinations of NVCC and GCC from
an undefined == operator.

Specifically on Fedora 40 with CUDA 12.6.1 and gcc 13.3.1 as the host compiler:
```
[111/159] Building CUDA object src/CMakeFiles/objxgboost.dir/common/quantile.cu.o
FAILED: src/CMakeFiles/objxgboost.dir/common/quantile.cu.o 
/usr/local/cuda/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/usr/bin/g++-13 -DDMLC_CORE_USE_CMAKE -DDMLC_LOG_CUSTOMIZE=1 -DDMLC_USE_CXX11=1 -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -DXGBOOST_BUILTIN_PREFETCH_PRESENT=1 -DXGBOOST_MM_PREFETCH_PRESENT=1 -DXGBOOST_USE_CUDA=1 -D_MWAITXINTRIN_H_INCLUDED -D__USE_XOPEN2K8 -I/home/chuck/Code/xgboost/source/master/include -I/home/chuck/Code/xgboost/source/master/dmlc-core/include -I/home/chuck/Code/xgboost/source/master/gputreeshap -I/home/chuck/Code/xgboost/build/master/dmlc-core/include -I/usr/local/cuda/include -isystem /usr/local/cuda/targets/x86_64-linux/include -O3 -DNDEBUG -std=c++17 "--generate-code=arch=compute_89,code=[sm_89]" -Xcompiler=-fPIC --expt-extended-lambda --expt-relaxed-constexpr -Xcompiler=-fopenmp -Xfatbin=-compress-all --default-stream per-thread -lineinfo -MD -MT src/CMakeFiles/objxgboost.dir/common/quantile.cu.o -MF src/CMakeFiles/objxgboost.dir/common/quantile.cu.o.d -x cu -c /home/chuck/Code/xgboost/source/master/src/common/quantile.cu -o src/CMakeFiles/objxgboost.dir/common/quantile.cu.o
/usr/local/cuda/targets/x86_64-linux/include/cuda/std/__utility/pair.h(560): error: no operator "==" matches these operands
           operand types are: const xgboost::common::WQSummary<float, float>::Entry == const xgboost::common::WQSummary<float, float>::Entry
    return __x.first == __y.first && __x.second == __y.second;
                                                ^
...
            instantiation of "size_t dh::SegmentedUnique(const thrust::THRUST_200500_890_NS::detail::execution_policy_base<DerivedPolicy> &, KeyInIt, KeyInIt, ValInIt, ValInIt, KeyOutIt, ValOutIt, CompValue, CompKey) [with DerivedPolicy=thrust::THRUST_200500_890_NS::detail::execute_with_allocator<dh::detail::XGBCachingDeviceAllocatorImpl<char>, thrust::THRUST_200500_890_NS::cuda_cub::execute_on_stream_nosync_base>, KeyInIt=xgboost::bst_idx_t *, KeyOutIt=xgboost::bst_idx_t *, ValInIt=xgboost::common::SketchEntry *, ValOutIt=xgboost::common::SketchEntry *, CompValue=xgboost::common::detail::SketchUnique, CompKey=thrust::THRUST_200500_890_NS::equal_to<size_t>]" at line 399 of /home/chuck/Code/xgboost/source/master/src/common/quantile.cu

1 error detected in the compilation of "/home/chuck/Code/xgboost/source/master/src/common/quantile.cu".
[134/159] Building CUDA object src/CMakeFiles/objxgboost.dir/data/quantile_dmatrix.cu.o
```