### PR TITLE
[doc] Clarify JVM API parameter reference path

### DIFF
--- a/doc/jvm/api.rst
+++ b/doc/jvm/api.rst
@@ -7,3 +7,9 @@ API Docs for the JVM packages
 * `XGBoost4J-Spark Scala API <../jvm_docs/scaladocs/xgboost4j-spark/index.html>`_
 * `XGBoost4J-Spark-GPU Scala API <../jvm_docs/scaladocs/xgboost4j-spark-gpu/index.html>`_
 * `XGBoost4J-Flink Scala API <../jvm_docs/scaladocs/xgboost4j-flink/index.html>`_
+
+.. note::
+
+   Some JVM API pages focus on class signatures and may not include full prose for every
+   training parameter. For detailed parameter semantics and defaults, refer to
+   :doc:`/parameter` and map names to the corresponding JVM estimator params.


### PR DESCRIPTION
## Summary\n- add a short note on the JVM API docs page explaining where to find full training parameter descriptions\n- point JVM users to the canonical parameter reference page when scaladocs are signature-focused\n\n## Issue\nCloses #11239\n\n## Testing\n- docs-only change