### PR TITLE
Fix make_array_interface reporting wrong shape for empty results

### DIFF
--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -215,6 +215,11 @@ def make_array_interface(
     assert addr is not None or length == 0
 
     if addr is None:
+        # `array` still has the placeholder (0,) shape from the empty array used
+        # to derive `typestr`/`descr` above; update it to the actual requested
+        # shape (e.g. (0, n_features) for an empty multi-dimensional result)
+        # instead of always reporting a flat 1-D empty shape.
+        array["shape"] = shape
         return array
 
     array["data"] = (addr, True)


### PR DESCRIPTION
# Fix make_array_interface reporting wrong shape for empty results

## Summary
`make_array_interface()` builds its return value by starting from
`numpy.empty(shape=(0,), dtype=dtype).__array_interface__`, purely to get a
correctly-typed dict skeleton (`typestr`/`descr`) for the given `dtype`,
then overwrites `data`/`shape`/`strides` for the real, requested shape.

But in the early-return branch for a null/empty-dataset pointer
(`addr is None`, `length == 0`), the function returned that dict as-is
without ever updating its `shape` — meaning it always reported shape
`(0,)`, regardless of what `shape` was actually requested. For a caller
requesting a genuinely multi-dimensional empty result, e.g. `shape=(0, 5)`
(0 samples, 5 features), the returned array interface would incorrectly
claim shape `(0,)` instead.

## Why this is reachable
This is reachable via `core.py`'s `_prediction_output`, which calls
`make_array_interface` with a shape taken directly from the C API's own
reported prediction dimensions. Predicting on an empty `DMatrix` with a
multi-dimensional output (e.g. `pred_contribs`, which appends a bias
column) could plausibly hit this path.

The wrong shape genuinely propagates: `from_array_interface`'s `Array`
wrapper passes the interface dict straight through to numpy's/cupy's
array-interface protocol, so the final array a user gets back would have
the wrong shape.

## Change
```diff
     if addr is None:
+        # `array` still has the placeholder (0,) shape from the empty array
+        # used to derive `typestr`/`descr` above; update it to the actual
+        # requested shape (e.g. (0, n_features) for an empty multi-dimensional
+        # result) instead of always reporting a flat 1-D empty shape.
+        array["shape"] = shape
         return array
```

## Verification

- **1-D empty case** (the common case) — shape `(0,)` unchanged, zero
  regression risk
- **2-D empty case** (the bug case) — shape now correctly `(0, 5)` instead
  of `(0,)`
- **Non-empty case** — completely unaffected
- Constructed an actual numpy array via the `__array_interface__` protocol
  from the fixed dict and confirmed it has the correct `(0, 5)` shape

`mypy` and `ruff` both pass on the modified file.