### PR TITLE
[dask] Optional support for client-side logging

### DIFF
--- a/demo/dask/forward_logging.py
+++ b/demo/dask/forward_logging.py
@@ -58,7 +58,7 @@ class ForwardLoggingMonitor(EvaluationMonitor):
         )
 
 
-class WorkEventMonitor(EvaluationMonitor):
+class WorkerEventMonitor(EvaluationMonitor):
     """Use :py:meth:`distributed.print` to forward the log. A downside is that not only
     all clients connected to the cluster can see the log, the logs are also printed on
     the worker. If you use a local cluster, the log is duplicated.
@@ -118,5 +118,5 @@ if __name__ == "__main__":
 
             # Use distributed.print, the logs in this demo are duplicated as the same
             # log is printed in all workers along with the client.
-            monitor = WorkEventMonitor()
+            monitor = WorkerEventMonitor()
             hist_train(client, X, y, monitor).compute()

--- a/demo/dask/forward_logging.py
+++ b/demo/dask/forward_logging.py
@@ -1,15 +1,19 @@
-"""
-Example of forwarding evaluation logs to the client
+"""Example of forwarding evaluation logs to the client
 ===================================================
-"""
 
-import dask
-from dask import array as da
-from distributed import Client
-from dask_cuda import LocalCUDACluster
-import distributed
+The example runs on GPU. Two classes are defined to show how to use Dask builtins to
+forward the logs to the client process.
+
+"""
 
 import logging
+
+import dask
+import distributed
+from dask import array as da
+from dask_cuda import LocalCUDACluster
+from distributed import Client
+
 from xgboost import dask as dxgb
 from xgboost.callback import EvaluationMonitor
 

--- a/demo/dask/forward_logging.py
+++ b/demo/dask/forward_logging.py
@@ -1,0 +1,118 @@
+"""
+Example of forwarding evaluation logs to the client
+===================================================
+"""
+
+import dask
+from dask import array as da
+from distributed import Client
+from dask_cuda import LocalCUDACluster
+import distributed
+
+import logging
+from xgboost import dask as dxgb
+from xgboost.callback import EvaluationMonitor
+
+
+def _get_logger() -> logging.Logger:
+    logger = logging.getLogger("[xgboost.dask]")
+    logger.setLevel(logging.INFO)
+    if not logger.hasHandlers():
+        handler = logging.StreamHandler()
+        logger.addHandler(handler)
+    return logger
+
+
+class ForwardLoggingMonitor(EvaluationMonitor):
+    def __init__(
+        self,
+        client: Client,
+        rank: int = 0,
+        period: int = 1,
+    ) -> None:
+        """Print the evaluation result at each iteration. The default monitor in the
+        native interface logs the result to the Dask scheduler process. This class can
+        be used to forward the logging to the client process. Important: see the
+        `client` parameter for more info.
+
+        Parameters
+        ----------
+        client :
+            Distributed client. This must be the top-level client. The class uses
+            :py:meth:`distributed.Client.forward_logging` in conjunction with the Python
+            :py:mod:`logging` module to forward the evaluation results to the client
+            process. It has undefined behaviour if called in a nested task. As a result,
+            client-side logging is not enabled by default.
+
+        """
+        client.forward_logging(_get_logger().name)
+
+        super().__init__(
+            rank=rank,
+            period=period,
+            logger=lambda msg: _get_logger().info(msg.strip()),
+        )
+
+
+class WorkEventMonitor(EvaluationMonitor):
+    """Use :py:meth:`distributed.print` to forward the log. A downside is that not only
+    all clients connected to the cluster can see the log, the logs are also printed on
+    the worker. If you use a local cluster, the log is duplicated.
+
+    """
+
+    def __init__(self, rank: int = 0, period: int = 1) -> None:
+        super().__init__(
+            rank=rank, period=period, logger=lambda msg: distributed.print(msg.strip())
+        )
+
+
+def hist_train(
+    client: Client, X: da.Array, y: da.Array, monitor: EvaluationMonitor
+) -> da.Array:
+    # `DaskQuantileDMatrix` is used instead of `DaskDMatrix`, be careful that it can not
+    # be used for anything else other than as a training DMatrix, unless a reference is
+    # specified. See the `ref` argument of `DaskQuantileDMatrix`.
+    dtrain = dxgb.DaskQuantileDMatrix(client, X, y)
+    output = dxgb.train(
+        client,
+        # Make sure the device is set to CUDA.
+        {"tree_method": "hist", "device": "cuda"},
+        dtrain,
+        num_boost_round=4,
+        evals=[(dtrain, "train")],
+        # Use the monitor to forward the log.
+        callbacks=[monitor],
+        # Disable the internal logging and prefer the client-side `EvaluationMonitor`.
+        verbose_eval=False,
+    )
+    bst = output["booster"]
+    history = output["history"]
+
+    prediction = dxgb.predict(client, bst, X)
+    print("Evaluation history:", history)
+    return prediction
+
+
+if __name__ == "__main__":
+    # `LocalCUDACluster` is used for assigning GPU to XGBoost processes.  Here
+    # `n_workers` represents the number of GPUs since we use one GPU per worker process.
+    with LocalCUDACluster(n_workers=2, threads_per_worker=4) as cluster:
+        # Create client from cluster, set the backend to GPU array (cupy).
+        with Client(cluster) as client, dask.config.set({"array.backend": "cupy"}):
+            # Generate some random data for demonstration
+            rng = da.random.default_rng(1)
+
+            m = 2**18
+            n = 100
+            X = rng.uniform(size=(m, n), chunks=(128**2, -1))
+            y = X.sum(axis=1)
+
+            # Use forwarding, the client must be the top client.
+            monitor: EvaluationMonitor = ForwardLoggingMonitor(client)
+            hist_train(client, X, y, monitor).compute()
+
+            # Use distributed.print, the logs in this demo are duplicated as the same
+            # log is printed in all workers along with the client.
+            monitor = WorkEventMonitor()
+            hist_train(client, X, y, monitor).compute()

--- a/doc/tutorials/dask.rst
+++ b/doc/tutorials/dask.rst
@@ -633,6 +633,20 @@ environment variable depending on the setting of the cluster. Please note that I
 support is Unix only.
 
 
+******************************
+Logging the evaluation results
+******************************
+
+By default, the Dask interface prints evaluation results in the scheduler process. This
+makes it difficult for a user to monitor training progress. We can define custom
+evaluation monitors using callback functions. See
+:ref:`sphx_glr_python_dask-examples_forward_logging.py` for a worked example on how to
+forward the logs to the client process. In the example, there are two potential solutions
+using Dask builtin methods, including :py:meth:`distributed.Client.forward_logging` and
+:py:func:`distributed.print`. Both of them have some caveats but can be a good starting
+point for developing more sophisticated methods like writing to files.
+
+
 *****************************************************************************
 Why is the initialization of ``DaskDMatrix``  so slow and throws weird errors
 *****************************************************************************

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -1082,6 +1082,7 @@ def train(  # pylint: disable=unused-argument
     _assert_dask_support()
     client = _xgb_get_client(client)
     args = locals()
+
     return client.sync(
         _train_async,
         global_config=config.get_config(),

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -1082,7 +1082,6 @@ def train(  # pylint: disable=unused-argument
     _assert_dask_support()
     client = _xgb_get_client(client)
     args = locals()
-
     return client.sync(
         _train_async,
         global_config=config.get_config(),

--- a/tests/test_distributed/test_gpu_with_dask/test_gpu_demos.py
+++ b/tests/test_distributed/test_gpu_with_dask/test_gpu_demos.py
@@ -25,3 +25,11 @@ def test_dask_sklearn_demo():
     script = os.path.join(tm.demo_dir(__file__), "dask", "sklearn_gpu_training.py")
     cmd = ["python", script]
     subprocess.check_call(cmd)
+
+
+@pytest.mark.mgpu
+@pytest.mark.skipif(**tm.no_cupy())
+def test_forward_logging_demo():
+    script = os.path.join(tm.demo_dir(__file__), "dask", "forward_logging.py")
+    cmd = ["python", script]
+    subprocess.check_call(cmd)


### PR DESCRIPTION
- Accept custom logger in the evaluation monitor.
- Example for defining a custom logger for dask.

Close https://github.com/dmlc/xgboost/issues/9994 .