### PR TITLE
Fix VM fallback logic on WSL2

### DIFF
--- a/src/common/cuda_dr_utils.cc
+++ b/src/common/cuda_dr_utils.cc
@@ -154,7 +154,8 @@ void MakeCuMemLocation(CUmemLocationType type, CUmemLocation *loc) {
   // Use the first GPU
   auto smi_ver = Split(TrimFirst(smi_split[1]), '.');
   // 570.124.06
-  if (smi_ver.size() != 3) {
+  // On WSL2, you can have driver version with two components, e.g. 573.24
+  if (smi_ver.size() != 2 && smi_ver.size() != 3) {
     return Invalid();
   }
   try {


### PR DESCRIPTION
On WSL2, `nvidia-smi` returns a driver version of form `573.24`, with two components instead of three.

I tested this change on my work laptop (Dell Precision 5480, NVIDIA RTX A1000 6GB Laptop GPU, Windows 11 with WSL2).











































