### PR TITLE
Feature/trees to dataframe category names

### DIFF
--- a/doc/tutorials/categorical.rst
+++ b/doc/tutorials/categorical.rst
@@ -239,6 +239,16 @@ categories by exporting it to arrow arrays. This interface is still experimental
   categories = booster.get_categories(export_to_arrow=True)
   print(categories.to_arrow())
 
+To inspect how categorical splits use these categories inside the trained trees,
+:py:meth:`~xgboost.Booster.trees_to_dataframe` has a ``use_category_names`` option that
+resolves the raw category codes shown in the ``Category`` column back to their original
+values:
+
+.. code-block:: python
+
+  df = booster.trees_to_dataframe(use_category_names=True)
+  print(df[df.Feature != "Leaf"][["Feature", "Category"]])
+
 
 In addition to the notes above, there's a `blog post
 <https://developer.nvidia.com/blog/training-xgboost-models-with-gpu-accelerated-polars-dataframes/>`__

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -3081,7 +3081,9 @@ class Booster:
         return results
 
     # pylint: disable=too-many-locals, too-many-statements
-    def trees_to_dataframe(self, fmap: PathLike = "") -> PdDataFrame:
+    def trees_to_dataframe(
+        self, fmap: PathLike = "", use_category_names: bool = False
+    ) -> PdDataFrame:
         """Parse a boosted tree model into a pandas DataFrame.
 
         This feature is only defined when the decision tree model is chosen as base
@@ -3094,6 +3096,16 @@ class Booster:
             :attr:`.feature_names`.
 
             .. deprecated:: 3.4.0
+
+        use_category_names :
+            For categorical splits, resolve the raw category codes in the
+            ``Category`` column to the original category values (e.g. ``"red"``
+            instead of ``2``) using :py:meth:`get_categories`, when available.
+            Defaults to ``False``, which keeps the existing behavior of reporting
+            raw integer codes, to avoid changing the dtype of the ``Category``
+            column for existing code that expects it.
+
+            .. versionadded:: 3.4.0
 
         """
         if not is_pandas_available():
@@ -3118,12 +3130,20 @@ class Booster:
         fnames = dict(enumerate(self.feature_names or []))
         ftypes = dict(enumerate(self.feature_types or []))
 
+        cat_names_by_feature: Dict[str, List[str]] = {}
+        if use_category_names:
+            cats = self.get_categories(export_to_arrow=True)
+            if not cats.empty():
+                for fname, arr in cats.to_arrow():
+                    if arr is not None:
+                        cat_names_by_feature[fname] = [str(v) for v in arr]
+
         tree_ids: List[int] = []
         target_ids: List[Optional[int]] = []
         node_ids: List[int] = []
         fids: List[str] = []
         splits: List[float | None] = []
-        categories: List[None | List[int]] = []
+        categories: List[None | List[int] | List[str]] = []
         y_directs: List[str | None] = []
         n_directs: List[str | None] = []
         missings: List[str | None] = []
@@ -3196,12 +3216,22 @@ class Booster:
                 target_ids.append(None if is_vector else tree_target)
                 node_ids.append(nid)
                 fidx = sindex[nid]
-                fids.append(fnames.get(fidx, f"f{fidx}"))
+                fname = fnames.get(fidx, f"f{fidx}")
+                fids.append(fname)
                 dft_child = left[nid] if dft_left[nid] else right[nid]
                 if stypes[nid] == 1:  # categorical
                     yes, no = right[nid], left[nid]
                     splits.append(None)
-                    categories.append(node_cats.get(nid))
+                    node_cat_codes = node_cats.get(nid)
+                    cat_names = cat_names_by_feature.get(fname)
+                    if node_cat_codes is not None and cat_names is not None:
+                        resolved: List[str] = [
+                            cat_names[c] if 0 <= c < len(cat_names) else str(c)
+                            for c in node_cat_codes
+                        ]
+                        categories.append(resolved)
+                    else:
+                        categories.append(node_cat_codes)
                 elif ftypes.get(fidx, "q") == "i":  # indicator (boolean)
                     # No split threshold; missing follows the "no" (default) branch.
                     yes, no = (right[nid] if dft_left[nid] else left[nid]), dft_child

--- a/python-package/xgboost/testing/parse_tree.py
+++ b/python-package/xgboost/testing/parse_tree.py
@@ -47,6 +47,58 @@ def run_tree_to_df_categorical(tree_method: str, device: Device) -> None:
             assert x["Missing"] in all_ids
 
 
+def run_tree_to_df_use_category_names(tree_method: str, device: Device) -> None:
+    """Tests trees_to_dataframe's use_category_names option with genuine string
+    category names, not just numeric-looking codes.
+
+    """
+    import pandas as pd
+
+    rng = np.random.default_rng(1994)
+    n_samples = 256
+    colors = pd.Categorical.from_codes(
+        rng.integers(0, 4, size=n_samples), categories=["red", "green", "blue", "cyan"]
+    )
+    X = pd.DataFrame({"color": colors, "num": rng.standard_normal(n_samples)})
+    y = rng.standard_normal(n_samples)
+
+    Xy = DMatrix(X, y, enable_categorical=True)
+    booster = train(
+        {"tree_method": tree_method, "device": device}, Xy, num_boost_round=10
+    )
+
+    df_codes = booster.trees_to_dataframe()
+    df_names = booster.trees_to_dataframe(use_category_names=True)
+
+    # The two calls must agree on everything except the Category column itself.
+    for col in df_codes.columns:
+        if col == "Category":
+            continue
+        pd.testing.assert_series_equal(df_codes[col], df_names[col])
+
+    color_splits = df_codes["Feature"] == "color"
+    assert color_splits.any(), "test setup should produce at least one categorical split"
+
+    valid_names = set(colors.categories)
+    for (_, row_codes), (_, row_names) in zip(
+        df_codes[color_splits].iterrows(), df_names[color_splits].iterrows()
+    ):
+        codes = row_codes["Category"]
+        names = row_names["Category"]
+        assert isinstance(codes, list) and isinstance(names, list)
+        assert len(codes) == len(names)
+        # Every resolved name must be a real category name, not a raw code.
+        assert all(n in valid_names for n in names)
+        # And they must correspond position-for-position to the original codes.
+        assert names == [colors.categories[int(c)] for c in codes]
+
+    # Non-categorical (numerical) splits are untouched either way.
+    num_splits = df_codes["Feature"] == "num"
+    if num_splits.any():
+        assert df_codes.loc[num_splits, "Category"].isna().all()
+        assert df_names.loc[num_splits, "Category"].isna().all()
+
+
 def _expected_leaf_vectors(booster: Booster) -> dict[tuple[int, int], list[float]]:
     """Map ``(tree_id, node_id) -> list[float]`` of leaf outputs."""
     model = json.loads(booster.save_raw(raw_format="json"))

--- a/tests/python/test_parse_tree.py
+++ b/tests/python/test_parse_tree.py
@@ -5,6 +5,7 @@ from xgboost import testing as tm
 from xgboost.testing.parse_tree import (
     run_split_value_histograms,
     run_tree_to_df_categorical,
+    run_tree_to_df_use_category_names,
     run_tree_to_df_vector_leaf_mixed,
 )
 
@@ -67,6 +68,9 @@ class TestTreesToDataFrame:
 
     def test_tree_to_df_categorical(self) -> None:
         run_tree_to_df_categorical("approx", "cpu")
+
+    def test_tree_to_df_use_category_names(self) -> None:
+        run_tree_to_df_use_category_names("approx", "cpu")
 
     def test_tree_to_df_vector_leaf_mixed(self) -> None:
         run_tree_to_df_vector_leaf_mixed("cpu")


### PR DESCRIPTION
# Add use_category_names option to trees_to_dataframe

## Summary
`trees_to_dataframe()`'s `Category` column reports raw integer category codes
(e.g. `[3, 7, 12]`) for categorical splits, even when the model was trained on
a pandas categorical column with real string category names (e.g. `"red"`,
`"green"`, `"blue"`). The mapping from code to name is already recoverable
via `booster.get_categories()`, but users had to manually cross-reference it
themselves — this adds an opt-in option to do it for you.

## Commits
1. **Add `use_category_names` option to `trees_to_dataframe`** — new
   parameter, default `False` to avoid changing the existing `Category`
   column's dtype for any code that already expects integer codes. When
   enabled, resolves each category code to its original name using
   `get_categories(export_to_arrow=True)`, falling back to the string
   representation of the code for any out-of-bounds code (defensive; keeps
   the resulting list consistently `str`-typed).
2. **Add test coverage** — `make_categorical()` (the existing test-data
   helper) only produces numeric-looking category codes, so it can't
   exercise this meaningfully. Added a dedicated test helper with a
   hand-built DataFrame using real string categories (`red`/`green`/`blue`/
   `cyan`), verifying: the two calls (with/without the option) agree on
   every column except `Category`; resolved names are real category names
   that correspond position-for-position to the original codes; and
   non-categorical splits are unaffected either way.
3. **Document it in the categorical-data tutorial** — added right after the
   existing `get_categories(export_to_arrow=True)` example, since that's the
   natural place a reader learning about inspecting categorical data would
   look.

## Backward compatibility
When `use_category_names=False` (the default) or the booster has no
categorical features, the internal lookup dict stays empty and the
`Category` column is completely unchanged, byte-for-byte the same as before
this change.

## Verification

- Normal resolution: codes correctly map to names
- `use_category_names=False` / empty lookup: codes pass through unchanged
  (backward compatible)
- Non-categorical split (`None` codes): stays `None`
- Out-of-bounds code: falls back to `str(code)`, list stays consistently
  string-typed (this was actually caught by `mypy`, which correctly flagged
  a mixed `int`/`str` list in my first attempt)

`mypy` and `ruff` pass on all modified files.