### PR TITLE
[doc] Add R tab to DART tutorial

### DIFF
--- a/doc/tutorials/dart.rst
+++ b/doc/tutorials/dart.rst
@@ -95,19 +95,40 @@ Additional parameters are noted below:
 Sample Script
 *************
 
-.. code-block:: python
+.. tabs::
+    .. code-tab:: py
 
-  import xgboost as xgb
-  # read in data
-  dtrain = xgb.DMatrix('demo/data/agaricus.txt.train?format=libsvm')
-  dtest = xgb.DMatrix('demo/data/agaricus.txt.test?format=libsvm')
-  # specify parameters via map
-  param = {'max_depth': 5, 'learning_rate': 0.1,
-           'objective': 'binary:logistic',
-           'sample_type': 'uniform',
-           'normalize_type': 'tree',
-           'rate_drop': 0.1,
-           'skip_drop': 0.5}
-  num_round = 50
-  bst = xgb.train(param, dtrain, num_round)
-  preds = bst.predict(dtest)
+        import xgboost as xgb
+        # read in data
+        dtrain = xgb.DMatrix('demo/data/agaricus.txt.train?format=libsvm')
+        dtest = xgb.DMatrix('demo/data/agaricus.txt.test?format=libsvm')
+        # specify parameters via map
+        param = {'max_depth': 5, 'learning_rate': 0.1,
+                 'objective': 'binary:logistic',
+                 'sample_type': 'uniform',
+                 'normalize_type': 'tree',
+                 'rate_drop': 0.1,
+                 'skip_drop': 0.5}
+        num_round = 50
+        bst = xgb.train(param, dtrain, num_round)
+        preds = bst.predict(dtest)
+
+    .. code-tab:: r R
+
+        library(xgboost)
+        # read in data
+        dtrain <- xgb.DMatrix("demo/data/agaricus.txt.train?format=libsvm")
+        dtest <- xgb.DMatrix("demo/data/agaricus.txt.test?format=libsvm")
+        # specify parameters via list
+        params <- list(
+          max_depth = 5,
+          learning_rate = 0.1,
+          objective = "binary:logistic",
+          sample_type = "uniform",
+          normalize_type = "tree",
+          rate_drop = 0.1,
+          skip_drop = 0.5
+        )
+        num_round <- 50
+        bst <- xgb.train(params = params, data = dtrain, nrounds = num_round)
+        preds <- predict(bst, dtest)


### PR DESCRIPTION
## Summary

- present the existing Python DART sample in a language tab
- add an equivalent R sample using `xgb.DMatrix()` and `xgb.train()`
- keep the parameters and training flow aligned across both languages

Part of #11413.

## Testing

- `git diff --check`
- verified the R parameter names and `xgb.train()` signature against the current R package source
- checked the RST tab structure and end-of-file newline