### PR TITLE
[python-package] Replace bare Any with specific types in sklearn helpers

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -649,7 +649,7 @@ def get_model_categories(
 
 
 def pick_ref_categories(
-    X: Any,
+    X: ArrayLike,
     model_cats: Optional[Union[FeatureTypes, Categories]],
     Xy_cats: Optional[Categories],
 ) -> Optional[Union[FeatureTypes, Categories]]:
@@ -682,22 +682,22 @@ def pick_ref_categories(
 def _wrap_evaluation_matrices(
     *,
     missing: float,
-    X: Any,
-    y: Any,
-    group: Optional[Any],
-    qid: Optional[Any],
-    sample_weight: Optional[Any],
-    base_margin: Optional[Any],
+    X: ArrayLike,
+    y: ArrayLike,
+    group: Optional[ArrayLike],
+    qid: Optional[ArrayLike],
+    sample_weight: Optional[ArrayLike],
+    base_margin: Optional[ArrayLike],
     feature_weights: Optional[ArrayLike],
-    eval_set: Optional[Sequence[Tuple[Any, Any]]],
-    sample_weight_eval_set: Optional[Sequence[Any]],
-    base_margin_eval_set: Optional[Sequence[Any]],
-    eval_group: Optional[Sequence[Any]],
-    eval_qid: Optional[Sequence[Any]],
+    eval_set: Optional[Sequence[Tuple[ArrayLike, ArrayLike]]],
+    sample_weight_eval_set: Optional[Sequence[ArrayLike]],
+    base_margin_eval_set: Optional[Sequence[ArrayLike]],
+    eval_group: Optional[Sequence[ArrayLike]],
+    eval_qid: Optional[Sequence[ArrayLike]],
     create_dmatrix: Callable,
     enable_categorical: bool,
     feature_types: Optional[Union[FeatureTypes, Categories]],
-) -> Tuple[Any, List[Tuple[Any, str]]]:
+) -> Tuple[DMatrix, List[Tuple[DMatrix, str]]]:
     """Convert array_like evaluation matrices into DMatrix. Perform sanity checks on the
     way.
 
@@ -1209,7 +1209,7 @@ class XGBModel(XGBModelBase):
                 wrapped = _metric_decorator(m)
             return wrapped
 
-        def invalid_type(m: Any) -> None:
+        def invalid_type(m: object) -> None:
             msg = f"Invalid type for the `eval_metric`: {type(m)}"
             raise TypeError(msg)
 

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -697,7 +697,7 @@ def _wrap_evaluation_matrices(
     create_dmatrix: Callable,
     enable_categorical: bool,
     feature_types: Optional[Union[FeatureTypes, Categories]],
-) -> Tuple[DMatrix, List[Tuple[DMatrix, str]]]:
+) -> Tuple[Any, List[Tuple[Any, str]]]:
     """Convert array_like evaluation matrices into DMatrix. Perform sanity checks on the
     way.
 


### PR DESCRIPTION
## Summary

Replace generic `Any` annotations with more descriptive types in sklearn.py internal helper functions. Follow-up to #6496.

**Changes:**

| Function | Parameter | Before | After |
|----------|-----------|--------|-------|
| `_wrap_evaluation_matrices` | `X`, `y` | `Any` | `ArrayLike` |
| `_wrap_evaluation_matrices` | `group`, `qid`, `sample_weight`, `base_margin` | `Optional[Any]` | `Optional[ArrayLike]` |
| `_wrap_evaluation_matrices` | `eval_set` | `Optional[Sequence[Tuple[Any, Any]]]` | `Optional[Sequence[Tuple[ArrayLike, ArrayLike]]]` |
| `_wrap_evaluation_matrices` | `*_eval_set`, `eval_group`, `eval_qid` | `Optional[Sequence[Any]]` | `Optional[Sequence[ArrayLike]]` |
| `pick_ref_categories` | `X` | `Any` | `ArrayLike` |
| `invalid_type` | `m` | `Any` | `object` |

The return type of `_wrap_evaluation_matrices` stays `Tuple[Any, ...]` since it is called with both `DMatrix` and `DaskDMatrix` (which does not extend `DMatrix`).

Remaining `Any` usages (`**kwargs: Any`, `Dict[str, Any]` for params) are intentional — they represent genuinely heterogeneous data or standard sklearn patterns.

## Test plan

- [x] CI pre-commit passes
- [x] CI mypy type check passes