### PR TITLE
Cleanup the expand entry.

### DIFF
--- a/plugin/sycl/tree/expand_entry.h
+++ b/plugin/sycl/tree/expand_entry.h
@@ -16,7 +16,7 @@ namespace sycl {
 namespace tree {
 /* tree growing policies */
 struct ExpandEntry : public xgboost::tree::ExpandEntryImpl<ExpandEntry> {
-  static constexpr bst_node_t kRootNid  = 0;
+  static constexpr bst_node_t kRootNid = 0;
 
   xgboost::tree::SplitEntry split;
 

--- a/plugin/sycl/tree/expand_entry.h
+++ b/plugin/sycl/tree/expand_entry.h
@@ -31,15 +31,6 @@ struct ExpandEntry : public xgboost::tree::ExpandEntryImpl<ExpandEntry> {
   bst_node_t GetSiblingId(::xgboost::tree::ScalarTreeView const& tree, size_t parent_id) const {
     return tree.IsLeftChild(nid) ? tree.RightChild(parent_id) : tree.LeftChild(parent_id);
   }
-
-  bool IsValidImpl(xgboost::tree::TrainParam const &param, int32_t num_leaves) const {
-    if (split.loss_chg <= kRtEps) return false;
-    if (split.loss_chg < param.min_split_loss) return false;
-    if (param.max_depth > 0 && depth == param.max_depth) return false;
-    if (param.max_leaves > 0 && num_leaves == param.max_leaves) return false;
-
-    return true;
-  }
 };
 
 }  // namespace tree

--- a/plugin/sycl/tree/hist_updater.cc
+++ b/plugin/sycl/tree/hist_updater.cc
@@ -10,6 +10,7 @@
 
 #include "../../src/collective/allreduce.h"
 #include "../../src/tree/common_row_partitioner.h"
+#include "../../src/tree/driver.h"
 #include "../common/hist_util.h"
 #include "xgboost/linalg.h"
 
@@ -260,7 +261,7 @@ void HistUpdater<GradientSumT>::ExpandWithLossGuide(const common::GHistIndexMatr
     const ExpandEntry candidate = qexpand_loss_guided_->top();
     const int nid = candidate.nid;
     qexpand_loss_guided_->pop();
-    if (!candidate.IsValid(param_, num_leaves)) {
+    if (!::xgboost::tree::IsValidExpandEntry(candidate, param_, num_leaves)) {
       (*p_tree)[nid].SetLeaf(snode_host_[nid].weight * lr);
     } else {
       auto evaluator = tree_evaluator_.GetEvaluator();

--- a/src/tree/driver.h
+++ b/src/tree/driver.h
@@ -1,23 +1,25 @@
-/*!
- * Copyright 2021 by XGBoost Contributors
+/**
+ * Copyright 2021-2026, XGBoost Contributors
  */
-#ifndef XGBOOST_TREE_DRIVER_H_
-#define XGBOOST_TREE_DRIVER_H_
+#pragma once
+
 #include <xgboost/span.h>
-#include <queue>
-#include <vector>
-#include "./param.h"
 
-namespace xgboost {
-namespace tree {
+#include <cstddef>     // for size_t
+#include <functional>  // for function
+#include <queue>       // for priority_queue
+#include <vector>      // for vector
 
+#include "./param.h"  // for TrainParam
+
+namespace xgboost::tree {
 template <typename ExpandEntryT>
-inline bool DepthWise(const ExpandEntryT& lhs, const ExpandEntryT& rhs) {
+bool DepthWise(const ExpandEntryT& lhs, const ExpandEntryT& rhs) {
   return lhs.GetNodeId() > rhs.GetNodeId();  // favor small depth
 }
 
 template <typename ExpandEntryT>
-inline bool LossGuide(const ExpandEntryT& lhs, const ExpandEntryT& rhs) {
+bool LossGuide(const ExpandEntryT& lhs, const ExpandEntryT& rhs) {
   if (lhs.GetLossChange() == rhs.GetLossChange()) {
     return lhs.GetNodeId() > rhs.GetNodeId();  // favor small timestamp
   } else {
@@ -47,9 +49,8 @@ template <typename ExpandEntryT>
 // Drives execution of tree building on device
 template <typename ExpandEntryT>
 class Driver {
-  using ExpandQueue =
-      std::priority_queue<ExpandEntryT, std::vector<ExpandEntryT>,
-                          std::function<bool(ExpandEntryT, ExpandEntryT)>>;
+  using ExpandQueue = std::priority_queue<ExpandEntryT, std::vector<ExpandEntryT>,
+                                          std::function<bool(ExpandEntryT, ExpandEntryT)>>;
 
  public:
   explicit Driver(TrainParam param, std::size_t max_node_batch_size = 256)
@@ -66,14 +67,12 @@ class Driver {
       }
     }
   }
-  void Push(const std::vector<ExpandEntryT> &entries) {
+  void Push(const std::vector<ExpandEntryT>& entries) {
     this->Push(entries.begin(), entries.end());
   }
   void Push(ExpandEntryT const& e) { queue_.push(e); }
 
-  bool IsEmpty() {
-    return queue_.empty();
-  }
+  bool IsEmpty() { return queue_.empty(); }
 
   // Can a child of this entry still be expanded?
   // can be used to avoid extra work
@@ -124,7 +123,4 @@ class Driver {
   std::size_t max_node_batch_size_;
   ExpandQueue queue_;
 };
-}  // namespace tree
-}  // namespace xgboost
-
-#endif  // XGBOOST_TREE_DRIVER_H_
+}  // namespace xgboost::tree

--- a/src/tree/driver.h
+++ b/src/tree/driver.h
@@ -25,6 +25,25 @@ inline bool LossGuide(const ExpandEntryT& lhs, const ExpandEntryT& rhs) {
   }
 }
 
+template <typename ExpandEntryT>
+[[nodiscard]] bool IsValidExpandEntry(ExpandEntryT const& entry, TrainParam const& param,
+                                      bst_node_t num_leaves) {
+  auto loss_chg = entry.GetLossChange();
+  if (loss_chg <= kRtEps) {
+    return false;
+  }
+  if (loss_chg < param.min_split_loss) {
+    return false;
+  }
+  if (param.max_depth > 0 && entry.depth == param.max_depth) {
+    return false;
+  }
+  if (param.max_leaves > 0 && num_leaves == param.max_leaves) {
+    return false;
+  }
+  return true;
+}
+
 // Drives execution of tree building on device
 template <typename ExpandEntryT>
 class Driver {
@@ -42,7 +61,7 @@ class Driver {
   void Push(EntryIterT begin, EntryIterT end) {
     for (auto it = begin; it != end; ++it) {
       const ExpandEntryT& e = *it;
-      if (e.split.loss_chg > kRtEps) {
+      if (e.GetLossChange() > kRtEps) {
         queue_.push(e);
       }
     }
@@ -74,7 +93,7 @@ class Driver {
       ExpandEntryT e = queue_.top();
       queue_.pop();
 
-      if (e.IsValid(param_, num_leaves_)) {
+      if (IsValidExpandEntry(e, param_, num_leaves_)) {
         num_leaves_++;
         return {e};
       } else {
@@ -87,7 +106,7 @@ class Driver {
     int level = e.depth;
     while (e.depth == level && !queue_.empty() && result.size() < max_node_batch_size_) {
       queue_.pop();
-      if (e.IsValid(param_, num_leaves_)) {
+      if (IsValidExpandEntry(e, param_, num_leaves_)) {
         num_leaves_++;
         result.emplace_back(e);
       }

--- a/src/tree/gpu_hist/expand_entry.cuh
+++ b/src/tree/gpu_hist/expand_entry.cuh
@@ -7,7 +7,6 @@
 #include <limits>   // for numeric_limits
 #include <utility>  // for move
 
-#include "../param.h"                 // for TrainParam
 #include "../updater_gpu_common.cuh"  // for DeviceSplitCandidate
 #include "xgboost/base.h"             // for bst_node_t
 
@@ -30,24 +29,6 @@ struct GPUExpandEntry {
         base_weight{base},
         left_weight{left},
         right_weight{right} {}
-  [[nodiscard]] bool IsValid(TrainParam const& param, bst_node_t num_leaves) const {
-    if (split.loss_chg <= kRtEps) {
-      return false;
-    }
-    if (split.left_sum.GetQuantisedHess() == 0 || split.right_sum.GetQuantisedHess() == 0) {
-      return false;
-    }
-    if (split.loss_chg < param.min_split_loss) {
-      return false;
-    }
-    if (param.max_depth > 0 && depth == param.max_depth) {
-      return false;
-    }
-    if (param.max_leaves > 0 && num_leaves == param.max_leaves) {
-      return false;
-    }
-    return true;
-  }
 
   [[nodiscard]] float GetLossChange() const { return split.loss_chg; }
 
@@ -84,27 +65,6 @@ struct MultiExpandEntry {
   [[nodiscard]] bst_node_t GetNodeId() const { return nidx; }
 
   [[nodiscard]] bst_node_t GetDepth() const { return depth; }
-
-  [[nodiscard]] bool IsValid(TrainParam const& param, bst_node_t n_leaves) const {
-    // The split evaluator handles the zero Hessian case. It returns an expand entry with
-    // -inf loss_chg if the Hessian is invalid.
-    if (split.loss_chg <= kRtEps) {
-      return false;
-    }
-    if (base_weight.empty()) {
-      return false;
-    }
-    if (split.loss_chg < param.min_split_loss) {
-      return false;
-    }
-    if (param.max_depth > 0 && depth == param.max_depth) {
-      return false;
-    }
-    if (param.max_leaves > 0 && n_leaves == param.max_leaves) {
-      return false;
-    }
-    return true;
-  }
 
   /**
    * @brief Update hessian statistics.

--- a/src/tree/gpu_hist/expand_entry.cuh
+++ b/src/tree/gpu_hist/expand_entry.cuh
@@ -34,8 +34,6 @@ struct GPUExpandEntry {
 
   [[nodiscard]] bst_node_t GetNodeId() const { return nidx; }
 
-  [[nodiscard]] bst_node_t GetDepth() const { return depth; }
-
   friend std::ostream& operator<<(std::ostream& os, const GPUExpandEntry& e) {
     os << "GPUExpandEntry: \n";
     os << "nidx: " << e.nidx << "\n";
@@ -63,8 +61,6 @@ struct MultiExpandEntry {
   [[nodiscard]] float GetLossChange() const { return split.loss_chg; }
 
   [[nodiscard]] bst_node_t GetNodeId() const { return nidx; }
-
-  [[nodiscard]] bst_node_t GetDepth() const { return depth; }
 
   /**
    * @brief Update hessian statistics.

--- a/src/tree/gpu_hist/row_partitioner.cuh
+++ b/src/tree/gpu_hist/row_partitioner.cuh
@@ -160,7 +160,7 @@ void SortPositionBatch(Context const* ctx, common::Span<const PerNodeData<OpData
         std::int32_t nidx_in_batch;
         std::size_t item_idx;
         AssignBatch(batch_info_itr, idx, &nidx_in_batch, &item_idx);
-        auto go_left = op(ridx[item_idx], nidx_in_batch, batch_info_itr[nidx_in_batch].data);
+        auto go_left = op(ridx[item_idx], batch_info_itr[nidx_in_batch].data);
         return IndexFlagTuple{static_cast<cuda_impl::RowIndexT>(item_idx), go_left, nidx_in_batch,
                               go_left};
       }));

--- a/src/tree/hist/expand_entry.h
+++ b/src/tree/hist/expand_entry.h
@@ -4,19 +4,16 @@
 #ifndef XGBOOST_TREE_HIST_EXPAND_ENTRY_H_
 #define XGBOOST_TREE_HIST_EXPAND_ENTRY_H_
 
-#include <algorithm>  // for all_of
-#include <ostream>    // for ostream
-#include <string>     // for string
-#include <utility>    // for move
-#include <vector>     // for vector
+#include <ostream>  // for ostream
+#include <utility>  // for move
+#include <vector>   // for vector
 
-#include "../param.h"      // for SplitEntry, SplitEntryContainer, TrainParam
+#include "../param.h"      // for SplitEntry, SplitEntryContainer
 #include "xgboost/base.h"  // for GradientPairPrecise, bst_node_t
-#include "xgboost/json.h"  // for Json
 
 namespace xgboost::tree {
 /**
- * \brief Structure for storing tree split candidate.
+ * @brief Structure for storing tree split candidate.
  */
 template <typename Impl>
 struct ExpandEntryImpl {
@@ -27,10 +24,6 @@ struct ExpandEntryImpl {
     return static_cast<Impl const*>(this)->split.loss_chg;
   }
   [[nodiscard]] bst_node_t GetNodeId() const { return nid; }
-
-  [[nodiscard]] bool IsValid(TrainParam const& param, bst_node_t num_leaves) const {
-    return static_cast<Impl const*>(this)->IsValidImpl(param, num_leaves);
-  }
 };
 
 struct CPUExpandEntry : public ExpandEntryImpl<CPUExpandEntry> {
@@ -40,23 +33,6 @@ struct CPUExpandEntry : public ExpandEntryImpl<CPUExpandEntry> {
   CPUExpandEntry(bst_node_t nidx, bst_node_t depth, SplitEntry split)
       : ExpandEntryImpl{nidx, depth}, split(std::move(split)) {}
   CPUExpandEntry(bst_node_t nidx, bst_node_t depth) : ExpandEntryImpl{nidx, depth} {}
-
-  [[nodiscard]] bool IsValidImpl(TrainParam const& param, bst_node_t num_leaves) const {
-    if (split.loss_chg <= kRtEps) return false;
-    if (split.left_sum.GetHess() == 0 || split.right_sum.GetHess() == 0) {
-      return false;
-    }
-    if (split.loss_chg < param.min_split_loss) {
-      return false;
-    }
-    if (param.max_depth > 0 && depth == param.max_depth) {
-      return false;
-    }
-    if (param.max_leaves > 0 && num_leaves == param.max_leaves) {
-      return false;
-    }
-    return true;
-  }
 
   friend std::ostream& operator<<(std::ostream& os, CPUExpandEntry const& e) {
     os << "ExpandEntry:\n";
@@ -73,27 +49,6 @@ struct MultiExpandEntry : public ExpandEntryImpl<MultiExpandEntry> {
 
   MultiExpandEntry() = default;
   MultiExpandEntry(bst_node_t nidx, bst_node_t depth) : ExpandEntryImpl{nidx, depth} {}
-
-  [[nodiscard]] bool IsValidImpl(TrainParam const& param, bst_node_t num_leaves) const {
-    if (split.loss_chg <= kRtEps) return false;
-    auto is_zero = [](auto const& sum) {
-      return std::all_of(sum.cbegin(), sum.cend(),
-                         [&](auto const& g) { return g.GetHess() - .0 == .0; });
-    };
-    if (is_zero(split.left_sum) || is_zero(split.right_sum)) {
-      return false;
-    }
-    if (split.loss_chg < param.min_split_loss) {
-      return false;
-    }
-    if (param.max_depth > 0 && depth == param.max_depth) {
-      return false;
-    }
-    if (param.max_leaves > 0 && num_leaves == param.max_leaves) {
-      return false;
-    }
-    return true;
-  }
 
   friend std::ostream& operator<<(std::ostream& os, MultiExpandEntry const& e) {
     os << "ExpandEntry: \n";

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -403,59 +403,6 @@ struct SplitEntryContainer {
     return os;
   }
 
-  /**
-   * @brief Copy primitive fields into this, and collect cat_bits into a vector.
-   *
-   * This is used for allgather.
-   *
-   * @param that The other entry to copy from
-   * @param collected_cat_bits The vector to collect cat_bits
-   * @param cat_bits_sizes The sizes of the collected cat_bits
-   */
-  void CopyAndCollect(SplitEntryContainer<GradientT> const &that,
-                      std::vector<uint32_t> *collected_cat_bits,
-                      std::vector<std::size_t> *cat_bits_sizes) {
-    loss_chg = that.loss_chg;
-    sindex = that.sindex;
-    split_value = that.split_value;
-    is_cat = that.is_cat;
-    static_assert(std::is_trivially_copyable_v<GradientT>);
-    left_sum = that.left_sum;
-    right_sum = that.right_sum;
-    collected_cat_bits->insert(collected_cat_bits->end(), that.cat_bits.cbegin(),
-                               that.cat_bits.cend());
-    cat_bits_sizes->emplace_back(that.cat_bits.size());
-  }
-
-  /**
-   * @brief Copy primitive fields into this, and collect cat_bits and gradient sums into vectors.
-   *
-   * This is used for allgather.
-   *
-   * @param that The other entry to copy from
-   * @param collected_cat_bits The vector to collect cat_bits
-   * @param cat_bits_sizes The sizes of the collected cat_bits
-   * @param collected_gradients The vector to collect gradients
-   */
-  template <typename G>
-  void CopyAndCollect(SplitEntryContainer<GradientT> const &that,
-                      std::vector<uint32_t> *collected_cat_bits,
-                      std::vector<std::size_t> *cat_bits_sizes,
-                      std::vector<G> *collected_gradients) {
-    loss_chg = that.loss_chg;
-    sindex = that.sindex;
-    split_value = that.split_value;
-    is_cat = that.is_cat;
-    collected_cat_bits->insert(collected_cat_bits->end(), that.cat_bits.cbegin(),
-                               that.cat_bits.cend());
-    cat_bits_sizes->emplace_back(that.cat_bits.size());
-    static_assert(!std::is_trivially_copyable_v<GradientT>);
-    collected_gradients->insert(collected_gradients->end(), that.left_sum.cbegin(),
-                                that.left_sum.cend());
-    collected_gradients->insert(collected_gradients->end(), that.right_sum.cbegin(),
-                                that.right_sum.cend());
-  }
-
   /*!\return feature index to split on */
   [[nodiscard]] bst_feature_t SplitIndex() const { return sindex & ((1U << 31) - 1U); }
   /*!\return whether missing value goes to left branch */
@@ -486,7 +433,7 @@ struct SplitEntryContainer {
    * \param e candidate split solution
    * \return whether the proposed split is better and can replace current split
    */
-  inline bool Update(const SplitEntryContainer &e) {
+  bool Update(const SplitEntryContainer &e) {
     if (this->NeedReplace(e.loss_chg, e.SplitIndex())) {
       this->loss_chg = e.loss_chg;
       this->sindex = e.sindex;

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -13,7 +13,6 @@
 #include <utility>          // for move
 #include <vector>           // for vector
 
-#include "../../src/collective/comm.h"  // for Op
 #include "../collective/aggregator.h"
 #include "../collective/communicator-inl.h"  // for IsDistributed
 #include "../common/categorical.h"           // for KCatBitField

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -42,8 +42,7 @@ template <typename GoLeftOp>
 struct GoLeftWrapperOp {
   GoLeftOp go_left;
   template <typename NodeSplitData>
-  __device__ bool operator()(RowIndexT ridx, int /*nidx_in_batch*/,
-                             const NodeSplitData& data) const {
+  __device__ bool operator()(RowIndexT ridx, const NodeSplitData& data) const {
     return go_left(ridx, data);
   }
 };

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -5,6 +5,7 @@
 
 #include <cmath>  // for isnan
 
+#include "../../../../src/tree/driver.h"
 #include "../../../../src/tree/gpu_hist/evaluate_splits.cuh"
 #include "../../../../src/tree/gpu_hist/multi_evaluate_splits.cuh"
 #include "../../helpers.h"
@@ -253,7 +254,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   auto no_split = no_split_evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
   ASSERT_TRUE(no_split.split.child_sum.empty());
-  ASSERT_FALSE(no_split.IsValid(no_split_param, 100));
+  ASSERT_FALSE(IsValidExpandEntry(no_split, no_split_param, 100));
   AssertDeviceVecEq(no_split.base_weight, std::vector<float>{2.25f, 1.75f});
   ASSERT_EQ(no_split.left_sum, 8.0);
   ASSERT_EQ(no_split.right_sum, 0.0);

--- a/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
+++ b/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
@@ -37,9 +37,8 @@ void TestUpdatePositionBatch() {
   dh::DeviceUVector<cuda_impl::RowIndexT> ridx_tmp(kNumRows);
   // Send the first five training instances to the right node
   // and the second 5 to the left node
-  rp.UpdatePositionBatch(
-      &ctx, {0}, {1}, {2}, extra_data, dh::ToSpan(ridx_tmp),
-      [=] __device__(RowPartitioner::RowIndexT ridx, int, int) { return ridx > 4; });
+  rp.UpdatePositionBatch(&ctx, {0}, {1}, {2}, extra_data, dh::ToSpan(ridx_tmp),
+                         [=] __device__(RowPartitioner::RowIndexT ridx, int) { return ridx > 4; });
   rows = rp.GetRowsHost(1);
   for (auto r : rows) {
     EXPECT_GT(r, 4);
@@ -50,9 +49,8 @@ void TestUpdatePositionBatch() {
   }
 
   // Split the left node again
-  rp.UpdatePositionBatch(
-      &ctx, {1}, {3}, {4}, extra_data, dh::ToSpan(ridx_tmp),
-      [=] __device__(RowPartitioner::RowIndexT ridx, int, int) { return ridx < 7; });
+  rp.UpdatePositionBatch(&ctx, {1}, {3}, {4}, extra_data, dh::ToSpan(ridx_tmp),
+                         [=] __device__(RowPartitioner::RowIndexT ridx, int) { return ridx < 7; });
   EXPECT_EQ(rp.GetRows(3).size(), 2);
   EXPECT_EQ(rp.GetRows(4).size(), 3);
 }
@@ -65,7 +63,7 @@ void TestSortPositionBatch(const std::vector<int>& ridx_in, const std::vector<Se
   thrust::device_vector<cuda_impl::RowIndexT> ridx_tmp(ridx_in.size());
   thrust::device_vector<cuda_impl::RowIndexT> counts(segments.size());
 
-  auto op = [=] __device__(auto ridx, int split_index, int data) {
+  auto op = [=] __device__(auto ridx, int data) {
     return ridx % 2 == 0;
   };  // NOLINT
   std::vector<int> op_data(segments.size());
@@ -127,8 +125,7 @@ template <typename Accessor>
 struct LessThanOp {
   Accessor acc;
   explicit LessThanOp(Accessor acc) : acc{acc} {}
-  __device__ bool operator()(bst_idx_t ridx, std::int32_t nidx_in_batch,
-                             RegTree::Node const& node) const {
+  __device__ bool operator()(bst_idx_t ridx, RegTree::Node const& node) const {
     auto fvalue = acc.GetFvalue(ridx, node.SplitIndex());
     return fvalue <= node.SplitCond();
   }
@@ -220,9 +217,7 @@ void TestEmptyNode(std::int32_t n_workers) {
     dh::DeviceUVector<cuda_impl::RowIndexT> ridx_tmp(n_samples);
     partitioner.UpdatePositionBatch(
         &ctx, {0}, {1}, {2}, splits, dh::ToSpan(ridx_tmp),
-        [] XGBOOST_DEVICE(bst_idx_t ridx, std::int32_t /*nidx_in_batch*/, RegTree::Node) {
-          return ridx < 3;
-        });
+        [] XGBOOST_DEVICE(bst_idx_t ridx, RegTree::Node) { return ridx < 3; });
     ASSERT_EQ(partitioner.GetNumNodes(), 3);
     if (collective::GetRank() == 0) {
       for (std::size_t i = 0; i < 3; ++i) {


### PR DESCRIPTION
We can now unify the expand entry checks after unifying the evaluator.