### PR TITLE
[jvm-packages] shade xgboost spark packages

### DIFF
--- a/jvm-packages/xgboost4j-spark-gpu/pom.xml
+++ b/jvm-packages/xgboost4j-spark-gpu/pom.xml
@@ -19,6 +19,27 @@
                     <skipAssembly>false</skipAssembly>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                  <shadedArtifactAttached>false</shadedArtifactAttached>
+                  <createDependencyReducedPom>true</createDependencyReducedPom>
+                  <artifactSet>
+                    <includes>
+                      <include>ml.dmlc:xgboost4j-spark_${scala.binary.version}</include>
+                    </includes>
+                  </artifactSet>
+                </configuration>
+                <executions>
+                  <execution>
+                    <phase>package</phase>
+                    <goals>
+                      <goal>shade</goal>
+                    </goals>
+                  </execution>
+                </executions>
+              </plugin>
         </plugins>
     </build>
     <dependencies>
@@ -31,6 +52,12 @@
             <groupId>ml.dmlc</groupId>
             <artifactId>xgboost4j-spark_2.12</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+              <exclusion>
+                  <groupId>ml.dmlc</groupId>
+                  <artifactId>xgboost4j_2.12</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/jvm-packages/xgboost4j-spark-gpu/pom.xml
+++ b/jvm-packages/xgboost4j-spark-gpu/pom.xml
@@ -24,7 +24,6 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                   <shadedArtifactAttached>false</shadedArtifactAttached>
-                  <createDependencyReducedPom>true</createDependencyReducedPom>
                   <artifactSet>
                     <includes>
                       <include>ml.dmlc:xgboost4j-spark_${scala.binary.version}</include>

--- a/jvm-packages/xgboost4j-spark/pom.xml
+++ b/jvm-packages/xgboost4j-spark/pom.xml
@@ -19,6 +19,27 @@
                     <skipAssembly>false</skipAssembly>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                  <shadedArtifactAttached>false</shadedArtifactAttached>
+                  <createDependencyReducedPom>true</createDependencyReducedPom>
+                  <artifactSet>
+                    <includes>
+                      <include>ml.dmlc:xgboost4j_${scala.binary.version}</include>
+                    </includes>
+                  </artifactSet>
+                </configuration>
+                <executions>
+                  <execution>
+                    <phase>package</phase>
+                    <goals>
+                      <goal>shade</goal>
+                    </goals>
+                  </execution>
+                </executions>
+              </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/jvm-packages/xgboost4j-spark/pom.xml
+++ b/jvm-packages/xgboost4j-spark/pom.xml
@@ -24,7 +24,6 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                   <shadedArtifactAttached>false</shadedArtifactAttached>
-                  <createDependencyReducedPom>true</createDependencyReducedPom>
                   <artifactSet>
                     <includes>
                       <include>ml.dmlc:xgboost4j_${scala.binary.version}</include>


### PR DESCRIPTION
This PR assembles xgboost4j.jar/xgboost4j-spark.jar into the existing xgboost4j-spark.jar and xgboost4j.jar/xgboost4j-spark.jar/xgboost4j-spark-gpu.jar into xgboost4j-spark-gpu.jar. So with this PR, user can use xgboost4j-spark.jar for xgboost cases without specifying the xgboost4j.jar explicitly. Similary to xgboost4j-spark-gpu.jar