### PR TITLE
Adding `enable_categorical` to .apply method

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -1416,6 +1416,7 @@ class XGBModel(XGBModelBase):
                 missing=self.missing,
                 feature_types=self.feature_types,
                 nthread=self.n_jobs,
+                enable_categorical=self.enable_categorical
             )
             return self.get_booster().predict(
                 test_dmatrix, pred_leaf=True, iteration_range=iteration_range


### PR DESCRIPTION
Currently, `XGBModel` can be trained with `enable_categorical=True` when the input data fields have `categorical` type when appropriate. However, the `.apply` method will throw when trying to retrieve leaf values.



Example
```python
import xgboost as xgb
import numpy as np
import pandas as pd

model = xgb.XGBClassifier(enable_categorical = True)

arr = np.random.rand(5,5)

df = pd.DataFrame(arr)

df['test']= ['one', 'two','three', 'four', 'five']


df = df.convert_dtypes()

# convert string to categorical
df['test'] = df['test'].astype('category')

model.fit(df, [0,1,2,3,4]) # works


model.apply(df) # fails
```

Produces

```
Exception has occurred: ValueError
DataFrame.dtypes for data must be int, float, bool or category. When categorical type is supplied, the experimental DMatrix parameter`enable_categorical` must be set to `True`.  Invalid columns:test: category
KeyError: 'category'

During handling of the above exception, another exception occurred:

  File "/path/to/python/file/test.py", line 22, in <module>
    model.apply(df)
ValueError: DataFrame.dtypes for data must be int, float, bool or category. When categorical type is supplied, the experimental DMatrix parameter`enable_categorical` must be set to `True`.  Invalid columns:test: category
```