### PR TITLE
Simplify DaskScikitLearnBase.predict

### DIFF
--- a/ops/pipeline/get-image-tag.sh
+++ b/ops/pipeline/get-image-tag.sh
@@ -1,4 +1,4 @@
 ## Update the following line to test changes to CI images
 ## See https://xgboost.readthedocs.io/en/latest/contrib/ci.html#making-changes-to-ci-containers
 
-IMAGE_TAG=main
+IMAGE_TAG=PR-14

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -1521,7 +1521,7 @@ class DaskScikitLearnBase(XGBModel):
         return predts
 
     @_deprecate_positional_args
-    def predict(
+    def predict(  # pylint: disable=R0912
         self,
         X: _DataT,
         *,
@@ -1531,15 +1531,15 @@ class DaskScikitLearnBase(XGBModel):
         iteration_range: Optional[IterationRange] = None,
     ) -> Any:
         iteration_range = self._get_iteration_range(iteration_range)
-        dmatrix_options = dict(
-            base_margin=base_margin,
-            missing=self.missing,
-        )
-        predict_options = dict(
-            output_margin=output_margin,
-            validate_features=validate_features,
-            iteration_range=iteration_range,
-        )
+        dmatrix_options = {
+            "base_margin": base_margin,
+            "missing": self.missing,
+        }
+        predict_options = {
+            "output_margin": output_margin,
+            "validate_features": validate_features,
+            "iteration_range": iteration_range,
+        }
 
         is_regression = isinstance(self, XGBRegressorBase)
 

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -88,7 +88,7 @@ from dask.delayed import Delayed
 from distributed import Future
 
 from .. import collective, config
-from .._typing import FeatureNames, FeatureTypes, IterationRange, DataType
+from .._typing import DataType, FeatureNames, FeatureTypes, IterationRange
 from ..callback import TrainingCallback
 from ..collective import Config as CollConfig
 from ..collective import _Args as CollArgs

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -1444,7 +1444,9 @@ async def _async_wrap_evaluation_matrices(
     return train_dmatrix, awaited
 
 
-def _mapped_predict(partition, *, booster: Booster, booster_options, predict_options) -> numpy.ndarray:
+def _mapped_predict(
+    partition, *, booster: Booster, booster_options, predict_options
+) -> numpy.ndarray:
     m = DMatrix(partition, **booster_options)
     predt = booster.predict(m, **predict_options)
     return predt
@@ -1524,11 +1526,11 @@ class DaskScikitLearnBase(XGBModel):
         iteration_range: Optional[IterationRange] = None,
     ) -> Any:
         iteration_range = self._get_iteration_range(iteration_range)
-        booster_options=dict(
+        booster_options = dict(
             base_margin=base_margin,
             missing=self.missing,
         )
-        predict_options=dict(
+        predict_options = dict(
             output_margin=output_margin,
             validate_features=validate_features,
             iteration_range=iteration_range,
@@ -1568,7 +1570,7 @@ class DaskScikitLearnBase(XGBModel):
                     meta = numpy.zeros((0,), dtype=numpy.float32)
                     chunks = X.chunks[:1]
                     drop_axis = 1
-    
+
             result = X.map_blocks(
                 _mapped_predict,
                 booster=self.get_booster(),

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -655,7 +655,7 @@ def run_dask_classifier(
 
     assert prediction.ndim == 1
     assert prediction.shape[0] == kRows
-    
+
     if model == "boosting":
         # currently failing for 'rf'
         expected = expected_classifier.predict(X.compute())


### PR DESCRIPTION
This PR simplifies the `DaskScikitLearnBase.predict` method. The main change is to use `map_partitions` on the input rather than the current code which is hitting https://github.com/dask/distributed/issues/8998.

Opening this up early for feedback and to get it tested in CI. I've tested locally with dask==2024.9.1, 2024.12.1, and 2025.2.0., and everything in `tests/test_distributed/test_with_dask/test_with_dask.py` passes. Unfortunately, there are failures on `dask@main`, but those are different from the current set of failures.

Closes https://github.com/dmlc/xgboost/issues/10994