### PR TITLE
[dask] Disable the flaky `worker_left` test.

### DIFF
--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -2191,7 +2191,7 @@ class TestDaskCallbacks:
     clean_kwargs={"processes": False, "threads": False},
     allow_unclosed=True,
 )
-@pytest.mark.skip
+@pytest.mark.skip(reason="dmlc/xgboost#11405: test_worker_left is flaky")
 async def test_worker_left(c: Client, s: Scheduler, a: Worker, b: Worker):
     async with Worker(s.address):
         dx = da.random.random((1000, 10)).rechunk(chunks=(10, None))

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -2191,6 +2191,7 @@ class TestDaskCallbacks:
     clean_kwargs={"processes": False, "threads": False},
     allow_unclosed=True,
 )
+@pytest.mark.skip
 async def test_worker_left(c: Client, s: Scheduler, a: Worker, b: Worker):
     async with Worker(s.address):
         dx = da.random.random((1000, 10)).rechunk(chunks=(10, None))


### PR DESCRIPTION
Error resilience support relies on the timeout option in rabit. Direct handling is not well supported. To avoid hanging in shutdown, we can change the communication protocol or wait for Dask to implement something similar to the Spark barrier. For now, we will disable the test.

https://github.com/dmlc/xgboost/actions/runs/14381427963/job/40337545246