### PR TITLE
[CI] Use macos-15-intel instead of unsupported macos-13

### DIFF
--- a/.github/workflows/jvm_tests.yml
+++ b/.github/workflows/jvm_tests.yml
@@ -77,7 +77,7 @@ jobs:
           - description: "MacOS (Intel)"
             script: ops/pipeline/build-jvm-macos-intel.sh
             libname: libxgboost4j_intel.dylib
-            runner: macos-14-large
+            runner: macos-15-intel
     steps:
       - uses: actions/checkout@v4
         with:
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-14-large]
+        os: [windows-latest, macos-15-intel]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -152,7 +152,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('./jvm-packages/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2-${{ hashFiles('./jvm-packages/pom.xml') }}
       - name: Test XGBoost4J (Core) on macos
-        if: matrix.os == 'macos-14-large'
+        if: matrix.os == 'macos-15-intel'
         run: |
           cd jvm-packages
           mvn test -B -pl :xgboost4j_2.12 -Duse.openmp=OFF

--- a/.github/workflows/jvm_tests.yml
+++ b/.github/workflows/jvm_tests.yml
@@ -205,7 +205,7 @@ jobs:
           SCALA_VERSION: ${{ matrix.scala_version }}
 
   deploy-jvm-packages:
-    name: Deploy JVM packages to S3 (${{ matrix.variant.name }})
+    name: Deploy JVM packages to S3 (${{ matrix.variant.name }}, Scala ${{ matrix.scala_version }})
     needs: [build-jvm-gpu, build-test-jvm-packages, test-jvm-packages-gpu]
     runs-on:
       - runs-on

--- a/.github/workflows/jvm_tests.yml
+++ b/.github/workflows/jvm_tests.yml
@@ -77,7 +77,7 @@ jobs:
           - description: "MacOS (Intel)"
             script: ops/pipeline/build-jvm-macos-intel.sh
             libname: libxgboost4j_intel.dylib
-            runner: macos-13
+            runner: macos-14
     steps:
       - uses: actions/checkout@v4
         with:
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-13]
+        os: [windows-latest, macos-14]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -152,7 +152,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('./jvm-packages/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2-${{ hashFiles('./jvm-packages/pom.xml') }}
       - name: Test XGBoost4J (Core) on macos
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
         run: |
           cd jvm-packages
           mvn test -B -pl :xgboost4j_2.12 -Duse.openmp=OFF

--- a/.github/workflows/jvm_tests.yml
+++ b/.github/workflows/jvm_tests.yml
@@ -77,7 +77,7 @@ jobs:
           - description: "MacOS (Intel)"
             script: ops/pipeline/build-jvm-macos-intel.sh
             libname: libxgboost4j_intel.dylib
-            runner: macos-14
+            runner: macos-14-large
     steps:
       - uses: actions/checkout@v4
         with:
@@ -132,12 +132,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-14]
+        os: [windows-latest, macos-14-large]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '8'
@@ -152,7 +152,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('./jvm-packages/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2-${{ hashFiles('./jvm-packages/pom.xml') }}
       - name: Test XGBoost4J (Core) on macos
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-14-large'
         run: |
           cd jvm-packages
           mvn test -B -pl :xgboost4j_2.12 -Duse.openmp=OFF

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14-large, windows-latest, ubuntu-latest]
+        os: [macos-15-intel, windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,13 +32,13 @@ jobs:
       - name: Install extra package for MacOS
         run: |
           mamba install -c conda-forge llvm-openmp
-        if: matrix.os == 'macos-14-large'
+        if: matrix.os == 'macos-15-intel'
       - name: Build and install XGBoost
         run: bash ops/pipeline/test-python-sdist.sh
 
   python-tests-on-macos:
-    name: Test XGBoost Python package on macos-14-large
-    runs-on: macos-14-large
+    name: Test XGBoost Python package on macos-15-intel
+    runs-on: macos-15-intel
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, windows-latest, ubuntu-latest]
+        os: [macos-14-large, windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,13 +32,13 @@ jobs:
       - name: Install extra package for MacOS
         run: |
           mamba install -c conda-forge llvm-openmp
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-14-large'
       - name: Build and install XGBoost
         run: bash ops/pipeline/test-python-sdist.sh
 
   python-tests-on-macos:
-    name: Test XGBoost Python package on macos-14
-    runs-on: macos-14
+    name: Test XGBoost Python package on macos-14-large
+    runs-on: macos-14-large
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, windows-latest, ubuntu-latest]
+        os: [macos-14, windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,13 +32,13 @@ jobs:
       - name: Install extra package for MacOS
         run: |
           mamba install -c conda-forge llvm-openmp
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
       - name: Build and install XGBoost
         run: bash ops/pipeline/test-python-sdist.sh
 
   python-tests-on-macos:
-    name: Test XGBoost Python package on macos-13
-    runs-on: macos-13
+    name: Test XGBoost Python package on macos-14
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python_wheels_macos.yml
+++ b/.github/workflows/python_wheels_macos.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: macos-14
+        - os: macos-14-large
           platform_id: macosx_x86_64
         - os: macos-14
           platform_id: macosx_arm64

--- a/.github/workflows/python_wheels_macos.yml
+++ b/.github/workflows/python_wheels_macos.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: macos-13
+        - os: macos-14
           platform_id: macosx_x86_64
         - os: macos-14
           platform_id: macosx_arm64

--- a/.github/workflows/python_wheels_macos.yml
+++ b/.github/workflows/python_wheels_macos.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: macos-14-large
+        - os: macos-15-intel
           platform_id: macosx_x86_64
         - os: macos-14
           platform_id: macosx_arm64


### PR DESCRIPTION
Hopefully this will fix the failing CI jobs, e.g. https://github.com/dmlc/xgboost/actions/runs/18171596832/job/51727385933