### PR TITLE
Cleanup IO functions and add IO for GPU QDM.

### DIFF
--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 by XGBoost Contributors
+ * Copyright 2017-2025, XGBoost Contributors
  * \file hist_util.cc
  */
 #include "hist_util.h"
@@ -10,6 +10,7 @@
 
 #include "../data/adapter.h"         // for SparsePageAdapterBatch
 #include "../data/gradient_index.h"  // for GHistIndexMatrix
+#include "io.h"                      // for AlignedResourceReadStream, AlignedFileWriteStream
 #include "quantile.h"
 #include "xgboost/base.h"
 #include "xgboost/context.h"  // for Context
@@ -27,6 +28,27 @@
 namespace xgboost::common {
 HistogramCuts::HistogramCuts() {
   cut_ptrs_.HostVector().emplace_back(0);
+}
+
+void HistogramCuts::Save(common::AlignedFileWriteStream *fo) const {
+  auto const &ptrs = this->Ptrs();
+  CHECK_EQ(Span{ptrs}.size_bytes(), fo->Write(ptrs.data(), Span{ptrs}.size_bytes()));
+  auto const &vals = this->Values();
+  CHECK_EQ(Span{vals}.size_bytes(), fo->Write(vals.data(), Span{vals}.size_bytes()));
+  auto const &mins = this->MinValues();
+  CHECK_EQ(Span{mins}.size_bytes(), fo->Write(mins.data(), Span{mins}.size_bytes()));
+  CHECK_EQ(fo->Write(has_categorical_), has_categorical_);
+  CHECK_EQ(fo->Write(max_cat_), max_cat_);
+}
+
+[[nodiscard]] HistogramCuts *HistogramCuts::Load(common::AlignedResourceReadStream *fi) {
+  auto p_cuts = new HistogramCuts;
+  CHECK(fi->Read(&p_cuts->cut_ptrs_.HostVector()));
+  CHECK(fi->Read(&p_cuts->cut_values_.HostVector()));
+  CHECK(fi->Read(&p_cuts->min_vals_.HostVector()));
+  CHECK(fi->Read(&p_cuts->has_categorical_));
+  CHECK(fi->Read(&p_cuts->max_cat_));
+  return p_cuts;
 }
 
 HistogramCuts SketchOnDMatrix(Context const *ctx, DMatrix *m, bst_bin_t max_bins, bool use_sorted,

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -32,20 +32,20 @@ HistogramCuts::HistogramCuts() {
 
 void HistogramCuts::Save(common::AlignedFileWriteStream *fo) const {
   auto const &ptrs = this->Ptrs();
-  CHECK_EQ(Span{ptrs}.size_bytes(), fo->Write(ptrs.data(), Span{ptrs}.size_bytes()));
+  CHECK_LE(Span{ptrs}.size_bytes(), WriteVec(fo, ptrs));
   auto const &vals = this->Values();
-  CHECK_EQ(Span{vals}.size_bytes(), fo->Write(vals.data(), Span{vals}.size_bytes()));
+  CHECK_LE(Span{vals}.size_bytes(), WriteVec(fo, vals));
   auto const &mins = this->MinValues();
-  CHECK_EQ(Span{mins}.size_bytes(), fo->Write(mins.data(), Span{mins}.size_bytes()));
-  CHECK_EQ(fo->Write(has_categorical_), has_categorical_);
-  CHECK_EQ(fo->Write(max_cat_), max_cat_);
+  CHECK_LE(Span{mins}.size_bytes(), WriteVec(fo, mins));
+  CHECK_GE(fo->Write(has_categorical_), sizeof(has_categorical_));
+  CHECK_GE(fo->Write(max_cat_), sizeof(max_cat_));
 }
 
 [[nodiscard]] HistogramCuts *HistogramCuts::Load(common::AlignedResourceReadStream *fi) {
   auto p_cuts = new HistogramCuts;
-  CHECK(fi->Read(&p_cuts->cut_ptrs_.HostVector()));
-  CHECK(fi->Read(&p_cuts->cut_values_.HostVector()));
-  CHECK(fi->Read(&p_cuts->min_vals_.HostVector()));
+  CHECK(ReadVec(fi, &p_cuts->cut_ptrs_.HostVector()));
+  CHECK(ReadVec(fi, &p_cuts->cut_values_.HostVector()));
+  CHECK(ReadVec(fi, &p_cuts->min_vals_.HostVector()));
   CHECK(fi->Read(&p_cuts->has_categorical_));
   CHECK(fi->Read(&p_cuts->max_cat_));
   return p_cuts;

--- a/src/common/hist_util.h
+++ b/src/common/hist_util.h
@@ -24,6 +24,9 @@ namespace xgboost {
 class GHistIndexMatrix;
 
 namespace common {
+class AlignedFileWriteStream;
+class AlignedResourceReadStream;
+
 /*!
  * \brief A single row in global histogram index.
  *  Directly represent the global index in the histogram entry.
@@ -175,6 +178,9 @@ class HistogramCuts {
     this->min_vals_.SetDevice(d);
     this->min_vals_.ConstDevicePointer();
   }
+
+  void Save(common::AlignedFileWriteStream* fo) const;
+  [[nodiscard]] static HistogramCuts* Load(common::AlignedResourceReadStream* fi);
 };
 
 /**

--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -13,7 +13,9 @@
 #include <xgboost/windefs.h>
 
 #if defined(xgboost_IS_WIN)
-#include <windows.h>
+
+#include <windows.h>  // for CreateFileMapping2, CreateFileEx...
+
 #endif  // defined(xgboost_IS_WIN)
 
 #endif  // defined(__unix__) || defined(__APPLE__)
@@ -173,6 +175,57 @@ std::string FileExtension(std::string fname, bool lower) {
   }
 }
 
+struct MmapFileImpl {
+#if defined(xgboost_IS_WIN)
+  HANDLE fd{INVALID_HANDLE_VALUE};
+  HANDLE file_map{INVALID_HANDLE_VALUE};
+#else
+  std::int32_t fd{0};
+#endif  // defined(xgboost_IS_WIN)
+  std::byte* base_ptr{nullptr};
+  std::size_t base_size{0};
+  std::size_t delta{0};
+  std::string path;
+
+  MmapFileImpl() = default;
+
+#if defined(xgboost_IS_WIN)
+  MmapFileImpl(HANDLE fd, HANDLE fm, std::byte* base_ptr, std::size_t base_size, std::size_t delta,
+               std::string path)
+      : fd{fd},
+        file_map{fm},
+        base_ptr{base_ptr},
+        base_size{base_size},
+        delta{delta},
+        path{std::move(path)} {}
+#else
+  MMAPFile(std::int32_t fd, std::byte* base_ptr, std::size_t base_size, std::size_t delta,
+           std::string path)
+      : fd{fd}, base_ptr{base_ptr}, base_size{base_size}, delta{delta}, path{std::move(path)} {}
+#endif  // defined(xgboost_IS_WIN)
+
+  void const* Data() const { return this->base_ptr + this->delta; }
+  void* Data() { return this->base_ptr + this->delta; }
+};
+
+void const* MMAPFile::Data() const {
+  if (!this->p_impl) {
+    return nullptr;
+  }
+  return this->p_impl->Data();
+}
+
+void* MMAPFile::Data() {
+  if (!this->p_impl) {
+    return nullptr;
+  }
+  return this->p_impl->Data();
+}
+
+[[nodiscard]] Span<std::byte> MMAPFile::BasePtr() const {
+  return Span{this->p_impl->base_ptr, this->p_impl->base_size};
+}
+
 // For some reason, NVCC 12.1 marks the function deleted if we expose it in the header.
 // NVCC 11.8 doesn't allow `noexcept(false) = default` altogether.
 ResourceHandler::~ResourceHandler() noexcept(false) {}  // NOLINT
@@ -203,23 +256,26 @@ MMAPFile* detail::OpenMmap(std::string path, std::size_t offset, std::size_t len
   CHECK_NE(ptr, MAP_FAILED) << "Failed to map: " << path << ". " << error::SystemError().message();
   auto handle = new MMAPFile{fd, ptr, view_size, offset - view_start, std::move(path)};
 #elif defined(xgboost_IS_WIN)
-  auto file_size = GetFileSize(fd, nullptr);
-  DWORD access = PAGE_READONLY;
-  auto map_file = CreateFileMapping(fd, nullptr, access, 0, file_size, nullptr);
-  access = FILE_MAP_READ;
-  std::uint32_t loff = static_cast<std::uint32_t>(view_start);
-  std::uint32_t hoff = view_start >> 32;
+  LARGE_INTEGER file_size;
+  CHECK_NE(GetFileSizeEx(fd, &file_size), 0) << error::SystemError().message();
+  auto map_file = CreateFileMappingA(fd, nullptr, PAGE_READONLY, file_size.HighPart,
+                                     file_size.LowPart, nullptr);
   CHECK(map_file) << "Failed to map: " << path << ". " << error::SystemError().message();
-  ptr = reinterpret_cast<std::byte*>(MapViewOfFile(map_file, access, hoff, loff, view_size));
+
+  auto li_vs = reinterpret_cast<LARGE_INTEGER*>(&view_start);
+  ptr = reinterpret_cast<std::byte*>(
+      MapViewOfFile(map_file, FILE_MAP_READ, li_vs->HighPart, li_vs->LowPart, view_size));
   CHECK_NE(ptr, nullptr) << "Failed to map: " << path << ". " << error::SystemError().message();
-  auto handle = new MMAPFile{fd, map_file, ptr, view_size, offset - view_start, std::move(path)};
+  auto handle = new MMAPFile{std::make_unique<MmapFileImpl>(fd, map_file, ptr, view_size,
+                                                            offset - view_start, std::move(path))};
 #else
   CHECK_LE(offset, std::numeric_limits<off_t>::max())
       << "File size has exceeded the limit on the current system.";
   int prot{PROT_READ};
   ptr = reinterpret_cast<std::byte*>(mmap(nullptr, view_size, prot, MAP_PRIVATE, fd, view_start));
   CHECK_NE(ptr, MAP_FAILED) << "Failed to map: " << path << ". " << error::SystemError().message();
-  auto handle = new MMAPFile{fd, ptr, view_size, offset - view_start, std::move(path)};
+  auto handle = new MMAPFile{
+      std::make_unique<MmapFileImpl>(fd, ptr, view_size, offset - view_start, std::move(path))};
 #endif  // defined(__linux__) || defined(__GLIBC__)
 
   return handle;
@@ -230,25 +286,27 @@ void detail::CloseMmap(MMAPFile* handle) {
     return;
   }
 #if defined(xgboost_IS_WIN)
-  if (handle->base_ptr) {
-    CHECK(UnmapViewOfFile(handle->base_ptr))
+  if (handle->p_impl->base_ptr) {
+    CHECK(UnmapViewOfFile(handle->p_impl->base_ptr))
         << "Failed to call munmap: " << error::SystemError().message();
   }
-  if (handle->fd != INVALID_HANDLE_VALUE) {
-    CHECK(CloseHandle(handle->fd)) << "Failed to close handle: " << error::SystemError().message();
+  if (handle->p_impl->fd != INVALID_HANDLE_VALUE) {
+    CHECK(CloseHandle(handle->p_impl->fd))
+        << "Failed to close handle: " << error::SystemError().message();
   }
-  if (handle->file_map != INVALID_HANDLE_VALUE) {
-    CHECK(CloseHandle(handle->file_map))
+  if (handle->p_impl->file_map != INVALID_HANDLE_VALUE) {
+    CHECK(CloseHandle(handle->p_impl->file_map))
         << "Failed to close mapping object: " << error::SystemError().message();
   }
 #else
-  if (handle->base_ptr) {
-    CHECK_NE(munmap(handle->base_ptr, handle->base_size), -1)
-        << "Failed to call munmap: `" << handle->path << "`. " << error::SystemError().message();
+  if (handle->p_impl->base_ptr) {
+    CHECK_NE(munmap(handle->base_ptr, handle->p_impl->base_size), -1)
+        << "Failed to call munmap: `" << handle->p_impl->path << "`. "
+        << error::SystemError().message();
   }
-  if (handle->fd != 0) {
-    CHECK_NE(close(handle->fd), -1)
-        << "Failed to close: `" << handle->path << "`. " << error::SystemError().message();
+  if (handle->p_impl->fd != 0) {
+    CHECK_NE(close(handle->p_impl->fd), -1)
+        << "Failed to close: `" << handle->p_impl->path << "`. " << error::SystemError().message();
   }
 #endif
   delete handle;

--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -20,7 +20,6 @@
 
 #include <algorithm>     // for copy, transform
 #include <cctype>        // for tolower
-#include <cerrno>        // for errno
 #include <cstddef>       // for size_t
 #include <cstdint>       // for int32_t, uint32_t
 #include <cstdio>        // for fread, fseek

--- a/src/common/io.h
+++ b/src/common/io.h
@@ -7,12 +7,6 @@
 #ifndef XGBOOST_COMMON_IO_H_
 #define XGBOOST_COMMON_IO_H_
 
-#include <xgboost/windefs.h>
-
-#if defined(xgboost_IS_WIN)
-#include <windows.h>
-#endif  // defined(xgboost_IS_WIN)
-
 #include <algorithm>    // for min, fill_n, copy_n
 #include <array>        // for array
 #include <cstddef>      // for byte, size_t
@@ -230,40 +224,16 @@ inline std::string ReadAll(std::string const &path) {
   return content;
 }
 
+struct MmapFileImpl;
+
 /**
  * @brief A handle to mmap file.
  */
 struct MMAPFile {
-#if defined(xgboost_IS_WIN)
-  HANDLE fd{INVALID_HANDLE_VALUE};
-  HANDLE file_map{INVALID_HANDLE_VALUE};
-#else
-  std::int32_t fd{0};
-#endif  // defined(xgboost_IS_WIN)
-  std::byte* base_ptr{nullptr};
-  std::size_t base_size{0};
-  std::size_t delta{0};
-  std::string path;
-
-  MMAPFile() = default;
-
-#if defined(xgboost_IS_WIN)
-  MMAPFile(HANDLE fd, HANDLE fm, std::byte* base_ptr, std::size_t base_size, std::size_t delta,
-           std::string path)
-      : fd{fd},
-        file_map{fm},
-        base_ptr{base_ptr},
-        base_size{base_size},
-        delta{delta},
-        path{std::move(path)} {}
-#else
-  MMAPFile(std::int32_t fd, std::byte* base_ptr, std::size_t base_size, std::size_t delta,
-           std::string path)
-      : fd{fd}, base_ptr{base_ptr}, base_size{base_size}, delta{delta}, path{std::move(path)} {}
-#endif  // defined(xgboost_IS_WIN)
-
-  void const* Data() const { return this->base_ptr + this->delta; }
-  void* Data() { return this->base_ptr + this->delta; }
+  std::unique_ptr<MmapFileImpl> p_impl;
+  [[nodiscard]] void const* Data() const;
+  [[nodiscard]] void* Data();
+  [[nodiscard]] Span<std::byte> BasePtr() const;
 };
 
 namespace detail {

--- a/src/data/ellpack_page.cuh
+++ b/src/data/ellpack_page.cuh
@@ -302,8 +302,8 @@ class EllpackPageImpl {
   /**
    * @brief Get an accessor backed by the device storage.
    */
-  [[nodiscard]] EllpackAccessor GetDeviceEllpack(
-      Context const* ctx, common::Span<FeatureType const> feature_types = {}) const;
+  EllpackAccessor GetDeviceEllpack(Context const* ctx,
+                                   common::Span<FeatureType const> feature_types = {}) const;
   /**
    * @brief Get an accessor backed by the host storage.
    *
@@ -311,9 +311,9 @@ class EllpackPageImpl {
    *
    * @return An accessor variant.
    */
-  [[nodiscard]] EllpackAccessor GetHostEllpack(
-      Context const* ctx, std::vector<common::CompressedByteT>* h_gidx_buffer,
-      common::Span<FeatureType const> feature_types = {}) const;
+  EllpackAccessor GetHostEllpack(Context const* ctx,
+                                 std::vector<common::CompressedByteT>* h_gidx_buffer,
+                                 common::Span<FeatureType const> feature_types = {}) const;
   /**
    * @brief Vistor pattern.
    *

--- a/src/data/iterative_dmatrix.h
+++ b/src/data/iterative_dmatrix.h
@@ -68,7 +68,7 @@ class IterativeDMatrix : public QuantileDMatrix {
   BatchSet<ExtSparsePage> GetExtBatches(Context const *ctx, BatchParam const &param) override;
 
   void Save(common::AlignedFileWriteStream *fo) const;
-  [[nodiscard]] IterativeDMatrix *Load(common::AlignedResourceReadStream *fi);
+  [[nodiscard]] static IterativeDMatrix *Load(common::AlignedResourceReadStream *fi);
 };
 }  // namespace data
 }  // namespace xgboost

--- a/src/data/iterative_dmatrix.h
+++ b/src/data/iterative_dmatrix.h
@@ -1,8 +1,7 @@
 /**
- * Copyright 2020-2024, XGBoost Contributors
- * \file iterative_dmatrix.h
+ * Copyright 2020-2025, XGBoost Contributors
  *
- * \brief Implementation of the higher-level `QuantileDMatrix`.
+ * @brief Implementation of the higher-level `QuantileDMatrix`.
  */
 #ifndef XGBOOST_DATA_ITERATIVE_DMATRIX_H_
 #define XGBOOST_DATA_ITERATIVE_DMATRIX_H_
@@ -18,7 +17,9 @@
 namespace xgboost {
 namespace common {
 class HistogramCuts;
-}
+class AlignedFileWriteStream;
+class AlignedResourceReadStream;
+}  // namespace common
 
 namespace data {
 /**
@@ -35,13 +36,17 @@ class IterativeDMatrix : public QuantileDMatrix {
   BatchParam batch_;
 
   DMatrixHandle proxy_;
-  DataIterResetCallback *reset_;
-  XGDMatrixCallbackNext *next_;
 
   void InitFromCUDA(Context const *ctx, BatchParam const &p, std::int64_t max_quantile_blocks,
-                    DataIterHandle iter_handle, float missing, std::shared_ptr<DMatrix> ref);
-  void InitFromCPU(Context const *ctx, BatchParam const &p, DataIterHandle iter_handle,
+                    DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext> &&iter,
+                    float missing, std::shared_ptr<DMatrix> ref);
+  void InitFromCPU(Context const *ctx, BatchParam const &p,
+                   DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext> &&iter,
                    float missing, std::shared_ptr<DMatrix> ref);
+
+  explicit IterativeDMatrix(std::shared_ptr<EllpackPage> ellpack) : ellpack_{std::move(ellpack)} {
+    this->fmat_ctx_.UpdateAllowUnknown(Args{{"device", DeviceSym::CUDA()}});
+  }
 
  public:
   explicit IterativeDMatrix(DataIterHandle iter_handle, DMatrixHandle proxy,
@@ -55,13 +60,15 @@ class IterativeDMatrix : public QuantileDMatrix {
 
   ~IterativeDMatrix() override = default;
 
-  bool EllpackExists() const override { return static_cast<bool>(ellpack_); }
-  bool GHistIndexExists() const override { return static_cast<bool>(ghist_); }
+  [[nodiscard]] bool EllpackExists() const override { return static_cast<bool>(ellpack_); }
+  [[nodiscard]] bool GHistIndexExists() const override { return static_cast<bool>(ghist_); }
 
   BatchSet<GHistIndexMatrix> GetGradientIndex(Context const *ctx, BatchParam const &param) override;
-
   BatchSet<EllpackPage> GetEllpackBatches(Context const *ctx, const BatchParam &param) override;
   BatchSet<ExtSparsePage> GetExtBatches(Context const *ctx, BatchParam const &param) override;
+
+  void Save(common::AlignedFileWriteStream *fo) const;
+  [[nodiscard]] IterativeDMatrix *Load(common::AlignedResourceReadStream *fi);
 };
 }  // namespace data
 }  // namespace xgboost

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -1006,14 +1006,14 @@ void RegTree::SaveCategoricalSplit(Json* p_out) const {
   for (size_t i = 0; i < nodes_.size(); ++i) {
     split_type.Set(i, static_cast<std::underlying_type_t<FeatureType>>(this->NodeSplitType(i)));
     if (this->split_types_[i] == FeatureType::kCategorical) {
-      categories_nodes.GetArray().emplace_back(i);
+      categories_nodes.GetArray().emplace_back(static_cast<std::int32_t>(i));
       auto begin = categories.Size();
       categories_segments.GetArray().emplace_back(begin);
       auto segment = this->split_categories_segments_[i];
       auto cat_bits = common::GetNodeCats(this->GetSplitCategories(), segment);
       for (size_t i = 0; i < cat_bits.Capacity(); ++i) {
         if (cat_bits.Check(i)) {
-          categories.GetArray().emplace_back(i);
+          categories.GetArray().emplace_back(static_cast<std::int32_t>(i));
         }
       }
       size_t size = categories.Size() - begin;

--- a/tests/cpp/common/test_config.cc
+++ b/tests/cpp/common/test_config.cc
@@ -1,5 +1,5 @@
-/*!
- * Copyright 2019 by Contributors
+/**
+ * Copyright 2019-2025, XGBoost Contributors
  */
 #include <gtest/gtest.h>
 
@@ -7,7 +7,7 @@
 #include <string>
 
 #include "../../../src/common/config.h"
-#include "../filesystem.h"  // dmlc::TemporaryDirectory
+#include "../filesystem.h"  // for TemporaryDirectory
 #include "../helpers.h"
 
 namespace xgboost {
@@ -15,8 +15,8 @@ namespace common {
 
 TEST(ConfigParser, NormalizeConfigEOL) {
   // Test whether strings with NL are loaded correctly.
-  dmlc::TemporaryDirectory tempdir;
-  const std::string tmp_file = tempdir.path + "/my.conf";
+  common::TemporaryDirectory tempdir;
+  const std::string tmp_file = tempdir.Str() + "/my.conf";
   /* Old Mac OS uses \r for line ending */
   {
     std::string const input = "foo\rbar\rdog\r";
@@ -65,8 +65,8 @@ TEST(ConfigParser, TrimWhitespace) {
 
 TEST(ConfigParser, ParseKeyValuePair) {
   // Create dummy configuration file
-  dmlc::TemporaryDirectory tempdir;
-  const std::string tmp_file = tempdir.path + "/my.conf";
+  common::TemporaryDirectory tempdir;
+  const std::string tmp_file = tempdir.Str() + "/my.conf";
   {
     std::ofstream fp(tmp_file);
     fp << "";

--- a/tests/cpp/common/test_hist_util.cc
+++ b/tests/cpp/common/test_hist_util.cc
@@ -262,7 +262,7 @@ TEST(HistUtil, DenseCutsExternalMemory) {
   Context ctx;
   for (auto num_rows : sizes) {
     HostDeviceVector<float> x{GenerateRandom(num_rows, num_columns)};
-    dmlc::TemporaryDirectory tmpdir;
+    common::TemporaryDirectory tmpdir;
     auto dmat = GetExternalMemoryDMatrixFromData(x, num_rows, num_columns, tmpdir);
     for (auto num_bins : bin_sizes) {
       HistogramCuts cuts = SketchOnDMatrix(&ctx, dmat.get(), num_bins);

--- a/tests/cpp/common/test_hist_util.cu
+++ b/tests/cpp/common/test_hist_util.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024, XGBoost Contributors
+ * Copyright 2019-2025, XGBoost Contributors
  */
 #include <gtest/gtest.h>
 #include <thrust/device_vector.h>
@@ -24,7 +24,7 @@
 #include "../../../src/data/device_adapter.cuh"
 #include "../../../src/data/simple_dmatrix.h"
 #include "../data/test_array_interface.h"
-#include "../filesystem.h"  // dmlc::TemporaryDirectory
+#include "../filesystem.h"  // for TemporaryDirectory
 #include "../helpers.h"
 #include "test_hist_util.h"
 
@@ -334,7 +334,7 @@ TEST(HistUtil, DeviceSketchMultipleColumnsExternal) {
   int num_columns =5;
   for (auto num_rows : sizes) {
     HostDeviceVector<float> x{GenerateRandom(num_rows, num_columns)};
-    dmlc::TemporaryDirectory temp;
+    common::TemporaryDirectory temp;
     auto dmat = GetExternalMemoryDMatrixFromData(x, num_rows, num_columns, temp);
     for (auto num_bins : bin_sizes) {
       auto cuts = DeviceSketch(&ctx, dmat.get(), num_bins);
@@ -349,7 +349,7 @@ TEST(HistUtil, DeviceSketchExternalMemoryWithWeights) {
   auto bin_sizes = {2, 16, 256, 512};
   auto sizes = {100, 1000, 1500};
   int num_columns = 5;
-  dmlc::TemporaryDirectory temp;
+  common::TemporaryDirectory temp;
   for (auto num_rows : sizes) {
     HostDeviceVector<float> x{GenerateRandom(num_rows, num_columns)};
     auto dmat = GetExternalMemoryDMatrixFromData(x, num_rows, num_columns, temp);

--- a/tests/cpp/common/test_io.cc
+++ b/tests/cpp/common/test_io.cc
@@ -8,7 +8,7 @@
 #include <numeric>  // for iota
 
 #include "../../../src/common/io.h"
-#include "../filesystem.h"  // dmlc::TemporaryDirectory
+#include "../filesystem.h"  // TemporaryDirectory
 #include "../helpers.h"
 
 namespace xgboost::common {
@@ -58,8 +58,8 @@ TEST(IO, FixedSizeStream) {
 TEST(IO, LoadSequentialFile) {
   EXPECT_THROW(LoadSequentialFile("non-exist"), dmlc::Error);
 
-  dmlc::TemporaryDirectory tempdir;
-  std::ofstream fout(tempdir.path + "test_file");
+  common::TemporaryDirectory tempdir;
+  std::ofstream fout(tempdir.Path() / "test_file");
   std::string content;
 
   // Generate a JSON file.
@@ -77,7 +77,7 @@ TEST(IO, LoadSequentialFile) {
   std::vector<char> str;
   Json::Dump(out, &str);
 
-  std::string tmpfile = tempdir.path + "/model.json";
+  std::string tmpfile = tempdir.Path() / "model.json";
   {
     std::unique_ptr<dmlc::Stream> fo(dmlc::Stream::Create(tmpfile.c_str(), "w"));
     fo->Write(str.data(), str.size());

--- a/tests/cpp/common/test_io.cc
+++ b/tests/cpp/common/test_io.cc
@@ -77,7 +77,7 @@ TEST(IO, LoadSequentialFile) {
   std::vector<char> str;
   Json::Dump(out, &str);
 
-  std::string tmpfile = tempdir.Path() / "model.json";
+  std::string tmpfile = tempdir.Str() + "/model.json";
   {
     std::unique_ptr<dmlc::Stream> fo(dmlc::Stream::Create(tmpfile.c_str(), "w"));
     fo->Write(str.data(), str.size());
@@ -136,8 +136,8 @@ TEST(IO, Resource) {
 
   {
     // test mmap
-    dmlc::TemporaryDirectory tmpdir;
-    auto path = tmpdir.path + "/testfile";
+    common::TemporaryDirectory tmpdir;
+    auto path = tmpdir.Str() + "/testfile";
 
     std::ofstream fout(path, std::ios::binary);
     double val{1.0};
@@ -156,8 +156,8 @@ class TestFileStream : public ::testing::Test {
  public:
   template <typename TestStreamT>
   void Run() {
-    dmlc::TemporaryDirectory tempdir;
-    auto path = tempdir.path + "/testfile";
+    common::TemporaryDirectory tempdir;
+    auto path = tempdir.Str() + "/testfile";
 
     // The page size on Linux is usually set to 4096, while the allocation granularity on
     // the Windows machine where this test is writted is 65536. We span the test to cover

--- a/tests/cpp/common/test_json.cc
+++ b/tests/cpp/common/test_json.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024, XGBoost Contributors
+ * Copyright 2019-2025, XGBoost Contributors
  */
 #include <gtest/gtest.h>
 
@@ -11,7 +11,7 @@
 #include "../../../src/common/io.h"
 #include "../../../src/common/json_utils.h"
 #include "../../../src/common/threading_utils.h"  // for ParallelFor
-#include "../filesystem.h"                        // dmlc::TemporaryDirectory
+#include "../filesystem.h"                        // for TemporaryDirectory
 #include "../helpers.h"
 #include "dmlc/logging.h"
 #include "xgboost/json.h"
@@ -422,8 +422,8 @@ TEST(Json, LoadDump) {
   std::string ori_buffer = GetModelStr();
   Json origin{Json::Load(StringView{ori_buffer.c_str(), ori_buffer.size()})};
 
-  dmlc::TemporaryDirectory tempdir;
-  auto const& path = tempdir.path + "test_model_dump";
+  common::TemporaryDirectory tempdir;
+  auto const& path = tempdir.Path() / "test_model_dump";
 
   std::string out;
   Json::Dump(origin, &out);
@@ -432,7 +432,7 @@ TEST(Json, LoadDump) {
   ASSERT_TRUE(fout);
   fout << out << std::flush;
 
-  std::vector<char> new_buffer = common::LoadSequentialFile(path);
+  std::vector<char> new_buffer = common::LoadSequentialFile(path.string());
 
   Json load_back{Json::Load(StringView(new_buffer.data(), new_buffer.size()))};
   ASSERT_EQ(load_back, origin);

--- a/tests/cpp/common/test_numa_topo.cc
+++ b/tests/cpp/common/test_numa_topo.cc
@@ -8,7 +8,7 @@
 #include <vector>      // for vector
 
 #include "../../../src/common/numa_topo.h"
-#include "../filesystem.h"
+#include "../filesystem.h"  // for TemporaryDirectory
 
 namespace xgboost::common {
 namespace {
@@ -16,8 +16,8 @@ namespace fs = std::filesystem;
 }
 
 TEST(Numa, CpuListParser) {
-  dmlc::TemporaryDirectory tmpdir;
-  auto path = fs::path{tmpdir.path} / "cpulist";
+  common::TemporaryDirectory tmpdir;
+  auto path = tmpdir.Path() / "cpulist";
   std::vector<std::int32_t> cpus;
 
   auto write = [&](auto const& cpulist) {
@@ -104,7 +104,7 @@ TEST(Numa, CpuListParser) {
     check_4cpu_case();
   }
   {
-    auto path = fs::path{tmpdir.path} / "foo";
+    auto path = tmpdir.Path() / "foo";
     testing::internal::CaptureStderr();
     ReadCpuList(path, &cpus);
     std::string output = testing::internal::GetCapturedStderr();

--- a/tests/cpp/common/test_version.cc
+++ b/tests/cpp/common/test_version.cc
@@ -1,5 +1,5 @@
-/*!
- * Copyright 2019 XGBoost contributors
+/**
+ * Copyright 2019-2025, XGBoost contributors
  */
 #include <dmlc/io.h>
 #include <gtest/gtest.h>
@@ -19,8 +19,8 @@ TEST(Version, Basic) {
   auto triplet { Version::Load(j_ver) };
   ASSERT_TRUE(Version::Same(triplet));
 
-  dmlc::TemporaryDirectory tempdir;
-  const std::string fname = tempdir.path + "/version";
+  common::TemporaryDirectory tempdir;
+  const std::string fname = tempdir.Str() + "/version";
 
   {
     std::unique_ptr<dmlc::Stream> fo(dmlc::Stream::Create(fname.c_str(), "w"));

--- a/tests/cpp/data/test_data.cc
+++ b/tests/cpp/data/test_data.cc
@@ -1,13 +1,12 @@
 /**
- * Copyright 2019-2023 by XGBoost Contributors
+ * Copyright 2019-2025, XGBoost Contributors
  */
 #include <gtest/gtest.h>
 
-#include <fstream>
 #include <memory>
 #include <vector>
 
-#include "../filesystem.h"  // dmlc::TemporaryDirectory
+#include "../filesystem.h"  // TemporaryDirectory
 #include "../helpers.h"
 #include "xgboost/data.h"
 
@@ -116,15 +115,15 @@ TEST(DMatrix, Uri) {
   auto constexpr kRows {16};
   auto constexpr kCols {8};
 
-  dmlc::TemporaryDirectory tmpdir;
-  auto const path = tmpdir.path + "/small.csv";
+  common::TemporaryDirectory tmpdir;
+  auto const path = tmpdir.Path() / "small.csv";
   CreateTestCSV(path, kRows, kCols);
 
   std::unique_ptr<DMatrix> dmat;
   // FIXME(trivialfis): Enable the following test by restricting csv parser in dmlc-core.
   // EXPECT_THROW(dmat.reset(DMatrix::Load(path, false, true)), dmlc::Error);
 
-  std::string uri = path + "?format=csv";
+  std::string uri = path.string() + "?format=csv";
   dmat.reset(DMatrix::Load(uri, false));
 
   ASSERT_EQ(dmat->Info().num_col_, kCols);

--- a/tests/cpp/data/test_data.cc
+++ b/tests/cpp/data/test_data.cc
@@ -117,7 +117,7 @@ TEST(DMatrix, Uri) {
 
   common::TemporaryDirectory tmpdir;
   auto const path = tmpdir.Path() / "small.csv";
-  CreateTestCSV(path, kRows, kCols);
+  CreateTestCSV(path.string(), kRows, kCols);
 
   std::unique_ptr<DMatrix> dmat;
   // FIXME(trivialfis): Enable the following test by restricting csv parser in dmlc-core.

--- a/tests/cpp/data/test_ellpack_page_raw_format.cu
+++ b/tests/cpp/data/test_ellpack_page_raw_format.cu
@@ -44,7 +44,7 @@ class TestEllpackPageRawFormat : public ::testing::TestWithParam<bool> {
 
     auto m = RandomDataGenerator{100, 14, 0.5}.GenerateDMatrix();
     common::TemporaryDirectory tmpdir;
-    std::string path = tmpdir.Path() / "ellpack.page";
+    std::string path = tmpdir.Str() + "/ellpack.page";
 
     std::shared_ptr<common::HistogramCuts const> cuts;
     for (auto const &page : m->GetBatches<EllpackPage>(&ctx, param)) {

--- a/tests/cpp/data/test_ellpack_page_raw_format.cu
+++ b/tests/cpp/data/test_ellpack_page_raw_format.cu
@@ -9,7 +9,7 @@
 #include "../../../src/data/ellpack_page_source.h"      // for EllpackFormatStreamPolicy
 #include "../../../src/tree/param.h"                    // for TrainParam
 #include "../../../src/data/batch_utils.h"              // for AutoHostRatio
-#include "../filesystem.h"                              // dmlc::TemporaryDirectory
+#include "../filesystem.h"                              // for TemporaryDirectory
 #include "../helpers.h"
 
 namespace xgboost::data {
@@ -43,8 +43,8 @@ class TestEllpackPageRawFormat : public ::testing::TestWithParam<bool> {
     param.prefetch_copy = prefetch_copy;
 
     auto m = RandomDataGenerator{100, 14, 0.5}.GenerateDMatrix();
-    dmlc::TemporaryDirectory tmpdir;
-    std::string path = tmpdir.path + "/ellpack.page";
+    common::TemporaryDirectory tmpdir;
+    std::string path = tmpdir.Path() / "ellpack.page";
 
     std::shared_ptr<common::HistogramCuts const> cuts;
     for (auto const &page : m->GetBatches<EllpackPage>(&ctx, param)) {

--- a/tests/cpp/data/test_file_iterator.cc
+++ b/tests/cpp/data/test_file_iterator.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2023 XGBoost contributors
+ * Copyright 2021-2025, XGBoost contributors
  */
 #include <gtest/gtest.h>
 
@@ -9,7 +9,7 @@
 #include "../../../src/data/adapter.h"
 #include "../../../src/data/file_iterator.h"
 #include "../../../src/data/proxy_dmatrix.h"
-#include "../filesystem.h"  // dmlc::TemporaryDirectory
+#include "../filesystem.h"  // for TemporaryDirectory
 #include "../helpers.h"
 
 namespace xgboost::data {
@@ -25,9 +25,9 @@ TEST(FileIterator, Basic) {
     ASSERT_EQ(n_features, 5);
   };
 
-  dmlc::TemporaryDirectory tmpdir;
+  common::TemporaryDirectory tmpdir;
   {
-    auto zpath = tmpdir.path + "/0-based.svm";
+    auto zpath = tmpdir.Str() + "/0-based.svm";
     CreateBigTestData(zpath, 3 * 64, true);
     zpath += "?indexing_mode=0&format=libsvm";
     FileIterator iter{zpath, 0, 1};
@@ -35,7 +35,7 @@ TEST(FileIterator, Basic) {
   }
 
   {
-    auto opath = tmpdir.path + "/1-based.svm";
+    auto opath = tmpdir.Str() + "/1-based.svm";
     CreateBigTestData(opath, 3 * 64, false);
     opath += "?indexing_mode=1&format=libsvm";
     FileIterator iter{opath, 0, 1};

--- a/tests/cpp/data/test_gradient_index_page_raw_format.cc
+++ b/tests/cpp/data/test_gradient_index_page_raw_format.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2024, XGBoost contributors
+ * Copyright 2021-2025, XGBoost contributors
  */
 #include <gtest/gtest.h>
 #include <xgboost/context.h>  // for Context
@@ -20,7 +20,7 @@ TEST(GHistIndexPageRawFormat, IO) {
 
   auto m = RandomDataGenerator{100, 14, 0.5}.GenerateDMatrix();
   common::TemporaryDirectory tmpdir;
-  std::string path = tmpdir.Path() / "ghistindex.page";
+  std::string path = tmpdir.Str() + "/ghistindex.page";
   auto batch = BatchParam{256, 0.5};
 
   common::HistogramCuts cuts;

--- a/tests/cpp/data/test_gradient_index_page_raw_format.cc
+++ b/tests/cpp/data/test_gradient_index_page_raw_format.cc
@@ -19,8 +19,8 @@ TEST(GHistIndexPageRawFormat, IO) {
   Context ctx;
 
   auto m = RandomDataGenerator{100, 14, 0.5}.GenerateDMatrix();
-  dmlc::TemporaryDirectory tmpdir;
-  std::string path = tmpdir.path + "/ghistindex.page";
+  common::TemporaryDirectory tmpdir;
+  std::string path = tmpdir.Path() / "ghistindex.page";
   auto batch = BatchParam{256, 0.5};
 
   common::HistogramCuts cuts;

--- a/tests/cpp/data/test_iterative_dmatrix.cu
+++ b/tests/cpp/data/test_iterative_dmatrix.cu
@@ -11,6 +11,7 @@
 #include "../../../src/data/ellpack_page.h"
 #include "../../../src/data/iterative_dmatrix.h"
 #include "../../../src/tree/param.h"  // TrainParam
+#include "../filesystem.h"            // for TemporaryDirectory
 #include "../helpers.h"
 #include "test_iterative_dmatrix.h"
 
@@ -19,9 +20,9 @@ void TestEquivalent(float sparsity) {
   auto ctx = MakeCUDACtx(0);
 
   CudaArrayIterForTest iter{sparsity};
-  IterativeDMatrix m{&iter, iter.Proxy(), nullptr, Reset, Next,
-                     std::numeric_limits<float>::quiet_NaN(), 0, 256,
-                     std::numeric_limits<std::int64_t>::max()};
+  IterativeDMatrix m{&iter, iter.Proxy(), nullptr,
+                     Reset, Next,         std::numeric_limits<float>::quiet_NaN(),
+                     0,     256,          std::numeric_limits<std::int64_t>::max()};
   std::size_t offset = 0;
   auto first = (*m.GetEllpackBatches(&ctx, {}).begin()).Impl();
   std::unique_ptr<EllpackPageImpl> page_concatenated{new EllpackPageImpl{
@@ -99,15 +100,14 @@ TEST(IterativeDeviceDMatrix, RowMajor) {
   std::string interface_str = iter.AsArray();
   Context ctx{MakeCUDACtx(0)};
   for (auto& ellpack : m.GetBatches<EllpackPage>(&ctx, {})) {
-    n_batches ++;
+    n_batches++;
     auto impl = ellpack.Impl();
 
     auto cols = CudaArrayIterForTest::Cols();
     auto rows = CudaArrayIterForTest::Rows();
 
-    auto j_interface =
-        Json::Load({interface_str.c_str(), interface_str.size()});
-    ArrayInterface<2> loaded {get<Object const>(j_interface)};
+    auto j_interface = Json::Load({interface_str.c_str(), interface_str.size()});
+    ArrayInterface<2> loaded{get<Object const>(j_interface)};
     std::vector<float> h_data(cols * rows);
     common::Span<float const> s_data{static_cast<float const*>(loaded.data), cols * rows};
     dh::CopyDeviceSpanToVector(&h_data, s_data);
@@ -143,8 +143,8 @@ TEST(IterativeDeviceDMatrix, RowMajorMissing) {
   h_data[1] = kMissing;
   h_data[5] = kMissing;
   h_data[6] = kMissing;
-  h_data[9] = kMissing;  // idx = (2, 0)
-  h_data[10] = kMissing; // idx = (2, 1)
+  h_data[9] = kMissing;   // idx = (2, 0)
+  h_data[10] = kMissing;  // idx = (2, 1)
   auto ptr =
       thrust::device_ptr<float>(reinterpret_cast<float*>(get<Integer>(j_interface["data"][0])));
   thrust::copy(h_data.cbegin(), h_data.cend(), ptr);
@@ -196,11 +196,35 @@ TEST(IterativeDeviceDMatrix, Ref) {
 }
 
 TEST(IterativeDeviceDMatrix, IO) {
+  auto ctx = MakeCUDACtx(0);
   std::size_t n_samples = 2048, n_features = 128;
-  auto p_fmat = RandomDataGenerator{n_samples, n_features, 0.0}.GenerateQuantileDMatrix(true);
+  auto p_fmat = RandomDataGenerator{n_samples, n_features, 0.0}
+                    .Bins(32)
+                    .Device(ctx.Device())
+                    .GenerateQuantileDMatrix(true);
   auto qdm = std::dynamic_pointer_cast<IterativeDMatrix>(p_fmat);
   ASSERT_TRUE(qdm);
-  auto fo = std::make_unique<common::AlignedFileWriteStream>("data.qdm", "wb");
-  qdm->Save(fo.get());
+  common::TemporaryDirectory tmpdir;
+  auto path = tmpdir.Path() / "data.qdm";
+  {
+    auto fo = std::make_unique<common::AlignedFileWriteStream>(path.string(), "wb");
+    qdm->Save(fo.get());
+  }
+  auto fsize = std::filesystem::file_size(path);
+  auto fi = std::make_unique<common::MemBufFileReadStream>(path.string(), 0ul, fsize);
+  auto loaded = std::shared_ptr<IterativeDMatrix>(IterativeDMatrix::Load(fi.get()));
+  for (auto const& orig_page : qdm->GetBatches<EllpackPage>(&ctx, {})) {
+    for (auto const& new_page : loaded->GetBatches<EllpackPage>(&ctx, {})) {
+      std::vector<common::CompressedByteT> h_orig, h_new;
+      orig_page.Impl()->GetHostEllpack(&ctx, &h_orig);
+      new_page.Impl()->GetHostEllpack(&ctx, &h_new);
+      ASSERT_EQ(h_orig, h_new);
+      auto orig_cuts = orig_page.Impl()->Cuts();
+      auto new_cuts = new_page.Impl()->Cuts();
+      ASSERT_EQ(orig_cuts.Ptrs(), new_cuts.Ptrs());
+      ASSERT_EQ(orig_cuts.Values(), new_cuts.Values());
+      ASSERT_EQ(orig_cuts.MinValues(), new_cuts.MinValues());
+    }
+  }
 }
 }  // namespace xgboost::data

--- a/tests/cpp/data/test_iterative_dmatrix.cu
+++ b/tests/cpp/data/test_iterative_dmatrix.cu
@@ -3,6 +3,9 @@
  */
 #include <gtest/gtest.h>
 
+#include <memory>  // for dynamic_pointer_cast
+
+#include "../../../src/common/io.h"  // for AlignedFileWriteStream
 #include "../../../src/data/device_adapter.cuh"
 #include "../../../src/data/ellpack_page.cuh"
 #include "../../../src/data/ellpack_page.h"
@@ -190,5 +193,14 @@ TEST(IterativeDeviceDMatrix, Ref) {
   Context ctx{MakeCUDACtx(0)};
   TestRefDMatrix<EllpackPage, CudaArrayIterForTest>(
       &ctx, [](EllpackPage const& page) { return page.Impl()->Cuts(); });
+}
+
+TEST(IterativeDeviceDMatrix, IO) {
+  std::size_t n_samples = 2048, n_features = 128;
+  auto p_fmat = RandomDataGenerator{n_samples, n_features, 0.0}.GenerateQuantileDMatrix(true);
+  auto qdm = std::dynamic_pointer_cast<IterativeDMatrix>(p_fmat);
+  ASSERT_TRUE(qdm);
+  auto fo = std::make_unique<common::AlignedFileWriteStream>("data.qdm", "wb");
+  qdm->Save(fo.get());
 }
 }  // namespace xgboost::data

--- a/tests/cpp/data/test_metainfo.cc
+++ b/tests/cpp/data/test_metainfo.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2024, XGBoost contributors
+ * Copyright 2016-2025, XGBoost contributors
  */
 #include "test_metainfo.h"
 
@@ -11,7 +11,7 @@
 #include <string>
 
 #include "../collective/test_worker.h"  // for TestDistributedGlobal
-#include "../filesystem.h"              // dmlc::TemporaryDirectory
+#include "../filesystem.h"              // TemporaryDirectory
 #include "../helpers.h"                 // for GMockTHrow
 #include "xgboost/base.h"
 
@@ -153,8 +153,8 @@ TEST(MetaInfo, SaveLoadBinary) {
                  [](auto const &str) { return str.c_str(); });
   info.SetFeatureInfo(u8"feature_name", c_names.data(), c_names.size());;
 
-  dmlc::TemporaryDirectory tempdir;
-  const std::string tmp_file = tempdir.path + "/metainfo.binary";
+  common::TemporaryDirectory tempdir;
+  const std::string tmp_file = tempdir.Str() + "/metainfo.binary";
   {
     std::unique_ptr<dmlc::Stream> fs {
       dmlc::Stream::Create(tmp_file.c_str(), "w")
@@ -204,8 +204,8 @@ TEST(MetaInfo, SaveLoadBinary) {
 }
 
 TEST(MetaInfo, LoadQid) {
-  dmlc::TemporaryDirectory tempdir;
-  std::string tmp_file = tempdir.path + "/qid_test.libsvm";
+  common::TemporaryDirectory tempdir;
+  std::string tmp_file = tempdir.Str() + "/qid_test.libsvm";
   {
     std::unique_ptr<dmlc::Stream> fs(dmlc::Stream::Create(tmp_file.c_str(), "w"));
     dmlc::ostream os(fs.get());

--- a/tests/cpp/data/test_simple_dmatrix.cc
+++ b/tests/cpp/data/test_simple_dmatrix.cc
@@ -10,7 +10,7 @@
 #include "../../../src/data/adapter.h"         // ArrayAdapter
 #include "../../../src/data/simple_dmatrix.h"  // SimpleDMatrix
 #include "../collective/test_worker.h"         // for TestDistributedGlobal
-#include "../filesystem.h"                     // dmlc::TemporaryDirectory
+#include "../filesystem.h"                     // for TemporaryDirectory
 #include "../helpers.h"                        // RandomDataGenerator,CreateSimpleTestData
 #include "xgboost/base.h"
 #include "xgboost/host_device_vector.h"  // HostDeviceVector
@@ -23,8 +23,8 @@ std::string UriSVM(std::string name) { return name + "?format=libsvm"; }
 }  // namespace
 
 TEST(SimpleDMatrix, MetaInfo) {
-  dmlc::TemporaryDirectory tempdir;
-  const std::string tmp_file = tempdir.path + "/simple.libsvm";
+  common::TemporaryDirectory tempdir;
+  const std::string tmp_file = tempdir.Str() + "/simple.libsvm";
   CreateSimpleTestData(tmp_file);
   xgboost::DMatrix *dmat = xgboost::DMatrix::Load(UriSVM(tmp_file));
 
@@ -39,8 +39,8 @@ TEST(SimpleDMatrix, MetaInfo) {
 }
 
 TEST(SimpleDMatrix, RowAccess) {
-  dmlc::TemporaryDirectory tempdir;
-  const std::string tmp_file = tempdir.path + "/simple.libsvm";
+  common::TemporaryDirectory tempdir;
+  const std::string tmp_file = tempdir.Str() + "/simple.libsvm";
   CreateSimpleTestData(tmp_file);
   xgboost::DMatrix *dmat = xgboost::DMatrix::Load(UriSVM(tmp_file), false);
 
@@ -63,8 +63,8 @@ TEST(SimpleDMatrix, RowAccess) {
 
 TEST(SimpleDMatrix, ColAccessWithoutBatches) {
   Context ctx;
-  dmlc::TemporaryDirectory tempdir;
-  const std::string tmp_file = tempdir.path + "/simple.libsvm";
+  common::TemporaryDirectory tempdir;
+  const std::string tmp_file = tempdir.Str() + "/simple.libsvm";
   CreateSimpleTestData(tmp_file);
   xgboost::DMatrix *dmat = xgboost::DMatrix::Load(UriSVM(tmp_file));
 
@@ -217,8 +217,8 @@ TEST(SimpleDMatrix, FromCSC) {
 }
 
 TEST(SimpleDMatrix, FromFile) {
-  dmlc::TemporaryDirectory tempdir;
-  std::string filename = tempdir.path + "test.libsvm";
+  common::TemporaryDirectory tempdir;
+  std::string filename = tempdir.Str() + "/test.libsvm";
   CreateBigTestData(filename, 3 * 5);
   // Add an empty row at the end of the matrix
   {
@@ -399,13 +399,13 @@ TEST(SimpleDMatrix, SliceCol) {
 }
 
 TEST(SimpleDMatrix, SaveLoadBinary) {
-  dmlc::TemporaryDirectory tempdir;
-  const std::string tmp_file = tempdir.path + "/simple.libsvm";
+  common::TemporaryDirectory tempdir;
+  const std::string tmp_file = tempdir.Str() + "/simple.libsvm";
   CreateSimpleTestData(tmp_file);
   xgboost::DMatrix * dmat = xgboost::DMatrix::Load(UriSVM(tmp_file));
   data::SimpleDMatrix *simple_dmat = dynamic_cast<data::SimpleDMatrix*>(dmat);
 
-  const std::string tmp_binfile = tempdir.path + "/csr_source.binary";
+  const std::string tmp_binfile = tempdir.Str() + "/csr_source.binary";
   simple_dmat->SaveToLocalFile(tmp_binfile);
   xgboost::DMatrix * dmat_read = xgboost::DMatrix::Load(tmp_binfile);
 

--- a/tests/cpp/data/test_sparse_page_dmatrix.cc
+++ b/tests/cpp/data/test_sparse_page_dmatrix.cc
@@ -13,7 +13,7 @@
 #include "../../../src/data/batch_utils.h"  // for MatchingPageBytes
 #include "../../../src/data/sparse_page_dmatrix.h"
 #include "../../../src/tree/param.h"  // for TrainParam
-#include "../filesystem.h"            // dmlc::TemporaryDirectory
+#include "../filesystem.h"            // for TemporaryDirectory
 #include "../helpers.h"
 
 using namespace xgboost;  // NOLINT
@@ -147,10 +147,10 @@ INSTANTIATE_TEST_SUITE_P(SparsePageDMatrix, TestGradientIndexExt, testing::Bool(
 
 // Test GHistIndexMatrix can avoid loading sparse page after the initialization.
 TEST(SparsePageDMatrix, GHistIndexSkipSparsePage) {
-  dmlc::TemporaryDirectory tmpdir;
+  common::TemporaryDirectory tmpdir;
   std::size_t n_batches = 6;
   auto Xy = RandomDataGenerator{180, 12, 0.0}.Batches(n_batches).GenerateSparsePageDMatrix(
-      tmpdir.path + "/", true);
+      tmpdir.Str() + "/", true);
   Context ctx;
   bst_bin_t n_bins{256};
   double sparse_thresh{0.8};
@@ -229,9 +229,9 @@ TEST(SparsePageDMatrix, GHistIndexSkipSparsePage) {
 }
 
 TEST(SparsePageDMatrix, MetaInfo) {
-  dmlc::TemporaryDirectory tmpdir;
+  common::TemporaryDirectory tmpdir;
   auto dmat = RandomDataGenerator{256, 5, 0.0}.Batches(4).GenerateSparsePageDMatrix(
-      tmpdir.path + "/", true);
+      tmpdir.Str() + "/", true);
 
   // Test the metadata that was parsed
   EXPECT_EQ(dmat->Info().num_row_, 256ul);
@@ -253,7 +253,7 @@ TEST(SparsePageDMatrix, RowAccess) {
 }
 
 TEST(SparsePageDMatrix, ColAccess) {
-  dmlc::TemporaryDirectory tempdir;
+  common::TemporaryDirectory tempdir;
   Context ctx;
 
   auto nan = std::numeric_limits<float>::quiet_NaN();
@@ -348,8 +348,8 @@ auto TestSparsePageDMatrixDeterminism(std::int32_t n_threads) {
   std::vector<size_t> sparse_rptr;
   std::vector<bst_feature_t> sparse_cids;
 
-  dmlc::TemporaryDirectory tmpdir;
-  auto prefix = (std::filesystem::path{tmpdir.path} / "temp").string();
+  common::TemporaryDirectory tmpdir;
+  auto prefix = (tmpdir.Path() / "temp").string();
   auto dmat = RandomDataGenerator{4096, 64, 0.0}.Batches(4).GenerateSparsePageDMatrix(prefix, true);
 
   auto config = ExtMemConfig{prefix,

--- a/tests/cpp/data/test_sparse_page_raw_format.cc
+++ b/tests/cpp/data/test_sparse_page_raw_format.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2024, XGBoost contributors
+ * Copyright 2021-2025, XGBoost contributors
  */
 #include <gtest/gtest.h>
 #include <xgboost/data.h>  // for CSCPage, SortedCSCPage, SparsePage
@@ -9,8 +9,8 @@
 
 #include "../../../src/common/io.h"  // for PrivateMmapConstStream, AlignedResourceReadStream...
 #include "../../../src/data/sparse_page_writer.h"  // for CreatePageFormat
+#include "../filesystem.h"                         // for TemporaryDirectory
 #include "../helpers.h"                            // for RandomDataGenerator
-#include "dmlc/filesystem.h"                       // for TemporaryDirectory
 #include "xgboost/context.h"                       // for Context
 
 namespace xgboost::data {
@@ -20,8 +20,8 @@ template <typename S> void TestSparsePageRawFormat() {
 
   auto m = RandomDataGenerator{100, 14, 0.5}.GenerateDMatrix();
   ASSERT_TRUE(m->SingleColBlock());
-  dmlc::TemporaryDirectory tmpdir;
-  std::string path = tmpdir.path + "/sparse.page";
+  common::TemporaryDirectory tmpdir;
+  std::string path = tmpdir.Path() / "sparse.page";
   S orig;
   std::size_t n_bytes{0};
   {

--- a/tests/cpp/data/test_sparse_page_raw_format.cc
+++ b/tests/cpp/data/test_sparse_page_raw_format.cc
@@ -21,7 +21,7 @@ template <typename S> void TestSparsePageRawFormat() {
   auto m = RandomDataGenerator{100, 14, 0.5}.GenerateDMatrix();
   ASSERT_TRUE(m->SingleColBlock());
   common::TemporaryDirectory tmpdir;
-  std::string path = tmpdir.Path() / "sparse.page";
+  std::string path = tmpdir.Str() + "/sparse.page";
   S orig;
   std::size_t n_bytes{0};
   {

--- a/tests/cpp/filesystem.cc
+++ b/tests/cpp/filesystem.cc
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2025, XGBoost Contributors
+ */
+#include "filesystem.h"
+
+#include <filesystem>
+
+#if !defined(xgboost_IS_WIN)
+#include "../../src/common/error_msg.h"
+#else
+#include "xgboost/string_view.h"  // for StringView
+#endif                            // !defined(xgboost_IS_WIN)
+
+namespace xgboost::common {
+TemporaryDirectory::TemporaryDirectory() {
+  namespace fs = std::filesystem;
+
+  auto tmp = fs::temp_directory_path();
+
+#if defined(xgboost_IS_WIN)
+  std::default_random_engine rng;
+  auto make_name = [&rng] {
+    constexpr std::size_t kPathMax = 6;
+    constexpr StringView kAlphabet{"abcdefghijklmnopqrstuvwxyz"};
+    std::uniform_int_distribution dist{0, 25};
+    char path[kPathMax + 1];
+    std::memset(path, 0, sizeof(path));
+    for (std::size_t i = 0; i < kPathMax; ++i) {
+      auto k = dist(rng);
+      path[i] = kAlphabet[k];
+    }
+    auto res = std::string{path};
+    CHECK_EQ(res.size(), kPathMax);
+    return "xgboost-tmpdir-" + std::string{path};
+  };
+  auto dirname = tmp / make_name();
+  std::int32_t retry = 0;
+  while (fs::exists(dirname) && retry < 64) {
+    dirname = tmp / make_name();
+  }
+  if (retry >= 64) {
+    LOG(FATAL) << "Failed to create temporary directory.";
+  }
+  this->path_ = dirname.string();
+#else
+  auto dirtemplate = (tmp / "/xgboost-tmpdir-XXXXXX").string();
+  std::vector<char> dirtemplate_buf(dirtemplate.begin(), dirtemplate.end());
+  // https://man7.org/linux/man-pages/man3/mkdtemp.3.html
+  char* tmpdir = mkdtemp(dirtemplate_buf.data());
+  if (!tmpdir) {
+    LOG(FATAL) << error::SystemError().message();
+  }
+  this->path_ = tmpdir;
+#endif
+  LOG(INFO) << "TmpDir:" << this->path_;
+  CHECK(fs::create_directory(this->path_));
+}
+
+TemporaryDirectory::~TemporaryDirectory() noexcept(false) {
+  std::filesystem::remove_all(this->path_);
+}
+}  // namespace xgboost::common

--- a/tests/cpp/filesystem.cc
+++ b/tests/cpp/filesystem.cc
@@ -3,7 +3,8 @@
  */
 #include "filesystem.h"
 
-#include <filesystem>
+#include <filesystem>  // for path, temp_directory_path
+#include <random>      // for uniform_int_distribution
 
 #if !defined(xgboost_IS_WIN)
 #include "../../src/common/error_msg.h"
@@ -52,7 +53,7 @@ TemporaryDirectory::TemporaryDirectory() {
   }
   this->path_ = tmpdir;
 #endif
-  LOG(INFO) << "TmpDir:" << this->path_;
+  LOG(DEBUG) << "TmpDir:" << this->path_;
   CHECK(fs::create_directory(this->path_));
 }
 

--- a/tests/cpp/filesystem.cc
+++ b/tests/cpp/filesystem.cc
@@ -3,6 +3,8 @@
  */
 #include "filesystem.h"
 
+#include <xgboost/windefs.h>
+
 #include <filesystem>  // for path, temp_directory_path
 
 #if !defined(xgboost_IS_WIN)
@@ -51,7 +53,6 @@ TemporaryDirectory::TemporaryDirectory(std::string prefix) : prefix_{std::move(p
   CHECK(fs::create_directory(this->path_));
 #else
   auto dirtemplate = (tmp / (this->prefix_ + "tmpdir.XXXXXX")).string();
-  std::cout << dirtemplate << std::endl;
   // https://man7.org/linux/man-pages/man3/mkdtemp.3.html
   char* tmpdir = mkdtemp(dirtemplate.data());
   if (!tmpdir) {

--- a/tests/cpp/filesystem.h
+++ b/tests/cpp/filesystem.h
@@ -4,11 +4,7 @@
 #ifndef XGBOOST_TESTS_CPP_FILESYSTEM_H
 #define XGBOOST_TESTS_CPP_FILESYSTEM_H
 
-#include <xgboost/windefs.h>
-
 #include <filesystem>  // for path
-
-#include "dmlc/filesystem.h"
 
 namespace xgboost::common {
 class TemporaryDirectory {
@@ -19,6 +15,9 @@ class TemporaryDirectory {
   ~TemporaryDirectory() noexcept(false);
 
   [[nodiscard]] std::filesystem::path const& Path() const { return this->path_; }
+  // Path can be implicitly converted to string on unix, but not on windows, due its use
+  // of wchar.
+  [[nodiscard]] std::string Str() const { return this->path_.string(); }
 };
 }  // namespace xgboost::common
 

--- a/tests/cpp/filesystem.h
+++ b/tests/cpp/filesystem.h
@@ -9,9 +9,10 @@
 namespace xgboost::common {
 class TemporaryDirectory {
   std::filesystem::path path_;
+  std::string prefix_;
 
  public:
-  TemporaryDirectory();
+  explicit TemporaryDirectory(std::string prefix = "xgboost-");
   ~TemporaryDirectory() noexcept(false);
 
   [[nodiscard]] std::filesystem::path const& Path() const { return this->path_; }

--- a/tests/cpp/filesystem.h
+++ b/tests/cpp/filesystem.h
@@ -1,11 +1,25 @@
 /**
- * Copyright 2022-2024, XGBoost Contributors
+ * Copyright 2022-2025, XGBoost Contributors
  */
 #ifndef XGBOOST_TESTS_CPP_FILESYSTEM_H
 #define XGBOOST_TESTS_CPP_FILESYSTEM_H
 
 #include <xgboost/windefs.h>
 
+#include <filesystem>  // for path
+
 #include "dmlc/filesystem.h"
+
+namespace xgboost::common {
+class TemporaryDirectory {
+  std::filesystem::path path_;
+
+ public:
+  TemporaryDirectory();
+  ~TemporaryDirectory() noexcept(false);
+
+  [[nodiscard]] std::filesystem::path const& Path() const { return this->path_; }
+};
+}  // namespace xgboost::common
 
 #endif  // XGBOOST_TESTS_CPP_FILESYSTEM_H

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -14,7 +14,7 @@
 
 #include "../../../src/data/proxy_dmatrix.h"  // for DMatrixProxy
 #include "../../../src/gbm/gbtree.h"
-#include "../filesystem.h"  // dmlc::TemporaryDirectory
+#include "../filesystem.h"  // TemporaryDirectory
 #include "../helpers.h"
 #include "xgboost/base.h"
 #include "xgboost/predictor.h"
@@ -134,8 +134,8 @@ TEST(GBTree, ChoosePredictor) {
   }
   ASSERT_TRUE(data.HostCanWrite());
 
-  dmlc::TemporaryDirectory tempdir;
-  const std::string fname = tempdir.path + "/model_param.bst";
+  common::TemporaryDirectory tempdir;
+  const std::string fname = tempdir.Str() + "/model_param.bst";
   {
     std::unique_ptr<dmlc::Stream> fo(dmlc::Stream::Create(fname.c_str(), "w"));
     learner->Save(fo.get());

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -613,11 +613,11 @@ std::shared_ptr<DMatrix> GetDMatrixFromData(const std::vector<float>& x, std::si
 
 [[nodiscard]] std::shared_ptr<DMatrix> GetExternalMemoryDMatrixFromData(
     HostDeviceVector<float> const& x, bst_idx_t n_samples, bst_feature_t n_features,
-    const dmlc::TemporaryDirectory& tempdir, bst_idx_t n_batches) {
+    const common::TemporaryDirectory& tempdir, bst_idx_t n_batches) {
   Context ctx;
   auto iter = NumpyArrayIterForTest{&ctx, x, n_samples / n_batches, n_features, n_batches};
 
-  auto prefix = std::filesystem::path{tempdir.path} / "temp";
+  auto prefix = tempdir.Path() / "temp";
   auto config = ExtMemConfig{
       prefix.string(),
       false,

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <filesystem>  // for path
 #include <limits>      // for numeric_limits
+#include <random>      // for mt19937
 
 #include "../../src/collective/communicator-inl.h"  // for GetRank
 #include "../../src/data/adapter.h"
@@ -599,6 +600,19 @@ int NumpyArrayIterForTest::Next() {
   XGProxyDMatrixSetDataDense(proxy_, batches_[iter_].c_str());
   iter_++;
   return 1;
+}
+
+[[nodiscard]] std::vector<float> GenerateRandomCategoricalSingleColumn(std::size_t n,
+                                                                       std::size_t n_categories) {
+  std::vector<float> x(n);
+  std::mt19937 rng(0);
+  std::uniform_int_distribution<size_t> dist(0, n_categories - 1);
+  std::generate(x.begin(), x.end(), [&]() { return static_cast<float>(dist(rng)); });
+  // Make sure each category is present
+  for (size_t i = 0; i < n_categories; i++) {
+    x[i] = static_cast<decltype(x)::value_type>(i);
+  }
+  return x;
 }
 
 std::shared_ptr<DMatrix> GetDMatrixFromData(const std::vector<float>& x, std::size_t num_rows,

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -14,7 +14,6 @@
 #include <xgboost/model.h>    // for Configurable
 
 #include <cstdint>  // std::int32_t
-#include <random>
 #include <cstdio>
 #include <memory>
 #include <string>
@@ -356,17 +355,8 @@ inline std::shared_ptr<DMatrix> EmptyDMatrix() {
   return RandomDataGenerator{0, 0, 0.0}.GenerateDMatrix();
 }
 
-inline std::vector<float> GenerateRandomCategoricalSingleColumn(int n, size_t num_categories) {
-  std::vector<float> x(n);
-  std::mt19937 rng(0);
-  std::uniform_int_distribution<size_t> dist(0, num_categories - 1);
-  std::generate(x.begin(), x.end(), [&]() { return static_cast<float>(dist(rng)); });
-  // Make sure each category is present
-  for (size_t i = 0; i < num_categories; i++) {
-    x[i] = static_cast<decltype(x)::value_type>(i);
-  }
-  return x;
-}
+[[nodiscard]] std::vector<float> GenerateRandomCategoricalSingleColumn(std::size_t n,
+                                                                       std::size_t n_categories);
 
 std::shared_ptr<DMatrix> GetDMatrixFromData(const std::vector<float>& x, std::size_t num_rows,
                                             bst_feature_t num_columns);

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -14,6 +14,7 @@
 #include <xgboost/model.h>    // for Configurable
 
 #include <cstdint>  // std::int32_t
+#include <random>
 #include <cstdio>
 #include <memory>
 #include <string>
@@ -25,7 +26,7 @@
 #include "../../src/common/cuda_rt_utils.h"         // for AllVisibleGPUs
 #endif  // defined(__CUDACC__)
 
-#include "filesystem.h"  // dmlc::TemporaryDirectory
+#include "filesystem.h"  // for TemporaryDirectory
 #include "xgboost/linalg.h"
 
 #if defined(__CUDACC__)
@@ -372,7 +373,7 @@ std::shared_ptr<DMatrix> GetDMatrixFromData(const std::vector<float>& x, std::si
 
 [[nodiscard]] std::shared_ptr<DMatrix> GetExternalMemoryDMatrixFromData(
     HostDeviceVector<float> const& x, bst_idx_t n_samples, bst_feature_t n_features,
-    const dmlc::TemporaryDirectory& tempdir, bst_idx_t n_batches = 4);
+    const common::TemporaryDirectory& tempdir, bst_idx_t n_batches = 4);
 
 std::unique_ptr<GradientBooster> CreateTrainedGBM(std::string name, Args kwargs, size_t kRows,
                                                   size_t kCols,

--- a/tests/cpp/test_helpers.cc
+++ b/tests/cpp/test_helpers.cc
@@ -1,7 +1,11 @@
+/**
+ * Copyright 2020-2025, XGBoost Contributors
+ */
 #include <gtest/gtest.h>
 #include <algorithm>
 
 #include "helpers.h"
+#include "filesystem.h"  // for TemporaryDirectory
 #include "../../src/data/array_interface.h"
 namespace xgboost {
 
@@ -71,8 +75,8 @@ TEST(RandomDataGenerator, GenerateArrayInterfaceBatch) {
 TEST(RandomDataGenerator, SparseDMatrix) {
   bst_idx_t constexpr kCols{100}, kBatches{13};
   bst_idx_t n_samples{kBatches * 128};
-  dmlc::TemporaryDirectory tmpdir;
-  auto prefix = tmpdir.path + "/cache";
+  common::TemporaryDirectory tmpdir;
+  auto prefix = tmpdir.Str() + "/cache";
   auto p_ext_fmat =
       RandomDataGenerator{n_samples, kCols, 0.0}.Batches(kBatches).GenerateSparsePageDMatrix(prefix,
                                                                                              true);

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -172,7 +172,7 @@ TEST(Learner, JsonModelIO) {
     fout << out;
     fout.close();
 
-    auto loaded_str = common::LoadSequentialFile(tmpdir.Path() / "model.json");
+    auto loaded_str = common::LoadSequentialFile(tmpdir.Str() + "/model.json");
     Json loaded = Json::Load(StringView{loaded_str.data(), loaded_str.size()});
 
     learner->LoadModel(loaded);

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -166,13 +166,13 @@ TEST(Learner, JsonModelIO) {
     Json out { Object() };
     learner->SaveModel(&out);
 
-    dmlc::TemporaryDirectory tmpdir;
+    common::TemporaryDirectory tmpdir;
 
-    std::ofstream fout (tmpdir.path + "/model.json");
+    std::ofstream fout (tmpdir.Path() / "model.json");
     fout << out;
     fout.close();
 
-    auto loaded_str = common::LoadSequentialFile(tmpdir.path + "/model.json");
+    auto loaded_str = common::LoadSequentialFile(tmpdir.Path() / "model.json");
     Json loaded = Json::Load(StringView{loaded_str.data(), loaded_str.size()});
 
     learner->LoadModel(loaded);

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -12,7 +12,7 @@
 
 #include "../../src/common/io.h"
 #include "../../src/common/random.h"
-#include "filesystem.h"  // dmlc::TemporaryDirectory
+#include "filesystem.h"  // for TemporaryDirectory
 #include "helpers.h"
 
 namespace xgboost {
@@ -129,8 +129,8 @@ void TestLearnerSerialization(Args args, FeatureMap const& fmap, std::shared_ptr
 
   int32_t constexpr kIters = 2;
 
-  dmlc::TemporaryDirectory tempdir;
-  std::string const fname = tempdir.path + "/model";
+  common::TemporaryDirectory tempdir;
+  std::string const fname = tempdir.Path() / "model";
 
   std::vector<std::string> dumped_0;
   std::string model_at_kiter;

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2023, XGBoost Contributors
+ * Copyright 2019-2025, XGBoost Contributors
  */
 #include <gtest/gtest.h>
 #include <xgboost/base.h>
@@ -130,7 +130,7 @@ void TestLearnerSerialization(Args args, FeatureMap const& fmap, std::shared_ptr
   int32_t constexpr kIters = 2;
 
   common::TemporaryDirectory tempdir;
-  std::string const fname = tempdir.Path() / "model";
+  std::string const fname = tempdir.Str() + "/model";
 
   std::vector<std::string> dumped_0;
   std::string model_at_kiter;


### PR DESCRIPTION
- Remove the `windows.h` from `io.h`. Closes https://github.com/dmlc/xgboost/issues/11419
- Remove the use of the dmlc temporary directory to avoid Windows-specific function calls (to avoid windows.h)
- Implement IO for the QDM, GPU-only at the moment. This is not exposed to the user and is intended solely for development purposes.
- Support memory mapping large files on Windows. Closes https://github.com/dmlc/xgboost/issues/11440 