### PR TITLE
[R] Enable prefetch on windows configure script

### DIFF
--- a/R-package/configure.win
+++ b/R-package/configure.win
@@ -1,0 +1,21 @@
+R_EXE="${R_HOME}/bin${R_ARCH_BIN}/R.exe"
+CXX=`"${R_EXE}" CMD config CXX`
+
+cat > test.cpp <<EOL
+#include <xmmintrin.h>
+int main() {
+  char data = 0;
+  const char* address = &data;
+  _mm_prefetch(address, _MM_HINT_NTA);
+  return 0;
+}
+EOL
+
+XGBOOST_MM_PREFETCH_PRESENT=""
+${CXX} -o test test.cpp 2>/dev/null && ./test && XGBOOST_MM_PREFETCH_PRESENT="-DXGBOOST_MM_PREFETCH_PRESENT=1"
+rm -f ./test
+rm -f ./test.cpp
+
+sed \
+    -e "s/@XGBOOST_MM_PREFETCH_PRESENT@/$XGBOOST_MM_PREFETCH_PRESENT/" \
+    < src/Makevars.win.in > src/Makevars.win

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -22,6 +22,8 @@ PKG_CPPFLAGS = \
     -I$(PKGROOT)/include \
     -I$(PKGROOT)/dmlc-core/include \
     -I$(PKGROOT) \
+    -DXGBOOST_BUILTIN_PREFETCH_PRESENT=1 \
+    @XGBOOST_MM_PREFETCH_PRESENT@ \
     $(XGB_RFLAGS)
 
 PKG_CXXFLAGS = \

--- a/ops/script/test_r_package.py
+++ b/ops/script/test_r_package.py
@@ -63,7 +63,7 @@ def pack_rpackage() -> Path:
     if os.path.exists(osxmakef):
         os.remove(osxmakef)
     pkgroot("Makevars.in")
-    pkgroot("Makevars.win")
+    pkgroot("Makevars.win.in")
     # misc
     rwsp = Path("R-package") / "remove_warning_suppression_pragma.sh"
     if system() != "Windows":


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810
ref https://github.com/dmlc/xgboost/pull/11124

This PR adds prefetching to the compilation flags on windows when supported.

Since CRAN only uses MinGW for windows builds and the msvc build here was dropped, it enables the GC builtin unconditionally, since no other compiler will be used on windows.