### PR TITLE
[doc] Add Spark 4.0 compatibility warning for JVM packages

### DIFF
--- a/doc/jvm/xgboost4j_spark_tutorial.rst
+++ b/doc/jvm/xgboost4j_spark_tutorial.rst
@@ -40,6 +40,21 @@ in order to add XGBoost4J-Spark as a dependency for your project. We provide bot
   Also, make sure to install Spark directly from `Apache website <https://spark.apache.org/>`_. **Upstream XGBoost is not guaranteed to
   work with third-party distributions of Spark, such as Cloudera Spark.** Consult appropriate third parties to obtain their distribution of XGBoost.
 
+.. warning:: Spark 4.0.0 is not compatible with XGBoost4J-Spark
+
+  Apache Spark 4.0.0 introduced a breaking change to the ``org.apache.spark.ml.param.Param`` class
+  constructor (`SPARK-52259 <https://issues.apache.org/jira/browse/SPARK-52259>`_), which causes a
+  ``NoSuchMethodError`` when instantiating any XGBoost estimator:
+
+  .. code-block:: text
+
+    java.lang.NoSuchMethodError: 'void org.apache.spark.ml.param.Param.<init>(
+        org.apache.spark.ml.util.Identifiable, java.lang.String, java.lang.String, scala.Function1)'
+
+  This issue affects all third-party ML libraries that use ``Param``. It was fixed in
+  **Spark 4.0.1** and **Spark 4.1.0**. If you are using Spark 4.x, please upgrade to
+  **Spark 4.0.1 or later**.
+
 Data Preparation
 ================
 

--- a/doc/jvm/xgboost_spark_migration.rst
+++ b/doc/jvm/xgboost_spark_migration.rst
@@ -113,3 +113,18 @@ Starting from xgboost4j-spark 3.0, below parameters are removed.
 - singlePrecisionHistogram
 - lambdaBias
 - objectiveType
+
+***************************
+Spark 4.0 Compatibility
+***************************
+
+XGBoost4J-Spark JARs built against Spark 3.5 are binary compatible with **Spark 4.0.1+** and
+**Spark 4.1.0+**. No code changes are required.
+
+.. warning::
+
+  **Spark 4.0.0** is **not** compatible due to an upstream bug
+  (`SPARK-52259 <https://issues.apache.org/jira/browse/SPARK-52259>`_) that changed the
+  constructor signature of ``org.apache.spark.ml.param.Param``. This causes a
+  ``NoSuchMethodError`` at runtime when instantiating any XGBoost estimator. The fix is included
+  in Spark 4.0.1 and later. Please avoid Spark 4.0.0 and upgrade to at least **Spark 4.0.1**.


### PR DESCRIPTION
## Summary

- Add a warning to the XGBoost4J-Spark tutorial (`doc/jvm/xgboost4j_spark_tutorial.rst`) about Spark 4.0.0 binary incompatibility
- Add a "Spark 4.0 Compatibility" section to the migration guide (`doc/jvm/xgboost_spark_migration.rst`)

## Context

Apache Spark 4.0.0 introduced a breaking change to `org.apache.spark.ml.param.Param` constructor ([SPARK-52259](https://issues.apache.org/jira/browse/SPARK-52259)), which causes `NoSuchMethodError` when instantiating any XGBoost estimator (e.g., `XGBoostClassifier`, `XGBoostRegressor`). This affects all third-party ML libraries that use `Param`.

**Test results:**
| Spark Version | Result |
|---|---|
| 4.0.0 | **FAIL** — `NoSuchMethodError` on `Param` constructor |
| 4.1.0 | **PASS** — XGBoostClassifier trains and predicts correctly |

The upstream fix is included in Spark 4.0.1 (released 2025-09-02) and Spark 4.1.0. XGBoost4J-Spark JARs built against Spark 3.5 work on Spark 4.0.1+ without any code changes.

This PR adds documentation warnings so users know to avoid Spark 4.0.0 and use Spark 4.0.1 or later.

## Related

- #11510 — [discussion] How to support Spark 4.0
- #11498 — [jvm-packages] Upgrade to Java 17+
- [SPARK-52259](https://issues.apache.org/jira/browse/SPARK-52259) — Fix Param class binary compatibility

Made with [Cursor](https://cursor.com)