### PR TITLE
Define guard macros to prevent windows.h from conflicting with winsock2.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,9 @@ if(USE_CUDA)
 
   find_package(CUDAToolkit REQUIRED)
   find_package(CCCL CONFIG)
-  if(NOT CCCL_FOUND)
+  if(CCCL_FOUND)
+    message(STATUS "Standalone CCCL found.")
+  else()
     message(STATUS "Standalone CCCL not found. Attempting to use CCCL from CUDA Toolkit...")
     find_package(CCCL CONFIG
       HINTS ${CUDAToolkit_LIBRARY_DIR}/cmake)
@@ -237,6 +239,10 @@ if(USE_CUDA)
       add_library(CCCL::CCCL INTERFACE IMPORTED GLOBAL)
       target_link_libraries(CCCL::CCCL INTERFACE libcudacxx::libcudacxx CUB::CUB Thrust)
     endif()
+  endif()
+  # Define guard macros to prevent windows.h from conflicting with winsock2.h
+  if(WIN32)
+    target_compile_definitions(CCCL::CCCL INTERFACE NOMINMAX WIN32_LEAN_AND_MEAN _WINSOCKAPI_)
   endif()
 endif()
 

--- a/include/xgboost/collective/socket.h
+++ b/include/xgboost/collective/socket.h
@@ -99,6 +99,7 @@ inline auto ThrowAtError(StringView fn_name, std::int32_t errsv = LastError()) {
 using SocketT = SOCKET;
 #else
 using SocketT = int;
+#define INVALID_SOCKET -1
 #endif  // defined(_WIN32)
 
 #if !defined(xgboost_CHECK_SYS_CALL)
@@ -276,7 +277,7 @@ class TCPSocket {
   SockDomain domain_{SockDomain::kV4};
 #endif
 
-  constexpr static HandleT InvalidSocket() { return -1; }
+  constexpr static HandleT InvalidSocket() { return INVALID_SOCKET; }
 
   explicit TCPSocket(HandleT newfd) : handle_{newfd} {}
 

--- a/include/xgboost/windefs.h
+++ b/include/xgboost/windefs.h
@@ -20,7 +20,13 @@
 #endif  // !defined(NOMINMAX)
 
 // A macro used inside `windows.h` to avoid conflicts with `winsock2.h`
+#if !defined(WIN32_LEAN_AND_MEAN)
 #define WIN32_LEAN_AND_MEAN
+#endif  // !defined(WIN32_LEAN_AND_MEAN)
+// Stop windows.h from including winsock.h
+#if !defined(_WINSOCKAPI_)
+#define _WINSOCKAPI_
+#endif  // !defined(_WINSOCKAPI_)
 
 #if !defined(xgboost_IS_MINGW)
 

--- a/tests/cpp/common/test_device_vector.cu
+++ b/tests/cpp/common/test_device_vector.cu
@@ -10,6 +10,7 @@
 #include "../../../src/common/device_helpers.cuh"  // for CachingThrustPolicy, PinnedMemory
 #include "../../../src/common/device_vector.cuh"
 #include "xgboost/global_config.h"  // for GlobalConfigThreadLocalStore
+#include "xgboost/windefs.h"  // for xgboost_IS_WIN
 
 namespace dh {
 TEST(DeviceUVector, Basic) {
@@ -109,10 +110,14 @@ TEST(TestVirtualMem, Version) {
   xgboost::curt::DrVersion(&major, &minor);
   LOG(INFO) << "Latest supported CUDA version by the driver:" << major << "." << minor;
   PinnedMemory pinned;
+#if defined(xgboost_IS_WIN)
+  ASSERT_FALSE(pinned.IsVm());
+#else  // defined(xgboost_IS_WIN)
   if (major >= 12 && minor >= 5) {
     ASSERT_TRUE(pinned.IsVm());
   } else {
     ASSERT_FALSE(pinned.IsVm());
   }
+#endif  // defined(xgboost_IS_WIN)
 }
 }  // namespace dh


### PR DESCRIPTION
When building XGBoost on Windows with CUDA 12.5 and standalone CCCL (*), I get the following error:
```
error : invalid redeclaration of type name "sockaddr"
```
(from https://github.com/hcho3/xgboost-ci-ng/actions/runs/11471864036/job/31923485369)

The error occurs because `windows.h` includes `winsock.h`, which conflicts with `winsock2.h`. See https://stackoverflow.com/questions/1372480/c-redefinition-header-files-winsock2-h. Where does `windows.h` come from? Most likely from the standalone CCCL, as the error didn't occur when using the vendored CCCL from the CTK.

Fix. Define macros `_WINSOCKAPI_` so that `windows.h` doesn't include `winsock.h`. In addition, define macros `NOMINMAX`, `WIN32_LEAN_AND_MEAN`, and `_WINSOCKAPI_` as part of the CMake build so that they go into effect before CCCL headers are included.

Also: Use `INVALID_SOCKET` instead of `-1` to represent invalid sockets on Windows. See https://learn.microsoft.com/en-us/windows/win32/winsock/socket-data-type-2.

(\*) I use CCCL 2.6.1 from GitHub because CUDA 12.5 ships with a buggy version of CCCL (https://github.com/NVIDIA/cccl/issues/1956)