### PR TITLE
Auto re-coding for the CPU predictor.

### DIFF
--- a/python-package/xgboost/testing/data.py
+++ b/python-package/xgboost/testing/data.py
@@ -151,7 +151,7 @@ def pd_dtypes() -> Generator:
     # Categorical
     orig = orig.astype("category")
     for c in orig.columns:
-        orig[c] = orig[c].cat.rename_categories(lambda x: int(x))
+        orig[c] = orig[c].cat.rename_categories(int)
     for Null in (np.nan, None, pd.NA):
         df = pd.DataFrame(
             {"f0": [1, 2, Null, 3], "f1": [3, 2, Null, 1]},

--- a/python-package/xgboost/testing/data.py
+++ b/python-package/xgboost/testing/data.py
@@ -150,6 +150,8 @@ def pd_dtypes() -> Generator:
 
     # Categorical
     orig = orig.astype("category")
+    for c in orig.columns:
+        orig[c] = orig[c].cat.rename_categories(lambda x: int(x))
     for Null in (np.nan, None, pd.NA):
         df = pd.DataFrame(
             {"f0": [1, 2, Null, 3], "f1": [3, 2, Null, 1]},

--- a/python-package/xgboost/testing/data.py
+++ b/python-package/xgboost/testing/data.py
@@ -152,7 +152,7 @@ def pd_dtypes() -> Generator:
     orig = orig.astype("category")
     for Null in (np.nan, None, pd.NA):
         df = pd.DataFrame(
-            {"f0": [1.0, 2.0, Null, 3.0], "f1": [3.0, 2.0, Null, 1.0]},
+            {"f0": [1, 2, Null, 3], "f1": [3, 2, Null, 1]},
             dtype=pd.CategoricalDtype(),
         )
         yield orig, df

--- a/python-package/xgboost/testing/ordinal.py
+++ b/python-package/xgboost/testing/ordinal.py
@@ -262,5 +262,5 @@ def run_cat_predict(device: Literal["cpu", "cuda"]) -> None:
         predt2 = booster.predict(fmat)
         assert_allclose(device, predt0, predt2)
 
-    for dm in (DMatrix, ):
+    for dm in (DMatrix, QuantileDMatrix):
         run_dispatch(dm)

--- a/python-package/xgboost/testing/ordinal.py
+++ b/python-package/xgboost/testing/ordinal.py
@@ -355,6 +355,7 @@ def _make_dm(DMatrixT: Type[U], ref: DMatrix, *args: Any, **kwargs: Any) -> U:
 
 
 def run_cat_shap(device: Literal["cpu", "cuda"]) -> None:
+    """Basic tests for SHAP values."""
     Df, _ = get_df_impl(device)
 
     def run_shap(DMatrixT: Type) -> None:

--- a/python-package/xgboost/testing/ordinal.py
+++ b/python-package/xgboost/testing/ordinal.py
@@ -408,8 +408,7 @@ def run_cat_shap(device: Literal["cpu", "cuda"]) -> None:
 
 def run_cat_leaf(device: Literal["cpu", "cuda"]) -> None:
     """Basic tests for leaf prediction."""
-
-    for dm in (DMatrix, QuantileDMatrix):
-        _run_predt(
-            device, dm, pred_contribs=False, pred_interactions=False, pred_leaf=True
-        )
+    # QuantileDMatrix is not supported by leaf.
+    _run_predt(
+        device, DMatrix, pred_contribs=False, pred_interactions=False, pred_leaf=True
+    )

--- a/src/common/error_msg.h
+++ b/src/common/error_msg.h
@@ -128,5 +128,12 @@ constexpr StringView ZeroCudaMemory() {
          "support. If you are using other types of memory pool, please consider reserving a "
          "portion of the GPU memory for XGBoost.";
 }
+
+// float64 is not supported by JSON yet. Also, floating point as categories is tricky
+// since floating point equality test is inaccurate for most hardware.
+constexpr StringView NoFloatCat() {
+  return "Category index from DataFrame has floating point dtype, consider using strings or "
+         "integers instead.";
+}
 }  // namespace xgboost::error
 #endif  // XGBOOST_COMMON_ERROR_MSG_H_

--- a/src/data/adapter.h
+++ b/src/data/adapter.h
@@ -16,10 +16,11 @@
 #include <variant>    // for variant
 #include <vector>     // for vector
 
-#include "../common/math.h"
-#include "../encoder/ordinal.h"  // for CatStrArrayView
-#include "../encoder/types.h"    // for TupToVarT
-#include "array_interface.h"     // for CategoricalIndexArgTypes
+#include "../common/error_msg.h"  // for NoFloatCat
+#include "../common/math.h"       // for CheckNAN
+#include "../encoder/ordinal.h"   // for CatStrArrayView
+#include "../encoder/types.h"     // for TupToVarT
+#include "array_interface.h"      // for CategoricalIndexArgTypes
 #include "xgboost/base.h"
 #include "xgboost/data.h"
 #include "xgboost/logging.h"
@@ -627,6 +628,9 @@ template <typename CategoricalIndex, bool allow_mask>
     using T = typename decltype(t)::value_type;
     constexpr bool kKnownType = enc::MemberOf<std::remove_cv_t<T>, enc::CatPrimIndexTypes>::value;
     CHECK(kKnownType) << "Unsupported categorical index type.";
+    if constexpr (std::is_floating_point_v<T>) {
+      LOG(FATAL) << error::NoFloatCat();
+    }
     auto span = common::Span{t.Values().data(), t.Size()};
     if constexpr (kKnownType) {
       p_cat_columns->emplace_back(span);

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -43,7 +43,7 @@ CatContainer::CatContainer(enc::HostColumnsView const& df) : CatContainer{} {
 
                      // float64 is not supported by JSON yet. Also, floating point as
                      // categories is tricky since floating point equality test is
-                     // inaccurate for most hardward.
+                     // inaccurate for most hardware.
                      if constexpr (std::is_same_v<ElemT, double>) {
                        LOG(FATAL) << "Category index from DataFrame has f64 dtype, consider "
                                      "using strings or integers instead.";

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -39,6 +39,16 @@ CatContainer::CatContainer(enc::HostColumnsView const& df) : CatContainer{} {
                      using T =
                          typename cpu_impl::ViewToStorageImpl<std::decay_t<decltype(values)>>::Type;
                      this->cpu_impl_->columns.emplace_back();
+                     using ElemT = typename T::value_type;
+
+                     // float64 is not supported by JSON yet. Also, floating point as
+                     // categories is tricky since floating point equality test is
+                     // inaccurate for most hardward.
+                     if constexpr (std::is_same_v<ElemT, double>) {
+                       LOG(FATAL) << "Category index from DataFrame has f64 dtype, consider "
+                                     "using strings or integers instead.";
+                     }
+
                      this->cpu_impl_->columns.back().emplace<T>();
                      auto& v = std::get<T>(this->cpu_impl_->columns.back());
                      v.resize(values.size());

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -9,8 +9,9 @@
 #include <utility>    // for move
 #include <vector>     // for vector
 
-#include "../encoder/types.h"  // for Overloaded
-#include "xgboost/json.h"      // for Json
+#include "../common/error_msg.h"  // for NoFloatCat
+#include "../encoder/types.h"     // for Overloaded
+#include "xgboost/json.h"         // for Json
 
 namespace xgboost {
 CatContainer::CatContainer(enc::HostColumnsView const& df) : CatContainer{} {
@@ -41,12 +42,8 @@ CatContainer::CatContainer(enc::HostColumnsView const& df) : CatContainer{} {
                      this->cpu_impl_->columns.emplace_back();
                      using ElemT = typename T::value_type;
 
-                     // float64 is not supported by JSON yet. Also, floating point as
-                     // categories is tricky since floating point equality test is
-                     // inaccurate for most hardware.
-                     if constexpr (std::is_same_v<ElemT, double>) {
-                       LOG(FATAL) << "Category index from DataFrame has f64 dtype, consider "
-                                     "using strings or integers instead.";
+                     if constexpr (std::is_floating_point_v<ElemT>) {
+                       LOG(FATAL) << error::NoFloatCat();
                      }
 
                      this->cpu_impl_->columns.back().emplace<T>();

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -244,13 +244,13 @@ void CatContainer::Copy(Context const* ctx, CatContainer const& that) {
 
 [[nodiscard]] enc::HostColumnsView CatContainer::HostView() const { return this->HostViewImpl(); }
 
+[[nodiscard]] bool CatContainer::Empty() const { return this->cpu_impl_->columns.empty(); }
+
 void CatContainer::Sort(Context const* ctx) {
   CHECK(ctx->IsCPU());
   auto view = this->HostView();
   this->sorted_idx_.HostVector().resize(view.n_total_cats);
   enc::SortNames(enc::Policy<EncErrorPolicy>{}, view, this->sorted_idx_.HostSpan());
 }
-
-[[nodiscard]] bool CatContainer::DeviceCanRead() const { return false; }
 #endif  // !defined(XGBOOST_USE_CUDA)
 }  // namespace xgboost

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -236,7 +236,11 @@ CatContainer::CatContainer() : cpu_impl_{std::make_unique<cpu_impl::CatContainer
 
 CatContainer::~CatContainer() = default;
 
-void CatContainer::Copy(Context const*, CatContainer const& that) { this->CopyCommon(that); }
+void CatContainer::Copy(Context const* ctx, CatContainer const& that) {
+  this->CopyCommon(ctx, that);
+  [[maybe_unused]] auto h_view = that.HostView();
+  this->cpu_impl_->Copy(that.cpu_impl_.get());
+}
 
 [[nodiscard]] enc::HostColumnsView CatContainer::HostView() const { return this->HostViewImpl(); }
 

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -61,6 +61,9 @@ CatContainer::CatContainer(enc::HostColumnsView const& df) : CatContainer{} {
   CHECK(this->HostCanRead());
   CHECK_EQ(this->n_total_cats_, df.feature_segments.back());
   CHECK_GE(this->n_total_cats_, 0) << "Too many categories.";
+  if (this->n_total_cats_ > 0) {
+    CHECK(!this->cpu_impl_->columns.empty());
+  }
 }
 
 namespace {
@@ -237,8 +240,8 @@ CatContainer::CatContainer() : cpu_impl_{std::make_unique<cpu_impl::CatContainer
 CatContainer::~CatContainer() = default;
 
 void CatContainer::Copy(Context const* ctx, CatContainer const& that) {
-  this->CopyCommon(ctx, that);
   [[maybe_unused]] auto h_view = that.HostView();
+  this->CopyCommon(ctx, that);
   this->cpu_impl_->Copy(that.cpu_impl_.get());
 }
 

--- a/src/data/cat_container.cu
+++ b/src/data/cat_container.cu
@@ -151,7 +151,7 @@ CatContainer::~CatContainer() = default;
 void CatContainer::Copy(Context const* ctx, CatContainer const& that) {
   this->CopyCommon(that);
   if (ctx->IsCPU()) {
-    auto h_view = that.HostView();
+    [[maybe_unused]] auto h_view = that.HostView();
     this->cpu_impl_->Copy(that.cpu_impl_.get());
   } else {
     auto const& that_impl = that.cu_impl_;

--- a/src/data/cat_container.cu
+++ b/src/data/cat_container.cu
@@ -152,7 +152,6 @@ void CatContainer::Copy(Context const* ctx, CatContainer const& that) {
   this->CopyCommon(that);
   if (ctx->IsCPU()) {
     auto h_view = that.HostView();
-    CHECK(!h_view.Empty());
     this->cpu_impl_->Copy(that.cpu_impl_.get());
   } else {
     auto const& that_impl = that.cu_impl_;

--- a/src/data/cat_container.h
+++ b/src/data/cat_container.h
@@ -160,10 +160,9 @@ class CatContainer {
   [[nodiscard]] common::Span<bst_cat_t const> RefSortedIndex(Context const* ctx) const {
     std::lock_guard guard{device_mu_};
     if (ctx->IsCPU()) {
-      CHECK(this->sorted_idx_.HostCanRead());
       return this->sorted_idx_.ConstHostSpan();
     } else {
-      CHECK(this->sorted_idx_.DeviceCanRead());
+      sorted_idx_.SetDevice(ctx->Device());
       return this->sorted_idx_.ConstDeviceSpan();
     }
   }

--- a/src/data/cat_container.h
+++ b/src/data/cat_container.h
@@ -106,12 +106,16 @@ class CatContainer {
   /**
    * @brief Implementation of the Copy method, used by both CPU and GPU.
    */
-  void CopyCommon(CatContainer const& that) {
-    this->sorted_idx_.SetDevice(that.sorted_idx_.Device());
+  void CopyCommon(Context const* ctx, CatContainer const& that) {
+    auto device = ctx->Device();
+
+    that.sorted_idx_.SetDevice(device);
+    this->sorted_idx_.SetDevice(device);
     this->sorted_idx_.Resize(that.sorted_idx_.Size());
     this->sorted_idx_.Copy(that.sorted_idx_);
 
-    this->feature_segments_.SetDevice(that.feature_segments_.Device());
+    this->feature_segments_.SetDevice(device);
+    that.feature_segments_.SetDevice(device);
     this->feature_segments_.Resize(that.feature_segments_.Size());
     this->feature_segments_.Copy(that.feature_segments_);
 
@@ -141,7 +145,10 @@ class CatContainer {
 
   // Mostly used for testing.
   void Push(cpu_impl::ColumnType const& column) { this->cpu_impl_->columns.emplace_back(column); }
-
+  /**
+   * @brief Wether the container is initialized at all. If the input is not a DataFrame,
+   *        this method returns True.
+   */
   [[nodiscard]] bool Empty() const { return this->cpu_impl_->columns.empty(); }
 
   [[nodiscard]] std::size_t NumFeatures() const { return this->cpu_impl_->columns.size(); }

--- a/src/data/cat_container.h
+++ b/src/data/cat_container.h
@@ -138,10 +138,8 @@ class CatContainer {
 
   void Copy(Context const* ctx, CatContainer const& that);
 
-  [[nodiscard]] bool HostCanRead() const {
-    return !this->cpu_impl_->columns.empty() || this->n_total_cats_ == 0;
-  }
-  [[nodiscard]] bool DeviceCanRead() const;
+  [[nodiscard]] bool HostCanRead() const { return this->feature_segments_.HostCanRead(); }
+  [[nodiscard]] bool DeviceCanRead() const { return this->feature_segments_.DeviceCanRead(); }
 
   // Mostly used for testing.
   void Push(cpu_impl::ColumnType const& column) { this->cpu_impl_->columns.emplace_back(column); }
@@ -149,9 +147,12 @@ class CatContainer {
    * @brief Wether the container is initialized at all. If the input is not a DataFrame,
    *        this method returns True.
    */
-  [[nodiscard]] bool Empty() const { return this->cpu_impl_->columns.empty(); }
+  [[nodiscard]] bool Empty() const;
 
   [[nodiscard]] std::size_t NumFeatures() const { return this->cpu_impl_->columns.size(); }
+  /**
+   * @brief The number of categories across all features.
+   */
   [[nodiscard]] std::size_t NumCatsTotal() const { return this->n_total_cats_; }
 
   /**

--- a/src/data/device_adapter.cuh
+++ b/src/data/device_adapter.cuh
@@ -109,7 +109,7 @@ class CudfAdapter : public detail::SingleBatchDataIter<CudfAdapterBatch> {
   explicit CudfAdapter(std::string cuda_interfaces_str)
       : CudfAdapter{StringView{cuda_interfaces_str}} {}
 
-  const CudfAdapterBatch& Value() const override {
+  [[nodiscard]] CudfAdapterBatch const& Value() const override {
     CHECK_EQ(batch_.columns_.data(), columns_.data().get());
     return batch_;
   }

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -51,7 +51,13 @@ DMatrix* SimpleDMatrix::Slice(common::Span<int32_t const> ridxs) {
   }
   out->fmat_ctx_ = this->fmat_ctx_;
 
-  out->Info().Cats()->Copy(&this->fmat_ctx_, *this->Info().Cats());
+  std::shared_ptr<CatContainer> ptr;
+  if (this->fmat_ctx_.IsCPU()) {
+    ptr = std::make_shared<CatContainer>(this->Info().Cats()->HostView());
+  } else {
+    ptr = std::make_shared<CatContainer>(fmat_ctx_.Device(),
+                                         this->Info().Cats()->DeviceView(&fmat_ctx_));
+  }
   return out;
 }
 

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -50,10 +50,15 @@ DMatrix* SimpleDMatrix::Slice(common::Span<int32_t const> ridxs) {
     out->Info() = this->Info().Slice(&ctx, h_ridx, h_offset.back());
   }
   out->fmat_ctx_ = this->fmat_ctx_;
+
+  out->Info().Cats()->Copy(&this->fmat_ctx_, *this->Info().Cats());
   return out;
 }
 
 DMatrix* SimpleDMatrix::SliceCol(int num_slices, int slice_id) {
+  if (this->Cats()->HasCategorical()) {
+    LOG(FATAL) << "Slicing column is not supported for DataFrames with categorical columns.";
+  }
   auto out = new SimpleDMatrix;
   SparsePage& out_page = *out->sparse_page_;
   auto const slice_size = info_.num_col_ / num_slices;

--- a/src/data/simple_dmatrix.cc
+++ b/src/data/simple_dmatrix.cc
@@ -51,13 +51,7 @@ DMatrix* SimpleDMatrix::Slice(common::Span<int32_t const> ridxs) {
   }
   out->fmat_ctx_ = this->fmat_ctx_;
 
-  std::shared_ptr<CatContainer> ptr;
-  if (this->fmat_ctx_.IsCPU()) {
-    ptr = std::make_shared<CatContainer>(this->Info().Cats()->HostView());
-  } else {
-    ptr = std::make_shared<CatContainer>(fmat_ctx_.Device(),
-                                         this->Info().Cats()->DeviceView(&fmat_ctx_));
-  }
+  out->Info().Cats()->Copy(&fmat_ctx_, *this->Info().Cats());
   return out;
 }
 

--- a/src/data/simple_dmatrix.cu
+++ b/src/data/simple_dmatrix.cu
@@ -7,7 +7,7 @@
 
 #include "../common/cuda_rt_utils.h"  // for CurrentDevice
 #include "cat_container.h"            // for CatContainer
-#include "device_adapter.cuh"         // for CurrentDevice
+#include "device_adapter.cuh"
 #include "simple_dmatrix.cuh"
 #include "simple_dmatrix.h"
 #include "xgboost/context.h"  // for Context

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -127,7 +127,7 @@ BatchSet<SparsePage> SparsePageDMatrix::GetRowBatches() {
 }
 
 BatchSet<CSCPage> SparsePageDMatrix::GetColumnBatches(Context const *ctx) {
-  auto id = MakeCache(this, ".col.page", on_host_, cache_prefix_, &cache_info_);
+  auto id = MakeCache(this, ".col.page", false, cache_prefix_, &cache_info_);
   CHECK_NE(this->Info().num_col_, 0);
   this->InitializeSparsePage(ctx);
   if (!column_source_) {
@@ -141,7 +141,7 @@ BatchSet<CSCPage> SparsePageDMatrix::GetColumnBatches(Context const *ctx) {
 }
 
 BatchSet<SortedCSCPage> SparsePageDMatrix::GetSortedColumnBatches(Context const *ctx) {
-  auto id = MakeCache(this, ".sorted.col.page", on_host_, cache_prefix_, &cache_info_);
+  auto id = MakeCache(this, ".sorted.col.page", false, cache_prefix_, &cache_info_);
   CHECK_NE(this->Info().num_col_, 0);
   this->InitializeSparsePage(ctx);
   if (!sorted_column_source_) {
@@ -160,11 +160,11 @@ BatchSet<GHistIndexMatrix> SparsePageDMatrix::GetGradientIndex(Context const *ct
     CHECK_GE(param.max_bin, 2);
   }
   detail::CheckEmpty(batch_param_, param);
-  auto id = MakeCache(this, ".gradient_index.page", on_host_, cache_prefix_, &cache_info_);
+  auto id = MakeCache(this, ".gradient_index.page", false, cache_prefix_, &cache_info_);
   if (!cache_info_.at(id)->written || detail::RegenGHist(batch_param_, param)) {
     this->InitializeSparsePage(ctx);
     cache_info_.erase(id);
-    id = MakeCache(this, ".gradient_index.page", on_host_, cache_prefix_, &cache_info_);
+    id = MakeCache(this, ".gradient_index.page", false, cache_prefix_, &cache_info_);
     LOG(INFO) << "Generating new Gradient Index.";
     // Use sorted sketch for approx.
     auto sorted_sketch = param.regen;

--- a/src/encoder/ordinal.h
+++ b/src/encoder/ordinal.h
@@ -342,6 +342,13 @@ void Recode(ExecPolicy const &policy, HostColumnsView orig_enc, Span<std::int32_
   std::size_t out_idx = 0;
   for (std::size_t f_idx = 0, n_features = orig_enc.Size(); f_idx < n_features; f_idx++) {
     bool is_empty = std::visit([](auto &&arg) { return arg.empty(); }, orig_enc.columns[f_idx]);
+    bool new_is_empty = std::visit([](auto &&arg) { return arg.empty(); }, new_enc.columns[f_idx]);
+    if (is_empty != new_is_empty) {
+      std::stringstream ss;
+      ss << "Invalid new DataFrame input for the: " << f_idx
+         << "th feature. The data type doesn't match the one used in the training dataset.";
+      policy.Error(ss.str());
+    }
     if (is_empty) {
       continue;
     }

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -1,5 +1,6 @@
 /**
  * Copyright 2014-2025, XGBoost Contributors
+ *
  * \file gbtree.cc
  * \brief gradient boosted tree implementation.
  * \author Tianqi Chen
@@ -212,8 +213,10 @@ void GBTree::DoBoost(DMatrix* p_fmat, linalg::Matrix<GradientPair>* in_gpair,
   bst_target_t const n_groups = model_.learner_model_param->OutputLength();
   monitor_.Start("BoostNewTrees");
 
+  // Define the categories.
   if (this->model_.cats->Empty() && !p_fmat->Cats()->Empty()) {
     p_fmat->Info().Cats()->Sort(ctx_);
+    // fixme: test this doesn't hold the DMatrix.
     this->model_.cats = p_fmat->CatsShared();
   }
 

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -214,10 +214,9 @@ void GBTree::DoBoost(DMatrix* p_fmat, linalg::Matrix<GradientPair>* in_gpair,
   monitor_.Start("BoostNewTrees");
 
   // Define the categories.
-  if (this->model_.cats->Empty() && !p_fmat->Cats()->Empty()) {
-    p_fmat->Info().Cats()->Sort(ctx_);
-    // fixme: test this doesn't hold the DMatrix.
-    this->model_.cats = p_fmat->CatsShared();
+  if (this->model_.Cats()->Empty() && !p_fmat->Cats()->Empty()) {
+    this->model_.Cats()->Copy(this->ctx_, *p_fmat->Cats());
+    this->model_.Cats()->Sort(this->ctx_);
   }
 
   predt->predictions.SetDevice(ctx_->Device());

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -215,7 +215,8 @@ void GBTree::DoBoost(DMatrix* p_fmat, linalg::Matrix<GradientPair>* in_gpair,
 
   // Define the categories.
   if (this->model_.Cats()->Empty() && !p_fmat->Cats()->Empty()) {
-    this->model_.Cats()->Copy(this->ctx_, *p_fmat->Cats());
+    auto in_cats = p_fmat->Cats();
+    this->model_.Cats()->Copy(this->ctx_, *in_cats);
     this->model_.Cats()->Sort(this->ctx_);
   } else {
     CHECK_EQ(this->model_.Cats()->NumCatsTotal(), p_fmat->Cats()->NumCatsTotal())

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -217,6 +217,10 @@ void GBTree::DoBoost(DMatrix* p_fmat, linalg::Matrix<GradientPair>* in_gpair,
   if (this->model_.Cats()->Empty() && !p_fmat->Cats()->Empty()) {
     this->model_.Cats()->Copy(this->ctx_, *p_fmat->Cats());
     this->model_.Cats()->Sort(this->ctx_);
+  } else {
+    CHECK_EQ(this->model_.Cats()->NumCatsTotal(), p_fmat->Cats()->NumCatsTotal())
+        << "A new dataset with different categorical features is used for training an existing "
+           "model.";
   }
 
   predt->predictions.SetDevice(ctx_->Device());

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -212,6 +212,11 @@ void GBTree::DoBoost(DMatrix* p_fmat, linalg::Matrix<GradientPair>* in_gpair,
   bst_target_t const n_groups = model_.learner_model_param->OutputLength();
   monitor_.Start("BoostNewTrees");
 
+  if (this->model_.cats->Empty() && !p_fmat->Cats()->Empty()) {
+    p_fmat->Info().Cats()->Sort(ctx_);
+    this->model_.cats = p_fmat->CatsShared();
+  }
+
   predt->predictions.SetDevice(ctx_->Device());
   auto out = linalg::MakeTensorView(ctx_, &predt->predictions, p_fmat->Info().num_row_,
                                     model_.learner_model_param->OutputLength());

--- a/src/gbm/gbtree_model.cc
+++ b/src/gbm/gbtree_model.cc
@@ -144,11 +144,11 @@ void GBTreeModel::LoadModel(Json const& in) {
 
   auto const& jmodel = get<Object const>(in);
 
-  auto const& trees_json = get<Array const>(in["trees"]);
+  auto const& trees_json = get<Array const>(jmodel.at("trees"));
   CHECK_EQ(trees_json.size(), param.num_trees);
   trees.resize(param.num_trees);
 
-  auto const& tree_info_json = get<Array const>(in["tree_info"]);
+  auto const& tree_info_json = get<Array const>(jmodel.at("tree_info"));
   CHECK_EQ(tree_info_json.size(), param.num_trees);
   tree_info.resize(param.num_trees);
 
@@ -174,7 +174,10 @@ void GBTreeModel::LoadModel(Json const& in) {
   }
 
   auto p_cats = std::make_shared<CatContainer>();
-  p_cats->Load(in["cats"]);
+  auto cat_it = jmodel.find("cats");
+  if (cat_it != jmodel.cend()) {
+    p_cats->Load(cat_it->second);
+  }
   this->cats = std::move(p_cats);
   Validate(*this);
 }

--- a/src/gbm/gbtree_model.cc
+++ b/src/gbm/gbtree_model.cc
@@ -133,7 +133,7 @@ void GBTreeModel::SaveModel(Json* p_out) const {
                  [](bst_tree_t i) { return Integer{i}; });
   out["iteration_indptr"] = Array{std::move(jiteration_indptr)};
 
-  this->cats->Save(&out["cats"]);
+  this->Cats()->Save(&out["cats"]);
 }
 
 void GBTreeModel::LoadModel(Json const& in) {
@@ -178,7 +178,7 @@ void GBTreeModel::LoadModel(Json const& in) {
   if (cat_it != jmodel.cend()) {
     p_cats->Load(cat_it->second);
   }
-  this->cats = std::move(p_cats);
+  this->cats_ = std::move(p_cats);
   Validate(*this);
 }
 

--- a/src/gbm/gbtree_model.cc
+++ b/src/gbm/gbtree_model.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023, XGBoost Contributors
+ * Copyright 2019-2024, XGBoost Contributors
  */
 #include "gbtree_model.h"
 
@@ -132,6 +132,8 @@ void GBTreeModel::SaveModel(Json* p_out) const {
   std::transform(iteration_indptr.cbegin(), iteration_indptr.cend(), jiteration_indptr.begin(),
                  [](bst_tree_t i) { return Integer{i}; });
   out["iteration_indptr"] = Array{std::move(jiteration_indptr)};
+
+  this->cats->Save(&out["cats"]);
 }
 
 void GBTreeModel::LoadModel(Json const& in) {
@@ -171,6 +173,9 @@ void GBTreeModel::LoadModel(Json const& in) {
     MakeIndptr(this);
   }
 
+  auto p_cats = std::make_shared<CatContainer>();
+  p_cats->Load(in["cats"]);
+  this->cats = std::move(p_cats);
   Validate(*this);
 }
 

--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023, XGBoost Contributors
+ * Copyright 2017-2024, XGBoost Contributors
  * \file gbtree_model.h
  */
 #ifndef XGBOOST_GBM_GBTREE_MODEL_H_
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "../common/threading_utils.h"
+#include "../data/cat_container.h"  // for CatContainer
 
 namespace xgboost {
 
@@ -94,7 +95,7 @@ struct GBTreeModel : public Model {
 
   void InitTreesToUpdate() {
     if (trees_to_update.size() == 0u) {
-      for (auto & tree : trees) {
+      for (auto& tree : trees) {
         trees_to_update.push_back(std::move(tree));
       }
       trees.clear();
@@ -146,22 +147,23 @@ struct GBTreeModel : public Model {
   // model parameter
   GBTreeModelParam param;
   /*! \brief vector of trees stored in the model */
-  std::vector<std::unique_ptr<RegTree> > trees;
+  std::vector<std::unique_ptr<RegTree>> trees;
   /*! \brief for the update process, a place to keep the initial trees */
-  std::vector<std::unique_ptr<RegTree> > trees_to_update;
+  std::vector<std::unique_ptr<RegTree>> trees_to_update;
   /**
-   * \brief Group index for trees.
+   * @brief Group index for trees.
    */
   std::vector<int> tree_info;
   /**
-   * \brief Number of trees accumulated for each iteration.
+   * @brief Number of trees accumulated for each iteration.
    */
   std::vector<bst_tree_t> iteration_indptr{0};
+  /**
+   * @brief Categories in the training data.
+   */
+  std::shared_ptr<CatContainer const> cats{std::make_shared<CatContainer>()};
 
  private:
-  /**
-   * \brief Whether the stack contains multi-target tree.
-   */
   Context const* ctx_;
 };
 }  // namespace gbm

--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -1,6 +1,7 @@
 /**
- * Copyright 2017-2024, XGBoost Contributors
- * \file gbtree_model.h
+ * Copyright 2017-2025, XGBoost Contributors
+ *
+ * @file gbtree_model.h
  */
 #ifndef XGBOOST_GBM_GBTREE_MODEL_H_
 #define XGBOOST_GBM_GBTREE_MODEL_H_

--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -162,6 +162,7 @@ struct GBTreeModel : public Model {
 
   [[nodiscard]] CatContainer const* Cats() const { return this->cats_.get(); }
   [[nodiscard]] CatContainer* Cats() { return this->cats_.get(); }
+  void Cats(std::shared_ptr<CatContainer> cats) { this->cats_ = cats; }
 
  private:
   /**

--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -159,12 +159,15 @@ struct GBTreeModel : public Model {
    * @brief Number of trees accumulated for each iteration.
    */
   std::vector<bst_tree_t> iteration_indptr{0};
+
+  [[nodiscard]] CatContainer const* Cats() const { return this->cats_.get(); }
+  [[nodiscard]] CatContainer* Cats() { return this->cats_.get(); }
+
+ private:
   /**
    * @brief Categories in the training data.
    */
-  std::shared_ptr<CatContainer const> cats{std::make_shared<CatContainer>()};
-
- private:
+  std::shared_ptr<CatContainer> cats_{std::make_shared<CatContainer>()};
   Context const* ctx_;
 };
 }  // namespace gbm

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -843,7 +843,7 @@ class LearnerConfiguration : public Learner {
     }
   }
 
-  void InitEstimation(MetaInfo const& info, linalg::Tensor<float, 1>* base_score) {
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) {
     base_score->Reshape(1);
     collective::ApplyWithLabels(this->Ctx(), info, base_score->Data(),
                                 [&] { UsePtr(obj_)->InitEstimation(info, base_score); });

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -981,7 +981,7 @@ class CPUPredictor : public Predictor {
         }
       }
     };
-    if (model.Cats()->HasCategorical()) {
+    if (model.Cats()->HasCategorical() && p_fmat->CatsShared()->HasCategorical()) {
       auto [acc, mapping] = MakeCatAccessor(ctx_, p_fmat->Cats()->HostView(), model);
       launch(acc);
     } else {

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -370,7 +370,6 @@ static void InitThreadTemp(int nthread, std::vector<RegTree::FVec> *out) {
 auto MakeCatAccessor(Context const *ctx, enc::HostColumnsView const &cats,
                      gbm::GBTreeModel const &model) {
   std::vector<std::int32_t> mapping(cats.n_total_cats);
-  // fixme: thread safety!
   auto sorted_idx = model.cats->RefSortedIndex(ctx);
   auto orig_enc = model.cats->HostView();
   enc::Recode(cpu_impl::EncPolicy, orig_enc, sorted_idx, cats, common::Span{mapping});

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -899,7 +899,8 @@ class CPUPredictor : public Predictor {
     if (p_fmat->Info().IsColumnSplit()) {
       CHECK(!model.learner_model_param->IsVectorLeaf())
           << "Predict leaf with column split" << MTNotImplemented();
-
+      CHECK(!model.Cats()->HasCategorical())
+          << "Categorical feature is not yet supported with column-split.";
       ColumnSplitHelper helper(n_threads, model, 0, ntree_limit);
       helper.PredictLeaf(ctx_, p_fmat, &preds);
       return;

--- a/src/predictor/predict_fn.h
+++ b/src/predictor/predict_fn.h
@@ -82,6 +82,18 @@ struct CatAccessor {
     }
     return fvalue;
   }
+
+  [[nodiscard]] XGBOOST_DEVICE float operator()(Entry const &e) const {
+    auto fvalue = e.fvalue;
+    if (!enc.Empty() && !enc[e.index].empty()) {
+      auto f_mapping = enc[e.index];
+      auto cat_idx = common::AsCat(fvalue);
+      if (cat_idx >= 0 && cat_idx < common::AsCat(f_mapping.size())) {
+        fvalue = f_mapping.data()[cat_idx];
+      }
+    }
+    return fvalue;
+  }
 };
 
 /**
@@ -91,6 +103,7 @@ struct NoOpAccessor {
   XGBOOST_DEVICE explicit NoOpAccessor(enc::MappingView const &) {}
   NoOpAccessor() = default;
   [[nodiscard]] XGBOOST_DEVICE float operator()(data::COOTuple const &e) const { return e.value; }
+  [[nodiscard]] XGBOOST_DEVICE float operator()(Entry const &e) const { return e.fvalue; }
 };
 }  // namespace xgboost::predictor
 #endif  // XGBOOST_PREDICTOR_PREDICT_FN_H_

--- a/src/predictor/predict_fn.h
+++ b/src/predictor/predict_fn.h
@@ -66,6 +66,9 @@ inline bst_tree_t GetTreeLimit(std::vector<std::unique_ptr<RegTree>> const &tree
   return ntree_limit;
 }
 
+/**
+ * @brief Accessor for obtaining re-coded categories.
+ */
 struct CatAccessor {
   enc::MappingView enc;
   [[nodiscard]] XGBOOST_DEVICE float operator()(data::COOTuple const &e) const {
@@ -81,6 +84,9 @@ struct CatAccessor {
   }
 };
 
+/**
+ * @brief No-op accessor used to handle numeric data.
+ */
 struct NoOpAccessor {
   XGBOOST_DEVICE explicit NoOpAccessor(enc::MappingView const &) {}
   NoOpAccessor() = default;

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -208,7 +208,8 @@ class TestGPUUpdaters:
         dataset = tm.TestDataset(
             "ames_housing", tm.data.get_ames_housing, "reg:squarederror", "rmse"
         )
-        cat_parameters["tree_method"] = "gpu_hist"
+        cat_parameters["tree_method"] = "hist"
+        cat_parameters["device"] = "cuda"
         results = train_result(cat_parameters, dataset.get_dmat(), 16)
         tm.non_increasing(results["train"]["rmse"])
 

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -34,7 +34,8 @@ class TestGPUUpdatersMulti:
     )
     @settings(deadline=None, max_examples=50, print_blob=True)
     def test_hist(self, param, num_rounds, dataset):
-        param["tree_method"] = "gpu_hist"
+        param["tree_method"] = "hist"
+        param["device"] = "cuda"
         param = dataset.set_params(param)
         result = train_result(param, dataset.get_dmat(), num_rounds)
         note(str(result))
@@ -261,7 +262,8 @@ class TestGPUUpdaters:
     ) -> None:
         # We cannot handle empty dataset yet
         assume(len(dataset.y) > 0)
-        param["tree_method"] = "gpu_hist"
+        param["tree_method"] = "hist"
+        param["device"] = "cuda"
         param = dataset.set_params(param)
         result = train_result(
             param,
@@ -282,7 +284,8 @@ class TestGPUUpdaters:
             return
         # We cannot handle empty dataset yet
         assume(len(dataset.y) > 0)
-        param["tree_method"] = "gpu_hist"
+        param["tree_method"] = "hist"
+        param["device"] = "cuda"
         param = dataset.set_params(param)
         m = dataset.get_external_dmat()
         external_result = train_result(param, m, num_rounds)
@@ -318,8 +321,10 @@ class TestGPUUpdaters:
     @pytest.mark.mgpu
     @given(tm.make_dataset_strategy(), strategies.integers(0, 10))
     @settings(deadline=None, max_examples=10, print_blob=True)
-    def test_specified_gpu_id_gpu_update(self, dataset, gpu_id):
-        param = {"tree_method": "gpu_hist", "gpu_id": gpu_id}
+    def test_specified_gpu_id_gpu_update(
+        self, dataset: tm.TestDataset, gpu_id: int
+    ) -> None:
+        param = {"tree_method": "hist", "device": f"cuda:{gpu_id}"}
         param = dataset.set_params(param)
         result = train_result(param, dataset.get_dmat(), 10)
         assert tm.non_increasing(result["train"][dataset.metric])

--- a/tests/python-gpu/test_gpu_with_sklearn.py
+++ b/tests/python-gpu/test_gpu_with_sklearn.py
@@ -84,11 +84,14 @@ def test_categorical():
         os.path.join(data_dir, "agaricus.txt.train"), dtype=np.float32
     )
     clf = xgb.XGBClassifier(
-        tree_method="gpu_hist",
+        tree_method="hist",
+        device="cuda",
         enable_categorical=True,
         n_estimators=10,
     )
     X = pd.DataFrame(X.todense()).astype("category")
+    for c in X.columns:
+        X[c] = X[c].cat.rename_categories(int)
     clf.fit(X, y)
 
     with tempfile.TemporaryDirectory() as tempdir:
@@ -107,7 +110,7 @@ def test_categorical():
 
     def check_predt(X, y):
         reg = xgb.XGBRegressor(
-            tree_method="gpu_hist", enable_categorical=True, n_estimators=64
+            tree_method="hist", enable_categorical=True, n_estimators=64, device="cuda"
         )
         reg.fit(X, y)
         predts = reg.predict(X)

--- a/tests/python-gpu/test_gpu_with_sklearn.py
+++ b/tests/python-gpu/test_gpu_with_sklearn.py
@@ -80,7 +80,9 @@ def test_categorical():
     from sklearn.datasets import load_svmlight_file
 
     data_dir = tm.data_dir(__file__)
-    X, y = load_svmlight_file(os.path.join(data_dir, "agaricus.txt.train"))
+    X, y = load_svmlight_file(
+        os.path.join(data_dir, "agaricus.txt.train"), dtype=np.float32
+    )
     clf = xgb.XGBClassifier(
         tree_method="gpu_hist",
         enable_categorical=True,

--- a/tests/python/test_demos.py
+++ b/tests/python/test_demos.py
@@ -228,6 +228,8 @@ def test_cli_regression_demo() -> None:
     subprocess.check_call(cmd, cwd=reg_dir)
 
     exe = os.path.join(DEMO_DIR, os.path.pardir, "xgboost")
+    if not os.path.exists(exe):
+        pytest.skip("CLI executable not found.")
     conf = os.path.join(reg_dir, "machine.conf")
     subprocess.check_call([exe, conf], cwd=reg_dir)
 
@@ -237,6 +239,9 @@ def test_cli_regression_demo() -> None:
 )
 def test_cli_binary_classification() -> None:
     cls_dir = os.path.join(CLI_DEMO_DIR, "binary_classification")
+    exe = os.path.join(DEMO_DIR, os.path.pardir, "xgboost")
+    if not os.path.exists(exe):
+        pytest.skip("CLI executable not found.")
     with tm.DirectoryExcursion(cls_dir, cleanup=True):
         subprocess.check_call(["./runexp.sh"])
         os.remove("0002.model")

--- a/tests/python/test_ordinal.py
+++ b/tests/python/test_ordinal.py
@@ -5,6 +5,7 @@ from xgboost.testing.ordinal import (
     run_cat_container,
     run_cat_container_iter,
     run_cat_container_mixed,
+    run_cat_predict,
 )
 
 pytestmark = pytest.mark.skipif(**tm.no_multiple(tm.no_arrow(), tm.no_pandas()))
@@ -20,3 +21,7 @@ def test_cat_container_mixed() -> None:
 
 def test_cat_container_iter() -> None:
     run_cat_container_iter("cpu")
+
+
+def test_cat_predict() -> None:
+    run_cat_predict("cpu")

--- a/tests/python/test_ordinal.py
+++ b/tests/python/test_ordinal.py
@@ -6,6 +6,7 @@ from xgboost.testing.ordinal import (
     run_cat_container_iter,
     run_cat_container_mixed,
     run_cat_invalid,
+    run_cat_leaf,
     run_cat_predict,
     run_cat_shap,
     run_cat_thread_safety,
@@ -40,3 +41,7 @@ def test_cat_thread_safety() -> None:
 
 def test_cat_shap() -> None:
     run_cat_shap("cpu")
+
+
+def test_cat_leaf() -> None:
+    run_cat_leaf("cpu")

--- a/tests/python/test_ordinal.py
+++ b/tests/python/test_ordinal.py
@@ -7,6 +7,7 @@ from xgboost.testing.ordinal import (
     run_cat_container_mixed,
     run_cat_invalid,
     run_cat_predict,
+    run_cat_shap,
     run_cat_thread_safety,
 )
 
@@ -35,3 +36,7 @@ def test_cat_invalid() -> None:
 
 def test_cat_thread_safety() -> None:
     run_cat_thread_safety("cpu")
+
+
+def test_cat_shap() -> None:
+    run_cat_shap("cpu")

--- a/tests/python/test_ordinal.py
+++ b/tests/python/test_ordinal.py
@@ -7,6 +7,7 @@ from xgboost.testing.ordinal import (
     run_cat_container_mixed,
     run_cat_invalid,
     run_cat_predict,
+    run_cat_thread_safety,
 )
 
 pytestmark = pytest.mark.skipif(**tm.no_multiple(tm.no_arrow(), tm.no_pandas()))
@@ -30,3 +31,7 @@ def test_cat_predict() -> None:
 
 def test_cat_invalid() -> None:
     run_cat_invalid("cpu")
+
+
+def test_cat_thread_safety() -> None:
+    run_cat_thread_safety("cpu")

--- a/tests/python/test_ordinal.py
+++ b/tests/python/test_ordinal.py
@@ -5,6 +5,7 @@ from xgboost.testing.ordinal import (
     run_cat_container,
     run_cat_container_iter,
     run_cat_container_mixed,
+    run_cat_invalid,
     run_cat_predict,
 )
 
@@ -25,3 +26,7 @@ def test_cat_container_iter() -> None:
 
 def test_cat_predict() -> None:
     run_cat_predict("cpu")
+
+
+def test_cat_invalid() -> None:
+    run_cat_invalid("cpu")

--- a/tests/python/test_predict.py
+++ b/tests/python/test_predict.py
@@ -1,6 +1,7 @@
 """Tests for running inplace prediction."""
 
 from concurrent.futures import ThreadPoolExecutor
+from typing import List, Union
 
 import numpy as np
 import pandas as pd
@@ -251,11 +252,14 @@ class TestInplacePredict:
 
     @pytest.mark.skipif(**tm.no_pandas())
     def test_pd_dtypes(self) -> None:
+        import pandas as pd
         from pandas.api.types import is_bool_dtype
 
         for orig, x in pd_dtypes():
-            dtypes = orig.dtypes if isinstance(orig, pd.DataFrame) else [orig.dtypes]
-            if isinstance(orig, pd.DataFrame) and is_bool_dtype(dtypes[0]):
+            dtypes: Union[List, pd.Series] = (
+                orig.dtypes if isinstance(orig, pd.DataFrame) else [orig.dtypes]
+            )
+            if isinstance(orig, pd.DataFrame) and is_bool_dtype(dtypes.iloc[0]):
                 continue
             y = np.arange(x.shape[0])
             Xy = xgb.DMatrix(orig, y, enable_categorical=True)

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -1,4 +1,4 @@
-"""Copyright 2019-2024, XGBoost contributors"""
+"""Copyright 2019-2025, XGBoost contributors"""
 
 import asyncio
 import json


### PR DESCRIPTION
- inplace predict
- DMatrix
- Raise an error when input categories are floating points.

This PR integrates the re-coder into the CPU predictor by defining an accessor for calculating the mapped values on the fly. For a numeric-only dataset, it's a no op.

Took me some time to get the storage consistent across CPU and GPU. Some code here can be pruned once cuDF supports exporting device arrow arrays.

Ref https://github.com/dmlc/xgboost/issues/11088 .