### PR TITLE
demo: remove type ignore in custom_softmax plot history

### DIFF
--- a/demo/guide-python/custom_softmax.py
+++ b/demo/guide-python/custom_softmax.py
@@ -12,9 +12,10 @@ detailed tutorial and notes.
 """
 
 import argparse
-from typing import Dict, Tuple
+from typing import Dict, Tuple, cast
 
 import numpy as np
+from matplotlib.axes import Axes
 from matplotlib import pyplot as plt
 
 import xgboost as xgb
@@ -126,10 +127,11 @@ def merror(predt: np.ndarray, dtrain: xgb.DMatrix) -> Tuple[str, np.float64]:
 def plot_history(
     custom_results: Dict[str, Dict], native_results: Dict[str, Dict]
 ) -> None:
-    axs: np.ndarray
-    fig, axs = plt.subplots(2, 1)  # type: ignore
-    ax0 = axs[0]
-    ax1 = axs[1]
+    _, axes = plt.subplots(2, 1)
+    if not isinstance(axes, np.ndarray):
+        raise TypeError("Expected matplotlib to return an array of axes.")
+    ax0 = cast(Axes, axes[0])
+    ax1 = cast(Axes, axes[1])
 
     pymerror = custom_results["train"]["PyMError"]
     merror = native_results["train"]["merror"]


### PR DESCRIPTION
## Summary
- remove one `# type: ignore` from `demo/guide-python/custom_softmax.py`
- add explicit axis typing/casts around `matplotlib.pyplot.subplots` return value to satisfy static typing

## Why
This is an incremental typing improvement for Python demos, aligned with ongoing work in #6496.

## Validation
- `python3 -m py_compile demo/guide-python/custom_softmax.py`
- Could not run `mypy` locally because it is not installed in this environment.

Part of #6496
