### PR TITLE
[Tests] Spawn subprocesses with sys.executable, not a bare "python"

### DIFF
--- a/tests/python-gpu/test_gpu_demos.py
+++ b/tests/python-gpu/test_gpu_demos.py
@@ -1,9 +1,11 @@
 import os
 import subprocess
+import sys
 
 import pytest
-
 from xgboost import testing as tm
+
+PYTHON = sys.executable
 
 DEMO_DIR = tm.demo_dir(__file__)
 PYTHON_DEMO_DIR = os.path.join(DEMO_DIR, "guide-python")
@@ -12,19 +14,19 @@ PYTHON_DEMO_DIR = os.path.join(DEMO_DIR, "guide-python")
 @pytest.mark.skipif(**tm.no_cupy())
 def test_data_iterator() -> None:
     script = os.path.join(PYTHON_DEMO_DIR, "quantile_data_iterator.py")
-    cmd = ["python", script]
+    cmd = [PYTHON, script]
     subprocess.check_call(cmd)
 
 
 def test_update_process_demo() -> None:
     script = os.path.join(PYTHON_DEMO_DIR, "update_process.py")
-    cmd = ["python", script]
+    cmd = [PYTHON, script]
     subprocess.check_call(cmd)
 
 
 def test_categorical_demo() -> None:
     script = os.path.join(PYTHON_DEMO_DIR, "categorical.py")
-    cmd = ["python", script]
+    cmd = [PYTHON, script]
     subprocess.check_call(cmd)
 
 
@@ -32,7 +34,7 @@ def test_categorical_demo() -> None:
 @pytest.mark.skipif(**tm.no_cupy())
 def test_external_memory_demo() -> None:
     script = os.path.join(PYTHON_DEMO_DIR, "external_memory.py")
-    cmd = ["python", script, "--device=cuda"]
+    cmd = [PYTHON, script, "--device=cuda"]
     subprocess.check_call(cmd)
 
 
@@ -41,5 +43,5 @@ def test_external_memory_demo() -> None:
 @pytest.mark.mgpu
 def test_distributed_extmem_basic_demo() -> None:
     script = os.path.join(PYTHON_DEMO_DIR, "distributed_extmem_basic.py")
-    cmd = ["python", script, "--device=cuda"]
+    cmd = [PYTHON, script, "--device=cuda"]
     subprocess.check_call(cmd)

--- a/tests/python/test_openmp.py
+++ b/tests/python/test_openmp.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -8,6 +9,8 @@ import xgboost as xgb
 from xgboost import testing as tm
 
 pytestmark = tm.timeout(10)
+
+PYTHON = sys.executable
 
 
 class TestOMP:
@@ -84,7 +87,7 @@ class TestOMP:
     @pytest.mark.timeout(30)
     def test_with_omp_thread_limit(self, tmp_path: Path) -> None:
         args = [
-            "python",
+            PYTHON,
             os.path.join(os.path.dirname(tm.normpath(__file__)), "with_omp_limit.py"),
         ]
         results = []

--- a/tests/test_distributed/test_gpu_with_dask/test_gpu_demos.py
+++ b/tests/test_distributed/test_gpu_with_dask/test_gpu_demos.py
@@ -1,9 +1,11 @@
 import os
 import subprocess
+import sys
 
 import pytest
-
 from xgboost import testing as tm
+
+PYTHON = sys.executable
 
 pytestmark = [
     pytest.mark.skipif(**tm.no_dask()),
@@ -16,14 +18,14 @@ pytestmark = [
 @pytest.mark.mgpu
 def test_dask_training() -> None:
     script = os.path.join(tm.demo_dir(__file__), "dask", "gpu_training.py")
-    cmd = ["python", script]
+    cmd = [PYTHON, script]
     subprocess.check_call(cmd)
 
 
 @pytest.mark.mgpu
 def test_dask_sklearn_demo() -> None:
     script = os.path.join(tm.demo_dir(__file__), "dask", "sklearn_gpu_training.py")
-    cmd = ["python", script]
+    cmd = [PYTHON, script]
     subprocess.check_call(cmd)
 
 
@@ -31,5 +33,5 @@ def test_dask_sklearn_demo() -> None:
 @pytest.mark.skipif(**tm.no_cupy())
 def test_forward_logging_demo() -> None:
     script = os.path.join(tm.demo_dir(__file__), "dask", "forward_logging.py")
-    cmd = ["python", script]
+    cmd = [PYTHON, script]
     subprocess.check_call(cmd)

--- a/tests/test_distributed/test_with_dask/test_demos.py
+++ b/tests/test_distributed/test_with_dask/test_demos.py
@@ -1,22 +1,24 @@
 import os
 import subprocess
+import sys
 
 import pytest
-
 from xgboost import testing as tm
+
+PYTHON = sys.executable
 
 
 @pytest.mark.skipif(**tm.no_dask())
 def test_dask_cpu_training_demo() -> None:
     script = os.path.join(tm.demo_dir(__file__), "dask", "cpu_training.py")
-    cmd = ["python", script]
+    cmd = [PYTHON, script]
     subprocess.check_call(cmd)
 
 
 @pytest.mark.skipif(**tm.no_dask())
 def test_dask_cpu_survival_demo() -> None:
     script = os.path.join(tm.demo_dir(__file__), "dask", "cpu_survival.py")
-    cmd = ["python", script]
+    cmd = [PYTHON, script]
     subprocess.check_call(cmd)
 
 
@@ -25,12 +27,12 @@ def test_dask_cpu_survival_demo() -> None:
 @pytest.mark.skipif(**tm.no_dask_ml())
 def test_dask_callbacks_demo() -> None:
     script = os.path.join(tm.demo_dir(__file__), "dask", "dask_callbacks.py")
-    cmd = ["python", script]
+    cmd = [PYTHON, script]
     subprocess.check_call(cmd)
 
 
 @pytest.mark.skipif(**tm.no_dask())
 def test_dask_sklearn_demo() -> None:
     script = os.path.join(tm.demo_dir(__file__), "dask", "sklearn_cpu_training.py")
-    cmd = ["python", script]
+    cmd = [PYTHON, script]
     subprocess.check_call(cmd)


### PR DESCRIPTION
Several tests shell out to a demo or helper script using the literal command "python". That only works when a `python` executable happens to be on PATH and happens to be the same interpreter running the tests. It is on CI, which uses conda environments, but it fails outright in a virtualenv that has not been activated, where the interpreter is only reachable as `venv/bin/python`:

    subprocess.CalledProcessError: Command '['python', '.../with_omp_limit.py']'
    ModuleNotFoundError: No module named 'xgboost'

Worse than the inconvenience, when a bare `python` does exist but is a different interpreter, these tests silently exercise whichever xgboost that interpreter can import rather than the one under test.

tests/python/test_demos.py already handles this correctly with a module-level `PYTHON = sys.executable`. Apply the same pattern to the four files that were missing it.

ops/script/release_artifacts.py also invokes a bare "python", but it is release tooling that runs in a prepared environment rather than a test, so it is left alone.

Verified by running the affected tests with no `python` on PATH, which reproduced the failure before the change and passes after it.