### PR TITLE
Add demo test for multioutput_reduced_gradient.py

### DIFF
--- a/tests/python/test_demos.py
+++ b/tests/python/test_demos.py
@@ -166,6 +166,15 @@ def test_multioutput_reg() -> None:
 
 
 @pytest.mark.skipif(**tm.no_sklearn())
+def test_multioutput_reduced_gradient_demo() -> None:
+    # Runs with the default `--device cpu`; `cupy` is only imported on the
+    # (unused here) `--device cuda` code paths.
+    script = os.path.join(PYTHON_DEMO_DIR, "multioutput_reduced_gradient.py")
+    cmd = [PYTHON, script]
+    subprocess.check_call(cmd)
+
+
+@pytest.mark.skipif(**tm.no_sklearn())
 def test_prediction_intervals() -> None:
     script = os.path.join(PYTHON_DEMO_DIR, "prediction_intervals.py")
     cmd = [PYTHON, script]


### PR DESCRIPTION
# Add demo test for multioutput_reduced_gradient.py

## Summary
`test_demos.py` runs most demo scripts as a real subprocess smoke test.
`multioutput_reduced_gradient.py` had no coverage. This is genuinely the
**only** thing exercising `xgboost.objective.TreeObjective` at all (grepped
`tests/python/*.py` for both the script name and `TreeObjective` directly —
zero hits either way), so this is the sole safety net for that experimental
feature, not just a routine smoke test.

## Change
```diff
+@pytest.mark.skipif(**tm.no_sklearn())
+def test_multioutput_reduced_gradient_demo() -> None:
+    # Runs with the default `--device cpu`; `cupy` is only imported on the
+    # (unused here) `--device cuda` code paths.
+    script = os.path.join(PYTHON_DEMO_DIR, "multioutput_reduced_gradient.py")
+    cmd = [PYTHON, script]
+    subprocess.check_call(cmd)
```

## Verification
- Runs with the script's default `--device cpu` (no args needed)
- Its three `import cupy` statements are all inside `else` branches gated on
  `self.device == "cpu"` checks — confirmed by reading each one's
  surrounding context directly — so none of them execute on this path, no
  cupy/GPU dependency for this test
- `no_sklearn()` skip marker matches every other sklearn-dependent test in
  this file (the script uses `sklearn.datasets.make_regression`,
  `sklearn.base.BaseEstimator`, and `sklearn.decomposition.TruncatedSVD`,
  all part of core scikit-learn, no extra dependency)

I also checked the other 8 demo scripts currently missing test coverage
(`cat_in_the_dat.py`, `cover_type.py`, `gamma_regression.py`,
`gpu_tree_shap.py`, `learning_to_rank.py`, `quantile_data_iterator.py`,
`spark_estimator_examples.py`, `update_process.py`) and confirmed each is
correctly excluded for a real reason (local-only data files, GPU/RAPIDS
dependencies, a large external ranking dataset, or pyspark) — not further
oversights, so this PR is scoped to just the one genuine gap.