### PR TITLE
Use smooth MM updates for absolute error

### DIFF
--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -398,7 +398,10 @@ Specify the learning task and the corresponding learning objective. The objectiv
   - ``reg:squaredlogerror``: regression with squared log loss :math:`\frac{1}{2}[log(pred + 1) - log(label + 1)]^2`.  All input labels are required to be greater than -1.  Also, see metric ``rmsle`` for possible issue  with this objective.
   - ``reg:logistic``: logistic regression, output probability
   - ``reg:pseudohubererror``: regression with Pseudo Huber loss, a twice differentiable alternative to absolute loss.
-  - ``reg:absoluteerror``: Regression with L1 error. When tree model is used, leaf value is refreshed after tree construction. If used in distributed training, the leaf value is calculated as the mean value from all workers, which is not guaranteed to be optimal.
+  - ``reg:absoluteerror``: Regression with L1 error. The objective uses an automatically scaled
+    smooth majorization of absolute error for gradient-based tree construction. The automatic
+    scale is internal and does not require a user parameter. The initial ``base_score`` remains
+    the weighted median of the labels.
 
     .. versionadded:: 1.7.0
 

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -398,11 +398,7 @@ Specify the learning task and the corresponding learning objective. The objectiv
   - ``reg:squaredlogerror``: regression with squared log loss :math:`\frac{1}{2}[log(pred + 1) - log(label + 1)]^2`.  All input labels are required to be greater than -1.  Also, see metric ``rmsle`` for possible issue  with this objective.
   - ``reg:logistic``: logistic regression, output probability
   - ``reg:pseudohubererror``: regression with Pseudo Huber loss, a twice differentiable alternative to absolute loss.
-  - ``reg:absoluteerror``: Regression with L1 error. The objective uses an automatically scaled
-    smooth majorization of absolute error for gradient-based tree construction. The automatic
-    scale is internal and does not require a user parameter. The initial ``base_score`` is
-    estimated from the global weighted mean followed by one unregularized intercept update using
-    the same smooth majorization.
+  - ``reg:absoluteerror``: Regression with L1 error. A smooth approximation is used to optimize the L1 loss.
 
     .. versionadded:: 1.7.0
 

--- a/doc/parameter.rst
+++ b/doc/parameter.rst
@@ -400,8 +400,9 @@ Specify the learning task and the corresponding learning objective. The objectiv
   - ``reg:pseudohubererror``: regression with Pseudo Huber loss, a twice differentiable alternative to absolute loss.
   - ``reg:absoluteerror``: Regression with L1 error. The objective uses an automatically scaled
     smooth majorization of absolute error for gradient-based tree construction. The automatic
-    scale is internal and does not require a user parameter. The initial ``base_score`` remains
-    the weighted median of the labels.
+    scale is internal and does not require a user parameter. The initial ``base_score`` is
+    estimated from the global weighted mean followed by one unregularized intercept update using
+    the same smooth majorization.
 
     .. versionadded:: 1.7.0
 

--- a/python-package/xgboost/testing/intercept.py
+++ b/python-package/xgboost/testing/intercept.py
@@ -176,7 +176,9 @@ def run_adaptive(tree_method: str, weighted: bool, device: Device) -> None:
     config_0 = json.loads(booster_0.save_config())
     config_1 = json.loads(booster_1.save_config())
 
-    np.testing.assert_allclose(get_basescore(config_0), get_basescore(config_1))
+    np.testing.assert_allclose(
+        get_basescore(config_0), get_basescore(config_1), rtol=1e-6
+    )
 
     # check the base score is correctly serialized.
     raw_booster = booster_1.save_raw(raw_format="ubj")

--- a/python-package/xgboost/testing/intercept.py
+++ b/python-package/xgboost/testing/intercept.py
@@ -133,8 +133,6 @@ def run_init_estimation(tree_method: str, device: Device) -> None:
 def run_adaptive(tree_method: str, weighted: bool, device: Device) -> None:
     """Test for adaptive trees."""
     rng = np.random.RandomState(1994)
-    from sklearn.utils import stats
-
     n_samples = 256
     X, y = make_regression(  # pylint: disable=unbalanced-tuple-unpacking
         n_samples, 16, random_state=rng
@@ -144,13 +142,16 @@ def run_adaptive(tree_method: str, weighted: bool, device: Device) -> None:
         w -= w.min()
         Xy = DMatrix(X, y, weight=w)
 
-        kwargs = {"percentile_rank": 50}
-        base_score = stats._weighted_percentile(  # pylint: disable=protected-access
-            y, w, **kwargs
-        )
     else:
         Xy = DMatrix(X, y)
-        base_score = np.median(y)
+        w = np.ones_like(y)
+
+    mean = np.average(y, weights=w)
+    residual = mean - y
+    delta = np.average(np.sqrt(np.abs(residual)), weights=w) ** 2
+    norm = np.hypot(delta, residual)
+    curvature = np.divide(delta, norm, out=np.ones_like(norm), where=norm > 0.0)
+    base_score = mean - np.sum(w * residual * curvature) / np.sum(w * curvature)
 
     # Check the base score is expected.
     booster_0 = train(
@@ -175,7 +176,7 @@ def run_adaptive(tree_method: str, weighted: bool, device: Device) -> None:
     config_0 = json.loads(booster_0.save_config())
     config_1 = json.loads(booster_1.save_config())
 
-    assert get_basescore(config_0) == get_basescore(config_1)
+    np.testing.assert_allclose(get_basescore(config_0), get_basescore(config_1))
 
     # check the base score is correctly serialized.
     raw_booster = booster_1.save_raw(raw_format="ubj")

--- a/src/metric/multiclass_metric.cu
+++ b/src/metric/multiclass_metric.cu
@@ -152,6 +152,8 @@ class MultiClassMetricsReduction {
  */
 template <typename Derived>
 struct EvalMClassBase : public MetricNoCache {
+  ~EvalMClassBase() noexcept override = default;
+
   double Eval(const HostDeviceVector<float>& preds, const MetaInfo& info) override {
     CheckRowWeights(info);
     if (info.labels.Size() == 0) {

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -24,7 +24,6 @@
 #include "../common/utils.h"  // for NoOp
 #include "../tree/fit_stump.h"
 #include "./regression_loss.h"
-#include "adaptive.h"
 #include "init_estimation.h"  // FitIntercept
 #include "regression_param.h"
 #include "xgboost/base.h"
@@ -37,7 +36,6 @@
 #include "xgboost/objective.h"  // ObjFunction
 #include "xgboost/parameter.h"
 #include "xgboost/span.h"
-#include "xgboost/tree_model.h"  // RegTree
 
 #if defined(XGBOOST_USE_CUDA)
 #include "../common/algorithm.cuh"       // for AllOf
@@ -852,10 +850,25 @@ XGBOOST_REGISTER_OBJECTIVE(TweedieRegression, "reg:tweedie")
     .describe("Tweedie regression for insurance data.")
     .set_body([]() { return new TweedieRegression(); });
 
+/**
+ * @brief Smooth MM approximation to the mean absolute error.
+ *
+ * At each boosting iteration and for each target, choose the automatic scale
+ *
+ *   delta = E_w[sqrt(abs(prediction - label))]^2.
+ *
+ * For residual r, q = sqrt(1 + (r / delta)^2), the pseudo-Huber gradient is r / q.
+ * We use 1 / q as the Hessian instead of the exact pseudo-Huber Hessian 1 / q^3. This is
+ * the majorization curvature that produces a stable IRLS update while approaching the L1
+ * gradient as the residual scale contracts.
+ */
 class MeanAbsoluteError : public ObjFunction {
+  HostDeviceVector<float> root_residual_;
+  HostDeviceVector<float> scale_;
+
  public:
   void Configure(Args const&) override {}
-  [[nodiscard]] ObjInfo Task() const override { return {ObjInfo::kRegression, true, true}; }
+  [[nodiscard]] ObjInfo Task() const override { return {ObjInfo::kRegression, false, false}; }
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
     return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
   }
@@ -864,24 +877,61 @@ class MeanAbsoluteError : public ObjFunction {
                    std::int32_t /*iter*/, linalg::Matrix<GradientPair>* out_gpair) override {
     CheckRegInputs(info, preds);
     auto labels = info.labels.View(ctx_->Device());
+    auto const n_targets = this->Targets(info);
 
     out_gpair->SetDevice(ctx_->Device());
-    out_gpair->Reshape(info.num_row_, this->Targets(info));
+    out_gpair->Reshape(info.num_row_, n_targets);
     auto gpair = out_gpair->View(ctx_->Device());
 
     preds.SetDevice(ctx_->Device());
-    auto predt = linalg::MakeTensorView(ctx_, &preds, info.num_row_, this->Targets(info));
+    auto predt = linalg::MakeTensorView(ctx_, &preds, info.num_row_, n_targets);
     auto weight = common::MakeOptionalWeights(ctx_->Device(), info.weights_);
-    linalg::ElementWiseKernel(
-        ctx_, labels, [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
-          auto sign = [](auto x) {
-            return (x > static_cast<decltype(x)>(0)) - (x < static_cast<decltype(x)>(0));
-          };
-          auto y = labels(i, j);
-          auto hess = weight[i];
-          auto grad = sign(predt(i, j) - y) * hess;
-          gpair(i, j) = GradientPair{grad, hess};
-        });
+
+    root_residual_.SetDevice(ctx_->Device());
+    root_residual_.Resize(info.num_row_);
+    std::vector<double> scale_stats(n_targets + 1, 0.0);
+    for (bst_target_t target{0}; target < n_targets; ++target) {
+      common::Transform<>::Init(
+          [target, n_targets] XGBOOST_DEVICE(
+              std::size_t i, common::Span<float> root_residual, common::Span<float const> predts,
+              common::Span<float const> labels, common::Span<float const> weights) {
+            auto const offset = i * n_targets + target;
+            auto const w = weights.empty() ? 1.0f : weights[i];
+            root_residual[i] = w * sqrtf(fabsf(predts[offset] - labels[offset]));
+          },
+          common::Range{0, static_cast<std::int64_t>(info.num_row_)}, ctx_->Threads(),
+          ctx_->Device())
+          .Eval(&root_residual_, &preds, info.labels.Data(), &info.weights_);
+      scale_stats[target] = common::Reduce(ctx_, root_residual_);
+    }
+    scale_stats.back() = common::SumOptionalWeights(ctx_, weight, info.num_row_);
+    auto cpu_ctx = ctx_->MakeCPU();
+    auto rc =
+        collective::GlobalSum(&cpu_ctx, linalg::MakeVec(scale_stats.data(), scale_stats.size()));
+    collective::SafeColl(rc);
+
+    auto& h_scale = scale_.HostVector();
+    h_scale.resize(n_targets);
+    for (bst_target_t target{0}; target < n_targets; ++target) {
+      if (common::CloseTo(scale_stats.back(), 0.0)) {
+        h_scale[target] = 0.0f;
+      } else {
+        auto const root_mean = scale_stats[target] / scale_stats.back();
+        h_scale[target] = static_cast<float>(root_mean * root_mean);
+      }
+    }
+    scale_.SetDevice(ctx_->Device());
+    auto scale = ctx_->Device().IsCPU() ? scale_.ConstHostSpan() : scale_.ConstDeviceSpan();
+
+    linalg::ElementWiseKernel(ctx_, labels,
+                              [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
+                                auto const residual = predt(i, j) - labels(i, j);
+                                auto const delta = scale[j];
+                                auto const norm = hypotf(delta, residual);
+                                auto const curvature = norm > 0.0f ? delta / norm : 1.0f;
+                                auto const w = weight[i];
+                                gpair(i, j) = GradientPair{w * residual * curvature, w * curvature};
+                              });
   }
 
   void InitEstimation(MetaInfo const& info, linalg::Tensor<float, 1>* base_score) const override {
@@ -918,19 +968,6 @@ class MeanAbsoluteError : public ObjFunction {
     linalg::VecScaDiv(this->ctx_, intercept, sum_weight);
   }
 
-  void UpdateTreeLeaf(HostDeviceVector<bst_node_t> const& position, MetaInfo const& info,
-                      float learning_rate, HostDeviceVector<float> const& prediction,
-                      bst_target_t group_idx, RegTree* p_tree) const override {
-    std::vector<float> alphas;
-    if (p_tree->IsMultiTarget()) {
-      alphas.resize(p_tree->NumTargets(), 0.5);
-    } else {
-      alphas.push_back(0.5);
-    }
-    ::xgboost::obj::UpdateTreeLeaf(ctx_, position, group_idx, info, learning_rate, prediction,
-                                   alphas, p_tree);
-  }
-
   [[nodiscard]] const char* DefaultEvalMetric() const override { return "mae"; }
 
   void SaveConfig(Json* p_out) const override {
@@ -944,6 +981,6 @@ class MeanAbsoluteError : public ObjFunction {
 };
 
 XGBOOST_REGISTER_OBJECTIVE(MeanAbsoluteError, "reg:absoluteerror")
-    .describe("Mean absoluate error.")
+    .describe("Mean absolute error with automatic smooth majorization.")
     .set_body([]() { return new MeanAbsoluteError(); });
 }  // namespace xgboost::obj

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -9,6 +9,7 @@
 #include <algorithm>  // for all_of
 #include <cmath>
 #include <cstdint>  // for int32_t
+#include <memory>   // for unique_ptr
 #include <vector>   // for vector
 
 #include "../collective/aggregator.h"
@@ -934,9 +935,11 @@ class MeanAbsoluteError : public ObjFunction {
                               });
   }
 
-  void InitEstimation(MetaInfo const& info, linalg::Tensor<float, 1>* base_score) const override {
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
     CheckInitInputs(info);
-    base_score->Reshape(this->Targets(info));
+    auto const n_targets = this->Targets(info);
+    base_score->SetDevice(ctx_->Device());
+    base_score->Reshape(n_targets);
 
     double sum_weight{0.0};
     if (info.weights_.Empty()) {
@@ -944,20 +947,9 @@ class MeanAbsoluteError : public ObjFunction {
     } else {
       sum_weight = common::Reduce(ctx_, info.weights_);
     }
-
-    if (info.num_row_ == 0) {
-      auto out = base_score->HostView();
-      std::fill(linalg::begin(out), linalg::end(out), 0.0f);
-    } else {
-      common::Median(ctx_, info.labels, info.weights_, base_score);
-    }
-
-    auto intercept = base_score->View(this->ctx_->Device());
-    // weighted avg
-    linalg::VecScaMul(this->ctx_, intercept, sum_weight);
-    auto rc = collective::GlobalSum(ctx_, intercept, &sum_weight);
-    collective::SafeColl(rc);
-
+    auto cpu_ctx = ctx_->MakeCPU();
+    collective::SafeColl(
+        collective::GlobalSum(&cpu_ctx, linalg::MakeVec(&sum_weight, std::size_t{1})));
     if (common::CloseTo(sum_weight, 0.0)) {
       // Mostly for handling empty dataset test.
       LOG(WARNING) << "Sum of weights is close to 0.0, skipping base score estimation.";
@@ -965,7 +957,38 @@ class MeanAbsoluteError : public ObjFunction {
       return;
     }
 
-    linalg::VecScaDiv(this->ctx_, intercept, sum_weight);
+    linalg::Vector<float> mean;
+    if (info.weights_.Empty()) {
+      common::SampleMean(ctx_, info.labels, &mean);
+    } else {
+      common::WeightedSampleMean(ctx_, info.labels, info.weights_, &mean);
+    }
+    CHECK_EQ(mean.Size(), n_targets);
+
+    HostDeviceVector<float> predt(info.labels.Size(), 0.0f, ctx_->Device());
+    auto predt_view = linalg::MakeTensorView(ctx_, &predt, info.num_row_, n_targets);
+    mean.SetDevice(ctx_->Device());
+    auto mean_view = mean.View(ctx_->Device());
+    linalg::ElementWiseKernel(ctx_, predt_view,
+                              [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
+                                predt_view(i, j) = mean_view(j);
+                              });
+
+    Json config{Object{}};
+    this->SaveConfig(&config);
+    std::unique_ptr<ObjFunction> new_obj{
+        ObjFunction::Create(get<String const>(config["name"]), ctx_)};
+    new_obj->LoadConfig(config);
+
+    linalg::Matrix<GradientPair> gpair;
+    new_obj->GetGradient(predt, info, 0, &gpair);
+    tree::FitStump(ctx_, gpair, n_targets, base_score);
+
+    auto h_mean = mean.HostView();
+    auto out = base_score->HostView();
+    for (bst_target_t target{0}; target < n_targets; ++target) {
+      out(target) += h_mean(target);
+    }
   }
 
   [[nodiscard]] const char* DefaultEvalMetric() const override { return "mae"; }

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -864,9 +864,6 @@ XGBOOST_REGISTER_OBJECTIVE(TweedieRegression, "reg:tweedie")
  * gradient as the residual scale contracts.
  */
 class MeanAbsoluteError : public ObjFunction {
-  HostDeviceVector<float> root_residual_;
-  HostDeviceVector<float> scale_;
-
  public:
   void Configure(Args const&) override {}
   [[nodiscard]] ObjInfo Task() const override { return {ObjInfo::kRegression, false, false}; }
@@ -888,8 +885,7 @@ class MeanAbsoluteError : public ObjFunction {
     auto predt = linalg::MakeTensorView(ctx_, &preds, info.num_row_, n_targets);
     auto weight = common::MakeOptionalWeights(ctx_->Device(), info.weights_);
 
-    root_residual_.SetDevice(ctx_->Device());
-    root_residual_.Resize(info.num_row_);
+    HostDeviceVector<float> root_residual(info.num_row_, 0.0f, ctx_->Device());
     std::vector<double> scale_stats(n_targets + 1, 0.0);
     for (bst_target_t target{0}; target < n_targets; ++target) {
       common::Transform<>::Init(
@@ -902,8 +898,8 @@ class MeanAbsoluteError : public ObjFunction {
           },
           common::Range{0, static_cast<std::int64_t>(info.num_row_)}, ctx_->Threads(),
           ctx_->Device())
-          .Eval(&root_residual_, &preds, info.labels.Data(), &info.weights_);
-      scale_stats[target] = common::Reduce(ctx_, root_residual_);
+          .Eval(&root_residual, &preds, info.labels.Data(), &info.weights_);
+      scale_stats[target] = common::Reduce(ctx_, root_residual);
     }
     scale_stats.back() = common::SumOptionalWeights(ctx_, weight, info.num_row_);
     auto cpu_ctx = ctx_->MakeCPU();
@@ -911,8 +907,8 @@ class MeanAbsoluteError : public ObjFunction {
         collective::GlobalSum(&cpu_ctx, linalg::MakeVec(scale_stats.data(), scale_stats.size()));
     collective::SafeColl(rc);
 
-    auto& h_scale = scale_.HostVector();
-    h_scale.resize(n_targets);
+    HostDeviceVector<float> scale(n_targets, 0.0f, ctx_->Device());
+    auto h_scale = scale.HostSpan();
     for (bst_target_t target{0}; target < n_targets; ++target) {
       if (common::CloseTo(scale_stats.back(), 0.0)) {
         h_scale[target] = 0.0f;
@@ -921,13 +917,12 @@ class MeanAbsoluteError : public ObjFunction {
         h_scale[target] = static_cast<float>(root_mean * root_mean);
       }
     }
-    scale_.SetDevice(ctx_->Device());
-    auto scale = ctx_->Device().IsCPU() ? scale_.ConstHostSpan() : scale_.ConstDeviceSpan();
+    auto scale_view = ctx_->Device().IsCPU() ? scale.ConstHostSpan() : scale.ConstDeviceSpan();
 
     linalg::ElementWiseKernel(ctx_, labels,
                               [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
                                 auto const residual = predt(i, j) - labels(i, j);
-                                auto const delta = scale[j];
+                                auto const delta = scale_view[j];
                                 auto const norm = hypotf(delta, residual);
                                 auto const curvature = norm > 0.0f ? delta / norm : 1.0f;
                                 auto const w = weight[i];

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -889,16 +889,13 @@ class MeanAbsoluteError : public ObjFunction {
     std::vector<double> scale_stats(n_targets + 1, 0.0);
     for (bst_target_t target{0}; target < n_targets; ++target) {
       common::Transform<>::Init(
-          [target, n_targets] XGBOOST_DEVICE(
-              std::size_t i, common::Span<float> root_residual, common::Span<float const> predts,
-              common::Span<float const> labels, common::Span<float const> weights) {
-            auto const offset = i * n_targets + target;
-            auto const w = weights.empty() ? 1.0f : weights[i];
-            root_residual[i] = w * sqrtf(fabsf(predts[offset] - labels[offset]));
+          [target, labels, predt, weight] XGBOOST_DEVICE(std::size_t i,
+                                                         common::Span<float> root_residual) {
+            root_residual[i] = weight[i] * sqrtf(fabsf(predt(i, target) - labels(i, target)));
           },
           common::Range{0, static_cast<std::int64_t>(info.num_row_)}, ctx_->Threads(),
           ctx_->Device())
-          .Eval(&root_residual, &preds, info.labels.Data(), &info.weights_);
+          .Eval(&root_residual);
       scale_stats[target] = common::Reduce(ctx_, root_residual);
     }
     scale_stats.back() = common::SumOptionalWeights(ctx_, weight, info.num_row_);

--- a/tests/cpp/objective/test_regression_obj.cc
+++ b/tests/cpp/objective/test_regression_obj.cc
@@ -9,13 +9,12 @@
 #include <xgboost/objective.h>
 #include <xgboost/tree_model.h>  // for RegTree
 
+#include <cmath>    // for hypot, sqrt
 #include <memory>   // for unique_ptr
-#include <numeric>  // for iota
 #include <utility>  // for pair
 
 #include "../../../src/common/linalg_op.h"  // for begin, end
 #include "../../../src/common/math.h"       // for SoftPlus
-#include "../../../src/tree/param.h"        // for TrainParam
 #include "../../../src/tree/tree_view.h"    // for MultiTargetTreeView
 #include "../helpers.h"
 #include "../tree/test_multi_target_tree_model.h"  // for MakeMtTreeForTest
@@ -308,95 +307,55 @@ void TestAbsoluteError(const Context* ctx) {
   std::unique_ptr<ObjFunction> obj{ObjFunction::Create("reg:absoluteerror", ctx)};
   obj->Configure({});
   CheckConfigReload(obj, "reg:absoluteerror");
+  ASSERT_FALSE(obj->Task().const_hess);
+  ASSERT_FALSE(obj->Task().zero_hess);
+
+  auto check = [&](std::vector<float> const& predts, std::vector<float> const& labels,
+                   std::vector<float> const& weights) {
+    double sum_weight{0.0};
+    double sum_root_residual{0.0};
+    for (std::size_t i{0}; i < labels.size(); ++i) {
+      auto const w = weights.empty() ? 1.0f : weights[i];
+      sum_weight += w;
+      sum_root_residual += w * std::sqrt(std::abs(predts[i] - labels[i]));
+    }
+    auto const root_mean = sum_weight == 0.0 ? 0.0 : sum_root_residual / sum_weight;
+    auto const delta = static_cast<float>(root_mean * root_mean);
+    std::vector<float> grad(labels.size());
+    std::vector<float> hess(labels.size());
+    for (std::size_t i{0}; i < labels.size(); ++i) {
+      auto const residual = predts[i] - labels[i];
+      auto const norm = std::hypot(delta, residual);
+      auto const curvature = norm > 0.0f ? delta / norm : 1.0f;
+      auto const w = weights.empty() ? 1.0f : weights[i];
+      grad[i] = w * residual * curvature;
+      hess[i] = w * curvature;
+    }
+    CheckObjFunction(obj, predts, labels, weights, grad, hess);
+  };
+
+  check({0.0f, 2.0f, 5.0f}, {1.0f, 0.0f, 1.0f}, {1.0f, 2.0f, 0.5f});
+  check({0.0f, 2.0f, 5.0f}, {1.0f, 0.0f, 1.0f}, {});
+  check({1.0f, 2.0f}, {1.0f, 2.0f}, {});
 
   MetaInfo info;
-  std::vector<float> labels{0.f, 3.f, 2.f, 5.f, 4.f, 7.f};
-  info.labels.Reshape(6, 1);
-  info.labels.Data()->HostVector() = labels;
-  info.num_row_ = labels.size();
-
-  HostDeviceVector<float> predt{1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
-  info.weights_.HostVector() = {1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
-
-  CheckObjFunction(obj, predt.HostVector(), labels, info.weights_.HostVector(),
-                   {1.f, -1.f, 1.f, -1.f, 1.f, -1.f}, info.weights_.HostVector());
-
-  RegTree tree;
-  tree.ExpandNode(0, /*split_index=*/1, 2, true, 0.0f, 2.f, 3.f, 4.f, 2.f, 1.f, 1.f);
-  bst_node_t left_nidx = tree.LeftChild(RegTree::kRoot);
-  bst_node_t right_nidx = tree.RightChild(RegTree::kRoot);
-
-  HostDeviceVector<bst_node_t> position;
-  MakePositionsForTest(info.num_row_, left_nidx, right_nidx, &position);
-
-  auto& h_predt = predt.HostVector();
-  for (size_t i = 0; i < h_predt.size(); ++i) {
-    h_predt[i] = labels[i] + i;
+  info.num_row_ = 2;
+  info.labels.Reshape(2, 2);
+  info.labels.Data()->HostVector() = {0.0f, 0.0f, 0.0f, 0.0f};
+  HostDeviceVector<float> predts{{1.0f, 100.0f, 4.0f, 400.0f}};
+  linalg::Matrix<GradientPair> gpair;
+  obj->GetGradient(predts, info, 0, &gpair);
+  auto h_gpair = gpair.HostView();
+  for (std::size_t row{0}; row < 2; ++row) {
+    auto const residual = row == 0 ? 1.0f : 4.0f;
+    auto const delta = 2.25f;
+    auto const curvature = delta / std::hypot(delta, residual);
+    ASSERT_NEAR(h_gpair(row, 0).GetGrad(), residual * curvature, kRtEps);
+    ASSERT_NEAR(h_gpair(row, 1).GetGrad(), 100.0f * residual * curvature, 1.0e-4f);
+    ASSERT_NEAR(h_gpair(row, 0).GetHess(), curvature, kRtEps);
+    ASSERT_NEAR(h_gpair(row, 1).GetHess(), curvature, kRtEps);
   }
-
-  tree::TrainParam param;
-  param.Init(Args{});
-  auto lr = param.learning_rate;
-
-  obj->UpdateTreeLeaf(position, info, lr, predt, 0, &tree);
-  ASSERT_EQ(tree[1].LeafValue(), -1.0f * lr);
-  ASSERT_EQ(tree[2].LeafValue(), -4.0f * lr);
-}
-
-void TestAbsoluteErrorLeaf(const Context* ctx) {
-  bst_target_t constexpr kTargets = 3, kRows = 16;
-  std::unique_ptr<ObjFunction> obj{ObjFunction::Create("reg:absoluteerror", ctx)};
-  obj->Configure({});
-
-  MetaInfo info;
-  info.num_row_ = kRows;
-  info.labels.Reshape(16, kTargets);
-  HostDeviceVector<float> predt(info.labels.Size());
-
-  for (bst_target_t t{0}; t < kTargets; ++t) {
-    auto h_labels = info.labels.HostView().Slice(linalg::All(), t);
-    std::iota(linalg::begin(h_labels), linalg::end(h_labels), .0f);
-
-    auto h_predt =
-        linalg::MakeTensorView(ctx, predt.HostSpan(), kRows, kTargets).Slice(linalg::All(), t);
-    for (size_t i = 0; i < h_predt.Size(); ++i) {
-      h_predt(i) = h_labels(i) + i;
-    }
-
-    HostDeviceVector<bst_node_t> position(h_labels.Size(), 0);
-    auto& h_position = position.HostVector();
-    for (int32_t i = 0; i < 3; ++i) {
-      h_position[i] = ~i;  // negation for sampled nodes.
-    }
-    for (size_t i = 3; i < 8; ++i) {
-      h_position[i] = 3;
-    }
-    // empty leaf for node 4
-    for (size_t i = 8; i < 13; ++i) {
-      h_position[i] = 5;
-    }
-    for (size_t i = 13; i < h_labels.Size(); ++i) {
-      h_position[i] = 6;
-    }
-
-    RegTree tree;
-    tree.ExpandNode(0, /*split_index=*/1, 2, true, 0.0f, 2.f, 3.f, 4.f, 2.f, 1.f, 1.f);
-    tree.ExpandNode(1, /*split_index=*/1, 2, true, 0.0f, 2.f, 3.f, 4.f, 2.f, 1.f, 1.f);
-    tree.ExpandNode(2, /*split_index=*/1, 2, true, 0.0f, 2.f, 3.f, 4.f, 2.f, 1.f, 1.f);
-    ASSERT_EQ(tree.GetNumLeaves(), 4);
-
-    auto empty_leaf = tree[4].LeafValue();
-
-    tree::TrainParam param;
-    param.Init(Args{});
-    auto lr = param.learning_rate;
-
-    obj->UpdateTreeLeaf(position, info, lr, predt, t, &tree);
-    ASSERT_EQ(tree[3].LeafValue(), -5.0f * lr);
-    ASSERT_EQ(tree[4].LeafValue(), empty_leaf);
-    ASSERT_EQ(tree[5].LeafValue(), -10.0f * lr);
-    ASSERT_EQ(tree[6].LeafValue(), -14.0f * lr);
-  }
+  ASSERT_EQ(obj->DefaultEvalMetric(), std::string{"mae"});
 }
 
 void TestVectorLeafObj(Context const* ctx, std::string name, Args const& args, bst_idx_t n_samples,

--- a/tests/cpp/objective/test_regression_obj.cc
+++ b/tests/cpp/objective/test_regression_obj.cc
@@ -355,6 +355,57 @@ void TestAbsoluteError(const Context* ctx) {
     ASSERT_NEAR(h_gpair(row, 0).GetHess(), curvature, kRtEps);
     ASSERT_NEAR(h_gpair(row, 1).GetHess(), curvature, kRtEps);
   }
+
+  auto expected_intercept = [](std::vector<float> const& labels,
+                               std::vector<float> const& weights) {
+    double sum_weight{0.0};
+    double mean{0.0};
+    for (std::size_t i{0}; i < labels.size(); ++i) {
+      auto const w = weights.empty() ? 1.0f : weights[i];
+      sum_weight += w;
+      mean += w * labels[i];
+    }
+    mean /= sum_weight;
+
+    double root_residual{0.0};
+    for (std::size_t i{0}; i < labels.size(); ++i) {
+      auto const w = weights.empty() ? 1.0f : weights[i];
+      root_residual += w * std::sqrt(std::abs(mean - labels[i]));
+    }
+    auto const delta = std::pow(root_residual / sum_weight, 2.0);
+
+    double sum_grad{0.0};
+    double sum_hess{0.0};
+    for (std::size_t i{0}; i < labels.size(); ++i) {
+      auto const w = weights.empty() ? 1.0f : weights[i];
+      auto const residual = mean - labels[i];
+      auto const norm = std::hypot(delta, residual);
+      auto const curvature = norm > 0.0 ? delta / norm : 1.0;
+      sum_grad += w * residual * curvature;
+      sum_hess += w * curvature;
+    }
+    return static_cast<float>(mean - sum_grad / sum_hess);
+  };
+
+  auto init = [&](std::vector<float> labels, std::vector<float> const& weights) {
+    MetaInfo init_info;
+    init_info.num_row_ = labels.size();
+    init_info.labels.Reshape(labels.size(), 1);
+    init_info.labels.Data()->HostVector() = std::move(labels);
+    init_info.weights_.HostVector() = weights;
+    linalg::Vector<float> base_score;
+    obj->InitEstimation(init_info, &base_score);
+    return base_score.HostView()(0);
+  };
+
+  for (auto const& weights : std::vector<std::vector<float>>{{}, {1.0f, 2.0f, 3.0f, 4.0f}}) {
+    std::vector<float> labels{0.0f, 0.0f, 0.0f, 1000.0f};
+    auto const expected = expected_intercept(labels, weights);
+    ASSERT_NEAR(init(labels, weights), expected, 1.0e-4f);
+    std::transform(labels.cbegin(), labels.cend(), labels.begin(),
+                   [](float label) { return label + 1000.0f; });
+    ASSERT_NEAR(init(labels, weights), expected + 1000.0f, 1.0e-4f);
+  }
   ASSERT_EQ(obj->DefaultEvalMetric(), std::string{"mae"});
 }
 

--- a/tests/cpp/objective/test_regression_obj.h
+++ b/tests/cpp/objective/test_regression_obj.h
@@ -36,8 +36,6 @@ void TestCoxRegressionGPair(const Context* ctx);
 
 void TestAbsoluteError(const Context* ctx);
 
-void TestAbsoluteErrorLeaf(const Context* ctx);
-
 void TestVectorLeafObj(Context const* ctx, std::string name, Args const& args, bst_idx_t n_samples,
                        bst_idx_t n_target_labels, std::vector<float> const& sol_left,
                        std::vector<float> const& sol_right);

--- a/tests/cpp/objective/test_regression_obj_cpu.cc
+++ b/tests/cpp/objective/test_regression_obj_cpu.cc
@@ -148,19 +148,6 @@ TEST(Objective, DeclareUnifiedTest(AbsoluteError)) {
   TestAbsoluteError(&ctx);
 }
 
-TEST(Objective, DeclareUnifiedTest(AbsoluteErrorLeaf)) {
-  Context ctx = MakeCUDACtx(GPUIDX);
-  TestAbsoluteErrorLeaf(&ctx);
-}
-
-TEST(Objective, DeclareUnifiedTest(AbsoluteErrorVectorLeaf)) {
-  Context ctx = MakeCUDACtx(GPUIDX);
-  bst_idx_t n_samples = 16;
-  std::vector<float> sol_left{21.0f, 23.0f, 25.0f};
-  std::vector<float> sol_right{69.0f, 71.0f, 73.0f};
-  TestVectorLeafObj(&ctx, "reg:absoluteerror", Args{}, n_samples, 3u, sol_left, sol_right);
-}
-
 TEST(Adaptive, DeclareUnifiedTest(MissingLeaf)) {
   std::vector<bst_node_t> missing{1, 3};
 

--- a/tests/cpp/plugin/test_sycl_regression_obj.cc
+++ b/tests/cpp/plugin/test_sycl_regression_obj.cc
@@ -93,12 +93,6 @@ TEST(SyclObjective, AbsoluteError) {
   TestAbsoluteError(&ctx);
 }
 
-TEST(SyclObjective, AbsoluteErrorLeaf) {
-  Context ctx;
-  ctx.UpdateAllowUnknown(Args{{"device", "sycl"}});
-  TestAbsoluteErrorLeaf(&ctx);
-}
-
 TEST(SyclObjective, DeclareUnifiedTest(PseudoHuber)) {
   Context ctx;
   ctx.UpdateAllowUnknown(Args{{"device", "sycl"}});
@@ -108,13 +102,11 @@ TEST(SyclObjective, DeclareUnifiedTest(PseudoHuber)) {
 TEST(SyclObjective, CPUvsSycl) {
   Context ctx_sycl;
   ctx_sycl.UpdateAllowUnknown(Args{{"device", "sycl"}});
-  ObjFunction * obj_sycl =
-      ObjFunction::Create("reg:squarederror", &ctx_sycl);
+  ObjFunction* obj_sycl = ObjFunction::Create("reg:squarederror", &ctx_sycl);
 
   Context ctx_cpu;
   ctx_cpu.UpdateAllowUnknown(Args{{"device", "cpu"}});
-  ObjFunction * obj_cpu =
-      ObjFunction::Create("reg:squarederror", &ctx_cpu);
+  ObjFunction* obj_cpu = ObjFunction::Create("reg:squarederror", &ctx_cpu);
 
   linalg::Matrix<GradientPair> cpu_out_preds;
   linalg::Matrix<GradientPair> sycl_out_preds;
@@ -133,7 +125,7 @@ TEST(SyclObjective, CPUvsSycl) {
   info.labels.Reshape(kRows, 1);
   auto& h_labels = info.labels.Data()->HostVector();
   for (size_t i = 0; i < h_labels.size(); ++i) {
-    h_labels[i] = 1 / static_cast<float>(i+1);
+    h_labels[i] = 1 / static_cast<float>(i + 1);
   }
 
   {

--- a/tests/cpp/test_multi_target.cc
+++ b/tests/cpp/test_multi_target.cc
@@ -2,23 +2,20 @@
  * Copyright 2023-2025, XGBoost Contributors
  */
 #include <gtest/gtest.h>
-#include <xgboost/base.h>                         // for Args, bst_target_t
-#include <xgboost/data.h>                         // for DMatrix, MetaInfo
-#include <xgboost/json.h>                         // for Json, get, Object, String
-#include <xgboost/learner.h>                      // for Learner
+#include <xgboost/base.h>     // for Args, bst_target_t
+#include <xgboost/data.h>     // for DMatrix, MetaInfo
+#include <xgboost/json.h>     // for Json, get, Object, String
+#include <xgboost/learner.h>  // for Learner
 
-#include <algorithm>                              // for copy
-#include <cstddef>                                // for size_t
-#include <memory>                                 // for shared_ptr, allocator, __shared_ptr_access
-#include <numeric>                                // for accumulate
-#include <string>                                 // for stod, string
-#include <vector>                                 // for vector
+#include <algorithm>  // for copy
+#include <cstddef>    // for size_t
+#include <memory>     // for shared_ptr, allocator, __shared_ptr_access
+#include <string>     // for stod, string
+#include <vector>     // for vector
 
-#include "../../src/common/linalg_op.h"           // for begin, cbegin, cend
-#include "../../src/common/stats.h"               // for Median
-#include "helpers.h"                              // for RandomDataGenerator
-#include "xgboost/host_device_vector.h"           // for HostDeviceVector
-#include "xgboost/linalg.h"                       // for Tensor, All, TensorView, Vector
+#include "../../src/common/linalg_op.h"  // for begin, cbegin, cend
+#include "helpers.h"                     // for RandomDataGenerator
+#include "xgboost/linalg.h"              // for Tensor, All, TensorView, Vector
 
 namespace xgboost {
 class TestL1MultiTarget : public ::testing::Test {
@@ -96,9 +93,6 @@ class TestL1MultiTarget : public ::testing::Test {
       sl->SaveConfig(&s_config);
       auto s_base_score = GetBaseScore(s_config);
       ASSERT_EQ(s_base_score.size(), 1);
-      linalg::Vector<float> out;
-      common::Median(sl->Ctx(), t_Xy->Info().labels, t_Xy->Info().weights_, &out);
-      ASSERT_FLOAT_EQ(s_base_score[0], out(0));
       split_scores.push_back(s_base_score[0]);
     }
     ASSERT_EQ(split_scores, base_score);

--- a/tests/python/test_monotone_constraints.py
+++ b/tests/python/test_monotone_constraints.py
@@ -52,6 +52,16 @@ class TestMonotoneConstraints:
 
         assert is_correctly_constrained(constrained_learner, feature_names)
 
+    def test_absolute_error(self) -> None:
+        params = {
+            "objective": "reg:absoluteerror",
+            "tree_method": "hist",
+            "monotone_constraints": "(1, -1)",
+        }
+        constrained = xgb.train(params, training_dset, num_boost_round=16)
+
+        assert is_correctly_constrained(constrained)
+
     @pytest.mark.skipif(**tm.no_sklearn())
     def test_training_accuracy(self) -> None:
         from sklearn.metrics import accuracy_score

--- a/tests/python/test_tree_regularization.py
+++ b/tests/python/test_tree_regularization.py
@@ -1,7 +1,6 @@
 import numpy as np
-from numpy.testing import assert_approx_equal
-
 import xgboost as xgb
+from numpy.testing import assert_approx_equal
 
 train_data = xgb.DMatrix(np.array([[1]]), label=np.array([1]))
 

--- a/tests/python/test_tree_regularization.py
+++ b/tests/python/test_tree_regularization.py
@@ -67,6 +67,30 @@ class TestTreeRegularization:
         # 0.7 = 0.5 - (sum_grad - alpha * sgn(sum_grad)) / (sum_hess + lambda)
         assert_approx_equal(preds[0], 0.7)
 
+    def test_absolute_error_lambda(self):
+        params = {
+            "tree_method": "exact",
+            "verbosity": 0,
+            "objective": "reg:absoluteerror",
+            "eta": 1,
+            "alpha": 0,
+            "base_score": 0.5,
+            "max_depth": 1,
+            "min_child_weight": 0,
+        }
+
+        unregularized = xgb.train({**params, "lambda": 0}, train_data, 1)
+        regularized = xgb.train({**params, "lambda": 1}, train_data, 1)
+        unregularized_pred = unregularized.predict(train_data)
+        regularized_pred = regularized.predict(train_data)
+
+        # The residual is -0.5, so the automatic scale is 0.5 and the MM curvature is
+        # 1 / sqrt(2). With no regularization, -sum_grad / sum_hess is 0.5.
+        assert_approx_equal(unregularized_pred[0], 1.0)
+        curvature = 1.0 / np.sqrt(2.0)
+        expected = 0.5 + (0.5 * curvature) / (curvature + 1.0)
+        assert_approx_equal(regularized_pred[0], expected)
+
     def test_unlimited_depth(self):
         x = np.array([[0], [1], [2], [3]])
         y = np.array([0, 1, 2, 3])

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -1617,7 +1617,7 @@ class TestWithDask:
                     num_boost_round=1,
                 )
                 predt = booster.predict(Xy)
-                delta = ((np.sqrt(1000.0) / 4.0) ** 2)
+                delta = (np.sqrt(1000.0) / 4.0) ** 2
                 outlier_curvature = delta / np.hypot(delta, 1000.0)
                 expected = (1000.0 * outlier_curvature) / (3.0 + outlier_curvature)
                 np.testing.assert_allclose(predt, expected, rtol=1e-5)

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -1590,7 +1590,14 @@ class TestWithDask:
                 )
                 config = json.loads(booster.save_config())
                 base_score = get_basescore(config)
-                assert base_score == [250.0]
+                mean = 250.0
+                residuals = np.array([mean, mean, mean, mean - 1000.0])
+                delta = np.mean(np.sqrt(np.abs(residuals))) ** 2
+                curvature = delta / np.hypot(delta, residuals)
+                expected_base_score = mean - np.sum(residuals * curvature) / np.sum(
+                    curvature
+                )
+                np.testing.assert_allclose(base_score, [expected_base_score], rtol=1e-5)
 
                 # The smooth approximation scale must be global. Worker 0 has only zero
                 # residuals while worker 1 has one residual of -1000. A local scale would

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -1591,6 +1591,29 @@ class TestWithDask:
                 config = json.loads(booster.save_config())
                 base_score = get_basescore(config)
                 assert base_score == [250.0]
+
+                # The smooth approximation scale must be global. Worker 0 has only zero
+                # residuals while worker 1 has one residual of -1000. A local scale would
+                # therefore produce a different root update.
+                booster = xgb.train(
+                    {
+                        "tree_method": "hist",
+                        "objective": "reg:absoluteerror",
+                        "base_score": 0,
+                        "eta": 1,
+                        "max_depth": 1,
+                        "min_child_weight": 0,
+                        "reg_alpha": 0,
+                        "reg_lambda": 0,
+                    },
+                    Xy,
+                    num_boost_round=1,
+                )
+                predt = booster.predict(Xy)
+                delta = ((np.sqrt(1000.0) / 4.0) ** 2)
+                outlier_curvature = delta / np.hypot(delta, 1000.0)
+                expected = (1000.0 * outlier_curvature) / (3.0 + outlier_curvature)
+                np.testing.assert_allclose(predt, expected, rtol=1e-5)
                 return True
 
         workers = tm.dask.get_client_workers(client)


### PR DESCRIPTION
## Summary

- replace the specialized `reg:absoluteerror` sign-gradient and post-tree sorting update with an automatically scaled smooth MM approximation
- use the pseudo-Huber gradient with the stable MM/IRLS curvature, with an independently estimated scale for each target
- globally reduce the scale statistics so every distributed worker uses the same gradients and Hessians
- route absolute-error trees through the standard leaf-weight path so regularization and monotone constraints are honored
- initialize `base_score` from the global weighted mean followed by one unregularized MM intercept update

For residual $r$, the automatic scale and gradient pair are

$$
\delta = E_w[\sqrt{|r|}]^2,\quad
c = \frac{\delta}{\sqrt{\delta^2 + r^2}},\quad
g = wrc,\quad h = wc.
$$

This keeps the objective parameter-free while allowing the relaxation to contract with the residual scale during training.

Related to #12351.

## Validation

- built `testxgboost` and the shared CPU library
- passed all 31 `Objective.*` C++ tests
- passed focused absolute-error objective, multi-target (`hist`, `exact`, and `approx`), initializer, and serialization tests
- added closed-form and translation-equivariance coverage for the new initializer
- passed new Python tests showing that `reg_lambda` changes the fitted absolute-error leaf and that monotone constraints hold
- added a two-worker Dask regression test for the global scale and initializer calculations; it was not run locally because the optional `distributed` package is unavailable in the test environment
