### PR TITLE
[R] Remove obsolete 32-bit Windows thread_local workaround

### DIFF
--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -14,11 +14,6 @@ XGB_RFLAGS = \
     -DDMLC_ENABLE_STD_THREAD=$(ENABLE_STD_THREAD) \
     -DDMLC_DISABLE_STDIN=1 \
     -DDMLC_LOG_CUSTOMIZE=1
-
-# disable the use of thread_local for 32 bit windows:
-ifeq ($(R_OSTYPE)$(WIN),windows)
-    XGB_RFLAGS += -DDMLC_CXX11_THREAD_LOCAL=0
-endif
 $(foreach v, $(XGB_RFLAGS), $(warning $(v)))
 
 PKG_CPPFLAGS = \

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -11,11 +11,6 @@ XGB_RFLAGS = \
     -DDMLC_ENABLE_STD_THREAD=$(ENABLE_STD_THREAD) \
     -DDMLC_DISABLE_STDIN=1 \
     -DDMLC_LOG_CUSTOMIZE=1
-
-# disable the use of thread_local for 32 bit windows:
-ifeq ($(R_OSTYPE)$(WIN),windows)
-    XGB_RFLAGS += -DDMLC_CXX11_THREAD_LOCAL=0
-endif
 $(foreach v, $(XGB_RFLAGS), $(warning $(v)))
 
 PKG_CPPFLAGS = \


### PR DESCRIPTION
Fxes #12350

The R package fails to compile on Windows arm64 (Rtools aarch64) with:

```
src/c_api/c_api.cc:68:15: error: static assertion failed: XGBoost depends on thread-local storage.
```

Both `Makevars.win.in` and `Makevars.in` contain a workaround from #2994 (2017) that disables `thread_local` on 32-bit Windows:

```make
# disable the use of thread_local for 32 bit windows:
ifeq ($(R_OSTYPE)$(WIN),windows)
    XGB_RFLAGS += -DDMLC_CXX11_THREAD_LOCAL=0
endif
```

R dropped 32-bit Windows support in R 4.2, and `thread_local` works on all current Rtools toolchains (including clang/aarch64), so this removes the block entirely. Without the define, dmlc-core auto-detects `thread_local` support.

Failing build for reference: https://github.com/r-universe/cran/actions/runs/29968522901/job/89121138819
