### PR TITLE
[breaking][MT] Support trees to dataframe.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -3090,8 +3090,8 @@ class Booster:
         Parameters
         ----------
         fmap :
-            Deprecated and ignored. The methed uses :meth:`.feature_types` and
-            :meth:`.feature_names`.
+            Deprecated and ignored. The methed uses :attr:`.feature_types` and
+            :attr:`.feature_names`.
 
             .. deprecated:: 3.4.0
 
@@ -3123,7 +3123,7 @@ class Booster:
         node_ids: List[int] = []
         fids: List[str] = []
         splits: List[float | None] = []
-        categories: List[Union[Optional[float], List[str]]] = []
+        categories: List[None | List[int]] = []
         y_directs: List[str | None] = []
         n_directs: List[str | None] = []
         missings: List[str | None] = []

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -3090,7 +3090,7 @@ class Booster:
         Parameters
         ----------
         fmap :
-            Deprecated and ignored. The methed uses :attr:`.feature_types` and
+            Deprecated and ignored. The method uses :attr:`.feature_types` and
             :attr:`.feature_names`.
 
             .. deprecated:: 3.4.0

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2,6 +2,8 @@
 # pylint: disable=too-many-lines, too-many-locals
 """Core XGBoost Library."""
 
+from __future__ import annotations
+
 import copy
 import ctypes
 import json
@@ -45,9 +47,7 @@ from ._c_api import (
     from_pystr_to_cstr,
     make_jcargs,
 )
-from ._c_api import (
-    XGBoostError as _XGBoostError,
-)
+from ._c_api import XGBoostError as _XGBoostError
 from ._data_utils import (
     Categories,
     TransformedDf,
@@ -92,6 +92,7 @@ from .objective import Objective, TreeObjective, _grad_arrinf
 
 if TYPE_CHECKING:
     from pandas import DataFrame as PdDataFrame
+
 
 XGBoostError = _XGBoostError
 
@@ -3080,12 +3081,11 @@ class Booster:
         return results
 
     # pylint: disable=too-many-locals, too-many-statements
-    def trees_to_dataframe(self, fmap: PathLike = "") -> "PdDataFrame":
-        """Parse a boosted tree model into a pandas DataFrame structure.
+    def trees_to_dataframe(self, fmap: PathLike = "") -> PdDataFrame:
+        """Parse a boosted tree model into a pandas DataFrame.
 
         This feature is only defined when the decision tree model is chosen as base
-        learner (`booster in {gbtree, dart}`). It is not defined for other base learner
-        types, such as linear learners (`booster=gblinear`).
+        learner (`booster in {gbtree, dart}`).
 
         Parameters
         ----------
@@ -3108,10 +3108,7 @@ class Booster:
                 f"This method is not defined for Booster type {gbm['name']}"
             )
         trees = gbm["model"]["trees"]
-        if trees and int(trees[0]["tree_param"]["size_leaf_vector"]) > 1:
-            raise NotImplementedError(
-                "trees_to_dataframe doesn't support vector leaf trees."
-            )
+        tree_info = gbm["model"]["tree_info"]
         if fmap:
             warnings.warn(
                 "`fmap` has been deprecated. XGBoost now uses the"
@@ -3122,6 +3119,7 @@ class Booster:
         ftypes = dict(enumerate(self.feature_types or []))
 
         tree_ids: List[int] = []
+        target_ids: List[Optional[int]] = []
         node_ids: List[int] = []
         fids: List[str] = []
         splits: List[float | None] = []
@@ -3141,6 +3139,14 @@ class Booster:
             stypes = tree["split_type"]
             loss_chg = tree["loss_changes"]
             sum_hess = tree["sum_hessian"]
+            # For vector-leaf trees the leaf output is a vector stored in
+            # ``leaf_weights`` rather than in ``split_conditions``. The right child is
+            # re-used to store the leaf index.
+            size_leaf_vector = int(tree["tree_param"]["size_leaf_vector"])
+            is_vector = size_leaf_vector > 1
+            leaf_weights = tree["leaf_weights"] if is_vector else None
+            # The output group this tree contributes to.
+            tree_target = int(tree_info[tid])
 
             # Node id -> category codes (as strings), stored CSR-style.
             node_cats: Dict[int, List[str]] = {}
@@ -3156,21 +3162,39 @@ class Booster:
             stack = [0]
             while stack:
                 nid = stack.pop()
-                tree_ids.append(tid)
-                node_ids.append(nid)
                 if left[nid] == -1:  # leaf
-                    fids.append("Leaf")
-                    splits.append(None)
-                    categories.append(None)
-                    y_directs.append(None)
-                    n_directs.append(None)
-                    missings.append(None)
-                    gains.append(sconds[nid])
-                    covers.append(sum_hess[nid])
+                    if is_vector:
+                        assert leaf_weights is not None
+                        beg = right[nid] * size_leaf_vector
+                        leaf_rows = list(
+                            enumerate(
+                                float(v)
+                                for v in leaf_weights[beg : beg + size_leaf_vector]
+                            )
+                        )
+                    else:
+                        leaf_rows = [(tree_target, float(sconds[nid]))]
+                    for target, value in leaf_rows:
+                        tree_ids.append(tid)
+                        target_ids.append(target)
+                        node_ids.append(nid)
+                        fids.append("Leaf")
+                        splits.append(None)
+                        categories.append(None)
+                        y_directs.append(None)
+                        n_directs.append(None)
+                        missings.append(None)
+                        gains.append(value)
+                        covers.append(sum_hess[nid])
                     continue
 
                 stack.append(left[nid])
                 stack.append(right[nid])
+                tree_ids.append(tid)
+                # A vector-leaf split is shared by all targets, so it has no single
+                # target; scalar-tree splits belong to the tree's target.
+                target_ids.append(None if is_vector else tree_target)
+                node_ids.append(nid)
                 fidx = sindex[nid]
                 fids.append(fnames.get(fidx, f"f{fidx}"))
                 dft_child = left[nid] if dft_left[nid] else right[nid]
@@ -3200,6 +3224,7 @@ class Booster:
         df = DataFrame(
             {
                 "Tree": tree_ids,
+                "Target": target_ids,
                 "Node": node_ids,
                 "ID": ids,
                 "Feature": fids,
@@ -3215,6 +3240,7 @@ class Booster:
         df = df.astype(
             {
                 "Tree": "Int64",
+                "Target": "Int64",
                 "Node": "Int64",
                 "ID": "string",
                 "Feature": "string",
@@ -3224,11 +3250,11 @@ class Booster:
                 "Missing": "string",
                 "Gain": "Float64",
                 "Cover": "Float64",
-                # `Category`  holds Python lists
+                # `Category` holds Python lists
             }
         )
 
-        return df.sort_values(["Tree", "Node"]).reset_index(drop=True)
+        return df.sort_values(["Tree", "Node", "Target"]).reset_index(drop=True)
 
     def _assign_dmatrix_features(self, data: DMatrix) -> None:
         if data.num_row() == 0:
@@ -3285,7 +3311,7 @@ class Booster:
         fmap: PathLike = "",
         bins: Optional[int] = None,
         as_pandas: bool = True,
-    ) -> Union[np.ndarray, "PdDataFrame"]:
+    ) -> Union[np.ndarray, PdDataFrame]:
         """Get split value histogram of a feature
 
         Parameters

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -3148,14 +3148,14 @@ class Booster:
             # The output group this tree contributes to.
             tree_target = int(tree_info[tid])
 
-            # Node id -> category codes (as strings), stored CSR-style.
-            node_cats: Dict[int, List[str]] = {}
+            # Node id -> category codes, stored CSR-style.
+            node_cats: Dict[int, List[int]] = {}
             for nidx, beg, size in zip(
                 tree["categories_nodes"],
                 tree["categories_segments"],
                 tree["categories_sizes"],
             ):
-                node_cats[nidx] = [str(c) for c in tree["categories"][beg : beg + size]]
+                node_cats[nidx] = tree["categories"][beg : beg + size]
 
             # Depth-first traversal from the root so that pruned/deleted nodes, which
             # remain in the arrays but are unreachable, are skipped.

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -5,6 +5,7 @@
 import copy
 import ctypes
 import json
+import math
 import os
 import re
 import sys
@@ -3078,9 +3079,9 @@ class Booster:
                 results[feat] = float(score)
         return results
 
-    # pylint: disable=too-many-statements
+    # pylint: disable=too-many-locals, too-many-statements
     def trees_to_dataframe(self, fmap: PathLike = "") -> "PdDataFrame":
-        """Parse a boosted tree model text dump into a pandas DataFrame structure.
+        """Parse a boosted tree model into a pandas DataFrame structure.
 
         This feature is only defined when the decision tree model is chosen as base
         learner (`booster in {gbtree, dart}`). It is not defined for other base learner
@@ -3089,113 +3090,113 @@ class Booster:
         Parameters
         ----------
         fmap :
-           The name of feature map file.
+            Deprecated and ignored. The methed uses :meth:`.feature_types` and
+            :meth:`.feature_names`.
+
+            .. deprecated:: 3.4.0
+
         """
-        # pylint: disable=too-many-locals
+        if not is_pandas_available():
+            raise ImportError("pandas must be available to use this method.")
+
         from pandas import DataFrame
 
-        fmap = os.fspath(os.path.expanduser(fmap))
-        if not is_pandas_available():
-            raise ImportError(
-                (
-                    "pandas must be available to use this method."
-                    "Install pandas before calling again."
-                )
+        model = json.loads(self.save_raw(raw_format="json"))
+        gbm = model["learner"]["gradient_booster"]
+        if gbm["name"] not in {"gbtree", "dart"}:
+            raise ValueError(
+                f"This method is not defined for Booster type {gbm['name']}"
             )
-        booster = json.loads(self.save_config())["learner"]["gradient_booster"]["name"]
-        if booster not in {"gbtree", "dart"}:
-            raise ValueError(f"This method is not defined for Booster type {booster}")
+        trees = gbm["model"]["trees"]
+        if trees and int(trees[0]["tree_param"]["size_leaf_vector"]) > 1:
+            raise NotImplementedError(
+                "trees_to_dataframe doesn't support vector leaf trees."
+            )
+        if fmap:
+            warnings.warn(
+                "`fmap` has been deprecated. XGBoost now uses the"
+                " `Booster.feature_names` and `Booster.feature_types` by default.",
+                FutureWarning,
+            )
+        fnames = dict(enumerate(self.feature_names or []))
+        ftypes = dict(enumerate(self.feature_types or []))
 
-        tree_ids = []
-        node_ids = []
-        fids = []
-        splits: List[Union[float, str]] = []
+        tree_ids: List[int] = []
+        node_ids: List[int] = []
+        fids: List[str] = []
+        splits: List[float | None] = []
         categories: List[Union[Optional[float], List[str]]] = []
-        y_directs: List[Union[float, str]] = []
-        n_directs: List[Union[float, str]] = []
-        missings: List[Union[float, str]] = []
-        gains = []
-        covers = []
+        y_directs: List[str | None] = []
+        n_directs: List[str | None] = []
+        missings: List[str | None] = []
+        gains: List[float] = []
+        covers: List[float] = []
 
-        trees = self.get_dump(fmap, with_stats=True)
-        for i, tree in enumerate(trees):
-            for line in tree.split("\n"):
-                arr = line.split("[")
-                # Leaf node
-                if len(arr) == 1:
-                    # Last element of line.split is an empty string
-                    if arr == [""]:
-                        continue
-                    # parse string
-                    parse = arr[0].split(":")
-                    stats = re.split("=|,", parse[1])
+        for tid, tree in enumerate(trees):
+            left = tree["left_children"]
+            right = tree["right_children"]
+            sindex = tree["split_indices"]
+            sconds = tree["split_conditions"]
+            dft_left = tree["default_left"]
+            stypes = tree["split_type"]
+            loss_chg = tree["loss_changes"]
+            sum_hess = tree["sum_hessian"]
 
-                    # append to lists
-                    tree_ids.append(i)
-                    node_ids.append(int(re.findall(r"\b\d+\b", parse[0])[0]))
+            # Node id -> category codes (as strings), stored CSR-style.
+            node_cats: Dict[int, List[str]] = {}
+            for nidx, beg, size in zip(
+                tree["categories_nodes"],
+                tree["categories_segments"],
+                tree["categories_sizes"],
+            ):
+                node_cats[nidx] = [str(c) for c in tree["categories"][beg : beg + size]]
+
+            # Depth-first traversal from the root so that pruned/deleted nodes, which
+            # remain in the arrays but are unreachable, are skipped.
+            stack = [0]
+            while stack:
+                nid = stack.pop()
+                tree_ids.append(tid)
+                node_ids.append(nid)
+                if left[nid] == -1:  # leaf
                     fids.append("Leaf")
-                    splits.append(float("NAN"))
-                    categories.append(float("NAN"))
-                    y_directs.append(float("NAN"))
-                    n_directs.append(float("NAN"))
-                    missings.append(float("NAN"))
-                    gains.append(float(stats[1]))
-                    covers.append(float(stats[3]))
-                # Not a Leaf Node
-                else:
-                    # parse string
-                    fid = arr[1].split("]")
-                    if fid[0].find("<") != -1:
-                        # numerical
-                        parse = fid[0].split("<")
-                        splits.append(float(parse[1]))
-                        categories.append(None)
-                    elif fid[0].find(":{") != -1:
-                        # categorical
-                        parse = fid[0].split(":")
-                        cats = parse[1][1:-1]  # strip the {}
-                        cats_split = cats.split(",")
-                        splits.append(float("NAN"))
-                        categories.append(cats_split if cats_split else None)
-                    else:
-                        # indicator (boolean) feature: format is
-                        #   {nid}:[{fname}] yes={yes},no={no}
-                        # No split threshold or missing direction.
-                        bracket_expr = fid[0]
-                        remainder = fid[1] if len(fid) > 1 else ""
-                        if (
-                            "<" in bracket_expr
-                            or ":{" in bracket_expr
-                            or "yes=" not in remainder
-                            or "no=" not in remainder
-                        ):
-                            raise ValueError(
-                                f"Unrecognized split format: [{bracket_expr}]{remainder}"
-                            )
-                        parse = [bracket_expr]
-                        splits.append(float("NAN"))
-                        categories.append(None)
-                    stats = re.split("=|,", fid[1])
+                    splits.append(None)
+                    categories.append(None)
+                    y_directs.append(None)
+                    n_directs.append(None)
+                    missings.append(None)
+                    gains.append(sconds[nid])
+                    covers.append(sum_hess[nid])
+                    continue
 
-                    # append to lists
-                    tree_ids.append(i)
-                    node_ids.append(int(re.findall(r"\b\d+\b", arr[0])[0]))
-                    fids.append(parse[0])
-                    str_i = str(i)
-                    y_directs.append(str_i + "-" + stats[1])
-                    n_directs.append(str_i + "-" + stats[3])
-                    # Indicator nodes have no explicit missing= field;
-                    # the default (missing) child is the "no" direction.
-                    if len(stats) > 5 and stats[4] == "missing":
-                        missings.append(str_i + "-" + stats[5])
-                        gains.append(float(stats[7]))
-                        covers.append(float(stats[9]))
+                stack.append(left[nid])
+                stack.append(right[nid])
+                fidx = sindex[nid]
+                fids.append(fnames.get(fidx, f"f{fidx}"))
+                dft_child = left[nid] if dft_left[nid] else right[nid]
+                if stypes[nid] == 1:  # categorical
+                    yes, no = right[nid], left[nid]
+                    splits.append(None)
+                    categories.append(node_cats.get(nid))
+                elif ftypes.get(fidx, "q") == "i":  # indicator (boolean)
+                    # No split threshold; missing follows the "no" (default) branch.
+                    yes, no = (right[nid] if dft_left[nid] else left[nid]), dft_child
+                    splits.append(None)
+                    categories.append(None)
+                else:  # numerical
+                    yes, no = left[nid], right[nid]
+                    if ftypes.get(fidx, "q") == "int":
+                        splits.append(float(math.ceil(sconds[nid])))
                     else:
-                        missings.append(str_i + "-" + stats[3])
-                        gains.append(float(stats[5]))
-                        covers.append(float(stats[7]))
+                        splits.append(sconds[nid])
+                    categories.append(None)
+                y_directs.append(f"{tid}-{yes}")
+                n_directs.append(f"{tid}-{no}")
+                missings.append(f"{tid}-{dft_child}")
+                gains.append(loss_chg[nid])
+                covers.append(sum_hess[nid])
 
-        ids = [str(t_id) + "-" + str(n_id) for t_id, n_id in zip(tree_ids, node_ids)]
+        ids = [f"{t_id}-{n_id}" for t_id, n_id in zip(tree_ids, node_ids)]
         df = DataFrame(
             {
                 "Tree": tree_ids,
@@ -3209,6 +3210,21 @@ class Booster:
                 "Gain": gains,
                 "Cover": covers,
                 "Category": categories,
+            }
+        )
+        df = df.astype(
+            {
+                "Tree": "Int64",
+                "Node": "Int64",
+                "ID": "string",
+                "Feature": "string",
+                "Split": "Float64",
+                "Yes": "string",
+                "No": "string",
+                "Missing": "string",
+                "Gain": "Float64",
+                "Cover": "Float64",
+                # `Category`  holds Python lists
             }
         )
 

--- a/python-package/xgboost/testing/parse_tree.py
+++ b/python-package/xgboost/testing/parse_tree.py
@@ -1,12 +1,17 @@
 """Tests for parsing trees."""
 
+import json
+
+import numpy as np
 import pandas as pd
 import pytest
+from sklearn.datasets import make_regression
 
-from ..core import DMatrix
+from ..core import Booster, DMatrix, QuantileDMatrix
 from ..sklearn import XGBRegressor
 from ..training import train
 from .data import make_categorical
+from .updater import ResetStrategy
 from .utils import Device
 
 
@@ -39,6 +44,90 @@ def run_tree_to_df_categorical(tree_method: str, device: Device) -> None:
             assert x["Yes"] in all_ids
             assert x["No"] in all_ids
             assert x["Missing"] in all_ids
+
+
+def _expected_leaf_vectors(booster: Booster) -> dict[tuple[int, int], list[float]]:
+    """Map ``(tree_id, node_id) -> list[float]`` of leaf outputs from the raw JSON."""
+    model = json.loads(booster.save_raw(raw_format="json"))
+    trees = model["learner"]["gradient_booster"]["model"]["trees"]
+    out: dict[tuple[int, int], list[float]] = {}
+    for tid, tree in enumerate(trees):
+        size = int(tree["tree_param"]["size_leaf_vector"])
+        if size <= 1:
+            continue
+        left = tree["left_children"]
+        right = tree["right_children"]
+        leaf_weights = tree["leaf_weights"]
+        for nid, lc in enumerate(left):
+            if lc == -1:  # leaf
+                beg = right[nid] * size
+                out[(tid, nid)] = [float(v) for v in leaf_weights[beg : beg + size]]
+    return out
+
+
+def run_tree_to_df_vector_leaf_mixed(tree_method: str, device: Device) -> None:
+    """Tests trees_to_dataframe on a mixed scalar + vector-leaf booster."""
+    n_targets = 3
+    X, y = make_regression(
+        n_samples=512, n_features=10, n_targets=n_targets, random_state=2025
+    )
+    Xy = QuantileDMatrix(X, y)
+    booster = train(
+        {
+            "tree_method": tree_method,
+            "device": device,
+            "multi_strategy": "multi_output_tree",
+            "max_depth": 3,
+        },
+        Xy,
+        num_boost_round=6,
+        callbacks=[ResetStrategy()],
+    )
+
+    df = booster.trees_to_dataframe()
+    assert str(df["Gain"].dtype) == "Float64"
+    assert "Target" in df.columns
+
+    expected = _expected_leaf_vectors(booster)
+    # Tree ids that use vector leaves (each such tree has at least one leaf).
+    vector_tids = {tid for tid, _ in expected}
+    assert len(vector_tids) > 0
+
+    all_ids = set(df["ID"])
+    n_vector_leaf_rows = 0
+    for _, x in df.iterrows():
+        tid = int(x["Tree"])
+        key = (tid, int(x["Node"]))
+        if x["Feature"] == "Leaf":
+            # Leaf rows never carry split information, regardless of tree type.
+            assert pd.isna(x["Split"])
+            assert x["Category"] is None
+            assert pd.isna(x["Yes"])
+            assert pd.isna(x["No"])
+            assert pd.isna(x["Missing"])
+            if key in expected:
+                # Vector-leaf leaf: expanded into one row per target, with the scalar
+                # Gain equal to the target-th entry of the leaf vector.
+                n_vector_leaf_rows += 1
+                target = int(x["Target"])
+                assert target in range(n_targets)
+                np.testing.assert_allclose(float(x["Gain"]), expected[key][target])
+            else:
+                # Scalar-tree leaf: a single row carrying the tree's concrete target.
+                assert not pd.isna(x["Target"])
+        else:
+            assert isinstance(float(x["Gain"]), float)
+            assert x["Yes"] in all_ids
+            assert x["No"] in all_ids
+            assert x["Missing"] in all_ids
+            if tid in vector_tids:
+                # A split node does not have a concept of target.
+                assert pd.isna(x["Target"])
+            else:
+                # A scalar-tree split belongs to that tree's target.
+                assert not pd.isna(x["Target"])
+    # Every vector-leaf node expands into exactly `n_targets` rows.
+    assert n_vector_leaf_rows == n_targets * len(expected)
 
 
 def run_split_value_histograms(tree_method: str, device: Device) -> None:

--- a/python-package/xgboost/testing/parse_tree.py
+++ b/python-package/xgboost/testing/parse_tree.py
@@ -1,5 +1,6 @@
 """Tests for parsing trees."""
 
+import pandas as pd
 import pytest
 
 from ..core import DMatrix
@@ -11,15 +12,33 @@ from .utils import Device
 
 def run_tree_to_df_categorical(tree_method: str, device: Device) -> None:
     """Tests tree_to_df with categorical features."""
+
     X, y = make_categorical(100, 10, 31, onehot=False)
     Xy = DMatrix(X, y, enable_categorical=True)
     booster = train(
         {"tree_method": tree_method, "device": device}, Xy, num_boost_round=10
     )
     df = booster.trees_to_dataframe()
+
+    all_ids = set(df["ID"])
     for _, x in df.iterrows():
-        if x["Feature"] != "Leaf":
-            assert len(x["Category"]) >= 1
+        if x["Feature"] == "Leaf":
+            # A leaf carries its scalar weight in ``Gain`` and no split info.
+            assert pd.isna(x["Split"])
+            assert not isinstance(x["Category"], list)
+            assert pd.isna(x["Yes"])
+            assert pd.isna(x["No"])
+            assert pd.isna(x["Missing"])
+        else:
+            # A categorical split has a missing threshold and a non-empty list of
+            # integer category codes rendered as strings.
+            assert pd.isna(x["Split"])
+            assert isinstance(x["Category"], list) and len(x["Category"]) >= 1
+            assert all(isinstance(c, str) and int(c) >= 0 for c in x["Category"])
+            # Branch ids must reference existing nodes in the same frame.
+            assert x["Yes"] in all_ids
+            assert x["No"] in all_ids
+            assert x["Missing"] in all_ids
 
 
 def run_split_value_histograms(tree_method: str, device: Device) -> None:

--- a/python-package/xgboost/testing/parse_tree.py
+++ b/python-package/xgboost/testing/parse_tree.py
@@ -68,6 +68,8 @@ def _expected_leaf_vectors(booster: Booster) -> dict[tuple[int, int], list[float
 
 def run_tree_to_df_vector_leaf_mixed(device: Device) -> None:
     """Tests trees_to_dataframe on a mixed scalar + vector-leaf booster."""
+    import pandas as pd
+
     n_targets = 3
     X, y = make_regression(
         n_samples=512, n_features=10, n_targets=n_targets, random_state=2025

--- a/python-package/xgboost/testing/parse_tree.py
+++ b/python-package/xgboost/testing/parse_tree.py
@@ -40,7 +40,7 @@ def run_tree_to_df_categorical(tree_method: str, device: Device) -> None:
             # integer category codes rendered as strings.
             assert pd.isna(x["Split"])
             assert isinstance(x["Category"], list) and len(x["Category"]) >= 1
-            assert all(isinstance(c, str) and int(c) >= 0 for c in x["Category"])
+            assert all(int(c) >= 0 for c in x["Category"])
             # Branch ids must reference existing nodes in the same frame.
             assert x["Yes"] in all_ids
             assert x["No"] in all_ids

--- a/python-package/xgboost/testing/parse_tree.py
+++ b/python-package/xgboost/testing/parse_tree.py
@@ -47,39 +47,33 @@ def run_tree_to_df_categorical(tree_method: str, device: Device) -> None:
 
 
 def _expected_leaf_vectors(booster: Booster) -> dict[tuple[int, int], list[float]]:
-    """Map ``(tree_id, node_id) -> list[float]`` of leaf outputs from the raw JSON."""
+    """Map ``(tree_id, node_id) -> list[float]`` of leaf outputs."""
     model = json.loads(booster.save_raw(raw_format="json"))
     trees = model["learner"]["gradient_booster"]["model"]["trees"]
     out: dict[tuple[int, int], list[float]] = {}
     for tid, tree in enumerate(trees):
-        size = int(tree["tree_param"]["size_leaf_vector"])
-        if size <= 1:
+        n_targets = int(tree["tree_param"]["size_leaf_vector"])
+        if n_targets <= 1:
             continue
         left = tree["left_children"]
         right = tree["right_children"]
         leaf_weights = tree["leaf_weights"]
         for nid, lc in enumerate(left):
             if lc == -1:  # leaf
-                beg = right[nid] * size
-                out[(tid, nid)] = [float(v) for v in leaf_weights[beg : beg + size]]
+                beg = right[nid] * n_targets
+                out[(tid, nid)] = leaf_weights[beg : beg + n_targets]
     return out
 
 
-def run_tree_to_df_vector_leaf_mixed(tree_method: str, device: Device) -> None:
+def run_tree_to_df_vector_leaf_mixed(device: Device) -> None:
     """Tests trees_to_dataframe on a mixed scalar + vector-leaf booster."""
     n_targets = 3
     X, y = make_regression(
         n_samples=512, n_features=10, n_targets=n_targets, random_state=2025
     )
-    Xy = QuantileDMatrix(X, y)
     booster = train(
-        {
-            "tree_method": tree_method,
-            "device": device,
-            "multi_strategy": "multi_output_tree",
-            "max_depth": 3,
-        },
-        Xy,
+        {"device": device, "multi_strategy": "multi_output_tree", "max_depth": 3},
+        QuantileDMatrix(X, y),
         num_boost_round=6,
         callbacks=[ResetStrategy()],
     )
@@ -99,7 +93,7 @@ def run_tree_to_df_vector_leaf_mixed(tree_method: str, device: Device) -> None:
         tid = int(x["Tree"])
         key = (tid, int(x["Node"]))
         if x["Feature"] == "Leaf":
-            # Leaf rows never carry split information, regardless of tree type.
+            # Leaf rows don't carry split information
             assert pd.isna(x["Split"])
             assert x["Category"] is None
             assert pd.isna(x["Yes"])

--- a/python-package/xgboost/testing/parse_tree.py
+++ b/python-package/xgboost/testing/parse_tree.py
@@ -3,7 +3,6 @@
 import json
 
 import numpy as np
-import pandas as pd
 import pytest
 from sklearn.datasets import make_regression
 
@@ -17,6 +16,8 @@ from .utils import Device
 
 def run_tree_to_df_categorical(tree_method: str, device: Device) -> None:
     """Tests tree_to_df with categorical features."""
+
+    import pandas as pd
 
     X, y = make_categorical(100, 10, 31, onehot=False)
     Xy = DMatrix(X, y, enable_categorical=True)

--- a/tests/python/test_parse_tree.py
+++ b/tests/python/test_parse_tree.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 import pytest
 import xgboost as xgb
 from xgboost import testing as tm

--- a/tests/python/test_parse_tree.py
+++ b/tests/python/test_parse_tree.py
@@ -70,7 +70,7 @@ class TestTreesToDataFrame:
         run_tree_to_df_categorical("approx", "cpu")
 
     def test_tree_to_df_vector_leaf_mixed(self) -> None:
-        run_tree_to_df_vector_leaf_mixed("hist", "cpu")
+        run_tree_to_df_vector_leaf_mixed("cpu")
 
     def test_tree_to_df_indicator(self, tmp_path) -> None:
         """Test trees_to_dataframe with indicator (boolean) features."""

--- a/tests/python/test_parse_tree.py
+++ b/tests/python/test_parse_tree.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 import xgboost as xgb
 from xgboost import testing as tm
@@ -51,6 +52,47 @@ class TestTreesToDataFrame:
         cover_from_df = df.Cover.sum()
         assert np.allclose(cover_from_dump, cover_from_df)
 
+        # Structural checks on the JSON-derived frame: branch ids are well-formed and
+        # reference existing (reachable) nodes, and the missing direction always follows
+        # one of the two children.
+        all_ids = set(df["ID"])
+        non_leaf = df[df.Feature != "Leaf"]
+        assert non_leaf["Yes"].isin(all_ids).all()
+        assert non_leaf["No"].isin(all_ids).all()
+        assert non_leaf["Missing"].isin(all_ids).all()
+        assert (
+            (non_leaf["Missing"] == non_leaf["Yes"])
+            | (non_leaf["Missing"] == non_leaf["No"])
+        ).all()
+        # Numerical splits have a real threshold; leaves have a missing split.
+        assert non_leaf["Split"].notna().all()
+        assert df[df.Feature == "Leaf"]["Split"].isna().all()
+
+    def test_tree_to_df_mixed(self) -> None:
+        """Mixed numerical + categorical model: check ``Category`` column semantics."""
+        X, y = tm.make_categorical(256, 8, 17, onehot=False, cat_ratio=0.5)
+        Xy = xgb.DMatrix(X, y, enable_categorical=True)
+        bst = xgb.train({"tree_method": "hist"}, Xy, num_boost_round=4)
+        df = bst.trees_to_dataframe()
+
+        saw_numerical = saw_categorical = False
+        for _, x in df.iterrows():
+            if x["Feature"] == "Leaf":
+                # Leaves have no category and no split threshold.
+                assert x["Category"] is None
+                assert pd.isna(x["Split"])
+            elif isinstance(x["Category"], list):
+                # Categorical split: missing threshold, non-empty integer codes.
+                saw_categorical = True
+                assert pd.isna(x["Split"])
+                assert len(x["Category"]) >= 1
+            else:
+                # Numerical split: ``Category`` stays ``None`` and split is a number.
+                saw_numerical = True
+                assert x["Category"] is None
+                assert pd.notna(x["Split"])
+        assert saw_numerical and saw_categorical
+
     def test_tree_to_df_categorical(self) -> None:
         run_tree_to_df_categorical("approx", "cpu")
 
@@ -61,20 +103,15 @@ class TestTreesToDataFrame:
         X_int = rng.randint(0, 2, size=(n_samples, n_features))
         y = np.logical_xor(X_int[:, 0], X_int[:, 1]).astype(np.float32)
         X = X_int.astype(np.float32)
-        dtrain = xgb.DMatrix(X, label=y)
-
-        # Create a feature map with indicator type 'i'
-        fmap_path = str(tmp_path / "fmap.txt")
-        with open(fmap_path, "w", encoding="utf-8") as f:
-            for i in range(n_features):
-                f.write(f"{i}\tf{i}\ti\n")
+        # Use `i` as indicator
+        dtrain = xgb.DMatrix(X, label=y, feature_types=["i"] * n_features)
 
         bst = xgb.train(
             {"max_depth": 3, "objective": "binary:logistic", "verbosity": 0},
             dtrain,
             num_boost_round=5,
         )
-        df = bst.trees_to_dataframe(fmap=fmap_path)
+        df = bst.trees_to_dataframe()
 
         # Basic structure checks
         assert "Tree" in df.columns

--- a/tests/python/test_parse_tree.py
+++ b/tests/python/test_parse_tree.py
@@ -6,6 +6,7 @@ from xgboost import testing as tm
 from xgboost.testing.parse_tree import (
     run_split_value_histograms,
     run_tree_to_df_categorical,
+    run_tree_to_df_vector_leaf_mixed,
 )
 
 pytestmark = pytest.mark.skipif(**tm.no_pandas())
@@ -52,9 +53,6 @@ class TestTreesToDataFrame:
         cover_from_df = df.Cover.sum()
         assert np.allclose(cover_from_dump, cover_from_df)
 
-        # Structural checks on the JSON-derived frame: branch ids are well-formed and
-        # reference existing (reachable) nodes, and the missing direction always follows
-        # one of the two children.
         all_ids = set(df["ID"])
         non_leaf = df[df.Feature != "Leaf"]
         assert non_leaf["Yes"].isin(all_ids).all()
@@ -68,33 +66,11 @@ class TestTreesToDataFrame:
         assert non_leaf["Split"].notna().all()
         assert df[df.Feature == "Leaf"]["Split"].isna().all()
 
-    def test_tree_to_df_mixed(self) -> None:
-        """Mixed numerical + categorical model: check ``Category`` column semantics."""
-        X, y = tm.make_categorical(256, 8, 17, onehot=False, cat_ratio=0.5)
-        Xy = xgb.DMatrix(X, y, enable_categorical=True)
-        bst = xgb.train({"tree_method": "hist"}, Xy, num_boost_round=4)
-        df = bst.trees_to_dataframe()
-
-        saw_numerical = saw_categorical = False
-        for _, x in df.iterrows():
-            if x["Feature"] == "Leaf":
-                # Leaves have no category and no split threshold.
-                assert x["Category"] is None
-                assert pd.isna(x["Split"])
-            elif isinstance(x["Category"], list):
-                # Categorical split: missing threshold, non-empty integer codes.
-                saw_categorical = True
-                assert pd.isna(x["Split"])
-                assert len(x["Category"]) >= 1
-            else:
-                # Numerical split: ``Category`` stays ``None`` and split is a number.
-                saw_numerical = True
-                assert x["Category"] is None
-                assert pd.notna(x["Split"])
-        assert saw_numerical and saw_categorical
-
     def test_tree_to_df_categorical(self) -> None:
         run_tree_to_df_categorical("approx", "cpu")
+
+    def test_tree_to_df_vector_leaf_mixed(self) -> None:
+        run_tree_to_df_vector_leaf_mixed("hist", "cpu")
 
     def test_tree_to_df_indicator(self, tmp_path) -> None:
         """Test trees_to_dataframe with indicator (boolean) features."""


### PR DESCRIPTION
- Use the JSON model instead of parsing the text dump.
- Deprecate the use of the `fmap`.
- A new `Target` column has been added to the schema. It works with both scalar trees and vector trees.
- Use `pandas.NA` uniformly to denote that something is not available, instead of mixing `None` and `nan`.
- Support vector leaf.

The `trees_to_dataframe` was ported from the R implementation. This PR adds a new `Target` column, but the rest should remain semantically consistent with the original implementation.

ref: https://github.com/dmlc/xgboost/issues/9043