### PR TITLE
[MT] Defensive checks.

### DIFF
--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -365,7 +365,7 @@ void GBTree::BoostNewTrees(GradientContainer* gpair, DMatrix* p_fmat, int bst_gr
     if (!gpair->HasValueGrad()) {
       CHECK_EQ(gpair->gpair.Size(), n_out) << msg;
     }
-    CHECK(!dparam_.HasDropout()) << "dart " << MTNotImplemented();
+    CHECK(!dparam_.HasDropout()) << "dart" << MTNotImplemented();
   }
 
   out_position->resize(new_trees.size());

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -10,7 +10,7 @@
 #include <dmlc/omp.h>
 #include <dmlc/parameter.h>
 
-#include <algorithm>  // for equal
+#include <algorithm>  // for equal, any_of
 #include <cstdint>    // for uint32_t
 #include <memory>
 #include <string>
@@ -365,6 +365,7 @@ void GBTree::BoostNewTrees(GradientContainer* gpair, DMatrix* p_fmat, int bst_gr
     if (!gpair->HasValueGrad()) {
       CHECK_EQ(gpair->gpair.Size(), n_out) << msg;
     }
+    CHECK(!dparam_.HasDropout()) << "dart " << MTNotImplemented();
   }
 
   out_position->resize(new_trees.size());
@@ -383,8 +384,7 @@ void GBTree::CommitModel(TreesOneIter&& new_trees) {
   monitor_.Start("CommitModel");
   auto n_old_trees = model_.trees.size();
   auto has_tree_weights = !model_.weight_drop.empty();
-  auto dropout_configured =
-      dparam_.rate_drop != 0.0f || dparam_.one_drop || dparam_.skip_drop != 0.0f;
+  auto dropout_configured = dparam_.HasDropout();
   auto track_tree_weights = has_tree_weights || dropout_configured;
   if (track_tree_weights && model_.weight_drop.size() < n_old_trees) {
     model_.weight_drop.insert(model_.weight_drop.cend(), n_old_trees - model_.weight_drop.size(),
@@ -734,10 +734,6 @@ void GBTree::PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* out_preds, bool
 void GBTree::InplacePredict(std::shared_ptr<DMatrix> p_m, float missing,
                             PredictionCacheEntry* out_preds, bst_layer_t layer_begin,
                             bst_layer_t layer_end) const {
-  auto const* tree_weights = model_.TreeWeights();
-  if (tree_weights != nullptr) {
-    CHECK(!this->model_.learner_model_param->IsVectorLeaf()) << "dart" << MTNotImplemented();
-  }
   auto [tree_begin, tree_end] = detail::LayerToTree(model_, layer_begin, layer_end);
   CHECK_LE(tree_end, model_.trees.size()) << "Invalid number of trees.";
   if (p_m->Ctx()->Device() != this->ctx_->Device()) {

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -117,6 +117,10 @@ struct DartTrainParam : public XGBoostParameter<DartTrainParam> {
         .set_default(0.0f)
         .describe("Probability of skipping the dropout during a boosting iteration.");
   }
+
+  [[nodiscard]] bool HasDropout() const {
+    return this->rate_drop != 0.0f || this->one_drop || this->skip_drop != 0.0f;
+  }
 };
 
 namespace detail {

--- a/src/metric/auc.cc
+++ b/src/metric/auc.cc
@@ -257,6 +257,9 @@ std::pair<double, uint32_t> RankingAUC(Context const *ctx, std::vector<float> co
 template <typename Curve>
 class EvalAUC : public MetricNoCache {
   double Eval(const HostDeviceVector<bst_float> &preds, const MetaInfo &info) override {
+    if (info.group_ptr_.empty()) {
+      CheckRowWeights(info);
+    }
     double auc {0};
     if (ctx_->Device().IsCUDA()) {
       preds.SetDevice(ctx_->Device());

--- a/src/metric/auc.cc
+++ b/src/metric/auc.cc
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include "../common/algorithm.h"        // ArgSort
+#include "../common/algorithm.h"  // ArgSort
 #include "../common/math.h"
 #include "../common/optional_weight.h"  // OptionalWeights
 #include "metric_common.h"              // MetricNoCache
@@ -32,10 +32,10 @@ DMLC_REGISTRY_FILE_TAG(auc);
  * handle the normalization.
  */
 template <typename Fn>
-std::tuple<double, double, double>
-BinaryAUC(common::Span<float const> predts, linalg::VectorView<float const> labels,
-          common::OptionalWeights weights,
-          std::vector<size_t> const &sorted_idx, Fn &&area_fn) {
+std::tuple<double, double, double> BinaryAUC(common::Span<float const> predts,
+                                             linalg::VectorView<float const> labels,
+                                             common::OptionalWeights weights,
+                                             std::vector<size_t> const &sorted_idx, Fn &&area_fn) {
   CHECK_NE(labels.Size(), 0);
   CHECK_EQ(labels.Size(), predts.size());
   auto p_predts = predts.data();
@@ -149,7 +149,7 @@ std::tuple<double, double, double> BinaryROCAUC(Context const *ctx,
 /**
  * Calculate AUC for 1 ranking group;
  */
-double GroupRankingROC(Context const* ctx, common::Span<float const> predts,
+double GroupRankingROC(Context const *ctx, common::Span<float const> predts,
                        linalg::VectorView<float const> labels, float w) {
   // on ranking, we just count all pairs.
   double auc{0};
@@ -260,7 +260,7 @@ class EvalAUC : public MetricNoCache {
     if (info.group_ptr_.empty()) {
       CheckRowWeights(info);
     }
-    double auc {0};
+    double auc{0};
     if (ctx_->Device().IsCUDA()) {
       preds.SetDevice(ctx_->Device());
       info.labels.SetDevice(ctx_->Device());
@@ -289,8 +289,7 @@ class EvalAUC : public MetricNoCache {
       uint32_t valid_groups = 0;
       if (info.labels.Size() != 0) {
         CHECK_EQ(info.group_ptr_.back(), info.labels.Size());
-        std::tie(auc, valid_groups) =
-            static_cast<Curve *>(this)->EvalRanking(preds, info);
+        std::tie(auc, valid_groups) = static_cast<Curve *>(this)->EvalRanking(preds, info);
       }
       if (valid_groups != info.group_ptr_.size() - 1) {
         InvalidGroupAUC();
@@ -314,8 +313,7 @@ class EvalAUC : public MetricNoCache {
        */
       double fp{0}, tp{0};
       if (!(preds.Empty() || info.labels.Size() == 0)) {
-        std::tie(fp, tp, auc) =
-            static_cast<Curve *>(this)->EvalBinary(preds, info);
+        std::tie(fp, tp, auc) = static_cast<Curve *>(this)->EvalBinary(preds, info);
       }
       auc = collective::GlobalRatio(ctx_, info, auc, fp * tp);
       if (!std::isnan(auc)) {
@@ -349,8 +347,8 @@ class EvalROCAUC : public EvalAUC<EvalROCAUC> {
     return std::make_pair(auc, valid_groups);
   }
 
-  double EvalMultiClass(HostDeviceVector<float> const &predts,
-                        MetaInfo const &info, size_t n_classes) {
+  double EvalMultiClass(HostDeviceVector<float> const &predts, MetaInfo const &info,
+                        size_t n_classes) {
     double auc{0};
     auto n_threads = ctx_->Threads();
     CHECK_NE(n_classes, 0);
@@ -362,8 +360,8 @@ class EvalROCAUC : public EvalAUC<EvalROCAUC> {
     return auc;
   }
 
-  std::tuple<double, double, double>
-  EvalBinary(HostDeviceVector<float> const &predts, MetaInfo const &info) {
+  std::tuple<double, double, double> EvalBinary(HostDeviceVector<float> const &predts,
+                                                MetaInfo const &info) {
     double fp, tp, auc;
     if (ctx_->IsCUDA()) {
       std::tie(fp, tp, auc) =
@@ -377,14 +375,12 @@ class EvalROCAUC : public EvalAUC<EvalROCAUC> {
   }
 
  public:
-  [[nodiscard]] char const* Name() const override {
-    return "auc";
-  }
+  [[nodiscard]] char const *Name() const override { return "auc"; }
 };
 
 XGBOOST_REGISTER_METRIC(EvalAUC, "auc")
-.describe("Receiver Operating Characteristic Area Under the Curve.")
-.set_body([](const char*) { return new EvalROCAUC(); });
+    .describe("Receiver Operating Characteristic Area Under the Curve.")
+    .set_body([](const char *) { return new EvalROCAUC(); });
 
 #if !defined(XGBOOST_USE_CUDA)
 std::tuple<double, double, double> GPUBinaryROCAUC(Context const *, common::Span<float const>,
@@ -413,8 +409,8 @@ class EvalPRAUC : public EvalAUC<EvalPRAUC> {
   std::shared_ptr<DeviceAUCCache> d_cache_;
 
  public:
-  std::tuple<double, double, double>
-  EvalBinary(HostDeviceVector<float> const &predts, MetaInfo const &info) {
+  std::tuple<double, double, double> EvalBinary(HostDeviceVector<float> const &predts,
+                                                MetaInfo const &info) {
     double pr, re, auc;
     if (ctx_->IsCUDA()) {
       std::tie(pr, re, auc) = GPUBinaryPRAUC(ctx_, predts.ConstDeviceSpan(), info, &this->d_cache_);

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -47,6 +47,7 @@ namespace {
 template <typename Fn>
 PackedReduceResult Reduce(Context const* ctx, MetaInfo const& info, Fn&& loss,
                           size_t num_preds = 1) {
+  CheckRowWeights(info);
   PackedReduceResult result;
   // This function doesn't have sycl-specific implementation yet.
   // For that reason we transfer data to host in case of sycl is used for propper execution.
@@ -420,6 +421,9 @@ class QuantileError : public MetricNoCache {
 
   double Eval(HostDeviceVector<bst_float> const& preds, const MetaInfo& info) override {
     CHECK(!alpha_.Empty());
+    CHECK_EQ(info.labels.Shape(0), info.num_row_) << "Invalid shape of labels.";
+    CHECK_EQ(preds.Size(), info.labels.Size() * alpha_.Size())
+        << "Prediction size must equal label size times the number of alpha values.";
     if (info.num_row_ == 0) {
       // empty DMatrix on distributed env
       std::array<double, 2> dat{0.0, 0.0};
@@ -434,7 +438,7 @@ class QuantileError : public MetricNoCache {
     preds.SetDevice(ctx->Device());
     alpha_.SetDevice(ctx->Device());
     auto alpha = ctx->IsCPU() ? alpha_.ConstHostSpan() : alpha_.ConstDeviceSpan();
-    std::size_t n_targets = preds.Size() / info.num_row_ / alpha_.Size();
+    std::size_t n_targets = info.labels.Shape(1);
     CHECK_NE(n_targets, 0);
     auto y_predt = linalg::MakeTensorView(ctx, &preds, static_cast<std::size_t>(info.num_row_),
                                           alpha_.Size(), n_targets);
@@ -504,6 +508,9 @@ class ExpectileError : public MetricNoCache {
 
   double Eval(HostDeviceVector<bst_float> const& preds, const MetaInfo& info) override {
     CHECK(!alpha_.Empty());
+    CHECK_EQ(info.labels.Shape(0), info.num_row_) << "Invalid shape of labels.";
+    CHECK_EQ(preds.Size(), info.labels.Size() * alpha_.Size())
+        << "Prediction size must equal label size times the number of alpha values.";
     if (info.num_row_ == 0) {
       // empty DMatrix on distributed env
       std::array<double, 2> dat{0.0, 0.0};
@@ -518,7 +525,7 @@ class ExpectileError : public MetricNoCache {
     preds.SetDevice(ctx->Device());
     alpha_.SetDevice(ctx->Device());
     auto alpha = ctx->IsCPU() ? alpha_.ConstHostSpan() : alpha_.ConstDeviceSpan();
-    std::size_t n_targets = preds.Size() / info.num_row_ / alpha_.Size();
+    std::size_t n_targets = info.labels.Shape(1);
     CHECK_NE(n_targets, 0);
     auto y_predt = linalg::MakeTensorView(ctx, &preds, static_cast<std::size_t>(info.num_row_),
                                           alpha_.Size(), n_targets);

--- a/src/metric/metric_common.h
+++ b/src/metric/metric_common.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2024, Contributors
+ * Copyright 2018-2026, XGBoost Contributors
  */
 #ifndef XGBOOST_METRIC_METRIC_COMMON_H_
 #define XGBOOST_METRIC_METRIC_COMMON_H_
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "../collective/aggregator.h"
+#include "xgboost/logging.h"
 #include "xgboost/metric.h"
 
 namespace xgboost {
@@ -28,6 +29,15 @@ class MetricNoCache : public Metric {
 };
 
 namespace metric {
+inline void CheckRowWeights(MetaInfo const &info) {
+  if (info.weights_.Empty()) {
+    return;
+  }
+  CHECK(info.group_ptr_.empty()) << "Row-wise metric does not support query group weights.";
+  CHECK_EQ(info.weights_.Size(), info.num_row_)
+      << "Number of weights should be equal to the number of data points.";
+}
+
 // Ranking config to be used on device and host
 struct EvalRankConfig {
  public:

--- a/src/metric/multiclass_metric.cu
+++ b/src/metric/multiclass_metric.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2024, XGBoost Contributors
+ * Copyright 2015-2026, XGBoost Contributors
  * \file multiclass_metric.cc
  * \brief evaluation metrics for multiclass classification.
  * \author Kailong Chen, Tianqi Chen
@@ -16,7 +16,7 @@
 #include "metric_common.h"  // MetricNoCache
 
 #if defined(XGBOOST_USE_CUDA)
-#include <thrust/functional.h>        // thrust::plus<>
+#include <thrust/functional.h>  // thrust::plus<>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/transform_reduce.h>
 
@@ -39,9 +39,9 @@ class MultiClassMetricsReduction {
  public:
   MultiClassMetricsReduction() = default;
 
-  [[nodiscard]] PackedReduceResult CpuReduceMetrics(const HostDeviceVector<bst_float>& weights,
-                                                    const HostDeviceVector<bst_float>& labels,
-                                                    const HostDeviceVector<bst_float>& preds,
+  [[nodiscard]] PackedReduceResult CpuReduceMetrics(const HostDeviceVector<float>& weights,
+                                                    const HostDeviceVector<float>& labels,
+                                                    const HostDeviceVector<float>& preds,
                                                     const size_t n_class, int32_t n_threads) const {
     size_t ndata = labels.Size();
 
@@ -49,33 +49,29 @@ class MultiClassMetricsReduction {
     const auto& h_weights = weights.HostVector();
     const auto& h_preds = preds.HostVector();
 
-    std::atomic<int> label_error {0};
+    std::atomic<int> label_error{0};
     bool const is_null_weight = weights.Size() == 0;
 
     std::vector<double> scores_tloc(n_threads, 0);
     std::vector<double> weights_tloc(n_threads, 0);
     common::ParallelFor(ndata, n_threads, [&](size_t idx) {
-        bst_float weight = is_null_weight ? 1.0f : h_weights[idx];
-        auto label = static_cast<int>(h_labels[idx]);
-        if (label >= 0 && label < static_cast<int>(n_class)) {
-          auto t_idx = omp_get_thread_num();
-          scores_tloc[t_idx] +=
-              EvalRowPolicy::EvalRow(label, h_preds.data() + idx * n_class,
-                                     n_class) *
-              weight;
-          weights_tloc[t_idx] += weight;
-        } else {
-          label_error = label;
-        }
+      bst_float weight = is_null_weight ? 1.0f : h_weights[idx];
+      auto label = static_cast<int>(h_labels[idx]);
+      if (label >= 0 && label < static_cast<int>(n_class)) {
+        auto t_idx = omp_get_thread_num();
+        scores_tloc[t_idx] +=
+            EvalRowPolicy::EvalRow(label, h_preds.data() + idx * n_class, n_class) * weight;
+        weights_tloc[t_idx] += weight;
+      } else {
+        label_error = label;
+      }
     });
 
-    double residue_sum =
-        std::accumulate(scores_tloc.cbegin(), scores_tloc.cend(), 0.0);
-    double weights_sum =
-        std::accumulate(weights_tloc.cbegin(), weights_tloc.cend(), 0.0);
+    double residue_sum = std::accumulate(scores_tloc.cbegin(), scores_tloc.cend(), 0.0);
+    double weights_sum = std::accumulate(weights_tloc.cbegin(), weights_tloc.cend(), 0.0);
 
     CheckLabelError(label_error, n_class);
-    PackedReduceResult res { residue_sum, weights_sum };
+    PackedReduceResult res{residue_sum, weights_sum};
 
     return res;
   }
@@ -101,22 +97,19 @@ class MultiClassMetricsReduction {
     s_label_error[0] = 0;
 
     PackedReduceResult result = thrust::transform_reduce(
-        ctx->CUDACtx()->CTP(),
-        begin, end,
+        ctx->CUDACtx()->CTP(), begin, end,
         [=] XGBOOST_DEVICE(size_t idx) {
           bst_float weight = is_null_weight ? 1.0f : s_weights[idx];
           bst_float residue = 0;
           auto label = static_cast<int>(s_labels[idx]);
           if (label >= 0 && label < static_cast<int32_t>(n_class)) {
-            residue = EvalRowPolicy::EvalRow(
-                label, &s_preds[idx * n_class], n_class) * weight;
+            residue = EvalRowPolicy::EvalRow(label, &s_preds[idx * n_class], n_class) * weight;
           } else {
             s_label_error[0] = label;
           }
-          return PackedReduceResult{ residue, weight };
+          return PackedReduceResult{residue, weight};
         },
-        PackedReduceResult(),
-        thrust::plus<PackedReduceResult>());
+        PackedReduceResult(), thrust::plus<PackedReduceResult>());
     CheckLabelError(s_label_error[0], n_class);
 
     return result;
@@ -156,20 +149,22 @@ class MultiClassMetricsReduction {
  * \brief base class of multi-class evaluation
  * \tparam Derived the name of subclass
  */
-template<typename Derived>
+template <typename Derived>
 struct EvalMClassBase : public MetricNoCache {
-  double Eval(const HostDeviceVector<float> &preds, const MetaInfo &info) override {
+  double Eval(const HostDeviceVector<float>& preds, const MetaInfo& info) override {
+    CheckRowWeights(info);
     if (info.labels.Size() == 0) {
       CHECK_EQ(preds.Size(), 0);
     } else {
+      CHECK_EQ(info.labels.Shape(1), 1)
+          << "`merror` and `mlogloss` do not support multi-target labels.";
       CHECK(preds.Size() % info.labels.Size() == 0) << "label and prediction size not match";
     }
     std::array<double, 2> dat{0.0, 0.0};
     if (info.labels.Size() != 0) {
       const size_t nclass = preds.Size() / info.labels.Size();
-      CHECK_GE(nclass, 1U)
-          << "mlogloss and merror are only used for multi-class classification,"
-          << " use logloss for binary classification";
+      CHECK_GE(nclass, 1U) << "mlogloss and merror are only used for multi-class classification,"
+                           << " use logloss for binary classification";
       auto result = reducer_.Reduce(this->ctx_, nclass, info.weights_, *info.labels.Data(), preds);
       dat[0] = result.Residue();
       dat[1] = result.Weights();
@@ -185,41 +180,31 @@ struct EvalMClassBase : public MetricNoCache {
    * \param pred prediction value of current instance
    * \param nclass number of class in the prediction
    */
-  XGBOOST_DEVICE static bst_float EvalRow(int label,
-                                          const bst_float *pred,
-                                          size_t nclass);
+  XGBOOST_DEVICE static bst_float EvalRow(int label, const bst_float* pred, size_t nclass);
   /*!
    * \brief to be overridden by subclass, final transformation
    * \param esum the sum statistics returned by EvalRow
    * \param wsum sum of weight
    */
-  inline static double GetFinal(double esum, double wsum) {
-    return esum / wsum;
-  }
+  inline static double GetFinal(double esum, double wsum) { return esum / wsum; }
 
  private:
   MultiClassMetricsReduction<Derived> reducer_;
   // used to store error message
-  const char *error_msg_;
+  const char* error_msg_;
 };
 
 /*! \brief match error */
 struct EvalMatchError : public EvalMClassBase<EvalMatchError> {
-  const char* Name() const override {
-    return "merror";
-  }
-  XGBOOST_DEVICE static bst_float EvalRow(int label,
-                                          const bst_float *pred,
-                                          size_t nclass) {
+  const char* Name() const override { return "merror"; }
+  XGBOOST_DEVICE static bst_float EvalRow(int label, const bst_float* pred, size_t nclass) {
     return common::FindMaxIndex(pred, pred + nclass) != pred + static_cast<int>(label);
   }
 };
 
 /*! \brief match error */
 struct EvalMultiLogLoss : public EvalMClassBase<EvalMultiLogLoss> {
-  const char* Name() const override {
-    return "mlogloss";
-  }
+  const char* Name() const override { return "mlogloss"; }
   XGBOOST_DEVICE static bst_float EvalRow(int label, const bst_float* pred, size_t /*nclass*/) {
     const bst_float eps = 1e-16f;
     auto k = static_cast<size_t>(label);

--- a/src/metric/rank_metric.cc
+++ b/src/metric/rank_metric.cc
@@ -56,6 +56,7 @@ struct EvalAMS : public MetricNoCache {
   }
 
   double Eval(const HostDeviceVector<bst_float>& preds, const MetaInfo& info) override {
+    CheckRowWeights(info);
     CHECK(!collective::IsDistributed()) << "metric AMS do not support distributed evaluation";
     using namespace std;  // NOLINT(*)
 
@@ -245,12 +246,16 @@ class EvalRankWithCache : public Metric {
     double result{0.0};
     auto const& info = p_fmat->Info();
     collective::ApplyWithLabels(ctx_, info, &result, sizeof(double), [&] {
+      if (!info.labels.Empty()) {
+        CHECK_EQ(info.labels.Shape(1), 1) << "Ranking metrics do not support multi-target labels.";
+      }
+      CHECK_EQ(preds.Size(), info.labels.Size());
+
       auto p_cache = cache_.CacheItem(p_fmat, ctx_, info, param_);
       if (p_cache->Param() != param_) {
         p_cache = cache_.ResetItem(p_fmat, ctx_, info, param_);
       }
       CHECK(p_cache->Param() == param_);
-      CHECK_EQ(preds.Size(), info.labels.Size());
 
       result = this->Eval(preds, info, p_cache);
     });

--- a/src/metric/survival_metric.cu
+++ b/src/metric/survival_metric.cu
@@ -21,7 +21,7 @@
 
 #if defined(XGBOOST_USE_CUDA)
 #include "../common/cuda_context.cuh"  // for CUDAContext
-#endif  // XGBOOST_USE_CUDA
+#endif                                 // XGBOOST_USE_CUDA
 
 using AFTParam = xgboost::common::AFTParam;
 using ProbabilityDistributionType = xgboost::common::ProbabilityDistributionType;
@@ -36,9 +36,7 @@ template <typename EvalRow>
 class ElementWiseSurvivalMetricsReduction {
  public:
   ElementWiseSurvivalMetricsReduction() = default;
-  void Configure(EvalRow policy) {
-    policy_ = policy;
-  }
+  void Configure(EvalRow policy) { policy_ = policy; }
 
   [[nodiscard]] PackedReduceResult CpuReduceMetrics(
       const HostDeviceVector<bst_float>& weights,
@@ -57,14 +55,12 @@ class ElementWiseSurvivalMetricsReduction {
     std::vector<double> weight_tloc(n_threads, 0.0);
 
     common::ParallelFor(ndata, n_threads, [&](size_t i) {
-      const double wt =
-          h_weights.empty() ? 1.0 : static_cast<double>(h_weights[i]);
+      const double wt = h_weights.empty() ? 1.0 : static_cast<double>(h_weights[i]);
       auto t_idx = omp_get_thread_num();
-      score_tloc[t_idx] +=
-          policy_.EvalRow(static_cast<double>(h_labels_lower_bound[i]),
-                          static_cast<double>(h_labels_upper_bound[i]),
-                          static_cast<double>(h_preds[i])) *
-          wt;
+      score_tloc[t_idx] += policy_.EvalRow(static_cast<double>(h_labels_lower_bound[i]),
+                                           static_cast<double>(h_labels_upper_bound[i]),
+                                           static_cast<double>(h_preds[i])) *
+                           wt;
       weight_tloc[t_idx] += wt;
     });
 
@@ -145,41 +141,32 @@ class ElementWiseSurvivalMetricsReduction {
 struct EvalIntervalRegressionAccuracy {
   void Configure(const Args&) {}
 
-  [[nodiscard]] const char* Name() const {
-    return "interval-regression-accuracy";
-  }
+  [[nodiscard]] const char* Name() const { return "interval-regression-accuracy"; }
 
-  XGBOOST_DEVICE double EvalRow(
-      double label_lower_bound, double label_upper_bound, double log_pred) const {
+  XGBOOST_DEVICE double EvalRow(double label_lower_bound, double label_upper_bound,
+                                double log_pred) const {
     const double pred = exp(log_pred);
     return (pred >= label_lower_bound && pred <= label_upper_bound) ? 1.0 : 0.0;
   }
 
-  static double GetFinal(double esum, double wsum) {
-    return wsum == 0 ? esum : esum / wsum;
-  }
+  static double GetFinal(double esum, double wsum) { return wsum == 0 ? esum : esum / wsum; }
 };
 
 /*! \brief Negative log likelihood of Accelerated Failure Time model */
 template <typename Distribution>
 struct EvalAFTNLogLik {
-  void Configure(const Args& args) {
-    param_.UpdateAllowUnknown(args);
+  void Configure(const Args& args) { param_.UpdateAllowUnknown(args); }
+
+  [[nodiscard]] const char* Name() const { return "aft-nloglik"; }
+
+  XGBOOST_DEVICE double EvalRow(double label_lower_bound, double label_upper_bound,
+                                double pred) const {
+    return AFTLoss<Distribution>::Loss(label_lower_bound, label_upper_bound, pred,
+                                       param_.aft_loss_distribution_scale);
   }
 
-  [[nodiscard]] const char* Name() const {
-    return "aft-nloglik";
-  }
+  static double GetFinal(double esum, double wsum) { return wsum == 0 ? esum : esum / wsum; }
 
-  XGBOOST_DEVICE double EvalRow(
-      double label_lower_bound, double label_upper_bound, double pred) const {
-    return AFTLoss<Distribution>::Loss(
-        label_lower_bound, label_upper_bound, pred, param_.aft_loss_distribution_scale);
-  }
-
-  static double GetFinal(double esum, double wsum) {
-    return wsum == 0 ? esum : esum / wsum;
-  }
  private:
   AFTParam param_;
 };
@@ -196,6 +183,7 @@ struct EvalEWiseSurvivalBase : public MetricNoCache {
   }
 
   double Eval(const HostDeviceVector<float>& preds, const MetaInfo& info) override {
+    CheckRowWeights(info);
     CHECK_EQ(preds.Size(), info.labels_lower_bound_.Size());
     CHECK_EQ(preds.Size(), info.labels_upper_bound_.Size());
     CHECK(ctx_);
@@ -208,9 +196,7 @@ struct EvalEWiseSurvivalBase : public MetricNoCache {
     return Policy::GetFinal(dat[0], dat[1]);
   }
 
-  [[nodiscard]] const char* Name() const override {
-    return policy_.Name();
-  }
+  [[nodiscard]] const char* Name() const override { return policy_.Name(); }
 
  private:
   Policy policy_;
@@ -221,9 +207,7 @@ struct EvalEWiseSurvivalBase : public MetricNoCache {
 // This class exists because we want to perform dispatch according to the distribution type at
 // configuration time, not at prediction time.
 struct AFTNLogLikDispatcher : public MetricNoCache {
-  [[nodiscard]] const char* Name() const override {
-    return "aft-nloglik";
-  }
+  [[nodiscard]] const char* Name() const override { return "aft-nloglik"; }
 
   double Eval(const HostDeviceVector<bst_float>& preds, const MetaInfo& info) override {
     CHECK(metric_) << "AFT metric must be configured first, with distribution type and scale";
@@ -233,17 +217,18 @@ struct AFTNLogLikDispatcher : public MetricNoCache {
   void Configure(const Args& args) override {
     param_.UpdateAllowUnknown(args);
     switch (param_.aft_loss_distribution) {
-    case common::ProbabilityDistributionType::kNormal:
-      metric_.reset(new EvalEWiseSurvivalBase<EvalAFTNLogLik<common::NormalDistribution>>(ctx_));
-      break;
-    case common::ProbabilityDistributionType::kLogistic:
-      metric_.reset(new EvalEWiseSurvivalBase<EvalAFTNLogLik<common::LogisticDistribution>>(ctx_));
-      break;
-    case common::ProbabilityDistributionType::kExtreme:
-      metric_.reset(new EvalEWiseSurvivalBase<EvalAFTNLogLik<common::ExtremeDistribution>>(ctx_));
-      break;
-    default:
-      LOG(FATAL) << "Unknown probability distribution";
+      case common::ProbabilityDistributionType::kNormal:
+        metric_.reset(new EvalEWiseSurvivalBase<EvalAFTNLogLik<common::NormalDistribution>>(ctx_));
+        break;
+      case common::ProbabilityDistributionType::kLogistic:
+        metric_.reset(
+            new EvalEWiseSurvivalBase<EvalAFTNLogLik<common::LogisticDistribution>>(ctx_));
+        break;
+      case common::ProbabilityDistributionType::kExtreme:
+        metric_.reset(new EvalEWiseSurvivalBase<EvalAFTNLogLik<common::ExtremeDistribution>>(ctx_));
+        break;
+      default:
+        LOG(FATAL) << "Unknown probability distribution";
     }
     metric_->Configure(args);
   }
@@ -254,9 +239,7 @@ struct AFTNLogLikDispatcher : public MetricNoCache {
     out["aft_loss_param"] = ToJson(param_);
   }
 
-  void LoadConfig(const Json& in) override {
-    FromJson(in["aft_loss_param"], &param_);
-  }
+  void LoadConfig(const Json& in) override { FromJson(in["aft_loss_param"], &param_); }
 
  private:
   AFTParam param_;

--- a/src/predictor/interpretability/shap.cc
+++ b/src/predictor/interpretability/shap.cc
@@ -769,7 +769,7 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
   auto const base_score = model.learner_model_param->BaseScore(DeviceOrd::CPU());
   auto const h_tree_groups = model.TreeGroups(DeviceOrd::CPU());
   std::vector<RegTree::FVec> feats_tloc(n_threads);
-  std::vector<std::vector<float>> contribs_tloc(n_threads, std::vector<bst_float>(ncolumns));
+  std::vector<std::vector<float>> contribs_tloc(n_threads, std::vector<float>(ncolumns));
 
   auto device = ctx->Device().IsSycl() ? DeviceOrd::CPU() : ctx->Device();
   auto base_margin = info.base_margin_.View(device);

--- a/src/predictor/interpretability/shap.cc
+++ b/src/predictor/interpretability/shap.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>    // for copy, fill
 #include <array>        // for array
+#include <atomic>       // for atomic
 #include <cmath>        // for abs
 #include <type_traits>  // for remove_const_t
 #include <variant>      // for variant
@@ -751,9 +752,17 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
   contribs.resize(info.num_row_ * ncolumns * model.learner_model_param->num_output_group);
   std::fill(contribs.begin(), contribs.end(), 0);
   std::vector<std::vector<float>> mean_values(n_trees);
+  std::atomic<bool> is_vector_leaf = false;
   common::ParallelFor(n_trees, n_threads, [&](auto i) {
+    if (model.trees[i]->IsMultiTarget()) {
+      is_vector_leaf = true;
+      return;
+    }
     FillNodeMeanValues(model.trees[i]->HostScView(), &(mean_values[i]));
   });
+  if (is_vector_leaf) {
+    LOG(FATAL) << "Approximate predict contribution " << MTNotImplemented();
+  }
 
   auto const n_groups = model.learner_model_param->num_output_group;
   CHECK_NE(n_groups, 0);
@@ -765,7 +774,6 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
   auto device = ctx->Device().IsSycl() ? DeviceOrd::CPU() : ctx->Device();
   auto base_margin = info.base_margin_.View(device);
 
-  bool is_vector_leaf = false;
   auto process_view = [&](auto &&view) {
     common::ParallelFor(view.Size(), n_threads, [&](auto i) {
       auto tid = omp_get_thread_num();
@@ -783,10 +791,7 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
           if (h_tree_groups[j] != gid) {
             continue;
           }
-          if (model.trees[j]->IsMultiTarget()) {
-            is_vector_leaf = true;
-            return;
-          }
+
           std::fill(this_tree_contribs.begin(), this_tree_contribs.end(), 0);
           auto const sc_tree = model.trees[j]->HostScView();
           CalculateApproxContributions(sc_tree, feats, &mean_values[j], &this_tree_contribs);
@@ -807,9 +812,6 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
   };
 
   LaunchShap(ctx, p_fmat, model, process_view);
-  if (is_vector_leaf) {
-    LOG(FATAL) << "Approximate predict contribution " << MTNotImplemented();
-  }
 }
 
 void ShapInteractionValues(Context const *ctx, DMatrix *p_fmat,

--- a/src/predictor/interpretability/shap.cc
+++ b/src/predictor/interpretability/shap.cc
@@ -6,8 +6,6 @@
 #include <algorithm>    // for copy, fill
 #include <array>        // for array
 #include <cmath>        // for abs
-#include <cstdint>      // for uint32_t
-#include <limits>       // for numeric_limits
 #include <type_traits>  // for remove_const_t
 #include <variant>      // for variant
 #include <vector>       // for vector
@@ -740,7 +738,6 @@ void QuadratureTreeShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
 void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
                              HostDeviceVector<float> *out_contribs, gbm::GBTreeModel const &model,
                              bst_tree_t tree_end, std::vector<float> const *tree_weights) {
-  CHECK(!model.learner_model_param->IsVectorLeaf()) << "Predict contribution" << MTNotImplemented();
   CHECK(!p_fmat->Info().IsColumnSplit())
       << "Predict contribution support for column-wise data split is not yet implemented.";
   MetaInfo const &info = p_fmat->Info();
@@ -763,11 +760,12 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
   auto const base_score = model.learner_model_param->BaseScore(DeviceOrd::CPU());
   auto const h_tree_groups = model.TreeGroups(DeviceOrd::CPU());
   std::vector<RegTree::FVec> feats_tloc(n_threads);
-  std::vector<std::vector<bst_float>> contribs_tloc(n_threads, std::vector<bst_float>(ncolumns));
+  std::vector<std::vector<float>> contribs_tloc(n_threads, std::vector<bst_float>(ncolumns));
 
   auto device = ctx->Device().IsSycl() ? DeviceOrd::CPU() : ctx->Device();
   auto base_margin = info.base_margin_.View(device);
 
+  bool is_vector_leaf = false;
   auto process_view = [&](auto &&view) {
     common::ParallelFor(view.Size(), n_threads, [&](auto i) {
       auto tid = omp_get_thread_num();
@@ -784,6 +782,10 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
         for (bst_tree_t j = 0; j < tree_end; ++j) {
           if (h_tree_groups[j] != gid) {
             continue;
+          }
+          if (model.trees[j]->IsMultiTarget()) {
+            is_vector_leaf = true;
+            return;
           }
           std::fill(this_tree_contribs.begin(), this_tree_contribs.end(), 0);
           auto const sc_tree = model.trees[j]->HostScView();
@@ -805,6 +807,9 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
   };
 
   LaunchShap(ctx, p_fmat, model, process_view);
+  if (is_vector_leaf) {
+    LOG(FATAL) << "Approximate predict contribution " << MTNotImplemented();
+  }
 }
 
 void ShapInteractionValues(Context const *ctx, DMatrix *p_fmat,

--- a/tests/cpp/metric/test_distributed_metric.cc
+++ b/tests/cpp/metric/test_distributed_metric.cc
@@ -190,4 +190,21 @@ INSTANTIATE_TEST_SUITE_P(
       result += info.param.name;
       return result;
     });
+
+TEST(Metric, ExpectileLoadConfig) {
+  auto ctx = MakeCUDACtx(GPUIDX);
+  std::unique_ptr<xgboost::Metric> metric{xgboost::Metric::Create("expectile", &ctx)};
+  metric->Configure({{"expectile_alpha", "0.8"}});
+  Json config{Object{}};
+  metric->SaveConfig(&config);
+
+  std::unique_ptr<xgboost::Metric> loaded{xgboost::Metric::Create("expectile", &ctx)};
+  loaded->LoadConfig(config);
+
+  xgboost::HostDeviceVector<float> preds;
+  preds.HostVector() = {0.1f, 0.9f};
+  auto result = GetMetricEval(loaded.get(), preds, {0.0f, 1.0f}, {}, {}, DataSplitMode::kRow);
+  // alpha=0.8, diffs {0.1, -0.1} => losses {0.2*0.01, 0.8*0.01} -> mean 0.005.
+  EXPECT_NEAR(result, 0.005f, 1e-6f);
+}
 }  // namespace xgboost::metric

--- a/tests/cpp/metric/test_metric.cc
+++ b/tests/cpp/metric/test_metric.cc
@@ -1,8 +1,102 @@
-// Copyright by Contributors
+/**
+ * Copyright 2016-2026, XGBoost contributors
+ */
+#include <dmlc/registry.h>
+#include <xgboost/context.h>
+#include <xgboost/linalg.h>
 #include <xgboost/metric.h>
+
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "../helpers.h"
 namespace xgboost {
+namespace {
+bool AcceptsRowWeights(std::string const& name) {
+  // Learning-to-rank metrics consume one weight per query. The Cox metric does not consume weights.
+  return name != "pre" && name != "map" && name != "ndcg" && name != "cox-nloglik";
+}
+
+bool AcceptsQueryWeights(std::string const& name) { return name == "auc" || name == "aucpr"; }
+
+std::unique_ptr<Metric> CreateMetricForTest(Context const* ctx, std::string const& name) {
+  auto metric_name = name;
+  if (name == "ams") {
+    metric_name = "ams@0";
+  } else if (name == "tweedie-nloglik") {
+    metric_name = "tweedie-nloglik@1.5";
+  }
+
+  std::unique_ptr<Metric> metric{Metric::Create(metric_name, ctx)};
+  Args args;
+  if (name == "quantile") {
+    args.emplace_back("quantile_alpha", "0.5");
+  } else if (name == "expectile") {
+    args.emplace_back("expectile_alpha", "0.5");
+  }
+  metric->Configure(args);
+  return metric;
+}
+
+std::shared_ptr<DMatrix> MakeRowWeightData() {
+  auto p_fmat = EmptyDMatrix();
+  auto& info = p_fmat->Info();
+  info.num_row_ = 2;
+  info.labels.Reshape(info.num_row_, 1);
+  info.labels.Data()->HostVector() = {0.0f, 1.0f};
+  info.labels_lower_bound_.HostVector() = {1.0f, 1.0f};
+  info.labels_upper_bound_.HostVector() = {1.0f, 1.0f};
+  return p_fmat;
+}
+
+HostDeviceVector<float> MakePredictions(std::string const& name) {
+  auto n_predictions = name == "merror" || name == "mlogloss" ? 4 : 2;
+  return HostDeviceVector<float>(n_predictions, 0.5f);
+}
+
+void CheckInvalidRowWeights(Context const* ctx, std::string const& name) {
+  SCOPED_TRACE(name);
+  auto metric = CreateMetricForTest(ctx, name);
+  auto p_fmat = MakeRowWeightData();
+  auto& info = p_fmat->Info();
+  auto predts = MakePredictions(name);
+
+  // The number of row weights must match the number of rows.
+  info.weights_.HostVector() = {1.0f};
+  EXPECT_THROW(metric->Evaluate(predts, p_fmat), dmlc::Error);
+
+  if (AcceptsQueryWeights(name)) {
+    return;
+  }
+
+  // Row-wise metrics must not interpret query-group weights as row weights.
+  info.weights_.HostVector() = {1.0f, 1.0f};
+  info.group_ptr_ = {0, 2};
+  EXPECT_THROW(metric->Evaluate(predts, p_fmat), dmlc::Error);
+}
+
+void CheckInvalidQuantileShape(Context const* ctx, std::string const& name,
+                               std::string const& alpha_param) {
+  SCOPED_TRACE(name);
+  std::unique_ptr<Metric> metric{Metric::Create(name, ctx)};
+  metric->Configure({{alpha_param, "[0.2, 0.8]"}});
+
+  auto p_fmat = EmptyDMatrix();
+  auto& info = p_fmat->Info();
+  info.num_row_ = 2;
+  info.labels.Reshape(1, 2);
+  info.labels.Data()->HostVector() = {0.0f, 1.0f};
+  HostDeviceVector<float> predts(4, 0.5f);
+
+  EXPECT_THROW(metric->Evaluate(predts, p_fmat), dmlc::Error);
+
+  info.labels.Reshape(2, 1);
+  predts.Resize(3);
+  EXPECT_THROW(metric->Evaluate(predts, p_fmat), dmlc::Error);
+}
+}  // namespace
+
 TEST(Metric, UnknownMetric) {
   auto ctx = MakeCUDACtx(GPUIDX);
   xgboost::Metric* metric = nullptr;
@@ -15,20 +109,36 @@ TEST(Metric, UnknownMetric) {
   delete metric;
 }
 
-TEST(Metric, ExpectileLoadConfig) {
+TEST(MetricInvalidInput, RowWeights) {
   auto ctx = MakeCUDACtx(GPUIDX);
-  std::unique_ptr<xgboost::Metric> metric{xgboost::Metric::Create("expectile", &ctx)};
-  metric->Configure({{"expectile_alpha", "0.8"}});
-  Json config{Object{}};
-  metric->SaveConfig(&config);
+  for (auto const* entry : dmlc::Registry<MetricReg>::List()) {
+    if (AcceptsRowWeights(entry->name)) {
+      CheckInvalidRowWeights(&ctx, entry->name);
+    }
+  }
+}
 
-  std::unique_ptr<xgboost::Metric> loaded{xgboost::Metric::Create("expectile", &ctx)};
-  loaded->LoadConfig(config);
+TEST(MetricInvalidInput, QuantileShape) {
+  auto ctx = MakeCUDACtx(GPUIDX);
+  CheckInvalidQuantileShape(&ctx, "quantile", "quantile_alpha");
+  CheckInvalidQuantileShape(&ctx, "expectile", "expectile_alpha");
+}
 
-  xgboost::HostDeviceVector<float> preds;
-  preds.HostVector() = {0.1f, 0.9f};
-  auto result = GetMetricEval(loaded.get(), preds, {0.0f, 1.0f}, {}, {}, DataSplitMode::kRow);
-  // alpha=0.8, diffs {0.1, -0.1} => losses {0.2*0.01, 0.8*0.01} -> mean 0.005.
-  EXPECT_NEAR(result, 0.005f, 1e-6f);
+TEST(MetricInvalidInput, MultiTargetLabels) {
+  auto ctx = MakeCUDACtx(GPUIDX);
+  linalg::Tensor<float, 2> labels{{0.0f, 1.0f, 0.0f, 1.0f}, {2, 2}, DeviceOrd::CPU()};
+
+  for (auto const& name : {"merror", "mlogloss"}) {
+    SCOPED_TRACE(name);
+    std::unique_ptr<Metric> metric{Metric::Create(name, &ctx)};
+    HostDeviceVector<float> predts(8, 0.5f);
+    ASSERT_THAT([&] { GetMultiMetricEval(metric.get(), predts, labels); },
+                GMockThrow("multi-target"));
+  }
+
+  std::unique_ptr<Metric> rank_metric{Metric::Create("ndcg", &ctx)};
+  HostDeviceVector<float> rank_predts(4, 0.5f);
+  ASSERT_THAT([&] { GetMultiMetricEval(rank_metric.get(), rank_predts, labels); },
+              GMockThrow("multi-target"));
 }
 }  // namespace xgboost


### PR DESCRIPTION
- Check invalid row counts in metrics.
- Check for unsupported dart. The `multi_strategy` is a runtime-only parameter, not part of the model. The previous check in the inplace-predict was invalid.
- Check for unsupported approximate feature contribution.

The checks are meant to be helpful, not necessarily airtight.

Ref: https://github.com/dmlc/xgboost/issues/9043