### PR TITLE
[CI] Remove nccl RAS workaround.

### DIFF
--- a/ops/docker_run.py
+++ b/ops/docker_run.py
@@ -70,7 +70,6 @@ def docker_run(
     docker_run_cli_args.extend(
         itertools.chain.from_iterable([["-e", f"{k}={v}"] for k, v in user_ids.items()])
     )
-    docker_run_cli_args.extend(["-e", "NCCL_RAS_ENABLE=0"])
     docker_run_cli_args.extend(extra_args)
     docker_run_cli_args.append(image_uri)
     docker_run_cli_args.extend(command_args)

--- a/ops/pipeline/test-python-wheel-impl.sh
+++ b/ops/pipeline/test-python-wheel-impl.sh
@@ -45,7 +45,6 @@ case "$suite" in
   mgpu)
     echo "-- Run Python tests, using multiple GPUs"
     python -c 'from cupy.cuda import jitify; jitify._init_module()'
-    export NCCL_RAS_ENABLE=0
     pytest -v -s -rxXs --durations=0 -m 'mgpu' tests/python-gpu
     pytest -v -s -rxXs --durations=0 tests/test_distributed/test_gpu_with_dask
     pytest -v -s -rxXs --durations=0 tests/test_distributed/test_gpu_with_spark


### PR DESCRIPTION
NCCL 2.26 is available.

Ref https://github.com/dmlc/xgboost/issues/11154 
