### PR TITLE
Backport #12094: guard __doc__ assignments for python -OO

### DIFF
--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -2003,7 +2003,8 @@ class DaskXGBClassifier(DaskScikitLearnBase, XGBClassifierBase):
             iteration_range=iteration_range,
         )
 
-    predict_proba.__doc__ = XGBClassifier.predict_proba.__doc__
+    if XGBClassifier.predict_proba.__doc__ is not None:
+        predict_proba.__doc__ = XGBClassifier.predict_proba.__doc__
 
     async def _predict_async(
         self,
@@ -2146,7 +2147,8 @@ class DaskXGBRanker(DaskScikitLearnBase, XGBRankerMixIn):
 
     # FIXME(trivialfis): arguments differ due to additional parameters like group and
     # qid.
-    fit.__doc__ = XGBRanker.fit.__doc__
+    if XGBRanker.fit.__doc__ is not None:
+        fit.__doc__ = XGBRanker.fit.__doc__
 
 
 @xgboost_model_doc(

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -968,7 +968,8 @@ class XGBModel(XGBModelBase):
         self.get_booster().save_model(fname)
         self.get_booster().set_attr(scikit_learn=None)
 
-    save_model.__doc__ = f"""{Booster.save_model.__doc__}"""
+    if Booster.save_model.__doc__ is not None:
+        save_model.__doc__ = f"""{Booster.save_model.__doc__}"""
 
     def load_model(self, fname: ModelIn) -> None:
         # pylint: disable=attribute-defined-outside-init
@@ -991,7 +992,8 @@ class XGBModel(XGBModelBase):
         config = json.loads(self.get_booster().save_config())
         self._load_model_attributes(config)
 
-    load_model.__doc__ = f"""{Booster.load_model.__doc__}"""
+    if Booster.load_model.__doc__ is not None:
+        load_model.__doc__ = f"""{Booster.load_model.__doc__}"""
 
     def _load_model_attributes(self, config: dict) -> None:
         """Load model attributes without hyper-parameters."""
@@ -1616,10 +1618,10 @@ class XGBClassifier(XGBClassifierBase, XGBModel):
             self._set_evaluation_result(evals_result)
             return self
 
-    assert XGBModel.fit.__doc__ is not None
-    fit.__doc__ = XGBModel.fit.__doc__.replace(
-        "Fit gradient boosting model", "Fit gradient boosting classifier", 1
-    )
+    if XGBModel.fit.__doc__ is not None:
+        fit.__doc__ = XGBModel.fit.__doc__.replace(
+            "Fit gradient boosting model", "Fit gradient boosting classifier", 1
+        )
 
     def predict(
         self,


### PR DESCRIPTION
Backport of approved/merged PR #12094 to release_2.1.0.

Upstream PR: https://github.com/dmlc/xgboost/pull/12094

release_2.1.0 is the last release line supporting Python 3.8 (>=3.10 required from 3.x). Users on Python 3.8 running with `-OO` hit `AttributeError: 'NoneType' object has no attribute 'replace'` at import time because `assert XGBModel.fit.__doc__ is not None` is stripped under `-OO` and `__doc__` is None.

This cherry-picks the guard change from #12094 onto release_2.1.0.