### PR TITLE
[CI] Add pandas-stubs to type checking.

### DIFF
--- a/ops/conda_env/python_lint.yml
+++ b/ops/conda_env/python_lint.yml
@@ -10,6 +10,7 @@ dependencies:
 - numpy
 - scipy
 - pandas
+- pandas-stubs
 - pyarrow
 - scikit-learn
 - dask

--- a/ops/script/test_r_package.py
+++ b/ops/script/test_r_package.py
@@ -8,11 +8,6 @@ from io import StringIO
 from pathlib import Path
 from platform import system
 
-try:
-    import pandas as pd
-except ImportError:
-    pd = None  # type: ignore
-
 from test_utils import R_PACKAGE, ROOT, DirectoryExcursion, cd, print_time, record_time
 
 
@@ -103,6 +98,11 @@ def build_rpackage(path: str) -> str:
 
 
 def check_example_timing(rcheck_dir: Path, threshold: float) -> None:
+    try:
+        import pandas as pd
+    except ImportError:
+        return
+
     with open(rcheck_dir / "xgboost-Ex.timings", "r") as fd:
         timings = fd.readlines()
         newlines = []
@@ -183,8 +183,7 @@ def check_rpackage(path: str) -> None:
     if check_log.find("Examples with CPU time") != -1:
         print(msg)
         raise ValueError("Suspicious NOTE.")
-    if pd is not None:
-        check_example_timing(rcheck_dir, threshold)
+    check_example_timing(rcheck_dir, threshold)
 
 
 @cd(R_PACKAGE)

--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -236,28 +236,22 @@ def is_arrow_dict(data: Any) -> TypeGuard["pa.DictionaryArray"]:
 
 
 class DfCatAccessor(Protocol):
-    """Protocol for pandas cat accessor."""
+    """Protocol for a dataframe categorical accessor."""
 
     @property
     def categories(  # pylint: disable=missing-function-docstring
         self,
-    ) -> "pd.Index": ...
+    ) -> Any: ...
 
     @property
-    def codes(self) -> "pd.Series": ...  # pylint: disable=missing-function-docstring
+    def codes(self) -> Any: ...  # pylint: disable=missing-function-docstring
+
+
+class CudfCatIndex(_CudaArrayLikeArg, Protocol):
+    """Protocol for a cuDF categorical index."""
 
     @property
     def dtype(self) -> np.dtype: ...  # pylint: disable=missing-function-docstring
-
-    @property
-    def values(self) -> np.ndarray: ...  # pylint: disable=missing-function-docstring
-
-    def to_arrow(  # pylint: disable=missing-function-docstring
-        self,
-    ) -> Union["pa.StringArray", "pa.IntegerArray"]: ...
-
-    @property
-    def __cuda_array_interface__(self) -> CudaArrayInf: ...
 
     @property
     def _column(self) -> Any: ...
@@ -556,7 +550,7 @@ def check_cudf_meta(data: _CudaArrayLikeArg, field: str) -> None:
         raise ValueError(f"Missing value is not allowed for: {field}")
 
 
-def _cudf_str_cat_inf(cats: DfCatAccessor) -> Tuple[CudaStringArray, Tuple]:
+def _cudf_str_cat_inf(cats: CudfCatIndex) -> Tuple[CudaStringArray, Tuple]:
     """String category index path for :py:func:`cudf_cat_inf`."""
     import pylibcudf as plc  # pylint: disable=import-outside-toplevel
 
@@ -593,7 +587,7 @@ def _cudf_str_cat_inf(cats: DfCatAccessor) -> Tuple[CudaStringArray, Tuple]:
 
 
 def cudf_cat_inf(
-    cats: DfCatAccessor, codes: "pd.Series"
+    cats: CudfCatIndex, codes: _CudaArrayLikeArg
 ) -> Tuple[Union[CudaArrayInf, CudaStringArray], ArrayInf, Tuple]:
     """Obtain the cuda array interface for cuDF categories."""
     cp = import_cupy()

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -1,6 +1,8 @@
 # pylint: disable=unused-import
 """For compatibility and optional dependencies."""
 
+from __future__ import annotations
+
 import functools
 import importlib.util
 import logging
@@ -255,9 +257,11 @@ def concat(value: Sequence[_T]) -> _T:  # pylint: disable=too-many-return-statem
         # other sparse format will be converted to CSR.
         return scipy_sparse.vstack(value, format="csr")
     if _is_pandas_df(value[0]) or _is_pandas_series(value[0]):
+        import pandas as pd
         from pandas import concat as pd_concat
 
-        return pd_concat(value, axis=0)
+        value_pd = cast(Sequence[pd.DataFrame | pd.Series], value)
+        return cast(_T, pd_concat(value_pd, axis=0))
     if lazy_isinstance(value[0], "cudf.core.dataframe", "DataFrame") or lazy_isinstance(
         value[0], "cudf.core.series", "Series"
     ):

--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -19,6 +19,7 @@ from typing import (
     TypeAlias,
     TypeGuard,
     Union,
+    cast,
 )
 
 import numpy as np
@@ -80,6 +81,7 @@ if TYPE_CHECKING:
     import pyarrow as pa
     from pandas import DataFrame as PdDataFrame
     from pandas import Series as PdSeries
+    from pandas.arrays import SparseArray as PdSparseArray
 
     from .core import DMatrix, _ProxyDMatrix
 
@@ -534,7 +536,7 @@ def pandas_transform_data(
     np_dtypes = _lazy_has_npdtypes()
 
     def cat_codes(ser: "PdSeries") -> DfCatAccessor:
-        return ser.cat
+        return cast(DfCatAccessor, ser.cat)
 
     def nu_type(ser: "PdSeries") -> np.ndarray:
         # Avoid conversion when possible
@@ -580,8 +582,7 @@ def pandas_transform_data(
         elif is_nullable_dtype(dtype):
             result.append(nu_type(data[col]))
         elif is_pd_sparse_dtype(dtype):
-            arr = data[col].values
-            arr = arr.to_dense()
+            arr = cast("PdSparseArray", data[col].values).to_dense()
             if _is_np_array_like(arr):
                 arr, _ = _ensure_np_dtype(arr, arr.dtype)
             result.append(arr)

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 def stack_series(series: pd.Series) -> np.ndarray:
     """Stack a series of arrays."""
     array = series.to_numpy(copy=False)
-    return np.stack(cast(Sequence[Any], array))
+    return np.stack(cast(Sequence[np.ndarray], array))
 
 
 # Global constant for defining column alias shared between estimator and data

--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -1,11 +1,24 @@
 # pylint: disable=protected-access
 """Utilities for processing spark partitions."""
 
+from __future__ import annotations
+
 from collections import defaultdict, namedtuple
-from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
 import numpy as np
-import pandas as pd
 from scipy.sparse import csr_matrix
 
 from .._typing import ArrayLike
@@ -14,12 +27,14 @@ from ..core import DataIter, DMatrix, QuantileDMatrix
 from ..sklearn import XGBModel
 from .utils import get_logger
 
+if TYPE_CHECKING:
+    import pandas as pd
+
 
 def stack_series(series: pd.Series) -> np.ndarray:
     """Stack a series of arrays."""
     array = series.to_numpy(copy=False)
-    array = np.stack(array)  # type: ignore[arg-type]
-    return array
+    return np.stack(cast(Sequence[Any], array))
 
 
 # Global constant for defining column alias shared between estimator and data
@@ -218,7 +233,7 @@ def create_dmatrix_from_partitions(  # pylint: disable=too-many-arguments
                 and feature_cols is not None
                 and part[feature_cols].shape[0] > 0  # guard against empty partition
             ):
-                array: Optional[np.ndarray] = part[feature_cols]
+                array: Any = part[feature_cols]
             elif part[name].shape[0] > 0:
                 array = part[name]
                 if name == alias.data:

--- a/python-package/xgboost/testing/dask.py
+++ b/python-package/xgboost/testing/dask.py
@@ -386,9 +386,11 @@ def make_ltr(  # pylint: disable=too-many-locals,too-many-arguments
     n_samples_per_worker = n_samples // len(workers)
 
     if device == "cpu":
-        from pandas import DataFrame as DF
+        DF: Any = pd.DataFrame
     else:
-        from cudf import DataFrame as DF
+        from cudf import DataFrame as CudfDataFrame
+
+        DF = CudfDataFrame
 
     def make(n: int, seed: int) -> pd.DataFrame:
         rng = np.random.default_rng(seed)

--- a/python-package/xgboost/testing/dask.py
+++ b/python-package/xgboost/testing/dask.py
@@ -1,7 +1,9 @@
 """Tests for dask shared by different test modules."""
 
+from __future__ import annotations
+
 import json
-from typing import Any, List, Literal, Tuple, Type, Union, cast, overload
+from typing import TYPE_CHECKING, Any, List, Literal, Tuple, Type, Union, cast, overload
 
 import numpy as np
 import pandas as pd
@@ -25,6 +27,12 @@ from .data import make_categorical as make_cat_local
 from .multi_target import LsObj1, LsObj2
 from .ordinal import make_recoded
 from .utils import Device, assert_allclose
+
+if TYPE_CHECKING:
+    import cudf
+
+    DF_union = Union[pd.DataFrame, cudf.DataFrame]
+    DF_T_union = Union[Type[pd.DataFrame], Type[cudf.DataFrame]]
 
 
 def check_init_estimation_clf(tree_method: str, device: Device, client: Client) -> None:
@@ -386,13 +394,13 @@ def make_ltr(  # pylint: disable=too-many-locals,too-many-arguments
     n_samples_per_worker = n_samples // len(workers)
 
     if device == "cpu":
-        DF: Any = pd.DataFrame
+        DF: DF_T_union = pd.DataFrame
     else:
         from cudf import DataFrame as CudfDataFrame
 
         DF = CudfDataFrame
 
-    def make(n: int, seed: int) -> pd.DataFrame:
+    def make(n: int, seed: int) -> DF_union:
         rng = np.random.default_rng(seed)
         X, y = make_classification(
             n,

--- a/python-package/xgboost/testing/data.py
+++ b/python-package/xgboost/testing/data.py
@@ -373,7 +373,7 @@ def get_ames_housing() -> Tuple[DataFrameT, np.ndarray]:
             x,
             dtype=pd.CategoricalDtype(
                 # not NA
-                filter(lambda x: isinstance(x, str), keys)
+                [key for key in keys if isinstance(key, str)]
             ),
         )
         return series
@@ -503,7 +503,7 @@ def get_ames_housing() -> Tuple[DataFrameT, np.ndarray]:
         if isinstance(df[c].dtype, pd.CategoricalDtype):
             y += df[c].cat.codes.astype(np.float64)
         else:
-            y += df[c].values
+            y += df[c].to_numpy()
 
     # Shift and scale to match the original y.
     y *= 79442.50288288662 / y.std()

--- a/python-package/xgboost/testing/ordinal.py
+++ b/python-package/xgboost/testing/ordinal.py
@@ -123,8 +123,6 @@ def run_cat_container(device: Device) -> None:
 # pylint: disable=too-many-statements
 def run_cat_container_mixed(device: Device) -> None:
     """Run checks with mixed types."""
-    import pandas as pd
-
     try:
         is_cudf_cat = _lazy_load_cudf_is_cat()
     except ImportError:
@@ -134,7 +132,7 @@ def run_cat_container_mixed(device: Device) -> None:
 
     n_samples = int(2**10)
 
-    def check(Xy: DMatrix, X: pd.DataFrame) -> None:
+    def check(Xy: DMatrix, X: Any) -> None:
         cats = Xy.get_categories(export_to_arrow=True).to_arrow()
         assert cats is not None
         cats_di = dict(cats)
@@ -556,8 +554,8 @@ def make_recoded(device: Device, *, n_features: int = 4096) -> Tuple:
     n_samples = 1024
 
     # Same between old and new, with 0 ("a") and 1 ("b") exchanged their position.
-    old_cats = ["a", "b", "c", "d"]
-    new_cats = ["b", "a", "c", "d"]
+    old_cats = pd.Index(["a", "b", "c", "d"])
+    new_cats = pd.Index(["b", "a", "c", "d"])
     mapping = {0: 1, 1: 0}
 
     rng = np.random.default_rng(2025)
@@ -567,17 +565,16 @@ def make_recoded(device: Device, *, n_features: int = 4096) -> Tuple:
         low=0, high=4, size=(n_samples, n_features // 2), dtype=np.int32
     )
 
-    df = {}  # avoid fragmentation warning from pandas
+    df: dict[str, Any] = {}  # avoid fragmentation warning from pandas
     for c in range(n_features):
         if c % 2 == 0:
-            col = col_numeric[:, c // 2]
+            df[f"f{c}"] = col_numeric[:, c // 2]
         else:
             codes = col_categorical[:, c // 2]
-            col = pd.Categorical.from_codes(
+            df[f"f{c}"] = pd.Categorical.from_codes(
                 categories=old_cats,
                 codes=codes,
             )
-        df[f"f{c}"] = col
 
     enc = Df(df)
     y = rng.normal(size=n_samples)
@@ -605,8 +602,8 @@ def run_specified_cat(  # pylint: disable=too-many-locals
     import pandas as pd
 
     # Same between old and new, with 0 ("a") and 1 ("b") exchanged their position.
-    old_cats = ["a", "b", "c", "d"]
-    new_cats = ["b", "a", "c", "d"]
+    old_cats = pd.Index(["a", "b", "c", "d"])
+    new_cats = pd.Index(["b", "a", "c", "d"])
 
     col0 = np.arange(0, 9)
     col1 = pd.Categorical.from_codes(
@@ -691,8 +688,8 @@ def run_recode_dmatrix(device: Device) -> None:
     Df, _ = get_df_impl(device)
 
     # String index
-    old_cats = ["café", "猫", "c", "🐍"]
-    new_cats = ["猫", "café", "c", "🐍"]
+    old_cats = pd.Index(["café", "猫", "c", "🐍"])
+    new_cats = pd.Index(["猫", "café", "c", "🐍"])
 
     col0 = np.arange(0, 9)
     col1 = pd.Categorical.from_codes(
@@ -721,12 +718,12 @@ def run_recode_dmatrix(device: Device) -> None:
     assert predictor_equal(Xy_0, Xy_1)
 
     # Numeric index
-    col0 = pd.Categorical.from_codes(
-        categories=[5, 6, 7, 8],
+    cat_col = pd.Categorical.from_codes(
+        categories=pd.Index([5, 6, 7, 8]),
         codes=[0, 0, 2, 3, 1, 2, 2, 3, 1],
     )
     Df, _ = get_df_impl(device)
-    df = Df({"cat": col0})
+    df = Df({"cat": cat_col})
     for DMatrixT in (DMatrix, QuantileDMatrix):
         Xy = DMatrixT(df, enable_categorical=True)
         cats_0 = Xy.get_categories(export_to_arrow=True)

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -452,7 +452,7 @@ def cv(
     callbacks: Optional[Sequence[TrainingCallback]] = None,
     shuffle: bool = True,
     custom_metric: Optional[Metric] = None,
-) -> Union[Dict[str, float], "PdDataFrame"]:
+) -> Union[Dict[str, List[float]], "PdDataFrame"]:
     """Cross-validation with given parameters.
 
     Parameters
@@ -610,14 +610,16 @@ def cv(
             for k in results.keys():  # pylint: disable=consider-iterating-dictionary
                 results[k] = results[k][: (booster.best_iteration + 1)]
             break
+
+    results_df: Union[Dict[str, List[float]], "PdDataFrame"] = results
     if as_pandas:
         try:
             import pandas as pd
-
-            results = pd.DataFrame.from_dict(results)
         except ImportError:
             pass
+        else:
+            results_df = pd.DataFrame.from_dict(results)
 
     callbacks_container.after_training(booster)
 
-    return results
+    return results_df

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -497,7 +497,7 @@ def cv(
         transformed versions of those.
     as_pandas : bool, default True
         Return pd.DataFrame when pandas is installed.
-        If False or pandas is not installed, return np.ndarray
+        If False or pandas is not installed, returns a dictionary.
     verbose_eval : bool, int, or None, default None
         Whether to display the progress. If None, progress will be displayed
         when np.ndarray is returned. If True, progress will be displayed at

--- a/tests/python-gpu/test_gpu_prediction.py
+++ b/tests/python-gpu/test_gpu_prediction.py
@@ -305,10 +305,10 @@ class TestGPUPredict:
         cols = 10
         rng = np.random.RandomState(1994)
         cp.cuda.runtime.setDevice(0)
-        X = rng.randn(rows, cols)
-        X = pd.DataFrame(X)
+        X_np = rng.randn(rows, cols)
+        X_pd = pd.DataFrame(X_np)
         y = rng.randn(rows)
-        X = cudf.from_pandas(X)
+        X = cudf.from_pandas(X_pd)
 
         dtrain = xgb.DMatrix(X, y)
 

--- a/tests/python/test_ordinal.py
+++ b/tests/python/test_ordinal.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Literal, cast
 
 import numpy as np
 import pytest
@@ -39,7 +39,9 @@ def test_cat_container() -> None:
         ("UInt64", [1, np.iinfo(np.int64).max]),
     ],
 )
-def test_pd_cat_nullable_integer(dtype: str, values: list[int]) -> None:
+def test_pd_cat_nullable_integer(
+    dtype: Literal["Int64", "UInt16", "UInt32", "UInt64"], values: list[int]
+) -> None:
     import pandas as pd
 
     categories = pd.Index(pd.array(values, dtype=dtype))


### PR DESCRIPTION
- Fix checks with the full pandas typing module available.
- Start using Python 3.12 with annotations to leverage lazy type evaluation.