### PR TITLE
Add interpretability SHAP C API

### DIFF
--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -1227,8 +1227,10 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle, DMatrixHandle dmat
  * @brief Compute SHAP values for a DMatrix.
  *
  * This function is the public C API entry point for interpretability algorithms.
- * It returns feature SHAP values and the bias term as separate buffers.  The
- * optional background DMatrix is reserved for interventional SHAP algorithms.
+ * It returns feature SHAP values and the bias term as separate array-interface
+ * objects.  The optional background DMatrix is reserved for interventional SHAP
+ * algorithms.  The returned array-interface objects reference internal storage.
+ * The arrays are read-only and should be copied before the next XGBoost call.
  *
  * @param handle Booster handle.
  * @param dmat Foreground DMatrix handle.
@@ -1244,21 +1246,14 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle, DMatrixHandle dmat
  *    "iteration_end": int
  *      End iteration.  Set to 0 to use all trees.
  *
- * @param out_values_shape Shape of feature SHAP values (copy before use).
- * @param out_values_dim Dimension of feature SHAP values.
- * @param out_values Buffer storing feature SHAP values (copy before use).
- * @param out_bias_shape Shape of the bias term (copy before use).
- * @param out_bias_dim Dimension of the bias term.
- * @param out_bias Buffer storing the bias term (copy before use).
+ * @param out_values JSON encoded __(cuda)_array_interface__ for feature SHAP values.
+ * @param out_bias JSON encoded __(cuda)_array_interface__ for the bias term.
  *
  * @return 0 when success, -1 when failure happens
  */
 XGB_DLL int XGBoosterInterpretShapValues(BoosterHandle handle, DMatrixHandle dmat,
                                          DMatrixHandle background, char const *config,
-                                         bst_ulong const **out_values_shape,
-                                         bst_ulong *out_values_dim, float const **out_values,
-                                         bst_ulong const **out_bias_shape, bst_ulong *out_bias_dim,
-                                         float const **out_bias);
+                                         char const **out_values, char const **out_bias);
 /**
  * @example inference.c
  */

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -1243,9 +1243,6 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle, DMatrixHandle dmat
  *      Beginning iteration.
  *    "iteration_end": int
  *      End iteration.  Set to 0 to use all trees.
- *    "strict_shape": bool
- *      Whether output shapes should include the output-group dimension even when
- *      there is only one output group.
  *
  * @param out_values_shape Shape of feature SHAP values (copy before use).
  * @param out_values_dim Dimension of feature SHAP values.

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -1222,6 +1222,46 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle, DMatrixHandle dmat, int optio
 XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle, DMatrixHandle dmat,
                                         char const *config, bst_ulong const **out_shape,
                                         bst_ulong *out_dim, float const **out_result);
+
+/**
+ * @brief Compute SHAP values for a DMatrix.
+ *
+ * This function is the public C API entry point for interpretability algorithms.
+ * It returns feature SHAP values and the bias term as separate buffers.  The
+ * optional background DMatrix is reserved for interventional SHAP algorithms.
+ *
+ * @param handle Booster handle.
+ * @param dmat Foreground DMatrix handle.
+ * @param background Optional background DMatrix handle. Pass NULL when not used.
+ * @param config String encoded interpretability configuration in JSON format, with following
+ *                      available fields in the JSON object:
+ *
+ *    "algorithm": string
+ *      SHAP algorithm. Supported values are "auto" and "tree_path_dependent".
+ *      "interventional" is reserved for use with the background DMatrix.
+ *    "iteration_begin": int
+ *      Beginning iteration.
+ *    "iteration_end": int
+ *      End iteration.  Set to 0 to use all trees.
+ *    "strict_shape": bool
+ *      Whether output shapes should include the output-group dimension even when
+ *      there is only one output group.
+ *
+ * @param out_values_shape Shape of feature SHAP values (copy before use).
+ * @param out_values_dim Dimension of feature SHAP values.
+ * @param out_values Buffer storing feature SHAP values (copy before use).
+ * @param out_bias_shape Shape of the bias term (copy before use).
+ * @param out_bias_dim Dimension of the bias term.
+ * @param out_bias Buffer storing the bias term (copy before use).
+ *
+ * @return 0 when success, -1 when failure happens
+ */
+XGB_DLL int XGBoosterInterpretShapValues(BoosterHandle handle, DMatrixHandle dmat,
+                                         DMatrixHandle background, char const *config,
+                                         bst_ulong const **out_values_shape,
+                                         bst_ulong *out_values_dim, float const **out_values,
+                                         bst_ulong const **out_bias_shape, bst_ulong *out_bias_dim,
+                                         float const **out_bias);
 /**
  * @example inference.c
  */

--- a/python-package/xgboost/interpret.py
+++ b/python-package/xgboost/interpret.py
@@ -1,11 +1,21 @@
 """Interpretability functions for XGBoost models."""
 
+import ctypes
+import json
 from typing import Optional, Tuple, Union
 
 import numpy as np
 
 from ._typing import ArrayLike, FloatCompatible, IterationRange
-from .core import Booster, DMatrix
+from .core import (
+    _LIB,
+    Booster,
+    DMatrix,
+    _check_call,
+    _prediction_output,
+    c_bst_ulong,
+    from_pystr_to_cstr,
+)
 
 
 def _as_booster(model: object) -> Booster:
@@ -47,6 +57,44 @@ def _as_prediction_dmatrix(
         nthread=getattr(model, "n_jobs", None),
         feature_types=getattr(model, "feature_types", None),
         enable_categorical=getattr(model, "enable_categorical", False),
+    )
+
+
+def _capi_shap_values(
+    booster: Booster,
+    data: DMatrix,
+    background: Optional[DMatrix],
+    iteration_range: IterationRange,
+) -> Tuple[np.ndarray, np.ndarray]:
+    values_shape = ctypes.POINTER(c_bst_ulong)()
+    values_dim = c_bst_ulong()
+    values = ctypes.POINTER(ctypes.c_float)()
+    bias_shape = ctypes.POINTER(c_bst_ulong)()
+    bias_dim = c_bst_ulong()
+    bias = ctypes.POINTER(ctypes.c_float)()
+    config = {
+        "algorithm": "auto",
+        "iteration_begin": int(iteration_range[0]),
+        "iteration_end": int(iteration_range[1]),
+        "strict_shape": False,
+    }
+    _check_call(
+        _LIB.XGBoosterInterpretShapValues(
+            booster.handle,
+            data.handle,
+            background.handle if background is not None else None,
+            from_pystr_to_cstr(json.dumps(config)),
+            ctypes.byref(values_shape),
+            ctypes.byref(values_dim),
+            ctypes.byref(values),
+            ctypes.byref(bias_shape),
+            ctypes.byref(bias_dim),
+            ctypes.byref(bias),
+        )
+    )
+    return (
+        _prediction_output(values_shape, values_dim, values, False),
+        _prediction_output(bias_shape, bias_dim, bias, False),
     )
 
 
@@ -100,24 +148,26 @@ def shap_values(  # pylint: disable=too-many-arguments
     To use GPU algorithms, configure the model before calling this function, for
     example with ``booster.set_param({"device": "cuda"})``.
     """
-    if X_background is not None:
-        raise NotImplementedError("`X_background` is not yet supported.")
     # SHAP contributions currently correspond to the model margin. Keep this
     # argument in the initial API so callers can use the proposed signature.
     _ = output_margin
 
     booster = _as_booster(model)
     data = _as_prediction_dmatrix(model, X, missing)
-    contribs = booster.predict(
-        data,
-        pred_contribs=True,
-        validate_features=validate_features,
-        iteration_range=_get_iteration_range(model, iteration_range),
+    if validate_features:
+        validate = getattr(booster, "_validate_features")
+        validate(data.feature_names)
+    background = (
+        _as_prediction_dmatrix(model, X_background, missing=None)
+        if X_background is not None
+        else None
     )
-
-    values = contribs[..., :-1]
-    bias = contribs[..., -1]
-    return values, bias
+    return _capi_shap_values(
+        booster,
+        data,
+        background,
+        _get_iteration_range(model, iteration_range),
+    )
 
 
 __all__ = ["shap_values"]

--- a/python-package/xgboost/interpret.py
+++ b/python-package/xgboost/interpret.py
@@ -4,16 +4,13 @@ import ctypes
 import json
 from typing import Optional, Tuple, Union
 
-import numpy as np
-
-from ._typing import ArrayLike, FloatCompatible, IterationRange
+from ._data_utils import from_array_interface
+from ._typing import ArrayLike, FloatCompatible, IterationRange, NumpyOrCupy
 from .core import (
     _LIB,
     Booster,
     DMatrix,
     _check_call,
-    _prediction_output,
-    c_bst_ulong,
     from_pystr_to_cstr,
 )
 
@@ -65,13 +62,9 @@ def _capi_shap_values(
     data: DMatrix,
     background: Optional[DMatrix],
     iteration_range: IterationRange,
-) -> Tuple[np.ndarray, np.ndarray]:
-    values_shape = ctypes.POINTER(c_bst_ulong)()
-    values_dim = c_bst_ulong()
-    values = ctypes.POINTER(ctypes.c_float)()
-    bias_shape = ctypes.POINTER(c_bst_ulong)()
-    bias_dim = c_bst_ulong()
-    bias = ctypes.POINTER(ctypes.c_float)()
+) -> Tuple[NumpyOrCupy, NumpyOrCupy]:
+    values = ctypes.c_char_p()
+    bias = ctypes.c_char_p()
     config = {
         "algorithm": "auto",
         "iteration_begin": int(iteration_range[0]),
@@ -83,16 +76,14 @@ def _capi_shap_values(
             data.handle,
             background.handle if background is not None else None,
             from_pystr_to_cstr(json.dumps(config)),
-            ctypes.byref(values_shape),
-            ctypes.byref(values_dim),
             ctypes.byref(values),
-            ctypes.byref(bias_shape),
-            ctypes.byref(bias_dim),
             ctypes.byref(bias),
         )
     )
-    values_out = _prediction_output(values_shape, values_dim, values, False)
-    bias_out = _prediction_output(bias_shape, bias_dim, bias, False)
+    assert values.value is not None
+    assert bias.value is not None
+    values_out = from_array_interface(json.loads(values.value))
+    bias_out = from_array_interface(json.loads(bias.value))
     if values_out.shape[-1] == 1:
         values_out = values_out[..., 0]
         bias_out = bias_out[..., 0]
@@ -108,7 +99,7 @@ def shap_values(  # pylint: disable=too-many-arguments
     iteration_range: Optional[IterationRange] = None,
     missing: Optional[FloatCompatible] = None,
     validate_features: bool = True,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> Tuple[NumpyOrCupy, NumpyOrCupy]:
     """Return SHAP values for an XGBoost model.
 
     This function accepts either a :py:class:`xgboost.Booster` or an sklearn-style
@@ -142,7 +133,8 @@ def shap_values(  # pylint: disable=too-many-arguments
         ``values`` contains feature SHAP values with the bias term removed.
         ``bias`` contains the separated bias term. For multi-target models, the
         output shape follows the corresponding prediction shape with the final
-        feature dimension split into ``values`` and ``bias``.
+        feature dimension split into ``values`` and ``bias``. Returns NumPy
+        arrays on CPU and CuPy arrays on CUDA.
 
     Notes
     -----

--- a/python-package/xgboost/interpret.py
+++ b/python-package/xgboost/interpret.py
@@ -76,7 +76,6 @@ def _capi_shap_values(
         "algorithm": "auto",
         "iteration_begin": int(iteration_range[0]),
         "iteration_end": int(iteration_range[1]),
-        "strict_shape": False,
     }
     _check_call(
         _LIB.XGBoosterInterpretShapValues(
@@ -92,10 +91,12 @@ def _capi_shap_values(
             ctypes.byref(bias),
         )
     )
-    return (
-        _prediction_output(values_shape, values_dim, values, False),
-        _prediction_output(bias_shape, bias_dim, bias, False),
-    )
+    values_out = _prediction_output(values_shape, values_dim, values, False)
+    bias_out = _prediction_output(bias_shape, bias_dim, bias, False)
+    if values_out.shape[-1] == 1:
+        values_out = values_out[..., 0]
+        bias_out = bias_out[..., 0]
+    return values_out, bias_out
 
 
 def shap_values(  # pylint: disable=too-many-arguments

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1389,7 +1389,6 @@ XGB_DLL int XGBoosterInterpretShapValues(
   auto p_m = *static_cast<std::shared_ptr<DMatrix> *>(dmat);
   auto iteration_begin = OptionalArg<Integer>(config, "iteration_begin", Integer::Int{0});
   auto iteration_end = OptionalArg<Integer>(config, "iteration_end", Integer::Int{0});
-  bool strict_shape = OptionalArg<Boolean>(config, "strict_shape", false);
 
   learner->Predict(p_m, false, &entry.predictions, iteration_begin, iteration_end, false, false,
                    true, false, false);
@@ -1407,29 +1406,23 @@ XGB_DLL int XGBoosterInterpretShapValues(
   for (std::size_t row = 0; row < rows; ++row) {
     for (std::size_t group = 0; group < groups; ++group) {
       std::size_t contrib_offset = row * groups * (cols + 1) + group * (cols + 1);
-      std::size_t value_offset = row * groups * cols + group * cols;
-      std::copy_n(contribs.cbegin() + contrib_offset, cols, values.begin() + value_offset);
+      for (std::size_t col = 0; col < cols; ++col) {
+        std::size_t value_offset = row * cols * groups + col * groups + group;
+        values[value_offset] = contribs[contrib_offset + col];
+      }
       bias[row * groups + group] = contribs[contrib_offset + cols];
     }
   }
 
   auto &values_shape = local.prediction_shape;
   auto &bias_shape = local.prediction_shape_1;
-  if (groups == 1 && !strict_shape) {
-    values_shape.resize(2);
-    values_shape[0] = rows;
-    values_shape[1] = cols;
-    bias_shape.resize(1);
-    bias_shape[0] = rows;
-  } else {
-    values_shape.resize(3);
-    values_shape[0] = rows;
-    values_shape[1] = groups;
-    values_shape[2] = cols;
-    bias_shape.resize(2);
-    bias_shape[0] = rows;
-    bias_shape[1] = groups;
-  }
+  values_shape.resize(3);
+  values_shape[0] = rows;
+  values_shape[1] = cols;
+  values_shape[2] = groups;
+  bias_shape.resize(2);
+  bias_shape[0] = rows;
+  bias_shape[1] = groups;
 
   xgboost_CHECK_C_ARG_PTR(out_values_dim);
   xgboost_CHECK_C_ARG_PTR(out_values_shape);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1360,11 +1360,51 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle, DMatrixHandle dmat
   API_END();
 }
 
-XGB_DLL int XGBoosterInterpretShapValues(
-    BoosterHandle handle, DMatrixHandle dmat, DMatrixHandle background, char const *c_json_config,
-    xgboost::bst_ulong const **out_values_shape, xgboost::bst_ulong *out_values_dim,
-    bst_float const **out_values, xgboost::bst_ulong const **out_bias_shape,
-    xgboost::bst_ulong *out_bias_dim, bst_float const **out_bias) {
+namespace xgboost::c_api {
+namespace cuda_impl {
+#if defined(XGBOOST_USE_CUDA)
+void SplitShapValues(Context const *ctx, HostDeviceVector<float> const &contribs, std::size_t rows,
+                     std::size_t cols, std::size_t groups, HostDeviceVector<float> *out_values,
+                     HostDeviceVector<float> *out_bias);
+#endif  // defined(XGBOOST_USE_CUDA)
+}  // namespace cuda_impl
+
+void SplitShapValues(Context const *ctx, HostDeviceVector<float> const &contribs, std::size_t rows,
+                     std::size_t cols, std::size_t groups, HostDeviceVector<float> *out_values,
+                     HostDeviceVector<float> *out_bias) {
+  auto out_device = ctx->IsCUDA() ? ctx->Device() : DeviceOrd::CPU();
+  out_values->SetDevice(out_device);
+  out_bias->SetDevice(out_device);
+  out_values->Resize(rows * groups * cols);
+  out_bias->Resize(rows * groups);
+
+#if defined(XGBOOST_USE_CUDA)
+  if (ctx->IsCUDA()) {
+    cuda_impl::SplitShapValues(ctx, contribs, rows, cols, groups, out_values, out_bias);
+    return;
+  }
+#endif  // defined(XGBOOST_USE_CUDA)
+
+  auto const &contribs_h = contribs.ConstHostVector();
+  auto &values_h = out_values->HostVector();
+  auto &bias_h = out_bias->HostVector();
+
+  for (std::size_t row = 0; row < rows; ++row) {
+    for (std::size_t group = 0; group < groups; ++group) {
+      std::size_t contrib_offset = row * groups * (cols + 1) + group * (cols + 1);
+      for (std::size_t col = 0; col < cols; ++col) {
+        std::size_t value_offset = row * cols * groups + col * groups + group;
+        values_h[value_offset] = contribs_h[contrib_offset + col];
+      }
+      bias_h[row * groups + group] = contribs_h[contrib_offset + cols];
+    }
+  }
+}
+}  // namespace xgboost::c_api
+
+XGB_DLL int XGBoosterInterpretShapValues(BoosterHandle handle, DMatrixHandle dmat,
+                                         DMatrixHandle background, char const *c_json_config,
+                                         char const **out_values, char const **out_bias) {
   API_BEGIN();
   if (handle == nullptr) {
     LOG(FATAL) << "Booster has not been initialized or has already been disposed.";
@@ -1373,6 +1413,8 @@ XGB_DLL int XGBoosterInterpretShapValues(
     LOG(FATAL) << "DMatrix has not been initialized or has already been disposed.";
   }
   xgboost_CHECK_C_ARG_PTR(c_json_config);
+  xgboost_CHECK_C_ARG_PTR(out_values);
+  xgboost_CHECK_C_ARG_PTR(out_bias);
   auto config = Json::Load(StringView{c_json_config});
 
   auto algorithm = OptionalArg<String>(config, "algorithm", std::string{"auto"});
@@ -1396,47 +1438,29 @@ XGB_DLL int XGBoosterInterpretShapValues(
   std::size_t rows = p_m->Info().num_row_;
   std::size_t cols = p_m->Info().num_col_;
   std::size_t groups = learner->Groups();
-  auto const &contribs = entry.predictions.ConstHostVector();
 
-  auto &values = local.ret_vec_float;
-  auto &bias = local.ret_vec_float_1;
-  values.resize(rows * groups * cols);
-  bias.resize(rows * groups);
+  auto *ctx = learner->Ctx();
+  auto out_ctx = ctx->IsCUDA() ? *ctx : ctx->MakeCPU();
+  auto &values = local.ret_hdv_float;
+  auto &bias = local.ret_hdv_float_1;
+  c_api::SplitShapValues(ctx, entry.predictions, rows, cols, groups, &values, &bias);
 
-  for (std::size_t row = 0; row < rows; ++row) {
-    for (std::size_t group = 0; group < groups; ++group) {
-      std::size_t contrib_offset = row * groups * (cols + 1) + group * (cols + 1);
-      for (std::size_t col = 0; col < cols; ++col) {
-        std::size_t value_offset = row * cols * groups + col * groups + group;
-        values[value_offset] = contribs[contrib_offset + col];
-      }
-      bias[row * groups + group] = contribs[contrib_offset + cols];
-    }
-  }
+  auto const &values_ref = values;
+  auto const &bias_ref = bias;
+  auto &ret_vec_str = local.ret_vec_str;
+  ret_vec_str.clear();
+  ret_vec_str.emplace_back(
+      linalg::ArrayInterfaceStr(linalg::MakeTensorView(&out_ctx, &values_ref, rows, cols, groups)));
+  ret_vec_str.emplace_back(
+      linalg::ArrayInterfaceStr(linalg::MakeTensorView(&out_ctx, &bias_ref, rows, groups)));
 
-  auto &values_shape = local.prediction_shape;
-  auto &bias_shape = local.prediction_shape_1;
-  values_shape.resize(3);
-  values_shape[0] = rows;
-  values_shape[1] = cols;
-  values_shape[2] = groups;
-  bias_shape.resize(2);
-  bias_shape[0] = rows;
-  bias_shape[1] = groups;
+  auto &ret_vec_charp = local.ret_vec_charp;
+  ret_vec_charp.resize(ret_vec_str.size());
+  std::transform(ret_vec_str.cbegin(), ret_vec_str.cend(), ret_vec_charp.begin(),
+                 [](auto const &str) { return str.c_str(); });
 
-  xgboost_CHECK_C_ARG_PTR(out_values_dim);
-  xgboost_CHECK_C_ARG_PTR(out_values_shape);
-  xgboost_CHECK_C_ARG_PTR(out_values);
-  xgboost_CHECK_C_ARG_PTR(out_bias_dim);
-  xgboost_CHECK_C_ARG_PTR(out_bias_shape);
-  xgboost_CHECK_C_ARG_PTR(out_bias);
-
-  *out_values_dim = values_shape.size();
-  *out_values_shape = dmlc::BeginPtr(values_shape);
-  *out_values = dmlc::BeginPtr(values);
-  *out_bias_dim = bias_shape.size();
-  *out_bias_shape = dmlc::BeginPtr(bias_shape);
-  *out_bias = dmlc::BeginPtr(bias);
+  *out_values = ret_vec_charp[0];
+  *out_bias = ret_vec_charp[1];
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1360,6 +1360,93 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle, DMatrixHandle dmat
   API_END();
 }
 
+XGB_DLL int XGBoosterInterpretShapValues(
+    BoosterHandle handle, DMatrixHandle dmat, DMatrixHandle background, char const *c_json_config,
+    xgboost::bst_ulong const **out_values_shape, xgboost::bst_ulong *out_values_dim,
+    bst_float const **out_values, xgboost::bst_ulong const **out_bias_shape,
+    xgboost::bst_ulong *out_bias_dim, bst_float const **out_bias) {
+  API_BEGIN();
+  if (handle == nullptr) {
+    LOG(FATAL) << "Booster has not been initialized or has already been disposed.";
+  }
+  if (dmat == nullptr) {
+    LOG(FATAL) << "DMatrix has not been initialized or has already been disposed.";
+  }
+  xgboost_CHECK_C_ARG_PTR(c_json_config);
+  auto config = Json::Load(StringView{c_json_config});
+
+  auto algorithm = OptionalArg<String>(config, "algorithm", std::string{"auto"});
+  if (algorithm != "auto" && algorithm != "tree_path_dependent" && algorithm != "interventional") {
+    LOG(FATAL) << "Unknown SHAP algorithm: `" << algorithm << "`.";
+  }
+  if (background != nullptr || algorithm == "interventional") {
+    LOG(FATAL) << "Interventional SHAP is not yet implemented.";
+  }
+
+  auto *learner = static_cast<Learner *>(handle);
+  auto &local = learner->GetThreadLocal();
+  auto &entry = local.prediction_entry;
+  auto p_m = *static_cast<std::shared_ptr<DMatrix> *>(dmat);
+  auto iteration_begin = OptionalArg<Integer>(config, "iteration_begin", Integer::Int{0});
+  auto iteration_end = OptionalArg<Integer>(config, "iteration_end", Integer::Int{0});
+  bool strict_shape = OptionalArg<Boolean>(config, "strict_shape", false);
+
+  learner->Predict(p_m, false, &entry.predictions, iteration_begin, iteration_end, false, false,
+                   true, false, false);
+
+  std::size_t rows = p_m->Info().num_row_;
+  std::size_t cols = p_m->Info().num_col_;
+  std::size_t groups = learner->Groups();
+  auto const &contribs = entry.predictions.ConstHostVector();
+
+  auto &values = local.ret_vec_float;
+  auto &bias = local.ret_vec_float_1;
+  values.resize(rows * groups * cols);
+  bias.resize(rows * groups);
+
+  for (std::size_t row = 0; row < rows; ++row) {
+    for (std::size_t group = 0; group < groups; ++group) {
+      std::size_t contrib_offset = row * groups * (cols + 1) + group * (cols + 1);
+      std::size_t value_offset = row * groups * cols + group * cols;
+      std::copy_n(contribs.cbegin() + contrib_offset, cols, values.begin() + value_offset);
+      bias[row * groups + group] = contribs[contrib_offset + cols];
+    }
+  }
+
+  auto &values_shape = local.prediction_shape;
+  auto &bias_shape = local.prediction_shape_1;
+  if (groups == 1 && !strict_shape) {
+    values_shape.resize(2);
+    values_shape[0] = rows;
+    values_shape[1] = cols;
+    bias_shape.resize(1);
+    bias_shape[0] = rows;
+  } else {
+    values_shape.resize(3);
+    values_shape[0] = rows;
+    values_shape[1] = groups;
+    values_shape[2] = cols;
+    bias_shape.resize(2);
+    bias_shape[0] = rows;
+    bias_shape[1] = groups;
+  }
+
+  xgboost_CHECK_C_ARG_PTR(out_values_dim);
+  xgboost_CHECK_C_ARG_PTR(out_values_shape);
+  xgboost_CHECK_C_ARG_PTR(out_values);
+  xgboost_CHECK_C_ARG_PTR(out_bias_dim);
+  xgboost_CHECK_C_ARG_PTR(out_bias_shape);
+  xgboost_CHECK_C_ARG_PTR(out_bias);
+
+  *out_values_dim = values_shape.size();
+  *out_values_shape = dmlc::BeginPtr(values_shape);
+  *out_values = dmlc::BeginPtr(values);
+  *out_bias_dim = bias_shape.size();
+  *out_bias_shape = dmlc::BeginPtr(bias_shape);
+  *out_bias = dmlc::BeginPtr(bias);
+  API_END();
+}
+
 void InplacePredictImpl(std::shared_ptr<DMatrix> p_m, char const *c_json_config, Learner *learner,
                         xgboost::bst_ulong const **out_shape, xgboost::bst_ulong *out_dim,
                         const float **out_result) {

--- a/src/c_api/interpretability.cu
+++ b/src/c_api/interpretability.cu
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ */
+
+#include <cstddef>  // for size_t
+
+#include "../common/cuda_context.cuh"    // for CUDAContext
+#include "../common/device_helpers.cuh"  // for LaunchN
+#include "xgboost/context.h"             // for Context
+#include "xgboost/host_device_vector.h"  // for HostDeviceVector
+
+namespace xgboost::c_api::cuda_impl {
+void SplitShapValues(Context const *ctx, HostDeviceVector<float> const &contribs, std::size_t rows,
+                     std::size_t cols, std::size_t groups, HostDeviceVector<float> *out_values,
+                     HostDeviceVector<float> *out_bias) {
+  auto cuctx = ctx->CUDACtx();
+  auto contribs_d = contribs.ConstDeviceSpan();
+  auto values_d = out_values->DeviceSpan();
+  auto bias_d = out_bias->DeviceSpan();
+
+  dh::LaunchN(values_d.size(), cuctx->Stream(), [=] __device__(std::size_t idx) {
+    auto group = idx % groups;
+    auto col = (idx / groups) % cols;
+    auto row = idx / (cols * groups);
+    auto contrib_offset = row * groups * (cols + 1) + group * (cols + 1);
+    values_d[idx] = contribs_d[contrib_offset + col];
+  });
+  dh::LaunchN(bias_d.size(), cuctx->Stream(), [=] __device__(std::size_t idx) {
+    auto group = idx % groups;
+    auto row = idx / groups;
+    auto contrib_offset = row * groups * (cols + 1) + group * (cols + 1);
+    bias_d[idx] = contribs_d[contrib_offset + cols];
+  });
+}
+}  // namespace xgboost::c_api::cuda_impl

--- a/src/common/api_entry.h
+++ b/src/common/api_entry.h
@@ -6,8 +6,9 @@
 #include <string>  // std::string
 #include <vector>  // std::vector
 
-#include "xgboost/base.h"       // GradientPair,bst_ulong
-#include "xgboost/predictor.h"  // PredictionCacheEntry
+#include "xgboost/base.h"                // GradientPair,bst_ulong
+#include "xgboost/host_device_vector.h"  // HostDeviceVector
+#include "xgboost/predictor.h"           // PredictionCacheEntry
 
 namespace xgboost {
 /**
@@ -24,8 +25,10 @@ struct XGBAPIThreadLocalEntry {
   std::vector<const char *> ret_vec_charp;
   /*! \brief returning float vector. */
   std::vector<float> ret_vec_float;
-  /*! \brief secondary returning float vector. */
-  std::vector<float> ret_vec_float_1;
+  /*! \brief returning device-capable float vector. */
+  HostDeviceVector<float> ret_hdv_float;
+  /*! \brief secondary returning device-capable float vector. */
+  HostDeviceVector<float> ret_hdv_float_1;
   /*! \brief returning uint vector. */
   std::vector<std::uint64_t> ret_vec_u64;
   /*! \brief temp variable of gradient pairs. */
@@ -34,8 +37,6 @@ struct XGBAPIThreadLocalEntry {
   PredictionCacheEntry prediction_entry;
   /*! \brief Temp variable for returning prediction shape. */
   std::vector<bst_ulong> prediction_shape;
-  /*! \brief Secondary temp variable for returning prediction shape. */
-  std::vector<bst_ulong> prediction_shape_1;
 };
 }  // namespace xgboost
 #endif  // XGBOOST_COMMON_API_ENTRY_H_

--- a/src/common/api_entry.h
+++ b/src/common/api_entry.h
@@ -3,8 +3,8 @@
  */
 #ifndef XGBOOST_COMMON_API_ENTRY_H_
 #define XGBOOST_COMMON_API_ENTRY_H_
-#include <string>               // std::string
-#include <vector>               // std::vector
+#include <string>  // std::string
+#include <vector>  // std::vector
 
 #include "xgboost/base.h"       // GradientPair,bst_ulong
 #include "xgboost/predictor.h"  // PredictionCacheEntry
@@ -24,6 +24,8 @@ struct XGBAPIThreadLocalEntry {
   std::vector<const char *> ret_vec_charp;
   /*! \brief returning float vector. */
   std::vector<float> ret_vec_float;
+  /*! \brief secondary returning float vector. */
+  std::vector<float> ret_vec_float_1;
   /*! \brief returning uint vector. */
   std::vector<std::uint64_t> ret_vec_u64;
   /*! \brief temp variable of gradient pairs. */
@@ -32,6 +34,8 @@ struct XGBAPIThreadLocalEntry {
   PredictionCacheEntry prediction_entry;
   /*! \brief Temp variable for returning prediction shape. */
   std::vector<bst_ulong> prediction_shape;
+  /*! \brief Secondary temp variable for returning prediction shape. */
+  std::vector<bst_ulong> prediction_shape_1;
 };
 }  // namespace xgboost
 #endif  // XGBOOST_COMMON_API_ENTRY_H_

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -712,4 +712,93 @@ TEST(CAPI, PredictReuseProxy) {
   ASSERT_EQ(XGBoosterFree(booster_hdl), 0);
   ASSERT_EQ(XGDMatrixFree(proxy_hdl), 0);
 }
+
+TEST(CAPI, InterpretShapValues) {
+  Json fmat_cfg{Object{}};
+  fmat_cfg["missing"] = std::numeric_limits<float>::quiet_NaN();
+  auto sfmat_cfg = Json::Dump(fmat_cfg);
+
+  HostDeviceVector<float> storage;
+  bst_idx_t n_samples = 16;
+  bst_idx_t n_features = 4;
+  auto inf = RandomDataGenerator{n_samples, n_features, 0.0}.GenerateArrayInterface(&storage);
+  HostDeviceVector<float> storage_y;
+  auto y_inf = RandomDataGenerator{n_samples, 1, 0.0}.GenerateArrayInterface(&storage_y);
+
+  DMatrixHandle fmat_hdl{nullptr};
+  ASSERT_EQ(XGDMatrixCreateFromDense(inf.c_str(), sfmat_cfg.c_str(), &fmat_hdl), 0);
+  ASSERT_EQ(XGDMatrixSetInfoFromInterface(fmat_hdl, "label", y_inf.c_str()), 0);
+
+  std::array<DMatrixHandle, 1> mats{fmat_hdl};
+  BoosterHandle booster_hdl{nullptr};
+  ASSERT_EQ(XGBoosterCreate(mats.data(), 1, &booster_hdl), 0);
+  ASSERT_EQ(XGBoosterSetParam(booster_hdl, "tree_method", "hist"), 0);
+
+  for (std::int32_t i = 0; i < 3; ++i) {
+    ASSERT_EQ(XGBoosterUpdateOneIter(booster_hdl, i, fmat_hdl), 0);
+  }
+
+  Json shap_config{Object{}};
+  shap_config["algorithm"] = String{"auto"};
+  shap_config["iteration_begin"] = Integer{0};
+  shap_config["iteration_end"] = Integer{0};
+  shap_config["strict_shape"] = Boolean{false};
+  auto sshap_config = Json::Dump(shap_config);
+
+  bst_ulong const *values_shape{nullptr};
+  bst_ulong values_dim{0};
+  float const *values{nullptr};
+  bst_ulong const *bias_shape{nullptr};
+  bst_ulong bias_dim{0};
+  float const *bias{nullptr};
+  ASSERT_EQ(XGBoosterInterpretShapValues(booster_hdl, fmat_hdl, nullptr, sshap_config.c_str(),
+                                         &values_shape, &values_dim, &values, &bias_shape,
+                                         &bias_dim, &bias),
+            0);
+  ASSERT_EQ(values_dim, 2);
+  ASSERT_EQ(values_shape[0], n_samples);
+  ASSERT_EQ(values_shape[1], n_features);
+  ASSERT_EQ(bias_dim, 1);
+  ASSERT_EQ(bias_shape[0], n_samples);
+
+  Json pred_config{Object{}};
+  pred_config["type"] = Integer{2};
+  pred_config["iteration_begin"] = Integer{0};
+  pred_config["iteration_end"] = Integer{0};
+  pred_config["strict_shape"] = Boolean{false};
+  pred_config["training"] = Boolean{false};
+  auto spred_config = Json::Dump(pred_config);
+
+  bst_ulong const *contribs_shape{nullptr};
+  bst_ulong contribs_dim{0};
+  float const *contribs{nullptr};
+  ASSERT_EQ(XGBoosterPredictFromDMatrix(booster_hdl, fmat_hdl, spred_config.c_str(),
+                                        &contribs_shape, &contribs_dim, &contribs),
+            0);
+  ASSERT_EQ(contribs_dim, 2);
+  ASSERT_EQ(contribs_shape[0], n_samples);
+  ASSERT_EQ(contribs_shape[1], n_features + 1);
+
+  for (bst_idx_t row = 0; row < n_samples; ++row) {
+    for (bst_idx_t feature = 0; feature < n_features; ++feature) {
+      ASSERT_EQ(values[row * n_features + feature], contribs[row * (n_features + 1) + feature]);
+    }
+    ASSERT_EQ(bias[row], contribs[row * (n_features + 1) + n_features]);
+  }
+
+  ASSERT_EQ(XGBoosterInterpretShapValues(booster_hdl, fmat_hdl, fmat_hdl, sshap_config.c_str(),
+                                         &values_shape, &values_dim, &values, &bias_shape,
+                                         &bias_dim, &bias),
+            -1);
+
+  shap_config["algorithm"] = String{"interventional"};
+  sshap_config = Json::Dump(shap_config);
+  ASSERT_EQ(XGBoosterInterpretShapValues(booster_hdl, fmat_hdl, nullptr, sshap_config.c_str(),
+                                         &values_shape, &values_dim, &values, &bias_shape,
+                                         &bias_dim, &bias),
+            -1);
+
+  ASSERT_EQ(XGDMatrixFree(fmat_hdl), 0);
+  ASSERT_EQ(XGBoosterFree(booster_hdl), 0);
+}
 }  // namespace xgboost

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -744,23 +744,25 @@ TEST(CAPI, InterpretShapValues) {
   shap_config["iteration_end"] = Integer{0};
   auto sshap_config = Json::Dump(shap_config);
 
-  bst_ulong const *values_shape{nullptr};
-  bst_ulong values_dim{0};
-  float const *values{nullptr};
-  bst_ulong const *bias_shape{nullptr};
-  bst_ulong bias_dim{0};
-  float const *bias{nullptr};
+  char const *values{nullptr};
+  char const *bias{nullptr};
   ASSERT_EQ(XGBoosterInterpretShapValues(booster_hdl, fmat_hdl, nullptr, sshap_config.c_str(),
-                                         &values_shape, &values_dim, &values, &bias_shape,
-                                         &bias_dim, &bias),
+                                         &values, &bias),
             0);
-  ASSERT_EQ(values_dim, 3);
-  ASSERT_EQ(values_shape[0], n_samples);
-  ASSERT_EQ(values_shape[1], n_features);
-  ASSERT_EQ(values_shape[2], 1);
-  ASSERT_EQ(bias_dim, 2);
-  ASSERT_EQ(bias_shape[0], n_samples);
-  ASSERT_EQ(bias_shape[1], 1);
+  ArrayInterface<3, false> values_interface{StringView{values}};
+  ASSERT_EQ(values_interface.type, ArrayInterfaceHandler::kF4);
+  ASSERT_EQ(values_interface.Shape<0>(), n_samples);
+  ASSERT_EQ(values_interface.Shape<1>(), n_features);
+  ASSERT_EQ(values_interface.Shape<2>(), 1);
+  auto values_data = static_cast<float const *>(values_interface.data);
+  ASSERT_TRUE(values_data);
+
+  ArrayInterface<2, false> bias_interface{StringView{bias}};
+  ASSERT_EQ(bias_interface.type, ArrayInterfaceHandler::kF4);
+  ASSERT_EQ(bias_interface.Shape<0>(), n_samples);
+  ASSERT_EQ(bias_interface.Shape<1>(), 1);
+  auto bias_data = static_cast<float const *>(bias_interface.data);
+  ASSERT_TRUE(bias_data);
 
   Json pred_config{Object{}};
   pred_config["type"] = Integer{2};
@@ -782,21 +784,20 @@ TEST(CAPI, InterpretShapValues) {
 
   for (bst_idx_t row = 0; row < n_samples; ++row) {
     for (bst_idx_t feature = 0; feature < n_features; ++feature) {
-      ASSERT_EQ(values[row * n_features + feature], contribs[row * (n_features + 1) + feature]);
+      ASSERT_EQ(values_data[row * n_features + feature],
+                contribs[row * (n_features + 1) + feature]);
     }
-    ASSERT_EQ(bias[row], contribs[row * (n_features + 1) + n_features]);
+    ASSERT_EQ(bias_data[row], contribs[row * (n_features + 1) + n_features]);
   }
 
   ASSERT_EQ(XGBoosterInterpretShapValues(booster_hdl, fmat_hdl, fmat_hdl, sshap_config.c_str(),
-                                         &values_shape, &values_dim, &values, &bias_shape,
-                                         &bias_dim, &bias),
+                                         &values, &bias),
             -1);
 
   shap_config["algorithm"] = String{"interventional"};
   sshap_config = Json::Dump(shap_config);
   ASSERT_EQ(XGBoosterInterpretShapValues(booster_hdl, fmat_hdl, nullptr, sshap_config.c_str(),
-                                         &values_shape, &values_dim, &values, &bias_shape,
-                                         &bias_dim, &bias),
+                                         &values, &bias),
             -1);
 
   ASSERT_EQ(XGDMatrixFree(fmat_hdl), 0);

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -742,7 +742,6 @@ TEST(CAPI, InterpretShapValues) {
   shap_config["algorithm"] = String{"auto"};
   shap_config["iteration_begin"] = Integer{0};
   shap_config["iteration_end"] = Integer{0};
-  shap_config["strict_shape"] = Boolean{false};
   auto sshap_config = Json::Dump(shap_config);
 
   bst_ulong const *values_shape{nullptr};
@@ -755,11 +754,13 @@ TEST(CAPI, InterpretShapValues) {
                                          &values_shape, &values_dim, &values, &bias_shape,
                                          &bias_dim, &bias),
             0);
-  ASSERT_EQ(values_dim, 2);
+  ASSERT_EQ(values_dim, 3);
   ASSERT_EQ(values_shape[0], n_samples);
   ASSERT_EQ(values_shape[1], n_features);
-  ASSERT_EQ(bias_dim, 1);
+  ASSERT_EQ(values_shape[2], 1);
+  ASSERT_EQ(bias_dim, 2);
   ASSERT_EQ(bias_shape[0], n_samples);
+  ASSERT_EQ(bias_shape[1], 1);
 
   Json pred_config{Object{}};
   pred_config["type"] = Integer{2};

--- a/tests/python/test_interpret.py
+++ b/tests/python/test_interpret.py
@@ -54,7 +54,7 @@ def test_shap_values_rejects_background_data() -> None:
     y = rng.randn(16)
     booster = xgb.train({"tree_method": "hist"}, xgb.DMatrix(X, label=y), 4)
 
-    with pytest.raises(NotImplementedError, match="X_background"):
+    with pytest.raises(xgb.core.XGBoostError, match="Interventional SHAP"):
         interpret.shap_values(booster, X, X_background=X)
 
 


### PR DESCRIPTION
## Summary

This adds a dedicated C API entry point for SHAP values:

- `XGBoosterInterpretShapValues`
- separate output buffers for feature values and bias
- JSON config for interpretability options
- nullable background `DMatrixHandle` reserved for interventional SHAP
- Python `xgboost.interpret.shap_values` now routes through the new C API

The initial implementation supports the existing tree-path-dependent SHAP behavior by reusing the current contribution prediction path and splitting the final bias column into a separate output. Interventional SHAP is not implemented yet, but the C API shape now includes the background handle needed for it.

## Testing

- `pre-commit run --files include/xgboost/c_api.h src/c_api/c_api.cc src/common/api_entry.h tests/cpp/c_api/test_c_api.cc python-package/xgboost/interpret.py tests/python/test_interpret.py`
- `build-cpu/testxgboost --gtest_filter=CAPI.InterpretShapValues`
- `PYTHONPATH=/home/nfs/rorym/xgboost-wt/interpret-capi/python-package LD_LIBRARY_PATH=/home/nfs/rorym/xgboost-wt/interpret-capi/lib conda run -n xgboost python -m pytest tests/python/test_interpret.py`
