### PR TITLE
[R] Restric threads in DMatrix creation from examples and tests

### DIFF
--- a/R-package/R/utils.R
+++ b/R-package/R/utils.R
@@ -485,7 +485,7 @@ xgb.createFolds <- function(y, k) {
 #' data(agaricus.train, package = "xgboost")
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(agaricus.train$data, label = agaricus.train$label),
+#'   data = xgb.DMatrix(agaricus.train$data, label = agaricus.train$label, nthread = 1),
 #'   nrounds = 2,
 #'   params = xgb.params(
 #'     max_depth = 2,

--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -265,7 +265,7 @@ xgb.get.handle <- function(object) {
 #' test <- agaricus.test
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(train$data, label = train$label),
+#'   data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
 #'   nrounds = 5,
 #'   params = xgb.params(
 #'     max_depth = 2,
@@ -309,7 +309,7 @@ xgb.get.handle <- function(object) {
 #' set.seed(11)
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb),
+#'   data = xgb.DMatrix(as.matrix(iris[, -5], nthread = 1), label = lb),
 #'   nrounds = 10,
 #'   params = xgb.params(
 #'     max_depth = 4,
@@ -332,7 +332,7 @@ xgb.get.handle <- function(object) {
 #' set.seed(11)
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb),
+#'   data = xgb.DMatrix(as.matrix(iris[, -5], nthread = 1), label = lb),
 #'   nrounds = 10,
 #'   params = xgb.params(
 #'     max_depth = 4,
@@ -664,7 +664,7 @@ validate.features <- function(bst, newdata) {
 #' train <- agaricus.train
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(train$data, label = train$label),
+#'   data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
 #'   nrounds = 2,
 #'   params = xgb.params(
 #'     max_depth = 2,
@@ -771,7 +771,7 @@ xgb.attributes <- function(object) {
 #' train <- agaricus.train
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(train$data, label = train$label),
+#'   data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
 #'   nrounds = 2,
 #'   params = xgb.params(
 #'     max_depth = 2,
@@ -825,7 +825,7 @@ xgb.config <- function(object) {
 #' train <- agaricus.train
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(train$data, label = train$label),
+#'   data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
 #'   nrounds = 2,
 #'   params = xgb.params(
 #'     max_depth = 2,
@@ -1276,7 +1276,7 @@ xgb.is.same.Booster <- function(obj1, obj2) {
 #' train <- agaricus.train
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(train$data, label = train$label),
+#'   data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
 #'   nrounds = 2,
 #'   params = xgb.params(
 #'     max_depth = 2,

--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -99,7 +99,7 @@
 #' )
 #' fname <- file.path(tempdir(), "xgb.DMatrix.data")
 #' xgb.DMatrix.save(dtrain, fname)
-#' dtrain <- xgb.DMatrix(fname)
+#' dtrain <- xgb.DMatrix(fname, nthread = 1)
 #' @export
 #' @rdname xgb.DMatrix
 xgb.DMatrix <- function(

--- a/R-package/R/xgb.DMatrix.save.R
+++ b/R-package/R/xgb.DMatrix.save.R
@@ -12,7 +12,7 @@
 #' dtrain <- with(agaricus.train, xgb.DMatrix(data, label = label, nthread = 2))
 #' fname <- file.path(tempdir(), "xgb.DMatrix.data")
 #' xgb.DMatrix.save(dtrain, fname)
-#' dtrain <- xgb.DMatrix(fname)
+#' dtrain <- xgb.DMatrix(fname, nthread = 1)
 #' @export
 xgb.DMatrix.save <- function(dmatrix, fname) {
   if (typeof(fname) != "character")

--- a/R-package/R/xgb.create.features.R
+++ b/R-package/R/xgb.create.features.R
@@ -67,10 +67,10 @@
 #'
 #' # learning with new features
 #' new.dtrain <- xgb.DMatrix(
-#'   data = new.features.train, label = agaricus.train$label
+#'   data = new.features.train, label = agaricus.train$label, nthread = 1
 #' )
 #' new.dtest <- xgb.DMatrix(
-#'   data = new.features.test, label = agaricus.test$label
+#'   data = new.features.test, label = agaricus.test$label, nthread = 1
 #' )
 #' bst <- xgb.train(params = param, data = new.dtrain, nrounds = nrounds)
 #'

--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -310,7 +310,7 @@ xgb.cv <- function(params = xgb.params(), data, nrounds, nfold,
 #'
 #' train <- agaricus.train
 #' cv <- xgb.cv(
-#'   data = xgb.DMatrix(train$data, label = train$label),
+#'   data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
 #'   nfold = 5,
 #'   nrounds = 2,
 #'   params = xgb.params(

--- a/R-package/R/xgb.dump.R
+++ b/R-package/R/xgb.dump.R
@@ -30,7 +30,7 @@
 #' test <- agaricus.test
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(train$data, label = train$label),
+#'   data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
 #'   nrounds = 2,
 #'   params = xgb.params(
 #'     max_depth = 2,

--- a/R-package/R/xgb.load.R
+++ b/R-package/R/xgb.load.R
@@ -31,7 +31,7 @@
 #' test <- agaricus.test
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(train$data, label = train$label),
+#'   data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
 #'   nrounds = 2,
 #'   params = xgb.params(
 #'     max_depth = 2,

--- a/R-package/R/xgb.model.dt.tree.R
+++ b/R-package/R/xgb.model.dt.tree.R
@@ -43,7 +43,7 @@
 #' data.table::setDTthreads(nthread)
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(agaricus.train$data, label = agaricus.train$label),
+#'   data = xgb.DMatrix(agaricus.train$data, label = agaricus.train$label, nthread = 1),
 #'   nrounds = 2,
 #'   params = xgb.params(
 #'     max_depth = 2,

--- a/R-package/R/xgb.save.R
+++ b/R-package/R/xgb.save.R
@@ -43,7 +43,7 @@
 #' test <- agaricus.test
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(train$data, label = train$label),
+#'   data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
 #'   nrounds = 2,
 #'   params = xgb.params(
 #'     max_depth = 2,

--- a/R-package/R/xgb.save.raw.R
+++ b/R-package/R/xgb.save.raw.R
@@ -22,7 +22,7 @@
 #' test <- agaricus.test
 #'
 #' bst <- xgb.train(
-#'   data = xgb.DMatrix(train$data, label = train$label),
+#'   data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
 #'   nrounds = 2,
 #'   params = xgb.params(
 #'     max_depth = 2,

--- a/R-package/man/a-compatibility-note-for-saveRDS-save.Rd
+++ b/R-package/man/a-compatibility-note-for-saveRDS-save.Rd
@@ -80,7 +80,7 @@ For more details and explanation about model persistence and archival, consult t
 data(agaricus.train, package = "xgboost")
 
 bst <- xgb.train(
-  data = xgb.DMatrix(agaricus.train$data, label = agaricus.train$label),
+  data = xgb.DMatrix(agaricus.train$data, label = agaricus.train$label, nthread = 1),
   nrounds = 2,
   params = xgb.params(
     max_depth = 2,

--- a/R-package/man/predict.xgb.Booster.Rd
+++ b/R-package/man/predict.xgb.Booster.Rd
@@ -224,7 +224,7 @@ train <- agaricus.train
 test <- agaricus.test
 
 bst <- xgb.train(
-  data = xgb.DMatrix(train$data, label = train$label),
+  data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
   nrounds = 5,
   params = xgb.params(
     max_depth = 2,
@@ -268,7 +268,7 @@ num_class <- 3
 set.seed(11)
 
 bst <- xgb.train(
-  data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb),
+  data = xgb.DMatrix(as.matrix(iris[, -5], nthread = 1), label = lb),
   nrounds = 10,
   params = xgb.params(
     max_depth = 4,
@@ -291,7 +291,7 @@ sum(pred_labels != lb) / length(lb)
 set.seed(11)
 
 bst <- xgb.train(
-  data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb),
+  data = xgb.DMatrix(as.matrix(iris[, -5], nthread = 1), label = lb),
   nrounds = 10,
   params = xgb.params(
     max_depth = 4,

--- a/R-package/man/print.xgb.Booster.Rd
+++ b/R-package/man/print.xgb.Booster.Rd
@@ -22,7 +22,7 @@ data(agaricus.train, package = "xgboost")
 train <- agaricus.train
 
 bst <- xgb.train(
-  data = xgb.DMatrix(train$data, label = train$label),
+  data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
   nrounds = 2,
   params = xgb.params(
     max_depth = 2,

--- a/R-package/man/print.xgb.cv.Rd
+++ b/R-package/man/print.xgb.cv.Rd
@@ -25,7 +25,7 @@ data(agaricus.train, package = "xgboost")
 
 train <- agaricus.train
 cv <- xgb.cv(
-  data = xgb.DMatrix(train$data, label = train$label),
+  data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
   nfold = 5,
   nrounds = 2,
   params = xgb.params(

--- a/R-package/man/xgb.DMatrix.Rd
+++ b/R-package/man/xgb.DMatrix.Rd
@@ -190,5 +190,5 @@ dtrain <- with(
 )
 fname <- file.path(tempdir(), "xgb.DMatrix.data")
 xgb.DMatrix.save(dtrain, fname)
-dtrain <- xgb.DMatrix(fname)
+dtrain <- xgb.DMatrix(fname, nthread = 1)
 }

--- a/R-package/man/xgb.DMatrix.save.Rd
+++ b/R-package/man/xgb.DMatrix.save.Rd
@@ -21,5 +21,5 @@ data(agaricus.train, package = "xgboost")
 dtrain <- with(agaricus.train, xgb.DMatrix(data, label = label, nthread = 2))
 fname <- file.path(tempdir(), "xgb.DMatrix.data")
 xgb.DMatrix.save(dtrain, fname)
-dtrain <- xgb.DMatrix(fname)
+dtrain <- xgb.DMatrix(fname, nthread = 1)
 }

--- a/R-package/man/xgb.attr.Rd
+++ b/R-package/man/xgb.attr.Rd
@@ -65,7 +65,7 @@ data(agaricus.train, package = "xgboost")
 train <- agaricus.train
 
 bst <- xgb.train(
-  data = xgb.DMatrix(train$data, label = train$label),
+  data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
   nrounds = 2,
   params = xgb.params(
     max_depth = 2,

--- a/R-package/man/xgb.config.Rd
+++ b/R-package/man/xgb.config.Rd
@@ -36,7 +36,7 @@ data.table::setDTthreads(nthread)
 train <- agaricus.train
 
 bst <- xgb.train(
-  data = xgb.DMatrix(train$data, label = train$label),
+  data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
   nrounds = 2,
   params = xgb.params(
     max_depth = 2,

--- a/R-package/man/xgb.create.features.Rd
+++ b/R-package/man/xgb.create.features.Rd
@@ -77,10 +77,10 @@ new.features.test <- xgb.create.features(model = bst, agaricus.test$data)
 
 # learning with new features
 new.dtrain <- xgb.DMatrix(
-  data = new.features.train, label = agaricus.train$label
+  data = new.features.train, label = agaricus.train$label, nthread = 1
 )
 new.dtest <- xgb.DMatrix(
-  data = new.features.test, label = agaricus.test$label
+  data = new.features.test, label = agaricus.test$label, nthread = 1
 )
 bst <- xgb.train(params = param, data = new.dtrain, nrounds = nrounds)
 

--- a/R-package/man/xgb.dump.Rd
+++ b/R-package/man/xgb.dump.Rd
@@ -64,7 +64,7 @@ train <- agaricus.train
 test <- agaricus.test
 
 bst <- xgb.train(
-  data = xgb.DMatrix(train$data, label = train$label),
+  data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
   nrounds = 2,
   params = xgb.params(
     max_depth = 2,

--- a/R-package/man/xgb.load.Rd
+++ b/R-package/man/xgb.load.Rd
@@ -37,7 +37,7 @@ train <- agaricus.train
 test <- agaricus.test
 
 bst <- xgb.train(
-  data = xgb.DMatrix(train$data, label = train$label),
+  data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
   nrounds = 2,
   params = xgb.params(
     max_depth = 2,

--- a/R-package/man/xgb.model.dt.tree.Rd
+++ b/R-package/man/xgb.model.dt.tree.Rd
@@ -72,7 +72,7 @@ nthread <- 1
 data.table::setDTthreads(nthread)
 
 bst <- xgb.train(
-  data = xgb.DMatrix(agaricus.train$data, label = agaricus.train$label),
+  data = xgb.DMatrix(agaricus.train$data, label = agaricus.train$label, nthread = 1),
   nrounds = 2,
   params = xgb.params(
     max_depth = 2,

--- a/R-package/man/xgb.model.parameters.Rd
+++ b/R-package/man/xgb.model.parameters.Rd
@@ -35,7 +35,7 @@ data(agaricus.train, package = "xgboost")
 train <- agaricus.train
 
 bst <- xgb.train(
-  data = xgb.DMatrix(train$data, label = train$label),
+  data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
   nrounds = 2,
   params = xgb.params(
     max_depth = 2,

--- a/R-package/man/xgb.save.Rd
+++ b/R-package/man/xgb.save.Rd
@@ -51,7 +51,7 @@ train <- agaricus.train
 test <- agaricus.test
 
 bst <- xgb.train(
-  data = xgb.DMatrix(train$data, label = train$label),
+  data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
   nrounds = 2,
   params = xgb.params(
     max_depth = 2,

--- a/R-package/man/xgb.save.raw.Rd
+++ b/R-package/man/xgb.save.raw.Rd
@@ -33,7 +33,7 @@ train <- agaricus.train
 test <- agaricus.test
 
 bst <- xgb.train(
-  data = xgb.DMatrix(train$data, label = train$label),
+  data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
   nrounds = 2,
   params = xgb.params(
     max_depth = 2,

--- a/R-package/tests/helper_scripts/generate_models.R
+++ b/R-package/tests/helper_scripts/generate_models.R
@@ -40,7 +40,7 @@ generate_regression_model <- function() {
   print('Regression')
   y <- rnorm(metadata$kRows)
 
-  data <- xgb.DMatrix(X, label = y)
+  data <- xgb.DMatrix(X, label = y, nthread = 1)
   params <- list(tree_method = 'hist', num_parallel_tree = metadata$kForests,
                  max_depth = metadata$kMaxDepth)
   booster <- xgb.train(params, data, nrounds = metadata$kRounds)
@@ -56,7 +56,7 @@ generate_logistic_model <- function() {
   name <- c('logit', 'logitraw')
 
   for (i in seq_len(length(objective))) {
-    data <- xgb.DMatrix(X, label = y, weight = w)
+    data <- xgb.DMatrix(X, label = y, weight = w, nthread = 1)
     params <- list(tree_method = 'hist', num_parallel_tree = metadata$kForests,
                    max_depth = metadata$kMaxDepth, objective = objective[i])
     booster <- xgb.train(params, data, nrounds = metadata$kRounds)
@@ -69,7 +69,7 @@ generate_classification_model <- function() {
   y <- sample(0:(metadata$kClasses - 1), size = metadata$kRows, replace = TRUE)
   stopifnot(max(y) == metadata$kClasses - 1, min(y) == 0)
 
-  data <- xgb.DMatrix(X, label = y, weight = w)
+  data <- xgb.DMatrix(X, label = y, weight = w, nthread = 1)
   params <- list(num_class = metadata$kClasses, tree_method = 'hist',
                  num_parallel_tree = metadata$kForests, max_depth = metadata$kMaxDepth,
                  objective = 'multi:softmax')
@@ -85,7 +85,7 @@ generate_ranking_model <- function() {
   w <- runif(kGroups)
   g <- rep(50, times = kGroups)
 
-  data <- xgb.DMatrix(X, label = y, group = g)
+  data <- xgb.DMatrix(X, label = y, group = g, nthread = 1)
   # setinfo(data, 'weight', w)
   # ^^^ does not work in version <= 1.1.0; see https://github.com/dmlc/xgboost/issues/5942
   # So call low-level function XGDMatrixSetInfo_R directly. Since this function is not an exported

--- a/R-package/tests/testthat/test_basic.R
+++ b/R-package/tests/testthat/test_basic.R
@@ -17,7 +17,7 @@ test_that("train and predict binary classification", {
   nrounds <- 2
   expect_output(
     bst <- xgb.train(
-      data = xgb.DMatrix(train$data, label = train$label),
+      data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
       nrounds = nrounds,
       params = xgb.params(
         max_depth = 2,
@@ -26,7 +26,7 @@ test_that("train and predict binary classification", {
         objective = "binary:logistic",
         eval_metric = "error"
       ),
-      evals = list(train = xgb.DMatrix(train$data, label = train$label))
+      evals = list(train = xgb.DMatrix(train$data, label = train$label, nthread = 1))
     ),
     "train-error"
   )
@@ -109,7 +109,7 @@ test_that("dart prediction works", {
 
   set.seed(1994)
   booster_by_xgboost <- xgb.train(
-    data = xgb.DMatrix(d, label = y),
+    data = xgb.DMatrix(d, label = y, nthread = 1),
     nrounds = nrounds,
     params = xgb.params(
       max_depth = 2,
@@ -157,13 +157,13 @@ test_that("train and predict softprob", {
   set.seed(11)
   expect_output(
     bst <- xgb.train(
-      data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb),
+      data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb, nthread = 1),
       nrounds = 5,
       params = xgb.params(
         max_depth = 3, learning_rate = 0.5, nthread = n_threads,
         objective = "multi:softprob", num_class = 3, eval_metric = "merror"
       ),
-      evals = list(train = xgb.DMatrix(as.matrix(iris[, -5]), label = lb))
+      evals = list(train = xgb.DMatrix(as.matrix(iris[, -5]), label = lb, nthread = 1))
     ),
     "train-merror"
   )
@@ -216,13 +216,13 @@ test_that("train and predict softmax", {
   set.seed(11)
   expect_output(
     bst <- xgb.train(
-      data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb),
+      data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb, nthread = 1),
       nrounds = 5,
       params = xgb.params(
         max_depth = 3, learning_rate = 0.5, nthread = n_threads,
         objective = "multi:softmax", num_class = 3, eval_metric = "merror"
       ),
-      evals = list(train = xgb.DMatrix(as.matrix(iris[, -5]), label = lb))
+      evals = list(train = xgb.DMatrix(as.matrix(iris[, -5]), label = lb, nthread = 1))
     ),
     "train-merror"
   )
@@ -241,7 +241,7 @@ test_that("train and predict RF", {
   lb <- train$label
   # single iteration
   bst <- xgb.train(
-    data = xgb.DMatrix(train$data, label = lb),
+    data = xgb.DMatrix(train$data, label = lb, nthread = 1),
     nrounds = 1,
     params = xgb.params(
       max_depth = 5,
@@ -249,7 +249,7 @@ test_that("train and predict RF", {
       objective = "binary:logistic", eval_metric = "error",
       num_parallel_tree = 20, subsample = 0.6, colsample_bytree = 0.1
     ),
-    evals = list(train = xgb.DMatrix(train$data, label = lb)),
+    evals = list(train = xgb.DMatrix(train$data, label = lb, nthread = 1)),
     verbose = 0
   )
   expect_equal(xgb.get.num.boosted.rounds(bst), 1)
@@ -269,7 +269,7 @@ test_that("train and predict RF with softprob", {
   nrounds <- 15
   set.seed(11)
   bst <- xgb.train(
-    data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb),
+    data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb, nthread = 1),
     nrounds = nrounds,
     verbose = 0,
     params = xgb.params(
@@ -283,7 +283,7 @@ test_that("train and predict RF with softprob", {
       subsample = 0.5,
       colsample_bytree = 0.5
     ),
-    evals = list(train = xgb.DMatrix(as.matrix(iris[, -5]), label = lb))
+    evals = list(train = xgb.DMatrix(as.matrix(iris[, -5]), label = lb, nthread = 1))
   )
   expect_equal(xgb.get.num.boosted.rounds(bst), 15)
   # predict for all iterations:
@@ -301,14 +301,14 @@ test_that("train and predict RF with softprob", {
 test_that("use of multiple eval metrics works", {
   expect_output(
     bst <- xgb.train(
-      data = xgb.DMatrix(train$data, label = train$label),
+      data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
       nrounds = 2,
       params = list(
         max_depth = 2,
         learning_rate = 1, nthread = n_threads, objective = "binary:logistic",
         eval_metric = "error", eval_metric = "auc", eval_metric = "logloss"
       ),
-      evals = list(train = xgb.DMatrix(train$data, label = train$label))
+      evals = list(train = xgb.DMatrix(train$data, label = train$label, nthread = 1))
     ),
     "train-error.*train-auc.*train-logloss"
   )
@@ -317,7 +317,7 @@ test_that("use of multiple eval metrics works", {
   expect_equal(colnames(attributes(bst)$evaluation_log), c("iter", "train_error", "train_auc", "train_logloss"))
   expect_output(
     bst2 <- xgb.train(
-      data = xgb.DMatrix(train$data, label = train$label),
+      data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
       nrounds = 2,
       params = xgb.params(
         max_depth = 2,
@@ -326,7 +326,7 @@ test_that("use of multiple eval metrics works", {
         objective = "binary:logistic",
         eval_metric = list("error", "auc", "logloss")
       ),
-      evals = list(train = xgb.DMatrix(train$data, label = train$label))
+      evals = list(train = xgb.DMatrix(train$data, label = train$label, nthread = 1))
     ),
     "train-error.*train-auc.*train-logloss"
   )
@@ -377,7 +377,7 @@ test_that("xgb.cv works", {
   set.seed(11)
   expect_output(
     cv <- xgb.cv(
-      data = xgb.DMatrix(train$data, label = train$label),
+      data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
       nfold = 5,
       nrounds = 2,
       params = xgb.params(
@@ -436,7 +436,7 @@ test_that("train and predict with non-strict classes", {
   # standard dense matrix input
   train_dense <- as.matrix(train$data)
   bst <- xgb.train(
-    data = xgb.DMatrix(train_dense, label = train$label),
+    data = xgb.DMatrix(train_dense, label = train$label, nthread = 1),
     nrounds = 2,
     params = xgb.params(
       max_depth = 2,
@@ -452,7 +452,7 @@ test_that("train and predict with non-strict classes", {
   expect_true(is.matrix(train_dense))
   expect_error(
     bst <- xgb.train(
-      data = xgb.DMatrix(train_dense, label = train$label),
+      data = xgb.DMatrix(train_dense, label = train$label, nthread = 1),
       nrounds = 2,
       params = xgb.params(
         max_depth = 2,
@@ -471,7 +471,7 @@ test_that("train and predict with non-strict classes", {
   expect_true(is.matrix(train_dense))
   expect_error(
     bst <- xgb.train(
-      data = xgb.DMatrix(train_dense, label = train$label),
+      data = xgb.DMatrix(train_dense, label = train$label, nthread = 1),
       nrounds = 2,
       params = xgb.params(
         max_depth = 2,
@@ -540,7 +540,7 @@ test_that("colsample_bytree works", {
 
 test_that("Configuration works", {
   bst <- xgb.train(
-    data = xgb.DMatrix(train$data, label = train$label),
+    data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
     nrounds = 2,
     params = xgb.params(
       max_depth = 2,
@@ -595,7 +595,7 @@ test_that("strict_shape works", {
     X <- as.matrix(iris[, -5])
 
     bst <- xgb.train(
-      data = xgb.DMatrix(X, label = y),
+      data = xgb.DMatrix(X, label = y, nthread = 1),
       nrounds = n_rounds,
       params = xgb.params(
         max_depth = 2, nthread = n_threads,
@@ -613,7 +613,7 @@ test_that("strict_shape works", {
     y <- agaricus.train$label
 
     bst <- xgb.train(
-      data = xgb.DMatrix(X, label = y),
+      data = xgb.DMatrix(X, label = y, nthread = 1),
       nrounds = n_rounds,
       params = xgb.params(
         max_depth = 2, nthread = n_threads,
@@ -635,7 +635,7 @@ test_that("'predict' accepts CSR data", {
   x_csr <- as(x_csc, "RsparseMatrix")
   x_spv <- as(x_csc, "sparseVector")
   bst <- xgb.train(
-    data = xgb.DMatrix(X, label = y),
+    data = xgb.DMatrix(X, label = y, nthread = 1),
     nrounds = 5L, verbose = FALSE,
     params = xgb.params(
       objective = "binary:logistic",
@@ -653,7 +653,7 @@ test_that("Quantile regression accepts multiple quantiles", {
   data(mtcars)
   y <- mtcars[, 1]
   x <- as.matrix(mtcars[, -1])
-  dm <- xgb.DMatrix(data = x, label = y)
+  dm <- xgb.DMatrix(data = x, label = y, nthread = 1)
   model <- xgb.train(
     data = dm,
     params = xgb.params(
@@ -734,8 +734,8 @@ test_that("Can use ranking objectives with either 'qid' or 'group'", {
   qid <- c(rep(1, 20), rep(2, 20), rep(3, 60))
   gr <- c(20, 20, 60)
 
-  dmat_qid <- xgb.DMatrix(x, label = y, qid = qid)
-  dmat_gr <- xgb.DMatrix(x, label = y, group = gr)
+  dmat_qid <- xgb.DMatrix(x, label = y, qid = qid, nthread = 1)
+  dmat_gr <- xgb.DMatrix(x, label = y, group = gr, nthread = 1)
 
   params <- xgb.params(
     tree_method = "hist",
@@ -770,7 +770,7 @@ test_that("Can predict on data.frame objects", {
     nrounds = 5
   )
 
-  pred_mat <- predict(model, xgb.DMatrix(x_mat))
+  pred_mat <- predict(model, xgb.DMatrix(x_mat, nthread = 1))
   pred_df <- predict(model, x_df)
   expect_equal(pred_mat, unname(pred_df))
 })
@@ -792,7 +792,7 @@ test_that("'base_margin' gives the same result in DMatrix as in inplace_predict"
 
   set.seed(123)
   base_margin <- rnorm(nrow(x))
-  dm_w_base <- xgb.DMatrix(data = x, base_margin = base_margin)
+  dm_w_base <- xgb.DMatrix(data = x, base_margin = base_margin, nthread = 1)
   pred_from_dm <- predict(model, dm_w_base)
   pred_from_mat <- predict(model, x, base_margin = base_margin)
 
@@ -913,7 +913,7 @@ test_that("DMatrix field are set to booster when training", {
 
   dm_unnamed <- xgb.DMatrix(x, label = y, nthread = 1)
   dm_feature_names <- xgb.DMatrix(x, label = y, feature_names = c("a", "b", "c"), nthread = 1)
-  dm_feature_types <- xgb.DMatrix(x, label = y)
+  dm_feature_types <- xgb.DMatrix(x, label = y, nthread = 1)
   setinfo(dm_feature_types, "feature_type", c("q", "c", "q"))
   dm_both <- xgb.DMatrix(x, label = y, feature_names = c("a", "b", "c"), nthread = 1)
   setinfo(dm_both, "feature_type", c("q", "c", "q"))
@@ -1041,7 +1041,7 @@ test_that("xgb.cv works for ranking", {
   x <- iris[, -(4:5)]
   y <- as.integer(iris$Petal.Width)
   group <- rep(50, 3)
-  dm <- xgb.DMatrix(x, label = y, group = group)
+  dm <- xgb.DMatrix(x, label = y, group = group, nthread = 1)
   res <- xgb.cv(
     data = dm,
     params = xgb.params(
@@ -1081,7 +1081,7 @@ test_that("Row names are preserved in outputs", {
   data(mtcars)
   y <- mtcars[, 1]
   x <- as.matrix(mtcars[, -1])
-  dm <- xgb.DMatrix(data = x, label = y)
+  dm <- xgb.DMatrix(data = x, label = y, nthread = 1)
   model <- xgb.train(
     data = dm,
     params = xgb.params(

--- a/R-package/tests/testthat/test_callbacks.R
+++ b/R-package/tests/testthat/test_callbacks.R
@@ -327,7 +327,7 @@ test_that("early stopping works with titanic", {
   dty <- titanic$Survived
 
   xgb.train(
-    data = xgb.DMatrix(dtx, label = dty),
+    data = xgb.DMatrix(dtx, label = dty, nthread = 1),
     params = xgb.params(
       objective = "binary:logistic",
       eval_metric = "auc",
@@ -336,7 +336,7 @@ test_that("early stopping works with titanic", {
     nrounds = 100,
     early_stopping_rounds = 3,
     verbose = 0,
-    evals = list(train = xgb.DMatrix(dtx, label = dty))
+    evals = list(train = xgb.DMatrix(dtx, label = dty, nthread = 1))
   )
 
   expect_true(TRUE)  # should not crash
@@ -426,7 +426,7 @@ test_that("prediction in xgb.cv for softprob works", {
   expect_warning(
     {
       cv <- xgb.cv(
-        data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb),
+        data = xgb.DMatrix(as.matrix(iris[, -5]), label = lb, nthread = 1),
         nfold = 4,
         nrounds = 5,
         params = xgb.params(

--- a/R-package/tests/testthat/test_custom_objective.R
+++ b/R-package/tests/testthat/test_custom_objective.R
@@ -133,7 +133,7 @@ test_that("custom objective with multi-class works", {
   data <- as.matrix(iris[, -5])
   label <- as.numeric(iris$Species) - 1
 
-  dtrain <- xgb.DMatrix(data = data, label = label)
+  dtrain <- xgb.DMatrix(data = data, label = label, nthread = 1)
 
   param$num_class <- 3
   param$objective <- softprob
@@ -153,7 +153,7 @@ test_that("custom objective with multi-class works", {
 test_that("custom metric with multi-target passes reshaped data to feval", {
   x <- as.matrix(iris[, -5])
   y <- as.numeric(iris$Species) - 1
-  dtrain <- xgb.DMatrix(data = x, label = y)
+  dtrain <- xgb.DMatrix(data = x, label = y, nthread = 1)
 
   multinomial.ll <- function(predt, dtrain) {
     expect_equal(dim(predt), c(nrow(iris), 3L))

--- a/R-package/tests/testthat/test_dmatrix.R
+++ b/R-package/tests/testthat/test_dmatrix.R
@@ -104,9 +104,9 @@ test_that("xgb.DMatrix: saving, loading", {
   expect_true(xgb.DMatrix.save(dtest1, tmp_file))
   # read from a local file
   xgb.set.config(verbosity = 2)
-  expect_output(dtest3 <- xgb.DMatrix(tmp_file), "entries loaded from")
+  expect_output(dtest3 <- xgb.DMatrix(tmp_file, nthread = 1), "entries loaded from")
   xgb.set.config(verbosity = 1)
-  expect_output(dtest3 <- xgb.DMatrix(tmp_file), NA)
+  expect_output(dtest3 <- xgb.DMatrix(tmp_file, nthread = 1), NA)
   unlink(tmp_file)
   expect_equal(getinfo(dtest1, 'label'), getinfo(dtest3, 'label'))
 
@@ -131,7 +131,7 @@ test_that("xgb.DMatrix: saving, loading", {
   tmp_file <- tempfile('xgb.DMatrix_')
   xgb.DMatrix.save(dtrain, tmp_file)
   xgb.set.config(verbosity = 0)
-  dtrain <- xgb.DMatrix(tmp_file)
+  dtrain <- xgb.DMatrix(tmp_file, nthread = 1)
   expect_equal(colnames(dtrain), cnames)
 
   ft <- rep(c("c", "q"), each = length(cnames) / 2)
@@ -350,8 +350,8 @@ test_that("xgb.DMatrix: can get group for both 'qid' and 'group' constructors", 
   group <- c(20, 20, 60)
   qid <- c(rep(1, 20), rep(2, 20), rep(3, 60))
 
-  gr_mat <- xgb.DMatrix(x, group = group)
-  qid_mat <- xgb.DMatrix(x, qid = qid)
+  gr_mat <- xgb.DMatrix(x, group = group, nthread = 1)
+  qid_mat <- xgb.DMatrix(x, qid = qid, nthread = 1)
 
   info_gr <- getinfo(gr_mat, "group")
   info_qid <- getinfo(qid_mat, "group")
@@ -372,7 +372,7 @@ test_that("xgb.DMatrix: data.frame", {
     stringsAsFactors = TRUE
   )
 
-  m <- xgb.DMatrix(df)
+  m <- xgb.DMatrix(df, nthread = 1)
   expect_equal(colnames(m), colnames(df))
   expect_equal(
     getinfo(m, "feature_type"), c("float", "float", "int", "i", "c", "c")
@@ -383,7 +383,7 @@ test_that("xgb.DMatrix: data.frame", {
     valid = c("a", "b", "d", "c"),
     stringsAsFactors = TRUE
   )
-  m <- xgb.DMatrix(df)
+  m <- xgb.DMatrix(df, nthread = 1)
   expect_equal(getinfo(m, "feature_type"), c("c", "c"))
 })
 
@@ -406,7 +406,7 @@ test_that("xgb.DMatrix: can take multi-dimensional 'base_margin'", {
   pred_only_x <- predict(model, x)
   pred_w_base <- predict(
     model,
-    xgb.DMatrix(data = x, base_margin = b)
+    xgb.DMatrix(data = x, base_margin = b, nthread = 1)
   )
   expect_equal(pred_only_x, pred_w_base - b, tolerance = 1e-5)
 })
@@ -491,7 +491,7 @@ test_that("xgb.DMatrix: ExtMemDMatrix produces the same results as regular DMatr
     nthread = n_threads
   )
   model <- xgb.train(
-    data = xgb.DMatrix(x, label = y),
+    data = xgb.DMatrix(x, label = y, nthread = 1),
     params = params,
     nrounds = 5
   )
@@ -670,18 +670,18 @@ test_that("xgb.DMatrix: R errors thrown on DataIterator are thrown back to the u
 
 test_that("xgb.DMatrix: number of non-missing matches data", {
   x <- matrix(1:10, nrow = 5)
-  dm1 <- xgb.DMatrix(x)
+  dm1 <- xgb.DMatrix(x, nthread = 1)
   expect_equal(xgb.get.DMatrix.num.non.missing(dm1), 10)
 
   x[2, 2] <- NA
   x[4, 1] <- NA
-  dm2 <- xgb.DMatrix(x)
+  dm2 <- xgb.DMatrix(x, nthread = 1)
   expect_equal(xgb.get.DMatrix.num.non.missing(dm2), 8)
 })
 
 test_that("xgb.DMatrix: retrieving data as CSR", {
   data(mtcars)
-  dm <- xgb.DMatrix(as.matrix(mtcars))
+  dm <- xgb.DMatrix(as.matrix(mtcars), nthread = 1)
   csr <- xgb.get.DMatrix.data(dm)
   expect_equal(dim(csr), dim(mtcars))
   expect_equal(colnames(csr), colnames(mtcars))
@@ -692,7 +692,7 @@ test_that("xgb.DMatrix: quantile cuts look correct", {
   data(mtcars)
   y <- mtcars$mpg
   x <- as.matrix(mtcars[, -1])
-  dm <- xgb.DMatrix(x, label = y)
+  dm <- xgb.DMatrix(x, label = y, nthread = 1)
   model <- xgb.train(
     data = dm,
     params = list(
@@ -774,7 +774,7 @@ test_that("xgb.DMatrix: can read CSV", {
   fname <- file.path(tempdir(), "data.csv")
   writeChar(txt, fname)
   uri <- paste0(fname, "?format=csv&label_column=0")
-  dm <- xgb.DMatrix(uri, silent = TRUE)
+  dm <- xgb.DMatrix(uri, silent = TRUE, nthread = 1)
   expect_equal(getinfo(dm, "label"), c(1, -1))
   expect_equal(
     as.matrix(xgb.get.DMatrix.data(dm)),

--- a/R-package/tests/testthat/test_interaction_constraints.R
+++ b/R-package/tests/testthat/test_interaction_constraints.R
@@ -14,7 +14,7 @@ train <- matrix(c(x1, x2, x3), ncol = 3)
 test_that("interaction constraints for regression", {
   # Fit a model that only allows interaction between x1 and x2
   bst <- xgb.train(
-    data = xgb.DMatrix(train, label = y),
+    data = xgb.DMatrix(train, label = y, nthread = 1),
     nrounds = 100, verbose = 0,
     params = xgb.params(
       max_depth = 3,

--- a/R-package/tests/testthat/test_interactions.R
+++ b/R-package/tests/testthat/test_interactions.R
@@ -109,7 +109,7 @@ test_that("SHAP contribution values are not NAN", {
       eval_metric = "rmse",
       nthread = n_threads
     ),
-    data = xgb.DMatrix(as.matrix(subset(d, fold == 2)[, ivs]), label = subset(d, fold == 2)$y),
+    data = xgb.DMatrix(as.matrix(subset(d, fold == 2)[, ivs]), label = subset(d, fold == 2)$y, nthread = 1),
     nrounds = 3
   )
 
@@ -159,7 +159,7 @@ test_that("SHAP single sample works", {
   train <- agaricus.train
   test <- agaricus.test
   booster <- xgb.train(
-    data = xgb.DMatrix(train$data, label = train$label),
+    data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
     nrounds = 4,
     params = xgb.params(
       max_depth = 2,

--- a/R-package/tests/testthat/test_io.R
+++ b/R-package/tests/testthat/test_io.R
@@ -8,7 +8,7 @@ test <- agaricus.test
 test_that("load/save raw works", {
   nrounds <- 8
   booster <- xgb.train(
-    data = xgb.DMatrix(train$data, label = train$label),
+    data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
     nrounds = nrounds,
     params = xgb.params(
       objective = "binary:logistic",

--- a/R-package/tests/testthat/test_monotone.R
+++ b/R-package/tests/testthat/test_monotone.R
@@ -8,7 +8,7 @@ train <- matrix(x, ncol = 1)
 
 test_that("monotone constraints for regression", {
     bst <- xgb.train(
-        data = xgb.DMatrix(train, label = y),
+        data = xgb.DMatrix(train, label = y, nthread = 1),
         nrounds = 100, verbose = 0,
         params = xgb.params(
             max_depth = 2,

--- a/R-package/tests/testthat/test_poisson_regression.R
+++ b/R-package/tests/testthat/test_poisson_regression.R
@@ -5,7 +5,7 @@ set.seed(1994)
 test_that("Poisson regression works", {
   data(mtcars)
   bst <- xgb.train(
-    data = xgb.DMatrix(as.matrix(mtcars[, -11]), label = mtcars[, 11]),
+    data = xgb.DMatrix(as.matrix(mtcars[, -11]), label = mtcars[, 11], nthread = 1),
     nrounds = 10, verbose = 0,
     params = xgb.params(objective = 'count:poisson',  nthread = 2)
   )
@@ -21,7 +21,7 @@ test_that("Poisson regression is centered around mean", {
   y <- rpois(m, n)
   x <- matrix(rnorm(m * n), nrow = m)
   model <- xgb.train(
-    data = xgb.DMatrix(x, label = y),
+    data = xgb.DMatrix(x, label = y, nthread = 1),
     params = xgb.params(objective = "count:poisson", min_split_loss = 1e4),
     nrounds = 1
   )
@@ -41,7 +41,7 @@ test_that("Poisson regression is centered around mean", {
 
   w <- y + 1
   model_weighted <- xgb.train(
-    data = xgb.DMatrix(x, label = y, weight = w),
+    data = xgb.DMatrix(x, label = y, weight = w, nthread = 1),
     params = xgb.params(objective = "count:poisson", min_split_loss = 1e4),
     nrounds = 1
   )

--- a/R-package/tests/testthat/test_unicode.R
+++ b/R-package/tests/testthat/test_unicode.R
@@ -9,7 +9,7 @@ set.seed(1994)
 test_that("Can save and load models with Unicode paths", {
   nrounds <- 2
   bst <- xgb.train(
-    data = xgb.DMatrix(train$data, label = train$label),
+    data = xgb.DMatrix(train$data, label = train$label, nthread = 1),
     nrounds = nrounds,
     params = xgb.params(
       max_depth = 2,

--- a/R-package/vignettes/xgboost_introduction.Rmd
+++ b/R-package/vignettes/xgboost_introduction.Rmd
@@ -165,7 +165,8 @@ Example usage of `xgb.train()`:
 data("agaricus.train")
 dmatrix <- xgb.DMatrix(
     data = agaricus.train$data,  # a sparse CSC matrix ('dgCMatrix')
-    label = agaricus.train$label # zeros and ones
+    label = agaricus.train$label, # zeros and ones
+    nthread = 1
 )
 booster <- xgb.train(
     data = dmatrix,
@@ -178,7 +179,7 @@ booster <- xgb.train(
 )
 
 data("agaricus.test")
-dmatrix_test <- xgb.DMatrix(agaricus.test$data)
+dmatrix_test <- xgb.DMatrix(agaricus.test$data, nthread = 1)
 pred_prob <- predict(booster, dmatrix_test)
 pred_raw <- predict(booster, dmatrix_test, outputmargin = TRUE)
 ```

--- a/R-package/vignettes/xgboostfromJSON.Rmd
+++ b/R-package/vignettes/xgboostfromJSON.Rmd
@@ -53,7 +53,7 @@ labels <- c(1, 1, 1,
 data <- data.frame(dates = dates, labels = labels)
 
 bst <- xgb.train(
-  data = xgb.DMatrix(as.matrix(data$dates), label = labels, missing = NA),
+  data = xgb.DMatrix(as.matrix(data$dates), label = labels, missing = NA, nthread = 1),
   nrounds = 1,
   params = xgb.params(
     objective = "binary:logistic",


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost/pull/11257#issuecomment-2660761981

Per the comment above, this PR modifies the calls to `xgb.DMatrix` in examples, test and vignettes to limit the amount of threads, in order to conform to CRAN policies.