### PR TITLE
[R] Use `predict.xgb.Booster` internally when needed

### DIFF
--- a/R-package/R/xgb.create.features.R
+++ b/R-package/R/xgb.create.features.R
@@ -86,7 +86,7 @@
 #' @export
 xgb.create.features <- function(model, data, ...) {
   check.deprecation(...)
-  pred_with_leaf <- predict(model, data, predleaf = TRUE)
+  pred_with_leaf <- predict.xgb.Booster(model, data, predleaf = TRUE)
   cols <- lapply(as.data.frame(pred_with_leaf), factor)
   cbind(data, sparse.model.matrix(~ . -1, cols)) # nolint
 }

--- a/R-package/R/xgb.plot.shap.R
+++ b/R-package/R/xgb.plot.shap.R
@@ -16,7 +16,7 @@
 #' @param target_class Only relevant for multiclass models. The default (`NULL`)
 #'   averages the SHAP values over all classes. Pass a (0-based) class index
 #'   to show only SHAP values of that class.
-#' @param approxcontrib Passed to `predict()` when `shap_contrib = NULL`.
+#' @param approxcontrib Passed to [predict.xgb.Booster()] when `shap_contrib = NULL`.
 #' @param subsample Fraction of data points randomly picked for plotting.
 #'   The default (`NULL`) will use up to 100k data points.
 #' @param n_col Number of columns in a grid of plots.
@@ -353,7 +353,7 @@ xgb.shap.data <- function(data, shap_contrib = NULL, features = NULL, top_n = 1,
   }
 
   if (is.null(shap_contrib)) {
-    shap_contrib <- predict(
+    shap_contrib <- predict.xgb.Booster(
       model,
       newdata = data,
       predcontrib = TRUE,

--- a/R-package/man/xgb.plot.shap.Rd
+++ b/R-package/man/xgb.plot.shap.Rd
@@ -54,7 +54,7 @@ Only used when \code{features = NULL}.}
 averages the SHAP values over all classes. Pass a (0-based) class index
 to show only SHAP values of that class.}
 
-\item{approxcontrib}{Passed to \code{predict()} when \code{shap_contrib = NULL}.}
+\item{approxcontrib}{Passed to \code{\link[=predict.xgb.Booster]{predict.xgb.Booster()}} when \code{shap_contrib = NULL}.}
 
 \item{subsample}{Fraction of data points randomly picked for plotting.
 The default (\code{NULL}) will use up to 100k data points.}

--- a/R-package/man/xgb.plot.shap.summary.Rd
+++ b/R-package/man/xgb.plot.shap.summary.Rd
@@ -51,7 +51,7 @@ Only used when \code{features = NULL}.}
 averages the SHAP values over all classes. Pass a (0-based) class index
 to show only SHAP values of that class.}
 
-\item{approxcontrib}{Passed to \code{predict()} when \code{shap_contrib = NULL}.}
+\item{approxcontrib}{Passed to \code{\link[=predict.xgb.Booster]{predict.xgb.Booster()}} when \code{shap_contrib = NULL}.}
 
 \item{subsample}{Fraction of data points randomly picked for plotting.
 The default (\code{NULL}) will use up to 100k data points.}


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

After previous PR got merged: https://github.com/dmlc/xgboost/pull/11041
Some functions which internally call `predict` on model objects now need to explicitly call the old `predict.xgb.Booster` in case they get passed an object from `xgboost()`, since otherwise R will dispatch `predict.xgboost` for them.