### PR TITLE
Fix plot_importance value-label offset for small importances

### DIFF
--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -120,8 +120,11 @@ def plot_importance(
     ax.barh(ylocs, values, align="center", height=height, **kwargs)
 
     if show_values is True:
+        # Offset labels by a fraction of the scale; a fixed 1 pushes them off
+        # the axes for small importances like "gain" or "cover".
+        offset = max(values) * 0.01
         for x, y in zip(values, ylocs):
-            ax.text(x + 1, float(y), values_format.format(v=x), va="center")
+            ax.text(x + offset, float(y), values_format.format(v=x), va="center")
 
     ax.set_yticks(ylocs)
     ax.set_yticklabels(labels)

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -117,11 +117,11 @@ def plot_importance(
         _, ax = plt.subplots(1, 1)
 
     ylocs = np.arange(len(values))
-    bar = ax.barh(ylocs, values, align="center", height=height, **kwargs)
+    barh = ax.barh(ylocs, values, align="center", height=height, **kwargs)
 
     if show_values is True:
         bar_labels = [values_format.format(v=value) for value in values]
-        ax.bar_label(bar, labels=bar_labels, padding=3)
+        ax.bar_label(barh, labels=bar_labels, padding=3)
 
     ax.set_yticks(ylocs)
     ax.set_yticklabels(labels)

--- a/python-package/xgboost/plotting.py
+++ b/python-package/xgboost/plotting.py
@@ -117,14 +117,11 @@ def plot_importance(
         _, ax = plt.subplots(1, 1)
 
     ylocs = np.arange(len(values))
-    ax.barh(ylocs, values, align="center", height=height, **kwargs)
+    bar = ax.barh(ylocs, values, align="center", height=height, **kwargs)
 
     if show_values is True:
-        # Offset labels by a fraction of the scale; a fixed 1 pushes them off
-        # the axes for small importances like "gain" or "cover".
-        offset = max(values) * 0.01
-        for x, y in zip(values, ylocs):
-            ax.text(x + offset, float(y), values_format.format(v=x), va="center")
+        bar_labels = [values_format.format(v=value) for value in values]
+        ax.bar_label(bar, labels=bar_labels, padding=3)
 
     ax.set_yticks(ylocs)
     ax.set_yticklabels(labels)

--- a/tests/python/test_plotting.py
+++ b/tests/python/test_plotting.py
@@ -101,18 +101,18 @@ class TestPlotting:
         assert ax.get_xlim() == (0.0, 5.0)
         assert ax.get_ylim() == (10.0, 71.0)
 
-    def test_importance_plot_show_values(self):
-        # Regression test: with `show_values=True` the value labels used to be
-        # offset by a fixed amount of `1`, which pushed them off the axes for
-        # small importances (e.g. "gain" or "cover"). Every label should stay
-        # within the x-axis limits.
+    def test_importance_plot_show_values(self) -> None:
         importance = {"f0": 0.02, "f1": 0.05, "f2": 0.1}
         ax = xgb.plot_importance(importance, show_values=True)
-        xmin, xmax = ax.get_xlim()
-        assert len(ax.texts) == len(importance)
-        for text in ax.texts:
-            x = text.get_position()[0]
-            assert xmin <= x <= xmax
+        ax.figure.canvas.draw()
+        renderer = ax.figure.canvas.get_renderer()
+
+        assert [text.get_text() for text in ax.texts] == ["0.02", "0.05", "0.1"]
+        for bar, text in zip(ax.patches, ax.texts):
+            bar_bbox = bar.get_window_extent(renderer)
+            text_bbox = text.get_window_extent(renderer)
+            assert bar_bbox.x1 < text_bbox.x0  # text is positioned after the bar
+            assert text_bbox.x1 <= ax.bbox.x1  # and before the axis ends
 
     @pytest.mark.skipif(**tm.no_pandas())
     def test_categorical(self) -> None:

--- a/tests/python/test_plotting.py
+++ b/tests/python/test_plotting.py
@@ -101,6 +101,19 @@ class TestPlotting:
         assert ax.get_xlim() == (0.0, 5.0)
         assert ax.get_ylim() == (10.0, 71.0)
 
+    def test_importance_plot_show_values(self):
+        # Regression test: with `show_values=True` the value labels used to be
+        # offset by a fixed amount of `1`, which pushed them off the axes for
+        # small importances (e.g. "gain" or "cover"). Every label should stay
+        # within the x-axis limits.
+        importance = {"f0": 0.02, "f1": 0.05, "f2": 0.1}
+        ax = xgb.plot_importance(importance, show_values=True)
+        xmin, xmax = ax.get_xlim()
+        assert len(ax.texts) == len(importance)
+        for text in ax.texts:
+            x = text.get_position()[0]
+            assert xmin <= x <= xmax
+
     @pytest.mark.skipif(**tm.no_pandas())
     def test_categorical(self) -> None:
         run_categorical("approx", "cpu")


### PR DESCRIPTION
`plot_importance(..., show_values=True)` offsets each value label by a fixed `x + 1`. That is fine for the default `importance_type="weight"` (integer counts), but for `gain`/`cover` or any pre-normalized importances (values around 1 or smaller) it pushes the labels far outside the axes, so they never render.

Repro:

```python
import matplotlib; matplotlib.use("Agg")
import xgboost as xgb
ax = xgb.plot_importance({"f0": 0.02, "f1": 0.05, "f2": 0.1}, show_values=True)
# xlim is (0, 0.11); the labels are placed at x = 1.02, 1.05, 1.1, all off the axes
```

This offsets the label by a small fraction of the value range (`max(values) * 0.01`) so it sits just past each bar at any scale. The default weight case is unchanged (for integer counts the offset stays on the same order as the previous fixed `1`).
