### PR TITLE
[python-package] Fix python -OO crash by guarding __doc__ assignments

### DIFF
--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -1826,7 +1826,8 @@ class DaskXGBClassifier(XGBClassifierBase, DaskScikitLearnBase):
             iteration_range=iteration_range,
         )
 
-    predict_proba.__doc__ = XGBClassifier.predict_proba.__doc__
+    if XGBClassifier.predict_proba.__doc__ is not None:
+        predict_proba.__doc__ = XGBClassifier.predict_proba.__doc__
 
     async def _predict_async(
         self,
@@ -2094,7 +2095,8 @@ class DaskXGBRanker(XGBRankerMixIn, DaskScikitLearnBase):
 
     # FIXME(trivialfis): arguments differ due to additional parameters like group and
     # qid.
-    fit.__doc__ = XGBRanker.fit.__doc__
+    if XGBRanker.fit.__doc__ is not None:
+        fit.__doc__ = XGBRanker.fit.__doc__
 
 
 @xgboost_model_doc(

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -1122,7 +1122,8 @@ class XGBModel(XGBModelBase):
         self.get_booster().save_model(fname)
         self.get_booster().set_attr(scikit_learn=None)
 
-    save_model.__doc__ = f"""{Booster.save_model.__doc__}"""
+    if Booster.save_model.__doc__ is not None:
+        save_model.__doc__ = f"""{Booster.save_model.__doc__}"""
 
     def load_model(self, fname: ModelIn) -> None:
         # pylint: disable=attribute-defined-outside-init
@@ -1144,7 +1145,8 @@ class XGBModel(XGBModelBase):
         config = json.loads(self.get_booster().save_config())
         self._load_model_attributes(config)
 
-    load_model.__doc__ = f"""{Booster.load_model.__doc__}"""
+    if Booster.load_model.__doc__ is not None:
+        load_model.__doc__ = f"""{Booster.load_model.__doc__}"""
 
     def _load_model_attributes(self, config: dict) -> None:
         """Load model attributes without hyper-parameters."""
@@ -1822,10 +1824,10 @@ class XGBClassifier(XGBClassifierBase, XGBModel):
             self._set_evaluation_result(evals_result)
             return self
 
-    assert XGBModel.fit.__doc__ is not None
-    fit.__doc__ = XGBModel.fit.__doc__.replace(
-        "Fit gradient boosting model", "Fit gradient boosting classifier", 1
-    )
+    if XGBModel.fit.__doc__ is not None:
+        fit.__doc__ = XGBModel.fit.__doc__.replace(
+            "Fit gradient boosting model", "Fit gradient boosting classifier", 1
+        )
 
     @_deprecate_positional_args
     def predict(


### PR DESCRIPTION
## Summary

Fixes an import crash when running `python -OO` (or `PYTHONOPTIMIZE=2`) by guarding all runtime `__doc__` assignments against `None`.

Under `-OO`, Python strips all docstrings so `__doc__` is `None`. The existing code:
- Uses f-strings interpolating `Booster.save_model.__doc__` / `Booster.load_model.__doc__` (produces `None` in output)  
- Asserts `XGBModel.fit.__doc__ is not None` then calls `.replace()` on it (crashes with `AssertionError`)
- Copies `__doc__` from sklearn wrappers in dask (assigns `None` — harmless but pointless)

This PR wraps each `__doc__` assignment with `if source.__doc__ is not None:` so:
- Under `-OO`: assignments are silently skipped, no crash
- Under normal Python: docstrings work exactly as before

Closes #8537

Supersedes #12085 (reworked based on review feedback — previous approach removed docstrings entirely, this one preserves them)

## Test plan
- [x] `python -OO -c "import xgboost"` no longer crashes
- [x] Normal `python -c "import xgboost; help(xgboost.XGBClassifier.fit)"` still shows full docstrings