### PR TITLE
Fix ranking tests with weight norm.

### DIFF
--- a/tests/cpp/objective/test_lambdarank_obj.cc
+++ b/tests/cpp/objective/test_lambdarank_obj.cc
@@ -56,14 +56,18 @@ void TestNDCGGPair(Context const* ctx) {
                             {0, 2, 4},
                             {2.06611f, -2.06611f, 0.0f, 0.0f},
                             {2.169331f, 2.169331f, 0.0f, 0.0f});
-
-    CheckRankingObjFunction(obj,
-                            {0, 0.1f, 0, 0.1f},
-                            {0,   1, 0, 1},
-                            {2.0f, 2.0f},
-                            {0, 2, 4},
-                            {2.06611f, -2.06611f, 2.06611f, -2.06611f},
-                            {2.169331f, 2.169331f, 2.169331f, 2.169331f});
+  }
+  {
+    std::unique_ptr<xgboost::ObjFunction> obj{xgboost::ObjFunction::Create("rank:ndcg", ctx)};
+    obj->Configure(Args{{"lambdarank_pair_method", "topk"}});
+    float weight_norm = 0.5;  // n_groups / sum_weights
+    std::vector<float> out_grad{2.06611f, -2.06611f, 2.06611f, -2.06611f};
+    std::vector<float> out_hess{2.169331f, 2.169331f, 2.169331f, 2.169331f};
+    auto norm = [=](auto v) { return v * weight_norm; };
+    std::transform(out_grad.begin(), out_grad.end(), out_grad.begin(), norm);
+    std::transform(out_hess.begin(), out_hess.end(), out_hess.begin(), norm);
+    CheckRankingObjFunction(obj, {0, 0.1f, 0, 0.1f}, {0, 1, 0, 1}, {2.0f, 2.0f}, {0, 2, 4},
+                            out_grad, out_hess);
   }
 
   std::unique_ptr<xgboost::ObjFunction> obj{xgboost::ObjFunction::Create("rank:ndcg", ctx)};
@@ -320,8 +324,7 @@ TEST(LambdaRank, MAPStat) {
 
 void TestMAPGPair(Context const* ctx) {
   std::unique_ptr<xgboost::ObjFunction> obj{xgboost::ObjFunction::Create("rank:map", ctx)};
-  Args args;
-  obj->Configure(args);
+  obj->Configure({});
 
   CheckConfigReload(obj, "rank:map");
 
@@ -332,14 +335,20 @@ void TestMAPGPair(Context const* ctx) {
                           {0, 2, 4},                                           // group
                           {1.2054923f, -1.2054923f, 1.2054923f, -1.2054923f},  // out grad
                           {1.2657166f, 1.2657166f, 1.2657166f, 1.2657166f});
+
+  obj.reset(xgboost::ObjFunction::Create("rank:map", ctx));
+  obj->Configure({});
+
   // disable the second query group with 0 weight
-  CheckRankingObjFunction(obj,                                  // obj
-                          {0, 0.1f, 0, 0.1f},                   // score
-                          {0, 1, 0, 1},                         // label
-                          {2.0f, 0.0f},                         // weight
-                          {0, 2, 4},                            // group
-                          {1.2054923f, -1.2054923f, .0f, .0f},  // out grad
-                          {1.2657166f, 1.2657166f, .0f, .0f});
+  auto w = 2.0f;  // weight for the first group
+  // weight norm is 1.0 (n_groups / sum_weights)
+  CheckRankingObjFunction(obj,                                          // obj
+                          {0, 0.1f, 0, 0.1f},                           // score
+                          {0, 1, 0, 1},                                 // label
+                          {w, 0.0f},                                    // weight
+                          {0, 2, 4},                                    // group
+                          {1.2054923f * w, -1.2054923f * w, .0f, .0f},  // out grad
+                          {1.2657166f * w, 1.2657166f * w, .0f, .0f});
 }
 
 TEST(LambdaRank, MAPGPair) {


### PR DESCRIPTION
The test might fail if the objective cache is renewed. This PR makes sure the objective and its cache is recreated for each test case, and multiple the normalization factor into the expected results.