### PR TITLE
Add TreeSHAP references to documentation

### DIFF
--- a/doc/contrib/featuremap.rst
+++ b/doc/contrib/featuremap.rst
@@ -45,7 +45,8 @@ XGBoost includes features designed to improve understanding of the model. Here's
 - Tree visualization.
 - Tree as dataframe.
 
-For GPU support, the SHAP value uses XGBoost's in-tree ``QuadratureTreeSHAP`` implementation. It supports categorical features, while vector-leaf is still in progress.
+SHAP values use XGBoost's in-tree ``QuadratureTreeSHAP`` implementation on both CPU and
+GPU. It supports categorical features, while vector-leaf is still in progress.
 
 ----------
 Evaluation

--- a/doc/gpu/index.rst
+++ b/doc/gpu/index.rst
@@ -36,8 +36,9 @@ The GPU algorithms currently work with CLI, Python, R, and JVM packages. See :do
 GPU-Accelerated SHAP values
 =============================
 XGBoost uses its in-tree ``QuadratureTreeSHAP`` implementation for computing SHAP values
-on both CPU and GPU. The GPU path uses this same Quadrature-TreeSHAP formulation
-(Wettenstein et al. 2026) for exact TreeSHAP feature attributions when the GPU is selected.
+on both CPU and GPU. The GPU path uses the same Quadrature-TreeSHAP formulation described
+by Wettenstein et al. (2026) for exact TreeSHAP feature attributions when the GPU is
+selected.
 
 .. code-block:: python
 

--- a/doc/gpu/index.rst
+++ b/doc/gpu/index.rst
@@ -35,7 +35,9 @@ The GPU algorithms currently work with CLI, Python, R, and JVM packages. See :do
 
 GPU-Accelerated SHAP values
 =============================
-XGBoost provides an in-tree GPU implementation of ``QuadratureTreeSHAP`` for computing SHAP values when the GPU is used.
+XGBoost uses its in-tree ``QuadratureTreeSHAP`` implementation for computing SHAP values
+on both CPU and GPU. The GPU path uses this same Quadrature-TreeSHAP formulation
+(Wettenstein et al. 2026) for exact TreeSHAP feature attributions when the GPU is selected.
 
 .. code-block:: python
 
@@ -91,6 +93,10 @@ The application may be profiled with annotations by specifying ``USE_NTVX`` to c
 References
 **********
 `Mitchell R, Frank E. (2017) Accelerating the XGBoost algorithm using GPU computing. PeerJ Computer Science 3:e127 https://doi.org/10.7717/peerj-cs.127 <https://peerj.com/articles/cs-127/>`_
+
+`Lundberg SM, Erion GG, Lee S-I. (2018) Consistent Individualized Feature Attribution for Tree Ensembles. arXiv:1802.03888 <https://arxiv.org/abs/1802.03888>`_
+
+`Wettenstein R, Mitchell R, Yu P. (2026) Quadrature-TreeSHAP: Depth-Independent TreeSHAP and Shapley Interactions. arXiv:2605.04497 <https://arxiv.org/abs/2605.04497>`_
 
 `NVIDIA Parallel Forall: Gradient Boosting, Decision Trees and XGBoost with CUDA <https://devblogs.nvidia.com/parallelforall/gradient-boosting-decision-trees-xgboost-cuda/>`_
 

--- a/doc/prediction.rst
+++ b/doc/prediction.rst
@@ -40,11 +40,12 @@ After 1.4 release, we added a new parameter called ``strict_shape``, one can set
   Output is a 3-dim array, with ``(rows, groups, columns + 1)`` as shape.  Whether
   ``approx_contribs`` is used does not change the output shape. If the strict shape
   parameter is not set, it can be a 2 or 3 dimension array depending on whether multi-class
-  model is being used. See `Lundberg et al. (2018) <https://arxiv.org/abs/1802.03888>`__
-  for the original TreeSHAP feature attribution method. XGBoost uses the
-  ``QuadratureTreeSHAP`` implementation described by `Wettenstein et al. (2026)
-  <https://arxiv.org/abs/2605.04497>`__ for exact TreeSHAP feature attributions on both
-  CPU and GPU.
+  model is being used. See `Lundberg et al. (2018)`_ for the original TreeSHAP feature
+  attribution method. When ``approx_contribs`` is ``False``, XGBoost uses the
+  ``QuadratureTreeSHAP`` implementation described by `Wettenstein et al. (2026)`_ for exact
+  TreeSHAP feature attributions on both CPU and GPU. When ``approx_contribs`` is ``True``,
+  XGBoost uses an approximate contribution method on CPU; the GPU predictor does not
+  implement approximated contributions.
 
 - When using ``pred_interactions`` with ``strict_shape`` set to ``True``:
 
@@ -195,3 +196,5 @@ More information and examples are given in the `Concrete ML documentation`_.
 .. _Zama: https://www.zama.ai/
 .. _Concrete ML: https://github.com/zama-ai/concrete-ml
 .. _Concrete ML documentation: https://docs.zama.ai/concrete-ml
+.. _Lundberg et al. (2018): https://arxiv.org/abs/1802.03888
+.. _Wettenstein et al. (2026): https://arxiv.org/abs/2605.04497

--- a/doc/prediction.rst
+++ b/doc/prediction.rst
@@ -39,8 +39,10 @@ After 1.4 release, we added a new parameter called ``strict_shape``, one can set
 
   Output is a 3-dim array, with ``(rows, groups, columns + 1)`` as shape.  Whether
   ``approx_contribs`` is used does not change the output shape. If the strict shape
-  parameter is not set, it can be a 2 or 3 dimension array depending on whether
-  multi-class model is being used.
+  parameter is not set, it can be a 2 or 3 dimension array depending on whether multi-class
+  model is being used. See Lundberg et al. (2018) for the original TreeSHAP feature
+  attribution method. XGBoost uses the ``QuadratureTreeSHAP`` implementation described by
+  Wettenstein et al. (2026) for exact TreeSHAP feature attributions on both CPU and GPU.
 
 - When using ``pred_interactions`` with ``strict_shape`` set to ``True``:
 

--- a/doc/prediction.rst
+++ b/doc/prediction.rst
@@ -40,9 +40,11 @@ After 1.4 release, we added a new parameter called ``strict_shape``, one can set
   Output is a 3-dim array, with ``(rows, groups, columns + 1)`` as shape.  Whether
   ``approx_contribs`` is used does not change the output shape. If the strict shape
   parameter is not set, it can be a 2 or 3 dimension array depending on whether multi-class
-  model is being used. See Lundberg et al. (2018) for the original TreeSHAP feature
-  attribution method. XGBoost uses the ``QuadratureTreeSHAP`` implementation described by
-  Wettenstein et al. (2026) for exact TreeSHAP feature attributions on both CPU and GPU.
+  model is being used. See `Lundberg et al. (2018) <https://arxiv.org/abs/1802.03888>`__
+  for the original TreeSHAP feature attribution method. XGBoost uses the
+  ``QuadratureTreeSHAP`` implementation described by `Wettenstein et al. (2026)
+  <https://arxiv.org/abs/2605.04497>`__ for exact TreeSHAP feature attributions on both
+  CPU and GPU.
 
 - When using ``pred_interactions`` with ``strict_shape`` set to ``True``:
 


### PR DESCRIPTION
## Summary
- Add documentation references for the original TreeSHAP paper and the Quadrature-TreeSHAP paper.
- Clarify that XGBoost uses the in-tree `QuadratureTreeSHAP` implementation for exact TreeSHAP feature attributions on both CPU and GPU.
- Keep inline text citations in prose and full linked bibliographic entries in the GPU documentation references section.

## Testing
- `git diff --check`
- `MPLCONFIGDIR=/tmp/matplotlib-xgboost-docs make html SPHINXOPTS="--keep-going"`

Note: the docs build succeeds with existing unrelated warnings about skipped Doxygen, missing generated R docs, and Sphinx extension deprecations.