### PR TITLE
fix: include unistd.h on macOS to expose mkdtemp in filesystem.cc

### DIFF
--- a/tests/cpp/filesystem.cc
+++ b/tests/cpp/filesystem.cc
@@ -9,6 +9,10 @@
 
 #if !defined(xgboost_IS_WIN)
 
+#if defined(__APPLE__)
+#include <unistd.h>  // for mkdtemp on macOS
+#endif
+
 #include <cstdlib>  // for mkdtemp
 
 #include "../../src/common/error_msg.h"  // for SystemError


### PR DESCRIPTION
Include `<unistd.h>` under `#if defined(__APPLE__)` in `tests/cpp/filesystem.cc` to expose `mkdtemp` on macOS.
Tested on macOS Apple Silicon (arm64).

Closes #12186