### PR TITLE
Optimize device regex, test reusing a ProxyDMatrix.

### DIFF
--- a/demo/c-api/inference/inference.c
+++ b/demo/c-api/inference/inference.c
@@ -1,7 +1,10 @@
-/*!
- * Copyright 2021 XGBoost contributors
+/**
+ * Copyright 2021-2025, XGBoost contributors
  *
- * \brief A simple example of using prediction functions.
+ * @brief A simple example of using prediction functions.
+ *
+ * See more examples in test_c_api.cc on how to reuse a ProxyDMatrix object for reducing
+ * the latency of DMatrix creation.
  */
 #include <stddef.h>
 #include <stdlib.h>

--- a/src/context.cc
+++ b/src/context.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2024, XGBoost Contributors
+ * Copyright 2014-2025, XGBoost Contributors
  *
  * \brief Context object used for controlling runtime parameters.
  */
@@ -11,11 +11,16 @@
 #include <optional>   // for optional
 #include <regex>      // for regex_replace, regex_match
 
-#include "common/common.h"         // AssertGPUSupport
 #include "common/cuda_rt_utils.h"  // for AllVisibleGPUs
 #include "common/error_msg.h"      // WarnDeprecatedGPUId
 #include "common/threading_utils.h"
 #include "xgboost/string_view.h"
+
+#if !defined(XGBOOST_USE_CUDA)
+
+#include "common/common.h"  // for AssertGPUSupport
+
+#endif  // !defined(XGBOOST_USE_CUDA)
 
 namespace xgboost {
 
@@ -108,7 +113,8 @@ DeviceOrd CUDAOrdinal(DeviceOrd device, bool) {
   bool valid = substr == "cpu" || substr == "cud" || substr == "gpu" || substr == "syc";
   CHECK(valid) << msg;
 #else
-  std::regex pattern{"gpu(:[0-9]+)?|cuda(:[0-9]+)?|cpu|sycl(:cpu|:gpu)?(:-1|:[0-9]+)?"};
+  thread_local static std::regex pattern{
+      "gpu(:[0-9]+)?|cuda(:[0-9]+)?|cpu|sycl(:cpu|:gpu)?(:-1|:[0-9]+)?"};
   if (!std::regex_match(input, pattern)) {
     fatal();
   }

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -621,7 +621,7 @@ TEST(CAPI, PredictReuseProxy) {
   bst_idx_t n_samples = 1024;
   auto inf = RandomDataGenerator{n_samples, 256, 0.0}.GenerateArrayInterface(&storage);
   HostDeviceVector<float> storage_y;
-  auto y_inf = RandomDataGenerator{1024, 1, 0.0}.GenerateArrayInterface(&storage_y);
+  auto y_inf = RandomDataGenerator{n_samples, 1, 0.0}.GenerateArrayInterface(&storage_y);
 
   // Create a DMatrix for training
   DMatrixHandle fmat_hdl{nullptr};

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -613,8 +613,8 @@ TEST(CAPI, PredictReuseProxy) {
   config["type"] = Integer{0};
   config["iteration_begin"] = config["iteration_end"] = Integer{0};
   config["missing"] = Number{std::numeric_limits<float>::quiet_NaN()};
-  config["strict_shape"] = true;
-  config["training"] = false;
+  config["strict_shape"] = Boolean{true};
+  config["training"] = Boolean{false};
   auto scfg = Json::Dump(config);
 
   HostDeviceVector<float> storage;


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/11271 .

- Reuse the compiled regular expression.
- Test reusing the proxy DMatrix for inference.