### PR TITLE
Normalize non-native NumPy array byte order

### DIFF
--- a/python-package/xgboost/_data_utils.py
+++ b/python-package/xgboost/_data_utils.py
@@ -408,6 +408,9 @@ def _ensure_np_dtype(
     data: DataType, dtype: Optional[NumpyDType]
 ) -> Tuple[np.ndarray, Optional[NumpyDType]]:
     """Ensure the np array has correct type and is contiguous."""
+    if not data.dtype.isnative:
+        data = data.astype(data.dtype.newbyteorder("="), copy=False)
+        dtype = data.dtype
     if array_hasobject(data) or data.dtype in [np.float16, np.bool_]:
         dtype = np.float32
         data = data.astype(dtype, copy=False)

--- a/tests/python/test_dmatrix.py
+++ b/tests/python/test_dmatrix.py
@@ -62,6 +62,19 @@ class TestDMatrix:
         with pytest.raises(ValueError):
             xgb.DMatrix(data)
 
+    def test_dmatrix_numpy_non_native_byte_order(self):
+        data = np.arange(1, 7, dtype=np.float32).reshape(2, 3)
+        labels = np.arange(1, 3, dtype=np.float32)
+        swapped_data = data.astype(data.dtype.newbyteorder("S"))
+        swapped_labels = labels.astype(labels.dtype.newbyteorder("S"))
+        assert not swapped_data.dtype.isnative
+        assert not swapped_labels.dtype.isnative
+
+        dmat = xgb.DMatrix(swapped_data, label=swapped_labels)
+
+        np.testing.assert_array_equal(dmat.get_data().toarray(), data)
+        np.testing.assert_array_equal(dmat.get_label(), labels)
+
     def test_np_view(self):
         # Sliced Float32 array
         y = np.array([12, 34, 56], np.float32)[::2]


### PR DESCRIPTION
## Summary

- normalize non-native-endian NumPy arrays before passing their array interface to native XGBoost code
- add a regression test covering both feature data and labels

Fixes #12433.

## Root cause and impact

NumPy's array interface records byte order in `typestr`, but XGBoost's NumPy normalization path did not convert non-native dtypes before the native reader accessed the underlying buffer. On a little-endian host, for example, a valid `>f4` value of `1.0` was silently read as approximately `4.6e-41`.

Normalizing these arrays to native byte order in `_ensure_np_dtype` covers dense matrix input and metadata such as labels. The same shared helper is also used by other NumPy-backed paths, including in-place prediction.

## Validation

- `pre-commit run --files python-package/xgboost/_data_utils.py tests/python/test_dmatrix.py`
- `pytest tests/python/test_dmatrix.py -q` (`24 passed, 1 skipped`)
- `pytest tests/python/test_predict.py tests/python/test_quantile_dmatrix.py -q` (`37 passed`)
- `pytest tests/python/test_data_iterator.py -q` (`13 passed, 1 skipped`)
- manually checked swapped-endian float and integer dtypes, labels, and parity between native and swapped-endian `inplace_predict` input on a CPU build

## AI assistance disclosure

OpenAI Codex assisted with repository inspection, reproduction, implementation, test execution, and drafting this pull request. I reviewed the focused diff and verified the reported behavior and validation results locally.
