### PR TITLE
Javadocs for TrackerProperties.java

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/TrackerProperties.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/TrackerProperties.java
@@ -7,6 +7,9 @@ import java.util.Properties;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+/**
+ * Class to load properties from the file xgboost-tracker.properties.
+ */
 public class TrackerProperties {
   private static String PROPERTIES_FILENAME = "xgboost-tracker.properties";
   private static String HOST_IP = "host-ip";
@@ -46,10 +49,28 @@ public class TrackerProperties {
     }
   }
 
+  /**
+   * Static method to return a non null initialized instance of TrackerProperties
+   * since the constructor is a private constructor not supposed to be accessed
+   * outside this class.
+   * @return The non null initialized instance.
+   */
   public static TrackerProperties getInstance() {
     return instance;
   }
 
+  /**
+   * Get the host IP address used by the tracker. To correctly use this function,
+   * the property must be defined in the following way in the xgboost-tracker.properties file:
+   *
+   * {@code host-ip=<example-ip-address>}
+   *
+   * Example:
+   *
+   * {code host-ip=127.0.0.1}
+   *
+   * @return The host IP address as a String, null if not defined.
+   */
   public String getHostIp(){
     return this.properties.getProperty(HOST_IP);
   }


### PR DESCRIPTION
Adding the javadocs for the class `TrackerProperties.java` since there is no information available to the user on how to use this class to read the XGBoost Tracker properties.

Documentation explains to the user that the `xgboost-tracker.properties` must be present in the `resources` directory to ensure that the tracker properties are read correctly without throwing any errors.

Documentation has also been shown on how the host IP address should be declared in `xgboost-tracker.properties` so that it can be read properly using the `getHostIp()` function. 