### PR TITLE
Cleanup the softmax implementation and cub functions.

### DIFF
--- a/include/xgboost/objective.h
+++ b/include/xgboost/objective.h
@@ -27,7 +27,7 @@ struct Context;
 /** @brief The interface of objective function */
 class ObjFunction : public Configurable {
  protected:
-  Context const* ctx_;
+  Context const* ctx_{nullptr};
 
  public:
   static constexpr float DefaultBaseScore() { return 0.5f; }

--- a/src/common/algorithm.cuh
+++ b/src/common/algorithm.cuh
@@ -332,11 +332,9 @@ void InclusiveSum(Context const *ctx, InputIteratorT d_in, OutputIteratorT d_out
 template <typename... Args>
 void RunLengthEncode(dh::CUDAStreamView stream, Args &&...args) {
   std::size_t n_bytes = 0;
-  dh::safe_cuda(
-      cub::DeviceRunLengthEncode::Encode(nullptr, n_bytes, std::forward<Args>(args)..., stream));
+  dh::safe_cuda(cub::DeviceRunLengthEncode::Encode(nullptr, n_bytes, args..., stream));
   dh::CachingDeviceUVector<char> tmp(n_bytes);
-  dh::safe_cuda(
-      cub::DeviceRunLengthEncode::Encode(tmp.data(), n_bytes, std::forward<Args>(args)..., stream));
+  dh::safe_cuda(cub::DeviceRunLengthEncode::Encode(tmp.data(), n_bytes, args..., stream));
 }
 
 template <typename... Args>

--- a/src/common/linalg_op.cuh
+++ b/src/common/linalg_op.cuh
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2023, XGBoost Contributors
+ * Copyright 2021-2025, XGBoost Contributors
  */
 #ifndef XGBOOST_COMMON_LINALG_OP_CUH_
 #define XGBOOST_COMMON_LINALG_OP_CUH_
@@ -32,7 +32,7 @@ template <typename T>
 struct ElementWiseImpl<T, 1> {
   template <typename Fn>
   void operator()(TensorView<T, 1> t, Fn&& fn, cudaStream_t s) {
-    dh::LaunchN(t.Size(), s, [=] __device__(std::size_t i) { fn(i); });
+    dh::LaunchN(t.Size(), s, [=] __device__(std::size_t i) mutable { fn(i); });
   }
 };
 

--- a/src/data/data.cu
+++ b/src/data/data.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024, XGBoost Contributors
+ * Copyright 2019-2025, XGBoost Contributors
  *
  * \file data.cu
  * \brief Handles setting metainfo from array interface.
@@ -7,6 +7,7 @@
 #include <thrust/gather.h>   // for gather
 #include <thrust/logical.h>  // for none_of
 
+#include "../common/algorithm.cuh"  // for RunLengthEncode
 #include "../common/cuda_context.cuh"
 #include "../common/device_helpers.cuh"
 #include "../common/linalg_op.cuh"
@@ -102,17 +103,13 @@ void CopyQidImpl(Context const* ctx, ArrayInterface<1> array_interface,
   dh::safe_cuda(cudaMemcpy(&non_dec, flag.data().get(), sizeof(bool),
                            cudaMemcpyDeviceToHost));
   CHECK(non_dec) << "`qid` must be sorted in increasing order along with data.";
-  size_t bytes = 0;
+
   dh::caching_device_vector<uint32_t> out(array_interface.Shape<0>());
   dh::caching_device_vector<uint32_t> cnt(array_interface.Shape<0>());
   HostDeviceVector<int> d_num_runs_out(1, 0, d);
-  cub::DeviceRunLengthEncode::Encode(nullptr, bytes, it, out.begin(), cnt.begin(),
-                                     d_num_runs_out.DevicePointer(), array_interface.Shape<0>(),
-                                     cuctx->Stream());
-  dh::CachingDeviceUVector<char> tmp(bytes);
-  cub::DeviceRunLengthEncode::Encode(tmp.data(), bytes, it, out.begin(), cnt.begin(),
-                                     d_num_runs_out.DevicePointer(), array_interface.Shape<0>(),
-                                     cuctx->Stream());
+
+  common::RunLengthEncode(cuctx->Stream(), it, out.begin(), cnt.begin(),
+                          d_num_runs_out.DevicePointer(), array_interface.Shape<0>());
 
   auto h_num_runs_out = d_num_runs_out.HostSpan()[0];
   group_ptr_.clear();

--- a/src/objective/multiclass_obj.cu
+++ b/src/objective/multiclass_obj.cu
@@ -1,156 +1,173 @@
 /**
- * Copyright 2015-2023, XGBoost Contributors
+ * Copyright 2015-2025, XGBoost Contributors
  * \file multi_class.cc
  * \brief Definition of multi-class classification objectives.
  * \author Tianqi Chen
  */
 #include <dmlc/omp.h>
 
-#include <vector>
-#include <algorithm>
+#include <cassert>  // for assert
 #include <limits>
-#include <utility>
 
-#include "xgboost/parameter.h"
+#include "../common/common.h"  // for AssertGPUSupport
+#include "../common/linalg_op.h"
+#include "../common/math.h"
+#include "../common/optional_weight.h"  // for MakeOptionalWeights
+#include "../common/transform.h"
 #include "xgboost/data.h"
+#include "xgboost/json.h"
 #include "xgboost/logging.h"
 #include "xgboost/objective.h"
-#include "xgboost/json.h"
 
-#include "../common/common.h"
-#include "../common/math.h"
-#include "../common/transform.h"
+#if defined(XGBOOST_USE_CUDA)
+
+#include "../common/algorithm.cuh"     // for AllOf
+#include "../common/cuda_context.cuh"  // for CUDAContext
+#include "../common/linalg_op.cuh"     // for tcbegin
+
+#endif  // defined(XGBOOST_USE_CUDA)
+
+#if defined(XGBOOST_USE_SYCL)
+#include "../../plugin/sycl/common/linalg_op.h"
+#endif
 
 #include "multiclass_param.h"
 
-namespace xgboost {
-namespace obj {
-
+namespace xgboost::obj {
 #if defined(XGBOOST_USE_CUDA)
 DMLC_REGISTRY_FILE_TAG(multiclass_obj_gpu);
 #endif  // defined(XGBOOST_USE_CUDA)
 
+namespace {
+void ValidateLabel(Context const* ctx, MetaInfo const& info, std::int64_t n_classes) {
+  auto label = info.labels.View(ctx->Device());
+  CHECK_EQ(label.Shape(1), 1) << "multi-class-multi-label is not yet supported.";
+  auto check = [=] XGBOOST_DEVICE(float y) -> bool {
+    return y >= 0 && y < n_classes && std::floor(y) == y;
+  };
+  auto valid = ctx->DispatchDevice(
+      [&] { return std::all_of(linalg::cbegin(label), linalg::cend(label), check); },
+      [&] {
+#if defined(XGBOOST_USE_CUDA)
+        return common::AllOf(ctx->CUDACtx()->CTP(), linalg::tcbegin(label), linalg::tcend(label),
+                             check);
+#else
+        common::AssertGPUSupport();
+        return false;
+#endif  // defined(XGBOOST_USE_CUDA)
+      });
+  CHECK(valid)
+      << "SoftmaxMultiClassObj: label must be discrete values in the range of [0, num_class).";
+}
+}  // namespace
+
 class SoftmaxMultiClassObj : public ObjFunction {
  public:
-  explicit SoftmaxMultiClassObj(bool output_prob)
-  : output_prob_(output_prob) {}
+  explicit SoftmaxMultiClassObj(bool output_prob) : output_prob_(output_prob) {}
 
-  void Configure(Args const& args) override {
-    param_.UpdateAllowUnknown(args);
-  }
+  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
 
   ObjInfo Task() const override { return ObjInfo::kClassification; }
 
-  void GetGradient(const HostDeviceVector<bst_float>& preds, const MetaInfo& info, std::int32_t,
+  void GetGradient(HostDeviceVector<float> const& preds, const MetaInfo& info, std::int32_t iter,
                    linalg::Matrix<GradientPair>* out_gpair) override {
     if (info.labels.Size() == 0) {
       return;
     }
-    CHECK(preds.Size() == (static_cast<size_t>(param_.num_class) * info.labels.Size()))
+    std::int64_t n_classes = param_.num_class;
+    CHECK(preds.Size() == (static_cast<std::size_t>(n_classes) * info.labels.Size()))
         << "SoftmaxMultiClassObj: label size and pred size does not match.\n"
-        << "label.Size() * num_class: "
-        << info.labels.Size() * static_cast<size_t>(param_.num_class) << "\n"
+        << "label.Size() * num_class: " << info.labels.Size() * n_classes << "\n"
         << "num_class: " << param_.num_class << "\n"
         << "preds.Size(): " << preds.Size();
 
-    const int nclass = param_.num_class;
-    const auto ndata = static_cast<int64_t>(preds.Size() / nclass);
+    if (iter == 0) {
+      ValidateLabel(this->ctx_, info, n_classes);
+    }
 
-    auto device = ctx_->DeviceFP64();
-    out_gpair->SetDevice(device);
-    info.labels.SetDevice(device);
-    info.weights_.SetDevice(device);
-    preds.SetDevice(device);
+    const auto n_samples = preds.Size() / n_classes;
+    CHECK_EQ(n_samples, info.num_row_);
 
-    label_correct_.Resize(1);
-    label_correct_.SetDevice(device);
+    auto device = ctx_->Device();
+    auto labels = info.labels.View(ctx_->Device());
 
-    out_gpair->Reshape(info.num_row_, static_cast<std::uint64_t>(nclass));
-    label_correct_.Fill(1);
+    out_gpair->SetDevice(ctx_->Device());
+    out_gpair->Reshape(info.num_row_, n_classes);
+    auto gpair = out_gpair->View(ctx_->Device());
 
-    const bool is_null_weight = info.weights_.Size() == 0;
-    if (!is_null_weight) {
-      CHECK_EQ(info.weights_.Size(), ndata)
+    if (!info.weights_.Empty()) {
+      CHECK_EQ(info.weights_.Size(), n_samples)
           << "Number of weights should be equal to number of data points.";
     }
+    info.weights_.SetDevice(device);
+    auto weights = common::MakeOptionalWeights(this->ctx_, info.weights_);
 
-    common::Transform<>::Init(
-        [=] XGBOOST_DEVICE(size_t idx,
-                           common::Span<GradientPair> gpair,
-                           common::Span<bst_float const> labels,
-                           common::Span<bst_float const> preds,
-                           common::Span<bst_float const> weights,
-                           common::Span<int> _label_correct) {
-          common::Span<bst_float const> point = preds.subspan(idx * nclass, nclass);
+    preds.SetDevice(device);
+    auto predt = linalg::MakeTensorView(this->ctx_, &preds, n_samples, n_classes);
 
-          // Part of Softmax function
-          bst_float wmax = std::numeric_limits<bst_float>::min();
-          for (auto const i : point) { wmax = fmaxf(i, wmax); }
-          double wsum = 0.0f;
-          for (auto const i : point) { wsum += expf(i - wmax); }
-          auto label = labels[idx];
-          if (label < 0 || label >= nclass) {
-            _label_correct[0] = 0;
-            label = 0;
-          }
-          bst_float wt = is_null_weight ? 1.0f : weights[idx];
-          for (int k = 0; k < nclass; ++k) {
-            // Computation duplicated to avoid creating a cache.
-            bst_float p = expf(point[k] - wmax) / static_cast<float>(wsum);
-            const float eps = 1e-16f;
-            const bst_float h = fmax(2.0f * p * (1.0f - p) * wt, eps);
-            p = label == k ? p - 1.0f : p;
-            gpair[idx * nclass + k] = GradientPair(p * wt, h);
-          }
-        }, common::Range{0, ndata}, ctx_->Threads(), device)
-        .Eval(out_gpair->Data(), info.labels.Data(), &preds, &info.weights_, &label_correct_);
+    CHECK_EQ(labels.Shape(1), 1);
+    auto y1d = labels.Slice(linalg::All(), 0);
+    CHECK_EQ(y1d.Shape(0), info.num_row_);
+    linalg::ElementWiseKernel(this->ctx_, y1d, [=] XGBOOST_DEVICE(std::size_t idx) mutable {
+      auto point = predt.Slice(idx, linalg::All());
+      assert(point.Size() == static_cast<std::size_t>(n_classes));
 
-    std::vector<int>& label_correct_h = label_correct_.HostVector();
-    for (auto const flag : label_correct_h) {
-      if (flag != 1) {
-        LOG(FATAL) << "SoftmaxMultiClassObj: label must be in [0, num_class).";
+      // Part of the common::Softmax function
+      float wmax = std::numeric_limits<float>::min();
+      for (std::size_t k = 0, m = point.Size(); k < m; ++k) {
+        wmax = fmaxf(point(k), wmax);
       }
-    }
+      double wsum = 0.0f;
+      for (std::size_t k = 0, m = point.Size(); k < m; ++k) {
+        wsum += expf(point(k) - wmax);
+      }
+      auto label = y1d(idx);
+
+      float wt = weights[idx];
+      for (decltype(n_classes) k = 0; k < n_classes; ++k) {
+        // Computation duplicated to avoid creating a cache.
+        float p = expf(point(k) - wmax) / static_cast<float>(wsum);
+        constexpr float kEps = 1e-16f;
+        float h = fmax(2.0f * p * (1.0f - p) * wt, kEps);
+        p = label == k ? p - 1.0f : p;
+        gpair(idx, k) = GradientPair{p * wt, h};
+      }
+    });
   }
-  void PredTransform(HostDeviceVector<bst_float>* io_preds) const override {
+
+  void PredTransform(HostDeviceVector<float>* io_preds) const override {
     this->Transform(io_preds, output_prob_);
   }
-  void EvalTransform(HostDeviceVector<bst_float>* io_preds) override {
+  void EvalTransform(HostDeviceVector<float>* io_preds) override {
     this->Transform(io_preds, true);
   }
-  const char* DefaultEvalMetric() const override {
-    return "mlogloss";
-  }
+  const char* DefaultEvalMetric() const override { return "mlogloss"; }
 
-  inline void Transform(HostDeviceVector<bst_float> *io_preds, bool prob) const {
-    const int nclass = param_.num_class;
-    const auto ndata = static_cast<int64_t>(io_preds->Size() / nclass);
+  void Transform(HostDeviceVector<float>* io_preds, bool prob) const {
+    const int n_classes = param_.num_class;
+    const auto n_samples = static_cast<int64_t>(io_preds->Size() / n_classes);
 
     auto device = io_preds->Device();
     if (prob) {
       common::Transform<>::Init(
-          [=] XGBOOST_DEVICE(size_t _idx, common::Span<bst_float> _preds) {
-            common::Span<bst_float> point =
-                _preds.subspan(_idx * nclass, nclass);
+          [=] XGBOOST_DEVICE(size_t _idx, common::Span<float> _preds) {
+            common::Span<float> point = _preds.subspan(_idx * n_classes, n_classes);
             common::Softmax(point.begin(), point.end());
           },
-          common::Range{0, ndata}, this->ctx_->Threads(), device)
+          common::Range{0, n_samples}, this->ctx_->Threads(), device)
           .Eval(io_preds);
     } else {
       io_preds->SetDevice(device);
-      HostDeviceVector<bst_float> max_preds;
+      HostDeviceVector<float> max_preds;
       max_preds.SetDevice(device);
-      max_preds.Resize(ndata);
+      max_preds.Resize(n_samples);
       common::Transform<>::Init(
-          [=] XGBOOST_DEVICE(size_t _idx, common::Span<const bst_float> _preds,
-                             common::Span<bst_float> _max_preds) {
-            common::Span<const bst_float> point =
-                _preds.subspan(_idx * nclass, nclass);
-            _max_preds[_idx] =
-                common::FindMaxIndex(point.cbegin(), point.cend()) -
-                point.cbegin();
+          [=] XGBOOST_DEVICE(size_t _idx, common::Span<const float> _preds,
+                             common::Span<float> _max_preds) {
+            common::Span<const float> point = _preds.subspan(_idx * n_classes, n_classes);
+            _max_preds[_idx] = common::FindMaxIndex(point.cbegin(), point.cend()) - point.cbegin();
           },
-          common::Range{0, ndata}, this->ctx_->Threads(), device)
+          common::Range{0, n_samples}, this->ctx_->Threads(), device)
           .Eval(io_preds, &max_preds);
       io_preds->Resize(max_preds.Size());
       io_preds->Copy(max_preds);
@@ -167,29 +184,23 @@ class SoftmaxMultiClassObj : public ObjFunction {
     out["softmax_multiclass_param"] = ToJson(param_);
   }
 
-  void LoadConfig(Json const& in) override {
-    FromJson(in["softmax_multiclass_param"], &param_);
-  }
+  void LoadConfig(Json const& in) override { FromJson(in["softmax_multiclass_param"], &param_); }
 
  private:
   // output probability
-  bool output_prob_;
+  bool const output_prob_;
   // parameter
   SoftmaxMultiClassParam param_;
-  // Cache for max_preds
-  HostDeviceVector<int> label_correct_;
 };
 
 // register the objective functions
 DMLC_REGISTER_PARAMETER(SoftmaxMultiClassParam);
 
 XGBOOST_REGISTER_OBJECTIVE(SoftmaxMultiClass, "multi:softmax")
-.describe("Softmax for multi-class classification, output class index.")
-.set_body([]() { return new SoftmaxMultiClassObj(false); });
+    .describe("Softmax for multi-class classification, output class index.")
+    .set_body([]() { return new SoftmaxMultiClassObj(false); });
 
 XGBOOST_REGISTER_OBJECTIVE(SoftprobMultiClass, "multi:softprob")
-.describe("Softmax for multi-class classification, output probability distribution.")
-.set_body([]() { return new SoftmaxMultiClassObj(true); });
-
-}  // namespace obj
-}  // namespace xgboost
+    .describe("Softmax for multi-class classification, output probability distribution.")
+    .set_body([]() { return new SoftmaxMultiClassObj(true); });
+}  // namespace xgboost::obj

--- a/src/objective/multiclass_param.h
+++ b/src/objective/multiclass_param.h
@@ -1,25 +1,21 @@
-/*!
- * Copyright 2015-2023 by Contributors
- * \file multiclass_param.h
- * \brief Definition of multi-class classification parameters.
+/**
+ * Copyright 2015-2025, XGBoost Contributors
+ *
+ * @brief Definition of multi-class classification parameters.
  */
 #ifndef XGBOOST_OBJECTIVE_MULTICLASS_PARAM_H_
 #define XGBOOST_OBJECTIVE_MULTICLASS_PARAM_H_
 
 #include "xgboost/parameter.h"
 
-namespace xgboost {
-namespace obj {
-
+namespace xgboost::obj {
 struct SoftmaxMultiClassParam : public XGBoostParameter<SoftmaxMultiClassParam> {
-  int num_class;
+  int num_class{1};
   // declare parameters
   DMLC_DECLARE_PARAMETER(SoftmaxMultiClassParam) {
-    DMLC_DECLARE_FIELD(num_class).set_lower_bound(1)
-        .describe("Number of output class in the multi-class classification.");
+    DMLC_DECLARE_FIELD(num_class).set_lower_bound(1).describe(
+        "Number of output class in the multi-class classification.");
   }
 };
-
-}  // namespace obj
-}  // namespace xgboost
+}  // namespace xgboost::obj
 #endif  // XGBOOST_OBJECTIVE_MULTICLASS_PARAM_H_

--- a/tests/cpp/objective/test_objective.cc
+++ b/tests/cpp/objective/test_objective.cc
@@ -50,7 +50,7 @@ class TestDefaultObjConfig : public ::testing::TestWithParam<std::string> {
 
  public:
   void Run(std::string objective) {
-    auto Xy = MakeFmatForObjTest(objective, 10, 10);
+    auto Xy = MakeFmatForObjTest(objective, 10, 10, 3);
     std::unique_ptr<Learner> learner{Learner::Create({Xy})};
     std::unique_ptr<ObjFunction> objfn{ObjFunction::Create(objective, &ctx_)};
 

--- a/tests/cpp/objective_helpers.cc
+++ b/tests/cpp/objective_helpers.cc
@@ -31,15 +31,18 @@ void MakeLabelForObjTest(std::shared_ptr<DMatrix> p_fmat, std::string const& obj
 [[nodiscard]] std::shared_ptr<DMatrix> MakeFmatForObjTest(std::string const& obj,
                                                           bst_idx_t n_samples,
                                                           bst_feature_t n_features,
-                                                          bst_target_t n_classes) {
+                                                          bst_target_t n_classes, bool make_label) {
   std::shared_ptr<DMatrix> p_fmat;
   if (obj.find("multi:") != std::string::npos) {
     CHECK_GE(n_classes, 3);
-    p_fmat = RandomDataGenerator{n_samples, n_features, 0}.Classes(n_classes).GenerateDMatrix(true);
+    p_fmat = RandomDataGenerator{n_samples, n_features, 0}.Classes(n_classes).GenerateDMatrix(
+        make_label);
   } else {
-    p_fmat = RandomDataGenerator{n_samples, n_features, 0}.GenerateDMatrix(true);
+    p_fmat = RandomDataGenerator{n_samples, n_features, 0}.GenerateDMatrix(make_label);
   }
-  MakeLabelForObjTest(p_fmat, obj);
+  if (make_label) {
+    MakeLabelForObjTest(p_fmat, obj);
+  }
   return p_fmat;
 }
 }  // namespace xgboost

--- a/tests/cpp/objective_helpers.cc
+++ b/tests/cpp/objective_helpers.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023-2024, XGBoost contributors
+ * Copyright 2023-2025, XGBoost contributors
  */
 #include "objective_helpers.h"
 
@@ -28,10 +28,18 @@ void MakeLabelForObjTest(std::shared_ptr<DMatrix> p_fmat, std::string const& obj
   }
 }
 
-std::shared_ptr<DMatrix> MakeFmatForObjTest(std::string const& obj, bst_idx_t n_samples,
-                                            bst_feature_t n_features) {
-  auto p_fmat = RandomDataGenerator{n_samples, n_features, 0}.GenerateDMatrix(true);
+[[nodiscard]] std::shared_ptr<DMatrix> MakeFmatForObjTest(std::string const& obj,
+                                                          bst_idx_t n_samples,
+                                                          bst_feature_t n_features,
+                                                          bst_target_t n_classes) {
+  std::shared_ptr<DMatrix> p_fmat;
+  if (obj.find("multi:") != std::string::npos) {
+    CHECK_GE(n_classes, 3);
+    p_fmat = RandomDataGenerator{n_samples, n_features, 0}.Classes(n_classes).GenerateDMatrix(true);
+  } else {
+    p_fmat = RandomDataGenerator{n_samples, n_features, 0}.GenerateDMatrix(true);
+  }
   MakeLabelForObjTest(p_fmat, obj);
   return p_fmat;
-};
+}
 }  // namespace xgboost

--- a/tests/cpp/objective_helpers.h
+++ b/tests/cpp/objective_helpers.h
@@ -37,6 +37,8 @@ inline std::string ObjTestNameGenerator(const ::testing::TestParamInfo<ParamType
  */
 void MakeLabelForObjTest(std::shared_ptr<DMatrix> p_fmat, std::string const& obj);
 
-std::shared_ptr<DMatrix> MakeFmatForObjTest(std::string const& obj, bst_idx_t n_samples,
-                                            bst_feature_t n_features);
+[[nodiscard]] std::shared_ptr<DMatrix> MakeFmatForObjTest(std::string const& obj,
+                                                          bst_idx_t n_samples,
+                                                          bst_feature_t n_features,
+                                                          bst_target_t n_classes);
 }  // namespace xgboost

--- a/tests/cpp/objective_helpers.h
+++ b/tests/cpp/objective_helpers.h
@@ -40,5 +40,6 @@ void MakeLabelForObjTest(std::shared_ptr<DMatrix> p_fmat, std::string const& obj
 [[nodiscard]] std::shared_ptr<DMatrix> MakeFmatForObjTest(std::string const& obj,
                                                           bst_idx_t n_samples,
                                                           bst_feature_t n_features,
-                                                          bst_target_t n_classes);
+                                                          bst_target_t n_classes,
+                                                          bool make_label = true);
 }  // namespace xgboost

--- a/tests/cpp/plugin/federated/test_federated_learner.cc
+++ b/tests/cpp/plugin/federated/test_federated_learner.cc
@@ -16,6 +16,7 @@
 
 namespace xgboost {
 namespace {
+inline constexpr bst_target_t kClassesForTest = 3;
 auto MakeModel(std::string tree_method, std::string device, std::string objective,
                std::shared_ptr<DMatrix> dmat) {
   std::unique_ptr<Learner> learner{Learner::Create({dmat})};
@@ -26,7 +27,7 @@ auto MakeModel(std::string tree_method, std::string device, std::string objectiv
     learner->SetParam("quantile_alpha", "0.5");
   }
   if (objective.find("multi") != std::string::npos) {
-    learner->SetParam("num_class", "3");
+    learner->SetParam("num_class", std::to_string(kClassesForTest));
   }
   learner->UpdateOneIter(0, dmat);
   Json config{Object{}};
@@ -41,11 +42,8 @@ void VerifyObjective(std::size_t rows, std::size_t cols, float expected_base_sco
                      Json expected_model, std::string const &tree_method, std::string device,
                      std::string const &objective) {
   auto rank = collective::GetRank();
-  std::shared_ptr<DMatrix> dmat{RandomDataGenerator{rows, cols, 0}.GenerateDMatrix(rank == 0)};
-
-  if (rank == 0) {
-    MakeLabelForObjTest(dmat, objective);
-  }
+  std::shared_ptr<DMatrix> dmat =
+      MakeFmatForObjTest(objective, rows, cols, kClassesForTest, rank == 0);
   std::shared_ptr<DMatrix> sliced{dmat->SliceCol(collective::GetWorldSize(), rank)};
 
   auto model = MakeModel(tree_method, device, objective, sliced);
@@ -63,26 +61,7 @@ class VerticalFederatedLearnerTest : public ::testing::TestWithParam<std::string
     static auto constexpr kRows{16};
     static auto constexpr kCols{16};
 
-    std::shared_ptr<DMatrix> dmat{RandomDataGenerator{kRows, kCols, 0}.GenerateDMatrix(true)};
-    MakeLabelForObjTest(dmat, objective);
-
-    auto &h_upper = dmat->Info().labels_upper_bound_.HostVector();
-    auto &h_lower = dmat->Info().labels_lower_bound_.HostVector();
-    h_lower.resize(kRows);
-    h_upper.resize(kRows);
-    for (size_t i = 0; i < kRows; ++i) {
-      h_lower[i] = 1;
-      h_upper[i] = 10;
-    }
-    if (objective.find("rank:") != std::string::npos) {
-      auto h_label = dmat->Info().labels.HostView();
-      std::size_t k = 0;
-      for (auto &v : h_label) {
-        v = k % 2 == 0;
-        ++k;
-      }
-    }
-
+    auto dmat = MakeFmatForObjTest(objective, kRows, kCols, kClassesForTest);
     auto model = MakeModel(tree_method, device, objective, dmat);
     auto score = GetBaseScore(model);
     collective::TestFederatedGlobal(kWorldSize, [&]() {

--- a/tests/python-gpu/test_gpu_prediction.py
+++ b/tests/python-gpu/test_gpu_prediction.py
@@ -362,6 +362,7 @@ class TestGPUPredict:
         strategies.integers(1, 10), tm.make_dataset_strategy(), shap_parameter_strategy
     )
     @settings(deadline=None, max_examples=10, print_blob=True)
+    @pytest.mark.timeout(90)
     def test_shap_interactions(
         self, num_rounds: int, dataset: tm.TestDataset, param: dict
     ) -> None:


### PR DESCRIPTION
- Group cub function calls.
- Use linalg for the softmax implementation.
- Use valid label values for obj tests.

Extracted from https://github.com/dmlc/xgboost/pull/11656 .
Ref https://github.com/dmlc/xgboost/issues/9043