### PR TITLE
[dask] Optional support for client-side logging.

### DIFF
--- a/demo/dask/cpu_training.py
+++ b/demo/dask/cpu_training.py
@@ -8,28 +8,20 @@ from dask import array as da
 from dask.distributed import Client, LocalCluster
 
 from xgboost import dask as dxgb
-from xgboost.dask import DaskDMatrix
+from xgboost.dask.callback import EvaluationMonitor
 
 
-def main(client: Client) -> None:
-    # generate some random data for demonstration
-    m = 100000
-    n = 100
-    rng = da.random.default_rng(1)
-    X = rng.normal(size=(m, n), chunks=(10000, -1))
-    y = X.sum(axis=1)
+def approx_train(client: Client, X: da.Array, y: da.Array) -> da.Array:
+    # DaskDMatrix acts like normal DMatrix, works as a proxy for local DMatrix scatter
+    # around workers.
+    dtrain = dxgb.DaskDMatrix(client, X, y)
 
-    # DaskDMatrix acts like normal DMatrix, works as a proxy for local
-    # DMatrix scatter around workers.
-    dtrain = DaskDMatrix(client, X, y)
-
-    # Use train method from xgboost.dask instead of xgboost.  This
-    # distributed version of train returns a dictionary containing the
-    # resulting booster and evaluation history obtained from
-    # evaluation metrics.
+    # Use train method from xgboost.dask instead of xgboost.  This distributed version
+    # of train returns a dictionary containing the resulting booster and evaluation
+    # history obtained from evaluation metrics.
     output = dxgb.train(
         client,
-        {"verbosity": 1, "tree_method": "hist"},
+        {"tree_method": "approx", "device": "cpu"},
         dtrain,
         num_boost_round=4,
         evals=[(dtrain, "train")],
@@ -40,11 +32,49 @@ def main(client: Client) -> None:
     # you can pass output directly into `predict` too.
     prediction = dxgb.predict(client, bst, dtrain)
     print("Evaluation history:", history)
-    print("Error:", da.sqrt((prediction - y) ** 2).mean().compute())
+    return prediction
+
+
+def hist_train(client: Client, X: da.Array, y: da.Array) -> da.Array:
+    """`DaskQuantileDMatrix` is a data type specialized for `hist` tree methods for
+     reducing memory usage.
+
+    .. versionadded:: 1.2.0
+
+    """
+    # `DaskQuantileDMatrix` is used instead of `DaskDMatrix`, be careful that it can not
+    # be used for anything else other than as a training DMatrix, unless a reference is
+    # specified. See the `ref` argument of `DaskQuantileDMatrix`.
+    dtrain = dxgb.DaskQuantileDMatrix(client, X, y)
+    output = dxgb.train(
+        client,
+        {"tree_method": "hist", "device": "cpu"},
+        dtrain,
+        num_boost_round=4,
+        evals=[(dtrain, "train")],
+        # See the document of `EvaluationMonitor` for why it's used this way.
+        callbacks=[EvaluationMonitor(client, period=1)],
+        # Disable the internal logging and prefer the client-side `EvaluationMonitor`.
+        verbose_eval=False,
+    )
+    bst = output["booster"]
+    history = output["history"]
+
+    prediction = dxgb.predict(client, bst, X)
+    print("Evaluation history:", history)
+    return prediction
 
 
 if __name__ == "__main__":
-    # or use other clusters for scaling
     with LocalCluster(n_workers=7, threads_per_worker=4) as cluster:
         with Client(cluster) as client:
-            main(client)
+            m = 100000
+            n = 100
+            rng = da.random.default_rng(1)
+            X = rng.normal(size=(m, n), chunks=(10000, -1))
+            y = X.sum(axis=1)
+
+            print("Using DaskQuantileDMatrix")
+            from_ddqdm = hist_train(client, X, y).compute()
+            print("Using DMatrix")
+            from_dmatrix = approx_train(client, X, y).compute()

--- a/doc/python/python_api.rst
+++ b/doc/python/python_api.rst
@@ -158,6 +158,13 @@ Dask API
     :show-inheritance:
 
 
+.. automodule:: xgboost.dask.callback
+
+.. autoclass:: xgboost.dask.callback.EvaluationMonitor
+    :members:
+    :inherited-members:
+    :show-inheritance:
+
 PySpark API
 -----------
 

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -502,26 +502,18 @@ class EarlyStopping(TrainingCallback):
         return model
 
 
-class EvaluationMonitor(TrainingCallback):
-    """Print the evaluation result at each iteration.
-
-    .. versionadded:: 1.3.0
-
-    Parameters
-    ----------
-
-    rank :
-        Which worker should be used for printing the result.
-    period :
-        How many epoches between printing.
-    show_stdv :
-        Used in cv to show standard deviation.  Users should not specify it.
-    """
-
-    def __init__(self, rank: int = 0, period: int = 1, show_stdv: bool = False) -> None:
+class _EvaluationMonitorImpl(TrainingCallback):
+    def __init__(
+        self,
+        logger: Callable[[str], None],
+        rank: int = 0,
+        period: int = 1,
+        show_stdv: bool = False,
+    ):
         self.printer_rank = rank
         self.show_stdv = show_stdv
         self.period = period
+        self._logger = logger
         assert period > 0
         # last error message, useful when early stopping and period are used together.
         self._latest: Optional[str] = None
@@ -556,7 +548,7 @@ class EvaluationMonitor(TrainingCallback):
             msg += "\n"
 
             if (epoch % self.period) == 0 or self.period == 1:
-                collective.communicator_print(msg)
+                self._logger(msg)
                 self._latest = None
             else:
                 # There is skipped message
@@ -565,8 +557,33 @@ class EvaluationMonitor(TrainingCallback):
 
     def after_training(self, model: _Model) -> _Model:
         if collective.get_rank() == self.printer_rank and self._latest is not None:
-            collective.communicator_print(self._latest)
+            self._logger(self._latest)
         return model
+
+
+class EvaluationMonitor(_EvaluationMonitorImpl):
+    """Print the evaluation result at each iteration.
+
+    .. versionadded:: 1.3.0
+
+    Parameters
+    ----------
+
+    rank :
+        Which worker should be used for printing the result.
+    period :
+        How many epoches between printing.
+    show_stdv :
+        Used in cv to show standard deviation.  Users should not specify it.
+    """
+
+    def __init__(self, rank: int = 0, period: int = 1, show_stdv: bool = False) -> None:
+        super().__init__(
+            logger=collective.communicator_print,
+            rank=rank,
+            period=period,
+            show_stdv=show_stdv,
+        )
 
 
 class TrainingCheckPoint(TrainingCallback):

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -1082,6 +1082,7 @@ def train(  # pylint: disable=unused-argument
     _assert_dask_support()
     client = _xgb_get_client(client)
     args = locals()
+
     return client.sync(
         _train_async,
         global_config=config.get_config(),

--- a/python-package/xgboost/dask/callback.py
+++ b/python-package/xgboost/dask/callback.py
@@ -1,0 +1,88 @@
+"""Callback functions specialized for the Dask interface. The Dask interface accepts
+normal training callbacks defined in :py:mod:`xgboost.callback` as well. Classes defined
+here are tailored to the Dask interface.
+
+    .. versionadded:: 3.0
+
+"""
+
+import logging
+
+from distributed import Client
+
+from ..callback import _EvaluationMonitorImpl
+
+__all__ = ["EvaluationMonitor"]
+
+
+def _get_logger() -> logging.Logger:
+    logger = logging.getLogger("[xgboost.dask]")
+    logger.setLevel(logging.INFO)
+    if not logger.hasHandlers():
+        handler = logging.StreamHandler()
+        logger.addHandler(handler)
+    return logger
+
+
+class EvaluationMonitor(_EvaluationMonitorImpl):
+    """Print the evaluation result at each iteration. The default monitor in the native
+    interface logs the result to the Dask scheduler process. This class can be used to
+    forward the logging to the client process. Important: see the `client` parameter for
+    more info.
+
+    .. versionadded:: 3.0.0
+
+    """
+
+    def __init__(
+        self,
+        client: Client,
+        rank: int = 0,
+        period: int = 1,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        client :
+            Distributed client. This must be the top-level client. The class uses
+            :py:meth:`distributed.Client.forward_logging` in conjunction with the Python
+            :py:mod:`logging` module to forward the evaluation results to the client
+            process. It has undefined behaviour if called in a nested task. As a result,
+            client-side logging is not enabled by default.
+
+        Examples
+        --------
+
+        .. code-block:: python
+
+            from distribtued import get_client
+
+            from xgboost import dask as dxgb
+            from xgboost.dask.callback import EvaluationMonitor
+
+
+            def invalid():
+                with get_client() as client:
+                    EvaluationMonitor(client)  # Undefined!!
+
+            def main(client):
+                client.submit(invalid)  # bad
+
+                callback = EvaluationMonitor(client)  # good
+                # Disable the verbose_eval to use this custom monitor
+                dxgb.train(client, {}, Xy, callbacks=[callback], verbose_eval=False)
+
+
+            if __name__ == "__main__":
+                with Client(scheduler_file="sched.json") as client:
+                    main()
+
+        """
+        client.forward_logging(_get_logger().name)
+
+        super().__init__(
+            lambda msg: _get_logger().info(msg.strip()),
+            rank=rank,
+            period=period,
+            show_stdv=False,
+        )


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/9994 .

Currently, XGBoost logs the evaluation result in the cluster's scheduler process. This PR makes it possible to log the result in the client side instead.