### PR TITLE
[EM] Optimization for deep trees.

### DIFF
--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -190,11 +190,12 @@ class EllpackHostCacheStreamImpl {
       auto& new_impl = this->cache_->pages.back();
       auto offset = new_impl->Copy(&ctx, impl, this->cache_->offsets.back());
       this->cache_->offsets.back() += offset;
-      // No need to copy if it's already in device.
-      if (last_page && !this->cache_->on_device.back()) {
-        auto commited = commit_host_page(this->cache_->pages.back().get());
-        this->cache_->pages.back() = std::move(commited);
-      }
+    }
+
+    // No need to copy if it's already in device.
+    if (last_page && !this->cache_->on_device.back()) {
+      auto commited = commit_host_page(this->cache_->pages.back().get());
+      this->cache_->pages.back() = std::move(commited);
     }
 
     return new_page;

--- a/src/tree/gpu_hist/row_partitioner.cuh
+++ b/src/tree/gpu_hist/row_partitioner.cuh
@@ -21,7 +21,7 @@ namespace xgboost::tree {
 namespace cuda_impl {
 using RowIndexT = std::uint32_t;
 // TODO(Rory): Can be larger. To be tuned alongside other batch operations.
-static const std::int32_t kMaxUpdatePositionBatchSize = 32;
+static const std::int32_t kMaxUpdatePositionBatchSize = 256;
 }  // namespace cuda_impl
 
 /**

--- a/src/tree/gpu_hist/row_partitioner.cuh
+++ b/src/tree/gpu_hist/row_partitioner.cuh
@@ -341,45 +341,27 @@ class RowPartitioner {
     dh::safe_cuda(cudaMemcpyAsync(d_batch_info.data().get(), h_batch_info.data(),
                                   h_batch_info.size_bytes(), cudaMemcpyDefault,
                                   ctx->CUDACtx()->Stream()));
+    // Temporary arrays
+    auto h_counts = pinned_.GetSpan<RowIndexT>(nidx.size());
+    // Must initialize with 0 as 0 count is not written in the kernel.
+    dh::TemporaryArray<RowIndexT> d_counts(nidx.size(), 0);
 
     // Process a sub-batch
     auto sub_batch_impl = [ctx, op, this](common::Span<bst_node_t const> nidx,
                                           common::Span<bst_node_t const> left_nidx,
                                           common::Span<bst_node_t const> right_nidx,
-                                          common::Span<PerNodeData<OpDataT>> d_batch_info) {
+                                          common::Span<PerNodeData<OpDataT>> d_batch_info,
+                                          common::Span<RowIndexT> d_counts) {
       std::size_t total_rows = 0;
       for (bst_node_t i : nidx) {
-        total_rows += ridx_segments_[i].segment.Size();
+        total_rows += this->ridx_segments_[i].segment.Size();
       }
-
-      // Temporary arrays
-      auto h_counts = pinned_.GetSpan<RowIndexT>(nidx.size());
-      // Must initialize with 0 as 0 count is not written in the kernel.
-      dh::TemporaryArray<RowIndexT> d_counts(nidx.size(), 0);
 
       // Partition the rows according to the operator
-      SortPositionBatch<UpdatePositionOpT, OpDataT>(ctx, d_batch_info, dh::ToSpan(ridx_),
-                                                    dh::ToSpan(ridx_tmp_), dh::ToSpan(d_counts),
-                                                    total_rows, op, &tmp_);
-      dh::safe_cuda(cudaMemcpyAsync(h_counts.data(), d_counts.data().get(), h_counts.size_bytes(),
-                                    cudaMemcpyDefault, ctx->CUDACtx()->Stream()));
-      // TODO(Rory): this synchronisation hurts performance a lot
-      // Future optimisation should find a way to skip this
-      ctx->CUDACtx()->Stream().Sync();
+      SortPositionBatch<UpdatePositionOpT, OpDataT>(
+          ctx, d_batch_info, dh::ToSpan(this->ridx_), dh::ToSpan(this->ridx_tmp_),
+          dh::ToSpan(d_counts), total_rows, op, &this->tmp_);
 
-      // Update segments
-      for (std::size_t i = 0; i < nidx.size(); i++) {
-        auto segment = ridx_segments_.at(nidx[i]).segment;
-        auto left_count = h_counts[i];
-        CHECK_LE(left_count, segment.Size());
-        ridx_segments_.resize(std::max(static_cast<bst_node_t>(ridx_segments_.size()),
-                                       std::max(left_nidx[i], right_nidx[i]) + 1));
-        ridx_segments_[nidx[i]] = NodePositionInfo{segment, left_nidx[i], right_nidx[i]};
-        ridx_segments_[left_nidx[i]] =
-            NodePositionInfo{Segment{segment.begin, segment.begin + left_count}};
-        ridx_segments_[right_nidx[i]] =
-            NodePositionInfo{Segment{segment.begin + left_count, segment.end}};
-      }
     };
 
     // Divide inputs into sub-batches.
@@ -391,7 +373,28 @@ class RowPartitioner {
       auto left_batch = common::Span{left_nidx}.subspan(batch_begin, batch_size);
       auto right_batch = common::Span{right_nidx}.subspan(batch_begin, batch_size);
       auto d_info_batch = dh::ToSpan(d_batch_info).subspan(batch_begin, batch_size);
-      sub_batch_impl(nidx_batch, left_batch, right_batch, d_info_batch);
+      auto d_counts_batch = dh::ToSpan(d_counts).subspan(batch_begin, batch_size);
+      sub_batch_impl(nidx_batch, left_batch, right_batch, d_info_batch, d_counts_batch);
+    }
+
+    dh::safe_cuda(cudaMemcpyAsync(h_counts.data(), d_counts.data().get(), h_counts.size_bytes(),
+                                  cudaMemcpyDefault, ctx->CUDACtx()->Stream()));
+    // TODO(Rory): this synchronisation hurts performance a lot
+    // Future optimisation should find a way to skip this
+    ctx->CUDACtx()->Stream().Sync();
+
+    // Update segments
+    for (std::size_t i = 0; i < nidx.size(); i++) {
+      auto segment = ridx_segments_.at(nidx[i]).segment;
+      auto left_count = h_counts[i];
+      CHECK_LE(left_count, segment.Size());
+      ridx_segments_.resize(std::max(static_cast<bst_node_t>(ridx_segments_.size()),
+                                     std::max(left_nidx[i], right_nidx[i]) + 1));
+      ridx_segments_[nidx[i]] = NodePositionInfo{segment, left_nidx[i], right_nidx[i]};
+      ridx_segments_[left_nidx[i]] =
+          NodePositionInfo{Segment{segment.begin, segment.begin + left_count}};
+      ridx_segments_[right_nidx[i]] =
+          NodePositionInfo{Segment{segment.begin + left_count, segment.end}};
     }
   }
 

--- a/src/tree/gpu_hist/row_partitioner.cuh
+++ b/src/tree/gpu_hist/row_partitioner.cuh
@@ -346,8 +346,6 @@ class RowPartitioner {
     auto sub_batch_impl = [ctx, op, this](common::Span<bst_node_t const> nidx,
                                           common::Span<bst_node_t const> left_nidx,
                                           common::Span<bst_node_t const> right_nidx,
-                                          common::Span<OpDataT const> op_data,
-                                          common::Span<PerNodeData<OpDataT>> h_batch_info,
                                           common::Span<PerNodeData<OpDataT>> d_batch_info) {
       std::size_t total_rows = 0;
       for (bst_node_t i : nidx) {
@@ -392,10 +390,8 @@ class RowPartitioner {
       auto nidx_batch = common::Span{nidx}.subspan(batch_begin, batch_size);
       auto left_batch = common::Span{left_nidx}.subspan(batch_begin, batch_size);
       auto right_batch = common::Span{right_nidx}.subspan(batch_begin, batch_size);
-      auto opdata_batch = common::Span{op_data}.subspan(batch_begin, batch_size);
-      auto h_info_batch = h_batch_info.subspan(batch_begin, batch_size);
       auto d_info_batch = dh::ToSpan(d_batch_info).subspan(batch_begin, batch_size);
-      sub_batch_impl(nidx_batch, left_batch, right_batch, opdata_batch, h_info_batch, d_info_batch);
+      sub_batch_impl(nidx_batch, left_batch, right_batch, d_info_batch);
     }
   }
 

--- a/src/tree/gpu_hist/row_partitioner.cuh
+++ b/src/tree/gpu_hist/row_partitioner.cuh
@@ -167,6 +167,7 @@ void SortPositionBatch(Context const* ctx, common::Span<const PerNodeData<OpData
   // Avoid using int as the offset type
   std::size_t n_bytes = 0;
   if (tmp->empty()) {
+    // fixme: document why this cache is correct.
     auto ret =
         cub::DispatchScan<decltype(input_iterator), decltype(discard_write_iterator), IndexFlagOp,
                           cub::NullType, std::int64_t>::Dispatch(nullptr, n_bytes, input_iterator,

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -718,7 +718,7 @@ struct GPUHistMakerDevice {
   void UpdateTree(HostDeviceVector<GradientPair>* gpair_all, DMatrix* p_fmat, ObjInfo const* task,
                   RegTree* p_tree, HostDeviceVector<bst_node_t>* p_out_position) {
     // Process maximum 32 nodes at a time
-    Driver<GPUExpandEntry> driver(param, 32);
+    Driver<GPUExpandEntry> driver{param, 256};
 
     p_fmat = this->Reset(gpair_all, p_fmat);
     driver.Push({this->InitRoot(p_fmat, p_tree)});

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -718,7 +718,7 @@ struct GPUHistMakerDevice {
   void UpdateTree(HostDeviceVector<GradientPair>* gpair_all, DMatrix* p_fmat, ObjInfo const* task,
                   RegTree* p_tree, HostDeviceVector<bst_node_t>* p_out_position) {
     // Process maximum 32 nodes at a time
-    Driver<GPUExpandEntry> driver{param, 512};
+    Driver<GPUExpandEntry> driver{param, 256};
 
     p_fmat = this->Reset(gpair_all, p_fmat);
     driver.Push({this->InitRoot(p_fmat, p_tree)});

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -718,7 +718,7 @@ struct GPUHistMakerDevice {
   void UpdateTree(HostDeviceVector<GradientPair>* gpair_all, DMatrix* p_fmat, ObjInfo const* task,
                   RegTree* p_tree, HostDeviceVector<bst_node_t>* p_out_position) {
     // Process maximum 32 nodes at a time
-    Driver<GPUExpandEntry> driver{param, 256};
+    Driver<GPUExpandEntry> driver{param, cuda_impl::kMaxUpdatePositionBatchSize};
 
     p_fmat = this->Reset(gpair_all, p_fmat);
     driver.Push({this->InitRoot(p_fmat, p_tree)});

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -475,7 +475,7 @@ struct GPUHistMakerDevice {
     AssignNodes(p_tree, this->quantiser.get(), candidates, build_nidx, subtraction_nidx);
     auto prefetch_copy = !build_nidx.empty();
     bst_idx_t n_samples = 0;
-    for (auto const c : candidates) {
+    for (auto const& c : candidates) {
       for (auto const& part : this->partitioners_) {
         n_samples += part->GetRows(c.nid).size();
       }

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2024, XGBoost contributors
+ * Copyright 2017-2025, XGBoost contributors
  */
 #include <thrust/functional.h>  // for plus
 #include <thrust/transform.h>   // for transform

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -718,7 +718,7 @@ struct GPUHistMakerDevice {
   void UpdateTree(HostDeviceVector<GradientPair>* gpair_all, DMatrix* p_fmat, ObjInfo const* task,
                   RegTree* p_tree, HostDeviceVector<bst_node_t>* p_out_position) {
     // Process maximum 32 nodes at a time
-    Driver<GPUExpandEntry> driver{param, 256};
+    Driver<GPUExpandEntry> driver{param, 512};
 
     p_fmat = this->Reset(gpair_all, p_fmat);
     driver.Push({this->InitRoot(p_fmat, p_tree)});

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -475,9 +475,9 @@ struct GPUHistMakerDevice {
     AssignNodes(p_tree, this->quantiser.get(), candidates, build_nidx, subtraction_nidx);
     auto prefetch_copy = !build_nidx.empty();
     bst_idx_t n_samples = 0;
-    for (auto nidx : build_nidx) {
+    for (auto const c : candidates) {
       for (auto const& part : this->partitioners_) {
-        n_samples += part->GetRows(nidx).size();
+        n_samples += part->GetRows(c.nid).size();
       }
     }
     prefetch_copy = prefetch_copy && n_samples * 4 > p_fmat->Info().num_row_;


### PR DESCRIPTION
- Decouple the row partition batch size from the driver batch size. This will allow us to process more nodes for each data batch.
- Pick a heuristic to use ATS instead of data copy to handle cases where we have a large number of small nodes.
- Make sure a new page that happens to be the last is placed on the host.

The optimization is specifically for external memory. We need some kernel fusion to further improve in-core training.

todo:
- [x] Perf test
- [x] Make sure the benchmark is deterministic.


### in-core

| depth/branch | PR                | master             |
|:-------------|:------------------|:-------------------|
| 6            | 160.2554975748062 | 160.7703891992569  |
| 12           | 275.5357859134674 | 277.49394392967224 |

### out-of-core
|    | PR          | Master      |
|:---|:------------|:------------|
| 12 | 2990.530539 | 7855.628397 |