### PR TITLE
[CI] Set up a nightly pipeline to test XGBoost with latest CCCL/RMM

### DIFF
--- a/.github/workflows/cccl_nightly.yml
+++ b/.github/workflows/cccl_nightly.yml
@@ -1,0 +1,71 @@
+name: Test XGBoost with latest CCCL and RMM
+on:
+  workflow_dispatch:  # Can be manually triggered
+  schedule:
+    - cron: "0 7 * * *"  # Run once daily
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  get-latest-cccl-version:
+    name: Query the latest version of CCCL
+    runs-on: ubuntu-latest
+    outputs:
+      cccl_version: ${{ steps.query_version_step.outputs.cccl_version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: query_version_step
+        name: Query version
+        run: |
+          source ops/pipeline/query-latest-cccl.sh
+          echo "cccl_version=${CCCL_VERSION}" >> "$GITHUB_OUTPUT"
+
+  test-latest-cccl:
+    name: Test building XGBoost with latest CCCL (RC included)
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=linux-amd64-cpu
+      - tag=nightly-cccl
+    needs: get-latest-cccl-version
+    steps:
+      # Restart Docker daemon so that it recognizes the ephemeral disks
+      - run: sudo systemctl restart docker
+      - uses: actions/checkout@v4
+        with:
+          submodules: "true"
+      - name: Log into Docker registry (AWS ECR)
+        run: bash ops/pipeline/login-docker-registry.sh
+      - name: Build XGBoost with latest CCCL
+        run: |
+          bash ops/pipeline/nightly-test-cccl.sh ${{ needs.get-latest-cccl-version.outputs.cccl_version }}
+
+  test-latest-rmm:
+    name: Test building XGBoost with latest nightly version of RMM
+    # This job uses the stable CCCL used by RMM and rest of RAPIDS
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=linux-amd64-cpu
+      - tag=nightly-rmm
+    steps:
+      # Restart Docker daemon so that it recognizes the ephemeral disks
+      - run: sudo systemctl restart docker
+      - uses: actions/checkout@v4
+        with:
+          submodules: "true"
+      - name: Log into Docker registry (AWS ECR)
+        run: bash ops/pipeline/login-docker-registry.sh
+      - name: Build XGBoost with latest RMM
+        run: |
+          bash ops/pipeline/nightly-test-rmm.sh

--- a/ops/pipeline/nightly-test-cccl-impl.sh
+++ b/ops/pipeline/nightly-test-cccl-impl.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+## Companion script for ops/pipeline/nightly-test-cccl.sh
+
+set -eo pipefail
+# Cannot set -u before Conda env activation
+
+if [[ "$#" -lt 1 ]]
+then
+  echo "Usage: $0 [cccl_version]"
+  exit 1
+fi
+cccl_version="$1"
+
+# Set up Conda env
+gosu root chown -R $(id -u):$(id -g) /opt/miniforge/envs /opt/miniforge/pkgs/cache
+gosu root chown $(id -u):$(id -g) /opt/miniforge/pkgs
+mamba create -y -n cccl_test -c conda-forge python=3.13 \
+  cuda-version=13.0 cxx-compiler cuda-cudart-dev cuda-nvcc gcc_linux-64=14.* ninja \
+  gtest nccl
+
+source activate cccl_test
+
+set -xu
+git clone https://github.com/NVIDIA/cccl.git -b "${cccl_version}" --depth 1
+cd cccl
+cmake . -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -GNinja
+ninja install
+
+if [[ "${BUILD_ONLY_SM75:-}" == 1 ]]
+then
+  cmake_args='-DGPU_COMPUTE_VER=75'
+else
+  cmake_args=''
+fi
+
+cd ..
+mkdir -p build
+cd build
+cmake .. \
+  -GNinja \
+  -DCMAKE_PREFIX_PATH="${CONDA_PREFIX}" \
+  -DUSE_CUDA=ON \
+  -DUSE_OPENMP=ON \
+  -DHIDE_CXX_SYMBOLS=ON \
+  -DUSE_NCCL=ON \
+  -DUSE_DLOPEN_NCCL=ON \
+  -DGOOGLE_TEST=ON \
+  -DENABLE_ALL_WARNINGS=ON \
+  -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF \
+  ${cmake_args}
+ninja -v

--- a/ops/pipeline/nightly-test-cccl.sh
+++ b/ops/pipeline/nightly-test-cccl.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+## Test XGBoost against latest CCCL
+
+set -euo pipefail
+
+if [[ "$#" -lt 1 ]]
+then
+  echo "Usage: $0 [cccl_version]"
+  exit 1
+fi
+cccl_version="$1"
+
+source ops/pipeline/classify-git-branch.sh
+source ops/pipeline/get-docker-registry-details.sh
+source ops/pipeline/get-image-tag.sh
+
+IMAGE_REPO="xgb-ci.gpu_build_cuda13_rockylinux8"
+BUILD_IMAGE_URI="${DOCKER_REGISTRY_URL}/${IMAGE_REPO}:${IMAGE_TAG}"
+
+echo "--- Build XGBoost with CCCL ${cccl_version}"
+
+if [[ ($is_pull_request == 1) || ($is_release_branch == 0) ]]
+then
+  export BUILD_ONLY_SM75=1
+else
+  export BUILD_ONLY_SM75=0
+fi
+echo "BUILD_ONLY_SM75=${BUILD_ONLY_SM75}"
+
+set -x
+
+python3 ops/docker_run.py \
+  --image-uri ${BUILD_IMAGE_URI} \
+  --run-args='-e BUILD_ONLY_SM75' \
+  -- ops/pipeline/nightly-test-cccl-impl.sh "${cccl_version}"

--- a/ops/pipeline/nightly-test-rmm-impl.sh
+++ b/ops/pipeline/nightly-test-rmm-impl.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+## Companion script for ops/pipeline/nightly-test-rmm.sh
+
+set -eo pipefail
+# Cannot set -u before Conda env activation
+
+if [[ "$#" -lt 1 ]]
+then
+  echo "Usage: $0 [rmm_version]"
+  exit 1
+fi
+rmm_version="$1"
+
+# Set up Conda env
+gosu root chown -R $(id -u):$(id -g) /opt/miniforge/envs /opt/miniforge/pkgs/cache
+gosu root chown $(id -u):$(id -g) /opt/miniforge/pkgs
+mamba create -y -n rmm_test -c conda-forge -c rapidsai-nightly python=3.13 \
+  cuda-version=13.0 cxx-compiler cuda-cudart-dev cuda-nvcc gcc_linux-64=14.* ninja \
+  gtest nccl "rmm=${rmm_version%.*}.*,>=0.0.0a0"
+
+source activate rmm_test
+
+if [[ "${BUILD_ONLY_SM75:-}" == 1 ]]
+then
+  cmake_args='-DGPU_COMPUTE_VER=75'
+else
+  cmake_args=''
+fi
+
+cmake_args="${cmake_args} -DPLUGIN_RMM=ON"
+
+mkdir -p build
+cd build
+cmake .. \
+  -GNinja \
+  -DCMAKE_PREFIX_PATH="${CONDA_PREFIX}" \
+  -DUSE_CUDA=ON \
+  -DUSE_OPENMP=ON \
+  -DHIDE_CXX_SYMBOLS=ON \
+  -DUSE_NCCL=ON \
+  -DUSE_DLOPEN_NCCL=ON \
+  -DGOOGLE_TEST=ON \
+  -DENABLE_ALL_WARNINGS=ON \
+  -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF \
+  ${cmake_args}
+ninja -v

--- a/ops/pipeline/nightly-test-rmm.sh
+++ b/ops/pipeline/nightly-test-rmm.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+## Test XGBoost against latest RMM
+
+set -euo pipefail
+
+source ops/pipeline/classify-git-branch.sh
+source ops/pipeline/get-docker-registry-details.sh
+source ops/pipeline/get-image-tag.sh
+
+IMAGE_REPO="xgb-ci.gpu_build_cuda13_rockylinux8"
+BUILD_IMAGE_URI="${DOCKER_REGISTRY_URL}/${IMAGE_REPO}:${IMAGE_TAG}"
+
+export rmm_version="$(wget https://raw.githubusercontent.com/rapidsai/rmm/refs/heads/main/VERSION -q -O -)"
+
+echo "--- Build XGBoost with RMM ${rmm_version}"
+
+if [[ ($is_pull_request == 1) || ($is_release_branch == 0) ]]
+then
+  export BUILD_ONLY_SM75=1
+else
+  export BUILD_ONLY_SM75=0
+fi
+
+set -x
+
+python3 ops/docker_run.py \
+  --image-uri ${BUILD_IMAGE_URI} \
+  --run-args='-e BUILD_ONLY_SM75' \
+  -- ops/pipeline/nightly-test-rmm-impl.sh "${rmm_version}"

--- a/ops/pipeline/query-latest-cccl.sh
+++ b/ops/pipeline/query-latest-cccl.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+## Query latest version of CCCL using GitHub CLI
+## Note: RC version may be selected if available
+
+set -euo pipefail
+
+tmpfile="$(mktemp /tmp/abc-script.XXXXXX)"
+cat >"$tmpfile" <<EOL
+import fileinput
+
+from packaging.version import InvalidVersion, Version
+
+versions = []
+for e in fileinput.input():
+    try:
+        tag = e.strip()
+        versions.append((tag, Version(tag)))
+    except InvalidVersion:
+        pass
+print(max(versions, key=lambda x : x[1])[0])
+EOL
+export CCCL_VERSION=$(
+  gh api repos/NVIDIA/cccl/tags --paginate --jq '.[].name' | python3 "$tmpfile"
+)
+echo "--- Latest CCCL version: ${CCCL_VERSION}"
+rm "$tmpfile"


### PR DESCRIPTION
Example CI run: https://github.com/dmlc/xgboost/actions/runs/20156973678, where the pipeline detects breakage with CCCL 3.2.0 RC1 and RMM 26.02 nightly.

There are two jobs in the pipeline:
* `test-latest-cccl` builds XGBoost with the latest version of CCCL (RC included). RMM is turned off for this job. (This is to avoid incompatibilities between latest CCCL and latest RMM.)
* `test-latest-rmm` builds XGBoost with the latest development version of RMM. The job uses the same CCCL version as rest of Rapids.

cc @csadorf @jakirkham @bdice 

The pipeline will run on a nightly basis. In addition, it's also possible to manually trigger the pipeline via the workflow dispatch.

@trivialfis Eventually this testing will be moved to CCCL and cuML for the sake of better visibility. For now, we host it in the XGBoost repo. It is set up as a nightly pipeline so that it doesn't block daily development.