### PR TITLE
[python] Default enable_categorical to true

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -850,7 +850,7 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         label_lower_bound: Optional[ArrayLike] = None,
         label_upper_bound: Optional[ArrayLike] = None,
         feature_weights: Optional[ArrayLike] = None,
-        enable_categorical: bool = False,
+        enable_categorical: bool = True,
         data_split_mode: DataSplitMode = DataSplitMode.ROW,
     ) -> None:
         """Parameters
@@ -1677,7 +1677,7 @@ class QuantileDMatrix(DMatrix, _RefMixIn):
         label_lower_bound: Optional[ArrayLike] = None,
         label_upper_bound: Optional[ArrayLike] = None,
         feature_weights: Optional[ArrayLike] = None,
-        enable_categorical: bool = False,
+        enable_categorical: bool = True,
         max_quantile_batches: Optional[int] = None,
         data_split_mode: DataSplitMode = DataSplitMode.ROW,
     ) -> None:
@@ -1812,7 +1812,7 @@ class ExtMemQuantileDMatrix(DMatrix, _RefMixIn):
         nthread: Optional[int] = None,
         max_bin: Optional[int] = None,
         ref: Optional[DMatrix] = None,
-        enable_categorical: bool = False,
+        enable_categorical: bool = True,
         max_quantile_batches: Optional[int] = None,
         cache_host_ratio: Optional[float] = None,
     ) -> None:

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -309,7 +309,7 @@ class DaskDMatrix:
         label_lower_bound: Optional[_DaskCollection] = None,
         label_upper_bound: Optional[_DaskCollection] = None,
         feature_weights: Optional[_DaskCollection] = None,
-        enable_categorical: bool = False,
+        enable_categorical: bool = True,
     ) -> None:
         client = _get_client(client)
 
@@ -606,7 +606,7 @@ class DaskQuantileDMatrix(DaskDMatrix):
         label_lower_bound: Optional[_DaskCollection] = None,
         label_upper_bound: Optional[_DaskCollection] = None,
         feature_weights: Optional[_DaskCollection] = None,
-        enable_categorical: bool = False,
+        enable_categorical: bool = True,
         max_quantile_batches: Optional[int] = None,
     ) -> None:
         super().__init__(

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -836,7 +836,7 @@ class XGBModel(XGBModelBase):
         importance_type: Optional[str] = None,
         device: Optional[str] = None,
         validate_parameters: Optional[bool] = None,
-        enable_categorical: bool = False,
+        enable_categorical: bool = True,
         feature_types: Optional[FeatureTypes] = None,
         feature_weights: Optional[ArrayLike] = None,
         max_cat_to_onehot: Optional[int] = None,

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -805,6 +805,12 @@ def test_get_params_works_as_expected():
     assert params["colsample_bynode"] == 0.8
 
 
+def test_enable_categorical_defaults_to_true():
+    assert xgb.XGBModel().enable_categorical is True
+    assert xgb.XGBClassifier().enable_categorical is True
+    assert xgb.XGBRegressor().enable_categorical is True
+
+
 def test_kwargs_error():
     params = {'updater': 'grow_gpu_hist', 'subsample': .5, 'n_jobs': -1}
     with pytest.raises(TypeError):


### PR DESCRIPTION
## Summary
- switch Python API defaults for `enable_categorical` from `False` to `True` in:
  - `DMatrix`
  - `QuantileDMatrix`
  - `ExtMemQuantileDMatrix`
  - `XGBModel` (and sklearn estimators inheriting from it)
  - `DaskDMatrix`
  - `DaskQuantileDMatrix`
- add a sklearn-side regression test that asserts the default is `True`

## Why
Issue #12014 proposes removing the need to explicitly set `enable_categorical` by making the default behavior categorical-enabled.

## Validation
- `python3 -m compileall python-package/xgboost/core.py python-package/xgboost/sklearn.py python-package/xgboost/dask/__init__.py`
- `python3 -m compileall tests/python/test_with_sklearn.py`
- `python3 -m pytest tests/python/test_with_sklearn.py -k enable_categorical_defaults_to_true -q`
  - Result in this environment: `1 skipped`

Closes #12014
