### PR TITLE
Fix XGBClassifier.predict_proba returning invalid values for objective binary:logitraw

### DIFF
--- a/python-package/xgboost/sklearn.py
+++ b/python-package/xgboost/sklearn.py
@@ -27,7 +27,7 @@ from typing import (
 )
 
 import numpy as np
-from scipy.special import softmax
+from scipy.special import expit, softmax
 
 from ._c_api import _parse_version, _py_version
 from ._data_utils import Categories
@@ -1961,7 +1961,8 @@ class XGBClassifier(XGBClassifierMixIn, XGBModel):
         # softprob:        Do nothing, output is proba.
         # softmax:         Use softmax from scipy
         # binary:logistic: Expand the prob vector into 2-class matrix after predict.
-        # binary:logitraw: Unsupported by predict_proba()
+        # binary:logitraw: Apply the sigmoid to the raw margin, then expand the same
+        #                  way as binary:logistic.
         if self.objective == "multi:softmax":
             raw_predt = super().predict(
                 X=X,
@@ -1978,6 +1979,11 @@ class XGBClassifier(XGBClassifierMixIn, XGBModel):
             base_margin=base_margin,
             iteration_range=iteration_range,
         )
+        if self.objective == "binary:logitraw":
+            # `binary:logitraw` outputs the raw margin instead of a probability, so it
+            # needs to be transformed into a probability before it can be expanded into
+            # a 2-class matrix.
+            class_probs = expit(class_probs)
         return _cls_predict_proba(self.n_classes_, class_probs, np.vstack)
 
 

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -47,6 +47,26 @@ def test_binary_classification():
             assert err < 0.1
 
 
+def test_predict_proba_logitraw():
+    # Regression test for `binary:logitraw` producing an invalid first column in
+    # `predict_proba`, since the raw margin isn't a probability and can't be expanded
+    # into a 2-class matrix without first passing it through a sigmoid.
+    from scipy.special import expit
+
+    X = rng.standard_normal(size=(100, 4))
+    y = rng.randint(2, size=X.shape[0])
+
+    clf = xgb.XGBClassifier(objective="binary:logitraw", n_estimators=2)
+    clf.fit(X, y)
+
+    proba = clf.predict_proba(X)
+    assert np.all(proba >= 0.0) and np.all(proba <= 1.0)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, rtol=1e-5)
+
+    raw = clf.get_booster().inplace_predict(X)
+    np.testing.assert_allclose(proba[:, 1], expit(raw), rtol=1e-5)
+
+
 @pytest.mark.parametrize("objective", ["multi:softmax", "multi:softprob"])
 def test_multiclass_classification(objective):
     from sklearn.datasets import load_iris


### PR DESCRIPTION
Fixes #11373

`binary:logitraw` makes the booster output a raw margin (logit), not a probability, but `predict_proba` always expanded the raw output into a 2-class matrix via `classzero = 1 - p`, which is only valid when `p` is already a probability. This produced values outside `[0, 1]` whose rows didn't sum to 1.

**Fix:** apply `scipy.special.expit` (sigmoid) to the raw margin before the existing 2-class expansion when `objective == "binary:logitraw"`, making it consistent with `binary:logistic`.

Added `test_predict_proba_logitraw`, checking probabilities are in `[0,1]`, rows sum to 1, and column 1 matches `expit(raw_margin)`.
