### PR TITLE
[python-package] Fix import crash under python -OO by removing outdated docstring assignments

### DIFF
--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -1826,8 +1826,6 @@ class DaskXGBClassifier(XGBClassifierBase, DaskScikitLearnBase):
             iteration_range=iteration_range,
         )
 
-    predict_proba.__doc__ = XGBClassifier.predict_proba.__doc__
-
     async def _predict_async(
         self,
         data: _DataT,
@@ -2091,10 +2089,6 @@ class DaskXGBRanker(XGBRankerMixIn, DaskScikitLearnBase):
             base_margin_eval_set=base_margin_eval_set,
             feature_weights=feature_weights,
         )
-
-    # FIXME(trivialfis): arguments differ due to additional parameters like group and
-    # qid.
-    fit.__doc__ = XGBRanker.fit.__doc__
 
 
 @xgboost_model_doc(

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -1122,8 +1122,6 @@ class XGBModel(XGBModelBase):
         self.get_booster().save_model(fname)
         self.get_booster().set_attr(scikit_learn=None)
 
-    save_model.__doc__ = f"""{Booster.save_model.__doc__}"""
-
     def load_model(self, fname: ModelIn) -> None:
         # pylint: disable=attribute-defined-outside-init
         if not self.__sklearn_is_fitted__():
@@ -1143,8 +1141,6 @@ class XGBModel(XGBModelBase):
         self.get_booster().set_attr(scikit_learn=None)
         config = json.loads(self.get_booster().save_config())
         self._load_model_attributes(config)
-
-    load_model.__doc__ = f"""{Booster.load_model.__doc__}"""
 
     def _load_model_attributes(self, config: dict) -> None:
         """Load model attributes without hyper-parameters."""
@@ -1821,11 +1817,6 @@ class XGBClassifier(XGBClassifierBase, XGBModel):
 
             self._set_evaluation_result(evals_result)
             return self
-
-    assert XGBModel.fit.__doc__ is not None
-    fit.__doc__ = XGBModel.fit.__doc__.replace(
-        "Fit gradient boosting model", "Fit gradient boosting classifier", 1
-    )
 
     @_deprecate_positional_args
     def predict(


### PR DESCRIPTION
## Summary

Running XGBoost with `python -OO` (or `PYTHONOPTIMIZE=2`) strips all docstrings,
making `__doc__` attributes `None`. This causes an `AttributeError` at import time:

```
File "xgboost/sklearn.py", line 1826
    fit.__doc__ = XGBModel.fit.__doc__.replace(
AttributeError: 'NoneType' object has no attribute 'replace'
```

Additionally, `save_model` and `load_model` would display the literal string
`"None"` as their docstring under `-OO` due to f-string interpolation of `None`.

These manual `__doc__` overrides are all redundant — the `@xgboost_model_doc`
decorator already generates complete, accurate docstrings for all sklearn-compatible
classes.

## Changes

Removed the following outdated docstring assignments:

- `XGBClassifier.fit.__doc__` — `assert` + `.replace()` on `XGBModel.fit.__doc__` (crash)
- `XGBModel.save_model.__doc__` — f-string of `Booster.save_model.__doc__` (displays `"None"`)
- `XGBModel.load_model.__doc__` — f-string of `Booster.load_model.__doc__` (displays `"None"`)
- `DaskXGBRanker.fit.__doc__` — copy of `XGBRanker.fit.__doc__` (pointless under `-OO`)
- `DaskXGBClassifier.predict_proba.__doc__` — copy of `XGBClassifier.predict_proba.__doc__` (pointless under `-OO`)

## Files changed

- `python-package/xgboost/sklearn.py` — 7 lines removed
- `python-package/xgboost/dask/__init__.py` — 6 lines removed

Closes https://github.com/dmlc/xgboost/issues/8537