### PR TITLE
Initial support for polars.

### DIFF
--- a/ops/conda_env/linux_cpu_test.yml
+++ b/ops/conda_env/linux_cpu_test.yml
@@ -16,6 +16,7 @@ dependencies:
 - scipy
 - scikit-learn>=1.4.1
 - pandas
+- polars
 - matplotlib
 - dask<=2024.10.0
 - distributed<=2024.10.0

--- a/ops/conda_env/python_lint.yml
+++ b/ops/conda_env/python_lint.yml
@@ -10,6 +10,7 @@ dependencies:
 - numpy
 - scipy
 - pandas
+- pyarrow
 - scikit-learn
 - dask
 - distributed

--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -16,11 +16,15 @@ class _ArrayLikeArg(Protocol):
     def __array_interface__(self) -> "ArrayInf": ...
 
 
-class _TransformedDf(Protocol):
-    def array_interface(self) -> bytes: ...
+class TransformedDf(Protocol):
+    """Protocol class for storing transformed dataframe."""
+
+    def array_interface(self) -> bytes:
+        """Get a JSON-encoded list of array interfaces."""
 
     @property
-    def shape(self) -> Tuple[int, int]: ...
+    def shape(self) -> Tuple[int, int]:
+        """Return the shape of the dataframe."""
 
 
 ArrayInf = TypedDict(

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -123,6 +123,13 @@ def import_cupy() -> types.ModuleType:
     return cupy
 
 
+@functools.cache
+def import_polars() -> types.ModuleType:
+    import polars as pl
+
+    return pl
+
+
 try:
     import scipy.sparse as scipy_sparse
     from scipy.sparse import csr_matrix as scipy_csr

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -124,7 +124,16 @@ def import_cupy() -> types.ModuleType:
 
 
 @functools.cache
+def is_pyarrow_available() -> bool:
+    """Check pyarrow package available or not"""
+    if importlib.util.find_spec("pyarrow") is None:
+        return False
+    return True
+
+
+@functools.cache
 def import_pyarrow() -> types.ModuleType:
+    """Import pyarrow with memory cache."""
     import pyarrow as pa
 
     return pa
@@ -132,6 +141,7 @@ def import_pyarrow() -> types.ModuleType:
 
 @functools.cache
 def import_polars() -> types.ModuleType:
+    """Import polars with memory cache."""
     import polars as pl
 
     return pl

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -124,6 +124,13 @@ def import_cupy() -> types.ModuleType:
 
 
 @functools.cache
+def import_pyarrow() -> types.ModuleType:
+    import pyarrow as pa
+
+    return pa
+
+
+@functools.cache
 def import_polars() -> types.ModuleType:
     import polars as pl
 

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -37,7 +37,7 @@ import numpy as np
 import scipy.sparse
 
 from ._data_utils import (
-    _TransformedDf,
+    TransformedDf,
     array_interface,
     cuda_array_interface,
     from_array_interface,
@@ -1432,11 +1432,8 @@ class _ProxyDMatrix(DMatrix):
         """Reference data from numpy array."""
         _check_call(_LIB.XGProxyDMatrixSetDataDense(self.handle, array_interface(data)))
 
-    def _ref_data_from_pandas(self, data: _TransformedDf) -> None:
-        """Reference data from a pandas DataFrame. The input is a PandasTransformed
-        instance.
-
-        """
+    def _ref_data_from_columnar(self, data: TransformedDf) -> None:
+        """Reference data from a CPU DataFrame."""
         _check_call(
             _LIB.XGProxyDMatrixSetDataColumnar(self.handle, data.array_interface())
         )

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -65,7 +65,7 @@ from ._typing import (
     TransformedData,
     c_bst_ulong,
 )
-from .compat import PANDAS_INSTALLED, DataFrame, py_str, import_polars
+from .compat import PANDAS_INSTALLED, DataFrame, import_polars, py_str
 from .libpath import find_lib_path
 
 
@@ -2613,11 +2613,11 @@ class Booster:
             _is_pandas_df,
             _is_pandas_series,
             _is_polars,
-            _is_tuple,
             _is_polars_series,
-            _transform_polars_df,
+            _is_tuple,
             _transform_arrow_table,
             _transform_pandas_df,
+            _transform_polars_df,
         )
 
         if _is_cudf_pandas(data):

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -780,9 +780,7 @@ class ArrowTransformed(TransformedDf):
         else:
             pa = import_pyarrow()
 
-        def array_inf(
-            col: Union["pa.NumericArray", "pa.DictionaryArray"]
-        ) -> ArrayInf:
+        def array_inf(col: Union["pa.NumericArray", "pa.DictionaryArray"]) -> ArrayInf:
             buffers = col.buffers()
             if isinstance(col, pa.DictionaryArray):
                 mask, _, data = col.buffers()

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -52,7 +52,13 @@ from .core import (
     _parse_version,
     _py_version,
 )
-from .data import _is_cudf_df, _is_cudf_ser, _is_cupy_alike, _is_pandas_df
+from .data import (
+    _is_cudf_df,
+    _is_cudf_ser,
+    _is_cupy_alike,
+    _is_pandas_df,
+    _is_polars_lazyframe,
+)
 from .training import train
 
 
@@ -1577,6 +1583,8 @@ class XGBClassifier(XGBClassifierBase, XGBModel):
             # We keep the n_classes_ as a simple member instead of loading it from
             # booster in a Python property. This way we can have efficient and
             # thread-safe prediction.
+            if _is_polars_lazyframe(y):
+                y = y.collect()
             if _is_cudf_df(y) or _is_cudf_ser(y):
                 cp = import_cupy()
 

--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -143,6 +143,7 @@ def no_arrow() -> PytestSkip:
 def no_polars() -> PytestSkip:
     return no_mod("polars")
 
+
 def no_modin() -> PytestSkip:
     try:
         import modin.pandas as md

--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -140,6 +140,9 @@ def no_arrow() -> PytestSkip:
     return no_mod("pyarrow")
 
 
+def no_polars() -> PytestSkip:
+    return no_mod("polars")
+
 def no_modin() -> PytestSkip:
     try:
         import modin.pandas as md

--- a/tests/python/test_with_arrow.py
+++ b/tests/python/test_with_arrow.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import numpy as np
 import pytest

--- a/tests/python/test_with_polars.py
+++ b/tests/python/test_with_polars.py
@@ -2,6 +2,7 @@ from typing import Type, Union
 
 import numpy as np
 import pytest
+
 import xgboost as xgb
 from xgboost import testing as tm
 

--- a/tests/python/test_with_polars.py
+++ b/tests/python/test_with_polars.py
@@ -80,7 +80,7 @@ def test_classififer() -> None:
         path0 = os.path.join(tmpdir, "clf0.json")
         clf0.save_model(path0)
 
-        path1 = os.path.join(tmpdir, "clf0.json")
+        path1 = os.path.join(tmpdir, "clf1.json")
         clf1.save_model(path1)
 
         with open(path0, "r") as fd:
@@ -88,6 +88,8 @@ def test_classififer() -> None:
         with open(path1, "r") as fd:
             model1 = json.load(fd)
 
+    model0["learner"]["feature_names"] = []
+    model0["learner"]["feature_types"] = []
     assert model0 == model1
 
     predt0 = clf0.predict(X)

--- a/tests/python/test_with_polars.py
+++ b/tests/python/test_with_polars.py
@@ -1,0 +1,55 @@
+from typing import Type, Union
+
+import numpy as np
+import pytest
+import xgboost as xgb
+from xgboost import testing as tm
+
+pytestmark = [pytest.mark.skipif(**tm.no_polars()), tm.timeout(30)]
+
+import polars as pl
+
+
+@pytest.mark.parametrize("DMatrixT", [xgb.DMatrix, xgb.QuantileDMatrix])
+def test_polars_basic(
+    DMatrixT: Union[Type[xgb.DMatrix], Type[xgb.QuantileDMatrix]]
+) -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5]})
+    Xy = DMatrixT(df)
+    assert Xy.num_row() == df.shape[0]
+    assert Xy.num_col() == df.shape[1]
+    assert Xy.num_nonmissing() == np.prod(df.shape)
+
+    res = Xy.get_data().toarray()
+    res1 = df.to_numpy()
+
+    if isinstance(Xy, xgb.QuantileDMatrix):
+        np.testing.assert_allclose(res[1:, :], res1[1:, :])
+    else:
+        np.testing.assert_allclose(res, res1)
+
+    # boolean
+    df = pl.DataFrame({"a": [True, False, False], "b": [False, False, True]})
+    Xy = DMatrixT(df)
+    np.testing.assert_allclose(
+        Xy.get_data().data, np.array([1, 0, 0, 0, 0, 1]), atol=1e-5
+    )
+
+
+def test_polars_missing() -> None:
+    df = pl.DataFrame({"a": [1, None, 3], "b": [3, 4, None]})
+    Xy = xgb.DMatrix(df)
+    assert Xy.num_row() == df.shape[0]
+    assert Xy.num_col() == df.shape[1]
+    assert Xy.num_nonmissing() == 4
+
+    np.testing.assert_allclose(Xy.get_data().data, np.array([1, 3, 4, 3]))
+    np.testing.assert_allclose(Xy.get_data().indptr, np.array([0, 2, 3, 4]))
+    np.testing.assert_allclose(Xy.get_data().indices, np.array([0, 1, 1, 0]))
+
+    ser = pl.Series("y", np.arange(0, df.shape[0]))
+    Xy.set_info(label=ser)
+    booster = xgb.train({}, Xy, num_boost_round=1)
+    predt0 = booster.inplace_predict(df)
+    predt1 = booster.predict(Xy)
+    np.testing.assert_allclose(predt0, predt1)

--- a/tests/python/test_with_polars.py
+++ b/tests/python/test_with_polars.py
@@ -4,11 +4,8 @@ import numpy as np
 import pytest
 
 import xgboost as xgb
-from xgboost import testing as tm
 
-pytestmark = [pytest.mark.skipif(**tm.no_polars()), tm.timeout(30)]
-
-import polars as pl
+pl = pytest.importorskip("polars")
 
 
 @pytest.mark.parametrize("DMatrixT", [xgb.DMatrix, xgb.QuantileDMatrix])

--- a/tests/python/test_with_polars.py
+++ b/tests/python/test_with_polars.py
@@ -1,3 +1,5 @@
+"""Copyright 2024, XGBoost contributors"""
+
 from typing import Type, Union
 
 import numpy as np

--- a/tests/python/test_with_polars.py
+++ b/tests/python/test_with_polars.py
@@ -64,7 +64,7 @@ def test_polars_missing() -> None:
 
 
 def test_classififer() -> None:
-    from sklearn.datasets import make_classification
+    from sklearn.datasets import make_classification, make_multilabel_classification
 
     X, y = make_classification(random_state=2024)
     X_df = pl.DataFrame(X)
@@ -99,6 +99,20 @@ def test_classififer() -> None:
 
     assert (clf0.feature_names_in_ == X_df.columns).all()
     assert clf0.n_features_in_ == X_df.shape[1]
+
+    X, y = make_multilabel_classification(128)
+    X_df = pl.DataFrame(X)
+    y_df = pl.DataFrame(y)
+    clf = xgb.XGBClassifier(n_estimators=1)
+    clf.fit(X_df, y_df)
+    assert clf.n_classes_ == 2
+
+    X, y = make_classification(n_classes=3, n_informative=5)
+    X_df = pl.DataFrame(X)
+    y_ser = pl.Series(y)
+    clf = xgb.XGBClassifier(n_estimators=1)
+    clf.fit(X_df, y_ser)
+    assert clf.n_classes_ == 3
 
 
 def test_regressor() -> None:

--- a/tests/python/test_with_polars.py
+++ b/tests/python/test_with_polars.py
@@ -99,3 +99,23 @@ def test_classififer() -> None:
 
     assert (clf0.feature_names_in_ == X_df.columns).all()
     assert clf0.n_features_in_ == X_df.shape[1]
+
+
+def test_regressor() -> None:
+    from sklearn.datasets import make_regression
+
+    X, y = make_regression(n_targets=3)
+    X_df = pl.DataFrame(X)
+    y_df = pl.DataFrame(y)
+    assert y_df.shape[1] == 3
+
+    reg0 = xgb.XGBRegressor()
+    reg0.fit(X_df, y_df)
+
+    reg1 = xgb.XGBRegressor()
+    reg1.fit(X, y)
+
+    predt0 = reg0.predict(X)
+    predt1 = reg1.predict(X)
+
+    np.testing.assert_allclose(predt0, predt1)

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -1,7 +1,6 @@
 import json
 import os
 import pickle
-import random
 import re
 import tempfile
 import warnings


### PR DESCRIPTION
pyarrow is required for polars input. Categorical data is not yet supported, will wait until the re-coder is completed. This patch also helps setup the code for accepting CPU-based arrow data.

- Add masked dataframe support
- Initial support for polars.
- No GPU yet.
- Reuse the code for handling pyarrow table.

todo:
- [x] perf check
- [x] make specialization if needed.