### PR TITLE
Fix static linking C++ libraries on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,7 @@ if(JVM_BINDINGS)
   xgboost_target_defs(xgboost4j)
 endif()
 
-if(USE_OPENMP AND APPLE)
+if(USE_OPENMP AND APPLE AND NOT BUILD_STATIC_LIB)
   patch_openmp_path_macos(xgboost libxgboost)
 endif()
 


### PR DESCRIPTION
Currently, if OpenMP is enabled and you're on macOS, the `patch_openmp_path_macos(...)` helper function is called to adjust the RPATH in `libxgboost.dylib` to allow usage of other OpenMP libraries at install time, as described here: https://github.com/dmlc/xgboost/blob/68182c26503083a17bf06ecc530cf09c5d0dd942/cmake/FindOpenMPMacOS.cmake#L29-L35

Problem is, when you are compiling xgboost statically via `BUILD_STATIC_LIB=ON`, the expected `.dylib` file will not exist, and the call to `install_name_tool` will error.

This PR adds an extra check to where the call to `patch_openmp_path_macos(...)` is made to simply not do that if `BUILD_STATIC_LIB` is `ON`.  Note that I did _not_ apply this to the JVM-bindings version of the call, because xgboost doesn't support static builds for JVM bindings (guarded by this: https://github.com/dmlc/xgboost/blob/68182c26503083a17bf06ecc530cf09c5d0dd942/CMakeLists.txt#L169-L170).