### PR TITLE
[R] Deprecation warning for non-function objective as argument

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -139,8 +139,24 @@ check.custom.obj <- function(params, objective) {
   if (!is.null(params[['objective']]) && !is.null(objective))
     stop("Setting objectives in 'params' and 'objective' at the same time is not allowed")
 
-  if (!is.null(objective) && typeof(objective) != 'closure')
+  if (!is.null(objective) && typeof(objective) != 'closure') {
+    if (is.character(objective)) {
+      msg <- paste(
+        "Argument 'objective' is only for custom objectives.",
+        "For built-in objectives, pass the objective under 'params'.",
+        sep = " "
+      )
+      error_on_deprecated <- getOption("xgboost.strict_mode", default = FALSE)
+      if (error_on_deprecated) {
+        stop(msg)
+      } else {
+        warning(msg, " This warning will become an error in a future version.")
+      }
+      params$objective <- objective
+      return(list(params = params, objective = NULL))
+    }
     stop("'objective' must be a function")
+  }
 
   # handle the case when custom objective function was provided through params
   if (!is.null(params[['objective']]) &&


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810
ref https://github.com/dmlc/xgboost/issues/9734#issuecomment-2637066535

Previously, functions `xgb.train` and `xgb.cv` were accepting parameters as either function arguments or as entries under `params`, but now they have been changed to only accept `params`.

One problematic case here is `objective`, since it is accepted as a function argument when it is a function, in line with the python package.

The warning-on-deprecation mechanism thus doesn't cover the case of built-in objectives being passed as parameters. This PR should fix it, and hopefully help to ease migration and avoid failures in reverse dependencies.