### PR TITLE
[R] Fix memory safety issues

### DIFF
--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -685,8 +685,8 @@ XGB_DLL SEXP XGProxyDMatrixCreate_R() {
   CHECK_CALL(XGProxyDMatrixCreate(&proxy_dmat_handle));
   R_SetExternalPtrAddr(out, proxy_dmat_handle);
   R_RegisterCFinalizerEx(out, _DMatrixFinalizer, TRUE);
-  Rf_unprotect(1);
   R_API_END();
+  Rf_unprotect(1);
   return out;
 }
 
@@ -829,8 +829,8 @@ SEXP XGDMatrixCreateFromCallbackGeneric_R(
 
   R_SetExternalPtrAddr(out, out_dmat);
   R_RegisterCFinalizerEx(out, _DMatrixFinalizer, TRUE);
-  Rf_unprotect(2);
   R_API_END();
+  Rf_unprotect(2);
   return out;
 }
 


### PR DESCRIPTION
Fixes a few issues detected by rchk.

@trivialfis You'll likely be asked to resubmit a fixed version of xgboost to CRAN after a few days. This PR will need to be backported if there isn't any 3.2 release by then. There might be more required changes from other checks, so let's wait for their email before resubmitting.