### PR TITLE
Update unit_tests.rst

### DIFF
--- a/doc/contrib/unit_tests.rst
+++ b/doc/contrib/unit_tests.rst
@@ -95,7 +95,10 @@ To run Python unit tests, first install `pytest <https://docs.pytest.org/en/late
 
   pip3 install pytest
 
-Then compile XGBoost according to instructions in :ref:`build_shared_lib`. Finally, invoke pytest at the project root directory:
+Then compile XGBoost according to instructions in :ref:`build_shared_lib`. When
+compiling, be sure to enable the build flag ``BUILD_DEPRECATED_CLI`` to build
+the CLI, which is used in some of the python tests.
+Finally, invoke pytest at the project root directory:
 
 .. code:: bash
 


### PR DESCRIPTION
When following the instructions described in https://xgboost.readthedocs.io/en/stable/contrib/unit_tests.html#running-pytest to run the python unit tests locally, the following tests will fail:
```
FAILED tests/python/test_cli.py::TestCLI::test_cli_model - AssertionError: assert False
FAILED tests/python/test_cli.py::TestCLI::test_cli_help - AssertionError: assert False
FAILED tests/python/test_cli.py::TestCLI::test_cli_model_json - AssertionError: assert False
FAILED tests/python/test_cli.py::TestCLI::test_cli_save_model - AssertionError: assert False
FAILED tests/python/test_demos.py::test_cli_regression_demo - FileNotFoundError: [Errno 2] No such file or directory: '/Users/mlacayo/xgboost/demo/../xgboost'
FAILED tests/python/test_demos.py::test_cli_binary_classification - subprocess.CalledProcessError: Command '['./runexp.sh']' returned non-zero exit status 1.
```
The reason for these errors is because the default CMake build options exclude the building of the CLI (behavior introduced in #9485 )

To help avoid confusion, I updated the python section of the unit test documentation to mention this build option.


Here is a sample stack trace for the test_cli_model test case that shows that the executable is missing:
```
self = <test_cli.TestCLI object at 0x123c78890>

    def get_exe(self):
        if platform.system() == 'Windows':
            exe = 'xgboost.exe'
        else:
            exe = 'xgboost'
        exe = os.path.join(self.PROJECT_ROOT, exe)
>       assert os.path.exists(exe)
E       AssertionError: assert False
E        +  where False = <function exists at 0x104b47600>('/Users/mlacayo/xgboost/xgboost')
E        +    where <function exists at 0x104b47600> = <module 'posixpath' (frozen)>.exists
E        +      where <module 'posixpath' (frozen)> = os.path
```