### PR TITLE
Use parallel sort for quantile calculation when appropriate.

### DIFF
--- a/src/common/algorithm.h
+++ b/src/common/algorithm.h
@@ -1,10 +1,10 @@
 /**
- * Copyright 2022-2023 by XGBoost Contributors
+ * Copyright 2022-2025, XGBoost Contributors
  */
 #ifndef XGBOOST_COMMON_ALGORITHM_H_
 #define XGBOOST_COMMON_ALGORITHM_H_
 #include <algorithm>          // upper_bound, stable_sort, sort, max
-#include <cinttypes>          // size_t
+#include <cstddef>            // size_t
 #include <functional>         // less
 #include <iterator>           // iterator_traits, distance
 #include <vector>             // vector
@@ -16,6 +16,9 @@
 #if defined(__GNUC__) && (__GNUC__ >= 4) && !defined(__sun) && !defined(sun) && \
     !defined(__APPLE__) && __has_include(<omp.h>) && __has_include(<parallel/algorithm>)
 #define GCC_HAS_PARALLEL 1
+constexpr bool kGccHasParallel = true;
+#else
+constexpr bool kGccHasParallel = false;
 #endif  // GLIC_VERSION
 
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)

--- a/src/common/algorithm.h
+++ b/src/common/algorithm.h
@@ -16,9 +16,9 @@
 #if defined(__GNUC__) && (__GNUC__ >= 4) && !defined(__sun) && !defined(sun) && \
     !defined(__APPLE__) && __has_include(<omp.h>) && __has_include(<parallel/algorithm>)
 #define GCC_HAS_PARALLEL 1
-constexpr bool kGccHasParallel = true;
+constexpr bool kHasParallelStableSort = true;
 #else
-constexpr bool kGccHasParallel = false;
+constexpr bool kHasParallelStableSort = false;
 #endif  // GLIC_VERSION
 
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)

--- a/src/common/stats.h
+++ b/src/common/stats.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2024, XGBoost Contributors
+ * Copyright 2022-2025, XGBoost Contributors
  */
 #ifndef XGBOOST_COMMON_STATS_H_
 #define XGBOOST_COMMON_STATS_H_
@@ -42,13 +42,8 @@ float Quantile(Context const* ctx, double alpha, Iter const& begin, Iter const& 
 
   std::vector<std::size_t> sorted_idx(n);
   std::iota(sorted_idx.begin(), sorted_idx.end(), 0);
-  if (omp_in_parallel()) {
-    std::stable_sort(sorted_idx.begin(), sorted_idx.end(),
-                     [&](std::size_t l, std::size_t r) { return *(begin + l) < *(begin + r); });
-  } else {
-    StableSort(ctx, sorted_idx.begin(), sorted_idx.end(),
-               [&](std::size_t l, std::size_t r) { return *(begin + l) < *(begin + r); });
-  }
+  StableSort(ctx, sorted_idx.begin(), sorted_idx.end(),
+             [&](std::size_t l, std::size_t r) { return *(begin + l) < *(begin + r); });
 
   auto val = [&](size_t i) { return *(begin + sorted_idx[i]); };
   static_assert(std::is_same_v<decltype(val(0)), float>);
@@ -85,13 +80,8 @@ float WeightedQuantile(Context const* ctx, double alpha, Iter begin, Iter end, W
   }
   std::vector<size_t> sorted_idx(n);
   std::iota(sorted_idx.begin(), sorted_idx.end(), 0);
-  if (omp_in_parallel()) {
-    std::stable_sort(sorted_idx.begin(), sorted_idx.end(),
-                     [&](std::size_t l, std::size_t r) { return *(begin + l) < *(begin + r); });
-  } else {
-    StableSort(ctx, sorted_idx.begin(), sorted_idx.end(),
-               [&](std::size_t l, std::size_t r) { return *(begin + l) < *(begin + r); });
-  }
+  StableSort(ctx, sorted_idx.begin(), sorted_idx.end(),
+             [&](std::size_t l, std::size_t r) { return *(begin + l) < *(begin + r); });
 
   auto val = [&](size_t i) { return *(begin + sorted_idx[i]); };
 

--- a/src/common/stats.h
+++ b/src/common/stats.h
@@ -32,8 +32,9 @@ namespace common {
  *
  * \return The result of interpolation.
  */
-template <typename Iter>
-float Quantile(Context const* ctx, double alpha, Iter const& begin, Iter const& end) {
+template <typename Iter,
+          typename R = std::remove_reference_t<typename std::iterator_traits<Iter>::value_type>>
+[[nodiscard]] R Quantile(Context const* ctx, double alpha, Iter const& begin, Iter const& end) {
   CHECK(alpha >= 0 && alpha <= 1);
   auto n = static_cast<double>(std::distance(begin, end));
   if (n == 0) {
@@ -45,7 +46,9 @@ float Quantile(Context const* ctx, double alpha, Iter const& begin, Iter const& 
   StableSort(ctx, sorted_idx.begin(), sorted_idx.end(),
              [&](std::size_t l, std::size_t r) { return *(begin + l) < *(begin + r); });
 
-  auto val = [&](size_t i) { return *(begin + sorted_idx[i]); };
+  auto val = [&](size_t i) {
+    return *(begin + sorted_idx[i]);
+  };
   static_assert(std::is_same_v<decltype(val(0)), float>);
 
   if (alpha <= (1 / (n + 1))) {
@@ -72,8 +75,10 @@ float Quantile(Context const* ctx, double alpha, Iter const& begin, Iter const& 
  *   See https://aakinshin.net/posts/weighted-quantiles/ for some discussions on computing
  *   weighted quantile with interpolation.
  */
-template <typename Iter, typename WeightIter>
-float WeightedQuantile(Context const* ctx, double alpha, Iter begin, Iter end, WeightIter w_begin) {
+template <typename Iter, typename WeightIter,
+          typename R = std::remove_reference_t<typename std::iterator_traits<Iter>::value_type>>
+[[nodiscard]] R WeightedQuantile(Context const* ctx, double alpha, Iter begin, Iter end,
+                                 WeightIter w_begin) {
   auto n = static_cast<double>(std::distance(begin, end));
   if (n == 0) {
     return std::numeric_limits<float>::quiet_NaN();
@@ -83,7 +88,9 @@ float WeightedQuantile(Context const* ctx, double alpha, Iter begin, Iter end, W
   StableSort(ctx, sorted_idx.begin(), sorted_idx.end(),
              [&](std::size_t l, std::size_t r) { return *(begin + l) < *(begin + r); });
 
-  auto val = [&](size_t i) { return *(begin + sorted_idx[i]); };
+  auto val = [&](size_t i) {
+    return *(begin + sorted_idx[i]);
+  };
 
   std::vector<float> weight_cdf(n);  // S_n
   // weighted cdf is sorted during construction

--- a/src/objective/adaptive.cc
+++ b/src/objective/adaptive.cc
@@ -109,14 +109,16 @@ void UpdateTreeLeafHost(Context const* ctx, std::vector<bst_node_t> const& posit
   // parallel region.
   std::int32_t n_threads;
   if constexpr (kHasParallelStableSort) {
-    constexpr std::size_t kNeedParallelSort = 1000000;
     CHECK_GE(h_node_ptr.size(), 1);
     auto it = common::MakeIndexTransformIter(
         [&](std::size_t i) { return h_node_ptr[i + 1] - h_node_ptr[i]; });
-    n_threads =
-        std::any_of(it, it + h_node_ptr.size() - 1, [](auto n) { return n > kNeedParallelSort; })
-            ? 1
-            : ctx->Threads();
+    n_threads = std::any_of(it, it + h_node_ptr.size() - 1,
+                            [](auto n) {
+                              constexpr std::size_t kNeedParallelSort = 1000000;
+                              return n > kNeedParallelSort;
+                            })
+                    ? 1
+                    : ctx->Threads();
   } else {
     n_threads = ctx->Threads();
   }

--- a/src/objective/adaptive.cc
+++ b/src/objective/adaptive.cc
@@ -108,8 +108,8 @@ void UpdateTreeLeafHost(Context const* ctx, std::vector<bst_node_t> const& posit
   // performed using a single thread as openmp cannot allocate new threads inside a
   // parallel region.
   std::int32_t n_threads;
-  if constexpr (kGccHasParallel) {
-    constexpr std::size_t kNeedParallelSort = 100000;
+  if constexpr (kHasParallelStableSort) {
+    constexpr std::size_t kNeedParallelSort = 1000000;
     auto it = common::MakeIndexTransformIter(
         [&](std::size_t i) { return h_node_ptr[i + 1] - h_node_ptr[i]; });
     n_threads =

--- a/src/objective/adaptive.cc
+++ b/src/objective/adaptive.cc
@@ -110,6 +110,7 @@ void UpdateTreeLeafHost(Context const* ctx, std::vector<bst_node_t> const& posit
   std::int32_t n_threads;
   if constexpr (kHasParallelStableSort) {
     constexpr std::size_t kNeedParallelSort = 1000000;
+    CHECK_GE(h_node_ptr.size(), 1);
     auto it = common::MakeIndexTransformIter(
         [&](std::size_t i) { return h_node_ptr[i + 1] - h_node_ptr[i]; });
     n_threads =

--- a/src/objective/adaptive.cc
+++ b/src/objective/adaptive.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2024, XGBoost Contributors
+ * Copyright 2022-2025, XGBoost Contributors
  */
 #include "adaptive.h"
 
@@ -104,10 +104,26 @@ void UpdateTreeLeafHost(Context const* ctx, std::vector<bst_node_t> const& posit
   auto h_predt = linalg::MakeTensorView(ctx, predt.ConstHostSpan(), info.num_row_,
                                         predt.Size() / info.num_row_);
 
+  // A heuristic to use parallel sort. If we use multiple threads here, the sorting is
+  // performed using a single thread as openmp cannot allocate new threads inside a
+  // parallel region.
+  std::int32_t n_threads;
+  if constexpr (kGccHasParallel) {
+    constexpr std::size_t kNeedParallelSort = 100000;
+    auto it = common::MakeIndexTransformIter(
+        [&](std::size_t i) { return h_node_ptr[i + 1] - h_node_ptr[i]; });
+    n_threads =
+        std::any_of(it, it + h_node_ptr.size() - 1, [](auto n) { return n > kNeedParallelSort; })
+            ? 1
+            : ctx->Threads();
+  } else {
+    n_threads = ctx->Threads();
+  }
+
   collective::ApplyWithLabels(
       ctx, info, static_cast<void*>(quantiles.data()), quantiles.size() * sizeof(float), [&] {
         // loop over each leaf
-        common::ParallelFor(quantiles.size(), ctx->Threads(), [&](size_t k) {
+        common::ParallelFor(quantiles.size(), n_threads, [&](size_t k) {
           auto nidx = h_node_idx[k];
           CHECK(tree[nidx].IsLeaf());
           CHECK_LT(k + 1, h_node_ptr.size());

--- a/src/objective/adaptive.cc
+++ b/src/objective/adaptive.cc
@@ -114,7 +114,7 @@ void UpdateTreeLeafHost(Context const* ctx, std::vector<bst_node_t> const& posit
         [&](std::size_t i) { return h_node_ptr[i + 1] - h_node_ptr[i]; });
     n_threads = std::any_of(it, it + h_node_ptr.size() - 1,
                             [](auto n) {
-                              constexpr std::size_t kNeedParallelSort = 1000000;
+                              constexpr std::size_t kNeedParallelSort = 1ul << 19;
                               return n > kNeedParallelSort;
                             })
                     ? 1

--- a/tests/cpp/common/test_threading_utils.cc
+++ b/tests/cpp/common/test_threading_utils.cc
@@ -1,12 +1,12 @@
 /**
  * Copyright 2019-2024, XGBoost Contributors
  */
+#include <dmlc/omp.h>  // for omp_in_parallel
 #include <gtest/gtest.h>
 
-#include <cstddef>  // std::size_t
+#include <cstddef>  // for std::size_t
 
 #include "../../../src/common/threading_utils.h"  // BlockedSpace2d,ParallelFor2d,ParallelFor
-#include "dmlc/omp.h"                             // omp_in_parallel
 #include "xgboost/context.h"                      // Context
 
 namespace xgboost::common {
@@ -99,6 +99,7 @@ TEST(ParallelFor, Basic) {
     ASSERT_LT(i, n);
   });
   ASSERT_FALSE(omp_in_parallel());
+  ParallelFor(n, 1, [&](auto) { ASSERT_FALSE(omp_in_parallel()); });
 }
 
 TEST(OmpGetNumThreads, Max) {


### PR DESCRIPTION
- Drop the duplicated `omp_in_parallel` check.
- Use parallel sort instead of parallel leaf values based on a heuristic.

Close https://github.com/dmlc/xgboost/issues/11274