### PR TITLE
Fix a few comment/docstring typos

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -176,7 +176,7 @@ def build_info() -> dict:
     """Build information of XGBoost.  The returned value format is not stable. Also,
     please note that build time dependency is not the same as runtime dependency. For
     instance, it's possible to build XGBoost with older CUDA version but run it with the
-    lastest one.
+    latest one.
 
       .. versionadded:: 1.6.0
 
@@ -431,7 +431,7 @@ class DataIter(ABC):  # pylint: disable=too-many-instance-attributes
             #
             # To construct the QDM, one needs 4 iterations on CPU, or 2 iterations on
             # GPU. If the QDM has only one batch of input (most of the cases), we can
-            # avoid transforming the data repeatly.
+            # avoid transforming the data repeatedly.
             try:
                 ref = weakref.ref(data)
             except TypeError:

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -489,7 +489,7 @@ def is_pd_sparse_dtype(dtype: PandasDType) -> bool:
 
 
 def pandas_pa_type(ser: Any) -> np.ndarray:
-    """Handle pandas pyarrow extention."""
+    """Handle pandas pyarrow extension."""
     pd = import_pandas()
 
     if TYPE_CHECKING:


### PR DESCRIPTION
Found with codespell, scoped to comment/docstring-only fixes with no identifier renames (avoided touching variable names like 'splited', 'sconds', 'missings' since those need call-site verification I can't run in this environment):

- xgboost/core.py: 'lastest' -> 'latest' (docstring)
- xgboost/core.py: 'repeatly' -> 'repeatedly' (comment)
- xgboost/data.py: 'extention' -> 'extension' (docstring)

Verified with codespell (no longer flagged) and confirmed mypy/ruff still pass on both files.