### PR TITLE
Fix compilation of Xgboost on WoA

### DIFF
--- a/src/common/bitfield.h
+++ b/src/common/bitfield.h
@@ -272,7 +272,7 @@ inline std::uint32_t TrailingZeroBits(std::uint32_t value) {
   }
 #if defined(__GNUC__)
   return __builtin_ctz(value);
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && defined(_M_X64)
   return _tzcnt_u32(value);
 #else
   return detail::TrailingZeroBitsImpl(value);


### PR DESCRIPTION
PR Description:

- The PR fixes compilation of Xgboost library on WoA(Windows on ARM).
- Building xgboost from source on native WoA device fails while including bitfield.h header due to x64 based intrinsic function call _tzcnt_u32(v).
- The PR adds a macro to call _tzcnt_u32(v) only for x64 based MSVC-like compilers
- This leads to successful build of xgboost on WoA using MSVC toolchain.