### PR TITLE
Fix vector_logic lint failing the R package CI job

### DIFF
--- a/R-package/tests/testthat/test_interaction_constraints.R
+++ b/R-package/tests/testthat/test_interaction_constraints.R
@@ -41,7 +41,7 @@ test_that("interaction constraints for regression", {
   test2 <- all(abs(diff2 - diff2[1]) < 1e-4)
 
   expect_true({
-    test1 & test2
+    test1 && test2
   }, "Interaction Contraint Satisfied")
 })
 


### PR DESCRIPTION
The "Test R package on Debian" CI job is currently failing on master (and on every open PR, e.g. #12307) with a lint error rather than a test failure:

```
tests/testthat/test_interaction_constraints.R:44:11: warning: [vector_logic] Use `&&` in conditional expressions.
    test1 & test2
          ^
```

The job pulls `rhub/ubuntu-release:latest`, so a newer lintr appears to have made this rule effective without any code change on master.

Both operands are scalar logicals produced by `all(...)`, so `&&` is semantically identical here. One-character fix; unblocks CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
