### PR TITLE
Fix typo in predict docstring

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2416,7 +2416,7 @@ class Booster:
         strict_shape: bool = False,
     ) -> np.ndarray:
         """Predict with data.  The full model will be used unless `iteration_range` is
-        specified, meaning user have to either slice the model or use the
+        specified, meaning users have to either slice the model or use the
         ``best_iteration`` attribute to get prediction from best model returned from
         early stopping.
 


### PR DESCRIPTION
Fix a typo in the Python `predict` docstring in `core.py`.

- `user have` -> `users have`

No functional change.