### PR TITLE
[ci] Consolidate version query scripts into shared Python module

### DIFF
--- a/ops/pipeline/query-latest-cccl.sh
+++ b/ops/pipeline/query-latest-cccl.sh
@@ -4,23 +4,5 @@
 
 set -euo pipefail
 
-tmpfile="$(mktemp /tmp/abc-script.XXXXXX)"
-cat >"$tmpfile" <<EOL
-import fileinput
-
-from packaging.version import InvalidVersion, Version
-
-versions = []
-for e in fileinput.input():
-    try:
-        tag = e.strip()
-        versions.append((tag, Version(tag)))
-    except InvalidVersion:
-        pass
-print(max(versions, key=lambda x : x[1])[0])
-EOL
-export CCCL_VERSION=$(
-  gh api repos/NVIDIA/cccl/tags --paginate --jq '.[].name' | python3 "$tmpfile"
-)
+export CCCL_VERSION=$(python3 ops/pipeline/query-latest-version.py --repo NVIDIA/cccl)
 echo "--- Latest CCCL version: ${CCCL_VERSION}"
-rm "$tmpfile"

--- a/ops/pipeline/query-latest-rmm.sh
+++ b/ops/pipeline/query-latest-rmm.sh
@@ -3,27 +3,5 @@
 
 set -euo pipefail
 
-tmpfile="$(mktemp /tmp/abc-script.XXXXXX)"
-cat >"$tmpfile" <<EOL
-import fileinput
-import re
-
-from packaging.version import InvalidVersion, Version
-
-versions = []
-for e in fileinput.input():
-    try:
-        tag = e.strip()
-        versions.append((tag, Version(tag)))
-    except InvalidVersion:
-        pass
-latest_tag = max(versions, key=lambda x : x[1])[0]
-
-m = re.search(r"v([0-9]{2}.[0-9]{2})", latest_tag)
-print(m.group(1))
-EOL
-export RMM_VERSION=$(
-  gh api repos/rapidsai/rmm/tags --paginate --jq '.[].name' | python3 "$tmpfile"
-)
+export RMM_VERSION=$(python3 ops/pipeline/query-latest-version.py --repo rapidsai/rmm --extract-minor)
 echo "--- Latest RMM version: ${RMM_VERSION}"
-rm "$tmpfile"

--- a/ops/pipeline/query-latest-version.py
+++ b/ops/pipeline/query-latest-version.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Query the latest version tag from a GitHub repository.
+
+Usage:
+    python3 ops/pipeline/query-latest-version.py --repo NVIDIA/cccl
+    python3 ops/pipeline/query-latest-version.py --repo rapidsai/rmm --extract-minor
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+from packaging.version import InvalidVersion, Version
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Query the latest version tag from a GitHub repository."
+    )
+    parser.add_argument(
+        "--repo", required=True, help="GitHub repo, e.g. NVIDIA/cccl or rapidsai/rmm"
+    )
+    parser.add_argument(
+        "--extract-minor",
+        action="store_true",
+        help="Extract only the major.minor version (e.g. 25.06 from v25.06.00a1)",
+    )
+    args = parser.parse_args()
+
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{args.repo}/tags",
+            "--paginate",
+            "--jq",
+            ".[].name",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    versions = []
+    for tag in result.stdout.strip().split("\n"):
+        tag = tag.strip()
+        if not tag:
+            continue
+        try:
+            versions.append((tag, Version(tag)))
+        except InvalidVersion:
+            pass
+
+    if not versions:
+        print(f"No valid version tags found in {args.repo}", file=sys.stderr)
+        sys.exit(1)
+
+    latest_tag = max(versions, key=lambda x: x[1])[0]
+
+    if args.extract_minor:
+        m = re.search(r"v?(\d+\.\d+)", latest_tag)
+        if m:
+            print(m.group(1))
+        else:
+            print(latest_tag)
+    else:
+        print(latest_tag)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Extract duplicated inline Python from `query-latest-cccl.sh` and `query-latest-rmm.sh` into a shared `query-latest-version.py` script. Ref #11870.

**Before:** Each shell script created a tmpfile with ~20 lines of inline Python (parsing version tags via `packaging.Version`), ran it, then cleaned up. The logic was near-identical between the two scripts.

**After:** A single `query-latest-version.py` handles both repos:
```bash
python3 ops/pipeline/query-latest-version.py --repo NVIDIA/cccl
python3 ops/pipeline/query-latest-version.py --repo rapidsai/rmm --extract-minor
```

The shell scripts become thin wrappers (4 lines each) that set the expected environment variable. No workflow YAML changes needed.

**Net result:** -42 lines of duplicated bash/inline-python, +74 lines of clean Python with proper arg parsing and error handling.

## Test plan

- [x] CI pre-commit passes (verified locally in Docker container)
- [x] ruff check + ruff format pass
- [x] mypy passes with `--disallow-untyped-defs`