### PR TITLE
[R] Update deprecated and removed parameter lists for `xgboost()`

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -560,6 +560,29 @@ deprecated_train_params <- list(
   ),
   removed = character()
 )
+deprecated_xgboost_params <- list(
+  renamed = list(
+    'data' = 'x',
+    'label' = 'y',
+    'eta' = 'learning_rate',
+    'gamma' = 'min_split_loss',
+    'lambda' = 'reg_lambda',
+    'alpha' = 'reg_alpha',
+    'min.split.loss' = 'min_split_loss',
+    'reg.lambda' = 'reg_lambda',
+    'reg.alpha' = 'reg_alpha',
+    'watchlist' = 'evals'
+  ),
+  removed = c(
+    'params',
+    'save_period',
+    'save_name',
+    'xgb_model',
+    'callbacks',
+    'missing',
+    'maximize'
+  )
+)
 deprecated_dttree_params <- list(
   renamed = list('n_first_tree' = 'trees'),
   removed = c("feature_names", "text")

--- a/R-package/R/xgboost.R
+++ b/R-package/R/xgboost.R
@@ -1065,6 +1065,7 @@ check.early.stopping.rounds <- function(early_stopping_rounds, eval_set) {
 #' - `"shotgun"`: Parallel coordinate descent algorithm based on shotgun algorithm. Uses 'hogwild' parallelism and therefore produces a nondeterministic solution on each run.
 #' - `"coord_descent"`: Ordinary coordinate descent algorithm. Also multithreaded but still produces a deterministic solution. When the `device` parameter is set to `"cuda"` or `"gpu"`, a GPU variant would be used.
 #' @inheritParams xgb.params
+#' @inheritParams xgb.train
 #' @return A model object, inheriting from both `xgboost` and `xgb.Booster`. Compared to the regular
 #'   `xgb.Booster` model class produced by [xgb.train()], this `xgboost` class will have an
 #'
@@ -1140,9 +1141,11 @@ xgboost <- function(
   tweedie_variance_power = NULL,
   huber_slope = NULL,
   quantile_alpha = NULL,
-  aft_loss_distribution = NULL
+  aft_loss_distribution = NULL,
+  ...
 ) {
 # nolint end
+  check.deprecation(deprecated_xgboost_params, match.call(), ...)
   params <- as.list(environment())
   params <- params[
     (names(params) %in% formalArgs(xgb.params))

--- a/R-package/man/xgboost.Rd
+++ b/R-package/man/xgboost.Rd
@@ -62,7 +62,8 @@ xgboost(
   tweedie_variance_power = NULL,
   huber_slope = NULL,
   quantile_alpha = NULL,
-  aft_loss_distribution = NULL
+  aft_loss_distribution = NULL,
+  ...
 )
 }
 \arguments{
@@ -614,6 +615,21 @@ Version added: 2.0.0}
 
 \item{aft_loss_distribution}{(for using AFT Survival Loss (\code{"survival:aft"}) and Negative Log Likelihood of AFT metric (\code{"aft-nloglik"}))
 Probability Density Function, \code{"normal"}, \code{"logistic"}, or \code{"extreme"}.}
+
+\item{...}{Not used.
+
+Some arguments that were part of this function in previous XGBoost versions are currently
+deprecated or have been renamed. If a deprecated or renamed argument is passed, will throw
+a warning (by default) and use its current equivalent instead. This warning will become an
+error if using the \link[=xgboost-options]{'strict mode' option}.
+
+If some additional argument is passed that is neither a current function argument nor
+a deprecated or renamed argument, a warning or error will be thrown depending on the
+'strict mode' option.
+
+\bold{Important:} \code{...} will be removed in a future version, and all the current
+deprecation warnings will become errors. Please use only arguments that form part of
+the function signature.}
 }
 \value{
 A model object, inheriting from both \code{xgboost} and \code{xgb.Booster}. Compared to the regular


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810
ref https://github.com/dmlc/xgboost/pull/11109
ref https://github.com/dmlc/xgboost/pull/11095

This PR adds previous arguments of `xgboost()` to the lists of deprecations and removals.