### PR TITLE
[MT] Apply splits by batches.

### DIFF
--- a/include/xgboost/multi_target_tree_model.h
+++ b/include/xgboost/multi_target_tree_model.h
@@ -20,21 +20,44 @@
 namespace xgboost {
 namespace tree {
 struct MultiTargetTreeView;
-using CatWordT = uint32_t;
+using CatWordT = std::uint32_t;
 
+/** @brief Inputs for expanding multiple leaves in a multi-target tree. */
 struct ExpandBatch {
-  std::vector<float> nidxs;
+  std::vector<bst_node_t> nidxs;
   std::vector<bst_feature_t> fidxs;
   std::vector<float> conds;
-  std::vector<std::int32_t> dft_lefts;
-  std::vector<common::Span<float>> base_weight_batch;
-  std::vector<common::Span<float>> left_weight_batch;
-  std::vector<common::Span<float>> right_weight_batch;
+  std::vector<std::uint8_t> dft_lefts;
+  std::vector<common::Span<float const>> base_weight_batch;
+  std::vector<common::Span<float const>> left_weight_batch;
+  std::vector<common::Span<float const>> right_weight_batch;
   std::vector<float> loss_chgs;
   std::vector<double> left_sums;
   std::vector<double> right_sums;
   std::vector<common::Span<CatWordT const>> cat_bits;
+  DeviceOrd device;
   float eta;
+
+  ExpandBatch(DeviceOrd device, float eta) : device{device}, eta{eta} {}
+
+  [[nodiscard]] std::size_t Size() const { return nidxs.size(); }
+
+  void Push(bst_node_t nidx, bst_feature_t fidx, float cond, bool dft_left,
+            common::Span<float const> base_weight, common::Span<float const> left_weight,
+            common::Span<float const> right_weight, float loss_chg, double left_sum,
+            double right_sum, common::Span<CatWordT const> cats = {}) {
+    nidxs.push_back(nidx);
+    fidxs.push_back(fidx);
+    conds.push_back(cond);
+    dft_lefts.push_back(dft_left);
+    base_weight_batch.emplace_back(base_weight);
+    left_weight_batch.emplace_back(left_weight);
+    right_weight_batch.emplace_back(right_weight);
+    loss_chgs.push_back(loss_chg);
+    left_sums.push_back(left_sum);
+    right_sums.push_back(right_sum);
+    cat_bits.emplace_back(cats);
+  }
 };
 }  // namespace tree
 struct TreeParam;
@@ -84,13 +107,6 @@ class MultiTargetTree : public Model {
     auto v = this->weights_.ConstHostSpan().subspan(beg, this->NumSplitTargets());
     return linalg::MakeTensorView(DeviceOrd::CPU(), v, v.size());
   }
-  // Unlike the const version, `NumSplitTargets` is not reliable if the tree can change.
-  [[nodiscard]] linalg::VectorView<float> NodeWeight(bst_node_t nidx,
-                                                     bst_target_t n_split_targets) {
-    auto beg = nidx * n_split_targets;
-    auto v = this->weights_.HostSpan().subspan(beg, n_split_targets);
-    return linalg::MakeTensorView(DeviceOrd::CPU(), v, v.size());
-  }
   [[nodiscard]] bst_node_t LeafIdx(bst_node_t nidx) const { return this->RightChild(nidx); }
 
  public:
@@ -108,13 +124,12 @@ class MultiTargetTree : public Model {
    */
   void SetRoot(linalg::VectorView<float const> weight, float sum_hess);
   /**
-   * @brief Expand a leaf into split node.
+   * @brief Expand a batch of leaves and apply learning rate to child weights.
+   *
+   * Base weights are stored unchanged. Left and right child weights are multiplied by
+   * `batch.eta`.
    */
-  void Expand(bst_node_t nidx, bst_feature_t split_idx, float split_cond, bool default_left,
-              linalg::VectorView<float const> base_weight,
-              linalg::VectorView<float const> left_weight,
-              linalg::VectorView<float const> right_weight, float loss_chg, float sum_hess,
-              float left_sum, float right_sum);
+  void Expand(tree::ExpandBatch const& batch);
   /** @see RegTree::SetLeaves */
   void SetLeaves(std::vector<bst_node_t> leaves, common::Span<float const> weights);
   /** @brief Copy base weight into leaf weight for a non-reduced multi-target tree. */

--- a/include/xgboost/multi_target_tree_model.h
+++ b/include/xgboost/multi_target_tree_model.h
@@ -47,18 +47,20 @@ struct ExpandBatch {
             common::Span<float const> base_weight, common::Span<float const> left_weight,
             common::Span<float const> right_weight, float loss_chg, double left_sum,
             double right_sum, common::Span<CatWordT const> cats = {}) {
-    nidxs.push_back(nidx);
-    fidxs.push_back(fidx);
-    conds.push_back(cond);
-    dft_lefts.push_back(dft_left);
-    base_weight_batch.emplace_back(base_weight);
-    left_weight_batch.emplace_back(left_weight);
-    right_weight_batch.emplace_back(right_weight);
-    loss_chgs.push_back(loss_chg);
-    left_sums.push_back(left_sum);
-    right_sums.push_back(right_sum);
-    cat_bits.emplace_back(cats);
-    n_cat_words += cats.size();
+    this->nidxs.push_back(nidx);
+    this->fidxs.push_back(fidx);
+    this->conds.push_back(cond);
+    this->dft_lefts.push_back(dft_left);
+    this->base_weight_batch.emplace_back(base_weight);
+    this->left_weight_batch.emplace_back(left_weight);
+    this->right_weight_batch.emplace_back(right_weight);
+    this->loss_chgs.push_back(loss_chg);
+    this->left_sums.push_back(left_sum);
+    this->right_sums.push_back(right_sum);
+    this->cat_bits.emplace_back(cats);
+    this->n_cat_words += cats.size();
+    CHECK_EQ(left_weight.size(), base_weight.size());
+    CHECK_EQ(right_weight.size(), base_weight.size());
   }
 };
 }  // namespace tree

--- a/include/xgboost/multi_target_tree_model.h
+++ b/include/xgboost/multi_target_tree_model.h
@@ -20,7 +20,23 @@
 namespace xgboost {
 namespace tree {
 struct MultiTargetTreeView;
-}
+using CatWordT = uint32_t;
+
+struct ExpandBatch {
+  std::vector<float> nidxs;
+  std::vector<bst_feature_t> fidxs;
+  std::vector<float> conds;
+  std::vector<std::int32_t> dft_lefts;
+  std::vector<common::Span<float>> base_weight_batch;
+  std::vector<common::Span<float>> left_weight_batch;
+  std::vector<common::Span<float>> right_weight_batch;
+  std::vector<float> loss_chgs;
+  std::vector<double> left_sums;
+  std::vector<double> right_sums;
+  std::vector<common::Span<CatWordT const>> cat_bits;
+  float eta;
+};
+}  // namespace tree
 struct TreeParam;
 
 /**

--- a/include/xgboost/multi_target_tree_model.h
+++ b/include/xgboost/multi_target_tree_model.h
@@ -35,10 +35,11 @@ struct ExpandBatch {
   std::vector<double> left_sums;
   std::vector<double> right_sums;
   std::vector<common::Span<CatWordT const>> cat_bits;
-  DeviceOrd device;
+  // Total number of CatWordT storage elements in cat_bits.
+  std::size_t n_cat_words{0};
   float eta;
 
-  ExpandBatch(DeviceOrd device, float eta) : device{device}, eta{eta} {}
+  explicit ExpandBatch(float eta) : eta{eta} {}
 
   [[nodiscard]] std::size_t Size() const { return nidxs.size(); }
 
@@ -57,6 +58,7 @@ struct ExpandBatch {
     left_sums.push_back(left_sum);
     right_sums.push_back(right_sum);
     cat_bits.emplace_back(cats);
+    n_cat_words += cats.size();
   }
 };
 }  // namespace tree
@@ -129,7 +131,7 @@ class MultiTargetTree : public Model {
    * Base weights are stored unchanged. Left and right child weights are multiplied by
    * `batch.eta`.
    */
-  void Expand(tree::ExpandBatch const& batch);
+  void Expand(Context const* ctx, tree::ExpandBatch const& batch);
   /** @see RegTree::SetLeaves */
   void SetLeaves(std::vector<bst_node_t> leaves, common::Span<float const> weights);
   /** @brief Copy base weight into leaf weight for a non-reduced multi-target tree. */

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -306,7 +306,7 @@ class RegTree : public Model {
    *
    * A non-empty category span marks a categorical split; an empty span marks a numerical split.
    */
-  void Expand(tree::ExpandBatch const& batch);
+  void Expand(Context const* ctx, tree::ExpandBatch const& batch);
   /**
    * @brief Set all leaf weights for a multi-target tree.
    *

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -302,22 +302,15 @@ class RegTree : public Model {
                   bst_float loss_change, float sum_hess, float left_sum, float right_sum,
                   bst_node_t leaf_right_child = kInvalidNodeId);
   /**
-   * @brief Expands a leaf node into two additional leaf nodes for a multi-target tree.
+   * @brief Expand multiple leaves in a multi-target tree.
    *
-   * @param gain      The gain (loss change) from this split.
-   * @param sum_hess  The sum of hessians for the parent node (coverage).
-   * @param left_sum  The sum of hessians for the left child (coverage).
-   * @param right_sum The sum of hessians for the right child (coverage).
+   * A non-empty category span marks a categorical split; an empty span marks a numerical split.
    */
-  void ExpandNode(bst_node_t nidx, bst_feature_t split_index, float split_cond, bool default_left,
-                  linalg::VectorView<float const> base_weight,
-                  linalg::VectorView<float const> left_weight,
-                  linalg::VectorView<float const> right_weight, float loss_chg, float sum_hess,
-                  float left_sum, float right_sum);
+  void Expand(tree::ExpandBatch const& batch);
   /**
    * @brief Set all leaf weights for a multi-target tree.
    *
-   * The leaf weight can be different from the internal weight stored by @ref ExpandNode
+   * The leaf weight can be different from the internal weight stored by @ref Expand.
    * This function is used to set the leaf at the end of tree construction.
    *
    * @param leaves  The node indices for all leaves. This must contain all the leaves in this tree.
@@ -346,15 +339,6 @@ class RegTree : public Model {
                          bst_float base_weight, bst_float left_leaf_weight,
                          bst_float right_leaf_weight, bst_float loss_change, float sum_hess,
                          float left_sum, float right_sum);
-  /**
-   * @brief Expands a leaf node with categories for a multi-target tree.
-   */
-  void ExpandCategorical(bst_node_t nidx, bst_feature_t split_index,
-                         common::Span<tree::CatWordT const> split_cat, bool default_left,
-                         linalg::VectorView<float const> base_weight,
-                         linalg::VectorView<float const> left_weight,
-                         linalg::VectorView<float const> right_weight, float loss_chg,
-                         float sum_hess, float left_sum, float right_sum);
   /**
    * @brief Whether this tree has categorical split.
    */

--- a/include/xgboost/tree_model.h
+++ b/include/xgboost/tree_model.h
@@ -25,7 +25,6 @@
 #include <vector>
 
 namespace xgboost {
-
 namespace tree {
 struct ScalarTreeView;
 struct MultiTargetTreeView;
@@ -343,7 +342,7 @@ class RegTree : public Model {
    * \param right_sum         The sum hess of right leaf.
    */
   void ExpandCategorical(bst_node_t nid, bst_feature_t split_index,
-                         common::Span<const uint32_t> split_cat, bool default_left,
+                         common::Span<tree::CatWordT const> split_cat, bool default_left,
                          bst_float base_weight, bst_float left_leaf_weight,
                          bst_float right_leaf_weight, bst_float loss_change, float sum_hess,
                          float left_sum, float right_sum);
@@ -351,7 +350,7 @@ class RegTree : public Model {
    * @brief Expands a leaf node with categories for a multi-target tree.
    */
   void ExpandCategorical(bst_node_t nidx, bst_feature_t split_index,
-                         common::Span<const uint32_t> split_cat, bool default_left,
+                         common::Span<tree::CatWordT const> split_cat, bool default_left,
                          linalg::VectorView<float const> base_weight,
                          linalg::VectorView<float const> left_weight,
                          linalg::VectorView<float const> right_weight, float loss_chg,

--- a/plugin/sycl/tree/expand_entry.h
+++ b/plugin/sycl/tree/expand_entry.h
@@ -16,7 +16,7 @@ namespace sycl {
 namespace tree {
 /* tree growing policies */
 struct ExpandEntry : public xgboost::tree::ExpandEntryImpl<ExpandEntry> {
-  static constexpr bst_node_t kRootNid  = 0;
+  static constexpr bst_node_t kRootNid = 0;
 
   xgboost::tree::SplitEntry split;
 

--- a/plugin/sycl/tree/expand_entry.h
+++ b/plugin/sycl/tree/expand_entry.h
@@ -31,15 +31,6 @@ struct ExpandEntry : public xgboost::tree::ExpandEntryImpl<ExpandEntry> {
   bst_node_t GetSiblingId(::xgboost::tree::ScalarTreeView const& tree, size_t parent_id) const {
     return tree.IsLeftChild(nid) ? tree.RightChild(parent_id) : tree.LeftChild(parent_id);
   }
-
-  bool IsValidImpl(xgboost::tree::TrainParam const &param, int32_t num_leaves) const {
-    if (split.loss_chg <= kRtEps) return false;
-    if (split.loss_chg < param.min_split_loss) return false;
-    if (param.max_depth > 0 && depth == param.max_depth) return false;
-    if (param.max_leaves > 0 && num_leaves == param.max_leaves) return false;
-
-    return true;
-  }
 };
 
 }  // namespace tree

--- a/plugin/sycl/tree/hist_updater.cc
+++ b/plugin/sycl/tree/hist_updater.cc
@@ -10,6 +10,7 @@
 
 #include "../../src/collective/allreduce.h"
 #include "../../src/tree/common_row_partitioner.h"
+#include "../../src/tree/driver.h"
 #include "../common/hist_util.h"
 #include "xgboost/linalg.h"
 
@@ -260,7 +261,7 @@ void HistUpdater<GradientSumT>::ExpandWithLossGuide(const common::GHistIndexMatr
     const ExpandEntry candidate = qexpand_loss_guided_->top();
     const int nid = candidate.nid;
     qexpand_loss_guided_->pop();
-    if (!candidate.IsValid(param_, num_leaves)) {
+    if (!::xgboost::tree::IsValidExpandEntry(candidate, param_, num_leaves)) {
       (*p_tree)[nid].SetLeaf(snode_host_[nid].weight * lr);
     } else {
       auto evaluator = tree_evaluator_.GetEvaluator();

--- a/src/common/categorical.h
+++ b/src/common/categorical.h
@@ -1,9 +1,7 @@
 /**
- * Copyright 2020-2024, XGBoost Contributors
- * \file categorical.h
+ * Copyright 2020-2026, XGBoost Contributors
  */
-#ifndef XGBOOST_COMMON_CATEGORICAL_H_
-#define XGBOOST_COMMON_CATEGORICAL_H_
+#pragma once
 
 #include "bitfield.h"
 #include "xgboost/base.h"
@@ -97,6 +95,6 @@ inline auto GetNodeCats(common::Span<CatBitField::value_type const> categories,
   KCatBitField node_cats{categories.subspan(seg.beg, seg.size)};
   return node_cats;
 }
-}  // namespace xgboost::common
 
-#endif  // XGBOOST_COMMON_CATEGORICAL_H_
+static_assert(std::is_same_v<CatBitField::value_type, tree::CatWordT>);
+}  // namespace xgboost::common

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -20,6 +20,7 @@
 #include <cuda/std/iterator>  // for iterator_traits
 #include <cuda/std/utility>   // for pair
 #include <functional>         // for equal_to
+#include <limits>             // for numeric_limits
 #include <variant>            // for variant, visit
 #include <vector>             // for vector
 
@@ -735,8 +736,9 @@ template <cudaMemcpyKind kind, typename T, typename U>
                                            std::size_t count, std::size_t *fail_idx,
                                            cudaStream_t stream) {
 #if CUDART_VERSION >= 12080
-  static_assert(kind == cudaMemcpyDeviceToHost || kind == cudaMemcpyHostToDevice,
-                "Not implemented.");
+  static_assert(kind == cudaMemcpyDeviceToHost || kind == cudaMemcpyHostToDevice ||
+                    kind == cudaMemcpyDeviceToDevice,
+                "Unsupported copy direction.");
   cudaMemcpyAttributes attr;
   attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
   attr.flags = cudaMemcpyFlagPreferOverlapWithCompute;
@@ -752,15 +754,32 @@ template <cudaMemcpyKind kind, typename T, typename U>
   if constexpr (kind == cudaMemcpyDeviceToHost) {
     assign_device(&attr.srcLocHint);
     assign_host(&attr.dstLocHint);
-  } else {
+  } else if constexpr (kind == cudaMemcpyHostToDevice) {
     assign_host(&attr.srcLocHint);
     assign_device(&attr.dstLocHint);
+  } else {
+    assign_device(&attr.srcLocHint);
+    assign_device(&attr.dstLocHint);
   }
+#if CUDART_VERSION >= 13000
+  // CUDA 13 no longer exposes the per-copy failure index in this overload.
+  *fail_idx = std::numeric_limits<std::size_t>::max();
+  return cudaMemcpyBatchAsync(dsts, srcs, const_cast<std::size_t *>(sizes), count, attr, stream);
+#else
   return cudaMemcpyBatchAsync(dsts, srcs, const_cast<std::size_t *>(sizes), count, attr, fail_idx,
                               stream);
+#endif  // CUDART_VERSION >= 13000
 #else
-  LOG(FATAL) << "CUDA >= 12.8 is required.";
-  return cudaErrorInvalidValue;
+  // Keep callers compatible with CUDA toolkits predating the native batch API.
+  for (std::size_t i = 0; i < count; ++i) {
+    auto status = cudaMemcpyAsync(dsts[i], srcs[i], sizes[i], kind, stream);
+    if (status != cudaSuccess) {
+      *fail_idx = i;
+      return status;
+    }
+  }
+  *fail_idx = std::numeric_limits<std::size_t>::max();
+  return cudaSuccess;
 #endif  // CUDART_VERSION >= 12080
 }
 

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -711,14 +711,13 @@ void CopyTo(Src const &src, Dst *dst,
 }
 
 /**
- * @brief Wrapper for the @ref cudaMemcpyBatchAsync .
+ * @brief Thin wrapper of the @ref cudaMemcpyBatchAsync .
  *
  * @param dsts Host pointer to a list of device pointers.
  * @param srcs Host pointer to a list of device pointers.
  * @param sizes Host pointer to a list of sizes.
  * @param count How many batches.
- * @param fail_idx Which batch has failed, if any. When it's assigned to SIZE_MAX, then
- *   it's a general error.
+ * @param fail_idx Which batch has failed, if any. This is always SIZE_MAX in CUDA 13.
  * @param stream CUDA stream. The wrapper enforces stream order access.
  */
 template <cudaMemcpyKind kind, typename T, typename U>

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -764,7 +764,7 @@ template <cudaMemcpyKind kind, typename T, typename U>
 #if CUDART_VERSION >= 13000
   // CUDA 13 no longer exposes the per-copy failure index in this overload.
   *fail_idx = std::numeric_limits<std::size_t>::max();
-  return cudaMemcpyBatchAsync(dsts, srcs, const_cast<std::size_t *>(sizes), count, attr, stream);
+  return cudaMemcpyBatchAsync(dsts, srcs, sizes, count, attr, stream);
 #else
   return cudaMemcpyBatchAsync(dsts, srcs, const_cast<std::size_t *>(sizes), count, attr, fail_idx,
                               stream);

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -35,10 +35,9 @@
 #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 600 || defined(__clang__)
 
 #else  // In device code and CUDA < 600
-__device__ __forceinline__ double atomicAdd(double* address, double val) {  // NOLINT
-  unsigned long long int* address_as_ull =
-      (unsigned long long int*)address;                   // NOLINT
-  unsigned long long int old = *address_as_ull, assumed;  // NOLINT
+__device__ __forceinline__ double atomicAdd(double *address, double val) {     // NOLINT
+  unsigned long long int *address_as_ull = (unsigned long long int *)address;  // NOLINT
+  unsigned long long int old = *address_as_ull, assumed;                       // NOLINT
 
   do {
     assumed = old;
@@ -61,7 +60,7 @@ constexpr bool BuildWithCUDACub() {
   return false;
 #else
   return true;
-#endif // defined(THRUST_IGNORE_CUB_VERSION_CHECK) && THRUST_IGNORE_CUB_VERSION_CHECK == 1
+#endif  // defined(THRUST_IGNORE_CUB_VERSION_CHECK) && THRUST_IGNORE_CUB_VERSION_CHECK == 1
 }
 
 namespace detail {
@@ -84,9 +83,9 @@ struct AtomicDispatcher<sizeof(uint64_t)> {
 
 // atomicAdd is not defined for size_t.
 template <typename T = size_t,
-          std::enable_if_t<std::is_same_v<size_t, T> &&
-                           !std::is_same_v<size_t, unsigned long long>> * =  // NOLINT
-              nullptr>
+          std::enable_if_t<std::is_same_v<size_t, T> && !std::is_same_v<size_t, unsigned long long>>
+              * =  // NOLINT
+          nullptr>
 XGBOOST_DEV_INLINE T atomicAdd(T *addr, T v) {  // NOLINT
   using Type = typename dh::detail::AtomicDispatcher<sizeof(T)>::Type;
   Type ret = ::atomicAdd(reinterpret_cast<Type *>(addr), static_cast<Type>(v));
@@ -121,7 +120,8 @@ inline int32_t CurrentDevice() {
 
 // Helper function to get a device from a potentially CPU context.
 inline auto GetDevice(xgboost::Context const *ctx) {
-  auto d = (ctx->IsCUDA()) ? ctx->Device() : xgboost::DeviceOrd::CUDA(::xgboost::curt::CurrentDevice());
+  auto d =
+      (ctx->IsCUDA()) ? ctx->Device() : xgboost::DeviceOrd::CUDA(::xgboost::curt::CurrentDevice());
   CHECK(!d.IsCPU());
   return d;
 }
@@ -136,9 +136,8 @@ inline auto GetDevice(xgboost::Context const *ctx) {
 
 inline size_t MaxSharedMemory(int device_idx) {
   int max_shared_memory = 0;
-  dh::safe_cuda(cudaDeviceGetAttribute
-                (&max_shared_memory, cudaDevAttrMaxSharedMemoryPerBlock,
-                 device_idx));
+  dh::safe_cuda(
+      cudaDeviceGetAttribute(&max_shared_memory, cudaDevAttrMaxSharedMemoryPerBlock, device_idx));
   return static_cast<std::size_t>(max_shared_memory);
 }
 
@@ -153,17 +152,15 @@ inline size_t MaxSharedMemory(int device_idx) {
 
 inline size_t MaxSharedMemoryOptin(int device_idx) {
   int max_shared_memory = 0;
-  dh::safe_cuda(cudaDeviceGetAttribute
-                (&max_shared_memory, cudaDevAttrMaxSharedMemoryPerBlockOptin,
-                 device_idx));
+  dh::safe_cuda(cudaDeviceGetAttribute(&max_shared_memory, cudaDevAttrMaxSharedMemoryPerBlockOptin,
+                                       device_idx));
   return static_cast<std::size_t>(max_shared_memory);
 }
 
-XGBOOST_DEV_INLINE void AtomicOrByte(unsigned int *__restrict__ buffer,
-                                     size_t ibyte, unsigned char b) {
-  atomicOr(&buffer[ibyte / sizeof(unsigned int)],
-           static_cast<unsigned int>(b)
-               << (ibyte % (sizeof(unsigned int)) * 8));
+XGBOOST_DEV_INLINE void AtomicOrByte(unsigned int *__restrict__ buffer, size_t ibyte,
+                                     unsigned char b) {
+  atomicOr(&buffer[ibyte / sizeof(unsigned int)], static_cast<unsigned int>(b)
+                                                      << (ibyte % (sizeof(unsigned int)) * 8));
 }
 
 template <typename T>
@@ -217,10 +214,10 @@ class LaunchKernel {
   cudaStream_t stream_;
 
  public:
-  LaunchKernel(uint32_t _grids, uint32_t _blk, size_t _shmem=0, cudaStream_t _s=nullptr) :
-      grids_{_grids, 1, 1}, blocks_{_blk, 1, 1}, shmem_size_{_shmem}, stream_{_s} {}
-  LaunchKernel(dim3 _grids, dim3 _blk, size_t _shmem=0, cudaStream_t _s=nullptr) :
-      grids_{_grids}, blocks_{_blk}, shmem_size_{_shmem}, stream_{_s} {}
+  LaunchKernel(uint32_t _grids, uint32_t _blk, size_t _shmem = 0, cudaStream_t _s = nullptr)
+      : grids_{_grids, 1, 1}, blocks_{_blk, 1, 1}, shmem_size_{_shmem}, stream_{_s} {}
+  LaunchKernel(dim3 _grids, dim3 _blk, size_t _shmem = 0, cudaStream_t _s = nullptr)
+      : grids_{_grids}, blocks_{_blk}, shmem_size_{_shmem}, stream_{_s} {}
 
   template <typename K, typename... Args>
   void operator()(K kernel, Args... args) {
@@ -275,7 +272,7 @@ class TemporaryArray {
     LaunchN(this->size(), [=] __device__(size_t idx) { d_data[idx] = val; });
   }
   thrust::device_ptr<T> data() { return ptr_; }  // NOLINT
-  size_t size() { return size_; }  // NOLINT
+  size_t size() { return size_; }                // NOLINT
 
  private:
   thrust::device_ptr<T> ptr_;
@@ -332,8 +329,8 @@ xgboost::common::Span<T> LazyResize(xgboost::Context const *ctx,
 template <typename T>
 void CopyDeviceSpanToVector(std::vector<T> *dst, xgboost::common::Span<T> src) {
   CHECK_EQ(dst->size(), src.size());
-  dh::safe_cuda(cudaMemcpyAsync(dst->data(), src.data(), dst->size() * sizeof(T),
-                                cudaMemcpyDeviceToHost));
+  dh::safe_cuda(
+      cudaMemcpyAsync(dst->data(), src.data(), dst->size() * sizeof(T), cudaMemcpyDeviceToHost));
 }
 
 /**
@@ -346,8 +343,8 @@ void CopyDeviceSpanToVector(std::vector<T> *dst, xgboost::common::Span<T> src) {
 template <typename T>
 void CopyDeviceSpanToVector(std::vector<T> *dst, xgboost::common::Span<const T> src) {
   CHECK_EQ(dst->size(), src.size());
-  dh::safe_cuda(cudaMemcpyAsync(dst->data(), src.data(), dst->size() * sizeof(T),
-                                cudaMemcpyDeviceToHost));
+  dh::safe_cuda(
+      cudaMemcpyAsync(dst->data(), src.data(), dst->size() * sizeof(T), cudaMemcpyDeviceToHost));
 }
 
 // Keep track of pinned memory allocation
@@ -386,19 +383,16 @@ class PinnedMemory {
 template <typename T>
 typename std::iterator_traits<T>::value_type SumReduction(T in, int nVals) {
   using ValueT = typename std::iterator_traits<T>::value_type;
-  size_t tmpSize {0};
+  size_t tmpSize{0};
   ValueT *dummy_out = nullptr;
   dh::safe_cuda(cub::DeviceReduce::Sum(nullptr, tmpSize, in, dummy_out, nVals));
 
   TemporaryArray<char> temp(tmpSize + sizeof(ValueT));
   auto ptr = reinterpret_cast<ValueT *>(temp.data().get()) + 1;
-  dh::safe_cuda(cub::DeviceReduce::Sum(
-      reinterpret_cast<void *>(ptr), tmpSize, in,
-      reinterpret_cast<ValueT *>(temp.data().get()),
-      nVals));
+  dh::safe_cuda(cub::DeviceReduce::Sum(reinterpret_cast<void *>(ptr), tmpSize, in,
+                                       reinterpret_cast<ValueT *>(temp.data().get()), nVals));
   ValueT sum;
-  dh::safe_cuda(cudaMemcpy(&sum, temp.data().get(), sizeof(ValueT),
-                           cudaMemcpyDeviceToHost));
+  dh::safe_cuda(cudaMemcpy(&sum, temp.data().get(), sizeof(ValueT), cudaMemcpyDeviceToHost));
   return sum;
 }
 
@@ -430,7 +424,7 @@ class TypedDiscard : public thrust::discard_iterator<T> {
  public:
   using value_type = T;  // NOLINT
 };
-} // namespace detail
+}  // namespace detail
 
 template <typename T>
 using TypedDiscard = std::conditional_t<HasThrustMinorVer<12>(), detail::TypedDiscardCTK114<T>,
@@ -467,42 +461,42 @@ xgboost::common::Span<std::add_const_t<T>> ToSpan(DeviceUVector<T> const &vec) {
 
 // thrust begin, similiar to std::begin
 template <typename T>
-thrust::device_ptr<T> tbegin(xgboost::HostDeviceVector<T>& vector) {  // NOLINT
+thrust::device_ptr<T> tbegin(xgboost::HostDeviceVector<T> &vector) {  // NOLINT
   return thrust::device_ptr<T>(vector.DevicePointer());
 }
 
 template <typename T>
-thrust::device_ptr<T> tend(xgboost::HostDeviceVector<T>& vector) {  // // NOLINT
+thrust::device_ptr<T> tend(xgboost::HostDeviceVector<T> &vector) {  // // NOLINT
   return tbegin(vector) + vector.Size();
 }
 
 template <typename T>
-thrust::device_ptr<T const> tcbegin(xgboost::HostDeviceVector<T> const& vector) {  // NOLINT
+thrust::device_ptr<T const> tcbegin(xgboost::HostDeviceVector<T> const &vector) {  // NOLINT
   return thrust::device_ptr<T const>(vector.ConstDevicePointer());
 }
 
 template <typename T>
-thrust::device_ptr<T const> tcend(xgboost::HostDeviceVector<T> const& vector) {  // NOLINT
+thrust::device_ptr<T const> tcend(xgboost::HostDeviceVector<T> const &vector) {  // NOLINT
   return tcbegin(vector) + vector.Size();
 }
 
 template <typename T>
-XGBOOST_DEVICE thrust::device_ptr<T> tbegin(xgboost::common::Span<T>& span) {  // NOLINT
+XGBOOST_DEVICE thrust::device_ptr<T> tbegin(xgboost::common::Span<T> &span) {  // NOLINT
   return thrust::device_ptr<T>(span.data());
 }
 
 template <typename T>
-XGBOOST_DEVICE thrust::device_ptr<T> tbegin(xgboost::common::Span<T> const& span) {  // NOLINT
+XGBOOST_DEVICE thrust::device_ptr<T> tbegin(xgboost::common::Span<T> const &span) {  // NOLINT
   return thrust::device_ptr<T>(span.data());
 }
 
 template <typename T>
-XGBOOST_DEVICE thrust::device_ptr<T> tend(xgboost::common::Span<T>& span) {  // NOLINT
+XGBOOST_DEVICE thrust::device_ptr<T> tend(xgboost::common::Span<T> &span) {  // NOLINT
   return tbegin(span) + span.size();
 }
 
 template <typename T>
-XGBOOST_DEVICE thrust::device_ptr<T> tend(xgboost::common::Span<T> const& span) {  // NOLINT
+XGBOOST_DEVICE thrust::device_ptr<T> tend(xgboost::common::Span<T> const &span) {  // NOLINT
   return tbegin(span) + span.size();
 }
 
@@ -517,12 +511,13 @@ XGBOOST_DEVICE auto trend(xgboost::common::Span<T> &span) {  // NOLINT
 }
 
 template <typename T>
-XGBOOST_DEVICE thrust::device_ptr<T const> tcbegin(xgboost::common::Span<T> const& span) {  // NOLINT
+XGBOOST_DEVICE thrust::device_ptr<T const> tcbegin(
+    xgboost::common::Span<T> const &span) {  // NOLINT
   return thrust::device_ptr<T const>(span.data());
 }
 
 template <typename T>
-XGBOOST_DEVICE thrust::device_ptr<T const> tcend(xgboost::common::Span<T> const& span) {  // NOLINT
+XGBOOST_DEVICE thrust::device_ptr<T const> tcend(xgboost::common::Span<T> const &span) {  // NOLINT
   return tcbegin(span) + span.size();
 }
 
@@ -538,21 +533,17 @@ XGBOOST_DEVICE auto tcrend(xgboost::common::Span<T> const &span) {  // NOLINT
 
 // Atomic add function for gradients
 template <typename OutputGradientT, typename InputGradientT>
-XGBOOST_DEV_INLINE void AtomicAddGpair(OutputGradientT* dest,
-                                       const InputGradientT& gpair) {
-  auto dst_ptr = reinterpret_cast<typename OutputGradientT::ValueT*>(dest);
+XGBOOST_DEV_INLINE void AtomicAddGpair(OutputGradientT *dest, const InputGradientT &gpair) {
+  auto dst_ptr = reinterpret_cast<typename OutputGradientT::ValueT *>(dest);
 
-  atomicAdd(dst_ptr,
-            static_cast<typename OutputGradientT::ValueT>(gpair.GetGrad()));
-  atomicAdd(dst_ptr + 1,
-            static_cast<typename OutputGradientT::ValueT>(gpair.GetHess()));
+  atomicAdd(dst_ptr, static_cast<typename OutputGradientT::ValueT>(gpair.GetGrad()));
+  atomicAdd(dst_ptr + 1, static_cast<typename OutputGradientT::ValueT>(gpair.GetHess()));
 }
-
 
 // Thrust version of this function causes error on Windows
 template <typename ReturnT, typename IterT, typename FuncT>
-XGBOOST_DEVICE thrust::transform_iterator<FuncT, IterT, ReturnT> MakeTransformIterator(
-  IterT iter, FuncT func) {
+XGBOOST_DEVICE thrust::transform_iterator<FuncT, IterT, ReturnT> MakeTransformIterator(IterT iter,
+                                                                                       FuncT func) {
   return thrust::transform_iterator<FuncT, IterT, ReturnT>(iter, func);
 }
 
@@ -576,7 +567,7 @@ namespace detail {
 template <typename Key, typename KeyOutIt>
 struct SegmentedUniqueReduceOp {
   KeyOutIt key_out;
-  __device__ Key const& operator()(Key const& key) const {
+  __device__ Key const &operator()(Key const &key) const {
     auto constexpr kOne = static_cast<std::remove_reference_t<decltype(*(key_out + key.first))>>(1);
     atomicAdd(&(*(key_out + key.first)), kOne);
     return key;
@@ -619,20 +610,19 @@ size_t SegmentedUnique(const thrust::detail::execution_policy_base<DerivedPolicy
   auto reduce_it = thrust::make_transform_output_iterator(
       thrust::make_discard_iterator(),
       detail::SegmentedUniqueReduceOp<Key, KeyOutIt>{key_segments_out});
-  auto uniques_ret = thrust::unique_by_key_copy(
-      exec, unique_key_it, unique_key_it + n_inputs,
-      val_first, reduce_it, val_out,
-      [=] __device__(Key const &l, Key const &r) {
-        if (comp_key(l.first, r.first)) {
-          // In the same segment.
-          return comp(l.second, r.second);
-        }
-        return false;
-      });
+  auto uniques_ret =
+      thrust::unique_by_key_copy(exec, unique_key_it, unique_key_it + n_inputs, val_first,
+                                 reduce_it, val_out, [=] __device__(Key const &l, Key const &r) {
+                                   if (comp_key(l.first, r.first)) {
+                                     // In the same segment.
+                                     return comp(l.second, r.second);
+                                   }
+                                   return false;
+                                 });
   auto n_uniques = uniques_ret.second - val_out;
   CHECK_LE(n_uniques, n_inputs);
-  thrust::exclusive_scan(exec, key_segments_out,
-                         key_segments_out + segments_len, key_segments_out, 0);
+  thrust::exclusive_scan(exec, key_segments_out, key_segments_out + segments_len, key_segments_out,
+                         0);
   return n_uniques;
 }
 

--- a/src/common/device_helpers.cuh
+++ b/src/common/device_helpers.cuh
@@ -83,9 +83,9 @@ struct AtomicDispatcher<sizeof(uint64_t)> {
 
 // atomicAdd is not defined for size_t.
 template <typename T = size_t,
-          std::enable_if_t<std::is_same_v<size_t, T> && !std::is_same_v<size_t, unsigned long long>>
-              * =  // NOLINT
-          nullptr>
+          std::enable_if_t<std::is_same_v<size_t, T> &&
+                           !std::is_same_v<size_t, unsigned long long>>  // NOLINT
+              * = nullptr>
 XGBOOST_DEV_INLINE T atomicAdd(T *addr, T v) {  // NOLINT
   using Type = typename dh::detail::AtomicDispatcher<sizeof(T)>::Type;
   Type ret = ::atomicAdd(reinterpret_cast<Type *>(addr), static_cast<Type>(v));
@@ -511,8 +511,8 @@ XGBOOST_DEVICE auto trend(xgboost::common::Span<T> &span) {  // NOLINT
 }
 
 template <typename T>
-XGBOOST_DEVICE thrust::device_ptr<T const> tcbegin(
-    xgboost::common::Span<T> const &span) {  // NOLINT
+XGBOOST_DEVICE thrust::device_ptr<T const> tcbegin(  // NOLINT
+    xgboost::common::Span<T> const &span) {
   return thrust::device_ptr<T const>(span.data());
 }
 

--- a/src/tree/driver.h
+++ b/src/tree/driver.h
@@ -1,23 +1,25 @@
-/*!
- * Copyright 2021 by XGBoost Contributors
+/**
+ * Copyright 2021-2026, XGBoost Contributors
  */
-#ifndef XGBOOST_TREE_DRIVER_H_
-#define XGBOOST_TREE_DRIVER_H_
+#pragma once
+
 #include <xgboost/span.h>
-#include <queue>
-#include <vector>
-#include "./param.h"
 
-namespace xgboost {
-namespace tree {
+#include <cstddef>     // for size_t
+#include <functional>  // for function
+#include <queue>       // for priority_queue
+#include <vector>      // for vector
 
+#include "./param.h"  // for TrainParam
+
+namespace xgboost::tree {
 template <typename ExpandEntryT>
-inline bool DepthWise(const ExpandEntryT& lhs, const ExpandEntryT& rhs) {
+bool DepthWise(const ExpandEntryT& lhs, const ExpandEntryT& rhs) {
   return lhs.GetNodeId() > rhs.GetNodeId();  // favor small depth
 }
 
 template <typename ExpandEntryT>
-inline bool LossGuide(const ExpandEntryT& lhs, const ExpandEntryT& rhs) {
+bool LossGuide(const ExpandEntryT& lhs, const ExpandEntryT& rhs) {
   if (lhs.GetLossChange() == rhs.GetLossChange()) {
     return lhs.GetNodeId() > rhs.GetNodeId();  // favor small timestamp
   } else {
@@ -47,9 +49,8 @@ template <typename ExpandEntryT>
 // Drives execution of tree building on device
 template <typename ExpandEntryT>
 class Driver {
-  using ExpandQueue =
-      std::priority_queue<ExpandEntryT, std::vector<ExpandEntryT>,
-                          std::function<bool(ExpandEntryT, ExpandEntryT)>>;
+  using ExpandQueue = std::priority_queue<ExpandEntryT, std::vector<ExpandEntryT>,
+                                          std::function<bool(ExpandEntryT, ExpandEntryT)>>;
 
  public:
   explicit Driver(TrainParam param, std::size_t max_node_batch_size = 256)
@@ -66,14 +67,12 @@ class Driver {
       }
     }
   }
-  void Push(const std::vector<ExpandEntryT> &entries) {
+  void Push(const std::vector<ExpandEntryT>& entries) {
     this->Push(entries.begin(), entries.end());
   }
   void Push(ExpandEntryT const& e) { queue_.push(e); }
 
-  bool IsEmpty() {
-    return queue_.empty();
-  }
+  bool IsEmpty() { return queue_.empty(); }
 
   // Can a child of this entry still be expanded?
   // can be used to avoid extra work
@@ -124,7 +123,4 @@ class Driver {
   std::size_t max_node_batch_size_;
   ExpandQueue queue_;
 };
-}  // namespace tree
-}  // namespace xgboost
-
-#endif  // XGBOOST_TREE_DRIVER_H_
+}  // namespace xgboost::tree

--- a/src/tree/driver.h
+++ b/src/tree/driver.h
@@ -25,6 +25,25 @@ inline bool LossGuide(const ExpandEntryT& lhs, const ExpandEntryT& rhs) {
   }
 }
 
+template <typename ExpandEntryT>
+[[nodiscard]] bool IsValidExpandEntry(ExpandEntryT const& entry, TrainParam const& param,
+                                      bst_node_t num_leaves) {
+  auto loss_chg = entry.GetLossChange();
+  if (loss_chg <= kRtEps) {
+    return false;
+  }
+  if (loss_chg < param.min_split_loss) {
+    return false;
+  }
+  if (param.max_depth > 0 && entry.depth == param.max_depth) {
+    return false;
+  }
+  if (param.max_leaves > 0 && num_leaves == param.max_leaves) {
+    return false;
+  }
+  return true;
+}
+
 // Drives execution of tree building on device
 template <typename ExpandEntryT>
 class Driver {
@@ -42,7 +61,7 @@ class Driver {
   void Push(EntryIterT begin, EntryIterT end) {
     for (auto it = begin; it != end; ++it) {
       const ExpandEntryT& e = *it;
-      if (e.split.loss_chg > kRtEps) {
+      if (e.GetLossChange() > kRtEps) {
         queue_.push(e);
       }
     }
@@ -74,7 +93,7 @@ class Driver {
       ExpandEntryT e = queue_.top();
       queue_.pop();
 
-      if (e.IsValid(param_, num_leaves_)) {
+      if (IsValidExpandEntry(e, param_, num_leaves_)) {
         num_leaves_++;
         return {e};
       } else {
@@ -87,7 +106,7 @@ class Driver {
     int level = e.depth;
     while (e.depth == level && !queue_.empty() && result.size() < max_node_batch_size_) {
       queue_.pop();
-      if (e.IsValid(param_, num_leaves_)) {
+      if (IsValidExpandEntry(e, param_, num_leaves_)) {
         num_leaves_++;
         result.emplace_back(e);
       }

--- a/src/tree/gpu_hist/expand_entry.cu
+++ b/src/tree/gpu_hist/expand_entry.cu
@@ -40,9 +40,6 @@ std::ostream& operator<<(std::ostream& os, MultiExpandEntry const& e) {
   }
   print_span(e.split.child_sum);
 
-  os << "base_weight: ";
-  print_span(e.base_weight);
-
   return os;
 }
 }  // namespace xgboost::tree::cuda_impl

--- a/src/tree/gpu_hist/expand_entry.cuh
+++ b/src/tree/gpu_hist/expand_entry.cuh
@@ -7,7 +7,6 @@
 #include <limits>   // for numeric_limits
 #include <utility>  // for move
 
-#include "../param.h"                 // for TrainParam
 #include "../updater_gpu_common.cuh"  // for DeviceSplitCandidate
 #include "xgboost/base.h"             // for bst_node_t
 
@@ -30,24 +29,6 @@ struct GPUExpandEntry {
         base_weight{base},
         left_weight{left},
         right_weight{right} {}
-  [[nodiscard]] bool IsValid(TrainParam const& param, bst_node_t num_leaves) const {
-    if (split.loss_chg <= kRtEps) {
-      return false;
-    }
-    if (split.left_sum.GetQuantisedHess() == 0 || split.right_sum.GetQuantisedHess() == 0) {
-      return false;
-    }
-    if (split.loss_chg < param.min_split_loss) {
-      return false;
-    }
-    if (param.max_depth > 0 && depth == param.max_depth) {
-      return false;
-    }
-    if (param.max_leaves > 0 && num_leaves == param.max_leaves) {
-      return false;
-    }
-    return true;
-  }
 
   [[nodiscard]] float GetLossChange() const { return split.loss_chg; }
 
@@ -84,27 +65,6 @@ struct MultiExpandEntry {
   [[nodiscard]] bst_node_t GetNodeId() const { return nidx; }
 
   [[nodiscard]] bst_node_t GetDepth() const { return depth; }
-
-  [[nodiscard]] bool IsValid(TrainParam const& param, bst_node_t n_leaves) const {
-    // The split evaluator handles the zero Hessian case. It returns an expand entry with
-    // -inf loss_chg if the Hessian is invalid.
-    if (split.loss_chg <= kRtEps) {
-      return false;
-    }
-    if (base_weight.empty()) {
-      return false;
-    }
-    if (split.loss_chg < param.min_split_loss) {
-      return false;
-    }
-    if (param.max_depth > 0 && depth == param.max_depth) {
-      return false;
-    }
-    if (param.max_leaves > 0 && n_leaves == param.max_leaves) {
-      return false;
-    }
-    return true;
-  }
 
   /**
    * @brief Update hessian statistics.

--- a/src/tree/gpu_hist/expand_entry.cuh
+++ b/src/tree/gpu_hist/expand_entry.cuh
@@ -34,8 +34,6 @@ struct GPUExpandEntry {
 
   [[nodiscard]] bst_node_t GetNodeId() const { return nidx; }
 
-  [[nodiscard]] bst_node_t GetDepth() const { return depth; }
-
   friend std::ostream& operator<<(std::ostream& os, const GPUExpandEntry& e) {
     os << "GPUExpandEntry: \n";
     os << "nidx: " << e.nidx << "\n";
@@ -63,8 +61,6 @@ struct MultiExpandEntry {
   [[nodiscard]] float GetLossChange() const { return split.loss_chg; }
 
   [[nodiscard]] bst_node_t GetNodeId() const { return nidx; }
-
-  [[nodiscard]] bst_node_t GetDepth() const { return depth; }
 
   /**
    * @brief Update hessian statistics.

--- a/src/tree/gpu_hist/expand_entry.cuh
+++ b/src/tree/gpu_hist/expand_entry.cuh
@@ -51,7 +51,6 @@ struct MultiExpandEntry {
   bst_node_t depth{0};
   MultiSplitCandidate split;
 
-  common::Span<float> base_weight;
   // Sum of hessians across all targets for left/right children.
   double left_sum{0};
   double right_sum{0};

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -17,6 +17,7 @@
 #include <vector>                    // for vector
 
 #include "../../common/cuda_context.cuh"
+#include "../../common/nvtx_utils.h"  // for xgboost_NVTX_FN_RANGE
 #include "../tree_view.h"             // for MultiTargetTreeView
 #include "multi_evaluate_splits.cuh"  // for MultiEvalauteSplitInputs, MultiEvaluateSplitSharedInputs
 #include "quantiser.cuh"              // for GradientQuantiser
@@ -754,6 +755,7 @@ void MultiHistEvaluator::ApplyTreeSplit(Context const *ctx, RegTree const *p_tre
                                         common::Span<MultiExpandEntry const> h_candidates,
                                         common::Span<MultiExpandEntry const> d_candidates,
                                         bst_target_t n_targets) {
+  xgboost_NVTX_FN_RANGE();
   CHECK_EQ(h_candidates.size(), d_candidates.size());
   CHECK(!h_candidates.empty());
   CHECK_EQ(n_targets, this->GetEvaluator().n_targets);

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -758,11 +758,10 @@ void MultiHistEvaluator::ApplyTreeSplit(Context const *ctx, RegTree const *p_tre
   CHECK(!h_candidates.empty());
   CHECK_EQ(n_targets, this->GetEvaluator().n_targets);
 
-  auto h_tree = p_tree->HostMtView();
   auto weights = this->GetNodeWeights(n_targets);
   for (auto const &candidate : h_candidates) {
-    auto left = h_tree.LeftChild(candidate.nidx);
-    auto right = h_tree.RightChild(candidate.nidx);
+    auto left = p_tree->LeftChild(candidate.nidx);
+    auto right = p_tree->RightChild(candidate.nidx);
     common::Span<float const> left_weight = weights.Left(candidate.nidx);
     common::Span<float const> right_weight = weights.Right(candidate.nidx);
     this->tree_evaluator_->AddSplit(candidate.nidx, left, right, candidate.split.findex,

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -678,7 +678,7 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
 
     if (best_split.child_sum.empty()) {
       // Invalid split
-      out_splits[nidx_in_set] = {nidx, input.depth, best_split, base_weight};
+      out_splits[nidx_in_set] = {nidx, input.depth, best_split};
       out_splits[nidx_in_set].UpdateHessian(parent_hess, 0.0);
       return;
     }
@@ -743,8 +743,8 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
       right_hess += rg.GetHess();
     }
 
-    // Set up the output entry with spans pointing to persistent weight storage
-    out_splits[nidx_in_set] = {nidx, input.depth, best_split, base_weight};
+    // Set up the output entry after persisting its weights and split sum by node ID.
+    out_splits[nidx_in_set] = {nidx, input.depth, best_split};
     out_splits[nidx_in_set].split.loss_chg -= parent_gain;
     out_splits[nidx_in_set].UpdateHessian(left_hess, right_hess);
   });

--- a/src/tree/gpu_hist/multi_evaluate_splits.cuh
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cuh
@@ -147,12 +147,9 @@ class MultiHistEvaluator {
   [[nodiscard]] NodeWeightBuffer GetNodeWeights(bst_target_t n_targets) {
     return NodeWeightBuffer{dh::ToSpan(this->node_weights_), n_targets};
   }
-  [[nodiscard]] std::vector<CatST> GetHostNodeCats(bst_node_t nidx) const {
-    std::vector<CatST> out(this->node_cat_storage_size_);
-    auto cats = dh::ToSpan(this->split_cats_)
-                    .subspan(nidx * this->node_cat_storage_size_, this->node_cat_storage_size_);
-    dh::CopyDeviceSpanToVector(&out, cats);
-    return out;
+  [[nodiscard]] common::Span<CatST const> GetNodeCats(bst_node_t nidx) const {
+    return dh::ToSpan(this->split_cats_)
+        .subspan(nidx * this->node_cat_storage_size_, this->node_cat_storage_size_);
   }
   /**
    * @brief Copy weights for a node from device to host vectors.

--- a/src/tree/gpu_hist/multi_evaluate_splits.cuh
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cuh
@@ -151,25 +151,6 @@ class MultiHistEvaluator {
     return dh::ToSpan(this->split_cats_)
         .subspan(nidx * this->node_cat_storage_size_, this->node_cat_storage_size_);
   }
-  /**
-   * @brief Copy weights for a node from device to host vectors.
-   *
-   * Uses the split targets count stored during allocation, which may differ from tree targets
-   * when using reduced gradient.
-   *
-   * TODO(jiamingy): Remove this method and use device-only buffer.
-   */
-  void CopyNodeWeightsToHost(bst_node_t nidx, bst_target_t n_targets,
-                             std::vector<float> *base_weight, std::vector<float> *left_weight,
-                             std::vector<float> *right_weight) {
-    auto weights = this->GetNodeWeights(n_targets);
-    base_weight->resize(n_targets);
-    left_weight->resize(n_targets);
-    right_weight->resize(n_targets);
-    dh::CopyDeviceSpanToVector(base_weight, weights.Base(nidx));
-    dh::CopyDeviceSpanToVector(left_weight, weights.Left(nidx));
-    dh::CopyDeviceSpanToVector(right_weight, weights.Right(nidx));
-  }
 
   // Update the tree evaluator state and track child gradient sums.
   void ApplyTreeSplit(Context const *ctx, RegTree const *p_tree,

--- a/src/tree/gpu_hist/multi_evaluate_splits.cuh
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cuh
@@ -12,8 +12,6 @@
 namespace xgboost::tree::cuda_impl {
 /** @brief Evaluator for vector leaf. */
 class MultiHistEvaluator {
-  using CatST = common::CatBitField::value_type;
-
  public:
   template <typename GradT>
   static XGBOOST_DEVICE common::Span<GradT> GetNodeSumImpl(common::Span<GradT> node_sums,
@@ -83,7 +81,7 @@ class MultiHistEvaluator {
   NodeSumBuffer split_sums_;
   // Category bit fields for evaluated nodes, indexed by node id. They must remain valid
   // while candidates are waiting in the loss-guide queue.
-  dh::DeviceUVector<CatST> split_cats_;
+  dh::DeviceUVector<CatWordT> split_cats_;
   std::size_t node_cat_storage_size_{0};
   // Whether any categorical feature requires partition-based evaluation.
   bool need_sort_histogram_{false};
@@ -147,7 +145,7 @@ class MultiHistEvaluator {
   [[nodiscard]] NodeWeightBuffer GetNodeWeights(bst_target_t n_targets) {
     return NodeWeightBuffer{dh::ToSpan(this->node_weights_), n_targets};
   }
-  [[nodiscard]] common::Span<CatST const> GetNodeCats(bst_node_t nidx) const {
+  [[nodiscard]] common::Span<CatWordT const> GetNodeCats(bst_node_t nidx) const {
     return dh::ToSpan(this->split_cats_)
         .subspan(nidx * this->node_cat_storage_size_, this->node_cat_storage_size_);
   }

--- a/src/tree/gpu_hist/row_partitioner.cuh
+++ b/src/tree/gpu_hist/row_partitioner.cuh
@@ -160,7 +160,7 @@ void SortPositionBatch(Context const* ctx, common::Span<const PerNodeData<OpData
         std::int32_t nidx_in_batch;
         std::size_t item_idx;
         AssignBatch(batch_info_itr, idx, &nidx_in_batch, &item_idx);
-        auto go_left = op(ridx[item_idx], nidx_in_batch, batch_info_itr[nidx_in_batch].data);
+        auto go_left = op(ridx[item_idx], batch_info_itr[nidx_in_batch].data);
         return IndexFlagTuple{static_cast<cuda_impl::RowIndexT>(item_idx), go_left, nidx_in_batch,
                               go_left};
       }));

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -266,15 +266,14 @@ class HistEvaluator {
 
  public:
   void EvaluateSplits(const BoundedHistCollection &hist, common::HistogramCuts const &cut,
-                      common::Span<FeatureType const> feature_types, const RegTree &tree,
+                      common::Span<FeatureType const> feature_types,
                       std::vector<CPUExpandEntry> *p_entries) {
     auto n_threads = ctx_->Threads();
     auto &entries = *p_entries;
     // All nodes are on the same level, so we can store the shared ptr.
     std::vector<std::shared_ptr<HostDeviceVector<bst_feature_t>>> features(entries.size());
     for (size_t nidx_in_set = 0; nidx_in_set < entries.size(); ++nidx_in_set) {
-      auto nidx = entries[nidx_in_set].nid;
-      features[nidx_in_set] = column_sampler_->GetFeatureSet(ctx_, tree.GetDepth(nidx));
+      features[nidx_in_set] = column_sampler_->GetFeatureSet(ctx_, entries[nidx_in_set].depth);
     }
     CHECK(!features.empty());
     const size_t grain_size = std::max<size_t>(1, features.front()->Size() / n_threads);
@@ -608,7 +607,7 @@ class HistMultiEvaluator {
   }
 
  public:
-  void EvaluateSplits(RegTree const &tree, common::Span<const BoundedHistCollection *> hist,
+  void EvaluateSplits(common::Span<const BoundedHistCollection *> hist,
                       common::HistogramCuts const &cut,
                       common::Span<FeatureType const> feature_types,
                       std::vector<MultiExpandEntry> *p_entries) {
@@ -618,8 +617,7 @@ class HistMultiEvaluator {
     std::vector<std::shared_ptr<HostDeviceVector<bst_feature_t>>> features(entries.size());
 
     for (std::size_t nidx_in_set = 0; nidx_in_set < entries.size(); ++nidx_in_set) {
-      auto nidx = entries[nidx_in_set].nid;
-      features[nidx_in_set] = column_sampler_->GetFeatureSet(ctx_, tree.GetDepth(nidx));
+      features[nidx_in_set] = column_sampler_->GetFeatureSet(ctx_, entries[nidx_in_set].depth);
     }
     CHECK(!features.empty());
 
@@ -759,16 +757,6 @@ class HistMultiEvaluator {
     evaluator.CalcSplitWeights(*param_, candidate.nid, candidate.split.SplitIndex(), left_sum,
                                right_sum, left_weight, right_weight);
 
-    auto leaf_weight = linalg::Empty<float>(ctx_, 2, n_split_targets);
-    auto left_leaf_weight = leaf_weight.Slice(0, linalg::All());
-    auto right_leaf_weight = leaf_weight.Slice(1, linalg::All());
-    std::transform(linalg::cbegin(left_weight), linalg::cend(left_weight),
-                   linalg::begin(left_leaf_weight),
-                   [&](float w) { return w * param_->learning_rate; });
-    std::transform(linalg::cbegin(right_weight), linalg::cend(right_weight),
-                   linalg::begin(right_leaf_weight),
-                   [&](float w) { return w * param_->learning_rate; });
-
     // Compute the loss_chg and sum hessians for parent and children
     float loss_chg = candidate.split.loss_chg;
     // Sum hessians across all targets for each child
@@ -777,24 +765,24 @@ class HistMultiEvaluator {
       left_sum_hess += candidate.split.left_sum[t].GetHess();
       right_sum_hess += candidate.split.right_sum[t].GetHess();
     }
-    double sum_hess = left_sum_hess + right_sum_hess;
 
+    common::Span<CatWordT const> cat_bits;
     if (candidate.split.is_cat) {
-      p_tree->ExpandCategorical(candidate.nid, candidate.split.SplitIndex(),
-                                candidate.split.cat_bits, candidate.split.DefaultLeft(),
-                                base_weight, left_leaf_weight, right_leaf_weight, loss_chg,
-                                sum_hess, left_sum_hess, right_sum_hess);
-    } else {
-      p_tree->ExpandNode(candidate.nid, candidate.split.SplitIndex(), candidate.split.split_value,
-                         candidate.split.DefaultLeft(), base_weight, left_leaf_weight,
-                         right_leaf_weight, loss_chg, sum_hess, left_sum_hess, right_sum_hess);
+      cat_bits = candidate.split.cat_bits;
     }
+    auto as_span = [](linalg::VectorView<float const> weight) {
+      return weight.Values().subspan(0, weight.Size());
+    };
+    ExpandBatch batch{ctx_->Device(), param_->learning_rate};
+    batch.Push(candidate.nid, candidate.split.SplitIndex(), candidate.split.split_value,
+               candidate.split.DefaultLeft(), as_span(base_weight), as_span(left_weight),
+               as_span(right_weight), loss_chg, left_sum_hess, right_sum_hess, cat_bits);
+    p_tree->Expand(batch);
 
     CHECK(p_tree->IsMultiTarget());
-    auto mt_tree = p_tree->HostMtView();
-    auto left_child = mt_tree.LeftChild(candidate.nid);
+    auto left_child = p_tree->LeftChild(candidate.nid);
     CHECK_GT(left_child, candidate.nid);
-    auto right_child = mt_tree.RightChild(candidate.nid);
+    auto right_child = p_tree->RightChild(candidate.nid);
     CHECK_GT(right_child, candidate.nid);
 
     tree_evaluator_.AddSplit(candidate.nid, left_child, right_child, candidate.split.SplitIndex(),
@@ -803,7 +791,7 @@ class HistMultiEvaluator {
     interaction_constraints_.Split(candidate.nid, candidate.split.SplitIndex(), left_child,
                                    right_child);
 
-    std::size_t n_nodes = mt_tree.Size();
+    std::size_t n_nodes = p_tree->Size();
     gain_.resize(n_nodes);
     gain_[left_child] = evaluator.CalcGainGivenWeight(*param_, left_sum, left_weight);
     gain_[right_child] = evaluator.CalcGainGivenWeight(*param_, right_sum, right_weight);

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -773,11 +773,11 @@ class HistMultiEvaluator {
     auto as_span = [](linalg::VectorView<float const> weight) {
       return weight.Values().subspan(0, weight.Size());
     };
-    ExpandBatch batch{ctx_->Device(), param_->learning_rate};
+    ExpandBatch batch{param_->learning_rate};
     batch.Push(candidate.nid, candidate.split.SplitIndex(), candidate.split.split_value,
                candidate.split.DefaultLeft(), as_span(base_weight), as_span(left_weight),
                as_span(right_weight), loss_chg, left_sum_hess, right_sum_hess, cat_bits);
-    p_tree->Expand(batch);
+    p_tree->Expand(ctx_, batch);
 
     CHECK(p_tree->IsMultiTarget());
     auto left_child = p_tree->LeftChild(candidate.nid);

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -771,6 +771,7 @@ class HistMultiEvaluator {
       cat_bits = candidate.split.cat_bits;
     }
     auto as_span = [](linalg::VectorView<float const> weight) {
+      // sliced weight might have larger span as the underlying data
       return weight.Values().subspan(0, weight.Size());
     };
     ExpandBatch batch{param_->learning_rate};

--- a/src/tree/hist/expand_entry.h
+++ b/src/tree/hist/expand_entry.h
@@ -4,19 +4,16 @@
 #ifndef XGBOOST_TREE_HIST_EXPAND_ENTRY_H_
 #define XGBOOST_TREE_HIST_EXPAND_ENTRY_H_
 
-#include <algorithm>  // for all_of
-#include <ostream>    // for ostream
-#include <string>     // for string
-#include <utility>    // for move
-#include <vector>     // for vector
+#include <ostream>  // for ostream
+#include <utility>  // for move
+#include <vector>   // for vector
 
-#include "../param.h"      // for SplitEntry, SplitEntryContainer, TrainParam
+#include "../param.h"      // for SplitEntry, SplitEntryContainer
 #include "xgboost/base.h"  // for GradientPairPrecise, bst_node_t
-#include "xgboost/json.h"  // for Json
 
 namespace xgboost::tree {
 /**
- * \brief Structure for storing tree split candidate.
+ * @brief Structure for storing tree split candidate.
  */
 template <typename Impl>
 struct ExpandEntryImpl {
@@ -27,10 +24,6 @@ struct ExpandEntryImpl {
     return static_cast<Impl const*>(this)->split.loss_chg;
   }
   [[nodiscard]] bst_node_t GetNodeId() const { return nid; }
-
-  [[nodiscard]] bool IsValid(TrainParam const& param, bst_node_t num_leaves) const {
-    return static_cast<Impl const*>(this)->IsValidImpl(param, num_leaves);
-  }
 };
 
 struct CPUExpandEntry : public ExpandEntryImpl<CPUExpandEntry> {
@@ -40,23 +33,6 @@ struct CPUExpandEntry : public ExpandEntryImpl<CPUExpandEntry> {
   CPUExpandEntry(bst_node_t nidx, bst_node_t depth, SplitEntry split)
       : ExpandEntryImpl{nidx, depth}, split(std::move(split)) {}
   CPUExpandEntry(bst_node_t nidx, bst_node_t depth) : ExpandEntryImpl{nidx, depth} {}
-
-  [[nodiscard]] bool IsValidImpl(TrainParam const& param, bst_node_t num_leaves) const {
-    if (split.loss_chg <= kRtEps) return false;
-    if (split.left_sum.GetHess() == 0 || split.right_sum.GetHess() == 0) {
-      return false;
-    }
-    if (split.loss_chg < param.min_split_loss) {
-      return false;
-    }
-    if (param.max_depth > 0 && depth == param.max_depth) {
-      return false;
-    }
-    if (param.max_leaves > 0 && num_leaves == param.max_leaves) {
-      return false;
-    }
-    return true;
-  }
 
   friend std::ostream& operator<<(std::ostream& os, CPUExpandEntry const& e) {
     os << "ExpandEntry:\n";
@@ -73,27 +49,6 @@ struct MultiExpandEntry : public ExpandEntryImpl<MultiExpandEntry> {
 
   MultiExpandEntry() = default;
   MultiExpandEntry(bst_node_t nidx, bst_node_t depth) : ExpandEntryImpl{nidx, depth} {}
-
-  [[nodiscard]] bool IsValidImpl(TrainParam const& param, bst_node_t num_leaves) const {
-    if (split.loss_chg <= kRtEps) return false;
-    auto is_zero = [](auto const& sum) {
-      return std::all_of(sum.cbegin(), sum.cend(),
-                         [&](auto const& g) { return g.GetHess() - .0 == .0; });
-    };
-    if (is_zero(split.left_sum) || is_zero(split.right_sum)) {
-      return false;
-    }
-    if (split.loss_chg < param.min_split_loss) {
-      return false;
-    }
-    if (param.max_depth > 0 && depth == param.max_depth) {
-      return false;
-    }
-    if (param.max_leaves > 0 && num_leaves == param.max_leaves) {
-      return false;
-    }
-    return true;
-  }
 
   friend std::ostream& operator<<(std::ostream& os, MultiExpandEntry const& e) {
     os << "ExpandEntry: \n";

--- a/src/tree/multi_target_tree_model.cc
+++ b/src/tree/multi_target_tree_model.cc
@@ -20,6 +20,81 @@
 #include "xgboost/tree_model.h"  // for TreeParam
 
 namespace xgboost {
+namespace tree::cuda_impl {
+void CopyBatch(Context const* ctx, common::Span<void*> dsts, common::Span<void const*> srcs,
+               common::Span<std::size_t const> sizes);
+void ApplyLearningRate(Context const* ctx, common::Span<float> weights, float eta);
+}  // namespace tree::cuda_impl
+
+namespace {
+template <typename T>
+struct CopyBatchItem {
+  std::size_t dst_offset;
+  common::Span<T const> src;
+
+  CopyBatchItem(std::size_t dst_offset, common::Span<T const> src)
+      : dst_offset{dst_offset}, src{src} {}
+};
+
+template <typename T>
+void CopyBatch(Context const* ctx, std::size_t size, std::vector<CopyBatchItem<T>> const& copies,
+               HostDeviceVector<T>* out) {
+  out->SetDevice(ctx->Device());
+#if defined(XGBOOST_USE_CUDA)
+  if (ctx->IsCUDA()) {
+    (void)out->DeviceSpan();
+    out->Resize(size);
+    auto dst = out->DeviceSpan();
+    std::vector<void*> dsts(copies.size());
+    std::vector<void const*> srcs(copies.size());
+    std::vector<std::size_t> sizes(copies.size());
+    for (std::size_t i = 0; i < copies.size(); ++i) {
+      dsts[i] = dst.data() + copies[i].dst_offset;
+      srcs[i] = copies[i].src.data();
+      sizes[i] = copies[i].src.size_bytes();
+    }
+    tree::cuda_impl::CopyBatch(ctx, dsts, srcs, sizes);
+    return;
+  }
+#endif  // defined(XGBOOST_USE_CUDA)
+
+  out->Resize(size);
+  auto dst = out->HostSpan();
+  for (auto const& copy : copies) {
+    std::copy(copy.src.cbegin(), copy.src.cend(), dst.begin() + copy.dst_offset);
+  }
+}
+
+void ApplyLearningRate(Context const* ctx, std::size_t offset, std::size_t size, float eta,
+                       HostDeviceVector<float>* values) {
+  values->SetDevice(ctx->Device());
+#if defined(XGBOOST_USE_CUDA)
+  if (ctx->IsCUDA()) {
+    tree::cuda_impl::ApplyLearningRate(ctx, values->DeviceSpan().subspan(offset, size), eta);
+    return;
+  }
+#endif  // defined(XGBOOST_USE_CUDA)
+
+  auto out = values->HostSpan().subspan(offset, size);
+  std::transform(out.cbegin(), out.cend(), out.begin(),
+                 [eta](float weight) { return weight * eta; });
+}
+}  // namespace
+
+namespace tree {
+void CopyCategoryStorage(Context const* ctx, std::size_t offset, ExpandBatch const& batch,
+                         HostDeviceVector<CatWordT>* out) {
+  std::vector<CopyBatchItem<CatWordT>> copies;
+  for (auto cats : batch.cat_bits) {
+    if (!cats.empty()) {
+      copies.emplace_back(offset, cats);
+      offset += cats.size();
+    }
+  }
+  CopyBatch(ctx, offset, copies, out);
+}
+}  // namespace tree
+
 MultiTargetTree::MultiTargetTree(TreeParam const* param)
     : param_{param},
       left_(1ul, InvalidNodeId()),
@@ -88,74 +163,57 @@ void MultiTargetTree::SetRoot(linalg::VectorView<float const> weight, float sum_
   CHECK_EQ(this->NumSplitTargets(), weight.Size());
 }
 
-void MultiTargetTree::Expand(bst_node_t nidx, bst_feature_t split_idx, float split_cond,
-                             bool default_left, linalg::VectorView<float const> base_weight,
-                             linalg::VectorView<float const> left_weight,
-                             linalg::VectorView<float const> right_weight, float loss_chg,
-                             float sum_hess, float left_sum, float right_sum) {
-  CHECK(this->IsLeaf(nidx));
-  CHECK_GE(parent_.Size(), 1);
-  CHECK_EQ(parent_.Size(), left_.Size());
-  CHECK_EQ(left_.Size(), right_.Size());
-  auto n_split_targets = this->NumSplitTargets();
-  CHECK_EQ(base_weight.Size(), n_split_targets);
+void MultiTargetTree::Expand(Context const* ctx, tree::ExpandBatch const& batch) {
+  auto const batch_size = batch.Size();
+  auto const n_split_targets = this->NumSplitTargets();
+  auto const old_n_nodes = this->Size();
+  auto const n_nodes = old_n_nodes + batch_size * 2;
+  left_.Resize(n_nodes, InvalidNodeId());
+  right_.Resize(n_nodes, InvalidNodeId());
+  parent_.Resize(n_nodes, InvalidNodeId());
+  split_index_.Resize(n_nodes);
+  split_conds_.Resize(n_nodes, DftBadValue());
+  default_left_.Resize(n_nodes);
 
-  std::size_t n = param_->num_nodes + 2;
-  CHECK_LT(split_idx, this->param_->num_feature);
-  left_.Resize(n, InvalidNodeId());
-  right_.Resize(n, InvalidNodeId());
-  parent_.Resize(n, InvalidNodeId());
-
-  auto left_child = parent_.Size() - 2;
-  auto right_child = parent_.Size() - 1;
-
-  CHECK_NE(left_child, nidx);
-  left_.HostVector()[nidx] = left_child;
-  right_.HostVector()[nidx] = right_child;
-
-  auto& h_parent = parent_.HostVector();
-  if (nidx != 0) {
-    CHECK_NE(h_parent[nidx], InvalidNodeId());
+  auto h_left = left_.HostSpan();
+  auto h_right = right_.HostSpan();
+  auto h_parent = parent_.HostSpan();
+  auto h_split_index = split_index_.HostSpan();
+  auto h_split_conds = split_conds_.HostSpan();
+  auto h_default_left = default_left_.HostSpan();
+  for (std::size_t i = 0; i < batch_size; ++i) {
+    auto const nidx = batch.nidxs[i];
+    h_left[nidx] = static_cast<bst_node_t>(old_n_nodes + i * 2);
+    h_right[nidx] = h_left[nidx] + 1;
+    h_parent[h_left[nidx]] = nidx;
+    h_parent[h_right[nidx]] = nidx;
+    h_split_index[nidx] = batch.fidxs[i];
+    h_split_conds[nidx] = batch.cat_bits[i].empty() ? batch.conds[i] : DftBadValue();
+    h_default_left[nidx] = batch.dft_lefts[i];
   }
 
-  h_parent[left_child] = nidx;
-  h_parent[right_child] = nidx;
-
-  split_index_.Resize(n);
-  split_index_.HostVector()[nidx] = split_idx;
-
-  split_conds_.Resize(n, DftBadValue());
-  split_conds_.HostVector()[nidx] = split_cond;
-
-  default_left_.Resize(n);
-  default_left_.HostVector()[nidx] = static_cast<std::uint8_t>(default_left);
-
-  // Set weights
-  weights_.Resize(n * base_weight.Size());
-  auto p_weight = this->NodeWeight(nidx, n_split_targets);
-  CHECK_GE(p_weight.Size(), base_weight.Size());
-  auto l_weight = this->NodeWeight(left_child, n_split_targets);
-  CHECK_GE(l_weight.Size(), left_weight.Size());
-  auto r_weight = this->NodeWeight(right_child, n_split_targets);
-  CHECK_GE(r_weight.Size(), right_weight.Size());
-
-  CHECK_EQ(base_weight.Size(), left_weight.Size());
-  CHECK_EQ(base_weight.Size(), right_weight.Size());
-
-  for (std::size_t i = 0, n = base_weight.Size(); i < n; ++i) {
-    p_weight(i) = base_weight(i);
-    l_weight(i) = left_weight(i);
-    r_weight(i) = right_weight(i);
+  std::vector<CopyBatchItem<float>> weight_copies;
+  for (std::size_t i = 0; i < batch_size; ++i) {
+    auto const nidx = batch.nidxs[i];
+    weight_copies.emplace_back(nidx * n_split_targets, batch.base_weight_batch[i]);
+    weight_copies.emplace_back(h_left[nidx] * n_split_targets, batch.left_weight_batch[i]);
+    weight_copies.emplace_back(h_right[nidx] * n_split_targets, batch.right_weight_batch[i]);
   }
+  CopyBatch(ctx, n_nodes * n_split_targets, weight_copies, &weights_);
+  auto const n_child_weights = batch_size * 2 * n_split_targets;
+  ApplyLearningRate(ctx, old_n_nodes * n_split_targets, n_child_weights, batch.eta, &weights_);
 
-  loss_chg_.Resize(n, 0.0f);
-  loss_chg_.HostVector()[nidx] = loss_chg;
-
-  sum_hess_.Resize(n, 0.0f);
-  auto& h_hess = sum_hess_.HostVector();
-  h_hess[nidx] = sum_hess;
-  h_hess[left_child] = left_sum;
-  h_hess[right_child] = right_sum;
+  loss_chg_.Resize(n_nodes, 0.0f);
+  sum_hess_.Resize(n_nodes, 0.0f);
+  auto h_loss_chg = loss_chg_.HostSpan();
+  auto h_sum_hess = sum_hess_.HostSpan();
+  for (std::size_t i = 0; i < batch_size; ++i) {
+    auto const nidx = batch.nidxs[i];
+    h_loss_chg[nidx] = batch.loss_chgs[i];
+    h_sum_hess[nidx] = batch.left_sums[i] + batch.right_sums[i];
+    h_sum_hess[h_left[nidx]] = batch.left_sums[i];
+    h_sum_hess[h_right[nidx]] = batch.right_sums[i];
+  }
 }
 
 void MultiTargetTree::SetLeaves(std::vector<bst_node_t> leaves, common::Span<float const> weights) {

--- a/src/tree/multi_target_tree_model.cc
+++ b/src/tree/multi_target_tree_model.cc
@@ -13,6 +13,7 @@
 
 #include "../common/cuda_rt_utils.h"  // for MemcpyAsync
 #include "../common/linalg_op.h"      // for cbegin
+#include "../common/nvtx_utils.h"     // for xgboost_NVTX_FN_RANGE
 #include "io_utils.h"                 // for I32ArrayT, FloatArrayT, GetElem, ...
 #include "xgboost/base.h"             // for bst_node_t, bst_feature_t, bst_target_t
 #include "xgboost/json.h"             // for Json, get, Object, Number, Integer, ...
@@ -84,6 +85,7 @@ void ApplyLearningRate(Context const* ctx, std::size_t offset, std::size_t size,
 namespace tree {
 void CopyCategoryStorage(Context const* ctx, std::size_t offset, ExpandBatch const& batch,
                          HostDeviceVector<CatWordT>* out) {
+  xgboost_NVTX_FN_RANGE();
   std::vector<CopyBatchItem<CatWordT>> copies;
   for (auto cats : batch.cat_bits) {
     if (!cats.empty()) {
@@ -164,6 +166,7 @@ void MultiTargetTree::SetRoot(linalg::VectorView<float const> weight, float sum_
 }
 
 void MultiTargetTree::Expand(Context const* ctx, tree::ExpandBatch const& batch) {
+  xgboost_NVTX_FN_RANGE();
   auto const batch_size = batch.Size();
   auto const n_split_targets = this->NumSplitTargets();
   auto const old_n_nodes = this->Size();

--- a/src/tree/multi_target_tree_model.cc
+++ b/src/tree/multi_target_tree_model.cc
@@ -22,7 +22,8 @@
 
 namespace xgboost {
 namespace tree::cuda_impl {
-void CopyBatch(Context const* ctx, common::Span<void*> dsts, common::Span<void const*> srcs,
+template <typename T>
+void CopyBatch(Context const* ctx, common::Span<T*> dsts, common::Span<T const*> srcs,
                common::Span<std::size_t const> sizes);
 void ApplyLearningRate(Context const* ctx, common::Span<float> weights, float eta);
 }  // namespace tree::cuda_impl
@@ -46,15 +47,15 @@ void CopyBatch(Context const* ctx, std::size_t size, std::vector<CopyBatchItem<T
     (void)out->DeviceSpan();
     out->Resize(size);
     auto dst = out->DeviceSpan();
-    std::vector<void*> dsts(copies.size());
-    std::vector<void const*> srcs(copies.size());
+    std::vector<T*> dsts(copies.size());
+    std::vector<T const*> srcs(copies.size());
     std::vector<std::size_t> sizes(copies.size());
     for (std::size_t i = 0; i < copies.size(); ++i) {
       dsts[i] = dst.data() + copies[i].dst_offset;
       srcs[i] = copies[i].src.data();
       sizes[i] = copies[i].src.size_bytes();
     }
-    tree::cuda_impl::CopyBatch(ctx, dsts, srcs, sizes);
+    tree::cuda_impl::CopyBatch(ctx, common::Span{dsts}, common::Span{srcs}, sizes);
     return;
   }
 #endif  // defined(XGBOOST_USE_CUDA)

--- a/src/tree/multi_target_tree_model.cu
+++ b/src/tree/multi_target_tree_model.cu
@@ -1,14 +1,16 @@
 /**
  * Copyright 2026, XGBoost Contributors
  */
-#include <xgboost/context.h>  // for Context
-#include <xgboost/span.h>     // for Span
+#include <thrust/transform.h>  // for transform
+#include <xgboost/context.h>   // for Context
+#include <xgboost/span.h>      // for Span
 
-#include <cstddef>  // for size_t
-#include <limits>   // for numeric_limits
+#include <cstddef>          // for size_t
+#include <cuda/functional>  // for proclaim_copyable_arguments
+#include <limits>           // for numeric_limits
 
 #include "../common/cuda_context.cuh"    // for CUDAContext
-#include "../common/device_helpers.cuh"  // for LaunchN, MemcpyBatchAsync
+#include "../common/device_helpers.cuh"  // for MemcpyBatchAsync
 
 namespace xgboost::tree::cuda_impl {
 void CopyBatch(Context const* ctx, common::Span<void*> dsts, common::Span<void const*> srcs,
@@ -23,7 +25,8 @@ void CopyBatch(Context const* ctx, common::Span<void*> dsts, common::Span<void c
 }
 
 void ApplyLearningRate(Context const* ctx, common::Span<float> weights, float eta) {
-  dh::LaunchN(weights.size(), ctx->CUDACtx()->Stream(),
-              [=] XGBOOST_DEVICE(std::size_t i) mutable { weights[i] *= eta; });
+  thrust::transform(
+      ctx->CUDACtx()->CTP(), dh::tcbegin(weights), dh::tcend(weights), dh::tbegin(weights),
+      cuda::proclaim_copyable_arguments([=] XGBOOST_DEVICE(float w) { return w * eta; }));
 }
 }  // namespace xgboost::tree::cuda_impl

--- a/src/tree/multi_target_tree_model.cu
+++ b/src/tree/multi_target_tree_model.cu
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ */
+#include <xgboost/context.h>  // for Context
+#include <xgboost/span.h>     // for Span
+
+#include <cstddef>  // for size_t
+#include <limits>   // for numeric_limits
+
+#include "../common/cuda_context.cuh"    // for CUDAContext
+#include "../common/device_helpers.cuh"  // for LaunchN, MemcpyBatchAsync
+
+namespace xgboost::tree::cuda_impl {
+void CopyBatch(Context const* ctx, common::Span<void*> dsts, common::Span<void const*> srcs,
+               common::Span<std::size_t const> sizes) {
+  std::size_t fail_idx{std::numeric_limits<std::size_t>::max()};
+  auto status = dh::MemcpyBatchAsync<cudaMemcpyDeviceToDevice>(
+      dsts.data(), srcs.data(), sizes.data(), dsts.size(), &fail_idx, ctx->CUDACtx()->Stream());
+  if (status != cudaSuccess) {
+    LOG(FATAL) << "CUDA batch copy failed at index " << fail_idx << ": "
+               << cudaGetErrorString(status);
+  }
+}
+
+void ApplyLearningRate(Context const* ctx, common::Span<float> weights, float eta) {
+  dh::LaunchN(weights.size(), ctx->CUDACtx()->Stream(),
+              [=] XGBOOST_DEVICE(std::size_t i) mutable { weights[i] *= eta; });
+}
+}  // namespace xgboost::tree::cuda_impl

--- a/src/tree/multi_target_tree_model.cu
+++ b/src/tree/multi_target_tree_model.cu
@@ -9,11 +9,13 @@
 #include <cuda/functional>  // for proclaim_copyable_arguments
 #include <limits>           // for numeric_limits
 
-#include "../common/cuda_context.cuh"    // for CUDAContext
-#include "../common/device_helpers.cuh"  // for MemcpyBatchAsync
+#include "../common/cuda_context.cuh"         // for CUDAContext
+#include "../common/device_helpers.cuh"       // for MemcpyBatchAsync
+#include "xgboost/multi_target_tree_model.h"  // for CatWordT
 
 namespace xgboost::tree::cuda_impl {
-void CopyBatch(Context const* ctx, common::Span<void*> dsts, common::Span<void const*> srcs,
+template <typename T>
+void CopyBatch(Context const* ctx, common::Span<T*> dsts, common::Span<T const*> srcs,
                common::Span<std::size_t const> sizes) {
   std::size_t fail_idx{std::numeric_limits<std::size_t>::max()};
   auto status = dh::MemcpyBatchAsync<cudaMemcpyDeviceToDevice>(
@@ -23,6 +25,11 @@ void CopyBatch(Context const* ctx, common::Span<void*> dsts, common::Span<void c
                << cudaGetErrorString(status);
   }
 }
+
+template void CopyBatch(Context const* ctx, common::Span<float*> dsts,
+                        common::Span<float const*> srcs, common::Span<std::size_t const> sizes);
+template void CopyBatch(Context const* ctx, common::Span<CatWordT*> dsts,
+                        common::Span<CatWordT const*> srcs, common::Span<std::size_t const> sizes);
 
 void ApplyLearningRate(Context const* ctx, common::Span<float> weights, float eta) {
   thrust::transform(

--- a/src/tree/multi_target_tree_model.cu
+++ b/src/tree/multi_target_tree_model.cu
@@ -18,12 +18,8 @@ template <typename T>
 void CopyBatch(Context const* ctx, common::Span<T*> dsts, common::Span<T const*> srcs,
                common::Span<std::size_t const> sizes) {
   std::size_t fail_idx{std::numeric_limits<std::size_t>::max()};
-  auto status = dh::MemcpyBatchAsync<cudaMemcpyDeviceToDevice>(
-      dsts.data(), srcs.data(), sizes.data(), dsts.size(), &fail_idx, ctx->CUDACtx()->Stream());
-  if (status != cudaSuccess) {
-    LOG(FATAL) << "CUDA batch copy failed at index " << fail_idx << ": "
-               << cudaGetErrorString(status);
-  }
+  dh::safe_cuda(dh::MemcpyBatchAsync<cudaMemcpyDeviceToDevice>(
+      dsts.data(), srcs.data(), sizes.data(), dsts.size(), &fail_idx, ctx->CUDACtx()->Stream()));
 }
 
 template void CopyBatch(Context const* ctx, common::Span<float*> dsts,

--- a/src/tree/param.h
+++ b/src/tree/param.h
@@ -403,59 +403,6 @@ struct SplitEntryContainer {
     return os;
   }
 
-  /**
-   * @brief Copy primitive fields into this, and collect cat_bits into a vector.
-   *
-   * This is used for allgather.
-   *
-   * @param that The other entry to copy from
-   * @param collected_cat_bits The vector to collect cat_bits
-   * @param cat_bits_sizes The sizes of the collected cat_bits
-   */
-  void CopyAndCollect(SplitEntryContainer<GradientT> const &that,
-                      std::vector<uint32_t> *collected_cat_bits,
-                      std::vector<std::size_t> *cat_bits_sizes) {
-    loss_chg = that.loss_chg;
-    sindex = that.sindex;
-    split_value = that.split_value;
-    is_cat = that.is_cat;
-    static_assert(std::is_trivially_copyable_v<GradientT>);
-    left_sum = that.left_sum;
-    right_sum = that.right_sum;
-    collected_cat_bits->insert(collected_cat_bits->end(), that.cat_bits.cbegin(),
-                               that.cat_bits.cend());
-    cat_bits_sizes->emplace_back(that.cat_bits.size());
-  }
-
-  /**
-   * @brief Copy primitive fields into this, and collect cat_bits and gradient sums into vectors.
-   *
-   * This is used for allgather.
-   *
-   * @param that The other entry to copy from
-   * @param collected_cat_bits The vector to collect cat_bits
-   * @param cat_bits_sizes The sizes of the collected cat_bits
-   * @param collected_gradients The vector to collect gradients
-   */
-  template <typename G>
-  void CopyAndCollect(SplitEntryContainer<GradientT> const &that,
-                      std::vector<uint32_t> *collected_cat_bits,
-                      std::vector<std::size_t> *cat_bits_sizes,
-                      std::vector<G> *collected_gradients) {
-    loss_chg = that.loss_chg;
-    sindex = that.sindex;
-    split_value = that.split_value;
-    is_cat = that.is_cat;
-    collected_cat_bits->insert(collected_cat_bits->end(), that.cat_bits.cbegin(),
-                               that.cat_bits.cend());
-    cat_bits_sizes->emplace_back(that.cat_bits.size());
-    static_assert(!std::is_trivially_copyable_v<GradientT>);
-    collected_gradients->insert(collected_gradients->end(), that.left_sum.cbegin(),
-                                that.left_sum.cend());
-    collected_gradients->insert(collected_gradients->end(), that.right_sum.cbegin(),
-                                that.right_sum.cend());
-  }
-
   /*!\return feature index to split on */
   [[nodiscard]] bst_feature_t SplitIndex() const { return sindex & ((1U << 31) - 1U); }
   /*!\return whether missing value goes to left branch */
@@ -486,7 +433,7 @@ struct SplitEntryContainer {
    * \param e candidate split solution
    * \return whether the proposed split is better and can replace current split
    */
-  inline bool Update(const SplitEntryContainer &e) {
+  bool Update(const SplitEntryContainer &e) {
     if (this->NeedReplace(e.loss_chg, e.SplitIndex())) {
       this->loss_chg = e.loss_chg;
       this->sindex = e.sindex;

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -14,10 +14,9 @@
 #include <sstream>
 #include <type_traits>  // for is_floating_point_v
 
-#include "../common/categorical.h"      // for GetNodeCats
-#include "../common/common.h"           // for EscapeU8
-#include "io_utils.h"                   // for GetElem
-#include "multi_target_tree_model.cuh"  // for CopyBatch
+#include "../common/categorical.h"  // for GetNodeCats
+#include "../common/common.h"       // for EscapeU8
+#include "io_utils.h"               // for GetElem
 #include "param.h"
 #include "tree_view.h"
 #include "xgboost/base.h"
@@ -27,8 +26,11 @@
 
 namespace xgboost {
 namespace tree {
+void CopyCategoryStorage(Context const* ctx, std::size_t offset, ExpandBatch const& batch,
+                         HostDeviceVector<CatWordT>* out);
+
 DMLC_REGISTER_PARAMETER(TrainParam);
-}
+}  // namespace tree
 
 namespace {
 constexpr auto NoTruncate() { return std::numeric_limits<bst_target_t>::max(); }
@@ -878,24 +880,37 @@ void RegTree::ExpandNode(bst_node_t nid, unsigned split_index, bst_float split_v
   this->split_types_.HostVector().at(nid) = FeatureType::kNumerical;
 }
 
-void RegTree::ExpandNode(bst_node_t nidx, bst_feature_t split_index, float split_cond,
-                         bool default_left, linalg::VectorView<float const> base_weight,
-                         linalg::VectorView<float const> left_weight,
-                         linalg::VectorView<float const> right_weight, float loss_chg,
-                         float sum_hess, float left_sum, float right_sum) {
+void RegTree::Expand(Context const* ctx, tree::ExpandBatch const& batch) {
   CHECK(IsMultiTarget());
-  CHECK_LT(split_index, this->param_.num_feature);
-  CHECK(this->p_mt_tree_);
-  CHECK_GT(param_.size_leaf_vector, 1);
 
-  this->p_mt_tree_->Expand(nidx, split_index, split_cond, default_left, base_weight, left_weight,
-                           right_weight, loss_chg, sum_hess, left_sum, right_sum);
+  auto const categories_begin = split_categories_.Size();
+  this->p_mt_tree_->Expand(ctx, batch);
 
-  split_types_.HostVector().resize(this->Size(), FeatureType::kNumerical);
-  split_categories_segments_.HostVector().resize(this->Size());
-  this->split_types_.HostVector().at(nidx) = FeatureType::kNumerical;
+  auto const n_nodes = this->p_mt_tree_->Size();
+  auto& h_split_types = split_types_.HostVector();
+  h_split_types.resize(n_nodes, FeatureType::kNumerical);
+  auto& h_segments = split_categories_segments_.HostVector();
+  h_segments.resize(n_nodes);
 
-  this->param_.num_nodes = this->p_mt_tree_->Size();
+  if (batch.n_cat_words != 0) {
+    tree::CopyCategoryStorage(ctx, categories_begin, batch, &split_categories_);
+  }
+
+  std::size_t category_offset = categories_begin;
+  for (std::size_t i = 0; i < batch.Size(); ++i) {
+    auto nidx = batch.nidxs[i];
+    auto cats = batch.cat_bits[i];
+    if (cats.empty()) {
+      h_split_types[nidx] = FeatureType::kNumerical;
+      h_segments[nidx] = {};
+    } else {
+      h_split_types[nidx] = FeatureType::kCategorical;
+      h_segments[nidx] = CategoricalSplitMatrix::Segment{category_offset, cats.size()};
+      category_offset += cats.size();
+    }
+  }
+
+  this->param_.num_nodes = n_nodes;
 }
 
 void RegTree::SetLeaves(std::vector<bst_node_t> leaves, common::Span<float const> weights) {
@@ -912,29 +927,6 @@ void RegTree::ExpandCategorical(bst_node_t nidx, bst_feature_t split_index,
   CHECK(!IsMultiTarget());
   this->ExpandNode(nidx, split_index, DftBadValue(), default_left, base_weight, left_leaf_weight,
                    right_leaf_weight, loss_change, sum_hess, left_sum, right_sum);
-
-  auto& h_split_categories = split_categories_.HostVector();
-  std::size_t orig_size = h_split_categories.size();
-  h_split_categories.resize(orig_size + split_cat.size());
-  std::copy(split_cat.data(), split_cat.data() + split_cat.size(),
-            h_split_categories.begin() + orig_size);
-
-  this->split_types_.HostVector().at(nidx) = FeatureType::kCategorical;
-
-  auto& h_split_categories_segments = this->split_categories_segments_.HostVector();
-  h_split_categories_segments.at(nidx).beg = orig_size;
-  h_split_categories_segments.at(nidx).size = split_cat.size();
-}
-
-void RegTree::ExpandCategorical(bst_node_t nidx, bst_feature_t split_index,
-                                common::Span<common::KCatBitField::value_type> split_cat,
-                                bool default_left, linalg::VectorView<float const> base_weight,
-                                linalg::VectorView<float const> left_weight,
-                                linalg::VectorView<float const> right_weight, float loss_chg,
-                                float sum_hess, float left_sum, float right_sum) {
-  CHECK(IsMultiTarget());
-  this->ExpandNode(nidx, split_index, DftBadValue(), default_left, base_weight, left_weight,
-                   right_weight, loss_chg, sum_hess, left_sum, right_sum);
 
   auto& h_split_categories = split_categories_.HostVector();
   std::size_t orig_size = h_split_categories.size();

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -12,7 +12,7 @@
 #include <iomanip>
 #include <limits>  // for numeric_limits
 #include <sstream>
-#include <type_traits>  // for is_floating_point_v
+#include <type_traits>  // for is_floating_point_v, add_const_t
 
 #include "../common/categorical.h"  // for GetNodeCats
 #include "../common/common.h"       // for EscapeU8
@@ -922,12 +922,12 @@ void RegTree::SetLeaves(std::vector<bst_node_t> leaves, common::Span<float const
 }
 
 void RegTree::ExpandCategorical(bst_node_t nidx, bst_feature_t split_index,
-                                common::Span<common::KCatBitField::value_type> split_cat,
-                                bool default_left, bst_float base_weight,
-                                bst_float left_leaf_weight, bst_float right_leaf_weight,
-                                bst_float loss_change, float sum_hess, float left_sum,
-                                float right_sum) {
-  CHECK(!IsMultiTarget());
+                                common::Span<tree::CatWordT const> split_cat, bool default_left,
+                                bst_float base_weight, bst_float left_leaf_weight,
+                                bst_float right_leaf_weight, bst_float loss_change, float sum_hess,
+                                float left_sum, float right_sum) {
+  static_assert(std::is_same_v<common::KCatBitField::value_type, std::add_const_t<tree::CatWordT>>);
+  CHECK(!this->IsMultiTarget());
   this->ExpandNode(nidx, split_index, DftBadValue(), default_left, base_weight, left_leaf_weight,
                    right_leaf_weight, loss_change, sum_hess, left_sum, right_sum);
 

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -14,9 +14,10 @@
 #include <sstream>
 #include <type_traits>  // for is_floating_point_v
 
-#include "../common/categorical.h"  // for GetNodeCats
-#include "../common/common.h"       // for EscapeU8
-#include "io_utils.h"               // for GetElem
+#include "../common/categorical.h"      // for GetNodeCats
+#include "../common/common.h"           // for EscapeU8
+#include "io_utils.h"                   // for GetElem
+#include "multi_target_tree_model.cuh"  // for CopyBatch
 #include "param.h"
 #include "tree_view.h"
 #include "xgboost/base.h"

--- a/src/tree/tree_model.cc
+++ b/src/tree/tree_model.cc
@@ -16,6 +16,7 @@
 
 #include "../common/categorical.h"  // for GetNodeCats
 #include "../common/common.h"       // for EscapeU8
+#include "../common/nvtx_utils.h"   // for xgboost_NVTX_FN_RANGE
 #include "io_utils.h"               // for GetElem
 #include "param.h"
 #include "tree_view.h"
@@ -882,6 +883,8 @@ void RegTree::ExpandNode(bst_node_t nid, unsigned split_index, bst_float split_v
 
 void RegTree::Expand(Context const* ctx, tree::ExpandBatch const& batch) {
   CHECK(IsMultiTarget());
+
+  xgboost_NVTX_FN_RANGE();
 
   auto const categories_begin = split_categories_.Size();
   this->p_mt_tree_->Expand(ctx, batch);

--- a/src/tree/updater_approx.cc
+++ b/src/tree/updater_approx.cc
@@ -122,7 +122,7 @@ class GlobalApproxBuilder {
 
     auto const &histograms = histogram_builder_.Histogram(0);
     auto ft = p_fmat->Info().feature_types.ConstHostSpan();
-    evaluator_.EvaluateSplits(histograms, feature_values_, ft, *p_tree, &nodes);
+    evaluator_.EvaluateSplits(histograms, feature_values_, ft, &nodes);
     monitor_->Stop(__func__);
 
     return nodes.front();
@@ -230,7 +230,7 @@ class GlobalApproxBuilder {
         auto const &histograms = histogram_builder_.Histogram(0);
         auto ft = p_fmat->Info().feature_types.ConstHostSpan();
         monitor_->Start("EvaluateSplits");
-        evaluator_.EvaluateSplits(histograms, feature_values_, ft, *p_tree, &best_splits);
+        evaluator_.EvaluateSplits(histograms, feature_values_, ft, &best_splits);
         monitor_->Stop("EvaluateSplits");
       }
       driver.Push(best_splits.begin(), best_splits.end());

--- a/src/tree/updater_gpu_common.cuh
+++ b/src/tree/updater_gpu_common.cuh
@@ -69,8 +69,6 @@ struct DeviceSplitCandidate {
     }
   }
 
-  [[nodiscard]] XGBOOST_DEVICE bool IsValid() const { return loss_chg > 0.0f; }
-
   friend std::ostream& operator<<(std::ostream& os, DeviceSplitCandidate const& c) {
     os << "loss_chg:" << c.loss_chg << ", "
        << "dir: " << c.dir << ", "
@@ -128,8 +126,6 @@ struct MultiSplitCandidate {
       findex = findex_in;
     }
   }
-
-  [[nodiscard]] XGBOOST_DEVICE bool IsValid() const { return loss_chg > 0.0f; }
 };
 
 namespace cuda_impl {

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -13,7 +13,6 @@
 #include <utility>          // for move
 #include <vector>           // for vector
 
-#include "../../src/collective/comm.h"  // for Op
 #include "../collective/aggregator.h"
 #include "../collective/communicator-inl.h"  // for IsDistributed
 #include "../common/categorical.h"           // for KCatBitField

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -22,6 +22,7 @@
 #include "../common/device_helpers.cuh"
 #include "../common/device_vector.cuh"  // for device_vector
 #include "../common/hist_util.h"        // for HistogramCuts
+#include "../common/nvtx_utils.h"       // for xgboost_NVTX_FN_RANGE
 #include "../common/random.h"           // for ColumnSampler
 #include "../common/timer.h"
 #include "../data/batch_utils.h"     // for StaticBatch

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -386,8 +386,7 @@ struct GPUHistMakerDevice {
     // Prepare for build hist
     std::vector<bst_node_t> build_nidx(candidates.size());
     std::vector<bst_node_t> subtraction_nidx(candidates.size());
-    auto const& tree = p_tree->HostScView();
-    cuda_impl::AssignNodes(tree, candidates, build_nidx, subtraction_nidx,
+    cuda_impl::AssignNodes(*p_tree, candidates, build_nidx, subtraction_nidx,
                            [&](GPUExpandEntry const& e) {
                              auto const& q = (*this->quantiser)[0];
                              auto left_sum = q.ToFloatingPoint(e.split.left_sum);

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -308,6 +308,7 @@ class MultiTargetHistMaker {
 
     CHECK(!h_candidates.empty());
     auto n_targets = this->split_gpair_.Shape(1);
+    dh::device_vector<MultiExpandEntry> candidates{h_candidates};
 
     // Get weights by node ID from the evaluator's buffer.
     //
@@ -355,7 +356,6 @@ class MultiTargetHistMaker {
                                       mt_tree.RightChild(candidate.nidx));
     }
 
-    dh::device_vector<MultiExpandEntry> candidates{h_candidates};
     this->evaluator_.ApplyTreeSplit(this->ctx_, p_tree,
                                     common::Span<MultiExpandEntry const>{h_candidates},
                                     dh::ToSpan(candidates), n_targets);

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -42,8 +42,7 @@ template <typename GoLeftOp>
 struct GoLeftWrapperOp {
   GoLeftOp go_left;
   template <typename NodeSplitData>
-  __device__ bool operator()(RowIndexT ridx, int /*nidx_in_batch*/,
-                             const NodeSplitData& data) const {
+  __device__ bool operator()(RowIndexT ridx, const NodeSplitData& data) const {
     return go_left(ridx, data);
   }
 };

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -313,70 +313,33 @@ class MultiTargetHistMaker {
     // look up the persistent weight storage by node ID.
     auto weights = this->evaluator_.GetNodeWeights(n_targets);
 
-    ExpandBatch batch;
-    batch.eta = param_.learning_rate;
+    ExpandBatch batch{this->param_.learning_rate};
 
     for (auto const& candidate : h_candidates) {
-      batch.nidxs.push_back(candidate.nidx);
-      batch.fidxs.push_back(candidate.split.findex);
-      batch.conds.push_back(candidate.split.fvalue);
-      batch.dft_lefts.push_back(candidate.split.dir == kLeftDir);
-
       auto base_weight = weights.Base(candidate.nidx);
       auto left_weight = weights.Left(candidate.nidx);
       auto right_weight = weights.Right(candidate.nidx);
 
-      batch.base_weight_batch.emplace_back(base_weight);
-      batch.left_weight_batch.emplace_back(left_weight);
-      batch.right_weight_batch.emplace_back(right_weight);
-
-      batch.loss_chgs.push_back(candidate.split.loss_chg);
-      batch.left_sums.push_back(candidate.left_sum);
-      batch.right_sums.push_back(candidate.right_sum);
-    }
-
-    for (auto const& candidate : h_candidates) {
-      std::vector<float> h_base_weight(n_targets);
-      std::vector<float> h_left_weight(n_targets);
-      std::vector<float> h_right_weight(n_targets);
-      dh::CopyDeviceSpanToVector(&h_base_weight, weights.Base(candidate.nidx));
-      dh::CopyDeviceSpanToVector(&h_left_weight, weights.Left(candidate.nidx));
-      dh::CopyDeviceSpanToVector(&h_right_weight, weights.Right(candidate.nidx));
-      auto h_left_leaf = h_left_weight;
-      auto h_right_leaf = h_right_weight;
-      auto eta = this->param_.learning_rate;
-      std::transform(h_left_leaf.cbegin(), h_left_leaf.cend(), h_left_leaf.begin(),
-                     [=](float w) { return w * eta; });
-      std::transform(h_right_leaf.cbegin(), h_right_leaf.cend(), h_right_leaf.begin(),
-                     [=](float w) { return w * eta; });
-      // Get loss_chg from the split, and sum hessians for parent and children
-      auto loss_chg = candidate.split.loss_chg;
-      double sum_hess = candidate.left_sum + candidate.right_sum;
-      bool default_left = candidate.split.dir == kLeftDir;
+      common::Span<CatWordT const> cat_bits;
       if (candidate.split.is_cat) {
         auto fidx = candidate.split.findex;
-        auto cat_bits = this->evaluator_.GetHostNodeCats(candidate.nidx);
+        auto node_cats = this->evaluator_.GetNodeCats(candidate.nidx);
         auto n_bins_feature = this->cuts_->FeatureBins(fidx);
         auto n_words = common::CatBitField::ComputeStorageSize(n_bins_feature);
-        CHECK_LE(n_words, cat_bits.size());
-        cat_bits.resize(n_words);
-        p_tree->ExpandCategorical(candidate.nidx, fidx, cat_bits, default_left,
-                                  linalg::MakeVec(h_base_weight), linalg::MakeVec(h_left_leaf),
-                                  linalg::MakeVec(h_right_leaf), loss_chg, sum_hess,
-                                  candidate.left_sum, candidate.right_sum);
-      } else {
-        p_tree->ExpandNode(candidate.nidx, candidate.split.findex, candidate.split.fvalue,
-                           default_left, linalg::MakeVec(h_base_weight),
-                           linalg::MakeVec(h_left_leaf), linalg::MakeVec(h_right_leaf), loss_chg,
-                           sum_hess, candidate.left_sum, candidate.right_sum);
+        CHECK_LE(n_words, node_cats.size());
+        cat_bits = node_cats.subspan(0, n_words);
       }
+      batch.Push(candidate.nidx, candidate.split.findex, candidate.split.fvalue,
+                 candidate.split.dir == kLeftDir, base_weight, left_weight, right_weight,
+                 candidate.split.loss_chg, candidate.left_sum, candidate.right_sum, cat_bits);
     }
 
-    auto mt_tree = p_tree->HostMtView();
+    p_tree->Expand(this->ctx_, batch);
+
     for (auto const& candidate : h_candidates) {
       interaction_constraints_->Split(this->ctx_, candidate.nidx, candidate.split.findex,
-                                      mt_tree.LeftChild(candidate.nidx),
-                                      mt_tree.RightChild(candidate.nidx));
+                                      p_tree->LeftChild(candidate.nidx),
+                                      p_tree->RightChild(candidate.nidx));
     }
 
     this->evaluator_.ApplyTreeSplit(this->ctx_, p_tree,
@@ -463,17 +426,15 @@ class MultiTargetHistMaker {
   PartitionNodes CreatePartitionNodes(RegTree const* p_tree,
                                       std::vector<MultiExpandEntry> const& candidates) {
     PartitionNodes nodes(candidates.size());
-    auto tree = p_tree->HostMtView();
-    // TODO(jiamingy) Avoid pulling the host tree.
+    auto split_types = p_tree->GetSplitTypes(DeviceOrd::CPU());
     for (std::size_t i = 0, n = candidates.size(); i < n; i++) {
       auto const& e = candidates[i];
-      auto split_type = tree.SplitType(e.nidx);
       nodes.nidx.at(i) = e.nidx;
-      nodes.left_nidx[i] = tree.LeftChild(e.nidx);
-      nodes.right_nidx[i] = tree.RightChild(e.nidx);
+      nodes.left_nidx[i] = p_tree->LeftChild(e.nidx);
+      nodes.right_nidx[i] = p_tree->RightChild(e.nidx);
       nodes.split_data[i] = NodeSplitData{e.nidx};
 
-      CHECK_EQ(split_type == FeatureType::kCategorical, e.split.is_cat);
+      CHECK_EQ(split_types[e.nidx] == FeatureType::kCategorical, e.split.is_cat);
     }
     return nodes;
   }
@@ -554,8 +515,7 @@ class MultiTargetHistMaker {
 
     std::vector<bst_node_t> build_nidx(candidates.size());
     std::vector<bst_node_t> subtraction_nidx(candidates.size());
-    auto mt_tree = p_tree->HostMtView();
-    AssignNodes(mt_tree, candidates, build_nidx, subtraction_nidx, [](MultiExpandEntry const& e) {
+    AssignNodes(*p_tree, candidates, build_nidx, subtraction_nidx, [](MultiExpandEntry const& e) {
       bool fewer_right = e.right_sum < e.left_sum;
       return fewer_right;
     });
@@ -614,15 +574,16 @@ class MultiTargetHistMaker {
 
     for (std::size_t i = 0; i < candidates.size(); i++) {
       auto candidate = candidates.at(i);
-      bst_node_t left_nidx = mt_tree.LeftChild(candidate.nidx);
-      bst_node_t right_nidx = mt_tree.RightChild(candidate.nidx);
+      bst_node_t left_nidx = tree.LeftChild(candidate.nidx);
+      bst_node_t right_nidx = tree.RightChild(candidate.nidx);
 
-      auto left_sampled_features = column_sampler_->GetFeatureSet(ctx_, tree.GetDepth(left_nidx));
+      auto child_depth = candidate.depth + 1;
+      auto left_sampled_features = column_sampler_->GetFeatureSet(ctx_, child_depth);
       feature_sets.emplace_back(left_sampled_features);
       common::Span<bst_feature_t const> left_feature_set =
           interaction_constraints_->Query(left_sampled_features->ConstDeviceSpan(), left_nidx);
 
-      auto right_sampled_features = column_sampler_->GetFeatureSet(ctx_, tree.GetDepth(right_nidx));
+      auto right_sampled_features = column_sampler_->GetFeatureSet(ctx_, child_depth);
       feature_sets.emplace_back(right_sampled_features);
       common::Span<bst_feature_t const> right_feature_set =
           interaction_constraints_->Query(right_sampled_features->ConstDeviceSpan(), right_nidx);

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -310,15 +310,39 @@ class MultiTargetHistMaker {
     auto n_targets = this->split_gpair_.Shape(1);
     dh::device_vector<MultiExpandEntry> candidates{h_candidates};
 
-    // Get weights by node ID from the evaluator's buffer.
-    //
-    // TODO(jiamingy):
-    // - Avoid device to host copies.
-    // - Apply expand in batches
+    // Candidate spans can become stale while entries wait in the loss-guide queue, so
+    // look up the persistent weight storage by node ID.
+    auto weights = this->evaluator_.GetNodeWeights(n_targets);
+
+    ExpandBatch batch;
+    batch.eta = param_.learning_rate;
+
     for (auto const& candidate : h_candidates) {
-      std::vector<float> h_base_weight, h_left_weight, h_right_weight;
-      this->evaluator_.CopyNodeWeightsToHost(candidate.nidx, n_targets, &h_base_weight,
-                                             &h_left_weight, &h_right_weight);
+      batch.nidxs.push_back(candidate.nidx);
+      batch.fidxs.push_back(candidate.split.findex);
+      batch.conds.push_back(candidate.split.fvalue);
+      batch.dft_lefts.push_back(candidate.split.dir == kLeftDir);
+
+      auto base_weight = weights.Base(candidate.nidx);
+      auto left_weight = weights.Left(candidate.nidx);
+      auto right_weight = weights.Right(candidate.nidx);
+
+      batch.base_weight_batch.emplace_back(base_weight);
+      batch.left_weight_batch.emplace_back(left_weight);
+      batch.right_weight_batch.emplace_back(right_weight);
+
+      batch.loss_chgs.push_back(candidate.split.loss_chg);
+      batch.left_sums.push_back(candidate.left_sum);
+      batch.right_sums.push_back(candidate.right_sum);
+    }
+
+    for (auto const& candidate : h_candidates) {
+      std::vector<float> h_base_weight(n_targets);
+      std::vector<float> h_left_weight(n_targets);
+      std::vector<float> h_right_weight(n_targets);
+      dh::CopyDeviceSpanToVector(&h_base_weight, weights.Base(candidate.nidx));
+      dh::CopyDeviceSpanToVector(&h_left_weight, weights.Left(candidate.nidx));
+      dh::CopyDeviceSpanToVector(&h_right_weight, weights.Right(candidate.nidx));
       auto h_left_leaf = h_left_weight;
       auto h_right_leaf = h_right_weight;
       auto eta = this->param_.learning_rate;

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -283,8 +283,7 @@ class MultiTargetHistMaker {
     auto sampled_features = column_sampler_->GetFeatureSet(ctx_, 0);
     common::Span<bst_feature_t const> feature_set =
         interaction_constraints_->Query(sampled_features->ConstDeviceSpan(), RegTree::kRoot);
-    MultiEvaluateSplitInputs input{RegTree::kRoot, p_tree->GetDepth(RegTree::kRoot), d_root_sum,
-                                   feature_set, node_hist};
+    MultiEvaluateSplitInputs input{RegTree::kRoot, 0, d_root_sum, feature_set, node_hist};
 
     auto shared_inputs = MakeSharedInputs(static_cast<bst_feature_t>(feature_set.size()));
     auto entry = this->evaluator_.EvaluateSingleSplit(ctx_, input, shared_inputs);
@@ -567,7 +566,7 @@ class MultiTargetHistMaker {
     histogram_.AllocateHistograms(this->ctx_, build_nidx, subtraction_nidx);
 
     // Pull to device (stats not needed for partitioning)
-    mt_tree = MultiTargetTreeView{this->ctx_->Device(), false, p_tree};
+    auto mt_tree = MultiTargetTreeView{this->ctx_->Device(), false, p_tree};
 
     std::int32_t k{0};
     for (auto const& page :
@@ -603,7 +602,6 @@ class MultiTargetHistMaker {
     dh::device_vector<MultiEvaluateSplitInputs> inputs(2 * candidates.size());
     dh::device_vector<MultiExpandEntry> outputs(2 * candidates.size());
 
-    auto mt_tree = tree.HostMtView();
     std::vector<MultiEvaluateSplitInputs> h_node_inputs(candidates.size() * 2);
 
     // Store the feature set ptrs so they don't go out of scope before the kernel is called

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -275,8 +275,7 @@ class MultiTargetHistBuilder {
     monitor_->Stop(__func__);
   }
 
-  void EvaluateSplits(DMatrix *p_fmat, RegTree const *p_tree,
-                      std::vector<MultiExpandEntry> *best_splits) {
+  void EvaluateSplits(DMatrix *p_fmat, std::vector<MultiExpandEntry> *best_splits) {
     monitor_->Start(__func__);
     std::vector<BoundedHistCollection const *> hists;
     // Use histogram builder's number of targets (may differ from tree for reduced gradient)
@@ -286,7 +285,7 @@ class MultiTargetHistBuilder {
     }
     auto ft = p_fmat->Info().feature_types.ConstHostSpan();
     for (auto const &gmat : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, HistBatch(param_))) {
-      evaluator_->EvaluateSplits(*p_tree, hists, gmat.cut, ft, best_splits);
+      evaluator_->EvaluateSplits(hists, gmat.cut, ft, best_splits);
       break;
     }
     monitor_->Stop(__func__);
@@ -492,13 +491,12 @@ class HistUpdater {
     monitor_->Stop(__func__);
   }
 
-  void EvaluateSplits(DMatrix *p_fmat, RegTree const *p_tree,
-                      std::vector<CPUExpandEntry> *best_splits) {
+  void EvaluateSplits(DMatrix *p_fmat, std::vector<CPUExpandEntry> *best_splits) {
     monitor_->Start(__func__);
     auto const &histograms = histogram_builder_->Histogram(0);
     auto ft = p_fmat->Info().feature_types.ConstHostSpan();
     for (auto const &gmat : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, HistBatch(param_))) {
-      evaluator_->EvaluateSplits(histograms, gmat.cut, ft, *p_tree, best_splits);
+      evaluator_->EvaluateSplits(histograms, gmat.cut, ft, best_splits);
       break;
     }
     monitor_->Stop(__func__);
@@ -553,8 +551,7 @@ class HistUpdater {
       monitor_->Start("EvaluateSplits");
       auto ft = p_fmat->Info().feature_types.ConstHostSpan();
       for (auto const &gmat : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, HistBatch(param_))) {
-        evaluator_->EvaluateSplits(histogram_builder_->Histogram(0), gmat.cut, ft, *p_tree,
-                                   &entries);
+        evaluator_->EvaluateSplits(histogram_builder_->Histogram(0), gmat.cut, ft, &entries);
         break;
       }
       monitor_->Stop("EvaluateSplits");

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -39,7 +39,6 @@
 #include "xgboost/linalg.h"                  // for MatrixView, TensorView, All, Matrix, Empty
 #include "xgboost/logging.h"                 // for LogCheck_EQ, CHECK_EQ, CHECK, LogCheck_GE
 #include "xgboost/span.h"                    // for Span, operator!=, SpanIterator
-#include "xgboost/string_view.h"             // for operator<<
 #include "xgboost/task.h"                    // for ObjInfo
 #include "xgboost/tree_model.h"              // for RegTree, MTNotImplemented, RTreeNodeStat
 #include "xgboost/tree_updater.h"            // for TreeUpdater, TreeUpdaterReg, XGBOOST_REGISTE...
@@ -133,12 +132,13 @@ void UpdateTree(common::Monitor *monitor, linalg::MatrixView<GradientPair const>
       for (auto const &candidate : valid_candidates) {
         auto left_child_nidx = tree.LeftChild(candidate.nid);
         auto right_child_nidx = tree.RightChild(candidate.nid);
-        ExpandEntry l_best{left_child_nidx, tree.GetDepth(left_child_nidx)};
-        ExpandEntry r_best{right_child_nidx, tree.GetDepth(right_child_nidx)};
+        auto child_depth = candidate.depth + 1;
+        ExpandEntry l_best{left_child_nidx, child_depth};
+        ExpandEntry r_best{right_child_nidx, child_depth};
         best_splits.push_back(l_best);
         best_splits.push_back(r_best);
       }
-      updater->EvaluateSplits(p_fmat, p_tree, &best_splits);
+      updater->EvaluateSplits(p_fmat, &best_splits);
     }
     driver.Push(best_splits.begin(), best_splits.end());
     expand_set = driver.Pop();
@@ -258,7 +258,7 @@ class MultiTargetHistBuilder {
     }
     auto ft = p_fmat->Info().feature_types.ConstHostSpan();
     for (auto const &gmat : p_fmat->GetBatches<GHistIndexMatrix>(ctx_, HistBatch(param_))) {
-      evaluator_->EvaluateSplits(*p_tree, hists, gmat.cut, ft, &nodes);
+      evaluator_->EvaluateSplits(hists, gmat.cut, ft, &nodes);
       break;
     }
     monitor_->Stop(__func__);

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -553,10 +553,11 @@ void TestVectorLeafPrediction(Context const *ctx) {
 
   auto &tree = trees.front();
   tree->SetRoot(linalg::MakeVec(p_w.data(), p_w.size()), /*sum_hess=*/1.0f);
-  tree->ExpandNode(0, static_cast<bst_feature_t>(1), 2.0, true,
-                   linalg::MakeVec(p_w.data(), p_w.size()), linalg::MakeVec(l_w.data(), l_w.size()),
-                   linalg::MakeVec(r_w.data(), r_w.size()), /*loss_chg=*/0.5f, /*sum_hess=*/1.0f,
-                   /*left_sum=*/0.6f, /*right_sum=*/0.4f);
+  Context tree_ctx;
+  xgboost::tree::ExpandBatch batch{1.0f};
+  batch.Push(0, static_cast<bst_feature_t>(1), 2.0, true, p_w, l_w, r_w,
+             /*loss_chg=*/0.5f, /*left_sum=*/0.6f, /*right_sum=*/0.4f);
+  tree->Expand(&tree_ctx, batch);
   tree->GetMultiTargetTree()->SetLeaves();
   ASSERT_TRUE(tree->IsMultiTarget());
   ASSERT_TRUE(mparam.IsVectorLeaf());

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -171,7 +171,9 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalOneHot) {
   // is the non-missing "other categories" (left child), so dir is kRightDir.
   ASSERT_EQ(candidate.split.dir, kRightDir);
   ASSERT_EQ(static_cast<bst_cat_t>(candidate.split.fvalue), 3);
-  auto h_cats = evaluator.GetHostNodeCats(candidate.nidx);
+  auto d_cats = evaluator.GetNodeCats(candidate.nidx);
+  std::vector<std::uint32_t> h_cats(d_cats.size());
+  dh::CopyDeviceSpanToVector(&h_cats, d_cats);
   common::KCatBitField cats{h_cats};
   ASSERT_TRUE(cats.Check(3));
 
@@ -221,7 +223,9 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   ASSERT_EQ(candidate.split.findex, 0);
   ASSERT_TRUE(std::isnan(candidate.split.fvalue));
   ASSERT_EQ(candidate.split.thresh, 1);
-  auto h_cats = evaluator.GetHostNodeCats(candidate.nidx);
+  auto d_cats = evaluator.GetNodeCats(candidate.nidx);
+  std::vector<std::uint32_t> h_cats(d_cats.size());
+  dh::CopyDeviceSpanToVector(&h_cats, d_cats);
   common::KCatBitField cats{h_cats};
   ASSERT_FALSE(cats.Check(0));
   ASSERT_FALSE(cats.Check(1));

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -103,8 +103,7 @@ void AssertDeviceVecEq(common::Span<T> span, std::vector<V> const& exp) {
 }
 
 void AssertNodeWeightsEq(MultiHistEvaluator& evaluator, bst_node_t nidx,
-                         std::vector<float> const& exp_base,
-                         std::vector<float> const& exp_left,
+                         std::vector<float> const& exp_base, std::vector<float> const& exp_left,
                          std::vector<float> const& exp_right) {
   ASSERT_EQ(exp_base.size(), exp_left.size());
   ASSERT_EQ(exp_base.size(), exp_right.size());

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -102,13 +102,13 @@ void AssertDeviceVecEq(common::Span<T> span, std::vector<V> const& exp) {
   AssertVecEq(h_vec, exp);
 }
 
-void AssertNodeWeightsEq(MultiHistEvaluator& evaluator, bst_node_t nidx,
+void AssertNodeWeightsEq(MultiHistEvaluator* evaluator, bst_node_t nidx,
                          std::vector<float> const& exp_base, std::vector<float> const& exp_left,
                          std::vector<float> const& exp_right) {
   ASSERT_EQ(exp_base.size(), exp_left.size());
   ASSERT_EQ(exp_base.size(), exp_right.size());
   auto n_targets = static_cast<bst_target_t>(exp_base.size());
-  auto weights = evaluator.GetNodeWeights(n_targets);
+  auto weights = evaluator->GetNodeWeights(n_targets);
   AssertDeviceVecEq(weights.Base(nidx), exp_base);
   AssertDeviceVecEq(weights.Left(nidx), exp_left);
   AssertDeviceVecEq(weights.Right(nidx), exp_right);
@@ -133,7 +133,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, Root) {
     auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
     ASSERT_NEAR(candidate.split.loss_chg, 3.04239, 1e-5);
 
-    AssertNodeWeightsEq(evaluator, candidate.nidx, exp_base_weight, exp_left_weight,
+    AssertNodeWeightsEq(&evaluator, candidate.nidx, exp_base_weight, exp_left_weight,
                         exp_right_weight);
 
     std::stringstream ss;
@@ -193,7 +193,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalOneHot) {
   std::vector<float> exp_base_weight{-1.4, -0.75};
   std::vector<float> exp_left_weight{-1.5, -0.655172};
   std::vector<float> exp_right_weight{-1.25, -0.951219};
-  AssertNodeWeightsEq(evaluator, candidate.nidx, exp_base_weight, exp_left_weight,
+  AssertNodeWeightsEq(&evaluator, candidate.nidx, exp_base_weight, exp_left_weight,
                       exp_right_weight);
 }
 
@@ -241,7 +241,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   std::vector<GradientPairInt64> exp_child_sum{{-2, 2}, {-2, 2}};
   AssertDeviceVecEq(candidate.split.child_sum, exp_child_sum);
 
-  AssertNodeWeightsEq(evaluator, candidate.nidx, std::vector<float>{2.25f, 1.75f},
+  AssertNodeWeightsEq(&evaluator, candidate.nidx, std::vector<float>{2.25f, 1.75f},
                       std::vector<float>{3.5f, 2.5f}, std::vector<float>{1.0f, 1.0f});
   ASSERT_EQ(candidate.left_sum, 4.0);
   ASSERT_EQ(candidate.right_sum, 4.0);

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -101,6 +101,19 @@ void AssertDeviceVecEq(common::Span<T> span, std::vector<V> const& exp) {
   dh::CopyDeviceSpanToVector(&h_vec, span);
   AssertVecEq(h_vec, exp);
 }
+
+void AssertNodeWeightsEq(MultiHistEvaluator& evaluator, bst_node_t nidx,
+                         std::vector<float> const& exp_base,
+                         std::vector<float> const& exp_left,
+                         std::vector<float> const& exp_right) {
+  ASSERT_EQ(exp_base.size(), exp_left.size());
+  ASSERT_EQ(exp_base.size(), exp_right.size());
+  auto n_targets = static_cast<bst_target_t>(exp_base.size());
+  auto weights = evaluator.GetNodeWeights(n_targets);
+  AssertDeviceVecEq(weights.Base(nidx), exp_base);
+  AssertDeviceVecEq(weights.Left(nidx), exp_left);
+  AssertDeviceVecEq(weights.Right(nidx), exp_right);
+}
 }  // namespace
 
 TEST_F(GpuMultiHistEvaluatorBasicTest, Root) {
@@ -121,12 +134,8 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, Root) {
     auto candidate = evaluator.EvaluateSingleSplit(&ctx, input, shared);
     ASSERT_NEAR(candidate.split.loss_chg, 3.04239, 1e-5);
 
-    std::vector<float> base, left, right;
-    evaluator.CopyNodeWeightsToHost(candidate.nidx, candidate.base_weight.size(), &base, &left,
-                                    &right);
-    AssertVecEq(base, exp_base_weight);
-    AssertVecEq(left, exp_left_weight);
-    AssertVecEq(right, exp_right_weight);
+    AssertNodeWeightsEq(evaluator, candidate.nidx, exp_base_weight, exp_left_weight,
+                        exp_right_weight);
 
     std::stringstream ss;
     ss << candidate;
@@ -181,16 +190,12 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalOneHot) {
   std::vector<GradientPairInt64> exp_child_sum{{36, 24}, {57, 87}};
   AssertDeviceVecEq(candidate.split.child_sum, exp_child_sum);
 
-  std::vector<float> base, left, right;
-  evaluator.CopyNodeWeightsToHost(candidate.nidx, candidate.base_weight.size(), &base, &left,
-                                  &right);
   // Left child = other categories {36,24},{57,87}; right child = category 3 {20,16},{39,41}.
   std::vector<float> exp_base_weight{-1.4, -0.75};
   std::vector<float> exp_left_weight{-1.5, -0.655172};
   std::vector<float> exp_right_weight{-1.25, -0.951219};
-  AssertVecEq(base, exp_base_weight);
-  AssertVecEq(left, exp_left_weight);
-  AssertVecEq(right, exp_right_weight);
+  AssertNodeWeightsEq(evaluator, candidate.nidx, exp_base_weight, exp_left_weight,
+                      exp_right_weight);
 }
 
 TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
@@ -237,12 +242,8 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   std::vector<GradientPairInt64> exp_child_sum{{-2, 2}, {-2, 2}};
   AssertDeviceVecEq(candidate.split.child_sum, exp_child_sum);
 
-  std::vector<float> base, left, right;
-  evaluator.CopyNodeWeightsToHost(candidate.nidx, candidate.base_weight.size(), &base, &left,
-                                  &right);
-  AssertVecEq(base, std::vector<float>{2.25f, 1.75f});
-  AssertVecEq(left, std::vector<float>{3.5f, 2.5f});
-  AssertVecEq(right, std::vector<float>{1.0f, 1.0f});
+  AssertNodeWeightsEq(evaluator, candidate.nidx, std::vector<float>{2.25f, 1.75f},
+                      std::vector<float>{3.5f, 2.5f}, std::vector<float>{1.0f, 1.0f});
   ASSERT_EQ(candidate.left_sum, 4.0);
   ASSERT_EQ(candidate.right_sum, 4.0);
 
@@ -259,7 +260,8 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
 
   ASSERT_TRUE(no_split.split.child_sum.empty());
   ASSERT_FALSE(IsValidExpandEntry(no_split, no_split_param, 100));
-  AssertDeviceVecEq(no_split.base_weight, std::vector<float>{2.25f, 1.75f});
+  auto no_split_weights = no_split_evaluator.GetNodeWeights(shared.Targets());
+  AssertDeviceVecEq(no_split_weights.Base(no_split.nidx), std::vector<float>{2.25f, 1.75f});
   ASSERT_EQ(no_split.left_sum, 8.0);
   ASSERT_EQ(no_split.right_sum, 0.0);
 }

--- a/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
+++ b/tests/cpp/tree/gpu_hist/test_multi_evaluate_splits.cu
@@ -5,6 +5,7 @@
 
 #include <cmath>  // for isnan
 
+#include "../../../../src/tree/driver.h"
 #include "../../../../src/tree/gpu_hist/evaluate_splits.cuh"
 #include "../../../../src/tree/gpu_hist/multi_evaluate_splits.cuh"
 #include "../../helpers.h"
@@ -253,7 +254,7 @@ TEST_F(GpuMultiHistEvaluatorBasicTest, CategoricalPartition) {
   auto no_split = no_split_evaluator.EvaluateSingleSplit(&ctx, input, shared);
 
   ASSERT_TRUE(no_split.split.child_sum.empty());
-  ASSERT_FALSE(no_split.IsValid(no_split_param, 100));
+  ASSERT_FALSE(IsValidExpandEntry(no_split, no_split_param, 100));
   AssertDeviceVecEq(no_split.base_weight, std::vector<float>{2.25f, 1.75f});
   ASSERT_EQ(no_split.left_sum, 8.0);
   ASSERT_EQ(no_split.right_sum, 0.0);

--- a/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
+++ b/tests/cpp/tree/gpu_hist/test_row_partitioner.cu
@@ -37,9 +37,8 @@ void TestUpdatePositionBatch() {
   dh::DeviceUVector<cuda_impl::RowIndexT> ridx_tmp(kNumRows);
   // Send the first five training instances to the right node
   // and the second 5 to the left node
-  rp.UpdatePositionBatch(
-      &ctx, {0}, {1}, {2}, extra_data, dh::ToSpan(ridx_tmp),
-      [=] __device__(RowPartitioner::RowIndexT ridx, int, int) { return ridx > 4; });
+  rp.UpdatePositionBatch(&ctx, {0}, {1}, {2}, extra_data, dh::ToSpan(ridx_tmp),
+                         [=] __device__(RowPartitioner::RowIndexT ridx, int) { return ridx > 4; });
   rows = rp.GetRowsHost(1);
   for (auto r : rows) {
     EXPECT_GT(r, 4);
@@ -50,9 +49,8 @@ void TestUpdatePositionBatch() {
   }
 
   // Split the left node again
-  rp.UpdatePositionBatch(
-      &ctx, {1}, {3}, {4}, extra_data, dh::ToSpan(ridx_tmp),
-      [=] __device__(RowPartitioner::RowIndexT ridx, int, int) { return ridx < 7; });
+  rp.UpdatePositionBatch(&ctx, {1}, {3}, {4}, extra_data, dh::ToSpan(ridx_tmp),
+                         [=] __device__(RowPartitioner::RowIndexT ridx, int) { return ridx < 7; });
   EXPECT_EQ(rp.GetRows(3).size(), 2);
   EXPECT_EQ(rp.GetRows(4).size(), 3);
 }
@@ -65,7 +63,7 @@ void TestSortPositionBatch(const std::vector<int>& ridx_in, const std::vector<Se
   thrust::device_vector<cuda_impl::RowIndexT> ridx_tmp(ridx_in.size());
   thrust::device_vector<cuda_impl::RowIndexT> counts(segments.size());
 
-  auto op = [=] __device__(auto ridx, int split_index, int data) {
+  auto op = [=] __device__(auto ridx, int data) {
     return ridx % 2 == 0;
   };  // NOLINT
   std::vector<int> op_data(segments.size());
@@ -127,8 +125,7 @@ template <typename Accessor>
 struct LessThanOp {
   Accessor acc;
   explicit LessThanOp(Accessor acc) : acc{acc} {}
-  __device__ bool operator()(bst_idx_t ridx, std::int32_t nidx_in_batch,
-                             RegTree::Node const& node) const {
+  __device__ bool operator()(bst_idx_t ridx, RegTree::Node const& node) const {
     auto fvalue = acc.GetFvalue(ridx, node.SplitIndex());
     return fvalue <= node.SplitCond();
   }
@@ -220,9 +217,7 @@ void TestEmptyNode(std::int32_t n_workers) {
     dh::DeviceUVector<cuda_impl::RowIndexT> ridx_tmp(n_samples);
     partitioner.UpdatePositionBatch(
         &ctx, {0}, {1}, {2}, splits, dh::ToSpan(ridx_tmp),
-        [] XGBOOST_DEVICE(bst_idx_t ridx, std::int32_t /*nidx_in_batch*/, RegTree::Node) {
-          return ridx < 3;
-        });
+        [] XGBOOST_DEVICE(bst_idx_t ridx, RegTree::Node) { return ridx < 3; });
     ASSERT_EQ(partitioner.GetNumNodes(), 3);
     if (collective::GetRank() == 0) {
       for (std::size_t i = 0; i < 3; ++i) {

--- a/tests/cpp/tree/hist/test_evaluate_splits.cc
+++ b/tests/cpp/tree/hist/test_evaluate_splits.cc
@@ -131,13 +131,12 @@ void TestEvaluateSplits(bool force_read_by_column) {
     total_gpair += GradientPairPrecise(e);
   }
 
-  RegTree tree;
   std::vector<CPUExpandEntry> entries(1);
   entries.front().nid = 0;
   entries.front().depth = 0;
 
   evaluator.InitRoot(GradStats{total_gpair});
-  evaluator.EvaluateSplits(hist, gmat.cut, {}, tree, &entries);
+  evaluator.EvaluateSplits(hist, gmat.cut, {}, &entries);
 
   auto best_loss_chg = evaluator.Evaluator().CalcSplitGain(
                            param, 0, entries.front().split.SplitIndex(),
@@ -198,14 +197,7 @@ TEST(HistMultiEvaluator, Evaluate) {
     root_sum(t) += node_hist[1];
   }
 
-  RegTree tree{n_targets, n_features};
   auto weight = evaluator.InitRoot(root_sum.HostView());
-  // Compute root sum_hess by summing hessians across all targets
-  float root_sum_hess = 0.0f;
-  for (bst_target_t t{0}; t < n_targets; ++t) {
-    root_sum_hess += static_cast<float>(root_sum.HostView()(t).GetHess());
-  }
-  tree.SetRoot(weight.HostView(), root_sum_hess);
   auto w = weight.HostView();
   ASSERT_EQ(w.Size(), n_targets);
   ASSERT_EQ(w(0), -1.5);
@@ -221,7 +213,7 @@ TEST(HistMultiEvaluator, Evaluate) {
   std::transform(histogram.cbegin(), histogram.cend(), std::back_inserter(ptrs),
                  [](auto const &h) { return std::addressof(h); });
 
-  evaluator.EvaluateSplits(tree, ptrs, cuts, {}, &entries);
+  evaluator.EvaluateSplits(ptrs, cuts, {}, &entries);
 
   ASSERT_EQ(entries.front().split.loss_chg, 12.5);
   ASSERT_EQ(entries.front().split.split_value, 0.5);
@@ -269,9 +261,8 @@ TEST_F(TestPartitionBasedSplit, CPUHist) {
   auto sampler = std::make_shared<common::ColumnSampler>();
   HistEvaluator evaluator{&ctx, &param_, info_, sampler};
   evaluator.InitRoot(GradStats{total_gpair_});
-  RegTree tree;
   std::vector<CPUExpandEntry> entries(1);
-  evaluator.EvaluateSplits(hist_, cuts_, {ft}, tree, &entries);
+  evaluator.EvaluateSplits(hist_, cuts_, {ft}, &entries);
   ASSERT_NEAR(entries[0].split.loss_chg, best_score_, 1e-16);
 }
 
@@ -319,9 +310,8 @@ auto CompareOneHotAndPartition(bool onehot) {
       node_hist[i] = {static_cast<double>(node_hist.size() - i), 1.0};
       total_gpair += node_hist[i];
     }
-    RegTree tree;
     evaluator.InitRoot(GradStats{total_gpair});
-    evaluator.EvaluateSplits(hist, gmat.cut, ft, tree, &entries);
+    evaluator.EvaluateSplits(hist, gmat.cut, ft, &entries);
   }
   return entries.front();
 }
@@ -352,8 +342,7 @@ TEST_F(TestCategoricalSplitWithMissing, HistEvaluator) {
   auto evaluator = HistEvaluator{&ctx, &param_, info, sampler};
   evaluator.InitRoot(GradStats{parent_sum_});
   std::vector<CPUExpandEntry> entries(1);
-  RegTree tree;
-  evaluator.EvaluateSplits(hist, cuts_, info.feature_types.ConstHostSpan(), tree, &entries);
+  evaluator.EvaluateSplits(hist, cuts_, info.feature_types.ConstHostSpan(), &entries);
   auto const &split = entries.front().split;
 
   this->CheckResult(split.loss_chg, split.SplitIndex(), split.split_value, split.is_cat,
@@ -434,7 +423,7 @@ class TestHistMultiEvaluator : public ::testing::Test {
     }
     tree_.SetRoot(weight.HostView(), root_sum_hess);
 
-    evaluator_->EvaluateSplits(tree_, histogram_ptrs_, cuts_, info_.feature_types.ConstHostSpan(),
+    evaluator_->EvaluateSplits(histogram_ptrs_, cuts_, info_.feature_types.ConstHostSpan(),
                                &entries_);
   }
 

--- a/tests/cpp/tree/test_multi_target_tree_model.cc
+++ b/tests/cpp/tree/test_multi_target_tree_model.cc
@@ -12,9 +12,25 @@
 #include <memory>   // for unique_ptr
 #include <numeric>  // for iota
 
+#include "../../../src/common/categorical.h"  // for CatBitField, GetNodeCats
+#include "../../../src/tree/io_utils.h"       // for DftBadValue
 #include "../../../src/tree/tree_view.h"
+#include "../helpers.h"  // for AssertVecEq
 
 namespace xgboost {
+namespace {
+void Expand(RegTree* p_tree, bst_node_t nidx, bst_feature_t fidx, float cond, bool dft_left,
+            linalg::VectorView<float const> base_weight,
+            linalg::VectorView<float const> left_weight,
+            linalg::VectorView<float const> right_weight, float loss_chg, double left_sum,
+            double right_sum, float eta = 1.0f, common::Span<tree::CatWordT const> cat_bits = {}) {
+  tree::ExpandBatch batch{base_weight.Device(), eta};
+  batch.Push(nidx, fidx, cond, dft_left, base_weight.Values(), left_weight.Values(),
+             right_weight.Values(), loss_chg, left_sum, right_sum, cat_bits);
+  p_tree->Expand(batch);
+}
+}  // namespace
+
 std::unique_ptr<RegTree> MakeMtTreeForTest(bst_target_t n_targets) {
   bst_feature_t n_features{4};
   std::unique_ptr<RegTree> tree{std::make_unique<RegTree>(n_targets, n_features)};
@@ -43,9 +59,9 @@ std::unique_ptr<RegTree> MakeMtTreeForTest(bst_target_t n_targets) {
     iota_weights(3.0f, data, shape);
   });
 
-  tree->ExpandNode(RegTree::kRoot, /*split_idx=*/1, 0.5f, true, base_weight.HostView(),
-                   left_weight.HostView(), right_weight.HostView(), /*loss_chg=*/0.5f,
-                   /*sum_hess=*/1.0f, /*left_sum=*/0.6f, /*right_sum=*/0.4f);
+  Expand(tree.get(), RegTree::kRoot, /*split_idx=*/1, 0.5f, true, base_weight.HostView(),
+         left_weight.HostView(), right_weight.HostView(), /*loss_chg=*/0.5f,
+         /*left_sum=*/0.6f, /*right_sum=*/0.4f);
   tree->GetMultiTargetTree()->SetLeaves();
   return tree;
 }
@@ -113,9 +129,9 @@ void TestTreeDump(std::string format, std::string leaf_key) {
     RegTree tree{n_targets, n_features};
     linalg::Vector<float> weight{{1.0f, 2.0f, 3.0f, 4.0f}, {4ul}, DeviceOrd::CPU()};
     tree.SetRoot(weight.HostView(), /*sum_hess=*/1.0f);
-    tree.ExpandNode(RegTree::kRoot, /*split_idx=*/1, 0.5f, true, weight.HostView(),
-                    weight.HostView(), weight.HostView(), /*loss_chg=*/0.5f, /*sum_hess=*/1.0f,
-                    /*left_sum=*/0.6f, /*right_sum=*/0.4f);
+    Expand(&tree, RegTree::kRoot, /*split_idx=*/1, 0.5f, true, weight.HostView(), weight.HostView(),
+           weight.HostView(), /*loss_chg=*/0.5f,
+           /*left_sum=*/0.6f, /*right_sum=*/0.4f);
     tree.GetMultiTargetTree()->SetLeaves();
     auto str = tree.DumpModel(fmap, false, format);
     if (format != "json") {
@@ -154,9 +170,9 @@ TEST(MultiTargetTree, SetLeaves) {
 
   linalg::Vector<float> left_weight{{2.0f, 3.0f}, {2ul}, DeviceOrd::CPU()};
   linalg::Vector<float> right_weight{{3.0f, 4.0f}, {2ul}, DeviceOrd::CPU()};
-  tree->ExpandNode(RegTree::kRoot, /*split_idx=*/1, 0.5f, true, base_weight.HostView(),
-                   left_weight.HostView(), right_weight.HostView(), /*loss_chg=*/0.5f,
-                   /*sum_hess=*/1.0f, /*left_sum=*/0.6f, /*right_sum=*/0.4f);
+  Expand(tree.get(), RegTree::kRoot, /*split_idx=*/1, 0.5f, true, base_weight.HostView(),
+         left_weight.HostView(), right_weight.HostView(), /*loss_chg=*/0.5f,
+         /*left_sum=*/0.6f, /*right_sum=*/0.4f);
 
   std::vector<float> leaf_weights(n_targets * 2);
   std::iota(leaf_weights.begin(), leaf_weights.end(), 0);

--- a/tests/cpp/tree/test_multi_target_tree_model.cc
+++ b/tests/cpp/tree/test_multi_target_tree_model.cc
@@ -24,10 +24,11 @@ void Expand(RegTree* p_tree, bst_node_t nidx, bst_feature_t fidx, float cond, bo
             linalg::VectorView<float const> left_weight,
             linalg::VectorView<float const> right_weight, float loss_chg, double left_sum,
             double right_sum, float eta = 1.0f, common::Span<tree::CatWordT const> cat_bits = {}) {
-  tree::ExpandBatch batch{base_weight.Device(), eta};
+  Context ctx;
+  tree::ExpandBatch batch{eta};
   batch.Push(nidx, fidx, cond, dft_left, base_weight.Values(), left_weight.Values(),
              right_weight.Values(), loss_chg, left_sum, right_sum, cat_bits);
-  p_tree->Expand(batch);
+  p_tree->Expand(&ctx, batch);
 }
 }  // namespace
 

--- a/tests/cpp/tree/test_multi_target_tree_model.cc
+++ b/tests/cpp/tree/test_multi_target_tree_model.cc
@@ -12,10 +12,7 @@
 #include <memory>   // for unique_ptr
 #include <numeric>  // for iota
 
-#include "../../../src/common/categorical.h"  // for CatBitField, GetNodeCats
-#include "../../../src/tree/io_utils.h"       // for DftBadValue
 #include "../../../src/tree/tree_view.h"
-#include "../helpers.h"  // for AssertVecEq
 
 namespace xgboost {
 namespace {

--- a/tests/cpp/tree/test_partitioner.h
+++ b/tests/cpp/tree/test_partitioner.h
@@ -1,8 +1,8 @@
 /**
- * Copyright 2021-2026 by XGBoost contributors.
+ * Copyright 2021-2026, XGBoost contributors.
  */
-#ifndef XGBOOST_TESTS_CPP_TREE_TEST_PARTITIONER_H_
-#define XGBOOST_TESTS_CPP_TREE_TEST_PARTITIONER_H_
+#pragma once
+
 #include <xgboost/context.h>     // for Context
 #include <xgboost/linalg.h>      // for Constant, Vector
 #include <xgboost/logging.h>     // for CHECK
@@ -46,4 +46,3 @@ inline void GetMultiSplitForTest(RegTree *tree, float split_value,
   tree->GetMultiTargetTree()->SetLeaves();
 }
 }  // namespace xgboost::tree
-#endif  // XGBOOST_TESTS_CPP_TREE_TEST_PARTITIONER_H_

--- a/tests/cpp/tree/test_partitioner.h
+++ b/tests/cpp/tree/test_partitioner.h
@@ -34,12 +34,12 @@ inline void GetMultiSplitForTest(RegTree *tree, float split_value,
   linalg::Vector<float> left_weight{linalg::Constant(&ctx, 0.0f, n_targets)};
   linalg::Vector<float> right_weight{linalg::Constant(&ctx, 0.0f, n_targets)};
   tree->SetRoot(base_weight.HostView(), /*sum_hess=*/0.0f);
-  ExpandBatch batch{DeviceOrd::CPU(), 1.0f};
+  ExpandBatch batch{1.0f};
   batch.Push(/*nidx=*/RegTree::kRoot, /*split_index=*/0, /*split_value=*/split_value,
              /*default_left=*/true, base_weight.HostView().Values(),
              left_weight.HostView().Values(), right_weight.HostView().Values(),
              /*loss_chg=*/0.0f, /*left_sum=*/0.0f, /*right_sum=*/0.0f);
-  tree->Expand(batch);
+  tree->Expand(&ctx, batch);
   candidates->front().split.split_value = split_value;
   candidates->front().split.sindex = 0;
   candidates->front().split.sindex |= (1U << 31);

--- a/tests/cpp/tree/test_partitioner.h
+++ b/tests/cpp/tree/test_partitioner.h
@@ -3,12 +3,12 @@
  */
 #ifndef XGBOOST_TESTS_CPP_TREE_TEST_PARTITIONER_H_
 #define XGBOOST_TESTS_CPP_TREE_TEST_PARTITIONER_H_
-#include <xgboost/context.h>                      // for Context
-#include <xgboost/linalg.h>                       // for Constant, Vector
-#include <xgboost/logging.h>                      // for CHECK
-#include <xgboost/tree_model.h>                   // for RegTree
+#include <xgboost/context.h>     // for Context
+#include <xgboost/linalg.h>      // for Constant, Vector
+#include <xgboost/logging.h>     // for CHECK
+#include <xgboost/tree_model.h>  // for RegTree
 
-#include <vector>                                 // for vector
+#include <vector>  // for vector
 
 #include "../../../src/tree/hist/expand_entry.h"  // for CPUExpandEntry, MultiExpandEntry
 
@@ -34,10 +34,12 @@ inline void GetMultiSplitForTest(RegTree *tree, float split_value,
   linalg::Vector<float> left_weight{linalg::Constant(&ctx, 0.0f, n_targets)};
   linalg::Vector<float> right_weight{linalg::Constant(&ctx, 0.0f, n_targets)};
   tree->SetRoot(base_weight.HostView(), /*sum_hess=*/0.0f);
-  tree->ExpandNode(/*nidx=*/RegTree::kRoot, /*split_index=*/0, /*split_value=*/split_value,
-                   /*default_left=*/true, base_weight.HostView(), left_weight.HostView(),
-                   right_weight.HostView(), /*loss_chg=*/0.0f, /*sum_hess=*/0.0f, /*left_sum=*/0.0f,
-                   /*right_sum=*/0.0f);
+  ExpandBatch batch{DeviceOrd::CPU(), 1.0f};
+  batch.Push(/*nidx=*/RegTree::kRoot, /*split_index=*/0, /*split_value=*/split_value,
+             /*default_left=*/true, base_weight.HostView().Values(),
+             left_weight.HostView().Values(), right_weight.HostView().Values(),
+             /*loss_chg=*/0.0f, /*left_sum=*/0.0f, /*right_sum=*/0.0f);
+  tree->Expand(batch);
   candidates->front().split.split_value = split_value;
   candidates->front().split.sindex = 0;
   candidates->front().split.sindex |= (1U << 31);

--- a/tests/python/test_tracker.py
+++ b/tests/python/test_tracker.py
@@ -8,7 +8,6 @@ import pytest
 from hypothesis import HealthCheck, given, settings, strategies
 from xgboost import RabitTracker, collective
 from xgboost import testing as tm
-from xgboost.testing.collective import get_avail_port
 
 
 def test_rabit_tracker() -> None:
@@ -65,8 +64,9 @@ def test_worker_port() -> None:
     args = tracker.worker_args()
 
     def local_test(worker_id: int, rabit_args: dict) -> int:
-        cfg = collective.Config(worker_port=get_avail_port)
+        cfg = collective.Config(worker_port=lambda: 0)
         cfg.update_worker_args(rabit_args)
+        assert rabit_args["dmlc_worker_port"] == 0
         with collective.CommunicatorContext(**rabit_args):
             a = np.array([1])
             result = collective.allreduce(a, collective.Op.SUM)


### PR DESCRIPTION
- Batch the tree node expand calls.
- Avoid small cross device copies. We still have some copies due to host-device tree views, but the copies are no longer performed per node.
- Clean up the expand entries after unifying the evaluator and removing the column split. Unfortunately, due to differences in backing storage, we can not unify all of them (yet).
- Unify the node expand methods between numeric and categorical.

Ref: https://github.com/dmlc/xgboost/issues/9043