### PR TITLE
Implement double-buffer for ellpack.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ Rplots.pdf
 
 # nsys
 *.nsys-rep
+rmm_log.dev*

--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2024, XGBoost Contributors
+ * Copyright 2015-2025, XGBoost Contributors
  * \file base.h
  * \brief Defines configuration macros and basic types for xgboost.
  */
@@ -72,6 +72,14 @@
 #define XGBOOST_DEV_INLINE
 #endif  // defined(__CUDA__) || defined(__CUDACC__)
 
+
+// restrict
+#if defined(_MSC_VER)
+#define XGBOOST_RESTRICT __restrict
+#else
+#define XGBOOST_RESTRICT __restrict__
+#endif
+
 // These check are for Makefile.
 #if !defined(XGBOOST_MM_PREFETCH_PRESENT) && !defined(XGBOOST_BUILTIN_PREFETCH_PRESENT)
 /* default logic for software pre-fetching */
@@ -122,7 +130,7 @@ using bst_target_t = std::uint32_t;  // NOLINT
  */
 using bst_layer_t = std::int32_t;  // NOLINT
 /**
- * \brief Type for indexing trees.
+ * @brief Type for indexing trees.
  */
 using bst_tree_t = std::int32_t;  // NOLINT
 /**

--- a/src/common/compressed_iterator.h
+++ b/src/common/compressed_iterator.h
@@ -221,7 +221,7 @@ class CompressedIterator {
  *
  * This accessor is significantly slower than the single buffer one due to pipeline
  * stalling and should not be used as default. Pre-calculating the buffer selection
- * indicator can help mitigate it. But we only used this iterator for external memory
+ * indicator can help mitigate it. But we only use this iterator for external memory with
  * direct memory access, which is slow anyway.
  *
  * Use the single buffer one as a reference for how it works.

--- a/src/common/compressed_iterator.h
+++ b/src/common/compressed_iterator.h
@@ -260,7 +260,7 @@ class DoubleCompressedIter {
     CHECK(detail::IsAligned(reinterpret_cast<std::uintptr_t>(buf1), alignof(std::uint32_t)));
   }
 
-  __device__ __forceinline__ reference operator*() const {
+  XGBOOST_HOST_DEV_INLINE reference operator*() const {
     constexpr std::int32_t kBitsPerByte = 8;
     std::size_t start_bit_idx = ((offset_ + 1) * symbol_bits_ - 1);
     std::size_t start_byte_idx = start_bit_idx >> 3;

--- a/src/common/compressed_iterator.h
+++ b/src/common/compressed_iterator.h
@@ -302,7 +302,7 @@ class DoubleCompressedIter {
 
       // Difference between the original ptr and the aligned ptr.
       auto diff = reinterpret_cast<std::uintptr_t>(beg_ptr) - aligned_beg_ptr;
-      // Beginning ptr that points to the laoded values
+      // Beginning ptr that points to the first loaded values
       auto loaded_beg_ptr = reinterpret_cast<CompressedByteT const *>(&v) + diff;
       // Read 5 bytes - the maximum we will need
       tmp = static_cast<std::uint64_t>(loaded_beg_ptr[0]) << 32 |

--- a/src/common/compressed_iterator.h
+++ b/src/common/compressed_iterator.h
@@ -23,12 +23,10 @@ namespace detail {
 }
 // rmm::align_down
 [[nodiscard]] constexpr std::size_t AlignDown(std::size_t value, std::size_t alignment) noexcept {
-  assert(is_pow2(alignment));
   return value & ~(alignment - 1);
 }
 // rmm:is_aligned
 [[nodiscard]] constexpr bool IsAligned(std::size_t value, std::size_t alignment) noexcept {
-  assert(is_pow2(alignment));
   return value == AlignDown(value, alignment);
 }
 

--- a/src/common/compressed_iterator.h
+++ b/src/common/compressed_iterator.h
@@ -5,9 +5,10 @@
 #pragma once
 #include <xgboost/base.h>  // for XGBOOST_RESTRICT
 
-#include <cmath>    // for ceil, log2
-#include <cstddef>  // for size_t
-#include <cstdint>  // for uint32_t
+#include <algorithm>  // for max
+#include <cmath>      // for ceil, log2
+#include <cstddef>    // for size_t
+#include <cstdint>    // for uint32_t
 
 #include "common.h"
 

--- a/src/common/compressed_iterator.h
+++ b/src/common/compressed_iterator.h
@@ -80,7 +80,8 @@ class CompressedBufferWriter {
     size_t ret = std::ceil(static_cast<double>(compressed_size + detail::kPadding) /
                            static_cast<double>(sizeof(std::uint32_t))) *
                  sizeof(std::uint32_t);
-    return ret;
+    // Need at least 5 bytes for the reader
+    return std::max(ret, static_cast<std::size_t>(detail::kPadding + 1));
   }
 
   template <typename T>

--- a/src/common/compressed_iterator.h
+++ b/src/common/compressed_iterator.h
@@ -263,9 +263,9 @@ class DoubleCompressedIter {
       auto getv = [&](auto shift) {
         auto shifted = start_byte_idx - shift;
         bool ind = (shifted >= n0_);  // indicator for which buffer to read
-        shifted -= ind * n0_;
         // Pick the buffer to read
-        auto const *XGBOOST_RESTRICT buf = (start_byte_idx < n0_) ? buf0_ : buf1_;
+        auto const *XGBOOST_RESTRICT buf = ind ? buf1_ : buf0_;
+        shifted -= ind * n0_;
         return static_cast<std::uint64_t>(buf[shifted]);
       };
       // Read 5 bytes - the maximum we will need

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -829,8 +829,7 @@ template <cudaMemcpyKind kind, typename T, typename U>
                                            std::size_t count, std::size_t *fail_idx,
                                            cudaStream_t stream) {
 #if CUDART_VERSION >= 12080
-  static_assert(kind == cudaMemcpyDeviceToHost || kind == cudaMemcpyHostToDevice ||
-                    kind == cudaMemcpyDeviceToDevice,
+  static_assert(kind == cudaMemcpyDeviceToHost || kind == cudaMemcpyHostToDevice,
                 "Not implemented.");
   cudaMemcpyAttributes attr;
   attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
@@ -847,12 +846,8 @@ template <cudaMemcpyKind kind, typename T, typename U>
   if constexpr (kind == cudaMemcpyDeviceToHost) {
     assign_device(&attr.srcLocHint);
     assign_host(&attr.dstLocHint);
-  } else if (kind == cudaMemcpyHostToDevice) {
-    assign_host(&attr.srcLocHint);
-    assign_device(&attr.dstLocHint);
   } else {
-    static_assert(cudaMemcpyDeviceToDevice == kind);
-    assign_device(&attr.srcLocHint);
+    assign_host(&attr.srcLocHint);
     assign_device(&attr.dstLocHint);
   }
   return cudaMemcpyBatchAsync(dsts, srcs, const_cast<std::size_t *>(sizes), count, attr, fail_idx,

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -319,7 +319,7 @@ void CopyDataToEllpack(Context const* ctx, const AdapterBatchT& batch,
 
   auto get_ridx = [=] __device__(std::size_t idx) {
     return batch.GetElement(idx).row_idx;
-  };
+  };  // NOLINT
   auto get_is_valid = [=] __device__(std::size_t idx) -> std::size_t {
     return is_valid(batch.GetElement(idx));
   };

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024, XGBoost contributors
+ * Copyright 2019-2025, XGBoost contributors
  */
 #include <thrust/binary_search.h>                       // for lower_bound,  upper_bound
 #include <thrust/extrema.h>                             // for max_element

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -300,20 +300,40 @@ class EllpackPageImpl {
     this->SetBaseRowId(page->base_rowid);
     this->SetNumSymbols(page->NumSymbols());
   }
+  /**
+   * @brief Get an accessor backed by the device storage.
+   */
   [[nodiscard]] EllpackAccessor GetDeviceEllpack(
       Context const* ctx, common::Span<FeatureType const> feature_types = {}) const;
-
+  /**
+   * @brief Get an accessor backed by the host storage.
+   *
+   * @param h_gidx_buffer A buffer used as the backing storage of the accessor.
+   *
+   * @return An accessor variant.
+   */
   [[nodiscard]] EllpackAccessor GetHostEllpack(
       Context const* ctx, std::vector<common::CompressedByteT>* h_gidx_buffer,
       common::Span<FeatureType const> feature_types = {}) const;
-
+  /**
+   * @brief Vistor pattern.
+   *
+   * @param fn A callable that accepts both variants of the ellpack accessor.
+   *
+   * @return An accessor variant.
+   */
   template <typename Fn>
   decltype(auto) Visit(Context const* ctx, common::Span<FeatureType const> feature_types,
                        Fn&& fn) const {
     auto acc = this->GetDeviceEllpack(ctx, feature_types);
     return std::visit(std::forward<Fn>(fn), acc);
   }
-
+  /**
+   * @brief Vistor pattern with a host accessor.
+   *
+   * @param h_gidx_buffer A buffer used as the backing storage of the accessor.
+   * @param fn A callable that accepts both variants of the ellpack accessor.
+   */
   template <typename Fn>
   decltype(auto) VisitOnHost(Context const* ctx,
                              std::vector<common::CompressedByteT>* h_gidx_buffer,

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -23,7 +23,7 @@ namespace xgboost {
  * Does not own the underlying memory and may be trivially copied into kernels.
  */
 template <typename IterT>
-struct EllpackDeviceAccessorImpl {
+struct EllpackAccessorImpl {
  private:
   /**
    * @brief Stores the null value and whether the matrix is dense. The `IsDense` is stored in the
@@ -55,11 +55,11 @@ struct EllpackDeviceAccessorImpl {
   /** @brief Type of each feature, categorical or numerical. */
   common::Span<const FeatureType> feature_types;
 
-  EllpackDeviceAccessorImpl() = delete;
-  EllpackDeviceAccessorImpl(Context const* ctx, std::shared_ptr<const common::HistogramCuts> cuts,
-                            bst_idx_t row_stride, bst_idx_t base_rowid, bst_idx_t n_rows,
-                            IterType gidx_iter, bst_idx_t null_value, bool is_dense,
-                            common::Span<FeatureType const> feature_types)
+  EllpackAccessorImpl() = delete;
+  EllpackAccessorImpl(Context const* ctx, std::shared_ptr<const common::HistogramCuts> cuts,
+                      bst_idx_t row_stride, bst_idx_t base_rowid, bst_idx_t n_rows,
+                      IterType gidx_iter, bst_idx_t null_value, bool is_dense,
+                      common::Span<FeatureType const> feature_types)
       : null_value_{null_value},
         row_stride{row_stride},
         base_rowid{base_rowid},
@@ -162,10 +162,9 @@ struct EllpackDeviceAccessorImpl {
   [[nodiscard]] XGBOOST_HOST_DEV_INLINE size_t NumFeatures() const { return min_fvalue.size(); }
 };
 
-using EllpackDeviceAccessor = EllpackDeviceAccessorImpl<common::CompressedIterator<std::uint32_t>>;
+using EllpackDeviceAccessor = EllpackAccessorImpl<common::CompressedIterator<std::uint32_t>>;
 
-using DoubleEllpackAccessor =
-    EllpackDeviceAccessorImpl<common::DoubleCompressedIter<std::uint32_t>>;
+using DoubleEllpackAccessor = EllpackAccessorImpl<common::DoubleCompressedIter<std::uint32_t>>;
 
 /**
  * @brief The ellpack accessor uses different graident index iterator to facilitate

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024, XGBoost Contributors
+ * Copyright 2019-2025, XGBoost Contributors
  */
 #ifndef XGBOOST_DATA_ELLPACK_PAGE_CUH_
 #define XGBOOST_DATA_ELLPACK_PAGE_CUH_

--- a/src/data/ellpack_page_raw_format.cu
+++ b/src/data/ellpack_page_raw_format.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024, XGBoost contributors
+ * Copyright 2019-2025, XGBoost contributors
  */
 #include <dmlc/registry.h>
 

--- a/src/data/ellpack_page_raw_format.cu
+++ b/src/data/ellpack_page_raw_format.cu
@@ -86,7 +86,8 @@ template <typename T>
   bytes += fo->Write(impl->info.row_stride);
   std::vector<common::CompressedByteT> h_gidx_buffer;
   Context ctx = Context{}.MakeCUDA(curt::CurrentDevice());
-  [[maybe_unused]] auto h_accessor = impl->GetHostAccessor(&ctx, &h_gidx_buffer);
+  // write data into the h_gidx_buffer
+  [[maybe_unused]] auto h_accessor = impl->GetHostEllpack(&ctx, &h_gidx_buffer);
   bytes += common::WriteVec(fo, h_gidx_buffer);
   bytes += fo->Write(impl->base_rowid);
   bytes += fo->Write(impl->NumSymbols());

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -245,9 +245,10 @@ class EllpackHostCacheStreamImpl {
                                       ctx.CUDACtx()->Stream()));
       }
     } else {
-      auto res = d_page->empty() ? h_page->gidx_buffer.Resource() : d_page->Resource();
+      auto h_res = h_page->gidx_buffer.Resource();
+      CHECK(h_res->DataAs<common::CompressedByteT>() == h_page->gidx_buffer.data());
       out_impl->gidx_buffer = common::RefResourceView<common::CompressedByteT>{
-          res->DataAs<common::CompressedByteT>(), h_page->gidx_buffer.size(), res};
+          h_res->DataAs<common::CompressedByteT>(), h_page->gidx_buffer.size(), h_res};
       CHECK(out_impl->d_gidx_buffer.empty());
       if (!d_page->empty()) {
         out_impl->d_gidx_buffer = common::RefResourceView<common::CompressedByteT const>{

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -230,10 +230,6 @@ class EllpackHostCacheStreamImpl {
     auto [h_page, d_page] = this->cache_->At(this->ptr_);
 
     auto ctx = Context{}.MakeCUDA(dh::CurrentDevice());
-    // FIXME(jiamingy): Accessing split cache directly is not yet supported.
-    if (0.0 < this->cache_->cache_host_ratio && this->cache_->cache_host_ratio < 1.0) {
-      prefetch_copy = true;
-    }
     auto out_impl = out->Impl();
     if (prefetch_copy) {
       auto n_bytes = this->cache_->GidxSizeBytes(this->ptr_);
@@ -249,10 +245,14 @@ class EllpackHostCacheStreamImpl {
                                       ctx.CUDACtx()->Stream()));
       }
     } else {
-      CHECK(d_page->empty() || h_page->gidx_buffer.empty());
       auto res = d_page->empty() ? h_page->gidx_buffer.Resource() : d_page->Resource();
       out_impl->gidx_buffer = common::RefResourceView<common::CompressedByteT>{
           res->DataAs<common::CompressedByteT>(), h_page->gidx_buffer.size(), res};
+      CHECK(out_impl->d_gidx_buffer.empty());
+      if (!d_page->empty()) {
+        out_impl->d_gidx_buffer = common::RefResourceView<common::CompressedByteT const>{
+            d_page->data(), d_page->size(), d_page->Resource()};
+      }
     }
 
     out_impl->CopyInfo(h_page);

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -226,8 +226,6 @@ class EllpackHostCacheStreamImpl {
   }
 
   void Read(EllpackPage* out, bool prefetch_copy) const {
-    auto stream = this->cache_->streams->Next();
-
     CHECK_EQ(this->cache_->h_pages.size(), this->cache_->d_pages.size());
     auto [h_page, d_page] = this->cache_->At(this->ptr_);
 
@@ -243,8 +241,8 @@ class EllpackHostCacheStreamImpl {
       }
       if (!d_page->empty()) {
         auto beg = out_impl->gidx_buffer.data() + h_page->gidx_buffer.size();
-        dh::safe_cuda(
-            cudaMemcpyAsync(beg, d_page->data(), d_page->size_bytes(), cudaMemcpyDefault, stream));
+        dh::safe_cuda(cudaMemcpyAsync(beg, d_page->data(), d_page->size_bytes(), cudaMemcpyDefault,
+                                      ctx.CUDACtx()->Stream()));
       }
     } else {
       auto h_res = h_page->gidx_buffer.Resource();
@@ -259,10 +257,6 @@ class EllpackHostCacheStreamImpl {
     }
 
     out_impl->CopyInfo(h_page);
-
-    dh::CUDAEvent e;
-    e.Record(stream);
-    dh::DefaultStream().Wait(e);
   }
 };
 

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -243,8 +243,11 @@ class EllpackHostCacheStreamImpl {
       }
       if (!d_page->empty()) {
         auto beg = out_impl->gidx_buffer.data() + h_page->gidx_buffer.size();
-        dh::safe_cuda(
-            cudaMemcpyAsync(beg, d_page->data(), d_page->size_bytes(), cudaMemcpyDefault, stream));
+        auto src = d_page->data();
+        std::size_t size = d_page->size_bytes();
+        std::size_t fail_idx = SIZE_MAX;
+        dh::safe_cuda(dh::MemcpyBatchAsync<cudaMemcpyDeviceToDevice>(&beg, &src, &size, 1,
+                                                                     &fail_idx, stream));
       }
     } else {
       auto h_res = h_page->gidx_buffer.Resource();

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -243,11 +243,8 @@ class EllpackHostCacheStreamImpl {
       }
       if (!d_page->empty()) {
         auto beg = out_impl->gidx_buffer.data() + h_page->gidx_buffer.size();
-        auto src = d_page->data();
-        std::size_t size = d_page->size_bytes();
-        std::size_t fail_idx = SIZE_MAX;
-        dh::safe_cuda(dh::MemcpyBatchAsync<cudaMemcpyDeviceToDevice>(&beg, &src, &size, 1,
-                                                                     &fail_idx, stream));
+        dh::safe_cuda(
+            cudaMemcpyAsync(beg, d_page->data(), d_page->size_bytes(), cudaMemcpyDefault, stream));
       }
     } else {
       auto h_res = h_page->gidx_buffer.Resource();

--- a/src/data/gradient_index.cu
+++ b/src/data/gradient_index.cu
@@ -18,39 +18,39 @@ template <typename BinT, typename DecompressOffset>
 void SetIndexData(Context const* ctx, EllpackPageImpl const* page,
                   std::vector<size_t>* p_hit_count_tloc, DecompressOffset&& get_offset,
                   GHistIndexMatrix* out) {
-  std::vector<common::CompressedByteT> h_gidx_buffer;
-  auto accessor = page->GetHostAccessor(ctx, &h_gidx_buffer);
-  auto const kNull = static_cast<bst_bin_t>(accessor.NullValue());
+  page->VisitOnHost(ctx, [&](auto&& accessor) {
+    auto const kNull = static_cast<bst_bin_t>(accessor.NullValue());
 
-  auto index_data_span = common::Span{out->index.data<BinT>(), out->index.Size()};
-  auto n_bins_total = page->Cuts().TotalBins();
+    auto index_data_span = common::Span{out->index.data<BinT>(), out->index.Size()};
+    auto n_bins_total = page->Cuts().TotalBins();
 
-  auto& hit_count_tloc = *p_hit_count_tloc;
-  hit_count_tloc.clear();
-  hit_count_tloc.resize(ctx->Threads() * n_bins_total, 0);
-  bool dense_compressed = page->IsDenseCompressed() && !page->IsDense();
-  common::ParallelFor(page->Size(), ctx->Threads(), [&](auto ridx) {
-    auto tid = omp_get_thread_num();
-    size_t in_rbegin = page->info.row_stride * ridx;
-    size_t out_rbegin = out->row_ptr[ridx];
-    if (dense_compressed) {
-      for (std::size_t j = 0, k = 0; j < page->info.row_stride; ++j) {
-        bst_bin_t bin_idx = accessor.gidx_iter[in_rbegin + j];
-        if (XGBOOST_EXPECT((bin_idx != kNull), true)) {  // relatively dense
-          bin_idx = get_offset(bin_idx, j);
-          index_data_span[out_rbegin + k++] = bin_idx;
-          ++hit_count_tloc[tid * n_bins_total + bin_idx];
+    auto& hit_count_tloc = *p_hit_count_tloc;
+    hit_count_tloc.clear();
+    hit_count_tloc.resize(ctx->Threads() * n_bins_total, 0);
+    bool dense_compressed = page->IsDenseCompressed() && !page->IsDense();
+    common::ParallelFor(page->Size(), ctx->Threads(), [&](auto ridx) {
+      auto tid = omp_get_thread_num();
+      size_t in_rbegin = page->info.row_stride * ridx;
+      size_t out_rbegin = out->row_ptr[ridx];
+      if (dense_compressed) {
+        for (std::size_t j = 0, k = 0; j < page->info.row_stride; ++j) {
+          bst_bin_t bin_idx = accessor.gidx_iter[in_rbegin + j];
+          if (XGBOOST_EXPECT((bin_idx != kNull), true)) {  // relatively dense
+            bin_idx = get_offset(bin_idx, j);
+            index_data_span[out_rbegin + k++] = bin_idx;
+            ++hit_count_tloc[tid * n_bins_total + bin_idx];
+          }
+        }
+      } else {
+        auto r_size = out->row_ptr[ridx + 1] - out->row_ptr[ridx];
+        for (size_t j = 0; j < r_size; ++j) {
+          bst_bin_t bin_idx = accessor.gidx_iter[in_rbegin + j];
+          assert(bin_idx != kNull);
+          index_data_span[out_rbegin + j] = bin_idx;
+          ++hit_count_tloc[tid * n_bins_total + get_offset(bin_idx, j)];
         }
       }
-    } else {
-      auto r_size = out->row_ptr[ridx + 1] - out->row_ptr[ridx];
-      for (size_t j = 0; j < r_size; ++j) {
-        bst_bin_t bin_idx = accessor.gidx_iter[in_rbegin + j];
-        assert(bin_idx != kNull);
-        index_data_span[out_rbegin + j] = bin_idx;
-        ++hit_count_tloc[tid * n_bins_total + get_offset(bin_idx, j)];
-      }
-    }
+    });
   });
 }
 
@@ -61,18 +61,18 @@ void GetRowPtrFromEllpack(Context const* ctx, EllpackPageImpl const* page,
   if (page->IsDense()) {
     std::fill(row_ptr.begin() + 1, row_ptr.end(), page->info.row_stride);
   } else {
-    std::vector<common::CompressedByteT> h_gidx_buffer;
-    auto accessor = page->GetHostAccessor(ctx, &h_gidx_buffer);
-    auto const kNull = static_cast<bst_bin_t>(accessor.NullValue());
+    page->VisitOnHost(ctx, [&](auto& accessor) {
+      auto const kNull = static_cast<bst_bin_t>(accessor.NullValue());
 
-    common::ParallelFor(page->Size(), ctx->Threads(), [&](auto i) {
-      size_t ibegin = page->info.row_stride * i;
-      for (size_t j = 0; j < page->info.row_stride; ++j) {
-        bst_bin_t bin_idx = accessor.gidx_iter[ibegin + j];
-        if (bin_idx != kNull) {
-          row_ptr[i + 1]++;
+      common::ParallelFor(page->Size(), ctx->Threads(), [&](auto i) {
+        size_t ibegin = page->info.row_stride * i;
+        for (size_t j = 0; j < page->info.row_stride; ++j) {
+          bst_bin_t bin_idx = accessor.gidx_iter[ibegin + j];
+          if (bin_idx != kNull) {
+            row_ptr[i + 1]++;
+          }
         }
-      }
+      });
     });
   }
   std::partial_sum(row_ptr.begin(), row_ptr.end(), row_ptr.begin());

--- a/src/data/gradient_index.cu
+++ b/src/data/gradient_index.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2024, XGBoost Contributors
+ * Copyright 2022-2025, XGBoost Contributors
  */
 #include <cstddef>  // for size_t
 #include <memory>   // for unique_ptr

--- a/src/tree/gpu_hist/histogram.cu
+++ b/src/tree/gpu_hist/histogram.cu
@@ -456,7 +456,7 @@ struct DeviceHistogramBuilderImpl {
   void Reset(Args&&... args) {
     this->simpl.Reset(std::forward<Args>(args)...);
     this->dimpl.Reset(std::forward<Args>(args)...);
-  };
+  }
 
   template <typename Accessor, typename... Args>
   void BuildHistogram(CUDAContext const* ctx, Accessor const& matrix, Args&&... args) {

--- a/src/tree/gpu_hist/histogram.cu
+++ b/src/tree/gpu_hist/histogram.cu
@@ -30,9 +30,9 @@ XGBOOST_DEV_INLINE bst_feature_t FeatIdx(FeatureGroup const& group, bst_idx_t id
   return fidx;
 }
 
-template <typename Accessor>
-XGBOOST_DEV_INLINE bst_idx_t IterIdx(Accessor const& matrix, RowPartitioner::RowIndexT ridx,
-                                     bst_feature_t fidx) {
+template <typename IterT>
+XGBOOST_DEV_INLINE bst_idx_t IterIdx(EllpackAccessorImpl<IterT> const& matrix,
+                                     RowPartitioner::RowIndexT ridx, bst_feature_t fidx) {
   // ridx_local = ridx - base_rowid  <== Row index local to each batch
   // entry_idx = ridx_local * row_stride <== Starting entry index for this row in the matrix
   // entry_idx += start_feature  <== Inside a row, first column inside this feature group

--- a/src/tree/gpu_hist/histogram.cu
+++ b/src/tree/gpu_hist/histogram.cu
@@ -30,8 +30,9 @@ XGBOOST_DEV_INLINE bst_feature_t FeatIdx(FeatureGroup const& group, bst_idx_t id
   return fidx;
 }
 
-XGBOOST_DEV_INLINE bst_idx_t IterIdx(EllpackDeviceAccessor const& matrix,
-                                     RowPartitioner::RowIndexT ridx, bst_feature_t fidx) {
+template <typename Accessor>
+XGBOOST_DEV_INLINE bst_idx_t IterIdx(Accessor const& matrix, RowPartitioner::RowIndexT ridx,
+                                     bst_feature_t fidx) {
   // ridx_local = ridx - base_rowid  <== Row index local to each batch
   // entry_idx = ridx_local * row_stride <== Starting entry index for this row in the matrix
   // entry_idx += start_feature  <== Inside a row, first column inside this feature group
@@ -116,7 +117,7 @@ GradientQuantiser::GradientQuantiser(Context const* ctx, common::Span<GradientPa
 
 XGBOOST_DEV_INLINE void AtomicAddGpairShared(xgboost::GradientPairInt64* dest,
                                              xgboost::GradientPairInt64 const& gpair) {
-  auto dst_ptr = reinterpret_cast<int64_t *>(dest);
+  auto dst_ptr = reinterpret_cast<int64_t*>(dest);
   auto g = gpair.GetQuantisedGrad();
   auto h = gpair.GetQuantisedHess();
 
@@ -136,7 +137,7 @@ XGBOOST_DEV_INLINE void AtomicAddGpairGlobal(xgboost::GradientPairInt64* dest,
   atomicAdd(dst_ptr + 1, *reinterpret_cast<uint64_t*>(&h));
 }
 
-template <bool kCompressed, bool kDense, int kBlockThreads, int kItemsPerThread>
+template <typename Accessor, bool kCompressed, bool kDense, int kBlockThreads, int kItemsPerThread>
 class HistogramAgent {
   int constexpr static kItemsPerTile = kBlockThreads * kItemsPerThread;
 
@@ -147,7 +148,7 @@ class HistogramAgent {
   dh::LDGIterator<const Idx> d_ridx_;
   const GradientPair* d_gpair_;
   const FeatureGroup group_;
-  const EllpackDeviceAccessor& matrix_;
+  Accessor const& matrix_;
   const int feature_stride_;
   const bst_idx_t n_elements_;
   const GradientQuantiser& rounding_;
@@ -157,7 +158,7 @@ class HistogramAgent {
  public:
   __device__ HistogramAgent(GradientPairInt64* smem_arr,
                             GradientPairInt64* __restrict__ d_node_hist, const FeatureGroup& group,
-                            const EllpackDeviceAccessor& matrix, common::Span<const Idx> d_ridx,
+                            Accessor const& matrix, common::Span<const Idx> d_ridx,
                             const GradientQuantiser& rounding, const GradientPair* d_gpair)
       : smem_arr_{smem_arr},
         d_node_hist_{d_node_hist},
@@ -264,11 +265,10 @@ class HistogramAgent {
   }
 };
 
-template <bool kCompressed, bool kDense, bool use_shared_memory_histograms, int kBlockThreads,
-          int kItemsPerThread>
+template <typename Accessor, bool kCompressed, bool kDense, bool use_shared_memory_histograms,
+          int kBlockThreads, int kItemsPerThread>
 __global__ void __launch_bounds__(kBlockThreads)
-    SharedMemHistKernel(const EllpackDeviceAccessor matrix,
-                        const FeatureGroupsAccessor feature_groups,
+    SharedMemHistKernel(Accessor const matrix, const FeatureGroupsAccessor feature_groups,
                         common::Span<const RowPartitioner::RowIndexT> d_ridx,
                         GradientPairInt64* __restrict__ d_node_hist,
                         const GradientPair* __restrict__ d_gpair,
@@ -276,7 +276,7 @@ __global__ void __launch_bounds__(kBlockThreads)
   extern __shared__ char smem[];
   const FeatureGroup group = feature_groups[blockIdx.y];
   auto smem_arr = reinterpret_cast<GradientPairInt64*>(smem);
-  auto agent = HistogramAgent<kCompressed, kDense, kBlockThreads, kItemsPerThread>(
+  auto agent = HistogramAgent<Accessor, kCompressed, kDense, kBlockThreads, kItemsPerThread>(
       smem_arr, d_node_hist, group, matrix, d_ridx, rounding, d_gpair);
   if (use_shared_memory_histograms) {
     agent.BuildHistogramWithShared();
@@ -292,13 +292,19 @@ constexpr std::int32_t ItemsPerTile() { return kBlockThreads * kItemsPerThread; 
 }  // namespace
 
 // Use auto deduction guide to workaround compiler error.
-template <auto GlobalCompr =
-              SharedMemHistKernel<true, false, false, kBlockThreads, kItemsPerThread>,
-          auto Global = SharedMemHistKernel<false, false, false, kBlockThreads, kItemsPerThread>,
-          auto SharedCompr = SharedMemHistKernel<true, false, true, kBlockThreads, kItemsPerThread>,
-          auto Shared = SharedMemHistKernel<false, false, true, kBlockThreads, kItemsPerThread>,
-          auto GlobalDense = SharedMemHistKernel<true, true, false, kBlockThreads, kItemsPerThread>,
-          auto SharedDense = SharedMemHistKernel<true, true, true, kBlockThreads, kItemsPerThread>>
+template <typename Accessor,
+          auto GlobalCompr =
+              SharedMemHistKernel<Accessor, true, false, false, kBlockThreads, kItemsPerThread>,
+          auto Global =
+              SharedMemHistKernel<Accessor, false, false, false, kBlockThreads, kItemsPerThread>,
+          auto SharedCompr =
+              SharedMemHistKernel<Accessor, true, false, true, kBlockThreads, kItemsPerThread>,
+          auto Shared =
+              SharedMemHistKernel<Accessor, false, false, true, kBlockThreads, kItemsPerThread>,
+          auto GlobalDense =
+              SharedMemHistKernel<Accessor, true, true, false, kBlockThreads, kItemsPerThread>,
+          auto SharedDense =
+              SharedMemHistKernel<Accessor, true, true, true, kBlockThreads, kItemsPerThread>>
 struct HistogramKernel {
   enum KernelType : std::size_t {
     kGlobalCompr = 0,
@@ -310,20 +316,20 @@ struct HistogramKernel {
   };
   // Kernel for working with dense Ellpack using the global memory.
   decltype(GlobalCompr) global_compr_kernel{
-      SharedMemHistKernel<true, false, false, kBlockThreads, kItemsPerThread>};
+      SharedMemHistKernel<Accessor, true, false, false, kBlockThreads, kItemsPerThread>};
   // Kernel for working with sparse Ellpack using the global memory.
   decltype(Global) global_kernel{
-      SharedMemHistKernel<false, false, false, kBlockThreads, kItemsPerThread>};
+      SharedMemHistKernel<Accessor, false, false, false, kBlockThreads, kItemsPerThread>};
   // Kernel for working with dense Ellpack using the shared memory.
   decltype(SharedCompr) shared_compr_kernel{
-      SharedMemHistKernel<true, false, true, kBlockThreads, kItemsPerThread>};
+      SharedMemHistKernel<Accessor, true, false, true, kBlockThreads, kItemsPerThread>};
   // Kernel for working with sparse Ellpack using the shared memory.
   decltype(Shared) shared_kernel{
-      SharedMemHistKernel<false, false, true, kBlockThreads, kItemsPerThread>};
+      SharedMemHistKernel<Accessor, false, false, true, kBlockThreads, kItemsPerThread>};
   decltype(GlobalDense) global_dense_kernel{
-      SharedMemHistKernel<true, true, false, kBlockThreads, kItemsPerThread>};
+      SharedMemHistKernel<Accessor, true, true, false, kBlockThreads, kItemsPerThread>};
   decltype(SharedDense) shared_dense_kernel{
-      SharedMemHistKernel<true, true, true, kBlockThreads, kItemsPerThread>};
+      SharedMemHistKernel<Accessor, true, true, true, kBlockThreads, kItemsPerThread>};
 
   bool shared{false};
   std::array<std::uint32_t, 6> grid_sizes{0, 0, 0, 0, 0, 0};
@@ -372,19 +378,21 @@ struct HistogramKernel {
   }
 };
 
-class DeviceHistogramBuilderImpl {
-  std::unique_ptr<HistogramKernel<>> kernel_{nullptr};
+template <typename Accessor>
+class DeviceHistogramDispatchAccessor {
+  std::unique_ptr<HistogramKernel<Accessor>> kernel_{nullptr};
 
  public:
   void Reset(Context const* ctx, FeatureGroupsAccessor const& feature_groups,
              bool force_global_memory) {
-    this->kernel_ = std::make_unique<HistogramKernel<>>(ctx, feature_groups, force_global_memory);
+    this->kernel_ =
+        std::make_unique<HistogramKernel<Accessor>>(ctx, feature_groups, force_global_memory);
     if (force_global_memory) {
       CHECK(!this->kernel_->shared);
     }
   }
 
-  void BuildHistogram(CUDAContext const* ctx, EllpackDeviceAccessor const& matrix,
+  void BuildHistogram(CUDAContext const* ctx, Accessor const& matrix,
                       FeatureGroupsAccessor const& feature_groups,
                       common::Span<GradientPair const> gpair,
                       common::Span<const cuda_impl::RowIndexT> d_ridx,
@@ -410,7 +418,7 @@ class DeviceHistogramBuilderImpl {
           kernel, matrix, feature_groups, d_ridx, histogram.data(), gpair.data(), rounding);
     };
 
-    using K = HistogramKernel<>::KernelType;
+    using K = HistogramKernel<EllpackDeviceAccessor>::KernelType;
     if (!this->kernel_->shared) {  // Use global memory
       CHECK_EQ(this->kernel_->smem_size, 0);
       if (matrix.IsDense()) {
@@ -439,6 +447,28 @@ class DeviceHistogramBuilderImpl {
   }
 };
 
+// Dispatch between single buffer accessor and double buffer accessor.
+struct DeviceHistogramBuilderImpl {
+  DeviceHistogramDispatchAccessor<EllpackDeviceAccessor> simpl;
+  DeviceHistogramDispatchAccessor<DoubleEllpackAccessor> dimpl;
+
+  template <typename... Args>
+  void Reset(Args&&... args) {
+    this->simpl.Reset(std::forward<Args>(args)...);
+    this->dimpl.Reset(std::forward<Args>(args)...);
+  };
+
+  template <typename Accessor, typename... Args>
+  void BuildHistogram(CUDAContext const* ctx, Accessor const& matrix, Args&&... args) {
+    if constexpr (std::is_same_v<Accessor, EllpackDeviceAccessor>) {
+      this->simpl.BuildHistogram(ctx, matrix, std::forward<Args>(args)...);
+    } else {
+      static_assert(std::is_same_v<Accessor, DoubleEllpackAccessor>);
+      this->dimpl.BuildHistogram(ctx, matrix, std::forward<Args>(args)...);
+    }
+  }
+};
+
 DeviceHistogramBuilder::DeviceHistogramBuilder()
     : p_impl_{std::make_unique<DeviceHistogramBuilderImpl>()} {
   monitor_.Init(__func__);
@@ -455,15 +485,19 @@ void DeviceHistogramBuilder::Reset(Context const* ctx, std::size_t max_cached_hi
   this->monitor_.Stop(__func__);
 }
 
-void DeviceHistogramBuilder::BuildHistogram(CUDAContext const* ctx,
-                                            EllpackDeviceAccessor const& matrix,
+void DeviceHistogramBuilder::BuildHistogram(CUDAContext const* ctx, EllpackAccessor const& matrix,
                                             FeatureGroupsAccessor const& feature_groups,
                                             common::Span<GradientPair const> gpair,
                                             common::Span<const cuda_impl::RowIndexT> ridx,
                                             common::Span<GradientPairInt64> histogram,
                                             GradientQuantiser rounding) {
   this->monitor_.Start(__func__);
-  this->p_impl_->BuildHistogram(ctx, matrix, feature_groups, gpair, ridx, histogram, rounding);
+  std::visit(
+      [&](auto&& matrix) {
+        this->p_impl_->BuildHistogram(ctx, matrix, feature_groups, gpair, ridx, histogram,
+                                      rounding);
+      },
+      matrix);
   this->monitor_.Stop(__func__);
 }
 

--- a/src/tree/gpu_hist/histogram.cuh
+++ b/src/tree/gpu_hist/histogram.cuh
@@ -158,7 +158,8 @@ class DeviceHistogramBuilder {
   void Reset(Context const* ctx, std::size_t max_cached_hist_nodes,
              FeatureGroupsAccessor const& feature_groups, bst_bin_t n_total_bins,
              bool force_global_memory);
-  void BuildHistogram(CUDAContext const* ctx, EllpackDeviceAccessor const& matrix,
+
+  void BuildHistogram(CUDAContext const* ctx, EllpackAccessor const& matrix,
                       FeatureGroupsAccessor const& feature_groups,
                       common::Span<GradientPair const> gpair,
                       common::Span<const std::uint32_t> ridx,

--- a/src/tree/gpu_hist/histogram.cuh
+++ b/src/tree/gpu_hist/histogram.cuh
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2024, XGBoost Contributors
+ * Copyright 2020-2025, XGBoost Contributors
  */
 #ifndef HISTOGRAM_CUH_
 #define HISTOGRAM_CUH_

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -582,7 +582,7 @@ struct GPUHistMakerDevice {
         node = s_split_data[nidx].split_node;
       }
       return encode_op(row_id, nidx);
-    };
+    }
   };
 
   // After tree update is finished, update the position of all training

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -111,25 +111,40 @@ struct GPUHistMakerDevice {
   std::shared_ptr<common::HistogramCuts const> const cuts_;
   std::unique_ptr<FeatureGroups> feature_groups_;
 
-  auto CreatePartitionNodes(RegTree const* p_tree, std::vector<GPUExpandEntry> const& candidates) {
-    std::vector<bst_node_t> nidx(candidates.size());
-    std::vector<bst_node_t> left_nidx(candidates.size());
-    std::vector<bst_node_t> right_nidx(candidates.size());
-    std::vector<NodeSplitData> split_data(candidates.size());
+  struct PartitionNodes {
+    std::vector<bst_node_t> nidx;
+    std::vector<bst_node_t> left_nidx;
+    std::vector<bst_node_t> right_nidx;
+    std::vector<NodeSplitData> split_data;
+
+    explicit PartitionNodes(std::size_t n_candidates)
+        : nidx(n_candidates),
+          left_nidx(n_candidates),
+          right_nidx(n_candidates),
+          split_data(n_candidates) {}
+  };
+
+  PartitionNodes CreatePartitionNodes(RegTree const* p_tree,
+                                      std::vector<GPUExpandEntry> const& candidates) {
+    PartitionNodes nodes(candidates.size());
+    // std::vector<bst_node_t> nidx(candidates.size());
+    // std::vector<bst_node_t> left_nidx(candidates.size());
+    // std::vector<bst_node_t> right_nidx(candidates.size());
+    // std::vector<NodeSplitData> split_data(candidates.size());
 
     for (std::size_t i = 0, n = candidates.size(); i < n; i++) {
       auto const& e = candidates[i];
       RegTree::Node split_node = (*p_tree)[e.nid];
       auto split_type = p_tree->NodeSplitType(e.nid);
-      nidx.at(i) = e.nid;
-      left_nidx[i] = split_node.LeftChild();
-      right_nidx[i] = split_node.RightChild();
-      split_data[i] =
+      nodes.nidx.at(i) = e.nid;
+      nodes.left_nidx[i] = split_node.LeftChild();
+      nodes.right_nidx[i] = split_node.RightChild();
+      nodes.split_data[i] =
           NodeSplitData{split_node, split_type, this->evaluator_.GetDeviceNodeCats(e.nid)};
 
       CHECK_EQ(split_type == FeatureType::kCategorical, e.split.is_cat);
     }
-    return std::make_tuple(nidx, left_nidx, right_nidx, split_data);
+    return nodes;
   }
 
  public:
@@ -325,13 +340,12 @@ struct GPUHistMakerDevice {
   void BuildHist(EllpackPage const& page, std::int32_t k, bst_bin_t nidx) {
     monitor.Start(__func__);
     auto d_node_hist = histogram_.GetNodeHistogram(nidx);
-    auto batch = page.Impl();
-    auto acc = batch->GetDeviceAccessor(ctx_);
-
     auto d_ridx = partitioners_.at(k)->GetRows(nidx);
-    this->histogram_.BuildHistogram(ctx_->CUDACtx(), acc,
-                                    feature_groups_->DeviceAccessor(ctx_->Device()), this->gpair,
-                                    d_ridx, d_node_hist, *quantiser);
+    page.Impl()->Visit(this->ctx_, {}, [&](auto&& acc) {
+      this->histogram_.BuildHistogram(ctx_->CUDACtx(), acc,
+                                      feature_groups_->DeviceAccessor(ctx_->Device()), this->gpair,
+                                      d_ridx, d_node_hist, *quantiser);
+    });
     monitor.Stop(__func__);
   }
 
@@ -367,7 +381,8 @@ struct GPUHistMakerDevice {
     this->monitor.Stop(__func__);
   }
 
-  void UpdatePositionColumnSplit(EllpackDeviceAccessor d_matrix,
+  template <typename Iter>
+  void UpdatePositionColumnSplit(EllpackDeviceAccessorImpl<Iter> d_matrix,
                                  std::vector<NodeSplitData> const& split_data,
                                  std::vector<bst_node_t> const& nidx,
                                  std::vector<bst_node_t> const& left_nidx,
@@ -435,8 +450,9 @@ struct GPUHistMakerDevice {
         });
   }
 
+  template <typename Accessor>
   struct GoLeftOp {
-    EllpackDeviceAccessor d_matrix;
+    Accessor d_matrix;
 
     __device__ bool operator()(cuda_impl::RowIndexT ridx, NodeSplitData const& data) const {
       RegTree::Node const& node = data.split_node;
@@ -474,6 +490,15 @@ struct GPUHistMakerDevice {
     return n_samples * kNeedCopyThreshold > n_total_samples;
   }
 
+  template <typename Accessor>
+  struct GoLeftWrapperOp {
+    GoLeftOp<Accessor> go_left;
+    __device__ bool operator()(cuda_impl::RowIndexT ridx, int /*nidx_in_batch*/,
+                               const NodeSplitData& data) const {
+      return go_left(ridx, data);
+    }
+  };
+
   // Update position and build histogram.
   void PartitionAndBuildHist(DMatrix* p_fmat, std::vector<GPUExpandEntry> const& expand_set,
                              std::vector<GPUExpandEntry> const& candidates, RegTree const* p_tree) {
@@ -489,8 +514,7 @@ struct GPUHistMakerDevice {
     bool const is_single_block = p_fmat->SingleColBlock();
 
     // Prepare for update partition
-    auto [nidx, left_nidx, right_nidx, split_data] =
-        this->CreatePartitionNodes(p_tree, is_single_block ? candidates : expand_set);
+    auto nodes = this->CreatePartitionNodes(p_tree, is_single_block ? candidates : expand_set);
 
     // Prepare for build hist
     std::vector<bst_node_t> build_nidx(candidates.size());
@@ -504,26 +528,27 @@ struct GPUHistMakerDevice {
 
     std::int32_t k{0};
     for (auto const& page : p_fmat->GetBatches<EllpackPage>(ctx_, StaticBatch(prefetch_copy))) {
-      auto d_matrix = page.Impl()->GetDeviceAccessor(ctx_);
-      auto go_left = GoLeftOp{d_matrix};
+      page.Impl()->Visit(ctx_, {}, [&](auto&& d_matrix) {
+        using Acc = std::remove_reference_t<decltype(d_matrix)>;
+        auto go_left = GoLeftOp<Acc>{d_matrix};
 
-      // Partition histogram.
-      monitor.Start("UpdatePositionBatch");
-      if (p_fmat->Info().IsColumnSplit()) {
-        UpdatePositionColumnSplit(d_matrix, split_data, nidx, left_nidx, right_nidx);
-      } else {
-        partitioners_.at(k)->UpdatePositionBatch(
-            ctx_, nidx, left_nidx, right_nidx, split_data,
-            [=] __device__(cuda_impl::RowIndexT ridx, int /*nidx_in_batch*/,
-                           const NodeSplitData& data) { return go_left(ridx, data); });
-      }
+        // Partition histogram.
+        monitor.Start("UpdatePositionBatch");
+        if (p_fmat->Info().IsColumnSplit()) {
+          UpdatePositionColumnSplit(d_matrix, nodes.split_data, nodes.nidx, nodes.left_nidx,
+                                    nodes.right_nidx);
+        } else {
+          partitioners_.at(k)->UpdatePositionBatch(ctx_, nodes.nidx, nodes.left_nidx,
+                                                   nodes.right_nidx, nodes.split_data,
+                                                   GoLeftWrapperOp<Acc>{go_left});
+        }
 
-      monitor.Stop("UpdatePositionBatch");
+        monitor.Stop("UpdatePositionBatch");
 
-      for (auto nidx : build_nidx) {
-        this->BuildHist(page, k, nidx);
-      }
-
+        for (auto nidx : build_nidx) {
+          this->BuildHist(page, k, nidx);
+        }
+      });
       ++k;
     }
 
@@ -533,6 +558,32 @@ struct GPUHistMakerDevice {
 
     monitor.Stop(__func__);
   }
+
+  struct EncodeOp {
+    common::Span<GradientPair const> d_gpair;
+    __device__ bst_node_t operator()(bst_idx_t ridx, bst_node_t nidx) const {
+      bool is_invalid = d_gpair[ridx].GetHess() - .0f == 0.f;
+      return SamplePosition::Encode(nidx, !is_invalid);
+    }
+  };
+
+  template <typename Accessor>
+  struct FinalizeOp {
+    common::Span<NodeSplitData> s_split_data;
+    GoLeftOp<Accessor> go_left_op;
+    EncodeOp encode_op;
+
+    __device__ auto operator()(bst_idx_t row_id, bst_node_t nidx) const {
+      auto split_data = s_split_data[nidx];
+      auto node = split_data.split_node;
+      while (!node.IsLeaf()) {
+        auto go_left = go_left_op(row_id, split_data);
+        nidx = go_left ? node.LeftChild() : node.RightChild();
+        node = s_split_data[nidx].split_node;
+      }
+      return encode_op(row_id, nidx);
+    };
+  };
 
   // After tree update is finished, update the position of all training
   // instances to their final leaf. This information is used later to update the
@@ -556,10 +607,6 @@ struct GPUHistMakerDevice {
     auto d_out_position = p_out_position->DeviceSpan();
 
     auto d_gpair = this->gpair;
-    auto encode_op = [=] __device__(bst_idx_t ridx, bst_node_t nidx) {
-      bool is_invalid = d_gpair[ridx].GetHess() - .0f == 0.f;
-      return SamplePosition::Encode(nidx, !is_invalid);
-    };  // NOLINT
 
     if (!p_fmat->SingleColBlock()) {
       for (std::size_t k = 0; k < partitioners_.size(); ++k) {
@@ -568,7 +615,7 @@ struct GPUHistMakerDevice {
         auto base_ridx = batch_ptr_[k];
         auto n_samples = batch_ptr_.at(k + 1) - base_ridx;
         part->FinalisePosition(ctx_, d_out_position.subspan(base_ridx, n_samples), base_ridx,
-                               encode_op);
+                               EncodeOp{d_gpair});
       }
       dh::CopyTo(d_out_position, &positions_, this->ctx_->CUDACtx()->Stream());
       monitor.Stop(__func__);
@@ -582,8 +629,6 @@ struct GPUHistMakerDevice {
     auto ft = p_fmat->Info().feature_types.ConstDeviceSpan();
 
     for (auto const& page : p_fmat->GetBatches<EllpackPage>(ctx_, StaticBatch(true))) {
-      auto d_matrix = page.Impl()->GetDeviceAccessor(ctx_, ft);
-
       std::vector<NodeSplitData> split_data(p_tree->NumNodes());
       auto const& tree = *p_tree;
       for (std::size_t i = 0, n = split_data.size(); i < n; ++i) {
@@ -593,24 +638,19 @@ struct GPUHistMakerDevice {
         split_data[i] = NodeSplitData{std::move(split_node), split_type, node_cats};
       }
 
-      auto go_left_op = GoLeftOp{d_matrix};
       dh::CachingDeviceUVector<NodeSplitData> d_split_data;
       dh::CopyTo(split_data, &d_split_data, this->ctx_->CUDACtx()->Stream());
       auto s_split_data = dh::ToSpan(d_split_data);
 
-      partitioners_.front()->FinalisePosition(ctx_, d_out_position, page.BaseRowId(),
-                                              [=] __device__(bst_idx_t row_id, bst_node_t nidx) {
-                                                auto split_data = s_split_data[nidx];
-                                                auto node = split_data.split_node;
-                                                while (!node.IsLeaf()) {
-                                                  auto go_left = go_left_op(row_id, split_data);
-                                                  nidx = go_left ? node.LeftChild()
-                                                                 : node.RightChild();
-                                                  node = s_split_data[nidx].split_node;
-                                                }
-                                                return encode_op(row_id, nidx);
-                                              });
-      dh::CopyTo(d_out_position, &positions_, this->ctx_->CUDACtx()->Stream());
+      page.Impl()->Visit(ctx_, ft, [&](auto&& d_matrix) {
+        auto go_left_op = GoLeftOp<std::remove_reference_t<decltype(d_matrix)>>{d_matrix};
+        partitioners_.front()->FinalisePosition(
+            ctx_, d_out_position, page.BaseRowId(),
+            FinalizeOp<std::remove_reference_t<decltype(d_matrix)>>{s_split_data, go_left_op,
+                                                                    EncodeOp{d_gpair}});
+
+        dh::CopyTo(d_out_position, &positions_, this->ctx_->CUDACtx()->Stream());
+      });
     }
     monitor.Stop(__func__);
   }

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -127,11 +127,6 @@ struct GPUHistMakerDevice {
   PartitionNodes CreatePartitionNodes(RegTree const* p_tree,
                                       std::vector<GPUExpandEntry> const& candidates) {
     PartitionNodes nodes(candidates.size());
-    // std::vector<bst_node_t> nidx(candidates.size());
-    // std::vector<bst_node_t> left_nidx(candidates.size());
-    // std::vector<bst_node_t> right_nidx(candidates.size());
-    // std::vector<NodeSplitData> split_data(candidates.size());
-
     for (std::size_t i = 0, n = candidates.size(); i < n; i++) {
       auto const& e = candidates[i];
       RegTree::Node split_node = (*p_tree)[e.nid];
@@ -382,7 +377,7 @@ struct GPUHistMakerDevice {
   }
 
   template <typename Iter>
-  void UpdatePositionColumnSplit(EllpackDeviceAccessorImpl<Iter> d_matrix,
+  void UpdatePositionColumnSplit(EllpackAccessorImpl<Iter> d_matrix,
                                  std::vector<NodeSplitData> const& split_data,
                                  std::vector<bst_node_t> const& nidx,
                                  std::vector<bst_node_t> const& left_nidx,
@@ -542,7 +537,6 @@ struct GPUHistMakerDevice {
                                                    nodes.right_nidx, nodes.split_data,
                                                    GoLeftWrapperOp<Acc>{go_left});
         }
-
         monitor.Stop("UpdatePositionBatch");
 
         for (auto nidx : build_nidx) {

--- a/tests/cpp/common/test_gpu_compressed_iterator.cu
+++ b/tests/cpp/common/test_gpu_compressed_iterator.cu
@@ -143,6 +143,7 @@ TEST_P(TestDoubleCompressedIter, Basic) {
 }
 
 INSTANTIATE_TEST_SUITE_P(Gpu, TestDoubleCompressedIter,
-                         ::testing::Values(0, kCnBytes, 1, kCnBytes - 1, kCnBytes / 2,
-                                           kCnBytes / 3));
+                         ::testing::Values(0, kCnBytes, 1, kCnBytes - 1, kCnBytes / 2, kCnBytes / 3,
+                                           kCnBytes / 4, kCnBytes / 6, kCnBytes / 8,
+                                           kCnBytes / 12));
 }  // namespace xgboost::common

--- a/tests/cpp/common/test_gpu_compressed_iterator.cu
+++ b/tests/cpp/common/test_gpu_compressed_iterator.cu
@@ -1,28 +1,31 @@
 /**
  * Copyright 2018-2025, XGBoost Contributors
  */
+#include <gtest/gtest.h>
 #include <thrust/device_vector.h>
+#include <thrust/sequence.h>  // for sequence
 
-#include <algorithm>
-#include <vector>  // for vector
+#include <algorithm>  // for generate
+#include <cstddef>    // for size_t
+#include <cstdint>    // for int32_t, uint32_t
+#include <vector>     // for vector
 
 #include "../../../src/common/compressed_iterator.h"
-#include "../../../src/common/device_helpers.cuh"
-#include "../../../src/common/device_vector.cuh"  // for DeviceUVector
-#include "gtest/gtest.h"
+#include "../../../src/common/cuda_context.cuh"    // for CUDAContext
+#include "../../../src/common/device_helpers.cuh"  // for LaunchN
+#include "../../../src/common/device_vector.cuh"   // for DeviceUVector
+#include "../helpers.h"
 
 namespace xgboost::common {
 struct WriteSymbolFunction {
   CompressedBufferWriter cbw;
   unsigned char* buffer_data_d;
-  int* input_data_d;
+  int const* input_data_d;
   WriteSymbolFunction(CompressedBufferWriter cbw, unsigned char* buffer_data_d,
-                      int* input_data_d)
-    : cbw(cbw), buffer_data_d(buffer_data_d), input_data_d(input_data_d) {}
+                      int const* input_data_d)
+      : cbw(cbw), buffer_data_d(buffer_data_d), input_data_d(input_data_d) {}
 
-  __device__ void operator()(size_t i) {
-    cbw.AtomicWriteSymbol(buffer_data_d, input_data_d[i], i);
-  }
+  __device__ void operator()(size_t i) { cbw.AtomicWriteSymbol(buffer_data_d, input_data_d[i], i); }
 };
 
 struct ReadSymbolFunction {
@@ -75,8 +78,71 @@ TEST(CompressedIterator, TestGPU) {
   }
 }
 
-TEST(DoubleCompressedIter, Alignment) {
-  std::vector<std::uint32_t> buf0;
-  dh::DeviceUVector<std::uint32_t> buf1;
+namespace {
+class TestDoubleCompressedIter : public ::testing::TestWithParam<std::size_t> {
+ public:
+  constexpr std::size_t static CompressedBytes() { return 24; }
+
+ private:
+  dh::DeviceUVector<std::int32_t> input_;
+  Context ctx_{MakeCUDACtx(0)};
+  std::size_t n_symbols_{11};
+
+  void SetUp() override {
+    input_.resize(n_symbols_ * 3);
+    auto policy = ctx_.CUDACtx()->CTP();
+    for (std::size_t i = 0; i < 3; ++i) {
+      auto beg = input_.begin() + n_symbols_ * i;
+      auto end = beg + n_symbols_;
+      thrust::sequence(policy, beg, end, 0);
+    }
+  }
+
+ public:
+  void Run(std::size_t n0_bytes) const {
+    auto policy = ctx_.CUDACtx()->CTP();
+
+    auto compressed_nbytes = CompressedBufferWriter::CalculateBufferSize(input_.size(), n_symbols_);
+    ASSERT_EQ(compressed_nbytes, CompressedBytes());
+
+    dh::device_vector<CompressedByteT> buf(compressed_nbytes, 0);
+    CompressedBufferWriter cbw(n_symbols_);
+    dh::LaunchN(input_.size(), ctx_.CUDACtx()->Stream(),
+                WriteSymbolFunction{cbw, buf.data().get(), input_.data()});
+
+    dh::device_vector<CompressedByteT> buf0(n0_bytes);
+    dh::device_vector<CompressedByteT> buf1(compressed_nbytes - buf0.size());
+    thrust::copy_n(policy, buf.begin(), buf0.size(), buf0.begin());
+    thrust::copy_n(policy, buf.begin() + buf0.size(), buf1.size(), buf1.begin());
+
+    HostDeviceVector<std::int32_t> output(input_.size(), 0, ctx_.Device());
+    auto it = DoubleCompressedIter<std::uint32_t>{buf0.data().get(), buf0.size(), buf1.data().get(),
+                                                  n_symbols_};
+    auto d_out = output.DeviceSpan();
+    dh::LaunchN(input_.size(), ctx_.CUDACtx()->Stream(),
+                [=] __device__(std::size_t i) { d_out[i] = it[i]; });
+    auto h_out = output.ConstHostVector();
+    for (std::size_t i = 0; i < 3; ++i) {
+      auto beg = h_out.begin() + n_symbols_ * i;
+      auto end = beg + n_symbols_;
+      std::size_t k = 0;
+      for (auto it = beg; it != end; ++it) {
+        ASSERT_EQ(*it, k);
+        k++;
+      }
+    }
+  }
+};
+
+inline auto kCnBytes = TestDoubleCompressedIter::CompressedBytes();
+}  // namespace
+
+TEST_P(TestDoubleCompressedIter, Basic) {
+  auto n0_bytes = this->GetParam();
+  this->Run(n0_bytes);
 }
+
+INSTANTIATE_TEST_SUITE_P(Gpu, TestDoubleCompressedIter,
+                         ::testing::Values(0, kCnBytes, 1, kCnBytes - 1, kCnBytes / 2,
+                                           kCnBytes / 3));
 }  // namespace xgboost::common

--- a/tests/cpp/common/test_gpu_compressed_iterator.cu
+++ b/tests/cpp/common/test_gpu_compressed_iterator.cu
@@ -1,12 +1,17 @@
-#include "../../../src/common/compressed_iterator.h"
-#include "../../../src/common/device_helpers.cuh"
-#include "gtest/gtest.h"
-#include <algorithm>
+/**
+ * Copyright 2018-2025, XGBoost Contributors
+ */
 #include <thrust/device_vector.h>
 
-namespace xgboost {
-namespace common {
+#include <algorithm>
+#include <vector>  // for vector
 
+#include "../../../src/common/compressed_iterator.h"
+#include "../../../src/common/device_helpers.cuh"
+#include "../../../src/common/device_vector.cuh"  // for DeviceUVector
+#include "gtest/gtest.h"
+
+namespace xgboost::common {
 struct WriteSymbolFunction {
   CompressedBufferWriter cbw;
   unsigned char* buffer_data_d;
@@ -70,5 +75,8 @@ TEST(CompressedIterator, TestGPU) {
   }
 }
 
-}  // namespace common
-}  // namespace xgboost
+TEST(DoubleCompressedIter, Alignment) {
+  std::vector<std::uint32_t> buf0;
+  dh::DeviceUVector<std::uint32_t> buf1;
+}
+}  // namespace xgboost::common

--- a/tests/cpp/data/test_ellpack_page.cu
+++ b/tests/cpp/data/test_ellpack_page.cu
@@ -29,7 +29,7 @@ TEST(EllpackPage, EmptyDMatrix) {
   auto impl = page.Impl();
   ASSERT_EQ(impl->info.row_stride, 0);
   ASSERT_EQ(impl->Cuts().TotalBins(), 0);
-  ASSERT_EQ(impl->gidx_buffer.size(), 4);
+  ASSERT_EQ(impl->gidx_buffer.size(), 5);
 }
 
 TEST(EllpackPage, BuildGidxDense) {

--- a/tests/cpp/data/test_ellpack_page.cu
+++ b/tests/cpp/data/test_ellpack_page.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024, XGBoost contributors
+ * Copyright 2019-2025, XGBoost contributors
  */
 #include <xgboost/base.h>
 

--- a/tests/cpp/data/test_ellpack_page.cu
+++ b/tests/cpp/data/test_ellpack_page.cu
@@ -36,8 +36,6 @@ TEST(EllpackPage, BuildGidxDense) {
   bst_idx_t n_samples = 16, n_features = 8;
   auto ctx = MakeCUDACtx(0);
   auto page = BuildEllpackPage(&ctx, n_samples, n_features);
-  std::vector<common::CompressedByteT> h_gidx_buffer;
-  auto h_accessor = page->GetHostAccessor(&ctx, &h_gidx_buffer);
 
   ASSERT_EQ(page->info.row_stride, n_features);
 
@@ -59,22 +57,22 @@ TEST(EllpackPage, BuildGidxDense) {
     2, 4, 8, 10, 14, 15, 19, 22,
     1, 4, 7, 10, 14, 16, 19, 21,
   };
-  for (size_t i = 0; i < n_samples * n_features; ++i) {
-    auto fidx = i % n_features;
-    ASSERT_EQ(solution[i], h_accessor.gidx_iter[i] + h_accessor.feature_segments[fidx]);
-  }
+
+  page->VisitOnHost(&ctx, [&](auto&& h_accessor) {
+    for (size_t i = 0; i < n_samples * n_features; ++i) {
+      auto fidx = i % n_features;
+      ASSERT_EQ(solution[i], h_accessor.gidx_iter[i] + h_accessor.feature_segments[fidx]);
+      ASSERT_EQ(page->NumSymbols(), h_accessor.NullValue());
+    }
+  });
   ASSERT_EQ(page->NumSymbols(), 3);
   ASSERT_EQ(page->NumNonMissing(&ctx, {}), n_samples * n_features);
-  ASSERT_EQ(page->NumSymbols(), h_accessor.NullValue());
 }
 
 TEST(EllpackPage, BuildGidxSparse) {
   int constexpr kNRows = 16, kNCols = 8;
   auto ctx = MakeCUDACtx(0);
   auto page = BuildEllpackPage(&ctx, kNRows, kNCols, 0.9f);
-
-  std::vector<common::CompressedByteT> h_gidx_buffer;
-  auto h_acc = page->GetHostAccessor(&ctx, &h_gidx_buffer);
 
   ASSERT_EQ(page->info.row_stride, 3);
 
@@ -84,9 +82,11 @@ TEST(EllpackPage, BuildGidxSparse) {
     24, 24, 24, 24, 24,  5, 24, 24,  0, 16, 24, 15, 24, 24, 24, 24,
     24,  7, 14, 16,  4, 24, 24, 24, 24, 24,  9, 24, 24,  1, 24, 24
   };
-  for (size_t i = 0; i < kNRows * page->info.row_stride; ++i) {
-    ASSERT_EQ(solution[i], h_acc.gidx_iter[i]);
-  }
+  page->VisitOnHost(&ctx, [&](auto&& h_acc) {
+    for (size_t i = 0; i < kNRows * page->info.row_stride; ++i) {
+      ASSERT_EQ(solution[i], h_acc.gidx_iter[i]);
+    }
+  });
 }
 
 TEST(EllpackPage, FromCategoricalBasic) {
@@ -101,31 +101,30 @@ TEST(EllpackPage, FromCategoricalBasic) {
   auto ctx = MakeCUDACtx(0);
   auto p = BatchParam{max_bins, tree::TrainParam::DftSparseThreshold()};
   auto ellpack = EllpackPage(&ctx, m.get(), p);
-  auto accessor = ellpack.Impl()->GetDeviceAccessor(&ctx);
-  ASSERT_EQ(kCats, accessor.NumBins());
 
   auto x_copy = x;
   std::sort(x_copy.begin(), x_copy.end());
   auto n_uniques = std::unique(x_copy.begin(), x_copy.end()) - x_copy.begin();
   ASSERT_EQ(n_uniques, kCats);
 
-  std::vector<uint32_t> h_cuts_ptr(accessor.NumFeatures() + 1);
-  dh::safe_cuda(cudaMemcpyAsync(h_cuts_ptr.data(), accessor.feature_segments,
-                                sizeof(bst_feature_t) * h_cuts_ptr.size(), cudaMemcpyDefault));
-  std::vector<float> h_cuts_values(accessor.gidx_fvalue_map.size());
-  dh::CopyDeviceSpanToVector(&h_cuts_values, accessor.gidx_fvalue_map);
+  ellpack.Impl()->Visit(&ctx, {}, [&](auto&& accessor) {
+    ASSERT_EQ(kCats, accessor.NumBins());
+    std::vector<uint32_t> h_cuts_ptr(accessor.NumFeatures() + 1);
+    dh::safe_cuda(cudaMemcpyAsync(h_cuts_ptr.data(), accessor.feature_segments,
+                                  sizeof(bst_feature_t) * h_cuts_ptr.size(), cudaMemcpyDefault));
+    std::vector<float> h_cuts_values(accessor.gidx_fvalue_map.size());
+    dh::CopyDeviceSpanToVector(&h_cuts_values, accessor.gidx_fvalue_map);
+    ASSERT_EQ(h_cuts_ptr.size(), 2);
+    ASSERT_EQ(h_cuts_values.size(), kCats);
 
-  ASSERT_EQ(h_cuts_ptr.size(), 2);
-  ASSERT_EQ(h_cuts_values.size(), kCats);
-
-  std::vector<common::CompressedByteT> h_gidx_buffer;
-  auto h_accessor = ellpack.Impl()->GetHostAccessor(&ctx, &h_gidx_buffer);
-
-  for (size_t i = 0; i < x.size(); ++i) {
-    auto bin = h_accessor.gidx_iter[i];
-    auto bin_value = h_cuts_values.at(bin);
-    ASSERT_EQ(AsCat(x[i]), AsCat(bin_value));
-  }
+    ellpack.Impl()->VisitOnHost(&ctx, [&](auto&& h_accessor) {
+      for (size_t i = 0; i < x.size(); ++i) {
+        auto bin = h_accessor.gidx_iter[i];
+        auto bin_value = h_cuts_values.at(bin);
+        ASSERT_EQ(AsCat(x[i]), AsCat(bin_value));
+      }
+    });
+  });
 }
 
 TEST(EllpackPage, FromCategoricalMissing) {
@@ -146,24 +145,24 @@ TEST(EllpackPage, FromCategoricalMissing) {
   }
   cuts->SetDevice(ctx.Device());
   for (auto const& page : p_fmat->GetBatches<EllpackPage>(&ctx, p)) {
-    std::vector<common::CompressedByteT> h_buffer;
-    auto h_acc = page.Impl()->GetHostAccessor(&ctx, &h_buffer,
-                                              p_fmat->Info().feature_types.ConstDeviceSpan());
-    ASSERT_EQ(h_acc.n_rows, 2);
-    ASSERT_EQ(cuts->NumFeatures(), 3);
-    ASSERT_EQ(h_acc.row_stride, 2);
-    ASSERT_EQ(h_acc.gidx_iter[0], 0);
-    ASSERT_EQ(h_acc.gidx_iter[1], 4);  // cat 1
-    ASSERT_EQ(h_acc.gidx_iter[2], 1);
-    ASSERT_EQ(h_acc.gidx_iter[3], 3);  // cat 0
+    page.Impl()->VisitOnHost(&ctx, [&](auto&& h_acc) {
+      ASSERT_EQ(h_acc.n_rows, 2);
+      ASSERT_EQ(cuts->NumFeatures(), 3);
+      ASSERT_EQ(h_acc.row_stride, 2);
+      ASSERT_EQ(h_acc.gidx_iter[0], 0);
+      ASSERT_EQ(h_acc.gidx_iter[1], 4);  // cat 1
+      ASSERT_EQ(h_acc.gidx_iter[2], 1);
+      ASSERT_EQ(h_acc.gidx_iter[3], 3);  // cat 0
+    });
   }
 }
 
+template <typename Accessor>
 struct ReadRowFunction {
-  EllpackDeviceAccessor matrix;
-  int row;
+  Accessor matrix;
+  std::size_t row;
   bst_float* row_data_d;
-  ReadRowFunction(EllpackDeviceAccessor matrix, int row, bst_float* row_data_d)
+  ReadRowFunction(Accessor matrix, std::size_t row, bst_float* row_data_d)
       : matrix(std::move(matrix)), row(row), row_data_d(row_data_d) {}
 
   __device__ void operator()(size_t col) {
@@ -206,12 +205,13 @@ TEST(EllpackPage, Copy) {
     EXPECT_EQ(impl->base_rowid, current_row);
 
     for (size_t i = 0; i < impl->Size(); i++) {
-      dh::LaunchN(kCols,
-                  ReadRowFunction(impl->GetDeviceAccessor(&ctx), current_row, row_d.data().get()));
+      impl->Visit(&ctx, {}, [&](auto&& acc) {
+        dh::LaunchN(kCols, ReadRowFunction(acc, current_row, row_d.data().get()));
+      });
       thrust::copy(row_d.begin(), row_d.end(), row.begin());
-
-      dh::LaunchN(kCols, ReadRowFunction(result.GetDeviceAccessor(&ctx), current_row,
-                                         row_result_d.data().get()));
+      result.Visit(&ctx, {}, [&](auto&& acc) {
+        dh::LaunchN(kCols, ReadRowFunction(acc, current_row, row_result_d.data().get()));
+      });
       thrust::copy(row_result_d.begin(), row_result_d.end(), row_result.begin());
 
       EXPECT_EQ(row, row_result);
@@ -262,13 +262,16 @@ TEST(EllpackPage, Compact) {
         continue;
       }
 
-      dh::LaunchN(kCols,
-                  ReadRowFunction(impl->GetDeviceAccessor(&ctx), current_row, row_d.data().get()));
+      impl->Visit(&ctx, {}, [&](auto&& acc) {
+        dh::LaunchN(kCols, ReadRowFunction{acc, current_row, row_d.data().get()});
+      });
+
       dh::safe_cuda(cudaDeviceSynchronize());
       thrust::copy(row_d.begin(), row_d.end(), row.begin());
 
-      dh::LaunchN(kCols, ReadRowFunction(result.GetDeviceAccessor(&ctx), compacted_row,
-                                         row_result_d.data().get()));
+      result.Visit(&ctx, {}, [&](auto&& acc) {
+        dh::LaunchN(kCols, ReadRowFunction(acc, compacted_row, row_result_d.data().get()));
+      });
       thrust::copy(row_result_d.begin(), row_result_d.end(), row_result.begin());
 
       EXPECT_EQ(row, row_result);
@@ -300,17 +303,18 @@ class CompressedDense : public ::testing::TestWithParam<std::size_t> {
     ASSERT_EQ(impl.NumSymbols(), batch.max_bin + 1);
 
     std::vector<common::CompressedByteT> h_gidx;
-    auto h_acc = impl.GetHostAccessor(ctx, &h_gidx);
-    ASSERT_EQ(h_acc.row_stride, h_acc.NumFeatures());
-    ASSERT_EQ(h_acc.NullValue(), batch.max_bin);
-    for (std::size_t i = 0; i < h_acc.row_stride * h_acc.n_rows; ++i) {
-      auto [m, n] = linalg::UnravelIndex(i, h_acc.n_rows, h_acc.row_stride);
-      if (n == null_column && m != 0) {
-        ASSERT_EQ(static_cast<std::int32_t>(h_acc.gidx_iter[i]), h_acc.NullValue());
-      } else {
-        ASSERT_EQ(static_cast<std::int32_t>(h_acc.gidx_iter[i]), m);
+    impl.VisitOnHost(ctx, [&](auto&& h_acc) {
+      ASSERT_EQ(h_acc.row_stride, h_acc.NumFeatures());
+      ASSERT_EQ(h_acc.NullValue(), batch.max_bin);
+      for (std::size_t i = 0; i < h_acc.row_stride * h_acc.n_rows; ++i) {
+        auto [m, n] = linalg::UnravelIndex(i, h_acc.n_rows, h_acc.row_stride);
+        if (n == null_column && m != 0) {
+          ASSERT_EQ(static_cast<std::int32_t>(h_acc.gidx_iter[i]), h_acc.NullValue());
+        } else {
+          ASSERT_EQ(static_cast<std::int32_t>(h_acc.gidx_iter[i]), m);
+        }
       }
-    }
+    });
   }
 
  public:
@@ -438,11 +442,15 @@ class SparseEllpack : public testing::TestWithParam<float> {
       ASSERT_EQ(from_sparse_page->gidx_buffer.size(), from_ghist->gidx_buffer.size());
       ASSERT_EQ(from_sparse_page->NumSymbols(), from_ghist->NumSymbols());
       std::vector<common::CompressedByteT> h_gidx_from_sparse, h_gidx_from_ghist;
-      auto from_ghist_acc = from_ghist->GetHostAccessor(&gpu_ctx, &h_gidx_from_ghist);
-      auto from_sparse_acc = from_sparse_page->GetHostAccessor(&gpu_ctx, &h_gidx_from_sparse);
-      for (size_t i = 0; i < from_ghist->n_rows * from_ghist->info.row_stride; ++i) {
-        ASSERT_EQ(from_ghist_acc.gidx_iter[i], from_sparse_acc.gidx_iter[i]);
-      }
+      auto from_ghist_acc = from_ghist->GetHostEllpack(&gpu_ctx, &h_gidx_from_ghist);
+      auto from_sparse_acc = from_sparse_page->GetHostEllpack(&gpu_ctx, &h_gidx_from_sparse);
+      std::visit(
+          [&](auto&& from_ghist_acc, auto&& from_sparse_acc) {
+            for (size_t i = 0; i < from_ghist->n_rows * from_ghist->info.row_stride; ++i) {
+              ASSERT_EQ(from_ghist_acc.gidx_iter[i], from_sparse_acc.gidx_iter[i]);
+            }
+          },
+          from_ghist_acc, from_sparse_acc);
     }
   }
 
@@ -473,22 +481,24 @@ TEST(EllpackPage, IsDense) {
     auto p = BatchParam{16, tree::TrainParam::DftSparseThreshold()};
     auto ctx = MakeCUDACtx(0);
     for (auto const& page : p_fmat->GetBatches<EllpackPage>(&ctx, p)) {
-      auto d_acc = page.Impl()->GetDeviceAccessor(&ctx);
-      if (sparsity == 0.0) {
-        ASSERT_EQ(d_acc.IsDense(), page.Impl()->IsDense());
-        ASSERT_TRUE(d_acc.IsDense());
-        ASSERT_EQ(p.max_bin, d_acc.NullValue());
-      } else {
-        ASSERT_FALSE(d_acc.IsDense());
-        ASSERT_EQ(p.max_bin * p_fmat->Info().num_col_, d_acc.NullValue());
-      }
-      std::vector<common::CompressedByteT> h_storage;
-      auto h_acc = page.Impl()->GetHostAccessor(&ctx, &h_storage);
-      if (sparsity == 0.0) {
-        ASSERT_TRUE(h_acc.IsDense());
-      } else {
-        ASSERT_FALSE(h_acc.IsDense());
-      }
+      page.Impl()->Visit(&ctx, {}, [&](auto&& d_acc) {
+        if (sparsity == 0.0) {
+          ASSERT_EQ(d_acc.IsDense(), page.Impl()->IsDense());
+          ASSERT_TRUE(d_acc.IsDense());
+          ASSERT_EQ(p.max_bin, d_acc.NullValue());
+        } else {
+          ASSERT_FALSE(d_acc.IsDense());
+          ASSERT_EQ(p.max_bin * p_fmat->Info().num_col_, d_acc.NullValue());
+        }
+      });
+
+      page.Impl()->VisitOnHost(&ctx, [&](auto&& h_acc) {
+        if (sparsity == 0.0) {
+          ASSERT_TRUE(h_acc.IsDense());
+        } else {
+          ASSERT_FALSE(h_acc.IsDense());
+        }
+      });
     }
   };
   test(0.0);

--- a/tests/cpp/data/test_sparse_page_dmatrix.cu
+++ b/tests/cpp/data/test_sparse_page_dmatrix.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024, XGBoost Contributors
+ * Copyright 2019-2025, XGBoost Contributors
  */
 #include <xgboost/data.h>  // for DMatrix
 

--- a/tests/cpp/data/test_sparse_page_dmatrix.cu
+++ b/tests/cpp/data/test_sparse_page_dmatrix.cu
@@ -157,7 +157,7 @@ TEST(SparsePageDMatrix, RetainEllpackPage) {
 
   for (size_t i = 0; i < iterators.size(); ++i) {
     std::vector<common::CompressedByteT> h_buf;
-    [[maybe_unused]] auto h_acc = (*iterators[i]).Impl()->GetHostAccessor(&ctx, &h_buf);
+    [[maybe_unused]] auto h_acc = (*iterators[i]).Impl()->GetHostEllpack(&ctx, &h_buf);
     ASSERT_EQ(h_buf, gidx_buffers.at(i).HostVector());
     // The last page is still kept in the DMatrix until Reset is called.
     if (i == iterators.size() - 1) {
@@ -226,9 +226,9 @@ class TestEllpackPageExt : public ::testing::TestWithParam<std::tuple<bool, bool
     ASSERT_EQ(impl_ext->Cuts().TotalBins(), 4);
 
     std::vector<common::CompressedByteT> buffer;
-    [[maybe_unused]] auto h_acc = impl->GetHostAccessor(&ctx, &buffer);
+    [[maybe_unused]] auto h_acc = impl->GetHostEllpack(&ctx, &buffer);
     std::vector<common::CompressedByteT> buffer_ext;
-    [[maybe_unused]] auto h_ext_acc = impl_ext->GetHostAccessor(&ctx, &buffer_ext);
+    [[maybe_unused]] auto h_ext_acc = impl_ext->GetHostEllpack(&ctx, &buffer_ext);
     ASSERT_EQ(buffer, buffer_ext);
   }
 };
@@ -258,12 +258,13 @@ INSTANTIATE_TEST_SUITE_P(EllpackPageExt, TestEllpackPageExt, ::testing::ValuesIn
                            return ss.str();
                          });
 
+template <typename Accessor>
 struct ReadRowFunction {
-  EllpackDeviceAccessor matrix;
-  int row;
+  Accessor matrix;
+  bst_idx_t row;
   bst_float* row_data_d;
-  ReadRowFunction(EllpackDeviceAccessor matrix, int row, bst_float* row_data_d)
-      : matrix(std::move(matrix)), row(row), row_data_d(row_data_d) {}
+  ReadRowFunction(Accessor matrix, bst_idx_t row, bst_float* row_data_d)
+      : matrix(std::move(matrix)), row{row}, row_data_d(row_data_d) {}
 
   __device__ void operator()(size_t col) {
     auto value = matrix.GetFvalue(row, col);
@@ -303,12 +304,15 @@ TEST(SparsePageDMatrix, MultipleEllpackPageContent) {
     EXPECT_EQ(impl_ext->base_rowid, current_row);
 
     for (size_t i = 0; i < impl_ext->Size(); i++) {
-      dh::LaunchN(kCols,
-                  ReadRowFunction(impl->GetDeviceAccessor(&ctx), current_row, row_d.data().get()));
-      thrust::copy(row_d.begin(), row_d.end(), row.begin());
+      impl->Visit(&ctx, {}, [&](auto&& acc) {
+        dh::LaunchN(kCols, ReadRowFunction{acc, current_row, row_d.data().get()});
+      });
 
-      dh::LaunchN(kCols, ReadRowFunction(impl_ext->GetDeviceAccessor(&ctx), current_row,
-                                         row_ext_d.data().get()));
+      thrust::copy(row_d.begin(), row_d.end(), row.begin());
+      impl_ext->Visit(&ctx, {}, [&](auto&& acc) {
+        dh::LaunchN(kCols, ReadRowFunction{acc, current_row, row_ext_d.data().get()});
+      });
+
       thrust::copy(row_ext_d.begin(), row_ext_d.end(), row_ext.begin());
 
       EXPECT_EQ(row, row_ext);

--- a/tests/cpp/tree/gpu_hist/test_histogram.cu
+++ b/tests/cpp/tree/gpu_hist/test_histogram.cu
@@ -5,6 +5,7 @@
 #include <xgboost/context.h>  // for Context
 
 #include <memory>  // for unique_ptr
+#include <tuple>   // for tuple
 #include <vector>  // for vector
 
 #include "../../../../src/tree/gpu_hist/histogram.cuh"
@@ -424,17 +425,45 @@ TEST(Histogram, Quantiser) {
   }
 }
 namespace {
-class HistogramExternalMemoryTest : public ::testing::TestWithParam<std::tuple<float, bool>> {
+enum CacheMode {
+  kNoCache = 0,
+  kCopy = 1,
+  kDirect = 2,
+};
+
+class HistogramExternalMemoryTest
+    : public ::testing::TestWithParam<std::tuple<float, bool, CacheMode>> {
  public:
-  void Run(float sparsity, bool force_global) {
+  void Run(float sparsity, bool force_global, CacheMode cache_mode) {
+    auto ctx = MakeCUDACtx(0);
     bst_idx_t n_samples{512}, n_features{12}, n_batches{3};
     std::vector<std::unique_ptr<RowPartitioner>> partitioners;
-    auto p_fmat = RandomDataGenerator{n_samples, n_features, sparsity}
-                      .Batches(n_batches)
-                      .GenerateSparsePageDMatrix("cache", true);
+    auto rng = RandomDataGenerator{n_samples, n_features, sparsity}.Batches(n_batches);
     bst_bin_t n_bins = 16;
+    std::shared_ptr<DMatrix> p_fmat;
+    switch (cache_mode) {
+      case kCopy:
+      case kDirect: {
+        p_fmat = rng.CacheHostRatio(0.5)
+                     .Device(ctx.Device())
+                     .Bins(n_bins)
+                     .OnHost(true)
+                     .MinPageCacheBytes(n_bins * n_features)
+                     .GenerateExtMemQuantileDMatrix("cache", true);
+        break;
+      }
+      case kNoCache: {
+        p_fmat = rng.GenerateSparsePageDMatrix("cache", true);
+        break;
+      }
+    }
+
     BatchParam p{n_bins, TrainParam::DftSparseThreshold()};
-    auto ctx = MakeCUDACtx(0);
+    if (cache_mode == kDirect) {
+      p.prefetch_copy = false;
+    } else if (cache_mode == kCopy) {
+      p.prefetch_copy = true;
+    }
 
     std::unique_ptr<FeatureGroups> fg;
     dh::device_vector<GradientPairInt64> single_hist;
@@ -445,6 +474,7 @@ class HistogramExternalMemoryTest : public ::testing::TestWithParam<std::tuple<f
     auto quantiser = GradientQuantiser{&ctx, gpair.ConstDeviceSpan(), p_fmat->Info()};
     std::shared_ptr<common::HistogramCuts> cuts;
 
+    std::size_t row_stride = 0;
     {
       /**
        * Multi page.
@@ -452,6 +482,7 @@ class HistogramExternalMemoryTest : public ::testing::TestWithParam<std::tuple<f
       std::int32_t k{0};
       for (auto const& page : p_fmat->GetBatches<EllpackPage>(&ctx, p)) {
         auto impl = page.Impl();
+        row_stride = impl->info.row_stride;
         if (k == 0) {
           // Initialization
           fg = std::make_unique<FeatureGroups>(impl->Cuts());
@@ -473,7 +504,6 @@ class HistogramExternalMemoryTest : public ::testing::TestWithParam<std::tuple<f
           builder.BuildHistogram(ctx.CUDACtx(), acc, fg->DeviceAccessor(ctx.Device()),
                                  gpair.ConstDeviceSpan(), ridx, d_histogram, quantiser);
         });
-
         ++k;
       }
       ASSERT_EQ(k, n_batches);
@@ -486,18 +516,19 @@ class HistogramExternalMemoryTest : public ::testing::TestWithParam<std::tuple<f
       RowPartitioner partitioner;
       partitioner.Reset(&ctx, p_fmat->Info().num_row_, 0);
 
-      SparsePage concat;
+      auto concat = EllpackPageImpl(&ctx, cuts, sparsity == 0.0, row_stride, n_samples);
       std::vector<float> hess(p_fmat->Info().num_row_, 1.0f);
-      for (auto const& page : p_fmat->GetBatches<SparsePage>()) {
-        concat.Push(page);
+      std::size_t offset = 0;
+      for (auto const& page : p_fmat->GetBatches<EllpackPage>(&ctx, p)) {
+        bst_idx_t num_elements = concat.Copy(&ctx, page.Impl(), offset);
+        offset += num_elements;
       }
-      EllpackPageImpl page{&ctx, cuts, concat, p_fmat->IsDense(), p_fmat->Info().num_col_, {}};
       auto ridx = partitioner.GetRows(0);
       auto d_histogram = dh::ToSpan(single_hist);
       DeviceHistogramBuilder builder;
       builder.Reset(&ctx, HistMakerTrainParam::CudaDefaultNodes(), fg->DeviceAccessor(ctx.Device()),
                     d_histogram.size(), force_global);
-      page.Visit(&ctx, {}, [&](auto&& acc) {
+      concat.Visit(&ctx, {}, [&](auto&& acc) {
         builder.BuildHistogram(ctx.CUDACtx(), acc, fg->DeviceAccessor(ctx.Device()),
                                gpair.ConstDeviceSpan(), ridx, d_histogram, quantiser);
       });
@@ -509,7 +540,7 @@ class HistogramExternalMemoryTest : public ::testing::TestWithParam<std::tuple<f
     thrust::copy(multi_hist.begin(), multi_hist.end(), h_multi.begin());
 
     for (std::size_t i = 0; i < single_hist.size(); ++i) {
-      ASSERT_EQ(h_single[i].GetQuantisedGrad(), h_multi[i].GetQuantisedGrad());
+      ASSERT_EQ(h_single[i].GetQuantisedGrad(), h_multi[i].GetQuantisedGrad()) << i;
       ASSERT_EQ(h_single[i].GetQuantisedHess(), h_multi[i].GetQuantisedHess());
     }
   }
@@ -520,7 +551,25 @@ TEST_P(HistogramExternalMemoryTest, ExternalMemory) {
   std::apply(&HistogramExternalMemoryTest::Run, std::tuple_cat(std::make_tuple(this), GetParam()));
 }
 
-INSTANTIATE_TEST_SUITE_P(Histogram, HistogramExternalMemoryTest,
-                         ::testing::Combine(::testing::Values(0.0f, 0.2f, 0.8f),
-                                            ::testing::Bool()));
+INSTANTIATE_TEST_SUITE_P(
+    Histogram, HistogramExternalMemoryTest,
+    ::testing::Combine(::testing::Values(0.0f, 0.2f, 0.8f), ::testing::Bool(),
+                       ::testing::Values(kNoCache, kDirect, kCopy)),
+    [](::testing::TestParamInfo<HistogramExternalMemoryTest::ParamType> const& info) {
+      std::stringstream ss;
+      auto const& p = info.param;
+      ss << "sparsity_0" << (std::get<0>(p) * 10) << "_global_" << std::get<1>(p) << "_dcache_";
+      switch (std::get<2>(p)) {
+        case kNoCache:
+          ss << "nocache";
+          break;
+        case kDirect:
+          ss << "direct";
+          break;
+        case kCopy:
+          ss << "copy";
+          break;
+      }
+      return ss.str();
+    });
 }  // namespace xgboost::tree

--- a/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
+++ b/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
@@ -119,6 +119,19 @@ void GetSplit(RegTree* tree, float split_value, std::vector<GPUExpandEntry>* can
   candidates->front().split.findex = 0;
 }
 
+namespace {
+template <typename Accessor>
+struct LessThanOp {
+  Accessor acc;
+  explicit LessThanOp(Accessor acc) : acc{acc} {}
+  __device__ bool operator()(bst_idx_t ridx, std::int32_t nidx_in_batch,
+                             RegTree::Node const& node) const {
+    auto fvalue = acc.GetFvalue(ridx, node.SplitIndex());
+    return fvalue <= node.SplitCond();
+  }
+};
+}  // namespace
+
 void TestExternalMemory() {
   auto ctx = MakeCUDACtx(0);
 
@@ -149,13 +162,9 @@ void TestExternalMemory() {
     partitioners.emplace_back(std::make_unique<RowPartitioner>());
     partitioners.back()->Reset(&ctx, page.Size(), page.BaseRowId());
     std::vector<RegTree::Node> splits{tree[0]};
-    auto acc = page.Impl()->GetDeviceAccessor(&ctx);
-    partitioners.back()->UpdatePositionBatch(
-        &ctx, {0}, {1}, {2}, splits,
-        [=] __device__(bst_idx_t ridx, std::int32_t nidx_in_batch, RegTree::Node const& node) {
-          auto fvalue = acc.GetFvalue(ridx, node.SplitIndex());
-          return fvalue <= node.SplitCond();
-        });
+    page.Impl()->Visit(&ctx, {}, [&](auto&& acc) {
+      partitioners.back()->UpdatePositionBatch(&ctx, {0}, {1}, {2}, splits, LessThanOp{acc});
+    });
     partitioners.back()->FinalisePosition(
         &ctx, dh::ToSpan(position).subspan(page.BaseRowId(), page.Size()), page.BaseRowId(),
         encode_op);

--- a/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
+++ b/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024, XGBoost Contributors
+ * Copyright 2019-2025, XGBoost Contributors
  */
 #include <gtest/gtest.h>
 #include <thrust/device_vector.h>


### PR DESCRIPTION
This helps us to have the external memory cache in two different places.

- Make the accessor a variant type.
- Most of the changes are for calling a visit function instead of actual code changes.

todos:
- [x] Test the new iterator.
- [x] Test for external memory.
- [x] Alignment.
- [x] Profiling.