### PR TITLE
Use conda CUDA host compiler for RMM nightly build

### DIFF
--- a/ops/pipeline/nightly-test-rmm-impl.sh
+++ b/ops/pipeline/nightly-test-rmm-impl.sh
@@ -19,6 +19,7 @@ mamba create -y -n rmm_test -c conda-forge -c rapidsai-nightly python=3.13 \
   gtest nccl "rmm=${rmm_version%.*}.*,>=0.0.0a0"
 
 source activate rmm_test
+export CUDAHOSTCXX="${CXX}"
 
 if [[ "${BUILD_ONLY_SM75:-}" == 1 ]]
 then


### PR DESCRIPTION
## Summary
- Set `CUDAHOSTCXX` to the activated conda C++ compiler for the nightly RMM build.
- Avoid using the CUDA host compiler baked into the CUDA 13 CI image after installing a newer conda toolchain.

Closes #12213

## Testing
- Built the matching `xgb-ci.gpu_build_cuda13_rockylinux8:main` image locally from `dmlc/xgboost-devops`.
- Reproduced the RMM 26.06 failure with the unmodified script.
- Verified `BUILD_ONLY_SM75=1 python3 ops/docker_run.py --image-uri 492475357299.dkr.ecr.us-west-2.amazonaws.com/xgb-ci.gpu_build_cuda13_rockylinux8:main --run-args='-e BUILD_ONLY_SM75' -- ops/pipeline/nightly-test-rmm-impl.sh 26.06` passes with this change.