### PR TITLE
Replace the name `num_output_group` with the number of targets.

### DIFF
--- a/demo/guide-python/model_parser.py
+++ b/demo/guide-python/model_parser.py
@@ -25,17 +25,21 @@ ParamT = Dict[str, str]
 
 def to_integers(data: Union[bytes, List[int]]) -> List[int]:
     """Convert a sequence of bytes to a list of Python integer"""
-    return [v for v in data]
+    return list(data)
 
 
 @unique
 class SplitType(IntEnum):
+    """Feature type used for tree split."""
+
     numerical = 0
     categorical = 1
 
 
 @dataclass
-class Node:
+class Node:  # pylint: disable=too-many-instance-attributes
+    """Scalar tree node."""
+
     # properties
     left: int
     right: int
@@ -87,6 +91,7 @@ class Tree:
         return self.nodes[node_id].split_type == SplitType.categorical
 
     def is_numerical(self, node_id: int) -> bool:
+        """Is this a numerical split."""
         return not self.is_categorical(node_id)
 
     def parent(self, node_id: int) -> int:
@@ -143,6 +148,7 @@ class Tree:
 class Model:
     """Gradient boosted tree model."""
 
+    # pylint: disable=too-many-locals, too-many-statements
     def __init__(self, model: dict) -> None:
         """Construct the Model from a JSON object.
 
@@ -152,12 +158,16 @@ class Model:
         """
         # Basic properties of a model
         self.learner_model_shape: ParamT = model["learner"]["learner_model_param"]
-        self.num_output_group = int(self.learner_model_shape["num_class"])
+        self.n_targets = max(
+            int(self.learner_model_shape["num_class"]),
+            int(self.learner_model_shape.get("num_target", 1)),
+            1,
+        )
         self.num_feature = int(self.learner_model_shape["num_feature"])
         self.base_score: List[float] = json.loads(
             self.learner_model_shape["base_score"]
         )
-        # A field encoding which output group a tree belongs
+        # Scalar-tree target routing indices; vector-leaf trees use a zero sentinel.
         self.tree_info = model["learner"]["gradient_booster"]["model"]["tree_info"]
 
         model_shape: ParamT = model["learner"]["gradient_booster"]["model"][
@@ -254,22 +264,17 @@ class Model:
         self.trees = trees
 
     def print_model(self) -> None:
+        """Print the model to stdout."""
         for i, tree in enumerate(self.trees):
             print("\ntree_id:", i)
             print(tree)
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Demonstration for loading XGBoost JSON/UBJSON model."
-    )
-    parser.add_argument(
-        "--model", type=str, required=True, help="Path to .json/.ubj model file."
-    )
-    args = parser.parse_args()
+def main(args: argparse.Namespace) -> None:
+    """Entry point."""
     if args.model.endswith("json"):
         # use json format
-        with open(args.model, "r") as fd:
+        with open(args.model, "r", encoding="utf-8") as fd:
             model = json.load(fd)
     elif args.model.endswith("ubj"):
         if ubjson is None:
@@ -283,3 +288,14 @@ if __name__ == "__main__":
         )
     model = Model(model)
     model.print_model()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Demonstration for loading XGBoost JSON/UBJSON model."
+    )
+    parser.add_argument(
+        "--model", type=str, required=True, help="Path to .json/.ubj model file."
+    )
+    cli_args = parser.parse_args()
+    main(cli_args)

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -122,7 +122,7 @@ class GradientBooster : public Model, public Configurable {
 
   /*!
    * \brief feature contributions to individual predictions; the output will be a vector
-   *         of length (nfeats + 1) * num_output_group * nsample, arranged in that order
+   *         of length (nfeats + 1) * n_targets * nsample, arranged in that order
    * \param dmat feature matrix
    * \param out_contribs output vector to hold the contributions
    * \param layer_begin Beginning of boosted tree layer used for prediction.

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -146,9 +146,9 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    */
   virtual int32_t BoostedRounds() const = 0;
   /**
-   * \brief Get the number of output groups from the model.
+   * \brief Get the number of targets from the model.
    */
-  virtual std::uint32_t Groups() const = 0;
+  virtual bst_target_t NumTargets() const = 0;
 
   void LoadModel(Json const& in) override = 0;
   void SaveModel(Json* out) const override = 0;
@@ -316,7 +316,7 @@ struct LearnerModelParam {
   /**
    * @brief The number of classes or targets.
    */
-  std::uint32_t num_output_group{0};
+  bst_target_t n_targets{0};
   /**
    * @brief Current task, determined by objective.
    */
@@ -331,10 +331,10 @@ struct LearnerModelParam {
                     linalg::Vector<float> base_score, ObjInfo t, MultiStrategy multi_strategy);
   // This ctor is only used by tests.
   LearnerModelParam(bst_feature_t n_features, linalg::Vector<float> base_score,
-                    std::uint32_t n_groups, bst_target_t n_targets, MultiStrategy multi_strategy)
+                    bst_target_t n_targets, MultiStrategy multi_strategy)
       : base_score_{std::move(base_score)},
         num_feature{n_features},
-        num_output_group{std::max(n_groups, n_targets)},
+        n_targets{n_targets},
         multi_strategy{multi_strategy} {}
 
   linalg::VectorView<float const> BaseScore(Context const* ctx) const;
@@ -344,13 +344,13 @@ struct LearnerModelParam {
   [[nodiscard]] bool IsVectorLeaf() const noexcept {
     return multi_strategy == MultiStrategy::kMultiOutputTree;
   }
-  [[nodiscard]] bst_target_t OutputLength() const noexcept { return this->num_output_group; }
-  [[nodiscard]] bst_target_t LeafLength() const noexcept {
-    return this->IsVectorLeaf() ? this->OutputLength() : 1;
+  [[nodiscard]] bst_target_t NumTargets() const noexcept { return this->n_targets; }
+  [[nodiscard]] bst_target_t NumTreeTargets() const noexcept {
+    return this->IsVectorLeaf() ? this->NumTargets() : 1;
   }
 
   /* \brief Whether this parameter is initialized with LearnerModelParamLegacy. */
-  [[nodiscard]] bool Initialized() const { return num_feature != 0 && num_output_group != 0; }
+  [[nodiscard]] bool Initialized() const { return num_feature != 0 && n_targets != 0; }
 };
 
 }  // namespace xgboost

--- a/include/xgboost/objective.h
+++ b/include/xgboost/objective.h
@@ -123,13 +123,13 @@ class ObjFunction : public Configurable {
    * @param info MetaInfo providing labels and weights.
    * @param learning_rate The learning rate for current iteration.
    * @param prediction Model prediction after transformation.
-   * @param group_idx The group index for this tree, 0 when it's not multi-target or multi-class.
+   * @param target_idx Target index for a scalar tree; zero for a vector-leaf tree.
    * @param p_tree Tree that needs to be updated.
    */
   virtual void UpdateTreeLeaf(HostDeviceVector<bst_node_t> const& /*position*/,
                               MetaInfo const& /*info*/, float /*learning_rate*/,
                               HostDeviceVector<float> const& /*prediction*/,
-                              bst_target_t /*group_idx*/, RegTree* /*p_tree*/) const {}
+                              bst_target_t /*target_idx*/, RegTree* /*p_tree*/) const {}
   /**
    * @brief Create an objective function according to the name.
    *

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -143,7 +143,7 @@ class Predictor {
 
   /**
    * \brief feature contributions to individual predictions; the output will be
-   * a vector of length (nfeats + 1) * num_output_group * nsample, arranged in
+   * a vector of length (nfeats + 1) * n_targets * nsample, arranged in
    * that order.
    *
    * \param [in,out]  dmat               The input feature matrix.

--- a/plugin/sycl/predictor/predictor.cc
+++ b/plugin/sycl/predictor/predictor.cc
@@ -84,7 +84,7 @@ class DeviceModel {
       }
     }
 
-    int num_group = model.learner_model_param->num_output_group;
+    int num_group = model.learner_model_param->NumTargets();
     if (num_group > 1) {
       tree_group.Resize(model.tree_info.Size());
       auto& tree_group_host = tree_group.HostVector();
@@ -405,7 +405,7 @@ class Predictor : public xgboost::Predictor {
 
     device_model.Init(model, tree_begin, tree_end);
 
-    int num_group = model.learner_model_param->num_output_group;
+    int num_group = model.learner_model_param->NumTargets();
     int num_features = dmat->Info().num_col_;
 
     float* out_predictions = out_preds->DevicePointer();

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -2505,8 +2505,8 @@ class Booster:
         strict_shape :
             When set to True, output shape is invariant to whether classification is
             used.  For both value and margin prediction, the output shape is (n_samples,
-            n_groups), n_groups == 1 when multi-class is not used.  Default to False, in
-            which case the output shape can be (n_samples, ) if multi-class is not used.
+            n_targets), where n_targets == 1 for single-output models.  Default to False,
+            in which case the output shape can be (n_samples, ) for single-output models.
 
             .. versionadded:: 1.4.0
 
@@ -3163,7 +3163,7 @@ class Booster:
             size_leaf_vector = int(tree["tree_param"]["size_leaf_vector"])
             is_vector = size_leaf_vector > 1
             leaf_weights = tree["leaf_weights"] if is_vector else None
-            # The output group this tree contributes to.
+            # Scalar-tree target routing index; vector-leaf trees use a zero sentinel.
             tree_target = int(tree_info[tid])
 
             # Node id -> category codes, stored CSR-style.

--- a/python-package/xgboost/testing/shared.py
+++ b/python-package/xgboost/testing/shared.py
@@ -17,11 +17,11 @@ def validate_leaf_output(leaf: np.ndarray, num_parallel_tree: int) -> None:
     """Validate output for predict leaf tests."""
     for i in range(leaf.shape[0]):  # n_samples
         for j in range(leaf.shape[1]):  # n_rounds
-            for k in range(leaf.shape[2]):  # n_classes
-                tree_group = leaf[i, j, k, :]
-                assert tree_group.shape[0] == num_parallel_tree
+            for k in range(leaf.shape[2]):  # n_targets
+                parallel_trees = leaf[i, j, k, :]
+                assert parallel_trees.shape[0] == num_parallel_tree
                 # No sampling, all trees within forest are the same
-                assert np.all(tree_group == tree_group[0])
+                assert np.all(parallel_trees == parallel_trees[0])
 
 
 def validate_data_initialization(

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1344,7 +1344,7 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle, DMatrixHandle dmat
   xgboost_CHECK_C_ARG_PTR(out_shape);
 
   CalcPredictShape(strict_shape, type, p_m->Info().num_row_, p_m->Info().num_col_, chunksize,
-                   learner->Groups(), n_rounds, &shape, out_dim);
+                   learner->NumTargets(), n_rounds, &shape, out_dim);
   *out_shape = dmlc::BeginPtr(shape);
   API_END();
 }
@@ -1370,7 +1370,7 @@ void InplacePredictImpl(std::shared_ptr<DMatrix> p_m, char const *c_json_config,
   bool strict_shape = RequiredArg<Boolean>(config, "strict_shape", __func__);
 
   xgboost_CHECK_C_ARG_PTR(out_dim);
-  CalcPredictShape(strict_shape, type, n_samples, n_features, chunksize, learner->Groups(),
+  CalcPredictShape(strict_shape, type, n_samples, n_features, chunksize, learner->NumTargets(),
                    learner->BoostedRounds(), &shape, out_dim);
   CHECK_GE(p_predt->Size(), n_samples);
 

--- a/src/c_api/c_api.cu
+++ b/src/c_api/c_api.cu
@@ -104,12 +104,11 @@ void CopyGradientFromCudaArrays(Context const *ctx, ArrayInterface<2, false> con
     });
   });
 }
-}                        // namespace xgboost
+}  // namespace xgboost
 
 using namespace xgboost;  // NOLINT
 
-XGB_DLL int XGDMatrixCreateFromCudaColumnar(char const *data,
-                                            char const* c_json_config,
+XGB_DLL int XGDMatrixCreateFromCudaColumnar(char const *data, char const *c_json_config,
                                             DMatrixHandle *out) {
   API_BEGIN();
 
@@ -122,13 +121,11 @@ XGB_DLL int XGDMatrixCreateFromCudaColumnar(char const *data,
   float missing = GetMissing(config);
   auto n_threads = OptionalArg<Integer, std::int64_t>(config, "nthread", 0);
   data::CudfAdapter adapter(json_str);
-  *out =
-      new std::shared_ptr<DMatrix>(DMatrix::Create(&adapter, missing, n_threads));
+  *out = new std::shared_ptr<DMatrix>(DMatrix::Create(&adapter, missing, n_threads));
   API_END();
 }
 
-XGB_DLL int XGDMatrixCreateFromCudaArrayInterface(char const *data,
-                                                  char const* c_json_config,
+XGB_DLL int XGDMatrixCreateFromCudaArrayInterface(char const *data, char const *c_json_config,
                                                   DMatrixHandle *out) {
   API_BEGIN();
   std::string json_str{data};
@@ -136,8 +133,7 @@ XGB_DLL int XGDMatrixCreateFromCudaArrayInterface(char const *data,
   float missing = GetMissing(config);
   auto n_threads = OptionalArg<Integer, std::int64_t>(config, "nthread", 0);
   data::CupyAdapter adapter(json_str);
-  *out =
-      new std::shared_ptr<DMatrix>(DMatrix::Create(&adapter, missing, n_threads));
+  *out = new std::shared_ptr<DMatrix>(DMatrix::Create(&adapter, missing, n_threads));
   API_END();
 }
 
@@ -186,7 +182,7 @@ int InplacePreidctCUDA(BoosterHandle handle, char const *data, char const *c_jso
   xgboost_CHECK_C_ARG_PTR(out_dim);
 
   CalcPredictShape(strict_shape, type, n_samples, p_m->Info().num_col_, chunksize,
-                   learner->Groups(), learner->BoostedRounds(), &shape, out_dim);
+                   learner->NumTargets(), learner->BoostedRounds(), &shape, out_dim);
   *out_shape = dmlc::BeginPtr(shape);
   *out_result = p_predt->ConstDevicePointer();
   API_END();

--- a/src/c_api/c_api_utils.h
+++ b/src/c_api/c_api_utils.h
@@ -27,102 +27,101 @@
 namespace xgboost {
 /* \brief Determine the output shape of prediction.
  *
- * \param strict_shape Whether should we reshape the output with consideration of groups
+ * \param strict_shape Whether should we reshape the output with consideration of targets
  *                     and forest.
  * \param type         Prediction type
  * \param rows         Input samples
  * \param cols         Input features
  * \param chunksize    Total elements of output / rows
- * \param groups       Number of output groups from Learner
+ * \param n_targets    Number of targets from Learner
  * \param rounds       end_iteration - beg_iteration
  * \param out_shape    Output shape
  * \param out_dim      Output dimension
  */
 inline void CalcPredictShape(bool strict_shape, PredictionType type, size_t rows, size_t cols,
-                             size_t chunksize, size_t groups, size_t rounds,
-                             std::vector<bst_ulong> *out_shape,
-                             xgboost::bst_ulong *out_dim) {
+                             size_t chunksize, size_t n_targets, size_t rounds,
+                             std::vector<bst_ulong> *out_shape, xgboost::bst_ulong *out_dim) {
   auto &shape = *out_shape;
   if (type == PredictionType::kMargin && rows != 0) {
     // When kValue is used, softmax can change the chunksize.
-    CHECK_EQ(chunksize, groups);
+    CHECK_EQ(chunksize, n_targets);
   }
 
   switch (type) {
-  case PredictionType::kValue:
-  case PredictionType::kMargin: {
-    if (chunksize == 1 && !strict_shape) {
-      *out_dim = 1;
-      shape.resize(*out_dim);
-      shape.front() = rows;
-    } else {
-      *out_dim = 2;
-      shape.resize(*out_dim);
-      shape.front() = rows;
-      // chunksize can be 1 if it's softmax
-      shape.back() = std::min(groups, chunksize);
+    case PredictionType::kValue:
+    case PredictionType::kMargin: {
+      if (chunksize == 1 && !strict_shape) {
+        *out_dim = 1;
+        shape.resize(*out_dim);
+        shape.front() = rows;
+      } else {
+        *out_dim = 2;
+        shape.resize(*out_dim);
+        shape.front() = rows;
+        // chunksize can be 1 if it's softmax
+        shape.back() = std::min(n_targets, chunksize);
+      }
+      break;
     }
-    break;
-  }
-  case PredictionType::kApproxContribution:
-  case PredictionType::kContribution: {
-    if (groups == 1 && !strict_shape) {
-      *out_dim = 2;
-      shape.resize(*out_dim);
-      shape.front() = rows;
-      shape.back() = cols + 1;
-    } else {
-      *out_dim = 3;
-      shape.resize(*out_dim);
-      shape[0] = rows;
-      shape[1] = groups;
-      shape[2] = cols + 1;
+    case PredictionType::kApproxContribution:
+    case PredictionType::kContribution: {
+      if (n_targets == 1 && !strict_shape) {
+        *out_dim = 2;
+        shape.resize(*out_dim);
+        shape.front() = rows;
+        shape.back() = cols + 1;
+      } else {
+        *out_dim = 3;
+        shape.resize(*out_dim);
+        shape[0] = rows;
+        shape[1] = n_targets;
+        shape[2] = cols + 1;
+      }
+      break;
     }
-    break;
-  }
-  case PredictionType::kApproxInteraction:
-  case PredictionType::kInteraction: {
-    if (groups == 1 && !strict_shape) {
-      *out_dim = 3;
-      shape.resize(*out_dim);
-      shape[0] = rows;
-      shape[1] = cols + 1;
-      shape[2] = cols + 1;
-    } else {
-      *out_dim = 4;
-      shape.resize(*out_dim);
-      shape[0] = rows;
-      shape[1] = groups;
-      shape[2] = cols + 1;
-      shape[3] = cols + 1;
+    case PredictionType::kApproxInteraction:
+    case PredictionType::kInteraction: {
+      if (n_targets == 1 && !strict_shape) {
+        *out_dim = 3;
+        shape.resize(*out_dim);
+        shape[0] = rows;
+        shape[1] = cols + 1;
+        shape[2] = cols + 1;
+      } else {
+        *out_dim = 4;
+        shape.resize(*out_dim);
+        shape[0] = rows;
+        shape[1] = n_targets;
+        shape[2] = cols + 1;
+        shape[3] = cols + 1;
+      }
+      break;
     }
-    break;
-  }
-  case PredictionType::kLeaf: {
-    if (strict_shape) {
-      shape.resize(4);
-      shape[0] = rows;
-      shape[1] = rounds;
-      shape[2] = groups;
-      auto forest = chunksize / (shape[1] * shape[2]);
-      forest = std::max(static_cast<decltype(forest)>(1), forest);
-      shape[3] = forest;
-      *out_dim = shape.size();
-    } else if (chunksize == 1) {
-      *out_dim = 1;
-      shape.resize(*out_dim);
-      shape.front() = rows;
-    } else {
-      *out_dim = 2;
-      shape.resize(*out_dim);
-      shape.front() = rows;
-      shape.back() = chunksize;
+    case PredictionType::kLeaf: {
+      if (strict_shape) {
+        shape.resize(4);
+        shape[0] = rows;
+        shape[1] = rounds;
+        shape[2] = n_targets;
+        auto forest = chunksize / (shape[1] * shape[2]);
+        forest = std::max(static_cast<decltype(forest)>(1), forest);
+        shape[3] = forest;
+        *out_dim = shape.size();
+      } else if (chunksize == 1) {
+        *out_dim = 1;
+        shape.resize(*out_dim);
+        shape.front() = rows;
+      } else {
+        *out_dim = 2;
+        shape.resize(*out_dim);
+        shape.front() = rows;
+        shape.back() = chunksize;
+      }
+      break;
     }
-    break;
-  }
-  default: {
-    LOG(FATAL) << "Unknown prediction type:" << static_cast<int>(type);
-  }
+    default: {
+      LOG(FATAL) << "Unknown prediction type:" << static_cast<int>(type);
+    }
   }
   CHECK_EQ(
       std::accumulate(shape.cbegin(), shape.cend(), static_cast<bst_ulong>(1), std::multiplies<>{}),
@@ -180,7 +179,7 @@ inline float GetMissing(Json const &config) {
 // Safe guard some global variables from being changed by XGBoost.
 class XGBoostAPIGuard {
 #if defined(XGBOOST_USE_CUDA)
-  std::int32_t device_id_ {0};
+  std::int32_t device_id_{0};
 
   void SetGPUAttribute();
   void RestoreGPUAttribute();
@@ -190,15 +189,11 @@ class XGBoostAPIGuard {
 #endif
 
  public:
-  XGBoostAPIGuard() {
-    SetGPUAttribute();
-  }
-  ~XGBoostAPIGuard() {
-    RestoreGPUAttribute();
-  }
+  XGBoostAPIGuard() { SetGPUAttribute(); }
+  ~XGBoostAPIGuard() { RestoreGPUAttribute(); }
 };
 
-inline FeatureMap LoadFeatureMap(std::string const& uri) {
+inline FeatureMap LoadFeatureMap(std::string const &uri) {
   FeatureMap feat;
   if (uri.size() != 0) {
     std::unique_ptr<dmlc::Stream> fs(dmlc::Stream::Create(uri.c_str(), "r"));
@@ -209,11 +204,10 @@ inline FeatureMap LoadFeatureMap(std::string const& uri) {
 }
 
 inline void GenerateFeatureMap(Learner const *learner,
-                               std::vector<Json> const &custom_feature_names,
-                               size_t n_features, FeatureMap *out_feature_map) {
+                               std::vector<Json> const &custom_feature_names, size_t n_features,
+                               FeatureMap *out_feature_map) {
   auto &feature_map = *out_feature_map;
-  auto maybe = [&](std::vector<std::string> const &values, size_t i,
-                   std::string const &dft) {
+  auto maybe = [&](std::vector<std::string> const &values, size_t i, std::string const &dft) {
     return values.empty() ? dft : values[i];
   };
   if (feature_map.Size() == 0) {
@@ -225,8 +219,7 @@ inline void GenerateFeatureMap(Learner const *learner,
     // 3. from booster
     // 4. default feature name.
     if (!custom_feature_names.empty()) {
-      CHECK_EQ(custom_feature_names.size(), n_features)
-          << "Incorrect number of feature names.";
+      CHECK_EQ(custom_feature_names.size(), n_features) << "Incorrect number of feature names.";
       feature_names.resize(custom_feature_names.size());
       std::transform(custom_feature_names.begin(), custom_feature_names.end(),
                      feature_names.begin(),
@@ -245,16 +238,14 @@ inline void GenerateFeatureMap(Learner const *learner,
     }
 
     for (size_t i = 0; i < n_features; ++i) {
-      feature_map.PushBack(
-          i,
-          maybe(feature_names, i, "f" + std::to_string(i)).data(),
-          maybe(feature_types, i, "q").data());
+      feature_map.PushBack(i, maybe(feature_names, i, "f" + std::to_string(i)).data(),
+                           maybe(feature_types, i, "q").data());
     }
   }
   CHECK_EQ(feature_map.Size(), n_features);
 }
 
-void XGBBuildInfoDevice(Json* p_info);
+void XGBBuildInfoDevice(Json *p_info);
 
 /**
  * \brief Get shared ptr from DMatrix C handle with additional checks.

--- a/src/data/data.cc
+++ b/src/data/data.cc
@@ -522,8 +522,8 @@ void ReshapeInfo(bst_idx_t n_samples, linalg::Matrix<float>* p_info, StringView 
     CHECK_EQ(p_info->Size() % n_samples, 0)
         << "Invalid size for `" << name << "`:(" << p_info->Shape(0) << "," << p_info->Shape(1)
         << "). n_samples:" << n_samples;
-    std::size_t n_groups = p_info->Size() / n_samples;
-    p_info->Reshape(n_samples, n_groups);
+    std::size_t n_targets = p_info->Size() / n_samples;
+    p_info->Reshape(n_samples, n_targets);
   }
 }
 }  // namespace

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -157,11 +157,11 @@ class GBLinear : public GradientBooster {
     model_.LazyInitModel();
     LinearCheckLayer(layer_begin);
     auto base_margin = p_fmat->Info().base_margin_.View(DeviceOrd::CPU());
-    const int ngroup = model_.learner_model_param->num_output_group;
+    auto const n_targets = model_.learner_model_param->NumTargets();
     const size_t ncolumns = model_.learner_model_param->num_feature + 1;
-    // allocate space for (#features + bias) times #groups times #rows
+    // Allocate space for (#features + bias) times #targets times #rows.
     std::vector<bst_float>& contribs = out_contribs->HostVector();
-    contribs.resize(p_fmat->Info().num_row_ * ncolumns * ngroup);
+    contribs.resize(p_fmat->Info().num_row_ * ncolumns * n_targets);
     // make sure contributions is zeroed, we could be reusing a previously allocated one
     std::fill(contribs.begin(), contribs.end(), 0);
     auto base_score = learner_model_param_->BaseScore(ctx_);
@@ -173,18 +173,18 @@ class GBLinear : public GradientBooster {
       common::ParallelFor(nsize, ctx_->Threads(), [&](bst_omp_uint i) {
         auto inst = page[i];
         auto row_idx = static_cast<size_t>(batch.base_rowid + i);
-        // loop over output groups
-        for (int gid = 0; gid < ngroup; ++gid) {
-          bst_float* p_contribs = &contribs[(row_idx * ngroup + gid) * ncolumns];
+        // Loop over targets.
+        for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+          bst_float* p_contribs = &contribs[(row_idx * n_targets + target_idx) * ncolumns];
           // calculate linear terms' contributions
           for (auto& ins : inst) {
             if (ins.index >= model_.learner_model_param->num_feature) continue;
-            p_contribs[ins.index] = ins.fvalue * model_[ins.index][gid];
+            p_contribs[ins.index] = ins.fvalue * model_[ins.index][target_idx];
           }
           // add base margin to BIAS
           p_contribs[ncolumns - 1] =
-              model_.Bias()[gid] +
-              ((base_margin.Size() != 0) ? base_margin(row_idx, gid) : base_score(0));
+              model_.Bias()[target_idx] +
+              ((base_margin.Size() != 0) ? base_margin(row_idx, target_idx) : base_score(0));
         }
       });
     }
@@ -199,8 +199,7 @@ class GBLinear : public GradientBooster {
     // linear models have no interaction effects
     const size_t nelements =
         model_.learner_model_param->num_feature * model_.learner_model_param->num_feature;
-    contribs.resize(p_fmat->Info().num_row_ * nelements *
-                    model_.learner_model_param->num_output_group);
+    contribs.resize(p_fmat->Info().num_row_ * nelements * model_.learner_model_param->NumTargets());
     std::fill(contribs.begin(), contribs.end(), 0);
   }
 
@@ -220,14 +219,14 @@ class GBLinear : public GradientBooster {
     std::iota(out_features->begin(), out_features->end(), 0);
     // Don't include the bias term in the feature importance scores
     // The bias is the last weight
-    out_scores->resize(model_.weight.size() - learner_model_param_->num_output_group, 0);
-    auto n_groups = learner_model_param_->num_output_group;
+    out_scores->resize(model_.weight.size() - learner_model_param_->NumTargets(), 0);
+    auto n_targets = learner_model_param_->NumTargets();
     auto scores = linalg::MakeTensorView(DeviceOrd::CPU(),
                                          common::Span{out_scores->data(), out_scores->size()},
-                                         learner_model_param_->num_feature, n_groups);
+                                         learner_model_param_->num_feature, n_targets);
     for (size_t i = 0; i < learner_model_param_->num_feature; ++i) {
-      for (bst_group_t g = 0; g < n_groups; ++g) {
-        scores(i, g) = model_[i][g];
+      for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+        scores(i, target_idx) = model_[i][target_idx];
       }
     }
   }
@@ -239,25 +238,25 @@ class GBLinear : public GradientBooster {
     std::vector<bst_float>& preds = *out_preds;
     auto base_margin = p_fmat->Info().base_margin_.View(DeviceOrd::CPU());
     // start collecting the prediction
-    const int ngroup = model_.learner_model_param->num_output_group;
-    preds.resize(p_fmat->Info().num_row_ * ngroup);
+    auto const n_targets = model_.learner_model_param->NumTargets();
+    preds.resize(p_fmat->Info().num_row_ * n_targets);
 
     auto base_score = learner_model_param_->BaseScore(DeviceOrd::CPU());
     for (const auto& page : p_fmat->GetBatches<SparsePage>()) {
       auto const& batch = page.GetView();
       // output convention: nrow * k, where nrow is number of rows
-      // k is number of group
+      // k is the number of targets.
       // parallel over local batch
       const auto nsize = static_cast<omp_ulong>(batch.Size());
       if (base_margin.Size() != 0) {
-        CHECK_EQ(base_margin.Size(), nsize * ngroup);
+        CHECK_EQ(base_margin.Size(), nsize * n_targets);
       }
       common::ParallelFor(nsize, ctx_->Threads(), [&](omp_ulong i) {
         const size_t ridx = page.base_rowid + i;
-        // loop over output groups
-        for (int gid = 0; gid < ngroup; ++gid) {
-          float margin = (base_margin.Size() != 0) ? base_margin(ridx, gid) : base_score(0);
-          this->Pred(batch[i], &preds[ridx * ngroup], gid, margin);
+        // Loop over targets.
+        for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+          float margin = (base_margin.Size() != 0) ? base_margin(ridx, target_idx) : base_score(0);
+          this->Pred(batch[i], &preds[ridx * n_targets], target_idx, margin);
         }
       });
     }
@@ -291,13 +290,14 @@ class GBLinear : public GradientBooster {
     }
   }
 
-  void Pred(const SparsePage::Inst& inst, bst_float* preds, int gid, bst_float base) {
-    bst_float psum = model_.Bias()[gid] + base;
+  void Pred(const SparsePage::Inst& inst, bst_float* preds, bst_target_t target_idx,
+            bst_float base) {
+    bst_float psum = model_.Bias()[target_idx] + base;
     for (const auto& ins : inst) {
       if (ins.index >= model_.learner_model_param->num_feature) continue;
-      psum += ins.fvalue * model_[ins.index][gid];
+      psum += ins.fvalue * model_[ins.index][target_idx];
     }
-    preds[gid] = psum;
+    preds[target_idx] = psum;
   }
 
   // biase margin score

--- a/src/gbm/gblinear_model.h
+++ b/src/gbm/gblinear_model.h
@@ -6,14 +6,14 @@
 #include <dmlc/parameter.h>
 #include <xgboost/learner.h>
 
-#include <vector>
-#include <string>
 #include <cstring>
+#include <string>
+#include <vector>
 
 #include "xgboost/base.h"
 #include "xgboost/feature_map.h"
-#include "xgboost/model.h"
 #include "xgboost/json.h"
+#include "xgboost/model.h"
 
 namespace xgboost {
 class Json;
@@ -22,12 +22,12 @@ namespace gbm {
 class GBLinearModel : public Model {
  public:
   std::int32_t num_boosted_rounds{0};
-  LearnerModelParam const* learner_model_param;
+  LearnerModelParam const *learner_model_param;
 
  public:
   explicit GBLinearModel(LearnerModelParam const *learner_model_param)
       : learner_model_param{learner_model_param} {}
-  void Configure(Args const &) { }
+  void Configure(Args const &) {}
 
   // weight for each of feature, bias is the last one
   std::vector<bst_float> weight;
@@ -37,8 +37,7 @@ class GBLinearModel : public Model {
       return;
     }
     // bias is the last weight
-    weight.resize((learner_model_param->num_feature + 1) *
-                  learner_model_param->num_output_group);
+    weight.resize((learner_model_param->num_feature + 1) * learner_model_param->NumTargets());
     std::fill(weight.begin(), weight.end(), 0.0f);
   }
 
@@ -47,56 +46,49 @@ class GBLinearModel : public Model {
 
   // model bias
   inline bst_float *Bias() {
-    return &weight[learner_model_param->num_feature *
-                   learner_model_param->num_output_group];
+    return &weight[learner_model_param->num_feature * learner_model_param->NumTargets()];
   }
   inline const bst_float *Bias() const {
-    return &weight[learner_model_param->num_feature *
-                   learner_model_param->num_output_group];
+    return &weight[learner_model_param->num_feature * learner_model_param->NumTargets()];
   }
   // get i-th weight
-  inline bst_float *operator[](size_t i) {
-    return &weight[i * learner_model_param->num_output_group];
-  }
+  inline bst_float *operator[](size_t i) { return &weight[i * learner_model_param->NumTargets()]; }
   inline const bst_float *operator[](size_t i) const {
-    return &weight[i * learner_model_param->num_output_group];
+    return &weight[i * learner_model_param->NumTargets()];
   }
 
-  std::vector<std::string> DumpModel(const FeatureMap &, bool,
-                                     std::string format) const {
-    const int ngroup = learner_model_param->num_output_group;
+  std::vector<std::string> DumpModel(const FeatureMap &, bool, std::string format) const {
+    auto const n_targets = learner_model_param->NumTargets();
     const unsigned nfeature = learner_model_param->num_feature;
 
     std::stringstream fo("");
     if (format == "json") {
       fo << "  { \"bias\": [" << std::endl;
-      for (int gid = 0; gid < ngroup; ++gid) {
-        if (gid != 0) {
+      for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+        if (target_idx != 0) {
           fo << "," << std::endl;
         }
-        fo << "      " << this->Bias()[gid];
+        fo << "      " << this->Bias()[target_idx];
       }
-      fo << std::endl
-         << "    ]," << std::endl
-         << "    \"weight\": [" << std::endl;
+      fo << std::endl << "    ]," << std::endl << "    \"weight\": [" << std::endl;
       for (unsigned i = 0; i < nfeature; ++i) {
-        for (int gid = 0; gid < ngroup; ++gid) {
-          if (i != 0 || gid != 0) {
+        for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+          if (i != 0 || target_idx != 0) {
             fo << "," << std::endl;
           }
-          fo << "      " << (*this)[i][gid];
+          fo << "      " << (*this)[i][target_idx];
         }
       }
       fo << std::endl << "    ]" << std::endl << "  }";
     } else if (format == "text") {
       fo << "bias:\n";
-      for (int gid = 0; gid < ngroup; ++gid) {
-        fo << this->Bias()[gid] << std::endl;
+      for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+        fo << this->Bias()[target_idx] << std::endl;
       }
       fo << "weight:\n";
       for (unsigned i = 0; i < nfeature; ++i) {
-        for (int gid = 0; gid < ngroup; ++gid) {
-          fo << (*this)[i][gid] << std::endl;
+        for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+          fo << (*this)[i][target_idx] << std::endl;
         }
       }
     } else {

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -160,7 +160,7 @@ void GBTreeModel::InitTreesToUpdate() {
   }
 }
 
-void GPUCopyGradient(Context const*, linalg::Matrix<GradientPair> const*, bst_group_t,
+void GPUCopyGradient(Context const*, linalg::Matrix<GradientPair> const*, bst_target_t,
                      linalg::Matrix<GradientPair>*)
 #if defined(XGBOOST_USE_CUDA)
     ;  // NOLINT
@@ -171,15 +171,15 @@ void GPUCopyGradient(Context const*, linalg::Matrix<GradientPair> const*, bst_gr
 #endif
 
 void CopyGradient(Context const* ctx, linalg::Matrix<GradientPair> const* in_gpair,
-                  bst_group_t group_id, linalg::Matrix<GradientPair>* out_gpair) {
+                  bst_target_t target_idx, linalg::Matrix<GradientPair>* out_gpair) {
   out_gpair->SetDevice(ctx->Device());
   out_gpair->Reshape(in_gpair->Shape(0), 1);
   if (ctx->IsCUDA()) {
-    GPUCopyGradient(ctx, in_gpair, group_id, out_gpair);
+    GPUCopyGradient(ctx, in_gpair, target_idx, out_gpair);
   } else {
     auto const& in = *in_gpair;
     auto h_tmp = out_gpair->HostView();
-    auto h_in = in.HostView().Slice(linalg::All(), group_id);
+    auto h_in = in.HostView().Slice(linalg::All(), target_idx);
     CHECK_EQ(h_tmp.Size(), h_in.Size());
     common::ParallelFor(h_in.Size(), ctx->Threads(), [&](auto i) { h_tmp(i) = h_in(i); });
   }
@@ -191,8 +191,8 @@ void CopyGradient(Context const* ctx, linalg::Matrix<GradientPair> const* in_gpa
  * \param predts     Prediction for current tree.
  * \param tree_w     Tree weight.
  */
-void GPUDartPredictInc(common::Span<float>, common::Span<float>, float, size_t, bst_group_t,
-                       bst_group_t)
+void GPUDartPredictInc(common::Span<float>, common::Span<float>, float, size_t, bst_target_t,
+                       bst_target_t)
 #if defined(XGBOOST_USE_CUDA)
     ;  // NOLINT
 #else
@@ -202,7 +202,7 @@ void GPUDartPredictInc(common::Span<float>, common::Span<float>, float, size_t, 
 #endif
 
 void GBTree::UpdateTreeLeaf(DMatrix const* p_fmat, HostDeviceVector<float> const& predictions,
-                            ObjFunction const* obj, std::int32_t group_idx,
+                            ObjFunction const* obj, bst_target_t target_idx,
                             std::vector<HostDeviceVector<bst_node_t>> const& node_position,
                             TreesOneGroup* p_trees) {
   CHECK(!updaters_.empty());
@@ -218,7 +218,7 @@ void GBTree::UpdateTreeLeaf(DMatrix const* p_fmat, HostDeviceVector<float> const
   for (std::size_t tree_idx = 0; tree_idx < trees.size(); ++tree_idx) {
     auto const& position = node_position[tree_idx];
     obj->UpdateTreeLeaf(position, p_fmat->Info(), tree_param_.learning_rate / trees.size(),
-                        predictions, group_idx, trees[tree_idx].get());
+                        predictions, target_idx, trees[tree_idx].get());
   }
 }
 
@@ -237,7 +237,7 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
   }
 
   TreesOneIter new_trees;
-  bst_target_t const n_groups = model_.learner_model_param->OutputLength();
+  bst_target_t const n_targets = model_.learner_model_param->NumTargets();
   monitor_.Start("BoostNewTrees");
 
   // Define the categories.
@@ -253,8 +253,8 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
 
   predt->predictions.SetDevice(ctx_->Device());
   auto out = linalg::MakeTensorView(ctx_, &predt->predictions, p_fmat->Info().num_row_,
-                                    model_.learner_model_param->OutputLength());
-  CHECK_NE(n_groups, 0);
+                                    model_.learner_model_param->NumTargets());
+  CHECK_NE(n_targets, 0);
 
   // The node position for each row, 1 HDV for each tree in the forest.  Note that the
   // position is negated if the row is sampled out.
@@ -271,7 +271,7 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
         updaters_.back()->UpdatePredictionCache(p_fmat, common::Span{node_position}, out)) {
       predt->Update(1);
     }
-  } else if (model_.learner_model_param->OutputLength() == 1u) {
+  } else if (model_.learner_model_param->NumTargets() == 1u) {
     // Single target
     TreesOneGroup ret;
     BoostNewTrees(in_gpair, p_fmat, 0, &node_position, &ret);
@@ -284,21 +284,21 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
     }
   } else {
     // Multi-target, scalar leaf
-    CHECK_EQ(in_gpair->gpair.Size() % n_groups, 0U)
-        << "Must have exactly n_groups * n_samples gpairs.";
+    CHECK_EQ(in_gpair->gpair.Size() % n_targets, 0U)
+        << "Must have exactly n_targets * n_samples gpairs.";
     GradientContainer tmp;
     tmp.gpair = linalg::Matrix<GradientPair>{
         {in_gpair->gpair.Shape(0), static_cast<std::size_t>(1ul)}, ctx_->Device()};
     bool update_predict = true;
-    for (bst_target_t gid = 0; gid < n_groups; ++gid) {
+    for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
       node_position.clear();
-      CopyGradient(ctx_, &in_gpair->gpair, gid, &tmp.gpair);
+      CopyGradient(ctx_, &in_gpair->gpair, target_idx, &tmp.gpair);
       TreesOneGroup ret;
-      BoostNewTrees(&tmp, p_fmat, gid, &node_position, &ret);
-      UpdateTreeLeaf(p_fmat, predt->predictions, obj, gid, node_position, &ret);
+      BoostNewTrees(&tmp, p_fmat, target_idx, &node_position, &ret);
+      UpdateTreeLeaf(p_fmat, predt->predictions, obj, target_idx, node_position, &ret);
       const size_t num_new_trees = ret.size();
       new_trees.push_back(std::move(ret));
-      auto v_predt = out.Slice(linalg::All(), linalg::Range(gid, gid + 1));
+      auto v_predt = out.Slice(linalg::All(), linalg::Range(target_idx, target_idx + 1));
       // random forest doesn't support the prediction cache yet.
       if (!(updaters_.size() > 0 && predt->predictions.Size() > 0 && num_new_trees == 1 &&
             updaters_.back()->UpdatePredictionCache(p_fmat, common::Span{node_position},
@@ -315,7 +315,7 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
   this->CommitModel(std::move(new_trees));
 }
 
-std::vector<RegTree*> GBTree::InitNewTrees(bst_target_t bst_group, TreesOneGroup* ret) {
+std::vector<RegTree*> GBTree::InitNewTrees(bst_target_t target_idx, TreesOneGroup* ret) {
   std::vector<RegTree*> new_trees;
   ret->clear();
   // create the trees
@@ -328,7 +328,7 @@ std::vector<RegTree*> GBTree::InitNewTrees(bst_target_t bst_group, TreesOneGroup
           << "Set `process_type` to `update` if you want to update existing "
              "trees.";
       // create new tree
-      std::unique_ptr<RegTree> ptr(new RegTree{this->model_.learner_model_param->LeafLength(),
+      std::unique_ptr<RegTree> ptr(new RegTree{this->model_.learner_model_param->NumTreeTargets(),
                                                this->model_.learner_model_param->num_feature});
       new_trees.push_back(ptr.get());
       ret->push_back(std::move(ptr));
@@ -344,7 +344,7 @@ std::vector<RegTree*> GBTree::InitNewTrees(bst_target_t bst_group, TreesOneGroup
           << "boosting rounds can not exceed previous training rounds";
       // move an existing tree from trees_to_update
       auto t = std::move(model_.trees_to_update[model_.trees.size() +
-                                                bst_group * model_.param.num_parallel_tree + i]);
+                                                target_idx * model_.param.num_parallel_tree + i]);
       new_trees.push_back(t.get());
       ret->push_back(std::move(t));
     }
@@ -352,13 +352,13 @@ std::vector<RegTree*> GBTree::InitNewTrees(bst_target_t bst_group, TreesOneGroup
   return new_trees;
 }
 
-void GBTree::BoostNewTrees(GradientContainer* gpair, DMatrix* p_fmat, int bst_group,
+void GBTree::BoostNewTrees(GradientContainer* gpair, DMatrix* p_fmat, bst_target_t target_idx,
                            std::vector<HostDeviceVector<bst_node_t>>* out_position,
                            TreesOneGroup* ret) {
-  std::vector<RegTree*> new_trees = this->InitNewTrees(bst_group, ret);
+  std::vector<RegTree*> new_trees = this->InitNewTrees(target_idx, ret);
 
   // update the trees
-  auto n_out = model_.learner_model_param->OutputLength() * p_fmat->Info().num_row_;
+  auto n_out = model_.learner_model_param->NumTargets() * p_fmat->Info().num_row_;
   StringView msg{
       "Mismatching size between number of rows from input data and size of gradient vector."};
   if (!model_.learner_model_param->IsVectorLeaf() && p_fmat->Info().num_row_ != 0) {
@@ -644,8 +644,8 @@ void GBTree::Slice(bst_layer_t begin, bst_layer_t end, bst_layer_t step, Gradien
         std::unique_ptr<RegTree> new_tree{this->model_.trees.at(in_tree_idx)->Copy()};
         out_trees.emplace_back(std::move(new_tree));
 
-        bst_group_t group = in_tree_info[in_tree_idx];
-        out_tree_info.push_back(group);
+        bst_target_t target_idx = in_tree_info[in_tree_idx];
+        out_tree_info.push_back(target_idx);
 
         out_model.iteration_indptr[out_l + 1]++;
       });

--- a/src/gbm/gbtree.cu
+++ b/src/gbm/gbtree.cu
@@ -10,8 +10,8 @@
 
 namespace xgboost::gbm {
 void GPUCopyGradient(Context const *ctx, linalg::Matrix<GradientPair> const *in_gpair,
-                     bst_group_t group_id, linalg::Matrix<GradientPair> *out_gpair) {
-  auto v_in = in_gpair->View(ctx->Device()).Slice(linalg::All(), group_id);
+                     bst_target_t target_idx, linalg::Matrix<GradientPair> *out_gpair) {
+  auto v_in = in_gpair->View(ctx->Device()).Slice(linalg::All(), target_idx);
   out_gpair->SetDevice(ctx->Device());
   out_gpair->Reshape(v_in.Size(), 1);
   auto d_out = out_gpair->View(ctx->Device());
@@ -21,23 +21,22 @@ void GPUCopyGradient(Context const *ctx, linalg::Matrix<GradientPair> const *in_
   thrust::copy(cuctx->CTP(), it, it + v_in.Size(), d_out.Values().data());
 }
 
-void GPUDartPredictInc(common::Span<float> out_predts,
-                       common::Span<float> predts, float tree_w, size_t n_rows,
-                       bst_group_t n_groups, bst_group_t group) {
+void GPUDartPredictInc(common::Span<float> out_predts, common::Span<float> predts, float tree_w,
+                       size_t n_rows, bst_target_t n_targets, bst_target_t target_idx) {
   dh::LaunchN(n_rows, [=] XGBOOST_DEVICE(size_t ridx) {
-    const size_t offset = ridx * n_groups + group;
+    const size_t offset = ridx * n_targets + target_idx;
     out_predts[offset] += (predts[offset] * tree_w);
   });
 }
 
 void GPUDartInplacePredictInc(common::Span<float> out_predts, common::Span<float> predts,
                               float tree_w, size_t n_rows,
-                              linalg::TensorView<float const, 1> base_score, bst_group_t n_groups,
-                              bst_group_t group) {
-  CHECK_EQ(base_score.Size(), n_groups);
+                              linalg::TensorView<float const, 1> base_score, bst_target_t n_targets,
+                              bst_target_t target_idx) {
+  CHECK_EQ(base_score.Size(), n_targets);
   dh::LaunchN(n_rows, [=] XGBOOST_DEVICE(size_t ridx) {
-    const size_t offset = ridx * n_groups + group;
-    out_predts[offset] += (predts[offset] - base_score(group)) * tree_w;
+    const size_t offset = ridx * n_targets + target_idx;
+    out_predts[offset] += (predts[offset] - base_score(target_idx)) * tree_w;
   });
 }
 }  // namespace xgboost::gbm

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -182,11 +182,13 @@ class GBTree : public GradientBooster {
   void Configure(Args const& cfg) override;
   /**
    * @brief Optionally update the leaf value.
+   *
+   * @param target_idx Target index for scalar trees; zero for vector-leaf trees.
    */
   void UpdateTreeLeaf(DMatrix const* p_fmat, HostDeviceVector<float> const& predictions,
-                      ObjFunction const* obj, std::int32_t group_idx,
+                      ObjFunction const* obj, bst_target_t target_idx,
                       std::vector<HostDeviceVector<bst_node_t>> const& node_position,
-                      std::vector<std::unique_ptr<RegTree>>* p_trees);
+                      TreesOneGroup* p_trees);
   /**
    * @brief Carry out one iteration of boosting.
    */
@@ -341,11 +343,10 @@ class GBTree : public GradientBooster {
   [[nodiscard]] std::vector<float> DropTrees(bool is_training);
   [[nodiscard]] std::size_t NormalizeTrees(std::size_t size_new_trees);
 
-  void BoostNewTrees(GradientContainer* gpair, DMatrix* p_fmat, int bst_group,
-                     std::vector<HostDeviceVector<bst_node_t>>* out_position,
-                     std::vector<std::unique_ptr<RegTree>>* ret);
+  void BoostNewTrees(GradientContainer* gpair, DMatrix* p_fmat, bst_target_t target_idx,
+                     std::vector<HostDeviceVector<bst_node_t>>* out_position, TreesOneGroup* ret);
 
-  std::vector<RegTree*> InitNewTrees(bst_target_t bst_group, TreesOneGroup* ret);
+  std::vector<RegTree*> InitNewTrees(bst_target_t target_idx, TreesOneGroup* ret);
 
   [[nodiscard]] std::unique_ptr<Predictor> const& GetPredictor(
       bool is_training, HostDeviceVector<float> const* out_pred = nullptr,

--- a/src/gbm/gbtree_model.cc
+++ b/src/gbm/gbtree_model.cc
@@ -24,16 +24,16 @@ void MakeIndptr(GBTreeModel* out_model) {
     return;
   }
 
-  auto n_groups = *std::max_element(tree_info.cbegin(), tree_info.cend()) + 1;
+  auto n_targets = *std::max_element(tree_info.cbegin(), tree_info.cend()) + 1;
 
   auto& indptr = out_model->iteration_indptr;
-  auto layer_trees = out_model->param.num_parallel_tree * n_groups;
+  auto layer_trees = out_model->param.num_parallel_tree * n_targets;
   CHECK_NE(layer_trees, 0);
   indptr.resize(out_model->param.num_trees / layer_trees + 1, 0);
   indptr[0] = 0;
 
   for (std::size_t i = 1; i < indptr.size(); ++i) {
-    indptr[i] = n_groups * out_model->param.num_parallel_tree;
+    indptr[i] = n_targets * out_model->param.num_parallel_tree;
   }
   std::partial_sum(indptr.cbegin(), indptr.cend(), indptr.begin());
 }
@@ -153,9 +153,9 @@ bst_tree_t GBTreeModel::CommitModel(TreesOneIter&& new_trees) {
     n_new_trees += new_trees.front().size();
     this->CommitModelGroup(std::move(new_trees.front()), 0);
   } else {
-    for (bst_target_t gidx{0}; gidx < learner_model_param->OutputLength(); ++gidx) {
-      n_new_trees += new_trees[gidx].size();
-      this->CommitModelGroup(std::move(new_trees[gidx]), gidx);
+    for (bst_target_t target_idx{0}; target_idx < learner_model_param->NumTargets(); ++target_idx) {
+      n_new_trees += new_trees[target_idx].size();
+      this->CommitModelGroup(std::move(new_trees[target_idx]), target_idx);
     }
   }
 
@@ -164,11 +164,11 @@ bst_tree_t GBTreeModel::CommitModel(TreesOneIter&& new_trees) {
   return n_new_trees;
 }
 
-void GBTreeModel::CommitModelGroup(TreesOneGroup&& new_trees, bst_target_t group_idx) {
+void GBTreeModel::CommitModelGroup(TreesOneGroup&& new_trees, bst_target_t target_idx) {
   auto& h_tree_info = this->tree_info.HostVector();
   for (auto& new_tree : new_trees) {
     trees.push_back(std::move(new_tree));
-    h_tree_info.push_back(group_idx);
+    h_tree_info.push_back(target_idx);
   }
   param.num_trees += static_cast<int>(new_trees.size());
 }

--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -91,7 +91,7 @@ struct GBTreeModel : public Model {
    */
   bst_tree_t CommitModel(TreesOneIter&& new_trees);
 
-  void CommitModelGroup(TreesOneGroup&& new_trees, bst_target_t group_idx);
+  void CommitModelGroup(TreesOneGroup&& new_trees, bst_target_t target_idx);
 
   [[nodiscard]] std::int32_t BoostedRounds() const {
     if (trees.empty()) {

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -158,8 +158,8 @@ struct LearnerModelParamLegacy : public dmlc::Parameter<LearnerModelParamLegacy>
   }
   // Handle old model formats, before 3.1, the intercept was always a scalar.
   void HandleOldFormat() {
-    if (this->base_score.size() == 1 && this->OutputLength() > 1) {
-      this->base_score.Resize(this->OutputLength(), this->base_score[0]);
+    if (this->base_score.size() == 1 && this->NumTargets() > 1) {
+      this->base_score.Resize(this->NumTargets(), this->base_score[0]);
     }
   }
 
@@ -175,8 +175,8 @@ struct LearnerModelParamLegacy : public dmlc::Parameter<LearnerModelParamLegacy>
     }
     return dmlc::Parameter<LearnerModelParamLegacy>::UpdateAllowUnknown(kwargs);
   }
-  // The number of outputs of the model.
-  [[nodiscard]] bst_target_t OutputLength() const noexcept {
+  // The number of targets in the model.
+  [[nodiscard]] bst_target_t NumTargets() const noexcept {
     return std::max({this->num_target, static_cast<bst_target_t>(this->num_class),
                      static_cast<bst_target_t>(1)});
   }
@@ -241,7 +241,7 @@ namespace xgboost {
 LearnerModelParam::LearnerModelParam(LearnerModelParamLegacy const& user_param, ObjInfo t,
                                      MultiStrategy multi_strategy)
     : num_feature{user_param.num_feature},
-      num_output_group{user_param.OutputLength()},
+      n_targets{user_param.NumTargets()},
       task{t},
       multi_strategy{multi_strategy} {
   if (user_param.num_class > 1 && user_param.num_target > 1) {
@@ -294,7 +294,7 @@ void LearnerModelParam::Copy(LearnerModelParam const& that) {
   CHECK(base_score_.Data()->HostCanRead());
 
   num_feature = that.num_feature;
-  num_output_group = that.num_output_group;
+  n_targets = that.n_targets;
   task = that.task;
   multi_strategy = that.multi_strategy;
 }
@@ -376,7 +376,7 @@ class Intercept : public Learner {
  private:
   void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) {
     base_score->SetDevice(this->Ctx()->Device());
-    base_score->Reshape(this->mparam_.OutputLength());
+    base_score->Reshape(this->mparam_.NumTargets());
     UsePtr(obj_)->InitEstimation(info, base_score);
   }
 
@@ -438,8 +438,7 @@ class Intercept : public Learner {
 
     if (this->NeedFit()) {
       // Initialize with a sensible default value to get prediction/model io going.
-      this->mparam_.base_score.Resize(this->mparam_.OutputLength(),
-                                      ObjFunction::DefaultBaseScore());
+      this->mparam_.base_score.Resize(this->mparam_.NumTargets(), ObjFunction::DefaultBaseScore());
       this->InitModelParam(tparam, false);
       // This should not be altered, we will estimate it later.
       CHECK(this->NeedFit());
@@ -881,7 +880,7 @@ class LearnerConfiguration : public Intercept {
 
   void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) {
     base_score->SetDevice(this->Ctx()->Device());
-    base_score->Reshape(this->mparam_.OutputLength());
+    base_score->Reshape(this->mparam_.NumTargets());
     UsePtr(obj_)->InitEstimation(info, base_score);
   }
 };
@@ -1144,10 +1143,10 @@ class LearnerImpl : public LearnerIO {
 
     this->ValidateDMatrix(train.get(), true);
     if (in_gpair->HasValueGrad()) {
-      CHECK_EQ(this->learner_model_param_.OutputLength(), in_gpair->NumTargets())
+      CHECK_EQ(this->learner_model_param_.NumTargets(), in_gpair->NumTargets())
           << "Value gradient should have the same number of targets as the overall model.";
     } else {
-      CHECK_EQ(this->learner_model_param_.OutputLength(), in_gpair->NumSplitTargets())
+      CHECK_EQ(this->learner_model_param_.NumTargets(), in_gpair->NumSplitTargets())
           << "The number of columns in gradient should be equal to the number of "
              "targets/classes in the model.";
     }
@@ -1238,10 +1237,10 @@ class LearnerImpl : public LearnerIO {
     return this->gbm_->BoostedRounds();
   }
 
-  uint32_t Groups() const override {
+  bst_target_t NumTargets() const override {
     CHECK(!this->need_configuration_);
     this->CheckModelInitialized();
-    return this->learner_model_param_.num_output_group;
+    return this->learner_model_param_.NumTargets();
   }
 
   XGBAPIThreadLocalEntry& GetThreadLocal() const override {
@@ -1316,14 +1315,14 @@ class LearnerImpl : public LearnerIO {
       error::WarnEmptyDataset();
     }
     if (!p_fmat->Info().base_margin_.Empty()) {
-      CHECK_EQ(p_fmat->Info().base_margin_.Shape(1), this->mparam_.OutputLength());
+      CHECK_EQ(p_fmat->Info().base_margin_.Shape(1), this->mparam_.NumTargets());
     }
   }
 
  private:
   void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info, std::int32_t iter,
                    linalg::Matrix<GradientPair>* out_gpair) {
-    out_gpair->Reshape(info.num_row_, this->learner_model_param_.OutputLength());
+    out_gpair->Reshape(info.num_row_, this->learner_model_param_.NumTargets());
     obj_->GetGradient(preds, info, iter, out_gpair);
   }
 

--- a/src/linear/coordinate_common.h
+++ b/src/linear/coordinate_common.h
@@ -73,16 +73,16 @@ inline double CoordinateDeltaBias(double sum_grad, double sum_hess) {
 /**
  * \brief Get the gradient with respect to a single feature.
  *
- * \param group_idx Zero-based index of the group.
- * \param num_group Number of groups.
+ * \param target_idx Zero-based target index.
+ * \param n_targets  Number of targets.
  * \param fidx      The target feature.
  * \param gpair     Gradients.
  * \param p_fmat    The feature matrix.
  *
  * \return  The gradient and diagonal Hessian entry for a given feature.
  */
-inline std::pair<double, double> GetGradient(Context const *ctx, int group_idx, int num_group,
-                                             bst_feature_t fidx,
+inline std::pair<double, double> GetGradient(Context const *ctx, bst_target_t target_idx,
+                                             bst_target_t n_targets, bst_feature_t fidx,
                                              std::vector<GradientPair> const &gpair,
                                              DMatrix *p_fmat) {
   double sum_grad = 0.0, sum_hess = 0.0;
@@ -92,7 +92,7 @@ inline std::pair<double, double> GetGradient(Context const *ctx, int group_idx, 
     const auto ndata = static_cast<bst_omp_uint>(col.size());
     for (bst_omp_uint j = 0; j < ndata; ++j) {
       const bst_float v = col[j].fvalue;
-      auto &p = gpair[col[j].index * num_group + group_idx];
+      auto &p = gpair[col[j].index * n_targets + target_idx];
       if (p.GetHess() < 0.0f) continue;
       sum_grad += p.GetGrad() * v;
       sum_hess += p.GetHess() * v * v;
@@ -104,16 +104,16 @@ inline std::pair<double, double> GetGradient(Context const *ctx, int group_idx, 
 /**
  * \brief Get the gradient with respect to a single feature. Row-wise multithreaded.
  *
- * \param group_idx Zero-based index of the group.
- * \param num_group Number of groups.
+ * \param target_idx Zero-based target index.
+ * \param n_targets  Number of targets.
  * \param fidx      The target feature.
  * \param gpair     Gradients.
  * \param p_fmat    The feature matrix.
  *
  * \return  The gradient and diagonal Hessian entry for a given feature.
  */
-inline std::pair<double, double> GetGradientParallel(Context const *ctx, int group_idx,
-                                                     int num_group, int fidx,
+inline std::pair<double, double> GetGradientParallel(Context const *ctx, bst_target_t target_idx,
+                                                     bst_target_t n_targets, int fidx,
                                                      const std::vector<GradientPair> &gpair,
                                                      DMatrix *p_fmat) {
   std::vector<double> sum_grad_tloc(ctx->Threads(), 0.0);
@@ -125,7 +125,7 @@ inline std::pair<double, double> GetGradientParallel(Context const *ctx, int gro
     const auto ndata = static_cast<bst_omp_uint>(col.size());
     common::ParallelFor(ndata, ctx->Threads(), [&](size_t j) {
       const bst_float v = col[j].fvalue;
-      auto &p = gpair[col[j].index * num_group + group_idx];
+      auto &p = gpair[col[j].index * n_targets + target_idx];
       if (p.GetHess() < 0.0f) {
         return;
       }
@@ -142,14 +142,15 @@ inline std::pair<double, double> GetGradientParallel(Context const *ctx, int gro
 /**
  * \brief Get the gradient with respect to the bias. Row-wise multithreaded.
  *
- * \param group_idx Zero-based index of the group.
- * \param num_group Number of groups.
+ * \param target_idx Zero-based target index.
+ * \param n_targets  Number of targets.
  * \param gpair     Gradients.
  * \param p_fmat    The feature matrix.
  *
  * \return  The gradient and diagonal Hessian entry for the bias.
  */
-inline std::pair<double, double> GetBiasGradientParallel(int group_idx, int num_group,
+inline std::pair<double, double> GetBiasGradientParallel(bst_target_t target_idx,
+                                                         bst_target_t n_targets,
                                                          const std::vector<GradientPair> &gpair,
                                                          DMatrix *p_fmat, int32_t n_threads) {
   const auto ndata = static_cast<bst_omp_uint>(p_fmat->Info().num_row_);
@@ -158,7 +159,7 @@ inline std::pair<double, double> GetBiasGradientParallel(int group_idx, int num_
 
   common::ParallelFor(ndata, n_threads, [&](auto i) {
     auto tid = omp_get_thread_num();
-    auto &p = gpair[i * num_group + group_idx];
+    auto &p = gpair[i * n_targets + target_idx];
     if (p.GetHess() >= 0.0f) {
       sum_grad_tloc[tid] += p.GetGrad();
       sum_hess_tloc[tid] += p.GetHess();
@@ -172,16 +173,16 @@ inline std::pair<double, double> GetBiasGradientParallel(int group_idx, int num_
 /**
  * \brief Updates the gradient vector with respect to a change in weight.
  *
- * \param fidx      The feature index.
- * \param group_idx Zero-based index of the group.
- * \param num_group Number of groups.
- * \param dw        The change in weight.
- * \param in_gpair  The gradient vector to be updated.
- * \param p_fmat    The input feature matrix.
+ * \param fidx       The feature index.
+ * \param target_idx Zero-based target index.
+ * \param n_targets  Number of targets.
+ * \param dw         The change in weight.
+ * \param in_gpair   The gradient vector to be updated.
+ * \param p_fmat     The input feature matrix.
  */
-inline void UpdateResidualParallel(Context const *ctx, bst_feature_t fidx, int group_idx,
-                                   int num_group, float dw, std::vector<GradientPair> *in_gpair,
-                                   DMatrix *p_fmat) {
+inline void UpdateResidualParallel(Context const *ctx, bst_feature_t fidx, bst_target_t target_idx,
+                                   bst_target_t n_targets, float dw,
+                                   std::vector<GradientPair> *in_gpair, DMatrix *p_fmat) {
   if (dw == 0.0f) return;
   for (const auto &batch : p_fmat->GetBatches<CSCPage>(ctx)) {
     auto page = batch.GetView();
@@ -189,7 +190,7 @@ inline void UpdateResidualParallel(Context const *ctx, bst_feature_t fidx, int g
     // update grad value
     const auto num_row = static_cast<bst_omp_uint>(col.size());
     common::ParallelFor(num_row, ctx->Threads(), [&](auto j) {
-      GradientPair &p = (*in_gpair)[col[j].index * num_group + group_idx];
+      GradientPair &p = (*in_gpair)[col[j].index * n_targets + target_idx];
       if (p.GetHess() < 0.0f) return;
       p += GradientPair(p.GetHess() * col[j].fvalue * dw, 0);
     });
@@ -199,19 +200,19 @@ inline void UpdateResidualParallel(Context const *ctx, bst_feature_t fidx, int g
 /**
  * \brief Updates the gradient vector based on a change in the bias.
  *
- * \param group_idx Zero-based index of the group.
- * \param num_group Number of groups.
- * \param dbias     The change in bias.
- * \param in_gpair  The gradient vector to be updated.
- * \param p_fmat    The input feature matrix.
+ * \param target_idx Zero-based target index.
+ * \param n_targets  Number of targets.
+ * \param dbias      The change in bias.
+ * \param in_gpair   The gradient vector to be updated.
+ * \param p_fmat     The input feature matrix.
  */
-inline void UpdateBiasResidualParallel(Context const *ctx, int group_idx, int num_group,
-                                       float dbias, std::vector<GradientPair> *in_gpair,
-                                       DMatrix *p_fmat) {
+inline void UpdateBiasResidualParallel(Context const *ctx, bst_target_t target_idx,
+                                       bst_target_t n_targets, float dbias,
+                                       std::vector<GradientPair> *in_gpair, DMatrix *p_fmat) {
   if (dbias == 0.0f) return;
   const auto ndata = static_cast<bst_omp_uint>(p_fmat->Info().num_row_);
   common::ParallelFor(ndata, ctx->Threads(), [&](auto i) {
-    GradientPair &g = (*in_gpair)[i * num_group + group_idx];
+    GradientPair &g = (*in_gpair)[i * n_targets + target_idx];
     if (g.GetHess() < 0.0f) return;
     g += GradientPair(g.GetHess() * dbias, 0);
   });
@@ -244,20 +245,20 @@ class FeatureSelector {
   /**
    * \brief Select next coordinate to update.
    *
-   * \param ctx       Booster context
-   * \param iteration The iteration in a loop through features
-   * \param model     The model.
-   * \param group_idx Zero-based index of the group.
-   * \param gpair     The gpair.
-   * \param p_fmat    The feature matrix.
-   * \param alpha     Regularisation alpha.
-   * \param lambda    Regularisation lambda.
+   * \param ctx        Booster context
+   * \param iteration  The iteration in a loop through features
+   * \param model      The model.
+   * \param target_idx Zero-based target index.
+   * \param gpair      The gpair.
+   * \param p_fmat     The feature matrix.
+   * \param alpha      Regularisation alpha.
+   * \param lambda     Regularisation lambda.
    *
    * \return  The index of the selected feature. -1 indicates none selected.
    */
   virtual int NextFeature(Context const *ctx, int iteration, const gbm::GBLinearModel &model,
-                          int group_idx, const std::vector<GradientPair> &gpair, DMatrix *p_fmat,
-                          float alpha, float lambda) = 0;
+                          bst_target_t target_idx, const std::vector<GradientPair> &gpair,
+                          DMatrix *p_fmat, float alpha, float lambda) = 0;
 };
 
 /**
@@ -266,7 +267,7 @@ class FeatureSelector {
 class CyclicFeatureSelector : public FeatureSelector {
  public:
   using FeatureSelector::FeatureSelector;
-  int NextFeature(Context const *, int iteration, const gbm::GBLinearModel &model, int,
+  int NextFeature(Context const *, int iteration, const gbm::GBLinearModel &model, bst_target_t,
                   const std::vector<GradientPair> &, DMatrix *, float, float) override {
     return iteration % model.learner_model_param->num_feature;
   }
@@ -288,7 +289,7 @@ class ShuffleFeatureSelector : public FeatureSelector {
     std::shuffle(feat_index_.begin(), feat_index_.end(), ctx->Rng());
   }
 
-  int NextFeature(Context const *, int iteration, const gbm::GBLinearModel &model, int,
+  int NextFeature(Context const *, int iteration, const gbm::GBLinearModel &model, bst_target_t,
                   const std::vector<GradientPair> &, DMatrix *, float, float) override {
     return feat_index_[iteration % model.learner_model_param->num_feature];
   }
@@ -304,7 +305,7 @@ class ShuffleFeatureSelector : public FeatureSelector {
 class RandomFeatureSelector : public FeatureSelector {
  public:
   using FeatureSelector::FeatureSelector;
-  int NextFeature(Context const *ctx, int, const gbm::GBLinearModel &model, int,
+  int NextFeature(Context const *ctx, int, const gbm::GBLinearModel &model, bst_target_t,
                   const std::vector<GradientPair> &, DMatrix *, float, float) override {
     return ctx->Rng()() % model.learner_model_param->num_feature;
   }
@@ -314,7 +315,7 @@ class RandomFeatureSelector : public FeatureSelector {
  * \brief Select coordinate with the greatest gradient magnitude.
  * \note It has O(num_feature^2) complexity. It is fully deterministic.
  *
- * \note It allows restricting the selection to top_k features per group with
+ * \note It allows restricting the selection to top_k features per target with
  * the largest magnitude of univariate weight change, by passing the top_k value
  * through the `param` argument of Setup(). That would reduce the complexity to
  * O(num_feature*top_k).
@@ -325,26 +326,26 @@ class GreedyFeatureSelector : public FeatureSelector {
   void Setup(Context const *, const gbm::GBLinearModel &model, const std::vector<GradientPair> &,
              DMatrix *, float, float, int param) override {
     top_k_ = static_cast<bst_uint>(param);
-    const bst_uint ngroup = model.learner_model_param->num_output_group;
+    auto const n_targets = model.learner_model_param->NumTargets();
     if (param <= 0) top_k_ = std::numeric_limits<bst_uint>::max();
     if (counter_.size() == 0) {
-      counter_.resize(ngroup);
-      gpair_sums_.resize(model.learner_model_param->num_feature * ngroup);
+      counter_.resize(n_targets);
+      gpair_sums_.resize(model.learner_model_param->num_feature * n_targets);
     }
-    for (bst_uint gid = 0u; gid < ngroup; ++gid) {
-      counter_[gid] = 0u;
+    for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+      counter_[target_idx] = 0u;
     }
   }
 
-  int NextFeature(Context const *ctx, int, const gbm::GBLinearModel &model, int group_idx,
+  int NextFeature(Context const *ctx, int, const gbm::GBLinearModel &model, bst_target_t target_idx,
                   const std::vector<GradientPair> &gpair, DMatrix *p_fmat, float alpha,
                   float lambda) override {
-    // k-th selected feature for a group
-    auto k = counter_[group_idx]++;
-    // stop after either reaching top-K or going through all the features in a group
-    if (k >= top_k_ || counter_[group_idx] == model.learner_model_param->num_feature) return -1;
+    // k-th selected feature for a target
+    auto k = counter_[target_idx]++;
+    // Stop after either reaching top-K or going through all the features for a target.
+    if (k >= top_k_ || counter_[target_idx] == model.learner_model_param->num_feature) return -1;
 
-    const int ngroup = model.learner_model_param->num_output_group;
+    auto const n_targets = model.learner_model_param->NumTargets();
     const bst_omp_uint nfeat = model.learner_model_param->num_feature;
     // Calculate univariate gradient sums
     std::fill(gpair_sums_.begin(), gpair_sums_.end(), std::make_pair(0., 0.));
@@ -353,10 +354,10 @@ class GreedyFeatureSelector : public FeatureSelector {
       common::ParallelFor(nfeat, ctx->Threads(), [&](bst_omp_uint i) {
         const auto col = page[i];
         const bst_uint ndata = col.size();
-        auto &sums = gpair_sums_[group_idx * nfeat + i];
+        auto &sums = gpair_sums_[target_idx * nfeat + i];
         for (bst_uint j = 0u; j < ndata; ++j) {
           const bst_float v = col[j].fvalue;
-          auto &p = gpair[col[j].index * ngroup + group_idx];
+          auto &p = gpair[col[j].index * n_targets + target_idx];
           if (p.GetHess() < 0.f) continue;
           sums.first += p.GetGrad() * v;
           sums.second += p.GetHess() * v * v;
@@ -367,9 +368,9 @@ class GreedyFeatureSelector : public FeatureSelector {
     int best_fidx = 0;
     double best_weight_update = 0.0f;
     for (bst_omp_uint fidx = 0; fidx < nfeat; ++fidx) {
-      auto &s = gpair_sums_[group_idx * nfeat + fidx];
+      auto &s = gpair_sums_[target_idx * nfeat + fidx];
       float dw = std::abs(static_cast<bst_float>(
-          CoordinateDelta(s.first, s.second, model[fidx][group_idx], alpha, lambda)));
+          CoordinateDelta(s.first, s.second, model[fidx][target_idx], alpha, lambda)));
       if (dw > best_weight_update) {
         best_weight_update = dw;
         best_fidx = fidx;
@@ -391,7 +392,7 @@ class GreedyFeatureSelector : public FeatureSelector {
  * their univariate weight changes. This operation is multithreaded and is a
  * linear complexity approximation of the quadratic greedy selection.
  *
- * \note It allows restricting the selection to top_k features per group with
+ * \note It allows restricting the selection to top_k features per target with
  * the largest magnitude of univariate weight change, by passing the top_k value
  * through the `param` argument of Setup().
  */
@@ -404,14 +405,14 @@ class ThriftyFeatureSelector : public FeatureSelector {
              int param) override {
     top_k_ = static_cast<bst_uint>(param);
     if (param <= 0) top_k_ = std::numeric_limits<bst_uint>::max();
-    const bst_uint ngroup = model.learner_model_param->num_output_group;
+    auto const n_targets = model.learner_model_param->NumTargets();
     const bst_omp_uint nfeat = model.learner_model_param->num_feature;
 
     if (deltaw_.size() == 0) {
-      deltaw_.resize(nfeat * ngroup);
-      sorted_idx_.resize(nfeat * ngroup);
-      counter_.resize(ngroup);
-      gpair_sums_.resize(nfeat * ngroup);
+      deltaw_.resize(nfeat * n_targets);
+      sorted_idx_.resize(nfeat * n_targets);
+      counter_.resize(n_targets);
+      gpair_sums_.resize(nfeat * n_targets);
     }
     // Calculate univariate gradient sums
     std::fill(gpair_sums_.begin(), gpair_sums_.end(), std::make_pair(0., 0.));
@@ -421,11 +422,11 @@ class ThriftyFeatureSelector : public FeatureSelector {
       common::ParallelFor(nfeat, ctx->Threads(), [&](auto i) {
         const auto col = page[i];
         const bst_uint ndata = col.size();
-        for (bst_uint gid = 0u; gid < ngroup; ++gid) {
-          auto &sums = gpair_sums_[gid * nfeat + i];
+        for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+          auto &sums = gpair_sums_[target_idx * nfeat + i];
           for (bst_uint j = 0u; j < ndata; ++j) {
             const bst_float v = col[j].fvalue;
-            auto &p = gpair[col[j].index * ngroup + gid];
+            auto &p = gpair[col[j].index * n_targets + target_idx];
             if (p.GetHess() < 0.f) continue;
             sums.first += p.GetGrad() * v;
             sums.second += p.GetHess() * v * v;
@@ -433,36 +434,36 @@ class ThriftyFeatureSelector : public FeatureSelector {
         }
       });
     }
-    // rank by descending weight magnitude within the groups
+    // Rank by descending weight magnitude within each target.
     std::fill(deltaw_.begin(), deltaw_.end(), 0.f);
     std::iota(sorted_idx_.begin(), sorted_idx_.end(), 0);
     bst_float *pdeltaw = &deltaw_[0];
-    for (bst_uint gid = 0u; gid < ngroup; ++gid) {
+    for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
       // Calculate univariate weight changes
       for (bst_omp_uint i = 0; i < nfeat; ++i) {
-        auto ii = gid * nfeat + i;
+        auto ii = target_idx * nfeat + i;
         auto &s = gpair_sums_[ii];
         deltaw_[ii] = static_cast<bst_float>(
-            CoordinateDelta(s.first, s.second, model[i][gid], alpha, lambda));
+            CoordinateDelta(s.first, s.second, model[i][target_idx], alpha, lambda));
       }
       // sort in descending order of deltaw abs values
-      auto start = sorted_idx_.begin() + gid * nfeat;
+      auto start = sorted_idx_.begin() + target_idx * nfeat;
       std::sort(start, start + nfeat, [pdeltaw](size_t i, size_t j) {
         return std::abs(*(pdeltaw + i)) > std::abs(*(pdeltaw + j));
       });
-      counter_[gid] = 0u;
+      counter_[target_idx] = 0u;
     }
   }
 
-  int NextFeature(Context const *, int, const gbm::GBLinearModel &model, int group_idx,
+  int NextFeature(Context const *, int, const gbm::GBLinearModel &model, bst_target_t target_idx,
                   const std::vector<GradientPair> &, DMatrix *, float, float) override {
-    // k-th selected feature for a group
-    auto k = counter_[group_idx]++;
-    // stop after either reaching top-N or going through all the features in a group
-    if (k >= top_k_ || counter_[group_idx] == model.learner_model_param->num_feature) return -1;
+    // k-th selected feature for a target
+    auto k = counter_[target_idx]++;
+    // Stop after either reaching top-N or going through all the features for a target.
+    if (k >= top_k_ || counter_[target_idx] == model.learner_model_param->num_feature) return -1;
     // note that sorted_idx stores the "long" indices
-    const size_t grp_offset = group_idx * model.learner_model_param->num_feature;
-    return static_cast<int>(sorted_idx_[grp_offset + k] - grp_offset);
+    const size_t target_offset = target_idx * model.learner_model_param->num_feature;
+    return static_cast<int>(sorted_idx_[target_offset + k] - target_offset);
   }
 
  protected:

--- a/src/linear/updater_coordinate.cc
+++ b/src/linear/updater_coordinate.cc
@@ -4,8 +4,9 @@
  */
 
 #include <xgboost/linear_updater.h>
-#include "./param.h"
+
 #include "../common/timer.h"
+#include "./param.h"
 #include "coordinate_common.h"
 #include "xgboost/json.h"
 
@@ -24,17 +25,15 @@ DMLC_REGISTRY_FILE_TAG(updater_coordinate);
 class CoordinateUpdater : public LinearUpdater {
  public:
   // set training parameter
-  void Configure(Args const& args) override {
-    const std::vector<std::pair<std::string, std::string> > rest {
-      tparam_.UpdateAllowUnknown(args)
-    };
+  void Configure(Args const &args) override {
+    const std::vector<std::pair<std::string, std::string> > rest{tparam_.UpdateAllowUnknown(args)};
     cparam_.UpdateAllowUnknown(rest);
     selector_.reset(FeatureSelector::Create(tparam_.feature_selector));
     monitor_.Init("CoordinateUpdater");
   }
 
-  void LoadConfig(Json const& in) override {
-    auto const& config = get<Object const>(in);
+  void LoadConfig(Json const &in) override {
+    auto const &config = get<Object const>(in);
     FromJson(config.at("linear_train_param"), &tparam_);
     FromJson(config.at("coordinate_param"), &cparam_);
   }
@@ -49,44 +48,43 @@ class CoordinateUpdater : public LinearUpdater {
               double sum_instance_weight) override {
     auto gpair = in_gpair->Data();
     tparam_.DenormalizePenalties(sum_instance_weight);
-    auto ngroup = model->learner_model_param->num_output_group;
+    auto n_targets = model->learner_model_param->NumTargets();
     // update bias
-    for (decltype(ngroup) group_idx = 0; group_idx < ngroup; ++group_idx) {
-      auto grad = GetBiasGradientParallel(group_idx, ngroup, gpair->ConstHostVector(), p_fmat,
+    for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+      auto grad = GetBiasGradientParallel(target_idx, n_targets, gpair->ConstHostVector(), p_fmat,
                                           ctx_->Threads());
       auto dbias =
           static_cast<float>(tparam_.learning_rate * CoordinateDeltaBias(grad.first, grad.second));
-      model->Bias()[group_idx] += dbias;
-      UpdateBiasResidualParallel(ctx_, group_idx, ngroup, dbias, &gpair->HostVector(), p_fmat);
+      model->Bias()[target_idx] += dbias;
+      UpdateBiasResidualParallel(ctx_, target_idx, n_targets, dbias, &gpair->HostVector(), p_fmat);
     }
     // prepare for updating the weights
     selector_->Setup(ctx_, *model, gpair->ConstHostVector(), p_fmat, tparam_.reg_alpha_denorm,
                      tparam_.reg_lambda_denorm, cparam_.top_k);
     // update weights
-    for (decltype(ngroup) group_idx = 0; group_idx < ngroup; ++group_idx) {
+    for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
       for (unsigned i = 0U; i < model->learner_model_param->num_feature; i++) {
         int fidx =
-            selector_->NextFeature(ctx_, i, *model, group_idx, gpair->ConstHostVector(), p_fmat,
+            selector_->NextFeature(ctx_, i, *model, target_idx, gpair->ConstHostVector(), p_fmat,
                                    tparam_.reg_alpha_denorm, tparam_.reg_lambda_denorm);
         if (fidx < 0) break;
-        this->UpdateFeature(fidx, group_idx, &gpair->HostVector(), p_fmat, model);
+        this->UpdateFeature(fidx, target_idx, &gpair->HostVector(), p_fmat, model);
       }
     }
     monitor_.Stop("UpdateFeature");
   }
 
-  void UpdateFeature(int fidx, int group_idx, std::vector<GradientPair> *in_gpair, DMatrix *p_fmat,
-                     gbm::GBLinearModel *model) {
-    const int ngroup = model->learner_model_param->num_output_group;
-    bst_float &w = (*model)[fidx][group_idx];
-    auto gradient = GetGradientParallel(ctx_, group_idx, ngroup, fidx,
-                                        *in_gpair, p_fmat);
-    auto dw = static_cast<float>(
-        tparam_.learning_rate *
-        CoordinateDelta(gradient.first, gradient.second, w, tparam_.reg_alpha_denorm,
-                        tparam_.reg_lambda_denorm));
+  void UpdateFeature(int fidx, bst_target_t target_idx, std::vector<GradientPair> *in_gpair,
+                     DMatrix *p_fmat, gbm::GBLinearModel *model) {
+    auto n_targets = model->learner_model_param->NumTargets();
+    bst_float &w = (*model)[fidx][target_idx];
+    auto gradient = GetGradientParallel(ctx_, target_idx, n_targets, fidx, *in_gpair, p_fmat);
+    auto dw =
+        static_cast<float>(tparam_.learning_rate * CoordinateDelta(gradient.first, gradient.second,
+                                                                   w, tparam_.reg_alpha_denorm,
+                                                                   tparam_.reg_lambda_denorm));
     w += dw;
-    UpdateResidualParallel(ctx_, fidx, group_idx, ngroup, dw, in_gpair, p_fmat);
+    UpdateResidualParallel(ctx_, fidx, target_idx, n_targets, dw, in_gpair, p_fmat);
   }
 
  private:

--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -7,13 +7,13 @@
 #include <thrust/inner_product.h>
 #include <xgboost/data.h>
 #include <xgboost/linear_updater.h>
-#include "xgboost/span.h"
 
-#include "coordinate_common.h"
 #include "../common/common.h"
 #include "../common/device_helpers.cuh"
 #include "../common/timer.h"
 #include "./param.h"
+#include "coordinate_common.h"
+#include "xgboost/span.h"
 
 namespace xgboost::linear {
 
@@ -35,8 +35,8 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     monitor_.Init("GPUCoordinateUpdater");
   }
 
-  void LoadConfig(Json const& in) override {
-    auto const& config = get<Object const>(in);
+  void LoadConfig(Json const &in) override {
+    auto const &config = get<Object const>(in);
     FromJson(config.at("linear_train_param"), &tparam_);
     FromJson(config.at("coordinate_param"), &coord_param_);
   }
@@ -71,25 +71,20 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
       auto cmp = [](Entry e1, Entry e2) {
         return e1.index < e2.index;
       };
-      auto column_begin =
-          std::lower_bound(col.cbegin(), col.cend(),
-                           xgboost::Entry(0, 0.0f), cmp);
+      auto column_begin = std::lower_bound(col.cbegin(), col.cend(), xgboost::Entry(0, 0.0f), cmp);
       auto column_end =
-          std::lower_bound(col.cbegin(), col.cend(),
-                           xgboost::Entry(num_row_, 0.0f), cmp);
+          std::lower_bound(col.cbegin(), col.cend(), xgboost::Entry(num_row_, 0.0f), cmp);
       column_segments.emplace_back(static_cast<bst_uint>(column_begin - col.cbegin()),
                                    static_cast<bst_uint>(column_end - col.cbegin()));
       row_ptr_.push_back(row_ptr_.back() + (column_end - column_begin));
     }
     data_.resize(row_ptr_.back());
-    gpair_.resize(num_row_ * model_param.num_output_group);
+    gpair_.resize(num_row_ * model_param.NumTargets());
     for (size_t fidx = 0; fidx < batch.Size(); fidx++) {
       auto col = page[fidx];
       auto seg = column_segments[fidx];
-      dh::safe_cuda(cudaMemcpy(
-          data_.data().get() + row_ptr_[fidx],
-          col.data() + seg.first,
-          sizeof(Entry) * (seg.second - seg.first), cudaMemcpyHostToDevice));
+      dh::safe_cuda(cudaMemcpy(data_.data().get() + row_ptr_[fidx], col.data() + seg.first,
+                               sizeof(Entry) * (seg.second - seg.first), cudaMemcpyHostToDevice));
     }
   }
 
@@ -115,84 +110,82 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     selector_->Setup(ctx_, *model, in_gpair->Data()->ConstHostVector(), p_fmat,
                      tparam_.reg_alpha_denorm, tparam_.reg_lambda_denorm, coord_param_.top_k);
     monitor_.Start("UpdateFeature");
-    for (uint32_t group_idx = 0; group_idx < model->learner_model_param->num_output_group;
-         ++group_idx) {
+    for (bst_target_t target_idx = 0; target_idx < model->learner_model_param->NumTargets();
+         ++target_idx) {
       for (auto i = 0U; i < model->learner_model_param->num_feature; i++) {
         auto fidx =
-            selector_->NextFeature(ctx_, i, *model, group_idx, in_gpair->Data()->ConstHostVector(),
+            selector_->NextFeature(ctx_, i, *model, target_idx, in_gpair->Data()->ConstHostVector(),
                                    p_fmat, tparam_.reg_alpha_denorm, tparam_.reg_lambda_denorm);
         if (fidx < 0) break;
-        this->UpdateFeature(fidx, group_idx, model);
+        this->UpdateFeature(fidx, target_idx, model);
       }
     }
     monitor_.Stop("UpdateFeature");
   }
 
   void UpdateBias(gbm::GBLinearModel *model) {
-    for (uint32_t group_idx = 0; group_idx < model->learner_model_param->num_output_group;
-         ++group_idx) {
+    auto n_targets = model->learner_model_param->NumTargets();
+    for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
       // Get gradient
       auto grad = GradientPair(0, 0);
       if (ctx_->IsCUDA()) {
-        grad = GetBiasGradient(group_idx, model->learner_model_param->num_output_group);
+        grad = GetBiasGradient(target_idx, n_targets);
       }
-      auto dbias = static_cast<float>(
-          tparam_.learning_rate *
-              CoordinateDeltaBias(grad.GetGrad(), grad.GetHess()));
-      model->Bias()[group_idx] += dbias;
+      auto dbias = static_cast<float>(tparam_.learning_rate *
+                                      CoordinateDeltaBias(grad.GetGrad(), grad.GetHess()));
+      model->Bias()[target_idx] += dbias;
 
       // Update residual
       if (ctx_->IsCUDA()) {
-        UpdateBiasResidual(dbias, group_idx, model->learner_model_param->num_output_group);
+        UpdateBiasResidual(dbias, target_idx, n_targets);
       }
     }
   }
 
-  void UpdateFeature(int fidx, int group_idx,
-                     gbm::GBLinearModel *model) {
-    bst_float &w = (*model)[fidx][group_idx];
+  void UpdateFeature(int fidx, bst_target_t target_idx, gbm::GBLinearModel *model) {
+    auto n_targets = model->learner_model_param->NumTargets();
+    bst_float &w = (*model)[fidx][target_idx];
     // Get gradient
     auto grad = GradientPair(0, 0);
     if (ctx_->IsCUDA()) {
-      grad = GetGradient(group_idx, model->learner_model_param->num_output_group, fidx);
+      grad = GetGradient(target_idx, n_targets, fidx);
     }
-    auto dw = static_cast<float>(tparam_.learning_rate *
-                                 CoordinateDelta(grad.GetGrad(), grad.GetHess(),
-                                                 w, tparam_.reg_alpha_denorm,
-                                                 tparam_.reg_lambda_denorm));
+    auto dw =
+        static_cast<float>(tparam_.learning_rate * CoordinateDelta(grad.GetGrad(), grad.GetHess(),
+                                                                   w, tparam_.reg_alpha_denorm,
+                                                                   tparam_.reg_lambda_denorm));
     w += dw;
 
     if (ctx_->IsCUDA()) {
-      UpdateResidual(dw, group_idx, model->learner_model_param->num_output_group, fidx);
+      UpdateResidual(dw, target_idx, n_targets, fidx);
     }
   }
 
   // This needs to be public because of the __device__ lambda.
-  GradientPair GetBiasGradient(int group_idx, int num_group) {
+  GradientPair GetBiasGradient(bst_target_t target_idx, bst_target_t n_targets) {
     dh::safe_cuda(cudaSetDevice(ctx_->Ordinal()));
     auto counting = thrust::make_counting_iterator(0ull);
     auto f = [=] __device__(size_t idx) {
-      return idx * num_group + group_idx;
+      return idx * n_targets + target_idx;
     };  // NOLINT
-    thrust::transform_iterator<decltype(f), decltype(counting), size_t> skip(
-        counting, f);
+    thrust::transform_iterator<decltype(f), decltype(counting), size_t> skip(counting, f);
     auto perm = thrust::make_permutation_iterator(gpair_.data(), skip);
 
     return dh::SumReduction(perm, num_row_);
   }
 
   // This needs to be public because of the __device__ lambda.
-  void UpdateBiasResidual(float dbias, int group_idx, int num_groups) {
+  void UpdateBiasResidual(float dbias, bst_target_t target_idx, bst_target_t n_targets) {
     if (dbias == 0.0f) return;
     auto d_gpair = dh::ToSpan(gpair_);
     dh::LaunchN(num_row_, [=] __device__(size_t idx) {
-      auto &g = d_gpair[idx * num_groups + group_idx];
+      auto &g = d_gpair[idx * n_targets + target_idx];
       g += GradientPair(g.GetHess() * dbias, 0);
     });
   }
 
   // This needs to be public because of the __device__ lambda.
-  GradientPair GetGradient(int group_idx, int num_group, int fidx) {
+  GradientPair GetGradient(bst_target_t target_idx, bst_target_t n_targets, int fidx) {
     dh::safe_cuda(cudaSetDevice(ctx_->Ordinal()));
     common::Span<xgboost::Entry> d_col = dh::ToSpan(data_).subspan(row_ptr_[fidx]);
     size_t col_size = row_ptr_[fidx + 1] - row_ptr_[fidx];
@@ -200,36 +193,32 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     auto counting = thrust::make_counting_iterator(0ull);
     auto f = [=] __device__(size_t idx) {
       auto entry = d_col[idx];
-      auto g = d_gpair[entry.index * num_group + group_idx];
+      auto g = d_gpair[entry.index * n_targets + target_idx];
       return GradientPair{g.GetGrad() * entry.fvalue, g.GetHess() * entry.fvalue * entry.fvalue};
     };  // NOLINT
-    thrust::transform_iterator<decltype(f), decltype(counting), GradientPair>
-        multiply_iterator(counting, f);
+    thrust::transform_iterator<decltype(f), decltype(counting), GradientPair> multiply_iterator(
+        counting, f);
     return dh::SumReduction(multiply_iterator, col_size);
   }
 
   // This needs to be public because of the __device__ lambda.
-  void UpdateResidual(float dw, int group_idx, int num_groups, int fidx) {
+  void UpdateResidual(float dw, bst_target_t target_idx, bst_target_t n_targets, int fidx) {
     common::Span<GradientPair> d_gpair = dh::ToSpan(gpair_);
     common::Span<Entry> d_col = dh::ToSpan(data_).subspan(row_ptr_[fidx]);
     size_t col_size = row_ptr_[fidx + 1] - row_ptr_[fidx];
     dh::LaunchN(col_size, [=] __device__(size_t idx) {
       auto entry = d_col[idx];
-      auto &g = d_gpair[entry.index * num_groups + group_idx];
+      auto &g = d_gpair[entry.index * n_targets + target_idx];
       g += GradientPair(g.GetHess() * dw * entry.fvalue, 0);
     });
   }
 
  private:
-  bool IsEmpty() {
-    return num_row_ == 0;
-  }
+  bool IsEmpty() { return num_row_ == 0; }
 
   void UpdateGpair(const std::vector<GradientPair> &host_gpair) {
-    dh::safe_cuda(cudaMemcpyAsync(
-        gpair_.data().get(),
-        host_gpair.data(),
-        gpair_.size() * sizeof(GradientPair), cudaMemcpyHostToDevice));
+    dh::safe_cuda(cudaMemcpyAsync(gpair_.data().get(), host_gpair.data(),
+                                  gpair_.size() * sizeof(GradientPair), cudaMemcpyHostToDevice));
   }
 
   // training parameter

--- a/src/linear/updater_shotgun.cc
+++ b/src/linear/updater_shotgun.cc
@@ -4,6 +4,7 @@
  */
 
 #include <xgboost/linear_updater.h>
+
 #include "coordinate_common.h"
 
 namespace xgboost::linear {
@@ -13,21 +14,20 @@ DMLC_REGISTRY_FILE_TAG(updater_shotgun);
 class ShotgunUpdater : public LinearUpdater {
  public:
   // set training parameter
-  void Configure(Args const& args) override {
+  void Configure(Args const &args) override {
     param_.UpdateAllowUnknown(args);
-    if (param_.feature_selector != kCyclic &&
-        param_.feature_selector != kShuffle) {
+    if (param_.feature_selector != kCyclic && param_.feature_selector != kShuffle) {
       LOG(FATAL) << "Unsupported feature selector for shotgun updater.\n"
                  << "Supported options are: {cyclic, shuffle}";
     }
     selector_.reset(FeatureSelector::Create(param_.feature_selector));
   }
-  void LoadConfig(Json const& in) override {
-    auto const& config = get<Object const>(in);
+  void LoadConfig(Json const &in) override {
+    auto const &config = get<Object const>(in);
     FromJson(config.at("linear_train_param"), &param_);
   }
-  void SaveConfig(Json* p_out) const override {
-    auto& out = *p_out;
+  void SaveConfig(Json *p_out) const override {
+    auto &out = *p_out;
     out["linear_train_param"] = ToJson(param_);
   }
 
@@ -35,16 +35,16 @@ class ShotgunUpdater : public LinearUpdater {
               double sum_instance_weight) override {
     auto gpair = in_gpair->Data();
     param_.DenormalizePenalties(sum_instance_weight);
-    const int ngroup = model->learner_model_param->num_output_group;
+    auto const n_targets = model->learner_model_param->NumTargets();
 
     // update bias
-    for (int gid = 0; gid < ngroup; ++gid) {
-      auto grad = GetBiasGradientParallel(gid, ngroup, gpair->ConstHostVector(), p_fmat,
+    for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
+      auto grad = GetBiasGradientParallel(target_idx, n_targets, gpair->ConstHostVector(), p_fmat,
                                           ctx_->Threads());
       auto dbias = static_cast<bst_float>(param_.learning_rate *
-                               CoordinateDeltaBias(grad.first, grad.second));
-      model->Bias()[gid] += dbias;
-      UpdateBiasResidualParallel(ctx_, gid, ngroup, dbias, &gpair->HostVector(), p_fmat);
+                                          CoordinateDeltaBias(grad.first, grad.second));
+      model->Bias()[target_idx] += dbias;
+      UpdateBiasResidualParallel(ctx_, target_idx, n_targets, dbias, &gpair->HostVector(), p_fmat);
     }
 
     // lock-free parallel updates of weights
@@ -60,16 +60,16 @@ class ShotgunUpdater : public LinearUpdater {
         if (ii < 0) return;
         const bst_uint fid = ii;
         auto col = page[ii];
-        for (int gid = 0; gid < ngroup; ++gid) {
+        for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
           double sum_grad = 0.0, sum_hess = 0.0;
           for (auto &c : col) {
-            const GradientPair &p = h_gpair[c.index * ngroup + gid];
+            const GradientPair &p = h_gpair[c.index * n_targets + target_idx];
             if (p.GetHess() < 0.0f) continue;
             const bst_float v = c.fvalue;
             sum_grad += p.GetGrad() * v;
             sum_hess += p.GetHess() * v * v;
           }
-          bst_float &w = (*model)[fid][gid];
+          bst_float &w = (*model)[fid][target_idx];
           auto dw = static_cast<bst_float>(
               param_.learning_rate * CoordinateDelta(sum_grad, sum_hess, w, param_.reg_alpha_denorm,
                                                      param_.reg_lambda_denorm));
@@ -77,7 +77,7 @@ class ShotgunUpdater : public LinearUpdater {
           w += dw;
           // update grad values
           for (auto &c : col) {
-            GradientPair &p = h_gpair[c.index * ngroup + gid];
+            GradientPair &p = h_gpair[c.index * n_targets + target_idx];
             if (p.GetHess() < 0.0f) continue;
             p += GradientPair(p.GetHess() * c.fvalue * dw, 0);
           }

--- a/src/objective/adaptive.cc
+++ b/src/objective/adaptive.cc
@@ -105,7 +105,7 @@ namespace {
 }  // namespace
 
 void UpdateTreeLeaf(Context const* ctx, std::vector<bst_node_t> const& position,
-                    bst_target_t group_idx, MetaInfo const& info, float learning_rate,
+                    bst_target_t target_idx, MetaInfo const& info, float learning_rate,
                     HostDeviceVector<float> const& predt, std::vector<float> const& alphas,
                     RegTree* p_tree) {
   std::vector<bst_node_t> nidx;
@@ -142,11 +142,11 @@ void UpdateTreeLeaf(Context const* ctx, std::vector<bst_node_t> const& position,
     auto h_weights = linalg::MakeVec(&info.weights_);
     // Loop over each target (quantile).
     for (std::size_t alpha_idx = 0; alpha_idx < n_alphas; ++alpha_idx) {
-      // If it's vector-leaf, group_idx is 0, alpha_idx is used. Otherwise,
-      // alpha_idx is 0, the group idx is used.
-      auto predt_idx = std::max(alpha_idx, static_cast<std::size_t>(group_idx));
+      // If it's vector-leaf, target_idx is 0, alpha_idx is used. Otherwise,
+      // alpha_idx is 0, the target idx is used.
+      auto predt_idx = std::max(alpha_idx, static_cast<std::size_t>(target_idx));
       // label is a single column for quantile regression, but it's a matrix for MAE.
-      auto y_idx = std::max(alpha_idx, static_cast<std::size_t>(group_idx));
+      auto y_idx = std::max(alpha_idx, static_cast<std::size_t>(target_idx));
       y_idx = std::min(y_idx, h_labels.Shape(1) - 1);
       auto iter = common::MakeIndexTransformIter([&](std::size_t i) -> float {
         auto row_idx = h_row_set[i];

--- a/src/objective/adaptive.cu
+++ b/src/objective/adaptive.cu
@@ -144,7 +144,7 @@ void EncodeTreeLeafDevice(Context const* ctx, common::Span<bst_node_t const> pos
 
 namespace cuda_impl {
 void UpdateTreeLeaf(Context const* ctx, common::Span<bst_node_t const> position,
-                    bst_target_t group_idx, MetaInfo const& info, float learning_rate,
+                    bst_target_t target_idx, MetaInfo const& info, float learning_rate,
                     HostDeviceVector<float> const& predt, std::vector<float> const& h_alphas,
                     RegTree* p_tree) {
   dh::safe_cuda(cudaSetDevice(ctx->Ordinal()));
@@ -163,7 +163,7 @@ void UpdateTreeLeaf(Context const* ctx, common::Span<bst_node_t const> position,
   predt.SetDevice(ctx->Device());
   auto d_predt = linalg::MakeTensorView(ctx, predt.ConstDeviceSpan(), info.num_row_,
                                         predt.Size() / info.num_row_);
-  CHECK_LT(group_idx, d_predt.Shape(1));
+  CHECK_LT(target_idx, d_predt.Shape(1));
   if (p_tree->IsMultiTarget()) {
     CHECK_EQ(d_predt.Shape(1), h_alphas.size());
   }
@@ -178,11 +178,11 @@ void UpdateTreeLeaf(Context const* ctx, common::Span<bst_node_t const> position,
   auto d_labels = info.labels.View(ctx->Device());
 
   auto values = [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) {
-    // If it's vector-leaf, group_idx is 0, j is used. Otherwise, j is 0, group idx is used.
-    auto p_idx = cuda::std::max(j, static_cast<std::size_t>(group_idx));
+    // If it's vector-leaf, target_idx is 0, j is used. Otherwise, j is 0, target idx is used.
+    auto p_idx = cuda::std::max(j, static_cast<std::size_t>(target_idx));
     auto p = d_predt(d_row_index[i], p_idx);
     // label is a single column for quantile regression, but it's a matrix for MAE.
-    auto y_idx = cuda::std::max(j, static_cast<std::size_t>(group_idx));
+    auto y_idx = cuda::std::max(j, static_cast<std::size_t>(target_idx));
     y_idx = cuda::std::min(y_idx, d_labels.Shape(1) - 1);
     auto y = d_labels(d_row_index[i], y_idx);
     return y - p;

--- a/src/objective/adaptive.h
+++ b/src/objective/adaptive.h
@@ -89,10 +89,10 @@ inline void UpdateLeafValues(Context const* ctx, std::vector<float>* p_quantiles
   }
 }
 
-inline std::size_t IdxY(MetaInfo const& info, bst_group_t group_idx) {
+inline std::size_t IdxY(MetaInfo const& info, bst_target_t target_idx) {
   std::size_t y_idx{0};
   if (info.labels.Shape(1) > 1) {
-    y_idx = group_idx;
+    y_idx = target_idx;
   }
   CHECK_LE(y_idx, info.labels.Shape(1));
   return y_idx;
@@ -101,29 +101,29 @@ inline std::size_t IdxY(MetaInfo const& info, bst_group_t group_idx) {
 
 namespace cpu_impl {
 void UpdateTreeLeaf(Context const* ctx, std::vector<bst_node_t> const& position,
-                    bst_target_t group_idx, MetaInfo const& info, float learning_rate,
+                    bst_target_t target_idx, MetaInfo const& info, float learning_rate,
                     HostDeviceVector<float> const& predt, std::vector<float> const& alphas,
                     RegTree* p_tree);
 }
 
 namespace cuda_impl {
 void UpdateTreeLeaf(Context const* ctx, common::Span<bst_node_t const> position,
-                    bst_target_t group_idx, MetaInfo const& info, float learning_rate,
+                    bst_target_t target_idx, MetaInfo const& info, float learning_rate,
                     HostDeviceVector<float> const& predt, std::vector<float> const& alphas,
                     RegTree* p_tree);
 }
 
 inline void UpdateTreeLeaf(Context const* ctx, HostDeviceVector<bst_node_t> const& position,
-                           bst_target_t group_idx, MetaInfo const& info, float learning_rate,
+                           bst_target_t target_idx, MetaInfo const& info, float learning_rate,
                            HostDeviceVector<float> const& predt, std::vector<float> const& alphas,
                            RegTree* p_tree) {
   if (ctx->IsCUDA()) {
     position.SetDevice(ctx->Device());
-    cuda_impl::UpdateTreeLeaf(ctx, position.ConstDeviceSpan(), group_idx, info, learning_rate,
+    cuda_impl::UpdateTreeLeaf(ctx, position.ConstDeviceSpan(), target_idx, info, learning_rate,
                               predt, alphas, p_tree);
   } else {
-    cpu_impl::UpdateTreeLeaf(ctx, position.ConstHostVector(), group_idx, info, learning_rate, predt,
-                             alphas, p_tree);
+    cpu_impl::UpdateTreeLeaf(ctx, position.ConstHostVector(), target_idx, info, learning_rate,
+                             predt, alphas, p_tree);
   }
 }
 }  // namespace xgboost::obj

--- a/src/objective/quantile_obj.cu
+++ b/src/objective/quantile_obj.cu
@@ -161,17 +161,17 @@ class QuantileRegression : public ObjFunction {
 
   void UpdateTreeLeaf(HostDeviceVector<bst_node_t> const& position, MetaInfo const& info,
                       float learning_rate, HostDeviceVector<float> const& prediction,
-                      bst_target_t group_idx, RegTree* p_tree) const override {
+                      bst_target_t target_idx, RegTree* p_tree) const override {
     auto const& alphas = param_.quantile_alpha.Get();
     if (p_tree->IsMultiTarget()) {
-      CHECK_EQ(group_idx, 0);
+      CHECK_EQ(target_idx, 0);
       // Pass all the alphas
-      ::xgboost::obj::UpdateTreeLeaf(ctx_, position, group_idx, info, learning_rate, prediction,
+      ::xgboost::obj::UpdateTreeLeaf(ctx_, position, target_idx, info, learning_rate, prediction,
                                      alphas, p_tree);
     } else {
-      // Use only the alpha for the current group.
-      ::xgboost::obj::UpdateTreeLeaf(ctx_, position, group_idx, info, learning_rate, prediction,
-                                     std::vector{alphas[group_idx]}, p_tree);
+      // Use only the alpha for the current target.
+      ::xgboost::obj::UpdateTreeLeaf(ctx_, position, target_idx, info, learning_rate, prediction,
+                                     std::vector{alphas[target_idx]}, p_tree);
     }
   }
 

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -920,14 +920,14 @@ class MeanAbsoluteError : public ObjFunction {
 
   void UpdateTreeLeaf(HostDeviceVector<bst_node_t> const& position, MetaInfo const& info,
                       float learning_rate, HostDeviceVector<float> const& prediction,
-                      bst_target_t group_idx, RegTree* p_tree) const override {
+                      bst_target_t target_idx, RegTree* p_tree) const override {
     std::vector<float> alphas;
     if (p_tree->IsMultiTarget()) {
       alphas.resize(p_tree->NumTargets(), 0.5);
     } else {
       alphas.push_back(0.5);
     }
-    ::xgboost::obj::UpdateTreeLeaf(ctx_, position, group_idx, info, learning_rate, prediction,
+    ::xgboost::obj::UpdateTreeLeaf(ctx_, position, target_idx, info, learning_rate, prediction,
                                    alphas, p_tree);
   }
 

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -8,23 +8,18 @@
 #include <memory>     // for unique_ptr, shared_ptr
 #include <vector>     // for vector
 
-#include "../collective/allreduce.h"         // for Allreduce
-#include "../collective/communicator-inl.h"  // for IsDistributed
-#include "../common/bitfield.h"              // for RBitField8
-#include "../common/column_matrix.h"         // for ColumnMatrix
-#include "../common/error_msg.h"             // for InplacePredictProxy
-#include "../common/math.h"                  // for CheckNAN
-#include "../common/optional_weight.h"       // for OptionalWeights
-#include "../common/threading_utils.h"       // for ParallelFor
-#include "../data/adapter.h"                 // for ArrayAdapter, CSRAdapter, CSRArrayAdapter
-#include "../data/cat_container.h"           // for CatContainer
-#include "../data/gradient_index.h"          // for GHistIndexMatrix
-#include "../data/proxy_dmatrix.h"           // for DMatrixProxy
-#include "../gbm/gbtree_model.h"             // for GBTreeModel, GBTreeModelParam
-#include "array_tree_layout.h"               // for ProcessArrayTree
-#include "data_accessor.h"                   // for GHistIndexMatrixView, SparsePageView
-#include "dmlc/registry.h"                   // for DMLC_REGISTRY_FILE_TAG
-#include "gbtree_view.h"                     // for GBTreeModelView
+#include "../common/error_msg.h"        // for InplacePredictProxy
+#include "../common/optional_weight.h"  // for OptionalWeights
+#include "../common/threading_utils.h"  // for ParallelFor
+#include "../data/adapter.h"            // for ArrayAdapter, CSRAdapter, CSRArrayAdapter
+#include "../data/cat_container.h"      // for CatContainer
+#include "../data/gradient_index.h"     // for GHistIndexMatrix
+#include "../data/proxy_dmatrix.h"      // for DMatrixProxy
+#include "../gbm/gbtree_model.h"        // for GBTreeModel, GBTreeModelParam
+#include "array_tree_layout.h"          // for ProcessArrayTree
+#include "data_accessor.h"              // for GHistIndexMatrixView, SparsePageView
+#include "dmlc/registry.h"              // for DMLC_REGISTRY_FILE_TAG
+#include "gbtree_view.h"                // for GBTreeModelView
 #include "interpretability/shap.h"  // for ShapValues, ApproxFeatureImportance, ShapInteractionValues
 #include "predict_fn.h"             // for GetNextNode, GetNextNodeMulti
 #include "utils.h"                  // for CheckProxyDMatrix
@@ -87,8 +82,8 @@ template <bool has_categorical>
 template <bool has_categorical, bool any_missing, bool use_array_tree_layout>
 void PredValueByOneTree(tree::ScalarTreeView const &tree, std::size_t const predict_offset,
                         common::Span<RegTree::FVec> fvec_tloc, std::size_t const block_size,
-                        linalg::MatrixView<float> out_predt, bst_node_t *p_nidx, int depth, int gid,
-                        float tree_weight) {
+                        linalg::MatrixView<float> out_predt, bst_node_t *p_nidx, int depth,
+                        bst_target_t target_idx, float tree_weight) {
   auto const &cats = tree.GetCategoriesMatrix();
   if constexpr (use_array_tree_layout) {
     ProcessArrayTree<has_categorical, any_missing>(tree, fvec_tloc, block_size, p_nidx, depth);
@@ -103,7 +98,7 @@ void PredValueByOneTree(tree::ScalarTreeView const &tree, std::size_t const pred
       nidx = p_nidx[i];
       p_nidx[i] = 0;
     }
-    out_predt(predict_offset + i, gid) +=
+    out_predt(predict_offset + i, target_idx) +=
         PredValueByOneTree<has_categorical>(fvec_tloc[i], tree, cats, nidx) * tree_weight;
   }
 }
@@ -169,15 +164,15 @@ void PredictBlockByAllTrees(HostModel const &model, std::size_t const predict_of
     std::visit(
         enc::Overloaded{[&](tree::ScalarTreeView const &tree) {
                           bool has_categorical = tree.HasCategoricalSplit();
-                          auto const gid = model.tree_groups[tree_id];
+                          auto const target_idx = model.tree_groups[tree_id];
                           if (has_categorical) {
                             scalar::PredValueByOneTree<true, any_missing, use_array_tree_layout>(
                                 tree, predict_offset, fvec_tloc, block_size, out_predt, nidx.data(),
-                                depth, gid, weight);
+                                depth, target_idx, weight);
                           } else {
                             scalar::PredValueByOneTree<false, any_missing, use_array_tree_layout>(
                                 tree, predict_offset, fvec_tloc, block_size, out_predt, nidx.data(),
-                                depth, gid, weight);
+                                depth, target_idx, weight);
                           }
                         },
                         [&](tree::MultiTargetTreeView const &tree) {
@@ -423,7 +418,6 @@ void PredictBatchByBlockKernel(DataView const &batch, HostModel const &model,
     batch.FVecDrop(fvec_tloc);
   });
 }
-
 }  // anonymous namespace
 
 class CPUPredictor : public Predictor {
@@ -434,10 +428,10 @@ class CPUPredictor : public Predictor {
     auto const n_threads = this->ctx_->Threads();
 
     // Create a writable view on the output prediction vector.
-    bst_idx_t n_groups = model.learner_model_param->OutputLength();
+    bst_target_t n_targets = model.learner_model_param->NumTargets();
     bst_idx_t n_samples = p_fmat->Info().num_row_;
-    CHECK_EQ(out_preds->size(), n_samples * n_groups);
-    auto out_predt = linalg::MakeTensorView(ctx_, *out_preds, n_samples, n_groups);
+    CHECK_EQ(out_preds->size(), n_samples * n_targets);
+    auto out_predt = linalg::MakeTensorView(ctx_, *out_preds, n_samples, n_targets);
     bool any_missing = !(p_fmat->IsDense());
     auto const h_model =
         HostModel{DeviceOrd::CPU(), model, false, tree_begin, tree_end, CopyViews{}};
@@ -489,7 +483,7 @@ class CPUPredictor : public Predictor {
     auto const n_threads = this->ctx_->Threads();
     // Always use block as we don't know the nnz.
     ThreadTmp<BlockPolicy::kBlockOfRowsSize> feat_vecs{n_threads};
-    bst_idx_t n_groups = model.learner_model_param->OutputLength();
+    bst_target_t n_targets = model.learner_model_param->NumTargets();
     auto const h_model =
         HostModel{DeviceOrd::CPU(), model, false, tree_begin, tree_end, CopyViews{}};
     auto const *tree_weights = model.TreeWeights();
@@ -499,7 +493,7 @@ class CPUPredictor : public Predictor {
                                                  static_cast<std::size_t>(tree_end - tree_begin)}};
 
     auto kernel = [&](auto &&view) {
-      auto out_predt = linalg::MakeTensorView(ctx_, predictions, view.Size(), n_groups);
+      auto out_predt = linalg::MakeTensorView(ctx_, predictions, view.Size(), n_targets);
       PredictBatchByBlockKernel<BlockPolicy::kBlockOfRowsSize>(view, h_model, &feat_vecs, n_threads,
                                                                any_missing, out_predt, weights);
     };

--- a/src/predictor/gbtree_view.h
+++ b/src/predictor/gbtree_view.h
@@ -32,7 +32,7 @@ class GBTreeModelView {
   bst_tree_t const tree_begin;
   bst_tree_t const tree_end;
   common::Span<bst_target_t const> tree_groups;
-  bst_target_t const n_groups;
+  bst_target_t const n_targets;
   bst_feature_t const n_features;
   bst_node_t n_nodes{0};
 
@@ -41,7 +41,7 @@ class GBTreeModelView {
                            bst_tree_t tree_begin, bst_tree_t tree_end, CopyViews&& copy)
       : tree_begin{tree_begin},
         tree_end{tree_end},
-        n_groups{model.learner_model_param->OutputLength()},
+        n_targets{model.learner_model_param->NumTargets()},
         n_features{model.learner_model_param->num_feature} {
     // Make sure the trees are pulled to target device without race.
     std::lock_guard guard{model.Mutex()};

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -6,7 +6,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include "../common/categorical.h"
 #include "../common/common.h"
 #include "../common/cuda_context.cuh"  // for CUDAContext
 #include "../common/cuda_rt_utils.h"   // for AllVisibleGPUs, SetDevice
@@ -204,7 +203,7 @@ __global__ void PredictKernel(Data data, common::Span<TreeViewVar const> d_trees
                               common::Span<float> d_out_predictions,
                               common::Span<bst_target_t const> d_tree_groups,
                               common::OptionalWeights tree_weights, bst_feature_t num_features,
-                              bool use_shared, bst_target_t n_groups, float missing,
+                              bool use_shared, bst_target_t n_targets, float missing,
                               EncAccessor acc) {
   auto n_rows = data.NumRows();
   bst_idx_t global_idx = blockDim.x * blockIdx.x + threadIdx.x;
@@ -213,7 +212,7 @@ __global__ void PredictKernel(Data data, common::Span<TreeViewVar const> d_trees
     return;
   }
 
-  if (n_groups == 1u) {
+  if (n_targets == 1u) {
     float sum = 0;
     for (std::size_t tree_idx = 0; tree_idx < d_trees.size(); ++tree_idx) {
       auto const& d_tree = d_trees[tree_idx];
@@ -230,14 +229,14 @@ __global__ void PredictKernel(Data data, common::Span<TreeViewVar const> d_trees
       cuda::std::visit(
           enc::Overloaded{[&](tree::ScalarTreeView const& tree) {
                             auto leaf = GetLeafWeight<has_missing>(global_idx, tree, &loader);
-                            bst_idx_t out_prediction_idx = global_idx * n_groups + tree_group;
+                            bst_idx_t out_prediction_idx = global_idx * n_targets + tree_group;
                             d_out_predictions[out_prediction_idx] += leaf * tree_weights[tree_idx];
                           },
                           [&](tree::MultiTargetTreeView const& tree) {
                             // Tree group is 0.
                             auto leaf = GetLeafWeight<has_missing>(global_idx, tree, &loader);
                             for (std::size_t i = 0, n = leaf.Shape(0); i < n; ++i) {
-                              bst_idx_t out_prediction_idx = global_idx * n_groups + i;
+                              bst_idx_t out_prediction_idx = global_idx * n_targets + i;
                               d_out_predictions[out_prediction_idx] +=
                                   leaf(i) * tree_weights[tree_idx];
                             }
@@ -321,9 +320,10 @@ class LaunchConfig {
     auto kernel = PredictKernel<typename Loader::Type, common::GetValueT<decltype(batch)>,
                                 HasMissing(), EncAccessorT>;
     auto d_tree_groups = d_model.tree_groups;
-    this->Launch<Loader>(
-        kernel, std::move(batch), d_model.Trees(), predictions->DeviceSpan().subspan(batch_offset),
-        d_tree_groups, tree_weights, n_features, this->UseShared(), d_model.n_groups, missing, acc);
+    this->Launch<Loader>(kernel, std::move(batch), d_model.Trees(),
+                         predictions->DeviceSpan().subspan(batch_offset), d_tree_groups,
+                         tree_weights, n_features, this->UseShared(), d_model.n_targets, missing,
+                         acc);
   }
 
   [[nodiscard]] bool UseShared() const { return shared_memory_bytes_ != 0; }
@@ -429,7 +429,7 @@ class GPUPredictor : public xgboost::Predictor {
         cfg.template LaunchPredictKernel<Loader>(
             std::move(batch), std::numeric_limits<float>::quiet_NaN(), n_features, d_model, acc,
             batch_offset, out_preds, tree_weights);
-        batch_offset += n_rows * model.learner_model_param->OutputLength();
+        batch_offset += n_rows * model.learner_model_param->NumTargets();
       });
     });
   }

--- a/src/predictor/interpretability/shap.cc
+++ b/src/predictor/interpretability/shap.cc
@@ -458,7 +458,7 @@ QuadratureTreeShapModelData MakeQuadratureTreeShapModelData(
     auto weight = tree_weights == nullptr ? 1.0f : (*tree_weights)[i];
     if (model.trees[i]->IsMultiTarget()) {
       auto const n_targets = model.trees[i]->GetMultiTargetTree()->NumTargets();
-      CHECK_EQ(n_targets, n_targets);
+      CHECK_EQ(n_targets, model.learner_model_param->NumTreeTargets());
       for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
         auto entry_idx = out.entries.size();
         out.entries.push_back(

--- a/src/predictor/interpretability/shap.cc
+++ b/src/predictor/interpretability/shap.cc
@@ -458,7 +458,7 @@ QuadratureTreeShapModelData MakeQuadratureTreeShapModelData(
     auto weight = tree_weights == nullptr ? 1.0f : (*tree_weights)[i];
     if (model.trees[i]->IsMultiTarget()) {
       auto const n_targets = model.trees[i]->GetMultiTargetTree()->NumTargets();
-      CHECK_EQ(n_targets, model.learner_model_param->NumTreeTargets());
+      CHECK_EQ(n_targets, model.learner_model_param->NumTargets());
       for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
         auto entry_idx = out.entries.size();
         out.entries.push_back(

--- a/src/predictor/interpretability/shap.cc
+++ b/src/predictor/interpretability/shap.cc
@@ -441,11 +441,11 @@ QuadratureTreeShapModelData MakeQuadratureTreeShapModelData(
     gbm::GBTreeModel const &model, bst_tree_t tree_end, std::vector<float> const *tree_weights) {
   auto const n_trees = static_cast<std::size_t>(tree_end);
   auto const h_tree_groups = model.TreeGroups(DeviceOrd::CPU());
-  auto const n_groups = model.learner_model_param->num_output_group;
+  auto const n_targets = model.learner_model_param->NumTargets();
 
   QuadratureTreeShapModelData out;
   out.trees.reserve(n_trees);
-  out.entries_by_group.resize(n_groups);
+  out.entries_by_group.resize(n_targets);
 
   for (std::size_t i = 0; i < n_trees; ++i) {
     if (model.trees[i]->IsMultiTarget()) {
@@ -458,7 +458,7 @@ QuadratureTreeShapModelData MakeQuadratureTreeShapModelData(
     auto weight = tree_weights == nullptr ? 1.0f : (*tree_weights)[i];
     if (model.trees[i]->IsMultiTarget()) {
       auto const n_targets = model.trees[i]->GetMultiTargetTree()->NumTargets();
-      CHECK_EQ(n_targets, n_groups);
+      CHECK_EQ(n_targets, n_targets);
       for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
         auto entry_idx = out.entries.size();
         out.entries.push_back(
@@ -472,13 +472,13 @@ QuadratureTreeShapModelData MakeQuadratureTreeShapModelData(
       out.entries_by_group[gid].push_back(entry_idx);
     }
   }
-  std::vector<double> group_root_mean_sums(n_groups, 0.0);
+  std::vector<double> group_root_mean_sums(n_targets, 0.0);
   for (bst_tree_t i = 0; i < tree_end; ++i) {
     auto const weight = tree_weights == nullptr ? 1.0f : (*tree_weights)[i];
     if (model.trees[i]->IsMultiTarget()) {
       auto const tree = model.trees[i]->HostMtView();
       auto const n_targets = tree.NumTargets();
-      CHECK_EQ(n_targets, n_groups);
+      CHECK_EQ(n_targets, n_targets);
       std::vector<double> root_means(n_targets, 0.0);
       detail::FillRootMeanValues(tree, RegTree::kRoot, 1.0, &root_means);
       for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
@@ -560,13 +560,13 @@ void QuadratureTreeShapValues(Context const *ctx, DMatrix *p_fmat,
   CHECK_GE(tree_end, 0);
   ValidateTreeWeights(tree_weights, tree_end);
   auto const n_threads = ctx->Threads();
-  auto const n_groups = model.learner_model_param->num_output_group;
+  auto const n_targets = model.learner_model_param->NumTargets();
   auto const n_features = model.learner_model_param->num_feature;
   size_t const ncolumns = model.learner_model_param->num_feature + 1;
   std::vector<bst_float> &contribs = out_contribs->HostVector();
-  contribs.resize(info.num_row_ * ncolumns * model.learner_model_param->num_output_group);
+  contribs.resize(info.num_row_ * ncolumns * model.learner_model_param->NumTargets());
   std::fill(contribs.begin(), contribs.end(), 0.0f);
-  CHECK_NE(n_groups, 0);
+  CHECK_NE(n_targets, 0);
   auto const &rule = detail::GetQuadratureRule();
   auto const base_score = model.learner_model_param->BaseScore(DeviceOrd::CPU());
   auto model_data = MakeQuadratureTreeShapModelData(model, tree_end, tree_weights);
@@ -590,8 +590,8 @@ void QuadratureTreeShapValues(Context const *ctx, DMatrix *p_fmat,
       auto row_idx = view.base_rowid + i;
       auto n_valid = view.DoFill(i, feats.Data().data());
       feats.HasMissing(n_valid != feats.Size());
-      for (bst_target_t gid = 0; gid < n_groups; ++gid) {
-        float *p_contribs = &contribs[(row_idx * n_groups + gid) * ncolumns];
+      for (bst_target_t gid = 0; gid < n_targets; ++gid) {
+        float *p_contribs = &contribs[(row_idx * n_targets + gid) * ncolumns];
         for (auto entry_idx : model_data.entries_by_group[gid]) {
           auto const &entry = model_data.entries[entry_idx];
           std::fill(this_tree_contribs.begin(), this_tree_contribs.end(), 0.0f);
@@ -611,7 +611,7 @@ void QuadratureTreeShapValues(Context const *ctx, DMatrix *p_fmat,
         }
         p_contribs[ncolumns - 1] += model_data.group_root_mean_sums[gid];
         if (base_margin.Size() != 0) {
-          CHECK_EQ(base_margin.Shape(1), n_groups);
+          CHECK_EQ(base_margin.Shape(1), n_targets);
           p_contribs[ncolumns - 1] += base_margin(row_idx, gid);
         } else {
           p_contribs[ncolumns - 1] += base_score(gid);
@@ -639,10 +639,10 @@ void QuadratureTreeShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
   ValidateTreeWeights(tree_weights, tree_end);
 
   auto const n_threads = ctx->Threads();
-  auto const n_groups = model.learner_model_param->num_output_group;
+  auto const n_targets = model.learner_model_param->NumTargets();
   auto const n_features = model.learner_model_param->num_feature;
   auto const ncolumns = n_features + 1;
-  auto const row_chunk = n_groups * ncolumns * ncolumns;
+  auto const row_chunk = n_targets * ncolumns * ncolumns;
   auto const matrix_chunk = ncolumns * ncolumns;
 
   std::vector<bst_float> &contribs = out_contribs->HostVector();
@@ -675,8 +675,8 @@ void QuadratureTreeShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
       auto n_valid = view.DoFill(i, feats.Data().data());
       feats.HasMissing(n_valid != feats.Size());
 
-      for (bst_target_t gid = 0; gid < n_groups; ++gid) {
-        auto const offset = (row_idx * n_groups + gid) * matrix_chunk;
+      for (bst_target_t gid = 0; gid < n_targets; ++gid) {
+        auto const offset = (row_idx * n_targets + gid) * matrix_chunk;
         auto matrix = DenseInteractionMatrixView<bst_float>{contribs.data() + offset, ncolumns};
         std::fill(diag.begin(), diag.end(), 0.0f);
 
@@ -696,7 +696,7 @@ void QuadratureTreeShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
 
         diag[ncolumns - 1] += model_data.group_root_mean_sums[gid];
         if (base_margin.Size() != 0) {
-          CHECK_EQ(base_margin.Shape(1), n_groups);
+          CHECK_EQ(base_margin.Shape(1), n_targets);
           diag[ncolumns - 1] += base_margin(row_idx, gid);
         } else {
           diag[ncolumns - 1] += base_score(gid);
@@ -743,7 +743,7 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
   auto const n_threads = ctx->Threads();
   size_t const ncolumns = model.learner_model_param->num_feature + 1;
   std::vector<bst_float> &contribs = out_contribs->HostVector();
-  contribs.resize(info.num_row_ * ncolumns * model.learner_model_param->num_output_group);
+  contribs.resize(info.num_row_ * ncolumns * model.learner_model_param->NumTargets());
   std::fill(contribs.begin(), contribs.end(), 0);
   std::vector<std::vector<float>> mean_values(n_trees);
   std::atomic<bool> is_vector_leaf = false;
@@ -758,8 +758,8 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
     LOG(FATAL) << "Approximate predict contribution " << MTNotImplemented();
   }
 
-  auto const n_groups = model.learner_model_param->num_output_group;
-  CHECK_NE(n_groups, 0);
+  auto const n_targets = model.learner_model_param->NumTargets();
+  CHECK_NE(n_targets, 0);
   auto const base_score = model.learner_model_param->BaseScore(DeviceOrd::CPU());
   auto const h_tree_groups = model.TreeGroups(DeviceOrd::CPU());
   std::vector<RegTree::FVec> feats_tloc(n_threads);
@@ -779,8 +779,8 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
       auto row_idx = view.base_rowid + i;
       auto n_valid = view.DoFill(i, feats.Data().data());
       feats.HasMissing(n_valid != feats.Size());
-      for (bst_target_t gid = 0; gid < n_groups; ++gid) {
-        float *p_contribs = &contribs[(row_idx * n_groups + gid) * ncolumns];
+      for (bst_target_t gid = 0; gid < n_targets; ++gid) {
+        float *p_contribs = &contribs[(row_idx * n_targets + gid) * ncolumns];
         for (bst_tree_t j = 0; j < tree_end; ++j) {
           if (h_tree_groups[j] != gid) {
             continue;
@@ -795,7 +795,7 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
           }
         }
         if (base_margin.Size() != 0) {
-          CHECK_EQ(base_margin.Shape(1), n_groups);
+          CHECK_EQ(base_margin.Shape(1), n_targets);
           p_contribs[ncolumns - 1] += base_margin(row_idx, gid);
         } else {
           p_contribs[ncolumns - 1] += base_score(gid);
@@ -820,20 +820,20 @@ void ShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
   CHECK(!model.learner_model_param->IsVectorLeaf())
       << "Predict interaction contribution" << MTNotImplemented();
   MetaInfo const &info = p_fmat->Info();
-  auto const ngroup = model.learner_model_param->num_output_group;
+  auto const n_targets = model.learner_model_param->NumTargets();
   auto const ncolumns = model.learner_model_param->num_feature;
-  const std::size_t row_chunk = ngroup * (ncolumns + 1) * (ncolumns + 1);
+  const std::size_t row_chunk = n_targets * (ncolumns + 1) * (ncolumns + 1);
   const std::size_t mrow_chunk = (ncolumns + 1) * (ncolumns + 1);
-  const std::size_t crow_chunk = ngroup * (ncolumns + 1);
+  const std::size_t crow_chunk = n_targets * (ncolumns + 1);
 
   // allocate space for (number of features^2) times the number of rows and tmp off/on contribs
   std::vector<bst_float> &contribs = out_contribs->HostVector();
-  contribs.resize(info.num_row_ * ngroup * (ncolumns + 1) * (ncolumns + 1));
-  HostDeviceVector<bst_float> contribs_off_hdv(info.num_row_ * ngroup * (ncolumns + 1));
+  contribs.resize(info.num_row_ * n_targets * (ncolumns + 1) * (ncolumns + 1));
+  HostDeviceVector<bst_float> contribs_off_hdv(info.num_row_ * n_targets * (ncolumns + 1));
   auto &contribs_off = contribs_off_hdv.HostVector();
-  HostDeviceVector<bst_float> contribs_on_hdv(info.num_row_ * ngroup * (ncolumns + 1));
+  HostDeviceVector<bst_float> contribs_on_hdv(info.num_row_ * n_targets * (ncolumns + 1));
   auto &contribs_on = contribs_on_hdv.HostVector();
-  HostDeviceVector<bst_float> contribs_diag_hdv(info.num_row_ * ngroup * (ncolumns + 1));
+  HostDeviceVector<bst_float> contribs_diag_hdv(info.num_row_ * n_targets * (ncolumns + 1));
   auto &contribs_diag = contribs_diag_hdv.HostVector();
 
   // Compute the difference in effects when conditioning on each of the features on and off
@@ -845,7 +845,7 @@ void ShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
     ApproxFeatureImportance(ctx, p_fmat, &contribs_on_hdv, model, tree_end, tree_weights);
 
     for (size_t j = 0; j < info.num_row_; ++j) {
-      for (std::remove_const_t<decltype(ngroup)> l = 0; l < ngroup; ++l) {
+      for (std::remove_const_t<decltype(n_targets)> l = 0; l < n_targets; ++l) {
         const std::size_t o_offset = j * row_chunk + l * mrow_chunk;
         const std::size_t c_offset = j * crow_chunk + l * (ncolumns + 1);
         auto matrix =

--- a/src/predictor/interpretability/shap.cu
+++ b/src/predictor/interpretability/shap.cu
@@ -7,13 +7,10 @@
 
 #include <algorithm>
 #include <array>
-#include <cmath>
 #include <cstdlib>
 #include <cuda/std/utility>  // for swap
 #include <cuda/std/variant>  // for variant
 #include <limits>
-#include <memory>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -25,7 +22,6 @@
 #include "../../common/device_helpers.cuh"
 #include "../../common/math.h"
 #include "../../common/nvtx_utils.h"
-#include "../../common/optional_weight.h"
 #include "../../data/batch_utils.h"      // for StaticBatch
 #include "../../data/cat_container.cuh"  // for EncPolicy, MakeCatAccessor
 #include "../../data/cat_container.h"    // for NoOpAccessor
@@ -1246,29 +1242,29 @@ void ShapValues(Context const* ctx, DMatrix* p_fmat, HostDeviceVector<float>* ou
   CHECK_EQ(condition_feature, 0) << "GPU QuadratureTreeSHAP does not support conditional SHAP.";
 
   tree_end = predictor::GetTreeLimit(model.trees, tree_end);
-  auto const ngroup = model.learner_model_param->num_output_group;
-  CHECK_NE(ngroup, 0);
+  auto const n_targets = model.learner_model_param->NumTargets();
+  CHECK_NE(n_targets, 0);
   auto const ncolumns = model.learner_model_param->num_feature + 1;
-  auto dim_size = ncolumns * ngroup;
+  auto dim_size = ncolumns * n_targets;
   out_contribs->SetDevice(ctx->Device());
   out_contribs->Resize(p_fmat->Info().num_row_ * dim_size);
   out_contribs->Fill(0.0f);
 
   auto prepared =
-      PrepareGpuQuadratureModel(model, tree_end, ngroup, tree_weights, "Predict contribution");
+      PrepareGpuQuadratureModel(model, tree_end, n_targets, tree_weights, "Predict contribution");
 
   auto new_enc =
       p_fmat->Cats()->NeedRecode() ? p_fmat->Cats()->DeviceView(ctx) : enc::DeviceColumnsView{};
   auto group_root_mean_sums = prepared.GroupRootMeanSums();
 
   LaunchShap(ctx, p_fmat, new_enc, model, [&](auto&& loader, bst_idx_t base_rowid) {
-    LaunchQuadratureShapBuckets<16>(ctx, loader, base_rowid, ngroup, ncolumns,
+    LaunchQuadratureShapBuckets<16>(ctx, loader, base_rowid, n_targets, ncolumns,
                                     prepared.compressed[0], prepared.rule, out_contribs);
-    LaunchQuadratureShapBuckets<32>(ctx, loader, base_rowid, ngroup, ncolumns,
+    LaunchQuadratureShapBuckets<32>(ctx, loader, base_rowid, n_targets, ncolumns,
                                     prepared.compressed[1], prepared.rule, out_contribs);
-    LaunchQuadratureShapBuckets<64>(ctx, loader, base_rowid, ngroup, ncolumns,
+    LaunchQuadratureShapBuckets<64>(ctx, loader, base_rowid, n_targets, ncolumns,
                                     prepared.compressed[2], prepared.rule, out_contribs);
-    LaunchQuadratureShapBuckets<128>(ctx, loader, base_rowid, ngroup, ncolumns,
+    LaunchQuadratureShapBuckets<128>(ctx, loader, base_rowid, n_targets, ncolumns,
                                      prepared.compressed[3], prepared.rule, out_contribs);
   });
 
@@ -1277,8 +1273,8 @@ void ShapValues(Context const* ctx, DMatrix* p_fmat, HostDeviceVector<float>* ou
   auto base_score = model.learner_model_param->BaseScore(ctx);
   auto phis = out_contribs->DeviceSpan();
   auto n_samples = p_fmat->Info().num_row_;
-  dh::LaunchN(n_samples * ngroup, ctx->CUDACtx()->Stream(), [=] __device__(std::size_t idx) {
-    auto [_, gid] = linalg::UnravelIndex(idx, n_samples, ngroup);
+  dh::LaunchN(n_samples * n_targets, ctx->CUDACtx()->Stream(), [=] __device__(std::size_t idx) {
+    auto [_, gid] = linalg::UnravelIndex(idx, n_samples, n_targets);
     phis[(idx + 1) * ncolumns - 1] +=
         group_root_mean_sums[gid] + (margin.empty() ? base_score(gid) : margin[idx]);
   });
@@ -1294,15 +1290,15 @@ void ShapInteractionValues(Context const* ctx, DMatrix* p_fmat,
   }
 
   tree_end = predictor::GetTreeLimit(model.trees, tree_end);
-  auto const ngroup = model.learner_model_param->num_output_group;
-  CHECK_NE(ngroup, 0);
+  auto const n_targets = model.learner_model_param->NumTargets();
+  CHECK_NE(n_targets, 0);
   auto const ncolumns = model.learner_model_param->num_feature + 1;
-  auto dim_size = ncolumns * ncolumns * ngroup;
+  auto dim_size = ncolumns * ncolumns * n_targets;
   out_contribs->SetDevice(ctx->Device());
   out_contribs->Resize(p_fmat->Info().num_row_ * dim_size);
   out_contribs->Fill(0.0f);
 
-  auto prepared = PrepareGpuQuadratureModel(model, tree_end, ngroup, tree_weights,
+  auto prepared = PrepareGpuQuadratureModel(model, tree_end, n_targets, tree_weights,
                                             "Predict interaction contribution");
 
   auto new_enc =
@@ -1310,13 +1306,13 @@ void ShapInteractionValues(Context const* ctx, DMatrix* p_fmat,
   auto group_root_mean_sums = prepared.GroupRootMeanSums();
 
   LaunchShap(ctx, p_fmat, new_enc, model, [&](auto&& loader, bst_idx_t base_rowid) {
-    LaunchQuadratureShapInteractionBuckets<16>(ctx, loader, base_rowid, ngroup, ncolumns,
+    LaunchQuadratureShapInteractionBuckets<16>(ctx, loader, base_rowid, n_targets, ncolumns,
                                                prepared.compressed[0], prepared.rule, out_contribs);
-    LaunchQuadratureShapInteractionBuckets<32>(ctx, loader, base_rowid, ngroup, ncolumns,
+    LaunchQuadratureShapInteractionBuckets<32>(ctx, loader, base_rowid, n_targets, ncolumns,
                                                prepared.compressed[1], prepared.rule, out_contribs);
-    LaunchQuadratureShapInteractionBuckets<64>(ctx, loader, base_rowid, ngroup, ncolumns,
+    LaunchQuadratureShapInteractionBuckets<64>(ctx, loader, base_rowid, n_targets, ncolumns,
                                                prepared.compressed[2], prepared.rule, out_contribs);
-    LaunchQuadratureShapInteractionBuckets<128>(ctx, loader, base_rowid, ngroup, ncolumns,
+    LaunchQuadratureShapInteractionBuckets<128>(ctx, loader, base_rowid, n_targets, ncolumns,
                                                 prepared.compressed[3], prepared.rule,
                                                 out_contribs);
   });
@@ -1326,12 +1322,13 @@ void ShapInteractionValues(Context const* ctx, DMatrix* p_fmat,
   auto base_score = model.learner_model_param->BaseScore(ctx);
   auto phis = out_contribs->DeviceSpan();
   auto n_samples = p_fmat->Info().num_row_;
-  dh::LaunchN(n_samples * ngroup, ctx->CUDACtx()->Stream(), [=] __device__(std::size_t idx) {
-    auto [ridx, gid] = linalg::UnravelIndex(idx, n_samples, ngroup);
-    auto matrix_offset = (static_cast<std::size_t>(ridx) * ngroup + gid) * ncolumns * ncolumns;
+  dh::LaunchN(n_samples * n_targets, ctx->CUDACtx()->Stream(), [=] __device__(std::size_t idx) {
+    auto [ridx, target_idx] = linalg::UnravelIndex(idx, n_samples, n_targets);
+    auto matrix_offset =
+        (static_cast<std::size_t>(ridx) * n_targets + target_idx) * ncolumns * ncolumns;
     auto matrix = phis.subspan(matrix_offset, ncolumns * ncolumns);
     matrix[(ncolumns - 1) * ncolumns + (ncolumns - 1)] +=
-        group_root_mean_sums[gid] + (margin.empty() ? base_score(gid) : margin[idx]);
+        group_root_mean_sums[target_idx] + (margin.empty() ? base_score(target_idx) : margin[idx]);
     for (bst_feature_t r = 0; r < ncolumns; ++r) {
       for (bst_feature_t c = r + 1; c < ncolumns; ++c) {
         auto sym = 0.5f * (matrix[r * ncolumns + c] + matrix[c * ncolumns + r]);

--- a/src/predictor/predictor.cc
+++ b/src/predictor/predictor.cc
@@ -9,7 +9,7 @@
 #include <string>   // for string, to_string
 
 #include "../gbm/gbtree_model.h"         // for GBTreeModel
-#include "xgboost/base.h"                // for Args, bst_group_t, bst_idx_t
+#include "xgboost/base.h"                // for Args, bst_idx_t, bst_target_t
 #include "xgboost/context.h"             // for Context
 #include "xgboost/data.h"                // for MetaInfo
 #include "xgboost/host_device_vector.h"  // for HostDeviceVector
@@ -35,12 +35,12 @@ Predictor* Predictor::Create(std::string const& name, Context const* ctx) {
 
 template <int32_t D>
 void ValidateBaseMarginShape(linalg::Tensor<float, D> const& margin, bst_idx_t n_samples,
-                             bst_group_t n_groups) {
+                             bst_target_t n_targets) {
   // FIXME: Bindings other than Python and R don't have shape.
   std::string expected{"Invalid shape of base_margin. Expected: (" + std::to_string(n_samples) +
-                       ", " + std::to_string(n_groups) + ")"};
+                       ", " + std::to_string(n_targets) + ")"};
   CHECK_EQ(margin.Shape(0), n_samples) << expected;
-  CHECK_EQ(margin.Shape(1), n_groups) << expected;
+  CHECK_EQ(margin.Shape(1), n_targets) << expected;
 }
 
 namespace cuda_impl {
@@ -55,20 +55,20 @@ void InitOutPredictions(Context const* ctx, linalg::VectorView<float const> base
 
 void Predictor::InitOutPredictions(const MetaInfo& info, HostDeviceVector<float>* out_preds,
                                    gbm::GBTreeModel const& model) const {
-  CHECK_NE(model.learner_model_param->num_output_group, 0);
+  CHECK_NE(model.learner_model_param->NumTargets(), 0);
 
   if (!ctx_->Device().IsCPU()) {
     out_preds->SetDevice(ctx_->Device());
   }
 
   // Cannot rely on the Resize to fill as it might skip if the size is already correct.
-  auto n = static_cast<size_t>(model.learner_model_param->OutputLength() * info.num_row_);
+  auto n = static_cast<size_t>(model.learner_model_param->NumTargets() * info.num_row_);
   out_preds->Resize(n);
 
   HostDeviceVector<float> const* base_margin = info.base_margin_.Data();
   if (!base_margin->Empty()) {
     ValidateBaseMarginShape(info.base_margin_, info.num_row_,
-                            model.learner_model_param->OutputLength());
+                            model.learner_model_param->NumTargets());
     out_preds->Copy(*base_margin);
     return;
   }
@@ -82,7 +82,7 @@ void Predictor::InitOutPredictions(const MetaInfo& info, HostDeviceVector<float>
 
   // Handle multi-output models where base_score is a vector.
   auto predt = linalg::MakeTensorView(this->ctx_, out_preds, info.num_row_,
-                                      model.learner_model_param->OutputLength());
+                                      model.learner_model_param->NumTargets());
   CHECK_EQ(predt.Size(), out_preds->Size());
 
   if (this->ctx_->IsCUDA()) {

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -215,7 +215,7 @@ Json GetArrayInterface(HostDeviceVector<T> const* storage, size_t rows, size_t c
   array_interface["shape"][1] = cols;
 
   char t = linalg::detail::ArrayInterfaceHandler::TypeChar<T>();
-  array_interface["typestr"] = String(std::string("<") + t + std::to_string(sizeof(T)));
+  array_interface["typestr"] = String(std::string{"<"} + t + std::to_string(sizeof(T)));  // NOLINT
   array_interface["version"] = 3;
   return array_interface;
 }
@@ -492,11 +492,11 @@ RMMAllocatorPtr SetUpRMMResourceForCppTests(int argc, char** argv);
 /*
  * \brief Make learner model param
  */
-inline LearnerModelParam MakeMP(bst_feature_t n_features, float base_score, uint32_t n_groups,
+inline LearnerModelParam MakeMP(bst_feature_t n_features, float base_score, bst_target_t n_targets,
                                 DeviceOrd device = DeviceOrd::CPU()) {
   size_t shape[1]{1};
   LearnerModelParam mparam(n_features, linalg::Tensor<float, 1>{{base_score}, shape, device},
-                           n_groups, 1, MultiStrategy::kOneOutputPerTree);
+                           n_targets, MultiStrategy::kOneOutputPerTree);
   return mparam;
 }
 

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -541,15 +541,15 @@ void TestVectorLeafPrediction(Context const *ctx) {
   size_t constexpr kCols = 5;
 
   LearnerModelParam mparam{static_cast<bst_feature_t>(kCols),
-                           linalg::Vector<float>{{0.5}, {1}, ctx->Device()}, 1, 3,
+                           linalg::Vector<float>{{0.5}, {1}, ctx->Device()}, 3,
                            MultiStrategy::kMultiOutputTree};
 
   std::vector<std::unique_ptr<RegTree>> trees;
-  trees.emplace_back(new RegTree{mparam.LeafLength(), mparam.num_feature});
+  trees.emplace_back(new RegTree{mparam.NumTreeTargets(), mparam.num_feature});
 
-  std::vector<float> p_w(mparam.LeafLength(), 0.0f);
-  std::vector<float> l_w(mparam.LeafLength(), 1.0f);
-  std::vector<float> r_w(mparam.LeafLength(), 2.0f);
+  std::vector<float> p_w(mparam.NumTreeTargets(), 0.0f);
+  std::vector<float> l_w(mparam.NumTreeTargets(), 1.0f);
+  std::vector<float> r_w(mparam.NumTreeTargets(), 2.0f);
 
   auto &tree = trees.front();
   tree->SetRoot(linalg::MakeVec(p_w.data(), p_w.size()), /*sum_hess=*/1.0f);
@@ -568,7 +568,7 @@ void TestVectorLeafPrediction(Context const *ctx) {
     auto p_fmat = GetDMatrixFromData(p_data->ConstHostVector(), kRows, kCols);
     PredictionCacheEntry predt_cache;
     predictor->InitOutPredictions(p_fmat->Info(), &predt_cache.predictions, model);
-    ASSERT_EQ(predt_cache.predictions.Size(), kRows * mparam.LeafLength());
+    ASSERT_EQ(predt_cache.predictions.Size(), kRows * mparam.NumTreeTargets());
     predictor->PredictBatch(p_fmat.get(), &predt_cache, model, 0, 1);
     auto const &h_predt = predt_cache.predictions.HostVector();
     for (auto v : h_predt) {

--- a/tests/cpp/predictor/test_predictor.h
+++ b/tests/cpp/predictor/test_predictor.h
@@ -18,17 +18,18 @@
 
 namespace xgboost {
 inline std::unique_ptr<gbm::GBTreeModel> CreateTestModel(LearnerModelParam const* param,
-                                                         Context const* ctx, size_t n_classes = 1) {
+                                                         Context const* ctx,
+                                                         bst_target_t n_targets = 1) {
   auto model = std::make_unique<gbm::GBTreeModel>(param, ctx);
 
-  for (size_t i = 0; i < n_classes; ++i) {
+  for (bst_target_t target_idx = 0; target_idx < n_targets; ++target_idx) {
     std::vector<std::unique_ptr<RegTree>> trees;
     trees.push_back(std::unique_ptr<RegTree>(new RegTree));
-    if (i == 0) {
+    if (target_idx == 0) {
       (*trees.back())[0].SetLeaf(1.5f);
       (*trees.back()).Stat(0).sum_hess = 1.0f;
     }
-    model->CommitModelGroup(std::move(trees), i);
+    model->CommitModelGroup(std::move(trees), target_idx);
   }
 
   return model;

--- a/tests/cpp/predictor/test_shap.cc
+++ b/tests/cpp/predictor/test_shap.cc
@@ -112,9 +112,10 @@ std::unique_ptr<gbm::GBTreeModel> LoadGBTreeModel(Learner* learner, Context cons
   }
 
   auto n_features = static_cast<bst_feature_t>(std::stol(num_feature));
-  auto n_classes = static_cast<bst_target_t>(std::stol(num_class));
-  auto n_targets = static_cast<bst_target_t>(std::stol(num_target));
-  auto n_groups = static_cast<uint32_t>(std::max(n_classes, n_targets));
+  auto persisted_num_class = static_cast<bst_target_t>(std::stol(num_class));
+  auto persisted_num_target = static_cast<bst_target_t>(std::stol(num_target));
+  auto n_targets =
+      std::max({persisted_num_class, persisted_num_target, static_cast<bst_target_t>(1)});
   auto multi_strategy = MultiStrategy::kOneOutputPerTree;
   for (auto const& kv : model_args) {
     if (kv.first == "multi_strategy") {
@@ -124,7 +125,7 @@ std::unique_ptr<gbm::GBTreeModel> LoadGBTreeModel(Learner* learner, Context cons
       break;
     }
   }
-  LearnerModelParam tmp{n_features, std::move(base_score_vec), n_groups, n_targets, multi_strategy};
+  LearnerModelParam tmp{n_features, std::move(base_score_vec), n_targets, multi_strategy};
   out_param->Copy(tmp);
 
   auto gbtree = std::make_unique<gbm::GBTreeModel>(out_param, ctx);
@@ -332,7 +333,7 @@ void CheckShapHandlesDeepTree(Context const* ctx) {
   if (!ctx->Device().IsCPU()) {
     std::as_const(base_score).View(ctx->Device());
   }
-  LearnerModelParam mparam{1, std::move(base_score), 1, 1, MultiStrategy::kOneOutputPerTree};
+  LearnerModelParam mparam{1, std::move(base_score), 1, MultiStrategy::kOneOutputPerTree};
   gbm::GBTreeModel model{&mparam, ctx};
 
   bst_node_t constexpr kDepth = 64;
@@ -389,7 +390,7 @@ void CheckShapHandlesZeroCover(Context const* ctx, bool zero_parent_cover) {
   if (!ctx->Device().IsCPU()) {
     std::as_const(base_score).View(ctx->Device());
   }
-  LearnerModelParam mparam{1, std::move(base_score), 1, 1, MultiStrategy::kOneOutputPerTree};
+  LearnerModelParam mparam{1, std::move(base_score), 1, MultiStrategy::kOneOutputPerTree};
   gbm::GBTreeModel model{&mparam, ctx};
 
   gbm::TreesOneGroup trees;

--- a/tests/cpp/test_multi_target.cc
+++ b/tests/cpp/test_multi_target.cc
@@ -2,23 +2,23 @@
  * Copyright 2023-2025, XGBoost Contributors
  */
 #include <gtest/gtest.h>
-#include <xgboost/base.h>                         // for Args, bst_target_t
-#include <xgboost/data.h>                         // for DMatrix, MetaInfo
-#include <xgboost/json.h>                         // for Json, get, Object, String
-#include <xgboost/learner.h>                      // for Learner
+#include <xgboost/base.h>     // for Args, bst_target_t
+#include <xgboost/data.h>     // for DMatrix, MetaInfo
+#include <xgboost/json.h>     // for Json, get, Object, String
+#include <xgboost/learner.h>  // for Learner
 
-#include <algorithm>                              // for copy
-#include <cstddef>                                // for size_t
-#include <memory>                                 // for shared_ptr, allocator, __shared_ptr_access
-#include <numeric>                                // for accumulate
-#include <string>                                 // for stod, string
-#include <vector>                                 // for vector
+#include <algorithm>  // for copy
+#include <cstddef>    // for size_t
+#include <memory>     // for shared_ptr, allocator, __shared_ptr_access
+#include <numeric>    // for accumulate
+#include <string>     // for stod, string
+#include <vector>     // for vector
 
-#include "../../src/common/linalg_op.h"           // for begin, cbegin, cend
-#include "../../src/common/stats.h"               // for Median
-#include "helpers.h"                              // for RandomDataGenerator
-#include "xgboost/host_device_vector.h"           // for HostDeviceVector
-#include "xgboost/linalg.h"                       // for Tensor, All, TensorView, Vector
+#include "../../src/common/linalg_op.h"  // for begin, cbegin, cend
+#include "../../src/common/stats.h"      // for Median
+#include "helpers.h"                     // for RandomDataGenerator
+#include "xgboost/host_device_vector.h"  // for HostDeviceVector
+#include "xgboost/linalg.h"              // for Tensor, All, TensorView, Vector
 
 namespace xgboost {
 class TestL1MultiTarget : public ::testing::Test {
@@ -77,7 +77,7 @@ class TestL1MultiTarget : public ::testing::Test {
     for (auto i = 0; i < 4; ++i) {
       learner->UpdateOneIter(i, p_fmat);
     }
-    ASSERT_EQ(learner->Groups(), 3);
+    ASSERT_EQ(learner->NumTargets(), 3);
 
     Json config{Object{}};
     learner->SaveConfig(&config);
@@ -138,7 +138,7 @@ TEST(MultiStrategy, Configure) {
   std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
   learner->SetParams(Args{{"multi_strategy", "multi_output_tree"}, {"num_target", "2"}});
   learner->Configure();
-  ASSERT_EQ(learner->Groups(), 2);
+  ASSERT_EQ(learner->NumTargets(), 2);
 
   learner->SetParams(Args{{"multi_strategy", "multi_output_tree"}, {"num_target", "0"}});
   ASSERT_THROW({ learner->Configure(); }, dmlc::Error);

--- a/tests/cpp/tree/test_tree_stat.cc
+++ b/tests/cpp/tree/test_tree_stat.cc
@@ -374,7 +374,7 @@ class TestMinSplitLoss : public ::testing::Test {
               {"gamma", std::to_string(gamma)}};
 
     RegTree tree{static_cast<bst_target_t>(this->gpair_.gpair.Shape(1)),
-                 static_cast<bst_target_t>(this->p_fmat_->Info().num_col_)};
+                 static_cast<bst_feature_t>(this->p_fmat_->Info().num_col_)};
 
     BuildTree(ctx, p_fmat_.get(), &gpair_, updater, args, &tree);
     auto n_nodes = tree.NumExtraNodes();
@@ -446,7 +446,7 @@ class TestRegularization : public ::testing::Test {
     auto gpairs = GenerateRandomGradients(ctx, n_samples, n_targets);
 
     RegTree tree_0{static_cast<bst_target_t>(gpairs.gpair.Shape(1)),
-                   static_cast<bst_target_t>(p_fmat->Info().num_col_)};
+                   static_cast<bst_feature_t>(p_fmat->Info().num_col_)};
     BuildTree(ctx, p_fmat.get(), &gpairs, updater, Args{{p, "0.0"}}, &tree_0);
     // not exact, just checking the tree can be built
     if (n_targets > 1) {
@@ -456,7 +456,7 @@ class TestRegularization : public ::testing::Test {
     }
 
     RegTree tree_1{static_cast<bst_target_t>(gpairs.gpair.Shape(1)),
-                   static_cast<bst_target_t>(p_fmat->Info().num_col_)};
+                   static_cast<bst_feature_t>(p_fmat->Info().num_col_)};
     BuildTree(ctx, p_fmat.get(), &gpairs, updater, Args{{p, "1024.0"}}, &tree_1);
     ASSERT_EQ(tree_1.NumNodes(), 1);
   }
@@ -552,7 +552,7 @@ class TestMaxDeltaStep : public ::testing::Test {
     auto gpairs = GenerateRandomGradients(ctx, n_samples, n_targets);
 
     RegTree tree_0{static_cast<bst_target_t>(gpairs.gpair.Shape(1)),
-                   static_cast<bst_target_t>(p_fmat->Info().num_col_)};
+                   static_cast<bst_feature_t>(p_fmat->Info().num_col_)};
     BuildTree(ctx, p_fmat.get(), &gpairs, updater, Args{{"max_delta_step", std::to_string(0.5)}},
               &tree_0);
     ASSERT_EQ(tree_0.NumNodes(), 1);


### PR DESCRIPTION
After the multi-output implementation, we have concepts for groups and targets, the group was derived from the `num_class` parameter. In this PR, we unify them under the `n_targets` name.

In addition, due to historical reasons, the `bst_group_t` is misused as a target index. This PR uses `bst_target_t` consistently.