### PR TITLE
Simplify `winsock2` workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,10 +249,6 @@ if(USE_CUDA)
       target_link_libraries(CCCL::CCCL INTERFACE libcudacxx::libcudacxx CUB::CUB Thrust)
     endif()
   endif()
-  # Define guard macros to prevent windows.h from conflicting with winsock2.h
-  if(WIN32)
-    target_compile_definitions(CCCL::CCCL INTERFACE NOMINMAX WIN32_LEAN_AND_MEAN _WINSOCKAPI_)
-  endif()
 endif()
 
 if(FORCE_COLORED_OUTPUT AND (CMAKE_GENERATOR STREQUAL "Ninja") AND

--- a/include/xgboost/windefs.h
+++ b/include/xgboost/windefs.h
@@ -19,15 +19,6 @@
 #define NOMINMAX
 #endif  // !defined(NOMINMAX)
 
-// A macro used inside `windows.h` to avoid conflicts with `winsock2.h`
-#if !defined(WIN32_LEAN_AND_MEAN)
-#define WIN32_LEAN_AND_MEAN
-#endif  // !defined(WIN32_LEAN_AND_MEAN)
-// Stop windows.h from including winsock.h
-#if !defined(_WINSOCKAPI_)
-#define _WINSOCKAPI_
-#endif  // !defined(_WINSOCKAPI_)
-
 #if !defined(xgboost_IS_MINGW)
 
 #if defined(__MINGW32__)

--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -12,6 +12,7 @@
 #include <xgboost/windefs.h>
 
 #if defined(xgboost_IS_WIN)
+#include <winsock2.h>
 #include <windows.h>
 #endif  // defined(xgboost_IS_WIN)
 

--- a/src/common/io.h
+++ b/src/common/io.h
@@ -10,6 +10,7 @@
 #include <xgboost/windefs.h>
 
 #if defined(xgboost_IS_WIN)
+#include <winsock2.h>
 #include <windows.h>
 #endif  // defined(xgboost_IS_WIN)
 


### PR DESCRIPTION
On Windows, make sure to `#include <winsock2.h>` before `#include <windows.h>`. Otherwise `#include <windows.h>` will `#include <winsock.h>`, which is only for legacy support.

xref: https://github.com/dmlc/xgboost/pull/10923