### PR TITLE
Updates for RMM 25.12 compatibility

### DIFF
--- a/src/common/device_vector.cuh
+++ b/src/common/device_vector.cuh
@@ -9,7 +9,14 @@
 #if defined(XGBOOST_USE_RMM) && XGBOOST_USE_RMM == 1
 #include <cuda/memory_resource>               // for async_resource_ref
 #include <cuda/stream_ref>                    // for stream_ref
+
+// TODO(hcho3): Remove this guard once we require Rapids 25.12+
+#if (RMM_MAJOR_VERSION == 25 && RMM_MINOR_VERSION == 12) || RMM_MAJOR_VERSION >= 26
 #include <rmm/mr/per_device_resource.hpp>     // for get_current_device_resource
+#else  // (RMM_MAJOR_VERSION == 25 && RMM_MINOR_VERSION == 12) || RMM_MAJOR_VERSION >= 26
+#include <rmm/mr/device/device_memory_resource.hpp>  // for device_memory_resource
+#include <rmm/mr/device/per_device_resource.hpp>     // for get_current_device_resource
+#endif  // (RMM_MAJOR_VERSION == 25 && RMM_MINOR_VERSION == 12) || RMM_MAJOR_VERSION >= 26
 
 #include "xgboost/global_config.h"  // for GlobalConfigThreadLocalStore
 
@@ -265,7 +272,13 @@ namespace detail {
  */
 template <typename T>
 class ThrustAllocMrAdapter : public thrust::device_malloc_allocator<T> {
+
+// TODO(hcho3): Remove this guard once we require Rapids 25.12+
+#if (RMM_MAJOR_VERSION == 25 && RMM_MINOR_VERSION == 12) || RMM_MAJOR_VERSION >= 26
   DeviceAsyncResourceRef mr_{rmm::mr::get_current_device_resource_ref()};
+#else  // (RMM_MAJOR_VERSION == 25 && RMM_MINOR_VERSION == 12) || RMM_MAJOR_VERSION >= 26
+  DeviceAsyncResourceRef mr_{rmm::mr::get_current_device_resource()};
+#endif  // (RMM_MAJOR_VERSION == 25 && RMM_MINOR_VERSION == 12) || RMM_MAJOR_VERSION >= 26
 
  public:
   using Super = thrust::device_malloc_allocator<T>;

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -29,9 +29,18 @@
 #if defined(XGBOOST_USE_RMM) && XGBOOST_USE_RMM == 1
 #include <memory>
 #include <vector>
+
+// TODO(hcho3): Remove this guard once we require Rapids 25.12+
+#if (RMM_MAJOR_VERSION == 25 && RMM_MINOR_VERSION == 12) || RMM_MAJOR_VERSION >= 26
 #include "rmm/mr/per_device_resource.hpp"
 #include "rmm/mr/cuda_memory_resource.hpp"
 #include "rmm/mr/pool_memory_resource.hpp"
+#else  // (RMM_MAJOR_VERSION == 25 && RMM_MINOR_VERSION == 12) || RMM_MAJOR_VERSION >= 26
+#include "rmm/mr/device/per_device_resource.hpp"
+#include "rmm/mr/device/cuda_memory_resource.hpp"
+#include "rmm/mr/device/pool_memory_resource.hpp"
+#endif  // (RMM_MAJOR_VERSION == 25 && RMM_MINOR_VERSION == 12) || RMM_MAJOR_VERSION >= 26
+
 #endif  // defined(XGBOOST_USE_RMM) && XGBOOST_USE_RMM == 1
 
 bool FileExists(const std::string& filename) {


### PR DESCRIPTION
This PR updates the usage of RMM for compatibility with 25.12. The main changes are migrations in header locations and changes in the allocation API to align with CCCL's memory resource design.

This change requires RMM 25.12 or higher, so we may need some updates in the CI system.
