### PR TITLE
Fix loading nccl 2.28.

### DIFF
--- a/python-package/xgboost/collective.py
+++ b/python-package/xgboost/collective.py
@@ -315,7 +315,6 @@ def _find_nccl() -> Optional[str]:
     files = os.listdir(dirname)
     if not files:
         return None
-    assert len(files) >= 1
 
     libname: Optional[str] = None
     for name in files:


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/11804

The latest nccl pypi package no longer has the `__file__` attribute in its modules (it no longer has modules). We will use the `__path__` from the namespace instead.