### PR TITLE
[MT] Unify split evaluator.

### DIFF
--- a/src/tree/gpu_hist/leaf_sum.cu
+++ b/src/tree/gpu_hist/leaf_sum.cu
@@ -100,14 +100,20 @@ void LeafGradSum(Context const* ctx, std::vector<LeafInfo> const& h_leaves,
 }
 
 void LeafWeight(Context const* ctx, GPUTrainingParam const& param,
+                TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
+                common::Span<bst_node_t const> nidx,
                 common::Span<GradientQuantiser const> roundings,
                 linalg::MatrixView<GradientPairInt64 const> grad_sum,
                 linalg::MatrixView<float> out_weights) {
   CHECK(grad_sum.Contiguous());
+  CHECK_EQ(nidx.size(), grad_sum.Shape(0));
+  CHECK_EQ(out_weights.Shape(0), grad_sum.Shape(0));
+  CHECK_EQ(out_weights.Shape(1), grad_sum.Shape(1));
   dh::LaunchN(grad_sum.Size(), ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(std::size_t i) mutable {
     auto [nidx_in_set, t] = linalg::UnravelIndex(i, grad_sum.Shape());
     auto g = roundings[t].ToFloatingPoint(grad_sum(nidx_in_set, t));
-    out_weights(nidx_in_set, t) = CalcWeight(param, g.GetGrad(), g.GetHess()) * param.learning_rate;
+    auto weight = evaluator.CalcWeight(nidx[nidx_in_set], param, g);
+    out_weights(nidx_in_set, t) = weight * param.learning_rate;
   });
 }
 }  // namespace xgboost::tree::cuda_impl

--- a/src/tree/gpu_hist/leaf_sum.cuh
+++ b/src/tree/gpu_hist/leaf_sum.cuh
@@ -5,6 +5,7 @@
 
 #include <vector>  // for vector
 
+#include "../split_evaluator.h"       // for TreeEvaluator
 #include "../updater_gpu_common.cuh"  // for GPUTrainingParam
 #include "quantiser.cuh"              // for GradientQuantiser
 #include "row_partitioner.cuh"        // for RowIndexT, LeafInfo
@@ -31,6 +32,8 @@ void LeafGradSum(Context const* ctx, std::vector<LeafInfo> const& h_leaves,
  *   shape(out_weights) == (n_leaves, n_targets)
  */
 void LeafWeight(Context const* ctx, GPUTrainingParam const& param,
+                TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
+                common::Span<bst_node_t const> nidx,
                 common::Span<GradientQuantiser const> roundings,
                 linalg::MatrixView<GradientPairInt64 const> grad_sum,
                 linalg::MatrixView<float> out_weights);

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -12,7 +12,8 @@
 #include <cuda/std/functional>       // for identity
 #include <cuda/std/tuple>            // for get, make_tuple, tuple
 #include <limits>
-#include <vector>  // for vector
+#include <type_traits>  // for is_trivially_copyable_v
+#include <vector>       // for vector
 
 #include "../../common/cuda_context.cuh"
 #include "../tree_view.h"             // for MultiTargetTreeView
@@ -186,40 +187,65 @@ __global__ __launch_bounds__(kBlockThreads) void ScanHistogramKernel(
 }
 
 namespace {
+struct QuantizedGradientSum {
+  common::Span<GradientPairInt64 const> values;
+  common::Span<GradientQuantiser const> roundings;
+
+  [[nodiscard]] XGBOOST_DEVICE std::size_t Size() const {
+    SPAN_CHECK(values.size() == roundings.size());
+    return values.size();
+  }
+  [[nodiscard]] XGBOOST_DEVICE GradientPairPrecise operator()(std::size_t t) const {
+    SPAN_CHECK(t < this->Size());
+    return roundings[t].ToFloatingPoint(values[t]);
+  }
+};
+
+struct QuantizedGradientDifference {
+  common::Span<GradientPairInt64 const> parent;
+  common::Span<GradientPairInt64 const> child;
+  common::Span<GradientQuantiser const> roundings;
+
+  [[nodiscard]] XGBOOST_DEVICE std::size_t Size() const {
+    SPAN_CHECK(parent.size() == child.size());
+    SPAN_CHECK(parent.size() == roundings.size());
+    return parent.size();
+  }
+  [[nodiscard]] XGBOOST_DEVICE GradientPairPrecise operator()(std::size_t t) const {
+    SPAN_CHECK(t < this->Size());
+    auto parent_t = roundings[t].ToFloatingPoint(parent[t]);
+    auto child_t = roundings[t].ToFloatingPoint(child[t]);
+    return parent_t - child_t;
+  }
+};
+
+static_assert(std::is_trivially_copyable_v<QuantizedGradientSum>);
+static_assert(std::is_trivially_copyable_v<QuantizedGradientDifference>);
+
 struct EvaluateSplitAgent {
   using ArgMaxT = cub::KeyValuePair<std::uint32_t, double>;
   using MaxReduceT = cub::WarpReduce<ArgMaxT>;
 
   typename MaxReduceT::TempStorage *temp_storage;
   bst_feature_t fidx;
+  TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator;
 
   // Calculate the split gain for one bin. `child_scan` has the bin-major layout
-  // [bins][targets] and stores the non-missing child sum. The sibling (containing missing
-  // values) is recovered as parent - child. The gain is symmetric in the two children, so
-  // this helper is shared by the numerical and one-hot paths.
-  static __device__ double ComputeGain(MultiEvaluateSplitInputs const &node,
-                                       MultiEvaluateSplitSharedInputs const &shared,
-                                       common::Span<GradientPairInt64 const> child_scan,
-                                       bst_bin_t bin_idx, bst_target_t n_targets) {
-    auto roundings = shared.roundings.data();
+  // [bins][targets] and stores the non-missing child sum.
+  template <DefaultDirection d_dir>
+  static __device__ double ComputeGain(
+      MultiEvaluateSplitInputs const &node, MultiEvaluateSplitSharedInputs const &shared,
+      common::Span<GradientPairInt64 const> child_scan, bst_bin_t bin_idx, bst_target_t n_targets,
+      bst_feature_t fidx, TreeEvaluator::SplitEvaluator<GPUTrainingParam> const &evaluator) {
     auto offset = bin_idx * n_targets;
-    double child_hess{0.0}, sibling_hess{0.0};
-    double gain{0.0};
-    for (bst_target_t t = 0; t < n_targets; ++t) {
-      auto parent_sum = roundings[t].ToFloatingPoint(node.parent_sum[t]);
-      auto child_sum = roundings[t].ToFloatingPoint(child_scan[offset + t]);
-      auto sibling_sum = parent_sum - child_sum;
-      child_hess += child_sum.GetHess();
-      sibling_hess += sibling_sum.GetHess();
-      gain += CalcGain(shared.param, child_sum.GetGrad(), child_sum.GetHess());
-      gain += CalcGain(shared.param, sibling_sum.GetGrad(), sibling_sum.GetHess());
+    auto child_values = child_scan.subspan(offset, n_targets);
+    QuantizedGradientSum child{child_values, shared.roundings};
+    QuantizedGradientDifference sibling{node.parent_sum, child_values, shared.roundings};
+    if constexpr (d_dir == kRightDir) {
+      return evaluator.CalcSplitGain(shared.param, node.nidx, fidx, child, sibling);
+    } else {
+      return evaluator.CalcSplitGain(shared.param, node.nidx, fidx, sibling, child);
     }
-
-    auto k = static_cast<double>(n_targets);
-    if (!IsValidSplit(shared.param, child_hess / k, sibling_hess / k)) {
-      return -std::numeric_limits<double>::infinity();
-    }
-    return gain;
   }
 
   template <DefaultDirection d_dir>
@@ -239,8 +265,9 @@ struct EvaluateSplitAgent {
       bool thread_active = bin_idx < gidx_end;
 
       auto constexpr kNullGain = -std::numeric_limits<double>::infinity();
-      double gain =
-          thread_active ? ComputeGain(node, shared, node_scan, bin_idx, n_targets) : kNullGain;
+      double gain = thread_active ? ComputeGain<d_dir>(node, shared, node_scan, bin_idx, n_targets,
+                                                       fidx, evaluator)
+                                  : kNullGain;
 
       auto best = MaxReduceT(*temp_storage).Reduce({threadIdx.x, gain}, cub::ArgMax{});
       auto best_thread = __shfl_sync(dh::WarpFullMask(), best.key, 0);
@@ -294,8 +321,9 @@ struct EvaluateSplitAgent {
       bool thread_active = bin_idx < gidx_end;
 
       auto constexpr kNullGain = -std::numeric_limits<double>::infinity();
-      double gain =
-          thread_active ? ComputeGain(node, shared, region, bin_idx, n_targets) : kNullGain;
+      double gain = thread_active ? ComputeGain<d_dir>(node, shared, region, bin_idx, n_targets,
+                                                       fidx, evaluator)
+                                  : kNullGain;
 
       auto best = MaxReduceT(*temp_storage).Reduce({threadIdx.x, gain}, cub::ArgMax{});
       auto best_thread = __shfl_sync(dh::WarpFullMask(), best.key, 0);
@@ -336,8 +364,9 @@ struct EvaluateSplitAgent {
       bool thread_active = bin_idx < gidx_begin + n_bins - 1;
 
       auto constexpr kNullGain = -std::numeric_limits<double>::infinity();
-      double gain =
-          thread_active ? ComputeGain(node, shared, node_scan, bin_idx, n_targets) : kNullGain;
+      double gain = thread_active ? ComputeGain<d_dir>(node, shared, node_scan, bin_idx, n_targets,
+                                                       fidx, evaluator)
+                                  : kNullGain;
 
       auto best = MaxReduceT(*temp_storage).Reduce({threadIdx.x, gain}, cub::ArgMax{});
       auto best_thread = __shfl_sync(dh::WarpFullMask(), best.key, 0);
@@ -365,6 +394,7 @@ template <std::int32_t kBlockThreads>
 __global__ __launch_bounds__(kBlockThreads) void EvaluateSplitsKernel(
     common::Span<MultiEvaluateSplitInputs const> nodes, MultiEvaluateSplitSharedInputs shared,
     common::Span<common::Span<GradientPairInt64>> bin_scans,
+    TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
     common::Span<MultiSplitCandidate> out_candidates) {
   static_assert(kBlockThreads % dh::WarpThreads() == 0);
 
@@ -390,7 +420,7 @@ __global__ __launch_bounds__(kBlockThreads) void EvaluateSplitsKernel(
     return;
   }
   auto fidx = node.feature_set[fidx_in_set];
-  AgentT agent{&temp_storage[warp_id_in_blk], fidx};
+  AgentT agent{&temp_storage[warp_id_in_blk], fidx, evaluator};
   // The number of candidates is allocated using active features
   auto candidate_idx = nidx * shared.max_active_feature + fidx_in_set;
 
@@ -424,12 +454,14 @@ void MultiHistEvaluator::Reset(Context const *ctx,
                                common::Span<std::uint32_t const> feature_segments,
                                common::Span<FeatureType const> feature_types,
                                TrainParam const &param) {
+  CHECK_GT(feature_segments.size(), 0);
+  auto n_features = static_cast<bst_feature_t>(feature_segments.size() - 1);
+  this->tree_evaluator_ = TreeEvaluator{param, n_features, ctx->Device()};
   this->need_sort_histogram_ = false;
   if (feature_types.empty()) {
     return;
   }
 
-  auto n_features = feature_segments.size() - 1;
   auto feature_it = thrust::make_counting_iterator<bst_feature_t>(0);
   auto max_cat_to_onehot = param.max_cat_to_onehot;
   this->need_sort_histogram_ =
@@ -452,14 +484,6 @@ void MultiHistEvaluator::Reset(Context const *ctx,
   auto d_outputs = dh::ToSpan(outputs);
   this->EvaluateSplits(ctx, dh::ToSpan(inputs), shared_inputs, input.nidx, d_outputs);
 
-  // The `EvaluateSplits` apply eta for leaf nodes only, we need to apply it for the base
-  // weight.
-  auto n_targets = shared_inputs.Targets();
-  dh::LaunchN(n_targets, ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(std::size_t t) {
-    auto weight = d_outputs[0].base_weight;
-    weight[t] *= shared_inputs.param.learning_rate;
-  });
-
   return outputs[0];
 }
 
@@ -467,6 +491,7 @@ namespace {
 // Sort histogram based on projected score, see CPU implementation for details.
 void SortHistogram(Context const *ctx, MultiEvaluateSplitSharedInputs const &shared_inputs,
                    common::Span<MultiEvaluateSplitInputs const> d_inputs,
+                   TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
                    dh::device_vector<std::size_t> *p_sorted_idx) {
   auto &sorted_idx = *p_sorted_idx;
   auto n_nodes = d_inputs.size();
@@ -504,10 +529,8 @@ void SortHistogram(Context const *ctx, MultiEvaluateSplitSharedInputs const &sha
           auto target_hist = node.histogram.subspan(t * bins_per_tar, bins_per_tar);
           auto child_sum = quantizer.ToFloatingPoint(target_hist[bin_idx]);
           auto parent_sum = quantizer.ToFloatingPoint(node.parent_sum[t]);
-          auto child_weight =
-              CalcWeight(shared_inputs.param, child_sum.GetGrad(), child_sum.GetHess());
-          auto parent_weight =
-              CalcWeight(shared_inputs.param, parent_sum.GetGrad(), parent_sum.GetHess());
+          auto child_weight = evaluator.CalcWeightCat(shared_inputs.param, child_sum);
+          auto parent_weight = evaluator.CalcWeight(node.nidx, shared_inputs.param, parent_sum);
           sc += child_weight * parent_weight;
         }
         return cuda::std::make_tuple(nidx_in_set, fidx, sc);
@@ -534,6 +557,7 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
                                         bst_node_t max_nidx,
                                         common::Span<MultiExpandEntry> out_splits) {
   auto n_targets = shared_inputs.Targets();
+  auto evaluator = this->GetEvaluator();
   CHECK_GT(n_targets, 0);
   CHECK_GE(shared_inputs.n_total_bins_per_tar, 1);
   auto n_features = shared_inputs.max_active_feature;
@@ -574,7 +598,7 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   // The values are node-local bin indices. Sort by (node, feature, score)
   dh::device_vector<std::size_t> sorted_idx;
   if (this->need_sort_histogram_) {
-    SortHistogram(ctx, shared_inputs, d_inputs, &sorted_idx);
+    SortHistogram(ctx, shared_inputs, d_inputs, evaluator, &sorted_idx);
   }
   auto d_sorted_idx = common::Span<std::size_t const>{dh::ToSpan(sorted_idx)};
 
@@ -597,7 +621,7 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     auto n_warps = n_nodes * n_features;
     auto n_blocks = common::DivRoundUp(n_warps, kWarpsPerBlk);
     dh::LaunchKernel{n_blocks, kBlockThreads, 0, ctx->CUDACtx()->Stream()}(  // NOLINT
-        EvaluateSplitsKernel<kBlockThreads>, d_inputs, shared_inputs, dh::ToSpan(scans),
+        EvaluateSplitsKernel<kBlockThreads>, d_inputs, shared_inputs, dh::ToSpan(scans), evaluator,
         dh::ToSpan(d_splits));
   }
 
@@ -646,13 +670,12 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     bst_node_t nidx = input.nidx;
     auto base_weight = d_weights.Base(nidx);
     auto roundings = shared_inputs.roundings;
-    double parent_gain = 0;
+    QuantizedGradientSum parent_sum{input.parent_sum, roundings};
+    double parent_gain = evaluator.CalcGain(nidx, shared_inputs.param, parent_sum);
     double parent_hess = 0;
     for (bst_target_t t = 0; t < n_targets; ++t) {
       auto g = roundings[t].ToFloatingPoint(input.parent_sum[t]);
-      base_weight[t] = CalcWeight(shared_inputs.param, g.GetGrad(), g.GetHess());
-      parent_gain +=
-          CalcGainGivenWeight(shared_inputs.param, g.GetGrad(), g.GetHess(), base_weight[t]);
+      base_weight[t] = evaluator.CalcWeight(nidx, shared_inputs.param, g);
       parent_hess += g.GetHess();
     }
 
@@ -698,7 +721,6 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     auto split_sum_dest = GetNodeSumImpl(d_split_sums, nidx, n_targets);
 
     double left_hess = 0, right_hess = 0;  // Sum of child hessians across all targets
-    auto eta = shared_inputs.param.learning_rate;
 
     for (bst_target_t t = 0; t < n_targets; ++t) {
       auto quantizer = roundings[t];
@@ -711,15 +733,15 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
       if (best_split.dir == kRightDir) {
         // forward pass, split_sum is the left sum
         lg = quantizer.ToFloatingPoint(split_sum[t]);
-        left_weight[t] = CalcWeight(shared_inputs.param, lg.GetGrad(), lg.GetHess()) * eta;
+        left_weight[t] = evaluator.CalcWeight(nidx, shared_inputs.param, lg);
         rg = quantizer.ToFloatingPoint(sibling_sum);
-        right_weight[t] = CalcWeight(shared_inputs.param, rg.GetGrad(), rg.GetHess()) * eta;
+        right_weight[t] = evaluator.CalcWeight(nidx, shared_inputs.param, rg);
       } else {
         // backward pass, split_sum is the right sum
         rg = quantizer.ToFloatingPoint(split_sum[t]);
-        right_weight[t] = CalcWeight(shared_inputs.param, rg.GetGrad(), rg.GetHess()) * eta;
+        right_weight[t] = evaluator.CalcWeight(nidx, shared_inputs.param, rg);
         lg = quantizer.ToFloatingPoint(sibling_sum);
-        left_weight[t] = CalcWeight(shared_inputs.param, lg.GetGrad(), lg.GetHess()) * eta;
+        left_weight[t] = evaluator.CalcWeight(nidx, shared_inputs.param, lg);
       }
 
       left_hess += lg.GetHess();

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -193,7 +193,7 @@ struct QuantizedGradientSum {
 
   [[nodiscard]] XGBOOST_DEVICE std::size_t Size() const { return roundings.size(); }
   [[nodiscard]] XGBOOST_DEVICE GradientPairPrecise operator()(std::size_t t) const {
-    return roundings[t].ToFloatingPoint(values[t]);
+    return roundings.data()[t].ToFloatingPoint(values[t]);
   }
 };
 

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -188,33 +188,24 @@ __global__ __launch_bounds__(kBlockThreads) void ScanHistogramKernel(
 
 namespace {
 struct QuantizedGradientSum {
-  common::Span<GradientPairInt64 const> values;
+  GradientPairInt64 const *values;
   common::Span<GradientQuantiser const> roundings;
 
-  [[nodiscard]] XGBOOST_DEVICE std::size_t Size() const {
-    SPAN_CHECK(values.size() == roundings.size());
-    return values.size();
-  }
+  [[nodiscard]] XGBOOST_DEVICE std::size_t Size() const { return roundings.size(); }
   [[nodiscard]] XGBOOST_DEVICE GradientPairPrecise operator()(std::size_t t) const {
-    SPAN_CHECK(t < this->Size());
     return roundings[t].ToFloatingPoint(values[t]);
   }
 };
 
 struct QuantizedGradientDifference {
-  common::Span<GradientPairInt64 const> parent;
-  common::Span<GradientPairInt64 const> child;
+  GradientPairInt64 const *parent;
+  GradientPairInt64 const *child;
   common::Span<GradientQuantiser const> roundings;
 
-  [[nodiscard]] XGBOOST_DEVICE std::size_t Size() const {
-    SPAN_CHECK(parent.size() == child.size());
-    SPAN_CHECK(parent.size() == roundings.size());
-    return parent.size();
-  }
+  [[nodiscard]] XGBOOST_DEVICE std::size_t Size() const { return roundings.size(); }
   [[nodiscard]] XGBOOST_DEVICE GradientPairPrecise operator()(std::size_t t) const {
-    SPAN_CHECK(t < this->Size());
-    auto parent_t = roundings[t].ToFloatingPoint(parent[t]);
-    auto child_t = roundings[t].ToFloatingPoint(child[t]);
+    auto parent_t = roundings.data()[t].ToFloatingPoint(parent[t]);
+    auto child_t = roundings.data()[t].ToFloatingPoint(child[t]);
     return parent_t - child_t;
   }
 };
@@ -239,8 +230,9 @@ struct EvaluateSplitAgent {
       bst_feature_t fidx, TreeEvaluator::SplitEvaluator<GPUTrainingParam> const &evaluator) {
     auto offset = bin_idx * n_targets;
     auto child_values = child_scan.subspan(offset, n_targets);
-    QuantizedGradientSum child{child_values, shared.roundings};
-    QuantizedGradientDifference sibling{node.parent_sum, child_values, shared.roundings};
+    QuantizedGradientSum child{child_values.data(), shared.roundings};
+    QuantizedGradientDifference sibling{node.parent_sum.data(), child_values.data(),
+                                        shared.roundings};
     if constexpr (d_dir == kRightDir) {
       return evaluator.CalcSplitGain(shared.param, node.nidx, fidx, child, sibling);
     } else {
@@ -670,7 +662,7 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     bst_node_t nidx = input.nidx;
     auto base_weight = d_weights.Base(nidx);
     auto roundings = shared_inputs.roundings;
-    QuantizedGradientSum parent_sum{input.parent_sum, roundings};
+    QuantizedGradientSum parent_sum{input.parent_sum.data(), roundings};
     double parent_gain = evaluator.CalcGain(nidx, shared_inputs.param, parent_sum);
     double parent_hess = 0;
     for (bst_target_t t = 0; t < n_targets; ++t) {

--- a/src/tree/gpu_hist/multi_evaluate_splits.cuh
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cuh
@@ -68,6 +68,7 @@ class MultiHistEvaluator {
   };
 
  private:
+  TreeEvaluator tree_evaluator_;
   // Persistent buffer for node weights, indexed by node id.
   dh::DeviceUVector<float> node_weights_;
   // Buffer for histogram scans.
@@ -98,8 +99,15 @@ class MultiHistEvaluator {
   }
 
  public:
+  MultiHistEvaluator(TrainParam const &param, bst_feature_t n_features, DeviceOrd device)
+      : tree_evaluator_{param, n_features, device} {}
+
   void Reset(Context const *ctx, common::Span<std::uint32_t const> feature_segments,
              common::Span<FeatureType const> feature_types, TrainParam const &param);
+
+  [[nodiscard]] auto GetEvaluator() const {
+    return tree_evaluator_.GetEvaluator<GPUTrainingParam>();
+  }
 
   /**
    * @brief Run evaluation for the root node.
@@ -167,7 +175,7 @@ class MultiHistEvaluator {
     dh::CopyDeviceSpanToVector(right_weight, weights.Right(nidx));
   }
 
-  // Track the child gradient sum.
+  // Update the tree evaluator state and track child gradient sums.
   void ApplyTreeSplit(Context const *ctx, RegTree const *p_tree,
                       common::Span<MultiExpandEntry const> d_candidates, bst_target_t n_targets);
 };

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -473,37 +473,18 @@ class HistMultiEvaluator {
   std::vector<double> gain_;
   linalg::Matrix<GradientPairPrecise> stats_;
   TrainParam const *param_;
+  TreeEvaluator tree_evaluator_;
   FeatureInteractionConstraintHost interaction_constraints_;
   std::shared_ptr<common::ColumnSampler> column_sampler_;
   Context const *ctx_;
   bool is_col_split_{false};
 
  private:
-  static double MultiCalcSplitGain(TrainParam const &param,
-                                   linalg::VectorView<GradientPairPrecise const> left_sum,
-                                   linalg::VectorView<GradientPairPrecise const> right_sum) {
-    double left_hess{0.0}, right_hess{0.0};
-    double gain{0.0};
-    for (std::size_t t = 0; t < left_sum.Size(); ++t) {
-      auto const &left = left_sum(t);
-      auto const &right = right_sum(t);
-      left_hess += left.GetHess();
-      right_hess += right.GetHess();
-      gain += CalcGain(param, left.GetGrad(), left.GetHess());
-      gain += CalcGain(param, right.GetGrad(), right.GetHess());
-    }
-
-    auto n_targets = static_cast<double>(left_sum.Size());
-    if (!IsValidSplit(param, left_hess / n_targets, right_hess / n_targets)) {
-      return -std::numeric_limits<double>::infinity();
-    }
-    return gain;
-  }
-
   template <bst_bin_t d_step>
   bool EnumerateSplit(common::HistogramCuts const &cut, bst_feature_t fidx,
                       common::Span<common::ConstGHistRow> hist,
                       linalg::VectorView<GradientPairPrecise const> parent_sum, double parent_gain,
+                      bst_node_t nidx, TreeEvaluator::SplitEvaluator<TrainParam> const &evaluator,
                       SplitEntryContainer<std::vector<GradientPairPrecise>> *p_best) const {
     auto const &cut_ptr = cut.Ptrs();
     auto const &cut_val = cut.Values();
@@ -532,11 +513,13 @@ class HistMultiEvaluator {
 
       if (d_step > 0) {
         auto split_pt = cut_val[i];
-        auto loss_chg = MultiCalcSplitGain(*param_, right_sum, left_sum) - parent_gain;
+        auto loss_chg =
+            evaluator.CalcSplitGain(*param_, nidx, fidx, left_sum, right_sum) - parent_gain;
         p_best->Update(loss_chg, fidx, split_pt, d_step == -1, false, left_sum, right_sum);
       } else {
         auto split_pt = common::HistogramCuts::NumericBinLowerBound(cut_ptr, cut_val, fidx, i);
-        auto loss_chg = MultiCalcSplitGain(*param_, right_sum, left_sum) - parent_gain;
+        auto loss_chg =
+            evaluator.CalcSplitGain(*param_, nidx, fidx, right_sum, left_sum) - parent_gain;
         p_best->Update(loss_chg, fidx, split_pt, d_step == -1, false, right_sum, left_sum);
       }
     }
@@ -551,6 +534,7 @@ class HistMultiEvaluator {
   void EnumerateOneHot(common::HistogramCuts const &cut, bst_feature_t fidx,
                        common::Span<common::ConstGHistRow> hist,
                        linalg::VectorView<GradientPairPrecise const> parent_sum, double parent_gain,
+                       bst_node_t nidx, TreeEvaluator::SplitEvaluator<TrainParam> const &evaluator,
                        SplitEntryContainer<std::vector<GradientPairPrecise>> *p_best) const {
     auto const &cut_ptr = cut.Ptrs();
     auto const &cut_val = cut.Values();
@@ -587,7 +571,8 @@ class HistMultiEvaluator {
         right_sum(t) = GradientPairPrecise{hist[t][i]};
         left_sum(t) = parent_sum(t) - right_sum(t);
       }
-      auto missing_left_gain = MultiCalcSplitGain(*param_, left_sum, right_sum) - parent_gain;
+      auto missing_left_gain =
+          evaluator.CalcSplitGain(*param_, nidx, fidx, left_sum, right_sum) - parent_gain;
       best.Update(missing_left_gain, fidx, split_pt, true, true, left_sum, right_sum);
 
       // Missing on right (missing grouped with chosen category).
@@ -595,7 +580,8 @@ class HistMultiEvaluator {
         right_sum(t) = GradientPairPrecise{hist[t][i]} + missing(t);  // NOLINT
         left_sum(t) = parent_sum(t) - right_sum(t);
       }
-      auto missing_right_gain = MultiCalcSplitGain(*param_, left_sum, right_sum) - parent_gain;
+      auto missing_right_gain =
+          evaluator.CalcSplitGain(*param_, nidx, fidx, left_sum, right_sum) - parent_gain;
       best.Update(missing_right_gain, fidx, split_pt, false, true, left_sum, right_sum);
     }
 
@@ -612,6 +598,7 @@ class HistMultiEvaluator {
   template <bst_bin_t d_step>
   void EnumeratePart(common::HistogramCuts const &cut, common::Span<size_t const> sorted_idx,
                      common::Span<common::ConstGHistRow> hist, bst_feature_t fidx, bst_node_t nidx,
+                     TreeEvaluator::SplitEvaluator<TrainParam> const &evaluator,
                      SplitEntryContainer<std::vector<GradientPairPrecise>> *p_best) {
     static_assert(d_step == +1 || d_step == -1, "Invalid step.");
     auto n_targets = hist.size();
@@ -654,7 +641,8 @@ class HistMultiEvaluator {
         }
       }
 
-      auto loss_chg = MultiCalcSplitGain(*param_, left_sum, right_sum) - parent_gain;
+      auto loss_chg =
+          evaluator.CalcSplitGain(*param_, nidx, fidx, left_sum, right_sum) - parent_gain;
       // We don't have a numeric split point, nan here is a dummy split.
       if (best.Update(loss_chg, fidx, std::numeric_limits<float>::quiet_NaN(), d_step == 1, true,
                       left_sum, right_sum)) {
@@ -706,6 +694,7 @@ class HistMultiEvaluator {
       }
     }
 
+    auto evaluator = tree_evaluator_.GetEvaluator();
     common::ParallelFor2d(space, n_threads, [&](std::size_t nidx_in_set, common::Range1d r) {
       auto tidx = omp_get_thread_num();
       auto entry = &tloc_candidates[n_threads * nidx_in_set + tidx];
@@ -714,7 +703,7 @@ class HistMultiEvaluator {
       auto parent_sum = stats_.Slice(entry->nid, linalg::All());
       auto base_weight = linalg::Zeros<float>(ctx_, parent_sum.Shape());
       auto h_bw = base_weight.HostView();
-      CalcWeight(*param_, parent_sum, h_bw);
+      evaluator.CalcWeight(entry->nid, *param_, parent_sum, h_bw);
 
       std::vector<common::ConstGHistRow> node_hist;
       for (auto t_hist : hist) {
@@ -732,10 +721,11 @@ class HistMultiEvaluator {
         bool is_cat = common::IsCat(feature_types, fidx);
         // Numeric split
         if (!is_cat) {
-          bool missing =
-              this->EnumerateSplit<+1>(cut, fidx, node_hist, parent_sum, parent_gain, best);
+          bool missing = this->EnumerateSplit<+1>(cut, fidx, node_hist, parent_sum, parent_gain,
+                                                  entry->nid, evaluator, best);
           if (missing) {
-            this->EnumerateSplit<-1>(cut, fidx, node_hist, parent_sum, parent_gain, best);
+            this->EnumerateSplit<-1>(cut, fidx, node_hist, parent_sum, parent_gain, entry->nid,
+                                     evaluator, best);
           }
           continue;
         }
@@ -744,7 +734,8 @@ class HistMultiEvaluator {
         auto n_bins = cut_ptr.at(fidx + 1) - cut_ptr[fidx];
         // One hot split
         if (common::UseOneHot(n_bins, param_->max_cat_to_onehot)) {
-          this->EnumerateOneHot(cut, fidx, node_hist, parent_sum, parent_gain, best);
+          this->EnumerateOneHot(cut, fidx, node_hist, parent_sum, parent_gain, entry->nid,
+                                evaluator, best);
           continue;
         }
 
@@ -764,7 +755,8 @@ class HistMultiEvaluator {
             auto f_hist = node_hist[t_idx].subspan(cut_ptr[fidx], n_bins);
             h_grads(t_idx) = f_hist[bin_idx];
           }
-          CalcWeight(*param_, h_grads, linalg::MakeVec(child_w.data(), child_w.size()));
+          evaluator.CalcWeight(entry->nid, *param_, h_grads,
+                               linalg::MakeVec(child_w.data(), child_w.size()));
           double sc = .0;
           for (decltype(n_targets) t_idx = 0; t_idx < n_targets; ++t_idx) {
             sc += h_bw(t_idx) * child_w[t_idx];
@@ -775,8 +767,8 @@ class HistMultiEvaluator {
         std::stable_sort(sorted_idx.begin(), sorted_idx.end(),
                          [&](std::size_t l, std::size_t r) { return scores[l] < scores[r]; });
 
-        this->EnumeratePart<+1>(cut, sorted_idx, node_hist, fidx, entry->nid, best);
-        this->EnumeratePart<-1>(cut, sorted_idx, node_hist, fidx, entry->nid, best);
+        this->EnumeratePart<+1>(cut, sorted_idx, node_hist, fidx, entry->nid, evaluator, best);
+        this->EnumeratePart<-1>(cut, sorted_idx, node_hist, fidx, entry->nid, evaluator, best);
       }
     });
 
@@ -805,8 +797,9 @@ class HistMultiEvaluator {
     gain_.resize(1);
 
     linalg::Vector<float> weight({n_targets}, ctx_->Device());
-    CalcWeight(*param_, root_sum, weight.HostView());
-    auto root_gain = CalcGainGivenWeight(*param_, root_sum, weight.HostView());
+    auto evaluator = tree_evaluator_.GetEvaluator();
+    evaluator.CalcWeight(RegTree::kRoot, *param_, root_sum, weight.HostView());
+    auto root_gain = evaluator.CalcGainGivenWeight(*param_, root_sum, weight.HostView());
     gain_.front() = root_gain;
 
     auto h_stats = stats_.HostView();
@@ -821,19 +814,30 @@ class HistMultiEvaluator {
     auto n_split_targets = candidate.split.left_sum.size();
     auto parent_sum = stats_.Slice(candidate.nid, linalg::All());
 
+    auto evaluator = tree_evaluator_.GetEvaluator();
     auto weight = linalg::Empty<float>(ctx_, 3, n_split_targets);
     auto base_weight = weight.Slice(0, linalg::All());
-    CalcWeight(*param_, parent_sum, base_weight);
+    evaluator.CalcWeight(candidate.nid, *param_, parent_sum, base_weight);
 
     auto left_weight = weight.Slice(1, linalg::All());
     auto left_sum =
         linalg::MakeVec(candidate.split.left_sum.data(), candidate.split.left_sum.size());
-    CalcWeight(*param_, left_sum, param_->learning_rate, left_weight);
+    evaluator.CalcWeight(candidate.nid, *param_, left_sum, left_weight);
 
     auto right_weight = weight.Slice(2, linalg::All());
     auto right_sum =
         linalg::MakeVec(candidate.split.right_sum.data(), candidate.split.right_sum.size());
-    CalcWeight(*param_, right_sum, param_->learning_rate, right_weight);
+    evaluator.CalcWeight(candidate.nid, *param_, right_sum, right_weight);
+
+    auto leaf_weight = linalg::Empty<float>(ctx_, 2, n_split_targets);
+    auto left_leaf_weight = leaf_weight.Slice(0, linalg::All());
+    auto right_leaf_weight = leaf_weight.Slice(1, linalg::All());
+    std::transform(linalg::cbegin(left_weight), linalg::cend(left_weight),
+                   linalg::begin(left_leaf_weight),
+                   [&](float w) { return w * param_->learning_rate; });
+    std::transform(linalg::cbegin(right_weight), linalg::cend(right_weight),
+                   linalg::begin(right_leaf_weight),
+                   [&](float w) { return w * param_->learning_rate; });
 
     // Compute the loss_chg and sum hessians for parent and children
     float loss_chg = candidate.split.loss_chg;
@@ -848,12 +852,12 @@ class HistMultiEvaluator {
     if (candidate.split.is_cat) {
       p_tree->ExpandCategorical(candidate.nid, candidate.split.SplitIndex(),
                                 candidate.split.cat_bits, candidate.split.DefaultLeft(),
-                                base_weight, left_weight, right_weight, loss_chg, sum_hess,
-                                left_sum_hess, right_sum_hess);
+                                base_weight, left_leaf_weight, right_leaf_weight, loss_chg,
+                                sum_hess, left_sum_hess, right_sum_hess);
     } else {
       p_tree->ExpandNode(candidate.nid, candidate.split.SplitIndex(), candidate.split.split_value,
-                         candidate.split.DefaultLeft(), base_weight, left_weight, right_weight,
-                         loss_chg, sum_hess, left_sum_hess, right_sum_hess);
+                         candidate.split.DefaultLeft(), base_weight, left_leaf_weight,
+                         right_leaf_weight, loss_chg, sum_hess, left_sum_hess, right_sum_hess);
     }
 
     CHECK(p_tree->IsMultiTarget());
@@ -863,16 +867,14 @@ class HistMultiEvaluator {
     auto right_child = mt_tree.RightChild(candidate.nid);
     CHECK_GT(right_child, candidate.nid);
 
+    evaluator = tree_evaluator_.GetEvaluator();
     interaction_constraints_.Split(candidate.nid, candidate.split.SplitIndex(), left_child,
                                    right_child);
 
     std::size_t n_nodes = mt_tree.Size();
     gain_.resize(n_nodes);
-    // Re-calculate weight without learning rate.
-    CalcWeight(*param_, left_sum, left_weight);
-    CalcWeight(*param_, right_sum, right_weight);
-    gain_[left_child] = CalcGainGivenWeight(*param_, left_sum, left_weight);
-    gain_[right_child] = CalcGainGivenWeight(*param_, right_sum, right_weight);
+    gain_[left_child] = evaluator.CalcGainGivenWeight(*param_, left_sum, left_weight);
+    gain_[right_child] = evaluator.CalcGainGivenWeight(*param_, right_sum, right_weight);
 
     if (n_nodes >= stats_.Shape(0)) {
       stats_.Reshape(n_nodes * 2, stats_.Shape(1));
@@ -889,6 +891,7 @@ class HistMultiEvaluator {
   explicit HistMultiEvaluator(Context const *ctx, MetaInfo const &info, TrainParam const *param,
                               std::shared_ptr<common::ColumnSampler> sampler)
       : param_{param},
+        tree_evaluator_{*param, static_cast<bst_feature_t>(info.num_col_), DeviceOrd::CPU()},
         column_sampler_{std::move(sampler)},
         ctx_{ctx},
         is_col_split_{info.IsColumnSplit()} {
@@ -896,6 +899,8 @@ class HistMultiEvaluator {
     column_sampler_->Init(ctx, info.num_col_, info.feature_weights, param_->colsample_bynode,
                           param_->colsample_bylevel, param_->colsample_bytree);
   }
+
+  [[nodiscard]] auto Evaluator() const { return tree_evaluator_.GetEvaluator(); }
 };
 
 /**

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -842,12 +842,12 @@ class HistMultiEvaluator {
     // Compute the loss_chg and sum hessians for parent and children
     float loss_chg = candidate.split.loss_chg;
     // Sum hessians across all targets for each child
-    float left_sum_hess = 0.0f, right_sum_hess = 0.0f;
+    double left_sum_hess = 0.0, right_sum_hess = 0.0;
     for (std::size_t t = 0; t < candidate.split.left_sum.size(); ++t) {
       left_sum_hess += candidate.split.left_sum[t].GetHess();
       right_sum_hess += candidate.split.right_sum[t].GetHess();
     }
-    float sum_hess = left_sum_hess + right_sum_hess;
+    double sum_hess = left_sum_hess + right_sum_hess;
 
     if (candidate.split.is_cat) {
       p_tree->ExpandCategorical(candidate.nid, candidate.split.SplitIndex(),

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -295,35 +295,6 @@ XGBOOST_DEVICE float CalcWeight(const TrainingParams &p, GpairT sum_grad) {
   return CalcWeight(p, sum_grad.GetGrad(), sum_grad.GetHess());
 }
 
-/**
- * @brief multi-target weight, calculated with learning rate.
- */
-inline void CalcWeight(TrainParam const &p, linalg::VectorView<GradientPairPrecise const> grad_sum,
-                       float eta, linalg::VectorView<float> out_w) {
-  for (bst_target_t t = 0, n_targets = out_w.Size(); t < n_targets; ++t) {
-    out_w(t) = CalcWeight(p, grad_sum(t).GetGrad(), grad_sum(t).GetHess()) * eta;
-  }
-}
-
-/**
- * @brief multi-target weight
- */
-inline void CalcWeight(TrainParam const &p, linalg::VectorView<GradientPairPrecise const> grad_sum,
-                       linalg::VectorView<float> out_w) {
-  return CalcWeight(p, grad_sum, 1.0f, out_w);
-}
-
-inline double CalcGainGivenWeight(TrainParam const &p,
-                                  linalg::VectorView<GradientPairPrecise const> sum_grad,
-                                  linalg::VectorView<float const> weight) {
-  double gain{0};
-  for (bst_target_t t = 0, n_targets = weight.Size(); t < n_targets; ++t) {
-    auto const &stats = sum_grad(t);
-    gain += CalcGainGivenWeight(p, stats.GetGrad(), stats.GetHess(), weight(t));
-  }
-  return gain;
-}
-
 /*! \brief core statistics used for tree construction */
 struct XGBOOST_ALIGNAS(16) GradStats {
   using GradType = double;

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -247,8 +247,7 @@ ThresholdL1(T0 sum_grad, T1 alpha) {
 
 // calculate the cost of loss function
 template <typename TrainingParams, typename T0, typename T1>
-XGBOOST_DEVICE inline T0 CalcGainGivenWeight(TrainingParams const &p, T0 sum_grad, T0 sum_hess,
-                                             T1 w) {
+XGBOOST_DEVICE T0 CalcGainGivenWeight(TrainingParams const &p, T0 sum_grad, T0 sum_hess, T1 w) {
   return -(static_cast<T0>(2.0) * sum_grad * w + (sum_hess + p.reg_lambda) * common::Sqr(w) +
            (static_cast<T0>(2.0) * p.reg_alpha * std::abs(w)));
 }
@@ -286,13 +285,13 @@ XGBOOST_DEVICE T CalcGain(TrainingParams const &p, T sum_grad, T sum_hess) {
 }
 
 template <typename TrainingParams, typename StatT, typename T = decltype(StatT().GetHess())>
-XGBOOST_DEVICE inline T CalcGain(const TrainingParams &p, StatT stat) {
+XGBOOST_DEVICE T CalcGain(const TrainingParams &p, StatT stat) {
   return CalcGain(p, stat.GetGrad(), stat.GetHess());
 }
 
 // Used in GPU code where GradientPair is used for gradient sum, not GradStats.
 template <typename TrainingParams, typename GpairT>
-XGBOOST_DEVICE inline float CalcWeight(const TrainingParams &p, GpairT sum_grad) {
+XGBOOST_DEVICE float CalcWeight(const TrainingParams &p, GpairT sum_grad) {
   return CalcWeight(p, sum_grad.GetGrad(), sum_grad.GetHess());
 }
 

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -8,20 +8,32 @@
 #ifndef XGBOOST_TREE_SPLIT_EVALUATOR_H_
 #define XGBOOST_TREE_SPLIT_EVALUATOR_H_
 
-#include <dmlc/registry.h>
 #include <xgboost/base.h>
 
-#include <algorithm>
-#include <limits>
-#include <vector>
+#include <algorithm>    // for any_of
+#include <cstddef>      // for size_t
+#include <limits>       // for numeric_limits
+#include <type_traits>  // for void_t, false_type, declval
 
 #include "../common/math.h"
 #include "../common/transform.h"
-#include "param.h"
-#include "xgboost/context.h"
+#include "param.h"  // for TrainParam
 #include "xgboost/host_device_vector.h"
+#include "xgboost/linalg.h"
 
 namespace xgboost::tree {
+namespace split_evaluator_detail {
+template <typename T, typename = void>
+struct IsVectorGradientSum : std::false_type {};
+
+template <typename T>
+struct IsVectorGradientSum<T,
+                           std::void_t<decltype(std::declval<T const&>().Size()),
+                                       decltype(std::declval<T const&>()(std::size_t{}).GetGrad()),
+                                       decltype(std::declval<T const&>()(std::size_t{}).GetHess())>>
+    : std::true_type {};
+}  // namespace split_evaluator_detail
+
 class TreeEvaluator {
   HostDeviceVector<float> lower_bounds_;
   HostDeviceVector<float> upper_bounds_;
@@ -38,18 +50,18 @@ class TreeEvaluator {
       monotone_.SetDevice(device);
     }
 
-    if (p.monotone_constraints.empty()) {
-      monotone_.HostVector().resize(n_features, 0);
-      has_constraint_ = false;
-    } else {
+    if (!p.monotone_constraints.empty()) {
       CHECK_LE(p.monotone_constraints.size(), n_features)
           << "The size of monotone constraint should be less or equal to the number of features.";
-      monotone_.HostVector() = p.monotone_constraints;
-      monotone_.HostVector().resize(n_features, 0);
+    }
+    monotone_.HostVector() = p.monotone_constraints;
+    monotone_.HostVector().resize(n_features, 0);
+    has_constraint_ = std::any_of(p.monotone_constraints.cbegin(), p.monotone_constraints.cend(),
+                                  [](auto v) { return v != 0; });
+    if (has_constraint_) {
       // Initialised to some small size, can grow if needed
       lower_bounds_.Resize(256, -std::numeric_limits<float>::max());
       upper_bounds_.Resize(256, std::numeric_limits<float>::max());
-      has_constraint_ = true;
     }
 
     if (device_.IsCUDA()) {
@@ -67,14 +79,16 @@ class TreeEvaluator {
     const float* upper;
     bool has_constraint;
 
-    template <typename GradientSumT>
+    template <typename GradientSumT,
+              std::enable_if_t<!split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value,
+                               int> = 0>
     XGBOOST_DEVICE float CalcSplitGain(const ParamT& param, bst_node_t nidx, bst_feature_t fidx,
                                        GradientSumT const& left, GradientSumT const& right) const {
-      const float negative_infinity = -std::numeric_limits<float>::infinity();
+      constexpr float kNegInf = -std::numeric_limits<float>::infinity();
       auto left_hess = left.GetHess();
       auto right_hess = right.GetHess();
       if (!IsValidSplit(param, left_hess, right_hess)) {
-        return negative_infinity;
+        return kNegInf;
       }
 
       int constraint = has_constraint ? constraints[fidx] : 0;
@@ -88,13 +102,48 @@ class TreeEvaluator {
         // no constraint
         return gain;
       } else if (constraint > 0) {
-        return wleft <= wright ? gain : negative_infinity;
+        return wleft <= wright ? gain : kNegInf;
       } else {
-        return wleft >= wright ? gain : negative_infinity;
+        return wleft >= wright ? gain : kNegInf;
       }
     }
 
-    template <typename GradientSumT>
+    template <
+        typename LeftGradientSumT, typename RightGradientSumT,
+        std::enable_if_t<split_evaluator_detail::IsVectorGradientSum<LeftGradientSumT>::value &&
+                             split_evaluator_detail::IsVectorGradientSum<RightGradientSumT>::value,
+                         int> = 0>
+    XGBOOST_DEVICE double CalcSplitGain(const ParamT& param, [[maybe_unused]] bst_node_t nidx,
+                                        [[maybe_unused]] bst_feature_t fidx,
+                                        LeftGradientSumT const& left,
+                                        RightGradientSumT const& right) const {
+      auto n_targets = left.Size();
+      SPAN_CHECK(n_targets != 0);
+      SPAN_CHECK(n_targets == right.Size());
+
+      double left_hess{0.0};
+      double right_hess{0.0};
+      double gain{0.0};
+      for (std::size_t t = 0; t < n_targets; ++t) {
+        auto const left_t = left(t);
+        auto const right_t = right(t);
+        left_hess += left_t.GetHess();
+        right_hess += right_t.GetHess();
+        gain += tree::CalcGain(param, left_t.GetGrad(), left_t.GetHess());
+        gain += tree::CalcGain(param, right_t.GetGrad(), right_t.GetHess());
+      }
+
+      auto k = static_cast<double>(n_targets);
+      if (!IsValidSplit(param, left_hess / k, right_hess / k)) {
+        return -std::numeric_limits<double>::infinity();
+      }
+      return gain;
+    }
+
+    // Weight
+    template <typename GradientSumT,
+              std::enable_if_t<!split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value,
+                               int> = 0>
     XGBOOST_DEVICE float CalcWeight(bst_node_t nidx, ParamT const& param,
                                     GradientSumT const& stats) const {
       // boxed by max_delta_step
@@ -112,7 +161,20 @@ class TreeEvaluator {
       }
     }
 
-    template <typename GradientSumT>
+    template <
+        typename GradientSumT,
+        std::enable_if_t<split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value, int> = 0>
+    void CalcWeight(bst_node_t nidx, ParamT const& param, GradientSumT const& stats,
+                    linalg::VectorView<float> out) const {
+      SPAN_CHECK(stats.Size() == out.Size());
+      for (std::size_t t = 0; t < stats.Size(); ++t) {
+        out(t) = this->CalcWeight(nidx, param, stats(t));
+      }
+    }
+
+    template <typename GradientSumT,
+              std::enable_if_t<!split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value,
+                               int> = 0>
     XGBOOST_DEVICE float CalcWeightCat(ParamT const& param, GradientSumT const& stats) const {
       // FIXME(jiamingy): This is a temporary solution until we have categorical feature
       // specific regularization parameters.  During sorting we should try to avoid any
@@ -120,7 +182,10 @@ class TreeEvaluator {
       return ::xgboost::tree::CalcWeight(param, stats);
     }
 
-    template <typename GradientSumT>
+    // Gain given weight
+    template <typename GradientSumT,
+              std::enable_if_t<!split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value,
+                               int> = 0>
     XGBOOST_DEVICE float CalcGainGivenWeight(ParamT const& p, GradientSumT const& stats,
                                              float w) const {
       if (stats.GetHess() <= 0) {
@@ -129,10 +194,41 @@ class TreeEvaluator {
       return tree::CalcGainGivenWeight<ParamT>(p, stats.GetGrad(), stats.GetHess(), w);
     }
 
-    template <typename GradientSumT>
+    template <
+        typename GradientSumT, typename WeightT,
+        std::enable_if_t<split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value, int> = 0>
+    XGBOOST_DEVICE double CalcGainGivenWeight(ParamT const& p, GradientSumT const& stats,
+                                              WeightT const& weight) const {
+      SPAN_CHECK(stats.Size() == weight.Size());
+      double gain{0.0};
+      for (std::size_t t = 0; t < stats.Size(); ++t) {
+        auto const stats_t = stats(t);
+        gain += tree::CalcGainGivenWeight(p, stats_t.GetGrad(), stats_t.GetHess(), weight(t));
+      }
+      return gain;
+    }
+
+    // Gain
+    template <typename GradientSumT,
+              std::enable_if_t<!split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value,
+                               int> = 0>
     XGBOOST_DEVICE float CalcGain(bst_node_t nid, ParamT const& p,
                                   GradientSumT const& stats) const {
       return this->CalcGainGivenWeight(p, stats, this->CalcWeight(nid, p, stats));
+    }
+
+    template <
+        typename GradientSumT,
+        std::enable_if_t<split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value, int> = 0>
+    XGBOOST_DEVICE double CalcGain(bst_node_t nid, ParamT const& p,
+                                   GradientSumT const& stats) const {
+      double gain{0.0};
+      for (std::size_t t = 0, n_targets = stats.Size(); t < n_targets; ++t) {
+        auto const stats_t = stats(t);
+        auto weight = this->CalcWeight(nid, p, stats_t);
+        gain += tree::CalcGainGivenWeight(p, stats_t.GetGrad(), stats_t.GetHess(), weight);
+      }
+      return gain;
     }
   };
 

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -164,8 +164,8 @@ class TreeEvaluator {
     template <
         typename GradientSumT,
         std::enable_if_t<split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value, int> = 0>
-    void CalcWeight(bst_node_t nidx, ParamT const& param, GradientSumT const& stats,
-                    linalg::VectorView<float> out) const {
+    XGBOOST_DEVICE void CalcWeight(bst_node_t nidx, ParamT const& param, GradientSumT const& stats,
+                                   linalg::VectorView<float> out) const {
       SPAN_CHECK(stats.Size() == out.Size());
       for (std::size_t t = 0; t < stats.Size(); ++t) {
         out(t) = this->CalcWeight(nidx, param, stats(t));

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -23,9 +23,6 @@
 
 namespace xgboost::tree {
 class TreeEvaluator {
-  // hist and exact use parent id to calculate constraints.
-  static constexpr bst_node_t kRootParentId = (-1 & static_cast<bst_node_t>((1U << 31) - 1));
-
   HostDeviceVector<float> lower_bounds_;
   HostDeviceVector<float> upper_bounds_;
   HostDeviceVector<int32_t> monotone_;
@@ -98,7 +95,7 @@ class TreeEvaluator {
     }
 
     template <typename GradientSumT>
-    XGBOOST_DEVICE float CalcWeight(bst_node_t nodeid, const ParamT& param,
+    XGBOOST_DEVICE float CalcWeight(bst_node_t nidx, ParamT const& param,
                                     GradientSumT const& stats) const {
       // boxed by max_delta_step
       float w = ::xgboost::tree::CalcWeight(param, stats);
@@ -106,12 +103,10 @@ class TreeEvaluator {
         return w;
       }
       // Calculate bound weight, boxed by monotone constraint
-      if (nodeid == kRootParentId) {
-        return w;
-      } else if (w < lower[nodeid]) {
-        return lower[nodeid];
-      } else if (w > upper[nodeid]) {
-        return upper[nodeid];
+      if (w < lower[nidx]) {
+        return lower[nidx];
+      } else if (w > upper[nidx]) {
+        return upper[nidx];
       } else {
         return w;
       }
@@ -180,7 +175,7 @@ class TreeEvaluator {
           lower[rightid] = lower[nodeid];
           upper[rightid] = upper[nodeid];
           int32_t c = monotone[f];
-          bst_float mid = (left_weight + right_weight) / 2;
+          float mid = (left_weight + right_weight) / 2.0f;
 
           SPAN_CHECK(!common::CheckNAN(mid));
 

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -22,7 +22,7 @@
 #include "xgboost/linalg.h"
 
 namespace xgboost::tree {
-namespace split_evaluator_detail {
+namespace split_impl {
 template <typename T, typename = void>
 struct IsVectorGradientSum : std::false_type {};
 
@@ -32,7 +32,13 @@ struct IsVectorGradientSum<T,
                                        decltype(std::declval<T const&>()(std::size_t{}).GetGrad()),
                                        decltype(std::declval<T const&>()(std::size_t{}).GetHess())>>
     : std::true_type {};
-}  // namespace split_evaluator_detail
+
+template <typename... T>
+using EnableVecGrad = std::enable_if_t<(split_impl::IsVectorGradientSum<T>::value && ...), int>;
+
+template <typename... T>
+using EnableScaGrad = std::enable_if_t<!(split_impl::IsVectorGradientSum<T>::value || ...), int>;
+}  // namespace split_impl
 
 class TreeEvaluator {
   HostDeviceVector<float> lower_bounds_;
@@ -79,9 +85,7 @@ class TreeEvaluator {
     const float* upper;
     bool has_constraint;
 
-    template <typename GradientSumT,
-              std::enable_if_t<!split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value,
-                               int> = 0>
+    template <typename GradientSumT, split_impl::EnableScaGrad<GradientSumT> = 0>
     XGBOOST_DEVICE float CalcSplitGain(const ParamT& param, bst_node_t nidx, bst_feature_t fidx,
                                        GradientSumT const& left, GradientSumT const& right) const {
       constexpr float kNegInf = -std::numeric_limits<float>::infinity();
@@ -108,11 +112,8 @@ class TreeEvaluator {
       }
     }
 
-    template <
-        typename LeftGradientSumT, typename RightGradientSumT,
-        std::enable_if_t<split_evaluator_detail::IsVectorGradientSum<LeftGradientSumT>::value &&
-                             split_evaluator_detail::IsVectorGradientSum<RightGradientSumT>::value,
-                         int> = 0>
+    template <typename LeftGradientSumT, typename RightGradientSumT,
+              split_impl::EnableVecGrad<LeftGradientSumT, RightGradientSumT> = 0>
     XGBOOST_DEVICE double CalcSplitGain(const ParamT& param, [[maybe_unused]] bst_node_t nidx,
                                         [[maybe_unused]] bst_feature_t fidx,
                                         LeftGradientSumT const& left,
@@ -141,9 +142,7 @@ class TreeEvaluator {
     }
 
     // Weight
-    template <typename GradientSumT,
-              std::enable_if_t<!split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value,
-                               int> = 0>
+    template <typename GradientSumT, split_impl::EnableScaGrad<GradientSumT> = 0>
     XGBOOST_DEVICE float CalcWeight(bst_node_t nidx, ParamT const& param,
                                     GradientSumT const& stats) const {
       // boxed by max_delta_step
@@ -161,9 +160,7 @@ class TreeEvaluator {
       }
     }
 
-    template <
-        typename GradientSumT,
-        std::enable_if_t<split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value, int> = 0>
+    template <typename GradientSumT, split_impl::EnableVecGrad<GradientSumT> = 0>
     XGBOOST_DEVICE void CalcWeight(bst_node_t nidx, ParamT const& param, GradientSumT const& stats,
                                    linalg::VectorView<float> out) const {
       SPAN_CHECK(stats.Size() == out.Size());
@@ -172,20 +169,24 @@ class TreeEvaluator {
       }
     }
 
-    template <typename GradientSumT,
-              std::enable_if_t<!split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value,
-                               int> = 0>
+    template <typename GradientSumT, split_impl::EnableScaGrad<GradientSumT> = 0>
     XGBOOST_DEVICE float CalcWeightCat(ParamT const& param, GradientSumT const& stats) const {
       // FIXME(jiamingy): This is a temporary solution until we have categorical feature
       // specific regularization parameters.  During sorting we should try to avoid any
       // regularization.
       return ::xgboost::tree::CalcWeight(param, stats);
     }
+    template <typename GradientSumT, split_impl::EnableVecGrad<GradientSumT> = 0>
+    XGBOOST_DEVICE void CalcWeightCat(ParamT const& param, GradientSumT const& stats,
+                                      linalg::VectorView<float> out) const {
+      SPAN_CHECK(stats.Size() == out.Size());
+      for (std::size_t t = 0; t < stats.Size(); ++t) {
+        out(t) = this->CalcWeightCat(param, stats(t));
+      }
+    }
 
     // Gain given weight
-    template <typename GradientSumT,
-              std::enable_if_t<!split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value,
-                               int> = 0>
+    template <typename GradientSumT, split_impl::EnableScaGrad<GradientSumT> = 0>
     XGBOOST_DEVICE float CalcGainGivenWeight(ParamT const& p, GradientSumT const& stats,
                                              float w) const {
       if (stats.GetHess() <= 0) {
@@ -194,9 +195,7 @@ class TreeEvaluator {
       return tree::CalcGainGivenWeight<ParamT>(p, stats.GetGrad(), stats.GetHess(), w);
     }
 
-    template <
-        typename GradientSumT, typename WeightT,
-        std::enable_if_t<split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value, int> = 0>
+    template <typename GradientSumT, typename WeightT, split_impl::EnableVecGrad<GradientSumT> = 0>
     XGBOOST_DEVICE double CalcGainGivenWeight(ParamT const& p, GradientSumT const& stats,
                                               WeightT const& weight) const {
       SPAN_CHECK(stats.Size() == weight.Size());
@@ -209,17 +208,13 @@ class TreeEvaluator {
     }
 
     // Gain
-    template <typename GradientSumT,
-              std::enable_if_t<!split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value,
-                               int> = 0>
+    template <typename GradientSumT, split_impl::EnableScaGrad<GradientSumT> = 0>
     XGBOOST_DEVICE float CalcGain(bst_node_t nid, ParamT const& p,
                                   GradientSumT const& stats) const {
       return this->CalcGainGivenWeight(p, stats, this->CalcWeight(nid, p, stats));
     }
 
-    template <
-        typename GradientSumT,
-        std::enable_if_t<split_evaluator_detail::IsVectorGradientSum<GradientSumT>::value, int> = 0>
+    template <typename GradientSumT, split_impl::EnableVecGrad<GradientSumT> = 0>
     XGBOOST_DEVICE double CalcGain(bst_node_t nid, ParamT const& p,
                                    GradientSumT const& stats) const {
       double gain{0.0};

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -86,7 +86,7 @@ class TreeEvaluator {
     bool has_constraint;
 
     template <typename GradientSumT, split_impl::EnableScaGrad<GradientSumT> = 0>
-    XGBOOST_DEVICE float CalcSplitGain(const ParamT& param, bst_node_t nidx, bst_feature_t fidx,
+    XGBOOST_DEVICE float CalcSplitGain(ParamT const& param, bst_node_t nidx, bst_feature_t fidx,
                                        GradientSumT const& left, GradientSumT const& right) const {
       constexpr float kNegInf = -std::numeric_limits<float>::infinity();
       auto left_hess = left.GetHess();
@@ -114,14 +114,11 @@ class TreeEvaluator {
 
     template <typename LeftGradientSumT, typename RightGradientSumT,
               split_impl::EnableVecGrad<LeftGradientSumT, RightGradientSumT> = 0>
-    XGBOOST_DEVICE double CalcSplitGain(const ParamT& param, [[maybe_unused]] bst_node_t nidx,
+    XGBOOST_DEVICE double CalcSplitGain(ParamT const& param, [[maybe_unused]] bst_node_t nidx,
                                         [[maybe_unused]] bst_feature_t fidx,
                                         LeftGradientSumT const& left,
                                         RightGradientSumT const& right) const {
       auto n_targets = left.Size();
-      SPAN_CHECK(n_targets != 0);
-      SPAN_CHECK(n_targets == right.Size());
-
       double left_hess{0.0};
       double right_hess{0.0};
       double gain{0.0};
@@ -163,7 +160,6 @@ class TreeEvaluator {
     template <typename GradientSumT, split_impl::EnableVecGrad<GradientSumT> = 0>
     XGBOOST_DEVICE void CalcWeight(bst_node_t nidx, ParamT const& param, GradientSumT const& stats,
                                    linalg::VectorView<float> out) const {
-      SPAN_CHECK(stats.Size() == out.Size());
       for (std::size_t t = 0; t < stats.Size(); ++t) {
         out(t) = this->CalcWeight(nidx, param, stats(t));
       }
@@ -179,7 +175,6 @@ class TreeEvaluator {
     template <typename GradientSumT, split_impl::EnableVecGrad<GradientSumT> = 0>
     XGBOOST_DEVICE void CalcWeightCat(ParamT const& param, GradientSumT const& stats,
                                       linalg::VectorView<float> out) const {
-      SPAN_CHECK(stats.Size() == out.Size());
       for (std::size_t t = 0; t < stats.Size(); ++t) {
         out(t) = this->CalcWeightCat(param, stats(t));
       }
@@ -198,7 +193,6 @@ class TreeEvaluator {
     template <typename GradientSumT, typename WeightT, split_impl::EnableVecGrad<GradientSumT> = 0>
     XGBOOST_DEVICE double CalcGainGivenWeight(ParamT const& p, GradientSumT const& stats,
                                               WeightT const& weight) const {
-      SPAN_CHECK(stats.Size() == weight.Size());
       double gain{0.0};
       for (std::size_t t = 0; t < stats.Size(); ++t) {
         auto const stats_t = stats(t);
@@ -209,18 +203,18 @@ class TreeEvaluator {
 
     // Gain
     template <typename GradientSumT, split_impl::EnableScaGrad<GradientSumT> = 0>
-    XGBOOST_DEVICE float CalcGain(bst_node_t nid, ParamT const& p,
+    XGBOOST_DEVICE float CalcGain(bst_node_t nidx, ParamT const& p,
                                   GradientSumT const& stats) const {
-      return this->CalcGainGivenWeight(p, stats, this->CalcWeight(nid, p, stats));
+      return this->CalcGainGivenWeight(p, stats, this->CalcWeight(nidx, p, stats));
     }
 
     template <typename GradientSumT, split_impl::EnableVecGrad<GradientSumT> = 0>
-    XGBOOST_DEVICE double CalcGain(bst_node_t nid, ParamT const& p,
+    XGBOOST_DEVICE double CalcGain(bst_node_t nidx, ParamT const& p,
                                    GradientSumT const& stats) const {
       double gain{0.0};
       for (std::size_t t = 0, n_targets = stats.Size(); t < n_targets; ++t) {
         auto const stats_t = stats(t);
-        auto weight = this->CalcWeight(nid, p, stats_t);
+        auto weight = this->CalcWeight(nidx, p, stats_t);
         gain += tree::CalcGainGivenWeight(p, stats_t.GetGrad(), stats_t.GetHess(), weight);
       }
       return gain;

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -46,12 +46,12 @@ struct ColMakerTrainParam : XGBoostParameter<ColMakerTrainParam> {
   }
 
   /*! \brief whether need forward small to big search: default right */
-  inline bool NeedForwardSearch(float col_density, bool indicator) const {
+  bool NeedForwardSearch(float col_density, bool indicator) const {
     return default_direction == 2 ||
            (default_direction == 0 && (col_density < opt_dense_col) && !indicator);
   }
   /*! \brief whether need backward big to small search: default left */
-  inline bool NeedBackwardSearch() const { return default_direction != 2; }
+  bool NeedBackwardSearch() const { return default_direction != 2; }
 };
 
 DMLC_REGISTER_PARAMETER(ColMakerTrainParam);
@@ -168,10 +168,11 @@ class ColMaker : public TreeUpdater {
           interaction_constraints_{std::move(_interaction_constraints)},
           column_densities_(column_densities) {}
     // update one tree, growing
-    virtual void Update(const std::vector<GradientPair> &gpair, DMatrix *p_fmat, RegTree *p_tree) {
-      std::vector<int> newnodes;
+    void Update(std::vector<GradientPair> const &gpair, DMatrix *p_fmat, RegTree *p_tree) {
       this->InitData(gpair, *p_fmat);
-      this->InitNewNode(qexpand_, gpair, *p_fmat, *p_tree);
+      this->InitRoot(gpair, *p_fmat, *p_tree);
+
+      std::vector<int> newnodes;
       // We can check max_leaves too, but might break some grid searching pipelines.
       CHECK_GT(param_.max_depth, 0) << "exact tree method doesn't support unlimited depth.";
       for (int depth = 0; depth < param_.max_depth; ++depth) {
@@ -209,7 +210,7 @@ class ColMaker : public TreeUpdater {
 
    protected:
     // initialize temp data structure
-    inline void InitData(const std::vector<GradientPair> &gpair, const DMatrix &fmat) {
+    void InitData(const std::vector<GradientPair> &gpair, const DMatrix &fmat) {
       {
         // setup position
         position_.resize(gpair.size());
@@ -252,17 +253,12 @@ class ColMaker : public TreeUpdater {
         // expand query
         qexpand_.reserve(256);
         qexpand_.clear();
-        qexpand_.push_back(0);
+        qexpand_.push_back(RegTree::kRoot);
       }
     }
-    /*!
-     * \brief initialize the base_weight, root_gain,
-     *  and NodeEntry for all the new nodes in qexpand
-     */
-    void InitNewNode(const std::vector<int> &qexpand, const std::vector<GradientPair> &gpair,
-                     const DMatrix &fmat, RegTree const &tree) {
+    void InitNodeStats(const std::vector<int> &nodes, const std::vector<GradientPair> &gpair,
+                       const DMatrix &fmat, RegTree const &tree) {
       auto n_nodes = tree.NumNodes();
-      auto sc_tree = tree.HostScView();
       {
         // setup statistics space for each tree node
         for (auto &i : stemp_) {
@@ -278,7 +274,7 @@ class ColMaker : public TreeUpdater {
         stemp_[tid][position_[ridx]].stats.Add(gpair[ridx]);
       });
       // sum the per thread statistics together
-      for (int nid : qexpand) {
+      for (int nid : nodes) {
         GradStats stats;
         for (auto &s : stemp_) {
           stats.Add(s[nid].stats);
@@ -286,7 +282,33 @@ class ColMaker : public TreeUpdater {
         // update node statistics
         snode_[nid].stats = stats;
       }
+    }
 
+    void InitRoot(std::vector<GradientPair> const &gpair, const DMatrix &fmat,
+                  RegTree const &tree) {
+      CHECK_EQ(qexpand_.size(), 1);
+      CHECK_EQ(qexpand_.front(), RegTree::kRoot);
+
+      this->InitNodeStats(qexpand_, gpair, fmat, tree);
+
+      auto evaluator = tree_evaluator_.GetEvaluator();
+      auto &root = snode_[RegTree::kRoot];
+      root.weight = static_cast<float>(evaluator.CalcWeight(RegTree::kRoot, param_, root.stats));
+      root.root_gain = static_cast<float>(evaluator.CalcGain(RegTree::kRoot, param_, root.stats));
+    }
+
+    /**
+     * @brief Initialize the base_weight, root_gain, and NodeEntry for all the new non-root nodes.
+     */
+    void InitNewNode(const std::vector<int> &qexpand, const std::vector<GradientPair> &gpair,
+                     const DMatrix &fmat, RegTree const &tree) {
+      for (auto nidx : qexpand) {
+        CHECK_NE(nidx, RegTree::kRoot);
+      }
+
+      this->InitNodeStats(qexpand, gpair, fmat, tree);
+
+      auto sc_tree = tree.HostScView();
       auto evaluator = tree_evaluator_.GetEvaluator();
       // calculating the weights
       for (bst_node_t nidx : qexpand) {
@@ -311,11 +333,9 @@ class ColMaker : public TreeUpdater {
     }
 
     // update enumeration solution
-    inline void UpdateEnumeration(
-        int nid, GradientPair gstats, bst_float fvalue, int d_step, bst_uint fid,
-        GradStats &c,                    // NOLINT
-        std::vector<ThreadEntry> &temp,  // NOLINT(*)
-        TreeEvaluator::SplitEvaluator<TrainParam> const &evaluator) const {
+    void UpdateEnumeration(int nid, GradientPair gstats, bst_float fvalue, int d_step, bst_uint fid,
+                           GradStats &c, std::vector<ThreadEntry> &temp,  // NOLINT
+                           TreeEvaluator::SplitEvaluator<TrainParam> const &evaluator) const {
       // get the statistics of nid
       ThreadEntry &e = temp[nid];
       // test if first hit, this is fine, because we set 0 during init
@@ -513,9 +533,9 @@ class ColMaker : public TreeUpdater {
         }
       });
     }
-    // customization part
+
     // synchronize the best solution of each node
-    virtual void SyncBestSolution(const std::vector<int> &qexpand) {
+    void SyncBestSolution(const std::vector<int> &qexpand) {
       for (int nid : qexpand) {
         NodeEntry &e = snode_[nid];
         CHECK(this->ctx_);
@@ -524,8 +544,8 @@ class ColMaker : public TreeUpdater {
         }
       }
     }
-    virtual void SetNonDefaultPosition(const std::vector<int> &qexpand, DMatrix *p_fmat,
-                                       const RegTree &tree) {
+    void SetNonDefaultPosition(const std::vector<int> &qexpand, DMatrix *p_fmat,
+                               const RegTree &tree) {
       // step 1, classify the non-default data into right places
       auto sc_tree = tree.HostScView();
       std::vector<unsigned> fsplits;

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -6,8 +6,8 @@
 #include <thrust/version.h>  // for THRUST_MAJOR_VERSION
 
 #include <algorithm>  // for copy_if, max, transform
-#include <memory>  // for unique_ptr
-#include <vector>  // for vector
+#include <memory>     // for unique_ptr
+#include <vector>     // for vector
 
 #include "../collective/aggregator.h"          // for GlobalSum
 #include "../common/categorical.h"             // for CatBitField
@@ -292,8 +292,14 @@ class MultiTargetHistMaker {
     auto weights = this->evaluator_.GetNodeWeights(n_targets);
     // Root's sum_hess is the sum of left and right child hessians
     float root_sum_hess = static_cast<float>(entry.left_sum + entry.right_sum);
-    p_tree->SetRoot(linalg::MakeVec(this->ctx_->Device(), weights.Base(RegTree::kRoot)),
-                    root_sum_hess);
+    auto root_weight = linalg::Empty<float>(this->ctx_, n_targets);
+    auto d_root_weight = root_weight.View(this->ctx_->Device());
+    auto base_weight = weights.Base(RegTree::kRoot);
+    auto eta = this->param_.learning_rate;
+    dh::LaunchN(
+        n_targets, this->ctx_->CUDACtx()->Stream(),
+        [=] XGBOOST_DEVICE(std::size_t t) mutable { d_root_weight(t) = base_weight[t] * eta; });
+    p_tree->SetRoot(d_root_weight, root_sum_hess);
 
     return entry;
   }
@@ -306,11 +312,20 @@ class MultiTargetHistMaker {
 
     // Get weights by node ID from the evaluator's buffer.
     //
-    // TODO(jiamingy): Avoid device to host copies.
+    // TODO(jiamingy):
+    // - Avoid device to host copies.
+    // - Apply expand in batches
     for (auto const& candidate : h_candidates) {
       std::vector<float> h_base_weight, h_left_weight, h_right_weight;
       this->evaluator_.CopyNodeWeightsToHost(candidate.nidx, n_targets, &h_base_weight,
                                              &h_left_weight, &h_right_weight);
+      auto h_left_leaf = h_left_weight;
+      auto h_right_leaf = h_right_weight;
+      auto eta = this->param_.learning_rate;
+      std::transform(h_left_leaf.cbegin(), h_left_leaf.cend(), h_left_leaf.begin(),
+                     [=](float w) { return w * eta; });
+      std::transform(h_right_leaf.cbegin(), h_right_leaf.cend(), h_right_leaf.begin(),
+                     [=](float w) { return w * eta; });
       // Get loss_chg from the split, and sum hessians for parent and children
       float loss_chg = candidate.split.loss_chg;
       float left_sum = static_cast<float>(candidate.left_sum);
@@ -325,14 +340,14 @@ class MultiTargetHistMaker {
         CHECK_LE(n_words, cat_bits.size());
         cat_bits.resize(n_words);
         p_tree->ExpandCategorical(candidate.nidx, fidx, cat_bits, default_left,
-                                  linalg::MakeVec(h_base_weight), linalg::MakeVec(h_left_weight),
-                                  linalg::MakeVec(h_right_weight), loss_chg, sum_hess, left_sum,
+                                  linalg::MakeVec(h_base_weight), linalg::MakeVec(h_left_leaf),
+                                  linalg::MakeVec(h_right_leaf), loss_chg, sum_hess, left_sum,
                                   right_sum);
       } else {
         p_tree->ExpandNode(candidate.nidx, candidate.split.findex, candidate.split.fvalue,
                            default_left, linalg::MakeVec(h_base_weight),
-                           linalg::MakeVec(h_left_weight), linalg::MakeVec(h_right_weight),
-                           loss_chg, sum_hess, left_sum, right_sum);
+                           linalg::MakeVec(h_left_leaf), linalg::MakeVec(h_right_leaf), loss_chg,
+                           sum_hess, left_sum, right_sum);
       }
     }
 
@@ -344,7 +359,8 @@ class MultiTargetHistMaker {
     }
 
     dh::device_vector<MultiExpandEntry> candidates{h_candidates};
-    this->evaluator_.ApplyTreeSplit(this->ctx_, p_tree, dh::ToSpan(candidates), n_targets);
+    this->evaluator_.ApplyTreeSplit(this->ctx_, p_tree,
+                                    dh::ToSpan(candidates), n_targets);
   }
   /**
    * @brief Calculate the leaf weight based on the node sum for each leaf.
@@ -399,9 +415,11 @@ class MultiTargetHistMaker {
 
     auto param = GPUTrainingParam{this->param_};
     auto out_weight = linalg::Empty<float>(this->ctx_, n_leaves, p_tree->NumTargets());
+    dh::device_vector<bst_node_t> d_leaves{leaves_idx};
     // Use full value gradient for leaf values.
-    LeafWeight(this->ctx_, param, this->value_quantizer_->DeviceSpan(),
-               out_sum.View(this->ctx_->Device()), out_weight.View(this->ctx_->Device()));
+    LeafWeight(this->ctx_, param, this->evaluator_.GetEvaluator(), dh::ToSpan(d_leaves),
+               this->value_quantizer_->DeviceSpan(), out_sum.View(this->ctx_->Device()),
+               out_weight.View(this->ctx_->Device()));
 
     p_tree->SetLeaves(leaves_idx, out_weight.Data()->ConstHostSpan());
   }
@@ -734,6 +752,7 @@ class MultiTargetHistMaker {
         cuts_{std::move(cuts)},
         feature_groups_{std::make_unique<FeatureGroups>(*cuts_, dense_compressed,
                                                         DftMtHistShmemBytes(ctx_->Ordinal()))},
+        evaluator_{param_, cuts_->NumFeatures(), ctx_->Device()},
         column_sampler_{std::move(column_sampler)},
         interaction_constraints_{
             std::make_unique<FeatureInteractionConstraintDevice>(param_, cuts_->NumFeatures())} {}

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -327,10 +327,8 @@ class MultiTargetHistMaker {
       std::transform(h_right_leaf.cbegin(), h_right_leaf.cend(), h_right_leaf.begin(),
                      [=](float w) { return w * eta; });
       // Get loss_chg from the split, and sum hessians for parent and children
-      float loss_chg = candidate.split.loss_chg;
-      float left_sum = static_cast<float>(candidate.left_sum);
-      float right_sum = static_cast<float>(candidate.right_sum);
-      float sum_hess = left_sum + right_sum;
+      auto loss_chg = candidate.split.loss_chg;
+      double sum_hess = candidate.left_sum + candidate.right_sum;
       bool default_left = candidate.split.dir == kLeftDir;
       if (candidate.split.is_cat) {
         auto fidx = candidate.split.findex;
@@ -341,13 +339,13 @@ class MultiTargetHistMaker {
         cat_bits.resize(n_words);
         p_tree->ExpandCategorical(candidate.nidx, fidx, cat_bits, default_left,
                                   linalg::MakeVec(h_base_weight), linalg::MakeVec(h_left_leaf),
-                                  linalg::MakeVec(h_right_leaf), loss_chg, sum_hess, left_sum,
-                                  right_sum);
+                                  linalg::MakeVec(h_right_leaf), loss_chg, sum_hess,
+                                  candidate.left_sum, candidate.right_sum);
       } else {
         p_tree->ExpandNode(candidate.nidx, candidate.split.findex, candidate.split.fvalue,
                            default_left, linalg::MakeVec(h_base_weight),
                            linalg::MakeVec(h_left_leaf), linalg::MakeVec(h_right_leaf), loss_chg,
-                           sum_hess, left_sum, right_sum);
+                           sum_hess, candidate.left_sum, candidate.right_sum);
       }
     }
 
@@ -359,8 +357,7 @@ class MultiTargetHistMaker {
     }
 
     dh::device_vector<MultiExpandEntry> candidates{h_candidates};
-    this->evaluator_.ApplyTreeSplit(this->ctx_, p_tree,
-                                    dh::ToSpan(candidates), n_targets);
+    this->evaluator_.ApplyTreeSplit(this->ctx_, p_tree, dh::ToSpan(candidates), n_targets);
   }
   /**
    * @brief Calculate the leaf weight based on the node sum for each leaf.

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -8,7 +8,6 @@
 #include <cstddef>    // for size_t
 #include <cstdint>    // for uint32_t, int32_t
 #include <memory>     // for allocator, unique_ptr, make_unique, shared_ptr
-#include <ostream>    // for operator<<, basic_ostream, char_traits
 #include <utility>    // for move
 #include <vector>     // for vector
 
@@ -377,11 +376,15 @@ class MultiTargetHistBuilder {
     linalg::Matrix<float> weights = linalg::Empty<float>(ctx_, n_leaves, n_targets);
     auto h_weights = weights.HostView();
     auto eta = this->param_->learning_rate;
+    auto evaluator = this->evaluator_->Evaluator();
 
     common::ParallelFor(n_leaves, n_threads, [&](auto leaf_idx) {
       auto grad_sum = h_leaf_sums.Slice(leaf_idx, linalg::All());
       auto weight = h_weights.Slice(leaf_idx, linalg::All());
-      CalcWeight(*param_, grad_sum, eta, weight);
+      evaluator.CalcWeight(leaves_idx[leaf_idx], *param_, grad_sum, weight);
+      for (bst_target_t t = 0; t < n_targets; ++t) {
+        weight(t) *= eta;
+      }
     });
 
     // Set leaf weights

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -111,10 +111,11 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, Root) {
   std::vector<float> exp_left_weight{-1.5, -0.655172};
   std::vector<float> exp_right_weight{-1.25, -0.951219};
 
+  auto param = this->MakeParam();
   for (auto one_pass : {OnePass::kNone, OnePass::kForward, OnePass::kBackward}) {
     auto shared = this->shared_inputs;
     shared.one_pass = one_pass;
-    MultiHistEvaluator evaluator;
+    MultiHistEvaluator evaluator{param, 1, ctx.Device()};
     auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
     ASSERT_NEAR(candidate.split.loss_chg, 3.04239, 1e-5);
 
@@ -139,10 +140,10 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, Root) {
     }
   }
 
-  auto param = this->MakeParam(Args{{"reg_alpha", "0.1"}, {"max_delta_step", "1.45"}});
+  param = this->MakeParam(Args{{"reg_alpha", "0.1"}, {"max_delta_step", "1.45"}});
   auto shared = this->shared_inputs;
   shared.param = GPUTrainingParam{param};
-  MultiHistEvaluator evaluator;
+  MultiHistEvaluator evaluator{param, 1, ctx.Device()};
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
   ASSERT_NEAR(candidate.split.loss_chg, 2.55177, 1e-5);
 }
@@ -157,7 +158,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalOneHot) {
   auto param = this->MakeParam(Args{{"max_cat_to_onehot", "100"}});
   auto shared = this->MakeCategoricalInputs(param);
 
-  MultiHistEvaluator evaluator;
+  MultiHistEvaluator evaluator{param, 1, ctx.Device()};
   evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param);
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
@@ -207,7 +208,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   auto param = this->MakeParam(Args{{"max_cat_to_onehot", "1"}});
   auto shared = this->MakeCategoricalInputs(param);
 
-  MultiHistEvaluator evaluator;
+  MultiHistEvaluator evaluator{param, 1, ctx.Device()};
   evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param);
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
@@ -244,7 +245,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
       this->MakeParam(Args{{"max_cat_to_onehot", "1"}, {"max_cat_threshold", "1"}});
   shared.param = GPUTrainingParam{no_split_param};
 
-  MultiHistEvaluator no_split_evaluator;
+  MultiHistEvaluator no_split_evaluator{no_split_param, 1, ctx.Device()};
   no_split_evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, no_split_param);
   auto no_split = no_split_evaluator.EvaluateSingleSplit(&ctx, input, shared);
 

--- a/tests/cpp/tree/test_param.cc
+++ b/tests/cpp/tree/test_param.cc
@@ -140,24 +140,4 @@ TEST(Param, CalcGainWithL1AndMaxDeltaStep) {
   EXPECT_FLOAT_EQ(CalcWeight(param, kGrad, kHess), -0.5f);
   EXPECT_FLOAT_EQ(CalcGain(param, kGrad, kHess), 2.5f);
 }
-
-TEST(Param, CalcVectorGainWithMaxDeltaStep) {
-  TrainParam param;
-  param.UpdateAllowUnknown(
-      xgboost::Args{{"reg_alpha", "1"}, {"reg_lambda", "0"}, {"max_delta_step", "0.5"}});
-
-  linalg::Vector<xgboost::GradientPairPrecise> stats({2}, xgboost::DeviceOrd::CPU());
-  auto h_stats = stats.HostView();
-  h_stats(0) = {8.0, 2.0};
-  h_stats(1) = {-2.0, 4.0};
-
-  linalg::Vector<float> weight({2}, xgboost::DeviceOrd::CPU());
-  auto h_weight = weight.HostView();
-  CalcWeight(param, h_stats, h_weight);
-  ASSERT_FLOAT_EQ(h_weight(0), -0.5f);
-  ASSERT_FLOAT_EQ(h_weight(1), 0.25f);
-
-  // 6.5 from the clipped first target and 0.25 from the second target.
-  EXPECT_DOUBLE_EQ(CalcGainGivenWeight(param, h_stats, h_weight), 6.75);
-}
 }  // namespace xgboost::tree

--- a/tests/cpp/tree/test_split_evaluator.cc
+++ b/tests/cpp/tree/test_split_evaluator.cc
@@ -3,7 +3,9 @@
  */
 #include <gtest/gtest.h>
 
+#include "../../../src/tree/param.h"  // for TrainParam
 #include "../../../src/tree/split_evaluator.h"
+#include "xgboost/linalg.h"  // for Vector
 
 namespace xgboost::tree {
 TEST(TreeEvaluator, CalcVectorGainWithMaxDeltaStep) {
@@ -28,4 +30,4 @@ TEST(TreeEvaluator, CalcVectorGainWithMaxDeltaStep) {
   EXPECT_DOUBLE_EQ(evaluator.CalcGainGivenWeight(param, h_stats, h_weight), 6.75);
   EXPECT_DOUBLE_EQ(evaluator.CalcGain(0, param, h_stats), 6.75);
 }
-}  // namespace xgboost
+}  // namespace xgboost::tree

--- a/tests/cpp/tree/test_split_evaluator.cc
+++ b/tests/cpp/tree/test_split_evaluator.cc
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ */
+#include <gtest/gtest.h>
+
+#include "../../../src/tree/split_evaluator.h"
+
+namespace xgboost::tree {
+TEST(TreeEvaluator, CalcVectorGainWithMaxDeltaStep) {
+  TrainParam param;
+  param.UpdateAllowUnknown(
+      xgboost::Args{{"reg_alpha", "1"}, {"reg_lambda", "0"}, {"max_delta_step", "0.5"}});
+
+  linalg::Vector<xgboost::GradientPairPrecise> stats({2}, xgboost::DeviceOrd::CPU());
+  auto h_stats = stats.HostView();
+  h_stats(0) = {8.0, 2.0};
+  h_stats(1) = {-2.0, 4.0};
+
+  linalg::Vector<float> weight({2}, xgboost::DeviceOrd::CPU());
+  auto h_weight = weight.HostView();
+  TreeEvaluator tree_evaluator{param, 1, DeviceOrd::CPU()};
+  auto evaluator = tree_evaluator.GetEvaluator();
+  evaluator.CalcWeight(0, param, h_stats, h_weight);
+  ASSERT_FLOAT_EQ(h_weight(0), -0.5f);
+  ASSERT_FLOAT_EQ(h_weight(1), 0.25f);
+
+  // 6.5 from the clipped first target and 0.25 from the second target.
+  EXPECT_DOUBLE_EQ(evaluator.CalcGainGivenWeight(param, h_stats, h_weight), 6.75);
+  EXPECT_DOUBLE_EQ(evaluator.CalcGain(0, param, h_stats), 6.75);
+}
+}  // namespace xgboost


### PR DESCRIPTION
- Add a `InitRoot` to the column maker to remove the specialization in the shared evaluator. This aligns the exact tree method with the hist tree method.
- Share the evaluator between the scalar tree updater and the vector tree updater.
- Extract the `eta` computation from the updater evaluators as we will need the raw weights in the future.

Ref: https://github.com/dmlc/xgboost/issues/9043