### PR TITLE
Split squared-error and logistic objective kernels

### DIFF
--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -51,8 +51,10 @@ OBJECTS= \
     $(PKGROOT)/src/objective/lambdarank_obj.o \
     $(PKGROOT)/src/objective/gamma_obj.o \
     $(PKGROOT)/src/objective/hinge.o \
+    $(PKGROOT)/src/objective/logistic_obj.o \
     $(PKGROOT)/src/objective/poisson_obj.o \
     $(PKGROOT)/src/objective/pseudohuber_obj.o \
+    $(PKGROOT)/src/objective/squared_error_obj.o \
     $(PKGROOT)/src/objective/squared_log_obj.o \
     $(PKGROOT)/src/objective/tweedie_obj.o \
     $(PKGROOT)/src/objective/aft_obj.o \

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -50,8 +50,10 @@ OBJECTS= \
     $(PKGROOT)/src/objective/lambdarank_obj.o \
     $(PKGROOT)/src/objective/gamma_obj.o \
     $(PKGROOT)/src/objective/hinge.o \
+    $(PKGROOT)/src/objective/logistic_obj.o \
     $(PKGROOT)/src/objective/poisson_obj.o \
     $(PKGROOT)/src/objective/pseudohuber_obj.o \
+    $(PKGROOT)/src/objective/squared_error_obj.o \
     $(PKGROOT)/src/objective/squared_log_obj.o \
     $(PKGROOT)/src/objective/tweedie_obj.o \
     $(PKGROOT)/src/objective/aft_obj.o \

--- a/src/objective/logistic_obj.cc
+++ b/src/objective/logistic_obj.cc
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file logistic_obj.cc
+ * \brief CPU implementations and registration of logistic objectives.
+ */
+#include "logistic_obj.h"
+
+#include <dmlc/registry.h>
+
+#include <algorithm>  // for all_of, max
+#include <cmath>      // for abs
+#include <cstddef>    // for size_t
+#include <cstdint>    // for int32_t
+
+#include "../common/kernel.h"   // for DispatchKernel
+#include "init_estimation.h"    // for CheckInitInputs, FitIntercept, FitInterceptGlmLike
+#include "regression_param.h"   // for RegLossParam
+#include "xgboost/json.h"       // for FromJson, Json, Object, String, ToJson
+#include "xgboost/logging.h"    // for CHECK, LOG
+#include "xgboost/objective.h"  // for ObjFunction
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(logistic_obj);
+
+namespace {
+auto const kRegisterLogisticGradientCpu = elementwise::RegisterGradientCpu<LogisticGradient>();
+auto const kRegisterLogisticPredTransformCpu =
+    elementwise::RegisterTransformCpu<LogisticPredTransform>();
+auto const kRegisterLogisticProbToMarginCpu =
+    elementwise::RegisterTransformCpu<LogisticProbToMargin>();
+auto const kRegisterLogisticValidationCpu =
+    elementwise::RegisterValidationCpu<LogisticLabelCheck>();
+
+enum class LogisticKind { kRegression, kClassification, kRaw };
+
+template <LogisticKind kKind>
+class LogisticObjective : public FitInterceptGlmLike {
+ public:
+  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  [[nodiscard]] ObjInfo Task() const override {
+    if constexpr (kKind == LogisticKind::kClassification) {
+      return ObjInfo::kBinary;
+    }
+    return ObjInfo::kRegression;
+  }
+  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
+    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
+  }
+
+  void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info, std::int32_t iter,
+                   linalg::Matrix<GradientPair>* out_gpair) override {
+    CheckInitInputs(info);
+    CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
+    if (iter == 0) {
+      auto valid =
+          common::DispatchKernel<LogisticValidationKernel>(ctx_, info.labels, LogisticLabelCheck{});
+      if (!valid) {
+        LOG(FATAL) << "label must be in [0,1] for logistic regression";
+      }
+      if (!info.weights_.Empty()) {
+        CHECK_EQ(info.weights_.Size(), info.num_row_)
+            << "Number of weights should be equal to the number of data points.";
+      }
+    }
+    common::DispatchKernel<LogisticGradientKernel>(ctx_, preds, info, this->Targets(info),
+                                                   LogisticGradient{param_.scale_pos_weight},
+                                                   out_gpair);
+  }
+
+  void PredTransform(HostDeviceVector<float>* io_preds) const override {
+    if constexpr (kKind != LogisticKind::kRaw) {
+      common::DispatchKernel<LogisticPredTransformKernel>(ctx_, io_preds, LogisticPredTransform{});
+    }
+  }
+
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
+    if (std::abs(param_.scale_pos_weight - 1.0f) > kRtEps) {
+      FitIntercept::InitEstimation(info, base_score);
+    } else {
+      FitInterceptGlmLike::InitEstimation(info, base_score);
+    }
+  }
+
+  void ProbToMargin(linalg::Vector<float>* base_score) const override {
+    if constexpr (kKind != LogisticKind::kRaw) {
+      auto intercept = base_score->HostView();
+      auto valid = std::all_of(linalg::cbegin(intercept), linalg::cend(intercept),
+                               [](float value) { return value >= 0.0f && value <= 1.0f; });
+      CHECK(valid) << "base_score must be in (0,1) for the logistic loss.";
+      common::DispatchKernel<LogisticProbToMarginKernel>(ctx_, base_score->Data(),
+                                                         LogisticProbToMargin{});
+    }
+  }
+
+  [[nodiscard]] const char* DefaultEvalMetric() const override {
+    if constexpr (kKind == LogisticKind::kRegression) {
+      return "rmse";
+    }
+    return "logloss";
+  }
+
+  void SaveConfig(Json* p_out) const override {
+    auto& out = *p_out;
+    out["name"] = String{Name()};
+    out["reg_loss_param"] = ToJson(param_);
+  }
+  void LoadConfig(Json const& in) override {
+    auto obj = get<Object const>(in);
+    auto it = obj.find("reg_loss_param");
+    if (it != obj.cend()) {
+      FromJson(it->second, &param_);
+    }
+  }
+
+  static char const* Name() {
+    if constexpr (kKind == LogisticKind::kRegression) {
+      return "reg:logistic";
+    } else if constexpr (kKind == LogisticKind::kClassification) {
+      return "binary:logistic";
+    } else {
+      return "binary:logitraw";
+    }
+  }
+
+ private:
+  RegLossParam param_;
+};
+}  // namespace
+
+using LogisticRegression = LogisticObjective<LogisticKind::kRegression>;
+using LogisticClassification = LogisticObjective<LogisticKind::kClassification>;
+using LogisticRaw = LogisticObjective<LogisticKind::kRaw>;
+
+XGBOOST_REGISTER_OBJECTIVE(LogisticRegression, LogisticRegression::Name())
+    .describe("Logistic regression for probability regression task.")
+    .set_body([]() { return new LogisticRegression(); });
+
+XGBOOST_REGISTER_OBJECTIVE(LogisticClassification, LogisticClassification::Name())
+    .describe("Logistic regression for binary classification task.")
+    .set_body([]() { return new LogisticClassification(); });
+
+XGBOOST_REGISTER_OBJECTIVE(LogisticRaw, LogisticRaw::Name())
+    .describe(
+        "Logistic regression for classification, output score "
+        "before logistic transformation.")
+    .set_body([]() { return new LogisticRaw(); });
+}  // namespace xgboost::obj

--- a/src/objective/logistic_obj.cu
+++ b/src/objective/logistic_obj.cu
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file logistic_obj.cu
+ * \brief CUDA implementations of logistic objective kernels.
+ */
+#include <dmlc/registry.h>
+
+#include "elementwise_objective.cuh"
+#include "logistic_obj.h"
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(logistic_kernel_cuda);
+namespace {
+auto const kRegisterLogisticGradientCuda = elementwise::RegisterGradientCuda<LogisticGradient>();
+auto const kRegisterLogisticPredTransformCuda =
+    elementwise::RegisterTransformCuda<LogisticPredTransform>();
+auto const kRegisterLogisticProbToMarginCuda =
+    elementwise::RegisterTransformCuda<LogisticProbToMargin>();
+auto const kRegisterLogisticValidationCuda =
+    elementwise::RegisterValidationCuda<LogisticLabelCheck>();
+}  // namespace
+}  // namespace xgboost::obj

--- a/src/objective/logistic_obj.h
+++ b/src/objective/logistic_obj.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file logistic_obj.h
+ * \brief Shared declarations for logistic objectives.
+ */
+#ifndef XGBOOST_OBJECTIVE_LOGISTIC_OBJ_H_
+#define XGBOOST_OBJECTIVE_LOGISTIC_OBJ_H_
+
+#include <cmath>  // for fmaxf
+
+#include "../common/common.h"       // for Min, Max
+#include "../common/math.h"         // for Logit, Sigmoid
+#include "elementwise_objective.h"  // for elementwise kernels
+#include "xgboost/base.h"           // for GradientPair
+
+namespace xgboost::obj {
+struct LogisticGradient {
+  float scale_pos_weight;
+
+  XGBOOST_DEVICE GradientPair operator()(float predt, float label, float weight) const {
+    auto prediction = common::Sigmoid(predt);
+    if (label == 1.0f) {
+      weight *= scale_pos_weight;
+    }
+    auto hess = fmaxf(prediction * (1.0f - prediction), 1e-16f);
+    return {(prediction - label) * weight, hess * weight};
+  }
+};
+
+struct LogisticPredTransform {
+  XGBOOST_DEVICE float operator()(float value) const { return common::Sigmoid(value); }
+};
+struct LogisticProbToMargin {
+  XGBOOST_DEVICE float operator()(float value) const {
+    value = common::Min(common::Max(value, kRtEps), 1.0f - kRtEps);
+    return common::Logit(value);
+  }
+};
+struct LogisticLabelCheck {
+  XGBOOST_DEVICE bool operator()(float value) const { return value >= 0.0f && value <= 1.0f; }
+};
+
+using LogisticGradientKernel = elementwise::GradientKernel<LogisticGradient>;
+using LogisticPredTransformKernel = elementwise::TransformKernel<LogisticPredTransform>;
+using LogisticProbToMarginKernel = elementwise::TransformKernel<LogisticProbToMargin>;
+using LogisticValidationKernel = elementwise::ValidationKernel<LogisticLabelCheck>;
+}  // namespace xgboost::obj
+
+#endif  // XGBOOST_OBJECTIVE_LOGISTIC_OBJ_H_

--- a/src/objective/objective.cc
+++ b/src/objective/objective.cc
@@ -43,8 +43,10 @@ namespace obj {
 // List of files that will be force linked in static links.
 DMLC_REGISTRY_LINK_TAG(gamma_obj);
 DMLC_REGISTRY_LINK_TAG(hinge_obj);
+DMLC_REGISTRY_LINK_TAG(logistic_obj);
 DMLC_REGISTRY_LINK_TAG(poisson_obj);
 DMLC_REGISTRY_LINK_TAG(pseudohuber_obj);
+DMLC_REGISTRY_LINK_TAG(squared_error_obj);
 DMLC_REGISTRY_LINK_TAG(squared_log_obj);
 DMLC_REGISTRY_LINK_TAG(tweedie_obj);
 #ifdef XGBOOST_USE_CUDA
@@ -52,8 +54,10 @@ DMLC_REGISTRY_LINK_TAG(regression_obj_gpu);
 DMLC_REGISTRY_LINK_TAG(quantile_obj_gpu);
 DMLC_REGISTRY_LINK_TAG(gamma_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(hinge_kernel_cuda);
+DMLC_REGISTRY_LINK_TAG(logistic_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(poisson_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(pseudohuber_kernel_cuda);
+DMLC_REGISTRY_LINK_TAG(squared_error_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(squared_log_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(tweedie_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(multiclass_obj_gpu);

--- a/src/objective/regression_loss.h
+++ b/src/objective/regression_loss.h
@@ -4,98 +4,9 @@
 #ifndef XGBOOST_OBJECTIVE_REGRESSION_LOSS_H_
 #define XGBOOST_OBJECTIVE_REGRESSION_LOSS_H_
 
-#include <cmath>
-
-#include "../common/common.h"  // Min, Max
-#include "../common/math.h"
-#include "xgboost/string_view.h"
-#include "xgboost/task.h"  // ObjInfo
+#include "xgboost/base.h"  // for XGBOOST_DEVICE
 
 namespace xgboost::obj {
-// linear regression
-struct LinearSquareLoss {
-  XGBOOST_DEVICE static bst_float PredTransform(bst_float x) { return x; }
-  XGBOOST_DEVICE static bool CheckLabel(bst_float) { return true; }
-  XGBOOST_DEVICE static bst_float FirstOrderGradient(bst_float predt, bst_float label) {
-    return predt - label;
-  }
-  XGBOOST_DEVICE static bst_float SecondOrderGradient(bst_float, bst_float) { return 1.0f; }
-
-  XGBOOST_DEVICE static float ProbToMargin(float base_score) { return base_score; }
-  constexpr static StringView InterceptErrorMsg() { return ""; }
-  XGBOOST_DEVICE static bool CheckIntercept(float) { return true; }
-
-  static const char* LabelErrorMsg() { return ""; }
-  static const char* DefaultEvalMetric() { return "rmse"; }
-
-  static const char* Name() { return "reg:squarederror"; }
-  static ObjInfo Info() { return {ObjInfo::kRegression, true}; }
-};
-
-// logistic loss for probability regression task
-struct LogisticRegression {
-  XGBOOST_DEVICE static bst_float PredTransform(bst_float x) { return common::Sigmoid(x); }
-  XGBOOST_DEVICE static bool CheckLabel(bst_float x) { return x >= 0.0f && x <= 1.0f; }
-  XGBOOST_DEVICE static bst_float FirstOrderGradient(bst_float predt, bst_float label) {
-    return predt - label;
-  }
-  XGBOOST_DEVICE static bst_float SecondOrderGradient(bst_float predt, bst_float) {
-    const float eps = 1e-16f;
-    return fmaxf(predt * (1.0f - predt), eps);
-  }
-  XGBOOST_DEVICE static float ProbToMargin(float base_score) {
-    // Bound the base score
-    base_score = common::Min(common::Max(base_score, kRtEps), 1.0f - kRtEps);
-    return common::Logit(base_score);
-  }
-  constexpr static StringView InterceptErrorMsg() {
-    return "base_score must be in (0,1) for the logistic loss.";
-  }
-  XGBOOST_DEVICE static bool CheckIntercept(float base_score) {
-    // We accept equality for degenerate cases where all label is the same.
-    // https://github.com/dmlc/xgboost/issues/11499
-    return base_score >= 0.0f && base_score <= 1.0f;
-  }
-
-  static const char* LabelErrorMsg() { return "label must be in (0, 1) for logistic regression"; }
-  static const char* DefaultEvalMetric() { return "rmse"; }
-
-  static const char* Name() { return "reg:logistic"; }
-
-  static ObjInfo Info() { return ObjInfo::kRegression; }
-};
-
-// logistic loss for binary classification task
-struct LogisticClassification : public LogisticRegression {
-  static const char* DefaultEvalMetric() { return "logloss"; }
-  static const char* Name() { return "binary:logistic"; }
-  static ObjInfo Info() { return ObjInfo::kBinary; }
-};
-
-// logistic loss, but predict un-transformed margin
-struct LogisticRaw : public LogisticRegression {
-  XGBOOST_DEVICE static bst_float PredTransform(bst_float x) { return x; }
-  XGBOOST_DEVICE static bst_float FirstOrderGradient(bst_float predt, bst_float label) {
-    predt = common::Sigmoid(predt);
-    return predt - label;
-  }
-  XGBOOST_DEVICE static bst_float SecondOrderGradient(bst_float predt, bst_float) {
-    const float eps = 1e-16f;
-    predt = common::Sigmoid(predt);
-    return fmaxf(predt * (1.0f - predt), eps);
-  }
-
-  XGBOOST_DEVICE static float ProbToMargin(float base_score) { return base_score; }
-  constexpr static StringView InterceptErrorMsg() { return ""; }
-  XGBOOST_DEVICE static bool CheckIntercept(float) { return true; }
-
-  static const char* DefaultEvalMetric() { return "logloss"; }
-
-  static const char* Name() { return "binary:logitraw"; }
-
-  static ObjInfo Info() { return ObjInfo::kRegression; }
-};
-
 // Label validation for Poisson regression (labels must be non-negative)
 struct PoissonLabel {
   XGBOOST_DEVICE static bool CheckLabel(float x) { return x >= 0.0f; }

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -16,6 +16,7 @@
 #include "../common/common.h"
 #include "../common/expectile_loss_utils.h"  // for ExpectileLossParam
 #include "../common/linalg_op.h"             // for ElementWiseKernel
+#include "../common/math.h"                  // for CloseTo, Sigmoid, SoftPlus, SoftPlusInv
 #include "../common/numeric.h"               // for Reduce
 #include "../common/optional_weight.h"       // for MakeOptionalWeights
 #include "../common/stats.h"
@@ -23,9 +24,7 @@
 #include "../common/transform.h"
 #include "../common/utils.h"  // for NoOp
 #include "../tree/fit_stump.h"
-#include "./regression_loss.h"
 #include "init_estimation.h"  // FitIntercept
-#include "regression_param.h"
 #include "xgboost/base.h"
 #include "xgboost/context.h"  // Context
 #include "xgboost/data.h"     // MetaInfo
@@ -38,55 +37,15 @@
 #include "xgboost/span.h"
 
 #if defined(XGBOOST_USE_CUDA)
-#include "../common/algorithm.cuh"       // for AllOf
-#include "../common/cuda_context.cuh"    // for CUDAContext
-#include "../common/device_helpers.cuh"  // for MakeIndexTransformIter
-#endif                                   // defined(XGBOOST_USE_CUDA)
+#include "../common/algorithm.cuh"     // for AllOf
+#include "../common/cuda_context.cuh"  // for CUDAContext
+#endif                                 // defined(XGBOOST_USE_CUDA)
 
 namespace xgboost::obj {
 namespace {
 void CheckRegInputs(MetaInfo const& info, HostDeviceVector<float> const& preds) {
   CheckInitInputs(info);
   CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
-}
-
-template <typename Loss>
-void ValidateLabel(Context const* ctx, MetaInfo const& info) {
-  auto label = info.labels.View(ctx->Device());
-  auto valid = ctx->DispatchDevice(
-      [&] {
-        return std::all_of(linalg::cbegin(label), linalg::cend(label),
-                           [](float y) -> bool { return Loss::CheckLabel(y); });
-      },
-      [&] {
-#if defined(XGBOOST_USE_CUDA)
-        auto it = dh::MakeIndexTransformIter([=] XGBOOST_DEVICE(std::size_t i) -> float {
-          auto [m, n] = linalg::UnravelIndex(i, label.Shape());
-          return label(m, n);
-        });
-        return common::AllOf(ctx->CUDACtx()->CTP(), it, it + label.Size(),
-                             [] XGBOOST_DEVICE(float y) { return Loss::CheckLabel(y); });
-#else
-        common::AssertGPUSupport();
-        return false;
-#endif  // defined(XGBOOST_USE_CUDA)
-      },
-      [&] {
-#if defined(XGBOOST_USE_SYCL)
-        return sycl::linalg::Validate(ctx->Device(), label,
-                                      [](float y) -> bool { return Loss::CheckLabel(y); });
-#else
-        common::AssertSYCLSupport();
-        return false;
-#endif  // defined(XGBOOST_USE_SYCL)
-      });
-  if (!valid) {
-    LOG(FATAL) << Loss::LabelErrorMsg();
-  }
-  if (!info.weights_.Empty()) {
-    CHECK_EQ(info.weights_.Size(), info.num_row_)
-        << "Number of weights should be equal to the number of data points.";
-  }
 }
 
 template <typename Fn, typename Chk = common::NoOp<bool>, typename Err = common::NoOp<StringView>>
@@ -122,155 +81,6 @@ void ProbToMarginImpl(Context const* ctx, linalg::Vector<float>* base_score, Fn&
 #if defined(XGBOOST_USE_CUDA)
 DMLC_REGISTRY_FILE_TAG(regression_obj_gpu);
 #endif  // defined(XGBOOST_USE_CUDA)
-
-template <typename Loss>
-class RegLossObj : public FitInterceptGlmLike {
- protected:
-  HostDeviceVector<float> additional_input_;
-
- public:
-  // 0 - scale_pos_weight, 1 - is_null_weight
-  RegLossObj() : additional_input_(2) {}
-
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
-
-  [[nodiscard]] ObjInfo Task() const override { return Loss::Info(); }
-
-  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
-    // Multi-target regression.
-    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
-  }
-
-  void GetGradient(const HostDeviceVector<float>& preds, const MetaInfo& info, std::int32_t iter,
-                   linalg::Matrix<GradientPair>* out_gpair) override {
-    CheckRegInputs(info, preds);
-    if (iter == 0) {
-      ValidateLabel<Loss>(this->ctx_, info);
-    }
-
-    size_t const ndata = preds.Size();
-    out_gpair->SetDevice(ctx_->Device());
-    auto device = ctx_->Device();
-
-    bool is_null_weight = info.weights_.Size() == 0;
-    auto scale_pos_weight = param_.scale_pos_weight;
-    additional_input_.HostVector().begin()[0] = scale_pos_weight;
-    additional_input_.HostVector().begin()[1] = is_null_weight;
-
-    const size_t nthreads = ctx_->Threads();
-    bool on_device = !device.IsCPU();
-    // On CPU we run the transformation each thread processing a contigious block of data
-    // for better performance.
-    const size_t n_data_blocks = std::max(static_cast<size_t>(1), (on_device ? ndata : nthreads));
-    const size_t block_size = ndata / n_data_blocks + !!(ndata % n_data_blocks);
-    auto const n_targets = this->Targets(info);
-    out_gpair->Reshape(info.num_row_, n_targets);
-
-    common::Transform<>::Init(
-        [block_size, ndata, n_targets] XGBOOST_DEVICE(
-            size_t data_block_idx, common::Span<float> _additional_input,
-            common::Span<GradientPair> _out_gpair, common::Span<const bst_float> _preds,
-            common::Span<const bst_float> _labels, common::Span<const bst_float> _weights) {
-          const bst_float* preds_ptr = _preds.data();
-          const bst_float* labels_ptr = _labels.data();
-          const bst_float* weights_ptr = _weights.data();
-          GradientPair* out_gpair_ptr = _out_gpair.data();
-          const size_t begin = data_block_idx * block_size;
-          const size_t end = std::min(ndata, begin + block_size);
-          const float _scale_pos_weight = _additional_input[0];
-          const bool _is_null_weight = _additional_input[1];
-
-          for (size_t idx = begin; idx < end; ++idx) {
-            bst_float p = Loss::PredTransform(preds_ptr[idx]);
-            bst_float w = _is_null_weight ? 1.0f : weights_ptr[idx / n_targets];
-            bst_float label = labels_ptr[idx];
-            if (label == 1.0f) {
-              w *= _scale_pos_weight;
-            }
-            out_gpair_ptr[idx] = GradientPair(Loss::FirstOrderGradient(p, label) * w,
-                                              Loss::SecondOrderGradient(p, label) * w);
-          }
-        },
-        common::Range{0, static_cast<int64_t>(n_data_blocks)}, nthreads, device)
-        .Eval(&additional_input_, out_gpair->Data(), &preds, info.labels.Data(), &info.weights_);
-  }
-
- public:
-  [[nodiscard]] const char* DefaultEvalMetric() const override { return Loss::DefaultEvalMetric(); }
-
-  void PredTransform(HostDeviceVector<float>* io_preds) const override {
-    common::Transform<>::Init(
-        [] XGBOOST_DEVICE(size_t _idx, common::Span<float> _preds) {
-          _preds[_idx] = Loss::PredTransform(_preds[_idx]);
-        },
-        common::Range{0, static_cast<int64_t>(io_preds->Size())}, this->ctx_->Threads(),
-        io_preds->Device())
-        .Eval(io_preds);
-  }
-
-  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
-    if (std::abs(this->param_.scale_pos_weight - 1.0f) > kRtEps) {
-      // Use newton method if `scale_pos_weight` is present. The alternative is to use
-      // weighted mean, but we also need to take sample weight into account.
-      FitIntercept::InitEstimation(info, base_score);
-    } else {
-      FitInterceptGlmLike::InitEstimation(info, base_score);
-    }
-  }
-
-  void ProbToMargin(linalg::Vector<float>* base_score) const override {
-    ProbToMarginImpl(
-        this->ctx_, base_score, [] XGBOOST_DEVICE(float v) { return Loss::ProbToMargin(v); },
-        [] XGBOOST_DEVICE(float v) { return Loss::CheckIntercept(v); }, Loss::InterceptErrorMsg);
-  }
-
-  void SaveConfig(Json* p_out) const override {
-    auto& out = *p_out;
-    out["name"] = String(Loss::Name());
-    out["reg_loss_param"] = ToJson(param_);
-  }
-
-  void LoadConfig(Json const& in) override {
-    auto obj = get<Object const>(in);
-    auto it = obj.find("reg_loss_param");
-    if (it != obj.cend()) {
-      FromJson(it->second, &param_);
-    }
-  }
-
- protected:
-  RegLossParam param_;
-};
-
-// register the objective functions
-DMLC_REGISTER_PARAMETER(RegLossParam);
-
-XGBOOST_REGISTER_OBJECTIVE(SquaredLossRegression, LinearSquareLoss::Name())
-    .describe("Regression with squared error.")
-    .set_body([]() { return new RegLossObj<LinearSquareLoss>(); });
-
-XGBOOST_REGISTER_OBJECTIVE(LogisticRegression, LogisticRegression::Name())
-    .describe("Logistic regression for probability regression task.")
-    .set_body([]() { return new RegLossObj<LogisticRegression>(); });
-
-XGBOOST_REGISTER_OBJECTIVE(LogisticClassification, LogisticClassification::Name())
-    .describe("Logistic regression for binary classification task.")
-    .set_body([]() { return new RegLossObj<LogisticClassification>(); });
-
-XGBOOST_REGISTER_OBJECTIVE(LogisticRaw, LogisticRaw::Name())
-    .describe(
-        "Logistic regression for classification, output score "
-        "before logistic transformation.")
-    .set_body([]() { return new RegLossObj<LogisticRaw>(); });
-
-// Deprecated functions
-XGBOOST_REGISTER_OBJECTIVE(LinearRegression, "reg:linear")
-    .describe("Regression with squared error.")
-    .set_body([]() {
-      LOG(WARNING) << "reg:linear is now deprecated in favor of reg:squarederror.";
-      return new RegLossObj<LinearSquareLoss>();
-    });
-// End deprecated
 
 class ExpectileRegression : public FitIntercept {
   common::ExpectileLossParam param_;

--- a/src/objective/squared_error_obj.cc
+++ b/src/objective/squared_error_obj.cc
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file squared_error_obj.cc
+ * \brief CPU implementation and registration of the squared-error objective.
+ */
+#include "squared_error_obj.h"
+
+#include <dmlc/registry.h>
+
+#include <algorithm>  // for max
+#include <cmath>      // for abs
+#include <cstddef>    // for size_t
+#include <cstdint>    // for int32_t
+
+#include "../common/kernel.h"   // for DispatchKernel
+#include "init_estimation.h"    // for CheckInitInputs, FitIntercept, FitInterceptGlmLike
+#include "regression_param.h"   // for RegLossParam
+#include "xgboost/json.h"       // for FromJson, Json, Object, String, ToJson
+#include "xgboost/logging.h"    // for CHECK, LOG
+#include "xgboost/objective.h"  // for ObjFunction
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(squared_error_obj);
+DMLC_REGISTER_PARAMETER(RegLossParam);
+
+namespace {
+auto const kRegisterSquaredErrorGradientCpu =
+    elementwise::RegisterGradientCpu<SquaredErrorGradient>();
+}  // namespace
+
+class SquaredErrorRegression : public FitInterceptGlmLike {
+ public:
+  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  [[nodiscard]] ObjInfo Task() const override { return {ObjInfo::kRegression, true}; }
+  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
+    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
+  }
+
+  void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info, std::int32_t,
+                   linalg::Matrix<GradientPair>* out_gpair) override {
+    CheckInitInputs(info);
+    CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
+    if (!info.weights_.Empty()) {
+      CHECK_EQ(info.weights_.Size(), info.num_row_)
+          << "Number of weights should be equal to the number of data points.";
+    }
+    common::DispatchKernel<SquaredErrorGradientKernel>(
+        ctx_, preds, info, this->Targets(info), SquaredErrorGradient{param_.scale_pos_weight},
+        out_gpair);
+  }
+
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
+    if (std::abs(param_.scale_pos_weight - 1.0f) > kRtEps) {
+      FitIntercept::InitEstimation(info, base_score);
+    } else {
+      FitInterceptGlmLike::InitEstimation(info, base_score);
+    }
+  }
+
+  [[nodiscard]] const char* DefaultEvalMetric() const override { return "rmse"; }
+
+  void SaveConfig(Json* p_out) const override {
+    auto& out = *p_out;
+    out["name"] = String("reg:squarederror");
+    out["reg_loss_param"] = ToJson(param_);
+  }
+  void LoadConfig(Json const& in) override {
+    auto obj = get<Object const>(in);
+    auto it = obj.find("reg_loss_param");
+    if (it != obj.cend()) {
+      FromJson(it->second, &param_);
+    }
+  }
+
+ private:
+  RegLossParam param_;
+};
+
+XGBOOST_REGISTER_OBJECTIVE(SquaredErrorRegression, "reg:squarederror")
+    .describe("Regression with squared error.")
+    .set_body([]() { return new SquaredErrorRegression(); });
+
+XGBOOST_REGISTER_OBJECTIVE(LinearRegression, "reg:linear")
+    .describe("Regression with squared error.")
+    .set_body([]() {
+      LOG(WARNING) << "reg:linear is now deprecated in favor of reg:squarederror.";
+      return new SquaredErrorRegression();
+    });
+}  // namespace xgboost::obj

--- a/src/objective/squared_error_obj.cu
+++ b/src/objective/squared_error_obj.cu
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file squared_error_obj.cu
+ * \brief CUDA implementation of the squared-error objective kernel.
+ */
+#include <dmlc/registry.h>
+
+#include "elementwise_objective.cuh"
+#include "squared_error_obj.h"
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(squared_error_kernel_cuda);
+namespace {
+auto const kRegisterSquaredErrorGradientCuda =
+    elementwise::RegisterGradientCuda<SquaredErrorGradient>();
+}  // namespace
+}  // namespace xgboost::obj

--- a/src/objective/squared_error_obj.h
+++ b/src/objective/squared_error_obj.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file squared_error_obj.h
+ * \brief Shared declarations for the squared-error objective.
+ */
+#ifndef XGBOOST_OBJECTIVE_SQUARED_ERROR_OBJ_H_
+#define XGBOOST_OBJECTIVE_SQUARED_ERROR_OBJ_H_
+
+#include "elementwise_objective.h"  // for elementwise kernels
+#include "xgboost/base.h"           // for GradientPair
+
+namespace xgboost::obj {
+struct SquaredErrorGradient {
+  float scale_pos_weight;
+
+  XGBOOST_DEVICE GradientPair operator()(float predt, float label, float weight) const {
+    if (label == 1.0f) {
+      weight *= scale_pos_weight;
+    }
+    return {(predt - label) * weight, weight};
+  }
+};
+
+using SquaredErrorGradientKernel = elementwise::GradientKernel<SquaredErrorGradient>;
+}  // namespace xgboost::obj
+
+#endif  // XGBOOST_OBJECTIVE_SQUARED_ERROR_OBJ_H_


### PR DESCRIPTION
## Summary

- split squared error into dedicated `.h`, `.cc`, and `.cu` files while retaining the deprecated `reg:linear` alias
- split the logistic objective family into dedicated CPU and CUDA units for `reg:logistic`, `binary:logistic`, and `binary:logitraw`
- dispatch gradient, transform, and validation work through the typed elementwise objective kernels
- remove the obsolete generic `RegLossObj` implementation and move its registrations to the specialized units
- add static-link tags and R package build entries for the new translation units

The remaining objectives in `regression_obj.cu` have coupled targets, reductions, ordering, or other custom behavior and continue to use their existing implementations.

## Validation

- `./build/testxgboost --gtest_filter=Objective.*` (32 tests passed)
- compiled the modified regression CUDA unit and the new squared-error/logistic CPU and CUDA translation units with CUDA 12.9
- `python ops/script/lint_cpp.py` (386 files passed)
- `git diff --check`