### PR TITLE
Handle tuples in param_value_converter

### DIFF
--- a/python-package/xgboost/spark/estimator.py
+++ b/python-package/xgboost/spark/estimator.py
@@ -36,6 +36,8 @@ def _set_pyspark_xgb_cls_param_attrs(
             return {k: param_value_converter(nv) for k, nv in v.items()}
         if isinstance(v, list):
             return [param_value_converter(nv) for nv in v]
+        if isinstance(v, tuple):
+            return tuple(param_value_converter(nv) for nv in v)
         return v
 
     def set_param_attrs(attr_name: str, param: Param) -> None:


### PR DESCRIPTION
param_value_converter recurses into dicts and lists to convert numpy scalars to plain Python types, but not tuples. interaction_constraints is documented as Optional[Union[str, List[Tuple[str]]]], so a value like [(np.str_('f0'), np.str_('f1'))] would pass through with numpy scalars still inside the tuples.

Ran it: a tuple containing np.int64 values fails json.dumps with 'Object of type int64 is not JSON serializable', which is how Spark persists param values on save. Same conversion now applies to tuples as already applies to lists.