### PR TITLE
[R] More informative error when passing factors to DMatrix

### DIFF
--- a/R-package/R/xgb.DMatrix.R
+++ b/R-package/R/xgb.DMatrix.R
@@ -1063,6 +1063,9 @@ setinfo.xgb.DMatrix <- function(object, name, info) {
   if (name == "label") {
     if (NROW(info) != nrow(object))
       stop("The length of labels must equal to the number of rows in the input data")
+    if (is.factor(info)) {
+      stop("'label' must be a numeric variable.")
+    }
     .Call(XGDMatrixSetInfo_R, object, name, info)
     return(TRUE)
   }


### PR DESCRIPTION
DMatrix assumes that `label` is passed as an already-encoded vector or matrix. This PR makes it error out early when passing a `factor` type which is not supported, with an informative message, instead of erroring out later with some error that's harder to understand.