### PR TITLE
[MT] CPU implementation of partition-based categorical split.

### DIFF
--- a/python-package/xgboost/testing/updater.py
+++ b/python-package/xgboost/testing/updater.py
@@ -450,7 +450,7 @@ def check_categorical_ohe(  # pylint: disable=too-many-arguments
     cols: int,
     rounds: int,
     cats: int,
-    device: str,
+    device: Device,
     tree_method: str,
     extmem: bool = False,
     multi_target: bool = False,
@@ -537,7 +537,7 @@ def check_categorical_ohe(  # pylint: disable=too-many-arguments
     )
     assert non_increasing(by_builtin_results["Train"]["rmse"])
 
-    if not multi_target:
+    if device == "cpu" or (device == "cuda" and not multi_target):
         by_grouping: Dict[str, Dict[str, List[float]]] = {}
         # switch to partition-based splits
         parameters["max_cat_to_onehot"] = USE_PART

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -161,7 +161,7 @@ class HistEvaluator {
   }
 
   /**
-   * \brief Enumerate with partition-based splits.
+   * @brief Enumerate with partition-based splits.
    *
    * The implementation is different from LightGBM. Firstly we don't have a
    * pseudo-cateogry for missing value, instead of we make 2 complete scans over the

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -776,10 +776,8 @@ class HistMultiEvaluator {
         std::stable_sort(sorted_idx.begin(), sorted_idx.end(), [&](std::size_t l, std::size_t r) {
           for (decltype(n_targets) t = 0; t < n_targets; ++t) {
             auto f_hist = node_hist[t].subspan(cut_ptr[fidx], n_bins);
-            auto l_bin = f_hist[l];
-            auto r_bin = f_hist[r];
-            l_grads[t] = l_bin;
-            r_grads[t] = r_bin;
+            l_grads[t] = f_hist[l];
+            r_grads[t] = f_hist[r];
           }
 
           CalcWeight(*param_, linalg::MakeVec(l_grads), linalg::MakeVec(l_w.data(), l_w.size()));

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -469,17 +469,6 @@ class HistEvaluator {
   }
 };
 
-inline void Norm(linalg::VectorView<float> value) {
-  double s = 0;
-  for (auto v : value) {
-    s += v * v;
-  }
-  auto norm = std::sqrt(s);
-  for (auto &v : value) {
-    v /= norm;
-  }
-}
-
 class HistMultiEvaluator {
   std::vector<double> gain_;
   linalg::Matrix<GradientPairPrecise> stats_;
@@ -733,7 +722,6 @@ class HistMultiEvaluator {
       auto base_weight = linalg::Zeros<float>(ctx_, parent_sum.Shape());
       auto h_bw = base_weight.HostView();
       CalcWeight(*param_, parent_sum, h_bw);
-      Norm(h_bw);
 
       std::vector<common::ConstGHistRow> node_hist;
       for (auto t_hist : hist) {
@@ -775,6 +763,7 @@ class HistMultiEvaluator {
         auto r_grads = grads.Slice(linalg::Range(n_targets, grads.Shape(0)));
         std::vector<float> l_w(n_targets, .0f), r_w(n_targets, .0f);
 
+        // Sort by s_c = w_p^T w_c
         std::stable_sort(sorted_idx.begin(), sorted_idx.end(), [&](std::size_t l, std::size_t r) {
           for (decltype(n_targets) t = 0; t < n_targets; ++t) {
             auto f_hist = node_hist[t].subspan(cut_ptr[fidx], n_bins);
@@ -784,7 +773,8 @@ class HistMultiEvaluator {
 
           CalcWeight(*param_, l_grads, linalg::MakeVec(l_w.data(), l_w.size()));
           CalcWeight(*param_, r_grads, linalg::MakeVec(r_w.data(), r_w.size()));
-          // Run proj, compare score l_s < r_s
+          // Project onto the parent's update direction to compare score l_s < r_s
+          // Since we care only about the ordering, no need to divide the norm.
           float l_s = .0f, r_s = .0f;
           for (std::size_t i = 0; i < n_targets; ++i) {
             l_s += h_bw(i) * l_w[i];

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -771,10 +771,9 @@ class HistMultiEvaluator {
             auto f_hist = node_hist[t_idx].subspan(cut_ptr[fidx], n_bins);
             h_grads(t_idx) = f_hist[bin_idx];
           }
-
           CalcWeight(*param_, h_grads, linalg::MakeVec(child_w.data(), child_w.size()));
           double sc = .0;
-          for (std::size_t t_idx = 0; t_idx < n_targets; ++t_idx) {
+          for (decltype(n_targets) t_idx = 0; t_idx < n_targets; ++t_idx) {
             sc += h_bw(t_idx) * child_w[t_idx];
           }
           scores[bin_idx] = sc;

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -766,18 +766,18 @@ class HistMultiEvaluator {
         // Project onto the parent's update direction to compare scores l_s < r_s
         // Since we care only about the ordering, no need to divide the norm.
         std::vector<double> scores(n_bins);
-        for (std::size_t i = 0; i < n_bins; ++i) {
-          for (decltype(n_targets) t = 0; t < n_targets; ++t) {
-            auto f_hist = node_hist[t].subspan(cut_ptr[fidx], n_bins);
-            h_grads(t) = f_hist[i];
+        for (std::size_t bin_idx = 0; bin_idx < n_bins; ++bin_idx) {
+          for (decltype(n_targets) t_idx = 0; t_idx < n_targets; ++t_idx) {
+            auto f_hist = node_hist[t_idx].subspan(cut_ptr[fidx], n_bins);
+            h_grads(t_idx) = f_hist[bin_idx];
           }
 
           CalcWeight(*param_, h_grads, linalg::MakeVec(child_w.data(), child_w.size()));
           double sc = .0;
-          for (std::size_t i = 0; i < n_targets; ++i) {
-            sc += h_bw(i) * child_w[i];
+          for (std::size_t t_idx = 0; t_idx < n_targets; ++t_idx) {
+            sc += h_bw(t_idx) * child_w[t_idx];
           }
-          scores[i] = sc;
+          scores[bin_idx] = sc;
         }
 
         std::stable_sort(sorted_idx.begin(), sorted_idx.end(),

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -630,9 +630,12 @@ class HistMultiEvaluator {
                      common::Span<common::ConstGHistRow> hist, bst_feature_t fidx, bst_node_t nidx,
                      SplitEntryContainer<std::vector<GradientPairPrecise>> *p_best) {
     static_assert(d_step == +1 || d_step == -1, "Invalid step.");
+    auto n_targets = hist.size();
 
     auto const &cut_ptr = cut.Ptrs();
     auto const &cut_val = cut.Values();
+    auto parent_sum = stats_.Slice(nidx, linalg::All());
+    auto parent_gain = gain_[nidx];
 
     bst_bin_t f_begin = cut_ptr[fidx];
     bst_bin_t f_end = cut_ptr[fidx + 1];
@@ -647,6 +650,51 @@ class HistMultiEvaluator {
       it_begin = f_end - 1;
       it_end = it_begin - n_bins + 1;
     }
+
+    auto sum = linalg::Constant(ctx_, GradientPairPrecise{}, 2, n_targets);
+    auto left_sum = sum.Slice(0, linalg::All());
+    auto right_sum = sum.Slice(1, linalg::All());
+    auto weight = linalg::Empty<float>(ctx_, 2, n_targets);
+    auto left_weight = weight.Slice(0, linalg::All());
+    auto right_weight = weight.Slice(1, linalg::All());
+
+    SplitEntryContainer<std::vector<GradientPairPrecise>> best;
+    bst_bin_t best_thresh{-1};
+    for (bst_bin_t i = it_begin; i != it_end; i += d_step) {
+      auto j = i - f_begin;  // index local to current feature
+      for (bst_target_t t = 0; t < n_targets; ++t) {
+        auto f_hist = hist[t].subspan(f_begin, n_bins_feature);
+        if (d_step == 1) {
+          right_sum(t) += f_hist[sorted_idx[j]];
+          left_sum(t) = parent_sum(t) - right_sum(t);  // missing on left
+        } else {
+          left_sum(t) += f_hist[sorted_idx[j]];
+          right_sum(t) = parent_sum(t) - left_sum(t);  // missing on right
+        }
+      }
+
+      auto loss_chg =
+          MultiCalcSplitGain(*param_, left_sum, right_sum, left_weight, right_weight) - parent_gain;
+      // We don't have a numeric split point, nan here is a dummy split.
+      if (best.Update(loss_chg, fidx, std::numeric_limits<float>::quiet_NaN(), d_step == 1, true,
+                      left_sum, right_sum)) {
+        best_thresh = i;
+      }
+    }
+
+    if (best_thresh != -1) {
+      auto n = common::CatBitField::ComputeStorageSize(n_bins_feature);
+      best.cat_bits = decltype(best.cat_bits)(n, 0);
+      common::CatBitField cat_bits{best.cat_bits};
+      bst_bin_t partition = d_step == 1 ? (best_thresh - it_begin + 1) : (best_thresh - f_begin);
+      CHECK_GT(partition, 0);
+      std::for_each(sorted_idx.begin(), sorted_idx.begin() + partition, [&](std::size_t c) {
+        auto cat = cut_val[c + f_begin];
+        cat_bits.Set(cat);
+      });
+    }
+
+    p_best->Update(best);
   }
 
  public:
@@ -721,8 +769,9 @@ class HistMultiEvaluator {
 
         // Partition split
         std::vector<size_t> sorted_idx(n_bins);
-        std::iota(sorted_idx.begin(), sorted_idx.end(), 0);
+        std::iota(sorted_idx.begin(), sorted_idx.end(), 0ul);
         std::vector<GradientPairPrecise> l_grads(n_targets), r_grads(n_targets);
+        std::vector<float> l_w(n_targets, .0f), r_w(n_targets, .0f);
 
         std::stable_sort(sorted_idx.begin(), sorted_idx.end(), [&](std::size_t l, std::size_t r) {
           for (decltype(n_targets) t = 0; t < n_targets; ++t) {
@@ -732,8 +781,7 @@ class HistMultiEvaluator {
             l_grads[t] = l_bin;
             r_grads[t] = r_bin;
           }
-          std::vector<float> l_w(n_targets, 0);
-          std::vector<float> r_w(n_targets, 0);
+
           CalcWeight(*param_, linalg::MakeVec(l_grads), linalg::MakeVec(l_w.data(), l_w.size()));
           CalcWeight(*param_, linalg::MakeVec(r_grads), linalg::MakeVec(r_w.data(), r_w.size()));
           // Run proj, compare score l_s < r_s

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -774,8 +774,8 @@ class HistMultiEvaluator {
 
           CalcWeight(*param_, h_grads, linalg::MakeVec(child_w.data(), child_w.size()));
           double sc = .0;
-          for (std::size_t i = 0; i < n_targets; ++i) {
-            sc += h_bw(i) * child_w[i];
+          for (std::size_t t_idx = 0; t_idx < n_targets; ++t_idx) {
+            sc += h_bw(t_idx) * child_w[t_idx];
           }
           scores[i] = sc;
         }

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -758,30 +758,30 @@ class HistMultiEvaluator {
         // Partition split
         std::vector<size_t> sorted_idx(n_bins);
         std::iota(sorted_idx.begin(), sorted_idx.end(), 0ul);
-        linalg::Vector<GradientPairPrecise> grads({n_targets * 2}, this->ctx_->Device());
-        auto l_grads = grads.Slice(linalg::Range(0ul, n_targets));
-        auto r_grads = grads.Slice(linalg::Range(n_targets, grads.Shape(0)));
-        std::vector<float> l_w(n_targets, .0f), r_w(n_targets, .0f);
+        linalg::Vector<GradientPairPrecise> grads({n_targets}, this->ctx_->Device());
+        auto h_grads = grads.HostView();
+        std::vector<float> child_w(n_targets, .0f);
 
         // Sort by s_c = w_p^T w_c
-        std::stable_sort(sorted_idx.begin(), sorted_idx.end(), [&](std::size_t l, std::size_t r) {
+        // Project onto the parent's update direction to compare scores l_s < r_s
+        // Since we care only about the ordering, no need to divide the norm.
+        std::vector<double> scores(n_bins);
+        for (std::size_t i = 0; i < n_bins; ++i) {
           for (decltype(n_targets) t = 0; t < n_targets; ++t) {
             auto f_hist = node_hist[t].subspan(cut_ptr[fidx], n_bins);
-            l_grads(t) = f_hist[l];
-            r_grads(t) = f_hist[r];
+            h_grads(t) = f_hist[i];
           }
 
-          CalcWeight(*param_, l_grads, linalg::MakeVec(l_w.data(), l_w.size()));
-          CalcWeight(*param_, r_grads, linalg::MakeVec(r_w.data(), r_w.size()));
-          // Project onto the parent's update direction to compare score l_s < r_s
-          // Since we care only about the ordering, no need to divide the norm.
-          float l_s = .0f, r_s = .0f;
+          CalcWeight(*param_, h_grads, linalg::MakeVec(child_w.data(), child_w.size()));
+          double sc = .0;
           for (std::size_t i = 0; i < n_targets; ++i) {
-            l_s += h_bw(i) * l_w[i];
-            r_s += h_bw(i) * r_w[i];
+            sc += h_bw(i) * child_w[i];
           }
-          return l_s < r_s;
-        });
+          scores[i] = sc;
+        }
+
+        std::stable_sort(sorted_idx.begin(), sorted_idx.end(),
+                         [&](std::size_t l, std::size_t r) { return scores[l] < scores[r]; });
 
         this->EnumeratePart<+1>(cut, sorted_idx, node_hist, fidx, entry->nid, best);
         this->EnumeratePart<-1>(cut, sorted_idx, node_hist, fidx, entry->nid, best);

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -335,7 +335,7 @@ class HistEvaluator {
     auto evaluator = tree_evaluator_.GetEvaluator();
     auto const &cut_ptrs = cut.Ptrs();
 
-    common::ParallelFor2d(space, n_threads, [&](size_t nidx_in_set, common::Range1d r) {
+    common::ParallelFor2d(space, n_threads, [&](std::size_t nidx_in_set, common::Range1d r) {
       auto tidx = omp_get_thread_num();
       auto entry = &tloc_candidates[n_threads * nidx_in_set + tidx];
       auto best = &entry->split;
@@ -351,19 +351,19 @@ class HistEvaluator {
         if (is_cat) {
           auto n_bins = cut_ptrs.at(fidx + 1) - cut_ptrs[fidx];
           if (common::UseOneHot(n_bins, param_->max_cat_to_onehot)) {
-            EnumerateOneHot(cut, histogram, fidx, nidx, evaluator, best);
+            this->EnumerateOneHot(cut, histogram, fidx, nidx, evaluator, best);
           } else {
             std::vector<size_t> sorted_idx(n_bins);
             std::iota(sorted_idx.begin(), sorted_idx.end(), 0);
             auto feat_hist = histogram.subspan(cut_ptrs[fidx], n_bins);
             // Sort the histogram to get contiguous partitions.
-            std::stable_sort(sorted_idx.begin(), sorted_idx.end(), [&](size_t l, size_t r) {
-              auto ret = evaluator.CalcWeightCat(*param_, feat_hist[l]) <
-                         evaluator.CalcWeightCat(*param_, feat_hist[r]);
-              return ret;
-            });
-            EnumeratePart<+1>(cut, sorted_idx, histogram, fidx, nidx, evaluator, best);
-            EnumeratePart<-1>(cut, sorted_idx, histogram, fidx, nidx, evaluator, best);
+            std::stable_sort(sorted_idx.begin(), sorted_idx.end(),
+                             [&](std::size_t l, std::size_t r) {
+                               return evaluator.CalcWeightCat(*param_, feat_hist[l]) <
+                                      evaluator.CalcWeightCat(*param_, feat_hist[r]);
+                             });
+            this->EnumeratePart<+1>(cut, sorted_idx, histogram, fidx, nidx, evaluator, best);
+            this->EnumeratePart<-1>(cut, sorted_idx, histogram, fidx, nidx, evaluator, best);
           }
         } else {
           auto grad_stats = EnumerateSplit<+1>(cut, histogram, fidx, nidx, evaluator, best);
@@ -630,9 +630,9 @@ class HistMultiEvaluator {
 
     std::int32_t n_threads = ctx_->Threads();
     std::size_t const grain_size = std::max<std::size_t>(1, features.front()->Size() / n_threads);
-    common::BlockedSpace2d space(
+    common::BlockedSpace2d space{
         entries.size(), [&](std::size_t nidx_in_set) { return features[nidx_in_set]->Size(); },
-        grain_size);
+        grain_size};
 
     std::vector<MultiExpandEntry> tloc_candidates(n_threads * entries.size());
     for (std::size_t i = 0; i < entries.size(); ++i) {

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -770,18 +770,20 @@ class HistMultiEvaluator {
         // Partition split
         std::vector<size_t> sorted_idx(n_bins);
         std::iota(sorted_idx.begin(), sorted_idx.end(), 0ul);
-        std::vector<GradientPairPrecise> l_grads(n_targets), r_grads(n_targets);
+        linalg::Vector<GradientPairPrecise> grads({n_targets * 2}, this->ctx_->Device());
+        auto l_grads = grads.Slice(linalg::Range(0ul, n_targets));
+        auto r_grads = grads.Slice(linalg::Range(n_targets, grads.Shape(0)));
         std::vector<float> l_w(n_targets, .0f), r_w(n_targets, .0f);
 
         std::stable_sort(sorted_idx.begin(), sorted_idx.end(), [&](std::size_t l, std::size_t r) {
           for (decltype(n_targets) t = 0; t < n_targets; ++t) {
             auto f_hist = node_hist[t].subspan(cut_ptr[fidx], n_bins);
-            l_grads[t] = f_hist[l];
-            r_grads[t] = f_hist[r];
+            l_grads(t) = f_hist[l];
+            r_grads(t) = f_hist[r];
           }
 
-          CalcWeight(*param_, linalg::MakeVec(l_grads), linalg::MakeVec(l_w.data(), l_w.size()));
-          CalcWeight(*param_, linalg::MakeVec(r_grads), linalg::MakeVec(r_w.data(), r_w.size()));
+          CalcWeight(*param_, l_grads, linalg::MakeVec(l_w.data(), l_w.size()));
+          CalcWeight(*param_, r_grads, linalg::MakeVec(r_w.data(), r_w.size()));
           // Run proj, compare score l_s < r_s
           float l_s = .0f, r_s = .0f;
           for (std::size_t i = 0; i < n_targets; ++i) {

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -636,6 +636,17 @@ class HistMultiEvaluator {
 
     bst_bin_t f_begin = cut_ptr[fidx];
     bst_bin_t f_end = cut_ptr[fidx + 1];
+    bst_bin_t n_bins_feature{f_end - f_begin};
+    auto n_bins = std::min(param_->max_cat_threshold, n_bins_feature);
+
+    bst_bin_t it_begin, it_end;
+    if (d_step > 0) {
+      it_begin = f_begin;
+      it_end = it_begin + n_bins - 1;
+    } else {
+      it_begin = f_end - 1;
+      it_end = it_begin - n_bins + 1;
+    }
   }
 
  public:

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -469,6 +469,17 @@ class HistEvaluator {
   }
 };
 
+inline void Norm(linalg::VectorView<float> value) {
+  double s = 0;
+  for (auto v : value) {
+    s += v * v;
+  }
+  auto norm = std::sqrt(s);
+  for (auto &v : value) {
+    v /= norm;
+  }
+}
+
 class HistMultiEvaluator {
   std::vector<double> gain_;
   linalg::Matrix<GradientPairPrecise> stats_;
@@ -614,6 +625,19 @@ class HistMultiEvaluator {
     p_best->Update(best);
   }
 
+  template <bst_bin_t d_step>
+  void EnumeratePart(common::HistogramCuts const &cut, common::Span<size_t const> sorted_idx,
+                     common::Span<common::ConstGHistRow> hist, bst_feature_t fidx, bst_node_t nidx,
+                     SplitEntryContainer<std::vector<GradientPairPrecise>> *p_best) {
+    static_assert(d_step == +1 || d_step == -1, "Invalid step.");
+
+    auto const &cut_ptr = cut.Ptrs();
+    auto const &cut_val = cut.Values();
+
+    bst_bin_t f_begin = cut_ptr[fidx];
+    bst_bin_t f_end = cut_ptr[fidx + 1];
+  }
+
  public:
   void EvaluateSplits(RegTree const &tree, common::Span<const BoundedHistCollection *> hist,
                       common::HistogramCuts const &cut,
@@ -640,16 +664,24 @@ class HistMultiEvaluator {
         tloc_candidates[i * n_threads + j] = entries[i];
       }
     }
+
     common::ParallelFor2d(space, n_threads, [&](std::size_t nidx_in_set, common::Range1d r) {
       auto tidx = omp_get_thread_num();
       auto entry = &tloc_candidates[n_threads * nidx_in_set + tidx];
       auto best = &entry->split;
+
       auto parent_sum = stats_.Slice(entry->nid, linalg::All());
+      auto base_weight = linalg::Zeros<float>(ctx_, parent_sum.Shape());
+      auto h_bw = base_weight.HostView();
+      CalcWeight(*param_, parent_sum, h_bw);
+      Norm(h_bw);
+
       std::vector<common::ConstGHistRow> node_hist;
       for (auto t_hist : hist) {
         node_hist.emplace_back((*t_hist)[entry->nid]);
       }
       auto features_set = features[nidx_in_set]->ConstHostSpan();
+      auto n_targets = hist.size();
 
       for (auto fidx_in_set = r.begin(); fidx_in_set < r.end(); fidx_in_set++) {
         auto fidx = features_set[fidx_in_set];
@@ -658,15 +690,52 @@ class HistMultiEvaluator {
         }
         auto parent_gain = gain_[entry->nid];
         bool is_cat = common::IsCat(feature_types, fidx);
-        if (is_cat) {
-          this->EnumerateOneHot(cut, fidx, node_hist, parent_sum, parent_gain, best);
-        } else {
+        // Numeric split
+        if (!is_cat) {
           bool missing =
               this->EnumerateSplit<+1>(cut, fidx, node_hist, parent_sum, parent_gain, best);
           if (missing) {
             this->EnumerateSplit<-1>(cut, fidx, node_hist, parent_sum, parent_gain, best);
           }
+          continue;
         }
+
+        auto const &cut_ptr = cut.Ptrs();
+        auto n_bins = cut_ptr.at(fidx + 1) - cut_ptr[fidx];
+        // One hot split
+        if (common::UseOneHot(n_bins, param_->max_cat_to_onehot)) {
+          this->EnumerateOneHot(cut, fidx, node_hist, parent_sum, parent_gain, best);
+          continue;
+        }
+
+        // Partition split
+        std::vector<size_t> sorted_idx(n_bins);
+        std::iota(sorted_idx.begin(), sorted_idx.end(), 0);
+        std::vector<GradientPairPrecise> l_grads(n_targets), r_grads(n_targets);
+
+        std::stable_sort(sorted_idx.begin(), sorted_idx.end(), [&](std::size_t l, std::size_t r) {
+          for (decltype(n_targets) t = 0; t < n_targets; ++t) {
+            auto f_hist = node_hist[t].subspan(cut_ptr[fidx], n_bins);
+            auto l_bin = f_hist[l];
+            auto r_bin = f_hist[r];
+            l_grads[t] = l_bin;
+            r_grads[t] = r_bin;
+          }
+          std::vector<float> l_w(n_targets, 0);
+          std::vector<float> r_w(n_targets, 0);
+          CalcWeight(*param_, linalg::MakeVec(l_grads), linalg::MakeVec(l_w.data(), l_w.size()));
+          CalcWeight(*param_, linalg::MakeVec(r_grads), linalg::MakeVec(r_w.data(), r_w.size()));
+          // Run proj, compare score l_s < r_s
+          float l_s = .0f, r_s = .0f;
+          for (std::size_t i = 0; i < n_targets; ++i) {
+            l_s += h_bw(i) * l_w[i];
+            r_s += h_bw(i) * r_w[i];
+          }
+          return l_s < r_s;
+        });
+
+        this->EnumeratePart<+1>(cut, sorted_idx, node_hist, fidx, entry->nid, best);
+        this->EnumeratePart<-1>(cut, sorted_idx, node_hist, fidx, entry->nid, best);
       }
     });
 

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -402,6 +402,7 @@ class TestHistMultiEvaluator : public ::testing::Test {
     ASSERT_EQ(hist_data.size(), kNTargets);
     for (bst_target_t t = 0; t < kNTargets; ++t) {
       ASSERT_EQ(hist_data[t].size(), kNCats);
+      root_sum_(t) = GradientPairPrecise{};
       auto node_hist = histogram_[t][0];
       for (bst_bin_t b = 0; b < kNCats; ++b) {
         node_hist[b] = hist_data[t][b];

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -362,66 +362,88 @@ TEST_F(TestCategoricalSplitWithMissing, HistEvaluator) {
                     GradientPairPrecise{split.right_sum.GetGrad(), split.right_sum.GetHess()});
 }
 
-TEST(HistMultiEvaluator, CategoricalOneHot) {
-  Context ctx;
-  ctx.nthread = 1;
+namespace {
+class TestHistMultiEvaluator : public ::testing::Test {
+ protected:
+  static constexpr bst_feature_t kNFeatures{1};
+  static constexpr bst_target_t kNTargets{2};
+  static constexpr bst_bin_t kNCats{3};
 
-  TrainParam param;
-  param.Init(Args{{"min_child_weight", "0"}, {"reg_lambda", "0"}, {"max_cat_to_onehot", "100"}});
-  auto sampler = std::make_shared<common::ColumnSampler>();
+  Context ctx_;
+  TrainParam param_;
+  std::shared_ptr<common::ColumnSampler> sampler_{std::make_shared<common::ColumnSampler>()};
+  MetaInfo info_;
+  std::vector<BoundedHistCollection> histogram_ = std::vector<BoundedHistCollection>(kNTargets);
+  linalg::Vector<GradientPairPrecise> root_sum_{{kNTargets}, DeviceOrd::CPU()};
+  common::HistogramCuts cuts_{kNFeatures};
+  RegTree tree_{kNTargets, kNFeatures};
+  std::vector<MultiExpandEntry> entries_ = std::vector<MultiExpandEntry>(1, {0, 0});
+  std::vector<BoundedHistCollection const *> histogram_ptrs_;
+  std::unique_ptr<HistMultiEvaluator> evaluator_;
 
-  bst_feature_t n_features = 1;
-  bst_target_t n_targets = 2;
-  bst_bin_t n_cats = 3;
+  void SetUp() override {
+    ctx_.nthread = 1;
+    info_.num_col_ = kNFeatures;
+    info_.feature_types = {FeatureType::kCategorical};
 
-  MetaInfo info;
-  info.num_col_ = n_features;
-  info.feature_types = {FeatureType::kCategorical};
+    cuts_.cut_ptrs_ = {0, kNCats};
+    cuts_.cut_values_ = {0.0, 1.0, 2.0};
+    cuts_.SetCategorical(true, 2.0);
 
-  HistMultiEvaluator evaluator{&ctx, info, &param, sampler};
-  HistMakerTrainParam hist_param;
-
-  // Per-target histograms with n_cats bins each.
-  std::vector<BoundedHistCollection> histogram(n_targets);
-  linalg::Vector<GradientPairPrecise> root_sum({n_targets}, DeviceOrd::CPU());
-  std::vector<std::vector<GradientPairPrecise>> hist_data = {
-      {{1.0, 0.5}, {-0.5, 0.5}, {0.5, 0.5}},   // t-0
-      {{0.5, 0.5}, {1.0, 0.5}, {-0.5, 0.5}}};  // t-1
-
-  for (bst_target_t t = 0; t < n_targets; ++t) {
-    auto &hist = histogram[t];
-    hist.Reset(n_cats * n_features, hist_param.MaxCachedHistNodes(ctx.Device()));
-    hist.AllocateHistograms({0});
-    auto node_hist = hist[0];
-    for (bst_bin_t b = 0; b < n_cats; ++b) {
-      node_hist[b] = hist_data[t][b];
-      root_sum(t) += node_hist[b];
+    HistMakerTrainParam hist_param;
+    for (auto &hist : histogram_) {
+      hist.Reset(cuts_.TotalBins(), hist_param.MaxCachedHistNodes(ctx_.Device()));
+      hist.AllocateHistograms({0});
+      histogram_ptrs_.push_back(&hist);
     }
   }
 
-  common::HistogramCuts cuts{n_features};
-  cuts.cut_ptrs_ = {0, 3};
-  cuts.cut_values_ = {0.0, 1.0, 2.0};
-  cuts.SetCategorical(true, 2.0);
-
-  RegTree tree{n_targets, n_features};
-  auto weight = evaluator.InitRoot(root_sum.HostView());
-  float root_sum_hess = 0.0f;
-  for (bst_target_t t = 0; t < n_targets; ++t) {
-    root_sum_hess += static_cast<float>(root_sum.HostView()(t).GetHess());
-  }
-  tree.SetRoot(weight.HostView(), root_sum_hess);
-
-  std::vector<MultiExpandEntry> entries(1, {0, 0});
-  std::vector<BoundedHistCollection const *> ptrs;
-  for (auto &h : histogram) {
-    ptrs.push_back(&h);
+  void SetHistData(std::vector<std::vector<GradientPairPrecise>> const &hist_data) {
+    ASSERT_EQ(hist_data.size(), kNTargets);
+    for (bst_target_t t = 0; t < kNTargets; ++t) {
+      ASSERT_EQ(hist_data[t].size(), kNCats);
+      auto node_hist = histogram_[t][0];
+      for (bst_bin_t b = 0; b < kNCats; ++b) {
+        node_hist[b] = hist_data[t][b];
+        root_sum_(t) += node_hist[b];
+      }
+    }
   }
 
-  std::vector<FeatureType> ft{FeatureType::kCategorical};
-  evaluator.EvaluateSplits(tree, ptrs, cuts, ft, &entries);
+  void EvaluateSplits(char const *max_cat_to_onehot) {
+    param_.Init(Args{
+        {"min_child_weight", "0"}, {"reg_lambda", "0"}, {"max_cat_to_onehot", max_cat_to_onehot}});
+    evaluator_ = std::make_unique<HistMultiEvaluator>(&ctx_, info_, &param_, sampler_);
 
-  auto const &split = entries.front().split;
+    auto weight = evaluator_->InitRoot(root_sum_.HostView());
+    float root_sum_hess = 0.0f;
+    for (bst_target_t t = 0; t < kNTargets; ++t) {
+      root_sum_hess += static_cast<float>(root_sum_(t).GetHess());
+    }
+    tree_.SetRoot(weight.HostView(), root_sum_hess);
+
+    evaluator_->EvaluateSplits(tree_, histogram_ptrs_, cuts_, info_.feature_types.ConstHostSpan(),
+                               &entries_);
+  }
+
+  void ApplyTreeSplit() {
+    ASSERT_TRUE(entries_.front().split.is_cat);
+    evaluator_->ApplyTreeSplit(entries_.front(), &tree_);
+    ASSERT_TRUE(tree_.HasCategoricalSplit());
+    auto mt_view = tree_.HostMtView();
+    ASSERT_EQ(mt_view.SplitType(0), FeatureType::kCategorical);
+    ASSERT_FALSE(mt_view.NodeCats(0).empty());
+  }
+};
+}  // anonymous namespace
+
+TEST_F(TestHistMultiEvaluator, CategoricalOneHot) {
+  // Per-target histograms with kNCats bins each.
+  this->SetHistData({{{1.0, 0.5}, {-0.5, 0.5}, {0.5, 0.5}},    // t-0
+                     {{0.5, 0.5}, {1.0, 0.5}, {-0.5, 0.5}}});  // t-1
+  this->EvaluateSplits("100");
+
+  auto const &split = entries_.front().split;
   ASSERT_TRUE(split.is_cat);
   ASSERT_FALSE(split.cat_bits.empty());
   ASSERT_GT(split.loss_chg, 0.0f);
@@ -431,10 +453,35 @@ TEST(HistMultiEvaluator, CategoricalOneHot) {
   ASSERT_TRUE(cat_bits.Check(chosen_cat));
 
   // Verify ApplyTreeSplit works with categorical split.
-  evaluator.ApplyTreeSplit(entries.front(), &tree);
-  ASSERT_TRUE(tree.HasCategoricalSplit());
-  auto mt_view = tree.HostMtView();
-  ASSERT_EQ(mt_view.SplitType(0), FeatureType::kCategorical);
-  ASSERT_FALSE(mt_view.NodeCats(0).empty());
+  this->ApplyTreeSplit();
+}
+
+TEST_F(TestHistMultiEvaluator, CategoricalPartition) {
+  this->SetHistData({{{-3.0, 1.0}, {-3.0, 1.0}, {-3.0, 1.0}},    // t-0
+                     {{-3.0, 1.0}, {-3.0, 1.0}, {-2.0, 1.0}}});  // t-1
+  // Include gradients for missing feature values. The optimal split is found by the
+  // backward scan, with missing values assigned to the right child.
+  root_sum_(0) += GradientPairPrecise{-3.0, 1.0};
+  root_sum_(1) += GradientPairPrecise{-2.0, 1.0};
+  this->EvaluateSplits("1");
+
+  auto const &split = entries_.front().split;
+  ASSERT_TRUE(split.is_cat);
+  ASSERT_FLOAT_EQ(split.loss_chg, 1.0f);
+  ASSERT_FALSE(split.DefaultLeft());
+  ASSERT_EQ(split.left_sum.size(), kNTargets);
+  ASSERT_EQ(split.right_sum.size(), kNTargets);
+
+  common::KCatBitField cat_bits{split.cat_bits};
+  ASSERT_FALSE(cat_bits.Check(0));
+  ASSERT_FALSE(cat_bits.Check(1));
+  ASSERT_TRUE(cat_bits.Check(2));
+  ASSERT_EQ(split.right_sum[0], GradientPairPrecise(-6.0, 2.0));
+  ASSERT_EQ(split.right_sum[1], GradientPairPrecise(-4.0, 2.0));
+  for (bst_target_t t = 0; t < kNTargets; ++t) {
+    ASSERT_EQ(split.left_sum[t] + split.right_sum[t], root_sum_(t));
+  }
+
+  this->ApplyTreeSplit();
 }
 }  // namespace xgboost::tree


### PR DESCRIPTION
Ref: https://github.com/dmlc/xgboost/issues/9043

The following datasets are from UCI, categorical features are forced to use partition-based splits. The comparison is between scalar trees (one tree per target) and vector leaf.
```
solar_flare: train=1111, eval=278, features=10, outputs=3, rounds=128
  vector: 0.171 seconds, train-rmse=0.33245, eval-rmse=0.61139
  scalar: 0.162 seconds, train-rmse=0.33220, eval-rmse=0.63445
  eval-rmse chg (sc-vl): +0.02306, perf (sc/vl): 0.949783378134431

connect_4: train=54045, eval=13512, features=42, outputs=3, rounds=128
  vector: 0.698 seconds, train-mlogloss=0.33800, eval-mlogloss=0.39686
  scalar: 0.757 seconds, train-mlogloss=0.32513, eval-mlogloss=0.39425
  eval-mlogloss chg (sc-vl): -0.00260, perf (sc/vl): 1.0852552151512045

nursery: train=10368, eval=2592, features=8, outputs=5, rounds=128
  vector: 0.269 seconds, train-mlogloss=0.00328, eval-mlogloss=0.00366
  scalar: 0.306 seconds, train-mlogloss=0.00150, eval-mlogloss=0.00217
  eval-mlogloss chg (sc-vl): -0.00148, perf (sc/vl): 1.136013098815361

car_evaluation: train=1382, eval=346, features=6, outputs=4, rounds=128
  vector: 0.132 seconds, train-mlogloss=0.00585, eval-mlogloss=0.02363
  scalar: 0.158 seconds, train-mlogloss=0.00654, eval-mlogloss=0.02614
  eval-mlogloss chg (sc-vl): +0.00251, perf (sc/vl): 1.1940488904701243

poker_hand: train=820008, eval=205002, features=10, outputs=10, rounds=128
  vector: 17.451 seconds, train-mlogloss=0.28009, eval-mlogloss=0.28601
  scalar: 18.357 seconds, train-mlogloss=0.20474, eval-mlogloss=0.21644
  eval-mlogloss chg (sc-vl): -0.06958, perf (sc/vl): 1.0518899940441868

covertype: train=464809, eval=116203, features=12, outputs=7, rounds=128
  vector: 8.470 seconds, train-mlogloss=0.28692, eval-mlogloss=0.30212
  scalar: 8.356 seconds, train-mlogloss=0.24970, eval-mlogloss=0.27284
  eval-mlogloss chg (sc-vl): -0.02928, perf (sc/vl): 0.9864787202957024
```

The two features `Wilderness_Area` and `Soil_Type` in the `covtype` are recovered from OHE results.

We might run into issues with zero-weight parent nodes, and there are fallback strategies, but I don't want to make things too complicated at the moment, it's an approximation anyway.