### PR TITLE
[JVM-Packages] Allow XGBoost jvm package run on GPU without spark-rapids

### DIFF
--- a/jvm-packages/xgboost4j-spark-gpu/src/main/scala/ml/dmlc/xgboost4j/scala/spark/GpuXGBoostPlugin.scala
+++ b/jvm-packages/xgboost4j-spark-gpu/src/main/scala/ml/dmlc/xgboost4j/scala/spark/GpuXGBoostPlugin.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2024 by Contributors
+ Copyright (c) 2024-2025 by Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.


### PR DESCRIPTION
When I tried to run a simple xgboost4j spark  gpu example with GPU, xgboost throws exception indicating "Couldn't find ai/rapids/Table" which is in spark-rapids. Which is not correct, since xgboost4j-spark-gpu shouldn't be coupled with spark-rapids.


This PR fixes this issue.