### PR TITLE
[CI] Avoid the use of full trace with `pytest`.

### DIFF
--- a/ops/pipeline/test-python-wheel-impl.sh
+++ b/ops/pipeline/test-python-wheel-impl.sh
@@ -40,31 +40,28 @@ case "$suite" in
   gpu)
     echo "-- Run Python tests, using a single GPU"
     python -c 'from cupy.cuda import jitify; jitify._init_module()'
-    pytest -v -s -rxXs --fulltrace --durations=0 -m 'not mgpu' tests/python-gpu
+    pytest -v -s -rxXs --durations=0 -m 'not mgpu' tests/python-gpu
     ;;
   mgpu)
     echo "-- Run Python tests, using multiple GPUs"
     python -c 'from cupy.cuda import jitify; jitify._init_module()'
     export NCCL_RAS_ENABLE=0
-    pytest -v -s -rxXs --fulltrace --durations=0 -m 'mgpu' tests/python-gpu
-    pytest -v -s -rxXs --fulltrace --durations=0 -m 'mgpu' \
-      tests/test_distributed/test_gpu_with_dask
-    pytest -v -s -rxXs --fulltrace --durations=0 -m 'mgpu' \
-      tests/test_distributed/test_gpu_with_spark
-    pytest -v -s -rxXs --fulltrace --durations=0 -m 'mgpu' \
-      tests/test_distributed/test_gpu_federated
+    pytest -v -s -rxXs --durations=0 -m 'mgpu' tests/python-gpu
+    pytest -v -s -rxXs --durations=0 tests/test_distributed/test_gpu_with_dask
+    pytest -v -s -rxXs --durations=0 tests/test_distributed/test_gpu_with_spark
+    pytest -v -s -rxXs --durations=0 tests/test_distributed/test_gpu_federated
     ;;
   cpu)
     echo "-- Run Python tests (CPU)"
     export RAY_OBJECT_STORE_ALLOW_SLOW_STORAGE=1
-    pytest -v -s -rxXs --fulltrace --durations=0 tests/python
-    pytest -v -s -rxXs --fulltrace --durations=0 tests/test_distributed/test_with_dask
-    pytest -v -s -rxXs --fulltrace --durations=0 tests/test_distributed/test_with_spark
-    pytest -v -s -rxXs --fulltrace --durations=0 tests/test_distributed/test_federated
+    pytest -v -s -rxXs --durations=0 tests/python
+    pytest -v -s -rxXs --durations=0 tests/test_distributed/test_with_dask
+    pytest -v -s -rxXs --durations=0 tests/test_distributed/test_with_spark
+    pytest -v -s -rxXs --durations=0 tests/test_distributed/test_federated
     ;;
   cpu-arm64)
     echo "-- Run Python tests (CPU, ARM64)"
-    pytest -v -s -rxXs --fulltrace --durations=0 \
+    pytest -v -s -rxXs --durations=0 \
       tests/python/test_basic.py tests/python/test_basic_models.py \
       tests/python/test_model_compatibility.py
     ;;

--- a/ops/pipeline/test-win64-gpu.ps1
+++ b/ops/pipeline/test-win64-gpu.ps1
@@ -18,9 +18,9 @@ python -m pip install `
 if ($LASTEXITCODE -ne 0) { throw "Last command failed" }
 
 Write-Host "--- Run Python tests"
-python -X faulthandler -m pytest -v -s -rxXs --fulltrace tests/python
+python -X faulthandler -m pytest -v -s -rxXs tests/python
 if ($LASTEXITCODE -ne 0) { throw "Last command failed" }
 Write-Host "--- Run Python tests with GPU"
-python -X faulthandler -m pytest -v -s -rxXs --fulltrace -m "(not slow) and (not mgpu)"`
+python -X faulthandler -m pytest -v -s -rxXs -m "(not slow) and (not mgpu)"`
   tests/python-gpu
 if ($LASTEXITCODE -ne 0) { throw "Last command failed" }


### PR DESCRIPTION
Printing out the [entire](https://productionresultssa8.blob.core.windows.net/actions-results/b7a82dcf-1dff-49e7-9c18-2e773f11dc9f/workflow-job-run-6fc72486-4251-5fa4-9571-e6bb9d096930/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-03-08T18%3A05%3A05Z&sig=rHFcELGtf%2BYjYXK326KnZSqHnl7FF4dmXLswO%2FMq2k0%3D&ske=2025-03-09T03%3A39%3A01Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-03-08T15%3A39%3A01Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-03-08T17%3A55%3A00Z&sv=2025-01-05) file is not necessary.