### PR TITLE
Begin converting metrics to the kernel abstraction

### DIFF
--- a/src/metric/elementwise_metric.cc
+++ b/src/metric/elementwise_metric.cc
@@ -1,62 +1,7 @@
-/**
- * Copyright 2015-2026, XGBoost Contributors
- * \file elementwise_metric.cc
- * \brief Elementwise metric definitions and CPU kernel registrations.
- * \author Kailong Chen, Tianqi Chen
+/*!
+ * Copyright 2018 XGBoost contributors
  */
-#include "elementwise_metric.h"
-
-#include <dmlc/registry.h>
-
-#include <array>  // for array
-
-#include "../collective/aggregator.h"   // for GlobalSum
-#include "../common/kernel.h"           // for DispatchKernel
-#include "metric_common.h"              // for MetricNoCache
-#include "xgboost/collective/result.h"  // for SafeColl
-#include "xgboost/metric.h"             // for Metric
-
-namespace xgboost::metric {
-DMLC_REGISTRY_FILE_TAG(elementwise_metric);
-
-namespace {
-auto const kRegisterRMSECpu = elementwise::RegisterEvalCpu<EvalRowRMSE>();
-auto const kRegisterRMSLECpu = elementwise::RegisterEvalCpu<EvalRowRMSLE>();
-}  // namespace
-
-template <typename Policy>
-class EvalEWiseKernelBase : public MetricNoCache {
- public:
-  double Eval(HostDeviceVector<bst_float> const& preds, MetaInfo const& info) override {
-    CHECK_EQ(preds.Size(), info.labels.Size())
-        << "label and prediction size not match, "
-        << "hint: use merror or mlogloss for multi-class classification";
-    if (info.labels.Size() != 0) {
-      CHECK_NE(info.labels.Shape(1), 0);
-    }
-
-    auto result =
-        common::DispatchKernel<elementwise::EvalKernel<Policy>>(ctx_, preds, info, policy_);
-    std::array<double, 2> values{result.Residue(), result.Weights()};
-    auto rc = collective::GlobalSum(ctx_, linalg::MakeVec(values.data(), values.size()));
-    collective::SafeColl(rc);
-    return Policy::GetFinal(values[0], values[1]);
-  }
-
-  [[nodiscard]] char const* Name() const override { return policy_.Name(); }
-
- private:
-  Policy policy_;
-};
-
-XGBOOST_REGISTER_METRIC(RMSE, "rmse")
-    .describe("Rooted mean square error.")
-    .set_body([](char const*) { return new EvalEWiseKernelBase<EvalRowRMSE>(); });
-
-XGBOOST_REGISTER_METRIC(RMSLE, "rmsle")
-    .describe("Rooted mean square log error.")
-    .set_body([](char const*) { return new EvalEWiseKernelBase<EvalRowRMSLE>(); });
-}  // namespace xgboost::metric
+// Dummy file to keep the CUDA conditional compile trick.
 
 #if !defined(XGBOOST_USE_CUDA)
 #include "elementwise_metric.cu"

--- a/src/metric/elementwise_metric.cc
+++ b/src/metric/elementwise_metric.cc
@@ -1,7 +1,62 @@
-/*!
- * Copyright 2018 XGBoost contributors
+/**
+ * Copyright 2015-2026, XGBoost Contributors
+ * \file elementwise_metric.cc
+ * \brief Elementwise metric definitions and CPU kernel registrations.
+ * \author Kailong Chen, Tianqi Chen
  */
-// Dummy file to keep the CUDA conditional compile trick.
+#include "elementwise_metric.h"
+
+#include <dmlc/registry.h>
+
+#include <array>  // for array
+
+#include "../collective/aggregator.h"   // for GlobalSum
+#include "../common/kernel.h"           // for DispatchKernel
+#include "metric_common.h"              // for MetricNoCache
+#include "xgboost/collective/result.h"  // for SafeColl
+#include "xgboost/metric.h"             // for Metric
+
+namespace xgboost::metric {
+DMLC_REGISTRY_FILE_TAG(elementwise_metric);
+
+namespace {
+auto const kRegisterRMSECpu = elementwise::RegisterEvalCpu<EvalRowRMSE>();
+auto const kRegisterRMSLECpu = elementwise::RegisterEvalCpu<EvalRowRMSLE>();
+}  // namespace
+
+template <typename Policy>
+class EvalEWiseKernelBase : public MetricNoCache {
+ public:
+  double Eval(HostDeviceVector<bst_float> const& preds, MetaInfo const& info) override {
+    CHECK_EQ(preds.Size(), info.labels.Size())
+        << "label and prediction size not match, "
+        << "hint: use merror or mlogloss for multi-class classification";
+    if (info.labels.Size() != 0) {
+      CHECK_NE(info.labels.Shape(1), 0);
+    }
+
+    auto result =
+        common::DispatchKernel<elementwise::EvalKernel<Policy>>(ctx_, preds, info, policy_);
+    std::array<double, 2> values{result.Residue(), result.Weights()};
+    auto rc = collective::GlobalSum(ctx_, linalg::MakeVec(values.data(), values.size()));
+    collective::SafeColl(rc);
+    return Policy::GetFinal(values[0], values[1]);
+  }
+
+  [[nodiscard]] char const* Name() const override { return policy_.Name(); }
+
+ private:
+  Policy policy_;
+};
+
+XGBOOST_REGISTER_METRIC(RMSE, "rmse")
+    .describe("Rooted mean square error.")
+    .set_body([](char const*) { return new EvalEWiseKernelBase<EvalRowRMSE>(); });
+
+XGBOOST_REGISTER_METRIC(RMSLE, "rmsle")
+    .describe("Rooted mean square log error.")
+    .set_body([](char const*) { return new EvalEWiseKernelBase<EvalRowRMSLE>(); });
+}  // namespace xgboost::metric
 
 #if !defined(XGBOOST_USE_CUDA)
 #include "elementwise_metric.cu"

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -8,6 +8,11 @@
  */
 #include <dmlc/registry.h>
 
+#include "elementwise_metric.h"
+#if defined(XGBOOST_USE_CUDA)
+#include "elementwise_metric.cuh"
+#endif  // defined(XGBOOST_USE_CUDA)
+
 #include <array>
 #include <cmath>
 #include <numeric>  // for accumulate
@@ -35,8 +40,14 @@
 #endif                         // XGBOOST_USE_CUDA
 
 namespace xgboost::metric {
-// tag the this file, used by force static link later.
-DMLC_REGISTRY_FILE_TAG(elementwise_metric);
+#if defined(XGBOOST_USE_CUDA)
+DMLC_REGISTRY_FILE_TAG(elementwise_metric_cuda);
+
+namespace {
+auto const kRegisterRMSECuda = elementwise::RegisterEvalCuda<EvalRowRMSE>();
+auto const kRegisterRMSLECuda = elementwise::RegisterEvalCuda<EvalRowRMSLE>();
+}  // namespace
+#endif  // defined(XGBOOST_USE_CUDA)
 
 namespace {
 /**
@@ -105,30 +116,6 @@ PackedReduceResult Reduce(Context const* ctx, MetaInfo const& info, Fn&& loss,
   return result;
 }
 }  // anonymous namespace
-
-struct EvalRowRMSE {
-  char const* Name() const { return "rmse"; }
-
-  XGBOOST_DEVICE bst_float EvalRow(bst_float label, bst_float pred) const {
-    bst_float diff = label - pred;
-    return diff * diff;
-  }
-  static double GetFinal(double esum, double wsum) {
-    return wsum == 0 ? std::sqrt(esum) : std::sqrt(esum / wsum);
-  }
-};
-
-struct EvalRowRMSLE {
-  char const* Name() const { return "rmsle"; }
-
-  XGBOOST_DEVICE bst_float EvalRow(bst_float label, bst_float pred) const {
-    bst_float diff = std::log1p(label) - std::log1p(pred);
-    return diff * diff;
-  }
-  static double GetFinal(double esum, double wsum) {
-    return wsum == 0 ? std::sqrt(esum) : std::sqrt(esum / wsum);
-  }
-};
 
 struct EvalRowMAE {
   const char* Name() const { return "mae"; }
@@ -366,14 +353,6 @@ struct EvalEWiseBase : public MetricNoCache {
  private:
   Policy policy_;
 };
-
-XGBOOST_REGISTER_METRIC(RMSE, "rmse")
-    .describe("Rooted mean square error.")
-    .set_body([](const char*) { return new EvalEWiseBase<EvalRowRMSE>(); });
-
-XGBOOST_REGISTER_METRIC(RMSLE, "rmsle")
-    .describe("Rooted mean square log error.")
-    .set_body([](const char*) { return new EvalEWiseBase<EvalRowRMSLE>(); });
 
 XGBOOST_REGISTER_METRIC(MAE, "mae").describe("Mean absolute error.").set_body([](const char*) {
   return new EvalEWiseBase<EvalRowMAE>();

--- a/src/metric/elementwise_metric.cu
+++ b/src/metric/elementwise_metric.cu
@@ -8,11 +8,6 @@
  */
 #include <dmlc/registry.h>
 
-#include "elementwise_metric.h"
-#if defined(XGBOOST_USE_CUDA)
-#include "elementwise_metric.cuh"
-#endif  // defined(XGBOOST_USE_CUDA)
-
 #include <array>
 #include <cmath>
 #include <numeric>  // for accumulate
@@ -40,14 +35,8 @@
 #endif                         // XGBOOST_USE_CUDA
 
 namespace xgboost::metric {
-#if defined(XGBOOST_USE_CUDA)
-DMLC_REGISTRY_FILE_TAG(elementwise_metric_cuda);
-
-namespace {
-auto const kRegisterRMSECuda = elementwise::RegisterEvalCuda<EvalRowRMSE>();
-auto const kRegisterRMSLECuda = elementwise::RegisterEvalCuda<EvalRowRMSLE>();
-}  // namespace
-#endif  // defined(XGBOOST_USE_CUDA)
+// tag the this file, used by force static link later.
+DMLC_REGISTRY_FILE_TAG(elementwise_metric);
 
 namespace {
 /**

--- a/src/metric/elementwise_metric.cuh
+++ b/src/metric/elementwise_metric.cuh
@@ -1,7 +1,7 @@
 /**
- * Copyright 2015-2026, XGBoost Contributors
+ * Copyright 2026, XGBoost Contributors
  * \file elementwise_metric.cuh
- * \brief CUDA kernels for elementwise metrics.
+ * \brief CUDA implementations of the typed elementwise metric kernels.
  */
 #ifndef XGBOOST_METRIC_ELEMENTWISE_METRIC_CUH_
 #define XGBOOST_METRIC_ELEMENTWISE_METRIC_CUH_
@@ -16,18 +16,14 @@
 #include "../common/kernel.h"           // for KernelRegistration
 #include "../common/optional_weight.h"  // for MakeOptionalWeights
 #include "elementwise_metric.h"
-#include "xgboost/context.h"             // for Context, DeviceOrd
-#include "xgboost/host_device_vector.h"  // for HostDeviceVector
-#include "xgboost/linalg.h"              // for UnravelIndex
 
 namespace xgboost::metric::elementwise {
 namespace detail {
-template <typename Policy>
+template <typename EvalFn>
 PackedReduceResult EvalCuda(Context const* ctx, HostDeviceVector<float> const& preds,
-                            MetaInfo const& info, Policy policy) {
+                            MetaInfo const& info, EvalFn eval) {
   auto device = ctx->Device();
   CHECK(device.IsCUDA());
-  CheckRowWeights(info);
 
   auto labels = info.labels.View(device);
   preds.SetDevice(device);
@@ -41,17 +37,17 @@ PackedReduceResult EvalCuda(Context const* ctx, HostDeviceVector<float> const& p
       [=] XGBOOST_DEVICE(std::size_t i) {
         auto [sample_id, target_id] = linalg::UnravelIndex(i, labels.Shape());
         float weight = weights[sample_id];
-        float residue = policy.EvalRow(labels(sample_id, target_id), predts[i]) * weight;
+        float residue = eval(labels(sample_id, target_id), predts[i]) * weight;
         return PackedReduceResult{residue, weight};
       },
       PackedReduceResult{}, thrust::plus<PackedReduceResult>());
 }
 }  // namespace detail
 
-template <typename Policy>
+template <typename EvalFn>
 auto RegisterEvalCuda() {
-  using Kernel = EvalKernel<Policy>;
-  return common::KernelRegistration<Kernel>{DeviceOrd::kCUDA, &detail::EvalCuda<Policy>};
+  using Kernel = EvalKernel<EvalFn>;
+  return common::KernelRegistration<Kernel>{DeviceOrd::kCUDA, &detail::EvalCuda<EvalFn>};
 }
 }  // namespace xgboost::metric::elementwise
 

--- a/src/metric/elementwise_metric.cuh
+++ b/src/metric/elementwise_metric.cuh
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015-2026, XGBoost Contributors
+ * \file elementwise_metric.cuh
+ * \brief CUDA kernels for elementwise metrics.
+ */
+#ifndef XGBOOST_METRIC_ELEMENTWISE_METRIC_CUH_
+#define XGBOOST_METRIC_ELEMENTWISE_METRIC_CUH_
+
+#include <thrust/functional.h>                  // for plus
+#include <thrust/iterator/counting_iterator.h>  // for counting_iterator
+#include <thrust/transform_reduce.h>            // for transform_reduce
+
+#include <cstddef>  // for size_t
+
+#include "../common/cuda_context.cuh"   // for CUDAContext
+#include "../common/kernel.h"           // for KernelRegistration
+#include "../common/optional_weight.h"  // for MakeOptionalWeights
+#include "elementwise_metric.h"
+#include "xgboost/context.h"             // for Context, DeviceOrd
+#include "xgboost/host_device_vector.h"  // for HostDeviceVector
+#include "xgboost/linalg.h"              // for UnravelIndex
+
+namespace xgboost::metric::elementwise {
+namespace detail {
+template <typename Policy>
+PackedReduceResult EvalCuda(Context const* ctx, HostDeviceVector<float> const& preds,
+                            MetaInfo const& info, Policy policy) {
+  auto device = ctx->Device();
+  CHECK(device.IsCUDA());
+  CheckRowWeights(info);
+
+  auto labels = info.labels.View(device);
+  preds.SetDevice(device);
+  auto predts = preds.ConstDeviceSpan();
+  auto weights = common::MakeOptionalWeights(device, info.weights_);
+
+  thrust::counting_iterator<std::size_t> begin{0};
+  auto end = begin + labels.Size();
+  return thrust::transform_reduce(
+      ctx->CUDACtx()->CTP(), begin, end,
+      [=] XGBOOST_DEVICE(std::size_t i) {
+        auto [sample_id, target_id] = linalg::UnravelIndex(i, labels.Shape());
+        float weight = weights[sample_id];
+        float residue = policy.EvalRow(labels(sample_id, target_id), predts[i]) * weight;
+        return PackedReduceResult{residue, weight};
+      },
+      PackedReduceResult{}, thrust::plus<PackedReduceResult>());
+}
+}  // namespace detail
+
+template <typename Policy>
+auto RegisterEvalCuda() {
+  using Kernel = EvalKernel<Policy>;
+  return common::KernelRegistration<Kernel>{DeviceOrd::kCUDA, &detail::EvalCuda<Policy>};
+}
+}  // namespace xgboost::metric::elementwise
+
+#endif  // XGBOOST_METRIC_ELEMENTWISE_METRIC_CUH_

--- a/src/metric/elementwise_metric.h
+++ b/src/metric/elementwise_metric.h
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2015-2026, XGBoost Contributors
+ * \file elementwise_metric.h
+ * \brief Shared declarations and CPU kernels for elementwise metrics.
+ */
+#ifndef XGBOOST_METRIC_ELEMENTWISE_METRIC_H_
+#define XGBOOST_METRIC_ELEMENTWISE_METRIC_H_
+
+#include <cmath>    // for log1p, sqrt
+#include <cstddef>  // for size_t
+#include <numeric>  // for accumulate
+#include <vector>   // for vector
+
+#include "../common/kernel.h"            // for KernelRegistration
+#include "../common/optional_weight.h"   // for OptionalWeights
+#include "../common/threading_utils.h"   // for ParallelFor1d
+#include "metric_common.h"               // for CheckRowWeights, PackedReduceResult
+#include "xgboost/base.h"                // for bst_float
+#include "xgboost/context.h"             // for Context, DeviceOrd
+#include "xgboost/data.h"                // for MetaInfo
+#include "xgboost/host_device_vector.h"  // for HostDeviceVector
+#include "xgboost/linalg.h"              // for UnravelIndex
+
+namespace xgboost::metric {
+struct EvalRowRMSE {
+  char const* Name() const { return "rmse"; }
+
+  XGBOOST_DEVICE bst_float EvalRow(bst_float label, bst_float pred) const {
+    bst_float diff = label - pred;
+    return diff * diff;
+  }
+  static double GetFinal(double esum, double wsum) {
+    return wsum == 0 ? std::sqrt(esum) : std::sqrt(esum / wsum);
+  }
+};
+
+struct EvalRowRMSLE {
+  char const* Name() const { return "rmsle"; }
+
+  XGBOOST_DEVICE bst_float EvalRow(bst_float label, bst_float pred) const {
+    bst_float diff = std::log1p(label) - std::log1p(pred);
+    return diff * diff;
+  }
+  static double GetFinal(double esum, double wsum) {
+    return wsum == 0 ? std::sqrt(esum) : std::sqrt(esum / wsum);
+  }
+};
+
+namespace elementwise {
+template <typename Policy>
+struct EvalKernel {
+  using Signature = PackedReduceResult(Context const*, HostDeviceVector<float> const&,
+                                       MetaInfo const&, Policy);
+};
+
+namespace detail {
+template <typename Policy>
+PackedReduceResult EvalCpu(Context const* ctx, HostDeviceVector<float> const& preds,
+                           MetaInfo const& info, Policy policy) {
+  CheckRowWeights(info);
+  auto labels = info.labels.HostView();
+  auto predts = preds.ConstHostSpan();
+  common::OptionalWeights weights{info.weights_.ConstHostSpan()};
+
+  auto n_threads = ctx->Threads();
+  std::vector<double> score_tloc(n_threads, 0.0);
+  std::vector<double> weight_tloc(n_threads, 0.0);
+  std::size_t constexpr kBlockSize = 2048;
+  common::ParallelFor1d<kBlockSize>(labels.Size(), n_threads, [&](auto&& block) {
+    double sum_score = 0.0;
+    double sum_weight = 0.0;
+    for (std::size_t i = block.begin(), n = block.end(); i < n; ++i) {
+      auto [sample_id, target_id] = linalg::UnravelIndex(i, labels.Shape());
+      float weight = weights[sample_id];
+      float residue = policy.EvalRow(labels(sample_id, target_id), predts[i]) * weight;
+      sum_score += residue;
+      sum_weight += weight;
+    }
+
+    auto t_idx = omp_get_thread_num();
+    score_tloc[t_idx] += sum_score;
+    weight_tloc[t_idx] += sum_weight;
+  });
+
+  auto residue_sum = std::accumulate(score_tloc.cbegin(), score_tloc.cend(), 0.0);
+  auto weights_sum = std::accumulate(weight_tloc.cbegin(), weight_tloc.cend(), 0.0);
+  return PackedReduceResult{residue_sum, weights_sum};
+}
+}  // namespace detail
+
+template <typename Policy>
+auto RegisterEvalCpu() {
+  using Kernel = EvalKernel<Policy>;
+  return common::KernelRegistration<Kernel>{DeviceOrd::kCPU, &detail::EvalCpu<Policy>};
+}
+}  // namespace elementwise
+}  // namespace xgboost::metric
+
+#endif  // XGBOOST_METRIC_ELEMENTWISE_METRIC_H_

--- a/src/metric/elementwise_metric.h
+++ b/src/metric/elementwise_metric.h
@@ -1,12 +1,11 @@
 /**
- * Copyright 2015-2026, XGBoost Contributors
+ * Copyright 2026, XGBoost Contributors
  * \file elementwise_metric.h
- * \brief Shared declarations and CPU kernels for elementwise metrics.
+ * \brief Typed elementwise metric kernels and CPU implementations.
  */
 #ifndef XGBOOST_METRIC_ELEMENTWISE_METRIC_H_
 #define XGBOOST_METRIC_ELEMENTWISE_METRIC_H_
 
-#include <cmath>    // for log1p, sqrt
 #include <cstddef>  // for size_t
 #include <numeric>  // for accumulate
 #include <vector>   // for vector
@@ -14,50 +13,23 @@
 #include "../common/kernel.h"            // for KernelRegistration
 #include "../common/optional_weight.h"   // for OptionalWeights
 #include "../common/threading_utils.h"   // for ParallelFor1d
-#include "metric_common.h"               // for CheckRowWeights, PackedReduceResult
-#include "xgboost/base.h"                // for bst_float
+#include "metric_common.h"               // for PackedReduceResult
 #include "xgboost/context.h"             // for Context, DeviceOrd
 #include "xgboost/data.h"                // for MetaInfo
 #include "xgboost/host_device_vector.h"  // for HostDeviceVector
 #include "xgboost/linalg.h"              // for UnravelIndex
 
-namespace xgboost::metric {
-struct EvalRowRMSE {
-  char const* Name() const { return "rmse"; }
-
-  XGBOOST_DEVICE bst_float EvalRow(bst_float label, bst_float pred) const {
-    bst_float diff = label - pred;
-    return diff * diff;
-  }
-  static double GetFinal(double esum, double wsum) {
-    return wsum == 0 ? std::sqrt(esum) : std::sqrt(esum / wsum);
-  }
-};
-
-struct EvalRowRMSLE {
-  char const* Name() const { return "rmsle"; }
-
-  XGBOOST_DEVICE bst_float EvalRow(bst_float label, bst_float pred) const {
-    bst_float diff = std::log1p(label) - std::log1p(pred);
-    return diff * diff;
-  }
-  static double GetFinal(double esum, double wsum) {
-    return wsum == 0 ? std::sqrt(esum) : std::sqrt(esum / wsum);
-  }
-};
-
-namespace elementwise {
-template <typename Policy>
+namespace xgboost::metric::elementwise {
+template <typename EvalFn>
 struct EvalKernel {
   using Signature = PackedReduceResult(Context const*, HostDeviceVector<float> const&,
-                                       MetaInfo const&, Policy);
+                                       MetaInfo const&, EvalFn);
 };
 
 namespace detail {
-template <typename Policy>
+template <typename EvalFn>
 PackedReduceResult EvalCpu(Context const* ctx, HostDeviceVector<float> const& preds,
-                           MetaInfo const& info, Policy policy) {
-  CheckRowWeights(info);
+                           MetaInfo const& info, EvalFn eval) {
   auto labels = info.labels.HostView();
   auto predts = preds.ConstHostSpan();
   common::OptionalWeights weights{info.weights_.ConstHostSpan()};
@@ -72,7 +44,7 @@ PackedReduceResult EvalCpu(Context const* ctx, HostDeviceVector<float> const& pr
     for (std::size_t i = block.begin(), n = block.end(); i < n; ++i) {
       auto [sample_id, target_id] = linalg::UnravelIndex(i, labels.Shape());
       float weight = weights[sample_id];
-      float residue = policy.EvalRow(labels(sample_id, target_id), predts[i]) * weight;
+      float residue = eval(labels(sample_id, target_id), predts[i]) * weight;
       sum_score += residue;
       sum_weight += weight;
     }
@@ -88,12 +60,11 @@ PackedReduceResult EvalCpu(Context const* ctx, HostDeviceVector<float> const& pr
 }
 }  // namespace detail
 
-template <typename Policy>
+template <typename EvalFn>
 auto RegisterEvalCpu() {
-  using Kernel = EvalKernel<Policy>;
-  return common::KernelRegistration<Kernel>{DeviceOrd::kCPU, &detail::EvalCpu<Policy>};
+  using Kernel = EvalKernel<EvalFn>;
+  return common::KernelRegistration<Kernel>{DeviceOrd::kCPU, &detail::EvalCpu<EvalFn>};
 }
-}  // namespace elementwise
-}  // namespace xgboost::metric
+}  // namespace xgboost::metric::elementwise
 
 #endif  // XGBOOST_METRIC_ELEMENTWISE_METRIC_H_

--- a/src/metric/metric.cc
+++ b/src/metric/metric.cc
@@ -25,7 +25,7 @@ Metric* CreateMetricImpl(const std::string& name) {
       prefix = buf;
       param = nullptr;
     }
-    auto *e = ::dmlc::Registry<MetricRegistry>::Get()->Find(prefix.c_str());
+    auto* e = ::dmlc::Registry<MetricRegistry>::Get()->Find(prefix.c_str());
     if (e == nullptr) {
       return nullptr;
     }
@@ -33,7 +33,7 @@ Metric* CreateMetricImpl(const std::string& name) {
     return p_metric;
   } else {
     std::string prefix = buf.substr(0, pos);
-    auto *e = ::dmlc::Registry<MetricRegistry>::Get()->Find(prefix.c_str());
+    auto* e = ::dmlc::Registry<MetricRegistry>::Get()->Find(prefix.c_str());
     if (e == nullptr) {
       return nullptr;
     }
@@ -42,8 +42,7 @@ Metric* CreateMetricImpl(const std::string& name) {
   }
 }
 
-Metric *
-Metric::Create(const std::string& name, Context const* ctx) {
+Metric* Metric::Create(const std::string& name, Context const* ctx) {
   auto metric = CreateMetricImpl<MetricReg>(name);
   if (metric == nullptr) {
     LOG(FATAL) << "Unknown metric function " << name;

--- a/src/metric/metric.cc
+++ b/src/metric/metric.cc
@@ -67,6 +67,7 @@ DMLC_REGISTRY_LINK_TAG(survival_metric);
 DMLC_REGISTRY_LINK_TAG(rank_metric);
 #ifdef XGBOOST_USE_CUDA
 DMLC_REGISTRY_LINK_TAG(auc_gpu);
+DMLC_REGISTRY_LINK_TAG(elementwise_metric_cuda);
 DMLC_REGISTRY_LINK_TAG(rank_metric_gpu);
 #endif
 }  // namespace xgboost::metric

--- a/src/metric/metric.cc
+++ b/src/metric/metric.cc
@@ -62,12 +62,13 @@ namespace xgboost::metric {
 // List of files that will be force linked in static links.
 DMLC_REGISTRY_LINK_TAG(auc);
 DMLC_REGISTRY_LINK_TAG(elementwise_metric);
+DMLC_REGISTRY_LINK_TAG(rmse_metric);
 DMLC_REGISTRY_LINK_TAG(multiclass_metric);
 DMLC_REGISTRY_LINK_TAG(survival_metric);
 DMLC_REGISTRY_LINK_TAG(rank_metric);
 #ifdef XGBOOST_USE_CUDA
 DMLC_REGISTRY_LINK_TAG(auc_gpu);
-DMLC_REGISTRY_LINK_TAG(elementwise_metric_cuda);
+DMLC_REGISTRY_LINK_TAG(rmse_metric_cuda);
 DMLC_REGISTRY_LINK_TAG(rank_metric_gpu);
 #endif
 }  // namespace xgboost::metric

--- a/src/metric/rmse_metric.cc
+++ b/src/metric/rmse_metric.cc
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file rmse_metric.cc
+ * \brief CPU implementation and registration of the RMSE and RMSLE metrics.
+ */
+#include "rmse_metric.h"
+
+#include <dmlc/registry.h>
+
+#include <array>  // for array
+
+#include "../collective/aggregator.h"   // for GlobalSum
+#include "../common/kernel.h"           // for DispatchKernel
+#include "metric_common.h"              // for CheckRowWeights, MetricNoCache
+#include "xgboost/collective/result.h"  // for SafeColl
+#include "xgboost/metric.h"             // for Metric
+
+namespace xgboost::metric {
+DMLC_REGISTRY_FILE_TAG(rmse_metric);
+
+namespace {
+auto const kRegisterRMSECpu = elementwise::RegisterEvalCpu<EvalRowRMSE>();
+auto const kRegisterRMSLECpu = elementwise::RegisterEvalCpu<EvalRowRMSLE>();
+}  // namespace
+
+template <typename EvalFn, typename Kernel>
+class EvalEWiseMetric : public MetricNoCache {
+ public:
+  double Eval(HostDeviceVector<bst_float> const& preds, MetaInfo const& info) override {
+    CHECK_EQ(preds.Size(), info.labels.Size())
+        << "label and prediction size not match, "
+        << "hint: use merror or mlogloss for multi-class classification";
+    if (info.labels.Size() != 0) {
+      CHECK_NE(info.labels.Shape(1), 0);
+    }
+    CheckRowWeights(info);
+
+    auto result = common::DispatchKernel<Kernel>(ctx_, preds, info, eval_);
+    std::array<double, 2> values{result.Residue(), result.Weights()};
+    auto rc = collective::GlobalSum(ctx_, linalg::MakeVec(values.data(), values.size()));
+    collective::SafeColl(rc);
+    return EvalFn::GetFinal(values[0], values[1]);
+  }
+
+  [[nodiscard]] char const* Name() const override { return eval_.Name(); }
+
+ private:
+  EvalFn eval_;
+};
+
+XGBOOST_REGISTER_METRIC(RMSE, "rmse")
+    .describe("Rooted mean square error.")
+    .set_body([](char const*) { return new EvalEWiseMetric<EvalRowRMSE, RMSEEvalKernel>(); });
+
+XGBOOST_REGISTER_METRIC(RMSLE, "rmsle")
+    .describe("Rooted mean square log error.")
+    .set_body([](char const*) { return new EvalEWiseMetric<EvalRowRMSLE, RMSLEEvalKernel>(); });
+}  // namespace xgboost::metric

--- a/src/metric/rmse_metric.cu
+++ b/src/metric/rmse_metric.cu
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file rmse_metric.cu
+ * \brief CUDA implementations of the RMSE and RMSLE metric kernels.
+ */
+#include <dmlc/registry.h>
+
+#include "elementwise_metric.cuh"
+#include "rmse_metric.h"
+
+namespace xgboost::metric {
+DMLC_REGISTRY_FILE_TAG(rmse_metric_cuda);
+namespace {
+auto const kRegisterRMSECuda = elementwise::RegisterEvalCuda<EvalRowRMSE>();
+auto const kRegisterRMSLECuda = elementwise::RegisterEvalCuda<EvalRowRMSLE>();
+}  // namespace
+}  // namespace xgboost::metric

--- a/src/metric/rmse_metric.h
+++ b/src/metric/rmse_metric.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026, XGBoost Contributors
+ * \file rmse_metric.h
+ * \brief Shared declarations for the RMSE and RMSLE metrics.
+ */
+#ifndef XGBOOST_METRIC_RMSE_METRIC_H_
+#define XGBOOST_METRIC_RMSE_METRIC_H_
+
+#include <cmath>  // for log1p, sqrt
+
+#include "elementwise_metric.h"  // for elementwise kernels
+#include "xgboost/base.h"        // for bst_float
+
+namespace xgboost::metric {
+struct EvalRowRMSE {
+  char const* Name() const { return "rmse"; }
+
+  XGBOOST_DEVICE bst_float operator()(bst_float label, bst_float pred) const {
+    bst_float diff = label - pred;
+    return diff * diff;
+  }
+  static double GetFinal(double esum, double wsum) {
+    return wsum == 0 ? std::sqrt(esum) : std::sqrt(esum / wsum);
+  }
+};
+
+struct EvalRowRMSLE {
+  char const* Name() const { return "rmsle"; }
+
+  XGBOOST_DEVICE bst_float operator()(bst_float label, bst_float pred) const {
+    bst_float diff = std::log1p(label) - std::log1p(pred);
+    return diff * diff;
+  }
+  static double GetFinal(double esum, double wsum) {
+    return wsum == 0 ? std::sqrt(esum) : std::sqrt(esum / wsum);
+  }
+};
+
+using RMSEEvalKernel = elementwise::EvalKernel<EvalRowRMSE>;
+using RMSLEEvalKernel = elementwise::EvalKernel<EvalRowRMSLE>;
+}  // namespace xgboost::metric
+
+#endif  // XGBOOST_METRIC_RMSE_METRIC_H_


### PR DESCRIPTION
Begin converting metrics to the typed kernel abstraction, starting with RMSE and RMSLE.

This follows the existing objective structure:

- Add shared elementwise metric CPU and CUDA kernels.
- Move RMSE/RMSLE policies and kernel declarations into dedicated files.
- Register CPU and CUDA implementations separately.
- Preserve CPU fallback through the common kernel dispatcher.
- Leave the remaining metrics on the existing implementation.

Tests cover local and distributed CPU execution and GPU execution for both metrics.