### PR TITLE
Split pseudo-Huber objective CPU and CUDA kernels

### DIFF
--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -50,6 +50,7 @@ OBJECTS= \
     $(PKGROOT)/src/objective/multiclass_obj.o \
     $(PKGROOT)/src/objective/lambdarank_obj.o \
     $(PKGROOT)/src/objective/hinge.o \
+    $(PKGROOT)/src/objective/pseudohuber_obj.o \
     $(PKGROOT)/src/objective/aft_obj.o \
     $(PKGROOT)/src/objective/init_estimation.o \
     $(PKGROOT)/src/objective/quantile_obj.o \

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -49,6 +49,7 @@ OBJECTS= \
     $(PKGROOT)/src/objective/multiclass_obj.o \
     $(PKGROOT)/src/objective/lambdarank_obj.o \
     $(PKGROOT)/src/objective/hinge.o \
+    $(PKGROOT)/src/objective/pseudohuber_obj.o \
     $(PKGROOT)/src/objective/aft_obj.o \
     $(PKGROOT)/src/objective/init_estimation.o \
     $(PKGROOT)/src/objective/quantile_obj.o \

--- a/src/objective/elementwise_objective.cuh
+++ b/src/objective/elementwise_objective.cuh
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file elementwise_objective.cuh
+ * \brief CUDA implementations of the typed elementwise objective kernels.
+ */
+#ifndef XGBOOST_OBJECTIVE_ELEMENTWISE_OBJECTIVE_CUH_
+#define XGBOOST_OBJECTIVE_ELEMENTWISE_OBJECTIVE_CUH_
+
+#include <cstddef>  // for size_t
+
+#include "../common/device_helpers.cuh"  // for LaunchN
+#include "../common/linalg_op.cuh"      // for ElementWiseKernel
+#include "../common/optional_weight.h"  // for MakeOptionalWeights
+#include "elementwise_objective.h"
+
+namespace xgboost::obj::elementwise {
+namespace detail {
+template <typename GradientFn>
+void GradientCuda(Context const* ctx, HostDeviceVector<float> const& preds,
+                             MetaInfo const& info, bst_target_t n_targets, GradientFn gradient,
+                             linalg::Matrix<GradientPair>* out_gpair) {
+  auto device = ctx->Device();
+  CHECK(device.IsCUDA());
+
+  preds.SetDevice(device);
+  auto predt = linalg::MakeTensorView(ctx, &preds, info.num_row_, n_targets);
+  auto labels = info.labels.View(device);
+  auto weights = common::MakeOptionalWeights(device, info.weights_);
+
+  out_gpair->SetDevice(device);
+  out_gpair->Reshape(info.num_row_, n_targets);
+  auto gpair = out_gpair->View(device);
+
+  linalg::cuda_impl::ElementWiseKernel(
+      gpair,
+      [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
+        gpair(i, j) = gradient(predt(i, j), labels(i, j), weights[i]);
+      },
+      ctx->CUDACtx()->Stream());
+}
+
+template <typename TransformFn>
+void TransformCuda(Context const* ctx, HostDeviceVector<float>* preds,
+                              TransformFn transform) {
+  auto device = ctx->Device();
+  CHECK(device.IsCUDA());
+  preds->SetDevice(device);
+  auto values = preds->DeviceSpan();
+
+  dh::LaunchN(values.size(), ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(std::size_t i) {
+    values[i] = transform(values[i]);
+  });
+}
+}  // namespace detail
+
+template <typename GradientFn>
+auto RegisterGradientCuda() {
+  using Kernel = GradientKernel<GradientFn>;
+  return common::KernelRegistration<Kernel>{DeviceOrd::kCUDA,
+                                             &detail::GradientCuda<GradientFn>};
+}
+
+template <typename TransformFn>
+auto RegisterTransformCuda() {
+  using Kernel = TransformKernel<TransformFn>;
+  return common::KernelRegistration<Kernel>{DeviceOrd::kCUDA,
+                                             &detail::TransformCuda<TransformFn>};
+}
+}  // namespace xgboost::obj::elementwise
+
+#endif  // XGBOOST_OBJECTIVE_ELEMENTWISE_OBJECTIVE_CUH_

--- a/src/objective/elementwise_objective.h
+++ b/src/objective/elementwise_objective.h
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file elementwise_objective.h
+ * \brief Typed elementwise objective kernels and CPU implementations.
+ */
+#ifndef XGBOOST_OBJECTIVE_ELEMENTWISE_OBJECTIVE_H_
+#define XGBOOST_OBJECTIVE_ELEMENTWISE_OBJECTIVE_H_
+
+#include <cstddef>  // for size_t
+
+#include "../common/kernel.h"            // for KernelRegistration
+#include "../common/linalg_op.h"         // for ElementWiseKernel
+#include "../common/optional_weight.h"   // for OptionalWeights
+#include "../common/threading_utils.h"   // for ParallelFor
+#include "xgboost/base.h"                // for GradientPair, bst_target_t
+#include "xgboost/context.h"             // for Context
+#include "xgboost/data.h"                // for MetaInfo
+#include "xgboost/host_device_vector.h"  // for HostDeviceVector
+#include "xgboost/linalg.h"              // for Matrix
+
+namespace xgboost::obj::elementwise {
+template <typename GradientFn>
+struct GradientKernel {
+  using Signature = void(Context const*, HostDeviceVector<float> const&, MetaInfo const&,
+                         bst_target_t, GradientFn, linalg::Matrix<GradientPair>*);
+};
+
+template <typename TransformFn>
+struct TransformKernel {
+  using Signature = void(Context const*, HostDeviceVector<float>*, TransformFn);
+};
+
+namespace detail {
+template <typename GradientFn>
+void GradientCpu(Context const* ctx, HostDeviceVector<float> const& preds, MetaInfo const& info,
+                 bst_target_t n_targets, GradientFn gradient,
+                 linalg::Matrix<GradientPair>* out_gpair) {
+  auto device = DeviceOrd::CPU();
+  auto predt = linalg::MakeTensorView(device, preds.ConstHostSpan(), info.num_row_, n_targets);
+  auto labels = info.labels.HostView();
+  common::OptionalWeights weights{info.weights_.ConstHostSpan()};
+
+  out_gpair->SetDevice(device);
+  out_gpair->Reshape(info.num_row_, n_targets);
+  auto gpair = out_gpair->HostView();
+
+  linalg::cpu_impl::ElementWiseKernel(
+      gpair, ctx->Threads(), [=](std::size_t i, std::size_t j) mutable {
+        gpair(i, j) = gradient(predt(i, j), labels(i, j), weights[i]);
+      });
+}
+
+template <typename TransformFn>
+void TransformCpu(Context const* ctx, HostDeviceVector<float>* preds, TransformFn transform) {
+  auto values = preds->HostSpan();
+  common::ParallelFor(values.size(), ctx->Threads(),
+                      [=](std::size_t i) { values[i] = transform(values[i]); });
+}
+}  // namespace detail
+
+template <typename GradientFn>
+auto RegisterGradientCpu() {
+  using Kernel = GradientKernel<GradientFn>;
+  return common::KernelRegistration<Kernel>{DeviceOrd::kCPU, &detail::GradientCpu<GradientFn>};
+}
+
+template <typename TransformFn>
+auto RegisterTransformCpu() {
+  using Kernel = TransformKernel<TransformFn>;
+  return common::KernelRegistration<Kernel>{DeviceOrd::kCPU, &detail::TransformCpu<TransformFn>};
+}
+}  // namespace xgboost::obj::elementwise
+
+#endif  // XGBOOST_OBJECTIVE_ELEMENTWISE_OBJECTIVE_H_

--- a/src/objective/hinge.cc
+++ b/src/objective/hinge.cc
@@ -12,47 +12,17 @@
 #include <cstddef>    // for size_t
 #include <cstdint>    // for int32_t
 
-#include "../common/kernel.h"           // for DispatchKernel, KernelRegistration
-#include "../common/linalg_op.h"        // for ElementWiseKernel
-#include "../common/optional_weight.h"  // for OptionalWeights
-#include "../common/threading_utils.h"  // for ParallelFor
-#include "init_estimation.h"            // for FitIntercept
-#include "xgboost/json.h"               // for Json
-#include "xgboost/objective.h"          // for ObjFunction
+#include "../common/kernel.h"   // for DispatchKernel
+#include "init_estimation.h"    // for FitIntercept
+#include "xgboost/json.h"       // for Json
+#include "xgboost/objective.h"  // for ObjFunction
 
 namespace xgboost::obj {
 DMLC_REGISTRY_FILE_TAG(hinge_obj);
 
-namespace cpu_impl {
-void HingeGradient(Context const* ctx, HostDeviceVector<float> const& preds, MetaInfo const& info,
-                   bst_target_t n_targets, linalg::Matrix<GradientPair>* out_gpair) {
-  auto device = DeviceOrd::CPU();
-  auto predt = linalg::MakeTensorView(device, preds.ConstHostSpan(), info.num_row_, n_targets);
-  auto labels = info.labels.HostView();
-  common::OptionalWeights weights{info.weights_.ConstHostSpan()};
-
-  out_gpair->SetDevice(device);
-  out_gpair->Reshape(info.num_row_, n_targets);
-  auto gpair = out_gpair->HostView();
-
-  linalg::cpu_impl::ElementWiseKernel(
-      gpair, ctx->Threads(), [=](std::size_t i, std::size_t j) mutable {
-        gpair(i, j) = HingeLoss::Gradient(predt(i, j), labels(i, j), weights[i]);
-      });
-}
-
-void HingePredTransform(Context const* ctx, HostDeviceVector<float>* preds) {
-  auto values = preds->HostSpan();
-  common::ParallelFor(values.size(), ctx->Threads(),
-                      [=](std::size_t i) { values[i] = HingeLoss::PredTransform(values[i]); });
-}
-}  // namespace cpu_impl
-
 namespace {
-common::KernelRegistration<HingeGradientKernel> const kRegisterHingeGradientCpu{
-    DeviceOrd::kCPU, &cpu_impl::HingeGradient};
-common::KernelRegistration<HingePredTransformKernel> const kRegisterHingePredTransformCpu{
-    DeviceOrd::kCPU, &cpu_impl::HingePredTransform};
+auto const kRegisterHingeGradientCpu = elementwise::RegisterGradientCpu<HingeLoss>();
+auto const kRegisterHingePredTransformCpu = elementwise::RegisterTransformCpu<HingeLoss>();
 }  // namespace
 
 class HingeObj : public FitIntercept {
@@ -70,11 +40,12 @@ class HingeObj : public FitIntercept {
     CheckInitInputs(info);
     CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
 
-    common::DispatchKernel<HingeGradientKernel>(ctx_, preds, info, this->Targets(info), out_gpair);
+    common::DispatchKernel<HingeGradientKernel>(ctx_, preds, info, this->Targets(info), HingeLoss{},
+                                                out_gpair);
   }
 
   void PredTransform(HostDeviceVector<float>* io_preds) const override {
-    common::DispatchKernel<HingePredTransformKernel>(ctx_, io_preds);
+    common::DispatchKernel<HingePredTransformKernel>(ctx_, io_preds, HingeLoss{});
   }
 
   [[nodiscard]] const char* DefaultEvalMetric() const override { return "error"; }

--- a/src/objective/hinge.cu
+++ b/src/objective/hinge.cu
@@ -6,56 +6,14 @@
  */
 #include <dmlc/registry.h>
 
-#include <cstddef>  // for size_t
-
-#include "../common/device_helpers.cuh"  // for LaunchN
-#include "../common/kernel.h"            // for KernelRegistration
-#include "../common/linalg_op.cuh"       // for ElementWiseKernel
-#include "../common/optional_weight.h"   // for OptionalWeights
+#include "elementwise_objective.cuh"  // for elementwise kernel registration
 #include "hinge.h"
 
 namespace xgboost::obj {
 DMLC_REGISTRY_FILE_TAG(hinge_kernel_cuda);
 
-namespace cuda_impl {
-void HingeGradient(Context const* ctx, HostDeviceVector<float> const& preds, MetaInfo const& info,
-                   bst_target_t n_targets, linalg::Matrix<GradientPair>* out_gpair) {
-  auto device = ctx->Device();
-  CHECK(device.IsCUDA());
-
-  preds.SetDevice(device);
-  auto predt = linalg::MakeTensorView(ctx, &preds, info.num_row_, n_targets);
-  auto labels = info.labels.View(device);
-  auto weights = common::MakeOptionalWeights(device, info.weights_);
-
-  out_gpair->SetDevice(device);
-  out_gpair->Reshape(info.num_row_, n_targets);
-  auto gpair = out_gpair->View(device);
-
-  linalg::cuda_impl::ElementWiseKernel(
-      gpair,
-      [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
-        gpair(i, j) = HingeLoss::Gradient(predt(i, j), labels(i, j), weights[i]);
-      },
-      ctx->CUDACtx()->Stream());
-}
-
-void HingePredTransform(Context const* ctx, HostDeviceVector<float>* preds) {
-  auto device = ctx->Device();
-  CHECK(device.IsCUDA());
-  preds->SetDevice(device);
-  auto values = preds->DeviceSpan();
-
-  dh::LaunchN(values.size(), ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(std::size_t i) {
-    values[i] = HingeLoss::PredTransform(values[i]);
-  });
-}
-}  // namespace cuda_impl
-
 namespace {
-common::KernelRegistration<HingeGradientKernel> const kRegisterHingeGradientCuda{
-    DeviceOrd::kCUDA, &cuda_impl::HingeGradient};
-common::KernelRegistration<HingePredTransformKernel> const kRegisterHingePredTransformCuda{
-    DeviceOrd::kCUDA, &cuda_impl::HingePredTransform};
+auto const kRegisterHingeGradientCuda = elementwise::RegisterGradientCuda<HingeLoss>();
+auto const kRegisterHingePredTransformCuda = elementwise::RegisterTransformCuda<HingeLoss>();
 }  // namespace
 }  // namespace xgboost::obj

--- a/src/objective/hinge.h
+++ b/src/objective/hinge.h
@@ -8,15 +8,12 @@
 
 #include <limits>  // for numeric_limits
 
-#include "xgboost/base.h"                // for GradientPair, bst_target_t
-#include "xgboost/context.h"             // for Context
-#include "xgboost/data.h"                // for MetaInfo
-#include "xgboost/host_device_vector.h"  // for HostDeviceVector
-#include "xgboost/linalg.h"              // for Matrix
+#include "elementwise_objective.h"  // for elementwise::GradientKernel, elementwise::TransformKernel
+#include "xgboost/base.h"           // for GradientPair
 
 namespace xgboost::obj {
 struct HingeLoss {
-  XGBOOST_DEVICE static GradientPair Gradient(float margin, float label, float weight) {
+  XGBOOST_DEVICE GradientPair operator()(float margin, float label, float weight) const {
     auto y = label * 2.0f - 1.0f;
     if (margin * y < 1.0f) {
       return GradientPair{-y * weight, weight};
@@ -24,17 +21,11 @@ struct HingeLoss {
     return GradientPair{0.0f, std::numeric_limits<float>::min()};
   }
 
-  XGBOOST_DEVICE static float PredTransform(float margin) { return margin > 0.0f ? 1.0f : 0.0f; }
+  XGBOOST_DEVICE float operator()(float margin) const { return margin > 0.0f ? 1.0f : 0.0f; }
 };
 
-struct HingeGradientKernel {
-  using Signature = void(Context const*, HostDeviceVector<float> const&, MetaInfo const&,
-                         bst_target_t, linalg::Matrix<GradientPair>*);
-};
-
-struct HingePredTransformKernel {
-  using Signature = void(Context const*, HostDeviceVector<float>*);
-};
+using HingeGradientKernel = elementwise::GradientKernel<HingeLoss>;
+using HingePredTransformKernel = elementwise::TransformKernel<HingeLoss>;
 
 }  // namespace xgboost::obj
 

--- a/src/objective/objective.cc
+++ b/src/objective/objective.cc
@@ -42,10 +42,12 @@ namespace xgboost {
 namespace obj {
 // List of files that will be force linked in static links.
 DMLC_REGISTRY_LINK_TAG(hinge_obj);
+DMLC_REGISTRY_LINK_TAG(pseudohuber_obj);
 #ifdef XGBOOST_USE_CUDA
 DMLC_REGISTRY_LINK_TAG(regression_obj_gpu);
 DMLC_REGISTRY_LINK_TAG(quantile_obj_gpu);
 DMLC_REGISTRY_LINK_TAG(hinge_kernel_cuda);
+DMLC_REGISTRY_LINK_TAG(pseudohuber_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(multiclass_obj_gpu);
 DMLC_REGISTRY_LINK_TAG(lambdarank_obj);
 DMLC_REGISTRY_LINK_TAG(lambdarank_obj_cu);

--- a/src/objective/pseudohuber_obj.cc
+++ b/src/objective/pseudohuber_obj.cc
@@ -11,40 +11,18 @@
 #include <cstddef>    // for size_t
 #include <cstdint>    // for int32_t
 
-#include "../common/kernel.h"           // for DispatchKernel, KernelRegistration
-#include "../common/linalg_op.h"        // for ElementWiseKernel
-#include "../common/optional_weight.h"  // for OptionalWeights
-#include "../common/pseudo_huber.h"     // for PseudoHuberParam
-#include "init_estimation.h"            // for CheckInitInputs, FitIntercept
-#include "xgboost/json.h"               // for FromJson, Json, Object, String, ToJson
-#include "xgboost/objective.h"          // for ObjFunction
+#include "../common/kernel.h"        // for DispatchKernel
+#include "../common/pseudo_huber.h"  // for PseudoHuberParam
+#include "init_estimation.h"         // for CheckInitInputs, FitIntercept
+#include "xgboost/json.h"            // for FromJson, Json, Object, String, ToJson
+#include "xgboost/objective.h"       // for ObjFunction
 
 namespace xgboost::obj {
 DMLC_REGISTRY_FILE_TAG(pseudohuber_obj);
 
-namespace cpu_impl {
-void PseudoHuberGradient(Context const* ctx, HostDeviceVector<float> const& preds,
-                         MetaInfo const& info, bst_target_t n_targets, float slope,
-                         linalg::Matrix<GradientPair>* out_gpair) {
-  auto device = DeviceOrd::CPU();
-  auto predt = linalg::MakeTensorView(device, preds.ConstHostSpan(), info.num_row_, n_targets);
-  auto labels = info.labels.HostView();
-  common::OptionalWeights weights{info.weights_.ConstHostSpan()};
-
-  out_gpair->SetDevice(device);
-  out_gpair->Reshape(info.num_row_, n_targets);
-  auto gpair = out_gpair->HostView();
-
-  linalg::cpu_impl::ElementWiseKernel(
-      gpair, ctx->Threads(), [=](std::size_t i, std::size_t j) mutable {
-        gpair(i, j) = PseudoHuberLoss::Gradient(predt(i, j), labels(i, j), weights[i], slope);
-      });
-}
-}  // namespace cpu_impl
-
 namespace {
-common::KernelRegistration<PseudoHuberGradientKernel> const kRegisterPseudoHuberGradientCpu{
-    DeviceOrd::kCPU, &cpu_impl::PseudoHuberGradient};
+auto const kRegisterPseudoHuberGradientCpu =
+    elementwise::RegisterGradientCpu<PseudoHuberGradient>();
 }  // namespace
 
 class PseudoHuberRegression : public FitIntercept {
@@ -63,8 +41,8 @@ class PseudoHuberRegression : public FitIntercept {
     CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
     auto slope = param_.huber_slope;
     CHECK_NE(slope, 0.0) << "slope for pseudo huber cannot be 0.";
-    common::DispatchKernel<PseudoHuberGradientKernel>(ctx_, preds, info, this->Targets(info), slope,
-                                                      out_gpair);
+    common::DispatchKernel<PseudoHuberGradientKernel>(ctx_, preds, info, this->Targets(info),
+                                                      PseudoHuberGradient{slope}, out_gpair);
   }
 
   [[nodiscard]] const char* DefaultEvalMetric() const override { return "mphe"; }

--- a/src/objective/pseudohuber_obj.cc
+++ b/src/objective/pseudohuber_obj.cc
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file pseudohuber_obj.cc
+ * \brief CPU implementation and registration of the pseudo-Huber objective.
+ */
+#include "pseudohuber_obj.h"
+
+#include <dmlc/registry.h>
+
+#include <algorithm>  // for max
+#include <cstddef>    // for size_t
+#include <cstdint>    // for int32_t
+
+#include "../common/kernel.h"           // for DispatchKernel, KernelRegistration
+#include "../common/linalg_op.h"        // for ElementWiseKernel
+#include "../common/optional_weight.h"  // for OptionalWeights
+#include "../common/pseudo_huber.h"     // for PseudoHuberParam
+#include "init_estimation.h"            // for CheckInitInputs, FitIntercept
+#include "xgboost/json.h"               // for FromJson, Json, Object, String, ToJson
+#include "xgboost/objective.h"          // for ObjFunction
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(pseudohuber_obj);
+
+namespace cpu_impl {
+void PseudoHuberGradient(Context const* ctx, HostDeviceVector<float> const& preds,
+                         MetaInfo const& info, bst_target_t n_targets, float slope,
+                         linalg::Matrix<GradientPair>* out_gpair) {
+  auto device = DeviceOrd::CPU();
+  auto predt = linalg::MakeTensorView(device, preds.ConstHostSpan(), info.num_row_, n_targets);
+  auto labels = info.labels.HostView();
+  common::OptionalWeights weights{info.weights_.ConstHostSpan()};
+
+  out_gpair->SetDevice(device);
+  out_gpair->Reshape(info.num_row_, n_targets);
+  auto gpair = out_gpair->HostView();
+
+  linalg::cpu_impl::ElementWiseKernel(
+      gpair, ctx->Threads(), [=](std::size_t i, std::size_t j) mutable {
+        gpair(i, j) = PseudoHuberLoss::Gradient(predt(i, j), labels(i, j), weights[i], slope);
+      });
+}
+}  // namespace cpu_impl
+
+namespace {
+common::KernelRegistration<PseudoHuberGradientKernel> const kRegisterPseudoHuberGradientCpu{
+    DeviceOrd::kCPU, &cpu_impl::PseudoHuberGradient};
+}  // namespace
+
+class PseudoHuberRegression : public FitIntercept {
+  PseudoHuberParam param_;
+
+ public:
+  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
+  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
+    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
+  }
+
+  void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info,
+                   std::int32_t /*iter*/, linalg::Matrix<GradientPair>* out_gpair) override {
+    CheckInitInputs(info);
+    CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
+    auto slope = param_.huber_slope;
+    CHECK_NE(slope, 0.0) << "slope for pseudo huber cannot be 0.";
+    common::DispatchKernel<PseudoHuberGradientKernel>(ctx_, preds, info, this->Targets(info), slope,
+                                                      out_gpair);
+  }
+
+  [[nodiscard]] const char* DefaultEvalMetric() const override { return "mphe"; }
+
+  void SaveConfig(Json* p_out) const override {
+    auto& out = *p_out;
+    out["name"] = String("reg:pseudohubererror");
+    out["pseudo_huber_param"] = ToJson(param_);
+  }
+
+  void LoadConfig(Json const& in) override {
+    auto const& config = get<Object const>(in);
+    if (config.find("pseudo_huber_param") == config.cend()) {
+      // The parameter is added in 1.6.
+      return;
+    }
+    FromJson(in["pseudo_huber_param"], &param_);
+  }
+
+  [[nodiscard]] Json DefaultMetricConfig() const override {
+    CHECK(param_.GetInitialised());
+    Json config{Object{}};
+    config["name"] = String{this->DefaultEvalMetric()};
+    config["pseudo_huber_param"] = ToJson(param_);
+    return config;
+  }
+};
+
+XGBOOST_REGISTER_OBJECTIVE(PseudoHuberRegression, "reg:pseudohubererror")
+    .describe("Regression Pseudo Huber error.")
+    .set_body([]() { return new PseudoHuberRegression(); });
+}  // namespace xgboost::obj

--- a/src/objective/pseudohuber_obj.cu
+++ b/src/objective/pseudohuber_obj.cu
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file pseudohuber_obj.cu
+ * \brief CUDA implementation of the pseudo-Huber objective.
+ */
+#include <dmlc/registry.h>
+
+#include <cstddef>  // for size_t
+
+#include "../common/kernel.h"           // for KernelRegistration
+#include "../common/linalg_op.cuh"      // for ElementWiseKernel
+#include "../common/optional_weight.h"  // for MakeOptionalWeights
+#include "pseudohuber_obj.h"
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(pseudohuber_kernel_cuda);
+
+namespace cuda_impl {
+void PseudoHuberGradient(Context const* ctx, HostDeviceVector<float> const& preds,
+                         MetaInfo const& info, bst_target_t n_targets, float slope,
+                         linalg::Matrix<GradientPair>* out_gpair) {
+  auto device = ctx->Device();
+  CHECK(device.IsCUDA());
+
+  preds.SetDevice(device);
+  auto predt = linalg::MakeTensorView(ctx, &preds, info.num_row_, n_targets);
+  auto labels = info.labels.View(device);
+  auto weights = common::MakeOptionalWeights(device, info.weights_);
+
+  out_gpair->SetDevice(device);
+  out_gpair->Reshape(info.num_row_, n_targets);
+  auto gpair = out_gpair->View(device);
+
+  linalg::cuda_impl::ElementWiseKernel(
+      gpair,
+      [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
+        gpair(i, j) = PseudoHuberLoss::Gradient(predt(i, j), labels(i, j), weights[i], slope);
+      },
+      ctx->CUDACtx()->Stream());
+}
+}  // namespace cuda_impl
+
+namespace {
+common::KernelRegistration<PseudoHuberGradientKernel> const kRegisterPseudoHuberGradientCuda{
+    DeviceOrd::kCUDA, &cuda_impl::PseudoHuberGradient};
+}  // namespace
+}  // namespace xgboost::obj

--- a/src/objective/pseudohuber_obj.cu
+++ b/src/objective/pseudohuber_obj.cu
@@ -5,43 +5,14 @@
  */
 #include <dmlc/registry.h>
 
-#include <cstddef>  // for size_t
-
-#include "../common/kernel.h"           // for KernelRegistration
-#include "../common/linalg_op.cuh"      // for ElementWiseKernel
-#include "../common/optional_weight.h"  // for MakeOptionalWeights
+#include "elementwise_objective.cuh"  // for elementwise::RegisterGradientCuda
 #include "pseudohuber_obj.h"
 
 namespace xgboost::obj {
 DMLC_REGISTRY_FILE_TAG(pseudohuber_kernel_cuda);
 
-namespace cuda_impl {
-void PseudoHuberGradient(Context const* ctx, HostDeviceVector<float> const& preds,
-                         MetaInfo const& info, bst_target_t n_targets, float slope,
-                         linalg::Matrix<GradientPair>* out_gpair) {
-  auto device = ctx->Device();
-  CHECK(device.IsCUDA());
-
-  preds.SetDevice(device);
-  auto predt = linalg::MakeTensorView(ctx, &preds, info.num_row_, n_targets);
-  auto labels = info.labels.View(device);
-  auto weights = common::MakeOptionalWeights(device, info.weights_);
-
-  out_gpair->SetDevice(device);
-  out_gpair->Reshape(info.num_row_, n_targets);
-  auto gpair = out_gpair->View(device);
-
-  linalg::cuda_impl::ElementWiseKernel(
-      gpair,
-      [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
-        gpair(i, j) = PseudoHuberLoss::Gradient(predt(i, j), labels(i, j), weights[i], slope);
-      },
-      ctx->CUDACtx()->Stream());
-}
-}  // namespace cuda_impl
-
 namespace {
-common::KernelRegistration<PseudoHuberGradientKernel> const kRegisterPseudoHuberGradientCuda{
-    DeviceOrd::kCUDA, &cuda_impl::PseudoHuberGradient};
+auto const kRegisterPseudoHuberGradientCuda =
+    elementwise::RegisterGradientCuda<PseudoHuberGradient>();
 }  // namespace
 }  // namespace xgboost::obj

--- a/src/objective/pseudohuber_obj.h
+++ b/src/objective/pseudohuber_obj.h
@@ -8,15 +8,14 @@
 
 #include <cmath>  // for sqrtf
 
-#include "xgboost/base.h"                // for GradientPair, bst_target_t
-#include "xgboost/context.h"             // for Context
-#include "xgboost/data.h"                // for MetaInfo
-#include "xgboost/host_device_vector.h"  // for HostDeviceVector
-#include "xgboost/linalg.h"              // for Matrix
+#include "elementwise_objective.h"  // for elementwise::GradientKernel
+#include "xgboost/base.h"           // for GradientPair
 
 namespace xgboost::obj {
-struct PseudoHuberLoss {
-  XGBOOST_DEVICE static GradientPair Gradient(float predt, float label, float weight, float slope) {
+struct PseudoHuberGradient {
+  float slope;
+
+  XGBOOST_DEVICE GradientPair operator()(float predt, float label, float weight) const {
     auto z = predt - label;
     auto slope_sq = slope * slope;
     auto z_sq = z * z;
@@ -28,10 +27,7 @@ struct PseudoHuberLoss {
   }
 };
 
-struct PseudoHuberGradientKernel {
-  using Signature = void(Context const*, HostDeviceVector<float> const&, MetaInfo const&,
-                         bst_target_t, float, linalg::Matrix<GradientPair>*);
-};
+using PseudoHuberGradientKernel = elementwise::GradientKernel<PseudoHuberGradient>;
 }  // namespace xgboost::obj
 
 #endif  // XGBOOST_OBJECTIVE_PSEUDOHUBER_OBJ_H_

--- a/src/objective/pseudohuber_obj.h
+++ b/src/objective/pseudohuber_obj.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file pseudohuber_obj.h
+ * \brief Shared declarations for the pseudo-Huber objective.
+ */
+#ifndef XGBOOST_OBJECTIVE_PSEUDOHUBER_OBJ_H_
+#define XGBOOST_OBJECTIVE_PSEUDOHUBER_OBJ_H_
+
+#include <cmath>  // for sqrtf
+
+#include "xgboost/base.h"                // for GradientPair, bst_target_t
+#include "xgboost/context.h"             // for Context
+#include "xgboost/data.h"                // for MetaInfo
+#include "xgboost/host_device_vector.h"  // for HostDeviceVector
+#include "xgboost/linalg.h"              // for Matrix
+
+namespace xgboost::obj {
+struct PseudoHuberLoss {
+  XGBOOST_DEVICE static GradientPair Gradient(float predt, float label, float weight, float slope) {
+    auto z = predt - label;
+    auto slope_sq = slope * slope;
+    auto z_sq = z * z;
+    auto scale_sqrt = sqrtf(1.0f + z_sq / slope_sq);
+    auto grad = z / scale_sqrt;
+    auto scale = slope_sq + z_sq;
+    auto hess = slope_sq / (scale * scale_sqrt);
+    return {grad * weight, hess * weight};
+  }
+};
+
+struct PseudoHuberGradientKernel {
+  using Signature = void(Context const*, HostDeviceVector<float> const&, MetaInfo const&,
+                         bst_target_t, float, linalg::Matrix<GradientPair>*);
+};
+}  // namespace xgboost::obj
+
+#endif  // XGBOOST_OBJECTIVE_PSEUDOHUBER_OBJ_H_

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -18,7 +18,6 @@
 #include "../common/linalg_op.h"             // for ElementWiseKernel
 #include "../common/numeric.h"               // for Reduce
 #include "../common/optional_weight.h"       // for MakeOptionalWeights
-#include "../common/pseudo_huber.h"
 #include "../common/stats.h"
 #include "../common/threading_utils.h"
 #include "../common/transform.h"
@@ -324,74 +323,6 @@ class SquaredLogErrorRegression : public FitIntercept {
 XGBOOST_REGISTER_OBJECTIVE(SquaredLogErrorRegression, SquaredLogErrorRegression::Name())
     .describe("Root mean squared log error.")
     .set_body([]() { return new SquaredLogErrorRegression(); });
-
-class PseudoHuberRegression : public FitIntercept {
-  PseudoHuberParam param_;
-
- public:
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
-  [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
-  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
-    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
-  }
-
-  void GetGradient(HostDeviceVector<bst_float> const& preds, const MetaInfo& info, int /*iter*/,
-                   linalg::Matrix<GradientPair>* out_gpair) override {
-    CheckRegInputs(info, preds);
-    auto slope = param_.huber_slope;
-    CHECK_NE(slope, 0.0) << "slope for pseudo huber cannot be 0.";
-    auto labels = info.labels.View(ctx_->Device());
-
-    out_gpair->SetDevice(ctx_->Device());
-    out_gpair->Reshape(info.num_row_, this->Targets(info));
-    auto gpair = out_gpair->View(ctx_->Device());
-
-    preds.SetDevice(ctx_->Device());
-    auto predt = linalg::MakeTensorView(ctx_, &preds, info.num_row_, this->Targets(info));
-
-    auto weight = common::MakeOptionalWeights(ctx_->Device(), info.weights_);
-    linalg::ElementWiseKernel(
-        ctx_, labels, [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
-          float z = predt(i, j) - labels(i, j);
-          float scale_sqrt = std::sqrt(1 + common::Sqr(z) / common::Sqr(slope));
-          float grad = z / scale_sqrt;
-
-          auto scale = common::Sqr(slope) + common::Sqr(z);
-          float hess = common::Sqr(slope) / (scale * scale_sqrt);
-
-          auto w = weight[i];
-          gpair(i, j) = {grad * w, hess * w};
-        });
-  }
-
-  [[nodiscard]] const char* DefaultEvalMetric() const override { return "mphe"; }
-
-  void SaveConfig(Json* p_out) const override {
-    auto& out = *p_out;
-    out["name"] = String("reg:pseudohubererror");
-    out["pseudo_huber_param"] = ToJson(param_);
-  }
-
-  void LoadConfig(Json const& in) override {
-    auto const& config = get<Object const>(in);
-    if (config.find("pseudo_huber_param") == config.cend()) {
-      // The parameter is added in 1.6.
-      return;
-    }
-    FromJson(in["pseudo_huber_param"], &param_);
-  }
-  [[nodiscard]] Json DefaultMetricConfig() const override {
-    CHECK(param_.GetInitialised());
-    Json config{Object{}};
-    config["name"] = String{this->DefaultEvalMetric()};
-    config["pseudo_huber_param"] = ToJson(param_);
-    return config;
-  }
-};
-
-XGBOOST_REGISTER_OBJECTIVE(PseudoHuberRegression, "reg:pseudohubererror")
-    .describe("Regression Pseudo Huber error.")
-    .set_body([]() { return new PseudoHuberRegression(); });
 
 class ExpectileRegression : public FitIntercept {
   common::ExpectileLossParam param_;


### PR DESCRIPTION
## Summary

Follow up on #12411 by applying the typed device-kernel dispatch to `reg:pseudohubererror`.

- Move the objective and CPU gradient implementation into `pseudohuber_obj.cc`.
- Define the shared loss calculation and typed kernel signature in `pseudohuber_obj.h`.
- Put only the CUDA gradient implementation and registration in `pseudohuber_obj.cu`.
- Remove the pseudo-Huber implementation from the combined `regression_obj.cu` translation unit.
- Force-link the CPU and CUDA registration translation units for static builds.

## Why

The pseudo-Huber objective was compiled through the combined `.cu` objective file even though its control flow is device-independent. This change gives it the same CPU/CUDA boundary as the hinge objective while retaining its parameterized gradient behavior.

A SYCL context has no pseudo-Huber-specific code in core XGBoost and uses the registered CPU implementation through the dispatch fallback introduced in #12411.

There is no user-facing behavior or configuration change.

## Testing

- Repository pre-commit checks on all changed files
- `clang-format`
- C++ lint
- CPU `testxgboost` build
- `Objective.PseudoHuber`
- Direct compilation of `pseudohuber_obj.cc` with the CUDA build configuration
- Direct compilation of `pseudohuber_obj.cu` with CUDA 12.9
- `git diff --check`
