### PR TITLE
SYCL. Fix multiclass for sycl iGPUs

### DIFF
--- a/src/common/transform.h
+++ b/src/common/transform.h
@@ -37,7 +37,7 @@ template <typename Functor, typename... SpanType>
 __global__ void LaunchCUDAKernel(Functor _func, Range _range,
                                  SpanType... _spans) {
   for (auto i : dh::GridStrideRange(*_range.begin(), *_range.end())) {
-    _func(i, _spans...);
+    _func(i, std::true_type(), _spans...);
   }
 }
 #endif  // defined(__CUDACC__)
@@ -184,7 +184,7 @@ class Transform {
     void LaunchCPU(Functor func, HDV *...vectors) const {
       omp_ulong end = static_cast<omp_ulong>(*(range_.end()));
       SyncHost(vectors...);
-      ParallelFor(end, n_threads_, [&](omp_ulong idx) { func(idx, UnpackHDV(vectors)...); });
+      ParallelFor(end, n_threads_, [&](omp_ulong idx) { func(idx, std::true_type(), UnpackHDV(vectors)...); });
     }
 
    private:

--- a/src/objective/aft_obj.cu
+++ b/src/objective/aft_obj.cu
@@ -45,7 +45,7 @@ class AFTObj : public ObjFunction {
                        linalg::Matrix<GradientPair>* out_gpair, size_t ndata, DeviceOrd device,
                        bool is_null_weight, float aft_loss_distribution_scale) {
     common::Transform<>::Init(
-        [=] XGBOOST_DEVICE(size_t _idx,
+        [=] XGBOOST_DEVICE(size_t _idx, auto has_fp64_support,
         common::Span<GradientPair> _out_gpair,
         common::Span<const bst_float> _preds,
         common::Span<const bst_float> _labels_lower_bound,
@@ -104,7 +104,7 @@ class AFTObj : public ObjFunction {
   void PredTransform(HostDeviceVector<bst_float> *io_preds) const override {
     // Trees give us a prediction in log scale, so exponentiate
     common::Transform<>::Init(
-        [] XGBOOST_DEVICE(size_t _idx, common::Span<bst_float> _preds) {
+        [] XGBOOST_DEVICE(size_t _idx, auto has_fp64_support, common::Span<bst_float> _preds) {
           _preds[_idx] = exp(_preds[_idx]);
         },
         common::Range{0, static_cast<int64_t>(io_preds->Size())}, this->ctx_->Threads(),

--- a/src/objective/hinge.cu
+++ b/src/objective/hinge.cu
@@ -85,7 +85,7 @@ class HingeObj : public FitIntercept {
 
   void PredTransform(HostDeviceVector<float> *io_preds) const override {
     common::Transform<>::Init(
-        [] XGBOOST_DEVICE(std::size_t _idx, common::Span<float> _preds) {
+        [] XGBOOST_DEVICE(std::size_t _idx, auto has_fp64_support, common::Span<float> _preds) {
           _preds[_idx] = _preds[_idx] > 0.0 ? 1.0 : 0.0;
         },
         common::Range{0, static_cast<int64_t>(io_preds->Size()), 1}, this->ctx_->Threads(),

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -142,7 +142,8 @@ class RegLossObj : public FitInterceptGlmLike {
 
     common::Transform<>::Init(
         [block_size, ndata, n_targets] XGBOOST_DEVICE(
-            size_t data_block_idx, common::Span<float> _additional_input,
+            size_t data_block_idx, auto has_fp64_support,
+            common::Span<float> _additional_input,
             common::Span<GradientPair> _out_gpair,
             common::Span<const bst_float> _preds,
             common::Span<const bst_float> _labels,
@@ -179,7 +180,7 @@ class RegLossObj : public FitInterceptGlmLike {
 
   void PredTransform(HostDeviceVector<float> *io_preds) const override {
     common::Transform<>::Init(
-        [] XGBOOST_DEVICE(size_t _idx, common::Span<float> _preds) {
+        [] XGBOOST_DEVICE(size_t _idx, auto has_fp64_support, common::Span<float> _preds) {
           _preds[_idx] = Loss::PredTransform(_preds[_idx]);
         },
         common::Range{0, static_cast<int64_t>(io_preds->Size())}, this->ctx_->Threads(),
@@ -360,7 +361,7 @@ class PoissonRegression : public FitInterceptGlmLike {
     }
     bst_float max_delta_step = param_.max_delta_step;
     common::Transform<>::Init(
-        [=] XGBOOST_DEVICE(size_t _idx,
+        [=] XGBOOST_DEVICE(size_t _idx, auto has_fp64_support,
                            common::Span<int> _label_correct,
                            common::Span<GradientPair> _out_gpair,
                            common::Span<const bst_float> _preds,
@@ -387,7 +388,7 @@ class PoissonRegression : public FitInterceptGlmLike {
   }
   void PredTransform(HostDeviceVector<bst_float> *io_preds) const override {
     common::Transform<>::Init(
-        [] XGBOOST_DEVICE(size_t _idx, common::Span<bst_float> _preds) {
+        [] XGBOOST_DEVICE(size_t _idx, auto has_fp64_support, common::Span<bst_float> _preds) {
           _preds[_idx] = expf(_preds[_idx]);
         },
         common::Range{0, static_cast<int64_t>(io_preds->Size())}, this->ctx_->Threads(),
@@ -566,7 +567,7 @@ class TweedieRegression : public FitInterceptGlmLike {
 
     const float rho = param_.tweedie_variance_power;
     common::Transform<>::Init(
-        [=] XGBOOST_DEVICE(size_t _idx,
+        [=] XGBOOST_DEVICE(size_t _idx, auto has_fp64_support,
                            common::Span<int> _label_correct,
                            common::Span<GradientPair> _out_gpair,
                            common::Span<const bst_float> _preds,
@@ -597,7 +598,7 @@ class TweedieRegression : public FitInterceptGlmLike {
   }
   void PredTransform(HostDeviceVector<bst_float> *io_preds) const override {
     common::Transform<>::Init(
-        [] XGBOOST_DEVICE(size_t _idx, common::Span<bst_float> _preds) {
+        [] XGBOOST_DEVICE(size_t _idx, auto has_fp64_support, common::Span<bst_float> _preds) {
           _preds[_idx] = expf(_preds[_idx]);
         },
         common::Range{0, static_cast<int64_t>(io_preds->Size())}, this->ctx_->Threads(),

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -180,7 +180,8 @@ class TreeEvaluator {
     }
 
     common::Transform<>::Init(
-        [=] XGBOOST_DEVICE(size_t, common::Span<float> lower,
+        [=] XGBOOST_DEVICE(size_t, auto has_fp64_support,
+                           common::Span<float> lower,
                            common::Span<float> upper,
                            common::Span<int> monotone) {
           lower[leftid] = lower[nodeid];

--- a/tests/cpp/common/test_transform_range.cc
+++ b/tests/cpp/common/test_transform_range.cc
@@ -25,7 +25,8 @@ constexpr DeviceOrd TransformDevice() {
 
 template <typename T>
 struct TestTransformRange {
-  void XGBOOST_DEVICE operator()(std::size_t _idx, Span<float> _out, Span<const float> _in) {
+  template <class kBoolConst>
+  void XGBOOST_DEVICE operator()(std::size_t _idx, kBoolConst has_fp64_support, Span<float> _out, Span<const float> _in) {
     _out[_idx] = _in[_idx];
   }
 };
@@ -59,7 +60,7 @@ TEST(TransformDeathTest, Exception) {
   const HostDeviceVector<float> in_vec{h_in, DeviceOrd::CPU()};
   EXPECT_DEATH(
       {
-        Transform<>::Init([](size_t idx, common::Span<float const> _in) { _in[idx + 1]; },
+        Transform<>::Init([](size_t idx, auto has_fp64_support, common::Span<float const> _in) { _in[idx + 1]; },
                           Range(0, static_cast<Range::DifferenceType>(kSize)), AllThreadsForTest(),
                           DeviceOrd::CPU())
             .Eval(&in_vec);

--- a/tests/cpp/plugin/test_sycl_transform_range.cc
+++ b/tests/cpp/plugin/test_sycl_transform_range.cc
@@ -19,7 +19,8 @@ namespace xgboost::common {
 
 template <typename T>
 struct TestTransformRange {
-  void operator()(std::size_t _idx, Span<float> _out, Span<const float> _in) {
+  template <class kBoolConst>
+  void operator()(std::size_t _idx, kBoolConst has_fp64_support, Span<float> _out, Span<const float> _in) {
     _out[_idx] = _in[_idx];
   }
 };


### PR DESCRIPTION
The PR https://github.com/dmlc/xgboost/pull/11029 generalizes calculations of multiclass objectives for sycl. But some sycl devices (integrated graphics) don't support fp64 calculations. This fix adds dispatching to gradient calculations. And returns the basic xgboost functional to iGPUs.