### PR TITLE
[CI] [Don't merge] Test CI workflows with new VM from dmlc/xgboost-devops#39

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build docs for JVM packages
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=doc-build-jvm-docs
 
     steps:
@@ -49,7 +49,7 @@ jobs:
     name: Build docs for the R package
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=r-tests-build-docs
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks
@@ -84,7 +84,7 @@ jobs:
     name: Trigger Read The Docs build.
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=doc-trigger-rtd-build
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks

--- a/.github/workflows/i386.yml
+++ b/.github/workflows/i386.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build 32-bit
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=i386-build-32bit
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks

--- a/.github/workflows/jvm_tests.yml
+++ b/.github/workflows/jvm_tests.yml
@@ -30,7 +30,7 @@ jobs:
         - arch: aarch64
           runner: linux-arm64-cpu
         - arch: x86_64
-          runner: linux-amd64-cpu
+          runner: new-linux-amd64-cpu
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks
       - run: sudo systemctl restart docker
@@ -45,7 +45,7 @@ jobs:
     name: Build libxgboost4j.so with CUDA
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=jvm-tests-build-jvm-gpu
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks
@@ -99,7 +99,7 @@ jobs:
     name: Build and test JVM packages (Linux, Scala ${{ matrix.scala_version }})
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=jvm-tests-build-test-jvm-packages-scala${{ matrix.scala_version }}
     strategy:
       fail-fast: false
@@ -179,7 +179,7 @@ jobs:
     needs: [build-jvm-gpu]
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-mgpu
+      - runner=new-linux-amd64-mgpu
       - tag=jvm-tests-test-jvm-packages-gpu-scala${{ matrix.scala_version }}
     strategy:
       fail-fast: false
@@ -209,7 +209,7 @@ jobs:
     needs: [build-jvm-gpu, build-test-jvm-packages, test-jvm-packages-gpu]
     runs-on:
       - runs-on
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - run-id=${{ github.run_id }}
       - tag=jvm-tests-deploy-jvm-packages-${{ matrix.variant.name }}-scala${{ matrix.scala_version }}
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     name: Run clang-tidy
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=lint-clang-tidy
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build CPU
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=main-build-cpu
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks
@@ -40,7 +40,7 @@ jobs:
     name: Build CUDA + manylinux_2_28_x86_64 wheel
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=main-build-cuda
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks
@@ -63,7 +63,7 @@ jobs:
     name: Build CUDA with RMM
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=main-build-cuda-with-rmm
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks
@@ -86,7 +86,7 @@ jobs:
     name: Build CUDA with RMM (dev)
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=main-build-cuda-with-rmm-dev
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks
@@ -136,7 +136,7 @@ jobs:
         - arch: aarch64
           runner: linux-arm64-cpu
         - arch: x86_64
-          runner: linux-amd64-cpu
+          runner: new-linux-amd64-cpu
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks
       - run: sudo systemctl restart docker
@@ -163,13 +163,13 @@ jobs:
           runner: linux-arm64-cpu
         - manylinux_target: manylinux2014
           arch: x86_64
-          runner: linux-amd64-cpu
+          runner: new-linux-amd64-cpu
         - manylinux_target: manylinux_2_28
           arch: aarch64
           runner: linux-arm64-cpu
         - manylinux_target: manylinux_2_28
           arch: x86_64
-          runner: linux-amd64-cpu
+          runner: new-linux-amd64-cpu
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks
       - run: sudo systemctl restart docker
@@ -186,7 +186,7 @@ jobs:
     name: Build GPU-enabled R package
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=main-build-gpu-rpkg
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks
@@ -214,13 +214,13 @@ jobs:
       matrix:
         include:
           - suite: gpu
-            runner: linux-amd64-gpu
+            runner: new-linux-amd64-gpu
             artifact_from: build-cuda
           - suite: gpu-rmm
-            runner: linux-amd64-gpu
+            runner: new-linux-amd64-gpu
             artifact_from: build-cuda-with-rmm
           - suite: mgpu
-            runner: linux-amd64-mgpu
+            runner: new-linux-amd64-mgpu
             artifact_from: build-cuda
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks
@@ -256,17 +256,17 @@ jobs:
           - description: single-gpu
             image_repo: xgb-ci.gpu
             suite: gpu
-            runner: linux-amd64-gpu
+            runner: new-linux-amd64-gpu
             artifact_from: build-cuda
           - description: multiple-gpu
             image_repo: xgb-ci.gpu
             suite: mgpu
-            runner: linux-amd64-mgpu
+            runner: new-linux-amd64-mgpu
             artifact_from: build-cuda
           - description: cpu-amd64
             image_repo: xgb-ci.cpu
             suite: cpu
-            runner: linux-amd64-cpu
+            runner: new-linux-amd64-cpu
             artifact_from: build-cuda
           - description: cpu-arm64
             image_repo: xgb-ci.manylinux_2_28_aarch64

--- a/.github/workflows/python_wheels_variants.yml
+++ b/.github/workflows/python_wheels_variants.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build Python wheels using Wheel Variant prototype (WheelNext)
     runs-on:
       - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
+      - runner=new-linux-amd64-cpu
       - tag=python-wheels-variants
     steps:
       # Restart Docker daemon so that it recognizes the ephemeral disks


### PR DESCRIPTION
Make sure CI jobs can run on the new VMs with the latest CUDA driver (580, open-source flavor).