### PR TITLE
Add stream-aware storage APIs for DeviceUVector and TemporaryArray

### DIFF
--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -260,23 +260,30 @@ class TemporaryArray {
  public:
   using AllocT = XGBCachingDeviceAllocator<T>;
   using value_type = T;  // NOLINT
-  explicit TemporaryArray(size_t n) : size_(n) { ptr_ = AllocT().allocate(n); }
-  TemporaryArray(size_t n, T val) : size_(n) {
-    ptr_ = AllocT().allocate(n);
-    this->fill(val);
+  explicit TemporaryArray(
+      size_t n, xgboost::curt::StreamRef stream = xgboost::curt::DefaultStream())
+      : size_(n) {
+    alloc_.SetStream(stream);
+    ptr_ = alloc_.allocate(n);
   }
-  ~TemporaryArray() { AllocT().deallocate(ptr_, this->size()); }
-  void fill(T val)  // NOLINT
+  TemporaryArray(size_t n, T val,
+                 xgboost::curt::StreamRef stream = xgboost::curt::DefaultStream())
+      : TemporaryArray{n, stream} {
+    this->fill(val, stream);
+  }
+  ~TemporaryArray() { alloc_.deallocate(ptr_, this->size()); }
+  void fill(T val, xgboost::curt::StreamRef stream = xgboost::curt::DefaultStream())  // NOLINT
   {
     int device = 0;
     dh::safe_cuda(cudaGetDevice(&device));
     auto d_data = ptr_.get();
-    LaunchN(this->size(), [=] __device__(size_t idx) { d_data[idx] = val; });
+    LaunchN(this->size(), stream, [=] __device__(size_t idx) { d_data[idx] = val; });
   }
   thrust::device_ptr<T> data() { return ptr_; }  // NOLINT
   size_t size() { return size_; }  // NOLINT
 
  private:
+  AllocT alloc_;
   thrust::device_ptr<T> ptr_;
   size_t size_;
 };

--- a/src/common/device_vector.cuh
+++ b/src/common/device_vector.cuh
@@ -273,6 +273,8 @@ class ThrustAllocMrAdapter : public rmm::mr::thrust_allocator<T> {
   ThrustAllocMrAdapter()
       : rmm::mr::thrust_allocator<T>{
             rmm::cuda_stream_view{cudaStream_t{xgboost::curt::DefaultStream()}}} {};
+
+  void SetStream([[maybe_unused]] ::xgboost::curt::StreamRef stream) {}
 };
 
 template <typename T>
@@ -290,6 +292,7 @@ class XGBAsyncPoolAllocator : public thrust::device_malloc_allocator<T> {
   // entirely on Windows.
   std::int32_t use_async_pool_;
 #endif
+  ::xgboost::curt::StreamRef stream_{::xgboost::curt::DefaultStream()};
 
  public:
   using Super = thrust::device_malloc_allocator<T>;
@@ -308,6 +311,8 @@ class XGBAsyncPoolAllocator : public thrust::device_malloc_allocator<T> {
     using other = XGBAsyncPoolAllocator<U>;  // NOLINT(readability-identifier-naming)
   };
 
+  void SetStream(::xgboost::curt::StreamRef stream) { this->stream_ = stream; }
+
   pointer allocate(std::size_t n) {  // NOLINT
 #if defined(xgboost_IS_WIN)
     return Super::allocate(n);
@@ -318,7 +323,7 @@ class XGBAsyncPoolAllocator : public thrust::device_malloc_allocator<T> {
 
     T *raw_ptr = nullptr;
     auto n_bytes = xgboost::common::SizeBytes<T>(n);
-    safe_cuda(cudaMallocAsync(&raw_ptr, n_bytes, xgboost::curt::DefaultStream()));
+    safe_cuda(cudaMallocAsync(&raw_ptr, n_bytes, this->stream_));
     return thrust::device_pointer_cast(raw_ptr);
 #endif
   }
@@ -331,7 +336,7 @@ class XGBAsyncPoolAllocator : public thrust::device_malloc_allocator<T> {
       return Super::deallocate(ptr, n);
     }
 
-    safe_cuda(cudaFreeAsync(thrust::raw_pointer_cast(ptr), xgboost::curt::DefaultStream()));
+    safe_cuda(cudaFreeAsync(thrust::raw_pointer_cast(ptr), this->stream_));
 #endif
   }
 
@@ -491,7 +496,10 @@ class DeviceUVectorImpl {
 
  public:
   DeviceUVectorImpl() = default;
-  explicit DeviceUVectorImpl(std::size_t n) { this->resize(n); }
+  explicit DeviceUVectorImpl(std::size_t n,
+                             ::xgboost::curt::StreamRef stream = ::xgboost::curt::DefaultStream()) {
+    this->resize(n, stream);
+  }
   DeviceUVectorImpl(DeviceUVectorImpl const &that) = delete;
   DeviceUVectorImpl &operator=(DeviceUVectorImpl const &that) = delete;
   DeviceUVectorImpl(DeviceUVectorImpl &&that) = default;
@@ -500,7 +508,8 @@ class DeviceUVectorImpl {
   [[nodiscard]] std::size_t Capacity() const { return this->capacity_; }
 
   // Resize without init.
-  void resize(std::size_t n) {  // NOLINT
+  void resize(std::size_t n,
+              ::xgboost::curt::StreamRef stream = ::xgboost::curt::DefaultStream()) {  // NOLINT
     using ::xgboost::common::SizeBytes;
 
     if (n <= this->Capacity()) {
@@ -510,6 +519,7 @@ class DeviceUVectorImpl {
     }
     CHECK_LE(this->size(), this->Capacity());
 
+    this->alloc_.SetStream(stream);
     Alloc alloc = this->alloc_;
     decltype(data_) new_ptr{thrust::raw_pointer_cast(this->alloc_.allocate(n)),
                             [=](T *ptr) mutable {
@@ -519,9 +529,8 @@ class DeviceUVectorImpl {
                             }};
     CHECK(new_ptr.get());
 
-    auto s = ::xgboost::curt::DefaultStream();
     safe_cuda(cudaMemcpyAsync(new_ptr.get(), this->data(), SizeBytes<T>(this->size()),
-                              cudaMemcpyDefault, s));
+                              cudaMemcpyDefault, stream));
     this->size_ = n;
     this->capacity_ = n;
 
@@ -530,17 +539,18 @@ class DeviceUVectorImpl {
     // std::swap(this->data_, new_ptr);
   }
   // Resize with init
-  void resize(std::size_t n, T const &v) {  // NOLINT
+  void resize(std::size_t n, T const &v,
+              ::xgboost::curt::StreamRef stream = ::xgboost::curt::DefaultStream()) {  // NOLINT
     auto orig = this->size();
-    this->resize(n);
+    this->resize(n, stream);
     if (orig < n) {
-      auto exec = thrust::cuda::par_nosync.on(::xgboost::curt::DefaultStream());
+      auto exec = thrust::cuda::par_nosync.on(stream);
       thrust::fill(exec, this->begin() + orig, this->end(), v);
     }
   }
 
-  void clear() {  // NOLINT
-    this->resize(0);
+  void clear(::xgboost::curt::StreamRef stream = ::xgboost::curt::DefaultStream()) {  // NOLINT
+    this->resize(0, stream);
   }
 
   [[nodiscard]] std::size_t size() const { return this->size_; }  // NOLINT

--- a/tests/cpp/common/test_device_vector.cu
+++ b/tests/cpp/common/test_device_vector.cu
@@ -5,6 +5,8 @@
 #include <thrust/iterator/counting_iterator.h>  // for make_counting_iterator
 #include <thrust/sequence.h>                    // for sequence
 
+#include <algorithm>  // for all_of
+#include <cstdint>    // for int32_t
 #include <numeric>  // for iota
 #include <thread>   // for thread
 
@@ -65,6 +67,31 @@ TEST(DeviceUVector, Basic) {
   uvec1.clear();
   ASSERT_EQ(uvec1.size(), 0);
   ASSERT_EQ(uvec1.Capacity(), 32);
+}
+
+TEST(DeviceUVector, Stream) {
+  auto ctx = xgboost::MakeCUDACtx(0);
+  xgboost::curt::Stream stream{ctx.Device().ordinal};
+  DeviceUVector<float> uvec{8, stream.View()};
+  uvec.resize(16, 1.0f, stream.View());
+
+  std::vector<float> h_vec(uvec.size());
+  dh::safe_cuda(cudaMemcpyAsync(h_vec.data(), uvec.data(), uvec.size() * sizeof(float),
+                                cudaMemcpyDeviceToHost, stream.View()));
+  stream.Sync();
+  ASSERT_TRUE(std::all_of(h_vec.cbegin() + 8, h_vec.cend(), [](float v) { return v == 1.0f; }));
+}
+
+TEST(TemporaryArray, Stream) {
+  auto ctx = xgboost::MakeCUDACtx(0);
+  xgboost::curt::Stream stream{ctx.Device().ordinal};
+  TemporaryArray<std::int32_t> arr{16, 3, stream.View()};
+
+  std::vector<std::int32_t> h_arr(arr.size());
+  dh::safe_cuda(cudaMemcpyAsync(h_arr.data(), arr.data().get(), arr.size() * sizeof(std::int32_t),
+                                cudaMemcpyDeviceToHost, stream.View()));
+  stream.Sync();
+  ASSERT_TRUE(std::all_of(h_arr.cbegin(), h_arr.cend(), [](std::int32_t v) { return v == 3; }));
 }
 
 #if defined(__linux__)


### PR DESCRIPTION
Follow up for #12122.

This adds optional CUDA stream parameters to DeviceUVector and TemporaryArray storage paths while preserving default-stream behavior for existing callers.

Changes:
- Add optional stream arguments to DeviceUVector construction, resize, and clear.
- Use the selected stream for async allocation/copy/fill paths.
- Add stream-aware TemporaryArray allocation and fill.
- Add CUDA unit coverage using a non-default curt::Stream.

Tests:
- git diff --check
- CUDA C++ tests not run locally; cmake/nvcc unavailable in my local shell.