### PR TITLE
Install libuv headers for R CI

### DIFF
--- a/.github/workflows/r_tests.yml
+++ b/.github/workflows/r_tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt update
-          sudo apt install libcurl4-openssl-dev libssl-dev libssh2-1-dev libgit2-dev libglpk-dev libxml2-dev libharfbuzz-dev libfribidi-dev librsvg2-dev librsvg2-2
+          sudo apt install libcurl4-openssl-dev libssl-dev libssh2-1-dev libgit2-dev libglpk-dev libxml2-dev libharfbuzz-dev libfribidi-dev librsvg2-dev librsvg2-2 libuv1-dev
         if: matrix.os == 'ubuntu-latest'
       - uses: actions/checkout@v6.0.2
         with:
@@ -80,8 +80,8 @@ jobs:
       - name: Install system dependencies
         run: |
           # Must run before checkout to have the latest git installed.
-          apt update && apt install libcurl4-openssl-dev libssl-dev libssh2-1-dev libgit2-dev libglpk-dev libxml2-dev libharfbuzz-dev libfribidi-dev git librsvg2-dev librsvg2-2 pandoc -y
-          # cmake is required by the R `fs` package to build its bundled libuv.
+          apt update && apt install libcurl4-openssl-dev libssl-dev libssh2-1-dev libgit2-dev libglpk-dev libxml2-dev libharfbuzz-dev libfribidi-dev git librsvg2-dev librsvg2-2 pandoc libuv1-dev -y
+          # cmake is required by the R `fs` package if it builds its bundled libuv.
           apt install cmake -y
       - name: Trust git cloning project sources
         run: |


### PR DESCRIPTION
## Summary

Fix R CI dependency installation by installing `libuv1-dev` in the Linux R test jobs.

Recent R CI failures on both this PR and `master` show the R package `fs` failing to configure because `libuv` is unavailable via `pkg-config`:

```text
Package 'libuv', required by 'virtual:world', not found
Configuration failed because libuv was not found.
ERROR: configuration failed for package ‘fs’
```

The workflow already installs `cmake`, which previously allowed `fs` to build its bundled libuv, but the current dependency resolution now requires the system libuv development package. Installing `libuv1-dev` provides the headers and `libuv.pc`.

## Changes

- Add `libuv1-dev` to the Ubuntu R test system dependencies.
- Add `libuv1-dev` to the Debian-container R test system dependencies.
- Keep `cmake` installed as a fallback for `fs` bundled-libuv builds.

## Testing

- `git diff --check`
- Parsed `.github/workflows/r_tests.yml` with PyYAML.
- Commit hooks passed, including `check yaml`.
