### PR TITLE
Avoid forced log in the DMatrix binary loader.

### DIFF
--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -103,8 +103,7 @@ test_that("xgb.DMatrix: saving, loading", {
   on.exit(unlink(tmp_file))
   expect_true(xgb.DMatrix.save(dtest1, tmp_file))
   # read from a local file
-  expect_output(dtest3 <- xgb.DMatrix(tmp_file), "entries loaded from")
-  expect_output(dtest3 <- xgb.DMatrix(tmp_file, silent = TRUE), NA)
+  expect_output(dtest3 <- xgb.DMatrix(tmp_file), NA)
   unlink(tmp_file)
   expect_equal(getinfo(dtest1, 'label'), getinfo(dtest3, 'label'))
 

--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -103,6 +103,9 @@ test_that("xgb.DMatrix: saving, loading", {
   on.exit(unlink(tmp_file))
   expect_true(xgb.DMatrix.save(dtest1, tmp_file))
   # read from a local file
+  xgb.set.config(verbosity = 2)
+  expect_output(dtest3 <- xgb.DMatrix(tmp_file), "entries loaded from")
+  xgb.set.config(verbosity = 1)
   expect_output(dtest3 <- xgb.DMatrix(tmp_file), NA)
   unlink(tmp_file)
   expect_equal(getinfo(dtest1, 'label'), getinfo(dtest3, 'label'))

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -878,8 +878,8 @@ DMatrix* TryLoadBinary(std::string fname, bool silent) {
       if (magic == data::SimpleDMatrix::kMagic) {
         DMatrix* dmat = new data::SimpleDMatrix(&is);
         if (!silent) {
-          LOG(CONSOLE) << dmat->Info().num_row_ << 'x' << dmat->Info().num_col_ << " matrix with "
-                       << dmat->Info().num_nonzero_ << " entries loaded from " << fname;
+          LOG(INFO) << dmat->Info().num_row_ << 'x' << dmat->Info().num_col_ << " matrix with "
+                    << dmat->Info().num_nonzero_ << " entries loaded from " << fname;
         }
         return dmat;
       }


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/11075 .