### PR TITLE
Optional normalization for the ranknet loss.

### DIFF
--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -848,6 +848,7 @@ xgb.params <- function(
   lambdarank_pair_method = NULL,
   lambdarank_num_pair_per_sample = NULL,
   lambdarank_normalization = NULL,
+  lambdarank_score_normalization = NULL,
   lambdarank_unbiased = NULL,
   lambdarank_bias_norm = NULL,
   ndcg_exp_gain = NULL

--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -769,6 +769,21 @@ xgb.train <- function(params = xgb.params(), data, nrounds, evals = list(),
 #' Whether to normalize the leaf value by lambda gradient. This can sometimes stagnate the training progress.
 #'
 #' Version added: 2.1.0
+#'
+#' @param lambdarank_score_normalization
+#'
+#' Whether to normalize the delta metric by the difference of prediction scores. This can
+#' sometimes stagnate the training progress. With pairwise ranking, we can normalize the
+#' gradient using the difference between two samples in each pair to reduce influence from
+#' the pairs that have large difference in ranking scores. This can help us regularize the
+#' model to reduce bias and prevent overfitting. Similar to other regularization
+#' techniques, this might prevent training from converge.
+#'
+#' There was no normalization before 2.0. In 2.0 and later versions this is used by
+#' default. In 3.0, we made this an option that users can disable.
+#'
+#' Version added: 3.0.0
+#'
 #' @param lambdarank_unbiased (for learning to rank (`"rank:ndcg"`, `"rank:map"`, `"rank:pairwise"`)) (default = `FALSE`)
 #' Specify whether do we need to debias input click data.
 #' @param lambdarank_bias_norm (for learning to rank (`"rank:ndcg"`, `"rank:map"`, `"rank:pairwise"`)) (default = 2.0)

--- a/R-package/R/xgb.train.R
+++ b/R-package/R/xgb.train.R
@@ -777,7 +777,7 @@ xgb.train <- function(params = xgb.params(), data, nrounds, evals = list(),
 #' gradient using the difference between two samples in each pair to reduce influence from
 #' the pairs that have large difference in ranking scores. This can help us regularize the
 #' model to reduce bias and prevent overfitting. Similar to other regularization
-#' techniques, this might prevent training from converge.
+#' techniques, this might prevent training from converging.
 #'
 #' There was no normalization before 2.0. In 2.0 and later versions this is used by
 #' default. In 3.0, we made this an option that users can disable.

--- a/R-package/man/xgb.params.Rd
+++ b/R-package/man/xgb.params.Rd
@@ -519,7 +519,7 @@ sometimes stagnate the training progress. With pairwise ranking, we can normaliz
 gradient using the difference between two samples in each pair to reduce influence from
 the pairs that have large difference in ranking scores. This can help us regularize the
 model to reduce bias and prevent overfitting. Similar to other regularization
-techniques, this might prevent training from converge.
+techniques, this might prevent training from converging.
 
 There was no normalization before 2.0. In 2.0 and later versions this is used by
 default. In 3.0, we made this an option that users can disable.

--- a/R-package/man/xgb.params.Rd
+++ b/R-package/man/xgb.params.Rd
@@ -521,6 +521,18 @@ Specify whether do we need to debias input click data.}
 
 \item{ndcg_exp_gain}{(for learning to rank (\code{"rank:ndcg"}, \code{"rank:map"}, \code{"rank:pairwise"})) (default = \code{TRUE})
 Whether we should use exponential gain function for \code{NDCG}. There are two forms of gain function for \code{NDCG}, one is using relevance value directly while the other is using\eqn{2^{rel} - 1} to emphasize on retrieving relevant documents. When \code{ndcg_exp_gain} is \code{TRUE} (the default), relevance degree cannot be greater than 31.}
+
+\item{lambdarank_score_normalization}{Whether to normalize the delta metric by the difference of prediction scores. This can
+sometimes stagnate the training progress. With pairwise ranking, we can normalize the
+gradient using the difference between two samples in each pair to reduce influence from
+the pairs that have large difference in ranking scores. This can help us regularize the
+model to reduce bias and prevent overfitting. Similar to other regularization
+techniques, this might prevent training from converge.
+
+There was no normalization before 2.0. In 2.0 and later versions this is used by
+default. In 3.0, we made this an option that users can disable.
+
+Version added: 3.0.0}
 }
 \value{
 A list with the entries that were passed non-NULL values. It is intended to

--- a/R-package/man/xgb.params.Rd
+++ b/R-package/man/xgb.params.Rd
@@ -62,6 +62,7 @@ xgb.params(
   lambdarank_pair_method = NULL,
   lambdarank_num_pair_per_sample = NULL,
   lambdarank_normalization = NULL,
+  lambdarank_score_normalization = NULL,
   lambdarank_unbiased = NULL,
   lambdarank_bias_norm = NULL,
   ndcg_exp_gain = NULL
@@ -513,15 +514,6 @@ Whether to normalize the leaf value by lambda gradient. This can sometimes stagn
 
 Version added: 2.1.0}
 
-\item{lambdarank_unbiased}{(for learning to rank (\code{"rank:ndcg"}, \code{"rank:map"}, \code{"rank:pairwise"})) (default = \code{FALSE})
-Specify whether do we need to debias input click data.}
-
-\item{lambdarank_bias_norm}{(for learning to rank (\code{"rank:ndcg"}, \code{"rank:map"}, \code{"rank:pairwise"})) (default = 2.0)
-\eqn{L_p} normalization for position debiasing, default is \eqn{L_2}. Only relevant when \code{lambdarank_unbiased} is set to \code{TRUE}.}
-
-\item{ndcg_exp_gain}{(for learning to rank (\code{"rank:ndcg"}, \code{"rank:map"}, \code{"rank:pairwise"})) (default = \code{TRUE})
-Whether we should use exponential gain function for \code{NDCG}. There are two forms of gain function for \code{NDCG}, one is using relevance value directly while the other is using\eqn{2^{rel} - 1} to emphasize on retrieving relevant documents. When \code{ndcg_exp_gain} is \code{TRUE} (the default), relevance degree cannot be greater than 31.}
-
 \item{lambdarank_score_normalization}{Whether to normalize the delta metric by the difference of prediction scores. This can
 sometimes stagnate the training progress. With pairwise ranking, we can normalize the
 gradient using the difference between two samples in each pair to reduce influence from
@@ -533,6 +525,15 @@ There was no normalization before 2.0. In 2.0 and later versions this is used by
 default. In 3.0, we made this an option that users can disable.
 
 Version added: 3.0.0}
+
+\item{lambdarank_unbiased}{(for learning to rank (\code{"rank:ndcg"}, \code{"rank:map"}, \code{"rank:pairwise"})) (default = \code{FALSE})
+Specify whether do we need to debias input click data.}
+
+\item{lambdarank_bias_norm}{(for learning to rank (\code{"rank:ndcg"}, \code{"rank:map"}, \code{"rank:pairwise"})) (default = 2.0)
+\eqn{L_p} normalization for position debiasing, default is \eqn{L_2}. Only relevant when \code{lambdarank_unbiased} is set to \code{TRUE}.}
+
+\item{ndcg_exp_gain}{(for learning to rank (\code{"rank:ndcg"}, \code{"rank:map"}, \code{"rank:pairwise"})) (default = \code{TRUE})
+Whether we should use exponential gain function for \code{NDCG}. There are two forms of gain function for \code{NDCG}, one is using relevance value directly while the other is using\eqn{2^{rel} - 1} to emphasize on retrieving relevant documents. When \code{ndcg_exp_gain} is \code{TRUE} (the default), relevance degree cannot be greater than 31.}
 }
 \value{
 A list with the entries that were passed non-NULL values. It is intended to

--- a/demo/guide-python/learning_to_rank.py
+++ b/demo/guide-python/learning_to_rank.py
@@ -212,4 +212,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     ranking_demo(args)
-    click_data_demo(args)
+    # click_data_demo(args)

--- a/demo/guide-python/learning_to_rank.py
+++ b/demo/guide-python/learning_to_rank.py
@@ -212,4 +212,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     ranking_demo(args)
-    # click_data_demo(args)
+    click_data_demo(args)

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -549,7 +549,7 @@ These are parameters specific to learning to rank task. See :doc:`Learning to Ra
   gradient using the difference between two samples in each pair to reduce influence from
   the pairs that have large difference in ranking scores. This can help us regularize the
   model to reduce bias and prevent overfitting. Similar to other regularization
-  techniques, this might prevent training from converge.
+  techniques, this might prevent training from converging.
 
   There was no normalization before 2.0. In 2.0 and later versions this is used by
   default. In 3.0, we made this an option that users can disable.

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -540,11 +540,19 @@ These are parameters specific to learning to rank task. See :doc:`Learning to Ra
 
   Whether to normalize the leaf value by lambda gradient. This can sometimes stagnate the training progress.
 
-* ``lambdarank_diff_normalization`` [default = ``true``]
+* ``lambdarank_score_normalization`` [default = ``true``]
 
   .. versionadded:: 3.0.0
 
-  Whether to normalize the delta by prediction score difference. This can sometimes stagnate the training progress.
+  Whether to normalize the delta metric by the difference of prediction scores. This can
+  sometimes stagnate the training progress. With pairwise ranking, we can normalize the
+  gradient using the difference between two samples in each pair to reduce influence from
+  the pairs that have large difference in ranking scores. This can help us regularize the
+  model to reduce bias and prevent overfitting. Similar to other regularization
+  techniques, this might prevent training from converge.
+
+  There was no normalization before 2.0. In 2.0 and later versions this is used by
+  default. In 3.0, we made this an option that users can disable.
 
 *  ``lambdarank_unbiased`` [default = ``false``]
 

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -540,6 +540,12 @@ These are parameters specific to learning to rank task. See :doc:`Learning to Ra
 
   Whether to normalize the leaf value by lambda gradient. This can sometimes stagnate the training progress.
 
+* ``lambdarank_diff_normalization`` [default = ``true``]
+
+  .. versionadded:: 3.0.0
+
+  Whether to normalize the delta by prediction score difference. This can sometimes stagnate the training progress.
+
 *  ``lambdarank_unbiased`` [default = ``false``]
 
   Specify whether do we need to debias input click data.

--- a/doc/tutorials/learning_to_rank.rst
+++ b/doc/tutorials/learning_to_rank.rst
@@ -203,7 +203,7 @@ The learning to rank implementation has been significantly updated in 2.0 with a
         # 1.7 uses the ranknet loss while later versions use the NDCG weighted loss
         "objective": "rank:pairwise",
 	# 1.7 doesn't have this normalization.
-	"lambdarank_diff_normalization": False,
+	"lambdarank_score_normalization": False,
         "base_score": 0.5,
         # The default tree method has been changed from approx to hist.
         "tree_method": "approx",

--- a/doc/tutorials/learning_to_rank.rst
+++ b/doc/tutorials/learning_to_rank.rst
@@ -212,7 +212,7 @@ The learning to rank implementation has been significantly updated in 2.0 with a
         "lambdarank_num_pair_per_sample": 1,
     }
 
-The result still differs due to the change of random seed. But the overall training strategy would be the same for ``rank:pairwise``. Objectives including `NDCG` and `MAP` has additional normalization for the delta weight using the score difference in later versions.
+The result still differs due to the change of random seed. But the overall training strategy would be the same for ``rank:pairwise``.
 
 *******************
 Reproducible Result

--- a/doc/tutorials/learning_to_rank.rst
+++ b/doc/tutorials/learning_to_rank.rst
@@ -186,6 +186,32 @@ For a longer explanation, assuming the pairwise ranking method is used, we calcu
 
 However, it's possible that a distributed framework shuffles the data during map reduce and splits every query group into multiple workers. In that case, the performance would be disastrous. As a result, it depends on the data and the framework for whether a sorted groupby is needed.
 
+**********************************
+Comparing Results with Version 1.7
+**********************************
+
+The learning to rank implementation has been significantly updated in 2.0 with added hyper-parameters and training strategies. To obtain similar result as the 1.7 :py:class:`xgboost.XGBRanker`, following parameter should be used:
+
+.. code-block:: python
+
+    params = {
+        # 1.7 only supports sampling, while 2.0 and later use top-k as the default.
+	# See above sections for the trade-off.
+        "lambdarank_pair_method": "mean",
+        # Normalization was added in 2.0
+        "lambdarank_normalization": False,
+        # 1.7 uses the ranknet loss while later versions use the NDCG weighted loss
+        "objective": "rank:pairwise",
+        "base_score": 0.5,
+        # The default tree method has been changed from approx to hist.
+        "tree_method": "approx",
+        # The default for `mean` pair method is one pair each sample, which is the default in 1.7 as well.
+        # You can leave it as unset.
+        "lambdarank_num_pair_per_sample": 1,
+    }
+
+The result still differs due to the change of random seed. But the overall training strategy would be the same for ``rank:pairwise``. Objectives including `NDCG` and `MAP` has additional normalization for the delta weight using the score difference in later versions.
+
 *******************
 Reproducible Result
 *******************

--- a/doc/tutorials/learning_to_rank.rst
+++ b/doc/tutorials/learning_to_rank.rst
@@ -202,6 +202,8 @@ The learning to rank implementation has been significantly updated in 2.0 with a
         "lambdarank_normalization": False,
         # 1.7 uses the ranknet loss while later versions use the NDCG weighted loss
         "objective": "rank:pairwise",
+	# 1.7 doesn't have this normalization.
+	"lambdarank_diff_normalization": False,
         "base_score": 0.5,
         # The default tree method has been changed from approx to hist.
         "tree_method": "approx",

--- a/python-package/xgboost/testing/ranking.py
+++ b/python-package/xgboost/testing/ranking.py
@@ -121,7 +121,7 @@ def run_normalization(device: str) -> None:
 
 
 def run_score_normalization(device: str, objective: str) -> None:
-    print()
+    """Test normalization by score differences."""
     if objective == "rank:map":
         # Binary relevance
         X, y, qid, _ = tm.make_ltr(4096, 4, 64, max_rel=1)

--- a/python-package/xgboost/testing/ranking.py
+++ b/python-package/xgboost/testing/ranking.py
@@ -118,3 +118,30 @@ def run_normalization(device: str) -> None:
     ltr.fit(X, y, qid=qid, eval_set=[(X, y)], eval_qid=[qid])
     e1 = ltr.evals_result()
     assert e1["validation_0"]["ndcg@32"][-1] > e0["validation_0"]["ndcg@32"][-1]
+
+
+def run_score_normalization(device: str, objective: str) -> None:
+    print()
+    if objective == "rank:map":
+        # Binary relevance
+        X, y, qid, _ = tm.make_ltr(4096, 4, 64, max_rel=1)
+    else:
+        X, y, qid, _ = tm.make_ltr(4096, 4, 64, 3)
+    ltr = xgb.XGBRanker(objective=objective, n_estimators=4, device=device)
+    ltr.fit(X, y, qid=qid, eval_set=[(X, y)], eval_qid=[qid])
+    e0 = ltr.evals_result()
+
+    ltr = xgb.XGBRanker(
+        objective="rank:pairwise",
+        n_estimators=4,
+        device=device,
+        lambdarank_score_normalization=False,
+    )
+    ltr.fit(X, y, qid=qid, eval_set=[(X, y)], eval_qid=[qid])
+    e1 = ltr.evals_result()
+
+    m0, m1 = (
+        list(e0["validation_0"].values())[-1][-1],
+        list(e1["validation_0"].values())[-1][-1],
+    )
+    assert m0 != m1

--- a/src/common/ranking_utils.h
+++ b/src/common/ranking_utils.h
@@ -79,6 +79,7 @@ struct LambdaRankParam : public XGBoostParameter<LambdaRankParam> {
   // unbiased
   bool lambdarank_unbiased{false};
   bool lambdarank_normalization{true};
+  bool lambdarank_diff_normalization{true};
   double lambdarank_bias_norm{1.0};
   // ndcg
   bool ndcg_exp_gain{true};
@@ -88,6 +89,7 @@ struct LambdaRankParam : public XGBoostParameter<LambdaRankParam> {
            lambdarank_num_pair_per_sample == that.lambdarank_num_pair_per_sample &&
            lambdarank_unbiased == that.lambdarank_unbiased &&
            lambdarank_normalization == that.lambdarank_normalization &&
+           lambdarank_diff_normalization == that.lambdarank_diff_normalization &&
            lambdarank_bias_norm == that.lambdarank_bias_norm && ndcg_exp_gain == that.ndcg_exp_gain;
   }
   bool operator!=(LambdaRankParam const& that) const { return !(*this == that); }
@@ -139,6 +141,9 @@ struct LambdaRankParam : public XGBoostParameter<LambdaRankParam> {
     DMLC_DECLARE_FIELD(lambdarank_normalization)
         .set_default(true)
         .describe("Whether to normalize the leaf value for lambda rank.");
+    DMLC_DECLARE_FIELD(lambdarank_diff_normalization)
+        .set_default(true)
+        .describe("Whether to normalize the delta by prediction score difference.");
     DMLC_DECLARE_FIELD(lambdarank_bias_norm)
         .set_default(1.0)
         .set_lower_bound(0.0)

--- a/src/common/ranking_utils.h
+++ b/src/common/ranking_utils.h
@@ -79,7 +79,7 @@ struct LambdaRankParam : public XGBoostParameter<LambdaRankParam> {
   // unbiased
   bool lambdarank_unbiased{false};
   bool lambdarank_normalization{true};
-  bool lambdarank_diff_normalization{true};
+  bool lambdarank_score_normalization{true};
   double lambdarank_bias_norm{1.0};
   // ndcg
   bool ndcg_exp_gain{true};
@@ -89,7 +89,7 @@ struct LambdaRankParam : public XGBoostParameter<LambdaRankParam> {
            lambdarank_num_pair_per_sample == that.lambdarank_num_pair_per_sample &&
            lambdarank_unbiased == that.lambdarank_unbiased &&
            lambdarank_normalization == that.lambdarank_normalization &&
-           lambdarank_diff_normalization == that.lambdarank_diff_normalization &&
+           lambdarank_score_normalization == that.lambdarank_score_normalization &&
            lambdarank_bias_norm == that.lambdarank_bias_norm && ndcg_exp_gain == that.ndcg_exp_gain;
   }
   bool operator!=(LambdaRankParam const& that) const { return !(*this == that); }
@@ -141,7 +141,7 @@ struct LambdaRankParam : public XGBoostParameter<LambdaRankParam> {
     DMLC_DECLARE_FIELD(lambdarank_normalization)
         .set_default(true)
         .describe("Whether to normalize the leaf value for lambda rank.");
-    DMLC_DECLARE_FIELD(lambdarank_diff_normalization)
+    DMLC_DECLARE_FIELD(lambdarank_score_normalization)
         .set_default(true)
         .describe("Whether to normalize the delta by prediction score difference.");
     DMLC_DECLARE_FIELD(lambdarank_bias_norm)

--- a/src/objective/lambdarank_obj.cc
+++ b/src/objective/lambdarank_obj.cc
@@ -351,7 +351,7 @@ class LambdaRankNDCG : public LambdaRankObj<LambdaRankNDCG, ltr::NDCGCache> {
       return DeltaNDCG<exp_gain>(y_high, y_low, rank_high, rank_low, inv_IDCG(g), discount);
     };
 
-    if (this->param_.lambdarank_diff_normalization) {
+    if (this->param_.lambdarank_score_normalization) {
       this->CalcLambdaForGroup<unbiased, true>(iter, g_predt, g_label, w, g_rank, g, delta,
                                                g_gpair);
     } else {
@@ -540,13 +540,13 @@ class LambdaRankMAP : public LambdaRankObj<LambdaRankMAP, ltr::MAPCache> {
       auto args = std::make_tuple(this, iter, g_predt, g_label, w, g_rank, g, delta_map, g_gpair);
 
       if (param_.lambdarank_unbiased) {
-        if (this->param_.lambdarank_diff_normalization) {
+        if (this->param_.lambdarank_score_normalization) {
           std::apply(&LambdaRankMAP::CalcLambdaForGroup<true, true, D>, args);
         } else {
           std::apply(&LambdaRankMAP::CalcLambdaForGroup<true, false, D>, args);
         }
       } else {
-        if (this->param_.lambdarank_diff_normalization) {
+        if (this->param_.lambdarank_score_normalization) {
           std::apply(&LambdaRankMAP::CalcLambdaForGroup<false, true, D>, args);
         } else {
           std::apply(&LambdaRankMAP::CalcLambdaForGroup<false, false, D>, args);
@@ -623,13 +623,13 @@ class LambdaRankPairwise : public LambdaRankObj<LambdaRankPairwise, ltr::Ranking
 
       auto args = std::make_tuple(this, iter, g_predt, g_label, w, g_rank, g, delta, g_gpair);
       if (param_.lambdarank_unbiased) {
-        if (this->param_.lambdarank_diff_normalization) {
+        if (this->param_.lambdarank_score_normalization) {
           std::apply(&LambdaRankPairwise::CalcLambdaForGroup<true, true, D>, args);
         } else {
           std::apply(&LambdaRankPairwise::CalcLambdaForGroup<true, false, D>, args);
         }
       } else {
-        if (this->param_.lambdarank_diff_normalization) {
+        if (this->param_.lambdarank_score_normalization) {
           std::apply(&LambdaRankPairwise::CalcLambdaForGroup<false, true, D>, args);
         } else {
           std::apply(&LambdaRankPairwise::CalcLambdaForGroup<false, false, D>, args);

--- a/src/objective/lambdarank_obj.cc
+++ b/src/objective/lambdarank_obj.cc
@@ -355,8 +355,8 @@ class LambdaRankNDCG : public LambdaRankObj<LambdaRankNDCG, ltr::NDCGCache> {
       this->CalcLambdaForGroup<unbiased, true>(iter, g_predt, g_label, w, g_rank, g, delta,
                                                g_gpair);
     } else {
-      this->CalcLambdaForGroup<unbiased, true>(iter, g_predt, g_label, w, g_rank, g, delta,
-                                               g_gpair);
+      this->CalcLambdaForGroup<unbiased, false>(iter, g_predt, g_label, w, g_rank, g, delta,
+                                                g_gpair);
     }
   }
 

--- a/src/objective/lambdarank_obj.cu
+++ b/src/objective/lambdarank_obj.cu
@@ -77,7 +77,7 @@ using GradCostNorm = thrust::tuple<GradientPair, double, double>;
 /**
  * \brief Obtain and update the gradient for one pair.
  */
-template <bool unbiased, bool has_truncation, typename Delta>
+template <bool unbiased, bool has_truncation, bool norm_by_diff, typename Delta>
 struct GetGradOp {
   MakePairsOp<has_truncation> make_pair;
   Delta delta;
@@ -109,7 +109,8 @@ struct GetGradOp {
     double cost{0};
 
     auto delta_op = [&](auto const&... args) { return delta(args..., g); };
-    GradientPair pg = LambdaGrad<unbiased>(g_label, g_predt, g_rank, rank_high, rank_low, delta_op,
+    GradientPair pg =
+        LambdaGrad<unbiased, norm_by_diff>(g_label, g_predt, g_rank, rank_high, rank_low, delta_op,
                                            args.ti_plus, args.tj_minus, &cost);
 
     std::size_t idx_high = g_rank[rank_high];
@@ -157,7 +158,7 @@ struct GetGradOp {
   }
 };
 
-template <bool unbiased, bool has_truncation, typename Delta>
+template <bool unbiased, bool has_truncation, bool norm_by_diff, typename Delta>
 struct MakeGetGrad {
   MakePairsOp<has_truncation> make_pair;
   Delta delta;
@@ -166,8 +167,8 @@ struct MakeGetGrad {
 
   MakeGetGrad(KernelInputs args, Delta d) : make_pair{args}, delta{std::move(d)} {}
 
-  GetGradOp<unbiased, has_truncation, Delta> operator()(bool need_update) {
-    return GetGradOp<unbiased, has_truncation, Delta>{make_pair, delta, need_update};
+  auto operator()(bool need_update) {
+    return GetGradOp<unbiased, has_truncation, norm_by_diff, Delta>{make_pair, delta, need_update};
   }
 };
 
@@ -192,9 +193,9 @@ struct MakeGetGrad {
  * For performance, the segmented sort for sorted scores is the bottleneck and takes up
  * about half of the time, while the reduction and for_each takes up the second half.
  */
-template <bool unbiased, bool has_truncation, typename Delta>
+template <bool unbiased, bool has_truncation, bool norm_by_diff, typename Delta>
 void CalcGrad(Context const* ctx, MetaInfo const& info, std::shared_ptr<ltr::RankingCache> p_cache,
-              MakeGetGrad<unbiased, has_truncation, Delta> make_get_grad) {
+              MakeGetGrad<unbiased, has_truncation, norm_by_diff, Delta> make_get_grad) {
   auto n_groups = p_cache->Groups();
   auto d_threads_group_ptr = p_cache->CUDAThreadsGroupPtr();
   auto d_gptr = p_cache->DataGroupPtr(ctx);
@@ -283,7 +284,7 @@ void CalcGrad(Context const* ctx, MetaInfo const& info, std::shared_ptr<ltr::Ran
 /**
  * \brief Handles boilerplate code like getting device span.
  */
-template <typename Delta>
+template <bool norm_by_diff, typename Delta>
 void Launch(Context const* ctx, std::int32_t iter, HostDeviceVector<float> const& preds,
             const MetaInfo& info, std::shared_ptr<ltr::RankingCache> p_cache, Delta delta,
             linalg::VectorView<double const> ti_plus,   // input bias ratio
@@ -331,15 +332,15 @@ void Launch(Context const* ctx, std::int32_t iter, HostDeviceVector<float> const
   // dispatch based on unbiased and truncation
   if (p_cache->Param().HasTruncation()) {
     if (unbiased) {
-      CalcGrad(ctx, info, p_cache, MakeGetGrad<true, true, Delta>{args, delta});
+      CalcGrad(ctx, info, p_cache, MakeGetGrad<true, true, norm_by_diff, Delta>{args, delta});
     } else {
-      CalcGrad(ctx, info, p_cache, MakeGetGrad<false, true, Delta>{args, delta});
+      CalcGrad(ctx, info, p_cache, MakeGetGrad<false, true, norm_by_diff, Delta>{args, delta});
     }
   } else {
     if (unbiased) {
-      CalcGrad(ctx, info, p_cache, MakeGetGrad<true, false, Delta>{args, delta});
+      CalcGrad(ctx, info, p_cache, MakeGetGrad<true, false, norm_by_diff, Delta>{args, delta});
     } else {
-      CalcGrad(ctx, info, p_cache, MakeGetGrad<false, false, Delta>{args, delta});
+      CalcGrad(ctx, info, p_cache, MakeGetGrad<false, false, norm_by_diff, Delta>{args, delta});
     }
   }
 }
@@ -389,7 +390,7 @@ void LambdaRankGetGradientNDCG(Context const* ctx, std::int32_t iter,
     return exp_gain ? DeltaNDCG<true>(y_high, y_low, rank_high, rank_low, d_inv_IDCG(g), discount)
                     : DeltaNDCG<false>(y_high, y_low, rank_high, rank_low, d_inv_IDCG(g), discount);
   };
-  Launch(ctx, iter, preds, info, p_cache, delta_ndcg, ti_plus, tj_minus, li, lj, out_gpair);
+  Launch<true>(ctx, iter, preds, info, p_cache, delta_ndcg, ti_plus, tj_minus, li, lj, out_gpair);
 }
 
 void MAPStat(Context const* ctx, MetaInfo const& info, common::Span<std::size_t const> d_rank_idx,
@@ -472,7 +473,7 @@ void LambdaRankGetGradientMAP(Context const* ctx, std::int32_t iter,
     return d;
   };
 
-  Launch(ctx, iter, predt, info, p_cache, delta_map, ti_plus, tj_minus, li, lj, out_gpair);
+  Launch<true>(ctx, iter, predt, info, p_cache, delta_map, ti_plus, tj_minus, li, lj, out_gpair);
 }
 
 void LambdaRankGetGradientPairwise(Context const* ctx, std::int32_t iter,
@@ -492,7 +493,7 @@ void LambdaRankGetGradientPairwise(Context const* ctx, std::int32_t iter,
     return 1.0;
   };
 
-  Launch(ctx, iter, predt, info, p_cache, delta, ti_plus, tj_minus, li, lj, out_gpair);
+  Launch<false>(ctx, iter, predt, info, p_cache, delta, ti_plus, tj_minus, li, lj, out_gpair);
 }
 
 namespace {

--- a/src/objective/lambdarank_obj.cu
+++ b/src/objective/lambdarank_obj.cu
@@ -390,7 +390,7 @@ void LambdaRankGetGradientNDCG(Context const* ctx, std::int32_t iter,
     return exp_gain ? DeltaNDCG<true>(y_high, y_low, rank_high, rank_low, d_inv_IDCG(g), discount)
                     : DeltaNDCG<false>(y_high, y_low, rank_high, rank_low, d_inv_IDCG(g), discount);
   };
-  if (p_cache->Param().lambdarank_diff_normalization) {
+  if (p_cache->Param().lambdarank_score_normalization) {
     Launch<true>(ctx, iter, preds, info, p_cache, delta_ndcg, ti_plus, tj_minus, li, lj, out_gpair);
   } else {
     Launch<false>(ctx, iter, preds, info, p_cache, delta_ndcg, ti_plus, tj_minus, li, lj,
@@ -477,7 +477,7 @@ void LambdaRankGetGradientMAP(Context const* ctx, std::int32_t iter,
     auto d = DeltaMAP(y_high, y_low, rank_high, rank_low, g_n_rel, g_acc);
     return d;
   };
-  if (p_cache->Param().lambdarank_diff_normalization) {
+  if (p_cache->Param().lambdarank_score_normalization) {
     Launch<true>(ctx, iter, predt, info, p_cache, delta_map, ti_plus, tj_minus, li, lj, out_gpair);
   } else {
     Launch<false>(ctx, iter, predt, info, p_cache, delta_map, ti_plus, tj_minus, li, lj, out_gpair);
@@ -501,7 +501,7 @@ void LambdaRankGetGradientPairwise(Context const* ctx, std::int32_t iter,
     return 1.0;
   };
 
-  if (p_cache->Param().lambdarank_diff_normalization) {
+  if (p_cache->Param().lambdarank_score_normalization) {
     Launch<true>(ctx, iter, predt, info, p_cache, delta, ti_plus, tj_minus, li, lj, out_gpair);
   } else {
     Launch<false>(ctx, iter, predt, info, p_cache, delta, ti_plus, tj_minus, li, lj, out_gpair);

--- a/src/objective/lambdarank_obj.h
+++ b/src/objective/lambdarank_obj.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, XGBoost contributors
+ * Copyright 2023-2025, XGBoost contributors
  *
  * Vocabulary explanation:
  *
@@ -85,7 +85,6 @@ XGBOOST_DEVICE inline double DeltaMAP(float y_high, float y_low, std::size_t ran
  *
  * @tparam unbiased Whether positioin bias is taken into account.
  * @tparam norm_by_diff Do we need to normalize the delta metric using the score difference.
- *                      False for the ranknet loss.
  * @tparam Functor for calculating the delta weight.
  */
 template <bool unbiased, bool norm_by_diff, typename Delta>

--- a/tests/python-gpu/test_gpu_ranking.py
+++ b/tests/python-gpu/test_gpu_ranking.py
@@ -6,7 +6,7 @@ import pytest
 
 import xgboost
 from xgboost import testing as tm
-from xgboost.testing.ranking import run_normalization
+from xgboost.testing.ranking import run_normalization, run_score_normalization
 
 pytestmark = tm.timeout(30)
 
@@ -131,3 +131,8 @@ def test_with_mq2008(objective, metric) -> None:
 
 def test_normalization() -> None:
     run_normalization("cuda")
+
+
+@pytest.mark.parametrize("objective", ["rank:pairwise", "rank:ndcg", "rank:map"])
+def test_score_normalization(objective: str) -> None:
+    run_score_normalization("cuda", objective)

--- a/tests/python/test_ranking.py
+++ b/tests/python/test_ranking.py
@@ -13,7 +13,7 @@ import xgboost
 from xgboost import testing as tm
 from xgboost.testing.data import RelDataCV, simulate_clicks, sort_ltr_samples
 from xgboost.testing.params import lambdarank_parameter_strategy
-from xgboost.testing.ranking import run_normalization
+from xgboost.testing.ranking import run_normalization, run_score_normalization
 
 
 def test_ndcg_custom_gain():
@@ -211,6 +211,11 @@ def test_unbiased() -> None:
 
 def test_normalization() -> None:
     run_normalization("cpu")
+
+
+@pytest.mark.parametrize("objective", ["rank:pairwise", "rank:ndcg", "rank:map"])
+def test_score_normalization(objective: str) -> None:
+    run_score_normalization("cpu", objective)
 
 
 class TestRanking:


### PR DESCRIPTION
The old implementation has the seed `(iter + 1) *1111`, while the current implementation uses `iter`. Otherwise, everything is the same when the set of hyper-parameters in the new document is used.
