### PR TITLE
Fix discarded transform_scipy_sparse() return value in CSC path

### DIFF
--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -212,7 +212,7 @@ def _from_scipy_csc(
 ) -> DispatchedDataBackendReturnType:
     """Initialize data from a CSC matrix."""
     handle = ctypes.c_void_p()
-    transform_scipy_sparse(data, False)
+    data = transform_scipy_sparse(data, False)
     _check_call(
         _LIB.XGDMatrixCreateFromCSC(
             array_interface(data.indptr),


### PR DESCRIPTION
# Fix discarded transform_scipy_sparse() return value in CSC path
 
## Summary
`transform_scipy_sparse()` ensures a scipy sparse matrix's `indptr`, `indices`,
and `data` arrays have a correct, C-API-compatible dtype and are
memory-aligned, per `_ensure_np_dtype()`. When any of those arrays needs
correction (e.g. `float16`/`bool_`/object dtype, or non-aligned memory), it
does **not** mutate the input in place — it constructs and returns a **new**
`csr_matrix`/`csc_matrix` built from the corrected arrays, leaving the
original matrix untouched:
 
```python
def transform_scipy_sparse(data: DataType, is_csr: bool) -> DataType:
    ...
    if (
        indptr is not data.indptr
        or indices is not data.indices
        or values is not data.data
    ):
        if is_csr:
            data = csr_matrix((values, indices, indptr), shape=data.shape)
        else:
            data = csc_matrix((values, indices, indptr), shape=data.shape)
    return data
```
 
`_from_scipy_csr` correctly captures this:
```python
data = transform_scipy_sparse(data, True)
```
 
But `_from_scipy_csc` called it as a bare statement, discarding the return
value:
```python
transform_scipy_sparse(data, False)
```
and then went on to use the **original, uncorrected** `data.indptr` /
`data.indices` / `data.data` in the `XGDMatrixCreateFromCSC` call.
 
## Concrete impact
If a CSC matrix's `data`/`indices`/`indptr` end up in a dtype that needs
correcting (e.g. a user manually assigns a `float16` array to `.data`), the
correction computed by `transform_scipy_sparse` is silently thrown away, and
the **uncorrected** array interface gets passed to the C API instead.
 
## Change
```diff
     handle = ctypes.c_void_p()
-    transform_scipy_sparse(data, False)
+    data = transform_scipy_sparse(data, False)
     _check_call(
         _LIB.XGDMatrixCreateFromCSC(
```
 
One line — capture the return value, exactly matching the CSR path's
existing correct pattern.
 
## Verification
 
- **Before the fix**: a `float16` `.data` array is silently left uncorrected
  after the (discarded) `transform_scipy_sparse` call
- **After the fix**: capturing the return value correctly produces a
  `float32`-corrected matrix, matching what `_from_scipy_csr` already does
  correctly
`mypy` and `ruff` both pass on the modified file.