### PR TITLE
Split gamma and squared-log objective kernels

### DIFF
--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -49,9 +49,11 @@ OBJECTS= \
     $(PKGROOT)/src/objective/regression_obj.o \
     $(PKGROOT)/src/objective/multiclass_obj.o \
     $(PKGROOT)/src/objective/lambdarank_obj.o \
+    $(PKGROOT)/src/objective/gamma_obj.o \
     $(PKGROOT)/src/objective/hinge.o \
     $(PKGROOT)/src/objective/poisson_obj.o \
     $(PKGROOT)/src/objective/pseudohuber_obj.o \
+    $(PKGROOT)/src/objective/squared_log_obj.o \
     $(PKGROOT)/src/objective/tweedie_obj.o \
     $(PKGROOT)/src/objective/aft_obj.o \
     $(PKGROOT)/src/objective/init_estimation.o \

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -48,9 +48,11 @@ OBJECTS= \
     $(PKGROOT)/src/objective/regression_obj.o \
     $(PKGROOT)/src/objective/multiclass_obj.o \
     $(PKGROOT)/src/objective/lambdarank_obj.o \
+    $(PKGROOT)/src/objective/gamma_obj.o \
     $(PKGROOT)/src/objective/hinge.o \
     $(PKGROOT)/src/objective/poisson_obj.o \
     $(PKGROOT)/src/objective/pseudohuber_obj.o \
+    $(PKGROOT)/src/objective/squared_log_obj.o \
     $(PKGROOT)/src/objective/tweedie_obj.o \
     $(PKGROOT)/src/objective/aft_obj.o \
     $(PKGROOT)/src/objective/init_estimation.o \

--- a/src/objective/gamma_obj.cc
+++ b/src/objective/gamma_obj.cc
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file gamma_obj.cc
+ * \brief CPU implementation and registration of the gamma objective.
+ */
+#include "gamma_obj.h"
+
+#include <dmlc/registry.h>
+
+#include <algorithm>  // for all_of, max
+#include <cmath>      // for abs
+#include <cstddef>    // for size_t
+#include <cstdint>    // for int32_t
+
+#include "../common/kernel.h"   // for DispatchKernel
+#include "init_estimation.h"    // for CheckInitInputs, FitIntercept, FitInterceptGlmLike
+#include "regression_param.h"   // for RegLossParam
+#include "xgboost/json.h"       // for FromJson, Json, Object, String, ToJson
+#include "xgboost/logging.h"    // for CHECK, LOG
+#include "xgboost/objective.h"  // for ObjFunction
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(gamma_obj);
+
+namespace {
+auto const kRegisterGammaGradientCpu = elementwise::RegisterGradientCpu<GammaGradient>();
+auto const kRegisterGammaPredTransformCpu = elementwise::RegisterTransformCpu<GammaPredTransform>();
+auto const kRegisterGammaProbToMarginCpu = elementwise::RegisterTransformCpu<GammaProbToMargin>();
+auto const kRegisterGammaValidationCpu = elementwise::RegisterValidationCpu<GammaLabelCheck>();
+}  // namespace
+
+class GammaRegression : public FitInterceptGlmLike {
+ public:
+  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
+  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
+    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
+  }
+
+  void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info, std::int32_t iter,
+                   linalg::Matrix<GradientPair>* out_gpair) override {
+    CheckInitInputs(info);
+    CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
+    if (iter == 0) {
+      auto valid =
+          common::DispatchKernel<GammaValidationKernel>(ctx_, info.labels, GammaLabelCheck{});
+      if (!valid) {
+        LOG(FATAL) << GammaDeviance::LabelErrorMsg();
+      }
+      if (!info.weights_.Empty()) {
+        CHECK_EQ(info.weights_.Size(), info.num_row_)
+            << "Number of weights should be equal to the number of data points.";
+      }
+    }
+    common::DispatchKernel<GammaGradientKernel>(ctx_, preds, info, this->Targets(info),
+                                                GammaGradient{param_.scale_pos_weight}, out_gpair);
+  }
+
+  void PredTransform(HostDeviceVector<float>* io_preds) const override {
+    common::DispatchKernel<GammaPredTransformKernel>(ctx_, io_preds, GammaPredTransform{});
+  }
+
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
+    if (std::abs(param_.scale_pos_weight - 1.0f) > kRtEps) {
+      FitIntercept::InitEstimation(info, base_score);
+    } else {
+      FitInterceptGlmLike::InitEstimation(info, base_score);
+    }
+  }
+
+  void ProbToMargin(linalg::Vector<float>* base_score) const override {
+    auto intercept = base_score->HostView();
+    auto valid = std::all_of(linalg::cbegin(intercept), linalg::cend(intercept),
+                             [](float value) { return GammaDeviance::CheckIntercept(value); });
+    CHECK(valid) << GammaDeviance::InterceptErrorMsg();
+    common::DispatchKernel<GammaProbToMarginKernel>(ctx_, base_score->Data(), GammaProbToMargin{});
+  }
+
+  [[nodiscard]] const char* DefaultEvalMetric() const override { return "gamma-deviance"; }
+
+  void SaveConfig(Json* p_out) const override {
+    auto& out = *p_out;
+    out["name"] = String(GammaDeviance::Name());
+    out["reg_loss_param"] = ToJson(param_);
+  }
+
+  void LoadConfig(Json const& in) override {
+    auto obj = get<Object const>(in);
+    auto it = obj.find("reg_loss_param");
+    if (it != obj.cend()) {
+      FromJson(it->second, &param_);
+    }
+  }
+
+ private:
+  RegLossParam param_;
+};
+
+XGBOOST_REGISTER_OBJECTIVE(GammaRegression, GammaDeviance::Name())
+    .describe("Gamma regression using the gamma deviance loss with log link.")
+    .set_body([]() { return new GammaRegression(); });
+}  // namespace xgboost::obj

--- a/src/objective/gamma_obj.cu
+++ b/src/objective/gamma_obj.cu
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file gamma_obj.cu
+ * \brief CUDA implementations of the gamma objective kernels.
+ */
+#include <dmlc/registry.h>
+
+#include "elementwise_objective.cuh"
+#include "gamma_obj.h"
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(gamma_kernel_cuda);
+namespace {
+auto const kRegisterGammaGradientCuda = elementwise::RegisterGradientCuda<GammaGradient>();
+auto const kRegisterGammaPredTransformCuda =
+    elementwise::RegisterTransformCuda<GammaPredTransform>();
+auto const kRegisterGammaProbToMarginCuda = elementwise::RegisterTransformCuda<GammaProbToMargin>();
+auto const kRegisterGammaValidationCuda = elementwise::RegisterValidationCuda<GammaLabelCheck>();
+}  // namespace
+}  // namespace xgboost::obj

--- a/src/objective/gamma_obj.h
+++ b/src/objective/gamma_obj.h
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file gamma_obj.h
+ * \brief Shared declarations for the gamma objective.
+ */
+#ifndef XGBOOST_OBJECTIVE_GAMMA_OBJ_H_
+#define XGBOOST_OBJECTIVE_GAMMA_OBJ_H_
+
+#include <cmath>  // for expf, log
+
+#include "elementwise_objective.h"  // for elementwise kernels
+#include "xgboost/base.h"           // for GradientPair
+#include "xgboost/string_view.h"    // for StringView
+
+namespace xgboost::obj {
+class GammaDeviance {
+ public:
+  constexpr static StringView InterceptErrorMsg() {
+    return "`base_score` must be greater than 0 for gamma regression";
+  }
+  XGBOOST_DEVICE static bool CheckIntercept(float base_score) { return base_score > 0; }
+  XGBOOST_DEVICE static float FirstOrderGradient(float predt, float label) {
+    return 1.0f - label / predt;
+  }
+  XGBOOST_DEVICE static float SecondOrderGradient(float predt, float label) {
+    return label / predt;
+  }
+  static char const* Name() { return "reg:gamma"; }
+  XGBOOST_DEVICE static bool CheckLabel(float label) { return label > 0.0f; }
+  static char const* LabelErrorMsg() { return "label must be positive for gamma regression."; }
+};
+
+struct GammaGradient {
+  float scale_pos_weight;
+
+  XGBOOST_DEVICE GradientPair operator()(float predt, float label, float weight) const {
+    if (label == 1.0f) {
+      weight *= scale_pos_weight;
+    }
+    auto prediction = expf(predt);
+    auto grad = GammaDeviance::FirstOrderGradient(prediction, label);
+    auto hess = GammaDeviance::SecondOrderGradient(prediction, label);
+    return {grad * weight, hess * weight};
+  }
+};
+
+struct GammaPredTransform {
+  XGBOOST_DEVICE float operator()(float value) const { return expf(value); }
+};
+struct GammaProbToMargin {
+  XGBOOST_DEVICE float operator()(float value) const { return std::log(value); }
+};
+struct GammaLabelCheck {
+  XGBOOST_DEVICE bool operator()(float value) const { return GammaDeviance::CheckLabel(value); }
+};
+
+using GammaGradientKernel = elementwise::GradientKernel<GammaGradient>;
+using GammaPredTransformKernel = elementwise::TransformKernel<GammaPredTransform>;
+using GammaProbToMarginKernel = elementwise::TransformKernel<GammaProbToMargin>;
+using GammaValidationKernel = elementwise::ValidationKernel<GammaLabelCheck>;
+}  // namespace xgboost::obj
+
+#endif  // XGBOOST_OBJECTIVE_GAMMA_OBJ_H_

--- a/src/objective/objective.cc
+++ b/src/objective/objective.cc
@@ -41,16 +41,20 @@ void ObjFunction::InitEstimation(MetaInfo const& info, linalg::Vector<float>* ba
 namespace xgboost {
 namespace obj {
 // List of files that will be force linked in static links.
+DMLC_REGISTRY_LINK_TAG(gamma_obj);
 DMLC_REGISTRY_LINK_TAG(hinge_obj);
 DMLC_REGISTRY_LINK_TAG(poisson_obj);
 DMLC_REGISTRY_LINK_TAG(pseudohuber_obj);
+DMLC_REGISTRY_LINK_TAG(squared_log_obj);
 DMLC_REGISTRY_LINK_TAG(tweedie_obj);
 #ifdef XGBOOST_USE_CUDA
 DMLC_REGISTRY_LINK_TAG(regression_obj_gpu);
 DMLC_REGISTRY_LINK_TAG(quantile_obj_gpu);
+DMLC_REGISTRY_LINK_TAG(gamma_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(hinge_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(poisson_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(pseudohuber_kernel_cuda);
+DMLC_REGISTRY_LINK_TAG(squared_log_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(tweedie_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(multiclass_obj_gpu);
 DMLC_REGISTRY_LINK_TAG(lambdarank_obj);

--- a/src/objective/regression_loss.h
+++ b/src/objective/regression_loss.h
@@ -32,34 +32,6 @@ struct LinearSquareLoss {
   static ObjInfo Info() { return {ObjInfo::kRegression, true}; }
 };
 
-struct SquaredLogError {
-  XGBOOST_DEVICE static bst_float PredTransform(bst_float x) { return x; }
-  XGBOOST_DEVICE static bool CheckLabel(bst_float label) { return label > -1; }
-  XGBOOST_DEVICE static bst_float FirstOrderGradient(bst_float predt, bst_float label) {
-    predt = fmaxf(predt, -1 + 1e-6);  // ensure correct value for log1p
-    return (std::log1p(predt) - std::log1p(label)) / (predt + 1);
-  }
-  XGBOOST_DEVICE static bst_float SecondOrderGradient(bst_float predt, bst_float label) {
-    predt = fmaxf(predt, -1 + 1e-6);
-    float res = (-std::log1p(predt) + std::log1p(label) + 1) / std::pow(predt + 1, 2);
-    res = fmaxf(res, 1e-6f);
-    return res;
-  }
-
-  XGBOOST_DEVICE static float ProbToMargin(float base_score) { return base_score; }
-  constexpr static StringView InterceptErrorMsg() { return ""; }
-  XGBOOST_DEVICE static bool CheckIntercept(float) { return true; }
-
-  static const char* LabelErrorMsg() {
-    return "label must be greater than -1 for rmsle so that log(label + 1) can be valid.";
-  }
-  static const char* DefaultEvalMetric() { return "rmsle"; }
-
-  static const char* Name() { return "reg:squaredlogerror"; }
-
-  static ObjInfo Info() { return ObjInfo::kRegression; }
-};
-
 // logistic loss for probability regression task
 struct LogisticRegression {
   XGBOOST_DEVICE static bst_float PredTransform(bst_float x) { return common::Sigmoid(x); }
@@ -122,26 +94,6 @@ struct LogisticRaw : public LogisticRegression {
   static const char* Name() { return "binary:logitraw"; }
 
   static ObjInfo Info() { return ObjInfo::kRegression; }
-};
-
-// gamma deviance loss.
-class GammaDeviance {
- public:
-  XGBOOST_DEVICE static float PredTransform(float x) { return std::exp(x); }
-
-  XGBOOST_DEVICE static float ProbToMargin(float x) { return std::log(x); }
-  constexpr static StringView InterceptErrorMsg() {
-    return "`base_score` must be greater than 0 for gamma regression";
-  }
-  XGBOOST_DEVICE static bool CheckIntercept(float base_score) { return base_score > 0; }
-
-  XGBOOST_DEVICE static float FirstOrderGradient(float p, float y) { return 1.0f - y / p; }
-  XGBOOST_DEVICE static float SecondOrderGradient(float p, float y) { return y / p; }
-  static ObjInfo Info() { return ObjInfo::kRegression; }
-  static const char* Name() { return "reg:gamma"; }
-  static const char* DefaultEvalMetric() { return "gamma-deviance"; }
-  XGBOOST_DEVICE static bool CheckLabel(float x) { return x > 0.0f; }
-  static const char* LabelErrorMsg() { return "label must be positive for gamma regression."; }
 };
 
 // Label validation for Poisson regression (labels must be non-negative)

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -263,10 +263,6 @@ XGBOOST_REGISTER_OBJECTIVE(LogisticRaw, LogisticRaw::Name())
         "before logistic transformation.")
     .set_body([]() { return new RegLossObj<LogisticRaw>(); });
 
-XGBOOST_REGISTER_OBJECTIVE(GammaRegression, GammaDeviance::Name())
-    .describe("Gamma regression using the gamma deviance loss with log link.")
-    .set_body([]() { return new RegLossObj<GammaDeviance>(); });
-
 // Deprecated functions
 XGBOOST_REGISTER_OBJECTIVE(LinearRegression, "reg:linear")
     .describe("Regression with squared error.")
@@ -275,54 +271,6 @@ XGBOOST_REGISTER_OBJECTIVE(LinearRegression, "reg:linear")
       return new RegLossObj<LinearSquareLoss>();
     });
 // End deprecated
-
-class SquaredLogErrorRegression : public FitIntercept {
- public:
-  static auto Name() { return SquaredLogError::Name(); }
-
-  void Configure(Args const&) override {}
-  [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
-  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
-    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
-  }
-  void GetGradient(HostDeviceVector<bst_float> const& preds, const MetaInfo& info,
-                   std::int32_t iter, linalg::Matrix<GradientPair>* out_gpair) override {
-    CheckRegInputs(info, preds);
-    if (iter == 0) {
-      ValidateLabel<SquaredLogError>(this->ctx_, info);
-    }
-    auto labels = info.labels.View(ctx_->Device());
-
-    out_gpair->SetDevice(ctx_->Device());
-    out_gpair->Reshape(info.num_row_, this->Targets(info));
-    auto gpair = out_gpair->View(ctx_->Device());
-
-    preds.SetDevice(ctx_->Device());
-    auto predt = linalg::MakeTensorView(ctx_, &preds, info.num_row_, this->Targets(info));
-
-    auto weight = common::MakeOptionalWeights(ctx_->Device(), info.weights_);
-    linalg::ElementWiseKernel(this->ctx_, labels,
-                              [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
-                                auto p = predt(i, j);
-                                auto y = labels(i, j);
-                                auto w = weight[i];
-                                auto grad = SquaredLogError::FirstOrderGradient(p, y);
-                                auto hess = SquaredLogError::SecondOrderGradient(p, y);
-                                gpair(i, j) = {grad * w, hess * w};
-                              });
-  }
-  [[nodiscard]] const char* DefaultEvalMetric() const override { return "rmsle"; }
-
-  void SaveConfig(Json* p_out) const override {
-    auto& out = *p_out;
-    out["name"] = String(Name());
-  }
-  void LoadConfig(Json const&) override {}
-};
-
-XGBOOST_REGISTER_OBJECTIVE(SquaredLogErrorRegression, SquaredLogErrorRegression::Name())
-    .describe("Root mean squared log error.")
-    .set_body([]() { return new SquaredLogErrorRegression(); });
 
 class ExpectileRegression : public FitIntercept {
   common::ExpectileLossParam param_;

--- a/src/objective/squared_log_obj.cc
+++ b/src/objective/squared_log_obj.cc
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file squared_log_obj.cc
+ * \brief CPU implementation and registration of the squared-log objective.
+ */
+#include "squared_log_obj.h"
+
+#include <dmlc/registry.h>
+
+#include <algorithm>  // for max
+#include <cstddef>    // for size_t
+#include <cstdint>    // for int32_t
+
+#include "../common/kernel.h"   // for DispatchKernel
+#include "init_estimation.h"    // for CheckInitInputs, FitIntercept
+#include "xgboost/json.h"       // for Json, String
+#include "xgboost/logging.h"    // for CHECK, LOG
+#include "xgboost/objective.h"  // for ObjFunction
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(squared_log_obj);
+
+namespace {
+auto const kRegisterSquaredLogGradientCpu = elementwise::RegisterGradientCpu<SquaredLogGradient>();
+auto const kRegisterSquaredLogValidationCpu =
+    elementwise::RegisterValidationCpu<SquaredLogLabelCheck>();
+}  // namespace
+
+class SquaredLogErrorRegression : public FitIntercept {
+ public:
+  void Configure(Args const&) override {}
+  [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
+  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
+    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
+  }
+
+  void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info, std::int32_t iter,
+                   linalg::Matrix<GradientPair>* out_gpair) override {
+    CheckInitInputs(info);
+    CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
+    if (iter == 0) {
+      auto valid = common::DispatchKernel<SquaredLogValidationKernel>(ctx_, info.labels,
+                                                                      SquaredLogLabelCheck{});
+      if (!valid) {
+        LOG(FATAL) << SquaredLogError::LabelErrorMsg();
+      }
+      if (!info.weights_.Empty()) {
+        CHECK_EQ(info.weights_.Size(), info.num_row_)
+            << "Number of weights should be equal to the number of data points.";
+      }
+    }
+    common::DispatchKernel<SquaredLogGradientKernel>(ctx_, preds, info, this->Targets(info),
+                                                     SquaredLogGradient{}, out_gpair);
+  }
+
+  [[nodiscard]] const char* DefaultEvalMetric() const override { return "rmsle"; }
+
+  void SaveConfig(Json* p_out) const override {
+    auto& out = *p_out;
+    out["name"] = String(SquaredLogError::Name());
+  }
+  void LoadConfig(Json const&) override {}
+};
+
+XGBOOST_REGISTER_OBJECTIVE(SquaredLogErrorRegression, SquaredLogError::Name())
+    .describe("Root mean squared log error.")
+    .set_body([]() { return new SquaredLogErrorRegression(); });
+}  // namespace xgboost::obj

--- a/src/objective/squared_log_obj.cu
+++ b/src/objective/squared_log_obj.cu
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file squared_log_obj.cu
+ * \brief CUDA implementations of the squared-log objective kernels.
+ */
+#include <dmlc/registry.h>
+
+#include "elementwise_objective.cuh"
+#include "squared_log_obj.h"
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(squared_log_kernel_cuda);
+namespace {
+auto const kRegisterSquaredLogGradientCuda =
+    elementwise::RegisterGradientCuda<SquaredLogGradient>();
+auto const kRegisterSquaredLogValidationCuda =
+    elementwise::RegisterValidationCuda<SquaredLogLabelCheck>();
+}  // namespace
+}  // namespace xgboost::obj

--- a/src/objective/squared_log_obj.h
+++ b/src/objective/squared_log_obj.h
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file squared_log_obj.h
+ * \brief Shared declarations for the squared-log objective.
+ */
+#ifndef XGBOOST_OBJECTIVE_SQUARED_LOG_OBJ_H_
+#define XGBOOST_OBJECTIVE_SQUARED_LOG_OBJ_H_
+
+#include <cmath>  // for fmaxf, log1p, pow
+
+#include "elementwise_objective.h"  // for elementwise kernels
+#include "xgboost/base.h"           // for GradientPair
+
+namespace xgboost::obj {
+struct SquaredLogError {
+  XGBOOST_DEVICE static bool CheckLabel(float label) { return label > -1.0f; }
+  XGBOOST_DEVICE static float FirstOrderGradient(float predt, float label) {
+    predt = fmaxf(predt, -1.0f + 1e-6f);
+    return (std::log1p(predt) - std::log1p(label)) / (predt + 1.0f);
+  }
+  XGBOOST_DEVICE static float SecondOrderGradient(float predt, float label) {
+    predt = fmaxf(predt, -1.0f + 1e-6f);
+    auto hess = (-std::log1p(predt) + std::log1p(label) + 1.0f) / std::pow(predt + 1.0f, 2.0f);
+    return fmaxf(hess, 1e-6f);
+  }
+  static char const* LabelErrorMsg() {
+    return "label must be greater than -1 for rmsle so that log(label + 1) can be valid.";
+  }
+  static char const* Name() { return "reg:squaredlogerror"; }
+};
+
+struct SquaredLogGradient {
+  XGBOOST_DEVICE GradientPair operator()(float predt, float label, float weight) const {
+    auto grad = SquaredLogError::FirstOrderGradient(predt, label);
+    auto hess = SquaredLogError::SecondOrderGradient(predt, label);
+    return {grad * weight, hess * weight};
+  }
+};
+
+struct SquaredLogLabelCheck {
+  XGBOOST_DEVICE bool operator()(float value) const { return SquaredLogError::CheckLabel(value); }
+};
+
+using SquaredLogGradientKernel = elementwise::GradientKernel<SquaredLogGradient>;
+using SquaredLogValidationKernel = elementwise::ValidationKernel<SquaredLogLabelCheck>;
+}  // namespace xgboost::obj
+
+#endif  // XGBOOST_OBJECTIVE_SQUARED_LOG_OBJ_H_


### PR DESCRIPTION
## Summary

- split the gamma and squared-log objectives into dedicated `.h`, `.cc`, and `.cu` files
- dispatch their gradient, transform, and validation work through the elementwise objective kernels
- move the now-private gamma deviance and squared-log loss definitions out of `regression_loss.h`
- add static-link tags and R package build entries for the new translation units

## Validation

- `./build/testxgboost --gtest_filter=Objective.*` (32 tests passed)
- compiled the gamma and squared-log CPU and CUDA translation units with CUDA 12.9
- `git diff --check`