### PR TITLE
Fix macOS wheel OpenMP dependency resolution

### DIFF
--- a/ops/pipeline/build-python-wheels-macos.sh
+++ b/ops/pipeline/build-python-wheels-macos.sh
@@ -22,7 +22,6 @@ if [[ "$platform_id" == macosx_* ]]; then
         cpython_ver=310
         cibw_archs=x86_64
         export MACOSX_DEPLOYMENT_TARGET=10.15
-        export CIBW_CONFIG_SETTINGS='use_openmp=false'
     else
         echo "Platform not supported: $platform_id"
         exit 3
@@ -40,17 +39,7 @@ fi
 # Tell delocate-wheel to not vendor libomp.dylib into the wheel
 export CIBW_REPAIR_WHEEL_COMMAND_MACOS="delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} --exclude libomp.dylib"
 
-env | grep -E '^(CC|CXX|CFLAGS|CXXFLAGS|CPPFLAGS|LDFLAGS|SDKROOT|DEVELOPER_DIR|MACOSX_DEPLOYMENT_TARGET|PATH|CONDA_PREFIX)=' || true
-which clang || true
-which c++ || true
-/usr/bin/clang --version || true
-/usr/bin/c++ --version || true
-xcode-select -p || true
-brew list --versions libomp llvm llvm@18 || true
-ls -l /usr/local/opt/libomp /usr/local/opt/llvm@18 /usr/local/Cellar/llvm@18 || true
 brew unlink llvm@18 || true
-brew list --versions libomp llvm llvm@18 || true
-ls -l /usr/local/opt/libomp /usr/local/opt/llvm@18 /usr/local/Cellar/llvm@18 || true
 
 python -m pip install cibuildwheel
 python -m cibuildwheel python-package --output-dir wheelhouse

--- a/python-package/packager/nativelib.py
+++ b/python-package/packager/nativelib.py
@@ -43,19 +43,6 @@ def build_libxgboost(
     logger.info(
         "Building %s from the C++ source files in %s...", _lib_name(), str(cpp_src_dir)
     )
-    if system() == "Darwin":
-        for var_name in [
-            "CC",
-            "CXX",
-            "CFLAGS",
-            "CXXFLAGS",
-            "CPPFLAGS",
-            "LDFLAGS",
-            "SDKROOT",
-            "DEVELOPER_DIR",
-            "MACOSX_DEPLOYMENT_TARGET",
-        ]:
-            logger.info("%s=%s", var_name, os.environ.get(var_name, ""))
 
     def _build(*, generator: str) -> None:
         cmake_cmd = [
@@ -76,12 +63,7 @@ def build_libxgboost(
         else:
             nproc = os.cpu_count()
             assert build_tool is not None
-            build_cmd = [build_tool, f"-j{nproc}"]
-            if build_tool == "ninja":
-                build_cmd.append("-v")
-            else:
-                build_cmd.append("VERBOSE=1")
-            subprocess.check_call(build_cmd, cwd=build_dir)
+            subprocess.check_call([build_tool, f"-j{nproc}"], cwd=build_dir)
 
     if system() == "Windows":
         supported_generators = (
@@ -121,13 +103,7 @@ def build_libxgboost(
             build_config.use_openmp = False
             _build(generator=generator)
 
-    libxgboost = build_dir / "lib" / _lib_name()
-    if system() == "Darwin":
-        for cmd in (["otool", "-L", str(libxgboost)], ["otool", "-l", str(libxgboost)]):
-            logger.info("Running command: %s", " ".join(cmd))
-            logger.info("%s", subprocess.check_output(cmd, text=True))
-
-    return libxgboost
+    return build_dir / "lib" / _lib_name()
 
 
 def locate_local_libxgboost(


### PR DESCRIPTION
## Summary

This PR fixes the macOS x86_64 wheel CI failure.

The failing job was:

- `Build macOS wheel (macosx_x86_64)`

`delocate` failed while repairing the wheel because `libxgboost.dylib` picked up Homebrew LLVM's `libunwind.1.0.dylib`, and that dependency requires macOS 14.0 even though the wheel target is macOS 10.15.

## Root Cause

On the macOS Intel runner, the wheel build was resolving OpenMP through Homebrew. That introduced a dependency on Homebrew LLVM's `libunwind`, which caused wheel repair to fail with:

```text
delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 10.15:
.../libunwind.1.0.dylib has a minimum target of 14.0
