### PR TITLE
Use Sphinx Tabs to separate Python/R code in tutorial for advanced objectives

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -239,6 +239,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_gallery.gen_gallery",
     "sphinx_issues",
+    "sphinx_tabs.tabs",
     "breathe",
     "myst_parser",
 ]

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -12,6 +12,7 @@ myst-parser
 ray[train]
 sphinx-gallery
 sphinx-issues
+sphinx-tabs
 dask
 pyspark
 cloudpickle

--- a/doc/tutorials/slicing_model.rst
+++ b/doc/tutorials/slicing_model.rst
@@ -8,53 +8,51 @@ Slice tree model
 When ``booster`` is set to ``gbtree`` or ``dart``, XGBoost builds a tree model, which is a
 list of trees and can be sliced into multiple sub-models.
 
-In Python:
+.. tabs::
 
-.. code-block:: python
+    .. code-tab:: py
 
-    from sklearn.datasets import make_classification
-    num_classes = 3
-    X, y = make_classification(n_samples=1000, n_informative=5,
-                               n_classes=num_classes)
-    dtrain = xgb.DMatrix(data=X, label=y)
-    num_parallel_tree = 4
-    num_boost_round = 16
-    # total number of built trees is num_parallel_tree * num_classes * num_boost_round
+        import xgboost as xgb
+        from sklearn.datasets import make_classification
+        num_classes = 3
+        X, y = make_classification(n_samples=1000, n_informative=5,
+                                   n_classes=num_classes)
+        dtrain = xgb.DMatrix(data=X, label=y)
+        num_parallel_tree = 4
+        num_boost_round = 16
+        # total number of built trees is num_parallel_tree * num_classes * num_boost_round
 
-    # We build a boosted random forest for classification here.
-    booster = xgb.train({
-        'num_parallel_tree': 4, 'subsample': 0.5, 'num_class': 3},
-                        num_boost_round=num_boost_round, dtrain=dtrain)
+        # We build a boosted random forest for classification here.
+        booster = xgb.train({
+            'num_parallel_tree': 4, 'subsample': 0.5, 'num_class': 3},
+                            num_boost_round=num_boost_round, dtrain=dtrain)
 
-    # This is the sliced model, containing [3, 7) forests
-    # step is also supported with some limitations like negative step is invalid.
-    sliced: xgb.Booster = booster[3:7]
+        # This is the sliced model, containing [3, 7) forests
+        # step is also supported with some limitations like negative step is invalid.
+        sliced: xgb.Booster = booster[3:7]
 
-    # Access individual tree layer
-    trees = [_ for _ in booster]
-    assert len(trees) == num_boost_round
+        # Access individual tree layer
+        trees = [_ for _ in booster]
+        assert len(trees) == num_boost_round
 
-In R:
+    .. code-tab:: r R
 
-.. versionadded:: 3.0.0
+        library(xgboost)
+        data(agaricus.train, package = "xgboost")
+        dm <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 
-.. code-block:: R
-
-    data(agaricus.train, package = "xgboost")
-    dm <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
-
-    model <- xgb.train(
-      params = xgb.params(objective = "binary:logistic", max_depth = 4),
-      data = dm,
-      nrounds = 20
-    )
-    sliced <- model[seq(3, 7)]
-    ##### xgb.Booster
-    # of features: 126
-    # of rounds:  5
+        model <- xgb.train(
+          params = xgb.params(objective = "binary:logistic", max_depth = 4),
+          data = dm,
+          nrounds = 20
+        )
+        sliced <- model[seq(3, 7)]
+        ##### xgb.Booster
+        # of features: 126
+        # of rounds:  5
 
 The sliced model is a copy of selected trees, that means the model itself is immutable
-during slicing.  This feature is the basis of `save_best` option in early stopping
+during slicing. This feature is the basis of ``save_best`` option in early stopping
 callback. See :ref:`sphx_glr_python_examples_individual_trees.py` for a worked example on
 how to combine prediction with sliced trees.
 


### PR DESCRIPTION
Just discovered this non-built-in plugin for Sphinx which allows putting code snippets into tabs to separate different languages.

I'm using it here to separate the Python and R code snippets in the tutorial for advanced objectives only, but would be ideal to make multi-language versions of more tutorials in the future.