### PR TITLE
Rename splited -> split_result in _parse_eval_str

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -99,9 +99,9 @@ XGBoostError = _XGBoostError
 
 def _parse_eval_str(result: str) -> List[Tuple[str, float]]:
     """Parse an eval result string from the booster."""
-    splited = result.split()[1:]
+    split_result = result.split()[1:]
     # split up `test-error:0.1234`
-    metric_score_str = [tuple(s.split(":")) for s in splited]
+    metric_score_str = [tuple(s.split(":")) for s in split_result]
     # convert to float
     metric_score = [(n, float(s)) for n, s in metric_score_str]
     return metric_score


### PR DESCRIPTION
splited is a purely local variable, used only within this 4-line function, never referenced elsewhere. Confirmed with a repo-wide grep before renaming that nothing else depends on this name.

No behavior change, verified the function still produces identical output before and after the rename.

mypy, isort (via ruff --select I), and pylint (using the project's own pyproject.toml rcfile) all pass clean.