### PR TITLE
[WIP] Use memory pool for pinned allocation.

### DIFF
--- a/src/common/device_vector.cu
+++ b/src/common/device_vector.cu
@@ -29,6 +29,14 @@ void ThrowOOMError(std::string const &err, std::size_t bytes) {
   return std::accumulate(it, it + this->handles_.size(), static_cast<std::size_t>(0));
 }
 
+void GrowOnlyPinnedMemPool::Grow(std::size_t n_bytes) {
+  if (n_bytes > this->cur_n_bytes) {
+    return;
+  }
+  safe_cuda(cudaFreeAsync(storage, dh::DefaultStream()));
+  safe_cuda(cudaMallocFromPoolAsync(&storage, n_bytes, pool.Handle(), dh::DefaultStream()));
+}
+
 void GrowOnlyVirtualMemVec::Reserve(std::size_t new_size) {
   auto va_capacity = this->Capacity();
   if (new_size < va_capacity) {


### PR DESCRIPTION
This requires CTK12.6. Similar to the driver API, this prevents deadlock with NCCL. But the driver API might require special system capabilities, we will try the async pool as well when CTK12.6 is available.