### PR TITLE
Remove reintroduced GPU sketch memory estimation

### DIFF
--- a/src/common/hist_util.cu
+++ b/src/common/hist_util.cu
@@ -34,99 +34,6 @@ size_t RequiredSampleCutsPerColumn(int max_bins, size_t num_rows) {
   return std::min(num_cuts, num_rows);
 }
 
-size_t RequiredSampleCuts(bst_idx_t num_rows, bst_feature_t num_columns, size_t max_bins,
-                          bst_idx_t nnz) {
-  auto per_column = RequiredSampleCutsPerColumn(max_bins, num_rows);
-  auto if_dense = num_columns * per_column;
-  auto result = std::min(nnz, if_dense);
-  return result;
-}
-
-size_t RequiredMemory(bst_idx_t num_rows, bst_feature_t num_columns, size_t nnz, size_t num_bins,
-                      bool with_weights) {
-  size_t peak = 0;
-  auto cuts_bytes = RequiredSampleCuts(num_rows, num_bins, num_bins, nnz) * sizeof(SketchEntry);
-  // 0. Allocate cut pointer in quantile container by increasing: n_columns + 1
-  size_t total = (num_columns + 1) * sizeof(SketchContainer::OffsetT);
-  // 1. Copy and sort: 2 * bytes_per_element * shape
-  total += BytesPerElement(with_weights) * num_rows * num_columns;
-  peak = std::max(peak, total);
-  // 2. Deallocate bytes_per_element * shape due to reusing memory in sort.
-  total -= BytesPerElement(with_weights) * num_rows * num_columns / 2;
-  // 3. Allocate colomn size scan by increasing: n_columns + 1
-  total += (num_columns + 1) * sizeof(SketchContainer::OffsetT);
-  // 4. Allocate cut pointer by increasing: n_columns + 1
-  total += (num_columns + 1) * sizeof(SketchContainer::OffsetT);
-  // 5. Allocate cuts: assuming rows is greater than bins: n_columns * limit_size
-  total += cuts_bytes;
-  // 6. Install the first batch summary into the resident sketch while the temporary pruned
-  // summary is still live.
-  total += cuts_bytes;
-  // 7. Deallocate copied entries by reducing: bytes_per_element * shape.
-  peak = std::max(peak, total);
-  total -= (BytesPerElement(with_weights) * num_rows * num_columns) / 2;
-  // 8. Deallocate the temporary pruned batch summary after merge/prune commit.
-  peak = std::max(peak, total);
-  total -= cuts_bytes;
-  // 9. Deallocate column size scan.
-  peak = std::max(peak, total);
-  total -= (num_columns + 1) * sizeof(SketchContainer::OffsetT);
-  // 10. Deallocate cut size scan.
-  total -= (num_columns + 1) * sizeof(SketchContainer::OffsetT);
-  // 11. Allocate final cut values and cut ptrs: std::min(rows, bins + 1) * n_columns +
-  //    n_columns + 1
-  total += std::min(num_rows, num_bins) * num_columns * sizeof(float);
-  total +=
-      (num_columns + 1) *
-      sizeof(std::remove_reference_t<decltype(std::declval<HistogramCuts>().Ptrs())>::value_type);
-  peak = std::max(peak, total);
-
-  return peak;
-}
-
-bst_idx_t SketchBatchNumElements(bst_idx_t sketch_batch_num_elements, SketchShape shape, int device,
-                                 size_t num_cuts, bool has_weight, std::size_t container_bytes) {
-  auto constexpr kIntMax = static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max());
-
-  // Device available memory is not accurate when a memory pool is used.
-  auto avoid_estimation_with_pool = [&] {
-    (void)device;
-    double total_mem = curt::TotalMemory() - container_bytes;
-    double total_f32 = total_mem / sizeof(float);
-    double n_max_used_f32 = std::max(total_f32 / 8.0, 1.0);
-    if (shape.nnz > shape.Size()) {
-      // Unknown nnz
-      shape.nnz = shape.Size();
-    }
-    return std::min(static_cast<bst_idx_t>(n_max_used_f32), shape.nnz);
-  };
-
-#if defined(XGBOOST_USE_RMM) && XGBOOST_USE_RMM == 1
-  // Early exit with RMM pool
-  return avoid_estimation_with_pool();
-#endif  // defined(XGBOOST_USE_RMM) && XGBOOST_USE_RMM == 1
-  // Early exit with CUDA async pool
-  if (GlobalConfigThreadLocalStore::Get()->use_cuda_async_pool) {
-    return avoid_estimation_with_pool();
-  }
-
-  (void)container_bytes;  // We known the remaining size when RMM is not used.
-  if (sketch_batch_num_elements == detail::UnknownSketchNumElements()) {
-    auto required_memory =
-        RequiredMemory(shape.n_samples, shape.n_features, shape.nnz, num_cuts, has_weight);
-    // use up to 80% of available space
-    auto avail = dh::AvailableMemory(device) * 0.8;
-    CHECK_GT(avail, 0) << error::ZeroCudaMemory();
-    if (required_memory > avail) {
-      sketch_batch_num_elements = avail / BytesPerElement(has_weight);
-    } else {
-      sketch_batch_num_elements = std::min(shape.Size(), shape.nnz);
-    }
-  }
-
-  return std::min(sketch_batch_num_elements, kIntMax);
-}
-
 void SortByWeight(Context const* ctx, dh::device_vector<float>* weights,
                   dh::device_vector<Entry>* sorted_entries) {
   // Sort both entries and wegihts.
@@ -360,8 +267,7 @@ void ProcessWeightedBatch(Context const* ctx, const SparsePage& page, MetaInfo c
 }
 
 HistogramCuts DeviceSketchWithHessian(Context const* ctx, DMatrix* p_fmat, bst_bin_t max_bin,
-                                      Span<float const> hessian,
-                                      std::size_t sketch_batch_num_elements) {
+                                      Span<float const> hessian) {
   auto const& info = p_fmat->Info();
   bool has_weight = !info.weights_.Empty();
   info.feature_types.SetDevice(ctx->Device());
@@ -369,12 +275,8 @@ HistogramCuts DeviceSketchWithHessian(Context const* ctx, DMatrix* p_fmat, bst_b
   HostDeviceVector<float> weight;
   weight.SetDevice(ctx->Device());
 
-  // Configure batch size based on available memory
   std::size_t num_cuts_per_feature = detail::RequiredSampleCutsPerColumn(max_bin, info.num_row_);
-  sketch_batch_num_elements = detail::SketchBatchNumElements(
-      sketch_batch_num_elements,
-      detail::SketchShape{info.num_row_, info.num_col_, info.num_nonzero_}, ctx->Ordinal(),
-      num_cuts_per_feature, has_weight, 0);
+  auto sketch_batch_num_elements = detail::kSketchBatchNumElements;
 
   CUDAContext const* cuctx = ctx->CUDACtx();
 

--- a/src/common/hist_util.cuh
+++ b/src/common/hist_util.cuh
@@ -160,52 +160,11 @@ void GetColumnSizesScan(CUDAContext const* cuctx, DeviceOrd device, size_t num_c
                          column_sizes_scan->begin());
 }
 
-inline size_t constexpr BytesPerElement(bool has_weight) {
-  // Double the memory usage for sorting.  We need to assign weight for each element, so
-  // sizeof(float) is added to all elements.
-  return (has_weight ? sizeof(Entry) + sizeof(float) : sizeof(Entry)) * 2;
-}
-
-struct SketchShape {
-  bst_idx_t n_samples;
-  bst_feature_t n_features;
-  bst_idx_t nnz;
-
-  template <typename F, std::enable_if_t<std::is_integral_v<F>>* = nullptr>
-  SketchShape(bst_idx_t n_samples, F n_features, bst_idx_t nnz)
-      : n_samples{n_samples}, n_features{static_cast<bst_feature_t>(n_features)}, nnz{nnz} {}
-
-  [[nodiscard]] bst_idx_t Size() const { return n_samples * n_features; }
-};
-
-/**
- * @brief Calcuate the length of sliding window. Returns `sketch_batch_num_elements`
- *        directly if it's not 0.
- */
-bst_idx_t SketchBatchNumElements(bst_idx_t sketch_batch_num_elements, SketchShape shape, int device,
-                                 size_t num_cuts, bool has_weight, std::size_t container_bytes);
+constexpr bst_idx_t kSketchBatchNumElements = bst_idx_t{1} << 26;  // 64M
 
 // Compute number of sample cuts needed on local node to maintain accuracy
 // We take more cuts than needed and then reduce them later
 size_t RequiredSampleCutsPerColumn(int max_bins, size_t num_rows);
-
-/* \brief Estimate required memory for each sliding window.
- *
- *   It's not precise as to obtain exact memory usage for sparse dataset we need to walk
- *   through the whole dataset first.  Also if data is from host DMatrix, we copy the
- *   weight, group and offset on first batch, which is not considered in the function.
- *
- * \param num_rows     Number of rows in this worker.
- * \param num_columns  Number of columns for this dataset.
- * \param nnz          Number of non-zero element.  Put in something greater than rows *
- *                     cols if nnz is unknown.
- * \param num_bins     Number of histogram bins.
- * \param with_weights Whether weight is used, works the same for ranking and other models.
- *
- * \return The estimated bytes
- */
-size_t RequiredMemory(bst_idx_t num_rows, bst_feature_t num_columns, size_t nnz,
-                      size_t num_bins, bool with_weights);
 
 // Count the valid entries in each column and copy them out.
 template <typename AdapterBatch, typename BatchIter>
@@ -241,7 +200,6 @@ void RemoveDuplicatedCategories(Context const* ctx, MetaInfo const& info,
                                 dh::device_vector<float>* p_sorted_weights,
                                 dh::caching_device_vector<size_t>* p_column_sizes_scan);
 
-constexpr bst_idx_t UnknownSketchNumElements() { return 0; }
 }  // namespace detail
 
 /**
@@ -251,13 +209,11 @@ constexpr bst_idx_t UnknownSketchNumElements() { return 0; }
  * @param p_fmat  Training feature matrix
  * @param max_bin Maximum number of bins for each feature
  * @param hessian Hessian vector.
- * @param sketch_batch_num_elements 0 means autodetect. Only modify this for testing.
  *
  * @return Quantile cuts
  */
 HistogramCuts DeviceSketchWithHessian(Context const* ctx, DMatrix* p_fmat, bst_bin_t max_bin,
-                                      Span<float const> hessian,
-                                      std::size_t sketch_batch_num_elements = detail::UnknownSketchNumElements());
+                                      Span<float const> hessian);
 
 /**
  * @brief Compute sketch on DMatrix with GPU.
@@ -265,14 +221,11 @@ HistogramCuts DeviceSketchWithHessian(Context const* ctx, DMatrix* p_fmat, bst_b
  * @param ctx     Runtime context
  * @param p_fmat  Training feature matrix
  * @param max_bin Maximum number of bins for each feature
- * @param sketch_batch_num_elements 0 means autodetect. Only modify this for testing.
  *
  * @return Quantile cuts
  */
-inline HistogramCuts DeviceSketch(
-    Context const* ctx, DMatrix* p_fmat, bst_bin_t max_bin,
-    std::size_t sketch_batch_num_elements = detail::UnknownSketchNumElements()) {
-  return DeviceSketchWithHessian(ctx, p_fmat, max_bin, {}, sketch_batch_num_elements);
+inline HistogramCuts DeviceSketch(Context const* ctx, DMatrix* p_fmat, bst_bin_t max_bin) {
+  return DeviceSketchWithHessian(ctx, p_fmat, max_bin, {});
 }
 
 template <typename AdapterBatch>
@@ -393,13 +346,10 @@ void ProcessWeightedSlidingWindow(Context const* ctx, Batch batch, MetaInfo cons
  * @param info             Metainfo used for sketching.
  * @param missing          Floating point value that represents invalid value.
  * @param sketch_container Container for output sketch.
- * @param sketch_batch_num_elements Number of element per-sliding window, use it only for
- *                                  testing.
  */
 template <typename Batch>
 void AdapterDeviceSketch(Context const* ctx, Batch batch, bst_bin_t num_bins, MetaInfo const& info,
-                         float missing, SketchContainer* sketch_container,
-                         bst_idx_t sketch_batch_num_elements = detail::UnknownSketchNumElements()) {
+                         float missing, SketchContainer* sketch_container) {
   bst_idx_t num_rows = batch.NumRows();
   size_t num_cols = batch.NumCols();
 
@@ -408,16 +358,10 @@ void AdapterDeviceSketch(Context const* ctx, Batch batch, bst_bin_t num_bins, Me
   bst_idx_t const kRemaining = batch.Size();
   bst_idx_t begin = 0;
 
-  auto shape = detail::SketchShape{num_rows, num_cols, std::numeric_limits<bst_idx_t>::max()};
-
   while (begin < kRemaining) {
-    // Use total number of samples to estimate the needed cuts first, this doesn't hurt
-    // accuracy as total number of samples is larger.
     auto num_cuts_per_feature = detail::RequiredSampleCutsPerColumn(num_bins, num_rows);
-    // Estimate the memory usage based on the current available memory.
-    sketch_batch_num_elements = detail::SketchBatchNumElements(
-        sketch_batch_num_elements, shape, ctx->Ordinal(), num_cuts_per_feature, weighted,
-        sketch_container->MemCostBytes());
+    auto remaining = kRemaining - begin;
+    auto sketch_batch_num_elements = std::min(detail::kSketchBatchNumElements, remaining);
     // Re-estimate the needed number of cuts based on the size of the sub-batch.
     //
     // The estimation of `sketch_batch_num_elements` assumes dense input, so the

--- a/tests/cpp/common/test_hist_util.cu
+++ b/tests/cpp/common/test_hist_util.cu
@@ -276,29 +276,6 @@ TEST(HistUitl, DeviceSketchWeights) {
   }
 }
 
-TEST(HistUtil, DeviceSketchBatches) {
-  auto ctx = MakeCUDACtx(0);
-  int num_bins = 256;
-  int num_rows = 5000;
-  auto batch_sizes = {0, 100, 1500, 6000};
-  int num_columns = 5;
-  for (auto batch_size : batch_sizes) {
-    auto x = GenerateRandom(num_rows, num_columns);
-    auto dmat = GetDMatrixFromData(x, num_rows, num_columns);
-    auto cuts = DeviceSketch(&ctx, dmat.get(), num_bins, batch_size);
-    ValidateCuts(cuts, dmat.get(), num_bins);
-  }
-
-  num_rows = 1000;
-  size_t batches = 16;
-  auto x = GenerateRandom(num_rows * batches, num_columns);
-  auto dmat = GetDMatrixFromData(x, num_rows * batches, num_columns);
-  auto cuts_with_batches = DeviceSketch(&ctx, dmat.get(), num_bins, num_rows);
-  auto cuts = DeviceSketch(&ctx, dmat.get(), num_bins, 0);
-  ValidateCuts(cuts_with_batches, dmat.get(), num_bins);
-  ValidateCuts(cuts, dmat.get(), num_bins);
-}
-
 TEST(HistUtil, DeviceSketchMultipleColumnsExternal) {
   auto ctx = MakeCUDACtx(0);
   auto bin_sizes = {2, 16, 256, 512};
@@ -682,14 +659,13 @@ class DeviceSketchWithHessianTest
   }
 
   void CheckReg(Context const* ctx, std::shared_ptr<DMatrix> p_fmat, bst_bin_t n_bins,
-                HostDeviceVector<float> const& hessian, std::vector<float> const& w,
-                std::size_t n_elements) const {
+                HostDeviceVector<float> const& hessian, std::vector<float> const& w) const {
     auto const& h_hess = hessian.ConstHostVector();
     auto& h_weight = p_fmat->Info().weights_.HostVector();
     h_weight = w;
 
     HistogramCuts cuts_hess =
-        DeviceSketchWithHessian(ctx, p_fmat.get(), n_bins, hessian.ConstDeviceSpan(), n_elements);
+        DeviceSketchWithHessian(ctx, p_fmat.get(), n_bins, hessian.ConstDeviceSpan());
 
     // merge hessian
     ASSERT_EQ(h_weight.size(), h_hess.size());
@@ -698,7 +674,7 @@ class DeviceSketchWithHessianTest
     }
     ValidateCuts(cuts_hess, p_fmat.get(), n_bins, kMaxWeightedNormalizedRankError);
 
-    HistogramCuts cuts_wh = DeviceSketch(ctx, p_fmat.get(), n_bins, n_elements);
+    HistogramCuts cuts_wh = DeviceSketch(ctx, p_fmat.get(), n_bins);
     ValidateCuts(cuts_wh, p_fmat.get(), n_bins, kMaxWeightedNormalizedRankError);
     ASSERT_EQ(cuts_hess.Values().size(), cuts_wh.Values().size());
     for (std::size_t i = 0; i < cuts_hess.Values().size(); ++i) {
@@ -711,8 +687,7 @@ class DeviceSketchWithHessianTest
  protected:
   Context ctx_ = MakeCUDACtx(0);
 
-  void TestLTR(Context const* ctx, bst_idx_t n_samples, bst_bin_t n_bins,
-               std::size_t n_elements) const {
+  void TestLTR(Context const* ctx, bst_idx_t n_samples, bst_bin_t n_bins) const {
     auto x = GenerateRandom(n_samples, n_features_);
 
     std::vector<bst_group_t> gptr;
@@ -730,7 +705,7 @@ class DeviceSketchWithHessianTest
     std::vector<float> w(n_groups_, 1.0f);
     p_fmat->Info().weights_.HostVector() = w;
     HistogramCuts cuts_hess =
-        DeviceSketchWithHessian(ctx, p_fmat.get(), n_bins, hessian.ConstDeviceSpan(), n_elements);
+        DeviceSketchWithHessian(ctx, p_fmat.get(), n_bins, hessian.ConstDeviceSpan());
     // make validation easier by converting it into sample weight.
     p_fmat->Info().weights_.HostVector() = h_hess;
     p_fmat->Info().group_ptr_.clear();
@@ -742,8 +717,7 @@ class DeviceSketchWithHessianTest
     // test with random group weight
     w = GenerateRandomWeights(n_groups_);
     p_fmat->Info().weights_.HostVector() = w;
-    cuts_hess =
-        DeviceSketchWithHessian(ctx, p_fmat.get(), n_bins, hessian.ConstDeviceSpan(), n_elements);
+    cuts_hess = DeviceSketchWithHessian(ctx, p_fmat.get(), n_bins, hessian.ConstDeviceSpan());
     // make validation easier by converting it into sample weight.
     p_fmat->Info().weights_.Resize(n_samples);
     for (std::size_t i = 0; i < h_hess.size(); ++i) {
@@ -760,7 +734,7 @@ class DeviceSketchWithHessianTest
       auto gidx = dh::SegmentId(Span{gptr.data(), gptr.size()}, i);
       p_fmat->Info().weights_.HostVector()[i] = w[gidx] * h_hess[i];
     }
-    auto cuts = DeviceSketch(ctx, p_fmat.get(), n_bins, n_elements);
+    auto cuts = DeviceSketch(ctx, p_fmat.get(), n_bins);
     ValidateCuts(cuts, p_fmat.get(), n_bins, kMaxWeightedNormalizedRankError);
     ASSERT_EQ(cuts.Values().size(), cuts_hess.Values().size());
     for (std::size_t i = 0; i < cuts.Values().size(); ++i) {
@@ -768,15 +742,14 @@ class DeviceSketchWithHessianTest
     }
   }
 
-  void TestRegression(Context const* ctx, bst_idx_t n_samples, bst_bin_t n_bins,
-                      std::size_t n_elements) const {
+  void TestRegression(Context const* ctx, bst_idx_t n_samples, bst_bin_t n_bins) const {
     auto x = GenerateRandom(n_samples, n_features_);
     auto p_fmat = GetDMatrixFromData(x, n_samples, n_features_);
     std::vector<float> w = GenerateRandomWeights(n_samples);
 
     auto hessian = this->GenerateHessian(ctx, n_samples);
 
-    this->CheckReg(ctx, p_fmat, n_bins, hessian, w, n_elements);
+    this->CheckReg(ctx, p_fmat, n_bins, hessian, w);
   }
 };
 
@@ -799,11 +772,9 @@ TEST_P(DeviceSketchWithHessianTest, DeviceSketchWithHessian) {
   auto n_samples = std::get<1>(param);
   auto n_bins = std::get<2>(param);
   if (std::get<0>(param)) {
-    this->TestLTR(&ctx_, n_samples, n_bins, 0);
-    this->TestLTR(&ctx_, n_samples, n_bins, 512);
+    this->TestLTR(&ctx_, n_samples, n_bins);
   } else {
-    this->TestRegression(&ctx_, n_samples, n_bins, 0);
-    this->TestRegression(&ctx_, n_samples, n_bins, 512);
+    this->TestRegression(&ctx_, n_samples, n_bins);
   }
 }
 


### PR DESCRIPTION
## Summary

This removes the GPU sketch memory-estimation path that was accidentally reintroduced after `#12118`.

The GPU sketch batching policy goes back to the fixed `64M` sliding-window size:
- no `RequiredMemory(...)`
- no `SketchBatchNumElements(...)`
- no batch-size override plumbing on `DeviceSketch*` / `AdapterDeviceSketch`

## What Changed

- remove the estimator helpers and related API surface from `src/common/hist_util.cuh` and `src/common/hist_util.cu`
- restore fixed-window batching with `detail::kSketchBatchNumElements`
- remove the estimator-specific batch override test from `tests/cpp/common/test_hist_util.cu`
- make the fixed-window path a bit more robust:
  - `DeviceSketchWithHessian(...)` no longer depends on `info.num_nonzero_` for loop progress
  - `AdapterDeviceSketch(...)` sizes the last window from the true remaining elements

## Testing

- configured and rebuilt `testxgboost` with CUDA
- ran the focused GPU sketch / adapter / external-memory / hessian slice

Result:
- `66/66` passed
