### PR TITLE
[obj] Use the absolute-residual pseudo-Hessian |p - y| for multiclass softmax

### DIFF
--- a/R-package/tests/testthat/test_custom_objective.R
+++ b/R-package/tests/testthat/test_custom_objective.R
@@ -124,7 +124,8 @@ softprob <- function(predt, dtrain) {
       } else {
         p[c]
       }
-      h <- max((2.0 * p[c] * (1.0 - p[c])), 1e-6)
+      # absolute-residual pseudo-Hessian, matching the native objective
+      h <- max(abs(g), 1e-6)
       grad[i, c] <- g
       hess[i, c] <- h
     }

--- a/demo/guide-python/custom_softmax.py
+++ b/demo/guide-python/custom_softmax.py
@@ -79,8 +79,9 @@ def softprob_obj(predt: np.ndarray, data: xgb.DMatrix) -> Tuple[np.ndarray, np.n
             assert 0 <= target < kClasses
             pc = float(p[c])
             g = pc - 1.0 if c == target else pc
+            # Absolute-residual pseudo-Hessian, matching the native objective.
+            h = max(abs(g) * weight, eps)
             g = g * weight
-            h = max(2.0 * pc * (1.0 - pc) * weight, eps)
             grad[r, c] = g
             hess[r, c] = h
 

--- a/demo/guide-python/custom_softmax.py
+++ b/demo/guide-python/custom_softmax.py
@@ -43,9 +43,10 @@ def softmax(x: np.ndarray) -> np.ndarray:
 
 
 def softprob_obj(predt: np.ndarray, data: xgb.DMatrix) -> Tuple[np.ndarray, np.ndarray]:
-    """Loss function. Computing the gradient and upper bound on the
-    Hessian with a diagonal structure for XGBoost (note that this is
-    not the true Hessian).
+    """Loss function. Computing the gradient and a diagonal pseudo-Hessian
+    for XGBoost (note that this is neither the true Hessian nor an upper
+    bound on it; it is the absolute residual |p - y|, which keeps every leaf
+    value bounded).
     Reimplements the `multi:softprob` inside XGBoost.
 
     """
@@ -67,7 +68,7 @@ def softprob_obj(predt: np.ndarray, data: xgb.DMatrix) -> Tuple[np.ndarray, np.n
 
     eps = 1e-6
 
-    # compute the gradient and hessian upper bound, slow iterations in Python, only
+    # compute the gradient and pseudo-Hessian, slow iterations in Python, only
     # suitable for demo.  Also the one in native XGBoost core is more robust to
     # numeric overflow as we don't do anything to mitigate the `exp` in
     # `softmax` here.

--- a/doc/tutorials/custom_metric_obj.rst
+++ b/doc/tutorials/custom_metric_obj.rst
@@ -313,7 +313,7 @@ access ``DMatrix``:
             p = softmax(predt[r, :])
             for c in range(predt.shape[1]):
                 g = p[c] - 1.0 if c == target else p[c]
-                h = max((2.0 * p[c] * (1.0 - p[c])).item(), eps)
+                h = max(abs(g).item(), eps)  # absolute-residual pseudo-Hessian
                 grad[r, c] = g
                 hess[r, c] = h
 

--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -567,14 +567,18 @@ def softprob_obj(
         rows = labels.shape[0]
         grad = backend.zeros((rows, classes), dtype=np.float32)
         hess = backend.zeros((rows, classes), dtype=np.float32)
-        eps = 1e-6
+        # Same Hessian floor as the native kernel.  The tests compare this
+        # reimplementation with the native objective at tight tolerance, and a
+        # larger floor can move a node across `min_child_weight`.
+        eps = 1e-16
         for r in range(predt.shape[0]):
             target = labels[r]
             p = softmax(predt[r, :])
             for c in range(predt.shape[1]):
                 assert target >= 0 or target <= classes
                 g = p[c] - 1.0 if c == target else p[c]
-                h = max((2.0 * p[c] * (1.0 - p[c])).item(), eps)
+                # absolute-residual pseudo-Hessian, matching the native objective
+                h = max(abs(g).item(), eps)
                 grad[r, c] = g
                 hess[r, c] = h
 

--- a/python-package/xgboost/testing/__init__.py
+++ b/python-package/xgboost/testing/__init__.py
@@ -248,7 +248,8 @@ def make_batches_sparse(
 
 
 class TestDataset:
-    """Contains a dataset in numpy format as well as the relevant objective and metric."""
+    """Contains a dataset in numpy format as well as the relevant objective and
+    metric."""
 
     def __init__(
         self, name: str, get_dataset: Callable, objective: str, metric: str
@@ -538,7 +539,10 @@ def root_mean_square(y_true: np.ndarray, y_score: np.ndarray) -> float:
 
 
 def softmax(x: np.ndarray) -> np.ndarray:
-    e = np.exp(x)
+    # Subtract the maximum first, as the native objective does.  The custom
+    # softprob objective below is compared with the native one at tight
+    # tolerance, so the arithmetic has to match closely.
+    e = np.exp(x - np.max(x))
     return e / np.sum(e)
 
 

--- a/src/objective/multiclass_obj.cc
+++ b/src/objective/multiclass_obj.cc
@@ -58,8 +58,13 @@ void MulticlassGradientCpu(Context const* ctx, HostDeviceVector<float> const& pr
     auto weight = weights[row];
     for (std::int64_t k{0}; k < n_classes; ++k) {
       auto probability = expf(point(k) - wmax) / static_cast<float>(wsum);
-      auto hess = fmaxf(2.0f * probability * (1.0f - probability) * weight, 1e-16f);
       auto grad = label == k ? probability - 1.0f : probability;
+      // Absolute-residual pseudo-Hessian |p - y|.  Because sum|g| >= |sum g| in every
+      // leaf, the leaf value -G/H is bounded by 1, and the curvature never vanishes on a
+      // mis-predicted class.  The diagonal-dominance bound 2p(1-p) used previously
+      // collapses to ~0 for rare classes while the gradient stays O(1), producing
+      // unbounded leaf values at small reg_lambda.
+      auto hess = fmaxf(fabsf(grad) * weight, 1e-16f);
       gpair(row, k) = {grad * weight, hess};
     }
   });

--- a/src/objective/multiclass_obj.cu
+++ b/src/objective/multiclass_obj.cu
@@ -52,8 +52,9 @@ void MulticlassGradientCuda(Context const* ctx, HostDeviceVector<float> const& p
     auto weight = weights[row];
     for (std::int64_t k{0}; k < n_classes; ++k) {
       auto probability = expf(point(k) - wmax) / static_cast<float>(wsum);
-      auto hess = fmaxf(2.0f * probability * (1.0f - probability) * weight, 1e-16f);
       auto grad = label == k ? probability - 1.0f : probability;
+      // Absolute-residual pseudo-Hessian |p - y|; see the CPU kernel for the rationale.
+      auto hess = fmaxf(fabsf(grad) * weight, 1e-16f);
       gpair(row, k) = {grad * weight, hess};
     }
   });

--- a/tests/cpp/objective/test_multiclass_obj.cc
+++ b/tests/cpp/objective/test_multiclass_obj.cc
@@ -22,14 +22,14 @@ void TestSoftmaxMultiClassObjGPair(const Context* ctx) {
 		   {1.0f, 0.0f},	       // labels
 		   {1.0f, 1.0f},	       // weights
 		   {0.24f, -0.91f, 0.66f, -0.33f, 0.09f, 0.24f}, // grad
-		   {0.36f, 0.16f, 0.44f, 0.45f, 0.16f, 0.37f});	 // hess
+		   {0.24f, 0.91f, 0.67f, 0.33f, 0.09f, 0.24f});	 // hess = |grad|
 
   CheckObjFunction(obj,
 		   {1.0f, 0.0f, 2.0f, 2.0f, 0.0f, 1.0f}, // preds
 		   {1.0f, 0.0f},	       // labels
                    {},                         // weights
 		   {0.24f, -0.91f, 0.66f, -0.33f, 0.09f, 0.24f}, // grad
-		   {0.36f, 0.16f, 0.44f, 0.45f, 0.16f, 0.37f});	 // hess
+		   {0.24f, 0.91f, 0.67f, 0.33f, 0.09f, 0.24f});	 // hess = |grad|
 
   ASSERT_NO_THROW({ [[maybe_unused]] auto _ = obj->DefaultEvalMetric(); });
 }

--- a/tests/cpp/objective/test_multiclass_obj.cc
+++ b/tests/cpp/objective/test_multiclass_obj.cc
@@ -17,11 +17,13 @@ void TestSoftmaxMultiClassObjGPair(const Context* ctx) {
   obj->Configure(args);
   CheckConfigReload(obj, "multi:softmax");
 
+  // Non-unit, distinct weights so that the test detects the weight scaling of both the
+  // gradient and the pseudo-Hessian.
   CheckObjFunction(obj, {1.0f, 0.0f, 2.0f, 2.0f, 0.0f, 1.0f},     // preds
                    {1.0f, 0.0f},                                  // labels
-                   {1.0f, 1.0f},                                  // weights
-                   {0.24f, -0.91f, 0.66f, -0.33f, 0.09f, 0.24f},  // grad
-                   {0.24f, 0.91f, 0.67f, 0.33f, 0.09f, 0.24f});   // hess = |grad|
+                   {0.5f, 2.0f},                                  // weights
+                   {0.12f, -0.45f, 0.33f, -0.67f, 0.18f, 0.49f},  // grad = w (p - y)
+                   {0.12f, 0.45f, 0.33f, 0.67f, 0.18f, 0.49f});   // hess = w |p - y|
 
   CheckObjFunction(obj, {1.0f, 0.0f, 2.0f, 2.0f, 0.0f, 1.0f},     // preds
                    {1.0f, 0.0f},                                  // labels

--- a/tests/cpp/objective/test_multiclass_obj.cc
+++ b/tests/cpp/objective/test_multiclass_obj.cc
@@ -1,35 +1,33 @@
 /**
  * Copyright 2018-2025, XGBoost contributors
  */
-#include <xgboost/objective.h>
-#include <xgboost/context.h>
-#include "../helpers.h"
 #include "test_multiclass_obj.h"
+
+#include <xgboost/context.h>
+#include <xgboost/objective.h>
+
+#include "../helpers.h"
 
 namespace xgboost {
 
 void TestSoftmaxMultiClassObjGPair(const Context* ctx) {
-  std::vector<std::pair<std::string, std::string>> args {{"num_class", "3"}};
-  std::unique_ptr<ObjFunction> obj {
-    ObjFunction::Create("multi:softmax", ctx)
-  };
+  std::vector<std::pair<std::string, std::string>> args{{"num_class", "3"}};
+  std::unique_ptr<ObjFunction> obj{ObjFunction::Create("multi:softmax", ctx)};
 
   obj->Configure(args);
   CheckConfigReload(obj, "multi:softmax");
 
-  CheckObjFunction(obj,
-		   {1.0f, 0.0f, 2.0f, 2.0f, 0.0f, 1.0f}, // preds
-		   {1.0f, 0.0f},	       // labels
-		   {1.0f, 1.0f},	       // weights
-		   {0.24f, -0.91f, 0.66f, -0.33f, 0.09f, 0.24f}, // grad
-		   {0.24f, 0.91f, 0.67f, 0.33f, 0.09f, 0.24f});	 // hess = |grad|
+  CheckObjFunction(obj, {1.0f, 0.0f, 2.0f, 2.0f, 0.0f, 1.0f},     // preds
+                   {1.0f, 0.0f},                                  // labels
+                   {1.0f, 1.0f},                                  // weights
+                   {0.24f, -0.91f, 0.66f, -0.33f, 0.09f, 0.24f},  // grad
+                   {0.24f, 0.91f, 0.67f, 0.33f, 0.09f, 0.24f});   // hess = |grad|
 
-  CheckObjFunction(obj,
-		   {1.0f, 0.0f, 2.0f, 2.0f, 0.0f, 1.0f}, // preds
-		   {1.0f, 0.0f},	       // labels
-                   {},                         // weights
-		   {0.24f, -0.91f, 0.66f, -0.33f, 0.09f, 0.24f}, // grad
-		   {0.24f, 0.91f, 0.67f, 0.33f, 0.09f, 0.24f});	 // hess = |grad|
+  CheckObjFunction(obj, {1.0f, 0.0f, 2.0f, 2.0f, 0.0f, 1.0f},     // preds
+                   {1.0f, 0.0f},                                  // labels
+                   {},                                            // weights
+                   {0.24f, -0.91f, 0.66f, -0.33f, 0.09f, 0.24f},  // grad
+                   {0.24f, 0.91f, 0.67f, 0.33f, 0.09f, 0.24f});   // hess = |grad|
 
   ASSERT_NO_THROW({ [[maybe_unused]] auto _ = obj->DefaultEvalMetric(); });
 }
@@ -42,8 +40,7 @@ void TestSoftmaxMultiClassBasic(const Context* ctx) {
   obj->Configure(args);
   CheckConfigReload(obj, "multi:softmax");
 
-  HostDeviceVector<bst_float>  io_preds = {2.0f, 0.0f, 1.0f,
-                                           1.0f, 0.0f, 2.0f};
+  HostDeviceVector<bst_float> io_preds = {2.0f, 0.0f, 1.0f, 1.0f, 0.0f, 2.0f};
   std::vector<bst_float> out_preds = {0.0f, 2.0f};
   obj->PredTransform(&io_preds);
 
@@ -55,16 +52,14 @@ void TestSoftmaxMultiClassBasic(const Context* ctx) {
 }
 
 void TestSoftprobMultiClassBasic(const Context* ctx) {
-  std::vector<std::pair<std::string, std::string>> args {
-    std::pair<std::string, std::string>("num_class", "3")};
+  std::vector<std::pair<std::string, std::string>> args{
+      std::pair<std::string, std::string>("num_class", "3")};
 
-  std::unique_ptr<ObjFunction> obj {
-    ObjFunction::Create("multi:softprob", ctx)
-  };
+  std::unique_ptr<ObjFunction> obj{ObjFunction::Create("multi:softprob", ctx)};
   obj->Configure(args);
   CheckConfigReload(obj, "multi:softprob");
 
-  HostDeviceVector<bst_float>  io_preds = {2.0f, 0.0f, 1.0f};
+  HostDeviceVector<bst_float> io_preds = {2.0f, 0.0f, 1.0f};
   std::vector<bst_float> out_preds = {0.66524096f, 0.09003057f, 0.24472847f};
 
   obj->PredTransform(&io_preds);


### PR DESCRIPTION
## Summary

The multiclass objectives currently use $h = 2p(1-p)$ per class coordinate. This PR
replaces it with $h = \lvert p - y \rvert$ — the absolute value of the gradient — in both
the CPU and CUDA kernels. The gradient is unchanged. The change is one line per kernel; the
rest of the diff updates the C++ unit-test expectations, the `custom_softmax.py` demo (which
asserts bit-equality with the native objective), and the custom-objective tutorial.

Why: the shipped curvature collapses to ~0 on rare classes while the gradient stays $O(1)$,
which produces unbounded leaf values whenever `reg_lambda` is small. $\lvert p - y \rvert$
never vanishes on a mis-predicted coordinate, bounds every leaf value by 1 in exact
arithmetic, has a monotone-descent proof, and — after joint hyperparameter tuning on 18
public datasets — reaches lower held-out log loss than the current rule on 12 of 18 with a
geometric-mean ratio of 0.955. Nothing else in a tuning study of eight curvature rules
matched that combination.

## The problem being fixed

$2p(1-p)$ is the diagonal-dominance (Gershgorin) bound on the softmax Hessian: the exact
diagonal $p_k(1-p_k)$ plus the row sum of the off-diagonals $\sum_{j \ne k} p_k p_j$, which
is again $p_k(1-p_k)$. It is a worst-case charge that makes simultaneous per-class tree
updates a valid majoriser step. It is a function of the prediction only.

For a rare class $k$, $p_k \to 0$ on almost every row, so a leaf's Hessian mass for that
class is $\approx 2\,n_{\text{leaf}}\,p_k$, while any positive row in the leaf contributes
gradient $p_k - 1 \approx -1$. The leaf value $-G/(H + \lambda)$ is then bounded only by
$\lambda$:

| `reg_lambda` | trials with a training-loss increase (of 36) | total increasing rounds | max abs margin |
|---:|---:|---:|---:|
| 0 | 15 | 1006 | 9.3e20 |
| 0.001 | 4 | 484 | 5.8e5 |
| 0.01 | 2 | 317 | 117 |
| 0.1 | 3 | 46 | 1.8e4 |
| **1** | **0** | **0** | **28.6** |
| 10 | 1 | 4 | 29.7 |

(shipped $2p(1-p)$, 18 datasets, 12 configurations, `multi_output_tree`; margins of
1e20 are float overflow in progress.) The failure is a rare-class effect, not a
many-class one: across the 18 datasets the gain of residual-type rules over the shipped
curvature is predicted by the minimum class prior ($t = 2.3$ to $4.0$ depending on rule) and
only weakly by the number of classes; it appears at $K = 7$ (Covertype, Shuttle) as readily
as at $K = 1000$ (ALOI).

## The rule

For row weight $w$, class probability $p_k$, one-hot target $y_k$:

```math
g_k = w\,(p_k - y_k), \qquad
h_k = w\,\lvert p_k - y_k \rvert \quad\bigl(\text{was } 2\,w\,p_k(1 - p_k)\bigr)
```

Properties (from the accompanying analysis; proofs in the research log):

- **Bounded step.** In any leaf, $H = \sum \lvert g \rvert \ge \lvert \sum g \rvert = \lvert G \rvert$,
  so $\lvert \text{leaf} \rvert \le 1$ at $\lambda = 0$, closed under any row partition,
  with no dependence on `eta` or `max_delta_step`.
- **Monotone descent.** With $A$ = non-target residual mass and $B$ = target residual mass
  in a leaf, the step is $(B - A)/(A + B)$, which lies inside the descent interval
  $\bigl[0,\ \mathrm{atanh}\bigl((B - A)/(A + B)\bigr)\bigr]$ of a pairwise exponential
  majoriser of the exact softmax loss. The full step and every $\eta \in (0, 1]$ therefore
  decrease the exact training loss for any tree partition (unregularised, full rows,
  non-negative weights). $\gamma = 1$ is the sharp constant: $h = \gamma\,\lvert p - y \rvert$
  with $\gamma < 1$ leaves the interval.
- **Relationship to the old rule.** Under $y \sim \mathrm{Bernoulli}(p)$,
  $\mathbb{E}\,\lvert p - y \rvert = 2p(1-p)$. The shipped Hessian is the expectation of the
  new one over the label; the new one conditions on the label actually observed, which is
  exactly what a rare positive needs.

## Evidence

All numbers below are from the multiclass Hessian tuning study: 18 public datasets
(3 to 1,000 classes, minimum class prior 1e-5 to 0.34), 12 joint configurations spanning
`eta` 0.05–0.30, depth 3–8, `reg_lambda` 0–100, `min_child_weight` 0–100, validation-only
successive halving with per-method configuration and iteration selection, exact
class-prior intercept, `multi_strategy = multi_output_tree`, full row/column sampling.
Test data has not been read; all comparisons are on the validation split at the converge
stage.

### Held-out (validation) log loss after per-method tuning, ratio to shipped $2p(1-p)$

| rule | geomean | wins / 18 |
|---|---:|---:|
| $0.51\,\max(1, 2p_y)\,\lvert p - y \rvert$ (empirical, no certificate) | 0.945 | 14 |
| **$\lvert p - y \rvert$ (this PR)** | **0.955** | **12** |
| $\max\bigl(p(1-p),\ \lvert p - y \rvert / 8\bigr)$ (tail floor) | 1.023 | 11 |
| $p(1-p) + \lvert g \rvert \max(2\lvert g \rvert - 1, 0)/8$ | 1.024 | 11 |
| $p(1-p) + g^2/8$ | 1.018 | 13 |
| $\max\bigl(2p(1-p),\ \eta(2y + p)/6\bigr)$ | 1.028 | 10 |
| $(2p + y)/3$ | 1.146 | 4 |

Per dataset ($\lvert p - y \rvert$ / shipped):

| dataset | K | ratio | | dataset | K | ratio |
|---|---:|---:|---|---|---:|---:|
| shuttle | 7 | 0.707 | | connect4 | 3 | 0.991 |
| aloi | 1000 | 0.877 | | vehicle | 4 | 1.002 |
| segment | 7 | 0.886 | | optdigits | 10 | 1.013 |
| pendigits | 10 | 0.912 | | letter | 26 | 1.020 |
| gas_drift | 6 | 0.932 | | texture | 11 | 1.025 |
| poker_hand | 10 | 0.941 | | devnagari | 46 | 1.026 |
| satimage | 6 | 0.968 | | steel_faults | 7 | 1.041 |
| dionis | 355 | 0.971 | | | | |
| sensorless | 11 | 0.973 | | | | |
| isolet | 26 | 0.976 | | | | |
| covertype | 7 | 0.988 | | | | |

The largest gains are on the datasets with the rarest classes (Shuttle, ALOI); the
losses are small (≤ 4%) and on well-balanced datasets.

### Stability across all 216 trials per rule

| rule | trials with a genuine training-loss reversal (> 1e-3) | largest single increase |
|---|---:|---:|
| shipped $2p(1-p)$ | 11 | 2.3e17 |
| $\lvert p - y \rvert$ | **0** | **0.0** |
| tail floor $\max\bigl(p(1-p),\ \lvert p - y \rvert / 8\bigr)$ | 1 | 1.5 |

($\lvert p - y \rvert$ logs float-noise "increases" of magnitude 0.0 at recorded precision;
none are real. The tail-floor reversal is at $\lambda = 0$ on ALOI with margin 5,672.)

### Optimisation speed (training loss, fixed configurations)

Training-loss AUC over the first 8 path units, ratio to $\lvert p - y \rvert$, 216 paired
runs: shipped $2p(1-p)$ has geomean 2.49 (median 0.98) — the mean is dominated by its
divergences — and $\lvert p - y \rvert$ is roughly 1.5× slower early than the fastest
guarded rules while reaching the best late values. Its advantage is late-round and
rare-class; it is not the fastest starter.

### Hyperparameter behaviour

Validation-selected `reg_lambda` for $\lvert p - y \rvert$ is indistinguishable from the
shipped rule's (paired lower/same/higher 5/8/5 at the promote stage). The tuner does not
trade regularisation away; it selects slightly higher `eta` (3/8/7) and lower
`min_child_weight` (6/9/3), the latter partly because Hessian mass changes scale.

## Behaviour changes users will see

1. **All multiclass models train differently.** This is not a floor that leaves ordinary
   training untouched; the curvature changes on every coordinate. Existing training
   scripts will produce different (in the studied cases, usually slightly better)
   models; bit-for-bit reproducibility of old runs is lost. Saved models load and
   predict unchanged.
2. **`min_child_weight` and `reg_lambda` change meaning.** Hessian mass is now
   $\sum \lvert p - y \rvert$ rather than $\sum 2p(1-p)$. In the central region
   $\lvert p - y \rvert \ge p(1-p)$, so a given `min_child_weight` is somewhat less
   restrictive and a given `reg_lambda` somewhat weaker than before. Tuned pipelines may
   want to re-tune these.
3. **$K = 2$ no longer matches `binary:logistic`.** With two-logit softmax,
   $\lvert p - y \rvert$ gives both coordinates $h = 1 - p_y$, whereas `binary:logistic`
   uses $p(1-p)$. (The old $2p(1-p)$ was the compensation that made two per-class trees
   match one binary tree.) Binary problems should use `binary:logistic`, as the docs
   already recommend.
4. **Early-round convergence is slower** on many datasets; late convergence and
   stability are better. Users running very few rounds at small `eta` may see higher
   training loss at a fixed round count.

## Default-path check (`one_output_per_tree`)

The tuning study used vector leaves. This check uses the default strategy on 15 of the
datasets (the three dense image sets excluded on cost), XGBoost defaults otherwise
(depth 6, `reg_lambda = 1`, `min_child_weight = 1`), `eta` in {0.1, 0.3} selected per
method on validation with early stopping, test read once at the validation-best
iteration. Shipped native `multi:softprob` vs the exact $\lvert p - y \rvert$ rule.

Test log loss, $\lvert p - y \rvert$ / shipped:

| dataset | K | ratio | | dataset | K | ratio |
|---|---:|---:|---|---|---:|---:|
| satimage | 6 | 0.841 | | optdigits | 10 | 0.990 |
| poker_hand | 10 | 0.846 | | segment | 7 | 0.995 |
| covertype | 7 | 0.879 | | texture | 11 | 0.996 |
| shuttle | 7 | 0.908 | | isolet | 26 | 1.013 |
| gas_drift | 6 | 0.918 | | letter | 26 | 1.019 |
| vehicle | 4 | 0.957 | | pendigits | 10 | 1.020 |
| connect4 | 3 | 0.980 | | sensorless | 11 | 1.041 |
| steel_faults | 7 | 0.982 | | | | |

Geometric mean **0.957**, median 0.982, **11 of 15** lower. Paired at the same `eta`:
0.952 (11/15) at `eta = 0.1`, 0.855 (9/15) at `eta = 0.3`. Test error: 8/15 lower,
within noise elsewhere. Zero training-loss increases for either rule at $\lambda = 1$.
The default path therefore reproduces the vector-leaf result (0.955, 12/18) almost
exactly.

## Verification on this branch

- C++: all 54 tests in the `Objective` suites pass
  (`testxgboost --gtest_filter='Objective*:*Objective/*'`), including the updated
  `SoftmaxMultiClassObjGPair` expectations.
- The built library reproduces a numpy implementation of $\lvert p - y \rvert$ (with row
  weights) to a max margin difference of 7e-7 over 30 rounds, and differs from a numpy
  $2p(1-p)$ implementation by 3.05, i.e. the kernel does what the study measured.
- `demo/guide-python/custom_softmax.py` runs and its `predt_custom == predt_native`
  assertion holds with the updated demo formula.
- Python: `tests/python/test_basic_models.py` and `tests/python/test_demos.py` subsets
  selected on multiclass/softmax pass (4 tests).
- CUDA kernel: compiled with nvcc 12.9 for sm_120 and tested; `GPUSoftmaxMultiClassObjGPair`,
  `GPUSoftmaxMultiClassBasic` and `GPUSoftprobMultiClassBasic` pass against the same
  updated Hessian expectations as the CPU tests. End to end with the tree builder held
  fixed on GPU (`device=cuda`, 20 rounds, weighted rows), the native CUDA kernel matches a
  numpy $\lvert p - y \rvert$ custom objective to 4.8e-7 in margin and differs from a numpy
  $2p(1-p)$ objective by 3.05.

## Files changed

- `src/objective/multiclass_obj.cc`, `src/objective/multiclass_obj.cu` — the Hessian
  line in each kernel.
- `tests/cpp/objective/test_multiclass_obj.cc` — expected Hessians
  `{0.24, 0.91, 0.67, 0.33, 0.09, 0.24}` (= $\lvert \text{grad} \rvert$), replacing
  `{0.36, 0.16, 0.44, 0.45, 0.16, 0.37}`.
- `demo/guide-python/custom_softmax.py` — the demo reimplements the native objective
  and asserts equality with it; updated to the new rule.
- `doc/tutorials/custom_metric_obj.rst` — same formula in the tutorial snippet.
- `R-package/tests/testthat/test_custom_objective.R` — the R test likewise reimplements the
  native objective and asserts equal predictions; updated to the new rule.
- `python-package/xgboost/testing/__init__.py` — `softprob_obj`, the testing-module
  reimplementation compared against native at rtol 1e-4 in the sklearn tests: new rule, the
  kernel's 1e-16 Hessian floor, and a max-subtracting softmax. With `|p - y|` the per-class
  Hessian sums sit close to `min_child_weight = 1` on small data, so the reimplementation
  has to match native arithmetic closely for the parity test to hold.

## Reproducibility

The tuning study, pilot, default-path check and the numpy reference implementations used
for verification are in an internal research repository; scripts and per-trial results can
be attached on request. Test-split numbers from the study's one-time test evaluation will
be added when it completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
