### PR TITLE
Fix predict_proba for the binary:logitraw objective.

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -26,7 +26,7 @@ from typing import (
 )
 
 import numpy as np
-from scipy.special import softmax
+from scipy.special import expit, softmax
 
 from ._c_api import _parse_version, _py_version
 from ._data_utils import Categories
@@ -1908,7 +1908,7 @@ class XGBClassifier(XGBClassifierBase, XGBModel):
         # softprob:        Do nothing, output is proba.
         # softmax:         Use softmax from scipy
         # binary:logistic: Expand the prob vector into 2-class matrix after predict.
-        # binary:logitraw: Unsupported by predict_proba()
+        # binary:logitraw: Apply sigmoid to the raw logits to get probabilities (GH#11373).
         if self.objective == "multi:softmax":
             raw_predt = super().predict(
                 X=X,
@@ -1925,6 +1925,8 @@ class XGBClassifier(XGBClassifierBase, XGBModel):
             base_margin=base_margin,
             iteration_range=iteration_range,
         )
+        if self.objective == "binary:logitraw":
+            class_probs = expit(class_probs)
         return _cls_predict_proba(self.n_classes_, class_probs, np.vstack)
 
     @property

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -47,6 +47,26 @@ def test_binary_classification():
             assert err < 0.1
 
 
+def test_binary_logitraw_predict_proba_returns_probabilities():
+    # GH#11373: predict_proba must return probabilities for binary:logitraw.
+    rng_local = np.random.default_rng(seed=123)
+    X = rng_local.standard_normal(size=(100, 4))
+    y = rng_local.integers(2, size=X.shape[0])
+
+    model = xgb.XGBClassifier(objective="binary:logitraw").fit(X, y)
+    proba = model.predict_proba(X[:10])
+
+    assert proba.shape == (10, 2)
+    np.testing.assert_allclose(proba.sum(axis=1), np.ones(10), atol=1e-6)
+    assert ((proba >= 0.0) & (proba <= 1.0)).all()
+
+    # Sanity: the two columns must be sigmoid(raw) and 1 - sigmoid(raw).
+    raw = model.predict(X[:10], output_margin=True)
+    expected_class1 = 1.0 / (1.0 + np.exp(-raw))
+    np.testing.assert_allclose(proba[:, 1], expected_class1, atol=1e-6)
+    np.testing.assert_allclose(proba[:, 0], 1.0 - expected_class1, atol=1e-6)
+
+
 @pytest.mark.parametrize("objective", ["multi:softmax", "multi:softprob"])
 def test_multiclass_classification(objective):
     from sklearn.datasets import load_iris


### PR DESCRIPTION
`XGBClassifier(objective="binary:logitraw").predict_proba` returned the raw margin in the second column and `1 - margin` in the first, producing values outside `[0, 1]` and rows that did not sum to 1.

This applies a sigmoid (`scipy.special.expit`) to the raw logits before the 2-class expansion, so `predict_proba` returns valid probabilities consistent with `binary:logistic`. Added a regression test covering shape, range, and the sigmoid relationship.

Close #11373