### PR TITLE
[JVM] Drop support for glibc 2.17.

### DIFF
--- a/.github/workflows/jvm_tests.yml
+++ b/.github/workflows/jvm_tests.yml
@@ -25,15 +25,15 @@ jobs:
     with:
       tag-prefix: jvm-tests
 
-  build-jvm-manylinux2014:
+  build-jvm-manylinux:
     name: >-
-      Build libxgboost4j.so targeting glibc 2.17
+      Build libxgboost4j.so targeting glibc 2.28
       (arch ${{ matrix.arch }}, runner ${{ matrix.runner }})
     runs-on:
       - runs-on
       - runner=${{ matrix.runner }}
       - run-id=${{ github.run_id }}
-      - tag=jvm-tests-build-jvm-manylinux2014-${{ matrix.arch }}
+      - tag=jvm-tests-build-jvm-manylinux-${{ matrix.arch }}
     strategy:
       fail-fast: false
       matrix:
@@ -48,7 +48,15 @@ jobs:
           submodules: "true"
       - name: Log into Docker registry (AWS ECR)
         run: bash ops/pipeline/login-docker-registry.sh
-      - run: bash ops/pipeline/build-jvm-manylinux2014.sh ${{ matrix.arch }}
+      - run: bash ops/pipeline/build-jvm-manylinux.sh ${{ matrix.arch }}
+      - name: Stash x86_64 library
+        if: matrix.arch == 'x86_64'
+        run: |
+          sha256sum lib/libxgboost4j.so
+          python3 ops/pipeline/manage-artifacts.py upload \
+            --s3-bucket ${{ env.RUNS_ON_S3_BUCKET_CACHE }} \
+            --prefix cache/${{ github.run_id }}/build-jvm-manylinux-x86_64 \
+            lib/libxgboost4j.so
 
   build-jvm-gpu:
     name: Build libxgboost4j.so with CUDA
@@ -115,7 +123,7 @@ jobs:
 
   build-test-jvm-packages-linux:
     name: Build and test JVM packages (Linux, Scala ${{ matrix.scala_version }})
-    needs: ci-configure
+    needs: [ci-configure, build-jvm-manylinux]
     runs-on:
       - runs-on=${{ github.run_id }}
       - runner=linux-amd64-cpu
@@ -131,13 +139,25 @@ jobs:
         password: ${{ needs.ci-configure.outputs.docker_password }}
     env:
       SCALA_VERSION: ${{ matrix.scala_version }}
+      SKIP_NATIVE_BUILD: "1"
     steps:
       - uses: runs-on/action@v2
       - uses: actions/checkout@v7.0.1
         with:
           submodules: "true"
+      - name: Unstash x86_64 library
+        run: |
+          python3 ops/pipeline/manage-artifacts.py download \
+            --s3-bucket ${{ env.RUNS_ON_S3_BUCKET_CACHE }} \
+            --prefix cache/${{ github.run_id }}/build-jvm-manylinux-x86_64 \
+            --dest-dir lib \
+            libxgboost4j.so
+          sha256sum lib/libxgboost4j.so
       - name: Build and test JVM packages (Scala ${{ matrix.scala_version }})
-        run: bash ops/pipeline/build-test-jvm-packages.sh
+        run: |
+          sha256sum lib/libxgboost4j.so > /tmp/libxgboost4j.sha256
+          bash ops/pipeline/build-test-jvm-packages.sh
+          sha256sum --check /tmp/libxgboost4j.sha256
       - name: Stash files
         run: |
           python3 ops/pipeline/manage-artifacts.py upload \
@@ -265,6 +285,7 @@ jobs:
             --dest-dir lib \
             libxgboost4j.so
           ls -lh lib/libxgboost4j.so
+          sha256sum lib/libxgboost4j.so
       - name: Deploy JVM packages to S3
         run: bash ops/pipeline/deploy-jvm-packages.sh ${{ matrix.variant.name }} ${{ matrix.scala_version }}
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release_')

--- a/.github/workflows/jvm_tests.yml
+++ b/.github/workflows/jvm_tests.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Stash x86_64 library
         if: matrix.arch == 'x86_64'
         run: |
-          sha256sum lib/libxgboost4j.so
           python3 ops/pipeline/manage-artifacts.py upload \
             --s3-bucket ${{ env.RUNS_ON_S3_BUCKET_CACHE }} \
             --prefix cache/${{ github.run_id }}/build-jvm-manylinux-x86_64 \
@@ -152,12 +151,8 @@ jobs:
             --prefix cache/${{ github.run_id }}/build-jvm-manylinux-x86_64 \
             --dest-dir lib \
             libxgboost4j.so
-          sha256sum lib/libxgboost4j.so
       - name: Build and test JVM packages (Scala ${{ matrix.scala_version }})
-        run: |
-          sha256sum lib/libxgboost4j.so > /tmp/libxgboost4j.sha256
-          bash ops/pipeline/build-test-jvm-packages.sh
-          sha256sum --check /tmp/libxgboost4j.sha256
+        run: bash ops/pipeline/build-test-jvm-packages.sh
       - name: Stash files
         run: |
           python3 ops/pipeline/manage-artifacts.py upload \
@@ -285,7 +280,6 @@ jobs:
             --dest-dir lib \
             libxgboost4j.so
           ls -lh lib/libxgboost4j.so
-          sha256sum lib/libxgboost4j.so
       - name: Deploy JVM packages to S3
         run: bash ops/pipeline/deploy-jvm-packages.sh ${{ matrix.variant.name }} ${{ matrix.scala_version }}
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release_')

--- a/ops/pipeline/build-jvm-manylinux.sh
+++ b/ops/pipeline/build-jvm-manylinux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-## Build libxgboost4j.so targeting glibc 2.17 systems
+## Build libxgboost4j.so targeting glibc 2.28 systems
 
 set -euo pipefail
 
@@ -10,7 +10,7 @@ then
 fi
 
 arch=$1
-image_repo="xgb-ci.manylinux2014_${arch}"
+image_repo="xgb-ci.manylinux_2_28_${arch}"
 
 source ops/pipeline/classify-git-branch.sh
 source ops/pipeline/get-docker-registry-details.sh
@@ -19,7 +19,7 @@ source ops/pipeline/get-image-tag.sh
 IMAGE_URI="${DOCKER_REGISTRY_URL}/${image_repo}:${IMAGE_TAG}"
 
 # Build XGBoost4J binary
-echo "--- Build libxgboost4j.so (targeting glibc 2.17)"
+echo "--- Build libxgboost4j.so (targeting glibc 2.28)"
 set -x
 mkdir build
 python3 ops/docker_run.py \
@@ -32,7 +32,7 @@ objdump -T lib/libxgboost4j.so | grep GLIBC_ | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g
 if [[ ($is_pull_request == 0) && ($is_release_branch == 1) ]]
 then
   libname=lib/libxgboost4j_linux_${arch}.so
-  mv -v lib/libxgboost4j.so ${libname}
+  cp -v lib/libxgboost4j.so ${libname}
   python3 ops/pipeline/manage-artifacts.py upload \
     --s3-bucket xgboost-nightly-builds \
     --prefix ${BRANCH_NAME}/${GITHUB_SHA} --make-public \

--- a/ops/pipeline/build-python-wheels-cpu.sh
+++ b/ops/pipeline/build-python-wheels-cpu.sh
@@ -11,7 +11,7 @@ fi
 
 if [[ "$#" -lt 2 ]]
 then
-  echo "Usage: $0 {manylinux2014,manylinux_2_28} {x86_64,aarch64}"
+  echo "Usage: $0 manylinux_2_28 {x86_64,aarch64}"
   exit 1
 fi
 

--- a/ops/pipeline/build-test-jvm-packages.sh
+++ b/ops/pipeline/build-test-jvm-packages.sh
@@ -48,16 +48,6 @@ fi
 
 cd jvm-packages/
 
-# Ensure that XGBoost4J-Spark is compatible with multiple versions of Spark
-if [[ "${USE_CUDA:-}" != "1" && "${SCALA_VERSION}" == "2.12" ]]
-then
-  for spark_version in 3.1.3 3.2.4 3.3.4 3.4.3
-  do
-    mvn --no-transfer-progress clean package -Dspark.version=${spark_version} \
-      -pl xgboost4j,xgboost4j-spark
-  done
-fi
-
 set +x
 mvn_options=""
 if [[ "${USE_CUDA:-}" == "1" ]]
@@ -70,10 +60,20 @@ then
 fi
 set -x
 
+# Ensure that XGBoost4J-Spark is compatible with multiple versions of Spark
+if [[ "${USE_CUDA:-}" != "1" && "${SCALA_VERSION}" == "2.12" ]]
+then
+  for spark_version in 3.1.3 3.2.4 3.3.4 3.4.3
+  do
+    mvn --no-transfer-progress clean package -Dspark.version=${spark_version} \
+      -pl xgboost4j,xgboost4j-spark ${mvn_options}
+  done
+fi
+
 mvn --no-transfer-progress clean install ${mvn_options}
 
 # Integration tests
 if [[ "${USE_CUDA:-}" != "1" ]]
 then
-  mvn --no-transfer-progress test -pl xgboost4j-example
+  mvn --no-transfer-progress test -pl xgboost4j-example ${mvn_options}
 fi

--- a/ops/pipeline/get-image-tag.sh
+++ b/ops/pipeline/get-image-tag.sh
@@ -7,4 +7,4 @@
 # or PR number:
 # IMAGE_TAG=PR-88
 
-IMAGE_TAG=main
+IMAGE_TAG=PR-102

--- a/ops/pipeline/get-image-tag.sh
+++ b/ops/pipeline/get-image-tag.sh
@@ -7,4 +7,4 @@
 # or PR number:
 # IMAGE_TAG=PR-88
 
-IMAGE_TAG=PR-102
+IMAGE_TAG=main


### PR DESCRIPTION
ref https://github.com/dmlc/xgboost-devops/pull/102

- [x] Revert image tag.


# changes
- Use glibc 2.28.
- Use openjdk 17.