### PR TITLE
[doc] Fix custom_metric_obj.rst [skip ci] (#10796)

### DIFF
--- a/doc/tutorials/custom_metric_obj.rst
+++ b/doc/tutorials/custom_metric_obj.rst
@@ -52,7 +52,7 @@ If we compute the gradient of said objective function:
 As well as the hessian (the second derivative of the objective):
 
 .. math::
-   h = \frac{\partial^2{objective}}{\partial{pred}} = \frac{ - \log(pred + 1) + \log(label + 1) + 1}{(pred + 1)^2}
+   h = \frac{\partial^2{objective}}{\partial{pred}^2} = \frac{ - \log(pred + 1) + \log(label + 1) + 1}{(pred + 1)^2}
 
 *****************************
 Customized Objective Function


### PR DESCRIPTION
Added the square to the derivative in the hessian

Forward https://github.com/dmlc/xgboost/pull/10796 to the master branch.