### PR TITLE
fix: correct typo 'recieve' to 'receive'

### DIFF
--- a/src/encoder/ordinal.h
+++ b/src/encoder/ordinal.h
@@ -11,7 +11,7 @@
  * The algorithm proceeds as follow:
  *
  * Given the categories used for training [c, b, d, a], the ordering of this list is the
- * encoding, c maps to 0, b maps to 1, so on and so forth. At test time, we recieve an
+ * encoding, c maps to 0, b maps to 1, so on and so forth. At test time, we receive an
  * encoding [c, a, b], which differs from the encoding used for training and we need to
  * re-code the data.
  *

--- a/tests/python/test_callback.py
+++ b/tests/python/test_callback.py
@@ -36,7 +36,7 @@ def breast_cancer() -> BreastCancer:
 
 
 def eval_error_metric(predt: np.ndarray, dtrain: xgb.DMatrix) -> Tuple[str, np.float64]:
-    # No custom objective, recieve transformed output
+    # No custom objective, receive transformed output
     return tm.eval_error_metric(predt, dtrain, rev_link=False)
 
 


### PR DESCRIPTION
Fix typo 'recieve' to 'receive' in test file and encoder header.