### PR TITLE
[doc] Use language tabs for model saving examples

### DIFF
--- a/doc/tutorials/saving_model.rst
+++ b/doc/tutorials/saving_model.rst
@@ -57,21 +57,21 @@ To enable JSON format support for model IO (saving only the trees and objective)
 a filename with ``.json`` or ``.ubj`` as file extension, the latter is the extension for
 `Universal Binary JSON <https://ubjson.org/>`__
 
-.. code-block:: python
-  :caption: Python
+.. tabs::
+    .. code-tab:: python
+       :class: no-doctest
 
-  bst.save_model('model_file_name.json')
+       bst.save_model('model_file_name.json')
 
-.. code-block:: r
-  :caption: R
+    .. code-tab:: r R
+       :class: no-doctest
 
-  xgb.save(bst, 'model_file_name.json')
+       xgb.save(bst, 'model_file_name.json')
 
-.. code-block:: Scala
-  :caption: Scala
+    .. code-tab:: scala Scala
 
-  val format = "json"  // or val format = "ubj"
-  model.write.option("format", format).save("model_directory_path")
+       val format = "json"  // or val format = "ubj"
+       model.write.option("format", format).save("model_directory_path")
 
 .. note::
 


### PR DESCRIPTION
## Summary

- group the Python, R, and Scala model-saving examples into language tabs
- keep the state-dependent Python and R snippets out of doctests

This is one focused part of #11413.

## Test

- built `saving_model.rst` with Sphinx and confirmed all three tab panels render