### PR TITLE
[MT] GPU implementation of partition-based categorical split.

### DIFF
--- a/R-package/tests/testthat/test_interaction_constraints.R
+++ b/R-package/tests/testthat/test_interaction_constraints.R
@@ -41,7 +41,7 @@ test_that("interaction constraints for regression", {
   test2 <- all(abs(diff2 - diff2[1]) < 1e-4)
 
   expect_true({
-    test1 & test2
+    test1 && test2
   }, "Interaction Contraint Satisfied")
 })
 

--- a/doc/tutorials/categorical.rst
+++ b/doc/tutorials/categorical.rst
@@ -91,7 +91,8 @@ group the categories that output similar leaf values. During split finding, we f
 the gradient histogram to prepare the contiguous partitions then enumerate the splits
 according to these sorted values. One of the related parameters for XGBoost is
 ``max_cat_to_onehot``, which controls whether one-hot encoding or partitioning should be
-used for each feature, see :ref:`cat-param` for details.
+used for each feature, see :ref:`cat-param` for details. See :doc:`/tutorials/multioutput`
+for the vector-leaf variant.
 
 
 **********************

--- a/doc/tutorials/multioutput.rst
+++ b/doc/tutorials/multioutput.rst
@@ -137,6 +137,41 @@ implement the ``split_grad`` method.
 See :ref:`sphx_glr_python_examples_multioutput_reduced_gradient.py` for a complete worked
 example. The feature supports only the ``multi_strategy=multi_output_tree``.
 
+***********************************
+Partitioning for categorical splits
+***********************************
+
+.. versionadded:: 3.4.0
+
+For scalar leaves, XGBoost uses :doc:`optimal partitioning </tutorials/categorical>` to
+avoid enumerating all :math:`2^{k-1} - 1` binary partitions of :math:`k` categories.
+
+For vector leaves, each category has a weight vector and there is no canonical ordering of
+vectors. XGBoost induces an ordering by projecting each category weight onto the parent's
+Newton update direction:
+
+.. math::
+
+  u_p &= \frac{w_p}{\lVert w_p \rVert_2} \\
+  s_c &= u_p^T w_c
+
+where :math:`w_p` is the parent leaf weight and :math:`w_c` is the category-level leaf
+weight. The score measures how strongly category :math:`c` follows the parent update
+direction.
+
+The projection has some nice consistency properties. For one output, it agrees with the
+standard scalar ordering up to reversal. For parent-aligned vector effects,
+
+.. math::
+
+   w_c = \alpha_c w_p
+
+we have :math:`s_c = \alpha_c \lVert w_p \rVert_2`, so ordering the projected scores is
+equivalent to ordering the scalar coefficients :math:`\alpha_c`. In general, however, it
+is an approximation: category contrasts orthogonal to the parent update can be missed,
+and a weak parent update provides little ordering signal.
+
+
 **********
 References
 **********

--- a/python-package/xgboost/testing/multi_target.py
+++ b/python-package/xgboost/testing/multi_target.py
@@ -1,6 +1,7 @@
 """Tests for multi-target training."""
 
 # pylint: disable=unbalanced-tuple-unpacking
+import json
 from types import ModuleType
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -24,6 +25,68 @@ from ..training import train
 from .data import IteratorForTest
 from .updater import ResetStrategy, train_result
 from .utils import Device, assert_allclose, non_increasing
+
+
+def check_categorical_mixed(device: Device) -> None:  # pylint: disable=too-many-locals
+    """Test mixed numerical, one-hot, and partition-based splits."""
+    pd = pytest.importorskip("pandas")
+
+    features = np.stack(
+        [
+            np.repeat(np.arange(2), 16),
+            np.tile(np.repeat(np.arange(2), 8), 2),
+            np.tile(np.arange(8), 4),
+        ],
+        axis=1,
+    )
+    X = pd.DataFrame(
+        {
+            "numeric": features[:, 0].astype(np.float32),
+            "onehot": pd.Categorical(features[:, 1], categories=range(2)),
+            "partition": pd.Categorical(features[:, 2], categories=range(8)),
+        }
+    )
+    y = np.column_stack(
+        [
+            8.0 * features[:, 0],
+            6.0 * features[:, 1],
+            10.0 * (features[:, 2] >= 4),
+        ]
+    ).astype(np.float32)
+    Xy = DMatrix(X, y, enable_categorical=True)
+
+    booster = train(
+        {
+            "device": device,
+            "tree_method": "hist",
+            "multi_strategy": "multi_output_tree",
+            "max_cat_to_onehot": 4,
+            "max_depth": 3,
+            "learning_rate": 1.0,
+            "reg_lambda": 0,
+            "min_child_weight": 0,
+            "base_score": 0,
+        },
+        Xy,
+        num_boost_round=4,
+    )
+    np.testing.assert_allclose(booster.predict(Xy), y)
+
+    model = json.loads(booster.save_raw(raw_format="json"))
+    tree = model["learner"]["gradient_booster"]["model"]["trees"][0]
+    split_indices = np.asarray(tree["split_indices"])
+    split_types = np.asarray(tree["split_type"])
+    is_internal = np.asarray(tree["left_children"]) != -1
+    is_categorical = split_types.astype(bool)
+
+    numerical_features = split_indices[is_internal & ~is_categorical]
+    categorical_features = split_indices[is_internal & is_categorical]
+    category_sizes = np.asarray(tree["categories_sizes"])
+
+    assert set(numerical_features) == {0}
+    assert set(categorical_features) == {1, 2}
+    np.testing.assert_equal(category_sizes[categorical_features == 1], 1)
+    assert np.any(category_sizes[categorical_features == 2] > 1)
 
 
 def run_multiclass(device: Device, learning_rate: Optional[float]) -> None:

--- a/python-package/xgboost/testing/updater.py
+++ b/python-package/xgboost/testing/updater.py
@@ -416,6 +416,8 @@ def _create_dmatrix(  # pylint: disable=too-many-arguments
     onehot: bool,
     extmem: bool,
     enable_categorical: bool,
+    n_targets: int = 1,
+    max_bin: Optional[int] = None,
 ) -> DMatrix:
     n_batches = max(min(2, n_samples), 1)
     it = CatIter(
@@ -428,11 +430,12 @@ def _create_dmatrix(  # pylint: disable=too-many-arguments
         onehot=onehot,
         device=device,
         cache="cache" if extmem else None,
+        n_targets=n_targets,
     )
     if extmem:
         if tree_method == "hist":
             Xy: DMatrix = ExtMemQuantileDMatrix(
-                it, enable_categorical=enable_categorical
+                it, enable_categorical=enable_categorical, max_bin=max_bin
             )
         elif tree_method == "approx":
             Xy = DMatrix(it, enable_categorical=enable_categorical)
@@ -457,8 +460,6 @@ def check_categorical_ohe(  # pylint: disable=too-many-arguments
     max_bin: Optional[int] = None,
 ) -> None:
     "Test for one-hot encoding with categorical data."
-    pd = pytest.importorskip("pandas")
-
     by_etl_results: Dict[str, Dict[str, List[float]]] = {}
     by_builtin_results: Dict[str, Dict[str, List[float]]] = {}
 
@@ -472,45 +473,36 @@ def check_categorical_ohe(  # pylint: disable=too-many-arguments
     if max_bin is not None:
         parameters["max_bin"] = max_bin
 
+    n_targets = 3 if multi_target else 1
     if multi_target:
-        n_targets = 3
         parameters["multi_strategy"] = "multi_output_tree"
 
-        cat, label = make_categorical(
-            rows,
-            cols,
-            n_categories=cats,
-            onehot=False,
-            sparsity=0.0,
-            n_targets=n_targets,
-        )
-
-        # fixme: extmem
-        Xy_onehot = DMatrix(pd.get_dummies(cat), label)
-        Xy_cat = DMatrix(cat, label, enable_categorical=True)
-    else:
-        Xy_onehot = _create_dmatrix(
-            rows,
-            cols,
-            n_cats=cats,
-            device=device,
-            sparsity=0.0,
-            onehot=True,
-            tree_method=tree_method,
-            extmem=extmem,
-            enable_categorical=False,
-        )
-        Xy_cat = _create_dmatrix(
-            rows,
-            cols,
-            n_cats=cats,
-            device=device,
-            sparsity=0.0,
-            tree_method=tree_method,
-            onehot=False,
-            extmem=extmem,
-            enable_categorical=True,
-        )
+    Xy_onehot = _create_dmatrix(
+        rows,
+        cols,
+        n_cats=cats,
+        device=device,
+        sparsity=0.0,
+        onehot=True,
+        tree_method=tree_method,
+        extmem=extmem,
+        enable_categorical=False,
+        n_targets=n_targets,
+        max_bin=max_bin,
+    )
+    Xy_cat = _create_dmatrix(
+        rows,
+        cols,
+        n_cats=cats,
+        device=device,
+        sparsity=0.0,
+        tree_method=tree_method,
+        onehot=False,
+        extmem=extmem,
+        enable_categorical=True,
+        n_targets=n_targets,
+        max_bin=max_bin,
+    )
 
     train(
         parameters,
@@ -519,7 +511,7 @@ def check_categorical_ohe(  # pylint: disable=too-many-arguments
         evals=[(Xy_onehot, "Train")],
         evals_result=by_etl_results,
     )
-    train(
+    booster_onehot = train(
         parameters,
         Xy_cat,
         num_boost_round=rounds,
@@ -542,18 +534,30 @@ def check_categorical_ohe(  # pylint: disable=too-many-arguments
     by_grouping: Dict[str, Dict[str, List[float]]] = {}
     # switch to partition-based splits
     parameters["max_cat_to_onehot"] = USE_PART
-    train(
+    booster_partition = train(
         parameters,
         Xy_cat,
         num_boost_round=rounds,
         evals=[(Xy_cat, "Train")],
         evals_result=by_grouping,
     )
-    rmse_oh = by_builtin_results["Train"]["rmse"]
     rmse_group = by_grouping["Train"]["rmse"]
-    # always better or equal to onehot when there's no regularization.
-    for a, b in zip(rmse_oh, rmse_group):
-        assert a >= b
+    assert non_increasing(rmse_group)
+
+    model_onehot = json.loads(booster_onehot.save_raw(raw_format="json"))
+    model_partition = json.loads(booster_partition.save_raw(raw_format="json"))
+    tree_onehot = model_onehot["learner"]["gradient_booster"]["model"]["trees"][0]
+    tree_partition = model_partition["learner"]["gradient_booster"]["model"]["trees"][0]
+    assert tree_onehot["categories_sizes"]
+    assert tree_partition["categories_sizes"]
+    assert all(size == 1 for size in tree_onehot["categories_sizes"])
+
+    if not multi_target:
+        # Scalar partition sorting finds the best split for a fixed node. Compare the
+        # common root instead of complete greedy trees, whose later paths can diverge.
+        gain_onehot = tree_onehot["loss_changes"][0]
+        gain_partition = tree_partition["loss_changes"][0]
+        assert gain_partition >= gain_onehot or np.isclose(gain_partition, gain_onehot)
 
     parameters["reg_lambda"] = 1.0
     by_grouping = {}
@@ -608,7 +612,7 @@ def check_categorical_mixed(device: Device) -> None:
             "base_score": 0,
         },
         Xy,
-        num_boost_round=1,
+        num_boost_round=4,
     )
     np.testing.assert_allclose(booster.predict(Xy), y)
 

--- a/python-package/xgboost/testing/updater.py
+++ b/python-package/xgboost/testing/updater.py
@@ -571,68 +571,6 @@ def check_categorical_ohe(  # pylint: disable=too-many-arguments
     assert non_increasing(by_grouping["Train"]["rmse"]), by_grouping
 
 
-def check_categorical_mixed(device: Device) -> None:
-    """Test mixed numerical, one-hot, and partition-based splits."""
-    pd = pytest.importorskip("pandas")
-
-    features = np.stack(
-        [
-            np.repeat(np.arange(2), 16),
-            np.tile(np.repeat(np.arange(2), 8), 2),
-            np.tile(np.arange(8), 4),
-        ],
-        axis=1,
-    )
-    X = pd.DataFrame(
-        {
-            "numeric": features[:, 0].astype(np.float32),
-            "onehot": pd.Categorical(features[:, 1], categories=range(2)),
-            "partition": pd.Categorical(features[:, 2], categories=range(8)),
-        }
-    )
-    y = np.column_stack(
-        [
-            8.0 * features[:, 0],
-            6.0 * features[:, 1],
-            10.0 * (features[:, 2] >= 4),
-        ]
-    ).astype(np.float32)
-    Xy = DMatrix(X, y, enable_categorical=True)
-
-    booster = train(
-        {
-            "device": device,
-            "tree_method": "hist",
-            "multi_strategy": "multi_output_tree",
-            "max_cat_to_onehot": 4,
-            "max_depth": 3,
-            "learning_rate": 1.0,
-            "reg_lambda": 0,
-            "min_child_weight": 0,
-            "base_score": 0,
-        },
-        Xy,
-        num_boost_round=4,
-    )
-    np.testing.assert_allclose(booster.predict(Xy), y)
-
-    model = json.loads(booster.save_raw(raw_format="json"))
-    tree = model["learner"]["gradient_booster"]["model"]["trees"][0]
-    split_indices = np.asarray(tree["split_indices"])
-    split_types = np.asarray(tree["split_type"])
-    is_internal = np.asarray(tree["left_children"]) != -1
-    is_categorical = split_types.astype(bool)
-
-    numerical_features = split_indices[is_internal & ~is_categorical]
-    categorical_features = split_indices[is_internal & is_categorical]
-    category_sizes = np.asarray(tree["categories_sizes"])
-
-    assert set(numerical_features) == {0}
-    assert set(categorical_features) == {1, 2}
-    np.testing.assert_equal(category_sizes[categorical_features == 1], 1)
-    assert np.any(category_sizes[categorical_features == 2] > 1)
-
-
 def check_categorical_missing(  # pylint: disable=too-many-arguments
     rows: int,
     cols: int,

--- a/python-package/xgboost/testing/updater.py
+++ b/python-package/xgboost/testing/updater.py
@@ -571,6 +571,29 @@ def check_categorical_ohe(  # pylint: disable=too-many-arguments
     assert non_increasing(by_grouping["Train"]["rmse"]), by_grouping
 
 
+def check_categorical_bitfield_boundaries(
+    device: Device, cats: int, multi_target: bool
+) -> None:
+    """Test scalar and vector categorical splits at bit-field word boundaries."""
+    n_targets = 3 if multi_target else 1
+    X, y = tm.make_categorical(
+        1000, 2, cats, onehot=False, n_targets=n_targets, sparsity=0.0
+    )
+    Xy = QuantileDMatrix(X, y, enable_categorical=True)
+    params: Dict[str, Any] = {"device": device, "tree_method": "hist"}
+    if multi_target:
+        params["multi_strategy"] = "multi_output_tree"
+
+    for max_cat_to_onehot in [1, 128]:
+        params["max_cat_to_onehot"] = max_cat_to_onehot
+        booster = train(params, Xy, num_boost_round=1)
+
+        assert booster.get_score(importance_type="weight")
+        predt = booster.predict(Xy)
+        assert predt.shape == y.shape
+        assert np.isfinite(predt).all()
+
+
 def check_categorical_missing(  # pylint: disable=too-many-arguments
     rows: int,
     cols: int,

--- a/python-package/xgboost/testing/updater.py
+++ b/python-package/xgboost/testing/updater.py
@@ -466,6 +466,7 @@ def check_categorical_ohe(  # pylint: disable=too-many-arguments
         "tree_method": tree_method,
         # Use one-hot exclusively
         "max_cat_to_onehot": USE_ONEHOT,
+        "reg_lambda": 0,
         "device": device,
     }
     if max_bin is not None:
@@ -484,6 +485,7 @@ def check_categorical_ohe(  # pylint: disable=too-many-arguments
             n_targets=n_targets,
         )
 
+        # fixme: extmem
         Xy_onehot = DMatrix(pd.get_dummies(cat), label)
         Xy_cat = DMatrix(cat, label, enable_categorical=True)
     else:
@@ -537,34 +539,94 @@ def check_categorical_ohe(  # pylint: disable=too-many-arguments
     )
     assert non_increasing(by_builtin_results["Train"]["rmse"])
 
-    if device == "cpu" or (device == "cuda" and not multi_target):
-        by_grouping: Dict[str, Dict[str, List[float]]] = {}
-        # switch to partition-based splits
-        parameters["max_cat_to_onehot"] = USE_PART
-        parameters["reg_lambda"] = 0
-        train(
-            parameters,
-            Xy_cat,
-            num_boost_round=rounds,
-            evals=[(Xy_cat, "Train")],
-            evals_result=by_grouping,
-        )
-        rmse_oh = by_builtin_results["Train"]["rmse"]
-        rmse_group = by_grouping["Train"]["rmse"]
-        # always better or equal to onehot when there's no regularization.
-        for a, b in zip(rmse_oh, rmse_group):
-            assert a >= b
+    by_grouping: Dict[str, Dict[str, List[float]]] = {}
+    # switch to partition-based splits
+    parameters["max_cat_to_onehot"] = USE_PART
+    train(
+        parameters,
+        Xy_cat,
+        num_boost_round=rounds,
+        evals=[(Xy_cat, "Train")],
+        evals_result=by_grouping,
+    )
+    rmse_oh = by_builtin_results["Train"]["rmse"]
+    rmse_group = by_grouping["Train"]["rmse"]
+    # always better or equal to onehot when there's no regularization.
+    for a, b in zip(rmse_oh, rmse_group):
+        assert a >= b
 
-        parameters["reg_lambda"] = 1.0
-        by_grouping = {}
-        train(
-            parameters,
-            Xy_cat,
-            num_boost_round=32,
-            evals=[(Xy_cat, "Train")],
-            evals_result=by_grouping,
-        )
-        assert non_increasing(by_grouping["Train"]["rmse"]), by_grouping
+    parameters["reg_lambda"] = 1.0
+    by_grouping = {}
+    train(
+        parameters,
+        Xy_cat,
+        num_boost_round=32,
+        evals=[(Xy_cat, "Train")],
+        evals_result=by_grouping,
+    )
+    assert non_increasing(by_grouping["Train"]["rmse"]), by_grouping
+
+
+def check_categorical_mixed(device: Device) -> None:
+    """Test mixed numerical, one-hot, and partition-based splits."""
+    pd = pytest.importorskip("pandas")
+
+    features = np.stack(
+        [
+            np.repeat(np.arange(2), 16),
+            np.tile(np.repeat(np.arange(2), 8), 2),
+            np.tile(np.arange(8), 4),
+        ],
+        axis=1,
+    )
+    X = pd.DataFrame(
+        {
+            "numeric": features[:, 0].astype(np.float32),
+            "onehot": pd.Categorical(features[:, 1], categories=range(2)),
+            "partition": pd.Categorical(features[:, 2], categories=range(8)),
+        }
+    )
+    y = np.column_stack(
+        [
+            8.0 * features[:, 0],
+            6.0 * features[:, 1],
+            10.0 * (features[:, 2] >= 4),
+        ]
+    ).astype(np.float32)
+    Xy = DMatrix(X, y, enable_categorical=True)
+
+    booster = train(
+        {
+            "device": device,
+            "tree_method": "hist",
+            "multi_strategy": "multi_output_tree",
+            "max_cat_to_onehot": 4,
+            "max_depth": 3,
+            "learning_rate": 1.0,
+            "reg_lambda": 0,
+            "min_child_weight": 0,
+            "base_score": 0,
+        },
+        Xy,
+        num_boost_round=1,
+    )
+    np.testing.assert_allclose(booster.predict(Xy), y)
+
+    model = json.loads(booster.save_raw(raw_format="json"))
+    tree = model["learner"]["gradient_booster"]["model"]["trees"][0]
+    split_indices = np.asarray(tree["split_indices"])
+    split_types = np.asarray(tree["split_type"])
+    is_internal = np.asarray(tree["left_children"]) != -1
+    is_categorical = split_types.astype(bool)
+
+    numerical_features = split_indices[is_internal & ~is_categorical]
+    categorical_features = split_indices[is_internal & is_categorical]
+    category_sizes = np.asarray(tree["categories_sizes"])
+
+    assert set(numerical_features) == {0}
+    assert set(categorical_features) == {1, 2}
+    np.testing.assert_equal(category_sizes[categorical_features == 1], 1)
+    assert np.any(category_sizes[categorical_features == 2] > 1)
 
 
 def check_categorical_missing(  # pylint: disable=too-many-arguments

--- a/src/tree/gpu_hist/evaluate_splits.cu
+++ b/src/tree/gpu_hist/evaluate_splits.cu
@@ -357,7 +357,7 @@ void GPUHistEvaluator::LaunchEvaluateSplits(
                                                                DeviceSplitCandidate());
 
   // One block for each feature
-  uint32_t constexpr kBlockThreads = 32;
+  std::uint32_t constexpr kBlockThreads = dh::WarpThreads();
   dh::LaunchKernel{static_cast<uint32_t>(combined_num_features), kBlockThreads, 0,  // NOLINT
                    ctx->CUDACtx()->Stream()}(
       EvaluateSplitsKernel<kBlockThreads>, max_active_features, d_inputs, shared_inputs,

--- a/src/tree/gpu_hist/evaluate_splits.cuh
+++ b/src/tree/gpu_hist/evaluate_splits.cuh
@@ -235,6 +235,8 @@ struct MultiEvaluateSplitSharedInputs {
   // cut values
   float const *feature_values;
   common::Span<FeatureType const> feature_types;
+  // Number of bit-field storage elements required for one categorical split.
+  std::size_t cat_storage_size{0};
   // Number of histogram bins for one target, across all features.
   bst_bin_t n_total_bins_per_tar;
   bst_feature_t max_active_feature;

--- a/src/tree/gpu_hist/evaluator.cu
+++ b/src/tree/gpu_hist/evaluator.cu
@@ -4,8 +4,8 @@
  * @brief Some components of GPU Hist evaluator, this file only exist to reduce nvcc
  *        compilation time.
  */
-#include <thrust/logical.h>  // thrust::any_of
-#include <thrust/sort.h>     // thrust::stable_sort
+#include <thrust/logical.h>  // for any_of
+#include <thrust/sort.h>     // for stable_sort_by_key
 
 #include <cuda/std/tuple>  // for make_tuple, get
 
@@ -124,6 +124,7 @@ common::Span<bst_feature_t const> GPUHistEvaluator::SortHistogram(
                                }
                                return li < ri;
                              });
+
   return dh::ToSpan(cat_sorted_idx_);
 }
 }  // namespace xgboost::tree

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -565,7 +565,6 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   }
   dh::device_vector<common::Span<GradientPairInt64>> scans(h_scans);
 
-  auto cnt_it = thrust::make_counting_iterator(0ul);
   if (shared_inputs.cat_storage_size > 0) {
     this->AllocNodeCats(max_nidx, shared_inputs.cat_storage_size);
   }

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -601,8 +601,8 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     common::Span<common::CatBitField::value_type> node_cats;
     if (!d_split_cats.empty()) {
       node_cats = d_split_cats.subspan(input.nidx * node_cat_storage_size, node_cat_storage_size);
-      for (std::size_t i = 0; i < node_cats.size(); ++i) {
-        node_cats[i] = 0;
+      for (auto &node_cat : node_cats) {
+        node_cat = 0;
       }
     }
 

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -615,6 +615,7 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     common::Span<common::CatBitField::value_type> node_cats;
     if (!d_split_cats.empty()) {
       node_cats = d_split_cats.subspan(input.nidx * node_cat_storage_size, node_cat_storage_size);
+      // Clear the bits, we use it to store the best candidate.
       for (auto &node_cat : node_cats) {
         node_cat = 0;
       }
@@ -643,9 +644,9 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
 
     if (best_split.is_cat) {
       common::CatBitField cats{node_cats};
-      if (!isnan(best_split.fvalue)) {
+      if (!isnan(best_split.fvalue)) {  // OHE
         cats.Set(common::AsCat(best_split.fvalue));
-      } else {
+      } else {  // Partition
         auto fidx = best_split.findex;
         auto f_begin = shared_inputs.feature_segments[fidx];
         auto n_bins =

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -216,12 +216,11 @@ struct EvaluateSplitAgent {
     return gain;
   }
 
-  template <std::int32_t d_step>
+  template <DefaultDirection d_dir>
   __device__ void Numerical(MultiEvaluateSplitInputs const &node,
                             MultiEvaluateSplitSharedInputs const &shared,
                             common::Span<GradientPairInt64 const> node_scan,
                             MultiSplitCandidate *best_split) {
-    static_assert(d_step == +1 || d_step == -1, "Invalid step.");
     // Calculate split gain for each bin
     auto n_targets = shared.Targets();
     auto lane_id = static_cast<bst_bin_t>(cuda::ptx::get_sreg_laneid());
@@ -243,11 +242,11 @@ struct EvaluateSplitAgent {
       if (threadIdx.x == best_thread && !isinf(gain)) {
         // Update
         bst_bin_t split_gidx = bin_idx;
-        if (d_step == -1) {
+        if (d_dir == kLeftDir) {
           split_gidx = RevBinIdx(gidx_begin, gidx_end, bin_idx);
         }
         float fvalue;
-        if (d_step == +1) {
+        if (d_dir == kRightDir) {
           fvalue = shared.feature_values[split_gidx];
         } else {
           if (split_gidx == gidx_begin) {
@@ -261,8 +260,8 @@ struct EvaluateSplitAgent {
         auto scan_bin_offset = bin_idx * n_targets;
         auto scan_bin = node_scan.subspan(scan_bin_offset, n_targets);
         // Missing values go to right in the forward pass, go to left in the backward pass.
-        best_split->Update(gain, d_step == 1 ? kRightDir : kLeftDir, fvalue, fidx, scan_bin, false,
-                           shared.param, shared.roundings);
+        best_split->Update(gain, d_dir, fvalue, fidx, scan_bin, false, shared.param,
+                           shared.roundings);
       }
 
       __syncwarp();
@@ -310,12 +309,11 @@ struct EvaluateSplitAgent {
     }
   }
 
-  template <std::int32_t d_step>
+  template <DefaultDirection d_dir>
   __device__ void Partition(MultiEvaluateSplitInputs const &node,
                             MultiEvaluateSplitSharedInputs const &shared,
                             common::Span<GradientPairInt64 const> node_scan,
                             MultiSplitCandidate *best_split) {
-    static_assert(d_step == +1 || d_step == -1, "Invalid step.");
     auto n_targets = shared.Targets();
     auto lane_id = static_cast<bst_bin_t>(cuda::ptx::get_sreg_laneid());
 
@@ -342,12 +340,12 @@ struct EvaluateSplitAgent {
 
       if (threadIdx.x == best_thread && !isinf(gain)) {
         auto scan_offset = bin_idx - gidx_begin;
-        auto thresh =
-            d_step == +1 ? scan_offset : static_cast<bst_bin_t>(n_bins_feature - scan_offset - 1);
+        auto thresh = d_dir == kLeftDir ? scan_offset
+                                        : static_cast<bst_bin_t>(n_bins_feature - scan_offset - 1);
         auto scan_bin = node_scan.subspan(bin_idx * n_targets, n_targets);
         // The forward scan selects a right-child prefix with missing values on the
         // left. The backward scan selects a left-child suffix with missing on the right.
-        best_split->UpdateCat(gain, d_step == +1 ? kLeftDir : kRightDir,
+        best_split->UpdateCat(gain, d_dir,
                               static_cast<bst_cat_t>(thresh), fidx, scan_bin);
       }
 
@@ -403,19 +401,19 @@ __global__ __launch_bounds__(kBlockThreads) void EvaluateSplitsKernel(
       agent.template OneHot<kRightDir>(node, shared, first, &out_candidates[candidate_idx]);
       agent.template OneHot<kLeftDir>(node, shared, second, &out_candidates[candidate_idx]);
     } else {
-      agent.template Partition<+1>(node, shared, first, &out_candidates[candidate_idx]);
-      agent.template Partition<-1>(node, shared, second, &out_candidates[candidate_idx]);
+      agent.template Partition<kLeftDir>(node, shared, first, &out_candidates[candidate_idx]);
+      agent.template Partition<kRightDir>(node, shared, second, &out_candidates[candidate_idx]);
     }
     return;
   }
 
   if (shared.one_pass != MultiEvaluateSplitSharedInputs::kBackward) {
     auto forward = bin_scans[nidx].subspan(0, node.histogram.size());
-    agent.template Numerical<+1>(node, shared, forward, &out_candidates[candidate_idx]);
+    agent.template Numerical<kRightDir>(node, shared, forward, &out_candidates[candidate_idx]);
   }
   if (shared.one_pass != MultiEvaluateSplitSharedInputs::kForward) {
     auto backward = bin_scans[nidx].subspan(node.histogram.size(), node.histogram.size());
-    agent.template Numerical<-1>(node, shared, backward, &out_candidates[candidate_idx]);
+    agent.template Numerical<kLeftDir>(node, shared, backward, &out_candidates[candidate_idx]);
   }
 }
 

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -510,15 +510,17 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   if (this->need_sort_histogram_) {
     auto bins_per_tar = shared_inputs.n_total_bins_per_tar;
     std::size_t total_bins = static_cast<std::size_t>(n_nodes) * bins_per_tar;
+
     sorted_idx.resize(total_bins);
-    thrust::transform(ctx->CUDACtx()->CTP(), cnt_it, cnt_it + total_bins, sorted_idx.begin(),
-                      [=] XGBOOST_DEVICE(std::size_t i) { return i % bins_per_tar; });
+    auto d_sorted_idx = dh::ToSpan(sorted_idx);
 
     using SortKey = cuda::std::tuple<std::size_t, bst_feature_t, double>;
     dh::device_vector<SortKey> keys(total_bins);
+
     thrust::transform(
         ctx->CUDACtx()->CTP(), cnt_it, cnt_it + total_bins, keys.begin(),
         [=] XGBOOST_DEVICE(std::size_t i) {
+          d_sorted_idx[i] = i % bins_per_tar;  // segmented iota
           auto [nidx_in_set, bin_idx] = linalg::UnravelIndex(i, n_nodes, bins_per_tar);
           auto fidx =
               static_cast<bst_feature_t>(dh::SegmentId(shared_inputs.feature_segments, bin_idx));
@@ -546,7 +548,6 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
           }
           return cuda::std::make_tuple(nidx_in_set, fidx, sc);
         });
-
     thrust::stable_sort_by_key(ctx->CUDACtx()->CTP(), keys.begin(), keys.end(), sorted_idx.begin(),
                                [] XGBOOST_DEVICE(SortKey const &l, SortKey const &r) {
                                  // nidx_in_set

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -419,6 +419,29 @@ __global__ __launch_bounds__(kBlockThreads) void EvaluateSplitsKernel(
   }
 }
 
+void MultiHistEvaluator::Reset(Context const *ctx,
+                               common::Span<std::uint32_t const> feature_segments,
+                               common::Span<FeatureType const> feature_types,
+                               TrainParam const &param) {
+  this->need_sort_histogram_ = false;
+  if (feature_types.empty()) {
+    return;
+  }
+
+  auto n_features = feature_segments.size() - 1;
+  auto feature_it = thrust::make_counting_iterator<bst_feature_t>(0);
+  auto max_cat_to_onehot = param.max_cat_to_onehot;
+  this->need_sort_histogram_ =
+      thrust::any_of(ctx->CUDACtx()->CTP(), feature_it, feature_it + n_features,
+                     [=] XGBOOST_DEVICE(bst_feature_t fidx) {
+                       if (!common::IsCat(feature_types, fidx)) {
+                         return false;
+                       }
+                       auto n_cats = feature_segments[fidx + 1] - feature_segments[fidx];
+                       return !common::UseOneHot(n_cats, max_cat_to_onehot);
+                     });
+}
+
 [[nodiscard]] MultiExpandEntry MultiHistEvaluator::EvaluateSingleSplit(
     Context const *ctx, MultiEvaluateSplitInputs const &input,
     MultiEvaluateSplitSharedInputs const &shared_inputs) {
@@ -478,27 +501,13 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   dh::device_vector<common::Span<GradientPairInt64>> scans(h_scans);
 
   auto cnt_it = thrust::make_counting_iterator(0ul);
-  auto feature_it = thrust::make_counting_iterator<bst_feature_t>(0);
   if (shared_inputs.cat_storage_size > 0) {
     this->AllocNodeCats(max_nidx, shared_inputs.cat_storage_size);
   }
 
-  bool has_partition =
-      thrust::any_of(ctx->CUDACtx()->CTP(), feature_it, feature_it + shared_inputs.Features(),
-                     [=] XGBOOST_DEVICE(bst_feature_t fidx) {
-                       if (!shared_inputs.IsCategorical(fidx)) {
-                         return false;
-                       }
-                       auto n_cats = shared_inputs.feature_segments[fidx + 1] -
-                                     shared_inputs.feature_segments[fidx];
-                       return !common::UseOneHot(n_cats, shared_inputs.param.max_cat_to_onehot);
-                     });
-
-  // The values are node-local global bin indices. Sorting by (node, feature, score)
-  // preserves the feature segments while ordering partition-based categorical bins by the
-  // CPU projection score s_c = w_p^T w_c.
+  // The values are node-local bin indices. Sort by (node, feature, score)
   dh::device_vector<std::size_t> sorted_idx;
-  if (has_partition) {
+  if (this->need_sort_histogram_) {
     auto bins_per_tar = shared_inputs.n_total_bins_per_tar;
     std::size_t total_bins = static_cast<std::size_t>(n_nodes) * bins_per_tar;
     sorted_idx.resize(total_bins);
@@ -510,8 +519,7 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     thrust::transform(
         ctx->CUDACtx()->CTP(), cnt_it, cnt_it + total_bins, keys.begin(),
         [=] XGBOOST_DEVICE(std::size_t i) {
-          auto nidx_in_set = i / bins_per_tar;
-          auto bin_idx = i % bins_per_tar;
+          auto [nidx_in_set, bin_idx] = linalg::UnravelIndex(i, n_nodes, bins_per_tar);
           auto fidx =
               static_cast<bst_feature_t>(dh::SegmentId(shared_inputs.feature_segments, bin_idx));
           auto n_cats =
@@ -519,32 +527,37 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
           bool is_partition = shared_inputs.IsCategorical(fidx) &&
                               !common::UseOneHot(n_cats, shared_inputs.param.max_cat_to_onehot);
 
-          double score = 0.0;
-          if (is_partition) {
-            auto const &node = d_inputs[nidx_in_set];
-            for (bst_target_t t = 0; t < n_targets; ++t) {
-              auto quantizer = shared_inputs.roundings[t];
-              auto target_hist = node.histogram.subspan(t * bins_per_tar, bins_per_tar);
-              auto child_sum = quantizer.ToFloatingPoint(target_hist[bin_idx]);
-              auto parent_sum = quantizer.ToFloatingPoint(node.parent_sum[t]);
-              auto child_weight =
-                  CalcWeight(shared_inputs.param, child_sum.GetGrad(), child_sum.GetHess());
-              auto parent_weight =
-                  CalcWeight(shared_inputs.param, parent_sum.GetGrad(), parent_sum.GetHess());
-              score += child_weight * parent_weight;
-            }
+          double sc = 0.0;
+          if (!is_partition) {
+            return cuda::std::make_tuple(nidx_in_set, fidx, sc);
           }
-          return cuda::std::make_tuple(nidx_in_set, fidx, score);
+
+          auto const &node = d_inputs[nidx_in_set];
+          for (bst_target_t t = 0; t < n_targets; ++t) {
+            auto quantizer = shared_inputs.roundings[t];
+            auto target_hist = node.histogram.subspan(t * bins_per_tar, bins_per_tar);
+            auto child_sum = quantizer.ToFloatingPoint(target_hist[bin_idx]);
+            auto parent_sum = quantizer.ToFloatingPoint(node.parent_sum[t]);
+            auto child_weight =
+                CalcWeight(shared_inputs.param, child_sum.GetGrad(), child_sum.GetHess());
+            auto parent_weight =
+                CalcWeight(shared_inputs.param, parent_sum.GetGrad(), parent_sum.GetHess());
+            sc += child_weight * parent_weight;
+          }
+          return cuda::std::make_tuple(nidx_in_set, fidx, sc);
         });
 
     thrust::stable_sort_by_key(ctx->CUDACtx()->CTP(), keys.begin(), keys.end(), sorted_idx.begin(),
                                [] XGBOOST_DEVICE(SortKey const &l, SortKey const &r) {
+                                 // nidx_in_set
                                  if (cuda::std::get<0>(l) != cuda::std::get<0>(r)) {
                                    return cuda::std::get<0>(l) < cuda::std::get<0>(r);
                                  }
+                                 // fidx
                                  if (cuda::std::get<1>(l) != cuda::std::get<1>(r)) {
                                    return cuda::std::get<1>(l) < cuda::std::get<1>(r);
                                  }
+                                 // score
                                  return cuda::std::get<2>(l) < cuda::std::get<2>(r);
                                });
   }

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -462,6 +462,71 @@ void MultiHistEvaluator::Reset(Context const *ctx,
   return outputs[0];
 }
 
+namespace {
+// Sort histogram based on projected score, see CPU implementation for details.
+void SortHistogram(Context const *ctx, MultiEvaluateSplitSharedInputs const &shared_inputs,
+                   common::Span<MultiEvaluateSplitInputs const> d_inputs,
+                   dh::device_vector<std::size_t> *p_sorted_idx) {
+  auto &sorted_idx = *p_sorted_idx;
+  auto n_nodes = d_inputs.size();
+
+  auto bins_per_tar = shared_inputs.n_total_bins_per_tar;
+  std::size_t total_bins = static_cast<std::size_t>(n_nodes) * bins_per_tar;
+
+  sorted_idx.resize(total_bins);
+  auto d_sorted_idx = dh::ToSpan(sorted_idx);
+
+  using SortKey = cuda::std::tuple<std::size_t, bst_feature_t, double>;
+  dh::device_vector<SortKey> keys(total_bins);
+
+  auto cnt_it = thrust::make_counting_iterator(0ul);
+  thrust::transform(
+      ctx->CUDACtx()->CTP(), cnt_it, cnt_it + total_bins, keys.begin(),
+      [=] XGBOOST_DEVICE(std::size_t i) {
+        d_sorted_idx[i] = i % bins_per_tar;  // segmented iota
+        auto [nidx_in_set, bin_idx] = linalg::UnravelIndex(i, n_nodes, bins_per_tar);
+        auto fidx =
+            static_cast<bst_feature_t>(dh::SegmentId(shared_inputs.feature_segments, bin_idx));
+        auto n_cats =
+            shared_inputs.feature_segments[fidx + 1] - shared_inputs.feature_segments[fidx];
+        bool is_partition = shared_inputs.IsCategorical(fidx) &&
+                            !common::UseOneHot(n_cats, shared_inputs.param.max_cat_to_onehot);
+
+        double sc = 0.0;
+        if (!is_partition) {
+          return cuda::std::make_tuple(nidx_in_set, fidx, sc);
+        }
+
+        auto const &node = d_inputs[nidx_in_set];
+        for (bst_target_t t = 0; t < shared_inputs.Targets(); ++t) {
+          auto quantizer = shared_inputs.roundings[t];
+          auto target_hist = node.histogram.subspan(t * bins_per_tar, bins_per_tar);
+          auto child_sum = quantizer.ToFloatingPoint(target_hist[bin_idx]);
+          auto parent_sum = quantizer.ToFloatingPoint(node.parent_sum[t]);
+          auto child_weight =
+              CalcWeight(shared_inputs.param, child_sum.GetGrad(), child_sum.GetHess());
+          auto parent_weight =
+              CalcWeight(shared_inputs.param, parent_sum.GetGrad(), parent_sum.GetHess());
+          sc += child_weight * parent_weight;
+        }
+        return cuda::std::make_tuple(nidx_in_set, fidx, sc);
+      });
+  thrust::stable_sort_by_key(ctx->CUDACtx()->CTP(), keys.begin(), keys.end(), sorted_idx.begin(),
+                             [] XGBOOST_DEVICE(SortKey const &l, SortKey const &r) {
+                               // nidx_in_set
+                               if (cuda::std::get<0>(l) != cuda::std::get<0>(r)) {
+                                 return cuda::std::get<0>(l) < cuda::std::get<0>(r);
+                               }
+                               // fidx
+                               if (cuda::std::get<1>(l) != cuda::std::get<1>(r)) {
+                                 return cuda::std::get<1>(l) < cuda::std::get<1>(r);
+                               }
+                               // score
+                               return cuda::std::get<2>(l) < cuda::std::get<2>(r);
+                             });
+}
+}  // namespace
+
 void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
                                         common::Span<MultiEvaluateSplitInputs const> d_inputs,
                                         MultiEvaluateSplitSharedInputs const &shared_inputs,
@@ -508,59 +573,7 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   // The values are node-local bin indices. Sort by (node, feature, score)
   dh::device_vector<std::size_t> sorted_idx;
   if (this->need_sort_histogram_) {
-    auto bins_per_tar = shared_inputs.n_total_bins_per_tar;
-    std::size_t total_bins = static_cast<std::size_t>(n_nodes) * bins_per_tar;
-
-    sorted_idx.resize(total_bins);
-    auto d_sorted_idx = dh::ToSpan(sorted_idx);
-
-    using SortKey = cuda::std::tuple<std::size_t, bst_feature_t, double>;
-    dh::device_vector<SortKey> keys(total_bins);
-
-    thrust::transform(
-        ctx->CUDACtx()->CTP(), cnt_it, cnt_it + total_bins, keys.begin(),
-        [=] XGBOOST_DEVICE(std::size_t i) {
-          d_sorted_idx[i] = i % bins_per_tar;  // segmented iota
-          auto [nidx_in_set, bin_idx] = linalg::UnravelIndex(i, n_nodes, bins_per_tar);
-          auto fidx =
-              static_cast<bst_feature_t>(dh::SegmentId(shared_inputs.feature_segments, bin_idx));
-          auto n_cats =
-              shared_inputs.feature_segments[fidx + 1] - shared_inputs.feature_segments[fidx];
-          bool is_partition = shared_inputs.IsCategorical(fidx) &&
-                              !common::UseOneHot(n_cats, shared_inputs.param.max_cat_to_onehot);
-
-          double sc = 0.0;
-          if (!is_partition) {
-            return cuda::std::make_tuple(nidx_in_set, fidx, sc);
-          }
-
-          auto const &node = d_inputs[nidx_in_set];
-          for (bst_target_t t = 0; t < n_targets; ++t) {
-            auto quantizer = shared_inputs.roundings[t];
-            auto target_hist = node.histogram.subspan(t * bins_per_tar, bins_per_tar);
-            auto child_sum = quantizer.ToFloatingPoint(target_hist[bin_idx]);
-            auto parent_sum = quantizer.ToFloatingPoint(node.parent_sum[t]);
-            auto child_weight =
-                CalcWeight(shared_inputs.param, child_sum.GetGrad(), child_sum.GetHess());
-            auto parent_weight =
-                CalcWeight(shared_inputs.param, parent_sum.GetGrad(), parent_sum.GetHess());
-            sc += child_weight * parent_weight;
-          }
-          return cuda::std::make_tuple(nidx_in_set, fidx, sc);
-        });
-    thrust::stable_sort_by_key(ctx->CUDACtx()->CTP(), keys.begin(), keys.end(), sorted_idx.begin(),
-                               [] XGBOOST_DEVICE(SortKey const &l, SortKey const &r) {
-                                 // nidx_in_set
-                                 if (cuda::std::get<0>(l) != cuda::std::get<0>(r)) {
-                                   return cuda::std::get<0>(l) < cuda::std::get<0>(r);
-                                 }
-                                 // fidx
-                                 if (cuda::std::get<1>(l) != cuda::std::get<1>(r)) {
-                                   return cuda::std::get<1>(l) < cuda::std::get<1>(r);
-                                 }
-                                 // score
-                                 return cuda::std::get<2>(l) < cuda::std::get<2>(r);
-                               });
+    SortHistogram(ctx, shared_inputs, d_inputs, &sorted_idx);
   }
   auto d_sorted_idx = common::Span<std::size_t const>{dh::ToSpan(sorted_idx)};
 

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -1,13 +1,16 @@
 /**
  * Copyright 2025-2026, XGBoost contributors
  */
-#include <thrust/reduce.h>  // for reduce_by_key, reduce
+#include <thrust/logical.h>  // for any_of
+#include <thrust/reduce.h>   // for reduce_by_key, reduce
+#include <thrust/sort.h>     // for stable_sort_by_key
 
 #include <cub/block/block_scan.cuh>  // for BlockScan
 #include <cub/util_type.cuh>         // for KeyValuePair
 #include <cub/warp/warp_reduce.cuh>  // for WarpReduce
 #include <cuda/ptx>                  // for get_sreg_laneid
 #include <cuda/std/functional>       // for identity
+#include <cuda/std/tuple>            // for get, make_tuple, tuple
 #include <limits>
 #include <vector>  // for vector
 
@@ -41,7 +44,7 @@ struct ScanHistogramAgent {
   template <typename BinIndexFn>
   __device__ void ScanFeature(GradientPairInt64 const *node_histogram,
                               GradientPairInt64 *scan_result, bst_target_t t,
-                              BinIndexFn &&bin_idx_fn) {
+                              BinIndexFn &&bin_idx_fn) const {
     auto lane_id = static_cast<bst_bin_t>(cuda::ptx::get_sreg_laneid());
     // The forward pass and the backward pass differs in where the bin is read, which is
     // specified by the callback bin_idx_fn(). They write to the same output location.
@@ -66,12 +69,12 @@ struct ScanHistogramAgent {
   }
   // Forward scan pass
   __device__ void Forward(GradientPairInt64 const *node_histogram,
-                          common::Span<GradientPairInt64> scan_result, bst_target_t t) {
+                          common::Span<GradientPairInt64> scan_result, bst_target_t t) const {
     this->ScanFeature(node_histogram, scan_result.data(), t, cuda::std::identity{});
   }
   // Backward scan pass for missing values
   __device__ void Backward(GradientPairInt64 const *node_histogram,
-                           common::Span<GradientPairInt64> scan_result, bst_target_t t) {
+                           common::Span<GradientPairInt64> scan_result, bst_target_t t) const {
     this->ScanFeature(node_histogram, scan_result.data(), t,
                       [&](bst_bin_t bin_idx) { return RevBinIdx(gidx_begin, gidx_end, bin_idx); });
   }
@@ -87,7 +90,7 @@ struct ScanHistogramAgent {
   //     written non-missing child is the right.
   __device__ void OneHot(GradientPairInt64 const *node_histogram,
                          common::Span<GradientPairInt64> region_others,
-                         common::Span<GradientPairInt64> region_match, bst_target_t t) {
+                         common::Span<GradientPairInt64> region_match, bst_target_t t) const {
     auto lane_id = static_cast<bst_bin_t>(cuda::ptx::get_sreg_laneid());
     // Feature sum across all bins for this target.
     GradientPairInt64 local{};
@@ -102,6 +105,17 @@ struct ScanHistogramAgent {
       region_match[bin_idx * n_targets + t] = bin;
     }
   }
+
+  __device__ void Partition(GradientPairInt64 const *node_histogram,
+                            common::Span<std::size_t const> sorted_idx,
+                            common::Span<GradientPairInt64> forward,
+                            common::Span<GradientPairInt64> backward, bst_target_t t) const {
+    this->ScanFeature(node_histogram, forward.data(), t,
+                      [&](bst_bin_t bin_idx) { return sorted_idx[bin_idx]; });
+    this->ScanFeature(node_histogram, backward.data(), t, [&](bst_bin_t bin_idx) {
+      return sorted_idx[RevBinIdx(gidx_begin, gidx_end, bin_idx)];
+    });
+  }
 };
 }  // namespace
 
@@ -110,6 +124,7 @@ struct ScanHistogramAgent {
 template <std::int32_t kBlockThreads>
 __global__ __launch_bounds__(kBlockThreads) void ScanHistogramKernel(
     common::Span<MultiEvaluateSplitInputs const> nodes, MultiEvaluateSplitSharedInputs shared,
+    common::Span<std::size_t const> sorted_idx,
     common::Span<common::Span<GradientPairInt64>> outputs) {
   static_assert(kBlockThreads % dh::WarpThreads() == 0);
 
@@ -144,11 +159,18 @@ __global__ __launch_bounds__(kBlockThreads) void ScanHistogramKernel(
       node.histogram.subspan(shared.n_total_bins_per_tar * target_idx, shared.n_total_bins_per_tar);
 
   if (shared.IsCategorical(fidx)) {
-    // One-hot encoding. Both regions are always required (independent missing-directions),
-    // so `one_pass` does not apply to categorical features.
-    auto region_others = out.subspan(0, node.histogram.size());
-    auto region_match = out.subspan(node.histogram.size(), node.histogram.size());
-    agent.OneHot(t_hist.data(), region_others, region_match, target_idx);
+    auto first = out.subspan(0, node.histogram.size());
+    auto second = out.subspan(node.histogram.size(), node.histogram.size());
+    auto n_bins = gidx_end - gidx_begin;
+    if (common::UseOneHot(n_bins, shared.param.max_cat_to_onehot)) {
+      // Both regions are always required (independent missing-directions), so `one_pass`
+      // does not apply to categorical features.
+      agent.OneHot(t_hist.data(), first, second, target_idx);
+    } else {
+      auto node_sorted_idx = sorted_idx.subspan(nidx_in_set * shared.n_total_bins_per_tar,
+                                                shared.n_total_bins_per_tar);
+      agent.Partition(t_hist.data(), node_sorted_idx, first, second, target_idx);
+    }
     return;
   }
 
@@ -186,9 +208,8 @@ struct EvaluateSplitAgent {
       auto parent_sum = roundings[t].ToFloatingPoint(node.parent_sum[t]);
       auto child_sum = roundings[t].ToFloatingPoint(child_scan[offset + t]);
       auto sibling_sum = parent_sum - child_sum;
-      auto cw = ::xgboost::tree::CalcWeight(shared.param, child_sum.GetGrad(), child_sum.GetHess());
-      auto sw =
-          ::xgboost::tree::CalcWeight(shared.param, sibling_sum.GetGrad(), sibling_sum.GetHess());
+      auto cw = CalcWeight(shared.param, child_sum.GetGrad(), child_sum.GetHess());
+      auto sw = CalcWeight(shared.param, sibling_sum.GetGrad(), sibling_sum.GetHess());
       gain += -cw * ThresholdL1(child_sum.GetGrad(), shared.param.reg_alpha);
       gain += -sw * ThresholdL1(sibling_sum.GetGrad(), shared.param.reg_alpha);
     }
@@ -288,6 +309,51 @@ struct EvaluateSplitAgent {
       __syncwarp();
     }
   }
+
+  template <std::int32_t d_step>
+  __device__ void Partition(MultiEvaluateSplitInputs const &node,
+                            MultiEvaluateSplitSharedInputs const &shared,
+                            common::Span<GradientPairInt64 const> node_scan,
+                            MultiSplitCandidate *best_split) {
+    static_assert(d_step == +1 || d_step == -1, "Invalid step.");
+    auto n_targets = shared.Targets();
+    auto lane_id = static_cast<bst_bin_t>(cuda::ptx::get_sreg_laneid());
+
+    bst_bin_t gidx_begin = shared.feature_segments[fidx];
+    bst_bin_t gidx_end = shared.feature_segments[fidx + 1];
+    bst_bin_t n_bins_feature = gidx_end - gidx_begin;
+    bst_bin_t n_bins = std::min(shared.param.max_cat_threshold, n_bins_feature);
+    if (n_bins <= 1) {
+      return;
+    }
+
+    // A partition must leave at least one category on each side.
+    for (bst_bin_t scan_begin = gidx_begin; scan_begin < gidx_begin + n_bins - 1;
+         scan_begin += dh::WarpThreads()) {
+      auto bin_idx = scan_begin + lane_id;
+      bool thread_active = bin_idx < gidx_begin + n_bins - 1;
+
+      auto constexpr kNullGain = -std::numeric_limits<double>::infinity();
+      double gain =
+          thread_active ? ComputeGain(node, shared, node_scan, bin_idx, n_targets) : kNullGain;
+
+      auto best = MaxReduceT(*temp_storage).Reduce({threadIdx.x, gain}, cub::ArgMax{});
+      auto best_thread = __shfl_sync(dh::WarpFullMask(), best.key, 0);
+
+      if (threadIdx.x == best_thread && !isinf(gain)) {
+        auto scan_offset = bin_idx - gidx_begin;
+        auto thresh =
+            d_step == +1 ? scan_offset : static_cast<bst_bin_t>(n_bins_feature - scan_offset - 1);
+        auto scan_bin = node_scan.subspan(bin_idx * n_targets, n_targets);
+        // The forward scan selects a right-child prefix with missing values on the
+        // left. The backward scan selects a left-child suffix with missing on the right.
+        best_split->UpdateCat(gain, d_step == +1 ? kLeftDir : kRightDir,
+                              static_cast<bst_cat_t>(thresh), fidx, scan_bin);
+      }
+
+      __syncwarp();
+    }
+  }
 };
 }  // namespace
 
@@ -328,12 +394,18 @@ __global__ __launch_bounds__(kBlockThreads) void EvaluateSplitsKernel(
   auto candidate_idx = nidx * shared.max_active_feature + fidx_in_set;
 
   if (shared.IsCategorical(fidx)) {
-    // One-hot encoding. Both regions are always evaluated (independent missing-directions),
-    // so `one_pass` does not apply to categorical features.
-    auto region_others = bin_scans[nidx].subspan(0, node.histogram.size());
-    auto region_match = bin_scans[nidx].subspan(node.histogram.size(), node.histogram.size());
-    agent.template OneHot<kRightDir>(node, shared, region_others, &out_candidates[candidate_idx]);
-    agent.template OneHot<kLeftDir>(node, shared, region_match, &out_candidates[candidate_idx]);
+    auto first = bin_scans[nidx].subspan(0, node.histogram.size());
+    auto second = bin_scans[nidx].subspan(node.histogram.size(), node.histogram.size());
+    auto n_bins = shared.feature_segments[fidx + 1] - shared.feature_segments[fidx];
+    if (common::UseOneHot(n_bins, shared.param.max_cat_to_onehot)) {
+      // Both regions are always evaluated (independent missing-directions), so `one_pass`
+      // does not apply to categorical features.
+      agent.template OneHot<kRightDir>(node, shared, first, &out_candidates[candidate_idx]);
+      agent.template OneHot<kLeftDir>(node, shared, second, &out_candidates[candidate_idx]);
+    } else {
+      agent.template Partition<+1>(node, shared, first, &out_candidates[candidate_idx]);
+      agent.template Partition<-1>(node, shared, second, &out_candidates[candidate_idx]);
+    }
     return;
   }
 
@@ -405,6 +477,79 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   }
   dh::device_vector<common::Span<GradientPairInt64>> scans(h_scans);
 
+  auto cnt_it = thrust::make_counting_iterator(0ul);
+  auto feature_it = thrust::make_counting_iterator<bst_feature_t>(0);
+  if (shared_inputs.cat_storage_size > 0) {
+    this->AllocNodeCats(max_nidx, shared_inputs.cat_storage_size);
+  }
+
+  bool has_partition =
+      thrust::any_of(ctx->CUDACtx()->CTP(), feature_it, feature_it + shared_inputs.Features(),
+                     [=] XGBOOST_DEVICE(bst_feature_t fidx) {
+                       if (!shared_inputs.IsCategorical(fidx)) {
+                         return false;
+                       }
+                       auto n_cats = shared_inputs.feature_segments[fidx + 1] -
+                                     shared_inputs.feature_segments[fidx];
+                       return !common::UseOneHot(n_cats, shared_inputs.param.max_cat_to_onehot);
+                     });
+
+  // The values are node-local global bin indices. Sorting by (node, feature, score)
+  // preserves the feature segments while ordering partition-based categorical bins by the
+  // CPU projection score s_c = w_p^T w_c.
+  dh::device_vector<std::size_t> sorted_idx;
+  if (has_partition) {
+    auto bins_per_tar = shared_inputs.n_total_bins_per_tar;
+    std::size_t total_bins = static_cast<std::size_t>(n_nodes) * bins_per_tar;
+    sorted_idx.resize(total_bins);
+    thrust::transform(ctx->CUDACtx()->CTP(), cnt_it, cnt_it + total_bins, sorted_idx.begin(),
+                      [=] XGBOOST_DEVICE(std::size_t i) { return i % bins_per_tar; });
+
+    using SortKey = cuda::std::tuple<std::size_t, bst_feature_t, double>;
+    dh::device_vector<SortKey> keys(total_bins);
+    thrust::transform(
+        ctx->CUDACtx()->CTP(), cnt_it, cnt_it + total_bins, keys.begin(),
+        [=] XGBOOST_DEVICE(std::size_t i) {
+          auto nidx_in_set = i / bins_per_tar;
+          auto bin_idx = i % bins_per_tar;
+          auto fidx =
+              static_cast<bst_feature_t>(dh::SegmentId(shared_inputs.feature_segments, bin_idx));
+          auto n_cats =
+              shared_inputs.feature_segments[fidx + 1] - shared_inputs.feature_segments[fidx];
+          bool is_partition = shared_inputs.IsCategorical(fidx) &&
+                              !common::UseOneHot(n_cats, shared_inputs.param.max_cat_to_onehot);
+
+          double score = 0.0;
+          if (is_partition) {
+            auto const &node = d_inputs[nidx_in_set];
+            for (bst_target_t t = 0; t < n_targets; ++t) {
+              auto quantizer = shared_inputs.roundings[t];
+              auto target_hist = node.histogram.subspan(t * bins_per_tar, bins_per_tar);
+              auto child_sum = quantizer.ToFloatingPoint(target_hist[bin_idx]);
+              auto parent_sum = quantizer.ToFloatingPoint(node.parent_sum[t]);
+              auto child_weight =
+                  CalcWeight(shared_inputs.param, child_sum.GetGrad(), child_sum.GetHess());
+              auto parent_weight =
+                  CalcWeight(shared_inputs.param, parent_sum.GetGrad(), parent_sum.GetHess());
+              score += child_weight * parent_weight;
+            }
+          }
+          return cuda::std::make_tuple(nidx_in_set, fidx, score);
+        });
+
+    thrust::stable_sort_by_key(ctx->CUDACtx()->CTP(), keys.begin(), keys.end(), sorted_idx.begin(),
+                               [] XGBOOST_DEVICE(SortKey const &l, SortKey const &r) {
+                                 if (cuda::std::get<0>(l) != cuda::std::get<0>(r)) {
+                                   return cuda::std::get<0>(l) < cuda::std::get<0>(r);
+                                 }
+                                 if (cuda::std::get<1>(l) != cuda::std::get<1>(r)) {
+                                   return cuda::std::get<1>(l) < cuda::std::get<1>(r);
+                                 }
+                                 return cuda::std::get<2>(l) < cuda::std::get<2>(r);
+                               });
+  }
+  auto d_sorted_idx = common::Span<std::size_t const>{dh::ToSpan(sorted_idx)};
+
   // Launch histogram scan kernel, each warp handles one target of one feature of one node.
   {
     std::uint32_t constexpr kBlockThreads = 512;
@@ -412,7 +557,8 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     auto n_warps = n_nodes * n_targets * n_features;
     auto n_blocks = common::DivRoundUp(n_warps, kWarpsPerBlk);
     dh::LaunchKernel{n_blocks, kBlockThreads}(  // NOLINT
-        ScanHistogramKernel<kBlockThreads>, d_inputs, shared_inputs, dh::ToSpan(scans));
+        ScanHistogramKernel<kBlockThreads>, d_inputs, shared_inputs, d_sorted_idx,
+        dh::ToSpan(scans));
   }
 
   // Launch split evaluation kernel
@@ -430,6 +576,8 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   // Find best split for each node
   auto d_weights = this->GetNodeWeights(n_targets);
   auto d_split_sums = this->split_sums_.View();
+  auto d_split_cats = dh::ToSpan(this->split_cats_);
+  auto node_cat_storage_size = this->node_cat_storage_size_;
   auto s_d_splits = dh::ToSpan(d_splits);
 
   // Process results for each node
@@ -450,19 +598,62 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   dh::LaunchN(n_nodes, ctx->CUDACtx()->Stream(), [=] __device__(std::size_t nidx_in_set) {
     auto input = d_inputs[nidx_in_set];
     MultiSplitCandidate best_split = d_best_splits[nidx_in_set];
+    common::Span<common::CatBitField::value_type> node_cats;
+    if (!d_split_cats.empty()) {
+      node_cats = d_split_cats.subspan(input.nidx * node_cat_storage_size, node_cat_storage_size);
+      for (std::size_t i = 0; i < node_cats.size(); ++i) {
+        node_cats[i] = 0;
+      }
+    }
+
+    // The root weight is required even when no valid split is found. In particular,
+    // max_cat_threshold=1 does not enumerate any partition candidate.
+    bst_node_t nidx = input.nidx;
+    auto base_weight = d_weights.Base(nidx);
+    auto roundings = shared_inputs.roundings;
+    float parent_gain = 0;
+    double parent_hess = 0;
+    for (bst_target_t t = 0; t < n_targets; ++t) {
+      auto g = roundings[t].ToFloatingPoint(input.parent_sum[t]);
+      base_weight[t] = CalcWeight(shared_inputs.param, g.GetGrad(), g.GetHess());
+      parent_gain += -base_weight[t] * ThresholdL1(g.GetGrad(), shared_inputs.param.reg_alpha);
+      parent_hess += g.GetHess();
+    }
+
     if (best_split.child_sum.empty()) {
       // Invalid split
-      out_splits[nidx_in_set] = {};
+      out_splits[nidx_in_set] = {nidx, input.depth, best_split, base_weight};
+      out_splits[nidx_in_set].UpdateHessian(parent_hess, 0.0);
       return;
     }
 
+    if (best_split.is_cat) {
+      common::CatBitField cats{node_cats};
+      if (!isnan(best_split.fvalue)) {
+        cats.Set(common::AsCat(best_split.fvalue));
+      } else {
+        auto fidx = best_split.findex;
+        auto f_begin = shared_inputs.feature_segments[fidx];
+        auto n_bins =
+            shared_inputs.feature_segments[fidx + 1] - shared_inputs.feature_segments[fidx];
+        auto node_sorted_idx = d_sorted_idx.subspan(
+            nidx_in_set * shared_inputs.n_total_bins_per_tar, shared_inputs.n_total_bins_per_tar);
+        auto f_sorted_idx = node_sorted_idx.subspan(f_begin, n_bins);
+        bst_bin_t partition = best_split.dir == kLeftDir
+                                  ? static_cast<bst_bin_t>(best_split.thresh + 1)
+                                  : static_cast<bst_bin_t>(best_split.thresh);
+        KERNEL_CHECK(partition > 0);
+        for (bst_bin_t i = 0; i < partition; ++i) {
+          auto cat = shared_inputs.feature_values[f_sorted_idx[i]];
+          cats.Set(common::AsCat(cat));
+        }
+      }
+    }
+
     // Calculate weights for this node using the actual node id for persistent storage
-    bst_node_t nidx = input.nidx;
-    auto base_weight = d_weights.Base(nidx);
     auto left_weight = d_weights.Left(nidx);
     auto right_weight = d_weights.Right(nidx);
 
-    auto roundings = shared_inputs.roundings;
     auto split_sum = best_split.child_sum;
 
     // Copy split sum to persistent buffer for loss-guide grow policy support.
@@ -471,7 +662,6 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     auto split_sum_dest = GetNodeSumImpl(d_split_sums, nidx, n_targets);
 
     bool l = true, r = true;
-    float parent_gain = 0;
     double left_hess = 0, right_hess = 0;  // Sum of child hessians across all targets
     auto eta = shared_inputs.param.learning_rate;
 
@@ -479,10 +669,6 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
       auto quantizer = roundings[t];
       auto sibling_sum = input.parent_sum[t] - split_sum[t];
 
-      // Base weight and parent gain
-      auto g = quantizer.ToFloatingPoint(input.parent_sum[t]);
-      base_weight[t] = CalcWeight(shared_inputs.param, g.GetGrad(), g.GetHess());
-      parent_gain += -base_weight[t] * ThresholdL1(g.GetGrad(), shared_inputs.param.reg_alpha);
       split_sum_dest[t] = split_sum[t];
 
       // Check for empty hessian

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -345,8 +345,7 @@ struct EvaluateSplitAgent {
         auto scan_bin = node_scan.subspan(bin_idx * n_targets, n_targets);
         // The forward scan selects a right-child prefix with missing values on the
         // left. The backward scan selects a left-child suffix with missing on the right.
-        best_split->UpdateCat(gain, d_dir,
-                              static_cast<bst_cat_t>(thresh), fidx, scan_bin);
+        best_split->UpdateCat(gain, d_dir, static_cast<bst_cat_t>(thresh), fidx, scan_bin);
       }
 
       __syncwarp();

--- a/src/tree/gpu_hist/multi_evaluate_splits.cuh
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cuh
@@ -11,6 +11,8 @@
 namespace xgboost::tree::cuda_impl {
 /** @brief Evaluator for vector leaf. */
 class MultiHistEvaluator {
+  using CatST = common::CatBitField::value_type;
+
  public:
   template <typename GradT>
   static XGBOOST_DEVICE common::Span<GradT> GetNodeSumImpl(common::Span<GradT> node_sums,
@@ -77,6 +79,21 @@ class MultiHistEvaluator {
   // buffer is needed because we don't have the child node index during evaluation, which
   // is only available after applying split to the tree.
   NodeSumBuffer split_sums_;
+  // Category bit fields for evaluated nodes, indexed by node id. They must remain valid
+  // while candidates are waiting in the loss-guide queue.
+  dh::DeviceUVector<CatST> split_cats_;
+  std::size_t node_cat_storage_size_{0};
+
+  void AllocNodeCats(bst_node_t nidx, std::size_t storage_size) {
+    if (this->node_cat_storage_size_ == 0) {
+      this->node_cat_storage_size_ = storage_size;
+    }
+    CHECK_EQ(this->node_cat_storage_size_, storage_size);
+    auto required = (nidx + 1) * storage_size;
+    if (this->split_cats_.size() < required) {
+      this->split_cats_.resize(required);
+    }
+  }
 
  public:
   /**
@@ -117,6 +134,13 @@ class MultiHistEvaluator {
   }
   [[nodiscard]] NodeWeightBuffer GetNodeWeights(bst_target_t n_targets) {
     return NodeWeightBuffer{dh::ToSpan(this->node_weights_), n_targets};
+  }
+  [[nodiscard]] std::vector<CatST> GetHostNodeCats(bst_node_t nidx) const {
+    std::vector<CatST> out(this->node_cat_storage_size_);
+    auto cats = dh::ToSpan(this->split_cats_)
+                    .subspan(nidx * this->node_cat_storage_size_, this->node_cat_storage_size_);
+    dh::CopyDeviceSpanToVector(&out, cats);
+    return out;
   }
   /**
    * @brief Copy weights for a node from device to host vectors.

--- a/src/tree/gpu_hist/multi_evaluate_splits.cuh
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cuh
@@ -83,6 +83,8 @@ class MultiHistEvaluator {
   // while candidates are waiting in the loss-guide queue.
   dh::DeviceUVector<CatST> split_cats_;
   std::size_t node_cat_storage_size_{0};
+  // Whether any categorical feature requires partition-based evaluation.
+  bool need_sort_histogram_{false};
 
   void AllocNodeCats(bst_node_t nidx, std::size_t storage_size) {
     if (this->node_cat_storage_size_ == 0) {
@@ -96,6 +98,9 @@ class MultiHistEvaluator {
   }
 
  public:
+  void Reset(Context const *ctx, common::Span<std::uint32_t const> feature_segments,
+             common::Span<FeatureType const> feature_types, TrainParam const &param);
+
   /**
    * @brief Run evaluation for the root node.
    */

--- a/src/tree/gpu_hist/row_partitioner.cuh
+++ b/src/tree/gpu_hist/row_partitioner.cuh
@@ -243,9 +243,10 @@ __global__ __launch_bounds__(kBlockSize) void FinalisePositionKernel(
     OpT op) {
   for (auto idx : dh::GridStrideRange<std::size_t>(0, d_ridx.size())) {
     auto position = GetPositionFromSegments(idx, d_node_info.data());
-    cuda_impl::RowIndexT ridx = d_ridx[idx] - base_ridx;
-    bst_node_t new_position = op(ridx, position);
-    d_out_position[ridx] = new_position;
+    auto global_ridx = d_ridx[idx];
+    auto local_ridx = global_ridx - base_ridx;
+    bst_node_t new_position = op(global_ridx, position);
+    d_out_position[local_ridx] = new_position;
   }
 }
 
@@ -422,9 +423,9 @@ class RowPartitioner {
    * complete. Does not update any other meta information in this data structure, so
    * should only be used at the end of training.
    *
-   * @param p_out_position Node index for each row.
-   * @param op Device lambda. Should provide the row index and current position as an
-   *           argument and return the new position for this training instance.
+   * @param p_out_position Node index for each row in this batch.
+   * @param op Device lambda. Receives the global row index and current position, and returns the
+   *           new position for this training instance.
    */
   template <typename FinalisePositionOpT>
   void FinalisePosition(Context const* ctx, common::Span<bst_node_t> d_out_position,

--- a/src/tree/updater_gpu_common.cuh
+++ b/src/tree/updater_gpu_common.cuh
@@ -80,7 +80,7 @@ struct DeviceSplitCandidate {
   }
 
   /**
-   * \brief Update for partition-based splits.
+   * @brief Update for partition-based splits.
    */
   XGBOOST_DEVICE void UpdateCat(float loss_chg_in, DefaultDirection dir_in, bst_cat_t thresh_in,
                                 bst_feature_t findex_in, GradientPairInt64 left_sum_in,
@@ -141,6 +141,24 @@ struct MultiSplitCandidate {
       findex = findex_in;
     }
   }
+
+  /**
+   * @brief Update for partition-based splits.
+   */
+  XGBOOST_DEVICE void UpdateCat(float loss_chg_in, DefaultDirection dir_in, bst_cat_t thresh_in,
+                                bst_feature_t findex_in,
+                                common::Span<GradientPairInt64 const> node_sum_in) {
+    if (loss_chg_in > loss_chg) {
+      loss_chg = loss_chg_in;
+      dir = dir_in;
+      fvalue = std::numeric_limits<float>::quiet_NaN();
+      thresh = thresh_in;
+      is_cat = true;
+      child_sum = node_sum_in;
+      findex = findex_in;
+    }
+  }
+
   XGBOOST_DEVICE void Update(MultiSplitCandidate const& that, GPUTrainingParam const& param,
                              common::Span<GradientQuantiser const> roundings) {
     this->Update(that.loss_chg, that.dir, that.fvalue, that.findex, that.child_sum, that.is_cat,

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -400,7 +400,7 @@ struct GPUHistMakerDevice {
 
     __device__ bool operator()(cuda_impl::RowIndexT ridx, NodeSplitData const& data) const {
       RegTree::Node const& node = data.split_node;
-      // given a row index, returns the node id it belongs to
+      // Given a global row index, returns the node id it belongs to
       float cut_value = d_matrix.GetFvalue(ridx, node.SplitIndex());
       // Missing value
       bool go_left = true;

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -628,15 +628,13 @@ struct GPUHistMakerDevice {
     if (is_cat) {
       // should be set to nan in evaluation split.
       CHECK(common::CheckNAN(candidate.split.fvalue));
-      std::vector<common::CatBitField::value_type> split_cats;
-
-      auto h_cats = this->evaluator_.GetHostNodeCats(candidate.nidx);
+      auto cat_bits = this->evaluator_.GetHostNodeCats(candidate.nidx);
       auto n_bins_feature = cuts_->FeatureBins(candidate.split.findex);
-      split_cats.resize(common::CatBitField::ComputeStorageSize(n_bins_feature), 0);
-      CHECK_LE(split_cats.size(), h_cats.size());
-      std::copy(h_cats.data(), h_cats.data() + split_cats.size(), split_cats.data());
+      auto n_words = common::CatBitField::ComputeStorageSize(n_bins_feature);
+      CHECK_LE(n_words, cat_bits.size());
+      cat_bits = cat_bits.subspan(0, n_words);
 
-      tree.ExpandCategorical(candidate.nidx, candidate.split.findex, split_cats,
+      tree.ExpandCategorical(candidate.nidx, candidate.split.findex, cat_bits,
                              candidate.split.dir == kLeftDir, base_weight, left_weight,
                              right_weight, candidate.split.loss_chg, parent_hess, left_hess,
                              right_hess);

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -213,6 +213,10 @@ class MultiTargetHistMaker {
     // Cache feature types on device for categorical split detection.
     p_fmat->Info().feature_types.SetDevice(ctx_->Device());
     this->feature_types_ = p_fmat->Info().feature_types.ConstDeviceSpan();
+
+    /**
+     * Evaluator
+     */
     this->evaluator_.Reset(ctx_, this->cuts_->cut_ptrs_.ConstDeviceSpan(), this->feature_types_,
                            this->param_);
 

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -320,13 +320,10 @@ class MultiTargetHistMaker {
       if (candidate.split.is_cat) {
         auto fidx = candidate.split.findex;
         auto cat_bits = this->evaluator_.GetHostNodeCats(candidate.nidx);
-        // The evaluator sizes this bit field from the maximum category value, which is the
-        // authoritative capacity for potentially sparse category codes. Remove only unused
-        // trailing words before storing it in the tree.
-        while (!cat_bits.empty() && cat_bits.back() == 0) {
-          cat_bits.pop_back();
-        }
-        CHECK(!cat_bits.empty());
+        auto n_bins_feature = this->cuts_->FeatureBins(fidx);
+        auto n_words = common::CatBitField::ComputeStorageSize(n_bins_feature);
+        CHECK_LE(n_words, cat_bits.size());
+        cat_bits.resize(n_words);
         p_tree->ExpandCategorical(candidate.nidx, fidx, cat_bits, default_left,
                                   linalg::MakeVec(h_base_weight), linalg::MakeVec(h_left_weight),
                                   linalg::MakeVec(h_right_weight), loss_chg, sum_hess, left_sum,

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -5,6 +5,7 @@
 #include <thrust/reduce.h>   // for reduce_by_key
 #include <thrust/version.h>  // for THRUST_MAJOR_VERSION
 
+#include <algorithm>  // for copy_if, max, transform
 #include <memory>  // for unique_ptr
 #include <vector>  // for vector
 
@@ -181,10 +182,16 @@ class MultiTargetHistMaker {
   auto MakeSharedInputs(bst_feature_t max_active_feature) const {
     common::Span<GradientQuantiser const> d_roundings = this->split_quantizer_->DeviceSpan();
     GPUTrainingParam d_param{this->param_};
+    std::size_t cat_storage_size = 0;
+    if (this->cuts_->HasCategorical()) {
+      cat_storage_size =
+          common::CatBitField::ComputeStorageSize(common::AsCat(this->cuts_->MaxCategory()) + 1);
+    }
     return MultiEvaluateSplitSharedInputs{d_roundings,
                                           this->cuts_->cut_ptrs_.ConstDeviceSpan(),
                                           this->cuts_->cut_values_.ConstDevicePointer(),
                                           this->feature_types_,
+                                          cat_storage_size,
                                           this->cuts_->TotalBins(),
                                           max_active_feature,
                                           d_param};
@@ -305,14 +312,15 @@ class MultiTargetHistMaker {
       float sum_hess = left_sum + right_sum;
       bool default_left = candidate.split.dir == kLeftDir;
       if (candidate.split.is_cat) {
-        // One-hot categorical split: build a single-bit category field for the chosen
-        // category (carried in fvalue), mirroring the CPU HistMultiEvaluator.
         auto fidx = candidate.split.findex;
-        auto const& cut_ptrs = this->cuts_->cut_ptrs_.ConstHostVector();
-        bst_bin_t n_bins = cut_ptrs[fidx + 1] - cut_ptrs[fidx];
-        std::vector<std::uint32_t> cat_bits(common::CatBitField::ComputeStorageSize(n_bins + 1), 0);
-        common::CatBitField bits{cat_bits};
-        bits.Set(static_cast<bst_cat_t>(candidate.split.fvalue));
+        auto cat_bits = this->evaluator_.GetHostNodeCats(candidate.nidx);
+        // The evaluator sizes this bit field from the maximum category value, which is the
+        // authoritative capacity for potentially sparse category codes. Remove only unused
+        // trailing words before storing it in the tree.
+        while (!cat_bits.empty() && cat_bits.back() == 0) {
+          cat_bits.pop_back();
+        }
+        CHECK(!cat_bits.empty());
         p_tree->ExpandCategorical(candidate.nidx, fidx, cat_bits, default_left,
                                   linalg::MakeVec(h_base_weight), linalg::MakeVec(h_left_weight),
                                   linalg::MakeVec(h_right_weight), loss_chg, sum_hess, left_sum,

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -210,9 +210,11 @@ class MultiTargetHistMaker {
     // Clear the per-node allowed-feature sets before growing a new tree.
     this->interaction_constraints_->Reset(this->ctx_);
 
-    // Cache feature types on device for categorical one-hot split detection.
+    // Cache feature types on device for categorical split detection.
     p_fmat->Info().feature_types.SetDevice(ctx_->Device());
     this->feature_types_ = p_fmat->Info().feature_types.ConstDeviceSpan();
+    this->evaluator_.Reset(ctx_, this->cuts_->cut_ptrs_.ConstDeviceSpan(), this->feature_types_,
+                           this->param_);
 
     /**
      * Initialize the gradient matrix

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -452,7 +452,7 @@ class MultiTargetHistMaker {
     Accessor d_matrix;
     MultiTargetTreeView tree;
     __device__ bool operator()(RowIndexT ridx, NodeSplitData const& data) const {
-      // given a row index, returns the node id it belongs to
+      // Given a global row index, returns the node id it belongs to
       float cut_value = d_matrix.GetFvalue(ridx, tree.SplitIndex(data.nidx));
       // Missing value
       bool go_left = true;

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -158,6 +158,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalOneHot) {
   shared.param = GPUTrainingParam{param};
 
   MultiHistEvaluator evaluator;
+  evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param);
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
   ASSERT_TRUE(candidate.split.is_cat);
@@ -218,6 +219,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   shared.param = GPUTrainingParam{param};
 
   MultiHistEvaluator evaluator;
+  evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param);
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
   ASSERT_TRUE(candidate.split.is_cat);
@@ -258,6 +260,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   shared.param = GPUTrainingParam{no_split_param};
 
   MultiHistEvaluator no_split_evaluator;
+  no_split_evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, no_split_param);
   auto no_split = no_split_evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
   ASSERT_TRUE(no_split.split.child_sum.empty());

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -3,6 +3,8 @@
  */
 #include <gtest/gtest.h>
 
+#include <cmath>  // for isnan
+
 #include "../../../../src/tree/gpu_hist/evaluate_splits.cuh"
 #include "../../../../src/tree/gpu_hist/multi_evaluate_splits.cuh"
 #include "../../helpers.h"
@@ -147,6 +149,13 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalOneHot) {
   auto shared = this->shared_inputs;
   shared.feature_values = dh::ToSpan(cat_values).data();
   shared.feature_types = dh::ToSpan(ft);
+  shared.cat_storage_size = common::CatBitField::ComputeStorageSize(4);
+  TrainParam param;
+  param.Init(Args{{"min_child_weight", "0"},
+                  {"reg_lambda", "0"},
+                  {"learning_rate", "1"},
+                  {"max_cat_to_onehot", "100"}});
+  shared.param = GPUTrainingParam{param};
 
   MultiHistEvaluator evaluator;
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
@@ -157,6 +166,9 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalOneHot) {
   // is the non-missing "other categories" (left child), so dir is kRightDir.
   ASSERT_EQ(candidate.split.dir, kRightDir);
   ASSERT_EQ(static_cast<bst_cat_t>(candidate.split.fvalue), 3);
+  auto h_cats = evaluator.GetHostNodeCats(candidate.nidx);
+  common::KCatBitField cats{h_cats};
+  ASSERT_TRUE(cats.Check(3));
 
   // child_sum is the "other categories" = parent - hist[bin 3].
   std::vector<GradientPairInt64> exp_child_sum{{36, 24}, {57, 87}};
@@ -172,5 +184,86 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalOneHot) {
   AssertVecEq(base, exp_base_weight);
   AssertVecEq(left, exp_left_weight);
   AssertVecEq(right, exp_right_weight);
+}
+
+TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
+  // The optimal split groups categories {2, 3} together. No one-hot split can represent
+  // this 2-vs-2 partition.
+  parent_sum[0] = GradientPairInt64{-9, 4};
+  parent_sum[1] = GradientPairInt64{-7, 4};
+
+  // target 0
+  histogram[0] = GradientPairInt64{-4, 1};
+  histogram[1] = GradientPairInt64{-3, 1};
+  histogram[2] = GradientPairInt64{-1, 1};
+  histogram[3] = GradientPairInt64{-1, 1};
+  // target 1
+  histogram[4] = GradientPairInt64{-3, 1};
+  histogram[5] = GradientPairInt64{-2, 1};
+  histogram[6] = GradientPairInt64{-1, 1};
+  histogram[7] = GradientPairInt64{-1, 1};
+
+  dh::device_vector<float> cat_values{0.0f, 1.0f, 2.0f, 3.0f};
+  dh::device_vector<FeatureType> ft(1, FeatureType::kCategorical);
+
+  auto shared = this->shared_inputs;
+  shared.feature_values = dh::ToSpan(cat_values).data();
+  shared.feature_types = dh::ToSpan(ft);
+  shared.cat_storage_size = common::CatBitField::ComputeStorageSize(4);
+  TrainParam param;
+  param.Init(Args{{"min_child_weight", "0"},
+                  {"reg_lambda", "0"},
+                  {"learning_rate", "1"},
+                  {"max_cat_to_onehot", "1"}});
+  shared.param = GPUTrainingParam{param};
+
+  MultiHistEvaluator evaluator;
+  auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
+
+  ASSERT_TRUE(candidate.split.is_cat);
+  ASSERT_NEAR(candidate.split.loss_chg, 8.5, 1e-5);
+  ASSERT_EQ(candidate.split.dir, kLeftDir);
+  ASSERT_EQ(candidate.split.findex, 0);
+  ASSERT_TRUE(std::isnan(candidate.split.fvalue));
+  ASSERT_EQ(candidate.split.thresh, 1);
+  auto h_cats = evaluator.GetHostNodeCats(candidate.nidx);
+  common::KCatBitField cats{h_cats};
+  ASSERT_FALSE(cats.Check(0));
+  ASSERT_FALSE(cats.Check(1));
+  ASSERT_TRUE(cats.Check(2));
+  ASSERT_TRUE(cats.Check(3));
+
+  // Categories {2, 3} form the right child. `child_sum` stores the non-missing child,
+  // which is the right child when missing values default left.
+  std::vector<GradientPairInt64> exp_child_sum{{-2, 2}, {-2, 2}};
+  AssertDeviceVecEq(candidate.split.child_sum, exp_child_sum);
+
+  std::vector<float> base, left, right;
+  evaluator.CopyNodeWeightsToHost(candidate.nidx, candidate.base_weight.size(), &base, &left,
+                                  &right);
+  AssertVecEq(base, std::vector<float>{2.25f, 1.75f});
+  AssertVecEq(left, std::vector<float>{3.5f, 2.5f});
+  AssertVecEq(right, std::vector<float>{1.0f, 1.0f});
+  ASSERT_EQ(candidate.left_sum, 4.0);
+  ASSERT_EQ(candidate.right_sum, 4.0);
+
+  // max_cat_threshold=1 does not enumerate a partition. The resulting root-only tree
+  // must still retain its base weight and Hessian.
+  TrainParam no_split_param;
+  no_split_param.Init(Args{{"min_child_weight", "0"},
+                           {"reg_lambda", "0"},
+                           {"learning_rate", "1"},
+                           {"max_cat_to_onehot", "1"},
+                           {"max_cat_threshold", "1"}});
+  shared.param = GPUTrainingParam{no_split_param};
+
+  MultiHistEvaluator no_split_evaluator;
+  auto no_split = no_split_evaluator.EvaluateSingleSplit(&ctx, input, shared);
+
+  ASSERT_TRUE(no_split.split.child_sum.empty());
+  ASSERT_FALSE(no_split.IsValid(no_split_param, 100));
+  AssertDeviceVecEq(no_split.base_weight, std::vector<float>{2.25f, 1.75f});
+  ASSERT_EQ(no_split.left_sum, 8.0);
+  ASSERT_EQ(no_split.right_sum, 0.0);
 }
 }  // namespace xgboost::tree::cuda_impl

--- a/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
+++ b/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
@@ -1,9 +1,9 @@
 /**
- * Copyright 2019-2025, XGBoost Contributors
+ * Copyright 2019-2026, XGBoost Contributors
  */
 #include <gtest/gtest.h>
 #include <thrust/device_vector.h>
-#include <thrust/sort.h>    // for sort
+#include <thrust/sort.h>  // for sort
 #include <thrust/transform.h>
 #include <thrust/unique.h>  // for unique
 #include <xgboost/base.h>
@@ -17,7 +17,7 @@
 #include "../../../../src/data/ellpack_page.cuh"
 #include "../../../../src/tree/gpu_hist/expand_entry.cuh"  // for GPUExpandEntry
 #include "../../../../src/tree/gpu_hist/row_partitioner.cuh"
-#include "../../../../src/tree/param.h"    // for TrainParam
+#include "../../../../src/tree/param.h"  // for TrainParam
 #include "../../../../src/tree/sample_position.h"
 #include "../../collective/test_worker.h"  // for TestDistributedGlobal
 #include "../../helpers.h"                 // for RandomDataGenerator
@@ -67,7 +67,7 @@ void TestSortPositionBatch(const std::vector<int>& ridx_in, const std::vector<Se
 
   auto op = [=] __device__(auto ridx, int split_index, int data) {
     return ridx % 2 == 0;
-  };
+  };  // NOLINT
   std::vector<int> op_data(segments.size());
   std::vector<PerNodeData<int>> h_batch_info(segments.size());
   dh::TemporaryArray<PerNodeData<int>> d_batch_info(segments.size());
@@ -87,7 +87,7 @@ void TestSortPositionBatch(const std::vector<int>& ridx_in, const std::vector<Se
 
   auto op_without_data = [=] __device__(auto ridx) {
     return ridx % 2 == 0;
-  };
+  };  // NOLINT
   for (size_t i = 0; i < segments.size(); i++) {
     auto begin = ridx.begin() + segments[i].begin;
     auto end = ridx.begin() + segments[i].end;
@@ -187,11 +187,9 @@ void TestExternalMemory() {
   }
 
   RegTree::Node node = tree[RegTree::kRoot];
-  auto n_left_pos =
-      thrust::count_if(position.cbegin(), position.cend(),
-                       [=] XGBOOST_DEVICE(bst_node_t v) {
-                         return SamplePosition::Decode(v) == node.LeftChild();
-                       });
+  auto n_left_pos = thrust::count_if(
+      position.cbegin(), position.cend(),
+      [=] XGBOOST_DEVICE(bst_node_t v) { return SamplePosition::Decode(v) == node.LeftChild(); });
   ASSERT_EQ(n_left, n_left_pos);
 
   std::vector<bst_node_t> h_position(position.size());

--- a/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
+++ b/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <thrust/device_vector.h>
 #include <thrust/sort.h>    // for sort
+#include <thrust/transform.h>
 #include <thrust/unique.h>  // for unique
 #include <xgboost/base.h>
 #include <xgboost/tree_model.h>  // for RegTree
@@ -17,6 +18,7 @@
 #include "../../../../src/tree/gpu_hist/expand_entry.cuh"  // for GPUExpandEntry
 #include "../../../../src/tree/gpu_hist/row_partitioner.cuh"
 #include "../../../../src/tree/param.h"    // for TrainParam
+#include "../../../../src/tree/sample_position.h"
 #include "../../collective/test_worker.h"  // for TestDistributedGlobal
 #include "../../helpers.h"                 // for RandomDataGenerator
 
@@ -149,8 +151,9 @@ void TestExternalMemory() {
   bst_feature_t const split_ind = 0;
   dh::device_vector<bst_node_t> position(p_fmat->Info().num_row_, 0);
 
-  auto encode_op = [=] __device__(bst_idx_t, bst_node_t nidx) {
-    return nidx;
+  auto n_rows = p_fmat->Info().num_row_;
+  auto encode_op = [=] __device__(bst_idx_t ridx, bst_node_t nidx) {
+    return SamplePosition::Encode(nidx, ridx < n_rows / 2);
   };  // NOLINT
 
   for (auto const& page : p_fmat->GetBatches<EllpackPage>(&ctx, param)) {
@@ -186,8 +189,19 @@ void TestExternalMemory() {
   RegTree::Node node = tree[RegTree::kRoot];
   auto n_left_pos =
       thrust::count_if(position.cbegin(), position.cend(),
-                       [=] XGBOOST_DEVICE(bst_node_t v) { return v == node.LeftChild(); });
+                       [=] XGBOOST_DEVICE(bst_node_t v) {
+                         return SamplePosition::Decode(v) == node.LeftChild();
+                       });
   ASSERT_EQ(n_left, n_left_pos);
+
+  std::vector<bst_node_t> h_position(position.size());
+  dh::CopyDeviceSpanToVector(&h_position, dh::ToSpan(position));
+  for (bst_idx_t ridx = 0; ridx < n_rows; ++ridx) {
+    EXPECT_EQ(SamplePosition::IsValid(h_position[ridx]), ridx < n_rows / 2);
+  }
+
+  thrust::transform(thrust::device, position.cbegin(), position.cend(), position.begin(),
+                    [] XGBOOST_DEVICE(bst_node_t nidx) { return SamplePosition::Decode(nidx); });
   thrust::sort(position.begin(), position.end());
   auto end_it = thrust::unique(position.begin(), position.end());
   ASSERT_EQ(std::distance(position.begin(), end_it), 2);

--- a/tests/python-gpu/test_gpu_data_iterator.py
+++ b/tests/python-gpu/test_gpu_data_iterator.py
@@ -2,9 +2,8 @@ import sys
 
 import numpy as np
 import pytest
-from hypothesis import given, settings, strategies
-
 import xgboost as xgb
+from hypothesis import given, settings, strategies
 from xgboost import testing as tm
 from xgboost.testing import no_cupy
 from xgboost.testing.data_iter import check_invalid_cat_batches, check_uneven_sizes

--- a/tests/python-gpu/test_gpu_data_iterator.py
+++ b/tests/python-gpu/test_gpu_data_iterator.py
@@ -196,10 +196,13 @@ def test_categorical_missing(tree_method: str) -> None:
     )
 
 
-@pytest.mark.parametrize("tree_method", ["hist", "approx"])
+@pytest.mark.parametrize(
+    "tree_method,multi_target",
+    [("hist", False), ("approx", False), ("hist", True)],
+)
 @pytest.mark.skipif(**tm.no_cudf())
 @pytest.mark.skipif(**tm.no_cupy())
-def test_categorical_ohe(tree_method: str) -> None:
+def test_categorical_ohe(tree_method: str, multi_target: bool) -> None:
     check_categorical_ohe(
         rows=1024,
         cols=16,
@@ -208,6 +211,7 @@ def test_categorical_ohe(tree_method: str) -> None:
         device="cuda",
         tree_method=tree_method,
         extmem=True,
+        multi_target=multi_target,
     )
 
 

--- a/tests/python-gpu/test_gpu_multi_target.py
+++ b/tests/python-gpu/test_gpu_multi_target.py
@@ -11,6 +11,7 @@ from xgboost import config_context
 from xgboost import testing as tm
 from xgboost.testing.multi_target import (
     all_reg_objectives,
+    check_categorical_mixed,
     run_absolute_error,
     run_column_sampling,
     run_deterministic,
@@ -30,6 +31,11 @@ from xgboost.testing.multi_target import (
 from xgboost.testing.params import hist_parameter_strategy
 from xgboost.testing.updater import check_quantile_loss_rf, train_result
 from xgboost.testing.utils import Device
+
+
+@pytest.mark.skipif(**tm.no_pandas())
+def test_categorical_mixed() -> None:
+    check_categorical_mixed("cuda")
 
 
 @pytest.mark.parametrize("learning_rate", [1.0, None])

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -12,6 +12,7 @@ from xgboost.testing.params import (
     hist_parameter_strategy,
 )
 from xgboost.testing.updater import (
+    check_categorical_bitfield_boundaries,
     check_categorical_missing,
     check_categorical_ohe,
     check_get_quantile_cut,
@@ -232,24 +233,7 @@ class TestGPUUpdaters:
     def test_categorical_bitfield_boundaries(
         self, cats: int, multi_target: bool
     ) -> None:
-        """Test scalar and vector categorical splits at bit-field word boundaries."""
-        n_targets = 3 if multi_target else 1
-        X, y = tm.make_categorical(
-            1000, 2, cats, onehot=False, n_targets=n_targets, sparsity=0.0
-        )
-        Xy = xgb.DMatrix(X, y, enable_categorical=True)
-        params: Dict[str, Any] = {"device": "cuda", "tree_method": "hist"}
-        if multi_target:
-            params["multi_strategy"] = "multi_output_tree"
-
-        for max_cat_to_onehot in [1, 128]:
-            params["max_cat_to_onehot"] = max_cat_to_onehot
-            booster = xgb.train(params, Xy, num_boost_round=1)
-
-            assert booster.get_score(importance_type="weight")
-            predt = booster.predict(Xy)
-            assert predt.shape == y.shape
-            assert np.isfinite(predt).all()
+        check_categorical_bitfield_boundaries("cuda", cats, multi_target)
 
     @pytest.mark.skipif(**tm.no_cupy())
     @pytest.mark.parametrize("tree_method", ["hist", "approx"])

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -12,6 +12,7 @@ from xgboost.testing.params import (
     hist_parameter_strategy,
 )
 from xgboost.testing.updater import (
+    check_categorical_mixed,
     check_categorical_missing,
     check_categorical_ohe,
     check_get_quantile_cut,
@@ -146,6 +147,10 @@ class TestGPUUpdaters:
             max_bin=max_bin,
         )
 
+    @pytest.mark.skipif(**tm.no_pandas())
+    def test_categorical_mixed(self) -> None:
+        check_categorical_mixed("cuda")
+
     @given(
         tm.categorical_dataset_strategy,
         hist_parameter_strategy,
@@ -229,18 +234,29 @@ class TestGPUUpdaters:
     def test_max_cat(self, tree_method: str) -> None:
         run_max_cat(tree_method, "cuda")
 
-    def test_categorical_32_cat(self) -> None:
-        """32 hits the bound of integer bitset, so special test"""
-        rows = 1000
-        check_categorical_ohe(
-            rows=rows,
-            cols=10,
-            rounds=4,
-            cats=32,
-            device="cuda",
-            tree_method="hist",
-            extmem=False,
+    @pytest.mark.parametrize("cats", [32, 64])
+    @pytest.mark.parametrize("multi_target", [False, True])
+    def test_categorical_bitfield_boundaries(
+        self, cats: int, multi_target: bool
+    ) -> None:
+        """Test scalar and vector categorical splits at bit-field word boundaries."""
+        n_targets = 3 if multi_target else 1
+        X, y = tm.make_categorical(
+            1000, 2, cats, onehot=False, n_targets=n_targets, sparsity=0.0
         )
+        Xy = xgb.DMatrix(X, y, enable_categorical=True)
+        params: Dict[str, Any] = {"device": "cuda", "tree_method": "hist"}
+        if multi_target:
+            params["multi_strategy"] = "multi_output_tree"
+
+        for max_cat_to_onehot in [1, 128]:
+            params["max_cat_to_onehot"] = max_cat_to_onehot
+            booster = xgb.train(params, Xy, num_boost_round=1)
+
+            assert booster.get_score(importance_type="weight")
+            predt = booster.predict(Xy)
+            assert predt.shape == y.shape
+            assert np.isfinite(predt).all()
 
     @pytest.mark.skipif(**tm.no_cupy())
     @pytest.mark.parametrize("tree_method", ["hist", "approx"])

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -12,8 +12,8 @@ from xgboost.testing.params import (
     hist_parameter_strategy,
 )
 from xgboost.testing.updater import (
-    check_categorical_mixed,
     check_categorical_missing,
+    check_categorical_mixed,
     check_categorical_ohe,
     check_get_quantile_cut,
     check_quantile_loss,
@@ -119,41 +119,29 @@ class TestGPUUpdaters:
         strategies.integers(1, 2),
         strategies.integers(4, 7),
         strategies.integers(5, 16),
+        strategies.sampled_from([("approx", False), ("hist", False), ("hist", True)]),
     )
     @settings(deadline=None, max_examples=20, print_blob=True)
     @pytest.mark.skipif(**tm.no_pandas())
     def test_categorical_ohe(
-        self, rows: int, cols: int, rounds: int, cats: int, max_bin: int
+        self,
+        rows: int,
+        cols: int,
+        rounds: int,
+        cats: int,
+        max_bin: int,
+        config: tuple[str, bool],
     ) -> None:
+        tree_method, multi_target = config
         check_categorical_ohe(
             rows=rows,
             cols=cols,
             rounds=rounds,
             cats=cats,
             device="cuda",
-            tree_method="approx",
+            tree_method=tree_method,
             extmem=False,
-            max_bin=max_bin,
-        )
-        check_categorical_ohe(
-            rows=rows,
-            cols=cols,
-            rounds=rounds,
-            cats=cats,
-            device="cuda",
-            tree_method="hist",
-            extmem=False,
-            max_bin=max_bin,
-        )
-        check_categorical_ohe(
-            rows=rows,
-            cols=cols,
-            rounds=rounds,
-            cats=cats,
-            device="cuda",
-            tree_method="hist",
-            extmem=False,
-            multi_target=True,
+            multi_target=multi_target,
             max_bin=max_bin,
         )
 

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -131,6 +131,16 @@ class TestGPUUpdaters:
             rounds=rounds,
             cats=cats,
             device="cuda",
+            tree_method="approx",
+            extmem=False,
+            max_bin=max_bin,
+        )
+        check_categorical_ohe(
+            rows=rows,
+            cols=cols,
+            rounds=rounds,
+            cats=cats,
+            device="cuda",
             tree_method="hist",
             extmem=False,
             max_bin=max_bin,

--- a/tests/python-gpu/test_gpu_updaters.py
+++ b/tests/python-gpu/test_gpu_updaters.py
@@ -13,7 +13,6 @@ from xgboost.testing.params import (
 )
 from xgboost.testing.updater import (
     check_categorical_missing,
-    check_categorical_mixed,
     check_categorical_ohe,
     check_get_quantile_cut,
     check_quantile_loss,
@@ -144,10 +143,6 @@ class TestGPUUpdaters:
             multi_target=multi_target,
             max_bin=max_bin,
         )
-
-    @pytest.mark.skipif(**tm.no_pandas())
-    def test_categorical_mixed(self) -> None:
-        check_categorical_mixed("cuda")
 
     @given(
         tm.categorical_dataset_strategy,

--- a/tests/python/test_multi_target.py
+++ b/tests/python/test_multi_target.py
@@ -11,6 +11,7 @@ from hypothesis import given, note, settings, strategies
 from xgboost import testing as tm
 from xgboost.testing.multi_target import (
     all_reg_objectives,
+    check_categorical_mixed,
     run_absolute_error,
     run_column_sampling,
     run_eta,
@@ -34,6 +35,11 @@ from xgboost.testing.params import (
 )
 from xgboost.testing.updater import check_quantile_loss_rf, train_result
 from xgboost.testing.utils import Device
+
+
+@pytest.mark.skipif(**tm.no_pandas())
+def test_categorical_mixed() -> None:
+    check_categorical_mixed("cpu")
 
 
 @pytest.mark.parametrize("multi_strategy", ["multi_output_tree", "one_output_per_tree"])

--- a/tests/python/test_updaters.py
+++ b/tests/python/test_updaters.py
@@ -12,6 +12,7 @@ from xgboost.testing.params import (
     hist_parameter_strategy,
 )
 from xgboost.testing.updater import (
+    check_categorical_bitfield_boundaries,
     check_categorical_missing,
     check_categorical_ohe,
     check_get_quantile_cut,
@@ -314,6 +315,13 @@ class TestTreeMethod:
         check_categorical_missing(
             rows, cols, cats, device="cpu", tree_method="hist", extmem=False
         )
+
+    @pytest.mark.parametrize("cats", [32, 64])
+    @pytest.mark.parametrize("multi_target", [False, True])
+    def test_categorical_bitfield_boundaries(
+        self, cats: int, multi_target: bool
+    ) -> None:
+        check_categorical_bitfield_boundaries("cpu", cats, multi_target)
 
     @pytest.mark.parametrize("weighted", [True, False])
     def test_quantile_loss(self, weighted: bool) -> None:

--- a/tests/python/test_updaters.py
+++ b/tests/python/test_updaters.py
@@ -13,7 +13,6 @@ from xgboost.testing.params import (
 )
 from xgboost.testing.updater import (
     check_categorical_missing,
-    check_categorical_mixed,
     check_categorical_ohe,
     check_get_quantile_cut,
     check_quantile_loss,
@@ -254,10 +253,6 @@ class TestTreeMethod:
             tree_method=tree_method,
             multi_target=multi_target,
         )
-
-    @pytest.mark.skipif(**tm.no_pandas())
-    def test_categorical_mixed(self) -> None:
-        check_categorical_mixed("cpu")
 
     @given(
         tm.categorical_dataset_strategy,

--- a/tests/python/test_updaters.py
+++ b/tests/python/test_updaters.py
@@ -12,8 +12,8 @@ from xgboost.testing.params import (
     hist_parameter_strategy,
 )
 from xgboost.testing.updater import (
-    check_categorical_mixed,
     check_categorical_missing,
+    check_categorical_mixed,
     check_categorical_ohe,
     check_get_quantile_cut,
     check_quantile_loss,

--- a/tests/python/test_updaters.py
+++ b/tests/python/test_updaters.py
@@ -12,6 +12,7 @@ from xgboost.testing.params import (
     hist_parameter_strategy,
 )
 from xgboost.testing.updater import (
+    check_categorical_mixed,
     check_categorical_missing,
     check_categorical_ohe,
     check_get_quantile_cut,
@@ -262,6 +263,10 @@ class TestTreeMethod:
             tree_method="hist",
             multi_target=True,
         )
+
+    @pytest.mark.skipif(**tm.no_pandas())
+    def test_categorical_mixed(self) -> None:
+        check_categorical_mixed("cpu")
 
     @given(
         tm.categorical_dataset_strategy,

--- a/tests/python/test_updaters.py
+++ b/tests/python/test_updaters.py
@@ -232,36 +232,27 @@ class TestTreeMethod:
         strategies.integers(3, 8),
         strategies.integers(1, 2),
         strategies.integers(4, 7),
+        strategies.sampled_from([("approx", False), ("hist", False), ("hist", True)]),
     )
     @settings(deadline=None, print_blob=True, max_examples=10)
     @pytest.mark.skipif(**tm.no_pandas())
     def test_categorical_ohe(
-        self, rows: int, cols: int, rounds: int, cats: int
+        self,
+        rows: int,
+        cols: int,
+        rounds: int,
+        cats: int,
+        config: tuple[str, bool],
     ) -> None:
+        tree_method, multi_target = config
         check_categorical_ohe(
             rows=rows,
             cols=cols,
             rounds=rounds,
             cats=cats,
             device="cpu",
-            tree_method="approx",
-        )
-        check_categorical_ohe(
-            rows=rows,
-            cols=cols,
-            rounds=rounds,
-            cats=cats,
-            device="cpu",
-            tree_method="hist",
-        )
-        check_categorical_ohe(
-            rows=rows,
-            cols=cols,
-            rounds=rounds,
-            cats=cats,
-            device="cpu",
-            tree_method="hist",
-            multi_target=True,
+            tree_method=tree_method,
+            multi_target=multi_target,
         )
 
     @pytest.mark.skipif(**tm.no_pandas())

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -1278,14 +1278,21 @@ def test_invalid_config(client: "Client") -> None:
         dxgb.train(client, {}, dtrain, num_boost_round=1, coll_cfg=cfg)
 
 
-def test_worker_port(client_one_worker: "Client") -> None:
-    from xgboost.testing.collective import get_avail_port
-
+def test_worker_port(client_one_worker: "Client", tmp_path: Path) -> None:
     X, y, _ = generate_array()
     dtrain = DaskDMatrix(client_one_worker, X, y)
 
-    cfg = CollConfig(worker_port=get_avail_port)
+    marker = tmp_path / "worker-port-callback"
+
+    def worker_port() -> int:
+        marker.write_text(distributed.get_worker().address, encoding="utf-8")
+        # Let bind select and reserve the port atomically.
+        return 0
+
+    cfg = CollConfig(worker_port=worker_port)
     dxgb.train(client_one_worker, {}, dtrain, num_boost_round=4, coll_cfg=cfg)
+    worker_addr = marker.read_text(encoding="utf-8")
+    assert worker_addr in client_one_worker.scheduler_info()["workers"]
 
 
 class TestWithDask:


### PR DESCRIPTION
Ref: https://github.com/dmlc/xgboost/issues/9043

- Implement the vector leaf cat split for GPU.
- Brief document.
- Fix external memory finalize partition with sampling.
- Add tests for full coverage, including mixed split types and external memory.
- A bit of cleanup for the cat bit handling.