### PR TITLE
Small enhancements for doc and error messages.

### DIFF
--- a/demo/guide-python/distributed_extmem_basic.py
+++ b/demo/guide-python/distributed_extmem_basic.py
@@ -106,7 +106,8 @@ def setup_rmm() -> None:
         return
 
     try:
-        from cuda import cudart
+        # Use the arena pool if available
+        from cuda.bindings import runtime as cudart
         from rmm.mr import ArenaMemoryResource
 
         status, free, total = cudart.cudaMemGetInfo()

--- a/tests/cpp/collective/test_allreduce.cu
+++ b/tests/cpp/collective/test_allreduce.cu
@@ -111,7 +111,7 @@ TEST_F(MGPUAllreduceTest, Timeout) {
         auto rc = w->NoCheck();
         if (r == 1) {
           auto rep = rc.Report();
-          ASSERT_NE(rep.find("NCCL timeout."), std::string::npos) << rep;
+          ASSERT_NE(rep.find("NCCL timeout:"), std::string::npos) << rep;
         }
 
         w.reset();
@@ -131,7 +131,7 @@ TEST_F(MGPUAllreduceTest, Timeout) {
         // Only one of the workers is doing allreduce.
         if (r == 0) {
           auto rc = w->NoCheck();
-          ASSERT_NE(rc.Report().find("NCCL timeout."), std::string::npos) << rc.Report();
+          ASSERT_NE(rc.Report().find("NCCL timeout:"), std::string::npos) << rc.Report();
         }
 
         w.reset();


### PR DESCRIPTION
- Use the same setup_rmm for external memory demos.
- Display timeout seconds in nccl timeout.