### PR TITLE
Validate Booster.feature_names the same way DMatrix does

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -172,6 +172,18 @@ def _validate_feature_info(
     return feature_info
 
 
+def _validate_feature_names(feature_names: Sequence[str]) -> None:
+    """Reject names that would corrupt the text-based dump format."""
+    # prohibit the use symbols that may affect parsing. e.g. []<
+    if not all(
+        isinstance(f, str) and not any(x in f for x in ["[", "]", "<"])
+        for f in feature_names
+    ):
+        raise ValueError(
+            "feature_names must be string, and may not contain [, ] or <"
+        )
+
+
 def build_info() -> dict:
     """Build information of XGBoost.  The returned value format is not stable. Also,
     please note that build time dependency is not the same as runtime dependency. For
@@ -1288,13 +1300,7 @@ class DMatrix:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             )
 
         # prohibit the use symbols that may affect parsing. e.g. []<
-        if not all(
-            isinstance(f, str) and not any(x in f for x in ["[", "]", "<"])
-            for f in feature_names
-        ):
-            raise ValueError(
-                "feature_names must be string, and may not contain [, ] or <"
-            )
+        _validate_feature_names(feature_names)
 
         feature_names_bytes = [bytes(f, encoding="utf-8") for f in feature_names]
         c_feature_names = (ctypes.c_char_p * len(feature_names_bytes))(
@@ -2075,6 +2081,8 @@ class Booster:
     def _set_feature_info(self, features: Optional[FeatureInfo], field: str) -> None:
         if features is not None:
             assert isinstance(features, list)
+            if field == "feature_name":
+                _validate_feature_names(features)
             feature_info_bytes = [bytes(f, encoding="utf-8") for f in features]
             c_feature_info = (ctypes.c_char_p * len(feature_info_bytes))(
                 *feature_info_bytes


### PR DESCRIPTION
DMatrix.feature_names's setter rejects names containing [, ], or <, since XGBoost's text dump format uses these as delimiters. Booster's feature_names/feature_types setters go through a different code path (_set_feature_info) that had no such check, so setting booster.feature_names directly -- a real, tested usage pattern (test_basic.py, test_basic_models.py) -- could introduce names that corrupt the dump format, the same class of problem already handled for DMatrix.

Extracted the check into _validate_feature_names and call it from both DMatrix's setter and Booster._set_feature_info (only for the feature_name field, not feature_type, whose values are type codes like 'int'/'q'/'c', not user-chosen text).

Verified: valid names pass through unchanged on both DMatrix and Booster; invalid names now raise on both instead of only DMatrix; feature_type is correctly unaffected; clearing via None still works.

mypy, isort, and pylint (project's own pyproject.toml config) all pass clean.