### PR TITLE
mapPartition documentation.

### DIFF
--- a/jvm-packages/xgboost4j-flink/src/main/java/ml/dmlc/xgboost4j/java/flink/XGBoost.java
+++ b/jvm-packages/xgboost4j-flink/src/main/java/ml/dmlc/xgboost4j/java/flink/XGBoost.java
@@ -65,8 +65,9 @@ public class XGBoost {
     /**
      * Trains the XGBoost model based on the data elements in the given partition.
      *
-     * @param it The iterable object consisting of labeled points with vectors as features and
-     *           a double value as the label.
+     * @param it The iterable object consisting of Tuple2 instances where the first field (f0)
+     *           is a Vector representing the features and the second field (f1) is a Double
+     *           representing the label.
      * @param collector The collector object that is used to emit the trained XGBoost model.
      * @throws XGBoostError Error thrown during training.
      */


### PR DESCRIPTION
Add documentation for the mapPartition() function so that it is understandable to developers who want to use the function that is present in the flink package.