### PR TITLE
fix: align verbose default in XGBRanker.fit() with other estimators

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -2176,7 +2176,7 @@ class XGBRanker(XGBRankerMixIn, XGBModel):
         eval_set: Optional[Sequence[Tuple[ArrayLike, ArrayLike]]] = None,
         eval_group: Optional[Sequence[ArrayLike]] = None,
         eval_qid: Optional[Sequence[ArrayLike]] = None,
-        verbose: Optional[Union[bool, int]] = False,
+        verbose: Optional[Union[bool, int]] = True,
         xgb_model: Optional[Union[Booster, str, XGBModel]] = None,
         sample_weight_eval_set: Optional[Sequence[ArrayLike]] = None,
         base_margin_eval_set: Optional[Sequence[ArrayLike]] = None,

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -1391,6 +1391,26 @@ def test_evaluation_metric():
         clf.fit(X, y, eval_set=[(X, y)])
 
 
+def test_verbose_default_consistency() -> None:
+    import inspect
+
+    from xgboost import (
+        XGBClassifier,
+        XGBRanker,
+        XGBRegressor,
+        XGBRFClassifier,
+        XGBRFRegressor,
+    )
+
+    clf_default = inspect.signature(XGBClassifier.fit).parameters["verbose"].default
+    reg_default = inspect.signature(XGBRegressor.fit).parameters["verbose"].default
+    rank_default = inspect.signature(XGBRanker.fit).parameters["verbose"].default
+    rfc_default = inspect.signature(XGBRFClassifier.fit).parameters["verbose"].default
+    rfr_default = inspect.signature(XGBRFRegressor.fit).parameters["verbose"].default
+
+    assert clf_default == reg_default == rank_default == rfc_default == rfr_default
+
+
 def test_mixed_metrics() -> None:
     from sklearn.datasets import make_classification
     from sklearn.metrics import hamming_loss, hinge_loss, log_loss


### PR DESCRIPTION
`XGBRanker.fit()` had `verbose=False` as its default while `XGBModel`, 
`XGBClassifier`, and `XGBRegressor` all default to `verbose=True`. This 
caused inconsistent behavior when `eval_set` was provided — XGBRanker 
would silently suppress evaluation output while all other estimators 
printed it by default.

Changed `verbose` default in `XGBRanker.fit()` from `False` to `True` 
to match the rest of the sklearn API.

Added test_verbose_default_consistency to verify that verbose defaults to the same value across all sklearn estimators

Addresses #12183