### PR TITLE
[CI] Disable spot instances for all workers

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -22,6 +22,7 @@ runners:
     cpu: 16
     family: ["c7i-flex", "c7i", "c7a", "c5", "c5a"]
     image: linux-amd64
+    spot: "false"
   linux-amd64-gpu:
     family: ["g4dn.xlarge"]
     image: linux-amd64
@@ -34,6 +35,7 @@ runners:
     cpu: 16
     family: ["c6g", "c7g"]
     image: linux-arm64
+    spot: "false"
   windows-gpu:
     family: ["g4dn.2xlarge"]
     image: windows-amd64
@@ -42,3 +44,4 @@ runners:
     cpu: 32
     family: ["c7i-flex", "c7i", "c7a", "c5", "c5a"]
     image: windows-amd64
+    spot: "false"


### PR DESCRIPTION
Spot instances are prone to interruptions. Disable them so that our CI jobs don't get interrupted randomly.

cc @trivialfis 