### PR TITLE
Unify CI configure workflow

### DIFF
--- a/.github/workflows/ci_configure.yml
+++ b/.github/workflows/ci_configure.yml
@@ -1,0 +1,52 @@
+name: Configure CI Variables
+
+on:
+  workflow_call:
+    inputs:
+      tag-prefix:
+        description: Prefix for the runs-on runner tag.
+        required: true
+        type: string
+    outputs:
+      docker_registry:
+        description: ECR registry containing CI images.
+        value: ${{ jobs.ci-configure.outputs.docker_registry }}
+      docker_username:
+        description: Docker username for ECR.
+        value: ${{ jobs.ci-configure.outputs.docker_username }}
+      docker_password:
+        description: Docker password for ECR.
+        value: ${{ jobs.ci-configure.outputs.docker_password }}
+      image_tag:
+        description: CI image tag selected for this ref.
+        value: ${{ jobs.ci-configure.outputs.image_tag }}
+
+permissions:
+  contents: read  # to fetch code (actions/checkout)
+
+jobs:
+  ci-configure:
+    name: Configure variables for CI
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=linux-amd64-cpu
+      - tag=${{ inputs.tag-prefix }}-ci-configure
+    steps:
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.1.2
+        with:
+          mask-password: 'false'
+          registries: '492475357299'
+      - uses: actions/checkout@v6.0.2
+      - name: Get image tag
+        id: get-image-tag
+        run: |
+          source ops/pipeline/get-image-tag.sh
+          echo "Using image tag $IMAGE_TAG"
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+    outputs:
+      docker_registry: ${{ steps.login-ecr.outputs.registry }}
+      docker_username: ${{ steps.login-ecr.outputs.docker_username_492475357299_dkr_ecr_us_west_2_amazonaws_com }}
+      docker_password: ${{ steps.login-ecr.outputs.docker_password_492475357299_dkr_ecr_us_west_2_amazonaws_com }}
+      image_tag: ${{ steps.get-image-tag.outputs.image_tag }}

--- a/.github/workflows/jvm_tests.yml
+++ b/.github/workflows/jvm_tests.yml
@@ -21,29 +21,9 @@ env:
 jobs:
   ci-configure:
     name: Configure variables for CI
-    runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
-      - tag=jvm-tests-ci-configure
-    steps:
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2.1.2
-        with:
-          mask-password: 'false'
-          registries: '492475357299'
-      - uses: actions/checkout@v6.0.2
-      - name: Get image tag
-        id: get-image-tag
-        run: |
-          source ops/pipeline/get-image-tag.sh
-          echo "Using image tag $IMAGE_TAG"
-          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
-    outputs:
-      docker_registry: ${{ steps.login-ecr.outputs.registry }}
-      docker_username: ${{ steps.login-ecr.outputs.docker_username_492475357299_dkr_ecr_us_west_2_amazonaws_com }}
-      docker_password: ${{ steps.login-ecr.outputs.docker_password_492475357299_dkr_ecr_us_west_2_amazonaws_com }}
-      image_tag: ${{ steps.get-image-tag.outputs.image_tag }}
+    uses: ./.github/workflows/ci_configure.yml
+    with:
+      tag-prefix: jvm-tests
 
   build-jvm-manylinux2014:
     name: >-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,29 +21,9 @@ env:
 jobs:
   ci-configure:
     name: Configure variables for CI
-    runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
-      - tag=main-ci-configure
-    steps:
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2.1.2
-        with:
-          mask-password: 'false'
-          registries: '492475357299'
-      - uses: actions/checkout@v6.0.2
-      - name: Get image tag
-        id: get-image-tag
-        run: |
-          source ops/pipeline/get-image-tag.sh
-          echo "Using image tag $IMAGE_TAG"
-          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
-    outputs:
-      docker_registry: ${{ steps.login-ecr.outputs.registry }}
-      docker_username: ${{ steps.login-ecr.outputs.docker_username_492475357299_dkr_ecr_us_west_2_amazonaws_com }}
-      docker_password: ${{ steps.login-ecr.outputs.docker_password_492475357299_dkr_ecr_us_west_2_amazonaws_com }}
-      image_tag: ${{ steps.get-image-tag.outputs.image_tag }}
+    uses: ./.github/workflows/ci_configure.yml
+    with:
+      tag-prefix: main
 
   build-cpu:
     name: Build CPU (${{ matrix.variant }})

--- a/.github/workflows/misc.yml
+++ b/.github/workflows/misc.yml
@@ -21,29 +21,9 @@ env:
 jobs:
   ci-configure:
     name: Configure variables for CI
-    runs-on:
-      - runs-on=${{ github.run_id }}
-      - runner=linux-amd64-cpu
-      - tag=misc-ci-configure
-    steps:
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2.1.2
-        with:
-          mask-password: 'false'
-          registries: '492475357299'
-      - uses: actions/checkout@v6.0.2
-      - name: Get image tag
-        id: get-image-tag
-        run: |
-          source ops/pipeline/get-image-tag.sh
-          echo "Using image tag $IMAGE_TAG"
-          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
-    outputs:
-      docker_registry: ${{ steps.login-ecr.outputs.registry }}
-      docker_username: ${{ steps.login-ecr.outputs.docker_username_492475357299_dkr_ecr_us_west_2_amazonaws_com }}
-      docker_password: ${{ steps.login-ecr.outputs.docker_password_492475357299_dkr_ecr_us_west_2_amazonaws_com }}
-      image_tag: ${{ steps.get-image-tag.outputs.image_tag }}
+    uses: ./.github/workflows/ci_configure.yml
+    with:
+      tag-prefix: misc
 
   gtest-cpu-nonomp:
     name: Test Google C++ unittest (CPU Non-OMP)


### PR DESCRIPTION
## Summary

- Add a reusable `ci_configure.yml` workflow for ECR login and CI image tag resolution.
- Replace the duplicated `ci-configure` jobs in `main.yml`, `jvm_tests.yml`, and `misc.yml` with calls to the reusable workflow.
- Preserve the existing job id and output names so downstream `needs.ci-configure.outputs.*` references do not change.

## Rationale

The configure job still needs to run before containerized jobs because GitHub Actions resolves `container.image` and `container.credentials` before job steps execute. This change keeps that staging model, but removes the copied implementation from each workflow.

`python_wheels_variants.yml` still has a separate ECR login job because it uses a different `ecr-login` pattern and image tag flow.

## Testing

- `git diff --check`
- `pre-commit run --files .github/workflows/ci_configure.yml .github/workflows/main.yml .github/workflows/jvm_tests.yml .github/workflows/misc.yml`
- Parsed modified workflow YAML with PyYAML
- Checked that all callers still reference the reusable workflow outputs via `needs.ci-configure.outputs.*`
