### PR TITLE
[Doc] CUDA 12.0+ is now required

### DIFF
--- a/doc/changes/v3.0.0.rst
+++ b/doc/changes/v3.0.0.rst
@@ -196,6 +196,7 @@ This section lists breaking changes that affect all packages.
 - Support for saving the model in the ``deprecated`` has been removed. Users can still
   load old models in 3.0. (:pr:`10490`)
 - Support for the legacy (blocking) CUDA stream is removed (:pr:`10607`)
+- XGBoost now requires CUDA 12.0 or later.
 
 *********
 Bug Fixes

--- a/doc/gpu/index.rst
+++ b/doc/gpu/index.rst
@@ -4,7 +4,7 @@ XGBoost GPU Support
 
 This page contains information about GPU algorithms supported in XGBoost.
 
-.. note:: CUDA 11.0, Compute Capability 5.0 required (See `this list <https://en.wikipedia.org/wiki/CUDA#GPUs_supported>`_ to look up compute capability of your GPU card.)
+.. note:: CUDA 12.0, Compute Capability 5.0 required (See `this list <https://en.wikipedia.org/wiki/CUDA#GPUs_supported>`_ to look up compute capability of your GPU card.)
 
 *********************************************
 CUDA Accelerated Tree Construction Algorithms


### PR DESCRIPTION
In our CI pipelines, we run tests with CUDA 12.8. In addition, binary wheels we distribute are built using CUDA 12.8.
So we should probably ask users to use CUDA 12 as well.

I will also backport this PR to the 3.0 branch.