### PR TITLE
Fix collective.allreduce always returning a flattened 1-D array

### DIFF
--- a/python-package/xgboost/collective.py
+++ b/python-package/xgboost/collective.py
@@ -313,7 +313,10 @@ def allreduce(data: np.ndarray, op: Op) -> np.ndarray:
             int(op),
         )
     )
-    return buf
+    # `buf` is a flattened copy used for the underlying C call; reshape it back
+    # to the input's original shape so the result actually "has the same shape
+    # as data", as documented above, instead of always returning a 1-D array.
+    return buf.reshape(data.shape)
 
 
 def signal_error() -> None:


### PR DESCRIPTION
# Fix collective.allreduce always returning a flattened 1-D array

## Summary
`allreduce()`'s docstring documents:

```
Returns
-------
result :
    The result of allreduce, have same shape as data
```

But the implementation always returned `data.ravel().copy()` after the
underlying C call — i.e. always a flattened 1-D array. For any
multi-dimensional input, the returned array's shape does not match the
input's shape, contradicting the documented contract.

## Why this is reachable
`allreduce` is public API (`xgboost.collective`), intended for users
writing custom distributed/federated training code, not just internal
use. All current internal callers happen to only ever pass 1-D arrays
(`callback.py`'s `_aggcv` averaging, the existing tests in
`test_collective.py` / `test_tracker.py`), which is why this went
unnoticed — `reshape((n,))` on an already-1-D array of size `n` is a
no-op, so it doesn't manifest for those call sites. But nothing prevents
(or warns) a user from calling `allreduce()` with a genuinely
multi-dimensional array — e.g. reducing a 2-D gradient or weight matrix
across workers in custom code — and getting back a silently flattened
array instead of one matching their input's shape.

## Change
```diff
     _check_call(
         _LIB.XGCommunicatorAllreduce(
             buf.ctypes.data_as(ctypes.c_void_p),
             buf.size,
             _map_dtype(buf.dtype),
             int(op),
         )
     )
-    return buf
+    # `buf` is a flattened copy used for the underlying C call; reshape it back
+    # to the input's original shape so the result actually "has the same shape
+    # as data", as documented above, instead of always returning a 1-D array.
+    return buf.reshape(data.shape)
```

This is safe: `.ravel()` on a C-contiguous array followed by `.reshape()`
back to the original shape round-trips exactly (row-major order
preserved) — it doesn't touch the actual reduction, which already happened
via the C call on the flat buffer.

## Verification

- **1-D** input (the existing, common usage pattern) — confirmed the fix is
  a no-op here, zero regression risk for current callers
- **2-D** input (the bug case) — output shape now correctly matches input
- **0-D** scalar array — edge case, still works
- **3-D** input — shape and values both preserved

`mypy` and `ruff` both pass on the modified file.