### PR TITLE
[MT] Disable `pred_leaf` with strict shape, fix ext mem.

### DIFF
--- a/doc/prediction.rst
+++ b/doc/prediction.rst
@@ -60,7 +60,10 @@ After 1.4 release, we added a new parameter called ``strict_shape``, one can set
   as shape.  ``n_trees_in_forest`` is specified by the ``numb_parallel_tree`` during
   training.  When strict shape is set to False, output is a 2-dim array with last 3 dims
   concatenated into 1.  Also the last dimension is dropped if it equals to 1. When using
-  ``apply`` method in scikit learn interface, this is set to False by default.
+  ``apply`` method in scikit learn interface, this is set to False by default. Strict
+  shape is not supported for vector-leaf trees or models that mix scalar- and vector-leaf
+  trees, since they can contain different numbers of trees in each iteration. Use
+  ``strict_shape=False`` for these models.
 
 
 For R package, when ``strict_shape`` is specified, an ``array`` is returned, with the same

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -115,10 +115,10 @@ class GradientBooster : public Model, public Configurable {
    * \param out_preds output vector to hold the predictions
    * \param layer_begin Beginning of boosted tree layer used for prediction.
    * \param layer_end   End of booster layer. 0 means do not limit trees.
+   * @param strict_shape Validate whether it's actually possible to have uniform shape.
    */
-  virtual void PredictLeaf(DMatrix *dmat,
-                           HostDeviceVector<bst_float> *out_preds,
-                           unsigned layer_begin, unsigned layer_end) = 0;
+  virtual void PredictLeaf(DMatrix* dmat, HostDeviceVector<bst_float>* out_preds,
+                           bst_layer_t layer_begin, bst_layer_t layer_end, bool strict_shape) = 0;
 
   /*!
    * \brief feature contributions to individual predictions; the output will be a vector

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2025, XGBoost Contributors
+ * Copyright 2014-2026, XGBoost Contributors
  * \file gbm.h
  * \brief Interface of gradient booster,
  *  that learns through gradient statistics.
@@ -147,8 +147,7 @@ class GradientBooster : public Model, public Configurable {
   [[nodiscard]] virtual std::vector<std::string> DumpModel(const FeatureMap& fmap, bool with_stats,
                                                            std::string format) const = 0;
 
-  virtual void FeatureScore(std::string const& importance_type,
-                            common::Span<int32_t const> trees,
+  virtual void FeatureScore(std::string const& importance_type, common::Span<int32_t const> trees,
                             std::vector<bst_feature_t>* features,
                             std::vector<float>* scores) const = 0;
   /**
@@ -190,10 +189,10 @@ struct GradientBoosterReg
  *   });
  * \endcode
  */
-#define XGBOOST_REGISTER_GBM(UniqueId, Name)                            \
-  static DMLC_ATTRIBUTE_UNUSED ::xgboost::GradientBoosterReg &          \
-  __make_ ## GradientBoosterReg ## _ ## UniqueId ## __ =                \
-      ::dmlc::Registry< ::xgboost::GradientBoosterReg>::Get()->__REGISTER__(Name)
+#define XGBOOST_REGISTER_GBM(UniqueId, Name)                  \
+  static DMLC_ATTRIBUTE_UNUSED ::xgboost::GradientBoosterReg& \
+      __make_##GradientBoosterReg##_##UniqueId##__ =          \
+          ::dmlc::Registry< ::xgboost::GradientBoosterReg>::Get()->__REGISTER__(Name)
 
 }  // namespace xgboost
 #endif  // XGBOOST_GBM_H_

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -111,12 +111,14 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    * \param pred_contribs whether to only predict the feature contributions
    * \param approx_contribs whether to approximate the feature contributions for speed
    * \param pred_interactions whether to compute the feature pair contributions
+   * @param strict_shape Used by predict leaf to validate whether it's actually possible
+   *        to have uniform shape.
    */
   virtual void Predict(std::shared_ptr<DMatrix> data, bool output_margin,
                        HostDeviceVector<bst_float>* out_preds, bst_layer_t layer_begin,
                        bst_layer_t layer_end, bool training = false, bool pred_leaf = false,
                        bool pred_contribs = false, bool approx_contribs = false,
-                       bool pred_interactions = false) = 0;
+                       bool pred_interactions = false, bool strict_shape = false) = 0;
 
   /*!
    * \brief Inplace prediction.

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2025, XGBoost Contributors
+ * Copyright 2015-2026, XGBoost Contributors
  *
  * \brief Learner interface that integrates objective, gbm and evaluation together.
  *  This is the user facing XGBoost training module.
@@ -96,8 +96,7 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    * \param data_names name of each dataset
    * \return a string corresponding to the evaluation result
    */
-  virtual std::string EvalOneIter(int iter,
-                                  const std::vector<std::shared_ptr<DMatrix>>& data_sets,
+  virtual std::string EvalOneIter(int iter, const std::vector<std::shared_ptr<DMatrix>>& data_sets,
                                   const std::vector<std::string>& data_names) = 0;
   /*!
    * \brief get prediction given the model.
@@ -208,7 +207,7 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    * \brief Set the feature names for current booster.
    * \param fn Input feature names
    */
-  virtual  void SetFeatureNames(std::vector<std::string> const& fn) = 0;
+  virtual void SetFeatureNames(std::vector<std::string> const& fn) = 0;
   /*!
    * \brief Get the feature names for current booster.
    * \param fn Output feature names
@@ -247,8 +246,7 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    * \param format the format to dump the model in
    * \return a vector of dump for boosters.
    */
-  virtual std::vector<std::string> DumpModel(const FeatureMap& fmap,
-                                             bool with_stats,
+  virtual std::vector<std::string> DumpModel(const FeatureMap& fmap, bool with_stats,
                                              std::string format) = 0;
 
   virtual XGBAPIThreadLocalEntry& GetThreadLocal() const = 0;
@@ -261,7 +259,7 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    * \param cache_data The matrix to cache the prediction.
    * \return Created learner.
    */
-  static Learner* Create(const std::vector<std::shared_ptr<DMatrix> >& cache_data);
+  static Learner* Create(const std::vector<std::shared_ptr<DMatrix>>& cache_data);
   /**
    * \brief Return the context object of this Booster.
    */
@@ -278,7 +276,7 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
   /*! \brief The gradient booster used by the model*/
   std::unique_ptr<GradientBooster> gbm_;
   /*! \brief The evaluation metrics used to evaluate the model. */
-  std::vector<std::unique_ptr<Metric> > metrics_;
+  std::vector<std::unique_ptr<Metric>> metrics_;
   /*! \brief Training parameter. */
   Context ctx_;
 };

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -273,11 +273,6 @@ class RegTree : public Model {
   void LoadModel(Json const& in) override;
   void SaveModel(Json* out) const override;
 
-  bool operator==(const RegTree& b) const {
-    return nodes_.ConstHostVector() == b.nodes_.ConstHostVector() &&
-           stats_.ConstHostVector() == b.stats_.ConstHostVector() &&
-           deleted_nodes_ == b.deleted_nodes_ && param_ == b.param_;
-  }
   /*!
    * \brief Compares whether 2 trees are equal from a user's perspective.  The equality
    *        compares only non-deleted nodes.

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -273,13 +273,13 @@ class RegTree : public Model {
   void LoadModel(Json const& in) override;
   void SaveModel(Json* out) const override;
 
-  /*!
-   * \brief Compares whether 2 trees are equal from a user's perspective.  The equality
+  /**
+   * @brief Compares whether 2 trees are equal from a user's perspective.  The equality
    *        compares only non-deleted nodes.
    *
-   * \param b The other tree.
+   * @param b The other tree.
    */
-  [[nodiscard]] bool Equal(const RegTree& b) const;
+  [[nodiscard]] bool Equal(RegTree const& b) const;
 
   /**
    * \brief Expands a leaf node into two additional leaf nodes.

--- a/python-package/xgboost/testing/predict.py
+++ b/python-package/xgboost/testing/predict.py
@@ -1,14 +1,14 @@
 """Tests for inference."""
 
 import json
-from typing import Optional, Type
+from typing import Any, Optional, Type
 
 import numpy as np
 import pytest
 from scipy.special import logit  # pylint: disable=no-name-in-module
 
 from ..compat import import_cupy
-from ..core import DMatrix, ExtMemQuantileDMatrix, QuantileDMatrix
+from ..core import Booster, DMatrix, ExtMemQuantileDMatrix, QuantileDMatrix
 from ..training import train
 from .data import IteratorForTest
 from .shared import validate_leaf_output
@@ -19,32 +19,38 @@ from .utils import Device
 def _make_leaf_dmatrix(
     device: Device, DMatrixT: Type[DMatrix], X: np.ndarray, y: np.ndarray
 ) -> tuple[DMatrix, Optional[QuantileDMatrix]]:
-    """Make the prediction matrix and an in-memory external-memory reference."""
+    """Make a prediction matrix and an in-memory reference for external memory."""
     if DMatrixT is not ExtMemQuantileDMatrix:
         return DMatrixT(X, y), None
 
-    X_batches = np.array_split(X, 4)
-    y_batches = np.array_split(y, 4)
-    cache_host_ratio = None
-    if device.startswith("cuda"):
-        cp = import_cupy()
-        X_batches = [cp.asarray(batch) for batch in X_batches]
-        y_batches = [cp.asarray(batch) for batch in y_batches]
-        X = cp.asarray(X)  # type: ignore[assignment]
-        y = cp.asarray(y)  # type: ignore[assignment]
-        cache_host_ratio = 1.0
-
+    xp = import_cupy() if device.startswith("cuda") else np
+    X, y = xp.asarray(X), xp.asarray(y)
     it = IteratorForTest(
-        X_batches,
-        y_batches,
+        xp.array_split(X, 4),
+        xp.array_split(y, 4),
         None,
         cache="cache",
         on_host=True,
         min_cache_page_bytes=0,
     )
-    m = ExtMemQuantileDMatrix(it, cache_host_ratio=cache_host_ratio)
-    reference = QuantileDMatrix(X, y, ref=m)
-    return m, reference
+    m = ExtMemQuantileDMatrix(
+        it, cache_host_ratio=1.0 if device.startswith("cuda") else None
+    )
+    return m, QuantileDMatrix(X, y, ref=m)
+
+
+def _predict_leaf(
+    booster: Booster,
+    m: DMatrix,
+    reference: Optional[DMatrix],
+    **kwargs: Any,
+) -> np.ndarray:
+    """Predict leaves and compare external memory against in-memory data."""
+    predt = booster.predict(m, pred_leaf=True, **kwargs)
+    if reference is not None:
+        ref_predt = booster.predict(reference, pred_leaf=True, **kwargs)
+        np.testing.assert_array_equal(predt, ref_predt)
+    return predt
 
 
 def _validate_leaf_indices(leaf: np.ndarray, trees: list[dict]) -> None:
@@ -62,14 +68,11 @@ def _validate_leaf_indices(leaf: np.ndarray, trees: list[dict]) -> None:
         assert (left[node_idx] == -1).all()
 
 
-# pylint: disable=too-many-locals,too-many-statements
+# pylint: disable=too-many-locals
 def run_predict_leaf(device: Device, DMatrixT: Type[DMatrix]) -> np.ndarray:
     """Run tests for leaf index prediction."""
-    rows = 100
-    cols = 4
-    classes = 5
-    num_parallel_tree = 4
-    num_boost_round = 10
+    rows, cols, classes = 100, 4, 5
+    n_parallel, n_rounds = 4, 10
     rng = np.random.RandomState(1994)
     X = rng.randn(rows, cols)
     y = rng.randint(low=0, high=classes, size=rows)
@@ -78,61 +81,41 @@ def run_predict_leaf(device: Device, DMatrixT: Type[DMatrix]) -> np.ndarray:
     dtrain = DMatrix(X, y) if DMatrixT is ExtMemQuantileDMatrix else m
     booster = train(
         {
-            "num_parallel_tree": num_parallel_tree,
+            "num_parallel_tree": n_parallel,
             "num_class": classes,
             "tree_method": "hist",
         },
         dtrain,
-        num_boost_round=num_boost_round,
+        num_boost_round=n_rounds,
     )
-
     booster.set_param({"device": device})
-    empty = DMatrix(np.ones(shape=(0, cols)))
-    empty_leaf = booster.predict(empty, pred_leaf=True)
-    assert empty_leaf.shape[0] == 0
+    assert booster.predict(DMatrix(np.empty((0, cols))), pred_leaf=True).shape[0] == 0
 
-    leaf = booster.predict(m, pred_leaf=True, strict_shape=True)
-    if reference is not None:
-        ref_leaf = booster.predict(reference, pred_leaf=True, strict_shape=True)
-        np.testing.assert_array_equal(leaf, ref_leaf)
-    assert leaf.shape[0] == rows
-    assert leaf.shape[1] == num_boost_round
-    assert leaf.shape[2] == classes
-    assert leaf.shape[3] == num_parallel_tree
+    leaf = _predict_leaf(booster, m, reference, strict_shape=True)
+    assert leaf.shape == (rows, n_rounds, classes, n_parallel)
+    validate_leaf_output(leaf, n_parallel)
 
-    validate_leaf_output(leaf, num_parallel_tree)
-
-    n_iters = np.int32(2)
-    sliced = booster.predict(
+    n_iters = 2
+    sliced = _predict_leaf(
+        booster,
         m,
-        pred_leaf=True,
+        reference,
         iteration_range=(0, n_iters),
         strict_shape=True,
     )
-    if reference is not None:
-        ref_sliced = booster.predict(
-            reference,
-            pred_leaf=True,
-            iteration_range=(0, n_iters),
-            strict_shape=True,
-        )
-        np.testing.assert_array_equal(sliced, ref_sliced)
-    first = sliced[0, ...]
-
-    assert np.prod(first.shape) == classes * num_parallel_tree * n_iters
+    assert sliced.shape == (rows, n_iters, classes, n_parallel)
 
     # When there's only 1 tree, the output is a 1 dim vector
     booster = train({"tree_method": "hist"}, num_boost_round=1, dtrain=dtrain)
     booster.set_param({"device": device})
-    assert booster.predict(m, pred_leaf=True).shape == (rows,)
+    assert _predict_leaf(booster, m, reference).shape == (rows,)
 
     # The first two rounds have only vector-leaf trees. The full model contains
     # both vector- and scalar-leaf trees.
     mixed_rounds = 4
-    mixed_parallel_trees = classes
     booster = train(
         {
-            "num_parallel_tree": mixed_parallel_trees,
+            "num_parallel_tree": classes,
             "num_class": classes,
             "tree_method": "hist",
             "multi_strategy": "multi_output_tree",
@@ -150,36 +133,16 @@ def run_predict_leaf(device: Device, DMatrixT: Type[DMatrix]) -> np.ndarray:
     leaf_sizes = [int(tree["tree_param"]["size_leaf_vector"]) for tree in trees]
     vector_end = 2
     assert set(leaf_sizes) == {1, classes}
-    assert all(size == classes for size in leaf_sizes[: iteration_indptr[vector_end]])
-    # The total size can be reshaped into the legacy strict dimensions even
-    # though the per-iteration tree counts are ragged.
-    assert len(trees) % (mixed_rounds * classes) == 0
+    assert set(leaf_sizes[: iteration_indptr[vector_end]]) == {classes}
 
-    vector_leaf = booster.predict(m, pred_leaf=True, iteration_range=(0, vector_end))
-    vector_trees = trees[: iteration_indptr[vector_end]]
-    assert vector_leaf.shape == (rows, len(vector_trees))
-    _validate_leaf_indices(vector_leaf, vector_trees)
-    with pytest.raises(ValueError, match="uniform scalar-tree layout"):
-        booster.predict(
-            m,
-            pred_leaf=True,
-            iteration_range=(0, vector_end),
-            strict_shape=True,
-        )
-
-    mixed_leaf = booster.predict(m, pred_leaf=True)
-    assert mixed_leaf.shape == (rows, iteration_indptr[-1])
-    _validate_leaf_indices(mixed_leaf, trees)
-    with pytest.raises(ValueError, match="mixed scalar/vector-leaf"):
-        booster.predict(m, pred_leaf=True, strict_shape=True)
-
-    if reference is not None:
-        ref_vector_leaf = booster.predict(
-            reference, pred_leaf=True, iteration_range=(0, vector_end)
-        )
-        ref_mixed_leaf = booster.predict(reference, pred_leaf=True)
-        np.testing.assert_array_equal(vector_leaf, ref_vector_leaf)
-        np.testing.assert_array_equal(mixed_leaf, ref_mixed_leaf)
+    for end, n_trees in [(vector_end, iteration_indptr[vector_end]), (0, len(trees))]:
+        kwargs = {"iteration_range": (0, end)}
+        predt = _predict_leaf(booster, m, reference, **kwargs)
+        selected_trees = trees[:n_trees]
+        assert predt.shape == (rows, len(selected_trees))
+        _validate_leaf_indices(predt, selected_trees)
+        with pytest.raises(ValueError, match="vector leaf trees"):
+            booster.predict(m, pred_leaf=True, strict_shape=True, **kwargs)
 
     return leaf
 

--- a/python-package/xgboost/testing/predict.py
+++ b/python-package/xgboost/testing/predict.py
@@ -1,18 +1,68 @@
 """Tests for inference."""
 
-from typing import Type
+import json
+from typing import Optional, Type
 
 import numpy as np
+import pytest
 from scipy.special import logit  # pylint: disable=no-name-in-module
 
-from ..core import DMatrix
+from ..compat import import_cupy
+from ..core import DMatrix, ExtMemQuantileDMatrix, QuantileDMatrix
 from ..training import train
+from .data import IteratorForTest
 from .shared import validate_leaf_output
-from .updater import get_basescore
+from .updater import ResetStrategy, get_basescore
 from .utils import Device
 
 
-# pylint: disable=too-many-locals
+def _make_leaf_dmatrix(
+    device: Device, DMatrixT: Type[DMatrix], X: np.ndarray, y: np.ndarray
+) -> tuple[DMatrix, Optional[QuantileDMatrix]]:
+    """Make the prediction matrix and an in-memory external-memory reference."""
+    if DMatrixT is not ExtMemQuantileDMatrix:
+        return DMatrixT(X, y), None
+
+    X_batches = np.array_split(X, 4)
+    y_batches = np.array_split(y, 4)
+    cache_host_ratio = None
+    if device.startswith("cuda"):
+        cp = import_cupy()
+        X_batches = [cp.asarray(batch) for batch in X_batches]
+        y_batches = [cp.asarray(batch) for batch in y_batches]
+        X = cp.asarray(X)  # type: ignore[assignment]
+        y = cp.asarray(y)  # type: ignore[assignment]
+        cache_host_ratio = 1.0
+
+    it = IteratorForTest(
+        X_batches,
+        y_batches,
+        None,
+        cache="cache",
+        on_host=True,
+        min_cache_page_bytes=0,
+    )
+    m = ExtMemQuantileDMatrix(it, cache_host_ratio=cache_host_ratio)
+    reference = QuantileDMatrix(X, y, ref=m)
+    return m, reference
+
+
+def _validate_leaf_indices(leaf: np.ndarray, trees: list[dict]) -> None:
+    """Validate that each predicted node is a leaf in the corresponding tree."""
+    assert leaf.ndim == 2
+    assert leaf.shape[1] == len(trees)
+    for tree_idx, tree in enumerate(trees):
+        prediction = leaf[:, tree_idx]
+        assert np.isfinite(prediction).all()
+        node_idx = prediction.astype(np.int64)
+        np.testing.assert_array_equal(prediction, node_idx)
+
+        left = np.asarray(tree["left_children"])
+        assert ((0 <= node_idx) & (node_idx < left.size)).all()
+        assert (left[node_idx] == -1).all()
+
+
+# pylint: disable=too-many-locals,too-many-statements
 def run_predict_leaf(device: Device, DMatrixT: Type[DMatrix]) -> np.ndarray:
     """Run tests for leaf index prediction."""
     rows = 100
@@ -24,23 +74,27 @@ def run_predict_leaf(device: Device, DMatrixT: Type[DMatrix]) -> np.ndarray:
     X = rng.randn(rows, cols)
     y = rng.randint(low=0, high=classes, size=rows)
 
-    m = DMatrixT(X, y)
+    m, reference = _make_leaf_dmatrix(device, DMatrixT, X, y)
+    dtrain = DMatrix(X, y) if DMatrixT is ExtMemQuantileDMatrix else m
     booster = train(
         {
             "num_parallel_tree": num_parallel_tree,
             "num_class": classes,
             "tree_method": "hist",
         },
-        m,
+        dtrain,
         num_boost_round=num_boost_round,
     )
 
     booster.set_param({"device": device})
-    empty = DMatrixT(np.ones(shape=(0, cols)))
+    empty = DMatrix(np.ones(shape=(0, cols)))
     empty_leaf = booster.predict(empty, pred_leaf=True)
     assert empty_leaf.shape[0] == 0
 
     leaf = booster.predict(m, pred_leaf=True, strict_shape=True)
+    if reference is not None:
+        ref_leaf = booster.predict(reference, pred_leaf=True, strict_shape=True)
+        np.testing.assert_array_equal(leaf, ref_leaf)
     assert leaf.shape[0] == rows
     assert leaf.shape[1] == num_boost_round
     assert leaf.shape[2] == classes
@@ -55,14 +109,77 @@ def run_predict_leaf(device: Device, DMatrixT: Type[DMatrix]) -> np.ndarray:
         iteration_range=(0, n_iters),
         strict_shape=True,
     )
+    if reference is not None:
+        ref_sliced = booster.predict(
+            reference,
+            pred_leaf=True,
+            iteration_range=(0, n_iters),
+            strict_shape=True,
+        )
+        np.testing.assert_array_equal(sliced, ref_sliced)
     first = sliced[0, ...]
 
     assert np.prod(first.shape) == classes * num_parallel_tree * n_iters
 
     # When there's only 1 tree, the output is a 1 dim vector
-    booster = train({"tree_method": "hist"}, num_boost_round=1, dtrain=m)
+    booster = train({"tree_method": "hist"}, num_boost_round=1, dtrain=dtrain)
     booster.set_param({"device": device})
     assert booster.predict(m, pred_leaf=True).shape == (rows,)
+
+    # The first two rounds have only vector-leaf trees. The full model contains
+    # both vector- and scalar-leaf trees.
+    mixed_rounds = 4
+    mixed_parallel_trees = classes
+    booster = train(
+        {
+            "num_parallel_tree": mixed_parallel_trees,
+            "num_class": classes,
+            "tree_method": "hist",
+            "multi_strategy": "multi_output_tree",
+        },
+        dtrain,
+        num_boost_round=mixed_rounds,
+        callbacks=[ResetStrategy()],
+    )
+    booster.set_param({"device": device})
+
+    model = json.loads(booster.save_raw(raw_format="json"))
+    gbtree_model = model["learner"]["gradient_booster"]["model"]
+    trees = gbtree_model["trees"]
+    iteration_indptr = gbtree_model["iteration_indptr"]
+    leaf_sizes = [int(tree["tree_param"]["size_leaf_vector"]) for tree in trees]
+    vector_end = 2
+    assert set(leaf_sizes) == {1, classes}
+    assert all(size == classes for size in leaf_sizes[: iteration_indptr[vector_end]])
+    # The total size can be reshaped into the legacy strict dimensions even
+    # though the per-iteration tree counts are ragged.
+    assert len(trees) % (mixed_rounds * classes) == 0
+
+    vector_leaf = booster.predict(m, pred_leaf=True, iteration_range=(0, vector_end))
+    vector_trees = trees[: iteration_indptr[vector_end]]
+    assert vector_leaf.shape == (rows, len(vector_trees))
+    _validate_leaf_indices(vector_leaf, vector_trees)
+    with pytest.raises(ValueError, match="uniform scalar-tree layout"):
+        booster.predict(
+            m,
+            pred_leaf=True,
+            iteration_range=(0, vector_end),
+            strict_shape=True,
+        )
+
+    mixed_leaf = booster.predict(m, pred_leaf=True)
+    assert mixed_leaf.shape == (rows, iteration_indptr[-1])
+    _validate_leaf_indices(mixed_leaf, trees)
+    with pytest.raises(ValueError, match="mixed scalar/vector-leaf"):
+        booster.predict(m, pred_leaf=True, strict_shape=True)
+
+    if reference is not None:
+        ref_vector_leaf = booster.predict(
+            reference, pred_leaf=True, iteration_range=(0, vector_end)
+        )
+        ref_mixed_leaf = booster.predict(reference, pred_leaf=True)
+        np.testing.assert_array_equal(vector_leaf, ref_vector_leaf)
+        np.testing.assert_array_equal(mixed_leaf, ref_mixed_leaf)
 
     return leaf
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1276,7 +1276,7 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle, DMatrixHandle dmat, int optio
   learner->Predict(*static_cast<std::shared_ptr<DMatrix> *>(dmat), (option_mask & 1) != 0,
                    &entry.predictions, 0, iteration_end, static_cast<bool>(training),
                    (option_mask & 2) != 0, (option_mask & 4) != 0, (option_mask & 8) != 0,
-                   (option_mask & 16) != 0);
+                   (option_mask & 16) != 0, false);
 
   xgboost_CHECK_C_ARG_PTR(len);
   xgboost_CHECK_C_ARG_PTR(out_result);
@@ -1325,41 +1325,24 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle, DMatrixHandle dmat
   bool interactions =
       type == PredictionType::kInteraction || type == PredictionType::kApproxInteraction;
   bool training = RequiredArg<Boolean>(config, "training", __func__);
+  bool strict_shape = RequiredArg<Boolean>(config, "strict_shape", __func__);
   learner->Predict(p_m, type == PredictionType::kMargin, &entry.predictions, iteration_begin,
                    iteration_end, training, type == PredictionType::kLeaf, contribs, approximate,
-                   interactions);
+                   interactions, strict_shape);
 
   xgboost_CHECK_C_ARG_PTR(out_result);
   *out_result = dmlc::BeginPtr(entry.predictions.ConstHostVector());
 
   auto &shape = learner->GetThreadLocal().prediction_shape;
   auto chunksize = p_m->Info().num_row_ == 0 ? 0 : entry.predictions.Size() / p_m->Info().num_row_;
-  auto rounds = iteration_end - iteration_begin;
-  rounds = rounds == 0 ? learner->BoostedRounds() : rounds;
-  // Determine shape
-  bool strict_shape = RequiredArg<Boolean>(config, "strict_shape", __func__);
-  if (strict_shape && type == PredictionType::kLeaf && p_m->Info().num_row_ != 0) {
-    Json learner_config{Object()};
-    learner->SaveConfig(&learner_config);
-    auto const &booster_config = learner_config["learner"]["gradient_booster"];
-    auto const &booster = get<String const>(booster_config["name"]);
-    CHECK(booster == "gbtree" || booster == "dart");
-    auto const &gbtree_config = booster == "dart" ? booster_config["gbtree"] : booster_config;
-    auto const n_parallel_trees =
-        std::stoi(get<String const>(gbtree_config["gbtree_model_param"]["num_parallel_tree"]));
-    auto const expected =
-        static_cast<bst_ulong>(rounds) * learner->Groups() * n_parallel_trees;
-    CHECK_EQ(chunksize, expected)
-        << "`strict_shape=True` is not supported for `pred_leaf=True` when the selected "
-           "iterations do not have a uniform scalar-tree layout. This includes vector-leaf "
-           "trees and mixed scalar/vector-leaf models. Use `strict_shape=False` instead.";
-  }
+  auto n_rounds = iteration_end - iteration_begin;
+  n_rounds = n_rounds == 0 ? learner->BoostedRounds() : n_rounds;
 
   xgboost_CHECK_C_ARG_PTR(out_dim);
   xgboost_CHECK_C_ARG_PTR(out_shape);
 
   CalcPredictShape(strict_shape, type, p_m->Info().num_row_, p_m->Info().num_col_, chunksize,
-                   learner->Groups(), rounds, &shape, out_dim);
+                   learner->Groups(), n_rounds, &shape, out_dim);
   *out_shape = dmlc::BeginPtr(shape);
   API_END();
 }

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1338,6 +1338,22 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle, DMatrixHandle dmat
   rounds = rounds == 0 ? learner->BoostedRounds() : rounds;
   // Determine shape
   bool strict_shape = RequiredArg<Boolean>(config, "strict_shape", __func__);
+  if (strict_shape && type == PredictionType::kLeaf && p_m->Info().num_row_ != 0) {
+    Json learner_config{Object()};
+    learner->SaveConfig(&learner_config);
+    auto const &booster_config = learner_config["learner"]["gradient_booster"];
+    auto const &booster = get<String const>(booster_config["name"]);
+    CHECK(booster == "gbtree" || booster == "dart");
+    auto const &gbtree_config = booster == "dart" ? booster_config["gbtree"] : booster_config;
+    auto const n_parallel_trees =
+        std::stoi(get<String const>(gbtree_config["gbtree_model_param"]["num_parallel_tree"]));
+    auto const expected =
+        static_cast<bst_ulong>(rounds) * learner->Groups() * n_parallel_trees;
+    CHECK_EQ(chunksize, expected)
+        << "`strict_shape=True` is not supported for `pred_leaf=True` when the selected "
+           "iterations do not have a uniform scalar-tree layout. This includes vector-leaf "
+           "trees and mixed scalar/vector-leaf models. Use `strict_shape=False` instead.";
+  }
 
   xgboost_CHECK_C_ARG_PTR(out_dim);
   xgboost_CHECK_C_ARG_PTR(out_shape);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1234,6 +1234,8 @@ XGB_DLL int XGBoosterTrainOneIterWithSplitGrad(BoosterHandle handle, DMatrixHand
   }
 
   auto p_fmat = CastDMatrixHandle(dtrain);
+  CHECK_EQ(gpair.gpair.Shape(0), p_fmat->Info().num_row_);
+  CHECK_EQ(gpair.value_gpair.Shape(0), p_fmat->Info().num_row_);
   learner->BoostOneIter(iter, p_fmat, &gpair);
 
   API_END();

--- a/src/common/quantile.cu
+++ b/src/common/quantile.cu
@@ -662,7 +662,7 @@ void SketchContainer::AllReduce(Context const *ctx, bool is_column_split) {
   pack_payload(&payload, stream);
   rc = collective::AllreduceV(
       ctx, &payload, &scratch,
-      [&](dh::device_vector<std::int8_t> const &lhs, dh::device_vector<std::int8_t> const &rhs,
+      [&](dh::device_vector<std::int8_t> const &, dh::device_vector<std::int8_t> const &rhs,
           dh::device_vector<std::int8_t> *out, cudaStream_t stream) {
         auto rhs_view = ParseDeviceSketchPayload(rhs, this->num_columns_);
         this->Merge(ctx, rhs_view.columns_ptr, rhs_view.entries);

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -152,7 +152,8 @@ class GBLinear : public GradientBooster {
     monitor_.Stop("PredictBatch");
   }
 
-  void PredictLeaf(DMatrix *, HostDeviceVector<bst_float> *, unsigned, unsigned) override {
+  void PredictLeaf(DMatrix*, HostDeviceVector<bst_float>*, bst_layer_t, bst_layer_t,
+                   bool) override {
     LOG(FATAL) << "gblinear does not support prediction of leaf index";
   }
 

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2025, XGBoost Contributors
+ * Copyright 2014-2026, XGBoost Contributors
  * \file gblinear.cc
  * \brief Implementation of Linear booster, with L1/L2 regularization: Elastic Net
  *        the update rule is parallel coordinate descent (shotgun)
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-#include "../common/error_msg.h"      // NoCategorical, DeprecatedFunc
+#include "../common/error_msg.h"  // NoCategorical, DeprecatedFunc
 #include "../common/threading_utils.h"
 #include "../common/timer.h"
 #include "gblinear_model.h"
@@ -35,13 +35,10 @@ struct GBLinearTrainParam : public XGBoostParameter<GBLinearTrainParam> {
   size_t max_row_perbatch;
 
   DMLC_DECLARE_PARAMETER(GBLinearTrainParam) {
-    DMLC_DECLARE_FIELD(updater)
-        .set_default("shotgun")
-        .describe("Update algorithm for linear model. One of shotgun/coord_descent");
-    DMLC_DECLARE_FIELD(tolerance)
-        .set_lower_bound(0.0f)
-        .set_default(0.0f)
-        .describe("Stop if largest weight update is smaller than this number.");
+    DMLC_DECLARE_FIELD(updater).set_default("shotgun").describe(
+        "Update algorithm for linear model. One of shotgun/coord_descent");
+    DMLC_DECLARE_FIELD(tolerance).set_lower_bound(0.0f).set_default(0.0f).describe(
+        "Stop if largest weight update is smaller than this number.");
     DMLC_DECLARE_FIELD(max_row_perbatch)
         .set_default(std::numeric_limits<size_t>::max())
         .describe("Maximum rows per batch.");
@@ -86,9 +83,7 @@ class GBLinear : public GradientBooster {
     updater_->Configure(cfg);
   }
 
-  int32_t BoostedRounds() const override {
-    return model_.num_boosted_rounds;
-  }
+  int32_t BoostedRounds() const override { return model_.num_boosted_rounds; }
 
   bool ModelFitted() const override { return BoostedRounds() != 0; }
 
@@ -171,7 +166,7 @@ class GBLinear : public GradientBooster {
     std::fill(contribs.begin(), contribs.end(), 0);
     auto base_score = learner_model_param_->BaseScore(ctx_);
     // start collecting the contributions
-    for (const auto &batch : p_fmat->GetBatches<SparsePage>()) {
+    for (const auto& batch : p_fmat->GetBatches<SparsePage>()) {
       // parallel over local batch
       const auto nsize = static_cast<bst_omp_uint>(batch.Size());
       auto page = batch.GetView();
@@ -180,7 +175,7 @@ class GBLinear : public GradientBooster {
         auto row_idx = static_cast<size_t>(batch.base_rowid + i);
         // loop over output groups
         for (int gid = 0; gid < ngroup; ++gid) {
-          bst_float *p_contribs = &contribs[(row_idx * ngroup + gid) * ncolumns];
+          bst_float* p_contribs = &contribs[(row_idx * ngroup + gid) * ncolumns];
           // calculate linear terms' contributions
           for (auto& ins : inst) {
             if (ins.index >= model_.learner_model_param->num_feature) continue;
@@ -202,8 +197,8 @@ class GBLinear : public GradientBooster {
     std::vector<bst_float>& contribs = out_contribs->HostVector();
 
     // linear models have no interaction effects
-    const size_t nelements = model_.learner_model_param->num_feature *
-                             model_.learner_model_param->num_feature;
+    const size_t nelements =
+        model_.learner_model_param->num_feature * model_.learner_model_param->num_feature;
     contribs.resize(p_fmat->Info().num_row_ * nelements *
                     model_.learner_model_param->num_output_group);
     std::fill(contribs.begin(), contribs.end(), 0);
@@ -214,10 +209,9 @@ class GBLinear : public GradientBooster {
     return model_.DumpModel(fmap, with_stats, format);
   }
 
-  void FeatureScore(std::string const &importance_type,
-                    common::Span<int32_t const> trees,
-                    std::vector<bst_feature_t> *out_features,
-                    std::vector<float> *out_scores) const override {
+  void FeatureScore(std::string const& importance_type, common::Span<int32_t const> trees,
+                    std::vector<bst_feature_t>* out_features,
+                    std::vector<float>* out_scores) const override {
     CHECK(!model_.weight.empty()) << "Model is not initialized";
     CHECK(trees.empty()) << "gblinear doesn't support number of trees for feature importance.";
     CHECK_EQ(importance_type, "weight")
@@ -239,18 +233,17 @@ class GBLinear : public GradientBooster {
   }
 
  protected:
-  void PredictBatchInternal(DMatrix *p_fmat,
-                            std::vector<bst_float> *out_preds) {
+  void PredictBatchInternal(DMatrix* p_fmat, std::vector<bst_float>* out_preds) {
     monitor_.Start("PredictBatchInternal");
     model_.LazyInitModel();
-    std::vector<bst_float> &preds = *out_preds;
+    std::vector<bst_float>& preds = *out_preds;
     auto base_margin = p_fmat->Info().base_margin_.View(DeviceOrd::CPU());
     // start collecting the prediction
     const int ngroup = model_.learner_model_param->num_output_group;
     preds.resize(p_fmat->Info().num_row_ * ngroup);
 
     auto base_score = learner_model_param_->BaseScore(DeviceOrd::CPU());
-    for (const auto &page : p_fmat->GetBatches<SparsePage>()) {
+    for (const auto& page : p_fmat->GetBatches<SparsePage>()) {
       auto const& batch = page.GetView();
       // output convention: nrow * k, where nrow is number of rows
       // k is number of group
@@ -280,8 +273,7 @@ class GBLinear : public GradientBooster {
     }
     float largest_dw = 0.0;
     for (size_t i = 0; i < model_.weight.size(); i++) {
-      largest_dw = std::max(
-          largest_dw, std::abs(model_.weight[i] - previous_model_.weight[i]));
+      largest_dw = std::max(largest_dw, std::abs(model_.weight[i] - previous_model_.weight[i]));
     }
     previous_model_ = model_;
 
@@ -289,9 +281,9 @@ class GBLinear : public GradientBooster {
     return is_converged_;
   }
 
-  void LazySumWeights(DMatrix *p_fmat) {
+  void LazySumWeights(DMatrix* p_fmat) {
     if (!sum_weight_complete_) {
-      auto &info = p_fmat->Info();
+      auto& info = p_fmat->Info();
       for (size_t i = 0; i < info.num_row_; i++) {
         sum_instance_weight_ += info.GetWeight(i);
       }
@@ -299,8 +291,7 @@ class GBLinear : public GradientBooster {
     }
   }
 
-  void Pred(const SparsePage::Inst &inst, bst_float *preds, int gid,
-            bst_float base) {
+  void Pred(const SparsePage::Inst& inst, bst_float* preds, int gid, bst_float base) {
     bst_float psum = model_.Bias()[gid] + base;
     for (const auto& ins : inst) {
       if (ins.index >= model_.learner_model_param->num_feature) continue;

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -228,6 +228,10 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
         << "Only the hist tree method is supported for building multi-target trees with vector "
            "leaf.";
   }
+  if (in_gpair->HasValueGrad()) {
+    CHECK(model_.learner_model_param->IsVectorLeaf())
+        << "Reduced gradien must be used with vector leaf trees";
+  }
 
   TreesOneIter new_trees;
   bst_target_t const n_groups = model_.learner_model_param->OutputLength();

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -230,7 +230,7 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
   }
   if (in_gpair->HasValueGrad()) {
     CHECK(model_.learner_model_param->IsVectorLeaf())
-        << "Reduced gradien must be used with vector leaf trees";
+        << "Reduced gradient must be used with vector leaf trees";
   }
 
   TreesOneIter new_trees;

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -289,11 +289,22 @@ class GBTree : public GradientBooster {
 
   [[nodiscard]] CatContainer const* Cats() const override { return this->model_.Cats(); }
 
-  void PredictLeaf(DMatrix* p_fmat, HostDeviceVector<bst_float>* out_preds, uint32_t layer_begin,
-                   uint32_t layer_end) override {
+  void PredictLeaf(DMatrix* p_fmat, HostDeviceVector<bst_float>* out_preds, bst_layer_t layer_begin,
+                   bst_layer_t layer_end, bool strict_shape) override {
     auto [tree_begin, tree_end] = detail::LayerToTree(model_, layer_begin, layer_end);
     CHECK_EQ(tree_begin, 0) << "Predict leaf supports only iteration end: [0, "
                                "n_iteration), use model slicing instead.";
+    auto it = this->model_.trees.cbegin();
+    // There's no good representation for vector leaf for now as the existing shape is:
+    // `(n_samples, n_iterations, n_classes, n_trees_in_forest)`. But with vector leaf, we
+    // can have mixed tree types and `n_classes` is invalid.
+    if (strict_shape &&
+        std::any_of(it + tree_begin, it + tree_end, [](std::unique_ptr<RegTree> const& p_tree) {
+          return p_tree->IsMultiTarget();
+        })) {
+      LOG(FATAL)
+          << "`strict_shape` with predict leaf is not supported when vector leaf trees are used.";
+    }
     this->GetPredictor(false)->PredictLeaf(p_fmat, out_preds, model_, tree_end);
   }
 

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1197,7 +1197,7 @@ class LearnerImpl : public LearnerIO {
   void Predict(std::shared_ptr<DMatrix> data, bool output_margin,
                HostDeviceVector<float>* out_preds, bst_layer_t layer_begin, bst_layer_t layer_end,
                bool training, bool pred_leaf, bool pred_contribs, bool approx_contribs,
-               bool pred_interactions) override {
+               bool pred_interactions, bool strict_shape) override {
     int multiple_predictions = static_cast<int>(pred_leaf) + static_cast<int>(pred_interactions) +
                                static_cast<int>(pred_contribs);
     this->Configure();
@@ -1213,7 +1213,7 @@ class LearnerImpl : public LearnerIO {
       gbm_->PredictInteractionContributions(data.get(), out_preds, layer_begin, layer_end,
                                             approx_contribs);
     } else if (pred_leaf) {
-      gbm_->PredictLeaf(data.get(), out_preds, layer_begin, layer_end);
+      gbm_->PredictLeaf(data.get(), out_preds, layer_begin, layer_end, strict_shape);
     } else {
       auto predt = prediction_container_.Cache(data, ctx_.Device());
       this->PredictRaw(data.get(), predt.get(), training, layer_begin, layer_end);

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -187,6 +187,7 @@ __global__ void PredictLeafKernel(Data data, common::Span<TreeViewVar const> d_t
     return;
   }
   Loader loader{std::move(data), use_shared, num_features, n_rows, missing, std::move(acc)};
+  auto const n_trees = tree_end - tree_begin;
   for (bst_tree_t tree_idx = tree_begin; tree_idx < tree_end; ++tree_idx) {
     auto const& d_tree = d_trees[tree_idx - tree_begin];
     cuda::std::visit(
@@ -197,7 +198,7 @@ __global__ void PredictLeafKernel(Data data, common::Span<TreeViewVar const> d_t
           } else {
             leaf = GetLeafIndex<has_missing, false>(ridx, tree, &loader);
           }
-          d_out_predictions[ridx * (tree_end - tree_begin) + tree_idx] = leaf;
+          d_out_predictions[ridx * n_trees + tree_idx - tree_begin] = leaf;
         },
         d_tree);
   }
@@ -813,6 +814,7 @@ class GPUPredictor : public xgboost::Predictor {
 
     LaunchPredict(ctx_, p_fmat->IsDense(), new_enc, model, [&](auto&& cfg, auto&& acc) {
       bst_idx_t batch_offset = 0;
+      auto const n_trees = d_model.Trees().size();
       cfg.ForEachBatch(p_fmat, [&](auto&& loader_t, auto&& batch) {
         using Loader = typename common::GetValueT<decltype(loader_t)>;
         using Config = common::GetValueT<decltype(cfg)>;
@@ -825,7 +827,7 @@ class GPUPredictor : public xgboost::Predictor {
                                     cfg.UseShared(), std::numeric_limits<float>::quiet_NaN(),
                                     std::forward<typename Config::EncAccessorT>(acc));
 
-        batch_offset += n_rows;
+        batch_offset += n_rows * n_trees;
       });
     });
   }

--- a/src/predictor/interpretability/shap.cu
+++ b/src/predictor/interpretability/shap.cu
@@ -273,8 +273,8 @@ CompressedModel CompressTreeBucket(gbm::GBTreeModel const& model,
   return out;
 }
 
-GpuQuadratureModelData PrepareGpuQuadratureModel(Context const* ctx, gbm::GBTreeModel const& model,
-                                                 bst_tree_t tree_end, bst_target_t n_groups,
+GpuQuadratureModelData PrepareGpuQuadratureModel(gbm::GBTreeModel const& model, bst_tree_t tree_end,
+                                                 bst_target_t n_groups,
                                                  std::vector<float> const* tree_weights,
                                                  char const* prediction_kind) {
   if (tree_weights != nullptr) {
@@ -1257,7 +1257,7 @@ void ShapValues(Context const* ctx, DMatrix* p_fmat, HostDeviceVector<float>* ou
   out_contribs->Fill(0.0f);
 
   auto prepared =
-      PrepareGpuQuadratureModel(ctx, model, tree_end, ngroup, tree_weights, "Predict contribution");
+      PrepareGpuQuadratureModel(model, tree_end, ngroup, tree_weights, "Predict contribution");
 
   auto new_enc =
       p_fmat->Cats()->NeedRecode() ? p_fmat->Cats()->DeviceView(ctx) : enc::DeviceColumnsView{};

--- a/src/predictor/interpretability/shap.cu
+++ b/src/predictor/interpretability/shap.cu
@@ -1306,7 +1306,7 @@ void ShapInteractionValues(Context const* ctx, DMatrix* p_fmat,
   out_contribs->Resize(p_fmat->Info().num_row_ * dim_size);
   out_contribs->Fill(0.0f);
 
-  auto prepared = PrepareGpuQuadratureModel(ctx, model, tree_end, ngroup, tree_weights,
+  auto prepared = PrepareGpuQuadratureModel(model, tree_end, ngroup, tree_weights,
                                             "Predict interaction contribution");
 
   auto new_enc =

--- a/src/tree/hist/hist_param.cc
+++ b/src/tree/hist/hist_param.cc
@@ -41,6 +41,6 @@ void HistMakerTrainParam::CheckTreesSynchronized(Context const* ctx,
   RegTree ref_tree{};  // rank 0 tree
   auto j_ref_tree = Json::Load(StringView{s_model}, std::ios::binary);
   ref_tree.LoadModel(j_ref_tree);
-  CHECK(*local_tree == ref_tree);
+  CHECK(local_tree->Equal(ref_tree));
 }
 }  // namespace xgboost::tree

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -807,7 +807,9 @@ std::string RegTree::DumpModel(const FeatureMap& fmap, bool with_stats, std::str
       [&](auto const& lhs, auto const& rhs, bst_node_t nidx) {
         auto res = lhs.LeftChild(nidx) == rhs.LeftChild(nidx) &&
                    lhs.RightChild(nidx) == rhs.RightChild(nidx) &&
+                   lhs.SplitIndex(nidx) == rhs.SplitIndex(nidx) &&
                    lhs.DefaultLeft(nidx) == rhs.DefaultLeft(nidx) &&
+                   (!this->HasCategoricalSplit() || lhs.SplitType(nidx) == rhs.SplitType(nidx)) &&
                    lhs.IsLeaf(nidx) == rhs.IsLeaf(nidx) &&
                    (lhs.IsLeaf(nidx) ? leaf_same(lhs, rhs, nidx)
                                      : float_eq(lhs.SplitCond(nidx), rhs.SplitCond(nidx)));

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -753,6 +753,9 @@ std::string RegTree::DumpModel(const FeatureMap& fmap, bool with_stats, std::str
   if (this->NumExtraNodes() != b.NumExtraNodes()) {
     return false;
   }
+  if (this->Size() != b.Size()) {
+    return false;
+  }
   if (this->HasCategoricalSplit()) {
     auto device = DeviceOrd::CPU();
     auto res = [&] {
@@ -801,10 +804,7 @@ std::string RegTree::DumpModel(const FeatureMap& fmap, bool with_stats, std::str
   bool equal = false;
   tree::WalkTree(
       *this,
-      [&](auto lhs, auto rhs, bst_node_t nidx) {
-        if (lhs.Size() != rhs.Size()) {
-          return false;
-        }
+      [&](auto const& lhs, auto const& rhs, bst_node_t nidx) {
         auto res = lhs.LeftChild(nidx) == rhs.LeftChild(nidx) &&
                    lhs.RightChild(nidx) == rhs.RightChild(nidx) &&
                    lhs.DefaultLeft(nidx) == rhs.DefaultLeft(nidx) &&

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -744,7 +744,7 @@ std::string RegTree::DumpModel(const FeatureMap& fmap, bool with_stats, std::str
 }
 
 bool RegTree::Equal(const RegTree& b) const {
-  if (this->IsMultiTarget() != b.IsMultiTarget()) {
+  if (this->NumTargets() != b.NumTargets()) {
     return false;
   }
   if (this->HasCategoricalSplit() != b.HasCategoricalSplit()) {
@@ -806,11 +806,11 @@ bool RegTree::Equal(const RegTree& b) const {
           return false;
         }
         auto res = lhs.LeftChild(nidx) == rhs.LeftChild(nidx) &&
-                           lhs.RightChild(nidx) == rhs.RightChild(nidx) &&
-                           lhs.DefaultLeft(nidx) == rhs.DefaultLeft(nidx) &&
-                           lhs.IsLeaf(nidx) == rhs.IsLeaf(nidx) && lhs.IsLeaf(nidx)
-                       ? leaf_same(lhs, rhs, nidx)
-                       : float_eq(lhs.SplitCond(nidx), rhs.SplitCond(nidx));
+                   lhs.RightChild(nidx) == rhs.RightChild(nidx) &&
+                   lhs.DefaultLeft(nidx) == rhs.DefaultLeft(nidx) &&
+                   lhs.IsLeaf(nidx) == rhs.IsLeaf(nidx) &&
+                   (lhs.IsLeaf(nidx) ? leaf_same(lhs, rhs, nidx)
+                                     : float_eq(lhs.SplitCond(nidx), rhs.SplitCond(nidx)));
         equal = res;
         // Stop if two trees are not equal.
         return res;

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -744,23 +744,79 @@ std::string RegTree::DumpModel(const FeatureMap& fmap, bool with_stats, std::str
 }
 
 bool RegTree::Equal(const RegTree& b) const {
-  CHECK(!IsMultiTarget());
+  if (this->IsMultiTarget() != b.IsMultiTarget()) {
+    return false;
+  }
+  if (this->HasCategoricalSplit() != b.HasCategoricalSplit()) {
+    return false;
+  }
   if (NumExtraNodes() != b.NumExtraNodes()) {
     return false;
   }
-  auto const& self = *this;
-  bool ret{true};
-  auto sc_tree = this->HostScView();
-  auto const& lhs = self.nodes_.ConstHostVector();
-  auto const& rhs = b.nodes_.ConstHostVector();
-  sc_tree.WalkTree([&](bst_node_t nidx) {
-    if (!(lhs.at(nidx) == rhs.at(nidx))) {
-      ret = false;
-      return false;
+  if (this->HasCategoricalSplit()) {
+    auto device = DeviceOrd::CPU();
+    auto res = [&] {
+      using Seg = CategoricalSplitMatrix::Segment;
+      auto l_ptr = this->GetSplitCategoriesPtr();
+      auto r_ptr = b.GetSplitCategoriesPtr();
+      return l_ptr.size() == r_ptr.size() &&
+             std::equal(
+                 l_ptr.cbegin(), l_ptr.cend(), r_ptr.cbegin(),
+                 [](Seg const& l, Seg const& r) { return l.size == r.size && l.beg == r.beg; });
+    }() && [&] {
+      auto l_typ = this->GetSplitTypes(device);
+      auto r_typ = b.GetSplitTypes(device);
+      return l_typ.size() == r_typ.size() &&
+             std::equal(l_typ.cbegin(), l_typ.cend(), r_typ.cbegin());
+    }() && [&] {
+      auto l_cats = this->GetSplitCategories(device);
+      auto r_cats = b.GetSplitCategories(device);
+      return l_cats.size() == r_cats.size() &&
+             std::equal(l_cats.cbegin(), l_cats.cend(), r_cats.cbegin());
+    }();
+    if (!res) {
+      return res;
     }
-    return true;
-  });
-  return ret;
+  }
+  auto const& self = *this;
+  auto n_targets = self.NumTargets();
+
+  auto float_eq = [](float l, float r) {
+    return std::abs(l - r) < kRtEps;
+  };
+  auto leaf_same = [=](auto lhs, auto rhs, bst_node_t nidx) {
+    if constexpr (tree::IsScalarTree(lhs)) {
+      return float_eq(lhs.LeafValue(nidx), rhs.LeafValue(nidx));
+    } else {
+      auto l_leaf = lhs.LeafValue(nidx);
+      auto r_leaf = rhs.LeafValue(nidx);
+      for (decltype(n_targets) t = 0; t < n_targets; ++t) {
+        if (!float_eq(l_leaf(t), r_leaf(t))) {
+          return false;
+        }
+      }
+      return true;
+    }
+  };
+  bool equal = false;
+  tree::WalkTree(
+      *this,
+      [&](auto lhs, auto rhs, bst_node_t nidx) {
+        if (lhs.Size() != rhs.Size()) {
+          return false;
+        }
+        auto res = lhs.LeftChild(nidx) == rhs.LeftChild(nidx) &&
+                           lhs.RightChild(nidx) == rhs.RightChild(nidx) &&
+                           lhs.DefaultLeft(nidx) == rhs.DefaultLeft(nidx) &&
+                           lhs.IsLeaf(nidx) == rhs.IsLeaf(nidx) && lhs.IsLeaf(nidx)
+                       ? leaf_same(lhs, rhs, nidx)
+                       : float_eq(lhs.SplitCond(nidx), rhs.SplitCond(nidx));
+        equal = res;
+        // Stop if two trees are not equal.
+        return res;
+      },
+      b);
+  return equal;
 }
 
 [[nodiscard]] bst_node_t RegTree::GetNumLeaves() const {

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -743,14 +743,14 @@ std::string RegTree::DumpModel(const FeatureMap& fmap, bool with_stats, std::str
   }
 }
 
-bool RegTree::Equal(const RegTree& b) const {
+[[nodiscard]] bool RegTree::Equal(RegTree const& b) const {
   if (this->NumTargets() != b.NumTargets()) {
     return false;
   }
   if (this->HasCategoricalSplit() != b.HasCategoricalSplit()) {
     return false;
   }
-  if (NumExtraNodes() != b.NumExtraNodes()) {
+  if (this->NumExtraNodes() != b.NumExtraNodes()) {
     return false;
   }
   if (this->HasCategoricalSplit()) {

--- a/src/tree/updater_prune.cc
+++ b/src/tree/updater_prune.cc
@@ -73,6 +73,7 @@ class TreePruner : public TreeUpdater {
   /*! \brief do pruning of a tree */
   void DoPrune(TrainParam const* param, RegTree* p_tree) {
     auto& tree = *p_tree;
+    CHECK(!tree.IsMultiTarget()) << "Pruning" << MTNotImplemented();
     bst_node_t npruned = 0;
     for (int nid = 0; nid < tree.NumNodes(); ++nid) {
       if (tree[nid].IsLeaf() && !tree[nid].IsDeleted()) {

--- a/src/tree/updater_prune.cc
+++ b/src/tree/updater_prune.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2025, XGBoost Contributors
+ * Copyright 2014-2026, XGBoost Contributors
  * \file updater_prune.cc
  * \brief prune a tree given the statistics
  * \author Tianqi Chen
@@ -55,12 +55,11 @@ class TreePruner : public TreeUpdater {
     }
     bst_node_t pid = tree[nid].Parent();
     CHECK(!tree[pid].IsLeaf());
-    RTreeNodeStat const &s = tree.Stat(pid);
+    RTreeNodeStat const& s = tree.Stat(pid);
     // Only prune when both child are leaf.
     auto left = tree[pid].LeftChild();
     auto right = tree[pid].RightChild();
-    bool balanced = tree[left].IsLeaf() &&
-                    right != RegTree::kInvalidNodeId && tree[right].IsLeaf();
+    bool balanced = tree[left].IsLeaf() && right != RegTree::kInvalidNodeId && tree[right].IsLeaf();
     if (balanced && param->NeedPrune(s.loss_chg, depth)) {
       // need to be pruned
       tree.ChangeToLeaf(pid, param->learning_rate * s.base_weight);
@@ -80,8 +79,7 @@ class TreePruner : public TreeUpdater {
         npruned = this->TryPruneLeaf(param, p_tree, nid, tree.GetDepth(nid), npruned);
       }
     }
-    LOG(INFO) << "tree pruning end, "
-              << tree.NumExtraNodes() << " extra nodes, " << npruned
+    LOG(INFO) << "tree pruning end, " << tree.NumExtraNodes() << " extra nodes, " << npruned
               << " pruned nodes, max_depth=" << tree.MaxDepth();
   }
 
@@ -93,7 +91,5 @@ class TreePruner : public TreeUpdater {
 
 XGBOOST_REGISTER_TREE_UPDATER(TreePruner, "prune")
     .describe("Pruner that prune the tree according to statistics.")
-    .set_body([](Context const* ctx, ObjInfo const* task) {
-      return new TreePruner{ctx, task};
-    });
+    .set_body([](Context const* ctx, ObjInfo const* task) { return new TreePruner{ctx, task}; });
 }  // namespace xgboost::tree

--- a/tests/cpp/tree/test_tree_model.cc
+++ b/tests/cpp/tree/test_tree_model.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2025, XGBoost Contributors
+ * Copyright 2018-2026, XGBoost Contributors
  */
 #include <gtest/gtest.h>
 
@@ -78,8 +78,8 @@ TEST(Tree, ExpandCategoricalFeature) {
   {
     RegTree tree;
     bst_cat_t cat = 33;
-    std::vector<uint32_t> split_cats(LBitField32::ComputeStorageSize(cat+1));
-    LBitField32 bitset {split_cats};
+    std::vector<uint32_t> split_cats(LBitField32::ComputeStorageSize(cat + 1));
+    LBitField32 bitset{split_cats};
     bitset.Set(cat);
     tree.ExpandCategorical(0, 0, split_cats, true, 1.0, 2.0, 3.0, 11.0, 2.0,
                            /*left_sum=*/3.0, /*right_sum=*/4.0);
@@ -126,8 +126,7 @@ void GrowTree(RegTree* p_tree) {
     bst_feature_t f = feat(&lcg);
     if (is_cat) {
       bst_cat_t cat = common::AsCat(split_cat(&lcg));
-      std::vector<uint32_t> split_cats(
-          LBitField32::ComputeStorageSize(cat + 1));
+      std::vector<uint32_t> split_cats(LBitField32::ComputeStorageSize(cat + 1));
       LBitField32 bitset{split_cats};
       bitset.Set(cat);
       tree.ExpandCategorical(node, f, split_cats, true, 1.0, 2.0, 3.0, 11.0, 2.0,
@@ -143,7 +142,7 @@ void GrowTree(RegTree* p_tree) {
   }
 }
 
-void CheckReload(RegTree const &tree) {
+void CheckReload(RegTree const& tree) {
   Json out{Object()};
   tree.SaveModel(&out);
 
@@ -207,16 +206,16 @@ RegTree ConstructTreeCat(std::vector<bst_cat_t>* cond) {
   cond->push_back(14);
   cond->push_back(32);
 
-  tree.ExpandCategorical(0, /*split_index=*/0, cats_storage, true, 0.0f, 2.0,
-                         3.00, 11.0, 2.0, 3.0, 4.0);
+  tree.ExpandCategorical(0, /*split_index=*/0, cats_storage, true, 0.0f, 2.0, 3.00, 11.0, 2.0, 3.0,
+                         4.0);
   auto left = tree[0].LeftChild();
   auto right = tree[0].RightChild();
   tree.ExpandNode(
       /*nid=*/left, /*split_index=*/1, /*split_value=*/1.0f,
       /*default_left=*/false, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, /*left_sum=*/0.0f,
       /*right_sum=*/0.0f);
-  tree.ExpandCategorical(right, /*split_index=*/0, cats_storage, true, 0.0f,
-                         2.0, 3.00, 11.0, 2.0, 3.0, 4.0);
+  tree.ExpandCategorical(right, /*split_index=*/0, cats_storage, true, 0.0f, 2.0, 3.00, 11.0, 2.0,
+                         3.0, 4.0);
   return tree;
 }
 
@@ -286,14 +285,11 @@ TEST(Tree, DumpJson) {
   str = tree.DumpModel(fmap, false, "json");
   ASSERT_EQ(str.find("cover"), std::string::npos);
 
-
   auto j_tree = Json::Load({str.c_str(), str.size()});
   ASSERT_EQ(get<Array>(j_tree["children"]).size(), 2ul);
 }
 
-TEST(Tree, DumpJsonCategorical) {
-  TestCategoricalTreeDump("json", ", ");
-}
+TEST(Tree, DumpJsonCategorical) { TestCategoricalTreeDump("json", ", "); }
 
 TEST(Tree, DumpText) {
   auto tree = ConstructTree();
@@ -330,9 +326,7 @@ TEST(Tree, DumpText) {
   ASSERT_EQ(str.find("cover"), std::string::npos);
 }
 
-TEST(Tree, DumpTextCategorical) {
-  TestCategoricalTreeDump("text", ",");
-}
+TEST(Tree, DumpTextCategorical) { TestCategoricalTreeDump("text", ","); }
 
 TEST(Tree, DumpDot) {
   auto tree = ConstructTree();
@@ -372,9 +366,7 @@ TEST(Tree, DumpDot) {
   ASSERT_NE(str.find(R"(1 -> 4 [label="no, missing")"), std::string::npos);
 }
 
-TEST(Tree, DumpDotCategorical) {
-  TestCategoricalTreeDump("dot", ",");
-}
+TEST(Tree, DumpDotCategorical) { TestCategoricalTreeDump("dot", ","); }
 
 TEST(Tree, JsonIO) {
   RegTree tree;

--- a/tests/cpp/tree/test_tree_model.cc
+++ b/tests/cpp/tree/test_tree_model.cc
@@ -398,7 +398,7 @@ TEST(Tree, JsonIO) {
   RegTree loaded_tree;
   loaded_tree.LoadModel(j_tree);
   ASSERT_EQ(loaded_tree.NumNodes(), 3);
-  ASSERT_TRUE(loaded_tree == tree);
+  ASSERT_TRUE(loaded_tree.Equal(tree));
 
   auto left = tree[0].LeftChild();
   auto right = tree[0].RightChild();

--- a/tests/python-gpu/test_gpu_prediction.py
+++ b/tests/python-gpu/test_gpu_prediction.py
@@ -425,7 +425,9 @@ class TestGPUPredict:
             np.sum(shap, axis=len(shap.shape) - 1), margin, rtol=1e-3
         )
 
-    @pytest.mark.parametrize("DMatrixT", [xgb.DMatrix, xgb.QuantileDMatrix])
+    @pytest.mark.parametrize(
+        "DMatrixT", [xgb.DMatrix, xgb.QuantileDMatrix, xgb.ExtMemQuantileDMatrix]
+    )
     def test_predict_leaf_basic(self, DMatrixT: Type[xgb.DMatrix]) -> None:
         gpu_leaf = run_predict_leaf("cuda", DMatrixT)
         cpu_leaf = run_predict_leaf("cpu", DMatrixT)

--- a/tests/python/test_predict.py
+++ b/tests/python/test_predict.py
@@ -29,7 +29,9 @@ def run_threaded_predict(X, rows, predict_func):
         assert f.result()
 
 
-@pytest.mark.parametrize("DMatrixT", [xgb.DMatrix, xgb.QuantileDMatrix])
+@pytest.mark.parametrize(
+    "DMatrixT", [xgb.DMatrix, xgb.QuantileDMatrix, xgb.ExtMemQuantileDMatrix]
+)
 def test_predict_leaf(DMatrixT: Type[xgb.DMatrix]) -> None:
     run_predict_leaf("cpu", DMatrixT)
 


### PR DESCRIPTION
- Mark the `strict_shape` as unsupported for vector leaf trees.
Supporting it requires changing the output schema (shape, specifically) as explained in the code comments. In addition, we have mixed tree types, which cannot be represented by a dense array. As a result, this PR simply throws an exception when `strict_shape` is used with vector leaf trees.
- The PR fixes the row offset in the predict leaf function when external memory is used.
- Cleanup the `Equal` implementation used for testing.
- Some additional checks to prevent UB.

Ref: https://github.com/dmlc/xgboost/issues/9043