### PR TITLE
Define custom methods for capturing logs in tests.

### DIFF
--- a/tests/cpp/capture_std.h
+++ b/tests/cpp/capture_std.h
@@ -40,8 +40,8 @@ class CaptureStdRdBuf {
   }
 };
 
-using CaptureStderr = CaptureStdRdBuf<true>;
-using CaptureStdout = CaptureStdRdBuf<false>;
+using CaptureStderrImpl = CaptureStdRdBuf<true>;
+using CaptureStdoutImpl = CaptureStdRdBuf<false>;
 
 #else
 
@@ -67,7 +67,21 @@ class CaptureStdGtest {
   }
 };
 
-using CaptureStderr = CaptureStdGtest<true>;
-using CaptureStdout = CaptureStdGtest<false>;
+using CaptureStderrImpl = CaptureStdGtest<true>;
+using CaptureStdoutImpl = CaptureStdGtest<false>;
 #endif
+
+template <typename Fn>
+std::string CaptureStderr(Fn&& fn) {
+  CaptureStderrImpl capture;
+  fn();
+  return capture.StopAndGetStr();
+}
+
+template <typename Fn>
+std::string CaptureStdout(Fn&& fn) {
+  CaptureStdoutImpl capture;
+  fn();
+  return capture.StopAndGetStr();
+}
 }  // namespace xgboost

--- a/tests/cpp/common/test_numa_topo.cc
+++ b/tests/cpp/common/test_numa_topo.cc
@@ -106,9 +106,7 @@ TEST(Numa, CpuListParser) {
   }
   {
     auto path = tmpdir.Path() / "foo";
-    CaptureStderr capture;
-    ReadCpuList(path, &cpus);
-    std::string output = capture.StopAndGetStr();
+    std::string output = CaptureStderr([&] { ReadCpuList(path, &cpus); });
     ASSERT_TRUE(cpus.empty());
     ASSERT_NE(output.find("foo"), std::string::npos);
   }

--- a/tests/cpp/test_logging.cc
+++ b/tests/cpp/test_logging.cc
@@ -1,53 +1,46 @@
-#include <map>
-
+/**
+ * Copyright 2018-2025, XGBoost Contributors
+ */
 #include <gtest/gtest.h>
 #include <xgboost/logging.h>
 
-namespace xgboost {
+#include <map>
 
+#include "capture_std.h"  // for CaptureStderr
+
+namespace xgboost {
 TEST(Logging, Basic) {
-  std::map<std::string, std::string> args {};
-  std::string output;
+  auto verbosity = GlobalConfigThreadLocalStore::Get()->verbosity;
+  std::map<std::string, std::string> args{};
 
   args["verbosity"] = "0";  // silent
   ConsoleLogger::Configure({args.cbegin(), args.cend()});
-  testing::internal::CaptureStderr();
-  LOG(DEBUG) << "Test silent.";
-  output = testing::internal::GetCapturedStderr();
+  auto output = CaptureStderr([] { LOG(DEBUG) << "Test silent."; });
   ASSERT_EQ(output.length(), 0);
 
   args["verbosity"] = "3";  // debug
-  ConsoleLogger::Configure({args.cbegin(), args.cend()});
 
-  testing::internal::CaptureStderr();
-  LOG(WARNING) << "Test Log Warning.";
-  output = testing::internal::GetCapturedStderr();
+  ConsoleLogger::Configure({args.cbegin(), args.cend()});
+  output = CaptureStderr([&] { LOG(WARNING) << "Test Log Warning."; });
   ASSERT_NE(output.find("WARNING"), std::string::npos);
 
-  testing::internal::CaptureStderr();
-  LOG(INFO) << "Test Log Info.";
-  output = testing::internal::GetCapturedStderr();
+  output = CaptureStderr([&] { LOG(INFO) << "Test Log Info."; });
   ASSERT_NE(output.find("Test Log Info"), std::string::npos);
 
-  testing::internal::CaptureStderr();
-  LOG(DEBUG) << "Test Log Debug.";
-  output = testing::internal::GetCapturedStderr();
+  output = CaptureStderr([&] { LOG(DEBUG) << "Test Log Debug."; });
   ASSERT_NE(output.find("DEBUG"), std::string::npos);
 
   args["verbosity"] = "1";  // warning
   ConsoleLogger::Configure({args.cbegin(), args.cend()});
-  testing::internal::CaptureStderr();
-  LOG(INFO) << "INFO should not be displayed when set to warning.";
-  output = testing::internal::GetCapturedStderr();
+  output = CaptureStderr([&] { LOG(INFO) << "INFO should not be displayed when set to warning."; });
   ASSERT_EQ(output.size(), 0);
 
-  testing::internal::CaptureStderr();
-  LOG(CONSOLE) << "Test Log Console";  // ignore global setting.
-  output = testing::internal::GetCapturedStderr();
+  output = CaptureStderr([&] {
+    LOG(CONSOLE) << "Test Log Console";  // ignore global setting.
+  });
   ASSERT_NE(output.find("Test Log Console"), std::string::npos);
 
-  args["verbosity"] = "2";  // restore
+  args["verbosity"] = std::to_string(verbosity);
   ConsoleLogger::Configure({args.cbegin(), args.cend()});
 }
-
 }  // namespace xgboost


### PR DESCRIPTION
For some reason, the gtest capture are failing on my windows machine. This PR workaround the issue by redirecting `std::cout/cerr` to a string buffer.