### PR TITLE
[R] Fix lintr exclude scope

### DIFF
--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -381,7 +381,7 @@ xgb.train <- function(params = xgb.params(), data, nrounds, evals = list(),
   return(bst)
 }
 
-# nolint start: line_length_linter
+# nolint start: line_length_linter.
 #' @title XGBoost Parameters
 #' @description Convenience function to generate a list of named XGBoost parameters, which
 #' can be passed as argument `params` to [xgb.train()]. See the [online documentation](


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/11083

This PR fixes the linter exclusion syntax to apply it to only one type of rule.