### PR TITLE
Remove unused scipy_csr compat import

### DIFF
--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -152,10 +152,8 @@ def is_pandas_available() -> bool:
 
 try:
     import scipy.sparse as scipy_sparse
-    from scipy.sparse import csr_matrix as scipy_csr
 except ImportError:
     scipy_sparse = False
-    scipy_csr = object
 
 
 def _is_polars_lazyframe(data: DataType) -> bool:


### PR DESCRIPTION
# Remove unused scipy_csr compat import
 
## Summary
`xgboost/compat.py` imports `csr_matrix` as `scipy_csr` alongside the
`scipy.sparse` module import, but `scipy_csr` has no references anywhere
in the codebase. `scipy.sparse.csr_matrix` is always accessed via the
`scipy_sparse` module object directly instead (e.g. `scipy_sparse.csr_matrix`
in `compat.concat()`), never through this standalone alias.
 
## Change
```diff
 try:
     import scipy.sparse as scipy_sparse
-    from scipy.sparse import csr_matrix as scipy_csr
 except ImportError:
     scipy_sparse = False
-    scipy_csr = object
```
 
## Verification
- `vulture xgboost/compat.py --min-confidence 90` flags `scipy_csr` as unused
- `grep -rn scipy_csr` across the repo turns up no references to this
  variable (only unrelated function names `is_scipy_csr` / `_from_scipy_csr`
  in `data.py`, which are untouched and already work independently by
  importing `csr_matrix` directly where needed)
- `mypy xgboost/compat.py --ignore-missing-imports` passes before and after
No behavior change — this name was never imported or used anywhere else.