### PR TITLE
[R] Update note about `qs` serialization

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -462,9 +462,8 @@ NULL
 #' could in theory change again in the future, so XGBoost's serializers should be
 #' preferred for long-term storage.
 #'
-#' Furthermore, note that using the package `qs` for serialization will require
-#' version 0.26 or higher of said package, and will have the same compatibility
-#' restrictions as R serializers.
+#' Furthermore, note that model objects from XGBoost might not be serializable with third-party
+#' R packages like `qs` or `qs2`.
 #'
 #' @details
 #' Use [xgb.save()] to save the XGBoost model as a stand-alone file. You may opt into

--- a/R-package/man/a-compatibility-note-for-saveRDS-save.Rd
+++ b/R-package/man/a-compatibility-note-for-saveRDS-save.Rd
@@ -54,9 +54,8 @@ like \code{\link[=saveRDS]{saveRDS()}} or \code{\link[=save]{save()}} before ver
 could in theory change again in the future, so XGBoost's serializers should be
 preferred for long-term storage.
 
-Furthermore, note that using the package \code{qs} for serialization will require
-version 0.26 or higher of said package, and will have the same compatibility
-restrictions as R serializers.
+Furthermore, note that model objects from XGBoost might not be serializable with third-party
+R packages like \code{qs} or \code{qs2}.
 }
 \details{
 Use \code{\link[=xgb.save]{xgb.save()}} to save the XGBoost model as a stand-alone file. You may opt into


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

Package `qs` has been deprecated and its replacement will not support serialization of `ALTLIST` class as used by xgboost. This PR updates the serialization note to reflect this behavior.