### PR TITLE
[pyspark] Support columnar input for cpu pipeline

### DIFF
--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -449,12 +449,6 @@ class _SparkXGBParams(
                 "The `exact` tree method is not supported for distributed systems."
             )
 
-        if self.getOrDefault(self.features_cols):
-            if not self._run_on_gpu():
-                raise ValueError(
-                    "features_col param with list value requires `device=cuda`."
-                )
-
         if self.getOrDefault("objective") is not None:
             if not isinstance(self.getOrDefault("objective"), str):
                 raise ValueError("Only string type 'objective' param is allowed.")

--- a/tests/test_distributed/test_with_spark/test_spark_local.py
+++ b/tests/test_distributed/test_with_spark/test_spark_local.py
@@ -1796,6 +1796,23 @@ class XgboostLocalTest(SparkTestCase):
             loaded_model = SparkXGBClassifierModel.load(path)
             check_conf(loaded_model.getOrDefault(loaded_model.coll_cfg))
 
+    def test_classifier_with_multi_cols(self):
+        df = self.session.createDataFrame(
+            [
+                (1.0, 2.0, 0),
+                (3.1, 4.2, 1),
+            ],
+            ["a", "b", "label"],
+        )
+        features = ["a", "b"]
+        cls = SparkXGBClassifier(features_col=features, device="cpu", n_estimators=2)
+        model = cls.fit(df)
+        self.assertEqual(features, model.getOrDefault(model.features_cols))
+        self.assertTrue(not model.isSet(model.featuresCol))
+
+        # No exception
+        model.transform(df).collect()
+
 
 LTRData = namedtuple(
     "LTRData",


### PR DESCRIPTION
At every beginning, the columnar input has been restricted for the CPU pipeline, which means CPU only support vector/array as the input, while GPU could also support columnar apart from vector and array. 

This PR makes a change to make both cpu and gpu support vector/array/columnar.