### PR TITLE
[R] Update .rst docs for R

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -24,36 +24,31 @@ Code Examples
 -------------
 ### Features Walkthrough
 
+_Note: for the R package, see the in-package examples and vignettes instead_
+
 This is a list of short codes introducing different functionalities of xgboost packages.
 
 * Basic walkthrough of packages
   [python](guide-python/basic_walkthrough.py)
-  [R](../R-package/demo/basic_walkthrough.R)
   [Julia](https://github.com/antinucleon/XGBoost.jl/blob/master/demo/basic_walkthrough.jl)
   [PHP](https://github.com/bpachev/xgboost-php/blob/master/demo/titanic_demo.php)
 * Customize loss function, and evaluation metric
   [python](guide-python/custom_objective.py)
-  [R](../R-package/demo/custom_objective.R)
   [Julia](https://github.com/antinucleon/XGBoost.jl/blob/master/demo/custom_objective.jl)
 * Boosting from existing prediction
   [python](guide-python/boost_from_prediction.py)
-  [R](../R-package/demo/boost_from_prediction.R)
   [Julia](https://github.com/antinucleon/XGBoost.jl/blob/master/demo/boost_from_prediction.jl)
 * Predicting using first n trees
   [python](guide-python/predict_first_ntree.py)
-  [R](../R-package/demo/predict_first_ntree.R)
   [Julia](https://github.com/antinucleon/XGBoost.jl/blob/master/demo/predict_first_ntree.jl)
 * Generalized Linear Model
   [python](guide-python/generalized_linear_model.py)
-  [R](../R-package/demo/generalized_linear_model.R)
   [Julia](https://github.com/antinucleon/XGBoost.jl/blob/master/demo/generalized_linear_model.jl)
 * Cross validation
   [python](guide-python/cross_validation.py)
-  [R](../R-package/demo/cross_validation.R)
   [Julia](https://github.com/antinucleon/XGBoost.jl/blob/master/demo/cross_validation.jl)
 * Predicting leaf indices
   [python](guide-python/predict_leaf_indices.py)
-  [R](../R-package/demo/predict_leaf_indices.R)
 
 ### Basic Examples by Tasks
 

--- a/doc/R-package/index.rst
+++ b/doc/R-package/index.rst
@@ -14,7 +14,6 @@ Get Started
 ***********
 * Checkout the :doc:`Installation Guide </install>` contains instructions to install xgboost, and :doc:`Tutorials </tutorials/index>` for examples on how to use XGBoost for various tasks.
 * Read the `API documentation <https://cran.r-project.org/web/packages/xgboost/xgboost.pdf>`_.
-* Please visit `Walk-through Examples <https://github.com/dmlc/xgboost/tree/master/R-package/demo>`_.
 
 *********
 Tutorials

--- a/doc/get_started.rst
+++ b/doc/get_started.rst
@@ -44,7 +44,8 @@ R
   train <- agaricus.train
   test <- agaricus.test
   # fit model
-  bst <- xgboost(data = train$data, label = train$label, max.depth = 2, eta = 1, nrounds = 2,
+  bst <- xgboost(x = train$data, y = factor(train$label),
+                 max.depth = 2, eta = 1, nrounds = 2,
                  nthread = 2, objective = "binary:logistic")
   # predict
   pred <- predict(bst, test$data)


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

The code snippet for "getting started" with the R package is no longer valid. This PR updates it to reflect the current syntax.

Along the way, it also removes references to the R in-package demos that were removed in https://github.com/dmlc/xgboost/pull/10750