### PR TITLE
[jvm-packages] bring back camel case variants of parameters

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimatorSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimatorSuite.scala
@@ -69,6 +69,48 @@ class XGBoostEstimatorSuite extends AnyFunSuite with PerTest with TmpFolderPerSu
     assert(model.getContribPredictionCol === "contrib")
   }
 
+  test("camel case parameters") {
+    val xgbParams: Map[String, Any] = Map(
+      "max_depth" -> 5,
+      "featuresCol" -> "abc",
+      "num_workers" -> 2,
+      "numRound" -> 11
+    )
+    val estimator = new XGBoostClassifier(xgbParams)
+    assert(estimator.getFeaturesCol === "abc")
+    assert(estimator.getNumWorkers === 2)
+    assert(estimator.getNumRound === 11)
+    assert(estimator.getMaxDepth === 5)
+
+    val xgbParams1: Map[String, Any] = Map(
+      "maxDepth" -> 5,
+      "features_col" -> "abc",
+      "numWorkers" -> 2,
+      "num_round" -> 11
+    )
+    val estimator1 = new XGBoostClassifier(xgbParams1)
+    assert(estimator1.getFeaturesCol === "abc")
+    assert(estimator1.getNumWorkers === 2)
+    assert(estimator1.getNumRound === 11)
+    assert(estimator1.getMaxDepth === 5)
+  }
+
+  test("get xgboost parameters") {
+    val params: Map[String, Any] = Map(
+      "max_depth" -> 5,
+      "featuresCol" -> "abc",
+      "label" -> "class",
+      "num_workers" -> 2,
+      "tree_method" -> "hist",
+      "numRound" -> 11,
+      "not_exist_parameters" -> "hello"
+    )
+    val estimator = new XGBoostClassifier(params)
+    val xgbParams = estimator.getXGBoostParams
+    assert(xgbParams.size === 2)
+    assert(xgbParams.contains("max_depth") && xgbParams.contains("tree_method"))
+  }
+
   test("nthread") {
     val classifier = new XGBoostClassifier().setNthread(100)
 


### PR DESCRIPTION
This PR brings back the camel case variants of the parameters and keep compatible with the existing user experience.

For example,

```
```