### PR TITLE
Consistent Python relative imports.

### DIFF
--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -7,17 +7,17 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import csr_matrix
 
-from xgboost import DataIter, DMatrix, QuantileDMatrix, XGBModel
-from xgboost.compat import concat
-
 from .._typing import ArrayLike
-from .utils import get_logger  # type: ignore
+from ..compat import concat
+from ..core import DataIter, DMatrix, QuantileDMatrix
+from ..sklearn import XGBModel
+from .utils import get_logger
 
 
 def stack_series(series: pd.Series) -> np.ndarray:
     """Stack a series of arrays."""
     array = series.to_numpy(copy=False)
-    array = np.stack(array)
+    array = np.stack(array)  # type: ignore
     return array
 
 

--- a/python-package/xgboost/spark/estimator.py
+++ b/python-package/xgboost/spark/estimator.py
@@ -12,8 +12,7 @@ from pyspark import keyword_only
 from pyspark.ml.param import Param, Params
 from pyspark.ml.param.shared import HasProbabilityCol, HasRawPredictionCol
 
-from xgboost import XGBClassifier, XGBRanker, XGBRegressor
-
+from ..sklearn import XGBClassifier, XGBRanker, XGBRegressor
 from .core import (  # type: ignore
     _ClassificationModel,
     _SparkXGBEstimator,


### PR DESCRIPTION
This helps align the code base to use relative import consistently similar to the sklearn codebase. The testing module still has mixed import types as most of the helper code is in the init module.