### PR TITLE
Zero intercepts for LambdaRank and Cox

### DIFF
--- a/src/objective/lambdarank_obj.cc
+++ b/src/objective/lambdarank_obj.cc
@@ -22,7 +22,6 @@
 #include "../common/optional_weight.h"   // for MakeOptionalWeights, OptionalWeights
 #include "../common/ranking_utils.h"     // for RankingCache, LambdaRankParam, MAPCache, NDCGC...
 #include "../common/threading_utils.h"   // for ParallelFor, Sched
-#include "init_estimation.h"             // for FitIntercept
 #include "xgboost/base.h"                // for bst_group_t, GradientPair, kRtEps, GradientPai...
 #include "xgboost/context.h"             // for Context
 #include "xgboost/data.h"                // for MetaInfo
@@ -96,7 +95,7 @@ void LambdaRankUpdatePositionBias(Context const* ctx, linalg::VectorView<double 
  *   Pairwise Learning-to-Rank Algorithm`.
  */
 template <typename Loss, typename Cache>
-class LambdaRankObj : public FitIntercept {
+class LambdaRankObj : public ObjFunction {
   MetaInfo const* p_info_{nullptr};
 
   // Update position biased for unbiased click data
@@ -250,6 +249,10 @@ class LambdaRankObj : public FitIntercept {
   }
 
  public:
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
+    *base_score = linalg::Zeros<float>(this->ctx_, this->Targets(info));
+  }
+
   std::set<std::string> Configure(Args const& args) override {
     return UpdateAndGetUsedParameters(&param_, args);
   }

--- a/src/objective/regression_obj.cu
+++ b/src/objective/regression_obj.cu
@@ -18,7 +18,6 @@
 #include "../common/threading_utils.h"
 #include "../common/transform.h"
 #include "../common/utils.h"  // for NoOp
-#include "init_estimation.h"  // FitIntercept
 #include "xgboost/base.h"
 #include "xgboost/context.h"  // Context
 #include "xgboost/data.h"     // MetaInfo
@@ -72,10 +71,14 @@ DMLC_REGISTRY_FILE_TAG(regression_obj_gpu);
 #endif  // defined(XGBOOST_USE_CUDA)
 
 // cox regression for survival data (negative values mean they are censored)
-class CoxRegression : public FitIntercept {
+class CoxRegression : public ObjFunction {
  public:
   std::set<std::string> Configure(Args const&) override { return {}; }
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
+    *base_score = linalg::Zeros<float>(this->ctx_, this->Targets(info));
+    this->PredTransform(base_score->Data());
+  }
 
   void GetGradient(const HostDeviceVector<bst_float>& preds, const MetaInfo& info, int,
                    linalg::Matrix<GradientPair>* out_gpair) override {

--- a/tests/cpp/objective/test_lambdarank_obj.cc
+++ b/tests/cpp/objective/test_lambdarank_obj.cc
@@ -25,6 +25,22 @@
 #include "xgboost/span.h"                // for Span
 
 namespace xgboost::obj {
+TEST(LambdaRank, InitEstimation) {
+  Context ctx;
+  std::unique_ptr<ObjFunction> obj{ObjFunction::Create("rank:pairwise", &ctx)};
+  obj->Configure({});
+
+  MetaInfo info;
+  info.num_row_ = 4;
+  info.labels = linalg::Tensor<float, 2>{{3.0f, 0.0f, 1.0f, 2.0f}, {4, 1}, ctx.Device()};
+  info.group_ptr_ = {0, 4};
+
+  linalg::Vector<float> base_score;
+  obj->InitEstimation(info, &base_score);
+  ASSERT_EQ(base_score.Size(), 1);
+  ASSERT_FLOAT_EQ(base_score(0), 0.0f);
+}
+
 TEST(LambdaRank, NDCGJsonIO) {
   Context ctx;
   TestNDCGJsonIO(&ctx);
@@ -37,25 +53,15 @@ void TestNDCGGPair(Context const* ctx) {
     CheckConfigReload(obj, "rank:ndcg");
 
     // No gain in swapping 2 documents.
-    CheckRankingObjFunction(obj,
-                            {1, 1, 1, 1},
-                            {1, 1, 1, 1},
-                            {1.0f, 1.0f},
-                            {0, 2, 4},
-                            {0.0f, -0.0f, 0.0f, 0.0f},
-                            {0.0f, 0.0f, 0.0f, 0.0f});
+    CheckRankingObjFunction(obj, {1, 1, 1, 1}, {1, 1, 1, 1}, {1.0f, 1.0f}, {0, 2, 4},
+                            {0.0f, -0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f, 0.0f});
   }
   {
     std::unique_ptr<xgboost::ObjFunction> obj{xgboost::ObjFunction::Create("rank:ndcg", ctx)};
     obj->Configure(Args{{"lambdarank_pair_method", "topk"}});
     // Test with setting sample weight to second query group
-    CheckRankingObjFunction(obj,
-                            {0, 0.1f, 0, 0.1f},
-                            {0,   1, 0, 1},
-                            {2.0f, 0.0f},
-                            {0, 2, 4},
-                            {2.06611f, -2.06611f, 0.0f, 0.0f},
-                            {2.169331f, 2.169331f, 0.0f, 0.0f});
+    CheckRankingObjFunction(obj, {0, 0.1f, 0, 0.1f}, {0, 1, 0, 1}, {2.0f, 0.0f}, {0, 2, 4},
+                            {2.06611f, -2.06611f, 0.0f, 0.0f}, {2.169331f, 2.169331f, 0.0f, 0.0f});
   }
   {
     std::unique_ptr<xgboost::ObjFunction> obj{xgboost::ObjFunction::Create("rank:ndcg", ctx)};
@@ -63,7 +69,9 @@ void TestNDCGGPair(Context const* ctx) {
     float weight_norm = 0.5;  // n_groups / sum_weights
     std::vector<float> out_grad{2.06611f, -2.06611f, 2.06611f, -2.06611f};
     std::vector<float> out_hess{2.169331f, 2.169331f, 2.169331f, 2.169331f};
-    auto norm = [=](auto v) { return v * weight_norm; };
+    auto norm = [=](auto v) {
+      return v * weight_norm;
+    };
     std::transform(out_grad.begin(), out_grad.end(), out_grad.begin(), norm);
     std::transform(out_hess.begin(), out_hess.end(), out_hess.begin(), norm);
     CheckRankingObjFunction(obj, {0, 0.1f, 0, 0.1f}, {0, 1, 0, 1}, {2.0f, 2.0f}, {0, 2, 4},

--- a/tests/cpp/objective/test_regression_obj.cc
+++ b/tests/cpp/objective/test_regression_obj.cc
@@ -321,6 +321,20 @@ void TestCoxRegressionGPair(const Context* ctx) {
   // clang-format on
 }
 
+void TestCoxRegressionInitEstimation(const Context* ctx) {
+  std::unique_ptr<ObjFunction> obj{ObjFunction::Create("survival:cox", ctx)};
+  obj->Configure({});
+
+  MetaInfo info;
+  info.num_row_ = 4;
+  info.labels = linalg::Tensor<float, 2>{{1.0f, -2.0f, 3.0f, -4.0f}, {4, 1}, ctx->Device()};
+
+  linalg::Vector<float> base_score;
+  obj->InitEstimation(info, &base_score);
+  ASSERT_EQ(base_score.Size(), 1);
+  ASSERT_FLOAT_EQ(base_score(0), 1.0f);
+}
+
 void TestAbsoluteError(const Context* ctx) {
   std::unique_ptr<ObjFunction> obj{ObjFunction::Create("reg:absoluteerror", ctx)};
   obj->Configure({});

--- a/tests/cpp/objective/test_regression_obj.h
+++ b/tests/cpp/objective/test_regression_obj.h
@@ -31,6 +31,8 @@ void TestTweedieRegressionBasic(const Context* ctx);
 
 void TestCoxRegressionGPair(const Context* ctx);
 
+void TestCoxRegressionInitEstimation(const Context* ctx);
+
 void TestAbsoluteError(const Context* ctx);
 
 void TestPseudoHuber(const Context* ctx);

--- a/tests/cpp/objective/test_regression_obj_cpu.cc
+++ b/tests/cpp/objective/test_regression_obj_cpu.cc
@@ -140,6 +140,11 @@ TEST(Objective, CoxRegressionGPair) {
   Context ctx = MakeCUDACtx(GPUIDX);
   TestCoxRegressionGPair(&ctx);
 }
+
+TEST(Objective, CoxRegressionInitEstimation) {
+  Context ctx = MakeCUDACtx(GPUIDX);
+  TestCoxRegressionInitEstimation(&ctx);
+}
 #endif
 
 TEST(Objective, DeclareUnifiedTest(AbsoluteError)) {


### PR DESCRIPTION
These objectives currently calculate an intercept of 0 via a Newton step, which is unnecessary. We can just return zero.