### PR TITLE
Fix dmlc/xgboost#10752

### DIFF
--- a/.github/workflows/jvm_tests.yml
+++ b/.github/workflows/jvm_tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca  # v3.0.4
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         activate-environment: jvm_tests
         environment-file: tests/ci_build/conda_env/jvm_tests.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
         submodules: 'true'
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca  # v3.0.4
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         activate-environment: linux_sycl_test
         environment-file: tests/ci_build/conda_env/linux_sycl_test.yml
@@ -123,7 +123,7 @@ jobs:
         submodules: 'true'
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca  # v3.0.4
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         activate-environment: cpp_test
         environment-file: tests/ci_build/conda_env/cpp_test.yml

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -26,7 +26,7 @@ jobs:
         submodules: 'true'
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca  # v3.0.4
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         activate-environment: python_lint
         environment-file: tests/ci_build/conda_env/python_lint.yml
@@ -58,7 +58,7 @@ jobs:
         submodules: 'true'
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca  # v3.0.4
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         activate-environment: sdist_test
         environment-file: tests/ci_build/conda_env/sdist_test.yml
@@ -130,7 +130,7 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca  # v3.0.4
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         activate-environment: macos_cpu_test
         environment-file: tests/ci_build/conda_env/macos_cpu_test.yml
@@ -227,7 +227,7 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca  # v3.0.4
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         activate-environment: linux_cpu_test
         environment-file: tests/ci_build/conda_env/linux_cpu_test.yml
@@ -280,7 +280,7 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca  # v3.0.4
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         activate-environment: linux_sycl_test
         environment-file: tests/ci_build/conda_env/linux_sycl_test.yml

--- a/.github/workflows/python_wheels.yml
+++ b/.github/workflows/python_wheels.yml
@@ -34,7 +34,7 @@ jobs:
       run: brew install libomp
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca  # v3.0.4
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         python-version: "3.10"
         use-mamba: true

--- a/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
+++ b/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
@@ -97,6 +97,8 @@ def run_with_dask_dataframe(DMatrixT: Type, client: Client) -> None:
     cp.testing.assert_allclose(predt.values.compute(), single_node)
 
     # Make sure the output can be integrated back to original dataframe
+    X.columns = X.columns.astype("object")
+        # Work around https://github.com/dmlc/xgboost/issues/10752
     X["predict"] = predictions
     X["inplace_predict"] = series_predictions
 

--- a/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
+++ b/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
@@ -96,9 +96,9 @@ def run_with_dask_dataframe(DMatrixT: Type, client: Client) -> None:
 
     cp.testing.assert_allclose(predt.values.compute(), single_node)
 
-    # Make sure the output can be integrated back to original dataframe
+    # Work around https://github.com/dmlc/xgboost/issues/10752
     X.columns = X.columns.astype("object")
-        # Work around https://github.com/dmlc/xgboost/issues/10752
+    # Make sure the output can be integrated back to original dataframe
     X["predict"] = predictions
     X["inplace_predict"] = series_predictions
 


### PR DESCRIPTION
Closes #10752

In the test `run_with_dask_dataframe`, the dataframe `X` has columns with integer name. Attempting to add columns with non-integer names fails because the column index has `dtype=int64`. For now, manually set `dtype=object`.