### PR TITLE
Remove _check_glibc check

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -76,7 +76,7 @@ from .compat import (
     is_pyarrow_available,
     py_str,
 )
-from .libpath import find_lib_path, is_sphinx_build
+from .libpath import find_lib_path
 
 if TYPE_CHECKING:
     from pandas import DataFrame as PdDataFrame


### PR DESCRIPTION
Follow-up to #11673.

No need to check the GLIBC version, since we no longer provide wheels for `manylinux2014`.