### PR TITLE
Add missing assertion to run_normalization's top-k section

### DIFF
--- a/python-package/xgboost/testing/ranking.py
+++ b/python-package/xgboost/testing/ranking.py
@@ -133,6 +133,14 @@ def run_normalization(device: str) -> None:
     )
     ltr.fit(X, y, qid=qid, eval_set=[(X, y)], eval_qid=[qid])
     e1 = ltr.evals_result()
+    # For the (default) top-k pair method, normalization scales gradients by
+    # log2(1 + sum_lambda) / sum_lambda, which is strictly less than 1 whenever
+    # sum_lambda > 0 (see src/objective/lambdarank_obj.cc). Unlike the `mean`
+    # pair method with a single pair per sample (checked below, where
+    # normalization is a no-op and the two results are expected to match), this
+    # does change the effective gradient scale, so the two training runs are
+    # expected to diverge.
+    assert e1["validation_0"]["ndcg"][-1] != e0["validation_0"]["ndcg"][-1]
 
     # mean
     ltr = xgb.XGBRanker(


### PR DESCRIPTION
run_normalization() trains two models (lambdarank_normalization=True vs False) for three scenarios: top-k (default pair method), mean without a pair-count override, and mean with lambdarank_num_pair_per_sample=4. The latter two both have assertions comparing their NDCG results, but the first (top-k) section computed e0/e1 via two real fit() calls and then never asserted anything -- both variables were silently overwritten by the next section's e0/e1 before ever being read, discarding the training work entirely.

Traced src/objective/lambdarank_obj.cc to determine the correct expected relationship rather than guessing: for the top-k pair method, normalization scales gradients by log2(1 + sum_lambda) / sum_lambda, which is strictly less than 1 whenever sum_lambda > 0. Given the dataset used here (tm.make_ltr(2048, 4, 64, 3), real varied relevance labels across 64 query groups), sum_lambda is essentially certain to be positive, so normalization genuinely changes the effective gradient scale for this pair method -- unlike the 'mean, single pair per sample' case right below it (where normalization is documented in an existing comment to be a no-op), the two top-k training runs are expected to produce different NDCG results, not the same one.

Added the missing assertion (!=), matching the style and reasoning already used for the second 'mean' comparison in this same function (which also asserts !=), with a comment explaining the derivation.
