### PR TITLE
[doc] Use https for external links

### DIFF
--- a/doc/contrib/docs.rst
+++ b/doc/contrib/docs.rst
@@ -11,8 +11,8 @@ Documentation and Examples
 *************
 Documentation
 *************
-* Python and C documentation is built using `Sphinx <http://www.sphinx-doc.org/en/master/>`_.
-* Each document is written in `reStructuredText <http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_.
+* Python and C documentation is built using `Sphinx <https://www.sphinx-doc.org/en/master/>`_.
+* Each document is written in `reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_.
 * The documentation is the ``doc/`` directory.
 * You can build it locally using ``make html`` command.
 

--- a/doc/contrib/unit_tests.rst
+++ b/doc/contrib/unit_tests.rst
@@ -41,7 +41,7 @@ The JVM packages for XGBoost (XGBoost4J / XGBoost4J-Spark) use `the Maven Standa
 * `jvm-packages/xgboost4j-spark/src/test/ <https://github.com/dmlc/xgboost/tree/master/jvm-packages/xgboost4j-spark/src/test>`_
 
 To write a test for Java code, see `JUnit 5 tutorial <https://junit.org/junit5/docs/current/user-guide/>`_.
-To write a test for Scala, see `Scalatest tutorial <http://www.scalatest.org/user_guide/writing_your_first_test>`_.
+To write a test for Scala, see `Scalatest tutorial <https://www.scalatest.org/user_guide/writing_your_first_test>`_.
 
 You may try running your test by following instructions in :ref:`this section <running_jvm_tests>`.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -359,7 +359,7 @@ Then add XGBoost4J-Spark as a dependency:
 
 Look up the ``version`` field in `pom.xml <https://github.com/dmlc/xgboost/blob/master/jvm-packages/pom.xml>`_ to get the correct version number.
 
-The SNAPSHOT JARs are hosted by the XGBoost project. Every commit in the ``master`` branch will automatically trigger generation of a new SNAPSHOT JAR. You can control how often Maven should upgrade your SNAPSHOT installation by specifying ``updatePolicy``. See `here <http://maven.apache.org/pom.html#Repositories>`_ for details.
+The SNAPSHOT JARs are hosted by the XGBoost project. Every commit in the ``master`` branch will automatically trigger generation of a new SNAPSHOT JAR. You can control how often Maven should upgrade your SNAPSHOT installation by specifying ``updatePolicy``. See `here <https://maven.apache.org/pom.html#Repositories>`_ for details.
 
 You can browse the file listing of the Maven repository at https://s3-us-west-2.amazonaws.com/xgboost-maven-repo/list.html.
 

--- a/doc/treemethod.rst
+++ b/doc/treemethod.rst
@@ -20,7 +20,7 @@ Exact means XGBoost considers all candidates from data for tree splitting, but u
 the objective is still interpreted as a Taylor expansion.
 
 1. ``exact``: The vanilla gradient boosting tree algorithm described in `reference paper
-   <http://arxiv.org/abs/1603.02754>`_.  During split-finding, it iterates over all
+   <https://arxiv.org/abs/1603.02754>`_.  During split-finding, it iterates over all
    entries of input data.  It's more accurate (among other greedy methods) but
    computationally slower in compared to other tree methods.  Further more, its feature
    set is limited. Features like distributed training and external memory that require
@@ -38,7 +38,7 @@ histogram for each node and iterate through the histogram instead of real datase
 we introduce the implementations in XGBoost.
 
 1. ``approx`` tree method: An approximation tree method described in `reference paper
-   <http://arxiv.org/abs/1603.02754>`_.  It runs sketching before building each tree
+   <https://arxiv.org/abs/1603.02754>`_.  It runs sketching before building each tree
    using all the rows (rows belonging to the root). Hessian is used as weights during
    sketch.  The algorithm can be accessed by setting ``tree_method`` to ``approx``.
 
@@ -106,7 +106,7 @@ solely for the interest of documentation.
    have any real practical impact.
 
 3. ``grow_local_histmaker`` updater: An approximation tree method described in `reference
-   paper <http://arxiv.org/abs/1603.02754>`_.  This updater was rarely used in practice so
+   paper <https://arxiv.org/abs/1603.02754>`_.  This updater was rarely used in practice so
    it was still an updater rather than tree method.  During split finding, it first runs a
    weighted GK sketching for data points belong to current node to find split candidates,
    using hessian as weights.  The histogram is built upon this per-node sketch.  It was


### PR DESCRIPTION
Several documentation pages link to external sites using plain http, even though all of them serve https and redirect/enforce it:

- sphinx-doc.org (doc/contrib/docs.rst)
- scalatest.org (doc/contrib/unit_tests.rst)
- maven.apache.org (doc/install.rst)
- arxiv.org (doc/treemethod.rst)

Updated all four to use https. No content changes, only the scheme.

Verified each target still resolves correctly over https before making the change.