### PR TITLE
Use explicit re-export syntax for non_decreasing/non_increasing

### DIFF
--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -50,7 +50,8 @@ from .data import (
 )
 
 # Used to be defined in this top level module.
-from .utils import non_decreasing, non_increasing  # NOLINT
+from .utils import non_decreasing as non_decreasing
+from .utils import non_increasing as non_increasing
 
 hypothesis = pytest.importorskip("hypothesis")
 


### PR DESCRIPTION
xgboost/testing/__init__.py imports non_decreasing and non_increasing from .utils for other modules to use (e.g. xgboost/testing/dask.py imports them from the top-level xgboost.testing package), but plain imports aren't treated as intentional re-exports by static checkers.

This causes:
- ruff F401: imported but unused
- mypy attr-defined: Module "xgboost.testing" does not explicitly export attribute "non_increasing"/"non_decreasing"

Fix by using the standard explicit re-export idiom (import X as X).

Verified with:
  ruff check xgboost/testing/__init__.py       -> F401 gone
  mypy xgboost/testing/dask.py --ignore-missing-imports
      -> Success: no issues found in 1 source file