### PR TITLE
Fix typos in CONTRIBUTORS.md: 'a open' -> 'an open' and 'Committers comes' -> 'Committers come'

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,8 +43,8 @@ Committers are people who have made substantial contribution to the project and 
 
 Become a Committer
 ------------------
-XGBoost is a open source project and we are actively looking for new committers who are willing to help maintaining and lead the project.
-Committers comes from contributors who:
+XGBoost is an open source project and we are actively looking for new committers who are willing to help maintaining and lead the project.
+Committers come from contributors who:
 * Made substantial contribution to the project.
 * Willing to spent time on maintaining and lead the project.
 


### PR DESCRIPTION
Fix typos in CONTRIBUTORS.md

- Fix article usage: "a open source project" -> "an open source project"
  The indefinite article "a" should be "an" before a word starting with a vowel sound.
- Fix subject-verb agreement: "Committers comes" -> "Committers come"
  The plural subject "Committers" requires the plural form of the verb.

These changes improve the grammatical correctness of the documentation.