### PR TITLE
[coll] Avoid all-to-all connection.

### DIFF
--- a/include/xgboost/collective/socket.h
+++ b/include/xgboost/collective/socket.h
@@ -539,7 +539,7 @@ class TCPSocket {
   /**
    * @brief Listen to incoming requests. Should be called after bind.
    */
-  [[nodiscard]] Result Listen(std::int32_t backlog = 16) {
+  [[nodiscard]] Result Listen(std::int32_t backlog = 512) {
     if (listen(handle_, backlog) != 0) {
       return system::FailWithCode("Failed to listen.");
     }

--- a/src/collective/allgather.h
+++ b/src/collective/allgather.h
@@ -13,6 +13,7 @@
 #include "../common/type.h"             // for EraseType
 #include "comm.h"                       // for Comm, Channel
 #include "comm_group.h"                 // for CommGroup
+#include "topo.h"                       // for BootstrapNext, BootstrapPrev
 #include "xgboost/collective/result.h"  // for Result
 #include "xgboost/linalg.h"             // for MakeVec
 #include "xgboost/span.h"               // for Span

--- a/src/collective/broadcast.cc
+++ b/src/collective/broadcast.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, XGBoost Contributors
+ * Copyright 2023-2024, XGBoost Contributors
  */
 #include "broadcast.h"
 
@@ -7,45 +7,13 @@
 #include <cstdint>  // for int32_t, int8_t
 #include <utility>  // for move
 
-#include "../common/bitfield.h"         // for TrailingZeroBits, RBitField32
+
 #include "comm.h"                       // for Comm
 #include "xgboost/collective/result.h"  // for Result
 #include "xgboost/span.h"               // for Span
+#include "topo.h"                       // for ParentRank
 
 namespace xgboost::collective::cpu_impl {
-namespace {
-std::int32_t ShiftedParentRank(std::int32_t shifted_rank, std::int32_t depth) {
-  std::uint32_t mask{std::uint32_t{0} - 1};  // Oxff...
-  RBitField32 maskbits{common::Span<std::uint32_t>{&mask, 1}};
-  RBitField32 rankbits{
-      common::Span<std::uint32_t>{reinterpret_cast<std::uint32_t*>(&shifted_rank), 1}};
-  // prepare for counting trailing zeros.
-  for (std::int32_t i = 0; i < depth + 1; ++i) {
-    if (rankbits.Check(i)) {
-      maskbits.Set(i);
-    } else {
-      maskbits.Clear(i);
-    }
-  }
-
-  CHECK_NE(mask, 0);
-  auto k = TrailingZeroBits(mask);
-  auto shifted_parent = shifted_rank - (1 << k);
-  return shifted_parent;
-}
-
-// Shift the root node to rank 0
-std::int32_t ShiftLeft(std::int32_t rank, std::int32_t world, std::int32_t root) {
-  auto shifted_rank = (rank + world - root) % world;
-  return shifted_rank;
-}
-// shift back to the original rank
-std::int32_t ShiftRight(std::int32_t rank, std::int32_t world, std::int32_t root) {
-  auto orig = (rank + root) % world;
-  return orig;
-}
-}  // namespace
-
 Result Broadcast(Comm const& comm, common::Span<std::int8_t> data, std::int32_t root) {
   // Binomial tree broadcast
   // * Wiki
@@ -56,28 +24,47 @@ Result Broadcast(Comm const& comm, common::Span<std::int8_t> data, std::int32_t 
   auto rank = comm.Rank();
   auto world = comm.World();
 
-  // shift root to rank 0
-  auto shifted_rank = ShiftLeft(rank, world, root);
+  // Send data to the root to preserve the topology. Alternative is to shift the rank, but
+  // it requires a all-to-all connection.
+  //
+  // Most of the use of broadcasting in XGBoost are short messages, this should be
+  // fine. Otherwise, we can implement a linear pipeline broadcast.
+  if (root != 0) {
+    auto rc = Success() << [&] {
+      return (rank == 0) ? comm.Chan(root)->RecvAll(data) : Success();
+    } << [&] {
+      return (rank == root) ? comm.Chan(0)->SendAll(data) : Success();
+    } << [&] {
+      return comm.Block();
+    };
+    if (!rc.OK()) {
+      return Fail("Broadcast failed to send data to root.", std::move(rc));
+    }
+    root = 0;
+  }
+
   std::int32_t depth = std::ceil(std::log2(static_cast<double>(world))) - 1;
 
-  if (shifted_rank != 0) {  // not root
-    auto parent = ShiftRight(ShiftedParentRank(shifted_rank, depth), world, root);
-    auto rc = Success() << [&] { return comm.Chan(parent)->RecvAll(data); }
-                        << [&] { return comm.Chan(parent)->Block(); };
+  if (rank != 0) {  // not root
+    auto parent = ParentRank(rank, depth);
+    auto rc = Success() << [&] {
+      return comm.Chan(parent)->RecvAll(data);
+    } << [&] {
+      return comm.Chan(parent)->Block();
+    };
     if (!rc.OK()) {
-      return Fail("broadcast failed.", std::move(rc));
+      return Fail("Broadcast failed to send data to parent.", std::move(rc));
     }
   }
 
   for (std::int32_t i = depth; i >= 0; --i) {
     CHECK_GE((i + 1), 0);  // weird clang-tidy error that i might be negative
-    if (shifted_rank % (1 << (i + 1)) == 0 && shifted_rank + (1 << i) < world) {
-      auto sft_peer = shifted_rank + (1 << i);
-      auto peer = ShiftRight(sft_peer, world, root);
+    if (rank % (1 << (i + 1)) == 0 && rank + (1 << i) < world) {
+      auto peer = rank + (1 << i);
       CHECK_NE(peer, root);
       auto rc = comm.Chan(peer)->SendAll(data);
       if (!rc.OK()) {
-        return rc;
+        return Fail("Failed to seed to " + std::to_string(peer), std::move(rc));
       }
     }
   }

--- a/src/collective/comm.h
+++ b/src/collective/comm.h
@@ -20,21 +20,10 @@
 
 namespace xgboost::collective {
 
-inline constexpr std::int64_t DefaultTimeoutSec() { return 60 * 30; }  // 30min
-inline constexpr std::int32_t DefaultRetry() { return 3; }
+constexpr std::int64_t DefaultTimeoutSec() { return 60 * 30; }  // 30min
+constexpr std::int32_t DefaultRetry() { return 3; }
 
-// indexing into the ring
-inline std::int32_t BootstrapNext(std::int32_t r, std::int32_t world) {
-  auto nrank = (r + world + 1) % world;
-  return nrank;
-}
-
-inline std::int32_t BootstrapPrev(std::int32_t r, std::int32_t world) {
-  auto nrank = (r + world - 1) % world;
-  return nrank;
-}
-
-inline StringView DefaultNcclName() { return "libnccl.so.2"; }
+constexpr StringView DefaultNcclName() { return "libnccl.so.2"; }
 
 class Channel;
 class Coll;

--- a/src/collective/topo.cc
+++ b/src/collective/topo.cc
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2023-2024, XGBoost Contributors
+ */
+#include "topo.h"
+
+#include "../common/bitfield.h"  // for TrailingZeroBits, RBitField32
+namespace xgboost::collective {
+std::int32_t ParentRank(std::int32_t rank, std::int32_t depth) {
+  std::uint32_t mask{std::uint32_t{0} - 1};  // Oxff...
+  RBitField32 maskbits{common::Span<std::uint32_t>{&mask, 1}};
+  RBitField32 rankbits{common::Span<std::uint32_t>{reinterpret_cast<std::uint32_t*>(&rank), 1}};
+  // prepare for counting trailing zeros.
+  for (std::int32_t i = 0; i < depth + 1; ++i) {
+    if (rankbits.Check(i)) {
+      maskbits.Set(i);
+    } else {
+      maskbits.Clear(i);
+    }
+  }
+
+  CHECK_NE(mask, 0);
+  auto k = TrailingZeroBits(mask);
+  auto parent = rank - (1 << k);
+  return parent;
+}
+}  // namespace xgboost::collective

--- a/src/collective/topo.h
+++ b/src/collective/topo.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2023-2024, XGBoost Contributors
+ */
+#pragma once
+#include <cstdint>  // for int32_t
+
+namespace xgboost::collective {
+inline std::int32_t BootstrapNext(std::int32_t r, std::int32_t world) {
+  auto nrank = (r + world + 1) % world;
+  return nrank;
+}
+
+inline std::int32_t BootstrapPrev(std::int32_t r, std::int32_t world) {
+  auto nrank = (r + world - 1) % world;
+  return nrank;
+}
+
+std::int32_t ParentRank(std::int32_t rank, std::int32_t depth);
+}  // namespace xgboost::collective

--- a/src/collective/tracker.cc
+++ b/src/collective/tracker.cc
@@ -2,6 +2,8 @@
  * Copyright 2023-2024, XGBoost Contributors
  */
 
+#include "tracker.h"
+
 #if defined(__unix__) || defined(__APPLE__)
 #include <netdb.h>       // gethostbyname
 #include <sys/socket.h>  // socket, AF_INET6, AF_INET, connect, getsockname
@@ -23,10 +25,10 @@
 #include <utility>    // for move, forward
 
 #include "../common/json_utils.h"
-#include "../common/threading_utils.h"  // for NameThread
-#include "comm.h"
-#include "protocol.h"  // for kMagic, PeerInfo
-#include "tracker.h"
+#include "../common/threading_utils.h"      // for NameThread
+#include "../common/timer.h"                // for Timer
+#include "protocol.h"                       // for kMagic, PeerInfo
+#include "topo.h"                           // for BootstrapNext
 #include "xgboost/collective/poll_utils.h"  // for PollHelper
 #include "xgboost/collective/result.h"      // for Result, Fail, Success
 #include "xgboost/collective/socket.h"      // for GetHostName, FailWithCode, MakeSockAddress, ...

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -23,13 +23,10 @@
 #include <limits>                         // for numeric_limits
 #include <memory>                         // for allocator, unique_ptr, shared_ptr, operator==
 #include <mutex>                          // for mutex, lock_guard
-#include <set>                            // for set
 #include <sstream>                        // for operator<<, basic_ostream, basic_ostream::opera...
 #include <stack>                          // for stack
 #include <string>                         // for basic_string, char_traits, operator<, string
 #include <system_error>                   // for errc
-#include <tuple>                          // for get
-#include <unordered_map>                  // for operator!=, unordered_map
 #include <utility>                        // for pair, as_const, move, swap
 #include <vector>                         // for vector
 

--- a/tests/cpp/collective/test_worker.h
+++ b/tests/cpp/collective/test_worker.h
@@ -49,7 +49,7 @@ class WorkerForTest {
 
   void LimitSockBuf(std::int32_t n_bytes) {
     for (std::int32_t i = 0; i < comm_.World(); ++i) {
-      if (i != comm_.Rank()) {
+      if (comm_.Chan(i)->Socket()) {
         ASSERT_TRUE(comm_.Chan(i)->Socket()->NonBlocking());
         SafeColl(comm_.Chan(i)->Socket()->SetBufSize(n_bytes));
         SafeColl(comm_.Chan(i)->Socket()->SetNoDelay());


### PR DESCRIPTION
- Use a fixed tree topo for broadcast by always sending the data to the 0th node.

XGBoost always broadcast with 0th node as root anyway.

- Reduce the amount of connections.