### PR TITLE
[R] Remove redundant newline in configure prints

### DIFF
--- a/R-package/configure
+++ b/R-package/configure
@@ -3338,7 +3338,7 @@ printf "%s\n" "${ac_pkg_openmp}" >&6; }
     OPENMP_LIB=''
     echo '*****************************************************************************************'
     echo '         OpenMP is unavailable on this Mac OSX system. Training speed may be suboptimal.'
-    echo '         To use all CPU cores for training jobs, you should install OpenMP by running\n'
+    echo '         To use all CPU cores for training jobs, you should install OpenMP by running'
     echo '             brew install libomp'
     echo '*****************************************************************************************'
   fi

--- a/R-package/configure.ac
+++ b/R-package/configure.ac
@@ -108,7 +108,7 @@ then
     OPENMP_LIB=''
     echo '*****************************************************************************************'
     echo '         OpenMP is unavailable on this Mac OSX system. Training speed may be suboptimal.'
-    echo '         To use all CPU cores for training jobs, you should install OpenMP by running\n'
+    echo '         To use all CPU cores for training jobs, you should install OpenMP by running'
     echo '             brew install libomp'
     echo '*****************************************************************************************'
   fi


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

This PR removes a newline (`\n`) at the end of an `echo` call, which is not needed since `echo` already adds a newline terminator.