### PR TITLE
Fix missing string input tag in sklearn Tags dataclass conversion

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -937,6 +937,7 @@ class XGBModel(XGBModelBase):
         tags.input_tags.allow_nan = tags_dict["allow_nan"]
         tags.input_tags.sparse = tags_dict["sparse"]
         tags.input_tags.categorical = tags_dict["categorical"]
+        tags.input_tags.string = tags_dict["string"]
         return tags
 
     def __sklearn_tags__(self) -> _sklearn_Tags:


### PR DESCRIPTION
# Fix missing string input tag in sklearn Tags dataclass conversion

## Summary
`XGBModel._more_tags()` computes both `"categorical"` and `"string"` the
same way, from `self.enable_categorical`:

```python
tags["categorical"] = self.enable_categorical
tags["string"] = self.enable_categorical
```

But `_update_sklearn_tags_from_dict()`, which copies values from that dict
onto scikit-learn's newer `Tags`/`InputTags` dataclass (introduced in
sklearn 1.6), only propagated `"categorical"`:

```python
tags.input_tags.categorical = tags_dict["categorical"]
```

`"string"` was computed but never actually applied to
`tags.input_tags.string`, which sklearn's own `InputTags` dataclass does
have as a real field ("Whether the input can be an array-like of
strings" — confirmed directly against `sklearn.utils.InputTags`). This
left `tags.input_tags.string` always at its dataclass default (`False`)
for scikit-learn >= 1.6, regardless of `enable_categorical`, even though
the correct value was already sitting right there in `tags_dict`.

## Why this matters
This tag is consulted by scikit-learn's own estimator-validation
utilities/common tests to decide whether to exercise string-input handling
for an estimator, so a wrong value here could cause those checks to be
silently skipped.

## Change
```diff
         tags.input_tags.allow_nan = tags_dict["allow_nan"]
         tags.input_tags.sparse = tags_dict["sparse"]
         tags.input_tags.categorical = tags_dict["categorical"]
+        tags.input_tags.string = tags_dict["string"]
         return tags
```

One line, matching the existing pattern for `"categorical"` right above
it.

## Safety check
Checked all `_more_tags()` overrides in this file — the
classifier/ranking-mixin subclasses that override it (`XGBClassifier`,
`XGBRFRegressor`, etc.) all call `tags = super()._more_tags()` first, so
`"string"` set in the base `XGBModel` implementation is always present in
the dict regardless of which subclass is involved. No `KeyError` risk from
the bare `tags_dict["string"]` access.

## Verification
Verified against the **real** scikit-learn `Tags`/`InputTags` dataclasses
— constructed a real `sklearn.utils.Tags`
instance, ran the fixed update function, and confirmed
`tags.input_tags.string` correctly reflects the input dict's value.

`mypy` and `ruff` both pass on the modified file.