### PR TITLE
fix: best_iteration missing in xgb.cv results object

### DIFF
--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -297,6 +297,9 @@ xgb.cv <- function(params = xgb.params(), data, nrounds, nfold,
     folds = folds
   )
   ret <- c(ret, cb_outputs)
+  if ("early_stop" %in% cb_names && !("best_iteration" %in% names(ret)) {
+    ret$best_iteration <- ret$early_stop$best_iteration
+  }
 
   class(ret) <- 'xgb.cv.synchronous'
   return(invisible(ret))


### PR DESCRIPTION
Version 3.1.0's R-documentation of `xgb.cv` still lists "best_iteration" as element of the resulting object, however, it currently (at least when using early-stopping) just can be accessed from `cv_results$early_stop$best_iteration`.

As I was asked to update the `mllrnrs` R package to the new xgboost version, I would like to know, which "best_iteration" I can rely on in my code?

Thanks in advance,
Lorenz