### PR TITLE
Copy license into the Python package.

### DIFF
--- a/.github/workflows/python_wheels_winarm64.yml
+++ b/.github/workflows/python_wheels_winarm64.yml
@@ -55,7 +55,6 @@ jobs:
 
       - name: Build Python wheel xgboost for Win-ARM64
         run: |
-          python ops/script/pypi_variants.py --use-suffix=na --require-nccl-dep=cu12
           cd python-package
           mkdir -p wheelhouse
           pip wheel --no-deps -v . --wheel-dir wheelhouse/

--- a/ops/pipeline/build-cuda-impl.sh
+++ b/ops/pipeline/build-cuda-impl.sh
@@ -52,7 +52,6 @@ time ninja -v
 popd
 
 echo "--- Build binary wheel"
-python3 ops/script/pypi_variants.py --use-suffix=na --require-nccl-dep=cu12
 pushd python-package
 rm -rfv dist/*
 pip wheel --no-deps -v . --wheel-dir dist/

--- a/ops/pipeline/build-python-wheels-arm64-impl.sh
+++ b/ops/pipeline/build-python-wheels-arm64-impl.sh
@@ -26,7 +26,6 @@ ctest --extra-verbose
 popd
 
 echo "--- Build binary wheel"
-python3 ops/script/pypi_variants.py --use-suffix=na --require-nccl-dep=cu12
 pushd python-package
 rm -rfv dist/*
 pip wheel --no-deps -v . --wheel-dir dist/

--- a/ops/pipeline/build-python-wheels-macos.sh
+++ b/ops/pipeline/build-python-wheels-macos.sh
@@ -41,6 +41,5 @@ export CIBW_REPAIR_WHEEL_COMMAND_MACOS="delocate-wheel --require-archs {delocate
 
 brew unlink llvm@18 || true
 
-python3 ops/script/pypi_variants.py --use-suffix=na --require-nccl-dep=cu12
 python -m pip install cibuildwheel
 python -m cibuildwheel python-package --output-dir wheelhouse

--- a/ops/pipeline/build-test-sycl.sh
+++ b/ops/pipeline/build-test-sycl.sh
@@ -24,7 +24,6 @@ case "$suite" in
     ./build/testxgboost
     ;;
   pytest)
-    python3 ops/script/pypi_variants.py --use-suffix=na --require-nccl-dep=cu12
     cd python-package
     python --version
     pip install -v .

--- a/ops/pipeline/build-win64.ps1
+++ b/ops/pipeline/build-win64.ps1
@@ -70,10 +70,6 @@ if ($variant -eq "cpu") {
   conda activate
   python ops/script/pypi_variants.py --use-suffix=cpu --require-nccl-dep=na
   if ($LASTEXITCODE -ne 0) { throw "Last command failed" }
-} else {
-  conda activate
-  python ops/script/pypi_variants.py --use-suffix=na --require-nccl-dep=cu12
-  if ($LASTEXITCODE -ne 0) { throw "Last command failed" }
 }
 
 cd python-package

--- a/ops/pipeline/test-python-macos.sh
+++ b/ops/pipeline/test-python-macos.sh
@@ -14,7 +14,6 @@ cmake .. -GNinja -DCMAKE_PREFIX_PATH=$CONDA_PREFIX
 ninja
 popd
 
-python3 ops/script/pypi_variants.py --use-suffix=na --require-nccl-dep=cu12
 cd python-package
 python --version
 pip install -v .

--- a/ops/pipeline/test-python-with-sysprefix.sh
+++ b/ops/pipeline/test-python-with-sysprefix.sh
@@ -15,7 +15,6 @@ popd
 cp -v lib/* "$(python -c 'import sys; print(sys.base_prefix)')/lib"
 
 # Now configure Python XGBoost to use libxgboost.so from the system prefix
-python3 ops/script/pypi_variants.py --use-suffix=na --require-nccl-dep=cu12
 cd python-package
 pip install virtualenv
 virtualenv venv

--- a/ops/script/prepare_sdist.py
+++ b/ops/script/prepare_sdist.py
@@ -14,7 +14,6 @@ import pathlib
 import shutil
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
-PY_PACKAGE = REPO_ROOT / "python-package"
 STAGING_DIR = REPO_ROOT / "python-package" / "cpp_src"
 
 CPP_SUBDIRS = ["src", "include", "dmlc-core", "cmake", "plugin"]
@@ -22,8 +21,6 @@ CPP_FILES = ["CMakeLists.txt", "LICENSE"]
 
 
 def stage() -> None:
-    shutil.copy(REPO_ROOT / "LICENSE", PY_PACKAGE / "LICENSE")
-    print(f"Copy {REPO_ROOT / 'LICENSE'} -> {PY_PACKAGE / 'LICENSE'}")
     if STAGING_DIR.exists():
         shutil.rmtree(STAGING_DIR)
     STAGING_DIR.mkdir(parents=True)

--- a/ops/script/pypi_variants.py
+++ b/ops/script/pypi_variants.py
@@ -4,14 +4,12 @@ import argparse
 import os
 
 import tomllib
+from packaging.version import Version
 from test_utils import PY_PACKAGE
 
 IN_PATH = os.path.join(PY_PACKAGE, "pyproject.toml.in")
 STUB_IN_PATH = os.path.join(PY_PACKAGE, "pyproject.toml.stub.in")
 OUT_PATH = os.path.join(PY_PACKAGE, "pyproject.toml")
-REPO_ROOT = os.path.dirname(PY_PACKAGE)
-LICENSE_PATH = os.path.join(REPO_ROOT, "LICENSE")
-PY_PACKAGE_LICENSE_PATH = os.path.join(PY_PACKAGE, "LICENSE")
 
 NCCL_WHL = """    \"nvidia-nccl-{0} ; platform_system == 'Linux'\","""
 
@@ -64,11 +62,12 @@ def make_pyproject(
     pyproject = pyproject.replace(
         NAME, f"xgboost-{use_suffix}" if use_suffix != "na" else "xgboost"
     )
-    copyfile(LICENSE_PATH, PY_PACKAGE_LICENSE_PATH)
     if create_stub:
         copyfile(readme_stub, readme)
         pyproject_parsed = tomllib.loads(pyproject)
-        pyproject = pyproject.replace(VERSION, pyproject_parsed["project"]["version"])
+        pyproject = pyproject.replace(
+            VERSION, str(Version(pyproject_parsed["project"]["version"]))
+        )
     elif use_suffix == "cpu":
         copyfile(readme_cpu, readme)
     else:

--- a/python-package/LICENSE
+++ b/python-package/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (c) 2019 by Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
- Fix editable installation.

https://github.com/dmlc/xgboost/pull/12280 uses the CI script to copy, which is fine for CI but breaks the normal development flow. This PR permanently copies the LICENSE file into the Python directory.