### PR TITLE
Guard append_m_sparse against empty partitions

### DIFF
--- a/python-package/xgboost/spark/data.py
+++ b/python-package/xgboost/spark/data.py
@@ -244,13 +244,18 @@ def create_dmatrix_from_partitions(  # pylint: disable=too-many-arguments
         nonlocal n_features
 
         if name == alias.data or name in part.columns:
-            if name == alias.data:
-                array = _read_csr_matrix_from_unwrapped_spark_vec(part)
+            array: Optional[Any] = None
+            if name == alias.data and part.shape[0] > 0:
+                csr = _read_csr_matrix_from_unwrapped_spark_vec(part)
                 if n_features == 0:
-                    n_features = array.shape[1]
-                assert n_features == array.shape[1]
-            else:
+                    n_features = csr.shape[1]
+                assert n_features == csr.shape[1]
+                array = csr
+            elif name != alias.data:
                 array = part[name]
+
+            if array is None:
+                return
 
             if is_valid:
                 valid_data[name].append(array)


### PR DESCRIPTION
append_m (dense path) already skips empty partitions with a comment saying so. append_m_sparse (sparse path) didn't, so an empty partition arriving after n_features was already set from an earlier non-empty partition hits 'assert n_features == 0', crashing training. Empty partitions are ordinary in Spark (e.g. all rows in a partition landing on one side of a train/validation split).

Mirrors append_m's existing pattern: skip building an array at all when the partition has zero rows.