### PR TITLE
Add missing halffloat[pyarrow] entry to pandas_pyarrow_mapper

### DIFF
--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -336,6 +336,15 @@ pandas_pyarrow_mapper = {
     "float32[pyarrow]": "float",
     "double[pyarrow]": "float",
     "float64[pyarrow]": "float",
+    # pyarrow's own name for its 16-bit float type is "halffloat", not
+    # "float16" -- this is the actual `dtype.name` produced by a real
+    # `pandas.Series(..., dtype="float16[pyarrow]")`, verified at runtime.
+    # Every other numeric width (int8..uint64, float32, float64) already has
+    # an entry here; this one was simply missing, causing a real
+    # float16[pyarrow] column to hit the `KeyError` -> `_invalid_dataframe_dtype`
+    # fallback and raise a misleading "must be int, float, bool or category"
+    # error instead of being accepted.
+    "halffloat[pyarrow]": "float",
     "bool[pyarrow]": "i",
 }
 


### PR DESCRIPTION
# Add missing halffloat[pyarrow] entry to pandas_pyarrow_mapper

## Summary
`pandas_pyarrow_mapper` maps pandas `ArrowDtype` names to XGBoost's internal
feature-type codes. Every numeric width has an entry except one: pyarrow's
16-bit float type.

A real `pandas.Series(..., dtype="float16[pyarrow]")` produces a dtype
whose `.name` is `"halffloat[pyarrow]"`, **not** `"float16[pyarrow]"` —
this is pyarrow's own naming convention. (Similarly, `float32[pyarrow]` and
`float64[pyarrow]` actually produce `dtype.name == "float[pyarrow]"` and
`"double[pyarrow]"` respectively, which the dict already correctly
accounts for — verified all of this at runtime.)

Since `"halffloat[pyarrow]"` was simply absent from the dict, looking it up
raises `KeyError`, which the caller (`pandas_feature_info`) catches and
turns into `_invalid_dataframe_dtype()`'s error:

```
DataFrame.dtypes for data must be int, float, bool or category.
```

— a misleading message for a column that is, in fact, a perfectly valid
float type.

## Concrete impact
Any user with a `float16[pyarrow]` pandas column (e.g. from reading a
Parquet file with half-precision columns via pyarrow-backed pandas) would
hit this error when constructing a `DMatrix`, even though every other float
width (`float32`, `float64`) works fine.

## Change
```diff
     "float[pyarrow]": "float",
     "float32[pyarrow]": "float",
     "double[pyarrow]": "float",
     "float64[pyarrow]": "float",
+    "halffloat[pyarrow]": "float",
     "bool[pyarrow]": "i",
```

## Verification

```python
>>> import pandas as pd
>>> pd.Series([1.0], dtype="float16[pyarrow]").dtype.name
'halffloat[pyarrow]'
```

- Confirmed the lookup fails with `KeyError` against the dict **before**
  the fix, and resolves to `"float"` **after** adding the entry
- Re-checked every other pyarrow numeric dtype (`int8`..`uint64`,
  `float32`, `float64`, `bool`) against the dict to confirm no regressions

`mypy` and `ruff` both pass on the modified file.