### PR TITLE
Track parameters consumed during configuration

### DIFF
--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -12,7 +12,6 @@
 
 #include <cstdint>  // for int32_t, uint64_t, int16_t
 #include <ostream>  // for ostream
-#include <set>      // for set
 #include <string>   // for string
 #include <utility>  // for pair
 #include <vector>   // for vector

--- a/include/xgboost/base.h
+++ b/include/xgboost/base.h
@@ -12,6 +12,7 @@
 
 #include <cstdint>  // for int32_t, uint64_t, int16_t
 #include <ostream>  // for ostream
+#include <set>      // for set
 #include <string>   // for string
 #include <utility>  // for pair
 #include <vector>   // for vector

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -46,8 +46,9 @@ class GradientBooster : public Model, public Configurable {
    *  User must call configure once before InitModel and Training.
    *
    * @param cfg configurations on both training and model parameters.
+   * @return Names of parameters consumed by the booster and its components.
    */
-  virtual void Configure(Args const& cfg) = 0;
+  virtual std::set<std::string> Configure(Args const& cfg) = 0;
 
   /**
    * \brief Slice a model using boosting index. The slice m:n indicates taking all trees

--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/include/xgboost/linear_updater.h
+++ b/include/xgboost/linear_updater.h
@@ -10,6 +10,7 @@
 #include <xgboost/model.h>
 
 #include <functional>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>

--- a/include/xgboost/linear_updater.h
+++ b/include/xgboost/linear_updater.h
@@ -37,8 +37,9 @@ class LinearUpdater : public Configurable {
   /*!
    * \brief Initialize the updater with given arguments.
    * \param args arguments to the objective function.
+   * \return Names of parameters consumed by the updater.
    */
-  virtual void Configure(
+  virtual std::set<std::string> Configure(
       const std::vector<std::pair<std::string, std::string> >& args) = 0;
 
   /**

--- a/include/xgboost/linear_updater.h
+++ b/include/xgboost/linear_updater.h
@@ -14,7 +14,6 @@
 #include <utility>
 #include <vector>
 
-
 namespace xgboost {
 
 class Json;
@@ -64,16 +63,14 @@ class LinearUpdater : public Configurable {
  * \brief Registry entry for linear updater.
  */
 struct LinearUpdaterReg
-    : public dmlc::FunctionRegEntryBase<LinearUpdaterReg,
-                                        std::function<LinearUpdater*()> > {};
+    : public dmlc::FunctionRegEntryBase<LinearUpdaterReg, std::function<LinearUpdater*()> > {};
 
 /*!
  * \brief Macro to register linear updater.
  */
-#define XGBOOST_REGISTER_LINEAR_UPDATER(UniqueId, Name)                        \
-  static DMLC_ATTRIBUTE_UNUSED ::xgboost::LinearUpdaterReg&                    \
-      __make_##LinearUpdaterReg##_##UniqueId##__ =                             \
-          ::dmlc::Registry< ::xgboost::LinearUpdaterReg>::Get()->__REGISTER__( \
-              Name)
+#define XGBOOST_REGISTER_LINEAR_UPDATER(UniqueId, Name)     \
+  static DMLC_ATTRIBUTE_UNUSED ::xgboost::LinearUpdaterReg& \
+      __make_##LinearUpdaterReg##_##UniqueId##__ =          \
+          ::dmlc::Registry< ::xgboost::LinearUpdaterReg>::Get()->__REGISTER__(Name)
 
 }  // namespace xgboost

--- a/include/xgboost/logging.h
+++ b/include/xgboost/logging.h
@@ -10,13 +10,12 @@
 
 #include <dmlc/logging.h>
 #include <dmlc/thread_local.h>
-
 #include <xgboost/base.h>
-#include <xgboost/parameter.h>
 #include <xgboost/global_config.h>
+#include <xgboost/parameter.h>
 
-#include <sstream>
 #include <map>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -73,14 +72,10 @@ class TrackerLogger : public BaseLogger {
 class LogCallbackRegistry {
  public:
   using Callback = void (*)(const char*);
-  LogCallbackRegistry()
-    : log_callback_([] (const char* msg) { std::cerr << msg << std::endl; }) {}
-  inline void Register(Callback log_callback) {
-    this->log_callback_ = log_callback;
-  }
-  inline Callback Get() const {
-    return log_callback_;
-  }
+  LogCallbackRegistry() : log_callback_([](const char* msg) { std::cerr << msg << std::endl; }) {}
+  inline void Register(Callback log_callback) { this->log_callback_ = log_callback; }
+  inline Callback Get() const { return log_callback_; }
+
  private:
   Callback log_callback_;
 };
@@ -98,32 +93,26 @@ using LogCallbackRegistryStore = dmlc::ThreadLocalStore<LogCallbackRegistry>;
 
 // Redefines LOG_WARNING for controling verbosity
 #if defined(LOG_WARNING)
-#undef  LOG_WARNING
+#undef LOG_WARNING
 #endif  // defined(LOG_WARNING)
-#define LOG_WARNING                                                            \
-  if (::xgboost::ConsoleLogger::ShouldLog(                                     \
-          ::xgboost::ConsoleLogger::LV::kWarning))                             \
-  ::xgboost::ConsoleLogger(__FILE__, __LINE__,                                 \
-                           ::xgboost::ConsoleLogger::LogVerbosity::kWarning)
+#define LOG_WARNING                                                                \
+  if (::xgboost::ConsoleLogger::ShouldLog(::xgboost::ConsoleLogger::LV::kWarning)) \
+  ::xgboost::ConsoleLogger(__FILE__, __LINE__, ::xgboost::ConsoleLogger::LogVerbosity::kWarning)
 
 // Redefines LOG_INFO for controling verbosity
 #if defined(LOG_INFO)
-#undef  LOG_INFO
+#undef LOG_INFO
 #endif  // defined(LOG_INFO)
-#define LOG_INFO                                                               \
-  if (::xgboost::ConsoleLogger::ShouldLog(                                     \
-          ::xgboost::ConsoleLogger::LV::kInfo))                                \
-  ::xgboost::ConsoleLogger(__FILE__, __LINE__,                                 \
-                           ::xgboost::ConsoleLogger::LogVerbosity::kInfo)
+#define LOG_INFO                                                                \
+  if (::xgboost::ConsoleLogger::ShouldLog(::xgboost::ConsoleLogger::LV::kInfo)) \
+  ::xgboost::ConsoleLogger(__FILE__, __LINE__, ::xgboost::ConsoleLogger::LogVerbosity::kInfo)
 
 #if defined(LOG_DEBUG)
 #undef LOG_DEBUG
 #endif  // defined(LOG_DEBUG)
-#define LOG_DEBUG                                                              \
-  if (::xgboost::ConsoleLogger::ShouldLog(                                     \
-          ::xgboost::ConsoleLogger::LV::kDebug))                               \
-  ::xgboost::ConsoleLogger(__FILE__, __LINE__,                                 \
-                           ::xgboost::ConsoleLogger::LogVerbosity::kDebug)
+#define LOG_DEBUG                                                                \
+  if (::xgboost::ConsoleLogger::ShouldLog(::xgboost::ConsoleLogger::LV::kDebug)) \
+  ::xgboost::ConsoleLogger(__FILE__, __LINE__, ::xgboost::ConsoleLogger::LogVerbosity::kDebug)
 
 // redefines the logging macro if not existed
 #ifndef LOG
@@ -131,17 +120,15 @@ using LogCallbackRegistryStore = dmlc::ThreadLocalStore<LogCallbackRegistry>;
 #endif  // LOG
 
 // Enable LOG(CONSOLE) for print messages to console.
-#define LOG_CONSOLE ::xgboost::ConsoleLogger(           \
-    ::xgboost::ConsoleLogger::LogVerbosity::kIgnore)
+#define LOG_CONSOLE ::xgboost::ConsoleLogger(::xgboost::ConsoleLogger::LogVerbosity::kIgnore)
 // Enable LOG(TRACKER) for print messages to tracker
 #define LOG_TRACKER ::xgboost::TrackerLogger()
 
 #if defined(CHECK)
 #undef CHECK
-#define CHECK(cond)                                     \
-  if (XGBOOST_EXPECT(!(cond), false))                   \
-    dmlc::LogMessageFatal(__FILE__, __LINE__).stream()  \
-        << "Check failed: " #cond << ": "
+#define CHECK(cond)                   \
+  if (XGBOOST_EXPECT(!(cond), false)) \
+  dmlc::LogMessageFatal(__FILE__, __LINE__).stream() << "Check failed: " #cond << ": "
 #endif  // defined(CHECK)
 
 }  // namespace xgboost.

--- a/include/xgboost/logging.h
+++ b/include/xgboost/logging.h
@@ -15,6 +15,7 @@
 #include <xgboost/parameter.h>
 
 #include <map>
+#include <set>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/include/xgboost/logging.h
+++ b/include/xgboost/logging.h
@@ -51,7 +51,7 @@ class ConsoleLogger : public BaseLogger {
   LogVerbosity cur_verbosity_;
 
  public:
-  static void Configure(Args const& args);
+  static std::set<std::string> Configure(Args const& args);
 
   static LogVerbosity GlobalVerbosity();
   static LogVerbosity DefaultVerbosity();

--- a/include/xgboost/metric.h
+++ b/include/xgboost/metric.h
@@ -15,6 +15,7 @@
 
 #include <functional>
 #include <memory>  // shared_ptr
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>

--- a/include/xgboost/metric.h
+++ b/include/xgboost/metric.h
@@ -34,9 +34,12 @@ class Metric : public Configurable {
   /*!
    * \brief Configure the Metric with the specified parameters.
    * \param args arguments to the objective function.
+   * \return Names of parameters consumed by the metric.
    */
-  virtual void Configure(
-      const std::vector<std::pair<std::string, std::string> >&) {}
+  virtual std::set<std::string> Configure(
+      const std::vector<std::pair<std::string, std::string> >&) {
+    return {};
+  }
   /*!
    * \brief Load configuration from JSON object
    * By default, metric has no internal configuration;

--- a/include/xgboost/metric.h
+++ b/include/xgboost/metric.h
@@ -88,9 +88,7 @@ class Metric : public Configurable {
  *  For example, metric map@3, then: param == "3".
  */
 struct MetricReg
-    : public dmlc::FunctionRegEntryBase<MetricReg,
-                                        std::function<Metric* (const char*)> > {
-};
+    : public dmlc::FunctionRegEntryBase<MetricReg, std::function<Metric*(const char*)> > {};
 
 /*!
  * \brief Macro to register metric.
@@ -105,8 +103,8 @@ struct MetricReg
  *   });
  * \endcode
  */
-#define XGBOOST_REGISTER_METRIC(UniqueId, Name)                         \
-  ::xgboost::MetricReg&  __make_ ## MetricReg ## _ ## UniqueId ## __ =  \
+#define XGBOOST_REGISTER_METRIC(UniqueId, Name)               \
+  ::xgboost::MetricReg& __make_##MetricReg##_##UniqueId##__ = \
       ::dmlc::Registry< ::xgboost::MetricReg>::Get()->__REGISTER__(Name)
 }  // namespace xgboost
 #endif  // XGBOOST_METRIC_H_

--- a/include/xgboost/objective.h
+++ b/include/xgboost/objective.h
@@ -17,6 +17,7 @@
 
 #include <cstdint>  // for int32_t
 #include <functional>
+#include <set>
 #include <string>  // for string
 
 namespace xgboost {

--- a/include/xgboost/objective.h
+++ b/include/xgboost/objective.h
@@ -37,8 +37,9 @@ class ObjFunction : public Configurable {
    * @brief Configure the objective with the specified parameters.
    *
    * @param args arguments to the objective function.
+   * @return Names of parameters consumed by the objective.
    */
-  virtual void Configure(Args const& args) = 0;
+  virtual std::set<std::string> Configure(Args const& args) = 0;
   /**
    * @brief Get gradient over each of predictions, given existing information.
    *

--- a/include/xgboost/parameter.h
+++ b/include/xgboost/parameter.h
@@ -10,6 +10,7 @@
 
 #include <dmlc/parameter.h>
 #include <xgboost/base.h>
+
 #include <string>
 #include <type_traits>
 
@@ -47,43 +48,40 @@
  *   DMLC_REGISTER_PARAMETER(MyParam);
  * \endcode
  */
-#define DECLARE_FIELD_ENUM_CLASS(EnumClass) \
-namespace dmlc {  \
-namespace parameter {  \
-template <>  \
-class FieldEntry<EnumClass> : public FieldEntry<int> {  \
- public:  \
-  FieldEntry() {  \
-    static_assert(  \
-      std::is_same_v<int, typename std::underlying_type_t<EnumClass>>,  \
-      "enum class must be backed by int");  \
-    is_enum_ = true;  \
-  }  \
-  using Super = FieldEntry<int>;  \
-  void Set(void *head, const std::string &value) const override {  \
-    Super::Set(head, value);  \
-  }  \
-  inline FieldEntry<EnumClass>& add_enum(const std::string &key, EnumClass value) {  \
-    Super::add_enum(key, static_cast<int>(value));  \
-    return *this;  \
-  }  \
-  inline FieldEntry<EnumClass>& set_default(const EnumClass& default_value) {  \
-    default_value_ = static_cast<int>(default_value);  \
-    has_default_ = true;  \
-    return *this;  \
-  }  \
-  inline void Init(const std::string &key, void *head, EnumClass& ref) {  /* NOLINT */  \
-    Super::Init(key, head, *reinterpret_cast<int*>(&ref));  \
-  }  \
-};  \
-}  /* namespace parameter */  \
-}  /* namespace dmlc */
+#define DECLARE_FIELD_ENUM_CLASS(EnumClass)                                                    \
+  namespace dmlc {                                                                             \
+  namespace parameter {                                                                        \
+  template <>                                                                                  \
+  class FieldEntry<EnumClass> : public FieldEntry<int> {                                       \
+   public:                                                                                     \
+    FieldEntry() {                                                                             \
+      static_assert(std::is_same_v<int, typename std::underlying_type_t<EnumClass>>,           \
+                    "enum class must be backed by int");                                       \
+      is_enum_ = true;                                                                         \
+    }                                                                                          \
+    using Super = FieldEntry<int>;                                                             \
+    void Set(void* head, const std::string& value) const override { Super::Set(head, value); } \
+    inline FieldEntry<EnumClass>& add_enum(const std::string& key, EnumClass value) {          \
+      Super::add_enum(key, static_cast<int>(value));                                           \
+      return *this;                                                                            \
+    }                                                                                          \
+    inline FieldEntry<EnumClass>& set_default(const EnumClass& default_value) {                \
+      default_value_ = static_cast<int>(default_value);                                        \
+      has_default_ = true;                                                                     \
+      return *this;                                                                            \
+    }                                                                                          \
+    inline void Init(const std::string& key, void* head, EnumClass& ref) { /* NOLINT */        \
+      Super::Init(key, head, *reinterpret_cast<int*>(&ref));                                   \
+    }                                                                                          \
+  };                                                                                           \
+  } /* namespace parameter */                                                                  \
+  } /* namespace dmlc */
 
 namespace xgboost {
 template <typename Type>
 struct XGBoostParameter : public dmlc::Parameter<Type> {
  protected:
-  bool initialised_ {false};
+  bool initialised_{false};
 
  public:
   template <typename Container>

--- a/include/xgboost/parameter.h
+++ b/include/xgboost/parameter.h
@@ -11,6 +11,9 @@
 #include <dmlc/parameter.h>
 #include <xgboost/base.h>
 
+#include <algorithm>
+#include <iterator>
+#include <set>
 #include <string>
 #include <type_traits>
 
@@ -102,17 +105,19 @@ struct XGBoostParameter : public dmlc::Parameter<Type> {
  */
 template <typename Container, typename Unknown>
 std::set<std::string> GetUsedParameters(Container const& args, Unknown const& unknown) {
+  std::set<std::string> supplied;
+  for (auto const& arg : args) {
+    supplied.insert(arg.first);
+  }
+
   std::set<std::string> unknown_keys;
   for (auto const& arg : unknown) {
     unknown_keys.insert(arg.first);
   }
 
   std::set<std::string> used;
-  for (auto const& arg : args) {
-    if (unknown_keys.find(arg.first) == unknown_keys.end()) {
-      used.insert(arg.first);
-    }
-  }
+  std::set_difference(supplied.cbegin(), supplied.cend(), unknown_keys.cbegin(),
+                      unknown_keys.cend(), std::inserter(used, used.end()));
   return used;
 }
 

--- a/include/xgboost/parameter.h
+++ b/include/xgboost/parameter.h
@@ -98,6 +98,36 @@ struct XGBoostParameter : public dmlc::Parameter<Type> {
   }
   bool GetInitialised() const { return static_cast<bool>(this->initialised_); }
 };
+
+/**
+ * @brief Return the supplied parameter names that don't appear in the unknown arguments.
+ */
+template <typename Container, typename Unknown>
+std::set<std::string> GetUsedParameters(Container const& args, Unknown const& unknown) {
+  std::set<std::string> unknown_keys;
+  for (auto const& arg : unknown) {
+    unknown_keys.insert(arg.first);
+  }
+
+  std::set<std::string> used;
+  for (auto const& arg : args) {
+    if (unknown_keys.find(arg.first) == unknown_keys.end()) {
+      used.insert(arg.first);
+    }
+  }
+  return used;
+}
+
+/**
+ * @brief Update a parameter and return the names it consumed.
+ *
+ * The names retain the spelling supplied by the caller, including aliases.
+ */
+template <typename Parameter, typename Container>
+std::set<std::string> UpdateAndGetUsedParameters(Parameter* parameter, Container const& args) {
+  auto unknown = parameter->UpdateAllowUnknown(args);
+  return GetUsedParameters(args, unknown);
+}
 }  // namespace xgboost
 
 #endif  // XGBOOST_PARAMETER_H_

--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -44,8 +44,9 @@ class TreeUpdater : public Configurable {
   /**
    * @brief Initialize the updater with given arguments.
    * @param args arguments to the objective function.
+   * @return Names of parameters consumed by the updater.
    */
-  virtual void Configure(const Args& args) = 0;
+  virtual std::set<std::string> Configure(const Args& args) = 0;
   /**
    * @brief Whether this updater can be used for updating existing trees.
    *

--- a/include/xgboost/tree_updater.h
+++ b/include/xgboost/tree_updater.h
@@ -19,6 +19,7 @@
 #include <xgboost/tree_model.h>          // for RegTree
 
 #include <functional>  // for function
+#include <set>         // for set
 #include <string>      // for string
 #include <vector>      // for vector
 

--- a/plugin/example/custom_obj.cc
+++ b/plugin/example/custom_obj.cc
@@ -19,7 +19,9 @@ struct MyLogisticParam : public XGBoostParameter<MyLogisticParam> {
   float scale_neg_weight;
   // declare parameters
   DMLC_DECLARE_PARAMETER(MyLogisticParam) {
-    DMLC_DECLARE_FIELD(scale_neg_weight).set_default(1.0f).set_lower_bound(0.0f)
+    DMLC_DECLARE_FIELD(scale_neg_weight)
+        .set_default(1.0f)
+        .set_lower_bound(0.0f)
         .describe("Scale the weight of negative examples by this factor");
   }
 };
@@ -55,12 +57,10 @@ class MyLogistic : public ObjFunction {
       out_gpair_h(i) = GradientPair(grad, hess);
     }
   }
-  [[nodiscard]] const char* DefaultEvalMetric() const override {
-    return "logloss";
-  }
-  void PredTransform(HostDeviceVector<float> *io_preds) const override {
+  [[nodiscard]] const char* DefaultEvalMetric() const override { return "logloss"; }
+  void PredTransform(HostDeviceVector<float>* io_preds) const override {
     // transform margin value to probability.
-    std::vector<float> &preds = io_preds->HostVector();
+    std::vector<float>& preds = io_preds->HostVector();
     for (auto& pred : preds) {
       pred = 1.0f / (1.0f + std::exp(-pred));
     }
@@ -79,9 +79,7 @@ class MyLogistic : public ObjFunction {
     out["my_logistic_param"] = ToJson(param_);
   }
 
-  void LoadConfig(Json const& in) override {
-    FromJson(in["my_logistic_param"], &param_);
-  }
+  void LoadConfig(Json const& in) override { FromJson(in["my_logistic_param"], &param_); }
 
  private:
   MyLogisticParam param_;
@@ -90,7 +88,7 @@ class MyLogistic : public ObjFunction {
 // Finally register the objective function.
 // After it succeeds you can try use xgboost with objective=mylogistic
 XGBOOST_REGISTER_OBJECTIVE(MyLogistic, "mylogistic")
-.describe("User defined logistic regression plugin")
-.set_body([]() { return new MyLogistic(); });
+    .describe("User defined logistic regression plugin")
+    .set_body([]() { return new MyLogistic(); });
 
 }  // namespace xgboost::obj

--- a/plugin/example/custom_obj.cc
+++ b/plugin/example/custom_obj.cc
@@ -30,7 +30,9 @@ DMLC_REGISTER_PARAMETER(MyLogisticParam);
 // Implement the interface.
 class MyLogistic : public ObjFunction {
  public:
-  void Configure(const Args& args) override { param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(const Args& args) override {
+    return UpdateAndGetUsedParameters(&param_, args);
+  }
 
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
 

--- a/plugin/sycl/tree/updater_quantile_hist.cc
+++ b/plugin/sycl/tree/updater_quantile_hist.cc
@@ -25,12 +25,12 @@ DMLC_REGISTRY_FILE_TAG(updater_quantile_hist_sycl);
 
 DMLC_REGISTER_PARAMETER(HistMakerTrainParam);
 
-void QuantileHistMaker::Configure(const Args &args) {
+std::set<std::string> QuantileHistMaker::Configure(const Args &args) {
   const DeviceOrd device_spec = ctx_->Device();
   qu_ = device_manager.GetQueue(device_spec);
 
-  param_.UpdateAllowUnknown(args);
-  hist_maker_param_.UpdateAllowUnknown(args);
+  auto used = UpdateAndGetUsedParameters(&param_, args);
+  used.merge(UpdateAndGetUsedParameters(&hist_maker_param_, args));
 
   bool has_fp64_support = qu_->get_device().has(::sycl::aspect::fp64);
   if (hist_maker_param_.single_precision_histogram || !has_fp64_support) {
@@ -41,6 +41,7 @@ void QuantileHistMaker::Configure(const Args &args) {
   } else {
     hist_precision_ = HistPrecision::fp64;
   }
+  return used;
 }
 
 template <typename GradientSumT>

--- a/plugin/sycl/tree/updater_quantile_hist.h
+++ b/plugin/sycl/tree/updater_quantile_hist.h
@@ -45,7 +45,7 @@ class QuantileHistMaker : public TreeUpdater {
   QuantileHistMaker(Context const* ctx, ObjInfo const* task) : TreeUpdater(ctx), task_{task} {
     updater_monitor_.Init("SYCLQuantileHistMaker");
   }
-  void Configure(const Args& args) override;
+  std::set<std::string> Configure(const Args& args) override;
 
   void Update(xgboost::tree::TrainParam const* param, GradientContainer* in_gpair, DMatrix* dmat,
               xgboost::common::Span<HostDeviceVector<bst_node_t>> out_position,

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -62,11 +62,11 @@ class GBLinear : public GradientBooster {
     monitor_.Init(__func__);
   }
 
-  void Configure(const Args& cfg) override {
+  std::set<std::string> Configure(const Args& cfg) override {
     if (model_.weight.size() == 0) {
       model_.Configure(cfg);
     }
-    param_.UpdateAllowUnknown(cfg);
+    auto used = UpdateAndGetUsedParameters(&param_, cfg);
     if (param_.updater == "gpu_coord_descent") {
       LOG(FATAL) << error::DeprecatedFunc("gpu_coord_descent", "2.0.0",
                                           R"(device="cuda", updater="coord_descent")");
@@ -80,7 +80,8 @@ class GBLinear : public GradientBooster {
     LOG(INFO) << "Using the updater:" << name;
 
     updater_.reset(LinearUpdater::Create(name, ctx_));
-    updater_->Configure(cfg);
+    used.merge(updater_->Configure(cfg));
+    return used;
   }
 
   int32_t BoostedRounds() const override { return model_.num_boosted_rounds; }

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -84,12 +84,12 @@ bool UpdatersMatched(std::vector<std::string> updater_seq,
 
 }  // namespace
 
-void GBTree::Configure(Args const& cfg) {
-  tparam_.UpdateAllowUnknown(cfg);
-  dparam_.UpdateAllowUnknown(cfg);
-  tree_param_.UpdateAllowUnknown(cfg);
+std::set<std::string> GBTree::Configure(Args const& cfg) {
+  auto used = UpdateAndGetUsedParameters(&tparam_, cfg);
+  used.merge(UpdateAndGetUsedParameters(&dparam_, cfg));
+  used.merge(UpdateAndGetUsedParameters(&tree_param_, cfg));
 
-  model_.Configure(cfg);
+  used.merge(model_.Configure(cfg));
 
   // for the 'update' process_type, move trees into trees_to_update
   if (tparam_.process_type == TreeProcessType::kUpdate) {
@@ -119,8 +119,9 @@ void GBTree::Configure(Args const& cfg) {
   }
 
   for (auto& up : updaters_) {
-    up->Configure(cfg);
+    used.merge(up->Configure(cfg));
   }
+  return used;
 }
 
 void GBTreeModel::InitTreesToUpdate() {

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -210,7 +210,7 @@ class GBTree : public GradientBooster {
     monitor_.Init(__func__);
   }
 
-  void Configure(Args const& cfg) override;
+  std::set<std::string> Configure(Args const& cfg) override;
   /**
    * @brief Carry out one iteration of boosting.
    */

--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -65,11 +65,12 @@ struct GBTreeModel : public Model {
  public:
   explicit GBTreeModel(LearnerModelParam const* learner_model, Context const* ctx)
       : learner_model_param{learner_model}, ctx_{ctx} {}
-  void Configure(Args const& cfg) {
+  std::set<std::string> Configure(Args const& cfg) {
     // initialize model parameters if not yet been initialized.
     if (trees.size() == 0) {
-      param.UpdateAllowUnknown(cfg);
+      return UpdateAndGetUsedParameters(&param, cfg);
     }
+    return {};
   }
   /** @brief Move existing trees into the update queue. */
   void InitTreesToUpdate();

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -23,7 +23,6 @@
 #include <memory>         // for allocator, unique_ptr, shared_ptr, operator==
 #include <mutex>          // for mutex, lock_guard
 #include <sstream>        // for operator<<, basic_ostream, basic_ostream::opera...
-#include <stack>          // for stack
 #include <string>         // for basic_string, char_traits, operator<, string
 #include <system_error>   // for errc
 #include <unordered_map>  // for operator!=, unordered_map
@@ -533,15 +532,16 @@ class LearnerConfiguration : public Intercept {
     monitor_.Start("Configure");
     auto old_tparam = tparam_;
     Args args = {cfg_.cbegin(), cfg_.cend()};
+    auto provided = args;
 
-    tparam_.UpdateAllowUnknown(args);
-    mparam_.UpdateAllowUnknown(args);
+    auto used = UpdateAndGetUsedParameters(&tparam_, args);
+    used.merge(UpdateAndGetUsedParameters(&mparam_, args));
 
     auto initialized = ctx_.GetInitialised();
     auto old_seed = ctx_.seed;
-    ctx_.UpdateAllowUnknown(args);
+    used.merge(UpdateAndGetUsedParameters(&ctx_, args));
 
-    ConsoleLogger::Configure(args);
+    used.merge(ConsoleLogger::Configure(args));
 
     // set seed only before the model is initialized
     if (!initialized || ctx_.seed != old_seed) {
@@ -551,18 +551,18 @@ class LearnerConfiguration : public Intercept {
     // must precede configure gbm since num_features is required for gbm
     this->ConfigureNumFeatures();
     args = {cfg_.cbegin(), cfg_.cend()};  // renew
-    this->ConfigureObjective(old_tparam, &args);
+    used.merge(this->ConfigureObjective(old_tparam, &args));
 
     learner_model_param_.task = obj_->Task();  // required by gbm configuration.
-    this->ConfigureGBM(old_tparam, args);
+    used.merge(this->ConfigureGBM(old_tparam, args));
 
     this->InitModelUserParam(this->tparam_, this->cache_data_);
 
-    this->ConfigureMetrics(args);
+    used.merge(this->ConfigureMetrics(args));
 
     this->need_configuration_ = false;
     if (ctx_.validate_parameters) {
-      this->ValidateParameters();
+      this->ValidateParameters(provided, used);
     }
 
     cfg_.clear();
@@ -721,70 +721,20 @@ class LearnerConfiguration : public Intercept {
   Context const* Ctx() const override { return &ctx_; }
 
  private:
-  void ValidateParameters() {
-    Json config{Object()};
-    this->SaveConfig(&config);
-    std::stack<Json> stack;
-    stack.push(config);
-    std::string const postfix{"_param"};
-
-    auto is_parameter = [&postfix](std::string const& key) {
-      return key.size() > postfix.size() &&
-             std::equal(postfix.rbegin(), postfix.rend(), key.rbegin());
-    };
-
-    // Extract all parameters
-    std::vector<std::string> keys;
-    // First global parameters
-    Json const global_config{ToJson(*GlobalConfigThreadLocalStore::Get())};
-    for (auto const& items : get<Object const>(global_config)) {
-      keys.emplace_back(items.first);
-    }
-    // Parameters in various xgboost components.
-    while (!stack.empty()) {
-      auto j_obj = stack.top();
-      stack.pop();
-      auto const& obj = get<Object const>(j_obj);
-
-      for (auto const& kv : obj) {
-        if (is_parameter(kv.first)) {
-          auto parameter = get<Object const>(kv.second);
-          std::transform(
-              parameter.begin(), parameter.end(), std::back_inserter(keys),
-              [](std::pair<std::string const&, Json const&> const& kv) { return kv.first; });
-        } else if (IsA<Object>(kv.second)) {
-          stack.push(kv.second);
-        } else if (IsA<Array>(kv.second)) {
-          auto const& array = get<Array const>(kv.second);
-          for (auto const& v : array) {
-            if (IsA<Object>(v) || IsA<Array>(v)) {
-              stack.push(v);
-            }
-          }
-        }
-      }
-    }
-
-    // FIXME(trivialfis): Make eval_metric a training parameter.
-    keys.emplace_back(kEvalMetric);
-    keys.emplace_back("num_output_group");
-
-    std::sort(keys.begin(), keys.end());
-
-    std::vector<std::string> provided;
-    for (auto const& kv : cfg_) {
+  void ValidateParameters(Args const& args, std::set<std::string> const& used) {
+    std::set<std::string> provided;
+    for (auto const& kv : args) {
       if (std::any_of(kv.first.cbegin(), kv.first.cend(),
                       [](char ch) { return std::isspace(ch); })) {
         LOG(FATAL) << "Invalid parameter \"" << kv.first << "\" contains whitespace.";
       }
-      provided.push_back(kv.first);
+      provided.insert(kv.first);
     }
-    std::sort(provided.begin(), provided.end());
 
     std::vector<std::string> diff;
-    std::set_difference(provided.begin(), provided.end(), keys.begin(), keys.end(),
+    std::set_difference(provided.begin(), provided.end(), used.begin(), used.end(),
                         std::back_inserter(diff));
-    if (diff.size() != 0) {
+    if (!diff.empty()) {
       std::stringstream ss;
       ss << "\nParameters: { ";
       for (size_t i = 0; i < diff.size() - 1; ++i) {
@@ -825,7 +775,7 @@ class LearnerConfiguration : public Intercept {
         << "0 feature is supplied.  Are you using raw Booster interface?";
   }
 
-  void ConfigureGBM(LearnerTrainParam const& old, Args const& args) {
+  std::set<std::string> ConfigureGBM(LearnerTrainParam const& old, Args const& args) {
     tparam_.booster = CanonicalizeBoosterName(tparam_.booster);
     if (tparam_.booster == "gblinear") {
       LOG(WARNING) << "`booster=gblinear` is deprecated and support will be removed in a future "
@@ -835,10 +785,10 @@ class LearnerConfiguration : public Intercept {
     if (gbm_ == nullptr || old_booster != tparam_.booster) {
       gbm_.reset(GradientBooster::Create(tparam_.booster, &ctx_, &learner_model_param_));
     }
-    gbm_->Configure(args);
+    return gbm_->Configure(args);
   }
 
-  void ConfigureObjective(LearnerTrainParam const& old, Args* p_args) {
+  std::set<std::string> ConfigureObjective(LearnerTrainParam const& old, Args* p_args) {
     // Once binary IO is gone, NONE of these config is useful.
     if (cfg_.find("num_class") != cfg_.cend() && cfg_.at("num_class") != "0" &&
         tparam_.objective != "multi:softprob") {
@@ -864,13 +814,15 @@ class LearnerConfiguration : public Intercept {
     cfg_["num_class"] = std::to_string(mparam_.num_class);
     auto& args = *p_args;
     args = {cfg_.cbegin(), cfg_.cend()};  // renew
-    obj_->Configure(args);
+    auto used = obj_->Configure(args);
     if (!has_nc) {
       cfg_.erase("num_class");
     }
+    return used;
   }
 
-  void ConfigureMetrics(Args const& args) {
+  std::set<std::string> ConfigureMetrics(Args const& args) {
+    std::set<std::string> used;
     for (auto const& name : metric_names_) {
       auto DupCheck = [&name](std::unique_ptr<Metric> const& m) {
         return m->Name() != name;
@@ -881,8 +833,9 @@ class LearnerConfiguration : public Intercept {
     }
 
     for (auto& p_metric : metrics_) {
-      p_metric->Configure(args);
+      used.merge(p_metric->Configure(args));
     }
+    return used;
   }
 
   void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) {

--- a/src/linear/updater_coordinate.cc
+++ b/src/linear/updater_coordinate.cc
@@ -4,8 +4,9 @@
  */
 
 #include <xgboost/linear_updater.h>
-#include "./param.h"
+
 #include "../common/timer.h"
+#include "./param.h"
 #include "coordinate_common.h"
 #include "xgboost/json.h"
 
@@ -24,10 +25,8 @@ DMLC_REGISTRY_FILE_TAG(updater_coordinate);
 class CoordinateUpdater : public LinearUpdater {
  public:
   // set training parameter
-  std::set<std::string> Configure(Args const& args) override {
-    const std::vector<std::pair<std::string, std::string> > rest {
-      tparam_.UpdateAllowUnknown(args)
-    };
+  std::set<std::string> Configure(Args const &args) override {
+    const std::vector<std::pair<std::string, std::string> > rest{tparam_.UpdateAllowUnknown(args)};
     auto used = GetUsedParameters(args, rest);
     used.merge(UpdateAndGetUsedParameters(&cparam_, rest));
     selector_.reset(FeatureSelector::Create(tparam_.feature_selector));
@@ -35,8 +34,8 @@ class CoordinateUpdater : public LinearUpdater {
     return used;
   }
 
-  void LoadConfig(Json const& in) override {
-    auto const& config = get<Object const>(in);
+  void LoadConfig(Json const &in) override {
+    auto const &config = get<Object const>(in);
     FromJson(config.at("linear_train_param"), &tparam_);
     FromJson(config.at("coordinate_param"), &cparam_);
   }
@@ -81,12 +80,11 @@ class CoordinateUpdater : public LinearUpdater {
                      gbm::GBLinearModel *model) {
     const int ngroup = model->learner_model_param->num_output_group;
     bst_float &w = (*model)[fidx][group_idx];
-    auto gradient = GetGradientParallel(ctx_, group_idx, ngroup, fidx,
-                                        *in_gpair, p_fmat);
-    auto dw = static_cast<float>(
-        tparam_.learning_rate *
-        CoordinateDelta(gradient.first, gradient.second, w, tparam_.reg_alpha_denorm,
-                        tparam_.reg_lambda_denorm));
+    auto gradient = GetGradientParallel(ctx_, group_idx, ngroup, fidx, *in_gpair, p_fmat);
+    auto dw =
+        static_cast<float>(tparam_.learning_rate * CoordinateDelta(gradient.first, gradient.second,
+                                                                   w, tparam_.reg_alpha_denorm,
+                                                                   tparam_.reg_lambda_denorm));
     w += dw;
     UpdateResidualParallel(ctx_, fidx, group_idx, ngroup, dw, in_gpair, p_fmat);
   }

--- a/src/linear/updater_coordinate.cc
+++ b/src/linear/updater_coordinate.cc
@@ -24,13 +24,15 @@ DMLC_REGISTRY_FILE_TAG(updater_coordinate);
 class CoordinateUpdater : public LinearUpdater {
  public:
   // set training parameter
-  void Configure(Args const& args) override {
+  std::set<std::string> Configure(Args const& args) override {
     const std::vector<std::pair<std::string, std::string> > rest {
       tparam_.UpdateAllowUnknown(args)
     };
-    cparam_.UpdateAllowUnknown(rest);
+    auto used = GetUsedParameters(args, rest);
+    used.merge(UpdateAndGetUsedParameters(&cparam_, rest));
     selector_.reset(FeatureSelector::Create(tparam_.feature_selector));
     monitor_.Init("CoordinateUpdater");
+    return used;
   }
 
   void LoadConfig(Json const& in) override {

--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -7,13 +7,13 @@
 #include <thrust/inner_product.h>
 #include <xgboost/data.h>
 #include <xgboost/linear_updater.h>
-#include "xgboost/span.h"
 
-#include "coordinate_common.h"
 #include "../common/common.h"
 #include "../common/device_helpers.cuh"
 #include "../common/timer.h"
 #include "./param.h"
+#include "coordinate_common.h"
+#include "xgboost/span.h"
 
 namespace xgboost::linear {
 
@@ -36,8 +36,8 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     return used;
   }
 
-  void LoadConfig(Json const& in) override {
-    auto const& config = get<Object const>(in);
+  void LoadConfig(Json const &in) override {
+    auto const &config = get<Object const>(in);
     FromJson(config.at("linear_train_param"), &tparam_);
     FromJson(config.at("coordinate_param"), &coord_param_);
   }
@@ -72,12 +72,9 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
       auto cmp = [](Entry e1, Entry e2) {
         return e1.index < e2.index;
       };
-      auto column_begin =
-          std::lower_bound(col.cbegin(), col.cend(),
-                           xgboost::Entry(0, 0.0f), cmp);
+      auto column_begin = std::lower_bound(col.cbegin(), col.cend(), xgboost::Entry(0, 0.0f), cmp);
       auto column_end =
-          std::lower_bound(col.cbegin(), col.cend(),
-                           xgboost::Entry(num_row_, 0.0f), cmp);
+          std::lower_bound(col.cbegin(), col.cend(), xgboost::Entry(num_row_, 0.0f), cmp);
       column_segments.emplace_back(static_cast<bst_uint>(column_begin - col.cbegin()),
                                    static_cast<bst_uint>(column_end - col.cbegin()));
       row_ptr_.push_back(row_ptr_.back() + (column_end - column_begin));
@@ -87,10 +84,8 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     for (size_t fidx = 0; fidx < batch.Size(); fidx++) {
       auto col = page[fidx];
       auto seg = column_segments[fidx];
-      dh::safe_cuda(cudaMemcpy(
-          data_.data().get() + row_ptr_[fidx],
-          col.data() + seg.first,
-          sizeof(Entry) * (seg.second - seg.first), cudaMemcpyHostToDevice));
+      dh::safe_cuda(cudaMemcpy(data_.data().get() + row_ptr_[fidx], col.data() + seg.first,
+                               sizeof(Entry) * (seg.second - seg.first), cudaMemcpyHostToDevice));
     }
   }
 
@@ -137,9 +132,8 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
       if (ctx_->IsCUDA()) {
         grad = GetBiasGradient(group_idx, model->learner_model_param->num_output_group);
       }
-      auto dbias = static_cast<float>(
-          tparam_.learning_rate *
-              CoordinateDeltaBias(grad.GetGrad(), grad.GetHess()));
+      auto dbias = static_cast<float>(tparam_.learning_rate *
+                                      CoordinateDeltaBias(grad.GetGrad(), grad.GetHess()));
       model->Bias()[group_idx] += dbias;
 
       // Update residual
@@ -149,18 +143,17 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     }
   }
 
-  void UpdateFeature(int fidx, int group_idx,
-                     gbm::GBLinearModel *model) {
+  void UpdateFeature(int fidx, int group_idx, gbm::GBLinearModel *model) {
     bst_float &w = (*model)[fidx][group_idx];
     // Get gradient
     auto grad = GradientPair(0, 0);
     if (ctx_->IsCUDA()) {
       grad = GetGradient(group_idx, model->learner_model_param->num_output_group, fidx);
     }
-    auto dw = static_cast<float>(tparam_.learning_rate *
-                                 CoordinateDelta(grad.GetGrad(), grad.GetHess(),
-                                                 w, tparam_.reg_alpha_denorm,
-                                                 tparam_.reg_lambda_denorm));
+    auto dw =
+        static_cast<float>(tparam_.learning_rate * CoordinateDelta(grad.GetGrad(), grad.GetHess(),
+                                                                   w, tparam_.reg_alpha_denorm,
+                                                                   tparam_.reg_lambda_denorm));
     w += dw;
 
     if (ctx_->IsCUDA()) {
@@ -175,8 +168,7 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     auto f = [=] __device__(size_t idx) {
       return idx * num_group + group_idx;
     };  // NOLINT
-    thrust::transform_iterator<decltype(f), decltype(counting), size_t> skip(
-        counting, f);
+    thrust::transform_iterator<decltype(f), decltype(counting), size_t> skip(counting, f);
     auto perm = thrust::make_permutation_iterator(gpair_.data(), skip);
 
     return dh::SumReduction(perm, num_row_);
@@ -204,8 +196,8 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
       auto g = d_gpair[entry.index * num_group + group_idx];
       return GradientPair{g.GetGrad() * entry.fvalue, g.GetHess() * entry.fvalue * entry.fvalue};
     };  // NOLINT
-    thrust::transform_iterator<decltype(f), decltype(counting), GradientPair>
-        multiply_iterator(counting, f);
+    thrust::transform_iterator<decltype(f), decltype(counting), GradientPair> multiply_iterator(
+        counting, f);
     return dh::SumReduction(multiply_iterator, col_size);
   }
 
@@ -222,15 +214,11 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
   }
 
  private:
-  bool IsEmpty() {
-    return num_row_ == 0;
-  }
+  bool IsEmpty() { return num_row_ == 0; }
 
   void UpdateGpair(const std::vector<GradientPair> &host_gpair) {
-    dh::safe_cuda(cudaMemcpyAsync(
-        gpair_.data().get(),
-        host_gpair.data(),
-        gpair_.size() * sizeof(GradientPair), cudaMemcpyHostToDevice));
+    dh::safe_cuda(cudaMemcpyAsync(gpair_.data().get(), host_gpair.data(),
+                                  gpair_.size() * sizeof(GradientPair), cudaMemcpyHostToDevice));
   }
 
   // training parameter

--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -28,11 +28,12 @@ DMLC_REGISTRY_FILE_TAG(updater_gpu_coordinate);
 class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
  public:
   // set training parameter
-  void Configure(Args const &args) override {
-    tparam_.UpdateAllowUnknown(args);
-    coord_param_.UpdateAllowUnknown(args);
+  std::set<std::string> Configure(Args const &args) override {
+    auto used = UpdateAndGetUsedParameters(&tparam_, args);
+    used.merge(UpdateAndGetUsedParameters(&coord_param_, args));
     selector_.reset(FeatureSelector::Create(tparam_.feature_selector));
     monitor_.Init("GPUCoordinateUpdater");
+    return used;
   }
 
   void LoadConfig(Json const& in) override {

--- a/src/linear/updater_shotgun.cc
+++ b/src/linear/updater_shotgun.cc
@@ -13,14 +13,15 @@ DMLC_REGISTRY_FILE_TAG(updater_shotgun);
 class ShotgunUpdater : public LinearUpdater {
  public:
   // set training parameter
-  void Configure(Args const& args) override {
-    param_.UpdateAllowUnknown(args);
+  std::set<std::string> Configure(Args const& args) override {
+    auto used = UpdateAndGetUsedParameters(&param_, args);
     if (param_.feature_selector != kCyclic &&
         param_.feature_selector != kShuffle) {
       LOG(FATAL) << "Unsupported feature selector for shotgun updater.\n"
                  << "Supported options are: {cyclic, shuffle}";
     }
     selector_.reset(FeatureSelector::Create(param_.feature_selector));
+    return used;
   }
   void LoadConfig(Json const& in) override {
     auto const& config = get<Object const>(in);

--- a/src/linear/updater_shotgun.cc
+++ b/src/linear/updater_shotgun.cc
@@ -4,6 +4,7 @@
  */
 
 #include <xgboost/linear_updater.h>
+
 #include "coordinate_common.h"
 
 namespace xgboost::linear {
@@ -13,22 +14,21 @@ DMLC_REGISTRY_FILE_TAG(updater_shotgun);
 class ShotgunUpdater : public LinearUpdater {
  public:
   // set training parameter
-  std::set<std::string> Configure(Args const& args) override {
+  std::set<std::string> Configure(Args const &args) override {
     auto used = UpdateAndGetUsedParameters(&param_, args);
-    if (param_.feature_selector != kCyclic &&
-        param_.feature_selector != kShuffle) {
+    if (param_.feature_selector != kCyclic && param_.feature_selector != kShuffle) {
       LOG(FATAL) << "Unsupported feature selector for shotgun updater.\n"
                  << "Supported options are: {cyclic, shuffle}";
     }
     selector_.reset(FeatureSelector::Create(param_.feature_selector));
     return used;
   }
-  void LoadConfig(Json const& in) override {
-    auto const& config = get<Object const>(in);
+  void LoadConfig(Json const &in) override {
+    auto const &config = get<Object const>(in);
     FromJson(config.at("linear_train_param"), &param_);
   }
-  void SaveConfig(Json* p_out) const override {
-    auto& out = *p_out;
+  void SaveConfig(Json *p_out) const override {
+    auto &out = *p_out;
     out["linear_train_param"] = ToJson(param_);
   }
 
@@ -40,10 +40,10 @@ class ShotgunUpdater : public LinearUpdater {
 
     // update bias
     for (int gid = 0; gid < ngroup; ++gid) {
-      auto grad = GetBiasGradientParallel(gid, ngroup, gpair->ConstHostVector(), p_fmat,
-                                          ctx_->Threads());
+      auto grad =
+          GetBiasGradientParallel(gid, ngroup, gpair->ConstHostVector(), p_fmat, ctx_->Threads());
       auto dbias = static_cast<bst_float>(param_.learning_rate *
-                               CoordinateDeltaBias(grad.first, grad.second));
+                                          CoordinateDeltaBias(grad.first, grad.second));
       model->Bias()[gid] += dbias;
       UpdateBiasResidualParallel(ctx_, gid, ngroup, dbias, &gpair->HostVector(), p_fmat);
     }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -44,9 +44,9 @@ bool ConsoleLogger::ShouldLog(LogVerbosity verbosity) {
          verbosity == LV::kIgnore;
 }
 
-void ConsoleLogger::Configure(Args const& args) {
+std::set<std::string> ConsoleLogger::Configure(Args const& args) {
   auto& param = *GlobalConfigThreadLocalStore::Get();
-  param.UpdateAllowUnknown(args);
+  return UpdateAndGetUsedParameters(&param, args);
 }
 
 ConsoleLogger::LogVerbosity ConsoleLogger::DefaultVerbosity() {

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -13,8 +13,7 @@
 #if !defined(XGBOOST_STRICT_R_MODE) || XGBOOST_STRICT_R_MODE == 0
 // Override logging mechanism for non-R interfaces
 void dmlc::CustomLogMessage::Log(const std::string& msg) {
-  const xgboost::LogCallbackRegistry *registry =
-      xgboost::LogCallbackRegistryStore::Get();
+  const xgboost::LogCallbackRegistry* registry = xgboost::LogCallbackRegistryStore::Get();
   auto callback = registry->Get();
   callback(msg.c_str());
 }
@@ -39,8 +38,7 @@ TrackerLogger::~TrackerLogger() {
 namespace xgboost {
 
 bool ConsoleLogger::ShouldLog(LogVerbosity verbosity) {
-  return static_cast<int>(verbosity) <=
-             (GlobalConfigThreadLocalStore::Get()->verbosity) ||
+  return static_cast<int>(verbosity) <= (GlobalConfigThreadLocalStore::Get()->verbosity) ||
          verbosity == LV::kIgnore;
 }
 
@@ -49,50 +47,43 @@ std::set<std::string> ConsoleLogger::Configure(Args const& args) {
   return UpdateAndGetUsedParameters(&param, args);
 }
 
-ConsoleLogger::LogVerbosity ConsoleLogger::DefaultVerbosity() {
-  return LogVerbosity::kWarning;
-}
+ConsoleLogger::LogVerbosity ConsoleLogger::DefaultVerbosity() { return LogVerbosity::kWarning; }
 
 ConsoleLogger::LogVerbosity ConsoleLogger::GlobalVerbosity() {
-  LogVerbosity global_verbosity { LogVerbosity::kWarning };
+  LogVerbosity global_verbosity{LogVerbosity::kWarning};
   switch (GlobalConfigThreadLocalStore::Get()->verbosity) {
-  case 0:
-    global_verbosity = LogVerbosity::kSilent;
-    break;
-  case 1:
-    global_verbosity = LogVerbosity::kWarning;
-    break;
-  case 2:
-    global_verbosity = LogVerbosity::kInfo;
-    break;
-  case 3:
-    global_verbosity = LogVerbosity::kDebug;
-  default:
-    // global verbosity doesn't require kIgnore
-    break;
+    case 0:
+      global_verbosity = LogVerbosity::kSilent;
+      break;
+    case 1:
+      global_verbosity = LogVerbosity::kWarning;
+      break;
+    case 2:
+      global_verbosity = LogVerbosity::kInfo;
+      break;
+    case 3:
+      global_verbosity = LogVerbosity::kDebug;
+    default:
+      // global verbosity doesn't require kIgnore
+      break;
   }
 
   return global_verbosity;
 }
 
-ConsoleLogger::ConsoleLogger(LogVerbosity cur_verb) :
-    cur_verbosity_{cur_verb} {}
+ConsoleLogger::ConsoleLogger(LogVerbosity cur_verb) : cur_verbosity_{cur_verb} {}
 
-ConsoleLogger::ConsoleLogger(
-    const std::string& file, int line, LogVerbosity cur_verb) {
+ConsoleLogger::ConsoleLogger(const std::string& file, int line, LogVerbosity cur_verb) {
   cur_verbosity_ = cur_verb;
   switch (cur_verbosity_) {
     case LogVerbosity::kWarning:
-      BaseLogger::log_stream_ << "WARNING: "
-                              << file << ":" << line << ": ";
+      BaseLogger::log_stream_ << "WARNING: " << file << ":" << line << ": ";
       break;
     case LogVerbosity::kDebug:
-      BaseLogger::log_stream_ << "DEBUG: "
-                              << file << ":" << line << ": ";
+      BaseLogger::log_stream_ << "DEBUG: " << file << ":" << line << ": ";
       break;
     case LogVerbosity::kInfo:
-      BaseLogger::log_stream_ << "INFO: "
-                              << file << ":" << line << ": ";
+      BaseLogger::log_stream_ << "INFO: " << file << ":" << line << ": ";
       break;
     case LogVerbosity::kIgnore:
       BaseLogger::log_stream_ << file << ":" << line << ": ";

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -170,7 +170,9 @@ class PseudoErrorLoss : public MetricNoCache {
 
  public:
   const char* Name() const override { return "mphe"; }
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(Args const& args) override {
+    return UpdateAndGetUsedParameters(&param_, args);
+  }
   void LoadConfig(Json const& in) override { FromJson(in["pseudo_huber_param"], &param_); }
   void SaveConfig(Json* p_out) const override {
     auto& out = *p_out;
@@ -414,10 +416,11 @@ class QuantileError : public MetricNoCache {
   common::QuantileLossParam param_;
 
  public:
-  void Configure(Args const& args) override {
-    param_.UpdateAllowUnknown(args);
+  std::set<std::string> Configure(Args const& args) override {
+    auto used = UpdateAndGetUsedParameters(&param_, args);
     param_.Validate();
     alpha_.HostVector() = param_.quantile_alpha.Get();
+    return used;
   }
 
   double Eval(HostDeviceVector<bst_float> const& preds, const MetaInfo& info) override {
@@ -501,10 +504,11 @@ class ExpectileError : public MetricNoCache {
   common::ExpectileLossParam param_;
 
  public:
-  void Configure(Args const& args) override {
-    param_.UpdateAllowUnknown(args);
+  std::set<std::string> Configure(Args const& args) override {
+    auto used = UpdateAndGetUsedParameters(&param_, args);
     param_.Validate();
     alpha_.HostVector() = param_.expectile_alpha.Get();
+    return used;
   }
 
   double Eval(HostDeviceVector<bst_float> const& preds, const MetaInfo& info) override {

--- a/src/metric/rank_metric.cc
+++ b/src/metric/rank_metric.cc
@@ -339,16 +339,19 @@ class EvalNDCG : public EvalRankWithCache<ltr::NDCGCache> {
  public:
   using EvalRankWithCache::EvalRankWithCache;
 
-  void Configure(Args const& args) override {
+  std::set<std::string> Configure(Args const& args) override {
     // do not configure, otherwise the ndcg param like top-k will be forced into the same
     // as the one in objective. The metric has its own syntax for parameter.
+    std::set<std::string> used;
     for (auto const& [key, value] : args) {
       // Make a special case for the exp gain parameter, which is not exposed in the
       // metric configuration syntax.
       if (key == "ndcg_exp_gain") {
         this->param_.UpdateAllowUnknown(Args{{key, value}});
+        used.insert(key);
       }
     }
+    return used;
   }
 
   double Eval(HostDeviceVector<float> const& preds, MetaInfo const& info,

--- a/src/metric/survival_metric.cu
+++ b/src/metric/survival_metric.cu
@@ -156,7 +156,9 @@ struct EvalIntervalRegressionAccuracy {
 /*! \brief Negative log likelihood of Accelerated Failure Time model */
 template <typename Distribution>
 struct EvalAFTNLogLik {
-  std::set<std::string> Configure(const Args& args) { return UpdateAndGetUsedParameters(&param_, args); }
+  std::set<std::string> Configure(const Args& args) {
+    return UpdateAndGetUsedParameters(&param_, args);
+  }
 
   [[nodiscard]] const char* Name() const { return "aft-nloglik"; }
 

--- a/src/metric/survival_metric.cu
+++ b/src/metric/survival_metric.cu
@@ -140,7 +140,7 @@ class ElementWiseSurvivalMetricsReduction {
 };
 
 struct EvalIntervalRegressionAccuracy {
-  void Configure(const Args&) {}
+  std::set<std::string> Configure(const Args&) { return {}; }
 
   [[nodiscard]] const char* Name() const { return "interval-regression-accuracy"; }
 
@@ -156,7 +156,7 @@ struct EvalIntervalRegressionAccuracy {
 /*! \brief Negative log likelihood of Accelerated Failure Time model */
 template <typename Distribution>
 struct EvalAFTNLogLik {
-  void Configure(const Args& args) { param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(const Args& args) { return UpdateAndGetUsedParameters(&param_, args); }
 
   [[nodiscard]] const char* Name() const { return "aft-nloglik"; }
 
@@ -177,10 +177,11 @@ struct EvalEWiseSurvivalBase : public MetricNoCache {
   explicit EvalEWiseSurvivalBase(Context const* ctx) { ctx_ = ctx; }
   EvalEWiseSurvivalBase() = default;
 
-  void Configure(const Args& args) override {
-    policy_.Configure(args);
+  std::set<std::string> Configure(const Args& args) override {
+    auto used = policy_.Configure(args);
     reducer_.Configure(policy_);
     CHECK(ctx_);
+    return used;
   }
 
   double Eval(const HostDeviceVector<float>& preds, const MetaInfo& info) override {
@@ -215,8 +216,8 @@ struct AFTNLogLikDispatcher : public MetricNoCache {
     return metric_->Eval(preds, info);
   }
 
-  void Configure(const Args& args) override {
-    param_.UpdateAllowUnknown(args);
+  std::set<std::string> Configure(const Args& args) override {
+    auto used = UpdateAndGetUsedParameters(&param_, args);
     switch (param_.aft_loss_distribution) {
       case common::ProbabilityDistributionType::kNormal:
         metric_.reset(new EvalEWiseSurvivalBase<EvalAFTNLogLik<common::NormalDistribution>>(ctx_));
@@ -231,7 +232,8 @@ struct AFTNLogLikDispatcher : public MetricNoCache {
       default:
         LOG(FATAL) << "Unknown probability distribution";
     }
-    metric_->Configure(args);
+    used.merge(metric_->Configure(args));
+    return used;
   }
 
   void SaveConfig(Json* p_out) const override {

--- a/src/objective/aft_obj.cu
+++ b/src/objective/aft_obj.cu
@@ -31,8 +31,8 @@ DMLC_REGISTRY_FILE_TAG(aft_obj_gpu);
 
 class AFTObj : public ObjFunction {
  public:
-  void Configure(Args const& args) override {
-    param_.UpdateAllowUnknown(args);
+  std::set<std::string> Configure(Args const& args) override {
+    return UpdateAndGetUsedParameters(&param_, args);
   }
 
   ObjInfo Task() const override { return ObjInfo::kSurvival; }

--- a/src/objective/aft_obj.cu
+++ b/src/objective/aft_obj.cu
@@ -42,27 +42,24 @@ class AFTObj : public ObjFunction {
                        linalg::Matrix<GradientPair>* out_gpair, size_t ndata, DeviceOrd device,
                        bool is_null_weight, float aft_loss_distribution_scale) {
     common::Transform<>::Init(
-        [=] XGBOOST_DEVICE(size_t _idx,
-        common::Span<GradientPair> _out_gpair,
-        common::Span<const bst_float> _preds,
-        common::Span<const bst_float> _labels_lower_bound,
-        common::Span<const bst_float> _labels_upper_bound,
-        common::Span<const bst_float> _weights) {
-      const double pred = static_cast<double>(_preds[_idx]);
-      const double label_lower_bound = static_cast<double>(_labels_lower_bound[_idx]);
-      const double label_upper_bound = static_cast<double>(_labels_upper_bound[_idx]);
-      const float grad = static_cast<float>(
-          AFTLoss<Distribution>::Gradient(label_lower_bound, label_upper_bound,
-                                          pred, aft_loss_distribution_scale));
-      const float hess = static_cast<float>(
-          AFTLoss<Distribution>::Hessian(label_lower_bound, label_upper_bound,
-                                         pred, aft_loss_distribution_scale));
-      const bst_float w = is_null_weight ? 1.0f : _weights[_idx];
-      _out_gpair[_idx] = GradientPair(grad * w, hess * w);
-    },
-    common::Range{0, static_cast<int64_t>(ndata)}, this->ctx_->Threads(), device).Eval(
-        out_gpair->Data(), &preds, &info.labels_lower_bound_, &info.labels_upper_bound_,
-        &info.weights_);
+        [=] XGBOOST_DEVICE(size_t _idx, common::Span<GradientPair> _out_gpair,
+                           common::Span<const bst_float> _preds,
+                           common::Span<const bst_float> _labels_lower_bound,
+                           common::Span<const bst_float> _labels_upper_bound,
+                           common::Span<const bst_float> _weights) {
+          const double pred = static_cast<double>(_preds[_idx]);
+          const double label_lower_bound = static_cast<double>(_labels_lower_bound[_idx]);
+          const double label_upper_bound = static_cast<double>(_labels_upper_bound[_idx]);
+          const float grad = static_cast<float>(AFTLoss<Distribution>::Gradient(
+              label_lower_bound, label_upper_bound, pred, aft_loss_distribution_scale));
+          const float hess = static_cast<float>(AFTLoss<Distribution>::Hessian(
+              label_lower_bound, label_upper_bound, pred, aft_loss_distribution_scale));
+          const bst_float w = is_null_weight ? 1.0f : _weights[_idx];
+          _out_gpair[_idx] = GradientPair(grad * w, hess * w);
+        },
+        common::Range{0, static_cast<int64_t>(ndata)}, this->ctx_->Threads(), device)
+        .Eval(out_gpair->Data(), &preds, &info.labels_lower_bound_, &info.labels_upper_bound_,
+              &info.weights_);
   }
 
   void GetGradient(const HostDeviceVector<bst_float>& preds, const MetaInfo& info, int /*iter*/,
@@ -77,28 +74,28 @@ class AFTObj : public ObjFunction {
     const bool is_null_weight = info.weights_.Size() == 0;
     if (!is_null_weight) {
       CHECK_EQ(info.weights_.Size(), ndata)
-        << "Number of weights should be equal to number of data points.";
+          << "Number of weights should be equal to number of data points.";
     }
 
     switch (param_.aft_loss_distribution) {
-    case common::ProbabilityDistributionType::kNormal:
-      GetGradientImpl<common::NormalDistribution>(preds, info, out_gpair, ndata, device,
-                                                  is_null_weight, aft_loss_distribution_scale);
-      break;
-    case common::ProbabilityDistributionType::kLogistic:
-      GetGradientImpl<common::LogisticDistribution>(preds, info, out_gpair, ndata, device,
+      case common::ProbabilityDistributionType::kNormal:
+        GetGradientImpl<common::NormalDistribution>(preds, info, out_gpair, ndata, device,
                                                     is_null_weight, aft_loss_distribution_scale);
-      break;
-    case common::ProbabilityDistributionType::kExtreme:
-      GetGradientImpl<common::ExtremeDistribution>(preds, info, out_gpair, ndata, device,
-                                                   is_null_weight, aft_loss_distribution_scale);
-      break;
-    default:
-      LOG(FATAL) << "Unrecognized distribution";
+        break;
+      case common::ProbabilityDistributionType::kLogistic:
+        GetGradientImpl<common::LogisticDistribution>(preds, info, out_gpair, ndata, device,
+                                                      is_null_weight, aft_loss_distribution_scale);
+        break;
+      case common::ProbabilityDistributionType::kExtreme:
+        GetGradientImpl<common::ExtremeDistribution>(preds, info, out_gpair, ndata, device,
+                                                     is_null_weight, aft_loss_distribution_scale);
+        break;
+      default:
+        LOG(FATAL) << "Unrecognized distribution";
     }
   }
 
-  void PredTransform(HostDeviceVector<bst_float> *io_preds) const override {
+  void PredTransform(HostDeviceVector<bst_float>* io_preds) const override {
     // Trees give us a prediction in log scale, so exponentiate
     common::Transform<>::Init(
         [] XGBOOST_DEVICE(size_t _idx, common::Span<bst_float> _preds) {
@@ -120,9 +117,7 @@ class AFTObj : public ObjFunction {
     });
   }
 
-  const char* DefaultEvalMetric() const override {
-    return "aft-nloglik";
-  }
+  const char* DefaultEvalMetric() const override { return "aft-nloglik"; }
 
   void SaveConfig(Json* p_out) const override {
     auto& out = *p_out;
@@ -130,9 +125,7 @@ class AFTObj : public ObjFunction {
     out["aft_loss_param"] = ToJson(param_);
   }
 
-  void LoadConfig(Json const& in) override {
-    FromJson(in["aft_loss_param"], &param_);
-  }
+  void LoadConfig(Json const& in) override { FromJson(in["aft_loss_param"], &param_); }
   Json DefaultMetricConfig() const override {
     Json config{Object{}};
     config["name"] = String{this->DefaultEvalMetric()};
@@ -145,9 +138,9 @@ class AFTObj : public ObjFunction {
 };
 
 // register the objective functions
-XGBOOST_REGISTER_OBJECTIVE(AFTObj, "survival:aft")
-    .describe("AFT loss function")
-    .set_body([]() { return new AFTObj(); });
+XGBOOST_REGISTER_OBJECTIVE(AFTObj, "survival:aft").describe("AFT loss function").set_body([]() {
+  return new AFTObj();
+});
 
 }  // namespace obj
 }  // namespace xgboost

--- a/src/objective/gamma_obj.cc
+++ b/src/objective/gamma_obj.cc
@@ -31,7 +31,9 @@ auto const kRegisterGammaValidationCpu = elementwise::RegisterValidationCpu<Gamm
 
 class GammaRegression : public FitInterceptGlmLike {
  public:
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(Args const& args) override {
+    return UpdateAndGetUsedParameters(&param_, args);
+  }
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
     return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));

--- a/src/objective/hinge.cc
+++ b/src/objective/hinge.cc
@@ -27,7 +27,7 @@ auto const kRegisterHingePredTransformCpu = elementwise::RegisterTransformCpu<Hi
 
 class HingeObj : public FitIntercept {
  public:
-  void Configure(Args const&) override {}
+  std::set<std::string> Configure(Args const&) override { return {}; }
   ObjInfo Task() const override { return ObjInfo::kRegression; }
 
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {

--- a/src/objective/lambdarank_obj.cc
+++ b/src/objective/lambdarank_obj.cc
@@ -250,7 +250,9 @@ class LambdaRankObj : public FitIntercept {
   }
 
  public:
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(Args const& args) override {
+    return UpdateAndGetUsedParameters(&param_, args);
+  }
   void SaveConfig(Json* p_out) const override {
     auto& out = *p_out;
     out["name"] = String(Loss::Name());

--- a/src/objective/logistic_obj.cc
+++ b/src/objective/logistic_obj.cc
@@ -36,7 +36,9 @@ enum class LogisticKind { kRegression, kClassification, kRaw };
 template <LogisticKind kKind>
 class LogisticObjective : public FitInterceptGlmLike {
  public:
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(Args const& args) override {
+    return UpdateAndGetUsedParameters(&param_, args);
+  }
   [[nodiscard]] ObjInfo Task() const override {
     if constexpr (kKind == LogisticKind::kClassification) {
       return ObjInfo::kBinary;

--- a/src/objective/multiclass_obj.cu
+++ b/src/objective/multiclass_obj.cu
@@ -70,7 +70,9 @@ class SoftmaxMultiClassObj : public ObjFunction {
  public:
   explicit SoftmaxMultiClassObj(bool output_prob) : output_prob_(output_prob) {}
 
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(Args const& args) override {
+    return UpdateAndGetUsedParameters(&param_, args);
+  }
 
   ObjInfo Task() const override { return ObjInfo::kClassification; }
 

--- a/src/objective/poisson_obj.cc
+++ b/src/objective/poisson_obj.cc
@@ -31,7 +31,9 @@ auto const kRegisterPoissonValidationCpu = elementwise::RegisterValidationCpu<Po
 
 class PoissonRegression : public FitInterceptGlmLike {
  public:
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(Args const& args) override {
+    return UpdateAndGetUsedParameters(&param_, args);
+  }
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
     return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));

--- a/src/objective/pseudohuber_obj.cc
+++ b/src/objective/pseudohuber_obj.cc
@@ -29,7 +29,9 @@ class PseudoHuberRegression : public FitIntercept {
   PseudoHuberParam param_;
 
  public:
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(Args const& args) override {
+    return UpdateAndGetUsedParameters(&param_, args);
+  }
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
     return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));

--- a/src/objective/quantile_obj.cu
+++ b/src/objective/quantile_obj.cu
@@ -263,10 +263,11 @@ class QuantileRegression : public ObjFunction {
     double n_workers = collective::GetWorldSize();
     linalg::VecScaDiv(ctx_, intercept, n_workers);
   }
-  void Configure(Args const& args) override {
-    param_.UpdateAllowUnknown(args);
+  std::set<std::string> Configure(Args const& args) override {
+    auto used = UpdateAndGetUsedParameters(&param_, args);
     param_.Validate();
     this->alpha_.HostVector() = param_.quantile_alpha.Get();
+    return used;
   }
   [[nodiscard]] ObjInfo Task() const override { return {ObjInfo::kRegression, false}; }
   static char const* Name() { return "reg:quantileerror"; }

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -96,10 +96,11 @@ class ExpectileRegression : public FitIntercept {
   }
 
  public:
-  void Configure(Args const& args) override {
-    param_.UpdateAllowUnknown(args);
+  std::set<std::string> Configure(Args const& args) override {
+    auto used = UpdateAndGetUsedParameters(&param_, args);
     param_.Validate();
     alpha_.HostVector() = param_.expectile_alpha.Get();
+    return used;
   }
 
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
@@ -274,7 +275,7 @@ XGBOOST_REGISTER_OBJECTIVE(ExpectileRegression, "reg:expectileerror")
 // cox regression for survival data (negative values mean they are censored)
 class CoxRegression : public FitIntercept {
  public:
-  void Configure(Args const&) override {}
+  std::set<std::string> Configure(Args const&) override { return {}; }
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
 
   void GetGradient(const HostDeviceVector<bst_float>& preds, const MetaInfo& info, int,
@@ -378,7 +379,7 @@ XGBOOST_REGISTER_OBJECTIVE(CoxRegression, "survival:cox")
  */
 class MeanAbsoluteError : public ObjFunction {
  public:
-  void Configure(Args const&) override {}
+  std::set<std::string> Configure(Args const&) override { return {}; }
   [[nodiscard]] ObjInfo Task() const override { return {ObjInfo::kRegression, false}; }
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
     return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));

--- a/src/objective/squared_error_obj.cc
+++ b/src/objective/squared_error_obj.cc
@@ -30,7 +30,9 @@ auto const kRegisterSquaredErrorGradientCpu =
 
 class SquaredErrorRegression : public FitInterceptGlmLike {
  public:
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(Args const& args) override {
+    return UpdateAndGetUsedParameters(&param_, args);
+  }
   [[nodiscard]] ObjInfo Task() const override { return {ObjInfo::kRegression, true}; }
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
     return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));

--- a/src/objective/squared_log_obj.cc
+++ b/src/objective/squared_log_obj.cc
@@ -28,7 +28,7 @@ auto const kRegisterSquaredLogValidationCpu =
 
 class SquaredLogErrorRegression : public FitIntercept {
  public:
-  void Configure(Args const&) override {}
+  std::set<std::string> Configure(Args const&) override { return {}; }
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
     return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));

--- a/src/objective/tweedie_obj.cc
+++ b/src/objective/tweedie_obj.cc
@@ -33,11 +33,12 @@ auto const kRegisterTweedieValidationCpu = elementwise::RegisterValidationCpu<Tw
 
 class TweedieRegression : public FitInterceptGlmLike {
  public:
-  void Configure(Args const& args) override {
-    param_.UpdateAllowUnknown(args);
+  std::set<std::string> Configure(Args const& args) override {
+    auto used = UpdateAndGetUsedParameters(&param_, args);
     std::ostringstream os;
     os << "tweedie-nloglik@" << param_.tweedie_variance_power;
     metric_ = os.str();
+    return used;
   }
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {

--- a/src/tree/updater_approx.cc
+++ b/src/tree/updater_approx.cc
@@ -251,7 +251,9 @@ class GlobalApproxUpdater : public TreeUpdater {
     monitor_.Init(__func__);
   }
 
-  void Configure(Args const &args) override { hist_param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(Args const &args) override {
+    return UpdateAndGetUsedParameters(&hist_param_, args);
+  }
   void LoadConfig(Json const &in) override {
     auto const &config = get<Object const>(in);
     FromJson(config.at("hist_train_param"), &hist_param_);

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -61,7 +61,9 @@ class ColMaker : public TreeUpdater {
  public:
   explicit ColMaker(Context const *ctx)
       : TreeUpdater(ctx), column_sampler_{std::make_shared<common::ColumnSampler>()} {}
-  void Configure(const Args &args) override { colmaker_param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(const Args &args) override {
+    return UpdateAndGetUsedParameters(&colmaker_param_, args);
+  }
 
   void LoadConfig(Json const &in) override {
     auto const &config = get<Object const>(in);

--- a/src/tree/updater_gpu_hist.cu
+++ b/src/tree/updater_gpu_hist.cu
@@ -650,13 +650,14 @@ class GPUHistMaker : public TreeUpdater {
       : TreeUpdater(ctx),
         task_{task},
         column_sampler_{std::make_shared<common::ColumnSampler>()} {};
-  void Configure(const Args& args) override {
+  std::set<std::string> Configure(const Args& args) override {
     // Used in test to count how many configurations are performed
     LOG(DEBUG) << "[GPU Hist]: Configure";
-    hist_maker_param_.UpdateAllowUnknown(args);
+    auto used = UpdateAndGetUsedParameters(&hist_maker_param_, args);
     initialised_ = false;
 
     monitor_.Init("updater_gpu_hist");
+    return used;
   }
 
   void LoadConfig(Json const& in) override {
@@ -764,13 +765,14 @@ class GPUGlobalApproxMaker : public TreeUpdater {
       : TreeUpdater(ctx),
         column_sampler_{std::make_shared<common::ColumnSampler>()},
         task_{task} {};
-  void Configure(Args const& args) override {
+  std::set<std::string> Configure(Args const& args) override {
     // Used in test to count how many configurations are performed
     LOG(DEBUG) << "[GPU Approx]: Configure";
-    hist_maker_param_.UpdateAllowUnknown(args);
+    auto used = UpdateAndGetUsedParameters(&hist_maker_param_, args);
     initialised_ = false;
 
     monitor_.Init(this->Name());
+    return used;
   }
 
   void LoadConfig(Json const& in) override {

--- a/src/tree/updater_prune.cc
+++ b/src/tree/updater_prune.cc
@@ -31,7 +31,7 @@ class TreePruner : public TreeUpdater {
   explicit TreePruner(Context const* ctx) : TreeUpdater(ctx) { pruner_monitor_.Init("TreePruner"); }
   [[nodiscard]] char const* Name() const override { return "prune"; }
   // set training parameter
-  void Configure(const Args&) override {}
+  std::set<std::string> Configure(const Args&) override { return {}; }
 
   void LoadConfig(Json const&) override {}
   void SaveConfig(Json*) const override {}

--- a/src/tree/updater_quantile_hist.cc
+++ b/src/tree/updater_quantile_hist.cc
@@ -580,7 +580,9 @@ class QuantileHistMaker : public TreeUpdater {
   explicit QuantileHistMaker(Context const *ctx, ObjInfo const *)
       : TreeUpdater{ctx}, column_sampler_{std::make_shared<common::ColumnSampler>()} {}
 
-  void Configure(Args const &args) override { hist_param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(Args const &args) override {
+    return UpdateAndGetUsedParameters(&hist_param_, args);
+  }
   void LoadConfig(Json const &in) override {
     auto const &config = get<Object const>(in);
     FromJson(config.at("hist_train_param"), &hist_param_);

--- a/src/tree/updater_refresh.cc
+++ b/src/tree/updater_refresh.cc
@@ -25,7 +25,7 @@ DMLC_REGISTRY_FILE_TAG(updater_refresh);
 class TreeRefresher : public TreeUpdater {
  public:
   explicit TreeRefresher(Context const *ctx) : TreeUpdater(ctx) {}
-  void Configure(const Args &) override {}
+  std::set<std::string> Configure(const Args &) override { return {}; }
   void LoadConfig(Json const &) override {}
   void SaveConfig(Json *) const override {}
 

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -80,6 +80,42 @@ TEST(Learner, ParameterValidation) {
   ASSERT_THAT([&] { learner->Configure(); }, GMockThrow(R"("tree method" contains whitespace)"));
 }
 
+TEST(Learner, ParameterValidationUsesConsumedParameters) {
+  auto p_mat = RandomDataGenerator{1, 1, 0}.GenerateDMatrix(true);
+  auto configure = [&p_mat](Args params) {
+    auto learner = std::unique_ptr<Learner>(Learner::Create({p_mat}));
+    params.emplace_back("validate_parameters", "1");
+    params.emplace_back("verbosity", "1");
+    learner->SetParams(params);
+
+    testing::internal::CaptureStderr();
+    learner->Configure();
+    return testing::internal::GetCapturedStderr();
+  };
+
+  // Report the spelling supplied by the user, including aliases.
+  auto output = configure({{"eta", "0.3"},
+                           {"lambda", "1.0"},
+                           {"alpha", "0.0"},
+                           {"gamma", "0.0"},
+                           {"random_state", "0"},
+                           {"n_jobs", "1"}});
+  EXPECT_EQ(output.find("Parameters:"), std::string::npos);
+
+  // Collect parameters from the active model and updater recursively.
+  output = configure({{"tree_method", "hist"}, {"num_parallel_tree", "2"}, {"max_bin", "64"}});
+  EXPECT_EQ(output.find("Parameters:"), std::string::npos);
+
+  // A parameter for an inactive component is not consumed.
+  output = configure({{"booster", "gblinear"}, {"max_depth", "3"}});
+  EXPECT_NE(output.find(R"(Parameters: { "max_depth" })"), std::string::npos);
+
+  // More than one active component can consume the same parameter.
+  output = configure(
+      {{"objective", "reg:quantileerror"}, {"eval_metric", "quantile"}, {"quantile_alpha", "0.5"}});
+  EXPECT_EQ(output.find("Parameters:"), std::string::npos);
+}
+
 TEST(Learner, DeprecatedGblinearBooster) {
   auto p_mat = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix();
 


### PR DESCRIPTION
## Summary

- make component `Configure` methods return the parameter names they consume
- recursively merge consumed parameters through objectives, metrics, boosters, and updaters
- validate user-supplied parameters against those consumed names instead of traversing `SaveConfig()` JSON

## Motivation

Parameter validation currently infers valid keys from serialized configuration. This couples validation to the shape of `SaveConfig()` and loses the spelling supplied by the caller, including aliases.

This proposal records consumption at the point where each parameter object is updated. Composite components merge the results from their active children, and the learner compares the original input keys with the final consumed set. A key may still be consumed by more than one component; set union handles that naturally.

As a result, aliases are recognized without adding them to serialization, parameters for inactive components are reported, and configuration validation no longer depends on the persistence/debug representation.

## Developer impact

Internal component interfaces that implement `Configure` now return `std::set<std::string>`. Custom objective examples and the SYCL updater are migrated in this change.

`SaveConfig()` output and model serialization are unchanged.

## Validation

- built the CPU `testxgboost` target
- ran the `Learner.*` test suite (14 tests passed)
- added coverage for aliases, recursive updater parameters, inactive components, and a parameter shared by an objective and metric
- `git diff --check`