### PR TITLE
Fix in-place SetPrune aliasing

### DIFF
--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -233,17 +233,18 @@ struct WQSummary {
     }
     // Use raw pointers in this hot loop to avoid per-access Span bounds checks.
     auto const *src_data = this->data_.data();
-    auto *dst_data = data_.data();
     if (maxsize == 1) {
-      dst_data[0] = src_data[0];
+      data_[0] = src_data[0];
       this->current_elements_ = 1;
       return;
     }
+    std::vector<Entry> pruned(maxsize);
+    auto *dst_data = pruned.data();
     const RType begin = src_data[0].rmax;
     const RType range = src_data[src_size - 1].rmin - src_data[0].rmax;
     const size_t n = maxsize - 1;
     dst_data[0] = src_data[0];
-    this->current_elements_ = 1;
+    size_t current_elements = 1;
     // lastidx is used to avoid duplicated records
     size_t i = 1, lastidx = 0;
     for (size_t k = 1; k < n; ++k) {
@@ -255,19 +256,21 @@ struct WQSummary {
       if (i == src_size - 1) break;
       if (dx2 < src_data[i].RMinNext() + src_data[i + 1].RMaxPrev()) {
         if (i != lastidx) {
-          dst_data[current_elements_++] = src_data[i];
+          dst_data[current_elements++] = src_data[i];
           lastidx = i;
         }
       } else {
         if (i + 1 != lastidx) {
-          dst_data[current_elements_++] = src_data[i + 1];
+          dst_data[current_elements++] = src_data[i + 1];
           lastidx = i + 1;
         }
       }
     }
     if (lastidx != src_size - 1) {
-      dst_data[current_elements_++] = src_data[src_size - 1];
+      dst_data[current_elements++] = src_data[src_size - 1];
     }
+    std::copy_n(pruned.data(), current_elements, this->data_.data());
+    this->current_elements_ = current_elements;
   }
 
   /*!

--- a/src/common/quantile.h
+++ b/src/common/quantile.h
@@ -238,38 +238,42 @@ struct WQSummary {
       this->current_elements_ = 1;
       return;
     }
-    std::vector<Entry> pruned(maxsize);
-    auto *dst_data = pruned.data();
     const RType begin = src_data[0].rmax;
     const RType range = src_data[src_size - 1].rmin - src_data[0].rmax;
     const size_t n = maxsize - 1;
-    dst_data[0] = src_data[0];
+    Entry const tail = src_data[src_size - 1];
+    Entry left = src_data[1];
+    Entry right = src_data[2];
+    data_[0] = src_data[0];
     size_t current_elements = 1;
     // lastidx is used to avoid duplicated records
     size_t i = 1, lastidx = 0;
     for (size_t k = 1; k < n; ++k) {
       RType dx2 = 2 * ((k * range) / n + begin);
       // find first i such that  d < (rmax[i+1] + rmin[i+1]) / 2
-      while (i < src_size - 1 && dx2 >= src_data[i + 1].rmax + src_data[i + 1].rmin) {
+      while (i < src_size - 1 && dx2 >= right.rmax + right.rmin) {
         ++i;
+        left = right;
+        if (i < src_size - 1) {
+          right = src_data[i + 1];
+        }
       }
       if (i == src_size - 1) break;
-      if (dx2 < src_data[i].RMinNext() + src_data[i + 1].RMaxPrev()) {
+      if (dx2 < left.RMinNext() + right.RMaxPrev()) {
         if (i != lastidx) {
-          dst_data[current_elements++] = src_data[i];
+          data_[current_elements++] = left;
           lastidx = i;
         }
       } else {
         if (i + 1 != lastidx) {
-          dst_data[current_elements++] = src_data[i + 1];
+          data_[current_elements++] = right;
           lastidx = i + 1;
         }
       }
     }
     if (lastidx != src_size - 1) {
-      dst_data[current_elements++] = src_data[src_size - 1];
+      data_[current_elements++] = tail;
     }
-    std::copy_n(pruned.data(), current_elements, this->data_.data());
     this->current_elements_ = current_elements;
   }
 

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -227,6 +227,13 @@ auto EnumeratedSummaryEntries(std::size_t size, std::uint64_t code)
   return entries;
 }
 
+auto RepresentativePruneBudgets(std::size_t size) -> std::vector<std::size_t> {
+  std::vector<std::size_t> budgets{0, 1, 2, size / 4, size / 2, size - 1, size, size + 1};
+  std::sort(budgets.begin(), budgets.end());
+  budgets.erase(std::unique(budgets.begin(), budgets.end()), budgets.end());
+  return budgets;
+}
+
 }  // namespace
 
 TEST_P(QuantileSummaryTest, Invariants) {
@@ -286,7 +293,7 @@ TEST(Quantile, SetPrunePreservesIncreasingValuesWithAliasingGeometry) {
 }
 
 TEST(Quantile, SetPruneInPlaceMatchesOutOfPlaceReferenceOnSmallIntegerGeometries) {
-  for (std::size_t size = 3; size <= 6; ++size) {
+  for (std::size_t size = 3; size <= 5; ++size) {
     auto const n_cases = static_cast<std::uint64_t>(std::pow(9.0, static_cast<double>(size)));
     for (std::uint64_t code = 0; code < n_cases; ++code) {
       auto source = EnumeratedSummaryEntries(size, code);
@@ -298,10 +305,11 @@ TEST(Quantile, SetPruneInPlaceMatchesOutOfPlaceReferenceOnSmallIntegerGeometries
 }
 
 TEST(Quantile, SetPruneInPlaceMatchesOutOfPlaceReferenceOnRandomGeometries) {
-  for (std::size_t size = 3; size < 128; ++size) {
-    for (std::uint32_t seed = 0; seed < 100; ++seed) {
+  for (auto size : {3, 4, 5, 7, 8, 15, 16, 31, 32, 63, 64, 127, 256}) {
+    auto budgets = RepresentativePruneBudgets(size);
+    for (std::uint32_t seed = 0; seed < 16; ++seed) {
       auto source = RandomSummaryEntries(size, seed);
-      for (std::size_t maxsize = 0; maxsize <= size + 1; ++maxsize) {
+      for (auto maxsize : budgets) {
         SCOPED_TRACE(::testing::Message()
                      << "size=" << size << ", seed=" << seed << ", maxsize=" << maxsize);
         ExpectPruneMatchesReference(source, maxsize);

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -122,6 +122,111 @@ void AssertSameOnAllWorkers(Context const* ctx, HistogramCuts const& cuts) {
   }
 }
 
+auto ReferencePrune(Span<WQSummary<>::Entry const> src, std::size_t maxsize)
+    -> std::vector<WQSummary<>::Entry> {
+  using Entry = WQSummary<>::Entry;
+
+  if (maxsize == 0) {
+    return {};
+  }
+  if (src.size() <= maxsize) {
+    return {src.cbegin(), src.cend()};
+  }
+  if (maxsize == 1) {
+    return {src[0]};
+  }
+
+  std::vector<Entry> out(maxsize);
+  auto current_elements = std::size_t{1};
+  auto const begin = src[0].rmax;
+  auto const range = src[src.size() - 1].rmin - src[0].rmax;
+  auto const n = maxsize - 1;
+  out[0] = src[0];
+
+  std::size_t i = 1, lastidx = 0;
+  for (std::size_t k = 1; k < n; ++k) {
+    auto dx2 = 2 * ((k * range) / n + begin);
+    while (i < src.size() - 1 && dx2 >= src[i + 1].rmax + src[i + 1].rmin) {
+      ++i;
+    }
+    if (i == src.size() - 1) {
+      break;
+    }
+    if (dx2 < src[i].RMinNext() + src[i + 1].RMaxPrev()) {
+      if (i != lastidx) {
+        out[current_elements++] = src[i];
+        lastidx = i;
+      }
+    } else {
+      if (i + 1 != lastidx) {
+        out[current_elements++] = src[i + 1];
+        lastidx = i + 1;
+      }
+    }
+  }
+  if (lastidx != src.size() - 1) {
+    out[current_elements++] = src[src.size() - 1];
+  }
+  out.resize(current_elements);
+  return out;
+}
+
+void ExpectEntriesEq(Span<WQSummary<>::Entry const> entries,
+                     std::vector<WQSummary<>::Entry> const& expected) {
+  ASSERT_EQ(entries.size(), expected.size());
+  for (std::size_t i = 0; i < entries.size(); ++i) {
+    EXPECT_FLOAT_EQ(entries[i].rmin, expected[i].rmin) << "i=" << i;
+    EXPECT_FLOAT_EQ(entries[i].rmax, expected[i].rmax) << "i=" << i;
+    EXPECT_FLOAT_EQ(entries[i].wmin, expected[i].wmin) << "i=" << i;
+    EXPECT_FLOAT_EQ(entries[i].value, expected[i].value) << "i=" << i;
+  }
+}
+
+void ExpectPruneMatchesReference(std::vector<WQSummary<>::Entry> const& source,
+                                 std::size_t maxsize) {
+  auto expected = ReferencePrune({source.data(), source.size()}, maxsize);
+
+  WQSummaryContainer actual;
+  actual.Reserve(source.size());
+  std::copy(source.cbegin(), source.cend(), actual.space.begin());
+  actual.SetSize(source.size());
+  actual.SetPrune(maxsize);
+
+  ExpectEntriesEq(actual.Entries(), expected);
+}
+
+auto RandomSummaryEntries(std::size_t size, std::uint32_t seed) -> std::vector<WQSummary<>::Entry> {
+  using Entry = WQSummary<>::Entry;
+
+  SimpleLCG lcg{seed};
+  std::vector<Entry> entries(size);
+  auto cursor = 0.0f;
+  for (std::size_t i = 0; i < size; ++i) {
+    auto wmin = static_cast<float>((lcg() % 5 == 0) ? 0 : 1 + lcg() % 7);
+    auto slack = static_cast<float>(lcg() % 8);
+    entries[i] = Entry{cursor, cursor + wmin + slack, wmin, static_cast<float>(i)};
+    cursor = entries[i].RMinNext() + static_cast<float>(lcg() % 4);
+  }
+  return entries;
+}
+
+auto EnumeratedSummaryEntries(std::size_t size, std::uint64_t code)
+    -> std::vector<WQSummary<>::Entry> {
+  using Entry = WQSummary<>::Entry;
+
+  std::vector<Entry> entries(size);
+  auto cursor = 0.0f;
+  for (std::size_t i = 0; i < size; ++i) {
+    auto wmin = static_cast<float>(code % 3);
+    code /= 3;
+    auto slack = static_cast<float>((code % 3) * 2);
+    code /= 3;
+    entries[i] = Entry{cursor, cursor + wmin + slack, wmin, static_cast<float>(i)};
+    cursor = entries[i].RMinNext();
+  }
+  return entries;
+}
+
 }  // namespace
 
 TEST_P(QuantileSummaryTest, Invariants) {
@@ -177,6 +282,59 @@ TEST(Quantile, SetPrunePreservesIncreasingValuesWithAliasingGeometry) {
   }
   for (std::size_t i = 1; i < entries.size(); ++i) {
     EXPECT_LT(entries[i - 1].value, entries[i].value);
+  }
+}
+
+TEST(Quantile, SetPruneInPlaceMatchesOutOfPlaceReferenceOnSmallIntegerGeometries) {
+  for (std::size_t size = 3; size <= 6; ++size) {
+    auto const n_cases = static_cast<std::uint64_t>(std::pow(9.0, static_cast<double>(size)));
+    for (std::uint64_t code = 0; code < n_cases; ++code) {
+      auto source = EnumeratedSummaryEntries(size, code);
+      for (std::size_t maxsize = 0; maxsize <= size + 1; ++maxsize) {
+        ExpectPruneMatchesReference(source, maxsize);
+      }
+    }
+  }
+}
+
+TEST(Quantile, SetPruneInPlaceMatchesOutOfPlaceReferenceOnRandomGeometries) {
+  for (std::size_t size = 3; size < 128; ++size) {
+    for (std::uint32_t seed = 0; seed < 100; ++seed) {
+      auto source = RandomSummaryEntries(size, seed);
+      for (std::size_t maxsize = 0; maxsize <= size + 1; ++maxsize) {
+        SCOPED_TRACE(::testing::Message()
+                     << "size=" << size << ", seed=" << seed << ", maxsize=" << maxsize);
+        ExpectPruneMatchesReference(source, maxsize);
+      }
+    }
+  }
+}
+
+TEST(Quantile, SetPruneInPlaceMatchesOutOfPlaceReferenceOnBoundaryGeometries) {
+  using Entry = WQSummary<>::Entry;
+
+  for (std::size_t size = 3; size <= 12; ++size) {
+    for (std::size_t pivot = 1; pivot + 1 < size; ++pivot) {
+      for (float left_wmin : {0.0f, 1.0f, 4.0f}) {
+        for (float right_wmin : {0.0f, 1.0f, 4.0f}) {
+          std::vector<Entry> source(size);
+          for (std::size_t i = 0; i < size; ++i) {
+            auto rmin = static_cast<float>(i * 4);
+            source[i] = Entry{rmin, rmin + 2.0f, 1.0f, static_cast<float>(i)};
+          }
+          source[pivot].wmin = left_wmin;
+          source[pivot].rmax = source[pivot].rmin + left_wmin + 4.0f;
+          source[pivot + 1].wmin = right_wmin;
+          source[pivot + 1].rmax = source[pivot + 1].rmin + right_wmin + 4.0f;
+
+          for (std::size_t maxsize = 0; maxsize <= size + 1; ++maxsize) {
+            SCOPED_TRACE(::testing::Message()
+                         << "size=" << size << ", pivot=" << pivot << ", maxsize=" << maxsize);
+            ExpectPruneMatchesReference(source, maxsize);
+          }
+        }
+      }
+    }
   }
 }
 

--- a/tests/cpp/common/test_quantile.cc
+++ b/tests/cpp/common/test_quantile.cc
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>    // for array
 #include <cstdint>  // for int64_t
 
 #include "../../../src/collective/allreduce.h"
@@ -151,6 +152,33 @@ INSTANTIATE_TEST_SUITE_P(Anchors, QuantileSummaryTest, ::testing::ValuesIn(Summa
                          SummaryCaseName);
 INSTANTIATE_TEST_SUITE_P(RandomSamples, QuantileSummaryTest,
                          ::testing::ValuesIn(SummaryRandomCases(100)), SummaryCaseName);
+
+TEST(Quantile, SetPrunePreservesIncreasingValuesWithAliasingGeometry) {
+  using Entry = WQSummary<>::Entry;
+  WQSummaryContainer summary;
+  summary.Reserve(7);
+
+  summary.space[0] = Entry{0.0f, 0.0f, 0.0f, 1.0f};
+  summary.space[1] = Entry{0.0f, 4.0f, 0.0f, 2.0f};
+  summary.space[2] = Entry{4.0f, 5.0f, 1.0f, 3.0f};
+  summary.space[3] = Entry{5.0f, 6.0f, 1.0f, 4.0f};
+  summary.space[4] = Entry{8.0f, 9.0f, 1.0f, 5.0f};
+  summary.space[5] = Entry{9.0f, 10.0f, 1.0f, 6.0f};
+  summary.space[6] = Entry{10.0f, 10.0f, 0.0f, 7.0f};
+  summary.SetSize(7);
+
+  summary.SetPrune(6);
+  auto entries = summary.Entries();
+
+  ASSERT_EQ(entries.size(), 5u);
+  std::array<float, 5> expected_values{1.0f, 3.0f, 4.0f, 5.0f, 7.0f};
+  for (std::size_t i = 0; i < entries.size(); ++i) {
+    EXPECT_FLOAT_EQ(entries[i].value, expected_values[i]);
+  }
+  for (std::size_t i = 1; i < entries.size(); ++i) {
+    EXPECT_LT(entries[i - 1].value, entries[i].value);
+  }
+}
 
 TEST_P(QuantileContainerTest, Invariants) {
   auto c = GetParam();


### PR DESCRIPTION
## Summary

Fix `WQSummary::SetPrune` so its in-place compaction does not corrupt source entries that are still needed by later loop iterations.

The previous implementation read and wrote through the same `data_` buffer. For some rank geometries, an earlier output write could overwrite `src_data[i]`, and a later decision would then read the corrupted slot. This could produce duplicate value entries in the pruned summary, violating the strictly increasing value invariant.

This keeps `SetPrune` allocation-free by caching the active source window (`left`, `right`, and `tail`) before writes can clobber those entries.

## Tests

Added focused coverage for `SetPrune`:

- deterministic regression for the reported aliasing geometry
- out-of-place reference implementation used only in tests
- exhaustive small integer geometries
- randomized larger geometries
- targeted boundary-shaped geometries around zero/nonzero weights

Validated locally:

- `cmake --build build-cpu --target testxgboost -j35`
- `./build-cpu/testxgboost --gtest_filter='Quantile.SetPrune*'`
- `./build-cpu/testxgboost --gtest_filter=Quantile.*`
- `./build-cpu/testxgboost --gtest_filter='*QuantileSummaryTest*:*QuantileContainerTest*'`

## Performance

Compared against `upstream/master` with a standalone microbenchmark that repeatedly restores pre-generated summaries and calls `SetPrune`.

The in-place cached-entry fix is allocation-free but slightly slower for larger summaries. Pinned-core net prune timing was approximately:

| size -> maxsize | upstream | fixed | delta |
|---|---:|---:|---:|
| `32 -> 16` | 237.8 ns | 228.3 ns | 4.0% faster |
| `128 -> 32` | 649.5 ns | 651.5 ns | 0.3% slower |
| `512 -> 64` | 1562.1 ns | 1627.4 ns | 4.2% slower |
| `2048 -> 256` | 6295.7 ns | 6613.7 ns | 5.1% slower |
| `8192 -> 512` | 14446.4 ns | 16952.9 ns | 17.4% slower |

I also tried a lazy-cache variant that only cached entries when a write would overwrite the active read window. It passed the same tests but benchmarked worse due to extra branch/state overhead, so this PR keeps the simpler cached-window implementation.
