### PR TITLE
Add equality operators for WQSummary::Entry to support CUDA 12.6+

### DIFF
--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -48,6 +48,21 @@ struct WQSummary {
     // constructor
     XGBOOST_DEVICE Entry(RType rmin, RType rmax, RType wmin, DType value)
         : rmin(rmin), rmax(rmax), wmin(wmin), value(value) {}
+    /*!
+     * \brief equality comparison for Thrust algorithms
+     * \note Required by CUDA 12.6+ CCCL when using pair<..., Entry>
+     */
+    XGBOOST_DEVICE bool operator==(const Entry& other) const {
+      return rmin == other.rmin && rmax == other.rmax &&
+             wmin == other.wmin && value == other.value;
+    }
+    /*!
+     * \brief inequality comparison for Thrust algorithms
+     * \note Required by CUDA 12.6+ CCCL when using pair<..., Entry>
+     */
+    XGBOOST_DEVICE bool operator!=(const Entry& other) const {
+      return !(*this == other);
+    }
     /*! \return rmin estimation for v strictly bigger than value */
     XGBOOST_DEVICE RType RMinNext() const { return rmin + wmin; }
     /*! \return rmax estimation for v strictly smaller than value */


### PR DESCRIPTION
## Description
Add equality operators for `WQSummary::Entry` to support CUDA 12.6+ on Jetson platforms

## Background & Problem
When compiling XGBoost with **CUDA 12.6** , the build fails with the following error:

```
/usr/local/cuda/targets/aarch64-linux/include/cuda/std/__utility/pair.h(560): error: no operator "==" matches these operands
            operand types are: const xgboost::common::WQSummary<float, float>::Entry == const xgboost::common::WQSummary<float, float>::Entry
    return __x.first == __y.first && __x.second == __y.second;
```


This error occurs because **CUDA 12.6's CCCL (CUDA C++ Core Libraries)** requires types used in `thrust::pair` comparisons to have `operator==` defined. The error is triggered when Thrust algorithms like `unique_by_key` try to compare `thrust::pair<size_t, WQSummary<float, float>::Entry>` objects.

## Environment
- **CUDA Version**: 12.6
- **CUDA Architecture**: sm_87
- **Compiler**: GCC 11.4.0
- **XGBoost Version**: master

## Build Command
```bash
cmake .. \
  -DUSE_CUDA=ON \
  -DCMAKE_CUDA_ARCHITECTURES=87 \
  -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
  -DCMAKE_C_COMPILER=/usr/bin/gcc \
  -DCMAKE_CUDA_HOST_COMPILER=/usr/bin/gcc \
  -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
  -DBUILD_SHARED_LIBS=ON

make -j4
```

## Solution
Add the missing equality operators to WQSummary::Entry:

```
/*!
 * \brief equality comparison for Thrust algorithms
 * \note Required by CUDA 12.6+ CCCL when using pair<..., Entry>
 */
XGBOOST_DEVICE bool operator==(const Entry& other) const {
  return rmin == other.rmin && rmax == other.rmax &&
         wmin == other.wmin && value == other.value;
}

/*!
 * \brief inequality comparison for Thrust algorithms
 * \note Required by CUDA 12.6+ CCCL when using pair<..., Entry>
 */
XGBOOST_DEVICE bool operator!=(const Entry& other) const {
  return !(*this == other);
}
```