### PR TITLE
Cleanup CPU predict function.

### DIFF
--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -118,21 +118,6 @@ class GradientBooster : public Model, public Configurable {
     LOG(FATAL) << "Inplace predict is not supported by the current booster.";
   }
   /*!
-   * \brief online prediction function, predict score for one instance at a time
-   *  NOTE: use the batch prediction interface if possible, batch prediction is usually
-   *        more efficient than online prediction
-   *        This function is NOT threadsafe, make sure you only call from one thread
-   *
-   * \param inst the instance you want to predict
-   * \param out_preds output vector to hold the predictions
-   * \param layer_begin Beginning of boosted tree layer used for prediction.
-   * \param layer_end   End of booster layer. 0 means do not limit trees.
-   * \sa Predict
-   */
-  virtual void PredictInstance(const SparsePage::Inst& inst,
-                               std::vector<bst_float>* out_preds,
-                               unsigned layer_begin, unsigned layer_end) = 0;
-  /*!
    * \brief predict the leaf index of each tree, the output will be nsample * ntree vector
    *        this is only valid in gbtree predictor
    * \param dmat feature matrix

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2023 by XGBoost Contributors
+ * Copyright 2014-2025, XGBoost Contributors
  * \file gbm.h
  * \brief Interface of gradient booster,
  *  that learns through gradient statistics.
@@ -15,10 +15,8 @@
 #include <xgboost/model.h>
 
 #include <vector>
-#include <utility>
 #include <string>
 #include <functional>
-#include <unordered_map>
 #include <memory>
 
 namespace xgboost {
@@ -42,13 +40,13 @@ class GradientBooster : public Model, public Configurable {
  public:
   /*! \brief virtual destructor */
   ~GradientBooster() override = default;
-  /*!
-   * \brief Set the configuration of gradient boosting.
+  /**
+   * @brief Set the configuration of gradient boosting.
    *  User must call configure once before InitModel and Training.
    *
-   * \param cfg configurations on both training and model parameters.
+   * @param cfg configurations on both training and model parameters.
    */
-  virtual void Configure(const std::vector<std::pair<std::string, std::string> >& cfg) = 0;
+  virtual void Configure(Args const& cfg) = 0;
   /*!
    * \brief load model from stream
    * \param fi input stream.

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2024, XGBoost Contributors
+ * Copyright 2017-2025, XGBoost Contributors
  * \file predictor.h
  * \brief Interface of predictor,
  *  performs predictions for a gradient booster.
@@ -28,7 +28,7 @@ namespace xgboost {
  */
 struct PredictionCacheEntry {
   // A storage for caching prediction values
-  HostDeviceVector<bst_float> predictions;
+  HostDeviceVector<float> predictions;
   // The version of current cache, corresponding number of layers of trees
   std::uint32_t version{0};
 
@@ -91,7 +91,7 @@ class Predictor {
    * \param out_predt Prediction vector to be initialized.
    * \param model Tree model used for prediction.
    */
-  virtual void InitOutPredictions(const MetaInfo& info, HostDeviceVector<bst_float>* out_predt,
+  virtual void InitOutPredictions(const MetaInfo& info, HostDeviceVector<float>* out_predt,
                                   const gbm::GBTreeModel& model) const;
 
   /**
@@ -105,8 +105,8 @@ class Predictor {
    * \param           tree_end    The tree end index.
    */
   virtual void PredictBatch(DMatrix* dmat, PredictionCacheEntry* out_preds,
-                            const gbm::GBTreeModel& model, uint32_t tree_begin,
-                            uint32_t tree_end = 0) const = 0;
+                            gbm::GBTreeModel const& model, bst_tree_t tree_begin,
+                            bst_tree_t tree_end = 0) const = 0;
 
   /**
    * \brief Inplace prediction.
@@ -123,7 +123,7 @@ class Predictor {
    */
   virtual bool InplacePredict(std::shared_ptr<DMatrix> p_fmat, const gbm::GBTreeModel& model,
                               float missing, PredictionCacheEntry* out_preds,
-                              uint32_t tree_begin = 0, uint32_t tree_end = 0) const = 0;
+                              bst_tree_t tree_begin = 0, bst_tree_t tree_end = 0) const = 0;
 
   /**
    * \brief predict the leaf index of each tree, the output will be nsample *
@@ -135,9 +135,8 @@ class Predictor {
    * \param           tree_end    (Optional) The tree end index.
    */
 
-  virtual void PredictLeaf(DMatrix* dmat, HostDeviceVector<bst_float>* out_preds,
-                           const gbm::GBTreeModel& model,
-                           unsigned tree_end = 0) const = 0;
+  virtual void PredictLeaf(DMatrix* dmat, HostDeviceVector<float>* out_preds,
+                           gbm::GBTreeModel const& model, bst_tree_t tree_end = 0) const = 0;
 
   /**
    * \brief feature contributions to individual predictions; the output will be
@@ -154,18 +153,17 @@ class Predictor {
    * \param           condition_feature  Feature to condition on (i.e. fix) during calculations.
    */
 
-  virtual void
-  PredictContribution(DMatrix *dmat, HostDeviceVector<bst_float> *out_contribs,
-                      const gbm::GBTreeModel &model, unsigned tree_end = 0,
-                      std::vector<bst_float> const *tree_weights = nullptr,
-                      bool approximate = false, int condition = 0,
-                      unsigned condition_feature = 0) const = 0;
+  virtual void PredictContribution(DMatrix* dmat, HostDeviceVector<float>* out_contribs,
+                                   gbm::GBTreeModel const& model, bst_tree_t tree_end = 0,
+                                   std::vector<float> const* tree_weights = nullptr,
+                                   bool approximate = false, int condition = 0,
+                                   unsigned condition_feature = 0) const = 0;
 
-  virtual void PredictInteractionContributions(
-      DMatrix *dmat, HostDeviceVector<bst_float> *out_contribs,
-      const gbm::GBTreeModel &model, unsigned tree_end = 0,
-      std::vector<bst_float> const *tree_weights = nullptr,
-      bool approximate = false) const = 0;
+  virtual void PredictInteractionContributions(DMatrix* dmat, HostDeviceVector<float>* out_contribs,
+                                               gbm::GBTreeModel const& model,
+                                               bst_tree_t tree_end = 0,
+                                               std::vector<float> const* tree_weights = nullptr,
+                                               bool approximate = false) const = 0;
 
   /**
    * \brief Creates a new Predictor*.

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -124,24 +124,6 @@ class Predictor {
   virtual bool InplacePredict(std::shared_ptr<DMatrix> p_fmat, const gbm::GBTreeModel& model,
                               float missing, PredictionCacheEntry* out_preds,
                               uint32_t tree_begin = 0, uint32_t tree_end = 0) const = 0;
-  /**
-   * \brief online prediction function, predict score for one instance at a time
-   * NOTE: use the batch prediction interface if possible, batch prediction is
-   * usually more efficient than online prediction This function is NOT
-   * threadsafe, make sure you only call from one thread.
-   *
-   * \param           inst            The instance to predict.
-   * \param [in,out]  out_preds       The output preds.
-   * \param           model           The model to predict from
-   * \param           tree_end        (Optional) The tree end index.
-   * \param           is_column_split (Optional) If the data is split column-wise.
-   */
-
-  virtual void PredictInstance(const SparsePage::Inst& inst,
-                               std::vector<bst_float>* out_preds,
-                               const gbm::GBTreeModel& model,
-                               unsigned tree_end = 0,
-                               bool is_column_split = false) const = 0;
 
   /**
    * \brief predict the leaf index of each tree, the output will be nsample *

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -591,9 +591,10 @@ class RegTree : public Model {
     [[nodiscard]] common::Span<float> Data() { return data_; }
 
    private:
-    /*!
-     * \brief a union value of value and flag
-     *  when flag == -1, this indicate the value is missing
+    /**
+     * @brief A dense vector for a single sample.
+     *
+     * It's nan if the value is missing.
      */
     std::vector<float> data_;
     bool has_missing_;

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -562,7 +562,7 @@ class RegTree : public Model {
      * \brief fill the vector with sparse vector
      * \param inst The sparse instance to fill.
      */
-    void Fill(const SparsePage::Inst& inst);
+    void Fill(SparsePage::Inst const& inst);
 
     /*!
      * \brief drop the trace after fill, must be called after fill.
@@ -799,9 +799,11 @@ inline void RegTree::FVec::Init(size_t size) {
   has_missing_ = true;
 }
 
-inline void RegTree::FVec::Fill(const SparsePage::Inst& inst) {
-  size_t feature_count = 0;
-  for (auto const& entry : inst) {
+inline void RegTree::FVec::Fill(SparsePage::Inst const& inst) {
+  std::size_t feature_count = 0;
+  auto p_data = inst.data();
+  for (std::size_t i = 0, n = inst.size(); i < n; ++i) {
+    auto const& entry = p_data[i];
     if (entry.index >= data_.size()) {
       continue;
     }

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2024, XGBoost Contributors
+ * Copyright 2014-2025, XGBoost Contributors
  * \file tree_model.h
  * \brief model structure for tree
  * \author Tianqi Chen
@@ -586,7 +586,9 @@ class RegTree : public Model {
      */
     [[nodiscard]] bool IsMissing(size_t i) const;
     [[nodiscard]] bool HasMissing() const;
+    void HasMissing(bool has_missing) { this->has_missing_ = has_missing; }
 
+    [[nodiscard]] common::Span<float> Data() { return data_; }
 
    private:
     /*!
@@ -804,10 +806,7 @@ inline void RegTree::FVec::Fill(SparsePage::Inst const& inst) {
   has_missing_ = data_.size() != inst.size();
 }
 
-inline void RegTree::FVec::Drop() {
-  std::fill_n(data_.data(), data_.size(), std::numeric_limits<float>::quiet_NaN());
-  has_missing_ = true;
-}
+inline void RegTree::FVec::Drop() { this->Init(this->Size()); }
 
 inline size_t RegTree::FVec::Size() const {
   return data_.size();

--- a/plugin/sycl/predictor/predictor.cc
+++ b/plugin/sycl/predictor/predictor.cc
@@ -201,8 +201,8 @@ class Predictor : public xgboost::Predictor {
       }
 
   void PredictBatch(DMatrix *dmat, PredictionCacheEntry *predts,
-                    const gbm::GBTreeModel &model, uint32_t tree_begin,
-                    uint32_t tree_end = 0) const override {
+                    const gbm::GBTreeModel &model, bst_tree_t tree_begin,
+                    bst_tree_t tree_end = 0) const override {
     auto* out_preds = &predts->predictions;
     out_preds->SetDevice(ctx_->Device());
     if (tree_end == 0) {
@@ -221,28 +221,20 @@ class Predictor : public xgboost::Predictor {
 
   bool InplacePredict(std::shared_ptr<DMatrix> p_m,
                       const gbm::GBTreeModel &model, float missing,
-                      PredictionCacheEntry *out_preds, uint32_t tree_begin,
-                      unsigned tree_end) const override {
+                      PredictionCacheEntry *out_preds, bst_tree_t tree_begin,
+                      bst_tree_t tree_end) const override {
     LOG(WARNING) << "InplacePredict is not yet implemented for SYCL. CPU Predictor is used.";
     return cpu_predictor->InplacePredict(p_m, model, missing, out_preds, tree_begin, tree_end);
   }
 
-  void PredictInstance(const SparsePage::Inst& inst,
-                       std::vector<bst_float>* out_preds,
-                       const gbm::GBTreeModel& model, unsigned ntree_limit,
-                       bool is_column_split) const override {
-    LOG(WARNING) << "PredictInstance is not yet implemented for SYCL. CPU Predictor is used.";
-    cpu_predictor->PredictInstance(inst, out_preds, model, ntree_limit, is_column_split);
-  }
-
   void PredictLeaf(DMatrix* p_fmat, HostDeviceVector<bst_float>* out_preds,
-                   const gbm::GBTreeModel& model, unsigned ntree_limit) const override {
+                   const gbm::GBTreeModel& model, bst_tree_t ntree_limit) const override {
     LOG(WARNING) << "PredictLeaf is not yet implemented for SYCL. CPU Predictor is used.";
     cpu_predictor->PredictLeaf(p_fmat, out_preds, model, ntree_limit);
   }
 
   void PredictContribution(DMatrix* p_fmat, HostDeviceVector<float>* out_contribs,
-                           const gbm::GBTreeModel& model, uint32_t ntree_limit,
+                           const gbm::GBTreeModel& model, bst_tree_t ntree_limit,
                            const std::vector<bst_float>* tree_weights,
                            bool approximate, int condition,
                            unsigned condition_feature) const override {
@@ -252,7 +244,7 @@ class Predictor : public xgboost::Predictor {
   }
 
   void PredictInteractionContributions(DMatrix* p_fmat, HostDeviceVector<bst_float>* out_contribs,
-                                       const gbm::GBTreeModel& model, unsigned ntree_limit,
+                                       const gbm::GBTreeModel& model, bst_tree_t ntree_limit,
                                        const std::vector<bst_float>* tree_weights,
                                        bool approximate) const override {
     LOG(WARNING) << "PredictInteractionContributions is not yet implemented for SYCL. "

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2024, XGBoost Contributors
+ * Copyright 2017-2025, XGBoost Contributors
  * \file column_matrix.h
  * \brief Utility for fast column-wise access
  * \author Philip Cho

--- a/src/common/column_matrix.h
+++ b/src/common/column_matrix.h
@@ -45,7 +45,7 @@ class Column {
   virtual ~Column() = default;
 
   [[nodiscard]] bst_bin_t GetGlobalBinIdx(size_t idx) const {
-    return index_base_ + static_cast<bst_bin_t>(index_[idx]);
+    return index_base_ + static_cast<bst_bin_t>(index_.data()[idx]);
   }
 
   /* returns number of elements in column */
@@ -53,7 +53,7 @@ class Column {
 
  private:
   /* bin indexes in range [0, max_bins - 1] */
-  common::Span<const BinIdxType> index_;
+  common::Span<BinIdxType const> index_;
   /* bin index offset for specific feature */
   bst_bin_t const index_base_;
 };

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -83,10 +83,7 @@ class HistogramCuts {
   [[nodiscard]] bst_bin_t FeatureBins(bst_feature_t feature) const {
     return cut_ptrs_.ConstHostVector().at(feature + 1) - cut_ptrs_.ConstHostVector()[feature];
   }
-  [[nodiscard]] bst_feature_t NumFeatures() const {
-    CHECK_EQ(this->min_vals_.Size(), this->cut_ptrs_.Size() - 1);
-    return this->min_vals_.Size();
-  }
+  [[nodiscard]] bst_feature_t NumFeatures() const { return this->min_vals_.Size(); }
 
   std::vector<uint32_t> const& Ptrs()      const { return cut_ptrs_.ConstHostVector();   }
   std::vector<float>    const& Values()    const { return cut_values_.ConstHostVector(); }

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -83,7 +83,7 @@ class HistogramCuts {
   [[nodiscard]] bst_bin_t FeatureBins(bst_feature_t feature) const {
     return cut_ptrs_.ConstHostVector().at(feature + 1) - cut_ptrs_.ConstHostVector()[feature];
   }
-  [[nodiscard]] bst_feature_t NumFeatures() const { return this->min_vals_.Size(); }
+  [[nodiscard]] bst_feature_t NumFeatures() const { return this->cut_ptrs_.Size() - 1; }
 
   std::vector<uint32_t> const& Ptrs()      const { return cut_ptrs_.ConstHostVector();   }
   std::vector<float>    const& Values()    const { return cut_values_.ConstHostVector(); }

--- a/src/common/ref_resource_view.h
+++ b/src/common/ref_resource_view.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023-2024, XGBoost Contributors
+ * Copyright 2023-2025, XGBoost Contributors
  */
 #ifndef XGBOOST_COMMON_REF_RESOURCE_VIEW_H_
 #define XGBOOST_COMMON_REF_RESOURCE_VIEW_H_
@@ -88,6 +88,14 @@ class RefResourceView {
 
   [[nodiscard]] value_type& operator[](size_type i) { return ptr_[i]; }
   [[nodiscard]] value_type const& operator[](size_type i) const { return ptr_[i]; }
+  [[nodiscard]] value_type& at(size_type i) {  // NOLINT
+    SPAN_LT(i, this->size_);
+    return ptr_[i];
+  }
+  [[nodiscard]] value_type const& at(size_type i) const {  // NOLINT
+    SPAN_LT(i, this->size_);
+    return ptr_[i];
+  }
 
   /**
    * @brief Get the underlying resource.

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2019-2024, XGBoost Contributors
+ *  Copyright 2019-2025, XGBoost Contributors
  * \file adapter.h
  */
 #ifndef XGBOOST_DATA_ADAPTER_H_

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -546,12 +546,12 @@ class ColumnarAdapterBatch : public detail::NoMetaInfo {
         : columns_{columns}, ridx_{ridx} {}
     [[nodiscard]] std::size_t Size() const { return columns_.empty() ? 0 : columns_.size(); }
 
-    [[nodiscard]] COOTuple GetElement(std::size_t idx) const {
-      auto const& column = columns_[idx];
+    [[nodiscard]] COOTuple GetElement(std::size_t fidx) const {
+      auto const& column = columns_.data()[fidx];
       float value = column.valid.Data() == nullptr || column.valid.Check(ridx_)
                         ? column(ridx_)
                         : std::numeric_limits<float>::quiet_NaN();
-      return {ridx_, idx, value};
+      return {ridx_, fidx, value};
     }
   };
 

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2024, XGBoost Contributors
+ * Copyright 2017-2025, XGBoost Contributors
  * \brief Data type for fast histogram aggregation.
  */
 #include "gradient_index.h"

--- a/src/data/gradient_index.cc
+++ b/src/data/gradient_index.cc
@@ -215,6 +215,11 @@ float GHistIndexMatrix::GetFvalue(std::vector<std::uint32_t> const &ptrs,
     }
     return values[gidx];
   }
+  if (this->IsDense()) {
+    auto begin = RowIdx(ridx);
+    auto bin_idx = this->index[begin + fidx];
+    return common::HistogramCuts::NumericBinValue(ptrs, values, mins, fidx, bin_idx);
+  }
 
   auto get_bin_val = [&](auto &column) {
     auto bin_idx = column[ridx - this->base_rowid];

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -257,7 +257,7 @@ class GHistIndexMatrix {
   }
 
   [[nodiscard]] bst_idx_t Size() const { return row_ptr.empty() ? 0 : row_ptr.size() - 1; }
-  [[nodiscard]] bst_feature_t Features() const { return cut.cut_ptrs_.Size() - 1; }
+  [[nodiscard]] bst_feature_t Features() const { return cut.NumFeatures(); }
 
   [[nodiscard]] bool ReadColumnPage(common::AlignedResourceReadStream* fi);
   [[nodiscard]] std::size_t WriteColumnPage(common::AlignedFileWriteStream* fo) const;

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 by XGBoost Contributors
+ * Copyright 2017-2024, XGBoost Contributors
  * \brief Data type for fast histogram aggregation.
  */
 #ifndef XGBOOST_DATA_GRADIENT_INDEX_H_
@@ -9,8 +9,9 @@
 #include <atomic>     // for atomic
 #include <cstddef>    // for size_t
 #include <cstdint>    // for uint32_t
+#include <limits>     // for numeric_limits
 #include <memory>     // for make_unique
-#include <vector>
+#include <vector>     // for vector
 
 #include "../common/categorical.h"
 #include "../common/error_msg.h"  // for InfInData

--- a/src/data/gradient_index.h
+++ b/src/data/gradient_index.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2024, XGBoost Contributors
+ * Copyright 2017-2025, XGBoost Contributors
  * \brief Data type for fast histogram aggregation.
  */
 #ifndef XGBOOST_DATA_GRADIENT_INDEX_H_
@@ -250,12 +250,14 @@ class GHistIndexMatrix {
   void SetDense(bool is_dense) { isDense_ = is_dense; }
   [[nodiscard]] bst_idx_t BaseRowId() const { return base_rowid; }
   /**
-   * @brief Get the local row index.
+   * @brief Get the local row index from the global row index.
    */
-  [[nodiscard]] bst_idx_t RowIdx(bst_idx_t ridx) const { return row_ptr[ridx - this->base_rowid]; }
+  [[nodiscard]] bst_idx_t RowIdx(bst_idx_t gridx) const {
+    return row_ptr[gridx - this->base_rowid];
+  }
 
   [[nodiscard]] bst_idx_t Size() const { return row_ptr.empty() ? 0 : row_ptr.size() - 1; }
-  [[nodiscard]] bst_feature_t Features() const { return cut.Ptrs().size() - 1; }
+  [[nodiscard]] bst_feature_t Features() const { return cut.cut_ptrs_.Size() - 1; }
 
   [[nodiscard]] bool ReadColumnPage(common::AlignedResourceReadStream* fi);
   [[nodiscard]] std::size_t WriteColumnPage(common::AlignedFileWriteStream* fo) const;

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -163,17 +163,6 @@ class GBLinear : public GradientBooster {
     this->PredictBatchInternal(p_fmat, &out_preds->HostVector());
     monitor_.Stop("PredictBatch");
   }
-  // add base margin
-  void PredictInstance(const SparsePage::Inst& inst, std::vector<bst_float>* out_preds,
-                       uint32_t layer_begin, uint32_t) override {
-    LinearCheckLayer(layer_begin);
-    const int ngroup = model_.learner_model_param->num_output_group;
-
-    auto base_score = learner_model_param_->BaseScore(ctx_);
-    for (int gid = 0; gid < ngroup; ++gid) {
-      this->Pred(inst, dmlc::BeginPtr(*out_preds), gid, base_score(0));
-    }
-  }
 
   void PredictLeaf(DMatrix *, HostDeviceVector<bst_float> *, unsigned, unsigned) override {
     LOG(FATAL) << "gblinear does not support prediction of leaf index";

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2024, XGBoost Contributors
+ * Copyright 2014-2025, XGBoost Contributors
  * \file gblinear.cc
  * \brief Implementation of Linear booster, with L1/L2 regularization: Elastic Net
  *        the update rule is parallel coordinate descent (shotgun)

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -880,16 +880,6 @@ class Dart : public GBTree {
     }
   }
 
-  void PredictInstance(const SparsePage::Inst &inst,
-                       std::vector<bst_float> *out_preds,
-                       unsigned layer_begin, unsigned layer_end) override {
-    DropTrees(false);
-    auto &predictor = this->GetPredictor(false);
-    uint32_t _, tree_end;
-    std::tie(_, tree_end) = detail::LayerToTree(model_, layer_begin, layer_end);
-    predictor->PredictInstance(inst, out_preds, model_, tree_end);
-  }
-
   void PredictContribution(DMatrix* p_fmat, HostDeviceVector<bst_float>* out_contribs,
                            bst_layer_t layer_begin, bst_layer_t layer_end,
                            bool approximate) override {

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2024, XGBoost Contributors
+ * Copyright 2014-2025, XGBoost Contributors
  * \file gbtree.cc
  * \brief gradient boosted tree implementation.
  * \author Tianqi Chen

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -287,13 +287,6 @@ class GBTree : public GradientBooster {
     }
   }
 
-  void PredictInstance(const SparsePage::Inst& inst, std::vector<bst_float>* out_preds,
-                       uint32_t layer_begin, uint32_t layer_end) override {
-    std::uint32_t _, tree_end;
-    std::tie(_, tree_end) = detail::LayerToTree(model_, layer_begin, layer_end);
-    cpu_predictor_->PredictInstance(inst, out_preds, model_, tree_end);
-  }
-
   void PredictLeaf(DMatrix* p_fmat,
                    HostDeviceVector<bst_float>* out_preds,
                    uint32_t layer_begin, uint32_t layer_end) override {

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2024, XGBoost Contributors
+ * Copyright 2014-2025, XGBoost Contributors
  * \file gbtree.cc
  * \brief gradient boosted tree implementation.
  * \author Tianqi Chen

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2024, XGBoost Contributors
+ * Copyright 2015-2025, XGBoost Contributors
  * \file elementwise_metric.cu
  * \brief evaluation metrics for elementwise binary or regression.
  * \author Kailong Chen, Tianqi Chen

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -75,16 +75,27 @@ PackedReduceResult Reduce(Context const* ctx, MetaInfo const& info, Fn&& loss) {
     // for approximation in distributed setting.  For rmse:
     // - sqrt(1/w(sum_t0 + sum_t1 + ... + sum_tm))       // multi-target
     // - sqrt(avg_t0) + sqrt(avg_t1) + ... sqrt(avg_tm)  // distributed
-    common::ParallelFor(info.labels.Size(), ctx->Threads(), [&](size_t i) {
-      auto t_idx = omp_get_thread_num();
-      size_t sample_id;
-      size_t target_id;
-      std::tie(sample_id, target_id) = linalg::UnravelIndex(i, labels.Shape());
 
-      float v, wt;
-      std::tie(v, wt) = loss(i, sample_id, target_id);
-      score_tloc[t_idx] += v;
-      weight_tloc[t_idx] += wt;
+    auto size = info.labels.Size();
+    auto const kBlockSize = 2048;
+    auto n_blocks = size / kBlockSize + 1;
+
+    common::ParallelFor(n_blocks, n_threads, [&](auto block_idx) {
+      const size_t begin = block_idx * kBlockSize;
+      const size_t end = std::min(size, begin + kBlockSize);
+
+      double sum_score = 0, sum_weight = 0;
+      for (std::size_t i = begin; i < end; ++i) {
+        auto [sample_id, target_id] = linalg::UnravelIndex(i, labels.Shape());
+
+        auto [v, wt] = loss(i, sample_id, target_id);
+        sum_score += v;
+        sum_weight += wt;
+      }
+
+      auto t_idx = omp_get_thread_num();
+      score_tloc[t_idx] += sum_score;
+      weight_tloc[t_idx] += sum_weight;
     });
     double residue_sum = std::accumulate(score_tloc.cbegin(), score_tloc.cend(), 0.0);
     double weights_sum = std::accumulate(weight_tloc.cbegin(), weight_tloc.cend(), 0.0);

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -14,7 +14,6 @@
 #include "../collective/communicator-inl.h"   // for Allreduce, IsDistributed
 #include "../collective/allreduce.h"
 #include "../common/bitfield.h"               // for RBitField8
-#include "../common/categorical.h"            // for IsCat, Decision
 #include "../common/common.h"                 // for DivRoundUp
 #include "../common/error_msg.h"              // for InplacePredictProxy
 #include "../common/math.h"                   // for CheckNAN
@@ -216,7 +215,7 @@ struct GHistIndexMatrixView {
       non_missing += n_features_;
     } else {
       for (bst_feature_t c = 0; c < n_features_; ++c) {
-        float f = page_.GetFvalue(ptrs_, values_, mins_, r, c, false);
+        float f = page_.GetFvalue(ptrs_, values_, mins_, r, c, common::IsCat(ft_, c));
         if (!common::CheckNAN(f)) {
           ws[non_missing] = Entry{c, f};
           ++non_missing;

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -207,7 +207,12 @@ struct GHistIndexMatrixView {
         auto ptr = page_.index.data<T>();
         auto rbeg = page_.row_ptr[r];
         for (bst_feature_t c = 0; c < n_features_; ++c) {
-          auto bin_idx = ptr[rbeg + c] + page_.index.Offset()[c];
+          bst_bin_t bin_idx;
+          if (common::IsCat(ft_, c)) {
+            bin_idx = page_.GetGindex(r, c);
+          } else {
+            bin_idx = ptr[rbeg + c] + page_.index.Offset()[c];
+          }
           auto f = common::HistogramCuts::NumericBinValue(this->ptrs_, values_, mins_, c, bin_idx);
           ws[beg + c] = Entry{c, f};
         }

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2024, XGBoost Contributors
+ * Copyright 2017-2025, XGBoost Contributors
  */
 #include <GPUTreeShap/gpu_treeshap.h>
 #include <thrust/copy.h>
@@ -39,7 +39,7 @@ struct TreeView {
   common::Span<RegTree::Node const> d_tree;
 
   XGBOOST_DEVICE
-  TreeView(size_t tree_begin, size_t tree_idx, common::Span<const RegTree::Node> d_nodes,
+  TreeView(bst_tree_t tree_begin, bst_tree_t tree_idx, common::Span<const RegTree::Node> d_nodes,
            common::Span<size_t const> d_tree_segments,
            common::Span<FeatureType const> d_tree_split_types,
            common::Span<uint32_t const> d_cat_tree_segments,
@@ -252,7 +252,7 @@ PredictLeafKernel(Data data, common::Span<const RegTree::Node> d_nodes,
                   common::Span<RegTree::CategoricalSplitMatrix::Segment const> d_cat_node_segments,
                   common::Span<uint32_t const> d_categories,
 
-                  size_t tree_begin, size_t tree_end, bst_feature_t num_features,
+                  bst_tree_t tree_begin, bst_tree_t tree_end, bst_feature_t num_features,
                   size_t num_rows, bool use_shared,
                   float missing) {
   bst_idx_t ridx = blockDim.x * blockIdx.x + threadIdx.x;
@@ -260,7 +260,7 @@ PredictLeafKernel(Data data, common::Span<const RegTree::Node> d_nodes,
     return;
   }
   Loader loader{data, use_shared, num_features, num_rows, missing};
-  for (size_t tree_idx = tree_begin; tree_idx < tree_end; ++tree_idx) {
+  for (bst_tree_t tree_idx = tree_begin; tree_idx < tree_end; ++tree_idx) {
     TreeView d_tree{
         tree_begin,          tree_idx,           d_nodes,
         d_tree_segments,     d_tree_split_types, d_cat_tree_segments,
@@ -285,8 +285,8 @@ PredictKernel(Data data, common::Span<const RegTree::Node> d_nodes,
               common::Span<FeatureType const> d_tree_split_types,
               common::Span<uint32_t const> d_cat_tree_segments,
               common::Span<RegTree::CategoricalSplitMatrix::Segment const> d_cat_node_segments,
-              common::Span<uint32_t const> d_categories, size_t tree_begin,
-              size_t tree_end, size_t num_features, size_t num_rows,
+              common::Span<uint32_t const> d_categories, bst_tree_t tree_begin,
+              bst_tree_t tree_end, size_t num_features, size_t num_rows,
               bool use_shared, int num_group, float missing) {
   bst_uint global_idx = blockDim.x * blockIdx.x + threadIdx.x;
   Loader loader(data, use_shared, num_features, num_rows, missing);
@@ -294,7 +294,7 @@ PredictKernel(Data data, common::Span<const RegTree::Node> d_nodes,
 
   if (num_group == 1) {
     float sum = 0;
-    for (size_t tree_idx = tree_begin; tree_idx < tree_end; tree_idx++) {
+    for (bst_tree_t tree_idx = tree_begin; tree_idx < tree_end; tree_idx++) {
       TreeView d_tree{
           tree_begin,          tree_idx,           d_nodes,
           d_tree_segments,     d_tree_split_types, d_cat_tree_segments,
@@ -304,7 +304,7 @@ PredictKernel(Data data, common::Span<const RegTree::Node> d_nodes,
     }
     d_out_predictions[global_idx] += sum;
   } else {
-    for (size_t tree_idx = tree_begin; tree_idx < tree_end; tree_idx++) {
+    for (bst_tree_t tree_idx = tree_begin; tree_idx < tree_end; tree_idx++) {
       int tree_group = d_tree_group[tree_idx];
       TreeView d_tree{
           tree_begin,          tree_idx,           d_nodes,
@@ -474,7 +474,7 @@ struct ShapSplitCondition {
 struct PathInfo {
   int64_t leaf_position;  // -1 not a leaf
   size_t length;
-  size_t tree_idx;
+  bst_tree_t tree_idx;
 };
 
 // Transform model into path element form for GPUTreeShap
@@ -494,8 +494,7 @@ void ExtractPaths(Context const* ctx,
         if (!n.IsLeaf() || n.IsDeleted()) {
           return PathInfo{-1, 0, 0};
         }
-        size_t tree_idx =
-            dh::SegmentId(d_tree_segments.begin(), d_tree_segments.end(), idx);
+        bst_tree_t tree_idx = dh::SegmentId(d_tree_segments.begin(), d_tree_segments.end(), idx);
         size_t tree_offset = d_tree_segments[tree_idx];
         size_t path_length = 1;
         while (!n.IsRoot()) {
@@ -622,7 +621,7 @@ __global__ void MaskBitVectorKernel(
     common::Span<std::uint32_t const> d_cat_tree_segments,
     common::Span<RegTree::CategoricalSplitMatrix::Segment const> d_cat_node_segments,
     common::Span<std::uint32_t const> d_categories, BitVector decision_bits, BitVector missing_bits,
-    std::size_t tree_begin, std::size_t tree_end, bst_feature_t num_features, std::size_t num_rows,
+    bst_tree_t tree_begin, bst_tree_t tree_end, bst_feature_t num_features, std::size_t num_rows,
     std::size_t num_nodes, bool use_shared, float missing) {
   // This needs to be always instantiated since the data is loaded cooperatively by all threads.
   SparsePageLoader loader{data, use_shared, num_features, num_rows, missing};
@@ -695,7 +694,7 @@ __global__ void PredictByBitVectorKernel(
     common::Span<std::uint32_t const> d_cat_tree_segments,
     common::Span<RegTree::CategoricalSplitMatrix::Segment const> d_cat_node_segments,
     common::Span<std::uint32_t const> d_categories, BitVector decision_bits, BitVector missing_bits,
-    std::size_t tree_begin, std::size_t tree_end, std::size_t num_rows, std::size_t num_nodes,
+    bst_tree_t tree_begin, bst_tree_t tree_end, std::size_t num_rows, std::size_t num_nodes,
     std::uint32_t num_group) {
   auto const row_idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (row_idx >= num_rows) {
@@ -704,7 +703,7 @@ __global__ void PredictByBitVectorKernel(
 
   std::size_t tree_offset = 0;
   if constexpr (predict_leaf) {
-    for (size_t tree_idx = tree_begin; tree_idx < tree_end; ++tree_idx) {
+    for (auto tree_idx = tree_begin; tree_idx < tree_end; ++tree_idx) {
       TreeView d_tree{tree_begin,          tree_idx,           d_nodes,
                       d_tree_segments,     d_tree_split_types, d_cat_tree_segments,
                       d_cat_node_segments, d_categories};
@@ -942,9 +941,8 @@ class GPUPredictor : public xgboost::Predictor {
     }
   }
 
-  void PredictBatch(DMatrix* dmat, PredictionCacheEntry* predts,
-                    const gbm::GBTreeModel& model, uint32_t tree_begin,
-                    uint32_t tree_end = 0) const override {
+  void PredictBatch(DMatrix* dmat, PredictionCacheEntry* predts, const gbm::GBTreeModel& model,
+                    bst_tree_t tree_begin, bst_tree_t tree_end = 0) const override {
     CHECK(ctx_->Device().IsCUDA()) << "Set `device' to `cuda` for processing GPU data.";
     auto* out_preds = &predts->predictions;
     if (tree_end == 0) {
@@ -956,8 +954,8 @@ class GPUPredictor : public xgboost::Predictor {
   template <typename Adapter, typename Loader>
   void DispatchedInplacePredict(std::any const& x, std::shared_ptr<DMatrix> p_m,
                                 const gbm::GBTreeModel& model, float missing,
-                                PredictionCacheEntry* out_preds, uint32_t tree_begin,
-                                uint32_t tree_end) const {
+                                PredictionCacheEntry* out_preds, bst_tree_t tree_begin,
+                                bst_tree_t tree_end) const {
     uint32_t const output_groups =  model.learner_model_param->num_output_group;
 
     auto m = std::any_cast<std::shared_ptr<Adapter>>(x);
@@ -996,9 +994,9 @@ class GPUPredictor : public xgboost::Predictor {
         tree_begin, tree_end, m->NumColumns(), m->NumRows(), use_shared, output_groups, missing);
   }
 
-  bool InplacePredict(std::shared_ptr<DMatrix> p_m, const gbm::GBTreeModel& model, float missing,
-                      PredictionCacheEntry* out_preds, uint32_t tree_begin,
-                      unsigned tree_end) const override {
+  bool InplacePredict(std::shared_ptr<DMatrix> p_m, gbm::GBTreeModel const& model, float missing,
+                      PredictionCacheEntry* out_preds, bst_tree_t tree_begin,
+                      bst_tree_t tree_end) const override {
     auto proxy = dynamic_cast<data::DMatrixProxy*>(p_m.get());
     CHECK(proxy) << error::InplacePredictProxy();
     auto x = proxy->Adapter();
@@ -1016,11 +1014,9 @@ class GPUPredictor : public xgboost::Predictor {
     return true;
   }
 
-  void PredictContribution(DMatrix* p_fmat,
-                           HostDeviceVector<bst_float>* out_contribs,
-                           const gbm::GBTreeModel& model, unsigned tree_end,
-                           std::vector<bst_float> const* tree_weights,
-                           bool approximate, int,
+  void PredictContribution(DMatrix* p_fmat, HostDeviceVector<float>* out_contribs,
+                           const gbm::GBTreeModel& model, bst_tree_t tree_end,
+                           std::vector<bst_float> const* tree_weights, bool approximate, int,
                            unsigned) const override {
     std::string not_implemented{
         "contribution is not implemented in the GPU predictor, use CPU instead."};
@@ -1034,9 +1030,7 @@ class GPUPredictor : public xgboost::Predictor {
         << "Predict contribution support for column-wise data split is not yet implemented.";
     dh::safe_cuda(cudaSetDevice(ctx_->Ordinal()));
     out_contribs->SetDevice(ctx_->Device());
-    if (tree_end == 0 || tree_end > model.trees.size()) {
-      tree_end = static_cast<uint32_t>(model.trees.size());
-    }
+    tree_end = GetTreeLimit(model.trees, tree_end);
 
     const int ngroup = model.learner_model_param->num_output_group;
     CHECK_NE(ngroup, 0);
@@ -1087,11 +1081,9 @@ class GPUPredictor : public xgboost::Predictor {
                 });
   }
 
-  void PredictInteractionContributions(DMatrix* p_fmat,
-                                       HostDeviceVector<bst_float>* out_contribs,
-                                       const gbm::GBTreeModel& model,
-                                       unsigned tree_end,
-                                       std::vector<bst_float> const* tree_weights,
+  void PredictInteractionContributions(DMatrix* p_fmat, HostDeviceVector<float>* out_contribs,
+                                       gbm::GBTreeModel const& model, bst_tree_t tree_end,
+                                       std::vector<float> const* tree_weights,
                                        bool approximate) const override {
     std::string not_implemented{"contribution is not implemented in GPU "
                                 "predictor, use `cpu_predictor` instead."};
@@ -1103,9 +1095,7 @@ class GPUPredictor : public xgboost::Predictor {
     }
     dh::safe_cuda(cudaSetDevice(ctx_->Ordinal()));
     out_contribs->SetDevice(ctx_->Device());
-    if (tree_end == 0 || tree_end > model.trees.size()) {
-      tree_end = static_cast<uint32_t>(model.trees.size());
-    }
+    tree_end = GetTreeLimit(model.trees, tree_end);
 
     const int ngroup = model.learner_model_param->num_output_group;
     CHECK_NE(ngroup, 0);
@@ -1162,17 +1152,14 @@ class GPUPredictor : public xgboost::Predictor {
                 });
   }
 
-  void PredictLeaf(DMatrix *p_fmat, HostDeviceVector<bst_float> *predictions,
-                   const gbm::GBTreeModel &model,
-                   unsigned tree_end) const override {
+  void PredictLeaf(DMatrix* p_fmat, HostDeviceVector<float>* predictions,
+                   gbm::GBTreeModel const& model, bst_tree_t tree_end) const override {
     dh::safe_cuda(cudaSetDevice(ctx_->Ordinal()));
     auto max_shared_memory_bytes = ConfigureDevice(ctx_->Device());
 
     const MetaInfo& info = p_fmat->Info();
     bst_idx_t num_rows = info.num_row_;
-    if (tree_end == 0 || tree_end > model.trees.size()) {
-      tree_end = static_cast<uint32_t>(model.trees.size());
-    }
+    tree_end = GetTreeLimit(model.trees, tree_end);
     predictions->SetDevice(ctx_->Device());
     predictions->Resize(num_rows * tree_end);
     DeviceModel d_model;

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -1162,13 +1162,6 @@ class GPUPredictor : public xgboost::Predictor {
                 });
   }
 
-  void PredictInstance(const SparsePage::Inst&,
-                       std::vector<bst_float>*,
-                       const gbm::GBTreeModel&, unsigned, bool) const override {
-    LOG(FATAL) << "[Internal error]: " << __func__
-               << " is not implemented in GPU Predictor.";
-  }
-
   void PredictLeaf(DMatrix *p_fmat, HostDeviceVector<bst_float> *predictions,
                    const gbm::GBTreeModel &model,
                    unsigned tree_end) const override {

--- a/src/predictor/predict_fn.h
+++ b/src/predictor/predict_fn.h
@@ -20,9 +20,9 @@ XGBOOST_DEVICE bool GetDecision(RegTree::Node const &node, bst_node_t nid, float
 }
 
 template <bool has_missing, bool has_categorical>
-inline XGBOOST_DEVICE bst_node_t GetNextNode(const RegTree::Node &node, const bst_node_t nid,
-                                             float fvalue, bool is_missing,
-                                             RegTree::CategoricalSplitMatrix const &cats) {
+XGBOOST_DEVICE bst_node_t GetNextNode(const RegTree::Node &node, const bst_node_t nid, float fvalue,
+                                      bool is_missing,
+                                      RegTree::CategoricalSplitMatrix const &cats) {
   if (has_missing && is_missing) {
     return node.DefaultChild();
   } else {
@@ -31,10 +31,9 @@ inline XGBOOST_DEVICE bst_node_t GetNextNode(const RegTree::Node &node, const bs
 }
 
 template <bool has_missing, bool has_categorical>
-inline XGBOOST_DEVICE bst_node_t GetNextNodeMulti(MultiTargetTree const &tree,
-                                                  bst_node_t const nidx, float fvalue,
-                                                  bool is_missing,
-                                                  RegTree::CategoricalSplitMatrix const &cats) {
+XGBOOST_DEVICE bst_node_t GetNextNodeMulti(MultiTargetTree const &tree, bst_node_t const nidx,
+                                           float fvalue, bool is_missing,
+                                           RegTree::CategoricalSplitMatrix const &cats) {
   if (has_missing && is_missing) {
     return tree.DefaultChild(nidx);
   } else {
@@ -48,6 +47,5 @@ inline XGBOOST_DEVICE bst_node_t GetNextNodeMulti(MultiTargetTree const &tree,
     }
   }
 }
-
 }  // namespace xgboost::predictor
 #endif  // XGBOOST_PREDICTOR_PREDICT_FN_H_

--- a/src/predictor/predict_fn.h
+++ b/src/predictor/predict_fn.h
@@ -3,6 +3,10 @@
  */
 #ifndef XGBOOST_PREDICTOR_PREDICT_FN_H_
 #define XGBOOST_PREDICTOR_PREDICT_FN_H_
+
+#include <memory>  // for unique_ptr
+#include <vector>  // for vector
+
 #include "../common/categorical.h"  // for IsCat, Decision
 #include "xgboost/tree_model.h"     // for RegTree
 

--- a/src/predictor/predict_fn.h
+++ b/src/predictor/predict_fn.h
@@ -1,10 +1,10 @@
 /**
- * Copyright 2021-2023 by XGBoost Contributors
+ * Copyright 2021-2025, XGBoost Contributors
  */
 #ifndef XGBOOST_PREDICTOR_PREDICT_FN_H_
 #define XGBOOST_PREDICTOR_PREDICT_FN_H_
-#include "../common/categorical.h"
-#include "xgboost/tree_model.h"
+#include "../common/categorical.h"  // for IsCat, Decision
+#include "xgboost/tree_model.h"     // for RegTree
 
 namespace xgboost::predictor {
 /** @brief Whether it should traverse to the left branch of a tree. */
@@ -46,6 +46,19 @@ XGBOOST_DEVICE bst_node_t GetNextNodeMulti(MultiTargetTree const &tree, bst_node
       return tree.LeftChild(nidx) + !(fvalue < tree.SplitCond(nidx));
     }
   }
+}
+
+/**
+ * @brief Some old prediction methods accept the ntree_limit parameter and they use 0 to
+ *        indicate no limit.
+ */
+inline bst_tree_t GetTreeLimit(std::vector<std::unique_ptr<RegTree>> const &trees,
+                               bst_tree_t ntree_limit) {
+  auto n_trees = static_cast<bst_tree_t>(trees.size());
+  if (ntree_limit == 0 || ntree_limit > n_trees) {
+    ntree_limit = n_trees;
+  }
+  return ntree_limit;
 }
 }  // namespace xgboost::predictor
 #endif  // XGBOOST_PREDICTOR_PREDICT_FN_H_

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2024, XGBoost Contributors
+ * Copyright 2020-2025, XGBoost Contributors
  */
 #include "test_predictor.h"
 

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -47,16 +47,6 @@ void TestBasic(DMatrix* dmat, Context const *ctx) {
     ASSERT_EQ(out_predictions_h[i], 1.5);
   }
 
-  // Test predict instance
-  auto const& batch = *dmat->GetBatches<xgboost::SparsePage>().begin();
-  auto page = batch.GetView();
-  for (size_t i = 0; i < batch.Size(); i++) {
-    std::vector<float> instance_out_predictions;
-    predictor->PredictInstance(page[i], &instance_out_predictions, model, 0,
-                                   dmat->Info().IsColumnSplit());
-    ASSERT_EQ(instance_out_predictions[0], 1.5);
-  }
-
   // Test predict leaf
   HostDeviceVector<float> leaf_out_predictions;
   predictor->PredictLeaf(dmat, &leaf_out_predictions, model);

--- a/tests/python/test_quantile_dmatrix.py
+++ b/tests/python/test_quantile_dmatrix.py
@@ -286,10 +286,10 @@ class TestQuantileDMatrix:
     def test_ref_quantile_cut(self) -> None:
         check_ref_quantile_cut("cpu")
 
-    def test_ref_dmatrix(self) -> None:
+    @pytest.mark.parametrize("enable_cat", [True, False])
+    def test_ref_dmatrix(self, enable_cat: bool) -> None:
         rng = np.random.RandomState(1994)
-        self.run_ref_dmatrix(rng, "cpu", True)
-        self.run_ref_dmatrix(rng, "cpu", False)
+        self.run_ref_dmatrix(rng, "cpu", enable_cat)
 
     @pytest.mark.parametrize("sparsity", [0.0, 0.5])
     def test_predict(self, sparsity: float) -> None:


### PR DESCRIPTION
- Remove predict instance. It's dead code as we can't use it outside of XGBoost even with C++ include.
- Remove unroll. No performance benefit.
- Optimize dense QDM inference.
- optimize data loading by directly copying data to feature vector instead of going through a workspace.

Partially address https://github.com/dmlc/xgboost/issues/10793


The optimization mostly focuses on dense data and the result varies between CPUs:
```
| Xeon(R) Gold 6128 |            DMatrix |    QuantileDMatrix |
|-------------------+--------------------+--------------------|
| Master            | 27.980122327804565 | 55.665775775909424 |
| PR                |  23.63674759864807 | 30.158272981643677 |

| Ryzen 9 7900X3D |            DMatrix |    QuantileDMatrix |
|-----------------+--------------------+--------------------|
| Master          | 24.764960527420044 | 31.460495710372925 |
| PR              | 22.532921314239502 | 21.412014961242676 |
```