### PR TITLE
Extract the stream, event, and stream view.

### DIFF
--- a/plugin/federated/federated_comm.cuh
+++ b/plugin/federated/federated_comm.cuh
@@ -1,18 +1,18 @@
 /**
- * Copyright 2023-2024, XGBoost Contributors
+ * Copyright 2023-2025, XGBoost Contributors
  */
 #pragma once
 
 #include <memory>  // for shared_ptr
 
 #include "../../src/collective/coll.h"          // for Coll
-#include "../../src/common/device_helpers.cuh"  // for CUDAStreamView
+#include "../../src/common/cuda_stream.h"       // for StreamView
 #include "federated_comm.h"                     // for FederatedComm
 #include "xgboost/context.h"                    // for Context
 
 namespace xgboost::collective {
 class CUDAFederatedComm : public FederatedComm {
-  dh::CUDAStreamView stream_;
+  curt::StreamView stream_;
 
  public:
   explicit CUDAFederatedComm(Context const* ctx, std::shared_ptr<FederatedComm const> impl);

--- a/src/collective/coll.cu
+++ b/src/collective/coll.cu
@@ -13,7 +13,8 @@
 #include <type_traits>  // for invoke_result_t, is_same_v, enable_if_t
 #include <utility>      // for move
 
-#include "../common/device_helpers.cuh"  // for CUDAStreamView, CUDAEvent, device_vector
+#include "../common/cuda_stream.h"       // for StreamView, Event
+#include "../common/device_helpers.cuh"  // for device_vector
 #include "../common/threadpool.h"        // for ThreadPool
 #include "../common/utils.h"             // for MakeCleanup
 #include "../data/array_interface.h"     // for ArrayInterfaceHandler
@@ -87,16 +88,16 @@ struct Chan {
 };
 }  // namespace
 
-template <typename Fn, typename R = std::invoke_result_t<Fn, dh::CUDAStreamView>>
+template <typename Fn, typename R = std::invoke_result_t<Fn, curt::StreamView>>
 [[nodiscard]] std::enable_if_t<std::is_same_v<R, Result>, Result> AsyncLaunch(
     common::ThreadPool* pool, NCCLComm const* nccl, std::shared_ptr<NcclStub> stub,
-    dh::CUDAStreamView stream, Fn&& fn) {
-  dh::CUDAEvent e0;
+    curt::StreamView stream, Fn&& fn) {
+  curt::Event e0;
   e0.Record(nccl->Stream());
   stream.Wait(e0);
 
   auto cleanup = common::MakeCleanup([&] {
-    dh::CUDAEvent e1;
+    curt::Event e1;
     e1.Record(stream);
     nccl->Stream().Wait(e1);
   });
@@ -180,7 +181,7 @@ bool IsBitwiseOp(Op const& op) {
 }
 
 template <typename Func>
-void RunBitwiseAllreduce(dh::CUDAStreamView stream, common::Span<std::int8_t> out_buffer,
+void RunBitwiseAllreduce(curt::StreamView stream, common::Span<std::int8_t> out_buffer,
                          std::int8_t const* device_buffer, Func func, std::int32_t world_size,
                          std::size_t size) {
   dh::LaunchN(size, stream, [=] __device__(std::size_t idx) {
@@ -194,13 +195,13 @@ void RunBitwiseAllreduce(dh::CUDAStreamView stream, common::Span<std::int8_t> ou
 
 [[nodiscard]] Result BitwiseAllReduce(common::ThreadPool* pool, NCCLComm const* pcomm,
                                       common::Span<std::int8_t> data, Op op,
-                                      dh::CUDAStreamView stream) {
+                                      curt::StreamView stream) {
   dh::device_vector<std::int8_t> buffer(data.size() * pcomm->World());
   auto* device_buffer = buffer.data().get();
   auto stub = pcomm->Stub();
 
   // First gather data from all the workers.
-  auto rc = AsyncLaunch(pool, pcomm, stub, stream, [&](dh::CUDAStreamView s) {
+  auto rc = AsyncLaunch(pool, pcomm, stub, stream, [&](curt::StreamView s) {
     return stub->Allgather(data.data(), device_buffer, data.size(), ncclInt8, pcomm->Handle(), s);
   });
   if (!rc.OK()) {
@@ -263,7 +264,7 @@ ncclRedOp_t GetNCCLRedOp(Op const& op) {
         using T = decltype(t);
         auto rdata = common::RestoreType<T>(data);
         return AsyncLaunch(
-            &this->pool_, nccl, stub, this->stream_.View(), [&](dh::CUDAStreamView s) {
+            &this->pool_, nccl, stub, this->stream_.View(), [&](curt::StreamView s) {
               return stub->Allreduce(data.data(), data.data(), rdata.size(), GetNCCLType(type),
                                      GetNCCLRedOp(op), nccl->Handle(), s);
             });
@@ -285,7 +286,7 @@ ncclRedOp_t GetNCCLRedOp(Op const& op) {
 
   return Success() << [&] {
     return AsyncLaunch(&this->pool_, nccl, stub, this->stream_.View(),
-                       [data, nccl, root, stub](dh::CUDAStreamView s) {
+                       [data, nccl, root, stub](curt::StreamView s) {
                          return stub->Broadcast(data.data(), data.data(), data.size_bytes(),
                                                 ncclInt8, root, nccl->Handle(), s);
                        });
@@ -306,7 +307,7 @@ ncclRedOp_t GetNCCLRedOp(Op const& op) {
   auto send = data.subspan(comm.Rank() * size, size);
   return Success() << [&] {
     return AsyncLaunch(&this->pool_, nccl, stub, this->stream_.View(),
-                       [send, data, size, nccl, stub](dh::CUDAStreamView s) {
+                       [send, data, size, nccl, stub](curt::StreamView s) {
                          return stub->Allgather(send.data(), data.data(), size, ncclInt8,
                                                 nccl->Handle(), s);
                        });
@@ -321,7 +322,7 @@ namespace cuda_impl {
  *
  * https://arxiv.org/abs/1812.05964
  */
-Result BroadcastAllgatherV(NCCLComm const* comm, dh::CUDAStreamView s,
+Result BroadcastAllgatherV(NCCLComm const* comm, curt::StreamView s,
                            common::Span<std::int8_t const> data,
                            common::Span<std::int64_t const> sizes, common::Span<std::int8_t> recv) {
   auto stub = comm->Stub();
@@ -379,7 +380,7 @@ Result BroadcastAllgatherV(NCCLComm const* comm, dh::CUDAStreamView s,
       };
     }
     case AllgatherVAlgo::kBcast: {
-      return AsyncLaunch(&this->pool_, nccl, stub, this->stream_.View(), [&](dh::CUDAStreamView s) {
+      return AsyncLaunch(&this->pool_, nccl, stub, this->stream_.View(), [&](curt::StreamView s) {
         return cuda_impl::BroadcastAllgatherV(nccl, s, data, sizes, recv);
       });
     }

--- a/src/collective/coll.cuh
+++ b/src/collective/coll.cuh
@@ -1,21 +1,21 @@
 /**
- * Copyright 2023-2024, XGBoost Contributors
+ * Copyright 2023-2025, XGBoost Contributors
  */
 #pragma once
 
 #include <cstdint>  // for int8_t, int64_t
 
-#include "../common/device_helpers.cuh"  // for CUDAStream
-#include "../common/threadpool.h"        // for ThreadPool
-#include "../data/array_interface.h"     // for ArrayInterfaceHandler
-#include "coll.h"                        // for Coll
-#include "comm.h"                        // for Comm
-#include "xgboost/span.h"                // for Span
+#include "../common/cuda_stream.h"    // for Stream
+#include "../common/threadpool.h"     // for ThreadPool
+#include "../data/array_interface.h"  // for ArrayInterfaceHandler
+#include "coll.h"                     // for Coll
+#include "comm.h"                     // for Comm
+#include "xgboost/span.h"             // for Span
 
 namespace xgboost::collective {
 class NCCLColl : public Coll {
   common::ThreadPool pool_;
-  dh::CUDAStream stream_;
+  curt::Stream stream_;
 
  public:
   NCCLColl();

--- a/src/collective/comm.cu
+++ b/src/collective/comm.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023-2024, XGBoost Contributors
+ * Copyright 2023-2025, XGBoost Contributors
  */
 #if defined(XGBOOST_USE_NCCL)
 #include <algorithm>  // for sort
@@ -113,7 +113,7 @@ NCCLComm::NCCLComm(Context const* ctx, Comm const& root, std::shared_ptr<Coll> p
 
   for (std::int32_t r = 0; r < root.World(); ++r) {
     this->channels_.emplace_back(
-        std::make_shared<NCCLChannel>(root, r, nccl_comm_, stub_, dh::DefaultStream()));
+        std::make_shared<NCCLChannel>(root, r, nccl_comm_, stub_, curt::DefaultStream()));
   }
 }
 

--- a/src/collective/comm.cuh
+++ b/src/collective/comm.cuh
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, XGBoost Contributors
+ * Copyright 2023-2025, XGBoost Contributors
  */
 #pragma once
 
@@ -9,7 +9,7 @@
 
 #include <utility>  // for move
 
-#include "../common/device_helpers.cuh"
+#include "../common/cuda_stream.h"  // for StreamView
 #include "coll.h"
 #include "comm.h"
 #include "nccl_stub.h"  // for NcclStub
@@ -30,7 +30,7 @@ class NCCLComm : public Comm {
   ncclComm_t nccl_comm_{nullptr};
   std::shared_ptr<NcclStub> stub_;
   ncclUniqueId nccl_unique_id_{};
-  dh::CUDAStreamView stream_;
+  curt::StreamView stream_;
   std::string nccl_path_;
 
  public:
@@ -45,7 +45,7 @@ class NCCLComm : public Comm {
   }
   ~NCCLComm() override;
   [[nodiscard]] bool IsFederated() const override { return false; }
-  [[nodiscard]] dh::CUDAStreamView Stream() const { return stream_; }
+  [[nodiscard]] curt::StreamView Stream() const { return stream_; }
   [[nodiscard]] Result Block() const override {
     auto rc = this->Stream().Sync(false);
     return GetCUDAResult(rc);
@@ -60,16 +60,16 @@ class NCCLChannel : public Channel {
   std::int32_t rank_{-1};
   ncclComm_t nccl_comm_{};
   std::shared_ptr<NcclStub> stub_;
-  dh::CUDAStreamView stream_;
+  curt::StreamView stream_;
 
  public:
   explicit NCCLChannel(Comm const& comm, std::int32_t rank, ncclComm_t nccl_comm,
-                       std::shared_ptr<NcclStub> stub, dh::CUDAStreamView stream)
+                       std::shared_ptr<NcclStub> stub, curt::StreamView stream)
       : rank_{rank},
         nccl_comm_{nccl_comm},
         stub_{std::move(stub)},
         Channel{comm, nullptr},
-        stream_{stream} {}
+        stream_{std::move(stream)} {}
 
   [[nodiscard]] Result SendAll(std::int8_t const* ptr, std::size_t n) override {
     return stub_->Send(ptr, n, ncclInt8, rank_, nccl_comm_, stream_);

--- a/src/common/algorithm.cuh
+++ b/src/common/algorithm.cuh
@@ -4,10 +4,10 @@
 #ifndef XGBOOST_COMMON_ALGORITHM_CUH_
 #define XGBOOST_COMMON_ALGORITHM_CUH_
 
-#include <thrust/copy.h>                         // for copy
-#include <thrust/iterator/counting_iterator.h>   // for make_counting_iterator
-#include <thrust/sort.h>                         // for stable_sort_by_key
-#include <thrust/tuple.h>                        // for tuple, get
+#include <thrust/copy.h>                        // for copy
+#include <thrust/iterator/counting_iterator.h>  // for make_counting_iterator
+#include <thrust/sort.h>                        // for stable_sort_by_key
+#include <thrust/tuple.h>                       // for tuple, get
 
 #include <cstddef>      // size_t
 #include <cstdint>      // int32_t
@@ -18,11 +18,11 @@
 
 #include "common.h"            // safe_cuda
 #include "cuda_context.cuh"    // CUDAContext
+#include "cuda_stream.h"       // for StreamView
 #include "device_helpers.cuh"  // TemporaryArray,SegmentId,LaunchN,Iota
 #include "device_vector.cuh"   // for device_vector
 #include "xgboost/base.h"      // XGBOOST_DEVICE
 #include "xgboost/context.h"   // Context
-#include "xgboost/linalg.h"    // for VectorView
 #include "xgboost/logging.h"   // CHECK
 #include "xgboost/span.h"      // Span,byte
 
@@ -30,11 +30,11 @@ namespace xgboost::common {
 namespace detail {
 
 #if CUB_VERSION >= 300000
-  constexpr auto kCubSortOrderAscending = cub::SortOrder::Ascending;
-  constexpr auto kCubSortOrderDescending = cub::SortOrder::Descending;
+constexpr auto kCubSortOrderAscending = cub::SortOrder::Ascending;
+constexpr auto kCubSortOrderDescending = cub::SortOrder::Descending;
 #else
-  constexpr bool kCubSortOrderAscending = false;
-  constexpr bool kCubSortOrderDescending = true;
+constexpr bool kCubSortOrderAscending = false;
+constexpr bool kCubSortOrderDescending = true;
 #endif
 
 // Wrapper around cub sort to define is_decending
@@ -70,7 +70,7 @@ void DeviceSegmentedRadixSortPair(void *d_temp_storage,
                                   const ValueT *d_values_in, ValueT *d_values_out,
                                   std::size_t num_items, std::size_t num_segments,
                                   BeginOffsetIteratorT d_begin_offsets,
-                                  EndOffsetIteratorT d_end_offsets, dh::CUDAStreamView stream,
+                                  EndOffsetIteratorT d_end_offsets, curt::StreamView stream,
                                   int begin_bit = 0, int end_bit = sizeof(KeyT) * 8) {
   cub::DoubleBuffer<KeyT> d_keys(const_cast<KeyT *>(d_keys_in), d_keys_out);
   cub::DoubleBuffer<ValueT> d_values(const_cast<ValueT *>(d_values_in), d_values_out);
@@ -198,7 +198,7 @@ void SegmentedArgMergeSort(Context const *ctx, SegIt seg_begin, SegIt seg_end, V
                                if (thrust::get<0>(l) != thrust::get<0>(r)) {
                                  return thrust::get<0>(l) < thrust::get<0>(r);  // segment index
                                }
-                               return thrust::get<1>(l) < thrust::get<1>(r);    // residue
+                               return thrust::get<1>(l) < thrust::get<1>(r);  // residue
                              });
 }
 
@@ -224,46 +224,54 @@ void ArgSort(Context const *ctx, Span<U> keys, Span<IdxT> sorted_idx) {
   if (accending) {
     void *d_temp_storage = nullptr;
 #if THRUST_MAJOR_VERSION >= 2
-    dh::safe_cuda((cub::DispatchRadixSort<detail::kCubSortOrderAscending, KeyT, ValueT, OffsetT>::Dispatch(
-        d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
-        cuctx->Stream())));
+    dh::safe_cuda(
+        (cub::DispatchRadixSort<detail::kCubSortOrderAscending, KeyT, ValueT, OffsetT>::Dispatch(
+            d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
+            cuctx->Stream())));
 #else
-    dh::safe_cuda((cub::DispatchRadixSort<detail::kCubSortOrderAscending, KeyT, ValueT, OffsetT>::Dispatch(
-        d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
-        nullptr, false)));
+    dh::safe_cuda(
+        (cub::DispatchRadixSort<detail::kCubSortOrderAscending, KeyT, ValueT, OffsetT>::Dispatch(
+            d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
+            nullptr, false)));
 #endif
     dh::TemporaryArray<char> storage(bytes);
     d_temp_storage = storage.data().get();
 #if THRUST_MAJOR_VERSION >= 2
-    dh::safe_cuda((cub::DispatchRadixSort<detail::kCubSortOrderAscending, KeyT, ValueT, OffsetT>::Dispatch(
-        d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
-        cuctx->Stream())));
+    dh::safe_cuda(
+        (cub::DispatchRadixSort<detail::kCubSortOrderAscending, KeyT, ValueT, OffsetT>::Dispatch(
+            d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
+            cuctx->Stream())));
 #else
-    dh::safe_cuda((cub::DispatchRadixSort<detail::kCubSortOrderAscending, KeyT, ValueT, OffsetT>::Dispatch(
-        d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
-        nullptr, false)));
+    dh::safe_cuda(
+        (cub::DispatchRadixSort<detail::kCubSortOrderAscending, KeyT, ValueT, OffsetT>::Dispatch(
+            d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
+            nullptr, false)));
 #endif
   } else {
     void *d_temp_storage = nullptr;
 #if THRUST_MAJOR_VERSION >= 2
-    dh::safe_cuda((cub::DispatchRadixSort<detail::kCubSortOrderDescending, KeyT, ValueT, OffsetT>::Dispatch(
-        d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
-        cuctx->Stream())));
+    dh::safe_cuda(
+        (cub::DispatchRadixSort<detail::kCubSortOrderDescending, KeyT, ValueT, OffsetT>::Dispatch(
+            d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
+            cuctx->Stream())));
 #else
-    dh::safe_cuda((cub::DispatchRadixSort<detail::kCubSortOrderDescending, KeyT, ValueT, OffsetT>::Dispatch(
-        d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
-        nullptr, false)));
+    dh::safe_cuda(
+        (cub::DispatchRadixSort<detail::kCubSortOrderDescending, KeyT, ValueT, OffsetT>::Dispatch(
+            d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
+            nullptr, false)));
 #endif
     dh::TemporaryArray<char> storage(bytes);
     d_temp_storage = storage.data().get();
 #if THRUST_MAJOR_VERSION >= 2
-    dh::safe_cuda((cub::DispatchRadixSort<detail::kCubSortOrderDescending, KeyT, ValueT, OffsetT>::Dispatch(
-        d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
-        cuctx->Stream())));
+    dh::safe_cuda(
+        (cub::DispatchRadixSort<detail::kCubSortOrderDescending, KeyT, ValueT, OffsetT>::Dispatch(
+            d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
+            cuctx->Stream())));
 #else
-    dh::safe_cuda((cub::DispatchRadixSort<detail::kCubSortOrderDescending, KeyT, ValueT, OffsetT>::Dispatch(
-        d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
-        nullptr, false)));
+    dh::safe_cuda(
+        (cub::DispatchRadixSort<detail::kCubSortOrderDescending, KeyT, ValueT, OffsetT>::Dispatch(
+            d_temp_storage, bytes, d_keys, d_values, sorted_idx.size(), 0, sizeof(KeyT) * 8, false,
+            nullptr, false)));
 #endif
   }
 
@@ -330,7 +338,7 @@ void InclusiveSum(Context const *ctx, InputIteratorT d_in, OutputIteratorT d_out
 }
 
 template <typename... Args>
-void RunLengthEncode(dh::CUDAStreamView stream, Args &&...args) {
+void RunLengthEncode(curt::StreamView stream, Args &&...args) {
   std::size_t n_bytes = 0;
   dh::safe_cuda(cub::DeviceRunLengthEncode::Encode(nullptr, n_bytes, args..., stream));
   dh::CachingDeviceUVector<char> tmp(n_bytes);
@@ -338,7 +346,7 @@ void RunLengthEncode(dh::CUDAStreamView stream, Args &&...args) {
 }
 
 template <typename... Args>
-void SegmentedSum(dh::CUDAStreamView stream, Args &&...args) {
+void SegmentedSum(curt::StreamView stream, Args &&...args) {
   std::size_t n_bytes = 0;
   dh::safe_cuda(cub::DeviceSegmentedReduce::Sum(nullptr, n_bytes, args..., stream));
   dh::CachingDeviceUVector<char> tmp(n_bytes);

--- a/src/common/cuda_context.cuh
+++ b/src/common/cuda_context.cuh
@@ -1,11 +1,12 @@
 /**
- * Copyright 2022-2023, XGBoost Contributors
+ * Copyright 2022-2025, XGBoost Contributors
  */
 #ifndef XGBOOST_COMMON_CUDA_CONTEXT_CUH_
 #define XGBOOST_COMMON_CUDA_CONTEXT_CUH_
 #include <thrust/execution_policy.h>
 
-#include "device_helpers.cuh"
+#include "cuda_stream.h"      // for DefaultStream
+#include "device_vector.cuh"  // for XGBCachingDeviceAllocator, XGBDeviceAllocator
 
 namespace xgboost {
 struct CUDAContext {
@@ -19,9 +20,9 @@ struct CUDAContext {
    */
   auto CTP() const {
 #if THRUST_MAJOR_VERSION >= 2 || defined(XGBOOST_USE_RMM)
-    return thrust::cuda::par_nosync(caching_alloc_).on(dh::DefaultStream());
+    return thrust::cuda::par_nosync(caching_alloc_).on(curt::DefaultStream());
 #else
-    return thrust::cuda::par(caching_alloc_).on(dh::DefaultStream());
+    return thrust::cuda::par(caching_alloc_).on(curt::DefaultStream());
 #endif  // THRUST_MAJOR_VERSION >= 2
   }
   /**
@@ -29,12 +30,12 @@ struct CUDAContext {
    */
   auto TP() const {
 #if THRUST_MAJOR_VERSION >= 2
-    return thrust::cuda::par_nosync(alloc_).on(dh::DefaultStream());
+    return thrust::cuda::par_nosync(alloc_).on(curt::DefaultStream());
 #else
-    return thrust::cuda::par(alloc_).on(dh::DefaultStream());
+    return thrust::cuda::par(alloc_).on(curt::DefaultStream());
 #endif  // THRUST_MAJOR_VERSION >= 2
   }
-  auto Stream() const { return dh::DefaultStream(); }
+  auto Stream() const { return curt::DefaultStream(); }
 };
 }  // namespace xgboost
 #endif  // XGBOOST_COMMON_CUDA_CONTEXT_CUH_

--- a/src/common/cuda_stream.h
+++ b/src/common/cuda_stream.h
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2022-2025, XGBoost contributors
+ */
+#pragma once
+#include <cuda_runtime.h>
+
+#include <memory>  // for unique_ptr
+
+#include "common.h"
+namespace xgboost::curt {
+class StreamView;
+
+class Event {
+  std::unique_ptr<cudaEvent_t, void (*)(cudaEvent_t *)> event_;
+
+ public:
+  explicit Event(bool disable_timing = true)
+      : event_{[disable_timing] {
+                 auto e = new cudaEvent_t;
+                 dh::safe_cuda(cudaEventCreateWithFlags(
+                     e, disable_timing ? cudaEventDisableTiming : cudaEventDefault));
+                 return e;
+               }(),
+               [](cudaEvent_t *e) {
+                 if (e) {
+                   dh::safe_cuda(cudaEventDestroy(*e));
+                   delete e;
+                 }
+               }} {}
+
+  inline void Record(StreamView stream);  // NOLINT
+  // Define swap-based ctor to make sure an event is always valid.
+  Event(Event &&e) : Event() { std::swap(this->event_, e.event_); }
+  Event &operator=(Event &&e) {
+    std::swap(this->event_, e.event_);
+    return *this;
+  }
+
+  operator cudaEvent_t() const { return *event_; }                // NOLINT
+  cudaEvent_t const *data() const { return this->event_.get(); }  // NOLINT
+  void Sync() { dh::safe_cuda(cudaEventSynchronize(*this->data())); }
+};
+
+class StreamView {
+  cudaStream_t stream_{nullptr};
+
+ public:
+  explicit StreamView(cudaStream_t s) : stream_{s} {}
+  void Wait(Event const &e) {
+#if defined(__CUDACC_VER_MAJOR__)
+#if __CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 0
+    // CUDA == 11.0
+    dh::safe_cuda(cudaStreamWaitEvent(stream_, cudaEvent_t{e}, 0));
+#else
+    // CUDA > 11.0
+    dh::safe_cuda(cudaStreamWaitEvent(stream_, cudaEvent_t{e}, cudaEventWaitDefault));
+#endif  // __CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 0:
+#else   // clang
+    dh::safe_cuda(cudaStreamWaitEvent(stream_, cudaEvent_t{e}, cudaEventWaitDefault));
+#endif  //  defined(__CUDACC_VER_MAJOR__)
+  }
+  operator cudaStream_t() const {  // NOLINT
+    return stream_;
+  }
+  cudaError_t Sync(bool error = true) {
+    if (error) {
+      dh::safe_cuda(cudaStreamSynchronize(stream_));
+      return cudaSuccess;
+    }
+    return cudaStreamSynchronize(stream_);
+  }
+};
+
+inline void Event::Record(StreamView stream) {  // NOLINT
+  dh::safe_cuda(cudaEventRecord(*event_, cudaStream_t{stream}));
+}
+
+// Changing this has effect on prediction return, where we need to pass the pointer to
+// third-party libraries like cuPy
+inline StreamView DefaultStream() { return StreamView{cudaStreamPerThread}; }
+
+class Stream {
+  cudaStream_t stream_;
+
+ public:
+  Stream() { dh::safe_cuda(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking)); }
+  ~Stream() { dh::safe_cuda(cudaStreamDestroy(stream_)); }
+
+  [[nodiscard]] StreamView View() const { return StreamView{stream_}; }
+  [[nodiscard]] cudaStream_t Handle() const { return stream_; }
+
+  void Sync() { this->View().Sync(); }
+  void Wait(Event const &e) { this->View().Wait(e); }
+};
+}  // namespace xgboost::curt

--- a/src/common/cuda_stream_pool.h
+++ b/src/common/cuda_stream_pool.h
@@ -6,13 +6,13 @@
 #include <cstddef>  // for size_t
 #include <vector>   // for vector
 
-#include "device_helpers.cuh"  // for CUDAStreamView, CUDAStream
+#include "cuda_stream.h"       // for StreamView, Stream
 
 namespace xgboost::curt {
 // rmm cuda_stream_pool
 class StreamPool {
   mutable std::atomic<std::size_t> next_{0};
-  std::vector<dh::CUDAStream> stream_;
+  std::vector<curt::Stream> stream_;
 
  public:
   explicit StreamPool(std::size_t n) : stream_(n) {}
@@ -20,10 +20,8 @@ class StreamPool {
   StreamPool(StreamPool const& that) = delete;
   StreamPool& operator=(StreamPool const& that) = delete;
 
-  [[nodiscard]] dh::CUDAStreamView operator[](std::size_t i) const { return stream_[i].View(); }
-  [[nodiscard]] dh::CUDAStreamView Next() const {
-    return stream_[(next_++) % stream_.size()].View();
-  }
+  [[nodiscard]] curt::StreamView operator[](std::size_t i) const { return stream_[i].View(); }
+  [[nodiscard]] curt::StreamView Next() const { return stream_[(next_++) % stream_.size()].View(); }
   [[nodiscard]] std::size_t Size() const { return stream_.size(); }
 };
 }  // namespace xgboost::curt

--- a/src/common/device_compression.cu
+++ b/src/common/device_compression.cu
@@ -11,7 +11,8 @@
 #include <memory>   // for shared_ptr
 
 #include "device_compression.cuh"
-#include "device_helpers.cuh"  // for CUDAStreamView, MemcpyBatchAsync
+#include "cuda_stream.h"        // for StreamView
+#include "device_helpers.cuh"  // for MemcpyBatchAsync
 #include "xgboost/span.h"      // for Span
 
 #if defined(XGBOOST_USE_NVCOMP)
@@ -76,7 +77,7 @@ XGBOOST_DEVICE std::uint32_t GetUncompressedSize(std::uint8_t const* src, std::s
 void FillDecompParams(void const* const* d_in_chunk_ptrs, std::size_t const* d_in_chunk_nbytes,
                       common::Span<CUmemDecompressParams> de_params, size_t* d_act_nbytes,
                       std::size_t const* d_out_chunk_nbytes, std::int32_t* statuses,
-                      dh::CUDAStreamView stream) {
+                      curt::StreamView stream) {
   auto n_chunks = de_params.size();
   dh::LaunchN(n_chunks, stream,
               [d_in_chunk_ptrs, d_in_chunk_nbytes, d_out_chunk_nbytes, d_act_nbytes, de_params,
@@ -155,7 +156,7 @@ void SafeNvComp(nvcompStatus_t status) {
   return de;
 }
 
-SnappyDecomprMgrImpl::SnappyDecomprMgrImpl(dh::CUDAStreamView s,
+SnappyDecomprMgrImpl::SnappyDecomprMgrImpl(curt::StreamView s,
                                            std::shared_ptr<HostPinnedMemPool> pool,
                                            CuMemParams params,
                                            common::Span<std::uint8_t const> in_compressed_data)
@@ -253,7 +254,7 @@ SnappyDecomprMgr::~SnappyDecomprMgr() = default;
 
 SnappyDecomprMgrImpl* SnappyDecomprMgr::Impl() const { return this->pimpl_.get(); }
 
-void DecompressSnappy(dh::CUDAStreamView stream, SnappyDecomprMgr const& mgr,
+void DecompressSnappy(curt::StreamView stream, SnappyDecomprMgr const& mgr,
                       common::Span<common::CompressedByteT> out, bool allow_fallback) {
   xgboost_NVTX_FN_RANGE();
   auto mgr_impl = mgr.Impl();
@@ -409,7 +410,7 @@ void DecompressSnappy(dh::CUDAStreamView stream, SnappyDecomprMgr const& mgr,
 }
 
 [[nodiscard]] common::RefResourceView<std::uint8_t> CoalesceCompressedBuffersToHost(
-    dh::CUDAStreamView stream, std::shared_ptr<HostPinnedMemPool> pool,
+    curt::StreamView stream, std::shared_ptr<HostPinnedMemPool> pool,
     CuMemParams const& in_params, dh::DeviceUVector<std::uint8_t> const& in_buf,
     CuMemParams* p_out) {
   std::size_t n_total_act_bytes = in_params.TotalSrcActBytes();
@@ -462,7 +463,7 @@ void DecompressSnappy(dh::CUDAStreamView stream, SnappyDecomprMgr const& mgr,
 
 namespace xgboost::dc {
 // Impl
-SnappyDecomprMgrImpl::SnappyDecomprMgrImpl(dh::CUDAStreamView,
+SnappyDecomprMgrImpl::SnappyDecomprMgrImpl(curt::StreamView,
                                            std::shared_ptr<common::cuda_impl::HostPinnedMemPool>,
                                            CuMemParams,
                                            common::Span<common::CompressedByteT const>) {}
@@ -478,7 +479,7 @@ SnappyDecomprMgrImpl* SnappyDecomprMgr::Impl() const { return nullptr; }
 [[nodiscard]] std::size_t SnappyDecomprMgr::DecompressedBytes() const { return 0; }
 
 // Round-trip compression
-void DecompressSnappy(dh::CUDAStreamView, SnappyDecomprMgr const&,
+void DecompressSnappy(curt::StreamView, SnappyDecomprMgr const&,
                       common::Span<common::CompressedByteT>, bool) {
   common::AssertNvCompSupport();
 }
@@ -494,7 +495,7 @@ void DecompressSnappy(dh::CUDAStreamView, SnappyDecomprMgr const&,
 }
 
 [[nodiscard]] common::RefResourceView<std::uint8_t> CoalesceCompressedBuffersToHost(
-    dh::CUDAStreamView, std::shared_ptr<HostPinnedMemPool>, CuMemParams const& in_params,
+    curt::StreamView, std::shared_ptr<HostPinnedMemPool>, CuMemParams const& in_params,
     dh::DeviceUVector<std::uint8_t> const&, CuMemParams*) {
   std::size_t n_total_bytes = in_params.TotalSrcBytes();
   if (n_total_bytes == 0) {

--- a/src/common/device_compression.cuh
+++ b/src/common/device_compression.cuh
@@ -9,6 +9,7 @@
 #include "compressed_iterator.h"    // for CompressedByteT
 #include "cuda_dr_utils.h"          // for CUDA_HW_DECOM_AVAILABLE
 #include "cuda_pinned_allocator.h"  // for HostPinnedMemPool
+#include "cuda_stream.h"            // for StreamView
 #include "device_compression.h"     // for CuMemParams
 #include "device_vector.cuh"        // for DeviceUVector
 #include "ref_resource_view.h"      // for RefResourceView
@@ -40,7 +41,7 @@ using HostPinnedMemPool = common::cuda_impl::HostPinnedMemPool;
  * @param allow_fallback Allow fallback to nvcomp implementation if hardware accelerated
  *   implementation is not available. Used for testing.
  */
-void DecompressSnappy(dh::CUDAStreamView stream, SnappyDecomprMgr const& mgr,
+void DecompressSnappy(curt::StreamView stream, SnappyDecomprMgr const& mgr,
                       common::Span<common::CompressedByteT> out, bool allow_fallback);
 
 /**
@@ -53,7 +54,7 @@ void DecompressSnappy(dh::CUDAStreamView stream, SnappyDecomprMgr const& mgr,
  * @param p_out Re-newed parameters to keep track of the buffers.
  */
 [[nodiscard]] common::RefResourceView<std::uint8_t> CoalesceCompressedBuffersToHost(
-    dh::CUDAStreamView stream, std::shared_ptr<HostPinnedMemPool> pool,
+    curt::StreamView stream, std::shared_ptr<HostPinnedMemPool> pool,
     CuMemParams const& in_params, dh::DeviceUVector<std::uint8_t> const& in_buf,
     CuMemParams* p_out);
 
@@ -87,7 +88,7 @@ struct SnappyDecomprMgrImpl {
 #endif  // defined(CUDA_HW_DECOM_AVAILABLE)
   }
 
-  SnappyDecomprMgrImpl(dh::CUDAStreamView s, std::shared_ptr<HostPinnedMemPool> pool,
+  SnappyDecomprMgrImpl(curt::StreamView s, std::shared_ptr<HostPinnedMemPool> pool,
                        CuMemParams params, common::Span<std::uint8_t const> in_compressed_data);
 
 #if defined(CUDA_HW_DECOM_AVAILABLE) && defined(XGBOOST_USE_NVCOMP)
@@ -106,14 +107,14 @@ struct SnappyDecomprMgrImpl {
 
 #if defined(XGBOOST_USE_NVCOMP)
 [[nodiscard]] inline auto MakeSnappyDecomprMgr(
-    dh::CUDAStreamView s, std::shared_ptr<HostPinnedMemPool> pool, CuMemParams params,
+    curt::StreamView s, std::shared_ptr<HostPinnedMemPool> pool, CuMemParams params,
     common::Span<std::uint8_t const> in_compressed_data) {
   SnappyDecomprMgr mgr;
   *mgr.Impl() = SnappyDecomprMgrImpl{s, std::move(pool), std::move(params), in_compressed_data};
   return mgr;
 }
 #else
-[[nodiscard]] inline auto MakeSnappyDecomprMgr(dh::CUDAStreamView,
+[[nodiscard]] inline auto MakeSnappyDecomprMgr(curt::StreamView,
                                                std::shared_ptr<HostPinnedMemPool>, CuMemParams,
                                                common::Span<std::uint8_t const>) {
   SnappyDecomprMgr mgr;

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2024, XGBoost contributors
+ * Copyright 2017-2025, XGBoost contributors
  */
 #pragma once
 #include <thrust/binary_search.h>                       // thrust::upper_bound
@@ -21,6 +21,7 @@
 
 #include "common.h"
 #include "cuda_rt_utils.h"  // for GetNumaId, CurrentDevice
+#include "cuda_stream.h"    // for Stream
 #include "device_vector.cuh"
 #include "xgboost/host_device_vector.h"
 #include "xgboost/logging.h"
@@ -720,93 +721,9 @@ auto Reduce(Policy policy, InputIt first, InputIt second, Init init, Func reduce
   return aggregate;
 }
 
-class CUDAStreamView;
-
-class CUDAEvent {
-  std::unique_ptr<cudaEvent_t, void (*)(cudaEvent_t *)> event_;
-
- public:
-  explicit CUDAEvent(bool disable_timing = true)
-      : event_{[disable_timing] {
-                 auto e = new cudaEvent_t;
-                 dh::safe_cuda(cudaEventCreateWithFlags(
-                     e, disable_timing ? cudaEventDisableTiming : cudaEventDefault));
-                 return e;
-               }(),
-               [](cudaEvent_t *e) {
-                 if (e) {
-                   dh::safe_cuda(cudaEventDestroy(*e));
-                   delete e;
-                 }
-               }} {}
-
-  inline void Record(CUDAStreamView stream);  // NOLINT
-  // Define swap-based ctor to make sure an event is always valid.
-  CUDAEvent(CUDAEvent &&e) : CUDAEvent() { std::swap(this->event_, e.event_); }
-  CUDAEvent &operator=(CUDAEvent &&e) {
-    std::swap(this->event_, e.event_);
-    return *this;
-  }
-
-  operator cudaEvent_t() const { return *event_; }                // NOLINT
-  cudaEvent_t const *data() const { return this->event_.get(); }  // NOLINT
-  void Sync() { dh::safe_cuda(cudaEventSynchronize(*this->data())); }
-};
-
-class CUDAStreamView {
-  cudaStream_t stream_{nullptr};
-
- public:
-  explicit CUDAStreamView(cudaStream_t s) : stream_{s} {}
-  void Wait(CUDAEvent const &e) {
-#if defined(__CUDACC_VER_MAJOR__)
-#if __CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 0
-    // CUDA == 11.0
-    dh::safe_cuda(cudaStreamWaitEvent(stream_, cudaEvent_t{e}, 0));
-#else
-    // CUDA > 11.0
-    dh::safe_cuda(cudaStreamWaitEvent(stream_, cudaEvent_t{e}, cudaEventWaitDefault));
-#endif  // __CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 0:
-#else   // clang
-    dh::safe_cuda(cudaStreamWaitEvent(stream_, cudaEvent_t{e}, cudaEventWaitDefault));
-#endif  //  defined(__CUDACC_VER_MAJOR__)
-  }
-  operator cudaStream_t() const {  // NOLINT
-    return stream_;
-  }
-  cudaError_t Sync(bool error = true) {
-    if (error) {
-      dh::safe_cuda(cudaStreamSynchronize(stream_));
-      return cudaSuccess;
-    }
-    return cudaStreamSynchronize(stream_);
-  }
-};
-
-inline void CUDAEvent::Record(CUDAStreamView stream) {  // NOLINT
-  dh::safe_cuda(cudaEventRecord(*event_, cudaStream_t{stream}));
-}
-
-// Changing this has effect on prediction return, where we need to pass the pointer to
-// third-party libraries like cuPy
-inline CUDAStreamView DefaultStream() { return CUDAStreamView{cudaStreamPerThread}; }
-
-class CUDAStream {
-  cudaStream_t stream_;
-
- public:
-  CUDAStream() { dh::safe_cuda(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking)); }
-  ~CUDAStream() { dh::safe_cuda(cudaStreamDestroy(stream_)); }
-
-  [[nodiscard]] CUDAStreamView View() const { return CUDAStreamView{stream_}; }
-  [[nodiscard]] cudaStream_t Handle() const { return stream_; }
-
-  void Sync() { this->View().Sync(); }
-  void Wait(CUDAEvent const &e) { this->View().Wait(e); }
-};
-
 template <class Src, class Dst>
-void CopyTo(Src const &src, Dst *dst, CUDAStreamView stream = DefaultStream()) {
+void CopyTo(Src const &src, Dst *dst,
+            ::xgboost::curt::StreamView stream = ::xgboost::curt::DefaultStream()) {
   if (src.empty()) {
     dst->clear();
     return;
@@ -818,7 +735,6 @@ void CopyTo(Src const &src, Dst *dst, CUDAStreamView stream = DefaultStream()) {
   dh::safe_cuda(cudaMemcpyAsync(thrust::raw_pointer_cast(dst->data()), src.data(),
                                 src.size() * sizeof(SVT), cudaMemcpyDefault, stream));
 }
-
 
 /**
  * @brief Wrapper for the @ref cudaMemcpyBatchAsync .
@@ -868,7 +784,7 @@ template <cudaMemcpyKind kind, typename T, typename U>
 inline auto CachingThrustPolicy() {
   XGBCachingDeviceAllocator<char> alloc;
 #if THRUST_MAJOR_VERSION >= 2 || defined(XGBOOST_USE_RMM)
-  return thrust::cuda::par_nosync(alloc).on(DefaultStream());
+  return thrust::cuda::par_nosync(alloc).on(::xgboost::curt::DefaultStream());
 #else
   return thrust::cuda::par(alloc).on(DefaultStream());
 #endif  // THRUST_MAJOR_VERSION >= 2 || defined(XGBOOST_USE_RMM)

--- a/src/common/host_device_vector.cu
+++ b/src/common/host_device_vector.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2024, XGBoost contributors
+ * Copyright 2017-2025, XGBoost contributors
  */
 #include <thrust/fill.h>
 
@@ -7,6 +7,7 @@
 #include <cstddef>  // for size_t
 #include <cstdint>
 
+#include "cuda_stream.h"  // for DefaultStream
 #include "device_helpers.cuh"
 #include "device_vector.cuh"  // for DeviceUVector
 #include "xgboost/data.h"
@@ -92,7 +93,7 @@ class HostDeviceVectorImpl {
       gpu_access_ = GPUAccess::kWrite;
       SetDevice();
       auto s_data = dh::ToSpan(*data_d_);
-      dh::LaunchN(data_d_->size(), dh::DefaultStream(),
+      dh::LaunchN(data_d_->size(), curt::DefaultStream(),
                   [=] XGBOOST_DEVICE(size_t i) { s_data[i] = v; });
     }
   }
@@ -141,7 +142,7 @@ class HostDeviceVectorImpl {
       CHECK_EQ(this->Device(), other->Device());
       dh::safe_cuda(cudaMemcpyAsync(this->DevicePointer() + ori_size, ptr,
                                     other->Size() * sizeof(T), cudaMemcpyDeviceToDevice,
-                                    dh::DefaultStream()));
+                                    curt::DefaultStream()));
     }
   }
 
@@ -215,7 +216,7 @@ class HostDeviceVectorImpl {
     LazyResizeDevice(data_h_.size());
     SetDevice();
     dh::safe_cuda(cudaMemcpyAsync(data_d_->data(), data_h_.data(), data_d_->size() * sizeof(T),
-                                  cudaMemcpyHostToDevice, dh::DefaultStream()));
+                                  cudaMemcpyHostToDevice, curt::DefaultStream()));
     gpu_access_ = access;
   }
 
@@ -242,7 +243,7 @@ class HostDeviceVectorImpl {
       SetDevice();
       dh::safe_cuda(cudaMemcpyAsync(data_d_->data(), other->data_d_->data(),
                                     data_d_->size() * sizeof(T), cudaMemcpyDefault,
-                                    dh::DefaultStream()));
+                                    curt::DefaultStream()));
     }
   }
 
@@ -251,7 +252,7 @@ class HostDeviceVectorImpl {
     gpu_access_ = GPUAccess::kWrite;
     SetDevice();
     dh::safe_cuda(cudaMemcpyAsync(data_d_->data(), begin, data_d_->size() * sizeof(T),
-                                  cudaMemcpyDefault, dh::DefaultStream()));
+                                  cudaMemcpyDefault, curt::DefaultStream()));
   }
 
   void LazyResizeDevice(size_t new_size) {

--- a/src/common/ref_resource_view.cuh
+++ b/src/common/ref_resource_view.cuh
@@ -7,6 +7,7 @@
 #include <memory>   // for make_shared
 
 #include "cuda_context.cuh"     // for CUDAContext
+#include "cuda_stream.h"        // for StreamView
 #include "ref_resource_view.h"  // for RefResourceView
 #include "resource.cuh"         // for CudaAllocResource
 #include "xgboost/context.h"    // for Context
@@ -53,7 +54,7 @@ template <typename T>
 template <typename T>
 [[nodiscard]] RefResourceView<T> MakeFixedVecWithPinnedMemPool(
     std::shared_ptr<cuda_impl::HostPinnedMemPool> pool, std::size_t n_elements,
-    dh::CUDAStreamView stream) {
+    curt::StreamView stream) {
   auto resource = std::make_shared<common::HostPinnedMemPoolResource>(
       std::move(pool), n_elements * sizeof(T), stream);
   auto ref = RefResourceView{resource->DataAs<T>(), n_elements, resource};

--- a/src/common/resource.cuh
+++ b/src/common/resource.cuh
@@ -7,7 +7,7 @@
 #include <utility>     // for move
 
 #include "cuda_pinned_allocator.h"  // for SamAllocator, HostPinnedMemPool
-#include "device_helpers.cuh"       // for CUDAStreamView
+#include "cuda_stream.h"            // for StreamView
 #include "device_vector.cuh"        // for DeviceUVector, GrowOnlyVirtualMemVec
 #include "io.h"                     // for ResourceHandler, MMAPFile
 #include "xgboost/string_view.h"    // for StringView
@@ -85,12 +85,12 @@ class CudaPinnedResource : public ResourceHandler {
 class HostPinnedMemPoolResource : public ResourceHandler {
   std::shared_ptr<cuda_impl::HostPinnedMemPool> pool_;
   std::size_t n_bytes_;
-  dh::CUDAStreamView stream_;
+  curt::StreamView stream_;
   void* ptr_;
 
  public:
   explicit HostPinnedMemPoolResource(std::shared_ptr<cuda_impl::HostPinnedMemPool> pool,
-                                     std::size_t n_bytes, dh::CUDAStreamView stream)
+                                     std::size_t n_bytes, curt::StreamView stream)
       : ResourceHandler{kCudaPinnedMemPool},
         pool_{std::move(pool)},
         n_bytes_{n_bytes},

--- a/src/data/array_interface.cu
+++ b/src/data/array_interface.cu
@@ -1,10 +1,9 @@
 /**
- * Copyright 2021-2023, XGBoost Contributors
+ * Copyright 2021-2025, XGBoost Contributors
  */
 #include <cstdint>  // for int64_t
 
-#include "../common/common.h"
-#include "../common/device_helpers.cuh"  // for DefaultStream, CUDAEvent
+#include "../common/cuda_stream.h"  // for Event, StreamView, DefaultStream
 #include "array_interface.h"
 #include "xgboost/logging.h"
 
@@ -27,9 +26,9 @@ void ArrayInterfaceHandler::SyncCudaStream(std::int64_t stream) {
     case 2:
       // default per-thread stream
     default: {
-      dh::CUDAEvent e;
-      e.Record(dh::CUDAStreamView{reinterpret_cast<cudaStream_t>(stream)});
-      dh::DefaultStream().Wait(e);
+      curt::Event e;
+      e.Record(curt::StreamView{reinterpret_cast<cudaStream_t>(stream)});
+      curt::DefaultStream().Wait(e);
     }
   }
 }

--- a/src/data/cat_container.cuh
+++ b/src/data/cat_container.cuh
@@ -62,10 +62,10 @@ struct EncThrustPolicy {
 
   [[nodiscard]] auto ThrustPolicy() const {
     dh::XGBCachingDeviceAllocator<char> alloc;
-    auto exec = thrust::cuda::par_nosync(alloc).on(dh::DefaultStream());
+    auto exec = thrust::cuda::par_nosync(alloc).on(curt::DefaultStream());
     return exec;
   }
-  [[nodiscard]] auto Stream() const { return dh::DefaultStream(); }
+  [[nodiscard]] auto Stream() const { return curt::DefaultStream(); }
 };
 
 using EncPolicyT = enc::Policy<EncErrorPolicy, EncThrustPolicy>;

--- a/src/data/ellpack_page.cu
+++ b/src/data/ellpack_page.cu
@@ -15,6 +15,7 @@
 #include "../common/categorical.h"          // for IsCat
 #include "../common/cuda_context.cuh"       // for CUDAContext
 #include "../common/cuda_rt_utils.h"        // for SetDevice
+#include "../common/cuda_stream.h"          // for DefaultStream
 #include "../common/hist_util.cuh"          // for HistogramCuts
 #include "../common/ref_resource_view.cuh"  // for MakeFixedVecWithCudaMalloc
 #include "../common/transform_iterator.h"   // for MakeIndexTransformIter
@@ -496,7 +497,7 @@ EllpackPageImpl::EllpackPageImpl(Context const* ctx, GHistIndexMatrix const& pag
 
 EllpackPageImpl::~EllpackPageImpl() noexcept(false) {
   // Sync the stream to make sure all running CUDA kernels finish before deallocation.
-  auto status = dh::DefaultStream().Sync(false);
+  auto status = curt::DefaultStream().Sync(false);
   if (status != cudaSuccess) {
     auto str = cudaGetErrorString(status);
     // For external-memory, throwing here can trigger a series of calls to

--- a/src/data/ellpack_page_raw_format.cu
+++ b/src/data/ellpack_page_raw_format.cu
@@ -7,6 +7,7 @@
 #include <vector>   // for vector
 
 #include "../common/cuda_rt_utils.h"
+#include "../common/cuda_stream.h"          // for Event
 #include "../common/io.h"                   // for AlignedResourceReadStream, AlignedFileWriteStream
 #include "../common/ref_resource_view.cuh"  // for MakeFixedVecWithCudaMalloc
 #include "../common/ref_resource_view.h"    // for ReadVec, WriteVec
@@ -40,7 +41,8 @@ template <typename T>
   }
 
   *vec = common::MakeFixedVecWithCudaMalloc<T>(n);
-  dh::safe_cuda(cudaMemcpyAsync(vec->data(), ptr, n_bytes, cudaMemcpyDefault, dh::DefaultStream()));
+  dh::safe_cuda(
+      cudaMemcpyAsync(vec->data(), ptr, n_bytes, cudaMemcpyDefault, curt::DefaultStream()));
   return true;
 }
 }  // namespace
@@ -71,7 +73,7 @@ template <typename T>
 
   impl->SetCuts(this->cuts_);
 
-  dh::DefaultStream().Sync();
+  curt::DefaultStream().Sync();
   return true;
 }
 
@@ -92,7 +94,7 @@ template <typename T>
   bytes += fo->Write(impl->base_rowid);
   bytes += fo->Write(impl->NumSymbols());
 
-  dh::DefaultStream().Sync();
+  curt::DefaultStream().Sync();
   return bytes;
 }
 
@@ -110,7 +112,7 @@ template <typename T>
   };
 
   if (ConsoleLogger::GlobalVerbosity() == ConsoleLogger::LogVerbosity::kDebug) {
-    dh::CUDAEvent start{false}, stop{false};
+    curt::Event start{false}, stop{false};
     float milliseconds = 0;
     start.Record(ctx.CUDACtx()->Stream());
 
@@ -126,7 +128,7 @@ template <typename T>
     dispatch();
   }
 
-  dh::DefaultStream().Sync();
+  curt::DefaultStream().Sync();
 
   return true;
 }
@@ -136,7 +138,7 @@ template <typename T>
   xgboost_NVTX_FN_RANGE_C(3, 252, 198);
 
   bool new_page = fo->Write(page);
-  dh::DefaultStream().Sync();
+  curt::DefaultStream().Sync();
 
   if (new_page) {
     auto cache = fo->Share();

--- a/src/data/ellpack_page_source.cu
+++ b/src/data/ellpack_page_source.cu
@@ -11,7 +11,8 @@
 #include "../common/common.h"                // for HumanMemUnit, safe_cuda
 #include "../common/cuda_dr_utils.h"         // for CUDA_HW_DECOM_AVAILABLE
 #include "../common/cuda_rt_utils.h"         // for SetDevice, GetDrVersionGlobal
-#include "../common/cuda_stream_pool.cuh"    // for StreamPool
+#include "../common/cuda_stream.h"           // for Event
+#include "../common/cuda_stream_pool.h"      // for StreamPool
 #include "../common/device_compression.cuh"  // for CompressSnappy, MakeSnappyDecomprMgr
 #include "../common/device_helpers.cuh"      // for CUDAStreamView, DefaultStream
 #include "../common/numa_topo.h"             // for NumaMemCanCross, GetNumaMemBind
@@ -334,7 +335,7 @@ class EllpackHostCacheStreamImpl {
         auto out = out_impl->gidx_buffer.ToSpan().subspan(h_page->gidx_buffer.size_bytes(),
                                                           c_page->first.DecompressedBytes());
         dc::DecompressSnappy(stream, c_page->first, out, this->cache_->allow_decomp_fallback);
-        dh::CUDAEvent e;
+        curt::Event e;
         e.Record(stream);
         ctx->CUDACtx()->Stream().Wait(e);
       }

--- a/src/objective/adaptive.cu
+++ b/src/objective/adaptive.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2024, XGBoost Contributors
+ * Copyright 2022-2025, XGBoost Contributors
  */
 #include <thrust/sort.h>
 
@@ -8,6 +8,7 @@
 
 #include "../collective/aggregator.h"
 #include "../common/cuda_context.cuh"  // CUDAContext
+#include "../common/cuda_stream.h"     // for Event, Stream
 #include "../common/device_helpers.cuh"
 #include "../common/stats.cuh"
 #include "../tree/sample_position.h"  // for SamplePosition
@@ -69,10 +70,10 @@ void EncodeTreeLeafDevice(Context const* ctx, common::Span<bst_node_t const> pos
 
   dh::PinnedMemory pinned_pool;
   auto pinned = pinned_pool.GetSpan<char>(sizeof(size_t) + sizeof(bst_node_t));
-  dh::CUDAStream copy_stream;
+  curt::Stream copy_stream;
   size_t* h_num_runs = reinterpret_cast<size_t*>(pinned.subspan(0, sizeof(size_t)).data());
 
-  dh::CUDAEvent e;
+  curt::Event e;
   e.Record(cuctx->Stream());
   copy_stream.View().Wait(e);
   // flag for whether there's ignored position

--- a/src/tree/gpu_hist/evaluate_splits.cu
+++ b/src/tree/gpu_hist/evaluate_splits.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2024, XGBoost Contributors
+ * Copyright 2020-2025, XGBoost Contributors
  */
 #include <algorithm>  // for :max
 #include <limits>     // for numeric_limits
@@ -8,6 +8,7 @@
 #include "../../collective/communicator-inl.h"  // for GetWorldSize, GetRank
 #include "../../common/categorical.h"
 #include "../../common/cuda_context.cuh"  // for CUDAContext
+#include "../../common/cuda_stream.h"     // for Event
 #include "evaluate_splits.cuh"
 #include "expand_entry.cuh"
 
@@ -391,8 +392,8 @@ void GPUHistEvaluator::CopyToHost(const std::vector<bst_node_t> &nidx) {
   if (!has_categoricals_) return;
   auto d_cats = this->DeviceCatStorage(nidx);
   auto h_cats = this->HostCatStorage(nidx);
-  dh::CUDAEvent event;
-  event.Record(dh::DefaultStream());
+  curt::Event event;
+  event.Record(curt::DefaultStream());
   for (auto idx : nidx) {
     copy_stream_.View().Wait(event);
     dh::safe_cuda(cudaMemcpyAsync(

--- a/src/tree/gpu_hist/evaluate_splits.cuh
+++ b/src/tree/gpu_hist/evaluate_splits.cuh
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2024, XGBoost Contributors
+ * Copyright 2020-2025, XGBoost Contributors
  */
 #ifndef EVALUATE_SPLITS_CUH_
 #define EVALUATE_SPLITS_CUH_
@@ -7,6 +7,7 @@
 
 #include "../../common/categorical.h"
 #include "../../common/cuda_pinned_allocator.h"
+#include "../../common/cuda_stream.h"  // for Stream
 #include "../split_evaluator.h"
 #include "../updater_gpu_common.cuh"  // for DeviceSplitCandidate
 #include "expand_entry.cuh"
@@ -65,7 +66,7 @@ class GPUHistEvaluator {
   // host storage for categories for each node, used for sort based splits.
   std::vector<CatST, Alloc> h_split_cats_;
   // stream for copying categories from device back to host for expanding the decision tree.
-  dh::CUDAStream copy_stream_;
+  curt::Stream copy_stream_;
   // storage for sorted index of feature histogram, used for sort based splits.
   dh::device_vector<bst_feature_t> cat_sorted_idx_;
   // cached input for sorting the histogram, used for sort based splits.

--- a/src/tree/gpu_hist/evaluator.cu
+++ b/src/tree/gpu_hist/evaluator.cu
@@ -1,5 +1,5 @@
-/*!
- * Copyright 2022-2023 by XGBoost Contributors
+/**
+ * Copyright 2022-2025, XGBoost Contributors
  *
  * \brief Some components of GPU Hist evaluator, this file only exist to reduce nvcc
  *        compilation time.
@@ -8,6 +8,7 @@
 #include <thrust/sort.h>     // thrust::stable_sort
 
 #include "../../common/cuda_context.cuh"  // for CUDAContext
+#include "../../common/cuda_stream.h"     // for DefaultStream
 #include "../../common/device_helpers.cuh"
 #include "../../common/hist_util.h"  // common::HistogramCuts
 #include "evaluate_splits.cuh"
@@ -70,7 +71,7 @@ common::Span<bst_feature_t const> GPUHistEvaluator::SortHistogram(
     TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator) {
   dh::XGBCachingDeviceAllocator<char> alloc;
   auto sorted_idx = this->SortedIdx(d_inputs.size(), shared_inputs.feature_values.size());
-  dh::Iota(sorted_idx, dh::DefaultStream());
+  dh::Iota(sorted_idx, curt::DefaultStream());
   auto data = this->SortInput(d_inputs.size(), shared_inputs.feature_values.size());
   auto it = thrust::make_counting_iterator(0u);
   auto d_feature_idx = dh::ToSpan(feature_idx_);

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -15,6 +15,7 @@
 #include "../common/categorical.h"     // for KCatBitField
 #include "../common/cuda_context.cuh"  // for CUDAContext
 #include "../common/cuda_rt_utils.h"   // for SetDevice
+#include "../common/cuda_stream.h"     // for DefaultStream
 #include "../common/device_helpers.cuh"
 #include "../common/device_vector.cuh"  // for device_vector
 #include "../common/hist_util.h"        // for HistogramCuts
@@ -791,7 +792,7 @@ struct GPUHistMakerDevice {
       this->PartitionAndBuildHist(p_fmat, expand_set, valid_candidates, p_tree);
 
       this->EvaluateSplits(p_fmat, valid_candidates, *p_tree, new_candidates);
-      dh::DefaultStream().Sync();
+      curt::DefaultStream().Sync();
 
       driver.Push(new_candidates.begin(), new_candidates.end());
       expand_set = driver.Pop();

--- a/tests/cpp/common/test_cuda_host_allocator.cu
+++ b/tests/cpp/common/test_cuda_host_allocator.cu
@@ -7,8 +7,8 @@
 #include <vector>
 
 #include "../../../src/common/cuda_pinned_allocator.h"
-#include "../../../src/common/device_helpers.cuh"  // for DefaultStream
-#include "../../../src/common/numeric.h"           // for Iota
+#include "../../../src/common/cuda_stream.h"  // for DefaultStream
+#include "../../../src/common/numeric.h"      // for Iota
 
 namespace xgboost {
 TEST(CudaHostMalloc, Pinned) {
@@ -33,12 +33,12 @@ TEST(CudaHostMalloc, Managed) {
   loc.type = cudaMemLocationTypeDevice;
   loc.id = 0;
   dh::safe_cuda(
-      cudaMemPrefetchAsync(vec.data(), vec.size() * sizeof(float), loc, 0, dh::DefaultStream()));
+      cudaMemPrefetchAsync(vec.data(), vec.size() * sizeof(float), loc, 0, curt::DefaultStream()));
 #else
   dh::safe_cuda(
-      cudaMemPrefetchAsync(vec.data(), vec.size() * sizeof(float), 0, dh::DefaultStream()));
+      cudaMemPrefetchAsync(vec.data(), vec.size() * sizeof(float), 0, curt::DefaultStream()));
 #endif  // (CUDA_VERSION / 1000) >= 13
 #endif
-  dh::DefaultStream().Sync();
+  curt::DefaultStream().Sync();
 }
 }  // namespace xgboost

--- a/tests/cpp/common/test_cuda_rt_utils.cu
+++ b/tests/cpp/common/test_cuda_rt_utils.cu
@@ -7,7 +7,7 @@
 #include <cstdint>  // for int32_t
 #include <set>      // for set
 
-#include "../../../src/common/cuda_stream_pool.cuh"
+#include "../../../src/common/cuda_stream_pool.h"
 
 namespace xgboost::curt {
 TEST(RtUtils, StreamPool) {

--- a/tests/cpp/common/test_ref_resource_view.cu
+++ b/tests/cpp/common/test_ref_resource_view.cu
@@ -53,7 +53,7 @@ TEST(HostPinnedMemPool, Alloc) {
     // pool goes out of scope before refs does. Test memory safety.
     auto pool = std::make_shared<cuda_impl::HostPinnedMemPool>();
     for (std::size_t i = 0; i < 4; ++i) {
-      auto ref = MakeFixedVecWithPinnedMemPool<double>(pool, 128 + i, dh::DefaultStream());
+      auto ref = MakeFixedVecWithPinnedMemPool<double>(pool, 128 + i, curt::DefaultStream());
       refs.emplace_back(std::move(ref));
     }
     for (std::size_t i = 0; i < 4; ++i) {
@@ -69,7 +69,7 @@ TEST(HostPinnedMemPool, Alloc) {
     std::vector<std::future<RefResourceView<double>>> alloc_futs;
     for (std::int32_t i = 0, n = n_threads * 4; i < n; ++i) {
       auto fut = workers.Submit([i, pool] {
-        auto ref = MakeFixedVecWithPinnedMemPool<double>(pool, 128 + i, dh::DefaultStream());
+        auto ref = MakeFixedVecWithPinnedMemPool<double>(pool, 128 + i, curt::DefaultStream());
         return ref;
       });
       alloc_futs.emplace_back(std::move(fut));

--- a/tests/cpp/data/test_array_interface.cu
+++ b/tests/cpp/data/test_array_interface.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2024, XGBoost Contributors
+ * Copyright 2021-2025, XGBoost Contributors
  */
 #include <gtest/gtest.h>
 #include <xgboost/host_device_vector.h>
@@ -23,7 +23,7 @@ TEST(ArrayInterface, Stream) {
   HostDeviceVector<float> storage;
   auto arr_str = RandomDataGenerator{kRows, kCols, 0}.GenerateArrayInterface(&storage);
 
-  dh::CUDAStream stream;
+  curt::Stream stream;
 
   auto j_arr = Json::Load(StringView{arr_str});
   j_arr["stream"] = Integer(reinterpret_cast<int64_t>(stream.Handle()));

--- a/tests/cpp/data/test_ellpack_page.cu
+++ b/tests/cpp/data/test_ellpack_page.cu
@@ -7,6 +7,7 @@
 
 #include "../../../src/common/categorical.h"          // for AsCat
 #include "../../../src/common/compressed_iterator.h"  // for CompressedByteT
+#include "../../../src/common/cuda_stream.h"          // for DefaultStream
 #include "../../../src/common/hist_util.h"
 #include "../../../src/data/device_adapter.cuh"  // for CupyAdapter
 #include "../../../src/data/ellpack_page.cuh"
@@ -364,7 +365,7 @@ class CompressedDense : public ::testing::TestWithParam<std::size_t> {
                         false,      d_row_counts,    {},
                         n_features, n_samples,       cuts};
     this->CheckBasic(&ctx, batch, null_column, impl);
-    dh::DefaultStream().Sync();
+    curt::DefaultStream().Sync();
   }
 
   void CheckFromToGHist(std::size_t null_column) {


### PR DESCRIPTION
Aside from cleaning up the device helpers, we need to use them in CPP files in addition to cu files.