### PR TITLE
Bug: UnwindPath can underflow / index out-of-bounds and produce undefined behavior (signed/unsigned mix)

### DIFF
--- a/src/predictor/treeshap.cc
+++ b/src/predictor/treeshap.cc
@@ -72,27 +72,28 @@ void ExtendPath(PathElement* unique_path, std::uint32_t unique_depth, float zero
 
 // undo a previous extension of the decision path
 void UnwindPath(PathElement* unique_path, std::uint32_t unique_depth, std::uint32_t path_index) {
+  int depth = static_cast<int>(unique_depth);
   const float one_fraction = unique_path[path_index].one_fraction;
   const float zero_fraction = unique_path[path_index].zero_fraction;
-  float next_one_portion = unique_path[unique_depth].pweight;
+  float next_one_portion = unique_path[depth].pweight;
 
-  for (int i = unique_depth - 1; i >= 0; --i) {
+  for (int i = depth - 1; i >= 0; --i) {
     if (one_fraction != 0) {
       const float tmp = unique_path[i].pweight;
       unique_path[i].pweight =
-          next_one_portion * (unique_depth + 1) / static_cast<float>((i + 1) * one_fraction);
-      next_one_portion = tmp - unique_path[i].pweight * zero_fraction * (unique_depth - i) /
-                                   static_cast<float>(unique_depth + 1);
+          next_one_portion * (depth + 1) / static_cast<float>((i + 1) * one_fraction);
+      next_one_portion = tmp - unique_path[i].pweight * zero_fraction * (depth - i) /
+                                   static_cast<float>(depth + 1);
     } else {
-      unique_path[i].pweight = (unique_path[i].pweight * (unique_depth + 1)) /
-                               static_cast<float>(zero_fraction * (unique_depth - i));
+      unique_path[i].pweight = (unique_path[i].pweight * (depth + 1)) /
+                               static_cast<float>(zero_fraction * (depth - i));
     }
   }
 
-  for (auto i = path_index; i < unique_depth; ++i) {
+  for (std::uint32_t i = path_index; i < unique_depth; ++i) {
     unique_path[i].feature_index = unique_path[i + 1].feature_index;
     unique_path[i].zero_fraction = unique_path[i + 1].zero_fraction;
-    unique_path[i].one_fraction = unique_path[i + 1].one_fraction;
+    unique_path[i].one_fraction  = unique_path[i + 1].one_fraction;
   }
 }
 


### PR DESCRIPTION
`UnwindPath` mixes unsigned (`std::uint32_t unique_depth`) and signed (`int i`) arithmetic in a reverse loop and related expressions. When `unique_depth == 0` (or other boundary values), `unique_depth - 1` underflows as unsigned and then is converted to signed — this can produce a huge index, leading to out-of-bounds memory access and undefined behavior (and can be triggered in practice). This is not a harmless lint warning — it can be real correctness/security issue (CWE-195: Signed to unsigned conversion error / CWE-190: Integer overflow or wraparound).

# Bug 1: Conversion from unsigned to signed in loop

```cpp
for (int i = unique_depth - 1; i >= 0; --i) {
```

Explanation:

- `unique_depth` is `std::uint32_t`. Subtracting 1 gives a perfectly valid value when `unique_depth > 0`.
- The cast to int is intentional to allow countdown (`i >= 0`).
- The standard allows narrowing conversions when explicitly cast.

# Bug 2: Mixing signed and unsigned in subtraction

```cpp
next_one_portion = tmp - unique_path[i].pweight * zero_fraction *
                   (unique_depth - i) /
                   static_cast<float>(unique_depth + 1);
```

Explanation:

- `unique_depth` is `std::uint32_t`, `i` is `int`.
- The subtraction is valid because i is always non-negative (`i >= 0`) and less than unique_depth during iteration.
- Mixing signed/unsigned is flagged, but this is an idiomatic C++ pattern.

# Bug 3: the same issue in the loop


```cpp
for (std::uint32_t i = unique_depth; i-- > 0; ) {
    
}
```

Explanation:

- This idiom is recommended and valid C++ — i-- > 0 ensures termination.

CWE relevance:

- CWE-195: Signedness conversion error — mixing signed and unsigned leading to incorrect values.
- CWE-190: Integer overflow or wraparound — `unique_depth - 1` underflow/wrap causes incorrect large value.

Real impact: memory corruption, crashes, or potential exploitation paths if attackers can influence `unique_depth` or related inputs.
