### PR TITLE
Use exact intercepts for hinge and squared log error

### DIFF
--- a/src/objective/hinge.cc
+++ b/src/objective/hinge.cc
@@ -13,8 +13,10 @@
 #include <cstdint>    // for int32_t
 
 #include "../common/kernel.h"   // for DispatchKernel
-#include "init_estimation.h"    // for FitIntercept
+#include "../common/stats.h"    // for SampleMean, WeightedSampleMean
+#include "init_estimation.h"    // for CheckInitInputs
 #include "xgboost/json.h"       // for Json
+#include "xgboost/logging.h"    // for LOG
 #include "xgboost/objective.h"  // for ObjFunction
 
 namespace xgboost::obj {
@@ -23,22 +25,53 @@ DMLC_REGISTRY_FILE_TAG(hinge_obj);
 namespace {
 auto const kRegisterHingeGradientCpu = elementwise::RegisterGradientCpu<HingeLoss>();
 auto const kRegisterHingePredTransformCpu = elementwise::RegisterTransformCpu<HingeLoss>();
+auto const kRegisterHingeValidationCpu = elementwise::RegisterValidationCpu<HingeLabelCheck>();
+
+void CheckHingeLabels(Context const* ctx, MetaInfo const& info) {
+  auto valid = common::DispatchKernel<HingeValidationKernel>(ctx, info.labels, HingeLabelCheck{});
+  if (!valid) {
+    LOG(FATAL) << HingeLoss::LabelErrorMsg();
+  }
+}
 }  // namespace
 
-class HingeObj : public FitIntercept {
+class HingeObj : public ObjFunction {
  public:
   std::set<std::string> Configure(Args const&) override { return {}; }
   ObjInfo Task() const override { return ObjInfo::kRegression; }
+
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
+    CheckInitInputs(info);
+    CheckHingeLabels(ctx_, info);
+    if (info.weights_.Empty()) {
+      common::SampleMean(ctx_, info.labels, base_score);
+    } else {
+      common::WeightedSampleMean(ctx_, info.labels, info.weights_, base_score);
+    }
+    auto intercept = base_score->HostView();
+    for (std::size_t i = 0; i < intercept.Size(); ++i) {
+      if (intercept(i) > 0.5f) {
+        intercept(i) = 1.0f;
+      } else if (intercept(i) < 0.5f) {
+        intercept(i) = -1.0f;
+      } else {
+        intercept(i) = 0.0f;
+      }
+    }
+  }
 
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
     // Multi-target regression.
     return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
   }
 
-  void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info,
-                   std::int32_t /*iter*/, linalg::Matrix<GradientPair>* out_gpair) override {
+  void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info, std::int32_t iter,
+                   linalg::Matrix<GradientPair>* out_gpair) override {
     CheckInitInputs(info);
     CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
+    if (iter == 0) {
+      CheckHingeLabels(ctx_, info);
+    }
 
     common::DispatchKernel<HingeGradientKernel>(ctx_, preds, info, this->Targets(info), HingeLoss{},
                                                 out_gpair);
@@ -58,6 +91,6 @@ class HingeObj : public FitIntercept {
 };
 
 XGBOOST_REGISTER_OBJECTIVE(HingeObj, "binary:hinge")
-    .describe("Hinge loss. Expects labels to be in [0,1f]")
+    .describe("Hinge loss. Expects labels to be either 0 or 1")
     .set_body([]() { return new HingeObj(); });
 }  // namespace xgboost::obj

--- a/src/objective/hinge.cu
+++ b/src/objective/hinge.cu
@@ -15,5 +15,6 @@ DMLC_REGISTRY_FILE_TAG(hinge_kernel_cuda);
 namespace {
 auto const kRegisterHingeGradientCuda = elementwise::RegisterGradientCuda<HingeLoss>();
 auto const kRegisterHingePredTransformCuda = elementwise::RegisterTransformCuda<HingeLoss>();
+auto const kRegisterHingeValidationCuda = elementwise::RegisterValidationCuda<HingeLabelCheck>();
 }  // namespace
 }  // namespace xgboost::obj

--- a/src/objective/hinge.h
+++ b/src/objective/hinge.h
@@ -22,10 +22,17 @@ struct HingeLoss {
   }
 
   XGBOOST_DEVICE float operator()(float margin) const { return margin > 0.0f ? 1.0f : 0.0f; }
+
+  static char const* LabelErrorMsg() { return "label must be either 0 or 1 for hinge loss."; }
+};
+
+struct HingeLabelCheck {
+  XGBOOST_DEVICE bool operator()(float label) const { return label == 0.0f || label == 1.0f; }
 };
 
 using HingeGradientKernel = elementwise::GradientKernel<HingeLoss>;
 using HingePredTransformKernel = elementwise::TransformKernel<HingeLoss>;
+using HingeValidationKernel = elementwise::ValidationKernel<HingeLabelCheck>;
 
 }  // namespace xgboost::obj
 

--- a/src/objective/squared_log_obj.cc
+++ b/src/objective/squared_log_obj.cc
@@ -10,9 +10,11 @@
 #include <algorithm>  // for max
 #include <cstddef>    // for size_t
 #include <cstdint>    // for int32_t
+#include <limits>     // for numeric_limits
 
 #include "../common/kernel.h"   // for DispatchKernel
-#include "init_estimation.h"    // for CheckInitInputs, FitIntercept
+#include "../common/stats.h"    // for SampleMean, WeightedSampleMean
+#include "init_estimation.h"    // for CheckInitInputs
 #include "xgboost/json.h"       // for Json, String
 #include "xgboost/logging.h"    // for CHECK, LOG
 #include "xgboost/objective.h"  // for ObjFunction
@@ -21,17 +23,47 @@ namespace xgboost::obj {
 DMLC_REGISTRY_FILE_TAG(squared_log_obj);
 
 namespace {
+auto const kRegisterSquaredLogLabelTransformCpu =
+    elementwise::RegisterTransformCpu<SquaredLogLabelTransform>();
 auto const kRegisterSquaredLogGradientCpu = elementwise::RegisterGradientCpu<SquaredLogGradient>();
 auto const kRegisterSquaredLogValidationCpu =
     elementwise::RegisterValidationCpu<SquaredLogLabelCheck>();
 }  // namespace
 
-class SquaredLogErrorRegression : public FitIntercept {
+class SquaredLogErrorRegression : public ObjFunction {
  public:
   std::set<std::string> Configure(Args const&) override { return {}; }
   [[nodiscard]] ObjInfo Task() const override { return ObjInfo::kRegression; }
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
     return std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
+  }
+
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
+    CheckInitInputs(info);
+    auto valid = common::DispatchKernel<SquaredLogValidationKernel>(ctx_, info.labels,
+                                                                    SquaredLogLabelCheck{});
+    if (!valid) {
+      LOG(FATAL) << SquaredLogError::LabelErrorMsg();
+    }
+
+    linalg::Matrix<float> transformed_labels;
+    transformed_labels.SetDevice(ctx_->Device());
+    transformed_labels.Reshape(info.labels.Shape());
+    transformed_labels.Data()->Copy(*info.labels.Data());
+    common::DispatchKernel<SquaredLogLabelTransformKernel>(ctx_, transformed_labels.Data(),
+                                                           SquaredLogLabelTransform{});
+
+    if (info.weights_.Empty()) {
+      common::SampleMean(ctx_, transformed_labels, base_score);
+    } else {
+      common::WeightedSampleMean(ctx_, transformed_labels, info.weights_, base_score);
+    }
+    auto intercept = base_score->HostView();
+    auto max = static_cast<double>(std::numeric_limits<float>::max());
+    for (std::size_t i = 0; i < intercept.Size(); ++i) {
+      intercept(i) =
+          static_cast<float>(std::min(std::expm1(static_cast<double>(intercept(i))), max));
+    }
   }
 
   void GetGradient(HostDeviceVector<float> const& preds, MetaInfo const& info, std::int32_t iter,

--- a/src/objective/squared_log_obj.cu
+++ b/src/objective/squared_log_obj.cu
@@ -11,6 +11,8 @@
 namespace xgboost::obj {
 DMLC_REGISTRY_FILE_TAG(squared_log_kernel_cuda);
 namespace {
+auto const kRegisterSquaredLogLabelTransformCuda =
+    elementwise::RegisterTransformCuda<SquaredLogLabelTransform>();
 auto const kRegisterSquaredLogGradientCuda =
     elementwise::RegisterGradientCuda<SquaredLogGradient>();
 auto const kRegisterSquaredLogValidationCuda =

--- a/src/objective/squared_log_obj.h
+++ b/src/objective/squared_log_obj.h
@@ -41,6 +41,12 @@ struct SquaredLogLabelCheck {
   XGBOOST_DEVICE bool operator()(float value) const { return SquaredLogError::CheckLabel(value); }
 };
 
+struct SquaredLogLabelTransform {
+  XGBOOST_DEVICE float operator()(float value) const { return std::log1p(value); }
+};
+
+using SquaredLogLabelTransformKernel = elementwise::TransformKernel<SquaredLogLabelTransform>;
+
 using SquaredLogGradientKernel = elementwise::GradientKernel<SquaredLogGradient>;
 using SquaredLogValidationKernel = elementwise::ValidationKernel<SquaredLogLabelCheck>;
 }  // namespace xgboost::obj

--- a/tests/cpp/objective/test_hinge.cc
+++ b/tests/cpp/objective/test_hinge.cc
@@ -15,6 +15,8 @@ namespace xgboost {
 void TestHingeObj(const Context* ctx) {
   std::unique_ptr<ObjFunction> obj{ObjFunction::Create("binary:hinge", ctx)};
 
+  EXPECT_ANY_THROW(CheckObjFunction(obj, {0.0f}, {0.5f}, {}, {0.0f}, {1.0f}));
+
   float eps = std::numeric_limits<xgboost::bst_float>::min();
   std::vector<float> predt{-1.0f, -0.5f, 0.5f, 1.0f, -1.0f, -0.5f, 0.5f, 1.0f};
   std::vector<float> label{0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f};
@@ -29,6 +31,30 @@ void TestHingeObj(const Context* ctx) {
   ASSERT_EQ(transformed.ConstHostVector(), std::vector<float>({0.0f, 0.0f, 1.0f}));
 
   ASSERT_EQ(obj->DefaultEvalMetric(), StringView{"error"});
+
+  MetaInfo init_info;
+  init_info.num_row_ = 4;
+  init_info.labels = linalg::Tensor<float, 2>{
+      {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f},
+      {4, 3},
+      ctx->Device()};
+  linalg::Vector<float> base_score;
+  MetaInfo invalid_info;
+  invalid_info.num_row_ = 1;
+  invalid_info.labels = linalg::Tensor<float, 2>{{0.5f}, {1, 1}, ctx->Device()};
+  EXPECT_ANY_THROW(obj->InitEstimation(invalid_info, &base_score));
+
+  obj->InitEstimation(init_info, &base_score);
+  ASSERT_EQ(base_score.Size(), 3);
+  ASSERT_EQ(base_score(0), -1.0f);
+  ASSERT_EQ(base_score(1), 0.0f);
+  ASSERT_EQ(base_score(2), 1.0f);
+
+  init_info.weights_ = HostDeviceVector<float>{{1.0f, 1.0f, 1.0f, 4.0f}, ctx->Device()};
+  obj->InitEstimation(init_info, &base_score);
+  ASSERT_EQ(base_score(0), 1.0f);
+  ASSERT_EQ(base_score(1), 1.0f);
+  ASSERT_EQ(base_score(2), 1.0f);
 
   MetaInfo info;
   info.num_row_ = label.size();

--- a/tests/cpp/objective/test_regression_obj.cc
+++ b/tests/cpp/objective/test_regression_obj.cc
@@ -10,6 +10,7 @@
 #include <xgboost/tree_model.h>  // for RegTree
 
 #include <cmath>    // for hypot, sqrt
+#include <limits>   // for numeric_limits
 #include <memory>   // for unique_ptr
 #include <utility>  // for pair
 
@@ -80,6 +81,28 @@ void TestSquaredLog(const Context* ctx) {
                    { 1.3205f,  1.0492f,  0.69215f,  0.34115f, 0.1091f});
   // clang-format on
   ASSERT_EQ(obj->DefaultEvalMetric(), std::string{"rmsle"});
+
+  MetaInfo info;
+  info.num_row_ = 3;
+  info.labels =
+      linalg::Tensor<float, 2>{{0.0f, 3.0f, 3.0f, 3.0f, 15.0f, 3.0f}, {3, 2}, ctx->Device()};
+  linalg::Vector<float> base_score;
+  obj->InitEstimation(info, &base_score);
+  ASSERT_EQ(base_score.Size(), 2);
+  ASSERT_NEAR(base_score(0), 3.0f, kRtEps);
+  ASSERT_NEAR(base_score(1), 3.0f, kRtEps);
+
+  info.weights_ = HostDeviceVector<float>{{1.0f, 1.0f, 2.0f}, ctx->Device()};
+  obj->InitEstimation(info, &base_score);
+  ASSERT_NEAR(base_score(0), std::expm1(2.5f * std::log(2.0f)), kRtEps);
+  ASSERT_NEAR(base_score(1), 3.0f, kRtEps);
+
+  info.num_row_ = 1;
+  info.labels =
+      linalg::Tensor<float, 2>{{std::numeric_limits<float>::max()}, {1, 1}, ctx->Device()};
+  info.weights_.HostVector().clear();
+  obj->InitEstimation(info, &base_score);
+  ASSERT_EQ(base_score(0), std::numeric_limits<float>::max());
 }
 
 void TestLogisticRegressionGPair(const Context* ctx) {

--- a/tests/cpp/objective_helpers.cc
+++ b/tests/cpp/objective_helpers.cc
@@ -18,7 +18,7 @@ void MakeLabelForObjTest(std::shared_ptr<DMatrix> p_fmat, std::string const& obj
     h_upper[i] = 10;
   }
 
-  if (obj.find("rank:") != std::string::npos) {
+  if (obj.find("rank:") != std::string::npos || obj == "binary:hinge") {
     auto h_label = p_fmat->Info().labels.HostView();
     std::size_t k = 0;
     for (auto& v : h_label) {


### PR DESCRIPTION
Hinge and squared-log error currently estimate their intercepts with one Newton step. Both have exact constant solutions.

For hinge, the exact intercept is the weighted-majority margin: `-1` for a negative majority, `1` for a positive majority, and `0` for a tie.

The standard hinge formulation requires binary labels. This change validates that labels are exactly `0` or `1` during initialization and the first gradient calculation. Fractional labels were previously accepted, but produced an unintended formulation where the required margin diverges as the label approaches `0.5` and a label of `0.5` contributes zero gradient but positive Hessian.

For squared-log error, the exact intercept is:

```
expm1(weighted_mean(log1p(label)))
```

The implementation reuses the existing device-aware, distributed sample-mean helpers. Squared-log labels are transformed on their current device, while the small final intercept vector is converted on the host using double precision and capped at the largest finite float.

The initialization tests cover weights, multiple targets, fractional hinge-label rejection, and finite squared-log labels at `FLT_MAX`.

Tested with:

```
./build/testxgboost --gtest_filter='Objective.HingeObj:Objective.SquaredLog'
```
