### PR TITLE
[JVM] Support CUDA async pool in Spark.

### DIFF
--- a/jvm-packages/xgboost4j-spark-gpu/src/main/scala/ml/dmlc/xgboost4j/scala/spark/GpuXGBoostPlugin.scala
+++ b/jvm-packages/xgboost4j-spark-gpu/src/main/scala/ml/dmlc/xgboost4j/scala/spark/GpuXGBoostPlugin.scala
@@ -189,15 +189,14 @@ class GpuXGBoostPlugin extends XGBoostPlugin {
     )
 
     val sconf = dataset.sparkSession.conf
-    val rmmEnabled: Boolean = try {
-      sconf.get("spark.rapids.memory.gpu.pool").trim.toLowerCase != "none"
-    } catch {
-      case _: Throwable => false // Any exception will return false
-    }
-    val configs = if (rmmEnabled) {
-      Map("use_rmm" -> rmmEnabled).asInstanceOf[Map[String, AnyRef]]
-    } else {
-      Map.empty[String, AnyRef]
+    val rmmPool = sconf.get("spark.rapids.memory.gpu.pool", "async").trim.toLowerCase
+    val configs = rmmPool match {
+      case "async" =>
+        Map("use_cuda_async_pool" -> true).asInstanceOf[Map[String, AnyRef]]
+      case "none" =>
+        Map.empty[String, AnyRef]
+      case _ =>
+        Map("use_rmm" -> true).asInstanceOf[Map[String, AnyRef]]
     }
     (rdd, configs)
   }

--- a/jvm-packages/xgboost4j-spark-gpu/src/test/scala/ml/dmlc/xgboost4j/scala/spark/GpuXGBoostPluginSuite.scala
+++ b/jvm-packages/xgboost4j-spark-gpu/src/test/scala/ml/dmlc/xgboost4j/scala/spark/GpuXGBoostPluginSuite.scala
@@ -205,7 +205,8 @@ class GpuXGBoostPluginSuite extends GpuTestSuite {
         .setFeaturesCol(features)
         .setNumRound(2)
       val (_, configs) = PluginUtils.getPlugin.get.buildRddWatches(classifier, df)
-      assert(configs("use_rmm") == true)
+      assert(configs("use_cuda_async_pool") == true)
+      assert(!configs.contains("use_rmm"))
 
       // No exception
       classifier.fit(df)


### PR DESCRIPTION
Followup of https://github.com/dmlc/xgboost/pull/12415

As a bonus, the default XGBoost maven GPU package now works with the rapids spark plugin.