### PR TITLE
[DASK] Avoid persisting intermediate result

### DIFF
--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -396,8 +396,7 @@ class DaskDMatrix:
             pandas equivalents.
 
             """
-            d = client.persist(d)
-            delayed_obj = d.to_delayed()
+            delayed_obj = d.to_delayed(optimize_graph=False)
             if isinstance(delayed_obj, numpy.ndarray):
                 # da.Array returns an array to delayed objects
                 check_columns(delayed_obj)


### PR DESCRIPTION
This PR avoids persisting (materializing) an intermediate result during creation of the DMatrix. This materialization step could otherwise lead to a temporary increase in the memory footprint.