### PR TITLE
Fix tutorial typos: objetive(s), followings

### DIFF
--- a/doc/tutorials/advanced_custom_obj.rst
+++ b/doc/tutorials/advanced_custom_obj.rst
@@ -55,7 +55,7 @@ A Dirichlet regression model poses certain challenges for XGBoost:
 - An optimal intercept for this type of model would involve a vector of
   values rather than the same value for every target.
 
-In order to use this type of model as a custom objetive:
+In order to use this type of model as a custom objective:
 
 - It's possible to use the expected Hessian (a.k.a. the Fisher information
   matrix or expected information) instead of the true Hessian. The expected

--- a/doc/tutorials/custom_metric_obj.rst
+++ b/doc/tutorials/custom_metric_obj.rst
@@ -24,7 +24,7 @@ concepts should be readily applicable to other language bindings.
    * Breaking change was made in XGBoost 1.6.
 
 See also the advanced usage example for more information about limitations and
-workarounds for more complex objetives: :doc:`/tutorials/advanced_custom_obj`
+workarounds for more complex objectives: :doc:`/tutorials/advanced_custom_obj`
 
 In the following two sections, we will provide a step by step walk through of implementing
 the ``Squared Log Error (SLE)`` objective function:

--- a/doc/tutorials/dask.rst
+++ b/doc/tutorials/dask.rst
@@ -634,7 +634,7 @@ Troubleshooting
     pip install nvidia-nccl-cu12 # (or with any compatible CUDA version)
 
   The default conda installation of XGBoost should not encounter this error. If you are
-  using a customized XGBoost, please make sure one of the followings is true:
+  using a customized XGBoost, please make sure one of the following is true:
 
   + XGBoost is NOT compiled with the `USE_DLOPEN_NCCL` flag.
   + The `dmlc_nccl_path` parameter is set to full NCCL path when initializing the collective.


### PR DESCRIPTION
Found with codespell against doc/tutorials/:
- advanced_custom_obj.rst: objetive -> objective
- custom_metric_obj.rst: objetives -> objectives
- dask.rst: followings -> following

Verified codespell no longer flags any of the three after the fix. Excluded two false positives from the same codespell run: 'Rabit' (XGBoost's actual internal library name, not a typo) and 'AKS' (Azure Kubernetes Service, a real product name) in kubernetes.rst.