### PR TITLE
Skip unused per-tree depth precalculation for single-row prediction

### DIFF
--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -399,15 +399,20 @@ void PredictBatchByBlockKernel(DataView const &batch, HostModel const &model,
 
   /* Precalculate depth for each tree.
    * These values are required only for the ArrayLayout optimization,
-   * so we don't need them if kBlockOfRowsSize == 1
+   * so we don't need them if kBlockOfRowsSize == 1. They are equally unused
+   * when every block has size 1 (n_samples <= 1): DispatchArrayLayout only
+   * reads tree_depth when block_size > 1. Computing them walks every node of
+   * every tree, which would otherwise dominate single-row inplace prediction.
    */
   std::vector<int> tree_depth;
   if constexpr (kBlockOfRowsSize > 1) {
-    tree_depth.resize(model.tree_end - model.tree_begin);
-    CHECK_EQ(tree_depth.size(), model.Trees().size());
-    common::ParallelFor(model.tree_end - model.tree_begin, n_threads, [&](auto i) {
-      std::visit([&](auto &&tree) { tree_depth[i] = tree.MaxDepth(); }, model.Trees()[i]);
-    });
+    if (n_samples > 1) {
+      tree_depth.resize(model.tree_end - model.tree_begin);
+      CHECK_EQ(tree_depth.size(), model.Trees().size());
+      common::ParallelFor(model.tree_end - model.tree_begin, n_threads, [&](auto i) {
+        std::visit([&](auto &&tree) { tree_depth[i] = tree.MaxDepth(); }, model.Trees()[i]);
+      });
+    }
   }
   common::ParallelFor1d<kBlockOfRowsSize>(n_samples, n_threads, [&](auto &&block) {
     auto fvec_tloc = fvec.ThreadBuffer(block.Size());


### PR DESCRIPTION
`PredictBatchByBlockKernel` precomputes the depth of every tree before processing blocks; each depth is a full recursive walk of the tree, i.e. O(total nodes in the model) of setup per call. However, `DispatchArrayLayout` only reads `tree_depth` when `block_size > 1` (`use_array_tree_layout = block_size > 1`). For a single-row batch every block has size 1, so the depths are computed and never used.

This PR guards the precalculation on `n_samples > 1`. Batches with more than one row are completely unaffected.

**Measurement:** sampling profiler on a single-row CPU inplace-predict loop (127 features, 50 trees, `nthread=1`, Apple M3 Pro). The depth precalculation was ~21% of wall time for single-row inplace predict; removing it improves latency by a further ~22% (5.56us -> 4.31us per call, measured on top of #12306), with bit-identical predictions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
