### PR TITLE
Optimize memory allocations across the core tree module

### DIFF
--- a/src/tree/constraints.cu
+++ b/src/tree/constraints.cu
@@ -63,12 +63,18 @@ void FeatureInteractionConstraintDevice::Configure(tree::TrainParam const& param
   // Represent constraints as CSR format, flatten is the value vector,
   // ptr is row_ptr vector in CSR.
   std::vector<uint32_t> h_feature_constraints_flatten;
+  std::size_t total_constraints = 0;
+  for (auto const& constraints : h_feature_constraints) {
+    total_constraints += constraints.size();
+  }
+  h_feature_constraints_flatten.reserve(total_constraints);
   for (auto const& constraints : h_feature_constraints) {
     for (uint32_t c : constraints) {
       h_feature_constraints_flatten.emplace_back(c);
     }
   }
   std::vector<size_t> h_feature_constraints_ptr;
+  h_feature_constraints_ptr.reserve(h_feature_constraints.size() + 1);
   size_t n_features_in_constraints = 0;
   h_feature_constraints_ptr.emplace_back(n_features_in_constraints);
   for (auto const& v : h_feature_constraints) {

--- a/src/tree/hist/evaluate_splits.h
+++ b/src/tree/hist/evaluate_splits.h
@@ -645,6 +645,7 @@ class HistMultiEvaluator {
       evaluator.CalcWeightCat(*param_, parent_sum, h_bw);
 
       std::vector<common::ConstGHistRow> node_hist;
+      node_hist.reserve(hist.size());
       for (auto t_hist : hist) {
         node_hist.emplace_back((*t_hist)[entry->nid]);
       }

--- a/src/tree/multi_target_tree_model.cc
+++ b/src/tree/multi_target_tree_model.cc
@@ -88,6 +88,7 @@ void CopyCategoryStorage(Context const* ctx, std::size_t offset, ExpandBatch con
                          HostDeviceVector<CatWordT>* out) {
   xgboost_NVTX_FN_RANGE();
   std::vector<CopyBatchItem<CatWordT>> copies;
+  copies.reserve(batch.cat_bits.size());
   for (auto cats : batch.cat_bits) {
     if (!cats.empty()) {
       copies.emplace_back(offset, cats);
@@ -197,6 +198,7 @@ void MultiTargetTree::Expand(Context const* ctx, tree::ExpandBatch const& batch)
   }
 
   std::vector<CopyBatchItem<float>> weight_copies;
+  weight_copies.reserve(batch_size * 3);
   for (std::size_t i = 0; i < batch_size; ++i) {
     auto const nidx = batch.nidxs[i];
     weight_copies.emplace_back(nidx * n_split_targets, batch.base_weight_batch[i]);

--- a/src/tree/updater_approx.cc
+++ b/src/tree/updater_approx.cc
@@ -186,8 +186,10 @@ class GlobalApproxBuilder {
     while (!expand_set.empty()) {
       // candidates that can be further splited.
       std::vector<CPUExpandEntry> valid_candidates;
+      valid_candidates.reserve(expand_set.size());
       // candidates that can be applied.
       std::vector<CPUExpandEntry> applied;
+      applied.reserve(expand_set.size());
       for (auto const &candidate : expand_set) {
         evaluator_.ApplyTreeSplit(candidate, p_tree);
         applied.push_back(candidate);


### PR DESCRIPTION
### Description
This PR addresses missing memory pre-allocations in high-execution-frequency loops across the core `src/tree/` module to prevent unnecessary heap reallocations during tree building and model updates.

Specifically, it injects explicit `.reserve()` capacity calculations into:
1. `src/tree/updater_approx.cc`: Candidate queues `valid_candidates` and `applied` in `UpdatePosition`.
2. `src/tree/hist/evaluate_splits.h`: Histogram slice allocations for `node_hist`.
3. `src/tree/multi_target_tree_model.cc`: Batch copy allocations for categorical logic and tree weights.
4. `src/tree/constraints.cu`: CSR constraint matrix allocations (`h_feature_constraints_ptr` and `h_feature_constraints_flatten`).

### Motivation and Context
The tree building paths are the most computationally intensive sections of XGBoost. Omitting `.reserve()` when populating STL vectors in these deep loops causes compounding memory fragmentations and dynamic resizing overhead. Pre-allocating exact vector capacities eliminates these bottlenecks.

### How Has This Been Tested?
Compiled and verified the build via the MSVC C++ toolchain and NVIDIA CUDA compiler.