### PR TITLE
[R] Silence recently added verbose test

### DIFF
--- a/R-package/tests/testthat/test_xgboost.R
+++ b/R-package/tests/testthat/test_xgboost.R
@@ -1004,7 +1004,8 @@ test_that("'eval_set' as fraction works", {
     eval_set = 0.2,
     nthreads = 1L,
     nrounds = 4L,
-    max_depth = 2L
+    max_depth = 2L,
+    verbosity = 0L
   )
   expect_true(hasName(attributes(model), "evaluation_log"))
   evaluation_log <- attributes(model)$evaluation_log


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

After PR https://github.com/dmlc/xgboost/pull/11065 got merged, a new test was added which had not been included in the silencing of outputs from a previous PR (https://github.com/dmlc/xgboost/pull/11076).

This PR sets the verbosity of that test to zero, so that again we have clean test output with no logs from xgboost itself.