### PR TITLE
[R] Add removal warnings for 'info' in xgb.DMatrix

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -617,6 +617,13 @@ deprecated_predict_params <- list(
   renamed = list("ntreelimit" = "iterationrange"),
   removed = "reshape"
 )
+deprecated_dmatrix_params <- list(
+  renamed = character(),
+  removed = "info"
+)
+
+# These got moved from 'info' to function arguments
+args_previous_dmatrix_info <- c("label", "weight", "base_margin", "group")
 
 # Checks the dot-parameters for deprecated names
 # (including partial matching), gives a deprecation warning,
@@ -647,7 +654,12 @@ check.deprecation <- function(
   }
   list_renamed <- deprecated_list$renamed
   list_removed <- deprecated_list$removed
-  has_params_arg <- list_renamed[[1L]] == deprecated_train_params$renamed[[1L]]
+  has_params_arg <-
+    length(list_renamed) == length(deprecated_train_params$renamed) &&
+    list_renamed[[1L]] == deprecated_train_params$renamed[[1L]]
+  is_dmatrix_constructor <-
+    length(list_removed) == length(deprecated_dmatrix_params$removed) &&
+    list_removed[[1L]] == deprecated_dmatrix_params$removed[[1L]]
   all_match <- pmatch(names(params), names(list_renamed))
   # throw error on unrecognized parameters
   if (!allow_unrecognized && anyNA(all_match)) {
@@ -685,6 +697,25 @@ check.deprecation <- function(
         }
         names_unrecognized <- setdiff(names_unrecognized, names_under_params)
       }
+    } else if (is_dmatrix_constructor && NROW(params$info)) {
+      # same thing for the earlier 'info' in 'xgb.DMatrix'
+      throw_err_or_depr_msg(
+        "Passed invalid argument 'info' - entries on it should be passed as direct arguments."
+      )
+      entries_info <- names(params$info)
+      if (length(setdiff(entries_info, args_previous_dmatrix_info))) {
+        stop(
+          "Passed unrecognized entries under info: ",
+          paste(setdiff(entries_info, args_previous_dmatrix_info) |> head(), collapse = ", ")
+        )
+      }
+      for (entry_name in entries_info) {
+        if (!is.null(env[[entry_name]])) {
+          stop("Passed entry under both 'info' and function argument(s): ", entry_name)
+        }
+        env[[entry_name]] <- params$info[[entry_name]]
+      }
+      names_unrecognized <- setdiff(names_unrecognized, "info")
     }
 
     # check for parameters that were removed from a previous version
@@ -701,7 +732,7 @@ check.deprecation <- function(
     if (length(names_unrecognized)) {
       throw_err_or_depr_msg(
         "Passed unrecognized parameters: ",
-        paste(head(names_unrecognized), collapse = ", ")
+        paste(head(names_unrecognized), collapse = ", "), "."
       )
     }
 

--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -78,6 +78,7 @@
 #' @param label_upper_bound Upper bound for survival training.
 #' @param feature_weights Set feature weights for column sampling.
 #' @param data_split_mode Not used yet. This parameter is for distributed training, which is not yet available for the R package.
+#' @inheritParams xgb.train
 #' @return An 'xgb.DMatrix' object. If calling `xgb.QuantileDMatrix`, it will have additional
 #' subclass `xgb.QuantileDMatrix`.
 #'
@@ -116,8 +117,10 @@ xgb.DMatrix <- function(
   label_lower_bound = NULL,
   label_upper_bound = NULL,
   feature_weights = NULL,
-  data_split_mode = "row"
+  data_split_mode = "row",
+  ...
 ) {
+  check.deprecation(deprecated_dmatrix_params, match.call(), ...)
   if (!is.null(group) && !is.null(qid)) {
     stop("Either one of 'group' or 'qid' should be NULL")
   }

--- a/R-package/man/xgb.DMatrix.Rd
+++ b/R-package/man/xgb.DMatrix.Rd
@@ -20,7 +20,8 @@ xgb.DMatrix(
   label_lower_bound = NULL,
   label_upper_bound = NULL,
   feature_weights = NULL,
-  data_split_mode = "row"
+  data_split_mode = "row",
+  ...
 )
 
 xgb.QuantileDMatrix(
@@ -131,6 +132,21 @@ not be saved, so make sure that \code{factor} columns passed to \code{predict} h
 \item{feature_weights}{Set feature weights for column sampling.}
 
 \item{data_split_mode}{Not used yet. This parameter is for distributed training, which is not yet available for the R package.}
+
+\item{...}{Not used.
+
+Some arguments that were part of this function in previous XGBoost versions are currently
+deprecated or have been renamed. If a deprecated or renamed argument is passed, will throw
+a warning (by default) and use its current equivalent instead. This warning will become an
+error if using the \link[=xgboost-options]{'strict mode' option}.
+
+If some additional argument is passed that is neither a current function argument nor
+a deprecated or renamed argument, a warning or error will be thrown depending on the
+'strict mode' option.
+
+\bold{Important:} \code{...} will be removed in a future version, and all the current
+deprecation warnings will become errors. Please use only arguments that form part of
+the function signature.}
 
 \item{ref}{The training dataset that provides quantile information, needed when creating
 validation/test dataset with \code{\link[=xgb.QuantileDMatrix]{xgb.QuantileDMatrix()}}. Supplying the training DMatrix


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

This PR adds arguments from previous `xgb.DMatrix` "info" to the list of recognized removed parameters.

Along the way it also fixes a potential error that would have been encountered for other functions checking for removed / renamed parameters.

It should make it accept DMatrix fields under 'info' like it used to be, but with the same removal warning as for the other functions.