### PR TITLE
[breaking] Drop `min_child_weight` from gain and weight calculation.

### DIFF
--- a/plugin/sycl/tree/split_evaluator.h
+++ b/plugin/sycl/tree/split_evaluator.h
@@ -119,7 +119,7 @@ class TreeEvaluator {
     }
 
     inline GradType CalcWeight(GradType sum_grad, GradType sum_hess) const {
-      if (sum_hess < param.min_child_weight || sum_hess <= 0.0) {
+      if (sum_hess <= 0.0) {
         return 0.0;
       }
       GradType dw = -this->ThresholdL1(sum_grad, param.reg_alpha) / (sum_hess + param.reg_lambda);

--- a/plugin/sycl/tree/split_evaluator.h
+++ b/plugin/sycl/tree/split_evaluator.h
@@ -7,21 +7,20 @@
 
 #include <dmlc/registry.h>
 #include <xgboost/base.h>
+
+#include <limits>
+#include <sycl/sycl.hpp>
 #include <utility>
 #include <vector>
-#include <limits>
 
-#include "param.h"
-#include "../data.h"
-
-#include "xgboost/tree_model.h"
-#include "xgboost/host_device_vector.h"
-#include "xgboost/context.h"
-#include "../../src/common/transform.h"
 #include "../../src/common/math.h"
+#include "../../src/common/transform.h"
 #include "../../src/tree/param.h"
-
-#include <sycl/sycl.hpp>
+#include "../data.h"
+#include "param.h"
+#include "xgboost/context.h"
+#include "xgboost/host_device_vector.h"
+#include "xgboost/tree_model.h"
 
 namespace xgboost {
 namespace sycl {
@@ -32,11 +31,10 @@ namespace tree {
            functions from the original SplitEvaluator are currently not supported
  */
 
-template<typename GradType>
+template <typename GradType>
 class TreeEvaluator {
   // hist and exact use parent id to calculate constraints.
-  static constexpr bst_node_t kRootParentId =
-      (-1 & static_cast<bst_node_t>((1U << 31) - 1));
+  static constexpr bst_node_t kRootParentId = (-1 & static_cast<bst_node_t>((1U << 31) - 1));
 
   USMVector<GradType> lower_bounds_;
   USMVector<GradType> upper_bounds_;
@@ -60,7 +58,7 @@ class TreeEvaluator {
     if (has_constraint_) {
       monotone_.Resize(qu_, n_features, 0);
       qu_->memcpy(monotone_.Data(), p.monotone_constraints.data(),
-                 sizeof(int) * p.monotone_constraints.size());
+                  sizeof(int) * p.monotone_constraints.size());
       qu_->wait();
 
       lower_bounds_.Resize(qu_, p.MaxNodes(), std::numeric_limits<GradType>::lowest());
@@ -69,9 +67,7 @@ class TreeEvaluator {
     param_ = TrainParam(p);
   }
 
-  bool HasConstraint() const {
-    return has_constraint_;
-  }
+  bool HasConstraint() const { return has_constraint_; }
 
   TreeEvaluator(::sycl::queue* qu, xgboost::tree::TrainParam const& p, bst_feature_t n_features) {
     Reset(qu, p, n_features);
@@ -84,15 +80,13 @@ class TreeEvaluator {
     bool has_constraint;
     TrainParam param;
 
-    GradType CalcSplitGain(bst_node_t nidx,
-                        bst_feature_t fidx,
-                        const GradStats<GradType>& left,
-                        const GradStats<GradType>& right) const {
+    GradType CalcSplitGain(bst_node_t nidx, bst_feature_t fidx, const GradStats<GradType>& left,
+                           const GradStats<GradType>& right) const {
       const GradType negative_infinity = -std::numeric_limits<GradType>::infinity();
       GradType wleft = this->CalcWeight(nidx, left);
       GradType wright = this->CalcWeight(nidx, right);
 
-      GradType gain = this->CalcGainGivenWeight(nidx, left,  wleft) +
+      GradType gain = this->CalcGainGivenWeight(nidx, left, wleft) +
                       this->CalcGainGivenWeight(nidx, right, wright);
       if (!has_constraint) {
         return gain;
@@ -109,10 +103,10 @@ class TreeEvaluator {
     }
 
     inline static GradType ThresholdL1(GradType w, float alpha) {
-      if (w > + alpha) {
+      if (w > +alpha) {
         return w - alpha;
       }
-      if (w < - alpha) {
+      if (w < -alpha) {
         return w + alpha;
       }
       return 0.0;
@@ -171,15 +165,12 @@ class TreeEvaluator {
  public:
   /* Get a view to the evaluator that can be passed down to device. */
   auto GetEvaluator() const {
-    return SplitEvaluator{monotone_.DataConst(),
-                          lower_bounds_.DataConst(),
-                          upper_bounds_.DataConst(),
-                          has_constraint_,
-                          param_};
+    return SplitEvaluator{monotone_.DataConst(), lower_bounds_.DataConst(),
+                          upper_bounds_.DataConst(), has_constraint_, param_};
   }
 
-  void AddSplit(bst_node_t nodeid, bst_node_t leftid, bst_node_t rightid,
-                bst_feature_t f, GradType left_weight, GradType right_weight) {
+  void AddSplit(bst_node_t nodeid, bst_node_t leftid, bst_node_t rightid, bst_feature_t f,
+                GradType left_weight, GradType right_weight) {
     if (!has_constraint_) {
       return;
     }

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -233,7 +233,7 @@ XGBOOST_DEVICE inline T CalcGainGivenWeight(const TrainingParams &p, T sum_grad,
 template <typename TrainingParams, typename T>
 XGBOOST_DEVICE std::enable_if_t<std::is_floating_point_v<T>, T> CalcWeight(TrainingParams const &p,
                                                                            T sum_grad, T sum_hess) {
-  if (sum_hess < p.min_child_weight || sum_hess <= 0.0) {
+  if (sum_hess <= 0.0) {
     return 0.0;
   }
   T dw = -ThresholdL1(sum_grad, p.reg_alpha) / (sum_hess + p.reg_lambda);
@@ -246,7 +246,7 @@ XGBOOST_DEVICE std::enable_if_t<std::is_floating_point_v<T>, T> CalcWeight(Train
 // calculate the cost of loss function
 template <typename TrainingParams, typename T>
 XGBOOST_DEVICE T CalcGain(TrainingParams const &p, T sum_grad, T sum_hess) {
-  if (sum_hess < p.min_child_weight || sum_hess <= 0.0) {
+  if (sum_hess <= 0.0) {
     return static_cast<T>(0.0);
   }
   if (p.max_delta_step == 0.0f) {

--- a/tests/cpp/tree/test_refresh.cc
+++ b/tests/cpp/tree/test_refresh.cc
@@ -33,11 +33,9 @@ TEST(Updater, Refresh) {
                                              ctx.Device()};
 
   std::shared_ptr<DMatrix> p_dmat{
-    RandomDataGenerator{kRows, kCols, 0.4f}.Seed(3).GenerateDMatrix()};
+      RandomDataGenerator{kRows, kCols, 0.4f}.Seed(3).GenerateDMatrix()};
   std::vector<std::pair<std::string, std::string>> cfg{
-      {"reg_alpha", "0.0"},
-      {"num_feature", std::to_string(kCols)},
-      {"reg_lambda", "1"}};
+      {"reg_alpha", "0.0"}, {"num_feature", std::to_string(kCols)}, {"reg_lambda", "1"}};
 
   RegTree tree = RegTree{1u, kCols};
   std::vector<RegTree*> trees{&tree};

--- a/tests/cpp/tree/test_refresh.cc
+++ b/tests/cpp/tree/test_refresh.cc
@@ -61,7 +61,7 @@ TEST(Updater, Refresh) {
 
   bst_float constexpr kEps = 1e-6;
   ASSERT_NEAR(-0.183392, tree[cright].LeafValue(), kEps);
-  ASSERT_NEAR(-0.224489, tree.Stat(0).loss_chg, kEps);
+  ASSERT_NEAR(-0.167978, tree.Stat(0).loss_chg, kEps);
   ASSERT_NEAR(0, tree.Stat(cleft).loss_chg, kEps);
   ASSERT_NEAR(0, tree.Stat(1).loss_chg, kEps);
   ASSERT_NEAR(0, tree.Stat(2).loss_chg, kEps);

--- a/tests/cpp/tree/test_tree_stat.cc
+++ b/tests/cpp/tree/test_tree_stat.cc
@@ -284,7 +284,7 @@ class TestMinSplitLoss : public ::testing::Test {
     p_fmat_ =
         RandomDataGenerator(kRows, kCols, kSparsity).Seed(3).Targets(n_targets).GenerateDMatrix();
     Context ctx;
-    gpair_ = GenerateRandomGradients(&ctx, kRows, n_targets);
+    gpair_ = GenerateRandomGradients(&ctx, kRows, n_targets, 0.1f, 1.0f);
   }
 
   bst_node_t Update(Context const* ctx, std::string updater, float gamma) {


### PR DESCRIPTION
After this PR, the `min_child_weight` will be used only to prevent splits.

Existing use of `min_child_weight`:
- It clamps the node weight to 0. Notably, it clamps the root node to 0 (which is a "parent" node), since other nodes cannot be clamped due to the earlier check using this parameter. Invalid split candidates are rejected before weight or gain calculation. It doesn't make sense to clamp the root node, since we would end up building a root-only tree with 0 weight. Such usage is no longer about the "child" weight as suggested in the name. Also, it conflates two purposes into a single parameter.
- The partition-based sort uses `CalcWeight`. It doesn't make sense to clamp the weight there either. We should use raw weights to group similar bins.
- The refresh updater also shouldn't clamp the weight. Currently, it effectively disables a tree branch by outputting 0s without actually updating the tree structure.

I tried to trace the use of `min_child_weight`. Before PR #6037 , the use of the parameter wasn't consistent. Some updaters clamped the weight, while the now-removed evaluator didn't. I gave up tracing afterward.

The only concern from this PR is that we might run into numeric issues due to a small Hessian. This is mitigated by the `lambda` parameter.

Related: https://github.com/dmlc/xgboost/pull/12308 Cleanup the use of this parameter before getting the vector leaf implementation.