### PR TITLE
[R] Stop when handling deprecated parameters.

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -573,7 +573,7 @@ check.deprecation <- function(..., env = parent.frame()) {
     }
     .Deprecated(new_par, old = old_par, package = 'xgboost')
     if (new_par != 'NULL') {
-      eval(parse(text = paste(new_par, '<-', pars[[pars_par]])), envir = env)
+      stop()
     }
   }
 }

--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -572,8 +572,6 @@ check.deprecation <- function(..., env = parent.frame()) {
       warning("'", pars_par, "' was partially matched to '", old_par, "'")
     }
     .Deprecated(new_par, old = old_par, package = 'xgboost')
-    if (new_par != 'NULL') {
-      stop()
-    }
+    stop()
   }
 }

--- a/R-package/tests/testthat/test_helpers.R
+++ b/R-package/tests/testthat/test_helpers.R
@@ -537,14 +537,12 @@ test_that("check.deprecation works", {
   }
   res <- ttt(a = 1, DUMMY = 2, z = 3)
   expect_equal(res, list(a = 1, DUMMY = 2))
-  expect_warning(
-    res <- ttt(a = 1, dummy = 22, z = 3)
-  , "\'dummy\' is deprecated")
-  expect_equal(res, list(a = 1, DUMMY = 22))
-  expect_warning(
-    res <- ttt(a = 1, dumm = 22, z = 3)
-  , "\'dumm\' was partially matched to \'dummy\'")
-  expect_equal(res, list(a = 1, DUMMY = 22))
+  expect_error(
+    res <- ttt(a = 1, dummy = 22, z = 3),
+  )
+  expect_error(
+    res <- ttt(a = 1, dumm = 22, z = 3),
+  )
 })
 
 test_that('convert.labels works', {


### PR DESCRIPTION
Ran into the following error when using the old `watchlist` parameter:
```
Error in parse(text = paste(new_par, "<-", pars[[pars_par]])) : 
  <text>:1:10: unexpected '<'
1: evals <- <
             ^
Calls: xgb.train -> check.deprecation -> eval -> parse
In addition: Warning message:
In check.deprecation(...) : 'watchlist' is deprecated.
Use 'evals' instead.
See help("Deprecated") and help("xgboost-deprecated").
Execution halted
```

This is caused by the R `<pointer ..>` notation used for the DMatrix object. The PR drops the compatibility with old parameter names as it's quite difficult to make robust. A clear stop might be preferred.

After the PR:
```
Calls: xgb.train -> check.deprecation
In addition: Warning message:
In check.deprecation(...) : 'watchlist' is deprecated.
Use 'evals' instead.
See help("Deprecated") and help("xgboost-deprecated").
Execution halted
```