### PR TITLE
Optimize memory allocations in distributed collective operations

### DIFF
--- a/src/collective/allgather.cc
+++ b/src/collective/allgather.cc
@@ -131,7 +131,13 @@ namespace detail {
     offset[i] = offset[i - 1] + global_sizes[i - 1];
   }
 
+  std::size_t total_size = 0;
+  for (auto const& vec : input) {
+    total_size += vec.size();
+  }
+
   std::vector<char> collected;
+  collected.reserve(total_size);
   for (auto const& vec : input) {
     collected.insert(collected.end(), vec.cbegin(), vec.cend());
   }
@@ -141,6 +147,9 @@ namespace detail {
   auto out = common::RestoreType<char const>(recv.ConstHostSpan());
 
   std::vector<std::vector<char>> result;
+  if (offset.size() > 1) {
+    result.reserve(offset.size() - 1);
+  }
   for (std::size_t i = 1; i < offset.size(); ++i) {
     std::vector<char> local(out.cbegin() + offset[i - 1], out.cbegin() + offset[i]);
     result.emplace_back(std::move(local));

--- a/src/collective/tracker.cc
+++ b/src/collective/tracker.cc
@@ -146,6 +146,7 @@ Result RabitTracker::Bootstrap(std::vector<WorkerProxy>* p_workers) {
   std::sort(workers.begin(), workers.end(), WorkerCmp{this->sortby_});
 
   std::vector<std::thread> bootstrap_threads;
+  bootstrap_threads.reserve(n_workers_);
   for (std::int32_t r = 0; r < n_workers_; ++r) {
     auto& worker = workers[r];
     auto next = BootstrapNext(r, n_workers_);
@@ -166,6 +167,7 @@ Result RabitTracker::Bootstrap(std::vector<WorkerProxy>* p_workers) {
     t.join();
   }
 
+  worker_error_handles_.reserve(workers.size());
   for (auto const& w : workers) {
     worker_error_handles_.emplace_back(w.Host(), w.ErrorPort());
   }


### PR DESCRIPTION
### Description
This PR optimizes memory handling in the `src/collective/` module by pre-allocating exact capacities for `std::vector` collections initialized dynamically in loops.

Specifically, it applies `.reserve()` to:
1. `collected` buffer and `result` matrix in `allgather.cc` `VectorAllgatherV`.
2. `bootstrap_threads` and `worker_error_handles_` in `tracker.cc` `Bootstrap`.

### Motivation and Context
In distributed environments, dynamic resizing of buffers during synchronization phases like `Allgather` introduces latency spikes and memory fragmentation. By pre-allocating buffers whose final capacities are explicitly known ahead of the loop, this PR eliminates unnecessary O(N) heap re-allocations and improves the determinism of the communication backend execution speed.

### How Has This Been Tested?
Compiled and verified the build using the MSVC C++ toolchain and NVIDIA CUDA compiler.