### PR TITLE
[jvm-packages] Supports external memory

### DIFF
--- a/jvm-packages/create_jni.py
+++ b/jvm-packages/create_jni.py
@@ -95,11 +95,17 @@ def native_build(cli_args: argparse.Namespace) -> None:
             CONFIG["USE_DLOPEN_NCCL"] = "OFF"
 
         args = ["-D{0}:BOOL={1}".format(k, v) for k, v in CONFIG.items()]
+        if sys.platform != "win32":
+            try:
+                subprocess.check_call(["ninja", "--version"])
+                args.append("-GNinja")
+            except FileNotFoundError:
+                pass
 
         # if enviorment set GPU_ARCH_FLAG
         gpu_arch_flag = os.getenv("GPU_ARCH_FLAG", None)
         if gpu_arch_flag is not None:
-            args.append("%s" % gpu_arch_flag)
+            args.append("-DCMAKE_CUDA_ARCHITECTURES=%s" % gpu_arch_flag)
 
         with cd(build_dir):
             lib_dir = os.path.join(os.pardir, "lib")

--- a/jvm-packages/xgboost4j-spark-gpu/src/main/java/ml/dmlc/xgboost4j/java/CudfColumnBatch.java
+++ b/jvm-packages/xgboost4j-spark-gpu/src/main/java/ml/dmlc/xgboost4j/java/CudfColumnBatch.java
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2024 by Contributors
+ Copyright (c) 2021-2025 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -84,6 +84,16 @@ public class CudfColumnBatch extends ColumnBatch {
       .mapToObj(table::getColumn)
       .map(CudfColumn::from)
       .collect(Collectors.toList());
+  }
+
+  // visible for testing
+  public Table getFeatureTable() {
+    return featureTable;
+  }
+
+  // visible for testing
+  public Table getLabelTable() {
+    return labelTable;
   }
 
   public List<CudfColumn> getFeatures() {

--- a/jvm-packages/xgboost4j-spark-gpu/src/main/java/ml/dmlc/xgboost4j/java/QuantileDMatrix.java
+++ b/jvm-packages/xgboost4j-spark-gpu/src/main/java/ml/dmlc/xgboost4j/java/QuantileDMatrix.java
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2024 by Contributors
+ Copyright (c) 2021-2025 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,11 +15,40 @@
  */
 package ml.dmlc.xgboost4j.java;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+class F64NaNSerializer extends JsonSerializer<Double> {
+  @Override
+  public void serialize(Double value, JsonGenerator gen,
+                        SerializerProvider serializers) throws IOException {
+    if (value.isNaN()) {
+      gen.writeRawValue("NaN"); // Write NaN without quotes
+    } else {
+      gen.writeNumber(value);
+    }
+  }
+}
+
+class F32NaNSerializer extends JsonSerializer<Float> {
+  @Override
+  public void serialize(Float value, JsonGenerator gen,
+                        SerializerProvider serializers) throws IOException {
+    if (value.isNaN()) {
+      gen.writeRawValue("NaN"); // Write NaN without quotes
+    } else {
+      gen.writeNumber(value);
+    }
+  }
+}
 
 /**
  * QuantileDMatrix will only be used to train
@@ -121,8 +150,17 @@ public class QuantileDMatrix extends DMatrix {
     conf.put("max_bin", maxBin);
     conf.put("nthread", nthread);
     ObjectMapper mapper = new ObjectMapper();
+
+    // Handle NaN values. Jackson by default serializes NaN values into strings.
+    SimpleModule module = new SimpleModule();
+    module.addSerializer(Double.class, new F64NaNSerializer());
+    module.addSerializer(Float.class, new F32NaNSerializer());
+    mapper.registerModule(module);
+
     try {
-      return mapper.writeValueAsString(conf);
+      String config = mapper.writeValueAsString(conf);
+      System.out.println(config);
+      return config;
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Failed to serialize configuration", e);
     }

--- a/jvm-packages/xgboost4j-spark-gpu/src/main/java/ml/dmlc/xgboost4j/java/QuantileDMatrix.java
+++ b/jvm-packages/xgboost4j-spark-gpu/src/main/java/ml/dmlc/xgboost4j/java/QuantileDMatrix.java
@@ -61,14 +61,16 @@ public class QuantileDMatrix extends DMatrix {
    * @param missing the missing value
    * @param maxBin  the max bin
    * @param nthread the parallelism
+   * @param useExternalMemory whether to use external memory or not
    * @throws XGBoostError
    */
   public QuantileDMatrix(
       Iterator<ColumnBatch> iter,
       float missing,
       int maxBin,
-      int nthread) throws XGBoostError {
-    this(iter, null, missing, maxBin, nthread);
+      int nthread,
+      boolean useExternalMemory) throws XGBoostError {
+    this(iter, null, missing, maxBin, nthread, useExternalMemory);
   }
 
   /**
@@ -83,6 +85,7 @@ public class QuantileDMatrix extends DMatrix {
    * @param missing    the missing value
    * @param maxBin     the max bin
    * @param nthread    the parallelism
+   * @param useExternalMemory whether to use external memory or not
    * @throws XGBoostError
    */
   public QuantileDMatrix(
@@ -90,10 +93,11 @@ public class QuantileDMatrix extends DMatrix {
       QuantileDMatrix refDMatrix,
       float missing,
       int maxBin,
-      int nthread) throws XGBoostError {
+      int nthread,
+      boolean useExternalMemory) throws XGBoostError {
     super(0);
     long[] out = new long[1];
-    String conf = getConfig(missing, maxBin, nthread);
+    String conf = getConfig(missing, maxBin, nthread, useExternalMemory);
     long[] ref = null;
     if (refDMatrix != null) {
       ref = new long[1];
@@ -144,11 +148,12 @@ public class QuantileDMatrix extends DMatrix {
     throw new XGBoostError("QuantileDMatrix does not support setGroup.");
   }
 
-  private String getConfig(float missing, int maxBin, int nthread) {
+  private String getConfig(float missing, int maxBin, int nthread, boolean useExternalMemory) {
     Map<String, Object> conf = new java.util.HashMap<>();
     conf.put("missing", missing);
     conf.put("max_bin", maxBin);
     conf.put("nthread", nthread);
+    conf.put("use_ext_mem", useExternalMemory);
     ObjectMapper mapper = new ObjectMapper();
 
     // Handle NaN values. Jackson by default serializes NaN values into strings.
@@ -159,7 +164,6 @@ public class QuantileDMatrix extends DMatrix {
 
     try {
       String config = mapper.writeValueAsString(conf);
-      System.out.println(config);
       return config;
     } catch (JsonProcessingException e) {
       throw new RuntimeException("Failed to serialize configuration", e);

--- a/jvm-packages/xgboost4j-spark-gpu/src/main/java/ml/dmlc/xgboost4j/java/QuantileDMatrix.java
+++ b/jvm-packages/xgboost4j-spark-gpu/src/main/java/ml/dmlc/xgboost4j/java/QuantileDMatrix.java
@@ -16,6 +16,10 @@
 package ml.dmlc.xgboost4j.java;
 
 import java.util.Iterator;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * QuantileDMatrix will only be used to train
@@ -112,8 +116,15 @@ public class QuantileDMatrix extends DMatrix {
   }
 
   private String getConfig(float missing, int maxBin, int nthread) {
-    return String.format("{\"missing\":%f,\"max_bin\":%d,\"nthread\":%d}",
-                         missing, maxBin, nthread);
+    Map<String, Object> conf = new java.util.HashMap<>();
+    conf.put("missing", missing);
+    conf.put("max_bin", maxBin);
+    conf.put("nthread", nthread);
+    ObjectMapper mapper = new ObjectMapper();
+    try {
+      return mapper.writeValueAsString(conf);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize configuration", e);
+    }
   }
-
 }

--- a/jvm-packages/xgboost4j-spark-gpu/src/main/scala/ml/dmlc/xgboost4j/scala/QuantileDMatrix.scala
+++ b/jvm-packages/xgboost4j-spark-gpu/src/main/scala/ml/dmlc/xgboost4j/scala/QuantileDMatrix.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2024 by Contributors
+ Copyright (c) 2021-2025 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -30,31 +30,39 @@ class QuantileDMatrix private[scala](
    * @param missing the missing value
    * @param maxBin  the max bin
    * @param nthread the parallelism
+   * @param useExternalMemory whether to use external memory or not
    * @throws XGBoostError
    */
-  def this(iter: Iterator[ColumnBatch], missing: Float, maxBin: Int, nthread: Int) {
-    this(new JQuantileDMatrix(iter.asJava, missing, maxBin, nthread))
+  def this(iter: Iterator[ColumnBatch],
+           missing: Float,
+           maxBin: Int,
+           nthread: Int,
+           useExternalMemory: Boolean) {
+    this(new JQuantileDMatrix(iter.asJava, missing, maxBin, nthread, useExternalMemory))
   }
 
   /**
    * Create QuantileDMatrix from iterator based on the array interface
    *
    * @param iter       the XGBoost ColumnBatch batch to provide the corresponding array interface
-   * @param refDMatrix The reference QuantileDMatrix that provides quantile information, needed
+   * @param ref The reference QuantileDMatrix that provides quantile information, needed
    *                   when creating validation/test dataset with QuantileDMatrix. Supplying the
    *                   training DMatrix as a reference means that the same quantisation applied
    *                   to the training data is applied to the validation/test data
    * @param missing    the missing value
    * @param maxBin     the max bin
    * @param nthread    the parallelism
+   * @param useExternalMemory whether to use external memory or not
    * @throws XGBoostError
    */
   def this(iter: Iterator[ColumnBatch],
            ref: QuantileDMatrix,
            missing: Float,
            maxBin: Int,
-           nthread: Int) {
-    this(new JQuantileDMatrix(iter.asJava, ref.jDMatrix, missing, maxBin, nthread))
+           nthread: Int,
+           useExternalMemory: Boolean) {
+    this(new JQuantileDMatrix(iter.asJava, ref.jDMatrix, missing, maxBin, nthread,
+      useExternalMemory))
   }
 
   /**

--- a/jvm-packages/xgboost4j-spark-gpu/src/main/scala/ml/dmlc/xgboost4j/scala/spark/ExternalMemory.scala
+++ b/jvm-packages/xgboost4j-spark-gpu/src/main/scala/ml/dmlc/xgboost4j/scala/spark/ExternalMemory.scala
@@ -1,0 +1,221 @@
+/*
+ Copyright (c) 2025 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package ml.dmlc.xgboost4j.scala.spark
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+
+import scala.collection.mutable.ArrayBuffer
+
+import ai.rapids.cudf._
+
+import ml.dmlc.xgboost4j.java.{ColumnBatch, CudfColumnBatch}
+import ml.dmlc.xgboost4j.scala.spark.Utils.withResource
+
+private[spark] trait ExternalMemory[T] extends Iterator[Table] with AutoCloseable {
+
+  protected val buffers = ArrayBuffer.empty[T]
+  private lazy val buffersIterator = buffers.toIterator
+
+  /**
+   * Convert the table to T which will be cached
+   *
+   * @param table to be converted
+   * @return the content
+   */
+  def convertTable(table: Table): T
+
+  /**
+   * Load the content to the Table
+   *
+   * @param content to be loaded
+   * @return Table
+   */
+  def loadTable(content: T): Table
+
+  // Cache the table
+  def cacheTable(table: Table): Unit = {
+    val content = convertTable(table)
+    buffers.append(content)
+  }
+
+  override def hasNext: Boolean = buffersIterator.hasNext
+
+  override def next(): Table = loadTable(buffersIterator.next())
+
+  override def close(): Unit = {}
+}
+
+// The data will be cached into disk.
+private[spark] class DiskExternalMemoryIterator(val path: String) extends ExternalMemory[String] {
+
+  private lazy val root = {
+    val tmp = path + "/xgboost"
+    createDirectory(tmp)
+    tmp
+  }
+
+  private var counter = 0
+
+  private def createDirectory(dirPath: String): Unit = {
+    val path = Paths.get(dirPath)
+    if (!Files.exists(path)) {
+      Files.createDirectories(path)
+    } else {
+    }
+  }
+
+  /**
+   * Convert the table to file path which will be cached
+   *
+   * @param table to be converted
+   * @return the content
+   */
+  override def convertTable(table: Table): String = {
+    val names = (1 to table.getNumberOfColumns).map(_.toString)
+    val options = ArrowIPCWriterOptions.builder().withColumnNames(names: _*).build()
+    val path = root + "/table_" + counter + "_" + System.nanoTime();
+    counter += 1
+    withResource(Table.writeArrowIPCChunked(options, new File(path))) { writer =>
+      writer.write(table)
+    }
+    path
+  }
+
+  private def closeOnExcept[T <: AutoCloseable, V](r: ArrayBuffer[T])
+                                                  (block: ArrayBuffer[T] => V): V = {
+    try {
+      block(r)
+    } catch {
+      case t: Throwable =>
+        r.foreach(_.close())
+        throw t
+    }
+  }
+
+  /**
+   * Load the path from disk to the Table
+   *
+   * @param name to be loaded
+   * @return Table
+   */
+  override def loadTable(name: String): Table = {
+    val file = new File(name)
+    if (!file.exists()) {
+      throw new RuntimeException(s"The cached file ${name} not exist" )
+    }
+    try {
+      withResource(Table.readArrowIPCChunked(file)) { reader =>
+        val tables = ArrayBuffer.empty[Table]
+        closeOnExcept(tables) { tables =>
+          var table = Option(reader.getNextIfAvailable())
+          while (table.isDefined) {
+            tables.append(table.get)
+            table = Option(reader.getNextIfAvailable())
+          }
+        }
+        if (tables.size > 1) {
+          closeOnExcept(tables) { tables =>
+            Table.concatenate(tables.toArray: _*)
+          }
+        } else {
+          tables(0)
+        }
+      }
+    } catch {
+      case e: Throwable =>
+        close()
+        throw e
+    } finally {
+      if (file.exists()) {
+        file.delete()
+      }
+    }
+  }
+
+  override def close(): Unit = {
+    buffers.foreach { path =>
+      val file = new File(path)
+      if (file.exists()) {
+        file.delete()
+      }
+    }
+    buffers.clear()
+  }
+}
+
+private[spark] object ExternalMemory {
+  def apply(path: Option[String] = None): ExternalMemory[_] = {
+    path.map(new DiskExternalMemoryIterator(_))
+      .getOrElse(throw new RuntimeException("No disk path provided"))
+  }
+}
+
+/**
+ * ExternalMemoryIterator supports iterating the data twice if the `swap` is called.
+ *
+ * The first round iteration gets the input batch that will be
+ *   1. cached in the external memory
+ *      2. fed in QuantilDmatrix
+ *      The second round iteration returns the cached batch got from external memory.
+ *
+ * @param input   the spark input iterator
+ * @param indices column index
+ */
+private[scala] class ExternalMemoryIterator(val input: Iterator[Table],
+                                            val indices: ColumnIndices,
+                                            val path: Option[String] = None)
+  extends Iterator[ColumnBatch] {
+
+  private var iter = input
+
+  // Flag to indicate the input has been consumed.
+  private var inputIsConsumed = false
+  // Flag to indicate the input.next has been called which is valid
+  private var inputNextIsCalled = false
+
+  // visible for testing
+  private[spark] val externalMemory = ExternalMemory(path)
+
+  override def hasNext: Boolean = {
+    val value = iter.hasNext
+    if (!value && inputIsConsumed && inputNextIsCalled) {
+      externalMemory.close()
+    }
+    if (!inputIsConsumed && !value && inputNextIsCalled) {
+      inputIsConsumed = true
+      iter = externalMemory
+    }
+    value
+  }
+
+  override def next(): ColumnBatch = {
+    inputNextIsCalled = true
+    withResource(new GpuColumnBatch(iter.next())) { batch =>
+      if (iter.eq(input)) {
+        externalMemory.cacheTable(batch.table)
+      }
+      new CudfColumnBatch(
+        batch.select(indices.featureIds.get),
+        batch.select(indices.labelId),
+        batch.select(indices.weightId.getOrElse(-1)),
+        batch.select(indices.marginId.getOrElse(-1)),
+        batch.select(indices.groupId.getOrElse(-1)));
+    }
+  }
+
+}

--- a/jvm-packages/xgboost4j-spark-gpu/src/test/java/ml/dmlc/xgboost4j/java/BoosterTest.java
+++ b/jvm-packages/xgboost4j-spark-gpu/src/test/java/ml/dmlc/xgboost4j/java/BoosterTest.java
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2024 by Contributors
+ Copyright (c) 2021-2025 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ public class BoosterTest {
 
           List<ColumnBatch> tables = new LinkedList<>();
           tables.add(batch);
-          DMatrix incrementalDMatrix = new QuantileDMatrix(tables.iterator(), Float.NaN, maxBin, 1);
+          DMatrix incrementalDMatrix = new QuantileDMatrix(tables.iterator(), Float.NaN, maxBin, 1, false);
           //set watchList
           HashMap<String, DMatrix> watches1 = new HashMap<>();
           watches1.put("train", incrementalDMatrix);

--- a/jvm-packages/xgboost4j-spark-gpu/src/test/java/ml/dmlc/xgboost4j/java/DMatrixTest.java
+++ b/jvm-packages/xgboost4j-spark-gpu/src/test/java/ml/dmlc/xgboost4j/java/DMatrixTest.java
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2021-2024 by Contributors
+ Copyright (c) 2021-2025 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ public class DMatrixTest {
       tables.add(new CudfColumnBatch(X_0, y_0, w_0, m_0, q_0));
       tables.add(new CudfColumnBatch(X_1, y_1, w_1, m_1, q_1));
 
-      QuantileDMatrix dmat = new QuantileDMatrix(tables.iterator(), 0.0f, 256, 1);
+      QuantileDMatrix dmat = new QuantileDMatrix(tables.iterator(), 0.0f, 256, 1, false);
       float[] anchorLabel = convertFloatTofloat(label1, label2);
       float[] anchorWeight = convertFloatTofloat(weight1, weight2);
       float[] anchorBaseMargin = convertFloatTofloat(baseMargin1, baseMargin2);
@@ -166,11 +166,11 @@ public class DMatrixTest {
     ) {
       List<ColumnBatch> tables = new LinkedList<>();
       tables.add(new CudfColumnBatch(X_0, y_0, null, null, null));
-      QuantileDMatrix train = new QuantileDMatrix(tables.iterator(), 0.0f, 256, 1);
+      QuantileDMatrix train = new QuantileDMatrix(tables.iterator(), 0.0f, 256, 1, false);
 
       tables.clear();
       tables.add(new CudfColumnBatch(X_1, y_1, null, null, null));
-      QuantileDMatrix eval = new QuantileDMatrix(tables.iterator(),  train, 0.0f, 256, 1);
+      QuantileDMatrix eval = new QuantileDMatrix(tables.iterator(),  train, 0.0f, 256, 1, false);
 
       DMatrix.QuantileCut trainCut = train.getQuantileCut();
       DMatrix.QuantileCut evalCut = eval.getQuantileCut();

--- a/jvm-packages/xgboost4j-spark-gpu/src/test/scala/ml/dmlc/xgboost4j/scala/spark/ExternalMemorySuite.scala
+++ b/jvm-packages/xgboost4j-spark-gpu/src/test/scala/ml/dmlc/xgboost4j/scala/spark/ExternalMemorySuite.scala
@@ -1,0 +1,101 @@
+/*
+ Copyright (c) 2021-2025 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package ml.dmlc.xgboost4j.scala.spark
+
+import scala.collection.mutable.ArrayBuffer
+
+import ai.rapids.cudf.Table
+
+import ml.dmlc.xgboost4j.java.CudfColumnBatch
+import ml.dmlc.xgboost4j.scala.rapids.spark.GpuTestSuite
+import ml.dmlc.xgboost4j.scala.spark.Utils.withResource
+
+class ExternalMemorySuite extends GpuTestSuite {
+
+  private def assertColumnBatchEqual(lhs: Array[CudfColumnBatch],
+                                     rhs: Array[CudfColumnBatch]): Unit = {
+    def assertTwoTable(lhsTable: Table, rhsTable: Table): Unit = {
+      assert(lhsTable.getNumberOfColumns === rhsTable.getNumberOfColumns)
+      for (i <- 0 until lhsTable.getNumberOfColumns) {
+        val lColumn = lhsTable.getColumn(i)
+        val rColumn = rhsTable.getColumn(i)
+
+        val lHost = lColumn.copyToHost()
+        val rHost = rColumn.copyToHost()
+
+        assert(lHost.getRowCount === rHost.getRowCount)
+        for (j <- 0 until lHost.getRowCount.toInt) {
+          assert(lHost.getFloat(j) === rHost.getFloat(j))
+        }
+      }
+    }
+
+    assert(lhs.length === rhs.length)
+    for ((l, r) <- lhs.zip(rhs)) {
+      assertTwoTable(l.getFeatureTable, r.getFeatureTable)
+      assertTwoTable(l.getLabelTable, r.getLabelTable)
+    }
+  }
+
+  def runExternalMemoryTest(buildExternalMemory: (Iterator[Table], ColumnIndices) =>
+    ExternalMemoryIterator): Unit = {
+
+    withResource(new Table.TestBuilder()
+      .column(1.0f, 2.0f, 3.0f.asInstanceOf[java.lang.Float])
+      .column(4.0f, 5.0f, 6.0f.asInstanceOf[java.lang.Float])
+      .column(7.0f, 8.0f, 9.0f.asInstanceOf[java.lang.Float])
+      .build) { table1 =>
+
+      withResource(new Table.TestBuilder()
+        .column(11.0f, 12.0f, 13.0f.asInstanceOf[java.lang.Float])
+        .column(14.0f, 15.0f, 16.0f.asInstanceOf[java.lang.Float])
+        .column(17.0f, 18.0f, 19.0f.asInstanceOf[java.lang.Float])
+        .build) { table2 =>
+
+        val tables = Seq(table1, table2)
+
+        val indices = ColumnIndices(labelId = 0, featureIds = Some(Seq(1, 2)), featureId = None,
+          weightId = None, marginId = None, groupId = None)
+        val extMemIter = buildExternalMemory(tables.toIterator, indices)
+        val expectTables = ArrayBuffer.empty[CudfColumnBatch]
+        while (extMemIter.hasNext) {
+          val table = extMemIter.next().asInstanceOf[CudfColumnBatch]
+          expectTables.append(table)
+        }
+        // The hasNext has swap the iterator internally, so we can still get the
+        // value for the next round of iteration
+
+        val targetTables = ArrayBuffer.empty[CudfColumnBatch]
+        while (extMemIter.hasNext) {
+          val table = extMemIter.next().asInstanceOf[CudfColumnBatch]
+          targetTables.append(table)
+        }
+
+        assertColumnBatchEqual(expectTables.toArray, targetTables.toArray)
+      }
+    }
+  }
+
+  test("DiskExternalMemory") {
+    val buildIterator = (input: Iterator[Table], indices: ColumnIndices) => {
+      val iter = new ExternalMemoryIterator(input, indices, Some("/tmp/"))
+      assert(iter.externalMemory.isInstanceOf[DiskExternalMemoryIterator])
+      iter
+    }
+    runExternalMemoryTest(buildIterator)
+  }
+}

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2024 by Contributors
+ Copyright (c) 2024-2025 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import ml.dmlc.xgboost4j.scala.spark.params._
 /**
  * Hold the column index
  */
-private[spark] case class ColumnIndices(
+private[scala] case class ColumnIndices(
     labelId: Int,
     featureId: Option[Int], // the feature type is VectorUDT or Array
     featureIds: Option[Seq[Int]], // the feature type is columnar

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/XGBoostParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/XGBoostParams.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2024 by Contributors
+ Copyright (c) 2024-2025 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -179,14 +179,24 @@ private[spark] trait SparkParams[T <: Params] extends HasFeaturesCols with HasFe
 
   final def getFeatureTypes: Array[String] = $(featureTypes)
 
+  final val useExternalMemory = new BooleanParam(this, "useExternalMemory", "Whether to use " +
+    "the external memory or not when building QuantileDMatrix. Please note that " +
+    "useExternalMemory is useful only when `device` is set to `cuda` or `gpu`. When " +
+    "useExternalMemory is enabled, the directory specified by spark.local.dir if set will be " +
+    "used to cache the temporary files, if spark.local.dir is not set, the /tmp directory " +
+    "will be used.")
+
+  final def getUseExternalMemory: Boolean = $(useExternalMemory)
+
   setDefault(numRound -> 100, numWorkers -> 1, inferBatchSize -> (32 << 10),
     numEarlyStoppingRounds -> 0, forceRepartition -> false, missing -> Float.NaN,
     featuresCols -> Array.empty, customObj -> null, customEval -> null,
-    featureNames -> Array.empty, featureTypes -> Array.empty)
+    featureNames -> Array.empty, featureTypes -> Array.empty, useExternalMemory -> false)
 
   addNonXGBoostParam(numWorkers, numRound, numEarlyStoppingRounds, inferBatchSize, featuresCol,
     labelCol, baseMarginCol, weightCol, predictionCol, leafPredictionCol, contribPredictionCol,
-    forceRepartition, featuresCols, customEval, customObj, featureTypes, featureNames)
+    forceRepartition, featuresCols, customEval, customObj, featureTypes, featureNames,
+    useExternalMemory)
 
   final def getNumWorkers: Int = $(numWorkers)
 
@@ -223,6 +233,8 @@ private[spark] trait SparkParams[T <: Params] extends HasFeaturesCols with HasFe
   def setFeatureNames(value: Array[String]): T = set(featureNames, value).asInstanceOf[T]
 
   def setFeatureTypes(value: Array[String]): T = set(featureTypes, value).asInstanceOf[T]
+
+  def setUseExternalMemory(value: Boolean): T = set(useExternalMemory, value).asInstanceOf[T]
 
   protected[spark] def featureIsArrayType(schema: StructType): Boolean =
     schema(getFeaturesCol).dataType.isInstanceOf[ArrayType]

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Communicator.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Communicator.java
@@ -3,8 +3,6 @@ package ml.dmlc.xgboost4j.java;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/jvm-packages/xgboost4j/src/native/jvm_utils.h
+++ b/jvm-packages/xgboost4j/src/native/jvm_utils.h
@@ -1,15 +1,31 @@
+/**
+ *  Copyright 2014-2025, XGBoost Contributors
+ */
 #ifndef JVM_UTILS_H_
 #define JVM_UTILS_H_
 
-#define JVM_CHECK_CALL(__expr)                                                 \
-  {                                                                            \
-    int __errcode = (__expr);                                                  \
-    if (__errcode != 0) {                                                      \
-      return __errcode;                                                        \
-    }                                                                          \
+#include <jni.h>
+
+#include "xgboost/logging.h"  // for Check
+
+#define JVM_CHECK_CALL(__expr) \
+  {                            \
+    int __errcode = (__expr);  \
+    if (__errcode != 0) {      \
+      return __errcode;        \
+    }                          \
   }
 
-JavaVM*& GlobalJvm();
-void setHandle(JNIEnv *jenv, jlongArray jhandle, void* handle);
+JavaVM *&GlobalJvm();
+void setHandle(JNIEnv *jenv, jlongArray jhandle, void *handle);
+
+template <typename T>
+T CheckJvmCall(T const &v, JNIEnv *jenv) {
+  if (!v) {
+    CHECK(jenv->ExceptionOccurred());
+    jenv->ExceptionDescribe();
+  }
+  return v;
+}
 
 #endif  // JVM_UTILS_H_

--- a/jvm-packages/xgboost4j/src/native/xgboost4j-gpu.cu
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j-gpu.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2024, XGBoost Contributors
+ * Copyright 2021-2025, XGBoost Contributors
  */
 #include <jni.h>
 #include <xgboost/c_api.h>
@@ -7,40 +7,33 @@
 #include "../../../../src/common/cuda_pinned_allocator.h"
 #include "../../../../src/common/device_vector.cuh"  // for device_vector
 #include "../../../../src/data/array_interface.h"
-#include "jvm_utils.h"
+#include "jvm_utils.h"  // for CheckJvmCall
 
-namespace xgboost {
-namespace jni {
-
+namespace xgboost::jni {
 template <typename T, typename Alloc>
 T const *RawPtr(std::vector<T, Alloc> const &data) {
   return data.data();
 }
 
-template <typename T, typename Alloc> T *RawPtr(std::vector<T, Alloc> &data) {
+template <typename T, typename Alloc>
+T *RawPtr(std::vector<T, Alloc> &data) {
   return data.data();
 }
 
-template <typename T> T const *RawPtr(dh::device_vector<T> const &data) {
+template <typename T>
+T const *RawPtr(dh::device_vector<T> const &data) {
   return data.data().get();
 }
 
-template <typename T> T *RawPtr(dh::device_vector<T> &data) {
+template <typename T>
+T *RawPtr(dh::device_vector<T> &data) {
   return data.data().get();
-}
-
-template <typename T> T CheckJvmCall(T const &v, JNIEnv *jenv) {
-  if (!v) {
-    CHECK(jenv->ExceptionOccurred());
-    jenv->ExceptionDescribe();
-  }
-  return v;
 }
 
 template <typename VCont>
-void CopyColumnMask(xgboost::ArrayInterface<1> const &interface,
-                    std::vector<Json> const &columns, cudaMemcpyKind kind,
-                    size_t c, VCont *p_mask, Json *p_out, cudaStream_t stream) {
+void CopyColumnMask(xgboost::ArrayInterface<1> const &interface, std::vector<Json> const &columns,
+                    cudaMemcpyKind kind, size_t c, VCont *p_mask, Json *p_out,
+                    cudaStream_t stream) {
   auto &mask = *p_mask;
   auto &out = *p_out;
   auto size = sizeof(typename VCont::value_type) * interface.n;
@@ -48,22 +41,18 @@ void CopyColumnMask(xgboost::ArrayInterface<1> const &interface,
   CHECK(RawPtr(mask));
   CHECK(size);
   CHECK(interface.valid.Data());
-  dh::safe_cuda(
-      cudaMemcpyAsync(RawPtr(mask), interface.valid.Data(), size, kind, stream));
+  dh::safe_cuda(cudaMemcpyAsync(RawPtr(mask), interface.valid.Data(), size, kind, stream));
   auto const &mask_column = columns[c]["mask"];
   out["mask"] = Object();
-  std::vector<Json> mask_data{
-      Json{reinterpret_cast<Integer::Int>(RawPtr(mask))},
-      Json{get<Boolean const>(mask_column["data"][1])}};
+  std::vector<Json> mask_data{Json{reinterpret_cast<Integer::Int>(RawPtr(mask))},
+                              Json{get<Boolean const>(mask_column["data"][1])}};
   out["mask"]["data"] = Array(std::move(mask_data));
   if (get<Array const>(mask_column["shape"]).size() == 2) {
-    std::vector<Json> mask_shape{
-        Json{get<Integer const>(mask_column["shape"][0])},
-        Json{get<Integer const>(mask_column["shape"][1])}};
+    std::vector<Json> mask_shape{Json{get<Integer const>(mask_column["shape"][0])},
+                                 Json{get<Integer const>(mask_column["shape"][1])}};
     out["mask"]["shape"] = Array(std::move(mask_shape));
   } else if (get<Array const>(mask_column["shape"]).size() == 1) {
-    std::vector<Json> mask_shape{
-        Json{get<Integer const>(mask_column["shape"][0])}};
+    std::vector<Json> mask_shape{Json{get<Integer const>(mask_column["shape"][0])}};
     out["mask"]["shape"] = Array(std::move(mask_shape));
   } else {
     LOG(FATAL) << "Invalid shape of mask";
@@ -92,9 +81,8 @@ void CopyInterface(std::vector<xgboost::ArrayInterface<1>> &interface_arr,
 
     auto &out = (*p_out)[c];
     out = Object();
-    std::vector<Json> j_data{
-        Json{Integer(reinterpret_cast<Integer::Int>(RawPtr(data)))},
-        Json{Boolean{false}}};
+    std::vector<Json> j_data{Json{Integer(reinterpret_cast<Integer::Int>(RawPtr(data)))},
+                             Json{Boolean{false}}};
 
     out["data"] = Array(std::move(j_data));
     out["shape"] = Array(std::vector<Json>{Json(Integer(interface.Shape<0>()))});
@@ -116,127 +104,38 @@ void CopyMetaInfo(Json *p_interface, dh::device_vector<T> *out, cudaStream_t str
   out->resize(interface.Shape<0>());
   size_t element_size = interface.ElementSize();
   size_t size = element_size * interface.n;
-  dh::safe_cuda(cudaMemcpyAsync(RawPtr(*out), interface.data, size,
-                                cudaMemcpyDeviceToDevice, stream));
+  dh::safe_cuda(
+      cudaMemcpyAsync(RawPtr(*out), interface.data, size, cudaMemcpyDeviceToDevice, stream));
   j_interface[0]["data"][0] = reinterpret_cast<Integer::Int>(RawPtr(*out));
 }
 
-template <typename DCont, typename VCont> struct DataFrame {
+template <typename DCont, typename VCont>
+struct DataFrame {
   std::vector<DCont> data;
   std::vector<VCont> valid;
   std::vector<Json> interfaces;
 };
 
-class DataIteratorProxy {
-  DMatrixHandle proxy_;
+namespace {
+// constant names
+struct Symbols {
+  static constexpr StringView kLabel{"label"};
+  static constexpr StringView kWeight{"weight"};
+  static constexpr StringView kBaseMargin{"baseMargin"};
+  static constexpr StringView kQid{"qid"};
+};
+}  // namespace
+
+class JvmIter {
   JNIEnv *jenv_;
-  int jni_status_;
   jobject jiter_;
-  bool cache_on_host_{true}; // TODO(Bobby): Make this optional.
-
-  template <typename T>
-  using Alloc = xgboost::common::cuda_impl::PinnedAllocator<T>;
-  template <typename U>
-  using HostVector = std::vector<U, Alloc<U>>;
-
-  // This vector is created for staging device data on host to save GPU memory.
-  // When space is not of concern, we can stage them on device memory directly.
-  std::vector<
-      std::unique_ptr<DataFrame<HostVector<char>, HostVector<std::uint8_t>>>>
-      host_columns_;
-  // TODO(Bobby): Use this instead of `host_columns_` if staging is not
-  // required.
-  std::vector<std::unique_ptr<DataFrame<dh::device_vector<char>,
-                                        dh::device_vector<std::uint8_t>>>>
-      device_columns_;
-
-  // Staging area for metainfo.
-  // TODO(Bobby): label_upper_bound, label_lower_bound, group.
-  std::vector<std::unique_ptr<dh::device_vector<float>>> labels_;
-  std::vector<std::unique_ptr<dh::device_vector<float>>> weights_;
-  std::vector<std::unique_ptr<dh::device_vector<float>>> base_margins_;
-  std::vector<std::unique_ptr<dh::device_vector<int>>> qids_;
-  std::vector<Json> label_interfaces_;
-  std::vector<Json> weight_interfaces_;
-  std::vector<Json> margin_interfaces_;
-  std::vector<Json> qid_interfaces_;
-
-  size_t it_{0};
-  size_t n_batches_{0};
-  bool initialized_{false};
-  jobject last_batch_ {nullptr};
-
-  // Temp buffer on device, each `dh::device_vector` represents a column
-  // from cudf.
-  std::vector<dh::device_vector<char>> staging_data_;
-  std::vector<dh::device_vector<uint8_t>> staging_mask_;
-
-  cudaStream_t copy_stream_;
+  int jni_status_;
+  jobject last_batch_{nullptr};
 
  public:
-  explicit DataIteratorProxy(jobject jiter, bool cache_on_host = true)
-      : jiter_{jiter}, cache_on_host_{cache_on_host} {
-    XGProxyDMatrixCreate(&proxy_);
-    jni_status_ =
-        GlobalJvm()->GetEnv(reinterpret_cast<void **>(&jenv_), JNI_VERSION_1_6);
-    this->Reset();
-    dh::safe_cuda(cudaStreamCreateWithFlags(&copy_stream_, cudaStreamNonBlocking));
-  }
-  ~DataIteratorProxy() { XGDMatrixFree(proxy_);
-    dh::safe_cuda(cudaStreamDestroy(copy_stream_));
-  }
-
-  DMatrixHandle GetDMatrixHandle() const { return proxy_; }
-
-  // Helper function for staging meta info.
-  void StageMetaInfo(Json json_interface) {
-    CHECK(!IsA<Null>(json_interface));
-    auto json_map = get<Object const>(json_interface);
-    if (json_map.find("label") == json_map.cend()) {
-      LOG(FATAL) << "Must have a label field.";
-    }
-
-    Json label = json_interface["label"];
-    CHECK(!IsA<Null>(label));
-    labels_.emplace_back(new dh::device_vector<float>);
-    CopyMetaInfo(&label, labels_.back().get(), copy_stream_);
-    label_interfaces_.emplace_back(label);
-
-    std::string str;
-    Json::Dump(label, &str);
-    XGDMatrixSetInfoFromInterface(proxy_, "label", str.c_str());
-
-    if (json_map.find("weight") != json_map.cend()) {
-      Json weight = json_interface["weight"];
-      CHECK(!IsA<Null>(weight));
-      weights_.emplace_back(new dh::device_vector<float>);
-      CopyMetaInfo(&weight, weights_.back().get(), copy_stream_);
-      weight_interfaces_.emplace_back(weight);
-
-      Json::Dump(weight, &str);
-      XGDMatrixSetInfoFromInterface(proxy_, "weight", str.c_str());
-    }
-
-    if (json_map.find("baseMargin") != json_map.cend()) {
-      Json basemargin = json_interface["baseMargin"];
-      base_margins_.emplace_back(new dh::device_vector<float>);
-      CopyMetaInfo(&basemargin, base_margins_.back().get(), copy_stream_);
-      margin_interfaces_.emplace_back(basemargin);
-
-      Json::Dump(basemargin, &str);
-      XGDMatrixSetInfoFromInterface(proxy_, "base_margin", str.c_str());
-    }
-
-    if (json_map.find("qid") != json_map.cend()) {
-      Json qid = json_interface["qid"];
-      qids_.emplace_back(new dh::device_vector<int>);
-      CopyMetaInfo(&qid, qids_.back().get(), copy_stream_);
-      qid_interfaces_.emplace_back(qid);
-
-      Json::Dump(qid, &str);
-      XGDMatrixSetInfoFromInterface(proxy_, "qid", str.c_str());
-    }
-  }
+  explicit JvmIter(jobject jiter)
+      : jiter_{jiter},
+        jni_status_{GlobalJvm()->GetEnv(reinterpret_cast<void **>(&jenv_), JNI_VERSION_1_6)} {}
 
   void CloseJvmBatch() {
     if (last_batch_) {
@@ -247,54 +146,169 @@ class DataIteratorProxy {
     }
   }
 
-  void Reset() {
-    it_ = 0;
-    this->CloseJvmBatch();
-  }
+  auto Status() const { return jni_status_; }
 
-  int32_t PullIterFromJVM() {
+  template <typename Fn>
+  bool PullIterFromJVM(Fn &&fn) {
+    this->CloseJvmBatch();
     jclass iterClass = jenv_->FindClass("java/util/Iterator");
-    this->CloseJvmBatch();
 
-    jmethodID has_next =
-        CheckJvmCall(jenv_->GetMethodID(iterClass, "hasNext", "()Z"), jenv_);
-    jmethodID next = CheckJvmCall(
-        jenv_->GetMethodID(iterClass, "next", "()Ljava/lang/Object;"), jenv_);
+    jmethodID has_next = CheckJvmCall(jenv_->GetMethodID(iterClass, "hasNext", "()Z"), jenv_);
+    jmethodID next =
+        CheckJvmCall(jenv_->GetMethodID(iterClass, "next", "()Ljava/lang/Object;"), jenv_);
 
     if (jenv_->CallBooleanMethod(jiter_, has_next)) {
       // batch should be ColumnBatch from jvm
       jobject batch = CheckJvmCall(jenv_->CallObjectMethod(jiter_, next), jenv_);
       jclass batch_class = CheckJvmCall(jenv_->GetObjectClass(batch), jenv_);
-      jmethodID toJson = CheckJvmCall(jenv_->GetMethodID(
-        batch_class, "toJson", "()Ljava/lang/String;"), jenv_);
+      jmethodID toJson =
+          CheckJvmCall(jenv_->GetMethodID(batch_class, "toJson", "()Ljava/lang/String;"), jenv_);
 
-      auto jinterface =
-        static_cast<jstring>(jenv_->CallObjectMethod(batch, toJson));
-      CheckJvmCall(jinterface, jenv_);
-      char const *c_interface_str =
-          CheckJvmCall(jenv_->GetStringUTFChars(jinterface, nullptr), jenv_);
+      // Json array interface
+      auto jaif = static_cast<jstring>(jenv_->CallObjectMethod(batch, toJson));
+      CheckJvmCall(jaif, jenv_);
+      char const *cjaif = CheckJvmCall(jenv_->GetStringUTFChars(jaif, nullptr), jenv_);
 
-      StageData(c_interface_str);
+      fn(cjaif);
+      // this->StageData(cjaif);
 
-      jenv_->ReleaseStringUTFChars(jinterface, c_interface_str);
+      jenv_->ReleaseStringUTFChars(jaif, cjaif);
 
       last_batch_ = batch;
-      return 1;
+      return true;
     } else {
-      return 0;
+      return false;
     }
+  }
+};
+
+class DMatrixProxy {
+  DMatrixHandle proxy_;
+
+ public:
+  DMatrixProxy() { CHECK_EQ(XGProxyDMatrixCreate(&proxy_), 0); }
+  ~DMatrixProxy() { CHECK_EQ(XGDMatrixFree(proxy_), 0); }
+  auto GetDMatrixHandle() const { return proxy_; }
+
+  void SetInfo(StringView name, Json jaif) {
+    std::string str;
+    Json::Dump(jaif, &str);
+    CHECK_EQ(XGDMatrixSetInfoFromInterface(proxy_, name.c_str(), str.c_str()), 0);
+  }
+  void SetData(Json jaif) {
+    std::string str;
+    Json::Dump(jaif, &str);
+    CHECK_EQ(XGProxyDMatrixSetDataCudaColumnar(proxy_, str.c_str()), 0);
+  }
+};
+
+class DataIteratorProxy {
+  DMatrixProxy proxy_;
+  JvmIter jiter_;
+
+  template <typename T>
+  using Alloc = xgboost::common::cuda_impl::PinnedAllocator<T>;
+  template <typename U>
+  using HostVector = std::vector<U, Alloc<U>>;
+
+  // This vector is created for staging device data on host to save GPU memory.
+  // When space is not of concern, we can stage them on device memory directly.
+  std::vector<std::unique_ptr<DataFrame<HostVector<char>, HostVector<std::uint8_t>>>> host_columns_;
+
+  // Staging area for metainfo.
+  // TODO(Bobby): label_upper_bound, label_lower_bound.
+  std::vector<std::unique_ptr<dh::device_vector<float>>> labels_;
+  std::vector<std::unique_ptr<dh::device_vector<float>>> weights_;
+  std::vector<std::unique_ptr<dh::device_vector<float>>> base_margins_;
+  std::vector<std::unique_ptr<dh::device_vector<int>>> qids_;
+  std::vector<Json> label_interfaces_;
+  std::vector<Json> weight_interfaces_;
+  std::vector<Json> margin_interfaces_;
+  std::vector<Json> qid_interfaces_;
+
+  std::size_t it_{0};
+  std::size_t n_batches_{0};
+  bool initialized_{false};
+
+  // Temp buffer on device, each `dh::device_vector` represents a column
+  // from cudf.
+  std::vector<dh::device_vector<char>> staging_data_;
+  std::vector<dh::device_vector<std::uint8_t>> staging_mask_;
+
+  cudaStream_t copy_stream_;
+
+ public:
+  explicit DataIteratorProxy(jobject jiter) : jiter_{jiter} {
+    this->Reset();
+    dh::safe_cuda(cudaStreamCreateWithFlags(&copy_stream_, cudaStreamNonBlocking));
+  }
+  ~DataIteratorProxy() { dh::safe_cuda(cudaStreamDestroy(copy_stream_)); }
+
+  DMatrixHandle GetDMatrixHandle() const { return proxy_.GetDMatrixHandle(); }
+
+  // Helper function for staging meta info.
+  void StageMetaInfo(Json json_interface) {
+    CHECK(!IsA<Null>(json_interface));
+    auto json_map = get<Object const>(json_interface);
+    auto it = json_map.find(Symbols::kLabel);
+    if (it == json_map.cend()) {
+      LOG(FATAL) << "Must have a label field.";
+    }
+
+    Json label = json_interface[Symbols::kLabel.c_str()];
+    CHECK(!IsA<Null>(label));
+    labels_.emplace_back(std::make_unique<dh::device_vector<float>>());
+    CopyMetaInfo(&label, labels_.back().get(), copy_stream_);
+    label_interfaces_.emplace_back(label);
+    proxy_.SetInfo(Symbols::kLabel, label);
+
+    it = json_map.find(Symbols::kWeight);
+    if (it != json_map.cend()) {
+      Json weight = json_interface[Symbols::kWeight.c_str()];
+      CHECK(!IsA<Null>(weight));
+      weights_.emplace_back(new dh::device_vector<float>);
+      CopyMetaInfo(&weight, weights_.back().get(), copy_stream_);
+      weight_interfaces_.emplace_back(weight);
+
+      proxy_.SetInfo(Symbols::kWeight, weight);
+    }
+
+    it = json_map.find(Symbols::kBaseMargin);
+    if (it != json_map.cend()) {
+      Json base_margin = json_interface[Symbols::kBaseMargin.c_str()];
+      base_margins_.emplace_back(new dh::device_vector<float>);
+      CopyMetaInfo(&base_margin, base_margins_.back().get(), copy_stream_);
+      margin_interfaces_.emplace_back(base_margin);
+
+      proxy_.SetInfo("base_margin", base_margin);
+    }
+
+    it = json_map.find(Symbols::kQid);
+    if (it != json_map.cend()) {
+      Json qid = json_interface[Symbols::kQid.c_str()];
+      qids_.emplace_back(new dh::device_vector<int>);
+      CopyMetaInfo(&qid, qids_.back().get(), copy_stream_);
+      qid_interfaces_.emplace_back(qid);
+
+      proxy_.SetInfo(Symbols::kQid, qid);
+    }
+  }
+
+  void Reset() {
+    it_ = 0;
+    this->jiter_.CloseJvmBatch();
   }
 
   void StageData(std::string interface_str) {
     ++n_batches_;
     // DataFrame
     using T = decltype(host_columns_)::value_type::element_type;
-    host_columns_.emplace_back(std::unique_ptr<T>(new T));
+    host_columns_.emplace_back(std::make_unique<T>());
 
     // Stage the meta info.
-    auto json_interface =
-        Json::Load({interface_str.c_str(), interface_str.size()});
+    auto json_interface = Json::Load({interface_str.c_str(), interface_str.size()});
     CHECK(!IsA<Null>(json_interface));
+
     StageMetaInfo(json_interface);
 
     Json features = json_interface["features"];
@@ -307,25 +321,24 @@ class DataIteratorProxy {
       interfaces.emplace_back(column);
     }
     Json::Dump(features, &interface_str);
-    CopyInterface(interfaces, json_columns, cudaMemcpyDeviceToHost,
-                  &host_columns_.back()->data, &host_columns_.back()->valid,
-                  &host_columns_.back()->interfaces, copy_stream_);
+    CopyInterface(interfaces, json_columns, cudaMemcpyDeviceToHost, &host_columns_.back()->data,
+                  &host_columns_.back()->valid, &host_columns_.back()->interfaces, copy_stream_);
 
-    XGProxyDMatrixSetDataCudaColumnar(proxy_, interface_str.c_str());
+    proxy_.SetData(features);
     it_++;
   }
 
   int NextFirstLoop() {
     try {
       dh::safe_cuda(cudaStreamSynchronize(copy_stream_));
-      if (this->PullIterFromJVM()) {
+      if (this->jiter_.PullIterFromJVM([this](char const *cjaif) { this->StageData(cjaif); })) {
         return 1;
       } else {
         initialized_ = true;
         return 0;
       }
     } catch (dmlc::Error const &e) {
-      if (jni_status_ == JNI_EDETACHED) {
+      if (jiter_.Status() == JNI_EDETACHED) {
         GlobalJvm()->DetachCurrentThread();
       }
       LOG(FATAL) << e.what();
@@ -338,25 +351,21 @@ class DataIteratorProxy {
     std::string str;
     // Meta
     auto const &label = this->label_interfaces_.at(it_);
-    Json::Dump(label, &str);
-    XGDMatrixSetInfoFromInterface(proxy_, "label", str.c_str());
+    proxy_.SetInfo(Symbols::kLabel, label);
 
     if (n_batches_ == this->weight_interfaces_.size()) {
       auto const &weight = this->weight_interfaces_.at(it_);
-      Json::Dump(weight, &str);
-      XGDMatrixSetInfoFromInterface(proxy_, "weight", str.c_str());
+      proxy_.SetInfo(Symbols::kWeight, weight);
     }
 
     if (n_batches_ == this->margin_interfaces_.size()) {
       auto const &base_margin = this->margin_interfaces_.at(it_);
-      Json::Dump(base_margin, &str);
-      XGDMatrixSetInfoFromInterface(proxy_, "base_margin", str.c_str());
+      proxy_.SetInfo("base_margin", base_margin);
     }
 
     if (n_batches_ == this->qid_interfaces_.size()) {
       auto const &qid = this->qid_interfaces_.at(it_);
-      Json::Dump(qid, &str);
-      XGDMatrixSetInfoFromInterface(proxy_, "qid", str.c_str());
+      proxy_.SetInfo(Symbols::kQid, qid);
     }
 
     // Data
@@ -368,13 +377,11 @@ class DataIteratorProxy {
       in.emplace_back(column);
     }
     std::vector<Json> out;
-    CopyInterface(in, json_interface, cudaMemcpyHostToDevice, &staging_data_,
-                  &staging_mask_, &out, nullptr);
+    CopyInterface(in, json_interface, cudaMemcpyHostToDevice, &staging_data_, &staging_mask_, &out,
+                  nullptr);
 
     Json temp{Array(std::move(out))};
-    std::string interface_str;
-    Json::Dump(temp, &interface_str);
-    XGProxyDMatrixSetDataCudaColumnar(proxy_, interface_str.c_str());
+    proxy_.SetData(temp);
     it_++;
     return 1;
   }
@@ -425,5 +432,4 @@ XGB_DLL int XGQuantileDMatrixCreateFromCallbackImpl(JNIEnv *jenv, jclass, jobjec
   setHandle(jenv, jout, result);
   return ret;
 }
-} // namespace jni
-} // namespace xgboost
+} // namespace xgboost::jni

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -31,25 +31,18 @@
 #include <type_traits>
 #include <vector>
 
+#include "jvm_utils.h"  // for JVM_CHECK_CALL
 #include "../../../../src/c_api/c_api_error.h"
 #include "../../../../src/c_api/c_api_utils.h"
 #include "../../../../src/data/array_interface.h"  // for ArrayInterface
 
-#define JVM_CHECK_CALL(__expr)                                                 \
-  {                                                                            \
-    int __errcode = (__expr);                                                  \
-    if (__errcode != 0) {                                                      \
-      return __errcode;                                                        \
-    }                                                                          \
-  }
-
 // helper functions
 // set handle
-void setHandle(JNIEnv *jenv, jlongArray jhandle, void* handle) {
+void setHandle(JNIEnv *jenv, jlongArray jhandle, void *handle) {
 #ifdef __APPLE__
-  jlong out = (long) handle;
+  jlong out = (long)handle;
 #else
-  int64_t out = (int64_t) handle;
+  int64_t out = (int64_t)handle;
 #endif
   jenv->SetLongArrayRegion(jhandle, 0, 1, &out);
 }

--- a/src/c_api/c_api_error.h
+++ b/src/c_api/c_api_error.h
@@ -17,12 +17,19 @@
   LOG(CONSOLE) << "[XGBoost C API invocation] " << __PRETTY_FUNCTION__;        \
   try {                                                                        \
     auto __guard = ::xgboost::XGBoostAPIGuard();
+
+#define API_BEGIN_UNGUARD()                                             \
+  LOG(CONSOLE) << "[XGBoost C API invocation] " << __PRETTY_FUNCTION__; \
+  try {
+
 #else  // LOG_CAPI_INVOCATION
+
 #define API_BEGIN()                                                            \
   try {                                                                        \
     auto __guard = ::xgboost::XGBoostAPIGuard();
 
 #define API_BEGIN_UNGUARD() try {
+
 #endif  // LOG_CAPI_INVOCATION
 
 /*! \brief every function starts with API_BEGIN();

--- a/src/c_api/c_api_error.h
+++ b/src/c_api/c_api_error.h
@@ -28,6 +28,7 @@
     auto __guard = ::xgboost::XGBoostAPIGuard();
 
 #define API_BEGIN_UNGUARD() try {
+
 #endif  // LOG_CAPI_INVOCATION
 
 /*! \brief every function starts with API_BEGIN();

--- a/src/c_api/c_api_error.h
+++ b/src/c_api/c_api_error.h
@@ -21,7 +21,6 @@
 #define API_BEGIN_UNGUARD()                                             \
   LOG(CONSOLE) << "[XGBoost C API invocation] " << __PRETTY_FUNCTION__; \
   try {
-
 #else  // LOG_CAPI_INVOCATION
 
 #define API_BEGIN()                                                            \
@@ -29,7 +28,6 @@
     auto __guard = ::xgboost::XGBoostAPIGuard();
 
 #define API_BEGIN_UNGUARD() try {
-
 #endif  // LOG_CAPI_INVOCATION
 
 /*! \brief every function starts with API_BEGIN();


### PR DESCRIPTION
This PR introduces a new parameter "useExternalMemory" to indicate whether to use external memory when build QuantileDMatrix. If it's set to true, then the cached file will be cached into the directory specified by `spark.local.dir`, if `spark.local.dir` is not set, "/tmp/ will be used for the caching.