### PR TITLE
Allow runtime type validation of scikit-learn API

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -23,6 +23,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    runtime_checkable,
 )
 
 import numpy as np
@@ -156,6 +157,7 @@ def _can_use_qdm(tree_method: Optional[str], device: Optional[str]) -> bool:
     return tree_method in ("hist", None, "auto") and not_sycl
 
 
+@runtime_checkable
 class _SklObjWProto(Protocol):
     def __call__(
         self,


### PR DESCRIPTION
Pydantic (or other runtime type validation), in particular `validate_call`, is useful to ensure parameters are passed correctly. XGBoost benefits from this during ML experiments with often varying parameters, as frameworks like [hydra-zen](https://mit-ll-responsible-ai.github.io/hydra-zen/how_to/pydantic_guide.html) suggest.

Validation on `xgboost.sklearn.XGBoostRegressor` currently fails, because the constructor relies on `xgboost.sklearn_SklObjWProto` for typing, which is not [runtime_checkable](https://docs.python.org/3/library/typing.html#typing.runtime_checkable).

This PR introduces the minimally invasive change of adding the decorator to the class definition of `xgboost.sklearn_SklObjWProto`. No operational code is affected.

## Minimal reproducible example

To illustrate the problem, find a minimal reproducible example including the fix.

Run with the following. Present in all supported python versions, adjust with `--python=x`.

```sh
uv run --script --python=3.14 mre.py
```

Run the following to illustrate the fix

```sh
uv run --script --python=3.14 mre.py --fix
```

The code is a self-contained script (PEP723) and uses hydra-zen for its convenience function of pydantic validation. Copy as `mre.py` to run the commands above.

```python
#!/usr/bin/env -S uv run --script
# /// script
# requires-python = ">=3.12"
# dependencies = [
#   "hydra_zen",
#   "pydantic",
#   "xgboost",
# ]
# ///

from argparse import ArgumentParser
from platform import python_version
from typing import runtime_checkable

from hydra_zen.third_party.pydantic import pydantic_parser
from xgboost import XGBRegressor, __version__, sklearn


def fix_issue():
    """Fix the issue by adding the @runtime_checkable decorator to _SklObjWProto."""
    sklearn._SklObjWProto = runtime_checkable(sklearn._SklObjWProto)


if __name__ == "__main__":
    # Turn into working example if passing --fix
    parser = ArgumentParser()
    parser.add_argument("--fix", action="store_true")
    fix = parser.parse_args().fix
    if fix:
        fix_issue()

    print(f"python=={python_version()}")
    print(f"xgboost=={__version__}")
    print(f"fix=={fix}")

    # Offending command: Validate the XGBoostRegressor constructor signature
    pydantic_parser(XGBRegressor)  # Convenient pydantic wrapper by hydra-zen

```