### PR TITLE
[doc] Use https for more external links

### DIFF
--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -190,7 +190,7 @@ xgb.get.handle <- function(object) {
 #' values (Lundberg 2017) that sum to the difference between the expected output
 #' of the model and the current prediction (where the hessian weights are used to compute the expectations).
 #' Setting `approxcontrib = TRUE` approximates these values following the idea explained
-#' in \url{http://blog.datadive.net/interpreting-random-forests/}.
+#' in \url{https://blog.datadive.net/interpreting-random-forests/}.
 #'
 #' With `predinteraction = TRUE`, SHAP values of contributions of interaction of each pair of features
 #' are computed. Note that this operation might be rather expensive in terms of compute and memory.

--- a/R-package/R/xgboost.R
+++ b/R-package/R/xgboost.R
@@ -1557,7 +1557,7 @@ print.xgboost <- function(x, ...) {
 #' <https://archive.ics.uci.edu/ml/datasets/Mushroom>
 #'
 #' Bache, K. & Lichman, M. (2013). UCI Machine Learning Repository
-#' <http://archive.ics.uci.edu/ml>. Irvine, CA: University of California,
+#' <https://archive.ics.uci.edu/ml>. Irvine, CA: University of California,
 #' School of Information and Computer Science.
 #'
 #' @docType data
@@ -1581,7 +1581,7 @@ NULL
 #' <https://archive.ics.uci.edu/ml/datasets/Mushroom>
 #'
 #' Bache, K. & Lichman, M. (2013). UCI Machine Learning Repository
-#' <http://archive.ics.uci.edu/ml>. Irvine, CA: University of California,
+#' <https://archive.ics.uci.edu/ml>. Irvine, CA: University of California,
 #' School of Information and Computer Science.
 #'
 #' @docType data

--- a/R-package/README.md
+++ b/R-package/README.md
@@ -1,8 +1,8 @@
 XGBoost R Package
 =================
 
-[![CRAN Status Badge](http://www.r-pkg.org/badges/version/xgboost)](https://cran.r-project.org/web/packages/xgboost)
-[![CRAN Downloads](http://cranlogs.r-pkg.org/badges/xgboost)](https://cran.rstudio.com/web/packages/xgboost/index.html)
+[![CRAN Status Badge](https://www.r-pkg.org/badges/version/xgboost)](https://cran.r-project.org/web/packages/xgboost)
+[![CRAN Downloads](https://cranlogs.r-pkg.org/badges/xgboost)](https://cran.rstudio.com/web/packages/xgboost/index.html)
 [![Documentation Status](https://readthedocs.org/projects/xgboost/badge/?version=latest)](https://xgboost.readthedocs.org/en/latest/R-package/index.html)
 
 Resources

--- a/doc/R-package/index.rst
+++ b/doc/R-package/index.rst
@@ -4,8 +4,8 @@ XGBoost R Package
 
 .. raw:: html
 
-  <a href="http://cran.r-project.org/web/packages/xgboost"><img alt="CRAN Status Badge" src="http://www.r-pkg.org/badges/version/xgboost"></a>
-  <a href="http://cran.rstudio.com/web/packages/xgboost/index.html"><img alt="CRAN Downloads" src="http://cranlogs.r-pkg.org/badges/xgboost"></a>
+  <a href="https://cran.r-project.org/web/packages/xgboost"><img alt="CRAN Status Badge" src="https://www.r-pkg.org/badges/version/xgboost"></a>
+  <a href="https://cran.rstudio.com/web/packages/xgboost/index.html"><img alt="CRAN Downloads" src="https://cranlogs.r-pkg.org/badges/xgboost"></a>
 
 You have found the XGBoost R Package!
 

--- a/doc/jvm/xgboost4j_spark_tutorial.rst
+++ b/doc/jvm/xgboost4j_spark_tutorial.rst
@@ -128,7 +128,7 @@ we drop the column "class" and only keeps the feature columns and the transforme
 The ``fit`` and ``transform`` are two key operations in MLLIB. Basically, ``fit`` produces a "transformer", e.g. StringIndexer,
 and each transformer applies ``transform`` method on DataFrame to add new column(s) containing transformed features/labels or
 prediction results, etc. To understand more about ``fit`` and ``transform``, You can find more details in
-`here <http://spark.apache.org/docs/latest/ml-pipeline.html#pipeline-components>`_.
+`here <https://spark.apache.org/docs/latest/ml-pipeline.html#pipeline-components>`_.
 
 Similarly, we can use another transformer, `VectorAssembler <https://spark.apache.org/docs/latest/api/scala/org/apache/spark/ml/feature/VectorAssembler.html>`_,
 to assemble feature columns "sepal length", "sepal width", "petal length" and "petal width" as a vector.
@@ -507,7 +507,7 @@ This parameter controls how many parallel workers we want to have when training 
 
 Gang Scheduling
 ===============
-XGBoost uses `AllReduce <http://mpitutorial.com/tutorials/mpi-reduce-and-allreduce/>`_.
+XGBoost uses `AllReduce <https://mpitutorial.com/tutorials/mpi-reduce-and-allreduce/>`_.
 algorithm to synchronize the stats, e.g. histogram values, of each worker during training. Therefore XGBoost4J-Spark requires
 that all of ``nthread * numWorkers`` cores should be available before the training runs.
 

--- a/doc/tutorials/dart.rst
+++ b/doc/tutorials/dart.rst
@@ -13,7 +13,7 @@ compatibility.
 **************
 Original paper
 **************
-Rashmi Korlakai Vinayak, Ran Gilad-Bachrach. "DART: Dropouts meet Multiple Additive Regression Trees." [`PMLR <http://proceedings.mlr.press/v38/korlakaivinayak15.pdf>`_, `arXiv <https://arxiv.org/abs/1505.01866>`_].
+Rashmi Korlakai Vinayak, Ran Gilad-Bachrach. "DART: Dropouts meet Multiple Additive Regression Trees." [`PMLR <https://proceedings.mlr.press/v38/korlakaivinayak15.pdf>`_, `arXiv <https://arxiv.org/abs/1505.01866>`_].
 
 ********
 Features

--- a/doc/tutorials/model.rst
+++ b/doc/tutorials/model.rst
@@ -260,7 +260,7 @@ A left to right scan is sufficient to calculate the structure score of all possi
 
 .. note:: Limitation of additive tree learning
 
-  Since it is intractable to enumerate all possible tree structures, we add one split at a time. This approach works well most of the time, but there are some edge cases that fail due to this approach. For those edge cases, training results in a degenerate model because we consider only one feature dimension at a time. See `Can Gradient Boosting Learn Simple Arithmetic? <http://mariofilho.com/can-gradient-boosting-learn-simple-arithmetic/>`_ for an example.
+  Since it is intractable to enumerate all possible tree structures, we add one split at a time. This approach works well most of the time, but there are some edge cases that fail due to this approach. For those edge cases, training results in a degenerate model because we consider only one feature dimension at a time. See `Can Gradient Boosting Learn Simple Arithmetic? <https://mariofilho.com/can-gradient-boosting-learn-simple-arithmetic/>`_ for an example.
 
 **********************
 Final words on XGBoost


### PR DESCRIPTION
Follow-up to the previous https link fix, covering additional plain-http external links found across the doc/ and R-package/ trees:

- cran.r-project.org, www.r-pkg.org, cran.rstudio.com, cranlogs.r-pkg.org (doc/R-package/index.rst, R-package/README.md)
- spark.apache.org, mpitutorial.com (doc/jvm/xgboost4j_spark_tutorial.rst)
- proceedings.mlr.press (doc/tutorials/dart.rst)
- mariofilho.com (doc/tutorials/model.rst)
- blog.datadive.net (R-package/R/xgb.Booster.R)
- archive.ics.uci.edu (R-package/R/xgboost.R) -- note the sibling Mushroom dataset link on the line above was already https; this citation line was the odd one out.

Each target verified live and reachable over https before changing.

Left doc/tutorials/ray.rst untouched: it links to 'tune.io' several times, and I could not confirm that short/vanity domain still resolves the same way today (Ray Tune's own docs have since moved to docs.ray.io), so didn't want to guess on a domain change vs. a scheme change.