### PR TITLE
Exact intercepts for absolute error and quantile objectives

### DIFF
--- a/python-package/xgboost/testing/intercept.py
+++ b/python-package/xgboost/testing/intercept.py
@@ -146,12 +146,17 @@ def run_adaptive(tree_method: str, weighted: bool, device: Device) -> None:
         Xy = DMatrix(X, y)
         w = np.ones_like(y)
 
-    mean = np.average(y, weights=w)
-    residual = mean - y
-    delta = np.average(np.sqrt(np.abs(residual)), weights=w) ** 2
-    norm = np.hypot(delta, residual)
-    curvature = np.divide(delta, norm, out=np.ones_like(norm), where=norm > 0.0)
-    base_score = mean - np.sum(w * residual * curvature) / np.sum(w * curvature)
+    # DMatrix stores labels and weights as float32. Match the objective's
+    # step-function quantile: take the first label that reaches half the weight.
+    labels = y.astype(np.float32)
+    weights = w.astype(np.float32)
+    order = np.argsort(labels)
+    labels = labels[order]
+    cumulative_weight = np.cumsum(weights[order], dtype=np.float64)
+    median_idx = np.searchsorted(
+        cumulative_weight, cumulative_weight[-1] / 2.0, side="left"
+    )
+    base_score = labels[median_idx]
 
     # Check the base score is expected.
     booster_0 = train(

--- a/src/learner.cc
+++ b/src/learner.cc
@@ -29,6 +29,7 @@
 #include <utility>        // for pair, as_const, move, swap
 #include <vector>         // for vector
 
+#include "collective/aggregator.h"        // for GlobalMax
 #include "collective/allreduce.h"         // for Allreduce, SafeColl
 #include "collective/broadcast.h"         // for Broadcast
 #include "collective/communicator-inl.h"  // for GetRank, IsDistributed
@@ -345,7 +346,18 @@ class LearnerModelStateContainer : public Learner {
 
   [[nodiscard]] bst_target_t InitNumTargets(DMatrix const& train, CacheT const& cache) const {
     CHECK(this->obj_);
-    auto n_targets = this->obj_->Targets(train.Info());
+    auto local_n_targets = this->obj_->Targets(train.Info());
+    auto n_targets = local_n_targets;
+    // An empty distributed worker can have no label columns and report the single-target
+    // fallback. Agree on the target count before sizing the model and its intercept.
+    if (!model_state_.Initialized()) {
+      n_targets = collective::GlobalMax(Ctx(), n_targets);
+      auto inconsistent =
+          static_cast<std::int32_t>(local_n_targets != n_targets && train.Info().num_row_ != 0);
+      inconsistent = collective::GlobalMax(Ctx(), inconsistent);
+      CHECK_EQ(inconsistent, 0) << "Inconsistent number of targets across workers.";
+    }
+
     for (auto const& weak : cache) {
       auto d = weak.lock();
       if (!d) {

--- a/src/objective/absolute_error_obj.cc
+++ b/src/objective/absolute_error_obj.cc
@@ -13,7 +13,7 @@
 #include <cstdint>    // for int32_t
 #include <vector>     // for vector
 
-#include "../collective/aggregator.h"   // for GlobalSum
+#include "../collective/aggregator.h"   // for GlobalMax, GlobalSum
 #include "../common/common.h"           // for CloseTo
 #include "../common/kernel.h"           // for DispatchKernel, KernelRegistration
 #include "../common/linalg_op.h"        // for ElementWiseKernel
@@ -32,6 +32,12 @@ namespace xgboost::obj {
 DMLC_REGISTRY_FILE_TAG(absolute_error_obj);
 
 namespace {
+bst_target_t GlobalTargets(Context const* ctx, MetaInfo const& info) {
+  auto n_targets = static_cast<bst_target_t>(info.labels.Shape(1));
+  n_targets = collective::GlobalMax(ctx, n_targets);
+  return std::max(n_targets, bst_target_t{1});
+}
+
 void AbsoluteErrorGradientCpu(Context const* ctx, HostDeviceVector<float> const& preds,
                               MetaInfo const& info, bst_target_t n_targets,
                               linalg::Matrix<GradientPair>* out_gpair) {
@@ -43,14 +49,16 @@ void AbsoluteErrorGradientCpu(Context const* ctx, HostDeviceVector<float> const&
   HostDeviceVector<float> root_residual(info.num_row_, 0.0f, DeviceOrd::CPU());
   std::vector<double> scale_stats(n_targets + 1, 0.0);
   for (bst_target_t target{0}; target < n_targets; ++target) {
-    common::Transform<>::Init(
-        [=](std::size_t i, common::Span<float> residual) {
-          residual[i] = weights[i] * sqrtf(fabsf(predt(i, target) - labels(i, target)));
-        },
-        common::Range{0, static_cast<std::int64_t>(info.num_row_)}, ctx->Threads(),
-        DeviceOrd::CPU())
-        .Eval(&root_residual);
-    scale_stats[target] = common::Reduce(ctx, root_residual);
+    if (info.num_row_ != 0) {
+      common::Transform<>::Init(
+          [=](std::size_t i, common::Span<float> residual) {
+            residual[i] = weights[i] * sqrtf(fabsf(predt(i, target) - labels(i, target)));
+          },
+          common::Range{0, static_cast<std::int64_t>(info.num_row_)}, ctx->Threads(),
+          DeviceOrd::CPU())
+          .Eval(&root_residual);
+      scale_stats[target] = common::Reduce(ctx, root_residual);
+    }
   }
   scale_stats.back() = common::SumOptionalWeights(ctx, weights, info.num_row_);
   auto cpu_ctx = ctx->MakeCPU();
@@ -107,13 +115,15 @@ class MeanAbsoluteError : public ObjFunction {
                    linalg::Matrix<GradientPair>* out_gpair) override {
     CheckInitInputs(info);
     CHECK_EQ(info.labels.Size(), preds.Size()) << "Invalid shape of labels.";
-    common::DispatchKernel<AbsoluteErrorGradientKernel>(ctx_, preds, info, this->Targets(info),
-                                                        out_gpair);
+    auto n_targets = GlobalTargets(ctx_, info);
+    common::DispatchKernel<AbsoluteErrorGradientKernel>(ctx_, preds, info, n_targets, out_gpair);
   }
 
   void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
     CheckInitInputs(info);
-    auto n_targets = this->Targets(info);
+    // An empty distributed worker has a 0-by-0 label matrix. Agree on the target count before
+    // allocating the radix histograms so every worker enters equally sized collectives.
+    auto n_targets = GlobalTargets(ctx_, info);
     HostDeviceVector<float> alpha{{0.5f}};
     RadixSelect(ctx_, info.labels, info.weights_, alpha, n_targets, base_score);
     CHECK_EQ(base_score->Size(), n_targets);

--- a/src/objective/absolute_error_obj.cc
+++ b/src/objective/absolute_error_obj.cc
@@ -11,7 +11,6 @@
 #include <cmath>      // for fabsf, hypotf, sqrtf
 #include <cstddef>    // for size_t
 #include <cstdint>    // for int32_t
-#include <memory>     // for unique_ptr
 #include <vector>     // for vector
 
 #include "../collective/aggregator.h"   // for GlobalSum
@@ -21,12 +20,11 @@
 #include "../common/math.h"             // for CloseTo
 #include "../common/numeric.h"          // for Reduce
 #include "../common/optional_weight.h"  // for MakeOptionalWeights
-#include "../common/stats.h"            // for SampleMean, WeightedSampleMean
 #include "../common/transform.h"        // for Transform
-#include "../tree/fit_stump.h"          // for FitStump
 #include "init_estimation.h"            // for CheckInitInputs
+#include "radix_select.h"               // for RadixSelect
 #include "xgboost/json.h"               // for Json, Object, String
-#include "xgboost/logging.h"            // for CHECK, LOG
+#include "xgboost/logging.h"            // for CHECK
 #include "xgboost/objective.h"          // for ObjFunction
 #include "xgboost/string_view.h"        // for StringView
 
@@ -80,49 +78,9 @@ void AbsoluteErrorGradientCpu(Context const* ctx, HostDeviceVector<float> const&
       });
 }
 
-void AbsoluteErrorInitEstimationCpu(Context const* ctx, MetaInfo const& info,
-                                    bst_target_t n_targets, linalg::Vector<float>* base_score) {
-  double sum_weight = info.weights_.Empty() ? static_cast<double>(info.num_row_)
-                                            : common::Reduce(ctx, info.weights_);
-  collective::SafeColl(collective::GlobalSum(ctx, linalg::MakeVec(&sum_weight, std::size_t{1})));
-  if (common::CloseTo(sum_weight, 0.0)) {
-    LOG(WARNING) << "Sum of weights is close to 0.0, skipping base score estimation.";
-    *base_score = linalg::Zeros<float>(ctx, n_targets);
-    return;
-  }
-
-  linalg::Vector<float> mean;
-  if (info.weights_.Empty()) {
-    common::SampleMean(ctx, info.labels, &mean);
-  } else {
-    common::WeightedSampleMean(ctx, info.labels, info.weights_, &mean);
-  }
-  CHECK_EQ(mean.Size(), n_targets);
-
-  HostDeviceVector<float> predt(info.labels.Size(), 0.0f, DeviceOrd::CPU());
-  auto predt_h =
-      linalg::MakeTensorView(DeviceOrd::CPU(), predt.HostSpan(), info.num_row_, n_targets);
-  auto mean_h = mean.HostView();
-  linalg::cpu_impl::ElementWiseKernel(
-      predt_h, ctx->Threads(),
-      [=](std::size_t i, std::size_t target) mutable { predt_h(i, target) = mean_h(target); });
-
-  linalg::Matrix<GradientPair> gpair;
-  AbsoluteErrorGradientCpu(ctx, predt, info, n_targets, &gpair);
-  tree::FitStump(ctx, gpair, n_targets, base_score);
-
-  auto out = base_score->HostView();
-  for (bst_target_t target{0}; target < n_targets; ++target) {
-    out(target) += mean_h(target);
-  }
-}
-
 auto const kRegisterAbsoluteErrorGradientCpu =
     common::KernelRegistration<AbsoluteErrorGradientKernel>{DeviceOrd::kCPU,
                                                             &AbsoluteErrorGradientCpu};
-auto const kRegisterAbsoluteErrorInitEstimationCpu =
-    common::KernelRegistration<AbsoluteErrorInitEstimationKernel>{DeviceOrd::kCPU,
-                                                                  &AbsoluteErrorInitEstimationCpu};
 }  // namespace
 
 /**
@@ -155,8 +113,10 @@ class MeanAbsoluteError : public ObjFunction {
 
   void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
     CheckInitInputs(info);
-    common::DispatchKernel<AbsoluteErrorInitEstimationKernel>(ctx_, info, this->Targets(info),
-                                                              base_score);
+    auto n_targets = this->Targets(info);
+    HostDeviceVector<float> alpha{{0.5f}};
+    RadixSelect(ctx_, info.labels, info.weights_, alpha, n_targets, base_score);
+    CHECK_EQ(base_score->Size(), n_targets);
   }
 
   [[nodiscard]] const char* DefaultEvalMetric() const override { return "mae"; }

--- a/src/objective/absolute_error_obj.cu
+++ b/src/objective/absolute_error_obj.cu
@@ -15,11 +15,7 @@
 #include "../common/device_helpers.cuh"  // for LaunchN, MakeTransformIterator
 #include "../common/kernel.h"            // for KernelRegistration
 #include "../common/linalg_op.cuh"       // for ElementWiseKernel
-#include "../common/math.h"              // for CloseTo
-#include "../common/numeric.h"           // for Reduce
 #include "../common/optional_weight.h"   // for MakeOptionalWeights
-#include "../common/stats.h"
-#include "../tree/fit_stump.h"
 #include "absolute_error_obj.h"
 
 namespace xgboost::obj {
@@ -82,51 +78,8 @@ void AbsoluteErrorGradientCuda(Context const* ctx, HostDeviceVector<float> const
       ctx->CUDACtx()->Stream());
 }
 
-void AbsoluteErrorInitEstimationCuda(Context const* ctx, MetaInfo const& info,
-                                     bst_target_t n_targets, linalg::Vector<float>* base_score) {
-  auto device = ctx->Device();
-  double sum_weight = info.weights_.Empty() ? static_cast<double>(info.num_row_)
-                                            : common::Reduce(ctx, info.weights_);
-  auto cpu_ctx = ctx->MakeCPU();
-  collective::SafeColl(
-      collective::GlobalSum(&cpu_ctx, linalg::MakeVec(&sum_weight, std::size_t{1})));
-  if (common::CloseTo(sum_weight, 0.0)) {
-    LOG(WARNING) << "Sum of weights is close to 0.0, skipping base score estimation.";
-    *base_score = linalg::Zeros<float>(ctx, n_targets);
-    return;
-  }
-
-  linalg::Vector<float> mean;
-  if (info.weights_.Empty()) {
-    common::SampleMean(ctx, info.labels, &mean);
-  } else {
-    common::WeightedSampleMean(ctx, info.labels, info.weights_, &mean);
-  }
-  CHECK_EQ(mean.Size(), n_targets);
-  auto mean_d = mean.View(device);
-
-  HostDeviceVector<float> predt(info.labels.Size(), 0.0f, device);
-  auto predt_d = linalg::MakeTensorView(ctx, &predt, info.num_row_, n_targets);
-  linalg::cuda_impl::ElementWiseKernel(
-      predt_d,
-      [=] XGBOOST_DEVICE(std::size_t i, std::size_t target) mutable {
-        predt_d(i, target) = mean_d(target);
-      },
-      ctx->CUDACtx()->Stream());
-
-  linalg::Matrix<GradientPair> gpair;
-  AbsoluteErrorGradientCuda(ctx, predt, info, n_targets, &gpair);
-  tree::FitStump(ctx, gpair, n_targets, base_score);
-
-  auto out = base_score->View(device);
-  dh::LaunchN(n_targets, ctx->CUDACtx()->Stream(),
-              [=] XGBOOST_DEVICE(std::size_t target) mutable { out(target) += mean_d(target); });
-}
 auto const kRegisterAbsoluteErrorGradientCuda =
     common::KernelRegistration<AbsoluteErrorGradientKernel>{DeviceOrd::kCUDA,
                                                             &AbsoluteErrorGradientCuda};
-auto const kRegisterAbsoluteErrorInitEstimationCuda =
-    common::KernelRegistration<AbsoluteErrorInitEstimationKernel>{DeviceOrd::kCUDA,
-                                                                  &AbsoluteErrorInitEstimationCuda};
 }  // namespace
 }  // namespace xgboost::obj

--- a/src/objective/absolute_error_obj.h
+++ b/src/objective/absolute_error_obj.h
@@ -18,9 +18,6 @@ struct AbsoluteErrorGradientKernel {
                          bst_target_t, linalg::Matrix<GradientPair>*);
 };
 
-struct AbsoluteErrorInitEstimationKernel {
-  using Signature = void(Context const*, MetaInfo const&, bst_target_t, linalg::Vector<float>*);
-};
 }  // namespace xgboost::obj
 
 #endif  // XGBOOST_OBJECTIVE_ABSOLUTE_ERROR_OBJ_H_

--- a/src/objective/objective.cc
+++ b/src/objective/objective.cc
@@ -58,6 +58,7 @@ DMLC_REGISTRY_LINK_TAG(multiclass_obj);
 DMLC_REGISTRY_LINK_TAG(aft_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(expectile_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(regression_obj_gpu);
+DMLC_REGISTRY_LINK_TAG(radix_select_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(quantile_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(gamma_kernel_cuda);
 DMLC_REGISTRY_LINK_TAG(hinge_kernel_cuda);

--- a/src/objective/quantile_obj.cc
+++ b/src/objective/quantile_obj.cc
@@ -7,7 +7,7 @@
 
 #include <dmlc/registry.h>
 
-#include <algorithm>  // for max
+#include <algorithm>  // for sort
 #include <cmath>      // for fabsf, fmaxf, sqrtf, tanhf
 #include <cstddef>    // for size_t
 #include <cstdint>    // for int32_t
@@ -149,6 +149,13 @@ const auto kRegisterQuantileGradientCpu =
     common::KernelRegistration<QuantileGradientKernel>{DeviceOrd::kCPU, &QuantileGradientCpu};
 const auto kRegisterQuantileTransformCpu =
     common::KernelRegistration<QuantileTransformKernel>{DeviceOrd::kCPU, &QuantileTransformCpu};
+
+void CheckQuantileLabelShape(MetaInfo const& info) {
+  auto n_rows = info.labels.Shape(0);
+  auto n_columns = info.labels.Shape(1);
+  CHECK(n_columns == 1 || (n_rows == 0 && n_columns == 0))
+      << "Multi-target is not yet supported by the quantile loss.";
+}
 }  // namespace
 
 class QuantileRegression : public ObjFunction {
@@ -158,13 +165,9 @@ class QuantileRegression : public ObjFunction {
   [[nodiscard]] bst_target_t Targets(MetaInfo const& info) const override {
     auto const& alpha = param_.quantile_alpha.Get();
     CHECK_EQ(alpha.size(), alpha_.Size()) << "The objective is not yet configured.";
-    CHECK_EQ(info.labels.Shape(1), 1) << "Multi-target is not yet supported by the quantile loss.";
+    CheckQuantileLabelShape(info);
     CHECK(!alpha.empty());
-    // We have some placeholders for multi-target in the quantile loss. But it's not
-    // supported as the gbtree doesn't know how to slice the gradient and there's no 3-dim
-    // model shape in general.
-    auto n_y = std::max(static_cast<std::size_t>(1), info.labels.Shape(1));
-    return alpha_.Size() * n_y;
+    return alpha_.Size();
   }
 
  public:
@@ -180,9 +183,6 @@ class QuantileRegression : public ObjFunction {
     CHECK_NE(n_alphas, 0);
     CHECK_GE(n_targets, n_alphas);
     CHECK_EQ(preds.Size(), info.num_row_ * n_targets);
-    CHECK_EQ(info.labels.Shape(1), 1)
-        << "Multi-target for quantile regression is not yet supported.";
-
     common::DispatchKernel<QuantileGradientKernel>(ctx_, preds, info, n_targets, alpha_, out_gpair);
   }
 

--- a/src/objective/quantile_obj.cc
+++ b/src/objective/quantile_obj.cc
@@ -22,7 +22,8 @@
 #include "../common/quantile_loss_utils.h"  // for QuantileLossParam
 #include "../common/threading_utils.h"      // for ParallelFor
 #include "../common/transform.h"            // for Transform
-#include "init_estimation.h"                // for CheckInitInputs, FitIntercept
+#include "init_estimation.h"                // for CheckInitInputs
+#include "radix_select.h"                   // for RadixSelect
 #include "xgboost/json.h"                   // for FromJson, Json, Object, String, ToJson
 #include "xgboost/logging.h"                // for CHECK
 #include "xgboost/objective.h"              // for ObjFunction
@@ -150,7 +151,7 @@ const auto kRegisterQuantileTransformCpu =
     common::KernelRegistration<QuantileTransformKernel>{DeviceOrd::kCPU, &QuantileTransformCpu};
 }  // namespace
 
-class QuantileRegression : public FitIntercept {
+class QuantileRegression : public ObjFunction {
   common::QuantileLossParam param_;
   HostDeviceVector<float> alpha_;
 
@@ -183,6 +184,13 @@ class QuantileRegression : public FitIntercept {
         << "Multi-target for quantile regression is not yet supported.";
 
     common::DispatchKernel<QuantileGradientKernel>(ctx_, preds, info, n_targets, alpha_, out_gpair);
+  }
+
+  void InitEstimation(MetaInfo const& info, linalg::Vector<float>* base_score) const override {
+    CheckInitInputs(info);
+    auto n_targets = this->Targets(info);
+    RadixSelect(ctx_, info.labels, info.weights_, alpha_, n_targets, base_score);
+    CHECK_EQ(base_score->Size(), n_targets);
   }
 
   void PredTransform(HostDeviceVector<float>* predictions) const override {

--- a/src/objective/radix_select.cc
+++ b/src/objective/radix_select.cc
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file radix_select.cc
+ * \brief CPU implementation of float32 radix selection.
+ */
+#include "radix_select.h"
+
+#include <algorithm>  // std::clamp, std::fill, std::max
+#include <cstddef>    // std::size_t
+#include <cstdint>    // std::uint32_t
+#include <cstring>    // std::memcpy
+#include <limits>     // std::numeric_limits
+#include <numeric>    // std::accumulate
+#include <vector>     // std::vector
+
+#include "../collective/aggregator.h"   // for GlobalSum
+#include "../common/kernel.h"           // for DispatchKernel, KernelRegistration
+#include "../common/optional_weight.h"  // for OptionalWeights
+#include "../common/threading_utils.h"  // for ParallelFor
+#include "xgboost/logging.h"            // for CHECK
+
+namespace xgboost::obj {
+namespace {
+constexpr std::size_t kRadixBits{8};
+constexpr std::size_t kRadixBins{std::size_t{1} << kRadixBits};
+constexpr std::size_t kRadixPasses{sizeof(float) * 8 / kRadixBits};
+
+static_assert(sizeof(float) == sizeof(std::uint32_t));
+
+// Unsigned comparison of raw IEEE-754 bits does not match numeric comparison: the sign bit puts
+// negative values after positive values, and the magnitude bits run backwards within the negative
+// range. Complementing every bit of a negative value and flipping only the sign bit of a
+// non-negative value produces an unsigned key whose order matches the numeric float order.
+std::uint32_t ToOrderedKey(float value) {
+  std::uint32_t bits{0};
+  std::memcpy(&bits, &value, sizeof(value));
+  auto mask = bits & 0x80000000U ? std::numeric_limits<std::uint32_t>::max() : 0x80000000U;
+  return bits ^ mask;
+}
+
+// Reverse the order-preserving transformation in ToOrderedKey.
+float FromOrderedKey(std::uint32_t key) {
+  auto mask = key & 0x80000000U ? 0x80000000U : std::numeric_limits<std::uint32_t>::max();
+  auto bits = key ^ mask;
+  float value{0.0f};
+  std::memcpy(&value, &bits, sizeof(value));
+  return value;
+}
+
+// Interior quantiles select the first bin whose cumulative weight reaches the rank. At alpha=0
+// and alpha=1 the rank lies on a boundary, so explicitly choose the first or last non-empty bin.
+std::size_t SelectBin(common::Span<double const> histogram, double rank, float alpha) {
+  if (alpha == 0.0f) {
+    for (std::size_t bin{0}; bin < histogram.size(); ++bin) {
+      if (histogram[bin] > 0.0) {
+        return bin;
+      }
+    }
+  } else if (alpha == 1.0f) {
+    for (std::size_t bin = histogram.size(); bin-- > 0;) {
+      if (histogram[bin] > 0.0) {
+        return bin;
+      }
+    }
+  } else {
+    double cumulative{0.0};
+    for (std::size_t bin{0}; bin < histogram.size(); ++bin) {
+      cumulative += histogram[bin];
+      if (histogram[bin] > 0.0 && cumulative >= rank) {
+        return bin;
+      }
+    }
+  }
+  // Rounding can leave rank just above cumulative weight. Prefer the last value-bearing bin over
+  // returning an empty bin that cannot correspond to an input value.
+  for (std::size_t bin = histogram.size(); bin-- > 0;) {
+    if (histogram[bin] > 0.0) {
+      return bin;
+    }
+  }
+  return 0;
+}
+
+void RadixSelectCpu(Context const* ctx, linalg::Matrix<float> const& values,
+                    HostDeviceVector<float> const& weights, HostDeviceVector<float> const& alphas,
+                    bst_target_t n_targets, linalg::Vector<float>* out) {
+  CHECK(ctx->IsCPU());
+  auto n_alphas = alphas.Size();
+  auto n_outputs = n_targets;
+  *out = linalg::Zeros<float>(ctx, n_outputs);
+  if (n_outputs == 0) {
+    return;
+  }
+
+  auto h_values = values.HostView();
+  auto h_weights = common::OptionalWeights{weights.ConstHostSpan()};
+  auto h_alphas = alphas.ConstHostSpan();
+  auto n_threads = std::max<std::int32_t>(ctx->Threads(), 1);
+  // For each (column, alpha), prefix is the part of the selected key already known and rank is the
+  // cumulative weight still required within that prefix.
+  std::vector<std::uint32_t> prefixes(n_outputs, 0);
+  std::vector<double> ranks(n_outputs, 0.0);
+  std::vector<double> histogram(n_outputs * kRadixBins, 0.0);
+  // A histogram per thread avoids synchronization while scanning the rows.
+  std::vector<double> thread_histogram(n_threads * histogram.size(), 0.0);
+
+  for (std::size_t pass{0}; pass < kRadixPasses; ++pass) {
+    std::fill(thread_histogram.begin(), thread_histogram.end(), 0.0);
+    auto shift = 32 - (pass + 1) * kRadixBits;
+    auto prefix_mask = pass == 0 ? 0U : std::numeric_limits<std::uint32_t>::max() << (shift + 8);
+    // Count the next byte only for keys matching the prefix chosen in earlier passes.
+    common::ParallelFor(values.Shape(0) * n_outputs, n_threads, [&](std::size_t i) {
+      auto output = i / values.Shape(0);
+      auto row = i % values.Shape(0);
+      auto column = output / n_alphas;
+      auto key = ToOrderedKey(h_values(row, column));
+      if ((key & prefix_mask) != prefixes[output]) {
+        return;
+      }
+      auto bin = (key >> shift) & (kRadixBins - 1);
+      auto thread = omp_get_thread_num();
+      auto offset = (thread * n_outputs + output) * kRadixBins + bin;
+      thread_histogram[offset] += h_weights[row];
+    });
+
+    // Combine thread-local histograms, then combine the same bins across workers.
+    std::fill(histogram.begin(), histogram.end(), 0.0);
+    for (std::int32_t thread{0}; thread < n_threads; ++thread) {
+      auto offset = thread * histogram.size();
+      for (std::size_t i{0}; i < histogram.size(); ++i) {
+        histogram[i] += thread_histogram[offset + i];
+      }
+    }
+    collective::SafeColl(
+        collective::GlobalSum(ctx, linalg::MakeVec(histogram.data(), histogram.size())));
+
+    for (std::size_t output{0}; output < n_outputs; ++output) {
+      auto bins = common::Span<double const>{histogram.data() + output * kRadixBins, kRadixBins};
+      auto alpha = h_alphas[output % n_alphas];
+      if (pass == 0) {
+        auto total = std::accumulate(bins.begin(), bins.end(), 0.0);
+        if (total == 0.0) {
+          ranks[output] = -1.0;
+          continue;
+        }
+        ranks[output] = alpha * total;
+      } else if (ranks[output] < 0.0) {
+        continue;
+      }
+      // Keep the bin containing the remaining weighted rank. The selected bin becomes the next
+      // prefix byte, while weights in preceding bins are removed from the rank for the next pass.
+      auto bin = SelectBin(bins, ranks[output], alpha);
+      auto weight_before = std::accumulate(bins.begin(), bins.begin() + bin, 0.0);
+      ranks[output] = std::clamp(ranks[output] - weight_before, 0.0, bins[bin]);
+      prefixes[output] |= static_cast<std::uint32_t>(bin) << shift;
+    }
+  }
+
+  // All four bytes are now known, so the prefix is the ordered key of the selected float.
+  auto h_out = out->HostView();
+  for (std::size_t output{0}; output < n_outputs; ++output) {
+    h_out(output) = ranks[output] < 0.0 ? 0.0f : FromOrderedKey(prefixes[output]);
+  }
+}
+
+auto const kRegisterRadixSelectCpu =
+    common::KernelRegistration<RadixSelectKernel>{DeviceOrd::kCPU, &RadixSelectCpu};
+}  // namespace
+
+void RadixSelect(Context const* ctx, linalg::Matrix<float> const& values,
+                 HostDeviceVector<float> const& weights, HostDeviceVector<float> const& alphas,
+                 bst_target_t n_targets, linalg::Vector<float>* out) {
+  CHECK(ctx);
+  CHECK(weights.Empty() || weights.Size() == values.Shape(0));
+  CHECK(!alphas.Empty());
+  CHECK_NE(n_targets, 0);
+  CHECK(values.Shape(1) == 0 || values.Shape(1) * alphas.Size() == n_targets)
+      << "Invalid number of outputs.";
+  for (auto alpha : alphas.ConstHostSpan()) {
+    CHECK_GE(alpha, 0.0f);
+    CHECK_LE(alpha, 1.0f);
+  }
+  common::DispatchKernel<RadixSelectKernel>(ctx, values, weights, alphas, n_targets, out);
+}
+}  // namespace xgboost::obj

--- a/src/objective/radix_select.cu
+++ b/src/objective/radix_select.cu
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file radix_select.cu
+ * \brief CUDA implementation of float32 radix selection.
+ */
+#include <dmlc/registry.h>  // for DMLC_REGISTRY_FILE_TAG
+
+#include <cmath>    // fmax, fmin
+#include <cstddef>  // std::size_t
+#include <cstdint>  // std::uint32_t
+
+#include "../collective/aggregator.h"    // for GlobalSum
+#include "../common/cuda_context.cuh"    // for CUDAContext
+#include "../common/device_helpers.cuh"  // for LaunchN
+#include "../common/kernel.h"            // for KernelRegistration
+#include "../common/optional_weight.h"   // for OptionalWeights
+#include "radix_select.h"
+
+namespace xgboost::obj {
+DMLC_REGISTRY_FILE_TAG(radix_select_kernel_cuda);
+
+namespace {
+constexpr std::size_t kRadixBits{8};
+constexpr std::size_t kRadixBins{std::size_t{1} << kRadixBits};
+constexpr std::size_t kRadixPasses{sizeof(float) * 8 / kRadixBits};
+
+void RadixSelectCuda(Context const* ctx, linalg::Matrix<float> const& values,
+                     HostDeviceVector<float> const& weights, HostDeviceVector<float> const& alphas,
+                     bst_target_t n_targets, linalg::Vector<float>* out) {
+  auto device = ctx->Device();
+  CHECK(device.IsCUDA());
+  values.SetDevice(device);
+  weights.SetDevice(device);
+  alphas.SetDevice(device);
+  auto d_values = values.View(device);
+  auto d_weights = common::OptionalWeights{weights.ConstDeviceSpan()};
+  auto d_alphas = alphas.ConstDeviceSpan();
+  auto n_rows = values.Shape(0);
+  auto n_alphas = alphas.Size();
+  auto n_outputs = n_targets;
+  *out = linalg::Zeros<float>(ctx, n_outputs);
+  if (n_outputs == 0) {
+    return;
+  }
+
+  linalg::Vector<std::uint32_t> prefixes = linalg::Zeros<std::uint32_t>(ctx, n_outputs);
+  linalg::Vector<double> ranks = linalg::Zeros<double>(ctx, n_outputs);
+  linalg::Vector<double> histogram = linalg::Zeros<double>(ctx, n_outputs * kRadixBins);
+  auto d_prefixes = prefixes.View(device);
+  auto d_ranks = ranks.View(device);
+  auto d_histogram = histogram.View(device);
+  auto stream = ctx->CUDACtx()->Stream();
+
+  for (std::size_t pass{0}; pass < kRadixPasses; ++pass) {
+    dh::LaunchN(d_histogram.Size(), stream,
+                [=] __device__(std::size_t i) mutable { d_histogram(i) = 0.0; });
+    auto shift = 32 - (pass + 1) * kRadixBits;
+    auto prefix_mask = pass == 0 ? 0U : 0xffffffffU << (shift + 8);
+    // Histogram the next byte of the order-preserving float key for matching prefixes. Atomic
+    // updates replace the per-thread histograms used by the CPU implementation.
+    dh::LaunchN(n_rows * n_outputs, stream, [=] __device__(std::size_t i) mutable {
+      auto output = i / n_rows;
+      auto row = i % n_rows;
+      auto column = output / n_alphas;
+      auto bits = __float_as_uint(d_values(row, column));
+      // Complement negatives and flip the sign bit of non-negatives so unsigned key order agrees
+      // with numeric float order. This is the device equivalent of ToOrderedKey in the CPU file.
+      auto key = bits ^ (bits & 0x80000000U ? 0xffffffffU : 0x80000000U);
+      if ((key & prefix_mask) != d_prefixes(output)) {
+        return;
+      }
+      auto bin = (key >> shift) & (kRadixBins - 1);
+      atomicAdd(&d_histogram(output * kRadixBins + bin), static_cast<double>(d_weights[row]));
+    });
+    // All workers must choose the same prefix, so select from the globally summed histogram.
+    collective::SafeColl(collective::GlobalSum(ctx, d_histogram));
+
+    dh::LaunchN(n_outputs, stream, [=] __device__(std::size_t output) mutable {
+      auto alpha = d_alphas[output % n_alphas];
+      if (pass == 0) {
+        double total{0.0};
+        for (std::size_t bin{0}; bin < kRadixBins; ++bin) {
+          total += d_histogram(output * kRadixBins + bin);
+        }
+        if (total == 0.0) {
+          d_ranks(output) = -1.0;
+          return;
+        }
+        d_ranks(output) = alpha * total;
+      } else if (d_ranks(output) < 0.0) {
+        return;
+      }
+
+      std::size_t selected{0};
+      double before{0.0};
+      if (alpha == 0.0f) {
+        for (std::size_t bin{0}; bin < kRadixBins; ++bin) {
+          if (d_histogram(output * kRadixBins + bin) > 0.0) {
+            selected = bin;
+            break;
+          }
+        }
+      } else if (alpha == 1.0f) {
+        for (std::size_t bin = kRadixBins; bin-- > 0;) {
+          if (d_histogram(output * kRadixBins + bin) > 0.0) {
+            selected = bin;
+            break;
+          }
+        }
+        for (std::size_t bin{0}; bin < selected; ++bin) {
+          before += d_histogram(output * kRadixBins + bin);
+        }
+      } else {
+        double cumulative{0.0};
+        for (std::size_t bin{0}; bin < kRadixBins; ++bin) {
+          auto weight = d_histogram(output * kRadixBins + bin);
+          cumulative += weight;
+          // Keep the last non-empty bin as a fallback in case rounding leaves the remaining rank
+          // just above the accumulated weight.
+          if (weight > 0.0) {
+            selected = bin;
+            before = cumulative - weight;
+          }
+          if (weight > 0.0 && cumulative >= d_ranks(output)) {
+            break;
+          }
+        }
+      }
+      // Retain the rank within the selected bin and append that bin as the next prefix byte.
+      auto selected_weight = d_histogram(output * kRadixBins + selected);
+      d_ranks(output) = fmin(fmax(d_ranks(output) - before, 0.0), selected_weight);
+      d_prefixes(output) |= static_cast<std::uint32_t>(selected) << shift;
+    });
+  }
+
+  // Reverse the ordered-key transform after all four prefix bytes have been selected.
+  auto d_out = out->View(device);
+  dh::LaunchN(n_outputs, stream, [=] __device__(std::size_t output) mutable {
+    auto key = d_prefixes(output);
+    auto bits = key ^ (key & 0x80000000U ? 0x80000000U : 0xffffffffU);
+    d_out(output) = d_ranks(output) < 0.0 ? 0.0f : __uint_as_float(bits);
+  });
+}
+
+auto const kRegisterRadixSelectCuda =
+    common::KernelRegistration<RadixSelectKernel>{DeviceOrd::kCUDA, &RadixSelectCuda};
+}  // namespace
+}  // namespace xgboost::obj

--- a/src/objective/radix_select.h
+++ b/src/objective/radix_select.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file radix_select.h
+ * \brief Float32 radix-selection kernel for objective intercepts.
+ */
+#ifndef XGBOOST_OBJECTIVE_RADIX_SELECT_H_
+#define XGBOOST_OBJECTIVE_RADIX_SELECT_H_
+
+#include "xgboost/context.h"             // for Context
+#include "xgboost/host_device_vector.h"  // for HostDeviceVector
+#include "xgboost/linalg.h"              // for Matrix, Vector
+
+namespace xgboost::obj {
+struct RadixSelectKernel {
+  using Signature = void(Context const*, linalg::Matrix<float> const&,
+                         HostDeviceVector<float> const&, HostDeviceVector<float> const&,
+                         bst_target_t, linalg::Vector<float>*);
+};
+
+/**
+ * @brief Select weighted float32 quantiles without sorting.
+ *
+ * Absolute-error and quantile objectives need exact weighted quantiles to initialize their
+ * intercepts. Sorting all labels would require O(n log n) work and is inconvenient on GPUs and
+ * across distributed workers. Since the labels are float32, their ordered representation has
+ * only 32 bits. We can recover the selected value directly with four passes over the data.
+ *
+ * Each pass considers the next 8 bits, from most to least significant. It builds a weighted
+ * 256-bin histogram for values matching the prefix selected by previous passes, sums the
+ * histogram across workers, and selects the bin containing the requested cumulative weight. The
+ * selected bin extends the prefix by 8 bits and the weight of preceding bins is subtracted from
+ * the rank. After four passes the 32-bit prefix identifies the exact selected float.
+ *
+ * The result contains one quantile for each (input column, alpha) pair, with alpha varying
+ * fastest. The input is never sorted or modified. Other devices use the registered CPU kernel
+ * fallback. A globally zero total weight produces zero.
+ *
+ * n_targets is supplied independently of the local label shape because a distributed worker can
+ * have no data and a 0-by-0 label matrix. It must still allocate the same histograms and
+ * participate in the same collectives as workers that have data.
+ */
+void RadixSelect(Context const* ctx, linalg::Matrix<float> const& values,
+                 HostDeviceVector<float> const& weights, HostDeviceVector<float> const& alphas,
+                 bst_target_t n_targets, linalg::Vector<float>* out);
+}  // namespace xgboost::obj
+
+#endif  // XGBOOST_OBJECTIVE_RADIX_SELECT_H_

--- a/tests/cpp/objective/test_quantile_obj.cc
+++ b/tests/cpp/objective/test_quantile_obj.cc
@@ -133,43 +133,23 @@ void TestQuantileIntercept(Context const* ctx) {
     }
   });
 
-  auto check_init = [&] {
+  auto check_init = [&](std::vector<float> const& expected) {
     auto n_targets = obj->Targets(info);
-    HostDeviceVector<float> zero_predt(info.num_row_ * n_targets, 0.0f, ctx->Device());
-    linalg::Matrix<GradientPair> gpair;
-    obj->GetGradient(zero_predt, info, 0, &gpair);
-
-    std::vector<float> expected(n_targets);
-    auto h_gpair = gpair.HostView();
-    for (bst_target_t target{0}; target < n_targets; ++target) {
-      double sum_grad{0.0};
-      double sum_hess{0.0};
-      for (std::size_t row{0}; row < info.num_row_; ++row) {
-        sum_grad += h_gpair(row, target).GetGrad();
-        sum_hess += h_gpair(row, target).GetHess();
-      }
-      expected[target] = -sum_grad / std::max(sum_hess, static_cast<double>(kRtEps));
-    }
-    HostDeviceVector<float> expected_predt{expected};
-    expected_predt.SetDevice(ctx->Device());
-    obj->PredTransform(&expected_predt);
-
     linalg::Vector<float> base_scores;
     obj->InitEstimation(info, &base_scores);
     ASSERT_EQ(base_scores.Size(), n_targets);
-    auto const& h_expected = expected_predt.HostVector();
     auto h_base_scores = base_scores.HostView();
     for (bst_target_t target{0}; target < n_targets; ++target) {
-      ASSERT_NEAR(h_base_scores(target), h_expected[target], 1.0e-5);
+      ASSERT_EQ(h_base_scores(target), expected[target]);
     }
   };
 
-  check_init();
+  check_init({6.0f, 8.0f});
 
   for (std::size_t i = 0; i < info.num_row_; ++i) {
     info.weights_.HostVector().emplace_back(info.num_row_ - i - 1.0);
   }
 
-  check_init();
+  check_init({3.0f, 5.0f});
 }
 }  // namespace xgboost

--- a/tests/cpp/objective/test_radix_select.cc
+++ b/tests/cpp/objective/test_radix_select.cc
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ */
+#include <gtest/gtest.h>
+
+#include <algorithm>  // std::max, std::min
+#include <memory>     // std::unique_ptr
+#include <thread>     // std::thread
+#include <vector>     // std::vector
+
+#include "../../../src/objective/radix_select.h"
+#include "../collective/test_worker.h"   // for TestDistributedGlobal
+#include "../helpers.h"                  // for MakeCUDACtx
+#include "xgboost/context.h"             // for Context
+#include "xgboost/data.h"                // for MetaInfo
+#include "xgboost/host_device_vector.h"  // for HostDeviceVector
+#include "xgboost/linalg.h"              // for Matrix, Vector
+#include "xgboost/objective.h"           // for ObjFunction
+
+namespace xgboost::obj {
+namespace {
+void TestRadixSelect(Context const* ctx) {
+  linalg::Matrix<float> values{
+      {-100.0f, 9.0f, 3.0f, -4.0f, 2.0f, 0.0f, 1.0f, 2.0f, 1.0e20f, 1.0f}, {5, 2}, ctx->Device()};
+  HostDeviceVector<float> alphas{{0.0f, 0.5f, 1.0f}};
+  linalg::Vector<float> out;
+
+  HostDeviceVector<float> weights;
+  RadixSelect(ctx, values, weights, alphas, 6, &out);
+  auto h_out = out.HostView();
+  std::vector<float> expected{-100.0f, 2.0f, 1.0e20f, -4.0f, 1.0f, 9.0f};
+  ASSERT_EQ(h_out.Size(), expected.size());
+  for (std::size_t i{0}; i < expected.size(); ++i) {
+    ASSERT_EQ(h_out(i), expected[i]);
+  }
+
+  weights.HostVector() = {0.0f, 1.0f, 2.0f, 4.0f, 8.0f};
+  alphas.HostVector() = {0.25f, 0.5f, 0.75f};
+  RadixSelect(ctx, values, weights, alphas, 6, &out);
+  h_out = out.HostView();
+  expected = {1.0f, 1.0e20f, 1.0e20f, 1.0f, 1.0f, 2.0f};
+  for (std::size_t i{0}; i < expected.size(); ++i) {
+    ASSERT_EQ(h_out(i), expected[i]);
+  }
+
+  weights.HostVector().assign(5, 0.0f);
+  RadixSelect(ctx, values, weights, alphas, 6, &out);
+  h_out = out.HostView();
+  for (std::size_t i{0}; i < h_out.Size(); ++i) {
+    ASSERT_EQ(h_out(i), 0.0f);
+  }
+}
+}  // namespace
+
+TEST(ObjectiveRadixSelect, Select) {
+  Context ctx;
+  TestRadixSelect(&ctx);
+#if defined(XGBOOST_USE_CUDA)
+  ctx = MakeCUDACtx(0);
+  TestRadixSelect(&ctx);
+#endif  // defined(XGBOOST_USE_CUDA)
+}
+
+TEST(ObjectiveRadixSelect, Distributed) {
+  auto n_workers = std::max(1u, std::min(4u, std::thread::hardware_concurrency()));
+  collective::TestDistributedGlobal(n_workers, [n_workers] {
+    auto rank = collective::GetRank();
+    Context ctx;
+    collective::GetWorkerLocalThreads(collective::GetWorldSize(), &ctx);
+    auto empty = n_workers > 1 && rank == n_workers - 1;
+    auto n_rows = empty ? 0 : 2;
+    auto n_columns = empty ? 0 : 1;
+    linalg::Matrix<float> values({n_rows, n_columns}, ctx.Device());
+    if (!empty) {
+      auto first = static_cast<float>(2 * rank);
+      auto h_values = values.HostView();
+      h_values(0, 0) = first;
+      h_values(1, 0) = first + 1.0f;
+    }
+    HostDeviceVector<float> weights;
+    HostDeviceVector<float> alphas{{0.25f, 0.5f, 0.75f}};
+    linalg::Vector<float> out;
+    RadixSelect(&ctx, values, weights, alphas, 3, &out);
+    auto h_out = out.HostView();
+    auto n_values = 2 * (n_workers > 1 ? n_workers - 1 : 1);
+    auto lower = static_cast<float>((n_values + 3) / 4 - 1);
+    auto median = static_cast<float>(n_values / 2 - 1);
+    auto upper = static_cast<float>((3 * n_values + 3) / 4 - 1);
+    ASSERT_EQ(h_out(0), lower);
+    ASSERT_EQ(h_out(1), median);
+    ASSERT_EQ(h_out(2), upper);
+  });
+}
+
+TEST(ObjectiveRadixSelect, DistributedAbsoluteError) {
+  auto n_workers = std::max(1u, std::min(4u, std::thread::hardware_concurrency()));
+  collective::TestDistributedGlobal(n_workers, [n_workers] {
+    auto rank = collective::GetRank();
+    Context ctx;
+    collective::GetWorkerLocalThreads(collective::GetWorldSize(), &ctx);
+    auto empty = n_workers > 1 && rank == n_workers - 1;
+
+    MetaInfo info;
+    info.num_row_ = empty ? 0 : 2;
+    info.labels.ModifyInplace(
+        [&](HostDeviceVector<float>* labels, common::Span<std::size_t> shape) {
+          labels->Resize(info.num_row_);
+          shape[0] = info.num_row_;
+          shape[1] = empty ? 0 : 1;
+          if (!empty) {
+            auto first = static_cast<float>(2 * rank);
+            labels->HostVector() = {first, first + 1.0f};
+          }
+        });
+
+    std::unique_ptr<ObjFunction> objective{ObjFunction::Create("reg:absoluteerror", &ctx)};
+    objective->Configure({});
+    linalg::Vector<float> base_score;
+    objective->InitEstimation(info, &base_score);
+
+    ASSERT_EQ(base_score.Size(), 1);
+    auto n_values = 2 * (n_workers > 1 ? n_workers - 1 : 1);
+    auto expected = static_cast<float>(n_values / 2 - 1);
+    ASSERT_EQ(base_score(0), expected);
+  });
+}
+}  // namespace xgboost::obj

--- a/tests/cpp/objective/test_radix_select.cc
+++ b/tests/cpp/objective/test_radix_select.cc
@@ -62,7 +62,8 @@ TEST(ObjectiveRadixSelect, Select) {
 }
 
 TEST(ObjectiveRadixSelect, Distributed) {
-  auto n_workers = std::max(1u, std::min(4u, std::thread::hardware_concurrency()));
+  auto n_workers =
+      static_cast<int>(std::max(1u, std::min(4u, std::thread::hardware_concurrency())));
   collective::TestDistributedGlobal(n_workers, [n_workers] {
     auto rank = collective::GetRank();
     Context ctx;
@@ -93,7 +94,8 @@ TEST(ObjectiveRadixSelect, Distributed) {
 }
 
 TEST(ObjectiveRadixSelect, DistributedAbsoluteError) {
-  auto n_workers = std::max(1u, std::min(4u, std::thread::hardware_concurrency()));
+  auto n_workers =
+      static_cast<int>(std::max(1u, std::min(4u, std::thread::hardware_concurrency())));
   collective::TestDistributedGlobal(n_workers, [n_workers] {
     auto rank = collective::GetRank();
     Context ctx;

--- a/tests/cpp/objective/test_radix_select.cc
+++ b/tests/cpp/objective/test_radix_select.cc
@@ -14,6 +14,7 @@
 #include "xgboost/context.h"             // for Context
 #include "xgboost/data.h"                // for MetaInfo
 #include "xgboost/host_device_vector.h"  // for HostDeviceVector
+#include "xgboost/learner.h"             // for Learner
 #include "xgboost/linalg.h"              // for Matrix, Vector
 #include "xgboost/objective.h"           // for ObjFunction
 
@@ -133,6 +134,30 @@ TEST(ObjectiveRadixSelect, DistributedAbsoluteError) {
     linalg::Matrix<GradientPair> gpair;
     objective->GetGradient(predictions, info, 0, &gpair);
     ASSERT_EQ(gpair.Shape(1), n_targets);
+  });
+}
+
+TEST(ObjectiveRadixSelect, DistributedAbsoluteErrorLearner) {
+  constexpr bst_target_t n_targets{3};
+  constexpr auto n_workers = 2;
+  collective::TestDistributedGlobal(n_workers, [n_workers, n_targets] {
+    auto rank = collective::GetRank();
+    auto empty = n_workers > 1 && rank == n_workers - 1;
+    auto Xy =
+        RandomDataGenerator{empty ? 0ul : 2ul, 1, 0.0f}.Targets(n_targets).GenerateDMatrix(!empty);
+
+    std::unique_ptr<Learner> learner{Learner::Create({Xy})};
+    learner->Configure({{"objective", "reg:absoluteerror"},
+                        {"tree_method", "hist"},
+                        {"max_depth", "1"},
+                        {"min_child_weight", "0"}});
+    learner->UpdateOneIter(0, Xy);
+
+    ASSERT_EQ(learner->Groups(), n_targets);
+    Json config{Object{}};
+    learner->SaveConfig(&config);
+    auto base_score = GetBaseScore(config);
+    ASSERT_EQ(base_score.size(), n_targets);
   });
 }
 

--- a/tests/cpp/objective/test_radix_select.cc
+++ b/tests/cpp/objective/test_radix_select.cc
@@ -94,9 +94,53 @@ TEST(ObjectiveRadixSelect, Distributed) {
 }
 
 TEST(ObjectiveRadixSelect, DistributedAbsoluteError) {
+  constexpr bst_target_t n_targets{3};
   auto n_workers =
       static_cast<int>(std::max(1u, std::min(4u, std::thread::hardware_concurrency())));
-  collective::TestDistributedGlobal(n_workers, [n_workers] {
+  collective::TestDistributedGlobal(n_workers, [n_workers, n_targets] {
+    auto rank = collective::GetRank();
+    Context ctx;
+    collective::GetWorkerLocalThreads(collective::GetWorldSize(), &ctx);
+    auto empty = n_workers > 1 && rank == n_workers - 1;
+
+    MetaInfo info;
+    info.num_row_ = empty ? 0 : 2;
+    info.labels.ModifyInplace(
+        [&](HostDeviceVector<float>* labels, common::Span<std::size_t> shape) {
+          labels->Resize(info.num_row_ * n_targets);
+          shape[0] = info.num_row_;
+          shape[1] = empty ? 0 : n_targets;
+          if (!empty) {
+            auto first = static_cast<float>(2 * rank);
+            labels->HostVector() = {first,        first + 100.0f, first + 200.0f,
+                                    first + 1.0f, first + 101.0f, first + 201.0f};
+          }
+        });
+
+    std::unique_ptr<ObjFunction> objective{ObjFunction::Create("reg:absoluteerror", &ctx)};
+    objective->Configure({});
+    linalg::Vector<float> base_score;
+    objective->InitEstimation(info, &base_score);
+
+    ASSERT_EQ(base_score.Size(), n_targets);
+    auto n_values = 2 * (n_workers > 1 ? n_workers - 1 : 1);
+    auto expected = static_cast<float>(n_values / 2 - 1);
+    for (bst_target_t target{0}; target < n_targets; ++target) {
+      ASSERT_EQ(base_score(target), expected + 100.0f * target);
+    }
+
+    HostDeviceVector<float> predictions(info.num_row_ * n_targets, 0.0f);
+    linalg::Matrix<GradientPair> gpair;
+    objective->GetGradient(predictions, info, 0, &gpair);
+    ASSERT_EQ(gpair.Shape(1), n_targets);
+  });
+}
+
+TEST(ObjectiveRadixSelect, DistributedQuantile) {
+  constexpr bst_target_t n_targets{3};
+  auto n_workers =
+      static_cast<int>(std::max(1u, std::min(4u, std::thread::hardware_concurrency())));
+  collective::TestDistributedGlobal(n_workers, [n_workers, n_targets] {
     auto rank = collective::GetRank();
     Context ctx;
     collective::GetWorkerLocalThreads(collective::GetWorldSize(), &ctx);
@@ -115,15 +159,21 @@ TEST(ObjectiveRadixSelect, DistributedAbsoluteError) {
           }
         });
 
-    std::unique_ptr<ObjFunction> objective{ObjFunction::Create("reg:absoluteerror", &ctx)};
-    objective->Configure({});
+    std::unique_ptr<ObjFunction> objective{ObjFunction::Create("reg:quantileerror", &ctx)};
+    objective->Configure({{"quantile_alpha", "[0.25, 0.5, 0.75]"}});
     linalg::Vector<float> base_score;
     objective->InitEstimation(info, &base_score);
 
-    ASSERT_EQ(base_score.Size(), 1);
+    ASSERT_EQ(base_score.Size(), n_targets);
     auto n_values = 2 * (n_workers > 1 ? n_workers - 1 : 1);
-    auto expected = static_cast<float>(n_values / 2 - 1);
-    ASSERT_EQ(base_score(0), expected);
+    ASSERT_EQ(base_score(0), static_cast<float>((n_values + 3) / 4 - 1));
+    ASSERT_EQ(base_score(1), static_cast<float>(n_values / 2 - 1));
+    ASSERT_EQ(base_score(2), static_cast<float>((3 * n_values + 3) / 4 - 1));
+
+    HostDeviceVector<float> predictions(info.num_row_ * n_targets, 0.0f);
+    linalg::Matrix<GradientPair> gpair;
+    objective->GetGradient(predictions, info, 0, &gpair);
+    ASSERT_EQ(gpair.Shape(1), n_targets);
   });
 }
 }  // namespace xgboost::obj

--- a/tests/cpp/objective/test_regression_obj.cc
+++ b/tests/cpp/objective/test_regression_obj.cc
@@ -446,37 +446,6 @@ void TestAbsoluteError(const Context* ctx) {
     ASSERT_NEAR(h_gpair(row, 1).GetHess(), curvature, kRtEps);
   }
 
-  auto expected_intercept = [](std::vector<float> const& labels,
-                               std::vector<float> const& weights) {
-    double sum_weight{0.0};
-    double mean{0.0};
-    for (std::size_t i{0}; i < labels.size(); ++i) {
-      auto const w = weights.empty() ? 1.0f : weights[i];
-      sum_weight += w;
-      mean += w * labels[i];
-    }
-    mean /= sum_weight;
-
-    double root_residual{0.0};
-    for (std::size_t i{0}; i < labels.size(); ++i) {
-      auto const w = weights.empty() ? 1.0f : weights[i];
-      root_residual += w * std::sqrt(std::abs(mean - labels[i]));
-    }
-    auto const delta = std::pow(root_residual / sum_weight, 2.0);
-
-    double sum_grad{0.0};
-    double sum_hess{0.0};
-    for (std::size_t i{0}; i < labels.size(); ++i) {
-      auto const w = weights.empty() ? 1.0f : weights[i];
-      auto const residual = mean - labels[i];
-      auto const norm = std::hypot(delta, residual);
-      auto const curvature = norm > 0.0 ? delta / norm : 1.0;
-      sum_grad += w * residual * curvature;
-      sum_hess += w * curvature;
-    }
-    return static_cast<float>(mean - sum_grad / sum_hess);
-  };
-
   auto init = [&](std::vector<float> labels, std::vector<float> const& weights) {
     MetaInfo init_info;
     init_info.num_row_ = labels.size();
@@ -490,11 +459,10 @@ void TestAbsoluteError(const Context* ctx) {
 
   for (auto const& weights : std::vector<std::vector<float>>{{}, {1.0f, 2.0f, 3.0f, 4.0f}}) {
     std::vector<float> labels{0.0f, 0.0f, 0.0f, 1000.0f};
-    auto const expected = expected_intercept(labels, weights);
-    ASSERT_NEAR(init(labels, weights), expected, 1.0e-4f);
+    ASSERT_EQ(init(labels, weights), 0.0f);
     std::transform(labels.cbegin(), labels.cend(), labels.begin(),
                    [](float label) { return label + 1000.0f; });
-    ASSERT_NEAR(init(labels, weights), expected + 1000.0f, 1.0e-4f);
+    ASSERT_EQ(init(labels, weights), 1000.0f);
   }
   ASSERT_EQ(obj->DefaultEvalMetric(), std::string{"mae"});
 }

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -950,6 +950,9 @@ def test_empty_dmatrix(tree_method: str, client: "Client") -> None:
     run_empty_dmatrix_cls(client, parameters)
     parameters = {"tree_method": tree_method, "objective": "reg:absoluteerror"}
     run_empty_dmatrix_reg(client, parameters)
+    parameters = {"tree_method": tree_method, "objective": "reg:quantileerror"}
+    parameters["quantile_alpha"] = 0.5
+    run_empty_dmatrix_reg(client, parameters)
 
 
 async def run_from_dask_array_asyncio(scheduler_address: str) -> dxgb.TrainReturnT:
@@ -1573,14 +1576,8 @@ class TestWithDask:
                 )
                 config = json.loads(booster.save_config())
                 base_score = get_basescore(config)
-                mean = 250.0
-                residuals = np.array([mean, mean, mean, mean - 1000.0])
-                delta = np.mean(np.sqrt(np.abs(residuals))) ** 2
-                curvature = delta / np.hypot(delta, residuals)
-                expected_base_score = mean - np.sum(residuals * curvature) / np.sum(
-                    curvature
-                )
-                np.testing.assert_allclose(base_score, [expected_base_score], rtol=1e-5)
+                # Exact absolute-error initialization uses the lower weighted median.
+                np.testing.assert_allclose(base_score, [0.0], rtol=1e-5)
 
                 # The smooth approximation scale must be global. Worker 0 has only zero
                 # residuals while worker 1 has one residual of -1000. A local scale would

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -735,17 +735,27 @@ def test_empty_dmatrix_training_continuation(client: "Client") -> None:
     assert dxgb.predict(client, out, dtrain).compute().shape[0] == 1
 
 
-def run_empty_dmatrix_reg(client: "Client", parameters: dict) -> None:
+def run_empty_dmatrix_reg(
+    client: "Client", parameters: Dict[str, Any], n_targets: int = 1
+) -> None:
+    def _make_labels(n_rows: int) -> Any:
+        labels = np.random.rand(n_rows, n_targets)
+        if n_targets == 1:
+            labels = labels[:, 0]
+        return dd.from_array(labels)
+
     def _check_outputs(out: dxgb.TrainReturnT, predictions: np.ndarray) -> None:
         assert isinstance(out["booster"], dxgb.Booster)
         for _, v in out["history"]["validation"].items():
             assert len(v) == 2
         assert isinstance(predictions, np.ndarray)
         assert predictions.shape[0] == 1
+        if n_targets > 1:
+            assert predictions.shape[1] == n_targets
 
     kRows, kCols = 1, 97
     X = dd.from_array(np.random.randn(kRows, kCols))
-    y = dd.from_array(np.random.rand(kRows))
+    y = _make_labels(kRows)
     dtrain = dxgb.DaskDMatrix(client, X, y)
 
     out = dxgb.train(
@@ -761,7 +771,7 @@ def run_empty_dmatrix_reg(client: "Client", parameters: dict) -> None:
     # valid has more rows than train
     kRows += 1
     X = dd.from_array(np.random.randn(kRows, kCols))
-    y = dd.from_array(np.random.rand(kRows))
+    y = _make_labels(kRows)
     valid = dxgb.DaskDMatrix(client, X, y)
     out = dxgb.train(
         client,
@@ -777,7 +787,7 @@ def run_empty_dmatrix_reg(client: "Client", parameters: dict) -> None:
     valid = dtrain
     kRows += 1
     X = dd.from_array(np.random.randn(kRows, kCols))
-    y = dd.from_array(np.random.rand(kRows))
+    y = _make_labels(kRows)
     dtrain = dxgb.DaskDMatrix(client, X, y)
 
     out = dxgb.train(
@@ -950,6 +960,7 @@ def test_empty_dmatrix(tree_method: str, client: "Client") -> None:
     run_empty_dmatrix_cls(client, parameters)
     parameters = {"tree_method": tree_method, "objective": "reg:absoluteerror"}
     run_empty_dmatrix_reg(client, parameters)
+    run_empty_dmatrix_reg(client, parameters, n_targets=3)
     run_empty_dmatrix_reg(
         client,
         {

--- a/tests/test_distributed/test_with_dask/test_with_dask.py
+++ b/tests/test_distributed/test_with_dask/test_with_dask.py
@@ -950,9 +950,14 @@ def test_empty_dmatrix(tree_method: str, client: "Client") -> None:
     run_empty_dmatrix_cls(client, parameters)
     parameters = {"tree_method": tree_method, "objective": "reg:absoluteerror"}
     run_empty_dmatrix_reg(client, parameters)
-    parameters = {"tree_method": tree_method, "objective": "reg:quantileerror"}
-    parameters["quantile_alpha"] = 0.5
-    run_empty_dmatrix_reg(client, parameters)
+    run_empty_dmatrix_reg(
+        client,
+        {
+            "tree_method": tree_method,
+            "objective": "reg:quantileerror",
+            "quantile_alpha": 0.5,
+        },
+    )
 
 
 async def run_from_dask_array_asyncio(scheduler_address: str) -> dxgb.TrainReturnT:


### PR DESCRIPTION
## Summary

Replace the approximate intercept estimation for `reg:absoluteerror` and
`reg:quantileerror` with exact float32 weighted quantile selection.

The implementation introduces an objective-local radix-selection kernel with
separate CPU and CUDA implementations. Other devices use the existing CPU
kernel fallback.

## Motivation

The optimal intercept for absolute error is a weighted median. More generally,
each quantile objective has a weighted quantile as its optimal intercept.

The previous implementation approximated these intercepts using a mean followed
by one gradient/Hessian update. The result was not generally the optimum.

Sorting the labels would find the optimum, but requires `O(n log n)` work and is
awkward on GPUs and distributed workers. Since labels are stored as float32, the
selected value can instead be recovered in four 8-bit radix passes.

Each pass:

1. Builds a weighted 256-bin histogram for the next byte of each candidate.
2. Sums the histogram across distributed workers.
3. Selects the bin containing the requested cumulative weight.
4. Retains that prefix and refines the remaining rank.

After four passes, the selected 32-bit key identifies the exact input value.
The input is never sorted or modified.

The output count is passed independently of the local label shape. This allows
workers holding an empty, label-less DMatrix to allocate matching histograms
and participate in every collective operation.

## Performance

Measured on 20 million rows with one feature. Intercept cost is the difference
between one-round training with automatic estimation and training with an
explicit `base_score`.

| Device | Label distribution | Objective | Intercept cost |
|---|---|---|---:|
| GPU | Clustered in `[100, 1000)` | `reg:absoluteerror` | 15 ms |
| GPU | Clustered in `[100, 1000)` | `reg:quantileerror`, 3 alphas | 18 ms |
| GPU | Spread, `N(0, 1e10)` | `reg:absoluteerror` | 7 ms |
| CPU, 32 threads | Clustered in `[100, 1000)` | `reg:absoluteerror` | 27 ms |
| CPU, 32 threads | Clustered in `[100, 1000)` | `reg:quantileerror`, 3 alphas | 65 ms |

The clustered distribution is a difficult case for the CUDA implementation
because many rows contend for the same pass-0 histogram bins.

## Tests

- CPU and CUDA radix-selection tests
- Weighted and unweighted quantiles
- Multiple columns and quantile levels
- Zero total weight
- Distributed selection with an empty worker
- Distributed absolute-error initialization with a `0 x 0` label matrix
- CPU and GPU absolute-error and quantile intercept tests
- Python adaptive-tree intercept tests
