### PR TITLE
[CI] Add ARM CUDA worker on RunsOn

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -36,6 +36,10 @@ runners:
     family: ["c6g", "c7g"]
     image: linux-arm64
     spot: "false"
+  linux-arm64-gpu:
+    family: ["g5g.xlarge"]
+    image: linux-arm64
+    spot: "false"
   windows-gpu:
     family: ["g4dn.2xlarge"]
     image: windows-amd64


### PR DESCRIPTION
The CI always uses `runs-on.yml` from the `master` branch. So `runs-on.yml` needs to be updated before we can write workflow pipelines using it.