### PR TITLE
Handle `cudf.pandas` proxy objects properly

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2681,7 +2681,7 @@ class Booster:
         )
 
         if _is_cudf_pandas_df(data) or _is_cudf_pandas_ser(data):
-            data = data._fsproxy_fast
+            data = data._fsproxy_fast  # pylint: disable=protected-access
 
         enable_categorical = True
         if _is_arrow(data):

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2669,8 +2669,7 @@ class Booster:
             _arrow_transform,
             _is_arrow,
             _is_cudf_df,
-            _is_cudf_pandas_df,
-            _is_cudf_pandas_ser,
+            _is_cudf_pandas,
             _is_cupy_alike,
             _is_list,
             _is_np_array_like,
@@ -2680,7 +2679,7 @@ class Booster:
             _transform_pandas_df,
         )
 
-        if _is_cudf_pandas_df(data) or _is_cudf_pandas_ser(data):
+        if _is_cudf_pandas(data):
             data = data._fsproxy_fast  # pylint: disable=protected-access
 
         enable_categorical = True

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2679,6 +2679,7 @@ class Booster:
             _is_tuple,
             _transform_pandas_df,
         )
+
         if _is_cudf_pandas_df(data) or _is_cudf_pandas_ser(data):
             data = data._fsproxy_fast
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2669,6 +2669,8 @@ class Booster:
             _arrow_transform,
             _is_arrow,
             _is_cudf_df,
+            _is_cudf_pandas_df,
+            _is_cudf_pandas_ser,
             _is_cupy_alike,
             _is_list,
             _is_np_array_like,
@@ -2677,6 +2679,8 @@ class Booster:
             _is_tuple,
             _transform_pandas_df,
         )
+        if _is_cudf_pandas_df(data) or _is_cudf_pandas_ser(data):
+            data = data._fsproxy_fast
 
         enable_categorical = True
         if _is_arrow(data):

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -845,6 +845,12 @@ def _arrow_transform(data: DataType) -> Any:
 def _is_cudf_df(data: DataType) -> bool:
     return lazy_isinstance(data, "cudf.core.dataframe", "DataFrame")
 
+def _is_cudf_pandas_df(data: DataType) -> bool:
+    return str(type(data)) == "<class 'pandas.core.frame.DataFrame'>" and str(type(type(data))) == "<class 'cudf.pandas.fast_slow_proxy._FastSlowProxyMeta'>"
+
+def _is_cudf_pandas_ser(data: DataType) -> bool:
+    return str(type(data)) == "<class 'pandas.core.series.Series'>" and str(type(type(data))) == "<class 'cudf.pandas.fast_slow_proxy._FastSlowProxyMeta'>"
+
 
 def _get_cudf_cat_predicate() -> Callable[[Any], bool]:
     try:
@@ -1480,6 +1486,8 @@ def _proxy_transform(
     feature_types: Optional[FeatureTypes],
     enable_categorical: bool,
 ) -> TransformedData:
+    if _is_cudf_pandas_df(data) or _is_cudf_pandas_ser(data):
+        data = data._fsproxy_fast
     if _is_cudf_df(data) or _is_cudf_ser(data):
         return _transform_cudf_df(
             data, feature_names, feature_types, enable_categorical

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -845,11 +845,21 @@ def _arrow_transform(data: DataType) -> Any:
 def _is_cudf_df(data: DataType) -> bool:
     return lazy_isinstance(data, "cudf.core.dataframe", "DataFrame")
 
+
 def _is_cudf_pandas_df(data: DataType) -> bool:
-    return str(type(data)) == "<class 'pandas.core.frame.DataFrame'>" and str(type(type(data))) == "<class 'cudf.pandas.fast_slow_proxy._FastSlowProxyMeta'>"
+    return (
+        str(type(data)) == "<class 'pandas.core.frame.DataFrame'>"
+        and str(type(type(data)))
+        == "<class 'cudf.pandas.fast_slow_proxy._FastSlowProxyMeta'>"
+    )
+
 
 def _is_cudf_pandas_ser(data: DataType) -> bool:
-    return str(type(data)) == "<class 'pandas.core.series.Series'>" and str(type(type(data))) == "<class 'cudf.pandas.fast_slow_proxy._FastSlowProxyMeta'>"
+    return (
+        str(type(data)) == "<class 'pandas.core.series.Series'>"
+        and str(type(type(data)))
+        == "<class 'cudf.pandas.fast_slow_proxy._FastSlowProxyMeta'>"
+    )
 
 
 def _get_cudf_cat_predicate() -> Callable[[Any], bool]:

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -1497,7 +1497,7 @@ def _proxy_transform(
     enable_categorical: bool,
 ) -> TransformedData:
     if _is_cudf_pandas_df(data) or _is_cudf_pandas_ser(data):
-        data = data._fsproxy_fast
+        data = data._fsproxy_fast  # pylint: disable=protected-access
     if _is_cudf_df(data) or _is_cudf_ser(data):
         return _transform_cudf_df(
             data, feature_names, feature_types, enable_categorical


### PR DESCRIPTION
`cudf.pandas` proxy objects will not pass `is_cudf....` checks and rather they tend to only pass `is_pandas...`. But the pandas code-flows have many `to_numpy` calls that are introducing slow-downs incase of `cudf.pandas` objects. This PR bypasses this problem by introducing a mechanism to extract proper `cudf` objects out of `cudf.pandas` objects. That way there is no slow-down.