### PR TITLE
[Python] Remove obsolete py_str type suppression

### DIFF
--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -7,7 +7,7 @@ import functools
 import importlib.util
 import logging
 import types
-from typing import TYPE_CHECKING, Any, Sequence, TypeGuard, cast
+from typing import TYPE_CHECKING, Sequence, TypeGuard, cast
 
 import numpy as np
 
@@ -21,10 +21,10 @@ if TYPE_CHECKING:
 def py_str(x: bytes | None) -> str:
     """convert c string back to python string"""
     assert x is not None  # ctypes might return None
-    return x.decode("utf-8")  # type: ignore[union-attr]
+    return x.decode("utf-8")
 
 
-def lazy_isinstance(instance: Any, module: str, name: str) -> bool:
+def lazy_isinstance(instance: object, module: str, name: str) -> bool:
     """Use string representation to identify a type."""
 
     # Notice, we use .__class__ as opposed to type() in order

--- a/python-package/xgboost/compat.py
+++ b/python-package/xgboost/compat.py
@@ -7,7 +7,7 @@ import functools
 import importlib.util
 import logging
 import types
-from typing import TYPE_CHECKING, Sequence, TypeGuard, cast
+from typing import TYPE_CHECKING, Any, Sequence, TypeGuard, cast
 
 import numpy as np
 
@@ -24,7 +24,7 @@ def py_str(x: bytes | None) -> str:
     return x.decode("utf-8")
 
 
-def lazy_isinstance(instance: object, module: str, name: str) -> bool:
+def lazy_isinstance(instance: Any, module: str, name: str) -> bool:
     """Use string representation to identify a type."""
 
     # Notice, we use .__class__ as opposed to type() in order


### PR DESCRIPTION
Remove the obsolete `union-attr` suppression in `py_str`. The existing `assert x is not None` narrows the input to `bytes`, so the decode call type-checks without the suppression. Runtime code and `lazy_isinstance` are unchanged relative to upstream.

Related to #6496.

Validation: mypy 1.15.0 and current mypy with `--warn-unused-ignores`; all applicable project pre-commit hooks, including Ruff import/format checks and Pylint; and `git diff --check`. The final diff is one comment removal, so no tests were added.

Codex assisted with preparation, review, and validation.
