### PR TITLE
[EM] Improve external iterator.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,7 @@ jobs:
         architecture: 'x64'
     - name: Install Python packages
       run: |
-        python -m pip install wheel setuptools cmakelint cpplint pylint
+        python -m pip install wheel setuptools cmakelint cpplint==1.6.1 pylint
     - name: Run lint
       run: |
         python3 tests/ci_build/lint_cpp.py

--- a/demo/guide-python/external_memory.py
+++ b/demo/guide-python/external_memory.py
@@ -72,21 +72,21 @@ class Iterator(xgboost.DataIter):
         assert X.shape[0] == y.shape[0]
         return X, y
 
-    def next(self, input_data: Callable) -> int:
+    def next(self, input_data: Callable) -> bool:
         """Advance the iterator by 1 step and pass the data to XGBoost.  This function
         is called by XGBoost during the construction of ``DMatrix``
 
         """
         if self._it == len(self._file_paths):
-            # return 0 to let XGBoost know this is the end of iteration
-            return 0
+            # return False to let XGBoost know this is the end of iteration
+            return False
 
         # input_data is a function passed in by XGBoost and has the similar signature to
         # the ``DMatrix`` constructor.
         X, y = self.load_file()
         input_data(data=X, label=y)
         self._it += 1
-        return 1
+        return True
 
     def reset(self) -> None:
         """Reset the iterator to its beginning"""

--- a/demo/guide-python/external_memory.py
+++ b/demo/guide-python/external_memory.py
@@ -153,7 +153,7 @@ if __name__ == "__main__":
 
         # It's important to use RMM for GPU-based external memory to improve performance.
         # If XGBoost is not built with RMM support, a warning will be raised.
-        mr = rmm.mr.PoolMemoryResource(rmm.mr.CudaAsyncMemoryResource())
+        mr = rmm.mr.CudaAsyncMemoryResource()
         rmm.mr.set_current_device_resource(mr)
         # Set the allocator for cupy as well.
         cp.cuda.set_allocator(rmm_cupy_allocator)

--- a/doc/tutorials/external_memory.rst
+++ b/doc/tutorials/external_memory.rst
@@ -134,7 +134,7 @@ the GPU. This is a current limitation we aim to address in the future.
 
     # It's important to use RMM for GPU-based external memory to improve performance.
     # If XGBoost is not built with RMM support, a warning will be raised.
-    mr = rmm.mr.PoolMemoryResource(rmm.mr.CudaAsyncMemoryResource())
+    mr = rmm.mr.CudaAsyncMemoryResource()
     rmm.mr.set_current_device_resource(mr)
     # Set the allocator for cupy as well.
     cp.cuda.set_allocator(rmm_cupy_allocator)

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -665,7 +665,7 @@ class DataIter(ABC):  # pylint: disable=too-many-instance-attributes
         if self._release:
             self._temporary_data = None
         # pylint: disable=not-callable
-        return self._handle_exception(lambda: self.next(input_data), 0)
+        return self._handle_exception(lambda: int(self.next(input_data)), 0)
 
     @abstractmethod
     def reset(self) -> None:
@@ -673,7 +673,7 @@ class DataIter(ABC):  # pylint: disable=too-many-instance-attributes
         raise NotImplementedError()
 
     @abstractmethod
-    def next(self, input_data: Callable) -> int:
+    def next(self, input_data: Callable) -> bool:
         """Set the next batch of data.
 
         Parameters
@@ -685,7 +685,7 @@ class DataIter(ABC):  # pylint: disable=too-many-instance-attributes
 
         Returns
         -------
-        0 if there's no more batch, otherwise 1.
+        False if there's no more batch, otherwise True.
 
         """
         raise NotImplementedError()

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -636,11 +636,11 @@ class DaskPartitionIter(DataIter):  # pylint: disable=R0902
         """Reset the iterator"""
         self._iter = 0
 
-    def next(self, input_data: Callable) -> int:
+    def next(self, input_data: Callable) -> bool:
         """Yield next batch of data"""
         if self._iter == len(self._data):
-            # Return 0 when there's no more batch.
-            return 0
+            # Return False when there's no more batch.
+            return False
 
         input_data(
             data=self.data(),
@@ -656,7 +656,7 @@ class DaskPartitionIter(DataIter):  # pylint: disable=R0902
             feature_weights=self._feature_weights,
         )
         self._iter += 1
-        return 1
+        return True
 
 
 class DaskQuantileDMatrix(DaskDMatrix):

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -1472,12 +1472,12 @@ class SingleBatchInternalIter(DataIter):  # pylint: disable=R0902
         # might use memory.
         super().__init__(release_data=False)
 
-    def next(self, input_data: Callable) -> int:
+    def next(self, input_data: Callable) -> bool:
         if self.it == 1:
-            return 0
+            return False
         self.it += 1
         input_data(**self.kwargs)
-        return 1
+        return True
 
     def reset(self) -> None:
         self.it = 0

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -94,9 +94,9 @@ class PartIter(DataIter):
 
         return data[self._iter]
 
-    def next(self, input_data: Callable) -> int:
+    def next(self, input_data: Callable) -> bool:
         if self._iter == len(self._data[alias.data]):
-            return 0
+            return False
         input_data(
             data=self._fetch(self._data[alias.data]),
             label=self._fetch(self._data.get(alias.label, None)),
@@ -106,7 +106,7 @@ class PartIter(DataIter):
             **self._kwargs,
         )
         self._iter += 1
-        return 1
+        return True
 
     def reset(self) -> None:
         self._iter = 0

--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -235,9 +235,9 @@ class IteratorForTest(xgb.core.DataIter):
         self.it = 0
         super().__init__(cache_prefix=cache, on_host=on_host)
 
-    def next(self, input_data: Callable) -> int:
+    def next(self, input_data: Callable) -> bool:
         if self.it == len(self.X):
-            return 0
+            return False
 
         with pytest.raises(TypeError, match="Keyword argument"):
             input_data(self.X[self.it], self.y[self.it], None)
@@ -250,7 +250,7 @@ class IteratorForTest(xgb.core.DataIter):
         )
         gc.collect()  # clear up the copy, see if XGBoost access freed memory.
         self.it += 1
-        return 1
+        return True
 
     def reset(self) -> None:
         self.it = 0

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -239,9 +239,7 @@ void ExtEllpackPageSourceImpl<F>::Fetch() {
   curt::SetDevice(this->Device().ordinal);
   if (!this->ReadCache()) {
     auto iter = this->source_->Iter();
-    CHECK_EQ(this->count_, iter);
-    ++(*this->source_);
-    CHECK_GE(this->source_->Iter(), 1);
+    CHECK_EQ(this->Iter(), iter);
     cuda_impl::Dispatch(proxy_, [this](auto const& value) {
       CHECK(this->proxy_->Ctx()->IsCUDA()) << "All batches must use the same device type.";
       proxy_->Info().feature_types.SetDevice(dh::GetDevice(this->ctx_));

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -46,7 +46,7 @@ EllpackPageImpl const* EllpackHostCache::Get(std::int32_t k) {
  */
 class EllpackHostCacheStreamImpl {
   std::shared_ptr<EllpackHostCache> cache_;
-  std::int32_t ptr_;
+  std::int32_t ptr_{0};
 
  public:
   explicit EllpackHostCacheStreamImpl(std::shared_ptr<EllpackHostCache> cache)

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -1,8 +1,6 @@
 /**
  * Copyright 2019-2024, XGBoost contributors
  */
-#include <thrust/host_vector.h>  // for host_vector
-
 #include <cstddef>  // for size_t
 #include <cstdint>  // for int8_t, uint64_t, uint32_t
 #include <memory>   // for shared_ptr, make_unique, make_shared
@@ -267,7 +265,7 @@ void ExtEllpackPageSourceImpl<F>::Fetch() {
               << cuda_impl::Dispatch<false>(proxy_, [](auto const& adapter) {
                    return common::HumanMemUnit(adapter->SizeBytes());
                  });
-    this->page_->SetBaseRowId(this->ext_info_.base_rows.at(iter - 1));
+    this->page_->SetBaseRowId(this->ext_info_.base_rows.at(iter));
     this->WriteCache();
   }
 }

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -84,7 +84,9 @@ class EllpackFormatPolicy {
     curt::DrVersion(&major, &minor);
     if (!(major >= 12 && minor >= 7) && curt::SupportsAts()) {
       // Use ATS, but with an old kernel driver.
-      LOG(WARNING) << "Using an old kernel driver with supported CTK<12.7." << msg;
+      LOG(WARNING) << "Using an old kernel driver with supported CTK<12.7."
+                   << "The latest version of CTK supported by the current driver: " << major << "."
+                   << minor << "." << msg;
     }
   }
   // For testing with the HMM flag.

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -227,17 +227,6 @@ class ExtEllpackPageSourceImpl : public ExtQantileSourceMixin<EllpackPage, Forma
   }
 
   void Fetch() final;
-  // Need a specialized end iter as we can concatenate pages.
-  void EndIter() final {
-    if (this->cache_info_->written) {
-      CHECK_EQ(this->Iter(), this->cache_info_->Size());
-    } else {
-      CHECK_LE(this->cache_info_->Size(), this->ext_info_.n_batches);
-    }
-    this->cache_info_->Commit();
-    CHECK_GE(this->count_, 1);
-    this->count_ = 0;
-  }
 };
 
 // Cache to host

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -211,13 +211,8 @@ class ExtEllpackPageSourceImpl : public ExtQantileSourceMixin<EllpackPage, Forma
       Context const* ctx, float missing, MetaInfo* info, ExternalDataInfo ext_info,
       std::shared_ptr<Cache> cache, BatchParam param, std::shared_ptr<common::HistogramCuts> cuts,
       std::shared_ptr<DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>> source,
-      DMatrixProxy* proxy, std::vector<bst_idx_t> base_rows)
-      : Super{missing,
-              ctx->Threads(),
-              static_cast<bst_feature_t>(info->num_col_),
-              ext_info.n_batches,
-              source,
-              cache},
+      DMatrixProxy* proxy)
+      : Super{missing, ctx->Threads(), static_cast<bst_feature_t>(info->num_col_), source, cache},
         ctx_{ctx},
         p_{std::move(param)},
         proxy_{proxy},

--- a/src/data/extmem_quantile_dmatrix.cc
+++ b/src/data/extmem_quantile_dmatrix.cc
@@ -92,8 +92,7 @@ void ExtMemQuantileDMatrix::InitFromCPU(
    */
   auto id = MakeCache(this, ".gradient_index.page", false, cache_prefix_, &cache_info_);
   this->ghist_index_source_ = std::make_unique<ExtGradientIndexPageSource>(
-      ctx, missing, &this->Info(), ext_info.n_batches, cache_info_.at(id), p, cuts, iter, proxy,
-      ext_info.base_rows);
+      ctx, missing, &this->Info(), cache_info_.at(id), p, cuts, iter, proxy, ext_info.base_rows);
 
   /**
    * Force initialize the cache and do some sanity checks along the way

--- a/src/data/extmem_quantile_dmatrix.cu
+++ b/src/data/extmem_quantile_dmatrix.cu
@@ -44,7 +44,7 @@ void ExtMemQuantileDMatrix::InitFromCUDA(
       [&](auto &&ptr) {
         using SourceT = typename std::remove_reference_t<decltype(ptr)>::element_type;
         ptr = std::make_shared<SourceT>(ctx, missing, &this->Info(), ext_info, cache_info_.at(id),
-                                        p, cuts, iter, proxy, ext_info.base_rows);
+                                        p, cuts, iter, proxy);
       },
       ellpack_page_source_);
 

--- a/src/data/gradient_index_page_source.cc
+++ b/src/data/gradient_index_page_source.cc
@@ -32,7 +32,6 @@ void GradientIndexPageSource::Fetch() {
 void ExtGradientIndexPageSource::Fetch() {
   if (!this->ReadCache()) {
     CHECK_EQ(count_, source_->Iter());
-    CHECK_GE(source_->Iter(), 1);
     CHECK_NE(cuts_.Values().size(), 0);
     HostAdapterDispatch(proxy_, [this](auto const& value) {
       CHECK(this->proxy_->Ctx()->IsCPU()) << "All batches must use the same device type.";
@@ -48,9 +47,9 @@ void ExtGradientIndexPageSource::Fetch() {
       // FIXME(jiamingy): For now, we use the `info->IsDense()` to represent all batches
       // similar to the sparse DMatrix source. We should use per-batch property with proxy
       // DMatrix info instead. This requires more fine-grained tests.
-      this->page_ = std::make_shared<GHistIndexMatrix>(
-          value.NumRows(), this->base_rows_.at(source_->Iter() - 1), std::move(cuts),
-          this->p_.max_bin, info_->IsDense());
+      this->page_ =
+          std::make_shared<GHistIndexMatrix>(value.NumRows(), this->base_rows_.at(source_->Iter()),
+                                             std::move(cuts), this->p_.max_bin, info_->IsDense());
       bst_idx_t prev_sum = 0;
       bst_idx_t rbegin = 0;
       // Use `value.NumRows()` for the size of a single batch. Unlike the

--- a/src/data/gradient_index_page_source.cc
+++ b/src/data/gradient_index_page_source.cc
@@ -32,7 +32,6 @@ void GradientIndexPageSource::Fetch() {
 void ExtGradientIndexPageSource::Fetch() {
   if (!this->ReadCache()) {
     CHECK_EQ(count_, source_->Iter());
-    ++(*source_);
     CHECK_GE(source_->Iter(), 1);
     CHECK_NE(cuts_.Values().size(), 0);
     HostAdapterDispatch(proxy_, [this](auto const& value) {

--- a/src/data/proxy_dmatrix.h
+++ b/src/data/proxy_dmatrix.h
@@ -50,7 +50,7 @@ class DataIterProxy {
     reset_(iter_);
     count_ = 0;
   }
-  [[nodiscard]] std::uint32_t Iter() const { return this->count_; }
+  [[nodiscard]] std::int32_t Iter() const { return this->count_ == 0 ? 0 : this->count_ - 1; }
   DataIterProxy& operator++() {
     CHECK(this->Next());
     return *this;

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -78,14 +78,16 @@ void SparsePageDMatrix::InitializeSparsePage(Context const *ctx) {
   // Don't use proxy DMatrix once this is already initialized, this allows users to
   // release the iterator and data.
   if (cache_info_.at(id)->written) {
-    CHECK(sparse_page_source_);
-    sparse_page_source_->Reset({});
+    CHECK(this->sparse_page_source_);
+    this->sparse_page_source_->Reset({});
     return;
   }
 
   auto iter = DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>{iter_, reset_, next_};
   DMatrixProxy *proxy = MakeProxy(proxy_);
   sparse_page_source_.reset();  // clear before creating new one to prevent conflicts.
+  // During initialization, the n_batches_ is 0.
+  CHECK_EQ(this->n_batches_, static_cast<decltype(this->n_batches_)>(0));
   sparse_page_source_ = std::make_shared<SparsePageSource>(iter, proxy, this->missing_,
                                                            ctx->Threads(), this->info_.num_col_,
                                                            this->n_batches_, cache_info_.at(id));

--- a/src/data/sparse_page_source.h
+++ b/src/data/sparse_page_source.h
@@ -48,9 +48,7 @@ struct Cache {
   std::vector<bst_idx_t> offset;
 
   Cache(bool w, std::string n, std::string fmt, bool on_host)
-      : written{w}, on_host{on_host}, name{std::move(n)}, format{std::move(fmt)} {
-    offset.push_back(0);
-  }
+      : written{w}, on_host{on_host}, name{std::move(n)}, format{std::move(fmt)}, offset{0} {}
 
   [[nodiscard]] static std::string ShardName(std::string name, std::string format) {
     CHECK_EQ(format.front(), '.');
@@ -81,6 +79,10 @@ struct Cache {
    * @brief Call this once the write for the cache is complete.
    */
   void Commit();
+  /**
+   * @brief Returns the number of pages in the cache.
+   */
+  [[nodiscard]] bst_idx_t Size() const { return this->offset.size() - 1; }
 };
 
 inline void DeleteCacheFiles(std::map<std::string, std::shared_ptr<Cache>> const& cache_info) {
@@ -246,8 +248,6 @@ class SparsePageSourceImpl : public BatchIteratorImpl<S>, public FormatStreamPol
   bst_idx_t fetch_cnt_{0};  // Used for sanity check.
   // Index to the current page.
   std::uint32_t count_{0};
-  // Total number of batches.
-  bst_idx_t n_batches_{0};
   // How we pre-fetch the data.
   BatchParam param_;
 
@@ -267,13 +267,14 @@ class SparsePageSourceImpl : public BatchIteratorImpl<S>, public FormatStreamPol
     if (!cache_info_->written) {
       return false;
     }
+    auto n_batches = this->cache_info_->Size();
     if (ring_->empty()) {
-      ring_->resize(n_batches_);
+      ring_->resize(n_batches);
     }
 
     std::int32_t n_prefetches = std::min(nthreads_, this->param_.n_prefetch_batches);
     n_prefetches = std::max(n_prefetches, 1);
-    std::int32_t n_prefetch_batches = std::min(static_cast<bst_idx_t>(n_prefetches), n_batches_);
+    std::int32_t n_prefetch_batches = std::min(static_cast<bst_idx_t>(n_prefetches), n_batches);
     CHECK_GT(n_prefetch_batches, 0);
     CHECK_LE(n_prefetch_batches, this->param_.n_prefetch_batches);
     std::size_t fetch_it = count_;
@@ -285,8 +286,8 @@ class SparsePageSourceImpl : public BatchIteratorImpl<S>, public FormatStreamPol
     page_.reset();
 
     for (std::int32_t i = 0; i < n_prefetch_batches; ++i, ++fetch_it) {
-      bool restart = fetch_it == n_batches_;
-      fetch_it %= n_batches_;  // ring
+      bool restart = fetch_it == n_batches;
+      fetch_it %= n_batches;  // ring
       if (ring_->at(fetch_it).valid()) {
         continue;
       }
@@ -347,13 +348,12 @@ class SparsePageSourceImpl : public BatchIteratorImpl<S>, public FormatStreamPol
   virtual void Fetch() = 0;
 
  public:
-  SparsePageSourceImpl(float missing, int nthreads, bst_feature_t n_features, bst_idx_t n_batches,
+  SparsePageSourceImpl(float missing, int nthreads, bst_feature_t n_features,
                        std::shared_ptr<Cache> cache)
       : workers_{StringView{"ext-mem"}, std::max(2, std::min(nthreads, 16)), InitNewThread{}},
         missing_{missing},
         nthreads_{nthreads},
         n_features_{n_features},
-        n_batches_{n_batches},
         cache_info_{std::move(cache)} {
     monitor_.Init(typeid(S).name());  // not pretty, but works for basic profiling
   }
@@ -383,13 +383,11 @@ class SparsePageSourceImpl : public BatchIteratorImpl<S>, public FormatStreamPol
   [[nodiscard]] bool AtEnd() const override {
     return at_end_;
   }
-
   // Call this at the last iteration (it == n_batches).
-  void EndIter() {
-    CHECK_EQ(this->cache_info_->offset.size(), this->n_batches_ + 1);
+  virtual void EndIter() {
     this->cache_info_->Commit();
-    if (this->n_batches_ != 0) {
-      CHECK_EQ(this->count_, this->n_batches_);
+    if (this->cache_info_->Size() != 0) {
+      CHECK_EQ(this->count_, this->cache_info_->Size());
     }
     CHECK_GE(this->count_, 1);
     this->count_ = 0;
@@ -428,6 +426,8 @@ class SparsePageSource : public SparsePageSourceImpl<SparsePage> {
   DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext> iter_;
   DMatrixProxy* proxy_;
   std::size_t base_row_id_{0};
+  // Total number of batches.
+  bst_idx_t n_batches_{0};
 
   void Fetch() final {
     page_ = std::make_shared<SparsePage>();
@@ -447,18 +447,19 @@ class SparsePageSource : public SparsePageSourceImpl<SparsePage> {
 
       page_->SetBaseRowId(base_row_id_);
       base_row_id_ += page_->Size();
-      n_batches_++;
+      this->n_batches_++;
       this->WriteCache();
     }
   }
 
  public:
-  SparsePageSource(
-      DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext> iter,
-      DMatrixProxy *proxy, float missing, int nthreads,
-      bst_feature_t n_features, uint32_t n_batches, std::shared_ptr<Cache> cache)
-      : SparsePageSourceImpl(missing, nthreads, n_features, n_batches, cache),
-        iter_{iter}, proxy_{proxy} {
+  SparsePageSource(DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext> iter,
+                   DMatrixProxy* proxy, float missing, int nthreads, bst_feature_t n_features,
+                   bst_idx_t n_batches, std::shared_ptr<Cache> cache)
+      : SparsePageSourceImpl(missing, nthreads, n_features, cache),
+        iter_{iter},
+        proxy_{proxy},
+        n_batches_{n_batches} {
     if (!cache_info_->written) {
       iter_.Reset();
       CHECK(iter_.Next()) << "Must have at least 1 batch.";
@@ -511,11 +512,15 @@ class PageSourceIncMixIn : public SparsePageSourceImpl<S, FormatCreatePolicy> {
   // synchronize the row page, `hist` and `gpu_hist` don't need the original sparse page
   // so we avoid fetching it.
   bool const sync_;
+  // Total number of batches.
+  bst_idx_t const n_batches_{0};
 
  public:
   PageSourceIncMixIn(float missing, std::int32_t nthreads, bst_feature_t n_features,
                      bst_idx_t n_batches, std::shared_ptr<Cache> cache, bool sync)
-      : Super::SparsePageSourceImpl{missing, nthreads, n_features, n_batches, cache}, sync_{sync} {}
+      : Super::SparsePageSourceImpl{missing, nthreads, n_features, cache},
+        sync_{sync},
+        n_batches_{n_batches} {}
   // This function always operate on the source first, then the downstream. The downstream
   // can assume the source to be ready.
   [[nodiscard]] PageSourceIncMixIn& operator++() final {
@@ -606,8 +611,7 @@ class SortedCSCPageSource : public PageSourceIncMixIn<SortedCSCPage> {
 /**
  * @brief operator++ implementation for QDM.
  */
-template <typename S,
-          typename FormatCreatePolicy = DefaultFormatStreamPolicy<S, DefaultFormatPolicy>>
+template <typename S, typename FormatCreatePolicy>
 class ExtQantileSourceMixin : public SparsePageSourceImpl<S, FormatCreatePolicy> {
  protected:
   std::shared_ptr<DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>> source_;
@@ -615,10 +619,10 @@ class ExtQantileSourceMixin : public SparsePageSourceImpl<S, FormatCreatePolicy>
 
  public:
   ExtQantileSourceMixin(
-      float missing, std::int32_t nthreads, bst_feature_t n_features, bst_idx_t n_batches,
+      float missing, std::int32_t nthreads, bst_feature_t n_features,
       std::shared_ptr<DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>> source,
       std::shared_ptr<Cache> cache)
-      : Super::SparsePageSourceImpl{missing, nthreads, n_features, n_batches, cache},
+      : Super::SparsePageSourceImpl{missing, nthreads, n_features, cache},
         source_{std::move(source)} {}
   // This function always operate on the source first, then the downstream. The downstream
   // can assume the source to be ready.
@@ -627,7 +631,11 @@ class ExtQantileSourceMixin : public SparsePageSourceImpl<S, FormatCreatePolicy>
     // Increment self.
     ++this->count_;
     // Set at end.
-    this->at_end_ = this->count_ == this->n_batches_;
+    if (this->cache_info_->written) {
+      this->at_end_ = (this->Iter() == this->cache_info_->Size());
+    } else {
+      this->at_end_ = !this->source_->Next();
+    }
 
     if (this->at_end_) {
       this->EndIter();

--- a/src/data/sparse_page_source.h
+++ b/src/data/sparse_page_source.h
@@ -634,6 +634,7 @@ class ExtQantileSourceMixin : public SparsePageSourceImpl<S, FormatCreatePolicy>
     if (this->cache_info_->written) {
       this->at_end_ = (this->Iter() == this->cache_info_->Size());
     } else {
+      CHECK(this->source_);
       this->at_end_ = !this->source_->Next();
     }
 

--- a/src/data/sparse_page_source.h
+++ b/src/data/sparse_page_source.h
@@ -609,7 +609,7 @@ class SortedCSCPageSource : public PageSourceIncMixIn<SortedCSCPage> {
 };
 
 /**
- * @brief operator++ implementation for QDM.
+ * @brief operator++ implementation for ExtMemQDM.
  */
 template <typename S, typename FormatCreatePolicy>
 class ExtQantileSourceMixin : public SparsePageSourceImpl<S, FormatCreatePolicy> {
@@ -619,10 +619,10 @@ class ExtQantileSourceMixin : public SparsePageSourceImpl<S, FormatCreatePolicy>
 
  public:
   ExtQantileSourceMixin(
-      float missing, std::int32_t nthreads, bst_feature_t n_features,
+      float missing, std::int32_t n_threads, bst_feature_t n_features,
       std::shared_ptr<DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>> source,
       std::shared_ptr<Cache> cache)
-      : Super::SparsePageSourceImpl{missing, nthreads, n_features, cache},
+      : Super::SparsePageSourceImpl{missing, n_threads, n_features, cache},
         source_{std::move(source)} {}
   // This function always operate on the source first, then the downstream. The downstream
   // can assume the source to be ready.
@@ -641,7 +641,7 @@ class ExtQantileSourceMixin : public SparsePageSourceImpl<S, FormatCreatePolicy>
       this->EndIter();
 
       CHECK(this->cache_info_->written);
-      source_ = nullptr;  // release the source
+      source_.reset();  // release the source
     } else {
       this->Fetch();
     }

--- a/tests/cpp/data/test_extmem_quantile_dmatrix.cu
+++ b/tests/cpp/data/test_extmem_quantile_dmatrix.cu
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <xgboost/data.h>  // for BatchParam
 
+#include <tuple>   // for tuple
 #include <vector>  // for vector
 
 #include "../../../src/data/ellpack_page.cuh"  // for EllpackPageImpl
@@ -11,9 +12,9 @@
 #include "test_extmem_quantile_dmatrix.h"      // for TestExtMemQdmBasic
 
 namespace xgboost::data {
-class ExtMemQuantileDMatrixGpu : public ::testing::TestWithParam<float> {
+class ExtMemQuantileDMatrixGpu : public ::testing::TestWithParam<std::tuple<float, bool>> {
  public:
-  void Run(float sparsity) {
+  void Run(float sparsity, bool on_host) {
     auto equal = [](Context const* ctx, EllpackPage const& orig, EllpackPage const& sparse) {
       auto const& orig_cuts = orig.Cuts();
       auto const& sparse_cuts = sparse.Cuts();
@@ -34,15 +35,16 @@ class ExtMemQuantileDMatrixGpu : public ::testing::TestWithParam<float> {
     };
 
     auto ctx = MakeCUDACtx(0);
-    TestExtMemQdmBasic<EllpackPage>(&ctx, true, sparsity, equal, no_missing);
-    TestExtMemQdmBasic<EllpackPage>(&ctx, false, sparsity, equal, no_missing);
+    TestExtMemQdmBasic<EllpackPage>(&ctx, on_host, sparsity, equal, no_missing);
   }
 };
 
-TEST_P(ExtMemQuantileDMatrixGpu, Basic) { this->Run(this->GetParam()); }
+TEST_P(ExtMemQuantileDMatrixGpu, Basic) {
+  auto [sparsity, on_host] = this->GetParam();
+  this->Run(sparsity, on_host);
+}
 
-INSTANTIATE_TEST_SUITE_P(ExtMemQuantileDMatrix, ExtMemQuantileDMatrixGpu, ::testing::ValuesIn([] {
-                           std::vector<float> sparsities{0.0f, 0.2f, 0.4f, 0.8f};
-                           return sparsities;
-                         }()));
+INSTANTIATE_TEST_SUITE_P(ExtMemQuantileDMatrix, ExtMemQuantileDMatrixGpu,
+                         ::testing::Combine(::testing::Values(0.0f, 0.2f, 0.4f, 0.8f),
+                                            ::testing::Bool()));
 }  // namespace xgboost::data

--- a/tests/python/test_data_iterator.py
+++ b/tests/python/test_data_iterator.py
@@ -202,12 +202,12 @@ class IterForCacheTest(xgb.DataIter):
         self.kwargs = {"data": x, "label": y, "weight": w}
         super().__init__(release_data=release_data)
 
-    def next(self, input_data: Callable) -> int:
+    def next(self, input_data: Callable) -> bool:
         if self.it == 1:
-            return 0
+            return False
         self.it += 1
         input_data(**self.kwargs)
-        return 1
+        return True
 
     def reset(self) -> None:
         self.it = 0


### PR DESCRIPTION
- Use bool instead of int in the Python interface.
- Unify the internal advance operator for the ext qdm between CPU and GPU.
- Avoid the use of `n_batches` calculated from the external iterator and use the cache size instead. We will add support for internal page concatenation for ellpack to handle irregular batch sizes from distributed frameworks.