### PR TITLE
Made lib paths configurable via environment variable

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -270,6 +270,19 @@ There are several ways to build and install the package from source:
     cd python-package
     pip install . --config-settings use_system_libxgboost=True
 
+5. Set custom ``libxgboost.so`` directory via ``XGBOOST_LIBRARY_PATH`` environment variable.
+
+  For certain use cases, the system path (``sys.base_prefix``) may not correctly locate the
+  ``libxgboost.so`` shared library. Users can specify a custom directory where ``libxgboost.so``
+  is located by setting the ``XGBOOST_LIBRARY_PATH`` environment variable.
+
+  To configure this, set the environment variable as follows:
+  
+  .. code-block:: bash
+    
+    export XGBOOST_LIBRARY_PATH="/path/to/xgboost/build/"
+
+  **Important**: Do not include the `/lib/` suffix in the XGBOOST_LIBRARY_PATH value. It will be automatically appended.
 
 .. note::
 

--- a/python-package/xgboost/libpath.py
+++ b/python-package/xgboost/libpath.py
@@ -14,6 +14,9 @@ class XGBoostLibraryNotFound(Exception):
 def find_lib_path() -> List[str]:
     """Find the path to xgboost dynamic library files.
 
+    Supports use of XGBOOST_LIBRARY_PATH environment variable as a
+    a custom directory for dynamic library file location.
+
     Returns
     -------
     lib_path
@@ -29,6 +32,9 @@ def find_lib_path() -> List[str]:
         # option.
         os.path.join(sys.base_prefix, "lib"),
     ]
+
+    if "XGBOOST_LIBRARY_PATH" in os.environ:
+        dll_path.extend([os.path.join(os.environ.get("XGBOOST_LIBRARY_PATH"), "lib")])
 
     if sys.platform == "win32":
         # On Windows, Conda may install libs in different paths

--- a/python-package/xgboost/libpath.py
+++ b/python-package/xgboost/libpath.py
@@ -33,8 +33,9 @@ def find_lib_path() -> List[str]:
         os.path.join(sys.base_prefix, "lib"),
     ]
 
-    if "XGBOOST_LIBRARY_PATH" in os.environ:
-        dll_path.extend([os.path.join(os.environ.get("XGBOOST_LIBRARY_PATH"), "lib")])
+    custom_xgboost_path = os.environ.get("XGBOOST_LIBRARY_PATH")
+    if custom_xgboost_path is not None:
+        dll_path.extend([os.path.join(custom_xgboost_path, "lib")])
 
     if sys.platform == "win32":
         # On Windows, Conda may install libs in different paths


### PR DESCRIPTION
#9376 This PR adds documentation to clarify the use of the `XGBOOST_LIBRARY_PATH` environment variable, allowing users to set a custom directory for the `libxgboost.so` shared library. This is helpful for cases where the default system path does not correctly resolve the library location.