### PR TITLE
Add Tsallis entropy-based information gain split criterion

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -848,6 +848,8 @@ class XGBModel(XGBModelBase):
         max_cat_to_onehot: Optional[int] = None,
         max_cat_threshold: Optional[int] = None,
         multi_strategy: Optional[str] = None,
+        split_criterion: Optional[str] = None,
+        tsallis_beta: Optional[float] = None,
         eval_metric: Optional[Union[str, List[Union[str, Callable]], Callable]] = None,
         early_stopping_rounds: Optional[int] = None,
         callbacks: Optional[List[TrainingCallback]] = None,
@@ -901,6 +903,8 @@ class XGBModel(XGBModelBase):
         self.max_cat_to_onehot = max_cat_to_onehot
         self.max_cat_threshold = max_cat_threshold
         self.multi_strategy = multi_strategy
+        self.split_criterion = split_criterion
+        self.tsallis_beta = tsallis_beta
         self.eval_metric = eval_metric
         self.early_stopping_rounds = early_stopping_rounds
         self.callbacks = callbacks

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -36,6 +36,10 @@ struct TrainParam : public XGBoostParameter<TrainParam> {
   // growing policy
   enum TreeGrowPolicy { kDepthWise = 0, kLossGuide = 1 };
   int grow_policy;
+  // split criterion
+  enum SplitCriterion { kGain = 0, kTsallisIG = 1 };
+  int split_criterion;
+  float tsallis_beta;
 
   std::uint32_t max_cat_to_onehot{4};
 
@@ -106,6 +110,15 @@ struct TrainParam : public XGBoostParameter<TrainParam> {
             "Tree growing policy. 0: favor splitting at nodes closest to the node, "
             "i.e. grow depth-wise. 1: favor splitting at nodes with highest loss "
             "change. (cf. LightGBM)");
+    DMLC_DECLARE_FIELD(split_criterion)
+        .set_default(kGain)
+        .add_enum("gain", kGain)
+        .add_enum("tsallis_ig", kTsallisIG)
+        .describe("Split criterion for tree building.");
+    DMLC_DECLARE_FIELD(tsallis_beta)
+        .set_lower_bound(0.0f)
+        .set_default(0.5f)
+        .describe("Beta parameter for Tsallis entropy-based split criterion. Must be > 0 and != 1.");
     DMLC_DECLARE_FIELD(max_cat_to_onehot)
         .set_default(4)
         .set_lower_bound(1)
@@ -359,6 +372,45 @@ struct XGBOOST_ALIGNAS(16) GradStats {
   inline void Add(GradType grad, GradType hess) {
     sum_grad += grad;
     sum_hess += hess;
+  }
+};
+
+/*! \brief Statistics for Tsallis entropy-based information gain split criterion */
+struct IGStats {
+  double sum_xy{0};   // sum of feature_value * label
+  double sum_x2{0};   // sum of feature_value^2
+  double sum_y2{0};   // sum of label^2
+  double count{0};    // number of instances
+
+  IGStats() = default;
+
+  void Add(float x, float y) {
+    sum_xy += static_cast<double>(x) * y;
+    sum_x2 += static_cast<double>(x) * x;
+    sum_y2 += static_cast<double>(y) * y;
+    count += 1.0;
+  }
+  void Add(IGStats const& b) {
+    sum_xy += b.sum_xy; sum_x2 += b.sum_x2;
+    sum_y2 += b.sum_y2; count += b.count;
+  }
+  void SetSubtract(IGStats const& a, IGStats const& b) {
+    sum_xy = a.sum_xy - b.sum_xy; sum_x2 = a.sum_x2 - b.sum_x2;
+    sum_y2 = a.sum_y2 - b.sum_y2; count = a.count - b.count;
+  }
+  [[nodiscard]] bool Empty() const { return count == 0.0; }
+
+  // Compute IG(X, Y) = 1/(1-beta) * (1/sigma^{beta-1} - 1)
+  // sigma = (sum_y2 - sum_xy^2 / sum_x2) / count
+  static float CalcTsallisIG(float beta, IGStats const& s) {
+    if (s.count <= 1.0 || s.sum_x2 <= 0.0) return 0.0f;
+    double a = s.sum_xy / s.sum_x2;
+    double sigma = (s.sum_y2 - 2.0 * a * s.sum_xy + a * a * s.sum_x2) / s.count;
+    if (sigma <= 0.0) return 0.0f;
+    double exp = 1.0 - static_cast<double>(beta);
+    double ig = (1.0 / exp) * (std::pow(sigma, exp) - 1.0);
+    if (!std::isfinite(ig)) return 0.0f;
+    return static_cast<float>(ig);
   }
 };
 

--- a/src/tree/updater_approx.cc
+++ b/src/tree/updater_approx.cc
@@ -287,6 +287,9 @@ class GlobalApproxUpdater : public TreeUpdater {
   void Update(TrainParam const *param, GradientContainer *in_gpair, DMatrix *m,
               common::Span<HostDeviceVector<bst_node_t>> out_position,
               const std::vector<RegTree *> &trees) override {
+    if (param->split_criterion == TrainParam::kTsallisIG) {
+      LOG(FATAL) << "Tsallis IG split criterion is only supported by the exact tree method (tree_method='exact').";
+    }
     CHECK(hist_param_.GetInitialised());
     pimpl_ = std::make_unique<GlobalApproxBuilder>(param, &hist_param_, m->Info(), ctx_,
                                                    column_sampler_, task_, &monitor_);

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -109,6 +109,12 @@ class ColMaker : public TreeUpdater {
     if (param->colsample_bynode - 1.0 != 0.0) {
       LOG(FATAL) << "column sample by node is not yet supported by the exact tree method";
     }
+    if (param->split_criterion == TrainParam::kTsallisIG) {
+      CHECK_EQ(dmat->Info().labels.Shape(1), 1)
+          << "Tsallis IG split criterion only supports single-target regression.";
+      CHECK_GT(dmat->Info().labels.Size(), 0)
+          << "Tsallis IG split criterion requires labels.";
+    }
     this->LazyGetColumnDensity(dmat);
     // rescale learning rate according to size of trees
     interaction_constraints_.Configure(*param, dmat->Info().num_row_);
@@ -134,6 +140,8 @@ class ColMaker : public TreeUpdater {
   struct ThreadEntry {
     /*! \brief statistics of data */
     GradStats stats;
+    /*! \brief IG statistics for Tsallis entropy split criterion */
+    IGStats ig_stats;
     /*! \brief last feature value scanned */
     bst_float last_fvalue{0};
     /*! \brief current best solution */
@@ -170,6 +178,12 @@ class ColMaker : public TreeUpdater {
     // update one tree, growing
     virtual void Update(const std::vector<GradientPair> &gpair, DMatrix *p_fmat, RegTree *p_tree) {
       std::vector<int> newnodes;
+      auto const& h_labels = p_fmat->Info().labels;
+      if (param_.split_criterion == TrainParam::kTsallisIG) {
+        CHECK_EQ(h_labels.Shape(1), 1) << "Tsallis IG criterion only supports single-target.";
+        CHECK_GT(h_labels.Size(), 0) << "Tsallis IG criterion requires labels.";
+      }
+      labels_ptr_ = h_labels.Data()->ConstHostPointer();
       this->InitData(gpair, *p_fmat);
       this->InitNewNode(qexpand_, gpair, *p_fmat, *p_tree);
       // We can check max_leaves too, but might break some grid searching pipelines.
@@ -312,7 +326,7 @@ class ColMaker : public TreeUpdater {
 
     // update enumeration solution
     inline void UpdateEnumeration(
-        int nid, GradientPair gstats, bst_float fvalue, int d_step, bst_uint fid,
+        int nid, GradientPair gstats, bst_float fvalue, bst_float label, int d_step, bst_uint fid,
         GradStats &c,                    // NOLINT
         std::vector<ThreadEntry> &temp,  // NOLINT(*)
         TreeEvaluator::SplitEvaluator<TrainParam> const &evaluator) const {
@@ -321,6 +335,7 @@ class ColMaker : public TreeUpdater {
       // test if first hit, this is fine, because we set 0 during init
       if (e.stats.Empty()) {
         e.stats.Add(gstats);
+        e.ig_stats.Add(fvalue, label);
         e.last_fvalue = fvalue;
       } else {
         // try to find a split
@@ -328,7 +343,19 @@ class ColMaker : public TreeUpdater {
           c.SetSubstract(snode_[nid].stats, e.stats);
           if (c.sum_hess >= param_.min_child_weight) {
             bst_float loss_chg{0};
-            if (d_step == -1) {
+            if (param_.split_criterion == TrainParam::kTsallisIG) {
+              IGStats right_ig;
+              right_ig.SetSubtract(parent_ig_[nid][fid], e.ig_stats);
+              loss_chg = IGStats::CalcTsallisIG(param_.tsallis_beta, e.ig_stats)
+                       + IGStats::CalcTsallisIG(param_.tsallis_beta, right_ig)
+                       - IGStats::CalcTsallisIG(param_.tsallis_beta, parent_ig_[nid][fid]);
+              bst_float proposed_split = (fvalue + e.last_fvalue) * 0.5f;
+              if (proposed_split == fvalue) {
+                e.best.Update(loss_chg, fid, e.last_fvalue, d_step == -1, false, e.stats, c);
+              } else {
+                e.best.Update(loss_chg, fid, proposed_split, d_step == -1, false, e.stats, c);
+              }
+            } else if (d_step == -1) {
               loss_chg = static_cast<bst_float>(
                   evaluator.CalcSplitGain(param_, nid, fid, c, e.stats) - snode_[nid].root_gain);
               bst_float proposed_split = (fvalue + e.last_fvalue) * 0.5f;
@@ -351,6 +378,7 @@ class ColMaker : public TreeUpdater {
         }
         // update the statistics
         e.stats.Add(gstats);
+        e.ig_stats.Add(fvalue, label);
         e.last_fvalue = fvalue;
       }
     }
@@ -363,6 +391,7 @@ class ColMaker : public TreeUpdater {
       // clear all the temp statistics
       for (auto nid : qexpand) {
         temp[nid].stats = GradStats();
+        temp[nid].ig_stats = IGStats();
       }
       // left statistics
       GradStats c;
@@ -370,6 +399,7 @@ class ColMaker : public TreeUpdater {
       constexpr int kBuffer = 32;
       int buf_position[kBuffer] = {};
       GradientPair buf_gpair[kBuffer] = {};
+      float buf_label[kBuffer] = {};
       // aligned ending position
       const Entry *align_end;
       if (d_step > 0) {
@@ -386,13 +416,14 @@ class ColMaker : public TreeUpdater {
         for (i = 0, p = it; i < kBuffer; ++i, p += d_step) {
           buf_position[i] = position_[p->index];
           buf_gpair[i] = gpair[p->index];
+          buf_label[i] = labels_ptr_[p->index];
         }
         for (i = 0, p = it; i < kBuffer; ++i, p += d_step) {
           const int nid = buf_position[i];
           if (nid < 0 || !interaction_constraints_.Query(nid, fid)) {
             continue;
           }
-          this->UpdateEnumeration(nid, buf_gpair[i], p->fvalue, d_step, fid, c, temp, evaluator);
+          this->UpdateEnumeration(nid, buf_gpair[i], p->fvalue, buf_label[i], d_step, fid, c, temp, evaluator);
         }
       }
 
@@ -400,13 +431,14 @@ class ColMaker : public TreeUpdater {
       for (it = align_end, i = 0; it != end; ++i, it += d_step) {
         buf_position[i] = position_[it->index];
         buf_gpair[i] = gpair[it->index];
+        buf_label[i] = labels_ptr_[it->index];
       }
       for (it = align_end, i = 0; it != end; ++i, it += d_step) {
         const int nid = buf_position[i];
         if (nid < 0 || !interaction_constraints_.Query(nid, fid)) {
           continue;
         }
-        this->UpdateEnumeration(nid, buf_gpair[i], it->fvalue, d_step, fid, c, temp, evaluator);
+        this->UpdateEnumeration(nid, buf_gpair[i], it->fvalue, buf_label[i], d_step, fid, c, temp, evaluator);
       }
       // finish updating all statistics, check if it is possible to include all sum statistics
       for (int nid : qexpand) {
@@ -416,13 +448,22 @@ class ColMaker : public TreeUpdater {
           bst_float loss_chg;
           const bst_float gap = std::abs(e.last_fvalue) + kRtEps;
           const bst_float delta = d_step == +1 ? gap : -gap;
-          if (d_step == -1) {
+          if (param_.split_criterion == TrainParam::kTsallisIG) {
+            IGStats right_ig;
+            right_ig.SetSubtract(parent_ig_[nid][fid], e.ig_stats);
+            loss_chg = IGStats::CalcTsallisIG(param_.tsallis_beta, e.ig_stats)
+                     + IGStats::CalcTsallisIG(param_.tsallis_beta, right_ig)
+                     - IGStats::CalcTsallisIG(param_.tsallis_beta, parent_ig_[nid][fid]);
+          } else if (d_step == -1) {
             loss_chg = static_cast<bst_float>(
                 evaluator.CalcSplitGain(param_, nid, fid, c, e.stats) - snode_[nid].root_gain);
-            e.best.Update(loss_chg, fid, e.last_fvalue + delta, d_step == -1, false, c, e.stats);
           } else {
             loss_chg = static_cast<bst_float>(
                 evaluator.CalcSplitGain(param_, nid, fid, e.stats, c) - snode_[nid].root_gain);
+          }
+          if (d_step == -1) {
+            e.best.Update(loss_chg, fid, e.last_fvalue + delta, d_step == -1, false, c, e.stats);
+          } else {
             e.best.Update(loss_chg, fid, e.last_fvalue + delta, d_step == -1, false, e.stats, c);
           }
         }
@@ -463,6 +504,9 @@ class ColMaker : public TreeUpdater {
 
       auto feat_set = column_sampler_->GetFeatureSet(ctx_, depth);
       for (const auto &batch : p_fmat->GetBatches<SortedCSCPage>(ctx_)) {
+        if (param_.split_criterion == TrainParam::kTsallisIG) {
+          ComputeParentIG(qexpand, p_fmat->Info().num_col_, batch);
+        }
         this->UpdateSolution(batch, feat_set->HostVector(), gpair);
       }
       // after this each thread's stemp will get the best candidates, aggregate results
@@ -524,6 +568,26 @@ class ColMaker : public TreeUpdater {
         }
       }
     }
+    // compute parent IG stats for Tsallis criterion
+    void ComputeParentIG(std::vector<int> const& qexpand, bst_feature_t n_features,
+                         SortedCSCPage const& page) {
+      if (param_.split_criterion != TrainParam::kTsallisIG) return;
+      auto view = page.GetView();
+      parent_ig_.resize(snode_.size());
+      for (auto nid : qexpand) {
+        parent_ig_[nid].assign(n_features, IGStats());
+      }
+      for (bst_feature_t fid = 0; fid < static_cast<bst_feature_t>(view.Size()); ++fid) {
+        auto col = view[fid];
+        for (size_t j = 0; j < col.size(); ++j) {
+          int nid = position_[col[j].index];
+          if (nid < 0) continue;
+          if (static_cast<size_t>(nid) < parent_ig_.size() && !parent_ig_[nid].empty()) {
+            parent_ig_[nid][fid].Add(col[j].fvalue, labels_ptr_[col[j].index]);
+          }
+        }
+      }
+    }
     virtual void SetNonDefaultPosition(const std::vector<int> &qexpand, DMatrix *p_fmat,
                                        const RegTree &tree) {
       // step 1, classify the non-default data into right places
@@ -581,6 +645,8 @@ class ColMaker : public TreeUpdater {
 
     FeatureInteractionConstraintHost interaction_constraints_;
     const std::vector<float> &column_densities_;
+    const float* labels_ptr_{nullptr};            // pointer to label data
+    std::vector<std::vector<IGStats>> parent_ig_; // parent_ig_[nid][fid]
   };
 };
 

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -629,6 +629,9 @@ class QuantileHistMaker : public TreeUpdater {
   void Update(TrainParam const *param, GradientContainer *in_gpair, DMatrix *p_fmat,
               common::Span<HostDeviceVector<bst_node_t>> out_position,
               const std::vector<RegTree *> &trees) override {
+    if (param->split_criterion == TrainParam::kTsallisIG) {
+      LOG(FATAL) << "Tsallis IG split criterion is only supported by the exact tree method (tree_method='exact').";
+    }
     if (trees.front()->IsMultiTarget()) {
       CHECK(hist_param_.GetInitialised());
       if (!param->monotone_constraints.empty()) {


### PR DESCRIPTION
## Summary
- Adds a new split criterion (`split_criterion='tsallis_ig'`) for the exact tree method based on Tsallis entropy of OLS residuals
- **Formula**: `IG(X, Y) = 1/(1-beta) * (1/sigma^{beta-1} - 1)` where sigma is mean squared residual from OLS regression of Y on X
- Split quality = `IG_left + IG_right - IG_parent` (information gain decomposition)
- Only supported for `tree_method='exact'`; hist/approx methods produce a clear error
- New parameter: `tsallis_beta` (default 0.5, must be > 0 and != 1)

## Changes
| File | Changes |
|------|---------|
| `src/tree/param.h` | `SplitCriterion` enum, `split_criterion`/`tsallis_beta` params, `IGStats` struct |
| `src/tree/updater_colmaker.cc` | IG stats accumulation + IG-based loss_chg in exact method |
| `src/tree/updater_quantile_hist.cc` | Guard rejecting Tsallis IG with hist method |
| `src/tree/updater_approx.cc` | Guard rejecting Tsallis IG with approx method |
| `python-package/xgboost/sklearn.py` | `split_criterion` and `tsallis_beta` in sklearn API |

## Test plan
- [x] Default `split_criterion='gain'` still works
- [x] `split_criterion='tsallis_ig'` with `tree_method='exact'` trains and produces finite predictions
- [x] Sklearn `XGBRegressor(split_criterion='tsallis_ig')` works
- [x] Constant (all-zeros) feature does not crash (IG=0 for that feature)
- [x] `tree_method='hist'` with Tsallis IG correctly fails with error
- [x] Various beta values (0.1, 0.5, 1.5, 2.0) produce finite predictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)