### PR TITLE
[CI] Disable spot pricing for GPU workers

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -25,9 +25,11 @@ runners:
   linux-amd64-gpu:
     family: ["g4dn.xlarge"]
     image: linux-amd64
+    spot: "false"
   linux-amd64-mgpu:
     family: ["g4dn.12xlarge"]
     image: linux-amd64
+    spot: "false"
   linux-arm64-cpu:
     cpu: 16
     family: ["c6g", "c7g"]
@@ -35,6 +37,7 @@ runners:
   windows-gpu:
     family: ["g4dn.2xlarge"]
     image: windows-amd64
+    spot: "false"
   windows-cpu:
     cpu: 32
     family: ["c7i-flex", "c7i", "c7a", "c5", "c5a"]


### PR DESCRIPTION
Ensure that the GPU workers don't get interrupted by always using the On-Demand instances. Previously, we were using Spot instances, which are cheaper but have a non-zero probability of interruption.