### PR TITLE
Fix buffer corruption for non-ASCII pandas categorical names

### DIFF
--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -461,14 +461,21 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
             else:
                 strarr = np.asarray(strarr, dtype=object)
 
-        lenarr = np.vectorize(len)
-        offsets = np.cumsum(
-            np.concatenate([np.array([0], dtype=np.int64), lenarr(strarr)])
-        )
         if strarr.dtype.kind == "S":
             str_list = [s.decode("utf-8") for s in strarr.tolist()]
         else:
             str_list = [str(s) for s in strarr.tolist()]
+
+        # Offsets must be computed in UTF-8 *byte* length, matching the encoded
+        # buffer produced below. Using `len()` (character count) here would
+        # corrupt the offsets -- and the final buffer shape -- for any category
+        # name containing multi-byte UTF-8 characters (e.g. accented letters or
+        # non-Latin scripts), since Python's `str` length counts code points,
+        # not encoded bytes.
+        byte_lenarr = np.array([len(s.encode("utf-8")) for s in str_list], dtype=np.int64)
+        offsets = np.cumsum(
+            np.concatenate([np.array([0], dtype=np.int64), byte_lenarr])
+        )
         values = "".join(str_list)
         if "\0" in values:
             warnings.warn(
@@ -492,7 +499,7 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
     jvalues: ArrayInf = {
         "data": (ptr, True),
         "typestr": "|i1",
-        "shape": (len(name_values),),
+        "shape": (len(bvalues),),
         "strides": None,
         "version": 3,
         "mask": None,

--- a/python-package/xgboost/testing/ordinal.py
+++ b/python-package/xgboost/testing/ordinal.py
@@ -113,6 +113,28 @@ def run_cat_container(device: Device) -> None:
         comp_booster(device, Xy, "gbtree")
         comp_booster(device, Xy, "dart")
 
+        # Regression test: category names containing multi-byte UTF-8
+        # characters used to have their offsets computed using Python `str`
+        # character length instead of UTF-8 byte length, corrupting the
+        # Arrow string buffer for any category name that isn't pure ASCII.
+        utf8_cats = ["café", "naïve", "日本語", "plain", "😀emoji"]
+        df = Df({"c": utf8_cats}, dtype="category")
+        categories = df.c.cat.categories
+
+        Xy = DMatrixT(df, enable_categorical=True)
+        results = Xy.get_categories(export_to_arrow=True).to_arrow()
+        assert results is not None
+        results_di = dict(results)
+        assert len(results_di["c"]) == len(categories)
+        for i in range(len(results_di["c"])):
+            assert str(results_di["c"][i]) == str(categories[i]), (
+                results_di["c"][i],
+                categories[i],
+            )
+
+        comp_booster(device, Xy, "gbtree")
+        comp_booster(device, Xy, "dart")
+
         with pytest.raises(ValueError, match="export_to_arrow"):
             Xy.get_categories(export_to_arrow=False).to_arrow()
 


### PR DESCRIPTION
# Fix buffer corruption for non-ASCII pandas categorical names

## Summary
`pd_cat_inf()` builds an Arrow-style string array (offsets + byte buffer) to
describe a pandas categorical column's category names via the array
interface protocol, for consumption by the C++ core.

The per-string offsets, and the final buffer shape, were computed using
Python `str` **character** length (`len(s)`), while the actual backing
buffer is UTF-8 **encoded bytes** (`name_values.encode("utf-8")`). For any
category name containing multi-byte UTF-8 characters — accented Latin
letters, non-Latin scripts, emoji, etc, which is an entirely ordinary case,
not an edge case — character count and byte count diverge, corrupting both
the per-string slice offsets and the total buffer length advertised in the
array interface.

## Concrete repro
For categories `["café", "naïve", "plain"]`:

```
buggy (char-based)   offsets: [0, 4, 9, 14]
correct (byte-based) offsets: [0, 5, 11, 16]
```

Slicing the actual UTF-8 buffer at the buggy offsets returns garbage that
includes stray continuation bytes and is misaligned with string
boundaries, rather than the intended category name:

```python
>>> bvalues = "caféna\xc3\xafveplain".encode("utf-8")  # illustrative
>>> bvalues[4:9]   # buggy slice for "naïve"
b'\xa9na\xc3\xaf'  # garbage
>>> bvalues[5:11]  # correct slice
b'na\xc3\xafve'    # correct
```

## Change
Compute both the per-string offsets and the final `shape` from the
UTF-8-encoded byte length of each string, matching the buffer that's
actually constructed and read downstream:

```diff
-        lenarr = np.vectorize(len)
-        offsets = np.cumsum(
-            np.concatenate([np.array([0], dtype=np.int64), lenarr(strarr)])
-        )
         if strarr.dtype.kind == "S":
             str_list = [s.decode("utf-8") for s in strarr.tolist()]
         else:
             str_list = [str(s) for s in strarr.tolist()]
+
+        byte_lenarr = np.array([len(s.encode("utf-8")) for s in str_list], dtype=np.int64)
+        offsets = np.cumsum(
+            np.concatenate([np.array([0], dtype=np.int64), byte_lenarr])
+        )
         values = "".join(str_list)
```
```diff
-        "shape": (len(name_values),),
+        "shape": (len(bvalues),),
```

## Verification
I couldn't import `xgboost` directly in my sandbox (needs the compiled C++
core), so I reproduced the exact offset/buffer logic standalone and
verified:

- **Plain ASCII strings** — byte-for-byte identical behavior to before (no
  regression)
- **Non-ASCII strings** (accented Latin, CJK) — offsets now correctly
  round-trip every string; each slice decodes back to the exact original
  category name
- **Bytes-dtype (`"S"`) input array** — still works correctly
- **Existing embedded-NUL warning** — still fires correctly, unaffected
- **Empty-array edge case** — still returns a valid empty result

`mypy` and `ruff` both pass on the modified file.

## Why this matters
This affects any pandas DataFrame with categorical columns whose category
names aren't pure ASCII — a very ordinary scenario (e.g. category labels
in French, German, Japanese, or containing names with accents/emoji) — and
would silently pass corrupted category-name data into the C++ training
core rather than raising an error, which is the more concerning failure
mode.