### PR TITLE
Fix LTR pair sampling with training continuation.

### DIFF
--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -320,29 +320,6 @@ class TestDataset:
         return self.name
 
 
-def make_ltr(
-    n_samples: int,
-    n_features: int,
-    n_query_groups: int,
-    max_rel: int,
-    sort_qid: bool = True,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Make a dataset for testing LTR."""
-    rng = np.random.default_rng(1994)
-    X = rng.normal(0, 1.0, size=n_samples * n_features).reshape(n_samples, n_features)
-    y = np.sum(X, axis=1)
-    y -= y.min()
-    y = np.round(y / y.max() * max_rel).astype(np.int32)
-
-    qid = rng.integers(0, n_query_groups, size=n_samples, dtype=np.int32)
-    w = rng.normal(0, 1.0, size=n_query_groups)
-    w -= np.min(w)
-    w /= np.max(w)
-    if sort_qid:
-        qid = np.sort(qid)
-    return X, y, qid, w
-
-
 def _cat_sampled_from() -> strategies.SearchStrategy:
     @strategies.composite
     def _make_cat(draw: Callable) -> Tuple[int, int, int, float]:

--- a/python-package/xgboost/testing/continuation.py
+++ b/python-package/xgboost/testing/continuation.py
@@ -1,13 +1,15 @@
 """Tests for training continuation."""
 
 import json
-from typing import Any, Dict, TypeVar
+from typing import Any, Dict, TypeVar, cast
 
 import numpy as np
 import pytest
 from hypothesis import strategies
 
 import xgboost as xgb
+
+from .data import make_ltr
 
 
 # pylint: disable=too-many-locals
@@ -71,6 +73,7 @@ def run_training_continuation_determinism(
     colsample_bylevel: float,
     num_class: int,
     seed_per_iteration: bool,
+    learning_to_rank: bool,
 ) -> None:
     """Check that 2-session training (4+4 iters) equals single-session (8 iters)."""
     datasets = pytest.importorskip("sklearn.datasets")
@@ -80,7 +83,15 @@ def run_training_continuation_determinism(
     total_rounds = 8
     split_at = 4
 
-    if num_class > 1:
+    if learning_to_rank:
+        X, y, qid, _ = make_ltr(
+            n_samples=n_samples,
+            n_features=n_features,
+            n_query_groups=8,
+            max_rel=4,
+        )
+        objective = "rank:ndcg"
+    elif num_class > 1:
         X, y = datasets.make_classification(
             n_samples=n_samples,
             n_features=n_features,
@@ -95,7 +106,10 @@ def run_training_continuation_determinism(
         )
         objective = "reg:squarederror"
 
-    dtrain = xgb.DMatrix(X, y)
+    if learning_to_rank:
+        dtrain = xgb.DMatrix(X, y, qid=qid)
+    else:
+        dtrain = xgb.DMatrix(X, y)
 
     params: Dict[str, Any] = {
         "device": device,
@@ -108,7 +122,9 @@ def run_training_continuation_determinism(
         "colsample_bylevel": colsample_bylevel,
         "seed_per_iteration": seed_per_iteration,
     }
-    if num_class > 1:
+    if learning_to_rank:
+        params["lambdarank_pair_method"] = "mean"
+    elif num_class > 1:
         params["num_class"] = num_class
 
     bst_single = xgb.train(params, dtrain, num_boost_round=total_rounds)
@@ -141,12 +157,14 @@ def make_determinism_strategy(tree_methods: list[str]) -> "strategies.SearchStra
             "tree_method": strategies.sampled_from(tree_methods),
             "num_class": strategies.sampled_from([1, 3]),
             "seed_per_iteration": strategies.booleans(),
+            "learning_to_rank": strategies.booleans(),
         }
     ).filter(
         lambda x: (
             not (
                 x["sampling_method"] == "gradient_based" and x["tree_method"] != "hist"
             )
+            and not (bool(x["learning_to_rank"]) and cast(int, x["num_class"]) > 1)
         )
     )
     return strategy

--- a/python-package/xgboost/testing/continuation.py
+++ b/python-package/xgboost/testing/continuation.py
@@ -1,6 +1,7 @@
 """Tests for training continuation."""
 
 import json
+import pickle
 from typing import Any, Dict, TypeVar, cast
 
 import numpy as np
@@ -144,6 +145,13 @@ def run_training_continuation_determinism(
     pred_single = bst_single.predict(dtrain)
     pred_cont = bst_continued.predict(dtrain)
     np.testing.assert_allclose(pred_single, pred_cont)
+
+    bst_continued = xgb.train(
+        params,
+        dtrain,
+        num_boost_round=total_rounds - split_at,
+        xgb_model=pickle.loads(pickle.dumps(bst_first)),
+    )
 
 
 def make_determinism_strategy(tree_methods: list[str]) -> "strategies.SearchStrategy":

--- a/python-package/xgboost/testing/continuation.py
+++ b/python-package/xgboost/testing/continuation.py
@@ -152,6 +152,8 @@ def run_training_continuation_determinism(
         num_boost_round=total_rounds - split_at,
         xgb_model=pickle.loads(pickle.dumps(bst_first)),
     )
+    pred_cont = bst_continued.predict(dtrain)
+    np.testing.assert_allclose(pred_single, pred_cont, rtol=1e-4)
 
 
 def make_determinism_strategy(tree_methods: list[str]) -> "strategies.SearchStrategy":

--- a/python-package/xgboost/testing/data.py
+++ b/python-package/xgboost/testing/data.py
@@ -810,6 +810,29 @@ def simulate_clicks(cv_data: RelDataCV) -> Tuple[ClickFold, Optional[ClickFold]]
     return train, test
 
 
+def make_ltr(
+    n_samples: int,
+    n_features: int,
+    n_query_groups: int,
+    max_rel: int,
+    sort_qid: bool = True,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Make a dataset for testing LTR."""
+    rng = np.random.default_rng(1994)
+    X = rng.normal(0, 1.0, size=n_samples * n_features).reshape(n_samples, n_features)
+    y = np.sum(X, axis=1)
+    y -= y.min()
+    y = np.round(y / y.max() * max_rel).astype(np.int32)
+
+    qid = rng.integers(0, n_query_groups, size=n_samples, dtype=np.int32)
+    w = rng.normal(0, 1.0, size=n_query_groups)
+    w -= np.min(w)
+    w /= np.max(w)
+    if sort_qid:
+        qid = np.sort(qid)
+    return X, y, qid, w
+
+
 def sort_ltr_samples(
     X: sparse.csr_matrix,
     y: npt.NDArray[np.int32],

--- a/python-package/xgboost/testing/ranking.py
+++ b/python-package/xgboost/testing/ranking.py
@@ -10,6 +10,7 @@ import pytest
 import xgboost as xgb
 from xgboost import testing as tm
 
+from .data import make_ltr
 from .utils import Device
 
 
@@ -19,7 +20,7 @@ def run_ranking_qid_df(impl: ModuleType, tree_method: str, device: Device) -> No
     from sklearn.metrics import mean_squared_error
     from sklearn.model_selection import StratifiedGroupKFold, cross_val_score
 
-    X, y, q, _ = tm.make_ltr(n_samples=128, n_features=2, n_query_groups=8, max_rel=3)
+    X, y, q, _ = make_ltr(n_samples=128, n_features=2, n_query_groups=8, max_rel=3)
 
     # pack qid into x using dataframe
     df = impl.DataFrame(X)
@@ -119,7 +120,7 @@ def run_ranking_categorical(device: str) -> None:
 
 def run_normalization(device: str) -> None:
     """Test normalization."""
-    X, y, qid, _ = tm.make_ltr(2048, 4, 64, 3)
+    X, y, qid, _ = make_ltr(2048, 4, 64, 3)
     # top-k
     ltr = xgb.XGBRanker(objective="rank:pairwise", n_estimators=4, device=device)
     ltr.fit(X, y, qid=qid, eval_set=[(X, y)], eval_qid=[qid])
@@ -186,9 +187,9 @@ def run_score_normalization(device: str, objective: str) -> None:
     """Test normalization by score differences."""
     if objective == "rank:map":
         # Binary relevance
-        X, y, qid, _ = tm.make_ltr(4096, 4, 64, max_rel=1)
+        X, y, qid, _ = make_ltr(4096, 4, 64, max_rel=1)
     else:
-        X, y, qid, _ = tm.make_ltr(4096, 4, 64, 3)
+        X, y, qid, _ = make_ltr(4096, 4, 64, 3)
     ltr = xgb.XGBRanker(objective=objective, n_estimators=4, device=device)
     ltr.fit(X, y, qid=qid, eval_set=[(X, y)], eval_qid=[qid])
     e0 = ltr.evals_result()

--- a/src/common/random.cuh
+++ b/src/common/random.cuh
@@ -15,10 +15,14 @@ namespace xgboost::common::cuda_impl {
 using DefaultRng = cuda::std::philox4x64;
 template <typename T>
 using UniformRealDistribution = cuda::std::uniform_real_distribution<T>;
+template <typename T>
+using UniformIntDistribution = cuda::std::uniform_int_distribution<T>;
 #else
 using DefaultRng = thrust::default_random_engine;
 template <typename T>
 using UniformRealDistribution = thrust::uniform_real_distribution<T>;
+template <typename T>
+using UniformIntDistribution = thrust::uniform_int_distribution<T>;
 #endif
 }  // namespace xgboost::common::cuda_impl
 

--- a/src/objective/lambdarank_obj.cc
+++ b/src/objective/lambdarank_obj.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023-2025, XGBoost contributors
+ * Copyright 2023-2026, XGBoost contributors
  */
 #include "lambdarank_obj.h"
 

--- a/src/objective/lambdarank_obj.cc
+++ b/src/objective/lambdarank_obj.cc
@@ -162,7 +162,7 @@ class LambdaRankObj : public FitIntercept {
 
   // Calculate lambda gradient for each group on CPU.
   template <bool unbiased, bool norm_by_diff, typename Delta>
-  void CalcLambdaForGroup(std::int32_t iter, common::Span<float const> g_predt,
+  void CalcLambdaForGroup(std::uint32_t seed, common::Span<float const> g_predt,
                           linalg::VectorView<float const> g_label, float w,
                           common::Span<std::size_t const> g_rank, bst_group_t g, Delta delta,
                           linalg::VectorView<GradientPair> g_gpair) {
@@ -223,7 +223,7 @@ class LambdaRankObj : public FitIntercept {
       sum_lambda += -2.0 * static_cast<double>(pg.GetGrad());
     };
 
-    MakePairs(ctx_, iter, p_cache_, g, g_label, g_rank, loop);
+    MakePairs(ctx_, seed, p_cache_, g, g_label, g_rank, loop);
     if (param_.lambdarank_normalization) {
       double norm = 1.0;
       if (param_.IsMean()) {
@@ -317,7 +317,11 @@ class LambdaRankObj : public FitIntercept {
       li_full_ = linalg::Zeros<double>(ctx_, info.num_row_);
       lj_full_ = linalg::Zeros<double>(ctx_, info.num_row_);
     }
-    static_cast<Loss*>(this)->GetGradientImpl(iter, predt, info, out_gpair);
+    std::uint32_t seed{0};
+    if (param_.IsMean()) {
+      seed = static_cast<std::uint32_t>(ctx_->Rng()());
+    }
+    static_cast<Loss*>(this)->GetGradientImpl(seed, predt, info, out_gpair);
 
     if (param_.lambdarank_unbiased) {
       this->UpdatePositionBias();
@@ -328,7 +332,7 @@ class LambdaRankObj : public FitIntercept {
 class LambdaRankNDCG : public LambdaRankObj<LambdaRankNDCG, ltr::NDCGCache> {
  public:
   template <bool unbiased, bool exp_gain>
-  void CalcLambdaForGroupNDCG(std::int32_t iter, common::Span<float const> g_predt,
+  void CalcLambdaForGroupNDCG(std::uint32_t seed, common::Span<float const> g_predt,
                               linalg::VectorView<float const> g_label, float w,
                               common::Span<std::size_t const> g_rank,
                               linalg::VectorView<GradientPair> g_gpair,
@@ -341,19 +345,19 @@ class LambdaRankNDCG : public LambdaRankObj<LambdaRankNDCG, ltr::NDCGCache> {
     };
 
     if (this->param_.lambdarank_score_normalization) {
-      this->CalcLambdaForGroup<unbiased, true>(iter, g_predt, g_label, w, g_rank, g, delta,
+      this->CalcLambdaForGroup<unbiased, true>(seed, g_predt, g_label, w, g_rank, g, delta,
                                                g_gpair);
     } else {
-      this->CalcLambdaForGroup<unbiased, false>(iter, g_predt, g_label, w, g_rank, g, delta,
+      this->CalcLambdaForGroup<unbiased, false>(seed, g_predt, g_label, w, g_rank, g, delta,
                                                 g_gpair);
     }
   }
 
-  void GetGradientImpl(std::int32_t iter, const HostDeviceVector<float>& predt,
+  void GetGradientImpl(std::uint32_t seed, const HostDeviceVector<float>& predt,
                        const MetaInfo& info, linalg::Matrix<GradientPair>* out_gpair) {
     if (ctx_->IsCUDA()) {
       cuda_impl::LambdaRankGetGradientNDCG(
-          ctx_, iter, predt, info, GetCache(), ti_plus_.View(ctx_->Device()),
+          ctx_, seed, predt, info, GetCache(), ti_plus_.View(ctx_->Device()),
           tj_minus_.View(ctx_->Device()), li_full_.View(ctx_->Device()),
           lj_full_.View(ctx_->Device()), out_gpair);
       return;
@@ -388,7 +392,7 @@ class LambdaRankNDCG : public LambdaRankObj<LambdaRankNDCG, ltr::NDCGCache> {
       auto g_rank = rank_idx.subspan(gptr[g], cnt);
 
       auto args =
-          std::make_tuple(this, iter, g_predt, g_label, w, g_rank, g_gpair, inv_IDCG, dct, g);
+          std::make_tuple(this, seed, g_predt, g_label, w, g_rank, g_gpair, inv_IDCG, dct, g);
 
       if (param_.lambdarank_unbiased) {
         if (param_.ndcg_exp_gain) {
@@ -420,7 +424,7 @@ class LambdaRankNDCG : public LambdaRankObj<LambdaRankNDCG, ltr::NDCGCache> {
 
 namespace cuda_impl {
 #if !defined(XGBOOST_USE_CUDA)
-void LambdaRankGetGradientNDCG(Context const*, std::int32_t, HostDeviceVector<float> const&,
+void LambdaRankGetGradientNDCG(Context const*, std::uint32_t, HostDeviceVector<float> const&,
                                const MetaInfo&, std::shared_ptr<ltr::NDCGCache>,
                                linalg::VectorView<double const>,  // input bias ratio
                                linalg::VectorView<double const>,  // input bias ratio
@@ -474,11 +478,11 @@ void MAPStat(Context const* ctx, linalg::VectorView<float const> label,
 
 class LambdaRankMAP : public LambdaRankObj<LambdaRankMAP, ltr::MAPCache> {
  public:
-  void GetGradientImpl(std::int32_t iter, const HostDeviceVector<float>& predt,
+  void GetGradientImpl(std::uint32_t seed, const HostDeviceVector<float>& predt,
                        const MetaInfo& info, linalg::Matrix<GradientPair>* out_gpair) {
     if (ctx_->IsCUDA()) {
       return cuda_impl::LambdaRankGetGradientMAP(
-          ctx_, iter, predt, info, GetCache(), ti_plus_.View(ctx_->Device()),
+          ctx_, seed, predt, info, GetCache(), ti_plus_.View(ctx_->Device()),
           tj_minus_.View(ctx_->Device()), li_full_.View(ctx_->Device()),
           lj_full_.View(ctx_->Device()), out_gpair);
     }
@@ -528,7 +532,7 @@ class LambdaRankMAP : public LambdaRankObj<LambdaRankMAP, ltr::MAPCache> {
       auto g_label = h_label.Slice(make_range(g));
       auto g_rank = rank_idx.subspan(gptr[g], cnt);
 
-      auto args = std::make_tuple(this, iter, g_predt, g_label, w, g_rank, g, delta_map, g_gpair);
+      auto args = std::make_tuple(this, seed, g_predt, g_label, w, g_rank, g, delta_map, g_gpair);
 
       if (param_.lambdarank_unbiased) {
         if (this->param_.lambdarank_score_normalization) {
@@ -558,7 +562,7 @@ void MAPStat(Context const*, MetaInfo const&, common::Span<std::size_t const>,
   common::AssertGPUSupport();
 }
 
-void LambdaRankGetGradientMAP(Context const*, std::int32_t, HostDeviceVector<float> const&,
+void LambdaRankGetGradientMAP(Context const*, std::uint32_t, HostDeviceVector<float> const&,
                               const MetaInfo&, std::shared_ptr<ltr::MAPCache>,
                               linalg::VectorView<double const>,  // input bias ratio
                               linalg::VectorView<double const>,  // input bias ratio
@@ -574,11 +578,11 @@ void LambdaRankGetGradientMAP(Context const*, std::int32_t, HostDeviceVector<flo
  */
 class LambdaRankPairwise : public LambdaRankObj<LambdaRankPairwise, ltr::RankingCache> {
  public:
-  void GetGradientImpl(std::int32_t iter, const HostDeviceVector<float>& predt,
+  void GetGradientImpl(std::uint32_t seed, const HostDeviceVector<float>& predt,
                        const MetaInfo& info, linalg::Matrix<GradientPair>* out_gpair) {
     if (ctx_->IsCUDA()) {
       return cuda_impl::LambdaRankGetGradientPairwise(
-          ctx_, iter, predt, info, GetCache(), ti_plus_.View(ctx_->Device()),
+          ctx_, seed, predt, info, GetCache(), ti_plus_.View(ctx_->Device()),
           tj_minus_.View(ctx_->Device()), li_full_.View(ctx_->Device()),
           lj_full_.View(ctx_->Device()), out_gpair);
     }
@@ -612,7 +616,7 @@ class LambdaRankPairwise : public LambdaRankObj<LambdaRankPairwise, ltr::Ranking
       auto g_label = h_label.Slice(make_range(g));
       auto g_rank = rank_idx.subspan(gptr[g], cnt);
 
-      auto args = std::make_tuple(this, iter, g_predt, g_label, w, g_rank, g, delta, g_gpair);
+      auto args = std::make_tuple(this, seed, g_predt, g_label, w, g_rank, g, delta, g_gpair);
       if (param_.lambdarank_unbiased) {
         if (this->param_.lambdarank_score_normalization) {
           std::apply(&LambdaRankPairwise::CalcLambdaForGroup<true, true, D>, args);
@@ -644,7 +648,7 @@ class LambdaRankPairwise : public LambdaRankObj<LambdaRankPairwise, ltr::Ranking
 
 #if !defined(XGBOOST_USE_CUDA)
 namespace cuda_impl {
-void LambdaRankGetGradientPairwise(Context const*, std::int32_t, HostDeviceVector<float> const&,
+void LambdaRankGetGradientPairwise(Context const*, std::uint32_t, HostDeviceVector<float> const&,
                                    const MetaInfo&, std::shared_ptr<ltr::RankingCache>,
                                    linalg::VectorView<double const>,  // input bias ratio
                                    linalg::VectorView<double const>,  // input bias ratio

--- a/src/objective/lambdarank_obj.cu
+++ b/src/objective/lambdarank_obj.cu
@@ -301,7 +301,7 @@ void CalcGrad(Context const* ctx, MetaInfo const& info, std::shared_ptr<ltr::Ran
  * @brief Handles boilerplate code like getting device spans.
  */
 template <bool norm_by_diff, typename Delta>
-void Launch(Context const* ctx, std::int32_t iter, HostDeviceVector<float> const& preds,
+void Launch(Context const* ctx, std::uint32_t seed, HostDeviceVector<float> const& preds,
             const MetaInfo& info, std::shared_ptr<ltr::RankingCache> p_cache, Delta delta,
             linalg::VectorView<double const> ti_plus,   // input bias ratio
             linalg::VectorView<double const> tj_minus,  // input bias ratio
@@ -341,7 +341,7 @@ void Launch(Context const* ctx, std::int32_t iter, HostDeviceVector<float> const
 
   KernelInputs args{ti_plus,        tj_minus, li,     lj,     d_gptr,     d_threads_group_ptr,
                     rank_idx,       label,    predts, gpairs, d_rounding, d_cost_rounding.data(),
-                    d_y_sorted_idx, iter};
+                    d_y_sorted_idx, seed};
 
   // dispatch based on unbiased and truncation
   if (p_cache->Param().HasTruncation()) {
@@ -382,7 +382,7 @@ common::Span<std::size_t const> SortY(Context const* ctx, MetaInfo const& info,
   return d_y_sorted_idx;
 }
 
-void LambdaRankGetGradientNDCG(Context const* ctx, std::int32_t iter,
+void LambdaRankGetGradientNDCG(Context const* ctx, std::uint32_t seed,
                                const HostDeviceVector<float>& preds, const MetaInfo& info,
                                std::shared_ptr<ltr::NDCGCache> p_cache,
                                linalg::VectorView<double const> ti_plus,   // input bias ratio
@@ -405,9 +405,9 @@ void LambdaRankGetGradientNDCG(Context const* ctx, std::int32_t iter,
                     : DeltaNDCG<false>(y_high, y_low, rank_high, rank_low, d_inv_IDCG(g), discount);
   };
   if (p_cache->Param().lambdarank_score_normalization) {
-    Launch<true>(ctx, iter, preds, info, p_cache, delta_ndcg, ti_plus, tj_minus, li, lj, out_gpair);
+    Launch<true>(ctx, seed, preds, info, p_cache, delta_ndcg, ti_plus, tj_minus, li, lj, out_gpair);
   } else {
-    Launch<false>(ctx, iter, preds, info, p_cache, delta_ndcg, ti_plus, tj_minus, li, lj,
+    Launch<false>(ctx, seed, preds, info, p_cache, delta_ndcg, ti_plus, tj_minus, li, lj,
                   out_gpair);
   }
 }
@@ -456,7 +456,7 @@ void MAPStat(Context const* ctx, MetaInfo const& info, common::Span<std::size_t 
   }
 }
 
-void LambdaRankGetGradientMAP(Context const* ctx, std::int32_t iter,
+void LambdaRankGetGradientMAP(Context const* ctx, std::uint32_t seed,
                               HostDeviceVector<float> const& predt, const MetaInfo& info,
                               std::shared_ptr<ltr::MAPCache> p_cache,
                               linalg::VectorView<double const> ti_plus,   // input bias ratio
@@ -492,13 +492,13 @@ void LambdaRankGetGradientMAP(Context const* ctx, std::int32_t iter,
     return d;
   };
   if (p_cache->Param().lambdarank_score_normalization) {
-    Launch<true>(ctx, iter, predt, info, p_cache, delta_map, ti_plus, tj_minus, li, lj, out_gpair);
+    Launch<true>(ctx, seed, predt, info, p_cache, delta_map, ti_plus, tj_minus, li, lj, out_gpair);
   } else {
-    Launch<false>(ctx, iter, predt, info, p_cache, delta_map, ti_plus, tj_minus, li, lj, out_gpair);
+    Launch<false>(ctx, seed, predt, info, p_cache, delta_map, ti_plus, tj_minus, li, lj, out_gpair);
   }
 }
 
-void LambdaRankGetGradientPairwise(Context const* ctx, std::int32_t iter,
+void LambdaRankGetGradientPairwise(Context const* ctx, std::uint32_t seed,
                                    HostDeviceVector<float> const& predt, const MetaInfo& info,
                                    std::shared_ptr<ltr::RankingCache> p_cache,
                                    linalg::VectorView<double const> ti_plus,   // input bias ratio
@@ -516,9 +516,9 @@ void LambdaRankGetGradientPairwise(Context const* ctx, std::int32_t iter,
   };
 
   if (p_cache->Param().lambdarank_score_normalization) {
-    Launch<true>(ctx, iter, predt, info, p_cache, delta, ti_plus, tj_minus, li, lj, out_gpair);
+    Launch<true>(ctx, seed, predt, info, p_cache, delta, ti_plus, tj_minus, li, lj, out_gpair);
   } else {
-    Launch<false>(ctx, iter, predt, info, p_cache, delta, ti_plus, tj_minus, li, lj, out_gpair);
+    Launch<false>(ctx, seed, predt, info, p_cache, delta, ti_plus, tj_minus, li, lj, out_gpair);
   }
 }
 

--- a/src/objective/lambdarank_obj.cuh
+++ b/src/objective/lambdarank_obj.cuh
@@ -4,25 +4,25 @@
 #ifndef XGBOOST_OBJECTIVE_LAMBDARANK_OBJ_CUH_
 #define XGBOOST_OBJECTIVE_LAMBDARANK_OBJ_CUH_
 
-#include <thrust/binary_search.h>                      // for lower_bound, upper_bound
-#include <thrust/functional.h>                         // for greater
-#include <thrust/iterator/counting_iterator.h>         // for make_counting_iterator
-#include <thrust/random/linear_congruential_engine.h>  // for minstd_rand
-#include <thrust/random/uniform_int_distribution.h>    // for uniform_int_distribution
+#include <thrust/binary_search.h>                    // for lower_bound, upper_bound
+#include <thrust/functional.h>                       // for greater
+#include <thrust/iterator/counting_iterator.h>       // for make_counting_iterator
+#include <thrust/random/uniform_int_distribution.h>  // for uniform_int_distribution
 
-#include <cassert>                                     // for cassert
-#include <cstddef>                                     // for size_t
-#include <cstdint>                                     // for int32_t
-#include <tuple>                                       // for make_tuple, tuple
+#include <cassert>  // for cassert
+#include <cstddef>  // for size_t
+#include <cstdint>  // for uint32_t
+#include <tuple>    // for make_tuple, tuple
 
-#include "../common/device_helpers.cuh"                // for MakeTransformIterator
-#include "../common/ranking_utils.cuh"                 // for PairsForGroup
-#include "../common/ranking_utils.h"                   // for RankingCache
-#include "../common/threading_utils.cuh"               // for UnravelTrapeziodIdx
-#include "xgboost/base.h"    // for bst_group_t, GradientPair, XGBOOST_DEVICE
-#include "xgboost/data.h"    // for MetaInfo
-#include "xgboost/linalg.h"  // for VectorView, Range, UnravelIndex
-#include "xgboost/span.h"    // for Span
+#include "../common/device_helpers.cuh"   // for MakeTransformIterator
+#include "../common/random.cuh"           // for DefaultRng
+#include "../common/ranking_utils.cuh"    // for PairsForGroup
+#include "../common/ranking_utils.h"      // for RankingCache
+#include "../common/threading_utils.cuh"  // for UnravelTrapeziodIdx
+#include "xgboost/base.h"                 // for bst_group_t, GradientPair, XGBOOST_DEVICE
+#include "xgboost/data.h"                 // for MetaInfo
+#include "xgboost/linalg.h"               // for VectorView, Range, UnravelIndex
+#include "xgboost/span.h"                 // for Span
 
 namespace xgboost::obj::cuda_impl {
 /**
@@ -68,7 +68,7 @@ struct KernelInputs {
 
   common::Span<std::size_t const> d_y_sorted_idx;
 
-  std::int32_t iter;
+  std::uint32_t seed;
 };
 /**
  * @brief Functor for generating pairs
@@ -136,8 +136,7 @@ struct MakePairsOp {
     // The index pointing to the first element of the next bucket
     std::size_t right_bound = n_data - n_rights;
 
-    std::uint32_t seed = args.iter * (static_cast<std::uint32_t>(args.d_group_ptr.size()) - 1) + g;
-    thrust::minstd_rand rng(seed);
+    common::cuda_impl::DefaultRng rng{args.seed + static_cast<std::uint32_t>(g)};
     auto pair_idx = i;
     rng.discard(idx - args.d_threads_group_ptr[g]);  // idx within group
     thrust::uniform_int_distribution<std::size_t> dist(0, n_lefts + n_rights - 1);

--- a/src/objective/lambdarank_obj.cuh
+++ b/src/objective/lambdarank_obj.cuh
@@ -1,8 +1,7 @@
 /**
- * Copyright 2023-2024, XGBoost contributors
+ * Copyright 2023-2026, XGBoost contributors
  */
-#ifndef XGBOOST_OBJECTIVE_LAMBDARANK_OBJ_CUH_
-#define XGBOOST_OBJECTIVE_LAMBDARANK_OBJ_CUH_
+#pragma once
 
 #include <thrust/binary_search.h>                    // for lower_bound, upper_bound
 #include <thrust/functional.h>                       // for greater
@@ -26,18 +25,18 @@
 
 namespace xgboost::obj::cuda_impl {
 /**
- * \brief Find number of elements left to the label bucket
+ * @brief Find number of elements left to the label bucket
  */
 template <typename It, typename T = typename std::iterator_traits<It>::value_type>
 XGBOOST_DEVICE __forceinline__ std::size_t CountNumItemsToTheLeftOf(It items, std::size_t n, T v) {
-  return thrust::lower_bound(thrust::seq, items, items + n, v, thrust::greater<T>{}) - items;
+  return thrust::lower_bound(thrust::seq, items, items + n, v, cuda::std::greater{}) - items;
 }
 /**
- * \brief Find number of elements right to the label bucket
+ * @brief Find number of elements right to the label bucket
  */
 template <typename It, typename T = typename std::iterator_traits<It>::value_type>
 XGBOOST_DEVICE __forceinline__ std::size_t CountNumItemsToTheRightOf(It items, std::size_t n, T v) {
-  return n - (thrust::upper_bound(thrust::seq, items, items + n, v, thrust::greater<T>{}) - items);
+  return n - (thrust::upper_bound(thrust::seq, items, items + n, v, cuda::std::greater{}) - items);
 }
 /**
  * \brief Sort labels according to rank list for making pairs.
@@ -166,4 +165,3 @@ struct MakePairsOp {
   }
 };
 }  // namespace xgboost::obj::cuda_impl
-#endif  // XGBOOST_OBJECTIVE_LAMBDARANK_OBJ_CUH_

--- a/src/objective/lambdarank_obj.cuh
+++ b/src/objective/lambdarank_obj.cuh
@@ -138,7 +138,7 @@ struct MakePairsOp {
     common::cuda_impl::DefaultRng rng{args.seed + static_cast<std::uint32_t>(g)};
     auto pair_idx = i;
     rng.discard(idx - args.d_threads_group_ptr[g]);  // idx within group
-    thrust::uniform_int_distribution<std::size_t> dist(0, n_lefts + n_rights - 1);
+    common::cuda_impl::UniformIntDistribution<std::size_t> dist(0, n_lefts + n_rights - 1);
     auto ridx = dist(rng);
     SPAN_CHECK(ridx < n_lefts + n_rights);
     if (ridx >= n_lefts) {

--- a/src/objective/lambdarank_obj.h
+++ b/src/objective/lambdarank_obj.h
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023-2025, XGBoost contributors
+ * Copyright 2023-2026, XGBoost contributors
  *
  * Vocabulary explanation:
  *

--- a/src/objective/lambdarank_obj.h
+++ b/src/objective/lambdarank_obj.h
@@ -17,6 +17,7 @@
 #include <cassert>     // for assert
 #include <cmath>       // for log, abs
 #include <cstddef>     // for size_t
+#include <cstdint>     // for uint32_t
 #include <functional>  // for greater
 #include <memory>      // for shared_ptr
 #include <random>      // for minstd_rand, uniform_int_distribution
@@ -154,7 +155,7 @@ XGBOOST_DEVICE inline GradientPair Repulse(GradientPair pg) {
 }
 
 namespace cuda_impl {
-void LambdaRankGetGradientNDCG(Context const* ctx, std::int32_t iter,
+void LambdaRankGetGradientNDCG(Context const* ctx, std::uint32_t seed,
                                HostDeviceVector<float> const& preds, MetaInfo const& info,
                                std::shared_ptr<ltr::NDCGCache> p_cache,
                                linalg::VectorView<double const> t_plus,   // input bias ratio
@@ -168,7 +169,7 @@ void LambdaRankGetGradientNDCG(Context const* ctx, std::int32_t iter,
 void MAPStat(Context const* ctx, MetaInfo const& info, common::Span<std::size_t const> d_rank_idx,
              std::shared_ptr<ltr::MAPCache> p_cache);
 
-void LambdaRankGetGradientMAP(Context const* ctx, std::int32_t iter,
+void LambdaRankGetGradientMAP(Context const* ctx, std::uint32_t seed,
                               HostDeviceVector<float> const& predt, MetaInfo const& info,
                               std::shared_ptr<ltr::MAPCache> p_cache,
                               linalg::VectorView<double const> t_plus,   // input bias ratio
@@ -176,7 +177,7 @@ void LambdaRankGetGradientMAP(Context const* ctx, std::int32_t iter,
                               linalg::VectorView<double> li, linalg::VectorView<double> lj,
                               linalg::Matrix<GradientPair>* out_gpair);
 
-void LambdaRankGetGradientPairwise(Context const* ctx, std::int32_t iter,
+void LambdaRankGetGradientPairwise(Context const* ctx, std::uint32_t seed,
                                    HostDeviceVector<float> const& predt, const MetaInfo& info,
                                    std::shared_ptr<ltr::RankingCache> p_cache,
                                    linalg::VectorView<double const> ti_plus,   // input bias ratio
@@ -210,7 +211,7 @@ void MAPStat(Context const* ctx, linalg::VectorView<float const> label,
  * \tparam Op Functor for upgrading a pair of gradients.
  *
  * \param ctx     The global context.
- * \param iter    The boosting iteration.
+ * \param seed    Seed for sampling pairs.
  * \param cache   ltr cache.
  * \param g       The current query group
  * \param g_label label The labels for the current query group
@@ -219,7 +220,7 @@ void MAPStat(Context const* ctx, linalg::VectorView<float const> label,
  *                the ranked list (labels sorted according to model scores).
  */
 template <typename Op>
-void MakePairs(Context const* ctx, std::int32_t iter,
+void MakePairs(Context const* ctx, std::uint32_t seed,
                std::shared_ptr<ltr::RankingCache> const cache, bst_group_t g,
                linalg::VectorView<float const> g_label, common::Span<std::size_t const> g_rank,
                Op op) {
@@ -235,8 +236,7 @@ void MakePairs(Context const* ctx, std::int32_t iter,
   } else {
     CHECK_EQ(g_rank.size(), g_label.Size());
 
-    std::uint32_t seed = (iter + 1) * (static_cast<std::uint32_t>(group_ptr.size()) - 1) + g;
-    std::minstd_rand rnd(seed);
+    std::minstd_rand rnd(seed + static_cast<std::uint32_t>(g));
     // sort label according to the rank list
     auto it = common::MakeIndexTransformIter(
         [&g_rank, &g_label](std::size_t idx) { return g_label(g_rank[idx]); });

--- a/tests/python-gpu/test_device_quantile_dmatrix.py
+++ b/tests/python-gpu/test_device_quantile_dmatrix.py
@@ -2,9 +2,8 @@ import sys
 
 import numpy as np
 import pytest
-from hypothesis import given, settings, strategies
-
 import xgboost as xgb
+from hypothesis import given, settings, strategies
 from xgboost import testing as tm
 from xgboost.testing.data import check_inf, make_ltr
 from xgboost.testing.data_iter import run_mixed_sparsity

--- a/tests/python-gpu/test_device_quantile_dmatrix.py
+++ b/tests/python-gpu/test_device_quantile_dmatrix.py
@@ -6,7 +6,7 @@ from hypothesis import given, settings, strategies
 
 import xgboost as xgb
 from xgboost import testing as tm
-from xgboost.testing.data import check_inf
+from xgboost.testing.data import check_inf, make_ltr
 from xgboost.testing.data_iter import run_mixed_sparsity
 from xgboost.testing.quantile_dmatrix import (
     check_categorical_strings,
@@ -238,7 +238,7 @@ class TestQuantileDMatrix:
     def test_ltr(self) -> None:
         import cupy as cp
 
-        X, y, qid, w = tm.make_ltr(100, 3, 3, 5)
+        X, y, qid, w = make_ltr(100, 3, 3, 5)
         # make sure GPU is used to run sketching.
         cpX = cp.array(X)
         Xy_qdm = xgb.QuantileDMatrix(cpX, y, qid=qid, weight=w)

--- a/tests/python-gpu/test_gpu_training_continuation.py
+++ b/tests/python-gpu/test_gpu_training_continuation.py
@@ -18,7 +18,5 @@ def test_model_output(tree_method: str) -> None:
 @given(make_determinism_strategy(["hist", "approx"]))
 @settings(deadline=None, print_blob=True, max_examples=10)
 @pytest.mark.skipif(**tm.no_sklearn())
-def test_continuation_determinism(
-    kwargs: Any,
-) -> None:
+def test_continuation_determinism(kwargs: Any) -> None:
     run_training_continuation_determinism(device="cuda", **kwargs)

--- a/tests/python/generate_models.py
+++ b/tests/python/generate_models.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import xgboost
 from sklearn.datasets import make_classification
-from xgboost.testing import make_categorical, make_ltr
+from xgboost.testing.data import make_categorical, make_ltr
 
 kRounds = 4
 kRows = 1000

--- a/tests/python/test_quantile_dmatrix.py
+++ b/tests/python/test_quantile_dmatrix.py
@@ -10,10 +10,9 @@ from xgboost.testing import (
     make_batches,
     make_batches_sparse,
     make_categorical,
-    make_ltr,
     make_sparse_regression,
 )
-from xgboost.testing.data import check_inf, np_dtypes
+from xgboost.testing.data import check_inf, make_ltr, np_dtypes
 from xgboost.testing.data_iter import run_mixed_sparsity
 from xgboost.testing.quantile_dmatrix import (
     check_categorical_strings,

--- a/tests/python/test_ranking.py
+++ b/tests/python/test_ranking.py
@@ -10,7 +10,7 @@ import xgboost
 from hypothesis import given, note, settings
 from scipy.sparse import csr_matrix
 from xgboost import testing as tm
-from xgboost.testing.data import RelDataCV, simulate_clicks, sort_ltr_samples
+from xgboost.testing.data import RelDataCV, make_ltr, simulate_clicks, sort_ltr_samples
 from xgboost.testing.params import lambdarank_parameter_strategy
 from xgboost.testing.ranking import run_normalization, run_score_normalization
 
@@ -19,7 +19,7 @@ def test_ndcg_custom_gain():
     def ndcg_gain(y: np.ndarray) -> np.ndarray:
         return np.exp2(y.astype(np.float64)) - 1.0
 
-    X, y, q, w = tm.make_ltr(n_samples=1024, n_features=4, n_query_groups=3, max_rel=3)
+    X, y, q, w = make_ltr(n_samples=1024, n_features=4, n_query_groups=3, max_rel=3)
     y_gain = ndcg_gain(y)
 
     byxgb = xgboost.XGBRanker(tree_method="hist", ndcg_exp_gain=True, n_estimators=10)
@@ -54,7 +54,7 @@ def test_ndcg_custom_gain():
     assert byxgb_json == bynp_json
 
     # test pairwise can handle max_rel > 31, while ndcg metric is using custom gain
-    X, y, q, w = tm.make_ltr(n_samples=1024, n_features=4, n_query_groups=3, max_rel=33)
+    X, y, q, w = make_ltr(n_samples=1024, n_features=4, n_query_groups=3, max_rel=33)
     ranknet = xgboost.XGBRanker(
         tree_method="hist",
         ndcg_exp_gain=False,
@@ -70,7 +70,7 @@ def test_ndcg_custom_gain():
 
 def test_ndcg_non_exp() -> None:
     # NDCG exp gain must have label smaller than 32
-    X, y, q, w = tm.make_ltr(n_samples=1024, n_features=4, n_query_groups=3, max_rel=44)
+    X, y, q, w = make_ltr(n_samples=1024, n_features=4, n_query_groups=3, max_rel=44)
 
     def fit(ltr: xgboost.XGBRanker):
         ltr.fit(
@@ -173,7 +173,7 @@ def test_ranking_with_weighted_data():
 
 
 def test_error_msg() -> None:
-    X, y, qid, w = tm.make_ltr(10, 2, 2, 2)
+    X, y, qid, w = make_ltr(10, 2, 2, 2)
     ranker = xgboost.XGBRanker()
     with pytest.raises(ValueError, match=r"equal to the number of query groups"):
         ranker.fit(X, y, qid=qid, sample_weight=y)
@@ -186,7 +186,7 @@ def test_lambdarank_parameters(params):
         rel = 1
     else:
         rel = 4
-    X, y, q, w = tm.make_ltr(4096, 3, 13, rel)
+    X, y, q, w = make_ltr(4096, 3, 13, rel)
     ranker = xgboost.XGBRanker(tree_method="hist", n_estimators=64, **params)
     ranker.fit(X, y, qid=q, sample_weight=w, eval_set=[(X, y)], eval_qid=[q])
     for k, v in ranker.evals_result()["validation_0"].items():
@@ -201,7 +201,7 @@ def test_unbiased() -> None:
     import pandas as pd
     from sklearn.model_selection import train_test_split
 
-    X, y, q, w = tm.make_ltr(8192, 2, n_query_groups=6, max_rel=4)
+    X, y, q, w = make_ltr(8192, 2, n_query_groups=6, max_rel=4)
     X, Xe, y, ye, q, qe = train_test_split(X, y, q, test_size=0.2, random_state=3)
     X = csr_matrix(X)
     Xe = csr_matrix(Xe)

--- a/tests/python/test_training_continuation.py
+++ b/tests/python/test_training_continuation.py
@@ -172,7 +172,4 @@ class TestTrainingContinuation:
 @settings(deadline=None, print_blob=True, max_examples=10)
 @pytest.mark.skipif(**tm.no_sklearn())
 def test_continuation_determinism(kwargs: Any) -> None:
-    run_training_continuation_determinism(
-        device="cpu",
-        **kwargs,
-    )
+    run_training_continuation_determinism(device="cpu", **kwargs)

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -11,7 +11,7 @@ import pytest
 import xgboost as xgb
 from sklearn.utils.estimator_checks import parametrize_with_checks
 from xgboost import testing as tm
-from xgboost.testing.data import get_california_housing
+from xgboost.testing.data import get_california_housing, make_ltr
 from xgboost.testing.ranking import run_ranking_categorical, run_ranking_qid_df
 from xgboost.testing.shared import get_feature_weights, validate_data_initialization
 from xgboost.testing.updater import get_basescore
@@ -190,7 +190,7 @@ def test_ranking_categorical() -> None:
 def test_ranking_metric() -> None:
     from sklearn.metrics import roc_auc_score
 
-    X, y, qid, w = tm.make_ltr(512, 4, 3, 1)
+    X, y, qid, w = make_ltr(512, 4, 3, 1)
     # use auc for test as ndcg_score in sklearn works only on label gain instead of exp
     # gain.
     # note that the auc in sklearn is different from the one in XGBoost. The one in


### PR DESCRIPTION
close https://github.com/dmlc/xgboost/issues/12301

Please note that the `rng` state is kept in the configuration, not in the model. As a result, one needs to either use pickle for the `Booster` or manage `save_config` to get the exact result when training is continued.