### PR TITLE
Fix nine more doc typos found with codespell

### DIFF
--- a/doc/R-package/migration_guide.rst
+++ b/doc/R-package/migration_guide.rst
@@ -34,7 +34,7 @@ XGBoost's R language bindings had large breaking changes between versions 1.x an
 - Method ``predict``:
     - There are now two predict methods with different default arguments according to whether the model was produced through ``xgboost()`` or through ``xgb.train()``. Function ``xgboost()`` is more geared towards interactive usage, and thus the defaults for the 'predict' method on such objects (class "xgboost") by default will perform more data validations such as checking that column names match and reordering them otherwise. The 'predict' method for models created through ``xgb.train()`` (class "xgb.Booster") has the same defaults as before, so for example it will not reorder columns to match names under the default behavior.
     - The 'predict' method for objects of class "xgboost" (produced by ``xgboost()``, not by ``xgb.train()``) now can control the types of predictions to make through an argument ``type``, similarly as the 'predict' methods in the 'stats' module of base R - e.g. one can now do ``predict(model, type="class")``; while the 'predict' method for "xgb.Booster" objects (produced by ``xgb.train()``), just like before, controls those through separate arguments such as ``outputmargin``.
-    - Previously, predictions using a subset of the trees were using base-0 indexing and range syntax mimicing Python's ranges, whereas now they use base-1 indexing as is common in R, and their behavior for ranges matches that of R's ``seq`` function. Note that the syntax for "use all trees" and "use trees up to early-stopped criteria" have changed (see documentation for details).
+    - Previously, predictions using a subset of the trees were using base-0 indexing and range syntax mimicking Python's ranges, whereas now they use base-1 indexing as is common in R, and their behavior for ranges matches that of R's ``seq`` function. Note that the syntax for "use all trees" and "use trees up to early-stopped criteria" have changed (see documentation for details).
 
 - Booster objects:
     - The structure of these objects has been modified - now they are represented as a simple R "ALTLIST" (a special kind of 'list' object) with additional attributes.
@@ -42,13 +42,13 @@ XGBoost's R language bindings had large breaking changes between versions 1.x an
     - The objects distinguish between two types of attributes:
 
         - R-side attributes (which can be accessed and modified through R function ``attributes(model)`` and ``attributes(model)$field <- val``), which allow arbitrary objects. Many attributes are automatically added by the model building functions, such as evaluation logs (a ``data.table`` with metrics calculated per iteration), which previously were model fields.
-        - C-level attributes, which allow only JSON-compliant data and which can be accessed and set through function ``xgb.attributes(model)``. These C-level attributes are shareable through serialized models in different XGBoost interfaces, while the R-level ones are specific to the R interface. Some attributes that are standard among language bindings of XGBoost, such as the best interation, are kept as C attributes.
+        - C-level attributes, which allow only JSON-compliant data and which can be accessed and set through function ``xgb.attributes(model)``. These C-level attributes are shareable through serialized models in different XGBoost interfaces, while the R-level ones are specific to the R interface. Some attributes that are standard among language bindings of XGBoost, such as the best iteration, are kept as C attributes.
     - Previously, models that were just de-serialized from an on-disk format required calling method 'xgb.Booster.complete' on them to finish the full de-serialization process before being usable, or would otherwise call this method on their own automatically automatically at the first call to 'predict'. Serialization is now handled more gracefully, and there are no additional functions/methods involved - i.e. if one saves a model to disk with ``saveRDS()`` and then reads it back with ``readRDS()``, the model will be fully loaded straight away, without needing to call additional methods on it.
 
 Other recommendations
 ---------------------
 
-By default, XGBoost might recognize that some parameter has been removed or renamed from how it was in a previous version, and still accept the same function call as it used to do before with the renamed or removed arugments, but issuing a deprecation warning along the way that highlights the changes.
+By default, XGBoost might recognize that some parameter has been removed or renamed from how it was in a previous version, and still accept the same function call as it used to do before with the renamed or removed arguments, but issuing a deprecation warning along the way that highlights the changes.
 
 These behaviors will be removed in future versions, and function calls which currently return deprecation warnings will stop working in the future, so in order to make sure that code calling XGBoost will still keep working, it should be ensured that it doesn't issue deprecation warnings.
 
@@ -58,7 +58,7 @@ Optionally, these deprecation warnings can be turned into errors (while still ke
 
     options("xgboost.strict_mode" = TRUE)
 
-It can also be controlled through an environment variable `XGB_STRICT_MODE=1`, which takes precende over the R option - e.g.:
+It can also be controlled through an environment variable `XGB_STRICT_MODE=1`, which takes precedence over the R option - e.g.:
 
 .. code-block:: r
 

--- a/doc/contrib/ci.rst
+++ b/doc/contrib/ci.rst
@@ -291,7 +291,7 @@ Self-Hosted Runners with RunsOn
 self-hosted runners to use with GitHub Actions pipelines. RunsOn uses
 `Amazon Web Services (AWS) <https://aws.amazon.com/>`_ under the hood to provision runners with
 access to various amount of CPUs, memory, and NVIDIA GPUs. Thanks to this app, we are able to test
-GPU-accelerated and distributed algorithms of XGBoost while using the familar interface of
+GPU-accelerated and distributed algorithms of XGBoost while using the familiar interface of
 GitHub Actions.
 
 In GitHub Actions, jobs run on Microsoft-hosted runners by default.

--- a/doc/contrib/featuremap.rst
+++ b/doc/contrib/featuremap.rst
@@ -27,7 +27,7 @@ There's working-in-progress support for vector leaves, which are decision tree l
 ----------
 Inference
 ----------
-By inference, we specifically mean getting model prediction for the response variable. XGBoost supports two inference methods. The first one is the prediction on the ``DMatrix`` object (or ``QuantileDMatrix``, which is a subclass). Using a ``DMatrix`` object allows XGBoost to cache the prediction, hence getting faster performance when running prediction on the same data with new trees. The second method is ``inplace_predict``, which bypasses the construction of ``DMatrix``. It's more efficient but doesn't support cached prediction. In addtion to returning the estimated response, we also support returning the leaf index, which can be used to analyse the model and as a feature to another model.
+By inference, we specifically mean getting model prediction for the response variable. XGBoost supports two inference methods. The first one is the prediction on the ``DMatrix`` object (or ``QuantileDMatrix``, which is a subclass). Using a ``DMatrix`` object allows XGBoost to cache the prediction, hence getting faster performance when running prediction on the same data with new trees. The second method is ``inplace_predict``, which bypasses the construction of ``DMatrix``. It's more efficient but doesn't support cached prediction. In addition to returning the estimated response, we also support returning the leaf index, which can be used to analyse the model and as a feature to another model.
 
 ----------
 Model IO

--- a/doc/jvm/xgboost4j_spark_tutorial.rst
+++ b/doc/jvm/xgboost4j_spark_tutorial.rst
@@ -148,7 +148,7 @@ labels. A DataFrame like this (containing vector-represented features and numeri
 Dealing with missing values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-XGBoost supports missing values by default (`as desribed here <https://xgboost.readthedocs.io/en/latest/faq.html#how-to-deal-with-missing-values>`_).
+XGBoost supports missing values by default (`as described here <https://xgboost.readthedocs.io/en/latest/faq.html#how-to-deal-with-missing-values>`_).
 If given a SparseVector, XGBoost will treat any values absent from the SparseVector as missing. You are also able to
 specify to XGBoost to treat a specific value in your Dataset as if it was a missing value. By default XGBoost will treat NaN as the value representing missing.
 
@@ -443,7 +443,7 @@ After we get the PipelineModel, we can make prediction on the test dataset and e
   val evaluator = new MulticlassClassificationEvaluator()
   val accuracy = evaluator.evaluate(prediction)
 
-Pipeline with Hyper-parameter Tunning
+Pipeline with Hyper-parameter Tuning
 =====================================
 The most critical operation to maximize the power of XGBoost is to select the optimal parameters for the model.
 Tuning parameters manually is a tedious and labor-consuming process. With the latest version of XGBoost4J-Spark,

--- a/doc/python/sklearn_estimator.rst
+++ b/doc/python/sklearn_estimator.rst
@@ -67,7 +67,7 @@ stack of trees:
     clf = xgb.XGBClassifier(tree_method="hist", callbacks=[early_stop])
     clf.fit(X_train, y_train, eval_set=[(X_test, y_test)])
 
-At present, XGBoost doesn't implement data spliting logic within the estimator and relies
+At present, XGBoost doesn't implement data splitting logic within the estimator and relies
 on the ``eval_set`` parameter of the :py:meth:`xgboost.XGBModel.fit` method. If you want
 to use early stopping to prevent overfitting, you'll need to manually split your data into
 training and testing sets using the :py:func:`sklearn.model_selection.train_test_split`


### PR DESCRIPTION
- doc/contrib/ci.rst: familar -> familiar
- doc/contrib/featuremap.rst: addtion -> addition
- doc/jvm/xgboost4j_spark_tutorial.rst: desribed -> described, Tunning -> Tuning
- doc/R-package/migration_guide.rst: mimicing -> mimicking, arugments -> arguments, precende -> precedence, interation -> iteration
- doc/python/sklearn_estimator.rst: spliting -> splitting

Excluded four false positives from the same codespell sweep:
- 're-use' (doc/build.rst) -- correctly hyphenated, not a typo
- 'mape' (doc/parameter.rst) -- a real XGBoost metric name (mean absolute percentage error), not a typo
- 'coo' (doc/python/data_input.rst) -- scipy.sparse.coo, a real scipy sparse-matrix format name
- 'rabit'/'RABIT'/'AKS' (doc/Makefile, doc/changes/v2.1.0.rst, doc/contrib/featuremap.rst, doc/tutorials/kubernetes.rst) -- the real internal library name and Azure Kubernetes Service, respectively, both already correctly identified as false positives in an earlier PR this session

Verified codespell no longer flags any of the nine after the fix (only the known 'RABIT' false positive remains). Also specifically double-checked that changing 'Tunning' -> 'Tuning' in a section header didn't break its RST underline length requirement (the underline was already one character longer than the old header text, so it's still valid for the new, shorter text).