### PR TITLE
Fix broken dtype set-membership check in pandas_transform_data

### DIFF
--- a/python-package/xgboost/data.py
+++ b/python-package/xgboost/data.py
@@ -567,7 +567,7 @@ def pandas_transform_data(
             ),
         )
 
-        if npdtypes or dtype in {np.float32, np.float64}:
+        if npdtypes or dtype in {np.dtype(np.float32), np.dtype(np.float64)}:
             array = ser.to_numpy()
         else:
             # Specifying the dtype can significantly slow down the conversion (about


### PR DESCRIPTION
np.dtype('float32') == np.float32 is True, but they hash differently, so 'dtype in {np.float32, np.float64}' is always False for real pandas float32/float64 columns. Masked in practice by the 'npdtypes' isinstance check on the same line via 'or', except on numpy <= 1.25.0 where that flag is always False -- there, every native float32/ float64 column silently takes the slower na_value-explicit path instead of the fast one the code comment describes.

Fix: wrap the set values in np.dtype() so hashing is consistent.

Verified against real pandas: float32/float64 now correctly match, int64 correctly still doesn't.