### PR TITLE
Add timeout to RTD trigger request

### DIFF
--- a/ops/pipeline/trigger-rtd-impl.py
+++ b/ops/pipeline/trigger-rtd-impl.py
@@ -32,7 +32,7 @@ def trigger_build(token: str) -> None:
 
     URL = f"https://readthedocs.org/api/v3/projects/xgboost/versions/{branch}/builds/"
     HEADERS = {"Authorization": f"token {token}"}
-    response = requests.post(URL, headers=HEADERS)
+    response = requests.post(URL, headers=HEADERS, timeout=30)
     # 202 means the build is successfully triggered.
     if response.status_code != 202:
         status_text = http_responses[response.status_code]


### PR DESCRIPTION
## Summary
- add an explicit timeout to the Read the Docs trigger request

## Why
The CI helper triggers the Read the Docs API with requests.post(). If the service accepts the connection but stalls, the workflow can block on the socket. A bounded timeout lets CI fail clearly instead of hanging indefinitely.

## Testing
- python3 -m py_compile ops/pipeline/trigger-rtd-impl.py
- git diff --check