### PR TITLE
Separate learner model inputs from model state

### DIFF
--- a/include/xgboost/gbm.h
+++ b/include/xgboost/gbm.h
@@ -29,7 +29,7 @@ class ObjFunction;
 class CatContainer;
 
 struct Context;
-struct LearnerModelParam;
+struct LearnerModelState;
 
 /*!
  * \brief interface of gradient boosting model.
@@ -66,11 +66,6 @@ class GradientBooster : public Model, public Configurable {
    * @brief Return number of boosted rounds.
    */
   [[nodiscard]] virtual std::int32_t BoostedRounds() const = 0;
-  /**
-   * \brief Whether the model has already been trained. When tree booster is chosen, then
-   *        returns true when there are existing trees.
-   */
-  [[nodiscard]] virtual bool ModelFitted() const = 0;
   /**
    * @brief perform update to the model(boosting)
    *
@@ -162,11 +157,11 @@ class GradientBooster : public Model, public Configurable {
    * @brief create a gradient booster from given name
    * @param name name of gradient booster
    * @param generic_param Pointer to runtime parameters
-   * @param learner_model_param pointer to global model parameters
+   * @param learner_model_state pointer to global model parameters
    * @return The created booster.
    */
   static GradientBooster* Create(const std::string& name, Context const* ctx,
-                                 LearnerModelParam const* learner_model_param);
+                                 LearnerModelState const* learner_model_state);
 };
 
 /*!
@@ -175,7 +170,7 @@ class GradientBooster : public Model, public Configurable {
 struct GradientBoosterReg
     : public dmlc::FunctionRegEntryBase<
           GradientBoosterReg,
-          std::function<GradientBooster*(LearnerModelParam const* learner_model_param,
+          std::function<GradientBooster*(LearnerModelState const* learner_model_state,
                                          Context const* ctx)> > {};
 
 /*!

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -315,6 +315,7 @@ struct LearnerModelState {
   [[nodiscard]] linalg::VectorView<float const> BaseScore(DeviceOrd device) const;
   [[nodiscard]] std::vector<float> const& BaseScoreValue() const { return base_score_value_; }
   void SetBaseScore(Context const* ctx, std::vector<float> value, linalg::Vector<float> margin);
+  void ConfigureDevice(Context const* ctx);
 
   void Copy(LearnerModelState const& that);
   [[nodiscard]] bool IsVectorLeaf() const noexcept {

--- a/include/xgboost/learner.h
+++ b/include/xgboost/learner.h
@@ -260,8 +260,6 @@ class Learner : public Model, public Configurable, public dmlc::Serializable {
   Context ctx_;
 };
 
-struct LearnerModelParamLegacy;
-
 /**
  * @brief Strategy for building multi-target models.
  */
@@ -271,55 +269,54 @@ enum class MultiStrategy : std::int32_t {
 };
 
 /**
- * @brief Basic model parameters, used to describe the booster.
+ * @brief State shared by the learner and gradient booster.
  */
-struct LearnerModelParam {
+struct LearnerModelState {
  private:
   /**
-   * @brief Global bias, this is just a scalar value but can be extended to vector when we
-   *        support multi-class and multi-target.
-   *
-   * The value stored here is the value before applying the inverse link function, used
-   * for initializing the prediction matrix/vector.
+   * @brief Intercept in margin space, used to initialize predictions.
    */
   linalg::Vector<float> base_score_;
-
-  LearnerModelParam(LearnerModelParamLegacy const& user_param, ObjInfo t,
-                    MultiStrategy multi_strategy);
+  /** @brief Intercept in objective space, used for model serialization. */
+  std::vector<float> base_score_value_;
 
  public:
-  /**
-   * @brief The number of features.
-   */
+  /** @brief The number of features. */
   bst_feature_t num_feature{0};
-  /**
-   * @brief The number of classes or targets.
-   */
+  /** @brief Number of classes for a multi-class model. */
+  std::int32_t num_class{0};
+  /** @brief Number of targets. */
+  bst_target_t num_target{1};
+  /** @brief Whether the intercept should be estimated from training data. */
+  bool boost_from_average{true};
+  /** @brief The number of classes or targets. */
   std::uint32_t num_output_group{0};
-  /**
-   * @brief Current task, determined by objective.
-   */
+  /** @brief Current task, determined by objective. */
   ObjInfo task{ObjInfo::kRegression};
-  /**
-   * @brief Strategy for building multi-target models.
-   */
+  /** @brief Strategy for building multi-target models. */
   MultiStrategy multi_strategy{MultiStrategy::kOneOutputPerTree};
 
-  LearnerModelParam() = default;
-  LearnerModelParam(Context const* ctx, LearnerModelParamLegacy const& user_param,
-                    linalg::Vector<float> base_score, ObjInfo t, MultiStrategy multi_strategy);
+  LearnerModelState() = default;
+  LearnerModelState(Context const* ctx, bst_feature_t n_features, std::int32_t n_classes,
+                    bst_target_t n_targets, bool boost_from_average,
+                    std::vector<float> base_score_value, linalg::Vector<float> base_score,
+                    ObjInfo task, MultiStrategy multi_strategy);
   // This ctor is only used by tests.
-  LearnerModelParam(bst_feature_t n_features, linalg::Vector<float> base_score,
+  LearnerModelState(bst_feature_t n_features, linalg::Vector<float> base_score,
                     std::uint32_t n_groups, bst_target_t n_targets, MultiStrategy multi_strategy)
       : base_score_{std::move(base_score)},
         num_feature{n_features},
+        num_class{n_groups > 1 ? static_cast<std::int32_t>(n_groups) : 0},
+        num_target{n_targets},
         num_output_group{std::max(n_groups, n_targets)},
         multi_strategy{multi_strategy} {}
 
   linalg::VectorView<float const> BaseScore(Context const* ctx) const;
   [[nodiscard]] linalg::VectorView<float const> BaseScore(DeviceOrd device) const;
+  [[nodiscard]] std::vector<float> const& BaseScoreValue() const { return base_score_value_; }
+  void SetBaseScore(Context const* ctx, std::vector<float> value, linalg::Vector<float> margin);
 
-  void Copy(LearnerModelParam const& that);
+  void Copy(LearnerModelState const& that);
   [[nodiscard]] bool IsVectorLeaf() const noexcept {
     return multi_strategy == MultiStrategy::kMultiOutputTree;
   }
@@ -328,8 +325,10 @@ struct LearnerModelParam {
     return this->IsVectorLeaf() ? this->OutputLength() : 1;
   }
 
-  /* \brief Whether this parameter is initialized with LearnerModelParamLegacy. */
-  [[nodiscard]] bool Initialized() const { return num_feature != 0 && num_output_group != 0; }
+  [[nodiscard]] bool NeedsInitialization() const {
+    return num_feature == 0 || num_output_group == 0 || base_score_.Size() == 0;
+  }
+  [[nodiscard]] bool Initialized() const { return !this->NeedsInitialization(); }
 };
 
 }  // namespace xgboost

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/Booster.java
@@ -254,7 +254,7 @@ public class Booster implements Serializable, KryoSerializable {
 
   @Deprecated
   public void update(DMatrix dtrain, IObjective obj) throws XGBoostError {
-    float[][] predicts = this.predict(dtrain, true, 0, false, false);
+    float[][] predicts = this.predict(dtrain, true, 0, false, false, true);
     List<float[]> gradients = obj.getGradient(predicts, dtrain);
     this.boost(dtrain, gradients.get(0), gradients.get(1));
   }
@@ -268,7 +268,7 @@ public class Booster implements Serializable, KryoSerializable {
    * @throws XGBoostError native error
    */
   public void update(DMatrix dtrain, int iter, IObjective obj) throws XGBoostError {
-    float[][] predicts = this.predict(dtrain, true, 0, false, false);
+    float[][] predicts = this.predict(dtrain, true, 0, false, false, true);
     List<float[]> gradients = obj.getGradient(predicts, dtrain);
     this.boost(dtrain, iter, gradients.get(0), gradients.get(1));
   }
@@ -384,6 +384,15 @@ public class Booster implements Serializable, KryoSerializable {
                             int iterationEnd,
                             boolean predLeaf,
                             boolean predContribs) throws XGBoostError {
+    return predict(data, outputMargin, iterationEnd, predLeaf, predContribs, false);
+  }
+
+  private float[][] predict(DMatrix data,
+                            boolean outputMargin,
+                            int iterationEnd,
+                            boolean predLeaf,
+                            boolean predContribs,
+                            boolean training) throws XGBoostError {
     int predictType = 0;
     if (outputMargin) {
       predictType = 1;
@@ -396,7 +405,7 @@ public class Booster implements Serializable, KryoSerializable {
     }
     float[][] rawPredicts = new float[1][];
     XGBoostJNI.checkCall(XGBoostJNI.XGBoosterPredictFromDMatrix(handle, data.getHandle(),
-        predictType, iterationEnd, rawPredicts));
+        predictType, iterationEnd, training, rawPredicts));
     int row = (int) data.rowNum();
     int col = rawPredicts[0].length / row;
     float[][] predicts = new float[row][col];

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/XGBoostJNI.java
@@ -122,7 +122,7 @@ public class XGBoostJNI {
       String[] evnames, String[] eval_info);
 
   public final static native int XGBoosterPredictFromDMatrix(long handle, long dmat,
-      int predict_type, int iteration_end, float[][] predicts);
+      int predict_type, int iteration_end, boolean training, float[][] predicts);
 
   public final static native int XGBoosterPredictFromDense(long handle, float[] data,
       long nrow, long ncol, float missing, int iteration_begin, int iteration_end, int predict_type, float[] margin,

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.cpp
@@ -788,11 +788,11 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterEvalOneIt
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGBoosterPredictFromDMatrix
- * Signature: (JJII[[F)I
+ * Signature: (JJIIZ[[F)I
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFromDMatrix(
     JNIEnv *jenv, jclass jcls, jlong jhandle, jlong jdmat, jint jpredict_type, jint jiteration_end,
-    jobjectArray jout) {
+    jboolean jtraining, jobjectArray jout) {
   API_BEGIN();
   auto handle = reinterpret_cast<BoosterHandle>(jhandle);
   auto dmat = reinterpret_cast<DMatrixHandle>(jdmat);
@@ -801,7 +801,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFr
   config["type"] = xgboost::Integer{static_cast<std::int32_t>(jpredict_type)};
   config["iteration_begin"] = xgboost::Integer{0};
   config["iteration_end"] = xgboost::Integer{static_cast<xgboost::bst_layer_t>(jiteration_end)};
-  config["training"] = xgboost::Boolean{false};
+  config["training"] = xgboost::Boolean{static_cast<bool>(jtraining)};
   config["strict_shape"] = xgboost::Boolean{false};
   auto s_config = xgboost::Json::Dump(config);
 

--- a/jvm-packages/xgboost4j/src/native/xgboost4j.h
+++ b/jvm-packages/xgboost4j/src/native/xgboost4j.h
@@ -224,10 +224,10 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterEvalOneIt
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI
  * Method:    XGBoosterPredictFromDMatrix
- * Signature: (JJII[[F)I
+ * Signature: (JJIIZ[[F)I
  */
 JNIEXPORT jint JNICALL Java_ml_dmlc_xgboost4j_java_XGBoostJNI_XGBoosterPredictFromDMatrix(
-    JNIEnv *, jclass, jlong, jlong, jint, jint, jobjectArray);
+    JNIEnv *, jclass, jlong, jlong, jint, jint, jboolean, jobjectArray);
 
 /*
  * Class:     ml_dmlc_xgboost4j_java_XGBoostJNI

--- a/plugin/sycl/predictor/predictor.cc
+++ b/plugin/sycl/predictor/predictor.cc
@@ -85,7 +85,7 @@ class DeviceModel {
       }
     }
 
-    int num_group = model.learner_model_param->num_output_group;
+    int num_group = model.learner_model_state->num_output_group;
     if (num_group > 1) {
       tree_group.Resize(model.tree_info.Size());
       auto& tree_group_host = tree_group.HostVector();
@@ -454,7 +454,7 @@ class Predictor : public xgboost::Predictor {
 
     device_model.Init(model, tree_begin, tree_end);
 
-    int num_group = model.learner_model_param->num_output_group;
+    int num_group = model.learner_model_state->num_output_group;
     int num_features = dmat->Info().num_col_;
 
     float* out_predictions = out_preds->DevicePointer();

--- a/src/gbm/gblinear.cc
+++ b/src/gbm/gblinear.cc
@@ -54,11 +54,11 @@ void LinearCheckLayer(unsigned layer_begin) {
  */
 class GBLinear : public GradientBooster {
  public:
-  explicit GBLinear(LearnerModelParam const* learner_model_param, Context const* ctx)
+  explicit GBLinear(LearnerModelState const* learner_model_state, Context const* ctx)
       : GradientBooster{ctx},
-        learner_model_param_{learner_model_param},
-        model_{learner_model_param},
-        previous_model_{learner_model_param} {
+        learner_model_state_{learner_model_state},
+        model_{learner_model_state},
+        previous_model_{learner_model_state} {
     monitor_.Init(__func__);
   }
 
@@ -85,8 +85,6 @@ class GBLinear : public GradientBooster {
   }
 
   int32_t BoostedRounds() const override { return model_.num_boosted_rounds; }
-
-  bool ModelFitted() const override { return BoostedRounds() != 0; }
 
   void SaveModel(Json* p_out) const override {
     auto& out = *p_out;
@@ -157,14 +155,14 @@ class GBLinear : public GradientBooster {
     model_.LazyInitModel();
     LinearCheckLayer(layer_begin);
     auto base_margin = p_fmat->Info().base_margin_.View(DeviceOrd::CPU());
-    const int ngroup = model_.learner_model_param->num_output_group;
-    const size_t ncolumns = model_.learner_model_param->num_feature + 1;
+    const int ngroup = model_.learner_model_state->num_output_group;
+    const size_t ncolumns = model_.learner_model_state->num_feature + 1;
     // allocate space for (#features + bias) times #groups times #rows
     std::vector<bst_float>& contribs = out_contribs->HostVector();
     contribs.resize(p_fmat->Info().num_row_ * ncolumns * ngroup);
     // make sure contributions is zeroed, we could be reusing a previously allocated one
     std::fill(contribs.begin(), contribs.end(), 0);
-    auto base_score = learner_model_param_->BaseScore(ctx_);
+    auto base_score = learner_model_state_->BaseScore(ctx_);
     // start collecting the contributions
     for (const auto& batch : p_fmat->GetBatches<SparsePage>()) {
       // parallel over local batch
@@ -178,7 +176,7 @@ class GBLinear : public GradientBooster {
           bst_float* p_contribs = &contribs[(row_idx * ngroup + gid) * ncolumns];
           // calculate linear terms' contributions
           for (auto& ins : inst) {
-            if (ins.index >= model_.learner_model_param->num_feature) continue;
+            if (ins.index >= model_.learner_model_state->num_feature) continue;
             p_contribs[ins.index] = ins.fvalue * model_[ins.index][gid];
           }
           // add base margin to BIAS
@@ -198,9 +196,9 @@ class GBLinear : public GradientBooster {
 
     // linear models have no interaction effects
     const size_t nelements =
-        model_.learner_model_param->num_feature * model_.learner_model_param->num_feature;
+        model_.learner_model_state->num_feature * model_.learner_model_state->num_feature;
     contribs.resize(p_fmat->Info().num_row_ * nelements *
-                    model_.learner_model_param->num_output_group);
+                    model_.learner_model_state->num_output_group);
     std::fill(contribs.begin(), contribs.end(), 0);
   }
 
@@ -216,16 +214,16 @@ class GBLinear : public GradientBooster {
     CHECK(trees.empty()) << "gblinear doesn't support number of trees for feature importance.";
     CHECK_EQ(importance_type, "weight")
         << "gblinear only has `weight` defined for feature importance.";
-    out_features->resize(this->learner_model_param_->num_feature, 0);
+    out_features->resize(this->learner_model_state_->num_feature, 0);
     std::iota(out_features->begin(), out_features->end(), 0);
     // Don't include the bias term in the feature importance scores
     // The bias is the last weight
-    out_scores->resize(model_.weight.size() - learner_model_param_->num_output_group, 0);
-    auto n_groups = learner_model_param_->num_output_group;
+    out_scores->resize(model_.weight.size() - learner_model_state_->num_output_group, 0);
+    auto n_groups = learner_model_state_->num_output_group;
     auto scores = linalg::MakeTensorView(DeviceOrd::CPU(),
                                          common::Span{out_scores->data(), out_scores->size()},
-                                         learner_model_param_->num_feature, n_groups);
-    for (size_t i = 0; i < learner_model_param_->num_feature; ++i) {
+                                         learner_model_state_->num_feature, n_groups);
+    for (size_t i = 0; i < learner_model_state_->num_feature; ++i) {
       for (bst_group_t g = 0; g < n_groups; ++g) {
         scores(i, g) = model_[i][g];
       }
@@ -239,10 +237,10 @@ class GBLinear : public GradientBooster {
     std::vector<bst_float>& preds = *out_preds;
     auto base_margin = p_fmat->Info().base_margin_.View(DeviceOrd::CPU());
     // start collecting the prediction
-    const int ngroup = model_.learner_model_param->num_output_group;
+    const int ngroup = model_.learner_model_state->num_output_group;
     preds.resize(p_fmat->Info().num_row_ * ngroup);
 
-    auto base_score = learner_model_param_->BaseScore(DeviceOrd::CPU());
+    auto base_score = learner_model_state_->BaseScore(DeviceOrd::CPU());
     for (const auto& page : p_fmat->GetBatches<SparsePage>()) {
       auto const& batch = page.GetView();
       // output convention: nrow * k, where nrow is number of rows
@@ -294,14 +292,14 @@ class GBLinear : public GradientBooster {
   void Pred(const SparsePage::Inst& inst, bst_float* preds, int gid, bst_float base) {
     bst_float psum = model_.Bias()[gid] + base;
     for (const auto& ins : inst) {
-      if (ins.index >= model_.learner_model_param->num_feature) continue;
+      if (ins.index >= model_.learner_model_state->num_feature) continue;
       psum += ins.fvalue * model_[ins.index][gid];
     }
     preds[gid] = psum;
   }
 
   // biase margin score
-  LearnerModelParam const* learner_model_param_;
+  LearnerModelState const* learner_model_state_;
   // model field
   GBLinearModel model_;
   GBLinearModel previous_model_;
@@ -318,7 +316,7 @@ DMLC_REGISTER_PARAMETER(GBLinearTrainParam);
 
 XGBOOST_REGISTER_GBM(GBLinear, "gblinear")
     .describe("Linear booster, implement generalized linear model.")
-    .set_body([](LearnerModelParam const* booster_config, Context const* ctx) {
+    .set_body([](LearnerModelState const* booster_config, Context const* ctx) {
       return new GBLinear(booster_config, ctx);
     });
 }  // namespace xgboost::gbm

--- a/src/gbm/gblinear_model.h
+++ b/src/gbm/gblinear_model.h
@@ -6,14 +6,14 @@
 #include <dmlc/parameter.h>
 #include <xgboost/learner.h>
 
-#include <vector>
-#include <string>
 #include <cstring>
+#include <string>
+#include <vector>
 
 #include "xgboost/base.h"
 #include "xgboost/feature_map.h"
-#include "xgboost/model.h"
 #include "xgboost/json.h"
+#include "xgboost/model.h"
 
 namespace xgboost {
 class Json;
@@ -22,12 +22,12 @@ namespace gbm {
 class GBLinearModel : public Model {
  public:
   std::int32_t num_boosted_rounds{0};
-  LearnerModelParam const* learner_model_param;
+  LearnerModelState const *learner_model_state;
 
  public:
-  explicit GBLinearModel(LearnerModelParam const *learner_model_param)
-      : learner_model_param{learner_model_param} {}
-  void Configure(Args const &) { }
+  explicit GBLinearModel(LearnerModelState const *learner_model_state)
+      : learner_model_state{learner_model_state} {}
+  void Configure(Args const &) {}
 
   // weight for each of feature, bias is the last one
   std::vector<bst_float> weight;
@@ -37,8 +37,7 @@ class GBLinearModel : public Model {
       return;
     }
     // bias is the last weight
-    weight.resize((learner_model_param->num_feature + 1) *
-                  learner_model_param->num_output_group);
+    weight.resize((learner_model_state->num_feature + 1) * learner_model_state->num_output_group);
     std::fill(weight.begin(), weight.end(), 0.0f);
   }
 
@@ -47,25 +46,22 @@ class GBLinearModel : public Model {
 
   // model bias
   inline bst_float *Bias() {
-    return &weight[learner_model_param->num_feature *
-                   learner_model_param->num_output_group];
+    return &weight[learner_model_state->num_feature * learner_model_state->num_output_group];
   }
   inline const bst_float *Bias() const {
-    return &weight[learner_model_param->num_feature *
-                   learner_model_param->num_output_group];
+    return &weight[learner_model_state->num_feature * learner_model_state->num_output_group];
   }
   // get i-th weight
   inline bst_float *operator[](size_t i) {
-    return &weight[i * learner_model_param->num_output_group];
+    return &weight[i * learner_model_state->num_output_group];
   }
   inline const bst_float *operator[](size_t i) const {
-    return &weight[i * learner_model_param->num_output_group];
+    return &weight[i * learner_model_state->num_output_group];
   }
 
-  std::vector<std::string> DumpModel(const FeatureMap &, bool,
-                                     std::string format) const {
-    const int ngroup = learner_model_param->num_output_group;
-    const unsigned nfeature = learner_model_param->num_feature;
+  std::vector<std::string> DumpModel(const FeatureMap &, bool, std::string format) const {
+    const int ngroup = learner_model_state->num_output_group;
+    const unsigned nfeature = learner_model_state->num_feature;
 
     std::stringstream fo("");
     if (format == "json") {
@@ -76,9 +72,7 @@ class GBLinearModel : public Model {
         }
         fo << "      " << this->Bias()[gid];
       }
-      fo << std::endl
-         << "    ]," << std::endl
-         << "    \"weight\": [" << std::endl;
+      fo << std::endl << "    ]," << std::endl << "    \"weight\": [" << std::endl;
       for (unsigned i = 0; i < nfeature; ++i) {
         for (int gid = 0; gid < ngroup; ++gid) {
           if (i != 0 || gid != 0) {

--- a/src/gbm/gbm.cc
+++ b/src/gbm/gbm.cc
@@ -18,13 +18,13 @@ DMLC_REGISTRY_ENABLE(::xgboost::GradientBoosterReg);
 
 namespace xgboost {
 GradientBooster* GradientBooster::Create(const std::string& name, Context const* ctx,
-                                         LearnerModelParam const* learner_model_param) {
+                                         LearnerModelState const* learner_model_state) {
   auto const& gbm_name = name == "dart" ? std::string{"gbtree"} : name;
   auto* e = ::dmlc::Registry<::xgboost::GradientBoosterReg>::Get()->Find(gbm_name);
   if (e == nullptr) {
     LOG(FATAL) << "Unknown gbm type " << name;
   }
-  auto p_bst = (e->body)(learner_model_param, ctx);
+  auto p_bst = (e->body)(learner_model_state, ctx);
   return p_bst;
 }
 }  // namespace xgboost

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -113,7 +113,7 @@ std::set<std::string> GBTree::Configure(Args const& cfg) {
     updaters_.clear();
     for (auto const& name : up_names) {
       std::unique_ptr<TreeUpdater> up(
-          TreeUpdater::Create(name.c_str(), ctx_, &model_.learner_model_param->task));
+          TreeUpdater::Create(name.c_str(), ctx_, &model_.learner_model_state->task));
       updaters_.push_back(std::move(up));
     }
   }
@@ -183,20 +183,20 @@ void GPUDartPredictInc(common::Span<float>, common::Span<float>, float, size_t, 
 void GBTree::DoBoost(std::shared_ptr<DMatrix> p_fmat, GradientContainer* in_gpair,
                      ObjFunction const*) {
   auto predt = prediction_cache_.Cache(p_fmat, ctx_->Device());
-  if (model_.learner_model_param->IsVectorLeaf()) {
+  if (model_.learner_model_state->IsVectorLeaf()) {
     CHECK(tparam_.tree_method == TreeMethod::kHist || tparam_.tree_method == TreeMethod::kAuto)
         << "Only the hist tree method is supported for building multi-target trees with vector "
            "leaf.";
   }
   if (in_gpair->HasValueGrad()) {
-    CHECK(model_.learner_model_param->IsVectorLeaf())
+    CHECK(model_.learner_model_state->IsVectorLeaf())
         << "Reduced gradient must be used with vector leaf trees";
     CHECK(!tree_param_.HasMonotone())
         << "Monotonic constraints are not supported with reduced gradients.";
   }
 
   TreesOneIter new_trees;
-  bst_target_t const n_groups = model_.learner_model_param->OutputLength();
+  bst_target_t const n_groups = model_.learner_model_state->OutputLength();
   monitor_.Start("BoostNewTrees");
 
   // Define the categories.
@@ -217,7 +217,7 @@ void GBTree::DoBoost(std::shared_ptr<DMatrix> p_fmat, GradientContainer* in_gpai
     predictor->InitOutPredictions(p_fmat->Info(), &predt->predictions, model_);
   }
   auto out = linalg::MakeTensorView(ctx_, &predt->predictions, p_fmat->Info().num_row_,
-                                    model_.learner_model_param->OutputLength());
+                                    model_.learner_model_state->OutputLength());
   CHECK_NE(n_groups, 0);
 
   // The node position for each row, 1 HDV for each tree in the forest.  Note that the
@@ -242,8 +242,8 @@ void GBTree::DoBoost(std::shared_ptr<DMatrix> p_fmat, GradientContainer* in_gpai
     return true;
   };
 
-  if (model_.learner_model_param->IsVectorLeaf() ||
-      model_.learner_model_param->OutputLength() == 1u) {
+  if (model_.learner_model_state->IsVectorLeaf() ||
+      model_.learner_model_state->OutputLength() == 1u) {
     TreesOneGroup ret;
     BoostNewTrees(in_gpair, p_fmat.get(), 0, &node_position, &ret);
     if (predict_from_node_positions(node_position, ret, out)) {
@@ -289,8 +289,8 @@ std::vector<RegTree*> GBTree::InitNewTrees(bst_target_t bst_group, TreesOneGroup
           << "Set `process_type` to `update` if you want to update existing "
              "trees.";
       // create new tree
-      std::unique_ptr<RegTree> ptr(new RegTree{this->model_.learner_model_param->LeafLength(),
-                                               this->model_.learner_model_param->num_feature});
+      std::unique_ptr<RegTree> ptr(new RegTree{this->model_.learner_model_state->LeafLength(),
+                                               this->model_.learner_model_state->num_feature});
       new_trees.push_back(ptr.get());
       ret->push_back(std::move(ptr));
     } else if (tparam_.process_type == TreeProcessType::kUpdate) {
@@ -319,12 +319,12 @@ void GBTree::BoostNewTrees(GradientContainer* gpair, DMatrix* p_fmat, int bst_gr
   std::vector<RegTree*> new_trees = this->InitNewTrees(bst_group, ret);
 
   // update the trees
-  auto n_out = model_.learner_model_param->OutputLength() * p_fmat->Info().num_row_;
+  auto n_out = model_.learner_model_state->OutputLength() * p_fmat->Info().num_row_;
   StringView msg{
       "Mismatching size between number of rows from input data and size of gradient vector."};
-  if (!model_.learner_model_param->IsVectorLeaf() && p_fmat->Info().num_row_ != 0) {
+  if (!model_.learner_model_state->IsVectorLeaf() && p_fmat->Info().num_row_ != 0) {
     CHECK_EQ(n_out % gpair->gpair.Size(), 0) << msg;
-  } else if (model_.learner_model_param->IsVectorLeaf()) {
+  } else if (model_.learner_model_state->IsVectorLeaf()) {
     // vector leaf
     if (!gpair->HasValueGrad()) {
       CHECK_EQ(gpair->gpair.Size(), n_out) << msg;
@@ -410,7 +410,7 @@ void GBTree::LoadConfig(Json const& in) {
       name = "grow_quantile_histmaker";
       LOG(WARNING) << "Changing updater from `grow_gpu_hist` to `grow_quantile_histmaker`.";
     }
-    updaters_.emplace_back(TreeUpdater::Create(name, ctx_, &model_.learner_model_param->task));
+    updaters_.emplace_back(TreeUpdater::Create(name, ctx_, &model_.learner_model_state->task));
     updaters_.back()->LoadConfig(config);
   }
 
@@ -572,7 +572,7 @@ void GBTree::Slice(bst_layer_t begin, bst_layer_t end, bst_layer_t step, Gradien
   auto p_gbtree = dynamic_cast<GBTree*>(out);
   CHECK(p_gbtree);
   GBTreeModel& out_model = p_gbtree->model_;
-  CHECK(this->model_.learner_model_param->Initialized());
+  CHECK(this->model_.learner_model_state->Initialized());
 
   end = end == 0 ? model_.BoostedRounds() : end;
   CHECK_GE(step, 1);
@@ -790,7 +790,7 @@ DMLC_REGISTER_PARAMETER(DartTrainParam);
 
 XGBOOST_REGISTER_GBM(GBTree, "gbtree")
     .describe("Tree booster, gradient boosted trees.")
-    .set_body([](LearnerModelParam const* booster_config, Context const* ctx) {
+    .set_body([](LearnerModelState const* booster_config, Context const* ctx) {
       auto* p = new GBTree{booster_config, ctx};
       return p;
     });

--- a/src/gbm/gbtree.h
+++ b/src/gbm/gbtree.h
@@ -205,7 +205,7 @@ class PredictionContainer : public DMatrixCache<PredictionCacheEntry> {
 
 class GBTree : public GradientBooster {
  public:
-  explicit GBTree(LearnerModelParam const* booster_config, Context const* ctx)
+  explicit GBTree(LearnerModelState const* booster_config, Context const* ctx)
       : GradientBooster{ctx}, model_(booster_config, ctx_) {
     monitor_.Init(__func__);
   }
@@ -230,9 +230,6 @@ class GBTree : public GradientBooster {
              bool* out_of_bound) const override;
 
   [[nodiscard]] std::int32_t BoostedRounds() const override { return this->model_.BoostedRounds(); }
-  [[nodiscard]] bool ModelFitted() const override {
-    return !model_.trees.empty() || !model_.trees_to_update.empty();
-  }
 
   // Test-only accessor. The cache entry is thread-local and must have been initialized by
   // PredictBatch or DoBoost on this thread.
@@ -253,8 +250,8 @@ class GBTree : public GradientBooster {
     // Because feature with no importance doesn't appear in the return value so
     // we need to set up another pair of vectors to store the values during
     // computation.
-    std::vector<size_t> split_counts(this->model_.learner_model_param->num_feature, 0);
-    std::vector<float> gain_map(this->model_.learner_model_param->num_feature, 0);
+    std::vector<size_t> split_counts(this->model_.learner_model_state->num_feature, 0);
+    std::vector<float> gain_map(this->model_.learner_model_state->num_feature, 0);
     std::vector<int32_t> tree_idx;
     if (trees.empty()) {
       tree_idx.resize(this->model_.trees.size());

--- a/src/gbm/gbtree_model.cc
+++ b/src/gbm/gbtree_model.cc
@@ -11,7 +11,7 @@
 #include "../common/threading_utils.h"  // for ParallelFor
 #include "xgboost/context.h"            // for Context
 #include "xgboost/json.h"               // for Json, get, Integer, Array, FromJson, ToJson, Json...
-#include "xgboost/learner.h"            // for LearnerModelParam
+#include "xgboost/learner.h"            // for LearnerModelState
 #include "xgboost/logging.h"            // for LogCheck_EQ, CHECK_EQ, CHECK
 #include "xgboost/tree_model.h"         // for RegTree
 
@@ -149,11 +149,11 @@ bst_tree_t GBTreeModel::CommitModel(TreesOneIter&& new_trees) {
   CHECK_EQ(iteration_indptr.back(), param.num_trees);
   bst_tree_t n_new_trees{0};
 
-  if (learner_model_param->IsVectorLeaf()) {
+  if (learner_model_state->IsVectorLeaf()) {
     n_new_trees += new_trees.front().size();
     this->CommitModelGroup(std::move(new_trees.front()), 0);
   } else {
-    for (bst_target_t gidx{0}; gidx < learner_model_param->OutputLength(); ++gidx) {
+    for (bst_target_t gidx{0}; gidx < learner_model_state->OutputLength(); ++gidx) {
       n_new_trees += new_trees[gidx].size();
       this->CommitModelGroup(std::move(new_trees[gidx]), gidx);
     }

--- a/src/gbm/gbtree_model.h
+++ b/src/gbm/gbtree_model.h
@@ -63,8 +63,8 @@ struct GBTreeModelParam : public dmlc::Parameter<GBTreeModelParam> {
 
 struct GBTreeModel : public Model {
  public:
-  explicit GBTreeModel(LearnerModelParam const* learner_model, Context const* ctx)
-      : learner_model_param{learner_model}, ctx_{ctx} {}
+  explicit GBTreeModel(LearnerModelState const* learner_model, Context const* ctx)
+      : learner_model_state{learner_model}, ctx_{ctx} {}
   std::set<std::string> Configure(Args const& cfg) {
     // initialize model parameters if not yet been initialized.
     if (trees.size() == 0) {
@@ -102,7 +102,7 @@ struct GBTreeModel : public Model {
   }
 
   /** @brief Global model properties. */
-  LearnerModelParam const* learner_model_param;
+  LearnerModelState const* learner_model_state;
   /** @brief GBTree model parameters. */
   GBTreeModelParam param;
   /*! \brief vector of trees stored in the model */

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -93,6 +93,10 @@ void LearnerModelState::SetBaseScore(Context const* ctx, std::vector<float> valu
                                      linalg::Vector<float> base_score) {
   base_score_value_ = std::move(value);
   std::swap(base_score_, base_score);
+  this->ConfigureDevice(ctx);
+}
+
+void LearnerModelState::ConfigureDevice(Context const* ctx) {
   // Make sure read access everywhere for thread-safe prediction.
   std::as_const(base_score_).HostView();
   if (!ctx->IsCPU()) {
@@ -368,6 +372,7 @@ class LearnerModelStateContainer : public Learner {
     if (model_state_.NeedsInitialization()) {
       return;
     }
+    model_state_.ConfigureDevice(Ctx());
     auto has = [&args](char const* key) {
       return std::any_of(args.cbegin(), args.cend(),
                          [key](auto const& kv) { return kv.first == key; });
@@ -998,6 +1003,15 @@ class LearnerImpl : public LearnerIO {
 
   void Reset() override {
     this->Configure();
+    if (model_state_.NeedsInitialization()) {
+      for (auto const& weak : cache_data_) {
+        if (auto data = weak.lock()) {
+          this->InitializeModel(*data, this->cache_data_,
+                                InterceptInitialization::kEstimateIntercept);
+          break;
+        }
+      }
+    }
     this->CheckModelInitialized();
     // Global data
     auto local_map = LearnerAPIThreadLocalStore::Get();

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -97,6 +97,12 @@ void LearnerModelState::SetBaseScore(Context const* ctx, std::vector<float> valu
 }
 
 void LearnerModelState::ConfigureDevice(Context const* ctx) {
+  if (base_score_.Device() != ctx->Device()) {
+    auto const& h_base_score = std::as_const(base_score_).Data()->ConstHostVector();
+    linalg::Vector<float> base_score{
+        h_base_score.cbegin(), h_base_score.cend(), {h_base_score.size()}, ctx->Device()};
+    std::swap(base_score_, base_score);
+  }
   // Make sure read access everywhere for thread-safe prediction.
   std::as_const(base_score_).HostView();
   if (!ctx->IsCPU()) {

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -69,184 +69,29 @@ T& UsePtr(T& ptr) {  // NOLINT
 }
 }  // anonymous namespace
 
-/*! \brief training parameter for regression
- *
- * Should be deprecated, but still used for being compatible with binary IO.
- * Once it's gone, `LearnerModelParam` should handle transforming `base_score`
- * with objective by itself.
- */
-struct LearnerModelParamLegacy : public dmlc::Parameter<LearnerModelParamLegacy> {
-  /** @brief Global bias/intercept. */
-  common::ParamArray<float> base_score{"base_score"};
-  /** @brief number of features  */
-  bst_feature_t num_feature{0};
-  /** @brief number of classes, if it is multi-class classification, 0 otherwise.  */
-  std::int32_t num_class{0};
-  /**! @brief the version of XGBoost. */
-  std::int32_t major_version{std::get<0>(Version::Self())};
-  std::int32_t minor_version{std::get<1>(Version::Self())};
-  /**
-   * @brief Number of target variables.
-   */
-  bst_target_t num_target{1};
-  /**
-   * @brief Whether we should calculate the base score from training data.
-   *
-   *   This is a private parameter as we can't expose it as boolean due to binary model
-   *   format. Exposing it as integer creates inconsistency with other parameters.
-   *
-   *   Automatically disabled when base_score is specifed by user. int32 is used instead
-   *   of bool for the ease of serialization.
-   */
-  std::int32_t boost_from_average{true};
-
-  LearnerModelParamLegacy() = default;
-
-  [[nodiscard]] Json ToJson() const {
-    Json obj{Object{}};
-    std::stringstream ss;
-    ss << base_score;
-    obj["base_score"] = ss.str();
-
-    char integers[NumericLimits<int64_t>::kToCharsSize];
-    auto ret = to_chars(integers, integers + NumericLimits<int64_t>::kToCharsSize,
-                        static_cast<int64_t>(num_feature));
-    CHECK(ret.ec == std::errc());
-    obj["num_feature"] =
-        std::string{integers, static_cast<size_t>(std::distance(integers, ret.ptr))};
-    ret = to_chars(integers, integers + NumericLimits<int64_t>::kToCharsSize,
-                   static_cast<int64_t>(num_class));
-    CHECK(ret.ec == std::errc());
-    obj["num_class"] = std::string{integers, static_cast<size_t>(std::distance(integers, ret.ptr))};
-
-    ret = to_chars(integers, integers + NumericLimits<int64_t>::kToCharsSize,
-                   static_cast<int64_t>(num_target));
-    obj["num_target"] =
-        std::string{integers, static_cast<size_t>(std::distance(integers, ret.ptr))};
-
-    ret = to_chars(integers, integers + NumericLimits<std::int64_t>::kToCharsSize,
-                   static_cast<std::int64_t>(boost_from_average));
-    obj["boost_from_average"] =
-        std::string{integers, static_cast<std::size_t>(std::distance(integers, ret.ptr))};
-
-    return obj;
-  }
-  void FromJson(Json const& obj) {
-    auto const& j_param = get<Object const>(obj);
-    std::map<std::string, std::string> m;
-    m["num_feature"] = get<String const>(j_param.at("num_feature"));
-    m["num_class"] = get<String const>(j_param.at("num_class"));
-    auto n_targets_it = j_param.find("num_target");
-    if (n_targets_it != j_param.cend()) {
-      m["num_target"] = get<String const>(n_targets_it->second);
-    }
-    auto bse_it = j_param.find("boost_from_average");
-    if (bse_it != j_param.cend()) {
-      m["boost_from_average"] = get<String const>(bse_it->second);
-    }
-    std::string str = get<String const>(j_param.at("base_score"));
-    m["base_score"] = str;
-    this->Init(m);
-    this->HandleOldFormat();
-  }
-  // Handle old model formats, before 3.1, the intercept was always a scalar.
-  void HandleOldFormat() {
-    if (this->base_score.size() == 1 && this->OutputLength() > 1) {
-      this->base_score.Resize(this->OutputLength(), this->base_score[0]);
-    }
-  }
-
-  template <typename Container>
-  Args UpdateAllowUnknown(Container const& kwargs) {
-    // Detect whether user has made their own base score.
-    auto has_key = [&kwargs](char const* key) {
-      return std::find_if(kwargs.cbegin(), kwargs.cend(),
-                          [key](auto const& kv) { return kv.first == key; }) != kwargs.cend();
-    };
-    if (has_key("base_score")) {
-      this->boost_from_average = false;
-    }
-    return dmlc::Parameter<LearnerModelParamLegacy>::UpdateAllowUnknown(kwargs);
-  }
-  // The number of outputs of the model.
-  [[nodiscard]] bst_target_t OutputLength() const noexcept {
-    return std::max({this->num_target, static_cast<bst_target_t>(this->num_class),
-                     static_cast<bst_target_t>(1)});
-  }
-
-  // Sanity checks
-  void Validate(Context const* ctx) const {
-    this->ValidateLength();
-    CHECK(std::none_of(base_score.cbegin(), base_score.cend(),
-                       [](float v) { return std::isnan(v) || std::isinf(v); }));
-
-    if (!collective::IsDistributed()) {
-      return;
-    }
-
-    std::vector<char> data;
-    Json::Dump(this->ToJson(), &data, std::ios::binary);
-    std::vector<char> sync{data};
-
-    auto rc = collective::Broadcast(ctx, linalg::MakeVec(sync.data(), sync.size()), 0);
-    collective::SafeColl(rc);
-
-    CHECK(std::equal(data.cbegin(), data.cend(), sync.cbegin()))
-        << "Different model parameter across workers:\n\t"
-        << Json::Load(StringView{data.data(), data.size()}, std::ios::binary) << "\nvs.\n\t"
-        << Json::Load(StringView{sync.data(), sync.size()}, std::ios::binary);
-  }
-
-  void ValidateLength() const {
-    CHECK_GE(this->base_score.size(), 1);
-    std::size_t n_classes = static_cast<std::size_t>(num_class),
-                n_targets = static_cast<std::size_t>(num_target);
-    if (!(base_score.size() == n_classes || base_score.size() == n_targets)) {
-      error::InvalidIntercept(n_classes, n_targets, base_score.size());
-    }
-  }
-
-  // declare parameters
-  DMLC_DECLARE_PARAMETER(LearnerModelParamLegacy) {
-    DMLC_DECLARE_FIELD(base_score)
-        .describe("Global bias of the model.")
-        .set_default(common::ParamArray<float>{"base_score"});
-    DMLC_DECLARE_FIELD(num_feature)
-        .set_default(0)
-        .describe(
-            "Number of features in training data, this parameter will be automatically detected by "
-            "learner.");
-    DMLC_DECLARE_FIELD(num_class).set_default(0).set_lower_bound(0).describe(
-        "Number of class option for multi-class classifier. "
-        " By default equals 0 and corresponds to binary classifier.");
-    DMLC_DECLARE_FIELD(num_target)
-        .set_default(1)
-        .set_lower_bound(1)
-        .describe("Number of output targets. Can be set automatically if not specified.");
-    DMLC_DECLARE_FIELD(boost_from_average)
-        .set_default(true)
-        .describe("Whether we should calculate the base score from training data.");
-  }
-};
-}  // namespace xgboost
-
-namespace xgboost {
-LearnerModelParam::LearnerModelParam(LearnerModelParamLegacy const& user_param, ObjInfo t,
+LearnerModelState::LearnerModelState(Context const* ctx, bst_feature_t n_features,
+                                     std::int32_t n_classes, bst_target_t n_targets,
+                                     bool boost_from_average, std::vector<float> base_score_value,
+                                     linalg::Vector<float> base_score, ObjInfo task,
                                      MultiStrategy multi_strategy)
-    : num_feature{user_param.num_feature},
-      num_output_group{user_param.OutputLength()},
-      task{t},
+    : num_feature{n_features},
+      num_class{n_classes},
+      num_target{n_targets},
+      boost_from_average{boost_from_average},
+      num_output_group{std::max(
+          {n_targets, static_cast<bst_target_t>(n_classes), static_cast<bst_target_t>(1)})},
+      task{task},
       multi_strategy{multi_strategy} {
-  if (user_param.num_class > 1 && user_param.num_target > 1) {
-    LOG(FATAL) << "multi-target-multi-class is not yet supported. Output classes:"
-               << user_param.num_class << ", output targets:" << user_param.num_target;
+  if (num_class > 1 && num_target > 1) {
+    LOG(FATAL) << "multi-target-multi-class is not yet supported. Output classes:" << num_class
+               << ", output targets:" << num_target;
   }
+  this->SetBaseScore(ctx, std::move(base_score_value), std::move(base_score));
 }
 
-LearnerModelParam::LearnerModelParam(Context const* ctx, LearnerModelParamLegacy const& user_param,
-                                     linalg::Vector<float> base_score, ObjInfo t,
-                                     MultiStrategy multi_strategy)
-    : LearnerModelParam{user_param, t, multi_strategy} {
+void LearnerModelState::SetBaseScore(Context const* ctx, std::vector<float> value,
+                                     linalg::Vector<float> base_score) {
+  base_score_value_ = std::move(value);
   std::swap(base_score_, base_score);
   // Make sure read access everywhere for thread-safe prediction.
   std::as_const(base_score_).HostView();
@@ -256,7 +101,7 @@ LearnerModelParam::LearnerModelParam(Context const* ctx, LearnerModelParamLegacy
   CHECK(std::as_const(base_score_).Data()->HostCanRead());
 }
 
-linalg::VectorView<float const> LearnerModelParam::BaseScore(DeviceOrd device) const {
+linalg::VectorView<float const> LearnerModelState::BaseScore(DeviceOrd device) const {
   // multi-class is not yet supported.
   CHECK_GE(base_score_.Size(), 1) << ModelNotFitted();
   if (device.IsCPU()) {
@@ -271,11 +116,11 @@ linalg::VectorView<float const> LearnerModelParam::BaseScore(DeviceOrd device) c
   return v;
 }
 
-linalg::VectorView<float const> LearnerModelParam::BaseScore(Context const* ctx) const {
+linalg::VectorView<float const> LearnerModelState::BaseScore(Context const* ctx) const {
   return this->BaseScore(ctx->Device());
 }
 
-void LearnerModelParam::Copy(LearnerModelParam const& that) {
+void LearnerModelState::Copy(LearnerModelState const& that) {
   base_score_.Reshape(that.base_score_.Shape());
   base_score_.Data()->SetDevice(that.base_score_.Device());
   base_score_.Data()->Copy(*that.base_score_.Data());
@@ -286,24 +131,63 @@ void LearnerModelParam::Copy(LearnerModelParam const& that) {
   CHECK_EQ(base_score_.Data()->DeviceCanRead(), that.base_score_.Data()->DeviceCanRead());
   CHECK(base_score_.Data()->HostCanRead());
 
+  base_score_value_ = that.base_score_value_;
   num_feature = that.num_feature;
+  num_class = that.num_class;
+  num_target = that.num_target;
+  boost_from_average = that.boost_from_average;
   num_output_group = that.num_output_group;
   task = that.task;
   multi_strategy = that.multi_strategy;
 }
 
 struct LearnerTrainParam : public XGBoostParameter<LearnerTrainParam> {
+  // Parameters consumed when the model state is initialized.
+  common::ParamArray<float> base_score{"base_score"};
+  std::int32_t num_class{0};
+  bst_target_t num_target{1};
+  std::int32_t boost_from_average{true};
+
   // flag to disable default metric
   bool disable_default_eval_metric{false};
-  // FIXME(trivialfis): The following parameters belong to model itself, but can be
-  // specified by users.  Move them to model parameter once we can get rid of binary IO.
   std::string booster;
   std::string objective;
   // This is a training parameter and is not saved (nor loaded) in the model.
   MultiStrategy multi_strategy{MultiStrategy::kOneOutputPerTree};
 
-  // declare parameters
+  template <typename Container>
+  Args UpdateAllowUnknown(Container const& kwargs) {
+    auto has_key = [&kwargs](char const* key) {
+      return std::find_if(kwargs.cbegin(), kwargs.cend(),
+                          [key](auto const& kv) { return kv.first == key; }) != kwargs.cend();
+    };
+    auto unknown = XGBoostParameter<LearnerTrainParam>::UpdateAllowUnknown(kwargs);
+    // An explicit boost_from_average takes precedence when both parameters are supplied.
+    if (has_key("base_score") && !has_key("boost_from_average")) {
+      this->boost_from_average = false;
+    }
+    return unknown;
+  }
+
+  [[nodiscard]] bst_target_t OutputLength() const noexcept {
+    return std::max({this->num_target, static_cast<bst_target_t>(this->num_class),
+                     static_cast<bst_target_t>(1)});
+  }
+
   DMLC_DECLARE_PARAMETER(LearnerTrainParam) {
+    DMLC_DECLARE_FIELD(base_score)
+        .describe("Global bias of the model.")
+        .set_default(common::ParamArray<float>{"base_score"});
+    DMLC_DECLARE_FIELD(num_class).set_default(0).set_lower_bound(0).describe(
+        "Number of class option for multi-class classifier. "
+        " By default equals 0 and corresponds to binary classifier.");
+    DMLC_DECLARE_FIELD(num_target)
+        .set_default(1)
+        .set_lower_bound(1)
+        .describe("Number of output targets. Can be set automatically if not specified.");
+    DMLC_DECLARE_FIELD(boost_from_average)
+        .set_default(true)
+        .describe("Whether we should calculate the base score from training data.");
     DMLC_DECLARE_FIELD(disable_default_eval_metric)
         .set_default(false)
         .describe("Flag to disable default metric. Set to >0 to disable");
@@ -322,7 +206,6 @@ struct LearnerTrainParam : public XGBoostParameter<LearnerTrainParam> {
   }
 };
 
-DMLC_REGISTER_PARAMETER(LearnerModelParamLegacy);
 DMLC_REGISTER_PARAMETER(LearnerTrainParam);
 
 using LearnerAPIThreadLocalStore =
@@ -342,144 +225,246 @@ std::string CanonicalizeBoosterName(std::string booster) {
 }
 
 /**
- * @brief Handler for the `n_targets` property and the intercept.
+ * @brief Handler for learner model inputs and state initialization.
  */
-class Intercept : public Learner {
+class LearnerModelStateContainer : public Learner {
   using CacheT = std::vector<std::weak_ptr<DMatrix>>;
 
  protected:
-  /**
-   * @brief User-provided model parameter.
-   *
-   * This parameter is the most difficult one in XGBoost. It stores basic properties of
-   * the booster model and is saved as part of the booster. We need to configure it
-   * automatically from input training data while taking user-provided parameters into
-   * account.
-   *
-   * It's difficult because XGBoost has an interface that exposes many states. For
-   * instance, we need to have a valid model after configuration, without seeing the
-   * training data. This exposes a partially initialized model that's semi-valid.
-   */
-  LearnerModelParamLegacy mparam_;
-  /**
-   * @brief Internal model parameter.
-   */
-  LearnerModelParam learner_model_param_;
+  enum class InterceptInitialization { kEstimateIntercept, kUseDefaultIntercept };
+  /** @brief User-configurable inputs for constructing model state. */
+  LearnerTrainParam tparam_;
+  /** @brief Authoritative model state shared with the gradient booster. */
+  LearnerModelState model_state_;
 
  private:
-  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) {
+  void InitEstimation(MetaInfo const& info, bst_target_t output_length,
+                      linalg::Vector<float>* base_score) {
     base_score->SetDevice(this->Ctx()->Device());
-    base_score->Reshape(this->mparam_.OutputLength());
+    base_score->Reshape(output_length);
     UsePtr(obj_)->InitEstimation(info, base_score);
   }
 
-  [[nodiscard]] bool NeedFit() const {
-    return this->mparam_.boost_from_average && !UsePtr(gbm_)->ModelFitted();
+  static void HandleOldFormat(std::vector<float>* base_score, bst_target_t output_length) {
+    if (base_score->size() == 1 && output_length > 1) {
+      base_score->resize(output_length, base_score->front());
+    }
   }
 
-  // Create the internal model parameter from user inputs, this requires the user input to
-  // be initialized first.
-  //
-  // Don't apply the link function if the base_score is a dummy value.
-  //
-  // This function should be called for every `Configure` call ot make sure the base_score
-  // is stored in the right place.
-  void InitModelParam(LearnerTrainParam const& tparam, bool apply_link) {
-    auto const& in = this->mparam_.base_score;
-    auto task = UsePtr(this->obj_)->Task();
-    linalg::Vector<float> base_score{in.cbegin(), in.cend(), {in.size()}, this->ctx_.Device()};
-    if (apply_link) {
-      UsePtr(this->obj_)->ProbToMargin(&base_score);
+  [[nodiscard]] Json ModelStateToJson() const {
+    auto n_features = model_state_.Initialized() ? model_state_.num_feature : 0;
+    auto n_classes = model_state_.Initialized() ? model_state_.num_class : tparam_.num_class;
+    auto n_targets = model_state_.Initialized() ? model_state_.num_target : tparam_.num_target;
+    auto boost_from_average =
+        model_state_.Initialized() ? model_state_.boost_from_average : tparam_.boost_from_average;
+    std::vector<float> base_score;
+    if (model_state_.Initialized()) {
+      base_score = model_state_.BaseScoreValue();
+    } else {
+      base_score.assign(tparam_.base_score.cbegin(), tparam_.base_score.cend());
     }
 
-    learner_model_param_ =
-        LearnerModelParam{Ctx(), mparam_, std::move(base_score), task, tparam.multi_strategy};
+    common::ParamArray<float> value{"base_score"};
+    value = base_score;
+    std::stringstream ss;
+    ss << value;
+
+    Json out{Object{}};
+    out["base_score"] = ss.str();
+    out["num_feature"] = std::to_string(n_features);
+    out["num_class"] = std::to_string(n_classes);
+    out["num_target"] = std::to_string(n_targets);
+    out["boost_from_average"] = std::to_string(static_cast<std::int32_t>(boost_from_average));
+    return out;
   }
 
-  /**
-   * Get the number of targets from the cache using the objective function.
-   */
-  void GetNumTargets(CacheT const& cache) {
+  void ValidateModelState() const {
+    CHECK(model_state_.Initialized()) << ModelNotFitted();
+    auto const& base_score = model_state_.BaseScoreValue();
+    CHECK_GE(base_score.size(), 1);
+    auto n_classes = static_cast<std::size_t>(model_state_.num_class);
+    auto n_targets = static_cast<std::size_t>(model_state_.num_target);
+    if (!(base_score.size() == n_classes || base_score.size() == n_targets)) {
+      error::InvalidIntercept(n_classes, n_targets, base_score.size());
+    }
+    CHECK(std::none_of(base_score.cbegin(), base_score.cend(),
+                       [](float v) { return std::isnan(v) || std::isinf(v); }));
+
+    if (!collective::IsDistributed()) {
+      return;
+    }
+    std::vector<char> data;
+    Json::Dump(this->ModelStateToJson(), &data, std::ios::binary);
+    std::vector<char> sync{data};
+    auto rc = collective::Broadcast(&ctx_, linalg::MakeVec(sync.data(), sync.size()), 0);
+    collective::SafeColl(rc);
+    CHECK(std::equal(data.cbegin(), data.cend(), sync.cbegin()))
+        << "Different model state across workers:\n\t"
+        << Json::Load(StringView{data.data(), data.size()}, std::ios::binary) << "\nvs.\n\t"
+        << Json::Load(StringView{sync.data(), sync.size()}, std::ios::binary);
+  }
+
+  void InitModelState(bst_feature_t n_features, std::int32_t n_classes, bst_target_t n_targets,
+                      bool boost_from_average, std::vector<float> base_score_value) {
+    auto output_length =
+        std::max({n_targets, static_cast<bst_target_t>(n_classes), static_cast<bst_target_t>(1)});
+    HandleOldFormat(&base_score_value, output_length);
+    linalg::Vector<float> base_score{base_score_value.cbegin(),
+                                     base_score_value.cend(),
+                                     {base_score_value.size()},
+                                     this->ctx_.Device()};
+    UsePtr(this->obj_)->ProbToMargin(&base_score);
+    model_state_ = LearnerModelState{Ctx(),
+                                     n_features,
+                                     n_classes,
+                                     n_targets,
+                                     boost_from_average,
+                                     std::move(base_score_value),
+                                     std::move(base_score),
+                                     UsePtr(this->obj_)->Task(),
+                                     tparam_.multi_strategy};
+    this->ValidateModelState();
+  }
+
+  [[nodiscard]] bst_feature_t InitNumFeatures(DMatrix const& train) const {
+    auto n_features = train.Info().num_col_;
+    error::MaxFeatureSize(n_features);
+    CHECK_NE(n_features, 0) << "0 feature is supplied. Are you using the raw Booster interface?";
+    return static_cast<bst_feature_t>(n_features);
+  }
+
+  [[nodiscard]] bst_target_t InitNumTargets(DMatrix const& train, CacheT const& cache) const {
     CHECK(this->obj_);
-    bst_target_t n_targets = 1;
+    auto n_targets = this->obj_->Targets(train.Info());
     for (auto const& weak : cache) {
       auto d = weak.lock();
       if (!d) {
         continue;
       }
-      if (n_targets == 1) {
-        n_targets = this->obj_->Targets(d->Info());
-      } else {
-        auto t = this->obj_->Targets(d->Info());
-        CHECK(n_targets == t || 1 == t) << "Inconsistent labels.";
-      }
+      auto t = this->obj_->Targets(d->Info());
+      CHECK(n_targets == t || 1 == t) << "Inconsistent labels.";
     }
 
-    if (mparam_.num_target > 1) {
-      CHECK(n_targets == 1 || n_targets == mparam_.num_target)
-          << "Inconsistent configuration of the `num_target`.  Configuration result from input "
-          << "data:" << n_targets << ", configuration from parameters:" << mparam_.num_target;
-    } else {
-      mparam_.num_target = n_targets;
+    if (model_state_.Initialized()) {
+      CHECK(n_targets == 1 || n_targets == model_state_.num_target)
+          << "Inconsistent number of targets between data and model.";
+      return model_state_.num_target;
     }
+    if (tparam_.num_target > 1) {
+      CHECK(n_targets == 1 || n_targets == tparam_.num_target)
+          << "Inconsistent configuration of the `num_target`.  Configuration result from input "
+          << "data:" << n_targets << ", configuration from parameters:" << tparam_.num_target;
+      return tparam_.num_target;
+    }
+    return n_targets;
   }
 
  protected:
-  void CheckModelInitialized() const {
-    CHECK(learner_model_param_.Initialized()) << ModelNotFitted();
-    CHECK_NE(learner_model_param_.BaseScore(this->Ctx()).Size(), 0) << ModelNotFitted();
+  [[nodiscard]] Json SaveModelState() const { return this->ModelStateToJson(); }
+
+  void CheckModelInitialized() const { CHECK(model_state_.Initialized()) << ModelNotFitted(); }
+
+  void ConfigureModelState(LearnerTrainParam const& old_tparam, Args const& args) {
+    if (model_state_.NeedsInitialization()) {
+      return;
+    }
+    auto has = [&args](char const* key) {
+      return std::any_of(args.cbegin(), args.cend(),
+                         [key](auto const& kv) { return kv.first == key; });
+    };
+    bool model_input_changed =
+        has("base_score") || has("num_class") || has("num_target") || has("boost_from_average");
+    bool structure_changed = old_tparam.objective != tparam_.objective ||
+                             old_tparam.multi_strategy != tparam_.multi_strategy;
+    if (!model_input_changed && !structure_changed) {
+      return;
+    }
+
+    auto base_score = model_state_.BaseScoreValue();
+    auto n_classes = model_state_.num_class;
+    auto n_targets = model_state_.num_target;
+    auto boost_from_average = model_state_.boost_from_average;
+    if (has("base_score")) {
+      base_score.assign(tparam_.base_score.cbegin(), tparam_.base_score.cend());
+    }
+    if (has("num_class")) {
+      n_classes = tparam_.num_class;
+    }
+    if (has("num_target")) {
+      n_targets = tparam_.num_target;
+    }
+    if (has("boost_from_average") || has("base_score")) {
+      boost_from_average = tparam_.boost_from_average;
+    }
+    this->InitModelState(model_state_.num_feature, n_classes, n_targets, boost_from_average,
+                         std::move(base_score));
   }
 
-  void InitModelUserParam(LearnerTrainParam const& tparam, CacheT const& cache) {
-    this->GetNumTargets(cache);
+  void InitializeModel(DMatrix const& train, CacheT const& cache, InterceptInitialization mode) {
+    auto n_features = this->InitNumFeatures(train);
+    auto n_targets = this->InitNumTargets(train, cache);
+    if (model_state_.Initialized()) {
+      return;
+    }
 
-    if (this->NeedFit()) {
-      // Initialize with a sensible default value to get prediction/model io going.
-      this->mparam_.base_score.Resize(this->mparam_.OutputLength(),
-                                      ObjFunction::DefaultBaseScore());
-      this->InitModelParam(tparam, false);
-      // This should not be altered, we will estimate it later.
-      CHECK(this->NeedFit());
-    } else if (this->gbm_->ModelFitted()) {
-      this->mparam_.ValidateLength();
-      // Init with a valid (configured) mparam
-      this->InitModelParam(tparam, true);
+    auto output_length = std::max(
+        {n_targets, static_cast<bst_target_t>(tparam_.num_class), static_cast<bst_target_t>(1)});
+    std::vector<float> base_score;
+    if (!tparam_.boost_from_average) {
+      base_score.assign(tparam_.base_score.cbegin(), tparam_.base_score.cend());
+    } else if (mode == InterceptInitialization::kEstimateIntercept) {
+      auto const& info = train.Info();
+      info.Validate(Ctx()->Device());
+      linalg::Vector<float> estimated;
+      this->InitEstimation(info, output_length, &estimated);
+      base_score = estimated.Data()->ConstHostVector();
     } else {
-      // user-provided
-      this->mparam_.HandleOldFormat();
-      this->InitModelParam(tparam, true);
+      base_score.resize(output_length, ObjFunction::DefaultBaseScore());
     }
+    this->InitModelState(n_features, tparam_.num_class, n_targets, tparam_.boost_from_average,
+                         std::move(base_score));
   }
 
-  /**
-   * @brief Calculate the `base_score` based on input data.
-   *
-   * @param p_fmat The training DMatrix used to estimate the base score.
-   */
-  void FitIntercept(LearnerTrainParam const& tparam, DMatrix const* p_fmat) {
-    // Estimate the intercept if this is the first iteration.
-    if (this->NeedFit()) {
-      // The DMatrix can be null if a method other than training is called.
-      if (p_fmat) {
-        auto const& info = p_fmat->Info();
-        info.Validate(Ctx()->Device());
-        // We estimate it from the input data.
-        linalg::Vector<float> base_score;
-        this->InitEstimation(info, &base_score);
+  void LoadModelState(Json const& in) {
+    auto const& values = get<Object const>(in);
+    common::ParamArray<float> base_score_param{"base_score"};
+    std::istringstream is{get<String const>(values.at("base_score"))};
+    is >> base_score_param;
+    CHECK(!is.fail()) << "Invalid base_score in model.";
+    std::vector<float> base_score{base_score_param.cbegin(), base_score_param.cend()};
 
-        mparam_.base_score = base_score.Data()->ConstHostVector();
-      }
-      this->InitModelParam(tparam, true);
-      // Check whether the base score is valid.
-      mparam_.Validate(&ctx_);
+    auto n_features_value = std::stoull(get<String const>(values.at("num_feature")));
+    error::MaxFeatureSize(n_features_value);
+    auto n_features = static_cast<bst_feature_t>(n_features_value);
+    auto n_classes = std::stoi(get<String const>(values.at("num_class")));
+    CHECK_GE(n_classes, 0);
+    bst_target_t n_targets{1};
+    if (auto it = values.find("num_target"); it != values.cend()) {
+      auto value = std::stoull(get<String const>(it->second));
+      CHECK_LE(value, std::numeric_limits<bst_target_t>::max());
+      n_targets = static_cast<bst_target_t>(value);
+      CHECK_GE(n_targets, 1);
+    }
+    bool boost_from_average{true};
+    if (auto it = values.find("boost_from_average"); it != values.cend()) {
+      boost_from_average = std::stoi(get<String const>(it->second));
     }
 
-    this->CheckModelInitialized();
+    tparam_.base_score = base_score;
+    tparam_.num_class = n_classes;
+    tparam_.num_target = n_targets;
+    tparam_.boost_from_average = boost_from_average;
+    if (n_features == 0) {
+      model_state_ = LearnerModelState{};
+      return;
+    }
+    this->InitModelState(n_features, n_classes, n_targets, boost_from_average,
+                         std::move(base_score));
   }
 };
 }  // namespace
 
-class LearnerConfiguration : public Intercept {
+class LearnerConfiguration : public LearnerModelStateContainer {
  private:
   std::mutex config_lock_;
 
@@ -496,7 +481,6 @@ class LearnerConfiguration : public Intercept {
   std::vector<std::string> feature_types_;
 
   common::Monitor monitor_;
-  LearnerTrainParam tparam_;
   // Initial prediction.
   std::vector<std::weak_ptr<DMatrix>> cache_data_;
 
@@ -519,7 +503,6 @@ class LearnerConfiguration : public Intercept {
       this->need_configuration_ = true;
     }
 
-    // Varient of double checked lock
     if (!has_args && !this->need_configuration_) {
       return;
     }
@@ -548,7 +531,6 @@ class LearnerConfiguration : public Intercept {
     Args config_args{config.cbegin(), config.cend()};
 
     used.merge(UpdateAndGetUsedParameters(&tparam_, config_args));
-    used.merge(UpdateAndGetUsedParameters(&mparam_, config_args));
 
     auto initialized = ctx_.GetInitialised();
     auto old_seed = ctx_.seed;
@@ -561,15 +543,12 @@ class LearnerConfiguration : public Intercept {
       ctx_.Rng().seed(ctx_.seed);
     }
 
-    // must precede configure gbm since num_features is required for gbm
-    this->ConfigureNumFeatures();
     used.merge(this->ConfigureObjective(old_tparam, &config, &config_args));
 
-    learner_model_param_.task = obj_->Task();  // required by gbm configuration.
+    model_state_.task = obj_->Task();  // required by gbm configuration.
     used.merge(this->ConfigureGBM(old_tparam, config_args));
 
-    this->InitModelUserParam(this->tparam_, this->cache_data_);
-
+    this->ConfigureModelState(old_tparam, args);
     used.merge(this->ConfigureMetrics(config_args));
 
     this->need_configuration_ = false;
@@ -605,11 +584,11 @@ class LearnerConfiguration : public Intercept {
       obj_.reset(ObjFunction::Create(tparam_.objective, &ctx_));
     }
     obj_->LoadConfig(objective_fn);
-    learner_model_param_.task = obj_->Task();
+    model_state_.task = obj_->Task();
 
     tparam_.booster = CanonicalizeBoosterName(get<String>(gradient_booster["name"]));
     if (!gbm_) {
-      gbm_.reset(GradientBooster::Create(tparam_.booster, &ctx_, &learner_model_param_));
+      gbm_.reset(GradientBooster::Create(tparam_.booster, &ctx_, &model_state_));
     }
     gbm_->LoadConfig(gradient_booster);
 
@@ -651,7 +630,7 @@ class LearnerConfiguration : public Intercept {
     auto& learner_parameters = out["learner"];
 
     learner_parameters["learner_train_param"] = ToJson(tparam_);
-    learner_parameters["learner_model_param"] = mparam_.ToJson();
+    learner_parameters["learner_model_param"] = this->SaveModelState();
     learner_parameters["gradient_booster"] = Object();
     auto& gradient_booster = learner_parameters["gradient_booster"];
     gbm_->SaveConfig(&gradient_booster);
@@ -670,7 +649,7 @@ class LearnerConfiguration : public Intercept {
     learner_parameters["generic_param"] = ctx_.ToJson();
   }
 
-  uint32_t GetNumFeature() const override { return learner_model_param_.num_feature; }
+  uint32_t GetNumFeature() const override { return model_state_.num_feature; }
 
   void SetAttr(const std::string& key, const std::string& value) override {
     attributes_[key] = value;
@@ -744,34 +723,6 @@ class LearnerConfiguration : public Intercept {
     }
   }
 
-  void ConfigureNumFeatures() {
-    // Compute number of global features if parameter not already set
-    if (mparam_.num_feature == 0) {
-      // TODO(hcho3): Change num_feature to 64-bit integer
-      unsigned num_feature = 0;
-      for (auto it = cache_data_.begin(); it != cache_data_.end();) {
-        auto matrix = it->lock();
-        if (!matrix) {
-          it = cache_data_.erase(it);
-          continue;
-        }
-        const uint64_t num_col = matrix->Info().num_col_;
-        error::MaxFeatureSize(num_col);
-        num_feature = std::max(num_feature, static_cast<uint32_t>(num_col));
-        ++it;
-      }
-
-      auto rc =
-          collective::Allreduce(&ctx_, linalg::MakeVec(&num_feature, 1), collective::Op::kMax);
-      collective::SafeColl(rc);
-      if (num_feature > mparam_.num_feature) {
-        mparam_.num_feature = num_feature;
-      }
-    }
-    CHECK_NE(mparam_.num_feature, 0)
-        << "0 feature is supplied.  Are you using raw Booster interface?";
-  }
-
   std::set<std::string> ConfigureGBM(LearnerTrainParam const& old, Args const& args) {
     tparam_.booster = CanonicalizeBoosterName(tparam_.booster);
     if (tparam_.booster == "gblinear") {
@@ -780,7 +731,7 @@ class LearnerConfiguration : public Intercept {
     }
     auto old_booster = CanonicalizeBoosterName(old.booster);
     if (gbm_ == nullptr || old_booster != tparam_.booster) {
-      gbm_.reset(GradientBooster::Create(tparam_.booster, &ctx_, &learner_model_param_));
+      gbm_.reset(GradientBooster::Create(tparam_.booster, &ctx_, &model_state_));
     }
     return gbm_->Configure(args);
   }
@@ -805,7 +756,7 @@ class LearnerConfiguration : public Intercept {
     bool has_nc{config.find("num_class") != config.cend()};
     // Inject num_class into configuration.
     // FIXME(jiamingy): Remove the duplicated parameter in softmax
-    config["num_class"] = std::to_string(mparam_.num_class);
+    config["num_class"] = std::to_string(tparam_.num_class);
     auto& args = *p_args;
     args = {config.cbegin(), config.cend()};
     auto used = obj_->Configure(args);
@@ -831,12 +782,6 @@ class LearnerConfiguration : public Intercept {
     }
     return used;
   }
-
-  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) {
-    base_score->SetDevice(this->Ctx()->Device());
-    base_score->Reshape(this->mparam_.OutputLength());
-    UsePtr(obj_)->InitEstimation(info, base_score);
-  }
 };
 
 std::string const LearnerConfiguration::kEvalMetric{"eval_metric"};  // NOLINT
@@ -851,6 +796,7 @@ class LearnerIO : public LearnerConfiguration {
  protected:
   void LoadModelImpl(Json const& in) {
     CHECK(IsA<Object>(in));
+    model_state_ = LearnerModelState{};
     auto version = Version::Load(in);
     if (std::get<0>(version) == 1 && std::get<1>(version) < 6) {
       LOG(WARNING)
@@ -859,7 +805,6 @@ class LearnerIO : public LearnerConfiguration {
     }
 
     auto const& learner = get<Object>(in["learner"]);
-    mparam_.FromJson(learner.at("learner_model_param"));
 
     auto const& objective_fn = learner.at("objective");
 
@@ -868,11 +813,12 @@ class LearnerIO : public LearnerConfiguration {
     obj_.reset(ObjFunction::Create(name, &ctx_));
     obj_->LoadConfig(objective_fn);
 
+    this->LoadModelState(learner.at("learner_model_param"));
     auto const& gradient_booster = learner.at("gradient_booster");
     name = get<String>(gradient_booster["name"]);
     tparam_.UpdateAllowUnknown(Args{{"booster", name}});
     tparam_.booster = CanonicalizeBoosterName(tparam_.booster);
-    gbm_.reset(GradientBooster::Create(tparam_.booster, &ctx_, &learner_model_param_));
+    gbm_.reset(GradientBooster::Create(tparam_.booster, &ctx_, &model_state_));
     gbm_->LoadModel(gradient_booster);
 
     auto const& j_attributes = get<Object const>(learner.at("attributes"));
@@ -907,17 +853,15 @@ class LearnerIO : public LearnerConfiguration {
     this->Configure();
   }
 
-  void SaveModel(Json* p_out) const override {
-    CHECK(!this->need_configuration_) << "Call Configure before saving model.";
-    this->CheckModelInitialized();
-
+ private:
+  void SaveModelUnchecked(Json* p_out) const {
     Version::Save(p_out);
     Json& out{*p_out};
 
     out["learner"] = Object();
     auto& learner = out["learner"];
 
-    learner["learner_model_param"] = mparam_.ToJson();
+    learner["learner_model_param"] = this->SaveModelState();
     learner["gradient_booster"] = Object();
     auto& gradient_booster = learner["gradient_booster"];
     gbm_->SaveModel(&gradient_booster);
@@ -943,13 +887,21 @@ class LearnerIO : public LearnerConfiguration {
     }
   }
 
-  void Save(dmlc::Stream* fo) const override {
+ public:
+  void SaveModel(Json* p_out) const override {
+    CHECK(!this->need_configuration_) << "Call Configure before saving model.";
     this->CheckModelInitialized();
+    this->SaveModelUnchecked(p_out);
+  }
 
+  void Save(dmlc::Stream* fo) const override {
+    CHECK(!this->need_configuration_) << "Call Configure before saving model.";
     Json memory_snapshot{Object()};
     memory_snapshot["Model"] = Object();
     auto& model = memory_snapshot["Model"];
-    this->SaveModel(&model);
+    // A memory snapshot preserves pending parameters and metadata for an uninitialized
+    // learner. Unlike a model file, it does not require a fitted model.
+    this->SaveModelUnchecked(&model);
     memory_snapshot["Config"] = Object();
     auto& config = memory_snapshot["Config"];
     this->SaveConfig(&config);
@@ -1011,26 +963,26 @@ class LearnerImpl : public LearnerIO {
     this->Configure();
     this->CheckModelInitialized();
 
-    CHECK_NE(this->learner_model_param_.num_feature, 0);
+    CHECK_NE(this->model_state_.num_feature, 0);
     CHECK_GE(begin, 0);
     auto* out_impl = new LearnerImpl({});
-    out_impl->learner_model_param_.Copy(this->learner_model_param_);
+    out_impl->model_state_.Copy(this->model_state_);
+    out_impl->tparam_ = this->tparam_;
     out_impl->ctx_ = this->ctx_;
-    auto gbm = std::unique_ptr<GradientBooster>(GradientBooster::Create(
-        this->tparam_.booster, &out_impl->ctx_, &out_impl->learner_model_param_));
+    auto gbm = std::unique_ptr<GradientBooster>(
+        GradientBooster::Create(this->tparam_.booster, &out_impl->ctx_, &out_impl->model_state_));
     this->gbm_->Slice(begin, end, step, gbm.get(), out_of_bound);
     out_impl->gbm_ = std::move(gbm);
 
     Json config{Object()};
     this->SaveConfig(&config);
-    out_impl->mparam_ = this->mparam_;
     out_impl->attributes_ = this->attributes_;
     out_impl->SetFeatureNames(this->feature_names_);
     out_impl->SetFeatureTypes(this->feature_types_);
     out_impl->LoadConfig(config);
     out_impl->Configure();
-    CHECK_EQ(out_impl->learner_model_param_.num_feature, this->learner_model_param_.num_feature);
-    CHECK_NE(out_impl->learner_model_param_.num_feature, 0);
+    CHECK_EQ(out_impl->model_state_.num_feature, this->model_state_.num_feature);
+    CHECK_NE(out_impl->model_state_.num_feature, 0);
 
     auto erase_attr = [&](std::string attr) {
       // Erase invalid attributes.
@@ -1070,7 +1022,7 @@ class LearnerImpl : public LearnerIO {
     monitor_.Start("UpdateOneIter");
     TrainingObserver::Instance().Update(iter);
     this->Configure();
-    this->FitIntercept(this->tparam_, train.get());
+    this->InitializeModel(*train, this->cache_data_, InterceptInitialization::kEstimateIntercept);
 
     if (ctx_.seed_per_iteration) {
       ctx_.Rng().seed(ctx_.seed * kRandSeedMagic + this->BoostedRounds());
@@ -1098,6 +1050,7 @@ class LearnerImpl : public LearnerIO {
                     GradientContainer* in_gpair) override {
     this->monitor_.Start(__func__);
     this->Configure();
+    this->InitializeModel(*train, this->cache_data_, InterceptInitialization::kUseDefaultIntercept);
 
     if (ctx_.seed_per_iteration) {
       ctx_.Rng().seed(ctx_.seed * kRandSeedMagic + this->BoostedRounds());
@@ -1105,10 +1058,10 @@ class LearnerImpl : public LearnerIO {
 
     this->ValidateDMatrix(train.get(), true);
     if (in_gpair->HasValueGrad()) {
-      CHECK_EQ(this->learner_model_param_.OutputLength(), in_gpair->NumTargets())
+      CHECK_EQ(this->model_state_.OutputLength(), in_gpair->NumTargets())
           << "Value gradient should have the same number of targets as the overall model.";
     } else {
-      CHECK_EQ(this->learner_model_param_.OutputLength(), in_gpair->NumSplitTargets())
+      CHECK_EQ(this->model_state_.OutputLength(), in_gpair->NumSplitTargets())
           << "The number of columns in gradient should be equal to the number of "
              "targets/classes in the model.";
     }
@@ -1158,7 +1111,8 @@ class LearnerImpl : public LearnerIO {
                                static_cast<int>(pred_contribs);
     this->Configure();
     if (training) {
-      this->FitIntercept(this->tparam_, nullptr);
+      this->InitializeModel(*data, this->cache_data_,
+                            InterceptInitialization::kUseDefaultIntercept);
     }
     this->CheckModelInitialized();
 
@@ -1184,7 +1138,7 @@ class LearnerImpl : public LearnerIO {
   int32_t BoostedRounds() const override {
     if (!this->gbm_) {
       return 0;
-    }  // haven't call train or LoadModel.
+    }  // haven't called train or LoadModel.
     CHECK(!this->need_configuration_);
     return this->gbm_->BoostedRounds();
   }
@@ -1192,7 +1146,7 @@ class LearnerImpl : public LearnerIO {
   uint32_t Groups() const override {
     CHECK(!this->need_configuration_);
     this->CheckModelInitialized();
-    return this->learner_model_param_.num_output_group;
+    return this->model_state_.num_output_group;
   }
 
   XGBAPIThreadLocalEntry& GetThreadLocal() const override {
@@ -1250,11 +1204,11 @@ class LearnerImpl : public LearnerIO {
     info.Validate(ctx_.Device());
 
     if (is_training) {
-      CHECK_EQ(learner_model_param_.num_feature, p_fmat->Info().num_col_)
+      CHECK_EQ(model_state_.num_feature, p_fmat->Info().num_col_)
           << "Number of columns does not match number of features in "
              "booster.";
     } else {
-      CHECK_GE(learner_model_param_.num_feature, p_fmat->Info().num_col_)
+      CHECK_GE(model_state_.num_feature, p_fmat->Info().num_col_)
           << "Number of columns does not match number of features in "
              "booster.";
     }
@@ -1263,14 +1217,14 @@ class LearnerImpl : public LearnerIO {
       error::WarnEmptyDataset();
     }
     if (!p_fmat->Info().base_margin_.Empty()) {
-      CHECK_EQ(p_fmat->Info().base_margin_.Shape(1), this->mparam_.OutputLength());
+      CHECK_EQ(p_fmat->Info().base_margin_.Shape(1), this->model_state_.OutputLength());
     }
   }
 
  private:
   void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info, std::int32_t iter,
                    linalg::Matrix<GradientPair>* out_gpair) {
-    out_gpair->Reshape(info.num_row_, this->learner_model_param_.OutputLength());
+    out_gpair->Reshape(info.num_row_, this->model_state_.OutputLength());
     obj_->GetGradient(preds, info, iter, out_gpair);
   }
 

--- a/src/linear/coordinate_common.h
+++ b/src/linear/coordinate_common.h
@@ -268,7 +268,7 @@ class CyclicFeatureSelector : public FeatureSelector {
   using FeatureSelector::FeatureSelector;
   int NextFeature(Context const *, int iteration, const gbm::GBLinearModel &model, int,
                   const std::vector<GradientPair> &, DMatrix *, float, float) override {
-    return iteration % model.learner_model_param->num_feature;
+    return iteration % model.learner_model_state->num_feature;
   }
 };
 
@@ -282,7 +282,7 @@ class ShuffleFeatureSelector : public FeatureSelector {
   void Setup(Context const *ctx, const gbm::GBLinearModel &model, const std::vector<GradientPair> &,
              DMatrix *, float, float, int) override {
     if (feat_index_.size() == 0) {
-      feat_index_.resize(model.learner_model_param->num_feature);
+      feat_index_.resize(model.learner_model_state->num_feature);
       std::iota(feat_index_.begin(), feat_index_.end(), 0);
     }
     std::shuffle(feat_index_.begin(), feat_index_.end(), ctx->Rng());
@@ -290,7 +290,7 @@ class ShuffleFeatureSelector : public FeatureSelector {
 
   int NextFeature(Context const *, int iteration, const gbm::GBLinearModel &model, int,
                   const std::vector<GradientPair> &, DMatrix *, float, float) override {
-    return feat_index_[iteration % model.learner_model_param->num_feature];
+    return feat_index_[iteration % model.learner_model_state->num_feature];
   }
 
  protected:
@@ -306,7 +306,7 @@ class RandomFeatureSelector : public FeatureSelector {
   using FeatureSelector::FeatureSelector;
   int NextFeature(Context const *ctx, int, const gbm::GBLinearModel &model, int,
                   const std::vector<GradientPair> &, DMatrix *, float, float) override {
-    return ctx->Rng()() % model.learner_model_param->num_feature;
+    return ctx->Rng()() % model.learner_model_state->num_feature;
   }
 };
 
@@ -325,11 +325,11 @@ class GreedyFeatureSelector : public FeatureSelector {
   void Setup(Context const *, const gbm::GBLinearModel &model, const std::vector<GradientPair> &,
              DMatrix *, float, float, int param) override {
     top_k_ = static_cast<bst_uint>(param);
-    const bst_uint ngroup = model.learner_model_param->num_output_group;
+    const bst_uint ngroup = model.learner_model_state->num_output_group;
     if (param <= 0) top_k_ = std::numeric_limits<bst_uint>::max();
     if (counter_.size() == 0) {
       counter_.resize(ngroup);
-      gpair_sums_.resize(model.learner_model_param->num_feature * ngroup);
+      gpair_sums_.resize(model.learner_model_state->num_feature * ngroup);
     }
     for (bst_uint gid = 0u; gid < ngroup; ++gid) {
       counter_[gid] = 0u;
@@ -342,10 +342,10 @@ class GreedyFeatureSelector : public FeatureSelector {
     // k-th selected feature for a group
     auto k = counter_[group_idx]++;
     // stop after either reaching top-K or going through all the features in a group
-    if (k >= top_k_ || counter_[group_idx] == model.learner_model_param->num_feature) return -1;
+    if (k >= top_k_ || counter_[group_idx] == model.learner_model_state->num_feature) return -1;
 
-    const int ngroup = model.learner_model_param->num_output_group;
-    const bst_omp_uint nfeat = model.learner_model_param->num_feature;
+    const int ngroup = model.learner_model_state->num_output_group;
+    const bst_omp_uint nfeat = model.learner_model_state->num_feature;
     // Calculate univariate gradient sums
     std::fill(gpair_sums_.begin(), gpair_sums_.end(), std::make_pair(0., 0.));
     for (const auto &batch : p_fmat->GetBatches<CSCPage>(ctx)) {
@@ -404,8 +404,8 @@ class ThriftyFeatureSelector : public FeatureSelector {
              int param) override {
     top_k_ = static_cast<bst_uint>(param);
     if (param <= 0) top_k_ = std::numeric_limits<bst_uint>::max();
-    const bst_uint ngroup = model.learner_model_param->num_output_group;
-    const bst_omp_uint nfeat = model.learner_model_param->num_feature;
+    const bst_uint ngroup = model.learner_model_state->num_output_group;
+    const bst_omp_uint nfeat = model.learner_model_state->num_feature;
 
     if (deltaw_.size() == 0) {
       deltaw_.resize(nfeat * ngroup);
@@ -459,9 +459,9 @@ class ThriftyFeatureSelector : public FeatureSelector {
     // k-th selected feature for a group
     auto k = counter_[group_idx]++;
     // stop after either reaching top-N or going through all the features in a group
-    if (k >= top_k_ || counter_[group_idx] == model.learner_model_param->num_feature) return -1;
+    if (k >= top_k_ || counter_[group_idx] == model.learner_model_state->num_feature) return -1;
     // note that sorted_idx stores the "long" indices
-    const size_t grp_offset = group_idx * model.learner_model_param->num_feature;
+    const size_t grp_offset = group_idx * model.learner_model_state->num_feature;
     return static_cast<int>(sorted_idx_[grp_offset + k] - grp_offset);
   }
 

--- a/src/linear/updater_coordinate.cc
+++ b/src/linear/updater_coordinate.cc
@@ -50,7 +50,7 @@ class CoordinateUpdater : public LinearUpdater {
               double sum_instance_weight) override {
     auto gpair = in_gpair->Data();
     tparam_.DenormalizePenalties(sum_instance_weight);
-    auto ngroup = model->learner_model_param->num_output_group;
+    auto ngroup = model->learner_model_state->num_output_group;
     // update bias
     for (decltype(ngroup) group_idx = 0; group_idx < ngroup; ++group_idx) {
       auto grad = GetBiasGradientParallel(group_idx, ngroup, gpair->ConstHostVector(), p_fmat,
@@ -65,7 +65,7 @@ class CoordinateUpdater : public LinearUpdater {
                      tparam_.reg_lambda_denorm, cparam_.top_k);
     // update weights
     for (decltype(ngroup) group_idx = 0; group_idx < ngroup; ++group_idx) {
-      for (unsigned i = 0U; i < model->learner_model_param->num_feature; i++) {
+      for (unsigned i = 0U; i < model->learner_model_state->num_feature; i++) {
         int fidx =
             selector_->NextFeature(ctx_, i, *model, group_idx, gpair->ConstHostVector(), p_fmat,
                                    tparam_.reg_alpha_denorm, tparam_.reg_lambda_denorm);
@@ -78,7 +78,7 @@ class CoordinateUpdater : public LinearUpdater {
 
   void UpdateFeature(int fidx, int group_idx, std::vector<GradientPair> *in_gpair, DMatrix *p_fmat,
                      gbm::GBLinearModel *model) {
-    const int ngroup = model->learner_model_param->num_output_group;
+    const int ngroup = model->learner_model_state->num_output_group;
     bst_float &w = (*model)[fidx][group_idx];
     auto gradient = GetGradientParallel(ctx_, group_idx, ngroup, fidx, *in_gpair, p_fmat);
     auto dw =

--- a/src/linear/updater_gpu_coordinate.cu
+++ b/src/linear/updater_gpu_coordinate.cu
@@ -48,7 +48,7 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     out["coordinate_param"] = ToJson(coord_param_);
   }
 
-  void LazyInitDevice(DMatrix *p_fmat, const LearnerModelParam &model_param) {
+  void LazyInitDevice(DMatrix *p_fmat, const LearnerModelState &model_param) {
     if (ctx_->IsCPU()) return;
 
     num_row_ = static_cast<size_t>(p_fmat->Info().num_row_);
@@ -93,7 +93,7 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
               double sum_instance_weight) override {
     tparam_.DenormalizePenalties(sum_instance_weight);
     monitor_.Start("LazyInitDevice");
-    this->LazyInitDevice(p_fmat, *(model->learner_model_param));
+    this->LazyInitDevice(p_fmat, *(model->learner_model_state));
     monitor_.Stop("LazyInitDevice");
 
     monitor_.Start("UpdateGpair");
@@ -111,9 +111,9 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     selector_->Setup(ctx_, *model, in_gpair->Data()->ConstHostVector(), p_fmat,
                      tparam_.reg_alpha_denorm, tparam_.reg_lambda_denorm, coord_param_.top_k);
     monitor_.Start("UpdateFeature");
-    for (uint32_t group_idx = 0; group_idx < model->learner_model_param->num_output_group;
+    for (uint32_t group_idx = 0; group_idx < model->learner_model_state->num_output_group;
          ++group_idx) {
-      for (auto i = 0U; i < model->learner_model_param->num_feature; i++) {
+      for (auto i = 0U; i < model->learner_model_state->num_feature; i++) {
         auto fidx =
             selector_->NextFeature(ctx_, i, *model, group_idx, in_gpair->Data()->ConstHostVector(),
                                    p_fmat, tparam_.reg_alpha_denorm, tparam_.reg_lambda_denorm);
@@ -125,12 +125,12 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
   }
 
   void UpdateBias(gbm::GBLinearModel *model) {
-    for (uint32_t group_idx = 0; group_idx < model->learner_model_param->num_output_group;
+    for (uint32_t group_idx = 0; group_idx < model->learner_model_state->num_output_group;
          ++group_idx) {
       // Get gradient
       auto grad = GradientPair(0, 0);
       if (ctx_->IsCUDA()) {
-        grad = GetBiasGradient(group_idx, model->learner_model_param->num_output_group);
+        grad = GetBiasGradient(group_idx, model->learner_model_state->num_output_group);
       }
       auto dbias = static_cast<float>(tparam_.learning_rate *
                                       CoordinateDeltaBias(grad.GetGrad(), grad.GetHess()));
@@ -138,7 +138,7 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
 
       // Update residual
       if (ctx_->IsCUDA()) {
-        UpdateBiasResidual(dbias, group_idx, model->learner_model_param->num_output_group);
+        UpdateBiasResidual(dbias, group_idx, model->learner_model_state->num_output_group);
       }
     }
   }
@@ -148,7 +148,7 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     // Get gradient
     auto grad = GradientPair(0, 0);
     if (ctx_->IsCUDA()) {
-      grad = GetGradient(group_idx, model->learner_model_param->num_output_group, fidx);
+      grad = GetGradient(group_idx, model->learner_model_state->num_output_group, fidx);
     }
     auto dw =
         static_cast<float>(tparam_.learning_rate * CoordinateDelta(grad.GetGrad(), grad.GetHess(),
@@ -157,7 +157,7 @@ class GPUCoordinateUpdater : public LinearUpdater {  // NOLINT
     w += dw;
 
     if (ctx_->IsCUDA()) {
-      UpdateResidual(dw, group_idx, model->learner_model_param->num_output_group, fidx);
+      UpdateResidual(dw, group_idx, model->learner_model_state->num_output_group, fidx);
     }
   }
 

--- a/src/linear/updater_shotgun.cc
+++ b/src/linear/updater_shotgun.cc
@@ -36,7 +36,7 @@ class ShotgunUpdater : public LinearUpdater {
               double sum_instance_weight) override {
     auto gpair = in_gpair->Data();
     param_.DenormalizePenalties(sum_instance_weight);
-    const int ngroup = model->learner_model_param->num_output_group;
+    const int ngroup = model->learner_model_state->num_output_group;
 
     // update bias
     for (int gid = 0; gid < ngroup; ++gid) {

--- a/src/predictor/cpu_predictor.cc
+++ b/src/predictor/cpu_predictor.cc
@@ -33,7 +33,7 @@
 #include "xgboost/context.h"        // for Context
 #include "xgboost/data.h"           // for Entry, DMatrix, MetaInfo, SparsePage, Batch...
 #include "xgboost/host_device_vector.h"       // for HostDeviceVector
-#include "xgboost/learner.h"                  // for LearnerModelParam
+#include "xgboost/learner.h"                  // for LearnerModelState
 #include "xgboost/linalg.h"                   // for TensorView, All, VectorView, Tensor
 #include "xgboost/logging.h"                  // for LogCheck_EQ, CHECK_EQ, CHECK, LogCheck_NE
 #include "xgboost/multi_target_tree_model.h"  // for MultiTargetTree
@@ -435,7 +435,7 @@ class CPUPredictor : public Predictor {
     auto const n_threads = this->ctx_->Threads();
 
     // Create a writable view on the output prediction vector.
-    bst_idx_t n_groups = model.learner_model_param->OutputLength();
+    bst_idx_t n_groups = model.learner_model_state->OutputLength();
     bst_idx_t n_samples = p_fmat->Info().num_row_;
     CHECK_EQ(out_preds->size(), n_samples * n_groups);
     auto out_predt = linalg::MakeTensorView(ctx_, *out_preds, n_samples, n_groups);
@@ -489,7 +489,7 @@ class CPUPredictor : public Predictor {
     auto const n_threads = this->ctx_->Threads();
     // Always use block as we don't know the nnz.
     ThreadTmp<BlockPolicy::kBlockOfRowsSize> feat_vecs{n_threads};
-    bst_idx_t n_groups = model.learner_model_param->OutputLength();
+    bst_idx_t n_groups = model.learner_model_state->OutputLength();
     auto const h_model =
         HostModel{DeviceOrd::CPU(), model, false, tree_begin, tree_end, CopyViews{}};
     auto const *tree_weights = model.TreeWeights();
@@ -505,7 +505,7 @@ class CPUPredictor : public Predictor {
     };
     auto dispatch = [&](auto x) {
       using AdapterT = typename decltype(x)::element_type;
-      CheckProxyDMatrix(x, proxy, model.learner_model_param);
+      CheckProxyDMatrix(x, proxy, model.learner_model_state);
       LaunchPredict(
           this->ctx_, proxy, model,
           [&](auto &&policy) {
@@ -541,7 +541,7 @@ class CPUPredictor : public Predictor {
     std::vector<float> &preds = out_preds->HostVector();
     preds.resize(info.num_row_ * ntree_limit);
 
-    auto n_features = model.learner_model_param->num_feature;
+    auto n_features = model.learner_model_state->num_feature;
     ThreadTmp<1> feat_vecs{n_threads};
 
     auto const h_model = HostModel{DeviceOrd::CPU(), model, false, 0, ntree_limit, CopyViews{}};

--- a/src/predictor/gbtree_view.h
+++ b/src/predictor/gbtree_view.h
@@ -41,8 +41,8 @@ class GBTreeModelView {
                            bst_tree_t tree_begin, bst_tree_t tree_end, CopyViews&& copy)
       : tree_begin{tree_begin},
         tree_end{tree_end},
-        n_groups{model.learner_model_param->OutputLength()},
-        n_features{model.learner_model_param->num_feature} {
+        n_groups{model.learner_model_state->OutputLength()},
+        n_features{model.learner_model_state->num_feature} {
     // Make sure the trees are pulled to target device without race.
     std::lock_guard guard{model.Mutex()};
     // Create tree views.

--- a/src/predictor/gpu_predictor.cu
+++ b/src/predictor/gpu_predictor.cu
@@ -380,22 +380,22 @@ void LaunchPredict(Context const* ctx, bool is_dense, enc::DeviceColumnsView con
     if (model.Cats() && model.Cats()->HasCategorical() && new_enc.HasCategorical()) {
       auto [acc, mapping] = MakeCatAccessor(ctx, new_enc, model.Cats());
       auto cfg =
-          LaunchConfig<std::true_type, decltype(acc)>{ctx, model.learner_model_param->num_feature};
+          LaunchConfig<std::true_type, decltype(acc)>{ctx, model.learner_model_state->num_feature};
       launch(std::move(cfg), std::move(acc));
     } else {
       auto cfg =
-          LaunchConfig<std::true_type, NoOpAccessor>{ctx, model.learner_model_param->num_feature};
+          LaunchConfig<std::true_type, NoOpAccessor>{ctx, model.learner_model_state->num_feature};
       launch(std::move(cfg), NoOpAccessor{});
     }
   } else {
     if (model.Cats() && model.Cats()->HasCategorical() && new_enc.HasCategorical()) {
       auto [acc, mapping] = MakeCatAccessor(ctx, new_enc, model.Cats());
       auto cfg =
-          LaunchConfig<std::false_type, decltype(acc)>{ctx, model.learner_model_param->num_feature};
+          LaunchConfig<std::false_type, decltype(acc)>{ctx, model.learner_model_state->num_feature};
       launch(std::move(cfg), std::move(acc));
     } else {
       auto cfg =
-          LaunchConfig<std::false_type, NoOpAccessor>{ctx, model.learner_model_param->num_feature};
+          LaunchConfig<std::false_type, NoOpAccessor>{ctx, model.learner_model_state->num_feature};
       launch(std::move(cfg), NoOpAccessor{});
     }
   }
@@ -417,8 +417,8 @@ class GPUPredictor : public xgboost::Predictor {
     DeviceModel d_model{this->ctx_->Device(), model,    false,
                         tree_begin,           tree_end, CopyViews{this->ctx_}};
 
-    CHECK_LE(p_fmat->Info().num_col_, model.learner_model_param->num_feature);
-    auto n_features = model.learner_model_param->num_feature;
+    CHECK_LE(p_fmat->Info().num_col_, model.learner_model_state->num_feature);
+    auto n_features = model.learner_model_state->num_feature;
 
     auto new_enc =
         p_fmat->Cats()->NeedRecode() ? p_fmat->Cats()->DeviceView(ctx_) : enc::DeviceColumnsView{};
@@ -430,7 +430,7 @@ class GPUPredictor : public xgboost::Predictor {
         cfg.template LaunchPredictKernel<Loader>(
             std::move(batch), std::numeric_limits<float>::quiet_NaN(), n_features, d_model, acc,
             batch_offset, out_preds, tree_weights);
-        batch_offset += n_rows * model.learner_model_param->OutputLength();
+        batch_offset += n_rows * model.learner_model_state->OutputLength();
       });
     });
   }
@@ -477,7 +477,7 @@ class GPUPredictor : public xgboost::Predictor {
     out_preds->SetDevice(m->Device());
     using BatchT = common::GetValueT<decltype(std::declval<Adapter>().Value())>;
 
-    auto n_features = model.learner_model_param->num_feature;
+    auto n_features = model.learner_model_state->num_feature;
 
     DeviceModel d_model{ctx_->Device(), model, false, tree_begin, tree_end, CopyViews{this->ctx_}};
 
@@ -531,7 +531,7 @@ class GPUPredictor : public xgboost::Predictor {
     data::cuda_impl::DispatchAny<false>(
         proxy,
         [&](auto x) {
-          CheckProxyDMatrix(x, proxy, model.learner_model_param);
+          CheckProxyDMatrix(x, proxy, model.learner_model_state);
           this->DispatchedInplacePredict(x, p_m, model, missing, out_preds, tree_begin, tree_end,
                                          pred_weights);
         },
@@ -578,7 +578,7 @@ class GPUPredictor : public xgboost::Predictor {
 
     DeviceModel d_model{ctx_->Device(), model, false, 0, tree_end, CopyViews{this->ctx_}};
 
-    bst_feature_t n_features = model.learner_model_param->num_feature;
+    bst_feature_t n_features = model.learner_model_state->num_feature;
     auto new_enc =
         p_fmat->Cats()->NeedRecode() ? p_fmat->Cats()->DeviceView(ctx_) : enc::DeviceColumnsView{};
 

--- a/src/predictor/interpretability/shap.cc
+++ b/src/predictor/interpretability/shap.cc
@@ -441,7 +441,7 @@ QuadratureTreeShapModelData MakeQuadratureTreeShapModelData(
     gbm::GBTreeModel const &model, bst_tree_t tree_end, std::vector<float> const *tree_weights) {
   auto const n_trees = static_cast<std::size_t>(tree_end);
   auto const h_tree_groups = model.TreeGroups(DeviceOrd::CPU());
-  auto const n_groups = model.learner_model_param->num_output_group;
+  auto const n_groups = model.learner_model_state->num_output_group;
 
   QuadratureTreeShapModelData out;
   out.trees.reserve(n_trees);
@@ -560,15 +560,15 @@ void QuadratureTreeShapValues(Context const *ctx, DMatrix *p_fmat,
   CHECK_GE(tree_end, 0);
   ValidateTreeWeights(tree_weights, tree_end);
   auto const n_threads = ctx->Threads();
-  auto const n_groups = model.learner_model_param->num_output_group;
-  auto const n_features = model.learner_model_param->num_feature;
-  size_t const ncolumns = model.learner_model_param->num_feature + 1;
+  auto const n_groups = model.learner_model_state->num_output_group;
+  auto const n_features = model.learner_model_state->num_feature;
+  size_t const ncolumns = model.learner_model_state->num_feature + 1;
   std::vector<bst_float> &contribs = out_contribs->HostVector();
-  contribs.resize(info.num_row_ * ncolumns * model.learner_model_param->num_output_group);
+  contribs.resize(info.num_row_ * ncolumns * model.learner_model_state->num_output_group);
   std::fill(contribs.begin(), contribs.end(), 0.0f);
   CHECK_NE(n_groups, 0);
   auto const &rule = detail::GetQuadratureRule();
-  auto const base_score = model.learner_model_param->BaseScore(DeviceOrd::CPU());
+  auto const base_score = model.learner_model_state->BaseScore(DeviceOrd::CPU());
   auto model_data = MakeQuadratureTreeShapModelData(model, tree_end, tree_weights);
   std::vector<RegTree::FVec> feats_tloc(n_threads);
   std::vector<std::vector<float>> contribs_tloc(n_threads, std::vector<float>(ncolumns));
@@ -583,7 +583,7 @@ void QuadratureTreeShapValues(Context const *ctx, DMatrix *p_fmat,
       auto tid = omp_get_thread_num();
       auto &feats = feats_tloc[tid];
       if (feats.Size() == 0) {
-        feats.Init(model.learner_model_param->num_feature);
+        feats.Init(model.learner_model_state->num_feature);
       }
       auto &this_tree_contribs = contribs_tloc[tid];
       auto &path_prob = path_prob_tloc[tid];
@@ -639,8 +639,8 @@ void QuadratureTreeShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
   ValidateTreeWeights(tree_weights, tree_end);
 
   auto const n_threads = ctx->Threads();
-  auto const n_groups = model.learner_model_param->num_output_group;
-  auto const n_features = model.learner_model_param->num_feature;
+  auto const n_groups = model.learner_model_state->num_output_group;
+  auto const n_features = model.learner_model_state->num_feature;
   auto const ncolumns = n_features + 1;
   auto const row_chunk = n_groups * ncolumns * ncolumns;
   auto const matrix_chunk = ncolumns * ncolumns;
@@ -650,7 +650,7 @@ void QuadratureTreeShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
   std::fill(contribs.begin(), contribs.end(), 0.0f);
 
   auto const &rule = detail::GetQuadratureRule();
-  auto const base_score = model.learner_model_param->BaseScore(DeviceOrd::CPU());
+  auto const base_score = model.learner_model_state->BaseScore(DeviceOrd::CPU());
   auto model_data = MakeQuadratureTreeShapModelData(model, tree_end, tree_weights);
   std::vector<RegTree::FVec> feats_tloc(n_threads);
   std::vector<std::vector<QuadraturePathElement>> path_tloc(n_threads);
@@ -666,7 +666,7 @@ void QuadratureTreeShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
       auto tid = omp_get_thread_num();
       auto &feats = feats_tloc[tid];
       if (feats.Size() == 0) {
-        feats.Init(model.learner_model_param->num_feature);
+        feats.Init(model.learner_model_state->num_feature);
       }
       auto &path = path_tloc[tid];
       auto &path_prob = path_prob_tloc[tid];
@@ -741,9 +741,9 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
   ValidateTreeWeights(tree_weights, tree_end);
   auto const n_trees = static_cast<std::size_t>(tree_end);
   auto const n_threads = ctx->Threads();
-  size_t const ncolumns = model.learner_model_param->num_feature + 1;
+  size_t const ncolumns = model.learner_model_state->num_feature + 1;
   std::vector<bst_float> &contribs = out_contribs->HostVector();
-  contribs.resize(info.num_row_ * ncolumns * model.learner_model_param->num_output_group);
+  contribs.resize(info.num_row_ * ncolumns * model.learner_model_state->num_output_group);
   std::fill(contribs.begin(), contribs.end(), 0);
   std::vector<std::vector<float>> mean_values(n_trees);
   std::atomic<bool> is_vector_leaf = false;
@@ -758,9 +758,9 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
     LOG(FATAL) << "Approximate predict contribution " << MTNotImplemented();
   }
 
-  auto const n_groups = model.learner_model_param->num_output_group;
+  auto const n_groups = model.learner_model_state->num_output_group;
   CHECK_NE(n_groups, 0);
-  auto const base_score = model.learner_model_param->BaseScore(DeviceOrd::CPU());
+  auto const base_score = model.learner_model_state->BaseScore(DeviceOrd::CPU());
   auto const h_tree_groups = model.TreeGroups(DeviceOrd::CPU());
   std::vector<RegTree::FVec> feats_tloc(n_threads);
   std::vector<std::vector<float>> contribs_tloc(n_threads, std::vector<float>(ncolumns));
@@ -773,7 +773,7 @@ void ApproxFeatureImportance(Context const *ctx, DMatrix *p_fmat,
       auto tid = omp_get_thread_num();
       auto &feats = feats_tloc[tid];
       if (feats.Size() == 0) {
-        feats.Init(model.learner_model_param->num_feature);
+        feats.Init(model.learner_model_state->num_feature);
       }
       auto &this_tree_contribs = contribs_tloc[tid];
       auto row_idx = view.base_rowid + i;
@@ -817,11 +817,11 @@ void ShapInteractionValues(Context const *ctx, DMatrix *p_fmat,
                                         kQuadratureTreeShapPoints);
     return;
   }
-  CHECK(!model.learner_model_param->IsVectorLeaf())
+  CHECK(!model.learner_model_state->IsVectorLeaf())
       << "Predict interaction contribution" << MTNotImplemented();
   MetaInfo const &info = p_fmat->Info();
-  auto const ngroup = model.learner_model_param->num_output_group;
-  auto const ncolumns = model.learner_model_param->num_feature;
+  auto const ngroup = model.learner_model_state->num_output_group;
+  auto const ncolumns = model.learner_model_state->num_feature;
   const std::size_t row_chunk = ngroup * (ncolumns + 1) * (ncolumns + 1);
   const std::size_t mrow_chunk = (ncolumns + 1) * (ncolumns + 1);
   const std::size_t crow_chunk = ngroup * (ncolumns + 1);

--- a/src/predictor/interpretability/shap.cu
+++ b/src/predictor/interpretability/shap.cu
@@ -1196,7 +1196,7 @@ void DispatchByBatchLoader(Context const* ctx, DMatrix* p_fmat, bst_feature_t n_
 template <typename Fn>
 void LaunchShap(Context const* ctx, DMatrix* p_fmat, enc::DeviceColumnsView const& new_enc,
                 gbm::GBTreeModel const& model, Fn&& fn) {
-  auto n_features = model.learner_model_param->num_feature;
+  auto n_features = model.learner_model_state->num_feature;
   if (model.Cats() && model.Cats()->HasCategorical() && new_enc.HasCategorical()) {
     auto [acc, mapping] = ::xgboost::cuda_impl::MakeCatAccessor(ctx, new_enc, model.Cats());
     DispatchByBatchLoader(ctx, p_fmat, n_features, std::move(acc), fn);
@@ -1216,9 +1216,9 @@ void ShapValues(Context const* ctx, DMatrix* p_fmat, HostDeviceVector<float>* ou
   CHECK_EQ(condition_feature, 0) << "GPU QuadratureTreeSHAP does not support conditional SHAP.";
 
   tree_end = predictor::GetTreeLimit(model.trees, tree_end);
-  auto const ngroup = model.learner_model_param->num_output_group;
+  auto const ngroup = model.learner_model_state->num_output_group;
   CHECK_NE(ngroup, 0);
-  auto const ncolumns = model.learner_model_param->num_feature + 1;
+  auto const ncolumns = model.learner_model_state->num_feature + 1;
   auto dim_size = ncolumns * ngroup;
   out_contribs->SetDevice(ctx->Device());
   out_contribs->Resize(p_fmat->Info().num_row_ * dim_size);
@@ -1244,7 +1244,7 @@ void ShapValues(Context const* ctx, DMatrix* p_fmat, HostDeviceVector<float>* ou
 
   p_fmat->Info().base_margin_.SetDevice(ctx->Device());
   auto margin = p_fmat->Info().base_margin_.Data()->ConstDeviceSpan();
-  auto base_score = model.learner_model_param->BaseScore(ctx);
+  auto base_score = model.learner_model_state->BaseScore(ctx);
   auto phis = out_contribs->DeviceSpan();
   auto n_samples = p_fmat->Info().num_row_;
   dh::LaunchN(n_samples * ngroup, ctx->CUDACtx()->Stream(), [=] __device__(std::size_t idx) {
@@ -1264,9 +1264,9 @@ void ShapInteractionValues(Context const* ctx, DMatrix* p_fmat,
   }
 
   tree_end = predictor::GetTreeLimit(model.trees, tree_end);
-  auto const ngroup = model.learner_model_param->num_output_group;
+  auto const ngroup = model.learner_model_state->num_output_group;
   CHECK_NE(ngroup, 0);
-  auto const ncolumns = model.learner_model_param->num_feature + 1;
+  auto const ncolumns = model.learner_model_state->num_feature + 1;
   auto dim_size = ncolumns * ncolumns * ngroup;
   out_contribs->SetDevice(ctx->Device());
   out_contribs->Resize(p_fmat->Info().num_row_ * dim_size);
@@ -1293,7 +1293,7 @@ void ShapInteractionValues(Context const* ctx, DMatrix* p_fmat,
 
   p_fmat->Info().base_margin_.SetDevice(ctx->Device());
   auto margin = p_fmat->Info().base_margin_.Data()->ConstDeviceSpan();
-  auto base_score = model.learner_model_param->BaseScore(ctx);
+  auto base_score = model.learner_model_state->BaseScore(ctx);
   auto phis = out_contribs->DeviceSpan();
   auto n_samples = p_fmat->Info().num_row_;
   dh::LaunchN(n_samples * ngroup, ctx->CUDACtx()->Stream(), [=] __device__(std::size_t idx) {

--- a/src/predictor/predictor.cc
+++ b/src/predictor/predictor.cc
@@ -13,7 +13,7 @@
 #include "xgboost/context.h"             // for Context
 #include "xgboost/data.h"                // for MetaInfo
 #include "xgboost/host_device_vector.h"  // for HostDeviceVector
-#include "xgboost/learner.h"             // for LearnerModelParam
+#include "xgboost/learner.h"             // for LearnerModelState
 #include "xgboost/linalg.h"              // for Tensor, TensorView
 #include "xgboost/logging.h"             // for CHECK_EQ, CHECK_NE, LOG
 
@@ -53,34 +53,34 @@ void InitOutPredictions(Context const* ctx, linalg::VectorView<float const> base
 
 void Predictor::InitOutPredictions(const MetaInfo& info, HostDeviceVector<float>* out_preds,
                                    gbm::GBTreeModel const& model) const {
-  CHECK_NE(model.learner_model_param->num_output_group, 0);
+  CHECK_NE(model.learner_model_state->num_output_group, 0);
 
   if (!ctx_->Device().IsCPU()) {
     out_preds->SetDevice(ctx_->Device());
   }
 
   // Cannot rely on the Resize to fill as it might skip if the size is already correct.
-  auto n = static_cast<size_t>(model.learner_model_param->OutputLength() * info.num_row_);
+  auto n = static_cast<size_t>(model.learner_model_state->OutputLength() * info.num_row_);
   out_preds->Resize(n);
 
   HostDeviceVector<float> const* base_margin = info.base_margin_.Data();
   if (!base_margin->Empty()) {
     ValidateBaseMarginShape(info.base_margin_, info.num_row_,
-                            model.learner_model_param->OutputLength());
+                            model.learner_model_state->OutputLength());
     out_preds->Copy(*base_margin);
     return;
   }
 
-  auto base_score = model.learner_model_param->BaseScore(this->ctx_->Device());
+  auto base_score = model.learner_model_state->BaseScore(this->ctx_->Device());
   if (base_score.Size() == 1) {
     // Fill a scalar
-    out_preds->Fill(model.learner_model_param->BaseScore(DeviceOrd::CPU())(0));
+    out_preds->Fill(model.learner_model_state->BaseScore(DeviceOrd::CPU())(0));
     return;
   }
 
   // Handle multi-output models where base_score is a vector.
   auto predt = linalg::MakeTensorView(this->ctx_, out_preds, info.num_row_,
-                                      model.learner_model_param->OutputLength());
+                                      model.learner_model_state->OutputLength());
   CHECK_EQ(predt.Size(), out_preds->Size());
 
   if (this->ctx_->IsCUDA()) {

--- a/src/predictor/utils.h
+++ b/src/predictor/utils.h
@@ -6,12 +6,12 @@
 
 #include "../data/proxy_dmatrix.h"  // for DMatrixProxy
 #include "xgboost/data.h"           // for DMatrix
-#include "xgboost/learner.h"        // LearnerModelParam
+#include "xgboost/learner.h"        // LearnerModelState
 
 namespace xgboost::predictor {
 template <typename Adapter>
 void CheckProxyDMatrix(std::shared_ptr<Adapter> m, data::DMatrixProxy const* proxy,
-                       LearnerModelParam const* p) {
+                       LearnerModelState const* p) {
   CHECK(proxy);
   auto n_features_data = m->NumColumns();
   auto n_features_model = p->num_feature;

--- a/tests/cpp/gbm/test_gblinear.cc
+++ b/tests/cpp/gbm/test_gblinear.cc
@@ -17,11 +17,11 @@ TEST(GBLinear, JsonIO) {
   size_t constexpr kRows = 16, kCols = 16;
 
   Context ctx;
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> gbm{
       CreateTrainedGBM("gblinear", Args{}, kRows, kCols, &mparam, &ctx)};
-  Json model { Object() };
+  Json model{Object()};
   gbm->SaveModel(&model);
   ASSERT_TRUE(IsA<Object>(model));
 
@@ -41,7 +41,7 @@ TEST(GBLinear, JsonIO) {
 TEST(GBLinear, Dump) {
   Context ctx;
   size_t constexpr kRows = 16, kCols = 16;
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> gbm{
       CreateTrainedGBM("gblinear", Args{}, kRows, kCols, &mparam, &ctx)};

--- a/tests/cpp/gbm/test_gbtree.cc
+++ b/tests/cpp/gbm/test_gbtree.cc
@@ -25,7 +25,7 @@ TEST(GBTree, SelectTreeMethod) {
   size_t constexpr kCols = 10;
 
   Context ctx;
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> p_gbm{GradientBooster::Create("gbtree", &ctx, &mparam)};
   auto& gbtree = dynamic_cast<gbm::GBTree&>(*p_gbm);
@@ -57,7 +57,7 @@ TEST(GBTree, SelectTreeMethod) {
 TEST(GBTree, PredictionCache) {
   size_t constexpr kRows = 100, kCols = 10;
   Context ctx;
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> p_gbm{GradientBooster::Create("gbtree", &ctx, &mparam)};
   auto& gbtree = dynamic_cast<gbm::GBTree&>(*p_gbm);
@@ -102,7 +102,7 @@ TEST(GBTree, PredictionCache) {
 TEST(GBTree, PredictionCacheWithBaseMargin) {
   size_t constexpr kRows = 16, kCols = 4;
   Context ctx;
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> p_gbm{GradientBooster::Create("gbtree", &ctx, &mparam)};
   auto& gbtree = dynamic_cast<gbm::GBTree&>(*p_gbm);
@@ -313,7 +313,7 @@ TEST(GBTree, JsonIO) {
   size_t constexpr kRows = 16, kCols = 16;
 
   Context ctx;
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> gbm{
       CreateTrainedGBM("gbtree", Args{{"tree_method", "exact"}, {"default_direction", "left"}},
@@ -367,7 +367,7 @@ TEST(Dart, JsonIO) {
   size_t constexpr kRows = 16, kCols = 16;
 
   Context ctx;
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> gbm{
       CreateTrainedGBM("dart", Args{}, kRows, kCols, &mparam, &ctx)};
@@ -395,7 +395,7 @@ TEST(GBTree, LoadLegacyDartJson) {
   size_t constexpr kRows = 16, kCols = 16;
 
   Context ctx;
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> gbm{
       CreateTrainedGBM("gbtree", Args{{"rate_drop", "0.5"}}, kRows, kCols, &mparam, &ctx)};
@@ -436,7 +436,7 @@ TEST(GBTree, DropoutJsonIO) {
   size_t constexpr kRows = 16, kCols = 16;
 
   Context ctx;
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
 
   std::unique_ptr<GradientBooster> gbm{
       CreateTrainedGBM("gbtree", Args{{"rate_drop", "0.5"}}, kRows, kCols, &mparam, &ctx)};

--- a/tests/cpp/helpers.cc
+++ b/tests/cpp/helpers.cc
@@ -652,7 +652,7 @@ std::shared_ptr<DMatrix> GetDMatrixFromData(const std::vector<float>& x, std::si
 
 std::unique_ptr<GradientBooster> CreateTrainedGBM(std::string name, Args kwargs, size_t kRows,
                                                   size_t kCols,
-                                                  LearnerModelParam const* learner_model_param,
+                                                  LearnerModelState const* learner_model_param,
                                                   Context const* ctx) {
   std::unique_ptr<GradientBooster> gbm{GradientBooster::Create(name, ctx, learner_model_param)};
   gbm->Configure(kwargs);

--- a/tests/cpp/helpers.h
+++ b/tests/cpp/helpers.h
@@ -10,7 +10,7 @@
 #include <xgboost/base.h>
 #include <xgboost/context.h>
 #include <xgboost/json.h>
-#include <xgboost/learner.h>  // for LearnerModelParam
+#include <xgboost/learner.h>  // for LearnerModelState
 #include <xgboost/model.h>    // for Configurable
 
 #include <cstdint>  // std::int32_t
@@ -48,7 +48,7 @@
 namespace xgboost {
 class ObjFunction;
 class Metric;
-struct LearnerModelParam;
+struct LearnerModelState;
 class GradientBooster;
 }  // namespace xgboost
 
@@ -367,7 +367,7 @@ std::shared_ptr<DMatrix> GetDMatrixFromData(const std::vector<float>& x, std::si
 
 std::unique_ptr<GradientBooster> CreateTrainedGBM(std::string name, Args kwargs, size_t kRows,
                                                   size_t kCols,
-                                                  LearnerModelParam const* learner_model_param,
+                                                  LearnerModelState const* learner_model_state,
                                                   Context const* generic_param);
 
 /**
@@ -492,10 +492,10 @@ RMMAllocatorPtr SetUpRMMResourceForCppTests(int argc, char** argv);
 /*
  * \brief Make learner model param
  */
-inline LearnerModelParam MakeMP(bst_feature_t n_features, float base_score, uint32_t n_groups,
+inline LearnerModelState MakeMP(bst_feature_t n_features, float base_score, uint32_t n_groups,
                                 DeviceOrd device = DeviceOrd::CPU()) {
   size_t shape[1]{1};
-  LearnerModelParam mparam(n_features, linalg::Tensor<float, 1>{{base_score}, shape, device},
+  LearnerModelState mparam(n_features, linalg::Tensor<float, 1>{{base_score}, shape, device},
                            n_groups, 1, MultiStrategy::kOneOutputPerTree);
   return mparam;
 }

--- a/tests/cpp/linear/test_linear.cc
+++ b/tests/cpp/linear/test_linear.cc
@@ -1,12 +1,12 @@
 /*!
  * Copyright 2018-2019 by Contributors
  */
-#include <xgboost/linear_updater.h>
 #include <xgboost/gbm.h>
+#include <xgboost/linear_updater.h>
 
+#include "../../../src/gbm/gblinear_model.h"
 #include "../helpers.h"
 #include "test_json_io.h"
-#include "../../../src/gbm/gblinear_model.h"
 #include "xgboost/base.h"
 
 namespace xgboost {
@@ -18,7 +18,7 @@ TEST(Linear, Shotgun) {
   auto p_fmat = xgboost::RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
 
   auto ctx = MakeCUDACtx(GPUIDX);
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
 
   {
     auto updater =
@@ -33,15 +33,13 @@ TEST(Linear, Shotgun) {
     ASSERT_EQ(model.Bias()[0], 5.0f);
   }
   {
-    auto updater = std::unique_ptr<xgboost::LinearUpdater>(
-        xgboost::LinearUpdater::Create("shotgun", &ctx));
+    auto updater =
+        std::unique_ptr<xgboost::LinearUpdater>(xgboost::LinearUpdater::Create("shotgun", &ctx));
     EXPECT_ANY_THROW(updater->Configure({{"feature_selector", "random"}}));
   }
 }
 
-TEST(Shotgun, JsonIO) {
-  TestUpdaterJsonIO("shotgun");
-}
+TEST(Shotgun, JsonIO) { TestUpdaterJsonIO("shotgun"); }
 
 TEST(Linear, coordinate) {
   size_t constexpr kRows = 10;
@@ -50,7 +48,7 @@ TEST(Linear, coordinate) {
   auto p_fmat = xgboost::RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
 
   auto ctx = MakeCUDACtx(GPUIDX);
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
 
   auto updater = std::unique_ptr<xgboost::LinearUpdater>(
       xgboost::LinearUpdater::Create("coord_descent", &ctx));
@@ -64,8 +62,6 @@ TEST(Linear, coordinate) {
   ASSERT_EQ(model.Bias()[0], 5.0f);
 }
 
-TEST(Coordinate, JsonIO){
-  TestUpdaterJsonIO("coord_descent");
-}
+TEST(Coordinate, JsonIO) { TestUpdaterJsonIO("coord_descent"); }
 
 }  // namespace xgboost

--- a/tests/cpp/linear/test_linear.cu
+++ b/tests/cpp/linear/test_linear.cu
@@ -1,12 +1,12 @@
 /**
  * Copyright 2018-2023, XGBoost Contributors
  */
-#include <xgboost/linear_updater.h>
 #include <xgboost/gbm.h>
+#include <xgboost/linear_updater.h>
 
+#include "../../../src/gbm/gblinear_model.h"
 #include "../helpers.h"
 #include "test_json_io.h"
-#include "../../../src/gbm/gblinear_model.h"
 
 namespace xgboost {
 
@@ -17,7 +17,7 @@ TEST(Linear, GPUCoordinate) {
   auto mat = xgboost::RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
   auto ctx = MakeCUDACtx(0);
 
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1)};
   auto updater = std::unique_ptr<xgboost::LinearUpdater>(
       xgboost::LinearUpdater::Create("gpu_coord_descent", &ctx));
   updater->Configure({{"eta", "1."}});
@@ -30,7 +30,5 @@ TEST(Linear, GPUCoordinate) {
   ASSERT_EQ(model.Bias()[0], 5.0f);
 }
 
-TEST(GPUCoordinate, JsonIO) {
-  TestUpdaterJsonIO("gpu_coord_descent");
-}
+TEST(GPUCoordinate, JsonIO) { TestUpdaterJsonIO("gpu_coord_descent"); }
 }  // namespace xgboost

--- a/tests/cpp/predictor/test_cpu_predictor.cc
+++ b/tests/cpp/predictor/test_cpu_predictor.cc
@@ -169,7 +169,7 @@ TEST(CpuPredictor, InplacePredict) {
 namespace {
 void TestTrainingPredictionCache(bool use_subsampling) {
   std::size_t constexpr kRows = 64, kCols = 16, kClasses = 4;
-  LearnerModelParam mparam{MakeMP(kCols, .0, kClasses)};
+  LearnerModelState mparam{MakeMP(kCols, .0, kClasses)};
   Context ctx;
 
   std::unique_ptr<gbm::GBTree> gbm;

--- a/tests/cpp/predictor/test_gpu_predictor.cu
+++ b/tests/cpp/predictor/test_gpu_predictor.cu
@@ -35,7 +35,7 @@ TEST(GPUPredictor, Basic) {
     auto dmat = RandomDataGenerator(n_row, n_col, 0).GenerateDMatrix();
 
     auto ctx = MakeCUDACtx(0);
-    LearnerModelParam mparam{MakeMP(n_col, .5, 1, ctx.Device())};
+    LearnerModelState mparam{MakeMP(n_col, .5, 1, ctx.Device())};
     std::unique_ptr<gbm::GBTreeModel> p_model = CreateTestModel(&mparam, &ctx);
     auto const& model = *p_model;
 
@@ -103,7 +103,7 @@ template <typename Create>
 void TestDecisionStumpExternalMemory(Context const* ctx, bst_feature_t n_features,
                                      Create create_fn) {
   std::int32_t n_classes = 3;
-  LearnerModelParam mparam{MakeMP(n_features, .5, n_classes, ctx->Device())};
+  LearnerModelState mparam{MakeMP(n_features, .5, n_classes, ctx->Device())};
   std::unique_ptr<gbm::GBTreeModel> p_model = CreateTestModel(&mparam, ctx, n_classes);
   auto const& model = *p_model;
   std::unique_ptr<Predictor> gpu_predictor =
@@ -195,7 +195,7 @@ TEST(GPUPredictor, PredictLeafBasic) {
   std::unique_ptr<Predictor> gpu_predictor =
       std::unique_ptr<Predictor>(Predictor::Create("gpu_predictor", &lparam));
 
-  LearnerModelParam mparam{MakeMP(kCols, .0, 1)};
+  LearnerModelState mparam{MakeMP(kCols, .0, 1)};
   Context ctx;
   std::unique_ptr<gbm::GBTreeModel> p_model = CreateTestModel(&mparam, &ctx);
   auto const& model = *p_model;

--- a/tests/cpp/predictor/test_predictor.cc
+++ b/tests/cpp/predictor/test_predictor.cc
@@ -36,7 +36,7 @@ void TestBasic(DMatrix *dmat, Context const *ctx) {
 
   size_t const kCols = dmat->Info().num_col_;
 
-  LearnerModelParam mparam{MakeMP(kCols, .0, 1, ctx->Device())};
+  LearnerModelState mparam{MakeMP(kCols, .0, 1, ctx->Device())};
 
   std::unique_ptr<gbm::GBTreeModel> p_model = CreateTestModel(&mparam, ctx);
   auto const &model = *p_model;
@@ -70,7 +70,7 @@ void TestBasic(DMatrix *dmat, Context const *ctx) {
   HostDeviceVector<float> from_leaf_ids;
   predictor->InitOutPredictions(dmat->Info(), &from_leaf_ids, model);
   auto from_leaf_view = linalg::MakeTensorView(ctx, &from_leaf_ids, dmat->Info().num_row_,
-                                               model.learner_model_param->OutputLength());
+                                               model.learner_model_state->OutputLength());
   predictor->PredictFromLeafIds(common::Span{leaf_ids}, common::Span{trees}, from_leaf_view);
   auto const &h_from_leaf_ids = from_leaf_ids.ConstHostVector();
   ASSERT_EQ(h_from_leaf_ids.size(), out_predictions_h.size());
@@ -84,7 +84,7 @@ void TestBatchPredictionWithWeights(Context const *ctx) {
   auto dmat = RandomDataGenerator(kRows, kCols, 0).GenerateDMatrix();
   auto predictor = std::unique_ptr<Predictor>(CreatePredictorForTest(ctx));
 
-  LearnerModelParam mparam{MakeMP(kCols, .0, 1, ctx->Device())};
+  LearnerModelState mparam{MakeMP(kCols, .0, 1, ctx->Device())};
   auto model = std::make_unique<gbm::GBTreeModel>(&mparam, ctx);
   {
     std::vector<std::unique_ptr<RegTree>> trees;
@@ -126,7 +126,7 @@ void TestInplacePredictionWithWeights(Context const *ctx) {
   HostDeviceVector<float> data(kRows * kCols);
   auto predictor = std::unique_ptr<Predictor>(CreatePredictorForTest(ctx));
 
-  LearnerModelParam mparam{MakeMP(kCols, .0, 1, ctx->Device())};
+  LearnerModelState mparam{MakeMP(kCols, .0, 1, ctx->Device())};
   auto model = std::make_unique<gbm::GBTreeModel>(&mparam, ctx);
   {
     std::vector<std::unique_ptr<RegTree>> trees;
@@ -396,7 +396,7 @@ void TestCategoricalPrediction(bool use_gpu) {
   size_t constexpr kCols = 10;
   HostDeviceVector<float> out_predictions;
 
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1, ctx.Device())};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1, ctx.Device())};
   uint32_t split_ind = 3;
   bst_cat_t split_cat = 4;
   float left_weight = 1.3f;
@@ -433,7 +433,7 @@ void TestCategoricalPredictLeaf(Context const *ctx) {
   size_t constexpr kCols = 10;
   HostDeviceVector<float> out_predictions;
 
-  LearnerModelParam mparam{MakeMP(kCols, .5, 1, ctx->Device())};
+  LearnerModelState mparam{MakeMP(kCols, .5, 1, ctx->Device())};
 
   uint32_t split_ind = 3;
   bst_cat_t split_cat = 4;
@@ -560,7 +560,7 @@ void TestVectorLeafPrediction(Context const *ctx) {
   size_t constexpr kRows = 5;
   size_t constexpr kCols = 5;
 
-  LearnerModelParam mparam{static_cast<bst_feature_t>(kCols),
+  LearnerModelState mparam{static_cast<bst_feature_t>(kCols),
                            linalg::Vector<float>{{0.5}, {1}, ctx->Device()}, 1, 3,
                            MultiStrategy::kMultiOutputTree};
 

--- a/tests/cpp/predictor/test_predictor.h
+++ b/tests/cpp/predictor/test_predictor.h
@@ -17,7 +17,7 @@
 #include "../helpers.h"
 
 namespace xgboost {
-inline std::unique_ptr<gbm::GBTreeModel> CreateTestModel(LearnerModelParam const* param,
+inline std::unique_ptr<gbm::GBTreeModel> CreateTestModel(LearnerModelState const* param,
                                                          Context const* ctx, size_t n_classes = 1) {
   auto model = std::make_unique<gbm::GBTreeModel>(param, ctx);
 
@@ -50,7 +50,7 @@ void TestPredictionFromGradientIndex(Context const* ctx, size_t rows, size_t col
                                      std::shared_ptr<DMatrix> p_hist) {
   constexpr size_t kClasses{3};
 
-  LearnerModelParam mparam{MakeMP(cols, .5, kClasses, ctx->Device())};
+  LearnerModelState mparam{MakeMP(cols, .5, kClasses, ctx->Device())};
   auto cuda_ctx = MakeCUDACtx(0);
 
   std::unique_ptr<Predictor> predictor =

--- a/tests/cpp/predictor/test_shap.cc
+++ b/tests/cpp/predictor/test_shap.cc
@@ -68,7 +68,7 @@ Args BaseParams(Context const* ctx, std::string objective, std::string max_depth
 
 std::unique_ptr<gbm::GBTreeModel> LoadGBTreeModel(Learner* learner, Context const* ctx,
                                                   Args const& model_args,
-                                                  LearnerModelParam* out_param) {
+                                                  LearnerModelState* out_param) {
   Json model{Object{}};
   learner->SaveModel(&model);
 
@@ -105,7 +105,7 @@ std::unique_ptr<gbm::GBTreeModel> LoadGBTreeModel(Learner* learner, Context cons
   auto obj = std::unique_ptr<ObjFunction>(ObjFunction::Create(objective, ctx));
   obj->Configure(model_args);
   obj->ProbToMargin(&base_score_vec);
-  // Keep both host/device views readable, matching LearnerModelParam invariants.
+  // Keep both host/device views readable, matching LearnerModelState invariants.
   std::as_const(base_score_vec).HostView();
   if (!ctx->Device().IsCPU()) {
     std::as_const(base_score_vec).View(ctx->Device());
@@ -124,7 +124,7 @@ std::unique_ptr<gbm::GBTreeModel> LoadGBTreeModel(Learner* learner, Context cons
       break;
     }
   }
-  LearnerModelParam tmp{n_features, std::move(base_score_vec), n_groups, n_targets, multi_strategy};
+  LearnerModelState tmp{n_features, std::move(base_score_vec), n_groups, n_targets, multi_strategy};
   out_param->Copy(tmp);
 
   auto gbtree = std::make_unique<gbm::GBTreeModel>(out_param, ctx);
@@ -233,7 +233,7 @@ void CheckShapOutput(DMatrix* dmat, Args const& model_args) {
   learner->Predict(p_dmat, true, &margin_predt, 0, 0, false, false, false, false, false);
   size_t const n_outputs = margin_predt.HostVector().size() / kRows;
 
-  LearnerModelParam mparam;
+  LearnerModelState mparam;
   auto gbtree = LoadGBTreeModel(learner.get(), dmat->Ctx(), model_args, &mparam);
 
   HostDeviceVector<float> shap_values;
@@ -332,7 +332,7 @@ void CheckShapHandlesDeepTree(Context const* ctx) {
   if (!ctx->Device().IsCPU()) {
     std::as_const(base_score).View(ctx->Device());
   }
-  LearnerModelParam mparam{1, std::move(base_score), 1, 1, MultiStrategy::kOneOutputPerTree};
+  LearnerModelState mparam{1, std::move(base_score), 1, 1, MultiStrategy::kOneOutputPerTree};
   gbm::GBTreeModel model{&mparam, ctx};
 
   bst_node_t constexpr kDepth = 64;
@@ -389,7 +389,7 @@ void CheckShapHandlesZeroCover(Context const* ctx, bool zero_parent_cover) {
   if (!ctx->Device().IsCPU()) {
     std::as_const(base_score).View(ctx->Device());
   }
-  LearnerModelParam mparam{1, std::move(base_score), 1, 1, MultiStrategy::kOneOutputPerTree};
+  LearnerModelState mparam{1, std::move(base_score), 1, 1, MultiStrategy::kOneOutputPerTree};
   gbm::GBTreeModel model{&mparam, ctx};
 
   gbm::TreesOneGroup trees;
@@ -451,7 +451,7 @@ TEST(Predictor, ApproxContribsBasic) {
   HostDeviceVector<float> margin_predt;
   learner->Predict(dmat, true, &margin_predt, 0, 0, false, false, false, false, false);
 
-  LearnerModelParam mparam;
+  LearnerModelState mparam;
   auto gbtree = LoadGBTreeModel(learner.get(), dmat->Ctx(), args, &mparam);
 
   HostDeviceVector<float> approx_contribs;

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -41,6 +41,18 @@
 #include "xgboost/string_view.h"                    // for StringView
 
 namespace xgboost {
+TEST(LearnerModelState, Initialization) {
+  LearnerModelState state;
+  EXPECT_TRUE(state.NeedsInitialization());
+  state.num_feature = 1;
+  state.num_output_group = 1;
+  EXPECT_TRUE(state.NeedsInitialization());
+
+  auto initialized = MakeMP(1, 0.5f, 1);
+  EXPECT_FALSE(initialized.NeedsInitialization());
+  EXPECT_TRUE(initialized.Initialized());
+}
+
 TEST(Learner, Basic) {
   using Arg = std::pair<std::string, std::string>;
   auto args = {Arg("tree_method", "exact")};
@@ -187,7 +199,6 @@ TEST(Learner, Configuration) {
   std::string const emetric = "eval_metric";
   {
     std::unique_ptr<Learner> learner{Learner::Create({nullptr})};
-    learner->Configure({{"num_feature", "1"}});
     learner->Configure({{emetric, "auc"}});
     learner->Configure({{emetric, "rmsle"}});
     learner->Configure({{"foo", "bar"}});
@@ -225,6 +236,74 @@ TEST(Learner, PoissonMaxDeltaStepIsGeneric) {
   ASSERT_FLOAT_EQ(max_delta_step(), 0.5f);
 }
 
+TEST(Learner, ModelInitializedByTrainingData) {
+  auto train = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix(true);
+  auto eval = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix(true);
+  auto learner = std::unique_ptr<Learner>{Learner::Create({train, eval})};
+  learner->Configure({{"objective", "reg:absoluteerror"}});
+
+  EXPECT_EQ(learner->GetNumFeature(), 0);
+  Json config{Object{}};
+  EXPECT_NO_THROW(learner->SaveConfig(&config));
+
+  std::string snapshot;
+  common::MemoryBufferStream out{&snapshot};
+  EXPECT_NO_THROW(learner->Save(&out));
+  auto restored = std::unique_ptr<Learner>{Learner::Create({train})};
+  common::MemoryBufferStream in{&snapshot};
+  EXPECT_NO_THROW(restored->Load(&in));
+  EXPECT_EQ(restored->GetNumFeature(), 0);
+  Json restored_config{Object{}};
+  restored->SaveConfig(&restored_config);
+  EXPECT_EQ(config, restored_config);
+  restored->UpdateOneIter(0, train);
+  EXPECT_EQ(restored->GetNumFeature(), train->Info().num_col_);
+
+  HostDeviceVector<float> predt;
+  EXPECT_THROW(learner->Predict(eval, false, &predt, 0, 0), dmlc::Error);
+  EXPECT_EQ(learner->GetNumFeature(), 0);
+
+  learner->UpdateOneIter(0, train);
+  EXPECT_EQ(learner->GetNumFeature(), train->Info().num_col_);
+
+  learner.reset(Learner::Create({train}));
+  learner->Configure();
+  EXPECT_NO_THROW(learner->Predict(train, false, &predt, 0, 0, true));
+  EXPECT_EQ(learner->GetNumFeature(), train->Info().num_col_);
+}
+
+TEST(Learner, LoadPendingModelInputsFromOldSnapshot) {
+  auto train = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix(true);
+  auto learner = std::unique_ptr<Learner>{Learner::Create({train})};
+  learner->Configure({{"objective", "reg:absoluteerror"}, {"base_score", "1.3"}});
+
+  std::string snapshot;
+  common::MemoryBufferStream out{&snapshot};
+  learner->Save(&out);
+
+  auto memory_snapshot = Json::Load(StringView{snapshot}, std::ios::binary);
+  auto& train_param = get<Object>(memory_snapshot["Config"]["learner"]["learner_train_param"]);
+  for (auto key : {"base_score", "num_class", "num_target", "boost_from_average"}) {
+    train_param.erase(key);
+  }
+  std::vector<char> serialized;
+  Json::Dump(memory_snapshot, &serialized, std::ios::binary);
+  std::string old_snapshot{serialized.cbegin(), serialized.cend()};
+
+  auto restored = std::unique_ptr<Learner>{Learner::Create({train})};
+  common::MemoryBufferStream in{&old_snapshot};
+  restored->Load(&in);
+  EXPECT_EQ(restored->GetNumFeature(), 0);
+  restored->UpdateOneIter(0, train);
+
+  Json config{Object{}};
+  restored->SaveConfig(&config);
+  auto base_score = GetBaseScore(config);
+  ASSERT_EQ(base_score.size(), 1);
+  EXPECT_FLOAT_EQ(base_score.front(), 1.3);
+  EXPECT_EQ(get<String const>(config["learner"]["learner_model_param"]["boost_from_average"]), "0");
+}
+
 TEST(Learner, JsonModelIO) {
   // Test of comparing JSON object directly.
   size_t constexpr kRows = 8;
@@ -237,6 +316,9 @@ TEST(Learner, JsonModelIO) {
   {
     std::unique_ptr<Learner> learner{Learner::Create({p_dmat})};
     learner->Configure();
+    Json uninitialized{Object()};
+    EXPECT_THROW(learner->SaveModel(&uninitialized), dmlc::Error);
+    learner->UpdateOneIter(0, p_dmat);
     Json out{Object()};
     learner->SaveModel(&out);
 
@@ -337,6 +419,7 @@ TEST(Learner, MultiThreadedPredict) {
 
   std::shared_ptr<Learner> learner{Learner::Create({p_dmat})};
   learner->Configure();
+  learner->UpdateOneIter(0, p_dmat);
 
   std::vector<std::thread> threads;
 
@@ -482,6 +565,7 @@ TEST(Learner, FeatureInfo) {
   {
     std::unique_ptr<Learner> learner{Learner::Create({m})};
     learner->Configure();
+    learner->UpdateOneIter(0, m);
     learner->SetFeatureNames(names);
     learner->GetFeatureNames(&out_names);
 
@@ -515,6 +599,7 @@ TEST(Learner, MultiTarget) {
   {
     std::unique_ptr<Learner> learner{Learner::Create({m})};
     learner->Configure();
+    learner->UpdateOneIter(0, m);
 
     Json model{Object()};
     learner->SaveModel(&model);
@@ -565,6 +650,18 @@ class InitBaseScore : public ::testing::Test {
     learner->SaveConfig(&config);
     auto base_score2 = GetBaseScore(config);
     ASSERT_EQ(base_score, base_score2);
+
+    // Unrelated parameters don't rematerialize model state from stale user inputs.
+    learner->Configure({{"max_depth", "2"}});
+    learner->SaveConfig(&config);
+    ASSERT_EQ(base_score, GetBaseScore(config));
+
+    // Explicit model input updates are applied to initialized state.
+    learner->Configure({{"base_score", "1.3"}});
+    learner->SaveConfig(&config);
+    auto updated_base_score = GetBaseScore(config);
+    ASSERT_EQ(updated_base_score.size(), 1);
+    ASSERT_FLOAT_EQ(updated_base_score[0], 1.3);
   }
 
   void TestBoostFromAvgParam() {
@@ -580,12 +677,6 @@ class InitBaseScore : public ::testing::Test {
     // no change
     ASSERT_FLOAT_EQ(base_score[0], 1.3);
 
-    HostDeviceVector<float> predt;
-    learner->Predict(Xy_, false, &predt, 0, 0);
-    auto h_predt = predt.ConstHostSpan();
-    for (auto v : h_predt) {
-      ASSERT_FLOAT_EQ(v, 1.3);
-    }
     learner->UpdateOneIter(0, Xy_);
     learner->SaveConfig(&config);
     base_score = GetBaseScore(config);
@@ -612,52 +703,60 @@ class InitBaseScore : public ::testing::Test {
     learner->Configure();
 
     Json model{Object{}};
+    EXPECT_THROW(learner->SaveModel(&model), dmlc::Error);
+
+    learner->UpdateOneIter(0, Xy_);
     learner->SaveModel(&model);
     auto base_score = GetBaseScore(model);
     ASSERT_EQ(base_score.size(), 1);
     ASSERT_FALSE(std::isnan(base_score[0]));
-    ASSERT_EQ(base_score[0], ObjFunction::DefaultBaseScore());
+    ASSERT_NE(base_score[0], ObjFunction::DefaultBaseScore());
 
     learner.reset(Learner::Create({Xy_}));
     learner->LoadModel(model);
     Json config(Object{});
-    learner->Configure();
     learner->SaveConfig(&config);
-    base_score = GetBaseScore(config);
-    ASSERT_EQ(base_score[0], ObjFunction::DefaultBaseScore());
+    auto loaded_base_score = GetBaseScore(config);
+    ASSERT_EQ(base_score, loaded_base_score);
 
-    learner->UpdateOneIter(0, Xy_);
+    learner->UpdateOneIter(1, Xy_);
     learner->SaveConfig(&config);
-    base_score = GetBaseScore(config);
-    ASSERT_EQ(base_score.size(), 1);
-    ASSERT_FALSE(std::isnan(base_score[0]));
-    ASSERT_NE(base_score[0], ObjFunction::DefaultBaseScore());
+    loaded_base_score = GetBaseScore(config);
+    ASSERT_EQ(base_score, loaded_base_score);
   }
 
   void TestInitWithPredt() {
     std::unique_ptr<Learner> learner{Learner::Create({Xy_})};
     learner->Configure({{"objective", "reg:absoluteerror"}});
     HostDeviceVector<float> predt;
-    learner->Predict(Xy_, false, &predt, 0, 0);
-
-    auto h_predt = predt.ConstHostSpan();
-    for (auto v : h_predt) {
-      ASSERT_EQ(v, ObjFunction::DefaultBaseScore());
-    }
+    EXPECT_THROW(learner->Predict(Xy_, false, &predt, 0, 0), dmlc::Error);
+    EXPECT_EQ(learner->GetNumFeature(), 0);
 
     Json config(Object{});
     learner->SaveConfig(&config);
     auto base_score = GetBaseScore(config);
-    ASSERT_EQ(base_score.size(), 1);
-    ASSERT_EQ(base_score[0], ObjFunction::DefaultBaseScore());
+    ASSERT_TRUE(base_score.empty());
 
-    // since prediction is not used for trianing, the train procedure still runs estimation
+    // Prediction does not initialize the model; training still estimates the intercept.
     learner->UpdateOneIter(0, Xy_);
     learner->SaveConfig(&config);
     base_score = GetBaseScore(config);
     ASSERT_EQ(base_score.size(), 1);
     ASSERT_FALSE(std::isnan(base_score[0]));
     ASSERT_NE(base_score[0], ObjFunction::DefaultBaseScore());
+
+    learner.reset(Learner::Create({Xy_}));
+    learner->Configure({{"objective", "reg:absoluteerror"}});
+    learner->Predict(Xy_, false, &predt, 0, 0, true);
+    learner->SaveConfig(&config);
+    auto training_base_score = GetBaseScore(config);
+    ASSERT_EQ(training_base_score.size(), 1);
+    ASSERT_EQ(training_base_score[0], ObjFunction::DefaultBaseScore());
+
+    // The first training operation commits the intercept choice.
+    learner->UpdateOneIter(0, Xy_);
+    learner->SaveConfig(&config);
+    ASSERT_EQ(training_base_score, GetBaseScore(config));
   }
 
   void TestUpdateProcess() {

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -272,6 +272,18 @@ TEST(Learner, ModelInitializedByTrainingData) {
   EXPECT_EQ(learner->GetNumFeature(), train->Info().num_col_);
 }
 
+TEST(Learner, ResetInitializesCachedModel) {
+  auto train = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix(true);
+  auto learner = std::unique_ptr<Learner>{Learner::Create({train})};
+  learner->Configure({{"objective", "reg:absoluteerror"}});
+  EXPECT_EQ(learner->GetNumFeature(), 0);
+
+  EXPECT_NO_THROW(learner->Reset());
+  EXPECT_EQ(learner->GetNumFeature(), train->Info().num_col_);
+  Json model{Object{}};
+  EXPECT_NO_THROW(learner->SaveModel(&model));
+}
+
 TEST(Learner, LoadPendingModelInputsFromOldSnapshot) {
   auto train = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix(true);
   auto learner = std::unique_ptr<Learner>{Learner::Create({train})};

--- a/tests/cpp/test_learner.cu
+++ b/tests/cpp/test_learner.cu
@@ -31,7 +31,7 @@ TEST(LearnerModelState, ChangeCUDADevice) {
                           true,
                           h_base_score,
                           std::move(base_score),
-                          ObjInfo{},
+                          ObjInfo{ObjInfo::kRegression},
                           MultiStrategy::kOneOutputPerTree};
 
   ctx = MakeCUDACtx(1);

--- a/tests/cpp/test_learner.cu
+++ b/tests/cpp/test_learner.cu
@@ -8,11 +8,37 @@
 
 #include <cstdint>  // for int32_t
 #include <memory>   // for unique_ptr
+#include <utility>  // for move
+#include <vector>   // for vector
 
 #include "../../src/common/device_vector.cuh"  // for GlobalMemoryLogger
 #include "helpers.h"                           // for RandomDataGenerator
 
 namespace xgboost {
+TEST(LearnerModelState, ChangeCUDADevice) {
+  if (curt::AllVisibleGPUs() < 2) {
+    GTEST_SKIP() << "At least 2 GPUs are required.";
+  }
+
+  auto ctx = MakeCUDACtx(0);
+  std::vector<float> h_base_score{0.5f};
+  linalg::Vector<float> base_score{
+      h_base_score.cbegin(), h_base_score.cend(), {h_base_score.size()}, ctx.Device()};
+  LearnerModelState state{&ctx,
+                          1,
+                          0,
+                          1,
+                          true,
+                          h_base_score,
+                          std::move(base_score),
+                          ObjInfo{},
+                          MultiStrategy::kOneOutputPerTree};
+
+  ctx = MakeCUDACtx(1);
+  EXPECT_NO_THROW(state.ConfigureDevice(&ctx));
+  EXPECT_EQ(state.BaseScore(DeviceOrd::CPU())(0), h_base_score[0]);
+}
+
 TEST(Learner, Reset) {
   dh::GlobalMemoryLogger().Clear();
 

--- a/tests/cpp/test_multi_target.cc
+++ b/tests/cpp/test_multi_target.cc
@@ -131,6 +131,8 @@ TEST(MultiStrategy, Configure) {
   p_fmat->Info().labels.Reshape(p_fmat->Info().num_row_, 2);
   std::unique_ptr<Learner> learner{Learner::Create({p_fmat})};
   learner->Configure(Args{{"multi_strategy", "multi_output_tree"}, {"num_target", "2"}});
+  EXPECT_THROW(learner->Groups(), dmlc::Error);
+  learner->UpdateOneIter(0, p_fmat);
   ASSERT_EQ(learner->Groups(), 2);
 
   ASSERT_THROW(


### PR DESCRIPTION
## Summary

- rename `LearnerModelParam` to `LearnerModelState` to reflect that it is authoritative runtime/model state rather than a user parameter object
- move user inputs (`base_score`, `num_class`, `num_target`, and `boost_from_average`) into `LearnerTrainParam`
- materialize feature count, output shape, and intercept state when the learner first sees training data
- preserve empty learners in memory snapshots while requiring initialized state for ordinary prediction and model export
- remove `GradientBooster::ModelFitted()` as a proxy for learner initialization

The serialized `learner_model_param` key remains unchanged for model compatibility. Loading older snapshots also restores pending model inputs from that object when they are absent from `learner_train_param`.

This PR intentionally retains `need_configuration_` and the existing deferred component-configuration calls. It separates model initialization from that state machine first; configuration lifecycle cleanup can follow independently.

## Why

`LearnerModelParam` mixed user-provided construction inputs with model-derived, authoritative state. That made ordinary configuration responsible for creating a provisional model before training data was available and required booster internals to report whether the learner had been fitted. Separating the two lets configuration remain parameter handling while the first training operation creates a valid model state from both parameters and data.

## Validation

- `./build/testxgboost` (750 tests)
- focused learner/model-state and intercept tests after pre-commit formatting (11 tests)
- `pytest tests/python/test_basic_models.py tests/python/test_pickling.py tests/python/test_model_io.py tests/python/test_model_compatibility.py tests/python/test_multi_target.py` (61 passed, 1 skipped)
- `pre-commit run --files <34 changed files>`