### PR TITLE
Update C API tutorial

### DIFF
--- a/doc/tutorials/c_api_tutorial.rst
+++ b/doc/tutorials/c_api_tutorial.rst
@@ -180,7 +180,7 @@ Sample examples along with Code snippet to use C API functions
   const int data1[] = { 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0 };
 
   // 2D matrix
-  const int ROWS = 5, COLS = 3;
+  const int ROWS = 6, COLS = 3;
   const int data2[ROWS][COLS] = { {1, 2, 3}, {2, 4, 6}, {3, -1, 9}, {4, 8, -1}, {2, 5, 1}, {0, 1, 5} };
   DMatrixHandle dmatrix1, dmatrix2;
   // Pass the matrix, no of rows & columns contained in the matrix variable


### PR DESCRIPTION
Set C++17 as the minimum required version for the tutorial

The current code relies on features introduced in C++17, such as nested namespaces and std::is_same_v.
Without C++17, the compilation results in warnings like:
"nested namespace definition is a C++17 extension; define each namespace separately", and errors like:
"no template named 'is_same_v' in namespace 'std'".
To fix this, I've set C++17 as the minimum required version to ensure compatibility.

Additionally, I made a small fix to the matrix initialization in the tutorial.