### PR TITLE
Configure learner parameters in explicit batches

### DIFF
--- a/R-package/R/xgb.Booster.R
+++ b/R-package/R/xgb.Booster.R
@@ -855,9 +855,9 @@ xgb.config <- function(object) {
     }
   })
   handle <- xgb.get.handle(object)
-  for (i in seq_along(p)) {
-    .Call(XGBoosterSetParam_R, handle, names(p[i]), p[[i]])
-  }
+  params <- Map(function(name, value) unname(list(name, value)), names(p), p)
+  config <- jsonlite::toJSON(list(params = unname(params)), auto_unbox = TRUE)
+  .Call(XGBoosterSetParams_R, handle, config)
   return(object)
 }
 

--- a/R-package/src/init.c
+++ b/R-package/src/init.c
@@ -44,6 +44,7 @@ extern SEXP XGBoosterPredictFromColumnar_R(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP XGBoosterSaveModel_R(SEXP, SEXP);
 extern SEXP XGBoosterSetAttr_R(SEXP, SEXP, SEXP);
 extern SEXP XGBoosterSetParam_R(SEXP, SEXP, SEXP);
+extern SEXP XGBoosterSetParams_R(SEXP, SEXP);
 extern SEXP XGBoosterUpdateOneIter_R(SEXP, SEXP, SEXP);
 extern SEXP XGCheckNullPtr_R(SEXP);
 extern SEXP XGSetArrayDimNamesInplace_R(SEXP, SEXP);
@@ -108,6 +109,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"XGBoosterSaveModel_R", (DL_FUNC)&XGBoosterSaveModel_R, 2},
     {"XGBoosterSetAttr_R", (DL_FUNC)&XGBoosterSetAttr_R, 3},
     {"XGBoosterSetParam_R", (DL_FUNC)&XGBoosterSetParam_R, 3},
+    {"XGBoosterSetParams_R", (DL_FUNC)&XGBoosterSetParams_R, 2},
     {"XGBoosterUpdateOneIter_R", (DL_FUNC)&XGBoosterUpdateOneIter_R, 3},
     {"XGCheckNullPtr_R", (DL_FUNC)&XGCheckNullPtr_R, 1},
     {"XGSetArrayDimNamesInplace_R", (DL_FUNC)&XGSetArrayDimNamesInplace_R, 2},

--- a/R-package/src/xgboost_R.cc
+++ b/R-package/src/xgboost_R.cc
@@ -1125,6 +1125,15 @@ XGB_DLL SEXP XGBoosterSetParam_R(SEXP handle, SEXP name, SEXP val) {
   return R_NilValue;
 }
 
+XGB_DLL SEXP XGBoosterSetParams_R(SEXP handle, SEXP config) {
+  R_API_BEGIN();
+  SEXP config_ = Rf_protect(Rf_asChar(config));
+  CHECK_CALL(XGBoosterSetParams(R_ExternalPtrAddr(handle), CHAR(config_)));
+  Rf_unprotect(1);
+  R_API_END();
+  return R_NilValue;
+}
+
 XGB_DLL SEXP XGBoosterUpdateOneIter_R(SEXP handle, SEXP iter, SEXP dtrain) {
   R_API_BEGIN();
   CHECK_CALL(XGBoosterUpdateOneIter(R_ExternalPtrAddr(handle), Rf_asInteger(iter),

--- a/R-package/src/xgboost_R.h
+++ b/R-package/src/xgboost_R.h
@@ -332,6 +332,14 @@ XGB_DLL SEXP XGBoosterGetNumFeature_R(SEXP handle);
 XGB_DLL SEXP XGBoosterSetParam_R(SEXP handle, SEXP name, SEXP val);
 
 /*!
+ * \brief set a batch of parameters
+ * \param handle handle
+ * \param config JSON-encoded parameter batch
+ * \return R_NilValue
+ */
+XGB_DLL SEXP XGBoosterSetParams_R(SEXP handle, SEXP config);
+
+/*!
  * \brief update the model in one round using dtrain
  * \param handle handle
  * \param iter current iteration rounds

--- a/include/xgboost/c_api.h
+++ b/include/xgboost/c_api.h
@@ -1038,13 +1038,31 @@ XGB_DLL int XGBoosterSlice(BoosterHandle handle, int begin_layer, int end_layer,
 XGB_DLL int XGBoosterBoostedRounds(BoosterHandle handle, int *out);
 
 /**
- * @brief set parameters
+ * @brief Set and apply one parameter as a single-element configuration batch.
+ *
+ * @deprecated Prefer XGBoosterSetParams when setting multiple parameters so they are configured
+ * together.
+ *
  * @param handle handle
  * @param name  parameter name
  * @param value value of parameter
  * @return 0 when success, -1 when failure happens
  */
 XGB_DLL int XGBoosterSetParam(BoosterHandle handle, const char *name, const char *value);
+
+/**
+ * @brief Set and apply multiple parameters as one configuration step.
+ *
+ * The configuration is a JSON object with a `params` array containing name-value pairs. The array
+ * is ordered and preserves repeated parameters such as `eval_metric`. A successful return means
+ * that no configuration is pending. For example:
+ * `{"params": [["tree_method", "hist"], ["eval_metric", "mae"], ["eval_metric", "rmse"]]}`.
+ *
+ * @param handle Handle to the booster.
+ * @param config JSON-encoded parameter batch.
+ * @return 0 when success, -1 when failure happens.
+ */
+XGB_DLL int XGBoosterSetParams(BoosterHandle handle, char const *config);
 /**
  * @example c-api-demo.c
  */

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -154,20 +154,13 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
   void SaveModel(Json* out) const override = 0;
 
   /*!
-   * \brief Set multiple parameters at once.
+   * \brief Set and apply multiple parameters as one configuration step.
    *
-   * \param args parameters.
+   * A successful return guarantees that no configuration is pending.
+   *
+   * \param args Ordered parameter batch. Repeated parameters are preserved.
    */
   virtual void SetParams(Args const& args) = 0;
-  /*!
-   * \brief Set parameter for booster
-   *
-   *  The property will NOT be saved along with booster
-   *
-   * \param key   The key of parameter
-   * \param value The value of parameter
-   */
-  virtual void SetParam(const std::string& key, const std::string& value) = 0;
 
   /**
    * @brief Get the number of features of the booster.

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -20,7 +20,6 @@
 
 #include <algorithm>  // for max
 #include <cstdint>    // for int32_t, uint32_t, uint8_t
-#include <map>        // for map
 #include <memory>     // for shared_ptr, unique_ptr
 #include <string>     // for string
 #include <utility>    // for move
@@ -68,9 +67,10 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
  public:
   ~Learner() override;
   /*!
-   * \brief Configure Learner based on set parameters.
+   * \brief Configure Learner with a parameter batch.
+   * \param args Ordered parameter batch. Repeated parameters are preserved.
    */
-  virtual void Configure() = 0;
+  virtual void Configure(Args const& args = {}) = 0;
   /*!
    * \brief update the model for one iteration
    *  With the specified objective function.
@@ -152,15 +152,6 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
 
   void LoadModel(Json const& in) override = 0;
   void SaveModel(Json* out) const override = 0;
-
-  /*!
-   * \brief Set and apply multiple parameters as one configuration step.
-   *
-   * A successful return guarantees that no configuration is pending.
-   *
-   * \param args Ordered parameter batch. Repeated parameters are preserved.
-   */
-  virtual void SetParams(Args const& args) = 0;
 
   /**
    * @brief Get the number of features of the booster.
@@ -257,11 +248,6 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
    * \brief Return the context object of this Booster.
    */
   virtual Context const* Ctx() const = 0;
-  /*!
-   * \brief Get configuration arguments currently stored by the learner
-   * \return Key-value pairs representing configuration arguments
-   */
-  virtual const std::map<std::string, std::string>& GetConfigurationArguments() const = 0;
 
  protected:
   /*! \brief objective function */

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -16,6 +16,7 @@
 package ml.dmlc.xgboost4j.java;
 
 import java.io.*;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -28,6 +29,8 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -119,10 +122,23 @@ public class Booster implements Serializable, KryoSerializable {
    * @throws XGBoostError native error
    */
   public void setParams(Map<String, Object> params) throws XGBoostError {
-    if (params != null) {
-      for (Map.Entry<String, Object> entry : params.entrySet()) {
-        setParam(entry.getKey(), entry.getValue().toString());
-      }
+    if (params == null || params.isEmpty()) {
+      return;
+    }
+
+    List<List<String>> entries = new ArrayList<>(params.size());
+    for (Map.Entry<String, Object> entry : params.entrySet()) {
+      entries.add(Arrays.asList(entry.getKey(), entry.getValue().toString()));
+    }
+    Map<String, Object> config = new HashMap<>();
+    config.put("params", entries);
+
+    ObjectMapper mapper = new ObjectMapper();
+    try {
+      String json = mapper.writeValueAsString(config);
+      XGBoostJNI.checkCall(XGBoostJNI.XGBoosterSetParams(handle, json));
+    } catch (JsonProcessingException ex) {
+      throw new XGBoostError("Failed to encode booster parameters.", ex);
     }
   }
 

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -111,6 +111,8 @@ public class XGBoostJNI {
 
   public final static native int XGBoosterSetParam(long handle, String name, String value);
 
+  public final static native int XGBoosterSetParams(long handle, String config);
+
   public final static native int XGBoosterUpdateOneIter(long handle, int iter, long dtrain);
 
   public final static native int XGBoosterTrainOneIter(long handle, long dtrain, int iter, float[] grad,

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -670,6 +670,27 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetParam(
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGBoosterSetParams
+ * Signature: (JLjava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetParams(JNIEnv *jenv,
+                                                                                 jclass jcls,
+                                                                                 jlong jhandle,
+                                                                                 jstring jconfig) {
+  auto handle = reinterpret_cast<BoosterHandle>(jhandle);
+  std::unique_ptr<char const, Deleter<char const>> config{
+      jenv->GetStringUTFChars(jconfig, nullptr), [&](char const *ptr) {
+        if (ptr) {
+          jenv->ReleaseStringUTFChars(jconfig, ptr);
+        }
+      }};
+  int ret = XGBoosterSetParams(handle, config.get());
+  JVM_CHECK_CALL(ret);
+  return ret;
+}
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGBoosterUpdateOneIter
  * Signature: (JIJ)V
  */

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.h
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.h
@@ -190,6 +190,14 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetParam(
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
+ * Method:    XGBoosterSetParams
+ * Signature: (JLjava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterSetParams(JNIEnv *, jclass,
+                                                                                 jlong, jstring);
+
+/*
+ * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGBoosterUpdateOneIter
  * Signature: (JIJ)I
  */

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/BoosterImplTest.java
@@ -107,6 +107,22 @@ public class BoosterImplTest {
   }
 
   @Test
+  public void testSetParamsAsBatch() throws XGBoostError {
+    DMatrix trainMat = new DMatrix(this.train_uri);
+    Map<String, Object> params = new LinkedHashMap<>();
+    // This order is invalid when each parameter triggers configuration independently.
+    params.put("objective", "multi:softprob");
+    params.put("num_class", 3);
+
+    Map<String, DMatrix> watches = new HashMap<>();
+    watches.put("train", trainMat);
+
+    Booster booster = XGBoost.train(trainMat, params, 1, watches, null, null);
+    float[][] predictions = booster.predict(trainMat);
+    TestCase.assertEquals(3, predictions[0].length);
+  }
+
+  @Test
   public void testPredictionIterationEnd() throws XGBoostError {
     DMatrix trainMat = new DMatrix(this.train_uri);
     DMatrix testMat = new DMatrix(this.test_uri);

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1813,7 +1813,27 @@ class Booster:
         else:
             params_processed["validate_parameters"] = True
 
-        self.set_param(params_processed or {})
+        prepared = self._prepare_parameters(params_processed or {})
+        if cache or model_file is not None or params:
+            self._set_params(prepared)
+
+    @staticmethod
+    def _prepare_parameters(params: Iterable[Tuple[str, Any]]) -> List[Tuple[str, str]]:
+        prepared = []
+        for key, val in params:
+            if isinstance(val, np.ndarray):
+                val = val.tolist()
+            elif hasattr(val, "__cuda_array_interface__") and hasattr(val, "tolist"):
+                val = val.tolist()
+            if val is not None:
+                prepared.append((key, str(val)))
+        return prepared
+
+    def _set_params(self, params: List[Tuple[str, str]]) -> None:
+        if params:
+            _check_call(
+                _LIB.XGBoosterSetParams(self.handle, make_jcargs(params=params))
+            )
 
     def _transform_monotone_constrains(
         self, value: Union[Dict[str, int], str, Tuple[int, ...]]
@@ -2182,15 +2202,8 @@ class Booster:
             params = params.items()
         elif isinstance(params, str) and value is not None:
             params = [(params, value)]
-        for key, val in cast(Iterable[Tuple[str, str]], params):
-            if isinstance(val, np.ndarray):
-                val = val.tolist()
-            elif hasattr(val, "__cuda_array_interface__") and hasattr(val, "tolist"):
-                val = val.tolist()
-            if val is not None:
-                _check_call(
-                    _LIB.XGBoosterSetParam(self.handle, c_str(key), c_str(str(val)))
-                )
+        prepared = self._prepare_parameters(cast(Iterable[Tuple[str, Any]], params))
+        self._set_params(prepared)
 
     def update(
         self,

--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -1813,7 +1813,10 @@ class Booster:
         else:
             params_processed["validate_parameters"] = True
 
-        prepared = self._prepare_parameters(params_processed or {})
+        if isinstance(params_processed, dict):
+            prepared = self._prepare_parameters(params_processed.items())
+        else:
+            prepared = self._prepare_parameters(params_processed)
         if cache or model_file is not None or params:
             self._set_params(prepared)
 

--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -1189,8 +1189,9 @@ class XGBModel(XGBModelBase):
     def load_model(self, fname: ModelIn) -> None:
         # pylint: disable=attribute-defined-outside-init
         if not self.__sklearn_is_fitted__():
-            self._Booster = Booster({"n_jobs": self.n_jobs})
-        self.get_booster().load_model(fname)
+            self._Booster = Booster({"n_jobs": self.n_jobs}, model_file=fname)
+        else:
+            self.get_booster().load_model(fname)
 
         meta_str = self.get_booster().attr("scikit_learn")
         if meta_str is not None:

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1056,8 +1056,38 @@ XGB_DLL int XGBoosterReset(BoosterHandle handle) {
 
 XGB_DLL int XGBoosterSetParam(BoosterHandle handle, const char *name, const char *value) {
   API_BEGIN();
+  xgboost_CHECK_C_ARG_PTR(name);
+  xgboost_CHECK_C_ARG_PTR(value);
+  Json config{Object{}};
+  std::vector<Json> pair;
+  pair.emplace_back(String{std::string{name}});
+  pair.emplace_back(String{std::string{value}});
+  std::vector<Json> params;
+  params.emplace_back(Array{std::move(pair)});
+  config["params"] = Array{std::move(params)};
+  std::string s_config;
+  Json::Dump(config, &s_config);
+  return XGBoosterSetParams(handle, s_config.c_str());
+  API_END();
+}
+
+XGB_DLL int XGBoosterSetParams(BoosterHandle handle, char const *config) {
+  API_BEGIN();
   CHECK_HANDLE();
-  static_cast<Learner *>(handle)->SetParam(name, value);
+  xgboost_CHECK_C_ARG_PTR(config);
+  Json j_config{Json::Load(StringView{config})};
+  CHECK(IsA<Object>(j_config)) << "Booster parameter configuration must be a JSON object.";
+  auto const &params = get<Array const>(j_config["params"]);
+
+  Args args;
+  args.reserve(params.size());
+  for (auto const &j_param : params) {
+    CHECK(IsA<Array>(j_param)) << "Each booster parameter must be a JSON array.";
+    auto const &pair = get<Array const>(j_param);
+    CHECK_EQ(pair.size(), 2) << "Each booster parameter must contain a name and value.";
+    args.emplace_back(get<String const>(pair[0]), get<String const>(pair[1]));
+  }
+  static_cast<Learner *>(handle)->SetParams(args);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1087,7 +1087,7 @@ XGB_DLL int XGBoosterSetParams(BoosterHandle handle, char const *config) {
     CHECK_EQ(pair.size(), 2) << "Each booster parameter must contain a name and value.";
     args.emplace_back(get<String const>(pair[0]), get<String const>(pair[1]));
   }
-  static_cast<Learner *>(handle)->SetParams(args);
+  static_cast<Learner *>(handle)->Configure(args);
   API_END();
 }
 

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -652,21 +652,20 @@ class LearnerConfiguration : public Intercept {
     learner_parameters["generic_param"] = ctx_.ToJson();
   }
 
-  void SetParam(const std::string& key, const std::string& value) override {
-    this->need_configuration_ = true;
-    if (key == kEvalMetric) {
-      if (std::find(metric_names_.cbegin(), metric_names_.cend(), value) == metric_names_.cend()) {
-        metric_names_.emplace_back(value);
-      }
-    } else {
-      cfg_[key] = value;
-    }
-  }
-  // Short hand for setting multiple parameters
+  // Apply a complete parameter batch before returning.
   void SetParams(std::vector<std::pair<std::string, std::string>> const& args) override {
+    this->need_configuration_ = true;
     for (auto const& kv : args) {
-      this->SetParam(kv.first, kv.second);
+      if (kv.first == kEvalMetric) {
+        if (std::find(metric_names_.cbegin(), metric_names_.cend(), kv.second) ==
+            metric_names_.cend()) {
+          metric_names_.emplace_back(kv.second);
+        }
+      } else {
+        cfg_[kv.first] = kv.second;
+      }
     }
+    this->Configure();
   }
 
   uint32_t GetNumFeature() const override { return learner_model_param_.num_feature; }

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -492,7 +492,6 @@ class LearnerConfiguration : public Intercept {
 
  protected:
   std::atomic<bool> need_configuration_;
-  std::map<std::string, std::string> cfg_;
   // Stores information like best-iteration for early stopping.
   std::map<std::string, std::string> attributes_;
   // Name of each feature, usually set from DMatrix.
@@ -518,30 +517,48 @@ class LearnerConfiguration : public Intercept {
     }
   }
 
-  // Configuration before data is known.
-  void Configure() override {
+  void Configure(Args const& args = {}) override {
+    bool has_args = !args.empty();
+    if (has_args) {
+      this->need_configuration_ = true;
+    }
+
     // Varient of double checked lock
-    if (!this->need_configuration_) {
+    if (!has_args && !this->need_configuration_) {
       return;
     }
     std::lock_guard<std::mutex> guard(config_lock_);
-    if (!this->need_configuration_) {
+    if (!has_args && !this->need_configuration_) {
       return;
     }
 
     monitor_.Start("Configure");
     auto old_tparam = tparam_;
-    Args args = {cfg_.cbegin(), cfg_.cend()};
-    auto provided = args;
+    std::map<std::string, std::string> config;
+    std::set<std::string> used;
 
-    auto used = UpdateAndGetUsedParameters(&tparam_, args);
-    used.merge(UpdateAndGetUsedParameters(&mparam_, args));
+    for (auto const& [key, value] : args) {
+      if (key == kEvalMetric) {
+        used.insert(kEvalMetric);
+        if (std::find(metric_names_.cbegin(), metric_names_.cend(), value) ==
+            metric_names_.cend()) {
+          metric_names_.emplace_back(value);
+        }
+      } else {
+        config[key] = value;
+      }
+    }
+
+    Args config_args{config.cbegin(), config.cend()};
+
+    used.merge(UpdateAndGetUsedParameters(&tparam_, config_args));
+    used.merge(UpdateAndGetUsedParameters(&mparam_, config_args));
 
     auto initialized = ctx_.GetInitialised();
     auto old_seed = ctx_.seed;
-    used.merge(UpdateAndGetUsedParameters(&ctx_, args));
+    used.merge(UpdateAndGetUsedParameters(&ctx_, config_args));
 
-    used.merge(ConsoleLogger::Configure(args));
+    used.merge(ConsoleLogger::Configure(config_args));
 
     // set seed only before the model is initialized
     if (!initialized || ctx_.seed != old_seed) {
@@ -550,26 +567,25 @@ class LearnerConfiguration : public Intercept {
 
     // must precede configure gbm since num_features is required for gbm
     this->ConfigureNumFeatures();
-    args = {cfg_.cbegin(), cfg_.cend()};  // renew
-    used.merge(this->ConfigureObjective(old_tparam, &args));
+    used.merge(this->ConfigureObjective(old_tparam, &config, &config_args));
 
     learner_model_param_.task = obj_->Task();  // required by gbm configuration.
-    used.merge(this->ConfigureGBM(old_tparam, args));
+    used.merge(this->ConfigureGBM(old_tparam, config_args));
 
     this->InitModelUserParam(this->tparam_, this->cache_data_);
 
-    used.merge(this->ConfigureMetrics(args));
+    used.merge(this->ConfigureMetrics(config_args));
 
     this->need_configuration_ = false;
     if (ctx_.validate_parameters) {
-      this->ValidateParameters(provided, used);
+      this->ValidateParameters(args, used);
     }
 
-    cfg_.clear();
     monitor_.Stop("Configure");
   }
 
-  void LoadConfig(Json const& in) override {
+ protected:
+  void LoadConfigImpl(Json const& in) {
     // If configuration is loaded, ensure that the model came from the same version
     CHECK(IsA<Object>(in));
     auto origin_version = Version::Load(in);
@@ -624,6 +640,12 @@ class LearnerConfiguration : public Intercept {
     this->need_configuration_ = true;
   }
 
+ public:
+  void LoadConfig(Json const& in) override {
+    this->LoadConfigImpl(in);
+    this->Configure();
+  }
+
   void SaveConfig(Json* p_out) const override {
     CHECK(!this->need_configuration_) << "Call Configure before saving model.";
     Version::Save(p_out);
@@ -650,22 +672,6 @@ class LearnerConfiguration : public Intercept {
     learner_parameters["metrics"] = Array(std::move(metrics));
 
     learner_parameters["generic_param"] = ctx_.ToJson();
-  }
-
-  // Apply a complete parameter batch before returning.
-  void SetParams(std::vector<std::pair<std::string, std::string>> const& args) override {
-    this->need_configuration_ = true;
-    for (auto const& kv : args) {
-      if (kv.first == kEvalMetric) {
-        if (std::find(metric_names_.cbegin(), metric_names_.cend(), kv.second) ==
-            metric_names_.cend()) {
-          metric_names_.emplace_back(kv.second);
-        }
-      } else {
-        cfg_[kv.first] = kv.second;
-      }
-    }
-    this->Configure();
   }
 
   uint32_t GetNumFeature() const override { return learner_model_param_.num_feature; }
@@ -711,10 +717,6 @@ class LearnerConfiguration : public Intercept {
       out.emplace_back(kv.first);
     }
     return out;
-  }
-
-  const std::map<std::string, std::string>& GetConfigurationArguments() const override {
-    return cfg_;
   }
 
   Context const* Ctx() const override { return &ctx_; }
@@ -787,35 +789,38 @@ class LearnerConfiguration : public Intercept {
     return gbm_->Configure(args);
   }
 
-  std::set<std::string> ConfigureObjective(LearnerTrainParam const& old, Args* p_args) {
+  std::set<std::string> ConfigureObjective(LearnerTrainParam const& old,
+                                           std::map<std::string, std::string>* p_config,
+                                           Args* p_args) {
+    auto& config = *p_config;
     // Once binary IO is gone, NONE of these config is useful.
-    if (cfg_.find("num_class") != cfg_.cend() && cfg_.at("num_class") != "0" &&
+    if (config.find("num_class") != config.cend() && config.at("num_class") != "0" &&
         tparam_.objective != "multi:softprob") {
-      cfg_["num_output_group"] = cfg_["num_class"];
-      if (atoi(cfg_["num_class"].c_str()) > 1 && cfg_.count("objective") == 0) {
+      config["num_output_group"] = config["num_class"];
+      if (atoi(config["num_class"].c_str()) > 1 && config.count("objective") == 0) {
         tparam_.objective = "multi:softmax";
       }
     }
 
-    if (cfg_.find("max_delta_step") == cfg_.cend() && cfg_.find("objective") != cfg_.cend() &&
-        tparam_.objective == "count:poisson") {
+    if (config.find("max_delta_step") == config.cend() &&
+        config.find("objective") != config.cend() && tparam_.objective == "count:poisson") {
       // max_delta_step is a duplicated parameter in Poisson regression and tree param.
       // Rename one of them once binary IO is gone.
-      cfg_["max_delta_step"] = kMaxDeltaStepDefaultValue;
+      config["max_delta_step"] = kMaxDeltaStepDefaultValue;
     }
     if (obj_ == nullptr || tparam_.objective != old.objective) {
       obj_.reset(ObjFunction::Create(tparam_.objective, &ctx_));
     }
 
-    bool has_nc{cfg_.find("num_class") != cfg_.cend()};
+    bool has_nc{config.find("num_class") != config.cend()};
     // Inject num_class into configuration.
     // FIXME(jiamingy): Remove the duplicated parameter in softmax
-    cfg_["num_class"] = std::to_string(mparam_.num_class);
+    config["num_class"] = std::to_string(mparam_.num_class);
     auto& args = *p_args;
-    args = {cfg_.cbegin(), cfg_.cend()};  // renew
+    args = {config.cbegin(), config.cend()};
     auto used = obj_->Configure(args);
     if (!has_nc) {
-      cfg_.erase("num_class");
+      config.erase("num_class");
     }
     return used;
   }
@@ -853,7 +858,8 @@ class LearnerIO : public LearnerConfiguration {
  public:
   explicit LearnerIO(std::vector<std::shared_ptr<DMatrix>> cache) : LearnerConfiguration{cache} {}
 
-  void LoadModel(Json const& in) override {
+ protected:
+  void LoadModelImpl(Json const& in) {
     CHECK(IsA<Object>(in));
     auto version = Version::Load(in);
     if (std::get<0>(version) == 1 && std::get<1>(version) < 6) {
@@ -903,6 +909,12 @@ class LearnerIO : public LearnerConfiguration {
 
     this->need_configuration_ = true;
     this->ClearCaches();
+  }
+
+ public:
+  void LoadModel(Json const& in) override {
+    this->LoadModelImpl(in);
+    this->Configure();
   }
 
   void SaveModel(Json* p_out) const override {
@@ -976,8 +988,9 @@ class LearnerIO : public LearnerConfiguration {
       LOG(FATAL) << "Invalid serialization file.";
     }
 
-    this->LoadModel(memory_snapshot["Model"]);
-    this->LoadConfig(memory_snapshot["Config"]);
+    this->LoadModelImpl(memory_snapshot["Model"]);
+    this->LoadConfigImpl(memory_snapshot["Config"]);
+    this->Configure();
   }
 };
 
@@ -1128,7 +1141,7 @@ class LearnerImpl : public LearnerIO {
       if (!IsA<Null>(config)) {
         metrics_.back()->LoadConfig(config);
       }
-      metrics_.back()->Configure({cfg_.begin(), cfg_.end()});
+      metrics_.back()->Configure({});
     }
 
     for (size_t i = 0; i < data_sets.size(); ++i) {
@@ -1223,10 +1236,6 @@ class LearnerImpl : public LearnerIO {
     this->CheckModelInitialized();
 
     gbm_->FeatureScore(importance_type, trees, features, scores);
-  }
-
-  const std::map<std::string, std::string>& GetConfigurationArguments() const override {
-    return cfg_;
   }
 
  protected:

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -93,6 +93,31 @@ TEST(CAPI, XGDMatrixCreateFromCSR) {
   ASSERT_NE(msg.find("Column-wise data split has been removed"), std::string::npos);
 }
 
+TEST(CAPI, SetParams) {
+  auto p_dmat = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix();
+  std::array<DMatrixHandle, 1> mats{&p_dmat};
+  BoosterHandle booster;
+  ASSERT_EQ(XGBoosterCreate(mats.data(), mats.size(), &booster), 0);
+
+  char const *config =
+      R"({"params":[["objective","reg:absoluteerror"],["eval_metric","mae"],["eval_metric","rmse"]]})";
+  ASSERT_EQ(XGBoosterSetParams(booster, config), 0);
+
+  auto learner = static_cast<Learner *>(booster);
+  EXPECT_TRUE(learner->GetConfigurationArguments().empty());
+  Json saved_config{Object{}};
+  learner->SaveConfig(&saved_config);
+  EXPECT_EQ(get<String const>(saved_config["learner"]["objective"]["name"]), "reg:absoluteerror");
+  EXPECT_EQ(get<Array const>(saved_config["learner"]["metrics"]).size(), 2);
+
+  ASSERT_EQ(XGBoosterSetParam(booster, "objective", "reg:squarederror"), 0);
+  EXPECT_TRUE(learner->GetConfigurationArguments().empty());
+  Json single_config{Object{}};
+  learner->SaveConfig(&single_config);
+  EXPECT_EQ(get<String const>(single_config["learner"]["objective"]["name"]), "reg:squarederror");
+  EXPECT_EQ(XGBoosterFree(booster), 0);
+}
+
 TEST(CAPI, ConfigIO) {
   size_t constexpr kRows = 10;
   auto p_dmat = RandomDataGenerator(kRows, 10, 0).GenerateDMatrix();

--- a/tests/cpp/c_api/test_c_api.cc
+++ b/tests/cpp/c_api/test_c_api.cc
@@ -103,17 +103,14 @@ TEST(CAPI, SetParams) {
       R"({"params":[["objective","reg:absoluteerror"],["eval_metric","mae"],["eval_metric","rmse"]]})";
   ASSERT_EQ(XGBoosterSetParams(booster, config), 0);
 
-  auto learner = static_cast<Learner *>(booster);
-  EXPECT_TRUE(learner->GetConfigurationArguments().empty());
   Json saved_config{Object{}};
-  learner->SaveConfig(&saved_config);
+  static_cast<Learner *>(booster)->SaveConfig(&saved_config);
   EXPECT_EQ(get<String const>(saved_config["learner"]["objective"]["name"]), "reg:absoluteerror");
   EXPECT_EQ(get<Array const>(saved_config["learner"]["metrics"]).size(), 2);
 
   ASSERT_EQ(XGBoosterSetParam(booster, "objective", "reg:squarederror"), 0);
-  EXPECT_TRUE(learner->GetConfigurationArguments().empty());
   Json single_config{Object{}};
-  learner->SaveConfig(&single_config);
+  static_cast<Learner *>(booster)->SaveConfig(&single_config);
   EXPECT_EQ(get<String const>(single_config["learner"]["objective"]["name"]), "reg:squarederror");
   EXPECT_EQ(XGBoosterFree(booster), 0);
 }

--- a/tests/cpp/common/test_categorical.cc
+++ b/tests/cpp/common/test_categorical.cc
@@ -53,8 +53,8 @@ TEST(Categorical, MinimalSet) {
       RandomDataGenerator{kRows, kCols, 0.0}.Type(types).MaxCategory(kCat).GenerateDMatrix(true);
 
   std::unique_ptr<Learner> learner{Learner::Create({Xy})};
-  learner->SetParams({{"max_depth", "1"}});
-  learner->SetParams({{"tree_method", "hist"}});
+  learner->Configure({{"max_depth", "1"}});
+  learner->Configure({{"tree_method", "hist"}});
   learner->Configure();
   learner->UpdateOneIter(0, Xy);
 

--- a/tests/cpp/common/test_categorical.cc
+++ b/tests/cpp/common/test_categorical.cc
@@ -53,8 +53,8 @@ TEST(Categorical, MinimalSet) {
       RandomDataGenerator{kRows, kCols, 0.0}.Type(types).MaxCategory(kCat).GenerateDMatrix(true);
 
   std::unique_ptr<Learner> learner{Learner::Create({Xy})};
-  learner->SetParam("max_depth", "1");
-  learner->SetParam("tree_method", "hist");
+  learner->SetParams({{"max_depth", "1"}});
+  learner->SetParams({{"tree_method", "hist"}});
   learner->Configure();
   learner->UpdateOneIter(0, Xy);
 
@@ -66,8 +66,8 @@ TEST(Categorical, MinimalSet) {
 
   HostDeviceVector<float> predt;
   {
-    std::vector<float> data{static_cast<float>(kCat),
-                            static_cast<float>(kCat + 1), 32.0f, 33.0f, 34.0f};
+    std::vector<float> data{static_cast<float>(kCat), static_cast<float>(kCat + 1), 32.0f, 33.0f,
+                            34.0f};
     auto test = GetDMatrixFromData(data, data.size(), kCols);
     learner->Predict(test, false, &predt, 0, 0, false, /*pred_leaf=*/true);
     ASSERT_EQ(predt.Size(), data.size());

--- a/tests/cpp/common/test_io.cc
+++ b/tests/cpp/common/test_io.cc
@@ -66,7 +66,7 @@ TEST(IO, LoadSequentialFile) {
   size_t constexpr kRows = 1000, kCols = 100;
   std::shared_ptr<DMatrix> p_dmat{RandomDataGenerator{kRows, kCols, 0}.GenerateDMatrix(true)};
   std::unique_ptr<Learner> learner{Learner::Create({p_dmat})};
-  learner->SetParams({{"tree_method", "hist"}});
+  learner->Configure({{"tree_method", "hist"}});
   learner->Configure();
 
   for (int32_t iter = 0; iter < 10; ++iter) {

--- a/tests/cpp/common/test_io.cc
+++ b/tests/cpp/common/test_io.cc
@@ -66,7 +66,7 @@ TEST(IO, LoadSequentialFile) {
   size_t constexpr kRows = 1000, kCols = 100;
   std::shared_ptr<DMatrix> p_dmat{RandomDataGenerator{kRows, kCols, 0}.GenerateDMatrix(true)};
   std::unique_ptr<Learner> learner{Learner::Create({p_dmat})};
-  learner->SetParam("tree_method", "hist");
+  learner->SetParams({{"tree_method", "hist"}});
   learner->Configure();
 
   for (int32_t iter = 0; iter < 10; ++iter) {

--- a/tests/cpp/gbm/test_gblinear.cu
+++ b/tests/cpp/gbm/test_gblinear.cu
@@ -20,7 +20,7 @@ TEST(GBlinear, DispatchUpdater) {
   auto test = [](std::string device) {
     auto p_fmat = RandomDataGenerator{10, 10, 0.0f}.GenerateDMatrix(true);
     std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
-    learner->SetParams(
+    learner->Configure(
         Args{{"booster", "gblinear"}, {"updater", "coord_descent"}, {"device", device}});
     learner->Configure();
     for (std::int32_t iter = 0; iter < 3; ++iter) {

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -137,10 +137,10 @@ TEST(GBTree, WrongUpdater) {
 
   auto learner = std::unique_ptr<Learner>(Learner::Create({p_dmat}));
   // Hist can not be used for updating tree.
-  learner->SetParams(Args{{"tree_method", "hist"}, {"process_type", "update"}});
+  learner->Configure(Args{{"tree_method", "hist"}, {"process_type", "update"}});
   ASSERT_THROW(learner->UpdateOneIter(0, p_dmat), dmlc::Error);
   // Prune can not be used for learning new tree.
-  ASSERT_THROW(learner->SetParams(Args{{"tree_method", "prune"}, {"process_type", "default"}}),
+  ASSERT_THROW(learner->Configure(Args{{"tree_method", "prune"}, {"process_type", "default"}}),
                dmlc::Error);
 }
 
@@ -156,7 +156,7 @@ TEST(GBTree, ChoosePredictor) {
   p_dmat->Info().labels.Reshape(kRows);
 
   auto learner = std::unique_ptr<Learner>(Learner::Create({p_dmat}));
-  learner->SetParams(Args{{"tree_method", "hist"}, {"device", "cuda"}});
+  learner->Configure(Args{{"tree_method", "hist"}, {"device", "cuda"}});
   for (size_t i = 0; i < 4; ++i) {
     learner->UpdateOneIter(i, p_dmat);
   }
@@ -174,7 +174,7 @@ TEST(GBTree, ChoosePredictor) {
     std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(fname.c_str(), "r"));
     learner->Load(fi.get());
   }
-  learner->SetParams(Args{{"tree_method", "hist"}, {"device", "cuda"}});
+  learner->Configure(Args{{"tree_method", "hist"}, {"device", "cuda"}});
   for (size_t i = 0; i < 4; ++i) {
     learner->UpdateOneIter(i, p_dmat);
   }
@@ -190,7 +190,7 @@ TEST(GBTree, ChoosePredictor) {
 
   // another new learner
   learner = std::unique_ptr<Learner>(Learner::Create({p_dmat}));
-  learner->SetParams(Args{{"tree_method", "hist"}, {"device", "cuda"}});
+  learner->Configure(Args{{"tree_method", "hist"}, {"device", "cuda"}});
   for (size_t i = 0; i < 4; ++i) {
     learner->UpdateOneIter(i, p_dmat);
   }
@@ -207,11 +207,11 @@ TEST(GBTree, ChooseTreeMethod) {
                          std::optional<std::string> tree_method) {
     auto learner = std::unique_ptr<Learner>(Learner::Create({Xy}));
     if (tree_method.has_value()) {
-      learner->SetParams({{"tree_method", tree_method.value()}});
+      learner->Configure({{"tree_method", tree_method.value()}});
     }
     if (device.has_value()) {
       auto const& d = device.value();
-      learner->SetParams({{"device", d}});
+      learner->Configure({{"device", d}});
     }
     learner->Configure();
     for (std::int32_t i = 0; i < 3; ++i) {
@@ -227,11 +227,11 @@ TEST(GBTree, ChooseTreeMethod) {
   auto with_boost = [&](std::optional<std::string> device, std::optional<std::string> tree_method) {
     auto learner = std::unique_ptr<Learner>(Learner::Create({Xy}));
     if (tree_method.has_value()) {
-      learner->SetParams({{"tree_method", tree_method.value()}});
+      learner->Configure({{"tree_method", tree_method.value()}});
     }
     if (device.has_value()) {
       auto const& d = device.value();
-      learner->SetParams({{"device", d}});
+      learner->Configure({{"device", d}});
     }
     learner->Configure();
     Context ctx;
@@ -498,14 +498,14 @@ class Dart : public testing::TestWithParam<char const*> {
     p_mat->SetInfo("label", Make1dInterfaceTest(labels.data(), kRows));
 
     auto learner = std::unique_ptr<Learner>(Learner::Create({p_mat}));
-    learner->SetParams({{"booster", "dart"}});
-    learner->SetParams({{"rate_drop", "0.5"}});
+    learner->Configure({{"booster", "dart"}});
+    learner->Configure({{"rate_drop", "0.5"}});
     learner->Configure();
 
     for (size_t i = 0; i < 16; ++i) {
       learner->UpdateOneIter(i, p_mat);
     }
-    learner->SetParams({{"device", ctx.DeviceName()}});
+    learner->Configure({{"device", ctx.DeviceName()}});
 
     HostDeviceVector<float> predts_training;
     learner->Predict(p_mat, false, &predts_training, 0, 0, true);
@@ -562,7 +562,7 @@ std::pair<Json, Json> TestModelSlice(std::string booster) {
   if (booster == "dart") {
     args.emplace_back("rate_drop", "0.5");
   }
-  learner->SetParams(args);
+  learner->Configure(args);
 
   for (auto i = 0; i < kIters; ++i) {
     learner->UpdateOneIter(i, m);
@@ -688,7 +688,7 @@ TEST(GBTree, FeatureScore) {
   auto m = RandomDataGenerator{n_samples, n_features, 0.5}.Classes(n_classes).GenerateDMatrix(true);
 
   std::unique_ptr<Learner> learner{Learner::Create({m})};
-  learner->SetParams({{"num_class", std::to_string(n_classes)}});
+  learner->Configure({{"num_class", std::to_string(n_classes)}});
 
   learner->Configure();
   for (size_t i = 0; i < 2; ++i) {
@@ -725,7 +725,7 @@ TEST(GBTree, PredictRange) {
   auto m = RandomDataGenerator{n_samples, n_features, 0.5}.Classes(n_classes).GenerateDMatrix(true);
 
   std::unique_ptr<Learner> learner{Learner::Create({m})};
-  learner->SetParams({{"num_class", std::to_string(n_classes)}});
+  learner->Configure({{"num_class", std::to_string(n_classes)}});
 
   learner->Configure();
   for (size_t i = 0; i < 2; ++i) {
@@ -772,7 +772,7 @@ TEST(GBTree, InplacePredictionError) {
         RandomDataGenerator{n_samples, n_features, 0.5f}.Batches(2).GenerateSparsePageDMatrix(
             "cache", true);
     std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
-    learner->SetParams(Args{{"booster", booster}, {"device", ctx->DeviceName()}});
+    learner->Configure(Args{{"booster", booster}, {"device", ctx->DeviceName()}});
     learner->Configure();
     for (std::int32_t i = 0; i < 3; ++i) {
       learner->UpdateOneIter(i, p_fmat);
@@ -815,7 +815,7 @@ TEST(GBTree, InplacePredictionError) {
 #endif  // defined(XGBOOST_USE_CUDA)
     }
     std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
-    learner->SetParams(Args{{"booster", booster},
+    learner->Configure(Args{{"booster", booster},
                             {"max_bin", std::to_string(max_bins)},
                             {"device", ctx->DeviceName()}});
     learner->Configure();

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -140,8 +140,8 @@ TEST(GBTree, WrongUpdater) {
   learner->SetParams(Args{{"tree_method", "hist"}, {"process_type", "update"}});
   ASSERT_THROW(learner->UpdateOneIter(0, p_dmat), dmlc::Error);
   // Prune can not be used for learning new tree.
-  learner->SetParams(Args{{"tree_method", "prune"}, {"process_type", "default"}});
-  ASSERT_THROW(learner->UpdateOneIter(0, p_dmat), dmlc::Error);
+  ASSERT_THROW(learner->SetParams(Args{{"tree_method", "prune"}, {"process_type", "default"}}),
+               dmlc::Error);
 }
 
 #ifdef XGBOOST_USE_CUDA
@@ -207,11 +207,11 @@ TEST(GBTree, ChooseTreeMethod) {
                          std::optional<std::string> tree_method) {
     auto learner = std::unique_ptr<Learner>(Learner::Create({Xy}));
     if (tree_method.has_value()) {
-      learner->SetParam("tree_method", tree_method.value());
+      learner->SetParams({{"tree_method", tree_method.value()}});
     }
     if (device.has_value()) {
       auto const& d = device.value();
-      learner->SetParam("device", d);
+      learner->SetParams({{"device", d}});
     }
     learner->Configure();
     for (std::int32_t i = 0; i < 3; ++i) {
@@ -227,11 +227,11 @@ TEST(GBTree, ChooseTreeMethod) {
   auto with_boost = [&](std::optional<std::string> device, std::optional<std::string> tree_method) {
     auto learner = std::unique_ptr<Learner>(Learner::Create({Xy}));
     if (tree_method.has_value()) {
-      learner->SetParam("tree_method", tree_method.value());
+      learner->SetParams({{"tree_method", tree_method.value()}});
     }
     if (device.has_value()) {
       auto const& d = device.value();
-      learner->SetParam("device", d);
+      learner->SetParams({{"device", d}});
     }
     learner->Configure();
     Context ctx;
@@ -498,14 +498,14 @@ class Dart : public testing::TestWithParam<char const*> {
     p_mat->SetInfo("label", Make1dInterfaceTest(labels.data(), kRows));
 
     auto learner = std::unique_ptr<Learner>(Learner::Create({p_mat}));
-    learner->SetParam("booster", "dart");
-    learner->SetParam("rate_drop", "0.5");
+    learner->SetParams({{"booster", "dart"}});
+    learner->SetParams({{"rate_drop", "0.5"}});
     learner->Configure();
 
     for (size_t i = 0; i < 16; ++i) {
       learner->UpdateOneIter(i, p_mat);
     }
-    learner->SetParam("device", ctx.DeviceName());
+    learner->SetParams({{"device", ctx.DeviceName()}});
 
     HostDeviceVector<float> predts_training;
     learner->Predict(p_mat, false, &predts_training, 0, 0, true);
@@ -688,7 +688,7 @@ TEST(GBTree, FeatureScore) {
   auto m = RandomDataGenerator{n_samples, n_features, 0.5}.Classes(n_classes).GenerateDMatrix(true);
 
   std::unique_ptr<Learner> learner{Learner::Create({m})};
-  learner->SetParam("num_class", std::to_string(n_classes));
+  learner->SetParams({{"num_class", std::to_string(n_classes)}});
 
   learner->Configure();
   for (size_t i = 0; i < 2; ++i) {
@@ -725,7 +725,7 @@ TEST(GBTree, PredictRange) {
   auto m = RandomDataGenerator{n_samples, n_features, 0.5}.Classes(n_classes).GenerateDMatrix(true);
 
   std::unique_ptr<Learner> learner{Learner::Create({m})};
-  learner->SetParam("num_class", std::to_string(n_classes));
+  learner->SetParams({{"num_class", std::to_string(n_classes)}});
 
   learner->Configure();
   for (size_t i = 0; i < 2; ++i) {

--- a/tests/cpp/gbm/test_gbtree.cu
+++ b/tests/cpp/gbm/test_gbtree.cu
@@ -41,7 +41,7 @@ void TestInplaceFallback(Context const* ctx) {
 
   // learner is configured to the device specified by ctx
   std::unique_ptr<Learner> learner{Learner::Create({Xy})};
-  learner->SetParams({{"device", ctx->DeviceName()}});
+  learner->Configure({{"device", ctx->DeviceName()}});
   for (std::int32_t i = 0; i < 3; ++i) {
     learner->UpdateOneIter(i, Xy);
   }
@@ -65,7 +65,7 @@ void TestInplaceFallback(Context const* ctx) {
   Context new_ctx = *proxy->Ctx();
   ASSERT_NE(new_ctx.Ordinal(), ctx->Ordinal());
 
-  learner->SetParams({{"device", new_ctx.DeviceName()}});
+  learner->Configure({{"device", new_ctx.DeviceName()}});
   HostDeviceVector<float>* out_predt_1{nullptr};
   // no warning is raised
   ::testing::internal::CaptureStderr();

--- a/tests/cpp/gbm/test_gbtree.cu
+++ b/tests/cpp/gbm/test_gbtree.cu
@@ -41,7 +41,7 @@ void TestInplaceFallback(Context const* ctx) {
 
   // learner is configured to the device specified by ctx
   std::unique_ptr<Learner> learner{Learner::Create({Xy})};
-  learner->SetParam("device", ctx->DeviceName());
+  learner->SetParams({{"device", ctx->DeviceName()}});
   for (std::int32_t i = 0; i < 3; ++i) {
     learner->UpdateOneIter(i, Xy);
   }
@@ -65,7 +65,7 @@ void TestInplaceFallback(Context const* ctx) {
   Context new_ctx = *proxy->Ctx();
   ASSERT_NE(new_ctx.Ordinal(), ctx->Ordinal());
 
-  learner->SetParam("device", new_ctx.DeviceName());
+  learner->SetParams({{"device", new_ctx.DeviceName()}});
   HostDeviceVector<float>* out_predt_1{nullptr};
   // no warning is raised
   ::testing::internal::CaptureStderr();

--- a/tests/cpp/objective/test_objective.cc
+++ b/tests/cpp/objective/test_objective.cc
@@ -69,20 +69,20 @@ class TestDefaultObjConfig : public ::testing::TestWithParam<std::string> {
     std::unique_ptr<Learner> learner{Learner::Create({Xy})};
     std::unique_ptr<ObjFunction> objfn{ObjFunction::Create(objective, &ctx_)};
 
-    learner->SetParam("objective", objective);
+    Args args{{"objective", objective}};
     if (objective.find("multi") != std::string::npos) {
-      learner->SetParam("num_class", "3");
+      args.emplace_back("num_class", "3");
       objfn->Configure(Args{{"num_class", "3"}});
     } else if (objective.find("quantile") != std::string::npos) {
-      learner->SetParam("quantile_alpha", "0.5");
+      args.emplace_back("quantile_alpha", "0.5");
       objfn->Configure(Args{{"quantile_alpha", "0.5"}});
     } else if (objective.find("expectile") != std::string::npos) {
-      learner->SetParam("expectile_alpha", "0.5");
+      args.emplace_back("expectile_alpha", "0.5");
       objfn->Configure(Args{{"expectile_alpha", "0.5"}});
     } else {
       objfn->Configure(Args{});
     }
-    learner->Configure();
+    learner->SetParams(args);
     learner->UpdateOneIter(0, Xy);
     learner->EvalOneIter(0, {Xy}, {"train"});
     Json config{Object{}};

--- a/tests/cpp/objective/test_objective.cc
+++ b/tests/cpp/objective/test_objective.cc
@@ -82,7 +82,7 @@ class TestDefaultObjConfig : public ::testing::TestWithParam<std::string> {
     } else {
       objfn->Configure(Args{});
     }
-    learner->SetParams(args);
+    learner->Configure(args);
     learner->UpdateOneIter(0, Xy);
     learner->EvalOneIter(0, {Xy}, {"train"});
     Json config{Object{}};

--- a/tests/cpp/objective/test_quantile_obj_cpu.cc
+++ b/tests/cpp/objective/test_quantile_obj_cpu.cc
@@ -29,7 +29,7 @@ TEST(Objective, DeclareUnifiedTest(QuantileRegularization)) {
 
   auto train = [&](float reg_lambda) {
     std::unique_ptr<Learner> learner{Learner::Create({Xy})};
-    learner->SetParams(Args{{"tree_method", "exact"},
+    learner->Configure(Args{{"tree_method", "exact"},
                             {"objective", "reg:quantileerror"},
                             {"quantile_alpha", "0.5"},
                             {"base_score", "0.5"},
@@ -60,7 +60,7 @@ TEST(Objective, DeclareUnifiedTest(QuantileMonotoneConstraint)) {
   Xy->Info().labels.Data()->HostVector() = {3.0f, 2.0f, 1.0f, 0.0f};
 
   std::unique_ptr<Learner> learner{Learner::Create({Xy})};
-  learner->SetParams(Args{{"tree_method", "hist"},
+  learner->Configure(Args{{"tree_method", "hist"},
                           {"objective", "reg:quantileerror"},
                           {"quantile_alpha", "0.5"},
                           {"monotone_constraints", "(1)"},

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -209,7 +209,7 @@ void TestTrainingPrediction(Context const *ctx, size_t rows, size_t bins,
   }
 
   learner.reset(Learner::Create({}));
-  learner->SetParams(Args{{"objective", "multi:softprob"},
+  learner->Configure(Args{{"objective", "multi:softprob"},
                           {"num_feature", std::to_string(kCols)},
                           {"num_class", std::to_string(kClasses)},
                           {"max_bin", std::to_string(bins)},
@@ -225,7 +225,7 @@ void TestTrainingPrediction(Context const *ctx, size_t rows, size_t bins,
 
   learner.reset(Learner::Create({}));
   learner->LoadModel(model);
-  learner->SetParams({{"device", ctx->DeviceName()}});
+  learner->Configure({{"device", ctx->DeviceName()}});
   learner->Configure();
 
   HostDeviceVector<float> from_full;
@@ -247,16 +247,16 @@ void TestInplacePrediction(Context const *ctx, std::shared_ptr<DMatrix> x, bst_i
 
   std::unique_ptr<Learner> learner{Learner::Create({m})};
 
-  learner->SetParams({{"num_parallel_tree", "4"}});
-  learner->SetParams({{"num_class", std::to_string(kClasses)}});
-  learner->SetParams({{"seed", "0"}});
-  learner->SetParams({{"subsample", "0.5"}});
-  learner->SetParams({{"tree_method", "hist"}});
+  learner->Configure({{"num_parallel_tree", "4"}});
+  learner->Configure({{"num_class", std::to_string(kClasses)}});
+  learner->Configure({{"seed", "0"}});
+  learner->Configure({{"subsample", "0.5"}});
+  learner->Configure({{"tree_method", "hist"}});
   for (int32_t it = 0; it < 4; ++it) {
     learner->UpdateOneIter(it, m);
   }
 
-  learner->SetParams({{"device", ctx->DeviceName()}});
+  learner->Configure({{"device", ctx->DeviceName()}});
   learner->Configure();
 
   HostDeviceVector<float> *p_out_predictions_0{nullptr};
@@ -294,7 +294,7 @@ void TestInplacePrediction(Context const *ctx, std::shared_ptr<DMatrix> x, bst_i
     ASSERT_NEAR(h_pred[i], h_pred_0[i] + h_pred_1[i] - base_score.at(j), kRtEps);
   }
 
-  learner->SetParams({{"device", "cpu"}});
+  learner->Configure({{"device", "cpu"}});
   learner->Configure();
 }
 
@@ -302,7 +302,7 @@ namespace {
 std::unique_ptr<Learner> LearnerForTest(Context const *ctx, std::shared_ptr<DMatrix> dmat,
                                         size_t iters, size_t forest = 1) {
   std::unique_ptr<Learner> learner{Learner::Create({dmat})};
-  learner->SetParams(Args{{"num_parallel_tree", std::to_string(forest)},
+  learner->Configure(Args{{"num_parallel_tree", std::to_string(forest)},
                           {"device", ctx->IsSycl() ? "cpu" : ctx->DeviceName()}});
   for (size_t i = 0; i < iters; ++i) {
     learner->UpdateOneIter(i, dmat);
@@ -346,7 +346,7 @@ void TestPredictionDeviceAccess() {
   {
     ASSERT_TRUE(from_cpu.Device().IsCPU());
     Context cpu_ctx;
-    learner->SetParams({{"device", cpu_ctx.DeviceName()}});
+    learner->Configure({{"device", cpu_ctx.DeviceName()}});
     learner->Predict(m_test, false, &from_cpu, 0, 0);
     ASSERT_TRUE(from_cpu.HostCanWrite());
     ASSERT_FALSE(from_cpu.DeviceCanRead());
@@ -356,7 +356,7 @@ void TestPredictionDeviceAccess() {
   HostDeviceVector<float> from_cuda;
   {
     Context cuda_ctx = MakeCUDACtx(0);
-    learner->SetParams({{"device", cuda_ctx.DeviceName()}});
+    learner->Configure({{"device", cuda_ctx.DeviceName()}});
     learner->Predict(m_test, false, &from_cuda, 0, 0);
     ASSERT_EQ(from_cuda.Device(), DeviceOrd::CUDA(0));
     ASSERT_TRUE(from_cuda.DeviceCanWrite());
@@ -510,11 +510,11 @@ void TestSparsePrediction(Context const *ctx, float sparsity) {
 
   learner.reset(Learner::Create({Xy}));
   learner->LoadModel(model);
-  learner->SetParams({{"device", ctx->DeviceName()}});
+  learner->Configure({{"device", ctx->DeviceName()}});
   learner->Configure();
   if (!ctx->IsCPU()) {
-    learner->SetParams({{"tree_method", "hist"}});
-    learner->SetParams({{"device", ctx->Device().Name()}});
+    learner->Configure({{"tree_method", "hist"}});
+    learner->Configure({{"device", ctx->Device().Name()}});
   }
   learner->Predict(Xy, false, &sparse_predt, 0, 0);
 
@@ -530,8 +530,8 @@ void TestSparsePrediction(Context const *ctx, float sparsity) {
     }
   }
 
-  learner->SetParams({{"tree_method", "hist"}});
-  learner->SetParams({{"device", "cpu"}});
+  learner->Configure({{"tree_method", "hist"}});
+  learner->Configure({{"device", "cpu"}});
   // Xcode_12.4 doesn't compile with `std::make_shared`.
   auto dense = std::shared_ptr<DMatrix>(new data::DMatrixProxy{});
   auto array_interface = GetArrayInterface(&with_nan, kRows, kCols);

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -225,7 +225,7 @@ void TestTrainingPrediction(Context const *ctx, size_t rows, size_t bins,
 
   learner.reset(Learner::Create({}));
   learner->LoadModel(model);
-  learner->SetParam("device", ctx->DeviceName());
+  learner->SetParams({{"device", ctx->DeviceName()}});
   learner->Configure();
 
   HostDeviceVector<float> from_full;
@@ -247,16 +247,16 @@ void TestInplacePrediction(Context const *ctx, std::shared_ptr<DMatrix> x, bst_i
 
   std::unique_ptr<Learner> learner{Learner::Create({m})};
 
-  learner->SetParam("num_parallel_tree", "4");
-  learner->SetParam("num_class", std::to_string(kClasses));
-  learner->SetParam("seed", "0");
-  learner->SetParam("subsample", "0.5");
-  learner->SetParam("tree_method", "hist");
+  learner->SetParams({{"num_parallel_tree", "4"}});
+  learner->SetParams({{"num_class", std::to_string(kClasses)}});
+  learner->SetParams({{"seed", "0"}});
+  learner->SetParams({{"subsample", "0.5"}});
+  learner->SetParams({{"tree_method", "hist"}});
   for (int32_t it = 0; it < 4; ++it) {
     learner->UpdateOneIter(it, m);
   }
 
-  learner->SetParam("device", ctx->DeviceName());
+  learner->SetParams({{"device", ctx->DeviceName()}});
   learner->Configure();
 
   HostDeviceVector<float> *p_out_predictions_0{nullptr};
@@ -294,7 +294,7 @@ void TestInplacePrediction(Context const *ctx, std::shared_ptr<DMatrix> x, bst_i
     ASSERT_NEAR(h_pred[i], h_pred_0[i] + h_pred_1[i] - base_score.at(j), kRtEps);
   }
 
-  learner->SetParam("device", "cpu");
+  learner->SetParams({{"device", "cpu"}});
   learner->Configure();
 }
 
@@ -346,7 +346,7 @@ void TestPredictionDeviceAccess() {
   {
     ASSERT_TRUE(from_cpu.Device().IsCPU());
     Context cpu_ctx;
-    learner->SetParam("device", cpu_ctx.DeviceName());
+    learner->SetParams({{"device", cpu_ctx.DeviceName()}});
     learner->Predict(m_test, false, &from_cpu, 0, 0);
     ASSERT_TRUE(from_cpu.HostCanWrite());
     ASSERT_FALSE(from_cpu.DeviceCanRead());
@@ -356,7 +356,7 @@ void TestPredictionDeviceAccess() {
   HostDeviceVector<float> from_cuda;
   {
     Context cuda_ctx = MakeCUDACtx(0);
-    learner->SetParam("device", cuda_ctx.DeviceName());
+    learner->SetParams({{"device", cuda_ctx.DeviceName()}});
     learner->Predict(m_test, false, &from_cuda, 0, 0);
     ASSERT_EQ(from_cuda.Device(), DeviceOrd::CUDA(0));
     ASSERT_TRUE(from_cuda.DeviceCanWrite());
@@ -510,11 +510,11 @@ void TestSparsePrediction(Context const *ctx, float sparsity) {
 
   learner.reset(Learner::Create({Xy}));
   learner->LoadModel(model);
-  learner->SetParam("device", ctx->DeviceName());
+  learner->SetParams({{"device", ctx->DeviceName()}});
   learner->Configure();
   if (!ctx->IsCPU()) {
-    learner->SetParam("tree_method", "hist");
-    learner->SetParam("device", ctx->Device().Name());
+    learner->SetParams({{"tree_method", "hist"}});
+    learner->SetParams({{"device", ctx->Device().Name()}});
   }
   learner->Predict(Xy, false, &sparse_predt, 0, 0);
 
@@ -530,8 +530,8 @@ void TestSparsePrediction(Context const *ctx, float sparsity) {
     }
   }
 
-  learner->SetParam("tree_method", "hist");
-  learner->SetParam("device", "cpu");
+  learner->SetParams({{"tree_method", "hist"}});
+  learner->SetParams({{"device", "cpu"}});
   // Xcode_12.4 doesn't compile with `std::make_shared`.
   auto dense = std::shared_ptr<DMatrix>(new data::DMatrixProxy{});
   auto array_interface = GetArrayInterface(&with_nan, kRows, kCols);

--- a/tests/cpp/predictor/test_shap.cc
+++ b/tests/cpp/predictor/test_shap.cc
@@ -223,7 +223,7 @@ void CheckShapOutput(DMatrix* dmat, Args const& model_args) {
 
   std::shared_ptr<DMatrix> p_dmat{dmat, [](DMatrix*) {}};
   std::unique_ptr<Learner> learner{Learner::Create({p_dmat})};
-  learner->SetParams(model_args);
+  learner->Configure(model_args);
   learner->Configure();
   for (size_t i = 0; i < 2; ++i) {
     learner->UpdateOneIter(i, p_dmat);
@@ -254,7 +254,7 @@ void CheckDartShapOutput(Context const* ctx) {
   SetLabels(dmat.get(), 1);
 
   std::unique_ptr<Learner> learner{Learner::Create({dmat})};
-  learner->SetParams(Args{{"booster", "dart"},
+  learner->Configure(Args{{"booster", "dart"},
                           {"objective", "binary:logistic"},
                           {"max_depth", "3"},
                           {"rate_drop", "0.5"},
@@ -442,7 +442,7 @@ TEST(Predictor, ApproxContribsBasic) {
   args.emplace_back("tree_method", "approx");
 
   std::unique_ptr<Learner> learner{Learner::Create({dmat})};
-  learner->SetParams(args);
+  learner->Configure(args);
   learner->Configure();
   for (size_t i = 0; i < 3; ++i) {
     learner->UpdateOneIter(i, dmat);
@@ -486,7 +486,7 @@ TEST(Predictor, ShapIterationRange) {
                   .Classes(kClasses)
                   .GenerateDMatrix(true);
   std::unique_ptr<Learner> learner{Learner::Create({dmat})};
-  learner->SetParams(Args{{"num_parallel_tree", std::to_string(kForest)},
+  learner->Configure(Args{{"num_parallel_tree", std::to_string(kForest)},
                           {"device", ctx.IsSycl() ? "cpu" : ctx.DeviceName()}});
   for (size_t i = 0; i < kIters; ++i) {
     learner->UpdateOneIter(i, dmat);

--- a/tests/cpp/predictor/test_shap.cu
+++ b/tests/cpp/predictor/test_shap.cu
@@ -33,7 +33,7 @@ TEST(GPUPredictor, CompareCPUShap) {
   }
 
   std::unique_ptr<Learner> learner{Learner::Create({dmat})};
-  learner->SetParams(Args{{"objective", "binary:logistic"},
+  learner->Configure(Args{{"objective", "binary:logistic"},
                           {"max_depth", "12"},
                           {"min_split_loss", "0"},
                           {"min_child_weight", "0"},
@@ -52,12 +52,12 @@ TEST(GPUPredictor, CompareCPUShap) {
 
   std::unique_ptr<Learner> learner_gpu{Learner::Create({})};
   learner_gpu->LoadModel(model);
-  learner_gpu->SetParams({{"device", ctx.DeviceName()}});
+  learner_gpu->Configure({{"device", ctx.DeviceName()}});
   learner_gpu->Configure();
 
   std::unique_ptr<Learner> learner_cpu{Learner::Create({})};
   learner_cpu->LoadModel(model);
-  learner_cpu->SetParams({{"device", cpu_ctx.DeviceName()}});
+  learner_cpu->Configure({{"device", cpu_ctx.DeviceName()}});
   learner_cpu->Configure();
 
   learner_gpu->Predict(dmat, false, &predictions, 0, 0, false, false, true, false, false);

--- a/tests/cpp/predictor/test_shap.cu
+++ b/tests/cpp/predictor/test_shap.cu
@@ -52,12 +52,12 @@ TEST(GPUPredictor, CompareCPUShap) {
 
   std::unique_ptr<Learner> learner_gpu{Learner::Create({})};
   learner_gpu->LoadModel(model);
-  learner_gpu->SetParam("device", ctx.DeviceName());
+  learner_gpu->SetParams({{"device", ctx.DeviceName()}});
   learner_gpu->Configure();
 
   std::unique_ptr<Learner> learner_cpu{Learner::Create({})};
   learner_cpu->LoadModel(model);
-  learner_cpu->SetParam("device", cpu_ctx.DeviceName());
+  learner_cpu->SetParams({{"device", cpu_ctx.DeviceName()}});
   learner_cpu->Configure();
 
   learner_gpu->Predict(dmat, false, &predictions, 0, 0, false, false, true, false, false);

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -46,7 +46,7 @@ TEST(Learner, Basic) {
   auto args = {Arg("tree_method", "exact")};
   auto mat_ptr = RandomDataGenerator{10, 10, 0.0f}.GenerateDMatrix();
   auto learner = std::unique_ptr<Learner>(Learner::Create({mat_ptr}));
-  learner->SetParams(args);
+  learner->Configure(args);
 
   auto major = XGBOOST_VER_MAJOR;
   auto minor = XGBOOST_VER_MINOR;
@@ -57,14 +57,13 @@ TEST(Learner, Basic) {
   static_assert(std::is_integral_v<decltype(patch)>, "Wrong patch version type");
 }
 
-TEST(Learner, SetParamsConfigures) {
+TEST(Learner, ConfigureArguments) {
   auto p_mat = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix();
   auto learner = std::unique_ptr<Learner>{Learner::Create({p_mat})};
 
-  learner->SetParams(
+  learner->Configure(
       {{"objective", "reg:absoluteerror"}, {"eval_metric", "mae"}, {"eval_metric", "rmse"}});
 
-  EXPECT_TRUE(learner->GetConfigurationArguments().empty());
   Json config{Object{}};
   learner->SaveConfig(&config);
   EXPECT_EQ(get<String const>(config["learner"]["objective"]["name"]), "reg:absoluteerror");
@@ -80,7 +79,7 @@ TEST(Learner, ParameterValidation) {
   auto learner = std::unique_ptr<Learner>(Learner::Create({p_mat}));
 
   testing::internal::CaptureStderr();
-  learner->SetParams(Args{{"validate_parameters", "1"},
+  learner->Configure(Args{{"validate_parameters", "1"},
                           {"Knock-Knock", "Who's-there?"},
                           {"Silence", "...."},
                           {"tree_method", "exact"}});
@@ -89,7 +88,7 @@ TEST(Learner, ParameterValidation) {
   ASSERT_TRUE(output.find(R"(Parameters: { "Knock-Knock", "Silence" })") != std::string::npos);
 
   // whitespace
-  ASSERT_THAT([&] { learner->SetParams({{"tree method", "exact"}}); },
+  ASSERT_THAT([&] { learner->Configure({{"tree method", "exact"}}); },
               GMockThrow(R"("tree method" contains whitespace)"));
 }
 
@@ -99,10 +98,8 @@ TEST(Learner, ParameterValidationUsesConsumedParameters) {
     auto learner = std::unique_ptr<Learner>(Learner::Create({p_mat}));
     params.emplace_back("validate_parameters", "1");
     params.emplace_back("verbosity", "1");
-    learner->SetParams(params);
-
     testing::internal::CaptureStderr();
-    learner->Configure();
+    learner->Configure(params);
     return testing::internal::GetCapturedStderr();
   };
 
@@ -135,7 +132,7 @@ TEST(Learner, DeprecatedGblinearBooster) {
   std::unique_ptr<Learner> learner{Learner::Create({p_mat})};
 
   testing::internal::CaptureStderr();
-  learner->SetParams({{"booster", "gblinear"}, {"verbosity", "2"}});
+  learner->Configure({{"booster", "gblinear"}, {"verbosity", "2"}});
   auto output = testing::internal::GetCapturedStderr();
 
   ASSERT_NE(output.find("`booster=gblinear` is deprecated"), std::string::npos);
@@ -165,7 +162,7 @@ TEST(Learner, CheckGroup) {
 
   std::vector<std::shared_ptr<xgboost::DMatrix>> mat = {p_mat};
   auto learner = std::unique_ptr<Learner>(Learner::Create(mat));
-  learner->SetParams({Arg{"objective", "rank:pairwise"}});
+  learner->Configure({Arg{"objective", "rank:pairwise"}});
   EXPECT_NO_THROW(learner->UpdateOneIter(0, p_mat));
 
   group.resize(kNumGroups + 1);
@@ -182,7 +179,7 @@ TEST(Learner, CheckMultiBatch) {
 
   std::vector<std::shared_ptr<DMatrix>> mat{p_fmat};
   auto learner = std::unique_ptr<Learner>(Learner::Create(mat));
-  learner->SetParams(Args{{"objective", "binary:logistic"}});
+  learner->Configure(Args{{"objective", "binary:logistic"}});
   learner->UpdateOneIter(0, p_fmat);
 }
 
@@ -190,13 +187,10 @@ TEST(Learner, Configuration) {
   std::string const emetric = "eval_metric";
   {
     std::unique_ptr<Learner> learner{Learner::Create({nullptr})};
-    learner->SetParams({{"num_feature", "1"}});
-    learner->SetParams({{emetric, "auc"}});
-    learner->SetParams({{emetric, "rmsle"}});
-    learner->SetParams({{"foo", "bar"}});
-
-    auto attr_names = learner->GetConfigurationArguments();
-    ASSERT_TRUE(attr_names.empty());
+    learner->Configure({{"num_feature", "1"}});
+    learner->Configure({{emetric, "auc"}});
+    learner->Configure({{emetric, "rmsle"}});
+    learner->Configure({{"foo", "bar"}});
 
     Json config{Object{}};
     learner->SaveConfig(&config);
@@ -206,9 +200,7 @@ TEST(Learner, Configuration) {
   {
     auto p_mat = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix();
     std::unique_ptr<Learner> learner{Learner::Create({p_mat})};
-    learner->SetParams({{emetric, "auc"}, {emetric, "rmse"}, {emetric, "mae"}});
-    auto attr_names = learner->GetConfigurationArguments();
-    ASSERT_TRUE(attr_names.empty());
+    learner->Configure({{emetric, "auc"}, {emetric, "rmse"}, {emetric, "mae"}});
 
     Json config{Object{}};
     learner->SaveConfig(&config);
@@ -241,8 +233,6 @@ TEST(Learner, JsonModelIO) {
     Json loaded = Json::Load(StringView{loaded_str.data(), loaded_str.size()});
 
     learner->LoadModel(loaded);
-    learner->Configure();
-
     Json new_in{Object()};
     learner->SaveModel(&new_in);
     ASSERT_EQ(new_in, out);
@@ -259,8 +249,7 @@ TEST(Learner, JsonModelIO) {
     learner->SaveModel(&out);
 
     learner->LoadModel(out);
-    Json new_in{Object()};
-    learner->Configure();
+    Json new_in{Object{}};
     learner->SaveModel(&new_in);
 
     ASSERT_TRUE(IsA<Object>(out["learner"]["attributes"]));
@@ -275,15 +264,17 @@ TEST(Learner, ConfigIO) {
   std::shared_ptr<DMatrix> p_fmat{
       RandomDataGenerator{n_samples, n_features, 0}.Classes(2).GenerateDMatrix(true)};
 
+  Json config{Object{}};
   auto serialised_model_tmp = std::string{};
   std::string eval_res_0;
   std::string eval_res_1;
   {
     std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
-    learner->SetParams(Args{{"eval_metric", "ndcg"}, {"eval_metric", "map"}});
+    learner->Configure(Args{{"eval_metric", "ndcg"}, {"eval_metric", "map"}});
     learner->Configure();
     learner->UpdateOneIter(0, p_fmat);
     eval_res_0 = learner->EvalOneIter(0, {p_fmat}, {"Train"});
+    learner->SaveConfig(&config);
     common::MemoryBufferStream fo(&serialised_model_tmp);
     learner->Save(&fo);
   }
@@ -295,6 +286,15 @@ TEST(Learner, ConfigIO) {
     eval_res_1 = learner->EvalOneIter(0, {p_fmat}, {"Train"});
   }
   ASSERT_EQ(eval_res_0, eval_res_1);
+
+  {
+    std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
+    learner->LoadConfig(config);
+
+    Json loaded{Object{}};
+    learner->SaveConfig(&loaded);
+    ASSERT_EQ(get<Array const>(loaded["learner"]["metrics"]).size(), 2);
+  }
 }
 
 // Crashes the test runner if there are race condiditions.
@@ -362,14 +362,14 @@ TEST(Learner, GPUConfiguration) {
   p_dmat->Info().labels.Reshape(kRows);
   {
     std::unique_ptr<Learner> learner{Learner::Create(mat)};
-    learner->SetParams(
+    learner->Configure(
         {Arg{"booster", "gblinear"}, Arg{"updater", "coord_descent"}, Arg{"device", "cuda"}});
     learner->UpdateOneIter(0, p_dmat);
     ASSERT_EQ(learner->Ctx()->Device(), DeviceOrd::CUDA(0));
   }
   {
     std::unique_ptr<Learner> learner{Learner::Create(mat)};
-    learner->SetParams({Arg{"tree_method", "hist"}, {"device", "cuda"}});
+    learner->Configure({Arg{"tree_method", "hist"}, {"device", "cuda"}});
     learner->Configure();
     ASSERT_EQ(learner->Ctx()->Device(), DeviceOrd::CUDA(0));
     learner->UpdateOneIter(0, p_dmat);
@@ -377,14 +377,14 @@ TEST(Learner, GPUConfiguration) {
   }
   {
     std::unique_ptr<Learner> learner{Learner::Create(mat)};
-    learner->SetParams({Arg{"tree_method", "hist"}, Arg{"device", "cuda"}});
+    learner->Configure({Arg{"tree_method", "hist"}, Arg{"device", "cuda"}});
     learner->UpdateOneIter(0, p_dmat);
     ASSERT_EQ(learner->Ctx()->Device(), DeviceOrd::CUDA(0));
   }
   {
     // with CPU algorithm
     std::unique_ptr<Learner> learner{Learner::Create(mat)};
-    learner->SetParams({Arg{"tree_method", "hist"}});
+    learner->Configure({Arg{"tree_method", "hist"}});
     learner->UpdateOneIter(0, p_dmat);
     ASSERT_EQ(learner->Ctx()->Device(), DeviceOrd::CPU());
   }
@@ -395,14 +395,14 @@ TEST(Learner, Seed) {
   auto m = RandomDataGenerator{10, 10, 0}.GenerateDMatrix();
   std::unique_ptr<Learner> learner{Learner::Create({m})};
   auto seed = std::numeric_limits<int64_t>::max();
-  learner->SetParams({{"seed", std::to_string(seed)}});
+  learner->Configure({{"seed", std::to_string(seed)}});
   learner->Configure();
   Json config{Object()};
   learner->SaveConfig(&config);
   ASSERT_EQ(std::to_string(seed), get<String>(config["learner"]["generic_param"]["seed"]));
 
   seed = std::numeric_limits<int64_t>::min();
-  learner->SetParams({{"seed", std::to_string(seed)}});
+  learner->Configure({{"seed", std::to_string(seed)}});
   learner->Configure();
   learner->SaveConfig(&config);
   ASSERT_EQ(std::to_string(seed), get<String>(config["learner"]["generic_param"]["seed"]));
@@ -412,14 +412,14 @@ TEST(Learner, ConstantSeed) {
   auto m = RandomDataGenerator{10, 10, 0}.GenerateDMatrix(true);
   std::unique_ptr<Learner> learner{Learner::Create({m})};
   // Use exact as it doesn't initialize column sampler at construction, which alters the rng.
-  learner->SetParams({{"tree_method", "exact"}});
+  learner->Configure({{"tree_method", "exact"}});
   learner->Configure();
 
   std::uniform_real_distribution<float> dist;
   auto& rng = learner->Ctx()->Rng();
   float v_0 = dist(rng);
 
-  learner->SetParams({{"", ""}});
+  learner->Configure({{"", ""}});
   learner->Configure();  // check configure doesn't change the seed.
   float v_1 = dist(rng);
   CHECK_NE(v_0, v_1);
@@ -507,7 +507,7 @@ TEST(Learner, MultiTarget) {
   {
     std::unique_ptr<Learner> learner{Learner::Create({m})};
     // unsupported objective.
-    EXPECT_THROW({ learner->SetParams({{"objective", "multi:softprob"}}); }, dmlc::Error);
+    EXPECT_THROW({ learner->Configure({{"objective", "multi:softprob"}}); }, dmlc::Error);
   }
 }
 
@@ -524,7 +524,7 @@ class InitBaseScore : public ::testing::Test {
  public:
   void TestUpdateConfig() {
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParams({{"objective", "reg:absoluteerror"}});
+    learner->Configure({{"objective", "reg:absoluteerror"}});
     learner->UpdateOneIter(0, Xy_);
     Json config{Object{}};
     learner->SaveConfig(&config);
@@ -552,8 +552,8 @@ class InitBaseScore : public ::testing::Test {
 
   void TestBoostFromAvgParam() {
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParams({{"objective", "reg:absoluteerror"}});
-    learner->SetParams({{"base_score", "1.3"}});
+    learner->Configure({{"objective", "reg:absoluteerror"}});
+    learner->Configure({{"base_score", "1.3"}});
     Json config(Object{});
     learner->Configure();
     learner->SaveConfig(&config);
@@ -581,7 +581,7 @@ class InitBaseScore : public ::testing::Test {
     // from_avg is disabled when base score is set
     ASSERT_EQ(from_avg, 0);
     // in the future when we can deprecate the binary model, user can set the parameter directly.
-    learner->SetParams({{"boost_from_average", "1"}});
+    learner->Configure({{"boost_from_average", "1"}});
     learner->Configure();
     learner->SaveConfig(&config);
     from_avg = std::stoi(
@@ -591,7 +591,7 @@ class InitBaseScore : public ::testing::Test {
 
   void TestInitAfterLoad() {
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParams({{"objective", "reg:absoluteerror"}});
+    learner->Configure({{"objective", "reg:absoluteerror"}});
     learner->Configure();
 
     Json model{Object{}};
@@ -619,7 +619,7 @@ class InitBaseScore : public ::testing::Test {
 
   void TestInitWithPredt() {
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParams({{"objective", "reg:absoluteerror"}});
+    learner->Configure({{"objective", "reg:absoluteerror"}});
     HostDeviceVector<float> predt;
     learner->Predict(Xy_, false, &predt, 0, 0);
 
@@ -647,7 +647,7 @@ class InitBaseScore : public ::testing::Test {
     // Check that when training continuation is performed with update, the base score is
     // not re-evaluated.
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParams({{"objective", "reg:absoluteerror"}});
+    learner->Configure({{"objective", "reg:absoluteerror"}});
     learner->Configure();
 
     learner->UpdateOneIter(0, Xy_);
@@ -660,8 +660,8 @@ class InitBaseScore : public ::testing::Test {
     auto Xy1 = RandomDataGenerator{100, Cols(), 0}.Seed(321).GenerateDMatrix(true);
     learner.reset(Learner::Create({Xy1}));
     learner->LoadModel(model);
-    learner->SetParams({{"process_type", "update"}});
-    learner->SetParams({{"updater", "refresh"}});
+    learner->Configure({{"process_type", "update"}});
+    learner->Configure({{"updater", "refresh"}});
     learner->UpdateOneIter(1, Xy1);
 
     Json config(Object{});

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -57,6 +57,20 @@ TEST(Learner, Basic) {
   static_assert(std::is_integral_v<decltype(patch)>, "Wrong patch version type");
 }
 
+TEST(Learner, SetParamsConfigures) {
+  auto p_mat = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix();
+  auto learner = std::unique_ptr<Learner>{Learner::Create({p_mat})};
+
+  learner->SetParams(
+      {{"objective", "reg:absoluteerror"}, {"eval_metric", "mae"}, {"eval_metric", "rmse"}});
+
+  EXPECT_TRUE(learner->GetConfigurationArguments().empty());
+  Json config{Object{}};
+  learner->SaveConfig(&config);
+  EXPECT_EQ(get<String const>(config["learner"]["objective"]["name"]), "reg:absoluteerror");
+  EXPECT_EQ(get<Array const>(config["learner"]["metrics"]).size(), 2);
+}
+
 TEST(Learner, ParameterValidation) {
   ConsoleLogger::Configure({{"verbosity", "2"}});
   size_t constexpr kRows = 1;
@@ -64,20 +78,19 @@ TEST(Learner, ParameterValidation) {
   auto p_mat = RandomDataGenerator{kRows, kCols, 0}.GenerateDMatrix();
 
   auto learner = std::unique_ptr<Learner>(Learner::Create({p_mat}));
-  learner->SetParam("validate_parameters", "1");
-  learner->SetParam("Knock-Knock", "Who's-there?");
-  learner->SetParam("Silence", "....");
-  learner->SetParam("tree_method", "exact");
 
   testing::internal::CaptureStderr();
-  learner->Configure();
+  learner->SetParams(Args{{"validate_parameters", "1"},
+                          {"Knock-Knock", "Who's-there?"},
+                          {"Silence", "...."},
+                          {"tree_method", "exact"}});
   std::string output = testing::internal::GetCapturedStderr();
 
   ASSERT_TRUE(output.find(R"(Parameters: { "Knock-Knock", "Silence" })") != std::string::npos);
 
   // whitespace
-  learner->SetParam("tree method", "exact");
-  ASSERT_THAT([&] { learner->Configure(); }, GMockThrow(R"("tree method" contains whitespace)"));
+  ASSERT_THAT([&] { learner->SetParams({{"tree method", "exact"}}); },
+              GMockThrow(R"("tree method" contains whitespace)"));
 }
 
 TEST(Learner, ParameterValidationUsesConsumedParameters) {
@@ -120,11 +133,9 @@ TEST(Learner, DeprecatedGblinearBooster) {
   auto p_mat = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix();
 
   std::unique_ptr<Learner> learner{Learner::Create({p_mat})};
-  learner->SetParam("booster", "gblinear");
-  learner->SetParam("verbosity", "2");
 
   testing::internal::CaptureStderr();
-  learner->Configure();
+  learner->SetParams({{"booster", "gblinear"}, {"verbosity", "2"}});
   auto output = testing::internal::GetCapturedStderr();
 
   ASSERT_NE(output.find("`booster=gblinear` is deprecated"), std::string::npos);
@@ -179,23 +190,29 @@ TEST(Learner, Configuration) {
   std::string const emetric = "eval_metric";
   {
     std::unique_ptr<Learner> learner{Learner::Create({nullptr})};
-    learner->SetParam(emetric, "auc");
-    learner->SetParam(emetric, "rmsle");
-    learner->SetParam("foo", "bar");
+    learner->SetParams({{"num_feature", "1"}});
+    learner->SetParams({{emetric, "auc"}});
+    learner->SetParams({{emetric, "rmsle"}});
+    learner->SetParams({{"foo", "bar"}});
 
-    // eval_metric is not part of configuration
     auto attr_names = learner->GetConfigurationArguments();
-    ASSERT_EQ(attr_names.size(), 1ul);
-    ASSERT_EQ(attr_names.find(emetric), attr_names.cend());
-    ASSERT_EQ(attr_names.at("foo"), "bar");
+    ASSERT_TRUE(attr_names.empty());
+
+    Json config{Object{}};
+    learner->SaveConfig(&config);
+    ASSERT_EQ(get<Array const>(config["learner"]["metrics"]).size(), 2);
   }
 
   {
-    std::unique_ptr<Learner> learner{Learner::Create({nullptr})};
-    learner->SetParams({{"foo", "bar"}, {emetric, "auc"}, {emetric, "entropy"}, {emetric, "KL"}});
+    auto p_mat = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix();
+    std::unique_ptr<Learner> learner{Learner::Create({p_mat})};
+    learner->SetParams({{emetric, "auc"}, {emetric, "rmse"}, {emetric, "mae"}});
     auto attr_names = learner->GetConfigurationArguments();
-    ASSERT_EQ(attr_names.size(), 1ul);
-    ASSERT_EQ(attr_names.at("foo"), "bar");
+    ASSERT_TRUE(attr_names.empty());
+
+    Json config{Object{}};
+    learner->SaveConfig(&config);
+    ASSERT_EQ(get<Array const>(config["learner"]["metrics"]).size(), 3);
   }
 }
 
@@ -378,14 +395,14 @@ TEST(Learner, Seed) {
   auto m = RandomDataGenerator{10, 10, 0}.GenerateDMatrix();
   std::unique_ptr<Learner> learner{Learner::Create({m})};
   auto seed = std::numeric_limits<int64_t>::max();
-  learner->SetParam("seed", std::to_string(seed));
+  learner->SetParams({{"seed", std::to_string(seed)}});
   learner->Configure();
   Json config{Object()};
   learner->SaveConfig(&config);
   ASSERT_EQ(std::to_string(seed), get<String>(config["learner"]["generic_param"]["seed"]));
 
   seed = std::numeric_limits<int64_t>::min();
-  learner->SetParam("seed", std::to_string(seed));
+  learner->SetParams({{"seed", std::to_string(seed)}});
   learner->Configure();
   learner->SaveConfig(&config);
   ASSERT_EQ(std::to_string(seed), get<String>(config["learner"]["generic_param"]["seed"]));
@@ -395,14 +412,14 @@ TEST(Learner, ConstantSeed) {
   auto m = RandomDataGenerator{10, 10, 0}.GenerateDMatrix(true);
   std::unique_ptr<Learner> learner{Learner::Create({m})};
   // Use exact as it doesn't initialize column sampler at construction, which alters the rng.
-  learner->SetParam("tree_method", "exact");
+  learner->SetParams({{"tree_method", "exact"}});
   learner->Configure();
 
   std::uniform_real_distribution<float> dist;
   auto& rng = learner->Ctx()->Rng();
   float v_0 = dist(rng);
 
-  learner->SetParam("", "");
+  learner->SetParams({{"", ""}});
   learner->Configure();  // check configure doesn't change the seed.
   float v_1 = dist(rng);
   CHECK_NE(v_0, v_1);
@@ -489,9 +506,8 @@ TEST(Learner, MultiTarget) {
   }
   {
     std::unique_ptr<Learner> learner{Learner::Create({m})};
-    learner->SetParam("objective", "multi:softprob");
     // unsupported objective.
-    EXPECT_THROW({ learner->Configure(); }, dmlc::Error);
+    EXPECT_THROW({ learner->SetParams({{"objective", "multi:softprob"}}); }, dmlc::Error);
   }
 }
 
@@ -508,7 +524,7 @@ class InitBaseScore : public ::testing::Test {
  public:
   void TestUpdateConfig() {
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParam("objective", "reg:absoluteerror");
+    learner->SetParams({{"objective", "reg:absoluteerror"}});
     learner->UpdateOneIter(0, Xy_);
     Json config{Object{}};
     learner->SaveConfig(&config);
@@ -536,8 +552,8 @@ class InitBaseScore : public ::testing::Test {
 
   void TestBoostFromAvgParam() {
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParam("objective", "reg:absoluteerror");
-    learner->SetParam("base_score", "1.3");
+    learner->SetParams({{"objective", "reg:absoluteerror"}});
+    learner->SetParams({{"base_score", "1.3"}});
     Json config(Object{});
     learner->Configure();
     learner->SaveConfig(&config);
@@ -565,7 +581,7 @@ class InitBaseScore : public ::testing::Test {
     // from_avg is disabled when base score is set
     ASSERT_EQ(from_avg, 0);
     // in the future when we can deprecate the binary model, user can set the parameter directly.
-    learner->SetParam("boost_from_average", "1");
+    learner->SetParams({{"boost_from_average", "1"}});
     learner->Configure();
     learner->SaveConfig(&config);
     from_avg = std::stoi(
@@ -575,7 +591,7 @@ class InitBaseScore : public ::testing::Test {
 
   void TestInitAfterLoad() {
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParam("objective", "reg:absoluteerror");
+    learner->SetParams({{"objective", "reg:absoluteerror"}});
     learner->Configure();
 
     Json model{Object{}};
@@ -603,7 +619,7 @@ class InitBaseScore : public ::testing::Test {
 
   void TestInitWithPredt() {
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParam("objective", "reg:absoluteerror");
+    learner->SetParams({{"objective", "reg:absoluteerror"}});
     HostDeviceVector<float> predt;
     learner->Predict(Xy_, false, &predt, 0, 0);
 
@@ -631,7 +647,7 @@ class InitBaseScore : public ::testing::Test {
     // Check that when training continuation is performed with update, the base score is
     // not re-evaluated.
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParam("objective", "reg:absoluteerror");
+    learner->SetParams({{"objective", "reg:absoluteerror"}});
     learner->Configure();
 
     learner->UpdateOneIter(0, Xy_);
@@ -644,8 +660,8 @@ class InitBaseScore : public ::testing::Test {
     auto Xy1 = RandomDataGenerator{100, Cols(), 0}.Seed(321).GenerateDMatrix(true);
     learner.reset(Learner::Create({Xy1}));
     learner->LoadModel(model);
-    learner->SetParam("process_type", "update");
-    learner->SetParam("updater", "refresh");
+    learner->SetParams({{"process_type", "update"}});
+    learner->SetParams({{"updater", "refresh"}});
     learner->UpdateOneIter(1, Xy1);
 
     Json config(Object{});

--- a/tests/cpp/test_learner.cu
+++ b/tests/cpp/test_learner.cu
@@ -20,7 +20,7 @@ TEST(Learner, Reset) {
   ConsoleLogger::Configure({{"verbosity", "3"}});
   auto p_fmat = RandomDataGenerator{1024, 32, 0.0}.GenerateDMatrix(true);
   std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
-  learner->SetParams({{"device", DeviceSym::CUDA()}});
+  learner->Configure({{"device", DeviceSym::CUDA()}});
   learner->Configure();
   for (std::int32_t i = 0; i < 2; ++i) {
     learner->UpdateOneIter(i, p_fmat);

--- a/tests/cpp/test_learner.cu
+++ b/tests/cpp/test_learner.cu
@@ -20,7 +20,7 @@ TEST(Learner, Reset) {
   ConsoleLogger::Configure({{"verbosity", "3"}});
   auto p_fmat = RandomDataGenerator{1024, 32, 0.0}.GenerateDMatrix(true);
   std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
-  learner->SetParam("device", DeviceSym::CUDA());
+  learner->SetParams({{"device", DeviceSym::CUDA()}});
   learner->Configure();
   for (std::int32_t i = 0; i < 2; ++i) {
     learner->UpdateOneIter(i, p_fmat);

--- a/tests/cpp/test_multi_target.cc
+++ b/tests/cpp/test_multi_target.cc
@@ -131,10 +131,10 @@ TEST(MultiStrategy, Configure) {
   p_fmat->Info().labels.Reshape(p_fmat->Info().num_row_, 2);
   std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
   learner->SetParams(Args{{"multi_strategy", "multi_output_tree"}, {"num_target", "2"}});
-  learner->Configure();
   ASSERT_EQ(learner->Groups(), 2);
 
-  learner->SetParams(Args{{"multi_strategy", "multi_output_tree"}, {"num_target", "0"}});
-  ASSERT_THROW({ learner->Configure(); }, dmlc::Error);
+  ASSERT_THROW(
+      learner->SetParams(Args{{"multi_strategy", "multi_output_tree"}, {"num_target", "0"}}),
+      dmlc::Error);
 }
 }  // namespace xgboost

--- a/tests/cpp/test_multi_target.cc
+++ b/tests/cpp/test_multi_target.cc
@@ -67,7 +67,7 @@ class TestL1MultiTarget : public ::testing::Test {
   void RunTest(Context const* ctx, std::string const& tree_method, bool weight) {
     auto p_fmat = weight ? Xyw_ : Xy_;
     std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
-    learner->SetParams(Args{{"tree_method", tree_method},
+    learner->Configure(Args{{"tree_method", tree_method},
                             {"objective", "reg:absoluteerror"},
                             {"device", ctx->DeviceName()}});
     learner->Configure();
@@ -84,7 +84,7 @@ class TestL1MultiTarget : public ::testing::Test {
     for (bst_target_t t{0}; t < p_fmat->Info().labels.Shape(1); ++t) {
       auto t_Xy = weight ? single_w_[t] : single_[t];
       std::unique_ptr<Learner> sl{Learner::Create({t_Xy})};
-      sl->SetParams(Args{{"tree_method", tree_method},
+      sl->Configure(Args{{"tree_method", tree_method},
                          {"objective", "reg:absoluteerror"},
                          {"device", ctx->DeviceName()}});
       sl->Configure();
@@ -130,11 +130,11 @@ TEST(MultiStrategy, Configure) {
   auto p_fmat = RandomDataGenerator{12ul, 3ul, 0.0}.GenerateDMatrix();
   p_fmat->Info().labels.Reshape(p_fmat->Info().num_row_, 2);
   std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
-  learner->SetParams(Args{{"multi_strategy", "multi_output_tree"}, {"num_target", "2"}});
+  learner->Configure(Args{{"multi_strategy", "multi_output_tree"}, {"num_target", "2"}});
   ASSERT_EQ(learner->Groups(), 2);
 
   ASSERT_THROW(
-      learner->SetParams(Args{{"multi_strategy", "multi_output_tree"}, {"num_target", "0"}}),
+      learner->Configure(Args{{"multi_strategy", "multi_output_tree"}, {"num_target", "0"}}),
       dmlc::Error);
 }
 }  // namespace xgboost

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -165,7 +165,7 @@ void TestLearnerSerialization(Args args, FeatureMap const& fmap, std::shared_ptr
   {
     std::unique_ptr<dmlc::Stream> fo(dmlc::Stream::Create(fname.c_str(), "w"));
     std::unique_ptr<Learner> learner{Learner::Create({p_dmat})};
-    learner->SetParams(args);
+    learner->Configure(args);
     for (int32_t iter = 0; iter < kIters; ++iter) {
       learner->UpdateOneIter(iter, p_dmat);
     }
@@ -197,8 +197,6 @@ void TestLearnerSerialization(Args args, FeatureMap const& fmap, std::shared_ptr
       std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(fname.c_str(), "r"));
       std::unique_ptr<Learner> learner{Learner::Create({p_dmat})};
       learner->Load(fi.get());
-      learner->Configure();
-
       // verify the loaded model doesn't change.
       std::string serialised_model_tmp;
       common::MemoryBufferStream mem_out(&serialised_model_tmp);
@@ -220,7 +218,7 @@ void TestLearnerSerialization(Args args, FeatureMap const& fmap, std::shared_ptr
     {
       // Train 2 * kIters in one go
       std::unique_ptr<Learner> learner{Learner::Create({p_dmat})};
-      learner->SetParams(args);
+      learner->Configure(args);
       for (int32_t iter = 0; iter < 2 * kIters; ++iter) {
         learner->UpdateOneIter(iter, p_dmat);
 
@@ -260,7 +258,7 @@ void TestLearnerSerialization(Args args, FeatureMap const& fmap, std::shared_ptr
     // Set the model to device
     for (auto const& [key, value] : args) {
       if (key == "device") {
-        learner->SetParams({{key, value}});
+        learner->Configure({{key, value}});
       }
     }
 
@@ -443,7 +441,7 @@ TEST_F(SerializationTest, ConfigurationCount) {
   {
     auto learner = std::unique_ptr<Learner>(Learner::Create(mat));
 
-    learner->SetParams(Args{{"tree_method", "hist"}, {"device", "cuda"}});
+    learner->Configure(Args{{"tree_method", "hist"}, {"device", "cuda"}});
 
     for (size_t i = 0; i < 10; ++i) {
       learner->UpdateOneIter(i, p_dmat);

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -260,7 +260,7 @@ void TestLearnerSerialization(Args args, FeatureMap const& fmap, std::shared_ptr
     // Set the model to device
     for (auto const& [key, value] : args) {
       if (key == "device") {
-        learner->SetParam(key, value);
+        learner->SetParams({{key, value}});
       }
     }
 

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -215,7 +215,7 @@ TEST(GpuHist, MaxDepth) {
   auto p_mat = RandomDataGenerator{kRows, kCols, 0}.GenerateDMatrix();
 
   auto learner = std::unique_ptr<Learner>(Learner::Create({p_mat}));
-  learner->SetParams({{"max_depth", "32"}});
+  learner->Configure({{"max_depth", "32"}});
   learner->Configure();
 
   ASSERT_THROW({ learner->UpdateOneIter(0, p_mat); }, dmlc::Error);

--- a/tests/cpp/tree/test_gpu_hist.cu
+++ b/tests/cpp/tree/test_gpu_hist.cu
@@ -215,7 +215,7 @@ TEST(GpuHist, MaxDepth) {
   auto p_mat = RandomDataGenerator{kRows, kCols, 0}.GenerateDMatrix();
 
   auto learner = std::unique_ptr<Learner>(Learner::Create({p_mat}));
-  learner->SetParam("max_depth", "32");
+  learner->SetParams({{"max_depth", "32"}});
   learner->Configure();
 
   ASSERT_THROW({ learner->UpdateOneIter(0, p_mat); }, dmlc::Error);

--- a/tests/cpp/tree/test_prediction_cache.h
+++ b/tests/cpp/tree/test_prediction_cache.h
@@ -30,12 +30,12 @@ class TestPredictionCache : public ::testing::Test {
   void RunLearnerTest(Context const* ctx, std::string updater_name, float subsample,
                       std::string const& grow_policy, std::string const& strategy) {
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParam("device", ctx->DeviceName());
-    learner->SetParam("updater", updater_name);
-    learner->SetParam("multi_strategy", strategy);
-    learner->SetParam("grow_policy", grow_policy);
-    learner->SetParam("subsample", std::to_string(subsample));
-    learner->SetParam("nthread", "0");
+    learner->SetParams({{"device", ctx->DeviceName()}});
+    learner->SetParams({{"updater", updater_name}});
+    learner->SetParams({{"multi_strategy", strategy}});
+    learner->SetParams({{"grow_policy", grow_policy}});
+    learner->SetParams({{"subsample", std::to_string(subsample)}});
+    learner->SetParams({{"nthread", "0"}});
     learner->Configure();
 
     for (size_t i = 0; i < 8; ++i) {

--- a/tests/cpp/tree/test_prediction_cache.h
+++ b/tests/cpp/tree/test_prediction_cache.h
@@ -30,12 +30,12 @@ class TestPredictionCache : public ::testing::Test {
   void RunLearnerTest(Context const* ctx, std::string updater_name, float subsample,
                       std::string const& grow_policy, std::string const& strategy) {
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
-    learner->SetParams({{"device", ctx->DeviceName()}});
-    learner->SetParams({{"updater", updater_name}});
-    learner->SetParams({{"multi_strategy", strategy}});
-    learner->SetParams({{"grow_policy", grow_policy}});
-    learner->SetParams({{"subsample", std::to_string(subsample)}});
-    learner->SetParams({{"nthread", "0"}});
+    learner->Configure({{"device", ctx->DeviceName()}});
+    learner->Configure({{"updater", updater_name}});
+    learner->Configure({{"multi_strategy", strategy}});
+    learner->Configure({{"grow_policy", grow_policy}});
+    learner->Configure({{"subsample", std::to_string(subsample)}});
+    learner->Configure({{"nthread", "0"}});
     learner->Configure();
 
     for (size_t i = 0; i < 8; ++i) {

--- a/tests/cpp/tree/test_regen.cc
+++ b/tests/cpp/tree/test_regen.cc
@@ -65,9 +65,9 @@ class RegenTest : public ::testing::Test {
   size_t TestTreeMethod(Context const* ctx, std::string tree_method, std::string obj,
                         bool reset = true) const {
     auto learner = std::unique_ptr<Learner>{Learner::Create({p_fmat_})};
-    learner->SetParam("device", ctx->DeviceName());
-    learner->SetParam("tree_method", tree_method);
-    learner->SetParam("objective", obj);
+    learner->SetParams({{"device", ctx->DeviceName()}});
+    learner->SetParams({{"tree_method", tree_method}});
+    learner->SetParams({{"objective", obj}});
     learner->Configure();
 
     for (auto i = 0; i < Iter(); ++i) {

--- a/tests/cpp/tree/test_regen.cc
+++ b/tests/cpp/tree/test_regen.cc
@@ -65,9 +65,9 @@ class RegenTest : public ::testing::Test {
   size_t TestTreeMethod(Context const* ctx, std::string tree_method, std::string obj,
                         bool reset = true) const {
     auto learner = std::unique_ptr<Learner>{Learner::Create({p_fmat_})};
-    learner->SetParams({{"device", ctx->DeviceName()}});
-    learner->SetParams({{"tree_method", tree_method}});
-    learner->SetParams({{"objective", obj}});
+    learner->Configure({{"device", ctx->DeviceName()}});
+    learner->Configure({{"tree_method", tree_method}});
+    learner->Configure({{"objective", obj}});
     learner->Configure();
 
     for (auto i = 0; i < Iter(); ++i) {

--- a/tests/cpp/tree/test_tree_policy.cc
+++ b/tests/cpp/tree/test_tree_policy.cc
@@ -27,17 +27,17 @@ class TestGrowPolicy : public ::testing::Test {
             true);
 
     std::unique_ptr<Learner> learner{Learner::Create({Xy})};
-    learner->SetParams({{"tree_method", tree_method}});
-    learner->SetParams({{"device", ctx->DeviceName()}});
+    learner->Configure({{"tree_method", tree_method}});
+    learner->Configure({{"device", ctx->DeviceName()}});
     if (max_leaves >= 0) {
-      learner->SetParams({{"max_leaves", std::to_string(max_leaves)}});
+      learner->Configure({{"max_leaves", std::to_string(max_leaves)}});
     }
     if (max_depth >= 0) {
-      learner->SetParams({{"max_depth", std::to_string(max_depth)}});
+      learner->Configure({{"max_depth", std::to_string(max_depth)}});
     }
-    learner->SetParams({{"grow_policy", policy}});
+    learner->Configure({{"grow_policy", policy}});
     if (n_targets > 1) {
-      learner->SetParams({{"multi_strategy", "multi_output_tree"}});
+      learner->Configure({{"multi_strategy", "multi_output_tree"}});
     }
 
     auto check_max_leave = [&]() {

--- a/tests/cpp/tree/test_tree_policy.cc
+++ b/tests/cpp/tree/test_tree_policy.cc
@@ -27,17 +27,17 @@ class TestGrowPolicy : public ::testing::Test {
             true);
 
     std::unique_ptr<Learner> learner{Learner::Create({Xy})};
-    learner->SetParam("tree_method", tree_method);
-    learner->SetParam("device", ctx->DeviceName());
+    learner->SetParams({{"tree_method", tree_method}});
+    learner->SetParams({{"device", ctx->DeviceName()}});
     if (max_leaves >= 0) {
-      learner->SetParam("max_leaves", std::to_string(max_leaves));
+      learner->SetParams({{"max_leaves", std::to_string(max_leaves)}});
     }
     if (max_depth >= 0) {
-      learner->SetParam("max_depth", std::to_string(max_depth));
+      learner->SetParams({{"max_depth", std::to_string(max_depth)}});
     }
-    learner->SetParam("grow_policy", policy);
+    learner->SetParams({{"grow_policy", policy}});
     if (n_targets > 1) {
-      learner->SetParam("multi_strategy", "multi_output_tree");
+      learner->SetParams({{"multi_strategy", "multi_output_tree"}});
     }
 
     auto check_max_leave = [&]() {

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -169,6 +169,17 @@ class TestModels:
         assert len(evals_result["eval"]) == 3
         assert set(evals_result["eval"].keys()) == {"auc", "error", "logloss"}
 
+    def test_set_param_batch(self) -> None:
+        dtrain, _ = tm.load_agaricus(__file__)
+        booster = xgb.Booster(cache=[dtrain])
+
+        booster.set_param([("eval_metric", "mae"), ("eval_metric", "rmse")])
+        config = json.loads(booster.save_config())
+        assert len(config["learner"]["metrics"]) == 2
+
+        with pytest.raises(xgb.core.XGBoostError, match="Invalid Input"):
+            booster.set_param({"tree_method": "prune", "process_type": "default"})
+
     def test_fpreproc(self):
         param = {"max_depth": 2, "eta": 1, "objective": "binary:logistic"}
         num_round = 2


### PR DESCRIPTION
## Summary

- add `XGBoosterSetParams`, accepting an ordered parameter batch, and have `XGBoosterSetParam` delegate to it
- update the Python bindings to submit constructor and update parameters as batches
- pass each batch directly to `Learner::Configure` and remove the persistent `cfg_` parameter mailbox
- configure public model/config loads before returning, while configuring snapshots once after loading both sections

## Why

Learner parameters were previously accumulated in `cfg_` and consumed by a later `Configure()` call. This made parameter application an implicit, delayed lifecycle: callers could write parameters without knowing when the learner became consistently configured.

This change makes the transaction boundary explicit. A binding submits one ordered parameter batch, and `Configure(args)` applies it before returning. Repeated parameters such as `eval_metric` remain supported, while no pending parameter arguments survive the call.

The existing configuration failure semantics are unchanged; this PR does not attempt to make component updates rollback-able after an exception.

## Validation

- scoped pre-commit checks
- full CPU C++ test suite: 746 passed
- focused C++ configuration, C API, model I/O, and serialization tests: 12 passed
- Python model I/O and basic model tests: 24 passed, 1 skipped
- `git diff --check`
