### PR TITLE
Use the target's real cache line size in the hist builder

### DIFF
--- a/src/common/cache_manager.cc
+++ b/src/common/cache_manager.cc
@@ -1,14 +1,22 @@
 /**
- * Copyright 2021-2025, XGBoost Contributors
+ * Copyright 2021-2026, XGBoost Contributors
  */
 #include "cache_manager.h"
 
-#include <cstdint>  // for uint64_t
+#include <algorithm>  // for min
+#include <cstdint>    // for uint64_t
+#include <optional>   // for optional
 
 #if !defined(__x86_64__) && defined(__linux__)
 #include <fstream>  // for ifstream
 #include <string>   // for string, getline, stoll
-#endif              // !defined(__x86_64__) && defined(__linux__)
+#elif !defined(__x86_64__) && defined(__APPLE__)
+#include <sys/sysctl.h>  // for sysctlbyname
+
+#include <limits>  // for numeric_limits
+#include <string>  // for string, to_string
+#include <vector>  // for vector
+#endif             // !defined(__x86_64__) && defined(__linux__)
 
 #if defined(__x86_64__)
 
@@ -169,18 +177,126 @@ void DetectDataCachesSysfs(int64_t* cache_sizes) {
 
 }  // namespace
 
+#elif defined(__APPLE__)  // non-x86_64 Apple (Apple Silicon): read cache sizes from sysctl
+
+namespace {
+
+/* Read an integer sysctl by name. Empty when the key is absent, unreadable, or reports a
+ * non-positive size.
+ */
+std::optional<int64_t> ReadSysctlInt(const std::string& name) {
+  std::uint64_t value = 0;
+  std::size_t len = sizeof(value);
+  if (::sysctlbyname(name.c_str(), &value, &len, nullptr, 0) != 0) {
+    return std::nullopt;
+  }
+  // Cache sizes are reported as 64-bit quantities, topology counts such as
+  // `hw.nperflevels` as 32-bit ones. Both land in the low bytes of the zero-initialised
+  // buffer above, so a single reader handles either width.
+  if (len != sizeof(std::uint32_t) && len != sizeof(std::uint64_t)) {
+    return std::nullopt;
+  }
+  if (value == 0 || value > static_cast<std::uint64_t>(std::numeric_limits<int64_t>::max())) {
+    return std::nullopt;
+  }
+  return static_cast<int64_t>(value);
+}
+
+/* Query the sysctl `perflevel` hierarchy and store L1 -> [0] and L2 -> [1]. Anything that
+ * cannot be determined is left at its kUninitCache default so the compiled fallbacks in
+ * the header apply.
+ *
+ * This function is only the platform query; the policy that turns the readings into
+ * per-thread sizes lives in ReduceHeterogeneousCaches so it can be tested directly.
+ */
+template <std::int32_t kMaxCacheSize>
+void DetectDataCachesSysctl(int64_t* cache_sizes) {
+  static_assert(kMaxCacheSize >= 2, "Need slots for L1 and L2.");
+
+  const std::optional<int64_t> n_levels = ReadSysctlInt("hw.nperflevels");
+  if (!n_levels) {
+    return;
+  }
+
+  std::vector<xgboost::common::detail::PerfLevelCache> levels;
+  levels.reserve(static_cast<std::size_t>(*n_levels));
+  for (int64_t level = 0; level < *n_levels; ++level) {
+    const std::string prefix = "hw.perflevel" + std::to_string(level) + ".";
+    levels.push_back({ReadSysctlInt(prefix + "l1dcachesize"), ReadSysctlInt(prefix + "l2cachesize"),
+                      ReadSysctlInt(prefix + "cpusperl2")});
+  }
+
+  const auto sizes = xgboost::common::detail::ReduceHeterogeneousCaches(
+      xgboost::common::Span<xgboost::common::detail::PerfLevelCache const>{levels.data(),
+                                                                           levels.size()});
+  if (sizes.l1d) {
+    cache_sizes[0] = *sizes.l1d;
+  }
+  if (sizes.l2_per_cpu) {
+    cache_sizes[1] = *sizes.l2_per_cpu;
+  }
+  // The Apple system level cache is not exposed through sysctl; leave L3 unset.
+}
+
+}  // namespace
+
 #endif  // defined(__x86_64__)
 
 namespace xgboost::common {
+namespace detail {
+/* Reduce per-performance-level readings to the sizes one thread can rely on.
+ *
+ * Heterogeneous CPUs such as Apple Silicon differ from x86 in two ways that matter here:
+ *
+ *   - Performance and efficiency cores report different L1d and L2 sizes, and XGBoost
+ *     spreads its threads over both. The minimum is taken because, as the header notes,
+ *     overestimating a cache costs more than underestimating it: a block sized for a
+ *     performance core's L1 would spill on an efficiency core.
+ *   - L2 is shared by every core in a cluster rather than being private per core, so a
+ *     raw cluster size is not what a single thread can rely on. Dividing by the sharing
+ *     factor restores the per-thread meaning that the callers in hist_util.cc and
+ *     tree/hist/histogram.h assume.
+ *
+ * A level contributes an L2 estimate only when its sharing factor is also known, since an
+ * undivided cluster size would overestimate the per-thread budget several-fold.
+ *
+ * This is compiled on every platform, not just the ones with heterogeneous cores, so the
+ * policy stays under test everywhere.
+ */
+DataCacheSizes ReduceHeterogeneousCaches(Span<PerfLevelCache const> levels) {
+  DataCacheSizes out;
+  auto keep_min = [](std::optional<std::int64_t>* acc, std::int64_t value) {
+    *acc = acc->has_value() ? std::min(**acc, value) : value;
+  };
 
-/* Detect CPU cache sizes at runtime: CPUID on x86_64, sysfs on non-x86_64 Linux,
- * and compiled L1/L2/L3 defaults otherwise (or for any size detection leaves unset).
+  for (auto const& level : levels) {
+    if (level.l1d && *level.l1d > 0) {
+      keep_min(&out.l1d, *level.l1d);
+    }
+    if (level.l2 && level.cpus_per_l2 && *level.l2 > 0 && *level.cpus_per_l2 > 0) {
+      keep_min(&out.l2_per_cpu, *level.l2 / *level.cpus_per_l2);
+    }
+  }
+  // A cluster smaller than its sharing factor would divide to zero, which the callers
+  // would then treat as a real size rather than falling back to the default.
+  if (out.l2_per_cpu && *out.l2_per_cpu <= 0) {
+    out.l2_per_cpu.reset();
+  }
+  return out;
+}
+}  // namespace detail
+
+/* Detect CPU cache sizes at runtime: CPUID on x86_64, sysfs on non-x86_64 Linux, sysctl on
+ * non-x86_64 Apple, and compiled L1/L2/L3 defaults otherwise (or for any size detection
+ * leaves unset).
  */
 CacheManager::CacheManager() {
 #if defined(__x86_64__)
   DetectDataCaches<kMaxCacheSize>(cache_size_.data());
 #elif defined(__linux__)
   DetectDataCachesSysfs<kMaxCacheSize>(cache_size_.data());
+#elif defined(__APPLE__)
+  DetectDataCachesSysctl<kMaxCacheSize>(cache_size_.data());
 #else
   SetDefaultCaches();
 #endif  // defined(__x86_64__)

--- a/src/common/cache_manager.h
+++ b/src/common/cache_manager.h
@@ -5,6 +5,7 @@
 #define XGBOOST_COMMON_CACHE_MANAGER_H_
 
 #include <array>
+#include <cstddef>   // for size_t
 #include <cstdint>   // for int64_t
 #include <optional>  // for optional
 
@@ -39,6 +40,21 @@ struct DataCacheSizes {
  */
 [[nodiscard]] DataCacheSizes ReduceHeterogeneousCaches(Span<PerfLevelCache const> levels);
 }  // namespace detail
+
+/* Size of a cache line in bytes.
+ *
+ * Used to pick prefetch strides and to keep concurrently written data from sharing a
+ * line. Apple Silicon uses 128-byte lines; the remaining targets use 64.
+ *
+ * std::hardware_destructive_interference_size is deliberately not used: libc++ reports 64
+ * for it on arm64, including on Apple Silicon, so it would reintroduce the same wrong
+ * value this constant exists to correct.
+ */
+#if defined(__APPLE__) && defined(__aarch64__)
+constexpr std::size_t kCacheLineSize = 128;
+#else
+constexpr std::size_t kCacheLineSize = 64;
+#endif  // defined(__APPLE__) && defined(__aarch64__)
 
 /* Detect cache sizes at runtime,
  * or fall back to defaults if detection is not possible.

--- a/src/common/cache_manager.h
+++ b/src/common/cache_manager.h
@@ -1,13 +1,44 @@
 /**
- * Copyright 2021-2025, XGBoost Contributors
+ * Copyright 2021-2026, XGBoost Contributors
  */
 #ifndef XGBOOST_COMMON_CACHE_MANAGER_H_
 #define XGBOOST_COMMON_CACHE_MANAGER_H_
 
-#include <cstdint>     // for int64_t
 #include <array>
+#include <cstdint>   // for int64_t
+#include <optional>  // for optional
+
+#include "xgboost/span.h"  // for Span
 
 namespace xgboost::common {
+
+namespace detail {
+/* Data cache sizes reported for one CPU performance level. An empty field means the
+ * platform did not report that quantity.
+ */
+struct PerfLevelCache {
+  std::optional<std::int64_t> l1d;
+  std::optional<std::int64_t> l2;
+  /* Number of cores sharing one L2, needed because L2 is per-cluster on heterogeneous
+   * CPUs rather than private per core as on x86.
+   */
+  std::optional<std::int64_t> cpus_per_l2;
+};
+
+/* The sizes a single thread can rely on, reduced over all performance levels. */
+struct DataCacheSizes {
+  std::optional<std::int64_t> l1d;
+  std::optional<std::int64_t> l2_per_cpu;
+};
+
+/* Reduce per-performance-level cache readings to per-thread sizes.
+ *
+ * Split out from the platform query so the policy can be tested with synthetic readings
+ * on any host, including topologies not present on the build machine. See
+ * cache_manager.cc for why the minimum is taken and why L2 is divided.
+ */
+[[nodiscard]] DataCacheSizes ReduceHeterogeneousCaches(Span<PerfLevelCache const> levels);
+}  // namespace detail
 
 /* Detect cache sizes at runtime,
  * or fall back to defaults if detection is not possible.
@@ -16,14 +47,14 @@ class CacheManager {
  private:
   constexpr static int64_t kUninitCache = -1;
   constexpr static int kMaxCacheSize = 4;
-  std::array<int64_t, kMaxCacheSize> cache_size_ = {kUninitCache, kUninitCache,
-                                                    kUninitCache, kUninitCache};
+  std::array<int64_t, kMaxCacheSize> cache_size_ = {kUninitCache, kUninitCache, kUninitCache,
+                                                    kUninitCache};
 
   constexpr static int64_t kDefaultL1Size = 32 * 1024;    // 32KB
   constexpr static int64_t kDefaultL2Size = 1024 * 1024;  // 1MB
   constexpr static int64_t kDefaultL3Size = 0;            // 0MB
 
-  // If CPUID cannot be used, fall back to default L1/L2 cache sizes.
+  // If no runtime detection is available, fall back to default L1/L2 cache sizes.
   void SetDefaultCaches() {
     // Overestimating cache sizes harms performance more than underestimation,
     // so conservative defaults are used.

--- a/src/common/hist_util.cc
+++ b/src/common/hist_util.cc
@@ -122,7 +122,6 @@ void SubtractionHist(GHistRow dst, const GHistRow src1, const GHistRow src2, siz
 
 struct Prefetch {
  public:
-  static constexpr size_t kCacheLineSize = 64;
   static constexpr size_t kPrefetchOffset = 10;
 
  private:
@@ -132,9 +131,11 @@ struct Prefetch {
  public:
   static size_t NoPrefetchSize(size_t rows) { return std::min(rows, kNoPrefetchSize); }
 
+  // One prefetch per cache line. Understating the line size only costs redundant
+  // prefetches, but overstating it would leave lines unprefetched.
   template <typename T>
   static constexpr size_t GetPrefetchStep() {
-    return Prefetch::kCacheLineSize / sizeof(T);
+    return kCacheLineSize / sizeof(T);
   }
 };
 

--- a/src/tree/hist/histogram.h
+++ b/src/tree/hist/histogram.h
@@ -296,11 +296,11 @@ common::BlockedSpace2d ConstructHistSpace(Partitioner const &partitioners,
   }
   std::size_t block_size = space_in_l1_for_rows / l1_row_foot_print;
 
-  /* Minimum block size = 8 rows.
-   * This ensures that a full cache line is utilized when loading gradient pairs.
+  /* Minimum block size = one cache line worth of gradient pairs.
+   * This ensures that a full cache line is utilized when loading gradient pairs, and that
+   * neighbouring blocks, which are processed by different threads, do not share one.
    */
-  constexpr std::size_t kCacheLineSize = 64;
-  constexpr std::size_t kMinBlockSize = kCacheLineSize / sizeof(GradientPair);
+  constexpr std::size_t kMinBlockSize = common::kCacheLineSize / sizeof(GradientPair);
   block_size = std::max<std::size_t>(kMinBlockSize, block_size);
 
   common::BlockedSpace2d space{nodes_to_build.size(),

--- a/tests/cpp/common/test_cache_manager.cc
+++ b/tests/cpp/common/test_cache_manager.cc
@@ -17,6 +17,12 @@
 #endif                // !defined(__x86_64__) && defined(__APPLE__)
 
 namespace xgboost::common {
+// The line size divides byte counts to give element strides, so a zero or non
+// power-of-two value would silently corrupt those strides. Both are compile-time
+// properties, so they are checked at compile time.
+static_assert(kCacheLineSize >= 32, "Cache line is implausibly small.");
+static_assert((kCacheLineSize & (kCacheLineSize - 1)) == 0, "Cache line is not a power of two.");
+
 namespace {
 std::optional<std::int64_t> Some(std::int64_t v) { return std::optional<std::int64_t>{v}; }
 constexpr std::optional<std::int64_t> kNone = std::nullopt;
@@ -156,5 +162,14 @@ TEST(CacheManager, AppleSilicon) {
   }
 }
 
+// kCacheLineSize is a compile-time constant, so this checks the value compiled in against
+// what the machine running the tests actually reports.
+TEST(CacheManager, AppleSiliconCacheLineSize) {
+  auto const reported = ReadSysctlInt("hw.cachelinesize");
+  if (reported <= 0) {
+    GTEST_SKIP() << "sysctl does not report a cache line size.";
+  }
+  ASSERT_EQ(static_cast<std::int64_t>(kCacheLineSize), reported);
+}
 #endif  // !defined(__x86_64__) && defined(__APPLE__)
 }  // namespace xgboost::common

--- a/tests/cpp/common/test_cache_manager.cc
+++ b/tests/cpp/common/test_cache_manager.cc
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ */
+#include <gtest/gtest.h>
+
+#include <cstdint>   // for int64_t
+#include <optional>  // for optional
+#include <vector>    // for vector
+
+#include "../../../src/common/cache_manager.h"
+
+#if !defined(__x86_64__) && defined(__APPLE__)
+#include <sys/sysctl.h>  // for sysctlbyname
+
+#include <algorithm>  // for min
+#include <string>     // for string, to_string
+#endif                // !defined(__x86_64__) && defined(__APPLE__)
+
+namespace xgboost::common {
+namespace {
+std::optional<std::int64_t> Some(std::int64_t v) { return std::optional<std::int64_t>{v}; }
+constexpr std::optional<std::int64_t> kNone = std::nullopt;
+
+detail::DataCacheSizes Reduce(std::vector<detail::PerfLevelCache> const& levels) {
+  return detail::ReduceHeterogeneousCaches(
+      Span<detail::PerfLevelCache const>{levels.data(), levels.size()});
+}
+}  // namespace
+
+/* The reduction policy is where the judgement calls live, so it is tested directly with
+ * synthetic readings. This runs on every platform, including CPU topologies that are not
+ * available to test on natively.
+ */
+TEST(CacheManager, ReduceHeterogeneousCaches) {
+  // No readings at all: nothing is claimed, so the callers fall back to defaults.
+  {
+    auto out = Reduce({});
+    ASSERT_FALSE(out.l1d.has_value());
+    ASSERT_FALSE(out.l2_per_cpu.has_value());
+  }
+  // A single homogeneous level, L2 shared by 4 cores.
+  {
+    auto out = Reduce({{Some(64 * 1024), Some(4 * 1024 * 1024), Some(4)}});
+    ASSERT_EQ(out.l1d, 64 * 1024);
+    ASSERT_EQ(out.l2_per_cpu, 1024 * 1024);
+  }
+  // Two levels, as on an Apple M4 Max: 128KB/16MB shared by 6 performance cores and
+  // 64KB/4MB shared by 4 efficiency cores. The smaller of each must win, because a
+  // thread may land on either.
+  {
+    auto out = Reduce({{Some(128 * 1024), Some(16 * 1024 * 1024), Some(6)},
+                       {Some(64 * 1024), Some(4 * 1024 * 1024), Some(4)}});
+    ASSERT_EQ(out.l1d, 64 * 1024);
+    ASSERT_EQ(out.l2_per_cpu, 1024 * 1024);
+  }
+  // Order must not matter.
+  {
+    auto out = Reduce({{Some(64 * 1024), Some(4 * 1024 * 1024), Some(4)},
+                       {Some(128 * 1024), Some(16 * 1024 * 1024), Some(6)}});
+    ASSERT_EQ(out.l1d, 64 * 1024);
+    ASSERT_EQ(out.l2_per_cpu, 1024 * 1024);
+  }
+  // A level with an unknown sharing factor contributes no L2 estimate, since an
+  // undivided cluster size would overestimate the per-thread budget. Its L1 still counts.
+  {
+    auto out = Reduce({{Some(32 * 1024), Some(16 * 1024 * 1024), kNone}});
+    ASSERT_EQ(out.l1d, 32 * 1024);
+    ASSERT_FALSE(out.l2_per_cpu.has_value());
+  }
+  // Mixed: only the level that reports a sharing factor contributes L2.
+  {
+    auto out = Reduce({{Some(128 * 1024), Some(16 * 1024 * 1024), kNone},
+                       {Some(64 * 1024), Some(4 * 1024 * 1024), Some(4)}});
+    ASSERT_EQ(out.l1d, 64 * 1024);
+    ASSERT_EQ(out.l2_per_cpu, 1024 * 1024);
+  }
+  // Missing and non-positive readings are ignored rather than propagated as sizes.
+  {
+    auto out = Reduce({{kNone, kNone, kNone}, {Some(0), Some(-1), Some(0)}});
+    ASSERT_FALSE(out.l1d.has_value());
+    ASSERT_FALSE(out.l2_per_cpu.has_value());
+  }
+  // A sharing factor larger than the cluster would divide to zero; that must not be
+  // reported as a real size.
+  {
+    auto out = Reduce({{Some(64 * 1024), Some(2), Some(64)}});
+    ASSERT_EQ(out.l1d, 64 * 1024);
+    ASSERT_FALSE(out.l2_per_cpu.has_value());
+  }
+}
+
+TEST(CacheManager, Sizes) {
+  CacheManager cache_manager;
+
+  // The accessors substitute compiled defaults for anything detection left unset, so a
+  // size is always usable as a divisor or a budget.
+  ASSERT_GT(cache_manager.L1Size(), 0);
+  ASSERT_GT(cache_manager.L2Size(), 0);
+  ASSERT_GE(cache_manager.L3Size(), 0);
+
+  // The histogram heuristics treat L1 as a subset of the budget they compare against L2,
+  // so an inverted hierarchy would silently mis-tune them.
+  ASSERT_GE(cache_manager.L2Size(), cache_manager.L1Size());
+
+  // Detection must not depend on when the object is constructed.
+  CacheManager other;
+  ASSERT_EQ(cache_manager.L1Size(), other.L1Size());
+  ASSERT_EQ(cache_manager.L2Size(), other.L2Size());
+  ASSERT_EQ(cache_manager.L3Size(), other.L3Size());
+}
+
+#if !defined(__x86_64__) && defined(__APPLE__)
+namespace {
+std::int64_t ReadSysctlInt(std::string const& name) {
+  std::uint64_t value = 0;
+  std::size_t len = sizeof(value);
+  if (::sysctlbyname(name.c_str(), &value, &len, nullptr, 0) != 0) {
+    return -1;
+  }
+  return value > 0 ? static_cast<std::int64_t>(value) : -1;
+}
+}  // namespace
+
+// Guards against detection silently failing and leaving the compiled defaults in place,
+// which is invisible to the checks above because those defaults are also valid sizes.
+TEST(CacheManager, AppleSilicon) {
+  auto const n_levels = ReadSysctlInt("hw.nperflevels");
+  if (n_levels <= 0) {
+    GTEST_SKIP() << "sysctl does not report performance levels.";
+  }
+
+  std::int64_t expected_l1d = -1;
+  std::int64_t expected_l2 = -1;
+  for (std::int64_t level = 0; level < n_levels; ++level) {
+    auto const prefix = "hw.perflevel" + std::to_string(level) + ".";
+
+    auto const l1d = ReadSysctlInt(prefix + "l1dcachesize");
+    if (l1d > 0) {
+      expected_l1d = expected_l1d > 0 ? std::min(expected_l1d, l1d) : l1d;
+    }
+
+    auto const l2 = ReadSysctlInt(prefix + "l2cachesize");
+    auto const cpus_per_l2 = ReadSysctlInt(prefix + "cpusperl2");
+    if (l2 > 0 && cpus_per_l2 > 0) {
+      auto const per_cpu = l2 / cpus_per_l2;
+      expected_l2 = expected_l2 > 0 ? std::min(expected_l2, per_cpu) : per_cpu;
+    }
+  }
+
+  CacheManager cache_manager;
+  if (expected_l1d > 0) {
+    ASSERT_EQ(cache_manager.L1Size(), expected_l1d);
+  }
+  if (expected_l2 > 0) {
+    ASSERT_EQ(cache_manager.L2Size(), expected_l2);
+  }
+}
+
+#endif  // !defined(__x86_64__) && defined(__APPLE__)
+}  // namespace xgboost::common


### PR DESCRIPTION
The CPU histogram builder hardcodes a 64-byte cache line in two places:

- `src/common/hist_util.cc` — `Prefetch::kCacheLineSize`, which sets the prefetch
  stride and the size of the no-prefetch tail.
- `src/tree/hist/histogram.h` — a local `kCacheLineSize` used to floor the block
  size, with a comment stating its purpose is "to ensure a full cache line is
  utilized when loading gradient pairs".

Apple Silicon uses 128-byte lines (`sysctl hw.cachelinesize` reports 128). On
that target both constants work against their own stated intent: the prefetch
loop issues two prefetches per line instead of one, and the minimum block covers
half a line, so neighbouring blocks handed to different threads can share one.

This replaces both with a single `common::kCacheLineSize`, placed in
`cache_manager.h` next to the other cache facts and selected per target.

### Why not `std::hardware_destructive_interference_size`

That would be the idiomatic way to express this, and it is not usable here.
libc++ reports **64** for it on arm64, including Apple Silicon, so it would
reintroduce the exact value this constant exists to correct. Verified rather
than assumed:

```
$ clang++ -std=c++17 hdis.cc && ./a.out     # Apple clang 17, arm64
__cpp_lib_hardware_interference_size = 201703
destructive  = 64
constructive = 64
```

### Verification

The two compile-time properties — plausibility and power-of-two-ness — are
checked with `static_assert` rather than at runtime, since the compiler can
prove both. A separate test asserts the compiled constant against
`hw.cachelinesize`, so a wrong value fails loudly instead of silently mistuning
the build:

- `CacheManager.AppleSiliconCacheLineSize` — compiled constant vs. what the
  machine reports.

### Performance

**This is a correctness fix, not a measured speedup, and I want to be explicit
about that.** Across 27 interleaved training runs on an M4 Max — row-wise,
column-wise and sparse shapes, with rotated ordering — it made no difference
outside noise in either direction. The minimum block size rarely binds in
practice, because `block_size` is normally in the hundreds of rows.

It is worth having because the constant is simply wrong for the target, and
because the false sharing it permits is a function of thread count and partition
layout rather than of the three shapes I happened to measure.

### Compatibility

No behaviour change on any other target — `kCacheLineSize` is 64 there, exactly
as before. 745 C++ unit tests pass on macOS arm64, and the x86_64 branch was
cross-compiled to confirm it still builds.

### Note

Stacks on (`Detect CPU cache sizes on Apple Silicon`), which introduces the
new contents of `cache_manager.h`. Please merge that one first.