### PR TITLE
Feature/collective allreduce average

### DIFF
--- a/doc/python/python_api.rst
+++ b/doc/python/python_api.rst
@@ -212,6 +212,10 @@ Collective
 
 .. autofunction:: xgboost.collective.get_world_size
 
+.. autofunction:: xgboost.collective.allreduce
+
+.. autofunction:: xgboost.collective.allreduce_average
+
 .. autoclass:: xgboost.collective.CommunicatorContext
 
 .. automodule:: xgboost.tracker

--- a/python-package/xgboost/callback.py
+++ b/python-package/xgboost/callback.py
@@ -142,7 +142,7 @@ def _allreduce_metric(score: _ART) -> _ART:
             "xgboost.cv function should not be used in distributed environment."
         )
     arr = numpy.array([score])
-    arr = collective.allreduce(arr, collective.Op.SUM) / world
+    arr = collective.allreduce_average(arr)
     return arr[0]
 
 

--- a/python-package/xgboost/collective.py
+++ b/python-package/xgboost/collective.py
@@ -316,6 +316,46 @@ def allreduce(data: np.ndarray, op: Op) -> np.ndarray:
     return buf
 
 
+def allreduce_average(data: np.ndarray) -> np.ndarray:
+    """Compute the element-wise average of `data` across all workers.
+
+    This is a small convenience wrapper around :py:func:`allreduce` for the
+    common pattern of summing a value across all workers and dividing by the
+    number of workers, e.g. for averaging a per-worker metric or statistic in
+    custom distributed training code.
+
+    Parameters
+    ----------
+    data :
+        Input data.
+
+    Returns
+    -------
+    result :
+        The element-wise average of `data` across all workers, with the same
+        shape as `data`.
+
+    Notes
+    -----
+    This function is not thread-safe, the same as :py:func:`allreduce`.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import numpy as np
+        from xgboost import collective as coll
+
+        with coll.CommunicatorContext(...):
+            local_value = np.array([metric_value])
+            avg_value = coll.allreduce_average(local_value)
+    """
+    world = get_world_size()
+    if world == 1:
+        return data
+    return allreduce(data, Op.SUM) / world
+
+
 def signal_error() -> None:
     """Kill the process."""
     _check_call(_LIB.XGCommunicatorSignalError())

--- a/tests/python/test_collective.py
+++ b/tests/python/test_collective.py
@@ -19,6 +19,10 @@ def run_rabit_worker(rabit_env: dict, world_size: int) -> int:
         assert str(ret) == "test1234"
         reduced = xgb.collective.allreduce(np.asarray([1, 2, 3]), xgb.collective.Op.SUM)
         assert np.array_equal(reduced, np.asarray([2, 4, 6]))
+        # Every worker contributes the same values here, so the average across
+        # all workers should equal the original values, regardless of world size.
+        averaged = xgb.collective.allreduce_average(np.asarray([1.0, 2.0, 3.0]))
+        assert np.allclose(averaged, np.asarray([1.0, 2.0, 3.0]))
     return 0
 
 
@@ -89,3 +93,13 @@ def test_config_serialization() -> None:
     cfg = Config(retry=1, timeout=2, tracker_host_ip="127.0.0.1", tracker_port=None)
     cfg1 = Config(**asdict(cfg))
     assert cfg == cfg1
+
+
+def test_allreduce_average_single_worker() -> None:
+    # Outside of a CommunicatorContext, world size is 1, so
+    # allreduce_average should short-circuit and return the input unchanged
+    # without needing an actual distributed communicator.
+    assert xgb.collective.get_world_size() == 1
+    data = np.asarray([1.0, -2.5, 3.0])
+    result = xgb.collective.allreduce_average(data)
+    assert np.array_equal(result, data)


### PR DESCRIPTION
# Add collective.allreduce_average convenience helper

## Summary
Adds `xgboost.collective.allreduce_average()`, a small convenience wrapper
around the common "sum across workers, then divide by world size" pattern
for averaging a per-worker metric or statistic in custom distributed
training code.

This exact pattern was already being hand-written in `callback.py`'s
`_allreduce_metric` (`allreduce(arr, Op.SUM) / world`), so this both adds a
small piece of genuinely useful public API and removes some duplication.

## Commits
1. **Add `collective.allreduce_average` convenience helper** — the new
   function itself, short-circuiting to return the input unchanged when
   `world size == 1` (matching the same check already done by hand
   elsewhere in the codebase).
2. **Use `collective.allreduce_average` in `_allreduce_metric`** — refactors
   the existing hand-written pattern in `callback.py` to use the new
   helper, as a real usage example and to remove duplication. Deliberately
   left the surrounding `world == 1` early-return and the
   distributed-`xgb.cv`-misuse rejection check untouched, in the same
   order — only the final sum-then-divide lines were simplified. Verified
   this produces identical results to the previous implementation across
   several world-size and score values.
3. **Add test coverage** — extends the existing real multi-worker Rabit
   test (`run_rabit_worker`, using `loky`) to also exercise
   `allreduce_average` across actual worker processes, plus a standalone
   single-process test for the `world == 1` short-circuit path.
4. **Document `allreduce` and `allreduce_average` in the API reference** —
   `doc/python/python_api.rst`'s Collective section was missing several
   existing public functions (`allreduce`, `broadcast`, `is_distributed`,
   etc) even before this change. I'm not attempting to fix that broader,
   pre-existing gap here to keep this PR scoped to the new feature, but
   flagging it in case a maintainer wants a separate follow-up. Added
   entries for `allreduce` (pre-existing but undocumented on this page)
   and the new `allreduce_average`, since referencing the new function
   without its `allreduce` counterpart being nearby would be confusing.

## Verification

- The new function's logic (short-circuit + sum/divide) was verified
  standalone with a toy simulation across several world sizes and values
- The refactor's behavioral equivalence to the old code was verified
  standalone across several `(world, score)` combinations
`mypy` and `ruff` pass on all modified files.