### PR TITLE
Support vector leaf SHAP on GPU

### DIFF
--- a/src/predictor/interpretability/quadrature.h
+++ b/src/predictor/interpretability/quadrature.h
@@ -129,6 +129,38 @@ double FillRootMeanValue(Tree const& tree, bst_node_t nidx) {
   return FillRootMeanValue(tree, nidx, [&](bst_node_t leaf) { return tree.LeafValue(leaf); });
 }
 
+template <typename Tree>
+void FillRootMeanValues(Tree const& tree, bst_node_t nidx, double path_weight,
+                        std::vector<double>* p_out) {
+  auto& out = *p_out;
+  if (tree.IsLeaf(nidx)) {
+    auto leaf_value = tree.LeafValue(nidx);
+    auto const n_targets = static_cast<bst_target_t>(leaf_value.Size());
+    CHECK_EQ(static_cast<std::size_t>(n_targets), out.size());
+    for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+      out[target_idx] += path_weight * leaf_value(target_idx);
+    }
+    return;
+  }
+
+  auto left = tree.LeftChild(nidx);
+  auto right = tree.RightChild(nidx);
+  CHECK_GE(tree.SumHess(nidx), 0.0f)
+      << "QuadratureTreeSHAP is undefined for trees with negative cover at split nodes.";
+  CHECK_GE(tree.SumHess(left), 0.0f)
+      << "QuadratureTreeSHAP is undefined for trees with negative child cover.";
+  CHECK_GE(tree.SumHess(right), 0.0f)
+      << "QuadratureTreeSHAP is undefined for trees with negative child cover.";
+  auto const parent_cover = tree.SumHess(nidx);
+  if (parent_cover == 0.0f) {
+    FillRootMeanValues(tree, left, path_weight * 0.5, p_out);
+    FillRootMeanValues(tree, right, path_weight * 0.5, p_out);
+  } else {
+    FillRootMeanValues(tree, left, path_weight * tree.SumHess(left) / parent_cover, p_out);
+    FillRootMeanValues(tree, right, path_weight * tree.SumHess(right) / parent_cover, p_out);
+  }
+}
+
 template <typename TreeGroups, typename GetTree>
 std::vector<float> MakeGroupRootMeanSums(TreeGroups const& tree_groups, bst_target_t n_groups,
                                          bst_tree_t tree_end,

--- a/src/predictor/interpretability/shap.cc
+++ b/src/predictor/interpretability/shap.cc
@@ -474,15 +474,22 @@ QuadratureTreeShapModelData MakeQuadratureTreeShapModelData(
     }
   }
   std::vector<double> group_root_mean_sums(n_groups, 0.0);
-  for (auto const &entry : out.entries) {
-    auto root_mean = std::visit(
-        [&](auto const &tree) {
-          return detail::FillRootMeanValue(tree, RegTree::kRoot, [&](bst_node_t leaf) {
-            return LeafValue(tree, leaf, entry.target_idx);
-          });
-        },
-        out.trees[entry.tree_idx]);
-    group_root_mean_sums[entry.group_idx] += root_mean * entry.weight;
+  for (bst_tree_t i = 0; i < tree_end; ++i) {
+    auto const weight = tree_weights == nullptr ? 1.0f : (*tree_weights)[i];
+    if (model.trees[i]->IsMultiTarget()) {
+      auto const tree = model.trees[i]->HostMtView();
+      auto const n_targets = tree.NumTargets();
+      CHECK_EQ(n_targets, n_groups);
+      std::vector<double> root_means(n_targets, 0.0);
+      detail::FillRootMeanValues(tree, RegTree::kRoot, 1.0, &root_means);
+      for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+        group_root_mean_sums[target_idx] += root_means[target_idx] * weight;
+      }
+    } else {
+      auto const tree = model.trees[i]->HostScView();
+      group_root_mean_sums[h_tree_groups[i]] +=
+          detail::FillRootMeanValue(tree, RegTree::kRoot) * weight;
+    }
   }
   out.group_root_mean_sums.resize(group_root_mean_sums.size());
   std::transform(group_root_mean_sums.cbegin(), group_root_mean_sums.cend(),

--- a/src/predictor/interpretability/shap.cu
+++ b/src/predictor/interpretability/shap.cu
@@ -148,37 +148,6 @@ float LeafValue(tree::MultiTargetTreeView const& tree, bst_node_t nidx, bst_targ
   return leaf_value(target_idx);
 }
 
-void FillRootMeanValues(tree::MultiTargetTreeView const& tree, bst_node_t nidx, double path_weight,
-                        std::vector<double>* p_out) {
-  auto& out = *p_out;
-  if (tree.IsLeaf(nidx)) {
-    auto leaf_value = tree.LeafValue(nidx);
-    auto const n_targets = static_cast<bst_target_t>(leaf_value.Size());
-    CHECK_EQ(static_cast<std::size_t>(n_targets), out.size());
-    for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
-      out[target_idx] += path_weight * leaf_value(target_idx);
-    }
-    return;
-  }
-
-  auto left = tree.LeftChild(nidx);
-  auto right = tree.RightChild(nidx);
-  CHECK_GE(tree.SumHess(nidx), 0.0f)
-      << "QuadratureTreeSHAP is undefined for trees with negative cover at split nodes.";
-  CHECK_GE(tree.SumHess(left), 0.0f)
-      << "QuadratureTreeSHAP is undefined for trees with negative child cover.";
-  CHECK_GE(tree.SumHess(right), 0.0f)
-      << "QuadratureTreeSHAP is undefined for trees with negative child cover.";
-  auto const parent_cover = tree.SumHess(nidx);
-  if (parent_cover == 0.0f) {
-    FillRootMeanValues(tree, left, path_weight * 0.5, p_out);
-    FillRootMeanValues(tree, right, path_weight * 0.5, p_out);
-  } else {
-    FillRootMeanValues(tree, left, path_weight * tree.SumHess(left) / parent_cover, p_out);
-    FillRootMeanValues(tree, right, path_weight * tree.SumHess(right) / parent_cover, p_out);
-  }
-}
-
 template <typename Tree>
 void CompressTree(Tree const& tree, std::vector<CompressedNode>* p_nodes,
                   std::vector<float>* p_leaf_values, std::vector<std::uint32_t>* p_categories,
@@ -331,7 +300,7 @@ GpuQuadratureModelData PrepareGpuQuadratureModel(Context const* ctx, gbm::GBTree
       CHECK_EQ(n_targets, n_groups)
           << prediction_kind << " expects one vector-leaf target per output group.";
       std::vector<double> root_means(n_targets, 0.0);
-      FillRootMeanValues(tree, RegTree::kRoot, 1.0, &root_means);
+      detail::FillRootMeanValues(tree, RegTree::kRoot, 1.0, &root_means);
       for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
         group_root_mean_sums[target_idx] += root_means[target_idx] * weight;
       }

--- a/src/predictor/interpretability/shap.cu
+++ b/src/predictor/interpretability/shap.cu
@@ -65,7 +65,6 @@ constexpr unsigned kFullWarpMask = 0xffffffffu;
 // occupancy for shallower buckets.
 constexpr int kGpuQuadratureTreeBlockThreads = 64;
 constexpr int kGpuQuadratureWarpsPerBlock = kGpuQuadratureTreeBlockThreads / dh::WarpThreads();
-constexpr std::uint32_t kInvalidLeafBegin = std::numeric_limits<std::uint32_t>::max();
 
 // The traversal stack lives in shared memory and is sized at compile time. Group trees by depth so
 // shallow models use smaller stack/basis arrays, while deeper trees still get a bounded fallback
@@ -73,15 +72,25 @@ constexpr std::uint32_t kInvalidLeafBegin = std::numeric_limits<std::uint32_t>::
 constexpr std::array<std::size_t, 3> kGpuQuadratureDepthBuckets{{16, 32, 64}};
 constexpr std::size_t kMaxGpuQuadratureDepth = kGpuQuadratureDepthBuckets.back();
 using QuadratureRule = detail::QuadratureRule;
+// Leaf payload is interpreted by CompressedTree::is_vector_leaf: scalar trees keep the weighted
+// leaf value inline, while vector-leaf trees store an offset into CompressedModel::leaf_values.
+union LeafPayload {
+  float value;
+  std::uint32_t begin;
+
+  XGBOOST_DEVICE constexpr LeafPayload() : value{0.0f} {}
+  explicit constexpr LeafPayload(float value) : value{value} {}
+  explicit constexpr LeafPayload(std::uint32_t begin) : begin{begin} {}
+};
+
 struct CompressedNode {
   bst_node_t left{RegTree::kInvalidNodeId};
   bst_node_t right{RegTree::kInvalidNodeId};
   bst_feature_t split_global{0};
   float split_cond{0};
-  float leaf_value{0};
+  LeafPayload leaf{};
   float left_weight{0};
   float right_weight{0};
-  std::uint32_t leaf_begin{kInvalidLeafBegin};
   std::uint32_t cat_begin{0};
   std::uint32_t cat_size{0};
   std::uint8_t default_left{0};
@@ -97,6 +106,7 @@ struct CompressedTree {
   std::uint32_t node_begin{0};
   bst_target_t group_idx{0};
   bst_target_t target_idx{0};
+  std::uint8_t is_vector_leaf{0};
 };
 
 struct CompressedModel {
@@ -156,11 +166,11 @@ void CompressTree(Tree const& tree, std::vector<CompressedNode>* p_nodes,
     if (tree.IsLeaf(nidx)) {
       out.is_leaf = 1;
       if (tree.NumTargets() == 1) {
-        out.leaf_value = LeafValue(tree, nidx, 0) * weight;
+        out.leaf = LeafPayload{LeafValue(tree, nidx, 0) * weight};
       } else {
         CHECK_LE(h_leaf_values.size(),
                  static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
-        out.leaf_begin = static_cast<std::uint32_t>(h_leaf_values.size());
+        out.leaf = LeafPayload{static_cast<std::uint32_t>(h_leaf_values.size())};
         for (bst_target_t target_idx = 0; target_idx < tree.NumTargets(); ++target_idx) {
           h_leaf_values.push_back(LeafValue(tree, nidx, target_idx) * weight);
         }
@@ -240,12 +250,12 @@ CompressedModel CompressTreeBucket(gbm::GBTreeModel const& model,
       CHECK_EQ(n_targets, n_groups);
       CompressTree(tree, &h_nodes, &h_leaf_values, &h_categories, weight, &node_begin);
       for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
-        h_trees.push_back(CompressedTree{node_begin, target_idx, target_idx});
+        h_trees.push_back(CompressedTree{node_begin, target_idx, target_idx, true});
       }
     } else {
       auto const tree = model.trees.at(tree_idx)->HostScView();
       CompressTree(tree, &h_nodes, &h_leaf_values, &h_categories, weight, &node_begin);
-      h_trees.push_back(CompressedTree{node_begin, h_tree_groups[tree_idx], 0});
+      h_trees.push_back(CompressedTree{node_begin, h_tree_groups[tree_idx], 0, false});
     }
   }
 
@@ -629,9 +639,8 @@ struct QuadratureShapTaskRunner {
     int depth = *stack_size - 1;
     auto const& node = nodes_for_tree[shared.Node(warp, depth)];
     if (node.is_leaf) {
-      auto leaf_value = node.leaf_begin == kInvalidLeafBegin
-                            ? node.leaf_value
-                            : leaf_values[node.leaf_begin + tree.target_idx];
+      auto leaf_value =
+          tree.is_vector_leaf ? leaf_values[node.leaf.begin + tree.target_idx] : node.leaf.value;
       *ret_val = shared.Basis(warp, subgroup.row_slot, depth, subgroup.point) * leaf_value;
       (*stack_size)--;
       *have_return = true;
@@ -897,9 +906,8 @@ struct QuadratureShapInteractionTaskRunner {
     int depth = *stack_size - 1;
     auto const& node = nodes_for_tree[shared.Node(warp, depth)];
     if (node.is_leaf) {
-      auto leaf_value = node.leaf_begin == kInvalidLeafBegin
-                            ? node.leaf_value
-                            : leaf_values[node.leaf_begin + tree.target_idx];
+      auto leaf_value =
+          tree.is_vector_leaf ? leaf_values[node.leaf.begin + tree.target_idx] : node.leaf.value;
       *ret_val = shared.Basis(warp, subgroup.row_slot, depth, subgroup.point) * leaf_value;
       (*stack_size)--;
       *have_return = true;

--- a/src/predictor/interpretability/shap.cu
+++ b/src/predictor/interpretability/shap.cu
@@ -148,6 +148,37 @@ float LeafValue(tree::MultiTargetTreeView const& tree, bst_node_t nidx, bst_targ
   return leaf_value(target_idx);
 }
 
+void FillRootMeanValues(tree::MultiTargetTreeView const& tree, bst_node_t nidx, double path_weight,
+                        std::vector<double>* p_out) {
+  auto& out = *p_out;
+  if (tree.IsLeaf(nidx)) {
+    auto leaf_value = tree.LeafValue(nidx);
+    auto const n_targets = static_cast<bst_target_t>(leaf_value.Size());
+    CHECK_EQ(static_cast<std::size_t>(n_targets), out.size());
+    for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+      out[target_idx] += path_weight * leaf_value(target_idx);
+    }
+    return;
+  }
+
+  auto left = tree.LeftChild(nidx);
+  auto right = tree.RightChild(nidx);
+  CHECK_GE(tree.SumHess(nidx), 0.0f)
+      << "QuadratureTreeSHAP is undefined for trees with negative cover at split nodes.";
+  CHECK_GE(tree.SumHess(left), 0.0f)
+      << "QuadratureTreeSHAP is undefined for trees with negative child cover.";
+  CHECK_GE(tree.SumHess(right), 0.0f)
+      << "QuadratureTreeSHAP is undefined for trees with negative child cover.";
+  auto const parent_cover = tree.SumHess(nidx);
+  if (parent_cover == 0.0f) {
+    FillRootMeanValues(tree, left, path_weight * 0.5, p_out);
+    FillRootMeanValues(tree, right, path_weight * 0.5, p_out);
+  } else {
+    FillRootMeanValues(tree, left, path_weight * tree.SumHess(left) / parent_cover, p_out);
+    FillRootMeanValues(tree, right, path_weight * tree.SumHess(right) / parent_cover, p_out);
+  }
+}
+
 template <typename Tree>
 void CompressTree(Tree const& tree, std::vector<CompressedNode>* p_nodes,
                   std::vector<float>* p_leaf_values, std::vector<std::uint32_t>* p_categories,
@@ -168,8 +199,12 @@ void CompressTree(Tree const& tree, std::vector<CompressedNode>* p_nodes,
       if (tree.NumTargets() == 1) {
         out.leaf = LeafPayload{LeafValue(tree, nidx, 0) * weight};
       } else {
-        CHECK_LE(h_leaf_values.size(),
-                 static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
+        auto const n_targets = static_cast<std::size_t>(tree.NumTargets());
+        auto constexpr kMaxOffset =
+            static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max());
+        CHECK_LE(n_targets, kMaxOffset);
+        CHECK_LE(h_leaf_values.size(), kMaxOffset - n_targets)
+            << "Compressed GPU SHAP leaf value offsets exceed uint32_t range.";
         out.leaf = LeafPayload{static_cast<std::uint32_t>(h_leaf_values.size())};
         for (bst_target_t target_idx = 0; target_idx < tree.NumTargets(); ++target_idx) {
           h_leaf_values.push_back(LeafValue(tree, nidx, target_idx) * weight);
@@ -193,10 +228,12 @@ void CompressTree(Tree const& tree, std::vector<CompressedNode>* p_nodes,
     out.right_weight = detail::BranchWeight(tree.SumHess(right), parent_cover);
     if (common::IsCat(tree.cats.split_type, nidx)) {
       auto node_cats = tree.NodeCats(nidx);
-      CHECK_LE(node_cats.size(),
-               static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
-      CHECK_LE(h_categories.size(),
-               static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
+      auto constexpr kMaxOffset =
+          static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max());
+      CHECK_LE(node_cats.size(), kMaxOffset)
+          << "Compressed GPU SHAP category segment exceeds uint32_t range.";
+      CHECK_LE(h_categories.size(), kMaxOffset - node_cats.size())
+          << "Compressed GPU SHAP category offsets exceed uint32_t range.";
       out.cat_begin = static_cast<std::uint32_t>(h_categories.size());
       out.cat_size = static_cast<std::uint32_t>(node_cats.size());
       out.is_categorical = 1;
@@ -293,11 +330,10 @@ GpuQuadratureModelData PrepareGpuQuadratureModel(Context const* ctx, gbm::GBTree
       auto const n_targets = tree.NumTargets();
       CHECK_EQ(n_targets, n_groups)
           << prediction_kind << " expects one vector-leaf target per output group.";
+      std::vector<double> root_means(n_targets, 0.0);
+      FillRootMeanValues(tree, RegTree::kRoot, 1.0, &root_means);
       for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
-        auto root_mean = detail::FillRootMeanValue(tree, RegTree::kRoot, [&](bst_node_t leaf) {
-          return LeafValue(tree, leaf, target_idx);
-        });
-        group_root_mean_sums[target_idx] += root_mean * weight;
+        group_root_mean_sums[target_idx] += root_means[target_idx] * weight;
       }
     } else {
       auto const tree = model.trees[tree_idx]->HostScView();

--- a/src/predictor/interpretability/shap.cu
+++ b/src/predictor/interpretability/shap.cu
@@ -41,7 +41,6 @@
 #include "xgboost/host_device_vector.h"
 #include "xgboost/linalg.h"  // for UnravelIndex
 #include "xgboost/logging.h"
-#include "xgboost/multi_target_tree_model.h"  // for MTNotImplemented
 
 namespace xgboost::interpretability::cuda_impl {
 namespace {
@@ -66,6 +65,7 @@ constexpr unsigned kFullWarpMask = 0xffffffffu;
 // occupancy for shallower buckets.
 constexpr int kGpuQuadratureTreeBlockThreads = 64;
 constexpr int kGpuQuadratureWarpsPerBlock = kGpuQuadratureTreeBlockThreads / dh::WarpThreads();
+constexpr std::uint32_t kInvalidLeafBegin = std::numeric_limits<std::uint32_t>::max();
 
 // The traversal stack lives in shared memory and is sized at compile time. Group trees by depth so
 // shallow models use smaller stack/basis arrays, while deeper trees still get a bounded fallback
@@ -81,6 +81,7 @@ struct CompressedNode {
   float leaf_value{0};
   float left_weight{0};
   float right_weight{0};
+  std::uint32_t leaf_begin{kInvalidLeafBegin};
   std::uint32_t cat_begin{0};
   std::uint32_t cat_size{0};
   std::uint8_t default_left{0};
@@ -94,12 +95,14 @@ struct CompressedNode {
 
 struct CompressedTree {
   std::uint32_t node_begin{0};
-  bst_target_t group{0};
+  bst_target_t group_idx{0};
+  bst_target_t target_idx{0};
 };
 
 struct CompressedModel {
   dh::device_vector<CompressedTree> trees;
   dh::device_vector<CompressedNode> nodes;
+  dh::device_vector<float> leaf_values;
   dh::device_vector<std::uint32_t> categories;
 };
 
@@ -124,90 +127,132 @@ std::size_t DepthBucketIndex(std::size_t path_depth) {
   return kGpuQuadratureDepthBuckets.size() - 1;
 }
 
+float LeafValue(tree::ScalarTreeView const& tree, bst_node_t nidx, bst_target_t target_idx) {
+  CHECK_EQ(target_idx, 0);
+  return tree.LeafValue(nidx);
+}
+
+float LeafValue(tree::MultiTargetTreeView const& tree, bst_node_t nidx, bst_target_t target_idx) {
+  auto leaf_value = tree.LeafValue(nidx);
+  CHECK_LT(target_idx, leaf_value.Size());
+  return leaf_value(target_idx);
+}
+
+template <typename Tree>
+void CompressTree(Tree const& tree, std::vector<CompressedNode>* p_nodes,
+                  std::vector<float>* p_leaf_values, std::vector<std::uint32_t>* p_categories,
+                  float weight, std::uint32_t* p_node_begin) {
+  auto& h_nodes = *p_nodes;
+  auto& h_leaf_values = *p_leaf_values;
+  auto& h_categories = *p_categories;
+
+  auto node_begin = h_nodes.size();
+  CHECK_LE(node_begin, static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
+  *p_node_begin = static_cast<std::uint32_t>(node_begin);
+  h_nodes.resize(node_begin + tree.Size());
+
+  for (bst_node_t nidx = 0; nidx < tree.Size(); ++nidx) {
+    auto& out = h_nodes[node_begin + nidx];
+    if (tree.IsLeaf(nidx)) {
+      out.is_leaf = 1;
+      if (tree.NumTargets() == 1) {
+        out.leaf_value = LeafValue(tree, nidx, 0) * weight;
+      } else {
+        CHECK_LE(h_leaf_values.size(),
+                 static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
+        out.leaf_begin = static_cast<std::uint32_t>(h_leaf_values.size());
+        for (bst_target_t target_idx = 0; target_idx < tree.NumTargets(); ++target_idx) {
+          h_leaf_values.push_back(LeafValue(tree, nidx, target_idx) * weight);
+        }
+      }
+      continue;
+    }
+
+    auto left = tree.LeftChild(nidx);
+    auto right = tree.RightChild(nidx);
+    auto parent_cover = tree.SumHess(nidx);
+    CHECK_GE(parent_cover, 0.0f);
+    CHECK_GE(tree.SumHess(left), 0.0f);
+    CHECK_GE(tree.SumHess(right), 0.0f);
+
+    out.left = left;
+    out.right = right;
+    out.split_global = tree.SplitIndex(nidx);
+    out.split_cond = tree.SplitCond(nidx);
+    out.left_weight = detail::BranchWeight(tree.SumHess(left), parent_cover);
+    out.right_weight = detail::BranchWeight(tree.SumHess(right), parent_cover);
+    if (common::IsCat(tree.cats.split_type, nidx)) {
+      auto node_cats = tree.NodeCats(nidx);
+      CHECK_LE(node_cats.size(),
+               static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
+      CHECK_LE(h_categories.size(),
+               static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
+      out.cat_begin = static_cast<std::uint32_t>(h_categories.size());
+      out.cat_size = static_cast<std::uint32_t>(node_cats.size());
+      out.is_categorical = 1;
+      h_categories.insert(h_categories.end(), node_cats.begin(), node_cats.end());
+    }
+    out.default_left = tree.DefaultLeft(nidx);
+    out.is_leaf = 0;
+  }
+
+  for (bst_node_t nidx = 0; nidx < tree.Size(); ++nidx) {
+    auto& out = h_nodes[node_begin + nidx];
+    if (out.is_leaf) {
+      continue;
+    }
+
+    // Repeated feature splits need q_prev from the previous occurrence of the same feature,
+    // not the default probability 1.0. Compute that ancestor distance once during compression
+    // and keep the GPU traversal stack purely array-index based.
+    std::uint8_t prev_same_offset_plus1 = 0;
+    std::uint16_t distance = 0;
+    auto ancestor = nidx;
+    while (!tree.IsRoot(ancestor)) {
+      ancestor = tree.Parent(ancestor);
+      ++distance;
+      auto const& ancestor_node = h_nodes[node_begin + ancestor];
+      if (!ancestor_node.is_leaf && ancestor_node.split_global == out.split_global) {
+        prev_same_offset_plus1 = static_cast<std::uint8_t>(distance + 1);
+        break;
+      }
+    }
+    out.prev_same_offset_plus1 = prev_same_offset_plus1;
+  }
+}
+
 CompressedModel CompressTreeBucket(gbm::GBTreeModel const& model,
                                    std::vector<bst_tree_t> const& tree_indices,
                                    common::Span<bst_target_t const> h_tree_groups,
-                                   std::vector<float> const* tree_weights) {
+                                   bst_target_t n_groups, std::vector<float> const* tree_weights) {
   std::vector<CompressedTree> h_trees;
   std::vector<CompressedNode> h_nodes;
+  std::vector<float> h_leaf_values;
   std::vector<std::uint32_t> h_categories;
 
-  h_trees.reserve(tree_indices.size());
+  h_trees.reserve(tree_indices.size() * std::max<bst_target_t>(n_groups, 1));
   for (auto tree_idx : tree_indices) {
     auto const weight = tree_weights == nullptr ? 1.0f : (*tree_weights)[tree_idx];
-    auto const tree = model.trees.at(tree_idx)->HostScView();
-
-    auto node_begin = h_nodes.size();
-    CHECK_LE(node_begin, static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
-    h_nodes.resize(node_begin + tree.Size());
-
-    for (bst_node_t nidx = 0; nidx < tree.Size(); ++nidx) {
-      auto& out = h_nodes[node_begin + nidx];
-      if (tree.IsLeaf(nidx)) {
-        out.is_leaf = 1;
-        out.leaf_value = tree.LeafValue(nidx) * weight;
-        continue;
+    std::uint32_t node_begin{0};
+    if (model.trees.at(tree_idx)->IsMultiTarget()) {
+      auto const tree = model.trees.at(tree_idx)->HostMtView();
+      auto const n_targets = tree.NumTargets();
+      CHECK_EQ(n_targets, n_groups);
+      CompressTree(tree, &h_nodes, &h_leaf_values, &h_categories, weight, &node_begin);
+      for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+        h_trees.push_back(CompressedTree{node_begin, target_idx, target_idx});
       }
-
-      auto left = tree.LeftChild(nidx);
-      auto right = tree.RightChild(nidx);
-      auto parent_cover = tree.SumHess(nidx);
-      CHECK_GE(parent_cover, 0.0f);
-      CHECK_GE(tree.SumHess(left), 0.0f);
-      CHECK_GE(tree.SumHess(right), 0.0f);
-
-      out.left = left;
-      out.right = right;
-      out.split_global = tree.SplitIndex(nidx);
-      out.split_cond = tree.SplitCond(nidx);
-      out.left_weight = detail::BranchWeight(tree.SumHess(left), parent_cover);
-      out.right_weight = detail::BranchWeight(tree.SumHess(right), parent_cover);
-      if (common::IsCat(tree.cats.split_type, nidx)) {
-        auto node_cats = tree.NodeCats(nidx);
-        CHECK_LE(node_cats.size(),
-                 static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
-        CHECK_LE(h_categories.size(),
-                 static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
-        out.cat_begin = static_cast<std::uint32_t>(h_categories.size());
-        out.cat_size = static_cast<std::uint32_t>(node_cats.size());
-        out.is_categorical = 1;
-        h_categories.insert(h_categories.end(), node_cats.begin(), node_cats.end());
-      }
-      out.default_left = tree.DefaultLeft(nidx);
-      out.is_leaf = 0;
+    } else {
+      auto const tree = model.trees.at(tree_idx)->HostScView();
+      CompressTree(tree, &h_nodes, &h_leaf_values, &h_categories, weight, &node_begin);
+      h_trees.push_back(CompressedTree{node_begin, h_tree_groups[tree_idx], 0});
     }
-
-    for (bst_node_t nidx = 0; nidx < tree.Size(); ++nidx) {
-      auto& out = h_nodes[node_begin + nidx];
-      if (out.is_leaf) {
-        continue;
-      }
-
-      // Repeated feature splits need q_prev from the previous occurrence of the same feature,
-      // not the default probability 1.0. Compute that ancestor distance once during compression
-      // and keep the GPU traversal stack purely array-index based.
-      std::uint8_t prev_same_offset_plus1 = 0;
-      std::uint16_t distance = 0;
-      auto ancestor = nidx;
-      while (!tree.IsRoot(ancestor)) {
-        ancestor = tree.Parent(ancestor);
-        ++distance;
-        auto const& ancestor_node = h_nodes[node_begin + ancestor];
-        if (!ancestor_node.is_leaf && ancestor_node.split_global == out.split_global) {
-          prev_same_offset_plus1 = static_cast<std::uint8_t>(distance + 1);
-          break;
-        }
-      }
-      out.prev_same_offset_plus1 = prev_same_offset_plus1;
-    }
-
-    h_trees.push_back(
-        CompressedTree{static_cast<std::uint32_t>(node_begin), h_tree_groups[tree_idx]});
   }
 
   CompressedModel out;
   out.trees = dh::device_vector<CompressedTree>(h_trees.cbegin(), h_trees.cend());
   out.nodes = dh::device_vector<CompressedNode>(h_nodes.cbegin(), h_nodes.cend());
+  out.leaf_values = dh::device_vector<float>(h_leaf_values.cbegin(), h_leaf_values.cend());
   out.categories = dh::device_vector<std::uint32_t>(h_categories.cbegin(), h_categories.cend());
   return out;
 }
@@ -222,9 +267,9 @@ GpuQuadratureModelData PrepareGpuQuadratureModel(Context const* ctx, gbm::GBTree
   auto const h_tree_groups = model.TreeGroups(DeviceOrd::CPU());
   bst_node_t max_depth = 0;
   std::array<std::vector<bst_tree_t>, kGpuQuadratureDepthBuckets.size()> tree_buckets;
+  std::vector<double> group_root_mean_sums(n_groups, 0.0);
 
   for (bst_tree_t tree_idx = 0; tree_idx < tree_end; ++tree_idx) {
-    CHECK(!model.trees[tree_idx]->IsMultiTarget()) << prediction_kind << MTNotImplemented();
     auto tree_depth = model.trees[tree_idx]->MaxDepth();
     max_depth = std::max(max_depth, tree_depth);
     // MaxDepth counts edges, while the iterative traversal stack stores nodes along the active
@@ -232,21 +277,39 @@ GpuQuadratureModelData PrepareGpuQuadratureModel(Context const* ctx, gbm::GBTree
     auto path_depth = static_cast<std::size_t>(tree_depth) + 1;
     auto bucket_idx = DepthBucketIndex(path_depth);
     tree_buckets[bucket_idx].push_back(tree_idx);
+    auto const weight = tree_weights == nullptr ? 1.0f : (*tree_weights)[tree_idx];
+    if (model.trees[tree_idx]->IsMultiTarget()) {
+      auto const tree = model.trees[tree_idx]->HostMtView();
+      auto const n_targets = tree.NumTargets();
+      CHECK_EQ(n_targets, n_groups)
+          << prediction_kind << " expects one vector-leaf target per output group.";
+      for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+        auto root_mean = detail::FillRootMeanValue(tree, RegTree::kRoot, [&](bst_node_t leaf) {
+          return LeafValue(tree, leaf, target_idx);
+        });
+        group_root_mean_sums[target_idx] += root_mean * weight;
+      }
+    } else {
+      auto const tree = model.trees[tree_idx]->HostScView();
+      group_root_mean_sums[h_tree_groups[tree_idx]] +=
+          detail::FillRootMeanValue(tree, RegTree::kRoot) * weight;
+    }
   }
   CHECK_LE(max_depth + 1, static_cast<bst_node_t>(kMaxGpuQuadratureDepth))
       << "GPU QuadratureSHAP currently supports trees of depth up to "
       << (kMaxGpuQuadratureDepth - 1) << ".";
 
-  auto h_group_root_mean_sums = detail::MakeGroupRootMeanSums(
-      h_tree_groups, n_groups, tree_end, tree_weights,
-      [&](bst_tree_t tree_idx) { return model.trees.at(tree_idx)->HostScView(); });
+  std::vector<float> h_group_root_mean_sums(group_root_mean_sums.size());
+  std::transform(group_root_mean_sums.cbegin(), group_root_mean_sums.cend(),
+                 h_group_root_mean_sums.begin(), [](double v) { return static_cast<float>(v); });
 
   GpuQuadratureModelData out;
   out.rule = detail::GetQuadratureRule();
   out.group_root_mean_sums =
       dh::device_vector<float>(h_group_root_mean_sums.cbegin(), h_group_root_mean_sums.cend());
   for (std::size_t i = 0; i < tree_buckets.size(); ++i) {
-    out.compressed[i] = CompressTreeBucket(model, tree_buckets[i], h_tree_groups, tree_weights);
+    out.compressed[i] =
+        CompressTreeBucket(model, tree_buckets[i], h_tree_groups, n_groups, tree_weights);
   }
   return out;
 }
@@ -442,6 +505,7 @@ struct QuadratureShapTaskRunner {
   SharedT& shared;
   CompressedTree const* trees;
   CompressedNode const* nodes;
+  float const* leaf_values;
   std::uint32_t const* categories;
   float* phis;
   bst_idx_t base_rowid;
@@ -559,12 +623,16 @@ struct QuadratureShapTaskRunner {
     return true;
   }
 
-  XGBOOST_DEV_INLINE void Descend(CompressedNode const* nodes_for_tree, bst_idx_t ridx,
-                                  int* stack_size, bool* have_return, float* ret_val) {
+  XGBOOST_DEV_INLINE void Descend(CompressedTree const& tree, CompressedNode const* nodes_for_tree,
+                                  bst_idx_t ridx, int* stack_size, bool* have_return,
+                                  float* ret_val) {
     int depth = *stack_size - 1;
     auto const& node = nodes_for_tree[shared.Node(warp, depth)];
     if (node.is_leaf) {
-      *ret_val = shared.Basis(warp, subgroup.row_slot, depth, subgroup.point) * node.leaf_value;
+      auto leaf_value = node.leaf_begin == kInvalidLeafBegin
+                            ? node.leaf_value
+                            : leaf_values[node.leaf_begin + tree.target_idx];
+      *ret_val = shared.Basis(warp, subgroup.row_slot, depth, subgroup.point) * leaf_value;
       (*stack_size)--;
       *have_return = true;
       return;
@@ -640,13 +708,13 @@ struct QuadratureShapTaskRunner {
     float ret_val = 0.0f;
     while (stack_size > 0 || have_return) {
       if (have_return) {
-        if (!this->HandleReturn(row_idx, tree.group, nodes_for_tree, &stack_size, &have_return,
+        if (!this->HandleReturn(row_idx, tree.group_idx, nodes_for_tree, &stack_size, &have_return,
                                 &ret_val)) {
           break;
         }
         continue;
       }
-      this->Descend(nodes_for_tree, ridx, &stack_size, &have_return, &ret_val);
+      this->Descend(tree, nodes_for_tree, ridx, &stack_size, &have_return, &ret_val);
     }
   }
 };
@@ -658,6 +726,7 @@ struct QuadratureShapInteractionTaskRunner {
   SharedT& shared;
   CompressedTree const* trees;
   CompressedNode const* nodes;
+  float const* leaf_values;
   std::uint32_t const* categories;
   float* phis;
   bst_idx_t base_rowid;
@@ -822,12 +891,16 @@ struct QuadratureShapInteractionTaskRunner {
     return true;
   }
 
-  XGBOOST_DEV_INLINE void Descend(CompressedNode const* nodes_for_tree, bst_idx_t ridx,
-                                  int* stack_size, bool* have_return, float* ret_val) {
+  XGBOOST_DEV_INLINE void Descend(CompressedTree const& tree, CompressedNode const* nodes_for_tree,
+                                  bst_idx_t ridx, int* stack_size, bool* have_return,
+                                  float* ret_val) {
     int depth = *stack_size - 1;
     auto const& node = nodes_for_tree[shared.Node(warp, depth)];
     if (node.is_leaf) {
-      *ret_val = shared.Basis(warp, subgroup.row_slot, depth, subgroup.point) * node.leaf_value;
+      auto leaf_value = node.leaf_begin == kInvalidLeafBegin
+                            ? node.leaf_value
+                            : leaf_values[node.leaf_begin + tree.target_idx];
+      *ret_val = shared.Basis(warp, subgroup.row_slot, depth, subgroup.point) * leaf_value;
       (*stack_size)--;
       *have_return = true;
       return;
@@ -896,13 +969,13 @@ struct QuadratureShapInteractionTaskRunner {
     float ret_val = 0.0f;
     while (stack_size > 0 || have_return) {
       if (have_return) {
-        if (!this->HandleReturn(row_idx, tree.group, nodes_for_tree, &stack_size, &have_return,
+        if (!this->HandleReturn(row_idx, tree.group_idx, nodes_for_tree, &stack_size, &have_return,
                                 &ret_val)) {
           break;
         }
         continue;
       }
-      this->Descend(nodes_for_tree, ridx, &stack_size, &have_return, &ret_val);
+      this->Descend(tree, nodes_for_tree, ridx, &stack_size, &have_return, &ret_val);
     }
   }
 };
@@ -914,6 +987,7 @@ __global__ void __launch_bounds__(kGpuQuadratureTreeBlockThreads, 9)
                              std::size_t row_tiles, bst_idx_t valid_rows_in_tail,
                              std::size_t n_trees, CompressedTree const* __restrict__ trees,
                              CompressedNode const* __restrict__ nodes,
+                             float const* __restrict__ leaf_values,
                              std::uint32_t const* __restrict__ categories, QuadratureRule rule,
                              float* __restrict__ phis) {
   static_assert(DepthCap <= static_cast<int>(kMaxGpuQuadratureDepth));
@@ -945,6 +1019,7 @@ __global__ void __launch_bounds__(kGpuQuadratureTreeBlockThreads, 9)
                                                                      shared,
                                                                      trees,
                                                                      nodes,
+                                                                     leaf_values,
                                                                      categories,
                                                                      phis,
                                                                      base_rowid,
@@ -973,6 +1048,7 @@ void LaunchQuadratureShapTasks(Context const* ctx, Loader loader, bst_idx_t base
   }
   auto trees = thrust::raw_pointer_cast(compressed.trees.data());
   auto nodes = thrust::raw_pointer_cast(compressed.nodes.data());
+  auto leaf_values = thrust::raw_pointer_cast(compressed.leaf_values.data());
   auto categories = thrust::raw_pointer_cast(compressed.categories.data());
   auto phis = out_contribs->DeviceSpan().data();
   auto n_tasks = compressed.trees.size() * row_tiles;
@@ -981,7 +1057,7 @@ void LaunchQuadratureShapTasks(Context const* ctx, Loader loader, bst_idx_t base
       <<<static_cast<uint32_t>(grids), static_cast<uint32_t>(kGpuQuadratureTreeBlockThreads), 0,
          ctx->CUDACtx()->Stream()>>>(loader, base_rowid, n_groups, n_columns, row_tile_begin,
                                      row_tiles, valid_rows_in_tail, compressed.trees.size(), trees,
-                                     nodes, categories, rule, phis);
+                                     nodes, leaf_values, categories, rule, phis);
   dh::safe_cuda(cudaGetLastError());
 }
 
@@ -1012,6 +1088,7 @@ __global__ void __launch_bounds__(kGpuQuadratureTreeBlockThreads, 9)
                                         std::size_t n_trees,
                                         CompressedTree const* __restrict__ trees,
                                         CompressedNode const* __restrict__ nodes,
+                                        float const* __restrict__ leaf_values,
                                         std::uint32_t const* __restrict__ categories,
                                         QuadratureRule rule, float* __restrict__ phis) {
   static_assert(DepthCap <= static_cast<int>(kMaxGpuQuadratureDepth));
@@ -1044,6 +1121,7 @@ __global__ void __launch_bounds__(kGpuQuadratureTreeBlockThreads, 9)
                                                                       shared,
                                                                       trees,
                                                                       nodes,
+                                                                      leaf_values,
                                                                       categories,
                                                                       phis,
                                                                       base_rowid,
@@ -1073,6 +1151,7 @@ void LaunchQuadratureShapInteractionTasks(Context const* ctx, Loader loader, bst
   }
   auto trees = thrust::raw_pointer_cast(compressed.trees.data());
   auto nodes = thrust::raw_pointer_cast(compressed.nodes.data());
+  auto leaf_values = thrust::raw_pointer_cast(compressed.leaf_values.data());
   auto categories = thrust::raw_pointer_cast(compressed.categories.data());
   auto phis = out_contribs->DeviceSpan().data();
   auto n_tasks = compressed.trees.size() * row_tiles;
@@ -1081,7 +1160,7 @@ void LaunchQuadratureShapInteractionTasks(Context const* ctx, Loader loader, bst
       <<<static_cast<uint32_t>(grids), static_cast<uint32_t>(kGpuQuadratureTreeBlockThreads), 0,
          ctx->CUDACtx()->Stream()>>>(loader, base_rowid, n_groups, n_columns, row_tile_begin,
                                      row_tiles, valid_rows_in_tail, compressed.trees.size(), trees,
-                                     nodes, categories, rule, phis);
+                                     nodes, leaf_values, categories, rule, phis);
   dh::safe_cuda(cudaGetLastError());
 }
 
@@ -1152,7 +1231,6 @@ void ShapValues(Context const* ctx, DMatrix* p_fmat, HostDeviceVector<float>* ou
   SetShapDevice(ctx);
   CHECK_EQ(condition, 0) << "GPU QuadratureTreeSHAP does not support conditional SHAP.";
   CHECK_EQ(condition_feature, 0) << "GPU QuadratureTreeSHAP does not support conditional SHAP.";
-  CHECK(!model.learner_model_param->IsVectorLeaf()) << "Predict contribution" << MTNotImplemented();
   CHECK(!p_fmat->Info().IsColumnSplit())
       << "Predict contribution support for column-wise data split is not yet implemented.";
 
@@ -1201,8 +1279,6 @@ void ShapInteractionValues(Context const* ctx, DMatrix* p_fmat,
   if (approximate) {
     LOG(FATAL) << "Approximated contribution is not implemented in GPU predictor, use CPU instead.";
   }
-  CHECK(!model.learner_model_param->IsVectorLeaf())
-      << "Predict interaction contribution" << MTNotImplemented();
   CHECK(!p_fmat->Info().IsColumnSplit()) << "Predict interaction contribution support for "
                                             "column-wise data split is not yet implemented.";
 

--- a/tests/cpp/predictor/test_shap.cc
+++ b/tests/cpp/predictor/test_shap.cc
@@ -134,7 +134,7 @@ std::unique_ptr<gbm::GBTreeModel> LoadGBTreeModel(Learner* learner, Context cons
 }
 }  // namespace
 
-std::vector<ShapTestCase> BuildShapTestCases(Context const* ctx, bool include_vector_leaf) {
+std::vector<ShapTestCase> BuildShapTestCases(Context const* ctx) {
   std::vector<ShapTestCase> cases;
   auto device = ctx->Device();
 
@@ -197,17 +197,15 @@ std::vector<ShapTestCase> BuildShapTestCases(Context const* ctx, bool include_ve
     cases.emplace_back(dmat, std::move(args));
   }
 
-  if (include_vector_leaf) {
-    // multi-target vector-leaf tree
-    bst_target_t constexpr n_targets{2};
-    auto dmat = RandomDataGenerator(64, 6, 0.0).Device(device).GenerateDMatrix(true);
-    SetMultiTargetLabels(dmat.get(), n_targets);
-    auto args = BaseParams(ctx, "reg:squarederror", "3");
-    args.emplace_back("tree_method", "hist");
-    args.emplace_back("num_target", std::to_string(n_targets));
-    args.emplace_back("multi_strategy", "multi_output_tree");
-    cases.emplace_back(dmat, std::move(args));
-  }
+  // multi-target vector-leaf tree
+  bst_target_t constexpr n_targets{2};
+  auto dmat = RandomDataGenerator(64, 6, 0.0).Device(device).GenerateDMatrix(true);
+  SetMultiTargetLabels(dmat.get(), n_targets);
+  auto args = BaseParams(ctx, "reg:squarederror", "3");
+  args.emplace_back("tree_method", "hist");
+  args.emplace_back("num_target", std::to_string(n_targets));
+  args.emplace_back("multi_strategy", "multi_output_tree");
+  cases.emplace_back(dmat, std::move(args));
 
   {
     // compact dense classification case to keep runtime bounded
@@ -315,7 +313,7 @@ void CheckShapAdditivity(size_t rows, size_t cols, HostDeviceVector<float> const
 
 TEST(Predictor, ShapOutputCasesCPU) {
   Context ctx;
-  auto cases = BuildShapTestCases(&ctx, true);
+  auto cases = BuildShapTestCases(&ctx);
   for (auto const& [dmat, args] : cases) {
     CheckShapOutput(dmat.get(), args);
   }

--- a/tests/cpp/predictor/test_shap.cu
+++ b/tests/cpp/predictor/test_shap.cu
@@ -79,7 +79,7 @@ TEST(GPUPredictor, CompareCPUShap) {
 
 TEST(GPUPredictor, ShapOutputCasesGPU) {
   auto ctx = MakeCUDACtx(0);
-  auto cases = BuildShapTestCases(&ctx, false);
+  auto cases = BuildShapTestCases(&ctx);
   for (auto const& [dmat, args] : cases) {
     CheckShapOutput(dmat.get(), args);
   }

--- a/tests/cpp/predictor/test_shap.h
+++ b/tests/cpp/predictor/test_shap.h
@@ -25,7 +25,7 @@ void CheckShapAdditivity(size_t rows, size_t cols, HostDeviceVector<float> const
                          HostDeviceVector<float> const& margin_predt);
 
 using ShapTestCase = std::pair<std::shared_ptr<DMatrix>, Args>;
-std::vector<ShapTestCase> BuildShapTestCases(Context const* ctx, bool include_vector_leaf);
+std::vector<ShapTestCase> BuildShapTestCases(Context const* ctx);
 
 }  // namespace xgboost
 

--- a/tests/python-gpu/test_gpu_multi_target.py
+++ b/tests/python-gpu/test_gpu_multi_target.py
@@ -3,7 +3,9 @@
 # pylint: disable=too-many-positional-arguments,missing-function-docstring
 from typing import Any, Callable, Dict, Optional
 
+import numpy as np
 import pytest
+import xgboost as xgb
 from hypothesis import given, note, settings, strategies
 from xgboost import config_context
 from xgboost import testing as tm
@@ -49,6 +51,45 @@ def test_quantile_loss_rf(multi_strategy: str) -> None:
     check_quantile_loss_rf("cuda", "hist", multi_strategy)
     if multi_strategy == "one_output_per_tree":
         check_quantile_loss_rf("cuda", "approx", multi_strategy)
+
+
+def test_shap_multi_output_tree() -> None:
+    X = np.array(
+        [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [2.0, 1.0], [1.0, 2.0]],
+        dtype=np.float32,
+    )
+    y = np.stack([X[:, 0] + 2 * X[:, 1], -X[:, 0] + 0.5 * X[:, 1]], axis=1)
+    Xy = xgb.DMatrix(X, y)
+
+    booster = xgb.train(
+        {
+            "device": "cuda",
+            "tree_method": "hist",
+            "max_depth": 2,
+            "num_target": 2,
+            "multi_strategy": "multi_output_tree",
+            "objective": "reg:squarederror",
+        },
+        Xy,
+        num_boost_round=3,
+    )
+
+    margin = booster.predict(Xy, output_margin=True, strict_shape=True)
+    contribs = booster.predict(Xy, pred_contribs=True, strict_shape=True)
+    interactions = booster.predict(Xy, pred_interactions=True, strict_shape=True)
+
+    assert margin.shape == (X.shape[0], y.shape[1])
+    assert contribs.shape == (X.shape[0], y.shape[1], X.shape[1] + 1)
+    assert interactions.shape == (
+        X.shape[0],
+        y.shape[1],
+        X.shape[1] + 1,
+        X.shape[1] + 1,
+    )
+    np.testing.assert_allclose(contribs.sum(axis=2), margin, rtol=1e-4, atol=1e-4)
+    np.testing.assert_allclose(
+        interactions.sum(axis=(2, 3)), margin, rtol=1e-4, atol=1e-4
+    )
 
 
 def test_absolute_error() -> None:


### PR DESCRIPTION
## What changed

This extends the exact GPU QuadratureTreeSHAP implementation to support vector-leaf trees for both SHAP contributions and SHAP interaction contributions.

The GPU model compression now stores tree topology once and stores leaf outputs separately. For vector-leaf trees, each compressed leaf records an offset into the leaf-value array, and the kernel reads the target-specific value from that array. The per-target work is represented by lightweight compressed-tree task metadata, so split structure, categories, and branch weights are not duplicated in compressed memory.

The shared C++ SHAP test cases now always include the vector-leaf case, and the CUDA multi-target Python tests include a public API regression for `multi_output_tree` with `pred_contribs=True` and `pred_interactions=True`.

## Why

CPU SHAP already supports vector-leaf trees. The GPU predictor still rejected vector-leaf models for exact SHAP contributions and interactions. This removes that unsupported path while preserving the existing exact QuadratureTreeSHAP traversal.

## Validation

- `git diff --check`
- `cmake --build build-cuda --target testxgboost -j35`
- `build-cuda/testxgboost --gtest_filter=GPUPredictor.ShapOutputCasesGPU:GPUPredictor.DartShapOutputGPU:GPUPredictor.CompareCPUShap:Predictor.ShapOutputCasesCPU`
- `PYTHONPATH=/home/nfs/rorym/xgboost-wt/gpu-vector-leaf-shap/python-package /home/nfs/rorym/anaconda3/bin/conda run -n xgboost python -m pytest tests/python-gpu/test_gpu_multi_target.py::test_shap_multi_output_tree`
