### PR TITLE
SYCL. Minimize host-device memory synchronization for ColumnSampler

### DIFF
--- a/src/common/random.h
+++ b/src/common/random.h
@@ -177,7 +177,10 @@ class ColumnSampler {
     }
     Reset();
 
-    feature_set_tree_->SetDevice(ctx->Device());
+    // We process ColumnSampler on host for SYCL. So don't need to push data to device
+    if (!ctx->Device().IsSycl()) {
+      feature_set_tree_->SetDevice(ctx->Device());
+    }
     feature_set_tree_->Resize(num_col);
     if (ctx->IsCUDA()) {
 #if defined(XGBOOST_USE_CUDA)


### PR DESCRIPTION
This simple PR improve training speed-up on sycl-devices for `plastic `dataset on ~1.4x and for `santander `on ~1.2x by reducing the host-device memory synchronizations.