### PR TITLE
[R] Move gc data protection to R side

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -575,7 +575,7 @@ xgb.ProxyDMatrix <- function(proxy_handle, data_iterator, env_keep_alive) {
   }
   if (is.data.frame(lst$data)) {
     data <- lst$data
-    lst <- within(lst, rm("data"))
+    lst$data <- NULL
     tmp <- .process.df.for.dmatrix(data, lst$feature_types)
     lst$feature_types <- tmp$feature_types
     env_keep_alive$keepalive1 <- lst

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -687,7 +687,6 @@ XGB_DLL SEXP XGProxyDMatrixSetDataDense_R(SEXP handle, SEXP R_mat) {
   {
     std::string array_str = MakeArrayInterfaceFromRMat(R_mat);
     res_code = XGProxyDMatrixSetDataDense(proxy_dmat, array_str.c_str());
-    R_SetExternalPtrProtected(handle, R_mat);
   }
   CHECK_CALL(res_code);
   R_API_END();
@@ -708,7 +707,6 @@ XGB_DLL SEXP XGProxyDMatrixSetDataCSR_R(SEXP handle, SEXP lst) {
                                         array_str_indices.c_str(),
                                         array_str_data.c_str(),
                                         ncol);
-    R_SetExternalPtrProtected(handle, lst);
   }
   CHECK_CALL(res_code);
   R_API_END();
@@ -722,7 +720,6 @@ XGB_DLL SEXP XGProxyDMatrixSetDataColumnar_R(SEXP handle, SEXP lst) {
   {
     std::string sinterface = MakeArrayInterfaceFromRDataFrame(lst);
     res_code = XGProxyDMatrixSetDataColumnar(proxy_dmat, sinterface.c_str());
-    R_SetExternalPtrProtected(handle, lst);
   }
   CHECK_CALL(res_code);
   R_API_END();
@@ -736,20 +733,17 @@ struct _RDataIterator {
   SEXP f_reset;
   SEXP calling_env;
   SEXP continuation_token;
-  SEXP proxy_dmat;
 
   _RDataIterator(
-    SEXP f_next, SEXP f_reset, SEXP calling_env, SEXP continuation_token, SEXP proxy_dmat) :
+    SEXP f_next, SEXP f_reset, SEXP calling_env, SEXP continuation_token) :
   f_next(f_next), f_reset(f_reset), calling_env(calling_env),
-  continuation_token(continuation_token), proxy_dmat(proxy_dmat) {}
+  continuation_token(continuation_token) {}
 
   void reset() {
-    R_SetExternalPtrProtected(this->proxy_dmat, R_NilValue);
     SafeExecFun(this->f_reset, this->calling_env, this->continuation_token);
   }
 
   int next() {
-    R_SetExternalPtrProtected(this->proxy_dmat, R_NilValue);
     SEXP R_res = Rf_protect(
       SafeExecFun(this->f_next, this->calling_env, this->continuation_token));
     int res = Rf_asInteger(R_res);
@@ -777,7 +771,7 @@ SEXP XGDMatrixCreateFromCallbackGeneric_R(
 
   int res_code;
   try {
-    _RDataIterator data_iterator(f_next, f_reset, calling_env, continuation_token, proxy_dmat);
+    _RDataIterator data_iterator(f_next, f_reset, calling_env, continuation_token);
 
     std::string str_cache_prefix;
     xgboost::Json jconfig{xgboost::Object{}};


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810
ref https://github.com/dmlc/xgboost/pull/11092#issuecomment-2543526600

This PR moves the logic for protection of R data from the garbage collector towards the R side.

I'm not sure whether data holding _fields_ of the DMatrix also needs to be kept protected after setting it in the proxy dmatrix, but this PR does so just in case.