### PR TITLE
Use default intercept when resetting empty boosters

### DIFF
--- a/src/learner.cc
+++ b/src/learner.cc
@@ -1012,8 +1012,9 @@ class LearnerImpl : public LearnerIO {
     if (model_state_.NeedsInitialization()) {
       for (auto const& weak : cache_data_) {
         if (auto data = weak.lock()) {
+          // Constructor caches don't distinguish training data from evaluation data.
           this->InitializeModel(*data, this->cache_data_,
-                                InterceptInitialization::kEstimateIntercept);
+                                InterceptInitialization::kUseDefaultIntercept);
           break;
         }
       }

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -274,14 +274,26 @@ TEST(Learner, ModelInitializedByTrainingData) {
 
 TEST(Learner, ResetInitializesCachedModel) {
   auto train = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix(true);
-  auto learner = std::unique_ptr<Learner>{Learner::Create({train})};
-  learner->Configure({{"objective", "reg:absoluteerror"}});
-  EXPECT_EQ(learner->GetNumFeature(), 0);
+  auto eval = RandomDataGenerator{8, 4, 0.0f}.GenerateDMatrix(true);
+  std::fill(train->Info().labels.Data()->HostVector().begin(),
+            train->Info().labels.Data()->HostVector().end(), 10.0f);
+  std::fill(eval->Info().labels.Data()->HostVector().begin(),
+            eval->Info().labels.Data()->HostVector().end(), -5.0f);
 
-  EXPECT_NO_THROW(learner->Reset());
-  EXPECT_EQ(learner->GetNumFeature(), train->Info().num_col_);
-  Json model{Object{}};
-  EXPECT_NO_THROW(learner->SaveModel(&model));
+  for (auto const& cache : {std::vector<std::shared_ptr<DMatrix>>{train, eval},
+                            std::vector<std::shared_ptr<DMatrix>>{eval, train}}) {
+    auto learner = std::unique_ptr<Learner>{Learner::Create(cache)};
+    learner->Configure({{"objective", "reg:squarederror"}});
+    EXPECT_EQ(learner->GetNumFeature(), 0);
+
+    EXPECT_NO_THROW(learner->Reset());
+    EXPECT_EQ(learner->GetNumFeature(), train->Info().num_col_);
+    Json model{Object{}};
+    EXPECT_NO_THROW(learner->SaveModel(&model));
+    auto base_score = GetBaseScore(model);
+    ASSERT_EQ(base_score.size(), 1);
+    EXPECT_FLOAT_EQ(base_score.front(), ObjFunction::DefaultBaseScore());
+  }
 }
 
 TEST(Learner, LoadPendingModelInputsFromOldSnapshot) {


### PR DESCRIPTION
## Summary

- initialize an empty booster with the objective's default intercept during `Reset()` instead of estimating it from the first constructor cache entry
- continue using the cache matrix for structural metadata so the reset model remains initialized and serializable
- cover both cache orders with matrices whose labels have different means

## Motivation

`XGBoosterCreate()` cache entries do not identify which matrix is training data. Previously, resetting an empty booster estimated its intercept from the first live cache entry, so swapping training and evaluation matrices changed the zero-tree model's `base_score` and predictions.

`Reset()` should release runtime caches without selecting an arbitrary cache matrix as training data. Using the objective default preserves deterministic empty-model behavior while retaining the existing structural initialization.

Fixes #12457.

## Validation

- full CPU C++ suite: 749 passed, 3 platform-dependent tests skipped
- learner and intercept-focused C++ tests: 25 passed
- changed-file pre-commit hooks, including clang-format and cpplint
- Python public-API reproduction with both cache orders; both now produce `base_score = 0.5` and predictions of `0.5`
