### PR TITLE
Remove circular reference in DataIter

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -508,15 +508,15 @@ class DataIter(ABC):  # pylint: disable=too-many-instance-attributes
     def get_callbacks(self, enable_categorical: bool) -> Tuple[Callable, Callable]:
         """Get callback functions for iterating in C. This is an internal function."""
         assert hasattr(self, "cache_prefix"), "__init__ is not called."
-        self._reset_callback = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(
+        reset_callback = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(
             self._reset_wrapper
         )
-        self._next_callback = ctypes.CFUNCTYPE(
+        next_callback = ctypes.CFUNCTYPE(
             ctypes.c_int,
             ctypes.c_void_p,
         )(self._next_wrapper)
         self._enable_categorical = enable_categorical
-        return self._reset_callback, self._next_callback
+        return reset_callback, next_callback
 
     @property
     def proxy(self) -> "_ProxyDMatrix":


### PR DESCRIPTION
I observed a memory increase when training XGBoost ensembles. It is caused by circular references in the `DataIter.get_callbacks` method, which is invoked during the construction of `QuantileDMatrix`.

For example,
```
data = np.random.rand(10, 1)
label = np.random.rand(10, 1)
print("Initial ref count:", sys.getrefcount(data), sys.getrefcount(label))
xgb.QuantileDMatrix(data, label)
print("Ref count after QuantileDMatrix construction:", sys.getrefcount(data), sys.getrefcount(label))
gc.collect()
print("Ref count after gc.collect():", sys.getrefcount(data), sys.getrefcount(label))
```
Output
```
Initial ref count: 2 2
Ref count after QuantileDMatrix construction: 3 3
Ref count after gc.collect(): 2 2
```
The circular references increase the reference count of the input `data` and `label` by 1. Circular references can only be freed by the garbage collector (GC). If GC is not triggered in time, memory usage can grow significantly, leading to potential crashes when memory is exhausted.

For example, the following code demonstrates a scenario where the program crashes with a `Killed` error:
```
data = np.random.rand(2**30, 5)
label = np.random.rand(2**30, 1)

for i in range(5):
    new_data = data * i
    new_label = label * i
    xgb.QuantileDMatrix(new_data, new_label)
```
![image](https://github.com/user-attachments/assets/9a443cf1-1dd5-489f-9417-52a2e49235ae)

GC can be triggered manually, but the ideal solution is to avoid creating circular references in the first place.
This patch removes the circular references.
Output with this patch:
```
Initial ref count: 2 2
Ref count after QuantileDMatrix construction: 2 2
Ref count after gc.collect(): 2 2
```
![image](https://github.com/user-attachments/assets/fe6e456d-6232-41c0-9706-da67868878f9)
