### PR TITLE
update LightGBM links

### DIFF
--- a/R-package/CMakeLists.txt
+++ b/R-package/CMakeLists.txt
@@ -15,7 +15,7 @@ if(ENABLE_ALL_WARNINGS)
 endif()
 
 if(MSVC)
-  # https://github.com/microsoft/LightGBM/pull/6061
+  # https://github.com/lightgbm-org/LightGBM/pull/6061
   # MSVC doesn't work with anonymous types in structs. (R complex)
   #
   # syntax error: missing ';' before identifier 'private_data_c'

--- a/cmake/FindOpenMPMacOS.cmake
+++ b/cmake/FindOpenMPMacOS.cmake
@@ -29,8 +29,8 @@ endmacro()
 # Patch libxgboost.dylib so that it depends on @rpath/libomp.dylib instead of
 # /opt/homebrew/opt/libomp/lib/libomp.dylib or other hard-coded paths.
 # Doing so enables XGBoost to interoperate with multiple kinds of OpenMP
-# libraries. See https://github.com/microsoft/LightGBM/pull/6391 for detailed
-# explanation. Adapted from https://github.com/microsoft/LightGBM/pull/6391
+# libraries. See https://github.com/lightgbm-org/LightGBM/pull/6391 for detailed
+# explanation. Adapted from https://github.com/lightgbm-org/LightGBM/pull/6391
 # by James Lamb.
 # MacOS only.
 function(patch_openmp_path_macos target target_default_output_name)

--- a/src/objective/lambdarank_obj.cc
+++ b/src/objective/lambdarank_obj.cc
@@ -175,7 +175,7 @@ class LambdaRankObj : public FitIntercept {
     auto lj = GroupLoss(g, &lj_full_);
 
     // Normalization, first used by LightGBM.
-    // https://github.com/microsoft/LightGBM/pull/2331#issuecomment-523259298
+    // https://github.com/lightgbm-org/LightGBM/pull/2331#issuecomment-523259298
     double sum_lambda{0.0};
 
     auto delta_op = [&](auto const&... args) {


### PR DESCRIPTION
LightGBM has moved out of `Microsoft/` to its own organization: https://github.com/lightgbm-org/LightGBM/issues/7187

This updates links in this project to reflect that.