### PR TITLE
[CI] Rename container xgb-ci.aarch64 -> xgb-ci.manylinux_2_28_x86_64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,7 +269,7 @@ jobs:
             runner: linux-amd64-cpu
             artifact_from: build-cuda
           - description: cpu-arm64
-            image_repo: xgb-ci.aarch64
+            image_repo: xgb-ci.manylinux_2_28_aarch64
             suite: cpu-arm64
             runner: linux-arm64-cpu
             artifact_from: build-python-wheels-arm64


### PR DESCRIPTION
See https://github.com/dmlc/xgboost-devops/pull/20