### PR TITLE
fix(sklearn): raise ValueError in XGBRanker.score when qid is missing

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -2371,6 +2371,8 @@ class XGBRanker(XGBRankerMixIn, XGBModel):
 
         """
         X, qid = _get_qid(X, None)
+        if qid is None:
+            raise ValueError("The special column `qid` is required in `X` for ranking task.")
         # fixme(jiamingy): base margin and group weight is not yet supported. We might
         # need to make extra special fields in the dataframe.
         Xyq = DMatrix(

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -2371,8 +2371,10 @@ class XGBRanker(XGBRankerMixIn, XGBModel):
 
         """
         X, qid = _get_qid(X, None)
-        if qid is None:
-            raise ValueError("The special column `qid` is required in `X` for ranking task.")
+                if qid is None:
+            raise ValueError(
+                "The special column `qid` is required in `X` for ranking task."
+            )
         # fixme(jiamingy): base margin and group weight is not yet supported. We might
         # need to make extra special fields in the dataframe.
         Xyq = DMatrix(

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -2372,7 +2372,9 @@ class XGBRanker(XGBRankerMixIn, XGBModel):
         """
         X, qid = _get_qid(X, None)
         if qid is None:
-            raise ValueError("The special column `qid` is required in `X` for ranking task.")
+            raise ValueError(
+                "The special column `qid` is required in `X` for ranking task."
+            )
         # fixme(jiamingy): base margin and group weight is not yet supported. We might
         # need to make extra special fields in the dataframe.
         Xyq = DMatrix(

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -2371,10 +2371,8 @@ class XGBRanker(XGBRankerMixIn, XGBModel):
 
         """
         X, qid = _get_qid(X, None)
-                if qid is None:
-            raise ValueError(
-                "The special column `qid` is required in `X` for ranking task."
-            )
+        if qid is None:
+            raise ValueError("The special column `qid` is required in `X` for ranking task.")
         # fixme(jiamingy): base margin and group weight is not yet supported. We might
         # need to make extra special fields in the dataframe.
         Xyq = DMatrix(


### PR DESCRIPTION
Fixes #12334. If XGBRanker.score is evaluated without query IDs (qid column in X DataFrame), the C++ backend silently treats the entire evaluation dataset as a single query, producing invalid NDCG/MAP scores. This validation mirrors the checks done in fit().