### PR TITLE
[jvm-packages] Add opt-in sparse DMatrix construction for Spark vectors

### DIFF
--- a/doc/jvm/xgboost4j_spark_tutorial.rst
+++ b/doc/jvm/xgboost4j_spark_tutorial.rst
@@ -169,10 +169,29 @@ Example of setting a missing value (e.g. -999) to the "missing" parameter in XGB
 
 .. note:: Missing values
 
-  If the feature is vector type, the single feature instance could be a SparseVector, where "0" will be treated as the missing value.
-  In order to get the correct model, XGBoost4j-Spark will convert the SparseVector to array by restoring the "0". However, we can't
-  assume 0 for missing values as it may be meaningful. So in this case, users need to specify the missing value explicitly
-  even the missing value has been set to `Float.NaN` by default in the XGBoost4j-Spark.
+  A Spark ``SparseVector`` does not store zero-valued entries. By default, XGBoost4J-Spark
+  converts it to a dense representation so that these entries remain explicit zeros instead of
+  being interpreted as missing values. Since zero can be meaningful, users must explicitly set
+  the ``missing`` parameter when the input contains sparse vectors, even though its default value
+  is ``Float.NaN``.
+
+For high-dimensional sparse data where zero is the missing value, enable
+``enableSparseDataOptim`` to preserve ``SparseVector`` inputs during training and prediction.
+This avoids conversion work and memory proportional to the vector dimension; the conversion is
+instead proportional to the number of stored entries. The optimization is disabled by default and
+requires all of the following:
+
+* ``missing`` is set to ``0.0f``.
+* Features are supplied through one Spark ML Vector column with ``setFeaturesCol(String)``.
+  Array input and multiple feature columns are not supported in this mode.
+* ``DenseVector`` rows remain dense. A Vector column may contain both dense and sparse rows.
+
+.. code-block:: scala
+
+  val xgbClassifier = new XGBoostClassifier()
+    .setFeaturesCol("features")
+    .setMissing(0.0f)
+    .setEnableSparseDataOptim(true)
 
 Training
 ========

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/Utils.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/Utils.scala
@@ -17,7 +17,7 @@
 package ml.dmlc.xgboost4j.scala.spark
 
 import org.apache.spark.ml.feature.{LabeledPoint => MLLabeledPoint}
-import org.apache.spark.ml.linalg.{Vector, Vectors}
+import org.apache.spark.ml.linalg.{SparseVector, Vector, Vectors}
 import org.json4s.{DefaultFormats, FullTypeHints, JField, JValue, NoTypeHints, TypeHints}
 
 import ml.dmlc.xgboost4j.{LabeledPoint => XGBLabeledPoint}
@@ -44,19 +44,31 @@ private[scala] object Utils {
 
   private[spark] implicit class MLVectorToXGBLabeledPoint(val v: Vector) extends AnyVal {
     /**
-     * Converts a [[Vector]] to a data point with a dummy label.
+     * Converts a [[Vector]] to an XGBoost data point.
      *
-     * This is needed for constructing a [[ml.dmlc.xgboost4j.scala.DMatrix]]
-     * for prediction.
-     *
-     * A sparse vector is densified so that its implicit gaps become explicit 0.0 features,
-     * matching how the training path builds its [[XGBLabeledPoint]] in
-     * `XGBoostEstimator.toXGBLabeledPoint`. Keeping the vector sparse here would instead turn
-     * those gaps into missing values and silently diverge from the semantics the model was
-     * fit under.
+     * By default, a sparse vector is densified so that its implicit gaps become explicit 0.0
+     * features, matching how the training path builds its [[XGBLabeledPoint]]. The opt-in sparse
+     * path is valid only with `missing=0.0`, which makes omitted entries equivalent to dense zeros.
      */
-    def asXGB: XGBLabeledPoint =
-      new XGBLabeledPoint(0.0f, v.size, null, v.toArray.map(_.toFloat))
+    def asXGB: XGBLabeledPoint = asXGB(enableSparseDataOptim = false)
+
+    def asXGB(enableSparseDataOptim: Boolean): XGBLabeledPoint =
+      asXGB(0.0f, 1.0f, -1, Float.NaN, enableSparseDataOptim)
+
+    def asXGB(
+        label: Float,
+        weight: Float,
+        group: Int,
+        baseMargin: Float,
+        enableSparseDataOptim: Boolean): XGBLabeledPoint = v match {
+      case sparse: SparseVector if enableSparseDataOptim =>
+        new XGBLabeledPoint(
+          label, sparse.size, sparse.indices, sparse.values.map(_.toFloat),
+          weight, group, baseMargin)
+      case _ =>
+        new XGBLabeledPoint(
+          label, v.size, null, v.toArray.map(_.toFloat), weight, group, baseMargin)
+    }
   }
 
   def getSparkClassLoader: ClassLoader = getClass.getClassLoader

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimator.scala
@@ -233,17 +233,19 @@ private[spark] trait XGBoostEstimator[
   private[spark] def toXGBLabeledPoint(dataset: Dataset[_],
                                        columnIndexes: ColumnIndices): RDD[XGBLabeledPoint] = {
     val isSetMissing = isSet(missing)
+    val preserveSparse = getEnableSparseDataOptim
     dataset.toDF().rdd.map { row =>
       val label = row.getFloat(columnIndexes.labelId)
       val weight = columnIndexes.weightId.map(row.getFloat).getOrElse(1.0f)
       val baseMargin = columnIndexes.marginId.map(row.getFloat).getOrElse(Float.NaN)
       val group = columnIndexes.groupId.map(row.getInt).getOrElse(-1)
 
-      val values = row.schema(columnIndexes.featureId.get).dataType match {
+      row.schema(columnIndexes.featureId.get).dataType match {
         case ArrayType(_, _) =>
           // The driver has casted the array(*) to array(float), so it's safe to
           // specify it as WrappedArray[Float] directly
-          row.getAs[mutable.WrappedArray[Float]](columnIndexes.featureId.get).toArray
+          val values = row.getAs[mutable.WrappedArray[Float]](columnIndexes.featureId.get).toArray
+          new XGBLabeledPoint(label, values.length, null, values, weight, group, baseMargin)
         case other =>
           if (!SparkUtils.isVectorType(other)) {
             throw new IllegalArgumentException("Feature must be array or vector type")
@@ -258,10 +260,8 @@ private[spark] trait XGBoostEstimator[
             }
             case _ => // DenseVector
           }
-          // To make "0" meaningful, we convert sparse vector if possible to dense.
-          features.toArray.map(_.toFloat)
+          features.asXGB(label, weight, group, baseMargin, preserveSparse)
       }
-      new XGBLabeledPoint(label, values.length, null, values, weight, group, baseMargin)
     }
   }
 
@@ -427,6 +427,8 @@ private[spark] trait XGBoostEstimator[
       SparkUtils.checkNumericType(schema, $(baseMarginCol))
     }
 
+    validateSparseDataOptim(schema)
+
     if (isDefined(useExternalMemory) && getUseExternalMemory) {
       require(getDevice == "cuda" || getDevice == "gpu",
         "The `useExternalMemory` is only supported for GPU at the moment.")
@@ -445,7 +447,10 @@ private[spark] trait XGBoostEstimator[
   protected def train(dataset: Dataset[_]): M = {
     validate(dataset)
 
-    val (rdd, configs) = if (PluginUtils.isPluginEnabled(dataset)) {
+    // The columnar plugin does not accept Vector input. Preserve sparse vectors through the
+    // regular JVM DMatrix path when the optimization is enabled.
+    val (rdd, configs) = if (PluginUtils.isPluginEnabled(dataset) &&
+      !getEnableSparseDataOptim) {
       PluginUtils.getPlugin.get.buildRddWatches(this, dataset)
     } else {
       val (input, columnIndexes) = preprocess(dataset)
@@ -612,7 +617,10 @@ private[spark] trait XGBoostModel[M <: XGBoostModel[M]] extends Model[M] with ML
   }
 
   override def transform(dataset: Dataset[_]): DataFrame = {
-    if (PluginUtils.isPluginEnabled(dataset)) {
+    validateSparseDataOptim(dataset.schema)
+    // The columnar plugin does not accept Vector input. Preserve sparse vectors through the
+    // regular JVM DMatrix path when the optimization is enabled.
+    if (PluginUtils.isPluginEnabled(dataset) && !getEnableSparseDataOptim) {
       return PluginUtils.getPlugin.get.transform(this, dataset)
     }
     val (schema, pred) = preprocess(dataset)
@@ -632,6 +640,7 @@ private[spark] trait XGBoostModel[M <: XGBoostModel[M]] extends Model[M] with ML
     val bBooster = input.sparkSession.sparkContext.broadcast(nativeBooster)
     val inferBatchSize = getInferBatchSize
     val missing = getMissing
+    val preserveSparse = getEnableSparseDataOptim
 
     // Here, we use RDD instead of DF to avoid different encoders for different
     // spark versions for the compatibility issue.
@@ -642,7 +651,7 @@ private[spark] trait XGBoostModel[M <: XGBoostModel[M]] extends Model[M] with ML
         val features = batchRow.iterator.map(row => {
           if (!featureIsArray) {
             // Vector type
-            row.getAs[Vector](row.fieldIndex(featureName)).asXGB
+            row.getAs[Vector](row.fieldIndex(featureName)).asXGB(preserveSparse)
           } else {
             // Array type
             val values: Array[Float] = row.get(row.fieldIndex(featureName)) match {
@@ -679,7 +688,9 @@ private[spark] trait XGBoostModel[M <: XGBoostModel[M]] extends Model[M] with ML
     if (nativeBooster == null) {
       throw new IllegalArgumentException("The model has not been trained")
     }
-    val dm = new DMatrix(Iterator(features.asXGB), null, getMissing)
+    validateSparseDataOptim()
+    val dm = new DMatrix(
+      Iterator(features.asXGB(getEnableSparseDataOptim)), null, getMissing)
     nativeBooster.predict(data = dm)(0)
   }
 }

--- a/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/XGBoostParams.scala
+++ b/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/params/XGBoostParams.scala
@@ -149,6 +149,21 @@ private[spark] trait SparkParams[T <: Params] extends HasFeaturesCols with HasFe
   final def getInferBatchSize: Int = $(inferBatchSize)
 
   /**
+   * Whether to preserve Spark ML SparseVector inputs when building DMatrix for training and
+   * prediction. This requires missing=0.0 so that omitted sparse entries have the same semantics
+   * as dense zeros. DenseVector inputs remain dense. Default: false.
+   *
+   * @group param
+   */
+  final val enableSparseDataOptim = new BooleanParam(this, "enableSparseDataOptim",
+    "Whether to preserve Spark ML SparseVector inputs when building DMatrix for training and " +
+      "prediction. This requires missing=0.0 and a single Vector featuresCol. DenseVector " +
+      "inputs remain dense. Default: false.")
+
+  /** @group getParam */
+  final def getEnableSparseDataOptim: Boolean = $(enableSparseDataOptim)
+
+  /**
    * the value treated as missing. default: Float.NaN
    */
   final val missing = new FloatParam(this, "missing", "The value treated as missing")
@@ -209,14 +224,16 @@ private[spark] trait SparkParams[T <: Params] extends HasFeaturesCols with HasFe
   final def getCacheHostRatio: Float = $(cacheHostRatio)
 
   setDefault(numRound -> 100, numWorkers -> 1, inferBatchSize -> (32 << 10),
-    numEarlyStoppingRounds -> 0, forceRepartition -> false, missing -> Float.NaN,
+    numEarlyStoppingRounds -> 0, forceRepartition -> false, enableSparseDataOptim -> false,
+    missing -> Float.NaN,
     featuresCols -> Array.empty, customObj -> null, customEval -> null,
     featureNames -> Array.empty, featureTypes -> Array.empty, useExternalMemory -> false,
     maxQuantileBatches -> -1, minCachePageBytes -> -1)
 
-  addNonXGBoostParam(numWorkers, numRound, numEarlyStoppingRounds, inferBatchSize, featuresCol,
-    labelCol, baseMarginCol, weightCol, predictionCol, leafPredictionCol, contribPredictionCol,
-    forceRepartition, featuresCols, customEval, customObj, featureTypes, featureNames)
+  addNonXGBoostParam(numWorkers, numRound, numEarlyStoppingRounds, inferBatchSize,
+    enableSparseDataOptim, featuresCol, labelCol, baseMarginCol, weightCol, predictionCol,
+    leafPredictionCol, contribPredictionCol, forceRepartition, featuresCols, customEval,
+    customObj, featureTypes, featureNames)
 
   def setNumWorkers(value: Int): T = set(numWorkers, value).asInstanceOf[T]
 
@@ -237,6 +254,9 @@ private[spark] trait SparkParams[T <: Params] extends HasFeaturesCols with HasFe
   def setContribPredictionCol(value: String): T = set(contribPredictionCol, value).asInstanceOf[T]
 
   def setInferBatchSize(value: Int): T = set(inferBatchSize, value).asInstanceOf[T]
+
+  def setEnableSparseDataOptim(value: Boolean): T =
+    set(enableSparseDataOptim, value).asInstanceOf[T]
 
   def setMissing(value: Float): T = set(missing, value).asInstanceOf[T]
 
@@ -262,6 +282,24 @@ private[spark] trait SparkParams[T <: Params] extends HasFeaturesCols with HasFe
 
   def setCacheHostRatio(value: Float): T = set(cacheHostRatio, value)
     .asInstanceOf[T]
+
+  protected[spark] def validateSparseDataOptim(): Unit = {
+    if (getEnableSparseDataOptim) {
+      require(getMissing == 0.0f,
+        "If enableSparseDataOptim is true, missing must be 0.0.")
+    }
+  }
+
+  protected[spark] def validateSparseDataOptim(schema: StructType): Unit = {
+    validateSparseDataOptim()
+    if (getEnableSparseDataOptim) {
+      require(getFeaturesCols.isEmpty,
+        "If enableSparseDataOptim is true, featuresCols is not supported. " +
+          "Use a single Spark ML Vector featuresCol instead.")
+      require(SparkUtils.isVectorType(schema(getFeaturesCol).dataType),
+        "If enableSparseDataOptim is true, featuresCol must have Spark ML Vector type.")
+    }
+  }
 
   protected[spark] def featureIsArrayType(schema: StructType): Boolean =
     schema(getFeaturesCol).dataType.isInstanceOf[ArrayType]

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimatorSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimatorSuite.scala
@@ -366,6 +366,46 @@ class XGBoostEstimatorSuite extends AnyFunSuite with PerTest with TmpFolderPerSu
     }
   }
 
+  test("sparse data optimization preserves empty rows and trailing empty columns") {
+    val size = 128
+    val rows = (0 until 40).map { i =>
+      val features = if (i % 5 == 0) {
+        Vectors.sparse(size, Array.empty[Int], Array.empty[Double])
+      } else {
+        Vectors.sparse(size, Array(i % 3), Array(i.toDouble % 4 + 1.0))
+      }
+      (i, i.toDouble % 2, features)
+    }
+    val sparseDf = ss.createDataFrame(sc.parallelize(rows)).toDF("id", "label", "features")
+    val denseDf = ss.createDataFrame(sc.parallelize(
+      rows.map { case (id, label, v) => (id, label, Vectors.dense(v.toArray)) }))
+      .toDF("id", "label", "features")
+
+    val model = new XGBoostRegressor()
+      .setNumRound(5)
+      .setNumWorkers(1)
+      .setInferBatchSize(1)
+      .setMissing(0.0f)
+      .setEnableSparseDataOptim(true)
+      .setContribPredictionCol("contrib")
+      .fit(sparseDf)
+
+    val sparseResults = model.transform(sparseDf).select("id", "prediction", "contrib")
+      .collect().map { row =>
+        val contrib = row.getAs[DenseVector](2)
+        assert(contrib.size === size + 1)
+        row.getInt(0) -> row.getDouble(1)
+      }.toMap
+    val denseResults = model.transform(denseDf).select("id", "prediction").collect()
+      .map(row => row.getInt(0) -> row.getDouble(1)).toMap
+
+    assert(sparseResults.keySet === denseResults.keySet)
+    sparseResults.foreach { case (id, fromSparse) =>
+      assert(math.abs(fromSparse - denseResults(id)) < 1e-6,
+        s"sparse and dense encodings disagree for row $id")
+    }
+  }
+
   Seq(Float.NaN, 0.0f).foreach { missing =>
     test(s"transform matches training semantics for sparse vectors, missing $missing") {
       val rng = new java.util.Random(42)

--- a/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimatorSuite.scala
+++ b/jvm-packages/xgboost4j-spark/src/test/scala/ml/dmlc/xgboost4j/scala/spark/XGBoostEstimatorSuite.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.SparkException
 import org.apache.spark.ml.Pipeline
-import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vectors}
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.xgboost.SparkUtils
 import org.apache.spark.sql.functions.col
@@ -73,6 +73,9 @@ class XGBoostEstimatorSuite extends AnyFunSuite with PerTest with TmpFolderPerSu
     assert(model.getAlpha === 0.97)
     assert(model.getLeafPredictionCol === "leaf")
     assert(model.getContribPredictionCol === "contrib")
+
+    assert(!estimator.getEnableSparseDataOptim)
+    assert(!model.getEnableSparseDataOptim)
   }
 
   test("camel case parameters") {
@@ -80,25 +83,29 @@ class XGBoostEstimatorSuite extends AnyFunSuite with PerTest with TmpFolderPerSu
       "max_depth" -> 5,
       "featuresCol" -> "abc",
       "num_workers" -> 2,
-      "numRound" -> 11
+      "numRound" -> 11,
+      "enable_sparse_data_optim" -> true
     )
     val estimator = new XGBoostClassifier(xgbParams)
     assert(estimator.getFeaturesCol === "abc")
     assert(estimator.getNumWorkers === 2)
     assert(estimator.getNumRound === 11)
     assert(estimator.getMaxDepth === 5)
+    assert(estimator.getEnableSparseDataOptim)
 
     val xgbParams1: Map[String, Any] = Map(
       "maxDepth" -> 5,
       "features_col" -> "abc",
       "numWorkers" -> 2,
-      "num_round" -> 11
+      "num_round" -> 11,
+      "enableSparseDataOptim" -> true
     )
     val estimator1 = new XGBoostClassifier(xgbParams1)
     assert(estimator1.getFeaturesCol === "abc")
     assert(estimator1.getNumWorkers === 2)
     assert(estimator1.getNumRound === 11)
     assert(estimator1.getMaxDepth === 5)
+    assert(estimator1.getEnableSparseDataOptim)
   }
 
   test("get xgboost parameters") {
@@ -109,12 +116,52 @@ class XGBoostEstimatorSuite extends AnyFunSuite with PerTest with TmpFolderPerSu
       "num_workers" -> 2,
       "tree_method" -> "hist",
       "numRound" -> 11,
+      "enable_sparse_data_optim" -> true,
       "not_exist_parameters" -> "hello"
     )
     val estimator = new XGBoostClassifier(params)
     val xgbParams = estimator.getXGBoostParams
     assert(xgbParams.size === 2)
     assert(xgbParams.contains("max_depth") && xgbParams.contains("tree_method"))
+  }
+
+  test("sparse data optimization parameter validation") {
+    val vectorDf = smallBinaryClassificationVector
+
+    val missingError = intercept[IllegalArgumentException] {
+      new XGBoostClassifier()
+        .setEnableSparseDataOptim(true)
+        .validate(vectorDf)
+    }
+    assert(missingError.getMessage.contains("missing must be 0.0"))
+
+    new XGBoostClassifier()
+      .setEnableSparseDataOptim(true)
+      .setMissing(0.0f)
+      .validate(vectorDf)
+
+    val arrayDf = ss.createDataFrame(sc.parallelize(Seq(
+      (0.0, Array(1.0f, 2.0f))
+    ))).toDF("label", "features")
+    val featureTypeError = intercept[IllegalArgumentException] {
+      new XGBoostClassifier()
+        .setEnableSparseDataOptim(true)
+        .setMissing(0.0f)
+        .validate(arrayDf)
+    }
+    assert(featureTypeError.getMessage.contains("featuresCol must have Spark ML Vector type"))
+
+    val columnarDf = ss.createDataFrame(sc.parallelize(Seq(
+      (0.0, 1.0, 2.0)
+    ))).toDF("label", "feature_0", "feature_1")
+    val featuresColsError = intercept[IllegalArgumentException] {
+      new XGBoostClassifier()
+        .setEnableSparseDataOptim(true)
+        .setMissing(0.0f)
+        .setFeaturesCol(Array("feature_0", "feature_1"))
+        .validate(columnarDf)
+    }
+    assert(featuresColsError.getMessage.contains("featuresCols is not supported"))
   }
 
   test("nthread") {
@@ -197,6 +244,126 @@ class XGBoostEstimatorSuite extends AnyFunSuite with PerTest with TmpFolderPerSu
     assert(predictPoint.indices() === trainPoint.indices())
     assert(predictPoint.values() === trainPoint.values())
     assert(predictPoint.size() === trainPoint.size())
+  }
+
+  test("asXGB preserves a sparse vector when sparse data optimization is enabled") {
+    import Utils.MLVectorToXGBLabeledPoint
+
+    val sparse = Vectors.sparse(1000000, Array(1, 999999), Array(2.2, 4.4))
+    val point = sparse.asXGB(enableSparseDataOptim = true)
+
+    assert(point.size() === 1000000)
+    assert(point.indices() === Array(1, 999999))
+    assert(point.values() === Array(2.2f, 4.4f))
+
+    val dense = Vectors.dense(1.0, 0.0, 3.0)
+    val densePoint = dense.asXGB(enableSparseDataOptim = true)
+    assert(densePoint.indices() == null)
+    assert(densePoint.values() === Array(1.0f, 0.0f, 3.0f))
+  }
+
+  test("sparse data optimization agrees with the training path") {
+    import Utils.MLVectorToXGBLabeledPoint
+
+    val sparse = Vectors.sparse(1000000, Array(1, 999999), Array(2.2, 4.4))
+    val df = ss.createDataFrame(sc.parallelize(Seq((1.0, sparse)))).toDF("label", "features")
+
+    val classifier = new XGBoostClassifier()
+      .setMissing(0.0f)
+      .setEnableSparseDataOptim(true)
+    val (input, columnIndexes) = classifier.preprocess(df)
+    val trainPoint = classifier.toXGBLabeledPoint(input, columnIndexes).collect()(0)
+    val predictPoint = sparse.asXGB(enableSparseDataOptim = true)
+
+    assert(trainPoint.indices() === Array(1, 999999))
+    assert(trainPoint.values() === Array(2.2f, 4.4f))
+    assert(predictPoint.indices() === trainPoint.indices())
+    assert(predictPoint.values() === trainPoint.values())
+    assert(predictPoint.size() === trainPoint.size())
+  }
+
+  test("sparse data optimization supports mixed dense and sparse vector rows") {
+    val rows: Seq[(Double, Vector)] = Seq(
+      (0.0, Vectors.dense(0.0, 2.0, 0.0, 4.0)),
+      (1.0, Vectors.sparse(4, Array(1, 3), Array(2.0, 4.0))))
+    val df = ss.createDataFrame(sc.parallelize(rows)).toDF("label", "features")
+
+    val classifier = new XGBoostClassifier()
+      .setMissing(0.0f)
+      .setEnableSparseDataOptim(true)
+    val (input, columnIndexes) = classifier.preprocess(df)
+    val points = classifier.toXGBLabeledPoint(input, columnIndexes).collect().sortBy(_.label)
+
+    assert(points(0).indices() == null)
+    assert(points(0).values() === Array(0.0f, 2.0f, 0.0f, 4.0f))
+    assert(points(1).indices() === Array(1, 3))
+    assert(points(1).values() === Array(2.0f, 4.0f))
+    assert(points.forall(_.size() === 4))
+  }
+
+  test("sparse data optimization parameter persists") {
+    val rows: Seq[(Double, Vector)] = Seq(
+      (0.0, Vectors.dense(1.0, 0.0, 3.0)),
+      (1.0, Vectors.sparse(3, Array(1), Array(2.0))))
+    val df = ss.createDataFrame(sc.parallelize(Seq.fill(4)(rows).flatten))
+      .toDF("label", "features")
+    val classifier = new XGBoostClassifier()
+      .setNumRound(1)
+      .setMissing(0.0f)
+      .setEnableSparseDataOptim(true)
+
+    val estimatorPath = new File(tempDir.toFile, "sparseEstimator").getPath
+    classifier.write.overwrite().save(estimatorPath)
+    val loadedClassifier = XGBoostClassifier.load(estimatorPath)
+    assert(loadedClassifier.getEnableSparseDataOptim)
+    assert(loadedClassifier.getMissing === 0.0f)
+
+    val model = loadedClassifier.fit(df)
+    val modelPath = new File(tempDir.toFile, "sparseModel").getPath
+    model.write.overwrite().save(modelPath)
+    val loadedModel = XGBoostClassificationModel.load(modelPath)
+    assert(loadedModel.getEnableSparseDataOptim)
+    assert(loadedModel.getMissing === 0.0f)
+    loadedModel.transform(df).collect()
+
+    val invalidModel = loadedModel.copy(ParamMap.empty).setMissing(Float.NaN)
+    val transformError = intercept[IllegalArgumentException] {
+      invalidModel.transform(df)
+    }
+    assert(transformError.getMessage.contains("missing must be 0.0"))
+  }
+
+  test("sparse data optimization preserves prediction semantics") {
+    val rng = new java.util.Random(42)
+    val size = 1000
+    val rows = (0 until 40).map { i =>
+      val idx = Array(i % size, (i * 23 + 101) % size).sorted.distinct
+      val vals = idx.map(_ => rng.nextDouble() + 1.0)
+      (i, i.toDouble % 3, Vectors.sparse(size, idx, vals))
+    }
+    val sparseDf = ss.createDataFrame(sc.parallelize(rows)).toDF("id", "label", "features")
+    val denseDf = ss.createDataFrame(sc.parallelize(
+      rows.map { case (id, label, v) => (id, label, Vectors.dense(v.toArray)) }))
+      .toDF("id", "label", "features")
+
+    val model = new XGBoostRegressor()
+      .setNumRound(5)
+      .setNumWorkers(1)
+      .setMissing(0.0f)
+      .setEnableSparseDataOptim(true)
+      .fit(sparseDf)
+
+    assert(model.getEnableSparseDataOptim)
+    val sparsePreds = model.transform(sparseDf).select("id", "prediction").collect()
+      .map(row => row.getInt(0) -> row.getDouble(1)).toMap
+    val densePreds = model.transform(denseDf).select("id", "prediction").collect()
+      .map(row => row.getInt(0) -> row.getDouble(1)).toMap
+    assert(sparsePreds.keySet === densePreds.keySet)
+    sparsePreds.foreach { case (id, fromSparse) =>
+      val fromDense = densePreds(id)
+      assert(math.abs(fromSparse - fromDense) < 1e-6,
+        s"sparse and dense encodings disagree for row $id: $fromSparse vs $fromDense")
+    }
   }
 
   Seq(Float.NaN, 0.0f).foreach { missing =>


### PR DESCRIPTION
Fixes #12495.

## Summary

XGBoost4J-Spark currently converts Spark ML `SparseVector` inputs to dense arrays when building a `DMatrix`. This preserves the distinction between an implicit zero and a missing value, including the corrected batch prediction behavior from #12347, but it can require memory proportional to the full feature dimension for high-dimensional sparse data.

When `missing` is `0.0f`, omitted sparse entries and explicit dense zeros have the same XGBoost semantics. This PR adds an opt-in `enableSparseDataOptim` parameter that preserves `SparseVector` inputs in that case.

The optimization applies consistently to training, batched `transform`, and single-instance prediction. `DenseVector` rows remain dense, including when dense and sparse rows appear in the same Vector column.

## Changes

- Add `enableSparseDataOptim`, disabled by default and excluded from native XGBoost parameters.
- Require `missing == 0.0f` when the optimization is enabled.
- Restrict the optimized path to a single Spark ML Vector `featuresCol`; array input and `featuresCols` are rejected.
- Share the sparse-preserving conversion between training and prediction paths.
- Persist the parameter through Spark ML estimator and model save/load.
- Add documentation and tests for validation, conversion, mixed dense/sparse rows, persistence, and prediction equivalence.

## Correctness and compatibility

This does not revert or weaken the correctness fix in #12347. The existing dense conversion remains the default. Sparse construction is used only under the explicit `missing == 0.0f` contract, where omitted entries and dense zeros are equivalent missing values.

Existing applications are unchanged unless they explicitly enable the new parameter. There is no model-format change.

For a sparse row, JVM conversion and intermediate feature storage become proportional to the number of stored entries instead of the full vector dimension.

## Scope

This change targets the regular JVM `DMatrix` path. It does not modify the GPU module or GPU documentation and does not claim GPU-specific support. When the optimization is enabled, Vector input is kept on the regular JVM path rather than the columnar plugin path.

## Related work

- #5041 reports excessive memory use when training on a very wide sparse
  LIBSVM dataset with `missing=0`. This PR removes the JVM-side
  sparse-to-dense conversion for this configuration.
