### PR TITLE
Fixing a bug in the Spark fit-method when passing in None for certain parameters

### DIFF
--- a/python-package/xgboost/spark/core.py
+++ b/python-package/xgboost/spark/core.py
@@ -510,7 +510,7 @@ class _SparkXGBParams(
         )
 
     def _col_is_defined_not_empty(self, param: "Param[str]") -> bool:
-        return self.isDefined(param) and self.getOrDefault(param) != ""
+        return self.isDefined(param) and self.getOrDefault(param) not in (None, "")
 
 
 def _validate_and_convert_feature_col_as_float_col_list(


### PR DESCRIPTION
When working with the Spark Classifier class we are running into a small bug when trying to fit a model where we pass in `None` as the argument for `weight_col`. We worked around by passing in an empty string, but I figured I'd fix the issue here.

The issue is in  `_col_is_defined_not_empty` method in the python-package/xgboost/spark/core.py file.

When `weight_col = None`:
- `self.isDefined(param)` returns `True` (the parameter is set)
- `self.getOrDefault(param)` returns `None`
- `None != ""` evaluates to `True`

So the method incorrectly returns `True`, causing the code to try to select a column with name `None`

With this fix, the issue is resolved. 

Please let me know if you need anything else for me to do. I didn't add a test for this edge case because the overall method didn't have one either.