### PR TITLE
Unify and fix min_child_weight.

### DIFF
--- a/src/tree/gpu_hist/evaluate_splits.cu
+++ b/src/tree/gpu_hist/evaluate_splits.cu
@@ -133,7 +133,7 @@ class EvaluateSplitAgent {
         GradientPairInt64 left = missing_left ? bin + missing : bin;
         GradientPairInt64 right = parent_sum - left;
         best_split->Update(gain, missing_left ? kLeftDir : kRightDir, fvalue, fidx, left, right,
-                           false, param, rounding);
+                           false);
       }
 
       __syncwarp();
@@ -165,7 +165,7 @@ class EvaluateSplitAgent {
         GradientPairInt64 left = missing_left ? bin + missing : bin;
         GradientPairInt64 right = parent_sum - left;
         best_split->UpdateCat(gain, missing_left ? kLeftDir : kRightDir,
-                              static_cast<bst_cat_t>(fvalue), fidx, left, right, param, rounding);
+                              static_cast<bst_cat_t>(fvalue), fidx, left, right);
       }
 
       __syncwarp();
@@ -195,7 +195,7 @@ class EvaluateSplitAgent {
       // index of best threshold inside a feature.
       auto best_thresh = it - gidx_begin;
       best_split->UpdateCat(gain, missing_left ? kLeftDir : kRightDir, best_thresh, fidx, left_sum,
-                            right_sum, param, rounding);
+                            right_sum);
     }
 
     __syncwarp();

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -101,11 +101,6 @@ class HistEvaluator {
     }
   }
 
-  [[nodiscard]] bool IsValid(GradStats const &left, GradStats const &right) const {
-    return left.GetHess() >= param_->min_child_weight &&
-           right.GetHess() >= param_->min_child_weight;
-  }
-
   /**
    * \brief Use learned direction with one-hot split. Other implementations (LGB) create a
    *        pseudo-category for missing value but here we just do a complete scan to avoid
@@ -141,24 +136,18 @@ class HistEvaluator {
       // missing on left (treat missing as other categories)
       right_sum = GradStats{hist[i]};
       left_sum.SetSubstract(parent.stats, right_sum);
-      if (IsValid(left_sum, right_sum)) {
-        auto missing_left_chg =
-            static_cast<float>(evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{left_sum},
-                                                       GradStats{right_sum}) -
-                               parent.root_gain);
-        best.Update(missing_left_chg, fidx, split_pt, true, true, left_sum, right_sum);
-      }
+      auto missing_left_chg = static_cast<float>(
+          evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{left_sum}, GradStats{right_sum}) -
+          parent.root_gain);
+      best.Update(missing_left_chg, fidx, split_pt, true, true, left_sum, right_sum);
 
       // missing on right (treat missing as chosen category)
       right_sum.Add(missing);
       left_sum.SetSubstract(parent.stats, right_sum);
-      if (IsValid(left_sum, right_sum)) {
-        auto missing_right_chg =
-            static_cast<float>(evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{left_sum},
-                                                       GradStats{right_sum}) -
-                               parent.root_gain);
-        best.Update(missing_right_chg, fidx, split_pt, false, true, left_sum, right_sum);
-      }
+      auto missing_right_chg = static_cast<float>(
+          evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{left_sum}, GradStats{right_sum}) -
+          parent.root_gain);
+      best.Update(missing_right_chg, fidx, split_pt, false, true, left_sum, right_sum);
     }
 
     if (best.is_cat) {
@@ -229,15 +218,13 @@ class HistEvaluator {
         left_sum.Add(f_hist[sorted_idx[j]].GetGrad(), f_hist[sorted_idx[j]].GetHess());
         right_sum.SetSubstract(parent.stats, left_sum);  // missing on right
       }
-      if (IsValid(left_sum, right_sum)) {
-        auto loss_chg = evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{left_sum},
-                                                GradStats{right_sum}) -
-                        parent.root_gain;
-        // We don't have a numeric split point, nan here is a dummy split.
-        if (best.Update(loss_chg, fidx, std::numeric_limits<float>::quiet_NaN(), d_step == 1, true,
-                        left_sum, right_sum)) {
-          best_thresh = i;
-        }
+      auto loss_chg =
+          evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{left_sum}, GradStats{right_sum}) -
+          parent.root_gain;
+      // We don't have a numeric split point, nan here is a dummy split.
+      if (best.Update(loss_chg, fidx, std::numeric_limits<float>::quiet_NaN(), d_step == 1, true,
+                      left_sum, right_sum)) {
+        best_thresh = i;
       }
     }
 
@@ -296,26 +283,24 @@ class HistEvaluator {
       // try to find a split
       left_sum.Add(hist[i].GetGrad(), hist[i].GetHess());
       right_sum.SetSubstract(parent.stats, left_sum);
-      if (IsValid(left_sum, right_sum)) {
-        bst_float loss_chg;
-        bst_float split_pt;
-        if (d_step > 0) {
-          // forward enumeration: split at right bound of each bin
-          loss_chg =
-              static_cast<float>(evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{left_sum},
-                                                         GradStats{right_sum}) -
-                                 parent.root_gain);
-          split_pt = cut_val[i];  // not used for partition based
-          best.Update(loss_chg, fidx, split_pt, d_step == -1, false, left_sum, right_sum);
-        } else {
-          // backward enumeration: split at left bound of each bin
-          loss_chg =
-              static_cast<float>(evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{right_sum},
-                                                         GradStats{left_sum}) -
-                                 parent.root_gain);
-          split_pt = common::HistogramCuts::NumericBinLowerBound(cut_ptr, cut_val, fidx, i);
-          best.Update(loss_chg, fidx, split_pt, d_step == -1, false, right_sum, left_sum);
-        }
+      bst_float loss_chg;
+      bst_float split_pt;
+      if (d_step > 0) {
+        // forward enumeration: split at right bound of each bin
+        loss_chg =
+            static_cast<float>(evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{left_sum},
+                                                       GradStats{right_sum}) -
+                               parent.root_gain);
+        split_pt = cut_val[i];  // not used for partition based
+        best.Update(loss_chg, fidx, split_pt, d_step == -1, false, left_sum, right_sum);
+      } else {
+        // backward enumeration: split at left bound of each bin
+        loss_chg =
+            static_cast<float>(evaluator.CalcSplitGain(*param_, nidx, fidx, GradStats{right_sum},
+                                                       GradStats{left_sum}) -
+                               parent.root_gain);
+        split_pt = common::HistogramCuts::NumericBinLowerBound(cut_ptr, cut_val, fidx, i);
+        best.Update(loss_chg, fidx, split_pt, d_step == -1, false, right_sum, left_sum);
       }
     }
 

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2023 by Contributors
+ * Copyright 2018-2026, XGBoost Contributors
  * \file split_evaluator.h
  * \brief Used for implementing a loss term specific to decision trees. Useful for custom regularisation.
  * \author Henry Gouk

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -73,13 +73,20 @@ class TreeEvaluator {
     template <typename GradientSumT>
     XGBOOST_DEVICE float CalcSplitGain(const ParamT& param, bst_node_t nidx, bst_feature_t fidx,
                                        GradientSumT const& left, GradientSumT const& right) const {
-      int constraint = has_constraint ? constraints[fidx] : 0;
       const float negative_infinity = -std::numeric_limits<float>::infinity();
+      auto left_hess = left.GetHess();
+      auto right_hess = right.GetHess();
+      if (!(left_hess > 0.0 && right_hess > 0.0 && left_hess >= param.min_child_weight &&
+            right_hess >= param.min_child_weight)) {
+        return negative_infinity;
+      }
+
+      int constraint = has_constraint ? constraints[fidx] : 0;
       float wleft = this->CalcWeight(nidx, param, left);
       float wright = this->CalcWeight(nidx, param, right);
 
       float gain = this->CalcGainGivenWeight(param, left, wleft) +
-                    this->CalcGainGivenWeight(param, right, wright);
+                   this->CalcGainGivenWeight(param, right, wright);
 
       if (constraint == 0) {
         // no constraint
@@ -92,7 +99,7 @@ class TreeEvaluator {
     }
 
     template <typename GradientSumT>
-    XGBOOST_DEVICE float CalcWeight(bst_node_t nodeid, const ParamT &param,
+    XGBOOST_DEVICE float CalcWeight(bst_node_t nodeid, const ParamT& param,
                                     GradientSumT const& stats) const {
       float w = ::xgboost::tree::CalcWeight(param, stats);
       if (!has_constraint) {
@@ -138,11 +145,10 @@ class TreeEvaluator {
         return Divide(common::Sqr(ThresholdL1(stats.GetGrad(), p.reg_alpha)),
                       (stats.GetHess() + p.reg_lambda));
       }
-      return tree::CalcGainGivenWeight<ParamT, float>(p, stats.GetGrad(),
-                                                      stats.GetHess(), w);
+      return tree::CalcGainGivenWeight<ParamT, float>(p, stats.GetGrad(), stats.GetHess(), w);
     }
     template <typename GradientSumT>
-    XGBOOST_DEVICE float CalcGain(bst_node_t nid, ParamT const &p,
+    XGBOOST_DEVICE float CalcGain(bst_node_t nid, ParamT const& p,
                                   GradientSumT const& stats) const {
       return this->CalcGainGivenWeight(p, stats, this->CalcWeight(nid, p, stats));
     }
@@ -150,7 +156,8 @@ class TreeEvaluator {
 
  public:
   /* Get a view to the evaluator that can be passed down to device. */
-  template <typename ParamT = TrainParam> auto GetEvaluator() const {
+  template <typename ParamT = TrainParam>
+  auto GetEvaluator() const {
     if (device_.IsCUDA()) {
       auto constraints = monotone_.ConstDevicePointer();
       return SplitEvaluator<ParamT>{constraints, lower_bounds_.ConstDevicePointer(),
@@ -163,8 +170,8 @@ class TreeEvaluator {
   }
 
   template <bool CompiledWithCuda = WITH_CUDA()>
-  void AddSplit(bst_node_t nodeid, bst_node_t leftid, bst_node_t rightid,
-                bst_feature_t f, float left_weight, float right_weight) {
+  void AddSplit(bst_node_t nodeid, bst_node_t leftid, bst_node_t rightid, bst_feature_t f,
+                float left_weight, float right_weight) {
     if (!has_constraint_) {
       return;
     }
@@ -178,8 +185,7 @@ class TreeEvaluator {
     }
 
     common::Transform<>::Init(
-        [=] XGBOOST_DEVICE(size_t, common::Span<float> lower,
-                           common::Span<float> upper,
+        [=] XGBOOST_DEVICE(size_t, common::Span<float> lower, common::Span<float> upper,
                            common::Span<int> monotone) {
           lower[leftid] = lower[nodeid];
           upper[leftid] = upper[nodeid];

--- a/src/tree/updater_gpu_common.cuh
+++ b/src/tree/updater_gpu_common.cuh
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2024, XGBoost contributors
+ * Copyright 2017-2026, XGBoost contributors
  */
 #pragma once
 #include <limits>   // for numeric_limits

--- a/src/tree/updater_gpu_common.cuh
+++ b/src/tree/updater_gpu_common.cuh
@@ -67,11 +67,8 @@ struct DeviceSplitCandidate {
 
   XGBOOST_DEVICE void Update(float loss_chg_in, DefaultDirection dir_in, float fvalue_in,
                              int findex_in, GradientPairInt64 left_sum_in,
-                             GradientPairInt64 right_sum_in, bool cat,
-                             const GPUTrainingParam& param, const GradientQuantiser& quantiser) {
-    if (loss_chg_in > loss_chg &&
-        quantiser.ToFloatingPoint(left_sum_in).GetHess() >= param.min_child_weight &&
-        quantiser.ToFloatingPoint(right_sum_in).GetHess() >= param.min_child_weight) {
+                             GradientPairInt64 right_sum_in, bool cat) {
+    if (loss_chg_in > loss_chg) {
       loss_chg = loss_chg_in;
       dir = dir_in;
       fvalue = fvalue_in;
@@ -87,11 +84,8 @@ struct DeviceSplitCandidate {
    */
   XGBOOST_DEVICE void UpdateCat(float loss_chg_in, DefaultDirection dir_in, bst_cat_t thresh_in,
                                 bst_feature_t findex_in, GradientPairInt64 left_sum_in,
-                                GradientPairInt64 right_sum_in, GPUTrainingParam const& param,
-                                const GradientQuantiser& quantiser) {
-    if (loss_chg_in > loss_chg &&
-        quantiser.ToFloatingPoint(left_sum_in).GetHess() >= param.min_child_weight &&
-        quantiser.ToFloatingPoint(right_sum_in).GetHess() >= param.min_child_weight) {
+                                GradientPairInt64 right_sum_in) {
+    if (loss_chg_in > loss_chg) {
       loss_chg = loss_chg_in;
       dir = dir_in;
       fvalue = std::numeric_limits<float>::quiet_NaN();

--- a/tests/cpp/tree/test_tree_stat.cc
+++ b/tests/cpp/tree/test_tree_stat.cc
@@ -95,6 +95,74 @@ void BuildTree(Context const* ctx, DMatrix* p_fmat, GradientContainer* grad,
 }
 }  // namespace
 
+class TestMinChildWeight : public ::testing::Test {
+  std::shared_ptr<DMatrix> p_fmat_;
+  GradientContainer grad_;
+
+ public:
+  void SetUp() override {
+    p_fmat_ = GetDMatrixFromData({0.0f, 1.0f, 2.0f, 3.0f}, 4, 1);
+    Context cpu_ctx;
+    grad_ = GenerateRandomGradients(&cpu_ctx, 4, 1);
+    {
+      auto h_grad = grad_.gpair.HostView();
+      h_grad(0, 0) = GradientPair{10.0f, 0.2f};
+      h_grad(1, 0) = GradientPair{-9.0f, 0.8f};
+      h_grad(2, 0) = GradientPair{-1.0f, 1.0f};
+      h_grad(3, 0) = GradientPair{0.0f, 1.0f};
+    }
+  }
+
+  void Run(Context const* ctx, std::string const& updater) {
+    RegTree tree{1u, 1u};
+    Args args{{"max_depth", "1"},
+              {"min_child_weight", "1"},
+              {"reg_alpha", "0"},
+              {"reg_lambda", "0"},
+              {"learning_rate", "1"}};
+    BuildTree(ctx, p_fmat_.get(), &grad_, updater, args, &tree);
+
+    ASSERT_EQ(tree.NumExtraNodes(), 2);
+    ASSERT_FALSE(tree[RegTree::kRoot].IsLeaf());
+    EXPECT_EQ(tree[RegTree::kRoot].SplitIndex(), 0);
+    auto cond = updater == "grow_colmaker" ? 1.5f : 2.0f;  // exact uses mid point.
+    EXPECT_FLOAT_EQ(tree[RegTree::kRoot].SplitCond(), cond);
+
+    auto left = tree[RegTree::kRoot].LeftChild();
+    auto right = tree[RegTree::kRoot].RightChild();
+    EXPECT_NEAR(tree.Stat(RegTree::kRoot).sum_hess, 3.0f, kRtEps);
+    EXPECT_NEAR(tree.Stat(left).sum_hess, 1.0f, kRtEps);
+    EXPECT_NEAR(tree.Stat(right).sum_hess, 2.0f, kRtEps);
+  }
+};
+
+TEST_F(TestMinChildWeight, Hist) {
+  Context ctx;
+  Run(&ctx, "grow_quantile_histmaker");
+}
+
+TEST_F(TestMinChildWeight, Approx) {
+  Context ctx;
+  Run(&ctx, "grow_histmaker");
+}
+
+TEST_F(TestMinChildWeight, Exact) {
+  Context ctx;
+  Run(&ctx, "grow_colmaker");
+}
+
+#if defined(XGBOOST_USE_CUDA)
+TEST_F(TestMinChildWeight, GpuHist) {
+  auto ctx = MakeCUDACtx(0);
+  Run(&ctx, "grow_gpu_hist");
+}
+
+TEST_F(TestMinChildWeight, GpuApprox) {
+  auto ctx = MakeCUDACtx(0);
+  this->Run(&ctx, "grow_gpu_approx");
+}
+#endif  // defined(XGBOOST_USE_CUDA)
+
 /**
  * @brief Test changing learning rate doesn't change internal splits.
  */
@@ -415,7 +483,8 @@ class TestMaxDeltaStep : public ::testing::Test {
 
     RegTree tree_0{static_cast<bst_target_t>(gpairs.gpair.Shape(1)),
                    static_cast<bst_target_t>(p_fmat->Info().num_col_)};
-    BuildTree(ctx, p_fmat.get(), &gpairs, updater, Args{{"max_delta_step", std::to_string(0.5)}}, &tree_0);
+    BuildTree(ctx, p_fmat.get(), &gpairs, updater, Args{{"max_delta_step", std::to_string(0.5)}},
+              &tree_0);
     ASSERT_EQ(tree_0.NumNodes(), 1);
   }
 };


### PR DESCRIPTION
Currently, the CPU hist does a pre-check using `IsValid` to prevent a candidate from being evaluated, which is correct.

However, the GPU performs a post-check in `ExpandEntry::Update` that can allow an invalid candidate to win the evaluation over other valid candidates, only to be discarded afterward; hence, a bug.

The PR centralizes the handling of min child weight in the gain calculation and removes these pre- and post-checks.