### PR TITLE
Use bounded-step curvature for Tweedie objectives

### DIFF
--- a/src/objective/gamma_obj.cc
+++ b/src/objective/gamma_obj.cc
@@ -47,7 +47,7 @@ class GammaRegression : public FitInterceptGlmLike {
       auto valid =
           common::DispatchKernel<GammaValidationKernel>(ctx_, info.labels, GammaLabelCheck{});
       if (!valid) {
-        LOG(FATAL) << GammaDeviance::LabelErrorMsg();
+        LOG(FATAL) << "label must be positive for gamma regression.";
       }
       if (!info.weights_.Empty()) {
         CHECK_EQ(info.weights_.Size(), info.num_row_)
@@ -73,8 +73,8 @@ class GammaRegression : public FitInterceptGlmLike {
   void ProbToMargin(linalg::Vector<float>* base_score) const override {
     auto intercept = base_score->HostView();
     auto valid = std::all_of(linalg::cbegin(intercept), linalg::cend(intercept),
-                             [](float value) { return GammaDeviance::CheckIntercept(value); });
-    CHECK(valid) << GammaDeviance::InterceptErrorMsg();
+                             [](float value) { return value > 0.0f; });
+    CHECK(valid) << "`base_score` must be greater than 0 for gamma regression";
     common::DispatchKernel<GammaProbToMarginKernel>(ctx_, base_score->Data(), GammaProbToMargin{});
   }
 
@@ -82,7 +82,7 @@ class GammaRegression : public FitInterceptGlmLike {
 
   void SaveConfig(Json* p_out) const override {
     auto& out = *p_out;
-    out["name"] = String(GammaDeviance::Name());
+    out["name"] = String{"reg:gamma"};
     out["reg_loss_param"] = ToJson(param_);
   }
 
@@ -98,7 +98,7 @@ class GammaRegression : public FitInterceptGlmLike {
   RegLossParam param_;
 };
 
-XGBOOST_REGISTER_OBJECTIVE(GammaRegression, GammaDeviance::Name())
+XGBOOST_REGISTER_OBJECTIVE(GammaRegression, "reg:gamma")
     .describe("Gamma regression using the gamma deviance loss with log link.")
     .set_body([]() { return new GammaRegression(); });
 }  // namespace xgboost::obj

--- a/src/objective/gamma_obj.h
+++ b/src/objective/gamma_obj.h
@@ -10,26 +10,8 @@
 
 #include "elementwise_objective.h"  // for elementwise kernels
 #include "xgboost/base.h"           // for GradientPair
-#include "xgboost/string_view.h"    // for StringView
 
 namespace xgboost::obj {
-class GammaDeviance {
- public:
-  constexpr static StringView InterceptErrorMsg() {
-    return "`base_score` must be greater than 0 for gamma regression";
-  }
-  XGBOOST_DEVICE static bool CheckIntercept(float base_score) { return base_score > 0; }
-  XGBOOST_DEVICE static float FirstOrderGradient(float predt, float label) {
-    return 1.0f - label / predt;
-  }
-  XGBOOST_DEVICE static float SecondOrderGradient(float predt, float label) {
-    return label / predt;
-  }
-  static char const* Name() { return "reg:gamma"; }
-  XGBOOST_DEVICE static bool CheckLabel(float label) { return label > 0.0f; }
-  static char const* LabelErrorMsg() { return "label must be positive for gamma regression."; }
-};
-
 struct GammaGradient {
   float scale_pos_weight;
 
@@ -38,8 +20,12 @@ struct GammaGradient {
       weight *= scale_pos_weight;
     }
     auto prediction = expf(predt);
-    auto grad = GammaDeviance::FirstOrderGradient(prediction, label);
-    auto hess = GammaDeviance::SecondOrderGradient(prediction, label);
+    auto ratio = label / prediction;
+    auto grad = 1.0f - ratio;
+    // This is the rho=2 endpoint of the bounded-step Tweedie curvature. It retains
+    // the exact gradient while matching the exact optimized leaf gain through cubic
+    // order with an affine, row-additive curvature.
+    auto hess = (2.0f * ratio + 1.0f) / 3.0f;
     return {grad * weight, hess * weight};
   }
 };
@@ -51,7 +37,7 @@ struct GammaProbToMargin {
   XGBOOST_DEVICE float operator()(float value) const { return std::log(value); }
 };
 struct GammaLabelCheck {
-  XGBOOST_DEVICE bool operator()(float value) const { return GammaDeviance::CheckLabel(value); }
+  XGBOOST_DEVICE bool operator()(float value) const { return value > 0.0f; }
 };
 
 using GammaGradientKernel = elementwise::GradientKernel<GammaGradient>;

--- a/src/objective/gamma_obj.h
+++ b/src/objective/gamma_obj.h
@@ -22,9 +22,27 @@ struct GammaGradient {
     auto prediction = expf(predt);
     auto ratio = label / prediction;
     auto grad = 1.0f - ratio;
-    // This is the rho=2 endpoint of the bounded-step Tweedie curvature. It retains
-    // the exact gradient while matching the exact optimized leaf gain through cubic
-    // order with an affine, row-additive curvature.
+    // For Gamma loss, the exact gradient is 1 - y/mu and the exact Hessian is y/mu.
+    // Let A = sum(w_i * y_i/mu_i) and W = sum(w_i) in a leaf. The Newton update
+    // (A - W) / A tends to -infinity as A tends to zero.
+    //
+    // The third derivative is -y/mu, so after a margin update d the Hessian becomes
+    // (y/mu) * exp(-d). A large negative Newton update can therefore leave the region
+    // where its local quadratic approximation is accurate.
+    //
+    // Instead, consider XGBoost's leaf update d = -G/H and quadratic gain
+    // q = G^2/(2H). The exact leaf loss is L(d) = A * exp(-d) + W * d, with optimum
+    // d* = log(A/W). Matching q to the oracle reduction through cubic order near
+    // A = W gives H = (2A + W)/3, implemented row-wise by
+    // h = (2 * y/mu + 1)/3. The resulting step
+    //
+    //   d = 3 * (A - W) / (2 * A + W)
+    //
+    // lies between -3 and 3/2. It also satisfies
+    //
+    //   q <= L(0) - L(d) <= L(0) - L(d*),
+    //
+    // so the quadratic gain is a conservative estimate of the realized reduction.
     auto hess = (2.0f * ratio + 1.0f) / 3.0f;
     return {grad * weight, hess * weight};
   }

--- a/src/objective/poisson_obj.h
+++ b/src/objective/poisson_obj.h
@@ -17,14 +17,12 @@ struct PoissonGradient {
   XGBOOST_DEVICE GradientPair operator()(float predt, float label, float weight) const {
     auto mu = expf(predt);
     auto grad = (mu - label) * weight;
-    // For one leaf, let M = sum(w_i * mu_i) and Y = sum(w_i * y_i). The score after
-    // adding leaf value d is f(d) = M * exp(d) - Y. At d = 0, f = M - Y and
-    // f' = f'' = M, so Halley's root update is
-    //   d = -2 * f * f' / (2 * f'^2 - f * f'') = 2 * (Y - M) / (Y + M).
-    // Using the positive pseudo-Hessian h_i = w_i * (mu_i + y_i) / 2 makes the
-    // unregularized leaf calculation -sum(g_i) / sum(h_i) produce this update. For M, Y > 0,
-    // it is also 2 * tanh(log(Y / M) / 2), so it moves toward the exact optimum without crossing.
-    auto hess = 0.5f * (mu + label) * weight;
+    // This is the rho=1 endpoint of the bounded-step Tweedie curvature. For a leaf,
+    // M = sum(w_i * mu_i) and Y = sum(w_i * y_i). Among affine, row-additive
+    // curvatures c*Y + (1-c)*M, matching the exact optimized leaf gain through cubic
+    // order gives c=1/3. The resulting quadratic node and split gains lower-bound the
+    // realized unregularized full-step loss reduction.
+    auto hess = (2.0f * mu + label) * weight / 3.0f;
     return {grad, hess};
   }
 };

--- a/src/objective/poisson_obj.h
+++ b/src/objective/poisson_obj.h
@@ -17,11 +17,27 @@ struct PoissonGradient {
   XGBOOST_DEVICE GradientPair operator()(float predt, float label, float weight) const {
     auto mu = expf(predt);
     auto grad = (mu - label) * weight;
-    // This is the rho=1 endpoint of the bounded-step Tweedie curvature. For a leaf,
-    // M = sum(w_i * mu_i) and Y = sum(w_i * y_i). Among affine, row-additive
-    // curvatures c*Y + (1-c)*M, matching the exact optimized leaf gain through cubic
-    // order gives c=1/3. The resulting quadratic node and split gains lower-bound the
-    // realized unregularized full-step loss reduction.
+    // For Poisson loss, the exact gradient is mu - y and the exact Hessian is mu.
+    // Let M = sum(w_i * mu_i) and Y = sum(w_i * y_i) in a leaf. The Newton update
+    // (Y - M) / M tends to +infinity as M tends to zero with Y > 0.
+    //
+    // The third derivative is also mu, so after a margin update d the Hessian becomes
+    // mu * exp(d). A large Newton update can therefore leave the region where its
+    // local quadratic approximation is accurate.
+    //
+    // Instead, consider XGBoost's leaf update d = -G/H and quadratic gain
+    // q = G^2/(2H). The exact leaf loss is L(d) = M * exp(d) - Y * d, with optimum
+    // d* = log(Y/M). Matching q to the oracle reduction L(0) - L(d*) through cubic
+    // order near M = Y gives H = (2M + Y)/3, implemented row-wise by
+    // h = (2 * mu + y)/3. The resulting step
+    //
+    //   d = 3 * (Y - M) / (2 * M + Y)
+    //
+    // is bounded to [-3/2, 3). It also satisfies
+    //
+    //   q <= L(0) - L(d) <= L(0) - L(d*),
+    //
+    // so the quadratic gain is a conservative estimate of the realized reduction.
     auto hess = (2.0f * mu + label) * weight / 3.0f;
     return {grad, hess};
   }

--- a/src/objective/tweedie_obj.h
+++ b/src/objective/tweedie_obj.h
@@ -27,10 +27,16 @@ struct TweedieRegressionParam : public XGBoostParameter<TweedieRegressionParam> 
 struct TweedieGradient {
   float rho;
   XGBOOST_DEVICE GradientPair operator()(float predt, float label, float weight) const {
-    auto grad = -label * expf((1 - rho) * predt) + expf((2 - rho) * predt);
-    auto hess =
-        -label * (1 - rho) * std::exp((1 - rho) * predt) + (2 - rho) * expf((2 - rho) * predt);
-    return {grad * weight, hess * weight};
+    auto a = label * expf((1.0f - rho) * predt);
+    auto b = expf((2.0f - rho) * predt);
+    auto grad = (b - a) * weight;
+    // For one leaf, let A = sum(w_i * a_i) and B = sum(w_i * b_i). Among the affine,
+    // row-additive curvatures c*A + (1-c)*B, matching the exact optimized leaf gain
+    // through cubic order uniquely gives c = rho/3. The resulting unregularized leaf
+    // step is bounded and its quadratic node and split gains lower-bound the realized
+    // full-step loss reduction.
+    auto hess = (rho * a + (3.0f - rho) * b) * weight / 3.0f;
+    return {grad, hess};
   }
 };
 

--- a/src/objective/tweedie_obj.h
+++ b/src/objective/tweedie_obj.h
@@ -30,11 +30,33 @@ struct TweedieGradient {
     auto a = label * expf((1.0f - rho) * predt);
     auto b = expf((2.0f - rho) * predt);
     auto grad = (b - a) * weight;
-    // For one leaf, let A = sum(w_i * a_i) and B = sum(w_i * b_i). Among the affine,
-    // row-additive curvatures c*A + (1-c)*B, matching the exact optimized leaf gain
-    // through cubic order uniquely gives c = rho/3. The resulting unregularized leaf
-    // step is bounded and its quadratic node and split gains lower-bound the realized
-    // full-step loss reduction.
+    // For Tweedie loss, the exact gradient is b - a and the exact Hessian is
+    // (rho - 1) * a + (2 - rho) * b. Let A = sum(w_i * a_i) and
+    // B = sum(w_i * b_i) in a leaf. Its Newton update is
+    //
+    //   d = (A - B) / ((rho - 1) * A + (2 - rho) * B).
+    //
+    // The third derivative is -(rho - 1)^2 * a + (2 - rho)^2 * b. Since both terms
+    // vary exponentially with the margin, a large Newton update can leave the region
+    // where its local quadratic approximation is accurate.
+    //
+    // Instead, consider XGBoost's leaf update d = -G/H and quadratic gain
+    // q = G^2/(2H). For 1 < rho < 2, the exact leaf loss is
+    //
+    //   L(d) = A * exp((1 - rho) * d) / (rho - 1)
+    //        + B * exp((2 - rho) * d) / (2 - rho),
+    //
+    // with optimum d* = log(A/B). Matching q to the oracle reduction through cubic
+    // order near A = B gives H = (rho * A + (3 - rho) * B)/3, implemented row-wise
+    // below. The resulting step
+    //
+    //   d = 3 * (A - B) / (rho * A + (3 - rho) * B)
+    //
+    // lies between -3/(3 - rho) and 3/rho. It also satisfies
+    //
+    //   q <= L(0) - L(d) <= L(0) - L(d*),
+    //
+    // so the quadratic gain is a conservative estimate of the realized reduction.
     auto hess = (rho * a + (3.0f - rho) * b) * weight / 3.0f;
     return {grad, hess};
   }

--- a/tests/cpp/objective/test_regression_obj.cc
+++ b/tests/cpp/objective/test_regression_obj.cc
@@ -153,13 +153,13 @@ void TestPoissonRegressionGPair(const Context* ctx) {
                    {   0,     0,     0,    0,    1,     2,     3,    4},
                    {   1,     1,     1,    1,    1,     1,     1,    1},
                    { .14f,  .37f,     1, 2.71f, -.86f, -1.63f,    -2, -1.28f},
-                   {.068f, .184f,   .5f, 1.359f, .568f, 1.184f,     2, 3.359f});
+                   { .09f, .245f, .667f, 1.812f, .424f,  .912f, 1.667f, 3.146f});
   CheckObjFunction(obj,
                    {  -2,    -1,     0,    1,   -2,    -1,     0,    1},
                    {   0,     0,     0,    0,    1,     2,     3,    4},
                    {},  // Empty weight
                    { .14f,  .37f,     1, 2.71f, -.86f, -1.63f,    -2, -1.28f},
-                   {.068f, .184f,   .5f, 1.359f, .568f, 1.184f,     2, 3.359f});
+                   { .09f, .245f, .667f, 1.812f, .424f,  .912f, 1.667f, 3.146f});
   // clang-format on
 }
 
@@ -208,13 +208,13 @@ void TestGammaRegressionGPair(const Context* ctx) {
                    {2,   2,   2,   2, 1,    1,    1,    1},
                    {1,   1,   1,   1, 1,    1,    1,    1},
                    {-1,  -0.809, 0.187, 0.264, 0, 0.09f, 0.59f, 0.63f},
-                   {2,   1.809,  0.813, 0.735, 1, 0.90f, 0.40f, 0.36f});
+                   {1.667f, 1.540f, .875f, .824f, 1, .937f, .604f, .579f});
   CheckObjFunction(obj,
                    {0, 0.1f, 0.9f, 1, 0,  0.1f,  0.9f,    1},
                    {2,   2,   2,   2, 1,    1,    1,    1},
                    {},  // Empty weight
                    {-1,  -0.809, 0.187, 0.264, 0, 0.09f, 0.59f, 0.63f},
-                   {2,   1.809,  0.813, 0.735, 1, 0.90f, 0.40f, 0.36f});
+                   {1.667f, 1.540f, .875f, .824f, 1, .937f, .604f, .579f});
   // clang-format on
 }
 
@@ -258,15 +258,26 @@ void TestTweedieRegressionGPair(const Context* ctx) {
                    {   0,    0,    0,    0, 1,    1,    1,    1},
                    {   1,    1,    1,    1, 1,    1,    1,    1},
                    {   1, 1.09f, 2.24f, 2.45f, 0, 0.10f, 1.33f, 1.55f},
-                   {0.89f, 0.98f, 2.02f, 2.21f, 1, 1.08f, 2.11f, 2.30f});
+                   {.633f, .693f, 1.424f, 1.558f, 1, 1.056f, 1.759f, 1.890f});
   CheckObjFunction(obj,
                    {   0,  0.1f,  0.9f,    1, 0,  0.1f,  0.9f,    1},
                    {   0,    0,    0,    0, 1,    1,    1,    1},
                    {},  // Empty weight.
                    {   1, 1.09f, 2.24f, 2.45f, 0, 0.10f, 1.33f, 1.55f},
-                   {0.89f, 0.98f, 2.02f, 2.21f, 1, 1.08f, 2.11f, 2.30f});
+                   {.633f, .693f, 1.424f, 1.558f, 1, 1.056f, 1.759f, 1.890f});
   // clang-format on
   ASSERT_EQ(obj->DefaultEvalMetric(), std::string{"tweedie-nloglik@1.1"});
+
+  std::unique_ptr<ObjFunction> poisson_endpoint{ObjFunction::Create("reg:tweedie", ctx)};
+  poisson_endpoint->Configure({{"tweedie_variance_power", "1"}});
+  // clang-format off
+  CheckObjFunction(poisson_endpoint,
+                   {  -2,    -1,     0,    1,   -2,    -1,     0,    1},
+                   {   0,     0,     0,    0,    1,     2,     3,    4},
+                   {   1,     1,     1,    1,    1,     1,     1,    1},
+                   { .14f,  .37f,     1, 2.71f, -.86f, -1.63f,    -2, -1.28f},
+                   { .09f, .245f, .667f, 1.812f, .424f,  .912f, 1.667f, 3.146f});
+  // clang-format on
 }
 
 void TestTweedieRegressionBasic(const Context* ctx) {


### PR DESCRIPTION
## Motivation

The Poisson, compound Poisson-Gamma Tweedie, and Gamma objectives form one continuous power-variance family under the log-mean parameterization.

The Taylor Hessian can produce very large leaf updates when its local curvature is small. The bounded Halley curvature added to Poisson in #12431 fixes the leaf-update instability, but its ordinary `G^2/H` score can still overestimate the loss reduction used to justify a split.

This PR uses a bounded-step pseudo-Hessian across the complete Poisson-Tweedie-Gamma segment. It retains the exact gradient and does not change the tree builder, leaf formula, split-gain formula, or public parameters.

## Proposed curvature

Let

```
mu_i = exp(f_i)
A_i = w_i * y_i * mu_i^(1-p)
B_i = w_i * mu_i^(2-p)
```

The exact gradient and proposed curvature are

```
g_i = B_i - A_i
h_i = (p*A_i + (3-p)*B_i) / 3
```

The endpoints are:

| Objective | Power | Curvature |
|---|---:|---|
| `count:poisson` | 1 | `w * (y + 2*mu) / 3` |
| `reg:tweedie` | 1 <= p < 2 | `w * (p*y*mu^(1-p) + (3-p)*mu^(2-p)) / 3` |
| `reg:gamma` | 2 | `w * (2*y/mu + 1) / 3` |

At `p=1.5`, this is exactly the existing Taylor Hessian.

## Derivation and guarantees

For one leaf, put `A=sum(A_i)`, `B=sum(B_i)`, and `R=A/B`. The exact constant-leaf optimum is `log(R)`. For an affine row-additive curvature `H_c=c*A+(1-c)*B`, the quadratic reduction in loss units is

```
q_c / B = (R-1)^2 / (2 * (1 + c*(R-1))).
```

Calibrating this expression to the exact optimized leaf-loss reduction through cubic order uniquely gives `c=p/3` and the curvature above.

For nonnegative labels and weights, `1 <= p <= 2`, and the unregularized full-step problem:

- the induced leaf update satisfies `abs(d) <= 3`;
- a full step decreases the exact leaf loss, as does any shrinkage `0 < eta <= 1`;
- the quadratic node score lower-bounds both the reduction realized by its own update and the exact optimized reduction; and
- these lower bounds are preserved by the child-minus-parent split calculation.

The last property is important for XGBoost: the curvature controls both the leaf update `-G/H` and split score `G^2/H`. This is an optimized-score guarantee, not a claim that the quadratic is a pointwise MM majorizer.

## Previous synthetic results

A paired stress study evaluated powers `{1, 1.1, 1.5, 1.9, 2}`, four signal/initialization conditions, and 30 datasets per condition. Each method trained 50 depth-three histogram trees with `eta=1`, `min_child_weight=0`, and all regularization disabled.

The values below are median round-50 mean unit deviance divided by round-zero deviance; lower is better. "Taylor Newton" is a common comparator over the whole family, not the current Poisson implementation from #12431.

| Power | Bounded-step | Taylor Newton | Halley | Bounded-step vs Newton | Increasing rounds: bounded/Newton |
|---:|---:|---:|---:|---:|---:|
| 1.0 | 0.238 | 8.69e24 | 0.236 | 120/120 lower | 0 / 729 |
| 1.1 | 0.244 | 0.280 | 0.241 | 120/120 lower | 0 / 461 |
| 1.5 | 0.313 | 0.313 | 0.313 | 120/120 identical | 0 / 0 |
| 1.9 | 0.454 | 0.540 | 0.457 | 120/120 lower | 0 / 1,891 |
| 2.0 | 0.430 | 1.41e19 | 0.430 | 120/120 lower | 0 / 128 |

Across the 480 off-midpoint datasets, bounded-step curvature finished below Taylor Newton in every paired run. Bounded-step and Halley were close: bounded-step won 291/480 paired endpoints, and their condition-level median endpoints differed by at most about 1.75%.

The large endpoint values are deliberately adversarial unit-step stability results; they should not be interpreted as expected production magnitudes.

A separate Poisson study evaluated 36 candidate partitions for each of 1,000 synthetic parents:

| Method | Exact top-one agreement | Mean oracle-gain regret | Parents optimistic vs exact | Parents optimistic vs own update |
|---|---:|---:|---:|---:|
| Taylor Newton | 79.3% | 2.90% | 54.9% | 58.2% |
| Halley | 75.0% | 4.94% | 25.9% | 47.3% |
| Bounded-step | 78.8% | 3.78% | 0.0% | 0.0% |

Bounded-step curvature therefore retained split ranking close to Newton while eliminating score overstatement in this corpus, consistent with the analytical split certificate.

## Implementation

- Update the Poisson, Tweedie, and Gamma elementwise gradient functors.
- Keep their registrations, validation, metrics, and public interfaces separate.
- Remove the now-unnecessary `GammaDeviance` wrapper.
- Add an explicit `reg:tweedie` power-1 endpoint regression check.
- Update expected gradient-pair values for all three objectives.

## Validation

- `./build/testxgboost --gtest_filter='Objective.*'`: 32/32 passed.
- Unregularized stump checks converged to the aggregate optimum at powers 1, 1.1, 1.5, 1.9, and 2.

## Limitations

The analytical split certificate assumes the unregularized full-step problem. The synthetic study is a mechanism and stability test, not a held-out generalization benchmark or a hyperparameter-tuned comparison.
