### PR TITLE
Support vector leaf SHAP on CPU

### DIFF
--- a/src/predictor/interpretability/quadrature.h
+++ b/src/predictor/interpretability/quadrature.h
@@ -102,10 +102,10 @@ inline QuadratureRule const& GetQuadratureRule() {
   return kRule;
 }
 
-template <typename Tree>
-double FillRootMeanValue(Tree const& tree, bst_node_t nidx) {
+template <typename Tree, typename LeafValueFn>
+double FillRootMeanValue(Tree const& tree, bst_node_t nidx, LeafValueFn const& leaf_value) {
   if (tree.IsLeaf(nidx)) {
-    return tree.LeafValue(nidx);
+    return leaf_value(nidx);
   }
   auto left = tree.LeftChild(nidx);
   auto right = tree.RightChild(nidx);
@@ -116,12 +116,17 @@ double FillRootMeanValue(Tree const& tree, bst_node_t nidx) {
   CHECK_GE(tree.SumHess(right), 0.0f)
       << "QuadratureTreeSHAP is undefined for trees with negative child cover.";
   auto const parent_cover = tree.SumHess(nidx);
-  auto const left_mean = FillRootMeanValue(tree, left);
-  auto const right_mean = FillRootMeanValue(tree, right);
+  auto const left_mean = FillRootMeanValue(tree, left, leaf_value);
+  auto const right_mean = FillRootMeanValue(tree, right, leaf_value);
   if (parent_cover == 0.0f) {
     return 0.5 * (left_mean + right_mean);
   }
   return (left_mean * tree.SumHess(left) + right_mean * tree.SumHess(right)) / parent_cover;
+}
+
+template <typename Tree>
+double FillRootMeanValue(Tree const& tree, bst_node_t nidx) {
+  return FillRootMeanValue(tree, nidx, [&](bst_node_t leaf) { return tree.LeafValue(leaf); });
 }
 
 template <typename TreeGroups, typename GetTree>

--- a/src/predictor/interpretability/shap.cc
+++ b/src/predictor/interpretability/shap.cc
@@ -9,11 +9,12 @@
 #include <cstdint>      // for uint32_t
 #include <limits>       // for numeric_limits
 #include <type_traits>  // for remove_const_t
+#include <variant>      // for variant
 #include <vector>       // for vector
 
 #include "../../common/threading_utils.h"  // for ParallelFor
 #include "../../gbm/gbtree_model.h"        // for GBTreeModel
-#include "../../tree/tree_view.h"          // for ScalarTreeView
+#include "../../tree/tree_view.h"          // for MultiTargetTreeView, ScalarTreeView
 #include "../data_accessor.h"              // for GHistIndexMatrixView
 #include "../predict_fn.h"                 // for GetTreeLimit
 #include "dmlc/omp.h"                      // for omp_get_thread_num
@@ -25,11 +26,24 @@
 
 namespace xgboost::interpretability {
 namespace {
+using TreeView = std::variant<tree::ScalarTreeView, tree::MultiTargetTreeView>;
+
 void ValidateTreeWeights(std::vector<float> const *tree_weights, bst_tree_t tree_end) {
   if (tree_weights == nullptr) {
     return;
   }
   CHECK_GE(tree_weights->size(), static_cast<std::size_t>(tree_end));
+}
+
+float LeafValue(tree::ScalarTreeView const &tree, bst_node_t nidx, bst_target_t target_idx) {
+  CHECK_EQ(target_idx, 0);
+  return tree.LeafValue(nidx);
+}
+
+float LeafValue(tree::MultiTargetTreeView const &tree, bst_node_t nidx, bst_target_t target_idx) {
+  auto leaf_value = tree.LeafValue(nidx);
+  CHECK_LT(target_idx, leaf_value.Size());
+  return leaf_value(target_idx);
 }
 
 float FillNodeMeanValues(tree::ScalarTreeView const &tree, bst_node_t nidx,
@@ -141,10 +155,11 @@ float ExtractQuadratureInteractionDelta(QuadratureRule const &rule, QuadratureBu
   return acc;
 }
 
-void WriteWeightedLeafReturn(tree::ScalarTreeView const &tree, QuadratureRule const &rule,
-                             bst_node_t nidx, QuadratureBuffer const &c_vals, float w_prod,
+template <typename Tree>
+void WriteWeightedLeafReturn(Tree const &tree, QuadratureRule const &rule, bst_node_t nidx,
+                             bst_target_t target_idx, QuadratureBuffer const &c_vals, float w_prod,
                              QuadratureBuffer *out_h) {
-  auto const leaf_scale = w_prod * tree.LeafValue(nidx);
+  auto const leaf_scale = w_prod * LeafValue(tree, nidx, target_idx);
   for (std::size_t i = 0; i < kQuadratureTreeShapPoints; ++i) {
     (*out_h)[i] = c_vals[i] * leaf_scale * rule.weights[i];
   }
@@ -248,11 +263,6 @@ struct AdditiveContributionFormulation {
   }
   void PopPathSplit(bst_feature_t split_index) const { path_state.Pop(split_index); }
 
-  void HandleLeaf(tree::ScalarTreeView const &tree, QuadratureRule const &rule, bst_node_t nidx,
-                  QuadratureBuffer const &c_vals, float w_prod, QuadratureBuffer *out_h) const {
-    WriteWeightedLeafReturn(tree, rule, nidx, c_vals, w_prod, out_h);
-  }
-
   void HandleReturn(QuadratureRule const &rule, bst_feature_t split_index,
                     QuadratureBuffer const &h_vals, float p_enter, float p_exit) const {
     phi[split_index] += ExtractQuadratureDelta(rule, h_vals, p_enter, p_exit);
@@ -282,13 +292,6 @@ struct InteractionContributionFormulation {
     path_state.Push(split_index, p_child);
   }
   void PopPathSplit(bst_feature_t split_index) const { path_state.Pop(split_index); }
-
-  // Traversal still needs a weighted subtree return, so the interaction path shares the additive
-  // leaf behavior and changes only the return-edge algebra.
-  void HandleLeaf(tree::ScalarTreeView const &tree, QuadratureRule const &rule, bst_node_t nidx,
-                  QuadratureBuffer const &c_vals, float w_prod, QuadratureBuffer *out_h) const {
-    WriteWeightedLeafReturn(tree, rule, nidx, c_vals, w_prod, out_h);
-  }
 
   // Walk the live unique path excluding the current split. A pairwise formulation can distribute
   // the current edge effect across these partner features without reimplementing duplicate logic.
@@ -328,9 +331,10 @@ struct InteractionContributionFormulation {
 
 // Tree-walk engine for quadrature formulations. It owns feature evaluation, child descent, and
 // the live path-probability state, then hands leaf/return events to the selected formulation.
-template <typename ContributionFormulation>
+template <typename Tree, typename ContributionFormulation>
 struct QuadratureTreeShapRunner {
-  tree::ScalarTreeView const &tree;
+  Tree const &tree;
+  bst_target_t target_idx;
   RegTree::FVec const &feat;
   QuadratureRule const &rule;
   std::vector<float> *path_prob;
@@ -345,10 +349,10 @@ struct QuadratureTreeShapRunner {
   }
 
   [[nodiscard]] float ChildWeight(bst_node_t parent, bst_node_t child) const {
-    auto parent_cover = tree.Stat(parent).sum_hess;
+    auto parent_cover = tree.SumHess(parent);
     CHECK_GE(parent_cover, 0.0f);
-    CHECK_GE(tree.Stat(child).sum_hess, 0.0f);
-    return detail::BranchWeight(tree.Stat(child).sum_hess, parent_cover);
+    CHECK_GE(tree.SumHess(child), 0.0f);
+    return detail::BranchWeight(tree.SumHess(child), parent_cover);
   }
 
   void VisitChild(bst_node_t split_node, bst_node_t child_node, float child_weight, bool satisfies,
@@ -390,7 +394,7 @@ struct QuadratureTreeShapRunner {
   void RunNode(bst_node_t nidx, QuadratureBuffer const &c_vals, float w_prod,
                QuadratureBuffer *out_h) {
     if (tree.IsLeaf(nidx)) {
-      formulation.HandleLeaf(tree, rule, nidx, c_vals, w_prod, out_h);
+      WriteWeightedLeafReturn(tree, rule, nidx, target_idx, c_vals, w_prod, out_h);
       return;
     }
 
@@ -421,9 +425,16 @@ struct QuadratureTreeShapRunner {
 };
 
 struct QuadratureTreeShapModelData {
-  std::vector<tree::ScalarTreeView> trees;
-  std::vector<std::vector<bst_tree_t>> trees_by_group;
-  std::vector<float> weights;
+  struct TreeEntry {
+    bst_tree_t tree_idx;
+    bst_target_t target_idx;
+    bst_target_t group_idx;
+    float weight;
+  };
+
+  std::vector<TreeView> trees;
+  std::vector<TreeEntry> entries;
+  std::vector<std::vector<std::size_t>> entries_by_group;
   std::vector<float> group_root_mean_sums;
 };
 
@@ -435,21 +446,47 @@ QuadratureTreeShapModelData MakeQuadratureTreeShapModelData(
 
   QuadratureTreeShapModelData out;
   out.trees.reserve(n_trees);
-  out.trees_by_group.resize(n_groups);
-  out.weights.resize(n_trees, 1.0f);
+  out.entries_by_group.resize(n_groups);
 
   for (std::size_t i = 0; i < n_trees; ++i) {
-    out.trees.emplace_back(model.trees[i].get());
+    if (model.trees[i]->IsMultiTarget()) {
+      out.trees.emplace_back(model.trees[i]->HostMtView());
+    } else {
+      out.trees.emplace_back(model.trees[i]->HostScView());
+    }
   }
   for (bst_tree_t i = 0; i < tree_end; ++i) {
-    auto gid = h_tree_groups[i];
     auto weight = tree_weights == nullptr ? 1.0f : (*tree_weights)[i];
-    out.trees_by_group[gid].push_back(i);
-    out.weights[i] = weight;
+    if (model.trees[i]->IsMultiTarget()) {
+      auto const n_targets = model.trees[i]->GetMultiTargetTree()->NumTargets();
+      CHECK_EQ(n_targets, n_groups);
+      for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+        auto entry_idx = out.entries.size();
+        out.entries.push_back(
+            QuadratureTreeShapModelData::TreeEntry{i, target_idx, target_idx, weight});
+        out.entries_by_group[target_idx].push_back(entry_idx);
+      }
+    } else {
+      auto gid = h_tree_groups[i];
+      auto entry_idx = out.entries.size();
+      out.entries.push_back(QuadratureTreeShapModelData::TreeEntry{i, 0, gid, weight});
+      out.entries_by_group[gid].push_back(entry_idx);
+    }
   }
-  out.group_root_mean_sums = detail::MakeGroupRootMeanSums(
-      h_tree_groups, n_groups, tree_end, tree_weights,
-      [&](bst_tree_t tree_idx) -> tree::ScalarTreeView const & { return out.trees[tree_idx]; });
+  std::vector<double> group_root_mean_sums(n_groups, 0.0);
+  for (auto const &entry : out.entries) {
+    auto root_mean = std::visit(
+        [&](auto const &tree) {
+          return detail::FillRootMeanValue(tree, RegTree::kRoot, [&](bst_node_t leaf) {
+            return LeafValue(tree, leaf, entry.target_idx);
+          });
+        },
+        out.trees[entry.tree_idx]);
+    group_root_mean_sums[entry.group_idx] += root_mean * entry.weight;
+  }
+  out.group_root_mean_sums.resize(group_root_mean_sums.size());
+  std::transform(group_root_mean_sums.cbegin(), group_root_mean_sums.cend(),
+                 out.group_root_mean_sums.begin(), [](double v) { return static_cast<float>(v); });
   return out;
 }
 
@@ -509,7 +546,6 @@ void QuadratureTreeShapValues(Context const *ctx, DMatrix *p_fmat,
                               HostDeviceVector<float> *out_contribs, gbm::GBTreeModel const &model,
                               bst_tree_t tree_end, std::vector<float> const *tree_weights,
                               std::size_t quadrature_points) {
-  CHECK(!model.learner_model_param->IsVectorLeaf()) << "Predict contribution" << MTNotImplemented();
   CHECK(!p_fmat->Info().IsColumnSplit())
       << "Predict contribution support for column-wise data split is not yet implemented.";
   CHECK_EQ(quadrature_points, kQuadratureTreeShapPoints)
@@ -552,13 +588,19 @@ void QuadratureTreeShapValues(Context const *ctx, DMatrix *p_fmat,
       feats.HasMissing(n_valid != feats.Size());
       for (bst_target_t gid = 0; gid < n_groups; ++gid) {
         float *p_contribs = &contribs[(row_idx * n_groups + gid) * ncolumns];
-        for (auto j : model_data.trees_by_group[gid]) {
+        for (auto entry_idx : model_data.entries_by_group[gid]) {
+          auto const &entry = model_data.entries[entry_idx];
           std::fill(this_tree_contribs.begin(), this_tree_contribs.end(), 0.0f);
           auto formulation = AdditiveContributionFormulation{{this_tree_contribs.data(), ncolumns}};
-          auto runner = QuadratureTreeShapRunner<AdditiveContributionFormulation>{
-              model_data.trees[j], feats, rule, &path_prob, formulation};
-          runner.Run();
-          auto const weight = model_data.weights[j];
+          std::visit(
+              [&](auto const &tree) {
+                auto runner = QuadratureTreeShapRunner<std::decay_t<decltype(tree)>,
+                                                       AdditiveContributionFormulation>{
+                    tree, entry.target_idx, feats, rule, &path_prob, formulation};
+                runner.Run();
+              },
+              model_data.trees[entry.tree_idx]);
+          auto const weight = entry.weight;
           for (size_t ci = 0; ci + 1 < ncolumns; ++ci) {
             p_contribs[ci] += this_tree_contribs[ci] * weight;
           }
@@ -583,8 +625,6 @@ void QuadratureTreeShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
                                          gbm::GBTreeModel const &model, bst_tree_t tree_end,
                                          std::vector<float> const *tree_weights,
                                          std::size_t quadrature_points) {
-  CHECK(!model.learner_model_param->IsVectorLeaf())
-      << "Predict interaction contribution" << MTNotImplemented();
   CHECK(!p_fmat->Info().IsColumnSplit()) << "Predict interaction contribution support for "
                                             "column-wise data split is not yet implemented.";
   CHECK_EQ(quadrature_points, kQuadratureTreeShapPoints)
@@ -638,14 +678,18 @@ void QuadratureTreeShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
         auto matrix = DenseInteractionMatrixView<bst_float>{contribs.data() + offset, ncolumns};
         std::fill(diag.begin(), diag.end(), 0.0f);
 
-        for (auto j : model_data.trees_by_group[gid]) {
-          auto formulation = InteractionContributionFormulation{{&path},
-                                                                {diag.data(), ncolumns},
-                                                                {matrix.data, matrix.ncolumns},
-                                                                model_data.weights[j]};
-          auto runner = QuadratureTreeShapRunner<InteractionContributionFormulation>{
-              model_data.trees[j], feats, rule, &path_prob, formulation};
-          runner.Run();
+        for (auto entry_idx : model_data.entries_by_group[gid]) {
+          auto const &entry = model_data.entries[entry_idx];
+          auto formulation = InteractionContributionFormulation{
+              {&path}, {diag.data(), ncolumns}, {matrix.data, matrix.ncolumns}, entry.weight};
+          std::visit(
+              [&](auto const &tree) {
+                auto runner = QuadratureTreeShapRunner<std::decay_t<decltype(tree)>,
+                                                       InteractionContributionFormulation>{
+                    tree, entry.target_idx, feats, rule, &path_prob, formulation};
+                runner.Run();
+              },
+              model_data.trees[entry.tree_idx]);
         }
 
         diag[ncolumns - 1] += model_data.group_root_mean_sums[gid];

--- a/tests/cpp/predictor/test_shap.cc
+++ b/tests/cpp/predictor/test_shap.cc
@@ -43,6 +43,17 @@ void SetLabels(DMatrix* dmat, bst_target_t n_classes) {
   }
 }
 
+void SetMultiTargetLabels(DMatrix* dmat, bst_target_t n_targets) {
+  size_t const rows = dmat->Info().num_row_;
+  dmat->Info().labels.Reshape(rows, n_targets);
+  auto& h_labels = dmat->Info().labels.Data()->HostVector();
+  for (size_t r = 0; r < rows; ++r) {
+    for (bst_target_t t = 0; t < n_targets; ++t) {
+      h_labels[r * n_targets + t] = static_cast<float>((r + 1) * (t + 1));
+    }
+  }
+}
+
 Args BaseParams(Context const* ctx, std::string objective, std::string max_depth) {
   return Args{{"objective", std::move(objective)},
               {"max_depth", std::move(max_depth)},
@@ -104,8 +115,16 @@ std::unique_ptr<gbm::GBTreeModel> LoadGBTreeModel(Learner* learner, Context cons
   auto n_classes = static_cast<bst_target_t>(std::stol(num_class));
   auto n_targets = static_cast<bst_target_t>(std::stol(num_target));
   auto n_groups = static_cast<uint32_t>(std::max(n_classes, n_targets));
-  LearnerModelParam tmp{n_features, std::move(base_score_vec), n_groups, n_targets,
-                        MultiStrategy::kOneOutputPerTree};
+  auto multi_strategy = MultiStrategy::kOneOutputPerTree;
+  for (auto const& kv : model_args) {
+    if (kv.first == "multi_strategy") {
+      CHECK(kv.second == "one_output_per_tree" || kv.second == "multi_output_tree");
+      multi_strategy = kv.second == "multi_output_tree" ? MultiStrategy::kMultiOutputTree
+                                                        : MultiStrategy::kOneOutputPerTree;
+      break;
+    }
+  }
+  LearnerModelParam tmp{n_features, std::move(base_score_vec), n_groups, n_targets, multi_strategy};
   out_param->Copy(tmp);
 
   auto gbtree = std::make_unique<gbm::GBTreeModel>(out_param, ctx);
@@ -115,7 +134,7 @@ std::unique_ptr<gbm::GBTreeModel> LoadGBTreeModel(Learner* learner, Context cons
 }
 }  // namespace
 
-std::vector<ShapTestCase> BuildShapTestCases(Context const* ctx) {
+std::vector<ShapTestCase> BuildShapTestCases(Context const* ctx, bool include_vector_leaf) {
   std::vector<ShapTestCase> cases;
   auto device = ctx->Device();
 
@@ -175,6 +194,18 @@ std::vector<ShapTestCase> BuildShapTestCases(Context const* ctx) {
     SetLabels(dmat.get(), n_classes);
     auto args = BaseParams(ctx, "multi:softprob", "3");
     args.emplace_back("num_class", std::to_string(n_classes));
+    cases.emplace_back(dmat, std::move(args));
+  }
+
+  if (include_vector_leaf) {
+    // multi-target vector-leaf tree
+    bst_target_t constexpr n_targets{2};
+    auto dmat = RandomDataGenerator(64, 6, 0.0).Device(device).GenerateDMatrix(true);
+    SetMultiTargetLabels(dmat.get(), n_targets);
+    auto args = BaseParams(ctx, "reg:squarederror", "3");
+    args.emplace_back("tree_method", "hist");
+    args.emplace_back("num_target", std::to_string(n_targets));
+    args.emplace_back("multi_strategy", "multi_output_tree");
     cases.emplace_back(dmat, std::move(args));
   }
 
@@ -284,7 +315,7 @@ void CheckShapAdditivity(size_t rows, size_t cols, HostDeviceVector<float> const
 
 TEST(Predictor, ShapOutputCasesCPU) {
   Context ctx;
-  auto cases = BuildShapTestCases(&ctx);
+  auto cases = BuildShapTestCases(&ctx, true);
   for (auto const& [dmat, args] : cases) {
     CheckShapOutput(dmat.get(), args);
   }

--- a/tests/cpp/predictor/test_shap.cu
+++ b/tests/cpp/predictor/test_shap.cu
@@ -79,7 +79,7 @@ TEST(GPUPredictor, CompareCPUShap) {
 
 TEST(GPUPredictor, ShapOutputCasesGPU) {
   auto ctx = MakeCUDACtx(0);
-  auto cases = BuildShapTestCases(&ctx);
+  auto cases = BuildShapTestCases(&ctx, false);
   for (auto const& [dmat, args] : cases) {
     CheckShapOutput(dmat.get(), args);
   }

--- a/tests/cpp/predictor/test_shap.h
+++ b/tests/cpp/predictor/test_shap.h
@@ -25,7 +25,7 @@ void CheckShapAdditivity(size_t rows, size_t cols, HostDeviceVector<float> const
                          HostDeviceVector<float> const& margin_predt);
 
 using ShapTestCase = std::pair<std::shared_ptr<DMatrix>, Args>;
-std::vector<ShapTestCase> BuildShapTestCases(Context const* ctx);
+std::vector<ShapTestCase> BuildShapTestCases(Context const* ctx, bool include_vector_leaf);
 
 }  // namespace xgboost
 

--- a/tests/python/test_multi_target.py
+++ b/tests/python/test_multi_target.py
@@ -4,7 +4,9 @@
 # pylint: disable=missing-function-docstring
 from typing import Any, Callable, Dict
 
+import numpy as np
 import pytest
+import xgboost as xgb
 from hypothesis import given, note, settings, strategies
 from xgboost import testing as tm
 from xgboost.testing.multi_target import (
@@ -38,6 +40,44 @@ def test_quantile_loss_rf(multi_strategy: str) -> None:
     check_quantile_loss_rf("cpu", "hist", multi_strategy)
     if multi_strategy == "one_output_per_tree":
         check_quantile_loss_rf("cpu", "approx", multi_strategy)
+
+
+def test_shap_multi_output_tree() -> None:
+    X = np.array(
+        [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [2.0, 1.0], [1.0, 2.0]],
+        dtype=np.float32,
+    )
+    y = np.stack([X[:, 0] + 2 * X[:, 1], -X[:, 0] + 0.5 * X[:, 1]], axis=1)
+    Xy = xgb.DMatrix(X, y)
+
+    booster = xgb.train(
+        {
+            "tree_method": "hist",
+            "max_depth": 2,
+            "num_target": 2,
+            "multi_strategy": "multi_output_tree",
+            "objective": "reg:squarederror",
+        },
+        Xy,
+        num_boost_round=3,
+    )
+
+    margin = booster.predict(Xy, output_margin=True, strict_shape=True)
+    contribs = booster.predict(Xy, pred_contribs=True, strict_shape=True)
+    interactions = booster.predict(Xy, pred_interactions=True, strict_shape=True)
+
+    assert margin.shape == (X.shape[0], y.shape[1])
+    assert contribs.shape == (X.shape[0], y.shape[1], X.shape[1] + 1)
+    assert interactions.shape == (
+        X.shape[0],
+        y.shape[1],
+        X.shape[1] + 1,
+        X.shape[1] + 1,
+    )
+    np.testing.assert_allclose(contribs.sum(axis=2), margin, rtol=1e-4, atol=1e-4)
+    np.testing.assert_allclose(
+        interactions.sum(axis=(2, 3)), margin, rtol=1e-4, atol=1e-4
+    )
 
 
 class TestTreeMethodMulti:


### PR DESCRIPTION
## Summary

Add CPU support for exact SHAP contribution and interaction prediction for vector-leaf multi-output trees.

This updates the QuadratureTreeSHAP implementation to handle both scalar and multi-target tree views, expands vector-leaf trees into per-target SHAP entries, and preserves target-specific leaf values and root mean values when computing contributions.

## Changes

- Support vector-leaf trees in exact CPU `pred_contribs` and `pred_interactions`.
- Share the QuadratureTreeSHAP traversal across scalar and multi-target tree views.
- Preserve `multi_strategy=multi_output_tree` in the C++ SHAP test model-loading helper.
- Add vector-leaf coverage to the existing C++ SHAP case matrix.
- Add a Python API regression test for vector-leaf SHAP contribution and interaction shapes/additivity.

## Validation

- `cmake --build build-cpu --target testxgboost -j35`
- `build-cpu/testxgboost --gtest_filter=Predictor.ShapOutputCasesCPU:Predictor.DartShapOutputCPU:Predictor.ShapHandlesZeroCoverChild:Predictor.ShapHandlesZeroCoverParent`
- `python -m pytest tests/python/test_multi_target.py::test_shap_multi_output_tree`
- pre-commit hooks during commit
