### PR TITLE
Reduce flakiness of the pyspark conf test.

### DIFF
--- a/python-package/xgboost/testing/collective.py
+++ b/python-package/xgboost/testing/collective.py
@@ -1,4 +1,4 @@
-"""Collective modele related utilities."""
+"""Collective module related utilities."""
 
 import socket
 

--- a/python-package/xgboost/testing/collective.py
+++ b/python-package/xgboost/testing/collective.py
@@ -1,0 +1,15 @@
+"""Collective modele related utilities."""
+
+import socket
+
+
+def get_avail_port() -> int:
+    """Return a port that's available during the function call. It doesn't prevent the
+    port being used after the function returns. We can't reserve a port. The utility
+    makes a test more likely to pass.
+
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.bind(("127.0.0.1", 0))
+        port = server.getsockname()[1]
+    return port

--- a/python-package/xgboost/testing/collective.py
+++ b/python-package/xgboost/testing/collective.py
@@ -4,9 +4,9 @@ import socket
 
 
 def get_avail_port() -> int:
-    """Return a port that's available during the function call. It doesn't prevent the
-    port being used after the function returns. We can't reserve a port. The utility
-    makes a test more likely to pass.
+    """Returns a port that's available during the function call. It doesn't prevent the
+    port from being used after the function returns as we can't reserve the port. The
+    utility makes a test more likely to pass.
 
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:

--- a/tests/test_distributed/test_with_spark/test_spark_local.py
+++ b/tests/test_distributed/test_with_spark/test_spark_local.py
@@ -31,6 +31,7 @@ from xgboost.spark import (
 )
 from xgboost.spark.core import _non_booster_params
 from xgboost.spark.data import pred_contribs
+from xgboost.testing.collective import get_avail_port
 
 from .utils import SparkTestCase
 
@@ -1772,16 +1773,17 @@ class XgboostLocalTest(SparkTestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             path = "file:" + tmpdir
+            port = get_avail_port()
             classifier = SparkXGBClassifier(
                 launch_tracker_on_driver=True,
-                coll_cfg=Config(tracker_host_ip="127.0.0.1", tracker_port=58894),
+                coll_cfg=Config(tracker_host_ip="127.0.0.1", tracker_port=port),
                 num_workers=1,
                 n_estimators=1,
             )
 
             def check_conf(conf: Config) -> None:
                 assert conf.tracker_host_ip == "127.0.0.1"
-                assert conf.tracker_port == 58894
+                assert conf.tracker_port == port
 
             check_conf(classifier.getOrDefault(classifier.coll_cfg))
             classifier.write().overwrite().save(path)


### PR DESCRIPTION
https://github.com/dmlc/xgboost/actions/runs/14984163779/job/42095164840?pr=11451
https://github.com/dmlc/xgboost/actions/runs/14991077836/job/42115037318?pr=11453

Find an available port prior to running the test. We can't guarantee the port will continue to be available during the test, but this should reduce the chance of using an occupied port.