### PR TITLE
[R-package] gitignore CMake files in R package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ metastore_db
 
 # files from R-package source install
 **/config.status
+R-package/src/cmake-build
 R-package/src/config.h
 R-package/src/Makevars
 *.lib


### PR DESCRIPTION
While reviewing #12416, I tried building the CRAN-style tarball of the R package locally, and hit this error:

```console
$ python -B ops/script/test_r_package.py --task build
  File "/Users/jlamb/repos/xgboost/./ops/script/test_r_package.py", line 59, in pack_rpackage
    raise ValueError(
ValueError: Would remove R-package/src/cmake-build/
Please cleanup the working git repository.
```

Looks like building locally now leaves behind a `cmake-build/` directory, from here:

https://github.com/dmlc/xgboost/blob/75c51d67018d3ba963ed102aadb2c5c1e8bf4861/R-package/src/Makevars.in#L7

This adds it to `.gitignore`.

With this change, I'm able to build locally (on my M2 macbook).

```console
$ git clean -dfX
$  python -B ops/script/test_r_package.py --task build
...
* checking for file ‘xgboost/DESCRIPTION’ ... OK
* preparing ‘xgboost’:
...
* building ‘xgboost_3.5.0.0.tar.gz’

Name: main Called: 1 Elapsed: 58 secs
Name: pack_rpackage Called: 1 Elapsed: 0 secs
Name: build_rpackage Called: 1 Elapsed: 58 secs
```