### PR TITLE
Expand CPU quantile property tests and remove redundant cases

### DIFF
--- a/tests/cpp/common/test_hist_util.cc
+++ b/tests/cpp/common/test_hist_util.cc
@@ -141,44 +141,6 @@ TEST(HistUtil, DenseCutsCategorical) {
   }
 }
 
-TEST(HistUtil, DenseCutsAccuracyTest) {
-  Context ctx;
-  int bin_sizes[] = {2, 16, 256, 512};
-  int sizes[] = {100};
-  int num_columns = 5;
-  for (auto num_rows : sizes) {
-    auto x = GenerateRandom(num_rows, num_columns);
-    auto dmat = GetDMatrixFromData(x, num_rows, num_columns);
-    for (auto num_bins : bin_sizes) {
-      HistogramCuts cuts = SketchOnDMatrix(&ctx, dmat.get(), num_bins);
-      ValidateCuts(cuts, dmat.get(), num_bins);
-    }
-  }
-}
-
-TEST(HistUtil, DenseCutsAccuracyTestWeights) {
-  int bin_sizes[] = {2, 16, 256, 512};
-  int sizes[] = {100, 1000, 1500};
-  int num_columns = 5;
-  Context ctx;
-  for (auto num_rows : sizes) {
-    auto x = GenerateRandom(num_rows, num_columns);
-    auto dmat = GetDMatrixFromData(x, num_rows, num_columns);
-    auto w = GenerateRandomWeights(num_rows);
-    dmat->Info().weights_.HostVector() = w;
-    for (auto num_bins : bin_sizes) {
-      {
-        HistogramCuts cuts = SketchOnDMatrix(&ctx, dmat.get(), num_bins, true);
-        ValidateCuts(cuts, dmat.get(), num_bins);
-      }
-      {
-        HistogramCuts cuts = SketchOnDMatrix(&ctx, dmat.get(), num_bins, false);
-        ValidateCuts(cuts, dmat.get(), num_bins);
-      }
-    }
-  }
-}
-
 TEST(HistUtil, SortedWeightedExactCuts) {
   Context ctx;
   std::vector<float> x{0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f};

--- a/tests/cpp/common/test_hist_util.cc
+++ b/tests/cpp/common/test_hist_util.cc
@@ -121,47 +121,6 @@ TEST(ParallelGHistBuilder, Reset) { ParallelGHistBuilderReset(); }
 
 TEST(ParallelGHistBuilder, ReduceHist) { ParallelGHistBuilderReduceHist(); }
 
-TEST(HistUtil, DenseCutsCategorical) {
-  Context ctx;
-  int categorical_sizes[] = {2, 6, 8, 12};
-  int num_bins = 256;
-  int sizes[] = {25, 100, 1000};
-  for (auto n : sizes) {
-    for (auto num_categories : categorical_sizes) {
-      auto x = GenerateRandomCategoricalSingleColumn(n, num_categories);
-      std::vector<float> x_sorted(x);
-      std::sort(x_sorted.begin(), x_sorted.end());
-      auto dmat = GetDMatrixFromData(x, n, 1);
-      HistogramCuts cuts = SketchOnDMatrix(&ctx, dmat.get(), num_bins);
-      auto cuts_from_sketch = cuts.Values();
-      EXPECT_GT(cuts_from_sketch.front(), x_sorted.front());
-      EXPECT_GE(cuts_from_sketch.back(), x_sorted.back());
-      EXPECT_EQ(cuts_from_sketch.size(), static_cast<size_t>(num_categories));
-    }
-  }
-}
-
-TEST(HistUtil, SortedWeightedExactCuts) {
-  Context ctx;
-  std::vector<float> x{0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
-  std::vector<float> weights{3.0f, 0.25f, 7.0f, 2.0f, 0.5f, 4.0f};
-  auto dmat = GetDMatrixFromData(x, x.size(), 1);
-  dmat->Info().weights_.HostVector() = weights;
-
-  auto sorted_cuts = SketchOnDMatrix(&ctx, dmat.get(), x.size(), true);
-  auto row_cuts = SketchOnDMatrix(&ctx, dmat.get(), x.size(), false);
-
-  ASSERT_EQ(sorted_cuts.Ptrs(), row_cuts.Ptrs());
-  ASSERT_EQ(sorted_cuts.Values().size(), row_cuts.Values().size());
-  ASSERT_EQ(sorted_cuts.Values().size(), x.size());
-  for (std::size_t i = 1; i < x.size(); ++i) {
-    EXPECT_FLOAT_EQ(sorted_cuts.Values()[i - 1], x[i]);
-    EXPECT_FLOAT_EQ(sorted_cuts.Values()[i - 1], row_cuts.Values()[i - 1]);
-  }
-  EXPECT_GT(sorted_cuts.Values().back(), x.back());
-  EXPECT_FLOAT_EQ(sorted_cuts.Values().back(), row_cuts.Values().back());
-}
-
 void TestQuantileWithHessian(bool use_sorted) {
   int bin_sizes[] = {2, 16, 256, 512};
   int sizes[] = {1000, 1500};
@@ -386,13 +345,4 @@ TEST(HistUtil, GroupWeightsEquivalentToRowWeights) {
   TestGroupWeightsEquivalentToRowWeights(false);
 }
 
-TEST(HistUtil, SketchCategoricalFeatures) {
-  Context ctx;
-  TestCategoricalSketch(1000, 256, 32, false, [&ctx](DMatrix* p_fmat, int32_t num_bins) {
-    return SketchOnDMatrix(&ctx, p_fmat, num_bins);
-  });
-  TestCategoricalSketch(1000, 256, 32, true, [&ctx](DMatrix* p_fmat, int32_t num_bins) {
-    return SketchOnDMatrix(&ctx, p_fmat, num_bins);
-  });
-}
 }  // namespace xgboost::common

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -19,6 +19,7 @@ namespace quantile_test {
 class QuantileSummaryTest : public ::testing::TestWithParam<SummaryCase> {};
 class QuantileContainerTest : public ::testing::TestWithParam<ContainerCase> {};
 class QuantileDistributedContainerTest : public ::testing::TestWithParam<ContainerCase> {};
+class QuantileSketchOnDMatrixTest : public ::testing::TestWithParam<ContainerCase> {};
 
 namespace {
 void TestSummaryInvariants(SummaryCase const& c, WQSummaryContainer const& summary,
@@ -64,7 +65,8 @@ void TestSummaryInvariants(SummaryCase const& c, WQSummaryContainer const& summa
     }
   }
 }
-void TestContainerInvariants(ContainerCase const& c, HistogramCuts const& cuts, DMatrix* dmat) {
+void TestContainerInvariants(ContainerCase const& c, HistogramCuts const& cuts, DMatrix* dmat,
+                             std::vector<std::vector<WeightedValue>> const& columns) {
   ASSERT_EQ(cuts.Ptrs().size(), c.cols + 1) << "case=" << c.name;
   // Every feature should contribute at least one strictly increasing cut value sequence.
   for (std::size_t fidx = 0; fidx < c.cols; ++fidx) {
@@ -76,8 +78,6 @@ void TestContainerInvariants(ContainerCase const& c, HistogramCuts const& cuts, 
           << "case=" << c.name << ", feature=" << fidx;
     }
   }
-
-  auto columns = CollectWeightedColumns(dmat);
   auto ft = dmat->Info().feature_types.ConstHostSpan();
   auto max_error =
       c.weights == WeightKind::kRow ? kMaxWeightedNormalizedRankError : kMaxNormalizedRankError;
@@ -93,43 +93,50 @@ void TestContainerInvariants(ContainerCase const& c, HistogramCuts const& cuts, 
   }
 }
 
-auto MakeDenseReferenceDMatrix(std::vector<std::shared_ptr<DMatrix>> const& blocks,
-                               Span<FeatureType const> ft,
-                               std::vector<std::vector<float>> const& weights, std::size_t rows,
-                               std::size_t cols) -> std::shared_ptr<DMatrix> {
-  std::vector<float> full(rows * cols, std::numeric_limits<float>::quiet_NaN());
-  std::vector<float> full_weights;
-  if (!weights.empty()) {
-    full_weights.reserve(rows);
+void SameOnAllWorkers(Context const* ctx, HistogramCuts const& cuts) {
+  auto const world = collective::GetWorldSize();
+  if (world <= 1) {
+    return;
   }
 
-  std::size_t row_offset = 0;
-  for (std::size_t block_idx = 0; block_idx < blocks.size(); ++block_idx) {
-    auto const& m = blocks[block_idx];
-    std::size_t local_row = 0;
-    for (auto const& batch : m->GetBatches<SparsePage>()) {
-      auto page = batch.GetView();
-      for (std::size_t ridx = 0; ridx < batch.Size(); ++ridx) {
-        auto base = (row_offset + local_row) * cols;
-        for (auto e : page[ridx]) {
-          full[base + e.index] = e.fvalue;
-        }
-        ++local_row;
-      }
-    }
-    if (!weights.empty()) {
-      full_weights.insert(full_weights.end(), weights[block_idx].cbegin(),
-                          weights[block_idx].cend());
-    }
-    row_offset += m->Info().num_row_;
-  }
+  std::vector<float> cut_values(cuts.Values().size() * world, 0.0f);
+  std::vector<typename std::remove_reference_t<decltype(cuts.Ptrs())>::value_type> cut_ptrs(
+      cuts.Ptrs().size() * world, 0);
 
-  auto full_m = GetDMatrixFromData(full, rows, cols);
-  full_m->Info().feature_types.HostVector() = {ft.cbegin(), ft.cend()};
-  if (!full_weights.empty()) {
-    full_m->Info().weights_.HostVector() = std::move(full_weights);
+  std::int64_t value_size = cuts.Values().size();
+  std::int64_t ptr_size = cuts.Ptrs().size();
+  auto rc = collective::Success() << [&] {
+    return collective::Allreduce(ctx, &value_size, collective::Op::kMax);
+  } << [&] {
+    return collective::Allreduce(ctx, &ptr_size, collective::Op::kMax);
+  };
+  collective::SafeColl(rc);
+
+  auto rank = collective::GetRank();
+  auto value_offset = static_cast<std::size_t>(value_size) * rank;
+  std::copy(cuts.Values().begin(), cuts.Values().end(), cut_values.begin() + value_offset);
+  auto ptr_offset = static_cast<std::size_t>(ptr_size) * rank;
+  std::copy(cuts.Ptrs().cbegin(), cuts.Ptrs().cend(), cut_ptrs.begin() + ptr_offset);
+
+  rc = collective::Success() << [&] {
+    return collective::Allreduce(ctx, linalg::MakeVec(cut_values.data(), cut_values.size()),
+                                 collective::Op::kSum);
+  } << [&] {
+    return collective::Allreduce(ctx, linalg::MakeVec(cut_ptrs.data(), cut_ptrs.size()),
+                                 collective::Op::kSum);
+  };
+  collective::SafeColl(rc);
+
+  for (std::int32_t worker = 0; worker < world; ++worker) {
+    for (std::int64_t j = 0; j < value_size; ++j) {
+      auto idx = static_cast<std::size_t>(worker) * value_size + j;
+      ASSERT_NEAR(cuts.Values().at(j), cut_values.at(idx), kRtEps);
+    }
+    for (std::int64_t j = 0; j < ptr_size; ++j) {
+      auto idx = static_cast<std::size_t>(worker) * ptr_size + j;
+      ASSERT_EQ(cuts.Ptrs().at(j), cut_ptrs.at(idx));
+    }
   }
-  return full_m;
 }
 }  // namespace
 
@@ -187,7 +194,8 @@ TEST_P(QuantileContainerTest, Invariants) {
     row_sketch.PushRowPage(page, m->Info(), hess);
   }
   auto row_cuts = row_sketch.MakeCuts(&ctx, m->Info());
-  TestContainerInvariants(c, row_cuts, m.get());
+  auto columns = CollectWeightedColumns(m.get());
+  TestContainerInvariants(c, row_cuts, m.get(), columns);
 
   HostSketchContainer sorted_sketch(&ctx, c.max_bin, m->Info().feature_types.ConstHostSpan(),
                                     column_size, false);
@@ -195,7 +203,32 @@ TEST_P(QuantileContainerTest, Invariants) {
     sorted_sketch.PushColPage(page, m->Info(), hess);
   }
   auto sorted_cuts = sorted_sketch.MakeCuts(&ctx, m->Info());
-  TestContainerInvariants(c, sorted_cuts, m.get());
+  TestContainerInvariants(c, sorted_cuts, m.get(), columns);
+}
+
+TEST_P(QuantileSketchOnDMatrixTest, Invariants) {
+  auto c = GetParam();
+  Context ctx;
+  auto ft = FeatureTypes(c);
+  auto m = RandomDataGenerator{c.rows, c.cols, c.sparsity}
+               .Seed(c.seed)
+               .Lower(.0f)
+               .Upper(1.0f)
+               .Type(ft)
+               .MaxCategory(13)
+               .GenerateDMatrix();
+  if (c.weights == WeightKind::kRow) {
+    m->Info().weights_.HostVector() = GenerateWeights(c.rows, c.seed + 2048);
+  }
+
+  auto columns = CollectWeightedColumns(m.get());
+  std::vector<float> hessian(c.rows, 1.0f);
+  auto hess = Span<float const>{hessian};
+  auto row_cuts = SketchOnDMatrix(&ctx, m.get(), c.max_bin, false, hess);
+  TestContainerInvariants(c, row_cuts, m.get(), columns);
+
+  auto sorted_cuts = SketchOnDMatrix(&ctx, m.get(), c.max_bin, true, hess);
+  TestContainerInvariants(c, sorted_cuts, m.get(), columns);
 }
 
 namespace {
@@ -237,10 +270,14 @@ void DoPropertyDistributedQuantile(ContainerCase const& c) {
   }
   auto sorted_cuts = sorted_sketch.MakeCuts(&ctx, m->Info());
 
+  SameOnAllWorkers(&ctx, row_cuts);
+  SameOnAllWorkers(&ctx, sorted_cuts);
+
   collective::Finalize();
   CHECK_EQ(collective::GetWorldSize(), 1);
-  TestContainerInvariants(c, row_cuts, full_m.get());
-  TestContainerInvariants(c, sorted_cuts, full_m.get());
+  auto columns = CollectWeightedColumns(full_m.get());
+  TestContainerInvariants(c, row_cuts, full_m.get(), columns);
+  TestContainerInvariants(c, sorted_cuts, full_m.get(), columns);
 }
 }  // namespace
 
@@ -252,6 +289,8 @@ TEST_P(QuantileDistributedContainerTest, Invariants) {
 INSTANTIATE_TEST_SUITE_P(Anchors, QuantileContainerTest,
                          ::testing::ValuesIn(ContainerAnchorCases()), ContainerCaseName);
 INSTANTIATE_TEST_SUITE_P(Anchors, QuantileDistributedContainerTest,
+                         ::testing::ValuesIn(ContainerAnchorCases()), ContainerCaseName);
+INSTANTIATE_TEST_SUITE_P(Anchors, QuantileSketchOnDMatrixTest,
                          ::testing::ValuesIn(ContainerAnchorCases()), ContainerCaseName);
 }  // namespace quantile_test
 
@@ -436,73 +475,4 @@ TEST(Quantile, ColumnSplitSorted) {
   TestColSplitQuantile<true>(kRows, kCols);
 }
 
-namespace {
-void TestSameOnAllWorkers() {
-  auto const world = collective::GetWorldSize();
-  constexpr size_t kRows = 1000, kCols = 100;
-  Context ctx;
-
-  RunWithSeedsAndBins(kRows, [=, &ctx](int32_t seed, size_t n_bins, MetaInfo const&) {
-    auto rank = collective::GetRank();
-    HostDeviceVector<float> storage;
-    std::vector<FeatureType> ft(kCols);
-    for (size_t i = 0; i < ft.size(); ++i) {
-      ft[i] = (i % 2 == 0) ? FeatureType::kNumerical : FeatureType::kCategorical;
-    }
-
-    auto m = RandomDataGenerator{kRows, kCols, 0}
-                 .Device(DeviceOrd::CPU())
-                 .Type(ft)
-                 .MaxCategory(17)
-                 .Seed(rank + seed)
-                 .GenerateDMatrix();
-    auto cuts = SketchOnDMatrix(&ctx, m.get(), n_bins);
-    std::vector<float> cut_values(cuts.Values().size() * world, 0);
-    std::vector<typename std::remove_reference_t<decltype(cuts.Ptrs())>::value_type> cut_ptrs(
-        cuts.Ptrs().size() * world, 0);
-
-    std::int64_t value_size = cuts.Values().size();
-    std::int64_t ptr_size = cuts.Ptrs().size();
-
-    auto rc = collective::Success() << [&] {
-      return collective::Allreduce(&ctx, &value_size, collective::Op::kMax);
-    } << [&] {
-      return collective::Allreduce(&ctx, &ptr_size, collective::Op::kMax);
-    };
-    collective::SafeColl(rc);
-    ASSERT_EQ(ptr_size, kCols + 1);
-
-    std::size_t value_offset = value_size * rank;
-    std::copy(cuts.Values().begin(), cuts.Values().end(), cut_values.begin() + value_offset);
-    std::size_t ptr_offset = ptr_size * rank;
-    std::copy(cuts.Ptrs().cbegin(), cuts.Ptrs().cend(), cut_ptrs.begin() + ptr_offset);
-
-    rc = std::move(rc) << [&] {
-      return collective::Allreduce(&ctx, linalg::MakeVec(cut_values.data(), cut_values.size()),
-                                   collective::Op::kSum);
-    } << [&] {
-      return collective::Allreduce(&ctx, linalg::MakeVec(cut_ptrs.data(), cut_ptrs.size()),
-                                   collective::Op::kSum);
-    };
-    collective::SafeColl(rc);
-
-    for (std::int32_t i = 0; i < world; i++) {
-      for (std::int64_t j = 0; j < value_size; ++j) {
-        size_t idx = i * value_size + j;
-        ASSERT_NEAR(cuts.Values().at(j), cut_values.at(idx), kRtEps);
-      }
-
-      for (std::int64_t j = 0; j < ptr_size; ++j) {
-        size_t idx = i * ptr_size + j;
-        EXPECT_EQ(cuts.Ptrs().at(j), cut_ptrs.at(idx));
-      }
-    }
-  });
-}
-}  // anonymous namespace
-
-TEST(Quantile, SameOnAllWorkers) {
-  auto constexpr kWorkers = 4;
-  collective::TestDistributedGlobal(kWorkers, [] { TestSameOnAllWorkers(); });
-}
 }  // namespace xgboost::common

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -270,9 +270,6 @@ void DoPropertyDistributedQuantile(ContainerCase const& c) {
   }
   auto sorted_cuts = sorted_sketch.MakeCuts(&ctx, m->Info());
 
-  SameOnAllWorkers(&ctx, row_cuts);
-  SameOnAllWorkers(&ctx, sorted_cuts);
-
   collective::Finalize();
   CHECK_EQ(collective::GetWorldSize(), 1);
   auto columns = CollectWeightedColumns(full_m.get());
@@ -310,13 +307,6 @@ TEST(Quantile, LoadBalance) {
   CHECK_EQ(n_cols, kCols);
 }
 
-TEST(Quantile, InitWithEmptyColumn) {
-  WQuantileSketch sketch{0, 0.1};
-
-  auto out = sketch.GetSummary(1);
-  ASSERT_EQ(out.Size(), 0);
-}
-
 TEST(Quantile, TrackSketchElements) {
   WQuantileSketch sketch{16, 0.1};
   ASSERT_EQ(sketch.NumElements(), 0);
@@ -345,37 +335,50 @@ TEST(Quantile, TrackSketchElementsSorted) {
   ASSERT_EQ(sketch.NumElements(), 3);
 }
 namespace {
-template <bool use_column>
-void PushPage(HostSketchContainer* container, SparsePage const& page, MetaInfo const& info,
-              Span<float const> hessian) {
-  if constexpr (use_column) {
-    container->PushColPage(page, info, hessian);
-  } else {
-    container->PushRowPage(page, info, hessian);
+void TestColumnSplitInvariants(
+    quantile_test::ContainerCase const& c, HistogramCuts const& cuts, DMatrix* dmat,
+    std::vector<std::vector<quantile_test::WeightedValue>> const& columns, std::size_t f_begin,
+    std::size_t f_end) {
+  ASSERT_EQ(cuts.Ptrs().size(), c.cols + 1) << "case=" << c.name;
+  auto ft = dmat->Info().feature_types.ConstHostSpan();
+  auto max_error = c.weights == quantile_test::WeightKind::kRow
+                       ? quantile_test::kMaxWeightedNormalizedRankError
+                       : quantile_test::kMaxNormalizedRankError;
+  for (std::size_t i = f_begin; i < f_end; ++i) {
+    auto beg = cuts.Ptrs()[i];
+    auto end = cuts.Ptrs()[i + 1];
+    ASSERT_LT(beg, end) << "case=" << c.name << ", feature=" << i;
+    for (auto j = beg + 1; j < end; ++j) {
+      EXPECT_LT(cuts.Values()[j - 1], cuts.Values()[j]) << "case=" << c.name << ", feature=" << i;
+    }
+    if (columns[i].empty()) {
+      continue;
+    }
+    if (!ft.empty() && IsCat(ft, i)) {
+      quantile_test::ValidateCategoricalCuts(cuts, i, columns[i]);
+    } else {
+      quantile_test::ValidateNumericalCuts(cuts, i, columns[i], c.max_bin, max_error);
+    }
   }
 }
 
-template <bool use_column>
-void DoTestColSplitQuantile(size_t rows, size_t cols) {
+void DoPropertyColumnSplitQuantile(size_t rows, size_t cols) {
   Context ctx;
   auto const world = collective::GetWorldSize();
   auto const rank = collective::GetRank();
-
-  auto m = std::unique_ptr<DMatrix>{[=]() {
-    auto sparsity = 0.5f;
-    std::vector<FeatureType> ft(cols);
-    for (size_t i = 0; i < ft.size(); ++i) {
-      ft[i] = (i % 2 == 0) ? FeatureType::kNumerical : FeatureType::kCategorical;
-    }
-    auto dmat = RandomDataGenerator{rows, cols, sparsity}
+  auto sparsity = 0.5f;
+  std::vector<FeatureType> ft(cols);
+  for (size_t i = 0; i < ft.size(); ++i) {
+    ft[i] = (i % 2 == 0) ? FeatureType::kNumerical : FeatureType::kCategorical;
+  }
+  auto full_m = RandomDataGenerator{rows, cols, sparsity}
                     .Seed(0)
                     .Lower(.0f)
                     .Upper(1.0f)
                     .Type(ft)
                     .MaxCategory(13)
                     .GenerateDMatrix();
-    return dmat->SliceCol(world, rank);
-  }()};
+  auto m = std::shared_ptr<DMatrix>{full_m->SliceCol(world, rank)};
 
   std::vector<bst_idx_t> column_size(cols, 0);
   auto const slice_size = cols / world;
@@ -386,93 +389,49 @@ void DoTestColSplitQuantile(size_t rows, size_t cols) {
   }
 
   auto const n_bins = 64;
+  quantile_test::ContainerCase c;
+  c.name = rows == 10 ? "column_split_basic" : "column_split_large";
+  c.rows = rows;
+  c.cols = cols;
+  c.sparsity = sparsity;
+  c.max_bin = n_bins;
+  c.weights = quantile_test::WeightKind::kNone;
+  c.features = quantile_test::FeatureKind::kMixed;
+  c.seed = 0;
+  auto columns = quantile_test::CollectWeightedColumns(full_m.get());
+  std::vector<float> hessian(rows, 1.0f);
+  auto hess = Span<float const>{hessian};
 
-  // Generate cuts for distributed environment.
-  HistogramCuts distributed_cuts{0};
+  HistogramCuts row_cuts{0};
   {
     HostSketchContainer sketch_distributed(&ctx, n_bins, m->Info().feature_types.ConstHostSpan(),
                                            column_size, false);
-
-    std::vector<float> hessian(rows, 1.0);
-    auto hess = Span<float const>{hessian};
-    if (use_column) {
-      for (auto const& page : m->GetBatches<SortedCSCPage>(&ctx)) {
-        PushPage<use_column>(&sketch_distributed, page, m->Info(), hess);
-      }
-    } else {
-      for (auto const& page : m->GetBatches<SparsePage>(&ctx)) {
-        PushPage<use_column>(&sketch_distributed, page, m->Info(), hess);
-      }
+    for (auto const& page : m->GetBatches<SparsePage>(&ctx)) {
+      sketch_distributed.PushRowPage(page, m->Info(), hess);
     }
-
-    distributed_cuts = sketch_distributed.MakeCuts(&ctx, m->Info());
+    row_cuts = sketch_distributed.MakeCuts(&ctx, m->Info());
   }
 
-  // Generate cuts for single node environment
+  HistogramCuts sorted_cuts{0};
+  {
+    HostSketchContainer sketch_distributed(&ctx, n_bins, m->Info().feature_types.ConstHostSpan(),
+                                           column_size, false);
+    for (auto const& page : m->GetBatches<SortedCSCPage>(&ctx)) {
+      sketch_distributed.PushColPage(page, m->Info(), hess);
+    }
+    sorted_cuts = sketch_distributed.MakeCuts(&ctx, m->Info());
+  }
+
   collective::Finalize();
   CHECK_EQ(collective::GetWorldSize(), 1);
-  HistogramCuts single_node_cuts{0};
-  {
-    HostSketchContainer sketch_on_single_node(&ctx, n_bins, m->Info().feature_types.ConstHostSpan(),
-                                              column_size, false);
-
-    std::vector<float> hessian(rows, 1.0);
-    auto hess = Span<float const>{hessian};
-    if (use_column) {
-      for (auto const& page : m->GetBatches<SortedCSCPage>(&ctx)) {
-        PushPage<use_column>(&sketch_on_single_node, page, m->Info(), hess);
-      }
-    } else {
-      for (auto const& page : m->GetBatches<SparsePage>(&ctx)) {
-        PushPage<use_column>(&sketch_on_single_node, page, m->Info(), hess);
-      }
-    }
-
-    single_node_cuts = sketch_on_single_node.MakeCuts(&ctx, m->Info());
-  }
-
-  auto const& sptrs = single_node_cuts.Ptrs();
-  auto const& dptrs = distributed_cuts.Ptrs();
-  auto const& svals = single_node_cuts.Values();
-  auto const& dvals = distributed_cuts.Values();
-
-  EXPECT_EQ(sptrs.size(), dptrs.size());
-  for (size_t i = 0; i < sptrs.size(); ++i) {
-    EXPECT_EQ(sptrs[i], dptrs[i]) << "rank: " << rank << ", i: " << i;
-  }
-
-  EXPECT_EQ(svals.size(), dvals.size());
-  for (size_t i = 0; i < svals.size(); ++i) {
-    EXPECT_NEAR(svals[i], dvals[i], 2e-2f) << "rank: " << rank << ", i: " << i;
-  }
-}
-
-template <bool use_column>
-void TestColSplitQuantile(size_t rows, size_t cols) {
-  auto constexpr kWorkers = 4;
-  collective::TestDistributedGlobal(kWorkers,
-                                    [=] { DoTestColSplitQuantile<use_column>(rows, cols); });
+  TestColumnSplitInvariants(c, row_cuts, full_m.get(), columns, slice_start, slice_end);
+  TestColumnSplitInvariants(c, sorted_cuts, full_m.get(), columns, slice_start, slice_end);
 }
 }  // anonymous namespace
 
-TEST(Quantile, ColumnSplitBasic) {
-  constexpr size_t kRows = 10, kCols = 10;
-  TestColSplitQuantile<false>(kRows, kCols);
-}
-
 TEST(Quantile, ColumnSplit) {
   constexpr size_t kRows = 4000, kCols = 200;
-  TestColSplitQuantile<false>(kRows, kCols);
-}
-
-TEST(Quantile, ColumnSplitSortedBasic) {
-  constexpr size_t kRows = 10, kCols = 10;
-  TestColSplitQuantile<true>(kRows, kCols);
-}
-
-TEST(Quantile, ColumnSplitSorted) {
-  constexpr size_t kRows = 4000, kCols = 200;
-  TestColSplitQuantile<true>(kRows, kCols);
+  collective::TestDistributedGlobal(4, [&] { DoPropertyColumnSplitQuantile(kRows, kCols); });
 }
 
 }  // namespace xgboost::common

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -93,6 +93,64 @@ void TestContainerInvariants(ContainerCase const& c, HistogramCuts const& cuts, 
   }
 }
 
+void AssertSameOnAllWorkers(Context const* ctx, HistogramCuts const& cuts) {
+  auto const world = collective::GetWorldSize();
+  if (world <= 1) {
+    return;
+  }
+
+  auto const rank = collective::GetRank();
+  auto const local_value_size = static_cast<std::int64_t>(cuts.Values().size());
+  auto const local_ptr_size = static_cast<std::int64_t>(cuts.Ptrs().size());
+
+  std::vector<std::int64_t> value_sizes(world, 0);
+  std::vector<std::int64_t> ptr_sizes(world, 0);
+  value_sizes.at(rank) = local_value_size;
+  ptr_sizes.at(rank) = local_ptr_size;
+
+  auto rc = collective::Success() << [&] {
+    return collective::Allreduce(ctx, linalg::MakeVec(value_sizes.data(), value_sizes.size()),
+                                 collective::Op::kSum);
+  } << [&] {
+    return collective::Allreduce(ctx, linalg::MakeVec(ptr_sizes.data(), ptr_sizes.size()),
+                                 collective::Op::kSum);
+  };
+  collective::SafeColl(rc);
+
+  auto const max_value_size = *std::max_element(value_sizes.cbegin(), value_sizes.cend());
+  auto const max_ptr_size = *std::max_element(ptr_sizes.cbegin(), ptr_sizes.cend());
+  std::vector<float> cut_values(static_cast<std::size_t>(max_value_size) * world, 0.0f);
+  std::vector<typename std::remove_reference_t<decltype(cuts.Ptrs())>::value_type> cut_ptrs(
+      static_cast<std::size_t>(max_ptr_size) * world, 0);
+
+  auto const value_offset = static_cast<std::size_t>(max_value_size) * rank;
+  auto const ptr_offset = static_cast<std::size_t>(max_ptr_size) * rank;
+  std::copy(cuts.Values().cbegin(), cuts.Values().cend(), cut_values.begin() + value_offset);
+  std::copy(cuts.Ptrs().cbegin(), cuts.Ptrs().cend(), cut_ptrs.begin() + ptr_offset);
+
+  rc = collective::Success() << [&] {
+    return collective::Allreduce(ctx, linalg::MakeVec(cut_values.data(), cut_values.size()),
+                                 collective::Op::kSum);
+  } << [&] {
+    return collective::Allreduce(ctx, linalg::MakeVec(cut_ptrs.data(), cut_ptrs.size()),
+                                 collective::Op::kSum);
+  };
+  collective::SafeColl(rc);
+
+  for (std::int32_t worker = 0; worker < world; ++worker) {
+    ASSERT_EQ(value_sizes.at(worker), local_value_size);
+    ASSERT_EQ(ptr_sizes.at(worker), local_ptr_size);
+    for (std::int64_t j = 0; j < local_value_size; ++j) {
+      auto idx = static_cast<std::size_t>(worker) * max_value_size + static_cast<std::size_t>(j);
+      ASSERT_NEAR(cuts.Values().at(j), cut_values.at(idx), kRtEps);
+    }
+    for (std::int64_t j = 0; j < local_ptr_size; ++j) {
+      auto idx = static_cast<std::size_t>(worker) * max_ptr_size + static_cast<std::size_t>(j);
+      ASSERT_EQ(cuts.Ptrs().at(j), cut_ptrs.at(idx));
+    }
+  }
+}
+
 }  // namespace
 
 TEST_P(QuantileSummaryTest, Invariants) {
@@ -231,11 +289,67 @@ void DoPropertyDistributedQuantile(ContainerCase const& c) {
   TestContainerInvariants(c, row_cuts, full_m.get(), columns);
   TestContainerInvariants(c, sorted_cuts, full_m.get(), columns);
 }
+
+void DoSameOnAllWorkersDistributedQuantile(ContainerCase const& c) {
+  Context ctx;
+  auto const world = collective::GetWorldSize();
+  auto ft = FeatureTypes(c);
+  auto rank = collective::GetRank();
+  auto full_m = RandomDataGenerator{c.rows * static_cast<std::size_t>(world), c.cols, c.sparsity}
+                    .Seed(c.seed)
+                    .Lower(.0f)
+                    .Upper(1.0f)
+                    .Type(ft)
+                    .MaxCategory(13)
+                    .GenerateDMatrix();
+  if (c.weights == WeightKind::kRow) {
+    full_m->Info().weights_.HostVector() =
+        GenerateWeights(c.rows * static_cast<std::size_t>(world), c.seed + 4096);
+  }
+  std::vector<std::int32_t> ridxs(c.rows);
+  auto row_begin = static_cast<std::size_t>(rank) * c.rows;
+  std::iota(ridxs.begin(), ridxs.end(), static_cast<std::int32_t>(row_begin));
+  std::shared_ptr<DMatrix> m{full_m->Slice(Span<std::int32_t const>{ridxs.data(), ridxs.size()})};
+
+  std::vector<bst_idx_t> column_size(c.cols, c.rows);
+  std::vector<float> hessian(c.rows, 1.0f);
+  auto hess = Span<float const>{hessian};
+  HostSketchContainer row_sketch(&ctx, c.max_bin, m->Info().feature_types.ConstHostSpan(),
+                                 column_size, false);
+  for (auto const& page : m->GetBatches<SparsePage>(&ctx)) {
+    row_sketch.PushRowPage(page, m->Info(), hess);
+  }
+  auto row_cuts = row_sketch.MakeCuts(&ctx, m->Info());
+  AssertSameOnAllWorkers(&ctx, row_cuts);
+
+  HostSketchContainer sorted_sketch(&ctx, c.max_bin, m->Info().feature_types.ConstHostSpan(),
+                                    column_size, false);
+  for (auto const& page : m->GetBatches<SortedCSCPage>(&ctx)) {
+    sorted_sketch.PushColPage(page, m->Info(), hess);
+  }
+  auto sorted_cuts = sorted_sketch.MakeCuts(&ctx, m->Info());
+  AssertSameOnAllWorkers(&ctx, sorted_cuts);
+
+  collective::Finalize();
+}
 }  // namespace
 
 TEST_P(QuantileDistributedContainerTest, Invariants) {
   auto c = GetParam();
   collective::TestDistributedGlobal(4, [&] { DoPropertyDistributedQuantile(c); }, false);
+}
+
+TEST(Quantile, SameOnAllWorkers) {
+  auto c = ContainerCase{};
+  c.name = "same_on_all_workers";
+  c.rows = 1024;
+  c.cols = 8;
+  c.sparsity = 0.2f;
+  c.max_bin = 256;
+  c.weights = WeightKind::kRow;
+  c.features = FeatureKind::kNumerical;
+  c.seed = 11;
+  collective::TestDistributedGlobal(4, [&] { DoSameOnAllWorkersDistributedQuantile(c); }, false);
 }
 
 INSTANTIATE_TEST_SUITE_P(Anchors, QuantileContainerTest,

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -17,21 +17,16 @@
 namespace xgboost::common {
 namespace quantile_test {
 class QuantileSummaryTest : public ::testing::TestWithParam<SummaryCase> {};
-class QuantileSummarySortedTest : public ::testing::TestWithParam<SummaryCase> {};
+class QuantileContainerTest : public ::testing::TestWithParam<ContainerCase> {};
+class QuantileDistributedContainerTest : public ::testing::TestWithParam<ContainerCase> {};
 
-TEST_P(QuantileSummaryTest, Invariants) {
-  auto c = GetParam();
-  auto col = GenerateSummaryColumn(c);
-  WQuantileSketch sketch{c.rows, SketchEpsilon(c.max_bin, c.rows)};
-  for (std::size_t i = 0; i < col.values.size(); ++i) {
-    sketch.Push(col.values[i], col.weights[i]);
-  }
-  auto budget = SketchSummaryBudget(c.max_bin, c.rows);
-  auto summary = sketch.GetSummary(budget);
+namespace {
+void TestSummaryInvariants(SummaryCase const& c, WQSummaryContainer const& summary,
+                           GeneratedColumn const& col) {
   auto entries = summary.Entries();
   auto ref = AggregateReferenceColumn(col);
   auto nonzero_samples = NonZeroWeightCount(col);
-
+  auto budget = SketchSummaryBudget(c.max_bin, c.rows);
   // An empty sketch should remain empty after finalization.
   if (EmptyReference(ref)) {
     ASSERT_TRUE(entries.empty()) << "case=" << c.name;
@@ -69,44 +64,195 @@ TEST_P(QuantileSummaryTest, Invariants) {
     }
   }
 }
+void TestContainerInvariants(ContainerCase const& c, HistogramCuts const& cuts, DMatrix* dmat) {
+  ASSERT_EQ(cuts.Ptrs().size(), c.cols + 1) << "case=" << c.name;
+  // Every feature should contribute at least one strictly increasing cut value sequence.
+  for (std::size_t fidx = 0; fidx < c.cols; ++fidx) {
+    auto beg = cuts.Ptrs()[fidx];
+    auto end = cuts.Ptrs()[fidx + 1];
+    ASSERT_LT(beg, end) << "case=" << c.name << ", feature=" << fidx;
+    for (auto i = beg + 1; i < end; ++i) {
+      EXPECT_LT(cuts.Values()[i - 1], cuts.Values()[i])
+          << "case=" << c.name << ", feature=" << fidx;
+    }
+  }
 
-TEST_P(QuantileSummarySortedTest, QueryBound) {
+  auto columns = CollectWeightedColumns(dmat);
+  auto ft = dmat->Info().feature_types.ConstHostSpan();
+  auto max_error =
+      c.weights == WeightKind::kRow ? kMaxWeightedNormalizedRankError : kMaxNormalizedRankError;
+  for (std::size_t i = 0; i < columns.size(); ++i) {
+    if (columns[i].empty()) {
+      continue;
+    }
+    if (!ft.empty() && IsCat(ft, i)) {
+      ValidateCategoricalCuts(cuts, i, columns[i]);
+    } else {
+      ValidateNumericalCuts(cuts, i, columns[i], c.max_bin, max_error);
+    }
+  }
+}
+
+auto MakeDenseReferenceDMatrix(std::vector<std::shared_ptr<DMatrix>> const& blocks,
+                               Span<FeatureType const> ft,
+                               std::vector<std::vector<float>> const& weights, std::size_t rows,
+                               std::size_t cols) -> std::shared_ptr<DMatrix> {
+  std::vector<float> full(rows * cols, std::numeric_limits<float>::quiet_NaN());
+  std::vector<float> full_weights;
+  if (!weights.empty()) {
+    full_weights.reserve(rows);
+  }
+
+  std::size_t row_offset = 0;
+  for (std::size_t block_idx = 0; block_idx < blocks.size(); ++block_idx) {
+    auto const& m = blocks[block_idx];
+    std::size_t local_row = 0;
+    for (auto const& batch : m->GetBatches<SparsePage>()) {
+      auto page = batch.GetView();
+      for (std::size_t ridx = 0; ridx < batch.Size(); ++ridx) {
+        auto base = (row_offset + local_row) * cols;
+        for (auto e : page[ridx]) {
+          full[base + e.index] = e.fvalue;
+        }
+        ++local_row;
+      }
+    }
+    if (!weights.empty()) {
+      full_weights.insert(full_weights.end(), weights[block_idx].cbegin(),
+                          weights[block_idx].cend());
+    }
+    row_offset += m->Info().num_row_;
+  }
+
+  auto full_m = GetDMatrixFromData(full, rows, cols);
+  full_m->Info().feature_types.HostVector() = {ft.cbegin(), ft.cend()};
+  if (!full_weights.empty()) {
+    full_m->Info().weights_.HostVector() = std::move(full_weights);
+  }
+  return full_m;
+}
+}  // namespace
+
+TEST_P(QuantileSummaryTest, Invariants) {
   auto c = GetParam();
   auto col = GenerateSummaryColumn(c);
-  WQuantileSketch sketch{c.rows, SketchEpsilon(c.max_bin, c.rows)};
+
+  WQuantileSketch row_sketch{c.rows, SketchEpsilon(c.max_bin, c.rows)};
+  for (std::size_t i = 0; i < col.values.size(); ++i) {
+    row_sketch.Push(col.values[i], col.weights[i]);
+  }
+  auto row_summary = row_sketch.GetSummary(SketchSummaryBudget(c.max_bin, c.rows));
+  TestSummaryInvariants(c, row_summary, col);
+
+  WQuantileSketch sorted_sketch{c.rows, SketchEpsilon(c.max_bin, c.rows)};
   std::vector<::xgboost::Entry> sorted_col;
   sorted_col.reserve(col.values.size());
   for (std::size_t i = 0; i < col.values.size(); ++i) {
     sorted_col.emplace_back(i, col.values[i]);
   }
   std::sort(sorted_col.begin(), sorted_col.end(), ::xgboost::Entry::CmpValue);
-  sketch.PushSorted(Span<::xgboost::Entry const>{sorted_col.data(), sorted_col.size()}, col.weights,
-                    c.max_bin);
-  auto budget = SketchSummaryBudget(c.max_bin, c.rows);
-  auto summary = sketch.GetSummary(budget);
-  auto entries = summary.Entries();
-  auto ref = AggregateReferenceColumn(col);
-
-  if (EmptyReference(ref)) {
-    ASSERT_TRUE(entries.empty()) << "case=" << c.name;
-    return;
-  }
-
-  auto total = TotalWeight(ref);
-  auto max_error = MaxSummaryQueryRankError(summary, ref, c.max_bin);
-  auto eps = SketchEpsilon(c.max_bin, c.rows);
-  auto bound = (eps + 1.0 / static_cast<double>(budget)) * total;
-
-  EXPECT_LE(max_error, bound) << "case=" << c.name << ", total=" << total << ", budget=" << budget
-                              << ", eps=" << eps;
+  sorted_sketch.PushSorted(Span<::xgboost::Entry const>{sorted_col.data(), sorted_col.size()},
+                           col.weights, c.max_bin);
+  auto sorted_summary = sorted_sketch.GetSummary(SketchSummaryBudget(c.max_bin, c.rows));
+  TestSummaryInvariants(c, sorted_summary, col);
 }
 
 INSTANTIATE_TEST_SUITE_P(Anchors, QuantileSummaryTest, ::testing::ValuesIn(SummaryAnchorCases()),
-                         CaseName);
+                         SummaryCaseName);
 INSTANTIATE_TEST_SUITE_P(RandomSamples, QuantileSummaryTest,
-                         ::testing::ValuesIn(SummaryRandomCases(100)), CaseName);
-INSTANTIATE_TEST_SUITE_P(Anchors, QuantileSummarySortedTest,
-                         ::testing::ValuesIn(SummaryAnchorCases()), CaseName);
+                         ::testing::ValuesIn(SummaryRandomCases(100)), SummaryCaseName);
+
+TEST_P(QuantileContainerTest, Invariants) {
+  auto c = GetParam();
+  Context ctx;
+  auto ft = FeatureTypes(c);
+  auto m = RandomDataGenerator{c.rows, c.cols, c.sparsity}
+               .Seed(c.seed)
+               .Lower(.0f)
+               .Upper(1.0f)
+               .Type(ft)
+               .MaxCategory(13)
+               .GenerateDMatrix();
+  if (c.weights == WeightKind::kRow) {
+    m->Info().weights_.HostVector() = GenerateWeights(c.rows, c.seed + 1024);
+  }
+
+  std::vector<bst_idx_t> column_size(c.cols, c.rows);
+  std::vector<float> hessian(c.rows, 1.0f);
+  auto hess = Span<float const>{hessian};
+
+  HostSketchContainer row_sketch(&ctx, c.max_bin, m->Info().feature_types.ConstHostSpan(),
+                                 column_size, false);
+  for (auto const& page : m->GetBatches<SparsePage>(&ctx)) {
+    row_sketch.PushRowPage(page, m->Info(), hess);
+  }
+  auto row_cuts = row_sketch.MakeCuts(&ctx, m->Info());
+  TestContainerInvariants(c, row_cuts, m.get());
+
+  HostSketchContainer sorted_sketch(&ctx, c.max_bin, m->Info().feature_types.ConstHostSpan(),
+                                    column_size, false);
+  for (auto const& page : m->GetBatches<SortedCSCPage>(&ctx)) {
+    sorted_sketch.PushColPage(page, m->Info(), hess);
+  }
+  auto sorted_cuts = sorted_sketch.MakeCuts(&ctx, m->Info());
+  TestContainerInvariants(c, sorted_cuts, m.get());
+}
+
+namespace {
+void DoPropertyDistributedQuantile(ContainerCase const& c) {
+  Context ctx;
+  auto const world = collective::GetWorldSize();
+  auto ft = FeatureTypes(c);
+  auto rank = collective::GetRank();
+  auto full_m = RandomDataGenerator{c.rows * static_cast<std::size_t>(world), c.cols, c.sparsity}
+                    .Seed(c.seed)
+                    .Lower(.0f)
+                    .Upper(1.0f)
+                    .Type(ft)
+                    .MaxCategory(13)
+                    .GenerateDMatrix();
+  if (c.weights == WeightKind::kRow) {
+    full_m->Info().weights_.HostVector() =
+        GenerateWeights(c.rows * static_cast<std::size_t>(world), c.seed + 4096);
+  }
+  std::vector<std::int32_t> ridxs(c.rows);
+  auto row_begin = static_cast<std::size_t>(rank) * c.rows;
+  std::iota(ridxs.begin(), ridxs.end(), static_cast<std::int32_t>(row_begin));
+  std::shared_ptr<DMatrix> m{full_m->Slice(Span<std::int32_t const>{ridxs.data(), ridxs.size()})};
+
+  std::vector<bst_idx_t> column_size(c.cols, c.rows);
+  std::vector<float> hessian(c.rows, 1.0f);
+  auto hess = Span<float const>{hessian};
+  HostSketchContainer row_sketch(&ctx, c.max_bin, m->Info().feature_types.ConstHostSpan(),
+                                 column_size, false);
+  for (auto const& page : m->GetBatches<SparsePage>(&ctx)) {
+    row_sketch.PushRowPage(page, m->Info(), hess);
+  }
+  auto row_cuts = row_sketch.MakeCuts(&ctx, m->Info());
+
+  HostSketchContainer sorted_sketch(&ctx, c.max_bin, m->Info().feature_types.ConstHostSpan(),
+                                    column_size, false);
+  for (auto const& page : m->GetBatches<SortedCSCPage>(&ctx)) {
+    sorted_sketch.PushColPage(page, m->Info(), hess);
+  }
+  auto sorted_cuts = sorted_sketch.MakeCuts(&ctx, m->Info());
+
+  collective::Finalize();
+  CHECK_EQ(collective::GetWorldSize(), 1);
+  TestContainerInvariants(c, row_cuts, full_m.get());
+  TestContainerInvariants(c, sorted_cuts, full_m.get());
+}
+}  // namespace
+
+TEST_P(QuantileDistributedContainerTest, Invariants) {
+  auto c = GetParam();
+  collective::TestDistributedGlobal(4, [&] { DoPropertyDistributedQuantile(c); }, false);
+}
+
+INSTANTIATE_TEST_SUITE_P(Anchors, QuantileContainerTest,
+                         ::testing::ValuesIn(ContainerAnchorCases()), ContainerCaseName);
+INSTANTIATE_TEST_SUITE_P(Anchors, QuantileDistributedContainerTest,
+                         ::testing::ValuesIn(ContainerAnchorCases()), ContainerCaseName);
 }  // namespace quantile_test
 
 TEST(Quantile, LoadBalance) {
@@ -170,129 +316,6 @@ void PushPage(HostSketchContainer* container, SparsePage const& page, MetaInfo c
   }
 }
 
-template <bool use_column>
-void DoTestDistributedQuantile(size_t rows, size_t cols) {
-  Context ctx;
-  auto const world = collective::GetWorldSize();
-  std::vector<MetaInfo> infos(2);
-  auto& h_weights = infos.front().weights_.HostVector();
-  h_weights.resize(rows);
-  SimpleLCG lcg;
-  SimpleRealUniformDistribution<float> dist(3, 1000);
-  std::generate(h_weights.begin(), h_weights.end(), [&]() { return dist(&lcg); });
-  std::vector<bst_idx_t> column_size(cols, rows);
-  bst_bin_t n_bins = 64;
-
-  // Generate cuts for distributed environment.
-  auto sparsity = 0.5f;
-  auto rank = collective::GetRank();
-  std::vector<FeatureType> ft(cols);
-  for (size_t i = 0; i < ft.size(); ++i) {
-    ft[i] = (i % 2 == 0) ? FeatureType::kNumerical : FeatureType::kCategorical;
-  }
-
-  auto m = RandomDataGenerator{rows, cols, sparsity}
-               .Seed(rank)
-               .Lower(.0f)
-               .Upper(1.0f)
-               .Type(ft)
-               .MaxCategory(13)
-               .GenerateDMatrix();
-
-  std::vector<float> hessian(rows, 1.0);
-  auto hess = Span<float const>{hessian};
-
-  HostSketchContainer sketch_distributed(&ctx, n_bins, m->Info().feature_types.ConstHostSpan(),
-                                         column_size, false);
-
-  if (use_column) {
-    for (auto const& page : m->GetBatches<SortedCSCPage>(&ctx)) {
-      PushPage<use_column>(&sketch_distributed, page, m->Info(), hess);
-    }
-  } else {
-    for (auto const& page : m->GetBatches<SparsePage>(&ctx)) {
-      PushPage<use_column>(&sketch_distributed, page, m->Info(), hess);
-    }
-  }
-
-  auto distributed_cuts = sketch_distributed.MakeCuts(&ctx, m->Info());
-
-  // Generate cuts for single node environment
-  collective::Finalize();
-
-  CHECK_EQ(collective::GetWorldSize(), 1);
-  std::for_each(column_size.begin(), column_size.end(), [=](auto& size) { size *= world; });
-  m->Info().num_row_ = world * rows;
-  HostSketchContainer sketch_on_single_node(&ctx, n_bins, m->Info().feature_types.ConstHostSpan(),
-                                            column_size, false);
-  m->Info().num_row_ = rows;
-
-  for (auto rank = 0; rank < world; ++rank) {
-    auto m = RandomDataGenerator{rows, cols, sparsity}
-                 .Seed(rank)
-                 .Type(ft)
-                 .MaxCategory(13)
-                 .Lower(.0f)
-                 .Upper(1.0f)
-                 .GenerateDMatrix();
-    if (use_column) {
-      for (auto const& page : m->GetBatches<SortedCSCPage>(&ctx)) {
-        PushPage<use_column>(&sketch_on_single_node, page, m->Info(), hess);
-      }
-    } else {
-      for (auto const& page : m->GetBatches<SparsePage>()) {
-        PushPage<use_column>(&sketch_on_single_node, page, m->Info(), hess);
-      }
-    }
-  }
-
-  auto single_node_cuts = sketch_on_single_node.MakeCuts(&ctx, m->Info());
-
-  auto const& sptrs = single_node_cuts.Ptrs();
-  auto const& dptrs = distributed_cuts.Ptrs();
-  auto const& svals = single_node_cuts.Values();
-  auto const& dvals = distributed_cuts.Values();
-
-  ASSERT_EQ(sptrs.size(), dptrs.size());
-  for (size_t i = 0; i < sptrs.size(); ++i) {
-    ASSERT_EQ(sptrs[i], dptrs[i]) << i;
-  }
-
-  ASSERT_EQ(svals.size(), dvals.size());
-  for (size_t i = 0; i < svals.size(); ++i) {
-    ASSERT_NEAR(svals[i], dvals[i], 2e-2f);
-  }
-}
-
-template <bool use_column>
-void TestDistributedQuantile(size_t const rows, size_t const cols) {
-  auto constexpr kWorkers = 4;
-  collective::TestDistributedGlobal(
-      kWorkers, [=] { DoTestDistributedQuantile<use_column>(rows, cols); }, false);
-}
-}  // anonymous namespace
-
-TEST(Quantile, DistributedBasic) {
-  constexpr size_t kRows = 10, kCols = 10;
-  TestDistributedQuantile<false>(kRows, kCols);
-}
-
-TEST(Quantile, Distributed) {
-  constexpr size_t kRows = 4000, kCols = 200;
-  TestDistributedQuantile<false>(kRows, kCols);
-}
-
-TEST(Quantile, SortedDistributedBasic) {
-  constexpr size_t kRows = 10, kCols = 10;
-  TestDistributedQuantile<true>(kRows, kCols);
-}
-
-TEST(Quantile, SortedDistributed) {
-  constexpr size_t kRows = 4000, kCols = 200;
-  TestDistributedQuantile<true>(kRows, kCols);
-}
-
-namespace {
 template <bool use_column>
 void DoTestColSplitQuantile(size_t rows, size_t cols) {
   Context ctx;

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -93,51 +93,6 @@ void TestContainerInvariants(ContainerCase const& c, HistogramCuts const& cuts, 
   }
 }
 
-void SameOnAllWorkers(Context const* ctx, HistogramCuts const& cuts) {
-  auto const world = collective::GetWorldSize();
-  if (world <= 1) {
-    return;
-  }
-
-  std::vector<float> cut_values(cuts.Values().size() * world, 0.0f);
-  std::vector<typename std::remove_reference_t<decltype(cuts.Ptrs())>::value_type> cut_ptrs(
-      cuts.Ptrs().size() * world, 0);
-
-  std::int64_t value_size = cuts.Values().size();
-  std::int64_t ptr_size = cuts.Ptrs().size();
-  auto rc = collective::Success() << [&] {
-    return collective::Allreduce(ctx, &value_size, collective::Op::kMax);
-  } << [&] {
-    return collective::Allreduce(ctx, &ptr_size, collective::Op::kMax);
-  };
-  collective::SafeColl(rc);
-
-  auto rank = collective::GetRank();
-  auto value_offset = static_cast<std::size_t>(value_size) * rank;
-  std::copy(cuts.Values().begin(), cuts.Values().end(), cut_values.begin() + value_offset);
-  auto ptr_offset = static_cast<std::size_t>(ptr_size) * rank;
-  std::copy(cuts.Ptrs().cbegin(), cuts.Ptrs().cend(), cut_ptrs.begin() + ptr_offset);
-
-  rc = collective::Success() << [&] {
-    return collective::Allreduce(ctx, linalg::MakeVec(cut_values.data(), cut_values.size()),
-                                 collective::Op::kSum);
-  } << [&] {
-    return collective::Allreduce(ctx, linalg::MakeVec(cut_ptrs.data(), cut_ptrs.size()),
-                                 collective::Op::kSum);
-  };
-  collective::SafeColl(rc);
-
-  for (std::int32_t worker = 0; worker < world; ++worker) {
-    for (std::int64_t j = 0; j < value_size; ++j) {
-      auto idx = static_cast<std::size_t>(worker) * value_size + j;
-      ASSERT_NEAR(cuts.Values().at(j), cut_values.at(idx), kRtEps);
-    }
-    for (std::int64_t j = 0; j < ptr_size; ++j) {
-      auto idx = static_cast<std::size_t>(worker) * ptr_size + j;
-      ASSERT_EQ(cuts.Ptrs().at(j), cut_ptrs.at(idx));
-    }
-  }
-}
 }  // namespace
 
 TEST_P(QuantileSummaryTest, Invariants) {

--- a/tests/cpp/common/test_quantile_helpers.h
+++ b/tests/cpp/common/test_quantile_helpers.h
@@ -21,6 +21,11 @@ enum class WeightKind { kNone, kRow };
 
 enum class DataKind { kClustered, kDuplicateHeavy, kExactUnique, kStaircaseMass };
 
+enum class FeatureKind { kNumerical, kMixed };
+
+inline constexpr double kMaxNormalizedRankError = 2.0;
+inline constexpr double kMaxWeightedNormalizedRankError = 10.0;
+
 struct SummaryCase {
   std::string name;
   std::size_t rows{0};
@@ -45,9 +50,24 @@ struct ReferenceColumn {
   std::vector<double> prefix_weights;
 };
 
+struct ContainerCase {
+  std::string name;
+  std::size_t rows{0};
+  std::size_t cols{0};
+  float sparsity{0.0f};
+  bst_bin_t max_bin{0};
+  WeightKind weights{WeightKind::kNone};
+  FeatureKind features{FeatureKind::kNumerical};
+  std::uint32_t seed{0};
+};
+
 inline bool IsExactUniqueCase(SummaryCase const& c) { return c.data == DataKind::kExactUnique; }
 
-inline std::string CaseName(testing::TestParamInfo<SummaryCase> const& info) {
+inline std::string SummaryCaseName(testing::TestParamInfo<SummaryCase> const& info) {
+  return info.param.name;
+}
+
+inline std::string ContainerCaseName(testing::TestParamInfo<ContainerCase> const& info) {
   return info.param.name;
 }
 
@@ -97,6 +117,195 @@ inline std::vector<SummaryCase> SummaryRandomCases(std::size_t n_cases) {
   }
 
   return cases;
+}
+
+inline std::vector<ContainerCase> ContainerAnchorCases() {
+  return {
+      {"dense_numeric_unweighted", 256, 32, 0.0f, 32, WeightKind::kNone, FeatureKind::kNumerical,
+       11},
+      {"dense_numeric_weighted", 256, 32, 0.0f, 32, WeightKind::kRow, FeatureKind::kNumerical, 12},
+      {"sparse_numeric_weighted", 512, 48, 0.7f, 32, WeightKind::kRow, FeatureKind::kNumerical, 13},
+      {"dense_mixed_unweighted", 256, 24, 0.0f, 32, WeightKind::kNone, FeatureKind::kMixed, 14},
+      {"sparse_mixed_weighted", 512, 40, 0.8f, 32, WeightKind::kRow, FeatureKind::kMixed, 15},
+  };
+}
+
+inline std::vector<FeatureType> FeatureTypes(ContainerCase const& c) {
+  std::vector<FeatureType> ft(c.cols, FeatureType::kNumerical);
+  if (c.features == FeatureKind::kMixed) {
+    for (std::size_t i = 0; i < ft.size(); ++i) {
+      ft[i] = (i % 2 == 0) ? FeatureType::kNumerical : FeatureType::kCategorical;
+    }
+  }
+  return ft;
+}
+
+inline std::vector<float> GenerateWeights(std::size_t rows, std::uint32_t seed) {
+  std::vector<float> weights(rows, 1.0f);
+  SimpleLCG lcg{seed};
+  SimpleRealUniformDistribution<float> unit_dist(0.0f, 1.0f);
+  std::generate(weights.begin(), weights.end(), [&] { return std::exp(6.0f * unit_dist(&lcg)); });
+  return weights;
+}
+
+inline auto CollectWeightedColumns(DMatrix* dmat) -> std::vector<std::vector<WeightedValue>> {
+  std::vector<std::vector<WeightedValue>> columns(dmat->Info().num_col_);
+  std::vector<float> weights = dmat->Info().group_ptr_.empty()
+                                   ? dmat->Info().weights_.HostVector()
+                                   : detail::UnrollGroupWeights(dmat->Info());
+
+  bst_idx_t row_idx{0};
+  Context ctx;
+  for (auto const& batch : dmat->GetBatches<SparsePage>(&ctx)) {
+    auto page = batch.GetView();
+    CHECK_GT(batch.Size(), 0ul);
+    for (std::size_t i = 0; i < batch.Size(); ++i) {
+      auto row_weight =
+          weights.empty() ? 1.0
+                          : static_cast<double>(weights.at(static_cast<std::size_t>(row_idx + i)));
+      for (auto e : page[i]) {
+        columns[e.index].push_back({e.fvalue, row_weight});
+      }
+    }
+    row_idx += batch.Size();
+  }
+  CHECK_EQ(row_idx, dmat->Info().num_row_);
+
+  for (auto& column : columns) {
+    std::sort(column.begin(), column.end(),
+              [](auto const& lhs, auto const& rhs) { return lhs.value < rhs.value; });
+  }
+  return columns;
+}
+
+inline auto AggregateWeightedColumn(std::vector<WeightedValue> const& sorted_column)
+    -> ReferenceColumn {
+  ReferenceColumn ref;
+  ref.prefix_weights.push_back(0.0);
+  for (auto const& entry : sorted_column) {
+    if (!ref.values.empty() && ref.values.back() == entry.value) {
+      ref.prefix_weights.back() += entry.weight;
+    } else {
+      ref.values.push_back(entry.value);
+      ref.prefix_weights.push_back(ref.prefix_weights.back() + entry.weight);
+    }
+  }
+  return ref;
+}
+
+inline double DistanceToInterval(double target, double lo, double hi) {
+  if (target < lo) {
+    return lo - target;
+  }
+  if (target > hi) {
+    return target - hi;
+  }
+  return 0.0;
+}
+
+struct CutRankErrorSummary {
+  double max_normalized_error{0.0};
+  double max_absolute_error{0.0};
+  double target_rank{0.0};
+  double rank_lo{0.0};
+  double rank_hi{0.0};
+  double total_weight{0.0};
+  bst_feature_t feature{0};
+  std::size_t cut_index{0};
+  std::size_t num_interior_cuts{0};
+};
+
+inline auto MeasureCutRankError(HistogramCuts const& cuts, bst_feature_t column_idx,
+                                ReferenceColumn const& ref) -> CutRankErrorSummary {
+  CutRankErrorSummary summary;
+  summary.feature = column_idx;
+  if (ref.values.empty()) {
+    return summary;
+  }
+
+  auto beg = cuts.Ptrs()[column_idx];
+  auto end = cuts.Ptrs()[column_idx + 1];
+  auto num_cuts = end - beg;
+  if (num_cuts <= 1) {
+    return summary;
+  }
+  summary.num_interior_cuts = num_cuts - 1;  // Final cut is the sentinel upper bound.
+  summary.total_weight = ref.prefix_weights.back();
+  if (summary.total_weight == 0.0 || summary.num_interior_cuts == 0) {
+    return summary;
+  }
+
+  auto avg_bin_weight = summary.total_weight / static_cast<double>(summary.num_interior_cuts);
+  for (std::size_t cut_idx = 0; cut_idx < summary.num_interior_cuts; ++cut_idx) {
+    auto cut_value = cuts.Values()[beg + cut_idx];
+    auto lb = std::lower_bound(ref.values.cbegin(), ref.values.cend(), cut_value);
+    auto ub = std::upper_bound(ref.values.cbegin(), ref.values.cend(), cut_value);
+    auto rank_lo = ref.prefix_weights[std::distance(ref.values.cbegin(), lb)];
+    auto rank_hi = ref.prefix_weights[std::distance(ref.values.cbegin(), ub)];
+    auto target_rank = static_cast<double>(cut_idx + 1) * summary.total_weight /
+                       static_cast<double>(summary.num_interior_cuts);
+    auto absolute_error = DistanceToInterval(target_rank, rank_lo, rank_hi);
+    auto normalized_error = absolute_error / avg_bin_weight;
+    if (normalized_error > summary.max_normalized_error) {
+      summary.max_normalized_error = normalized_error;
+      summary.max_absolute_error = absolute_error;
+      summary.target_rank = target_rank;
+      summary.rank_lo = rank_lo;
+      summary.rank_hi = rank_hi;
+      summary.cut_index = cut_idx;
+    }
+  }
+
+  return summary;
+}
+
+inline void ValidateNumericalCuts(HistogramCuts const& cuts, bst_feature_t column_idx,
+                                  std::vector<WeightedValue> const& sorted_column,
+                                  std::size_t num_bins, double max_normalized_rank_error) {
+  auto ref = AggregateWeightedColumn(sorted_column);
+  CHECK(!ref.values.empty());
+
+  auto beg = cuts.Ptrs()[column_idx];
+  auto end = cuts.Ptrs()[column_idx + 1];
+  auto first_bin = HistogramCuts::NumericBinLowerBound(cuts.Ptrs(), cuts.Values(), column_idx, beg);
+  EXPECT_TRUE(std::isinf(first_bin));
+  EXPECT_LT(first_bin, 0.0f);
+  EXPECT_GT(cuts.Values()[beg], ref.values.front());
+  EXPECT_GE(cuts.Values()[end - 1], ref.values.back());
+
+  if (ref.values.size() <= num_bins) {
+    for (std::size_t i = 0; i < ref.values.size(); ++i) {
+      ASSERT_EQ(cuts.SearchBin(ref.values[i], column_idx), beg + i)
+          << "feature=" << column_idx << ", value_index=" << i;
+    }
+  } else {
+    auto stats = MeasureCutRankError(cuts, column_idx, ref);
+    EXPECT_LE(stats.max_normalized_error, max_normalized_rank_error)
+        << "feature=" << column_idx << ", cut=" << stats.cut_index
+        << ", normalized_error=" << stats.max_normalized_error
+        << ", absolute_error=" << stats.max_absolute_error << ", target_rank=" << stats.target_rank
+        << ", rank_lo=" << stats.rank_lo << ", rank_hi=" << stats.rank_hi
+        << ", total_weight=" << stats.total_weight
+        << ", num_interior_cuts=" << stats.num_interior_cuts;
+  }
+}
+
+inline void ValidateCategoricalCuts(HistogramCuts const& cuts, bst_feature_t column_idx,
+                                    std::vector<WeightedValue> const& sorted_column) {
+  std::vector<float> categories;
+  categories.reserve(sorted_column.size());
+  for (auto const& entry : sorted_column) {
+    categories.push_back(entry.value);
+  }
+  std::sort(categories.begin(), categories.end());
+  categories.erase(std::unique(categories.begin(), categories.end()), categories.end());
+
+  auto beg = cuts.Ptrs()[column_idx];
+  auto end = cuts.Ptrs()[column_idx + 1];
+  ASSERT_EQ(static_cast<std::size_t>(end - beg), categories.size()) << "feature=" << column_idx;
+  for (std::size_t i = 0; i < categories.size(); ++i) {
+    EXPECT_EQ(cuts.Values()[beg + i], categories[i]) << "feature=" << column_idx;
+  }
 }
 
 inline GeneratedColumn GenerateSummaryColumn(SummaryCase const& c) {

--- a/tests/cpp/common/test_quantile_helpers.h
+++ b/tests/cpp/common/test_quantile_helpers.h
@@ -121,6 +121,7 @@ inline std::vector<SummaryCase> SummaryRandomCases(std::size_t n_cases) {
 
 inline std::vector<ContainerCase> ContainerAnchorCases() {
   return {
+      {"empty_numeric_bins16", 0, 32, 0.0f, 16, WeightKind::kNone, FeatureKind::kNumerical, 10},
       {"dense_numeric_unweighted_bins2", 256, 32, 0.0f, 2, WeightKind::kNone,
        FeatureKind::kNumerical, 11},
       {"dense_numeric_unweighted_bins16", 256, 32, 0.0f, 16, WeightKind::kNone,
@@ -156,6 +157,9 @@ inline std::vector<float> GenerateWeights(std::size_t rows, std::uint32_t seed) 
 
 inline auto CollectWeightedColumns(DMatrix* dmat) -> std::vector<std::vector<WeightedValue>> {
   std::vector<std::vector<WeightedValue>> columns(dmat->Info().num_col_);
+  if (dmat->Info().num_row_ == 0) {
+    return columns;
+  }
   std::vector<float> weights = dmat->Info().group_ptr_.empty()
                                    ? dmat->Info().weights_.HostVector()
                                    : detail::UnrollGroupWeights(dmat->Info());
@@ -164,7 +168,6 @@ inline auto CollectWeightedColumns(DMatrix* dmat) -> std::vector<std::vector<Wei
   Context ctx;
   for (auto const& batch : dmat->GetBatches<SparsePage>(&ctx)) {
     auto page = batch.GetView();
-    CHECK_GT(batch.Size(), 0ul);
     for (std::size_t i = 0; i < batch.Size(); ++i) {
       auto row_weight =
           weights.empty() ? 1.0

--- a/tests/cpp/common/test_quantile_helpers.h
+++ b/tests/cpp/common/test_quantile_helpers.h
@@ -121,12 +121,18 @@ inline std::vector<SummaryCase> SummaryRandomCases(std::size_t n_cases) {
 
 inline std::vector<ContainerCase> ContainerAnchorCases() {
   return {
-      {"dense_numeric_unweighted", 256, 32, 0.0f, 32, WeightKind::kNone, FeatureKind::kNumerical,
-       11},
-      {"dense_numeric_weighted", 256, 32, 0.0f, 32, WeightKind::kRow, FeatureKind::kNumerical, 12},
-      {"sparse_numeric_weighted", 512, 48, 0.7f, 32, WeightKind::kRow, FeatureKind::kNumerical, 13},
-      {"dense_mixed_unweighted", 256, 24, 0.0f, 32, WeightKind::kNone, FeatureKind::kMixed, 14},
-      {"sparse_mixed_weighted", 512, 40, 0.8f, 32, WeightKind::kRow, FeatureKind::kMixed, 15},
+      {"dense_numeric_unweighted_bins2", 256, 32, 0.0f, 2, WeightKind::kNone,
+       FeatureKind::kNumerical, 11},
+      {"dense_numeric_unweighted_bins16", 256, 32, 0.0f, 16, WeightKind::kNone,
+       FeatureKind::kNumerical, 12},
+      {"dense_numeric_weighted_bins256", 512, 32, 0.0f, 256, WeightKind::kRow,
+       FeatureKind::kNumerical, 13},
+      {"sparse_numeric_weighted_bins32", 512, 48, 0.7f, 32, WeightKind::kRow,
+       FeatureKind::kNumerical, 14},
+      {"dense_mixed_unweighted_bins16", 256, 24, 0.0f, 16, WeightKind::kNone, FeatureKind::kMixed,
+       15},
+      {"sparse_mixed_weighted_bins64", 512, 40, 0.8f, 64, WeightKind::kRow, FeatureKind::kMixed,
+       16},
   };
 }
 


### PR DESCRIPTION
## Summary

This PR continues the CPU quantile test rewrite by expanding the property-style coverage in
`test_quantile.cc` and removing redundant legacy CPU quantile tests.

The new CPU property suites now cover:
- summary-level sketch invariants
- container-level cut invariants
- `SketchOnDMatrix` wrapper invariants
- distributed row-split and column-split properties

## What Changed

- broaden the shared CPU quantile case matrix in `tests/cpp/common/test_quantile_helpers.h`
- add local cut validators used by the new property tests
- replace legacy distributed identity-style tests with property checks against reference data
- remove redundant CPU quantile tests from `test_quantile.cc` and `test_hist_util.cc`

## Testing

- `cmake --build build-cpu --target testxgboost -j35`
- focused CPU quantile slice

Result:
- `140/140` passed
