### PR TITLE
[cmake] fix building with system-installed dmlc-core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,7 @@ endif()
 # core xgboost
 add_subdirectory(${xgboost_SOURCE_DIR}/src)
 # dmlc-core
-if(BUIILD_WTIH_SYSTEM_DMLC)
+if(BUILD_WTIH_SYSTEM_DMLC)
   target_link_libraries(objxgboost PUBLIC ${dmlc-LIBRARIES})
 else()
   target_link_libraries(objxgboost PUBLIC dmlc)


### PR DESCRIPTION
#12055 introduced a typo, `BUIILD_WTIH_SYSTEM_DMLC`, that prevents system-installed dlmc-core libraries from actually being linked with `target_link_libraries()`.

This fixes that.