### PR TITLE
Raise a clear error for multi-class gblinear models in plot_importance

### DIFF
--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -105,6 +105,15 @@ def plot_importance(
             + "This maybe caused by having all trees as decision dumps."
         )
 
+    if any(isinstance(v, list) for v in importance.values()):
+        raise ValueError(
+            "`plot_importance` doesn't support a per-class list of importance "
+            "values, which `Booster.get_score()` returns for a multi-class "
+            "`gblinear` model. Select a single class first, for instance by "
+            "passing `{k: v[i] for k, v in importance.items()}` for the i-th "
+            "class as the `booster` argument instead of the model directly."
+        )
+
     tuples = [(k, importance[k]) for k in importance]
     if max_num_features is not None:
         # pylint: disable=invalid-unary-operand-type


### PR DESCRIPTION
# Raise a clear error for multi-class gblinear models in plot_importance

## Summary
`Booster.get_score()` documents that for a multi-class `gblinear` model, the
score for each feature is a **list** with length `n_classes`, rather than a
scalar. `plot_importance()` didn't account for this: it sorts and bar-charts
the importance values assuming they're all scalars, crashing deep inside
matplotlib with:

```
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

when `values` ends up being a tuple of lists instead of floats.

## Why this is reachable
This is a real, reachable scenario, not a hypothetical: multi-class
`gblinear` is genuinely supported and documented, and calling
`plot_importance()` on a fitted model is an entirely ordinary usage
pattern. Nothing in `plot_importance()`'s own docstring mentions this
limitation.

## Repro (standalone, since I can't import `xgboost` in my sandbox)
```python
>>> importance = {"f0": [0.5, 0.3, 0.1], "f1": [0.2, 0.6, 0.4], "f2": [0.9, 0.1, 0.05]}
>>> tuples = sorted([(k, importance[k]) for k in importance], key=lambda x: x[1])
>>> labels, values = zip(*tuples)
>>> ax.barh(ylocs, values, align="center")  # <- crashes here
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

## Change
Detect the per-class list case up front and raise a clear, actionable
`ValueError` explaining the situation and suggesting how to select a single
class's importance to plot, instead of letting the user hit a cryptic
matplotlib `TypeError` several calls deep with no indication of the real
cause:

```diff
     if not importance:
         raise ValueError(
             "Booster.get_score() results in empty.  "
             + "This maybe caused by having all trees as decision dumps."
         )
 
+    if any(isinstance(v, list) for v in importance.values()):
+        raise ValueError(
+            "`plot_importance` doesn't support a per-class list of importance "
+            "values, which `Booster.get_score()` returns for a multi-class "
+            "`gblinear` model. Select a single class first, for instance by "
+            "passing `{k: v[i] for k, v in importance.items()}` for the i-th "
+            "class as the `booster` argument instead of the model directly."
+        )
+
     tuples = [(k, importance[k]) for k in importance]
```

## Verification

- Reproduced the crash by feeding a dict of list-valued importances through
  the actual sorting/zip/barh pipeline used in `plot_importance()`,
  confirming the `TypeError`
- Confirmed the new check correctly raises a clear `ValueError` for that
  same input
- Confirmed the check does not false-positive on the normal, scalar-valued
  case

`mypy` and `ruff` both pass on the modified file.