### PR TITLE
Enforce cmake configure file newline style

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,7 +492,8 @@ if(GOOGLE_TEST)
   configure_file(
     ${xgboost_SOURCE_DIR}/tests/cli/machine.conf.in
     ${xgboost_BINARY_DIR}/tests/cli/machine.conf
-    @ONLY)
+    @ONLY
+    NEWLINE_STYLE UNIX)
   if(BUILD_DEPRECATED_CLI)
     add_test(
       NAME TestXGBoostCLI

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -2,5 +2,7 @@ function(write_version)
   message(STATUS "xgboost VERSION: ${xgboost_VERSION}")
   configure_file(
     ${xgboost_SOURCE_DIR}/cmake/version_config.h.in
-    ${xgboost_SOURCE_DIR}/include/xgboost/version_config.h @ONLY)
+    ${xgboost_SOURCE_DIR}/include/xgboost/version_config.h
+    @ONLY
+    NEWLINE_STYLE UNIX)
 endfunction()


### PR DESCRIPTION
To avoid creating different files on Windows.