### PR TITLE
Split multiclass and absolute-error objective kernels

### DIFF
--- a/R-package/src/Makevars.in
+++ b/R-package/src/Makevars.in
@@ -46,6 +46,7 @@ OBJECTS= \
     $(PKGROOT)/src/metric/auc.o \
     $(PKGROOT)/src/metric/survival_metric.o \
     $(PKGROOT)/src/objective/objective.o \
+    $(PKGROOT)/src/objective/absolute_error_obj.o \
     $(PKGROOT)/src/objective/regression_obj.o \
     $(PKGROOT)/src/objective/multiclass_obj.o \
     $(PKGROOT)/src/objective/lambdarank_obj.o \

--- a/R-package/src/Makevars.win.in
+++ b/R-package/src/Makevars.win.in
@@ -45,6 +45,7 @@ OBJECTS= \
     $(PKGROOT)/src/metric/auc.o \
     $(PKGROOT)/src/metric/survival_metric.o \
     $(PKGROOT)/src/objective/objective.o \
+    $(PKGROOT)/src/objective/absolute_error_obj.o \
     $(PKGROOT)/src/objective/regression_obj.o \
     $(PKGROOT)/src/objective/multiclass_obj.o \
     $(PKGROOT)/src/objective/lambdarank_obj.o \

--- a/src/objective/absolute_error_obj.cc
+++ b/src/objective/absolute_error_obj.cc
@@ -125,6 +125,18 @@ auto const kRegisterAbsoluteErrorInitEstimationCpu =
                                                                   &AbsoluteErrorInitEstimationCpu};
 }  // namespace
 
+/**
+ * @brief Smooth MM approximation to the mean absolute error.
+ *
+ * At each boosting iteration and for each target, choose the automatic scale
+ *
+ *   delta = E_w[sqrt(abs(prediction - label))]^2.
+ *
+ * For residual r, q = sqrt(1 + (r / delta)^2), the pseudo-Huber gradient is r / q.
+ * We use 1 / q as the Hessian instead of the exact pseudo-Huber Hessian 1 / q^3. This is
+ * the majorization curvature that produces a stable IRLS update while approaching the L1
+ * gradient as the residual scale contracts.
+ */
 class MeanAbsoluteError : public ObjFunction {
  public:
   std::set<std::string> Configure(Args const&) override { return {}; }

--- a/src/objective/absolute_error_obj.cc
+++ b/src/objective/absolute_error_obj.cc
@@ -127,7 +127,7 @@ auto const kRegisterAbsoluteErrorInitEstimationCpu =
 
 class MeanAbsoluteError : public ObjFunction {
  public:
-  void Configure(Args const&) override {}
+  std::set<std::string> Configure(Args const&) override { return {}; }
   [[nodiscard]] ObjInfo Task() const override { return {ObjInfo::kRegression, false}; }
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
     return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));

--- a/src/objective/absolute_error_obj.cc
+++ b/src/objective/absolute_error_obj.cc
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file absolute_error_obj.cc
+ * \brief CPU implementation and registration of the absolute-error objective.
+ */
+#include "absolute_error_obj.h"
+
+#include <dmlc/registry.h>
+
+#include <algorithm>  // for max
+#include <cmath>      // for fabsf, hypotf, sqrtf
+#include <cstddef>    // for size_t
+#include <cstdint>    // for int32_t
+#include <memory>     // for unique_ptr
+#include <vector>     // for vector
+
+#include "../collective/aggregator.h"   // for GlobalSum
+#include "../common/common.h"           // for CloseTo
+#include "../common/kernel.h"           // for DispatchKernel, KernelRegistration
+#include "../common/linalg_op.h"        // for ElementWiseKernel
+#include "../common/math.h"             // for CloseTo
+#include "../common/numeric.h"          // for Reduce
+#include "../common/optional_weight.h"  // for MakeOptionalWeights
+#include "../common/stats.h"            // for SampleMean, WeightedSampleMean
+#include "../common/transform.h"        // for Transform
+#include "../tree/fit_stump.h"          // for FitStump
+#include "init_estimation.h"            // for CheckInitInputs
+#include "xgboost/json.h"               // for Json, Object, String
+#include "xgboost/logging.h"            // for CHECK, LOG
+#include "xgboost/objective.h"          // for ObjFunction
+#include "xgboost/string_view.h"        // for StringView
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(absolute_error_obj);
+
+namespace {
+void AbsoluteErrorGradientCpu(Context const* ctx, HostDeviceVector<float> const& preds,
+                              MetaInfo const& info, bst_target_t n_targets,
+                              linalg::Matrix<GradientPair>* out_gpair) {
+  auto labels = info.labels.HostView();
+  auto predt =
+      linalg::MakeTensorView(DeviceOrd::CPU(), preds.ConstHostSpan(), info.num_row_, n_targets);
+  auto weights = common::MakeOptionalWeights(DeviceOrd::CPU(), info.weights_);
+
+  HostDeviceVector<float> root_residual(info.num_row_, 0.0f, DeviceOrd::CPU());
+  std::vector<double> scale_stats(n_targets + 1, 0.0);
+  for (bst_target_t target{0}; target < n_targets; ++target) {
+    common::Transform<>::Init(
+        [=](std::size_t i, common::Span<float> residual) {
+          residual[i] = weights[i] * sqrtf(fabsf(predt(i, target) - labels(i, target)));
+        },
+        common::Range{0, static_cast<std::int64_t>(info.num_row_)}, ctx->Threads(),
+        DeviceOrd::CPU())
+        .Eval(&root_residual);
+    scale_stats[target] = common::Reduce(ctx, root_residual);
+  }
+  scale_stats.back() = common::SumOptionalWeights(ctx, weights, info.num_row_);
+  auto cpu_ctx = ctx->MakeCPU();
+  collective::SafeColl(
+      collective::GlobalSum(&cpu_ctx, linalg::MakeVec(scale_stats.data(), scale_stats.size())));
+
+  std::vector<float> scale(n_targets, 0.0f);
+  for (bst_target_t target{0}; target < n_targets; ++target) {
+    if (!common::CloseTo(scale_stats.back(), 0.0)) {
+      auto root_mean = scale_stats[target] / scale_stats.back();
+      scale[target] = static_cast<float>(root_mean * root_mean);
+    }
+  }
+
+  out_gpair->SetDevice(DeviceOrd::CPU());
+  out_gpair->Reshape(info.num_row_, n_targets);
+  auto gpair = out_gpair->HostView();
+  linalg::cpu_impl::ElementWiseKernel(
+      gpair, ctx->Threads(), [=](std::size_t i, std::size_t j) mutable {
+        auto residual = predt(i, j) - labels(i, j);
+        auto norm = hypotf(scale[j], residual);
+        auto curvature = norm > 0.0f ? scale[j] / norm : 1.0f;
+        auto weight = weights[i];
+        gpair(i, j) = {weight * residual * curvature, weight * curvature};
+      });
+}
+
+auto const kRegisterAbsoluteErrorGradientCpu =
+    common::KernelRegistration<AbsoluteErrorGradientKernel>{DeviceOrd::kCPU,
+                                                            &AbsoluteErrorGradientCpu};
+}  // namespace
+
+class MeanAbsoluteError : public ObjFunction {
+ public:
+  void Configure(Args const&) override {}
+  [[nodiscard]] ObjInfo Task() const override { return {ObjInfo::kRegression, false}; }
+  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
+    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
+  }
+
+  void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info, std::int32_t,
+                   linalg::Matrix<GradientPair>* out_gpair) override {
+    CheckInitInputs(info);
+    CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
+    common::DispatchKernel<AbsoluteErrorGradientKernel>(ctx_, preds, info, this->Targets(info),
+                                                        out_gpair);
+  }
+
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
+    CheckInitInputs(info);
+    auto n_targets = this->Targets(info);
+    base_score->Reshape(n_targets);
+
+    double sum_weight = info.weights_.Empty() ? static_cast<double>(info.num_row_)
+                                              : common::Reduce(ctx_, info.weights_);
+    auto cpu_ctx = ctx_->MakeCPU();
+    collective::SafeColl(
+        collective::GlobalSum(&cpu_ctx, linalg::MakeVec(&sum_weight, std::size_t{1})));
+    if (common::CloseTo(sum_weight, 0.0)) {
+      LOG(WARNING) << "Sum of weights is close to 0.0, skipping base score estimation.";
+      *base_score = linalg::Zeros<float>(ctx_, n_targets);
+      return;
+    }
+
+    linalg::Vector<float> mean;
+    if (info.weights_.Empty()) {
+      common::SampleMean(ctx_, info.labels, &mean);
+    } else {
+      common::WeightedSampleMean(ctx_, info.labels, info.weights_, &mean);
+    }
+    CHECK_EQ(mean.Size(), n_targets);
+
+    auto mean_h = mean.HostView();
+    HostDeviceVector<float> predt(info.labels.Size());
+    auto predt_h = predt.HostSpan();
+    for (std::size_t i{0}; i < info.num_row_; ++i) {
+      for (bst_target_t target{0}; target < n_targets; ++target) {
+        predt_h[i * n_targets + target] = mean_h(target);
+      }
+    }
+
+    linalg::Matrix<GradientPair> gpair;
+    common::DispatchKernel<AbsoluteErrorGradientKernel>(ctx_, predt, info, n_targets, &gpair);
+    tree::FitStump(ctx_, gpair, n_targets, base_score);
+
+    auto out = base_score->HostView();
+    for (bst_target_t target{0}; target < n_targets; ++target) {
+      out(target) += mean_h(target);
+    }
+  }
+
+  [[nodiscard]] const char* DefaultEvalMetric() const override { return "mae"; }
+  void SaveConfig(Json* out) const override { (*out)["name"] = String("reg:absoluteerror"); }
+  void LoadConfig(Json const& in) override {
+    CHECK_EQ(StringView{get<String const>(in["name"])}, StringView{"reg:absoluteerror"});
+  }
+};
+
+XGBOOST_REGISTER_OBJECTIVE(MeanAbsoluteError, "reg:absoluteerror")
+    .describe("Mean absolute error with automatic smooth majorization.")
+    .set_body([]() { return new MeanAbsoluteError(); });
+}  // namespace xgboost::obj

--- a/src/objective/absolute_error_obj.cc
+++ b/src/objective/absolute_error_obj.cc
@@ -80,9 +80,49 @@ void AbsoluteErrorGradientCpu(Context const* ctx, HostDeviceVector<float> const&
       });
 }
 
+void AbsoluteErrorInitEstimationCpu(Context const* ctx, MetaInfo const& info,
+                                    bst_target_t n_targets, linalg::Vector<float>* base_score) {
+  double sum_weight = info.weights_.Empty() ? static_cast<double>(info.num_row_)
+                                            : common::Reduce(ctx, info.weights_);
+  collective::SafeColl(collective::GlobalSum(ctx, linalg::MakeVec(&sum_weight, std::size_t{1})));
+  if (common::CloseTo(sum_weight, 0.0)) {
+    LOG(WARNING) << "Sum of weights is close to 0.0, skipping base score estimation.";
+    *base_score = linalg::Zeros<float>(ctx, n_targets);
+    return;
+  }
+
+  linalg::Vector<float> mean;
+  if (info.weights_.Empty()) {
+    common::SampleMean(ctx, info.labels, &mean);
+  } else {
+    common::WeightedSampleMean(ctx, info.labels, info.weights_, &mean);
+  }
+  CHECK_EQ(mean.Size(), n_targets);
+
+  HostDeviceVector<float> predt(info.labels.Size(), 0.0f, DeviceOrd::CPU());
+  auto predt_h =
+      linalg::MakeTensorView(DeviceOrd::CPU(), predt.HostSpan(), info.num_row_, n_targets);
+  auto mean_h = mean.HostView();
+  linalg::cpu_impl::ElementWiseKernel(
+      predt_h, ctx->Threads(),
+      [=](std::size_t i, std::size_t target) mutable { predt_h(i, target) = mean_h(target); });
+
+  linalg::Matrix<GradientPair> gpair;
+  AbsoluteErrorGradientCpu(ctx, predt, info, n_targets, &gpair);
+  tree::FitStump(ctx, gpair, n_targets, base_score);
+
+  auto out = base_score->HostView();
+  for (bst_target_t target{0}; target < n_targets; ++target) {
+    out(target) += mean_h(target);
+  }
+}
+
 auto const kRegisterAbsoluteErrorGradientCpu =
     common::KernelRegistration<AbsoluteErrorGradientKernel>{DeviceOrd::kCPU,
                                                             &AbsoluteErrorGradientCpu};
+auto const kRegisterAbsoluteErrorInitEstimationCpu =
+    common::KernelRegistration<AbsoluteErrorInitEstimationKernel>{DeviceOrd::kCPU,
+                                                                  &AbsoluteErrorInitEstimationCpu};
 }  // namespace
 
 class MeanAbsoluteError : public ObjFunction {
@@ -103,45 +143,8 @@ class MeanAbsoluteError : public ObjFunction {
 
   void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
     CheckInitInputs(info);
-    auto n_targets = this->Targets(info);
-    base_score->Reshape(n_targets);
-
-    double sum_weight = info.weights_.Empty() ? static_cast<double>(info.num_row_)
-                                              : common::Reduce(ctx_, info.weights_);
-    auto cpu_ctx = ctx_->MakeCPU();
-    collective::SafeColl(
-        collective::GlobalSum(&cpu_ctx, linalg::MakeVec(&sum_weight, std::size_t{1})));
-    if (common::CloseTo(sum_weight, 0.0)) {
-      LOG(WARNING) << "Sum of weights is close to 0.0, skipping base score estimation.";
-      *base_score = linalg::Zeros<float>(ctx_, n_targets);
-      return;
-    }
-
-    linalg::Vector<float> mean;
-    if (info.weights_.Empty()) {
-      common::SampleMean(ctx_, info.labels, &mean);
-    } else {
-      common::WeightedSampleMean(ctx_, info.labels, info.weights_, &mean);
-    }
-    CHECK_EQ(mean.Size(), n_targets);
-
-    auto mean_h = mean.HostView();
-    HostDeviceVector<float> predt(info.labels.Size());
-    auto predt_h = predt.HostSpan();
-    for (std::size_t i{0}; i < info.num_row_; ++i) {
-      for (bst_target_t target{0}; target < n_targets; ++target) {
-        predt_h[i * n_targets + target] = mean_h(target);
-      }
-    }
-
-    linalg::Matrix<GradientPair> gpair;
-    common::DispatchKernel<AbsoluteErrorGradientKernel>(ctx_, predt, info, n_targets, &gpair);
-    tree::FitStump(ctx_, gpair, n_targets, base_score);
-
-    auto out = base_score->HostView();
-    for (bst_target_t target{0}; target < n_targets; ++target) {
-      out(target) += mean_h(target);
-    }
+    common::DispatchKernel<AbsoluteErrorInitEstimationKernel>(ctx_, info, this->Targets(info),
+                                                              base_score);
   }
 
   [[nodiscard]] const char* DefaultEvalMetric() const override { return "mae"; }

--- a/src/objective/absolute_error_obj.cu
+++ b/src/objective/absolute_error_obj.cu
@@ -4,17 +4,22 @@
  * \brief CUDA implementation of the absolute-error gradient kernel.
  */
 #include <dmlc/registry.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/discard_iterator.h>
+#include <thrust/reduce.h>
 
-#include <cmath>   // for fabsf, hypotf, sqrtf
-#include <vector>  // for vector
+#include <cmath>
+#include <cstddef>
 
-#include "../collective/aggregator.h"   // for GlobalSum
-#include "../common/kernel.h"           // for KernelRegistration
-#include "../common/linalg_op.cuh"      // for ElementWiseKernel
-#include "../common/math.h"             // for CloseTo
-#include "../common/numeric.h"          // for Reduce
-#include "../common/optional_weight.h"  // for MakeOptionalWeights
-#include "../common/transform.h"        // for Transform
+#include "../collective/aggregator.cuh"
+#include "../common/device_helpers.cuh"  // for LaunchN, MakeTransformIterator
+#include "../common/kernel.h"            // for KernelRegistration
+#include "../common/linalg_op.cuh"       // for ElementWiseKernel
+#include "../common/math.h"              // for CloseTo
+#include "../common/numeric.h"           // for Reduce
+#include "../common/optional_weight.h"   // for MakeOptionalWeights
+#include "../common/stats.h"
+#include "../tree/fit_stump.h"
 #include "absolute_error_obj.h"
 
 namespace xgboost::obj {
@@ -30,32 +35,37 @@ void AbsoluteErrorGradientCuda(Context const* ctx, HostDeviceVector<float> const
   auto predt = linalg::MakeTensorView(ctx, &preds, info.num_row_, n_targets);
   auto weights = common::MakeOptionalWeights(device, info.weights_);
 
-  HostDeviceVector<float> root_residual(info.num_row_, 0.0f, device);
-  std::vector<double> scale_stats(n_targets + 1, 0.0);
-  for (bst_target_t target{0}; target < n_targets; ++target) {
-    common::Transform<>::Init(
-        [=] XGBOOST_DEVICE(std::size_t i, common::Span<float> residual) {
-          residual[i] = weights[i] * sqrtf(fabsf(predt(i, target) - labels(i, target)));
-        },
-        common::Range{0, static_cast<std::int64_t>(info.num_row_)}, ctx->Threads(), device)
-        .Eval(&root_residual);
-    scale_stats[target] = common::Reduce(ctx, root_residual);
-  }
-  scale_stats.back() = common::SumOptionalWeights(ctx, weights, info.num_row_);
-  auto cpu_ctx = ctx->MakeCPU();
-  collective::SafeColl(
-      collective::GlobalSum(&cpu_ctx, linalg::MakeVec(scale_stats.data(), scale_stats.size())));
+  auto n_rows = info.num_row_;
+  auto n_stats = static_cast<std::size_t>(n_targets) + 1;
+  linalg::Vector<double> scale_stats = linalg::Zeros<double>(ctx, n_stats);
+  auto key_it = dh::MakeTransformIterator<bst_target_t>(
+      thrust::make_counting_iterator(0ul),
+      [=] XGBOOST_DEVICE(std::size_t i) { return static_cast<bst_target_t>(i / n_rows); });
+  auto value_it = dh::MakeTransformIterator<double>(
+      thrust::make_counting_iterator(0ul), [=] XGBOOST_DEVICE(std::size_t i) {
+        auto target = i / n_rows;
+        auto row = i % n_rows;
+        if (target == n_targets) {
+          return static_cast<double>(weights[row]);
+        }
+        return static_cast<double>(weights[row] *
+                                   sqrtf(fabsf(predt(row, target) - labels(row, target))));
+      });
+  auto stats = scale_stats.View(device);
+  auto n_values = n_rows * n_stats;
+  thrust::reduce_by_key(ctx->CUDACtx()->CTP(), key_it, key_it + n_values, value_it,
+                        thrust::make_discard_iterator(), stats.Values().data());
+  collective::SafeColl(collective::GlobalSum(ctx, stats));
 
   HostDeviceVector<float> scale(n_targets, 0.0f, device);
-  auto scale_h = scale.HostSpan();
-  for (bst_target_t target{0}; target < n_targets; ++target) {
-    if (!common::CloseTo(scale_stats.back(), 0.0)) {
-      auto root_mean = scale_stats[target] / scale_stats.back();
-      scale_h[target] = static_cast<float>(root_mean * root_mean);
+  auto scale_d = scale.DeviceSpan();
+  dh::LaunchN(n_targets, ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(std::size_t target) {
+    auto sum_weight = stats(n_targets);
+    if (sum_weight != 0.0) {
+      auto root_mean = stats(target) / sum_weight;
+      scale_d[target] = static_cast<float>(root_mean * root_mean);
     }
-  }
-  scale.SetDevice(device);
-  auto scale_d = scale.ConstDeviceSpan();
+  });
 
   out_gpair->SetDevice(device);
   out_gpair->Reshape(info.num_row_, n_targets);
@@ -72,8 +82,51 @@ void AbsoluteErrorGradientCuda(Context const* ctx, HostDeviceVector<float> const
       ctx->CUDACtx()->Stream());
 }
 
+void AbsoluteErrorInitEstimationCuda(Context const* ctx, MetaInfo const& info,
+                                     bst_target_t n_targets, linalg::Vector<float>* base_score) {
+  auto device = ctx->Device();
+  double sum_weight = info.weights_.Empty() ? static_cast<double>(info.num_row_)
+                                            : common::Reduce(ctx, info.weights_);
+  auto cpu_ctx = ctx->MakeCPU();
+  collective::SafeColl(
+      collective::GlobalSum(&cpu_ctx, linalg::MakeVec(&sum_weight, std::size_t{1})));
+  if (common::CloseTo(sum_weight, 0.0)) {
+    LOG(WARNING) << "Sum of weights is close to 0.0, skipping base score estimation.";
+    *base_score = linalg::Zeros<float>(ctx, n_targets);
+    return;
+  }
+
+  linalg::Vector<float> mean;
+  if (info.weights_.Empty()) {
+    common::SampleMean(ctx, info.labels, &mean);
+  } else {
+    common::WeightedSampleMean(ctx, info.labels, info.weights_, &mean);
+  }
+  CHECK_EQ(mean.Size(), n_targets);
+  auto mean_d = mean.View(device);
+
+  HostDeviceVector<float> predt(info.labels.Size(), 0.0f, device);
+  auto predt_d = linalg::MakeTensorView(ctx, &predt, info.num_row_, n_targets);
+  linalg::cuda_impl::ElementWiseKernel(
+      predt_d,
+      [=] XGBOOST_DEVICE(std::size_t i, std::size_t target) mutable {
+        predt_d(i, target) = mean_d(target);
+      },
+      ctx->CUDACtx()->Stream());
+
+  linalg::Matrix<GradientPair> gpair;
+  AbsoluteErrorGradientCuda(ctx, predt, info, n_targets, &gpair);
+  tree::FitStump(ctx, gpair, n_targets, base_score);
+
+  auto out = base_score->View(device);
+  dh::LaunchN(n_targets, ctx->CUDACtx()->Stream(),
+              [=] XGBOOST_DEVICE(std::size_t target) mutable { out(target) += mean_d(target); });
+}
 auto const kRegisterAbsoluteErrorGradientCuda =
     common::KernelRegistration<AbsoluteErrorGradientKernel>{DeviceOrd::kCUDA,
                                                             &AbsoluteErrorGradientCuda};
+auto const kRegisterAbsoluteErrorInitEstimationCuda =
+    common::KernelRegistration<AbsoluteErrorInitEstimationKernel>{DeviceOrd::kCUDA,
+                                                                  &AbsoluteErrorInitEstimationCuda};
 }  // namespace
 }  // namespace xgboost::obj

--- a/src/objective/absolute_error_obj.cu
+++ b/src/objective/absolute_error_obj.cu
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file absolute_error_obj.cu
+ * \brief CUDA implementation of the absolute-error gradient kernel.
+ */
+#include <dmlc/registry.h>
+
+#include <cmath>   // for fabsf, hypotf, sqrtf
+#include <vector>  // for vector
+
+#include "../collective/aggregator.h"   // for GlobalSum
+#include "../common/kernel.h"           // for KernelRegistration
+#include "../common/linalg_op.cuh"      // for ElementWiseKernel
+#include "../common/math.h"             // for CloseTo
+#include "../common/numeric.h"          // for Reduce
+#include "../common/optional_weight.h"  // for MakeOptionalWeights
+#include "../common/transform.h"        // for Transform
+#include "absolute_error_obj.h"
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(absolute_error_kernel_cuda);
+namespace {
+void AbsoluteErrorGradientCuda(Context const* ctx, HostDeviceVector<float> const& preds,
+                               MetaInfo const& info, bst_target_t n_targets,
+                               linalg::Matrix<GradientPair>* out_gpair) {
+  auto device = ctx->Device();
+  CHECK(device.IsCUDA());
+  auto labels = info.labels.View(device);
+  preds.SetDevice(device);
+  auto predt = linalg::MakeTensorView(ctx, &preds, info.num_row_, n_targets);
+  auto weights = common::MakeOptionalWeights(device, info.weights_);
+
+  HostDeviceVector<float> root_residual(info.num_row_, 0.0f, device);
+  std::vector<double> scale_stats(n_targets + 1, 0.0);
+  for (bst_target_t target{0}; target < n_targets; ++target) {
+    common::Transform<>::Init(
+        [=] XGBOOST_DEVICE(std::size_t i, common::Span<float> residual) {
+          residual[i] = weights[i] * sqrtf(fabsf(predt(i, target) - labels(i, target)));
+        },
+        common::Range{0, static_cast<std::int64_t>(info.num_row_)}, ctx->Threads(), device)
+        .Eval(&root_residual);
+    scale_stats[target] = common::Reduce(ctx, root_residual);
+  }
+  scale_stats.back() = common::SumOptionalWeights(ctx, weights, info.num_row_);
+  auto cpu_ctx = ctx->MakeCPU();
+  collective::SafeColl(
+      collective::GlobalSum(&cpu_ctx, linalg::MakeVec(scale_stats.data(), scale_stats.size())));
+
+  HostDeviceVector<float> scale(n_targets, 0.0f, device);
+  auto scale_h = scale.HostSpan();
+  for (bst_target_t target{0}; target < n_targets; ++target) {
+    if (!common::CloseTo(scale_stats.back(), 0.0)) {
+      auto root_mean = scale_stats[target] / scale_stats.back();
+      scale_h[target] = static_cast<float>(root_mean * root_mean);
+    }
+  }
+  scale.SetDevice(device);
+  auto scale_d = scale.ConstDeviceSpan();
+
+  out_gpair->SetDevice(device);
+  out_gpair->Reshape(info.num_row_, n_targets);
+  auto gpair = out_gpair->View(device);
+  linalg::cuda_impl::ElementWiseKernel(
+      gpair,
+      [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
+        auto residual = predt(i, j) - labels(i, j);
+        auto norm = hypotf(scale_d[j], residual);
+        auto curvature = norm > 0.0f ? scale_d[j] / norm : 1.0f;
+        auto weight = weights[i];
+        gpair(i, j) = {weight * residual * curvature, weight * curvature};
+      },
+      ctx->CUDACtx()->Stream());
+}
+
+auto const kRegisterAbsoluteErrorGradientCuda =
+    common::KernelRegistration<AbsoluteErrorGradientKernel>{DeviceOrd::kCUDA,
+                                                            &AbsoluteErrorGradientCuda};
+}  // namespace
+}  // namespace xgboost::obj

--- a/src/objective/absolute_error_obj.h
+++ b/src/objective/absolute_error_obj.h
@@ -17,6 +17,10 @@ struct AbsoluteErrorGradientKernel {
   using Signature = void(Context const*, HostDeviceVector<float> const&, MetaInfo const&,
                          bst_target_t, linalg::Matrix<GradientPair>*);
 };
+
+struct AbsoluteErrorInitEstimationKernel {
+  using Signature = void(Context const*, MetaInfo const&, bst_target_t, linalg::Vector<float>*);
+};
 }  // namespace xgboost::obj
 
 #endif  // XGBOOST_OBJECTIVE_ABSOLUTE_ERROR_OBJ_H_

--- a/src/objective/absolute_error_obj.h
+++ b/src/objective/absolute_error_obj.h
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file absolute_error_obj.h
+ * \brief Shared declarations for the absolute-error objective.
+ */
+#ifndef XGBOOST_OBJECTIVE_ABSOLUTE_ERROR_OBJ_H_
+#define XGBOOST_OBJECTIVE_ABSOLUTE_ERROR_OBJ_H_
+
+#include "xgboost/base.h"                // for GradientPair, bst_target_t
+#include "xgboost/context.h"             // for Context
+#include "xgboost/data.h"                // for MetaInfo
+#include "xgboost/host_device_vector.h"  // for HostDeviceVector
+#include "xgboost/linalg.h"              // for Matrix
+
+namespace xgboost::obj {
+struct AbsoluteErrorGradientKernel {
+  using Signature = void(Context const*, HostDeviceVector<float> const&, MetaInfo const&,
+                         bst_target_t, linalg::Matrix<GradientPair>*);
+};
+}  // namespace xgboost::obj
+
+#endif  // XGBOOST_OBJECTIVE_ABSOLUTE_ERROR_OBJ_H_

--- a/src/objective/multiclass_obj.cc
+++ b/src/objective/multiclass_obj.cc
@@ -17,6 +17,7 @@
 
 #include "../collective/aggregator.h"   // for GlobalSum
 #include "../common/kernel.h"           // for DispatchKernel, KernelRegistration
+#include "../common/linalg_op.h"        // for SmallHistogram, vector operations
 #include "../common/math.h"             // for FindMaxIndex, Softmax
 #include "../common/optional_weight.h"  // for OptionalWeights
 #include "../common/stats.h"            // for Mean
@@ -84,8 +85,29 @@ void MulticlassTransformCpu(Context const* ctx, HostDeviceVector<float>* predict
   }
 }
 
+void MulticlassInitEstimationCpu(Context const* ctx, MetaInfo const& info, std::int64_t n_classes,
+                                 linalg::Vector<float>* base_score) {
+  *base_score = linalg::Zeros<float>(ctx, n_classes);
+  auto labels = info.labels.HostView();
+  common::OptionalWeights weights{info.weights_.ConstHostSpan()};
+  auto intercept = base_score->HostView();
+  linalg::SmallHistogram(ctx, labels, weights, intercept);
+  auto sum_weight = common::SumOptionalWeights(ctx, weights, info.labels.Size());
+  collective::SafeColl(collective::GlobalSum(ctx, intercept, &sum_weight));
+  CHECK_GE(sum_weight, kRtEps);
+  linalg::VecScaDiv(ctx, intercept, sum_weight);
+  linalg::LogE(ctx, intercept, kRtEps);
+  linalg::Vector<float> mean;
+  common::Mean(ctx, intercept, &mean);
+  common::DispatchKernel<MulticlassCenterKernel>(ctx, base_score->Data(),
+                                                 MulticlassCenter{mean.HostView()(0)});
+}
+
 auto const kRegisterMulticlassGradientCpu =
     common::KernelRegistration<MulticlassGradientKernel>{DeviceOrd::kCPU, &MulticlassGradientCpu};
+auto const kRegisterMulticlassInitEstimationCpu =
+    common::KernelRegistration<MulticlassInitEstimationKernel>{DeviceOrd::kCPU,
+                                                               &MulticlassInitEstimationCpu};
 auto const kRegisterMulticlassTransformCpu =
     common::KernelRegistration<MulticlassTransformKernel>{DeviceOrd::kCPU, &MulticlassTransformCpu};
 auto const kRegisterMulticlassValidationCpu =
@@ -153,21 +175,7 @@ class SoftmaxMultiClassObj : public ObjFunction {
     CHECK(valid)
         << "SoftmaxMultiClassObj: label must be discrete values in the range of [0, num_class).";
 
-    *base_score = linalg::Zeros<float>(ctx_, n_classes);
-    auto labels = info.labels.View(ctx_->Device());
-    auto weights = common::MakeOptionalWeights(ctx_->Device(), info.weights_);
-    auto intercept = base_score->View(ctx_->Device());
-    linalg::SmallHistogram(ctx_, labels, weights, intercept);
-    auto sum_weight = common::SumOptionalWeights(ctx_, weights, info.labels.Size());
-    collective::SafeColl(collective::GlobalSum(ctx_, intercept, &sum_weight));
-    CHECK_GE(sum_weight, kRtEps);
-    linalg::VecScaDiv(ctx_, intercept, sum_weight);
-    linalg::LogE(ctx_, intercept, kRtEps);
-    linalg::Vector<float> mean;
-    common::Mean(ctx_, intercept, &mean);
-    auto mean_h = mean.HostView();
-    common::DispatchKernel<MulticlassCenterKernel>(ctx_, base_score->Data(),
-                                                   MulticlassCenter{mean_h(0)});
+    common::DispatchKernel<MulticlassInitEstimationKernel>(ctx_, info, n_classes, base_score);
   }
 
  private:

--- a/src/objective/multiclass_obj.cc
+++ b/src/objective/multiclass_obj.cc
@@ -118,7 +118,9 @@ auto const kRegisterMulticlassCenterCpu = elementwise::RegisterTransformCpu<Mult
 class SoftmaxMultiClassObj : public ObjFunction {
  public:
   explicit SoftmaxMultiClassObj(bool output_prob) : output_prob_{output_prob} {}
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  std::set<std::string> Configure(Args const& args) override {
+    return UpdateAndGetUsedParameters(&param_, args);
+  }
   ObjInfo Task() const override { return ObjInfo::kClassification; }
 
   void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info, std::int32_t iter,

--- a/src/objective/multiclass_obj.cc
+++ b/src/objective/multiclass_obj.cc
@@ -1,18 +1,184 @@
-/*!
- * Copyright 2018 XGBoost contributors
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file multiclass_obj.cc
+ * \brief CPU implementations and registration of multiclass objectives.
  */
-
-// Dummy file to keep the CUDA conditional compile trick.
+#include "multiclass_obj.h"
 
 #include <dmlc/registry.h>
-namespace xgboost {
-namespace obj {
 
+#include <algorithm>  // for max
+#include <cassert>    // for assert
+#include <cmath>      // for expf, fmaxf
+#include <cstddef>    // for size_t
+#include <cstdint>    // for int32_t, int64_t
+#include <limits>     // for numeric_limits
+#include <vector>     // for vector
+
+#include "../collective/aggregator.h"   // for GlobalSum
+#include "../common/kernel.h"           // for DispatchKernel, KernelRegistration
+#include "../common/math.h"             // for FindMaxIndex, Softmax
+#include "../common/optional_weight.h"  // for OptionalWeights
+#include "../common/stats.h"            // for Mean
+#include "../common/threading_utils.h"  // for ParallelFor
+#include "multiclass_param.h"           // for SoftmaxMultiClassParam
+#include "xgboost/json.h"               // for FromJson, Json, String, ToJson
+#include "xgboost/logging.h"            // for CHECK
+#include "xgboost/objective.h"          // for ObjFunction
+
+namespace xgboost::obj {
 DMLC_REGISTRY_FILE_TAG(multiclass_obj);
+DMLC_REGISTER_PARAMETER(SoftmaxMultiClassParam);
 
-}  // namespace obj
-}  // namespace xgboost
+namespace {
+void MulticlassGradientCpu(Context const* ctx, HostDeviceVector<float> const& preds,
+                           MetaInfo const& info, std::int64_t n_classes,
+                           linalg::Matrix<GradientPair>* out_gpair) {
+  auto n_samples = info.num_row_;
+  auto predt =
+      linalg::MakeTensorView(DeviceOrd::CPU(), preds.ConstHostSpan(), n_samples, n_classes);
+  auto labels = info.labels.HostView();
+  common::OptionalWeights weights{info.weights_.ConstHostSpan()};
+  out_gpair->SetDevice(DeviceOrd::CPU());
+  out_gpair->Reshape(n_samples, n_classes);
+  auto gpair = out_gpair->HostView();
 
-#ifndef XGBOOST_USE_CUDA
-#include "multiclass_obj.cu"
-#endif  // XGBOOST_USE_CUDA
+  common::ParallelFor(n_samples, ctx->Threads(), [&](std::size_t row) {
+    auto point = predt.Slice(row, linalg::All());
+    float wmax = std::numeric_limits<float>::min();
+    for (std::size_t k{0}; k < point.Size(); ++k) {
+      wmax = fmaxf(point(k), wmax);
+    }
+    double wsum{0.0};
+    for (std::size_t k{0}; k < point.Size(); ++k) {
+      wsum += expf(point(k) - wmax);
+    }
+    auto label = labels(row, 0);
+    auto weight = weights[row];
+    for (std::int64_t k{0}; k < n_classes; ++k) {
+      auto probability = expf(point(k) - wmax) / static_cast<float>(wsum);
+      auto hess = fmaxf(2.0f * probability * (1.0f - probability) * weight, 1e-16f);
+      auto grad = label == k ? probability - 1.0f : probability;
+      gpair(row, k) = {grad * weight, hess};
+    }
+  });
+}
+
+void MulticlassTransformCpu(Context const* ctx, HostDeviceVector<float>* predictions,
+                            std::int32_t n_classes, bool probability) {
+  auto values = predictions->HostSpan();
+  auto n_samples = values.size() / n_classes;
+  if (probability) {
+    common::ParallelFor(n_samples, ctx->Threads(), [&](std::size_t row) {
+      auto point = values.subspan(row * n_classes, n_classes);
+      common::Softmax(point.begin(), point.end());
+    });
+  } else {
+    std::vector<float> output(n_samples);
+    common::ParallelFor(n_samples, ctx->Threads(), [&](std::size_t row) {
+      auto point = common::Span<float const>{values.data() + row * n_classes,
+                                             static_cast<std::size_t>(n_classes)};
+      output[row] = common::FindMaxIndex(point.cbegin(), point.cend()) - point.cbegin();
+    });
+    predictions->HostVector() = std::move(output);
+  }
+}
+
+auto const kRegisterMulticlassGradientCpu =
+    common::KernelRegistration<MulticlassGradientKernel>{DeviceOrd::kCPU, &MulticlassGradientCpu};
+auto const kRegisterMulticlassTransformCpu =
+    common::KernelRegistration<MulticlassTransformKernel>{DeviceOrd::kCPU, &MulticlassTransformCpu};
+auto const kRegisterMulticlassValidationCpu =
+    elementwise::RegisterValidationCpu<MulticlassLabelCheck>();
+auto const kRegisterMulticlassCenterCpu = elementwise::RegisterTransformCpu<MulticlassCenter>();
+}  // namespace
+
+class SoftmaxMultiClassObj : public ObjFunction {
+ public:
+  explicit SoftmaxMultiClassObj(bool output_prob) : output_prob_{output_prob} {}
+  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+  ObjInfo Task() const override { return ObjInfo::kClassification; }
+
+  void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info, std::int32_t iter,
+                   linalg::Matrix<GradientPair>* out_gpair) override {
+    if (info.labels.Size() == 0) {
+      return;
+    }
+    auto n_classes = static_cast<std::int64_t>(param_.num_class);
+    CHECK_EQ(preds.Size(), static_cast<std::size_t>(n_classes) * info.labels.Size())
+        << "SoftmaxMultiClassObj: label size and pred size does not match.";
+    CHECK_EQ(preds.Size() / n_classes, info.num_row_);
+    CHECK_LE(info.labels.Shape(1), 1) << "multi-class-multi-label is not yet supported.";
+    if (!info.weights_.Empty()) {
+      CHECK_EQ(info.weights_.Size(), info.num_row_)
+          << "Number of weights should be equal to number of data points.";
+    }
+
+    auto device = ctx_->DeviceFP64();
+    auto kernel_ctx = device.IsCPU() ? ctx_->MakeCPU() : *ctx_;
+    if (iter == 0) {
+      auto valid = common::DispatchKernel<MulticlassValidationKernel>(
+          &kernel_ctx, info.labels, MulticlassLabelCheck{n_classes});
+      CHECK(valid)
+          << "SoftmaxMultiClassObj: label must be discrete values in the range of [0, num_class).";
+    }
+    common::DispatchKernel<MulticlassGradientKernel>(&kernel_ctx, preds, info, n_classes,
+                                                     out_gpair);
+  }
+
+  void PredTransform(HostDeviceVector<float>* predictions) const override {
+    this->Transform(predictions, output_prob_);
+  }
+  void EvalTransform(HostDeviceVector<float>* predictions) override {
+    this->Transform(predictions, true);
+  }
+  char const* DefaultEvalMetric() const override { return "mlogloss"; }
+
+  void Transform(HostDeviceVector<float>* predictions, bool probability) const {
+    common::DispatchKernel<MulticlassTransformKernel>(ctx_, predictions, param_.num_class,
+                                                      probability);
+  }
+
+  void SaveConfig(Json* out) const override {
+    (*out)["name"] = String(output_prob_ ? "multi:softprob" : "multi:softmax");
+    (*out)["softmax_multiclass_param"] = ToJson(param_);
+  }
+  void LoadConfig(Json const& in) override { FromJson(in["softmax_multiclass_param"], &param_); }
+
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
+    auto n_classes = static_cast<std::int64_t>(param_.num_class);
+    CHECK_LE(info.labels.Shape(1), 1) << "multi-class-multi-label is not yet supported.";
+    auto valid = common::DispatchKernel<MulticlassValidationKernel>(
+        ctx_, info.labels, MulticlassLabelCheck{n_classes});
+    CHECK(valid)
+        << "SoftmaxMultiClassObj: label must be discrete values in the range of [0, num_class).";
+
+    *base_score = linalg::Zeros<float>(ctx_, n_classes);
+    auto labels = info.labels.View(ctx_->Device());
+    auto weights = common::MakeOptionalWeights(ctx_->Device(), info.weights_);
+    auto intercept = base_score->View(ctx_->Device());
+    linalg::SmallHistogram(ctx_, labels, weights, intercept);
+    auto sum_weight = common::SumOptionalWeights(ctx_, weights, info.labels.Size());
+    collective::SafeColl(collective::GlobalSum(ctx_, intercept, &sum_weight));
+    CHECK_GE(sum_weight, kRtEps);
+    linalg::VecScaDiv(ctx_, intercept, sum_weight);
+    linalg::LogE(ctx_, intercept, kRtEps);
+    linalg::Vector<float> mean;
+    common::Mean(ctx_, intercept, &mean);
+    auto mean_h = mean.HostView();
+    common::DispatchKernel<MulticlassCenterKernel>(ctx_, base_score->Data(),
+                                                   MulticlassCenter{mean_h(0)});
+  }
+
+ private:
+  bool const output_prob_;
+  SoftmaxMultiClassParam param_;
+};
+
+XGBOOST_REGISTER_OBJECTIVE(SoftmaxMultiClass, "multi:softmax")
+    .describe("Softmax for multi-class classification, output class index.")
+    .set_body([]() { return new SoftmaxMultiClassObj(false); });
+XGBOOST_REGISTER_OBJECTIVE(SoftprobMultiClass, "multi:softprob")
+    .describe("Softmax for multi-class classification, output probability distribution.")
+    .set_body([]() { return new SoftmaxMultiClassObj(true); });
+}  // namespace xgboost::obj

--- a/src/objective/multiclass_obj.cu
+++ b/src/objective/multiclass_obj.cu
@@ -1,243 +1,95 @@
 /**
- * Copyright 2015-2025, XGBoost Contributors
- * \file multi_class.cc
- * \brief Definition of multi-class classification objectives.
- * \author Tianqi Chen
+ * Copyright 2026, XGBoost Contributors
+ * \file multiclass_obj.cu
+ * \brief CUDA implementations of multiclass objective kernels.
  */
-#include <dmlc/omp.h>
+#include <dmlc/registry.h>
 
 #include <cassert>  // for assert
-#include <limits>
+#include <cmath>    // for expf, fmaxf
+#include <cstddef>  // for size_t
+#include <limits>   // for numeric_limits
 
-#include "../collective/aggregator.h"  // for GlobalSum
-#include "../common/common.h"          // for AssertGPUSupport
-#include "../common/linalg_op.h"
-#include "../common/math.h"
-#include "../common/optional_weight.h"  // for MakeOptionalWeights
-#include "../common/stats.h"            // for Mean
-#include "../common/transform.h"
-#include "xgboost/data.h"
-#include "xgboost/json.h"
-#include "xgboost/logging.h"
-#include "xgboost/objective.h"
-
-#if defined(XGBOOST_USE_CUDA)
-
-#include "../common/algorithm.cuh"     // for AllOf
-#include "../common/cuda_context.cuh"  // for CUDAContext
-
-#endif  // defined(XGBOOST_USE_CUDA)
-
-#include "multiclass_param.h"
+#include "../common/device_helpers.cuh"  // for LaunchN
+#include "../common/kernel.h"            // for KernelRegistration
+#include "../common/math.h"              // for FindMaxIndex, Softmax
+#include "../common/optional_weight.h"   // for MakeOptionalWeights
+#include "../common/transform.h"         // for Transform
+#include "elementwise_objective.cuh"     // for CUDA elementwise kernels
+#include "multiclass_obj.h"
 
 namespace xgboost::obj {
-#if defined(XGBOOST_USE_CUDA)
-DMLC_REGISTRY_FILE_TAG(multiclass_obj_gpu);
-#endif  // defined(XGBOOST_USE_CUDA)
-
+DMLC_REGISTRY_FILE_TAG(multiclass_kernel_cuda);
 namespace {
-void ValidateLabel(Context const* ctx, MetaInfo const& info, std::int64_t n_classes) {
-  auto label = info.labels.View(ctx->Device());
-  CHECK_LE(label.Shape(1), 1) << "multi-class-multi-label is not yet supported.";
-  auto check = [=] XGBOOST_DEVICE(float y) -> bool {
-    return y >= 0 && y < n_classes && std::floor(y) == y;
-  };
-  auto valid = ctx->DispatchDevice(
-      [&] { return std::all_of(linalg::cbegin(label), linalg::cend(label), check); },
-      [&] {
-#if defined(XGBOOST_USE_CUDA)
-        return common::AllOf(ctx->CUDACtx()->CTP(), linalg::tcbegin(label), linalg::tcend(label),
-                             check);
-#else
-        common::AssertGPUSupport();
-        return false;
-#endif  // defined(XGBOOST_USE_CUDA)
-      },
-      [&] {
-#if defined(XGBOOST_USE_SYCL)
-        return sycl::linalg::Validate(ctx->Device(), label, check);
-#else
-        common::AssertSYCLSupport();
-        return false;
-#endif  // defined(XGBOOST_USE_SYCL)
-      });
-  CHECK(valid)
-      << "SoftmaxMultiClassObj: label must be discrete values in the range of [0, num_class).";
+void MulticlassGradientCuda(Context const* ctx, HostDeviceVector<float> const& preds,
+                            MetaInfo const& info, std::int64_t n_classes,
+                            linalg::Matrix<GradientPair>* out_gpair) {
+  auto device = ctx->Device();
+  CHECK(device.IsCUDA());
+  preds.SetDevice(device);
+  auto predt = linalg::MakeTensorView(ctx, &preds, info.num_row_, n_classes);
+  auto labels = info.labels.View(device);
+  auto weights = common::MakeOptionalWeights(device, info.weights_);
+  out_gpair->SetDevice(device);
+  out_gpair->Reshape(info.num_row_, n_classes);
+  auto gpair = out_gpair->View(device);
+
+  dh::LaunchN(info.num_row_, ctx->CUDACtx()->Stream(), [=] XGBOOST_DEVICE(std::size_t row) mutable {
+    auto point = predt.Slice(row, linalg::All());
+    assert(point.Size() == static_cast<std::size_t>(n_classes));
+    float wmax = std::numeric_limits<float>::min();
+    for (std::size_t k{0}; k < point.Size(); ++k) {
+      wmax = fmaxf(point(k), wmax);
+    }
+    double wsum{0.0};
+    for (std::size_t k{0}; k < point.Size(); ++k) {
+      wsum += expf(point(k) - wmax);
+    }
+    auto label = labels(row, 0);
+    auto weight = weights[row];
+    for (std::int64_t k{0}; k < n_classes; ++k) {
+      auto probability = expf(point(k) - wmax) / static_cast<float>(wsum);
+      auto hess = fmaxf(2.0f * probability * (1.0f - probability) * weight, 1e-16f);
+      auto grad = label == k ? probability - 1.0f : probability;
+      gpair(row, k) = {grad * weight, hess};
+    }
+  });
 }
+
+void MulticlassTransformCuda(Context const* ctx, HostDeviceVector<float>* predictions,
+                             std::int32_t n_classes, bool probability) {
+  auto device = ctx->Device();
+  CHECK(device.IsCUDA());
+  auto n_samples = predictions->Size() / n_classes;
+  if (probability) {
+    common::Transform<>::Init(
+        [=] XGBOOST_DEVICE(std::size_t row, common::Span<float> values) {
+          auto point = values.subspan(row * n_classes, n_classes);
+          common::Softmax(point.begin(), point.end());
+        },
+        common::Range{0, static_cast<std::int64_t>(n_samples)}, ctx->Threads(), device)
+        .Eval(predictions);
+  } else {
+    HostDeviceVector<float> output(n_samples, 0.0f, device);
+    common::Transform<>::Init(
+        [=] XGBOOST_DEVICE(std::size_t row, common::Span<float const> values,
+                           common::Span<float> output) {
+          auto point = values.subspan(row * n_classes, n_classes);
+          output[row] = common::FindMaxIndex(point.cbegin(), point.cend()) - point.cbegin();
+        },
+        common::Range{0, static_cast<std::int64_t>(n_samples)}, ctx->Threads(), device)
+        .Eval(predictions, &output);
+    predictions->Resize(output.Size());
+    predictions->Copy(output);
+  }
+}
+
+auto const kRegisterMulticlassGradientCuda =
+    common::KernelRegistration<MulticlassGradientKernel>{DeviceOrd::kCUDA, &MulticlassGradientCuda};
+auto const kRegisterMulticlassTransformCuda = common::KernelRegistration<MulticlassTransformKernel>{
+    DeviceOrd::kCUDA, &MulticlassTransformCuda};
+auto const kRegisterMulticlassValidationCuda =
+    elementwise::RegisterValidationCuda<MulticlassLabelCheck>();
+auto const kRegisterMulticlassCenterCuda = elementwise::RegisterTransformCuda<MulticlassCenter>();
 }  // namespace
-
-class SoftmaxMultiClassObj : public ObjFunction {
- public:
-  explicit SoftmaxMultiClassObj(bool output_prob) : output_prob_(output_prob) {}
-
-  std::set<std::string> Configure(Args const& args) override {
-    return UpdateAndGetUsedParameters(&param_, args);
-  }
-
-  ObjInfo Task() const override { return ObjInfo::kClassification; }
-
-  void GetGradient(HostDeviceVector<float> const& preds, const MetaInfo& info, std::int32_t iter,
-                   linalg::Matrix<GradientPair>* out_gpair) override {
-    if (info.labels.Size() == 0) {
-      return;
-    }
-    std::int64_t n_classes = param_.num_class;
-    CHECK(preds.Size() == (static_cast<std::size_t>(n_classes) * info.labels.Size()))
-        << "SoftmaxMultiClassObj: label size and pred size does not match.\n"
-        << "label.Size() * num_class: " << info.labels.Size() * n_classes << "\n"
-        << "num_class: " << param_.num_class << "\n"
-        << "preds.Size(): " << preds.Size();
-
-    if (iter == 0) {
-      ValidateLabel(this->ctx_, info, n_classes);
-    }
-
-    const auto n_samples = preds.Size() / n_classes;
-    CHECK_EQ(n_samples, info.num_row_);
-
-    // fallback to cpu if current device doesn't supports fp64
-    auto device = ctx_->DeviceFP64();
-    auto labels = info.labels.View(device);
-
-    out_gpair->SetDevice(device);
-    out_gpair->Reshape(info.num_row_, n_classes);
-    auto gpair = out_gpair->View(device);
-
-    if (!info.weights_.Empty()) {
-      CHECK_EQ(info.weights_.Size(), n_samples)
-          << "Number of weights should be equal to number of data points.";
-    }
-    info.weights_.SetDevice(device);
-    auto weights = common::MakeOptionalWeights(this->ctx_->Device(), info.weights_);
-
-    preds.SetDevice(device);
-    auto predt = linalg::MakeTensorView(this->ctx_, &preds, n_samples, n_classes);
-    CHECK_EQ(labels.Shape(1), 1);
-    auto y1d = labels.Slice(linalg::All(), 0);
-    CHECK_EQ(y1d.Shape(0), info.num_row_);
-    linalg::ElementWiseKernel(this->ctx_, y1d, [=] XGBOOST_DEVICE(std::size_t idx) mutable {
-      auto point = predt.Slice(idx, linalg::All());
-      assert(point.Size() == static_cast<std::size_t>(n_classes));
-
-      // Part of the common::Softmax function
-      float wmax = std::numeric_limits<float>::min();
-      for (std::size_t k = 0, m = point.Size(); k < m; ++k) {
-        wmax = fmaxf(point(k), wmax);
-      }
-      double wsum = 0.0f;
-      for (std::size_t k = 0, m = point.Size(); k < m; ++k) {
-        wsum += expf(point(k) - wmax);
-      }
-      auto label = y1d(idx);
-
-      float wt = weights[idx];
-      for (decltype(n_classes) k = 0; k < n_classes; ++k) {
-        // Computation duplicated to avoid creating a cache.
-        float p = expf(point(k) - wmax) / static_cast<float>(wsum);
-        constexpr float kEps = 1e-16f;
-        float h = fmax(2.0f * p * (1.0f - p) * wt, kEps);
-        p = label == k ? p - 1.0f : p;
-        gpair(idx, k) = GradientPair{p * wt, h};
-      }
-    });
-  }
-
-  void PredTransform(HostDeviceVector<float>* io_preds) const override {
-    this->Transform(io_preds, output_prob_);
-  }
-  void EvalTransform(HostDeviceVector<float>* io_preds) override {
-    this->Transform(io_preds, true);
-  }
-  const char* DefaultEvalMetric() const override { return "mlogloss"; }
-
-  void Transform(HostDeviceVector<float>* io_preds, bool prob) const {
-    const int n_classes = param_.num_class;
-    const auto n_samples = static_cast<int64_t>(io_preds->Size() / n_classes);
-
-    auto device = io_preds->Device();
-    if (prob) {
-      common::Transform<>::Init(
-          [=] XGBOOST_DEVICE(size_t _idx, common::Span<float> _preds) {
-            common::Span<float> point = _preds.subspan(_idx * n_classes, n_classes);
-            common::Softmax(point.begin(), point.end());
-          },
-          common::Range{0, n_samples}, this->ctx_->Threads(), device)
-          .Eval(io_preds);
-    } else {
-      io_preds->SetDevice(device);
-      HostDeviceVector<float> max_preds;
-      max_preds.SetDevice(device);
-      max_preds.Resize(n_samples);
-      common::Transform<>::Init(
-          [=] XGBOOST_DEVICE(size_t _idx, common::Span<const float> _preds,
-                             common::Span<float> _max_preds) {
-            common::Span<const float> point = _preds.subspan(_idx * n_classes, n_classes);
-            _max_preds[_idx] = common::FindMaxIndex(point.cbegin(), point.cend()) - point.cbegin();
-          },
-          common::Range{0, n_samples}, this->ctx_->Threads(), device)
-          .Eval(io_preds, &max_preds);
-      io_preds->Resize(max_preds.Size());
-      io_preds->Copy(max_preds);
-    }
-  }
-
-  void SaveConfig(Json* p_out) const override {
-    auto& out = *p_out;
-    if (this->output_prob_) {
-      out["name"] = String("multi:softprob");
-    } else {
-      out["name"] = String("multi:softmax");
-    }
-    out["softmax_multiclass_param"] = ToJson(param_);
-  }
-
-  void LoadConfig(Json const& in) override { FromJson(in["softmax_multiclass_param"], &param_); }
-
-  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
-    std::int64_t n_classes = this->param_.num_class;
-    ValidateLabel(this->ctx_, info, n_classes);
-
-    *base_score = linalg::Zeros<float>(this->ctx_, n_classes);
-
-    std::size_t n = info.labels.Size();
-    // Calculate probability
-    auto labels = info.labels.View(ctx_->Device());
-    auto weights = common::MakeOptionalWeights(this->ctx_->Device(), info.weights_);
-    auto intercept = base_score->View(ctx_->Device());
-    CHECK_EQ(intercept.Size(), n_classes);
-    CHECK_EQ(n, info.num_row_);
-    linalg::SmallHistogram(ctx_, labels, weights, intercept);
-    auto sum_weight = common::SumOptionalWeights(this->ctx_, weights, n);
-    auto status = collective::GlobalSum(this->ctx_, intercept, &sum_weight);
-    collective::SafeColl(status);
-    CHECK_GE(sum_weight, kRtEps);
-    linalg::VecScaDiv(this->ctx_, intercept, sum_weight);
-    CHECK_EQ(base_score->Size(), n_classes);
-
-    // Transform it back to margin
-    // ln(v) - E[ln(v)]
-    linalg::Vector<float> mean;
-    linalg::LogE(this->ctx_, intercept, kRtEps);
-    common::Mean(this->ctx_, intercept, &mean);
-    auto d_mean = mean.View(this->ctx_->Device());
-    TransformKernel(this->ctx_, intercept, [=] XGBOOST_DEVICE(float v) { return v - d_mean(0); });
-  }
-
- private:
-  // output probability
-  bool const output_prob_;
-  // parameter
-  SoftmaxMultiClassParam param_;
-};
-
-// register the objective functions
-DMLC_REGISTER_PARAMETER(SoftmaxMultiClassParam);
-
-XGBOOST_REGISTER_OBJECTIVE(SoftmaxMultiClass, "multi:softmax")
-    .describe("Softmax for multi-class classification, output class index.")
-    .set_body([]() { return new SoftmaxMultiClassObj(false); });
-
-XGBOOST_REGISTER_OBJECTIVE(SoftprobMultiClass, "multi:softprob")
-    .describe("Softmax for multi-class classification, output probability distribution.")
-    .set_body([]() { return new SoftmaxMultiClassObj(true); });
 }  // namespace xgboost::obj

--- a/src/objective/multiclass_obj.cu
+++ b/src/objective/multiclass_obj.cu
@@ -10,10 +10,13 @@
 #include <cstddef>  // for size_t
 #include <limits>   // for numeric_limits
 
+#include "../collective/aggregator.h"    // for GlobalSum
 #include "../common/device_helpers.cuh"  // for LaunchN
 #include "../common/kernel.h"            // for KernelRegistration
+#include "../common/linalg_op.cuh"       // for SmallHistogram, vector operations
 #include "../common/math.h"              // for FindMaxIndex, Softmax
 #include "../common/optional_weight.h"   // for MakeOptionalWeights
+#include "../common/stats.h"             // for Mean
 #include "../common/transform.h"         // for Transform
 #include "elementwise_objective.cuh"     // for CUDA elementwise kernels
 #include "multiclass_obj.h"
@@ -84,8 +87,32 @@ void MulticlassTransformCuda(Context const* ctx, HostDeviceVector<float>* predic
   }
 }
 
+void MulticlassInitEstimationCuda(Context const* ctx, MetaInfo const& info, std::int64_t n_classes,
+                                  linalg::Vector<float>* base_score) {
+  auto device = ctx->Device();
+  CHECK(device.IsCUDA());
+  *base_score = linalg::Zeros<float>(ctx, n_classes);
+  auto labels = info.labels.View(device);
+  auto weights = common::MakeOptionalWeights(device, info.weights_);
+  auto intercept = base_score->View(device);
+  linalg::SmallHistogram(ctx, labels, weights, intercept);
+  auto sum_weight = common::SumOptionalWeights(ctx, weights, info.labels.Size());
+  collective::SafeColl(collective::GlobalSum(ctx, intercept, &sum_weight));
+  CHECK_GE(sum_weight, kRtEps);
+  linalg::VecScaDiv(ctx, intercept, sum_weight);
+  linalg::LogE(ctx, intercept, kRtEps);
+  linalg::Vector<float> mean;
+  common::Mean(ctx, intercept, &mean);
+  auto mean_d = mean.View(device);
+  dh::LaunchN(intercept.Size(), ctx->CUDACtx()->Stream(),
+              [=] XGBOOST_DEVICE(std::size_t i) mutable { intercept(i) -= mean_d(0); });
+}
+
 auto const kRegisterMulticlassGradientCuda =
     common::KernelRegistration<MulticlassGradientKernel>{DeviceOrd::kCUDA, &MulticlassGradientCuda};
+auto const kRegisterMulticlassInitEstimationCuda =
+    common::KernelRegistration<MulticlassInitEstimationKernel>{DeviceOrd::kCUDA,
+                                                               &MulticlassInitEstimationCuda};
 auto const kRegisterMulticlassTransformCuda = common::KernelRegistration<MulticlassTransformKernel>{
     DeviceOrd::kCUDA, &MulticlassTransformCuda};
 auto const kRegisterMulticlassValidationCuda =

--- a/src/objective/multiclass_obj.h
+++ b/src/objective/multiclass_obj.h
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file multiclass_obj.h
+ * \brief Shared declarations for multiclass objectives.
+ */
+#ifndef XGBOOST_OBJECTIVE_MULTICLASS_OBJ_H_
+#define XGBOOST_OBJECTIVE_MULTICLASS_OBJ_H_
+
+#include <cmath>    // for floor
+#include <cstdint>  // for int64_t
+
+#include "elementwise_objective.h"       // for TransformKernel, ValidationKernel
+#include "xgboost/base.h"                // for GradientPair
+#include "xgboost/context.h"             // for Context
+#include "xgboost/data.h"                // for MetaInfo
+#include "xgboost/host_device_vector.h"  // for HostDeviceVector
+#include "xgboost/linalg.h"              // for Matrix
+
+namespace xgboost::obj {
+struct MulticlassLabelCheck {
+  std::int64_t n_classes;
+  XGBOOST_DEVICE bool operator()(float value) const {
+    return value >= 0.0f && value < n_classes && std::floor(value) == value;
+  }
+};
+
+struct MulticlassCenter {
+  float mean;
+  XGBOOST_DEVICE float operator()(float value) const { return value - mean; }
+};
+
+struct MulticlassGradientKernel {
+  using Signature = void(Context const*, HostDeviceVector<float> const&, MetaInfo const&,
+                         std::int64_t, linalg::Matrix<GradientPair>*);
+};
+
+struct MulticlassTransformKernel {
+  using Signature = void(Context const*, HostDeviceVector<float>*, std::int32_t, bool);
+};
+
+using MulticlassValidationKernel = elementwise::ValidationKernel<MulticlassLabelCheck>;
+using MulticlassCenterKernel = elementwise::TransformKernel<MulticlassCenter>;
+}  // namespace xgboost::obj
+
+#endif  // XGBOOST_OBJECTIVE_MULTICLASS_OBJ_H_

--- a/src/objective/multiclass_obj.h
+++ b/src/objective/multiclass_obj.h
@@ -34,6 +34,10 @@ struct MulticlassGradientKernel {
                          std::int64_t, linalg::Matrix<GradientPair>*);
 };
 
+struct MulticlassInitEstimationKernel {
+  using Signature = void(Context const*, MetaInfo const&, std::int64_t, linalg::Vector<float>*);
+};
+
 struct MulticlassTransformKernel {
   using Signature = void(Context const*, HostDeviceVector<float>*, std::int32_t, bool);
 };

--- a/src/objective/objective.cc
+++ b/src/objective/objective.cc
@@ -41,6 +41,7 @@ void ObjFunction::InitEstimation(MetaInfo const& info, linalg::Vector<float>* ba
 namespace xgboost {
 namespace obj {
 // List of files that will be force linked in static links.
+DMLC_REGISTRY_LINK_TAG(absolute_error_obj);
 DMLC_REGISTRY_LINK_TAG(gamma_obj);
 DMLC_REGISTRY_LINK_TAG(hinge_obj);
 DMLC_REGISTRY_LINK_TAG(logistic_obj);
@@ -49,6 +50,7 @@ DMLC_REGISTRY_LINK_TAG(pseudohuber_obj);
 DMLC_REGISTRY_LINK_TAG(squared_error_obj);
 DMLC_REGISTRY_LINK_TAG(squared_log_obj);
 DMLC_REGISTRY_LINK_TAG(tweedie_obj);
+DMLC_REGISTRY_LINK_TAG(multiclass_obj);
 #ifdef XGBOOST_USE_CUDA
 DMLC_REGISTRY_LINK_TAG(regression_obj_gpu);
 DMLC_REGISTRY_LINK_TAG(quantile_obj_gpu);
@@ -60,13 +62,13 @@ DMLC_REGISTRY_LINK_TAG(pseudohuber_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(squared_error_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(squared_log_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(tweedie_kernel_cuda);
-DMLC_REGISTRY_LINK_TAG(multiclass_obj_gpu);
+DMLC_REGISTRY_LINK_TAG(absolute_error_kernel_cuda);
+DMLC_REGISTRY_LINK_TAG(multiclass_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(lambdarank_obj);
 DMLC_REGISTRY_LINK_TAG(lambdarank_obj_cu);
 #else
 DMLC_REGISTRY_LINK_TAG(regression_obj);
 DMLC_REGISTRY_LINK_TAG(quantile_obj);
-DMLC_REGISTRY_LINK_TAG(multiclass_obj);
 DMLC_REGISTRY_LINK_TAG(lambdarank_obj);
 #endif  // XGBOOST_USE_CUDA
 }  // namespace obj

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -16,7 +16,6 @@
 #include "../common/common.h"
 #include "../common/expectile_loss_utils.h"  // for ExpectileLossParam
 #include "../common/linalg_op.h"             // for ElementWiseKernel
-#include "../common/math.h"                  // for CloseTo, Sigmoid, SoftPlus, SoftPlusInv
 #include "../common/numeric.h"               // for Reduce
 #include "../common/optional_weight.h"       // for MakeOptionalWeights
 #include "../common/stats.h"
@@ -24,7 +23,9 @@
 #include "../common/transform.h"
 #include "../common/utils.h"  // for NoOp
 #include "../tree/fit_stump.h"
+#include "./regression_loss.h"
 #include "init_estimation.h"  // FitIntercept
+#include "regression_param.h"
 #include "xgboost/base.h"
 #include "xgboost/context.h"  // Context
 #include "xgboost/data.h"     // MetaInfo
@@ -37,15 +38,55 @@
 #include "xgboost/span.h"
 
 #if defined(XGBOOST_USE_CUDA)
-#include "../common/algorithm.cuh"     // for AllOf
-#include "../common/cuda_context.cuh"  // for CUDAContext
-#endif                                 // defined(XGBOOST_USE_CUDA)
+#include "../common/algorithm.cuh"       // for AllOf
+#include "../common/cuda_context.cuh"    // for CUDAContext
+#include "../common/device_helpers.cuh"  // for MakeIndexTransformIter
+#endif                                   // defined(XGBOOST_USE_CUDA)
 
 namespace xgboost::obj {
 namespace {
 void CheckRegInputs(MetaInfo const& info, HostDeviceVector<float> const& preds) {
   CheckInitInputs(info);
   CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
+}
+
+template <typename Loss>
+void ValidateLabel(Context const* ctx, MetaInfo const& info) {
+  auto label = info.labels.View(ctx->Device());
+  auto valid = ctx->DispatchDevice(
+      [&] {
+        return std::all_of(linalg::cbegin(label), linalg::cend(label),
+                           [](float y) -> bool { return Loss::CheckLabel(y); });
+      },
+      [&] {
+#if defined(XGBOOST_USE_CUDA)
+        auto it = dh::MakeIndexTransformIter([=] XGBOOST_DEVICE(std::size_t i) -> float {
+          auto [m, n] = linalg::UnravelIndex(i, label.Shape());
+          return label(m, n);
+        });
+        return common::AllOf(ctx->CUDACtx()->CTP(), it, it + label.Size(),
+                             [] XGBOOST_DEVICE(float y) { return Loss::CheckLabel(y); });
+#else
+        common::AssertGPUSupport();
+        return false;
+#endif  // defined(XGBOOST_USE_CUDA)
+      },
+      [&] {
+#if defined(XGBOOST_USE_SYCL)
+        return sycl::linalg::Validate(ctx->Device(), label,
+                                      [](float y) -> bool { return Loss::CheckLabel(y); });
+#else
+        common::AssertSYCLSupport();
+        return false;
+#endif  // defined(XGBOOST_USE_SYCL)
+      });
+  if (!valid) {
+    LOG(FATAL) << Loss::LabelErrorMsg();
+  }
+  if (!info.weights_.Empty()) {
+    CHECK_EQ(info.weights_.Size(), info.num_row_)
+        << "Number of weights should be equal to the number of data points.";
+  }
 }
 
 template <typename Fn, typename Chk = common::NoOp<bool>, typename Err = common::NoOp<StringView>>
@@ -82,6 +123,155 @@ void ProbToMarginImpl(Context const* ctx, linalg::Vector<float>* base_score, Fn&
 DMLC_REGISTRY_FILE_TAG(regression_obj_gpu);
 #endif  // defined(XGBOOST_USE_CUDA)
 
+template <typename Loss>
+class RegLossObj : public FitInterceptGlmLike {
+ protected:
+  HostDeviceVector<float> additional_input_;
+
+ public:
+  // 0 - scale_pos_weight, 1 - is_null_weight
+  RegLossObj() : additional_input_(2) {}
+
+  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
+
+  [[nodiscard]] ObjInfo Task() const override { return Loss::Info(); }
+
+  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
+    // Multi-target regression.
+    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
+  }
+
+  void GetGradient(const HostDeviceVector<float>& preds, const MetaInfo& info, std::int32_t iter,
+                   linalg::Matrix<GradientPair>* out_gpair) override {
+    CheckRegInputs(info, preds);
+    if (iter == 0) {
+      ValidateLabel<Loss>(this->ctx_, info);
+    }
+
+    size_t const ndata = preds.Size();
+    out_gpair->SetDevice(ctx_->Device());
+    auto device = ctx_->Device();
+
+    bool is_null_weight = info.weights_.Size() == 0;
+    auto scale_pos_weight = param_.scale_pos_weight;
+    additional_input_.HostVector().begin()[0] = scale_pos_weight;
+    additional_input_.HostVector().begin()[1] = is_null_weight;
+
+    const size_t nthreads = ctx_->Threads();
+    bool on_device = !device.IsCPU();
+    // On CPU we run the transformation each thread processing a contigious block of data
+    // for better performance.
+    const size_t n_data_blocks = std::max(static_cast<size_t>(1), (on_device ? ndata : nthreads));
+    const size_t block_size = ndata / n_data_blocks + !!(ndata % n_data_blocks);
+    auto const n_targets = this->Targets(info);
+    out_gpair->Reshape(info.num_row_, n_targets);
+
+    common::Transform<>::Init(
+        [block_size, ndata, n_targets] XGBOOST_DEVICE(
+            size_t data_block_idx, common::Span<float> _additional_input,
+            common::Span<GradientPair> _out_gpair, common::Span<const bst_float> _preds,
+            common::Span<const bst_float> _labels, common::Span<const bst_float> _weights) {
+          const bst_float* preds_ptr = _preds.data();
+          const bst_float* labels_ptr = _labels.data();
+          const bst_float* weights_ptr = _weights.data();
+          GradientPair* out_gpair_ptr = _out_gpair.data();
+          const size_t begin = data_block_idx * block_size;
+          const size_t end = std::min(ndata, begin + block_size);
+          const float _scale_pos_weight = _additional_input[0];
+          const bool _is_null_weight = _additional_input[1];
+
+          for (size_t idx = begin; idx < end; ++idx) {
+            bst_float p = Loss::PredTransform(preds_ptr[idx]);
+            bst_float w = _is_null_weight ? 1.0f : weights_ptr[idx / n_targets];
+            bst_float label = labels_ptr[idx];
+            if (label == 1.0f) {
+              w *= _scale_pos_weight;
+            }
+            out_gpair_ptr[idx] = GradientPair(Loss::FirstOrderGradient(p, label) * w,
+                                              Loss::SecondOrderGradient(p, label) * w);
+          }
+        },
+        common::Range{0, static_cast<int64_t>(n_data_blocks)}, nthreads, device)
+        .Eval(&additional_input_, out_gpair->Data(), &preds, info.labels.Data(), &info.weights_);
+  }
+
+ public:
+  [[nodiscard]] const char* DefaultEvalMetric() const override { return Loss::DefaultEvalMetric(); }
+
+  void PredTransform(HostDeviceVector<float>* io_preds) const override {
+    common::Transform<>::Init(
+        [] XGBOOST_DEVICE(size_t _idx, common::Span<float> _preds) {
+          _preds[_idx] = Loss::PredTransform(_preds[_idx]);
+        },
+        common::Range{0, static_cast<int64_t>(io_preds->Size())}, this->ctx_->Threads(),
+        io_preds->Device())
+        .Eval(io_preds);
+  }
+
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
+    if (std::abs(this->param_.scale_pos_weight - 1.0f) > kRtEps) {
+      // Use newton method if `scale_pos_weight` is present. The alternative is to use
+      // weighted mean, but we also need to take sample weight into account.
+      FitIntercept::InitEstimation(info, base_score);
+    } else {
+      FitInterceptGlmLike::InitEstimation(info, base_score);
+    }
+  }
+
+  void ProbToMargin(linalg::Vector<float>* base_score) const override {
+    ProbToMarginImpl(
+        this->ctx_, base_score, [] XGBOOST_DEVICE(float v) { return Loss::ProbToMargin(v); },
+        [] XGBOOST_DEVICE(float v) { return Loss::CheckIntercept(v); }, Loss::InterceptErrorMsg);
+  }
+
+  void SaveConfig(Json* p_out) const override {
+    auto& out = *p_out;
+    out["name"] = String(Loss::Name());
+    out["reg_loss_param"] = ToJson(param_);
+  }
+
+  void LoadConfig(Json const& in) override {
+    auto obj = get<Object const>(in);
+    auto it = obj.find("reg_loss_param");
+    if (it != obj.cend()) {
+      FromJson(it->second, &param_);
+    }
+  }
+
+ protected:
+  RegLossParam param_;
+};
+
+// register the objective functions
+DMLC_REGISTER_PARAMETER(RegLossParam);
+
+XGBOOST_REGISTER_OBJECTIVE(SquaredLossRegression, LinearSquareLoss::Name())
+    .describe("Regression with squared error.")
+    .set_body([]() { return new RegLossObj<LinearSquareLoss>(); });
+
+XGBOOST_REGISTER_OBJECTIVE(LogisticRegression, LogisticRegression::Name())
+    .describe("Logistic regression for probability regression task.")
+    .set_body([]() { return new RegLossObj<LogisticRegression>(); });
+
+XGBOOST_REGISTER_OBJECTIVE(LogisticClassification, LogisticClassification::Name())
+    .describe("Logistic regression for binary classification task.")
+    .set_body([]() { return new RegLossObj<LogisticClassification>(); });
+
+XGBOOST_REGISTER_OBJECTIVE(LogisticRaw, LogisticRaw::Name())
+    .describe(
+        "Logistic regression for classification, output score "
+        "before logistic transformation.")
+    .set_body([]() { return new RegLossObj<LogisticRaw>(); });
+
+// Deprecated functions
+XGBOOST_REGISTER_OBJECTIVE(LinearRegression, "reg:linear")
+    .describe("Regression with squared error.")
+    .set_body([]() {
+      LOG(WARNING) << "reg:linear is now deprecated in favor of reg:squarederror.";
+      return new RegLossObj<LinearSquareLoss>();
+    });
+// End deprecated
+
 class ExpectileRegression : public FitIntercept {
   common::ExpectileLossParam param_;
   HostDeviceVector<float> alpha_;
@@ -96,11 +286,10 @@ class ExpectileRegression : public FitIntercept {
   }
 
  public:
-  std::set<std::string> Configure(Args const& args) override {
-    auto used = UpdateAndGetUsedParameters(&param_, args);
+  void Configure(Args const& args) override {
+    param_.UpdateAllowUnknown(args);
     param_.Validate();
     alpha_.HostVector() = param_.expectile_alpha.Get();
-    return used;
   }
 
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
@@ -275,7 +464,7 @@ XGBOOST_REGISTER_OBJECTIVE(ExpectileRegression, "reg:expectileerror")
 // cox regression for survival data (negative values mean they are censored)
 class CoxRegression : public FitIntercept {
  public:
-  std::set<std::string> Configure(Args const&) override { return {}; }
+  void Configure(Args const&) override {}
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
 
   void GetGradient(const HostDeviceVector<bst_float>& preds, const MetaInfo& info, int,
@@ -365,151 +554,4 @@ XGBOOST_REGISTER_OBJECTIVE(CoxRegression, "survival:cox")
         "Cox regression for censored survival data (negative labels are considered censored).")
     .set_body([]() { return new CoxRegression(); });
 
-/**
- * @brief Smooth MM approximation to the mean absolute error.
- *
- * At each boosting iteration and for each target, choose the automatic scale
- *
- *   delta = E_w[sqrt(abs(prediction - label))]^2.
- *
- * For residual r, q = sqrt(1 + (r / delta)^2), the pseudo-Huber gradient is r / q.
- * We use 1 / q as the Hessian instead of the exact pseudo-Huber Hessian 1 / q^3. This is
- * the majorization curvature that produces a stable IRLS update while approaching the L1
- * gradient as the residual scale contracts.
- */
-class MeanAbsoluteError : public ObjFunction {
- public:
-  std::set<std::string> Configure(Args const&) override { return {}; }
-  [[nodiscard]] ObjInfo Task() const override { return {ObjInfo::kRegression, false}; }
-  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
-    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
-  }
-
-  void GetGradient(HostDeviceVector<float> const& preds, const MetaInfo& info,
-                   std::int32_t /*iter*/, linalg::Matrix<GradientPair>* out_gpair) override {
-    CheckRegInputs(info, preds);
-    auto labels = info.labels.View(ctx_->Device());
-    auto const n_targets = this->Targets(info);
-
-    out_gpair->SetDevice(ctx_->Device());
-    out_gpair->Reshape(info.num_row_, n_targets);
-    auto gpair = out_gpair->View(ctx_->Device());
-
-    preds.SetDevice(ctx_->Device());
-    auto predt = linalg::MakeTensorView(ctx_, &preds, info.num_row_, n_targets);
-    auto weight = common::MakeOptionalWeights(ctx_->Device(), info.weights_);
-
-    HostDeviceVector<float> root_residual(info.num_row_, 0.0f, ctx_->Device());
-    std::vector<double> scale_stats(n_targets + 1, 0.0);
-    for (bst_target_t target{0}; target < n_targets; ++target) {
-      common::Transform<>::Init(
-          [target, labels, predt, weight] XGBOOST_DEVICE(std::size_t i,
-                                                         common::Span<float> root_residual) {
-            root_residual[i] = weight[i] * sqrtf(fabsf(predt(i, target) - labels(i, target)));
-          },
-          common::Range{0, static_cast<std::int64_t>(info.num_row_)}, ctx_->Threads(),
-          ctx_->Device())
-          .Eval(&root_residual);
-      scale_stats[target] = common::Reduce(ctx_, root_residual);
-    }
-    scale_stats.back() = common::SumOptionalWeights(ctx_, weight, info.num_row_);
-    auto cpu_ctx = ctx_->MakeCPU();
-    auto rc =
-        collective::GlobalSum(&cpu_ctx, linalg::MakeVec(scale_stats.data(), scale_stats.size()));
-    collective::SafeColl(rc);
-
-    HostDeviceVector<float> scale(n_targets, 0.0f, ctx_->Device());
-    auto h_scale = scale.HostSpan();
-    for (bst_target_t target{0}; target < n_targets; ++target) {
-      if (common::CloseTo(scale_stats.back(), 0.0)) {
-        h_scale[target] = 0.0f;
-      } else {
-        auto const root_mean = scale_stats[target] / scale_stats.back();
-        h_scale[target] = static_cast<float>(root_mean * root_mean);
-      }
-    }
-    auto scale_view = ctx_->Device().IsCPU() ? scale.ConstHostSpan() : scale.ConstDeviceSpan();
-
-    linalg::ElementWiseKernel(ctx_, labels,
-                              [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
-                                auto const residual = predt(i, j) - labels(i, j);
-                                auto const delta = scale_view[j];
-                                auto const norm = hypotf(delta, residual);
-                                auto const curvature = norm > 0.0f ? delta / norm : 1.0f;
-                                auto const w = weight[i];
-                                gpair(i, j) = GradientPair{w * residual * curvature, w * curvature};
-                              });
-  }
-
-  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
-    CheckInitInputs(info);
-    auto const n_targets = this->Targets(info);
-    base_score->SetDevice(ctx_->Device());
-    base_score->Reshape(n_targets);
-
-    double sum_weight{0.0};
-    if (info.weights_.Empty()) {
-      sum_weight = static_cast<double>(info.num_row_);
-    } else {
-      sum_weight = common::Reduce(ctx_, info.weights_);
-    }
-    auto cpu_ctx = ctx_->MakeCPU();
-    collective::SafeColl(
-        collective::GlobalSum(&cpu_ctx, linalg::MakeVec(&sum_weight, std::size_t{1})));
-    if (common::CloseTo(sum_weight, 0.0)) {
-      // Mostly for handling empty dataset test.
-      LOG(WARNING) << "Sum of weights is close to 0.0, skipping base score estimation.";
-      *base_score = linalg::Zeros<float>(ctx_, base_score->Shape(0));
-      return;
-    }
-
-    linalg::Vector<float> mean;
-    if (info.weights_.Empty()) {
-      common::SampleMean(ctx_, info.labels, &mean);
-    } else {
-      common::WeightedSampleMean(ctx_, info.labels, info.weights_, &mean);
-    }
-    CHECK_EQ(mean.Size(), n_targets);
-
-    HostDeviceVector<float> predt(info.labels.Size(), 0.0f, ctx_->Device());
-    auto predt_view = linalg::MakeTensorView(ctx_, &predt, info.num_row_, n_targets);
-    mean.SetDevice(ctx_->Device());
-    auto mean_view = mean.View(ctx_->Device());
-    linalg::ElementWiseKernel(ctx_, predt_view,
-                              [=] XGBOOST_DEVICE(std::size_t i, std::size_t j) mutable {
-                                predt_view(i, j) = mean_view(j);
-                              });
-
-    Json config{Object{}};
-    this->SaveConfig(&config);
-    std::unique_ptr<ObjFunction> new_obj{
-        ObjFunction::Create(get<String const>(config["name"]), ctx_)};
-    new_obj->LoadConfig(config);
-
-    linalg::Matrix<GradientPair> gpair;
-    new_obj->GetGradient(predt, info, 0, &gpair);
-    tree::FitStump(ctx_, gpair, n_targets, base_score);
-
-    auto h_mean = mean.HostView();
-    auto out = base_score->HostView();
-    for (bst_target_t target{0}; target < n_targets; ++target) {
-      out(target) += h_mean(target);
-    }
-  }
-
-  [[nodiscard]] const char* DefaultEvalMetric() const override { return "mae"; }
-
-  void SaveConfig(Json* p_out) const override {
-    auto& out = *p_out;
-    out["name"] = String("reg:absoluteerror");
-  }
-
-  void LoadConfig(Json const& in) override {
-    CHECK_EQ(StringView{get<String const>(in["name"])}, StringView{"reg:absoluteerror"});
-  }
-};
-
-XGBOOST_REGISTER_OBJECTIVE(MeanAbsoluteError, "reg:absoluteerror")
-    .describe("Mean absolute error with automatic smooth majorization.")
-    .set_body([]() { return new MeanAbsoluteError(); });
 }  // namespace xgboost::obj

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -16,6 +16,7 @@
 #include "../common/common.h"
 #include "../common/expectile_loss_utils.h"  // for ExpectileLossParam
 #include "../common/linalg_op.h"             // for ElementWiseKernel
+#include "../common/math.h"                  // for CloseTo, Sigmoid, SoftPlus, SoftPlusInv
 #include "../common/numeric.h"               // for Reduce
 #include "../common/optional_weight.h"       // for MakeOptionalWeights
 #include "../common/stats.h"
@@ -23,9 +24,7 @@
 #include "../common/transform.h"
 #include "../common/utils.h"  // for NoOp
 #include "../tree/fit_stump.h"
-#include "./regression_loss.h"
 #include "init_estimation.h"  // FitIntercept
-#include "regression_param.h"
 #include "xgboost/base.h"
 #include "xgboost/context.h"  // Context
 #include "xgboost/data.h"     // MetaInfo
@@ -38,55 +37,15 @@
 #include "xgboost/span.h"
 
 #if defined(XGBOOST_USE_CUDA)
-#include "../common/algorithm.cuh"       // for AllOf
-#include "../common/cuda_context.cuh"    // for CUDAContext
-#include "../common/device_helpers.cuh"  // for MakeIndexTransformIter
-#endif                                   // defined(XGBOOST_USE_CUDA)
+#include "../common/algorithm.cuh"     // for AllOf
+#include "../common/cuda_context.cuh"  // for CUDAContext
+#endif                                 // defined(XGBOOST_USE_CUDA)
 
 namespace xgboost::obj {
 namespace {
 void CheckRegInputs(MetaInfo const& info, HostDeviceVector<float> const& preds) {
   CheckInitInputs(info);
   CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
-}
-
-template <typename Loss>
-void ValidateLabel(Context const* ctx, MetaInfo const& info) {
-  auto label = info.labels.View(ctx->Device());
-  auto valid = ctx->DispatchDevice(
-      [&] {
-        return std::all_of(linalg::cbegin(label), linalg::cend(label),
-                           [](float y) -> bool { return Loss::CheckLabel(y); });
-      },
-      [&] {
-#if defined(XGBOOST_USE_CUDA)
-        auto it = dh::MakeIndexTransformIter([=] XGBOOST_DEVICE(std::size_t i) -> float {
-          auto [m, n] = linalg::UnravelIndex(i, label.Shape());
-          return label(m, n);
-        });
-        return common::AllOf(ctx->CUDACtx()->CTP(), it, it + label.Size(),
-                             [] XGBOOST_DEVICE(float y) { return Loss::CheckLabel(y); });
-#else
-        common::AssertGPUSupport();
-        return false;
-#endif  // defined(XGBOOST_USE_CUDA)
-      },
-      [&] {
-#if defined(XGBOOST_USE_SYCL)
-        return sycl::linalg::Validate(ctx->Device(), label,
-                                      [](float y) -> bool { return Loss::CheckLabel(y); });
-#else
-        common::AssertSYCLSupport();
-        return false;
-#endif  // defined(XGBOOST_USE_SYCL)
-      });
-  if (!valid) {
-    LOG(FATAL) << Loss::LabelErrorMsg();
-  }
-  if (!info.weights_.Empty()) {
-    CHECK_EQ(info.weights_.Size(), info.num_row_)
-        << "Number of weights should be equal to the number of data points.";
-  }
 }
 
 template <typename Fn, typename Chk = common::NoOp<bool>, typename Err = common::NoOp<StringView>>
@@ -123,155 +82,6 @@ void ProbToMarginImpl(Context const* ctx, linalg::Vector<float>* base_score, Fn&
 DMLC_REGISTRY_FILE_TAG(regression_obj_gpu);
 #endif  // defined(XGBOOST_USE_CUDA)
 
-template <typename Loss>
-class RegLossObj : public FitInterceptGlmLike {
- protected:
-  HostDeviceVector<float> additional_input_;
-
- public:
-  // 0 - scale_pos_weight, 1 - is_null_weight
-  RegLossObj() : additional_input_(2) {}
-
-  void Configure(Args const& args) override { param_.UpdateAllowUnknown(args); }
-
-  [[nodiscard]] ObjInfo Task() const override { return Loss::Info(); }
-
-  [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
-    // Multi-target regression.
-    return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
-  }
-
-  void GetGradient(const HostDeviceVector<float>& preds, const MetaInfo& info, std::int32_t iter,
-                   linalg::Matrix<GradientPair>* out_gpair) override {
-    CheckRegInputs(info, preds);
-    if (iter == 0) {
-      ValidateLabel<Loss>(this->ctx_, info);
-    }
-
-    size_t const ndata = preds.Size();
-    out_gpair->SetDevice(ctx_->Device());
-    auto device = ctx_->Device();
-
-    bool is_null_weight = info.weights_.Size() == 0;
-    auto scale_pos_weight = param_.scale_pos_weight;
-    additional_input_.HostVector().begin()[0] = scale_pos_weight;
-    additional_input_.HostVector().begin()[1] = is_null_weight;
-
-    const size_t nthreads = ctx_->Threads();
-    bool on_device = !device.IsCPU();
-    // On CPU we run the transformation each thread processing a contigious block of data
-    // for better performance.
-    const size_t n_data_blocks = std::max(static_cast<size_t>(1), (on_device ? ndata : nthreads));
-    const size_t block_size = ndata / n_data_blocks + !!(ndata % n_data_blocks);
-    auto const n_targets = this->Targets(info);
-    out_gpair->Reshape(info.num_row_, n_targets);
-
-    common::Transform<>::Init(
-        [block_size, ndata, n_targets] XGBOOST_DEVICE(
-            size_t data_block_idx, common::Span<float> _additional_input,
-            common::Span<GradientPair> _out_gpair, common::Span<const bst_float> _preds,
-            common::Span<const bst_float> _labels, common::Span<const bst_float> _weights) {
-          const bst_float* preds_ptr = _preds.data();
-          const bst_float* labels_ptr = _labels.data();
-          const bst_float* weights_ptr = _weights.data();
-          GradientPair* out_gpair_ptr = _out_gpair.data();
-          const size_t begin = data_block_idx * block_size;
-          const size_t end = std::min(ndata, begin + block_size);
-          const float _scale_pos_weight = _additional_input[0];
-          const bool _is_null_weight = _additional_input[1];
-
-          for (size_t idx = begin; idx < end; ++idx) {
-            bst_float p = Loss::PredTransform(preds_ptr[idx]);
-            bst_float w = _is_null_weight ? 1.0f : weights_ptr[idx / n_targets];
-            bst_float label = labels_ptr[idx];
-            if (label == 1.0f) {
-              w *= _scale_pos_weight;
-            }
-            out_gpair_ptr[idx] = GradientPair(Loss::FirstOrderGradient(p, label) * w,
-                                              Loss::SecondOrderGradient(p, label) * w);
-          }
-        },
-        common::Range{0, static_cast<int64_t>(n_data_blocks)}, nthreads, device)
-        .Eval(&additional_input_, out_gpair->Data(), &preds, info.labels.Data(), &info.weights_);
-  }
-
- public:
-  [[nodiscard]] const char* DefaultEvalMetric() const override { return Loss::DefaultEvalMetric(); }
-
-  void PredTransform(HostDeviceVector<float>* io_preds) const override {
-    common::Transform<>::Init(
-        [] XGBOOST_DEVICE(size_t _idx, common::Span<float> _preds) {
-          _preds[_idx] = Loss::PredTransform(_preds[_idx]);
-        },
-        common::Range{0, static_cast<int64_t>(io_preds->Size())}, this->ctx_->Threads(),
-        io_preds->Device())
-        .Eval(io_preds);
-  }
-
-  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
-    if (std::abs(this->param_.scale_pos_weight - 1.0f) > kRtEps) {
-      // Use newton method if `scale_pos_weight` is present. The alternative is to use
-      // weighted mean, but we also need to take sample weight into account.
-      FitIntercept::InitEstimation(info, base_score);
-    } else {
-      FitInterceptGlmLike::InitEstimation(info, base_score);
-    }
-  }
-
-  void ProbToMargin(linalg::Vector<float>* base_score) const override {
-    ProbToMarginImpl(
-        this->ctx_, base_score, [] XGBOOST_DEVICE(float v) { return Loss::ProbToMargin(v); },
-        [] XGBOOST_DEVICE(float v) { return Loss::CheckIntercept(v); }, Loss::InterceptErrorMsg);
-  }
-
-  void SaveConfig(Json* p_out) const override {
-    auto& out = *p_out;
-    out["name"] = String(Loss::Name());
-    out["reg_loss_param"] = ToJson(param_);
-  }
-
-  void LoadConfig(Json const& in) override {
-    auto obj = get<Object const>(in);
-    auto it = obj.find("reg_loss_param");
-    if (it != obj.cend()) {
-      FromJson(it->second, &param_);
-    }
-  }
-
- protected:
-  RegLossParam param_;
-};
-
-// register the objective functions
-DMLC_REGISTER_PARAMETER(RegLossParam);
-
-XGBOOST_REGISTER_OBJECTIVE(SquaredLossRegression, LinearSquareLoss::Name())
-    .describe("Regression with squared error.")
-    .set_body([]() { return new RegLossObj<LinearSquareLoss>(); });
-
-XGBOOST_REGISTER_OBJECTIVE(LogisticRegression, LogisticRegression::Name())
-    .describe("Logistic regression for probability regression task.")
-    .set_body([]() { return new RegLossObj<LogisticRegression>(); });
-
-XGBOOST_REGISTER_OBJECTIVE(LogisticClassification, LogisticClassification::Name())
-    .describe("Logistic regression for binary classification task.")
-    .set_body([]() { return new RegLossObj<LogisticClassification>(); });
-
-XGBOOST_REGISTER_OBJECTIVE(LogisticRaw, LogisticRaw::Name())
-    .describe(
-        "Logistic regression for classification, output score "
-        "before logistic transformation.")
-    .set_body([]() { return new RegLossObj<LogisticRaw>(); });
-
-// Deprecated functions
-XGBOOST_REGISTER_OBJECTIVE(LinearRegression, "reg:linear")
-    .describe("Regression with squared error.")
-    .set_body([]() {
-      LOG(WARNING) << "reg:linear is now deprecated in favor of reg:squarederror.";
-      return new RegLossObj<LinearSquareLoss>();
-    });
-// End deprecated
-
 class ExpectileRegression : public FitIntercept {
   common::ExpectileLossParam param_;
   HostDeviceVector<float> alpha_;
@@ -286,10 +96,11 @@ class ExpectileRegression : public FitIntercept {
   }
 
  public:
-  void Configure(Args const& args) override {
-    param_.UpdateAllowUnknown(args);
+  std::set<std::string> Configure(Args const& args) override {
+    auto used = UpdateAndGetUsedParameters(&param_, args);
     param_.Validate();
     alpha_.HostVector() = param_.expectile_alpha.Get();
+    return used;
   }
 
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
@@ -464,7 +275,7 @@ XGBOOST_REGISTER_OBJECTIVE(ExpectileRegression, "reg:expectileerror")
 // cox regression for survival data (negative values mean they are censored)
 class CoxRegression : public FitIntercept {
  public:
-  void Configure(Args const&) override {}
+  std::set<std::string> Configure(Args const&) override { return {}; }
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
 
   void GetGradient(const HostDeviceVector<bst_float>& preds, const MetaInfo& info, int,


### PR DESCRIPTION
## Summary

- replace the multiclass objective compile wrapper with a normal objective implementation and registered CPU/CUDA gradient and prediction-transform kernels
- keep multiclass label validation and intercept centering on the existing typed validation and transform kernels
- move absolute error into dedicated `.h`, `.cc`, and `.cu` files with a custom gradient kernel that retains its reduction-derived MM scale
- remove the absolute-error implementation from `regression_obj.cu`
- update static-link tags and R package build manifests for the new translation unit

These objectives use dedicated signatures instead of introducing a generalized row-wise abstraction: multiclass operates across classes, while absolute error includes a dataset reduction before gradient generation.

## Validation

- `./build/testxgboost --gtest_filter=Objective.*` (32 tests passed)
- focused multiclass and absolute-error CPU tests passed after the final rebuild
- compiled the multiclass and absolute-error CPU/CUDA units, modified regression CUDA unit, and registry wiring with CUDA 12.9
- `python ops/script/lint_cpp.py` (384 files passed)
- `git diff --check`