### PR TITLE
Reuse multi-target histogram builder across trees

### DIFF
--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -209,7 +209,9 @@ class MultiTargetHistBuilder {
     partitioner_.resize(page_idx);
 
     bst_target_t n_targets = gpair.Shape(1);
-    histogram_builder_ = std::make_unique<MultiHistogramBuilder>();
+    if (!histogram_builder_) {
+      histogram_builder_ = std::make_unique<MultiHistogramBuilder>();
+    }
     histogram_builder_->Reset(ctx_, n_total_bins, n_targets, HistBatch(param_),
                               collective::IsDistributed(), hist_param_);
 


### PR DESCRIPTION
## Summary

Reuse `MultiHistogramBuilder` across boosting rounds in `MultiTargetHistBuilder` and call `Reset()` for each new tree, matching the lifetime used by the scalar histogram updater.

## Root cause

`MultiTargetHistBuilder::InitData()` reconstructed `MultiHistogramBuilder` for every tree. This discarded the histogram collections and thread-local buffers after each boosting round, forcing their storage to be allocated again for the next tree. `MultiHistogramBuilder::Reset()` already resizes the target builders and reconfigures them for the current target count, bin count, batch parameters, and distributed state.

## Benchmarks

Local release CPU build (`USE_CUDA=OFF`) on an AMD Ryzen Threadripper PRO 7975WX, using 8 training threads. Each timing is a fresh `xgb.train` call; three repetitions are shown.

Direct multi-output benchmark:

- 100,000 rows, 50 dense float32 features, 2 regression targets
- `multi_strategy=multi_output_tree`, `tree_method=hist`
- 100 boosting rounds, `max_depth=8`, `max_bin=256`

| Implementation | Training times (s) | Median (s) |
|---|---:|---:|
| Recreate builder per tree | 6.802, 6.382, 6.026 | 6.382 |
| Reuse builder | 1.547, 1.465, 1.593 | 1.547 |

This is a 4.1x speedup (75.8% lower median training time). Predictions were bit-for-bit identical (`SHA256 6743b38a...aea91`), and both serialized models were 2,182,892 bytes.

This issue was initially found while routing scalar training through a size-one vector-leaf tree. On a 100,000 x 50, 150-round depth-8 workload:

| Path | Median training time (s) |
|---|---:|
| Scalar updater | 1.321 |
| Size-one vector updater, recreate builder | 5.191 |
| Size-one vector updater, reuse builder | 1.292 |

Predictions from all three paths were bit-for-bit identical. Internal monitor timings on a separate 50-round workload localized the regression to histogram construction:

| Phase | Scalar (s) | Vector before (s) | Vector after (s) |
|---|---:|---:|---:|
| `BuildHistogram` | 0.169 | 1.076 | 0.145 |
| `EvaluateSplits` | 0.164 | 0.166 | 0.154 |
| `InitData` | 0.086 | 0.233 | 0.084 |

## Validation

```text
python -m pytest -q tests/python/test_multi_target.py \
  -k "shap_multi_output_tree or reduced_grad or with_iter or categorical_mixed or grow_policy"

6 passed, 29 deselected
```

These cases cover normal multi-output hist training, reduced gradients, iterator input, categorical data, SHAP, and both depthwise and lossguide growth policies.