### PR TITLE
[R] Don't throw `stratified=FALSE` warning when nothing changes

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -285,7 +285,7 @@ generate.cv.folds <- function(nfold, nrows, stratified, label, group, params) {
     return(generate.group.folds(nfold, group))
   }
   objective <- params$objective
-  if (!is.character(objective)) {
+  if (stratified && !is.character(objective)) {
     warning("Will use unstratified splitting (custom objective used)")
     stratified <- FALSE
   }


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

This PR changes a condition that was introduced recently that made `xgb.cv` throw a warning about using `stratified=FALSE` even when that was already the case.