### PR TITLE
[doc] Use RTD canonical URL.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -378,6 +378,9 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
+# See RTD document for the effect of using canonical URL on SEO.
+html_baseurl: str = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = "sphinx_rtd_theme"


### PR DESCRIPTION
Reference:

https://docs.readthedocs.com/platform/stable/canonical-urls.html#canonical-urls

> If canonical URLs aren’t used, it’s easy for outdated documentation to be the top search result for various pages in your documentation. This is not a perfect solution for this problem, but generally people finding outdated documentation is a big problem, and this is one of the suggested ways to solve it from search engines.


Related: https://github.com/dmlc/xgboost/issues/12242

I don't know how much impact it will have. Let's see.