### PR TITLE
Remove all use of custom thrust exec.

### DIFF
--- a/include/xgboost/data.h
+++ b/include/xgboost/data.h
@@ -211,8 +211,8 @@ class MetaInfo {
   bool HasCategorical() const { return has_categorical_; }
 
  private:
-  void SetInfoFromHost(Context const& ctx, StringView key, Json arr);
-  void SetInfoFromCUDA(Context const& ctx, StringView key, Json arr);
+  void SetInfoFromHost(Context const* ctx, StringView key, Json arr);
+  void SetInfoFromCUDA(Context const* ctx, StringView key, Json arr);
 
   /*! \brief argsort of labels */
   mutable std::vector<size_t> label_order_cache_;

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -680,8 +680,7 @@ size_t SegmentedUniqueByKey(
         return thrust::make_pair(seg, *(key_first + i));
       });
   size_t segments_len = key_segments_last - key_segments_first;
-  thrust::fill(thrust::device, key_segments_out,
-               key_segments_out + segments_len, 0);
+  thrust::fill(exec, key_segments_out, key_segments_out + segments_len, 0);
   size_t n_inputs = std::distance(key_first, key_last);
   // Reduce the number of uniques elements per segment, avoid creating an
   // intermediate array for `reduce_by_key`.  It's limited by the types that

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -465,7 +465,7 @@ MetaInfo MetaInfo::Copy() const {
 
 namespace {
 template <int32_t D, typename T>
-void CopyTensorInfoImpl(Context const& ctx, Json arr_interface, linalg::Tensor<T, D>* p_out) {
+void CopyTensorInfoImpl(Context const* ctx, Json arr_interface, linalg::Tensor<T, D>* p_out) {
   ArrayInterface<D> array{arr_interface};
   if (array.n == 0) {
     p_out->Reshape(array.shape);
@@ -489,7 +489,7 @@ void CopyTensorInfoImpl(Context const& ctx, Json arr_interface, linalg::Tensor<T
   CHECK(t_out.CContiguous());
   auto const shape = t_out.Shape();
   DispatchDType(array, DeviceOrd::CPU(), [&](auto&& in) {
-    linalg::ElementWiseTransformHost(t_out, ctx.Threads(), [&](auto i, auto) {
+    linalg::ElementWiseTransformHost(t_out, ctx->Threads(), [&](auto i, auto) {
       return std::apply(in, linalg::UnravelIndex<D>(i, shape));
     });
   });
@@ -513,13 +513,13 @@ void MetaInfo::SetInfo(Context const& ctx, StringView key, StringView interface_
   }
 
   if (is_cuda) {
-    this->SetInfoFromCUDA(ctx, key, j_interface);
+    this->SetInfoFromCUDA(&ctx, key, j_interface);
   } else {
-    this->SetInfoFromHost(ctx, key, j_interface);
+    this->SetInfoFromHost(&ctx, key, j_interface);
   }
 }
 
-void MetaInfo::SetInfoFromHost(Context const& ctx, StringView key, Json arr) {
+void MetaInfo::SetInfoFromHost(Context const* ctx, StringView key, Json arr) {
   // multi-dim float info
   if (key == "base_margin") {
     CopyTensorInfoImpl(ctx, arr, &this->base_margin_);

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -833,7 +833,7 @@ void MetaInfo::Validate(DeviceOrd device) const {
 }
 
 #if !defined(XGBOOST_USE_CUDA)
-void MetaInfo::SetInfoFromCUDA(Context const&, StringView, Json) { common::AssertGPUSupport(); }
+void MetaInfo::SetInfoFromCUDA(Context const*, StringView, Json) { common::AssertGPUSupport(); }
 #endif  // !defined(XGBOOST_USE_CUDA)
 
 bool MetaInfo::IsVerticalFederated() const {

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -311,7 +311,7 @@ void CopyDataToEllpack(Context const* ctx, const AdapterBatchT& batch,
                        common::Span<FeatureType const> feature_types, EllpackPageImpl* dst,
                        float missing) {
   data::IsValidFunctor is_valid(missing);
-  bool valid = data::NoInfInData(batch, is_valid);
+  bool valid = data::NoInfInData(ctx, batch, is_valid);
   CHECK(valid) << error::InfInData();
 
   auto cnt = thrust::make_counting_iterator(0llu);

--- a/src/data/simple_dmatrix.cu
+++ b/src/data/simple_dmatrix.cu
@@ -37,7 +37,8 @@ SimpleDMatrix::SimpleDMatrix(AdapterT* adapter, float missing, std::int32_t nthr
   // Enforce single batch
   CHECK(!adapter->Next());
 
-  info_.num_nonzero_ = CopyToSparsePage(adapter->Value(), device, missing, sparse_page_.get());
+  info_.num_nonzero_ =
+      CopyToSparsePage(&ctx, adapter->Value(), device, missing, sparse_page_.get());
   info_.num_col_ = adapter->NumColumns();
   info_.num_row_ = adapter->NumRows();
   // Synchronise worker columns

--- a/src/data/simple_dmatrix.cuh
+++ b/src/data/simple_dmatrix.cuh
@@ -28,24 +28,25 @@ struct COOToEntryOp {
 // Here the data is already correctly ordered and simply needs to be compacted
 // to remove missing data
 template <typename AdapterBatchT>
-void CopyDataToDMatrix(AdapterBatchT batch, common::Span<Entry> data, float missing) {
+void CopyDataToDMatrix(Context const* ctx, AdapterBatchT batch, common::Span<Entry> data,
+                       float missing) {
   auto counting = thrust::make_counting_iterator(0llu);
   COOToEntryOp<decltype(batch)> transform_op{batch};
   thrust::transform_iterator<decltype(transform_op), decltype(counting)> transform_iter(
       counting, transform_op);
   auto begin_output = thrust::device_pointer_cast(data.data());
-  auto ctx = Context{}.MakeCUDA(dh::CurrentDevice());
-  common::CopyIf(ctx.CUDACtx(), transform_iter, transform_iter + batch.Size(), begin_output,
+  common::CopyIf(ctx->CUDACtx(), transform_iter, transform_iter + batch.Size(), begin_output,
                  IsValidFunctor(missing));
 }
 
 template <typename AdapterBatchT>
-void CountRowOffsets(const AdapterBatchT& batch, common::Span<bst_idx_t> offset, DeviceOrd device,
-                     float missing) {
+void CountRowOffsets(Context const* ctx, const AdapterBatchT& batch, common::Span<bst_idx_t> offset,
+                     DeviceOrd device, float missing) {
   dh::safe_cuda(cudaSetDevice(device.ordinal));
   IsValidFunctor is_valid(missing);
+  auto cuctx = ctx->CUDACtx();
   // Count elements per row
-  dh::LaunchN(batch.Size(), [=] __device__(size_t idx) {
+  dh::LaunchN(batch.Size(), cuctx->Stream(), [=] __device__(size_t idx) {
     auto element = batch.GetElement(idx);
     if (is_valid(element)) {
       atomicAdd(reinterpret_cast<unsigned long long*>(  // NOLINT
@@ -54,26 +55,25 @@ void CountRowOffsets(const AdapterBatchT& batch, common::Span<bst_idx_t> offset,
     }
   });
 
-  dh::XGBCachingDeviceAllocator<char> alloc;
-  thrust::exclusive_scan(thrust::cuda::par(alloc), thrust::device_pointer_cast(offset.data()),
+  thrust::exclusive_scan(cuctx->CTP(), thrust::device_pointer_cast(offset.data()),
                          thrust::device_pointer_cast(offset.data() + offset.size()),
                          thrust::device_pointer_cast(offset.data()));
 }
 
 template <typename AdapterBatchT>
-size_t CopyToSparsePage(AdapterBatchT const& batch, DeviceOrd device, float missing,
-                        SparsePage* page) {
-  bool valid = NoInfInData(batch, IsValidFunctor{missing});
+bst_idx_t CopyToSparsePage(Context const* ctx, AdapterBatchT const& batch, DeviceOrd device,
+                           float missing, SparsePage* page) {
+  bool valid = NoInfInData(ctx, batch, IsValidFunctor{missing});
   CHECK(valid) << error::InfInData();
 
   page->offset.SetDevice(device);
   page->data.SetDevice(device);
   page->offset.Resize(batch.NumRows() + 1);
   auto s_offset = page->offset.DeviceSpan();
-  CountRowOffsets(batch, s_offset, device, missing);
+  CountRowOffsets(ctx, batch, s_offset, device, missing);
   auto num_nonzero_ = page->offset.HostVector().back();
   page->data.Resize(num_nonzero_);
-  CopyDataToDMatrix(batch, page->data.DeviceSpan(), missing);
+  CopyDataToDMatrix(ctx, batch, page->data.DeviceSpan(), missing);
 
   return num_nonzero_;
 }

--- a/src/data/sparse_page_source.cu
+++ b/src/data/sparse_page_source.cu
@@ -14,9 +14,10 @@ void DevicePush(DMatrixProxy *proxy, float missing, SparsePage *page) {
     device = DeviceOrd::CUDA(dh::CurrentDevice());
   }
   CHECK(device.IsCUDA());
+  auto ctx = Context{}.MakeCUDA(device.ordinal);
 
-  cuda_impl::Dispatch(proxy,
-                      [&](auto const &value) { CopyToSparsePage(value, device, missing, page); });
+  cuda_impl::Dispatch(
+      proxy, [&](auto const &value) { CopyToSparsePage(&ctx, value, device, missing, page); });
 }
 
 void InitNewThread::operator()() const {

--- a/src/metric/auc.cu
+++ b/src/metric/auc.cu
@@ -112,10 +112,9 @@ std::tuple<double, double, double> GPUBinaryAUC(Context const *ctx,
     return thrust::make_pair(fp, tp);
   };  // NOLINT
   auto d_fptp = dh::ToSpan(cache->fptp);
-  dh::LaunchN(d_sorted_idx.size(),
+  dh::LaunchN(d_sorted_idx.size(), ctx->CUDACtx()->Stream(),
               [=] XGBOOST_DEVICE(size_t i) { d_fptp[i] = get_fp_tp(i); });
 
-  dh::XGBDeviceAllocator<char> alloc;
   auto d_unique_idx = dh::ToSpan(cache->unique_idx);
   dh::Iota(d_unique_idx, ctx->CUDACtx()->Stream());
 
@@ -123,9 +122,8 @@ std::tuple<double, double, double> GPUBinaryAUC(Context const *ctx,
       thrust::make_counting_iterator(0),
       [=] XGBOOST_DEVICE(size_t i) { return predts[d_sorted_idx[i]]; });
   auto end_unique = thrust::unique_by_key_copy(
-      thrust::cuda::par(alloc), uni_key, uni_key + d_sorted_idx.size(),
-      dh::tbegin(d_unique_idx), thrust::make_discard_iterator(),
-      dh::tbegin(d_unique_idx));
+      ctx->CUDACtx()->TP(), uni_key, uni_key + d_sorted_idx.size(), dh::tbegin(d_unique_idx),
+      thrust::make_discard_iterator(), dh::tbegin(d_unique_idx));
   d_unique_idx = d_unique_idx.subspan(0, end_unique.second - dh::tbegin(d_unique_idx));
 
   common::InclusiveScan(ctx, dh::tbegin(d_fptp), dh::tbegin(d_fptp), PairPlus<double, double>{},
@@ -134,7 +132,7 @@ std::tuple<double, double, double> GPUBinaryAUC(Context const *ctx,
   auto d_neg_pos = dh::ToSpan(cache->neg_pos);
   // scatter unique negaive/positive values
   // shift to right by 1 with initial value being 0
-  dh::LaunchN(d_unique_idx.size(), [=] XGBOOST_DEVICE(size_t i) {
+  dh::LaunchN(d_unique_idx.size(), ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(size_t i) {
     if (d_unique_idx[i] == 0) {  // first unique index is 0
       assert(i == 0);
       d_neg_pos[0] = {0, 0};
@@ -165,7 +163,7 @@ std::tuple<double, double, double> GPUBinaryAUC(Context const *ctx,
       });
 
   Pair last = cache->fptp.back();
-  double auc = thrust::reduce(thrust::cuda::par(alloc), in, in + d_unique_idx.size());
+  double auc = thrust::reduce(ctx->CUDACtx()->CTP(), in, in + d_unique_idx.size());
   return std::make_tuple(last.first, last.second, auc);
 }
 
@@ -273,16 +271,13 @@ void SegmentedFPTP(Context const *ctx, common::Span<Pair> d_fptp, Fn segment_id)
  * Reduce the values of AUC for each group/class.
  */
 template <typename Area, typename Seg>
-void SegmentedReduceAUC(common::Span<size_t const> d_unique_idx,
+void SegmentedReduceAUC(Context const *ctx, common::Span<size_t const> d_unique_idx,
                         common::Span<uint32_t const> d_class_ptr,
                         common::Span<uint32_t const> d_unique_class_ptr,
-                        std::shared_ptr<DeviceAUCCache> cache,
-                        Area area_fn,
-                        Seg segment_id,
+                        std::shared_ptr<DeviceAUCCache> cache, Area area_fn, Seg segment_id,
                         common::Span<double> d_auc) {
   auto d_fptp = dh::ToSpan(cache->fptp);
   auto d_neg_pos = dh::ToSpan(cache->neg_pos);
-  dh::XGBDeviceAllocator<char> alloc;
   auto key_in = dh::MakeTransformIterator<uint32_t>(
       thrust::make_counting_iterator(0), [=] XGBOOST_DEVICE(size_t i) {
         size_t class_id = segment_id(d_unique_idx[i]);
@@ -305,8 +300,7 @@ void SegmentedReduceAUC(common::Span<size_t const> d_unique_idx,
         double auc = area_fn(fp_prev, fp, tp_prev, tp, class_id);
         return auc;
       });
-  thrust::reduce_by_key(thrust::cuda::par(alloc), key_in,
-                        key_in + d_unique_idx.size(), val_in,
+  thrust::reduce_by_key(ctx->CUDACtx()->TP(), key_in, key_in + d_unique_idx.size(), val_in,
                         thrust::make_discard_iterator(), dh::tbegin(d_auc));
 }
 
@@ -365,7 +359,6 @@ double GPUMultiClassAUCOVR(Context const *ctx, MetaInfo const &info,
   /**
    *  Handle duplicated predictions
    */
-  dh::XGBDeviceAllocator<char> alloc;
   auto d_unique_idx = dh::ToSpan(cache->unique_idx);
   dh::Iota(d_unique_idx, ctx->CUDACtx()->Stream());
   auto uni_key = dh::MakeTransformIterator<thrust::pair<uint32_t, float>>(
@@ -379,7 +372,7 @@ double GPUMultiClassAUCOVR(Context const *ctx, MetaInfo const &info,
   dh::TemporaryArray<uint32_t> unique_class_ptr(d_class_ptr.size());
   auto d_unique_class_ptr = dh::ToSpan(unique_class_ptr);
   auto n_uniques = dh::SegmentedUniqueByKey(
-      thrust::cuda::par(alloc),
+      ctx->CUDACtx()->TP(),
       dh::tbegin(d_class_ptr),
       dh::tend(d_class_ptr),
       uni_key,
@@ -397,7 +390,7 @@ double GPUMultiClassAUCOVR(Context const *ctx, MetaInfo const &info,
   auto d_neg_pos = dh::ToSpan(cache->neg_pos);
   // When dataset is not empty, each class must have at least 1 (unique) sample
   // prediction, so no need to handle special case.
-  dh::LaunchN(d_unique_idx.size(), [=] XGBOOST_DEVICE(size_t i) {
+  dh::LaunchN(d_unique_idx.size(), ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(size_t i) {
     if (d_unique_idx[i] % n_samples == 0) {  // first unique index is 0
       assert(d_unique_idx[i] % n_samples == 0);
       d_neg_pos[d_unique_idx[i]] = {0, 0};   // class_id * n_samples = i
@@ -417,8 +410,8 @@ double GPUMultiClassAUCOVR(Context const *ctx, MetaInfo const &info,
    * Reduce the result for each class
    */
   auto s_d_auc = dh::ToSpan(d_auc);
-  SegmentedReduceAUC(d_unique_idx, d_class_ptr, d_unique_class_ptr, cache,
-                     area_fn, get_class_id, s_d_auc);
+  SegmentedReduceAUC(ctx, d_unique_idx, d_class_ptr, d_unique_class_ptr, cache, area_fn,
+                     get_class_id, s_d_auc);
 
   /**
    * Scale the classes with number of samples for each class.
@@ -430,7 +423,7 @@ double GPUMultiClassAUCOVR(Context const *ctx, MetaInfo const &info,
   auto tp = d_results.subspan(2 * n_classes, n_classes);
   auto auc = d_results.subspan(3 * n_classes, n_classes);
 
-  dh::LaunchN(n_classes, [=] XGBOOST_DEVICE(size_t c) {
+  dh::LaunchN(n_classes, ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(size_t c) {
     auc[c] = s_d_auc[c];
     auto last = d_fptp[n_samples * c + (n_samples - 1)];
     fp[c] = last.first;
@@ -455,7 +448,7 @@ void MultiClassSortedIdx(Context const *ctx, common::Span<float const> predts,
     return;
   }
   Transpose(predts, d_predts_t, n_samples, n_classes);
-  dh::LaunchN(n_classes + 1,
+  dh::LaunchN(n_classes + 1, ctx->CUDACtx()->Stream(),
               [=] XGBOOST_DEVICE(size_t i) { d_class_ptr[i] = i * n_samples; });
   auto d_sorted_idx = dh::ToSpan(cache->sorted_idx);
   common::SegmentedArgSort<false, false>(ctx, d_predts_t, d_class_ptr, d_sorted_idx);
@@ -496,7 +489,6 @@ std::pair<double, std::uint32_t> GPURankingAUC(Context const *ctx, common::Span<
   InitCacheOnce<false>(predts, p_cache);
 
   dh::caching_device_vector<bst_group_t> group_ptr(info.group_ptr_);
-  dh::XGBCachingDeviceAllocator<char> alloc;
 
   auto d_group_ptr = dh::ToSpan(group_ptr);
   /**
@@ -505,9 +497,9 @@ std::pair<double, std::uint32_t> GPURankingAUC(Context const *ctx, common::Span<
   auto check_it = dh::MakeTransformIterator<size_t>(
       thrust::make_counting_iterator(0),
       [=] XGBOOST_DEVICE(size_t i) { return d_group_ptr[i + 1] - d_group_ptr[i]; });
-  size_t n_valid = thrust::count_if(
-      thrust::cuda::par(alloc), check_it, check_it + group_ptr.size() - 1,
-      [=] XGBOOST_DEVICE(size_t len) { return len >= 3; });
+  size_t n_valid =
+      thrust::count_if(ctx->CUDACtx()->CTP(), check_it, check_it + group_ptr.size() - 1,
+                       [=] XGBOOST_DEVICE(size_t len) { return len >= 3; });
   if (n_valid < info.group_ptr_.size() - 1) {
     InvalidGroupAUC();
   }
@@ -604,8 +596,7 @@ std::pair<double, std::uint32_t> GPURankingAUC(Context const *ctx, common::Span<
   /**
    * Scale the AUC with number of items in each group.
    */
-  double auc = thrust::reduce(thrust::cuda::par(alloc), dh::tbegin(s_d_auc),
-                              dh::tend(s_d_auc), 0.0);
+  double auc = thrust::reduce(ctx->CUDACtx()->CTP(), dh::tbegin(s_d_auc), dh::tend(s_d_auc), 0.0);
   return std::make_pair(auc, n_valid);
 }
 
@@ -631,11 +622,9 @@ std::tuple<double, double, double> GPUBinaryPRAUC(Context const *ctx,
         return thrust::make_pair(labels(d_sorted_idx[i]) * w,
                                  (1.0f - labels(d_sorted_idx[i])) * w);
       });
-  dh::XGBCachingDeviceAllocator<char> alloc;
   double total_pos, total_neg;
-  thrust::tie(total_pos, total_neg) =
-      thrust::reduce(thrust::cuda::par(alloc), it, it + labels.Size(),
-                     Pair{0.0, 0.0}, PairPlus<double, double>{});
+  thrust::tie(total_pos, total_neg) = thrust::reduce(ctx->CUDACtx()->CTP(), it, it + labels.Size(),
+                                                     Pair{0.0, 0.0}, PairPlus<double, double>{});
 
   if (total_pos <= 0.0 || total_neg <= 0.0) {
     return {0.0f, 0.0f, 0.0f};
@@ -686,11 +675,9 @@ double GPUMultiClassPRAUC(Context const *ctx, common::Span<float const> predts,
         auto y = labels(idx) == class_id;
         return thrust::make_pair(y * w, (1.0f - y) * w);
       });
-  dh::XGBCachingDeviceAllocator<char> alloc;
-  thrust::reduce_by_key(thrust::cuda::par(alloc), key_it,
-                        key_it + predts.size(), val_it,
-                        thrust::make_discard_iterator(), totals.begin(),
-                        thrust::equal_to<size_t>{}, PairPlus<double, double>{});
+  thrust::reduce_by_key(ctx->CUDACtx()->CTP(), key_it, key_it + predts.size(), val_it,
+                        thrust::make_discard_iterator(), totals.begin(), thrust::equal_to<size_t>{},
+                        PairPlus<double, double>{});
 
   /**
    * Calculate AUC
@@ -739,13 +726,12 @@ std::pair<double, uint32_t> GPURankingPRAUCImpl(Context const *ctx,
     float tp = label * w;
     return thrust::make_pair(fp, tp);
   };  // NOLINT
-  dh::LaunchN(d_sorted_idx.size(),
+  dh::LaunchN(d_sorted_idx.size(), ctx->CUDACtx()->Stream(),
               [=] XGBOOST_DEVICE(size_t i) { d_fptp[i] = get_fp_tp(i); });
 
   /**
    *  Handle duplicated predictions
    */
-  dh::XGBDeviceAllocator<char> alloc;
   auto d_unique_idx = dh::ToSpan(cache->unique_idx);
   dh::Iota(d_unique_idx, ctx->CUDACtx()->Stream());
   auto uni_key = dh::MakeTransformIterator<thrust::pair<uint32_t, float>>(
@@ -760,7 +746,7 @@ std::pair<double, uint32_t> GPURankingPRAUCImpl(Context const *ctx,
   dh::TemporaryArray<uint32_t> unique_class_ptr(d_group_ptr.size());
   auto d_unique_class_ptr = dh::ToSpan(unique_class_ptr);
   auto n_uniques = dh::SegmentedUniqueByKey(
-      thrust::cuda::par(alloc),
+      ctx->CUDACtx()->TP(),
       dh::tbegin(d_group_ptr),
       dh::tend(d_group_ptr),
       uni_key,
@@ -799,8 +785,8 @@ std::pair<double, uint32_t> GPURankingPRAUCImpl(Context const *ctx,
    * Reduce the result for each group
    */
   auto s_d_auc = dh::ToSpan(d_auc);
-  SegmentedReduceAUC(d_unique_idx, d_group_ptr, d_unique_class_ptr, cache,
-                     area_fn, get_group_id, s_d_auc);
+  SegmentedReduceAUC(ctx, d_unique_idx, d_group_ptr, d_unique_class_ptr, cache, area_fn,
+                     get_group_id, s_d_auc);
 
   /**
    * Scale the groups with number of samples for each group.
@@ -819,9 +805,9 @@ std::pair<double, uint32_t> GPURankingPRAUCImpl(Context const *ctx,
           }
           return thrust::make_pair(0.0, static_cast<uint32_t>(1));
         });
-    thrust::tie(auc, invalid_groups) = thrust::reduce(
-        thrust::cuda::par(alloc), it, it + n_groups,
-        thrust::pair<double, uint32_t>(0.0, 0), PairPlus<double, uint32_t>{});
+    thrust::tie(auc, invalid_groups) =
+        thrust::reduce(ctx->CUDACtx()->CTP(), it, it + n_groups,
+                       thrust::pair<double, uint32_t>(0.0, 0), PairPlus<double, uint32_t>{});
   }
   return std::make_pair(auc, n_groups - invalid_groups);
 }
@@ -850,10 +836,9 @@ std::pair<double, std::uint32_t> GPURankingPRAUC(Context const *ctx,
   auto d_sorted_idx = dh::ToSpan(cache->sorted_idx);
   common::SegmentedArgSort<false, false>(ctx, predts, d_group_ptr, d_sorted_idx);
 
-  dh::XGBDeviceAllocator<char> alloc;
   auto labels = info.labels.View(ctx->Device());
-  if (thrust::any_of(thrust::cuda::par(alloc), dh::tbegin(labels.Values()),
-                     dh::tend(labels.Values()), PRAUCLabelInvalid{})) {
+  if (thrust::any_of(ctx->CUDACtx()->CTP(), dh::tbegin(labels.Values()), dh::tend(labels.Values()),
+                     PRAUCLabelInvalid{})) {
     InvalidLabels();
   }
   /**
@@ -875,10 +860,9 @@ std::pair<double, std::uint32_t> GPURankingPRAUC(Context const *ctx,
         auto y = labels(i);
         return thrust::make_pair(y * w, (1.0 - y) * w);
       });
-  thrust::reduce_by_key(thrust::cuda::par(alloc), key_it,
-                        key_it + predts.size(), val_it,
-                        thrust::make_discard_iterator(), totals.begin(),
-                        thrust::equal_to<size_t>{}, PairPlus<double, double>{});
+  thrust::reduce_by_key(ctx->CUDACtx()->CTP(), key_it, key_it + predts.size(), val_it,
+                        thrust::make_discard_iterator(), totals.begin(), thrust::equal_to<size_t>{},
+                        PairPlus<double, double>{});
 
   /**
    * Calculate AUC

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -22,7 +22,6 @@
 #include "xgboost/metric.h"
 
 #if defined(XGBOOST_USE_CUDA)
-#include <thrust/execution_policy.h>  // thrust::cuda::par
 #include <thrust/functional.h>        // thrust::plus<>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform_reduce.h>

--- a/src/metric/multiclass_metric.cu
+++ b/src/metric/multiclass_metric.cu
@@ -16,11 +16,11 @@
 #include "metric_common.h"  // MetricNoCache
 
 #if defined(XGBOOST_USE_CUDA)
-#include <thrust/execution_policy.h>  // thrust::cuda::par
 #include <thrust/functional.h>        // thrust::plus<>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform_reduce.h>
 
+#include "../common/cuda_context.cuh"  // for CUDAContext
 #include "../common/device_helpers.cuh"
 #endif  // XGBOOST_USE_CUDA
 
@@ -82,11 +82,11 @@ class MultiClassMetricsReduction {
 
 #if defined(XGBOOST_USE_CUDA)
 
-  PackedReduceResult DeviceReduceMetrics(
-      const HostDeviceVector<bst_float>& weights,
-      const HostDeviceVector<bst_float>& labels,
-      const HostDeviceVector<bst_float>& preds,
-      const size_t n_class) {
+  PackedReduceResult DeviceReduceMetrics(Context const* ctx,
+                                         const HostDeviceVector<bst_float>& weights,
+                                         const HostDeviceVector<bst_float>& labels,
+                                         const HostDeviceVector<bst_float>& preds,
+                                         const size_t n_class) {
     size_t n_data = labels.Size();
 
     thrust::counting_iterator<size_t> begin(0);
@@ -100,9 +100,8 @@ class MultiClassMetricsReduction {
     auto s_label_error = label_error_.GetSpan<int32_t>(1);
     s_label_error[0] = 0;
 
-    dh::XGBCachingDeviceAllocator<char> alloc;
     PackedReduceResult result = thrust::transform_reduce(
-        thrust::cuda::par(alloc),
+        ctx->CUDACtx()->CTP(),
         begin, end,
         [=] XGBOOST_DEVICE(size_t idx) {
           bst_float weight = is_null_weight ? 1.0f : s_weights[idx];
@@ -125,25 +124,23 @@ class MultiClassMetricsReduction {
 
 #endif  // XGBOOST_USE_CUDA
 
-  PackedReduceResult Reduce(const Context& ctx, DeviceOrd device, size_t n_class,
+  PackedReduceResult Reduce(Context const* ctx, size_t n_class,
                             const HostDeviceVector<bst_float>& weights,
                             const HostDeviceVector<bst_float>& labels,
                             const HostDeviceVector<bst_float>& preds) {
     PackedReduceResult result;
 
-    if (!device.IsCUDA()) {
-      result =
-          CpuReduceMetrics(weights, labels, preds, n_class, ctx.Threads());
+    if (ctx->IsCPU()) {
+      result = CpuReduceMetrics(weights, labels, preds, n_class, ctx->Threads());
     }
 #if defined(XGBOOST_USE_CUDA)
     else {  // NOLINT
-      device_ = ctx.Device();
-      preds.SetDevice(device_);
-      labels.SetDevice(device_);
-      weights.SetDevice(device_);
+      preds.SetDevice(ctx->Device());
+      labels.SetDevice(ctx->Device());
+      weights.SetDevice(ctx->Device());
 
-      dh::safe_cuda(cudaSetDevice(device_.ordinal));
-      result = DeviceReduceMetrics(weights, labels, preds, n_class);
+      dh::safe_cuda(cudaSetDevice(ctx->Ordinal()));
+      result = DeviceReduceMetrics(ctx, weights, labels, preds, n_class);
     }
 #endif  // defined(XGBOOST_USE_CUDA)
     return result;
@@ -152,7 +149,6 @@ class MultiClassMetricsReduction {
  private:
 #if defined(XGBOOST_USE_CUDA)
   dh::PinnedMemory label_error_;
-  DeviceOrd device_{DeviceOrd::CPU()};
 #endif  // defined(XGBOOST_USE_CUDA)
 };
 
@@ -174,9 +170,7 @@ struct EvalMClassBase : public MetricNoCache {
       CHECK_GE(nclass, 1U)
           << "mlogloss and merror are only used for multi-class classification,"
           << " use logloss for binary classification";
-      auto device = ctx_->Device();
-      auto result =
-          reducer_.Reduce(*ctx_, device, nclass, info.weights_, *info.labels.Data(), preds);
+      auto result = reducer_.Reduce(this->ctx_, nclass, info.weights_, *info.labels.Data(), preds);
       dat[0] = result.Residue();
       dat[1] = result.Weights();
     }

--- a/src/tree/constraints.cu
+++ b/src/tree/constraints.cu
@@ -159,7 +159,8 @@ void FeatureInteractionConstraintDevice::ClearBuffers() {
       output_buffer_bits_, input_buffer_bits_);
 }
 
-common::Span<bst_feature_t> FeatureInteractionConstraintDevice::QueryNode(int32_t node_id) {
+common::Span<bst_feature_t> FeatureInteractionConstraintDevice::QueryNode(Context const* ctx,
+                                                                          bst_node_t node_id) {
   if (!has_constraint_) { return {}; }
   CHECK_LT(node_id, s_node_constraints_.size());
 
@@ -171,10 +172,7 @@ common::Span<bst_feature_t> FeatureInteractionConstraintDevice::QueryNode(int32_
   LBitField64 node_constraints = s_node_constraints_[node_id];
 
   thrust::device_ptr<bst_feature_t> const out_end = thrust::copy_if(
-      thrust::device,
-      begin, end,
-      p_result_buffer,
-      [=]__device__(int32_t pos) {
+      ctx->CUDACtx()->CTP(), begin, end, p_result_buffer, [=] __device__(int32_t pos) {
         bool res = node_constraints.Check(pos);
         return res;
       });

--- a/src/tree/constraints.cuh
+++ b/src/tree/constraints.cuh
@@ -80,7 +80,7 @@ struct FeatureInteractionConstraintDevice {
   /*! \brief Reset before constructing a new tree. */
   void Reset(Context const* ctx);
   /*! \brief Return a list of features given node id */
-  common::Span<bst_feature_t> QueryNode(int32_t nid);
+  common::Span<bst_feature_t> QueryNode(Context const* ctx, bst_node_t nid);
   /*!
    * \brief Return a list of selected features from given feature_list and node id.
    *


### PR DESCRIPTION
- Avoid `cudaMalloc` in thrust.
- Avoid synchronization.

I have checked regression model training using gdb, and there's no more `cudaMalloc` calls in thrust. But we might still have lingering thrust calls that don't have any execution policy in other model types. Also, NCCL might allocate memory using cuda driver API.