### PR TITLE
Fix locale-dependent float serialization in xgboost4j

### DIFF
--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -346,7 +347,7 @@ public class Booster implements Serializable, KryoSerializable {
       DMatrix evalMat = evalMatrixs[i];
       float evalResult = eval.eval(predict(evalMat), evalMat);
       String evalMetric = eval.getMetric();
-      evalInfo += "\t" + evalName + "-" + evalMetric + ":" + Float.toString(evalResult);
+      evalInfo += String.format(Locale.ROOT, "\t%s-%s:%f", evalName, evalMetric, evalResult);
       metricsOut[i] = evalResult;
     }
     return evalInfo;

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -346,7 +346,7 @@ public class Booster implements Serializable, KryoSerializable {
       DMatrix evalMat = evalMatrixs[i];
       float evalResult = eval.eval(predict(evalMat), evalMat);
       String evalMetric = eval.getMetric();
-      evalInfo += String.format("\t%s-%s:%f", evalName, evalMetric, evalResult);
+      evalInfo += "\t" + evalName + "-" + evalMetric + ":" + Float.toString(evalResult);
       metricsOut[i] = evalResult;
     }
     return evalInfo;

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -563,7 +563,7 @@ public class XGBoost {
         value += tvalue;
       }
       value /= cvMap.get(key).size();
-      aggResult += "\tcv-" + key + ":" + Float.toString(value);
+      aggResult += String.format(Locale.ROOT, "\tcv-%s:%f", key, value);
     }
 
     return aggResult;

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoost.java
@@ -563,7 +563,7 @@ public class XGBoost {
         value += tvalue;
       }
       value /= cvMap.get(key).size();
-      aggResult += String.format("\tcv-%s:%f", key, value);
+      aggResult += "\tcv-" + key + ":" + Float.toString(value);
     }
 
     return aggResult;


### PR DESCRIPTION
## Problem

`String.format(...)` is locale-dependent when formatting floating-point numbers.

In some locales (e.g. Germany), the decimal separator is a comma instead of a dot. This leads to inconsistent serialization of evaluation results, which are later parsed using `Float.valueOf(...)`.

This mismatch causes parsing errors when custom evaluation and cross-validation are used together.

In particular, `Booster.java` (`evalSet(...)`) generates evaluation output strings using `String.format(...)`, which are later consumed by `XGBoost.java` (`aggCVResults(...)`) and parsed back into floats.

---

## Fix

There are two places where floating-point values are serialized into strings:

- `evalSet(...)` in `Booster.java`
- `aggCVResults(...)` in `XGBoost.java`

In both locations, `String.format(...)` has been replaced with locale-independent formatting using `Float.toString(...)`.

This ensures that floating-point values are always serialized using a dot (`.`) as decimal separator, independent of the system locale.

---

## Result

- Consistent numeric serialization across all locales
- No parsing errors in `Float.valueOf(...)` in case of custom evaluation + cross-validation