### PR TITLE
[EM] More rigorous check for potential cross socket access.

### DIFF
--- a/src/common/cuda_dr_utils.cc
+++ b/src/common/cuda_dr_utils.cc
@@ -86,7 +86,7 @@ void CuDriverApi::ThrowIfError(CUresult status, StringView fn, std::int32_t line
 
 [[nodiscard]] CuDriverApi &GetGlobalCuDriverApi() {
   std::int32_t cu_major = -1, cu_minor = -1;
-  curt::DrVersion(&cu_major, &cu_minor);
+  GetDrVersionGlobal(&cu_major, &cu_minor);
 
   std::int32_t kdm_major = -1, kdm_minor = -1;
   if (!GetVersionFromSmiGlobal(&kdm_major, &kdm_minor)) {
@@ -182,6 +182,14 @@ void MakeCuMemLocation(CUmemLocationType type, CUmemLocation *loc) {
   *p_major = major;
   *p_minor = minor;
   return result;
+}
+
+void GetDrVersionGlobal(std::int32_t *p_major, std::int32_t *p_minor) {
+  static std::once_flag once;
+  static std::int32_t major{0}, minor{0};
+  std::call_once(once, [] { xgboost::curt::DrVersion(&major, &minor); });
+  *p_major = major;
+  *p_minor = minor;
 }
 
 namespace detail {

--- a/src/common/cuda_dr_utils.cc
+++ b/src/common/cuda_dr_utils.cc
@@ -86,7 +86,7 @@ void CuDriverApi::ThrowIfError(CUresult status, StringView fn, std::int32_t line
 
 [[nodiscard]] CuDriverApi &GetGlobalCuDriverApi() {
   std::int32_t cu_major = -1, cu_minor = -1;
-  GetDrVersionGlobal(&cu_major, &cu_minor);
+  curt::DrVersion(&cu_major, &cu_minor);
 
   std::int32_t kdm_major = -1, kdm_minor = -1;
   if (!GetVersionFromSmiGlobal(&kdm_major, &kdm_minor)) {
@@ -182,14 +182,6 @@ void MakeCuMemLocation(CUmemLocationType type, CUmemLocation *loc) {
   *p_major = major;
   *p_minor = minor;
   return result;
-}
-
-void GetDrVersionGlobal(std::int32_t *p_major, std::int32_t *p_minor) {
-  static std::once_flag once;
-  static std::int32_t major{0}, minor{0};
-  std::call_once(once, [] { xgboost::curt::DrVersion(&major, &minor); });
-  *p_major = major;
-  *p_minor = minor;
 }
 
 namespace detail {

--- a/src/common/cuda_dr_utils.cc
+++ b/src/common/cuda_dr_utils.cc
@@ -86,7 +86,7 @@ void CuDriverApi::ThrowIfError(CUresult status, StringView fn, std::int32_t line
 
 [[nodiscard]] CuDriverApi &GetGlobalCuDriverApi() {
   std::int32_t cu_major = -1, cu_minor = -1;
-  curt::DrVersion(&cu_major, &cu_minor);
+  curt::GetDrVersionGlobal(&cu_major, &cu_minor);
 
   std::int32_t kdm_major = -1, kdm_minor = -1;
   if (!GetVersionFromSmiGlobal(&kdm_major, &kdm_minor)) {

--- a/src/common/cuda_dr_utils.h
+++ b/src/common/cuda_dr_utils.h
@@ -131,6 +131,11 @@ void MakeCuMemLocation(CUmemLocationType type, CUmemLocation *loc);
  */
 [[nodiscard]] bool GetVersionFromSmiGlobal(std::int32_t *p_major, std::int32_t *p_minor);
 
+/**
+ * @brief Cache the result from @ref DrVersion in a global variable
+ */
+void GetDrVersionGlobal(std::int32_t *p_major, std::int32_t *p_minor);
+
 namespace detail {
 [[nodiscard]] std::int32_t GetC2cLinkCountFromSmiImpl(std::string const &smi_output);
 }  // namespace detail

--- a/src/common/cuda_dr_utils.h
+++ b/src/common/cuda_dr_utils.h
@@ -131,11 +131,6 @@ void MakeCuMemLocation(CUmemLocationType type, CUmemLocation *loc);
  */
 [[nodiscard]] bool GetVersionFromSmiGlobal(std::int32_t *p_major, std::int32_t *p_minor);
 
-/**
- * @brief Cache the result from @ref DrVersion in a global variable
- */
-void GetDrVersionGlobal(std::int32_t *p_major, std::int32_t *p_minor);
-
 namespace detail {
 [[nodiscard]] std::int32_t GetC2cLinkCountFromSmiImpl(std::string const &smi_output);
 }  // namespace detail

--- a/src/common/cuda_rt_utils.cc
+++ b/src/common/cuda_rt_utils.cc
@@ -95,12 +95,12 @@ void GetVersionImpl(Fn&& fn, std::int32_t* major, std::int32_t* minor) {
 }
 }  // namespace
 
-void RtVersion(std::int32_t* major, std::int32_t* minor) {
+void GetRtVersionGlobal(std::int32_t* major, std::int32_t* minor) {
   GetVersionImpl([](std::int32_t* ver) { dh::safe_cuda(cudaRuntimeGetVersion(ver)); }, major,
                  minor);
 }
 
-void DrVersion(std::int32_t* major, std::int32_t* minor) {
+void GetDrVersionGlobal(std::int32_t* major, std::int32_t* minor) {
   GetVersionImpl([](std::int32_t* ver) { dh::safe_cuda(cudaDriverGetVersion(ver)); }, major, minor);
 }
 

--- a/src/common/cuda_rt_utils.h
+++ b/src/common/cuda_rt_utils.h
@@ -30,10 +30,10 @@ void SetDevice(std::int32_t device);
 [[nodiscard]] std::size_t TotalMemory();
 
 // Returns the CUDA Runtime version.
-void RtVersion(std::int32_t* major, std::int32_t* minor);
+void GetRtVersionGlobal(std::int32_t* major, std::int32_t* minor);
 
 // Returns the latest version of CUDA supported by the driver.
-void DrVersion(std::int32_t* major, std::int32_t* minor);
+void GetDrVersionGlobal(std::int32_t* major, std::int32_t* minor);
 
 // Get the current device's numa ID.
 [[nodiscard]] std::int32_t GetNumaId();

--- a/src/common/device_compression.cu
+++ b/src/common/device_compression.cu
@@ -421,6 +421,7 @@ void DecompressSnappy(dh::CUDAStreamView stream, SnappyDecomprMgr const& mgr,
   }
   // copy from device buffer to the host cache.
   CHECK_EQ(n_total_bytes, in_buf.size());
+  CHECK(pool);
   auto c_page =
       common::MakeFixedVecWithPinnedMemPool<std::remove_reference_t<decltype(in_buf)>::value_type>(
           pool, n_total_act_bytes, stream);

--- a/src/common/device_helpers.cu
+++ b/src/common/device_helpers.cu
@@ -16,7 +16,7 @@ namespace {
 // Host NUMA allocation requires driver that supports CTK >= 12.5 to be stable
 [[nodiscard]] bool CheckVmAlloc() {
   std::int32_t major{0}, minor{0};
-  xgboost::curt::DrVersion(&major, &minor);
+  xgboost::curt::GetDrVersionGlobal(&major, &minor);
 
   bool vm_flag = true;
   if (IsSupportedDrVer(major, minor)) {

--- a/src/common/device_helpers.cu
+++ b/src/common/device_helpers.cu
@@ -16,7 +16,7 @@ namespace {
 // Host NUMA allocation requires driver that supports CTK >= 12.5 to be stable
 [[nodiscard]] bool CheckVmAlloc() {
   std::int32_t major{0}, minor{0};
-  xgboost::cudr::GetDrVersionGlobal(&major, &minor);
+  xgboost::curt::DrVersion(&major, &minor);
 
   bool vm_flag = true;
   if (IsSupportedDrVer(major, minor)) {

--- a/src/common/device_helpers.cu
+++ b/src/common/device_helpers.cu
@@ -16,7 +16,7 @@ namespace {
 // Host NUMA allocation requires driver that supports CTK >= 12.5 to be stable
 [[nodiscard]] bool CheckVmAlloc() {
   std::int32_t major{0}, minor{0};
-  xgboost::curt::DrVersion(&major, &minor);
+  xgboost::cudr::GetDrVersionGlobal(&major, &minor);
 
   bool vm_flag = true;
   if (IsSupportedDrVer(major, minor)) {

--- a/src/common/numa_topo.cc
+++ b/src/common/numa_topo.cc
@@ -9,9 +9,8 @@
 #include <sys/syscall.h>      // for SYS_get_mempolicy
 #include <unistd.h>           // for syscall
 
-
 #endif  // defined(__linux__)
-#include <sched.h>
+
 #include <cctype>      // for isalnum
 #include <cstddef>     // for size_t
 #include <cstdint>     // for int32_t

--- a/src/common/numa_topo.cc
+++ b/src/common/numa_topo.cc
@@ -9,8 +9,9 @@
 #include <sys/syscall.h>      // for SYS_get_mempolicy
 #include <unistd.h>           // for syscall
 
-#endif  // defined(__linux__)
 
+#endif  // defined(__linux__)
+#include <sched.h>
 #include <cctype>      // for isalnum
 #include <cstddef>     // for size_t
 #include <cstdint>     // for int32_t

--- a/src/common/numa_topo.cc
+++ b/src/common/numa_topo.cc
@@ -202,12 +202,12 @@ void GetNumaHasNormalMemoryNodes(std::vector<std::int32_t> *p_nodes) {
 
 void GetNumaHasCpuNodes(std::vector<std::int32_t> *p_nodes) {
 #if defined(__linux__)
-  fs::path has_nm{"/sys/devices/system/node/has_cpu"};
+  fs::path has_cpu{"/sys/devices/system/node/has_cpu"};
   p_nodes->clear();
-  if (!fs::exists(has_nm)) {
+  if (!fs::exists(has_cpu)) {
     return;
   }
-  ReadCpuList(has_nm, p_nodes);
+  ReadCpuList(has_cpu, p_nodes);
 #endif  // defined(__linux__)
 }
 

--- a/src/common/numa_topo.cc
+++ b/src/common/numa_topo.cc
@@ -188,4 +188,34 @@ void GetNumaNodeCpus(std::int32_t node_id, std::vector<std::int32_t> *p_cpus) {
 #endif  // defined(__linux__)
   return -1;
 }
+
+void GetNumaHasNormalMemoryNodes(std::vector<std::int32_t> *p_nodes) {
+#if defined(__linux__)
+  fs::path has_nm{"/sys/devices/system/node/has_normal_memory"};
+  p_nodes->clear();
+  if (!fs::exists(has_nm)) {
+    return;
+  }
+  ReadCpuList(has_nm, p_nodes);
+#endif  // defined(__linux__)
+}
+
+void GetNumaHasCpuNodes(std::vector<std::int32_t> *p_nodes) {
+#if defined(__linux__)
+  fs::path has_nm{"/sys/devices/system/node/has_cpu"};
+  p_nodes->clear();
+  if (!fs::exists(has_nm)) {
+    return;
+  }
+  ReadCpuList(has_nm, p_nodes);
+#endif  // defined(__linux__)
+}
+
+[[nodiscard]] bool GetCpuNuma(unsigned int* cpu, unsigned int* numa) {
+#ifdef SYS_getcpu
+  return syscall(SYS_getcpu, cpu, numa, NULL) == 0;
+#else
+  return false;
+#endif
+}
 }  // namespace xgboost::common

--- a/src/common/numa_topo.h
+++ b/src/common/numa_topo.h
@@ -57,7 +57,7 @@ void GetNumaNodeCpus(std::int32_t node_id, std::vector<std::int32_t> *p_cpus);
 void GetNumaHasNormalMemoryNodes(std::vector<std::int32_t> *p_nodes);
 
 /**
- * @brief Read the `has_normal_memory` system file.
+ * @brief Read the `has_cpu` system file.
  */
 void GetNumaHasCpuNodes(std::vector<std::int32_t> *p_nodes);
 

--- a/src/common/numa_topo.h
+++ b/src/common/numa_topo.h
@@ -50,4 +50,32 @@ void GetNumaNodeCpus(std::int32_t node_id, std::vector<std::int32_t> *p_cpus);
  * @return -1 if there's no NUMA node. Otherwise, returns the number of NUMA nodes.
  */
 [[nodiscard]] std::int32_t GetNumaNumNodes();
+
+/**
+ * @brief Read the `has_normal_memory` system file.
+ */
+void GetNumaHasNormalMemoryNodes(std::vector<std::int32_t> *p_nodes);
+
+/**
+ * @brief Read the `has_normal_memory` system file.
+ */
+void GetNumaHasCpuNodes(std::vector<std::int32_t> *p_nodes);
+
+/**
+ * @brief Get numa node on Linux. Other platforms are not supported. Returns false if the
+ *        call fails.
+ */
+[[nodiscard]] bool GetCpuNuma(unsigned int* cpu, unsigned int* numa);
+
+/**
+ * @brief Is it physically possible to access the wrong memory?
+ */
+[[nodiscard]] inline bool NumaMemCanCross() {
+  std::vector<std::int32_t> nodes;
+  GetNumaHasCpuNodes(&nodes);
+  bool result = nodes.size() > 1;
+  GetNumaHasNormalMemoryNodes(&nodes);
+  result &= nodes.size() > 1;
+  return result;
+}
 }  // namespace xgboost::common

--- a/src/common/threading_utils.cc
+++ b/src/common/threading_utils.cc
@@ -121,14 +121,6 @@ std::int32_t OmpGetNumThreads(std::int32_t n_threads) noexcept(true) {
   return n_threads;
 }
 
-[[nodiscard]] bool GetCpuNuma(unsigned int* cpu, unsigned int* numa) {
-#ifdef SYS_getcpu
-  return syscall(SYS_getcpu, cpu, numa, NULL) == 0;
-#else
-  return false;
-#endif
-}
-
 void NameThread(std::thread* t, StringView name) {
 #if defined(__linux__) && (!defined(__ANDROID__) || __ANDROID_API__ >= 26)
   auto handle = t->native_handle();

--- a/src/common/threading_utils.h
+++ b/src/common/threading_utils.h
@@ -320,12 +320,6 @@ class MemStackAllocator {
 std::int32_t constexpr DefaultMaxThreads() { return 128; }
 
 /**
- * @brief Get numa node on Linux. Other platforms are not supported. Returns false if the
- *        call fails.
- */
-[[nodiscard]] bool GetCpuNuma(unsigned int* cpu, unsigned int* numa);
-
-/**
  * @brief Give the thread a name. Supports only pthread on linux.
  */
 void NameThread(std::thread* t, StringView name);

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -53,7 +53,7 @@ EllpackMemCache::EllpackMemCache(EllpackCacheInfo cinfo, std::int32_t n_workers)
       pool{[] {
 #if defined(__linux__)
         std::int32_t major = -1, minor = -1;
-        curt::DrVersion(&major, &minor);
+        cudr::GetDrVersionGlobal(&major, &minor);
         if (major >= 12 && minor >= 5 || major > 12) {
           return std::make_shared<dc::HostPinnedMemPool>();
         }

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -604,11 +604,12 @@ ExtEllpackPageSourceImpl<EllpackMmapStreamPolicy<EllpackPage, EllpackFormatPolic
 
 namespace detail {
 void EllpackFormatCheckNuma(StringView msg) {
+#if defined(__linux__)
   bool can_cross = common::NumaMemCanCross();
   std::uint32_t numa = -1;
   auto incorrect = [&] {
     std::uint32_t cpu = -1;
-    return common::GetCpuNuma(&cpu, &numa) && numa != curt::GetNumaId();
+    return common::GetCpuNuma(&cpu, &numa) && static_cast<std::int32_t>(numa) != curt::GetNumaId();
   };
 
   if (can_cross && !common::GetNumaMemBind()) {
@@ -617,6 +618,9 @@ void EllpackFormatCheckNuma(StringView msg) {
     LOG(WARNING) << "Incorrect NUMA CPU bind, CPU node:" << numa
                  << ", GPU node:" << curt::GetNumaId() << "." << msg;
   }
+#else
+  (void)msg;
+#endif
 }
 }  // namespace detail
 }  // namespace xgboost::data

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -52,7 +52,12 @@ EllpackMemCache::EllpackMemCache(EllpackCacheInfo cinfo, std::int32_t n_workers)
       streams{std::make_unique<curt::StreamPool>(n_workers)},
       pool{[] {
 #if defined(__linux__)
-        return std::make_shared<dc::HostPinnedMemPool>();
+        std::int32_t major = -1, minor = -1;
+        cudr::GetDrVersionGlobal(&major, &minor);
+        if (major >= 12 && minor >= 5 || major > 12) {
+          return std::make_shared<dc::HostPinnedMemPool>();
+        }
+        return std::shared_ptr<dc::HostPinnedMemPool>{nullptr};
 #else
         return std::shared_ptr<dc::HostPinnedMemPool>{nullptr};
 #endif

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -53,7 +53,7 @@ EllpackMemCache::EllpackMemCache(EllpackCacheInfo cinfo, std::int32_t n_workers)
       pool{[] {
 #if defined(__linux__)
         std::int32_t major = -1, minor = -1;
-        curt::DrVersion(&major, &minor);
+        curt::GetDrVersionGlobal(&major, &minor);
         if (major >= 12 && minor >= 5 || major > 12) {
           return std::make_shared<dc::HostPinnedMemPool>();
         }

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -10,10 +10,11 @@
 
 #include "../common/common.h"                // for HumanMemUnit, safe_cuda
 #include "../common/cuda_dr_utils.h"         // for CUDA_HW_DECOM_AVAILABLE
-#include "../common/cuda_rt_utils.h"         // for SetDevice
+#include "../common/cuda_rt_utils.h"         // for SetDevice, GetDrVersionGlobal
 #include "../common/cuda_stream_pool.cuh"    // for StreamPool
 #include "../common/device_compression.cuh"  // for CompressSnappy, MakeSnappyDecomprMgr
 #include "../common/device_helpers.cuh"      // for CUDAStreamView, DefaultStream
+#include "../common/numa_topo.h"             // for NumaMemCanCross, GetNumaMemBind
 #include "../common/ref_resource_view.cuh"   // for MakeFixedVecWithCudaMalloc
 #include "../common/resource.cuh"            // for PrivateCudaMmapConstStream
 #include "../common/transform_iterator.h"    // for MakeIndexTransformIter

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -606,9 +606,9 @@ namespace detail {
 void EllpackFormatCheckNuma(StringView msg) {
 #if defined(__linux__)
   bool can_cross = common::NumaMemCanCross();
-  std::uint32_t numa = -1;
-  auto incorrect = [&] {
-    std::uint32_t cpu = -1;
+  std::uint32_t numa = 0;
+  auto incorrect = [&numa] {
+    std::uint32_t cpu = 0;
     return common::GetCpuNuma(&cpu, &numa) && static_cast<std::int32_t>(numa) != curt::GetNumaId();
   };
 

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -53,7 +53,7 @@ EllpackMemCache::EllpackMemCache(EllpackCacheInfo cinfo, std::int32_t n_workers)
       pool{[] {
 #if defined(__linux__)
         std::int32_t major = -1, minor = -1;
-        cudr::GetDrVersionGlobal(&major, &minor);
+        curt::DrVersion(&major, &minor);
         if (major >= 12 && minor >= 5 || major > 12) {
           return std::make_shared<dc::HostPinnedMemPool>();
         }

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -200,7 +200,7 @@ class EllpackFormatPolicy {
       LOG(WARNING) << "`use_rmm` is set to false." << msg;
     }
     std::int32_t major{0}, minor{0};
-    curt::DrVersion(&major, &minor);
+    curt::GetDrVersionGlobal(&major, &minor);
     if ((major < 12 || (major == 12 && minor < 7)) && curt::SupportsAts()) {
       // Use ATS, but with an old kernel driver.
       LOG(WARNING) << "Using an old kernel driver with supported CTK<12.7."

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -202,7 +202,7 @@ class EllpackFormatPolicy {
                    << "The latest version of CTK supported by the current driver: " << major << "."
                    << minor << "." << msg;
     }
-    if (common::GetNumaNumNodes() > 1 && !common::GetNumaMemBind()) {
+    if (common::NumaMemCanCross() && !common::GetNumaMemBind()) {
       LOG(WARNING) << "Running on a NUMA system without membind." << msg;
     }
   }

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -168,6 +168,11 @@ class EllpackHostCacheStream {
   [[nodiscard]] bool Write(EllpackPage const& page);
 };
 
+namespace detail {
+// Not a member of `EllpackFormatPolicy`. Hide the impl without requiring template specialization.
+void EllpackFormatCheckNuma(StringView msg);
+}  // namespace detail
+
 template <typename S>
 class EllpackFormatPolicy {
   std::shared_ptr<common::HistogramCuts const> cuts_{nullptr};
@@ -202,9 +207,7 @@ class EllpackFormatPolicy {
                    << "The latest version of CTK supported by the current driver: " << major << "."
                    << minor << "." << msg;
     }
-    if (common::NumaMemCanCross() && !common::GetNumaMemBind()) {
-      LOG(WARNING) << "Running on a NUMA system without membind." << msg;
-    }
+    detail::EllpackFormatCheckNuma(msg);
   }
   // For testing with the HMM flag.
   explicit EllpackFormatPolicy(bool has_hmm) : has_hmm_{has_hmm} {}

--- a/src/data/ellpack_page_source.h
+++ b/src/data/ellpack_page_source.h
@@ -16,7 +16,6 @@
 #include "../common/cuda_rt_utils.h"        // for SupportsPageableMem, SupportsAts
 #include "../common/device_compression.h"   // for SnappyDecomprMgr
 #include "../common/hist_util.h"            // for HistogramCuts
-#include "../common/numa_topo.h"            // for GetNumaNumNodes, GetNumaMemBind
 #include "../common/ref_resource_view.h"    // for RefResourceView
 #include "../data/batch_utils.h"            // for AutoHostRatio
 #include "ellpack_page.h"                   // for EllpackPage

--- a/tests/cpp/common/test_device_vector.cu
+++ b/tests/cpp/common/test_device_vector.cu
@@ -108,7 +108,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(TestVirtualMem, Version) {
   std::int32_t major, minor;
-  xgboost::curt::DrVersion(&major, &minor);
+  xgboost::curt::GetDrVersionGlobal(&major, &minor);
   LOG(INFO) << "Latest supported CUDA version by the driver:" << major << "." << minor;
   PinnedMemory pinned;
 #if defined(xgboost_IS_WIN)

--- a/tests/cpp/common/test_numa_topo.cc
+++ b/tests/cpp/common/test_numa_topo.cc
@@ -149,4 +149,24 @@ TEST(Numa, GetNumNodes) {
   ASSERT_EQ(n_nodes, -1);
 #endif  // defined(__linux__)
 }
+
+TEST(Numa, GetHasCpuNodes) {
+  std::vector<std::int32_t> nodes;
+  GetNumaHasCpuNodes(&nodes);
+#if defined(__linux__)
+  ASSERT_GE(nodes.size(), 1);
+#else
+  ASSERT_EQ(nodes.size(), 0);
+#endif  // defined(__linux__)
+}
+
+TEST(Numa, GetHasNormalMemoryNodes) {
+  std::vector<std::int32_t> nodes;
+  GetNumaHasNormalMemoryNodes(&nodes);
+#if defined(__linux__)
+  ASSERT_GE(nodes.size(), 1);
+#else
+  ASSERT_EQ(nodes.size(), 0);
+#endif  // defined(__linux__)
+}
 }  // namespace xgboost::common

--- a/tests/cpp/data/test_sparse_page_dmatrix.cc
+++ b/tests/cpp/data/test_sparse_page_dmatrix.cc
@@ -5,8 +5,9 @@
 #include <xgboost/data.h>
 #include <xgboost/host_device_vector.h>  // for HostDeviceVector
 
-#include <future>
-#include <thread>
+#include <filesystem>  // for path
+#include <future>      // for future, async
+#include <thread>      // for sleep_for
 
 #include "../../../src/common/io.h"
 #include "../../../src/data/batch_utils.h"  // for MatchingPageBytes


### PR DESCRIPTION
- Move the get cpu function.
- Use `has_normal_memory` and `has_cpu` to avoid false positives.
- Check invalid node bind.
- Workaround old CTK for the host cache.
- Cleanup version functions.