### PR TITLE
[jvm-packages] support array features type for cpu

### DIFF
--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
@@ -187,16 +187,21 @@ private[spark] trait XGBoostEstimator[
    * @return
    */
   private[spark] def preprocess(dataset: Dataset[_]): (Dataset[_], ColumnIndices) = {
+    val schema = dataset.schema
+    validateFeatureType(schema)
+    val featureIsArray: Boolean = featureIsArrayType(schema)
 
     // Columns to be selected for XGBoost training
     val selectedCols: ArrayBuffer[Column] = ArrayBuffer.empty
-    val schema = dataset.schema
 
     def selectCol(c: Param[String], targetType: DataType) = {
       if (isDefinedNonEmpty(c)) {
-        // Validation col should be a boolean column.
         if (c == featuresCol) {
-          selectedCols.append(col($(c)))
+          // If feature is array type, we force to cast it to array of float
+          val featureCol = if (featureIsArray) {
+            col($(featuresCol)).cast(ArrayType(FloatType))
+          } else col($(featuresCol))
+          selectedCols.append(featureCol)
         } else {
           selectedCols.append(castIfNeeded(schema, $(c), targetType))
         }
@@ -219,22 +224,33 @@ private[spark] trait XGBoostEstimator[
                                        columnIndexes: ColumnIndices): RDD[XGBLabeledPoint] = {
     val isSetMissing = isSet(missing)
     dataset.toDF().rdd.map { row =>
-      val features = row.getAs[Vector](columnIndexes.featureId.get)
       val label = row.getFloat(columnIndexes.labelId)
       val weight = columnIndexes.weightId.map(row.getFloat).getOrElse(1.0f)
       val baseMargin = columnIndexes.marginId.map(row.getFloat).getOrElse(Float.NaN)
       val group = columnIndexes.groupId.map(row.getInt).getOrElse(-1)
-      // To make "0" meaningful, we convert sparse vector if possible to dense to create DMatrix.
-      features match {
-        case _: SparseVector => if (!isSetMissing) {
-          throw new IllegalArgumentException("We've detected sparse vectors in the dataset that " +
-            "need conversion to dense format. However, we can't assume 0 for missing values as " +
-            "it may be meaningful. Please specify the missing value explicitly to ensure " +
-            "accurate data representation for analysis.")
-        }
-        case _ =>
+
+      val values = row.schema(columnIndexes.featureId.get).dataType match {
+        case ArrayType(_, _) =>
+          // The driver has casted the array(*) to array(float), so it's safe to
+          // specify it as WrappedArray[Float] directly
+          row.getAs[mutable.WrappedArray[Float]](columnIndexes.featureId.get).toArray
+        case other =>
+          if (!SparkUtils.isVectorType(other)) {
+            throw new IllegalArgumentException("Feature must be array or vector type")
+          }
+          val features = row.getAs[Vector](columnIndexes.featureId.get)
+          features match {
+            case _: SparseVector => if (!isSetMissing) {
+              throw new IllegalArgumentException("We've detected sparse vectors in the dataset " +
+                "that need conversion to dense format. However, we can't assume 0 for missing " +
+                "values as it may be meaningful. Please specify the missing value explicitly to" +
+                "ensure accurate data representation for analysis.")
+            }
+            case _ => // DenseVector
+          }
+          // To make "0" meaningful, we convert sparse vector if possible to dense.
+          features.toArray.map(_.toFloat)
       }
-      val values = features.toArray.map(_.toFloat)
       XGBLabeledPoint(label, values.length, null, values, weight, group, baseMargin)
     }
   }
@@ -488,6 +504,7 @@ private[spark] trait XGBoostModel[M <: XGBoostModel[M]] extends Model[M] with ML
   private[spark] def preprocess(dataset: Dataset[_]): (StructType, PredictedColumns) = {
     // Be careful about the order of columns
     var schema = dataset.schema
+    validateFeatureType(schema)
 
     /** If the parameter is defined, add it to schema and turn true */
     def addToSchema(param: Param[String], colName: Option[String] = None): Boolean = {
@@ -581,18 +598,19 @@ private[spark] trait XGBoostModel[M <: XGBoostModel[M]] extends Model[M] with ML
   }
 
   override def transform(dataset: Dataset[_]): DataFrame = {
-
     if (getPlugin.isDefined) {
       return getPlugin.get.transform(this, dataset)
     }
 
     val (schema, pred) = preprocess(dataset)
+    // Broadcast the booster to each executor.
     val bBooster = dataset.sparkSession.sparkContext.broadcast(nativeBooster)
     // TODO configurable
     val inferBatchSize = 32 << 10
-    // Broadcast the booster to each executor.
     val featureName = getFeaturesCol
     val missing = getMissing
+
+    val featureIsArray = featureIsArrayType(dataset.schema)
 
     // Here, we use RDD instead of DF to avoid different encoders for different
     // spark versions for the compatibility issue.
@@ -600,10 +618,26 @@ private[spark] trait XGBoostModel[M <: XGBoostModel[M]] extends Model[M] with ML
     // 3.5-, RowEncoder(schema)
     val outRDD = dataset.asInstanceOf[Dataset[Row]].rdd.mapPartitions { rowIter =>
       rowIter.grouped(inferBatchSize).flatMap { batchRow =>
-        val features = batchRow.iterator.map(row => row.getAs[Vector](
-          row.fieldIndex(featureName)))
+        val features = batchRow.iterator.map(row => {
+          if (!featureIsArray) {
+            // Vector type
+            row.getAs[Vector](row.fieldIndex(featureName)).asXGB
+          } else {
+            // Array type
+            val values: Array[Float] = row.get(row.fieldIndex(featureName)) match {
+              case v: mutable.WrappedArray[_] =>
+                v.array match {
+                  case f: Array[java.lang.Float] => f.map(_.toFloat)
+                  case d: Array[java.lang.Double] => d.map(_.toFloat)
+                  case _ => throw new RuntimeException("Unsupported feature array type")
+                }
+              case _ => throw new RuntimeException("Unsupported feature type")
+            }
+            XGBLabeledPoint(0.0f, values.size, null, values)
+          }
+        })
         // DMatrix used to prediction
-        val dm = new DMatrix(features.map(_.asXGB), null, missing)
+        val dm = new DMatrix(features, null, missing)
         try {
           predictInternal(bBooster.value, dm, pred, batchRow.toIterator)
         } finally {

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
@@ -504,7 +504,6 @@ private[spark] trait XGBoostModel[M <: XGBoostModel[M]] extends Model[M] with ML
   private[spark] def preprocess(dataset: Dataset[_]): (StructType, PredictedColumns) = {
     // Be careful about the order of columns
     var schema = dataset.schema
-    validateFeatureType(schema)
 
     /** If the parameter is defined, add it to schema and turn true */
     def addToSchema(param: Param[String], colName: Option[String] = None): Boolean = {
@@ -601,7 +600,7 @@ private[spark] trait XGBoostModel[M <: XGBoostModel[M]] extends Model[M] with ML
     if (getPlugin.isDefined) {
       return getPlugin.get.transform(this, dataset)
     }
-
+    validateFeatureType(dataset.schema)
     val (schema, pred) = preprocess(dataset)
     // Broadcast the booster to each executor.
     val bBooster = dataset.sparkSession.sparkContext.broadcast(nativeBooster)

--- a/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/ml/xgboost/SparkUtils.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/ml/xgboost/SparkUtils.scala
@@ -135,4 +135,11 @@ object SparkUtils {
                             nullable: Boolean = false): StructType = {
     SchemaUtils.appendColumn(schema, colName, dataType, nullable)
   }
+
+  def isVectorType(dt: DataType): Boolean = {
+    dt match {
+      case _: VectorUDT => true
+      case _ => false
+    }
+  }
 }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/ml/xgboost/SparkUtils.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/org/apache/spark/ml/xgboost/SparkUtils.scala
@@ -136,10 +136,5 @@ object SparkUtils {
     SchemaUtils.appendColumn(schema, colName, dataType, nullable)
   }
 
-  def isVectorType(dt: DataType): Boolean = {
-    dt match {
-      case _: VectorUDT => true
-      case _ => false
-    }
-  }
+  def isVectorType(dataType: DataType): Boolean = dataType.isInstanceOf[VectorUDT]
 }

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/PerTest.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/PerTest.scala
@@ -112,6 +112,15 @@ trait PerTest extends BeforeAndAfterEach {
     (1.0, -0.4, -2.1, Vectors.dense(0.5, 2.2, 1.7))
   ))).toDF("label", "margin", "weight", "features")
 
+  def smallBinaryClassificationArray: DataFrame = ss.createDataFrame(sc.parallelize(Seq(
+    (1.0, 0.5, 1.0, Seq(1.0, 2.0, 3.0)),
+    (0.0, 0.4, -3.0, Seq(0.0, 0.0, 0.0)),
+    (0.0, 0.3, 1.0, Seq(0.0, 3.0, 0.0)),
+    (1.0, 1.2, 0.2, Seq(2.0, 0.0, 4.0)),
+    (0.0, -0.5, 0.0, Seq(0.2, 1.2, 2.0)),
+    (1.0, -0.4, -2.1, Seq(0.5, 2.2, 1.7))
+  ))).toDF("label", "margin", "weight", "features")
+
   def smallMultiClassificationVector: DataFrame = ss.createDataFrame(sc.parallelize(Seq(
     (1.0, 0.5, 1.0, Vectors.dense(1.0, 2.0, 3.0)),
     (0.0, 0.4, -3.0, Vectors.dense(0.0, 0.0, 0.0)),
@@ -120,7 +129,6 @@ trait PerTest extends BeforeAndAfterEach {
     (0.0, -0.5, 0.0, Vectors.dense(0.2, 1.2, 2.0)),
     (2.0, -0.4, -2.1, Vectors.dense(0.5, 2.2, 1.7))
   ))).toDF("label", "margin", "weight", "features")
-
 
   def smallGroupVector: DataFrame = ss.createDataFrame(sc.parallelize(Seq(
     (1.0, 0, 0.5, 2.0, Vectors.dense(1.0, 2.0, 3.0)),


### PR DESCRIPTION
This PR introduces a new feature that can support array input type for both training and transform. Users can not only train with vector but also train with array, and the model also can predict the array or vector input.

