### PR TITLE
[R] Correct docs about attributes of cv object

### DIFF
--- a/R-package/R/xgb.cv.R
+++ b/R-package/R/xgb.cv.R
@@ -104,7 +104,7 @@
 #' print(cv)
 #' print(cv, verbose = TRUE)
 #'
-#' Callbacks might add additional attributes, separated by the name of the callback
+#' # Callbacks might add additional attributes, separated by the name of the callback
 #' cv$early_stop$best_iteration
 #' head(cv$cv_predict$pred)
 #' @export

--- a/R-package/man/xgb.cv.Rd
+++ b/R-package/man/xgb.cv.Rd
@@ -215,7 +215,7 @@ cv <- xgb.cv(
 print(cv)
 print(cv, verbose = TRUE)
 
-Callbacks might add additional attributes, separated by the name of the callback
+# Callbacks might add additional attributes, separated by the name of the callback
 cv$early_stop$best_iteration
 head(cv$cv_predict$pred)
 }


### PR DESCRIPTION
closes https://github.com/dmlc/xgboost/pull/11731

This PR updates the docs of the CV object by removing an attribute which is now under a callback name instead of under the object directly, expanding the in-doc example to make it more clear.