### PR TITLE
[R] Error out when trying to compile with MSVC

### DIFF
--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -27,6 +27,10 @@
 
 #include "./xgboost_R.h"  // Must follow other includes.
 
+#ifdef _MSC_VER
+#error "Compilation of R package with MSVC is not supported due to issues handling R headers"
+#endif
+
 namespace {
 
 /* Note: this class is used as a throwable exception.


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810
ref https://github.com/dmlc/xgboost/pull/11145

This PR makes it throw a compilation error with a clear message when a user tries to build the R package with the MSVC compiler. Hopefully this should save users some headaches as they'd otherwise run into runtime segfaults if the package gets compiled with MSVC.