### PR TITLE
SYCL. Fallback to CPU in multiclass_obj for fp32 devices.

### DIFF
--- a/include/xgboost/context.h
+++ b/include/xgboost/context.h
@@ -206,6 +206,13 @@ struct Context : public XGBoostParameter<Context> {
    * @brief Get the current device and ordinal.
    */
   [[nodiscard]] DeviceOrd Device() const { return device_; }
+
+   /**
+   * @brief Get the current device and ordinal, if it supports fp64,
+            otherwise returns default CPU
+   */
+  [[nodiscard]] DeviceOrd DeviceFP64() const;
+
   /**
    * @brief Get the CUDA device ordinal. -1 if XGBoost is running on CPU.
    */

--- a/plugin/sycl/context_helper.cc
+++ b/plugin/sycl/context_helper.cc
@@ -1,0 +1,26 @@
+/*!
+ * Copyright 2017-2025 by Contributors
+ * \file context_helper.cc
+ */
+
+#include <sycl/sycl.hpp>
+
+
+#include "device_manager.h"
+#include "context_helper.h"
+
+namespace xgboost {
+namespace sycl {
+
+DeviceOrd DeviceFP64(const DeviceOrd& device) {
+  DeviceManager device_manager;
+  bool support_fp64 = device_manager.GetQueue(device)->get_device().has(::sycl::aspect::fp64);
+  if (support_fp64) {
+    return device;
+  } else {
+    LOG(WARNING) << "Current device doesn't support fp64";
+    return DeviceOrd::CPU();
+  }
+}
+}  // namespace sycl
+}  // namespace xgboost

--- a/plugin/sycl/context_helper.h
+++ b/plugin/sycl/context_helper.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2021-2025, XGBoost Contributors
+ * \file context_helper.h
+ */
+#ifndef PLUGIN_SYCL_CONTEXT_HELPER_H_
+#define PLUGIN_SYCL_CONTEXT_HELPER_H_
+
+#include <xgboost/context.h>
+
+namespace xgboost {
+namespace sycl {
+
+DeviceOrd DeviceFP64(const DeviceOrd& device);
+
+}  // namespace sycl
+}  // namespace xgboost
+#endif  // PLUGIN_SYCL_CONTEXT_HELPER_H_

--- a/src/context.cc
+++ b/src/context.cc
@@ -22,6 +22,10 @@
 
 #endif  // !defined(XGBOOST_USE_CUDA)
 
+#if defined(XGBOOST_USE_SYCL)
+#include "../plugin/sycl/context_helper.h"
+#endif  // defined (XGBOOST_USE_SYCL)
+
 namespace xgboost {
 
 DMLC_REGISTER_PARAMETER(Context);
@@ -280,6 +284,14 @@ std::int32_t Context::Threads() const {
     n_threads = std::min(n_threads, cfs_cpu_count_);
   }
   return n_threads;
+}
+
+DeviceOrd Context::DeviceFP64() const {
+  #if defined(XGBOOST_USE_SYCL)
+    return sycl::DeviceFP64(device_);
+  #else
+    return device_;
+  #endif  // defined(XGBOOST_USE_SYCL)
 }
 
 #if !defined(XGBOOST_USE_CUDA)

--- a/src/objective/multiclass_obj.cu
+++ b/src/objective/multiclass_obj.cu
@@ -56,7 +56,7 @@ class SoftmaxMultiClassObj : public ObjFunction {
     const int nclass = param_.num_class;
     const auto ndata = static_cast<int64_t>(preds.Size() / nclass);
 
-    auto device = ctx_->Device();
+    auto device = ctx_->DeviceFP64();
     out_gpair->SetDevice(device);
     info.labels.SetDevice(device);
     info.weights_.SetDevice(device);

--- a/tests/cpp/plugin/test_sycl_multiclass_obj.cc
+++ b/tests/cpp/plugin/test_sycl_multiclass_obj.cc
@@ -21,7 +21,7 @@ TEST(SyclObjective, SoftmaxMultiClassObjGPair) {
 TEST(SyclObjective, SoftmaxMultiClassBasic) {
   Context ctx;
   ctx.UpdateAllowUnknown(Args{{"device", "sycl"}});
-  TestSoftmaxMultiClassObjGPair(&ctx);
+  TestSoftmaxMultiClassBasic(&ctx);
 }
 
 TEST(SyclObjective, SoftprobMultiClassBasic) {


### PR DESCRIPTION
In continuation of https://github.com/dmlc/xgboost/pull/11292

This PR introduce a fallback to default CPU implementation for multiclass_obj, if the target sycl device, doesn't have fp64 support.