### PR TITLE
Remove cpp tests for deprecated binary model.

### DIFF
--- a/src/tree/updater_sync.cc
+++ b/src/tree/updater_sync.cc
@@ -1,17 +1,17 @@
 /**
- * Copyright 2014-2024, XBGoost Contributors
+ * Copyright 2014-2025, XBGoost Contributors
  * \file updater_sync.cc
  * \brief synchronize the tree in all distributed nodes
  */
-#include <xgboost/tree_updater.h>
-
 #include <string>
 #include <vector>
 
 #include "../collective/broadcast.h"
-#include "../collective/communicator-inl.h"
-#include "../common/io.h"
-#include "xgboost/json.h"
+#include "../collective/communicator-inl.h"  // for GetRank, GetWorldSize
+#include "xgboost/context.h"                 // for Context
+#include "xgboost/json.h"                    // for Json, Object
+#include "xgboost/linalg.h"                  // for Matrix
+#include "xgboost/tree_updater.h"            // for TreeUpdater
 
 namespace xgboost::tree {
 
@@ -29,25 +29,26 @@ class TreeSyncher : public TreeUpdater {
   void LoadConfig(Json const&) override {}
   void SaveConfig(Json*) const override {}
 
-  [[nodiscard]] char const* Name() const override { return "prune"; }
+  [[nodiscard]] char const* Name() const override { return "sync"; }
 
   void Update(TrainParam const*, linalg::Matrix<GradientPair>*, DMatrix*,
               common::Span<HostDeviceVector<bst_node_t>> /*out_position*/,
               const std::vector<RegTree*>& trees) override {
-    if (collective::GetWorldSize() == 1) return;
-    std::string s_model;
-    common::MemoryBufferStream fs(&s_model);
+    if (collective::GetWorldSize() == 1) {
+      return;
+    }
+    Json model{Object{}};
     int rank = collective::GetRank();
     if (rank == 0) {
       for (auto tree : trees) {
-        tree->Save(&fs);
+        tree->SaveModel(&model);
       }
     }
-    fs.Seek(0);
+    auto s_model = Json::Dump(model);
     auto rc = collective::Broadcast(ctx_, linalg::MakeVec(s_model.data(), s_model.size()), 0);
     SafeColl(rc);
     for (auto tree : trees) {
-      tree->Load(&fs);
+      tree->LoadModel(model);
     }
   }
 };

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2024, XGBoost contributors
+ * Copyright 2017-2025, XGBoost contributors
  */
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -281,38 +281,6 @@ TEST(Learner, MultiThreadedPredict) {
   for (auto &thread : threads) {
     thread.join();
   }
-}
-
-TEST(Learner, BinaryModelIO) {
-  size_t constexpr kRows = 8;
-  int32_t constexpr kIters = 4;
-  auto p_dmat = RandomDataGenerator{kRows, 10, 0}.GenerateDMatrix();
-  p_dmat->Info().labels.Reshape(kRows);
-
-  std::unique_ptr<Learner> learner{Learner::Create({p_dmat})};
-  learner->SetParam("eval_metric", "rmsle");
-  learner->Configure();
-  for (int32_t iter = 0; iter < kIters; ++iter) {
-    learner->UpdateOneIter(iter, p_dmat);
-  }
-  dmlc::TemporaryDirectory tempdir;
-  std::string const fname = tempdir.path + "binary_model_io.bin";
-  {
-    // Make sure the write is complete before loading.
-    std::unique_ptr<dmlc::Stream> fo(dmlc::Stream::Create(fname.c_str(), "w"));
-    learner->SaveModel(fo.get());
-  }
-
-  learner.reset(Learner::Create({p_dmat}));
-  std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(fname.c_str(), "r"));
-  learner->LoadModel(fi.get());
-  learner->Configure();
-  Json config { Object() };
-  learner->SaveConfig(&config);
-  std::string config_str;
-  Json::Dump(config, &config_str);
-  ASSERT_NE(config_str.find("rmsle"), std::string::npos);
-  ASSERT_EQ(config_str.find("WARNING"), std::string::npos);
 }
 
 #if defined(XGBOOST_USE_CUDA)

--- a/tests/cpp/tree/test_tree_model.cc
+++ b/tests/cpp/tree/test_tree_model.cc
@@ -16,20 +16,6 @@ TEST(Tree, ModelShape) {
   RegTree tree{1u, n_features};
   ASSERT_EQ(tree.NumFeatures(), n_features);
 
-  dmlc::TemporaryDirectory tempdir;
-  const std::string tmp_file = tempdir.path + "/tree.model";
-  {
-    // binary dump
-    std::unique_ptr<dmlc::Stream> fo(dmlc::Stream::Create(tmp_file.c_str(), "w"));
-    tree.Save(fo.get());
-  }
-  {
-    // binary load
-    RegTree new_tree;
-    std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(tmp_file.c_str(), "r"));
-    new_tree.Load(fi.get());
-    ASSERT_EQ(new_tree.NumFeatures(), n_features);
-  }
   {
     // json
     Json j_tree{Object{}};
@@ -55,88 +41,6 @@ TEST(Tree, ModelShape) {
     ASSERT_EQ(new_tree.NumFeatures(), n_features);
   }
 }
-
-#if DMLC_IO_NO_ENDIAN_SWAP  // skip on big-endian machines
-// Manually construct tree in binary format
-// Do not use structs in case they change
-// We want to preserve backwards compatibility
-TEST(Tree, Load) {
-  dmlc::TemporaryDirectory tempdir;
-  const std::string tmp_file = tempdir.path + "/tree.model";
-  std::unique_ptr<dmlc::Stream> fo(dmlc::Stream::Create(tmp_file.c_str(), "w"));
-
-  // Write params
-  EXPECT_EQ(sizeof(TreeParam), (31 + 6) * sizeof(int));
-  int num_roots = 1;
-  int num_nodes = 2;
-  int num_deleted = 0;
-  int max_depth = 1;
-  int num_feature = 0;
-  int size_leaf_vector = 0;
-  int reserved[31];
-  fo->Write(&num_roots, sizeof(int));
-  fo->Write(&num_nodes, sizeof(int));
-  fo->Write(&num_deleted, sizeof(int));
-  fo->Write(&max_depth, sizeof(int));
-  fo->Write(&num_feature, sizeof(int));
-  fo->Write(&size_leaf_vector, sizeof(int));
-  fo->Write(reserved, sizeof(int) * 31);
-
-  // Write 2 nodes
-  EXPECT_EQ(sizeof(RegTree::Node),
-            3 * sizeof(int) + 1 * sizeof(unsigned) + sizeof(float));
-  int parent = -1;
-  int cleft = 1;
-  int cright = -1;
-  unsigned sindex = 5;
-  float split_or_weight = 0.5;
-  fo->Write(&parent, sizeof(int));
-  fo->Write(&cleft, sizeof(int));
-  fo->Write(&cright, sizeof(int));
-  fo->Write(&sindex, sizeof(unsigned));
-  fo->Write(&split_or_weight, sizeof(float));
-  parent = 0;
-  cleft = -1;
-  cright = -1;
-  sindex = 2;
-  split_or_weight = 0.1;
-  fo->Write(&parent, sizeof(int));
-  fo->Write(&cleft, sizeof(int));
-  fo->Write(&cright, sizeof(int));
-  fo->Write(&sindex, sizeof(unsigned));
-  fo->Write(&split_or_weight, sizeof(float));
-
-  // Write 2x node stats
-  EXPECT_EQ(sizeof(RTreeNodeStat), 3 * sizeof(float) + sizeof(int));
-  bst_float loss_chg = 5.0;
-  bst_float sum_hess = 1.0;
-  bst_float base_weight = 3.0;
-  int leaf_child_cnt = 0;
-  fo->Write(&loss_chg, sizeof(float));
-  fo->Write(&sum_hess, sizeof(float));
-  fo->Write(&base_weight, sizeof(float));
-  fo->Write(&leaf_child_cnt, sizeof(int));
-
-  loss_chg = 50.0;
-  sum_hess = 10.0;
-  base_weight = 30.0;
-  leaf_child_cnt = 0;
-  fo->Write(&loss_chg, sizeof(float));
-  fo->Write(&sum_hess, sizeof(float));
-  fo->Write(&base_weight, sizeof(float));
-  fo->Write(&leaf_child_cnt, sizeof(int));
-  fo.reset();
-  std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(tmp_file.c_str(), "r"));
-
-  xgboost::RegTree tree;
-  tree.Load(fi.get());
-  EXPECT_EQ(tree.GetDepth(1), 1);
-  EXPECT_EQ(tree[0].SplitCond(), 0.5f);
-  EXPECT_EQ(tree[0].SplitIndex(), 5ul);
-  EXPECT_EQ(tree[1].LeafValue(), 0.1f);
-  EXPECT_TRUE(tree[1].IsLeaf());
-}
-#endif  // DMLC_IO_NO_ENDIAN_SWAP
 
 TEST(Tree, AllocateNode) {
   RegTree tree;


### PR DESCRIPTION
- Remove related CPP tests.
- Fix the sync updater.