### PR TITLE
[CI] Set timeout for freebsd vm launch.

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     name: A job to run test in FreeBSD
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
In case it takes forever to launch the VM. https://github.com/dmlc/xgboost/actions/runs/11077267440/job/30782144754 