### PR TITLE
[Don't merge] Test XGBoost with Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,7 +200,7 @@ jobs:
       - uses: actions/checkout@v6.0.3
       - name: Pick Python
         run: |
-          export PATH=/opt/python/cp312-cp312/bin/:$PATH
+          export PATH=/opt/python/cp311-cp311/bin/:$PATH
           echo ${PATH} >> $GITHUB_PATH
       - name: Install dependencies
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.11"
       - name: Install pre-commit
         run: python -m pip install pre-commit
       - name: Run pre-commit on updated files

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -62,8 +62,8 @@ jobs:
       - uses: actions/checkout@v6.0.3
         with:
           submodules: 'true'
-      - name: Set up Python 3.12
+      - name: Set up Python 3.11
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.11"
       - run: bash ops/pipeline/test-python-with-sysprefix.sh

--- a/.github/workflows/python_wheels_variants.yml
+++ b/.github/workflows/python_wheels_variants.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v6.0.3
       - name: Pick Python
         run: |
-          export PATH=/opt/python/cp312-cp312/bin/:$PATH
+          export PATH=/opt/python/cp311-cp311/bin/:$PATH
           echo ${PATH} >> $GITHUB_PATH
       - name: Install dependencies
         run: |

--- a/.github/workflows/python_wheels_winarm64.yml
+++ b/.github/workflows/python_wheels_winarm64.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: '3.12'
+          python-version: '3.11'
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/r_tests.yml
+++ b/.github/workflows/r_tests.yml
@@ -49,7 +49,7 @@ jobs:
           r-version: ${{ matrix.r }}
       - uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           architecture: 'x64'
       - uses: r-lib/actions/setup-tinytex@v2
       - uses: dmlc/xgboost-devops/actions/sccache@main

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ submodules:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.11"
   apt_packages:
     - graphviz
     - cmake

--- a/doc/xgboost_doc.yml
+++ b/doc/xgboost_doc.yml
@@ -1,6 +1,6 @@
 name: xgboost_docs
 dependencies:
-  - python=3.12
+  - python=3.11
   - pip
   - pygraphviz
   - sphinx

--- a/ops/conda_env/aarch64_test.yml
+++ b/ops/conda_env/aarch64_test.yml
@@ -2,7 +2,7 @@ name: aarch64_test
 channels:
 - conda-forge
 dependencies:
-- python=3.12
+- python=3.11
 - pip
 - wheel
 - pytest

--- a/ops/conda_env/linux_cpu_test.yml
+++ b/ops/conda_env/linux_cpu_test.yml
@@ -2,7 +2,7 @@ name: linux_cpu_test
 channels:
 - conda-forge
 dependencies:
-- python=3.12
+- python=3.11
 - cmake>=3.26.4
 - c-compiler
 - cxx-compiler

--- a/ops/conda_env/linux_sycl_test.yml
+++ b/ops/conda_env/linux_sycl_test.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - https://software.repos.intel.com/python/conda/
 dependencies:
-- python=3.12
+- python=3.11
 - cmake>=3.26.4
 - c-compiler
 - cxx-compiler

--- a/ops/conda_env/macos_cpu_test.yml
+++ b/ops/conda_env/macos_cpu_test.yml
@@ -2,7 +2,7 @@ name: macos_test
 channels:
 - conda-forge
 dependencies:
-- python=3.12
+- python=3.11
 - pip
 - wheel
 - pyyaml

--- a/ops/conda_env/minimal.yml
+++ b/ops/conda_env/minimal.yml
@@ -2,5 +2,5 @@ name: minimal
 channels:
 - conda-forge
 dependencies:
-- python=3.12
+- python=3.11
 - awscli

--- a/ops/conda_env/python_lint.yml
+++ b/ops/conda_env/python_lint.yml
@@ -2,7 +2,7 @@ name: python_lint
 channels:
 - conda-forge
 dependencies:
-- python=3.12
+- python=3.11
 - pylint
 - wheel
 - setuptools

--- a/ops/conda_env/sdist_test.yml
+++ b/ops/conda_env/sdist_test.yml
@@ -3,7 +3,7 @@ name: sdist_test
 channels:
 - conda-forge
 dependencies:
-- python=3.12
+- python=3.11
 - pip
 - wheel
 - cmake

--- a/ops/conda_env/win64_test.yml
+++ b/ops/conda_env/win64_test.yml
@@ -2,7 +2,7 @@ name: win64_env
 channels:
 - conda-forge
 dependencies:
-- python=3.12
+- python=3.11
 - numpy
 - scipy
 - matplotlib

--- a/ops/pipeline/build-python-wheels-cpu.sh
+++ b/ops/pipeline/build-python-wheels-cpu.sh
@@ -25,7 +25,7 @@ source ops/pipeline/get-image-tag.sh
 WHEEL_TAG="${manylinux_target}_${arch}"
 IMAGE_REPO="xgb-ci.${WHEEL_TAG}"
 IMAGE_URI="${DOCKER_REGISTRY_URL}/${IMAGE_REPO}:${IMAGE_TAG}"
-PYTHON_BIN="/opt/python/cp312-cp312/bin/python"
+PYTHON_BIN="/opt/python/cp311-cp311/bin/python"
 
 echo "--- Build binary wheel for ${WHEEL_TAG} (CPU only)"
 set -x

--- a/ops/pipeline/build-python-wheels-macos.sh
+++ b/ops/pipeline/build-python-wheels-macos.sh
@@ -14,12 +14,12 @@ commit_id=$2
 if [[ "$platform_id" == macosx_* ]]; then
     if [[ "$platform_id" == macosx_arm64 ]]; then
         # MacOS, Apple Silicon
-        cpython_ver=312
+        cpython_ver=311
         cibw_archs=arm64
         export MACOSX_DEPLOYMENT_TARGET=12.0
     elif [[ "$platform_id" == macosx_x86_64 ]]; then
         # MacOS, Intel
-        cpython_ver=312
+        cpython_ver=311
         cibw_archs=x86_64
         export MACOSX_DEPLOYMENT_TARGET=10.15
     else

--- a/ops/pipeline/get-image-tag.sh
+++ b/ops/pipeline/get-image-tag.sh
@@ -7,4 +7,4 @@
 # or PR number:
 # IMAGE_TAG=PR-88
 
-IMAGE_TAG=main
+IMAGE_TAG=PR-96

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
     { name = "Jiaming Yuan", email = "jm.yuan@outlook.com" }
 ]
 version = "3.3.0"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
@@ -25,6 +25,7 @@ classifiers = [
     "Typing :: Typed",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",

--- a/python-package/pyproject.toml.in
+++ b/python-package/pyproject.toml.in
@@ -15,7 +15,7 @@ authors = [
     { name = "Jiaming Yuan", email = "jm.yuan@outlook.com" }
 ]
 version = "3.3.0"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
@@ -24,6 +24,7 @@ classifiers = [
     "Typing :: Typed",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",

--- a/python-package/pyproject.toml.stub.in
+++ b/python-package/pyproject.toml.stub.in
@@ -13,7 +13,7 @@ authors = [
     { name = "Jiaming Yuan", email = "jm.yuan@outlook.com" }
 ]
 version = "3.3.0"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
@@ -22,6 +22,7 @@ classifiers = [
     "Typing :: Typed",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]

--- a/python-package/xgboost/testing/dask.py
+++ b/python-package/xgboost/testing/dask.py
@@ -189,6 +189,14 @@ def get_client_workers(client: Client) -> List[str]:
     return list(workers.keys())
 
 
+async def get_client_workers_async(client: Client) -> List[str]:
+    "Get workers from a dask client (async)."
+    kwargs = {"n_workers": -1} if _DASK_VERSION() >= parse_version("2025.4.0") else {}
+    info = await client.scheduler.identity(**kwargs)
+    workers = info["workers"]
+    return list(workers.keys())
+
+
 def make_ltr(  # pylint: disable=too-many-locals,too-many-arguments
     client: Client,
     n_samples: int,

--- a/tests/test_distributed/test_with_dask/test_external_memory.py
+++ b/tests/test_distributed/test_with_dask/test_external_memory.py
@@ -3,7 +3,6 @@
 import pytest
 from distributed import Client, Scheduler, Worker
 from distributed.utils_test import gen_cluster
-
 from xgboost import testing as tm
 from xgboost.testing.dask import check_external_memory, get_rabit_args
 
@@ -13,7 +12,7 @@ from xgboost.testing.dask import check_external_memory, get_rabit_args
 async def test_external_memory(
     client: Client, s: Scheduler, a: Worker, b: Worker, is_qdm: bool
 ) -> None:
-    workers = tm.dask.get_client_workers(client)
+    workers = await tm.dask.get_client_workers_async(client)
     n_workers = len(workers)
     args = await get_rabit_args(client, n_workers)
 


### PR DESCRIPTION
Rapids 26.08 needs to package a patched version of XGBoost 3.3 with Python 3.11 support. Filing a draft pull request now to run tests.