### PR TITLE
Update install doc for Conda

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -104,25 +104,25 @@ Conda should be able to detect the existence of a GPU on your machine and instal
 
 .. code-block:: bash
 
-   # CPU only
-   conda install -c conda-forge py-xgboost-cpu
-   # Use NVIDIA GPU
-   conda install -c conda-forge py-xgboost-gpu
+   # CPU variant
+   conda install -c conda-forge py-xgboost=*=cpu*
+   # GPU variant
+   conda install -c conda-forge py-xgboost=*=cuda*
 
 To force the installation of the GPU variant on a machine that does not have an NVIDIA GPU, use environment variable ``CONDA_OVERRIDE_CUDA``,
 as described in `"Managing Virtual Packages" in the conda docs <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html>`_.
 
 .. code-block:: bash
 
-  export CONDA_OVERRIDE_CUDA="12.5"
-  conda install -c conda-forge py-xgboost-gpu
+  export CONDA_OVERRIDE_CUDA="12.8"
+  conda install -c conda-forge py-xgboost=*=cuda*
 
 Visit the `Miniconda website <https://docs.conda.io/en/latest/miniconda.html>`_ to obtain Conda.
 
-.. note:: ``py-xgboost-gpu`` not available on Windows.
+.. note:: The GPU variant not available on Windows.
 
-   The ``py-xgboost-gpu`` is currently not available on Windows. If you are using Windows,
-   please use ``pip`` to install XGBoost with GPU support.
+   The GPU variant (``py-xgboost=*=cuda*``) is currently not available on Windows.
+   If you are using Windows, please use ``pip`` to install XGBoost with GPU support.
 
 R
 -

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -119,11 +119,6 @@ as described in `"Managing Virtual Packages" in the conda docs <https://conda.io
 
 Visit the `Miniconda website <https://docs.conda.io/en/latest/miniconda.html>`_ to obtain Conda.
 
-.. note:: The GPU variant not available on Windows.
-
-   The GPU variant (``py-xgboost=*=cuda*``) is currently not available on Windows.
-   If you are using Windows, please use ``pip`` to install XGBoost with GPU support.
-
 R
 -
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -117,7 +117,7 @@ as described in `"Managing Virtual Packages" in the conda docs <https://conda.io
   export CONDA_OVERRIDE_CUDA="12.8"
   conda install -c conda-forge py-xgboost=*=cuda*
 
-Visit the `Miniconda website <https://docs.conda.io/en/latest/miniconda.html>`_ to obtain Conda.
+You can install Conda from the following link: `Download the conda-forge Installer <https://conda-forge.org/download/>`_.
 
 R
 -


### PR DESCRIPTION
* There is no longer Conda package called `py-xgboost-gpu`. Use variants instead, e.g. `py-xgboost=*=cuda*`.
* The GPU variant is now available on Windows. I just tested it on my Windows workstation.
* Recommend Miniforge instead of Miniconda.

Preview: https://xgboost--11483.org.readthedocs.build/en/11483/install.html#conda

@trivialfis Unfortunately, this isn't part of the 3.0.2 tag, so the `stable` doc on RTD won't display the updated Conda installation method. I'm inclined to create a new tag `3.0.2-post0` so that the RTD shows the updated install doc. What do you think?