### PR TITLE
Fix build on android with API less than 26

### DIFF
--- a/src/common/threading_utils.cc
+++ b/src/common/threading_utils.cc
@@ -130,7 +130,7 @@ std::int32_t OmpGetNumThreads(std::int32_t n_threads) noexcept(true) {
 }
 
 void NameThread(std::thread* t, StringView name) {
-#if defined(__linux__)
+#if defined(__linux__) && (!defined(__ANDROID__) || __ANDROID_API__ >= 26)
   auto handle = t->native_handle();
   char old[16];
   auto ret = pthread_getname_np(handle, old, 16);


### PR DESCRIPTION
When building XGBoost as part of a C++ library for Android, the following compilation error occurs on API levels below 26:

```
src/common/threading_utils.cc:136:14: error: use of undeclared identifier 'pthread_getname_np'
C/C++:   136 |   auto ret = pthread_getname_np(handle, old, 16);
C/C++:          |              ^
C/C++: 1 error generated.
```

This happens because `pthread_getname_np` was introduced in the Android NDK starting from API level 26 ([source](https://android.googlesource.com/platform/bionic/+/8189e77/libc/include/pthread.h#269)). Older Android versions do not provide this function, leading to build failures.

Additional preprocessor checks to determine if build is happening in android and the API level are then needed.