### PR TITLE
[python-package] Fix custom feature names for Arrow inputs

### DIFF
--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -819,8 +819,7 @@ def _transform_arrow_table(
         feature_types = t_types
 
     columns = []
-    for cname in feature_names:
-        col0 = data.column(cname)
+    for col0 in data.columns:
         col: Union["pa.NumericArray", "pa.DictionaryArray"] = col0.combine_chunks()
         if isinstance(col, pa.BooleanArray):
             col = col.cast(pa.int8())  # bit-compressed array, not supported.

--- a/tests/python/test_with_arrow.py
+++ b/tests/python/test_with_arrow.py
@@ -34,6 +34,13 @@ class TestArrowTable:
         assert dm.num_row() == 2
         assert dm.num_col() == 4
 
+    @pytest.mark.parametrize("DMatrixT", [xgb.DMatrix, xgb.QuantileDMatrix])
+    def test_arrow_table_with_custom_feature_names(self, DMatrixT):
+        table = pa.table({"a": [1, 2], "b": [1.0, 2.0]})
+        dm = DMatrixT(table, feature_names=["x", "y"])
+        assert dm.feature_names == ["x", "y"]
+        assert dm.feature_types == ["int", "float"]
+
     def test_arrow_table_with_label(self):
         df = pd.DataFrame([[1, 2.0, 3.0], [2, 3.0, 4.0]], columns=["a", "b", "c"])
         table = pa.Table.from_pandas(df)

--- a/tests/python/test_with_arrow.py
+++ b/tests/python/test_with_arrow.py
@@ -37,6 +37,9 @@ class TestArrowTable:
     @pytest.mark.parametrize("DMatrixT", [xgb.DMatrix, xgb.QuantileDMatrix])
     def test_arrow_table_with_custom_feature_names(self, DMatrixT):
         table = pa.table({"a": [1, 2], "b": [1.0, 2.0]})
+        dm = DMatrixT(table)
+        assert dm.feature_names == ["a", "b"]
+
         dm = DMatrixT(table, feature_names=["x", "y"])
         assert dm.feature_names == ["x", "y"]
         assert dm.feature_types == ["int", "float"]


### PR DESCRIPTION
## Summary

- Fix PyArrow table ingestion when callers supply custom `feature_names` to `DMatrix` or `QuantileDMatrix`.
- Add a regression test that checks custom names and inferred types for both constructors.

When a table's schema uses names such as `a` and `b`, custom names such as `x` and `y` are output metadata, not schema selectors. The Arrow conversion previously used the custom names to look up table columns and raised `KeyError: Field "x" does not exist in schema`. The conversion now iterates over the table's actual columns while preserving the supplied feature names.

## Validation

```text
PYTHONPATH=./python-package python -m pytest -q tests/python/test_with_arrow.py::TestArrowTable::test_arrow_table_with_custom_feature_names
# 2 passed

PYTHONPATH=./python-package python -m pytest -q tests/python/test_with_arrow.py tests/python/test_with_pandas.py::TestPandas::test_pandas
# 10 passed

pre-commit run --files python-package/xgboost/data.py tests/python/test_with_arrow.py
# all applicable hooks passed
```

## AI assistance

This patch was prepared with AI assistance; the reported behavior was reproduced and the listed local tests were run against the submitted diff.
