### PR TITLE
[CI] Avoid push runs caused by dependabot.

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,6 +1,11 @@
 name: FreeBSD
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/jvm_tests.yml
+++ b/.github/workflows/jvm_tests.yml
@@ -1,6 +1,11 @@
 name: JVM Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 permissions:
   contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: XGBoost CI (Lint)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 permissions:
   contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: XGBoost CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 permissions:
   contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -1,6 +1,11 @@
 name: Miscellaneous
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 permissions:
   contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,11 @@
 name: XGBoost CI (Pre-commit)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,6 +1,11 @@
 name: Python tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/python_wheels_variants.yml
+++ b/.github/workflows/python_wheels_variants.yml
@@ -1,6 +1,11 @@
 name: Build Python wheels using Wheel Variant prototype (WheelNext)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 permissions:
   contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/python_wheels_winarm64.yml
+++ b/.github/workflows/python_wheels_winarm64.yml
@@ -1,6 +1,11 @@
 name: Build Python wheels targeting Windows ARM64
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 permissions:
   contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/r_tests.yml
+++ b/.github/workflows/r_tests.yml
@@ -1,6 +1,11 @@
 name: R Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sycl_tests.yml
+++ b/.github/workflows/sycl_tests.yml
@@ -1,6 +1,11 @@
 name: XGBoost CI (oneAPI)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 permissions:
   contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,11 @@
 name: Windows
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - 'release_*'
+  pull_request:
 
 permissions:
   contents: read  # to fetch code (actions/checkout)


### PR DESCRIPTION
Only run tests on persistent branches.

related: https://github.com/dmlc/xgboost/pull/12034