### PR TITLE
[MT][Dask] Support multi-label for sklearn-like estimators, Support SHAP.

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1728,6 +1728,7 @@ class ExtMemQuantileDMatrix(DMatrix, _RefMixIn):
 
 
 PlainObj = Callable[[np.ndarray, DMatrix], Tuple[np.ndarray, np.ndarray]]
+CustomObj = Union[PlainObj, Objective]
 Metric = Callable[[np.ndarray, DMatrix], Tuple[str, float]]
 
 
@@ -2195,7 +2196,7 @@ class Booster:
         self,
         dtrain: DMatrix,
         iteration: int,
-        fobj: Optional[PlainObj] = None,
+        fobj: Optional[CustomObj] = None,
     ) -> None:
         """Update for one iteration, with objective function calculated
         internally.
@@ -2240,7 +2241,7 @@ class Booster:
         *,
         grad: Optional[NumpyOrCupy] = None,
         hess: Optional[NumpyOrCupy] = None,
-        fobj: Optional[PlainObj] = None,
+        fobj: Optional[CustomObj] = None,
     ) -> None:
         """Boost the booster for one iteration with customized gradient statistics.
 

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -69,6 +69,7 @@ from typing import (
     List,
     Optional,
     ParamSpec,
+    Self,
     Sequence,
     Set,
     Tuple,
@@ -1600,7 +1601,7 @@ class DaskXGBRegressor(XGBRegressorBase, DaskScikitLearnBase):
         verbose: Union[int, bool],
         xgb_model: Optional[Union[Booster, XGBModel]],
         feature_weights: Optional[_DaskCollection],
-    ) -> _DaskCollection:
+    ) -> Self:
         params = self.get_xgb_params()
         model, metric, params, feature_weights = self._configure_fit(
             xgb_model, params, feature_weights
@@ -1693,7 +1694,7 @@ class DaskXGBClassifier(XGBClassifierBase, DaskScikitLearnBase):
         verbose: Union[int, bool],
         xgb_model: Optional[Union[Booster, XGBModel]],
         feature_weights: Optional[_DaskCollection],
-    ) -> "DaskXGBClassifier":
+    ) -> Self:
         params = self.get_xgb_params()
         model, metric, params, feature_weights = self._configure_fit(
             xgb_model, params, feature_weights
@@ -1739,7 +1740,7 @@ class DaskXGBClassifier(XGBClassifierBase, DaskScikitLearnBase):
                 def flatten(block: Any) -> Any:
                     return block.reshape(-1)
 
-                # Use map_blocks to keep the computation lazy, we that we don't go
+                # Use map_blocks to keep the computation lazy, so that we don't go
                 # through the data twice (shape and unique).
                 labels = da.map_blocks(
                     flatten,
@@ -1950,7 +1951,7 @@ class DaskXGBRanker(XGBRankerMixIn, DaskScikitLearnBase):
         verbose: Union[int, bool],
         xgb_model: Optional[Union[XGBModel, Booster]],
         feature_weights: Optional[_DaskCollection],
-    ) -> "DaskXGBRanker":
+    ) -> Self:
         params = self.get_xgb_params()
         model, metric, params, feature_weights = self._configure_fit(
             xgb_model, params, feature_weights

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -109,11 +109,11 @@ from ..core import (
 )
 from ..sklearn import (
     XGBClassifier,
-    XGBClassifierBase,
+    XGBClassifierMixIn,
     XGBModel,
     XGBRanker,
     XGBRankerMixIn,
-    XGBRegressorBase,
+    XGBRegressorMixIn,
     _can_use_qdm,
     _check_rf_callback,
     _cls_predict_proba,
@@ -1585,7 +1585,7 @@ class DaskScikitLearnBase(XGBModel):
 @xgboost_model_doc(
     """Implementation of the Scikit-Learn API for XGBoost.""", ["estimators", "model"]
 )
-class DaskXGBRegressor(XGBRegressorBase, DaskScikitLearnBase):
+class DaskXGBRegressor(XGBRegressorMixIn, DaskScikitLearnBase):
     """dummy doc string to workaround pylint, replaced by the decorator."""
 
     async def _fit_async(
@@ -1679,7 +1679,7 @@ class DaskXGBRegressor(XGBRegressorBase, DaskScikitLearnBase):
     "Implementation of the scikit-learn API for XGBoost classification.",
     ["estimators", "model"],
 )
-class DaskXGBClassifier(XGBClassifierBase, DaskScikitLearnBase):
+class DaskXGBClassifier(XGBClassifierMixIn, DaskScikitLearnBase):
     # pylint: disable=missing-class-docstring
     async def _fit_async(
         self,
@@ -1750,14 +1750,14 @@ class DaskXGBClassifier(XGBClassifierBase, DaskScikitLearnBase):
                     dtype=labels.dtype,
                 )
             classes = da.unique(labels)
-        self.classes_ = await self.client.compute(classes)
+        classes = await self.client.compute(classes)
 
-        if _is_cudf_ser(self.classes_):
-            self.classes_ = self.classes_.to_cupy()
-        if _is_cupy_alike(self.classes_):
-            self.classes_ = self.classes_.get()
-        self.classes_ = numpy.unique(numpy.asarray(self.classes_))
-        self.n_classes_ = len(self.classes_)
+        if _is_cudf_ser(classes):
+            classes = classes.to_cupy()
+        if _is_cupy_alike(classes):
+            classes = classes.get()
+        classes = numpy.unique(numpy.asarray(classes))
+        self.n_classes_ = len(classes)
 
         if self.n_classes_ > 2:
             params["objective"] = "multi:softprob"

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -95,7 +95,7 @@ from ..callback import TrainingCallback
 from ..collective import Config as CollConfig
 from ..collective import _Args as CollArgs
 from ..collective import _ArgVals as CollArgsVals
-from ..compat import _is_cudf_df, _is_cupy_alike
+from ..compat import _is_cudf_df, _is_cudf_ser, _is_cupy_alike
 from ..core import (
     Booster,
     CustomObj,
@@ -1722,29 +1722,40 @@ class DaskXGBClassifier(XGBClassifierBase, DaskScikitLearnBase):
         )
 
         # pylint: disable=attribute-defined-outside-init
-        if isinstance(y, da.Array):
-            labels = y
+        if isinstance(y, dd.Series) or (
+            isinstance(y, dd.DataFrame) and len(y.columns) == 1
+        ):
+            labels_series = y if isinstance(y, dd.Series) else y[y.columns[0]]
+            # The result is collected on the client, so avoid a distributed shuffle
+            # using only 1 output partition.
+            classes = labels_series.drop_duplicates(split_out=1)
         else:
-            labels = y.to_dask_array()
-        if labels.ndim == 2:
-            n_columns = labels.shape[1]
-            assert isinstance(n_columns, int)
-            row_chunks = tuple(chunk * n_columns for chunk in labels.chunks[0])
+            labels = y if isinstance(y, da.Array) else y.to_dask_array()
+            if labels.ndim == 2:
+                n_columns = labels.shape[1]
+                assert isinstance(n_columns, int)
+                row_chunks = tuple(chunk * n_columns for chunk in labels.chunks[0])
 
-            def flatten(block: Any) -> Any:
-                return block.reshape(-1)
+                def flatten(block: Any) -> Any:
+                    return block.reshape(-1)
 
-            labels = da.map_blocks(
-                flatten,
-                labels,
-                chunks=(row_chunks,),
-                drop_axis=1,
-                dtype=labels.dtype,
-            )
-        self.classes_ = await self.client.compute(da.unique(labels))
+                # Use map_blocks to keep the computation lazy, we that we don't go
+                # through the data twice (shape and unique).
+                labels = da.map_blocks(
+                    flatten,
+                    labels,
+                    chunks=(row_chunks,),
+                    drop_axis=1,
+                    dtype=labels.dtype,
+                )
+            classes = da.unique(labels)
+        self.classes_ = await self.client.compute(classes)
+
+        if _is_cudf_ser(self.classes_):
+            self.classes_ = self.classes_.to_cupy()
         if _is_cupy_alike(self.classes_):
             self.classes_ = self.classes_.get()
-        self.classes_ = numpy.array(self.classes_)
+        self.classes_ = numpy.unique(numpy.asarray(self.classes_))
         self.n_classes_ = len(self.classes_)
 
         if self.n_classes_ > 2:

--- a/python-package/xgboost/dask/__init__.py
+++ b/python-package/xgboost/dask/__init__.py
@@ -95,12 +95,12 @@ from ..callback import TrainingCallback
 from ..collective import Config as CollConfig
 from ..collective import _Args as CollArgs
 from ..collective import _ArgVals as CollArgsVals
-from ..compat import _is_cudf_df, _is_cudf_ser, _is_cupy_alike
+from ..compat import _is_cudf_df, _is_cupy_alike
 from ..core import (
     Booster,
+    CustomObj,
     DMatrix,
     Metric,
-    PlainObj,
     XGBoostError,
     _check_distributed_params,
     _deprecate_positional_args,
@@ -728,7 +728,7 @@ async def _train_async(
     dtrain: DaskDMatrix,
     num_boost_round: int,
     evals: Optional[Sequence[Tuple[DaskDMatrix, str]]],
-    obj: Optional[PlainObj],
+    obj: Optional[CustomObj],
     early_stopping_rounds: Optional[int],
     verbose_eval: Union[int, bool],
     xgb_model: Optional[Booster],
@@ -836,7 +836,7 @@ def train(  # pylint: disable=unused-argument
     num_boost_round: int = 10,
     *,
     evals: Optional[Sequence[Tuple[DaskDMatrix, str]]] = None,
-    obj: Optional[PlainObj] = None,
+    obj: Optional[CustomObj] = None,
     early_stopping_rounds: Optional[int] = None,
     xgb_model: Optional[Booster] = None,
     verbose_eval: Union[int, bool] = True,
@@ -981,16 +981,14 @@ async def _direct_predict_impl(  # pylint: disable=too-many-branches
                 new_axis = list(range(len(output_shape) - 2))
             else:
                 new_axis = [i + 2 for i in range(len(output_shape) - 2)]
-        if len(output_shape) == 2:
-            # Somehow dask fail to infer output shape change for 2-dim prediction, and
-            #  `chunks = (None, output_shape[1])` doesn't work due to None is not
-            #  supported in map_blocks.
-
-            # data must be an array here as dataframe + 2-dim output predict will return
-            # a dataframe instead.
-            chunks: Optional[List[Tuple]] = list(data.chunks)
-            assert isinstance(chunks, list)
-            chunks[1] = (output_shape[1],)
+        if len(output_shape) >= 2:
+            # Dask cannot infer changed or newly introduced output dimensions.
+            # `None` is not supported for chunks in map_blocks, so use the inferred
+            # prediction shape for every non-row dimension.
+            assert isinstance(data, da.Array)
+            output_chunks: List[Tuple] = [data.chunks[0]]
+            output_chunks.extend((size,) for size in output_shape[1:])
+            chunks: Optional[List[Tuple]] = output_chunks
         else:
             chunks = None
         predictions = da.map_blocks(
@@ -1631,7 +1629,7 @@ class DaskXGBRegressor(XGBRegressorBase, DaskScikitLearnBase):
         )
 
         if callable(self.objective):
-            obj: Optional[Callable] = _objective_decorator(self.objective)
+            obj: Optional[CustomObj] = _objective_decorator(self.objective)
         else:
             obj = None
         results = await self.client.sync(
@@ -1725,11 +1723,25 @@ class DaskXGBClassifier(XGBClassifierBase, DaskScikitLearnBase):
 
         # pylint: disable=attribute-defined-outside-init
         if isinstance(y, da.Array):
-            self.classes_ = await self.client.compute(da.unique(y))
+            labels = y
         else:
-            self.classes_ = await self.client.compute(y.drop_duplicates())
-        if _is_cudf_ser(self.classes_):
-            self.classes_ = self.classes_.to_cupy()
+            labels = y.to_dask_array()
+        if labels.ndim == 2:
+            n_columns = labels.shape[1]
+            assert isinstance(n_columns, int)
+            row_chunks = tuple(chunk * n_columns for chunk in labels.chunks[0])
+
+            def flatten(block: Any) -> Any:
+                return block.reshape(-1)
+
+            labels = da.map_blocks(
+                flatten,
+                labels,
+                chunks=(row_chunks,),
+                drop_axis=1,
+                dtype=labels.dtype,
+            )
+        self.classes_ = await self.client.compute(da.unique(labels))
         if _is_cupy_alike(self.classes_):
             self.classes_ = self.classes_.get()
         self.classes_ = numpy.array(self.classes_)
@@ -1742,7 +1754,7 @@ class DaskXGBClassifier(XGBClassifierBase, DaskScikitLearnBase):
             params["objective"] = "binary:logistic"
 
         if callable(self.objective):
-            obj: Optional[Callable] = _objective_decorator(self.objective)
+            obj: Optional[CustomObj] = _objective_decorator(self.objective)
         else:
             obj = None
         results = await self.client.sync(
@@ -1854,13 +1866,17 @@ class DaskXGBClassifier(XGBClassifierBase, DaskScikitLearnBase):
         else:
             assert len(pred_probs.shape) == 2
             assert isinstance(pred_probs, da.Array)
-            # when using da.argmax directly, dask will construct a numpy based return
-            # array, which runs into error when computing GPU based prediction.
+            if self.n_classes_ != 2:
+                # when using da.argmax directly, dask will construct a numpy based return
+                # array, which runs into error when computing GPU based prediction.
 
-            def _argmax(x: Any) -> Any:
-                return x.argmax(axis=1)
+                def _argmax(x: Any) -> Any:
+                    return x.argmax(axis=1)
 
-            preds = da.map_blocks(_argmax, pred_probs, drop_axis=1)
+                preds = da.map_blocks(_argmax, pred_probs, drop_axis=1)
+            else:
+                # Multi-label classification has one binary output per target.
+                preds = (pred_probs > 0.5).astype(int)
         return preds
 
 

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -55,9 +55,9 @@ from .compat import (
 from .config import config_context
 from .core import (
     Booster,
+    CustomObj,
     DMatrix,
     Metric,
-    PlainObj,
     QuantileDMatrix,
     XGBoostError,
     _deprecate_positional_args,
@@ -71,6 +71,7 @@ from .data import (
     _is_pandas_df,
     _is_polars_lazyframe,
 )
+from .objective import Objective
 from .training import train
 
 
@@ -123,10 +124,13 @@ class _SklObjWProto(Protocol):
 
 
 _SklObjProto = Callable[[ArrayLike, ArrayLike], Tuple[np.ndarray, np.ndarray]]
-SklObjective = Optional[Union[str, _SklObjWProto, _SklObjProto]]
+SklObjectiveCallable = Union[_SklObjWProto, _SklObjProto]
+SklObjective = Optional[Union[str, Objective, SklObjectiveCallable]]
 
 
-def _objective_decorator(func: Union[_SklObjWProto, _SklObjProto]) -> PlainObj:
+def _objective_decorator(
+    func: Union[Objective, SklObjectiveCallable],
+) -> CustomObj:
     """Decorate an objective function
 
     Converts an objective function using the typical sklearn metrics
@@ -156,6 +160,9 @@ def _objective_decorator(func: Union[_SklObjWProto, _SklObjProto]) -> PlainObj:
             The training set from which the labels will be extracted using
             ``dmatrix.get_label()``
     """
+
+    if isinstance(func, Objective):
+        return func
 
     parameters = signature(func).parameters
     supports_sw = "sample_weight" in parameters
@@ -1375,7 +1382,7 @@ class XGBModel(XGBModelBase):
             )
 
             if callable(self.objective):
-                obj: Optional[PlainObj] = _objective_decorator(self.objective)
+                obj: Optional[CustomObj] = _objective_decorator(self.objective)
                 params["objective"] = "reg:squarederror"
             else:
                 obj = None
@@ -1781,7 +1788,7 @@ class XGBClassifier(XGBClassifierBase, XGBModel):
             params = self.get_xgb_params()
 
             if callable(self.objective):
-                obj: Optional[PlainObj] = _objective_decorator(self.objective)
+                obj: Optional[CustomObj] = _objective_decorator(self.objective)
                 # Use default value. Is it really not used ?
                 params["objective"] = "binary:logistic"
             else:

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -124,22 +124,18 @@ class _SklObjWProto(Protocol):
 
 
 _SklObjProto = Callable[[ArrayLike, ArrayLike], Tuple[np.ndarray, np.ndarray]]
-SklObjectiveCallable = Union[_SklObjWProto, _SklObjProto]
-SklObjective = Optional[Union[str, Objective, SklObjectiveCallable]]
+SklObjectiveCallable = Union[Objective, _SklObjWProto, _SklObjProto]
+SklObjective = Optional[Union[str, SklObjectiveCallable]]
 
 
-def _objective_decorator(
-    func: Union[Objective, SklObjectiveCallable],
-) -> CustomObj:
-    """Decorate an objective function
-
-    Converts an objective function using the typical sklearn metrics
-    signature so that it is usable with ``xgboost.training.train``
+def _objective_decorator(func: SklObjectiveCallable) -> CustomObj:
+    """Decorate or forward a custom objective.
 
     Parameters
     ----------
     func:
-        Expects a callable with signature ``func(y_true, y_pred)``:
+        An :py:class:`Objective` instance or a callable with signature
+        ``func(y_true, y_pred)``:
 
         y_true: array_like of shape [n_samples]
             The target values
@@ -151,14 +147,15 @@ def _objective_decorator(
     Returns
     -------
     new_func:
-        The new objective function as expected by ``xgboost.training.train``.
-        The signature is ``new_func(preds, dmatrix)``:
+        The original :py:class:`Objective` or a function with the signature
+        ``new_func(preds, dmatrix)``:
 
         preds: array_like, shape [n_samples]
             The predicted values
         dmatrix: ``DMatrix``
             The training set from which the labels will be extracted using
             ``dmatrix.get_label()``
+
     """
 
     if isinstance(func, Objective):
@@ -285,7 +282,7 @@ __model_doc = f"""
     objective : {SklObjective}
 
         Specify the learning task and the corresponding learning objective or a custom
-        objective function to be used.
+        objective to be used.
 
         For custom objective, see :doc:`/tutorials/custom_metric_obj` and
         :ref:`custom-obj-metric` for more information, along with the end note for

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -103,6 +103,9 @@ class XGBClassifierMixIn(XGBClassifierBase):
     @property
     def classes_(self) -> np.ndarray:
         """Classes represented by this estimator."""
+        from sklearn.utils.validation import check_is_fitted
+
+        check_is_fitted(self, "n_classes_")
         return np.arange(self.n_classes_)
 
 

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -84,6 +84,45 @@ class XGBRankerMixIn:
     _estimator_type = "ranker"
 
 
+class XGBClassifierMixIn(XGBClassifierBase):
+    """Metadata shared by the single-node and Dask classifier estimators."""
+
+    n_classes_: int
+
+    def _more_tags(self) -> Dict[str, bool]:
+        tags = super()._more_tags()
+        tags["multilabel"] = True
+        return tags
+
+    def __sklearn_tags__(self) -> _sklearn_Tags:
+        tags = super().__sklearn_tags__()
+        tags_dict = self._more_tags()
+        tags.classifier_tags.multi_label = tags_dict["multilabel"]
+        return tags
+
+    @property
+    def classes_(self) -> np.ndarray:
+        """Classes represented by this estimator."""
+        return np.arange(self.n_classes_)
+
+
+class XGBRegressorMixIn(XGBRegressorBase):
+    """Metadata shared by the single-node and Dask regressor estimators."""
+
+    def _more_tags(self) -> Dict[str, bool]:
+        tags = super()._more_tags()
+        tags["multioutput"] = True
+        tags["multioutput_only"] = False
+        return tags
+
+    def __sklearn_tags__(self) -> _sklearn_Tags:
+        tags = super().__sklearn_tags__()
+        tags_dict = self._more_tags()
+        tags.target_tags.multi_output = tags_dict["multioutput"]
+        tags.target_tags.single_output = not tags_dict["multioutput_only"]
+        return tags
+
+
 def _check_rf_callback(
     early_stopping_rounds: Optional[int],
     callbacks: Optional[Sequence[TrainingCallback]],
@@ -1713,7 +1752,7 @@ def _cls_predict_proba(n_classes: int, prediction: PredtT, vstack: Callable) -> 
         Number of boosting rounds.
 """,
 )
-class XGBClassifier(XGBClassifierBase, XGBModel):
+class XGBClassifier(XGBClassifierMixIn, XGBModel):
     # pylint: disable=missing-docstring,too-many-instance-attributes
     @_deprecate_positional_args
     def __init__(
@@ -1723,17 +1762,6 @@ class XGBClassifier(XGBClassifierBase, XGBModel):
         **kwargs: Any,
     ) -> None:
         super().__init__(objective=objective, **kwargs)
-
-    def _more_tags(self) -> Dict[str, bool]:
-        tags = super()._more_tags()
-        tags["multilabel"] = True
-        return tags
-
-    def __sklearn_tags__(self) -> _sklearn_Tags:
-        tags = super().__sklearn_tags__()
-        tags_dict = self._more_tags()
-        tags.classifier_tags.multi_label = tags_dict["multilabel"]
-        return tags
 
     @_deprecate_positional_args
     def fit(
@@ -1945,10 +1973,6 @@ class XGBClassifier(XGBClassifierBase, XGBModel):
         )
         return _cls_predict_proba(self.n_classes_, class_probs, np.vstack)
 
-    @property
-    def classes_(self) -> np.ndarray:
-        return np.arange(self.n_classes_)
-
 
 @xgboost_model_doc(
     """scikit-learn API for XGBoost random forest classification.
@@ -2021,26 +2045,13 @@ class XGBRFClassifier(XGBClassifier):
     "Implementation of the scikit-learn API for XGBoost regression.",
     ["estimators", "model", "objective"],
 )
-class XGBRegressor(XGBRegressorBase, XGBModel):
+class XGBRegressor(XGBRegressorMixIn, XGBModel):
     # pylint: disable=missing-docstring
     @_deprecate_positional_args
     def __init__(
         self, *, objective: SklObjective = "reg:squarederror", **kwargs: Any
     ) -> None:
         super().__init__(objective=objective, **kwargs)
-
-    def _more_tags(self) -> Dict[str, bool]:
-        tags = super()._more_tags()
-        tags["multioutput"] = True
-        tags["multioutput_only"] = False
-        return tags
-
-    def __sklearn_tags__(self) -> _sklearn_Tags:
-        tags = super().__sklearn_tags__()
-        tags_dict = self._more_tags()
-        tags.target_tags.multi_output = tags_dict["multioutput"]
-        tags.target_tags.single_output = not tags_dict["multioutput_only"]
-        return tags
 
 
 @xgboost_model_doc(

--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -35,7 +35,7 @@ from scipy import sparse
 import xgboost as xgb
 from xgboost import RabitTracker
 from xgboost.core import ArrayLike
-from xgboost.sklearn import SklObjective
+from xgboost.sklearn import SklObjectiveCallable
 
 from .._typing import PathLike
 from .data import (
@@ -545,7 +545,7 @@ def softmax(x: np.ndarray) -> np.ndarray:
 
 def softprob_obj(
     classes: int, use_cupy: bool = False, order: str = "C", gdtype: str = "float32"
-) -> SklObjective:
+) -> SklObjectiveCallable:
     """Custom softprob objective for testing.
 
     Parameters

--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -35,7 +35,6 @@ from scipy import sparse
 import xgboost as xgb
 from xgboost import RabitTracker
 from xgboost.core import ArrayLike
-from xgboost.sklearn import SklObjectiveCallable
 
 from .._typing import PathLike
 from .data import (
@@ -545,7 +544,7 @@ def softmax(x: np.ndarray) -> np.ndarray:
 
 def softprob_obj(
     classes: int, use_cupy: bool = False, order: str = "C", gdtype: str = "float32"
-) -> SklObjectiveCallable:
+) -> Callable[[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray]]:
     """Custom softprob objective for testing.
 
     Parameters

--- a/python-package/xgboost/testing/dask.py
+++ b/python-package/xgboost/testing/dask.py
@@ -22,6 +22,7 @@ from ..dask import _get_rabit_args
 from ..dask.utils import _DASK_VERSION
 from .data import make_batches
 from .data import make_categorical as make_cat_local
+from .multi_target import LsObj1, LsObj2
 from .ordinal import make_recoded
 from .utils import Device, assert_allclose
 
@@ -115,11 +116,20 @@ def make_multi_output_regression(
     return dX, dy
 
 
-def check_multi_output_tree(client: Client, device: Device) -> None:
+def check_multi_output_tree(  # pylint: disable=too-many-locals,too-many-statements
+    client: Client, device: Device
+) -> None:
     """Test Dask vector-leaf hist with train and sklearn-style APIs."""
     tolerance = 1e-3
+    shap_tolerance = 1e-4 if device == "cuda" else 1e-5
     n_targets = 3
     X, y = make_multi_output_regression(device, n_targets=n_targets)
+
+    def as_numpy(array: Any) -> np.ndarray:
+        if hasattr(array, "get"):
+            array = array.get()
+        return np.asarray(array)
+
     Xy = dxgb.DaskDMatrix(client, X, y)
     result = dxgb.train(
         client,
@@ -143,11 +153,49 @@ def check_multi_output_tree(client: Client, device: Device) -> None:
     assert np.isfinite(np.asarray(history)).all()
     assert tm.non_increasing(history, tolerance=tolerance)
 
-    predt = dxgb.predict(client, result["booster"], Xy).compute()
-    if hasattr(predt, "get"):
-        predt = predt.get()
+    predt = as_numpy(dxgb.predict(client, result["booster"], Xy).compute())
     assert predt.shape == (X.shape[0], n_targets)
     assert np.isfinite(predt).all()
+
+    margin = as_numpy(
+        dxgb.predict(client, result["booster"], X, output_margin=True).compute()
+    )
+    n_features = X.shape[1]
+    assert isinstance(n_features, int)
+    contributions = dxgb.predict(client, result["booster"], X, pred_contribs=True)
+    contributions_shape = (X.shape[0], n_targets, n_features + 1)
+    assert contributions.shape == contributions_shape
+    assert contributions.chunks == (
+        X.chunks[0],
+        (n_targets,),
+        (n_features + 1,),
+    )
+    contributions = as_numpy(contributions.compute())
+    assert contributions.shape == contributions_shape
+    np.testing.assert_allclose(
+        contributions.sum(axis=-1),
+        margin,
+        rtol=shap_tolerance,
+        atol=shap_tolerance,
+    )
+
+    interactions = dxgb.predict(client, result["booster"], X, pred_interactions=True)
+    interactions_shape = (X.shape[0], n_targets, n_features + 1, n_features + 1)
+    assert interactions.shape == interactions_shape
+    assert interactions.chunks == (
+        X.chunks[0],
+        (n_targets,),
+        (n_features + 1,),
+        (n_features + 1,),
+    )
+    interactions = as_numpy(interactions.compute())
+    assert interactions.shape == interactions_shape
+    np.testing.assert_allclose(
+        interactions.sum(axis=(-2, -1)),
+        margin,
+        rtol=shap_tolerance,
+        atol=1e-4,
+    )
 
     reg = dxgb.DaskXGBRegressor(
         n_estimators=4,
@@ -161,9 +209,7 @@ def check_multi_output_tree(client: Client, device: Device) -> None:
     reg.client = client
     reg.fit(X, y, eval_set=[(X, y)])
 
-    predt = reg.predict(X).compute()
-    if hasattr(predt, "get"):
-        predt = predt.get()
+    predt = as_numpy(reg.predict(X).compute())
     assert predt.shape == (X.shape[0], n_targets)
     assert np.isfinite(predt).all()
 
@@ -171,6 +217,55 @@ def check_multi_output_tree(client: Client, device: Device) -> None:
     assert config["learner"]["learner_train_param"]["multi_strategy"] == (
         "multi_output_tree"
     )
+
+    for objective in (LsObj1(device), LsObj2(device, False)):
+        reg = dxgb.DaskXGBRegressor(
+            n_estimators=2,
+            device=device,
+            tree_method="hist",
+            objective=objective,
+            multi_strategy="multi_output_tree",
+            max_depth=2,
+            max_bin=64,
+        )
+        reg.client = client
+        reg.fit(X, y)
+        predt = as_numpy(reg.predict(X).compute())
+        assert predt.shape == (X.shape[0], n_targets)
+        assert np.isfinite(predt).all()
+
+    def check_classifier(labels: Union[da.Array, dd.DataFrame]) -> None:
+        clf = dxgb.DaskXGBClassifier(
+            n_estimators=2,
+            device=device,
+            tree_method="hist",
+            objective=LsObj2(device, False),
+            multi_strategy="multi_output_tree",
+            max_depth=2,
+            max_bin=64,
+        )
+        clf.client = client
+        clf.fit(X, labels)
+
+        assert isinstance(clf.classes_, np.ndarray)
+        np.testing.assert_array_equal(clf.classes_, np.array([0, 1]))
+        assert clf.n_classes_ == 2
+
+        predt = as_numpy(clf.predict(X).compute())
+        proba = as_numpy(clf.predict_proba(X).compute())
+        assert predt.shape == (X.shape[0], n_targets)
+        assert proba.shape == predt.shape
+        np.testing.assert_array_equal(predt, (proba > 0.5).astype(predt.dtype))
+
+        config = json.loads(clf.get_booster().save_config())["learner"]
+        assert config["objective"]["name"] == "binary:logistic"
+        assert int(config["learner_model_param"]["num_class"]) == 0
+
+    y_ind = (y > 0.0).astype(np.int32)
+    check_classifier(y_ind)
+    if device == "cuda":
+        y_df = dd.from_dask_array(y_ind).to_backend("cudf")
+        check_classifier(y_df)
 
 
 def check_external_memory(  # pylint: disable=too-many-locals

--- a/python-package/xgboost/testing/dask.py
+++ b/python-package/xgboost/testing/dask.py
@@ -263,9 +263,10 @@ def check_multi_output_tree(  # pylint: disable=too-many-locals,too-many-stateme
 
     y_ind = (y > 0.0).astype(np.int32)
     check_classifier(y_ind)
+    y_df = dd.from_dask_array(y_ind)
     if device == "cuda":
-        y_df = dd.from_dask_array(y_ind).to_backend("cudf")
-        check_classifier(y_df)
+        y_df = y_df.to_backend("cudf")
+    check_classifier(y_df)
 
 
 def check_external_memory(  # pylint: disable=too-many-locals

--- a/python-package/xgboost/testing/dask.py
+++ b/python-package/xgboost/testing/dask.py
@@ -18,7 +18,7 @@ from xgboost.testing.updater import get_basescore
 
 from .. import dask as dxgb
 from .._typing import EvalsLog
-from ..dask import _get_rabit_args
+from ..dask import TrainReturnT, _get_rabit_args
 from ..dask.utils import _DASK_VERSION
 from .data import make_batches
 from .data import make_categorical as make_cat_local
@@ -116,20 +116,17 @@ def make_multi_output_regression(
     return dX, dy
 
 
-def check_multi_output_tree(  # pylint: disable=too-many-locals,too-many-statements
+def _as_numpy(array: Any) -> np.ndarray:
+    if hasattr(array, "get"):
+        array = array.get()
+    return np.asarray(array)
+
+
+def _train_multi_output_tree(
     client: Client, device: Device
-) -> None:
-    """Test Dask vector-leaf hist with train and sklearn-style APIs."""
-    tolerance = 1e-3
-    shap_tolerance = 1e-4 if device == "cuda" else 1e-5
+) -> Tuple[da.Array, da.Array, dxgb.DaskDMatrix, TrainReturnT]:
     n_targets = 3
     X, y = make_multi_output_regression(device, n_targets=n_targets)
-
-    def as_numpy(array: Any) -> np.ndarray:
-        if hasattr(array, "get"):
-            array = array.get()
-        return np.asarray(array)
-
     Xy = dxgb.DaskDMatrix(client, X, y)
     result = dxgb.train(
         client,
@@ -148,54 +145,25 @@ def check_multi_output_tree(  # pylint: disable=too-many-locals,too-many-stateme
         num_boost_round=4,
         evals=[(Xy, "train")],
     )
+    return X, y, Xy, result
+
+
+def check_multi_output_tree_mae(  # pylint: disable=too-many-locals,too-many-statements
+    client: Client, device: Device
+) -> None:
+    """Test Dask vector-leaf MAE with train and sklearn-style APIs."""
+    tolerance = 1e-3
+    X, y, Xy, result = _train_multi_output_tree(client, device)
+    n_targets = y.shape[1]
+    assert isinstance(n_targets, int)
 
     history = result["history"]["train"]["mae"]
     assert np.isfinite(np.asarray(history)).all()
     assert tm.non_increasing(history, tolerance=tolerance)
 
-    predt = as_numpy(dxgb.predict(client, result["booster"], Xy).compute())
+    predt = _as_numpy(dxgb.predict(client, result["booster"], Xy).compute())
     assert predt.shape == (X.shape[0], n_targets)
     assert np.isfinite(predt).all()
-
-    margin = as_numpy(
-        dxgb.predict(client, result["booster"], X, output_margin=True).compute()
-    )
-    n_features = X.shape[1]
-    assert isinstance(n_features, int)
-    contributions = dxgb.predict(client, result["booster"], X, pred_contribs=True)
-    contributions_shape = (X.shape[0], n_targets, n_features + 1)
-    assert contributions.shape == contributions_shape
-    assert contributions.chunks == (
-        X.chunks[0],
-        (n_targets,),
-        (n_features + 1,),
-    )
-    contributions = as_numpy(contributions.compute())
-    assert contributions.shape == contributions_shape
-    np.testing.assert_allclose(
-        contributions.sum(axis=-1),
-        margin,
-        rtol=shap_tolerance,
-        atol=shap_tolerance,
-    )
-
-    interactions = dxgb.predict(client, result["booster"], X, pred_interactions=True)
-    interactions_shape = (X.shape[0], n_targets, n_features + 1, n_features + 1)
-    assert interactions.shape == interactions_shape
-    assert interactions.chunks == (
-        X.chunks[0],
-        (n_targets,),
-        (n_features + 1,),
-        (n_features + 1,),
-    )
-    interactions = as_numpy(interactions.compute())
-    assert interactions.shape == interactions_shape
-    np.testing.assert_allclose(
-        interactions.sum(axis=(-2, -1)),
-        margin,
-        rtol=shap_tolerance,
-        atol=1e-4,
-    )
 
     reg = dxgb.DaskXGBRegressor(
         n_estimators=4,
@@ -209,7 +177,7 @@ def check_multi_output_tree(  # pylint: disable=too-many-locals,too-many-stateme
     reg.client = client
     reg.fit(X, y, eval_set=[(X, y)])
 
-    predt = as_numpy(reg.predict(X).compute())
+    predt = _as_numpy(reg.predict(X).compute())
     assert predt.shape == (X.shape[0], n_targets)
     assert np.isfinite(predt).all()
 
@@ -230,7 +198,7 @@ def check_multi_output_tree(  # pylint: disable=too-many-locals,too-many-stateme
         )
         reg.client = client
         reg.fit(X, y)
-        predt = as_numpy(reg.predict(X).compute())
+        predt = _as_numpy(reg.predict(X).compute())
         assert predt.shape == (X.shape[0], n_targets)
         assert np.isfinite(predt).all()
 
@@ -251,8 +219,8 @@ def check_multi_output_tree(  # pylint: disable=too-many-locals,too-many-stateme
         np.testing.assert_array_equal(clf.classes_, np.array([0, 1]))
         assert clf.n_classes_ == 2
 
-        predt = as_numpy(clf.predict(X).compute())
-        proba = as_numpy(clf.predict_proba(X).compute())
+        predt = _as_numpy(clf.predict(X).compute())
+        proba = _as_numpy(clf.predict_proba(X).compute())
         assert predt.shape == (X.shape[0], n_targets)
         assert proba.shape == predt.shape
         np.testing.assert_array_equal(predt, (proba > 0.5).astype(predt.dtype))
@@ -267,6 +235,52 @@ def check_multi_output_tree(  # pylint: disable=too-many-locals,too-many-stateme
     if device == "cuda":
         y_df = y_df.to_backend("cudf")
     check_classifier(y_df)
+
+
+def check_multi_output_tree_shap(client: Client, device: Device) -> None:
+    """Test SHAP output shapes for Dask vector-leaf models."""
+    X, y, _, result = _train_multi_output_tree(client, device)
+    n_targets = y.shape[1]
+    assert isinstance(n_targets, int)
+    booster = result["booster"]
+
+    margin = _as_numpy(dxgb.predict(client, booster, X, output_margin=True).compute())
+    n_features = X.shape[1]
+    assert isinstance(n_features, int)
+    contributions = dxgb.predict(client, booster, X, pred_contribs=True)
+    contributions_shape = (X.shape[0], n_targets, n_features + 1)
+    assert contributions.shape == contributions_shape
+    assert contributions.chunks == (
+        X.chunks[0],
+        (n_targets,),
+        (n_features + 1,),
+    )
+    contributions = _as_numpy(contributions.compute())
+    assert contributions.shape == contributions_shape
+    np.testing.assert_allclose(
+        contributions.sum(axis=-1),
+        margin,
+        rtol=1e-4,
+        atol=1e-4,
+    )
+
+    interactions = dxgb.predict(client, booster, X, pred_interactions=True)
+    interactions_shape = (X.shape[0], n_targets, n_features + 1, n_features + 1)
+    assert interactions.shape == interactions_shape
+    assert interactions.chunks == (
+        X.chunks[0],
+        (n_targets,),
+        (n_features + 1,),
+        (n_features + 1,),
+    )
+    interactions = _as_numpy(interactions.compute())
+    assert interactions.shape == interactions_shape
+    np.testing.assert_allclose(
+        interactions.sum(axis=(-2, -1)),
+        margin,
+        rtol=1e-4,
+        atol=1e-4,
+    )
 
 
 def check_external_memory(  # pylint: disable=too-many-locals

--- a/python-package/xgboost/testing/dask.py
+++ b/python-package/xgboost/testing/dask.py
@@ -148,10 +148,8 @@ def _train_multi_output_tree(
     return X, y, Xy, result
 
 
-def check_multi_output_tree_mae(  # pylint: disable=too-many-locals,too-many-statements
-    client: Client, device: Device
-) -> None:
-    """Test Dask vector-leaf MAE with train and sklearn-style APIs."""
+def check_multi_output_tree_regressor(client: Client, device: Device) -> None:
+    """Test Dask vector-leaf regression with train and sklearn-style APIs."""
     tolerance = 1e-3
     X, y, Xy, result = _train_multi_output_tree(client, device)
     n_targets = y.shape[1]
@@ -201,6 +199,12 @@ def check_multi_output_tree_mae(  # pylint: disable=too-many-locals,too-many-sta
         predt = _as_numpy(reg.predict(X).compute())
         assert predt.shape == (X.shape[0], n_targets)
         assert np.isfinite(predt).all()
+
+
+def check_multi_output_tree_classifier(client: Client, device: Device) -> None:
+    """Test Dask vector-leaf classification with array and dataframe labels."""
+    n_targets = 3
+    X, y = make_multi_output_regression(device, n_targets=n_targets)
 
     def check_classifier(labels: Union[da.Array, dd.DataFrame]) -> None:
         clf = dxgb.DaskXGBClassifier(

--- a/python-package/xgboost/testing/multi_target.py
+++ b/python-package/xgboost/testing/multi_target.py
@@ -20,7 +20,7 @@ from .._typing import ArrayLike
 from ..compat import import_cupy
 from ..core import Booster, DMatrix, ExtMemQuantileDMatrix, QuantileDMatrix, build_info
 from ..objective import Objective, TreeObjective
-from ..sklearn import XGBClassifier
+from ..sklearn import XGBClassifier, XGBRegressor
 from ..training import train
 from .data import IteratorForTest
 from .updater import ResetStrategy, train_result
@@ -338,6 +338,39 @@ def run_reduced_grad(device: Device) -> None:  # pylint: disable=too-many-locals
     with pytest.raises(AssertionError):
         run_test(LsObj2(device, True))
 
+    def run_reg(obj: Objective) -> None:
+        reg = XGBRegressor(
+            n_estimators=2,
+            device=device,
+            tree_method="hist",
+            multi_strategy="multi_output_tree",
+            objective=obj,
+        )
+        reg.fit(X, y)
+        predt = reg.predict(X)
+        assert predt.shape == y.shape
+        assert np.isfinite(predt).all()
+
+    run_reg(LsObj1(device))
+    run_reg(LsObj2(device, False))
+    with pytest.raises(AssertionError):
+        run_reg(LsObj2(device, True))
+
+    y_ind = (y > np.median(y, axis=0)).astype(np.int32)
+    clf = XGBClassifier(
+        n_estimators=2,
+        device=device,
+        tree_method="hist",
+        multi_strategy="multi_output_tree",
+        objective=LsObj2(device, False),
+    )
+    clf.fit(X, y_ind)
+    predt = clf.predict(X)
+    proba = clf.predict_proba(X)
+    assert predt.shape == y_ind.shape
+    assert proba.shape == y_ind.shape
+    np.testing.assert_array_equal(predt, (proba > 0.5).astype(np.int32))
+
     with pytest.raises(
         ValueError,
         match="Monotonic constraints are not supported with reduced gradients",
@@ -566,8 +599,9 @@ def run_column_sampling(device: Device) -> None:
         device=device,
         colsample_bynode=0.2,
         min_child_weight=0.0,
+        feature_weights=np.arange(0, X.shape[1]),
     )
-    clf.fit(X, y, feature_weights=np.arange(0, X.shape[1]))
+    clf.fit(X, y)
     fi = clf.feature_importances_
     assert fi[0] == 0.0
     assert fi[-1] > fi[1] * 5

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -30,9 +30,9 @@ from .callback import (
 from .compat import SKLEARN_INSTALLED, XGBStratifiedKFold
 from .core import (
     Booster,
+    CustomObj,
     DMatrix,
     Metric,
-    PlainObj,
     XGBoostError,
     _deprecate_positional_args,
     _RefMixIn,
@@ -56,7 +56,7 @@ def train(
     num_boost_round: int = 10,
     *,
     evals: Optional[Sequence[Tuple[DMatrix, str]]] = None,
-    obj: Optional[PlainObj] = None,
+    obj: Optional[CustomObj] = None,
     maximize: Optional[bool] = None,
     early_stopping_rounds: Optional[int] = None,
     evals_result: Optional[TrainingCallback.EvalsLog] = None,
@@ -227,7 +227,7 @@ class CVPack:
 
         return _inner
 
-    def update(self, iteration: int, fobj: Optional[PlainObj]) -> None:
+    def update(self, iteration: int, fobj: Optional[CustomObj]) -> None:
         """ "Update the boosters for one iteration"""
         self.bst.update(self.dtrain, iteration, fobj)
 
@@ -240,7 +240,7 @@ class _PackedBooster:
     def __init__(self, cvfolds: _CVFolds) -> None:
         self.cvfolds = cvfolds
 
-    def update(self, iteration: int, obj: Optional[PlainObj]) -> None:
+    def update(self, iteration: int, obj: Optional[CustomObj]) -> None:
         """Iterate through folds for update"""
         for fold in self.cvfolds:
             fold.update(iteration, obj)
@@ -441,7 +441,7 @@ def cv(
     stratified: bool = False,
     folds: Optional[XGBStratifiedKFold] = None,
     metrics: Sequence[str] = (),
-    obj: Optional[PlainObj] = None,
+    obj: Optional[CustomObj] = None,
     maximize: Optional[bool] = None,
     early_stopping_rounds: Optional[int] = None,
     fpreproc: Optional[FPreProcCallable] = None,

--- a/src/common/device_vector.cuh
+++ b/src/common/device_vector.cuh
@@ -269,7 +269,6 @@ class ThrustAllocMrAdapter : public rmm::mr::thrust_allocator<T> {
     using other = ThrustAllocMrAdapter<U>;  // NOLINT(readability-identifier-naming)
   };
 
-
   ThrustAllocMrAdapter()
       : rmm::mr::thrust_allocator<T>{
             rmm::cuda_stream_view{cudaStream_t{xgboost::curt::DefaultStream()}}} {};
@@ -492,6 +491,9 @@ class DeviceUVectorImpl {
  public:
   DeviceUVectorImpl() = default;
   explicit DeviceUVectorImpl(std::size_t n) { this->resize(n); }
+  explicit DeviceUVectorImpl(std::size_t n, T v, ::xgboost::curt::StreamRef stream) {
+    this->resize(n, v, stream);
+  }
   DeviceUVectorImpl(DeviceUVectorImpl const &that) = delete;
   DeviceUVectorImpl &operator=(DeviceUVectorImpl const &that) = delete;
   DeviceUVectorImpl(DeviceUVectorImpl &&that) = default;
@@ -500,7 +502,8 @@ class DeviceUVectorImpl {
   [[nodiscard]] std::size_t Capacity() const { return this->capacity_; }
 
   // Resize without init.
-  void resize(std::size_t n) {  // NOLINT
+  void resize(std::size_t n,  // NOLINT
+              ::xgboost::curt::StreamRef stream = ::xgboost::curt::DefaultStream()) {
     using ::xgboost::common::SizeBytes;
 
     if (n <= this->Capacity()) {
@@ -519,9 +522,8 @@ class DeviceUVectorImpl {
                             }};
     CHECK(new_ptr.get());
 
-    auto s = ::xgboost::curt::DefaultStream();
     safe_cuda(cudaMemcpyAsync(new_ptr.get(), this->data(), SizeBytes<T>(this->size()),
-                              cudaMemcpyDefault, s));
+                              cudaMemcpyDefault, stream));
     this->size_ = n;
     this->capacity_ = n;
 
@@ -530,11 +532,12 @@ class DeviceUVectorImpl {
     // std::swap(this->data_, new_ptr);
   }
   // Resize with init
-  void resize(std::size_t n, T const &v) {  // NOLINT
+  void resize(std::size_t n, T const &v,  // NOLINT
+              ::xgboost::curt::StreamRef stream = ::xgboost::curt::DefaultStream()) {
     auto orig = this->size();
-    this->resize(n);
+    this->resize(n, stream);
     if (orig < n) {
-      auto exec = thrust::cuda::par_nosync.on(::xgboost::curt::DefaultStream());
+      auto exec = thrust::cuda::par_nosync.on(stream);
       thrust::fill(exec, this->begin() + orig, this->end(), v);
     }
   }

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -1,9 +1,11 @@
 /**
  * Copyright 2025-2026, XGBoost contributors
  */
-#include <thrust/logical.h>  // for any_of
-#include <thrust/reduce.h>   // for reduce_by_key, reduce
-#include <thrust/sort.h>     // for stable_sort_by_key
+#include <thrust/iterator/counting_iterator.h>   // for make_counting_iterator
+#include <thrust/iterator/transform_iterator.h>  // for make_transform_iterator
+#include <thrust/logical.h>                      // for any_of
+#include <thrust/reduce.h>                       // for reduce_by_key, reduce
+#include <thrust/sort.h>                         // for stable_sort_by_key
 
 #include <cub/block/block_scan.cuh>  // for BlockScan
 #include <cub/util_type.cuh>         // for KeyValuePair
@@ -123,11 +125,10 @@ struct ScanHistogramAgent {
 
 // The scan kernel reads from target-major histogram layout and writes the bin-major scan
 // buffer. This helps us keep a reference to the bin in the split candidate.
-template <std::int32_t kBlockThreads>
+template <std::int32_t kBlockThreads, typename OutputBinScans>
 __global__ __launch_bounds__(kBlockThreads) void ScanHistogramKernel(
     common::Span<MultiEvaluateSplitInputs const> nodes, MultiEvaluateSplitSharedInputs shared,
-    common::Span<std::size_t const> sorted_idx,
-    common::Span<common::Span<GradientPairInt64>> outputs) {
+    common::Span<std::size_t const> sorted_idx, OutputBinScans outputs) {
   static_assert(kBlockThreads % dh::WarpThreads() == 0);
 
   constexpr std::int32_t kWarpsPerBlk = kBlockThreads / dh::WarpThreads();
@@ -383,11 +384,10 @@ struct EvaluateSplitAgent {
 // Find the best split based on the scan result
 //
 // The scan buffer has a bin-major layout.
-template <std::int32_t kBlockThreads>
+template <std::int32_t kBlockThreads, typename BinScans>
 __global__ __launch_bounds__(kBlockThreads) void EvaluateSplitsKernel(
     common::Span<MultiEvaluateSplitInputs const> nodes, MultiEvaluateSplitSharedInputs shared,
-    common::Span<common::Span<GradientPairInt64>> bin_scans,
-    TreeEvaluator::SplitEvaluator<EvalParam> evaluator,
+    BinScans bin_scans, TreeEvaluator::SplitEvaluator<EvalParam> evaluator,
     common::Span<MultiSplitCandidate> out_candidates) {
   static_assert(kBlockThreads % dh::WarpThreads() == 0);
 
@@ -581,13 +581,14 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   this->scan_buffer_.resize(total_hist_size * 2);
 
   // Create spans for each node's scan results
-  dh::DeviceUVector<common::Span<GradientPairInt64>> scans(n_nodes);
   auto in_scans = dh::ToSpan(this->scan_buffer_);
-  auto d_scans = dh::ToSpan(scans);
-  dh::LaunchN(n_nodes, ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(std::size_t nidx_in_set) {
-    d_scans[nidx_in_set] = in_scans.subspan(nidx_in_set * node_hist_size * 2, node_hist_size * 2);
-  });
-
+  auto d_scans = common::IterSpan{
+      thrust::make_transform_iterator(
+          thrust::make_counting_iterator(0ul),
+          [=] XGBOOST_DEVICE(std::size_t nidx_in_set) -> common::Span<GradientPairInt64> {
+            return in_scans.subspan(nidx_in_set * node_hist_size * 2, node_hist_size * 2);
+          }),
+      n_nodes};
   if (shared_inputs.cat_storage_size > 0) {
     this->AllocNodeCats(max_nidx, shared_inputs.cat_storage_size);
   }
@@ -606,7 +607,8 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     auto n_warps = n_nodes * n_targets * n_features;
     auto n_blocks = common::DivRoundUp(n_warps, kWarpsPerBlk);
     dh::LaunchKernel{n_blocks, kBlockThreads, 0, ctx->CUDACtx()->Stream()}(  // NOLINT
-        ScanHistogramKernel<kBlockThreads>, d_inputs, shared_inputs, d_sorted_idx, d_scans);
+        ScanHistogramKernel<kBlockThreads, decltype(d_scans)>, d_inputs, shared_inputs,
+        d_sorted_idx, d_scans);
   }
 
   // Launch split evaluation kernel
@@ -617,8 +619,8 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     auto n_warps = n_nodes * n_features;
     auto n_blocks = common::DivRoundUp(n_warps, kWarpsPerBlk);
     dh::LaunchKernel{n_blocks, kBlockThreads, 0, ctx->CUDACtx()->Stream()}(  // NOLINT
-        EvaluateSplitsKernel<kBlockThreads>, d_inputs, shared_inputs, dh::ToSpan(scans), evaluator,
-        dh::ToSpan(d_splits));
+        EvaluateSplitsKernel<kBlockThreads, decltype(d_scans)>, d_inputs, shared_inputs, d_scans,
+        evaluator, dh::ToSpan(d_splits));
   }
 
   // Find best split for each node

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -612,7 +612,8 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   }
 
   // Launch split evaluation kernel
-  dh::device_vector<MultiSplitCandidate> d_splits(n_nodes * n_features);
+  dh::DeviceUVector<MultiSplitCandidate> d_splits(n_nodes * n_features, MultiSplitCandidate{},
+                                                  ctx->CUDACtx()->Stream());
   {
     std::uint32_t constexpr kBlockThreads = 512;
     constexpr std::int32_t kWarpsPerBlk = kBlockThreads / dh::WarpThreads();
@@ -636,7 +637,9 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     // Returns nidx_in_set
     return i / n_features;
   });
-  dh::device_vector<MultiSplitCandidate> best_splits(out_splits.size());
+  dh::DeviceUVector<MultiSplitCandidate> best_splits(out_splits.size(), MultiSplitCandidate{},
+                                                     ctx->CUDACtx()->Stream());
+
   thrust::reduce_by_key(
       ctx->CUDACtx()->CTP(), key_it, key_it + s_d_splits.size(), dh::tcbegin(s_d_splits),
       thrust::make_discard_iterator(), best_splits.begin(), std::equal_to{},

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -14,7 +14,6 @@
 #include <limits>                    // for numeric_limits
 #include <memory>                    // for make_unique
 #include <type_traits>               // for is_trivially_copyable_v
-#include <vector>                    // for vector
 
 #include "../../common/cuda_context.cuh"
 #include "../../common/nvtx_utils.h"  // for xgboost_NVTX_FN_RANGE

--- a/src/tree/gpu_hist/multi_evaluate_splits.cu
+++ b/src/tree/gpu_hist/multi_evaluate_splits.cu
@@ -582,12 +582,12 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
   this->scan_buffer_.resize(total_hist_size * 2);
 
   // Create spans for each node's scan results
-  std::vector<common::Span<GradientPairInt64>> h_scans(n_nodes);
-  for (decltype(n_nodes) nidx_in_set = 0; nidx_in_set < n_nodes; ++nidx_in_set) {
-    h_scans[nidx_in_set] = dh::ToSpan(this->scan_buffer_)
-                               .subspan(nidx_in_set * node_hist_size * 2, node_hist_size * 2);
-  }
-  dh::device_vector<common::Span<GradientPairInt64>> scans(h_scans);
+  dh::DeviceUVector<common::Span<GradientPairInt64>> scans(n_nodes);
+  auto in_scans = dh::ToSpan(this->scan_buffer_);
+  auto d_scans = dh::ToSpan(scans);
+  dh::LaunchN(n_nodes, ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(std::size_t nidx_in_set) {
+    d_scans[nidx_in_set] = in_scans.subspan(nidx_in_set * node_hist_size * 2, node_hist_size * 2);
+  });
 
   if (shared_inputs.cat_storage_size > 0) {
     this->AllocNodeCats(max_nidx, shared_inputs.cat_storage_size);
@@ -606,9 +606,8 @@ void MultiHistEvaluator::EvaluateSplits(Context const *ctx,
     constexpr std::int32_t kWarpsPerBlk = kBlockThreads / dh::WarpThreads();
     auto n_warps = n_nodes * n_targets * n_features;
     auto n_blocks = common::DivRoundUp(n_warps, kWarpsPerBlk);
-    dh::LaunchKernel{n_blocks, kBlockThreads}(  // NOLINT
-        ScanHistogramKernel<kBlockThreads>, d_inputs, shared_inputs, d_sorted_idx,
-        dh::ToSpan(scans));
+    dh::LaunchKernel{n_blocks, kBlockThreads, 0, ctx->CUDACtx()->Stream()}(  // NOLINT
+        ScanHistogramKernel<kBlockThreads>, d_inputs, shared_inputs, d_sorted_idx, d_scans);
   }
 
   // Launch split evaluation kernel

--- a/src/tree/updater_gpu_hist.cuh
+++ b/src/tree/updater_gpu_hist.cuh
@@ -559,10 +559,10 @@ class MultiTargetHistMaker {
     }
     xgboost_NVTX_FN_RANGE();
 
-    dh::device_vector<MultiEvaluateSplitInputs> inputs(2 * candidates.size());
-    dh::device_vector<MultiExpandEntry> outputs(2 * candidates.size());
+    dh::DeviceUVector<MultiEvaluateSplitInputs> inputs(2 * candidates.size());
+    dh::DeviceUVector<MultiExpandEntry> outputs(2 * candidates.size());
 
-    std::vector<MultiEvaluateSplitInputs> h_node_inputs(candidates.size() * 2);
+    std::vector<MultiEvaluateSplitInputs> h_node_inputs(inputs.size());
 
     // Store the feature set ptrs so they don't go out of scope before the kernel is called
     std::vector<std::shared_ptr<HostDeviceVector<bst_feature_t>>> feature_sets;
@@ -603,14 +603,14 @@ class MultiTargetHistMaker {
                                      static_cast<std::size_t>(max_active_feature)});
       max_nidx = std::max({max_nidx, left_nidx, right_nidx});
     }
-    dh::safe_cuda(cudaMemcpyAsync(inputs.data().get(), h_node_inputs.data(),
+    dh::safe_cuda(cudaMemcpyAsync(inputs.data(), h_node_inputs.data(),
                                   common::SizeBytes<MultiEvaluateSplitInputs>(h_node_inputs.size()),
                                   cudaMemcpyDefault, ctx_->CUDACtx()->Stream()));
 
     auto shared_inputs = MakeSharedInputs(max_active_feature);
     this->evaluator_.EvaluateSplits(this->ctx_, dh::ToSpan(inputs), shared_inputs, max_nidx,
                                     dh::ToSpan(outputs));
-    dh::safe_cuda(cudaMemcpyAsync(pinned_candidates_out.data(), outputs.data().get(),
+    dh::safe_cuda(cudaMemcpyAsync(pinned_candidates_out.data(), outputs.data(),
                                   pinned_candidates_out.size_bytes(), cudaMemcpyDefault,
                                   ctx_->CUDACtx()->Stream()));
   }

--- a/tests/python-gpu/test_gpu_multi_target.py
+++ b/tests/python-gpu/test_gpu_multi_target.py
@@ -1,6 +1,7 @@
 """Tests for the CUDA implementation of multi-target."""
 
 # pylint: disable=too-many-positional-arguments,missing-function-docstring
+import sys
 from typing import Any, Callable, Dict, Optional
 
 import numpy as np
@@ -112,7 +113,7 @@ def test_reduced_grad() -> None:
 
 
 def test_with_iter() -> None:
-    if build_info().get("USE_RMM", False) is True:
+    if build_info().get("USE_RMM", False) is True or sys.platform.startswith("win"):
         with config_context(use_rmm=True):
             run_with_iter("cuda")
     else:

--- a/tests/python-gpu/test_gpu_multi_target.py
+++ b/tests/python-gpu/test_gpu_multi_target.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import xgboost as xgb
 from hypothesis import given, note, settings, strategies
-from xgboost import config_context
+from xgboost import build_info, config_context
 from xgboost import testing as tm
 from xgboost.testing.multi_target import (
     all_reg_objectives,
@@ -112,8 +112,12 @@ def test_reduced_grad() -> None:
 
 
 def test_with_iter() -> None:
-    with config_context(use_rmm=True):
-        run_with_iter("cuda")
+    if build_info().get("USE_RMM", False) is True:
+        with config_context(use_rmm=True):
+            run_with_iter("cuda")
+    else:
+        with config_context(use_cuda_async_pool=True):
+            run_with_iter("cuda")
 
 
 def test_eta() -> None:

--- a/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
+++ b/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
@@ -298,6 +298,7 @@ class TestDistributedGPU:
         )
 
     @pytest.mark.skipif(**tm.no_cupy())
+    @pytest.mark.skipif(**tm.no_dask_cudf())
     def test_gpu_hist_multi_absolute_error(self, local_cuda_client: Client) -> None:
         check_multi_output_tree(local_cuda_client, "cuda")
 

--- a/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
+++ b/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
@@ -50,7 +50,8 @@ from dask_cuda import LocalCUDACluster
 from xgboost import dask as dxgb
 from xgboost.testing.dask import (
     check_init_estimation,
-    check_multi_output_tree_mae,
+    check_multi_output_tree_classifier,
+    check_multi_output_tree_regressor,
     check_multi_output_tree_shap,
     check_uneven_nan,
 )
@@ -298,9 +299,13 @@ class TestDistributedGPU:
         )
 
     @pytest.mark.skipif(**tm.no_cupy())
+    def test_gpu_hist_multi_regressor(self, local_cuda_client: Client) -> None:
+        check_multi_output_tree_regressor(local_cuda_client, "cuda")
+
+    @pytest.mark.skipif(**tm.no_cupy())
     @pytest.mark.skipif(**tm.no_dask_cudf())
-    def test_gpu_hist_multi_mae(self, local_cuda_client: Client) -> None:
-        check_multi_output_tree_mae(local_cuda_client, "cuda")
+    def test_gpu_hist_multi_classifier(self, local_cuda_client: Client) -> None:
+        check_multi_output_tree_classifier(local_cuda_client, "cuda")
 
     @pytest.mark.skipif(**tm.no_cupy())
     def test_gpu_hist_multi_shap(self, local_cuda_client: Client) -> None:

--- a/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
+++ b/tests/test_distributed/test_gpu_with_dask/test_gpu_with_dask.py
@@ -12,7 +12,6 @@ import pytest
 import xgboost as xgb
 from hypothesis import given, note, settings, strategies
 from hypothesis._settings import duration
-from packaging.version import parse as parse_version
 from xgboost import testing as tm
 from xgboost.collective import CommunicatorContext
 from xgboost.testing.dask import get_rabit_args, make_categorical, run_recode
@@ -51,7 +50,8 @@ from dask_cuda import LocalCUDACluster
 from xgboost import dask as dxgb
 from xgboost.testing.dask import (
     check_init_estimation,
-    check_multi_output_tree,
+    check_multi_output_tree_mae,
+    check_multi_output_tree_shap,
     check_uneven_nan,
 )
 
@@ -299,8 +299,12 @@ class TestDistributedGPU:
 
     @pytest.mark.skipif(**tm.no_cupy())
     @pytest.mark.skipif(**tm.no_dask_cudf())
-    def test_gpu_hist_multi_absolute_error(self, local_cuda_client: Client) -> None:
-        check_multi_output_tree(local_cuda_client, "cuda")
+    def test_gpu_hist_multi_mae(self, local_cuda_client: Client) -> None:
+        check_multi_output_tree_mae(local_cuda_client, "cuda")
+
+    @pytest.mark.skipif(**tm.no_cupy())
+    def test_gpu_hist_multi_shap(self, local_cuda_client: Client) -> None:
+        check_multi_output_tree_shap(local_cuda_client, "cuda")
 
     @given(
         params=hist_parameter_strategy,

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -33,7 +33,8 @@ from xgboost.collective import Config as CollConfig
 from xgboost.dask import DaskDMatrix
 from xgboost.testing.dask import (
     check_init_estimation,
-    check_multi_output_tree,
+    check_multi_output_tree_mae,
+    check_multi_output_tree_shap,
     check_uneven_nan,
     get_rabit_args,
     make_categorical,
@@ -1486,8 +1487,11 @@ class TestWithDask:
         params.update(cache_param)
         self.run_updater_test(client, params, num_rounds, dataset, "hist")
 
-    def test_hist_multi_absolute_error(self, client: "Client") -> None:
-        check_multi_output_tree(client, "cpu")
+    def test_hist_multi_mae(self, client: "Client") -> None:
+        check_multi_output_tree_mae(client, "cpu")
+
+    def test_hist_multi_shap(self, client: "Client") -> None:
+        check_multi_output_tree_shap(client, "cpu")
 
     def test_quantile_dmatrix(self, client: Client) -> None:
         X, y = make_categorical(client, 3000, 30, 13)

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -1958,6 +1958,7 @@ class TestWithDask:
         cls = dxgb.DaskXGBClassifier()
         cls.load_model(path)
         assert cls.n_classes_ == 10
+        np.testing.assert_array_equal(cls.classes_, np.arange(cls.n_classes_))
         predt_2 = cls.predict(X)
         proba_2 = cls.predict_proba(X)
 

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -81,17 +81,20 @@ def generate_array(
     return X, y, None
 
 
-@pytest.mark.parametrize("to_frame", [True, False])
-def test_xgbclassifier_classes_type_and_value(to_frame: bool, client: "Client") -> None:
+@pytest.mark.parametrize("label_type", ["array", "series", "dataframe"])
+def test_xgbclassifier_classes_type_and_value(
+    label_type: Literal["array", "series", "dataframe"], client: "Client"
+) -> None:
     X, y = make_classification(n_samples=1000, n_features=4, random_state=123)
-    if to_frame:
+    if label_type != "array":
         import pandas as pd
 
         feats = [f"var_{i}" for i in range(4)]
         df = pd.DataFrame(X, columns=feats)
         df["target"] = y
         df = dd.from_pandas(df, npartitions=1)
-        X, y = df[feats], df["target"]
+        X = df[feats]
+        y = df[["target"]] if label_type == "dataframe" else df["target"]
     else:
         X = da.from_array(X)
         y = da.from_array(y)

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -33,7 +33,8 @@ from xgboost.collective import Config as CollConfig
 from xgboost.dask import DaskDMatrix
 from xgboost.testing.dask import (
     check_init_estimation,
-    check_multi_output_tree_mae,
+    check_multi_output_tree_classifier,
+    check_multi_output_tree_regressor,
     check_multi_output_tree_shap,
     check_uneven_nan,
     get_rabit_args,
@@ -1487,8 +1488,11 @@ class TestWithDask:
         params.update(cache_param)
         self.run_updater_test(client, params, num_rounds, dataset, "hist")
 
-    def test_hist_multi_mae(self, client: "Client") -> None:
-        check_multi_output_tree_mae(client, "cpu")
+    def test_hist_multi_regressor(self, client: "Client") -> None:
+        check_multi_output_tree_regressor(client, "cpu")
+
+    def test_hist_multi_classifier(self, client: "Client") -> None:
+        check_multi_output_tree_classifier(client, "cpu")
 
     def test_hist_multi_shap(self, client: "Client") -> None:
         check_multi_output_tree_shap(client, "cpu")


### PR DESCRIPTION
- Support multi-label classification in dask sklearn-like estimators. Add missing sklearn tags.
- Fix SHAP output shape for multi-output models.
- Handle reduced gradient objective.
- Small optimization for the evaluator. Not much faster overall, but the nsys is nicer to read since we remove a memory allocation, an initialization `for_each` call, multiple stream syncs during vector initialization, and paged memory copies.


Ref: https://github.com/dmlc/xgboost/issues/9043