### PR TITLE
Make the serialized RNG state portable across platforms

### DIFF
--- a/include/xgboost/context.h
+++ b/include/xgboost/context.h
@@ -5,13 +5,13 @@
 #ifndef XGBOOST_CONTEXT_H_
 #define XGBOOST_CONTEXT_H_
 
-#include <xgboost/base.h>       // for bst_d_ordinal_t
-#include <xgboost/logging.h>    // for CHECK_GE
-#include <xgboost/parameter.h>  // for XGBoostParameter
+#include <xgboost/base.h>           // for bst_d_ordinal_t
+#include <xgboost/logging.h>        // for CHECK_GE
+#include <xgboost/parameter.h>      // for XGBoostParameter
+#include <xgboost/philox_engine.h>  // for Philox4x32
 
 #include <cstdint>      // for int16_t, int32_t, int64_t
 #include <memory>       // for shared_ptr
-#include <random>       // for mt19937
 #include <string>       // for string, to_string
 #include <type_traits>  // for invoke_result_t, is_same_v, underlying_type_t
 
@@ -20,24 +20,31 @@ namespace xgboost {
 class Json;
 struct CUDAContext;
 /**
- * @brief Define mt19937 as default type Random Engine.
+ * @brief The default random engine, a counter-based Philox.
+ *
+ * @ref PhiloxEngine matches C++26's `std::philox_engine`, so this becomes an alias for the
+ * standard type once the implementations we build against ship one.
  */
-using RandomEngine = std::mt19937;
+using RandomEngine = Philox4x32;
 
 /**
  * @brief A @ref RandomEngine whose state can be serialized portably.
  *
- * The text written by `operator<<` for `std::mt19937` is not portable across standard
- * library implementations. libstdc++ emits the state words in raw order followed by the
- * current position, while libc++ and the MSVC STL emit the words rotated into canonical
- * order and omit the position. libstdc++ also forces `std::dec` as the standard requires,
- * whereas the MSVC STL honours whatever format flags the stream carries. A memory
- * snapshot (Python pickle, R RDS) holding that text is therefore unreadable on a platform
- * other than the one that wrote it.
+ * An engine's own textual form is no help here. `operator<<` for `std::mt19937`, which we
+ * used to write out, is spelled differently by every standard library: libstdc++ emits the
+ * state words in raw order followed by the current position, while libc++ and the MSVC STL
+ * emit them rotated into canonical order and omit the position. libstdc++ also forces
+ * `std::dec` as the standard requires, whereas the MSVC STL honours whatever format flags
+ * the stream carries. A memory snapshot (Python pickle, R RDS) holding that text was
+ * therefore unreadable on any platform other than the one that wrote it.
  *
  * So record the seed and the number of draws taken since it was applied instead. Both are
  * plain integers, and replaying the draws with @ref RandomEngine::discard reconstructs the
- * state exactly on every implementation.
+ * state exactly. The format says nothing about how the engine works internally, so it
+ * survives a change of engine as long as the new one can be seeded and skipped ahead.
+ *
+ * Skipping ahead is why the engine is counter-based: @ref PhiloxEngine::discard is O(1),
+ * so restoring is a constant-time operation however long the model trained for.
  */
 class SerializableRandomEngine {
  public:

--- a/include/xgboost/context.h
+++ b/include/xgboost/context.h
@@ -24,6 +24,63 @@ struct CUDAContext;
  */
 using RandomEngine = std::mt19937;
 
+/**
+ * @brief A @ref RandomEngine whose state can be serialized portably.
+ *
+ * The text written by `operator<<` for `std::mt19937` is not portable across standard
+ * library implementations. libstdc++ emits the state words in raw order followed by the
+ * current position, while libc++ and the MSVC STL emit the words rotated into canonical
+ * order and omit the position. libstdc++ also forces `std::dec` as the standard requires,
+ * whereas the MSVC STL honours whatever format flags the stream carries. A memory
+ * snapshot (Python pickle, R RDS) holding that text is therefore unreadable on a platform
+ * other than the one that wrote it.
+ *
+ * So record the seed and the number of draws taken since it was applied instead. Both are
+ * plain integers, and replaying the draws with @ref RandomEngine::discard reconstructs the
+ * state exactly on every implementation.
+ */
+class SerializableRandomEngine {
+ public:
+  using result_type = RandomEngine::result_type;  // NOLINT
+
+ private:
+  RandomEngine engine_;
+  result_type seed_{RandomEngine::default_seed};
+  // Number of draws taken since the engine was last seeded.
+  std::uint64_t n_advanced_{0};
+
+ public:
+  SerializableRandomEngine() = default;
+  explicit SerializableRandomEngine(result_type seed) { this->seed(seed); }
+
+  [[nodiscard]] static constexpr result_type min() { return RandomEngine::min(); }  // NOLINT
+  [[nodiscard]] static constexpr result_type max() { return RandomEngine::max(); }  // NOLINT
+
+  void seed(result_type seed) {  // NOLINT
+    this->seed_ = seed;
+    this->n_advanced_ = 0;
+    this->engine_.seed(seed);
+  }
+  result_type operator()() {
+    this->n_advanced_++;
+    return this->engine_();
+  }
+  void discard(std::uint64_t z) {  // NOLINT
+    this->n_advanced_ += z;
+    this->engine_.discard(z);
+  }
+
+  /** @brief The seed that the engine was last seeded with. */
+  [[nodiscard]] result_type Seed() const { return this->seed_; }
+  /** @brief Number of draws taken since the engine was last seeded. */
+  [[nodiscard]] std::uint64_t NumAdvanced() const { return this->n_advanced_; }
+  /** @brief Restore a state previously read out of @ref Seed and @ref NumAdvanced. */
+  void Restore(result_type seed, std::uint64_t n_advanced) {
+    this->seed(seed);
+    this->discard(n_advanced);
+  }
+};
+
 // symbolic names
 struct DeviceSym {
   static auto constexpr CPU() { return "cpu"; }
@@ -227,7 +284,7 @@ struct Context : public XGBoostParameter<Context> {
   /**
    * @brief Get the random engine.
    */
-  [[nodiscard]] RandomEngine& Rng() const { return rng_; }
+  [[nodiscard]] SerializableRandomEngine& Rng() const { return rng_; }
 
   [[nodiscard]] Json ToJson() const;
   void FromJson(Json const& in);
@@ -320,7 +377,7 @@ struct Context : public XGBoostParameter<Context> {
   // shared_ptr is used instead of unique_ptr as with unique_ptr it's difficult to define
   // p_impl while trying to hide CUDA code from the host compiler.
   mutable std::shared_ptr<CUDAContext> cuctx_;
-  mutable RandomEngine rng_;
+  mutable SerializableRandomEngine rng_;
   // cached value for CFS CPU limit. (used in containerized env)
   std::int32_t cfs_cpu_count_;  // NOLINT
 };

--- a/include/xgboost/philox_engine.h
+++ b/include/xgboost/philox_engine.h
@@ -1,0 +1,247 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ *
+ * @brief A counter-based random number engine, matching C++26's `std::philox_engine`.
+ */
+#ifndef XGBOOST_PHILOX_ENGINE_H_
+#define XGBOOST_PHILOX_ENGINE_H_
+
+#include <array>        // for array
+#include <cstddef>      // for size_t
+#include <cstdint>      // for uint32_t, uint64_t
+#include <limits>       // for numeric_limits
+#include <type_traits>  // for is_unsigned_v
+
+namespace xgboost {
+namespace detail {
+/**
+ * @brief The full 2w-bit product of two w-bit words, as a pair of 64-bit halves.
+ *
+ * Written out by hand from 32-bit partial products. `__uint128_t` is not available on
+ * MSVC, and `_umul128` is not available off x86-64, but this is portable everywhere and
+ * compiles down to a single multiply instruction on the platforms that have one.
+ */
+inline void UMul64(std::uint64_t a, std::uint64_t b, std::uint64_t* p_hi, std::uint64_t* p_lo) {
+  constexpr std::uint64_t kLoMask = 0xffffffffULL;
+  std::uint64_t const a_lo = a & kLoMask, a_hi = a >> 32;
+  std::uint64_t const b_lo = b & kLoMask, b_hi = b >> 32;
+
+  std::uint64_t const ll = a_lo * b_lo;
+  std::uint64_t const lh = a_lo * b_hi;
+  std::uint64_t const hl = a_hi * b_lo;
+  std::uint64_t const hh = a_hi * b_hi;
+
+  std::uint64_t const cross = (ll >> 32) + (hl & kLoMask) + lh;
+  *p_hi = hh + (cross >> 32) + (hl >> 32);
+  *p_lo = (cross << 32) | (ll & kLoMask);
+}
+}  // namespace detail
+
+/**
+ * @brief A counter-based random number engine of the Philox family.
+ *
+ * The interface and the generated sequence both follow `std::philox_engine`, specified in
+ * [rand.eng.philox] for C++26. We carry our own copy because no standard library we build
+ * against ships one yet; when they do, this can become an alias for `std::philox_engine`
+ * without changing a single number. @ref Philox4x32 and @ref Philox4x64 correspond to
+ * `std::philox4x32` and `std::philox4x64`.
+ *
+ * Unlike the Mersenne twister, the state here is a key and a counter rather than a large
+ * buffer that each draw shuffles forward. The output is a pure function of the two, which
+ * buys two properties that matter to us:
+ *
+ * - @ref discard is O(1). Skipping ahead is addition on the counter, not replay. That is
+ *   what lets a serialized state be restored in constant time. See
+ *   @ref SerializableRandomEngine.
+ * - The state is a handful of integers with a layout we define, so it can be written down
+ *   and read back on any platform. The textual form of `std::mt19937` cannot: libstdc++,
+ *   libc++ and the MSVC STL each spell it differently.
+ *   See https://github.com/dmlc/xgboost/issues/12459 .
+ *
+ * The device-side code already draws from Philox through libcu++
+ * (`common::cuda_impl::DefaultRng`), so this also brings the host in line with it.
+ *
+ * @tparam UIntType The unsigned result type.
+ * @tparam w        Word size in bits.
+ * @tparam n        Number of words in the counter and in the output block.
+ * @tparam r        Number of rounds.
+ * @tparam consts   The n constants, alternating multiplier and round constant.
+ */
+template <typename UIntType, std::size_t w, std::size_t n, std::size_t r, UIntType... consts>
+class PhiloxEngine {
+  static_assert(std::is_unsigned_v<UIntType>, "UIntType must be an unsigned integer type.");
+  static_assert(sizeof...(consts) == n, "Expecting n constants.");
+  static_assert(n == 2 || n == 4, "Only 2 and 4 words are specified.");
+  static_assert(r > 0, "At least one round is required.");
+  static_assert(w > 0 && w <= std::numeric_limits<UIntType>::digits, "Invalid word size.");
+  static_assert(w <= 64, "Words wider than 64 bits are not supported.");
+
+ public:
+  using result_type = UIntType;  // NOLINT
+
+  static constexpr std::size_t word_size = w;             // NOLINT
+  static constexpr std::size_t word_count = n;            // NOLINT
+  static constexpr std::size_t round_count = r;           // NOLINT
+  static constexpr result_type default_seed = 20111115u;  // NOLINT
+
+ private:
+  static constexpr std::array<result_type, n> kConsts{consts...};
+
+  static constexpr std::array<result_type, n / 2> SelectConsts(std::size_t offset) {
+    std::array<result_type, n / 2> out{};
+    for (std::size_t k = 0; k < n / 2; ++k) {
+      out[k] = kConsts[2 * k + offset];
+    }
+    return out;
+  }
+
+ public:
+  /** @brief The multipliers, the even-indexed template constants. */
+  static constexpr std::array<result_type, n / 2> multipliers = SelectConsts(0);  // NOLINT
+  /** @brief The Weyl round constants, the odd-indexed template constants. */
+  static constexpr std::array<result_type, n / 2> round_consts = SelectConsts(1);  // NOLINT
+
+  [[nodiscard]] static constexpr result_type min() { return 0; }  // NOLINT
+  [[nodiscard]] static constexpr result_type max() {              // NOLINT
+    if constexpr (w == std::numeric_limits<result_type>::digits) {
+      return std::numeric_limits<result_type>::max();
+    } else {
+      return static_cast<result_type>((static_cast<result_type>(1) << w) - 1);
+    }
+  }
+
+ private:
+  // The counter, incremented once per generated block.
+  std::array<result_type, n> x_{};
+  // The key, derived from the seed.
+  std::array<result_type, n / 2> k_{};
+  // The current block of outputs.
+  std::array<result_type, n> y_{};
+  // Index of the next output within the block.
+  std::size_t i_{n - 1};
+
+  static constexpr std::uint64_t kMax64 = static_cast<std::uint64_t>(max());
+
+  [[nodiscard]] static result_type MulHi(result_type a, result_type b) {
+    std::uint64_t hi = 0, lo = 0;
+    detail::UMul64(static_cast<std::uint64_t>(a), static_cast<std::uint64_t>(b), &hi, &lo);
+    if constexpr (w == 64) {
+      return static_cast<result_type>(hi);
+    } else {
+      return static_cast<result_type>(((hi << (64 - w)) | (lo >> w)) & kMax64);
+    }
+  }
+  [[nodiscard]] static result_type MulLo(result_type a, result_type b) {
+    auto product = static_cast<std::uint64_t>(a) * static_cast<std::uint64_t>(b);
+    return static_cast<result_type>(product & kMax64);
+  }
+  /**
+   * @brief The word permutation f_n. Identity for n == 2, (2, 1, 0, 3) for n == 4.
+   */
+  [[nodiscard]] static constexpr std::size_t Permute(std::size_t j) {
+    if constexpr (n == 2) {
+      return j;
+    } else {
+      return j == 0 ? 2 : (j == 2 ? 0 : j);
+    }
+  }
+
+  /** @brief Fill the output block from the current key and counter. */
+  void GenerateBlock() {
+    auto state = this->x_;
+    for (std::size_t q = 0; q < r; ++q) {
+      std::array<result_type, n> v{};
+      for (std::size_t j = 0; j < n; ++j) {
+        v[j] = state[Permute(j)];
+      }
+      for (std::size_t k = 0; k < n / 2; ++k) {
+        // The key for this round, bumped by a Weyl increment each round.
+        auto key = static_cast<result_type>(
+            (static_cast<std::uint64_t>(this->k_[k]) +
+             static_cast<std::uint64_t>(q) * static_cast<std::uint64_t>(round_consts[k])) &
+            kMax64);
+        state[2 * k] =
+            static_cast<result_type>(MulHi(v[2 * k], multipliers[k]) ^ key ^ v[2 * k + 1]);
+        state[2 * k + 1] = MulLo(v[2 * k], multipliers[k]);
+      }
+    }
+    this->y_ = state;
+  }
+
+  /** @brief Add @p z to the counter, which is an n * w bit unsigned integer. */
+  void AdvanceCounter(std::uint64_t z) {
+    for (std::size_t j = 0; j < n && z != 0; ++j) {
+      std::uint64_t const sum = static_cast<std::uint64_t>(this->x_[j]) + (z & kMax64);
+      this->x_[j] = static_cast<result_type>(sum & kMax64);
+      std::uint64_t const carry = sum > kMax64 ? 1 : 0;
+      if constexpr (w >= 64) {
+        z = carry;
+      } else {
+        z = (z >> w) + carry;
+      }
+    }
+  }
+
+ public:
+  PhiloxEngine() : PhiloxEngine{default_seed} {}
+  explicit PhiloxEngine(result_type value) { this->seed(value); }
+
+  /**
+   * @brief Restart the sequence from @p value.
+   *
+   * Sets the first word of the key to @p value, zeros the rest of the key and the whole
+   * counter, and positions the engine at the end of a block so that the next draw
+   * generates a fresh one.
+   */
+  void seed(result_type value = default_seed) {  // NOLINT
+    this->x_.fill(0);
+    this->k_.fill(0);
+    this->y_.fill(0);
+    this->k_[0] = static_cast<result_type>(static_cast<std::uint64_t>(value) & kMax64);
+    this->i_ = n - 1;
+  }
+
+  result_type operator()() {
+    this->i_++;
+    if (this->i_ == n) {
+      this->GenerateBlock();
+      this->AdvanceCounter(1);
+      this->i_ = 0;
+    }
+    return this->y_[this->i_];
+  }
+
+  /**
+   * @brief Skip @p z draws.
+   *
+   * Equivalent to calling @ref operator() @p z times, but the cost does not depend on
+   * @p z: at most one block is generated no matter how far ahead we jump.
+   */
+  void discard(std::uint64_t z) {  // NOLINT
+    std::uint64_t const pos = static_cast<std::uint64_t>(this->i_) + z;
+    std::uint64_t const n_blocks = pos / n;
+    if (n_blocks > 0) {
+      // The block we land in was generated from the counter as it stood `n_blocks - 1`
+      // steps on, and the counter is left one step past that.
+      this->AdvanceCounter(n_blocks - 1);
+      this->GenerateBlock();
+      this->AdvanceCounter(1);
+    }
+    this->i_ = static_cast<std::size_t>(pos % n);
+  }
+
+  [[nodiscard]] bool operator==(PhiloxEngine const& that) const {
+    return this->x_ == that.x_ && this->k_ == that.k_ && this->y_ == that.y_ && this->i_ == that.i_;
+  }
+  [[nodiscard]] bool operator!=(PhiloxEngine const& that) const { return !(*this == that); }
+};
+
+/** @brief Equivalent to `std::philox4x32`. */
+using Philox4x32 =
+    PhiloxEngine<std::uint32_t, 32, 4, 10, 0xCD9E8D57, 0x9E3779B9, 0xD2511F53, 0xBB67AE85>;
+/** @brief Equivalent to `std::philox4x64`. */
+using Philox4x64 =
+    PhiloxEngine<std::uint64_t, 64, 4, 10, 0xCA5A826395121157ULL, 0x9E3779B97F4A7C15ULL,
+                 0xD2E7470EE14C6C93ULL, 0xBB67AE8584CAA73BULL>;
+}  // namespace xgboost
+#endif  // XGBOOST_PHILOX_ENGINE_H_

--- a/include/xgboost/philox_engine.h
+++ b/include/xgboost/philox_engine.h
@@ -58,8 +58,10 @@ inline void UMul64(std::uint64_t a, std::uint64_t b, std::uint64_t* p_hi, std::u
  *   libc++ and the MSVC STL each spell it differently.
  *   See https://github.com/dmlc/xgboost/issues/12459 .
  *
- * The device-side code already draws from Philox through libcu++
- * (`common::cuda_impl::DefaultRng`), so this also brings the host in line with it.
+ * The device-side code already draws from the same family through libcu++
+ * (`common::cuda_impl::DefaultRng` is `cuda::std::philox4x64`). Host and device still run
+ * separate engines over separate streams, so the draws do not line up; only the algorithm
+ * is now shared.
  *
  * @tparam UIntType The unsigned result type.
  * @tparam w        Word size in bits.
@@ -171,13 +173,16 @@ class PhiloxEngine {
   /** @brief Add @p z to the counter, which is an n * w bit unsigned integer. */
   void AdvanceCounter(std::uint64_t z) {
     for (std::size_t j = 0; j < n && z != 0; ++j) {
-      std::uint64_t const sum = static_cast<std::uint64_t>(this->x_[j]) + (z & kMax64);
+      auto const x = static_cast<std::uint64_t>(this->x_[j]);
+      std::uint64_t const sum = x + (z & kMax64);
       this->x_[j] = static_cast<result_type>(sum & kMax64);
-      std::uint64_t const carry = sum > kMax64 ? 1 : 0;
       if constexpr (w >= 64) {
-        z = carry;
+        // A word this wide has already wrapped modulo 2^64 by the time we get here, so the
+        // carry shows up as a sum that came out below the addend. There is no value of
+        // `sum` above `kMax64` to compare against.
+        z = sum < x ? 1 : 0;
       } else {
-        z = (z >> w) + carry;
+        z = (z >> w) + (sum > kMax64 ? 1 : 0);
       }
     }
   }

--- a/src/common/error_msg.h
+++ b/src/common/error_msg.h
@@ -84,6 +84,20 @@ inline void WarnOldSerialization() {
   logged = true;
 }
 
+inline void WarnOldRngState() {
+  // Display it once is enough. Otherwise this can be really verbose in distributed
+  // environments.
+  static thread_local bool logged{false};
+  if (logged) {
+    return;
+  }
+  LOG(WARNING) << "Ignoring a random number generator state that was written in an older, "
+                  "platform-specific format, and restarting the generator from the `seed` "
+                  "parameter instead. The loaded model is unaffected; only the random "
+                  "numbers drawn by further training differ.";
+  logged = true;
+}
+
 [[nodiscard]] std::string InvalidModel(StringView fname);
 
 [[nodiscard]] std::string OldBinaryModel(StringView fname);

--- a/src/common/random.cc
+++ b/src/common/random.cc
@@ -4,24 +4,86 @@
 #include "random.h"
 
 #include <algorithm>  // for sort, max, copy
+#include <cstddef>    // for size_t
+#include <cstdint>    // for uint64_t
+#include <limits>     // for numeric_limits
 #include <memory>     // for shared_ptr
-#include <sstream>    // for stringstream
-#include <string>     // for string
+#include <string>     // for string, to_string
 
+#include "error_msg.h"                   // for WarnOldRngState
 #include "xgboost/host_device_vector.h"  // for HostDeviceVector
-#include "xgboost/json.h"                // for Json, String, get
+#include "xgboost/json.h"                // for Json, Object, String, get, IsA
 
 namespace xgboost::common {
-void SaveRng(Json *p_out, RandomEngine const &rng) {
-  std::stringstream ss;
-  ss << std::hex << rng;
+namespace {
+/**
+ * @brief Read the two space-separated decimal integers written by @ref SaveRng.
+ *
+ * Parsed by hand rather than through `std::istream`, whose extraction of numbers consults
+ * the global locale. Anything else is rejected, including the several hundred state words
+ * that older versions wrote here.
+ */
+[[nodiscard]] bool ParseRngState(std::string const &str, std::uint64_t *p_seed,
+                                 std::uint64_t *p_n_advanced) {
+  std::uint64_t values[2]{};
+  std::size_t pos = 0;
+
+  for (auto &value : values) {
+    while (pos < str.size() && str[pos] == ' ') {
+      pos++;
+    }
+    auto const begin = pos;
+    while (pos < str.size() && str[pos] >= '0' && str[pos] <= '9') {
+      auto digit = static_cast<std::uint64_t>(str[pos] - '0');
+      if (value > (std::numeric_limits<std::uint64_t>::max() - digit) / 10) {
+        return false;  // Overflow.
+      }
+      value = value * 10 + digit;
+      pos++;
+    }
+    if (pos == begin) {
+      return false;  // Not a number.
+    }
+  }
+
+  while (pos < str.size() && str[pos] == ' ') {
+    pos++;
+  }
+  if (pos != str.size()) {
+    return false;  // Trailing content.
+  }
+
+  *p_seed = values[0];
+  *p_n_advanced = values[1];
+  return true;
+}
+}  // anonymous namespace
+
+void SaveRng(Json *p_out, SerializableRandomEngine const &rng) {
   auto &out = *p_out;
-  out["rng_state"] = String{ss.str()};
+  // The surrounding object holds XGBoost parameters, whose values are all strings.
+  out["rng_state"] = String{std::to_string(rng.Seed()) + " " + std::to_string(rng.NumAdvanced())};
 }
 
-void LoadRng(Json const &in, RandomEngine *rng) {
-  std::stringstream ss{get<String const>(in["rng_state"])};
-  ss >> std::hex >> *rng;
+bool LoadRng(Json const &in, SerializableRandomEngine *rng) {
+  auto const &obj = get<Object const>(in);
+  auto it = obj.find("rng_state");
+  if (it == obj.cend() || !IsA<String>(it->second)) {
+    return false;
+  }
+
+  std::uint64_t seed = 0;
+  std::uint64_t n_advanced = 0;
+  if (!ParseRngState(get<String const>(it->second), &seed, &n_advanced)) {
+    // Older versions wrote the text produced by `operator<<` for `std::mt19937`, which
+    // cannot be read back on a different standard library implementation. See
+    // `SerializableRandomEngine`.
+    error::WarnOldRngState();
+    return false;
+  }
+
+  rng->Restore(static_cast<SerializableRandomEngine::result_type>(seed), n_advanced);
+  return true;
 }
 
 std::shared_ptr<HostDeviceVector<bst_feature_t>> ColumnSampler::ColSample(

--- a/src/common/random.h
+++ b/src/common/random.h
@@ -175,7 +175,14 @@ class ColumnSampler {
   }
 };
 
-void SaveRng(Json* p_out, RandomEngine const& rng);
-void LoadRng(Json const& in, RandomEngine* rng);
+void SaveRng(Json* p_out, SerializableRandomEngine const& rng);
+/**
+ * @brief Restore the state written by @ref SaveRng.
+ *
+ * @return Whether a state was restored. False if @p in carries no state at all, or carries
+ *         the non-portable `std::mt19937` text written by 3.3.0 and earlier, in which case
+ *         @p rng is left untouched and the caller should re-seed it.
+ */
+[[nodiscard]] bool LoadRng(Json const& in, SerializableRandomEngine* rng);
 }  // namespace xgboost::common
 #endif  // XGBOOST_COMMON_RANDOM_H_

--- a/src/common/random.h
+++ b/src/common/random.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <memory>
 #include <numeric>
+#include <random>  // for uniform_real_distribution
 #include <vector>
 
 #include "algorithm.h"        // ArgSort

--- a/src/context.cc
+++ b/src/context.cc
@@ -294,7 +294,11 @@ DeviceOrd Context::DeviceFP64() const {
 
 void Context::FromJson(Json const& in) {
   ::xgboost::FromJson(in, this);
-  common::LoadRng(in, &this->rng_);
+  if (!common::LoadRng(in, &this->rng_)) {
+    // No state to restore, or a state written by an older version that this platform
+    // cannot read. Start a fresh stream from the configured seed.
+    this->rng_.seed(static_cast<SerializableRandomEngine::result_type>(this->seed));
+  }
 }
 
 #if !defined(XGBOOST_USE_CUDA)

--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -13,6 +13,7 @@
 #include <algorithm>  // for equal, any_of
 #include <cstdint>    // for uint32_t
 #include <memory>
+#include <random>  // for uniform_real_distribution, uniform_int_distribution
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/tree/updater_colmaker.cc
+++ b/src/tree/updater_colmaker.cc
@@ -6,6 +6,7 @@
  */
 #include <algorithm>
 #include <cmath>
+#include <random>  // for bernoulli_distribution
 #include <vector>
 
 #include "../collective/communicator-inl.h"  // for IsDistributed

--- a/tests/cpp/common/test_random.cc
+++ b/tests/cpp/common/test_random.cc
@@ -4,6 +4,7 @@
 #include <algorithm>  // for shuffle
 #include <cstddef>    // for size_t
 #include <numeric>    // for iota
+#include <random>     // for mt19937
 #include <sstream>    // for stringstream
 #include <vector>     // for vector
 
@@ -252,7 +253,7 @@ TEST(RngState, RejectsLegacyState) {
   rng.seed(7);
 
   std::stringstream ss;
-  ss << std::hex << RandomEngine{1994};
+  ss << std::hex << std::mt19937{1994};
   Json legacy{Object{}};
   legacy["rng_state"] = String{ss.str()};
   ASSERT_FALSE(LoadRng(legacy, &rng));
@@ -271,7 +272,7 @@ TEST(RngState, RejectsLegacyState) {
   ASSERT_EQ(rng.Seed(), 7u);
 }
 
-// Advancing by hand and restoring must agree, since restoring replays the draws with
+// Advancing by hand and restoring must agree, since restoring skips the draws with
 // `discard`.
 TEST(RngState, RestoreMatchesReplay) {
   SerializableRandomEngine reference;
@@ -288,9 +289,9 @@ TEST(RngState, RestoreMatchesReplay) {
   }
 }
 
-// The wrapper must stay a drop-in for `std::mt19937` so that call sites can keep handing
-// it to standard distributions and algorithms.
-TEST(RngState, MatchesStdEngine) {
+// The wrapper must stay a drop-in for the engine it holds, so that call sites can keep
+// handing it to standard distributions and algorithms.
+TEST(RngState, MatchesPlainEngine) {
   SerializableRandomEngine wrapped{1994};
   RandomEngine plain{1994};
 

--- a/tests/cpp/common/test_random.cc
+++ b/tests/cpp/common/test_random.cc
@@ -1,10 +1,17 @@
 /**
  * Copyright 2018-2026, XGBoost Contributors
  */
+#include <algorithm>  // for shuffle
+#include <cstddef>    // for size_t
+#include <numeric>    // for iota
+#include <sstream>    // for stringstream
+#include <vector>     // for vector
+
 #include "../../../src/common/random.h"
 #include "../helpers.h"
 #include "gtest/gtest.h"
-#include "xgboost/context.h"  // for Context
+#include "xgboost/context.h"  // for Context, SerializableRandomEngine
+#include "xgboost/json.h"     // for Json, Object, String, get, IsA
 
 namespace xgboost::common {
 namespace {
@@ -200,4 +207,108 @@ TEST(ColumnSampler, GPUWeightedMultiSampling) {
   TestWeightedMultiSampling(&ctx);
 }
 #endif  // defined(XGBOOST_USE_CUDA)
+
+namespace {
+// The state must survive a round trip, and must do so through plain integers only. The
+// textual form of `std::mt19937` differs between standard library implementations, so a
+// snapshot holding it could not be moved between platforms. See
+// https://github.com/dmlc/xgboost/issues/12459 .
+TEST(RngState, RoundTrip) {
+  SerializableRandomEngine rng;
+  rng.seed(1994);
+  for (std::size_t i = 0; i < 17; ++i) {
+    static_cast<void>(rng());
+  }
+
+  Json out{Object{}};
+  SaveRng(&out, rng);
+
+  SerializableRandomEngine loaded;
+  ASSERT_TRUE(LoadRng(out, &loaded));
+  ASSERT_EQ(loaded.Seed(), rng.Seed());
+  ASSERT_EQ(loaded.NumAdvanced(), rng.NumAdvanced());
+  for (std::size_t i = 0; i < 32; ++i) {
+    ASSERT_EQ(loaded(), rng());
+  }
+}
+
+TEST(RngState, IsPlatformIndependent) {
+  SerializableRandomEngine rng;
+  rng.seed(3);
+  static_cast<void>(rng());
+
+  Json out{Object{}};
+  SaveRng(&out, rng);
+
+  // The seed and the draw count, spelled out by us. Nothing here can vary with the
+  // standard library that wrote it.
+  ASSERT_EQ(get<String const>(out["rng_state"]), "3 1");
+}
+
+TEST(RngState, RejectsLegacyState) {
+  // 3.3.0 and earlier wrote the text produced by `operator<<` for `std::mt19937`. It must
+  // be refused rather than misread, and refusing it must not throw.
+  SerializableRandomEngine rng;
+  rng.seed(7);
+
+  std::stringstream ss;
+  ss << std::hex << RandomEngine{1994};
+  Json legacy{Object{}};
+  legacy["rng_state"] = String{ss.str()};
+  ASSERT_FALSE(LoadRng(legacy, &rng));
+  // Left untouched for the caller to re-seed.
+  ASSERT_EQ(rng.Seed(), 7u);
+  ASSERT_EQ(rng.NumAdvanced(), 0ul);
+
+  // Neither a missing state nor a malformed one is an error.
+  Json empty{Object{}};
+  ASSERT_FALSE(LoadRng(empty, &rng));
+  for (auto const& malformed : {"", " ", "12", "1 2 3", "-1 2", "1 x"}) {
+    Json bad{Object{}};
+    bad["rng_state"] = String{malformed};
+    ASSERT_FALSE(LoadRng(bad, &rng)) << "accepted: '" << malformed << "'";
+  }
+  ASSERT_EQ(rng.Seed(), 7u);
+}
+
+// Advancing by hand and restoring must agree, since restoring replays the draws with
+// `discard`.
+TEST(RngState, RestoreMatchesReplay) {
+  SerializableRandomEngine reference;
+  reference.seed(11);
+  for (std::size_t i = 0; i < 1000; ++i) {
+    static_cast<void>(reference());
+  }
+
+  SerializableRandomEngine restored;
+  restored.Restore(11, 1000);
+  ASSERT_EQ(restored.NumAdvanced(), reference.NumAdvanced());
+  for (std::size_t i = 0; i < 8; ++i) {
+    ASSERT_EQ(restored(), reference());
+  }
+}
+
+// The wrapper must stay a drop-in for `std::mt19937` so that call sites can keep handing
+// it to standard distributions and algorithms.
+TEST(RngState, MatchesStdEngine) {
+  SerializableRandomEngine wrapped{1994};
+  RandomEngine plain{1994};
+
+  ASSERT_EQ(SerializableRandomEngine::min(), RandomEngine::min());
+  ASSERT_EQ(SerializableRandomEngine::max(), RandomEngine::max());
+  for (std::size_t i = 0; i < 64; ++i) {
+    ASSERT_EQ(wrapped(), plain());
+  }
+  ASSERT_EQ(wrapped.NumAdvanced(), 64ul);
+
+  std::vector<int> a(32), b(32);
+  std::iota(a.begin(), a.end(), 0);
+  std::iota(b.begin(), b.end(), 0);
+  wrapped.seed(7);
+  plain.seed(7);
+  std::shuffle(a.begin(), a.end(), wrapped);
+  std::shuffle(b.begin(), b.end(), plain);
+  ASSERT_EQ(a, b);
+}
+}  // namespace
 }  // namespace xgboost::common

--- a/tests/cpp/test_context.cc
+++ b/tests/cpp/test_context.cc
@@ -5,6 +5,7 @@
 #include <xgboost/base.h>
 #include <xgboost/context.h>
 
+#include <random>  // for mt19937
 #include <sstream>
 #include <string>
 
@@ -40,7 +41,7 @@ TEST(Context, LegacyRngState) {
 
   // Overwrite with the state as older versions wrote it.
   std::stringstream ss;
-  ss << std::hex << RandomEngine{7};
+  ss << std::hex << std::mt19937{7};
   j["rng_state"] = String{ss.str()};
 
   // It must be refused rather than misread, and the engine falls back to the seed.

--- a/tests/cpp/test_context.cc
+++ b/tests/cpp/test_context.cc
@@ -6,8 +6,51 @@
 #include <xgboost/context.h>
 
 #include <sstream>
+#include <string>
+
+#include "../../src/common/random.h"  // for SaveRng
+#include "xgboost/json.h"             // for Json, Object, String, get
 
 namespace xgboost {
+// The RNG state must survive a config round trip, and must be written in a form that does
+// not depend on the standard library that wrote it. The text produced by `operator<<` for
+// `std::mt19937` is not: libstdc++, libc++ and the MSVC STL each spell it differently, so
+// a snapshot written on Linux could not be read on Windows.
+// https://github.com/dmlc/xgboost/issues/12459
+TEST(Context, RngStateRoundTrip) {
+  Context ctx;
+  ctx.Init({{"seed", "1994"}});
+  for (std::size_t i = 0; i < 13; ++i) {
+    static_cast<void>(ctx.Rng()());
+  }
+
+  Context loaded;
+  loaded.FromJson(ctx.ToJson());
+  ASSERT_EQ(loaded.seed, 1994);
+  ASSERT_EQ(loaded.Rng().NumAdvanced(), ctx.Rng().NumAdvanced());
+  for (std::size_t i = 0; i < 16; ++i) {
+    ASSERT_EQ(loaded.Rng()(), ctx.Rng()());
+  }
+}
+
+TEST(Context, LegacyRngState) {
+  Context ctx;
+  ctx.Init({{"seed", "1994"}});
+  auto j = ctx.ToJson();
+
+  // Overwrite with the state as older versions wrote it.
+  std::stringstream ss;
+  ss << std::hex << RandomEngine{7};
+  j["rng_state"] = String{ss.str()};
+
+  // It must be refused rather than misread, and the engine falls back to the seed.
+  Context loaded;
+  loaded.FromJson(j);
+  ASSERT_EQ(loaded.seed, 1994);
+  ASSERT_EQ(loaded.Rng().Seed(), 1994u);
+  ASSERT_EQ(loaded.Rng().NumAdvanced(), 0ul);
+}
+
 TEST(Context, CPU) {
   Context ctx;
   ASSERT_EQ(ctx.Device(), DeviceOrd::CPU());

--- a/tests/cpp/test_learner.cc
+++ b/tests/cpp/test_learner.cc
@@ -544,6 +544,42 @@ TEST(Learner, ConstantSeed) {
   }
 }
 
+// A memory snapshot must carry the RNG state across a save/load boundary, and must encode
+// it in a way that does not depend on the standard library that wrote it.
+// https://github.com/dmlc/xgboost/issues/12459
+TEST(Learner, SerializedSeed) {
+  auto m = RandomDataGenerator{10, 10, 0}.GenerateDMatrix(true);
+
+  std::unique_ptr<Learner> learner{Learner::Create({m})};
+  // `subsample` draws from the engine, so there is a non-trivial state to carry over.
+  learner->Configure({{"tree_method", "exact"}, {"seed", "1994"}, {"subsample", "0.5"}});
+  learner->UpdateOneIter(0, m);
+  ASSERT_GT(learner->Ctx()->Rng().NumAdvanced(), 0ul);
+
+  std::string snapshot;
+  common::MemoryBufferStream fo{&snapshot};
+  learner->Save(&fo);
+
+  // The snapshot holds the seed and a draw count, never the engine text. The latter runs
+  // to hundreds of words and is spelled differently by each standard library.
+  Json config{Object{}};
+  learner->SaveConfig(&config);
+  auto state = get<String const>(config["learner"]["generic_param"]["rng_state"]);
+  ASSERT_EQ(state.substr(0, state.find(' ')), "1994");
+  ASSERT_EQ(std::count(state.cbegin(), state.cend(), ' '), 1);
+
+  common::MemoryBufferStream fi{&snapshot};
+  std::unique_ptr<Learner> loaded{Learner::Create({m})};
+  loaded->Load(&fi);
+
+  // Both engines continue the same stream.
+  ASSERT_EQ(loaded->Ctx()->Rng().NumAdvanced(), learner->Ctx()->Rng().NumAdvanced());
+  std::uniform_real_distribution<float> dist;
+  for (std::size_t i = 0; i < 8; ++i) {
+    ASSERT_EQ(dist(loaded->Ctx()->Rng()), dist(learner->Ctx()->Rng()));
+  }
+}
+
 TEST(Learner, FeatureInfo) {
   size_t constexpr kCols = 10;
   auto m = RandomDataGenerator{10, kCols, 0}.GenerateDMatrix(true);

--- a/tests/cpp/test_philox_engine.cc
+++ b/tests/cpp/test_philox_engine.cc
@@ -97,6 +97,29 @@ TEST(PhiloxEngine, DiscardIsAdditive) {
   }
 }
 
+// The counter is an n * w bit integer, so advancing it has to carry between words. Only
+// the 64-bit words exercise the wrap of a whole word, and they take 2^64 blocks to get
+// there, which is only reachable at all because `discard` does not replay anything.
+TEST(PhiloxEngine, CounterCarry) {
+  Philox4x64 rng{1994};
+  // 2^64 - 4 draws is 2^62 - 1 blocks, the most a single call can cover.
+  for (std::size_t i = 0; i < 4; ++i) {
+    rng.discard(~0ull - 3);
+  }
+  // Four blocks short of 2^64. These take the low word over.
+  rng.discard(16);
+
+  Philox4x64 from_zero{1994};
+  bool differs = false;
+  for (std::size_t i = 0; i < 4; ++i) {
+    if (rng() != from_zero()) {
+      differs = true;
+    }
+  }
+  // Losing the carry would leave the counter back at zero, repeating the first block.
+  ASSERT_TRUE(differs);
+}
+
 TEST(PhiloxEngine, Seed) {
   Philox4x32 rng{7};
   std::vector<std::uint32_t> first;

--- a/tests/cpp/test_philox_engine.cc
+++ b/tests/cpp/test_philox_engine.cc
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ */
+#include <gtest/gtest.h>
+#include <xgboost/philox_engine.h>
+
+#include <cstddef>  // for size_t
+#include <cstdint>  // for uint32_t, uint64_t
+#include <random>   // for philox_engine
+#include <vector>   // for vector
+
+namespace xgboost {
+namespace {
+// The sequence has to be the one C++26 specifies, since the point of writing this out
+// ourselves is to be able to drop it for `std::philox_engine` later without changing a
+// single number. [rand.predef] pins the two engines down with these values.
+TEST(PhiloxEngine, RequiredBehavior) {
+  {
+    Philox4x32 rng;
+    std::uint32_t v = 0;
+    for (std::size_t i = 0; i < 10000; ++i) {
+      v = rng();
+    }
+    ASSERT_EQ(v, 1955073260u);
+  }
+  {
+    Philox4x64 rng;
+    std::uint64_t v = 0;
+    for (std::size_t i = 0; i < 10000; ++i) {
+      v = rng();
+    }
+    ASSERT_EQ(v, 3409172418970261260ull);
+  }
+}
+
+// Philox predates the standard, and the standard adopted the generator unchanged. Seeding
+// with 0 leaves both the key and the counter all zero, which is the first published test
+// vector for philox4x32-10 in Random123, the reference implementation.
+TEST(PhiloxEngine, KnownAnswer) {
+  Philox4x32 rng{0};
+  std::vector<std::uint32_t> const expected{0x6627e8d5, 0xe169c58d, 0xbc57ac4c, 0x9b00dbd8};
+  for (auto e : expected) {
+    ASSERT_EQ(rng(), e);
+  }
+}
+
+TEST(PhiloxEngine, Constants) {
+  ASSERT_EQ(Philox4x32::min(), 0u);
+  ASSERT_EQ(Philox4x32::max(), 4294967295u);
+  ASSERT_EQ(Philox4x64::min(), 0ull);
+  ASSERT_EQ(Philox4x64::max(), 18446744073709551615ull);
+
+  ASSERT_EQ(Philox4x32::word_size, 32ul);
+  ASSERT_EQ(Philox4x32::word_count, 4ul);
+  ASSERT_EQ(Philox4x32::round_count, 10ul);
+  ASSERT_EQ(Philox4x32::default_seed, 20111115u);
+
+  // Even-indexed template constants are the multipliers, odd-indexed the Weyl constants.
+  ASSERT_EQ(Philox4x32::multipliers[0], 0xCD9E8D57u);
+  ASSERT_EQ(Philox4x32::multipliers[1], 0xD2511F53u);
+  ASSERT_EQ(Philox4x32::round_consts[0], 0x9E3779B9u);
+  ASSERT_EQ(Philox4x32::round_consts[1], 0xBB67AE85u);
+}
+
+// `discard` is the reason for a counter-based engine here: restoring a serialized state
+// skips forward by however many draws the model took while training, and that has to cost
+// the same whether it is ten draws or ten billion. It still has to land exactly where the
+// draws would have.
+TEST(PhiloxEngine, DiscardMatchesDraws) {
+  // Around and across the four-word block boundary.
+  for (std::uint64_t z :
+       {0ull, 1ull, 2ull, 3ull, 4ull, 5ull, 7ull, 8ull, 9ull, 63ull, 64ull, 1000ull}) {
+    Philox4x32 drawn{1994};
+    for (std::uint64_t i = 0; i < z; ++i) {
+      static_cast<void>(drawn());
+    }
+    Philox4x32 skipped{1994};
+    skipped.discard(z);
+    ASSERT_EQ(drawn, skipped) << "z: " << z;
+    for (std::size_t i = 0; i < 8; ++i) {
+      ASSERT_EQ(drawn(), skipped()) << "z: " << z;
+    }
+  }
+}
+
+TEST(PhiloxEngine, DiscardIsAdditive) {
+  // Far enough that replaying the draws would not be an option.
+  std::uint64_t constexpr kHalf = 1ull << 39;
+  Philox4x32 once{5};
+  once.discard(kHalf * 2);
+  Philox4x32 twice{5};
+  twice.discard(kHalf);
+  twice.discard(kHalf);
+  ASSERT_EQ(once, twice);
+  for (std::size_t i = 0; i < 8; ++i) {
+    ASSERT_EQ(once(), twice());
+  }
+}
+
+TEST(PhiloxEngine, Seed) {
+  Philox4x32 rng{7};
+  std::vector<std::uint32_t> first;
+  for (std::size_t i = 0; i < 16; ++i) {
+    first.push_back(rng());
+  }
+  // Re-seeding restarts the sequence, whatever the engine was doing before.
+  rng.discard(1234);
+  rng.seed(7);
+  for (auto v : first) {
+    ASSERT_EQ(rng(), v);
+  }
+
+  ASSERT_NE(Philox4x32{7}, Philox4x32{8});
+  ASSERT_EQ(Philox4x32{}, Philox4x32{Philox4x32::default_seed});
+}
+
+#if defined(__cpp_lib_philox_engine)
+// Once a standard library ships one, ours has to agree with it. When they all do, this
+// implementation can go and `RandomEngine` can name `std::philox4x32` directly.
+TEST(PhiloxEngine, MatchesStd) {
+  Philox4x32 ours{1994};
+  std::philox4x32 theirs{1994};
+  for (std::size_t i = 0; i < 4096; ++i) {
+    ASSERT_EQ(ours(), theirs());
+  }
+  ours.discard(100000);
+  theirs.discard(100000);
+  ASSERT_EQ(ours(), theirs());
+
+  Philox4x64 ours64{1994};
+  std::philox4x64 theirs64{1994};
+  for (std::size_t i = 0; i < 4096; ++i) {
+    ASSERT_EQ(ours64(), theirs64());
+  }
+}
+#endif  // defined(__cpp_lib_philox_engine)
+}  // namespace
+}  // namespace xgboost

--- a/tests/python/test_pickling.py
+++ b/tests/python/test_pickling.py
@@ -61,3 +61,44 @@ class TestPickling:
         params = {"nthread": 8, "tree_method": "exact", "subsample": 0.5}
         config = self.run_model_pickling(params)
         check(config)
+
+    def test_rng_state_is_portable(self):
+        """The pickled RNG state must not depend on the C++ standard library that wrote
+        it.
+
+        Serializing the text form of ``std::mt19937`` made a pickle produced on Linux
+        unreadable on Windows, since libstdc++, libc++ and the MSVC STL each spell that
+        text differently.  See https://github.com/dmlc/xgboost/issues/12459 .
+        """
+        X, y = generate_data()
+        params = {"tree_method": "exact", "subsample": 0.5, "seed": 1994}
+        bst = xgb.train(params, xgb.DMatrix(X, y), num_boost_round=4)
+
+        config = json.loads(bst.save_config())
+        state = config["learner"]["generic_param"]["rng_state"]
+
+        # The seed followed by a draw count, and nothing else.  The old format ran to
+        # several hundred state words.
+        seed, n_advanced = state.split(" ")
+        assert seed == "1994"
+        assert int(n_advanced) > 0
+
+    def test_rng_state_survives_pickling(self):
+        """Training resumed from a pickle must match uninterrupted training."""
+        X, y = generate_data()
+        dtrain = xgb.DMatrix(X, y)
+        params = {"tree_method": "exact", "subsample": 0.5, "seed": 1994}
+
+        straight = xgb.train(params, dtrain, num_boost_round=8)
+
+        half = xgb.train(params, dtrain, num_boost_round=4)
+        resumed = xgb.train(
+            params,
+            dtrain,
+            num_boost_round=4,
+            xgb_model=pickle.loads(pickle.dumps(half)),
+        )
+
+        np.testing.assert_allclose(
+            straight.predict(dtrain), resumed.predict(dtrain), rtol=1e-6
+        )

--- a/tests/python/test_with_sklearn.py
+++ b/tests/python/test_with_sklearn.py
@@ -8,8 +8,9 @@ from typing import Optional, Type
 
 import numpy as np
 import pytest
-import xgboost as xgb
 from sklearn.utils.estimator_checks import parametrize_with_checks
+
+import xgboost as xgb
 from xgboost import testing as tm
 from xgboost.testing.data import get_california_housing, make_ltr
 from xgboost.testing.ranking import run_ranking_categorical, run_ranking_qid_df
@@ -1185,8 +1186,13 @@ def test_pandas_input():
 def test_feature_weights(tree_method):
     kRows = 512
     kCols = 64
-    X = rng.randn(kRows, kCols)
-    y = rng.randn(kRows)
+    # Seeded here rather than drawn from the module-level generator. The assertions below
+    # are thresholds on a sampled quantity, so the test needs the same data every run;
+    # sharing the generator with the rest of the file made the data depend on which tests
+    # ran first.
+    data_rng = np.random.RandomState(1994)
+    X = data_rng.randn(kRows, kCols)
+    y = data_rng.randn(kRows)
 
     fw = np.ones(shape=(kCols,))
     for i in range(kCols):
@@ -1214,8 +1220,8 @@ def test_feature_weights(tree_method):
         model=xgb.XGBRegressor,
     )
 
-    # Approxmated test, this is dependent on the implementation of random
-    # number generator in std library.
+    # Approximated test, this is dependent on the implementation of the random number
+    # generator used for column sampling.
     assert poly_increasing[0] > 0.08
     assert poly_decreasing[0] < -0.08
 


### PR DESCRIPTION
Closes #12459.

## Root cause

XGBoost keeps the state of `Context::rng_` (a `std::mt19937`) in the memory snapshot, written out as text by the engine's stream operator:

```cpp
ss << std::hex << rng;
out["rng_state"] = String{ss.str()};
```

That text is not portable, for two reasons.

First, the format flags. The standard makes the engine's `operator<<` set `ios_base::dec` itself, so libstdc++ ignores the `std::hex` and writes decimal. The MSVC STL does not reset the flags, so it writes and reads hex. Windows therefore parses Linux's decimal words as hex. A 10-digit word read as hex exceeds 32 bits, the `uint32_t` being read into overflows, and the stream sets `failbit`. I measured it on libstdc++: 610 of the 625 tokens fail to parse. That is the `input stream corrupted` in the reported traceback.

Second, the layout. libstdc++ writes 624 state words in raw order plus the position, 625 tokens in all. libc++ and the MSVC STL write 624 words rotated into canonical order with no position. The standard only says the output holds "the textual representations of `x_i`", and each library read that differently.

That second reason is why dropping the `std::hex` would not be enough. The format cannot be repaired, only replaced.

It also explains why Windows was the only platform to fail loudly. libc++ reads the first 624 of the 625 decimal tokens and stops, so macOS gets a rotated but structurally valid state and no error at all. That silence is why `tests/cross-platform/test_cross_platform_model.py` never caught this, despite pickling a Booster from Linux to macOS.

## Fix

Record the seed and the number of draws taken since it was applied, both plain integers. Restoring re-seeds and skips forward with `RandomEngine::discard`, which the standard defines as equivalent to that many calls to `operator()`, so the state comes back exactly on any implementation. The format describes what to do rather than how the engine is built internally, so it survives a change of engine.

Following @RAMitchell's review, the engine itself is now a counter-based Philox rather than the Mersenne twister. `PhiloxEngine` in the new `include/xgboost/philox_engine.h` follows [rand.eng.philox], the C++26 specification of `std::philox_engine`, so `Philox4x32` and `Philox4x64` are the same engines as `std::philox4x32` and `std::philox4x64`. `RandomEngine` can become an alias for the standard type once the libraries we build against ship one; a parity test compiles in as soon as `__cpp_lib_philox_engine` is defined.

The output is a pure function of a key and a counter, so `discard` is O(1): skipping ahead is addition on the counter rather than replay. Restoring a state 20 billion draws in takes 60 ns, against roughly 19 s to replay the same distance through mt19937.

`SerializableRandomEngine` in `include/xgboost/context.h` wraps that engine and keeps the counter. It still satisfies `UniformRandomBitGenerator` and still has `seed()`, so the call sites passing `ctx->Rng()` to `std::shuffle` and the standard distributions did not change.

The random stream does change, though. A given seed samples different rows and columns than 3.3.0 did, so models are not bit-identical across this commit. That is unavoidable when changing engine, and I did not find a way to fix the serialization without it.

`"rng_state"` is now `"1994 74"` in place of roughly 6.7 KB of engine text. I parse it by hand instead of with `std::istream`, whose integer extraction consults the global locale. A state in the old format is refused rather than misread, and the engine falls back to the `seed` parameter.

Two corrections since the first Philox push, both in the last commit.

`AdvanceCounter` compared against `kMax64` to spot a carry out of a word. For a 64-bit word that comparison can never be true, since `sum` is a `uint64_t` and `kMax64` is its maximum, so `Philox4x64` dropped every carry and its counter wrapped back to zero after 2^64 blocks, repeating the sequence from the start. It compares against the addend now. `RandomEngine` names `Philox4x32`, which was never affected, but the header offers both engines as matching the standard, so both have to.

I also overstated the libcu++ connection. The device code draws from `cuda::std::philox4x64` and the host now runs `Philox4x32`, so the two share an algorithm and nothing else. The header comment says that now rather than implying the draws line up.

## Testing

All 767 C++ tests pass; cpplint and clang-format are clean.

I validated the engine against the three published Random123 test vectors for philox4x32-10, and against both values [rand.predef] requires of a default-constructed engine at the 10000th invocation. `discard` is checked against explicit draws around and across the block boundary. `PhiloxEngine.CounterCarry` walks a 4x64 counter the whole 2^64 blocks to the word boundary, which is a test you can only write because `discard` does not replay.

Training with `subsample`, pickling and resuming now matches uninterrupted training for both `hist` and `exact`. A 3.3.0 pickle from PyPI still loads and re-saves in the new format. Reverting just the restore step makes three of the new tests fail, so they are not vacuous.

One test needed a change. `test_feature_weights` drew its data from the generator shared across `test_with_sklearn.py`, so which data it saw depended on which tests ran before it. It asserts thresholds on a sampled quantity, and on one such draw the new stream put the slope at 0.027 against a bound of 0.08, with the sign still correct. I seeded it locally rather than moving the threshold. It passes either side of this change, and I ran it across eight different data seeds: the tightest margin was 0.103 against the same 0.08 bound, so the seed I happened to pick is not what is carrying the test.

## One open question

`WarnOldRngState()` is close to unreachable. `LoadConfigImpl` already returns early when `Version::Same()` fails, so a snapshot from an older release never reaches the RNG code. It only fires for a same-version snapshot straddling this commit, i.e. for nightly users. Happy to drop it.
