### PR TITLE
Feat/cv oof predictions

### DIFF
--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -479,7 +479,12 @@ def cv(
     callbacks: Optional[Sequence[TrainingCallback]] = None,
     shuffle: bool = True,
     custom_metric: Optional[Metric] = None,
-) -> Union[Dict[str, float], "PdDataFrame"]:
+    return_oof_preds: bool = False,
+) -> Union[
+    Dict[str, float],
+    "PdDataFrame",
+    Tuple[Union[Dict[str, float], "PdDataFrame"], np.ndarray],
+]:
     """Cross-validation with given parameters.
 
     Parameters
@@ -561,6 +566,10 @@ def cv(
 
         Custom metric function.  See :doc:`Custom Metric </tutorials/custom_metric_obj>`
         for details.
+    return_oof_preds : bool
+        If True, also return the out-of-fold predictions: each row predicted by
+        the fold that held it out during training. Changes the return value to
+        a ``(results, oof_preds)`` tuple.
 
     Returns
     -------
@@ -647,4 +656,6 @@ def cv(
 
     callbacks_container.after_training(booster)
 
+    if return_oof_preds:
+        return results, booster.oof_predict()
     return results

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -213,11 +213,16 @@ class CVPack:
     """ "Auxiliary datastruct to hold one fold of CV."""
 
     def __init__(
-        self, dtrain: DMatrix, dtest: DMatrix, param: Optional[Union[Dict, List]]
+        self,
+        dtrain: DMatrix,
+        dtest: DMatrix,
+        param: Optional[Union[Dict, List]],
+        test_idx: np.ndarray,
     ) -> None:
         """Initialize the CVPack."""
         self.dtrain = dtrain
         self.dtest = dtest
+        self.test_idx = test_idx
         self.watchlist = [(dtrain, "train"), (dtest, "test")]
         self.bst = Booster(param, [dtrain, dtest])
 
@@ -354,7 +359,7 @@ def mkgroupfold(
         else:
             tparam = param
         plst = list(tparam.items()) + [("eval_metric", itm) for itm in evals]
-        ret.append(CVPack(dtrain, dtest, plst))
+        ret.append(CVPack(dtrain, dtest, plst, out_idset[k]))
     return ret
 
 
@@ -427,7 +432,7 @@ def mknfold(
         else:
             tparam = param
         plst = list(tparam.items()) + [("eval_metric", itm) for itm in evals]
-        ret.append(CVPack(dtrain, dtest, plst))
+        ret.append(CVPack(dtrain, dtest, plst, out_idset[k]))
     return ret
 
 

--- a/python-package/xgboost/training.py
+++ b/python-package/xgboost/training.py
@@ -298,6 +298,28 @@ class _PackedBooster:
     def best_score(self, score: float) -> None:
         self.set_attr(best_score=score)
 
+    def oof_predict(self, **kwargs: Any) -> np.ndarray:
+        """Out-of-fold prediction: each row is predicted by the fold that held
+        it out during training.
+
+        Parameters
+        ----------
+        kwargs :
+            Forwarded to :py:meth:`Booster.predict` for every fold.
+
+        """
+        n_total = sum(fold.dtest.num_row() for fold in self.cvfolds)
+        preds: Optional[np.ndarray] = None
+        for fold in self.cvfolds:
+            fold_pred = fold.bst.predict(fold.dtest, **kwargs)
+            if preds is None:
+                preds = np.full(
+                    (n_total,) + fold_pred.shape[1:], np.nan, dtype=np.float32
+                )
+            preds[fold.test_idx] = fold_pred
+        assert preds is not None
+        return preds
+
 
 def groups_to_rows(groups: np.ndarray, boundaries: np.ndarray) -> np.ndarray:
     """

--- a/tests/python/test_basic_models.py
+++ b/tests/python/test_basic_models.py
@@ -2,7 +2,9 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
+
 import xgboost as xgb
 from xgboost import testing as tm
 from xgboost.core import Integer
@@ -203,6 +205,21 @@ class TestModels:
             seed=0,
             show_stdv=False,
         )
+
+    def test_cv_oof_predict(self):
+        param = {"max_depth": 2, "eta": 1, "objective": "binary:logistic"}
+        dtrain, _ = tm.load_agaricus(__file__)
+        nfold = 5
+
+        results = xgb.cv(param, dtrain, 2, nfold=nfold, seed=0, shuffle=False)
+        results_with_oof, oof_preds = xgb.cv(
+            param, dtrain, 2, nfold=nfold, seed=0, shuffle=False, return_oof_preds=True
+        )
+
+        # Same aggregated results either way; only the extra return value differs.
+        pd.testing.assert_frame_equal(results, results_with_oof)
+        assert oof_preds.shape == (dtrain.num_row(),)
+        assert not np.isnan(oof_preds).any()
 
     def test_prediction_cache(self, tmp_path: Path) -> None:
         X, y = tm.make_sparse_regression(512, 4, 0.5, as_dense=False)


### PR DESCRIPTION
Adds an opt-in return_oof_preds parameter to xgb.cv(). When set, returns (results, oof_preds) where each row of oof_preds was predicted by the fold that held it out.
Related: the C++ OOF-prediction work landing on fused-cv addresses this at a lower level; this is a standalone Python-side addition using the already-trained fold boosters, no C++ changes.
Default behavior (return_oof_preds=False) is unchanged.