### PR TITLE
Warning for polars lazy frame.

### DIFF
--- a/doc/python/python_intro.rst
+++ b/doc/python/python_intro.rst
@@ -118,6 +118,7 @@ Markers
 - F: Not supported.
 - NE: Invalid type for the use case. For instance, `pd.Series` can not be multi-target label.
 - NPA: Support with the help of numpy array.
+- AT: Support with the help of arrow table.
 - CPA: Support with the help of cupy array.
 - SciCSR: Support with the help of scripy sparse CSR. The conversion to scipy CSR may or may not be possible. Raise a type error if conversion fails.
 - FF: We can look forward to having its support in recent future if requested.
@@ -170,12 +171,23 @@ Support Matrix
 +-------------------------+-----------+-------------------+-----------+-----------+--------------------+-------------+
 | modin.Series            | NPA       | FF                | NPA       | NPA       | FF                 |             |
 +-------------------------+-----------+-------------------+-----------+-----------+--------------------+-------------+
-| pyarrow.Table           | NPA       | NPA               | NPA       | NPA       | NPA                | NPA         |
+| pyarrow.Table           | T         | T                 | T         | T         | T                  | T           |
++-------------------------+-----------+-------------------+-----------+-----------+--------------------+-------------+
+| polars.DataFrame        | AT        | AT                | AT        | AT        | AT                 | AT          |
++-------------------------+-----------+-------------------+-----------+-----------+--------------------+-------------+
+| polars.LazyFrame (WARN) | AT        | AT                | AT        | AT        | AT                 | AT          |
++-------------------------+-----------+-------------------+-----------+-----------+--------------------+-------------+
+| polars.Series           | AT        | AT                | AT        | AT        | AT                 | NE          |
 +-------------------------+-----------+-------------------+-----------+-----------+--------------------+-------------+
 | _\_array\_\_            | NPA       | F                 | NPA       | NPA       | H                  |             |
 +-------------------------+-----------+-------------------+-----------+-----------+--------------------+-------------+
 | Others                  | SciCSR    | F                 |           | F         | F                  |             |
 +-------------------------+-----------+-------------------+-----------+-----------+--------------------+-------------+
+
+The polars ``LazyFrame.collect`` supports many configurations, ranging from the choice of
+query engine to type coercion. XGBoost simply uses the default parameter. Please run
+``collect`` to obtain the ``DataFrame`` before passing it into XGBoost for finer control
+over the behaviour.
 
 Setting Parameters
 ------------------

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -961,6 +961,11 @@ def _transform_polars_df(
 ) -> Tuple[ArrowTransformed, Optional[FeatureNames], Optional[FeatureTypes]]:
     if _is_polars_lazyframe(data):
         df = data.collect()
+        warnings.warn(
+            "Using the default parameters for the polars `LazyFrame.collect`. Consider"
+            " passing a realized `DataFrame` or `Series` instead.",
+            UserWarning,
+        )
     else:
         df = data
 

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -1143,7 +1143,7 @@ class XGBModel(XGBModelBase):
         Parameters
         ----------
         X :
-            Feature matrix. See :ref:`py-data` for a list of supported types.
+            Input feature matrix. See :ref:`py-data` for a list of supported types.
 
             When the ``tree_method`` is set to ``hist``, internally, the
             :py:class:`QuantileDMatrix` will be used instead of the :py:class:`DMatrix`
@@ -1267,7 +1267,7 @@ class XGBModel(XGBModelBase):
         Parameters
         ----------
         X :
-            Data to predict with.
+            Data to predict with. See :ref:`py-data` for a list of supported types.
         output_margin :
             Whether to output the raw untransformed margin value.
         validate_features :
@@ -1334,8 +1334,8 @@ class XGBModel(XGBModelBase):
 
         Parameters
         ----------
-        X : array_like, shape=[n_samples, n_features]
-            Input features matrix.
+        X :
+            Input features matrix. See :ref:`py-data` for a list of supported types.
 
         iteration_range :
             See :py:meth:`predict`.


### PR DESCRIPTION
We might eventually reuse the booster `device` config for the `collect` call. But for now, a warning should be enough. Otherwise, we need to check whether the polars is built with GPU support in addition to retrieving the JSON configuration from XGBoost for every inference call.