### PR TITLE
[dask] Prevent the training from hang due to aborted worker.

### DIFF
--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -11,17 +11,25 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Dict, Generator, Literal, Optional, Tuple, Type, Union
 
+import dask
+import dask.array as da
+import dask.dataframe as dd
 import hypothesis
 import numpy as np
 import pytest
 import scipy
 import sklearn
+from distributed import Client, LocalCluster, Nanny, Worker
+from distributed.utils_test import async_poll_for, gen_cluster
 from hypothesis import HealthCheck, assume, given, note, settings
 from sklearn.datasets import make_classification, make_regression
 
 import xgboost as xgb
+from xgboost import collective as coll
 from xgboost import dask as dxgb
 from xgboost import testing as tm
+from xgboost.dask import DaskDMatrix
+from xgboost.testing.dask import check_init_estimation, check_uneven_nan
 from xgboost.testing.params import hist_cache_strategy, hist_parameter_strategy
 from xgboost.testing.shared import (
     get_feature_weights,
@@ -29,18 +37,9 @@ from xgboost.testing.shared import (
     validate_leaf_output,
 )
 
-pytestmark = [tm.timeout(60), pytest.mark.skipif(**tm.no_dask())]
-
-import dask
-import dask.array as da
-import dask.dataframe as dd
-from distributed import Client, LocalCluster, Nanny, Worker
-from distributed.utils_test import async_poll_for, gen_cluster
-
-from xgboost.dask import DaskDMatrix
-from xgboost.testing.dask import check_init_estimation, check_uneven_nan
-
 dask.config.set({"distributed.scheduler.allowed-failures": False})
+
+pytestmark = tm.timeout(60)
 
 
 if hasattr(HealthCheck, "function_scoped_fixture"):
@@ -1307,6 +1306,30 @@ def test_dask_iteration_range(client: "Client"):
     full_predt = dxgb.predict(client, booster, X, iteration_range=(0, n_rounds))
     default = dxgb.predict(client, booster, X)
     np.testing.assert_allclose(full_predt.compute(), default.compute())
+
+
+def test_killed_task_wo_hang():
+    # Test that aborting a worker doesn't lead to hang.
+    class Eve(xgb.callback.TrainingCallback):
+        def after_iteration(self, model, epoch: int, evals_log) -> bool:
+            if coll.get_rank() == 1:
+                os.abort()
+            return False
+
+    with LocalCluster(n_workers=2) as cluster:
+        with Client(cluster) as client:
+            X, y, _ = generate_array()
+            n_rounds = 10
+            dXy = dxgb.DaskDMatrix(client, X, y)
+            # The precise error message depends on Dask scheduler.
+            with pytest.raises(ValueError):
+                dxgb.train(
+                    client,
+                    {"tree_method": "hist"},
+                    dXy,
+                    num_boost_round=n_rounds,
+                    callbacks=[Eve()],
+                )
 
 
 class TestWithDask:


### PR DESCRIPTION
Set `allow_other_workers=True` in `client.submit`. See code comments for the rationale.