### PR TITLE
[pyspark] Add barrier before initializing Rabit

### DIFF
--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -1026,6 +1026,7 @@ class _SparkXGBEstimator(Estimator, _SparkXGBParams, MLReadable, MLWritable):
             from pyspark import BarrierTaskContext
 
             context = BarrierTaskContext.get()
+            context.barrier()
 
             dev_ordinal = None
             use_qdm = _can_use_qdm(


### PR DESCRIPTION
Add barrier before initializing the rabit tracker to make sure all workers are up. 