### PR TITLE
[doc] Add warnings about distributed training OS support. [skip ci]

### DIFF
--- a/doc/tutorials/dask.rst
+++ b/doc/tutorials/dask.rst
@@ -11,6 +11,10 @@ algorithms.  For an overview of GPU based training and internal workings, see `A
 Official Dask API for XGBoost
 <https://medium.com/rapids-ai/a-new-official-dask-api-for-xgboost-e8b10f3d1eb7>`_.
 
+.. note::
+
+  The integration is not tested with Windows.
+
 **Contents**
 
 .. contents::

--- a/doc/tutorials/spark_estimator.rst
+++ b/doc/tutorials/spark_estimator.rst
@@ -6,7 +6,7 @@ Starting from version 1.7.0, xgboost supports pyspark estimator APIs.
 
 .. note::
 
-   The feature is still experimental and not yet ready for production use.
+  The integration is only tested on Linux distributions.
 
 .. contents::
   :backlinks: none


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/11067 .

I won't add additional checks in XGBoost and will defer these support status checks in upstream libraries.

For reference, XGBoost Dask CPU should work on Windows, we run tests on Windows for the collective module in XGBoost (rabit), but I don't think we will get a Windows cluster. GPU is not supported there due to NCCL.