### PR TITLE
Add helper script to run rchk.

### DIFF
--- a/src/data/extmem_quantile_dmatrix.h
+++ b/src/data/extmem_quantile_dmatrix.h
@@ -65,9 +65,7 @@ class ExtMemQuantileDMatrix : public QuantileDMatrix {
 
   std::map<std::string, std::shared_ptr<Cache>> cache_info_;
   std::string cache_prefix_;
-#if defined(XGBOOST_USE_CUDA)
   bool const on_host_;
-#endif  // defined(XGBOOST_USE_CUDA)
   BatchParam batch_;
   bst_idx_t n_batches_{0};
 

--- a/src/data/sparse_page_dmatrix.h
+++ b/src/data/sparse_page_dmatrix.h
@@ -73,11 +73,9 @@ class SparsePageDMatrix : public DMatrix {
   float const missing_;
   Context fmat_ctx_;
   std::string cache_prefix_;
-#if defined(XGBOOST_USE_CUDA)
   bool const on_host_;
   float const cache_host_ratio_;
   std::int64_t const min_cache_page_bytes_;
-#endif  // defined(XGBOOST_USE_CUDA)
   ExternalDataInfo ext_info_;
 
   // sparse page is the source to other page types, we make a special member function.


### PR DESCRIPTION
- A small help script for running rchk.
- Cleanup unused variables.

Result looks harmless??
```
objdump: Warning: Unrecognized form: 0x23
objdump: Warning: DIE at offset 0x218e25 refers to abbreviation number 3736 which does not exist

Library name (usually package name): xgboost
Initialization function: R_init_xgboost
Functions: 62
Checked call to R_registerRoutines: 1
ERROR: too many states (abstraction error?) in function strptime_internal
ERROR: too many states (abstraction error?) in function bcEval_loop
ERROR: too many states (abstraction error?) in function RunGenCollect
Analyzed 66039 functions, traversed 201910 states.

Rchk version: 059dc9aac8b9d2fe2e1f53f2a1fea79dc85212f2
R version: 89293/R Under development (unstable) (2026-01-09 r89293)
LLVM version: 14.0.0
```