### PR TITLE
Use the pytest tmp path fixture

### DIFF
--- a/tests/python/test_openmp.py
+++ b/tests/python/test_openmp.py
@@ -1,10 +1,9 @@
 import os
 import subprocess
-import tempfile
+from pathlib import Path
 
 import numpy as np
 import pytest
-
 import xgboost as xgb
 from xgboost import testing as tm
 
@@ -15,65 +14,67 @@ class TestOMP:
     def test_omp(self):
         dtrain, dtest = tm.load_agaricus(__file__)
 
-        param = {'booster': 'gbtree',
-                 'objective': 'binary:logistic',
-                 'grow_policy': 'depthwise',
-                 'tree_method': 'hist',
-                 'eval_metric': 'error',
-                 'max_depth': 5,
-                 'min_child_weight': 0}
+        param = {
+            "booster": "gbtree",
+            "objective": "binary:logistic",
+            "grow_policy": "depthwise",
+            "tree_method": "hist",
+            "eval_metric": "error",
+            "max_depth": 5,
+            "min_child_weight": 0,
+        }
 
-        watchlist = [(dtest, 'eval'), (dtrain, 'train')]
+        watchlist = [(dtest, "eval"), (dtrain, "train")]
         num_round = 5
 
         def run_trial():
             res = {}
             bst = xgb.train(param, dtrain, num_round, watchlist, evals_result=res)
-            metrics = [res['train']['error'][-1], res['eval']['error'][-1]]
+            metrics = [res["train"]["error"][-1], res["eval"]["error"][-1]]
             preds = bst.predict(dtest)
             return metrics, preds
 
         def consist_test(title, n):
             auc, pred = run_trial()
-            for i in range(n-1):
+            for i in range(n - 1):
                 auc2, pred2 = run_trial()
                 try:
                     assert auc == auc2
                     assert np.array_equal(pred, pred2)
                 except Exception as e:
-                    print('-------test %s failed, num_trial: %d-------' % (title, i))
+                    print("-------test %s failed, num_trial: %d-------" % (title, i))
                     raise e
                 auc, pred = auc2, pred2
             return auc, pred
 
-        print('test approx ...')
-        param['tree_method'] = 'approx'
+        print("test approx ...")
+        param["tree_method"] = "approx"
 
         n_trials = 10
-        param['nthread'] = 1
-        auc_1, pred_1 = consist_test('approx_thread_1', n_trials)
+        param["nthread"] = 1
+        auc_1, pred_1 = consist_test("approx_thread_1", n_trials)
 
-        param['nthread'] = 2
-        auc_2, pred_2 = consist_test('approx_thread_2', n_trials)
+        param["nthread"] = 2
+        auc_2, pred_2 = consist_test("approx_thread_2", n_trials)
 
-        param['nthread'] = 3
-        auc_3, pred_3 = consist_test('approx_thread_3', n_trials)
+        param["nthread"] = 3
+        auc_3, pred_3 = consist_test("approx_thread_3", n_trials)
 
         assert auc_1 == auc_2 == auc_3
         assert np.array_equal(auc_1, auc_2)
         assert np.array_equal(auc_1, auc_3)
 
-        print('test hist ...')
-        param['tree_method'] = 'hist'
+        print("test hist ...")
+        param["tree_method"] = "hist"
 
-        param['nthread'] = 1
-        auc_1, pred_1 = consist_test('hist_thread_1', n_trials)
+        param["nthread"] = 1
+        auc_1, pred_1 = consist_test("hist_thread_1", n_trials)
 
-        param['nthread'] = 2
-        auc_2, pred_2 = consist_test('hist_thread_2', n_trials)
+        param["nthread"] = 2
+        auc_2, pred_2 = consist_test("hist_thread_2", n_trials)
 
-        param['nthread'] = 3
-        auc_3, pred_3 = consist_test('hist_thread_3', n_trials)
+        param["nthread"] = 3
+        auc_3, pred_3 = consist_test("hist_thread_3", n_trials)
 
         assert auc_1 == auc_2 == auc_3
         assert np.array_equal(auc_1, auc_2)
@@ -81,29 +82,27 @@ class TestOMP:
 
     @pytest.mark.skipif(**tm.no_sklearn())
     @pytest.mark.timeout(30)
-    def test_with_omp_thread_limit(self):
+    def test_with_omp_thread_limit(self, tmp_path: Path) -> None:
         args = [
-            "python", os.path.join(
-                os.path.dirname(tm.normpath(__file__)), "with_omp_limit.py"
-            )
+            "python",
+            os.path.join(os.path.dirname(tm.normpath(__file__)), "with_omp_limit.py"),
         ]
         results = []
-        with tempfile.TemporaryDirectory() as tmpdir:
-            for i in (1, 2, 16):
-                path = os.path.join(tmpdir, str(i))
-                with open(path, "w") as fd:
-                    fd.write("\n")
-                cp = args.copy()
-                cp.append(path)
+        for i in (1, 2, 16):
+            path = tmp_path / str(i)
+            with open(path, "w") as fd:
+                fd.write("\n")
+            cp = args.copy()
+            cp.append(str(path))
 
-                env = os.environ.copy()
-                env["OMP_THREAD_LIMIT"] = str(i)
+            env = os.environ.copy()
+            env["OMP_THREAD_LIMIT"] = str(i)
 
-                status = subprocess.call(cp, env=env)
-                assert status == 0
+            status = subprocess.call(cp, env=env)
+            assert status == 0
 
-                with open(path, "r") as fd:
-                    results.append(float(fd.read()))
+            with open(path, "r") as fd:
+                results.append(float(fd.read()))
 
         for auc in results:
             np.testing.assert_allclose(auc, results[0])

--- a/tests/python/test_with_polars.py
+++ b/tests/python/test_with_polars.py
@@ -1,8 +1,7 @@
 """Copyright 2024, XGBoost contributors"""
 
 import json
-import os
-import tempfile
+from pathlib import Path
 from typing import Type, Union
 
 import numpy as np
@@ -69,7 +68,7 @@ def test_polars_missing() -> None:
     np.testing.assert_allclose(predt0, predt1)
 
 
-def test_classififer() -> None:
+def test_classififer(tmp_path: Path) -> None:
     from sklearn.datasets import make_classification, make_multilabel_classification
 
     X, y = make_classification(random_state=2024)
@@ -82,17 +81,16 @@ def test_classififer() -> None:
     clf1 = xgb.XGBClassifier()
     clf1.fit(X, y)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path0 = os.path.join(tmpdir, "clf0.json")
-        clf0.save_model(path0)
+    path0 = tmp_path / "clf0.json"
+    clf0.save_model(path0)
 
-        path1 = os.path.join(tmpdir, "clf1.json")
-        clf1.save_model(path1)
+    path1 = tmp_path / "clf1.json"
+    clf1.save_model(path1)
 
-        with open(path0, "r") as fd:
-            model0 = json.load(fd)
-        with open(path1, "r") as fd:
-            model1 = json.load(fd)
+    with open(path0, "r") as fd:
+        model0 = json.load(fd)
+    with open(path1, "r") as fd:
+        model1 = json.load(fd)
 
     model0["learner"]["feature_names"] = []
     model0["learner"]["feature_types"] = []

--- a/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
+++ b/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
@@ -1,9 +1,10 @@
-"""Copyright 2019-2024, XGBoost contributors"""
+"""Copyright 2019-2026, XGBoost contributors"""
 
 import asyncio
 import json
 from collections import OrderedDict
 from inspect import signature
+from pathlib import Path
 from typing import Any, Dict, List, Type, TypeVar
 
 import numpy as np
@@ -579,13 +580,13 @@ class TestDistributedGPU:
 
 
 @pytest.mark.skipif(**tm.no_dask_cudf())
-def test_categorical(local_cuda_client: Client) -> None:
+def test_categorical(tmp_path: Path, local_cuda_client: Client) -> None:
     X, y = make_categorical(local_cuda_client, 10000, 30, 13)
     X = X.to_backend("cudf")
 
     X_onehot, _ = make_categorical(local_cuda_client, 10000, 30, 13, onehot=True)
     X_onehot = X_onehot.to_backend("cudf")
-    run_categorical(local_cuda_client, "hist", "cuda", X, X_onehot, y)
+    run_categorical(local_cuda_client, "hist", "cuda", X, X_onehot, y, tmp_path)
 
 
 @pytest.mark.skipif(**tm.no_dask_cudf())


### PR DESCRIPTION
This PR uses the `tmp_path` pytest fixture to replace the use of the `tempfile` module, in addition to some small cleanups for the tests. 

Lots of bulk changes are caused by pre-commit ruff.