### PR TITLE
Move prediction cache into GBTree

### DIFF
--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -29,7 +29,6 @@ class CatContainer;
 
 struct Context;
 struct LearnerModelParam;
-struct PredictionCacheEntry;
 
 /*!
  * \brief interface of gradient boosting model.
@@ -79,8 +78,8 @@ class GradientBooster : public Model, public Configurable {
    *                   the booster may change content of gpair
    * @param obj The objective function used for boosting.
    */
-  virtual void DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair,
-                       PredictionCacheEntry* prediction, ObjFunction const* obj) = 0;
+  virtual void DoBoost(std::shared_ptr<DMatrix> p_fmat, GradientContainer* in_gpair,
+                       ObjFunction const* obj) = 0;
 
   /**
    * \brief Generate predictions for given feature matrix
@@ -92,8 +91,8 @@ class GradientBooster : public Model, public Configurable {
    * \param begin    Beginning of boosted tree layer used for prediction.
    * \param end      End of booster layer. 0 means do not limit trees.
    */
-  virtual void PredictBatch(DMatrix* dmat, PredictionCacheEntry* out_preds, bool training,
-                            bst_layer_t begin, bst_layer_t end) = 0;
+  virtual void PredictBatch(std::shared_ptr<DMatrix> dmat, HostDeviceVector<float>* out_preds,
+                            bool training, bst_layer_t begin, bst_layer_t end) = 0;
 
   /**
    * \brief Inplace prediction.
@@ -104,8 +103,8 @@ class GradientBooster : public Model, public Configurable {
    * \param           begin     (Optional) Beginning of boosted tree layer used for prediction.
    * \param           end       (Optional) End of booster layer. 0 means do not limit trees.
    */
-  virtual void InplacePredict(std::shared_ptr<DMatrix>, float, PredictionCacheEntry*, bst_layer_t,
-                              bst_layer_t) const {
+  virtual void InplacePredict(std::shared_ptr<DMatrix>, float, HostDeviceVector<float>*,
+                              bst_layer_t, bst_layer_t) const {
     LOG(FATAL) << "Inplace predict is not supported by the current booster.";
   }
   /*!

--- a/include/xgboost/predictor.h
+++ b/include/xgboost/predictor.h
@@ -7,9 +7,7 @@
 #pragma once
 #include <dmlc/registry.h>    // for FunctionRegEntryBase
 #include <xgboost/base.h>     // for bst_tree_t
-#include <xgboost/cache.h>    // for DMatrixCache
 #include <xgboost/context.h>  // for Context
-#include <xgboost/context.h>
 #include <xgboost/data.h>
 #include <xgboost/host_device_vector.h>
 #include <xgboost/linalg.h>
@@ -27,43 +25,6 @@ struct GBTreeModel;
 
 namespace xgboost {
 class RegTree;
-/**
- * \brief Contains pointer to input matrix and associated cached predictions.
- */
-struct PredictionCacheEntry {
-  // A storage for caching prediction values
-  HostDeviceVector<float> predictions;
-  // The version of current cache, corresponding number of layers of trees
-  std::uint32_t version{0};
-
-  PredictionCacheEntry() = default;
-  /**
-   * \brief Update the cache entry by number of versions.
-   *
-   * \param v Added versions.
-   */
-  void Update(std::uint32_t v) { version += v; }
-  void Reset() { version = 0; }
-};
-
-/**
- * \brief A container for managed prediction caches.
- */
-class PredictionContainer : public DMatrixCache<PredictionCacheEntry> {
-  // We cache up to 64 DMatrix for all threads
-  std::size_t static constexpr DefaultSize() { return 64; }
-
- public:
-  PredictionContainer() : DMatrixCache<PredictionCacheEntry>{DefaultSize()} {}
-  std::shared_ptr<PredictionCacheEntry> Cache(std::shared_ptr<DMatrix> m, DeviceOrd device) {
-    auto p_cache = this->CacheItem(m);
-    if (!device.IsCPU()) {
-      p_cache->predictions.SetDevice(device);
-    }
-    return p_cache;
-  }
-};
-
 /**
  * \class Predictor
  *
@@ -109,7 +70,7 @@ class Predictor {
    * \param           tree_end    The tree end index.
    * \param           tree_weights_override Optional weights for temporary prediction overrides.
    */
-  virtual void PredictBatch(DMatrix* dmat, PredictionCacheEntry* out_preds,
+  virtual void PredictBatch(DMatrix* dmat, HostDeviceVector<float>* out_preds,
                             gbm::GBTreeModel const& model, bst_tree_t tree_begin,
                             bst_tree_t tree_end = 0,
                             std::vector<float> const* tree_weights_override = nullptr) const = 0;
@@ -128,7 +89,7 @@ class Predictor {
    * \return True if the data can be handled by current predictor, false otherwise.
    */
   virtual bool InplacePredict(std::shared_ptr<DMatrix> p_fmat, const gbm::GBTreeModel& model,
-                              float missing, PredictionCacheEntry* out_preds,
+                              float missing, HostDeviceVector<float>* out_preds,
                               bst_tree_t tree_begin = 0, bst_tree_t tree_end = 0) const = 0;
 
   /**

--- a/plugin/sycl/predictor/predictor.cc
+++ b/plugin/sycl/predictor/predictor.cc
@@ -172,17 +172,16 @@ class Predictor : public xgboost::Predictor {
       : xgboost::Predictor::Predictor{context},
         cpu_predictor(xgboost::Predictor::Create("cpu_predictor", context)) {}
 
-  void PredictBatch(DMatrix* dmat, PredictionCacheEntry* predts, const gbm::GBTreeModel& model,
-                    bst_tree_t tree_begin, bst_tree_t tree_end = 0,
+  void PredictBatch(DMatrix* dmat, HostDeviceVector<float>* out_preds,
+                    const gbm::GBTreeModel& model, bst_tree_t tree_begin, bst_tree_t tree_end = 0,
                     std::vector<float> const* tree_weights_override = nullptr) const override {
     if (tree_weights_override != nullptr || model.TreeWeights() != nullptr) {
       LOG(WARNING) << "Weighted batch prediction is not yet implemented for SYCL. CPU Predictor "
                       "is used.";
-      return cpu_predictor->PredictBatch(dmat, predts, model, tree_begin, tree_end,
+      return cpu_predictor->PredictBatch(dmat, out_preds, model, tree_begin, tree_end,
                                          tree_weights_override);
     }
 
-    auto* out_preds = &predts->predictions;
     device_model.SetDevice(ctx_->Device());
     qu_ = device_manager.GetQueue(ctx_->Device());
     if (device_ != ctx_->Device()) {
@@ -206,7 +205,7 @@ class Predictor : public xgboost::Predictor {
   }
 
   bool InplacePredict(std::shared_ptr<DMatrix> p_m, const gbm::GBTreeModel& model, float missing,
-                      PredictionCacheEntry* out_preds, bst_tree_t tree_begin,
+                      HostDeviceVector<float>* out_preds, bst_tree_t tree_begin,
                       bst_tree_t tree_end) const override {
     LOG(WARNING) << "InplacePredict is not yet implemented for SYCL. CPU Predictor is used.";
     return cpu_predictor->InplacePredict(p_m, model, missing, out_preds, tree_begin, tree_end);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -45,7 +45,6 @@
 #include "xgboost/json.h"                // for Json, get, Integer, IsA, Boolean, String
 #include "xgboost/learner.h"             // for Learner, PredictionType
 #include "xgboost/logging.h"             // for LOG_FATAL, LogMessageFatal, CHECK, LogCheck_EQ
-#include "xgboost/predictor.h"           // for PredictionCacheEntry
 #include "xgboost/span.h"                // for Span
 #include "xgboost/string_view.h"         // for StringView, operator<<
 #include "xgboost/version_config.h"      // for XGBOOST_VER_MAJOR, XGBOOST_VER_MINOR, XGBOOS...
@@ -1273,18 +1272,18 @@ XGB_DLL int XGBoosterPredict(BoosterHandle handle, DMatrixHandle dmat, int optio
   API_BEGIN();
   CHECK_HANDLE();
   auto *learner = static_cast<Learner *>(handle);
-  auto &entry = learner->GetThreadLocal().prediction_entry;
+  auto &predictions = learner->GetThreadLocal().predictions;
   auto iteration_end = GetIterationFromTreeLimit(ntree_limit, learner);
   learner->Predict(*static_cast<std::shared_ptr<DMatrix> *>(dmat), (option_mask & 1) != 0,
-                   &entry.predictions, 0, iteration_end, static_cast<bool>(training),
+                   &predictions, 0, iteration_end, static_cast<bool>(training),
                    (option_mask & 2) != 0, (option_mask & 4) != 0, (option_mask & 8) != 0,
                    (option_mask & 16) != 0, false);
 
   xgboost_CHECK_C_ARG_PTR(len);
   xgboost_CHECK_C_ARG_PTR(out_result);
 
-  *out_result = dmlc::BeginPtr(entry.predictions.ConstHostVector());
-  *len = static_cast<xgboost::bst_ulong>(entry.predictions.Size());
+  *out_result = dmlc::BeginPtr(predictions.ConstHostVector());
+  *len = static_cast<xgboost::bst_ulong>(predictions.Size());
   API_END();
 }
 
@@ -1303,7 +1302,7 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle, DMatrixHandle dmat
   auto config = Json::Load(StringView{c_json_config});
 
   auto *learner = static_cast<Learner *>(handle);
-  auto &entry = learner->GetThreadLocal().prediction_entry;
+  auto &predictions = learner->GetThreadLocal().predictions;
   auto p_m = *static_cast<std::shared_ptr<DMatrix> *>(dmat);
 
   auto type = PredictionType(RequiredArg<Integer>(config, "type", __func__));
@@ -1328,15 +1327,15 @@ XGB_DLL int XGBoosterPredictFromDMatrix(BoosterHandle handle, DMatrixHandle dmat
       type == PredictionType::kInteraction || type == PredictionType::kApproxInteraction;
   bool training = RequiredArg<Boolean>(config, "training", __func__);
   bool strict_shape = RequiredArg<Boolean>(config, "strict_shape", __func__);
-  learner->Predict(p_m, type == PredictionType::kMargin, &entry.predictions, iteration_begin,
+  learner->Predict(p_m, type == PredictionType::kMargin, &predictions, iteration_begin,
                    iteration_end, training, type == PredictionType::kLeaf, contribs, approximate,
                    interactions, strict_shape);
 
   xgboost_CHECK_C_ARG_PTR(out_result);
-  *out_result = dmlc::BeginPtr(entry.predictions.ConstHostVector());
+  *out_result = dmlc::BeginPtr(predictions.ConstHostVector());
 
   auto &shape = learner->GetThreadLocal().prediction_shape;
-  auto chunksize = p_m->Info().num_row_ == 0 ? 0 : entry.predictions.Size() / p_m->Info().num_row_;
+  auto chunksize = p_m->Info().num_row_ == 0 ? 0 : predictions.Size() / p_m->Info().num_row_;
   auto n_rounds = iteration_end - iteration_begin;
   n_rounds = n_rounds == 0 ? learner->BoostedRounds() : n_rounds;
 

--- a/src/common/api_entry.h
+++ b/src/common/api_entry.h
@@ -3,11 +3,11 @@
  */
 #ifndef XGBOOST_COMMON_API_ENTRY_H_
 #define XGBOOST_COMMON_API_ENTRY_H_
-#include <string>               // std::string
-#include <vector>               // std::vector
+#include <string>  // std::string
+#include <vector>  // std::vector
 
-#include "xgboost/base.h"       // GradientPair,bst_ulong
-#include "xgboost/predictor.h"  // PredictionCacheEntry
+#include "xgboost/base.h"                // GradientPair,bst_ulong
+#include "xgboost/host_device_vector.h"  // HostDeviceVector
 
 namespace xgboost {
 /**
@@ -29,7 +29,7 @@ struct XGBAPIThreadLocalEntry {
   /*! \brief temp variable of gradient pairs. */
   std::vector<GradientPair> tmp_gpair;
   /*! \brief Temp variable for returning prediction result. */
-  PredictionCacheEntry prediction_entry;
+  HostDeviceVector<float> predictions;
   /*! \brief Temp variable for returning prediction shape. */
   std::vector<bst_ulong> prediction_shape;
 };

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -118,7 +118,7 @@ class GBLinear : public GradientBooster {
     this->updater_->SaveConfig(&j_updater);
   }
 
-  void DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCacheEntry*,
+  void DoBoost(std::shared_ptr<DMatrix> p_fmat, GradientContainer* in_gpair,
                ObjFunction const*) override {
     if (in_gpair->HasValueGrad()) {
       LOG(FATAL)
@@ -129,21 +129,20 @@ class GBLinear : public GradientBooster {
 
     CHECK(!p_fmat->Info().HasCategorical()) << error::NoCategorical("`gblinear`");
     model_.LazyInitModel();
-    this->LazySumWeights(p_fmat);
+    this->LazySumWeights(p_fmat.get());
 
     if (!this->CheckConvergence()) {
-      updater_->Update(in_gpair->Grad(), p_fmat, &model_, sum_instance_weight_);
+      updater_->Update(in_gpair->Grad(), p_fmat.get(), &model_, sum_instance_weight_);
     }
     model_.num_boosted_rounds++;
     monitor_.Stop("DoBoost");
   }
 
-  void PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* predts, bool /*training*/,
-                    bst_layer_t layer_begin, bst_layer_t) override {
+  void PredictBatch(std::shared_ptr<DMatrix> p_fmat, HostDeviceVector<float>* out_preds,
+                    bool /*training*/, bst_layer_t layer_begin, bst_layer_t) override {
     monitor_.Start("PredictBatch");
     LinearCheckLayer(layer_begin);
-    auto* out_preds = &predts->predictions;
-    this->PredictBatchInternal(p_fmat, &out_preds->HostVector());
+    this->PredictBatchInternal(p_fmat.get(), &out_preds->HostVector());
     monitor_.Stop("PredictBatch");
   }
 

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -201,8 +201,9 @@ void GPUDartPredictInc(common::Span<float>, common::Span<float>, float, size_t, 
 }
 #endif
 
-void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCacheEntry* predt,
+void GBTree::DoBoost(std::shared_ptr<DMatrix> p_fmat, GradientContainer* in_gpair,
                      ObjFunction const*) {
+  auto predt = prediction_cache_.Cache(p_fmat, ctx_->Device());
   if (model_.learner_model_param->IsVectorLeaf()) {
     CHECK(tparam_.tree_method == TreeMethod::kHist || tparam_.tree_method == TreeMethod::kAuto)
         << "Only the hist tree method is supported for building multi-target trees with vector "
@@ -231,7 +232,7 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
   }
 
   predt->predictions.SetDevice(ctx_->Device());
-  auto const& predictor = this->GetPredictor(false, &predt->predictions, p_fmat);
+  auto const& predictor = this->GetPredictor(false, &predt->predictions, p_fmat.get());
   if (predt->predictions.Size() == 0 && p_fmat->Info().num_row_ != 0) {
     CHECK_EQ(predt->version, 0);
     predictor->InitOutPredictions(p_fmat->Info(), &predt->predictions, model_);
@@ -243,9 +244,9 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
   // The node position for each row, 1 HDV for each tree in the forest.  Note that the
   // position is negated if the row is sampled out.
   std::vector<HostDeviceVector<bst_node_t>> node_position;
-  auto update_prediction_cache = [&](std::vector<HostDeviceVector<bst_node_t>>& positions,
-                                     TreesOneGroup const& trees,
-                                     linalg::MatrixView<float> out_preds) {
+  auto predict_from_node_positions = [&](std::vector<HostDeviceVector<bst_node_t>>& positions,
+                                         TreesOneGroup const& trees,
+                                         linalg::MatrixView<float> out_preds) {
     CHECK_EQ(positions.size(), trees.size());
     for (auto& position : positions) {
       if (out_preds.Shape(0) != 0 && position.Size() != out_preds.Shape(0)) {
@@ -262,19 +263,11 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
     return true;
   };
 
-  if (model_.learner_model_param->IsVectorLeaf()) {
-    // Multi-target, vector leaf
+  if (model_.learner_model_param->IsVectorLeaf() ||
+      model_.learner_model_param->OutputLength() == 1u) {
     TreesOneGroup ret;
-    BoostNewTrees(in_gpair, p_fmat, 0, &node_position, &ret);
-    if (update_prediction_cache(node_position, ret, out)) {
-      predt->Update(1);
-    }
-    new_trees.push_back(std::move(ret));
-  } else if (model_.learner_model_param->OutputLength() == 1u) {
-    // Single target
-    TreesOneGroup ret;
-    BoostNewTrees(in_gpair, p_fmat, 0, &node_position, &ret);
-    if (update_prediction_cache(node_position, ret, out)) {
+    BoostNewTrees(in_gpair, p_fmat.get(), 0, &node_position, &ret);
+    if (predict_from_node_positions(node_position, ret, out)) {
       predt->Update(1);
     }
     new_trees.push_back(std::move(ret));
@@ -290,9 +283,9 @@ void GBTree::DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCac
       node_position.clear();
       CopyGradient(ctx_, &in_gpair->gpair, gid, &tmp.gpair);
       TreesOneGroup ret;
-      BoostNewTrees(&tmp, p_fmat, gid, &node_position, &ret);
+      BoostNewTrees(&tmp, p_fmat.get(), gid, &node_position, &ret);
       auto v_predt = out.Slice(linalg::All(), linalg::Range(gid, gid + 1));
-      cache_updated = update_prediction_cache(node_position, ret, v_predt) && cache_updated;
+      cache_updated = predict_from_node_positions(node_position, ret, v_predt) && cache_updated;
       new_trees.push_back(std::move(ret));
     }
     if (cache_updated) {
@@ -655,11 +648,17 @@ void GBTree::Slice(bst_layer_t begin, bst_layer_t end, bst_layer_t step, Gradien
   }
 }
 
-void GBTree::PredictBatchImpl(DMatrix* p_fmat, PredictionCacheEntry* out_preds, bool is_training,
-                              bst_layer_t layer_begin, bst_layer_t layer_end,
-                              std::vector<float> const* tree_weights_override) const {
+void GBTree::PredictBatch(std::shared_ptr<DMatrix> p_fmat, HostDeviceVector<float>* out_preds,
+                          bool is_training, bst_layer_t layer_begin, bst_layer_t layer_end) {
+  auto cache = prediction_cache_.Cache(p_fmat, ctx_->Device());
+  auto const* tree_weights_override = static_cast<std::vector<float> const*>(nullptr);
+  auto dropped_weights = this->DropTrees(is_training);
+  if (!dropped_weights.empty()) {
+    tree_weights_override = &dropped_weights;
+  }
+
   // Unweighted prediction can reuse a cached prefix of the model output by tracking how many
-  // boosting iterations have already been accumulated in `out_preds->version`.
+  // boosting iterations have already been accumulated in `cache->version`.
   //
   // Weighted prediction is used by DART and does not participate in this cache, since tree
   // weights can change the accumulated output independently of the cached unweighted prefix.
@@ -667,12 +666,12 @@ void GBTree::PredictBatchImpl(DMatrix* p_fmat, PredictionCacheEntry* out_preds, 
     layer_end = this->BoostedRounds();
   }
 
-  auto cache_version = out_preds->version;
+  auto cache_version = cache->version;
   // We can preserve the cache only when:
   // - prediction is unweighted
   // - prediction starts from iteration 0, so the result is a cacheable prefix
-  auto preserve_cache =
-      tree_weights_override == nullptr && model_.TreeWeights() == nullptr && layer_begin == 0;
+  auto preserve_cache = tree_weights_override == nullptr && model_.TreeWeights() == nullptr &&
+                        p_fmat->Info().base_margin_.Empty() && layer_begin == 0;
   // We can reuse the existing cached prefix only when:
   // - the result itself is cacheable
   // - the requested range does not move backwards past the cached version
@@ -684,57 +683,54 @@ void GBTree::PredictBatchImpl(DMatrix* p_fmat, PredictionCacheEntry* out_preds, 
   auto prediction_begin = reuse_cache ? cache_version : layer_begin;
 
   if (!reuse_cache) {
-    out_preds->version = 0;
+    cache->version = 0;
     cache_version = 0;
   }
 
-  if (out_preds->predictions.Size() == 0 && p_fmat->Info().num_row_ != 0) {
-    CHECK_EQ(out_preds->version, 0);
+  if (cache->predictions.Size() == 0 && p_fmat->Info().num_row_ != 0) {
+    CHECK_EQ(cache->version, 0);
   }
 
-  auto const& predictor = GetPredictor(is_training, &out_preds->predictions, p_fmat);
+  auto const& predictor = GetPredictor(is_training, &cache->predictions, p_fmat.get());
   if (initialize_output) {
-    // out_preds->Size() can be non-zero as it's initialized here before any
+    // cache->Size() can be non-zero as it's initialized here before any
     // tree is built at the 0^th iterator.
-    predictor->InitOutPredictions(p_fmat->Info(), &out_preds->predictions, model_);
+    predictor->InitOutPredictions(p_fmat->Info(), &cache->predictions, model_);
   }
 
   auto [tree_begin, tree_end] = detail::LayerToTree(model_, prediction_begin, layer_end);
   CHECK_LE(tree_end, model_.trees.size()) << "Invalid number of trees.";
   if (tree_end > tree_begin) {
-    predictor->PredictBatch(p_fmat, out_preds, model_, tree_begin, tree_end, tree_weights_override);
+    predictor->PredictBatch(p_fmat.get(), &cache->predictions, model_, tree_begin, tree_end,
+                            tree_weights_override);
   }
 
   if (!preserve_cache) {
-    out_preds->version = 0;
+    cache->version = 0;
   } else {
-    out_preds->Update(layer_end - cache_version);
+    cache->Update(layer_end - cache_version);
   }
-}
 
-void GBTree::PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* out_preds, bool is_training,
-                          bst_layer_t layer_begin, bst_layer_t layer_end) {
-  auto const* tree_weights_override = static_cast<std::vector<float> const*>(nullptr);
-  auto dropped_weights = this->DropTrees(is_training);
-  if (!dropped_weights.empty()) {
-    tree_weights_override = &dropped_weights;
-  }
-  this->PredictBatchImpl(p_fmat, out_preds, is_training, layer_begin, layer_end,
-                         tree_weights_override);
+  out_preds->SetDevice(ctx_->Device());
+  out_preds->Resize(cache->predictions.Size());
+  out_preds->Copy(cache->predictions);
 }
 
 void GBTree::InplacePredict(std::shared_ptr<DMatrix> p_m, float missing,
-                            PredictionCacheEntry* out_preds, bst_layer_t layer_begin,
+                            HostDeviceVector<float>* out_preds, bst_layer_t layer_begin,
                             bst_layer_t layer_end) const {
   auto [tree_begin, tree_end] = detail::LayerToTree(model_, layer_begin, layer_end);
   CHECK_LE(tree_end, model_.trees.size()) << "Invalid number of trees.";
   if (p_m->Ctx()->Device() != this->ctx_->Device()) {
     error::MismatchedDevices(this->ctx_, p_m->Ctx());
-    CHECK_EQ(out_preds->version, 0);
     auto proxy = std::dynamic_pointer_cast<data::DMatrixProxy>(p_m);
     CHECK(proxy) << error::InplacePredictProxy();
     auto p_fmat = data::CreateDMatrixFromProxy(ctx_, proxy, missing);
-    this->PredictBatchImpl(p_fmat.get(), out_preds, false, layer_begin, layer_end, nullptr);
+    auto const& predictor = GetPredictor(false, out_preds, p_fmat.get());
+    predictor->InitOutPredictions(p_fmat->Info(), out_preds, model_);
+    if (tree_end > tree_begin) {
+      predictor->PredictBatch(p_fmat.get(), out_preds, model_, tree_begin, tree_end);
+    }
     return;
   }
 

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -22,6 +22,7 @@
 #include "../tree/tree_view.h"  // for WalkTree
 #include "gbtree_model.h"
 #include "xgboost/base.h"
+#include "xgboost/cache.h"
 #include "xgboost/data.h"
 #include "xgboost/gbm.h"
 #include "xgboost/host_device_vector.h"
@@ -172,6 +173,36 @@ bool SliceTrees(bst_layer_t begin, bst_layer_t end, bst_layer_t step, GBTreeMode
 }  // namespace detail
 
 // gradient boosted trees
+/**
+ * \brief Cached predictions owned by GBTree.
+ */
+struct PredictionCacheEntry {
+  HostDeviceVector<float> predictions;
+  std::uint32_t version{0};
+
+  PredictionCacheEntry() = default;
+
+  void Update(std::uint32_t v) { version += v; }
+  void Reset() { version = 0; }
+};
+
+/**
+ * \brief A container for GBTree prediction caches.
+ */
+class PredictionContainer : public DMatrixCache<PredictionCacheEntry> {
+  std::size_t static constexpr DefaultSize() { return 64; }
+
+ public:
+  PredictionContainer() : DMatrixCache<PredictionCacheEntry>{DefaultSize()} {}
+  std::shared_ptr<PredictionCacheEntry> Cache(std::shared_ptr<DMatrix> m, DeviceOrd device) {
+    auto p_cache = this->CacheItem(m);
+    if (!device.IsCPU()) {
+      p_cache->predictions.SetDevice(device);
+    }
+    return p_cache;
+  }
+};
+
 class GBTree : public GradientBooster {
  public:
   explicit GBTree(LearnerModelParam const* booster_config, Context const* ctx)
@@ -183,7 +214,7 @@ class GBTree : public GradientBooster {
   /**
    * @brief Carry out one iteration of boosting.
    */
-  void DoBoost(DMatrix* p_fmat, GradientContainer* in_gpair, PredictionCacheEntry* predt,
+  void DoBoost(std::shared_ptr<DMatrix> p_fmat, GradientContainer* in_gpair,
                ObjFunction const* obj) override;
 
   [[nodiscard]] GBTreeTrainParam const& GetTrainParam() const { return tparam_; }
@@ -203,15 +234,18 @@ class GBTree : public GradientBooster {
     return !model_.trees.empty() || !model_.trees_to_update.empty();
   }
 
-  void PredictBatchImpl(DMatrix* p_fmat, PredictionCacheEntry* out_preds, bool is_training,
-                        bst_layer_t layer_begin, bst_layer_t layer_end,
-                        std::vector<float> const* tree_weights_override = nullptr) const;
+  // Test-only accessor. The cache entry is thread-local and must have been initialized by
+  // PredictBatch or DoBoost on this thread.
+  [[nodiscard]] PredictionCacheEntry const& PredictionCache(DMatrix const* p_fmat) const {
+    return *prediction_cache_.Entry(p_fmat);
+  }
 
-  void PredictBatch(DMatrix* p_fmat, PredictionCacheEntry* out_preds, bool training,
-                    bst_layer_t layer_begin, bst_layer_t layer_end) override;
+  void PredictBatch(std::shared_ptr<DMatrix> p_fmat, HostDeviceVector<float>* out_preds,
+                    bool training, bst_layer_t layer_begin, bst_layer_t layer_end) override;
 
-  void InplacePredict(std::shared_ptr<DMatrix> p_m, float missing, PredictionCacheEntry* out_preds,
-                      bst_layer_t layer_begin, bst_layer_t layer_end) const override;
+  void InplacePredict(std::shared_ptr<DMatrix> p_m, float missing,
+                      HostDeviceVector<float>* out_preds, bst_layer_t layer_begin,
+                      bst_layer_t layer_end) const override;
 
   void FeatureScore(std::string const& importance_type, common::Span<int32_t const> trees,
                     std::vector<bst_feature_t>* features,
@@ -365,6 +399,7 @@ class GBTree : public GradientBooster {
 #endif  // defined(XGBOOST_USE_SYCL)
   // indexes of dropped trees
   std::vector<size_t> idx_drop_;
+  mutable PredictionContainer prediction_cache_;
   common::Monitor monitor_;
 };
 

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -40,7 +40,6 @@
 #include "common/observer.h"              // for TrainingObserver
 #include "common/param_array.h"           // for ParamArray
 #include "common/timer.h"                 // for Monitor
-#include "common/type.h"                  // for GetValueT
 #include "common/version.h"               // for Version
 #include "xgboost/base.h"                 // for Args, GradientPair, bst_feature_t
 #include "xgboost/context.h"              // for Context
@@ -54,7 +53,6 @@
 #include "xgboost/metric.h"               // for Metric
 #include "xgboost/objective.h"            // for ObjFunction
 #include "xgboost/parameter.h"            // for DECLARE_FIELD_ENUM_CLASS, XGBoostParameter
-#include "xgboost/predictor.h"            // for PredictionContainer, PredictionCacheEntry
 #include "xgboost/string_view.h"          // for operator<<, StringView
 #include "xgboost/task.h"                 // for ObjInfo
 
@@ -352,7 +350,7 @@ std::string CanonicalizeBoosterName(std::string booster) {
  * @brief Handler for the `n_targets` property and the intercept.
  */
 class Intercept : public Learner {
-  using CacheT = common::GetValueT<decltype(std::declval<PredictionContainer>().Container())>;
+  using CacheT = std::vector<std::weak_ptr<DMatrix>>;
 
  protected:
   /**
@@ -409,11 +407,15 @@ class Intercept : public Learner {
   void GetNumTargets(CacheT const& cache) {
     CHECK(this->obj_);
     bst_target_t n_targets = 1;
-    for (auto const& d : cache) {
+    for (auto const& weak : cache) {
+      auto d = weak.lock();
+      if (!d) {
+        continue;
+      }
       if (n_targets == 1) {
-        n_targets = this->obj_->Targets(d.first.ptr->Info());
+        n_targets = this->obj_->Targets(d->Info());
       } else {
-        auto t = this->obj_->Targets(d.first.ptr->Info());
+        auto t = this->obj_->Targets(d->Info());
         CHECK(n_targets == t || 1 == t) << "Inconsistent labels.";
       }
     }
@@ -502,7 +504,7 @@ class LearnerConfiguration : public Intercept {
   common::Monitor monitor_;
   LearnerTrainParam tparam_;
   // Initial prediction.
-  PredictionContainer prediction_container_;
+  std::vector<std::weak_ptr<DMatrix>> cache_data_;
 
   std::vector<std::string> metric_names_;
 
@@ -512,7 +514,7 @@ class LearnerConfiguration : public Intercept {
     monitor_.Init("Learner");
     for (std::shared_ptr<DMatrix> const& d : cache) {
       if (d) {
-        prediction_container_.Cache(d, DeviceOrd::CPU());
+        cache_data_.emplace_back(d);
       }
     }
   }
@@ -554,7 +556,7 @@ class LearnerConfiguration : public Intercept {
     learner_model_param_.task = obj_->Task();  // required by gbm configuration.
     this->ConfigureGBM(old_tparam, args);
 
-    this->InitModelUserParam(this->tparam_, this->prediction_container_.Container());
+    this->InitModelUserParam(this->tparam_, this->cache_data_);
 
     this->ConfigureMetrics(args);
 
@@ -800,12 +802,16 @@ class LearnerConfiguration : public Intercept {
     if (mparam_.num_feature == 0) {
       // TODO(hcho3): Change num_feature to 64-bit integer
       unsigned num_feature = 0;
-      for (auto const& matrix : prediction_container_.Container()) {
-        CHECK(matrix.first.ptr);
-        CHECK(!matrix.second.ref.expired());
-        const uint64_t num_col = matrix.first.ptr->Info().num_col_;
+      for (auto it = cache_data_.begin(); it != cache_data_.end();) {
+        auto matrix = it->lock();
+        if (!matrix) {
+          it = cache_data_.erase(it);
+          continue;
+        }
+        const uint64_t num_col = matrix->Info().num_col_;
         error::MaxFeatureSize(num_col);
         num_feature = std::max(num_feature, static_cast<uint32_t>(num_col));
+        ++it;
       }
 
       auto rc =
@@ -890,7 +896,7 @@ std::string const LearnerConfiguration::kEvalMetric{"eval_metric"};  // NOLINT
 
 class LearnerIO : public LearnerConfiguration {
  protected:
-  void ClearCaches() { this->prediction_container_ = PredictionContainer{}; }
+  void ClearCaches() { this->cache_data_.clear(); }
 
  public:
   explicit LearnerIO(std::vector<std::shared_ptr<DMatrix>> cache) : LearnerConfiguration{cache} {}
@@ -1101,7 +1107,7 @@ class LearnerImpl : public LearnerIO {
     this->Load(&fs);
 
     // Learner self cache. Prediction is cleared in the load method
-    CHECK(this->prediction_container_.Container().empty());
+    CHECK(this->cache_data_.empty());
     this->gpair_ = decltype(this->gpair_){};
   }
 
@@ -1117,19 +1123,19 @@ class LearnerImpl : public LearnerIO {
 
     this->ValidateDMatrix(train.get(), true);
 
-    auto predt = prediction_container_.Cache(train, ctx_.Device());
+    HostDeviceVector<float> predt;
 
     monitor_.Start("PredictRaw");
-    this->PredictRaw(train.get(), predt.get(), true, 0, 0);
-    TrainingObserver::Instance().Observe(predt->predictions, "Predictions");
+    this->PredictRaw(train, &predt, true, 0, 0);
+    TrainingObserver::Instance().Observe(predt, "Predictions");
     monitor_.Stop("PredictRaw");
 
     monitor_.Start("GetGradient");
-    GetGradient(predt->predictions, train->Info(), iter, &gpair_.gpair);
+    GetGradient(predt, train->Info(), iter, &gpair_.gpair);
     monitor_.Stop("GetGradient");
     TrainingObserver::Instance().Observe(gpair_.Grad()->Data(), "Gradients");
 
-    gbm_->DoBoost(train.get(), &gpair_, predt.get(), obj_.get());
+    gbm_->DoBoost(train, &gpair_, obj_.get());
     monitor_.Stop("UpdateOneIter");
   }
 
@@ -1151,8 +1157,7 @@ class LearnerImpl : public LearnerIO {
           << "The number of columns in gradient should be equal to the number of "
              "targets/classes in the model.";
     }
-    auto predt = prediction_container_.Cache(train, ctx_.Device());
-    this->gbm_->DoBoost(train.get(), in_gpair, predt.get(), obj_.get());
+    this->gbm_->DoBoost(train, in_gpair, obj_.get());
     this->monitor_.Stop(__func__);
   }
 
@@ -1176,13 +1181,9 @@ class LearnerImpl : public LearnerIO {
 
     for (size_t i = 0; i < data_sets.size(); ++i) {
       std::shared_ptr<DMatrix> m = data_sets[i];
-      auto predt = prediction_container_.Cache(m, ctx_.Device());
       this->ValidateDMatrix(m.get(), false);
-      this->PredictRaw(m.get(), predt.get(), false, 0, 0);
-
-      auto& out = output_predictions_.Cache(m, ctx_.Device())->predictions;
-      out.Resize(predt->predictions.Size());
-      out.Copy(predt->predictions);
+      HostDeviceVector<float> out;
+      this->PredictRaw(m, &out, false, 0, 0);
 
       obj_->EvalTransform(&out);
       for (auto& ev : metrics_) {
@@ -1218,12 +1219,7 @@ class LearnerImpl : public LearnerIO {
       this->ValidateDMatrix(data.get(), false);
       gbm_->PredictLeaf(data.get(), out_preds, layer_begin, layer_end, strict_shape);
     } else {
-      auto predt = prediction_container_.Cache(data, ctx_.Device());
-      this->PredictRaw(data.get(), predt.get(), training, layer_begin, layer_end);
-      // Copy the prediction cache to output prediction. out_preds comes from C API
-      out_preds->SetDevice(ctx_.Device());
-      out_preds->Resize(predt->predictions.Size());
-      out_preds->Copy(predt->predictions);
+      this->PredictRaw(data, out_preds, training, layer_begin, layer_end);
       if (!output_margin) {
         obj_->PredTransform(out_preds);
       }
@@ -1254,19 +1250,19 @@ class LearnerImpl : public LearnerIO {
     this->Configure();
     this->CheckModelInitialized();
 
-    auto& out_predictions = this->GetThreadLocal().prediction_entry;
-    out_predictions.Reset();
+    auto& out_predictions = this->GetThreadLocal().predictions;
+    out_predictions.Resize(0);
 
     this->gbm_->InplacePredict(p_m, missing, &out_predictions, iteration_begin, iteration_end);
 
     if (type == PredictionType::kValue) {
-      obj_->PredTransform(&out_predictions.predictions);
+      obj_->PredTransform(&out_predictions);
     } else if (type == PredictionType::kMargin) {
       // do nothing
     } else {
       LOG(FATAL) << "Unsupported prediction type:" << static_cast<int>(type);
     }
-    *out_preds = &out_predictions.predictions;
+    *out_preds = &out_predictions;
   }
 
   void CalcFeatureScore(std::string const& importance_type, common::Span<int32_t const> trees,
@@ -1290,11 +1286,11 @@ class LearnerImpl : public LearnerIO {
    *   predictor, when it equals 0, this means we are using all the trees
    * \param training allow dropout when the DART booster is being used
    */
-  void PredictRaw(DMatrix* data, PredictionCacheEntry* out_preds, bool training,
+  void PredictRaw(std::shared_ptr<DMatrix> data, HostDeviceVector<float>* out_preds, bool training,
                   unsigned layer_begin, unsigned layer_end) const {
     CHECK(gbm_ != nullptr) << "Predict must happen after Load or configuration";
     this->CheckModelInitialized();
-    this->ValidateDMatrix(data, false);
+    this->ValidateDMatrix(data.get(), false);
     gbm_->PredictBatch(data, out_preds, training, layer_begin, layer_end);
   }
 
@@ -1331,9 +1327,6 @@ class LearnerImpl : public LearnerIO {
   static int32_t constexpr kRandSeedMagic = 127;
   // gradient pairs
   GradientContainer gpair_;
-  /*! \brief Temporary storage to prediction.  Useful for storing data transformed by
-   *  objective function */
-  PredictionContainer output_predictions_;
 };
 
 constexpr int32_t LearnerImpl::kRandSeedMagic;

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -37,7 +37,7 @@
 #include "xgboost/linalg.h"                   // for TensorView, All, VectorView, Tensor
 #include "xgboost/logging.h"                  // for LogCheck_EQ, CHECK_EQ, CHECK, LogCheck_NE
 #include "xgboost/multi_target_tree_model.h"  // for MultiTargetTree
-#include "xgboost/predictor.h"                // for PredictionCacheEntry, Predictor, PredictorReg
+#include "xgboost/predictor.h"                // for Predictor, PredictorReg
 #include "xgboost/span.h"                     // for Span
 #include "xgboost/tree_model.h"               // for RegTree, MTNotImplemented, RTreeNodeStat
 
@@ -456,10 +456,9 @@ class CPUPredictor : public Predictor {
  public:
   explicit CPUPredictor(Context const *ctx) : Predictor::Predictor{ctx} {}
 
-  void PredictBatch(DMatrix *dmat, PredictionCacheEntry *predts, gbm::GBTreeModel const &model,
-                    bst_tree_t tree_begin, bst_tree_t tree_end = 0,
+  void PredictBatch(DMatrix *dmat, HostDeviceVector<float> *out_preds,
+                    gbm::GBTreeModel const &model, bst_tree_t tree_begin, bst_tree_t tree_end = 0,
                     std::vector<float> const *tree_weights_override = nullptr) const override {
-    auto *out_preds = &predts->predictions;
     // This is actually already handled in gbm, but large amount of tests rely on the
     // behaviour.
     if (tree_end == 0) {
@@ -475,7 +474,7 @@ class CPUPredictor : public Predictor {
   }
 
   [[nodiscard]] bool InplacePredict(std::shared_ptr<DMatrix> p_m, gbm::GBTreeModel const &model,
-                                    float missing, PredictionCacheEntry *out_preds,
+                                    float missing, HostDeviceVector<float> *out_preds,
                                     bst_tree_t tree_begin, bst_tree_t tree_end) const override {
     auto proxy = dynamic_cast<data::DMatrixProxy *>(p_m.get());
     CHECK(proxy) << error::InplacePredictProxy();
@@ -483,8 +482,8 @@ class CPUPredictor : public Predictor {
       tree_end = model.trees.size();
     }
 
-    this->InitOutPredictions(p_m->Info(), &(out_preds->predictions), model);
-    auto &predictions = out_preds->predictions.HostVector();
+    this->InitOutPredictions(p_m->Info(), out_preds, model);
+    auto &predictions = out_preds->HostVector();
     bool any_missing = true;
 
     auto const n_threads = this->ctx_->Threads();

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -444,12 +444,11 @@ class GPUPredictor : public xgboost::Predictor {
     }
   }
 
-  void PredictBatch(DMatrix* dmat, PredictionCacheEntry* predts, const gbm::GBTreeModel& model,
-                    bst_tree_t tree_begin, bst_tree_t tree_end = 0,
+  void PredictBatch(DMatrix* dmat, HostDeviceVector<float>* out_preds,
+                    const gbm::GBTreeModel& model, bst_tree_t tree_begin, bst_tree_t tree_end = 0,
                     std::vector<float> const* tree_weights_override = nullptr) const override {
     xgboost_NVTX_FN_RANGE();
     CHECK(ctx_->Device().IsCUDA()) << "Set `device' to `cuda` for processing GPU data.";
-    auto* out_preds = &predts->predictions;
     if (tree_end == 0) {
       tree_end = model.trees.size();
     }
@@ -469,13 +468,13 @@ class GPUPredictor : public xgboost::Predictor {
   template <typename Adapter>
   void DispatchedInplacePredict(std::shared_ptr<Adapter> m, std::shared_ptr<DMatrix> p_m,
                                 const gbm::GBTreeModel& model, float missing,
-                                PredictionCacheEntry* out_preds, bst_tree_t tree_begin,
+                                HostDeviceVector<float>* out_preds, bst_tree_t tree_begin,
                                 bst_tree_t tree_end, common::OptionalWeights tree_weights) const {
     CHECK_EQ(dh::CurrentDevice(), m->Device().ordinal)
         << "XGBoost is running on device: " << this->ctx_->Device().Name() << ", "
         << "but data is on: " << m->Device().Name();
-    this->InitOutPredictions(p_m->Info(), &(out_preds->predictions), model);
-    out_preds->predictions.SetDevice(m->Device());
+    this->InitOutPredictions(p_m->Info(), out_preds, model);
+    out_preds->SetDevice(m->Device());
     using BatchT = common::GetValueT<decltype(std::declval<Adapter>().Value())>;
 
     auto n_features = model.learner_model_param->num_feature;
@@ -492,7 +491,7 @@ class GPUPredictor : public xgboost::Predictor {
               typename common::GetValueT<decltype(cfg)>::template LoaderType<LoaderImpl, 128>;
           cfg.template AllocShmem<Loader>();
           cfg.template LaunchPredictKernel<Loader>(m->Value(), missing, n_features, d_model, acc, 0,
-                                                   &out_preds->predictions, tree_weights);
+                                                   out_preds, tree_weights);
         });
         return;
       }
@@ -506,12 +505,12 @@ class GPUPredictor : public xgboost::Predictor {
           typename common::GetValueT<decltype(cfg)>::template LoaderType<LoaderImpl, 128>;
       cfg.template AllocShmem<Loader>();
       cfg.template LaunchPredictKernel<Loader>(m->Value(), missing, n_features, d_model, acc, 0,
-                                               &out_preds->predictions, tree_weights);
+                                               out_preds, tree_weights);
     });
   }
 
   [[nodiscard]] bool InplacePredict(std::shared_ptr<DMatrix> p_m, gbm::GBTreeModel const& model,
-                                    float missing, PredictionCacheEntry* out_preds,
+                                    float missing, HostDeviceVector<float>* out_preds,
                                     bst_tree_t tree_begin, bst_tree_t tree_end) const override {
     xgboost_NVTX_FN_RANGE();
     auto proxy = dynamic_cast<data::DMatrixProxy*>(p_m.get());

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -67,35 +67,64 @@ TEST(GBTree, PredictionCache) {
 
   GradientContainer gpair = GenerateRandomGradients(&ctx, kRows, 1);
 
-  PredictionCacheEntry out_predictions;
-  gbtree.DoBoost(p_m.get(), &gpair, &out_predictions, nullptr);
+  HostDeviceVector<float> out_predictions;
+  gbtree.DoBoost(p_m, &gpair, nullptr);
 
-  gbtree.PredictBatch(p_m.get(), &out_predictions, false, 0, 0);
-  ASSERT_EQ(1, out_predictions.version);
-  std::vector<float> first_iter = out_predictions.predictions.HostVector();
+  gbtree.PredictBatch(p_m, &out_predictions, false, 0, 0);
+  ASSERT_EQ(1, gbtree.PredictionCache(p_m.get()).version);
+  std::vector<float> first_iter = out_predictions.HostVector();
   // Add 1 more boosted round
-  gbtree.DoBoost(p_m.get(), &gpair, &out_predictions, nullptr);
-  gbtree.PredictBatch(p_m.get(), &out_predictions, false, 0, 0);
-  ASSERT_EQ(2, out_predictions.version);
+  gbtree.DoBoost(p_m, &gpair, nullptr);
+  gbtree.PredictBatch(p_m, &out_predictions, false, 0, 0);
+  ASSERT_EQ(2, gbtree.PredictionCache(p_m.get()).version);
   // Update the cache for all rounds
-  out_predictions.version = 0;
-  gbtree.PredictBatch(p_m.get(), &out_predictions, false, 0, 0);
-  ASSERT_EQ(2, out_predictions.version);
+  gbtree.PredictBatch(p_m, &out_predictions, false, 1, 2);
+  ASSERT_EQ(0, gbtree.PredictionCache(p_m.get()).version);
+  gbtree.PredictBatch(p_m, &out_predictions, false, 0, 0);
+  ASSERT_EQ(2, gbtree.PredictionCache(p_m.get()).version);
 
-  gbtree.DoBoost(p_m.get(), &gpair, &out_predictions, nullptr);
+  gbtree.DoBoost(p_m, &gpair, nullptr);
   // drop the cache.
-  gbtree.PredictBatch(p_m.get(), &out_predictions, false, 1, 2);
-  ASSERT_EQ(0, out_predictions.version);
+  gbtree.PredictBatch(p_m, &out_predictions, false, 1, 2);
+  ASSERT_EQ(0, gbtree.PredictionCache(p_m.get()).version);
   // half open set [1, 3)
-  gbtree.PredictBatch(p_m.get(), &out_predictions, false, 1, 3);
-  ASSERT_EQ(0, out_predictions.version);
+  gbtree.PredictBatch(p_m, &out_predictions, false, 1, 3);
+  ASSERT_EQ(0, gbtree.PredictionCache(p_m.get()).version);
   // iteration end
-  gbtree.PredictBatch(p_m.get(), &out_predictions, false, 0, 2);
-  ASSERT_EQ(2, out_predictions.version);
+  gbtree.PredictBatch(p_m, &out_predictions, false, 0, 2);
+  ASSERT_EQ(2, gbtree.PredictionCache(p_m.get()).version);
   // restart the cache when end iteration is smaller than cache version
-  gbtree.PredictBatch(p_m.get(), &out_predictions, false, 0, 1);
-  ASSERT_EQ(1, out_predictions.version);
-  ASSERT_EQ(out_predictions.predictions.HostVector(), first_iter);
+  gbtree.PredictBatch(p_m, &out_predictions, false, 0, 1);
+  ASSERT_EQ(1, gbtree.PredictionCache(p_m.get()).version);
+  ASSERT_EQ(out_predictions.HostVector(), first_iter);
+}
+
+TEST(GBTree, PredictionCacheWithBaseMargin) {
+  size_t constexpr kRows = 16, kCols = 4;
+  Context ctx;
+  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+
+  std::unique_ptr<GradientBooster> p_gbm{GradientBooster::Create("gbtree", &ctx, &mparam)};
+  auto& gbtree = dynamic_cast<gbm::GBTree&>(*p_gbm);
+
+  gbtree.Configure({{"tree_method", "hist"}});
+  auto p_m = RandomDataGenerator{kRows, kCols, 0}.GenerateDMatrix();
+
+  HostDeviceVector<float> out_predictions;
+  p_m->Info().base_margin_.Reshape(kRows, 1);
+  p_m->Info().base_margin_.Data()->HostVector().assign(kRows, 1.0f);
+  gbtree.PredictBatch(p_m, &out_predictions, false, 0, 0);
+  auto first = out_predictions.HostVector();
+  ASSERT_EQ(0, gbtree.PredictionCache(p_m.get()).version);
+
+  p_m->Info().base_margin_.Data()->HostVector().assign(kRows, 2.0f);
+  gbtree.PredictBatch(p_m, &out_predictions, false, 0, 0);
+  auto second = out_predictions.HostVector();
+  ASSERT_EQ(0, gbtree.PredictionCache(p_m.get()).version);
+
+  for (size_t i = 0; i < kRows; ++i) {
+    ASSERT_NEAR(second[i] - first[i], 1.0f, kRtEps);
+  }
 }
 
 TEST(GBTree, WrongUpdater) {

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -654,7 +654,6 @@ std::unique_ptr<GradientBooster> CreateTrainedGBM(std::string name, Args kwargs,
                                                   size_t kCols,
                                                   LearnerModelParam const* learner_model_param,
                                                   Context const* ctx) {
-  auto caches = std::make_shared<PredictionContainer>();
   std::unique_ptr<GradientBooster> gbm{GradientBooster::Create(name, ctx, learner_model_param)};
   gbm->Configure(kwargs);
   auto p_dmat = RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
@@ -672,9 +671,7 @@ std::unique_ptr<GradientBooster> CreateTrainedGBM(std::string name, Args kwargs,
     h_gpair(i) = GradientPair{static_cast<float>(i), 1};
   }
 
-  PredictionCacheEntry predts;
-
-  gbm->DoBoost(p_dmat.get(), &gpair, &predts, nullptr);
+  gbm->DoBoost(p_dmat, &gpair, nullptr);
 
   return gbm;
 }

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -189,20 +189,18 @@ void TestTrainingPredictionCache(bool use_subsampling) {
     std::apply(h_gpair, linalg::UnravelIndex(i, kRows, kClasses)) = {static_cast<float>(i), 1};
   }
 
-  PredictionCacheEntry predtion_cache;
-  predtion_cache.predictions.Resize(kRows * kClasses, 0);
-  // after one training iteration predtion_cache is filled with cached in QuantileHistMaker
-  // prediction values
-  gbm->DoBoost(dmat.get(), &gpair, &predtion_cache, nullptr);
+  // After one training iteration, GBTree's prediction cache contains cached predictions.
+  gbm->DoBoost(dmat, &gpair, nullptr);
+  auto const& prediction_cache = gbm->PredictionCache(dmat.get());
 
-  PredictionCacheEntry out_predictions;
+  HostDeviceVector<float> out_predictions;
   // perform prediction from scratch on the same input data, should be equal to cached result
-  gbm->PredictBatch(dmat.get(), &out_predictions, false, 0, 0);
+  gbm->PredictBatch(dmat, &out_predictions, false, 0, 0);
 
-  std::vector<float>& out_predictions_h = out_predictions.predictions.HostVector();
-  std::vector<float>& predtion_cache_from_train = predtion_cache.predictions.HostVector();
+  std::vector<float>& out_predictions_h = out_predictions.HostVector();
+  auto const& prediction_cache_from_train = prediction_cache.predictions.ConstHostVector();
   for (size_t i = 0; i < out_predictions_h.size(); ++i) {
-    ASSERT_NEAR(out_predictions_h[i], predtion_cache_from_train[i], kRtEps);
+    ASSERT_NEAR(out_predictions_h[i], prediction_cache_from_train[i], kRtEps);
   }
 }
 }  // namespace

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -43,18 +43,18 @@ TEST(GPUPredictor, Basic) {
     auto const& model = *p_model;
 
     // Test predict batch
-    PredictionCacheEntry gpu_out_predictions;
-    PredictionCacheEntry cpu_out_predictions;
+    HostDeviceVector<float> gpu_out_predictions;
+    HostDeviceVector<float> cpu_out_predictions;
 
-    gpu_predictor->InitOutPredictions(dmat->Info(), &gpu_out_predictions.predictions, model);
+    gpu_predictor->InitOutPredictions(dmat->Info(), &gpu_out_predictions, model);
     gpu_predictor->PredictBatch(dmat.get(), &gpu_out_predictions, model, 0);
-    cpu_predictor->InitOutPredictions(dmat->Info(), &cpu_out_predictions.predictions, model);
+    cpu_predictor->InitOutPredictions(dmat->Info(), &cpu_out_predictions, model);
     cpu_predictor->PredictBatch(dmat.get(), &cpu_out_predictions, model, 0);
 
-    std::vector<float>& gpu_out_predictions_h = gpu_out_predictions.predictions.HostVector();
-    std::vector<float>& cpu_out_predictions_h = cpu_out_predictions.predictions.HostVector();
+    std::vector<float>& gpu_out_predictions_h = gpu_out_predictions.HostVector();
+    std::vector<float>& cpu_out_predictions_h = cpu_out_predictions.HostVector();
     float abs_tolerance = 0.001;
-    for (size_t j = 0; j < gpu_out_predictions.predictions.Size(); j++) {
+    for (size_t j = 0; j < gpu_out_predictions.Size(); j++) {
       ASSERT_NEAR(gpu_out_predictions_h[j], cpu_out_predictions_h[j], abs_tolerance);
     }
   }
@@ -115,11 +115,11 @@ void TestDecisionStumpExternalMemory(Context const* ctx, bst_feature_t n_feature
 
   for (auto p_fmat : {create_fn(400), create_fn(800), create_fn(2048)}) {
     p_fmat->Info().base_margin_ = linalg::Constant(ctx, 0.5f, p_fmat->Info().num_row_, n_classes);
-    PredictionCacheEntry out_predictions;
-    gpu_predictor->InitOutPredictions(p_fmat->Info(), &out_predictions.predictions, model);
+    HostDeviceVector<float> out_predictions;
+    gpu_predictor->InitOutPredictions(p_fmat->Info(), &out_predictions, model);
     gpu_predictor->PredictBatch(p_fmat.get(), &out_predictions, model, 0);
-    ASSERT_EQ(out_predictions.predictions.Size(), p_fmat->Info().num_row_ * n_classes);
-    auto const& h_predt = out_predictions.predictions.ConstHostVector();
+    ASSERT_EQ(out_predictions.Size(), p_fmat->Info().num_row_ * n_classes);
+    auto const& h_predt = out_predictions.ConstHostVector();
     for (size_t i = 0; i < h_predt.size() / n_classes; i++) {
       ASSERT_EQ(h_predt[i * n_classes], 2.0);
       ASSERT_EQ(h_predt[i * n_classes + 1], 0.5);

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -8,7 +8,7 @@
 #include <xgboost/data.h>                // for DMatrix, BatchIterator, BatchSet, MetaInfo
 #include <xgboost/host_device_vector.h>  // for HostDeviceVector
 #include <xgboost/json.h>                // for Json
-#include <xgboost/predictor.h>           // for PredictionCacheEntry, Predictor, Predic...
+#include <xgboost/predictor.h>           // for Predictor
 #include <xgboost/string_view.h>         // for StringView
 
 #include <limits>         // for numeric_limits
@@ -20,6 +20,7 @@
 #include "../../../src/common/bitfield.h"         // for LBitField32
 #include "../../../src/data/iterative_dmatrix.h"  // for IterativeDMatrix
 #include "../../../src/data/proxy_dmatrix.h"      // for DMatrixProxy
+#include "../../../src/gbm/gbtree.h"              // for PredictionContainer
 #include "../../../src/tree/tree_view.h"          // for MultiTargetTreeView
 #include "../collective/test_worker.h"            // for TestDistributedGlobal
 #include "../helpers.h"                           // for GetDMatrixFromData, RandomDataGenerator
@@ -41,12 +42,12 @@ void TestBasic(DMatrix *dmat, Context const *ctx) {
   auto const &model = *p_model;
 
   // Test predict batch
-  PredictionCacheEntry out_predictions;
-  predictor->InitOutPredictions(dmat->Info(), &out_predictions.predictions, model);
+  HostDeviceVector<float> out_predictions;
+  predictor->InitOutPredictions(dmat->Info(), &out_predictions, model);
   predictor->PredictBatch(dmat, &out_predictions, model, 0);
 
-  std::vector<float> &out_predictions_h = out_predictions.predictions.HostVector();
-  for (size_t i = 0; i < out_predictions.predictions.Size(); i++) {
+  std::vector<float> &out_predictions_h = out_predictions.HostVector();
+  for (size_t i = 0; i < out_predictions.Size(); i++) {
     ASSERT_EQ(out_predictions_h[i], 1.5);
   }
 
@@ -66,13 +67,12 @@ void TestBasic(DMatrix *dmat, Context const *ctx) {
     h_leaf_ids[i] = static_cast<bst_node_t>(h_leaf_out_predictions[i]);
   }
   std::vector<RegTree const *> trees{model.trees.front().get()};
-  PredictionCacheEntry from_leaf_ids;
-  predictor->InitOutPredictions(dmat->Info(), &from_leaf_ids.predictions, model);
-  auto from_leaf_view =
-      linalg::MakeTensorView(ctx, &from_leaf_ids.predictions, dmat->Info().num_row_,
-                             model.learner_model_param->OutputLength());
+  HostDeviceVector<float> from_leaf_ids;
+  predictor->InitOutPredictions(dmat->Info(), &from_leaf_ids, model);
+  auto from_leaf_view = linalg::MakeTensorView(ctx, &from_leaf_ids, dmat->Info().num_row_,
+                                               model.learner_model_param->OutputLength());
   predictor->PredictFromLeafIds(common::Span{leaf_ids}, common::Span{trees}, from_leaf_view);
-  auto const &h_from_leaf_ids = from_leaf_ids.predictions.ConstHostVector();
+  auto const &h_from_leaf_ids = from_leaf_ids.ConstHostVector();
   ASSERT_EQ(h_from_leaf_ids.size(), out_predictions_h.size());
   for (std::size_t i = 0; i < h_from_leaf_ids.size(); ++i) {
     ASSERT_EQ(h_from_leaf_ids[i], out_predictions_h[i]);
@@ -102,20 +102,20 @@ void TestBatchPredictionWithWeights(Context const *ctx) {
   }
   model->weight_drop = {0.5f, 2.0f};
 
-  PredictionCacheEntry weighted_predictions;
-  predictor->InitOutPredictions(dmat->Info(), &weighted_predictions.predictions, *model);
+  HostDeviceVector<float> weighted_predictions;
+  predictor->InitOutPredictions(dmat->Info(), &weighted_predictions, *model);
   predictor->PredictBatch(dmat.get(), &weighted_predictions, *model, 0, 0);
 
-  auto const &h_predt = weighted_predictions.predictions.ConstHostVector();
+  auto const &h_predt = weighted_predictions.ConstHostVector();
   for (auto v : h_predt) {
     ASSERT_EQ(v, 4.75f);
   }
 
-  PredictionCacheEntry ranged_predictions;
-  predictor->InitOutPredictions(dmat->Info(), &ranged_predictions.predictions, *model);
+  HostDeviceVector<float> ranged_predictions;
+  predictor->InitOutPredictions(dmat->Info(), &ranged_predictions, *model);
   predictor->PredictBatch(dmat.get(), &ranged_predictions, *model, 1, 2);
 
-  auto const &h_ranged = ranged_predictions.predictions.ConstHostVector();
+  auto const &h_ranged = ranged_predictions.ConstHostVector();
   for (auto v : h_ranged) {
     ASSERT_EQ(v, 4.0f);
   }
@@ -158,18 +158,18 @@ void TestInplacePredictionWithWeights(Context const *ctx) {
     dynamic_cast<data::DMatrixProxy *>(proxy.get())->SetArray(array_str.c_str());
   }
 
-  PredictionCacheEntry weighted_predictions;
+  HostDeviceVector<float> weighted_predictions;
   predictor->InplacePredict(proxy, *model, std::numeric_limits<float>::quiet_NaN(),
                             &weighted_predictions, 0, 0);
-  auto const &h_predt = weighted_predictions.predictions.ConstHostVector();
+  auto const &h_predt = weighted_predictions.ConstHostVector();
   for (auto v : h_predt) {
     ASSERT_EQ(v, 4.75f);
   }
 
-  PredictionCacheEntry ranged_predictions;
+  HostDeviceVector<float> ranged_predictions;
   predictor->InplacePredict(proxy, *model, std::numeric_limits<float>::quiet_NaN(),
                             &ranged_predictions, 1, 2);
-  auto const &h_ranged = ranged_predictions.predictions.ConstHostVector();
+  auto const &h_ranged = ranged_predictions.ConstHostVector();
   for (auto v : h_ranged) {
     ASSERT_EQ(v, 4.0f);
   }
@@ -178,7 +178,7 @@ void TestInplacePredictionWithWeights(Context const *ctx) {
 TEST(Predictor, PredictionCache) {
   size_t constexpr kRows = 16, kCols = 4;
 
-  PredictionContainer container;
+  gbm::PredictionContainer container;
   DMatrix *m;
   // Add a cache that is immediately expired.
   auto add_cache = [&]() {
@@ -373,7 +373,7 @@ void TestPredictionDeviceAccess() {
 
 void GBTreeModelForTest(gbm::GBTreeModel *model, uint32_t split_ind, bst_cat_t split_cat,
                         float left_weight, float right_weight) {
-  PredictionCacheEntry out_predictions;
+  HostDeviceVector<float> out_predictions;
 
   std::vector<std::unique_ptr<RegTree>> trees;
   trees.push_back(std::unique_ptr<RegTree>(new RegTree));
@@ -394,7 +394,7 @@ void TestCategoricalPrediction(bool use_gpu) {
     ctx = MakeCUDACtx(curt::AllVisibleGPUs() == 1 ? 0 : collective::GetRank());
   }
   size_t constexpr kCols = 10;
-  PredictionCacheEntry out_predictions;
+  HostDeviceVector<float> out_predictions;
 
   LearnerModelParam mparam{MakeMP(kCols, .5, 1, ctx.Device())};
   uint32_t split_ind = 3;
@@ -414,24 +414,24 @@ void TestCategoricalPrediction(bool use_gpu) {
   std::vector<FeatureType> types(10, FeatureType::kCategorical);
   m->Info().feature_types.HostVector() = types;
 
-  predictor->InitOutPredictions(m->Info(), &out_predictions.predictions, model);
+  predictor->InitOutPredictions(m->Info(), &out_predictions, model);
   predictor->PredictBatch(m.get(), &out_predictions, model, 0);
   auto score = mparam.BaseScore(DeviceOrd::CPU())(0);
-  ASSERT_EQ(out_predictions.predictions.Size(), 1ul);
-  ASSERT_EQ(out_predictions.predictions.HostVector()[0],
+  ASSERT_EQ(out_predictions.Size(), 1ul);
+  ASSERT_EQ(out_predictions.HostVector()[0],
             right_weight + score);  // go to right for matching cat
 
   row[split_ind] = split_cat + 1;
   m = GetDMatrixFromData(row, 1, kCols);
-  out_predictions.version = 0;
-  predictor->InitOutPredictions(m->Info(), &out_predictions.predictions, model);
+
+  predictor->InitOutPredictions(m->Info(), &out_predictions, model);
   predictor->PredictBatch(m.get(), &out_predictions, model, 0);
-  ASSERT_EQ(out_predictions.predictions.HostVector()[0], left_weight + score);
+  ASSERT_EQ(out_predictions.HostVector()[0], left_weight + score);
 }
 
 void TestCategoricalPredictLeaf(Context const *ctx) {
   size_t constexpr kCols = 10;
-  PredictionCacheEntry out_predictions;
+  HostDeviceVector<float> out_predictions;
 
   LearnerModelParam mparam{MakeMP(kCols, .5, 1, ctx->Device())};
 
@@ -449,17 +449,17 @@ void TestCategoricalPredictLeaf(Context const *ctx) {
   row[split_ind] = split_cat;
   auto m = GetDMatrixFromData(row, 1, kCols);
 
-  predictor->PredictLeaf(m.get(), &out_predictions.predictions, model);
-  CHECK_EQ(out_predictions.predictions.Size(), 1);
+  predictor->PredictLeaf(m.get(), &out_predictions, model);
+  CHECK_EQ(out_predictions.Size(), 1);
   // go to left if it doesn't match the category, otherwise right.
-  ASSERT_EQ(out_predictions.predictions.HostVector()[0], 2);
+  ASSERT_EQ(out_predictions.HostVector()[0], 2);
 
   row[split_ind] = split_cat + 1;
   m = GetDMatrixFromData(row, 1, kCols);
-  out_predictions.version = 0;
-  predictor->InitOutPredictions(m->Info(), &out_predictions.predictions, model);
-  predictor->PredictLeaf(m.get(), &out_predictions.predictions, model);
-  ASSERT_EQ(out_predictions.predictions.HostVector()[0], 1);
+
+  predictor->InitOutPredictions(m->Info(), &out_predictions, model);
+  predictor->PredictLeaf(m.get(), &out_predictions, model);
+  ASSERT_EQ(out_predictions.HostVector()[0], 1);
 }
 
 void TestIterationRange(Context const *ctx) {
@@ -587,19 +587,19 @@ void TestVectorLeafPrediction(Context const *ctx) {
 
   auto test_batch = [&](float expected, HostDeviceVector<float> const *p_data) {
     auto p_fmat = GetDMatrixFromData(p_data->ConstHostVector(), kRows, kCols);
-    PredictionCacheEntry predt_cache;
-    predictor->InitOutPredictions(p_fmat->Info(), &predt_cache.predictions, model);
-    ASSERT_EQ(predt_cache.predictions.Size(), kRows * mparam.LeafLength());
+    HostDeviceVector<float> predt_cache;
+    predictor->InitOutPredictions(p_fmat->Info(), &predt_cache, model);
+    ASSERT_EQ(predt_cache.Size(), kRows * mparam.LeafLength());
     predictor->PredictBatch(p_fmat.get(), &predt_cache, model, 0, 1);
-    auto const &h_predt = predt_cache.predictions.HostVector();
+    auto const &h_predt = predt_cache.HostVector();
     for (auto v : h_predt) {
       ASSERT_EQ(v, expected);
     }
   };
   auto test_inplace = [&](float expected, HostDeviceVector<float> const *p_data) {
-    PredictionCacheEntry predt_cache;
+    HostDeviceVector<float> predt_cache;
     std::shared_ptr<DMatrix> p_fmat = GetDMatrixFromData(p_data->ConstHostVector(), kRows, kCols);
-    predictor->InitOutPredictions(p_fmat->Info(), &predt_cache.predictions, model);
+    predictor->InitOutPredictions(p_fmat->Info(), &predt_cache, model);
     if (ctx->IsCUDA()) {
       // pull data to device.
       p_data->SetDevice(ctx->Device());
@@ -616,14 +616,14 @@ void TestVectorLeafPrediction(Context const *ctx) {
     }
     predictor->InplacePredict(proxy, model, std::numeric_limits<float>::quiet_NaN(), &predt_cache,
                               0, 1);
-    auto const &h_predt = predt_cache.predictions.HostVector();
+    auto const &h_predt = predt_cache.HostVector();
     for (auto v : h_predt) {
       ASSERT_EQ(v, expected);
     }
   };
   auto test_ghist = [&](float expected, HostDeviceVector<float> *p_data) {
     // ghist
-    PredictionCacheEntry predt_cache;
+    HostDeviceVector<float> predt_cache;
     auto &h_data = p_data->HostVector();
     // give it at least two bins, otherwise the histogram cuts only have min and max values.
     for (std::size_t i = 0; i < kCols; ++i) {
@@ -631,7 +631,7 @@ void TestVectorLeafPrediction(Context const *ctx) {
     }
     auto p_fmat = GetDMatrixFromData(p_data->ConstHostVector(), kRows, kCols);
 
-    predictor->InitOutPredictions(p_fmat->Info(), &predt_cache.predictions, model);
+    predictor->InitOutPredictions(p_fmat->Info(), &predt_cache, model);
 
     std::unique_ptr<ArrayIterForTest> iter;
     if (ctx->IsCUDA()) {
@@ -646,9 +646,9 @@ void TestVectorLeafPrediction(Context const *ctx) {
         std::make_shared<data::IterativeDMatrix>(iter.get(), iter->Proxy(), nullptr, Reset, Next,
                                                  std::numeric_limits<float>::quiet_NaN(), 0, 256);
 
-    predictor->InitOutPredictions(p_fmat->Info(), &predt_cache.predictions, model);
+    predictor->InitOutPredictions(p_fmat->Info(), &predt_cache, model);
     predictor->PredictBatch(p_fmat.get(), &predt_cache, model, 0, 1);
-    auto const &h_predt = predt_cache.predictions.HostVector();
+    auto const &h_predt = predt_cache.HostVector();
     // the smallest v uses the min_value from histogram cuts, which leads to a left leaf
     // during prediction.
     for (std::size_t i = 5; i < h_predt.size(); ++i) {

--- a/tests/cpp/predictor/test_predictor.h
+++ b/tests/cpp/predictor/test_predictor.h
@@ -63,17 +63,16 @@ void TestPredictionFromGradientIndex(Context const* ctx, size_t rows, size_t col
   {
     auto p_precise = RandomDataGenerator(rows, cols, 0).GenerateDMatrix();
 
-    PredictionCacheEntry approx_out_predictions;
-    predictor->InitOutPredictions(p_hist->Info(), &approx_out_predictions.predictions, model);
+    HostDeviceVector<float> approx_out_predictions;
+    predictor->InitOutPredictions(p_hist->Info(), &approx_out_predictions, model);
     predictor->PredictBatch(p_hist.get(), &approx_out_predictions, model, 0);
 
-    PredictionCacheEntry precise_out_predictions;
-    predictor->InitOutPredictions(p_precise->Info(), &precise_out_predictions.predictions, model);
+    HostDeviceVector<float> precise_out_predictions;
+    predictor->InitOutPredictions(p_precise->Info(), &precise_out_predictions, model);
     predictor->PredictBatch(p_precise.get(), &precise_out_predictions, model, 0);
 
     for (size_t i = 0; i < rows; ++i) {
-      CHECK_EQ(approx_out_predictions.predictions.HostVector()[i],
-               precise_out_predictions.predictions.HostVector()[i]);
+      CHECK_EQ(approx_out_predictions.HostVector()[i], precise_out_predictions.HostVector()[i]);
     }
   }
 
@@ -82,8 +81,8 @@ void TestPredictionFromGradientIndex(Context const* ctx, size_t rows, size_t col
     // histogram index from training data is valid and predictor doesn't known which
     // matrix is used for training.
     auto p_dmat = RandomDataGenerator(rows, cols, 0).GenerateDMatrix();
-    PredictionCacheEntry precise_out_predictions;
-    predictor->InitOutPredictions(p_dmat->Info(), &precise_out_predictions.predictions, model);
+    HostDeviceVector<float> precise_out_predictions;
+    predictor->InitOutPredictions(p_dmat->Info(), &precise_out_predictions, model);
     predictor->PredictBatch(p_dmat.get(), &precise_out_predictions, model, 0);
     CHECK(!p_dmat->PageExists<Page>());
   }

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -38,7 +38,6 @@
 #include "xgboost/json.h"                           // for Json, Object, get, String, IsA, opera...
 #include "xgboost/linalg.h"                         // for Tensor, TensorView
 #include "xgboost/logging.h"                        // for ConsoleLogger
-#include "xgboost/predictor.h"                      // for PredictionCacheEntry
 #include "xgboost/string_view.h"                    // for StringView
 
 namespace xgboost {
@@ -280,10 +279,10 @@ TEST(Learner, MultiThreadedPredict) {
   for (decltype(n_threads) thread_id = 0; thread_id < n_threads; ++thread_id) {
     threads.emplace_back([learner, p_data] {
       size_t constexpr kIters = 10;
-      auto& entry = learner->GetThreadLocal().prediction_entry;
+      auto& out_predictions = learner->GetThreadLocal().predictions;
       HostDeviceVector<float> predictions;
       for (size_t iter = 0; iter < kIters; ++iter) {
-        learner->Predict(p_data, false, &entry.predictions, 0, 0);
+        learner->Predict(p_data, false, &out_predictions, 0, 0);
 
         learner->Predict(p_data, false, &predictions, 0, 0, false, true);         // leaf
         learner->Predict(p_data, false, &predictions, 0, 0, false, false, true);  // contribs


### PR DESCRIPTION
## Summary

- Move prediction cache ownership from learner/predictor-facing APIs into GBTree.
- Change GBM and predictor prediction APIs to write into HostDeviceVector outputs instead of exposing PredictionCacheEntry.
- Keep GBLinear uncached while preserving prediction behavior and update tests/helpers for the vector-based API.

## Motivation

This keeps the prediction cache as GBTree implementation detail and reduces leakage of cache internals through learner, predictor, C API thread-local storage, and tests. It also leaves the code in a better shape for follow-up DART cache work.

## Validation

- git diff --check upstream/master...HEAD
- conda run -n xgboost cmake --build build --target testxgboost -j2
- ./build/testxgboost --gtest_filter=GBTree.PredictionCache:CPUPredictor.*:Predictor.*:Learner.MultiThreadedPredict:GBLinear.*:Linear.*

CUDA note: a local USE_CUDA=ON configure succeeded, but the CUDA test binary build timed out after 30 minutes before producing a result.