### PR TITLE
[MT] Monotonic constraint.

### DIFF
--- a/demo/guide-python/multioutput_regression.py
+++ b/demo/guide-python/multioutput_regression.py
@@ -133,15 +133,13 @@ if __name__ == "__main__":
     # Train with builtin RMSE objective
     # - One model per output.
     rmse_model("one_output_per_tree", axs[0, 0])
-    # - One model for all outputs, this is still working in progress, many features are
-    # missing.
+    # - One model for all outputs, this is still experimental.
     rmse_model("multi_output_tree", axs[0, 1])
 
     # Train with custom objective.
     # - One model per output.
     custom_rmse_model("one_output_per_tree", axs[1, 0])
-    # - One model for all outputs, this is still working in progress, many features are
-    # missing.
+    # - One model for all outputs, this is still experimental.
     custom_rmse_model("multi_output_tree", axs[1, 1])
     if args.plot == 1:
         plt.show()

--- a/demo/guide-python/multioutput_regression.py
+++ b/demo/guide-python/multioutput_regression.py
@@ -22,14 +22,14 @@ from typing import Dict, List, Optional, Tuple
 
 import matplotlib
 import numpy as np
-from matplotlib import pyplot as plt
-
 import xgboost as xgb
+from matplotlib import pyplot as plt
 
 
 def plot_predt(
     y: np.ndarray, y_predt: np.ndarray, name: str, ax: matplotlib.axes.Axes
 ) -> None:
+    """Plot the prediction from the model."""
     s = 25
     ax.scatter(y[:, 0], y[:, 1], c="navy", s=s, edgecolor="black", label=name)
     ax.scatter(y_predt[:, 0], y_predt[:, 1], c="cornflowerblue", s=s, edgecolor="black")
@@ -76,6 +76,7 @@ def custom_rmse_model(strategy: str, ax: Optional[matplotlib.axes.Axes]) -> None
 
     def hessian(predt: np.ndarray, dtrain: xgb.DMatrix) -> np.ndarray:
         """Compute the hessian for squared error."""
+        assert dtrain.num_row() == predt.shape[0]
         return np.ones(predt.shape)
 
     def squared_log(

--- a/doc/treemethod.rst
+++ b/doc/treemethod.rst
@@ -138,8 +138,9 @@ Following table summarizes some differences in supported features between 4 tree
 +------------------+-----------+---------------------+------------------------+------------------------+
 | Distributed      | F         | T                   | T                      | T                      |
 +------------------+-----------+---------------------+------------------------+------------------------+
+| Vector leaf      | F         | F                   | F                      | T                      |
++------------------+-----------+---------------------+------------------------+------------------------+
 
 Features/parameters that are not mentioned here are universally supported for all 3 tree
-methods (for instance, column sampling and constraints).  The `P` in external memory means
-special handling.  Please note that both categorical data and external memory are
-experimental.
+methods (for instance, column sampling and constraints). The `P` in external memory means
+supported but not recommended due to performance reasons.

--- a/doc/tutorials/categorical.rst
+++ b/doc/tutorials/categorical.rst
@@ -91,8 +91,41 @@ group the categories that output similar leaf values. During split finding, we f
 the gradient histogram to prepare the contiguous partitions then enumerate the splits
 according to these sorted values. One of the related parameters for XGBoost is
 ``max_cat_to_onehot``, which controls whether one-hot encoding or partitioning should be
-used for each feature, see :ref:`cat-param` for details. See :doc:`/tutorials/multioutput`
-for the vector-leaf variant.
+used for each feature, see :ref:`cat-param` for details.
+
+===========
+Vector Leaf
+===========
+
+.. versionadded:: 3.4.0
+
+For scalar leaves, the optimal partitioning method described above avoids enumerating all
+:math:`2^{k-1} - 1` binary partitions of :math:`k` categories.
+
+For vector leaves, each category has a weight vector and there is no canonical ordering of
+vectors. XGBoost induces an ordering by projecting each category weight onto the parent's
+Newton update direction:
+
+.. math::
+
+  u_p &= \frac{w_p}{\lVert w_p \rVert_2} \\
+  s_c &= u_p^T w_c
+
+where :math:`w_p` is the parent leaf weight and :math:`w_c` is the category-level leaf
+weight. The score measures how strongly category :math:`c` follows the parent update
+direction.
+
+The projection has some nice consistency properties. For one output, it agrees with the
+standard scalar ordering up to reversal. For parent-aligned vector effects,
+
+.. math::
+
+   w_c = \alpha_c w_p
+
+we have :math:`s_c = \alpha_c \lVert w_p \rVert_2`, so ordering the projected scores is
+equivalent to ordering the scalar coefficients :math:`\alpha_c`. In general, however, it
+is an approximation: category contrasts orthogonal to the parent update can be missed,
+and a weak parent update provides little ordering signal.
 
 
 **********************

--- a/doc/tutorials/monotonic.rst
+++ b/doc/tutorials/monotonic.rst
@@ -96,6 +96,8 @@ Some other examples:
 Vector Leaf
 ===========
 
+.. versionadded:: 3.4.0
+
 For vector leaves, XGBoost applies the same constraint independently to every output. If
 a target's child weights violate the required order, their constrained optimum is the
 common weight

--- a/doc/tutorials/monotonic.rst
+++ b/doc/tutorials/monotonic.rst
@@ -114,8 +114,7 @@ Here :math:`\operatorname{clip}` applies the inherited bounds.
 
 .. note::
 
-    With reduced gradients, the constraint applies only to the split-gradient coordinates
-    and does not guarantee monotonicity of the full-dimensional leaves.
+    Reduced gradient doesn't support monotone constraint.
 
 *******************
 Using feature names

--- a/doc/tutorials/monotonic.rst
+++ b/doc/tutorials/monotonic.rst
@@ -92,6 +92,29 @@ Some other examples:
    split candidates, in which case no split is made. To reduce the effect, you may want to
    increase the ``max_bin`` parameter to consider more split candidates.
 
+===========
+Vector Leaf
+===========
+
+For vector leaves, XGBoost applies the same constraint independently to every output. If
+a target's child weights violate the required order, their constrained optimum is the
+common weight
+
+.. math::
+
+    w_{l,t}=w_{r,t}=p_t
+    =\operatorname{clip}_{[L_{n,t},U_{n,t}]}\left(
+      -\frac{\operatorname{ThresholdL1}(G_{l,t}+G_{r,t},2\alpha)}
+             {H_{l,t}+H_{r,t}+2\lambda}
+    \right).
+
+Here :math:`\operatorname{clip}` applies the inherited bounds; ``max_delta_step`` is
+applied as usual.
+
+.. note::
+
+    With reduced gradients, the constraint applies only to the split-gradient coordinates
+    and does not guarantee monotonicity of the full-dimensional leaves.
 
 *******************
 Using feature names

--- a/doc/tutorials/monotonic.rst
+++ b/doc/tutorials/monotonic.rst
@@ -108,8 +108,7 @@ common weight
              {H_{l,t}+H_{r,t}+2\lambda}
     \right).
 
-Here :math:`\operatorname{clip}` applies the inherited bounds; ``max_delta_step`` is
-applied as usual.
+Here :math:`\operatorname{clip}` applies the inherited bounds.
 
 .. note::
 

--- a/doc/tutorials/multioutput.rst
+++ b/doc/tutorials/multioutput.rst
@@ -137,40 +137,6 @@ implement the ``split_grad`` method.
 See :ref:`sphx_glr_python_examples_multioutput_reduced_gradient.py` for a complete worked
 example. The feature supports only the ``multi_strategy=multi_output_tree``.
 
-***********************************
-Partitioning for categorical splits
-***********************************
-
-.. versionadded:: 3.4.0
-
-For scalar leaves, XGBoost uses :doc:`optimal partitioning </tutorials/categorical>` to
-avoid enumerating all :math:`2^{k-1} - 1` binary partitions of :math:`k` categories.
-
-For vector leaves, each category has a weight vector and there is no canonical ordering of
-vectors. XGBoost induces an ordering by projecting each category weight onto the parent's
-Newton update direction:
-
-.. math::
-
-  u_p &= \frac{w_p}{\lVert w_p \rVert_2} \\
-  s_c &= u_p^T w_c
-
-where :math:`w_p` is the parent leaf weight and :math:`w_c` is the category-level leaf
-weight. The score measures how strongly category :math:`c` follows the parent update
-direction.
-
-The projection has some nice consistency properties. For one output, it agrees with the
-standard scalar ordering up to reversal. For parent-aligned vector effects,
-
-.. math::
-
-   w_c = \alpha_c w_p
-
-we have :math:`s_c = \alpha_c \lVert w_p \rVert_2`, so ordering the projected scores is
-equivalent to ordering the scalar coefficients :math:`\alpha_c`. In general, however, it
-is an approximation: category contrasts orthogonal to the parent update can be missed,
-and a weak parent update provides little ordering signal.
-
 
 **********
 References

--- a/doc/tutorials/multioutput.rst
+++ b/doc/tutorials/multioutput.rst
@@ -59,10 +59,6 @@ Training with Vector Leaf
 
 .. versionadded:: 2.0.0
 
-.. note::
-
-   This is still working-in-progress, and most features are missing.
-
 XGBoost can optionally build multi-output trees with the size of leaf equals to the number
 of targets when the tree method `hist` is used. The behavior can be controlled by the
 ``multi_strategy`` training parameter, which can take the value `one_output_per_tree` (the
@@ -85,8 +81,8 @@ Using Reduced Gradient (Sketch Boost)
 
 .. note::
 
-   This is still working-in-progress, and most features are missing. It is documented here
-   for early testers to provide feedback. Related interface might change without notice.
+   This is experimental. It is documented here for early testers to provide feedback. Related
+   interface might change without notice.
 
 When the number of targets is large, training a gradient boosting tree model using the
 full gradient matrix becomes challenging. The training procedure may run out of memory for

--- a/python-package/xgboost/testing/monotone_constraints.py
+++ b/python-package/xgboost/testing/monotone_constraints.py
@@ -130,8 +130,8 @@ def run_parent_gain(device: Device, multi_strategy: str) -> None:
 
 def run_monotone_constraints(
     device: Device,
-    tree_method: str = "hist",
-    grow_policy: str = "depthwise",
+    tree_method: str,
+    grow_policy: str,
     multi_strategy: str = "one_output_per_tree",
 ) -> None:
     """Check for a positive (``f0``) and negative (``f1``) constraint."""
@@ -180,9 +180,7 @@ def _assert_monotone(
 
 
 def run_multi_output_monotone(
-    device: Device,
-    grow_policy: str = "depthwise",
-    multi_strategy: str = "multi_output_tree",
+    device: Device, grow_policy: str, multi_strategy: str
 ) -> None:
     """Monotonicity check for deep trees with mixed feature constraints.
 

--- a/python-package/xgboost/testing/monotone_constraints.py
+++ b/python-package/xgboost/testing/monotone_constraints.py
@@ -76,10 +76,12 @@ y = (
 training_dset = DMatrix(x, label=y)
 
 # Multi-output labels sharing the same ``(f0: increasing, f1: decreasing)`` structure as
-# ``y``. Each column is a positive-scale affine transform of ``y`` plus independent
-# noise, so every target must be increasing in ``f0`` and decreasing in ``f1`` while
-# still differing enough to exercise shared vector-leaf splits.
-_mt_noise = np.random.normal(loc=0.0, scale=0.01, size=(NUMBER_OF_DPOINTS, 2))
+# ``y``. Each column is a positive-scale affine transform of ``y``, so every target must
+# be increasing in ``f0`` and decreasing in ``f1`` while still differing enough to
+# exercise shared vector-leaf splits.
+_mt_noise = np.random.default_rng(2026).normal(
+    loc=0.0, scale=0.01, size=(NUMBER_OF_DPOINTS, 2)
+)
 y_mt = np.column_stack(
     [y, 2.0 * y + _mt_noise[:, 0], 0.5 * y + _mt_noise[:, 1]]
 ).astype(np.float32)

--- a/python-package/xgboost/testing/monotone_constraints.py
+++ b/python-package/xgboost/testing/monotone_constraints.py
@@ -69,9 +69,7 @@ y = (
 training_dset = DMatrix(x, label=y)
 
 
-def run_parent_gain(
-    device: Device, multi_strategy: str = "one_output_per_tree"
-) -> None:
+def run_parent_gain(device: Device, multi_strategy: str) -> None:
     """Test that parent gain uses the node's inherited monotonic bounds."""
     X = np.array(
         [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [1.0, 1.0, 1.0]],

--- a/python-package/xgboost/testing/monotone_constraints.py
+++ b/python-package/xgboost/testing/monotone_constraints.py
@@ -183,8 +183,6 @@ def run_multi_output_monotone(
     device: Device,
     grow_policy: str = "depthwise",
     multi_strategy: str = "multi_output_tree",
-    max_depth: int = 6,
-    seed: int = 1994,
 ) -> None:
     """Monotonicity check for deep trees with mixed feature constraints.
 
@@ -193,7 +191,7 @@ def run_multi_output_monotone(
 
     """
     constraints = (1, -1, 0, 0, 0)
-    rng = np.random.RandomState(seed)
+    rng = np.random.RandomState(2026)
     n_samples, n_features, n_targets = 2048, len(constraints), 3
     features = rng.rand(n_samples, n_features).astype(np.float32)
     labels = np.empty((n_samples, n_targets), dtype=np.float32)
@@ -211,11 +209,11 @@ def run_multi_output_monotone(
         "grow_policy": grow_policy,
         "multi_strategy": multi_strategy,
         "monotone_constraints": constraints,
-        "max_depth": max_depth,
+        "max_depth": 6,
         "eta": 0.3,
         "reg_lambda": 1.0,
         "reg_alpha": 0.1,
         "min_child_weight": 0.0,
     }
     booster = train(params, DMatrix(features, label=labels), num_boost_round=40)
-    _assert_monotone(booster, constraints, seed=seed + 1)
+    _assert_monotone(booster, constraints, seed=2026 + 1)

--- a/python-package/xgboost/testing/monotone_constraints.py
+++ b/python-package/xgboost/testing/monotone_constraints.py
@@ -1,7 +1,7 @@
 """Helpers for testing monotone constraints."""
 
 import json
-from typing import Optional
+from typing import Optional, Sequence
 
 import numpy as np
 import pytest
@@ -13,13 +13,20 @@ from .utils import Device
 
 
 def is_increasing(v: np.ndarray) -> bool:
-    """Whether is v increasing."""
-    return np.count_nonzero(np.diff(v) < 0.0) == 0
+    """Whether ``v`` is nondecreasing along the sweep axis.
+
+    ``v`` can be a 1-D vector (scalar leaf) or a 2-D ``(grid, targets)`` matrix (vector
+    leaf).  For a matrix every output column must be nondecreasing.
+    """
+    return np.count_nonzero(np.diff(v, axis=0) < 0.0) == 0
 
 
 def is_decreasing(v: np.ndarray) -> bool:
-    """Whether is v decreasing."""
-    return np.count_nonzero(np.diff(v) > 0.0) == 0
+    """Whether ``v`` is nonincreasing along the sweep axis.
+
+    See :py:func:`is_increasing` for the handling of vector-leaf prediction matrices.
+    """
+    return np.count_nonzero(np.diff(v, axis=0) > 0.0) == 0
 
 
 def is_correctly_constrained(
@@ -68,6 +75,15 @@ y = (
 )
 training_dset = DMatrix(x, label=y)
 
+# Multi-output labels sharing the same ``(f0: increasing, f1: decreasing)`` structure as
+# ``y``. Each column is a positive-scale affine transform of ``y`` plus independent
+# noise, so every target must be increasing in ``f0`` and decreasing in ``f1`` while
+# still differing enough to exercise shared vector-leaf splits.
+_mt_noise = np.random.normal(loc=0.0, scale=0.01, size=(NUMBER_OF_DPOINTS, 2))
+y_mt = np.column_stack(
+    [y, 2.0 * y + _mt_noise[:, 0], 0.5 * y + _mt_noise[:, 1]]
+).astype(np.float32)
+
 
 def run_parent_gain(device: Device, multi_strategy: str) -> None:
     """Test that parent gain uses the node's inherited monotonic bounds."""
@@ -110,3 +126,96 @@ def run_parent_gain(device: Device, multi_strategy: str) -> None:
     constrained_parent = trees["children"][1]["children"][1]
     assert constrained_parent["split"] == "f2"
     assert constrained_parent["gain"] == pytest.approx(expected_gain)
+
+
+def run_monotone_constraints(
+    device: Device,
+    tree_method: str = "hist",
+    grow_policy: str = "depthwise",
+    multi_strategy: str = "one_output_per_tree",
+) -> None:
+    """Check for a positive (``f0``) and negative (``f1``) constraint."""
+    label = y_mt if multi_strategy == "multi_output_tree" else y
+    dtrain = DMatrix(x, label=label)
+    params = {
+        "tree_method": tree_method,
+        "grow_policy": grow_policy,
+        "device": device,
+        "multi_strategy": multi_strategy,
+        "monotone_constraints": "(1, -1)",
+    }
+    model = train(params, dtrain, num_boost_round=16)
+    assert is_correctly_constrained(model)
+
+
+def _assert_monotone(
+    booster: Booster,
+    constraints: Sequence[int],
+    *,
+    n_grid: int = 64,
+    n_ref: int = 32,
+    seed: int = 0,
+) -> None:
+    """Grid-check monotonicity per output column for every constrained feature.
+
+    For each feature with a nonzero constraint, sweep it over ``[0, 1]`` while holding
+    the remaining features fixed at random reference rows.
+
+    """
+    rng = np.random.RandomState(seed)
+    n_features = len(constraints)
+    grid = np.linspace(0.0, 1.0, n_grid, dtype=np.float32)
+    for fidx, direction in enumerate(constraints):
+        if direction == 0:
+            continue
+        for _ in range(n_ref):
+            base = rng.rand(n_features).astype(np.float32)
+            features = np.tile(base, (n_grid, 1))
+            features[:, fidx] = grid
+            pred = booster.predict(DMatrix(features))
+            if direction > 0:
+                assert is_increasing(pred), (fidx, "increasing")
+            else:
+                assert is_decreasing(pred), (fidx, "decreasing")
+
+
+def run_multi_output_monotone(
+    device: Device,
+    grow_policy: str = "depthwise",
+    multi_strategy: str = "multi_output_tree",
+    max_depth: int = 6,
+    seed: int = 1994,
+) -> None:
+    """Monotonicity check for deep trees with mixed feature constraints.
+
+    Uses more features than constraints so that constrained splits are followed by
+    splits on unconstrained features.
+
+    """
+    constraints = (1, -1, 0, 0, 0)
+    rng = np.random.RandomState(seed)
+    n_samples, n_features, n_targets = 2048, len(constraints), 3
+    features = rng.rand(n_samples, n_features).astype(np.float32)
+    labels = np.empty((n_samples, n_targets), dtype=np.float32)
+    for t in range(n_targets):
+        labels[:, t] = (
+            (t + 1) * features[:, 0]
+            - (t + 1) * features[:, 1]
+            + np.sin(6.0 * features[:, 2])
+            + 0.5 * features[:, 3] * features[:, 4]
+            + rng.normal(scale=0.05, size=n_samples)
+        )
+    params = {
+        "tree_method": "hist",
+        "device": device,
+        "grow_policy": grow_policy,
+        "multi_strategy": multi_strategy,
+        "monotone_constraints": constraints,
+        "max_depth": max_depth,
+        "eta": 0.3,
+        "reg_lambda": 1.0,
+        "reg_alpha": 0.1,
+        "min_child_weight": 0.0,
+    }
+    booster = train(params, DMatrix(features, label=labels), num_boost_round=40)
+    _assert_monotone(booster, constraints, seed=seed + 1)

--- a/python-package/xgboost/testing/monotone_constraints.py
+++ b/python-package/xgboost/testing/monotone_constraints.py
@@ -13,19 +13,12 @@ from .utils import Device
 
 
 def is_increasing(v: np.ndarray) -> bool:
-    """Whether ``v`` is nondecreasing along the sweep axis.
-
-    ``v`` can be a 1-D vector (scalar leaf) or a 2-D ``(grid, targets)`` matrix (vector
-    leaf).  For a matrix every output column must be nondecreasing.
-    """
+    """Whether ``v`` is nondecreasing along the sweep axis."""
     return np.count_nonzero(np.diff(v, axis=0) < 0.0) == 0
 
 
 def is_decreasing(v: np.ndarray) -> bool:
-    """Whether ``v`` is nonincreasing along the sweep axis.
-
-    See :py:func:`is_increasing` for the handling of vector-leaf prediction matrices.
-    """
+    """Whether ``v`` is nonincreasing along the sweep axis."""
     return np.count_nonzero(np.diff(v, axis=0) > 0.0) == 0
 
 

--- a/python-package/xgboost/testing/monotone_constraints.py
+++ b/python-package/xgboost/testing/monotone_constraints.py
@@ -69,15 +69,24 @@ y = (
 training_dset = DMatrix(x, label=y)
 
 
-def run_parent_gain(device: Device) -> None:
+def run_parent_gain(
+    device: Device, multi_strategy: str = "one_output_per_tree"
+) -> None:
     """Test that parent gain uses the node's inherited monotonic bounds."""
     X = np.array(
         [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [1.0, 1.0, 1.0]],
         dtype=np.float32,
     )
-    gradients = np.array([3.0, -2.75, -0.125, 0.875], dtype=np.float32)
-    hessians = np.array([1.0, 0.5, 0.25, 0.25], dtype=np.float32)
-    dtrain = DMatrix(X, label=np.zeros(X.shape[0], dtype=np.float32))
+    grad = np.array([3.0, -2.75, -0.125, 0.875], dtype=np.float32)
+    hess = np.array([1.0, 0.5, 0.25, 0.25], dtype=np.float32)
+    expected_gain = 0.25
+    if multi_strategy == "multi_output_tree":
+        gradients = np.stack([grad, 2.0 * grad], axis=1)
+        hessians = np.stack([hess, hess], axis=1)
+        expected_gain += 1.0
+    else:
+        gradients, hessians = grad, hess
+    dtrain = DMatrix(X, label=np.zeros_like(gradients))
 
     def objective(
         _predt: np.ndarray, _dtrain: DMatrix
@@ -95,10 +104,11 @@ def run_parent_gain(device: Device) -> None:
         "eta": 1,
         "base_score": 0,
         "device": device,
+        "multi_strategy": multi_strategy,
     }
     model = train(params, dtrain, num_boost_round=1, obj=objective)
     trees = json.loads(model.get_dump(dump_format="json", with_stats=True)[0])
 
     constrained_parent = trees["children"][1]["children"][1]
     assert constrained_parent["split"] == "f2"
-    assert constrained_parent["gain"] == pytest.approx(0.25)
+    assert constrained_parent["gain"] == pytest.approx(expected_gain)

--- a/python-package/xgboost/testing/multi_target.py
+++ b/python-package/xgboost/testing/multi_target.py
@@ -338,24 +338,21 @@ def run_reduced_grad(device: Device) -> None:  # pylint: disable=too-many-locals
     with pytest.raises(AssertionError):
         run_test(LsObj2(device, True))
 
-    X_small = np.arange(32, dtype=np.float32).reshape(16, 2)
-    y_small = np.stack([X_small[:, 0], X_small[:, 1]], axis=1)
-    dtrain = QuantileDMatrix(X_small, y_small)
-    params = {
-        "device": device,
-        "tree_method": "hist",
-        "multi_strategy": "multi_output_tree",
-        "max_depth": 1,  # root-only to test leaf weights
-        "monotone_constraints": "(1, 0)",
-    }
-    booster = train(params, dtrain, num_boost_round=1, obj=LsObj2(device, False))
-    predt = booster.predict(dtrain)
-    assert predt.shape == y_small.shape
-
-    # Reduced-coordinate bounds must not constrain the full-dimensional leaf refresh.
-    params["monotone_constraints"] = "(0, 0)"
-    reference = train(params, dtrain, num_boost_round=1, obj=LsObj2(device, False))
-    np.testing.assert_allclose(predt, reference.predict(dtrain))
+    with pytest.raises(
+        ValueError,
+        match="Monotonic constraints are not supported with reduced gradients",
+    ):
+        train(
+            {
+                "device": device,
+                "tree_method": "hist",
+                "multi_strategy": "multi_output_tree",
+                "monotone_constraints": (1,),
+            },
+            Xy,
+            num_boost_round=1,
+            obj=LsObj2(device, False),
+        )
 
 
 def run_with_iter(device: Device) -> None:  # pylint: disable=too-many-locals

--- a/python-package/xgboost/testing/multi_target.py
+++ b/python-package/xgboost/testing/multi_target.py
@@ -294,7 +294,7 @@ class LsObj2(LsObj0):
         return sgrad, shess
 
 
-def run_reduced_grad(device: Device) -> None:
+def run_reduced_grad(device: Device) -> None:  # pylint: disable=too-many-locals
     """Basic test for using reduced gradient for tree splits."""
     X, y = make_regression(
         n_samples=1024, n_features=16, random_state=1994, n_targets=5

--- a/python-package/xgboost/testing/multi_target.py
+++ b/python-package/xgboost/testing/multi_target.py
@@ -338,6 +338,25 @@ def run_reduced_grad(device: Device) -> None:
     with pytest.raises(AssertionError):
         run_test(LsObj2(device, True))
 
+    X_small = np.arange(32, dtype=np.float32).reshape(16, 2)
+    y_small = np.stack([X_small[:, 0], X_small[:, 1]], axis=1)
+    dtrain = QuantileDMatrix(X_small, y_small)
+    params = {
+        "device": device,
+        "tree_method": "hist",
+        "multi_strategy": "multi_output_tree",
+        "max_depth": 1,  # root-only to test leaf weights
+        "monotone_constraints": "(1, 0)",
+    }
+    booster = train(params, dtrain, num_boost_round=1, obj=LsObj2(device, False))
+    predt = booster.predict(dtrain)
+    assert predt.shape == y_small.shape
+
+    # Reduced-coordinate bounds must not constrain the full-dimensional leaf refresh.
+    params["monotone_constraints"] = "(0, 0)"
+    reference = train(params, dtrain, num_boost_round=1, obj=LsObj2(device, False))
+    np.testing.assert_allclose(predt, reference.predict(dtrain))
+
 
 def run_with_iter(device: Device) -> None:  # pylint: disable=too-many-locals
     """Test vector leaf with external memory."""

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -231,6 +231,8 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
   if (in_gpair->HasValueGrad()) {
     CHECK(model_.learner_model_param->IsVectorLeaf())
         << "Reduced gradient must be used with vector leaf trees";
+    CHECK(!tree_param_.HasMonotone())
+        << "Monotonic constraints are not supported with reduced gradients.";
   }
 
   TreesOneIter new_trees;

--- a/src/tree/gpu_hist/evaluate_splits.cu
+++ b/src/tree/gpu_hist/evaluate_splits.cu
@@ -14,11 +14,13 @@
 
 namespace xgboost::tree {
 // With constraints
-XGBOOST_DEVICE float LossChangeMissing(
-    const GradientPairInt64 &scan, const GradientPairInt64 &missing,
-    const GradientPairInt64 &parent_sum, const GPUTrainingParam &param, bst_node_t nidx,
-    bst_feature_t fidx, TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
-    bool &missing_left_out, const GradientQuantiser &quantiser) {  // NOLINT
+XGBOOST_DEVICE float LossChangeMissing(const GradientPairInt64 &scan,
+                                       const GradientPairInt64 &missing,
+                                       const GradientPairInt64 &parent_sum, const EvalParam &param,
+                                       bst_node_t nidx, bst_feature_t fidx,
+                                       TreeEvaluator::SplitEvaluator<EvalParam> evaluator,
+                                       bool &missing_left_out,  // NOLINT
+                                       GradientQuantiser const &quantiser) {
   const auto left_sum = scan + missing;
   float missing_left_gain =
       evaluator.CalcSplitGain(param, nidx, fidx, quantiser.ToFloatingPoint(left_sum),
@@ -60,15 +62,15 @@ class EvaluateSplitAgent {
   const GradientQuantiser &rounding;
   const GradientPairInt64 parent_sum;
   const GradientPairInt64 missing;
-  const GPUTrainingParam &param;
-  const TreeEvaluator::SplitEvaluator<GPUTrainingParam> &evaluator;
+  const EvalParam &param;
+  const TreeEvaluator::SplitEvaluator<EvalParam> &evaluator;
   SumCallbackOp<GradientPairInt64> prefix_op;
   static float constexpr kNullGain = -std::numeric_limits<bst_float>::infinity();
 
   __device__ EvaluateSplitAgent(TempStorage *temp_storage, int fidx,
                                 const EvaluateSplitInputs &inputs,
                                 const EvaluateSplitSharedInputs &shared_inputs,
-                                const TreeEvaluator::SplitEvaluator<GPUTrainingParam> &evaluator)
+                                const TreeEvaluator::SplitEvaluator<EvalParam> &evaluator)
       : fidx(fidx),
         nidx(inputs.nidx),
         gidx_begin(__ldg(shared_inputs.feature_segments.data() + fidx)),
@@ -205,8 +207,7 @@ class EvaluateSplitAgent {
    */
   __device__ __forceinline__ void Partition(DeviceSplitCandidate *best_split,
                                             common::Span<bst_feature_t> sorted_idx,
-                                            std::size_t node_offset,
-                                            GPUTrainingParam const &param) {
+                                            std::size_t node_offset, EvalParam const &param) {
     bst_bin_t n_bins_feature = gidx_end - gidx_begin;
     auto n_bins = std::min(param.max_cat_threshold, n_bins_feature);
 
@@ -251,7 +252,7 @@ template <int kBlockThreads>
 __global__ __launch_bounds__(kBlockThreads) void EvaluateSplitsKernel(
     bst_feature_t max_active_features, common::Span<const EvaluateSplitInputs> d_inputs,
     const EvaluateSplitSharedInputs shared_inputs, common::Span<bst_feature_t> sorted_idx,
-    const TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
+    const TreeEvaluator::SplitEvaluator<EvalParam> evaluator,
     common::Span<DeviceSplitCandidate> out_candidates) {
   // Aligned && shared storage for best_split
   __shared__ cub::Uninitialized<DeviceSplitCandidate> uninitialized_split;
@@ -343,11 +344,11 @@ __device__ void SetCategoricalSplit(const EvaluateSplitSharedInputs &shared_inpu
   });
 }
 
-void GPUHistEvaluator::LaunchEvaluateSplits(
-    Context const *ctx, bst_feature_t max_active_features,
-    common::Span<const EvaluateSplitInputs> d_inputs, EvaluateSplitSharedInputs shared_inputs,
-    TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
-    common::Span<DeviceSplitCandidate> out_splits) {
+void GPUHistEvaluator::LaunchEvaluateSplits(Context const *ctx, bst_feature_t max_active_features,
+                                            common::Span<const EvaluateSplitInputs> d_inputs,
+                                            EvaluateSplitSharedInputs shared_inputs,
+                                            TreeEvaluator::SplitEvaluator<EvalParam> evaluator,
+                                            common::Span<DeviceSplitCandidate> out_splits) {
   if (need_sort_histogram_) {
     this->SortHistogram(ctx, d_inputs, shared_inputs, evaluator);
   }
@@ -398,7 +399,7 @@ void GPUHistEvaluator::EvaluateSplits(Context const *ctx, const std::vector<bst_
                                       common::Span<const EvaluateSplitInputs> d_inputs,
                                       EvaluateSplitSharedInputs shared_inputs,
                                       common::Span<GPUExpandEntry> out_entries) {
-  auto evaluator = this->tree_evaluator_.template GetEvaluator<GPUTrainingParam>();
+  auto evaluator = this->tree_evaluator_.template GetEvaluator<EvalParam>();
 
   dh::TemporaryArray<DeviceSplitCandidate> splits_out_storage(d_inputs.size());
   auto out_splits = dh::ToSpan(splits_out_storage);

--- a/src/tree/gpu_hist/evaluate_splits.cuh
+++ b/src/tree/gpu_hist/evaluate_splits.cuh
@@ -44,7 +44,7 @@ struct EvaluateSplitInputs {
 
 // Inputs necessary for all nodes
 struct EvaluateSplitSharedInputs {
-  GPUTrainingParam param;
+  EvalParam param;
   GradientQuantiser rounding;
   common::Span<FeatureType const> feature_types;
   common::Span<const uint32_t> feature_segments;
@@ -188,20 +188,20 @@ class GPUHistEvaluator {
                              candidate.right_weight);
   }
 
-  auto GetEvaluator() { return tree_evaluator_.GetEvaluator<GPUTrainingParam>(); }
+  auto GetEvaluator() { return tree_evaluator_.GetEvaluator<EvalParam>(); }
   /**
    * \brief Sort the histogram based on output to obtain contiguous partitions.
    */
   common::Span<bst_feature_t const> SortHistogram(
       Context const *ctx, common::Span<const EvaluateSplitInputs> d_inputs,
       EvaluateSplitSharedInputs shared_inputs,
-      TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator);
+      TreeEvaluator::SplitEvaluator<EvalParam> evaluator);
 
   // impl of evaluate splits, contains CUDA kernels so it's public
   void LaunchEvaluateSplits(Context const *ctx, bst_feature_t max_active_features,
                             common::Span<const EvaluateSplitInputs> d_inputs,
                             EvaluateSplitSharedInputs shared_inputs,
-                            TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
+                            TreeEvaluator::SplitEvaluator<EvalParam> evaluator,
                             common::Span<DeviceSplitCandidate> out_splits);
   /**
    * \brief Evaluate splits for left and right nodes.
@@ -241,7 +241,7 @@ struct MultiEvaluateSplitSharedInputs {
   // Number of histogram bins for one target, across all features.
   bst_bin_t n_total_bins_per_tar;
   bst_feature_t max_active_feature;
-  GPUTrainingParam param;
+  EvalParam param;
 
   // Used for testing
   enum OnePass {

--- a/src/tree/gpu_hist/evaluate_splits.cuh
+++ b/src/tree/gpu_hist/evaluate_splits.cuh
@@ -147,7 +147,7 @@ class GPUHistEvaluator {
 
  public:
   GPUHistEvaluator(TrainParam const &param, bst_feature_t n_features, DeviceOrd device)
-      : tree_evaluator_{param, n_features, device}, param_{param} {}
+      : tree_evaluator_{param, n_features, device, 1u}, param_{param} {}
   /**
    * \brief Reset the evaluator, should be called before any use.
    */

--- a/src/tree/gpu_hist/evaluator.cu
+++ b/src/tree/gpu_hist/evaluator.cu
@@ -69,8 +69,7 @@ void GPUHistEvaluator::Reset(Context const *ctx, common::HistogramCuts const &cu
 
 common::Span<bst_feature_t const> GPUHistEvaluator::SortHistogram(
     Context const *ctx, common::Span<const EvaluateSplitInputs> d_inputs,
-    EvaluateSplitSharedInputs shared_inputs,
-    TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator) {
+    EvaluateSplitSharedInputs shared_inputs, TreeEvaluator::SplitEvaluator<EvalParam> evaluator) {
   auto sorted_idx = this->SortedIdx(d_inputs.size(), shared_inputs.feature_values.size());
   dh::Iota(sorted_idx, ctx->CUDACtx()->Stream());
   auto data = this->SortInput(d_inputs.size(), shared_inputs.feature_values.size());

--- a/src/tree/gpu_hist/evaluator.cu
+++ b/src/tree/gpu_hist/evaluator.cu
@@ -20,7 +20,7 @@ void GPUHistEvaluator::Reset(Context const *ctx, common::HistogramCuts const &cu
                              common::Span<FeatureType const> ft, bst_feature_t n_features,
                              TrainParam const &param, bool is_column_split) {
   param_ = param;
-  tree_evaluator_ = TreeEvaluator{param, n_features, ctx->Device()};
+  tree_evaluator_ = TreeEvaluator{param, n_features, ctx->Device(), 1u};
   has_categoricals_ = cuts.HasCategorical();
   if (cuts.HasCategorical()) {
     auto ptrs = cuts.cut_ptrs_.ConstDeviceSpan();

--- a/src/tree/gpu_hist/leaf_sum.cu
+++ b/src/tree/gpu_hist/leaf_sum.cu
@@ -107,12 +107,13 @@ void LeafWeight(Context const* ctx, GPUTrainingParam const& param,
                 linalg::MatrixView<float> out_weights) {
   CHECK(grad_sum.Contiguous());
   CHECK_EQ(nidx.size(), grad_sum.Shape(0));
+  CHECK_EQ(roundings.size(), grad_sum.Shape(1));
   CHECK_EQ(out_weights.Shape(0), grad_sum.Shape(0));
   CHECK_EQ(out_weights.Shape(1), grad_sum.Shape(1));
   dh::LaunchN(grad_sum.Size(), ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(std::size_t i) mutable {
     auto [nidx_in_set, t] = linalg::UnravelIndex(i, grad_sum.Shape());
     auto g = roundings[t].ToFloatingPoint(grad_sum(nidx_in_set, t));
-    auto weight = evaluator.CalcWeight(nidx[nidx_in_set], param, g);
+    auto weight = evaluator.CalcWeight(nidx[nidx_in_set], t, param, g);
     out_weights(nidx_in_set, t) = weight * param.learning_rate;
   });
 }

--- a/src/tree/gpu_hist/leaf_sum.cu
+++ b/src/tree/gpu_hist/leaf_sum.cu
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025, XGBoost contributors
+ * Copyright 2025-2026, XGBoost contributors
  */
 #include <thrust/scan.h>     // for inclusive_scan
 #include <thrust/version.h>  // for THRUST_MAJOR_VERSION
@@ -9,7 +9,7 @@
 #include <cub/device/device_segmented_reduce.cuh>  // for DeviceSegmentedReduce
 #include <vector>                                  // for vector
 
-#include "../updater_gpu_common.cuh"  // for GPUTrainingParam
+#include "../split_evaluator.h"  // for GPUTrainingParam
 #include "leaf_sum.cuh"
 #include "quantiser.cuh"        // for GradientQuantiser
 #include "row_partitioner.cuh"  // for RowIndexT, LeafInfo
@@ -99,8 +99,8 @@ void LeafGradSum(Context const* ctx, std::vector<LeafInfo> const& h_leaves,
   }
 }
 
-void LeafWeight(Context const* ctx, GPUTrainingParam const& param,
-                TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
+void LeafWeight(Context const* ctx, EvalParam const& param,
+                TreeEvaluator::SplitEvaluator<EvalParam> evaluator,
                 common::Span<bst_node_t const> nidx,
                 common::Span<GradientQuantiser const> roundings,
                 linalg::MatrixView<GradientPairInt64 const> grad_sum,

--- a/src/tree/gpu_hist/leaf_sum.cuh
+++ b/src/tree/gpu_hist/leaf_sum.cuh
@@ -31,8 +31,8 @@ void LeafGradSum(Context const* ctx, std::vector<LeafInfo> const& h_leaves,
  *   shape(grad_sum) == (n_leaves, n_targets)
  *   shape(out_weights) == (n_leaves, n_targets)
  */
-void LeafWeight(Context const* ctx, GPUTrainingParam const& param,
-                TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
+void LeafWeight(Context const* ctx, EvalParam const& param,
+                TreeEvaluator::SplitEvaluator<EvalParam> evaluator,
                 common::Span<bst_node_t const> nidx,
                 common::Span<GradientQuantiser const> roundings,
                 linalg::MatrixView<GradientPairInt64 const> grad_sum,

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -11,9 +11,10 @@
 #include <cuda/ptx>                  // for get_sreg_laneid
 #include <cuda/std/functional>       // for identity
 #include <cuda/std/tuple>            // for get, make_tuple, tuple
-#include <limits>
-#include <type_traits>  // for is_trivially_copyable_v
-#include <vector>       // for vector
+#include <limits>                    // for numeric_limits
+#include <memory>                    // for make_unique
+#include <type_traits>               // for is_trivially_copyable_v
+#include <vector>                    // for vector
 
 #include "../../common/cuda_context.cuh"
 #include "../tree_view.h"             // for MultiTargetTreeView
@@ -447,7 +448,8 @@ void MultiHistEvaluator::Reset(Context const *ctx,
   CHECK_GT(feature_segments.size(), 0);
   CHECK_GT(n_targets, 0);
   auto n_features = static_cast<bst_feature_t>(feature_segments.size() - 1);
-  this->tree_evaluator_ = TreeEvaluator{param, n_features, ctx->Device(), n_targets};
+  this->tree_evaluator_ =
+      std::make_unique<TreeEvaluator>(param, n_features, ctx->Device(), n_targets);
   this->need_sort_histogram_ = false;
   if (feature_types.empty()) {
     return;
@@ -548,7 +550,7 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
                                         bst_node_t max_nidx,
                                         common::Span<MultiExpandEntry> out_splits) {
   auto n_targets = shared_inputs.Targets();
-  auto evaluator = this->GetEvaluator();
+  auto evaluator = this->GetEvaluator(true);
   CHECK_GT(n_targets, 0);
   CHECK_EQ(n_targets, evaluator.n_targets);
   CHECK_EQ(n_targets, shared_inputs.roundings.size());
@@ -752,7 +754,7 @@ void MultiHistEvaluator::ApplyTreeSplit(Context const *ctx, RegTree const *p_tre
                                         bst_target_t n_targets) {
   CHECK_EQ(h_candidates.size(), d_candidates.size());
   CHECK(!h_candidates.empty());
-  CHECK_EQ(n_targets, this->GetEvaluator().n_targets);
+  CHECK_EQ(n_targets, this->GetEvaluator(true).n_targets);
 
   auto h_tree = p_tree->HostMtView();
   auto weights = this->GetNodeWeights(n_targets);
@@ -761,9 +763,9 @@ void MultiHistEvaluator::ApplyTreeSplit(Context const *ctx, RegTree const *p_tre
     auto right = h_tree.RightChild(candidate.nidx);
     common::Span<float const> left_weight = weights.Left(candidate.nidx);
     common::Span<float const> right_weight = weights.Right(candidate.nidx);
-    this->tree_evaluator_.AddSplit(candidate.nidx, left, right, candidate.split.findex,
-                                   linalg::MakeVec(ctx->Device(), left_weight),
-                                   linalg::MakeVec(ctx->Device(), right_weight));
+    this->tree_evaluator_->AddSplit(candidate.nidx, left, right, candidate.split.findex,
+                                    linalg::MakeVec(ctx->Device(), left_weight),
+                                    linalg::MakeVec(ctx->Device(), right_weight));
   }
 
   // Assign the node sums here, for the next evaluate split call.

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -204,9 +204,7 @@ struct QuantizedGradientDifference {
 
   [[nodiscard]] XGBOOST_DEVICE std::size_t Size() const { return roundings.size(); }
   [[nodiscard]] XGBOOST_DEVICE GradientPairPrecise operator()(std::size_t t) const {
-    auto parent_t = roundings.data()[t].ToFloatingPoint(parent[t]);
-    auto child_t = roundings.data()[t].ToFloatingPoint(child[t]);
-    return parent_t - child_t;
+    return roundings.data()[t].ToFloatingPoint(parent[t] - child[t]);
   }
 };
 
@@ -445,10 +443,11 @@ __global__ __launch_bounds__(kBlockThreads) void EvaluateSplitsKernel(
 void MultiHistEvaluator::Reset(Context const *ctx,
                                common::Span<std::uint32_t const> feature_segments,
                                common::Span<FeatureType const> feature_types,
-                               TrainParam const &param) {
+                               TrainParam const &param, bst_target_t n_targets) {
   CHECK_GT(feature_segments.size(), 0);
+  CHECK_GT(n_targets, 0);
   auto n_features = static_cast<bst_feature_t>(feature_segments.size() - 1);
-  this->tree_evaluator_ = TreeEvaluator{param, n_features, ctx->Device()};
+  this->tree_evaluator_ = TreeEvaluator{param, n_features, ctx->Device(), n_targets};
   this->need_sort_histogram_ = false;
   if (feature_types.empty()) {
     return;
@@ -522,7 +521,7 @@ void SortHistogram(Context const *ctx, MultiEvaluateSplitSharedInputs const &sha
           auto child_sum = quantizer.ToFloatingPoint(target_hist[bin_idx]);
           auto parent_sum = quantizer.ToFloatingPoint(node.parent_sum[t]);
           auto child_weight = evaluator.CalcWeightCat(shared_inputs.param, child_sum);
-          auto parent_weight = evaluator.CalcWeight(node.nidx, shared_inputs.param, parent_sum);
+          auto parent_weight = evaluator.CalcWeightCat(shared_inputs.param, parent_sum);
           sc += child_weight * parent_weight;
         }
         return cuda::std::make_tuple(nidx_in_set, fidx, sc);
@@ -551,6 +550,8 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   auto n_targets = shared_inputs.Targets();
   auto evaluator = this->GetEvaluator();
   CHECK_GT(n_targets, 0);
+  CHECK_EQ(n_targets, evaluator.n_targets);
+  CHECK_EQ(n_targets, shared_inputs.roundings.size());
   CHECK_GE(shared_inputs.n_total_bins_per_tar, 1);
   auto n_features = shared_inputs.max_active_feature;
   CHECK_GE(n_features, 1);
@@ -667,7 +668,7 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     double parent_hess = 0;
     for (bst_target_t t = 0; t < n_targets; ++t) {
       auto g = roundings[t].ToFloatingPoint(input.parent_sum[t]);
-      base_weight[t] = evaluator.CalcWeight(nidx, shared_inputs.param, g);
+      base_weight[t] = evaluator.CalcWeight(nidx, t, shared_inputs.param, g);
       parent_hess += g.GetHess();
     }
 
@@ -711,30 +712,28 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     // The child_sum span in best_split points to scan_buffer_ which gets reused,
     // so we store it persistently indexed by node id.
     auto split_sum_dest = GetNodeSumImpl(d_split_sums, nidx, n_targets);
+    QuantizedGradientSum child{split_sum.data(), roundings};
+    QuantizedGradientDifference sibling{input.parent_sum.data(), split_sum.data(), roundings};
 
     double left_hess = 0, right_hess = 0;  // Sum of child hessians across all targets
 
     for (bst_target_t t = 0; t < n_targets; ++t) {
-      auto quantizer = roundings[t];
-      auto sibling_sum = input.parent_sum[t] - split_sum[t];
-
       split_sum_dest[t] = split_sum[t];
 
-      // Left/right weights
       GradientPairPrecise lg, rg;
       if (best_split.dir == kRightDir) {
         // forward pass, split_sum is the left sum
-        lg = quantizer.ToFloatingPoint(split_sum[t]);
-        left_weight[t] = evaluator.CalcWeight(nidx, shared_inputs.param, lg);
-        rg = quantizer.ToFloatingPoint(sibling_sum);
-        right_weight[t] = evaluator.CalcWeight(nidx, shared_inputs.param, rg);
+        lg = child(t);
+        rg = sibling(t);
       } else {
         // backward pass, split_sum is the right sum
-        rg = quantizer.ToFloatingPoint(split_sum[t]);
-        right_weight[t] = evaluator.CalcWeight(nidx, shared_inputs.param, rg);
-        lg = quantizer.ToFloatingPoint(sibling_sum);
-        left_weight[t] = evaluator.CalcWeight(nidx, shared_inputs.param, lg);
+        lg = sibling(t);
+        rg = child(t);
       }
+      auto [lw, rw] =
+          evaluator.CalcSplitWeights(shared_inputs.param, nidx, best_split.findex, t, lg, rg);
+      left_weight[t] = lw;
+      right_weight[t] = rw;
 
       left_hess += lg.GetHess();
       right_hess += rg.GetHess();
@@ -748,8 +747,25 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
 }
 
 void MultiHistEvaluator::ApplyTreeSplit(Context const *ctx, RegTree const *p_tree,
+                                        common::Span<MultiExpandEntry const> h_candidates,
                                         common::Span<MultiExpandEntry const> d_candidates,
                                         bst_target_t n_targets) {
+  CHECK_EQ(h_candidates.size(), d_candidates.size());
+  CHECK(!h_candidates.empty());
+  CHECK_EQ(n_targets, this->GetEvaluator().n_targets);
+
+  auto h_tree = p_tree->HostMtView();
+  auto weights = this->GetNodeWeights(n_targets);
+  for (auto const &candidate : h_candidates) {
+    auto left = h_tree.LeftChild(candidate.nidx);
+    auto right = h_tree.RightChild(candidate.nidx);
+    common::Span<float const> left_weight = weights.Left(candidate.nidx);
+    common::Span<float const> right_weight = weights.Right(candidate.nidx);
+    this->tree_evaluator_.AddSplit(candidate.nidx, left, right, candidate.split.findex,
+                                   linalg::MakeVec(ctx->Device(), left_weight),
+                                   linalg::MakeVec(ctx->Device(), right_weight));
+  }
+
   // Assign the node sums here, for the next evaluate split call.
   auto mt_tree = MultiTargetTreeView{ctx->Device(), false, p_tree};
   auto max_in_it = dh::MakeIndexTransformIter([=] __device__(std::size_t i) -> bst_node_t {

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -218,15 +218,17 @@ struct EvaluateSplitAgent {
 
   typename MaxReduceT::TempStorage *temp_storage;
   bst_feature_t fidx;
-  TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator;
+  TreeEvaluator::SplitEvaluator<EvalParam> evaluator;
 
   // Calculate the split gain for one bin. `child_scan` has the bin-major layout
   // [bins][targets] and stores the non-missing child sum.
   template <DefaultDirection d_dir>
-  static __device__ double ComputeGain(
-      MultiEvaluateSplitInputs const &node, MultiEvaluateSplitSharedInputs const &shared,
-      common::Span<GradientPairInt64 const> child_scan, bst_bin_t bin_idx, bst_target_t n_targets,
-      bst_feature_t fidx, TreeEvaluator::SplitEvaluator<GPUTrainingParam> const &evaluator) {
+  static __device__ double ComputeGain(MultiEvaluateSplitInputs const &node,
+                                       MultiEvaluateSplitSharedInputs const &shared,
+                                       common::Span<GradientPairInt64 const> child_scan,
+                                       bst_bin_t bin_idx, bst_target_t n_targets,
+                                       bst_feature_t fidx,
+                                       TreeEvaluator::SplitEvaluator<EvalParam> const &evaluator) {
     auto offset = bin_idx * n_targets;
     auto child_values = child_scan.subspan(offset, n_targets);
     QuantizedGradientSum child{child_values.data(), shared.roundings};
@@ -385,7 +387,7 @@ template <std::int32_t kBlockThreads>
 __global__ __launch_bounds__(kBlockThreads) void EvaluateSplitsKernel(
     common::Span<MultiEvaluateSplitInputs const> nodes, MultiEvaluateSplitSharedInputs shared,
     common::Span<common::Span<GradientPairInt64>> bin_scans,
-    TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
+    TreeEvaluator::SplitEvaluator<EvalParam> evaluator,
     common::Span<MultiSplitCandidate> out_candidates) {
   static_assert(kBlockThreads % dh::WarpThreads() == 0);
 
@@ -484,7 +486,7 @@ namespace {
 // Sort histogram based on projected score, see CPU implementation for details.
 void SortHistogram(Context const *ctx, MultiEvaluateSplitSharedInputs const &shared_inputs,
                    common::Span<MultiEvaluateSplitInputs const> d_inputs,
-                   TreeEvaluator::SplitEvaluator<GPUTrainingParam> evaluator,
+                   TreeEvaluator::SplitEvaluator<EvalParam> evaluator,
                    dh::device_vector<std::size_t> *p_sorted_idx) {
   auto &sorted_idx = *p_sorted_idx;
   auto n_nodes = d_inputs.size();
@@ -550,7 +552,7 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
                                         bst_node_t max_nidx,
                                         common::Span<MultiExpandEntry> out_splits) {
   auto n_targets = shared_inputs.Targets();
-  auto evaluator = this->GetEvaluator(true);
+  auto evaluator = this->GetEvaluator();
   CHECK_GT(n_targets, 0);
   CHECK_EQ(n_targets, evaluator.n_targets);
   CHECK_EQ(n_targets, shared_inputs.roundings.size());
@@ -754,7 +756,7 @@ void MultiHistEvaluator::ApplyTreeSplit(Context const *ctx, RegTree const *p_tre
                                         bst_target_t n_targets) {
   CHECK_EQ(h_candidates.size(), d_candidates.size());
   CHECK(!h_candidates.empty());
-  CHECK_EQ(n_targets, this->GetEvaluator(true).n_targets);
+  CHECK_EQ(n_targets, this->GetEvaluator().n_targets);
 
   auto h_tree = p_tree->HostMtView();
   auto weights = this->GetNodeWeights(n_targets);

--- a/src/tree/gpu_hist/multi_evaluate_splits.cuh
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cuh
@@ -2,6 +2,7 @@
  * Copyright 2025-2026, XGBoost contributors
  */
 #pragma once
+#include <memory>  // for unique_ptr
 
 #include "../../common/device_vector.cuh"  // for device_vector
 #include "evaluate_splits.cuh"             // for MultiEvaluateSplitSharedInputs
@@ -68,7 +69,7 @@ class MultiHistEvaluator {
   };
 
  private:
-  TreeEvaluator tree_evaluator_;
+  std::unique_ptr<TreeEvaluator> tree_evaluator_{nullptr};
   // Persistent buffer for node weights, indexed by node id.
   dh::DeviceUVector<float> node_weights_;
   // Buffer for histogram scans.
@@ -99,15 +100,12 @@ class MultiHistEvaluator {
   }
 
  public:
-  MultiHistEvaluator(TrainParam const &param, bst_feature_t n_features, DeviceOrd device)
-      : tree_evaluator_{param, n_features, device} {}
-
   void Reset(Context const *ctx, common::Span<std::uint32_t const> feature_segments,
              common::Span<FeatureType const> feature_types, TrainParam const &param,
              bst_target_t n_targets);
 
-  [[nodiscard]] auto GetEvaluator(bool use_constraint = true) const {
-    return tree_evaluator_.GetEvaluator<GPUTrainingParam>(use_constraint);
+  [[nodiscard]] auto GetEvaluator(bool use_constraint) const {
+    return tree_evaluator_->GetEvaluator<GPUTrainingParam>(use_constraint);
   }
 
   /**

--- a/src/tree/gpu_hist/multi_evaluate_splits.cuh
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cuh
@@ -103,10 +103,11 @@ class MultiHistEvaluator {
       : tree_evaluator_{param, n_features, device} {}
 
   void Reset(Context const *ctx, common::Span<std::uint32_t const> feature_segments,
-             common::Span<FeatureType const> feature_types, TrainParam const &param);
+             common::Span<FeatureType const> feature_types, TrainParam const &param,
+             bst_target_t n_targets);
 
-  [[nodiscard]] auto GetEvaluator() const {
-    return tree_evaluator_.GetEvaluator<GPUTrainingParam>();
+  [[nodiscard]] auto GetEvaluator(bool use_constraint = true) const {
+    return tree_evaluator_.GetEvaluator<GPUTrainingParam>(use_constraint);
   }
 
   /**
@@ -177,6 +178,7 @@ class MultiHistEvaluator {
 
   // Update the tree evaluator state and track child gradient sums.
   void ApplyTreeSplit(Context const *ctx, RegTree const *p_tree,
+                      common::Span<MultiExpandEntry const> h_candidates,
                       common::Span<MultiExpandEntry const> d_candidates, bst_target_t n_targets);
 };
 }  // namespace xgboost::tree::cuda_impl

--- a/src/tree/gpu_hist/multi_evaluate_splits.cuh
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cuh
@@ -104,8 +104,8 @@ class MultiHistEvaluator {
              common::Span<FeatureType const> feature_types, TrainParam const &param,
              bst_target_t n_targets);
 
-  [[nodiscard]] auto GetEvaluator(bool use_constraint) const {
-    return tree_evaluator_->GetEvaluator<GPUTrainingParam>(use_constraint);
+  [[nodiscard]] auto GetEvaluator() const {
+    return tree_evaluator_->GetEvaluator<EvalParam>();
   }
 
   /**

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -904,7 +904,9 @@ class HistMultiEvaluator {
                           param_->colsample_bylevel, param_->colsample_bytree);
   }
 
-  [[nodiscard]] auto Evaluator() const { return tree_evaluator_.GetEvaluator(); }
+  [[nodiscard]] auto Evaluator(bool use_constraint = true) const {
+    return tree_evaluator_.GetEvaluator(use_constraint);
+  }
 };
 
 /**

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -822,12 +822,12 @@ class HistMultiEvaluator {
     auto left_weight = weight.Slice(1, linalg::All());
     auto left_sum =
         linalg::MakeVec(candidate.split.left_sum.data(), candidate.split.left_sum.size());
-    evaluator.CalcWeight(candidate.nid, *param_, left_sum, left_weight);
 
     auto right_weight = weight.Slice(2, linalg::All());
     auto right_sum =
         linalg::MakeVec(candidate.split.right_sum.data(), candidate.split.right_sum.size());
-    evaluator.CalcWeight(candidate.nid, *param_, right_sum, right_weight);
+    evaluator.CalcSplitWeights(*param_, candidate.nid, candidate.split.SplitIndex(), left_sum,
+                               right_sum, left_weight, right_weight);
 
     auto leaf_weight = linalg::Empty<float>(ctx_, 2, n_split_targets);
     auto left_leaf_weight = leaf_weight.Slice(0, linalg::All());
@@ -867,6 +867,8 @@ class HistMultiEvaluator {
     auto right_child = mt_tree.RightChild(candidate.nid);
     CHECK_GT(right_child, candidate.nid);
 
+    tree_evaluator_.AddSplit(candidate.nid, left_child, right_child, candidate.split.SplitIndex(),
+                             left_weight, right_weight);
     evaluator = tree_evaluator_.GetEvaluator();
     interaction_constraints_.Split(candidate.nid, candidate.split.SplitIndex(), left_child,
                                    right_child);
@@ -889,9 +891,11 @@ class HistMultiEvaluator {
   }
 
   explicit HistMultiEvaluator(Context const *ctx, MetaInfo const &info, TrainParam const *param,
+                              bst_target_t n_targets,
                               std::shared_ptr<common::ColumnSampler> sampler)
       : param_{param},
-        tree_evaluator_{*param, static_cast<bst_feature_t>(info.num_col_), DeviceOrd::CPU()},
+        tree_evaluator_{*param, static_cast<bst_feature_t>(info.num_col_), DeviceOrd::CPU(),
+                        n_targets},
         column_sampler_{std::move(sampler)},
         ctx_{ctx},
         is_col_split_{info.IsColumnSplit()} {

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -703,7 +703,7 @@ class HistMultiEvaluator {
       auto parent_sum = stats_.Slice(entry->nid, linalg::All());
       auto base_weight = linalg::Zeros<float>(ctx_, parent_sum.Shape());
       auto h_bw = base_weight.HostView();
-      evaluator.CalcWeight(entry->nid, *param_, parent_sum, h_bw);
+      evaluator.CalcWeightCat(*param_, parent_sum, h_bw);
 
       std::vector<common::ConstGHistRow> node_hist;
       for (auto t_hist : hist) {
@@ -755,8 +755,8 @@ class HistMultiEvaluator {
             auto f_hist = node_hist[t_idx].subspan(cut_ptr[fidx], n_bins);
             h_grads(t_idx) = f_hist[bin_idx];
           }
-          evaluator.CalcWeight(entry->nid, *param_, h_grads,
-                               linalg::MakeVec(child_w.data(), child_w.size()));
+          evaluator.CalcWeightCat(*param_, h_grads,
+                                  linalg::MakeVec(child_w.data(), child_w.size()));
           double sc = .0;
           for (decltype(n_targets) t_idx = 0; t_idx < n_targets; ++t_idx) {
             sc += h_bw(t_idx) * child_w[t_idx];

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -904,9 +904,7 @@ class HistMultiEvaluator {
                           param_->colsample_bylevel, param_->colsample_bytree);
   }
 
-  [[nodiscard]] auto Evaluator(bool use_constraint = true) const {
-    return tree_evaluator_.GetEvaluator(use_constraint);
-  }
+  [[nodiscard]] auto Evaluator() const { return tree_evaluator_.GetEvaluator(); }
 };
 
 /**

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -461,7 +461,7 @@ class HistEvaluator {
       : ctx_{ctx},
         param_{param},
         column_sampler_{std::move(sampler)},
-        tree_evaluator_{*param, static_cast<bst_feature_t>(info.num_col_), DeviceOrd::CPU()},
+        tree_evaluator_{*param, static_cast<bst_feature_t>(info.num_col_), DeviceOrd::CPU(), 1u},
         is_col_split_{info.IsColumnSplit()} {
     interaction_constraints_.Configure(*param, info.num_col_);
     column_sampler_->Init(ctx, info.num_col_, info.feature_weights, param_->colsample_bynode,

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -7,7 +7,7 @@
 #ifndef XGBOOST_TREE_PARAM_H_
 #define XGBOOST_TREE_PARAM_H_
 
-#include <algorithm>
+#include <algorithm>  // for copy
 #include <cmath>
 #include <cstring>
 #include <string>
@@ -207,14 +207,6 @@ struct TrainParam : public XGBoostParameter<TrainParam> {
   }
 };
 
-inline void NoMonotoneConstraints(TrainParam const *param, StringView name) {
-  if (!param->monotone_constraints.empty() &&
-      std::any_of(param->monotone_constraints.cbegin(), param->monotone_constraints.cend(),
-                  [](auto v) { return v != 0; })) {
-    LOG(FATAL) << "Monotonic constraint is not supported by the " << name << ".";
-  }
-}
-
 /**
  * @brief Whether both children satisfy the Hessian requirement for a split.
  *
@@ -225,8 +217,6 @@ XGBOOST_DEVICE bool IsValidSplit(TrainingParams const &p, T left_hess, T right_h
   return left_hess > 0.0 && right_hess > 0.0 && left_hess >= p.min_child_weight &&
          right_hess >= p.min_child_weight;
 }
-
-/*! \brief Loss functions */
 
 /**
  * @brief Function for L1 cost

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -247,14 +247,6 @@ XGBOOST_DEVICE T0 CalcGainGivenWeight(TrainingParams const &p, T0 sum_grad, T0 s
            (static_cast<T0>(2.0) * p.reg_alpha * std::abs(w)));
 }
 
-template <typename TrainingParams, typename T>
-XGBOOST_DEVICE T ThresholdDeltaStep(TrainingParams const &p, T dw) {
-  if (p.max_delta_step != 0.0f && ::fabs(dw) > p.max_delta_step) {
-    dw = ::copysign(p.max_delta_step, dw);
-  }
-  return dw;
-}
-
 // calculate weight given the statistics
 template <typename TrainingParams, typename T>
 XGBOOST_DEVICE std::enable_if_t<std::is_floating_point_v<T>, T> CalcWeight(TrainingParams const &p,
@@ -263,7 +255,10 @@ XGBOOST_DEVICE std::enable_if_t<std::is_floating_point_v<T>, T> CalcWeight(Train
     return 0.0;
   }
   T dw = -ThresholdL1(sum_grad, p.reg_alpha) / (sum_hess + p.reg_lambda);
-  return ThresholdDeltaStep(p, dw);
+  if (p.max_delta_step != 0.0f && ::fabs(dw) > p.max_delta_step) {
+    dw = ::copysign(p.max_delta_step, dw);
+  }
+  return dw;
 }
 
 // calculate the cost of loss function

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -247,6 +247,14 @@ XGBOOST_DEVICE T0 CalcGainGivenWeight(TrainingParams const &p, T0 sum_grad, T0 s
            (static_cast<T0>(2.0) * p.reg_alpha * std::abs(w)));
 }
 
+template <typename TrainingParams, typename T>
+XGBOOST_DEVICE T ThresholdDeltaStep(TrainingParams const &p, T dw) {
+  if (p.max_delta_step != 0.0f && ::fabs(dw) > p.max_delta_step) {
+    dw = ::copysign(p.max_delta_step, dw);
+  }
+  return dw;
+}
+
 // calculate weight given the statistics
 template <typename TrainingParams, typename T>
 XGBOOST_DEVICE std::enable_if_t<std::is_floating_point_v<T>, T> CalcWeight(TrainingParams const &p,
@@ -255,10 +263,7 @@ XGBOOST_DEVICE std::enable_if_t<std::is_floating_point_v<T>, T> CalcWeight(Train
     return 0.0;
   }
   T dw = -ThresholdL1(sum_grad, p.reg_alpha) / (sum_hess + p.reg_lambda);
-  if (p.max_delta_step != 0.0f && ::fabs(dw) > p.max_delta_step) {
-    dw = ::copysign(p.max_delta_step, dw);
-  }
-  return dw;
+  return ThresholdDeltaStep(p, dw);
 }
 
 // calculate the cost of loss function

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -7,7 +7,7 @@
 #ifndef XGBOOST_TREE_PARAM_H_
 #define XGBOOST_TREE_PARAM_H_
 
-#include <algorithm>  // for copy
+#include <algorithm>  // for copy, any_of
 #include <cmath>
 #include <cstring>
 #include <string>
@@ -204,6 +204,11 @@ struct TrainParam : public XGBoostParameter<TrainParam> {
     }
     CHECK_GT(n_nodes, 0);
     return n_nodes;
+  }
+
+  [[nodiscard]] bool HasMonotone() const {
+    return std::any_of(this->monotone_constraints.cbegin(), this->monotone_constraints.cend(),
+                       [](auto v) { return v != 0; });
   }
 };
 

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -116,9 +116,7 @@ class TreeEvaluator {
       }
     }
 
-    // If the independent bounded optima violate the required order, the constrained minimum is
-    // on wleft = wright. Minimize both child objectives there by adding their gradients/Hessians,
-    // counting L1/L2 penalties twice, and clamping the shared solution to the inherited bounds.
+    // See the sphinx document about monotone constraint for how this works.
     template <typename LeftGradientSumT, typename RightGradientSumT,
               split_impl::EnableScaGrad<LeftGradientSumT, RightGradientSumT> = 0>
     [[nodiscard]] XGBOOST_DEVICE std::tuple<float, float> CalcSplitWeights(
@@ -144,10 +142,7 @@ class TreeEvaluator {
         auto sum_grad = left.GetGrad() + right.GetGrad();
         auto dw =
             -ThresholdL1(sum_grad, 2.0f * param.reg_alpha) / (sum_hess + 2.0f * param.reg_lambda);
-        if (param.max_delta_step != 0.0f && ::fabs(dw) > param.max_delta_step) {
-          dw = ::copysign(param.max_delta_step, dw);
-        }
-        pooled = dw;
+        pooled = ThresholdDeltaStep(param, dw);
       }
       pooled = this->ApplyBounds(nidx, target, pooled);
       return {pooled, pooled};

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -63,7 +63,7 @@ class TreeEvaluator {
  public:
   TreeEvaluator(TrainParam const& p, bst_feature_t n_features, DeviceOrd device,
                 bst_target_t n_targets)
-      : device_{device}, n_targets_{n_targets} {
+      : device_{device}, n_targets_{n_targets}, has_constraint_{p.HasMonotone()} {
     CHECK_GT(n_targets, 0);
     if (device.IsCUDA()) {
       lower_bounds_.SetDevice(device);
@@ -77,8 +77,7 @@ class TreeEvaluator {
     }
     monotone_.HostVector() = p.monotone_constraints;
     monotone_.HostVector().resize(n_features, 0);
-    has_constraint_ = std::any_of(p.monotone_constraints.cbegin(), p.monotone_constraints.cend(),
-                                  [](auto v) { return v != 0; });
+
     if (has_constraint_) {
       // Initialised to some small size, can grow if needed
       lower_bounds_.Resize(256 * n_targets, -std::numeric_limits<float>::max());

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -41,6 +41,33 @@ template <typename... T>
 using EnableScaGrad = std::enable_if_t<!(split_impl::IsVectorGradientSum<T>::value || ...), int>;
 }  // namespace split_impl
 
+struct EvalParam {
+  // minimum amount of hessian(weight) allowed in a child
+  float min_child_weight;
+  // L2 regularization factor
+  float reg_lambda;
+  // L1 regularization factor
+  float reg_alpha;
+  // maximum delta update we can add in weight estimation
+  // this parameter can be used to stabilize update
+  // default=0 means no constraint on weight delta
+  float max_delta_step;
+  float learning_rate;
+  std::uint32_t max_cat_to_onehot;
+  bst_bin_t max_cat_threshold;
+
+  EvalParam() = default;
+
+  XGBOOST_DEVICE explicit EvalParam(const TrainParam& param)
+      : min_child_weight(param.min_child_weight),
+        reg_lambda(param.reg_lambda),
+        reg_alpha(param.reg_alpha),
+        max_delta_step(param.max_delta_step),
+        learning_rate{param.learning_rate},
+        max_cat_to_onehot{param.max_cat_to_onehot},
+        max_cat_threshold{param.max_cat_threshold} {}
+};
+
 class TreeEvaluator {
   HostDeviceVector<float> lower_bounds_;
   HostDeviceVector<float> upper_bounds_;
@@ -119,6 +146,22 @@ class TreeEvaluator {
     // See the sphinx document about monotone constraint for how this works.
     template <typename LeftGradientSumT, typename RightGradientSumT,
               split_impl::EnableScaGrad<LeftGradientSumT, RightGradientSumT> = 0>
+    [[nodiscard]] XGBOOST_DEVICE auto CalcPooledWeight(ParamT const& param, bst_node_t nidx,
+                                                       bst_target_t target,
+                                                       LeftGradientSumT const& left,
+                                                       RightGradientSumT const& right) const {
+      // The common value still represents two leaves, each with its own regularization penalty.
+      EvalParam p;
+      p.reg_alpha = 2.0f * param.reg_alpha;
+      p.reg_lambda = 2.0f * param.reg_lambda;
+      p.max_delta_step = param.max_delta_step;
+      auto pooled_weight = ::xgboost::tree::CalcWeight(p, left.GetGrad() + right.GetGrad(),
+                                                       left.GetHess() + right.GetHess());
+      return this->ApplyBounds(nidx, target, pooled_weight);
+    }
+
+    template <typename LeftGradientSumT, typename RightGradientSumT,
+              split_impl::EnableScaGrad<LeftGradientSumT, RightGradientSumT> = 0>
     [[nodiscard]] XGBOOST_DEVICE std::tuple<float, float> CalcSplitWeights(
         ParamT const& param, bst_node_t nidx, bst_feature_t fidx, bst_target_t target,
         LeftGradientSumT const& left, RightGradientSumT const& right) const {
@@ -136,15 +179,7 @@ class TreeEvaluator {
         return {wleft, wright};
       }
 
-      auto sum_hess = left.GetHess() + right.GetHess();
-      float pooled{0.0f};
-      if (sum_hess > 0.0) {
-        auto sum_grad = left.GetGrad() + right.GetGrad();
-        auto dw =
-            -ThresholdL1(sum_grad, 2.0f * param.reg_alpha) / (sum_hess + 2.0f * param.reg_lambda);
-        pooled = ThresholdDeltaStep(param, dw);
-      }
-      pooled = this->ApplyBounds(nidx, target, pooled);
+      auto pooled = this->CalcPooledWeight(param, nidx, target, left, right);
       return {pooled, pooled};
     }
 
@@ -310,16 +345,16 @@ class TreeEvaluator {
  public:
   /* Get a view to the evaluator that can be passed down to device. */
   template <typename ParamT = TrainParam>
-  auto GetEvaluator(bool use_constraint = true) const {
-    auto has_constraint = has_constraint_ && use_constraint;
+  auto GetEvaluator() const {
     if (device_.IsCUDA()) {
       auto constraints = monotone_.ConstDevicePointer();
       return SplitEvaluator<ParamT>{constraints, lower_bounds_.ConstDevicePointer(),
-                                    upper_bounds_.ConstDevicePointer(), has_constraint, n_targets_};
+                                    upper_bounds_.ConstDevicePointer(), has_constraint_,
+                                    n_targets_};
     } else {
       auto constraints = monotone_.ConstHostPointer();
       return SplitEvaluator<ParamT>{constraints, lower_bounds_.ConstHostPointer(),
-                                    upper_bounds_.ConstHostPointer(), has_constraint, n_targets_};
+                                    upper_bounds_.ConstHostPointer(), has_constraint_, n_targets_};
     }
   }
 

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -364,15 +364,16 @@ class TreeEvaluator {
         .Eval(&lower_bounds_, &upper_bounds_, &monotone_);
   }
 
+  template <bool CompiledWithCuda = WITH_CUDA()>
   void AddSplit(bst_node_t nodeid, bst_node_t leftid, bst_node_t rightid, bst_feature_t f,
                 linalg::VectorView<float const> left_weight,
                 linalg::VectorView<float const> right_weight) {
     if (!has_constraint_) {
       return;
     }
-    CHECK(device_.IsCPU());
-    auto n_targets = left_weight.Size();
-    CHECK_EQ(right_weight.Size(), n_targets);
+    CHECK_EQ(left_weight.Size(), n_targets_);
+    CHECK_EQ(right_weight.Size(), n_targets_);
+    auto n_targets = n_targets_;
 
     auto max_nidx = std::max(leftid, rightid);
     this->EnsureBounds(max_nidx, n_targets);

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -62,7 +62,7 @@ class TreeEvaluator {
 
  public:
   TreeEvaluator(TrainParam const& p, bst_feature_t n_features, DeviceOrd device,
-                bst_target_t n_targets = 1)
+                bst_target_t n_targets)
       : device_{device}, n_targets_{n_targets} {
     CHECK_GT(n_targets, 0);
     if (device.IsCUDA()) {

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -316,16 +316,16 @@ class TreeEvaluator {
  public:
   /* Get a view to the evaluator that can be passed down to device. */
   template <typename ParamT = TrainParam>
-  auto GetEvaluator() const {
+  auto GetEvaluator(bool use_constraint = true) const {
+    auto has_constraint = has_constraint_ && use_constraint;
     if (device_.IsCUDA()) {
       auto constraints = monotone_.ConstDevicePointer();
       return SplitEvaluator<ParamT>{constraints, lower_bounds_.ConstDevicePointer(),
-                                    upper_bounds_.ConstDevicePointer(), has_constraint_,
-                                    n_targets_};
+                                    upper_bounds_.ConstDevicePointer(), has_constraint, n_targets_};
     } else {
       auto constraints = monotone_.ConstHostPointer();
       return SplitEvaluator<ParamT>{constraints, lower_bounds_.ConstHostPointer(),
-                                    upper_bounds_.ConstHostPointer(), has_constraint_, n_targets_};
+                                    upper_bounds_.ConstHostPointer(), has_constraint, n_targets_};
     }
   }
 

--- a/src/tree/split_evaluator.h
+++ b/src/tree/split_evaluator.h
@@ -13,6 +13,7 @@
 #include <algorithm>    // for any_of
 #include <cstddef>      // for size_t
 #include <limits>       // for numeric_limits
+#include <tuple>        // for tuple
 #include <type_traits>  // for void_t, false_type, declval
 
 #include "../common/math.h"
@@ -45,11 +46,25 @@ class TreeEvaluator {
   HostDeviceVector<float> upper_bounds_;
   HostDeviceVector<int32_t> monotone_;
   DeviceOrd device_;
+  bst_target_t n_targets_;
   bool has_constraint_;
 
+  void EnsureBounds(bst_node_t max_nidx, bst_target_t n_targets) {
+    auto n_nodes = static_cast<std::size_t>(max_nidx) * 2 + 1;
+    auto n = n_nodes * n_targets;
+    if (lower_bounds_.Size() < n) {
+      lower_bounds_.Resize(n, -std::numeric_limits<float>::max());
+    }
+    if (upper_bounds_.Size() < n) {
+      upper_bounds_.Resize(n, std::numeric_limits<float>::max());
+    }
+  }
+
  public:
-  TreeEvaluator(TrainParam const& p, bst_feature_t n_features, DeviceOrd device) {
-    device_ = device;
+  TreeEvaluator(TrainParam const& p, bst_feature_t n_features, DeviceOrd device,
+                bst_target_t n_targets = 1)
+      : device_{device}, n_targets_{n_targets} {
+    CHECK_GT(n_targets, 0);
     if (device.IsCUDA()) {
       lower_bounds_.SetDevice(device);
       upper_bounds_.SetDevice(device);
@@ -66,8 +81,8 @@ class TreeEvaluator {
                                   [](auto v) { return v != 0; });
     if (has_constraint_) {
       // Initialised to some small size, can grow if needed
-      lower_bounds_.Resize(256, -std::numeric_limits<float>::max());
-      upper_bounds_.Resize(256, std::numeric_limits<float>::max());
+      lower_bounds_.Resize(256 * n_targets, -std::numeric_limits<float>::max());
+      upper_bounds_.Resize(256 * n_targets, std::numeric_limits<float>::max());
     }
 
     if (device_.IsCUDA()) {
@@ -81,9 +96,63 @@ class TreeEvaluator {
   template <typename ParamT>
   struct SplitEvaluator {
     const int* constraints;
-    const float* lower;
+    const float* lower;  // shape: (n_nodes, n_targets)
     const float* upper;
     bool has_constraint;
+    bst_target_t n_targets;
+
+    [[nodiscard]] XGBOOST_DEVICE float ApplyBounds(bst_node_t nidx, bst_target_t target,
+                                                   float w) const {
+      if (!has_constraint) {
+        return w;
+      }
+      std::size_t strides[2]{n_targets, 1};
+      auto idx = linalg::detail::Offset<0>(strides, 0, nidx, target);
+      if (w < lower[idx]) {
+        return lower[idx];
+      } else if (w > upper[idx]) {
+        return upper[idx];
+      } else {
+        return w;
+      }
+    }
+
+    // If the independent bounded optima violate the required order, the constrained minimum is
+    // on wleft = wright. Minimize both child objectives there by adding their gradients/Hessians,
+    // counting L1/L2 penalties twice, and clamping the shared solution to the inherited bounds.
+    template <typename LeftGradientSumT, typename RightGradientSumT,
+              split_impl::EnableScaGrad<LeftGradientSumT, RightGradientSumT> = 0>
+    [[nodiscard]] XGBOOST_DEVICE std::tuple<float, float> CalcSplitWeights(
+        ParamT const& param, bst_node_t nidx, bst_feature_t fidx, bst_target_t target,
+        LeftGradientSumT const& left, RightGradientSumT const& right) const {
+      auto wleft = this->CalcWeight(nidx, target, param, left);
+      auto wright = this->CalcWeight(nidx, target, param, right);
+
+      if (!has_constraint) {
+        return {wleft, wright};
+      }
+
+      auto constraint = constraints[fidx];
+      bool ordered = constraint == 0 || (constraint > 0 && wleft <= wright) ||
+                     (constraint < 0 && wleft >= wright);
+      if (ordered) {
+        return {wleft, wright};
+      }
+
+      auto sum_hess = left.GetHess() + right.GetHess();
+      float pooled{0.0f};
+      if (sum_hess > 0.0) {
+        auto sum_grad = left.GetGrad() + right.GetGrad();
+        auto dw =
+            -ThresholdL1(sum_grad, 2.0f * param.reg_alpha) / (sum_hess + 2.0f * param.reg_lambda);
+        if (param.max_delta_step != 0.0f && ::fabs(dw) > param.max_delta_step) {
+          dw = ::copysign(param.max_delta_step, dw);
+        }
+        pooled = dw;
+      }
+      pooled = this->ApplyBounds(nidx, target, pooled);
+      return {pooled, pooled};
+    }
 
     template <typename GradientSumT, split_impl::EnableScaGrad<GradientSumT> = 0>
     XGBOOST_DEVICE float CalcSplitGain(ParamT const& param, bst_node_t nidx, bst_feature_t fidx,
@@ -127,41 +196,64 @@ class TreeEvaluator {
         auto const right_t = right(t);
         left_hess += left_t.GetHess();
         right_hess += right_t.GetHess();
-        gain += tree::CalcGain(param, left_t.GetGrad(), left_t.GetHess());
-        gain += tree::CalcGain(param, right_t.GetGrad(), right_t.GetHess());
+        if (!has_constraint) {
+          gain += tree::CalcGain(param, left_t.GetGrad(), left_t.GetHess());
+          gain += tree::CalcGain(param, right_t.GetGrad(), right_t.GetHess());
+        }
       }
 
       auto k = static_cast<double>(n_targets);
       if (!IsValidSplit(param, left_hess / k, right_hess / k)) {
         return -std::numeric_limits<double>::infinity();
       }
+      if (!has_constraint) {
+        return gain;
+      }
+
+      for (std::size_t t = 0; t < n_targets; ++t) {
+        auto const left_t = left(t);
+        auto const right_t = right(t);
+        auto [l_w, r_w] = this->CalcSplitWeights(param, nidx, fidx, t, left_t, right_t);
+        gain += tree::CalcGainGivenWeight(param, left_t.GetGrad(), left_t.GetHess(), l_w);
+        gain += tree::CalcGainGivenWeight(param, right_t.GetGrad(), right_t.GetHess(), r_w);
+      }
       return gain;
     }
 
     // Weight
     template <typename GradientSumT, split_impl::EnableScaGrad<GradientSumT> = 0>
-    XGBOOST_DEVICE float CalcWeight(bst_node_t nidx, ParamT const& param,
+    XGBOOST_DEVICE float CalcWeight(bst_node_t nidx, bst_target_t target, ParamT const& param,
                                     GradientSumT const& stats) const {
       // boxed by max_delta_step
       float w = ::xgboost::tree::CalcWeight(param, stats);
-      if (!has_constraint) {
-        return w;
-      }
-      // Calculate bound weight, boxed by monotone constraint
-      if (w < lower[nidx]) {
-        return lower[nidx];
-      } else if (w > upper[nidx]) {
-        return upper[nidx];
-      } else {
-        return w;
-      }
+      return this->ApplyBounds(nidx, target, w);
+    }
+
+    template <typename GradientSumT, split_impl::EnableScaGrad<GradientSumT> = 0>
+    XGBOOST_DEVICE float CalcWeight(bst_node_t nidx, ParamT const& param,
+                                    GradientSumT const& stats) const {
+      return this->CalcWeight(nidx, 0, param, stats);
     }
 
     template <typename GradientSumT, split_impl::EnableVecGrad<GradientSumT> = 0>
     XGBOOST_DEVICE void CalcWeight(bst_node_t nidx, ParamT const& param, GradientSumT const& stats,
                                    linalg::VectorView<float> out) const {
       for (std::size_t t = 0; t < stats.Size(); ++t) {
-        out(t) = this->CalcWeight(nidx, param, stats(t));
+        out(t) = this->CalcWeight(nidx, t, param, stats(t));
+      }
+    }
+
+    template <typename LeftGradientSumT, typename RightGradientSumT,
+              split_impl::EnableVecGrad<LeftGradientSumT, RightGradientSumT> = 0>
+    XGBOOST_DEVICE void CalcSplitWeights(ParamT const& param, bst_node_t nidx, bst_feature_t fidx,
+                                         LeftGradientSumT const& left,
+                                         RightGradientSumT const& right,
+                                         linalg::VectorView<float> left_weight,
+                                         linalg::VectorView<float> right_weight) const {
+      for (std::size_t t = 0; t < left.Size(); ++t) {
+        auto [l_w, r_w] = this->CalcSplitWeights(param, nidx, fidx, t, left(t), right(t));
+        left_weight(t) = l_w;
+        right_weight(t) = r_w;
       }
     }
 
@@ -214,7 +306,7 @@ class TreeEvaluator {
       double gain{0.0};
       for (std::size_t t = 0, n_targets = stats.Size(); t < n_targets; ++t) {
         auto const stats_t = stats(t);
-        auto weight = this->CalcWeight(nidx, p, stats_t);
+        auto weight = this->CalcWeight(nidx, t, p, stats_t);
         gain += tree::CalcGainGivenWeight(p, stats_t.GetGrad(), stats_t.GetHess(), weight);
       }
       return gain;
@@ -228,11 +320,12 @@ class TreeEvaluator {
     if (device_.IsCUDA()) {
       auto constraints = monotone_.ConstDevicePointer();
       return SplitEvaluator<ParamT>{constraints, lower_bounds_.ConstDevicePointer(),
-                                    upper_bounds_.ConstDevicePointer(), has_constraint_};
+                                    upper_bounds_.ConstDevicePointer(), has_constraint_,
+                                    n_targets_};
     } else {
       auto constraints = monotone_.ConstHostPointer();
       return SplitEvaluator<ParamT>{constraints, lower_bounds_.ConstHostPointer(),
-                                    upper_bounds_.ConstHostPointer(), has_constraint_};
+                                    upper_bounds_.ConstHostPointer(), has_constraint_, n_targets_};
     }
   }
 
@@ -243,13 +336,8 @@ class TreeEvaluator {
       return;
     }
 
-    size_t max_nidx = std::max(leftid, rightid);
-    if (lower_bounds_.Size() <= max_nidx) {
-      lower_bounds_.Resize(max_nidx * 2 + 1, -std::numeric_limits<float>::max());
-    }
-    if (upper_bounds_.Size() <= max_nidx) {
-      upper_bounds_.Resize(max_nidx * 2 + 1, std::numeric_limits<float>::max());
-    }
+    auto max_nidx = std::max(leftid, rightid);
+    this->EnsureBounds(max_nidx, 1u);
 
     common::Transform<>::Init(
         [=] XGBOOST_DEVICE(size_t, common::Span<float> lower, common::Span<float> upper,
@@ -273,6 +361,47 @@ class TreeEvaluator {
           }
         },
         common::Range(0, 1), 1, device_)
+        .Eval(&lower_bounds_, &upper_bounds_, &monotone_);
+  }
+
+  void AddSplit(bst_node_t nodeid, bst_node_t leftid, bst_node_t rightid, bst_feature_t f,
+                linalg::VectorView<float const> left_weight,
+                linalg::VectorView<float const> right_weight) {
+    if (!has_constraint_) {
+      return;
+    }
+    CHECK(device_.IsCPU());
+    auto n_targets = left_weight.Size();
+    CHECK_EQ(right_weight.Size(), n_targets);
+
+    auto max_nidx = std::max(leftid, rightid);
+    this->EnsureBounds(max_nidx, n_targets);
+
+    common::Transform<>::Init(
+        [=] XGBOOST_DEVICE(size_t t, common::Span<float> lower, common::Span<float> upper,
+                           common::Span<int> monotone) {
+          std::size_t strides[2]{n_targets, 1u};
+          auto parent_idx = linalg::detail::Offset<0>(strides, 0, nodeid, t);
+          auto left_idx = linalg::detail::Offset<0>(strides, 0, leftid, t);
+          auto right_idx = linalg::detail::Offset<0>(strides, 0, rightid, t);
+
+          lower[left_idx] = lower[parent_idx];
+          upper[left_idx] = upper[parent_idx];
+          lower[right_idx] = lower[parent_idx];
+          upper[right_idx] = upper[parent_idx];
+
+          auto mid = left_weight(t) + 0.5f * (right_weight(t) - left_weight(t));
+          SPAN_CHECK(!common::CheckNAN(mid));
+          auto constraint = monotone[f];
+          if (constraint < 0) {
+            lower[left_idx] = mid;
+            upper[right_idx] = mid;
+          } else if (constraint > 0) {
+            upper[left_idx] = mid;
+            lower[right_idx] = mid;
+          }
+        },
+        common::Range(0, n_targets), 1, device_)
         .Eval(&lower_bounds_, &upper_bounds_, &monotone_);
   }
 };

--- a/src/tree/updater_approx.cc
+++ b/src/tree/updater_approx.cc
@@ -177,6 +177,7 @@ class GlobalApproxBuilder {
 
   void UpdateTree(DMatrix *p_fmat, std::vector<GradientPair> const &gpair, common::Span<float> hess,
                   RegTree *p_tree, HostDeviceVector<bst_node_t> *p_out_position) {
+    CHECK(!p_tree->IsMultiTarget()) << "approx" << MTNotImplemented();
     p_last_tree_ = p_tree;
     this->InitData(p_fmat, p_tree, hess);
 

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -164,7 +164,7 @@ class ColMaker : public TreeUpdater {
           colmaker_train_param_{colmaker_train_param},
           ctx_{ctx},
           column_sampler_{std::move(column_sampler)},
-          tree_evaluator_(param_, column_densities.size(), DeviceOrd::CPU()),
+          tree_evaluator_(param_, column_densities.size(), DeviceOrd::CPU(), 1u),
           interaction_constraints_{std::move(_interaction_constraints)},
           column_densities_(column_densities) {}
     // update one tree, growing

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -117,6 +117,7 @@ class ColMaker : public TreeUpdater {
     CHECK_EQ(gpair->Shape(1), 1) << MTNotImplemented();
     for (auto tree : trees) {
       CHECK(ctx_);
+      CHECK(!tree->IsMultiTarget()) << "exact" << MTNotImplemented();
       Builder builder(*param, colmaker_param_, interaction_constraints_, ctx_, column_densities_,
                       column_sampler_);
       builder.Update(gpair->Data()->ConstHostVector(), dmat, tree);

--- a/src/tree/updater_gpu_common.cuh
+++ b/src/tree/updater_gpu_common.cuh
@@ -11,33 +11,6 @@
 #include "xgboost/task.h"         // for ObjInfo
 
 namespace xgboost::tree {
-struct GPUTrainingParam {
-  // minimum amount of hessian(weight) allowed in a child
-  float min_child_weight;
-  // L2 regularization factor
-  float reg_lambda;
-  // L1 regularization factor
-  float reg_alpha;
-  // maximum delta update we can add in weight estimation
-  // this parameter can be used to stabilize update
-  // default=0 means no constraint on weight delta
-  float max_delta_step;
-  float learning_rate;
-  uint32_t max_cat_to_onehot;
-  bst_bin_t max_cat_threshold;
-
-  GPUTrainingParam() = default;
-
-  XGBOOST_DEVICE explicit GPUTrainingParam(const TrainParam& param)
-      : min_child_weight(param.min_child_weight),
-        reg_lambda(param.reg_lambda),
-        reg_alpha(param.reg_alpha),
-        max_delta_step(param.max_delta_step),
-        learning_rate{param.learning_rate},
-        max_cat_to_onehot{param.max_cat_to_onehot},
-        max_cat_threshold{param.max_cat_threshold} {}
-};
-
 /**
  * @brief Default direction to be followed in case of missing values
  */

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -212,7 +212,7 @@ struct GPUHistMakerDevice {
 
   GPUExpandEntry EvaluateRootSplit(DMatrix const* p_fmat, GradientPairInt64 root_sum) {
     bst_node_t nidx = RegTree::kRoot;
-    GPUTrainingParam gpu_param(param);
+    EvalParam gpu_param(param);
     auto sampled_features = column_sampler_->GetFeatureSet(ctx_, 0);
     sampled_features->SetDevice(ctx_->Device());
     common::Span<bst_feature_t const> feature_set =
@@ -239,7 +239,7 @@ struct GPUHistMakerDevice {
     std::vector<bst_node_t> nidx(2 * candidates.size());
     auto h_node_inputs = pinned2.GetSpan<EvaluateSplitInputs>(2 * candidates.size());
     EvaluateSplitSharedInputs shared_inputs{
-        GPUTrainingParam{param}, (*quantiser)[0], p_fmat->Info().feature_types.ConstDeviceSpan(),
+        EvalParam{param}, (*quantiser)[0], p_fmat->Info().feature_types.ConstDeviceSpan(),
         cuts_->cut_ptrs_.ConstDeviceSpan(), cuts_->cut_values_.ConstDeviceSpan(),
         // is_dense represents the local data
         p_fmat->IsDense() && !collective::IsDistributed()};

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -181,7 +181,7 @@ class MultiTargetHistMaker {
 
   auto MakeSharedInputs(bst_feature_t max_active_feature) const {
     common::Span<GradientQuantiser const> d_roundings = this->split_quantizer_->DeviceSpan();
-    GPUTrainingParam d_param{this->param_};
+    EvalParam d_param{this->param_};
     std::size_t cat_storage_size = 0;
     if (this->cuts_->HasCategorical()) {
       cat_storage_size =
@@ -412,11 +412,10 @@ class MultiTargetHistMaker {
                                               d_out_sum.Size() * 2, ctx_->Device()));
     collective::SafeColl(rc);
 
-    auto param = GPUTrainingParam{this->param_};
+    auto param = EvalParam{this->param_};
     auto out_weight = linalg::Empty<float>(this->ctx_, n_leaves, p_tree->NumTargets());
     dh::device_vector<bst_node_t> d_leaves{leaves_idx};
-    // Reduced split-coordinate bounds do not apply to the full value gradient.
-    LeafWeight(this->ctx_, param, this->evaluator_.GetEvaluator(false), dh::ToSpan(d_leaves),
+    LeafWeight(this->ctx_, param, this->evaluator_.GetEvaluator(), dh::ToSpan(d_leaves),
                this->value_quantizer_->DeviceSpan(), out_sum.View(this->ctx_->Device()),
                out_weight.View(this->ctx_->Device()));
 

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -218,7 +218,7 @@ class MultiTargetHistMaker {
      * Evaluator
      */
     this->evaluator_.Reset(ctx_, this->cuts_->cut_ptrs_.ConstDeviceSpan(), this->feature_types_,
-                           this->param_);
+                           this->param_, gpair_all->Shape(1));
 
     /**
      * Initialize the gradient matrix
@@ -357,7 +357,9 @@ class MultiTargetHistMaker {
     }
 
     dh::device_vector<MultiExpandEntry> candidates{h_candidates};
-    this->evaluator_.ApplyTreeSplit(this->ctx_, p_tree, dh::ToSpan(candidates), n_targets);
+    this->evaluator_.ApplyTreeSplit(this->ctx_, p_tree,
+                                    common::Span<MultiExpandEntry const>{h_candidates},
+                                    dh::ToSpan(candidates), n_targets);
   }
   /**
    * @brief Calculate the leaf weight based on the node sum for each leaf.
@@ -413,8 +415,8 @@ class MultiTargetHistMaker {
     auto param = GPUTrainingParam{this->param_};
     auto out_weight = linalg::Empty<float>(this->ctx_, n_leaves, p_tree->NumTargets());
     dh::device_vector<bst_node_t> d_leaves{leaves_idx};
-    // Use full value gradient for leaf values.
-    LeafWeight(this->ctx_, param, this->evaluator_.GetEvaluator(), dh::ToSpan(d_leaves),
+    // Reduced split-coordinate bounds do not apply to the full value gradient.
+    LeafWeight(this->ctx_, param, this->evaluator_.GetEvaluator(false), dh::ToSpan(d_leaves),
                this->value_quantizer_->DeviceSpan(), out_sum.View(this->ctx_->Device()),
                out_weight.View(this->ctx_->Device()));
 
@@ -678,8 +680,6 @@ class MultiTargetHistMaker {
   void UpdateTree(GradientContainer* gpair, DMatrix* p_fmat, ObjInfo const* task, RegTree* p_tree,
                   HostDeviceVector<bst_node_t>* p_out_position) {
     xgboost_NVTX_FN_RANGE();
-
-    NoMonotoneConstraints(&param_, "vector leaf");
 
     auto* split_grad = gpair->Grad();
     if (gpair->HasValueGrad()) {

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -749,7 +749,6 @@ class MultiTargetHistMaker {
         cuts_{std::move(cuts)},
         feature_groups_{std::make_unique<FeatureGroups>(*cuts_, dense_compressed,
                                                         DftMtHistShmemBytes(ctx_->Ordinal()))},
-        evaluator_{param_, cuts_->NumFeatures(), ctx_->Device()},
         column_sampler_{std::move(column_sampler)},
         interaction_constraints_{
             std::make_unique<FeatureInteractionConstraintDevice>(param_, cuts_->NumFeatures())} {}

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -377,7 +377,8 @@ class MultiTargetHistBuilder {
     linalg::Matrix<float> weights = linalg::Empty<float>(ctx_, n_leaves, n_targets);
     auto h_weights = weights.HostView();
     auto eta = this->param_->learning_rate;
-    auto evaluator = this->evaluator_->Evaluator();
+    // Reduced split-gradient bounds don't map to the full value-gradient coordinates.
+    auto evaluator = this->evaluator_->Evaluator(false);
 
     common::ParallelFor(n_leaves, n_threads, [&](auto leaf_idx) {
       auto grad_sum = h_leaf_sums.Slice(leaf_idx, linalg::All());
@@ -635,9 +636,6 @@ class QuantileHistMaker : public TreeUpdater {
               const std::vector<RegTree *> &trees) override {
     if (trees.front()->IsMultiTarget()) {
       CHECK(hist_param_.GetInitialised());
-      if (in_gpair->HasValueGrad()) {
-        NoMonotoneConstraints(param, "vector leaf with a value gradient");
-      }
       if (!p_mtimpl_) {
         this->p_mtimpl_ = std::make_unique<MultiTargetHistBuilder>(ctx_, param, &hist_param_,
                                                                    column_sampler_, &monitor_);

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -377,8 +377,7 @@ class MultiTargetHistBuilder {
     linalg::Matrix<float> weights = linalg::Empty<float>(ctx_, n_leaves, n_targets);
     auto h_weights = weights.HostView();
     auto eta = this->param_->learning_rate;
-    // Reduced split-gradient bounds don't map to the full value-gradient coordinates.
-    auto evaluator = this->evaluator_->Evaluator(false);
+    auto evaluator = this->evaluator_->Evaluator();
 
     common::ParallelFor(n_leaves, n_threads, [&](auto leaf_idx) {
       auto grad_sum = h_leaf_sums.Slice(leaf_idx, linalg::All());

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -216,7 +216,8 @@ class MultiTargetHistBuilder {
                               collective::IsDistributed(), p_fmat->Info().IsColumnSplit(),
                               hist_param_);
 
-    evaluator_ = std::make_unique<HistMultiEvaluator>(ctx_, p_fmat->Info(), param_, col_sampler_);
+    evaluator_ =
+        std::make_unique<HistMultiEvaluator>(ctx_, p_fmat->Info(), param_, n_targets, col_sampler_);
     p_last_tree_ = p_tree;
     monitor_->Stop(__func__);
   }
@@ -634,7 +635,9 @@ class QuantileHistMaker : public TreeUpdater {
               const std::vector<RegTree *> &trees) override {
     if (trees.front()->IsMultiTarget()) {
       CHECK(hist_param_.GetInitialised());
-      NoMonotoneConstraints(param, "vector leaf");
+      if (in_gpair->HasValueGrad()) {
+        NoMonotoneConstraints(param, "vector leaf with a value gradient");
+      }
       if (!p_mtimpl_) {
         this->p_mtimpl_ = std::make_unique<MultiTargetHistBuilder>(ctx_, param, &hist_param_,
                                                                    column_sampler_, &monitor_);

--- a/src/tree/updater_refresh.cc
+++ b/src/tree/updater_refresh.cc
@@ -4,7 +4,6 @@
  * \brief refresh the statistics and leaf value on the tree on the dataset
  * \author Tianqi Chen
  */
-#include <algorithm>  // for any_of
 #include <limits>
 #include <vector>
 
@@ -38,10 +37,8 @@ class TreeRefresher : public TreeUpdater {
     if (trees.size() == 0) {
       return;
     }
-    if (std::any_of(param->monotone_constraints.cbegin(), param->monotone_constraints.cend(),
-                    [](auto v) { return v != 0; })) {
-      LOG(FATAL) << "Monotonic constraint is not supported by the `refresh` updater.";
-    }
+    CHECK(!param->HasMonotone())
+        << "Monotonic constraint is not supported by the `refresh` updater.";
 
     auto gpair = in_gpair->FullGradOnly();
     CHECK_EQ(gpair->Shape(1), 1) << MTNotImplemented();

--- a/src/tree/updater_refresh.cc
+++ b/src/tree/updater_refresh.cc
@@ -4,6 +4,7 @@
  * \brief refresh the statistics and leaf value on the tree on the dataset
  * \author Tianqi Chen
  */
+#include <algorithm>  // for any_of
 #include <limits>
 #include <vector>
 
@@ -37,7 +38,10 @@ class TreeRefresher : public TreeUpdater {
     if (trees.size() == 0) {
       return;
     }
-    NoMonotoneConstraints(param, "`refresh` updater");
+    if (std::any_of(param->monotone_constraints.cbegin(), param->monotone_constraints.cend(),
+                    [](auto v) { return v != 0; })) {
+      LOG(FATAL) << "Monotonic constraint is not supported by the `refresh` updater.";
+    }
 
     auto gpair = in_gpair->FullGradOnly();
     CHECK_EQ(gpair->Shape(1), 1) << MTNotImplemented();

--- a/tests/cpp/tree/gpu_hist/test_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_evaluate_splits.cu
@@ -39,7 +39,7 @@ thrust::device_vector<GradientPairInt64> ConvertToInteger(Context const* ctx,
 TEST_F(TestCategoricalSplitWithMissing, GPUHistEvaluator) {
   auto ctx = MakeCUDACtx(0);
   thrust::device_vector<bst_feature_t> feature_set = std::vector<bst_feature_t>{0};
-  GPUTrainingParam param{param_};
+  EvalParam param{param_};
   cuts_.cut_ptrs_.SetDevice(ctx.Device());
   cuts_.cut_values_.SetDevice(ctx.Device());
   thrust::device_vector<GradientPairInt64> feature_histogram{
@@ -72,7 +72,7 @@ TEST(GpuHist, PartitionBasic) {
   auto ctx = MakeCUDACtx(0);
   TrainParam tparam = ZeroParam();
   tparam.max_cat_to_onehot = 0;
-  GPUTrainingParam param{tparam};
+  EvalParam param{tparam};
 
   common::HistogramCuts cuts{1};
   cuts.cut_values_.HostVector() = std::vector<float>{0.0, 1.0, 2.0};
@@ -184,7 +184,7 @@ TEST(GpuHist, PartitionTwoFeatures) {
   auto ctx = MakeCUDACtx(0);
   TrainParam tparam = ZeroParam();
   tparam.max_cat_to_onehot = 0;
-  GPUTrainingParam param{tparam};
+  EvalParam param{tparam};
 
   common::HistogramCuts cuts{2};
   cuts.cut_values_.HostVector() = std::vector<float>{0.0, 1.0, 2.0, 0.0, 1.0, 2.0};
@@ -242,7 +242,7 @@ TEST(GpuHist, PartitionTwoNodes) {
   auto ctx = MakeCUDACtx(0);
   TrainParam tparam = ZeroParam();
   tparam.max_cat_to_onehot = 0;
-  GPUTrainingParam param{tparam};
+  EvalParam param{tparam};
 
   common::HistogramCuts cuts{1};
   cuts.cut_values_.HostVector() = std::vector<float>{0.0, 1.0, 2.0};
@@ -294,7 +294,7 @@ void TestEvaluateSingleSplit(bool is_categorical) {
   auto quantiser = DummyRoundingFactor(&ctx);
   auto parent_sum = quantiser.ToFixedPoint(GradientPairPrecise{0.0, 1.0});
   TrainParam tparam = ZeroParam();
-  GPUTrainingParam param{tparam};
+  EvalParam param{tparam};
 
   common::HistogramCuts cuts{MakeCutsForTest({1.0, 2.0, 11.0, 12.0}, {0, 2, 4}, ctx.Device())};
   thrust::device_vector<bst_feature_t> feature_set = std::vector<bst_feature_t>{0, 1};
@@ -343,7 +343,7 @@ TEST(GpuHist, EvaluateSingleSplitMissing) {
   auto quantiser = DummyRoundingFactor(&ctx);
   auto parent_sum = quantiser.ToFixedPoint(GradientPairPrecise{1.0, 1.5});
   TrainParam tparam = ZeroParam();
-  GPUTrainingParam param{tparam};
+  EvalParam param{tparam};
 
   thrust::device_vector<bst_feature_t> feature_set = std::vector<bst_feature_t>{0};
   thrust::device_vector<uint32_t> feature_segments = std::vector<bst_idx_t>{0, 2};
@@ -370,10 +370,9 @@ TEST(GpuHist, EvaluateSingleSplitEmpty) {
   GPUHistEvaluator evaluator(tparam, 1, FstCU());
   DeviceSplitCandidate result =
       evaluator
-          .EvaluateSingleSplit(
-              &ctx, EvaluateSplitInputs{},
-              EvaluateSplitSharedInputs{
-                  GPUTrainingParam(tparam), DummyRoundingFactor(&ctx), {}, {}, {}, false})
+          .EvaluateSingleSplit(&ctx, EvaluateSplitInputs{},
+                               EvaluateSplitSharedInputs{
+                                   EvalParam(tparam), DummyRoundingFactor(&ctx), {}, {}, {}, false})
           .split;
   EXPECT_EQ(result.findex, -1);
   EXPECT_LT(result.loss_chg, 0.0f);
@@ -386,7 +385,7 @@ TEST(GpuHist, EvaluateSingleSplitFeatureSampling) {
   auto parent_sum = quantiser.ToFixedPoint(GradientPairPrecise{0.0, 1.0});
   TrainParam tparam = ZeroParam();
   tparam.UpdateAllowUnknown(Args{});
-  GPUTrainingParam param{tparam};
+  EvalParam param{tparam};
 
   thrust::device_vector<bst_feature_t> feature_set = std::vector<bst_feature_t>{1};
   thrust::device_vector<uint32_t> feature_segments = std::vector<bst_idx_t>{0, 2, 4};
@@ -414,7 +413,7 @@ TEST(GpuHist, EvaluateSingleSplitBreakTies) {
   auto parent_sum = quantiser.ToFixedPoint(GradientPairPrecise{0.0, 1.0});
   TrainParam tparam = ZeroParam();
   tparam.UpdateAllowUnknown(Args{});
-  GPUTrainingParam param{tparam};
+  EvalParam param{tparam};
 
   thrust::device_vector<bst_feature_t> feature_set = std::vector<bst_feature_t>{0, 1};
   thrust::device_vector<uint32_t> feature_segments = std::vector<bst_idx_t>{0, 2, 4};
@@ -440,7 +439,7 @@ TEST(GpuHist, EvaluateSplits) {
   auto parent_sum = quantiser.ToFixedPoint(GradientPairPrecise{0.0, 1.0});
   TrainParam tparam = ZeroParam();
   tparam.UpdateAllowUnknown(Args{});
-  GPUTrainingParam param{tparam};
+  EvalParam param{tparam};
 
   thrust::device_vector<bst_feature_t> feature_set = std::vector<bst_feature_t>{0, 1};
   thrust::device_vector<uint32_t> feature_segments = std::vector<bst_idx_t>{0, 2, 4};
@@ -492,7 +491,7 @@ TEST_F(TestPartitionBasedSplit, GpuHist) {
 
   EvaluateSplitInputs input{0, 0, quantiser.ToFixedPoint(total_gpair_), dh::ToSpan(feature_set),
                             dh::ToSpan(d_hist)};
-  EvaluateSplitSharedInputs shared_inputs{GPUTrainingParam{param_},
+  EvaluateSplitSharedInputs shared_inputs{EvalParam{param_},
                                           quantiser,
                                           dh::ToSpan(ft),
                                           cuts_.cut_ptrs_.ConstDeviceSpan(),
@@ -511,7 +510,7 @@ void VerifyColumnSplitEvaluateSingleSplit(bool is_categorical) {
   auto quantiser = DummyRoundingFactor(&ctx);
   auto parent_sum = quantiser.ToFixedPoint(GradientPairPrecise{0.0, 1.0});
   TrainParam tparam = ZeroParam();
-  GPUTrainingParam param{tparam};
+  EvalParam param{tparam};
 
   common::HistogramCuts cuts{rank == 0 ? MakeCutsForTest({1.0, 2.0}, {0, 2, 2}, ctx.Device())
                                        : MakeCutsForTest({11.0, 12.0}, {0, 0, 2}, ctx.Device())};

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -115,7 +115,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, Root) {
   for (auto one_pass : {OnePass::kNone, OnePass::kForward, OnePass::kBackward}) {
     auto shared = this->shared_inputs;
     shared.one_pass = one_pass;
-    MultiHistEvaluator evaluator{param, 1, ctx.Device()};
+    MultiHistEvaluator evaluator;
     evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param, shared.Targets());
     auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
     ASSERT_NEAR(candidate.split.loss_chg, 3.04239, 1e-5);
@@ -144,7 +144,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, Root) {
   param = this->MakeParam(Args{{"reg_alpha", "0.1"}, {"max_delta_step", "1.45"}});
   auto shared = this->shared_inputs;
   shared.param = GPUTrainingParam{param};
-  MultiHistEvaluator evaluator{param, 1, ctx.Device()};
+  MultiHistEvaluator evaluator;
   evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param, shared.Targets());
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
   ASSERT_NEAR(candidate.split.loss_chg, 2.55177, 1e-5);
@@ -160,7 +160,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalOneHot) {
   auto param = this->MakeParam(Args{{"max_cat_to_onehot", "100"}});
   auto shared = this->MakeCategoricalInputs(param);
 
-  MultiHistEvaluator evaluator{param, 1, ctx.Device()};
+  MultiHistEvaluator evaluator;
   evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param, shared.Targets());
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
@@ -210,7 +210,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   auto param = this->MakeParam(Args{{"max_cat_to_onehot", "1"}});
   auto shared = this->MakeCategoricalInputs(param);
 
-  MultiHistEvaluator evaluator{param, 1, ctx.Device()};
+  MultiHistEvaluator evaluator;
   evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param, shared.Targets());
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
@@ -247,7 +247,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
       this->MakeParam(Args{{"max_cat_to_onehot", "1"}, {"max_cat_threshold", "1"}});
   shared.param = GPUTrainingParam{no_split_param};
 
-  MultiHistEvaluator no_split_evaluator{no_split_param, 1, ctx.Device()};
+  MultiHistEvaluator no_split_evaluator;
   no_split_evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, no_split_param,
                            shared.Targets());
   auto no_split = no_split_evaluator.EvaluateSingleSplit(&ctx, input, shared);

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -116,6 +116,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, Root) {
     auto shared = this->shared_inputs;
     shared.one_pass = one_pass;
     MultiHistEvaluator evaluator{param, 1, ctx.Device()};
+    evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param, shared.Targets());
     auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
     ASSERT_NEAR(candidate.split.loss_chg, 3.04239, 1e-5);
 
@@ -144,6 +145,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, Root) {
   auto shared = this->shared_inputs;
   shared.param = GPUTrainingParam{param};
   MultiHistEvaluator evaluator{param, 1, ctx.Device()};
+  evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param, shared.Targets());
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
   ASSERT_NEAR(candidate.split.loss_chg, 2.55177, 1e-5);
 }
@@ -159,7 +161,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalOneHot) {
   auto shared = this->MakeCategoricalInputs(param);
 
   MultiHistEvaluator evaluator{param, 1, ctx.Device()};
-  evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param);
+  evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param, shared.Targets());
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
   ASSERT_TRUE(candidate.split.is_cat);
@@ -209,7 +211,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   auto shared = this->MakeCategoricalInputs(param);
 
   MultiHistEvaluator evaluator{param, 1, ctx.Device()};
-  evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param);
+  evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param, shared.Targets());
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
   ASSERT_TRUE(candidate.split.is_cat);
@@ -246,7 +248,8 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   shared.param = GPUTrainingParam{no_split_param};
 
   MultiHistEvaluator no_split_evaluator{no_split_param, 1, ctx.Device()};
-  no_split_evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, no_split_param);
+  no_split_evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, no_split_param,
+                           shared.Targets());
   auto no_split = no_split_evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
   ASSERT_TRUE(no_split.split.child_sum.empty());

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -43,7 +43,7 @@ class GpuMultiHistEvaluatorBasicTest : public ::testing::Test {
     shared.feature_values = dh::ToSpan(cat_values).data();
     shared.feature_types = dh::ToSpan(cat_feature);
     shared.cat_storage_size = common::CatBitField::ComputeStorageSize(cat_values.size());
-    shared.param = GPUTrainingParam{param};
+    shared.param = EvalParam{param};
     return shared;
   }
 
@@ -89,7 +89,7 @@ class GpuMultiHistEvaluatorBasicTest : public ::testing::Test {
     shared_inputs.max_active_feature = 1;
 
     auto param = this->MakeParam();
-    shared_inputs.param = GPUTrainingParam{param};
+    shared_inputs.param = EvalParam{param};
   }
 };
 
@@ -143,7 +143,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, Root) {
 
   param = this->MakeParam(Args{{"reg_alpha", "0.1"}, {"max_delta_step", "1.45"}});
   auto shared = this->shared_inputs;
-  shared.param = GPUTrainingParam{param};
+  shared.param = EvalParam{param};
   MultiHistEvaluator evaluator;
   evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, param, shared.Targets());
   auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
@@ -245,7 +245,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   // must still retain its base weight and Hessian.
   auto no_split_param =
       this->MakeParam(Args{{"max_cat_to_onehot", "1"}, {"max_cat_threshold", "1"}});
-  shared.param = GPUTrainingParam{no_split_param};
+  shared.param = EvalParam{no_split_param};
 
   MultiHistEvaluator no_split_evaluator;
   no_split_evaluator.Reset(&ctx, shared.feature_segments, shared.feature_types, no_split_param,

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -180,7 +180,7 @@ TEST(HistMultiEvaluator, Evaluate) {
   auto p_fmat =
       RandomDataGenerator{n_samples, n_features, 0.5}.Targets(n_targets).GenerateDMatrix(true);
 
-  HistMultiEvaluator evaluator{&ctx, p_fmat->Info(), &param, sampler};
+  HistMultiEvaluator evaluator{&ctx, p_fmat->Info(), &param, n_targets, sampler};
   HistMakerTrainParam hist_param;
   std::vector<BoundedHistCollection> histogram(n_targets);
   linalg::Vector<GradientPairPrecise> root_sum({2}, DeviceOrd::CPU());
@@ -423,7 +423,7 @@ class TestHistMultiEvaluator : public ::testing::Test {
                                    {"max_delta_step", "0"},
                                    {"max_cat_to_onehot", "4"}});
     param_.UpdateAllowUnknown(args);
-    evaluator_ = std::make_unique<HistMultiEvaluator>(&ctx_, info_, &param_, sampler_);
+    evaluator_ = std::make_unique<HistMultiEvaluator>(&ctx_, info_, &param_, kNTargets, sampler_);
     entries_.clear();
     entries_.emplace_back(0, 0);
 
@@ -495,4 +495,5 @@ TEST_F(TestHistMultiEvaluator, CategoricalPartition) {
 
   this->ApplyTreeSplit();
 }
+
 }  // namespace xgboost::tree

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -61,8 +61,8 @@ void TestPartitionBasedSplit::SetUp() {
                                                    GradientPairPrecise parent_sum) {
     int32_t best_thresh = -1;
     float best_score{-std::numeric_limits<float>::infinity()};
-    TreeEvaluator evaluator{param_, static_cast<bst_feature_t>(n_feat), DeviceOrd::CPU()};
-    auto tree_evaluator = evaluator.GetEvaluator<TrainParam>();
+    TreeEvaluator evaluator{param_, static_cast<bst_feature_t>(n_feat), DeviceOrd::CPU(), 1u};
+    auto tree_evaluator = evaluator.GetEvaluator();
     GradientPairPrecise left_sum;
     auto parent_gain = tree_evaluator.CalcGain(0, param_, GradStats{total_gpair_});
     for (size_t i = 0; i < hist.size() - 1; ++i) {

--- a/tests/cpp/tree/test_split_evaluator.cc
+++ b/tests/cpp/tree/test_split_evaluator.cc
@@ -35,73 +35,73 @@ TEST(TreeEvaluator, CalcVectorGainWithMaxDeltaStep) {
   EXPECT_DOUBLE_EQ(all_zero.GetEvaluator().CalcGain(0, param, h_stats), 6.75);
 }
 
-TEST(TreeEvaluator, CalcMonotoneVectorSplitWeights) {
-  TrainParam param;
-  param.Init(Args{{"min_child_weight", "0"},
-                  {"reg_alpha", "0"},
-                  {"reg_lambda", "0"},
-                  {"monotone_constraints", "(1)"}});
-
-  linalg::Vector<GradientPairPrecise> left({2}, DeviceOrd::CPU());
-  linalg::Vector<GradientPairPrecise> right({2}, DeviceOrd::CPU());
-  auto h_left = left.HostView();
-  auto h_right = right.HostView();
-  // Crossing for an increasing constraint: 2 > 1.
-  h_left(0) = {-2.0, 1.0};
-  h_right(0) = {-1.0, 1.0};
-  // Already ordered: -1 < 1.
-  h_left(1) = {1.0, 1.0};
-  h_right(1) = {-1.0, 1.0};
-
-  TreeEvaluator tree_evaluator{param, 1, DeviceOrd::CPU(), 2};
-  auto evaluator = tree_evaluator.GetEvaluator();
-  linalg::Vector<float> left_weight({2}, DeviceOrd::CPU());
-  linalg::Vector<float> right_weight({2}, DeviceOrd::CPU());
-  evaluator.CalcSplitWeights(param, 0, 0, h_left, h_right, left_weight.HostView(),
-                             right_weight.HostView());
-
-  auto h_left_weight = left_weight.HostView();
-  auto h_right_weight = right_weight.HostView();
-  EXPECT_FLOAT_EQ(h_left_weight(0), 1.5f);
-  EXPECT_FLOAT_EQ(h_right_weight(0), 1.5f);
-  EXPECT_FLOAT_EQ(h_left_weight(1), -1.0f);
-  EXPECT_FLOAT_EQ(h_right_weight(1), 1.0f);
-  EXPECT_DOUBLE_EQ(evaluator.CalcSplitGain(param, 0, 0, h_left, h_right), 6.5);
-
-  // A crossing pair retains two copies of each regularizer.
-  param.reg_alpha = 0.5f;
-  param.reg_lambda = 1.0f;
-  auto [l_w, r_w] = evaluator.CalcSplitWeights(param, 0, 0, 0, h_left(0), h_right(0));
-  EXPECT_FLOAT_EQ(l_w, 0.5f);
-  EXPECT_FLOAT_EQ(r_w, 0.5f);
-  // max_delta_step applies once to the common weight.
-  param.max_delta_step = 0.4f;
-  std::tie(l_w, r_w) = evaluator.CalcSplitWeights(param, 0, 0, 0, h_left(0), h_right(0));
-  EXPECT_FLOAT_EQ(l_w, 0.4f);
-  EXPECT_FLOAT_EQ(r_w, 0.4f);
-}
-
 TEST(TreeEvaluator, PropagateVectorBounds) {
-  TrainParam param;
-  param.Init(Args{{"reg_lambda", "0"}, {"monotone_constraints", "(1, 0)"}});
+  for (auto monotone_direction : {1, -1}) {
+    SCOPED_TRACE(monotone_direction);
+    TrainParam param;
+    auto constraint = monotone_direction > 0 ? "(1, 0)" : "(-1, 0)";
+    param.Init(Args{{"min_child_weight", "0"},
+                    {"reg_alpha", "0"},
+                    {"reg_lambda", "0"},
+                    {"monotone_constraints", constraint}});
 
-  TreeEvaluator tree_evaluator{param, 2, DeviceOrd::CPU(), 2};
-  linalg::Vector<float> left_weight({2}, DeviceOrd::CPU());
-  linalg::Vector<float> right_weight({2}, DeviceOrd::CPU());
-  left_weight.HostView()(0) = 2.0f;
-  left_weight.HostView()(1) = -4.0f;
-  right_weight.HostView()(0) = 4.0f;
-  right_weight.HostView()(1) = -2.0f;
-  tree_evaluator.AddSplit(0, 1, 2, 0, left_weight.HostView(), right_weight.HostView());
+    // Unconstrained updates for the four (f0, f1) groups. Negating them tests decreasing f0.
+    constexpr float kUpdate[4][2]{
+        {-4.0f, 2.0f},  // f0=0, f1=0
+        {2.0f, 2.0f},   // f0=0, f1=1
+        {4.0f, 1.0f},   // f0=1, f1=0
+        {-2.0f, 1.0f},  // f0=1, f1=1
+    };
+    linalg::Matrix<GradientPairPrecise> leaf_stats({4, 2}, DeviceOrd::CPU());
+    auto h_leaf_stats = leaf_stats.HostView();
+    for (std::size_t row = 0; row < 4; ++row) {
+      for (bst_target_t target = 0; target < 2; ++target) {
+        h_leaf_stats(row, target) = {-monotone_direction * kUpdate[row][target], 1.0};
+      }
+    }
 
-  // An unconstrained descendant split must inherit the target-specific intervals.
-  tree_evaluator.AddSplit(1, 3, 4, 1, left_weight.HostView(), left_weight.HostView());
-  auto evaluator = tree_evaluator.GetEvaluator();
+    // The two f0 groups have mean updates (-1, 2) and (1, 1). The second target
+    // crosses, so its two weights are both projected to 1.5.
+    linalg::Matrix<GradientPairPrecise> root_stats({2, 2}, DeviceOrd::CPU());
+    auto h_root_stats = root_stats.HostView();
+    for (bst_target_t target = 0; target < 2; ++target) {
+      h_root_stats(0, target) = h_leaf_stats(0, target) + h_leaf_stats(1, target);
+      h_root_stats(1, target) = h_leaf_stats(2, target) + h_leaf_stats(3, target);
+    }
 
-  EXPECT_FLOAT_EQ(evaluator.CalcWeight(4, 0, param, GradientPairPrecise{-10.0, 1.0}), 3.0f);
-  EXPECT_FLOAT_EQ(evaluator.CalcWeight(4, 1, param, GradientPairPrecise{-1.0, 1.0}), -3.0f);
-  EXPECT_FLOAT_EQ(evaluator.CalcWeight(2, 0, param, GradientPairPrecise{1.0, 1.0}), 3.0f);
-  EXPECT_FLOAT_EQ(evaluator.CalcWeight(2, 1, param, GradientPairPrecise{10.0, 1.0}), -3.0f);
+    TreeEvaluator tree_evaluator{param, 2, DeviceOrd::CPU(), 2};
+    auto evaluator = tree_evaluator.GetEvaluator();
+    linalg::Matrix<float> root_weight({2, 2}, DeviceOrd::CPU());
+    evaluator.CalcSplitWeights(
+        param, 0, 0, root_stats.Slice(0, linalg::All()), root_stats.Slice(1, linalg::All()),
+        root_weight.Slice(0, linalg::All()), root_weight.Slice(1, linalg::All()));
+    auto h_root_weight = root_weight.HostView();
+    EXPECT_FLOAT_EQ(h_root_weight(0, 0), monotone_direction * -1.0f);
+    EXPECT_FLOAT_EQ(h_root_weight(0, 1), monotone_direction * 1.5f);
+    EXPECT_FLOAT_EQ(h_root_weight(1, 0), monotone_direction * 1.0f);
+    EXPECT_FLOAT_EQ(h_root_weight(1, 1), monotone_direction * 1.5f);
+
+    tree_evaluator.AddSplit(0, 1, 2, 0, root_weight.Slice(0, linalg::All()),
+                            root_weight.Slice(1, linalg::All()));
+    evaluator = tree_evaluator.GetEvaluator();
+
+    // f1 has no constraint, but each split inherits the target-specific bounds from f0.
+    linalg::Matrix<float> leaf_weight({4, 2}, DeviceOrd::CPU());
+    evaluator.CalcSplitWeights(
+        param, 1, 1, leaf_stats.Slice(0, linalg::All()), leaf_stats.Slice(1, linalg::All()),
+        leaf_weight.Slice(0, linalg::All()), leaf_weight.Slice(1, linalg::All()));
+    evaluator.CalcSplitWeights(
+        param, 2, 1, leaf_stats.Slice(2, linalg::All()), leaf_stats.Slice(3, linalg::All()),
+        leaf_weight.Slice(2, linalg::All()), leaf_weight.Slice(3, linalg::All()));
+
+    constexpr float kExpected[4][2]{{-4.0f, 1.5f}, {0.0f, 1.5f}, {4.0f, 1.5f}, {0.0f, 1.5f}};
+    auto h_leaf_weight = leaf_weight.HostView();
+    for (std::size_t row = 0; row < 4; ++row) {
+      for (bst_target_t target = 0; target < 2; ++target) {
+        EXPECT_FLOAT_EQ(h_leaf_weight(row, target), monotone_direction * kExpected[row][target]);
+      }
+    }
+  }
 }
 
 TEST(TreeEvaluator, ConstrainedVectorGainWithZeroHessianTarget) {

--- a/tests/cpp/tree/test_split_evaluator.cc
+++ b/tests/cpp/tree/test_split_evaluator.cc
@@ -20,7 +20,7 @@ TEST(TreeEvaluator, CalcVectorGainWithMaxDeltaStep) {
 
   linalg::Vector<float> weight({2}, xgboost::DeviceOrd::CPU());
   auto h_weight = weight.HostView();
-  TreeEvaluator tree_evaluator{param, 1, DeviceOrd::CPU()};
+  TreeEvaluator tree_evaluator{param, 1, DeviceOrd::CPU(), 1u};
   auto evaluator = tree_evaluator.GetEvaluator();
   evaluator.CalcWeight(0, param, h_stats, h_weight);
   ASSERT_FLOAT_EQ(h_weight(0), -0.5f);
@@ -31,7 +31,7 @@ TEST(TreeEvaluator, CalcVectorGainWithMaxDeltaStep) {
   EXPECT_DOUBLE_EQ(evaluator.CalcGain(0, param, h_stats), 6.75);
 
   param.monotone_constraints = {0};
-  TreeEvaluator all_zero{param, 1, DeviceOrd::CPU()};
+  TreeEvaluator all_zero{param, 1, DeviceOrd::CPU(), 1u};
   EXPECT_DOUBLE_EQ(all_zero.GetEvaluator().CalcGain(0, param, h_stats), 6.75);
 }
 

--- a/tests/cpp/tree/test_split_evaluator.cc
+++ b/tests/cpp/tree/test_split_evaluator.cc
@@ -29,5 +29,105 @@ TEST(TreeEvaluator, CalcVectorGainWithMaxDeltaStep) {
   // 6.5 from the clipped first target and 0.25 from the second target.
   EXPECT_DOUBLE_EQ(evaluator.CalcGainGivenWeight(param, h_stats, h_weight), 6.75);
   EXPECT_DOUBLE_EQ(evaluator.CalcGain(0, param, h_stats), 6.75);
+
+  param.monotone_constraints = {0};
+  TreeEvaluator all_zero{param, 1, DeviceOrd::CPU()};
+  EXPECT_DOUBLE_EQ(all_zero.GetEvaluator().CalcGain(0, param, h_stats), 6.75);
+}
+
+TEST(TreeEvaluator, CalcMonotoneVectorSplitWeights) {
+  TrainParam param;
+  param.Init(Args{{"min_child_weight", "0"},
+                  {"reg_alpha", "0"},
+                  {"reg_lambda", "0"},
+                  {"monotone_constraints", "(1)"}});
+
+  linalg::Vector<GradientPairPrecise> left({2}, DeviceOrd::CPU());
+  linalg::Vector<GradientPairPrecise> right({2}, DeviceOrd::CPU());
+  auto h_left = left.HostView();
+  auto h_right = right.HostView();
+  // Crossing for an increasing constraint: 2 > 1.
+  h_left(0) = {-2.0, 1.0};
+  h_right(0) = {-1.0, 1.0};
+  // Already ordered: -1 < 1.
+  h_left(1) = {1.0, 1.0};
+  h_right(1) = {-1.0, 1.0};
+
+  TreeEvaluator tree_evaluator{param, 1, DeviceOrd::CPU(), 2};
+  auto evaluator = tree_evaluator.GetEvaluator();
+  linalg::Vector<float> left_weight({2}, DeviceOrd::CPU());
+  linalg::Vector<float> right_weight({2}, DeviceOrd::CPU());
+  evaluator.CalcSplitWeights(param, 0, 0, h_left, h_right, left_weight.HostView(),
+                             right_weight.HostView());
+
+  auto h_left_weight = left_weight.HostView();
+  auto h_right_weight = right_weight.HostView();
+  EXPECT_FLOAT_EQ(h_left_weight(0), 1.5f);
+  EXPECT_FLOAT_EQ(h_right_weight(0), 1.5f);
+  EXPECT_FLOAT_EQ(h_left_weight(1), -1.0f);
+  EXPECT_FLOAT_EQ(h_right_weight(1), 1.0f);
+  EXPECT_DOUBLE_EQ(evaluator.CalcSplitGain(param, 0, 0, h_left, h_right), 6.5);
+
+  // A crossing pair retains two copies of each regularizer.
+  param.reg_alpha = 0.5f;
+  param.reg_lambda = 1.0f;
+  auto [l_w, r_w] = evaluator.CalcSplitWeights(param, 0, 0, 0, h_left(0), h_right(0));
+  EXPECT_FLOAT_EQ(l_w, 0.5f);
+  EXPECT_FLOAT_EQ(r_w, 0.5f);
+  // max_delta_step applies once to the common weight.
+  param.max_delta_step = 0.4f;
+  std::tie(l_w, r_w) = evaluator.CalcSplitWeights(param, 0, 0, 0, h_left(0), h_right(0));
+  EXPECT_FLOAT_EQ(l_w, 0.4f);
+  EXPECT_FLOAT_EQ(r_w, 0.4f);
+}
+
+TEST(TreeEvaluator, PropagateVectorBounds) {
+  TrainParam param;
+  param.Init(Args{{"reg_lambda", "0"}, {"monotone_constraints", "(1, 0)"}});
+
+  TreeEvaluator tree_evaluator{param, 2, DeviceOrd::CPU(), 2};
+  linalg::Vector<float> left_weight({2}, DeviceOrd::CPU());
+  linalg::Vector<float> right_weight({2}, DeviceOrd::CPU());
+  left_weight.HostView()(0) = 2.0f;
+  left_weight.HostView()(1) = -4.0f;
+  right_weight.HostView()(0) = 4.0f;
+  right_weight.HostView()(1) = -2.0f;
+  tree_evaluator.AddSplit(0, 1, 2, 0, left_weight.HostView(), right_weight.HostView());
+
+  // An unconstrained descendant split must inherit the target-specific intervals.
+  tree_evaluator.AddSplit(1, 3, 4, 1, left_weight.HostView(), left_weight.HostView());
+  auto evaluator = tree_evaluator.GetEvaluator();
+
+  EXPECT_FLOAT_EQ(evaluator.CalcWeight(4, 0, param, GradientPairPrecise{-10.0, 1.0}), 3.0f);
+  EXPECT_FLOAT_EQ(evaluator.CalcWeight(4, 1, param, GradientPairPrecise{-1.0, 1.0}), -3.0f);
+  EXPECT_FLOAT_EQ(evaluator.CalcWeight(2, 0, param, GradientPairPrecise{1.0, 1.0}), 3.0f);
+  EXPECT_FLOAT_EQ(evaluator.CalcWeight(2, 1, param, GradientPairPrecise{10.0, 1.0}), -3.0f);
+}
+
+TEST(TreeEvaluator, ConstrainedVectorGainWithZeroHessianTarget) {
+  TrainParam param;
+  param.Init(Args{{"min_child_weight", "0"},
+                  {"reg_alpha", "0"},
+                  {"reg_lambda", "1"},
+                  {"monotone_constraints", "(-1)"}});
+
+  linalg::Vector<GradientPairPrecise> left({2}, DeviceOrd::CPU());
+  linalg::Vector<GradientPairPrecise> right({2}, DeviceOrd::CPU());
+  auto h_left = left.HostView();
+  auto h_right = right.HostView();
+  h_left(0) = {0.0, 0.0};
+  h_right(0) = {-2.0, 1.0};
+  // Keep the normalized child Hessians valid.
+  h_left(1) = {0.0, 2.0};
+  h_right(1) = {0.0, 1.0};
+
+  TreeEvaluator tree_evaluator{param, 1, DeviceOrd::CPU(), 2};
+  auto evaluator = tree_evaluator.GetEvaluator();
+  auto [l_w, r_w] = evaluator.CalcSplitWeights(param, 0, 0, 0, h_left(0), h_right(0));
+  EXPECT_NEAR(l_w, 2.0f / 3.0f, kRtEps);
+  EXPECT_NEAR(r_w, 2.0f / 3.0f, kRtEps);
+
+  // Raw explicit gains include both regularized leaves: -4/9 + 16/9 = 4/3.
+  EXPECT_NEAR(evaluator.CalcSplitGain(param, 0, 0, h_left, h_right), 4.0 / 3.0, kRtEps);
 }
 }  // namespace xgboost::tree

--- a/tests/cpp/tree/test_split_evaluator.cc
+++ b/tests/cpp/tree/test_split_evaluator.cc
@@ -35,6 +35,39 @@ TEST(TreeEvaluator, CalcVectorGainWithMaxDeltaStep) {
   EXPECT_DOUBLE_EQ(all_zero.GetEvaluator().CalcGain(0, param, h_stats), 6.75);
 }
 
+TEST(TreeEvaluator, PooledWeightUsesTwoLeafRegularization) {
+  TrainParam param;
+  param.Init(Args{{"min_child_weight", "0"},
+                  {"reg_alpha", "0.25"},
+                  {"reg_lambda", "1"},
+                  {"monotone_constraints", "(1)"}});
+
+  linalg::Vector<GradientPairPrecise> left({1}, DeviceOrd::CPU());
+  linalg::Vector<GradientPairPrecise> right({1}, DeviceOrd::CPU());
+  auto h_left = left.HostView();
+  auto h_right = right.HostView();
+  h_left(0) = {-2.0, 1.0};
+  h_right(0) = {-1.0, 1.0};
+
+  TreeEvaluator tree_evaluator{param, 1, DeviceOrd::CPU(), 1};
+  auto evaluator = tree_evaluator.GetEvaluator();
+  auto pooled = evaluator.CalcPooledWeight(param, 0, 0, h_left(0), h_right(0));
+  EXPECT_FLOAT_EQ(pooled, 0.625f);
+
+  // Combining two equal-valued leaves is an ordinary one-leaf calculation with both
+  // regularization penalties doubled.
+  auto pooled_param = param;
+  pooled_param.reg_alpha *= 2.0f;
+  pooled_param.reg_lambda *= 2.0f;
+  auto sum = h_left(0) + h_right(0);
+  EXPECT_FLOAT_EQ(pooled, CalcWeight(pooled_param, sum));
+
+  auto gain = evaluator.CalcGainGivenWeight(param, h_left(0), pooled) +
+              evaluator.CalcGainGivenWeight(param, h_right(0), pooled);
+  EXPECT_DOUBLE_EQ(gain, CalcGain(pooled_param, sum));
+  EXPECT_DOUBLE_EQ(evaluator.CalcSplitGain(param, 0, 0, h_left, h_right), gain);
+}
+
 TEST(TreeEvaluator, PropagateVectorBounds) {
   for (auto monotone_direction : {1, -1}) {
     SCOPED_TRACE(monotone_direction);

--- a/tests/python-gpu/test_monotonic_constraints.py
+++ b/tests/python-gpu/test_monotonic_constraints.py
@@ -1,72 +1,35 @@
-import numpy as np
 import pytest
-import xgboost as xgb
-from xgboost import testing as tm
 from xgboost.testing.monotone_constraints import (
-    is_correctly_constrained,
-    is_decreasing,
-    is_increasing,
+    run_monotone_constraints,
+    run_multi_output_monotone,
     run_parent_gain,
-    training_dset,
 )
 
-rng = np.random.RandomState(1994)
 
-
-def assert_constraint(constraint: int, tree_method: str) -> None:
-    from sklearn.datasets import make_regression
-
-    n = 1000
-    X, y = make_regression(n, random_state=rng, n_features=1, n_informative=1)
-    dtrain = xgb.DMatrix(X, y)
-    param = {}
-    param["tree_method"] = tree_method
-    param["device"] = "cuda"
-    param["monotone_constraints"] = "(" + str(constraint) + ")"
-    bst = xgb.train(param, dtrain)
-    dpredict = xgb.DMatrix(X[X[:, 0].argsort()])
-    pred = bst.predict(dpredict)
-
-    if constraint > 0:
-        assert is_increasing(pred)
-    elif constraint < 0:
-        assert is_decreasing(pred)
-
-
-@pytest.mark.skipif(**tm.no_sklearn())
-def test_gpu_hist_basic() -> None:
-    assert_constraint(1, "hist")
-    assert_constraint(-1, "hist")
-
-
-@pytest.mark.skipif(**tm.no_sklearn())
-def test_gpu_approx_basic() -> None:
-    assert_constraint(1, "approx")
-    assert_constraint(-1, "approx")
-
-
-def test_gpu_hist_depthwise() -> None:
-    params = {
-        "tree_method": "hist",
-        "grow_policy": "depthwise",
-        "device": "cuda",
-        "monotone_constraints": "(1, -1)",
-    }
-    model = xgb.train(params, training_dset)
-    is_correctly_constrained(model)
-
-
-def test_gpu_hist_lossguide() -> None:
-    params = {
-        "tree_method": "hist",
-        "grow_policy": "lossguide",
-        "device": "cuda",
-        "monotone_constraints": "(1, -1)",
-    }
-    model = xgb.train(params, training_dset)
-    is_correctly_constrained(model)
+@pytest.mark.parametrize(
+    "tree_method,policy",
+    [
+        ("hist", "depthwise"),
+        ("approx", "depthwise"),
+        ("hist", "lossguide"),
+        ("approx", "lossguide"),
+    ],
+)
+def test_gpu_monotone_constraints(tree_method: str, policy: str) -> None:
+    run_monotone_constraints("cuda", tree_method, policy)
 
 
 @pytest.mark.parametrize("multi_strategy", ["one_output_per_tree", "multi_output_tree"])
 def test_parent_gain(multi_strategy: str) -> None:
     run_parent_gain("cuda", multi_strategy)
+
+
+@pytest.mark.parametrize("policy", ["depthwise", "lossguide"])
+def test_vector_leaf_monotone(policy: str) -> None:
+    run_monotone_constraints("cuda", "hist", policy, multi_strategy="multi_output_tree")
+
+
+@pytest.mark.parametrize("multi_strategy", ["one_output_per_tree", "multi_output_tree"])
+@pytest.mark.parametrize("policy", ["depthwise", "lossguide"])
+def test_deep_monotone(policy: str, multi_strategy: str) -> None:
+    run_multi_output_monotone("cuda", policy, multi_strategy)

--- a/tests/python-gpu/test_monotonic_constraints.py
+++ b/tests/python-gpu/test_monotonic_constraints.py
@@ -67,5 +67,6 @@ def test_gpu_hist_lossguide() -> None:
     is_correctly_constrained(model)
 
 
-def test_parent_gain() -> None:
-    run_parent_gain("cuda")
+@pytest.mark.parametrize("multi_strategy", ["one_output_per_tree", "multi_output_tree"])
+def test_parent_gain(multi_strategy: str) -> None:
+    run_parent_gain("cuda", multi_strategy)

--- a/tests/python/test_monotone_constraints.py
+++ b/tests/python/test_monotone_constraints.py
@@ -89,7 +89,7 @@ class TestMonotoneConstraints:
             "monotone_constraints": {"feature_0": 1, "feature_1": -1},
         }
 
-        if format == list:
+        if format is list:
             params = list(params.items())
 
         with pytest.raises(ValueError):
@@ -138,5 +138,6 @@ class TestMonotoneConstraints:
         assert accuracy_score(dtest.get_label(), pred_dtest) < 0.1
 
 
-def test_parent_gain() -> None:
-    run_parent_gain("cpu")
+@pytest.mark.parametrize("multi_strategy", ["one_output_per_tree", "multi_output_tree"])
+def test_parent_gain(multi_strategy: str) -> None:
+    run_parent_gain("cpu", multi_strategy)

--- a/tests/python/test_monotone_constraints.py
+++ b/tests/python/test_monotone_constraints.py
@@ -1,87 +1,27 @@
 from typing import Type
 
-import numpy as np
 import pytest
 import xgboost as xgb
 from xgboost import testing as tm
 from xgboost.testing.monotone_constraints import (
-    is_decreasing,
-    is_increasing,
+    is_correctly_constrained,
+    run_monotone_constraints,
+    run_multi_output_monotone,
     run_parent_gain,
     training_dset,
     x,
     y,
 )
 
-dpath = "demo/data/"
-
-
-def is_correctly_constrained(learner, feature_names=None):
-    n = 100
-    variable_x = np.linspace(0, 1, n).reshape((n, 1))
-    fixed_xs_values = np.linspace(0, 1, n)
-
-    for i in range(n):
-        fixed_x = fixed_xs_values[i] * np.ones((n, 1))
-        monotonically_increasing_x = np.column_stack((variable_x, fixed_x))
-        monotonically_increasing_dset = xgb.DMatrix(
-            monotonically_increasing_x, feature_names=feature_names
-        )
-        monotonically_increasing_y = learner.predict(monotonically_increasing_dset)
-
-        monotonically_decreasing_x = np.column_stack((fixed_x, variable_x))
-        monotonically_decreasing_dset = xgb.DMatrix(
-            monotonically_decreasing_x, feature_names=feature_names
-        )
-        monotonically_decreasing_y = learner.predict(monotonically_decreasing_dset)
-
-        if not (
-            is_increasing(monotonically_increasing_y)
-            and is_decreasing(monotonically_decreasing_y)
-        ):
-            return False
-
-    return True
-
 
 class TestMonotoneConstraints:
-    def test_monotone_constraints_for_exact_tree_method(self) -> None:
-        # first check monotonicity for the 'exact' tree method
-        params_for_constrained_exact_method = {
-            "tree_method": "exact",
-            "verbosity": 1,
-            "monotone_constraints": "(1, -1)",
-        }
-        constrained_exact_method = xgb.train(
-            params_for_constrained_exact_method, training_dset
-        )
-        assert is_correctly_constrained(constrained_exact_method)
-
-    @pytest.mark.parametrize(
-        "tree_method,policy",
-        [
-            ("hist", "depthwise"),
-            ("approx", "depthwise"),
-            ("hist", "lossguide"),
-            ("approx", "lossguide"),
-        ],
-    )
-    def test_monotone_constraints(self, tree_method: str, policy: str) -> None:
-        params_for_constrained = {
-            "tree_method": tree_method,
-            "grow_policy": policy,
-            "monotone_constraints": "(1, -1)",
-        }
-        constrained = xgb.train(params_for_constrained, training_dset)
-        assert is_correctly_constrained(constrained)
-
     def test_monotone_constraints_tuple(self) -> None:
         params_for_constrained = {"monotone_constraints": (1, -1)}
         constrained = xgb.train(params_for_constrained, training_dset)
         assert is_correctly_constrained(constrained)
 
-    @pytest.mark.parametrize("format", [dict, list])
-    def test_monotone_constraints_feature_names(self, format: Type) -> None:
+    @pytest.mark.parametrize("fmt", [dict, list])
+    def test_monotone_constraints_feature_names(self, fmt: Type) -> None:
         # next check monotonicity when initializing monotone_constraints by feature names
         params = {
             "tree_method": "hist",
@@ -89,8 +29,8 @@ class TestMonotoneConstraints:
             "monotone_constraints": {"feature_0": 1, "feature_1": -1},
         }
 
-        if format is list:
-            params = list(params.items())
+        if fmt is list:
+            params = list(params.items())  # type: ignore
 
         with pytest.raises(ValueError):
             xgb.train(params, training_dset)
@@ -116,6 +56,7 @@ class TestMonotoneConstraints:
     def test_training_accuracy(self) -> None:
         from sklearn.metrics import accuracy_score
 
+        dpath = "demo/data/"
         dtrain = xgb.DMatrix(dpath + "agaricus.txt.train?indexing_mode=1&format=libsvm")
         dtest = xgb.DMatrix(dpath + "agaricus.txt.test?indexing_mode=1&format=libsvm")
         params = {
@@ -138,6 +79,32 @@ class TestMonotoneConstraints:
         assert accuracy_score(dtest.get_label(), pred_dtest) < 0.1
 
 
+@pytest.mark.parametrize(
+    "tree_method,policy",
+    [
+        # exact only supports depthwise growth.
+        ("exact", "depthwise"),
+        ("hist", "depthwise"),
+        ("approx", "depthwise"),
+        ("hist", "lossguide"),
+        ("approx", "lossguide"),
+    ],
+)
+def test_monotone_constraints(tree_method: str, policy: str) -> None:
+    run_monotone_constraints("cpu", tree_method, policy)
+
+
 @pytest.mark.parametrize("multi_strategy", ["one_output_per_tree", "multi_output_tree"])
 def test_parent_gain(multi_strategy: str) -> None:
     run_parent_gain("cpu", multi_strategy)
+
+
+@pytest.mark.parametrize("policy", ["depthwise", "lossguide"])
+def test_vector_leaf_monotone(policy: str) -> None:
+    run_monotone_constraints("cpu", "hist", policy, multi_strategy="multi_output_tree")
+
+
+@pytest.mark.parametrize("multi_strategy", ["one_output_per_tree", "multi_output_tree"])
+@pytest.mark.parametrize("policy", ["depthwise", "lossguide"])
+def test_deep_monotone(policy: str, multi_strategy: str) -> None:
+    run_multi_output_monotone("cpu", policy, multi_strategy)

--- a/tests/python/test_multi_target.py
+++ b/tests/python/test_multi_target.py
@@ -236,11 +236,14 @@ def test_reduced_grad() -> None:
         "max_depth": 1,
         "monotone_constraints": "(1, 0)",
     }
-    with pytest.raises(xgb.core.XGBoostError, match="value gradient"):
-        xgb.train(params, Xy, num_boost_round=1, obj=LsObj2("cpu", False))
+    booster = xgb.train(params, Xy, num_boost_round=1, obj=LsObj2("cpu", False))
+    predt = booster.predict(Xy)
+    assert predt.shape == y.shape
 
+    # Reduced-gradient bounds must not be applied to the full-dimensional leaf refresh.
     params["monotone_constraints"] = "(0, 0)"
-    xgb.train(params, Xy, num_boost_round=1, obj=LsObj2("cpu", False))
+    reference = xgb.train(params, Xy, num_boost_round=1, obj=LsObj2("cpu", False))
+    np.testing.assert_allclose(predt, reference.predict(Xy))
 
 
 def test_with_iter() -> None:

--- a/tests/python/test_multi_target.py
+++ b/tests/python/test_multi_target.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 # pylint: disable=missing-function-docstring
-import json
 from typing import Any, Callable, Dict
 
 import numpy as np
@@ -11,7 +10,6 @@ import xgboost as xgb
 from hypothesis import given, note, settings, strategies
 from xgboost import testing as tm
 from xgboost.testing.multi_target import (
-    LsObj2,
     all_reg_objectives,
     check_categorical_mixed,
     run_absolute_error,
@@ -37,54 +35,6 @@ from xgboost.testing.params import (
 )
 from xgboost.testing.updater import check_quantile_loss_rf, train_result
 from xgboost.testing.utils import Device
-
-
-@pytest.mark.parametrize("grow_policy", ["depthwise", "lossguide"])
-@pytest.mark.parametrize("direction", [1, -1])
-def test_monotone_constraints_propagate(grow_policy: str, direction: int) -> None:
-    X = np.array([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=np.float32)
-    weights = direction * np.array(
-        [[-10.0, -6.0, 2.0], [8.0, 4.0, 2.0], [10.0, 6.0, 1.0], [-8.0, -4.0, 1.0]],
-        dtype=np.float32,
-    )
-    Xy = xgb.DMatrix(X, label=np.zeros_like(weights))
-
-    def objective(
-        _predt: np.ndarray, _dtrain: xgb.DMatrix
-    ) -> tuple[np.ndarray, np.ndarray]:
-        return -weights, np.ones_like(weights)
-
-    booster = xgb.train(
-        {
-            "tree_method": "hist",
-            "multi_strategy": "multi_output_tree",
-            "grow_policy": grow_policy,
-            "max_depth": 2,
-            "min_child_weight": 0,
-            "reg_lambda": 0,
-            "reg_alpha": 0,
-            "eta": 1,
-            "base_score": 0,
-            "monotone_constraints": f"({direction}, 0)",
-        },
-        Xy,
-        num_boost_round=1,
-        obj=objective,
-    )
-
-    tree = json.loads(booster.get_dump(dump_format="json")[0])
-    assert tree["split"] == "f0"
-    assert all(child["split"] == "f1" for child in tree["children"])
-    children = {child["nodeid"]: child for child in tree["children"]}
-    left = np.array([leaf["leaf"] for leaf in children[tree["yes"]]["children"]])
-    right = np.array([leaf["leaf"] for leaf in children[tree["no"]]["children"]])
-    if direction > 0:
-        assert np.all(left.max(axis=0) <= right.min(axis=0))
-    else:
-        assert np.all(left.min(axis=0) >= right.max(axis=0))
-    # The third target crosses at the root and is pooled instead of vetoing the shared split.
-    np.testing.assert_allclose(left[:, 2], 1.5 * direction)
-    np.testing.assert_allclose(right[:, 2], 1.5 * direction)
 
 
 @pytest.mark.skipif(**tm.no_pandas())
@@ -226,24 +176,6 @@ def test_absolute_error() -> None:
 
 def test_reduced_grad() -> None:
     run_reduced_grad("cpu")
-
-    X = np.arange(32, dtype=np.float32).reshape(16, 2)
-    y = np.stack([X[:, 0], X[:, 1]], axis=1)
-    Xy = xgb.QuantileDMatrix(X, y)
-    params = {
-        "tree_method": "hist",
-        "multi_strategy": "multi_output_tree",
-        "max_depth": 1,
-        "monotone_constraints": "(1, 0)",
-    }
-    booster = xgb.train(params, Xy, num_boost_round=1, obj=LsObj2("cpu", False))
-    predt = booster.predict(Xy)
-    assert predt.shape == y.shape
-
-    # Reduced-gradient bounds must not be applied to the full-dimensional leaf refresh.
-    params["monotone_constraints"] = "(0, 0)"
-    reference = xgb.train(params, Xy, num_boost_round=1, obj=LsObj2("cpu", False))
-    np.testing.assert_allclose(predt, reference.predict(Xy))
 
 
 def test_with_iter() -> None:

--- a/tests/python/test_multi_target.py
+++ b/tests/python/test_multi_target.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 # pylint: disable=missing-function-docstring
+import json
 from typing import Any, Callable, Dict
 
 import numpy as np
@@ -10,6 +11,7 @@ import xgboost as xgb
 from hypothesis import given, note, settings, strategies
 from xgboost import testing as tm
 from xgboost.testing.multi_target import (
+    LsObj2,
     all_reg_objectives,
     check_categorical_mixed,
     run_absolute_error,
@@ -35,6 +37,54 @@ from xgboost.testing.params import (
 )
 from xgboost.testing.updater import check_quantile_loss_rf, train_result
 from xgboost.testing.utils import Device
+
+
+@pytest.mark.parametrize("grow_policy", ["depthwise", "lossguide"])
+@pytest.mark.parametrize("direction", [1, -1])
+def test_monotone_constraints_propagate(grow_policy: str, direction: int) -> None:
+    X = np.array([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=np.float32)
+    weights = direction * np.array(
+        [[-10.0, -6.0, 2.0], [8.0, 4.0, 2.0], [10.0, 6.0, 1.0], [-8.0, -4.0, 1.0]],
+        dtype=np.float32,
+    )
+    Xy = xgb.DMatrix(X, label=np.zeros_like(weights))
+
+    def objective(
+        _predt: np.ndarray, _dtrain: xgb.DMatrix
+    ) -> tuple[np.ndarray, np.ndarray]:
+        return -weights, np.ones_like(weights)
+
+    booster = xgb.train(
+        {
+            "tree_method": "hist",
+            "multi_strategy": "multi_output_tree",
+            "grow_policy": grow_policy,
+            "max_depth": 2,
+            "min_child_weight": 0,
+            "reg_lambda": 0,
+            "reg_alpha": 0,
+            "eta": 1,
+            "base_score": 0,
+            "monotone_constraints": f"({direction}, 0)",
+        },
+        Xy,
+        num_boost_round=1,
+        obj=objective,
+    )
+
+    tree = json.loads(booster.get_dump(dump_format="json")[0])
+    assert tree["split"] == "f0"
+    assert all(child["split"] == "f1" for child in tree["children"])
+    children = {child["nodeid"]: child for child in tree["children"]}
+    left = np.array([leaf["leaf"] for leaf in children[tree["yes"]]["children"]])
+    right = np.array([leaf["leaf"] for leaf in children[tree["no"]]["children"]])
+    if direction > 0:
+        assert np.all(left.max(axis=0) <= right.min(axis=0))
+    else:
+        assert np.all(left.min(axis=0) >= right.max(axis=0))
+    # The third target crosses at the root and is pooled instead of vetoing the shared split.
+    np.testing.assert_allclose(left[:, 2], 1.5 * direction)
+    np.testing.assert_allclose(right[:, 2], 1.5 * direction)
 
 
 @pytest.mark.skipif(**tm.no_pandas())
@@ -176,6 +226,21 @@ def test_absolute_error() -> None:
 
 def test_reduced_grad() -> None:
     run_reduced_grad("cpu")
+
+    X = np.arange(32, dtype=np.float32).reshape(16, 2)
+    y = np.stack([X[:, 0], X[:, 1]], axis=1)
+    Xy = xgb.QuantileDMatrix(X, y)
+    params = {
+        "tree_method": "hist",
+        "multi_strategy": "multi_output_tree",
+        "max_depth": 1,
+        "monotone_constraints": "(1, 0)",
+    }
+    with pytest.raises(xgb.core.XGBoostError, match="value gradient"):
+        xgb.train(params, Xy, num_boost_round=1, obj=LsObj2("cpu", False))
+
+    params["monotone_constraints"] = "(0, 0)"
+    xgb.train(params, Xy, num_boost_round=1, obj=LsObj2("cpu", False))
 
 
 def test_with_iter() -> None:


### PR DESCRIPTION
Ref: https://github.com/dmlc/xgboost/issues/9043

- Use the optimal shared weight when the split doesn't meet the constraint. Instead of rejecting the split, let it continue the evaluation with this shared weight.
- Reject reduced gradient.
- Ensure categorical features histogram sort doesn't use the constraint to calculate the scores.
- Cleanup tests.