### PR TITLE
[docs] Clarify scale_pos_weight vs oversampling

### DIFF
--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -191,6 +191,7 @@ Parameters for Tree Booster
 * ``scale_pos_weight`` [default=1]
 
   - Control the balance of positive and negative weights, useful for unbalanced classes. A typical value to consider: ``sum(negative instances) / sum(positive instances)``. See :doc:`Parameters Tuning </tutorials/param_tuning>` for more discussion. Also, see Higgs Kaggle competition demo for examples: `R <https://github.com/dmlc/xgboost/blob/master/demo/kaggle-higgs/higgs-train.R>`_, `py1 <https://github.com/dmlc/xgboost/blob/master/demo/kaggle-higgs/higgs-numpy.py>`_, `py2 <https://github.com/dmlc/xgboost/blob/master/demo/kaggle-higgs/higgs-cv.py>`_, `py3 <https://github.com/dmlc/xgboost/blob/master/demo/guide-python/cross_validation.py>`_.
+  - ``scale_pos_weight`` is not exactly the same as duplicating positive rows. Oversampling changes the data distribution itself (and can interact with row/column subsampling), while ``scale_pos_weight`` keeps the dataset unchanged and adjusts positive-example contributions through per-instance weights.
 
 * ``updater``
 

--- a/doc/tutorials/param_tuning.rst
+++ b/doc/tutorials/param_tuning.rst
@@ -54,6 +54,7 @@ This can affect the training of XGBoost model, and there are two ways to improve
 * If you care only about the overall performance metric (AUC) of your prediction
 
   - Balance the positive and negative weights via ``scale_pos_weight``
+  - ``scale_pos_weight`` is usually preferred over naive oversampling when you only need ranking performance, since it preserves the original dataset while reweighting positive examples.
   - Use AUC for evaluation
 
 * If you care about predicting the right probability


### PR DESCRIPTION
## Summary
Adds a small documentation clarification for issue #11516:
- Explain that `scale_pos_weight` is not identical to duplicating positive rows (oversampling).
- Note why weighting is often preferred for ranking-focused imbalanced classification workflows.

## Files changed
- `doc/parameter.rst`
- `doc/tutorials/param_tuning.rst`

Closes #11516