### PR TITLE
Max relevance gain fix

### DIFF
--- a/src/common/ranking_utils.h
+++ b/src/common/ranking_utils.h
@@ -37,7 +37,7 @@ using position_t = std::uint32_t;  // NOLINT
  * \brief Maximum relevance degree for NDCG
  */
 constexpr std::size_t MaxRel() { return sizeof(rel_degree_t) * 8 - 1; }
-static_assert(MaxRel() == 31);
+static_assert(MaxRel() == 127);
 
 XGBOOST_DEVICE inline double CalcDCGGain(rel_degree_t label) {
   return static_cast<double>((1u << label) - 1);

--- a/src/common/ranking_utils.h
+++ b/src/common/ranking_utils.h
@@ -6,7 +6,7 @@
 #include <algorithm>                     // for min
 #include <cmath>                         // for log2, fabs, floor
 #include <cstddef>                       // for size_t
-#include <cstdint>                       // for uint32_t, uint8_t, int32_t
+#include <cstdint>                       // for uint64_t, uint8_t, int64_t
 #include <limits>                        // for numeric_limits
 #include <string>                        // for char_traits, string
 #include <vector>                        // for vector
@@ -27,17 +27,17 @@ namespace xgboost::ltr {
 /**
  * \brief Relevance degree
  */
-using rel_degree_t = std::uint32_t;  // NOLINT
+using rel_degree_t = std::uint64_t;  // NOLINT
 /**
  * \brief top-k position
  */
-using position_t = std::uint32_t;  // NOLINT
+using position_t = std::uint64_t;  // NOLINT
 
 /**
  * \brief Maximum relevance degree for NDCG
  */
-constexpr std::size_t MaxRel() { return sizeof(MaxRel()) * 8 - 1; }
-static_assert(MaxRel() == 127);
+constexpr std::size_t MaxRel() { return sizeof(rel_degree_t) * 8 - 1; }
+static_assert(MaxRel() == 63);
 
 XGBOOST_DEVICE inline double CalcDCGGain(rel_degree_t label) {
   return static_cast<double>((1u << label) - 1);
@@ -52,7 +52,7 @@ XGBOOST_DEVICE inline double CalcInvIDCG(double idcg) {
   return inv_idcg;
 }
 
-enum class PairMethod : std::int32_t {
+enum class PairMethod : std::int64_t {
   kTopK = 0,
   kMean = 1,
 };
@@ -63,7 +63,7 @@ DECLARE_FIELD_ENUM_CLASS(xgboost::ltr::PairMethod);
 namespace xgboost::ltr {
 struct LambdaRankParam : public XGBoostParameter<LambdaRankParam> {
  private:
-  static constexpr position_t DefaultK() { return 32; }
+  static constexpr position_t DefaultK() { return 64; }
   static constexpr position_t DefaultSamplePairs() { return 1; }
 
  protected:
@@ -228,7 +228,7 @@ class RankingCache {
     }
     // Hardcoded maximum size of positions to track. We don't need too many of them as the
     // bias decreases exponentially.
-    return std::min(max_group_size_, static_cast<std::size_t>(32));
+    return std::min(max_group_size_, static_cast<std::size_t>(64));
   }
   // Constructed as [1, n_samples] if group ptr is not supplied by the user
   common::Span<bst_group_t const> DataGroupPtr(Context const* ctx) const {

--- a/src/common/ranking_utils.h
+++ b/src/common/ranking_utils.h
@@ -36,7 +36,7 @@ using position_t = std::uint32_t;  // NOLINT
 /**
  * \brief Maximum relevance degree for NDCG
  */
-constexpr std::size_t MaxRel() { return sizeof(rel_degree_t) * 8 - 1; }
+constexpr std::size_t MaxRel() { return sizeof(MaxRel()) * 8 - 1; }
 static_assert(MaxRel() == 127);
 
 XGBOOST_DEVICE inline double CalcDCGGain(rel_degree_t label) {


### PR DESCRIPTION
Closes #11517 

Error reported by user of this library: 

`XGBoostError: [05:57:16] /Users/runner/work/xgboost/xgboost/src/common/ranking_utils.h:360: Check failed: label_is_valid: Relevance degress must be lesser than or equal to 31 when the exponential NDCG gain function is used. Set ndcg_exp_gain to false to use custom DCG gain.`

To fix this issue, the relevance degree has been increased from 31 to 63 and the integer size has been increased. 