### PR TITLE
Add Possibility to Load XGBoost Models as PySpark Models

### DIFF
--- a/python-package/xgboost/spark/estimator.py
+++ b/python-package/xgboost/spark/estimator.py
@@ -12,7 +12,7 @@ from pyspark.ml.param import Param, Params
 from pyspark.ml.param.shared import HasProbabilityCol, HasRawPredictionCol
 
 from ..collective import Config
-from ..sklearn import XGBClassifier, XGBRanker, XGBRegressor
+from ..sklearn import XGBClassifier, XGBModel, XGBRanker, XGBRegressor
 from .core import (  # type: ignore
     _ClassificationModel,
     _SparkXGBEstimator,
@@ -256,6 +256,12 @@ class SparkXGBRegressorModel(_SparkXGBModel):
     def _xgb_cls(cls) -> Type[XGBRegressor]:
         return XGBRegressor
 
+    @classmethod
+    def _load_model_as_sklearn_model(cls, model_path: str) -> XGBModel:
+        sklearn_model = XGBRegressor()
+        sklearn_model.load_model(model_path)
+        return sklearn_model
+
 
 _set_pyspark_xgb_cls_param_attrs(SparkXGBRegressor, SparkXGBRegressorModel)
 
@@ -452,6 +458,12 @@ class SparkXGBClassifierModel(_ClassificationModel):
     def _xgb_cls(cls) -> Type[XGBClassifier]:
         return XGBClassifier
 
+    @classmethod
+    def _load_model_as_sklearn_model(cls, model_path: str) -> XGBModel:
+        sklearn_model = XGBClassifier()
+        sklearn_model.load_model(model_path)
+        return sklearn_model
+
 
 _set_pyspark_xgb_cls_param_attrs(SparkXGBClassifier, SparkXGBClassifierModel)
 
@@ -638,6 +650,12 @@ class SparkXGBRankerModel(_SparkXGBModel):
     @classmethod
     def _xgb_cls(cls) -> Type[XGBRanker]:
         return XGBRanker
+
+    @classmethod
+    def _load_model_as_sklearn_model(cls, model_path: str) -> XGBModel:
+        sklearn_model = XGBRanker()
+        sklearn_model.load_model(model_path)
+        return sklearn_model
 
 
 _set_pyspark_xgb_cls_param_attrs(SparkXGBRanker, SparkXGBRankerModel)

--- a/tests/test_distributed/test_with_spark/test_spark_local.py
+++ b/tests/test_distributed/test_with_spark/test_spark_local.py
@@ -1,5 +1,6 @@
 import glob
 import logging
+import os
 import random
 import tempfile
 import uuid
@@ -1306,6 +1307,60 @@ class TestPySparkLocal:
             spark_xgb_model.training_summary.validation_objective_history["logloss"],
             atol=1e-3,
         )
+
+    def test_convert_sklearn_model_to_spark_xgb_model_classifier(
+        self, clf_data: ClfData
+    ) -> None:
+        X = np.array([[1.0, 2.0, 3.0], [0.0, 1.0, 5.5]])
+        y = np.array([0, 1])
+        cl1 = xgb.XGBClassifier()
+        cl1.fit(X, y)
+        spark_xgb_model = (
+            SparkXGBClassifierModel.convert_sklearn_model_to_spark_xgb_model(
+                xgb_sklearn_model=cl1
+            )
+        )
+        pred_result = spark_xgb_model.transform(clf_data.cls_df_test).collect()
+        for row in pred_result:
+            assert np.isclose(row.prediction, row.expected_prediction, atol=1e-3)
+            np.testing.assert_allclose(
+                row.probability, row.expected_probability, atol=1e-3
+            )
+
+    def test_convert_sklearn_model_to_spark_xgb_model_regressor(
+        self, reg_data: RegData
+    ):
+        X = np.array([[1.0, 2.0, 3.0], [0.0, 1.0, 5.5]])
+        y = np.array([0, 1])
+        reg1 = xgb.XGBRegressor()
+        reg1.fit(X, y)
+        spark_xgb_model = (
+            SparkXGBRegressorModel.convert_sklearn_model_to_spark_xgb_model(
+                xgb_sklearn_model=reg1
+            )
+        )
+        pred_result = spark_xgb_model.transform(reg_data.reg_df_test).collect()
+        for row in pred_result:
+            assert np.isclose(row.prediction, row.expected_prediction, atol=1e-3)
+
+    def test_load_model_as_spark_model(self):
+        X = np.array([[1.0, 2.0, 3.0], [0.0, 1.0, 5.5]])
+        y = np.array([0, 1])
+        cl1 = xgb.XGBClassifier()
+        cl1.fit(X, y)
+
+        X = np.array([[1.0, 2.0, 3.0], [0.0, 1.0, 5.5]])
+        y = np.array([0, 1])
+        reg1 = xgb.XGBRegressor()
+        reg1.fit(X, y)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            clf_model_path = os.path.join(tmpdir, "clf_model.json")
+            cl1.get_booster().save_model(clf_model_path)
+            SparkXGBClassifierModel.load_model(model_path=clf_model_path)
+
+            reg_model_path = os.path.join(tmpdir, "reg_model.json")
+            reg1.get_booster().save_model(reg_model_path)
+            SparkXGBRegressorModel.load_model(model_path=reg_model_path)
 
 
 class XgboostLocalTest(SparkTestCase):


### PR DESCRIPTION
Closes #11400 

The default values for `device`, `use_gpu` and `tree_method` were added due to this [function call](https://github.com/dmlc/xgboost/blob/69268dff557ebd79629d1a698d3a58059fc7a914/python-package/xgboost/spark/core.py#L1060), and eventually this [one](https://github.com/dmlc/xgboost/blob/69268dff557ebd79629d1a698d3a58059fc7a914/python-package/xgboost/spark/core.py#L507) which assumes they already exist in `_paramMap` or `_defaultParamMap`.