### PR TITLE
[jvm] Fix potential leaks during error handling.

### DIFF
--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>  // for unique_ptr
+#include <numeric>  // for accumulate
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -780,11 +781,16 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
    * Create array interface.
    */
   namespace linalg = xgboost::linalg;
-  jfloat *data = jenv->GetFloatArrayElements(jdata, nullptr);
+  std::unique_ptr<jfloat, Deleter<jfloat>> data{
+      jenv->GetFloatArrayElements(jdata, nullptr), [&](jfloat *ptr) {
+        if (ptr) {
+          jenv->ReleaseFloatArrayElements(jdata, ptr, 0);
+        }
+      }};
   xgboost::Context ctx;
   auto t_data = linalg::MakeTensorView(
       ctx.Device(),
-      xgboost::common::Span{data, static_cast<std::size_t>(num_rows * num_features)}, num_rows,
+      xgboost::common::Span{data.get(), static_cast<std::size_t>(num_rows * num_features)}, num_rows,
       num_features);
   auto s_array = linalg::ArrayInterfaceStr(t_data);
 
@@ -804,13 +810,24 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
   /**
    * Handle base margin
    */
-  BoosterHandle proxy{nullptr};
-
-  float *margin{nullptr};
+  std::unique_ptr<jfloat, Deleter<jfloat>> margin{
+      nullptr, [&](jfloat *ptr) {
+        if (ptr) {
+          jenv->ReleaseFloatArrayElements(jmargin, ptr, 0);
+        }
+      }};
+  DMatrixHandle proxy{nullptr};
+  std::unique_ptr<void, Deleter<void>> proxy_guard{
+      nullptr, [](void *ptr) {
+        if (ptr) {
+          XGDMatrixFree(ptr);
+        }
+      }};
   if (jmargin) {
-    margin = jenv->GetFloatArrayElements(jmargin, nullptr);
+    margin.reset(jenv->GetFloatArrayElements(jmargin, nullptr));
     JVM_CHECK_CALL(XGProxyDMatrixCreate(&proxy));
-    auto str = xgboost::linalg::Make1dInterface(margin, jenv->GetArrayLength(jmargin));
+    proxy_guard.reset(proxy);
+    auto str = xgboost::linalg::Make1dInterface(margin.get(), jenv->GetArrayLength(jmargin));
     JVM_CHECK_CALL(XGDMatrixSetInfoFromInterface(proxy, "base_margin", str.c_str()));
   }
 
@@ -820,20 +837,14 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
   auto ret = XGBoosterPredictFromDense(handle, s_array.c_str(), s_config.c_str(), proxy, &out_shape,
                                        &out_dim, &result);
 
-  jenv->ReleaseFloatArrayElements(jdata, data, 0);
-  if (proxy) {
-    XGDMatrixFree(proxy);
-    jenv->ReleaseFloatArrayElements(jmargin, margin, 0);
-  }
-
   if (ret != 0) {
     return ret;
   }
 
-  std::size_t n{1};
-  for (std::size_t i = 0; i < out_dim; ++i) {
-    n *= out_shape[i];
-  }
+  auto n = std::accumulate(out_shape, out_shape + out_dim, std::size_t{1},
+                           [](std::size_t acc, bst_ulong dim) {
+                             return acc * static_cast<std::size_t>(dim);
+                           });
 
   jfloatArray jarray = jenv->NewFloatArray(n);
 

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -31,7 +31,6 @@
 #include <numeric>     // for accumulate
 #include <string>
 #include <type_traits>
-#include <utility>  // for move
 #include <vector>
 
 #include "../../../../src/c_api/c_api_error.h"
@@ -95,126 +94,123 @@ jobjectArray MakeJStringArray(JNIEnv *jenv, jsize len, ValuesT values) {
 }
 }  // anonymous namespace
 
-XGB_EXTERN_C int XGBoost4jCallbackDataIterNext(
-    DataIterHandle data_handle,
-    XGBCallbackSetData* set_function,
-    DataHolderHandle set_function_handle) {
+XGB_EXTERN_C int XGBoost4jCallbackDataIterNext(DataIterHandle data_handle,
+                                               XGBCallbackSetData *set_function,
+                                               DataHolderHandle set_function_handle) {
   jobject jiter = static_cast<jobject>(data_handle);
-  JNIEnv* jenv;
-  int jni_status = GlobalJvm()->GetEnv((void **)&jenv, JNI_VERSION_1_6);
+  JNIEnv *jenv;
+  int jni_status = GlobalJvm()->GetEnv(reinterpret_cast<void **>(&jenv), JNI_VERSION_1_6);
   if (jni_status == JNI_EDETACHED) {
     GlobalJvm()->AttachCurrentThread(reinterpret_cast<void **>(&jenv), nullptr);
   } else {
     CHECK(jni_status == JNI_OK);
   }
+  std::unique_ptr<JavaVM, Deleter<JavaVM>> detach_guard{
+      jni_status == JNI_EDETACHED ? GlobalJvm() : nullptr, [](JavaVM *vm) {
+        if (vm) {
+          vm->DetachCurrentThread();
+        }
+      }};
   try {
-    jclass iterClass = jenv->FindClass("java/util/Iterator");
-    jmethodID hasNext = jenv->GetMethodID(iterClass,
-                                          "hasNext", "()Z");
-    jmethodID next = jenv->GetMethodID(iterClass,
-                                       "next", "()Ljava/lang/Object;");
+    auto iterClass = MakeJniLocalRef(jenv, jenv->FindClass("java/util/Iterator"));
+    jmethodID hasNext = jenv->GetMethodID(iterClass.get(), "hasNext", "()Z");
+    jmethodID next = jenv->GetMethodID(iterClass.get(), "next", "()Ljava/lang/Object;");
     int ret_value;
     if (jenv->CallBooleanMethod(jiter, hasNext)) {
       ret_value = 1;
-      jobject batch = jenv->CallObjectMethod(jiter, next);
-      if (batch == nullptr) {
+      auto batch = MakeJniLocalRef(jenv, jenv->CallObjectMethod(jiter, next));
+      if (batch.get() == nullptr) {
         CHECK(jenv->ExceptionOccurred());
         jenv->ExceptionDescribe();
         return -1;
       }
 
-      jclass batchClass = jenv->GetObjectClass(batch);
-      jlongArray joffset = (jlongArray)jenv->GetObjectField(
-          batch, jenv->GetFieldID(batchClass, "rowOffset", "[J"));
-      jfloatArray jlabel = (jfloatArray)jenv->GetObjectField(
-          batch, jenv->GetFieldID(batchClass, "label", "[F"));
-      jfloatArray jweight = (jfloatArray)jenv->GetObjectField(
-          batch, jenv->GetFieldID(batchClass, "weight", "[F"));
-      jintArray jindex = (jintArray)jenv->GetObjectField(
-          batch, jenv->GetFieldID(batchClass, "featureIndex", "[I"));
-      jfloatArray jvalue = (jfloatArray)jenv->GetObjectField(
-          batch, jenv->GetFieldID(batchClass, "featureValue", "[F"));
-      jint jcols = jenv->GetIntField(
-          batch, jenv->GetFieldID(batchClass, "featureCols", "I"));
+      auto batchClass = MakeJniLocalRef(jenv, jenv->GetObjectClass(batch.get()));
+      auto joffset = MakeJniLocalRef(
+          jenv, static_cast<jlongArray>(jenv->GetObjectField(
+                    batch.get(), jenv->GetFieldID(batchClass.get(), "rowOffset", "[J"))));
+      auto jlabel = MakeJniLocalRef(
+          jenv, static_cast<jfloatArray>(jenv->GetObjectField(
+                    batch.get(), jenv->GetFieldID(batchClass.get(), "label", "[F"))));
+      auto jweight = MakeJniLocalRef(
+          jenv, static_cast<jfloatArray>(jenv->GetObjectField(
+                    batch.get(), jenv->GetFieldID(batchClass.get(), "weight", "[F"))));
+      auto jindex = MakeJniLocalRef(
+          jenv, static_cast<jintArray>(jenv->GetObjectField(
+                    batch.get(), jenv->GetFieldID(batchClass.get(), "featureIndex", "[I"))));
+      auto jvalue = MakeJniLocalRef(
+          jenv, static_cast<jfloatArray>(jenv->GetObjectField(
+                    batch.get(), jenv->GetFieldID(batchClass.get(), "featureValue", "[F"))));
+      jint jcols =
+          jenv->GetIntField(batch.get(), jenv->GetFieldID(batchClass.get(), "featureCols", "I"));
 
-      std::unique_ptr<XGBoostBatchCSR, Deleter<XGBoostBatchCSR>> cbatch{
-          [&] {
-            auto ptr = new XGBoostBatchCSR;
-            auto &cbatch = *ptr;
-
-            // Init
-            cbatch.size = jenv->GetArrayLength(joffset) - 1;
-            cbatch.columns = jcols;
-            cbatch.offset = reinterpret_cast<jlong *>(jenv->GetLongArrayElements(joffset, nullptr));
-
-            if (jlabel != nullptr) {
-              cbatch.label = jenv->GetFloatArrayElements(jlabel, nullptr);
-              CHECK_EQ(jenv->GetArrayLength(jlabel), static_cast<long>(cbatch.size))
-                  << "batch.label.length must equal batch.numRows()";
-            } else {
-              cbatch.label = nullptr;
+      XGBoostBatchCSR cbatch;
+      cbatch.size = jenv->GetArrayLength(joffset.get()) - 1;
+      cbatch.columns = jcols;
+      std::unique_ptr<jlong, Deleter<jlong>> offset{
+          jenv->GetLongArrayElements(joffset.get(), nullptr), [&](jlong *ptr) {
+            if (ptr) {
+              jenv->ReleaseLongArrayElements(joffset.get(), ptr, 0);
             }
-
-            if (jweight != nullptr) {
-              cbatch.weight = jenv->GetFloatArrayElements(jweight, nullptr);
-              CHECK_EQ(jenv->GetArrayLength(jweight), static_cast<long>(cbatch.size))
-                  << "batch.weight.length must equal batch.numRows()";
-            } else {
-              cbatch.weight = nullptr;
-            }
-
-            auto max_elem = cbatch.offset[cbatch.size];
-            cbatch.index = (int *)jenv->GetIntArrayElements(jindex, nullptr);
-            cbatch.value = jenv->GetFloatArrayElements(jvalue, nullptr);
-            CHECK_EQ(jenv->GetArrayLength(jindex), max_elem)
-                << "batch.index.length must equal batch.offset.back()";
-            CHECK_EQ(jenv->GetArrayLength(jvalue), max_elem)
-                << "batch.index.length must equal batch.offset.back()";
-            return ptr;
-          }(),
-          [&](XGBoostBatchCSR *ptr) {
-            auto &cbatch = *ptr;
-            jenv->ReleaseLongArrayElements(joffset, reinterpret_cast<jlong *>(cbatch.offset), 0);
-            jenv->DeleteLocalRef(joffset);
-
-            if (jlabel) {
-              jenv->ReleaseFloatArrayElements(jlabel, cbatch.label, 0);
-              jenv->DeleteLocalRef(jlabel);
-            }
-            if (jweight) {
-              jenv->ReleaseFloatArrayElements(jweight, cbatch.weight, 0);
-              jenv->DeleteLocalRef(jweight);
-            }
-
-            jenv->ReleaseIntArrayElements(jindex, (jint *)cbatch.index, 0);
-            jenv->DeleteLocalRef(jindex);
-
-            jenv->ReleaseFloatArrayElements(jvalue, cbatch.value, 0);
-            jenv->DeleteLocalRef(jvalue);
-
-            delete ptr;
           }};
+      cbatch.offset = reinterpret_cast<decltype(cbatch.offset)>(offset.get());
 
-      CHECK_EQ((*set_function)(set_function_handle, *cbatch), 0) << XGBGetLastError();
+      std::unique_ptr<jfloat, Deleter<jfloat>> label{nullptr, [&](jfloat *ptr) {
+                                                       if (ptr) {
+                                                         jenv->ReleaseFloatArrayElements(
+                                                             jlabel.get(), ptr, 0);
+                                                       }
+                                                     }};
+      if (jlabel.get() != nullptr) {
+        label.reset(jenv->GetFloatArrayElements(jlabel.get(), nullptr));
+        CHECK_EQ(jenv->GetArrayLength(jlabel.get()), static_cast<long>(cbatch.size))
+            << "batch.label.length must equal batch.numRows()";
+      }
+      cbatch.label = label.get();
 
-      jenv->DeleteLocalRef(batch);
-      jenv->DeleteLocalRef(batchClass);
+      std::unique_ptr<jfloat, Deleter<jfloat>> weight{nullptr, [&](jfloat *ptr) {
+                                                        if (ptr) {
+                                                          jenv->ReleaseFloatArrayElements(
+                                                              jweight.get(), ptr, 0);
+                                                        }
+                                                      }};
+      if (jweight.get() != nullptr) {
+        weight.reset(jenv->GetFloatArrayElements(jweight.get(), nullptr));
+        CHECK_EQ(jenv->GetArrayLength(jweight.get()), static_cast<long>(cbatch.size))
+            << "batch.weight.length must equal batch.numRows()";
+      }
+      cbatch.weight = weight.get();
+
+      auto max_elem = cbatch.offset[cbatch.size];
+      std::unique_ptr<jint, Deleter<jint>> index{
+          jenv->GetIntArrayElements(jindex.get(), nullptr), [&](jint *ptr) {
+            if (ptr) {
+              jenv->ReleaseIntArrayElements(jindex.get(), ptr, 0);
+            }
+          }};
+      cbatch.index = reinterpret_cast<int *>(index.get());
+      std::unique_ptr<jfloat, Deleter<jfloat>> value{
+          jenv->GetFloatArrayElements(jvalue.get(), nullptr), [&](jfloat *ptr) {
+            if (ptr) {
+              jenv->ReleaseFloatArrayElements(jvalue.get(), ptr, 0);
+            }
+          }};
+      cbatch.value = value.get();
+      CHECK_EQ(jenv->GetArrayLength(jindex.get()), max_elem)
+          << "batch.index.length must equal batch.offset.back()";
+      CHECK_EQ(jenv->GetArrayLength(jvalue.get()), max_elem)
+          << "batch.index.length must equal batch.offset.back()";
+
+      CHECK_EQ((*set_function)(set_function_handle, cbatch), 0) << XGBGetLastError();
 
       ret_value = 1;
     } else {
       ret_value = 0;
     }
-    jenv->DeleteLocalRef(iterClass);
-    // only detach if it is a async call.
-    if (jni_status == JNI_EDETACHED) {
-      GlobalJvm()->DetachCurrentThread();
-    }
     return ret_value;
-  } catch(dmlc::Error const& e) {
+  } catch (dmlc::Error const &e) {
     // only detach if it is a async call.
-    if (jni_status == JNI_EDETACHED) {
-      GlobalJvm()->DetachCurrentThread();
-    }
+    detach_guard.reset();
     LOG(FATAL) << e.what();
     return -1;
   }
@@ -227,7 +223,7 @@ XGB_EXTERN_C int XGBoost4jCallbackDataIterNext(
  */
 JNIEXPORT jstring JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBGetLastError(JNIEnv *jenv,
                                                                                  jclass jcls) {
-  jstring jresult = 0;
+  jstring jresult = nullptr;
   const char *result = XGBGetLastError();
   if (result) {
     jresult = jenv->NewStringUTF(result);
@@ -276,7 +272,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
 
 namespace {
 using JavaIndT =
-    std::conditional_t<std::is_convertible<jint *, std::int32_t *>::value, std::int32_t, long>;
+    std::conditional_t<std::is_convertible_v<jint *, std::int32_t *>, std::int32_t, long>;
 /**
  * \brief Create from sparse matrix.
  *
@@ -304,7 +300,7 @@ jint MakeJVMSparseInput(JNIEnv *jenv, jlongArray jindptr, jintArray jindices, jf
 
   std::string sindptr, sindices, sdata;
   CHECK_EQ(indptr.get()[nindptr - 1], nelem);
-  using IndPtrT = std::conditional_t<std::is_convertible<jlong *, long *>::value, long, long long>;
+  using IndPtrT = std::conditional_t<std::is_convertible_v<jlong *, long *>, long, long long>;
   xgboost::detail::MakeSparseFromPtr(
       static_cast<IndPtrT const *>(indptr.get()), static_cast<JavaIndT const *>(indices.get()),
       static_cast<float const *>(data.get()), nindptr, &sindptr, &sindices, &sdata);
@@ -388,11 +384,11 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
     jlongArray jout) {
   DMatrixHandle result;
   std::unique_ptr<jfloat, Deleter<jfloat>> data{
-      jenv->GetFloatArrayElements(jdata, 0),
+      jenv->GetFloatArrayElements(jdata, nullptr),
       [&](jfloat *ptr) { jenv->ReleaseFloatArrayElements(jdata, ptr, 0); }};
 
-  bst_ulong nrow = (bst_ulong)jnrow;
-  bst_ulong ncol = (bst_ulong)jncol;
+  bst_ulong nrow = static_cast<bst_ulong>(jnrow);
+  bst_ulong ncol = static_cast<bst_ulong>(jncol);
   jint ret =
       XGDMatrixCreateFromMat(static_cast<float const *>(data.get()), nrow, ncol, jmiss, &result);
   JVM_CHECK_CALL(ret);
@@ -489,7 +485,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetFloatI
       jenv->GetFloatArrayElements(jarray, nullptr),
       [&](jfloat *ptr) { jenv->ReleaseFloatArrayElements(jarray, ptr, 0); }};
 
-  bst_ulong len = (bst_ulong)jenv->GetArrayLength(jarray);
+  bst_ulong len = static_cast<bst_ulong>(jenv->GetArrayLength(jarray));
   auto str = xgboost::linalg::Make1dInterface(array.get(), len);
   return XGDMatrixSetInfoFromInterface(handle, field.get(), str.c_str());
 }
@@ -511,7 +507,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetUIntIn
   std::unique_ptr<jint, Deleter<jint>> array{
       jenv->GetIntArrayElements(jarray, nullptr),
       [&](jint *ptr) { jenv->ReleaseIntArrayElements(jarray, ptr, 0); }};
-  bst_ulong len = (bst_ulong)jenv->GetArrayLength(jarray);
+  bst_ulong len = static_cast<bst_ulong>(jenv->GetArrayLength(jarray));
   auto str = xgboost::linalg::Make1dInterface(array.get(), len);
   return XGDMatrixSetInfoFromInterface(handle, field.get(), str.c_str());
 }
@@ -531,14 +527,14 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetFloatI
         }
       }};
   bst_ulong len;
-  float *result;
-  int ret = XGDMatrixGetFloatInfo(handle, field.get(), &len, (const float **)&result);
+  float const *result;
+  int ret = XGDMatrixGetFloatInfo(handle, field.get(), &len, &result);
   JVM_CHECK_CALL(ret);
 
-  jsize jlen = (jsize)len;
+  jsize jlen = static_cast<jsize>(len);
   jfloatArray jarray = jenv->NewFloatArray(jlen);
-  jenv->SetFloatArrayRegion(jarray, 0, jlen, (jfloat *)result);
-  jenv->SetObjectArrayElement(jout, 0, (jobject)jarray);
+  jenv->SetFloatArrayRegion(jarray, 0, jlen, static_cast<jfloat const *>(result));
+  jenv->SetObjectArrayElement(jout, 0, reinterpret_cast<jobject>(jarray));
 
   return ret;
 }
@@ -558,13 +554,13 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetUIntIn
         }
       }};
   bst_ulong len;
-  unsigned int *result;
-  int ret = (jint)XGDMatrixGetUIntInfo(handle, field.get(), &len, (const unsigned int **)&result);
+  unsigned int const *result;
+  int ret = static_cast<jint>(XGDMatrixGetUIntInfo(handle, field.get(), &len, &result));
   JVM_CHECK_CALL(ret);
 
-  jsize jlen = (jsize)len;
+  jsize jlen = static_cast<jsize>(len);
   jintArray jarray = jenv->NewIntArray(jlen);
-  jenv->SetIntArrayRegion(jarray, 0, jlen, (jint *)result);
+  jenv->SetIntArrayRegion(jarray, 0, jlen, reinterpret_cast<jint const *>(result));
   jenv->SetObjectArrayElement(jout, 0, jarray);
   return ret;
 }
@@ -773,16 +769,16 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredict(
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
   auto dmat = reinterpret_cast<DMatrixHandle>(jdmat);
   bst_ulong len;
-  float *result;
+  float const *result;
   int ret =
       XGBoosterPredict(handle, dmat, joption_mask, (unsigned int)jntree_limit,
                        /* training = */ 0,  // Currently this parameter is not supported by JVM
-                       &len, (const float **)&result);
+                       &len, &result);
   JVM_CHECK_CALL(ret);
   if (len) {
-    jsize jlen = (jsize)len;
+    jsize jlen = static_cast<jsize>(len);
     jfloatArray jarray = jenv->NewFloatArray(jlen);
-    jenv->SetFloatArrayRegion(jarray, 0, jlen, (jfloat *)result);
+    jenv->SetFloatArrayRegion(jarray, 0, jlen, result);
     jenv->SetObjectArrayElement(jout, 0, jarray);
   }
   return ret;
@@ -949,7 +945,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSaveModel
   JVM_CHECK_CALL(ret);
   if (result) {
     jbyteArray jarray = jenv->NewByteArray(len);
-    jenv->SetByteArrayRegion(jarray, 0, len, (jbyte *)result);
+    jenv->SetByteArrayRegion(jarray, 0, len, reinterpret_cast<jbyte const *>(result));
     jenv->SetObjectArrayElement(jout, 0, jarray);
   }
   return ret;
@@ -1095,7 +1091,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetAttr(
   }
 
   return ret;
-};
+}
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
@@ -1319,7 +1315,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorGetWor
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorAllreduce(
     JNIEnv *jenv, jclass jcls, jobject jsendrecvbuf, jint jcount, jint jenum_dtype, jint jenum_op) {
   void *ptr_sendrecvbuf = jenv->GetDirectBufferAddress(jsendrecvbuf);
-  JVM_CHECK_CALL(XGCommunicatorAllreduce(ptr_sendrecvbuf, (size_t)jcount, jenum_dtype, jenum_op));
+  JVM_CHECK_CALL(
+      XGCommunicatorAllreduce(ptr_sendrecvbuf, static_cast<size_t>(jcount), jenum_dtype, jenum_op));
   return 0;
 }
 
@@ -1467,7 +1464,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetStrFea
   std::unique_ptr<char const, Deleter<char const>> field{
       jenv->GetStringUTFChars(jfield, nullptr),
       [&](char const *ptr) { jenv->ReleaseStringUTFChars(jfield, ptr); }};
-  bst_ulong feature_num = (bst_ulong)jenv->GetArrayLength(jfeatures);
+  bst_ulong feature_num = static_cast<bst_ulong>(jenv->GetArrayLength(jfeatures));
 
   std::vector<std::string> features;
   std::vector<char const *> features_char;
@@ -1484,8 +1481,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetStrFea
     features.emplace_back(s.get(), jenv->GetStringLength(jfeature.get()));
   }
 
-  for (size_t i = 0; i < features.size(); ++i) {
-    features_char.push_back(features[i].c_str());
+  for (auto const &feature : features) {
+    features_char.push_back(feature.c_str());
   }
 
   return XGBoosterSetStrFeatureInfo(handle, field.get(), dmlc::BeginPtr(features_char),
@@ -1504,7 +1501,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetStrFea
       jenv->GetStringUTFChars(jfield, nullptr),
       [&](char const *ptr) { jenv->ReleaseStringUTFChars(jfield, ptr); }};
 
-  bst_ulong feature_num = (bst_ulong)jenv->GetArrayLength(jout);
+  bst_ulong feature_num = static_cast<bst_ulong>(jenv->GetArrayLength(jout));
 
   const char **features;
   std::vector<char *> features_char;

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -225,10 +225,10 @@ XGB_EXTERN_C int XGBoost4jCallbackDataIterNext(
  * Method:    XGBGetLastError
  * Signature: ()Ljava/lang/String;
  */
-JNIEXPORT jstring JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBGetLastError
-  (JNIEnv *jenv, jclass jcls) {
+JNIEXPORT jstring JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBGetLastError(JNIEnv *jenv,
+                                                                                 jclass jcls) {
   jstring jresult = 0;
-  const char* result = XGBGetLastError();
+  const char *result = XGBGetLastError();
   if (result) {
     jresult = jenv->NewStringUTF(result);
   }
@@ -240,19 +240,18 @@ JNIEXPORT jstring JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBGetLastError
  * Method:    XGDMatrixCreateFromDataIter
  * Signature: (Ljava/util/Iterator;Ljava/lang/String;[J)I
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromDataIter
-  (JNIEnv *jenv, jclass jcls, jobject jiter, jstring jcache_info, jfloat jmissing, jlongArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromDataIter(
+    JNIEnv *jenv, jclass jcls, jobject jiter, jstring jcache_info, jfloat jmissing,
+    jlongArray jout) {
   DMatrixHandle result;
   std::unique_ptr<char const, Deleter<char const>> cache_info;
   if (jcache_info != nullptr) {
-    cache_info = {jenv->GetStringUTFChars(jcache_info, nullptr), [&](char const *ptr) {
-                    jenv->ReleaseStringUTFChars(jcache_info, ptr);
-                  }};
+    cache_info = {jenv->GetStringUTFChars(jcache_info, nullptr),
+                  [&](char const *ptr) { jenv->ReleaseStringUTFChars(jcache_info, ptr); }};
   }
   auto missing = static_cast<float>(jmissing);
-  int ret =
-      XGDMatrixCreateFromDataIter(jiter, XGBoost4jCallbackDataIterNext, cache_info.get(),
-                                  missing,&result);
+  int ret = XGDMatrixCreateFromDataIter(jiter, XGBoost4jCallbackDataIterNext, cache_info.get(),
+                                        missing, &result);
   JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   return ret;
@@ -265,10 +264,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromFile(
     JNIEnv *jenv, jclass jcls, jstring jfname, jint jsilent, jlongArray jout) {
-  std::unique_ptr<char const, Deleter<char const>> fname{jenv->GetStringUTFChars(jfname, nullptr),
-                                                         [&](char const *ptr) {
-                                                           jenv->ReleaseStringUTFChars(jfname, ptr);
-                                                         }};
+  std::unique_ptr<char const, Deleter<char const>> fname{
+      jenv->GetStringUTFChars(jfname, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(jfname, ptr); }};
   DMatrixHandle result;
   int ret = XGDMatrixCreateFromFile(fname.get(), jsilent, &result);
   JVM_CHECK_CALL(ret);
@@ -291,18 +289,15 @@ jint MakeJVMSparseInput(JNIEnv *jenv, jlongArray jindptr, jintArray jindices, jf
                         jfloat jmissing, jint jnthread, Fn &&maker, jlongArray jout) {
   DMatrixHandle result;
 
-  std::unique_ptr<jlong, Deleter<jlong>> indptr{jenv->GetLongArrayElements(jindptr, nullptr),
-                                                [&](jlong *ptr) {
-                                                  jenv->ReleaseLongArrayElements(jindptr, ptr, 0);
-                                                }};
-  std::unique_ptr<jint, Deleter<jint>> indices{jenv->GetIntArrayElements(jindices, nullptr),
-                                               [&](jint *ptr) {
-                                                 jenv->ReleaseIntArrayElements(jindices, ptr, 0);
-                                               }};
-  std::unique_ptr<jfloat, Deleter<jfloat>> data{jenv->GetFloatArrayElements(jdata, nullptr),
-                                                [&](jfloat *ptr) {
-                                                  jenv->ReleaseFloatArrayElements(jdata, ptr, 0);
-                                                }};
+  std::unique_ptr<jlong, Deleter<jlong>> indptr{
+      jenv->GetLongArrayElements(jindptr, nullptr),
+      [&](jlong *ptr) { jenv->ReleaseLongArrayElements(jindptr, ptr, 0); }};
+  std::unique_ptr<jint, Deleter<jint>> indices{
+      jenv->GetIntArrayElements(jindices, nullptr),
+      [&](jint *ptr) { jenv->ReleaseIntArrayElements(jindices, ptr, 0); }};
+  std::unique_ptr<jfloat, Deleter<jfloat>> data{
+      jenv->GetFloatArrayElements(jdata, nullptr),
+      [&](jfloat *ptr) { jenv->ReleaseFloatArrayElements(jdata, ptr, 0); }};
 
   bst_ulong nindptr = static_cast<bst_ulong>(jenv->GetArrayLength(jindptr));
   bst_ulong nelem = static_cast<bst_ulong>(jenv->GetArrayLength(jdata));
@@ -371,29 +366,30 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
  * Method:    XGDMatrixCreateFromMatRef
  * Signature: (JIIF)J
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromMatRef
-  (JNIEnv *jenv, jclass jcls, jlong jdataRef, jint jnrow, jint jncol, jfloat jmiss, jlongArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromMatRef(
+    JNIEnv *jenv, jclass jcls, jlong jdataRef, jint jnrow, jint jncol, jfloat jmiss,
+    jlongArray jout) {
   DMatrixHandle result;
   bst_ulong nrow = (bst_ulong)jnrow;
   bst_ulong ncol = (bst_ulong)jncol;
-  jint ret = (jint) XGDMatrixCreateFromMat((float const *)jdataRef, nrow, ncol, jmiss, &result);
+  jint ret = (jint)XGDMatrixCreateFromMat((float const *)jdataRef, nrow, ncol, jmiss, &result);
   JVM_CHECK_CALL(ret);
   setHandle(jenv, jout, result);
   return ret;
 }
-
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGDMatrixCreateFromMat
  * Signature: ([FIIF)J
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromMat
-  (JNIEnv *jenv, jclass jcls, jfloatArray jdata, jint jnrow, jint jncol, jfloat jmiss, jlongArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromMat(
+    JNIEnv *jenv, jclass jcls, jfloatArray jdata, jint jnrow, jint jncol, jfloat jmiss,
+    jlongArray jout) {
   DMatrixHandle result;
-  std::unique_ptr<jfloat, Deleter<jfloat>> data{jenv->GetFloatArrayElements(jdata, 0), [&](jfloat* ptr) {
-    jenv->ReleaseFloatArrayElements(jdata, ptr, 0);
-  }};
+  std::unique_ptr<jfloat, Deleter<jfloat>> data{
+      jenv->GetFloatArrayElements(jdata, 0),
+      [&](jfloat *ptr) { jenv->ReleaseFloatArrayElements(jdata, ptr, 0); }};
 
   bst_ulong nrow = (bst_ulong)jnrow;
   bst_ulong ncol = (bst_ulong)jncol;
@@ -727,27 +723,27 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterTrainOneI
  * Method:    XGBoosterEvalOneIter
  * Signature: (JI[J[Ljava/lang/String;)Ljava/lang/String;
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterEvalOneIter
-  (JNIEnv *jenv, jclass jcls, jlong jhandle, jint jiter, jlongArray jdmats, jobjectArray jevnames, jobjectArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterEvalOneIter(
+    JNIEnv *jenv, jclass jcls, jlong jhandle, jint jiter, jlongArray jdmats, jobjectArray jevnames,
+    jobjectArray jout) {
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
   std::vector<DMatrixHandle> dmats;
   std::vector<std::string> evnames;
-  std::vector<const char*> evchars;
+  std::vector<const char *> evchars;
 
-  size_t len =  static_cast<size_t>(jenv->GetArrayLength(jdmats));
+  size_t len = static_cast<size_t>(jenv->GetArrayLength(jdmats));
   // put handle from jhandles to chandles
   std::unique_ptr<jlong, Deleter<jlong>> cjdmats{
-      jenv->GetLongArrayElements(jdmats, nullptr), [&](jlong *ptr) {
-        jenv->ReleaseLongArrayElements(jdmats, ptr, 0);
-      }};
+      jenv->GetLongArrayElements(jdmats, nullptr),
+      [&](jlong *ptr) { jenv->ReleaseLongArrayElements(jdmats, ptr, 0); }};
   for (size_t i = 0; i < len; ++i) {
     dmats.push_back(reinterpret_cast<DMatrixHandle>(cjdmats.get()[i]));
-    jstring jevname = (jstring)jenv->GetObjectArrayElement(jevnames, i);
-    std::unique_ptr<char const, Deleter<char const>> s{jenv->GetStringUTFChars(jevname, nullptr),
-                                                       [&](char const *ptr) {
-                                                         jenv->ReleaseStringUTFChars(jevname, ptr);
-                                                       }};
-    evnames.emplace_back(s.get(), jenv->GetStringLength(jevname));
+    auto jevname =
+        MakeJniLocalRef(jenv, static_cast<jstring>(jenv->GetObjectArrayElement(jevnames, i)));
+    std::unique_ptr<char const, Deleter<char const>> s{
+        jenv->GetStringUTFChars(jevname.get(), nullptr),
+        [&](char const *ptr) { jenv->ReleaseStringUTFChars(jevname.get(), ptr); }};
+    evnames.emplace_back(s.get(), jenv->GetStringLength(jevname.get()));
   }
 
   for (size_t i = 0; i < len; ++i) {
@@ -757,11 +753,12 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterEvalOneIt
   int ret = XGBoosterEvalOneIter(handle, jiter, dmlc::BeginPtr(dmats), dmlc::BeginPtr(evchars), len,
                                  &result);
   JVM_CHECK_CALL(ret);
-  jstring jinfo = nullptr;
   if (result != nullptr) {
-    jinfo = jenv->NewStringUTF(result);
+    auto jinfo = MakeJniLocalRef(jenv, jenv->NewStringUTF(result));
+    jenv->SetObjectArrayElement(jout, 0, jinfo.get());
+  } else {
+    jenv->SetObjectArrayElement(jout, 0, nullptr);
   }
-  jenv->SetObjectArrayElement(jout, 0, jinfo);
   return ret;
 }
 

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -43,7 +43,7 @@
 // set handle
 void setHandle(JNIEnv *jenv, jlongArray jhandle, void *handle) {
 #ifdef __APPLE__
-  jlong out = (long)handle;
+  jlong out = (long)handle;  // NOLINT
 #else
   int64_t out = (int64_t)handle;
 #endif
@@ -163,7 +163,7 @@ XGB_EXTERN_C int XGBoost4jCallbackDataIterNext(DataIterHandle data_handle,
                                                      }};
       if (jlabel.get() != nullptr) {
         label.reset(jenv->GetFloatArrayElements(jlabel.get(), nullptr));
-        CHECK_EQ(jenv->GetArrayLength(jlabel.get()), static_cast<long>(cbatch.size))
+        CHECK_EQ(jenv->GetArrayLength(jlabel.get()), static_cast<long>(cbatch.size))  // NOLINT
             << "batch.label.length must equal batch.numRows()";
       }
       cbatch.label = label.get();
@@ -176,7 +176,7 @@ XGB_EXTERN_C int XGBoost4jCallbackDataIterNext(DataIterHandle data_handle,
                                                       }};
       if (jweight.get() != nullptr) {
         weight.reset(jenv->GetFloatArrayElements(jweight.get(), nullptr));
-        CHECK_EQ(jenv->GetArrayLength(jweight.get()), static_cast<long>(cbatch.size))
+        CHECK_EQ(jenv->GetArrayLength(jweight.get()), static_cast<long>(cbatch.size))  // NOLINT
             << "batch.weight.length must equal batch.numRows()";
       }
       cbatch.weight = weight.get();
@@ -271,8 +271,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
 }
 
 namespace {
-using JavaIndT =
-    std::conditional_t<std::is_convertible_v<jint *, std::int32_t *>, std::int32_t, long>;
+using JavaIndT = std::conditional_t<std::is_convertible_v<jint *, std::int32_t *>, std::int32_t,
+                                    long>;  // NOLINT
 /**
  * \brief Create from sparse matrix.
  *
@@ -300,7 +300,8 @@ jint MakeJVMSparseInput(JNIEnv *jenv, jlongArray jindptr, jintArray jindices, jf
 
   std::string sindptr, sindices, sdata;
   CHECK_EQ(indptr.get()[nindptr - 1], nelem);
-  using IndPtrT = std::conditional_t<std::is_convertible_v<jlong *, long *>, long, long long>;
+  using IndPtrT =
+      std::conditional_t<std::is_convertible_v<jlong *, long *>, long, long long>;  // NOLINT
   xgboost::detail::MakeSparseFromPtr(
       static_cast<IndPtrT const *>(indptr.get()), static_cast<JavaIndT const *>(indices.get()),
       static_cast<float const *>(data.get()), nindptr, &sindptr, &sindices, &sdata);
@@ -406,7 +407,7 @@ auto SliceDMatrixWinWar(DMatrixHandle handle, T *ptr, std::size_t len, DMatrixHa
 }
 
 template <>
-auto SliceDMatrixWinWar<long>(DMatrixHandle handle, long *ptr, std::size_t len,
+auto SliceDMatrixWinWar<long>(DMatrixHandle handle, long *ptr, std::size_t len,  // NOLINT
                               DMatrixHandle *result) {
   std::vector<std::int32_t> copy(len);
   std::copy_n(ptr, len, copy.begin());

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -26,17 +26,19 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <memory>  // for unique_ptr
-#include <numeric>  // for accumulate
+#include <functional>  // for function
+#include <memory>      // for unique_ptr
+#include <numeric>     // for accumulate
 #include <string>
 #include <type_traits>
+#include <utility>  // for move
 #include <vector>
 
-#include "jvm_utils.h"  // for JVM_CHECK_CALL
 #include "../../../../src/c_api/c_api_error.h"
 #include "../../../../src/c_api/c_api_utils.h"
-#include "../../../../src/data/array_interface.h"  // for ArrayInterface
 #include "../../../../src/common/cuda_rt_utils.h"  // for xgboost::curt::SetDevice
+#include "../../../../src/data/array_interface.h"  // for ArrayInterface
+#include "jvm_utils.h"                             // for JVM_CHECK_CALL
 
 // helper functions
 // set handle
@@ -49,13 +51,13 @@ void setHandle(JNIEnv *jenv, jlongArray jhandle, void *handle) {
   jenv->SetLongArrayRegion(jhandle, 0, 1, &out);
 }
 
-JavaVM*& GlobalJvm() {
-  static JavaVM* vm;
+JavaVM *&GlobalJvm() {
+  static JavaVM *vm;
   return vm;
 }
 
 // Global device id for CUDA, -1 means not set yet
-std::int32_t& GlobalDeviceId() {
+std::int32_t &GlobalDeviceId() {
   static std::int32_t device_id = -1;
   return device_id;
 }
@@ -69,6 +71,28 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
 namespace {
 template <typename T>
 using Deleter = std::function<void(T *)>;
+
+template <typename T>
+auto MakeJniLocalRef(JNIEnv *jenv, T ref) {
+  using RawT = std::remove_pointer_t<T>;
+  return std::unique_ptr<RawT, Deleter<RawT>>{ref, [jenv](RawT *ptr) {
+                                                if (ptr) {
+                                                  jenv->DeleteLocalRef(ptr);
+                                                }
+                                              }};
+}
+
+template <typename ValuesT>
+jobjectArray MakeJStringArray(JNIEnv *jenv, jsize len, ValuesT values) {
+  auto string_cls = MakeJniLocalRef(jenv, jenv->FindClass("java/lang/String"));
+  auto empty = MakeJniLocalRef(jenv, jenv->NewStringUTF(""));
+  auto out = MakeJniLocalRef(jenv, jenv->NewObjectArray(len, string_cls.get(), empty.get()));
+  for (jsize i = 0; i < len; ++i) {
+    auto value = MakeJniLocalRef(jenv, jenv->NewStringUTF(values[i]));
+    jenv->SetObjectArrayElement(out.get(), i, value.get());
+  }
+  return out.release();
+}
 }  // anonymous namespace
 
 XGB_EXTERN_C int XGBoost4jCallbackDataIterNext(
@@ -390,7 +414,8 @@ auto SliceDMatrixWinWar(DMatrixHandle handle, T *ptr, std::size_t len, DMatrixHa
 }
 
 template <>
-auto SliceDMatrixWinWar<long>(DMatrixHandle handle, long *ptr, std::size_t len, DMatrixHandle *result) {
+auto SliceDMatrixWinWar<long>(DMatrixHandle handle, long *ptr, std::size_t len,
+                              DMatrixHandle *result) {
   std::vector<std::int32_t> copy(len);
   std::copy_n(ptr, len, copy.begin());
   // default to not allowing slicing with group ID specified -- feel free to add if necessary
@@ -408,10 +433,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSliceDMat
   DMatrixHandle result;
   auto handle = reinterpret_cast<DMatrixHandle>(jhandle);
 
-  std::unique_ptr<jint, Deleter<jint>> indexset{jenv->GetIntArrayElements(jindexset, nullptr),
-                                                [&](jint *ptr) {
-                                                  jenv->ReleaseIntArrayElements(jindexset, ptr, 0);
-                                                }};
+  std::unique_ptr<jint, Deleter<jint>> indexset{
+      jenv->GetIntArrayElements(jindexset, nullptr),
+      [&](jint *ptr) { jenv->ReleaseIntArrayElements(jindexset, ptr, 0); }};
   auto len = static_cast<bst_ulong>(jenv->GetArrayLength(jindexset));
   auto ret = SliceDMatrixWinWar(handle, indexset.get(), len, &result);
   JVM_CHECK_CALL(ret);
@@ -424,9 +448,10 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSliceDMat
  * Method:    XGDMatrixFree
  * Signature: (J)V
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixFree
-  (JNIEnv *jenv, jclass jcls, jlong jhandle) {
-  DMatrixHandle handle = (DMatrixHandle) jhandle;
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixFree(JNIEnv *jenv,
+                                                                            jclass jcls,
+                                                                            jlong jhandle) {
+  DMatrixHandle handle = (DMatrixHandle)jhandle;
   int ret = XGDMatrixFree(handle);
   return ret;
 }
@@ -464,10 +489,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetFloatI
           jenv->ReleaseStringUTFChars(jfield, ptr);
         }
       }};
-  std::unique_ptr<jfloat, Deleter<jfloat>> array{jenv->GetFloatArrayElements(jarray, nullptr),
-                                                 [&](jfloat *ptr) {
-                                                   jenv->ReleaseFloatArrayElements(jarray, ptr, 0);
-                                                 }};
+  std::unique_ptr<jfloat, Deleter<jfloat>> array{
+      jenv->GetFloatArrayElements(jarray, nullptr),
+      [&](jfloat *ptr) { jenv->ReleaseFloatArrayElements(jarray, ptr, 0); }};
 
   bst_ulong len = (bst_ulong)jenv->GetArrayLength(jarray);
   auto str = xgboost::linalg::Make1dInterface(array.get(), len);
@@ -479,8 +503,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetFloatI
  * Method:    XGDMatrixSetUIntInfo
  * Signature: (JLjava/lang/String;[I)V
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetUIntInfo
-  (JNIEnv *jenv, jclass jcls, jlong jhandle, jstring jfield, jintArray jarray) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetUIntInfo(
+    JNIEnv *jenv, jclass jcls, jlong jhandle, jstring jfield, jintArray jarray) {
   auto handle = reinterpret_cast<DMatrixHandle>(jhandle);
   std::unique_ptr<char const, Deleter<char const>> field{
       jenv->GetStringUTFChars(jfield, nullptr), [&](char const *ptr) {
@@ -488,10 +512,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetUIntIn
           jenv->ReleaseStringUTFChars(jfield, ptr);
         }
       }};
-  std::unique_ptr<jint, Deleter<jint>> array{jenv->GetIntArrayElements(jarray, nullptr),
-                                             [&](jint *ptr) {
-                                               jenv->ReleaseIntArrayElements(jarray, ptr, 0);
-                                             }};
+  std::unique_ptr<jint, Deleter<jint>> array{
+      jenv->GetIntArrayElements(jarray, nullptr),
+      [&](jint *ptr) { jenv->ReleaseIntArrayElements(jarray, ptr, 0); }};
   bst_ulong len = (bst_ulong)jenv->GetArrayLength(jarray);
   auto str = xgboost::linalg::Make1dInterface(array.get(), len);
   return XGDMatrixSetInfoFromInterface(handle, field.get(), str.c_str());
@@ -502,8 +525,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetUIntIn
  * Method:    XGDMatrixGetFloatInfo
  * Signature: (JLjava/lang/String;)[F
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetFloatInfo
-  (JNIEnv *jenv, jclass jcls, jlong jhandle, jstring jfield, jobjectArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetFloatInfo(
+    JNIEnv *jenv, jclass jcls, jlong jhandle, jstring jfield, jobjectArray jout) {
   auto handle = reinterpret_cast<DMatrixHandle>(jhandle);
   std::unique_ptr<char const, Deleter<char const>> field{
       jenv->GetStringUTFChars(jfield, nullptr), [&](char const *ptr) {
@@ -513,13 +536,13 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetFloatI
       }};
   bst_ulong len;
   float *result;
-  int ret = XGDMatrixGetFloatInfo(handle, field.get(), &len, (const float**) &result);
+  int ret = XGDMatrixGetFloatInfo(handle, field.get(), &len, (const float **)&result);
   JVM_CHECK_CALL(ret);
 
-  jsize jlen = (jsize) len;
+  jsize jlen = (jsize)len;
   jfloatArray jarray = jenv->NewFloatArray(jlen);
-  jenv->SetFloatArrayRegion(jarray, 0, jlen, (jfloat *) result);
-  jenv->SetObjectArrayElement(jout, 0, (jobject) jarray);
+  jenv->SetFloatArrayRegion(jarray, 0, jlen, (jfloat *)result);
+  jenv->SetObjectArrayElement(jout, 0, (jobject)jarray);
 
   return ret;
 }
@@ -529,8 +552,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetFloatI
  * Method:    XGDMatrixGetUIntInfo
  * Signature: (JLjava/lang/String;)[I
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetUIntInfo
-  (JNIEnv *jenv, jclass jcls, jlong jhandle, jstring jfield, jobjectArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetUIntInfo(
+    JNIEnv *jenv, jclass jcls, jlong jhandle, jstring jfield, jobjectArray jout) {
   auto handle = reinterpret_cast<DMatrixHandle>(jhandle);
   std::unique_ptr<char const, Deleter<char const>> field{
       jenv->GetStringUTFChars(jfield, nullptr), [&](char const *ptr) {
@@ -543,9 +566,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetUIntIn
   int ret = (jint)XGDMatrixGetUIntInfo(handle, field.get(), &len, (const unsigned int **)&result);
   JVM_CHECK_CALL(ret);
 
-  jsize jlen = (jsize) len;
+  jsize jlen = (jsize)len;
   jintArray jarray = jenv->NewIntArray(jlen);
-  jenv->SetIntArrayRegion(jarray, 0, jlen, (jint *) result);
+  jenv->SetIntArrayRegion(jarray, 0, jlen, (jint *)result);
   jenv->SetObjectArrayElement(jout, 0, jarray);
   return ret;
 }
@@ -555,13 +578,15 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetUIntIn
  * Method:    XGDMatrixNumRow
  * Signature: (J)J
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixNumRow
-  (JNIEnv *jenv, jclass jcls, jlong jhandle, jlongArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixNumRow(JNIEnv *jenv,
+                                                                              jclass jcls,
+                                                                              jlong jhandle,
+                                                                              jlongArray jout) {
   auto handle = reinterpret_cast<DMatrixHandle>(jhandle);
   bst_ulong result[1];
-  int ret = (jint) XGDMatrixNumRow(handle, result);
+  int ret = (jint)XGDMatrixNumRow(handle, result);
   JVM_CHECK_CALL(ret);
-  jenv->SetLongArrayRegion(jout, 0, 1, (const jlong *) result);
+  jenv->SetLongArrayRegion(jout, 0, 1, (const jlong *)result);
   return ret;
 }
 
@@ -587,15 +612,16 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixNumNonMis
  * Method:    XGBoosterCreate
  * Signature: ([J)J
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterCreate
-  (JNIEnv *jenv, jclass jcls, jlongArray jhandles, jlongArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterCreate(JNIEnv *jenv,
+                                                                              jclass jcls,
+                                                                              jlongArray jhandles,
+                                                                              jlongArray jout) {
   std::vector<DMatrixHandle> handles;
   if (jhandles != nullptr) {
     size_t len = jenv->GetArrayLength(jhandles);
     std::unique_ptr<jlong, Deleter<jlong>> cjhandles{
-        jenv->GetLongArrayElements(jhandles, nullptr), [&](jlong *ptr) {
-          jenv->ReleaseLongArrayElements(jhandles, ptr, 0);
-        }};
+        jenv->GetLongArrayElements(jhandles, nullptr),
+        [&](jlong *ptr) { jenv->ReleaseLongArrayElements(jhandles, ptr, 0); }};
     for (size_t i = 0; i < len; ++i) {
       handles.push_back(reinterpret_cast<DMatrixHandle>(cjhandles.get()[i]));
     }
@@ -649,8 +675,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetParam(
  * Method:    XGBoosterUpdateOneIter
  * Signature: (JIJ)V
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterUpdateOneIter
-  (JNIEnv *jenv, jclass jcls, jlong jhandle, jint jiter, jlong jdtrain) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterUpdateOneIter(
+    JNIEnv *jenv, jclass jcls, jlong jhandle, jint jiter, jlong jdtrain) {
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
   auto dtrain = reinterpret_cast<DMatrixHandle>(jdtrain);
   return XGBoosterUpdateOneIter(handle, jiter, dtrain);
@@ -673,14 +699,12 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterTrainOneI
   JVM_CHECK_CALL(XGDMatrixNumRow(dtrain, &n_samples));
 
   bst_ulong len = static_cast<bst_ulong>(jenv->GetArrayLength(jgrad));
-  std::unique_ptr<jfloat, Deleter<jfloat>> grad{jenv->GetFloatArrayElements(jgrad, nullptr),
-                                                [&](jfloat *ptr) {
-                                                  jenv->ReleaseFloatArrayElements(jgrad, ptr, 0);
-                                                }};
-  std::unique_ptr<jfloat, Deleter<jfloat>> hess{jenv->GetFloatArrayElements(jhess, nullptr),
-                                                [&](jfloat *ptr) {
-                                                  jenv->ReleaseFloatArrayElements(jhess, ptr, 0);
-                                                }};
+  std::unique_ptr<jfloat, Deleter<jfloat>> grad{
+      jenv->GetFloatArrayElements(jgrad, nullptr),
+      [&](jfloat *ptr) { jenv->ReleaseFloatArrayElements(jgrad, ptr, 0); }};
+  std::unique_ptr<jfloat, Deleter<jfloat>> hess{
+      jenv->GetFloatArrayElements(jhess, nullptr),
+      [&](jfloat *ptr) { jenv->ReleaseFloatArrayElements(jhess, ptr, 0); }};
   CHECK(grad);
   CHECK(hess);
 
@@ -746,20 +770,22 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterEvalOneIt
  * Method:    XGBoosterPredict
  * Signature: (JJIJ)[F
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredict
-  (JNIEnv *jenv, jclass jcls, jlong jhandle, jlong jdmat, jint joption_mask, jint jntree_limit, jobjectArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredict(
+    JNIEnv *jenv, jclass jcls, jlong jhandle, jlong jdmat, jint joption_mask, jint jntree_limit,
+    jobjectArray jout) {
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
   auto dmat = reinterpret_cast<DMatrixHandle>(jdmat);
   bst_ulong len;
   float *result;
-  int ret = XGBoosterPredict(handle, dmat, joption_mask, (unsigned int) jntree_limit,
-                             /* training = */ 0,  // Currently this parameter is not supported by JVM
-                             &len, (const float **) &result);
+  int ret =
+      XGBoosterPredict(handle, dmat, joption_mask, (unsigned int)jntree_limit,
+                       /* training = */ 0,  // Currently this parameter is not supported by JVM
+                       &len, (const float **)&result);
   JVM_CHECK_CALL(ret);
   if (len) {
-    jsize jlen = (jsize) len;
+    jsize jlen = (jsize)len;
     jfloatArray jarray = jenv->NewFloatArray(jlen);
-    jenv->SetFloatArrayRegion(jarray, 0, jlen, (jfloat *) result);
+    jenv->SetFloatArrayRegion(jarray, 0, jlen, (jfloat *)result);
     jenv->SetObjectArrayElement(jout, 0, jarray);
   }
   return ret;
@@ -781,17 +807,17 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
    * Create array interface.
    */
   namespace linalg = xgboost::linalg;
-  std::unique_ptr<jfloat, Deleter<jfloat>> data{
-      jenv->GetFloatArrayElements(jdata, nullptr), [&](jfloat *ptr) {
-        if (ptr) {
-          jenv->ReleaseFloatArrayElements(jdata, ptr, 0);
-        }
-      }};
+  std::unique_ptr<jfloat, Deleter<jfloat>> data{jenv->GetFloatArrayElements(jdata, nullptr),
+                                                [&](jfloat *ptr) {
+                                                  if (ptr) {
+                                                    jenv->ReleaseFloatArrayElements(jdata, ptr, 0);
+                                                  }
+                                                }};
   xgboost::Context ctx;
   auto t_data = linalg::MakeTensorView(
       ctx.Device(),
-      xgboost::common::Span{data.get(), static_cast<std::size_t>(num_rows * num_features)}, num_rows,
-      num_features);
+      xgboost::common::Span{data.get(), static_cast<std::size_t>(num_rows * num_features)},
+      num_rows, num_features);
   auto s_array = linalg::ArrayInterfaceStr(t_data);
 
   /**
@@ -810,19 +836,18 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
   /**
    * Handle base margin
    */
-  std::unique_ptr<jfloat, Deleter<jfloat>> margin{
-      nullptr, [&](jfloat *ptr) {
-        if (ptr) {
-          jenv->ReleaseFloatArrayElements(jmargin, ptr, 0);
-        }
-      }};
+  std::unique_ptr<jfloat, Deleter<jfloat>> margin{nullptr, [&](jfloat *ptr) {
+                                                    if (ptr) {
+                                                      jenv->ReleaseFloatArrayElements(jmargin, ptr,
+                                                                                      0);
+                                                    }
+                                                  }};
   DMatrixHandle proxy{nullptr};
-  std::unique_ptr<void, Deleter<void>> proxy_guard{
-      nullptr, [](void *ptr) {
-        if (ptr) {
-          XGDMatrixFree(ptr);
-        }
-      }};
+  std::unique_ptr<void, Deleter<void>> proxy_guard{nullptr, [](void *ptr) {
+                                                     if (ptr) {
+                                                       XGDMatrixFree(ptr);
+                                                     }
+                                                   }};
   if (jmargin) {
     margin.reset(jenv->GetFloatArrayElements(jmargin, nullptr));
     JVM_CHECK_CALL(XGProxyDMatrixCreate(&proxy));
@@ -841,10 +866,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
     return ret;
   }
 
-  auto n = std::accumulate(out_shape, out_shape + out_dim, std::size_t{1},
-                           [](std::size_t acc, bst_ulong dim) {
-                             return acc * static_cast<std::size_t>(dim);
-                           });
+  auto n = std::accumulate(
+      out_shape, out_shape + out_dim, std::size_t{1},
+      [](std::size_t acc, bst_ulong dim) { return acc * static_cast<std::size_t>(dim); });
 
   jfloatArray jarray = jenv->NewFloatArray(n);
 
@@ -864,10 +888,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterLoadModel
                                                                                  jlong jhandle,
                                                                                  jstring jfname) {
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
-  std::unique_ptr<char const, Deleter<char const>> fname{jenv->GetStringUTFChars(jfname, nullptr),
-                                                         [&](char const *ptr) {
-                                                           jenv->ReleaseStringUTFChars(jfname, ptr);
-                                                         }};
+  std::unique_ptr<char const, Deleter<char const>> fname{
+      jenv->GetStringUTFChars(jfname, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(jfname, ptr); }};
   return XGBoosterLoadModel(handle, fname.get());
 }
 
@@ -898,10 +921,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSaveModel
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterLoadModelFromBuffer(
     JNIEnv *jenv, jclass jcls, jlong jhandle, jbyteArray jbytes) {
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
-  std::unique_ptr<jbyte, Deleter<jbyte>> buffer{jenv->GetByteArrayElements(jbytes, nullptr),
-                                                [&](jbyte *ptr) {
-                                                  jenv->ReleaseByteArrayElements(jbytes, ptr, 0);
-                                                }};
+  std::unique_ptr<jbyte, Deleter<jbyte>> buffer{
+      jenv->GetByteArrayElements(jbytes, nullptr),
+      [&](jbyte *ptr) { jenv->ReleaseByteArrayElements(jbytes, ptr, 0); }};
   return XGBoosterLoadModelFromBuffer(handle, buffer.get(), jenv->GetArrayLength(jbytes));
 }
 
@@ -910,8 +932,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterLoadModel
  * Method:    XGBoosterSaveModelToBuffer
  * Signature: (JLjava/lang/String;[[B)I
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSaveModelToBuffer
-  (JNIEnv * jenv, jclass jcls, jlong jhandle, jstring jformat, jobjectArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSaveModelToBuffer(
+    JNIEnv *jenv, jclass jcls, jlong jhandle, jstring jformat, jobjectArray jout) {
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
   std::unique_ptr<char const, Deleter<char const>> format{
       jenv->GetStringUTFChars(jformat, nullptr), [&](char const *ptr) {
@@ -941,8 +963,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSaveModel
  * Method:    XGBoosterDumpModelEx
  * Signature: (JLjava/lang/String;ILjava/lang/String;[[Ljava/lang/String;)I
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModelEx
-  (JNIEnv *jenv, jclass jcls, jlong jhandle, jstring jfmap, jint jwith_stats, jstring jformat, jobjectArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModelEx(
+    JNIEnv *jenv, jclass jcls, jlong jhandle, jstring jfmap, jint jwith_stats, jstring jformat,
+    jobjectArray jout) {
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
   std::unique_ptr<char const, Deleter<char const>> fmap{jenv->GetStringUTFChars(jfmap, nullptr),
                                                         [&](char const *ptr) {
@@ -962,12 +985,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModel
   int ret = XGBoosterDumpModelEx(handle, fmap.get(), jwith_stats, format.get(), &len, &result);
   JVM_CHECK_CALL(ret);
 
-  jsize jlen = (jsize) len;
-  jobjectArray jinfos = jenv->NewObjectArray(jlen, jenv->FindClass("java/lang/String"), jenv->NewStringUTF(""));
-  for(int i=0 ; i<jlen; i++) {
-    jenv->SetObjectArrayElement(jinfos, i, jenv->NewStringUTF((const char*) result[i]));
-  }
-  jenv->SetObjectArrayElement(jout, 0, jinfos);
+  jsize jlen = (jsize)len;
+  auto jinfos = MakeJniLocalRef(jenv, MakeJStringArray(jenv, jlen, result));
+  jenv->SetObjectArrayElement(jout, 0, jinfos.get());
 
   return ret;
 }
@@ -977,27 +997,28 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModel
  * Method:    XGBoosterDumpModelExWithFeatures
  * Signature: (J[Ljava/lang/String;ILjava/lang/String;[[Ljava/lang/String;)I
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModelExWithFeatures
-  (JNIEnv *jenv, jclass jcls, jlong jhandle, jobjectArray jfeature_names, jint jwith_stats,
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModelExWithFeatures(
+    JNIEnv *jenv, jclass jcls, jlong jhandle, jobjectArray jfeature_names, jint jwith_stats,
     jstring jformat, jobjectArray jout) {
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
   bst_ulong feature_num = (bst_ulong)jenv->GetArrayLength(jfeature_names);
 
   std::vector<std::string> feature_names;
-  std::vector<char const*> feature_names_char;
+  std::vector<char const *> feature_names_char;
 
   std::string feature_type_q = "q";
   std::vector<char const *> feature_types_char;
 
   for (bst_ulong i = 0; i < feature_num; ++i) {
-    jstring jfeature_name = (jstring)jenv->GetObjectArrayElement(jfeature_names, i);
+    auto jfeature_name =
+        MakeJniLocalRef(jenv, static_cast<jstring>(jenv->GetObjectArrayElement(jfeature_names, i)));
     std::unique_ptr<char const, Deleter<char const>> s{
-        jenv->GetStringUTFChars(jfeature_name, nullptr), [&](char const *ptr) {
+        jenv->GetStringUTFChars(jfeature_name.get(), nullptr), [&](char const *ptr) {
           if (ptr != nullptr) {
-            jenv->ReleaseStringUTFChars(jfeature_name, ptr);
+            jenv->ReleaseStringUTFChars(jfeature_name.get(), ptr);
           }
         }};
-    feature_names.emplace_back(s.get(), jenv->GetStringLength(jfeature_name));
+    feature_names.emplace_back(s.get(), jenv->GetStringLength(jfeature_name.get()));
 
     if (feature_names.back().length() == 0) {
       feature_names.pop_back();
@@ -1024,12 +1045,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModel
       (const char ***)&result);
   JVM_CHECK_CALL(ret);
 
-  jsize jlen = (jsize) len;
-  jobjectArray jinfos = jenv->NewObjectArray(jlen, jenv->FindClass("java/lang/String"), jenv->NewStringUTF(""));
-  for(int i=0 ; i<jlen; i++) {
-    jenv->SetObjectArrayElement(jinfos, i, jenv->NewStringUTF((const char*) result[i]));
-  }
-  jenv->SetObjectArrayElement(jout, 0, jinfos);
+  jsize jlen = (jsize)len;
+  auto jinfos = MakeJniLocalRef(jenv, MakeJStringArray(jenv, jlen, result));
+  jenv->SetObjectArrayElement(jout, 0, jinfos.get());
 
   return ret;
 }
@@ -1039,20 +1057,17 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterDumpModel
  * Method:    XGBoosterGetAttrNames
  * Signature: (J[[Ljava/lang/String;)I
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetAttrNames
-  (JNIEnv *jenv, jclass jcls, jlong jhandle, jobjectArray jout) {
-  BoosterHandle handle = (BoosterHandle) jhandle;
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetAttrNames(
+    JNIEnv *jenv, jclass jcls, jlong jhandle, jobjectArray jout) {
+  BoosterHandle handle = (BoosterHandle)jhandle;
   bst_ulong len = 0;
   char **result;
-  int ret = XGBoosterGetAttrNames(handle, &len, (const char ***) &result);
+  int ret = XGBoosterGetAttrNames(handle, &len, (const char ***)&result);
   JVM_CHECK_CALL(ret);
 
-  jsize jlen = (jsize) len;
-  jobjectArray jinfos = jenv->NewObjectArray(jlen, jenv->FindClass("java/lang/String"), jenv->NewStringUTF(""));
-  for(int i=0 ; i<jlen; i++) {
-    jenv->SetObjectArrayElement(jinfos, i, jenv->NewStringUTF((const char*) result[i]));
-  }
-  jenv->SetObjectArrayElement(jout, 0, jinfos);
+  jsize jlen = (jsize)len;
+  auto jinfos = MakeJniLocalRef(jenv, MakeJStringArray(jenv, jlen, result));
+  jenv->SetObjectArrayElement(jout, 0, jinfos.get());
 
   return ret;
 }
@@ -1078,8 +1093,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetAttr(
   JVM_CHECK_CALL(ret);
 
   if (success > 0) {
-    jstring jret = jenv->NewStringUTF(result);
-    jenv->SetObjectArrayElement(jout, 0, jret);
+    auto jret = MakeJniLocalRef(jenv, jenv->NewStringUTF(result));
+    jenv->SetObjectArrayElement(jout, 0, jret.get());
   }
 
   return ret;
@@ -1165,10 +1180,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_TrackerCreate(
 
   TrackerHandle handle;
   Json config{Object{}};
-  std::unique_ptr<char const, Deleter<char const>> p_shost{jenv->GetStringUTFChars(host, nullptr),
-                                                           [&](char const *ptr) {
-                                                             jenv->ReleaseStringUTFChars(host, ptr);
-                                                           }};
+  std::unique_ptr<char const, Deleter<char const>> p_shost{
+      jenv->GetStringUTFChars(host, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(host, ptr); }};
   std::string shost{p_shost.get(),
                     static_cast<std::string::size_type>(jenv->GetStringLength(host))};
   if (!shost.empty()) {
@@ -1229,8 +1243,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_TrackerWorkerArgs(
   JVM_CHECK_CALL(XGTrackerWorkerArgs(handle, &args));
   auto jargs = Json::Load(StringView{args});
 
-  jstring jret = jenv->NewStringUTF(args);
-  jenv->SetObjectArrayElement(jout, 0, jret);
+  auto jret = MakeJniLocalRef(jenv, jenv->NewStringUTF(args));
+  jenv->SetObjectArrayElement(jout, 0, jret.get());
   return 0;
 }
 
@@ -1280,8 +1294,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorPrint(
  * Method:    CommunicatorGetRank
  * Signature: ([I)I
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorGetRank
-  (JNIEnv *jenv, jclass jcls, jintArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorGetRank(JNIEnv *jenv,
+                                                                                  jclass jcls,
+                                                                                  jintArray jout) {
   jint rank = XGCommunicatorGetRank();
   jenv->SetIntArrayRegion(jout, 0, 1, &rank);
   return 0;
@@ -1292,8 +1307,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorGetRan
  * Method:    CommunicatorGetWorldSize
  * Signature: ([I)I
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorGetWorldSize
-  (JNIEnv *jenv, jclass jcls, jintArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorGetWorldSize(
+    JNIEnv *jenv, jclass jcls, jintArray jout) {
   jint out = XGCommunicatorGetWorldSize();
   jenv->SetIntArrayRegion(jout, 0, 1, &out);
   return 0;
@@ -1304,10 +1319,10 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorGetWor
  * Method:    CommunicatorAllreduce
  * Signature: (Ljava/nio/ByteBuffer;III)I
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorAllreduce
-  (JNIEnv *jenv, jclass jcls, jobject jsendrecvbuf, jint jcount, jint jenum_dtype, jint jenum_op) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CommunicatorAllreduce(
+    JNIEnv *jenv, jclass jcls, jobject jsendrecvbuf, jint jcount, jint jenum_dtype, jint jenum_op) {
   void *ptr_sendrecvbuf = jenv->GetDirectBufferAddress(jsendrecvbuf);
-  JVM_CHECK_CALL(XGCommunicatorAllreduce(ptr_sendrecvbuf, (size_t) jcount, jenum_dtype, jenum_op));
+  JVM_CHECK_CALL(XGCommunicatorAllreduce(ptr_sendrecvbuf, (size_t)jcount, jenum_dtype, jenum_op));
   return 0;
 }
 
@@ -1322,12 +1337,10 @@ int QdmFromCallback(JNIEnv *jenv, jobject jdata_iter, jlongArray jref, char cons
  * Signature: (Ljava/util/Iterator;[JLjava/lang/String;[J)I
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGQuantileDMatrixCreateFromCallback(
-    JNIEnv *jenv, jclass, jobject jdata_iter, jlongArray jref, jstring jconf,
-    jlongArray jout) {
-  std::unique_ptr<char const, Deleter<char const>> conf{jenv->GetStringUTFChars(jconf, nullptr),
-                                                        [&](char const *ptr) {
-                                                          jenv->ReleaseStringUTFChars(jconf, ptr);
-                                                        }};
+    JNIEnv *jenv, jclass, jobject jdata_iter, jlongArray jref, jstring jconf, jlongArray jout) {
+  std::unique_ptr<char const, Deleter<char const>> conf{
+      jenv->GetStringUTFChars(jconf, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(jconf, ptr); }};
   return xgboost::jni::QdmFromCallback(jenv, jdata_iter, jref, conf.get(), false, jout);
 }
 
@@ -1340,10 +1353,9 @@ JNIEXPORT jint JNICALL
 Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGExtMemQuantileDMatrixCreateFromCallback(
     JNIEnv *jenv, jclass jcls, jobject jdata_iter, jlongArray jref, jstring jconf,
     jlongArray jout) {
-  std::unique_ptr<char const, Deleter<char const>> conf{jenv->GetStringUTFChars(jconf, nullptr),
-                                                        [&](char const *ptr) {
-                                                          jenv->ReleaseStringUTFChars(jconf, ptr);
-                                                        }};
+  std::unique_ptr<char const, Deleter<char const>> conf{
+      jenv->GetStringUTFChars(jconf, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(jconf, ptr); }};
   return xgboost::jni::QdmFromCallback(jenv, jdata_iter, jref, conf.get(), true, jout);
 }
 
@@ -1355,14 +1367,12 @@ Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGExtMemQuantileDMatrixCreateFromCallback
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetInfoFromInterface(
     JNIEnv *jenv, jclass jcls, jlong jhandle, jstring jfield, jstring jjson_columns) {
   auto handle = reinterpret_cast<DMatrixHandle>(jhandle);
-  std::unique_ptr<char const, Deleter<char const>> field{jenv->GetStringUTFChars(jfield, nullptr),
-                                                         [&](char const *ptr) {
-                                                           jenv->ReleaseStringUTFChars(jfield, ptr);
-                                                         }};
+  std::unique_ptr<char const, Deleter<char const>> field{
+      jenv->GetStringUTFChars(jfield, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(jfield, ptr); }};
   std::unique_ptr<char const, Deleter<char const>> cjson_columns{
-      jenv->GetStringUTFChars(jjson_columns, nullptr), [&](char const *ptr) {
-        jenv->ReleaseStringUTFChars(jjson_columns, ptr);
-      }};
+      jenv->GetStringUTFChars(jjson_columns, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(jjson_columns, ptr); }};
 
   return XGDMatrixSetInfoFromInterface(handle, field.get(), cjson_columns.get());
 }
@@ -1372,13 +1382,14 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetInfoFr
  * Method:    XGDMatrixCreateFromArrayInterfaceColumns
  * Signature: (Ljava/lang/String;FI[J)I
  */
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromArrayInterfaceColumns
-  (JNIEnv *jenv, jclass jcls, jstring jjson_columns, jfloat jmissing, jint jnthread, jlongArray jout) {
+JNIEXPORT jint JNICALL
+Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFromArrayInterfaceColumns(
+    JNIEnv *jenv, jclass jcls, jstring jjson_columns, jfloat jmissing, jint jnthread,
+    jlongArray jout) {
   DMatrixHandle result;
   std::unique_ptr<char const, Deleter<char const>> cjson_columns{
-      jenv->GetStringUTFChars(jjson_columns, nullptr), [&](char const *ptr) {
-        jenv->ReleaseStringUTFChars(jjson_columns, ptr);
-      }};
+      jenv->GetStringUTFChars(jjson_columns, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(jjson_columns, ptr); }};
   xgboost::Json config{xgboost::Object{}};
   auto missing = static_cast<float>(jmissing);
   auto n_threads = static_cast<int32_t>(jnthread);
@@ -1392,23 +1403,22 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixCreateFro
   return ret;
 }
 
-JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetStrFeatureInfo
-    (JNIEnv *jenv, jclass jclz, jlong jhandle, jstring jfield, jobjectArray jvalues) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixSetStrFeatureInfo(
+    JNIEnv *jenv, jclass jclz, jlong jhandle, jstring jfield, jobjectArray jvalues) {
   auto handle = reinterpret_cast<DMatrixHandle>(jhandle);
-  std::unique_ptr<char const, Deleter<char const>> field{jenv->GetStringUTFChars(jfield, nullptr),
-                                                         [&](char const *ptr) {
-                                                           jenv->ReleaseStringUTFChars(jfield, ptr);
-                                                         }};
+  std::unique_ptr<char const, Deleter<char const>> field{
+      jenv->GetStringUTFChars(jfield, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(jfield, ptr); }};
   int size = jenv->GetArrayLength(jvalues);
 
   // tmp storage for java strings
   std::vector<std::string> values;
   for (int i = 0; i < size; i++) {
-    jstring jstr = (jstring)(jenv->GetObjectArrayElement(jvalues, i));
-    std::unique_ptr<char const, Deleter<char const>> value{jenv->GetStringUTFChars(jstr, nullptr),
-                                                           [&](char const *ptr) {
-                                                             jenv->ReleaseStringUTFChars(jstr, ptr);
-                                                           }};
+    auto jstr =
+        MakeJniLocalRef(jenv, static_cast<jstring>(jenv->GetObjectArrayElement(jvalues, i)));
+    std::unique_ptr<char const, Deleter<char const>> value{
+        jenv->GetStringUTFChars(jstr.get(), nullptr),
+        [&](char const *ptr) { jenv->ReleaseStringUTFChars(jstr.get(), ptr); }};
     values.emplace_back(value.get());
   }
 
@@ -1429,24 +1439,21 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetStrFea
     JNIEnv *jenv, jclass jclz, jlong jhandle, jstring jfield, jlongArray joutLenArray,
     jobjectArray joutValueArray) {
   auto handle = reinterpret_cast<DMatrixHandle>(jhandle);
-  std::unique_ptr<char const, Deleter<char const>> field{jenv->GetStringUTFChars(jfield, nullptr),
-                                                         [&](char const *ptr) {
-                                                           jenv->ReleaseStringUTFChars(jfield, ptr);
-                                                         }};
+  std::unique_ptr<char const, Deleter<char const>> field{
+      jenv->GetStringUTFChars(jfield, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(jfield, ptr); }};
 
   bst_ulong out_len = 0;
   char const **c_out_features;
   int ret = XGDMatrixGetStrFeatureInfo(handle, field.get(), &out_len, &c_out_features);
+  JVM_CHECK_CALL(ret);
 
   jlong jlen = (jlong)out_len;
   jenv->SetLongArrayRegion(joutLenArray, 0, 1, &jlen);
 
-  jobjectArray jinfos =
-      jenv->NewObjectArray(jlen, jenv->FindClass("java/lang/String"), jenv->NewStringUTF(""));
-  for (int i = 0; i < jlen; i++) {
-    jenv->SetObjectArrayElement(jinfos, i, jenv->NewStringUTF(c_out_features[i]));
-  }
-  jenv->SetObjectArrayElement(joutValueArray, 0, jinfos);
+  auto jinfos =
+      MakeJniLocalRef(jenv, MakeJStringArray(jenv, static_cast<jsize>(jlen), c_out_features));
+  jenv->SetObjectArrayElement(joutValueArray, 0, jinfos.get());
 
   return ret;
 }
@@ -1456,30 +1463,28 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGDMatrixGetStrFea
  * Method:    XGBoosterSetStrFeatureInfo
  * Signature: (JLjava/lang/String;[Ljava/lang/String;])I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetStrFeatureInfo(
-    JNIEnv *jenv, jclass jclz, jlong jhandle, jstring jfield,
-    jobjectArray jfeatures) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetStrFeatureInfo(
+    JNIEnv *jenv, jclass jclz, jlong jhandle, jstring jfield, jobjectArray jfeatures) {
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
 
-  std::unique_ptr<char const, Deleter<char const>> field{jenv->GetStringUTFChars(jfield, nullptr),
-                                                         [&](char const *ptr) {
-                                                           jenv->ReleaseStringUTFChars(jfield, ptr);
-                                                         }};
+  std::unique_ptr<char const, Deleter<char const>> field{
+      jenv->GetStringUTFChars(jfield, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(jfield, ptr); }};
   bst_ulong feature_num = (bst_ulong)jenv->GetArrayLength(jfeatures);
 
   std::vector<std::string> features;
-  std::vector<char const*> features_char;
+  std::vector<char const *> features_char;
 
   for (bst_ulong i = 0; i < feature_num; ++i) {
-    jstring jfeature = (jstring)jenv->GetObjectArrayElement(jfeatures, i);
+    auto jfeature =
+        MakeJniLocalRef(jenv, static_cast<jstring>(jenv->GetObjectArrayElement(jfeatures, i)));
     std::unique_ptr<char const, Deleter<char const>> s{
-        jenv->GetStringUTFChars(jfeature, nullptr), [&](char const *ptr) {
+        jenv->GetStringUTFChars(jfeature.get(), nullptr), [&](char const *ptr) {
           if (ptr) {
-            jenv->ReleaseStringUTFChars(jfeature, ptr);
+            jenv->ReleaseStringUTFChars(jfeature.get(), ptr);
           }
         }};
-    features.emplace_back(s.get(), jenv->GetStringLength(jfeature));
+    features.emplace_back(s.get(), jenv->GetStringLength(jfeature.get()));
   }
 
   for (size_t i = 0; i < features.size(); ++i) {
@@ -1495,15 +1500,12 @@ Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetStrFeatureInfo(
  * Method:    XGBoosterSetGtrFeatureInfo
  * Signature: (JLjava/lang/String;[Ljava/lang/String;])I
  */
-JNIEXPORT jint JNICALL
-Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetStrFeatureInfo(
-    JNIEnv *jenv, jclass jclz, jlong jhandle, jstring jfield,
-    jobjectArray jout) {
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetStrFeatureInfo(
+    JNIEnv *jenv, jclass jclz, jlong jhandle, jstring jfield, jobjectArray jout) {
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
-  std::unique_ptr<char const, Deleter<char const>> field{jenv->GetStringUTFChars(jfield, nullptr),
-                                                         [&](char const *ptr) {
-                                                           jenv->ReleaseStringUTFChars(jfield, ptr);
-                                                         }};
+  std::unique_ptr<char const, Deleter<char const>> field{
+      jenv->GetStringUTFChars(jfield, nullptr),
+      [&](char const *ptr) { jenv->ReleaseStringUTFChars(jfield, ptr); }};
 
   bst_ulong feature_num = (bst_ulong)jenv->GetArrayLength(jout);
 
@@ -1515,8 +1517,8 @@ Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterGetStrFeatureInfo(
   JVM_CHECK_CALL(ret);
 
   for (bst_ulong i = 0; i < feature_num; i++) {
-    jstring jfeature = jenv->NewStringUTF(features[i]);
-    jenv->SetObjectArrayElement(jout, i, jfeature);
+    auto jfeature = MakeJniLocalRef(jenv, jenv->NewStringUTF(features[i]));
+    jenv->SetObjectArrayElement(jout, i, jfeature.get());
   }
 
   return ret;
@@ -1592,8 +1594,8 @@ Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBGetGlobalConfig(JNIEnv *jenv, jclass, 
   char const *args;
   auto ret = XGBGetGlobalConfig(&args);
   JVM_CHECK_CALL(ret);
-  jstring jret = jenv->NewStringUTF(args);
-  jenv->SetObjectArrayElement(jout, 0, jret);
+  auto jret = MakeJniLocalRef(jenv, jenv->NewStringUTF(args));
+  jenv->SetObjectArrayElement(jout, 0, jret.get());
   return 0;
 }
 
@@ -1605,7 +1607,7 @@ Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBGetGlobalConfig(JNIEnv *jenv, jclass, 
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_CudaSetDevice(JNIEnv *, jclass,
                                                                             jint id) {
   auto device_id = static_cast<std::int32_t>(id);
-  auto& global_device_id = GlobalDeviceId();
+  auto &global_device_id = GlobalDeviceId();
   if (global_device_id != -1 && global_device_id != device_id) {
     LOG(WARNING) << "Device ID is already set to " << global_device_id
                  << ", but a different device ID " << device_id << " is requested.";


### PR DESCRIPTION
Close https://github.com/dmlc/xgboost/issues/12284

The local reference guard is mostly for tidiness. They are not necessary, as the JVM can clean up local references after a native function call. The extra guard helps prevent local accumulation of the references, which makes the code a bit more rigorous.