### PR TITLE
Detect CPU cache sizes on Apple Silicon

### DIFF
--- a/src/common/cache_manager.cc
+++ b/src/common/cache_manager.cc
@@ -1,14 +1,22 @@
 /**
- * Copyright 2021-2025, XGBoost Contributors
+ * Copyright 2021-2026, XGBoost Contributors
  */
 #include "cache_manager.h"
 
-#include <cstdint>  // for uint64_t
+#include <algorithm>  // for min
+#include <cstdint>    // for uint64_t
+#include <optional>   // for optional
 
 #if !defined(__x86_64__) && defined(__linux__)
 #include <fstream>  // for ifstream
 #include <string>   // for string, getline, stoll
-#endif              // !defined(__x86_64__) && defined(__linux__)
+#elif !defined(__x86_64__) && defined(__APPLE__)
+#include <sys/sysctl.h>  // for sysctlbyname
+
+#include <limits>  // for numeric_limits
+#include <string>  // for string, to_string
+#include <vector>  // for vector
+#endif             // !defined(__x86_64__) && defined(__linux__)
 
 #if defined(__x86_64__)
 
@@ -169,18 +177,126 @@ void DetectDataCachesSysfs(int64_t* cache_sizes) {
 
 }  // namespace
 
+#elif defined(__APPLE__)  // non-x86_64 Apple (Apple Silicon): read cache sizes from sysctl
+
+namespace {
+
+/* Read an integer sysctl by name. Empty when the key is absent, unreadable, or reports a
+ * non-positive size.
+ */
+std::optional<int64_t> ReadSysctlInt(const std::string& name) {
+  std::uint64_t value = 0;
+  std::size_t len = sizeof(value);
+  if (::sysctlbyname(name.c_str(), &value, &len, nullptr, 0) != 0) {
+    return std::nullopt;
+  }
+  // Cache sizes are reported as 64-bit quantities, topology counts such as
+  // `hw.nperflevels` as 32-bit ones. Both land in the low bytes of the zero-initialised
+  // buffer above, so a single reader handles either width.
+  if (len != sizeof(std::uint32_t) && len != sizeof(std::uint64_t)) {
+    return std::nullopt;
+  }
+  if (value == 0 || value > static_cast<std::uint64_t>(std::numeric_limits<int64_t>::max())) {
+    return std::nullopt;
+  }
+  return static_cast<int64_t>(value);
+}
+
+/* Query the sysctl `perflevel` hierarchy and store L1 -> [0] and L2 -> [1]. Anything that
+ * cannot be determined is left at its kUninitCache default so the compiled fallbacks in
+ * the header apply.
+ *
+ * This function is only the platform query; the policy that turns the readings into
+ * per-thread sizes lives in ReduceHeterogeneousCaches so it can be tested directly.
+ */
+template <std::int32_t kMaxCacheSize>
+void DetectDataCachesSysctl(int64_t* cache_sizes) {
+  static_assert(kMaxCacheSize >= 2, "Need slots for L1 and L2.");
+
+  const std::optional<int64_t> n_levels = ReadSysctlInt("hw.nperflevels");
+  if (!n_levels) {
+    return;
+  }
+
+  std::vector<xgboost::common::detail::PerfLevelCache> levels;
+  levels.reserve(static_cast<std::size_t>(*n_levels));
+  for (int64_t level = 0; level < *n_levels; ++level) {
+    const std::string prefix = "hw.perflevel" + std::to_string(level) + ".";
+    levels.push_back({ReadSysctlInt(prefix + "l1dcachesize"), ReadSysctlInt(prefix + "l2cachesize"),
+                      ReadSysctlInt(prefix + "cpusperl2")});
+  }
+
+  const auto sizes = xgboost::common::detail::ReduceHeterogeneousCaches(
+      xgboost::common::Span<xgboost::common::detail::PerfLevelCache const>{levels.data(),
+                                                                           levels.size()});
+  if (sizes.l1d) {
+    cache_sizes[0] = *sizes.l1d;
+  }
+  if (sizes.l2_per_cpu) {
+    cache_sizes[1] = *sizes.l2_per_cpu;
+  }
+  // The Apple system level cache is not exposed through sysctl; leave L3 unset.
+}
+
+}  // namespace
+
 #endif  // defined(__x86_64__)
 
 namespace xgboost::common {
+namespace detail {
+/* Reduce per-performance-level readings to the sizes one thread can rely on.
+ *
+ * Heterogeneous CPUs such as Apple Silicon differ from x86 in two ways that matter here:
+ *
+ *   - Performance and efficiency cores report different L1d and L2 sizes, and XGBoost
+ *     spreads its threads over both. The minimum is taken because, as the header notes,
+ *     overestimating a cache costs more than underestimating it: a block sized for a
+ *     performance core's L1 would spill on an efficiency core.
+ *   - L2 is shared by every core in a cluster rather than being private per core, so a
+ *     raw cluster size is not what a single thread can rely on. Dividing by the sharing
+ *     factor restores the per-thread meaning that the callers in hist_util.cc and
+ *     tree/hist/histogram.h assume.
+ *
+ * A level contributes an L2 estimate only when its sharing factor is also known, since an
+ * undivided cluster size would overestimate the per-thread budget several-fold.
+ *
+ * This is compiled on every platform, not just the ones with heterogeneous cores, so the
+ * policy stays under test everywhere.
+ */
+DataCacheSizes ReduceHeterogeneousCaches(Span<PerfLevelCache const> levels) {
+  DataCacheSizes out;
+  auto keep_min = [](std::optional<std::int64_t>* acc, std::int64_t value) {
+    *acc = acc->has_value() ? std::min(**acc, value) : value;
+  };
 
-/* Detect CPU cache sizes at runtime: CPUID on x86_64, sysfs on non-x86_64 Linux,
- * and compiled L1/L2/L3 defaults otherwise (or for any size detection leaves unset).
+  for (auto const& level : levels) {
+    if (level.l1d && *level.l1d > 0) {
+      keep_min(&out.l1d, *level.l1d);
+    }
+    if (level.l2 && level.cpus_per_l2 && *level.l2 > 0 && *level.cpus_per_l2 > 0) {
+      keep_min(&out.l2_per_cpu, *level.l2 / *level.cpus_per_l2);
+    }
+  }
+  // A cluster smaller than its sharing factor would divide to zero, which the callers
+  // would then treat as a real size rather than falling back to the default.
+  if (out.l2_per_cpu && *out.l2_per_cpu <= 0) {
+    out.l2_per_cpu.reset();
+  }
+  return out;
+}
+}  // namespace detail
+
+/* Detect CPU cache sizes at runtime: CPUID on x86_64, sysfs on non-x86_64 Linux, sysctl on
+ * non-x86_64 Apple, and compiled L1/L2/L3 defaults otherwise (or for any size detection
+ * leaves unset).
  */
 CacheManager::CacheManager() {
 #if defined(__x86_64__)
   DetectDataCaches<kMaxCacheSize>(cache_size_.data());
 #elif defined(__linux__)
   DetectDataCachesSysfs<kMaxCacheSize>(cache_size_.data());
+#elif defined(__APPLE__)
+  DetectDataCachesSysctl<kMaxCacheSize>(cache_size_.data());
 #else
   SetDefaultCaches();
 #endif  // defined(__x86_64__)

--- a/src/common/cache_manager.h
+++ b/src/common/cache_manager.h
@@ -1,13 +1,44 @@
 /**
- * Copyright 2021-2025, XGBoost Contributors
+ * Copyright 2021-2026, XGBoost Contributors
  */
 #ifndef XGBOOST_COMMON_CACHE_MANAGER_H_
 #define XGBOOST_COMMON_CACHE_MANAGER_H_
 
-#include <cstdint>     // for int64_t
 #include <array>
+#include <cstdint>   // for int64_t
+#include <optional>  // for optional
+
+#include "xgboost/span.h"  // for Span
 
 namespace xgboost::common {
+
+namespace detail {
+/* Data cache sizes reported for one CPU performance level. An empty field means the
+ * platform did not report that quantity.
+ */
+struct PerfLevelCache {
+  std::optional<std::int64_t> l1d;
+  std::optional<std::int64_t> l2;
+  /* Number of cores sharing one L2, needed because L2 is per-cluster on heterogeneous
+   * CPUs rather than private per core as on x86.
+   */
+  std::optional<std::int64_t> cpus_per_l2;
+};
+
+/* The sizes a single thread can rely on, reduced over all performance levels. */
+struct DataCacheSizes {
+  std::optional<std::int64_t> l1d;
+  std::optional<std::int64_t> l2_per_cpu;
+};
+
+/* Reduce per-performance-level cache readings to per-thread sizes.
+ *
+ * Split out from the platform query so the policy can be tested with synthetic readings
+ * on any host, including topologies not present on the build machine. See
+ * cache_manager.cc for why the minimum is taken and why L2 is divided.
+ */
+[[nodiscard]] DataCacheSizes ReduceHeterogeneousCaches(Span<PerfLevelCache const> levels);
+}  // namespace detail
 
 /* Detect cache sizes at runtime,
  * or fall back to defaults if detection is not possible.
@@ -16,14 +47,14 @@ class CacheManager {
  private:
   constexpr static int64_t kUninitCache = -1;
   constexpr static int kMaxCacheSize = 4;
-  std::array<int64_t, kMaxCacheSize> cache_size_ = {kUninitCache, kUninitCache,
-                                                    kUninitCache, kUninitCache};
+  std::array<int64_t, kMaxCacheSize> cache_size_ = {kUninitCache, kUninitCache, kUninitCache,
+                                                    kUninitCache};
 
   constexpr static int64_t kDefaultL1Size = 32 * 1024;    // 32KB
   constexpr static int64_t kDefaultL2Size = 1024 * 1024;  // 1MB
   constexpr static int64_t kDefaultL3Size = 0;            // 0MB
 
-  // If CPUID cannot be used, fall back to default L1/L2 cache sizes.
+  // If no runtime detection is available, fall back to default L1/L2 cache sizes.
   void SetDefaultCaches() {
     // Overestimating cache sizes harms performance more than underestimation,
     // so conservative defaults are used.

--- a/tests/cpp/common/test_cache_manager.cc
+++ b/tests/cpp/common/test_cache_manager.cc
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ */
+#include <gtest/gtest.h>
+
+#include <cstdint>   // for int64_t
+#include <optional>  // for optional
+#include <vector>    // for vector
+
+#include "../../../src/common/cache_manager.h"
+
+#if !defined(__x86_64__) && defined(__APPLE__)
+#include <sys/sysctl.h>  // for sysctlbyname
+
+#include <algorithm>  // for min
+#include <string>     // for string, to_string
+#endif                // !defined(__x86_64__) && defined(__APPLE__)
+
+namespace xgboost::common {
+namespace {
+std::optional<std::int64_t> Some(std::int64_t v) { return std::optional<std::int64_t>{v}; }
+constexpr std::optional<std::int64_t> kNone = std::nullopt;
+
+detail::DataCacheSizes Reduce(std::vector<detail::PerfLevelCache> const& levels) {
+  return detail::ReduceHeterogeneousCaches(
+      Span<detail::PerfLevelCache const>{levels.data(), levels.size()});
+}
+}  // namespace
+
+/* The reduction policy is where the judgement calls live, so it is tested directly with
+ * synthetic readings. This runs on every platform, including CPU topologies that are not
+ * available to test on natively.
+ */
+TEST(CacheManager, ReduceHeterogeneousCaches) {
+  // No readings at all: nothing is claimed, so the callers fall back to defaults.
+  {
+    auto out = Reduce({});
+    ASSERT_FALSE(out.l1d.has_value());
+    ASSERT_FALSE(out.l2_per_cpu.has_value());
+  }
+  // A single homogeneous level, L2 shared by 4 cores.
+  {
+    auto out = Reduce({{Some(64 * 1024), Some(4 * 1024 * 1024), Some(4)}});
+    ASSERT_EQ(out.l1d, 64 * 1024);
+    ASSERT_EQ(out.l2_per_cpu, 1024 * 1024);
+  }
+  // Two levels, as on an Apple M4 Max: 128KB/16MB shared by 6 performance cores and
+  // 64KB/4MB shared by 4 efficiency cores. The smaller of each must win, because a
+  // thread may land on either.
+  {
+    auto out = Reduce({{Some(128 * 1024), Some(16 * 1024 * 1024), Some(6)},
+                       {Some(64 * 1024), Some(4 * 1024 * 1024), Some(4)}});
+    ASSERT_EQ(out.l1d, 64 * 1024);
+    ASSERT_EQ(out.l2_per_cpu, 1024 * 1024);
+  }
+  // Order must not matter.
+  {
+    auto out = Reduce({{Some(64 * 1024), Some(4 * 1024 * 1024), Some(4)},
+                       {Some(128 * 1024), Some(16 * 1024 * 1024), Some(6)}});
+    ASSERT_EQ(out.l1d, 64 * 1024);
+    ASSERT_EQ(out.l2_per_cpu, 1024 * 1024);
+  }
+  // A level with an unknown sharing factor contributes no L2 estimate, since an
+  // undivided cluster size would overestimate the per-thread budget. Its L1 still counts.
+  {
+    auto out = Reduce({{Some(32 * 1024), Some(16 * 1024 * 1024), kNone}});
+    ASSERT_EQ(out.l1d, 32 * 1024);
+    ASSERT_FALSE(out.l2_per_cpu.has_value());
+  }
+  // Mixed: only the level that reports a sharing factor contributes L2.
+  {
+    auto out = Reduce({{Some(128 * 1024), Some(16 * 1024 * 1024), kNone},
+                       {Some(64 * 1024), Some(4 * 1024 * 1024), Some(4)}});
+    ASSERT_EQ(out.l1d, 64 * 1024);
+    ASSERT_EQ(out.l2_per_cpu, 1024 * 1024);
+  }
+  // Missing and non-positive readings are ignored rather than propagated as sizes.
+  {
+    auto out = Reduce({{kNone, kNone, kNone}, {Some(0), Some(-1), Some(0)}});
+    ASSERT_FALSE(out.l1d.has_value());
+    ASSERT_FALSE(out.l2_per_cpu.has_value());
+  }
+  // A sharing factor larger than the cluster would divide to zero; that must not be
+  // reported as a real size.
+  {
+    auto out = Reduce({{Some(64 * 1024), Some(2), Some(64)}});
+    ASSERT_EQ(out.l1d, 64 * 1024);
+    ASSERT_FALSE(out.l2_per_cpu.has_value());
+  }
+}
+
+TEST(CacheManager, Sizes) {
+  CacheManager cache_manager;
+
+  // The accessors substitute compiled defaults for anything detection left unset, so a
+  // size is always usable as a divisor or a budget.
+  ASSERT_GT(cache_manager.L1Size(), 0);
+  ASSERT_GT(cache_manager.L2Size(), 0);
+  ASSERT_GE(cache_manager.L3Size(), 0);
+
+  // The histogram heuristics treat L1 as a subset of the budget they compare against L2,
+  // so an inverted hierarchy would silently mis-tune them.
+  ASSERT_GE(cache_manager.L2Size(), cache_manager.L1Size());
+
+  // Detection must not depend on when the object is constructed.
+  CacheManager other;
+  ASSERT_EQ(cache_manager.L1Size(), other.L1Size());
+  ASSERT_EQ(cache_manager.L2Size(), other.L2Size());
+  ASSERT_EQ(cache_manager.L3Size(), other.L3Size());
+}
+
+#if !defined(__x86_64__) && defined(__APPLE__)
+namespace {
+std::int64_t ReadSysctlInt(std::string const& name) {
+  std::uint64_t value = 0;
+  std::size_t len = sizeof(value);
+  if (::sysctlbyname(name.c_str(), &value, &len, nullptr, 0) != 0) {
+    return -1;
+  }
+  return value > 0 ? static_cast<std::int64_t>(value) : -1;
+}
+}  // namespace
+
+// Guards against detection silently failing and leaving the compiled defaults in place,
+// which is invisible to the checks above because those defaults are also valid sizes.
+TEST(CacheManager, AppleSilicon) {
+  auto const n_levels = ReadSysctlInt("hw.nperflevels");
+  if (n_levels <= 0) {
+    GTEST_SKIP() << "sysctl does not report performance levels.";
+  }
+
+  std::int64_t expected_l1d = -1;
+  std::int64_t expected_l2 = -1;
+  for (std::int64_t level = 0; level < n_levels; ++level) {
+    auto const prefix = "hw.perflevel" + std::to_string(level) + ".";
+
+    auto const l1d = ReadSysctlInt(prefix + "l1dcachesize");
+    if (l1d > 0) {
+      expected_l1d = expected_l1d > 0 ? std::min(expected_l1d, l1d) : l1d;
+    }
+
+    auto const l2 = ReadSysctlInt(prefix + "l2cachesize");
+    auto const cpus_per_l2 = ReadSysctlInt(prefix + "cpusperl2");
+    if (l2 > 0 && cpus_per_l2 > 0) {
+      auto const per_cpu = l2 / cpus_per_l2;
+      expected_l2 = expected_l2 > 0 ? std::min(expected_l2, per_cpu) : per_cpu;
+    }
+  }
+
+  CacheManager cache_manager;
+  if (expected_l1d > 0) {
+    ASSERT_EQ(cache_manager.L1Size(), expected_l1d);
+  }
+  if (expected_l2 > 0) {
+    ASSERT_EQ(cache_manager.L2Size(), expected_l2);
+  }
+}
+
+#endif  // !defined(__x86_64__) && defined(__APPLE__)
+}  // namespace xgboost::common


### PR DESCRIPTION
`CacheManager` detects cache sizes with CPUID on x86_64 and sysfs on non-x86_64 Linux, and falls back to compiled defaults everywhere else. macOS on arm64 hits the fallback, so XGBoost tunes its CPU histogram build against a 32KB L1 and a 1MB L2 regardless of the hardware it is running on.

Add a sysctl-based path for Apple Silicon. Two details differ from x86 and shape the implementation:

- Cores are heterogeneous, so sizes are read per performance level and the minimum is taken. Threads are spread over both core types, and the header already notes that overestimating a cache costs more than underestimating it: a block sized for a performance core's L1 would spill on an efficiency core.
- L2 is shared by every core in a cluster rather than being private per core, so the raw `hw.perflevelN.l2cachesize` is not what a single thread can rely on. Dividing by `cpusperl2` restores the per-thread meaning that the callers in hist_util.cc and tree/hist/histogram.h assume. A level only contributes an L2 estimate when its sharing factor is known, since an undivided cluster size would overestimate the budget several-fold.

The policy that reduces per-level readings to per-thread sizes is kept separate from the sysctl query, in ReduceHeterogeneousCaches, and is compiled on every platform rather than inside the Apple branch. Deciding what a thread can rely on across heterogeneous cores is a judgement call, and welding it to sysctl would have left every branch except the one the developer's machine happens to take untested. It is now covered directly with synthetic readings: one homogeneous level, a two-level performance/efficiency split in both orders, a level with an unknown sharing factor, absent and non-positive readings, and a sharing factor larger than the cluster.

That last case is why the separation was worth it. A cluster smaller than its sharing factor divides to zero, and zero would then have been stored as though it were a detected size, so callers would divide by it rather than fall back to the default. The reduction discards a non-positive result.

The query returns std::optional rather than a sentinel, so there is no -1 to keep in sync with CacheManager::kUninitCache, which is private to the class. A sysctl value that would overflow int64 is rejected rather than wrapping.

The Apple system level cache is not exposed through sysctl, so L3 is left unset and keeps its default of 0. Intel Macs are unaffected: they still take the CPUID path, which is checked first.

On an M4 Max (12P+4E) this raises the detected L1d from the compiled 32KB default to the 64KB the efficiency cores report. The derived per-thread L2 works out to exactly the 1MB default on that part, so L1 is the only value that changes there, but both are now read from the hardware rather than guessed.

The L1 value feeds block_size in ConstructHistSpace, which only matters on the read_by_column path that dense data takes once the histogram outgrows the L2 budget (above roughly 200 features at the default max_bin):

    usable_l1 = 0.8 * L1;  space = usable_l1 - 2 * sizeof(GradientPairPrecise) * max_bin
    block_size = space / (sizeof(GradientPair) + 3 * sizeof(size_t))

The size of the gain therefore depends on max_bin, since the per-column histogram is subtracted from the L1 budget before rows get the remainder. On an M4 Max, interleaved runs with rotated ordering, reporting the minimum and first quartile because the maximum is dominated by unrelated system activity:

    max_bin=512  500K x 400 dense  30 rounds  6.141 -> 4.743  (-22.8% min)
    max_bin=256  400K x 300 dense  25 rounds  1.362 -> 1.296  ( -4.9% min)
    max_bin=256  400K x 400 dense  25 rounds  1.761 -> 1.694  ( -3.8% min)

So a few percent at the default max_bin, growing with max_bin. Shapes that stay on the row-wise path are unaffected, as expected, since their histograms fit the L2 budget either way and L2 does not change on this part:

    max_bin=256  1M x 50 dense     100 rounds 1.806 -> 1.811  (+0.3% min)
    max_bin=256  1M x 100 sparse   100 rounds 2.018 -> 1.999  ( -1.0% min)
    max_bin=256  400K x 150 dense   25 rounds 0.607 -> 0.618  (+1.8% min)

Also reformat cache_manager.h, which did not match clang-format.