### PR TITLE
[doc] Prefer CUDA async pool for external memory.

### DIFF
--- a/demo/guide-python/distributed_extmem_basic.py
+++ b/demo/guide-python/distributed_extmem_basic.py
@@ -143,9 +143,7 @@ def setup_numa() -> None:
 
 
 def setup_async_pool() -> None:
-    """Setup CUDA async pool. As an alternative, the RMM plugin can be used as well.
-    This is the same as using the `CudaAsyncMemoryResource` from RMM, but without the
-    RMM dependency.
+    """Set up the CUDA async pool for GPU-based external memory training.
 
     .. versionadded:: 3.2.0
 

--- a/demo/guide-python/distributed_extmem_basic.py
+++ b/demo/guide-python/distributed_extmem_basic.py
@@ -149,6 +149,7 @@ def setup_async_pool() -> None:
 
     """
     import cuda.bindings.runtime as cudart
+    import cupy as cp
     from cuda.bindings import driver
     from cupy.cuda import MemoryAsyncPool
 
@@ -165,7 +166,6 @@ def setup_async_pool() -> None:
     )
     _checkcu(status)
     # Set the allocator for cupy as well.
-    import cupy as cp
 
     cp.cuda.set_allocator(MemoryAsyncPool().malloc)
 

--- a/demo/guide-python/external_memory.py
+++ b/demo/guide-python/external_memory.py
@@ -22,7 +22,6 @@ required:
 If `device` is `cuda`, following are also needed:
 
 - cupy
-- rmm
 - cuda-python
 
 .. seealso::
@@ -184,9 +183,7 @@ def main(work_dir: str, cli_args: argparse.Namespace) -> None:
 
 
 def setup_async_pool() -> None:
-    """Setup CUDA async pool. As an alternative, the RMM plugin can be used as well. See
-    the `setup_rmm`. This is the same as using the `CudaAsyncMemoryResource` from RMM,
-    but without the RMM dependency.
+    """Set up the CUDA async pool for GPU-based external memory training.
 
     .. versionadded:: 3.2.0
 
@@ -212,54 +209,14 @@ def setup_async_pool() -> None:
     cp.cuda.set_allocator(MemoryAsyncPool().malloc)
 
 
-def setup_rmm() -> None:
-    """Setup RMM for GPU-based external memory training.
-
-    It's important to use RMM with `CudaAsyncMemoryResource` or `ArenaMemoryResource`
-    for GPU-based external memory to improve performance. If XGBoost is not built with
-    RMM support, a warning is raised when constructing the `DMatrix`.
-
-    """
-
-    import rmm
-    from rmm.allocators.cupy import rmm_cupy_allocator
-    from rmm.mr import ArenaMemoryResource
-
-    if not xgboost.build_info()["USE_RMM"]:
-        return
-
-    import cupy as cp  # pylint: disable=import-outside-toplevel
-
-    total = device_mem_total()
-
-    mr: rmm.mr.DeviceMemoryResource = rmm.mr.CudaMemoryResource()
-    mr = ArenaMemoryResource(mr, arena_size=int(total * 0.9))
-
-    rmm.mr.set_current_device_resource(mr)
-    # Set the allocator for cupy as well.
-    cp.cuda.set_allocator(rmm_cupy_allocator)
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--device", choices=["cpu", "cuda"], default="cpu")
-    parser.add_argument(
-        "--memory_pool",
-        choices=["rmm", "cuda"],
-        default="rmm",
-        help="Use a memory pool for asynchronous memory allocation in XGBoost.",
-    )
     args = parser.parse_args()
     if args.device == "cuda":
-        if args.memory_pool == "rmm":
-            setup_rmm()
-        elif args.memory_pool == "cuda":
-            setup_async_pool()
-        # Make sure XGBoost is using RMM for all allocations.
-        with xgboost.config_context(
-            use_rmm=args.memory_pool == "rmm",
-            use_cuda_async_pool=args.memory_pool == "cuda",
-        ):
+        setup_async_pool()
+        # Make sure XGBoost is using the CUDA async pool for all allocations.
+        with xgboost.config_context(use_cuda_async_pool=True):
             with tempfile.TemporaryDirectory() as tmpdir:
                 main(tmpdir, args)
     else:

--- a/demo/guide-python/external_memory.py
+++ b/demo/guide-python/external_memory.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """
 Experimental support for external memory
 ========================================
@@ -189,7 +190,7 @@ def setup_async_pool() -> None:
 
     """
     import cuda.bindings.runtime as cudart
-    import cupy as cp  # pylint: disable=import-outside-toplevel
+    import cupy as cp
     from cuda.bindings import driver
     from cupy.cuda import MemoryAsyncPool
 

--- a/doc/tutorials/external_memory.rst
+++ b/doc/tutorials/external_memory.rst
@@ -176,16 +176,8 @@ data placement and memory usage.
 Inputs to the :py:class:`~xgboost.ExtMemQuantileDMatrix` (through the iterator) must be on
 the GPU. It's crucial to use an asynchronous memory pool for all memory allocations when
 training with external memory. XGBoost relies on the asynchronous memory pool to reduce
-the overhead of data fetching. There are two options for setting up the memory pool:
-
-- **CUDA Async Pool**: Uses the CUDA driver's built-in async memory pool. This option
-  doesn't require any additional dependencies. It's the same as using the
-  `CudaAsyncMemoryResource` from RMM (see below).
-- **RMM Pool**: Uses `RAPIDS Memory Manager (RMM) <https://github.com/rapidsai/rmm>`__
-  with an asynchronous memory resource. This option requires RMM to be installed and
-  XGBoost to be built with RMM support.
-
-Choose the one that best fits your use case.
+the overhead of data fetching. Use the CUDA driver's built-in async memory pool, which
+doesn't require additional dependencies.
 
 =====================
 Using CUDA Async Pool
@@ -230,46 +222,6 @@ threshold. See :ref:`global_config` for the parameter `use_cuda_async_pool`.
         booster = xgboost.train(
             {
                 "tree_method": "hist",
-                "max_bin": n_bins,
-                "device": device,
-            },
-            Xy_train,
-            num_boost_round=n_rounds,
-            evals=[(Xy_train, "Train"), (Xy_valid, "Valid")]
-        )
-
-==============
-Using RMM Pool
-==============
-
-Alternatively, you can use RMM with an asynchronous memory resource. If XGBoost is not
-built with RMM support, a warning will be raised:
-
-.. code-block:: python
-
-    import cupy as cp
-    import rmm
-    from rmm.allocators.cupy import rmm_cupy_allocator
-
-    # We use the pool memory resource here for simplicity, you can also try the
-    # `ArenaMemoryResource` for improved memory fragmentation handling.
-    mr = rmm.mr.PoolMemoryResource(rmm.mr.CudaAsyncMemoryResource())
-    rmm.mr.set_current_device_resource(mr)
-    # Set the allocator for cupy as well.
-    cp.cuda.set_allocator(rmm_cupy_allocator)
-
-    # Make sure XGBoost is using RMM for all allocations.
-    with xgboost.config_context(use_rmm=True):
-        # Construct the iterators for ExtMemQuantileDMatrix
-        # ...
-        # Build the ExtMemQuantileDMatrix and start training
-        Xy_train = xgboost.ExtMemQuantileDMatrix(it_train, max_bin=n_bins)
-        # Use the training DMatrix as a reference
-        Xy_valid = xgboost.ExtMemQuantileDMatrix(it_valid, max_bin=n_bins, ref=Xy_train)
-        booster = xgboost.train(
-            {
-                "tree_method": "hist",
-                "max_depth": 6,
                 "max_bin": n_bins,
                 "device": device,
             },
@@ -456,13 +408,11 @@ it takes to run inference, even if a C2C link is available.
     Xy_train = xgboost.ExtMemQuantileDMatrix(it_train, max_bin=n_bins)
     Xy_valid = xgboost.ExtMemQuantileDMatrix(it_valid, max_bin=n_bins, ref=Xy_train)
 
-In addition, since the GPU implementation relies on asynchronous memory pool, memory
-fragmentation can occur regardless of whether you use the CUDA async pool or RMM.  You
-might want to start the training with a fresh pool instead of starting training right
-after the ETL process. If you run into out-of-memory errors and you are convinced that the
-pool is not full yet (pool memory usage can be profiled with ``nsight-system``), consider
-using the :py:class:`~rmm.mr.ArenaMemoryResource` memory resource with RMM, or using the
-CUDA asynchronous pool with the latest NVIDIA kernel driver.
+In addition, since the GPU implementation relies on an asynchronous memory pool, memory
+fragmentation can occur. You might want to start the training with a fresh pool instead of
+starting training right after the ETL process. If you run into out-of-memory errors and
+you are convinced that the pool is not full yet (pool memory usage can be profiled with
+``nsight-system``), use the latest NVIDIA kernel driver.
 
 During CPU benchmarking, we used an NVMe connected to a PCIe-4 slot. Other types of
 storage can be too slow for practical usage. However, your system will likely perform some

--- a/doc/tutorials/external_memory.rst
+++ b/doc/tutorials/external_memory.rst
@@ -177,7 +177,7 @@ Inputs to the :py:class:`~xgboost.ExtMemQuantileDMatrix` (through the iterator) 
 the GPU. It's crucial to use an asynchronous memory pool for all memory allocations when
 training with external memory. XGBoost relies on the asynchronous memory pool to reduce
 the overhead of data fetching. Use the CUDA driver's built-in async memory pool, which
-doesn't require additional dependencies.
+avoids additional dependencies such as RMM.
 
 =====================
 Using CUDA Async Pool
@@ -412,7 +412,7 @@ In addition, since the GPU implementation relies on an asynchronous memory pool,
 fragmentation can occur. You might want to start the training with a fresh pool instead of
 starting training right after the ETL process. If you run into out-of-memory errors and
 you are convinced that the pool is not full yet (pool memory usage can be profiled with
-``nsight-system``), use the latest NVIDIA kernel driver.
+``nsight-systems``), use the latest NVIDIA kernel driver.
 
 During CPU benchmarking, we used an NVMe connected to a PCIe-4 slot. Other types of
 storage can be too slow for practical usage. However, your system will likely perform some


### PR DESCRIPTION
Remove the mention of RMM and focus on the use of CUDA built-in pool.