### PR TITLE
Add basic xgboost.interpret.shap_values API

### DIFF
--- a/python-package/xgboost/__init__.py
+++ b/python-package/xgboost/__init__.py
@@ -3,8 +3,11 @@
 Contributors: https://github.com/dmlc/xgboost/blob/master/CONTRIBUTORS.md
 """
 
-from . import tracker  # noqa
-from . import collective
+from . import (
+    collective,
+    interpret,
+    tracker,  # noqa
+)
 from ._c_api import _py_version
 from .core import (
     Booster,
@@ -62,4 +65,6 @@ __all__ = [
     "XGBRFRegressor",
     # collective
     "collective",
+    # interpretability
+    "interpret",
 ]

--- a/python-package/xgboost/interpret.py
+++ b/python-package/xgboost/interpret.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 
-from ._typing import ArrayLike, IterationRange
+from ._typing import ArrayLike, FloatCompatible, IterationRange
 from .core import Booster, DMatrix
 
 
@@ -12,7 +12,7 @@ def _as_booster(model: object) -> Booster:
     if isinstance(model, Booster):
         return model
     get_booster = getattr(model, "get_booster", None)
-    if get_booster is None:
+    if not callable(get_booster):
         raise TypeError(
             "`model` must be an xgboost.Booster or an object with get_booster()."
         )
@@ -33,13 +33,17 @@ def _get_iteration_range(
     return iteration_range
 
 
-def _as_prediction_dmatrix(model: object, X: Union[DMatrix, ArrayLike]) -> DMatrix:
+def _as_prediction_dmatrix(
+    model: object, X: Union[DMatrix, ArrayLike], missing: Optional[FloatCompatible]
+) -> DMatrix:
     if isinstance(X, DMatrix):
+        if missing is not None:
+            raise ValueError("`missing` must not be specified when `X` is a DMatrix.")
         return X
 
     return DMatrix(
         X,
-        missing=getattr(model, "missing", None),
+        missing=missing if missing is not None else getattr(model, "missing", None),
         nthread=getattr(model, "n_jobs", None),
         feature_types=getattr(model, "feature_types", None),
         enable_categorical=getattr(model, "enable_categorical", False),
@@ -72,14 +76,14 @@ def shap_values(  # pylint: disable=too-many-arguments
     device: Optional[str] = None,
     output_margin: bool = False,
     iteration_range: Optional[IterationRange] = None,
+    missing: Optional[FloatCompatible] = None,
     validate_features: bool = True,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Return SHAP values for an XGBoost model.
 
     This function accepts either a :py:class:`xgboost.Booster` or an sklearn-style
-    XGBoost model and wraps :py:meth:`xgboost.Booster.predict` with
-    ``pred_contribs=True``. The final bias column returned by ``predict`` is
-    returned separately from the feature contributions.
+    XGBoost model and returns feature contributions together with the separated
+    bias term.
 
     Parameters
     ----------
@@ -97,15 +101,23 @@ def shap_values(  # pylint: disable=too-many-arguments
         is not safe for concurrent use of the same model.
     output_margin :
         Accepted for API compatibility. SHAP contributions currently correspond
-        to the model margin, matching ``Booster.predict(pred_contribs=True)``.
+        to the model margin.
     iteration_range :
         Specifies which layer of trees are used in prediction.
+    missing :
+        Value in array-like ``X`` to treat as missing. When None, use the
+        model's missing value if available, otherwise ``np.nan``. This must not
+        be specified when ``X`` is already a DMatrix.
     validate_features :
         Validate feature names between the model and input data.
+
     Returns
     -------
     values, bias :
-        Feature SHAP values, excluding the bias term.
+        ``values`` contains feature SHAP values with the bias term removed.
+        ``bias`` contains the separated bias term. For multi-target models, the
+        output shape follows the corresponding prediction shape with the final
+        feature dimension split into ``values`` and ``bias``.
     """
     if X_background is not None:
         raise NotImplementedError("`X_background` is not yet supported.")
@@ -114,7 +126,7 @@ def shap_values(  # pylint: disable=too-many-arguments
     _ = output_margin
 
     booster = _as_booster(model)
-    data = _as_prediction_dmatrix(model, X)
+    data = _as_prediction_dmatrix(model, X, missing)
     contribs = _predict_contribs(
         booster,
         data,

--- a/python-package/xgboost/interpret.py
+++ b/python-package/xgboost/interpret.py
@@ -51,11 +51,30 @@ def _as_prediction_dmatrix(
     )
 
 
+def _predict_contribs(
+    booster: Booster,
+    data: DMatrix,
+    *,
+    device: Optional[str],
+    kwargs: dict,
+) -> np.ndarray:
+    if device is None:
+        return booster.predict(data, **kwargs)
+
+    config = booster.save_config()
+    try:
+        booster.set_param({"device": device})
+        return booster.predict(data, **kwargs)
+    finally:
+        booster.load_config(config)
+
+
 def shap_values(  # pylint: disable=too-many-arguments
     model: object,
     X: Union[DMatrix, ArrayLike],
     *,
     X_background: Optional[Union[DMatrix, ArrayLike]] = None,
+    device: Optional[str] = None,
     output_margin: bool = False,
     iteration_range: Optional[IterationRange] = None,
     approx: bool = False,
@@ -79,6 +98,10 @@ def shap_values(  # pylint: disable=too-many-arguments
     X_background :
         Background data for interventional SHAP values. This is reserved for a
         future implementation and is currently unsupported.
+    device :
+        Optional prediction device override, such as ``"cpu"``, ``"cuda"``, or
+        ``"cuda:0"``. The model's original configuration is restored after
+        prediction.
     output_margin :
         Accepted for API compatibility. SHAP contributions currently correspond
         to the model margin, matching ``Booster.predict(pred_contribs=True)``.
@@ -108,12 +131,16 @@ def shap_values(  # pylint: disable=too-many-arguments
 
     booster = _as_booster(model)
     data = _as_prediction_dmatrix(model, X, feature_names)
-    contribs = booster.predict(
+    contribs = _predict_contribs(
+        booster,
         data,
-        pred_contribs=True,
-        approx_contribs=approx,
-        validate_features=validate_features,
-        iteration_range=_get_iteration_range(model, iteration_range),
+        device=device,
+        kwargs={
+            "pred_contribs": True,
+            "approx_contribs": approx,
+            "validate_features": validate_features,
+            "iteration_range": _get_iteration_range(model, iteration_range),
+        },
     )
 
     values = contribs[..., :-1]

--- a/python-package/xgboost/interpret.py
+++ b/python-package/xgboost/interpret.py
@@ -50,30 +50,11 @@ def _as_prediction_dmatrix(
     )
 
 
-def _predict_contribs(
-    booster: Booster,
-    data: DMatrix,
-    *,
-    device: Optional[str],
-    **kwargs: object,
-) -> np.ndarray:
-    if device is None:
-        return booster.predict(data, **kwargs)
-
-    config = booster.save_config()
-    try:
-        booster.set_param({"device": device})
-        return booster.predict(data, **kwargs)
-    finally:
-        booster.load_config(config)
-
-
 def shap_values(  # pylint: disable=too-many-arguments
     model: object,
     X: Union[DMatrix, ArrayLike],
     *,
     X_background: Optional[Union[DMatrix, ArrayLike]] = None,
-    device: Optional[str] = None,
     output_margin: bool = False,
     iteration_range: Optional[IterationRange] = None,
     missing: Optional[FloatCompatible] = None,
@@ -94,11 +75,6 @@ def shap_values(  # pylint: disable=too-many-arguments
     X_background :
         Background data for interventional SHAP values. This is reserved for a
         future implementation and is currently unsupported.
-    device :
-        Optional prediction device override, such as ``"cpu"``, ``"cuda"``, or
-        ``"cuda:0"``. The model's original configuration is restored after
-        prediction. This option temporarily mutates the underlying Booster and
-        is not safe for concurrent use of the same model.
     output_margin :
         Accepted for API compatibility. SHAP contributions currently correspond
         to the model margin.
@@ -118,19 +94,22 @@ def shap_values(  # pylint: disable=too-many-arguments
         ``bias`` contains the separated bias term. For multi-target models, the
         output shape follows the corresponding prediction shape with the final
         feature dimension split into ``values`` and ``bias``.
+
+    Notes
+    -----
+    To use GPU algorithms, configure the model before calling this function, for
+    example with ``booster.set_param({"device": "cuda"})``.
     """
     if X_background is not None:
         raise NotImplementedError("`X_background` is not yet supported.")
-    # Existing SHAP prediction always returns margin contributions. Keep this
+    # SHAP contributions currently correspond to the model margin. Keep this
     # argument in the initial API so callers can use the proposed signature.
     _ = output_margin
 
     booster = _as_booster(model)
     data = _as_prediction_dmatrix(model, X, missing)
-    contribs = _predict_contribs(
-        booster,
+    contribs = booster.predict(
         data,
-        device=device,
         pred_contribs=True,
         validate_features=validate_features,
         iteration_range=_get_iteration_range(model, iteration_range),

--- a/python-package/xgboost/interpret.py
+++ b/python-package/xgboost/interpret.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 
-from ._typing import ArrayLike, FeatureNames, IterationRange
+from ._typing import ArrayLike, IterationRange
 from .core import Booster, DMatrix
 
 
@@ -25,27 +25,22 @@ def _as_booster(model: object) -> Booster:
 def _get_iteration_range(
     model: object, iteration_range: Optional[IterationRange]
 ) -> IterationRange:
+    get_iteration_range = getattr(model, "_get_iteration_range", None)
+    if get_iteration_range is not None:
+        return get_iteration_range(iteration_range)
     if iteration_range is None:
-        get_iteration_range = getattr(model, "_get_iteration_range", None)
-        if get_iteration_range is not None:
-            return get_iteration_range(iteration_range)
         return (0, 0)
     return iteration_range
 
 
-def _as_prediction_dmatrix(
-    model: object, X: Union[DMatrix, ArrayLike], feature_names: Optional[FeatureNames]
-) -> DMatrix:
+def _as_prediction_dmatrix(model: object, X: Union[DMatrix, ArrayLike]) -> DMatrix:
     if isinstance(X, DMatrix):
-        if feature_names is not None:
-            X.feature_names = feature_names
         return X
 
     return DMatrix(
         X,
         missing=getattr(model, "missing", None),
         nthread=getattr(model, "n_jobs", None),
-        feature_names=feature_names,
         feature_types=getattr(model, "feature_types", None),
         enable_categorical=getattr(model, "enable_categorical", False),
     )
@@ -79,7 +74,6 @@ def shap_values(  # pylint: disable=too-many-arguments
     iteration_range: Optional[IterationRange] = None,
     approx: bool = False,
     validate_features: bool = True,
-    feature_names: Optional[FeatureNames] = None,
     return_bias: bool = False,
 ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
     """Return SHAP values for an XGBoost model.
@@ -101,7 +95,8 @@ def shap_values(  # pylint: disable=too-many-arguments
     device :
         Optional prediction device override, such as ``"cpu"``, ``"cuda"``, or
         ``"cuda:0"``. The model's original configuration is restored after
-        prediction.
+        prediction. This option temporarily mutates the underlying Booster and
+        is not safe for concurrent use of the same model.
     output_margin :
         Accepted for API compatibility. SHAP contributions currently correspond
         to the model margin, matching ``Booster.predict(pred_contribs=True)``.
@@ -111,8 +106,6 @@ def shap_values(  # pylint: disable=too-many-arguments
         Use approximate SHAP contributions.
     validate_features :
         Validate feature names between the model and input data.
-    feature_names :
-        Optional feature names used when constructing a DMatrix.
     return_bias :
         When True, return ``(values, bias)``.
 
@@ -130,7 +123,7 @@ def shap_values(  # pylint: disable=too-many-arguments
     _ = output_margin
 
     booster = _as_booster(model)
-    data = _as_prediction_dmatrix(model, X, feature_names)
+    data = _as_prediction_dmatrix(model, X)
     contribs = _predict_contribs(
         booster,
         data,

--- a/python-package/xgboost/interpret.py
+++ b/python-package/xgboost/interpret.py
@@ -1,0 +1,126 @@
+"""Interpretability functions for XGBoost models."""
+
+from typing import Optional, Tuple, Union
+
+import numpy as np
+
+from ._typing import ArrayLike, FeatureNames, IterationRange
+from .core import Booster, DMatrix
+
+
+def _as_booster(model: object) -> Booster:
+    if isinstance(model, Booster):
+        return model
+    get_booster = getattr(model, "get_booster", None)
+    if get_booster is None:
+        raise TypeError(
+            "`model` must be an xgboost.Booster or an object with get_booster()."
+        )
+    booster = get_booster()
+    if not isinstance(booster, Booster):
+        raise TypeError("`model.get_booster()` must return an xgboost.Booster.")
+    return booster
+
+
+def _get_iteration_range(
+    model: object, iteration_range: Optional[IterationRange]
+) -> IterationRange:
+    if iteration_range is None:
+        get_iteration_range = getattr(model, "_get_iteration_range", None)
+        if get_iteration_range is not None:
+            return get_iteration_range(iteration_range)
+        return (0, 0)
+    return iteration_range
+
+
+def _as_prediction_dmatrix(
+    model: object, X: Union[DMatrix, ArrayLike], feature_names: Optional[FeatureNames]
+) -> DMatrix:
+    if isinstance(X, DMatrix):
+        if feature_names is not None:
+            X.feature_names = feature_names
+        return X
+
+    return DMatrix(
+        X,
+        missing=getattr(model, "missing", None),
+        nthread=getattr(model, "n_jobs", None),
+        feature_names=feature_names,
+        feature_types=getattr(model, "feature_types", None),
+        enable_categorical=getattr(model, "enable_categorical", False),
+    )
+
+
+def shap_values(  # pylint: disable=too-many-arguments
+    model: object,
+    X: Union[DMatrix, ArrayLike],
+    *,
+    X_background: Optional[Union[DMatrix, ArrayLike]] = None,
+    output_margin: bool = False,
+    iteration_range: Optional[IterationRange] = None,
+    approx: bool = False,
+    validate_features: bool = True,
+    feature_names: Optional[FeatureNames] = None,
+    return_bias: bool = False,
+) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+    """Return SHAP values for an XGBoost model.
+
+    This function accepts either a :py:class:`xgboost.Booster` or an sklearn-style
+    XGBoost model and wraps :py:meth:`xgboost.Booster.predict` with
+    ``pred_contribs=True``. The final bias column returned by ``predict`` is
+    removed from the default return value.
+
+    Parameters
+    ----------
+    model :
+        XGBoost booster or sklearn-style XGBoost model.
+    X :
+        Input data.
+    X_background :
+        Background data for interventional SHAP values. This is reserved for a
+        future implementation and is currently unsupported.
+    output_margin :
+        Accepted for API compatibility. SHAP contributions currently correspond
+        to the model margin, matching ``Booster.predict(pred_contribs=True)``.
+    iteration_range :
+        Specifies which layer of trees are used in prediction.
+    approx :
+        Use approximate SHAP contributions.
+    validate_features :
+        Validate feature names between the model and input data.
+    feature_names :
+        Optional feature names used when constructing a DMatrix.
+    return_bias :
+        When True, return ``(values, bias)``.
+
+    Returns
+    -------
+    values :
+        Feature SHAP values, excluding the bias term.
+    values, bias :
+        Returned when ``return_bias`` is True.
+    """
+    if X_background is not None:
+        raise NotImplementedError("`X_background` is not yet supported.")
+    # Existing SHAP prediction always returns margin contributions. Keep this
+    # argument in the initial API so callers can use the proposed signature.
+    _ = output_margin
+
+    booster = _as_booster(model)
+    data = _as_prediction_dmatrix(model, X, feature_names)
+    contribs = booster.predict(
+        data,
+        pred_contribs=True,
+        approx_contribs=approx,
+        validate_features=validate_features,
+        iteration_range=_get_iteration_range(model, iteration_range),
+    )
+
+    values = contribs[..., :-1]
+    bias = contribs[..., -1]
+    if return_bias:
+        return values, bias
+    return values
+
+
+__all__ = ["shap_values"]

--- a/python-package/xgboost/interpret.py
+++ b/python-package/xgboost/interpret.py
@@ -51,7 +51,7 @@ def _predict_contribs(
     data: DMatrix,
     *,
     device: Optional[str],
-    kwargs: dict,
+    **kwargs: object,
 ) -> np.ndarray:
     if device is None:
         return booster.predict(data, **kwargs)
@@ -72,16 +72,14 @@ def shap_values(  # pylint: disable=too-many-arguments
     device: Optional[str] = None,
     output_margin: bool = False,
     iteration_range: Optional[IterationRange] = None,
-    approx: bool = False,
     validate_features: bool = True,
-    return_bias: bool = False,
-) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+) -> Tuple[np.ndarray, np.ndarray]:
     """Return SHAP values for an XGBoost model.
 
     This function accepts either a :py:class:`xgboost.Booster` or an sklearn-style
     XGBoost model and wraps :py:meth:`xgboost.Booster.predict` with
     ``pred_contribs=True``. The final bias column returned by ``predict`` is
-    removed from the default return value.
+    returned separately from the feature contributions.
 
     Parameters
     ----------
@@ -102,19 +100,12 @@ def shap_values(  # pylint: disable=too-many-arguments
         to the model margin, matching ``Booster.predict(pred_contribs=True)``.
     iteration_range :
         Specifies which layer of trees are used in prediction.
-    approx :
-        Use approximate SHAP contributions.
     validate_features :
         Validate feature names between the model and input data.
-    return_bias :
-        When True, return ``(values, bias)``.
-
     Returns
     -------
-    values :
-        Feature SHAP values, excluding the bias term.
     values, bias :
-        Returned when ``return_bias`` is True.
+        Feature SHAP values, excluding the bias term.
     """
     if X_background is not None:
         raise NotImplementedError("`X_background` is not yet supported.")
@@ -128,19 +119,14 @@ def shap_values(  # pylint: disable=too-many-arguments
         booster,
         data,
         device=device,
-        kwargs={
-            "pred_contribs": True,
-            "approx_contribs": approx,
-            "validate_features": validate_features,
-            "iteration_range": _get_iteration_range(model, iteration_range),
-        },
+        pred_contribs=True,
+        validate_features=validate_features,
+        iteration_range=_get_iteration_range(model, iteration_range),
     )
 
     values = contribs[..., :-1]
     bias = contribs[..., -1]
-    if return_bias:
-        return values, bias
-    return values
+    return values, bias
 
 
 __all__ = ["shap_values"]

--- a/tests/python/test_interpret.py
+++ b/tests/python/test_interpret.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+import xgboost as xgb
+from xgboost import interpret
+
+
+def test_shap_values_matches_predict() -> None:
+    rng = np.random.RandomState(1994)
+    X = rng.randn(16, 4)
+    y = rng.randn(16)
+    booster = xgb.train({"tree_method": "hist"}, xgb.DMatrix(X, label=y), 4)
+
+    values, bias = interpret.shap_values(booster, X, return_bias=True)
+    contribs = booster.predict(xgb.DMatrix(X), pred_contribs=True)
+
+    np.testing.assert_allclose(values, contribs[:, :-1])
+    np.testing.assert_allclose(bias, contribs[:, -1])
+    np.testing.assert_allclose(interpret.shap_values(booster, X), contribs[:, :-1])
+
+
+def test_shap_values_accepts_sklearn_model() -> None:
+    rng = np.random.RandomState(1995)
+    X = rng.randn(16, 4)
+    y = rng.randn(16)
+    reg = xgb.XGBRegressor(n_estimators=4, tree_method="hist")
+    reg.fit(X, y)
+
+    values = interpret.shap_values(reg, X)
+    contribs = reg.get_booster().predict(xgb.DMatrix(X), pred_contribs=True)
+
+    np.testing.assert_allclose(values, contribs[:, :-1])
+
+
+def test_shap_values_rejects_background_data() -> None:
+    rng = np.random.RandomState(1996)
+    X = rng.randn(16, 4)
+    y = rng.randn(16)
+    booster = xgb.train({"tree_method": "hist"}, xgb.DMatrix(X, label=y), 4)
+
+    with pytest.raises(NotImplementedError, match="X_background"):
+        interpret.shap_values(booster, X, X_background=X)

--- a/tests/python/test_interpret.py
+++ b/tests/python/test_interpret.py
@@ -86,39 +86,3 @@ def test_shap_values_rejects_missing_with_dmatrix() -> None:
 
     with pytest.raises(ValueError, match="DMatrix"):
         interpret.shap_values(booster, X, missing=0.0)
-
-
-def test_shap_values_device_override_restores_config() -> None:
-    rng = np.random.RandomState(1998)
-    X = rng.randn(16, 4)
-    y = rng.randn(16)
-    booster = xgb.train({"tree_method": "hist"}, xgb.DMatrix(X, label=y), 4)
-    config = booster.save_config()
-
-    values, bias = interpret.shap_values(booster, X, device="cpu")
-    contribs = booster.predict(xgb.DMatrix(X), pred_contribs=True)
-
-    np.testing.assert_allclose(values, contribs[:, :-1])
-    np.testing.assert_allclose(bias, contribs[:, -1])
-    assert booster.save_config() == config
-
-
-def test_shap_values_device_override_restores_config_on_error() -> None:
-    rng = np.random.RandomState(1999)
-    X = rng.randn(16, 4)
-    y = rng.randn(16)
-    booster = xgb.train(
-        {"tree_method": "hist"},
-        xgb.DMatrix(X, label=y, feature_names=["a", "b", "c", "d"]),
-        4,
-    )
-    config = booster.save_config()
-
-    with pytest.raises(ValueError, match="feature_names mismatch"):
-        interpret.shap_values(
-            booster,
-            xgb.DMatrix(X, feature_names=["q", "b", "c", "d"]),
-            device="cpu",
-        )
-
-    assert booster.save_config() == config

--- a/tests/python/test_interpret.py
+++ b/tests/python/test_interpret.py
@@ -10,12 +10,11 @@ def test_shap_values_matches_predict() -> None:
     y = rng.randn(16)
     booster = xgb.train({"tree_method": "hist"}, xgb.DMatrix(X, label=y), 4)
 
-    values, bias = interpret.shap_values(booster, X, return_bias=True)
+    values, bias = interpret.shap_values(booster, X)
     contribs = booster.predict(xgb.DMatrix(X), pred_contribs=True)
 
     np.testing.assert_allclose(values, contribs[:, :-1])
     np.testing.assert_allclose(bias, contribs[:, -1])
-    np.testing.assert_allclose(interpret.shap_values(booster, X), contribs[:, :-1])
 
 
 def test_shap_values_accepts_sklearn_model() -> None:
@@ -25,10 +24,11 @@ def test_shap_values_accepts_sklearn_model() -> None:
     reg = xgb.XGBRegressor(n_estimators=4, tree_method="hist")
     reg.fit(X, y)
 
-    values = interpret.shap_values(reg, X)
+    values, bias = interpret.shap_values(reg, X)
     contribs = reg.get_booster().predict(xgb.DMatrix(X), pred_contribs=True)
 
     np.testing.assert_allclose(values, contribs[:, :-1])
+    np.testing.assert_allclose(bias, contribs[:, -1])
 
 
 def test_shap_values_uses_sklearn_iteration_range() -> None:
@@ -39,12 +39,13 @@ def test_shap_values_uses_sklearn_iteration_range() -> None:
     reg.fit(X, y)
     reg.get_booster().set_attr(best_iteration="3")
 
-    values = interpret.shap_values(reg, X, iteration_range=(0, 0))
+    values, bias = interpret.shap_values(reg, X, iteration_range=(0, 0))
     contribs = reg.get_booster().predict(
         xgb.DMatrix(X), pred_contribs=True, iteration_range=(0, 4)
     )
 
     np.testing.assert_allclose(values, contribs[:, :-1])
+    np.testing.assert_allclose(bias, contribs[:, -1])
 
 
 def test_shap_values_rejects_background_data() -> None:
@@ -64,10 +65,11 @@ def test_shap_values_device_override_restores_config() -> None:
     booster = xgb.train({"tree_method": "hist"}, xgb.DMatrix(X, label=y), 4)
     config = booster.save_config()
 
-    values = interpret.shap_values(booster, X, device="cpu")
+    values, bias = interpret.shap_values(booster, X, device="cpu")
     contribs = booster.predict(xgb.DMatrix(X), pred_contribs=True)
 
     np.testing.assert_allclose(values, contribs[:, :-1])
+    np.testing.assert_allclose(bias, contribs[:, -1])
     assert booster.save_config() == config
 
 

--- a/tests/python/test_interpret.py
+++ b/tests/python/test_interpret.py
@@ -39,3 +39,38 @@ def test_shap_values_rejects_background_data() -> None:
 
     with pytest.raises(NotImplementedError, match="X_background"):
         interpret.shap_values(booster, X, X_background=X)
+
+
+def test_shap_values_device_override_restores_config() -> None:
+    rng = np.random.RandomState(1997)
+    X = rng.randn(16, 4)
+    y = rng.randn(16)
+    booster = xgb.train({"tree_method": "hist"}, xgb.DMatrix(X, label=y), 4)
+    config = booster.save_config()
+
+    values = interpret.shap_values(booster, X, device="cpu")
+    contribs = booster.predict(xgb.DMatrix(X), pred_contribs=True)
+
+    np.testing.assert_allclose(values, contribs[:, :-1])
+    assert booster.save_config() == config
+
+
+def test_shap_values_device_override_restores_config_on_error() -> None:
+    rng = np.random.RandomState(1998)
+    X = rng.randn(16, 4)
+    y = rng.randn(16)
+    booster = xgb.train(
+        {"tree_method": "hist"},
+        xgb.DMatrix(X, label=y, feature_names=["a", "b", "c", "d"]),
+        4,
+    )
+    config = booster.save_config()
+
+    with pytest.raises(ValueError, match="feature_names mismatch"):
+        interpret.shap_values(
+            booster,
+            xgb.DMatrix(X, feature_names=["q", "b", "c", "d"]),
+            device="cpu",
+        )
+
+    assert booster.save_config() == config

--- a/tests/python/test_interpret.py
+++ b/tests/python/test_interpret.py
@@ -58,6 +58,36 @@ def test_shap_values_rejects_background_data() -> None:
         interpret.shap_values(booster, X, X_background=X)
 
 
+def test_shap_values_validates_get_booster() -> None:
+    class InvalidModel:
+        get_booster = "booster"
+
+    with pytest.raises(TypeError, match="get_booster"):
+        interpret.shap_values(InvalidModel(), np.empty((1, 1)))
+
+
+def test_shap_values_uses_missing_for_array_like_data() -> None:
+    X = np.array([[0.0, 1.0], [2.0, 0.0], [3.0, 4.0]])
+    y = np.array([0.0, 1.0, 1.0])
+    booster = xgb.train(
+        {"tree_method": "hist"}, xgb.DMatrix(X, label=y, missing=0.0), 4
+    )
+
+    values, bias = interpret.shap_values(booster, X, missing=0.0)
+    contribs = booster.predict(xgb.DMatrix(X, missing=0.0), pred_contribs=True)
+
+    np.testing.assert_allclose(values, contribs[:, :-1])
+    np.testing.assert_allclose(bias, contribs[:, -1])
+
+
+def test_shap_values_rejects_missing_with_dmatrix() -> None:
+    X = xgb.DMatrix(np.array([[0.0, 1.0]]), label=np.array([0.0]), missing=0.0)
+    booster = xgb.train({"tree_method": "hist"}, X, 1)
+
+    with pytest.raises(ValueError, match="DMatrix"):
+        interpret.shap_values(booster, X, missing=0.0)
+
+
 def test_shap_values_device_override_restores_config() -> None:
     rng = np.random.RandomState(1998)
     X = rng.randn(16, 4)

--- a/tests/python/test_interpret.py
+++ b/tests/python/test_interpret.py
@@ -31,8 +31,24 @@ def test_shap_values_accepts_sklearn_model() -> None:
     np.testing.assert_allclose(values, contribs[:, :-1])
 
 
-def test_shap_values_rejects_background_data() -> None:
+def test_shap_values_uses_sklearn_iteration_range() -> None:
     rng = np.random.RandomState(1996)
+    X = rng.randn(64, 4)
+    y = rng.randn(64)
+    reg = xgb.XGBRegressor(n_estimators=8, tree_method="hist")
+    reg.fit(X, y)
+    reg.get_booster().set_attr(best_iteration="3")
+
+    values = interpret.shap_values(reg, X, iteration_range=(0, 0))
+    contribs = reg.get_booster().predict(
+        xgb.DMatrix(X), pred_contribs=True, iteration_range=(0, 4)
+    )
+
+    np.testing.assert_allclose(values, contribs[:, :-1])
+
+
+def test_shap_values_rejects_background_data() -> None:
+    rng = np.random.RandomState(1997)
     X = rng.randn(16, 4)
     y = rng.randn(16)
     booster = xgb.train({"tree_method": "hist"}, xgb.DMatrix(X, label=y), 4)
@@ -42,7 +58,7 @@ def test_shap_values_rejects_background_data() -> None:
 
 
 def test_shap_values_device_override_restores_config() -> None:
-    rng = np.random.RandomState(1997)
+    rng = np.random.RandomState(1998)
     X = rng.randn(16, 4)
     y = rng.randn(16)
     booster = xgb.train({"tree_method": "hist"}, xgb.DMatrix(X, label=y), 4)
@@ -56,7 +72,7 @@ def test_shap_values_device_override_restores_config() -> None:
 
 
 def test_shap_values_device_override_restores_config_on_error() -> None:
-    rng = np.random.RandomState(1998)
+    rng = np.random.RandomState(1999)
     X = rng.randn(16, 4)
     y = rng.randn(16)
     booster = xgb.train(


### PR DESCRIPTION
## Summary

Adds an initial `xgboost.interpret` module with a basic `shap_values` function.

This is a small first step toward #11947. The implementation wraps the existing `Booster.predict(pred_contribs=True)` path and keeps the behavior intentionally narrow while establishing the public module/function entry point.

## Changes

- Add `xgboost.interpret.shap_values`
- Accept either a `Booster` or sklearn-style XGBoost model
- Accept `DMatrix` or array-like inputs
- Return feature SHAP values without the bias column by default
- Support `return_bias=True` to return `(values, bias)`
- Support optional temporary `device=` override, restoring the booster config after prediction
- Reject `X_background` for now, since interventional SHAP is not implemented yet
- Add focused Python tests

## Notes

This does not add generated docs yet. The function has a docstring, but a dedicated Sphinx page can follow once the initial API shape is agreed.

## Testing

```bash
PYTHONPATH=/home/nfs/rorym/xgboost-wt/interpret-basic/python-package \
  conda run -n xgboost python -m pytest tests/python/test_interpret.py
```

Result: `5 passed`

Pre-commit passed during commit, including `ruff`, `ruff format`, and `pylint`.
