### PR TITLE
Enable threaded data initialization for CPU.

### DIFF
--- a/src/common/threading_utils.h
+++ b/src/common/threading_utils.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2025, XGBoost Contributors
+ * Copyright 2019-2026, XGBoost Contributors
  */
 #ifndef XGBOOST_COMMON_THREADING_UTILS_H_
 #define XGBOOST_COMMON_THREADING_UTILS_H_
@@ -103,9 +103,7 @@ class BlockedSpace2d {
   }
 
   // Amount of blocks(tasks) in a space
-  [[nodiscard]] std::size_t Size() const {
-    return ranges_.size();
-  }
+  [[nodiscard]] std::size_t Size() const { return ranges_.size(); }
 
   // get index of the first dimension of i-th block(task)
   [[nodiscard]] std::size_t GetFirstDimension(std::size_t i) const {
@@ -135,7 +133,6 @@ class BlockedSpace2d {
   std::vector<Range1d> ranges_;
   std::vector<std::size_t> first_dimension_;
 };
-
 
 // Wrapper to implement nested parallelism with simple omp parallel for
 template <typename Func>
@@ -200,48 +197,48 @@ void ParallelFor(Index size, std::int32_t n_threads, Sched sched, Func&& fn) {
 
   dmlc::OMPException exc;
   switch (sched.sched) {
-  case Sched::kAuto: {
+    case Sched::kAuto: {
 #pragma omp parallel for num_threads(n_threads)
-    for (OmpInd i = 0; i < length; ++i) {
-      exc.Run(fn, i);
+      for (OmpInd i = 0; i < length; ++i) {
+        exc.Run(fn, i);
+      }
+      break;
     }
-    break;
-  }
-  case Sched::kDynamic: {
-    if (sched.chunk == 0) {
+    case Sched::kDynamic: {
+      if (sched.chunk == 0) {
 #pragma omp parallel for num_threads(n_threads) schedule(dynamic)
-      for (OmpInd i = 0; i < length; ++i) {
-        exc.Run(fn, i);
-      }
-    } else {
+        for (OmpInd i = 0; i < length; ++i) {
+          exc.Run(fn, i);
+        }
+      } else {
 #pragma omp parallel for num_threads(n_threads) schedule(dynamic, sched.chunk)
-      for (OmpInd i = 0; i < length; ++i) {
-        exc.Run(fn, i);
+        for (OmpInd i = 0; i < length; ++i) {
+          exc.Run(fn, i);
+        }
       }
+      break;
     }
-    break;
-  }
-  case Sched::kStatic: {
-    if (sched.chunk == 0) {
+    case Sched::kStatic: {
+      if (sched.chunk == 0) {
 #pragma omp parallel for num_threads(n_threads) schedule(static)
-      for (OmpInd i = 0; i < length; ++i) {
-        exc.Run(fn, i);
-      }
-    } else {
+        for (OmpInd i = 0; i < length; ++i) {
+          exc.Run(fn, i);
+        }
+      } else {
 #pragma omp parallel for num_threads(n_threads) schedule(static, sched.chunk)
+        for (OmpInd i = 0; i < length; ++i) {
+          exc.Run(fn, i);
+        }
+      }
+      break;
+    }
+    case Sched::kGuided: {
+#pragma omp parallel for num_threads(n_threads) schedule(guided)
       for (OmpInd i = 0; i < length; ++i) {
         exc.Run(fn, i);
       }
+      break;
     }
-    break;
-  }
-  case Sched::kGuided: {
-#pragma omp parallel for num_threads(n_threads) schedule(guided)
-    for (OmpInd i = 0; i < length; ++i) {
-      exc.Run(fn, i);
-    }
-    break;
-  }
   }
   exc.Rethrow();
 }
@@ -270,6 +267,21 @@ void ParallelFor1d(Index size, std::int32_t n_threads, Func&& fn) {
     std::size_t const block_beg = block_id * kBlockOfRowsSize;
     auto const block_size = std::min(static_cast<std::size_t>(size - block_beg), kBlockOfRowsSize);
     fn(common::Range1d{block_beg, block_beg + block_size});
+  });
+}
+
+/** @brief Use n_threads as the number of blocks. */
+template <typename Index, typename Func>
+void ParallelForBlock(Index size, std::int32_t n_threads, Func&& fn) {
+  static_assert(std::is_void_v<std::invoke_result_t<Func, common::Range1d>>);
+  std::size_t blk_size = size / n_threads + (size % n_threads > 0);
+  ParallelFor(n_threads, n_threads, [&](auto tid) {
+    auto blk_beg = tid * blk_size;
+    auto blk_end = std::min((tid + 1) * blk_size, size);
+    if (blk_end <= blk_beg) {
+      return;
+    }
+    fn(common::Range1d{blk_beg, blk_end});
   });
 }
 

--- a/src/data/gradient_index.cu
+++ b/src/data/gradient_index.cu
@@ -92,7 +92,7 @@ GHistIndexMatrix::GHistIndexMatrix(Context const* ctx, MetaInfo const& info,
   this->cut.Values();
   this->cut.MinValues();
 
-  this->ResizeIndex(info.num_nonzero_, page->IsDense());
+  this->ResizeIndex(ctx, info.num_nonzero_, page->IsDense());
   if (page->IsDense()) {
     this->index.SetBinOffset(page->Cuts().Ptrs());
   }

--- a/src/data/gradient_index_page_source.cc
+++ b/src/data/gradient_index_page_source.cc
@@ -13,6 +13,8 @@
 namespace xgboost::data {
 void GradientIndexPageSource::Fetch() {
   if (!this->ReadCache()) {
+    auto ctx = Context{};
+    ctx.Init(Args{{"nthread", std::to_string(nthreads_)}});
     // source is initialized to be the 0th page during construction, so when count_ is 0
     // there's no need to increment the source.
     if (this->count_ != 0 && !this->sync_) {
@@ -24,8 +26,8 @@ void GradientIndexPageSource::Fetch() {
     CHECK_EQ(this->count_, this->source_->Iter());
     auto const& csr = this->source_->Page();
     CHECK_NE(this->cuts_.Values().size(), 0);
-    this->page_.reset(new GHistIndexMatrix{*csr, feature_types_, cuts_, max_bin_per_feat_,
-                                           is_dense_, sparse_thresh_, nthreads_});
+    this->page_.reset(new GHistIndexMatrix{&ctx, *csr, feature_types_, cuts_, max_bin_per_feat_,
+                                           is_dense_, sparse_thresh_});
     this->WriteCache();
   }
 }

--- a/src/data/gradient_index_page_source.h
+++ b/src/data/gradient_index_page_source.h
@@ -48,12 +48,12 @@ class GradientIndexPageSource
   double sparse_thresh_;
 
  public:
-  GradientIndexPageSource(float missing, std::int32_t nthreads, bst_feature_t n_features,
+  GradientIndexPageSource(Context const* ctx, float missing, bst_feature_t n_features,
                           bst_idx_t n_batches, std::shared_ptr<Cache> cache, BatchParam param,
                           common::HistogramCuts cuts, bool is_dense,
                           common::Span<FeatureType const> feature_types,
                           std::shared_ptr<SparsePageSource> source)
-      : PageSourceIncMixIn(missing, nthreads, n_features, n_batches, cache,
+      : PageSourceIncMixIn(missing, ctx->Threads(), n_features, n_batches, cache,
                            std::isnan(param.sparse_thresh)),
         is_dense_{is_dense},
         max_bin_per_feat_{param.max_bin},

--- a/src/data/sparse_page_dmatrix.cc
+++ b/src/data/sparse_page_dmatrix.cc
@@ -42,8 +42,7 @@ SparsePageDMatrix::SparsePageDMatrix(DataIterHandle iter_handle, DMatrixHandle p
   cache_prefix_ = MakeCachePrefix(cache_prefix_);
 
   DMatrixProxy *proxy = MakeProxy(proxy_);
-  auto iter = DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>{
-      iter_, reset_, next_};
+  auto iter = DataIterProxy<DataIterResetCallback, XGDMatrixCallbackNext>{iter_, reset_, next_};
 
   auto get_cats = [](DMatrixProxy const *proxy) {
     if (proxy->Ctx()->IsCPU()) {
@@ -179,8 +178,8 @@ BatchSet<GHistIndexMatrix> SparsePageDMatrix::GetGradientIndex(Context const *ct
     CHECK_NE(cuts.Values().size(), 0);
     auto ft = this->info_.feature_types.ConstHostSpan();
     ghist_index_source_.reset(new GradientIndexPageSource(
-        this->missing_, ctx->Threads(), this->Info().num_col_, this->NumBatches(),
-        cache_info_.at(id), param, std::move(cuts), this->IsDense(), ft, sparse_page_source_));
+        ctx, this->missing_, this->Info().num_col_, this->NumBatches(), cache_info_.at(id), param,
+        std::move(cuts), this->IsDense(), ft, sparse_page_source_));
   } else {
     CHECK(ghist_index_source_);
     ghist_index_source_->Reset(param);

--- a/tests/cpp/tree/hist/test_histogram.cc
+++ b/tests/cpp/tree/hist/test_histogram.cc
@@ -38,7 +38,8 @@
 
 namespace xgboost::tree {
 namespace {
-void InitRowPartitionForTest(common::RowSetCollection *row_set, size_t n_samples, size_t base_rowid = 0) {
+void InitRowPartitionForTest(common::RowSetCollection *row_set, size_t n_samples,
+                             size_t base_rowid = 0) {
   auto &row_indices = *row_set->Data();
   row_indices.resize(n_samples);
   std::iota(row_indices.begin(), row_indices.end(), base_rowid);
@@ -80,7 +81,6 @@ void TestAddHistRows(bool is_distributed) {
     ASSERT_TRUE(histogram_builder.Histogram().HistogramExists(nidx));
   }
 }
-
 
 TEST(CPUHistogram, AddRows) {
   TestAddHistRows(true);
@@ -227,11 +227,11 @@ TEST(CPUHistogram, SyncHist) {
   TestSyncHist(false);
 }
 
-void TestBuildHistogram(Context const* ctx, bool is_distributed, bool force_read_by_column, bool is_col_split) {
+void TestBuildHistogram(Context const *ctx, bool is_distributed, bool force_read_by_column,
+                        bool is_col_split) {
   size_t constexpr kNRows = 8, kNCols = 16;
   int32_t constexpr kMaxBins = 4;
-  auto p_fmat =
-      RandomDataGenerator(kNRows, kNCols, 0.8).Seed(3).GenerateDMatrix();
+  auto p_fmat = RandomDataGenerator(kNRows, kNCols, 0.8).Seed(3).GenerateDMatrix();
   if (is_col_split) {
     p_fmat = std::shared_ptr<DMatrix>{
         p_fmat->SliceCol(collective::GetWorldSize(), collective::GetRank())};
@@ -241,9 +241,9 @@ void TestBuildHistogram(Context const* ctx, bool is_distributed, bool force_read
   uint32_t total_bins = gmat.cut.Ptrs().back();
 
   static double constexpr kEps = 1e-6;
-  std::vector<GradientPair> gpair = {
-      {0.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f}, {0.27f, 0.28f},
-      {0.27f, 0.29f}, {0.37f, 0.39f}, {0.47f, 0.49f}, {0.57f, 0.59f}};
+  std::vector<GradientPair> gpair = {{0.23f, 0.24f}, {0.24f, 0.25f}, {0.26f, 0.27f},
+                                     {0.27f, 0.28f}, {0.27f, 0.29f}, {0.37f, 0.39f},
+                                     {0.47f, 0.49f}, {0.57f, 0.59f}};
 
   bst_node_t nid = 0;
   HistogramBuilder histogram;
@@ -315,8 +315,7 @@ TEST(CPUHistogram, BuildHistColumnSplit) {
 
 namespace {
 template <typename GradientSumT>
-void ValidateCategoricalHistogram(size_t n_categories,
-                                  common::Span<GradientSumT> onehot,
+void ValidateCategoricalHistogram(size_t n_categories, common::Span<GradientSumT> onehot,
                                   common::Span<GradientSumT> cat) {
   auto cat_sum = std::accumulate(cat.cbegin(), cat.cend(), GradientPairPrecise{});
   for (size_t c = 0; c < n_categories; ++c) {
@@ -483,8 +482,8 @@ void TestHistogramExternalMemory(Context const *ctx, BatchParam batch_param, boo
     }
 
     auto cut = common::SketchOnDMatrix(ctx, m.get(), batch_param.max_bin, false, hess);
-    GHistIndexMatrix gmat(concat, {}, cut, batch_param.max_bin, false,
-                          std::numeric_limits<double>::quiet_NaN(), ctx->Threads());
+    GHistIndexMatrix gmat(ctx, concat, {}, cut, batch_param.max_bin, false,
+                          std::numeric_limits<double>::quiet_NaN());
 
     single_build.AddHistRows(tree.HostScView(), &nodes, &dummy_sub, false);
     single_build.BuildHist(0, space, gmat, row_set_collection, nodes,

--- a/tests/cpp/tree/test_quantile_hist.cc
+++ b/tests/cpp/tree/test_quantile_hist.cc
@@ -45,7 +45,7 @@ void TestPartitioner(bst_target_t n_targets) {
   auto cuts = common::SketchOnDMatrix(&ctx, Xy.get(), 64);
 
   for (auto const& page : Xy->GetBatches<SparsePage>()) {
-    GHistIndexMatrix gmat(page, {}, cuts, 64, true, 0.5, ctx.Threads());
+    GHistIndexMatrix gmat{&ctx, page, {}, cuts, 64, true, 0.5};
     bst_feature_t const split_ind = 0;
     common::ColumnMatrix column_indices;
     column_indices.InitFromSparse(page, gmat, 0.5, ctx.Threads());
@@ -126,7 +126,7 @@ void VerifyColumnSplitPartitioner(bst_target_t n_targets, size_t n_samples,
   auto cuts = common::SketchOnDMatrix(&ctx, dmat.get(), 64);
 
   for (auto const& page : Xy->GetBatches<SparsePage>()) {
-    GHistIndexMatrix gmat(page, {}, cuts, 64, true, 0.5, ctx.Threads());
+    GHistIndexMatrix gmat(&ctx, page, {}, cuts, 64, true, 0.5);
     common::ColumnMatrix column_indices;
     column_indices.InitFromSparse(page, gmat, 0.5, ctx.Threads());
     {
@@ -197,7 +197,7 @@ void TestColumnSplitPartitioner(bst_target_t n_targets) {
   float min_value, mid_value;
   CommonRowPartitioner mid_partitioner{&ctx, n_samples, base_rowid, false};
   for (auto const& page : Xy->GetBatches<SparsePage>()) {
-    GHistIndexMatrix gmat(page, {}, cuts, 64, true, 0.5, ctx.Threads());
+    GHistIndexMatrix gmat{&ctx, page, {}, cuts, 64, true, 0.5};
     bst_feature_t const split_ind = 0;
     common::ColumnMatrix column_indices;
     column_indices.InitFromSparse(page, gmat, 0.5, ctx.Threads());


### PR DESCRIPTION
Extracted from https://github.com/dmlc/xgboost/pull/11390 , modified to use the context instead. In addition, a new `ParallelForBlock` is created.