### PR TITLE
Simplify the GPU memory logger.

### DIFF
--- a/src/common/device_vector.cuh
+++ b/src/common/device_vector.cuh
@@ -56,6 +56,7 @@ std::remove_cv_t<T> AtomicFetchMax(std::atomic<T> &atom, T val,  // NOLINT
 class MemoryLogger {
   // Information for a single device
   struct DeviceStats {
+    // Use signed int to allow out-of-order allocation/deallocation.
     std::atomic<std::int64_t> currently_allocated_bytes{0};
     std::atomic<std::int64_t> peak_allocated_bytes{0};
     void RegisterAllocation(std::int64_t n) {

--- a/tests/cpp/common/test_device_vector.cu
+++ b/tests/cpp/common/test_device_vector.cu
@@ -124,8 +124,8 @@ TEST(AtomitFetch, Max) {
   decltype(n)::value_type add = 64;
   for (decltype(n_threads) t = 0; t < n_threads; ++t) {
     threads.emplace_back([=, &n] {
-      for (std::size_t i = 0; i < add; ++i) {
-        detail::AtomicFetchMax(n, static_cast<std::int64_t>(t + i));
+      for (decltype(add) i = 0; i < add; ++i) {
+        detail::AtomicFetchMax(n, static_cast<decltype(add)>(t + i));
       }
     });
   }


### PR DESCRIPTION
Simplify the logger to only keep tracker of the current and peak memory usage. The current locking mechanism doesn't guarantee the ordering of the lock and it's difficult to fix.

We can use rmm or nsys for detailed memory profiling in the future.