### PR TITLE
[R] Add 'label' to list of recognized removals for xgb.cv

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -576,6 +576,8 @@ deprecated_train_params <- list(
   ),
   removed = character()
 )
+deprecated_cv_params <- deprecated_train_params
+deprecated_cv_params$removed <- 'label'
 deprecated_xgboost_params <- list(
   renamed = list(
     'data' = 'x',

--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -110,7 +110,7 @@ xgb.cv <- function(params = xgb.params(), data, nrounds, nfold,
                    objective = NULL, custom_metric = NULL, stratified = "auto",
                    folds = NULL, train_folds = NULL, verbose = TRUE, print_every_n = 1L,
                    early_stopping_rounds = NULL, maximize = NULL, callbacks = list(), ...) {
-  check.deprecation(deprecated_train_params, match.call(), ...)
+  check.deprecation(deprecated_cv_params, match.call(), ...)
 
   stopifnot(inherits(data, "xgb.DMatrix"))
   if (inherits(data, "xgb.DMatrix") && .Call(XGCheckNullPtr_R, data)) {


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/issues/9810

This PR adds argument "label", which previously was accepted by `xgb.cv`, to the list of recognized removed arguments that issue informative warnings/errors.