### PR TITLE
[EM] Fix race in the iterator accessor policy.

### DIFF
--- a/src/data/sparse_page_source.h
+++ b/src/data/sparse_page_source.h
@@ -319,11 +319,11 @@ class SparsePageSourceImpl : public BatchIteratorImpl<S>, public FormatStreamPol
       if (restart) {
         this->param_.prefetch_copy = true;
       }
-      ring_->at(fetch_it) = this->workers_.Submit([fetch_it, self, this] {
+      auto p = this->param_;
+      ring_->at(fetch_it) = this->workers_.Submit([fetch_it, self, p, this] {
         auto page = std::make_shared<S>();
         this->exce_.Run([&] {
-          std::unique_ptr<typename FormatStreamPolicy::FormatT> fmt{
-              self->CreatePageFormat(self->param_)};
+          std::unique_ptr<typename FormatStreamPolicy::FormatT> fmt{self->CreatePageFormat(p)};
           auto name = self->cache_info_->ShardName();
           auto [offset, length] = self->cache_info_->View(fetch_it);
           std::unique_ptr<typename FormatStreamPolicy::ReaderT> fi{


### PR DESCRIPTION
Model accuracy is not affected, but a less efficient accessor might be used due to a race condition.

- Copy the parameter.

Fix https://github.com/dmlc/xgboost/actions/runs/17274795128/job/49029841092?pr=11663