### PR TITLE
[mt] Refactor the Python boost function.

### DIFF
--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -387,6 +387,10 @@ def _ensure_np_dtype(
     return data, dtype
 
 
+def _is_flatten(array: NumpyOrCupy) -> bool:
+    return len(array.shape) == 1 or array.shape[1] == 1
+
+
 def array_interface_dict(data: np.ndarray) -> ArrayInf:
     """Returns an array interface from the input."""
     if array_hasobject(data):

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -242,6 +242,10 @@ def is_dataframe(data: DataType) -> bool:
     )
 
 
+def _is_cupy_alike(data: DataType) -> bool:
+    return hasattr(data, "__cuda_array_interface__")
+
+
 def concat(value: Sequence[_T]) -> _T:  # pylint: disable=too-many-return-statements
     """Concatenate row-wise."""
     if isinstance(value[0], np.ndarray):
@@ -264,8 +268,6 @@ def concat(value: Sequence[_T]) -> _T:  # pylint: disable=too-many-return-statem
         from cudf import concat as CUDF_concat
 
         return CUDF_concat(value, axis=0)
-    from .data import _is_cupy_alike
-
     if _is_cupy_alike(value[0]):
         import cupy
 

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -93,18 +93,17 @@ from ..callback import TrainingCallback
 from ..collective import Config as CollConfig
 from ..collective import _Args as CollArgs
 from ..collective import _ArgVals as CollArgsVals
-from ..compat import _is_cudf_df
+from ..compat import _is_cudf_df, _is_cudf_ser, _is_cupy_alike
 from ..core import (
     Booster,
     DMatrix,
     Metric,
-    Objective,
+    PlainObj,
     XGBoostError,
     _check_distributed_params,
     _deprecate_positional_args,
     _expect,
 )
-from ..data import _is_cudf_ser, _is_cupy_alike
 from ..sklearn import (
     XGBClassifier,
     XGBClassifierBase,
@@ -726,7 +725,7 @@ async def _train_async(
     dtrain: DaskDMatrix,
     num_boost_round: int,
     evals: Optional[Sequence[Tuple[DaskDMatrix, str]]],
-    obj: Optional[Objective],
+    obj: Optional[PlainObj],
     early_stopping_rounds: Optional[int],
     verbose_eval: Union[int, bool],
     xgb_model: Optional[Booster],
@@ -831,7 +830,7 @@ def train(  # pylint: disable=unused-argument
     num_boost_round: int = 10,
     *,
     evals: Optional[Sequence[Tuple[DaskDMatrix, str]]] = None,
-    obj: Optional[Objective] = None,
+    obj: Optional[PlainObj] = None,
     early_stopping_rounds: Optional[int] = None,
     xgb_model: Optional[Booster] = None,
     verbose_eval: Union[int, bool] = True,

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -60,6 +60,7 @@ from .compat import (
     _is_cudf_df,
     _is_cudf_pandas,
     _is_cudf_ser,
+    _is_cupy_alike,
     _is_modin_df,
     _is_modin_series,
     _is_pandas_df,
@@ -1127,10 +1128,6 @@ def _from_cudf_df(
         )
     )
     return handle, feature_names, feature_types
-
-
-def _is_cupy_alike(data: DataType) -> bool:
-    return hasattr(data, "__cuda_array_interface__")
 
 
 def _transform_cupy_array(data: DataType) -> CupyT:

--- a/python-package/xgboost/objective.py
+++ b/python-package/xgboost/objective.py
@@ -9,10 +9,20 @@ reduction.
 
 """
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Tuple
 
-from ._typing import ArrayLike
+import numpy as np
+
+from ._data_utils import (
+    _ensure_np_dtype,
+    _is_flatten,
+    array_interface,
+    cuda_array_interface,
+)
+from ._typing import ArrayLike, NumpyOrCupy
+from .compat import _is_cupy_alike
 
 if TYPE_CHECKING:
     from .core import DMatrix
@@ -29,7 +39,7 @@ class Objective(ABC):
 
     @abstractmethod
     def __call__(
-        self, y_pred: ArrayLike, dtrain: "DMatrix"
+        self, iteration: int, y_pred: ArrayLike, dtrain: "DMatrix"
     ) -> Tuple[ArrayLike, ArrayLike]: ...
 
 
@@ -42,8 +52,37 @@ class TreeObjective(Objective):
 
     """
 
+    # pylint: disable=unused-argument
     def split_grad(
-        self, grad: ArrayLike, hess: ArrayLike
+        self, iteration: int, grad: ArrayLike, hess: ArrayLike
     ) -> Tuple[ArrayLike, ArrayLike]:
         """Provide a different gradient type for finding tree structures."""
         return grad, hess
+
+
+def _grad_arrinf(array: NumpyOrCupy, n_samples: int) -> bytes:
+    # Can we check for __array_interface__ instead of a specific type instead?
+    msg = (
+        "Expecting `np.ndarray` or `cupy.ndarray` for gradient and hessian."
+        f" Got: {type(array)}"
+    )
+    if not isinstance(array, np.ndarray) and not _is_cupy_alike(array):
+        raise TypeError(msg)
+
+    if array.shape[0] != n_samples and _is_flatten(array):
+        warnings.warn(
+            "Since 2.1.0, the shape of the gradient and hessian is required to"
+            " be (n_samples, n_targets) or (n_samples, n_classes).",
+            FutureWarning,
+        )
+        array = array.reshape(n_samples, array.size // n_samples)
+
+    if isinstance(array, np.ndarray):
+        array, _ = _ensure_np_dtype(array, array.dtype)
+        interface = array_interface(array)
+    elif _is_cupy_alike(array):
+        interface = cuda_array_interface(array)
+    else:
+        raise TypeError(msg)
+
+    return interface

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -55,7 +55,7 @@ from .core import (
     Booster,
     DMatrix,
     Metric,
-    Objective,
+    PlainObj,
     QuantileDMatrix,
     XGBoostError,
     _deprecate_positional_args,
@@ -112,7 +112,7 @@ _SklObjProto = Callable[[ArrayLike, ArrayLike], Tuple[np.ndarray, np.ndarray]]
 SklObjective = Optional[Union[str, _SklObjWProto, _SklObjProto]]
 
 
-def _objective_decorator(func: Union[_SklObjWProto, _SklObjProto]) -> Objective:
+def _objective_decorator(func: Union[_SklObjWProto, _SklObjProto]) -> PlainObj:
     """Decorate an objective function
 
     Converts an objective function using the typical sklearn metrics
@@ -1362,7 +1362,7 @@ class XGBModel(XGBModelBase):
             )
 
             if callable(self.objective):
-                obj: Optional[Objective] = _objective_decorator(self.objective)
+                obj: Optional[PlainObj] = _objective_decorator(self.objective)
                 params["objective"] = "reg:squarederror"
             else:
                 obj = None
@@ -1768,7 +1768,7 @@ class XGBClassifier(XGBClassifierBase, XGBModel):
             params = self.get_xgb_params()
 
             if callable(self.objective):
-                obj: Optional[Objective] = _objective_decorator(self.objective)
+                obj: Optional[PlainObj] = _objective_decorator(self.objective)
                 # Use default value. Is it really not used ?
                 params["objective"] = "binary:logistic"
             else:

--- a/python-package/xgboost/testing/multi_target.py
+++ b/python-package/xgboost/testing/multi_target.py
@@ -72,7 +72,7 @@ class LsObj0(TreeObjective):
     """Split grad is the same as value grad."""
 
     def __call__(
-        self, y_pred: ArrayLike, dtrain: DMatrix
+        self, iteration: int, y_pred: ArrayLike, dtrain: DMatrix
     ) -> Tuple[ArrayLike, ArrayLike]:
         cp = import_cupy()
 
@@ -81,7 +81,7 @@ class LsObj0(TreeObjective):
         return cp.array(grad), cp.array(hess)
 
     def split_grad(
-        self, grad: ArrayLike, hess: ArrayLike
+        self, iteration: int, grad: ArrayLike, hess: ArrayLike
     ) -> Tuple[ArrayLike, ArrayLike]:
         cp = import_cupy()
 
@@ -92,7 +92,7 @@ class LsObj1(Objective):
     """No split grad."""
 
     def __call__(
-        self, y_pred: ArrayLike, dtrain: DMatrix
+        self, iteration: int, y_pred: ArrayLike, dtrain: DMatrix
     ) -> Tuple[ArrayLike, ArrayLike]:
         cp = import_cupy()
 
@@ -151,7 +151,7 @@ def run_reduced_grad(device: Device) -> None:
             self._chk = check_used
 
         def split_grad(
-            self, grad: ArrayLike, hess: ArrayLike
+            self, iteration: int, grad: ArrayLike, hess: ArrayLike
         ) -> Tuple[cp.ndarray, cp.ndarray]:
             if self._chk:
                 assert False

--- a/python-package/xgboost/testing/utils.py
+++ b/python-package/xgboost/testing/utils.py
@@ -4,9 +4,8 @@ from typing import Any, Literal, TypeAlias
 
 import numpy as np
 
-from ..compat import import_cupy
+from ..compat import _is_cupy_alike, import_cupy
 from ..core import DMatrix
-from ..data import _is_cupy_alike
 
 Device: TypeAlias = Literal["cpu", "cuda"]
 

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -31,7 +31,7 @@ from .core import (
     Booster,
     DMatrix,
     Metric,
-    Objective,
+    PlainObj,
     XGBoostError,
     _deprecate_positional_args,
     _RefMixIn,
@@ -55,7 +55,7 @@ def train(
     num_boost_round: int = 10,
     *,
     evals: Optional[Sequence[Tuple[DMatrix, str]]] = None,
-    obj: Optional[Objective] = None,
+    obj: Optional[PlainObj] = None,
     maximize: Optional[bool] = None,
     early_stopping_rounds: Optional[int] = None,
     evals_result: Optional[TrainingCallback.EvalsLog] = None,
@@ -226,7 +226,7 @@ class CVPack:
 
         return _inner
 
-    def update(self, iteration: int, fobj: Optional[Objective]) -> None:
+    def update(self, iteration: int, fobj: Optional[PlainObj]) -> None:
         """ "Update the boosters for one iteration"""
         self.bst.update(self.dtrain, iteration, fobj)
 
@@ -239,7 +239,7 @@ class _PackedBooster:
     def __init__(self, cvfolds: _CVFolds) -> None:
         self.cvfolds = cvfolds
 
-    def update(self, iteration: int, obj: Optional[Objective]) -> None:
+    def update(self, iteration: int, obj: Optional[PlainObj]) -> None:
         """Iterate through folds for update"""
         for fold in self.cvfolds:
             fold.update(iteration, obj)
@@ -440,7 +440,7 @@ def cv(
     stratified: bool = False,
     folds: XGBStratifiedKFold = None,
     metrics: Sequence[str] = (),
-    obj: Optional[Objective] = None,
+    obj: Optional[PlainObj] = None,
     maximize: Optional[bool] = None,
     early_stopping_rounds: Optional[int] = None,
     fpreproc: Optional[FPreProcCallable] = None,


### PR DESCRIPTION
- Forward the gradient calculation to the boost function.
- Cleanup circular module dependencies.
- Add the parameter `iteration` to the custom objective prototypes to align with the internal obj definition and to prepare for potential support of batched gradient.
- Avoid exposing the split gradient as parameters.

Ref:https://github.com/dmlc/xgboost/issues/9043