### PR TITLE
[jvm-packages] Fix Maven deployment for xgboost4j-spark-gpu

### DIFF
--- a/jvm-packages/xgboost4j-spark-gpu/pom.xml
+++ b/jvm-packages/xgboost4j-spark-gpu/pom.xml
@@ -9,7 +9,9 @@
         <version>3.1.0-SNAPSHOT</version>
     </parent>
     <name>xgboost4j-spark-gpu</name>
+    <groupId>ml.dmlc</groupId>
     <artifactId>xgboost4j-spark-gpu_2.12</artifactId>
+    <version>3.1.0-SNAPSHOT</version>
     <description>JVM Package for XGBoost</description>
     <url>https://github.com/dmlc/xgboost/tree/master/jvm-packages</url>
     <licenses>

--- a/ops/script/change_version.py
+++ b/ops/script/change_version.py
@@ -152,9 +152,9 @@ source tree.
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--major", type=int)
-    parser.add_argument("--minor", type=int)
-    parser.add_argument("--patch", type=int)
+    parser.add_argument("--major", type=int, required=True)
+    parser.add_argument("--minor", type=int, required=True)
+    parser.add_argument("--patch", type=int, required=True)
     parser.add_argument("--rc", type=int, default=0)
     parser.add_argument("--is-rc", action="store_true")
     parser.add_argument("--is-dev", action="store_true")


### PR DESCRIPTION
* Maven Central now rejects packages that is missing `groupId` or `version`, even those sub-packages whose parent packages already supply these info. So we need to supply `groupId` and `version` in `xgboost4j-spark-gpu/pom.xml`.
* Update `ops/script/change_version.py` so that it would raise an error if the user forgets to provide the version parameters.