### PR TITLE
remove treelite references in library loader

### DIFF
--- a/python-package/packager/nativelib.py
+++ b/python-package/packager/nativelib.py
@@ -146,10 +146,10 @@ def locate_or_build_libxgboost(
             p.expanduser().resolve() for p in sys_prefix_candidates
         ]
         for candidate_dir in sys_prefix_candidates:
-            libtreelite_sys = candidate_dir / _lib_name()
-            if libtreelite_sys.exists():
-                logger.info("Using system XGBoost: %s", str(libtreelite_sys))
-                return libtreelite_sys
+            libxgboost_sys = candidate_dir / _lib_name()
+            if libxgboost_sys.exists():
+                logger.info("Using system XGBoost: %s", str(libxgboost_sys))
+                return libxgboost_sys
         raise RuntimeError(
             f"use_system_libxgboost was specified but {_lib_name()} is "
             f"not found. Paths searched (in order): \n"


### PR DESCRIPTION
The code in the Python package that looks for a system-installed `libxgboost` has some variables referring to `treelite`... it looks to me like those were mistakes.

This proposes switching those references to `libxgboost`, to reduce confusion.