### PR TITLE
[Python] Fix mypy var-annotated error in dask `_predict_async`

### DIFF
--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -1168,7 +1168,7 @@ async def _predict_async(
             )
             return predt
 
-    all_parts = []
+    all_parts: List[Future] = []
     all_orders = []
     all_shapes = []
     all_workers: List[str] = []


### PR DESCRIPTION
## Summary
`mypy` fails on `xgboost/dask/__init__.py` with:
 
```
xgboost/dask/__init__.py:1171: error: Need type annotation for "all_parts" (hint: "all_parts: list[<type>] = ...")  [var-annotated]
```
 
`all_parts` accumulates items pulled from `data.worker_map`, which is
typed `Dict[str, List[Future]]`, so it should be annotated as
`List[Future]` to match.
 
## Change
Single-line fix, no behavior change:
 
```diff
-    all_parts = []
+    all_parts: List[Future] = []
```
 
`Future` is already imported in this module (`from distributed import Future`).
 
## Verification
Before:
```
$ mypy xgboost/dask/__init__.py --ignore-missing-imports
Found 1 error in 1 file
```
 
After:
```
$ mypy xgboost/dask/__init__.py --ignore-missing-imports
Success: no issues found in 1 source file
```
 
This is a small piece of the broader mypy adoption tracked in #6496.