### PR TITLE
adds explicit <=> operators to IndexTransformIter

### DIFF
--- a/src/common/transform_iterator.h
+++ b/src/common/transform_iterator.h
@@ -52,6 +52,10 @@ class IndexTransformIter {
   auto operator-(IndexTransformIter const &that) const { return iter_ - that.iter_; }
   bool operator==(IndexTransformIter const &that) const { return iter_ == that.iter_; }
   bool operator!=(IndexTransformIter const &that) const { return !(*this == that); }
+  bool operator<(IndexTransformIter const &that) const { return iter_ < that.iter_; }
+  bool operator>(IndexTransformIter const &that) const { return that < *this; }
+  bool operator<=(IndexTransformIter const &that) const { return !(that < *this); }
+  bool operator>=(IndexTransformIter const &that) const { return !(*this < that); }
 
   IndexTransformIter &operator++() {
     iter_++;


### PR DESCRIPTION
Adds `<`, `>`, `<=`, `>=` operators to `IndexTransformIter`

This fixes an issue when compiling `xgboost` with `-D_GLIBCXX_DEBUG`.

I use the newer standard library:
```bash
$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/15.1.0/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: ../gcc-15-source/configure --enable-languages=c,c++ --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/issues --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 15.1.0 (GCC)

```

Compilation error:

```
In file included from /usr/include/c++/15.1.0/debug/stl_iterator.h:32,
                 from /usr/include/c++/15.1.0/bits/stl_iterator.h:3117,
                 from /usr/include/c++/15.1.0/bits/stl_algobase.h:67,
                 from /usr/include/c++/15.1.0/bits/stl_tree.h:65,
                 from /usr/include/c++/15.1.0/map:64,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/dmlc-core/include/dmlc/registry.h:9,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/objective/regression_obj.cc:7:
/usr/include/c++/15.1.0/debug/helper_functions.h: In instantiation of ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::random_access_iterator_tag) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >]’:
/usr/include/c++/15.1.0/debug/helper_functions.h:201:44:   required from ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::__false_type) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >]’
  201 |       return __gnu_debug::__valid_range_aux(__first, __last,
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  202 |                                             std::__iterator_category(__first));
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:271:44:   required from ‘constexpr bool __gnu_debug::__valid_range(_InputIterator, _InputIterator) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >]’
  271 |       return __gnu_debug::__valid_range_aux(__first, __last, _Integral());
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/stl_algo.h:4262:7:   required from ‘_OIter std::transform(_IIter, _IIter, _OIter, _UnaryOperation) [with _IIter = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >; _OIter = xgboost::common::IndexTransformIter<xgboost::linalg::begin<float, 1>(TensorView<float, 1>&)::<lambda(size_t)> >; _UnaryOperation = xgboost::obj::MeanAbsoluteError::InitEstimation(const xgboost::MetaInfo&, xgboost::linalg::Tensor<float, 1>*) const::<lambda(float)>]’
 4262 |       __glibcxx_requires_valid_range(__first, __last);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/src/objective/regression_obj.cu:685:19:   required from here
  685 |     std::transform(linalg::cbegin(out), linalg::cend(out), linalg::begin(out),
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  686 |                    [w](float v) { return v * w; });
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: error: no match for ‘operator<=’ (operand types are ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >’ and ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >’)
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note: there is 1 candidate
In file included from /home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/string_view.h:7,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/objective/../common/threading_utils.h:20,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/objective/../common/linalg_op.h:10,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/objective/regression_obj.cu:16,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/objective/regression_obj.cc:17:
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: candidate 1: ‘template<class T, long unsigned int X, class U, long unsigned int Y> constexpr bool xgboost::common::operator<=(Span<T, Extent>, Span<U, Y>)’
  645 | XGBOOST_DEVICE constexpr bool operator<=(Span<T, X> l, Span<U, Y> r) {
      |                               ^~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: template argument deduction/substitution failed:
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note:   ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >’ is not derived from ‘xgboost::common::Span<T, Extent>’
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h: In instantiation of ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::random_access_iterator_tag) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const float, 2>(const TensorView<const float, 2>&)::<lambda(size_t)> >]’:
/usr/include/c++/15.1.0/debug/helper_functions.h:201:44:   required from ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::__false_type) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const float, 2>(const TensorView<const float, 2>&)::<lambda(size_t)> >]’
  201 |       return __gnu_debug::__valid_range_aux(__first, __last,
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  202 |                                             std::__iterator_category(__first));
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:271:44:   required from ‘constexpr bool __gnu_debug::__valid_range(_InputIterator, _InputIterator) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const float, 2>(const TensorView<const float, 2>&)::<lambda(size_t)> >]’
  271 |       return __gnu_debug::__valid_range_aux(__first, __last, _Integral());
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/stl_algo.h:472:7:   required from ‘_IIter std::find_if_not(_IIter, _IIter, _Predicate) [with _IIter = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const float, 2>(const TensorView<const float, 2>&)::<lambda(size_t)> >; _Predicate = xgboost::obj::RegLossObj<xgboost::obj::GammaDeviance>::ValidateLabel(const xgboost::MetaInfo&)::<lambda()>::<lambda(float)>]’
  472 |       __glibcxx_requires_valid_range(__first, __last);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/stl_algo.h:413:40:   required from ‘bool std::all_of(_IIter, _IIter, _Predicate) [with _IIter = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const float, 2>(const TensorView<const float, 2>&)::<lambda(size_t)> >; _Predicate = xgboost::obj::RegLossObj<xgboost::obj::GammaDeviance>::ValidateLabel(const xgboost::MetaInfo&)::<lambda()>::<lambda(float)>]’
  413 |     { return __last == std::find_if_not(__first, __last, __pred); }
      |                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/src/objective/regression_obj.cu:74:29:   required from ‘void xgboost::obj::RegLossObj<Loss>::ValidateLabel(const xgboost::MetaInfo&) [with Loss = xgboost::obj::GammaDeviance]’
   74 |           return std::all_of(linalg::cbegin(label), linalg::cend(label),
      |                  ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   75 |                              [](float y) -> bool { return Loss::CheckLabel(y); });
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/src/objective/regression_obj.cu:122:7:   required from ‘void xgboost::obj::RegLossObj<Loss>::GetGradient(const xgboost::HostDeviceVector<float>&, const xgboost::MetaInfo&, int32_t, xgboost::linalg::Matrix<xgboost::detail::GradientPairInternal<float> >*) [with Loss = xgboost::obj::GammaDeviance; int32_t = int; xgboost::linalg::Matrix<xgboost::detail::GradientPairInternal<float> > = xgboost::linalg::Tensor<xgboost::detail::GradientPairInternal<float>, 2>]’
  122 |       ValidateLabel(info);
      |       ^~~~~~~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/src/objective/regression_obj.cu:118:8:   required from here
  118 |   void GetGradient(const HostDeviceVector<bst_float>& preds, const MetaInfo& info,
      |        ^~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: error: no match for ‘operator<=’ (operand types are ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const float, 2>(const TensorView<const float, 2>&)::<lambda(size_t)> >’ and ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const float, 2>(const TensorView<const float, 2>&)::<lambda(size_t)> >’)
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note: there is 1 candidate
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: candidate 1: ‘template<class T, long unsigned int X, class U, long unsigned int Y> constexpr bool xgboost::common::operator<=(Span<T, Extent>, Span<U, Y>)’
  645 | XGBOOST_DEVICE constexpr bool operator<=(Span<T, X> l, Span<U, Y> r) {
      |                               ^~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: template argument deduction/substitution failed:
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note:   ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const float, 2>(const TensorView<const float, 2>&)::<lambda(size_t)> >’ is not derived from ‘xgboost::common::Span<T, Extent>’
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
make[3]: *** [third_party/xgboost/src/CMakeFiles/objxgboost.dir/build.make:1196: third_party/xgboost/src/CMakeFiles/objxgboost.dir/objective/regression_obj.cc.o] Error 1
make[3]: *** Waiting for unfinished jobs....
In file included from /usr/include/c++/15.1.0/debug/stl_iterator.h:32,
                 from /usr/include/c++/15.1.0/bits/stl_iterator.h:3117,
                 from /usr/include/c++/15.1.0/bits/stl_algobase.h:67,
                 from /usr/include/c++/15.1.0/bits/stl_uninitialized.h:63,
                 from /usr/include/c++/15.1.0/memory:71,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/metric/rank_metric.h:6,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/metric/rank_metric.cc:4:
/usr/include/c++/15.1.0/debug/helper_functions.h: In instantiation of ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::random_access_iterator_tag) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<double, 1>(const TensorView<double, 1>&)::<lambda(size_t)> >]’:
/usr/include/c++/15.1.0/debug/helper_functions.h:201:44:   required from ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::__false_type) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<double, 1>(const TensorView<double, 1>&)::<lambda(size_t)> >]’
  201 |       return __gnu_debug::__valid_range_aux(__first, __last,
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  202 |                                             std::__iterator_category(__first));
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:271:44:   required from ‘constexpr bool __gnu_debug::__valid_range(_InputIterator, _InputIterator) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<double, 1>(const TensorView<double, 1>&)::<lambda(size_t)> >]’
  271 |       return __gnu_debug::__valid_range_aux(__first, __last, _Integral());
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/stl_numeric.h:138:7:   required from ‘_Tp std::accumulate(_InputIterator, _InputIterator, _Tp) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<double, 1>(const TensorView<double, 1>&)::<lambda(size_t)> >; _Tp = double]’
  138 |       __glibcxx_requires_valid_range(__first, __last);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/src/metric/rank_metric.cc:417:32:   required from here
  417 |     auto ndcg = std::accumulate(linalg::cbegin(ndcg_gloc), linalg::cend(ndcg_gloc), 0.0);
      |                 ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: error: no match for ‘operator<=’ (operand types are ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<double, 1>(const TensorView<double, 1>&)::<lambda(size_t)> >’ and ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<double, 1>(const TensorView<double, 1>&)::<lambda(size_t)> >’)
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note: there is 1 candidate
In file included from /home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/string_view.h:7,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/metric/../common/error_msg.h:16,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/metric/../common/ranking_utils.h:15,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/metric/rank_metric.h:9:
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: candidate 1: ‘template<class T, long unsigned int X, class U, long unsigned int Y> constexpr bool xgboost::common::operator<=(Span<T, Extent>, Span<U, Y>)’
  645 | XGBOOST_DEVICE constexpr bool operator<=(Span<T, X> l, Span<U, Y> r) {
      |                               ^~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: template argument deduction/substitution failed:
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note:   ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<double, 1>(const TensorView<double, 1>&)::<lambda(size_t)> >’ is not derived from ‘xgboost::common::Span<T, Extent>’
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
make[3]: *** [third_party/xgboost/src/CMakeFiles/objxgboost.dir/build.make:1056: third_party/xgboost/src/CMakeFiles/objxgboost.dir/metric/rank_metric.cc.o] Error 1
In file included from /usr/include/c++/15.1.0/debug/stl_iterator.h:32,
                 from /usr/include/c++/15.1.0/bits/stl_iterator.h:3117,
                 from /usr/include/c++/15.1.0/bits/stl_algobase.h:67,
                 from /usr/include/c++/15.1.0/algorithm:62,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/hist/histogram.h:7,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/hist/histogram.cc:4:
/usr/include/c++/15.1.0/debug/helper_functions.h: In instantiation of ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::random_access_iterator_tag) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:17)> >]’:
/usr/include/c++/15.1.0/debug/helper_functions.h:201:44:   required from ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::__false_type) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:17)> >]’
  201 |       return __gnu_debug::__valid_range_aux(__first, __last,
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  202 |                                             std::__iterator_category(__first));
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:271:44:   required from ‘constexpr bool __gnu_debug::__valid_range(_InputIterator, _InputIterator) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:17)> >]’
  271 |       return __gnu_debug::__valid_range_aux(__first, __last, _Integral());
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/stl_numeric.h:138:7:   required from ‘_Tp std::accumulate(_InputIterator, _InputIterator, _Tp) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:17)> >; _Tp = double]’
  138 |       __glibcxx_requires_valid_range(__first, __last);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/src/tree/hist/histogram.cc:31:36:   required from here
   31 |     auto left_sum = std::accumulate(lit, lit + c.split.left_sum.size(), .0);
      |                     ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: error: no match for ‘operator<=’ (operand types are ‘xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:17)> >’ and ‘xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:17)> >’)
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note: there is 1 candidate
In file included from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/hist/../../collective/../common/type.h:8,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/hist/../../collective/allreduce.h:10,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/hist/histogram.h:13:
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: candidate 1: ‘template<class T, long unsigned int X, class U, long unsigned int Y> constexpr bool xgboost::common::operator<=(Span<T, Extent>, Span<U, Y>)’
  645 | XGBOOST_DEVICE constexpr bool operator<=(Span<T, X> l, Span<U, Y> r) {
      |                               ^~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: template argument deduction/substitution failed:
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note:   ‘xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:17)> >’ is not derived from ‘xgboost::common::Span<T, Extent>’
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h: In instantiation of ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::random_access_iterator_tag) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:18)> >]’:
/usr/include/c++/15.1.0/debug/helper_functions.h:201:44:   required from ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::__false_type) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:18)> >]’
  201 |       return __gnu_debug::__valid_range_aux(__first, __last,
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  202 |                                             std::__iterator_category(__first));
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:271:44:   required from ‘constexpr bool __gnu_debug::__valid_range(_InputIterator, _InputIterator) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:18)> >]’
  271 |       return __gnu_debug::__valid_range_aux(__first, __last, _Integral());
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/stl_numeric.h:138:7:   required from ‘_Tp std::accumulate(_InputIterator, _InputIterator, _Tp) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:18)> >; _Tp = double]’
  138 |       __glibcxx_requires_valid_range(__first, __last);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/src/tree/hist/histogram.cc:34:37:   required from here
   34 |     auto right_sum = std::accumulate(rit, rit + c.split.right_sum.size(), .0);
      |                      ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: error: no match for ‘operator<=’ (operand types are ‘xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:18)> >’ and ‘xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:18)> >’)
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note: there is 1 candidate
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: candidate 1: ‘template<class T, long unsigned int X, class U, long unsigned int Y> constexpr bool xgboost::common::operator<=(Span<T, Extent>, Span<U, Y>)’
  645 | XGBOOST_DEVICE constexpr bool operator<=(Span<T, X> l, Span<U, Y> r) {
      |                               ^~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: template argument deduction/substitution failed:
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note:   ‘xgboost::common::IndexTransformIter<xgboost::tree::AssignNodes(const xgboost::RegTree*, const std::__debug::vector<MultiExpandEntry>&, xgboost::common::Span<int>, xgboost::common::Span<int>)::<lambda(auto:18)> >’ is not derived from ‘xgboost::common::Span<T, Extent>’
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
make[3]: *** [third_party/xgboost/src/CMakeFiles/objxgboost.dir/build.make:1280: third_party/xgboost/src/CMakeFiles/objxgboost.dir/tree/hist/histogram.cc.o] Error 1
In file included from /usr/include/c++/15.1.0/debug/stl_iterator.h:32,
                 from /usr/include/c++/15.1.0/bits/stl_iterator.h:3117,
                 from /usr/include/c++/15.1.0/bits/stl_algobase.h:67,
                 from /usr/include/c++/15.1.0/algorithm:62,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/updater_approx.cc:6:
/usr/include/c++/15.1.0/debug/helper_functions.h: In instantiation of ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::random_access_iterator_tag) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >]’:
/usr/include/c++/15.1.0/debug/helper_functions.h:201:44:   required from ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::__false_type) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >]’
  201 |       return __gnu_debug::__valid_range_aux(__first, __last,
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  202 |                                             std::__iterator_category(__first));
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:271:44:   required from ‘constexpr bool __gnu_debug::__valid_range(_InputIterator, _InputIterator) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >]’
  271 |       return __gnu_debug::__valid_range_aux(__first, __last, _Integral());
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/stl_algo.h:472:7:   required from ‘_IIter std::find_if_not(_IIter, _IIter, _Predicate) [with _IIter = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >; _Predicate = xgboost::tree::CommonRowPartitioner::LeafPartition(const xgboost::Context*, const xgboost::RegTree&, xgboost::linalg::TensorView<const xgboost::detail::GradientPairInternal<float>, 2>, xgboost::common::Span<int>) const::<lambda(size_t)>::<lambda(const xgboost::GradientPair&)>]’
  472 |       __glibcxx_requires_valid_range(__first, __last);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/stl_algo.h:413:40:   required from ‘bool std::all_of(_IIter, _IIter, _Predicate) [with _IIter = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >; _Predicate = xgboost::tree::CommonRowPartitioner::LeafPartition(const xgboost::Context*, const xgboost::RegTree&, xgboost::linalg::TensorView<const xgboost::detail::GradientPairInternal<float>, 2>, xgboost::common::Span<int>) const::<lambda(size_t)>::<lambda(const xgboost::GradientPair&)>]’
  413 |     { return __last == std::find_if_not(__first, __last, __pred); }
      |                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/src/tree/common_row_partitioner.h:326:31:   required from here
  326 |             return std::all_of(linalg::cbegin(sample), linalg::cend(sample),
      |                    ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  327 |                                [](GradientPair const& g) { return g.GetHess() - .0f == .0f; });
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: error: no match for ‘operator<=’ (operand types are ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >’ and ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >’)
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note: there is 1 candidate
In file included from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/../collective/../common/type.h:8,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/../collective/allreduce.h:10,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/../collective/aggregator.h:13,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/updater_approx.cc:13:
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: candidate 1: ‘template<class T, long unsigned int X, class U, long unsigned int Y> constexpr bool xgboost::common::operator<=(Span<T, Extent>, Span<U, Y>)’
  645 | XGBOOST_DEVICE constexpr bool operator<=(Span<T, X> l, Span<U, Y> r) {
      |                               ^~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: template argument deduction/substitution failed:
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note:   ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >’ is not derived from ‘xgboost::common::Span<T, Extent>’
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
make[3]: *** [third_party/xgboost/src/CMakeFiles/objxgboost.dir/build.make:1364: third_party/xgboost/src/CMakeFiles/objxgboost.dir/tree/updater_approx.cc.o] Error 1
In file included from /usr/include/c++/15.1.0/debug/stl_iterator.h:32,
                 from /usr/include/c++/15.1.0/bits/stl_iterator.h:3117,
                 from /usr/include/c++/15.1.0/bits/stl_algobase.h:67,
                 from /usr/include/c++/15.1.0/algorithm:62,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/updater_quantile_hist.cc:7:
/usr/include/c++/15.1.0/debug/helper_functions.h: In instantiation of ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::random_access_iterator_tag) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >]’:
/usr/include/c++/15.1.0/debug/helper_functions.h:201:44:   required from ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::__false_type) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >]’
  201 |       return __gnu_debug::__valid_range_aux(__first, __last,
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  202 |                                             std::__iterator_category(__first));
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:271:44:   required from ‘constexpr bool __gnu_debug::__valid_range(_InputIterator, _InputIterator) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >]’
  271 |       return __gnu_debug::__valid_range_aux(__first, __last, _Integral());
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/stl_algo.h:4262:7:   required from ‘_OIter std::transform(_IIter, _IIter, _OIter, _UnaryOperation) [with _IIter = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >; _OIter = xgboost::common::IndexTransformIter<xgboost::linalg::begin<float, 1>(TensorView<float, 1>&)::<lambda(size_t)> >; _UnaryOperation = xgboost::tree::MultiTargetHistBuilder::InitRoot(xgboost::DMatrix*, xgboost::linalg::MatrixView<const xgboost::detail::GradientPairInternal<float> >, xgboost::RegTree*)::<lambda(float)>]’
 4262 |       __glibcxx_requires_valid_range(__first, __last);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/src/tree/updater_quantile_hist.cc:209:19:   required from here
  209 |     std::transform(linalg::cbegin(weight_t), linalg::cend(weight_t), linalg::begin(weight_t),
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  210 |                    [&](float w) { return w * param_->learning_rate; });
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: error: no match for ‘operator<=’ (operand types are ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >’ and ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >’)
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note: there is 1 candidate
In file included from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/../collective/../common/type.h:8,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/../collective/allreduce.h:10,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/../collective/aggregator.h:13,
                 from /home/markdrozd/dev/my-project/third_party/xgboost/src/tree/updater_quantile_hist.cc:15:
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: candidate 1: ‘template<class T, long unsigned int X, class U, long unsigned int Y> constexpr bool xgboost::common::operator<=(Span<T, Extent>, Span<U, Y>)’
  645 | XGBOOST_DEVICE constexpr bool operator<=(Span<T, X> l, Span<U, Y> r) {
      |                               ^~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: template argument deduction/substitution failed:
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note:   ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<float, 1>(const TensorView<float, 1>&)::<lambda(size_t)> >’ is not derived from ‘xgboost::common::Span<T, Extent>’
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h: In instantiation of ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::random_access_iterator_tag) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >]’:
/usr/include/c++/15.1.0/debug/helper_functions.h:201:44:   required from ‘constexpr bool __gnu_debug::__valid_range_aux(_InputIterator, _InputIterator, std::__false_type) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >]’
  201 |       return __gnu_debug::__valid_range_aux(__first, __last,
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
  202 |                                             std::__iterator_category(__first));
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:271:44:   required from ‘constexpr bool __gnu_debug::__valid_range(_InputIterator, _InputIterator) [with _InputIterator = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >]’
  271 |       return __gnu_debug::__valid_range_aux(__first, __last, _Integral());
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/stl_algo.h:472:7:   required from ‘_IIter std::find_if_not(_IIter, _IIter, _Predicate) [with _IIter = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >; _Predicate = xgboost::tree::CommonRowPartitioner::LeafPartition(const xgboost::Context*, const xgboost::RegTree&, xgboost::linalg::TensorView<const xgboost::detail::GradientPairInternal<float>, 2>, xgboost::common::Span<int>) const::<lambda(size_t)>::<lambda(const xgboost::GradientPair&)>]’
  472 |       __glibcxx_requires_valid_range(__first, __last);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/bits/stl_algo.h:413:40:   required from ‘bool std::all_of(_IIter, _IIter, _Predicate) [with _IIter = xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >; _Predicate = xgboost::tree::CommonRowPartitioner::LeafPartition(const xgboost::Context*, const xgboost::RegTree&, xgboost::linalg::TensorView<const xgboost::detail::GradientPairInternal<float>, 2>, xgboost::common::Span<int>) const::<lambda(size_t)>::<lambda(const xgboost::GradientPair&)>]’
  413 |     { return __last == std::find_if_not(__first, __last, __pred); }
      |                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/src/tree/common_row_partitioner.h:326:31:   required from here
  326 |             return std::all_of(linalg::cbegin(sample), linalg::cend(sample),
      |                    ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  327 |                                [](GradientPair const& g) { return g.GetHess() - .0f == .0f; });
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: error: no match for ‘operator<=’ (operand types are ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >’ and ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >’)
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note: there is 1 candidate
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: candidate 1: ‘template<class T, long unsigned int X, class U, long unsigned int Y> constexpr bool xgboost::common::operator<=(Span<T, Extent>, Span<U, Y>)’
  645 | XGBOOST_DEVICE constexpr bool operator<=(Span<T, X> l, Span<U, Y> r) {
      |                               ^~~~~~~~
/home/markdrozd/dev/my-project/third_party/xgboost/include/xgboost/span.h:645:31: note: template argument deduction/substitution failed:
/usr/include/c++/15.1.0/debug/helper_functions.h:189:20: note:   ‘xgboost::common::IndexTransformIter<xgboost::linalg::cbegin<const xgboost::detail::GradientPairInternal<float>, 1>(const TensorView<const xgboost::detail::GradientPairInternal<float>, 1>&)::<lambda(size_t)> >’ is not derived from ‘xgboost::common::Span<T, Extent>’
  189 |         && __first <= __last;
      |            ~~~~~~~~^~~~~~~~~
make[3]: *** [third_party/xgboost/src/CMakeFiles/objxgboost.dir/build.make:1406: third_party/xgboost/src/CMakeFiles/objxgboost.dir/tree/updater_quantile_hist.cc.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:3606: third_party/xgboost/src/CMakeFiles/objxgboost.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:16821: test/CMakeFiles/run-astar.dir/rule] Error 2
make: *** [Makefile:5503: run-astar] Error 2
```

