### PR TITLE
Fix UTF-8 and nullable categories index in the recoder.

### DIFF
--- a/doc/tutorials/categorical.rst
+++ b/doc/tutorials/categorical.rst
@@ -206,7 +206,6 @@ have one of the following types:
 
 - string
 - integer, from 8-bit to 64-bit, both signed and unsigned are supported.
-- 32-bit or 64-bit floating point
 
 Other category types are not supported. Second, the input types must be strictly
 consistent. For example, XGBoost will raise an error if the categorical columns in the
@@ -226,8 +225,6 @@ encoder. To clarify, the type here refers to the type of the name of categories 
   {-1: 0, 1: 1, 3: 2, 7: 3}
   # depending on the dataframe implementation, it can be signed or unsigned.
   {5: 0, 1: 1, 3: 2, 7: 3}
-  # floating point type, both 32-bit and 64-bit are supported.
-  {-1.0: 0, 1.0: 1, 3.0: 2, 7.0: 3}
 
 Internally, XGBoost attempts to extract the categories from the dataframe inputs. For
 inference (predict), the re-coding happens on the fly and there's no data copy (baring

--- a/doc/tutorials/saving_model.rst
+++ b/doc/tutorials/saving_model.rst
@@ -298,7 +298,10 @@ As for numerical categories, the ``enc`` contains two keys: ``type`` and ``value
 ``type`` field is an integer ID that identifies the integer type of the categories, such
 as signed or unsigned 64-bit integers. Floating-point category index is not supported.
 The exact mapping between the type and the integer ID is internal but stable. The
-``values`` field is an array storing all categories in a feature.
+``values`` field is an array storing all categories in a feature. Since UBJSON only
+supports unsigned 8-bit integers, wider unsigned values are bit-copied into same-width
+signed storage and recovered according to the ``type`` field. Unsigned 64-bit category
+index (name) must not exceed the signed 64-bit range.
 
 *************
 Brief History

--- a/doc/tutorials/saving_model.rst
+++ b/doc/tutorials/saving_model.rst
@@ -295,10 +295,10 @@ chose to not store the ``values`` as a JSON string to avoid handling special cha
 and string encoding. The string names are stored exactly as given by the dataframe.
 
 As for numerical categories, the ``enc`` contains two keys: ``type`` and ``values``. The
-``type`` field is an integer ID that identifies the type of the categories, such as 64-bit
-integers and 32-bit floating points (note that they are all f32 inside a decision
-tree). The exact mapping between the type to the integer ID is internal but stable. The
-``values`` is an array storing all categories in a feature.
+``type`` field is an integer ID that identifies the integer type of the categories, such
+as signed or unsigned 64-bit integers. Floating-point category index is not supported.
+The exact mapping between the type and the integer ID is internal but stable. The
+``values`` field is an array storing all categories in a feature.
 
 *************
 Brief History

--- a/include/xgboost/json.h
+++ b/include/xgboost/json.h
@@ -49,11 +49,9 @@ class Value {
     kI8Array = 9,
     kU8Array = 10,
     kI16Array = 11,
-    kU16Array = 12,
     kI32Array = 13,
-    kU32Array = 14,
     kI64Array = 15,
-    kU64Array = 16,
+    // Values 12, 14, and 16 are reserved. ValueKind IDs must remain stable.
   };
 
   explicit Value(ValueKind _kind) : kind_{_kind} {}
@@ -200,25 +198,13 @@ using U8Array = JsonTypedArray<std::uint8_t, Value::ValueKind::kU8Array>;
  */
 using I16Array = JsonTypedArray<std::int16_t, Value::ValueKind::kI16Array>;
 /**
- * @brief Typed UBJSON array for uint16_t.
- */
-using U16Array = JsonTypedArray<std::uint16_t, Value::ValueKind::kU16Array>;
-/**
  * @brief Typed UBJSON array for int32_t.
  */
 using I32Array = JsonTypedArray<std::int32_t, Value::ValueKind::kI32Array>;
 /**
- * @brief Typed UBJSON array for uint32_t.
- */
-using U32Array = JsonTypedArray<std::uint32_t, Value::ValueKind::kU32Array>;
-/**
  * @brief Typed UBJSON array for int64_t.
  */
 using I64Array = JsonTypedArray<std::int64_t, Value::ValueKind::kI64Array>;
-/**
- * @brief Typed UBJSON array for uint64_t.
- */
-using U64Array = JsonTypedArray<std::uint64_t, Value::ValueKind::kU64Array>;
 
 class JsonObject : public Value {
  public:

--- a/include/xgboost/json.h
+++ b/include/xgboost/json.h
@@ -93,26 +93,23 @@ class JsonString : public Value {
 
  public:
   JsonString() : Value(ValueKind::kString) {}
-  JsonString(std::string const& str) :  // NOLINT
-      Value(ValueKind::kString), str_{str} {}
-  JsonString(std::string&& str) noexcept :  // NOLINT
-      Value(ValueKind::kString), str_{std::forward<std::string>(str)} {}
+  JsonString(std::string const& str) : Value(ValueKind::kString), str_{str} {}  // NOLINT
+  JsonString(std::string&& str) noexcept                                        // NOLINT
+      : Value(ValueKind::kString), str_{std::forward<std::string>(str)} {}
   JsonString(JsonString&& str) noexcept : Value(ValueKind::kString) {  // NOLINT
     std::swap(str.str_, this->str_);
   }
 
   void Save(JsonWriter* writer) const override;
 
-  std::string const& GetString() &&      { return str_; }
-  std::string const& GetString() const & { return str_; }
-  std::string&       GetString()       & { return str_; }
+  std::string const& GetString() && { return str_; }
+  std::string const& GetString() const& { return str_; }
+  std::string& GetString() & { return str_; }
 
   bool operator==(Value const& rhs) const override;
   Value& operator=(Value const& rhs) override = delete;
 
-  static bool IsClassOf(Value const* value) {
-    return value->Type() == ValueKind::kString;
-  }
+  static bool IsClassOf(Value const* value) { return value->Type() == ValueKind::kString; }
 };
 
 class JsonArray : public Value {
@@ -122,10 +119,9 @@ class JsonArray : public Value {
   JsonArray() : Value(ValueKind::kArray) {}
   JsonArray(std::vector<Json>&& arr) noexcept  // NOLINT
       : Value(ValueKind::kArray), vec_{std::forward<std::vector<Json>>(arr)} {}
-  JsonArray(std::vector<Json> const& arr) :  // NOLINT
-      Value(ValueKind::kArray), vec_{arr} {}
+  JsonArray(std::vector<Json> const& arr) : Value(ValueKind::kArray), vec_{arr} {}  // NOLINT
   JsonArray(JsonArray const& that) = delete;
-  JsonArray(JsonArray && that) noexcept;
+  JsonArray(JsonArray&& that) noexcept;
 
   void Save(JsonWriter* writer) const override;
 
@@ -133,16 +129,14 @@ class JsonArray : public Value {
   // silent the partial oveeridden warning
   Json& operator[](std::string const& key) override { return Value::operator[](key); }
 
-  std::vector<Json> const& GetArray() &&      { return vec_; }
-  std::vector<Json> const& GetArray() const & { return vec_; }
-  std::vector<Json>&       GetArray()       & { return vec_; }
+  std::vector<Json> const& GetArray() && { return vec_; }
+  std::vector<Json> const& GetArray() const& { return vec_; }
+  std::vector<Json>& GetArray() & { return vec_; }
 
   bool operator==(Value const& rhs) const override;
   Value& operator=(Value const& rhs) override = delete;
 
-  static bool IsClassOf(Value const* value) {
-    return value->Type() == ValueKind::kArray;
-  }
+  static bool IsClassOf(Value const* value) { return value->Type() == ValueKind::kArray; }
 };
 
 /**
@@ -249,7 +243,7 @@ class JsonNumber : public Value {
   using Float = float;
 
  private:
-  Float number_ { 0 };
+  Float number_{0};
 
  public:
   JsonNumber() : Value(ValueKind::kNumber) {}
@@ -263,16 +257,14 @@ class JsonNumber : public Value {
 
   void Save(JsonWriter* writer) const override;
 
-  Float const& GetNumber() &&      { return number_; }
-  Float const& GetNumber() const & { return number_; }
-  Float&       GetNumber()       & { return number_; }
+  Float const& GetNumber() && { return number_; }
+  Float const& GetNumber() const& { return number_; }
+  Float& GetNumber() & { return number_; }
 
   bool operator==(Value const& rhs) const override;
   Value& operator=(Value const& rhs) override = delete;
 
-  static bool IsClassOf(Value const* value) {
-    return value->Type() == ValueKind::kNumber;
-  }
+  static bool IsClassOf(Value const* value) { return value->Type() == ValueKind::kNumber; }
 };
 
 namespace detail {
@@ -281,13 +273,12 @@ using Not32SizeT = std::enable_if_t<std::is_same_v<IntT, std::uint32_t> &&
                                     !std::is_same_v<std::size_t, std::uint32_t>>;
 }
 
-
 class JsonInteger : public Value {
  public:
   using Int = int64_t;
 
  private:
-  Int integer_ {0};
+  Int integer_{0};
 
  public:
   JsonInteger() : Value(ValueKind::kInteger) {}  // NOLINT
@@ -304,20 +295,17 @@ class JsonInteger : public Value {
   JsonInteger(IntT value)  // NOLINT
       : Value(ValueKind::kInteger), integer_{static_cast<Int>(value)} {}
 
-  JsonInteger(JsonInteger &&that) noexcept
-      : Value{ValueKind::kInteger}, integer_{that.integer_} {}
+  JsonInteger(JsonInteger&& that) noexcept : Value{ValueKind::kInteger}, integer_{that.integer_} {}
 
   bool operator==(Value const& rhs) const override;
   Value& operator=(Value const& rhs) override = delete;
 
-  Int const& GetInteger() &&      { return integer_; }
-  Int const& GetInteger() const & { return integer_; }
-  Int& GetInteger() &             { return integer_; }
+  Int const& GetInteger() && { return integer_; }
+  Int const& GetInteger() const& { return integer_; }
+  Int& GetInteger() & { return integer_; }
   void Save(JsonWriter* writer) const override;
 
-  static bool IsClassOf(Value const* value) {
-    return value->Type() == ValueKind::kInteger;
-  }
+  static bool IsClassOf(Value const* value) { return value->Type() == ValueKind::kInteger; }
 };
 
 class JsonNull : public Value {
@@ -331,9 +319,7 @@ class JsonNull : public Value {
   bool operator==(Value const& rhs) const override;
   Value& operator=(Value const& rhs) override = delete;
 
-  static bool IsClassOf(Value const* value) {
-    return value->Type() == ValueKind::kNull;
-  }
+  static bool IsClassOf(Value const* value) { return value->Type() == ValueKind::kNull; }
 };
 
 /*! \brief Describes both true and false. */
@@ -345,21 +331,21 @@ class JsonBoolean : public Value {
   // Ambigious with JsonNumber.
   template <typename Bool, typename detail::IsSameT<std::remove_cv_t<Bool>, bool>* = nullptr>
   JsonBoolean(Bool value) : Value(ValueKind::kBoolean), boolean_{value} {}  // NOLINT
-  JsonBoolean(JsonBoolean&& value) noexcept:  // NOLINT
-      Value(ValueKind::kBoolean), boolean_{value.boolean_} {}
+  JsonBoolean(JsonBoolean&& value) noexcept
+      :  // NOLINT
+        Value(ValueKind::kBoolean),
+        boolean_{value.boolean_} {}
 
   void Save(JsonWriter* writer) const override;
 
-  bool const& GetBoolean() &&      { return boolean_; }
-  bool const& GetBoolean() const & { return boolean_; }
-  bool&       GetBoolean()       & { return boolean_; }
+  bool const& GetBoolean() && { return boolean_; }
+  bool const& GetBoolean() const& { return boolean_; }
+  bool& GetBoolean() & { return boolean_; }
 
   bool operator==(Value const& rhs) const override;
   Value& operator=(Value const& rhs) override = delete;
 
-  static bool IsClassOf(Value const* value) {
-    return value->Type() == ValueKind::kBoolean;
-  }
+  static bool IsClassOf(Value const* value) { return value->Type() == ValueKind::kBoolean; }
 };
 
 /*!
@@ -452,15 +438,13 @@ class Json {
     return *this;
   }
   // bool
-  explicit Json(JsonBoolean boolean) :
-      ptr_{new JsonBoolean(std::move(boolean))} {}
+  explicit Json(JsonBoolean boolean) : ptr_{new JsonBoolean(std::move(boolean))} {}
   Json& operator=(JsonBoolean boolean) {
     ptr_.reset(new JsonBoolean(std::move(boolean)));
     return *this;
   }
   // null
-  explicit Json(JsonNull null) :
-      ptr_{new JsonNull(std::move(null))} {}
+  explicit Json(JsonNull null) : ptr_{new JsonNull(std::move(null))} {}
   Json& operator=(JsonNull null) {
     ptr_.reset(new JsonNull(std::move(null)));
     return *this;
@@ -470,25 +454,23 @@ class Json {
   Json(Json const& other) = default;
   Json& operator=(Json const& other) = default;
   // move
-  Json(Json &&other) noexcept { std::swap(this->ptr_, other.ptr_); }
-  Json &operator=(Json &&other) noexcept {
+  Json(Json&& other) noexcept { std::swap(this->ptr_, other.ptr_); }
+  Json& operator=(Json&& other) noexcept {
     std::swap(this->ptr_, other.ptr_);
     return *this;
   }
 
   /*! \brief Index Json object with a std::string, used for Json Object. */
-  Json& operator[](std::string const & key) const { return (*ptr_)[key]; }
+  Json& operator[](std::string const& key) const { return (*ptr_)[key]; }
   /*! \brief Index Json object with int, used for Json Array. */
-  Json& operator[](int ind)                 const { return (*ptr_)[ind]; }
+  Json& operator[](int ind) const { return (*ptr_)[ind]; }
 
   /*! \brief Return the reference to stored Json value. */
   [[nodiscard]] Value const& GetValue() const& { return *ptr_; }
   Value const& GetValue() && { return *ptr_; }
   Value& GetValue() & { return *ptr_; }
 
-  bool operator==(Json const& rhs) const {
-    return *ptr_ == *(rhs.ptr_);
-  }
+  bool operator==(Json const& rhs) const { return *ptr_ == *(rhs.ptr_); }
 
   friend std::ostream& operator<<(std::ostream& os, Json const& j) {
     std::string str;
@@ -554,8 +536,7 @@ template <typename T, typename std::enable_if_t<std::is_same_v<T, JsonBoolean>>*
 bool& GetImpl(T& val) {  // NOLINT
   return val.GetBoolean();
 }
-template <typename T,
-          typename std::enable_if_t<std::is_same_v<T, JsonBoolean const>>* = nullptr>
+template <typename T, typename std::enable_if_t<std::is_same_v<T, JsonBoolean const>>* = nullptr>
 bool const& GetImpl(T& val) {  // NOLINT
   return val.GetBoolean();
 }
@@ -600,18 +581,18 @@ JsonObject::Map const& GetImpl(T& val) {  // NOLINT
  * \return Value contained in Json object of type T.
  */
 template <typename T, typename U>
-auto get(U& json) -> decltype(detail::GetImpl(*Cast<T>(&json.GetValue())))& { // NOLINT
+auto get(U& json) -> decltype(detail::GetImpl(*Cast<T>(&json.GetValue())))& {  // NOLINT
   auto& value = *Cast<T>(&json.GetValue());
   return detail::GetImpl(value);
 }
 
-using Object  = JsonObject;
-using Array   = JsonArray;
-using Number  = JsonNumber;
+using Object = JsonObject;
+using Array = JsonArray;
+using Number = JsonNumber;
 using Integer = JsonInteger;
 using Boolean = JsonBoolean;
-using String  = JsonString;
-using Null    = JsonNull;
+using String = JsonString;
+using Null = JsonNull;
 
 /**
  * \brief Convert XGBoost parameter to JSON object.

--- a/include/xgboost/json.h
+++ b/include/xgboost/json.h
@@ -49,9 +49,11 @@ class Value {
     kI8Array = 9,
     kU8Array = 10,
     kI16Array = 11,
+    kU16Array = 12,
     kI32Array = 13,
+    kU32Array = 14,
     kI64Array = 15,
-    // Values 12, 14, and 16 are reserved. ValueKind IDs must remain stable.
+    kU64Array = 16,
   };
 
   explicit Value(ValueKind _kind) : kind_{_kind} {}
@@ -140,7 +142,7 @@ class JsonArray : public Value {
 };
 
 /**
- * \brief Typed array for Universal Binary JSON.
+ * \brief Typed array used by JSON and UBJSON serialization.
  *
  * \tparam T The underlying primitive type.
  * \tparam kind Value kind defined by JSON type.
@@ -192,13 +194,25 @@ using U8Array = JsonTypedArray<std::uint8_t, Value::ValueKind::kU8Array>;
  */
 using I16Array = JsonTypedArray<std::int16_t, Value::ValueKind::kI16Array>;
 /**
+ * @brief Typed JSON array for uint16_t. (Ext type)
+ */
+using U16Array = JsonTypedArray<std::uint16_t, Value::ValueKind::kU16Array>;
+/**
  * @brief Typed UBJSON array for int32_t.
  */
 using I32Array = JsonTypedArray<std::int32_t, Value::ValueKind::kI32Array>;
 /**
+ * @brief Typed JSON array for uint32_t. (Ext type)
+ */
+using U32Array = JsonTypedArray<std::uint32_t, Value::ValueKind::kU32Array>;
+/**
  * @brief Typed UBJSON array for int64_t.
  */
 using I64Array = JsonTypedArray<std::int64_t, Value::ValueKind::kI64Array>;
+/**
+ * @brief Typed JSON array for uint64_t. (Ext type)
+ */
+using U64Array = JsonTypedArray<std::uint64_t, Value::ValueKind::kU64Array>;
 
 class JsonObject : public Value {
  public:

--- a/include/xgboost/json_io.h
+++ b/include/xgboost/json_io.h
@@ -153,8 +153,11 @@ class JsonWriter {
   virtual void Visit(I8Array const* arr);
   virtual void Visit(U8Array const* arr);
   virtual void Visit(I16Array const* arr);
+  virtual void Visit(U16Array const* arr);
   virtual void Visit(I32Array const* arr);
+  virtual void Visit(U32Array const* arr);
   virtual void Visit(I64Array const* arr);
+  virtual void Visit(U64Array const* arr);
   virtual void Visit(JsonObject const* obj);
   virtual void Visit(JsonNumber const* num);
   virtual void Visit(JsonInteger const* num);
@@ -233,8 +236,11 @@ class UBJWriter : public JsonWriter {
   void Visit(I8Array const* arr) override;
   void Visit(U8Array const* arr) override;
   void Visit(I16Array const* arr) override;
+  void Visit(U16Array const* arr) override;
   void Visit(I32Array const* arr) override;
+  void Visit(U32Array const* arr) override;
   void Visit(I64Array const* arr) override;
+  void Visit(U64Array const* arr) override;
   void Visit(JsonObject const* obj) override;
   void Visit(JsonNumber const* num) override;
   void Visit(JsonInteger const* num) override;

--- a/include/xgboost/json_io.h
+++ b/include/xgboost/json_io.h
@@ -153,11 +153,8 @@ class JsonWriter {
   virtual void Visit(I8Array const* arr);
   virtual void Visit(U8Array const* arr);
   virtual void Visit(I16Array const* arr);
-  virtual void Visit(U16Array const* arr);
   virtual void Visit(I32Array const* arr);
-  virtual void Visit(U32Array const* arr);
   virtual void Visit(I64Array const* arr);
-  virtual void Visit(U64Array const* arr);
   virtual void Visit(JsonObject const* obj);
   virtual void Visit(JsonNumber const* num);
   virtual void Visit(JsonInteger const* num);

--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -487,33 +487,24 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
             values = b""
         else:
             inferred = infer_dtype(strarr, skipna=False)
+            values_list = strarr.tolist()
             if inferred == "string":
-                lengths = np.fromiter(
-                    (len(value.encode("utf-8")) for value in strarr),
-                    dtype=np.int64,
-                    count=strarr.size,
-                )
-                offsets = _arrow_string_offsets(lengths)
-                values = "".join(strarr.tolist()).encode("utf-8")
+                encoded = [value.encode("utf-8") for value in values_list]
             elif inferred == "bytes":
-
-                def validated_len(value: bytes) -> int:
-                    value.decode("utf-8")
-                    return len(value)
-
-                lengths = np.fromiter(
-                    (validated_len(value) for value in strarr),
-                    dtype=np.int64,
-                    count=strarr.size,
-                )
-                offsets = _arrow_string_offsets(lengths)
-                values = b"".join(strarr.tolist())
+                encoded = values_list
             else:
                 raise TypeError(
                     "Category index must contain only values of the same type, "
                     "either string or integer. "
                     f"Got values of type `{inferred}`."
                 )
+            lengths = np.fromiter(
+                (len(value) for value in encoded),
+                dtype=np.int64,
+                count=strarr.size,
+            )
+            offsets = _arrow_string_offsets(lengths)
+            values = b"".join(encoded)
 
         if b"\0" in values:
             warnings.warn(

--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -431,29 +431,42 @@ def array_interface_dict(data: np.ndarray) -> ArrayInf:
     return cast(ArrayInf, ainf)
 
 
+def _arrow_string_offsets(lengths: List[int]) -> np.ndarray:
+    """Build 32-bit Arrow string offsets from encoded byte lengths."""
+    if sum(lengths) > np.iinfo(np.int32).max:
+        raise ValueError(
+            "The encoded categories exceed the maximum size of the 32-bit "
+            "offsets used by Arrow string arrays."
+        )
+    offsets = np.empty(len(lengths) + 1, dtype=np.int64)
+    offsets[0] = 0
+    np.cumsum(lengths, dtype=np.int64, out=offsets[1:])
+    return offsets.astype(np.int32)
+
+
 def pd_cat_inf(  # pylint: disable=too-many-locals
     cats: DfCatAccessor, codes: "pd.Series"
 ) -> Tuple[Union[StringArray, ArrayInf], ArrayInf, Tuple]:
     """Get the array interface representation of pandas category accessor."""
+    from pandas.api.types import infer_dtype, is_float_dtype, is_integer_dtype
+
     # pandas uses -1 to represent missing values for categorical features
     codes = codes.replace(-1, np.nan)
 
-    def is_prim() -> bool:
-        dtype = cats.dtype
-        try:
-            return np.issubdtype(dtype, np.floating) or np.issubdtype(dtype, np.integer)
-        except TypeError:
-            return False
-
-    if is_prim():
+    if is_integer_dtype(cats.dtype) or is_float_dtype(cats.dtype):
         # Numeric index type
-        name_values_num = cats.values
+        np_dtype = getattr(cats.dtype, "numpy_dtype", cats.dtype)
+        if hasattr(cats, "to_numpy"):
+            name_values_num = cats.to_numpy(dtype=np_dtype)
+        else:
+            name_values_num = np.asarray(cats.values, dtype=np_dtype)
+        name_values_num = np.require(name_values_num, requirements=["A", "C"])
         jarr_values = array_interface_dict(name_values_num)
         code_values = codes.values
         jarr_codes = array_interface_dict(code_values)
         return jarr_values, jarr_codes, (name_values_num, code_values)
 
-    def npstr_to_arrow_strarr(strarr: Any) -> Tuple[np.ndarray, str]:
+    def npstr_to_arrow_strarr(strarr: Any) -> Tuple[np.ndarray, bytes]:
         """Convert a string-like array to an arrow string array."""
         if not isinstance(strarr, np.ndarray):
             if hasattr(strarr, "to_numpy"):
@@ -461,16 +474,27 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
             else:
                 strarr = np.asarray(strarr, dtype=object)
 
-        lenarr = np.vectorize(len)
-        offsets = np.cumsum(
-            np.concatenate([np.array([0], dtype=np.int64), lenarr(strarr)])
-        )
-        if strarr.dtype.kind == "S":
-            str_list = [s.decode("utf-8") for s in strarr.tolist()]
+        encoded: List[bytes]
+        if strarr.size == 0:
+            encoded = []
         else:
-            str_list = [str(s) for s in strarr.tolist()]
-        values = "".join(str_list)
-        if "\0" in values:
+            inferred = infer_dtype(strarr, skipna=False)
+            if inferred == "string":
+                encoded = [s.encode("utf-8") for s in strarr.tolist()]
+            elif inferred == "bytes":
+                encoded = strarr.tolist()
+                for value in encoded:
+                    value.decode("utf-8")
+            else:
+                raise TypeError(
+                    "Category index must contain only values of the same type, "
+                    "either string or integer. "
+                    f"Got values of type `{inferred}`."
+                )
+
+        offsets = _arrow_string_offsets([len(value) for value in encoded])
+        values = b"".join(encoded)
+        if b"\0" in values:
             warnings.warn(
                 (
                     "Found embedded NUL (\\0) characters in string categories. "
@@ -478,25 +502,13 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
                 ),
                 UserWarning,
             )
-        return offsets.astype(np.int32), values
+        return offsets, values
 
     # String index type
     name_offsets, name_values = npstr_to_arrow_strarr(cats.values)
-    name_offsets, _ = _ensure_np_dtype(name_offsets, np.int32)
     joffsets = array_interface_dict(name_offsets)
-    bvalues = name_values.encode("utf-8")
-
-    ptr = ctypes.c_void_p.from_buffer(ctypes.c_char_p(bvalues)).value
-    assert ptr is not None
-
-    jvalues: ArrayInf = {
-        "data": (ptr, True),
-        "typestr": "|i1",
-        "shape": (len(name_values),),
-        "strides": None,
-        "version": 3,
-        "mask": None,
-    }
+    name_values_np = np.frombuffer(name_values, dtype=np.int8)
+    jvalues = array_interface_dict(name_values_np)
     jnames: StringArray = {"offsets": joffsets, "values": jvalues}
 
     code_values = codes.values
@@ -505,7 +517,7 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
     buf = (
         name_offsets,
         name_values,
-        bvalues,
+        name_values_np,
         code_values,
     )  # store temporary values
     return jnames, jcodes, buf

--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -445,9 +445,9 @@ def _arrow_string_offsets(lengths: List[int]) -> np.ndarray:
 
 
 def pd_cat_inf(  # pylint: disable=too-many-locals
-    cats: DfCatAccessor, codes: "pd.Series"
+    cats: "pd.Index", codes: "pd.Series"
 ) -> Tuple[Union[StringArray, ArrayInf], ArrayInf, Tuple]:
-    """Get the array interface representation of pandas category accessor."""
+    """Get the array interface representation of a pandas category index."""
     from pandas.api.types import infer_dtype, is_float_dtype, is_integer_dtype
 
     # pandas uses -1 to represent missing values for categorical features
@@ -455,14 +455,15 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
 
     if is_integer_dtype(cats.dtype) or is_float_dtype(cats.dtype):
         # Numeric index type
-        np_dtype = getattr(cats.dtype, "numpy_dtype", cats.dtype)
+        cat_dtype: Any = cats.dtype
+        np_dtype = np.dtype(getattr(cat_dtype, "numpy_dtype", cat_dtype))
         if hasattr(cats, "to_numpy"):
             name_values_num = cats.to_numpy(dtype=np_dtype)
         else:
             name_values_num = np.asarray(cats.values, dtype=np_dtype)
         name_values_num = np.require(name_values_num, requirements=["A", "C"])
         jarr_values = array_interface_dict(name_values_num)
-        code_values = codes.values
+        code_values = cast(np.ndarray, codes.values)
         jarr_codes = array_interface_dict(code_values)
         return jarr_values, jarr_codes, (name_values_num, code_values)
 
@@ -511,7 +512,7 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
     jvalues = array_interface_dict(name_values_np)
     jnames: StringArray = {"offsets": joffsets, "values": jvalues}
 
-    code_values = codes.values
+    code_values = cast(np.ndarray, codes.values)
     jcodes = array_interface_dict(code_values)
 
     buf = (

--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -431,16 +431,16 @@ def array_interface_dict(data: np.ndarray) -> ArrayInf:
     return cast(ArrayInf, ainf)
 
 
-def _arrow_string_offsets(lengths: List[int]) -> np.ndarray:
+def _arrow_string_offsets(lengths: np.ndarray) -> np.ndarray:
     """Build 32-bit Arrow string offsets from encoded byte lengths."""
-    if sum(lengths) > np.iinfo(np.int32).max:
+    offsets = np.empty(lengths.size + 1, dtype=np.int64)
+    offsets[0] = 0
+    np.cumsum(lengths, dtype=np.int64, out=offsets[1:])
+    if offsets[-1] > np.iinfo(np.int32).max:
         raise ValueError(
             "The encoded categories exceed the maximum size of the 32-bit "
             "offsets used by Arrow string arrays."
         )
-    offsets = np.empty(len(lengths) + 1, dtype=np.int64)
-    offsets[0] = 0
-    np.cumsum(lengths, dtype=np.int64, out=offsets[1:])
     return offsets.astype(np.int32)
 
 
@@ -475,17 +475,33 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
             else:
                 strarr = np.asarray(strarr, dtype=object)
 
-        encoded: List[bytes]
         if strarr.size == 0:
-            encoded = []
+            lengths = np.empty(0, dtype=np.int64)
+            offsets = _arrow_string_offsets(lengths)
+            values = b""
         else:
             inferred = infer_dtype(strarr, skipna=False)
             if inferred == "string":
-                encoded = [s.encode("utf-8") for s in strarr.tolist()]
+                lengths = np.fromiter(
+                    (len(value.encode("utf-8")) for value in strarr),
+                    dtype=np.int64,
+                    count=strarr.size,
+                )
+                offsets = _arrow_string_offsets(lengths)
+                values = "".join(strarr.tolist()).encode("utf-8")
             elif inferred == "bytes":
-                encoded = strarr.tolist()
-                for value in encoded:
+
+                def validated_len(value: bytes) -> int:
                     value.decode("utf-8")
+                    return len(value)
+
+                lengths = np.fromiter(
+                    (validated_len(value) for value in strarr),
+                    dtype=np.int64,
+                    count=strarr.size,
+                )
+                offsets = _arrow_string_offsets(lengths)
+                values = b"".join(strarr.tolist())
             else:
                 raise TypeError(
                     "Category index must contain only values of the same type, "
@@ -493,8 +509,6 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
                     f"Got values of type `{inferred}`."
                 )
 
-        offsets = _arrow_string_offsets([len(value) for value in encoded])
-        values = b"".join(encoded)
         if b"\0" in values:
             warnings.warn(
                 (

--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -462,6 +462,12 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
         else:
             name_values_num = np.asarray(cats.values, dtype=np_dtype)
         name_values_num = np.require(name_values_num, requirements=["A", "C"])
+        if np_dtype == np.dtype(np.uint64) and np.any(
+            name_values_num > np.iinfo(np.int64).max
+        ):
+            raise ValueError(
+                "Category value is outside the signed 64-bit integer range."
+            )
         jarr_values = array_interface_dict(name_values_num)
         code_values = cast(np.ndarray, codes.values)
         jarr_codes = array_interface_dict(code_values)

--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -466,7 +466,7 @@ def pd_cat_inf(  # pylint: disable=too-many-locals
             name_values_num > np.iinfo(np.int64).max
         ):
             raise ValueError(
-                "Category value is outside the signed 64-bit integer range."
+                "Category index values must not exceed the signed 64-bit range."
             )
         jarr_values = array_interface_dict(name_values_num)
         code_values = cast(np.ndarray, codes.values)

--- a/python-package/xgboost/testing/ordinal.py
+++ b/python-package/xgboost/testing/ordinal.py
@@ -69,7 +69,7 @@ def run_cat_container(device: Device) -> None:
     def run_dispatch(device: Device, DMatrixT: Type) -> None:
         Df, _ = get_df_impl(device)
         # Basic test with a single feature
-        df = Df({"c": ["cdef", "abc"]}, dtype="category")
+        df = Df({"c": ["猫", "café"]}, dtype="category")
         categories = df.c.cat.categories
 
         Xy = DMatrixT(df, enable_categorical=True)
@@ -86,15 +86,15 @@ def run_cat_container(device: Device) -> None:
             )
 
         # Test with missing values.
-        df = Df({"c": ["cdef", None, "abc", "abc"]}, dtype="category")
+        df = Df({"c": ["猫", None, "café", "café"]}, dtype="category")
         Xy = DMatrixT(df, enable_categorical=True)
 
         cats = Xy.get_categories(export_to_arrow=True).to_arrow()
         assert cats is not None
         cats_id = dict(cats)
         ser = cats_id["c"].to_pandas()
-        assert ser.iloc[0] == "abc"
-        assert ser.iloc[1] == "cdef"
+        assert ser.iloc[0] == "café"
+        assert ser.iloc[1] == "猫"
         assert ser.size == 2
 
         csr = Xy.get_data()
@@ -107,7 +107,7 @@ def run_cat_container(device: Device) -> None:
         comp_booster(device, Xy, "dart")
 
         # Test with explicit null-terminated strings.
-        df = Df({"c": ["cdef", None, "abc", "abc\0"]}, dtype="category")
+        df = Df({"c": ["猫", None, "café", "café\0", ""]}, dtype="category")
         Xy = DMatrixT(df, enable_categorical=True)
 
         comp_booster(device, Xy, "gbtree")
@@ -691,33 +691,34 @@ def run_recode_dmatrix(device: Device) -> None:
     Df, _ = get_df_impl(device)
 
     # String index
-    old_cats = ["a", "b", "c", "d"]
-    new_cats = ["b", "a", "c", "d"]
+    old_cats = ["café", "猫", "c", "🐍"]
+    new_cats = ["猫", "café", "c", "🐍"]
 
     col0 = np.arange(0, 9)
     col1 = pd.Categorical.from_codes(
-        # b, b, c, d, a, c, c, d, a
+        # 猫, 猫, c, 🐍, café, c, c, 🐍, café
         categories=old_cats,
         codes=[1, 1, 2, 3, 0, 2, 2, 3, 0],
     )
     df = Df({"f0": col0, "f1": col1})
 
-    Xy = DMatrix(df, enable_categorical=True)
-    cats_0 = Xy.get_categories(export_to_arrow=True)
-    assert Xy.feature_types == ["int", "c"]
+    Xy_0 = DMatrix(df, enable_categorical=True)
+    cats_0 = Xy_0.get_categories(export_to_arrow=True)
+    assert Xy_0.feature_types == ["int", "c"]
 
     col1 = pd.Categorical.from_codes(
-        # b, b, c, d, a, c, c, d, a
+        # 猫, 猫, c, 🐍, café, c, c, 🐍, café
         categories=new_cats,
         codes=[0, 0, 2, 3, 1, 2, 2, 3, 1],
     )
     df = Df({"f0": col0, "f1": col1})
-    Xy = DMatrix(df, enable_categorical=True, feature_types=cats_0)
+    Xy_1 = DMatrix(df, enable_categorical=True, feature_types=cats_0)
     # feature_types is still correct
-    assert Xy.feature_names == ["f0", "f1"]
-    assert Xy.feature_types == ["int", "c"]
-    cats_1 = Xy.get_categories(export_to_arrow=True)
+    assert Xy_1.feature_names == ["f0", "f1"]
+    assert Xy_1.feature_types == ["int", "c"]
+    cats_1 = Xy_1.get_categories(export_to_arrow=True)
     assert cats_0.to_arrow() == cats_1.to_arrow()
+    assert predictor_equal(Xy_0, Xy_1)
 
     # Numeric index
     col0 = pd.Categorical.from_codes(

--- a/src/common/json.cc
+++ b/src/common/json.cc
@@ -39,12 +39,27 @@ namespace {
 auto to_i64 = [](auto v) {
   return Json{static_cast<int64_t>(v)};
 };
+
+void CheckU64Range(U64Array const* arr) {
+  auto const& array = arr->GetArray();
+  auto supported_int = std::none_of(array.cbegin(), array.cend(), [](auto const& v) {
+    return v > static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+  });
+  CHECK(supported_int) << "Unsigned integers larger than INT64_MAX are not supported.";
+}
 }  // anonymous namespace
+
 void JsonWriter::Visit(I8Array const* arr) { this->WriteArray(arr, to_i64); }
 void JsonWriter::Visit(U8Array const* arr) { this->WriteArray(arr, to_i64); }
 void JsonWriter::Visit(I16Array const* arr) { this->WriteArray(arr, to_i64); }
+void JsonWriter::Visit(U16Array const* arr) { this->WriteArray(arr, to_i64); }
 void JsonWriter::Visit(I32Array const* arr) { this->WriteArray(arr, to_i64); }
+void JsonWriter::Visit(U32Array const* arr) { this->WriteArray(arr, to_i64); }
 void JsonWriter::Visit(I64Array const* arr) { this->WriteArray(arr, to_i64); }
+void JsonWriter::Visit(U64Array const* arr) {
+  CheckU64Range(arr);
+  this->WriteArray(arr, to_i64);
+}
 
 void JsonWriter::Visit(JsonObject const* obj) {
   stream_->emplace_back('{');
@@ -158,10 +173,16 @@ std::string Value::TypeStr() const {
       return "U8Array";
     case ValueKind::kI16Array:
       return "I16Array";
+    case ValueKind::kU16Array:
+      return "U16Array";
     case ValueKind::kI32Array:
       return "I32Array";
+    case ValueKind::kU32Array:
+      return "U32Array";
     case ValueKind::kI64Array:
       return "I64Array";
+    case ValueKind::kU64Array:
+      return "U64Array";
   }
   return "";
 }
@@ -280,8 +301,11 @@ template class JsonTypedArray<double, Value::ValueKind::kF64Array>;
 template class JsonTypedArray<std::int8_t, Value::ValueKind::kI8Array>;
 template class JsonTypedArray<std::uint8_t, Value::ValueKind::kU8Array>;
 template class JsonTypedArray<std::int16_t, Value::ValueKind::kI16Array>;
+template class JsonTypedArray<std::uint16_t, Value::ValueKind::kU16Array>;
 template class JsonTypedArray<std::int32_t, Value::ValueKind::kI32Array>;
+template class JsonTypedArray<std::uint32_t, Value::ValueKind::kU32Array>;
 template class JsonTypedArray<std::int64_t, Value::ValueKind::kI64Array>;
+template class JsonTypedArray<std::uint64_t, Value::ValueKind::kU64Array>;
 
 // Json Number
 bool JsonNumber::operator==(Value const& rhs) const {
@@ -950,23 +974,23 @@ void UBJWriter::Visit(JsonArray const* arr) {
   }
 }
 
-template <typename T, Value::ValueKind kind>
-void WriteTypedArray(JsonTypedArray<T, kind> const* arr, std::vector<char>* stream) {
+template <typename StorageT, typename T, Value::ValueKind kind>
+void WriteTypedArrayAs(JsonTypedArray<T, kind> const* arr, std::vector<char>* stream) {
   stream->emplace_back('[');
   stream->push_back('$');
-  if (std::is_same_v<T, float>) {
+  if (std::is_same_v<StorageT, float>) {
     stream->push_back('d');
-  } else if (std::is_same_v<T, double>) {
+  } else if (std::is_same_v<StorageT, double>) {
     stream->push_back('D');
-  } else if (std::is_same_v<T, std::int8_t>) {
+  } else if (std::is_same_v<StorageT, std::int8_t>) {
     stream->push_back('i');
-  } else if (std::is_same_v<T, std::uint8_t>) {
+  } else if (std::is_same_v<StorageT, std::uint8_t>) {
     stream->push_back('U');
-  } else if (std::is_same_v<T, std::int16_t>) {
+  } else if (std::is_same_v<StorageT, std::int16_t>) {
     stream->push_back('I');
-  } else if (std::is_same_v<T, std::int32_t>) {
+  } else if (std::is_same_v<StorageT, std::int32_t>) {
     stream->push_back('l');
-  } else if (std::is_same_v<T, std::int64_t>) {
+  } else if (std::is_same_v<StorageT, std::int64_t>) {
     stream->push_back('L');
   } else {
     LOG(FATAL) << "Not implemented";
@@ -978,13 +1002,25 @@ void WriteTypedArray(JsonTypedArray<T, kind> const* arr, std::vector<char>* stre
   int64_t n = arr->Size();
   WritePrimitive(n, stream);
   auto s = stream->size();
-  stream->resize(s + arr->Size() * sizeof(T));
+  stream->resize(s + arr->Size() * sizeof(StorageT));
   auto const& vec = arr->GetArray();
   for (int64_t i = 0; i < n; ++i) {
-    auto v = ToBigEndian(vec[i]);
+    StorageT v;
+    if constexpr (std::is_same_v<T, StorageT>) {
+      v = vec[i];
+    } else {
+      static_assert(sizeof(T) == sizeof(StorageT));
+      std::memcpy(&v, &vec[i], sizeof(v));
+    }
+    v = ToBigEndian(v);
     std::memcpy(stream->data() + s, &v, sizeof(v));
     s += sizeof(v);
   }
+}
+
+template <typename T, Value::ValueKind kind>
+void WriteTypedArray(JsonTypedArray<T, kind> const* arr, std::vector<char>* stream) {
+  WriteTypedArrayAs<T>(arr, stream);
 }
 
 void UBJWriter::Visit(F32Array const* arr) { WriteTypedArray(arr, stream_); }
@@ -992,8 +1028,11 @@ void UBJWriter::Visit(F64Array const* arr) { WriteTypedArray(arr, stream_); }
 void UBJWriter::Visit(I8Array const* arr) { WriteTypedArray(arr, stream_); }
 void UBJWriter::Visit(U8Array const* arr) { WriteTypedArray(arr, stream_); }
 void UBJWriter::Visit(I16Array const* arr) { WriteTypedArray(arr, stream_); }
+void UBJWriter::Visit(U16Array const* arr) { WriteTypedArrayAs<std::int16_t>(arr, stream_); }
 void UBJWriter::Visit(I32Array const* arr) { WriteTypedArray(arr, stream_); }
+void UBJWriter::Visit(U32Array const* arr) { WriteTypedArrayAs<std::int32_t>(arr, stream_); }
 void UBJWriter::Visit(I64Array const* arr) { WriteTypedArray(arr, stream_); }
+void UBJWriter::Visit(U64Array const* arr) { WriteTypedArrayAs<std::int64_t>(arr, stream_); }
 
 void UBJWriter::Visit(JsonObject const* obj) {
   stream_->emplace_back('{');

--- a/src/common/json.cc
+++ b/src/common/json.cc
@@ -43,11 +43,8 @@ auto to_i64 = [](auto v) {
 void JsonWriter::Visit(I8Array const* arr) { this->WriteArray(arr, to_i64); }
 void JsonWriter::Visit(U8Array const* arr) { this->WriteArray(arr, to_i64); }
 void JsonWriter::Visit(I16Array const* arr) { this->WriteArray(arr, to_i64); }
-void JsonWriter::Visit(U16Array const* arr) { this->WriteArray(arr, to_i64); }
 void JsonWriter::Visit(I32Array const* arr) { this->WriteArray(arr, to_i64); }
-void JsonWriter::Visit(U32Array const* arr) { this->WriteArray(arr, to_i64); }
 void JsonWriter::Visit(I64Array const* arr) { this->WriteArray(arr, to_i64); }
-void JsonWriter::Visit(U64Array const* arr) { this->WriteArray(arr, to_i64); }  // dangerous
 
 void JsonWriter::Visit(JsonObject const* obj) {
   stream_->emplace_back('{');
@@ -161,16 +158,10 @@ std::string Value::TypeStr() const {
       return "U8Array";
     case ValueKind::kI16Array:
       return "I16Array";
-    case ValueKind::kU16Array:
-      return "U16Array";
     case ValueKind::kI32Array:
       return "I32Array";
-    case ValueKind::kU32Array:
-      return "U32Array";
     case ValueKind::kI64Array:
       return "I64Array";
-    case ValueKind::kU64Array:
-      return "U64Array";
   }
   return "";
 }
@@ -289,11 +280,8 @@ template class JsonTypedArray<double, Value::ValueKind::kF64Array>;
 template class JsonTypedArray<std::int8_t, Value::ValueKind::kI8Array>;
 template class JsonTypedArray<std::uint8_t, Value::ValueKind::kU8Array>;
 template class JsonTypedArray<std::int16_t, Value::ValueKind::kI16Array>;
-template class JsonTypedArray<std::uint16_t, Value::ValueKind::kU16Array>;
 template class JsonTypedArray<std::int32_t, Value::ValueKind::kI32Array>;
-template class JsonTypedArray<std::uint32_t, Value::ValueKind::kU32Array>;
 template class JsonTypedArray<std::int64_t, Value::ValueKind::kI64Array>;
-template class JsonTypedArray<std::uint64_t, Value::ValueKind::kU64Array>;
 
 // Json Number
 bool JsonNumber::operator==(Value const& rhs) const {

--- a/src/data/adapter.cc
+++ b/src/data/adapter.cc
@@ -4,8 +4,8 @@
 #include "adapter.h"
 
 #include <algorithm>  // for all_of
+#include <cstddef>    // for size_t
 #include <cstdint>    // for int32_t
-#include <numeric>    // for partial_sum
 #include <utility>    // for move
 #include <vector>     // for vector
 
@@ -39,9 +39,10 @@ ColumnarAdapter::ColumnarAdapter(StringView columns) {
   CHECK(IsA<Array>(jdf));
   auto const& array = get<Array const>(jdf);
   bst_idx_t n_samples{0};
+  std::size_t n_total_cats{0};
   std::vector<std::int32_t> cat_segments{0};
   for (auto const& jcol : array) {
-    std::int32_t n_cats{0};
+    std::size_t n_cats{0};
     if (IsA<Array>(jcol)) {
       // This is a dictionary type (categorical values).
       auto const& first = get<Object const>(jcol[0]);
@@ -61,11 +62,9 @@ ColumnarAdapter::ColumnarAdapter(StringView columns) {
       this->n_bytes_ += columns_.back().ElementSize() * columns_.back().Shape<0>();
       n_samples = std::max(n_samples, static_cast<bst_idx_t>(columns_.back().Shape<0>()));
     }
-    cat_segments.push_back(n_cats);
+    n_total_cats = AddCatCount(n_cats, n_total_cats);
+    cat_segments.push_back(static_cast<std::int32_t>(n_total_cats));
   }
-  std::partial_sum(cat_segments.cbegin(), cat_segments.cend(), cat_segments.begin());
-  auto no_overflow = std::is_sorted(cat_segments.cbegin(), cat_segments.cend());
-  CHECK(no_overflow) << "Maximum number of categories exceeded.";
 
   // Check consistency.
   bool consistent = columns_.empty() || std::all_of(columns_.cbegin(), columns_.cend(),

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -3,11 +3,13 @@
  */
 #include "cat_container.h"
 
-#include <algorithm>  // for copy
-#include <cstddef>    // for size_t
-#include <memory>     // for make_unique
-#include <utility>    // for move
-#include <vector>     // for vector
+#include <algorithm>    // for copy
+#include <cstddef>      // for size_t
+#include <limits>       // for numeric_limits
+#include <memory>       // for make_unique
+#include <type_traits>  // for is_integral_v
+#include <utility>      // for move
+#include <vector>       // for vector
 
 #include "../collective/allreduce.h"         // for Allreduce
 #include "../collective/communicator-inl.h"  // for GetRank, GetWorldSize
@@ -64,41 +66,72 @@ CatContainer::CatContainer(enc::HostColumnsView const& df, bool is_ref) : CatCon
 }
 
 namespace {
+// These IDs are part of the serialized category schema and must remain stable. Unsigned
+// category values wider than uint8 are stored in the next larger signed UBJSON type.
+enum class CatIndexType : std::int64_t {
+  kF32 = 7,
+  kF64 = 8,
+  kI8 = 9,
+  kU8 = 10,
+  kI16 = 11,
+  kU16 = 12,
+  kI32 = 13,
+  kU32 = 14,
+  kI64 = 15,
+  kU64 = 16,
+};
+
 template <typename T>
-struct PrimToUbj;
+struct CatToJson;
+
+template <typename SerializedArrayT, CatIndexType category_type>
+struct CatToJsonImpl {
+  using SerializedArray = SerializedArrayT;
+  static constexpr CatIndexType kCategoryType{category_type};
+};
 
 template <>
-struct PrimToUbj<std::uint8_t> {
-  using Type = U8Array;
-};
+struct CatToJson<std::uint8_t> : CatToJsonImpl<U8Array, CatIndexType::kU8> {};
 template <>
-struct PrimToUbj<std::uint16_t> {
-  using Type = U16Array;
-};
+struct CatToJson<std::int8_t> : CatToJsonImpl<I8Array, CatIndexType::kI8> {};
 template <>
-struct PrimToUbj<std::uint32_t> {
-  using Type = U32Array;
-};
+struct CatToJson<std::int16_t> : CatToJsonImpl<I16Array, CatIndexType::kI16> {};
 template <>
-struct PrimToUbj<std::uint64_t> {
-  using Type = U64Array;
-};
+struct CatToJson<std::int32_t> : CatToJsonImpl<I32Array, CatIndexType::kI32> {};
 template <>
-struct PrimToUbj<std::int8_t> {
-  using Type = I8Array;
-};
+struct CatToJson<std::int64_t> : CatToJsonImpl<I64Array, CatIndexType::kI64> {};
+// There's no unsigned type in ubjson
 template <>
-struct PrimToUbj<std::int16_t> {
-  using Type = I16Array;
-};
+struct CatToJson<std::uint16_t> : CatToJsonImpl<I32Array, CatIndexType::kU16> {};
 template <>
-struct PrimToUbj<std::int32_t> {
-  using Type = I32Array;
-};
+struct CatToJson<std::uint32_t> : CatToJsonImpl<I64Array, CatIndexType::kU32> {};
 template <>
-struct PrimToUbj<std::int64_t> {
-  using Type = I64Array;
-};
+struct CatToJson<std::uint64_t> : CatToJsonImpl<I64Array, CatIndexType::kU64> {};
+
+template <typename Out, typename In>
+Out CheckedCatCast(In value) {
+  static_assert(std::is_integral_v<Out>);
+  static_assert(std::is_integral_v<In>);
+  if constexpr (std::is_unsigned_v<Out>) {
+    if constexpr (std::is_signed_v<In>) {
+      CHECK_GE(value, 0) << "Invalid negative category value.";
+    }
+    auto unsigned_value = static_cast<std::uint64_t>(value);
+    CHECK_LE(unsigned_value, static_cast<std::uint64_t>(std::numeric_limits<Out>::max()))
+        << "Category value is outside the supported range.";
+  } else if constexpr (std::is_unsigned_v<In>) {
+    CHECK_LE(static_cast<std::uint64_t>(value),
+             static_cast<std::uint64_t>(std::numeric_limits<Out>::max()))
+        << "Category value is outside the signed 64-bit integer range.";
+  } else {
+    auto signed_value = static_cast<std::int64_t>(value);
+    CHECK_GE(signed_value, static_cast<std::int64_t>(std::numeric_limits<Out>::min()))
+        << "Category value is outside the supported range.";
+    CHECK_LE(signed_value, static_cast<std::int64_t>(std::numeric_limits<Out>::max()))
+        << "Category value is outside the supported range.";
+  }
+  return static_cast<Out>(value);
+}
 }  // anonymous namespace
 
 void CatContainer::Save(Json* p_out) const {
@@ -127,12 +160,15 @@ void CatContainer::Save(Json* p_out) const {
                    [&f_out](auto&& values) {
                      using T =
                          std::remove_cv_t<typename std::decay_t<decltype(values)>::value_type>;
-                     using JT = typename PrimToUbj<T>::Type;
-                     JT array{values.size()};
-                     std::copy_n(values.data(), values.size(), array.GetArray().begin());
+                     using Serialization = CatToJson<T>;
+                     using SerializedArray = typename Serialization::SerializedArray;
+                     using SerializedValue = typename SerializedArray::value_type;
+                     SerializedArray array{values.size()};
+                     std::transform(values.cbegin(), values.cend(), array.GetArray().begin(),
+                                    [](T value) { return CheckedCatCast<SerializedValue>(value); });
 
                      Object out{};
-                     out["type"] = static_cast<std::int64_t>(array.Type());
+                     out["type"] = static_cast<std::int64_t>(Serialization::kCategoryType);
                      out["values"] = std::move(array);
 
                      f_out = std::move(out);
@@ -158,17 +194,21 @@ namespace {
 // Dispatch method for JSON and UBJSON
 template <typename U, typename Vec>
 void LoadJson(Json jvalues, Vec* p_out) {
+  std::vector<U> buf;
   if (IsA<Array>(jvalues)) {
     auto const& jarray = get<Array const>(jvalues);
-    std::vector<U> buf(jarray.size());
+    buf.resize(jarray.size());
     for (std::size_t i = 0, n = jarray.size(); i < n; ++i) {
-      buf[i] = static_cast<U>(get<Integer const>(jarray[i]));
+      buf[i] = CheckedCatCast<U>(get<Integer const>(jarray[i]));
     }
-    *p_out = std::move(buf);
-    return;
+  } else {
+    using SerializedArray = typename CatToJson<U>::SerializedArray;
+    auto const& values = get<SerializedArray const>(jvalues);
+    buf.resize(values.size());
+    std::transform(values.cbegin(), values.cend(), buf.begin(),
+                   [](auto value) { return CheckedCatCast<U>(value); });
   }
-  auto const& values = get<std::add_const_t<typename PrimToUbj<U>::Type>>(jvalues);
-  *p_out = std::move(values);
+  *p_out = std::move(buf);
 }
 }  // namespace
 
@@ -190,44 +230,43 @@ void CatContainer::Load(Json const& in) {
     } else {
       // numeric
       auto type = get<Integer const>(column.at("type"));
-      using T = Value::ValueKind;
       auto const& jvalues = column.at("values");
       columns.emplace_back();
-      switch (static_cast<Value::ValueKind>(type)) {
-        case T::kI8Array: {
+      switch (static_cast<CatIndexType>(type)) {
+        case CatIndexType::kI8: {
           LoadJson<std::int8_t>(jvalues, &columns.back());
           break;
         }
-        case T::kU8Array: {
+        case CatIndexType::kU8: {
           LoadJson<std::uint8_t>(jvalues, &columns.back());
           break;
         }
-        case T::kI16Array: {
+        case CatIndexType::kI16: {
           LoadJson<std::int16_t>(jvalues, &columns.back());
           break;
         }
-        case T::kU16Array: {
+        case CatIndexType::kU16: {
           LoadJson<std::uint16_t>(jvalues, &columns.back());
           break;
         }
-        case T::kI32Array: {
+        case CatIndexType::kI32: {
           LoadJson<std::int32_t>(jvalues, &columns.back());
           break;
         }
-        case T::kU32Array: {
+        case CatIndexType::kU32: {
           LoadJson<std::uint32_t>(jvalues, &columns.back());
           break;
         }
-        case T::kI64Array: {
+        case CatIndexType::kI64: {
           LoadJson<std::int64_t>(jvalues, &columns.back());
           break;
         }
-        case T::kU64Array: {
+        case CatIndexType::kU64: {
           LoadJson<std::uint64_t>(jvalues, &columns.back());
           break;
         }
-        case T::kF32Array:
-        case T::kF64Array: {
+        case CatIndexType::kF32:
+        case CatIndexType::kF64: {
           LOG(FATAL) << error::NoFloatCat();
           break;
         }

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -107,31 +107,6 @@ template <>
 struct CatToJson<std::uint32_t> : CatToJsonImpl<I64Array, CatIndexType::kU32> {};
 template <>
 struct CatToJson<std::uint64_t> : CatToJsonImpl<I64Array, CatIndexType::kU64> {};
-
-template <typename Out, typename In>
-Out CheckedCatCast(In value) {
-  static_assert(std::is_integral_v<Out>);
-  static_assert(std::is_integral_v<In>);
-  if constexpr (std::is_unsigned_v<Out>) {
-    if constexpr (std::is_signed_v<In>) {
-      CHECK_GE(value, 0) << "Invalid negative category value.";
-    }
-    auto unsigned_value = static_cast<std::uint64_t>(value);
-    CHECK_LE(unsigned_value, static_cast<std::uint64_t>(std::numeric_limits<Out>::max()))
-        << "Category value is outside the supported range.";
-  } else if constexpr (std::is_unsigned_v<In>) {
-    CHECK_LE(static_cast<std::uint64_t>(value),
-             static_cast<std::uint64_t>(std::numeric_limits<Out>::max()))
-        << "Category value is outside the signed 64-bit integer range.";
-  } else {
-    auto signed_value = static_cast<std::int64_t>(value);
-    CHECK_GE(signed_value, static_cast<std::int64_t>(std::numeric_limits<Out>::min()))
-        << "Category value is outside the supported range.";
-    CHECK_LE(signed_value, static_cast<std::int64_t>(std::numeric_limits<Out>::max()))
-        << "Category value is outside the supported range.";
-  }
-  return static_cast<Out>(value);
-}
 }  // anonymous namespace
 
 void CatContainer::Save(Json* p_out) const {
@@ -165,7 +140,7 @@ void CatContainer::Save(Json* p_out) const {
                      using SerializedValue = typename SerializedArray::value_type;
                      SerializedArray array{values.size()};
                      std::transform(values.cbegin(), values.cend(), array.GetArray().begin(),
-                                    [](T value) { return CheckedCatCast<SerializedValue>(value); });
+                                    [](T value) { return static_cast<SerializedValue>(value); });
 
                      Object out{};
                      out["type"] = static_cast<std::int64_t>(Serialization::kCategoryType);
@@ -199,14 +174,14 @@ void LoadJson(Json jvalues, Vec* p_out) {
     auto const& jarray = get<Array const>(jvalues);
     buf.resize(jarray.size());
     for (std::size_t i = 0, n = jarray.size(); i < n; ++i) {
-      buf[i] = CheckedCatCast<U>(get<Integer const>(jarray[i]));
+      buf[i] = static_cast<U>(get<Integer const>(jarray[i]));
     }
   } else {
     using SerializedArray = typename CatToJson<U>::SerializedArray;
     auto const& values = get<SerializedArray const>(jvalues);
     buf.resize(values.size());
     std::transform(values.cbegin(), values.cend(), buf.begin(),
-                   [](auto value) { return CheckedCatCast<U>(value); });
+                   [](auto value) { return static_cast<U>(value); });
   }
   *p_out = std::move(buf);
 }

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -84,9 +84,9 @@ enum class CatIndexType : std::int64_t {
 template <typename T>
 struct CatToJson;
 
-template <typename SerializedArrayT, CatIndexType category_type>
+template <typename JsonArrayT, CatIndexType category_type>
 struct CatToJsonImpl {
-  using SerializedArray = SerializedArrayT;
+  using JsonArray = JsonArrayT;
   static constexpr CatIndexType kCategoryType{category_type};
 };
 
@@ -100,13 +100,21 @@ template <>
 struct CatToJson<std::int32_t> : CatToJsonImpl<I32Array, CatIndexType::kI32> {};
 template <>
 struct CatToJson<std::int64_t> : CatToJsonImpl<I64Array, CatIndexType::kI64> {};
-// There's no unsigned type in ubjson
 template <>
-struct CatToJson<std::uint16_t> : CatToJsonImpl<I32Array, CatIndexType::kU16> {};
+struct CatToJson<std::uint16_t> : CatToJsonImpl<U16Array, CatIndexType::kU16> {};
 template <>
-struct CatToJson<std::uint32_t> : CatToJsonImpl<I64Array, CatIndexType::kU32> {};
+struct CatToJson<std::uint32_t> : CatToJsonImpl<U32Array, CatIndexType::kU32> {};
 template <>
-struct CatToJson<std::uint64_t> : CatToJsonImpl<I64Array, CatIndexType::kU64> {};
+struct CatToJson<std::uint64_t> : CatToJsonImpl<U64Array, CatIndexType::kU64> {};
+
+template <typename In, typename Out>
+void CopyBitPattern(std::vector<In> const& in, std::vector<Out>* out) {
+  static_assert(sizeof(In) == sizeof(Out));
+  out->resize(in.size());
+  if (!in.empty()) {
+    std::memcpy(out->data(), in.data(), in.size() * sizeof(In));
+  }
+}
 }  // anonymous namespace
 
 void CatContainer::Save(Json* p_out) const {
@@ -119,36 +127,42 @@ void CatContainer::Save(Json* p_out) const {
     auto& f_out = arr[fidx];
 
     auto const& col = columns[fidx];
-    std::visit(enc::Overloaded{
-                   [&f_out](cpu_impl::CatStrArray const& str) {
-                     f_out = Object{};
-                     I32Array joffsets{str.offsets.size()};
-                     auto const& f_offsets = str.offsets;
-                     std::copy(f_offsets.cbegin(), f_offsets.cend(), joffsets.GetArray().begin());
-                     f_out["offsets"] = std::move(joffsets);
+    std::visit(
+        enc::Overloaded{
+            [&f_out](cpu_impl::CatStrArray const& str) {
+              f_out = Object{};
+              I32Array joffsets{str.offsets.size()};
+              auto const& f_offsets = str.offsets;
+              std::copy(f_offsets.cbegin(), f_offsets.cend(), joffsets.GetArray().begin());
+              f_out["offsets"] = std::move(joffsets);
 
-                     I8Array jnames{str.values.size()};  // fixme: uint8
-                     auto const& f_names = str.values;
-                     std::copy(f_names.cbegin(), f_names.cend(), jnames.GetArray().begin());
-                     f_out["values"] = std::move(jnames);
-                   },
-                   [&f_out](auto&& values) {
-                     using T =
-                         std::remove_cv_t<typename std::decay_t<decltype(values)>::value_type>;
-                     using Serialization = CatToJson<T>;
-                     using SerializedArray = typename Serialization::SerializedArray;
-                     using SerializedValue = typename SerializedArray::value_type;
-                     SerializedArray array{values.size()};
-                     std::transform(values.cbegin(), values.cend(), array.GetArray().begin(),
-                                    [](T value) { return static_cast<SerializedValue>(value); });
+              I8Array jnames{str.values.size()};  // fixme: uint8
+              auto const& f_names = str.values;
+              std::copy(f_names.cbegin(), f_names.cend(), jnames.GetArray().begin());
+              f_out["values"] = std::move(jnames);
+            },
+            [&f_out](auto&& values) {
+              using T = std::remove_cv_t<typename std::decay_t<decltype(values)>::value_type>;
+              using Serialization = CatToJson<T>;
+              if constexpr (std::is_same_v<T, std::uint64_t>) {
+                auto valid = std::all_of(values.cbegin(), values.cend(), [](T value) {
+                  return value <=
+                         static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+                });
+                CHECK(valid) << "Category index values must not exceed the signed 64-bit range.";
+              }
+              using JsonArray = typename Serialization::JsonArray;
+              JsonArray array{values.size()};
+              auto& serialized = array.GetArray();
+              std::copy(values.cbegin(), values.cend(), serialized.begin());
 
-                     Object out{};
-                     out["type"] = static_cast<std::int64_t>(Serialization::kCategoryType);
-                     out["values"] = std::move(array);
+              Object out{};
+              out["type"] = static_cast<std::int64_t>(Serialization::kCategoryType);
+              out["values"] = std::move(array);
 
-                     f_out = std::move(out);
-                   }},
-               col);
+              f_out = std::move(out);
+            }},
+        col);
   }
 
   auto jf_segments = I32Array{this->feature_segments_.Size()};
@@ -166,22 +180,32 @@ void CatContainer::Save(Json* p_out) const {
 }
 
 namespace {
+// UBJSON only supports uint8; wider unsigned arrays use same-width signed storage.
+template <typename T>
+using UbjUnsignedStorageT =
+    std::conditional_t<(std::is_unsigned_v<T> && sizeof(T) > 1), std::make_signed_t<T>, T>;
+
 // Dispatch method for JSON and UBJSON
 template <typename U, typename Vec>
 void LoadJson(Json jvalues, Vec* p_out) {
   std::vector<U> buf;
-  if (IsA<Array>(jvalues)) {
+  if (IsA<Array>(jvalues)) {  // JSON
     auto const& jarray = get<Array const>(jvalues);
     buf.resize(jarray.size());
     for (std::size_t i = 0, n = jarray.size(); i < n; ++i) {
       buf[i] = static_cast<U>(get<Integer const>(jarray[i]));
     }
-  } else {
-    using SerializedArray = typename CatToJson<U>::SerializedArray;
-    auto const& values = get<SerializedArray const>(jvalues);
-    buf.resize(values.size());
-    std::transform(values.cbegin(), values.cend(), buf.begin(),
-                   [](auto value) { return static_cast<U>(value); });
+  } else {  // UBJSON
+    using JsonArray = typename CatToJson<U>::JsonArray;
+    if (IsA<JsonArray>(jvalues)) {  // Matches
+      auto const& values = get<JsonArray const>(jvalues);
+      buf.assign(values.cbegin(), values.cend());
+    } else {  // Unsigned, needs to bit cast
+      using UBJArray = typename CatToJson<UbjUnsignedStorageT<U>>::JsonArray;
+      CHECK((std::is_unsigned_v<U> && !std::is_same_v<U, std::uint8_t>));
+      auto const& values = get<UBJArray const>(jvalues);
+      CopyBitPattern(values, &buf);
+    }
   }
   *p_out = std::move(buf);
 }

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -43,12 +43,6 @@ CatContainer::CatContainer(enc::HostColumnsView const& df, bool is_ref) : CatCon
                      using T =
                          typename cpu_impl::ViewToStorageImpl<std::decay_t<decltype(values)>>::Type;
                      this->cpu_impl_->columns.emplace_back();
-                     using ElemT = typename T::value_type;
-
-                     if constexpr (std::is_floating_point_v<ElemT>) {
-                       LOG(FATAL) << error::NoFloatCat();
-                     }
-
                      this->cpu_impl_->columns.back().emplace<T>();
                      auto& v = std::get<T>(this->cpu_impl_->columns.back());
                      v.resize(values.size());
@@ -104,14 +98,6 @@ struct PrimToUbj<std::int32_t> {
 template <>
 struct PrimToUbj<std::int64_t> {
   using Type = I64Array;
-};
-template <>
-struct PrimToUbj<float> {
-  using Type = F32Array;
-};
-template <>
-struct PrimToUbj<double> {
-  using Type = F64Array;
 };
 }  // anonymous namespace
 
@@ -240,12 +226,9 @@ void CatContainer::Load(Json const& in) {
           LoadJson<std::uint64_t>(jvalues, &columns.back());
           break;
         }
-        case T::kF32Array: {
-          LoadJson<float>(jvalues, &columns.back());
-          break;
-        }
+        case T::kF32Array:
         case T::kF64Array: {
-          LoadJson<double>(jvalues, &columns.back());
+          LOG(FATAL) << error::NoFloatCat();
           break;
         }
         default: {

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -1,11 +1,10 @@
 /**
- * Copyright 2025, XGBoost Contributors
+ * Copyright 2025-2026, XGBoost Contributors
  */
 #include "cat_container.h"
 
 #include <algorithm>    // for copy
 #include <cstddef>      // for size_t
-#include <limits>       // for numeric_limits
 #include <memory>       // for make_unique
 #include <type_traits>  // for is_integral_v
 #include <utility>      // for move

--- a/src/data/cat_container.cc
+++ b/src/data/cat_container.cc
@@ -5,8 +5,10 @@
 
 #include <algorithm>    // for copy
 #include <cstddef>      // for size_t
+#include <cstring>      // for memcpy
+#include <limits>       // for numeric_limits
 #include <memory>       // for make_unique
-#include <type_traits>  // for is_integral_v
+#include <type_traits>  // for is_same_v
 #include <utility>      // for move
 #include <vector>       // for vector
 
@@ -65,8 +67,7 @@ CatContainer::CatContainer(enc::HostColumnsView const& df, bool is_ref) : CatCon
 }
 
 namespace {
-// These IDs are part of the serialized category schema and must remain stable. Unsigned
-// category values wider than uint8 are stored in the next larger signed UBJSON type.
+// These IDs are part of the serialized category schema and must remain stable.
 enum class CatIndexType : std::int64_t {
   kF32 = 7,
   kF64 = 8,

--- a/src/data/columnar.h
+++ b/src/data/columnar.h
@@ -8,6 +8,7 @@
 #include <algorithm>    // for max
 #include <cstddef>      // for size_t
 #include <cstdint>      // for int32_t
+#include <limits>       // for numeric_limits
 #include <type_traits>  // for is_floating_point_v
 #include <vector>       // for vector
 
@@ -27,6 +28,13 @@
 namespace xgboost::data {
 inline void CheckNonEmptyCategory(std::size_t n_categories) {
   CHECK_GT(n_categories, 0) << "Categorical feature must have at least one category.";
+}
+
+inline std::size_t AddCatCount(std::size_t n_categories, std::size_t n_total_categories) {
+  constexpr auto kMax = static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max());
+  CHECK_LE(n_total_categories, kMax) << "Maximum number of categories exceeded.";
+  CHECK_LE(n_categories, kMax - n_total_categories) << "Maximum number of categories exceeded.";
+  return n_total_categories + n_categories;
 }
 
 /**

--- a/src/data/columnar.h
+++ b/src/data/columnar.h
@@ -69,7 +69,7 @@ auto GetArrowNames(Object::Map const& jnames, std::vector<CategoricalIndex>* p_c
     DispatchDType(offset.type, [&](auto t) {
       using T = decltype(t);
       if constexpr (std::is_same_v<T, std::int32_t>) {
-        auto back = offset(offset_last_idx);
+        T back = TypedIndex<T, 1>{offset}(offset_last_idx);
         CHECK_GE(back, 0) << "Invalid negative string offset from category index.";
         CHECK_LE(static_cast<std::size_t>(back), strbuf.n)
             << "String offset exceeds the category values buffer.";

--- a/src/data/columnar.h
+++ b/src/data/columnar.h
@@ -25,6 +25,10 @@
 #endif
 
 namespace xgboost::data {
+inline void CheckNonEmptyCategory(std::size_t n_categories) {
+  CHECK_GT(n_categories, 0) << "Categorical feature must have at least one category.";
+}
+
 /**
  * @brief Get string-based category index from arrow.
  *
@@ -41,27 +45,22 @@ auto GetArrowNames(Object::Map const& jnames, std::vector<CategoricalIndex>* p_c
   auto strbuf = ArrayInterface<1>(jstr);
 
   // Obtain the size of the string buffer using the offset
-  CHECK_GE(offset.n, 2);
+  CHECK_GE(offset.n, 1);
   auto offset_last_idx = offset.n - 1;
   if (ArrayInterfaceHandler::IsCudaPtr(offset.data)) {
     CHECK_EQ(strbuf.n, 0);  // Unknown
 #if defined(XGBOOST_USE_CUDA)
     DispatchDType(offset.type, [&](auto t) {
       using T = decltype(t);
-      if (!std::is_same_v<T, std::int32_t>) {
+      if constexpr (std::is_same_v<T, std::int32_t>) {
+        T back{0};
+        dh::safe_cuda(cudaMemcpy(&back, static_cast<T const*>(offset.data) + offset_last_idx,
+                                 sizeof(T), cudaMemcpyDeviceToHost));
+        CHECK_GE(back, 0) << "Invalid negative string offset from category index.";
+        strbuf.n = static_cast<std::size_t>(back);
+      } else {
         LOG(FATAL) << "Invalid type for the string offset from category index.";
       }
-#if defined(__CUDACC__) && !defined(__clang__)
-#pragma nv_diagnostic push
-#pragma nv_diag_suppress 20208  // long double is treated as double in device code
-#endif                          // defined(__CUDACC__) && !defined(__clang__)
-      T back{0};
-      dh::safe_cuda(cudaMemcpy(&back, static_cast<T const*>(offset.data) + offset_last_idx,
-                               sizeof(T), cudaMemcpyDeviceToHost));
-      strbuf.n = back;
-#if defined(__CUDACC__) && !defined(__clang__)
-#pragma nv_diagnostic pop
-#endif  // defined(__CUDACC__) && !defined(__clang__)
     });
 #else
     common::AssertGPUSupport();
@@ -69,11 +68,15 @@ auto GetArrowNames(Object::Map const& jnames, std::vector<CategoricalIndex>* p_c
   } else {
     DispatchDType(offset.type, [&](auto t) {
       using T = decltype(t);
-      if (!std::is_same_v<T, std::int32_t>) {
+      if constexpr (std::is_same_v<T, std::int32_t>) {
+        auto back = offset(offset_last_idx);
+        CHECK_GE(back, 0) << "Invalid negative string offset from category index.";
+        CHECK_LE(static_cast<std::size_t>(back), strbuf.n)
+            << "String offset exceeds the category values buffer.";
+        strbuf.n = static_cast<std::size_t>(back);
+      } else {
         LOG(FATAL) << "Invalid type for the string offset from category index.";
       }
-      auto back = offset(offset_last_idx);
-      strbuf.n = back;
     });
   }
 
@@ -100,6 +103,7 @@ template <typename CategoricalIndex, bool allow_mask>
   CHECK_EQ(tup.size(), 2);
 
   auto names = GetArrowNames(get<Object const>(tup[0]), p_cat_columns);
+  CheckNonEmptyCategory(names.size());
 
   // arrow Integer array for encoded categories
   auto const& jcodes = get<Object const>(tup[1]);
@@ -124,19 +128,19 @@ template <typename CategoricalIndex>
                                                std::vector<CategoricalIndex>* p_cat_columns,
                                                std::size_t* p_n_bytes) {
   auto names = ArrayInterface<1>{jnames};
+  CheckNonEmptyCategory(names.n);
   auto& n_bytes = *p_n_bytes;
   DispatchDType(names, device, [&](auto t) {
     using T = typename decltype(t)::value_type;
-    constexpr bool kKnownType = enc::MemberOf<std::remove_cv_t<T>, enc::CatPrimIndexTypes>::value;
-    CHECK(kKnownType) << "Unsupported categorical index type: `"
-                      << ArrayInterfaceHandler::TypeStr(names.type) << "`.";
     if constexpr (std::is_floating_point_v<T>) {
       LOG(FATAL) << error::NoFloatCat();
-    }
-    auto span = common::Span{t.Values().data(), t.Size()};
-    if constexpr (kKnownType) {
+    } else if constexpr (enc::MemberOf<std::remove_cv_t<T>, enc::CatPrimIndexTypes>::value) {
+      auto span = common::Span{t.Values().data(), t.Size()};
       p_cat_columns->emplace_back(span);
       n_bytes += span.size_bytes();
+    } else {
+      LOG(FATAL) << "Unsupported categorical index type: `"
+                 << ArrayInterfaceHandler::TypeStr(names.type) << "`.";
     }
   });
   return names.n;

--- a/src/data/device_adapter.cu
+++ b/src/data/device_adapter.cu
@@ -2,6 +2,7 @@
  * Copyright 2019-2026, XGBoost Contributors
  */
 #include <algorithm>  // for all_of
+#include <cstddef>    // for size_t
 
 #include "../common/cuda_rt_utils.h"  // for SetDevice, CurrentDevice
 #include "columnar.h"                 // for GetRefCats, GetArrowDictionary
@@ -39,10 +40,11 @@ CudfAdapter::CudfAdapter(StringView cuda_arrinf) {
   CHECK_GT(n_columns, 0) << "The number of columns must not equal to 0.";
 
   std::vector<ArrayInterface<1>> columns;
+  std::size_t n_total_cats{0};
   std::vector<std::int32_t> cat_segments{0};
   std::int32_t device = -1;
   for (auto const& jcol : jcolumns) {
-    std::int32_t n_cats{0};
+    std::size_t n_cats{0};
     if (IsA<Array>(jcol)) {
       // This is a dictionary type (categorical values).
       auto const& first = get<Object const>(jcol[0]);
@@ -68,7 +70,8 @@ CudfAdapter::CudfAdapter(StringView cuda_arrinf) {
       this->num_rows_ = std::max(num_rows_, col.Shape<0>());
       n_bytes_ += col.ElementSize() * col.Shape<0>();
     }
-    cat_segments.emplace_back(n_cats);
+    n_total_cats = AddCatCount(n_cats, n_total_cats);
+    cat_segments.emplace_back(static_cast<std::int32_t>(n_total_cats));
     if (device == -1) {
       device = dh::CudaGetPointerDevice(columns.back().data);
     }
@@ -81,7 +84,6 @@ CudfAdapter::CudfAdapter(StringView cuda_arrinf) {
   CHECK(consistent) << "All columns should have the same number of rows.";
 
   // Categories
-  std::partial_sum(cat_segments.cbegin(), cat_segments.cend(), cat_segments.begin());
   this->n_total_cats_ = cat_segments.back();
   this->cat_segments_ = std::move(cat_segments);
   this->d_cats_ = this->cats_;  // thrust copy

--- a/src/data/device_adapter.cu
+++ b/src/data/device_adapter.cu
@@ -49,6 +49,7 @@ CudfAdapter::CudfAdapter(StringView cuda_arrinf) {
         if (device == -1) {
           auto const& first = get<Object const>(jcol[0]);
           auto names = ArrayInterface<1>{first};
+          CheckNonEmptyCategory(names.n);
           device = dh::CudaGetPointerDevice(names.data);
         }
         n_cats = GetArrowNumericIndex(DeviceOrd::CUDA(device), jcol, &cats_, &columns, &n_bytes_,

--- a/src/data/device_adapter.cu
+++ b/src/data/device_adapter.cu
@@ -1,6 +1,8 @@
 /**
- * Copyright 2019-2025, XGBoost Contributors
+ * Copyright 2019-2026, XGBoost Contributors
  */
+#include <algorithm>  // for all_of
+
 #include "../common/cuda_rt_utils.h"  // for SetDevice, CurrentDevice
 #include "columnar.h"                 // for GetRefCats, GetArrowDictionary
 #include "device_adapter.cuh"
@@ -64,7 +66,6 @@ CudfAdapter::CudfAdapter(StringView cuda_arrinf) {
       columns.push_back(col);
       this->cats_.emplace_back();
       this->num_rows_ = std::max(num_rows_, col.Shape<0>());
-      CHECK_EQ(num_rows_, col.Shape<0>()) << "All columns should have the same number of rows.";
       n_bytes_ += col.ElementSize() * col.Shape<0>();
     }
     cat_segments.emplace_back(n_cats);
@@ -74,6 +75,11 @@ CudfAdapter::CudfAdapter(StringView cuda_arrinf) {
     CHECK_EQ(device, dh::CudaGetPointerDevice(columns.back().data))
         << "All columns should use the same device.";
   }
+  auto consistent = std::all_of(columns.cbegin(), columns.cend(), [this](auto const& column) {
+    return column.template Shape<0>() == this->num_rows_;
+  });
+  CHECK(consistent) << "All columns should have the same number of rows.";
+
   // Categories
   std::partial_sum(cat_segments.cbegin(), cat_segments.cend(), cat_segments.begin());
   this->n_total_cats_ = cat_segments.back();

--- a/src/encoder/ordinal.h
+++ b/src/encoder/ordinal.h
@@ -78,11 +78,10 @@ struct CatStrArrayView {
 // add specializations. This way we can modify the type list with ease.
 
 /**
- * @brief All the primitive types supported by the encoder.
+ * @brief All the primitive integer types supported by the encoder.
  */
-using CatPrimIndexTypes =
-    std::tuple<std::uint8_t, std::int8_t, std::uint16_t, std::int16_t, std::uint32_t, std::int32_t,
-               std::uint64_t, std::int64_t, float, double>;
+using CatPrimIndexTypes = std::tuple<std::uint8_t, std::int8_t, std::uint16_t, std::int16_t,
+                                     std::uint32_t, std::int32_t, std::uint64_t, std::int64_t>;
 
 /**
  * @brief All the column types supported by the encoder.

--- a/tests/cpp/data/test_adapter.cc
+++ b/tests/cpp/data/test_adapter.cc
@@ -112,14 +112,14 @@ class CSRIterForTest {
       0, 1, 0, 1, 1};
   std::vector<std::remove_pointer_t<decltype(std::declval<XGBoostBatchCSR>().offset)>> row_ptr_{
       0, 2, 4, 5, 5};
-  size_t iter_ {0};
+  size_t iter_{0};
 
  public:
-  size_t static constexpr kRows { 4 };  // Test for the last row being empty
-  size_t static constexpr kCols { 13 };  // Test for having some missing columns
+  size_t static constexpr kRows{4};   // Test for the last row being empty
+  size_t static constexpr kCols{13};  // Test for having some missing columns
 
   XGBoostBatchCSR Next() {
-    for (auto& v : data_) {
+    for (auto &v : data_) {
       v += iter_;
     }
     XGBoostBatchCSR batch;
@@ -141,10 +141,9 @@ class CSRIterForTest {
 
 size_t constexpr CSRIterForTest::kCols;
 
-int CSRSetDataNextForTest(DataIterHandle data_handle,
-                          XGBCallbackSetData *set_function,
+int CSRSetDataNextForTest(DataIterHandle data_handle, XGBCallbackSetData *set_function,
                           DataHolderHandle set_function_handle) {
-  size_t constexpr kIters { 2 };
+  size_t constexpr kIters{2};
   auto iter = static_cast<CSRIterForTest *>(data_handle);
   if (iter->Iter() < kIters) {
     auto batch = iter->Next();
@@ -158,17 +157,16 @@ int CSRSetDataNextForTest(DataIterHandle data_handle,
 
 TEST(Adapter, IteratorAdapter) {
   CSRIterForTest iter;
-  data::IteratorAdapter<DataIterHandle, XGBCallbackDataIterNext,
-                        XGBoostBatchCSR> adapter{&iter, CSRSetDataNextForTest};
-  constexpr size_t kRows { 8 };
+  data::IteratorAdapter<DataIterHandle, XGBCallbackDataIterNext, XGBoostBatchCSR> adapter{
+      &iter, CSRSetDataNextForTest};
+  constexpr size_t kRows{8};
 
-  std::unique_ptr<DMatrix> data {
-    DMatrix::Create(&adapter, std::numeric_limits<float>::quiet_NaN(), 1)
-  };
+  std::unique_ptr<DMatrix> data{
+      DMatrix::Create(&adapter, std::numeric_limits<float>::quiet_NaN(), 1)};
   ASSERT_EQ(data->Info().num_col_, CSRIterForTest::kCols);
   ASSERT_EQ(data->Info().num_row_, kRows);
   int num_batch = 0;
-  for (auto const& batch : data->GetBatches<SparsePage>()) {
+  for (auto const &batch : data->GetBatches<SparsePage>()) {
     ASSERT_EQ(batch.offset.HostVector(), std::vector<bst_idx_t>({0, 2, 4, 5, 5, 7, 9, 10, 10}));
     ++num_batch;
   }

--- a/tests/cpp/data/test_adapter.cc
+++ b/tests/cpp/data/test_adapter.cc
@@ -4,8 +4,10 @@
 #include <gtest/gtest.h>
 #include <xgboost/data.h>
 
+#include <cstdint>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "../../../src/data/adapter.h"
 #include "../../../src/data/simple_dmatrix.h"
@@ -171,5 +173,30 @@ TEST(Adapter, IteratorAdapter) {
     ++num_batch;
   }
   ASSERT_EQ(num_batch, 1);
+}
+
+TEST(Adapter, EmptyCategories) {
+  HostDeviceVector<std::int8_t> codes{-1};
+  auto j_codes = GetArrayInterface(&codes, codes.Size(), 1);
+
+  {
+    HostDeviceVector<std::int32_t> offsets{0};
+    HostDeviceVector<std::int8_t> values;
+    Json names{Object{}};
+    names["offsets"] = GetArrayInterface(&offsets, offsets.Size(), 1);
+    names["values"] = GetArrayInterface(&values, values.Size(), 1);
+
+    Json column{Array(std::vector<Json>{names, j_codes})};
+    Json dataframe{Array(std::vector<Json>{column})};
+    EXPECT_THAT([&] { data::ColumnarAdapter{Json::Dump(dataframe)}; },
+                GMockThrow("Categorical feature must have at least one category."));
+  }
+  {
+    HostDeviceVector<std::int32_t> names;
+    Json column{Array(std::vector<Json>{GetArrayInterface(&names, names.Size(), 1), j_codes})};
+    Json dataframe{Array(std::vector<Json>{column})};
+    EXPECT_THAT([&] { data::ColumnarAdapter{Json::Dump(dataframe)}; },
+                GMockThrow("Categorical feature must have at least one category."));
+  }
 }
 }  // namespace xgboost

--- a/tests/cpp/data/test_cat_container.cc
+++ b/tests/cpp/data/test_cat_container.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025, XGBoost contributors
+ * Copyright 2025-2026, XGBoost contributors
  */
 
 #include "test_cat_container.h"
@@ -70,19 +70,6 @@ TEST(CatContainer, UnsignedSerialization) {
                                                      14);
   TestUnsignedSerialization<std::uint64_t, I64Array>(
       {1, static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())}, 16);
-}
-
-TEST(CatContainer, RejectLargeUInt64) {
-  std::vector<std::uint64_t> values{
-      static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1};
-  std::vector<enc::HostCatIndexView> columns{
-      common::Span<std::uint64_t const>{values.data(), values.size()}};
-  std::vector<std::int32_t> segments{0, 1};
-  auto view = enc::HostColumnsView{common::Span{columns}, common::Span{segments}, 1};
-  CatContainer cats{view, false};
-
-  Json saved;
-  EXPECT_THAT([&] { cats.Save(&saved); }, GMockThrow("signed 64-bit integer range"));
 }
 
 TEST(CatContainer, RejectFloat) {

--- a/tests/cpp/data/test_cat_container.cc
+++ b/tests/cpp/data/test_cat_container.cc
@@ -6,7 +6,11 @@
 
 #include <gtest/gtest.h>
 
+#include <utility>  // for move
+#include <vector>   // for vector
+
 #include "../encoder/df_mock.h"
+#include "../helpers.h"  // for GMockThrow
 
 namespace xgboost {
 using DfTest = enc::cpu_impl::DfTest;
@@ -23,5 +27,17 @@ TEST(CatContainer, Str) {
 TEST(CatContainer, Mixed) {
   Context ctx;
   TestCatContainerMixed<DfTest>(&ctx, eq_check);
+}
+
+TEST(CatContainer, RejectFloat) {
+  Json column{Object{}};
+  column["type"] = static_cast<std::int64_t>(Value::ValueKind::kF32Array);
+  column["values"] = F32Array{1};
+
+  Json in{Object{}};
+  in["enc"] = Array(std::vector<Json>{std::move(column)});
+
+  CatContainer cats;
+  EXPECT_THAT([&] { cats.Load(in); }, GMockThrow("floating point dtype"));
 }
 }  // namespace xgboost

--- a/tests/cpp/data/test_cat_container.cc
+++ b/tests/cpp/data/test_cat_container.cc
@@ -64,23 +64,40 @@ void TestUnsignedSerialization(std::vector<T> const& values, std::int64_t type) 
 }
 
 TEST(CatContainer, UnsignedSerialization) {
-  TestUnsignedSerialization<std::uint16_t, I32Array>({1, std::numeric_limits<std::uint16_t>::max()},
+  TestUnsignedSerialization<std::uint16_t, U16Array>({1, std::numeric_limits<std::uint16_t>::max()},
                                                      12);
-  TestUnsignedSerialization<std::uint32_t, I64Array>({1, std::numeric_limits<std::uint32_t>::max()},
+  TestUnsignedSerialization<std::uint32_t, U32Array>({1, std::numeric_limits<std::uint32_t>::max()},
                                                      14);
-  TestUnsignedSerialization<std::uint64_t, I64Array>(
-      {1, static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())}, 16);
+  constexpr auto kI64Max = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+  TestUnsignedSerialization<std::uint64_t, U64Array>({1, kI64Max}, 16);
 }
 
-TEST(CatContainer, RejectFloat) {
-  Json column{Object{}};
-  column["type"] = static_cast<std::int64_t>(Value::ValueKind::kF32Array);
-  column["values"] = F32Array{1};
+TEST(CatContainer, RejectInvalidValues) {
+  // Uint64
+  {
+    std::vector<std::uint64_t> values{
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1};
+    std::vector<enc::HostCatIndexView> columns{
+        common::Span<std::uint64_t const>{values.data(), values.size()}};
+    std::vector<std::int32_t> segments{0, 1};
+    auto view = enc::HostColumnsView{common::Span{columns}, common::Span{segments}, 1};
+    CatContainer cats{view, false};
 
-  Json in{Object{}};
-  in["enc"] = Array(std::vector<Json>{std::move(column)});
+    Json saved;
+    EXPECT_THAT([&] { cats.Save(&saved); }, GMockThrow("signed 64-bit range"));
+  }
 
-  CatContainer cats;
-  EXPECT_THAT([&] { cats.Load(in); }, GMockThrow("floating point dtype"));
+  // Floating points
+  {
+    Json column{Object{}};
+    column["type"] = static_cast<std::int64_t>(Value::ValueKind::kF32Array);
+    column["values"] = F32Array{1};
+
+    Json in{Object{}};
+    in["enc"] = Array(std::vector<Json>{std::move(column)});
+
+    CatContainer cats;
+    EXPECT_THAT([&] { cats.Load(in); }, GMockThrow("floating point dtype"));
+  }
 }
 }  // namespace xgboost

--- a/tests/cpp/data/test_cat_container.cc
+++ b/tests/cpp/data/test_cat_container.cc
@@ -6,6 +6,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>  // for uint16_t
+#include <ios>      // for openmode
+#include <limits>   // for numeric_limits
 #include <utility>  // for move
 #include <vector>   // for vector
 
@@ -27,6 +30,59 @@ TEST(CatContainer, Str) {
 TEST(CatContainer, Mixed) {
   Context ctx;
   TestCatContainerMixed<DfTest>(&ctx, eq_check);
+}
+
+template <typename T, typename JsonArray>
+void TestUnsignedSerialization(std::vector<T> const& values, std::int64_t type) {
+  std::vector<enc::HostCatIndexView> columns{common::Span<T const>{values.data(), values.size()}};
+  std::vector<std::int32_t> segments{0, static_cast<std::int32_t>(values.size())};
+  auto view = enc::HostColumnsView{common::Span{columns}, common::Span{segments}, segments.back()};
+  CatContainer cats{view, false};
+
+  Json saved{Object{}};
+  cats.Save(&saved);
+  auto const& enc = get<Array const>(saved["enc"]);
+  ASSERT_EQ(enc.size(), 1);
+  EXPECT_EQ(get<Integer const>(enc.front()["type"]), type);
+  EXPECT_TRUE(IsA<JsonArray>(enc.front()["values"]));
+
+  for (auto mode : {std::ios::out, std::ios::binary}) {
+    std::vector<char> buffer;
+    Json::Dump(saved, &buffer, mode);
+    auto parsed = Json::Load(StringView{buffer.data(), buffer.size()}, mode);
+
+    CatContainer loaded;
+    loaded.Load(parsed);
+    auto loaded_view = loaded.HostView();
+    ASSERT_EQ(loaded_view.columns.size(), 1);
+    auto actual = std::get<common::Span<T const>>(loaded_view.columns.front());
+    ASSERT_EQ(actual.size(), values.size());
+    for (std::size_t i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(actual[i], values[i]);
+    }
+  }
+}
+
+TEST(CatContainer, UnsignedSerialization) {
+  TestUnsignedSerialization<std::uint16_t, I32Array>({1, std::numeric_limits<std::uint16_t>::max()},
+                                                     12);
+  TestUnsignedSerialization<std::uint32_t, I64Array>({1, std::numeric_limits<std::uint32_t>::max()},
+                                                     14);
+  TestUnsignedSerialization<std::uint64_t, I64Array>(
+      {1, static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())}, 16);
+}
+
+TEST(CatContainer, RejectLargeUInt64) {
+  std::vector<std::uint64_t> values{
+      static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1};
+  std::vector<enc::HostCatIndexView> columns{
+      common::Span<std::uint64_t const>{values.data(), values.size()}};
+  std::vector<std::int32_t> segments{0, 1};
+  auto view = enc::HostColumnsView{common::Span{columns}, common::Span{segments}, 1};
+  CatContainer cats{view, false};
+
+  Json saved;
+  EXPECT_THAT([&] { cats.Save(&saved); }, GMockThrow("signed 64-bit integer range"));
 }
 
 TEST(CatContainer, RejectFloat) {

--- a/tests/cpp/data/test_device_adapter.cu
+++ b/tests/cpp/data/test_device_adapter.cu
@@ -2,20 +2,21 @@
  * Copyright 2019-2024, XGBoost contributors
  */
 #include <gtest/gtest.h>
+#include <thrust/device_vector.h>
 #include <xgboost/data.h>
+
 #include <cstdint>
 #include <vector>
+
 #include "../../../src/data/adapter.h"
-#include "../helpers.h"
-#include <thrust/device_vector.h>
 #include "../../../src/data/device_adapter.cuh"
+#include "../helpers.h"
 #include "test_array_interface.h"
 using namespace xgboost;  // NOLINT
 
-void TestCudfAdapter()
-{
-  constexpr size_t kRowsA {16};
-  constexpr size_t kRowsB {16};
+void TestCudfAdapter() {
+  constexpr size_t kRowsA{16};
+  constexpr size_t kRowsB{16};
   std::vector<Json> columns;
   thrust::device_vector<double> d_data_0(kRowsA);
   thrust::device_vector<uint32_t> d_data_1(kRowsB);
@@ -23,7 +24,7 @@ void TestCudfAdapter()
   columns.emplace_back(GenerateDenseColumn<double>("<f8", kRowsA, &d_data_0));
   columns.emplace_back(GenerateDenseColumn<uint32_t>("<u4", kRowsB, &d_data_1));
 
-  Json column_arr {columns};
+  Json column_arr{columns};
 
   std::string str;
   Json::Dump(column_arr, &str);
@@ -31,7 +32,7 @@ void TestCudfAdapter()
   data::CudfAdapter adapter(str);
 
   adapter.Next();
-  auto & batch = adapter.Value();
+  auto& batch = adapter.Value();
   EXPECT_EQ(batch.Size(), kRowsA + kRowsB);
 
   EXPECT_NO_THROW({
@@ -50,9 +51,7 @@ void TestCudfAdapter()
   });
 }
 
-TEST(DeviceAdapter, CudfAdapter) {
-  TestCudfAdapter();
-}
+TEST(DeviceAdapter, CudfAdapter) { TestCudfAdapter(); }
 
 TEST(DeviceAdapter, EmptyCategories) {
   thrust::device_vector<std::int32_t> names;

--- a/tests/cpp/data/test_device_adapter.cu
+++ b/tests/cpp/data/test_device_adapter.cu
@@ -3,6 +3,8 @@
  */
 #include <gtest/gtest.h>
 #include <xgboost/data.h>
+#include <cstdint>
+#include <vector>
 #include "../../../src/data/adapter.h"
 #include "../helpers.h"
 #include <thrust/device_vector.h>
@@ -50,6 +52,19 @@ void TestCudfAdapter()
 
 TEST(DeviceAdapter, CudfAdapter) {
   TestCudfAdapter();
+}
+
+TEST(DeviceAdapter, EmptyCategories) {
+  thrust::device_vector<std::int32_t> names;
+  thrust::device_vector<std::int8_t> codes;
+  auto j_names = GenerateDenseColumn<std::int32_t>("<i4", 0, &names);
+  auto j_codes = GenerateDenseColumn<std::int8_t>("<i1", 1, &codes);
+
+  Json column{Array(std::vector<Json>{j_names, j_codes})};
+  Json dataframe{Array(std::vector<Json>{column})};
+  auto str = Json::Dump(dataframe);
+  EXPECT_THAT([&] { data::CudfAdapter{str}; },
+              GMockThrow("Categorical feature must have at least one category."));
 }
 
 namespace xgboost::data {

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -114,24 +114,12 @@ void CompareJSON(Json l, Json r) {
       CompareIntArray<I16Array>(l, r);
       break;
     }
-    case Value::ValueKind::kU16Array: {
-      CompareIntArray<U16Array>(l, r);
-      break;
-    }
     case Value::ValueKind::kI32Array: {
       CompareIntArray<I32Array>(l, r);
       break;
     }
-    case Value::ValueKind::kU32Array: {
-      CompareIntArray<U32Array>(l, r);
-      break;
-    }
     case Value::ValueKind::kI64Array: {
       CompareIntArray<I64Array>(l, r);
-      break;
-    }
-    case Value::ValueKind::kU64Array: {
-      CompareIntArray<U64Array>(l, r);
       break;
     }
     case Value::ValueKind::kBoolean: {

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -114,12 +114,24 @@ void CompareJSON(Json l, Json r) {
       CompareIntArray<I16Array>(l, r);
       break;
     }
+    case Value::ValueKind::kU16Array: {
+      CompareIntArray<U16Array>(l, r);
+      break;
+    }
     case Value::ValueKind::kI32Array: {
       CompareIntArray<I32Array>(l, r);
       break;
     }
+    case Value::ValueKind::kU32Array: {
+      CompareIntArray<U32Array>(l, r);
+      break;
+    }
     case Value::ValueKind::kI64Array: {
       CompareIntArray<I64Array>(l, r);
+      break;
+    }
+    case Value::ValueKind::kU64Array: {
+      CompareIntArray<U64Array>(l, r);
       break;
     }
     case Value::ValueKind::kBoolean: {

--- a/tests/python/test_ordinal.py
+++ b/tests/python/test_ordinal.py
@@ -1,8 +1,10 @@
+from typing import cast
+
 import numpy as np
 import pytest
 import xgboost as xgb
 from xgboost import testing as tm
-from xgboost._data_utils import from_array_interface, pd_cat_inf
+from xgboost._data_utils import ArrayInf, from_array_interface, pd_cat_inf
 from xgboost.testing.ordinal import (
     run_cat_container,
     run_cat_container_iter,
@@ -46,8 +48,10 @@ def test_pd_cat_nullable_integer(dtype: str, values: list[int]) -> None:
     converted = temporary[0]
     assert converted.dtype == expected_dtype
     assert converted.flags.c_contiguous and converted.flags.aligned
-    assert names["typestr"] == expected_dtype.str
-    np.testing.assert_array_equal(from_array_interface(names), values)
+    assert "typestr" in names
+    numeric_names = cast(ArrayInf, names)
+    assert numeric_names["typestr"] == expected_dtype.str
+    np.testing.assert_array_equal(from_array_interface(numeric_names), values)
     code_values = np.asarray(from_array_interface(codes))
     assert code_values[0] == 0 and np.isnan(code_values[1]) and code_values[2] == 1
 

--- a/tests/python/test_ordinal.py
+++ b/tests/python/test_ordinal.py
@@ -34,7 +34,9 @@ def test_cat_container() -> None:
     "dtype, values",
     [
         ("Int64", [-2, 1]),
-        ("UInt64", [1, np.iinfo(np.int64).max + 1]),
+        ("UInt16", [1, np.iinfo(np.uint16).max]),
+        ("UInt32", [1, np.iinfo(np.uint32).max]),
+        ("UInt64", [1, np.iinfo(np.int64).max]),
     ],
 )
 def test_pd_cat_nullable_integer(dtype: str, values: list[int]) -> None:

--- a/tests/python/test_ordinal.py
+++ b/tests/python/test_ordinal.py
@@ -1,5 +1,8 @@
+import numpy as np
 import pytest
+import xgboost as xgb
 from xgboost import testing as tm
+from xgboost._data_utils import from_array_interface, pd_cat_inf
 from xgboost.testing.ordinal import (
     run_cat_container,
     run_cat_container_iter,
@@ -23,6 +26,39 @@ pytestmark = pytest.mark.skipif(**tm.no_multiple(tm.no_arrow(), tm.no_pandas()))
 
 def test_cat_container() -> None:
     run_cat_container("cpu")
+
+
+@pytest.mark.parametrize(
+    "dtype, values",
+    [
+        ("Int64", [-2, 1]),
+        ("UInt64", [1, np.iinfo(np.int64).max + 1]),
+    ],
+)
+def test_pd_cat_nullable_integer(dtype: str, values: list[int]) -> None:
+    import pandas as pd
+
+    categories = pd.Index(pd.array(values, dtype=dtype))
+    names, codes, temporary = pd_cat_inf(
+        categories, pd.Series([0, -1, 1], dtype=np.int8)
+    )
+    expected_dtype = np.dtype(dtype.lower())
+    converted = temporary[0]
+    assert converted.dtype == expected_dtype
+    assert converted.flags.c_contiguous and converted.flags.aligned
+    assert names["typestr"] == expected_dtype.str
+    np.testing.assert_array_equal(from_array_interface(names), values)
+    code_values = np.asarray(from_array_interface(codes))
+    assert code_values[0] == 0 and np.isnan(code_values[1]) and code_values[2] == 1
+
+
+def test_pd_cat_nullable_float() -> None:
+    import pandas as pd
+
+    categories = pd.Index(pd.array([1.0, 2.0], dtype="Float64"))
+    cat = pd.Categorical.from_codes([0, 1], categories=categories)
+    with pytest.raises(xgb.core.XGBoostError, match="floating point dtype"):
+        xgb.DMatrix(pd.DataFrame({"c": cat}), enable_categorical=True)
 
 
 def test_cat_container_mixed() -> None:

--- a/tests/python/test_with_polars.py
+++ b/tests/python/test_with_polars.py
@@ -141,7 +141,7 @@ def test_regressor() -> None:
 
 
 def test_categorical() -> None:
-    cats = ["aa", "cc", "bb", "ee", "ee"]
+    cats = ["a", "café", "猫", "🐍", "🐍"]
     df = pl.DataFrame(
         {"f0": [1, 3, 2, 4, 4], "f1": cats},
         schema=[("f0", pl.Int64()), ("f1", pl.Categorical())],


### PR DESCRIPTION
- Fix UTF-8 categories index.
- Handle pandas nullable type. We do not accept missing category index (name), but we need to handle this specific Pandas type.
- Remove unused float dispatching.
- Fix unsigned integer serialization.
- Optimize the construction of `offsets` for string categories after the UTF-8 handling. The encode/decode for UTF-8 nonetheless adds overhead.
- More checks for overflow.

close https://github.com/dmlc/xgboost/pull/12360