### PR TITLE
Update CUDA version for clang-tidy.

### DIFF
--- a/doc/contrib/ci.rst
+++ b/doc/contrib/ci.rst
@@ -56,7 +56,7 @@ To make changes to the CI container, carry out the following steps:
 
      IMAGE_TAG=PR-XX
 
-   where ``XX`` is the pull request number.
+   where ``XX`` is the pull request number. E.g. ``PR-204``.
 
 6. Now submit a pull request to `dmlc/xgboost <https://github.com/dmlc/xgboost>`_. The CI will
    run tests using the new container. Verify that all tests pass.

--- a/ops/pipeline/get-image-tag.sh
+++ b/ops/pipeline/get-image-tag.sh
@@ -1,4 +1,4 @@
 ## Update the following line to test changes to CI images
 ## See https://xgboost.readthedocs.io/en/latest/contrib/ci.html#making-changes-to-ci-containers
 
-IMAGE_TAG=main
+IMAGE_TAG=PR-12

--- a/ops/pipeline/get-image-tag.sh
+++ b/ops/pipeline/get-image-tag.sh
@@ -1,4 +1,4 @@
 ## Update the following line to test changes to CI images
 ## See https://xgboost.readthedocs.io/en/latest/contrib/ci.html#making-changes-to-ci-containers
 
-IMAGE_TAG=PR-12
+IMAGE_TAG=main

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -114,8 +114,8 @@ void CatContainer::Save(Json* p_out) const {
                      std::copy_n(values.data(), values.size(), array.GetArray().begin());
 
                      Object out{};
-                     out["values"] = std::move(array);
                      out["type"] = static_cast<std::int64_t>(array.Type());
+                     out["values"] = std::move(array);
 
                      f_out = std::move(out);
                    }},

--- a/tests/python-gpu/test_gpu_prediction.py
+++ b/tests/python-gpu/test_gpu_prediction.py
@@ -40,7 +40,7 @@ predict_parameter_strategy = strategies.fixed_dictionaries(
 )
 
 # cupy nvrtc compilation can take a long time for the first run
-pytestmark = tm.timeout(30)
+pytestmark = tm.timeout(60)
 
 
 class TestGPUPredict:


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost-devops/pull/12

- Increase timeout for one of the tests. For some reason, the XGBoost CUDA kernels are using jit.
- Update CUDA to 12.8 for the clang-tidy test. We need the bundled CCCL.
- Fix `use-after-move` in the cat container.