### PR TITLE
[python-package] fix _validate_feature_info() error message, other small fixes

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -163,7 +163,7 @@ def _validate_feature_info(
     feature_info = list(feature_info)
     if len(feature_info) != n_features and n_features != 0 and not is_column_split:
         msg = (
-            f"{name} must have the same length as the number of data columns, ",
+            f"{name} must have the same length as the number of data columns, "
             f"expected {n_features}, got {len(feature_info)}",
         )
         raise ValueError(msg)

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -266,7 +266,7 @@ def to_graphviz(
 
     if num_trees is not None:
         warnings.warn(
-            "The `num_trees` parameter is deprecated, use `tree_idx` insetad. ",
+            "The `num_trees` parameter is deprecated, use `tree_idx` instead. ",
             FutureWarning,
         )
         if tree_idx not in (0, num_trees):

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -281,7 +281,7 @@ class _PackedBooster:
 
     @best_iteration.setter
     def best_iteration(self, iteration: int) -> None:
-        """Get best_iteration"""
+        """Set best_iteration"""
         self.set_attr(best_iteration=iteration)
 
     @property
@@ -439,7 +439,7 @@ def cv(
     *,
     nfold: int = 3,
     stratified: bool = False,
-    folds: XGBStratifiedKFold = None,
+    folds: Optional[XGBStratifiedKFold] = None,
     metrics: Sequence[str] = (),
     obj: Optional[PlainObj] = None,
     maximize: Optional[bool] = None,


### PR DESCRIPTION
Fixes a couple tiny things in the Python package:

* an incomplete type hint in `cv()`
* a setter's docstring that said it "get"s a value
* issues in some error messages (a typo, an inadvertent tuple when string concatenation was intended)