### PR TITLE
[python-package] Warn when xgb_model booster type mismatches training config

### DIFF
--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -3,7 +3,9 @@
 """Training Library containing training routines."""
 
 import copy
+import json
 import os
+import warnings
 import weakref
 from typing import (
     TYPE_CHECKING,
@@ -181,6 +183,20 @@ def train(
             raise ValueError(_RefError)
 
     bst = Booster(params, [dtrain] + [d[0] for d in evals], model_file=xgb_model)
+
+    if xgb_model is not None:
+        config = json.loads(bst.save_config())
+        model_booster = config["learner"]["gradient_booster"]["name"]
+        configured_booster = params.get("booster", "gbtree")
+        if model_booster != configured_booster:
+            warnings.warn(
+                f"Booster type mismatch: `xgb_model` uses '{model_booster}' but "
+                f"training is configured with booster='{configured_booster}'. "
+                f"The trees from `xgb_model` will not be carried forward.",
+                UserWarning,
+                stacklevel=2,
+            )
+
     start_iteration = 0
 
     if verbose_eval:

--- a/tests/python/test_training_continuation.py
+++ b/tests/python/test_training_continuation.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -158,6 +159,29 @@ class TestTrainingContinuation:
         clf.set_params(eval_metric="error")
         clf.fit(X, y, eval_set=[(X, y)], xgb_model=loaded)
         assert tm.non_increasing(clf.evals_result()["validation_0"]["error"])
+
+    def test_booster_type_mismatch_warning(self) -> None:
+        X = rng.randn(100, 10)
+        y = rng.randint(0, 2, size=100).astype(np.float32)
+        dtrain = xgb.DMatrix(X, label=y)
+
+        bst_tree = xgb.train({"booster": "gbtree"}, dtrain, num_boost_round=2)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            xgb.train(
+                {"booster": "gblinear"}, dtrain, num_boost_round=2, xgb_model=bst_tree
+            )
+            assert len(w) == 1
+            assert "Booster type mismatch" in str(w[0].message)
+
+        # No warning when booster types match.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            xgb.train(
+                {"booster": "gbtree"}, dtrain, num_boost_round=2, xgb_model=bst_tree
+            )
+            assert len(w) == 0
 
     @pytest.mark.parametrize("tree_method", ["hist", "approx", "exact"])
     def test_model_output(self, tree_method: str) -> None:


### PR DESCRIPTION
## Summary

When passing an `xgb_model` trained with one booster type (e.g. `gbtree`) to
`xgb.train()` configured with a different booster type (e.g. `gblinear`), the
original model's trees are silently discarded. This can be confusing — users
expect training continuation but get a fresh model instead.

This PR adds a `UserWarning` when the booster types differ:

```
UserWarning: Booster type mismatch: `xgb_model` uses 'gbtree' but training
is configured with booster='gblinear'. The trees from `xgb_model` will not
be carried forward.
```

The check is in `training.py` so it covers both the core `xgb.train()` API
and the sklearn `fit()` wrapper.

## Test plan

- Added `test_booster_type_mismatch_warning` in `test_training_continuation.py`
- Verifies warning is raised on mismatch (gbtree -> gblinear)
- Verifies no warning when types match (gbtree -> gbtree)

Closes https://github.com/dmlc/xgboost/issues/11473