### PR TITLE
Remove the updater name `gpu_coord_descent`.

### DIFF
--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -329,9 +329,9 @@ TEST(Learner, GPUConfiguration) {
   p_dmat->Info().labels.Data()->HostVector() = labels;
   p_dmat->Info().labels.Reshape(kRows);
   {
-    std::unique_ptr<Learner> learner {Learner::Create(mat)};
-    learner->SetParams({Arg{"booster", "gblinear"},
-                        Arg{"updater", "gpu_coord_descent"}});
+    std::unique_ptr<Learner> learner{Learner::Create(mat)};
+    learner->SetParams(
+        {Arg{"booster", "gblinear"}, Arg{"updater", "coord_descent"}, Arg{"device", "cuda"}});
     learner->UpdateOneIter(0, p_dmat);
     ASSERT_EQ(learner->Ctx()->Device(), DeviceOrd::CUDA(0));
   }

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -437,7 +437,8 @@ TEST_F(SerializationTest, GPUCoordDescent) {
   TestLearnerSerialization({{"booster", "gblinear"},
                             {"seed", "0"},
                             {"nthread", "1"},
-                            {"updater", "gpu_coord_descent"}},
+                            {"device", "cuda"},
+                            {"updater", "coord_descent"}},
                            fmap_, p_dmat_);
 }
 #endif  // defined(XGBOOST_USE_CUDA)
@@ -599,7 +600,8 @@ TEST_F(LogitSerializationTest, GPUCoordDescent) {
                             {"objective", "binary:logistic"},
                             {"seed", "0"},
                             {"nthread", "1"},
-                            {"updater", "gpu_coord_descent"}},
+                            {"device", "cuda"},
+                            {"updater", "coord_descent"}},
                            fmap_, p_dmat_);
 }
 #endif  // defined(XGBOOST_USE_CUDA)
@@ -748,7 +750,8 @@ TEST_F(MultiClassesSerializationTest, GPUCoordDescent) {
                             {"num_class", std::to_string(kClasses)},
                             {"seed", "0"},
                             {"nthread", "1"},
-                            {"updater", "gpu_coord_descent"}},
+                            {"updater", "coord_descent"},
+                            {"device", "cuda"}},
                            fmap_, p_dmat_);
 }
 #endif  // defined(XGBOOST_USE_CUDA)

--- a/tests/python-gpu/test_gpu_pickling.py
+++ b/tests/python-gpu/test_gpu_pickling.py
@@ -71,14 +71,14 @@ class TestPickling:
         x, y = build_dataset()
         train_x = xgb.DMatrix(x, label=y)
 
-        param = {"tree_method": "gpu_hist", "gpu_id": 0}
+        param = {"tree_method": "hist", "device": "cuda"}
         bst = xgb.train(param, train_x)
         self.run_pickling(bst)
 
         bst = xgb.XGBRegressor(**param).fit(x, y)
         self.run_pickling(bst)
 
-        param = {"booster": "gblinear", "updater": "gpu_coord_descent", "gpu_id": 0}
+        param = {"booster": "gblinear", "updater": "coord_descent", "device": "cuda"}
         bst = xgb.train(param, train_x)
         self.run_pickling(bst)
 


### PR DESCRIPTION
Deprecated in 2.0. Use `device=cuda` instead.