### PR TITLE
Preserve positive Hessians in GPU fixed-point quantisation

### DIFF
--- a/src/tree/gpu_hist/quantiser.cuh
+++ b/src/tree/gpu_hist/quantiser.cuh
@@ -57,21 +57,29 @@ class GradientQuantiser {
   /* Convert fixed point representation back to floating point. */
   GradientPairPrecise to_floating_point_;
 
+  template <typename GradientPairT>
+  [[nodiscard]] XGBOOST_DEVICE GradientPairInt64
+  ToFixedPointImpl(GradientPairT const& gpair) const {
+    auto grad = static_cast<GradientPairInt64::ValueT>(gpair.GetGrad() * to_fixed_point_.GetGrad());
+    auto hess = static_cast<GradientPairInt64::ValueT>(gpair.GetHess() * to_fixed_point_.GetHess());
+    // Preserve positive curvature through fixed-point truncation.
+    if (gpair.GetHess() > 0.0 && hess == 0) {
+      hess = 1;
+    }
+    return {grad, hess};
+  }
+
  public:
   GradientQuantiser() = default;
   // Used for test
   GradientQuantiser(GradientPairPrecise to_fixed, GradientPairPrecise to_float)
       : to_fixed_point_{to_fixed}, to_floating_point_{to_float} {}
   [[nodiscard]] XGBOOST_DEVICE GradientPairInt64 ToFixedPoint(GradientPair const& gpair) const {
-    auto adjusted = GradientPairInt64(gpair.GetGrad() * to_fixed_point_.GetGrad(),
-                                      gpair.GetHess() * to_fixed_point_.GetHess());
-    return adjusted;
+    return this->ToFixedPointImpl(gpair);
   }
   [[nodiscard]] XGBOOST_DEVICE GradientPairInt64
   ToFixedPoint(GradientPairPrecise const& gpair) const {
-    auto adjusted = GradientPairInt64(gpair.GetGrad() * to_fixed_point_.GetGrad(),
-                                      gpair.GetHess() * to_fixed_point_.GetHess());
-    return adjusted;
+    return this->ToFixedPointImpl(gpair);
   }
   [[nodiscard]] XGBOOST_DEVICE GradientPairPrecise
   ToFloatingPoint(const GradientPairInt64& gpair) const {

--- a/tests/cpp/tree/gpu_hist/test_histogram.cu
+++ b/tests/cpp/tree/gpu_hist/test_histogram.cu
@@ -352,6 +352,19 @@ TEST(Histogram, Quantiser) {
     ASSERT_EQ(gh.GetGrad(), 1.0);
     ASSERT_EQ(gh.GetHess(), 1.0);
   }
+
+  GradientQuantiser hess_floor_quantiser{GradientPairPrecise{1.0, 10.0},
+                                         GradientPairPrecise{1.0, 0.1}};
+  auto tiny_hess = hess_floor_quantiser.ToFixedPoint(GradientPairPrecise{0.25, 0.05});
+  ASSERT_EQ(tiny_hess.GetQuantisedGrad(), 0);
+  ASSERT_EQ(tiny_hess.GetQuantisedHess(), 1);
+
+  auto zero_hess = hess_floor_quantiser.ToFixedPoint(GradientPairPrecise{0.25, 0.0});
+  ASSERT_EQ(zero_hess.GetQuantisedHess(), 0);
+
+  auto tiny_hess_float = hess_floor_quantiser.ToFixedPoint(GradientPair{0.25f, 0.05f});
+  ASSERT_EQ(tiny_hess_float.GetQuantisedGrad(), 0);
+  ASSERT_EQ(tiny_hess_float.GetQuantisedHess(), 1);
 }
 namespace {
 enum CacheMode {


### PR DESCRIPTION
## Summary
- Clamp positive Hessians that would truncate to zero during GPU fixed-point quantisation to one fixed-point unit.
- Keep exact zero Hessians and gradient quantisation behavior unchanged.
- Add a GPU histogram quantiser regression covering both `GradientPair` and `GradientPairPrecise`.

## Motivation
Addresses #12265.

GPU hist stores gradient pairs in fixed-point form, and downstream GPU code uses quantised Hessian zero as a meaningful state for no usable curvature / unsampled rows. Some objectives can emit tiny but positive Hessians. Fixed-point truncation can currently map these positive Hessians to zero, erasing the curvature signal before histogram construction and split evaluation.

This change preserves positive curvature with the smallest representable fixed-point Hessian.

## Notes
For affected examples, the Hessian is increased by at most one fixed-point quantum. This is conservative from an optimisation standpoint: it damps leaf weights and gains relative to losing the curvature entirely, while preserving exact zero Hessians as zero.

## Testing
- `conda run -n xgboost clang-format --dry-run --Werror src/tree/gpu_hist/quantiser.cuh tests/cpp/tree/gpu_hist/test_histogram.cu`
- `git diff --check`
- `conda run -n xgboost cmake --build /tmp/xgb-gpu-hessian-floor-20260625 --target testxgboost -j2`
- `/tmp/xgb-gpu-hessian-floor-20260625/testxgboost --gtest_filter=Histogram.Quantiser`
