### PR TITLE
Small cleanup to the logger.

### DIFF
--- a/include/xgboost/logging.h
+++ b/include/xgboost/logging.h
@@ -54,7 +54,6 @@ class ConsoleLogger : public BaseLogger {
   static void Configure(Args const& args);
 
   static LogVerbosity GlobalVerbosity();
-  static LogVerbosity DefaultVerbosity();
   static bool ShouldLog(LogVerbosity verbosity);
 
   ConsoleLogger() = delete;

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -49,10 +49,6 @@ void ConsoleLogger::Configure(Args const& args) {
   param.UpdateAllowUnknown(args);
 }
 
-ConsoleLogger::LogVerbosity ConsoleLogger::DefaultVerbosity() {
-  return LogVerbosity::kWarning;
-}
-
 ConsoleLogger::LogVerbosity ConsoleLogger::GlobalVerbosity() {
   LogVerbosity global_verbosity { LogVerbosity::kWarning };
   switch (GlobalConfigThreadLocalStore::Get()->verbosity) {

--- a/tests/cpp/test_global_config.cc
+++ b/tests/cpp/test_global_config.cc
@@ -16,7 +16,6 @@ TEST(GlobalConfiguration, Verbosity) {
   FromJson(config, &global_config);
   // Now verbosity should be updated
   EXPECT_EQ(ConsoleLogger::GlobalVerbosity(), ConsoleLogger::LogVerbosity::kSilent);
-  EXPECT_NE(ConsoleLogger::LogVerbosity::kSilent, ConsoleLogger::DefaultVerbosity());
   // GetConfig() should also return updated verbosity
   Json current_config{ToJson(*GlobalConfigThreadLocalStore::Get())};
   EXPECT_EQ(get<String>(current_config["verbosity"]), "0");


### PR DESCRIPTION
Remove the default verbosity method.