### PR TITLE
Remove inconsistency in return types between `predict` and `inplace_predict`

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -1294,10 +1294,6 @@ class XGBModel(XGBModelBase):
                         base_margin=base_margin,
                         validate_features=validate_features,
                     )
-                    if _is_cupy_alike(predts):
-                        cp = import_cupy()
-
-                        predts = cp.asnumpy(predts)  # ensure numpy array is used.
                     return predts
                 except TypeError:
                     # coo, csc, dt


### PR DESCRIPTION
I see that `inplace_predict` returns a `cupy` array but `predict` returns a numpy array always. Not sure if this is intentional. Can one of the maintainers comment on this?