### PR TITLE
[jvm-package] Change default missing value to NaN for better alignment.

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java
@@ -136,7 +136,7 @@ public class DMatrix {
   @Deprecated
   public DMatrix(float[] data, int nrow, int ncol) throws XGBoostError {
     long[] out = new long[1];
-    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCreateFromMat(data, nrow, ncol, 0.0f, out));
+    XGBoostJNI.checkCall(XGBoostJNI.XGDMatrixCreateFromMat(data, nrow, ncol, Float.NaN, out));
     handle = out[0];
   }
 
@@ -147,7 +147,7 @@ public class DMatrix {
    * @throws XGBoostError native error
    */
   public DMatrix(BigDenseMatrix matrix) throws XGBoostError {
-    this(matrix, 0.0f);
+    this(matrix, Float.NaN);
   }
 
   /**


### PR DESCRIPTION
#11221
This PR updates the default missing value to NaN for consistency in the JVM package and across bindings.

In the JVM package, the DMatrix is sometimes instantiated with the missing value set to 0 ([reference](https://github.com/dmlc/xgboost/blob/88c8d1ae59e48f49adec9c94dcb9e617fee70b13/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java#L139)) and sometimes as NaN ([reference](https://github.com/dmlc/xgboost/blob/88c8d1ae59e48f49adec9c94dcb9e617fee70b13/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/DMatrix.java#L92)).
This inconsistency occurs only in the Java part. In Scala, the missing value is always set to NaN ([reference](https://github.com/dmlc/xgboost/blob/88c8d1ae59e48f49adec9c94dcb9e617fee70b13/jvm-packages/xgboost4j/src/main/scala/ml/dmlc/xgboost4j/scala/DMatrix.scala)).