### PR TITLE
Explanation for isMaximizeEvaluation.

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -386,6 +386,32 @@ public class XGBoost {
   }
 
   // visiable for testing
+
+  /**
+   * This methods decides whether the evaluation metrics are to be maximized or
+   * not. The decision is made in the following order:
+   * <ul>
+   *   <li>If the {@code params} object contains the key "maximize_evaluation_metrics",
+   *   then it will make a decision whether the value corresponding to the
+   *   parameter is true or false.</li>
+   *   <li>If the {@code params} does not contain this key, then it will make a decision
+   *   whether the "eval_metric" parameter present or not.</li>
+   *   <li>If this parameter is null, then the metric name is inferred from the logs.
+   *   The parameters {@code evalInfo} and {@code evalNames} are passed to get the
+   *   metric name.</li>
+   *   <li>If the value is not null, then the metric name would be the value of the
+   *   parameter "eval_matric".</li>
+   *   <li>Finally if "mape" is the metric name, then return false.</li>
+   *   <li>If "mape" is not the metric name, then we iterate through the list of
+   *   all the values in {@code MAXIMIZ_METRICES}. If the value starts with any of
+   *   of the values in the array, return true.</li>
+   * </ul>
+   * @param evalInfo The evaluation log string from which the metric name is inferred.
+   * @param evalNames The names of the evaluation matrices.
+   * @param params The parameters that contain information regarding whethe the
+   *  evaluation metrics are to be maximized or not.
+   * @return True if the evaluation metrics are to be maximized, false otherwise.
+   */
   public static boolean isMaximizeEvaluation(String evalInfo,
                                              String[] evalNames,
                                              Map<String, Object> params) {


### PR DESCRIPTION
The function `isMaximizeEvaluation(String evalInfo, String[] evalNames, Map<String, Object> params)` is a function that is used to compute whether the evaluation metrics are maximization metrics or not. Since this is a public method that is accessible by developers, it is important for them to understand the use of this function before using this function in their model development.